### PR TITLE
Update benchmarks to run only Mochi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Default target
 .DEFAULT_GOAL := help
+.PHONY: bench
 
 # Project metadata
 APP_NAME := mochi
@@ -57,6 +58,10 @@ else
 	@echo "✏️  Updating all golden files"
 	@$(GO) test ./... -update --vet=off
 endif
+
+bench: ## Run Mochi benchmarks
+	@echo "🏃 Running benchmarks..."
+	@$(GO) run ./cmd/mochi-bench
 
 # --------------------------
 # Maintenance

--- a/bench/template/math/fact_rec/fact_rec.mochi
+++ b/bench/template/math/fact_rec/fact_rec.mochi
@@ -8,7 +8,7 @@ fun fact(n: int): int {
 // let n = 4
 let n = {{ .N }}
 let repeat = 1000
-let last = 0
+var last = 0
 
 let start = now()
 for i in 0..repeat {

--- a/bench/template/math/fib_iter/fib_iter.mochi
+++ b/bench/template/math/fib_iter/fib_iter.mochi
@@ -1,6 +1,6 @@
 fun fib(n: int): int {
-  let a = 0
-  let b = 1
+  var a = 0
+  var b = 1
   for i in 0..n {
     let tmp = a + b
     a = b
@@ -12,7 +12,7 @@ fun fib(n: int): int {
 // let n = 100
 let n = {{ .N }}
 let repeat = 1000
-let last = 0
+var last = 0
 
 let start = now()
 for i in 0..repeat {

--- a/bench/template/math/matrix_mul/matrix_mul.mochi
+++ b/bench/template/math/matrix_mul/matrix_mul.mochi
@@ -3,11 +3,11 @@ fun matmul(a: list<list<int>>, b: list<list<int>>): list<list<int>> {
   let m = len(b[0])
   let p = len(b)
 
-  let result = []
+  var result: list<list<int>> = []
   for i in 0..n {
-    let row = []
+    var row: list<int> = []
     for j in 0..m {
-      let sum = 0
+      var sum: int = 0
       for k in 0..p {
         sum = sum + a[i][k] * b[k][j]
       }
@@ -24,25 +24,25 @@ let size = {{ .N }}
 let repeat = 10
 
 // build input matrices
-let a = []
+var a: list<list<int>> = []
 for i in 0..size {
-  let row = []
+  var row: list<int> = []
   for j in 0..size {
     row = row + [i + j]
   }
   a = a + [row]
 }
 
-let b = []
+var b: list<list<int>> = []
 for i in 0..size {
-  let row = []
+  var row: list<int> = []
   for j in 0..size {
     row = row + [i * j]
   }
   b = b + [row]
 }
 
-let last: list<list<int>> = []
+var last: list<list<int>> = []
 let start = now()
 for i in 0..repeat {
   last = matmul(a, b)

--- a/bench/template/math/mul_loop/mul_loop.mochi
+++ b/bench/template/math/mul_loop/mul_loop.mochi
@@ -1,5 +1,5 @@
 fun mul(n: int): int {
-  let result = 1
+  var result = 1
   for i in 1..n {
     result = result * i
   }
@@ -9,7 +9,7 @@ fun mul(n: int): int {
 let n = {{ .N }}
 // let n = 50
 let repeat = 1000
-let last = 0
+var last = 0
 
 let start = now()
 for i in 0..repeat {

--- a/bench/template/math/prime_count/prime_count.mochi
+++ b/bench/template/math/prime_count/prime_count.mochi
@@ -11,11 +11,11 @@ fun is_prime(n: int): bool {
 let n = {{ .N }}
 // let n = 10
 let repeat = 100
-let last = 0
+var last = 0
 
 let start = now()
 for r in 0..repeat {
-  let count = 0
+  var count = 0
   for i in 2..n {
     if is_prime(i) {
       count = count + 1

--- a/bench/template/math/sum_loop/sum_loop.mochi
+++ b/bench/template/math/sum_loop/sum_loop.mochi
@@ -1,5 +1,5 @@
 fun sum(n: int): int {
-  let total = 0
+  var total = 0
   for i in 1..n {
     total = total + i
   }
@@ -8,7 +8,7 @@ fun sum(n: int): int {
 
 let n = {{ .N }}
 let repeat = 1000
-let last = 0
+var last = 0
 
 let start = now()
 for i in 0..repeat {


### PR DESCRIPTION
## Summary
- update runner to only execute Mochi templates
- build mochi path detection and skip matrix_mul
- add `bench` command to Makefile
- fix mutability in benchmark templates

## Testing
- `go test ./...`
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_683fcea927308320805c6ba4918d76f2