### PR TITLE
Add BENCHMARK markdown export to bench runner

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,0 +1,110 @@
+# Benchmarks
+
+## math.fact_rec.10
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 15.0000 | best |
+| mochi (vm) | 15.0000 | best |
+
+## math.fact_rec.20
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (vm) | 27.0000 | best |
+| mochi (interp) | 30.0000 | +11.1% |
+
+## math.fact_rec.30
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (vm) | 39.0000 | best |
+| mochi (interp) | 49.0000 | +25.6% |
+
+## math.fib_iter.10
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 7.0000 | best |
+| mochi (vm) | 17.0000 | +142.9% |
+
+## math.fib_iter.20
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 12.0000 | best |
+| mochi (vm) | 53.0000 | +341.7% |
+
+## math.fib_iter.30
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 19.0000 | best |
+| mochi (vm) | 58.0000 | +205.3% |
+
+## math.fib_rec.10
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 0.0000 | best |
+| mochi (vm) | 0.0000 | best |
+
+## math.fib_rec.20
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (vm) | 25.0000 | best |
+| mochi (interp) | 28.0000 | +12.0% |
+
+## math.fib_rec.30
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (vm) | 3598.0000 | best |
+| mochi (interp) | 4818.0000 | +33.9% |
+
+## math.mul_loop.10
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 5.0000 | best |
+| mochi (vm) | 13.0000 | +160.0% |
+
+## math.mul_loop.20
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 8.0000 | best |
+| mochi (vm) | 36.0000 | +350.0% |
+
+## math.mul_loop.30
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 11.0000 | best |
+| mochi (vm) | 34.0000 | +209.1% |
+
+## math.prime_count.10
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 2.0000 | best |
+| mochi (vm) | 4.0000 | +100.0% |
+
+## math.prime_count.20
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 7.0000 | best |
+| mochi (vm) | 14.0000 | +100.0% |
+
+## math.prime_count.30
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 12.0000 | best |
+| mochi (vm) | 22.0000 | +83.3% |
+
+## math.sum_loop.10
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 5.0000 | best |
+| mochi (vm) | 12.0000 | +140.0% |
+
+## math.sum_loop.20
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 7.0000 | best |
+| mochi (vm) | 33.0000 | +371.4% |
+
+## math.sum_loop.30
+| Language | Time (ms) | +/- |
+| --- | ---: | --- |
+| mochi (interp) | 12.0000 | best |
+| mochi (vm) | 42.0000 | +250.0% |
+

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ else
 	@$(GO) test ./... -update --vet=off
 endif
 
-bench: ## Run Mochi benchmarks
+bench: build-mochi ## Run Mochi benchmarks
 	@echo "🏃 Running benchmarks..."
 	@$(GO) run ./cmd/mochi-bench
 


### PR DESCRIPTION
## Summary
- generate `BENCHMARK.md` when running `mochi-bench`
- store benchmark results under version control
- update `bench` target to build binary first

## Testing
- `make test`
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_683fd1b9a1a48320b0624ba91deb09f6