### PR TITLE
Fix bench target to include home bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,7 @@ endif
 
 bench: build-mochi ## Run Mochi benchmarks
 	@echo "🏃 Running benchmarks..."
-	@$(GO) run ./cmd/mochi-bench
-
+	@PATH="$(BIN_DIR):$$PATH" $(GO) run ./cmd/mochi-bench
 # --------------------------
 # Maintenance
 # --------------------------


### PR DESCRIPTION
## Summary
- update Makefile `bench` target to ensure `$HOME/bin` is in the PATH when running benchmarks

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68401841de048320b0bc5b33c2f3a1f1