### PR TITLE
Add npx wrapper for Mochi

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Designed to be simple enough to explore in minutes, but powerful enough to build
 npx mochilang/mochi serve
 ```
 
+The first run downloads a prebuilt Mochi binary for your OS.
+
 This is the fastest way to try Mochi — no setup required.
 
 ### Build from Source

--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const bin = path.join(__dirname, 'bin', process.platform === 'win32' ? 'mochi.exe' : 'mochi');
+if (!fs.existsSync(bin)) {
+  console.error('Mochi binary not found. Please run `npm install` again.');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const proc = spawn(bin, args, { stdio: 'inherit' });
+proc.on('exit', code => process.exit(code));
+

--- a/install.js
+++ b/install.js
@@ -1,0 +1,53 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const tar = require('tar');
+
+const osMap = { darwin: 'Darwin', linux: 'Linux', win32: 'Windows' };
+const archMap = { x64: 'x86_64', arm64: 'arm64' };
+const platform = osMap[process.platform];
+const arch = archMap[process.arch];
+
+if (!platform || !arch) {
+  console.error(`Unsupported platform: ${process.platform} ${process.arch}`);
+  process.exit(1);
+}
+
+const filename = `mochi_${platform}_${arch}.tar.gz`;
+const url = `https://github.com/mochilang/mochi/releases/latest/download/${filename}`;
+const destDir = path.join(__dirname, 'bin');
+const destFile = path.join(destDir, filename);
+
+fs.mkdirSync(destDir, { recursive: true });
+
+function download(url, outputPath) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(outputPath);
+    https.get(url, res => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`Failed to download ${url}: ${res.statusCode}`));
+        return;
+      }
+      res.pipe(file);
+      file.on('finish', () => file.close(resolve));
+    }).on('error', reject);
+  });
+}
+
+async function run() {
+  try {
+    await download(url, destFile);
+    await tar.x({ file: destFile, cwd: destDir, gzip: true, filter: p => p === 'mochi' });
+    fs.unlinkSync(destFile);
+    if (process.platform !== 'win32') {
+      fs.chmodSync(path.join(destDir, 'mochi'), 0o755);
+    }
+    console.log('Mochi binary installed to', destDir);
+  } catch (err) {
+    console.error('Failed to install Mochi binary:', err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,122 @@
+{
+  "name": "mochi",
+  "version": "0.2.7",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mochi",
+      "version": "0.2.7",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "tar": "^6.2.0"
+      },
+      "bin": {
+        "mochi": "index.js"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mochi",
+  "version": "0.2.7",
+  "description": "Run the Mochi programming language via npx",
+  "bin": {
+    "mochi": "./index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mochilang/mochi"
+  },
+  "license": "MIT",
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "dependencies": {
+    "tar": "^6.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json, install.js, index.js for npx usage
- download prebuilt binary in install script
- note binary download in README

## Testing
- `node install.js` *(fails: connect ENETUNREACH)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68401dc5b708832096a5a74345c8d444