### PR TITLE
Add Go benchmark comparison

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -3,90 +3,126 @@
 ## math.fact_rec.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 16.0000 | best |
+| go | 0.0175 | best |
+| mochi (go) | 0.0198 | +13.1% |
+| mochi (interp) | 19.0000 | +108397.0% |
 
 ## math.fact_rec.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 18.0000 | best |
+| mochi (go) | 0.0396 | best |
+| go | 0.0396 | +0.2% |
+| mochi (interp) | 37.0000 | +93452.5% |
 
 ## math.fact_rec.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 22.0000 | best |
+| go | 0.1223 | best |
+| mochi (go) | 0.1481 | +21.0% |
+| mochi (interp) | 56.0000 | +45672.9% |
 
 ## math.fib_iter.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 3.0000 | best |
+| go | 0.0040 | best |
+| mochi (go) | 0.0110 | +175.0% |
+| mochi (interp) | 8.0000 | +199900.0% |
 
 ## math.fib_iter.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 6.0000 | best |
+| mochi (go) | 0.0070 | best |
+| go | 0.0070 | best |
+| mochi (interp) | 14.0000 | +199900.0% |
 
 ## math.fib_iter.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 8.0000 | best |
+| mochi (go) | 0.0110 | best |
+| go | 0.0110 | best |
+| mochi (interp) | 28.0000 | +254445.5% |
 
 ## math.fib_rec.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
 | mochi (interp) | 0.0000 | best |
+| mochi (go) | 0.0000 | best |
+| go | 0.0000 | best |
 
 ## math.fib_rec.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 14.0000 | best |
+| go | 0.0350 | best |
+| mochi (go) | 0.0490 | +40.0% |
+| mochi (interp) | 50.0000 | +142757.1% |
 
 ## math.fib_rec.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 1721.0000 | best |
+| go | 4.4080 | best |
+| mochi (go) | 4.6100 | +4.6% |
+| mochi (interp) | 5288.0000 | +119863.7% |
 
 ## math.mul_loop.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 2.0000 | best |
+| mochi (go) | 0.0050 | best |
+| go | 0.0060 | +20.0% |
+| mochi (interp) | 5.0000 | +99900.0% |
 
 ## math.mul_loop.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 3.0000 | best |
+| mochi (go) | 0.0070 | best |
+| go | 0.0070 | best |
+| mochi (interp) | 9.0000 | +128471.4% |
 
 ## math.mul_loop.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 5.0000 | best |
+| mochi (go) | 0.0170 | best |
+| go | 0.0260 | +52.9% |
+| mochi (interp) | 32.0000 | +188135.3% |
 
 ## math.prime_count.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 1.0000 | best |
+| mochi (go) | 0.0020 | best |
+| go | 0.0030 | +50.0% |
+| mochi (interp) | 2.0000 | +99900.0% |
 
 ## math.prime_count.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 3.0000 | best |
+| mochi (go) | 0.0070 | best |
+| go | 0.0070 | best |
+| mochi (interp) | 8.0000 | +114185.7% |
 
 ## math.prime_count.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 5.0000 | best |
+| mochi (go) | 0.0130 | best |
+| go | 0.0130 | best |
+| mochi (interp) | 14.0000 | +107592.3% |
 
 ## math.sum_loop.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 2.0000 | best |
+| go | 0.0040 | best |
+| mochi (go) | 0.0070 | +75.0% |
+| mochi (interp) | 5.0000 | +124900.0% |
 
 ## math.sum_loop.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 3.0000 | best |
+| go | 0.0070 | best |
+| mochi (go) | 0.0080 | +14.3% |
+| mochi (interp) | 8.0000 | +114185.7% |
 
 ## math.sum_loop.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (interp) | 5.0000 | best |
+| go | 0.0100 | best |
+| mochi (go) | 0.0120 | +20.0% |
+| mochi (interp) | 25.0000 | +249900.0% |
 


### PR DESCRIPTION
## Summary
- compare interpreter vs Go-compiled Mochi programs and pure Go
- document benchmark results

## Testing
- `go test ./... --vet=off -v`
- `go run ./cmd/mochi-bench`

------
https://chatgpt.com/codex/tasks/task_e_68402de0c2f88320bea7a8dd5f569762