### PR TITLE
Add build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Run the tests to ensure everything works:
 make test
 ```
 
+### Build a Mochi Program
+
+Compile a Mochi source file into a standalone binary:
+
+```bash
+./mochi build examples/hello.mochi -o hello
+./hello
+```
+
 ## Using Mochi in Claude Desktop
 
 Mochi works great inside Claude Desktop using the Model Context Protocol (MCP). Once configured, you can write and


### PR DESCRIPTION
## Summary
- add `build` subcommand to CLI to compile Mochi code into a Go binary
- document how to build a Mochi program in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68402f84a7dc8320a5d4503ea5b2be34