### PR TITLE
Refactor Go compiler type handling

### DIFF
--- a/bench/runner.go
+++ b/bench/runner.go
@@ -321,7 +321,7 @@ func compileToGo(mochiFile, goFile string) error {
 	if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 		return fmt.Errorf("type error: %v", errs[0])
 	}
-	c := gocode.New()
+	c := gocode.New(typeEnv)
 	code, err := c.Compile(prog)
 	if err != nil {
 		return err

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -178,7 +178,7 @@ func buildBinary(cmd *BuildCmd) error {
 		}
 		return fmt.Errorf("aborted due to type errors")
 	}
-	c := gocode.New()
+	c := gocode.New(env)
 	code, err := c.Compile(prog)
 	if err != nil {
 		return err

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -24,7 +24,7 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", errs[0])
 		}
-		c := gocode.New()
+		c := gocode.New(typeEnv)
 		code, err := c.Compile(prog)
 		if err != nil {
 			return nil, fmt.Errorf("❌ compile error: %w", err)
@@ -54,7 +54,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", errs[0])
 		}
-		c := gocode.New()
+		c := gocode.New(typeEnv)
 		code, err := c.Compile(prog)
 		if err != nil {
 			return nil, fmt.Errorf("❌ compile error: %w", err)

--- a/tests/gocompiler/valid/grouped_expr.go.out
+++ b/tests/gocompiler/valid/grouped_expr.go.out
@@ -5,7 +5,7 @@ import (
 )
 
 func main() {
-	var value = _mul((_add(1, 2)), 3)
+	var value = (((1 + 2)) * 3)
 	fmt.Println(value)
 }
 

--- a/tests/gocompiler/valid/if_else.go.out
+++ b/tests/gocompiler/valid/if_else.go.out
@@ -6,7 +6,7 @@ import (
 
 func main() {
 	var x = 5
-	if _gt(x, 3) {
+	if (x > 3) {
 		fmt.Println("big")
 	} else {
 		fmt.Println("small")

--- a/tests/gocompiler/valid/let_and_print.go.out
+++ b/tests/gocompiler/valid/let_and_print.go.out
@@ -7,7 +7,7 @@ import (
 func main() {
 	var a = 10
 	var b = 20
-	fmt.Println(_add(a, b))
+	fmt.Println((a + b))
 }
 
 


### PR DESCRIPTION
## Summary
- reduce runtime helpers by using simple type inference in Go codegen
- infer primitive types for binary operators and emit native ops when possible
- update golden files for Go compiler

## Testing
- `go test ./compile/go -update`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684035b079348320b8412381b3eea96a