### PR TITLE
Improve ts benchmarks timing

### DIFF
--- a/bench/out/math_fact_rec_10.ts.out
+++ b/bench/out/math_fact_rec_10.ts.out
@@ -11,11 +11,11 @@ function main(): void {
 	let n = 10
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = fact(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fact_rec_20.ts.out
+++ b/bench/out/math_fact_rec_20.ts.out
@@ -11,11 +11,11 @@ function main(): void {
 	let n = 20
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = fact(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fact_rec_30.ts.out
+++ b/bench/out/math_fact_rec_30.ts.out
@@ -11,11 +11,11 @@ function main(): void {
 	let n = 30
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = fact(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fib_iter_10.ts.out
+++ b/bench/out/math_fib_iter_10.ts.out
@@ -15,11 +15,11 @@ function main(): void {
 	let n = 10
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = fib(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fib_iter_20.ts.out
+++ b/bench/out/math_fib_iter_20.ts.out
@@ -15,11 +15,11 @@ function main(): void {
 	let n = 20
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = fib(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fib_iter_30.ts.out
+++ b/bench/out/math_fib_iter_30.ts.out
@@ -15,11 +15,11 @@ function main(): void {
 	let n = 30
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = fib(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fib_rec_10.ts.out
+++ b/bench/out/math_fib_rec_10.ts.out
@@ -9,9 +9,9 @@ function fib(n) {
 
 function main(): void {
 	let n = 10
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	let result = fib(n)
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: result}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fib_rec_20.ts.out
+++ b/bench/out/math_fib_rec_20.ts.out
@@ -9,9 +9,9 @@ function fib(n) {
 
 function main(): void {
 	let n = 20
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	let result = fib(n)
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: result}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_fib_rec_30.ts.out
+++ b/bench/out/math_fib_rec_30.ts.out
@@ -9,9 +9,9 @@ function fib(n) {
 
 function main(): void {
 	let n = 30
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	let result = fib(n)
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: result}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_mul_loop_10.ts.out
+++ b/bench/out/math_mul_loop_10.ts.out
@@ -12,11 +12,11 @@ function main(): void {
 	let n = 10
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = mul(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_mul_loop_20.ts.out
+++ b/bench/out/math_mul_loop_20.ts.out
@@ -12,11 +12,11 @@ function main(): void {
 	let n = 20
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = mul(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_mul_loop_30.ts.out
+++ b/bench/out/math_mul_loop_30.ts.out
@@ -12,11 +12,11 @@ function main(): void {
 	let n = 30
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = mul(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_prime_count_10.ts.out
+++ b/bench/out/math_prime_count_10.ts.out
@@ -16,7 +16,7 @@ function main(): void {
 	let n = 10
 	let repeat = 100
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let r = 0; r < repeat; r++) {
 		let count = 0
 		for (let i = 2; i < n; i++) {
@@ -26,7 +26,7 @@ function main(): void {
 		}
 		last = count
 	}
-	let end = Date.now()
+	let end = performance.now() * 1000000
 	let duration = (((end - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))

--- a/bench/out/math_prime_count_20.ts.out
+++ b/bench/out/math_prime_count_20.ts.out
@@ -16,7 +16,7 @@ function main(): void {
 	let n = 20
 	let repeat = 100
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let r = 0; r < repeat; r++) {
 		let count = 0
 		for (let i = 2; i < n; i++) {
@@ -26,7 +26,7 @@ function main(): void {
 		}
 		last = count
 	}
-	let end = Date.now()
+	let end = performance.now() * 1000000
 	let duration = (((end - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))

--- a/bench/out/math_prime_count_30.ts.out
+++ b/bench/out/math_prime_count_30.ts.out
@@ -16,7 +16,7 @@ function main(): void {
 	let n = 30
 	let repeat = 100
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let r = 0; r < repeat; r++) {
 		let count = 0
 		for (let i = 2; i < n; i++) {
@@ -26,7 +26,7 @@ function main(): void {
 		}
 		last = count
 	}
-	let end = Date.now()
+	let end = performance.now() * 1000000
 	let duration = (((end - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))

--- a/bench/out/math_sum_loop_10.ts.out
+++ b/bench/out/math_sum_loop_10.ts.out
@@ -12,11 +12,11 @@ function main(): void {
 	let n = 10
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = sum(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_sum_loop_20.ts.out
+++ b/bench/out/math_sum_loop_20.ts.out
@@ -12,11 +12,11 @@ function main(): void {
 	let n = 20
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = sum(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/bench/out/math_sum_loop_30.ts.out
+++ b/bench/out/math_sum_loop_30.ts.out
@@ -12,11 +12,11 @@ function main(): void {
 	let n = 30
 	let repeat = 1000
 	let last = 0
-	let start = Date.now()
+	let start = performance.now() * 1000000
 	for (let i = 0; i < repeat; i++) {
 		last = sum(n)
 	}
-	let duration = (((Date.now() - start)) / 1000000)
+	let duration = (((performance.now() * 1000000 - start)) / 1000000)
 	let output = {["duration_ms"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -339,7 +339,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "len":
 		return fmt.Sprintf("_len(%s)", argStr), nil
 	case "now":
-		return "Date.now()", nil
+		// performance.now() returns milliseconds as a float. Multiply
+		// by 1e6 so that `now()` is consistent with Go's UnixNano()
+		// and the interpreter which return nanoseconds.
+		return "performance.now() * 1000000", nil
 	case "json":
 		return fmt.Sprintf("console.log(JSON.stringify(%s))", argStr), nil
 	default:


### PR DESCRIPTION
## Summary
- use `performance.now()` for `now()` in TS
- update generated benchmark outputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840443a5db483209d77f6eb8823bf9d