### PR TITLE
docs: add v0.2.9 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 📦 CHANGELOG.md
 
+## [0.2.9] – 2025-06-06
+
+### Added
+
+* TypeScript compiler for generating `.ts` output via `mochi build --ts`
+* Integrated benchmarks that compile to Go and TypeScript with checked-in results
+
+### Changed
+
+* `mochi build` emits runtime helpers only when necessary
+* Benchmarks use `performance.now` for accurate Deno timings
+* Documentation covers new CLI options and Makefile tasks
+
+### Fixed
+
+* Minor Makefile issue affecting builds
+
+
 All notable changes to the Mochi programming language are documented in this file.
 
 ## [0.2.8] – 2025-06-05

--- a/releases/v0.2.9.md
+++ b/releases/v0.2.9.md
@@ -1,0 +1,20 @@
+# June 2025 (v0.2.9)
+
+Mochi continues to evolve with a focus on tooling. This update introduces a TypeScript compiler and smoother benchmarking workflow.
+
+## TypeScript compiler
+
+`mochi build --ts` can now translate Mochi programs directly into TypeScript. The compiler is tested with golden files so generated code stays stable.
+
+## Integrated benchmarks
+
+Benchmark templates compile to Go or TypeScript and run automatically. Generated outputs are checked in to keep results reproducible.
+
+## Optimized runtime helpers
+
+The compiler only emits runtime helper functions when needed, reducing output size.
+
+## Better documentation and timing fixes
+
+The README covers more CLI usage and Makefile tasks. Benchmarks now use `performance.now` for accurate durations when running under Deno.
+


### PR DESCRIPTION
## Summary
- document v0.2.9 release
- update changelog

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68404f245c7083208a9d489032b0dc1f