### PR TITLE
Add install target and rerun benchmarks

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -3,126 +3,126 @@
 ## math.fact_rec.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 0.0175 | best |
-| mochi (go) | 0.0198 | +13.1% |
-| mochi (interp) | 19.0000 | +108397.0% |
+| mochi (ts) | 0.4739 | best |
+| mochi (py) | 0.5823 | +22.9% |
+| mochi (interp) | 19.0000 | +3909.0% |
 
 ## math.fact_rec.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0396 | best |
-| go | 0.0396 | +0.2% |
-| mochi (interp) | 37.0000 | +93452.5% |
+| mochi (ts) | 0.7373 | best |
+| mochi (py) | 1.3593 | +84.4% |
+| mochi (interp) | 36.0000 | +4782.6% |
 
 ## math.fact_rec.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 0.1223 | best |
-| mochi (go) | 0.1481 | +21.0% |
-| mochi (interp) | 56.0000 | +45672.9% |
+| mochi (ts) | 1.2904 | best |
+| mochi (py) | 1.9997 | +55.0% |
+| mochi (interp) | 66.0000 | +5014.5% |
 
 ## math.fib_iter.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 0.0040 | best |
-| mochi (go) | 0.0110 | +175.0% |
-| mochi (interp) | 8.0000 | +199900.0% |
+| mochi (py) | 0.3835 | best |
+| mochi (ts) | 0.4471 | +16.6% |
+| mochi (interp) | 8.0000 | +1986.2% |
 
 ## math.fib_iter.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0070 | best |
-| go | 0.0070 | best |
-| mochi (interp) | 14.0000 | +199900.0% |
+| mochi (ts) | 0.5206 | best |
+| mochi (py) | 0.6884 | +32.2% |
+| mochi (interp) | 23.0000 | +4317.6% |
 
 ## math.fib_iter.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0110 | best |
-| go | 0.0110 | best |
-| mochi (interp) | 28.0000 | +254445.5% |
+| mochi (ts) | 0.6378 | best |
+| mochi (py) | 1.0440 | +63.7% |
+| mochi (interp) | 22.0000 | +3349.6% |
 
 ## math.fib_rec.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
 | mochi (interp) | 0.0000 | best |
-| mochi (go) | 0.0000 | best |
-| go | 0.0000 | best |
+| mochi (py) | 0.0112 | ++Inf% |
+| mochi (ts) | 0.0233 | ++Inf% |
 
 ## math.fib_rec.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 0.0350 | best |
-| mochi (go) | 0.0490 | +40.0% |
-| mochi (interp) | 50.0000 | +142757.1% |
+| mochi (ts) | 0.6390 | best |
+| mochi (py) | 1.1069 | +73.2% |
+| mochi (interp) | 47.0000 | +7254.9% |
 
 ## math.fib_rec.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 4.4080 | best |
-| mochi (go) | 4.6100 | +4.6% |
-| mochi (interp) | 5288.0000 | +119863.7% |
+| mochi (ts) | 9.8860 | best |
+| mochi (py) | 127.0458 | +1185.1% |
+| mochi (interp) | 5263.0000 | +53136.8% |
 
 ## math.mul_loop.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0050 | best |
-| go | 0.0060 | +20.0% |
-| mochi (interp) | 5.0000 | +99900.0% |
+| mochi (ts) | 0.3104 | best |
+| mochi (py) | 0.4355 | +40.3% |
+| mochi (interp) | 6.0000 | +1832.8% |
 
 ## math.mul_loop.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0070 | best |
-| go | 0.0070 | best |
-| mochi (interp) | 9.0000 | +128471.4% |
+| mochi (ts) | 0.5471 | best |
+| mochi (py) | 0.7984 | +45.9% |
+| mochi (interp) | 9.0000 | +1545.1% |
 
 ## math.mul_loop.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0170 | best |
-| go | 0.0260 | +52.9% |
-| mochi (interp) | 32.0000 | +188135.3% |
+| mochi (py) | 1.1405 | best |
+| mochi (ts) | 1.3958 | +22.4% |
+| mochi (interp) | 13.0000 | +1039.8% |
 
 ## math.prime_count.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0020 | best |
-| go | 0.0030 | +50.0% |
-| mochi (interp) | 2.0000 | +99900.0% |
+| mochi (py) | 0.2047 | best |
+| mochi (ts) | 0.2384 | +16.5% |
+| mochi (interp) | 2.0000 | +877.2% |
 
 ## math.prime_count.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0070 | best |
-| go | 0.0070 | best |
-| mochi (interp) | 8.0000 | +114185.7% |
+| mochi (ts) | 0.3204 | best |
+| mochi (py) | 0.5487 | +71.3% |
+| mochi (interp) | 9.0000 | +2709.3% |
 
 ## math.prime_count.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (go) | 0.0130 | best |
-| go | 0.0130 | best |
-| mochi (interp) | 14.0000 | +107592.3% |
+| mochi (ts) | 0.5465 | best |
+| mochi (py) | 0.9129 | +67.1% |
+| mochi (interp) | 15.0000 | +2644.8% |
 
 ## math.sum_loop.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 0.0040 | best |
-| mochi (go) | 0.0070 | +75.0% |
-| mochi (interp) | 5.0000 | +124900.0% |
+| mochi (py) | 0.3076 | best |
+| mochi (ts) | 0.3238 | +5.3% |
+| mochi (interp) | 6.0000 | +1850.4% |
 
 ## math.sum_loop.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 0.0070 | best |
-| mochi (go) | 0.0080 | +14.3% |
-| mochi (interp) | 8.0000 | +114185.7% |
+| mochi (ts) | 0.4609 | best |
+| mochi (py) | 0.6818 | +47.9% |
+| mochi (interp) | 10.0000 | +2069.8% |
 
 ## math.sum_loop.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| go | 0.0100 | best |
-| mochi (go) | 0.0120 | +20.0% |
-| mochi (interp) | 25.0000 | +249900.0% |
+| mochi (ts) | 0.5358 | best |
+| mochi (py) | 0.7691 | +43.5% |
+| mochi (interp) | 13.0000 | +2326.4% |
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Default target
 .DEFAULT_GOAL := help
-.PHONY: bench
+.PHONY: bench install
 
 # Project metadata
 APP_NAME := mochi
@@ -62,6 +62,23 @@ endif
 bench: build-mochi ## Run Mochi benchmarks
 	@echo "🏃 Running benchmarks..."
 	@$(GO) run ./cmd/mochi-bench
+
+install: ## Install Deno and Python for benchmarks
+	@echo "📥 Installing benchmark dependencies..."
+	@if ! command -v python3 > /dev/null 2>&1; then \
+	echo "🐍 Installing Python..."; \
+	apt-get update && apt-get install -y python3; \
+	else \
+	echo "🐍 Python already installed"; \
+	fi
+	@if ! command -v deno > /dev/null 2>&1; then \
+	echo "🦕 Installing Deno..."; \
+	curl -fsSL https://deno.land/install.sh | DENO_INSTALL=$(HOME)/.deno sh; \
+	install -m 755 $(HOME)/.deno/bin/deno /usr/local/bin/deno; \
+	else \
+	echo "🦕 Deno already installed"; \
+	fi
+	@echo "✅ Dependencies installed"
 
 # --------------------------
 # Maintenance


### PR DESCRIPTION
## Summary
- add a Makefile `install` target that installs Python and Deno
- regenerate benchmark results using the new target

## Testing
- `make install`
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_6840531f055c83208aa2259ee0569ccd