### PR TITLE
Enhance Go compiler type inference

### DIFF
--- a/tests/gocompiler/valid/for_list_collection.go.out
+++ b/tests/gocompiler/valid/for_list_collection.go.out
@@ -5,7 +5,7 @@ import (
 )
 
 func main() {
-	for _, n := range _iter([]any{1, 2, 3}) {
+	for _, n := range _iter([]int{1, 2, 3}) {
 		fmt.Println(n)
 	}
 }
@@ -14,6 +14,30 @@ func _iter(v any) []any {
     switch s := v.(type) {
     case []any:
         return s
+    case []int:
+        out := make([]any, len(s))
+        for i, v := range s {
+            out[i] = v
+        }
+        return out
+    case []float64:
+        out := make([]any, len(s))
+        for i, v := range s {
+            out[i] = v
+        }
+        return out
+    case []string:
+        out := make([]any, len(s))
+        for i, v := range s {
+            out[i] = v
+        }
+        return out
+    case []bool:
+        out := make([]any, len(s))
+        for i, v := range s {
+            out[i] = v
+        }
+        return out
     case map[string]any:
         out := make([]any, 0, len(s))
         for k := range s {

--- a/tests/gocompiler/valid/fun_call.go.out
+++ b/tests/gocompiler/valid/fun_call.go.out
@@ -4,12 +4,10 @@ import (
 	"fmt"
 )
 
-func add(a any, b any) any {
-	return _add(a, b)
+func add(a int, b int) int {
+	return (a + b)
 }
 
 func main() {
 	fmt.Println(add(2, 3))
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }

--- a/tests/gocompiler/valid/grouped_expr.go.out
+++ b/tests/gocompiler/valid/grouped_expr.go.out
@@ -5,6 +5,6 @@ import (
 )
 
 func main() {
-	var value = (((1 + 2)) * 3)
+	var value int = (((1 + 2)) * 3)
 	fmt.Println(value)
 }

--- a/tests/gocompiler/valid/if_else.go.out
+++ b/tests/gocompiler/valid/if_else.go.out
@@ -5,7 +5,7 @@ import (
 )
 
 func main() {
-	var x = 5
+	var x int = 5
 	if (x > 3) {
 		fmt.Println("big")
 	} else {

--- a/tests/gocompiler/valid/len_builtin.go.out
+++ b/tests/gocompiler/valid/len_builtin.go.out
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	fmt.Println(len([]any{1, 2, 3}))
+	fmt.Println(len([]int{1, 2, 3}))
 }

--- a/tests/gocompiler/valid/let_and_print.go.out
+++ b/tests/gocompiler/valid/let_and_print.go.out
@@ -5,7 +5,7 @@ import (
 )
 
 func main() {
-	var a = 10
-	var b = 20
+	var a int = 10
+	var b int = 20
 	fmt.Println((a + b))
 }

--- a/tests/gocompiler/valid/list_index.go.out
+++ b/tests/gocompiler/valid/list_index.go.out
@@ -5,13 +5,61 @@ import (
 )
 
 func main() {
-	var xs = []any{10, 20, 30}
+	var xs []int = []int{10, 20, 30}
 	fmt.Println(_index(xs, 1))
 }
 
 func _index(v any, k any) any {
     switch s := v.(type) {
     case []any:
+        i, ok := k.(int)
+        if !ok {
+            panic("invalid list index")
+        }
+        if i < 0 {
+            i += len(s)
+        }
+        if i < 0 || i >= len(s) {
+            panic("index out of range")
+        }
+        return s[i]
+    case []int:
+        i, ok := k.(int)
+        if !ok {
+            panic("invalid list index")
+        }
+        if i < 0 {
+            i += len(s)
+        }
+        if i < 0 || i >= len(s) {
+            panic("index out of range")
+        }
+        return s[i]
+    case []float64:
+        i, ok := k.(int)
+        if !ok {
+            panic("invalid list index")
+        }
+        if i < 0 {
+            i += len(s)
+        }
+        if i < 0 || i >= len(s) {
+            panic("index out of range")
+        }
+        return s[i]
+    case []string:
+        i, ok := k.(int)
+        if !ok {
+            panic("invalid list index")
+        }
+        if i < 0 {
+            i += len(s)
+        }
+        if i < 0 || i >= len(s) {
+            panic("index out of range")
+        }
+        return s[i]
+    case []bool:
         i, ok := k.(int)
         if !ok {
             panic("invalid list index")

--- a/tests/gocompiler/valid/var_assignment.go.out
+++ b/tests/gocompiler/valid/var_assignment.go.out
@@ -5,7 +5,7 @@ import (
 )
 
 func main() {
-	var x = 1
+	var x int = 1
 	x = 2
 	fmt.Println(x)
 }


### PR DESCRIPTION
## Prompt

Now enhance and refactor Mochi to Go compiler with detecting types, to reduce "any" in complied code, and make sure the code correctly runable.

## Summary
- use reflect-driven type comparisons in the Go compiler
- infer list/map element types and emit typed literals
- compile function/variable declarations with static types
- propagate parameter types when compiling functions and closures
- extend runtime helpers to handle typed slices
- update Go golden outputs

## Testing
- `go test ./compile/go -run TestGoCompiler_SubsetPrograms -count=1`
- `go test ./compile/go -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68405a9a5d448320b65c2920ac97678e