### PR TITLE
Fix Go benchmark compilation

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -3,108 +3,144 @@
 ## math.fact_rec.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 0.8127 | best |
-| mochi (interp) | 63.0000 | +7651.7% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.5326 | ++Inf% |
+| mochi (py) | 0.8088 | ++Inf% |
+| mochi (interp) | 72.0000 | ++Inf% |
 
 ## math.fact_rec.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 1.7251 | best |
-| mochi (interp) | 119.0000 | +6798.1% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 1.0044 | ++Inf% |
+| mochi (py) | 1.9505 | ++Inf% |
+| mochi (interp) | 56.0000 | ++Inf% |
 
 ## math.fact_rec.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 2.6813 | best |
-| mochi (interp) | 149.0000 | +5457.0% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 1.3113 | ++Inf% |
+| mochi (py) | 2.7980 | ++Inf% |
+| mochi (interp) | 108.0000 | ++Inf% |
 
 ## math.fib_iter.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 0.5667 | best |
-| mochi (interp) | 32.0000 | +5546.6% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.4820 | ++Inf% |
+| mochi (py) | 0.6586 | ++Inf% |
+| mochi (interp) | 14.0000 | ++Inf% |
 
 ## math.fib_iter.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 1.0410 | best |
-| mochi (interp) | 37.0000 | +3454.2% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.5874 | ++Inf% |
+| mochi (py) | 0.9773 | ++Inf% |
+| mochi (interp) | 33.0000 | ++Inf% |
 
 ## math.fib_iter.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 5.0435 | best |
-| mochi (interp) | 44.0000 | +772.4% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.6131 | ++Inf% |
+| mochi (py) | 1.3592 | ++Inf% |
+| mochi (interp) | 33.0000 | ++Inf% |
 
 ## math.fib_rec.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
 | mochi (interp) | 0.0000 | best |
-| mochi (py) | 0.0155 | ++Inf% |
+| mochi | 0.0000 | best |
+| mochi (py) | 0.0200 | ++Inf% |
+| mochi (ts) | 0.0317 | ++Inf% |
 
 ## math.fib_rec.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 1.4575 | best |
-| mochi (interp) | 135.0000 | +9162.6% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.7198 | ++Inf% |
+| mochi (py) | 1.4617 | ++Inf% |
+| mochi (interp) | 95.0000 | ++Inf% |
 
 ## math.fib_rec.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 181.7278 | best |
-| mochi (interp) | 9643.0000 | +5206.3% |
+| mochi | 6.0000 | best |
+| mochi (ts) | 14.3253 | +138.8% |
+| mochi (py) | 195.4566 | +3157.6% |
+| mochi (interp) | 8794.0000 | +146466.7% |
 
 ## math.mul_loop.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 3.0594 | best |
-| mochi (interp) | 13.0000 | +324.9% |
+| mochi | 0.0000 | best |
+| mochi (py) | 0.5140 | ++Inf% |
+| mochi (ts) | 0.6399 | ++Inf% |
+| mochi (interp) | 11.0000 | ++Inf% |
 
 ## math.mul_loop.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 1.0821 | best |
-| mochi (interp) | 25.0000 | +2210.3% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.7404 | ++Inf% |
+| mochi (py) | 1.0320 | ++Inf% |
+| mochi (interp) | 13.0000 | ++Inf% |
 
 ## math.mul_loop.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 1.8566 | best |
-| mochi (interp) | 29.0000 | +1462.0% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 1.0870 | ++Inf% |
+| mochi (py) | 1.6547 | ++Inf% |
+| mochi (interp) | 25.0000 | ++Inf% |
 
 ## math.prime_count.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 0.2952 | best |
-| mochi (interp) | 5.0000 | +1594.0% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.2630 | ++Inf% |
+| mochi (py) | 0.2874 | ++Inf% |
+| mochi (interp) | 5.0000 | ++Inf% |
 
 ## math.prime_count.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 0.8658 | best |
-| mochi (interp) | 13.0000 | +1401.6% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.4553 | ++Inf% |
+| mochi (py) | 0.7770 | ++Inf% |
+| mochi (interp) | 11.0000 | ++Inf% |
 
 ## math.prime_count.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 1.3450 | best |
-| mochi (interp) | 40.0000 | +2873.9% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.7854 | ++Inf% |
+| mochi (py) | 1.2990 | ++Inf% |
+| mochi (interp) | 21.0000 | ++Inf% |
 
 ## math.sum_loop.10
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 0.5615 | best |
-| mochi (interp) | 8.0000 | +1324.7% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.3948 | ++Inf% |
+| mochi (py) | 0.4529 | ++Inf% |
+| mochi (interp) | 22.0000 | ++Inf% |
 
 ## math.sum_loop.20
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 0.8461 | best |
-| mochi (interp) | 13.0000 | +1436.5% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.5848 | ++Inf% |
+| mochi (py) | 0.8404 | ++Inf% |
+| mochi (interp) | 23.0000 | ++Inf% |
 
 ## math.sum_loop.30
 | Language | Time (ms) | +/- |
 | --- | ---: | --- |
-| mochi (py) | 1.1165 | best |
-| mochi (interp) | 35.0000 | +3034.7% |
+| mochi | 0.0000 | best |
+| mochi (ts) | 0.6022 | ++Inf% |
+| mochi (py) | 1.1337 | ++Inf% |
+| mochi (interp) | 19.0000 | ++Inf% |
 

--- a/bench/out/math_fact_rec_10.go.out
+++ b/bench/out/math_fact_rec_10.go.out
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func fact(n any) any {
+func fact(n int) int {
 	if (n == 0) {
 		return 1
 	}
@@ -14,15 +14,15 @@ func fact(n any) any {
 }
 
 func main() {
-	var n = 10
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 10
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = fact(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
 

--- a/bench/out/math_fact_rec_20.go.out
+++ b/bench/out/math_fact_rec_20.go.out
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func fact(n any) any {
+func fact(n int) int {
 	if (n == 0) {
 		return 1
 	}
@@ -14,15 +14,15 @@ func fact(n any) any {
 }
 
 func main() {
-	var n = 20
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 20
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = fact(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
 

--- a/bench/out/math_fact_rec_30.go.out
+++ b/bench/out/math_fact_rec_30.go.out
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func fact(n any) any {
+func fact(n int) int {
 	if (n == 0) {
 		return 1
 	}
@@ -14,15 +14,15 @@ func fact(n any) any {
 }
 
 func main() {
-	var n = 30
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 30
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = fact(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
 

--- a/bench/out/math_fib_iter_10.go.out
+++ b/bench/out/math_fib_iter_10.go.out
@@ -6,11 +6,11 @@ import (
 	"time"
 )
 
-func fib(n any) any {
-	var a = 0
-	var b = 1
+func fib(n int) int {
+	var a int = 0
+	var b int = 1
 	for i := 0; i < n; i++ {
-		var tmp = _add(a, b)
+		var tmp int = (a + b)
 		a = b
 		b = tmp
 	}
@@ -18,17 +18,15 @@ func fib(n any) any {
 }
 
 func main() {
-	var n = 10
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 10
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = fib(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
 

--- a/bench/out/math_fib_iter_20.go.out
+++ b/bench/out/math_fib_iter_20.go.out
@@ -6,11 +6,11 @@ import (
 	"time"
 )
 
-func fib(n any) any {
-	var a = 0
-	var b = 1
+func fib(n int) int {
+	var a int = 0
+	var b int = 1
 	for i := 0; i < n; i++ {
-		var tmp = _add(a, b)
+		var tmp int = (a + b)
 		a = b
 		b = tmp
 	}
@@ -18,17 +18,15 @@ func fib(n any) any {
 }
 
 func main() {
-	var n = 20
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 20
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = fib(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
 

--- a/bench/out/math_fib_iter_30.go.out
+++ b/bench/out/math_fib_iter_30.go.out
@@ -6,11 +6,11 @@ import (
 	"time"
 )
 
-func fib(n any) any {
-	var a = 0
-	var b = 1
+func fib(n int) int {
+	var a int = 0
+	var b int = 1
 	for i := 0; i < n; i++ {
-		var tmp = _add(a, b)
+		var tmp int = (a + b)
 		a = b
 		b = tmp
 	}
@@ -18,17 +18,15 @@ func fib(n any) any {
 }
 
 func main() {
-	var n = 30
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 30
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = fib(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
 

--- a/bench/out/math_fib_rec_10.go.out
+++ b/bench/out/math_fib_rec_10.go.out
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func fib(n any) any {
+func fib(n int) int {
 	if (n <= 1) {
 		return n
 	}
@@ -14,11 +14,11 @@ func fib(n any) any {
 }
 
 func main() {
-	var n = 10
-	var start = time.Now().UnixNano()
-	var result = fib(n)
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": result}
+	var n int = 10
+	var start int = int(time.Now().UnixNano())
+	var result int = fib(n)
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": result}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
 

--- a/bench/out/math_fib_rec_20.go.out
+++ b/bench/out/math_fib_rec_20.go.out
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func fib(n any) any {
+func fib(n int) int {
 	if (n <= 1) {
 		return n
 	}
@@ -14,11 +14,11 @@ func fib(n any) any {
 }
 
 func main() {
-	var n = 20
-	var start = time.Now().UnixNano()
-	var result = fib(n)
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": result}
+	var n int = 20
+	var start int = int(time.Now().UnixNano())
+	var result int = fib(n)
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": result}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
 

--- a/bench/out/math_fib_rec_30.go.out
+++ b/bench/out/math_fib_rec_30.go.out
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func fib(n any) any {
+func fib(n int) int {
 	if (n <= 1) {
 		return n
 	}
@@ -14,11 +14,11 @@ func fib(n any) any {
 }
 
 func main() {
-	var n = 30
-	var start = time.Now().UnixNano()
-	var result = fib(n)
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": result}
+	var n int = 30
+	var start int = int(time.Now().UnixNano())
+	var result int = fib(n)
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": result}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
 

--- a/bench/out/math_mul_loop_10.go.out
+++ b/bench/out/math_mul_loop_10.go.out
@@ -6,26 +6,24 @@ import (
 	"time"
 )
 
-func mul(n any) any {
-	var result = 1
+func mul(n int) int {
+	var result int = 1
 	for i := 1; i < n; i++ {
-		result = _mul(result, i)
+		result = (result * i)
 	}
 	return result
 }
 
 func main() {
-	var n = 10
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 10
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = mul(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _mul(a, b any) any { return a.(int) * b.(int) }
 

--- a/bench/out/math_mul_loop_20.go.out
+++ b/bench/out/math_mul_loop_20.go.out
@@ -6,26 +6,24 @@ import (
 	"time"
 )
 
-func mul(n any) any {
-	var result = 1
+func mul(n int) int {
+	var result int = 1
 	for i := 1; i < n; i++ {
-		result = _mul(result, i)
+		result = (result * i)
 	}
 	return result
 }
 
 func main() {
-	var n = 20
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 20
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = mul(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _mul(a, b any) any { return a.(int) * b.(int) }
 

--- a/bench/out/math_mul_loop_30.go.out
+++ b/bench/out/math_mul_loop_30.go.out
@@ -6,26 +6,24 @@ import (
 	"time"
 )
 
-func mul(n any) any {
-	var result = 1
+func mul(n int) int {
+	var result int = 1
 	for i := 1; i < n; i++ {
-		result = _mul(result, i)
+		result = (result * i)
 	}
 	return result
 }
 
 func main() {
-	var n = 30
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 30
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = mul(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _mul(a, b any) any { return a.(int) * b.(int) }
 

--- a/bench/out/math_prime_count_10.go.out
+++ b/bench/out/math_prime_count_10.go.out
@@ -6,12 +6,12 @@ import (
 	"time"
 )
 
-func is_prime(n any) any {
+func is_prime(n int) bool {
 	if (n < 2) {
 		return true
 	}
 	for i := 2; i < ((n - 1)); i++ {
-		if (_mod(n, i) == 0) {
+		if ((n % i) == 0) {
 			return true
 		}
 	}
@@ -19,26 +19,22 @@ func is_prime(n any) any {
 }
 
 func main() {
-	var n = 10
-	var repeat = 100
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 10
+	var repeat int = 100
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for r := 0; r < repeat; r++ {
-		var count = 0
+		var count int = 0
 		for i := 2; i < n; i++ {
 			if is_prime(i) {
-				count = _add(count, 1)
+				count = (count + 1)
 			}
 		}
 		last = count
 	}
-	var end = time.Now().UnixNano()
-	var duration = (((end - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var end int = int(time.Now().UnixNano())
+	var duration int = (((end - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
-
-func _mod(a, b any) any { return a.(int) % b.(int) }
 

--- a/bench/out/math_prime_count_20.go.out
+++ b/bench/out/math_prime_count_20.go.out
@@ -6,12 +6,12 @@ import (
 	"time"
 )
 
-func is_prime(n any) any {
+func is_prime(n int) bool {
 	if (n < 2) {
 		return true
 	}
 	for i := 2; i < ((n - 1)); i++ {
-		if (_mod(n, i) == 0) {
+		if ((n % i) == 0) {
 			return true
 		}
 	}
@@ -19,26 +19,22 @@ func is_prime(n any) any {
 }
 
 func main() {
-	var n = 20
-	var repeat = 100
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 20
+	var repeat int = 100
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for r := 0; r < repeat; r++ {
-		var count = 0
+		var count int = 0
 		for i := 2; i < n; i++ {
 			if is_prime(i) {
-				count = _add(count, 1)
+				count = (count + 1)
 			}
 		}
 		last = count
 	}
-	var end = time.Now().UnixNano()
-	var duration = (((end - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var end int = int(time.Now().UnixNano())
+	var duration int = (((end - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
-
-func _mod(a, b any) any { return a.(int) % b.(int) }
 

--- a/bench/out/math_prime_count_30.go.out
+++ b/bench/out/math_prime_count_30.go.out
@@ -6,12 +6,12 @@ import (
 	"time"
 )
 
-func is_prime(n any) any {
+func is_prime(n int) bool {
 	if (n < 2) {
 		return true
 	}
 	for i := 2; i < ((n - 1)); i++ {
-		if (_mod(n, i) == 0) {
+		if ((n % i) == 0) {
 			return true
 		}
 	}
@@ -19,26 +19,22 @@ func is_prime(n any) any {
 }
 
 func main() {
-	var n = 30
-	var repeat = 100
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 30
+	var repeat int = 100
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for r := 0; r < repeat; r++ {
-		var count = 0
+		var count int = 0
 		for i := 2; i < n; i++ {
 			if is_prime(i) {
-				count = _add(count, 1)
+				count = (count + 1)
 			}
 		}
 		last = count
 	}
-	var end = time.Now().UnixNano()
-	var duration = (((end - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var end int = int(time.Now().UnixNano())
+	var duration int = (((end - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
-
-func _mod(a, b any) any { return a.(int) % b.(int) }
 

--- a/bench/out/math_sum_loop_10.go.out
+++ b/bench/out/math_sum_loop_10.go.out
@@ -6,26 +6,24 @@ import (
 	"time"
 )
 
-func sum(n any) any {
-	var total = 0
+func sum(n int) int {
+	var total int = 0
 	for i := 1; i < n; i++ {
-		total = _add(total, i)
+		total = (total + i)
 	}
 	return total
 }
 
 func main() {
-	var n = 10
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 10
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = sum(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
 

--- a/bench/out/math_sum_loop_20.go.out
+++ b/bench/out/math_sum_loop_20.go.out
@@ -6,26 +6,24 @@ import (
 	"time"
 )
 
-func sum(n any) any {
-	var total = 0
+func sum(n int) int {
+	var total int = 0
 	for i := 1; i < n; i++ {
-		total = _add(total, i)
+		total = (total + i)
 	}
 	return total
 }
 
 func main() {
-	var n = 20
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 20
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = sum(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
 

--- a/bench/out/math_sum_loop_30.go.out
+++ b/bench/out/math_sum_loop_30.go.out
@@ -6,26 +6,24 @@ import (
 	"time"
 )
 
-func sum(n any) any {
-	var total = 0
+func sum(n int) int {
+	var total int = 0
 	for i := 1; i < n; i++ {
-		total = _add(total, i)
+		total = (total + i)
 	}
 	return total
 }
 
 func main() {
-	var n = 30
-	var repeat = 1000
-	var last = 0
-	var start = time.Now().UnixNano()
+	var n int = 30
+	var repeat int = 1000
+	var last int = 0
+	var start int = int(time.Now().UnixNano())
 	for i := 0; i < repeat; i++ {
 		last = sum(n)
 	}
-	var duration = (((time.Now().UnixNano() - start)) / 1000000)
-	var output = map[string]any{"duration_ms": duration, "output": last}
+	var duration int = (((int(time.Now().UnixNano()) - start)) / 1000000)
+	var output map[string]int = map[string]int{"duration_ms": duration, "output": last}
 	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
 }
-
-func _add(a, b any) any { return a.(int) + b.(int) }
 


### PR DESCRIPTION
## Summary
- fix return type of `now()` calls in Go backend
- record variable types when compiling `let` and `var`
- track loop variable types during `for` compilation
- regenerate benchmark outputs

## Testing
- `go test ./...`
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_68405ea0830c8320a96f75ca5e7179d7