### PR TITLE
Fix map inference for Go compiler

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -792,6 +792,15 @@ func equalTypes(a, b types.Type) bool {
 	if _, ok := b.(types.AnyType); ok {
 		return true
 	}
+	if isInt64(a) && (isInt64(b) || isInt(b)) {
+		return true
+	}
+	if isInt64(b) && (isInt64(a) || isInt(a)) {
+		return true
+	}
+	if isInt(a) && isInt(b) {
+		return true
+	}
 	return reflect.DeepEqual(a, b)
 }
 


### PR DESCRIPTION
## Summary
- adjust Go compiler's `equalTypes` so int and int64 map values are compatible

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68406b31ec208320a98af988eecdddde