### PR TITLE
Adjust benchmark units to microseconds

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,110 +1,146 @@
 # Benchmarks
 
 ## math.fact_rec.10
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 21.0000 | best |
+| mochi (ts) | 385.1420 | +1734.0% |
+| mochi (py) | 579.7090 | +2660.5% |
+| mochi (interp) | 60472.0000 | +287861.9% |
 
 ## math.fact_rec.20
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 32.0000 | best |
+| mochi (ts) | 612.7460 | +1814.8% |
+| mochi (py) | 1263.8110 | +3849.4% |
+| mochi (interp) | 34057.0000 | +106328.1% |
 
 ## math.fact_rec.30
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 2 | ++Inf% |
+| mochi | 134.0000 | best |
+| mochi (ts) | 995.0940 | +642.6% |
+| mochi (py) | 3886.0300 | +2800.0% |
+| mochi (interp) | 107324.0000 | +79992.5% |
 
 ## math.fib_iter.10
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 0 | ++Inf% |
+| mochi | 4.0000 | best |
+| mochi (ts) | 262.1690 | +6454.2% |
+| mochi (py) | 388.6380 | +9615.9% |
+| mochi (interp) | 9539.0000 | +238375.0% |
 
 ## math.fib_iter.20
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 8.0000 | best |
+| mochi (ts) | 439.9140 | +5398.9% |
+| mochi (py) | 727.2470 | +8990.6% |
+| mochi (interp) | 15788.0000 | +197250.0% |
 
 ## math.fib_iter.30
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 12.0000 | best |
+| mochi (ts) | 558.6960 | +4555.8% |
+| mochi (py) | 984.8010 | +8106.7% |
+| mochi (interp) | 23535.0000 | +196025.0% |
 
 ## math.fib_rec.10
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 0 | ++Inf% |
+| mochi | 0.0000 | best |
+| mochi (py) | 11.3460 | ++Inf% |
+| mochi (ts) | 32.4680 | ++Inf% |
+| mochi (interp) | 633.0000 | ++Inf% |
 
 ## math.fib_rec.20
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 41.0000 | best |
+| mochi (ts) | 491.5120 | +1098.8% |
+| mochi (py) | 1095.4450 | +2571.8% |
+| mochi (interp) | 64237.0000 | +156575.6% |
 
 ## math.fib_rec.30
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 4 | best |
-| mochi (py) | 131 | +3180.1% |
+| mochi | 4631.0000 | best |
+| mochi (ts) | 9904.6190 | +113.9% |
+| mochi (py) | 130694.5020 | +2722.2% |
+| mochi (interp) | 5436314.0000 | +117289.6% |
 
 ## math.mul_loop.10
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 0 | ++Inf% |
+| mochi | 3.0000 | best |
+| mochi (ts) | 243.9810 | +8032.7% |
+| mochi (py) | 348.8260 | +11527.5% |
+| mochi (interp) | 6646.0000 | +221433.3% |
 
 ## math.mul_loop.20
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 8.0000 | best |
+| mochi (ts) | 416.4410 | +5105.5% |
+| mochi (py) | 755.8730 | +9348.4% |
+| mochi (interp) | 11832.0000 | +147800.0% |
 
 ## math.mul_loop.30
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 12.0000 | best |
+| mochi (ts) | 736.1370 | +6034.5% |
+| mochi (py) | 1295.7190 | +10697.7% |
+| mochi (interp) | 13747.0000 | +114458.3% |
 
 ## math.prime_count.10
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 0 | ++Inf% |
+| mochi | 6.0000 | best |
+| mochi (ts) | 134.8520 | +2147.5% |
+| mochi (py) | 201.1800 | +3253.0% |
+| mochi (interp) | 5157.0000 | +85850.0% |
 
 ## math.prime_count.20
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 23.0000 | best |
+| mochi (ts) | 297.5860 | +1193.9% |
+| mochi (py) | 556.0400 | +2317.6% |
+| mochi (interp) | 8229.0000 | +35678.3% |
 
 ## math.prime_count.30
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 36.0000 | best |
+| mochi (ts) | 488.7260 | +1257.6% |
+| mochi (py) | 1008.1050 | +2700.3% |
+| mochi (interp) | 15938.0000 | +44172.2% |
 
 ## math.sum_loop.10
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 0 | ++Inf% |
+| mochi | 3.0000 | best |
+| mochi (ts) | 218.7200 | +7190.7% |
+| mochi (py) | 314.6060 | +10386.9% |
+| mochi (interp) | 7636.0000 | +254433.3% |
 
 ## math.sum_loop.20
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 6.0000 | best |
+| mochi (ts) | 357.3930 | +5856.5% |
+| mochi (py) | 630.7300 | +10412.2% |
+| mochi (interp) | 9534.0000 | +158800.0% |
 
 ## math.sum_loop.30
-| Language | Time (ms) | +/- |
+| Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| mochi | 0 | best |
-| mochi (py) | 1 | ++Inf% |
+| mochi | 18.0000 | best |
+| mochi (ts) | 736.2500 | +3990.3% |
+| mochi (py) | 750.3300 | +4068.5% |
+| mochi (interp) | 13150.0000 | +72955.6% |
 

--- a/bench/out/math_fact_rec_10.go.out
+++ b/bench/out/math_fact_rec_10.go.out
@@ -7,7 +7,7 @@ import (
 )
 
 func fact(n int) int {
-	if (n == 0) {
+	if n == 0 {
 		return 1
 	}
 	return (n * fact((n - 1)))
@@ -21,8 +21,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = fact(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fact_rec_10.py.out
+++ b/bench/out/math_fact_rec_10.py.out
@@ -15,8 +15,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = fact(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fact_rec_10.ts.out
+++ b/bench/out/math_fact_rec_10.ts.out
@@ -15,8 +15,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = fact(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fact_rec_20.go.out
+++ b/bench/out/math_fact_rec_20.go.out
@@ -7,7 +7,7 @@ import (
 )
 
 func fact(n int) int {
-	if (n == 0) {
+	if n == 0 {
 		return 1
 	}
 	return (n * fact((n - 1)))
@@ -21,8 +21,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = fact(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fact_rec_20.py.out
+++ b/bench/out/math_fact_rec_20.py.out
@@ -15,8 +15,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = fact(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fact_rec_20.ts.out
+++ b/bench/out/math_fact_rec_20.ts.out
@@ -15,8 +15,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = fact(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fact_rec_30.go.out
+++ b/bench/out/math_fact_rec_30.go.out
@@ -7,7 +7,7 @@ import (
 )
 
 func fact(n int) int {
-	if (n == 0) {
+	if n == 0 {
 		return 1
 	}
 	return (n * fact((n - 1)))
@@ -21,8 +21,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = fact(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fact_rec_30.py.out
+++ b/bench/out/math_fact_rec_30.py.out
@@ -15,8 +15,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = fact(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fact_rec_30.ts.out
+++ b/bench/out/math_fact_rec_30.ts.out
@@ -15,8 +15,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = fact(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fib_iter_10.go.out
+++ b/bench/out/math_fib_iter_10.go.out
@@ -25,8 +25,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = fib(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fib_iter_10.py.out
+++ b/bench/out/math_fib_iter_10.py.out
@@ -19,8 +19,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = fib(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fib_iter_10.ts.out
+++ b/bench/out/math_fib_iter_10.ts.out
@@ -19,8 +19,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = fib(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fib_iter_20.go.out
+++ b/bench/out/math_fib_iter_20.go.out
@@ -25,8 +25,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = fib(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fib_iter_20.py.out
+++ b/bench/out/math_fib_iter_20.py.out
@@ -19,8 +19,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = fib(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fib_iter_20.ts.out
+++ b/bench/out/math_fib_iter_20.ts.out
@@ -19,8 +19,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = fib(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fib_iter_30.go.out
+++ b/bench/out/math_fib_iter_30.go.out
@@ -25,8 +25,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = fib(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fib_iter_30.py.out
+++ b/bench/out/math_fib_iter_30.py.out
@@ -19,8 +19,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = fib(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fib_iter_30.ts.out
+++ b/bench/out/math_fib_iter_30.ts.out
@@ -19,8 +19,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = fib(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fib_rec_10.go.out
+++ b/bench/out/math_fib_rec_10.go.out
@@ -7,7 +7,7 @@ import (
 )
 
 func fib(n int) int {
-	if (n <= 1) {
+	if n <= 1 {
 		return n
 	}
 	return (fib((n - 1)) + fib((n - 2)))
@@ -17,8 +17,7 @@ func main() {
 	var n int = 10
 	var start int64 = time.Now().UnixNano()
 	var result int = fib(n)
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(result)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(result)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fib_rec_10.py.out
+++ b/bench/out/math_fib_rec_10.py.out
@@ -12,8 +12,8 @@ def main():
 	n = 10
 	start = time.time_ns()
 	result = fib(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": result}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": result}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fib_rec_10.ts.out
+++ b/bench/out/math_fib_rec_10.ts.out
@@ -11,8 +11,8 @@ function main(): void {
 	let n = 10
 	let start = performance.now() * 1000000
 	let result = fib(n)
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: result}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: result}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fib_rec_20.go.out
+++ b/bench/out/math_fib_rec_20.go.out
@@ -7,7 +7,7 @@ import (
 )
 
 func fib(n int) int {
-	if (n <= 1) {
+	if n <= 1 {
 		return n
 	}
 	return (fib((n - 1)) + fib((n - 2)))
@@ -17,8 +17,7 @@ func main() {
 	var n int = 20
 	var start int64 = time.Now().UnixNano()
 	var result int = fib(n)
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(result)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(result)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fib_rec_20.py.out
+++ b/bench/out/math_fib_rec_20.py.out
@@ -12,8 +12,8 @@ def main():
 	n = 20
 	start = time.time_ns()
 	result = fib(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": result}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": result}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fib_rec_20.ts.out
+++ b/bench/out/math_fib_rec_20.ts.out
@@ -11,8 +11,8 @@ function main(): void {
 	let n = 20
 	let start = performance.now() * 1000000
 	let result = fib(n)
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: result}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: result}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_fib_rec_30.go.out
+++ b/bench/out/math_fib_rec_30.go.out
@@ -7,7 +7,7 @@ import (
 )
 
 func fib(n int) int {
-	if (n <= 1) {
+	if n <= 1 {
 		return n
 	}
 	return (fib((n - 1)) + fib((n - 2)))
@@ -17,8 +17,7 @@ func main() {
 	var n int = 30
 	var start int64 = time.Now().UnixNano()
 	var result int = fib(n)
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(result)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(result)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_fib_rec_30.py.out
+++ b/bench/out/math_fib_rec_30.py.out
@@ -12,8 +12,8 @@ def main():
 	n = 30
 	start = time.time_ns()
 	result = fib(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": result}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": result}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_fib_rec_30.ts.out
+++ b/bench/out/math_fib_rec_30.ts.out
@@ -11,8 +11,8 @@ function main(): void {
 	let n = 30
 	let start = performance.now() * 1000000
 	let result = fib(n)
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: result}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: result}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_mul_loop_10.go.out
+++ b/bench/out/math_mul_loop_10.go.out
@@ -22,8 +22,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = mul(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_mul_loop_10.py.out
+++ b/bench/out/math_mul_loop_10.py.out
@@ -16,8 +16,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = mul(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_mul_loop_10.ts.out
+++ b/bench/out/math_mul_loop_10.ts.out
@@ -16,8 +16,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = mul(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_mul_loop_20.go.out
+++ b/bench/out/math_mul_loop_20.go.out
@@ -22,8 +22,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = mul(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_mul_loop_20.py.out
+++ b/bench/out/math_mul_loop_20.py.out
@@ -16,8 +16,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = mul(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_mul_loop_20.ts.out
+++ b/bench/out/math_mul_loop_20.ts.out
@@ -16,8 +16,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = mul(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_mul_loop_30.go.out
+++ b/bench/out/math_mul_loop_30.go.out
@@ -22,8 +22,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = mul(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_mul_loop_30.py.out
+++ b/bench/out/math_mul_loop_30.py.out
@@ -16,8 +16,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = mul(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_mul_loop_30.ts.out
+++ b/bench/out/math_mul_loop_30.ts.out
@@ -16,8 +16,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = mul(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_prime_count_10.go.out
+++ b/bench/out/math_prime_count_10.go.out
@@ -7,11 +7,11 @@ import (
 )
 
 func is_prime(n int) bool {
-	if (n < 2) {
+	if n < 2 {
 		return true
 	}
-	for i := 2; i < ((n - 1)); i++ {
-		if ((n % i) == 0) {
+	for i := 2; i < (n - 1); i++ {
+		if (n % i) == 0 {
 			return true
 		}
 	}
@@ -33,8 +33,7 @@ func main() {
 		last = count
 	}
 	var end int64 = time.Now().UnixNano()
-	var duration int64 = (int64(((int64(end) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(end) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_prime_count_10.py.out
+++ b/bench/out/math_prime_count_10.py.out
@@ -23,8 +23,8 @@ def main():
 				count = (count + 1)
 		last = count
 	end = time.time_ns()
-	duration = (((end - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((end - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_prime_count_10.ts.out
+++ b/bench/out/math_prime_count_10.ts.out
@@ -27,8 +27,8 @@ function main(): void {
 		last = count
 	}
 	let end = performance.now() * 1000000
-	let duration = (((end - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((end - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_prime_count_20.go.out
+++ b/bench/out/math_prime_count_20.go.out
@@ -7,11 +7,11 @@ import (
 )
 
 func is_prime(n int) bool {
-	if (n < 2) {
+	if n < 2 {
 		return true
 	}
-	for i := 2; i < ((n - 1)); i++ {
-		if ((n % i) == 0) {
+	for i := 2; i < (n - 1); i++ {
+		if (n % i) == 0 {
 			return true
 		}
 	}
@@ -33,8 +33,7 @@ func main() {
 		last = count
 	}
 	var end int64 = time.Now().UnixNano()
-	var duration int64 = (int64(((int64(end) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(end) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_prime_count_20.py.out
+++ b/bench/out/math_prime_count_20.py.out
@@ -23,8 +23,8 @@ def main():
 				count = (count + 1)
 		last = count
 	end = time.time_ns()
-	duration = (((end - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((end - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_prime_count_20.ts.out
+++ b/bench/out/math_prime_count_20.ts.out
@@ -27,8 +27,8 @@ function main(): void {
 		last = count
 	}
 	let end = performance.now() * 1000000
-	let duration = (((end - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((end - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_prime_count_30.go.out
+++ b/bench/out/math_prime_count_30.go.out
@@ -7,11 +7,11 @@ import (
 )
 
 func is_prime(n int) bool {
-	if (n < 2) {
+	if n < 2 {
 		return true
 	}
-	for i := 2; i < ((n - 1)); i++ {
-		if ((n % i) == 0) {
+	for i := 2; i < (n - 1); i++ {
+		if (n % i) == 0 {
 			return true
 		}
 	}
@@ -33,8 +33,7 @@ func main() {
 		last = count
 	}
 	var end int64 = time.Now().UnixNano()
-	var duration int64 = (int64(((int64(end) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(end) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_prime_count_30.py.out
+++ b/bench/out/math_prime_count_30.py.out
@@ -23,8 +23,8 @@ def main():
 				count = (count + 1)
 		last = count
 	end = time.time_ns()
-	duration = (((end - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((end - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_prime_count_30.ts.out
+++ b/bench/out/math_prime_count_30.ts.out
@@ -27,8 +27,8 @@ function main(): void {
 		last = count
 	}
 	let end = performance.now() * 1000000
-	let duration = (((end - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((end - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_sum_loop_10.go.out
+++ b/bench/out/math_sum_loop_10.go.out
@@ -22,8 +22,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = sum(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_sum_loop_10.py.out
+++ b/bench/out/math_sum_loop_10.py.out
@@ -16,8 +16,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = sum(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_sum_loop_10.ts.out
+++ b/bench/out/math_sum_loop_10.ts.out
@@ -16,8 +16,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = sum(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_sum_loop_20.go.out
+++ b/bench/out/math_sum_loop_20.go.out
@@ -22,8 +22,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = sum(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_sum_loop_20.py.out
+++ b/bench/out/math_sum_loop_20.py.out
@@ -16,8 +16,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = sum(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_sum_loop_20.ts.out
+++ b/bench/out/math_sum_loop_20.ts.out
@@ -16,8 +16,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = sum(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/out/math_sum_loop_30.go.out
+++ b/bench/out/math_sum_loop_30.go.out
@@ -22,8 +22,7 @@ func main() {
 	for i := 0; i < repeat; i++ {
 		last = sum(n)
 	}
-	var duration int64 = (int64(((int64(time.Now().UnixNano()) - int64(start)))) / int64(1000000))
-	var output map[string]int64 = map[string]int64{"duration_ms": duration, "output": int64(last)}
-	func(){b,_:=json.Marshal(output);fmt.Println(string(b))}()
+	var duration int64 = (int64((int64(time.Now().UnixNano()) - int64(start))) / int64(1000))
+	var output map[string]int64 = map[string]int64{"duration_us": duration, "output": int64(last)}
+	func() { b, _ := json.Marshal(output); fmt.Println(string(b)) }()
 }
-

--- a/bench/out/math_sum_loop_30.py.out
+++ b/bench/out/math_sum_loop_30.py.out
@@ -16,8 +16,8 @@ def main():
 	start = time.time_ns()
 	for i in range(0, repeat):
 		last = sum(n)
-	duration = (((time.time_ns() - start)) / 1000000)
-	output = {"duration_ms": duration, "output": last}
+	duration = (((time.time_ns() - start)) / 1000)
+	output = {"duration_us": duration, "output": last}
 	print(json.dumps(output))
 
 if __name__ == "__main__":

--- a/bench/out/math_sum_loop_30.ts.out
+++ b/bench/out/math_sum_loop_30.ts.out
@@ -16,8 +16,8 @@ function main(): void {
 	for (let i = 0; i < repeat; i++) {
 		last = sum(n)
 	}
-	let duration = (((performance.now() * 1000000 - start)) / 1000000)
-	let output = {["duration_ms"]: duration, ["output"]: last}
+	let duration = (((performance.now() * 1000000 - start)) / 1000)
+	let output = {["duration_us"]: duration, ["output"]: last}
 	console.log(JSON.stringify(output))
 }
 main()

--- a/bench/template/math/fact_rec/fact_rec.mochi
+++ b/bench/template/math/fact_rec/fact_rec.mochi
@@ -14,10 +14,10 @@ let start = now()
 for i in 0..repeat {
   last = fact(n)
 }
-let duration = (now() - start) / 1000000
+let duration = (now() - start) / 1000
 
 let output = {
-  "duration_ms": duration,
+  "duration_us": duration,
   "output": last,
 }
 json(output)

--- a/bench/template/math/fib_iter/fib_iter.mochi
+++ b/bench/template/math/fib_iter/fib_iter.mochi
@@ -18,10 +18,10 @@ let start = now()
 for i in 0..repeat {
   last = fib(n)
 }
-let duration = (now() - start) / 1000000
+let duration = (now() - start) / 1000
 
 let output = {
-  "duration_ms": duration,
+  "duration_us": duration,
   "output": last,
 }
 json(output)

--- a/bench/template/math/fib_rec/fib_rec.mochi
+++ b/bench/template/math/fib_rec/fib_rec.mochi
@@ -7,10 +7,10 @@ fun fib(n: int): int {
 let n = {{ .N }}
 let start = now()
 let result = fib(n)
-let duration = (now() - start) / 1000000
+let duration = (now() - start) / 1000
 
 let output = {
-    "duration_ms": duration,
+    "duration_us": duration,
     "output": result,
 }
 json(output)

--- a/bench/template/math/matrix_mul/matrix_mul.mochi
+++ b/bench/template/math/matrix_mul/matrix_mul.mochi
@@ -48,10 +48,10 @@ for i in 0..repeat {
   last = matmul(a, b)
 }
 let end = now()
-let duration = (end - start) / 1000000
+let duration = (end - start) / 1000
 // print(start, end, end-start, duration)
 
 json({
-  "duration_ms": duration,
+  "duration_us": duration,
   "output": last[0][0], // last[0][0] type any does not support indexing
 })

--- a/bench/template/math/mul_loop/mul_loop.mochi
+++ b/bench/template/math/mul_loop/mul_loop.mochi
@@ -15,10 +15,10 @@ let start = now()
 for i in 0..repeat {
   last = mul(n)
 }
-let duration = (now() - start) / 1000000
+let duration = (now() - start) / 1000
 
 let output = {
-  "duration_ms": duration,
+  "duration_us": duration,
   "output": last,
 }
 json(output)

--- a/bench/template/math/prime_count/prime_count.mochi
+++ b/bench/template/math/prime_count/prime_count.mochi
@@ -24,11 +24,11 @@ for r in 0..repeat {
   last = count
 }
 let end = now()
-let duration = (end - start) / 1000000
+let duration = (end - start) / 1000
 // print(start, end, end - start, duration)
 
 let output = {
-  "duration_ms": duration,
+  "duration_us": duration,
   "output": last,
 }
 json(output)

--- a/bench/template/math/sum_loop/sum_loop.mochi
+++ b/bench/template/math/sum_loop/sum_loop.mochi
@@ -14,11 +14,11 @@ let start = now()
 for i in 0..repeat {
   last = sum(n)
 }
-let duration = (now() - start) / 1000000
+let duration = (now() - start) / 1000
 
 
 let output = {
-  "duration_ms": duration,
+  "duration_us": duration,
   "output": last,
 }
 json(output)


### PR DESCRIPTION
## Summary
- switch benchmark templates from milliseconds to microseconds
- update runner to handle `duration_us` and display µs
- regenerate benchmark outputs and markdown

## Testing
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_68406f873bdc8320aceda5eda15aac64