### PR TITLE
Add Go and Python compile targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ Compile a Mochi source file into a standalone binary:
 ./hello
 ```
 
-Generate TypeScript instead of a binary with the `--ts` flag:
+Generate Go, Python or TypeScript code by setting a target or using the output
+extension:
 
 ```bash
-./mochi build --ts examples/hello.mochi -o hello.ts
+./mochi build examples/hello.mochi -o hello.go             # auto-detects Go
+./mochi build --target py examples/hello.mochi -o hello.py
+./mochi build --target ts examples/hello.mochi -o hello.ts
 ```
 
 ### Mochi CLI


### PR DESCRIPTION
## Summary
- add `--target` option to `mochi build`
- auto-detect build target from output extension
- update README examples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684074b0117483208e8b7bbbdf7024f6