### PR TITLE
Add v0.2.10 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # 📦 CHANGELOG.md
 
+## [0.2.10] – 2025-06-07
+
+### Added
+
+* Python compiler via `mochi build --target py` or `.py` output
+* Build command auto-detects target language from extension
+* Benchmarks auto-install Mochi, Deno and Python
+
+### Changed
+
+* Benchmarks measure durations in microseconds
+* Clarified benchmark labels and merged test code
+
+### Fixed
+
+* Go compiler handles map literals with int values
+
 ## [0.2.9] – 2025-06-06
 
 ### Added

--- a/releases/v0.2.10.md
+++ b/releases/v0.2.10.md
@@ -1,0 +1,20 @@
+# June 2025 (v0.2.10)
+
+This release expands Mochi's multi-language tooling and streamlines the benchmark workflow.
+
+## Python Code Generation
+
+`mochi build` can now emit Python source by using `--target py` or a `.py` output file. The new compiler is tested with golden files so generated code is predictable across versions.
+
+## Automatic Target Selection
+
+The build command detects the desired output language from `--target` or the file extension. Supported targets are Go (`.go`), Python (`.py`) and TypeScript (`.ts`). Without a target it still produces a native binary.
+
+## Smarter Benchmarks
+
+The benchmark runner installs required tools (Mochi, Deno and Python) on demand and measures durations in microseconds for better precision. Output labels have been clarified and duplicate test code has been consolidated.
+
+## Compiler Fixes
+
+Map literal handling in the Go backend now casts integer values to `int64`, resolving previous type errors.
+


### PR DESCRIPTION
## Summary
- add release notes for v0.2.10
- update CHANGELOG for v0.2.10

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840771af1008320a1cc6a12bfd4f6c7