### PR TITLE
Add extensible LLM runtime package

### DIFF
--- a/runtime/llm/doc.go
+++ b/runtime/llm/doc.go
@@ -1,0 +1,8 @@
+package llm
+
+// Package llm provides a pluggable runtime for large language models.
+//
+// It is inspired by Go's database/sql package and allows different
+// providers to implement the low level communication with an LLM backend.
+// The high level Client API exposed here handles message formatting,
+// tool calls, structured output and optional streaming.

--- a/runtime/llm/llm.go
+++ b/runtime/llm/llm.go
@@ -1,0 +1,69 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+var (
+	mu        sync.RWMutex
+	providers = make(map[string]Provider)
+)
+
+// Register makes a provider available by name.
+// If a provider with the same name is already registered, it panics.
+func Register(name string, p Provider) {
+	mu.Lock()
+	defer mu.Unlock()
+	if name == "" {
+		panic("llm: empty provider name")
+	}
+	if p == nil {
+		panic("llm: provider is nil")
+	}
+	if _, dup := providers[name]; dup {
+		panic("llm: Register called twice for provider " + name)
+	}
+	providers[name] = p
+}
+
+// Open opens a new LLM client using the named provider.
+func Open(providerName string, opts Options) (*Client, error) {
+	mu.RLock()
+	prv := providers[providerName]
+	mu.RUnlock()
+	if prv == nil {
+		return nil, fmt.Errorf("llm: unknown provider %q", providerName)
+	}
+	conn, err := prv.Open(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{conn: conn}, nil
+}
+
+// Client represents a connection to an LLM backend.
+type Client struct{ conn Conn }
+
+// Close closes the underlying connection.
+func (c *Client) Close() error { return c.conn.Close() }
+
+// Chat sends the messages to the model and returns a single response.
+func (c *Client) Chat(ctx context.Context, msgs []Message, opts ...Option) (*ChatResponse, error) {
+	req := ChatRequest{Messages: msgs}
+	for _, opt := range opts {
+		opt(&req)
+	}
+	return c.conn.Chat(ctx, req)
+}
+
+// ChatStream requests a streaming response.
+func (c *Client) ChatStream(ctx context.Context, msgs []Message, opts ...Option) (Stream, error) {
+	req := ChatRequest{Messages: msgs, Stream: true}
+	for _, opt := range opts {
+		opt(&req)
+	}
+	req.Stream = true
+	return c.conn.ChatStream(ctx, req)
+}

--- a/runtime/llm/llm_test.go
+++ b/runtime/llm/llm_test.go
@@ -1,0 +1,105 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// echoProvider is a simple provider used for tests. It echoes the last user message.
+type echoProvider struct{}
+
+type echoConn struct{ opts Options }
+
+type echoStream struct {
+	content []rune
+	i       int
+}
+
+func (e echoProvider) Open(opts Options) (Conn, error) {
+	return &echoConn{opts: opts}, nil
+}
+
+func (c *echoConn) Close() error { return nil }
+
+func (c *echoConn) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	if len(req.Messages) == 0 {
+		return nil, errors.New("no messages")
+	}
+	last := req.Messages[len(req.Messages)-1]
+	return &ChatResponse{Message: Message{Role: "assistant", Content: last.Content}}, nil
+}
+
+func (c *echoConn) ChatStream(ctx context.Context, req ChatRequest) (Stream, error) {
+	if len(req.Messages) == 0 {
+		return nil, errors.New("no messages")
+	}
+	last := req.Messages[len(req.Messages)-1]
+	return &echoStream{content: []rune(last.Content)}, nil
+}
+
+func (s *echoStream) Recv() (*Chunk, error) {
+	if s.i >= len(s.content) {
+		return &Chunk{Done: true}, nil
+	}
+	ch := &Chunk{Content: string(s.content[s.i])}
+	s.i++
+	return ch, nil
+}
+
+func (s *echoStream) Close() error { return nil }
+
+func TestRegisterOpenChat(t *testing.T) {
+	mu.Lock()
+	providers = make(map[string]Provider)
+	mu.Unlock()
+	Register("echo", echoProvider{})
+
+	c, err := Open("echo", Options{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer c.Close()
+
+	resp, err := c.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if resp.Message.Content != "hi" {
+		t.Fatalf("unexpected response: %q", resp.Message.Content)
+	}
+}
+
+func TestChatStream(t *testing.T) {
+	mu.Lock()
+	providers = make(map[string]Provider)
+	mu.Unlock()
+	Register("echo", echoProvider{})
+
+	c, err := Open("echo", Options{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer c.Close()
+
+	stream, err := c.ChatStream(context.Background(), []Message{{Role: "user", Content: "yo"}})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var out string
+	for {
+		chunk, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		if chunk.Done {
+			break
+		}
+		out += chunk.Content
+	}
+
+	if out != "yo" {
+		t.Fatalf("unexpected stream output %q", out)
+	}
+}

--- a/runtime/llm/options.go
+++ b/runtime/llm/options.go
@@ -1,0 +1,44 @@
+package llm
+
+// Options are used when opening a connection to a provider.
+type Options struct {
+	Model          string
+	Temperature    float64
+	MaxTokens      int
+	Tools          []Tool
+	ToolChoice     string
+	ResponseFormat string
+}
+
+// ChatRequest contains the messages and per-call options sent to the provider.
+type ChatRequest struct {
+	Messages []Message
+	Options
+	Stream bool
+}
+
+// Option is a functional option for chat requests.
+type Option func(*ChatRequest)
+
+// WithModel sets the model name.
+func WithModel(model string) Option { return func(r *ChatRequest) { r.Model = model } }
+
+// WithTemperature sets the sampling temperature.
+func WithTemperature(t float64) Option { return func(r *ChatRequest) { r.Temperature = t } }
+
+// WithMaxTokens limits the number of completion tokens.
+func WithMaxTokens(n int) Option { return func(r *ChatRequest) { r.MaxTokens = n } }
+
+// WithTools declares available tools for the request.
+func WithTools(tools []Tool) Option { return func(r *ChatRequest) { r.Tools = tools } }
+
+// WithToolChoice specifies which tool should be used.
+func WithToolChoice(choice string) Option { return func(r *ChatRequest) { r.ToolChoice = choice } }
+
+// WithResponseFormat requests structured output.
+func WithResponseFormat(format string) Option {
+	return func(r *ChatRequest) { r.ResponseFormat = format }
+}
+
+// WithStream enables streaming responses.
+func WithStream() Option { return func(r *ChatRequest) { r.Stream = true } }

--- a/runtime/llm/types.go
+++ b/runtime/llm/types.go
@@ -1,0 +1,66 @@
+package llm
+
+import "context"
+
+// Message represents a chat message exchanged with the model.
+type Message struct {
+	Role    string
+	Content string
+	// Optional tool call returned by the model.
+	ToolCall *ToolCall
+}
+
+// ToolCall represents a request from the model to execute a tool.
+type ToolCall struct {
+	ID   string
+	Name string
+	Args map[string]any
+}
+
+// Tool defines a function that can be called by the model.
+type Tool struct {
+	Name        string
+	Description string
+	Parameters  map[string]any
+}
+
+// Usage tracks token usage information when provided by the provider.
+type Usage struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}
+
+// ChatResponse is a single response from the model.
+type ChatResponse struct {
+	Message    Message
+	Model      string
+	StopReason string
+	Usage      *Usage
+}
+
+// Chunk represents a streamed piece of a response.
+type Chunk struct {
+	Content   string
+	ToolCalls []ToolCall
+	Done      bool
+}
+
+// Stream yields chunks until completion or error.
+type Stream interface {
+	Recv() (*Chunk, error)
+	Close() error
+}
+
+// Conn is implemented by providers to handle the actual communication
+// with the backing LLM service.
+type Conn interface {
+	Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error)
+	ChatStream(ctx context.Context, req ChatRequest) (Stream, error)
+	Close() error
+}
+
+// Provider opens new connections for a given configuration.
+type Provider interface {
+	Open(opts Options) (Conn, error)
+}


### PR DESCRIPTION
## Summary
- implement `runtime/llm` modeled after `database/sql`
- allow registering drivers and opening a client
- support tool definitions, structured output and streaming
- include small echo driver tests
- rename Driver to Provider

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68408d8a9bb48320b15cd9d22ffbd673