### PR TITLE
Implement REST providers for LLMs

### DIFF
--- a/runtime/llm/provider/claude/claude.go
+++ b/runtime/llm/provider/claude/claude.go
@@ -1,0 +1,194 @@
+package claude
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"mochi/runtime/llm"
+)
+
+// Claude (Anthropic) provider using REST API.
+
+type provider struct{}
+
+type conn struct {
+	opts       llm.Options
+	key        string
+	baseURL    string
+	version    string
+	httpClient *http.Client
+}
+
+func init() { llm.Register("claude", provider{}) }
+
+func (provider) Open(opts llm.Options) (llm.Conn, error) {
+	key := os.Getenv("ANTHROPIC_API_KEY")
+	if key == "" {
+		key = os.Getenv("CLAUDE_API_KEY")
+	}
+	if key == "" {
+		return nil, errors.New("claude: missing ANTHROPIC_API_KEY")
+	}
+	base := os.Getenv("ANTHROPIC_BASE_URL")
+	if base == "" {
+		base = "https://api.anthropic.com/v1"
+	}
+	ver := os.Getenv("ANTHROPIC_VERSION")
+	if ver == "" {
+		ver = "2023-06-01"
+	}
+	return &conn{opts: opts, key: key, baseURL: base, version: ver, httpClient: http.DefaultClient}, nil
+}
+
+func (c *conn) Close() error { return nil }
+
+func (c *conn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("claude: %s", b)
+	}
+	var r struct {
+		ID      string `json:"id"`
+		Model   string `json:"model"`
+		Role    string `json:"role"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+		StopReason string `json:"stop_reason"`
+		Usage      struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	text := ""
+	if len(r.Content) > 0 {
+		text = r.Content[0].Text
+	}
+	msg := llm.Message{Role: "assistant", Content: text}
+	usage := &llm.Usage{PromptTokens: r.Usage.InputTokens, CompletionTokens: r.Usage.OutputTokens, TotalTokens: r.Usage.InputTokens + r.Usage.OutputTokens}
+	return &llm.ChatResponse{Message: msg, Model: r.Model, StopReason: r.StopReason, Usage: usage}, nil
+}
+
+func (c *conn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	req.Stream = true
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("claude: %s", b)
+	}
+	return &stream{r: bufio.NewReader(resp.Body), body: resp.Body}, nil
+}
+
+type stream struct {
+	r    *bufio.Reader
+	body io.ReadCloser
+}
+
+func (s *stream) Recv() (*llm.Chunk, error) {
+	for {
+		line, err := s.r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			return &llm.Chunk{Done: true}, nil
+		}
+		var r struct {
+			Type  string `json:"type"`
+			Delta struct {
+				Text       string `json:"text"`
+				StopReason string `json:"stop_reason"`
+			} `json:"delta"`
+		}
+		if err := json.Unmarshal([]byte(data), &r); err != nil {
+			continue
+		}
+		if r.Type == "message_delta" && r.Delta.StopReason != "" {
+			return &llm.Chunk{Done: true}, nil
+		}
+		if r.Type == "content_block_delta" {
+			return &llm.Chunk{Content: r.Delta.Text}, nil
+		}
+	}
+}
+
+func (s *stream) Close() error { return s.body.Close() }
+
+func (c *conn) doRequest(ctx context.Context, req llm.ChatRequest) (*http.Response, error) {
+	model := req.Model
+	if model == "" {
+		model = c.opts.Model
+	}
+	payload := map[string]any{
+		"model":    model,
+		"messages": convertMessages(req.Messages),
+	}
+	temp := req.Temperature
+	if temp == 0 {
+		temp = c.opts.Temperature
+	}
+	if temp != 0 {
+		payload["temperature"] = temp
+	}
+	mt := req.MaxTokens
+	if mt == 0 {
+		mt = c.opts.MaxTokens
+	}
+	if mt != 0 {
+		payload["max_tokens"] = mt
+	}
+	if req.Stream {
+		payload["stream"] = true
+	}
+	if len(req.Tools) > 0 {
+		payload["tools"] = req.Tools
+	}
+	if req.ToolChoice != "" {
+		payload["tool_choice"] = req.ToolChoice
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/messages", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-API-Key", c.key)
+	httpReq.Header.Set("anthropic-version", c.version)
+	return c.httpClient.Do(httpReq)
+}
+
+func convertMessages(msgs []llm.Message) []map[string]any {
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, map[string]any{"role": m.Role, "content": m.Content})
+	}
+	return out
+}

--- a/runtime/llm/provider/cohere/cohere.go
+++ b/runtime/llm/provider/cohere/cohere.go
@@ -1,0 +1,173 @@
+package cohere
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"mochi/runtime/llm"
+)
+
+// Cohere provider using REST API.
+
+type provider struct{}
+
+type conn struct {
+	opts       llm.Options
+	key        string
+	baseURL    string
+	httpClient *http.Client
+}
+
+func init() { llm.Register("cohere", provider{}) }
+
+func (provider) Open(opts llm.Options) (llm.Conn, error) {
+	key := os.Getenv("COHERE_API_KEY")
+	if key == "" {
+		return nil, errors.New("cohere: missing COHERE_API_KEY")
+	}
+	base := os.Getenv("COHERE_BASE_URL")
+	if base == "" {
+		base = "https://api.cohere.ai/v1"
+	}
+	return &conn{opts: opts, key: key, baseURL: base, httpClient: http.DefaultClient}, nil
+}
+
+func (c *conn) Close() error { return nil }
+
+func (c *conn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("cohere: %s", b)
+	}
+	var r struct {
+		Text  string `json:"text"`
+		Model string `json:"model"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	msg := llm.Message{Role: "assistant", Content: r.Text}
+	return &llm.ChatResponse{Message: msg, Model: r.Model}, nil
+}
+
+func (c *conn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	req.Stream = true
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("cohere: %s", b)
+	}
+	return &stream{r: bufio.NewReader(resp.Body), body: resp.Body}, nil
+}
+
+type stream struct {
+	r    *bufio.Reader
+	body io.ReadCloser
+}
+
+func (s *stream) Recv() (*llm.Chunk, error) {
+	for {
+		line, err := s.r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			return &llm.Chunk{Done: true}, nil
+		}
+		var r struct {
+			Text       string `json:"text"`
+			IsFinished bool   `json:"is_finished"`
+		}
+		if err := json.Unmarshal([]byte(data), &r); err != nil {
+			continue
+		}
+		if r.IsFinished {
+			return &llm.Chunk{Done: true}, nil
+		}
+		return &llm.Chunk{Content: r.Text}, nil
+	}
+}
+
+func (s *stream) Close() error { return s.body.Close() }
+
+func (c *conn) doRequest(ctx context.Context, req llm.ChatRequest) (*http.Response, error) {
+	model := req.Model
+	if model == "" {
+		model = c.opts.Model
+	}
+	message, history := prepareMessages(req.Messages)
+	payload := map[string]any{
+		"model":   model,
+		"message": message,
+	}
+	if len(history) > 0 {
+		payload["chat_history"] = history
+	}
+	temp := req.Temperature
+	if temp == 0 {
+		temp = c.opts.Temperature
+	}
+	if temp != 0 {
+		payload["temperature"] = temp
+	}
+	mt := req.MaxTokens
+	if mt == 0 {
+		mt = c.opts.MaxTokens
+	}
+	if mt != 0 {
+		payload["max_tokens"] = mt
+	}
+	if req.Stream {
+		payload["stream"] = true
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/chat", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.key)
+	httpReq.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(httpReq)
+}
+
+func prepareMessages(msgs []llm.Message) (string, []map[string]string) {
+	var history []map[string]string
+	var last string
+	for i, m := range msgs {
+		role := strings.ToUpper(m.Role)
+		if i == len(msgs)-1 {
+			last = m.Content
+		} else {
+			if role == "ASSISTANT" {
+				role = "CHATBOT"
+			}
+			history = append(history, map[string]string{"role": role, "message": m.Content})
+		}
+	}
+	return last, history
+}

--- a/runtime/llm/provider/mistral/mistral.go
+++ b/runtime/llm/provider/mistral/mistral.go
@@ -1,0 +1,183 @@
+package mistral
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"mochi/runtime/llm"
+)
+
+type provider struct{}
+
+type conn struct {
+	opts       llm.Options
+	key        string
+	baseURL    string
+	httpClient *http.Client
+}
+
+func init() { llm.Register("mistral", provider{}) }
+
+func (provider) Open(opts llm.Options) (llm.Conn, error) {
+	key := os.Getenv("MISTRAL_API_KEY")
+	if key == "" {
+		return nil, errors.New("mistral: missing MISTRAL_API_KEY")
+	}
+	base := os.Getenv("MISTRAL_BASE_URL")
+	if base == "" {
+		base = "https://api.mistral.ai/v1"
+	}
+	return &conn{opts: opts, key: key, baseURL: base, httpClient: http.DefaultClient}, nil
+}
+
+func (c *conn) Close() error { return nil }
+
+func (c *conn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("mistral: %s", b)
+	}
+	var r struct {
+		Model   string `json:"model"`
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	if len(r.Choices) == 0 {
+		return nil, errors.New("mistral: empty response")
+	}
+	ch := r.Choices[0]
+	msg := llm.Message{Role: ch.Message.Role, Content: ch.Message.Content}
+	usage := &llm.Usage{PromptTokens: r.Usage.PromptTokens, CompletionTokens: r.Usage.CompletionTokens, TotalTokens: r.Usage.TotalTokens}
+	return &llm.ChatResponse{Message: msg, Model: r.Model, StopReason: ch.FinishReason, Usage: usage}, nil
+}
+
+func (c *conn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	req.Stream = true
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("mistral: %s", b)
+	}
+	return &stream{r: bufio.NewReader(resp.Body), body: resp.Body}, nil
+}
+
+type stream struct {
+	r    *bufio.Reader
+	body io.ReadCloser
+}
+
+func (s *stream) Recv() (*llm.Chunk, error) {
+	for {
+		line, err := s.r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			return &llm.Chunk{Done: true}, nil
+		}
+		var r struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &r); err != nil {
+			continue
+		}
+		if len(r.Choices) == 0 {
+			continue
+		}
+		ch := r.Choices[0]
+		chunk := &llm.Chunk{Content: ch.Delta.Content}
+		if ch.FinishReason != "" {
+			chunk.Done = true
+		}
+		return chunk, nil
+	}
+}
+
+func (s *stream) Close() error { return s.body.Close() }
+
+func (c *conn) doRequest(ctx context.Context, req llm.ChatRequest) (*http.Response, error) {
+	model := req.Model
+	if model == "" {
+		model = c.opts.Model
+	}
+	payload := map[string]any{
+		"model":    model,
+		"messages": convertMessages(req.Messages),
+	}
+	temp := req.Temperature
+	if temp == 0 {
+		temp = c.opts.Temperature
+	}
+	if temp != 0 {
+		payload["temperature"] = temp
+	}
+	mt := req.MaxTokens
+	if mt == 0 {
+		mt = c.opts.MaxTokens
+	}
+	if mt != 0 {
+		payload["max_tokens"] = mt
+	}
+	if req.Stream {
+		payload["stream"] = true
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/chat/completions", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.key)
+	httpReq.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(httpReq)
+}
+
+func convertMessages(msgs []llm.Message) []map[string]any {
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, map[string]any{"role": m.Role, "content": m.Content})
+	}
+	return out
+}

--- a/runtime/llm/provider/ollama/ollama.go
+++ b/runtime/llm/provider/ollama/ollama.go
@@ -1,0 +1,135 @@
+package ollama
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"mochi/runtime/llm"
+)
+
+// Ollama provider using the REST API.
+
+type provider struct{}
+
+type conn struct {
+	opts       llm.Options
+	baseURL    string
+	httpClient *http.Client
+}
+
+func init() { llm.Register("ollama", provider{}) }
+
+func (provider) Open(opts llm.Options) (llm.Conn, error) {
+	base := os.Getenv("OLLAMA_BASE_URL")
+	if base == "" {
+		base = "http://localhost:11434/api"
+	}
+	return &conn{opts: opts, baseURL: base, httpClient: http.DefaultClient}, nil
+}
+
+func (c *conn) Close() error { return nil }
+
+func (c *conn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("ollama: %s", b)
+	}
+	var r struct {
+		Model   string `json:"model"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	msg := llm.Message{Role: r.Message.Role, Content: r.Message.Content}
+	return &llm.ChatResponse{Message: msg, Model: r.Model}, nil
+}
+
+func (c *conn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	req.Stream = true
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("ollama: %s", b)
+	}
+	return &stream{scan: bufio.NewScanner(resp.Body), body: resp.Body}, nil
+}
+
+type stream struct {
+	scan *bufio.Scanner
+	body io.ReadCloser
+}
+
+func (s *stream) Recv() (*llm.Chunk, error) {
+	if !s.scan.Scan() {
+		if err := s.scan.Err(); err != nil {
+			return nil, err
+		}
+		return &llm.Chunk{Done: true}, io.EOF
+	}
+	var r struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+		Done bool `json:"done"`
+	}
+	if err := json.Unmarshal(s.scan.Bytes(), &r); err != nil {
+		return nil, err
+	}
+	if r.Done {
+		return &llm.Chunk{Done: true}, nil
+	}
+	return &llm.Chunk{Content: r.Message.Content}, nil
+}
+
+func (s *stream) Close() error { return s.body.Close() }
+
+func (c *conn) doRequest(ctx context.Context, req llm.ChatRequest) (*http.Response, error) {
+	model := req.Model
+	if model == "" {
+		model = c.opts.Model
+	}
+	payload := map[string]any{
+		"model":    model,
+		"messages": convertMessages(req.Messages),
+	}
+	if req.Stream {
+		payload["stream"] = true
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/chat", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(httpReq)
+}
+
+func convertMessages(msgs []llm.Message) []map[string]any {
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, map[string]any{"role": m.Role, "content": m.Content})
+	}
+	return out
+}

--- a/runtime/llm/provider/openai/openai.go
+++ b/runtime/llm/provider/openai/openai.go
@@ -1,0 +1,250 @@
+package openai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"mochi/runtime/llm"
+)
+
+// OpenAI API provider using the REST API.
+
+type provider struct{}
+
+type conn struct {
+	opts       llm.Options
+	key        string
+	baseURL    string
+	httpClient *http.Client
+}
+
+func init() { llm.Register("openai", provider{}) }
+
+func (provider) Open(opts llm.Options) (llm.Conn, error) {
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		return nil, errors.New("openai: missing OPENAI_API_KEY")
+	}
+	base := os.Getenv("OPENAI_BASE_URL")
+	if base == "" {
+		base = "https://api.openai.com/v1"
+	}
+	return &conn{opts: opts, key: key, baseURL: base, httpClient: http.DefaultClient}, nil
+}
+
+func (c *conn) Close() error { return nil }
+
+func (c *conn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("openai: %s", b)
+	}
+	var r struct {
+		Model   string `json:"model"`
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Role      string `json:"role"`
+				Content   string `json:"content"`
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	if len(r.Choices) == 0 {
+		return nil, errors.New("openai: empty response")
+	}
+	ch := r.Choices[0]
+	msg := llm.Message{Role: ch.Message.Role, Content: ch.Message.Content}
+	if len(ch.Message.ToolCalls) > 0 {
+		tc := ch.Message.ToolCalls[0]
+		var args map[string]any
+		json.Unmarshal([]byte(tc.Function.Arguments), &args)
+		msg.ToolCall = &llm.ToolCall{ID: tc.ID, Name: tc.Function.Name, Args: args}
+	}
+	usage := &llm.Usage{PromptTokens: r.Usage.PromptTokens, CompletionTokens: r.Usage.CompletionTokens, TotalTokens: r.Usage.TotalTokens}
+	return &llm.ChatResponse{Message: msg, Model: r.Model, StopReason: ch.FinishReason, Usage: usage}, nil
+}
+
+func (c *conn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	req.Stream = true
+	resp, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("openai: %s", b)
+	}
+	return &stream{r: bufio.NewReader(resp.Body), body: resp.Body}, nil
+}
+
+type stream struct {
+	r    *bufio.Reader
+	body io.ReadCloser
+}
+
+func (s *stream) Recv() (*llm.Chunk, error) {
+	for {
+		line, err := s.r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			return &llm.Chunk{Done: true}, nil
+		}
+		var r struct {
+			Choices []struct {
+				Delta struct {
+					Content   string `json:"content"`
+					ToolCalls []struct {
+						ID       string `json:"id"`
+						Type     string `json:"type"`
+						Function struct {
+							Name      string `json:"name"`
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &r); err != nil {
+			continue
+		}
+		if len(r.Choices) == 0 {
+			continue
+		}
+		d := r.Choices[0].Delta
+		chunk := &llm.Chunk{Content: d.Content}
+		for _, tc := range d.ToolCalls {
+			var args map[string]any
+			json.Unmarshal([]byte(tc.Function.Arguments), &args)
+			chunk.ToolCalls = append(chunk.ToolCalls, llm.ToolCall{ID: tc.ID, Name: tc.Function.Name, Args: args})
+		}
+		if r.Choices[0].FinishReason != "" {
+			chunk.Done = true
+		}
+		return chunk, nil
+	}
+}
+
+func (s *stream) Close() error { return s.body.Close() }
+
+func (c *conn) doRequest(ctx context.Context, req llm.ChatRequest) (*http.Response, error) {
+	model := req.Model
+	if model == "" {
+		model = c.opts.Model
+	}
+	payload := map[string]any{
+		"model":    model,
+		"messages": convertMessages(req.Messages),
+	}
+	temp := req.Temperature
+	if temp == 0 {
+		temp = c.opts.Temperature
+	}
+	if temp != 0 {
+		payload["temperature"] = temp
+	}
+	mt := req.MaxTokens
+	if mt == 0 {
+		mt = c.opts.MaxTokens
+	}
+	if mt != 0 {
+		payload["max_tokens"] = mt
+	}
+	if len(req.Tools) > 0 {
+		payload["tools"] = convertTools(req.Tools)
+	}
+	if req.ToolChoice != "" {
+		payload["tool_choice"] = req.ToolChoice
+	}
+	if req.ResponseFormat != "" {
+		payload["response_format"] = map[string]any{"type": req.ResponseFormat}
+	}
+	if req.Stream {
+		payload["stream"] = true
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/chat/completions", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.key)
+	httpReq.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(httpReq)
+}
+
+func convertMessages(msgs []llm.Message) []map[string]any {
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		mm := map[string]any{"role": m.Role}
+		if m.Content != "" {
+			mm["content"] = m.Content
+		} else {
+			mm["content"] = ""
+		}
+		if m.ToolCall != nil {
+			args, _ := json.Marshal(m.ToolCall.Args)
+			mm["tool_calls"] = []map[string]any{{
+				"id":       m.ToolCall.ID,
+				"type":     "function",
+				"function": map[string]any{"name": m.ToolCall.Name, "arguments": string(args)},
+			}}
+		}
+		out = append(out, mm)
+	}
+	return out
+}
+
+func convertTools(tools []llm.Tool) []map[string]any {
+	out := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        t.Name,
+				"description": t.Description,
+				"parameters":  t.Parameters,
+			},
+		})
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add OpenAI provider using direct REST calls
- add Ollama provider
- add Claude (Anthropic) provider
- add Cohere provider
- refactor provider structs and helper names to follow Go naming style

## Testing
- `go test ./... --vet=off`


------
https://chatgpt.com/codex/tasks/task_e_684092dc3460832086d21b5d7eb7f830