### PR TITLE
Refactor LLM providers to accept DSN

### DIFF
--- a/runtime/llm/README.md
+++ b/runtime/llm/README.md
@@ -1,0 +1,110 @@
+# LLM Runtime
+
+The `llm` package provides a simple, provider‑agnostic client for large language models.
+It is inspired by Go's `database/sql` package and lets you swap back‑end providers
+without changing application code.
+
+```go
+import "mochi/runtime/llm"
+```
+
+## Opening a Client
+
+Create a client by calling `llm.Open` with the provider name, a DSN string and
+optional defaults:
+
+```go
+client, err := llm.Open("openai",
+    "https://api.openai.com/v1?api_key=sk-...",
+    llm.Options{Model: "gpt-3.5-turbo"},
+)
+if err != nil {
+    // handle error
+}
+defer client.Close()
+```
+
+### Chatting
+
+Send a set of messages and receive a single response:
+
+```go
+resp, err := client.Chat(ctx, []llm.Message{
+    {Role: "user", Content: "hello"},
+}, llm.WithTemperature(0.7))
+```
+
+Streaming works similarly:
+
+```go
+stream, err := client.ChatStream(ctx, msgs)
+for {
+    ch, err := stream.Recv()
+    if err != nil { /* handle */ }
+    if ch.Done { break }
+    fmt.Print(ch.Content)
+}
+```
+
+## Registering a Provider
+
+A provider implements the `llm.Conn` interface and exposes an `Open` method.
+Register it during initialization:
+
+```go
+type myProvider struct{}
+
+func (myProvider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
+    // parse DSN and return your connection implementation
+}
+
+func init() { llm.Register("my", myProvider{}) }
+```
+
+`llm.Conn` must implement `Chat`, `ChatStream` and `Close`.
+
+## Options
+
+`Options` passed to `llm.Open` supply defaults for each request:
+
+```go
+type Options struct {
+    Model          string
+    Temperature    float64
+    MaxTokens      int
+    Tools          []llm.Tool
+    ToolChoice     string
+    ResponseFormat string
+}
+```
+
+Per-call overrides use functional options such as `llm.WithModel`,
+`llm.WithTemperature`, `llm.WithMaxTokens` and `llm.WithStream`.
+
+## DSN Format
+
+Providers are configured through a DSN of the form:
+
+```
+BASE_URL?api_key=KEY&opt=value
+```
+
+The base URL may be omitted for providers with sensible defaults. Query
+parameters are provider specific. Below are examples for the built‑in
+providers.
+
+| Provider | Sample DSN | Notes |
+|----------|------------|-------|
+| openai   | `https://api.openai.com/v1?api_key=sk-...` | base optional, defaults to `https://api.openai.com/v1` |
+| claude   | `https://api.anthropic.com/v1?api_key=...&version=2023-06-01` | `version` defaults to `2023-06-01` |
+| cohere   | `https://api.cohere.ai/v1?api_key=...` | base optional |
+| gemini   | `https://generativelanguage.googleapis.com/v1beta?api_key=...` | base optional |
+| grok     | `https://api.grok.x.ai/v1?api_key=...` | base optional |
+| mistral  | `https://api.mistral.ai/v1?api_key=...` | base optional |
+| llamacpp | `http://localhost:8080/v1` | no API key |
+| ollama   | `http://localhost:11434/api` | no API key |
+| chutes   | `https://host.example/v1?api_token=...` | base and `api_token` required |
+
+Use the appropriate provider name with `llm.Open` to select one of these
+implementations.
+

--- a/runtime/llm/llm.go
+++ b/runtime/llm/llm.go
@@ -29,14 +29,14 @@ func Register(name string, p Provider) {
 }
 
 // Open opens a new LLM client using the named provider.
-func Open(providerName string, opts Options) (*Client, error) {
+func Open(providerName, dsn string, opts Options) (*Client, error) {
 	mu.RLock()
 	prv := providers[providerName]
 	mu.RUnlock()
 	if prv == nil {
 		return nil, fmt.Errorf("llm: unknown provider %q", providerName)
 	}
-	conn, err := prv.Open(opts)
+	conn, err := prv.Open(dsn, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/llm/llm_test.go
+++ b/runtime/llm/llm_test.go
@@ -16,7 +16,7 @@ type echoStream struct {
 	i       int
 }
 
-func (e echoProvider) Open(opts Options) (Conn, error) {
+func (e echoProvider) Open(dsn string, opts Options) (Conn, error) {
 	return &echoConn{opts: opts}, nil
 }
 
@@ -55,7 +55,7 @@ func TestRegisterOpenChat(t *testing.T) {
 	mu.Unlock()
 	Register("echo", echoProvider{})
 
-	c, err := Open("echo", Options{})
+	c, err := Open("echo", "", Options{})
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestChatStream(t *testing.T) {
 	mu.Unlock()
 	Register("echo", echoProvider{})
 
-	c, err := Open("echo", Options{})
+	c, err := Open("echo", "", Options{})
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/runtime/llm/provider/cohere/cohere.go
+++ b/runtime/llm/provider/cohere/cohere.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
+	"net/url"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -28,14 +28,25 @@ type conn struct {
 
 func init() { llm.Register("cohere", provider{}) }
 
-func (provider) Open(opts llm.Options) (llm.Conn, error) {
-	key := os.Getenv("COHERE_API_KEY")
-	if key == "" {
-		return nil, errors.New("cohere: missing COHERE_API_KEY")
+func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
+	base := "https://api.cohere.ai/v1"
+	var key string
+	if dsn != "" {
+		u, err := url.Parse(dsn)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme != "" {
+			base = u.Scheme + "://" + u.Host + u.Path
+		} else if u.Host != "" {
+			base = "https://" + u.Host + u.Path
+		} else if u.Path != "" {
+			base = u.Path
+		}
+		key = u.Query().Get("api_key")
 	}
-	base := os.Getenv("COHERE_BASE_URL")
-	if base == "" {
-		base = "https://api.cohere.ai/v1"
+	if key == "" {
+		return nil, errors.New("cohere: missing api_key")
 	}
 	return &conn{opts: opts, key: key, baseURL: base, httpClient: http.DefaultClient}, nil
 }

--- a/runtime/llm/provider/mistral/mistral.go
+++ b/runtime/llm/provider/mistral/mistral.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
+	"net/url"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -26,14 +26,25 @@ type conn struct {
 
 func init() { llm.Register("mistral", provider{}) }
 
-func (provider) Open(opts llm.Options) (llm.Conn, error) {
-	key := os.Getenv("MISTRAL_API_KEY")
-	if key == "" {
-		return nil, errors.New("mistral: missing MISTRAL_API_KEY")
+func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
+	base := "https://api.mistral.ai/v1"
+	var key string
+	if dsn != "" {
+		u, err := url.Parse(dsn)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme != "" {
+			base = u.Scheme + "://" + u.Host + u.Path
+		} else if u.Host != "" {
+			base = "https://" + u.Host + u.Path
+		} else if u.Path != "" {
+			base = u.Path
+		}
+		key = u.Query().Get("api_key")
 	}
-	base := os.Getenv("MISTRAL_BASE_URL")
-	if base == "" {
-		base = "https://api.mistral.ai/v1"
+	if key == "" {
+		return nil, errors.New("mistral: missing api_key")
 	}
 	return &conn{opts: opts, key: key, baseURL: base, httpClient: http.DefaultClient}, nil
 }

--- a/runtime/llm/types.go
+++ b/runtime/llm/types.go
@@ -62,5 +62,7 @@ type Conn interface {
 
 // Provider opens new connections for a given configuration.
 type Provider interface {
-	Open(opts Options) (Conn, error)
+	// Open initializes a new connection using the provider specific DSN.
+	// The DSN follows the form BASE_URL?api_key=KEY&opt=value.
+	Open(dsn string, opts Options) (Conn, error)
 }


### PR DESCRIPTION
## Summary
- update provider interface to `Open(dsn string, opts Options)`
- adjust `llm.Open` accordingly
- rewrite all provider implementations to parse DSN instead of relying on environment variables
- update tests for new interface
- document usage of the LLM runtime and DSN format

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68409b829adc8320b5b5d734323a02ff