### PR TITLE
Add release notes for v0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # 📦 CHANGELOG.md
 
-## [0.2.10] – 2025-06-07
+## [0.2.11] – 2025-06-05
+
+### Added
+
+* `runtime/llm` package with DSN-based providers (OpenAI, Claude, Cohere, Mistral, Gemini, Grok, Ollama, LlamaCPP, Chutes)
+* Experimental `generate text` expression
+* Optional Postgres logging via `tools/db`
+
+### Changed
+
+* MCP server logs full errors and disables color
+* `mochi_eval` accepts a filename parameter
+* Node installer works across platforms
+
+### Fixed
+
+* Various logging issues in the MCP server
+
+## [0.2.10] – 2025-06-04
 
 ### Added
 
@@ -17,7 +35,7 @@
 
 * Go compiler handles map literals with int values
 
-## [0.2.9] – 2025-06-06
+## [0.2.9] – 2025-06-04
 
 ### Added
 
@@ -37,7 +55,7 @@
 
 All notable changes to the Mochi programming language are documented in this file.
 
-## [0.2.8] – 2025-06-05
+## [0.2.8] – 2025-06-04
 
 ### Added
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ minimal but expressive.
 This roadmap outlines the language development toward a stable 1.0, with an emphasis on first-class data types, control
 flow, streaming logic, agents, and dataset support.
 
-Current release: v0.2.10. Upcoming 0.2.x versions will expand data types before moving on to streams and agents.
+Current release: v0.2.11. Upcoming 0.2.x versions will expand data types before moving on to streams and agents.
 
 # v0.2.x – Compose data types
 

--- a/releases/v0.2.11.md
+++ b/releases/v0.2.11.md
@@ -1,0 +1,24 @@
+# June 2025 (v0.2.11)
+
+This release introduces the first pieces of AI integration. Mochi now ships with a flexible runtime for calling large language models, a database layer for capturing runs and prompts, and improved tooling for the MCP server and npx installer.
+
+## LLM Runtime and Providers
+
+The new `runtime/llm` package exposes a simple interface for interacting with chat models via `llm.Open`. Providers are selected through a DSN string, making it easy to swap back ends without changing code. Built‑in connectors include OpenAI, Claude, Cohere, Mistral, Gemini, Grok, Ollama, LlamaCPP and Chutes.
+
+## Generate Text Expression
+
+A new experimental `generate text` block can be parsed and executed. At runtime the interpreter collects field values and returns a placeholder response while integration work continues.
+
+## Database Tools
+
+The `tools/db` package provides optional Postgres tables for recording LLM exchanges as well as runs, builds and golden tests. Logging hooks in the MCP server automatically write entries when enabled via the `POSTGRES_DSN` environment variable.
+
+## MCP Improvements
+
+The server logs full error output, disables ANSI colors by default and accepts an optional filename when evaluating code. These changes make it easier to trace problems when running the server in hosted environments.
+
+## Node Installer
+
+`index.js` and `install.js` have been hardened for cross‑platform use. Installation now correctly extracts the prebuilt binary regardless of operating system and surfaces errors when spawning the executable.
+


### PR DESCRIPTION
## Summary
- add release notes for `v0.2.11`
- record new version in CHANGELOG and Roadmap
- revert package version bumps

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68411665bfd08320acff91d4d5777fd4