### PR TITLE
Support env LLM_MODEL and improved logging

### DIFF
--- a/runtime/llm/README.md
+++ b/runtime/llm/README.md
@@ -25,9 +25,10 @@ defer client.Close()
 ```
 
 If no explicit client is created, `llm` initializes a package-level default
-client using the `LLM_PROVIDER` and `LLM_DSN` environment variables. The default
-falls back to the built-in `echo` provider which simply returns the last user
-message. Helper functions `llm.Chat` and `llm.ChatStream` use this client.
+client using the `LLM_PROVIDER`, `LLM_DSN` and `LLM_MODEL` environment
+variables. The provider defaults to `echo` which simply returns the last user
+message when `LLM_PROVIDER` is not set. Helper functions `llm.Chat` and
+`llm.ChatStream` use this client.
 
 ### Chatting
 
@@ -113,4 +114,20 @@ providers.
 
 Use the appropriate provider name with `llm.Open` to select one of these
 implementations.
+
+### Supported Models
+
+Each provider exposes different models. Common options include:
+
+| Provider | Example Models |
+|----------|----------------|
+| openai   | `gpt-3.5-turbo`, `gpt-4o` |
+| claude   | `claude-3-opus`, `claude-3-sonnet` |
+| cohere   | `command-r`, `command-r-plus` |
+| gemini   | `models/gemini-pro` (default) |
+| grok     | `grok-1`, `grok-1-hd` |
+| mistral  | `mistral-small`, `mistral-medium` |
+| llamacpp | any local model name |
+| ollama   | any local model name |
+| chutes   | any model exposed by the service |
 

--- a/runtime/llm/default.go
+++ b/runtime/llm/default.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Default is the client opened during package initialization.
-// It uses environment variables `LLM_PROVIDER` and `LLM_DSN`.
+// It uses environment variables `LLM_PROVIDER`, `LLM_DSN` and `LLM_MODEL`.
 // If not set, the provider defaults to "echo" which simply echoes
 // the last user message. This is useful for collecting metrics
 // without calling an external service.
@@ -20,8 +20,9 @@ func init() {
 		prv = "echo"
 	}
 	dsn := os.Getenv("LLM_DSN")
+	model := os.Getenv("LLM_MODEL")
 
-	c, err := Open(prv, dsn, Options{})
+	c, err := Open(prv, dsn, Options{Model: model})
 	if err != nil {
 		log.Printf("[llm] failed to open default provider %q: %v", prv, err)
 		return


### PR DESCRIPTION
## Summary
- allow default LLM model via `LLM_MODEL` env var
- capture chosen model when logging LLM calls
- document new env var and list example models

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68411cbf60508320ac81202afb2091e1