### PR TITLE
Integrate LLM runtime

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -5,6 +5,8 @@ import (
 	"mochi/golden"
 	"mochi/interpreter"
 	"mochi/parser"
+	"mochi/runtime/llm"
+	_ "mochi/runtime/llm/provider/echo"
 	"mochi/types"
 	"strings"
 	"testing"
@@ -18,6 +20,11 @@ func TestInterpreter_ValidPrograms(t *testing.T) {
 		}
 
 		typeEnv := types.NewEnv(nil)
+		var errOpen error
+		llm.Default, errOpen = llm.Open("echo", "", llm.Options{})
+		if errOpen != nil {
+			return nil, fmt.Errorf("❌ open llm: %w", errOpen)
+		}
 		typeErrors := types.Check(prog, typeEnv)
 		if len(typeErrors) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", typeErrors[0])

--- a/tests/interpreter/valid/generate_echo.mochi
+++ b/tests/interpreter/valid/generate_echo.mochi
@@ -1,0 +1,5 @@
+let poem = generate text {
+  prompt: "echo $word",
+  args: { "word": "hello" }
+}
+print(poem)

--- a/tests/interpreter/valid/generate_echo.out
+++ b/tests/interpreter/valid/generate_echo.out
@@ -1,0 +1,1 @@
+echo hello


### PR DESCRIPTION
## Summary
- call runtime/llm when evaluating `generate text`
- interpolate prompt parameters
- provide echo provider in interpreter tests
- add golden test for `generate text`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841219f14808320b44c5a38aa58b5cd