### PR TITLE
Add struct type support with example

### DIFF
--- a/examples/v0.3/types.mochi
+++ b/examples/v0.3/types.mochi
@@ -1,0 +1,78 @@
+// core/types.mochi
+// User-defined types: Person and Book
+
+/// Type: Person
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+/// Type: Book
+type Book {
+  title: string
+  author: Person
+  pages: int
+  tags: list<string>
+  metadata: map<string, string>
+  published: bool
+}
+
+/// Create a Person
+fun new_person(name: string, age: int, email: string): Person {
+  return Person {
+    name: name
+    age: age
+    email: email
+  }
+}
+
+/// Create a Book
+fun new_book(
+  title: string,
+  author: Person,
+  pages: int,
+  tags: list<string>,
+  metadata: map<string, string>,
+  published: bool
+): Book {
+  return Book {
+    title: title
+    author: author
+    pages: pages
+    tags: tags
+    metadata: metadata
+    published: published
+  }
+}
+
+/// Format a Person as string
+fun person_summary(p: Person): string {
+  return p.name + " (" + p.age + ") - " + p.email
+}
+
+/// Format a Book as string
+fun book_summary(b: Book): string {
+  let pub = if b.published { "published" } else { "draft" }
+  let tag_str = join(b.tags, ", ")
+  return "\"" + b.title + "\" by " + b.author.name + ", " +
+         b.pages + " pages [" + pub + "] — Tags: " + tag_str
+}
+
+// ------------------------------
+// ✅ Example usage
+// ------------------------------
+
+let author = new_person("Jane", 35, "jane@example.com")
+
+let book = new_book(
+  "Mochi Essentials",
+  author,
+  180,
+  ["language", "core", "intro"],
+  { "isbn": "111-222-333", "version": "1.0" },
+  true
+)
+
+print(person_summary(author))
+print(book_summary(book))

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -29,8 +29,8 @@ var Errors = map[string]diagnostic.Template{
 	"I013": {Code: "I013", Message: "index must be an integer, got %T", Help: "Use an `int` value as an index (e.g., `list[0]`)."},
 	"I014": {Code: "I014", Message: "index %d out of bounds for length %d", Help: "Use an index within bounds of the list or string."},
 	"I015": {Code: "I015", Message: "invalid slice range [%d:%d] for length %d", Help: "Make sure the slice range is valid and within bounds."},
-        "I016": {Code: "I016", Message: "cannot index value of type %s", Help: "Indexing is supported only on lists, strings, or maps."},
-        "I017": {Code: "I017", Message: "cannot take length of type %s", Help: "Use `len(...)` only on lists and strings."},
+	"I016": {Code: "I016", Message: "cannot index value of type %s", Help: "Indexing is supported only on lists, strings, or maps."},
+	"I017": {Code: "I017", Message: "cannot take length of type %s", Help: "Use `len(...)` only on lists and strings."},
 
 	// --- Testing ---
 	"I018": {Code: "I018", Message: "expect condition failed", Help: "The condition evaluated to `false`."},

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -351,6 +351,10 @@ func (i *Interpreter) evalStmt(s *parser.Statement) error {
 	case s.For != nil:
 		return i.evalFor(s.For)
 
+	case s.Type != nil:
+		// type declarations have no runtime effect
+		return nil
+
 	case s.Test != nil:
 		fmt.Printf("🔍 Test %s\n", s.Test.Name)
 		child := types.NewEnv(i.env)
@@ -843,6 +847,17 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 			val = obj[field]
 		}
 		return val, nil
+
+	case p.Struct != nil:
+		obj := map[string]any{}
+		for _, field := range p.Struct.Fields {
+			v, err := i.evalExpr(field.Value)
+			if err != nil {
+				return nil, err
+			}
+			obj[field.Name] = v
+		}
+		return obj, nil
 
 	case p.List != nil:
 		var elems []any

--- a/types/errors.go
+++ b/types/errors.go
@@ -43,6 +43,9 @@ var Errors = map[string]diagnostic.Template{
 	"T022": {Code: "T022", Message: "cannot iterate over type %s", Help: "Only `list<T>`, `map<K,V>`, or integer ranges are allowed in `for ... in ...` loops."},
 	"T023": {Code: "T023", Message: "range loop requires integer start and end expressions", Help: "Use `for i in 0..10` or ensure both expressions are of type `int`."},
 	"T024": {Code: "T024", Message: "cannot assign to `%s` (immutable)", Help: "Use `var` to declare mutable variables."},
+	"T025": {Code: "T025", Message: "unknown type: %s", Help: "Ensure the type is defined before use."},
+	"T026": {Code: "T026", Message: "unknown field `%s` on %s", Help: "Check the struct definition for valid fields."},
+	"T027": {Code: "T027", Message: "%s is not a struct", Help: "Field access is only valid on struct types."},
 }
 
 // --- Wrapper Functions ---
@@ -145,4 +148,16 @@ func errRangeRequiresInts(pos lexer.Position) error {
 
 func errAssignImmutableVar(pos lexer.Position, name string) error {
 	return Errors["T024"].New(pos, name)
+}
+
+func errUnknownType(pos lexer.Position, name string) error {
+	return Errors["T025"].New(pos, name)
+}
+
+func errUnknownField(pos lexer.Position, field string, typ Type) error {
+	return Errors["T026"].New(pos, field, typ)
+}
+
+func errNotStruct(pos lexer.Position, typ Type) error {
+	return Errors["T027"].New(pos, typ)
 }


### PR DESCRIPTION
## Summary
- add example for user-defined struct types
- extend parser with type declarations and struct literals
- add StructType and environment support
- update type checker and interpreter for structs

## Testing
- `make test STAGE=parser`
- `make test STAGE=types`
- `make test STAGE=interpreter`


------
https://chatgpt.com/codex/tasks/task_e_6841a2f6381083209503e80fbaea0c69