### PR TITLE
Support nested selector type checking

### DIFF
--- a/examples/v0.3/types.mochi
+++ b/examples/v0.3/types.mochi
@@ -33,3 +33,5 @@ let book: Book = Book {
 }
 
 print("custom types defined")
+print(book.author.name)
+

--- a/tests/interpreter/errors/field_access_non_object.err
+++ b/tests/interpreter/errors/field_access_non_object.err
@@ -1,8 +1,0 @@
-error[I007]: cannot access field `name` on non-object of type int
-  --> tests/interpreter/errors/field_access_non_object.mochi:2:7
-
-  2 | print(x.name) // 42 is not an object
-    |       ^
-
-help:
-  Access fields only on objects or maps.

--- a/tests/interpreter/errors/field_access_non_object.mochi
+++ b/tests/interpreter/errors/field_access_non_object.mochi
@@ -1,2 +1,0 @@
-let x = 42
-print(x.name) // 42 is not an object

--- a/tests/types/errors/not_struct_selector.err
+++ b/tests/types/errors/not_struct_selector.err
@@ -1,0 +1,8 @@
+1. error[T027]: int is not a struct
+  --> tests/types/errors/not_struct_selector.mochi:2:10
+
+  2 |  let y = x.foo
+    |          ^
+
+help:
+  Field access is only valid on struct types.

--- a/tests/types/errors/not_struct_selector.mochi
+++ b/tests/types/errors/not_struct_selector.mochi
@@ -1,0 +1,2 @@
+ let x = 1
+ let y = x.foo

--- a/tests/types/errors/user_unknown_field.err
+++ b/tests/types/errors/user_unknown_field.err
@@ -1,0 +1,8 @@
+1. error[T026]: unknown field `age` on Person
+  --> tests/types/errors/user_unknown_field.mochi:3:10
+
+  3 |  let x = p.age
+    |          ^
+
+help:
+  Check the struct definition for valid fields.

--- a/tests/types/errors/user_unknown_field.mochi
+++ b/tests/types/errors/user_unknown_field.mochi
@@ -1,0 +1,3 @@
+ type Person { name: string }
+ let p: Person
+ let x = p.age

--- a/tests/types/valid/user_type_selector.golden
+++ b/tests/types/valid/user_type_selector.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/user_type_selector.mochi
+++ b/tests/types/valid/user_type_selector.mochi
@@ -1,0 +1,4 @@
+ type Person { name: string }
+ type Book { author: Person }
+ let book: Book = Book { author: Person { name: "Bob" } }
+ let n: string = book.author.name

--- a/types/check.go
+++ b/types/check.go
@@ -763,7 +763,17 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		if err != nil {
 			return nil, errUnknownVariable(p.Pos, p.Selector.Root)
 		}
-		// TODO: implement proper struct/stream field access checking
+		for _, field := range p.Selector.Tail {
+			st, ok := typ.(StructType)
+			if !ok {
+				return nil, errNotStruct(p.Pos, typ)
+			}
+			ft, ok := st.Fields[field]
+			if !ok {
+				return nil, errUnknownField(p.Pos, field, st)
+			}
+			typ = ft
+		}
 		return typ, nil
 
 	case p.Call != nil:


### PR DESCRIPTION
## Summary
- implement struct field resolution for nested selectors
- update user-defined types example to show accessing nested fields
- add type checker tests for selector expressions
- remove obsolete interpreter field-access error test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841b04c41408320aa20b1e9bd08da6f