### PR TITLE
Infer JSON schema when generating structs

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -933,7 +933,11 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		}
 
 		if p.Generate.Target != "text" {
-			opts = append(opts, llm.WithResponseFormat(llm.ResponseFormat{Type: "json_object"}))
+			format := llm.ResponseFormat{Type: "json_object"}
+			if st, ok := i.types.GetStruct(p.Generate.Target); ok {
+				format.Schema = structToSchema(st)
+			}
+			opts = append(opts, llm.WithResponseFormat(format))
 		}
 
 		resp, err := llm.Chat(context.Background(), []llm.Message{{Role: "user", Content: prompt}}, opts...)

--- a/interpreter/schema.go
+++ b/interpreter/schema.go
@@ -1,0 +1,52 @@
+package interpreter
+
+import (
+	"sort"
+
+	"mochi/types"
+)
+
+func typeToSchema(t types.Type) map[string]any {
+	switch tt := t.(type) {
+	case types.IntType, types.Int64Type:
+		return map[string]any{"type": "integer"}
+	case types.FloatType:
+		return map[string]any{"type": "number"}
+	case types.StringType:
+		return map[string]any{"type": "string"}
+	case types.BoolType:
+		return map[string]any{"type": "boolean"}
+	case types.ListType:
+		return map[string]any{
+			"type":  "array",
+			"items": typeToSchema(tt.Elem),
+		}
+	case types.MapType:
+		return map[string]any{
+			"type":                 "object",
+			"additionalProperties": typeToSchema(tt.Value),
+		}
+	case types.StructType:
+		return structToSchema(tt)
+	default:
+		return map[string]any{}
+	}
+}
+
+func structToSchema(st types.StructType) map[string]any {
+	props := make(map[string]any, len(st.Fields))
+	required := make([]string, 0, len(st.Fields))
+	for name, ft := range st.Fields {
+		props[name] = typeToSchema(ft)
+		required = append(required, name)
+	}
+	sort.Strings(required)
+	schema := map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}

--- a/interpreter/schema_test.go
+++ b/interpreter/schema_test.go
@@ -1,0 +1,74 @@
+package interpreter_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/llm"
+	"mochi/types"
+)
+
+// capture provider records the last chat request.
+var captured *llm.ChatRequest
+
+type captureProvider struct{}
+
+type captureConn struct{}
+
+func init() { llm.Register("capture", captureProvider{}) }
+
+func (captureProvider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
+	return &captureConn{}, nil
+}
+
+func (c *captureConn) Close() error { return nil }
+
+func (c *captureConn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	r := req // copy
+	captured = &r
+	return &llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "{}"}, Model: "capture"}, nil
+}
+
+func (c *captureConn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	return nil, nil
+}
+
+func TestGenerateStructSchema(t *testing.T) {
+	src := `type Foo { bar: int }
+let f = generate Foo { prompt: "{}" }`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := types.NewEnv(nil)
+	llm.Default, err = llm.Open("capture", "", llm.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	interp := interpreter.New(prog, env)
+	if err := interp.Run(); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if captured == nil || captured.ResponseFormat == nil {
+		t.Fatal("missing response format")
+	}
+	expected := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"bar": map[string]any{"type": "integer"},
+		},
+		"required": []string{"bar"},
+	}
+	if captured.ResponseFormat.Type != "json_object" {
+		t.Fatalf("unexpected type %s", captured.ResponseFormat.Type)
+	}
+	if !reflect.DeepEqual(captured.ResponseFormat.Schema, expected) {
+		t.Fatalf("schema mismatch:\nwant %#v\ngot  %#v", expected, captured.ResponseFormat.Schema)
+	}
+}


### PR DESCRIPTION
## Summary
- generate JSON schema for struct types
- apply schema in interpreter when calling the LLM
- test schema inference using a capture provider

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841befca0108320b4b3f117e63e076c