### PR TITLE
Add v0.3.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # 📦 CHANGELOG.md
+## [0.3.1] – 2025-06-07
+
+### Added
+
+* Structured `generate` blocks return typed structs
+* Optional fields `temperature`, `top_p`, `max_tokens` and `stop`
+* `type` declarations and struct literals
+* Nested field selectors with type checking
+* Python compiler support for `test` blocks
+* JSON schema inference for `generate`
+
+### Changed
+
+* LLM parameters passed via `Params` map
+* Providers honor `ResponseFormat`
+* Cheatsheet updated with examples
+
+### Fixed
+
+* Type errors for struct fields
+* Minor provider issues
+
+
 ## [0.3.0] – 2025-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Explore the [`examples/`](./examples) directory:
 * `list.mochi`
 * `agent.mochi`
 * `generate.mochi`
+* `generate-struct.mochi`
+* `types.mochi`
 
 Edit one or start fresh. It’s all yours.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ minimal but expressive.
 This roadmap outlines the language development toward a stable 1.0, with an emphasis on first-class data types, control
 flow, streaming logic, agents, and dataset support.
 
-Current release: v0.3.0. Upcoming 0.3.x versions will focus on generative AI.
+Current release: v0.3.1. Upcoming 0.3.x versions will focus on generative AI.
 
 # v0.3.x – Generative AI
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Mochi Programming Language Specification (v0.3.0)
+# Mochi Programming Language Specification (v0.3.1)
 
-This document describes version 0.3.0 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
+This document describes version 0.3.1 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
 
 ## 0. Introduction
 
@@ -344,4 +344,4 @@ GenericType   = Identifier "<" TypeRef { "," TypeRef } ">" .
 FunType       = "fun" "(" [ TypeRef { "," TypeRef } ] ")" [ ":" TypeRef ] .
 ```
 
-This specification outlines the core language as of version 0.3.0. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.
+This specification outlines the core language as of version 0.3.1. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -147,7 +147,7 @@ func getAgent() string {
 // ServeStdio starts the MCP server using stdio (for Claude/GPT compatibility).
 func ServeStdio() error {
 	color.NoColor = true // important for non-TTY environments like Claude/GPT
-	s := server.NewMCPServer("mochi", "0.3.0")
+    s := server.NewMCPServer("mochi", "0.3.1")
 	Register(s)
 	return server.ServeStdio(s)
 }

--- a/mochi-tm/package.json
+++ b/mochi-tm/package.json
@@ -2,7 +2,7 @@
   "name": "mochi-tm",
   "displayName": "Mochi",
   "description": "TextMate grammar and language configuration for the Mochi programming language.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "mochi-lang.org",
   "license": "MIT",
   "engines": {

--- a/releases/v0.3.1.md
+++ b/releases/v0.3.1.md
@@ -1,0 +1,24 @@
+# June 2025 (v0.3.1)
+
+Mochi v0.3.1 expands the generative features introduced in v0.3.0. Structured results can now be produced directly from `generate` blocks and custom struct types are first-class citizens. Requests accept flexible parameters for fine-grained control over model behaviour.
+
+## Structured Generation
+
+- `generate Type { ... }` executes an LLM request and decodes the JSON response into the given struct.
+- The interpreter infers a JSON schema from the type and sends it via `response_format` to improve accuracy.
+
+## Parameterized Options
+
+- Fields like `temperature`, `top_p`, `max_tokens` and `stop` may be supplied in `generate` blocks.
+- Additional parameters are forwarded through the runtime using `llm.WithParam`.
+
+## User-defined Struct Types
+
+- `type` declarations introduce named structs with typed fields.
+- Struct literals construct values and nested field selectors are type checked.
+
+## Tooling Updates
+
+- The Python compiler supports `test` blocks and `expect` statements.
+- LLM provider structs include JSON tags and honour the `ResponseFormat` option.
+- The cheatsheet has been updated with new generation examples.


### PR DESCRIPTION
## Summary
- document changes in v0.3.1 release notes
- update CHANGELOG with v0.3.1 entry
- bump docs and tooling references to v0.3.1
- list new examples in README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6841c565320c8320b9680a59051e27c8