### PR TITLE
Implement model selection and aliases

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -32,6 +32,7 @@ type Statement struct {
 	Expect *ExpectStmt `parser:"| @@"`
 	Agent  *AgentDecl  `parser:"| @@"`
 	Stream *StreamDecl `parser:"| @@"`
+	Model  *ModelDecl  `parser:"| @@"`
 	Type   *TypeDecl   `parser:"| @@"`
 	On     *OnHandler  `parser:"| @@"`
 	Let    *LetStmt    `parser:"| @@"`
@@ -274,6 +275,18 @@ type StreamDecl struct {
 	Pos    lexer.Position
 	Name   string         `parser:"'stream' @Ident"`
 	Fields []*StreamField `parser:"'{' @@* '}'"`
+}
+
+type ModelDecl struct {
+	Pos    lexer.Position
+	Name   string        `parser:"'model' @Ident"`
+	Fields []*ModelField `parser:"'{' @@* '}'"`
+}
+
+type ModelField struct {
+	Pos   lexer.Position
+	Name  string `parser:"@Ident ':'"`
+	Value *Expr  `parser:"@@"`
 }
 
 type StreamField struct {

--- a/runtime/llm/provider/chutes/chutes.go
+++ b/runtime/llm/provider/chutes/chutes.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -40,6 +41,9 @@ func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
 	}
 	if base == "" {
 		return nil, errors.New("chutes: missing base url")
+	}
+	if key == "" {
+		key = os.Getenv("CHUTES_API_TOKEN")
 	}
 	if key == "" {
 		return nil, errors.New("chutes: missing api_token")

--- a/runtime/llm/provider/claude/claude.go
+++ b/runtime/llm/provider/claude/claude.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -50,6 +51,9 @@ func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
 		if v := q.Get("version"); v != "" {
 			ver = v
 		}
+	}
+	if key == "" {
+		key = os.Getenv("CLAUDE_API_KEY")
 	}
 	if key == "" {
 		return nil, errors.New("claude: missing api_key")

--- a/runtime/llm/provider/cohere/cohere.go
+++ b/runtime/llm/provider/cohere/cohere.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -44,6 +45,9 @@ func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
 			base = u.Path
 		}
 		key = u.Query().Get("api_key")
+	}
+	if key == "" {
+		key = os.Getenv("COHERE_API_KEY")
 	}
 	if key == "" {
 		return nil, errors.New("cohere: missing api_key")

--- a/runtime/llm/provider/gemini/gemini.go
+++ b/runtime/llm/provider/gemini/gemini.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -44,6 +45,9 @@ func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
 			base = u.Path
 		}
 		key = u.Query().Get("api_key")
+	}
+	if key == "" {
+		key = os.Getenv("GEMINI_API_KEY")
 	}
 	if key == "" {
 		return nil, errors.New("gemini: missing api_key")

--- a/runtime/llm/provider/grok/grok.go
+++ b/runtime/llm/provider/grok/grok.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -44,6 +45,9 @@ func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
 			base = u.Path
 		}
 		key = u.Query().Get("api_key")
+	}
+	if key == "" {
+		key = os.Getenv("GROK_API_KEY")
 	}
 	if key == "" {
 		return nil, errors.New("grok: missing api_key")

--- a/runtime/llm/provider/mistral/mistral.go
+++ b/runtime/llm/provider/mistral/mistral.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -42,6 +43,9 @@ func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
 			base = u.Path
 		}
 		key = u.Query().Get("api_key")
+	}
+	if key == "" {
+		key = os.Getenv("MISTRAL_API_KEY")
 	}
 	if key == "" {
 		return nil, errors.New("mistral: missing api_key")

--- a/runtime/llm/provider/openai/openai.go
+++ b/runtime/llm/provider/openai/openai.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"mochi/runtime/llm"
@@ -44,6 +45,9 @@ func (provider) Open(dsn string, opts llm.Options) (llm.Conn, error) {
 			base = u.Path
 		}
 		key = u.Query().Get("api_key")
+	}
+	if key == "" {
+		key = os.Getenv("OPENAI_API_KEY")
 	}
 	if key == "" {
 		return nil, errors.New("openai: missing api_key")

--- a/tests/interpreter/valid/generate_model.mochi
+++ b/tests/interpreter/valid/generate_model.mochi
@@ -1,0 +1,16 @@
+model quick {
+  provider: "echo"
+  name: "echo"
+}
+
+let a = generate text {
+  model: "quick",
+  prompt: "model alias"
+}
+print(a)
+
+let b = generate text {
+  model: "echo:whatever",
+  prompt: "colon"
+}
+print(b)

--- a/tests/interpreter/valid/generate_model.out
+++ b/tests/interpreter/valid/generate_model.out
@@ -1,0 +1,2 @@
+model alias
+colon

--- a/types/check.go
+++ b/types/check.go
@@ -414,6 +414,14 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type) error {
 		env.SetStruct(s.Type.Name, StructType{Name: s.Type.Name, Fields: fields})
 		return nil
 
+	case s.Model != nil:
+		for _, f := range s.Model.Fields {
+			if _, err := checkExpr(f.Value, env); err != nil {
+				return err
+			}
+		}
+		return nil
+
 	case s.Fun != nil:
 		name := s.Fun.Name
 		params := []Type{}


### PR DESCRIPTION
## Summary
- add `model` block for alias configuration
- implement provider-aware model selection with env API keys
- store model aliases in runtime env
- support provider-prefixed models in `generate` block
- add tests for model aliasing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841d0e0b0208320ac4d3563f4e96014