### PR TITLE
Implement model block docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,24 @@ test "math" {
 ### Generative AI
 
 Invoke large language models directly from Mochi using the `generate` block.
+Models can be configured globally with a `model` block and referenced by name.
 
 ```mochi
 let poem = generate text {
   prompt: "Write a haiku about spring"
 }
 print(poem)
+
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
+
+let fancy = generate text {
+  model: "quick"
+  prompt: "Write a haiku about spring"
+}
+print(fancy)
 
 type Person {
   name: string
@@ -321,6 +333,7 @@ Explore the [`examples/`](./examples) directory:
 * `agent.mochi`
 * `generate.mochi`
 * `generate-struct.mochi`
+* `generate-model.mochi`
 * `types.mochi`
 
 Edit one or start fresh. It’s all yours.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,9 +48,9 @@ let response = generate text {
 
 ## v0.3.2 – Model selection
 
-* [ ] `model` field with values like `"openai:gpt-4"` or `"claude:opus"`
-* [ ] Environment-based key loading per provider
-* [ ] Custom alias models via `model` block
+* [x] `model` field with values like `"openai:gpt-4"` or `"claude:opus"`
+* [x] Environment-based key loading per provider
+* [x] Custom alias models via `model` block
 
 ```
 model quick {

--- a/SPEC.md
+++ b/SPEC.md
@@ -70,7 +70,7 @@ let  var  fun  return
 if   else
 for  in
 stream  on  as
-agent  test  expect
+model  agent  test  expect
 ```
 
 ### Operators and Delimiters
@@ -306,7 +306,7 @@ The complete grammar for Mochi in EBNF notation:
 Program       = { Statement }.
 Statement     = LetStmt | VarStmt | AssignStmt | FunDecl | ReturnStmt |
                 IfStmt | ForStmt | ExprStmt | TestBlock |
-                ExpectStmt | StreamDecl | OnHandler | AgentDecl .
+                ExpectStmt | StreamDecl | OnHandler | ModelDecl | AgentDecl .
 LetStmt       = "let" Identifier [ ":" TypeRef ] [ "=" Expression ] .
 VarStmt       = "var" Identifier [ ":" TypeRef ] [ "=" Expression ] .
 AssignStmt    = PostfixExpr "=" Expression .
@@ -320,6 +320,7 @@ ExpectStmt    = "expect" Expression .
 StreamDecl    = "stream" Identifier Block .
 OnHandler     = "on" Identifier "as" Identifier Block .
 AgentDecl     = "agent" Identifier Block .
+ModelDecl     = "model" Identifier Block .
 
 Expression    = Equality .
 Equality      = Comparison { ("==" | "!=") Comparison } .

--- a/ast/convert.go
+++ b/ast/convert.go
@@ -94,6 +94,16 @@ func FromStatement(s *parser.Statement) *Node {
 		}
 		return n
 
+	case s.Model != nil:
+		n := &Node{Kind: "model", Value: s.Model.Name}
+		for _, f := range s.Model.Fields {
+			n.Children = append(n.Children, &Node{
+				Kind:     f.Name,
+				Children: []*Node{FromExpr(f.Value)},
+			})
+		}
+		return n
+
 	case s.Type != nil:
 		n := &Node{Kind: "type", Value: s.Type.Name}
 		for _, f := range s.Type.Fields {

--- a/cheatsheet.mochi
+++ b/cheatsheet.mochi
@@ -64,7 +64,13 @@ print(scores["a"])
 
 // 5. Generative AI
 
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
+
 generate text {
+  model: "quick"
   prompt: "Write a haiku about $topic"
   args: {
     topic: "spring rain"

--- a/examples/v0.3/generate-model.mochi
+++ b/examples/v0.3/generate-model.mochi
@@ -1,0 +1,11 @@
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
+
+let topic = "spring"
+let poem = generate text {
+  model: "quick"
+  prompt: "Write a haiku about " + topic
+}
+print(poem)

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -80,9 +80,14 @@ test "Some math operator" {
 }
 
 // 6. Generative AI
-let topic = "spring"
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
 
+let topic = "spring"
 let poem = generate text {
+  model: "quick"
   prompt: "Write a haiku about " + topic
 }
 

--- a/mochi-tm/mochi.tmLanguage.json
+++ b/mochi-tm/mochi.tmLanguage.json
@@ -6,7 +6,7 @@
   "patterns": [
     {
       "name": "keyword.control.mochi",
-      "match": "\\b(let|fun|func|return|if|else|for|in|on|as|test|expect|replay|simulate|agent|state|intent|stream|generate|text|await|async|call|cancel|emit|window|from|where|group|by|select|join|having)\\b"
+      "match": "\\b(let|fun|func|return|if|else|for|in|on|as|test|expect|replay|simulate|agent|state|intent|stream|model|generate|text|await|async|call|cancel|emit|window|from|where|group|by|select|join|having)\\b"
     },
     {
       "name": "storage.type.mochi",

--- a/tests/parser/valid/model_decl.golden
+++ b/tests/parser/valid/model_decl.golden
@@ -1,0 +1,6 @@
+(program
+  (model quick
+    (provider (string openai))
+    (name (string gpt-3.5-turbo))
+  )
+)

--- a/tests/parser/valid/model_decl.mochi
+++ b/tests/parser/valid/model_decl.mochi
@@ -1,0 +1,4 @@
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}

--- a/tests/types/valid/model_decl.golden
+++ b/tests/types/valid/model_decl.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/model_decl.mochi
+++ b/tests/types/valid/model_decl.mochi
@@ -1,0 +1,9 @@
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
+
+let poem: string = generate text {
+  model: "quick",
+  prompt: "hello"
+}


### PR DESCRIPTION
## Summary
- document `model` blocks and selection
- add example for model aliases
- cover `model` blocks in cheatsheets
- highlight `model` keyword in VS Code grammar
- support model nodes in AST converter
- test parser and type checker with model blocks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841d664701483208f432c27ad9199c2