### PR TITLE
Add llm runtime to generate blocks

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -44,7 +44,11 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		}
 		sort.Strings(keys)
 		for _, imp := range keys {
-			c.writeln(fmt.Sprintf("\"%s\"", imp))
+			if strings.Contains(imp, " ") {
+				c.writeln(imp)
+			} else {
+				c.writeln(fmt.Sprintf("\"%s\"", imp))
+			}
 		}
 		c.indent--
 		c.writeln(")")
@@ -563,36 +567,38 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 
 		return fmt.Sprintf("map[%s]%s{%s}", keyType, valType, strings.Join(parts, ", ")), nil
 
-        case p.Generate != nil:
-                return c.compileGenerateExpr(p.Generate)
-        default:
-                return "nil", fmt.Errorf("unsupported primary expression")
-        }
+	case p.Generate != nil:
+		return c.compileGenerateExpr(p.Generate)
+	default:
+		return "nil", fmt.Errorf("unsupported primary expression")
+	}
 }
 
 func (c *Compiler) compileGenerateExpr(g *parser.GenerateExpr) (string, error) {
-        var prompt string
-        args := "map[string]any{}"
-        for _, f := range g.Fields {
-                v, err := c.compileExpr(f.Value)
-                if err != nil {
-                        return "", err
-                }
-                switch f.Name {
-                case "prompt":
-                        prompt = v
-                case "args":
-                        args = v
-                }
-        }
-        if prompt == "" {
-                prompt = "\"\""
-        }
-        c.use("_genText")
-        c.use("_toAnyMap")
-        c.imports["fmt"] = true
-        c.imports["strings"] = true
-        return fmt.Sprintf("_genText(%s, _toAnyMap(%s))", prompt, args), nil
+	var prompt string
+	args := "map[string]any{}"
+	for _, f := range g.Fields {
+		v, err := c.compileExpr(f.Value)
+		if err != nil {
+			return "", err
+		}
+		switch f.Name {
+		case "prompt":
+			prompt = v
+		case "args":
+			args = v
+		}
+	}
+	if prompt == "" {
+		prompt = "\"\""
+	}
+	c.use("_genText")
+	c.use("_toAnyMap")
+	c.imports["fmt"] = true
+	c.imports["strings"] = true
+	c.imports["context"] = true
+	c.imports["mochi/runtime/llm"] = true
+	return fmt.Sprintf("_genText(%s, _toAnyMap(%s))", prompt, args), nil
 }
 
 func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
@@ -1222,27 +1228,30 @@ func (c *Compiler) scanPrimaryImports(p *parser.Primary) {
 		for _, e := range p.List.Elems {
 			c.scanExprImports(e)
 		}
-       case p.Map != nil:
-               for _, it := range p.Map.Items {
-                       c.scanExprImports(it.Key)
-                       c.scanExprImports(it.Value)
-               }
-       case p.Generate != nil:
-               c.imports["fmt"] = true
-               c.imports["strings"] = true
-               for _, f := range p.Generate.Fields {
-                       c.scanExprImports(f.Value)
-               }
-       case p.Selector != nil:
-               // no imports
-       case p.Lit != nil:
-               // none
-       }
+	case p.Map != nil:
+		for _, it := range p.Map.Items {
+			c.scanExprImports(it.Key)
+			c.scanExprImports(it.Value)
+		}
+	case p.Generate != nil:
+		c.imports["fmt"] = true
+		c.imports["strings"] = true
+		c.imports["context"] = true
+		c.imports["mochi/runtime/llm"] = true
+		c.imports["_ \"mochi/runtime/llm/provider/echo\""] = true
+		for _, f := range p.Generate.Fields {
+			c.scanExprImports(f.Value)
+		}
+	case p.Selector != nil:
+		// no imports
+	case p.Lit != nil:
+		// none
+	}
 }
 
 // Runtime helper functions injected into generated programs.
 const (
-        helperIndex = "func _index(v any, k any) any {\n" +
+	helperIndex = "func _index(v any, k any) any {\n" +
 		"    switch s := v.(type) {\n" +
 		"    case []any:\n" +
 		"        i, ok := k.(int)\n" +
@@ -1408,8 +1417,8 @@ const (
 		"    }\n" +
 		"}\n"
 
-        helperIter = "func _iter(v any) []any {\n" +
-                "    switch s := v.(type) {\n" +
+	helperIter = "func _iter(v any) []any {\n" +
+		"    switch s := v.(type) {\n" +
 		"    case []any:\n" +
 		"        return s\n" +
 		"    case []int:\n" +
@@ -1452,38 +1461,40 @@ const (
 		"    default:\n" +
 		"        return nil\n" +
 		"    }\n" +
-                "}\n"
+		"}\n"
 
-        helperGenText = "func _genText(prompt string, args map[string]any) string {\n" +
-                "    for k, v := range args {\n" +
-                "        placeholder := \"$\" + k\n" +
-                "        prompt = strings.ReplaceAll(prompt, placeholder, fmt.Sprintf(\"%v\", v))\n" +
-                "    }\n" +
-                "    return prompt\n" +
-                "}\n"
+	helperGenText = "func _genText(prompt string, args map[string]any) string {\n" +
+		"    for k, v := range args {\n" +
+		"        placeholder := \"$\" + k\n" +
+		"        prompt = strings.ReplaceAll(prompt, placeholder, fmt.Sprintf(\"%v\", v))\n" +
+		"    }\n" +
+		"    resp, err := llm.Chat(context.Background(), []llm.Message{{Role: \"user\", Content: prompt}})\n" +
+		"    if err != nil { panic(err) }\n" +
+		"    return resp.Message.Content\n" +
+		"}\n"
 
-       helperToAnyMap = "func _toAnyMap(m any) map[string]any {\n" +
-               "    switch v := m.(type) {\n" +
-               "    case map[string]any:\n" +
-               "        return v\n" +
-               "    case map[string]string:\n" +
-               "        out := make(map[string]any, len(v))\n" +
-               "        for k, vv := range v {\n" +
-               "            out[k] = vv\n" +
-               "        }\n" +
-               "        return out\n" +
-               "    default:\n" +
-               "        return nil\n" +
-               "    }\n" +
-               "}\n"
+	helperToAnyMap = "func _toAnyMap(m any) map[string]any {\n" +
+		"    switch v := m.(type) {\n" +
+		"    case map[string]any:\n" +
+		"        return v\n" +
+		"    case map[string]string:\n" +
+		"        out := make(map[string]any, len(v))\n" +
+		"        for k, vv := range v {\n" +
+		"            out[k] = vv\n" +
+		"        }\n" +
+		"        return out\n" +
+		"    default:\n" +
+		"        return nil\n" +
+		"    }\n" +
+		"}\n"
 )
 
 var helperMap = map[string]string{
-        "_index": helperIndex,
-        "_slice": helperSlice,
-        "_iter":  helperIter,
-        "_genText": helperGenText,
-       "_toAnyMap": helperToAnyMap,
+	"_index":    helperIndex,
+	"_slice":    helperSlice,
+	"_iter":     helperIter,
+	"_genText":  helperGenText,
+	"_toAnyMap": helperToAnyMap,
 }
 
 func (c *Compiler) use(name string) {

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -35,7 +35,7 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
 		cmd := exec.Command("go", "run", file)
-		cmd.Env = append(os.Environ(), "GO111MODULE=off")
+		cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return nil, fmt.Errorf("❌ go run error: %w\n%s", err, out)

--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -339,12 +339,12 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		return c.compileCallExpr(p.Call)
 	case p.List != nil:
 		return c.compileListLiteral(p.List)
-       case p.Map != nil:
-               return c.compileMapLiteral(p.Map)
-       case p.Generate != nil:
-                return c.compileGenerateExpr(p.Generate)
-        case p.Lit != nil:
-                return c.compileLiteral(p.Lit)
+	case p.Map != nil:
+		return c.compileMapLiteral(p.Map)
+	case p.Generate != nil:
+		return c.compileGenerateExpr(p.Generate)
+	case p.Lit != nil:
+		return c.compileLiteral(p.Lit)
 	case p.Group != nil:
 		expr, err := c.compileExpr(p.Group)
 		if err != nil {
@@ -434,25 +434,25 @@ func (c *Compiler) compileMapLiteral(m *parser.MapLiteral) (string, error) {
 }
 
 func (c *Compiler) compileGenerateExpr(g *parser.GenerateExpr) (string, error) {
-        var prompt string
-        args := "{}"
-        for _, f := range g.Fields {
-                v, err := c.compileExpr(f.Value)
-                if err != nil {
-                        return "", err
-                }
-                switch f.Name {
-                case "prompt":
-                        prompt = v
-                case "args":
-                        args = v
-                }
-        }
-        if prompt == "" {
-                prompt = "\"\""
-        }
-        c.use("_gen_text")
-        return fmt.Sprintf("_gen_text(%s, %s)", prompt, args), nil
+	var prompt string
+	args := "{}"
+	for _, f := range g.Fields {
+		v, err := c.compileExpr(f.Value)
+		if err != nil {
+			return "", err
+		}
+		switch f.Name {
+		case "prompt":
+			prompt = v
+		case "args":
+			args = v
+		}
+	}
+	if prompt == "" {
+		prompt = "\"\""
+	}
+	c.use("_gen_text")
+	return fmt.Sprintf("_gen_text(%s, %s)", prompt, args), nil
 }
 
 func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
@@ -491,15 +491,16 @@ var helperIndex = "def _index(v, k):\n" +
 	"    return v[k]\n"
 
 var helperSlice = "def _slice(v, start, end):\n" +
-        "    if isinstance(v, (list, str)):\n" +
-        "        return v[start:end]\n" +
-        "    raise Exception(\"invalid slice target\")\n"
+	"    if isinstance(v, (list, str)):\n" +
+	"        return v[start:end]\n" +
+	"    raise Exception(\"invalid slice target\")\n"
 
 var helperGenText = "def _gen_text(prompt, args):\n" +
-        "    for k, v in args.items():\n" +
-        "        placeholder = '$' + k\n" +
-        "        prompt = prompt.replace(placeholder, str(v))\n" +
-        "    return prompt\n"
+	"    # TODO: send prompt to your LLM of choice\n" +
+	"    for k, v in args.items():\n" +
+	"        placeholder = '$' + k\n" +
+	"        prompt = prompt.replace(placeholder, str(v))\n" +
+	"    return prompt\n"
 
 var helperMap = map[string]string{"_index": helperIndex, "_slice": helperSlice, "_gen_text": helperGenText}
 

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -304,12 +304,12 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		return c.compileCallExpr(p.Call)
 	case p.List != nil:
 		return c.compileListLiteral(p.List)
-       case p.Map != nil:
-               return c.compileMapLiteral(p.Map)
-       case p.Generate != nil:
-                return c.compileGenerateExpr(p.Generate)
-        case p.Lit != nil:
-                return c.compileLiteral(p.Lit)
+	case p.Map != nil:
+		return c.compileMapLiteral(p.Map)
+	case p.Generate != nil:
+		return c.compileGenerateExpr(p.Generate)
+	case p.Lit != nil:
+		return c.compileLiteral(p.Lit)
 	case p.Group != nil:
 		expr, err := c.compileExpr(p.Group)
 		if err != nil {
@@ -411,25 +411,25 @@ func (c *Compiler) compileMapLiteral(m *parser.MapLiteral) (string, error) {
 }
 
 func (c *Compiler) compileGenerateExpr(g *parser.GenerateExpr) (string, error) {
-        var prompt string
-        args := "{}"
-        for _, f := range g.Fields {
-                v, err := c.compileExpr(f.Value)
-                if err != nil {
-                        return "", err
-                }
-                switch f.Name {
-                case "prompt":
-                        prompt = v
-                case "args":
-                        args = v
-                }
-        }
-        if prompt == "" {
-                prompt = "\"\""
-        }
-        c.use("_gen_text")
-        return fmt.Sprintf("_gen_text(%s, %s)", prompt, args), nil
+	var prompt string
+	args := "{}"
+	for _, f := range g.Fields {
+		v, err := c.compileExpr(f.Value)
+		if err != nil {
+			return "", err
+		}
+		switch f.Name {
+		case "prompt":
+			prompt = v
+		case "args":
+			args = v
+		}
+	}
+	if prompt == "" {
+		prompt = "\"\""
+	}
+	c.use("_gen_text")
+	return fmt.Sprintf("_gen_text(%s, %s)", prompt, args), nil
 }
 
 func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
@@ -493,7 +493,7 @@ func sanitizeName(name string) string {
 
 // Runtime helper functions injected into generated programs.
 const (
-        helperIndex = "function _index(v: any, k: any): any {\n" +
+	helperIndex = "function _index(v: any, k: any): any {\n" +
 		"  if (Array.isArray(v) || typeof v === \"string\") {\n" +
 		"    const l = (v as any).length;\n" +
 		"    if (typeof k === \"number\" && k < 0) k = l + k;\n" +
@@ -511,26 +511,27 @@ const (
 		"  throw new Error(\"invalid slice target\");\n" +
 		"}\n"
 
-        helperLen = "function _len(v: any): number {\n" +
-                "  if (Array.isArray(v) || typeof v === \"string\") return (v as any).length;\n" +
-                "  if (v && typeof v === \"object\") return Object.keys(v).length;\n" +
-                "  return 0;\n" +
-                "}\n"
+	helperLen = "function _len(v: any): number {\n" +
+		"  if (Array.isArray(v) || typeof v === \"string\") return (v as any).length;\n" +
+		"  if (v && typeof v === \"object\") return Object.keys(v).length;\n" +
+		"  return 0;\n" +
+		"}\n"
 
-       helperGenText = "function _gen_text(prompt: string, args: Record<string, any>): string {\n" +
-               "  for (const k in args) {\n" +
-               "    const placeholder = '$' + k;\n" +
-               "    prompt = prompt.split(placeholder).join(String(args[k]));\n" +
-               "  }\n" +
-               "  return prompt;\n" +
-               "}\n"
+	helperGenText = "function _gen_text(prompt: string, args: Record<string, any>): string {\n" +
+		"  // TODO: integrate with your preferred LLM\n" +
+		"  for (const k in args) {\n" +
+		"    const placeholder = '$' + k;\n" +
+		"    prompt = prompt.split(placeholder).join(String(args[k]));\n" +
+		"  }\n" +
+		"  return prompt;\n" +
+		"}\n"
 )
 
 var helperMap = map[string]string{
-        "_index": helperIndex,
-        "_slice": helperSlice,
-        "_len":   helperLen,
-       "_gen_text": helperGenText,
+	"_index":    helperIndex,
+	"_slice":    helperSlice,
+	"_len":      helperLen,
+	"_gen_text": helperGenText,
 }
 
 func (c *Compiler) use(name string) {

--- a/tests/compiler/valid/generate_echo.go.out
+++ b/tests/compiler/valid/generate_echo.go.out
@@ -1,7 +1,10 @@
 package main
 
 import (
+	_ "mochi/runtime/llm/provider/echo"
+	"context"
 	"fmt"
+	"mochi/runtime/llm"
 	"strings"
 )
 
@@ -15,7 +18,9 @@ func _genText(prompt string, args map[string]any) string {
         placeholder := "$" + k
         prompt = strings.ReplaceAll(prompt, placeholder, fmt.Sprintf("%v", v))
     }
-    return prompt
+    resp, err := llm.Chat(context.Background(), []llm.Message{{Role: "user", Content: prompt}})
+    if err != nil { panic(err) }
+    return resp.Message.Content
 }
 
 func _toAnyMap(m any) map[string]any {

--- a/tests/compiler/valid/generate_echo.py.out
+++ b/tests/compiler/valid/generate_echo.py.out
@@ -5,6 +5,7 @@ def main():
 	print(poem)
 
 def _gen_text(prompt, args):
+    # TODO: send prompt to your LLM of choice
     for k, v in args.items():
         placeholder = '$' + k
         prompt = prompt.replace(placeholder, str(v))

--- a/tests/compiler/valid/generate_echo.ts.out
+++ b/tests/compiler/valid/generate_echo.ts.out
@@ -7,6 +7,7 @@ function main(): void {
 main()
 
 function _gen_text(prompt: string, args: Record<string, any>): string {
+  // TODO: integrate with your preferred LLM
   for (const k in args) {
     const placeholder = '$' + k;
     prompt = prompt.split(placeholder).join(String(args[k]));


### PR DESCRIPTION
## Summary
- update Go compiler to call llm runtime when using `generate` blocks
- add echo provider import and context/llm imports
- handle import aliases
- update Python/TypeScript stubs with TODO comments
- tweak Go compiler tests to run with modules and set default LLM provider
- update golden outputs

## Testing
- `go test ./compile/go -run TestGoCompiler_SubsetPrograms/generate_echo -v`
- `go test ./compile/go -run TestGoCompiler_GoldenOutput -update`
- `go test ./compile/py -run TestPyCompiler_GoldenOutput -update`
- `go test ./compile/ts -run TestTSCompiler_GoldenOutput -update`
- `go test ./compile/go ./compile/py ./compile/ts`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684243594960832081742ecfc976efee