### PR TITLE
Add release notes for v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # 📦 CHANGELOG.md
+## [0.3.2] – 2025-06-08
+
+### Added
+
+* `model` block for reusable model aliases
+* `model` field in `generate` blocks
+* `generate embedding` block producing vectors
+* Embedding support with optional `normalize`
+
+### Changed
+
+* Generate blocks call the shared LLM runtime
+* Removed interpolation in generate fields
+
+### Fixed
+
+* Documentation and tests for generative features
+
+
 ## [0.3.1] – 2025-06-07
 
 ### Added

--- a/releases/v0.3.2.md
+++ b/releases/v0.3.2.md
@@ -1,0 +1,46 @@
+# Jun 2025 (v0.3.2)
+
+Mochi v0.3.2 introduces model aliases and embedding generation. Programs can now
+define reusable model configurations and request vector embeddings directly from
+LLM providers. These features build on the unified runtime added in earlier
+releases and continue our push toward first-class generative workflows.
+
+## New Language Feature: Model Aliases
+
+Define models once using a `model` block and reference them by name inside
+generate blocks via the `model` field.
+
+```mochi
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
+
+let poem = generate text {
+  model: "quick"
+  prompt: "Write a haiku about spring"
+}
+print(poem)
+```
+
+## New Language Feature: Embedding Generation
+
+A `generate embedding` block returns a `list<float>` vector for the provided
+text. Normalization can be requested with the optional `normalize` field.
+
+```mochi
+let vec = generate embedding {
+  text: "hello world"
+  normalize: true
+}
+print(len(vec))
+```
+
+Embeddings are supported across all built-in providers and use the same runtime
+options as text generation.
+
+## Other Improvements
+
+* Generate blocks now call the shared LLM runtime
+* Removed legacy interpolation behaviour in `generate` fields
+* Expanded tests and documentation for generative features


### PR DESCRIPTION
## Summary
- document v0.3.2 in CHANGELOG
- add release notes file for v0.3.2

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684299b4e39c83208ca35d3d5431280f