### PR TITLE
Update documentation for v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ let p = generate Person {
   prompt: "Generate a fictional software engineer"
 }
 print(p.name)
+
+let vec = generate embedding {
+  text: "hello world"
+  normalize: true
+}
+print(len(vec))
 ```
 
 ## MCP Tools

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Mochi Programming Language Specification (v0.3.1)
+# Mochi Programming Language Specification (v0.3.2)
 
-This document describes version 0.3.1 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
+This document describes version 0.3.2 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
 
 ## 0. Introduction
 
@@ -268,6 +268,33 @@ agent Logger {
 }
 ```
 
+### Model Declarations
+
+`model` blocks define reusable language model aliases. Each block specifies a
+`provider`, `name`, and optional parameters. Models can be referenced by name in
+`generate` expressions.
+
+```mochi
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
+```
+
+### Generative Blocks
+
+`generate` expressions invoke a language model. `generate text` returns a string,
+`generate <Type>` returns a struct of the given type, and `generate embedding`
+produces a `list<float>` vector. Embeddings may be normalized with the optional
+`normalize` field.
+
+```mochi
+let vec = generate embedding {
+  text: "hello world"
+  normalize: true
+}
+```
+
 ## 6. Functions
 
 Functions are first-class. Parameters are typed, and the return type may be omitted in block-bodied functions if `return` is used. Functions may capture variables from their enclosing scope, forming closures.
@@ -345,4 +372,4 @@ GenericType   = Identifier "<" TypeRef { "," TypeRef } ">" .
 FunType       = "fun" "(" [ TypeRef { "," TypeRef } ] ")" [ ":" TypeRef ] .
 ```
 
-This specification outlines the core language as of version 0.3.1. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.
+This specification outlines the core language as of version 0.3.2. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.

--- a/cheatsheet.mochi
+++ b/cheatsheet.mochi
@@ -1,4 +1,4 @@
-// 0. Mochi
+// 0. Mochi (v0.3.2)
 // Mochi is a lightweight programming language for building AI agents, working with real-time data,
 // and querying datasets. It combines declarative and functional programming, with built-in support
 // for streams, datasets, tools, and prompt-based AI generation.
@@ -75,6 +75,12 @@ generate text {
   temperature: 0.7
   max_tokens: 64
 }
+
+let vec = generate embedding {
+  text: "hello world"
+  normalize: true
+}
+print(len(vec))
 
 
 // 6. Datasets and Queries

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -1,4 +1,4 @@
-// 0. Mochi (v0.3.1)
+// 0. Mochi (v0.3.2)
 // Mochi is a lightweight programming language for building AI agents, working with real-time data,
 // and querying datasets. It combines declarative and functional programming, with built-in support
 // for streams, datasets, tools, and prompt-based AI generation.
@@ -111,3 +111,10 @@ print("Generated Person:")
 print("Name: ",p.name)
 print("Age: ",  p.age)
 print("Email: ", p.email)
+
+// Request an embedding vector
+let vec = generate embedding {
+  text: "hello world"
+  normalize: true
+}
+print(len(vec))


### PR DESCRIPTION
## Summary
- bump spec version to 0.3.2 and document model and embedding blocks
- show embedding generation in README
- update cheatsheets with version and embedding example

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68429c5c6c8083209d10adb2e7102fa8