### PR TITLE
Add match expression example and test

### DIFF
--- a/examples/v0.3/match.mochi
+++ b/examples/v0.3/match.mochi
@@ -1,0 +1,50 @@
+// match.mochi
+
+// 1. Match integer
+let x = 2
+
+let label = match x {
+  1 => "one"
+  2 => "two"
+  3 => "three"
+  _ => "unknown"
+}
+
+print(label)  // "two"
+
+
+// 2. Match string
+let day = "sun"
+
+let mood = match day {
+  "mon" => "tired"
+  "fri" => "excited"
+  "sun" => "relaxed"
+  _     => "normal"
+}
+
+print(mood)  // "relaxed"
+
+
+// 3. Match boolean
+let ok = true
+
+let status = match ok {
+  true => "confirmed"
+  false => "denied"
+}
+
+print(status)  // "confirmed"
+
+
+// 4. Match inside function with return
+fun classify(n: int): string {
+  return match n {
+    0 => "zero"
+    1 => "one"
+    _ => "many"
+  }
+}
+
+print(classify(0))  // "zero"
+print(classify(5))  // "many"

--- a/tests/interpreter/valid/match_full.mochi
+++ b/tests/interpreter/valid/match_full.mochi
@@ -1,0 +1,41 @@
+let x = 2
+
+let label = match x {
+  1 => "one"
+  2 => "two"
+  3 => "three"
+  _ => "unknown"
+}
+
+print(label)
+
+let day = "sun"
+
+let mood = match day {
+  "mon" => "tired"
+  "fri" => "excited"
+  "sun" => "relaxed"
+  _     => "normal"
+}
+
+print(mood)
+
+let ok = true
+
+let status = match ok {
+  true => "confirmed"
+  false => "denied"
+}
+
+print(status)
+
+fun classify(n: int): string {
+  return match n {
+    0 => "zero"
+    1 => "one"
+    _ => "many"
+  }
+}
+
+print(classify(0))
+print(classify(5))

--- a/tests/interpreter/valid/match_full.out
+++ b/tests/interpreter/valid/match_full.out
@@ -1,0 +1,5 @@
+two
+relaxed
+confirmed
+zero
+many


### PR DESCRIPTION
## Summary
- add a comprehensive match expression example to `examples/v0.3`
- cover matching integers, strings and booleans along with a function return
- verify interpreter output with new golden tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6842a958f57c8320ae569147f449c2a5