### PR TITLE
Release notes for v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # 📦 CHANGELOG.md
+## [0.3.3] – 2025-06-09
+
+### Added
+
+* `match` expression with pattern cases
+* Logical operators `&&` and `||`
+
 ## [0.3.2] – 2025-06-08
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ minimal but expressive.
 This roadmap outlines the language development toward a stable 1.0, with an emphasis on first-class data types, control
 flow, streaming logic, agents, and dataset support.
 
-Current release: v0.3.1. Upcoming 0.3.x versions will focus on generative AI.
+Current release: v0.3.3. Upcoming 0.3.x versions will focus on generative AI.
 
 # v0.3.x – Generative AI
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Mochi Programming Language Specification (v0.3.2)
+# Mochi Programming Language Specification (v0.3.3)
 
-This document describes version 0.3.2 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
+This document describes version 0.3.3 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
 
 ## 0. Introduction
 
@@ -129,7 +129,9 @@ let scores: map<string, int> = {"alice": 1}
 Expressions compute values. The grammar defines expressions in precedence order.
 
 ```ebnf
-Expression  = Equality
+Expression  = OrExpr
+OrExpr      = AndExpr { "||" AndExpr }
+AndExpr     = Equality { "&&" Equality }
 Equality    = Comparison { ("==" | "!=") Comparison }
 Comparison  = Term { ("<" | "<=" | ">" | ">=") Term }
 Term        = Factor { ("+" | "-") Factor }
@@ -137,6 +139,7 @@ Factor      = Unary { ("*" | "/") Unary }
 Unary       = { "-" | "!" } PostfixExpr
 PostfixExpr = Primary { IndexOp }
 Primary     = FunExpr | CallExpr | SelectorExpr | ListLiteral |
+              MapLiteral | MatchExpr | GenerateExpr |
               Literal | Identifier | "(" Expression ")"
 ```
 
@@ -175,6 +178,18 @@ Maps use braces with `key: value` pairs and share the same indexing syntax.
 ```mochi
 let scores = {"alice": 1, "bob": 2}
 print(scores["alice"])
+```
+
+#### Match Expressions
+
+`match` evaluates patterns in order and yields the corresponding result. `_` matches any value.
+
+```mochi
+let label = match x {
+  1 => "one"
+  2 => "two"
+  _ => "other"
+}
 ```
 
 ## 5. Statements
@@ -349,15 +364,16 @@ OnHandler     = "on" Identifier "as" Identifier Block .
 AgentDecl     = "agent" Identifier Block .
 ModelDecl     = "model" Identifier Block .
 
-Expression    = Equality .
-Equality      = Comparison { ("==" | "!=") Comparison } .
-Comparison    = Term { ("<" | "<=" | ">" | ">=") Term } .
-Term          = Factor { ("+" | "-") Factor } .
-Factor        = Unary { ("*" | "/") Unary } .
-Unary         = { "-" | "!" } PostfixExpr .
-PostfixExpr   = Primary { IndexOp } .
-Primary       = FunExpr | CallExpr | SelectorExpr | ListLiteral | MapLiteral |
-                Literal | Identifier | "(" Expression ")" .
+Expression    = OrExpr .
+OrExpr       = AndExpr { "||" AndExpr } .
+AndExpr      = Equality { "&&" Equality } .
+Equality     = Comparison { ("==" | "!=") Comparison } .
+Comparison   = Term { ("<" | "<=" | ">" | ">=") Term } .
+Term         = Factor { ("+" | "-") Factor } .
+Factor       = Unary { ("*" | "/") Unary } .
+Unary        = { "-" | "!" } PostfixExpr .
+PostfixExpr  = Primary { IndexOp } .
+Primary      = FunExpr | CallExpr | SelectorExpr | ListLiteral | MapLiteral | MatchExpr | GenerateExpr | Literal | Identifier | "(" Expression ")" .
 FunExpr       = "fun" "(" [ ParamList ] ")" [ ":" TypeRef ] ("=>" Expression | Block) .
 CallExpr      = Identifier "(" [ Expression { "," Expression } ] ")" .
 SelectorExpr  = Identifier { "." Identifier } .
@@ -372,4 +388,4 @@ GenericType   = Identifier "<" TypeRef { "," TypeRef } ">" .
 FunType       = "fun" "(" [ TypeRef { "," TypeRef } ] ")" [ ":" TypeRef ] .
 ```
 
-This specification outlines the core language as of version 0.3.2. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.
+This specification outlines the core language as of version 0.3.3. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -1,4 +1,4 @@
-// 0. Mochi (v0.3.2)
+// 0. Mochi (v0.3.3)
 // Mochi is a lightweight programming language for building AI agents, working with real-time data,
 // and querying datasets. It combines declarative and functional programming, with built-in support
 // for streams, datasets, tools, and prompt-based AI generation.
@@ -118,3 +118,19 @@ let vec = generate embedding {
   normalize: true
 }
 print(len(vec))
+
+// 7. Pattern Matching
+let day = "sun"
+let mood = match day {
+  "mon" => "tired"
+  "sun" => "relaxed"
+  _     => "normal"
+}
+print(mood)
+
+// 8. Logical operators
+let a = true
+let b = false
+if a && b || !b {
+  print("logic works")
+}

--- a/releases/v0.3.3.md
+++ b/releases/v0.3.3.md
@@ -1,0 +1,30 @@
+# Jun 2025 (v0.3.3)
+
+Mochi v0.3.3 adds **pattern matching** and **logical operators**, expanding the language's expressiveness for control flow and boolean logic.
+
+## Pattern Matching
+
+A new `match` expression evaluates a target value against a series of patterns and returns the result of the first match. An underscore `_` matches any remaining cases.
+
+```mochi
+let label = match x {
+  1 => "one"
+  2 => "two"
+  _ => "other"
+}
+```
+
+Match expressions can appear anywhere an expression is allowed, including inside functions and variable declarations.
+
+## Logical Operators
+
+Boolean expressions now support `&&` (and) and `||` (or) with proper precedence.
+
+```mochi
+if a && b || c {
+  print("combined condition")
+}
+```
+
+These operators integrate with the type checker and interpreter just like other binary operators.
+


### PR DESCRIPTION
## Summary
- changelog entry for v0.3.3
- roadmap now lists v0.3.3 as current
- spec updated for v0.3.3 with match and logic operators
- cheatsheet updated with examples and version number
- add release notes file for v0.3.3

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6842b5d04360832097a18a5c990ed4f8