### PR TITLE
Add tool calling support for generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,31 @@ let vec = generate embedding {
 print(len(vec))
 ```
 
+You can also expose Mochi functions as tools for the LLM to call:
+
+```mochi
+fun getWeather(location: string): string {
+  if location == "Paris" {
+    return "sunny with a gentle breeze"
+  }
+  return "weather data unavailable"
+}
+
+fun calc(expression: string): string {
+  if expression == "2 + 2" {
+    return "4"
+  }
+  return "error"
+}
+
+let result = generate text {
+  tools: [getWeather, calc]
+  prompt: "What's the weather like in Paris and what's 2 + 2?"
+}
+
+print(result)
+```
+
 ## MCP Tools
 
 When running `mochi serve`, the following tools are available:
@@ -340,6 +365,7 @@ Explore the [`examples/`](./examples) directory:
 * `generate.mochi`
 * `generate-struct.mochi`
 * `generate-model.mochi`
+* `generate-tools.mochi`
 * `types.mochi`
 
 Edit one or start fresh. It’s all yours.

--- a/examples/v0.3/generate-tools.mochi
+++ b/examples/v0.3/generate-tools.mochi
@@ -1,0 +1,21 @@
+fun getWeather(location: string): string {
+  if location == "Paris" {
+    return "sunny with a gentle breeze"
+  }
+  return "weather data unavailable"
+}
+
+fun calc(expression: string): string {
+  if expression == "2 + 2" {
+    return "4"
+  }
+  return "error"
+}
+
+let result = generate text {
+  tools: [getWeather, calc]
+  prompt: "What's the weather like in Paris and what's 2 + 2?"
+}
+
+print(result)
+

--- a/interpreter/schema.go
+++ b/interpreter/schema.go
@@ -3,6 +3,8 @@ package interpreter
 import (
 	"sort"
 
+	"mochi/parser"
+	"mochi/runtime/llm"
 	"mochi/types"
 )
 
@@ -49,4 +51,24 @@ func structToSchema(st types.StructType) map[string]any {
 		schema["required"] = required
 	}
 	return schema
+}
+
+func funcToTool(name string, fn *parser.FunStmt, ft types.FuncType) llm.Tool {
+	props := make(map[string]any, len(fn.Params))
+	required := make([]string, 0, len(fn.Params))
+	for i, p := range fn.Params {
+		var t types.Type
+		if i < len(ft.Params) {
+			t = ft.Params[i]
+		} else {
+			t = types.AnyType{}
+		}
+		props[p.Name] = typeToSchema(t)
+		required = append(required, p.Name)
+	}
+	schema := map[string]any{"type": "object", "properties": props}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return llm.Tool{Name: name, Parameters: schema}
 }

--- a/interpreter/schema_test.go
+++ b/interpreter/schema_test.go
@@ -76,3 +76,43 @@ let f = generate Foo { prompt: "{}" }`
 		t.Fatalf("schema mismatch:\nwant %#v\ngot  %#v", expected, captured.ResponseFormat.Schema)
 	}
 }
+
+func TestGenerateToolsSchema(t *testing.T) {
+	src := `fun getWeather(location: string): string { return "" }
+fun calc(expression: string): string { return "" }
+let result = generate text { tools: [getWeather, calc], prompt: "hi" }`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := types.NewEnv(nil)
+	llm.Default, err = llm.Open("capture", "", llm.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	interp := interpreter.New(prog, env)
+	if err := interp.Run(); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("missing request")
+	}
+	if len(captured.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(captured.Tools))
+	}
+	if captured.Tools[0].Name != "getWeather" {
+		t.Fatalf("unexpected tool %s", captured.Tools[0].Name)
+	}
+	params := captured.Tools[0].Parameters
+	expected := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"location": map[string]any{"type": "string"}},
+		"required":   []string{"location"},
+	}
+	if !reflect.DeepEqual(params, expected) {
+		t.Fatalf("schema mismatch:\nwant %#v\ngot  %#v", expected, params)
+	}
+}

--- a/runtime/llm/options.go
+++ b/runtime/llm/options.go
@@ -18,8 +18,8 @@ type Options struct {
 // ChatRequest contains a series of messages and options for the LLM provider.
 type ChatRequest struct {
 	Messages []Message `json:"messages"` // chat history
-	Options                              // embeds Options fields
-	Stream   bool      `json:"stream"`   // whether to stream responses
+	Options            // embeds Options fields
+	Stream   bool      `json:"stream"` // whether to stream responses
 }
 
 // Option is a functional option for configuring ChatRequest.
@@ -43,4 +43,14 @@ func WithParam(name string, value any) Option {
 // WithResponseFormat sets the expected structured response format.
 func WithResponseFormat(format ResponseFormat) Option {
 	return func(r *ChatRequest) { r.ResponseFormat = &format }
+}
+
+// WithTools provides a list of callable tools.
+func WithTools(tools []Tool) Option {
+	return func(r *ChatRequest) { r.Tools = tools }
+}
+
+// WithToolChoice specifies a tool name to invoke.
+func WithToolChoice(name string) Option {
+	return func(r *ChatRequest) { r.ToolChoice = name }
 }

--- a/types/check.go
+++ b/types/check.go
@@ -959,7 +959,7 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 				expect = ListType{Elem: StringType{}}
 			case "normalize":
 				expect = BoolType{}
-			case "args":
+			case "args", "tools", "tool_choice":
 				expect = nil
 			}
 			var err error


### PR DESCRIPTION
## Summary
- support using named functions as values
- add LLM options to pass tools
- extend interpreter to detect tools and invoke them when requested
- convert function signatures to JSON schema
- document tool calls and provide example
- tests for tool schema capture

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6842b9acb1f88320a32ce24879a6188b