### PR TITLE
Fix tools example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ fun calc(expression: string): string {
 }
 
 let result = generate text {
-  tools: [getWeather, calc]
+  tools: [getWeather, calc],
   prompt: "What's the weather like in Paris and what's 2 + 2?"
 }
 

--- a/examples/v0.3/generate-tools.mochi
+++ b/examples/v0.3/generate-tools.mochi
@@ -13,7 +13,7 @@ fun calc(expression: string): string {
 }
 
 let result = generate text {
-  tools: [getWeather, calc]
+  tools: [getWeather, calc],
   prompt: "What's the weather like in Paris and what's 2 + 2?"
 }
 


### PR DESCRIPTION
## Summary
- add a missing comma after the `tools` list in the README
- update `generate-tools.mochi` example accordingly

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6842bd7fef9c83208f78cbc058009c34