### PR TITLE
Fix tool calling for OpenAI and Cohere

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1099,8 +1099,8 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 			if err != nil {
 				return nil, err
 			}
-			msgs = append(msgs, llm.Message{Role: "assistant", ToolCall: tc})
-			msgs = append(msgs, llm.Message{Role: "tool", Content: fmt.Sprint(result), ToolCall: &llm.ToolCall{ID: tc.ID}})
+			msgs = append(msgs, resp.Message)
+			msgs = append(msgs, llm.Message{Role: "tool", Content: fmt.Sprint(result), ToolCall: &llm.ToolCall{ID: tc.ID, Name: tc.Name}})
 		}
 		if p.Generate.Target == "text" {
 			return resp.Message.Content, nil

--- a/runtime/llm/provider/openai/openai.go
+++ b/runtime/llm/provider/openai/openai.go
@@ -302,18 +302,22 @@ func convertMessages(msgs []llm.Message) []map[string]any {
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
 		mm := map[string]any{"role": m.Role}
-		if m.Content != "" {
+		if m.Content != "" || m.Role == "tool" {
 			mm["content"] = m.Content
 		} else {
 			mm["content"] = ""
 		}
 		if m.ToolCall != nil {
-			args, _ := json.Marshal(m.ToolCall.Args)
-			mm["tool_calls"] = []map[string]any{{
-				"id":       m.ToolCall.ID,
-				"type":     "function",
-				"function": map[string]any{"name": m.ToolCall.Name, "arguments": string(args)},
-			}}
+			if m.Role == "tool" {
+				mm["tool_call_id"] = m.ToolCall.ID
+			} else {
+				args, _ := json.Marshal(m.ToolCall.Args)
+				mm["tool_calls"] = []map[string]any{{
+					"id":       m.ToolCall.ID,
+					"type":     "function",
+					"function": map[string]any{"name": m.ToolCall.Name, "arguments": string(args)},
+				}}
+			}
 		}
 		out = append(out, mm)
 	}


### PR DESCRIPTION
## Summary
- handle assistant tool responses in interpreter
- include tool_call_id for tool messages in OpenAI provider
- add tool result support in Cohere provider
- provide helper to convert tools for Cohere

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6842beebbefc832080b3e20c64ca839e