### PR TITLE
Fix missing tool description

### DIFF
--- a/interpreter/schema.go
+++ b/interpreter/schema.go
@@ -1,11 +1,12 @@
 package interpreter
 
 import (
-	"sort"
+        "fmt"
+        "sort"
 
-	"mochi/parser"
-	"mochi/runtime/llm"
-	"mochi/types"
+        "mochi/parser"
+        "mochi/runtime/llm"
+        "mochi/types"
 )
 
 func typeToSchema(t types.Type) map[string]any {
@@ -66,9 +67,10 @@ func funcToTool(name string, fn *parser.FunStmt, ft types.FuncType) llm.Tool {
 		props[p.Name] = typeToSchema(t)
 		required = append(required, p.Name)
 	}
-	schema := map[string]any{"type": "object", "properties": props}
-	if len(required) > 0 {
-		schema["required"] = required
-	}
-	return llm.Tool{Name: name, Parameters: schema}
+        schema := map[string]any{"type": "object", "properties": props}
+        if len(required) > 0 {
+                schema["required"] = required
+        }
+        desc := fmt.Sprintf("Call the %s function", name)
+        return llm.Tool{Name: name, Description: desc, Parameters: schema}
 }


### PR DESCRIPTION
## Summary
- include `fmt` to build a default tool description
- provide a description when converting functions to tools

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842c42c53c88320bd82a0fe0838e057