### PR TITLE
Fix Cohere tool call handling

### DIFF
--- a/runtime/llm/types.go
+++ b/runtime/llm/types.go
@@ -6,6 +6,7 @@ import "context"
 type Message struct {
 	Role     string    `json:"role"`
 	Content  string    `json:"content"`
+	ToolPlan string    `json:"tool_plan,omitempty"`
 	ToolCall *ToolCall `json:"tool_call,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- add `ToolPlan` field to `llm.Message`
- handle Cohere's `tool_plan` and `tool_calls` in chat responses
- send tools using `type:function` format for Cohere

## Testing
- `go test ./... --vet=off -v`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842cbefcde083209e8aca3616291e2f