### PR TITLE
Add tool description support

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,15 @@ fun calc(expression: string): string {
 }
 
 let result = generate text {
-  tools: [getWeather, calc],
-  prompt: "What's the weather like in Paris and what's 2 + 2?"
+  prompt: "What's the weather like in Paris and what's 2 + 2?",
+  tools: [
+    getWeather {
+      description: "Returns the current weather for a given city"
+    },
+    calc {
+      description: "Evaluates a simple math expression"
+    }
+  ]
 }
 
 print(result)
@@ -365,7 +372,7 @@ Explore the [`examples/`](./examples) directory:
 * `generate.mochi`
 * `generate-struct.mochi`
 * `generate-model.mochi`
-* `generate-tools.mochi`
+* `tools.mochi`
 * `types.mochi`
 
 Edit one or start fresh. It’s all yours.

--- a/examples/v0.3/tools.mochi
+++ b/examples/v0.3/tools.mochi
@@ -1,0 +1,28 @@
+fun getWeather(location: string): string {
+  if location == "Paris" {
+    return "sunny with a gentle breeze"
+  }
+  return "weather data unavailable"
+}
+
+fun calc(expression: string): string {
+  if expression == "2 + 2" {
+    return "4"
+  }
+  return "error"
+}
+
+let result = generate text {
+  prompt: "What's the weather like in Paris and what's 2 + 2?",
+  tools: [
+    getWeather {
+      description: "Returns the current weather for a given city"
+    },
+    calc {
+      description: "Evaluates a simple math expression"
+    }
+  ]
+}
+
+print(result)
+


### PR DESCRIPTION
## Summary
- add new `tools.mochi` example demonstrating descriptions in tool specs
- support tool descriptions in generate expressions
- allow unknown struct literals for tool specs in type checker
- update README docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6842d624e4548320bc08b6acb5deb83b