### PR TITLE
Add user-defined type support in compilers

### DIFF
--- a/bench/runner.go
+++ b/bench/runner.go
@@ -354,7 +354,7 @@ func compileToPy(mochiFile, pyFile string) error {
 	if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 		return fmt.Errorf("type error: %v", errs[0])
 	}
-	c := pycode.New()
+	c := pycode.New(typeEnv)
 	code, err := c.Compile(prog)
 	if err != nil {
 		return err
@@ -371,7 +371,7 @@ func compileToTs(mochiFile, tsFile string) error {
 	if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 		return fmt.Errorf("type error: %v", errs[0])
 	}
-	c := tscode.New()
+	c := tscode.New(typeEnv)
 	code, err := c.Compile(prog)
 	if err != nil {
 		return err

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -240,7 +240,7 @@ func build(cmd *BuildCmd) error {
 		if out == "" {
 			out = base + ".py"
 		}
-		code, err := pycode.New().Compile(prog)
+		code, err := pycode.New(env).Compile(prog)
 		if err == nil {
 			err = os.WriteFile(out, code, 0644)
 		}
@@ -252,7 +252,7 @@ func build(cmd *BuildCmd) error {
 		if out == "" {
 			out = base + ".ts"
 		}
-		code, err := tscode.New().Compile(prog)
+		code, err := tscode.New(env).Compile(prog)
 		if err == nil {
 			err = os.WriteFile(out, code, 0644)
 		}

--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -27,7 +27,7 @@ func TestPyCompiler_SubsetPrograms(t *testing.T) {
 		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", errs[0])
 		}
-		c := pycode.New()
+		c := pycode.New(typeEnv)
 		code, err := c.Compile(prog)
 		if err != nil {
 			return nil, fmt.Errorf("❌ compile error: %w", err)
@@ -56,7 +56,7 @@ func TestPyCompiler_GoldenOutput(t *testing.T) {
 		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", errs[0])
 		}
-		c := pycode.New()
+		c := pycode.New(typeEnv)
 		code, err := c.Compile(prog)
 		if err != nil {
 			return nil, fmt.Errorf("❌ compile error: %w", err)

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"mochi/parser"
+	"mochi/types"
 )
 
 // Compiler translates a Mochi AST into TypeScript source code that can be run with Deno.
@@ -14,11 +15,12 @@ type Compiler struct {
 	buf     bytes.Buffer
 	indent  int
 	helpers map[string]bool
+	env     *types.Env
 }
 
 // New creates a new TypeScript compiler instance.
-func New() *Compiler {
-	return &Compiler{helpers: make(map[string]bool)}
+func New(env *types.Env) *Compiler {
+	return &Compiler{helpers: make(map[string]bool), env: env}
 }
 
 // Compile generates TypeScript source code for the given program.
@@ -64,6 +66,8 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		return c.compileVar(s.Var)
 	case s.Assign != nil:
 		return c.compileAssign(s.Assign)
+	case s.Type != nil:
+		return c.compileTypeDecl(s.Type)
 	case s.Expr != nil:
 		expr, err := c.compileExpr(s.Expr.Expr)
 		if err != nil {
@@ -122,6 +126,18 @@ func (c *Compiler) compileAssign(s *parser.AssignStmt) error {
 		return err
 	}
 	c.writeln(fmt.Sprintf("%s = %s", name, value))
+	return nil
+}
+
+func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
+	name := sanitizeName(t.Name)
+	c.writeln(fmt.Sprintf("type %s = {", name))
+	c.indent++
+	for _, f := range t.Fields {
+		c.writeln(fmt.Sprintf("%s: any;", sanitizeName(f.Name)))
+	}
+	c.indent--
+	c.writeln("}")
 	return nil
 }
 
@@ -325,6 +341,16 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			expr += "." + sanitizeName(s)
 		}
 		return expr, nil
+	case p.Struct != nil:
+		parts := make([]string, len(p.Struct.Fields))
+		for i, f := range p.Struct.Fields {
+			v, err := c.compileExpr(f.Value)
+			if err != nil {
+				return "", err
+			}
+			parts[i] = fmt.Sprintf("%s: %s", sanitizeName(f.Name), v)
+		}
+		return "{" + strings.Join(parts, ", ") + "}", nil
 	case p.FunExpr != nil:
 		return c.compileFunExpr(p.FunExpr)
 	default:
@@ -444,6 +470,12 @@ func (c *Compiler) compileGenerateExpr(g *parser.GenerateExpr) (string, error) {
 		}
 		if prompt == "" {
 			prompt = "\"\""
+		}
+		if c.env != nil {
+			if _, ok := c.env.GetStruct(g.Target); ok {
+				c.use("_gen_struct")
+				return fmt.Sprintf("_gen_struct<%s>(%s)", sanitizeName(g.Target), prompt), nil
+			}
 		}
 		c.use("_gen_text")
 		return fmt.Sprintf("_gen_text(%s)", prompt), nil
@@ -575,14 +607,20 @@ const (
 		"  // TODO: integrate with your preferred embedding model\n" +
 		"  return Array.from(text).map(c => c.charCodeAt(0));\n" +
 		"}\n"
+
+	helperGenStruct = "function _gen_struct<T>(prompt: string): T {\n" +
+		"  // TODO: integrate with your preferred LLM and parse JSON\n" +
+		"  return JSON.parse(prompt) as T;\n" +
+		"}\n"
 )
 
 var helperMap = map[string]string{
-	"_index":     helperIndex,
-	"_slice":     helperSlice,
-	"_len":       helperLen,
-	"_gen_text":  helperGenText,
-	"_gen_embed": helperGenEmbed,
+	"_index":      helperIndex,
+	"_slice":      helperSlice,
+	"_len":        helperLen,
+	"_gen_text":   helperGenText,
+	"_gen_embed":  helperGenEmbed,
+	"_gen_struct": helperGenStruct,
 }
 
 func (c *Compiler) use(name string) {

--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -27,7 +27,7 @@ func TestTSCompiler_SubsetPrograms(t *testing.T) {
 		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", errs[0])
 		}
-		c := tscode.New()
+		c := tscode.New(typeEnv)
 		code, err := c.Compile(prog)
 		if err != nil {
 			return nil, fmt.Errorf("❌ compile error: %w", err)
@@ -56,7 +56,7 @@ func TestTSCompiler_GoldenOutput(t *testing.T) {
 		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", errs[0])
 		}
-		c := tscode.New()
+		c := tscode.New(typeEnv)
 		code, err := c.Compile(prog)
 		if err != nil {
 			return nil, fmt.Errorf("❌ compile error: %w", err)


### PR DESCRIPTION
## Summary
- support `type` declarations in Go/TS/Python compilers
- emit struct literals for custom types
- add runtime helpers for generating struct values
- fix generate handlers for Python/TS and pass type environment

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6842f586534483209ffa07db224fd1cc