### PR TITLE
Add method support to Mochi

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -106,12 +106,16 @@ func FromStatement(s *parser.Statement) *Node {
 
 	case s.Type != nil:
 		n := &Node{Kind: "type", Value: s.Type.Name}
-		for _, f := range s.Type.Fields {
-			n.Children = append(n.Children, &Node{
-				Kind:     "field",
-				Value:    f.Name,
-				Children: []*Node{FromTypeRef(f.Type)},
-			})
+		for _, m := range s.Type.Members {
+			if m.Field != nil {
+				n.Children = append(n.Children, &Node{
+					Kind:     "field",
+					Value:    m.Field.Name,
+					Children: []*Node{FromTypeRef(m.Field.Type)},
+				})
+			} else if m.Method != nil {
+				n.Children = append(n.Children, FromStatement(&parser.Statement{Fun: m.Method}))
+			}
 		}
 		return n
 

--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -228,10 +228,12 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 	name := sanitizeName(t.Name)
 	c.writeln(fmt.Sprintf("type %s struct {", name))
 	c.indent++
-	for _, f := range t.Fields {
-		fieldName := exportName(sanitizeName(f.Name))
-		typ := goType(resolveTypeRef(f.Type))
-		c.writeln(fmt.Sprintf("%s %s `json:\"%s\"`", fieldName, typ, f.Name))
+	for _, m := range t.Members {
+		if m.Field != nil {
+			fieldName := exportName(sanitizeName(m.Field.Name))
+			typ := goType(resolveTypeRef(m.Field.Type))
+			c.writeln(fmt.Sprintf("%s %s `json:\"%s\"`", fieldName, typ, m.Field.Name))
+		}
 	}
 	c.indent--
 	c.writeln("}")

--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -167,11 +167,20 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 	c.writeln("@dataclasses.dataclass")
 	c.writeln(fmt.Sprintf("class %s:", name))
 	c.indent++
-	if len(t.Fields) == 0 {
+	hasField := false
+	for _, m := range t.Members {
+		if m.Field != nil {
+			hasField = true
+			break
+		}
+	}
+	if !hasField {
 		c.writeln("pass")
 	} else {
-		for _, f := range t.Fields {
-			c.writeln(fmt.Sprintf("%s: typing.Any", sanitizeName(f.Name)))
+		for _, m := range t.Members {
+			if m.Field != nil {
+				c.writeln(fmt.Sprintf("%s: typing.Any", sanitizeName(m.Field.Name)))
+			}
 		}
 	}
 	c.indent--

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -133,8 +133,10 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 	name := sanitizeName(t.Name)
 	c.writeln(fmt.Sprintf("type %s = {", name))
 	c.indent++
-	for _, f := range t.Fields {
-		c.writeln(fmt.Sprintf("%s: any;", sanitizeName(f.Name)))
+	for _, m := range t.Members {
+		if m.Field != nil {
+			c.writeln(fmt.Sprintf("%s: any;", sanitizeName(m.Field.Name)))
+		}
 	}
 	c.indent--
 	c.writeln("}")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -94,9 +94,14 @@ type ForStmt struct {
 // --- User-defined Types ---
 
 type TypeDecl struct {
-	Pos    lexer.Position
-	Name   string       `parser:"'type' @Ident"`
-	Fields []*TypeField `parser:"'{' @@* '}'"`
+	Pos     lexer.Position
+	Name    string        `parser:"'type' @Ident"`
+	Members []*TypeMember `parser:"'{' @@* '}'"`
+}
+
+type TypeMember struct {
+	Field  *TypeField `parser:"@@"`
+	Method *FunStmt   `parser:"| @@"`
 }
 
 type TypeField struct {
@@ -254,16 +259,17 @@ type MatchCase struct {
 
 type Primary struct {
 	Pos      lexer.Position
-	FunExpr  *FunExpr       `parser:"@@"`
-	Struct   *StructLiteral `parser:"| @@"`
-	Call     *CallExpr      `parser:"| @@"`
-	Selector *SelectorExpr  `parser:"| @@"`
-	List     *ListLiteral   `parser:"| @@"`
-	Map      *MapLiteral    `parser:"| @@"`
-	Match    *MatchExpr     `parser:"| @@"`
-	Generate *GenerateExpr  `parser:"| @@"`
-	Lit      *Literal       `parser:"| @@"`
-	Group    *Expr          `parser:"| '(' @@ ')'"`
+	FunExpr  *FunExpr        `parser:"@@"`
+	Struct   *StructLiteral  `parser:"| @@"`
+	Method   *MethodCallExpr `parser:"| @@"`
+	Call     *CallExpr       `parser:"| @@"`
+	Selector *SelectorExpr   `parser:"| @@"`
+	List     *ListLiteral    `parser:"| @@"`
+	Map      *MapLiteral     `parser:"| @@"`
+	Match    *MatchExpr      `parser:"| @@"`
+	Generate *GenerateExpr   `parser:"| @@"`
+	Lit      *Literal        `parser:"| @@"`
+	Group    *Expr           `parser:"| '(' @@ ')'"`
 }
 
 type FunExpr struct {
@@ -285,6 +291,13 @@ type CallExpr struct {
 	Pos  lexer.Position
 	Func string  `parser:"@Ident '('"`
 	Args []*Expr `parser:"[ @@ { ',' @@ } ] ')'"`
+}
+
+type MethodCallExpr struct {
+	Pos  lexer.Position
+	Root string   `parser:"@Ident"`
+	Path []string `parser:"'.' @Ident { '.' @Ident } '('"`
+	Args []*Expr  `parser:"[ @@ { ',' @@ } ] ')'"`
 }
 
 type Literal struct {

--- a/tests/interpreter/valid/user_type_method.mochi
+++ b/tests/interpreter/valid/user_type_method.mochi
@@ -1,0 +1,17 @@
+type Circle {
+  radius: float
+
+  fun area(): float {
+    let a = 3.14 * radius * radius
+    print("Calculating area:", a)
+    return a
+  }
+
+  fun describe() {
+    print("Circle with radius", radius)
+    area()
+  }
+}
+
+let c = Circle { radius: 5.0 }
+c.describe()

--- a/tests/interpreter/valid/user_type_method.out
+++ b/tests/interpreter/valid/user_type_method.out
@@ -1,0 +1,2 @@
+Circle with radius 5
+Calculating area: 78.5

--- a/tests/parser/valid/user_type_method.golden
+++ b/tests/parser/valid/user_type_method.golden
@@ -1,0 +1,20 @@
+(program
+  (type Circle
+    (field radius (type float))
+    (fun area
+      (type float)
+      (let a
+        (binary *
+          (binary * (float 3.14) (selector radius))
+          (selector radius)
+        )
+      )
+      (call print (string "Calculating area:") (selector a))
+      (return (selector a))
+    )
+    (fun describe
+      (call print (string "Circle with radius") (selector radius))
+      (call area)
+    )
+  )
+)

--- a/tests/parser/valid/user_type_method.mochi
+++ b/tests/parser/valid/user_type_method.mochi
@@ -1,0 +1,14 @@
+type Circle {
+  radius: float
+
+  fun area(): float {
+    let a = 3.14 * radius * radius
+    print("Calculating area:", a)
+    return a
+  }
+
+  fun describe() {
+    print("Circle with radius", radius)
+    area()
+  }
+}

--- a/tests/types/valid/user_type_method.golden
+++ b/tests/types/valid/user_type_method.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/user_type_method.mochi
+++ b/tests/types/valid/user_type_method.mochi
@@ -1,0 +1,16 @@
+type Circle {
+  radius: float
+
+  fun area(): float {
+    let a = 3.14 * radius * radius
+    print("Calculating area:", a)
+    return a
+  }
+
+  fun describe() {
+    print("Circle with radius", radius)
+    area()
+  }
+}
+
+let c: Circle


### PR DESCRIPTION
## Summary
- support methods in `type` declarations
- parse method calls via `object.method()`
- execute methods with access to struct fields and other methods
- update type checker for methods
- add tests for new feature

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684306728798832085b953cebbc16f33