### PR TITLE
Add struct method support to Go backend

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -94,9 +94,14 @@ type ForStmt struct {
 // --- User-defined Types ---
 
 type TypeDecl struct {
-	Pos    lexer.Position
-	Name   string       `parser:"'type' @Ident"`
-	Fields []*TypeField `parser:"'{' @@* '}'"`
+	Pos     lexer.Position
+	Name    string        `parser:"'type' @Ident"`
+	Members []*TypeMember `parser:"'{' @@* '}'"`
+}
+
+type TypeMember struct {
+	Field  *TypeField `parser:"@@"`
+	Method *FunStmt   `parser:"| @@"`
 }
 
 type TypeField struct {
@@ -277,14 +282,15 @@ type FunExpr struct {
 // --- Atoms ---
 
 type SelectorExpr struct {
+	Pos  lexer.Position
 	Root string   `parser:"@Ident"`
 	Tail []string `parser:"{ '.' @Ident }"`
 }
 
 type CallExpr struct {
 	Pos  lexer.Position
-	Func string  `parser:"@Ident '('"`
-	Args []*Expr `parser:"[ @@ { ',' @@ } ] ')'"`
+	Func *SelectorExpr `parser:"@@ '('"`
+	Args []*Expr       `parser:"[ @@ { ',' @@ } ] ')'"`
 }
 
 type Literal struct {

--- a/tests/interpreter/valid/method.mochi
+++ b/tests/interpreter/valid/method.mochi
@@ -1,0 +1,17 @@
+type Circle {
+  radius: float
+
+  fun area(): float {
+    let a = 3.14 * radius * radius
+    print("Calculating area:", a)
+    return a
+  }
+
+  fun describe() {
+    print("Circle with radius", radius)
+  }
+}
+
+let c = Circle { radius: 5.0 }
+c.describe()
+print("Area is", c.area())

--- a/tests/interpreter/valid/method.out
+++ b/tests/interpreter/valid/method.out
@@ -1,0 +1,3 @@
+Circle with radius 5
+Calculating area: 78.5
+Area is 78.5

--- a/tests/parser/valid/method_decl.golden
+++ b/tests/parser/valid/method_decl.golden
@@ -1,0 +1,26 @@
+(program
+  (type Circle
+    (field radius (type float))
+    (fun area
+      (type float)
+      (let a
+        (binary *
+          (binary * (float 3.14) (selector radius))
+          (selector radius)
+        )
+      )
+      (call print (string "Calculating area:") (selector a))
+      (return (selector a))
+    )
+    (fun describe
+      (call print (string "Circle with radius") (selector radius))
+    )
+  )
+  (let c
+    (struct Circle
+      (field radius (float 5))
+    )
+  )
+  (call c.describe)
+  (call print (string "Area is") (call c.area))
+)

--- a/tests/parser/valid/method_decl.mochi
+++ b/tests/parser/valid/method_decl.mochi
@@ -1,0 +1,17 @@
+type Circle {
+  radius: float
+
+  fun area(): float {
+    let a = 3.14 * radius * radius
+    print("Calculating area:", a)
+    return a
+  }
+
+  fun describe() {
+    print("Circle with radius", radius)
+  }
+}
+
+let c = Circle { radius: 5.0 }
+c.describe()
+print("Area is", c.area())


### PR DESCRIPTION
## Summary
- extend parser with type members and improved call expressions
- allow struct methods in interpreter and Go compiler
- update type checker for methods
- add tests for method declarations and calls

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843071244488320b72f4ada2cdd67c2