### PR TITLE
Add inline method support

### DIFF
--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -133,8 +133,10 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 	name := sanitizeName(t.Name)
 	c.writeln(fmt.Sprintf("type %s = {", name))
 	c.indent++
-	for _, f := range t.Fields {
-		c.writeln(fmt.Sprintf("%s: any;", sanitizeName(f.Name)))
+	for _, m := range t.Members {
+		if m.Field != nil {
+			c.writeln(fmt.Sprintf("%s: any;", sanitizeName(m.Field.Name)))
+		}
 	}
 	c.indent--
 	c.writeln("}")
@@ -284,7 +286,22 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for _, idx := range p.Index {
+	for _, op := range p.Ops {
+		if op.Index == nil {
+			if op.Call != nil {
+				args := make([]string, len(op.Call.Args))
+				for i, a := range op.Call.Args {
+					v, err := c.compileExpr(a)
+					if err != nil {
+						return "", err
+					}
+					args[i] = v
+				}
+				expr = fmt.Sprintf("%s(%s)", expr, strings.Join(args, ", "))
+			}
+			continue
+		}
+		idx := op.Index
 		if idx.Colon != nil {
 			start := "0"
 			end := "0"
@@ -654,7 +671,7 @@ func isUnderscoreExpr(e *parser.Expr) bool {
 		return false
 	}
 	p := u.Value
-	if len(p.Index) != 0 {
+	if len(p.Ops) != 0 {
 		return false
 	}
 	if p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0 {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -96,8 +96,13 @@ type ForStmt struct {
 type TypeDecl struct {
 	Pos      lexer.Position
 	Name     string         `parser:"'type' @Ident"`
-	Fields   []*TypeField   `parser:"[ '{' @@* '}' ]"`
+	Members  []*TypeMember  `parser:"[ '{' @@* '}' ]"`
 	Variants []*TypeVariant `parser:"[ '=' @@ { '|' @@ } ]"`
+}
+
+type TypeMember struct {
+	Field  *TypeField `parser:"@@"`
+	Method *FunStmt   `parser:"| @@"`
 }
 
 type TypeVariant struct {
@@ -200,8 +205,18 @@ type Unary struct {
 }
 
 type PostfixExpr struct {
-	Target *Primary   `parser:"@@"`
-	Index  []*IndexOp `parser:"@@*"`
+	Target *Primary     `parser:"@@"`
+	Ops    []*PostfixOp `parser:"@@*"`
+}
+
+type PostfixOp struct {
+	Call  *CallOp  `parser:"@@"`
+	Index *IndexOp `parser:"| @@"`
+}
+
+type CallOp struct {
+	Pos  lexer.Position
+	Args []*Expr `parser:"'(' [ @@ { ',' @@ } ] ')'"`
 }
 
 type IndexOp struct {

--- a/tests/interpreter/valid/method.mochi
+++ b/tests/interpreter/valid/method.mochi
@@ -1,0 +1,17 @@
+type Circle {
+  radius: float
+
+  fun area(): float {
+    let a = 3.14 * radius * radius
+    print("Calculating area:", a)
+    return a
+  }
+
+  fun describe() {
+    print("Circle with radius", radius)
+  }
+}
+
+let c = Circle { radius: 5.0 }
+c.describe()
+print("Area is", c.area())

--- a/tests/interpreter/valid/method.out
+++ b/tests/interpreter/valid/method.out
@@ -1,0 +1,3 @@
+Circle with radius 5
+Calculating area: 78.5
+Area is 78.5

--- a/types/env.go
+++ b/types/env.go
@@ -203,14 +203,15 @@ func (e *Env) GetFunc(name string) (*parser.FunStmt, bool) {
 // Useful for closures capturing current bindings.
 func (e *Env) Copy() *Env {
 	newEnv := &Env{
-		parent: nil, // flatten parent chain
-		types:  make(map[string]Type, len(e.types)),
-		mut:    make(map[string]bool, len(e.mut)),
-		values: make(map[string]any, len(e.values)),
-		funcs:  make(map[string]*parser.FunStmt, len(e.funcs)),
-		unions: make(map[string]UnionType, len(e.unions)),
-		models: make(map[string]ModelSpec, len(e.models)),
-		output: e.output,
+		parent:  nil, // flatten parent chain
+		types:   make(map[string]Type, len(e.types)),
+		mut:     make(map[string]bool, len(e.mut)),
+		values:  make(map[string]any, len(e.values)),
+		funcs:   make(map[string]*parser.FunStmt, len(e.funcs)),
+		structs: make(map[string]StructType, len(e.structs)),
+		unions:  make(map[string]UnionType, len(e.unions)),
+		models:  make(map[string]ModelSpec, len(e.models)),
+		output:  e.output,
 	}
 	for k, v := range e.types {
 		newEnv.types[k] = v
@@ -223,6 +224,9 @@ func (e *Env) Copy() *Env {
 	}
 	for k, v := range e.funcs {
 		newEnv.funcs[k] = v
+	}
+	for k, v := range e.structs {
+		newEnv.structs[k] = v
 	}
 	for k, v := range e.unions {
 		newEnv.unions[k] = v


### PR DESCRIPTION
## Summary
- support inline methods in type declarations
- handle postfix call ops in parser, interpreter, and type checker
- update Go/TS/Python compilers for new AST
- add interpreter test for struct methods

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843158517c88320bf50197d3dca4b1d