### PR TITLE
Prepare v0.3.4 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # 📦 CHANGELOG.md
+## [0.3.4] – 2025-06-07
+
+### Added
+
+* Tool calling via `tools` field in `generate` blocks
+* Inline methods defined inside `type` blocks
+* Basic union types with pattern matching
+
+### Changed
+
+* Tool descriptions exported in schemas
+
+### Fixed
+
+* Various improvements to tool call handling
+
 ## [0.3.3] – 2025-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -350,6 +350,32 @@ let result = generate text {
 print(result)
 ```
 
+### Union Types and Methods
+
+Mochi now supports union types declared with the `|` syntax as well as inline
+methods defined inside `type` blocks.
+
+```mochi
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+fun sum(t: Tree): int {
+  return match t {
+    Leaf => 0
+    Node(l, v, r) => sum(l) + v + sum(r)
+  }
+}
+
+type Circle {
+  radius: float
+
+  fun area(): float {
+    return 3.14 * radius * radius
+  }
+}
+```
+
 ## MCP Tools
 
 When running `mochi serve`, the following tools are available:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ minimal but expressive.
 This roadmap outlines the language development toward a stable 1.0, with an emphasis on first-class data types, control
 flow, streaming logic, agents, and dataset support.
 
-Current release: v0.3.3. Upcoming 0.3.x versions will focus on generative AI.
+Current release: v0.3.4. Upcoming 0.3.x versions will focus on generative AI.
 
 # v0.3.x – Generative AI
 
@@ -65,7 +65,7 @@ let summary = generate text {
 }
 ```
 
-## v0.3.3 – Output postprocessing
+## v0.3.4 – Output postprocessing
 
 * [ ] `as` clause for structured result decoding
 * [ ] Modes: `json`, `yaml`, `list`, `lines`, `markdown`

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Mochi Programming Language Specification (v0.3.3)
+# Mochi Programming Language Specification (v0.3.4)
 
-This document describes version 0.3.3 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
+This document describes version 0.3.4 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
 
 ## 0. Introduction
 
@@ -388,4 +388,4 @@ GenericType   = Identifier "<" TypeRef { "," TypeRef } ">" .
 FunType       = "fun" "(" [ TypeRef { "," TypeRef } ] ")" [ ":" TypeRef ] .
 ```
 
-This specification outlines the core language as of version 0.3.3. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.
+This specification outlines the core language as of version 0.3.4. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -1,4 +1,4 @@
-// 0. Mochi (v0.3.3)
+// 0. Mochi (v0.3.4)
 // Mochi is a lightweight programming language for building AI agents, working with real-time data,
 // and querying datasets. It combines declarative and functional programming, with built-in support
 // for streams, datasets, tools, and prompt-based AI generation.
@@ -134,3 +134,32 @@ let b = false
 if a && b || !b {
   print("logic works")
 }
+
+// 9. Union Types
+
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+fun sum(t: Tree): int {
+  return match t {
+    Leaf => 0
+    Node(l, v, r) => sum(l) + v + sum(r)
+  }
+}
+
+let t = Node { left: Leaf, value: 1, right: Leaf }
+print(sum(t))
+
+// 10. Methods
+
+type Circle {
+  radius: float
+
+  fun area(): float {
+    return 3.14 * radius * radius
+  }
+}
+
+let c = Circle { radius: 5 }
+print(c.area())

--- a/releases/v0.3.4.md
+++ b/releases/v0.3.4.md
@@ -1,0 +1,55 @@
+# Jun 2025 (v0.3.4)
+
+Mochi v0.3.4 introduces **tool calling**, **union types**, and **inline methods**, enabling richer integrations and more expressive type definitions.
+
+## Tool Calling
+
+`generate` blocks can now invoke registered tools. Each tool may include a `description` used by the LLM when deciding to call it.
+
+```mochi
+fun getWeather(city: string): string {
+  return "Clear"
+}
+
+let reply = generate text {
+  prompt: "Weather in Paris?"
+  tools: [
+    getWeather { description: "Lookup current weather" }
+  ]
+}
+```
+
+## Union Types
+
+Programs may declare algebraic data types using the `type A = ... | ...` syntax. Pattern matching integrates seamlessly with these unions.
+
+```mochi
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+let total = match someTree {
+  Leaf => 0
+  Node(l, v, r) => v + total(l) + total(r)
+}
+```
+
+## Inline Methods
+
+Struct types can embed function members that act as methods:
+
+```mochi
+type Circle {
+  radius: float
+
+  fun area(): float {
+    return 3.14 * radius * radius
+  }
+}
+```
+
+## Other Changes
+
+- Tool descriptions exported in JSON schemas
+- Examples extended with method and binary tree demos
+- Fixed several issues around tool call handling


### PR DESCRIPTION
## Summary
- add release notes for v0.3.4
- bump docs and roadmap to v0.3.4
- document union types and inline methods
- revert version bumps in package files

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68431f6621cc8320ac3201494e51ec50