### PR TITLE
Add fetch expression and example

### DIFF
--- a/examples/v0.3/fetch.mochi
+++ b/examples/v0.3/fetch.mochi
@@ -1,0 +1,13 @@
+// fetch.mochi
+
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+
+print("Title:", todo.title)
+print("Completed:", todo.completed)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,7 +23,7 @@ func (b *boolLit) Capture(values []string) error {
 var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Comment", Pattern: `//[^\n]*|/\*([^*]|\*+[^*/])*\*+/`},
 	{Name: "Bool", Pattern: `\b(true|false)\b`},
-	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|type|fun|return|let|var|if|else|for|in|generate|match)\b`},
+	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|type|fun|return|let|var|if|else|for|in|generate|match|fetch)\b`},
 	{Name: "Ident", Pattern: `[\p{L}\p{So}_][\p{L}\p{So}\p{N}_]*`},
 	{Name: "Float", Pattern: `\d+\.\d+`},
 	{Name: "Int", Pattern: `\d+`},
@@ -262,6 +262,11 @@ type GenerateExpr struct {
 	Fields []*GenerateField `parser:"'{' [ @@ { ',' @@ } ] [ ',' ]? '}'"`
 }
 
+type FetchExpr struct {
+	Pos lexer.Position
+	URL *Expr `parser:"'fetch' @@"`
+}
+
 type MatchExpr struct {
 	Pos    lexer.Position
 	Target *Expr        `parser:"'match' @@ '{'"`
@@ -284,6 +289,7 @@ type Primary struct {
 	Map      *MapLiteral    `parser:"| @@"`
 	Match    *MatchExpr     `parser:"| @@"`
 	Generate *GenerateExpr  `parser:"| @@"`
+	Fetch    *FetchExpr     `parser:"| @@"`
 	Lit      *Literal       `parser:"| @@"`
 	Group    *Expr          `parser:"| '(' @@ ')'"`
 }


### PR DESCRIPTION
## Summary
- extend Mochi grammar with `fetch` keyword and expression
- implement runtime support for fetch in interpreter and Go compiler
- provide helper to perform HTTP GET and decode JSON
- add example using fetch to load a todo item

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684381e2ba288320ac6ebc78bcc97d1d