### PR TITLE
Add runtime HTTP fetch helper

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"github.com/alecthomas/participle/v2/lexer"
 	"github.com/fatih/color"
-	"io"
+
 	"mochi/parser"
+	mhttp "mochi/runtime/http"
 	"mochi/runtime/llm"
 	"mochi/types"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -1014,20 +1014,7 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		if !ok {
 			return nil, fmt.Errorf("fetch URL must be a string")
 		}
-		resp, err := http.Get(urlStr)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		var out any
-		if err := json.Unmarshal(data, &out); err != nil {
-			return nil, err
-		}
-		return out, nil
+		return mhttp.Fetch(urlStr)
 
 	case p.Generate != nil:
 		reqParams := map[string]any{}

--- a/runtime/http/fetch.go
+++ b/runtime/http/fetch.go
@@ -1,0 +1,28 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	nethttp "net/http"
+)
+
+// Fetch retrieves JSON from the given URL and unmarshals it into an
+// arbitrary Go value. It is used by the interpreter to implement the
+// `fetch` expression.
+func Fetch(url string) (any, error) {
+	resp, err := nethttp.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- introduce `runtime/http` package
- call `runtime/http.Fetch` from the interpreter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68438460f24483209173961275cf542f