### PR TITLE
Add fetch `with` block

### DIFF
--- a/examples/v0.3/fetch-post.mochi
+++ b/examples/v0.3/fetch-post.mochi
@@ -1,0 +1,39 @@
+// typed-post.mochi
+
+// Define the request body type
+type NewTodo {
+  userId: int
+  title: string
+  completed: bool
+}
+
+// Define the expected response type
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+// Create a request payload using the NewTodo type
+let payload: NewTodo = NewTodo {
+  userId: 1,
+  title: "Learn Mochi",
+  completed: false
+}
+
+// Perform a typed POST request
+// The `with {}` block is a nested map — use commas `,` between fields
+// This structure is flexible and easy to extend in the future (e.g. timeout, query)
+// Avoid hardcoding fixed arguments; treat this as a generic config map
+let result: Todo = fetch "https://jsonplaceholder.typicode.com/todos" with {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json"
+  },
+  body: payload
+}
+
+// Access fields from the typed response
+print("Created:", result.title)
+print("ID:", result.id)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -263,8 +263,9 @@ type GenerateExpr struct {
 }
 
 type FetchExpr struct {
-	Pos lexer.Position
-	URL *Expr `parser:"'fetch' @@"`
+	Pos  lexer.Position
+	URL  *Expr `parser:"'fetch' @@"`
+	With *Expr `parser:"[ 'with' @@ ]"`
 }
 
 type MatchExpr struct {

--- a/runtime/http/fetch.go
+++ b/runtime/http/fetch.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	nethttp "net/http"
@@ -10,7 +11,43 @@ import (
 // arbitrary Go value. It is used by the interpreter to implement the
 // `fetch` expression.
 func Fetch(url string) (any, error) {
-	resp, err := nethttp.Get(url)
+	return FetchWith(url, nil)
+}
+
+func FetchWith(url string, opts map[string]any) (any, error) {
+	method := "GET"
+	if opts != nil {
+		if m, ok := opts["method"].(string); ok {
+			method = m
+		}
+	}
+
+	var body io.Reader
+	if opts != nil {
+		if b, ok := opts["body"]; ok {
+			data, err := json.Marshal(b)
+			if err != nil {
+				return nil, err
+			}
+			body = bytes.NewReader(data)
+		}
+	}
+
+	req, err := nethttp.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if opts != nil {
+		if hs, ok := opts["headers"]; ok {
+			for k, v := range toAnyMap(hs) {
+				if s, ok := v.(string); ok {
+					req.Header.Set(k, s)
+				}
+			}
+		}
+	}
+
+	resp, err := nethttp.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -25,4 +62,19 @@ func Fetch(url string) (any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func toAnyMap(m any) map[string]any {
+	switch v := m.(type) {
+	case map[string]any:
+		return v
+	case map[string]string:
+		out := make(map[string]any, len(v))
+		for k, vv := range v {
+			out[k] = vv
+		}
+		return out
+	default:
+		return nil
+	}
 }


### PR DESCRIPTION
## Summary
- add `with` options block to `fetch`
- support options in interpreter and Go compiler
- add HTTP helper for option maps
- document typed POST example using the new `fetch with` syntax

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6843860c90048320af7270290bdf2eeb