### PR TITLE
Add type checking for fetch

### DIFF
--- a/tests/types/errors/fetch_option_type.err
+++ b/tests/types/errors/fetch_option_type.err
@@ -1,0 +1,8 @@
+1. error[T030]: invalid type for fetch option `method`: expected string, got int
+  --> tests/types/errors/fetch_option_type.mochi:1:53
+
+  1 | let x = fetch "https://example.com" with {"method": 10}
+    |                                                     ^
+
+help:
+  Ensure the option value matches the expected type.

--- a/tests/types/errors/fetch_option_type.mochi
+++ b/tests/types/errors/fetch_option_type.mochi
@@ -1,0 +1,1 @@
+let x = fetch "https://example.com" with {"method": 10}

--- a/tests/types/errors/fetch_opts_map.err
+++ b/tests/types/errors/fetch_opts_map.err
@@ -1,0 +1,8 @@
+1. error[T029]: fetch options must be a map
+  --> tests/types/errors/fetch_opts_map.mochi:1:9
+
+  1 | let x = fetch "https://example.com" with 10
+    |         ^
+
+help:
+  Pass a map like `{"method": "POST"}` after `with`.

--- a/tests/types/errors/fetch_opts_map.mochi
+++ b/tests/types/errors/fetch_opts_map.mochi
@@ -1,0 +1,1 @@
+let x = fetch "https://example.com" with 10

--- a/tests/types/errors/fetch_url_type.err
+++ b/tests/types/errors/fetch_url_type.err
@@ -1,0 +1,8 @@
+1. error[T028]: fetch URL must be a string
+  --> tests/types/errors/fetch_url_type.mochi:1:9
+
+  1 | let x = fetch 123
+    |         ^
+
+help:
+  Use a string literal or variable of type string.

--- a/tests/types/errors/fetch_url_type.mochi
+++ b/tests/types/errors/fetch_url_type.mochi
@@ -1,0 +1,1 @@
+let x = fetch 123

--- a/tests/types/valid/fetch_options.golden
+++ b/tests/types/valid/fetch_options.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/fetch_options.mochi
+++ b/tests/types/valid/fetch_options.mochi
@@ -1,0 +1,5 @@
+let result = fetch "https://example.com" with {
+  "method": "POST",
+  "headers": {"Content-Type": "application/json"},
+  "body": {"x": 1}
+}

--- a/types/errors.go
+++ b/types/errors.go
@@ -46,6 +46,9 @@ var Errors = map[string]diagnostic.Template{
 	"T025": {Code: "T025", Message: "unknown type: %s", Help: "Ensure the type is defined before use."},
 	"T026": {Code: "T026", Message: "unknown field `%s` on %s", Help: "Check the struct definition for valid fields."},
 	"T027": {Code: "T027", Message: "%s is not a struct", Help: "Field access is only valid on struct types."},
+	"T028": {Code: "T028", Message: "fetch URL must be a string", Help: "Use a string literal or variable of type string."},
+	"T029": {Code: "T029", Message: "fetch options must be a map", Help: "Pass a map like `{\"method\": \"POST\"}` after `with`."},
+	"T030": {Code: "T030", Message: "invalid type for fetch option `%s`: expected %s, got %s", Help: "Ensure the option value matches the expected type."},
 }
 
 // --- Wrapper Functions ---
@@ -160,4 +163,16 @@ func errUnknownField(pos lexer.Position, field string, typ Type) error {
 
 func errNotStruct(pos lexer.Position, typ Type) error {
 	return Errors["T027"].New(pos, typ)
+}
+
+func errFetchURLString(pos lexer.Position) error {
+	return Errors["T028"].New(pos)
+}
+
+func errFetchOptsMap(pos lexer.Position) error {
+	return Errors["T029"].New(pos)
+}
+
+func errFetchOptType(pos lexer.Position, name string, expected, actual Type) error {
+	return Errors["T030"].New(pos, name, expected, actual)
 }


### PR DESCRIPTION
## Summary
- introduce T028, T029 and T030 error codes for invalid fetch use
- validate fetch URL and options map in type checker
- check option field types when present
- test fetch type errors and valid usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843884f5fd48320b58edb52e360e1af