### PR TITLE
Add v0.3.5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # 📦 CHANGELOG.md
+## [0.3.5] – 2025-06-07
+
+### Added
+
+* `fetch` expression for HTTP requests with typed JSON
+* `with` options for method, headers and body
+* Python and TypeScript compiler support for `fetch`
+
+### Changed
+
+* Type checking for fetch options
+
+### Fixed
+
+* Minor runtime improvements for HTTP requests
+
 ## [0.3.4] – 2025-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -350,6 +350,31 @@ let result = generate text {
 print(result)
 ```
 
+### HTTP Fetch
+
+Retrieve JSON over HTTP with the new `fetch` expression. Results are automatically
+decoded into the expected type. Use `with` to supply options such as the HTTP
+method, headers, or request body.
+
+```mochi
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://example.com/todos/1"
+
+let created: Todo = fetch "https://example.com/todos" with {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json"
+  },
+  body: todo
+}
+```
+
 ### Union Types and Methods
 
 Mochi now supports union types declared with the `|` syntax as well as inline
@@ -400,6 +425,8 @@ Explore the [`examples/`](./examples) directory:
 * `generate-model.mochi`
 * `tools.mochi`
 * `types.mochi`
+* `fetch.mochi`
+* `fetch-post.mochi`
 
 Edit one or start fresh. It’s all yours.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ minimal but expressive.
 This roadmap outlines the language development toward a stable 1.0, with an emphasis on first-class data types, control
 flow, streaming logic, agents, and dataset support.
 
-Current release: v0.3.4. Upcoming 0.3.x versions will focus on generative AI.
+Current release: v0.3.5. Upcoming 0.3.x versions will focus on generative AI.
 
 # v0.3.x – Generative AI
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Mochi Programming Language Specification (v0.3.4)
+# Mochi Programming Language Specification (v0.3.5)
 
-This document describes version 0.3.4 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
+This document describes version 0.3.5 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
 
 ## 0. Introduction
 
@@ -139,7 +139,7 @@ Factor      = Unary { ("*" | "/") Unary }
 Unary       = { "-" | "!" } PostfixExpr
 PostfixExpr = Primary { IndexOp }
 Primary     = FunExpr | CallExpr | SelectorExpr | ListLiteral |
-              MapLiteral | MatchExpr | GenerateExpr |
+              MapLiteral | MatchExpr | GenerateExpr | FetchExpr |
               Literal | Identifier | "(" Expression ")"
 ```
 
@@ -310,6 +310,29 @@ let vec = generate embedding {
 }
 ```
 
+### Fetch Expression
+
+`fetch` performs an HTTP request and decodes the JSON response into the
+expected type. Additional options may be provided with `with`.
+
+```mochi
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://example.com/todos/1"
+```
+
+```mochi
+let created: Todo = fetch "https://example.com/todos" with {
+  method: "POST",
+  body: todo
+}
+```
+
 ## 6. Functions
 
 Functions are first-class. Parameters are typed, and the return type may be omitted in block-bodied functions if `return` is used. Functions may capture variables from their enclosing scope, forming closures.
@@ -373,7 +396,7 @@ Term         = Factor { ("+" | "-") Factor } .
 Factor       = Unary { ("*" | "/") Unary } .
 Unary        = { "-" | "!" } PostfixExpr .
 PostfixExpr  = Primary { IndexOp } .
-Primary      = FunExpr | CallExpr | SelectorExpr | ListLiteral | MapLiteral | MatchExpr | GenerateExpr | Literal | Identifier | "(" Expression ")" .
+Primary      = FunExpr | CallExpr | SelectorExpr | ListLiteral | MapLiteral | MatchExpr | GenerateExpr | FetchExpr | Literal | Identifier | "(" Expression ")" .
 FunExpr       = "fun" "(" [ ParamList ] ")" [ ":" TypeRef ] ("=>" Expression | Block) .
 CallExpr      = Identifier "(" [ Expression { "," Expression } ] ")" .
 SelectorExpr  = Identifier { "." Identifier } .
@@ -388,4 +411,4 @@ GenericType   = Identifier "<" TypeRef { "," TypeRef } ">" .
 FunType       = "fun" "(" [ TypeRef { "," TypeRef } ] ")" [ ":" TypeRef ] .
 ```
 
-This specification outlines the core language as of version 0.3.4. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.
+This specification outlines the core language as of version 0.3.5. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -1,4 +1,4 @@
-// 0. Mochi (v0.3.4)
+// 0. Mochi (v0.3.5)
 // Mochi is a lightweight programming language for building AI agents, working with real-time data,
 // and querying datasets. It combines declarative and functional programming, with built-in support
 // for streams, datasets, tools, and prompt-based AI generation.
@@ -163,3 +163,21 @@ type Circle {
 
 let c = Circle { radius: 5 }
 print(c.area())
+
+// 11. HTTP Fetch
+
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://example.com/todos/1"
+print(todo.title)
+
+let created: Todo = fetch "https://example.com/todos" with {
+  method: "POST",
+  body: todo
+}
+print(created.id)

--- a/releases/v0.3.5.md
+++ b/releases/v0.3.5.md
@@ -1,0 +1,33 @@
+# Jun 2025 (v0.3.5)
+
+Mochi v0.3.5 introduces a new **fetch** expression for performing HTTP requests.
+Responses are decoded into typed values, and optional `with` parameters allow
+setting the HTTP method, headers, and body. The interpreter ships with a simple
+HTTP helper and the Python and TypeScript compilers now emit fetch support.
+
+## Fetch Expression
+
+```mochi
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://example.com/todos/1"
+
+let created: Todo = fetch "https://example.com/todos" with {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json"
+  },
+  body: todo
+}
+```
+
+## Other Changes
+
+- Type checking for fetch options
+- Python and TypeScript compilers support `fetch`
+- Runtime HTTP helper for the interpreter


### PR DESCRIPTION
## Summary
- document new fetch expression in README, spec and cheatsheet
- list new examples in README
- update roadmap and changelog for v0.3.5
- add release notes for v0.3.5

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68438d0f003883208b3acc1ac90a0f68