### PR TITLE
Fix fetch-post example

### DIFF
--- a/examples/v0.3/fetch-post.mochi
+++ b/examples/v0.3/fetch-post.mochi
@@ -26,13 +26,13 @@ let payload: NewTodo = NewTodo {
 // The `with {}` block is a nested map — use commas `,` between fields
 // This structure is flexible and easy to extend in the future (e.g. timeout, query)
 // Avoid hardcoding fixed arguments; treat this as a generic config map
-let result: Todo = fetch "https://jsonplaceholder.typicode.com/todos" with {
-  method: "POST",
-  headers: {
+let result: Todo = (fetch "https://jsonplaceholder.typicode.com/todos" with {
+  "method": "POST",
+  "headers": {
     "Content-Type": "application/json"
   },
-  body: payload
-}
+  "body": payload
+}) as Todo
 
 // Access fields from the typed response
 print("Created:", result.title)


### PR DESCRIPTION
## Summary
- update `fetch-post.mochi` to use `as` casting and quoted keys so it runs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843c846f2048320b520468405bfd47f