### PR TITLE
Support unquoted map keys without new tokens

### DIFF
--- a/tests/types/valid/fetch_options.mochi
+++ b/tests/types/valid/fetch_options.mochi
@@ -1,5 +1,5 @@
 let result = fetch "https://example.com" with {
-  "method": "POST",
-  "headers": {"Content-Type": "application/json"},
-  "body": {"x": 1}
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  body: {"x": 1}
 }

--- a/types/check.go
+++ b/types/check.go
@@ -1080,9 +1080,15 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 	case p.Map != nil:
 		var keyT, valT Type
 		for _, item := range p.Map.Items {
-			kt, err := checkExpr(item.Key, env)
-			if err != nil {
-				return nil, err
+			var kt Type
+			if _, ok := stringKey(item.Key); ok {
+				kt = StringType{}
+			} else {
+				var err error
+				kt, err = checkExpr(item.Key, env)
+				if err != nil {
+					return nil, err
+				}
 			}
 			vt, err := checkExpr(item.Value, env)
 			if err != nil {


### PR DESCRIPTION
## Summary
- allow interpreter to treat bare identifiers as string keys
- revert special HttpMethod literals
- update parser and type checker accordingly
- adjust fetch options example to keep quoted HTTP method
- remove parser test for unquoted HTTP verb

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843ca5601d4832091f5176f51ba0a9f