### PR TITLE
Add stream example and implement stream support

### DIFF
--- a/examples/v0.4/stream.mochi
+++ b/examples/v0.4/stream.mochi
@@ -1,0 +1,29 @@
+// stream.mochi
+
+# Define a stream for sensor data
+stream Sensor {
+  id: string
+  temperature: float
+}
+
+# Print each reading when received
+on Sensor as r {
+  print("Reading from", r.id)
+  print(" →", r.temperature, "°C")
+}
+
+# Emit a few sample events
+emit Sensor {
+  id: "sensor-1",
+  temperature: 22.5
+}
+
+emit Sensor {
+  id: "sensor-2",
+  temperature: 30.2
+}
+
+emit Sensor {
+  id: "sensor-3",
+  temperature: 18.9
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,7 +23,7 @@ func (b *boolLit) Capture(values []string) error {
 var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Comment", Pattern: `//[^\n]*|/\*([^*]|\*+[^*/])*\*+/`},
 	{Name: "Bool", Pattern: `\b(true|false)\b`},
-	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|type|fun|return|break|continue|let|var|if|else|for|in|generate|match|fetch)\b`},
+	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|return|break|continue|let|var|if|else|for|in|generate|match|fetch)\b`},
 	{Name: "Ident", Pattern: `[\p{L}\p{So}_][\p{L}\p{So}\p{N}_]*`},
 	{Name: "Float", Pattern: `\d+\.\d+`},
 	{Name: "Int", Pattern: `\d+`},
@@ -48,6 +48,7 @@ type Statement struct {
 	Model    *ModelDecl    `parser:"| @@"`
 	Type     *TypeDecl     `parser:"| @@"`
 	On       *OnHandler    `parser:"| @@"`
+	Emit     *EmitStmt     `parser:"| @@"`
 	Let      *LetStmt      `parser:"| @@"`
 	Var      *VarStmt      `parser:"| @@"`
 	Assign   *AssignStmt   `parser:"| @@"`
@@ -387,6 +388,12 @@ type OnHandler struct {
 	Stream string       `parser:"'on' @Ident 'as'"`
 	Alias  string       `parser:"@Ident"`
 	Body   []*Statement `parser:"'{' @@* '}'"`
+}
+
+type EmitStmt struct {
+	Pos    lexer.Position
+	Stream string            `parser:"'emit' @Ident"`
+	Fields []*StructLitField `parser:"'{' [ @@ { ',' @@ } ] [ ',' ]? '}'"`
 }
 
 // --- Agent DSL ---


### PR DESCRIPTION
## Summary
- add example `stream.mochi`
- support `emit` statement in parser
- wire up streams in interpreter using `runtime/stream`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844711eca7c83209d009d9dd8f4907a