### PR TITLE
Add type checking for streams

### DIFF
--- a/tests/types/errors/emit_field_type.err
+++ b/tests/types/errors/emit_field_type.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected string, got int
+  --> tests/types/errors/emit_field_type.mochi:3:19
+
+  3 | emit Sensor { id: 123 }
+    |                   ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/emit_field_type.mochi
+++ b/tests/types/errors/emit_field_type.mochi
@@ -1,0 +1,3 @@
+stream Sensor { id: string }
+
+emit Sensor { id: 123 }

--- a/tests/types/errors/emit_unknown_stream.err
+++ b/tests/types/errors/emit_unknown_stream.err
@@ -1,0 +1,8 @@
+1. error[T031]: unknown stream: Foo
+  --> tests/types/errors/emit_unknown_stream.mochi:1:1
+
+  1 | emit Foo { value: 1 }
+    | ^
+
+help:
+  Declare the stream before using it.

--- a/tests/types/errors/emit_unknown_stream.mochi
+++ b/tests/types/errors/emit_unknown_stream.mochi
@@ -1,0 +1,1 @@
+emit Foo { value: 1 }

--- a/tests/types/errors/on_unknown_stream.err
+++ b/tests/types/errors/on_unknown_stream.err
@@ -1,0 +1,8 @@
+1. error[T031]: unknown stream: Foo
+  --> tests/types/errors/on_unknown_stream.mochi:1:1
+
+  1 | on Foo as e {
+    | ^
+
+help:
+  Declare the stream before using it.

--- a/tests/types/errors/on_unknown_stream.mochi
+++ b/tests/types/errors/on_unknown_stream.mochi
@@ -1,0 +1,3 @@
+on Foo as e {
+  print("hi")
+}

--- a/tests/types/valid/stream_on_emit.golden
+++ b/tests/types/valid/stream_on_emit.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/stream_on_emit.mochi
+++ b/tests/types/valid/stream_on_emit.mochi
@@ -1,0 +1,10 @@
+stream Sensor {
+  id: string
+  temperature: float
+}
+
+on Sensor as s {
+  print(s.id, s.temperature)
+}
+
+emit Sensor { id: "sensor-1", temperature: 22.5 }

--- a/types/env.go
+++ b/types/env.go
@@ -21,6 +21,7 @@ type Env struct {
 	types   map[string]Type            // static types
 	structs map[string]StructType      // user-defined struct types
 	unions  map[string]UnionType       // user-defined union types
+	streams map[string]StructType      // stream declarations
 	mut     map[string]bool            // mutability of variables
 	values  map[string]any             // runtime values
 	funcs   map[string]*parser.FunStmt // function declarations
@@ -40,6 +41,7 @@ func NewEnv(parent *Env) *Env {
 		types:   make(map[string]Type),
 		structs: make(map[string]StructType),
 		unions:  make(map[string]UnionType),
+		streams: make(map[string]StructType),
 		mut:     make(map[string]bool),
 		values:  make(map[string]any),
 		funcs:   make(map[string]*parser.FunStmt),
@@ -78,6 +80,20 @@ func (e *Env) GetUnion(name string) (UnionType, bool) {
 		return e.parent.GetUnion(name)
 	}
 	return UnionType{}, false
+}
+
+// SetStream defines a stream declaration.
+func (e *Env) SetStream(name string, st StructType) { e.streams[name] = st }
+
+// GetStream retrieves a stream by name.
+func (e *Env) GetStream(name string) (StructType, bool) {
+	if st, ok := e.streams[name]; ok {
+		return st, true
+	}
+	if e.parent != nil {
+		return e.parent.GetStream(name)
+	}
+	return StructType{}, false
 }
 
 // FindUnionByVariant returns the union type that contains the given variant name.
@@ -210,6 +226,7 @@ func (e *Env) Copy() *Env {
 		funcs:   make(map[string]*parser.FunStmt, len(e.funcs)),
 		structs: make(map[string]StructType, len(e.structs)),
 		unions:  make(map[string]UnionType, len(e.unions)),
+		streams: make(map[string]StructType, len(e.streams)),
 		models:  make(map[string]ModelSpec, len(e.models)),
 		output:  e.output,
 	}
@@ -230,6 +247,9 @@ func (e *Env) Copy() *Env {
 	}
 	for k, v := range e.unions {
 		newEnv.unions[k] = v
+	}
+	for k, v := range e.streams {
+		newEnv.streams[k] = v
 	}
 	for k, v := range e.models {
 		newEnv.models[k] = v

--- a/types/errors.go
+++ b/types/errors.go
@@ -49,6 +49,7 @@ var Errors = map[string]diagnostic.Template{
 	"T028": {Code: "T028", Message: "fetch URL must be a string", Help: "Use a string literal or variable of type string."},
 	"T029": {Code: "T029", Message: "fetch options must be a map", Help: "Pass a map like `{\"method\": \"POST\"}` after `with`."},
 	"T030": {Code: "T030", Message: "invalid type for fetch option `%s`: expected %s, got %s", Help: "Ensure the option value matches the expected type."},
+	"T031": {Code: "T031", Message: "unknown stream: %s", Help: "Declare the stream before using it."},
 }
 
 // --- Wrapper Functions ---
@@ -175,4 +176,8 @@ func errFetchOptsMap(pos lexer.Position) error {
 
 func errFetchOptType(pos lexer.Position, name string, expected, actual Type) error {
 	return Errors["T030"].New(pos, name, expected, actual)
+}
+
+func errUnknownStream(pos lexer.Position, name string) error {
+	return Errors["T031"].New(pos, name)
 }


### PR DESCRIPTION
## Summary
- support `stream`, `on` and `emit` in the type checker
- track declared streams in the type environment
- add diagnostics for unknown streams
- test valid and error cases for stream/on/emit

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_68447b0d748c832096a4d94eb7c7b1d2