### PR TITLE
Update changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # 📦 CHANGELOG.md
+## [0.4.0] – 2025-06-08
+
+### Added
+
+* `stream` declarations for typed event flows
+* `emit` statements for sending events
+* `on` handlers for asynchronous processing
+* Runtime library queuing and replay
+* Go, Python and TypeScript compiler support
+* Interpreter with async stream handlers
+
+### Changed
+
+* Stream runtime refactored with interfaces
+* Syntax highlighting updated for new keywords
+
+### Fixed
+
+* Go compiler deadlock in stream handler
+
 ## [0.3.5] – 2025-06-07
 
 ### Added

--- a/releases/v0.4.0.md
+++ b/releases/v0.4.0.md
@@ -1,0 +1,22 @@
+# Jun 2025 (v0.4.0)
+
+Mochi v0.4.0 introduces asynchronous **streams** for declarative event processing. Programs can define stream types, emit events, and handle them with `on` blocks. The runtime queues events and executes handlers deterministically.
+
+## Streams
+
+```mochi
+stream Sensor { id: string, temperature: float }
+
+on Sensor as s {
+  print(s.id, s.temperature)
+}
+
+emit Sensor { id: "sensor-1", temperature: 22.5 }
+```
+
+## Other Changes
+
+- Refactored stream runtime with interfaces
+- Go, Python and TypeScript compiler support
+- Async interpreter handlers
+- Updated syntax highlighting for keywords


### PR DESCRIPTION
## Summary
- document stream runtime in CHANGELOG
- add release notes for v0.4.0

## Testing
- `go test ./... --vet=off -run TestPlaceholder`

------
https://chatgpt.com/codex/tasks/task_e_6844f8a107088320bdcfe9dd20675bca