### PR TITLE
Add Mochi docs for features and usage

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,13 @@
+# Mochi Language Features
+
+This section outlines each major feature of the Mochi programming language.
+
+- [Variables](variables.md)
+- [Control Flow](control-flow.md)
+- [Functions](functions.md)
+- [Collections](collections.md)
+- [Tests](tests.md)
+- [Generative AI](generative-ai.md)
+- [HTTP Fetch](http-fetch.md)
+- [Union Types](union-types.md)
+- [Streams and Agents](streams.md)

--- a/docs/features/collections.md
+++ b/docs/features/collections.md
@@ -1,0 +1,13 @@
+## Collections
+
+Maps, sets and lists are built in.
+
+```mochi
+let user = {"name": "Ana", "age": 22}
+let tags = {"a", "b", "c"}
+let nums = [1, 2, 3]
+
+print(user["name"])
+print(tags)
+print(nums[1])
+```

--- a/docs/features/control-flow.md
+++ b/docs/features/control-flow.md
@@ -1,0 +1,15 @@
+## Control Flow
+
+Mochi offers standard conditionals and ranges for looping.
+
+```mochi
+if count > 0 {
+  print("positive")
+} else {
+  print("non-positive")
+}
+
+for i in 0..3 {
+  print(i)
+}
+```

--- a/docs/features/functions.md
+++ b/docs/features/functions.md
@@ -1,0 +1,11 @@
+## Functions
+
+Functions are declared with `fun`. Arrow functions provide a concise alternative.
+
+```mochi
+fun double(x: int): int {
+  return x * 2
+}
+
+let square = fun(x: int): int => x * x
+```

--- a/docs/features/generative-ai.md
+++ b/docs/features/generative-ai.md
@@ -1,0 +1,42 @@
+## Generative AI
+
+The `generate` expression invokes large language models. Models can be configured in `model` blocks.
+
+```mochi
+let poem = generate text {
+  prompt: "Write a haiku about spring"
+}
+print(poem)
+
+model quick {
+  provider: "openai"
+  name: "gpt-3.5-turbo"
+}
+
+let fancy = generate text {
+  model: "quick"
+  prompt: "Write a haiku about spring"
+}
+print(fancy)
+```
+
+Use functions as tools for the model to call:
+
+```mochi
+fun getWeather(location: string): string {
+  if location == "Paris" {
+    return "sunny with a gentle breeze"
+  }
+  return "weather data unavailable"
+}
+
+let result = generate text {
+  prompt: "What's the weather like in Paris?",
+  tools: [
+    getWeather {
+      description: "Returns the current weather for a given city"
+    }
+  ]
+}
+print(result)
+```

--- a/docs/features/http-fetch.md
+++ b/docs/features/http-fetch.md
@@ -1,0 +1,14 @@
+## HTTP Fetch
+
+Retrieve JSON over HTTP using `fetch`.
+
+```mochi
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo = fetch "https://example.com/todos/1" as Todo
+```

--- a/docs/features/streams.md
+++ b/docs/features/streams.md
@@ -1,0 +1,15 @@
+## Streams and Agents
+
+Define streams and react to emitted events.
+
+```mochi
+stream Sensor { id: string, temperature: float }
+
+on Sensor as s {
+  print(s.id, s.temperature)
+}
+
+emit Sensor { id: "sensor-1", temperature: 22.5 }
+```
+
+These features are explained further in the [language specification](../SPEC.md).

--- a/docs/features/tests.md
+++ b/docs/features/tests.md
@@ -1,0 +1,10 @@
+## Tests
+
+Use `test` blocks with `expect` to verify behavior.
+
+```mochi
+test "math" {
+  expect 2 + 2 == 4
+  expect 5 > 3
+}
+```

--- a/docs/features/union-types.md
+++ b/docs/features/union-types.md
@@ -1,0 +1,16 @@
+## Union Types and Methods
+
+Unions use `|` syntax. Types can contain inline methods.
+
+```mochi
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+fun sum(t: Tree): int {
+  return match t {
+    Leaf => 0
+    Node(l, v, r) => sum(l) + v + sum(r)
+  }
+}
+```

--- a/docs/features/variables.md
+++ b/docs/features/variables.md
@@ -1,0 +1,8 @@
+## Variables
+
+Bindings are immutable by default using `let`. Use `var` for mutable values.
+
+```mochi
+let name = "Mochi"
+var count = 1
+```

--- a/docs/guides/using-mochi.md
+++ b/docs/guides/using-mochi.md
@@ -1,0 +1,92 @@
+# Using Mochi
+
+This guide describes how to set up Mochi and explains the overall project layout.
+
+## Installation Methods
+
+Mochi can run as a single native binary, inside Docker, or built from source.
+
+### Prebuilt Binary
+
+1. Download the latest release from [Releases](https://github.com/mochilang/mochi/releases).
+2. Make it executable and run a program:
+
+```bash
+chmod +x mochi
+./mochi run examples/hello.mochi
+```
+
+### Docker
+
+Run Mochi without installing anything locally:
+
+```bash
+docker run -i --rm ghcr.io/mochilang/mochi run examples/hello.mochi
+docker run -i --rm ghcr.io/mochilang/mochi serve
+```
+
+For a more native feel, create an alias:
+
+```bash
+alias mochi="docker run -i --rm -v $PWD:/app -w /app ghcr.io/mochilang/mochi"
+```
+
+Then use `mochi` anywhere in your project directory.
+
+### Build from Source
+
+Clone the repository and build it yourself:
+
+```bash
+git clone https://github.com/mochilang/mochi
+cd mochi
+make build
+make test
+```
+
+This installs the `mochi` binary under `~/bin` and runs the full test suite.
+
+## Command-Line Usage
+
+The CLI provides several subcommands:
+
+```
+Usage: mochi [--version] <command> [args]
+
+Commands:
+  run     Run a Mochi source file
+  test    Run test blocks
+  build   Compile to binary or other languages
+  repl    Start interactive REPL
+  serve   Start MCP server
+```
+
+Examples:
+
+```bash
+mochi run examples/hello.mochi
+mochi test examples/math.mochi
+mochi build examples/hello.mochi -o hello
+mochi build --target py examples/hello.mochi -o hello.py
+```
+
+## Development Environment
+
+Mochi integrates well with agent-oriented tools. You can run an MCP server for Visual Studio Code or Claude Desktop using the `serve` subcommand. See the [README](../README.md) for full configuration examples.
+
+## Repository Overview
+
+The source tree is organized as follows:
+
+- `cmd/` – command-line entry points
+- `compile/` – compilers and code generation
+- `interpreter/` – reference interpreter implementation
+- `parser/` – language parser
+- `runtime/` – runtime packages including LLM clients
+- `examples/` – sample programs demonstrating language features
+- `tests/` – automated test suite
+
+Other directories contain supporting assets (`tools/`, `types/`, `ast/`) and release metadata.
+
+The main documentation lives in [`README.md`](../README.md) and [`SPEC.md`](../SPEC.md). Additional notes can be found in `ROADMAP.md` and release files.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# Mochi Documentation
+
+Welcome to the Mochi documentation. The guides and references here will be published at [https://docs.mochi-lang.dev](https://docs.mochi-lang.dev).
+
+## Guides
+
+- [Using Mochi](guides/using-mochi.md)
+
+## Language Features
+
+The language overview is split into individual topics for easy navigation:
+
+- [Variables](features/variables.md)
+- [Control Flow](features/control-flow.md)
+- [Functions](features/functions.md)
+- [Collections](features/collections.md)
+- [Tests](features/tests.md)
+- [Generative AI](features/generative-ai.md)
+- [HTTP Fetch](features/http-fetch.md)
+- [Union Types](features/union-types.md)
+- [Streams and Agents](features/streams.md)


### PR DESCRIPTION
## Summary
- break language features into individual files
- add docs index with links for later docs site
- move using-mochi guide under guides/

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6844fc683fac83209042231fea033d54