### PR TITLE
Add VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ This installs `mochi` into `~/bin` and runs the full test suite.
 
 ## Usage with Visual Studio Code
 
-You can run Mochi as an [MCP server](https://github.com/modelcontext/protocol) inside **VS Code’s agent mode**.
+There is a VS Code extension under `tools/vscode` that bundles the Mochi language syntax. Run `npm install` and `npm run package` in that folder to build `mochi.vsix` for local installation.
+
+You can also run Mochi as an [MCP server](https://github.com/modelcontext/protocol) inside **VS Code’s agent mode**.
 
 The easiest way is to use a `.vscode/mcp.json` config file in your project:
 

--- a/tools/vscode/README.md
+++ b/tools/vscode/README.md
@@ -1,0 +1,14 @@
+# Mochi VS Code Extension
+
+This folder contains a Visual Studio Code extension for the Mochi programming language. It bundles the TextMate grammar from `mochi-tm` and provides a simple "Hello, World" command.
+
+## Building
+
+Install dependencies and build the extension:
+
+```bash
+npm install
+npm run package
+```
+
+The command above produces `mochi-0.1.0.vsix` which can be installed in VS Code via the Extensions view.

--- a/tools/vscode/language-configuration.json
+++ b/tools/vscode/language-configuration.json
@@ -1,0 +1,25 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" },
+    { "open": "/*", "close": "*/" }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" },
+    { "open": "/*", "close": "*/" }
+  ]
+}

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "mochi",
+  "displayName": "Mochi",
+  "description": "VS Code extension for the Mochi programming language.",
+  "version": "0.1.0",
+  "publisher": "mochi-lang.org",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": ["Programming Languages"],
+  "activationEvents": ["onLanguage:mochi"],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "mochi",
+        "aliases": ["Mochi", "mochi"],
+        "extensions": [".mochi"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "mochi",
+        "scopeName": "source.mochi",
+        "path": "./syntaxes/mochi.tmLanguage.json"
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "package": "vsce package",
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.80.0",
+    "tslib": "^2.5.0",
+    "typescript": "^5.4.5",
+    "vsce": "^3.16.0"
+  }
+}

--- a/tools/vscode/src/extension.ts
+++ b/tools/vscode/src/extension.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('mochi.helloWorld', () => {
+    vscode.window.showInformationMessage('Hello from Mochi!');
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/tools/vscode/syntaxes/mochi.tmLanguage.json
+++ b/tools/vscode/syntaxes/mochi.tmLanguage.json
@@ -1,0 +1,70 @@
+{
+  "name": "Mochi",
+  "scopeName": "source.mochi",
+  "fileTypes": ["mochi"],
+  "uuid": "e65d71dc-9a56-41f6-a502-89adff3a0f3d",
+  "patterns": [
+    {
+      "name": "keyword.control.mochi",
+      "match": "\\b(test|expect|agent|intent|on|stream|emit|type|fun|return|break|continue|let|var|if|else|for|in|generate|match|fetch)\\b"
+    },
+    {
+      "name": "storage.type.mochi",
+      "match": "\\b(int|float|string|bool|list|map|fun\\([^)]*\\):\\s*\\w+)\\b"
+    },
+    {
+      "name": "constant.language.mochi",
+      "match": "\\b(true|false|null)\\b"
+    },
+    {
+      "name": "constant.numeric.mochi",
+      "match": "\\b\\d+(\\.\\d+)?\\b"
+    },
+    {
+      "name": "variable.other.mochi",
+      "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+    },
+    {
+      "name": "string.quoted.double.mochi",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.mochi",
+          "match": "\\\\."
+        }
+      ]
+    },
+    {
+      "name": "comment.line.double-slash.mochi",
+      "match": "//.*$"
+    },
+    {
+      "name": "comment.block.mochi",
+      "begin": "/\\*",
+      "end": "\\*/",
+      "patterns": [
+        {
+          "name": "comment.block.documentation.mochi",
+          "match": "(\\*\\s.*)"
+        }
+      ]
+    },
+    {
+      "name": "punctuation.definition.comment.mochi",
+      "match": "(//)"
+    },
+    {
+      "name": "keyword.operator.mochi",
+      "match": "==|!=|<=|>=|&&|\\|\\||=>|\\.\\.|[-+*/%=<>!|{}\\[\\](),.:]"
+    },
+    {
+      "name": "punctuation.separator.mochi",
+      "match": "[,;]"
+    },
+    {
+      "name": "punctuation.brackets.mochi",
+      "match": "[\\[\\]\\(\\)\\{\\}]"
+    }
+  ]
+}

--- a/tools/vscode/tsconfig.json
+++ b/tools/vscode/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- package `mochi-tm` grammar as a VS Code extension under `tools/vscode`
- provide build scripts and sample command
- document how to build the extension
- mention VS Code extension in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6844ff520c74832089376c266a22849e