### PR TITLE
Add VS Code extension notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Runtime library queuing and replay
 * Go, Python and TypeScript compiler support
 * Interpreter with async stream handlers
+* VS Code extension for syntax highlighting and agent integration
 
 ### Changed
 

--- a/releases/v0.4.0.md
+++ b/releases/v0.4.0.md
@@ -20,3 +20,4 @@ emit Sensor { id: "sensor-1", temperature: 22.5 }
 - Go, Python and TypeScript compiler support
 - Async interpreter handlers
 - Updated syntax highlighting for keywords
+- Visual Studio Code extension with syntax highlighting and agent integration


### PR DESCRIPTION
## Summary
- mention new VS Code extension in CHANGELOG
- document the extension in the v0.4.0 release notes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684501225930832084e1b79ee2bb2b33