### PR TITLE
Integrate agent runtime with interpreter

### DIFF
--- a/examples/v0.3/agent.mochi
+++ b/examples/v0.3/agent.mochi
@@ -1,0 +1,54 @@
+stream SensorReading {
+  id: string
+  temperature: float
+  timestamp: time
+}
+
+agent Monitor {
+  var count: int = 0
+  var lastTemp: float = 0.0
+
+  on SensorReading as r {
+    count = count + 1
+    lastTemp = r.temperature
+    print("handler", count)
+
+    if r.temperature > 30 {
+      print("High temperature from", r.id, ":", r.temperature)
+    }
+  }
+
+  intent status(): string {
+    return "Seen " + str(count) + " readings, last = " + str(lastTemp)
+  }
+
+  intent summary(): string {
+    return "Last recorded temperature is " + str(lastTemp) + " °C"
+  }
+}
+
+// Initialize agent
+let monitor = Monitor {}
+
+// Emit some events
+emit SensorReading {
+  id: "sensor-1",
+  temperature: 28.0,
+  timestamp: now(),
+}
+
+emit SensorReading {
+  id: "sensor-2",
+  temperature: 35.5,
+  timestamp: now(),
+}
+
+// Wait for async processing
+sleep(100)
+
+// Call intents (method style)
+let s = monitor.status()
+print(s)
+
+let summary = monitor.summary()
+print(summary)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -406,6 +406,7 @@ type AgentDecl struct {
 
 type AgentBlock struct {
 	Let    *LetStmt    `parser:"@@"`
+	Var    *VarStmt    `parser:"| @@"`
 	Assign *AssignStmt `parser:"| @@"`
 	On     *OnHandler  `parser:"| @@"`
 	Intent *IntentDecl `parser:"| @@"`

--- a/runtime/agent/README.md
+++ b/runtime/agent/README.md
@@ -1,0 +1,115 @@
+# `mochi/runtime/agent`
+
+The `agent` package defines the runtime model for agents in Mochi. An **agent** is a reactive entity that:
+
+* Listens to real-time `stream.Event`s
+* Mutates local state based on event handlers
+* Exposes `intent` functions for querying or triggering behavior
+
+This package is designed to integrate cleanly with the `mochi` interpreter, stream engine, and generative agent system.
+
+## Features
+
+* In-memory inbox for stream delivery
+* Dynamic stream handler registration
+* Named intent registration and execution
+* Mutable state with `Set` and `Get`
+* Safe `Start()` / `Stop()` lifecycle
+
+## Usage
+
+### 1. Create a Stream
+
+```go
+s := stream.New("SensorReading", 64)
+```
+
+### 2. Initialize an Agent
+
+```go
+a := agent.New(agent.Config{
+	Name:    "Monitor",
+	BufSize: 16,
+})
+```
+
+### 3. Register Event Handler
+
+```go
+a.On(s, func(ctx context.Context, ev *stream.Event) {
+	data := ev.Data.(map[string]any)
+	temp := data["temperature"].(float64)
+
+	count, _ := a.Get("count")
+	if count == nil {
+		a.Set("count", 1)
+	} else {
+		a.Set("count", count.(int)+1)
+	}
+
+	a.Set("lastTemp", temp)
+})
+```
+
+### 4. Register Intents
+
+```go
+a.RegisterIntent("status", func(ctx context.Context, args ...agent.Value) (agent.Value, error) {
+	count, _ := a.Get("count")
+	last, _ := a.Get("lastTemp")
+	return fmt.Sprintf("Seen %v readings, last = %v", count, last), nil
+})
+```
+
+### 5. Run Agent
+
+```go
+ctx := context.Background()
+a.Start(ctx)
+defer a.Stop()
+```
+
+### 6. Emit Stream Event
+
+```go
+s.Emit(ctx, map[string]any{
+	"id":          "sensor-1",
+	"temperature": 30.5,
+	"timestamp":   time.Now(),
+})
+```
+
+## API
+
+### `type Agent`
+
+| Method                          | Description                             |
+| ------------------------------- | --------------------------------------- |
+| `Start(ctx)`                    | Starts the agent loop                   |
+| `Stop()`                        | Stops the agent loop                    |
+| `On(stream, handler)`           | Registers a handler for incoming events |
+| `RegisterIntent(name, handler)` | Registers a named intent function       |
+| `Call(ctx, name, args...)`      | Calls a named intent                    |
+| `Set(name, value)`              | Updates internal state                  |
+| `Get(name) (value, ok)`         | Reads internal state                    |
+| `State() map[string]Value`      | Full access to agent state              |
+
+### `type IntentHandler`
+
+```go
+type IntentHandler func(ctx context.Context, args ...Value) (Value, error)
+```
+
+### `type Value`
+
+Aliased as `any`, used for flexible state and intent arguments.
+
+## Integration Notes
+
+This package is designed to be used by the **Mochi interpreter**, which will:
+
+* Parse and compile `agent { ... }` blocks
+* Call `agent.On(...)` and `RegisterIntent(...)` dynamically
+* Use `Set` / `Get` to reflect interpreter variables into agent state
+* Optionally inject LLM tooling or sandboxed control APIs in future
+

--- a/runtime/agent/agent.go
+++ b/runtime/agent/agent.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"mochi/runtime/stream"
+)
+
+// Value is a dynamic runtime value.
+type Value any
+
+// IntentHandler defines the function signature for handling an intent call.
+type IntentHandler func(context.Context, ...Value) (Value, error)
+
+// Agent is a reactive runtime component that handles stream events and intent calls.
+type Agent struct {
+	Name   string
+	Inbox  chan *stream.Event
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu       sync.RWMutex
+	state    map[string]Value
+	handlers map[string]func(context.Context, *stream.Event)
+	intents  map[string]IntentHandler
+}
+
+// Config provides initialization for Agent.
+type Config struct {
+	Name    string
+	BufSize int
+}
+
+// New creates a new Agent with empty state and inbox.
+func New(cfg Config) *Agent {
+	return &Agent{
+		Name:     cfg.Name,
+		Inbox:    make(chan *stream.Event, cfg.BufSize),
+		state:    make(map[string]Value),
+		handlers: make(map[string]func(context.Context, *stream.Event)),
+		intents:  make(map[string]IntentHandler),
+	}
+}
+
+// Start begins the agent’s event processing loop.
+func (a *Agent) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	a.cancel = cancel
+	a.wg.Add(1)
+
+	go func() {
+		defer a.wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e := <-a.Inbox:
+				if h, ok := a.handlers[e.Stream]; ok {
+					h(ctx, e)
+				}
+			}
+		}
+	}()
+}
+
+// Stop gracefully shuts down the agent.
+func (a *Agent) Stop() {
+	if a.cancel != nil {
+		a.cancel()
+	}
+	a.wg.Wait()
+}
+
+// On registers a stream handler and subscribes to the given stream.
+func (a *Agent) On(s stream.Stream, handler func(context.Context, *stream.Event)) error {
+	streamName := "" // assigned on first event
+	a.handlers[streamName] = handler
+
+	s.Subscribe(a.Name, func(ev *stream.Event) error {
+		if streamName == "" {
+			streamName = ev.Stream
+			a.handlers[streamName] = handler
+		}
+		select {
+		case a.Inbox <- ev:
+			return nil
+		default:
+			return nil // drop if inbox is full
+		}
+	})
+	return nil
+}
+
+// RegisterIntent binds a named intent handler to the agent.
+func (a *Agent) RegisterIntent(name string, handler IntentHandler) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.intents[name] = handler
+}
+
+// Call invokes a named intent handler.
+func (a *Agent) Call(ctx context.Context, method string, args ...Value) (Value, error) {
+	a.mu.RLock()
+	fn, ok := a.intents[method]
+	a.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown intent: %s", method)
+	}
+	return fn(ctx, args...)
+}
+
+// State returns a full snapshot of the agent’s internal state.
+func (a *Agent) State() map[string]Value {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	copy := make(map[string]Value, len(a.state))
+	for k, v := range a.state {
+		copy[k] = v
+	}
+	return copy
+}
+
+// Set sets a variable in the agent’s state.
+func (a *Agent) Set(name string, value Value) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.state[name] = value
+}
+
+// Get returns a variable from the agent’s state.
+func (a *Agent) Get(name string) (Value, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	v, ok := a.state[name]
+	return v, ok
+}

--- a/runtime/agent/agent_test.go
+++ b/runtime/agent/agent_test.go
@@ -1,0 +1,78 @@
+package agent_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"mochi/runtime/agent"
+	"mochi/runtime/stream"
+)
+
+func TestAgent_BasicFlow(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a test stream
+	s := stream.New("SensorReading", 64)
+
+	// Initialize agent
+	a := agent.New(agent.Config{
+		Name:    "monitor",
+		BufSize: 16,
+	})
+
+	// Register stream handler
+	err := a.On(s, func(ctx context.Context, ev *stream.Event) {
+		data := ev.Data.(map[string]any)
+
+		// Count readings
+		count, _ := a.Get("count")
+		if count == nil {
+			a.Set("count", 1)
+		} else {
+			a.Set("count", count.(int)+1)
+		}
+
+		// Track last temperature
+		a.Set("lastTemp", data["temperature"].(float64))
+	})
+	if err != nil {
+		t.Fatalf("On failed: %v", err)
+	}
+
+	// Register an intent
+	a.RegisterIntent("status", func(ctx context.Context, args ...agent.Value) (agent.Value, error) {
+		count, _ := a.Get("count")
+		last, _ := a.Get("lastTemp")
+		return fmt.Sprintf("Seen %v readings, last temp = %.1f", count, last), nil
+	})
+
+	a.Start(ctx)
+	defer a.Stop()
+
+	// Emit one reading
+	_, err = s.Emit(ctx, map[string]any{
+		"id":          "sensor-1",
+		"temperature": 38.5,
+		"timestamp":   time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	time.Sleep(30 * time.Millisecond) // wait for async delivery
+
+	// Call the intent
+	result, err := a.Call(ctx, "status")
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+
+	str := result.(string)
+	t.Logf("status: %s", str)
+
+	if str != "Seen 1 readings, last temp = 38.5" {
+		t.Errorf("unexpected result: %s", str)
+	}
+}


### PR DESCRIPTION
## Summary
- add new `runtime/agent` package for basic agent functionality
- allow `var` declarations inside `agent` blocks
- expose agent declarations and runtime instances in the interpreter
- extend type checker and environment for agents and new builtins
- implement `str` and `sleep` builtins
- provide running example `examples/v0.3/agent.mochi`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68453d23d69c83209ee9b00c9f4d79a7