### PR TITLE
Move agent example to v0.5 and add agent parser tests

### DIFF
--- a/examples/v0.5/agent.mochi
+++ b/examples/v0.5/agent.mochi
@@ -37,6 +37,9 @@ emit SensorReading {
   timestamp: now(),
 }
 
+// Give the agent time to process the first event
+sleep(50)
+
 emit SensorReading {
   id: "sensor-2",
   temperature: 35.5,

--- a/tests/parser/valid/agent_call.golden
+++ b/tests/parser/valid/agent_call.golden
@@ -1,0 +1,19 @@
+(program
+  (agent Greeter
+    (intent hi
+      (param name (type string))
+      (type string)
+      (return
+        (binary + (string "hi ") (selector name))
+      )
+    )
+  )
+  (let g (struct Greeter))
+  (let msg
+    (call
+      (selector hi (selector g))
+      (string mochi)
+    )
+  )
+)
+

--- a/tests/parser/valid/agent_call.mochi
+++ b/tests/parser/valid/agent_call.mochi
@@ -1,0 +1,8 @@
+agent Greeter {
+  intent hi(name: string): string {
+    return "hi " + name
+  }
+}
+
+let g = Greeter {}
+let msg = g.hi("mochi")

--- a/tests/parser/valid/agent_on_event.golden
+++ b/tests/parser/valid/agent_on_event.golden
@@ -1,0 +1,15 @@
+(program
+  (stream Temp (field "value:float"))
+  (agent Logger
+    (on Temp
+      (assign last
+        (selector value (selector t))
+      )
+    )
+    (intent lastTemp
+      (type float)
+      (return (selector last))
+    )
+  )
+)
+

--- a/tests/parser/valid/agent_on_event.mochi
+++ b/tests/parser/valid/agent_on_event.mochi
@@ -1,0 +1,13 @@
+stream Temp {
+  value: float
+}
+
+agent Logger {
+  var last: float = 0.0
+  on Temp as t {
+    last = t.value
+  }
+  intent lastTemp(): float {
+    return last
+  }
+}


### PR DESCRIPTION
## Summary
- move `examples/v0.3/agent.mochi` to `examples/v0.5/`
- pause after first event so both events are processed
- add parser golden tests `agent_on_event` and `agent_call`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845441abe6c8320bbdee3fb39f709ae