### PR TITLE
Document new agent features

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,28 @@ on Sensor as s {
 emit Sensor { id: "sensor-1", temperature: 22.5 }
 ```
 
+Agents can also maintain persistent state and expose **intent** functions that
+can be called like methods or via the MCP server.
+
+```mochi
+agent Monitor {
+  var count: int = 0
+
+  on Sensor as s {
+    count = count + 1
+  }
+
+  intent status(): string {
+    return "events = " + str(count)
+  }
+}
+
+let m = Monitor {}
+emit Sensor { id: "sensor-2", temperature: 30.0 }
+sleep(50)
+print(m.status())
+```
+
 ## MCP Tools
 
 When running `mochi serve`, the following tools are available:

--- a/SPEC.md
+++ b/SPEC.md
@@ -293,6 +293,23 @@ agent Logger {
 emit Click { x: 10, y: 20 }
 ```
 
+Agents may also declare persistent variables using `var` and expose `intent`
+functions that can be called from other code or via an MCP server.
+
+```mochi
+agent Counter {
+  var n: int = 0
+
+  on Click as _ {
+    n = n + 1
+  }
+
+  intent total(): int {
+    return n
+  }
+}
+```
+
 ### Model Declarations
 
 `model` blocks define reusable language model aliases. Each block specifies a
@@ -397,7 +414,9 @@ TestBlock     = "test" StringLiteral Block .
 ExpectStmt    = "expect" Expression .
 StreamDecl    = "stream" Identifier Block .
 OnHandler     = "on" Identifier "as" Identifier Block .
-AgentDecl     = "agent" Identifier Block .
+AgentDecl     = "agent" Identifier "{" AgentField* "}" .
+AgentField    = LetStmt | VarStmt | AssignStmt | OnHandler | IntentDecl .
+IntentDecl    = "intent" Identifier "(" [ ParamList ] ")" [ ":" TypeRef ] Block .
 ModelDecl     = "model" Identifier Block .
 
 Expression    = OrExpr .

--- a/docs/features/streams.md
+++ b/docs/features/streams.md
@@ -12,4 +12,25 @@ on Sensor as s {
 emit Sensor { id: "sensor-1", temperature: 22.5 }
 ```
 
+Agents may store state and expose **intent** functions for external callers.
+
+```mochi
+agent Monitor {
+  var count: int = 0
+
+  on Sensor as s {
+    count = count + 1
+  }
+
+  intent status(): string {
+    return "events = " + str(count)
+  }
+}
+
+let m = Monitor {}
+emit Sensor { id: "sensor-2", temperature: 30.0 }
+sleep(50)
+print(m.status())
+```
+
 These features are explained further in the [language specification](../SPEC.md).

--- a/docs/guides/using-mochi.md
+++ b/docs/guides/using-mochi.md
@@ -74,6 +74,9 @@ mochi build --target py examples/hello.mochi -o hello.py
 
 Mochi integrates well with agent-oriented tools. You can run an MCP server for Visual Studio Code or Claude Desktop using the `serve` subcommand. See the [README](../README.md) for full configuration examples.
 
+Agents now support persistent state and `intent` functions that can be called
+from editor integrations or other Mochi code.
+
 ## Repository Overview
 
 The source tree is organized as follows:

--- a/runtime/agent/README.md
+++ b/runtime/agent/README.md
@@ -5,6 +5,7 @@ The `agent` package defines the runtime model for agents in Mochi. An **agent** 
 * Listens to real-time `stream.Event`s
 * Mutates local state based on event handlers
 * Exposes `intent` functions for querying or triggering behavior
+* Persists `var` variables across events and intent calls
 
 This package is designed to integrate cleanly with the `mochi` interpreter, stream engine, and generative agent system.
 
@@ -111,5 +112,6 @@ This package is designed to be used by the **Mochi interpreter**, which will:
 * Parse and compile `agent { ... }` blocks
 * Call `agent.On(...)` and `RegisterIntent(...)` dynamically
 * Use `Set` / `Get` to reflect interpreter variables into agent state
+* Persist variables declared with `var` across events and intents
 * Optionally inject LLM tooling or sandboxed control APIs in future
 


### PR DESCRIPTION
## Summary
- mention persistent `var` state and `intent` functions in README
- document agent intents in feature guide
- update runtime agent docs with notes on variable persistence
- describe agent intents in using-mochi guide
- extend SPEC with agent `intent` grammar and example

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_68455db56c0c83208876a13e81b24254