### PR TITLE
Implement string membership operator

### DIFF
--- a/examples/v0.5/string.mochi
+++ b/examples/v0.5/string.mochi
@@ -1,0 +1,33 @@
+let s = "hello world"
+
+// Indexing: access individual characters by index (0-based)
+print("s[0] =", s[0])     // h
+print("s[4] =", s[4])     // o
+
+// Length of string
+print("length =", len(s)) // 11
+
+// Iteration: loop over each character
+for ch in s {
+  print("char:", ch)
+}
+
+// Use `in` operator: check if character is in the string
+if "w" in s {
+  print("'w' is in the string")
+}
+
+if "z" in s {
+  print("'z' is in the string") // will not print
+}
+
+// Count vowels
+let vowels = "aeiou"
+let count = 0
+
+for ch in s {
+  if ch in vowels {
+    count += 1
+  }
+}
+print("vowel count:", count) // 3

--- a/examples/v0.5/string_index_iterator.mochi
+++ b/examples/v0.5/string_index_iterator.mochi
@@ -16,7 +16,7 @@ let vowels = "aeiou"
 let count = 0
 
 for ch in s {
-  if vowels.contains(ch) {
+  if ch in vowels {
     count += 1
   }
 }

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -899,7 +899,7 @@ func (i *Interpreter) evalBinaryExpr(b *parser.BinaryExpr) (any, error) {
 		{"*", "/", "%"},        // highest
 		{"+", "-"},             // addition
 		{"<", "<=", ">", ">="}, // comparison
-		{"==", "!="},           // equality
+                {"==", "!=", "in"},           // equality and membership
 		{"&&"},                 // logical AND
 		{"||"},                 // logical OR (lowest)
 	} {
@@ -2111,16 +2111,18 @@ func applyBinaryValue(pos lexer.Position, left Value, op string, right Value) (V
 		}
 	case TagStr:
 		if right.Tag == TagStr {
-			switch op {
-			case "+":
-				return Value{Tag: TagStr, Str: left.Str + right.Str}, nil
-			case "==":
-				return Value{Tag: TagBool, Bool: left.Str == right.Str}, nil
-			case "!=":
-				return Value{Tag: TagBool, Bool: left.Str != right.Str}, nil
-			}
-		}
-	}
+                        switch op {
+                        case "+":
+                                return Value{Tag: TagStr, Str: left.Str + right.Str}, nil
+                        case "==":
+                                return Value{Tag: TagBool, Bool: left.Str == right.Str}, nil
+                        case "!=":
+                                return Value{Tag: TagBool, Bool: left.Str != right.Str}, nil
+                        case "in":
+                                return Value{Tag: TagBool, Bool: strings.Contains(right.Str, left.Str)}, nil
+                        }
+                }
+        }
 	return Value{}, errInvalidOperator(pos, op, left.Tag.String(), right.Tag.String())
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -214,7 +214,7 @@ type BinaryExpr struct {
 
 type BinaryOp struct {
 	Pos   lexer.Position
-	Op    string       `parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | '&&' | '||')"`
+    Op    string       `parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | 'in' | '&&' | '||')"`
 	Right *PostfixExpr `parser:"@@"`
 }
 

--- a/tests/interpreter/valid/in_operator.mochi
+++ b/tests/interpreter/valid/in_operator.mochi
@@ -1,0 +1,3 @@
+let s = "hello"
+print("e" in s)
+print("x" in s)

--- a/tests/interpreter/valid/in_operator.out
+++ b/tests/interpreter/valid/in_operator.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/parser/valid/in_operator.golden
+++ b/tests/parser/valid/in_operator.golden
@@ -1,0 +1,5 @@
+(program
+  (let x
+    (binary in (string w) (string hello))
+  )
+)

--- a/tests/parser/valid/in_operator.mochi
+++ b/tests/parser/valid/in_operator.mochi
@@ -1,0 +1,1 @@
+let x = "w" in "hello"

--- a/tests/types/valid/string_in_operator.golden
+++ b/tests/types/valid/string_in_operator.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/string_in_operator.mochi
+++ b/tests/types/valid/string_in_operator.mochi
@@ -1,0 +1,1 @@
+let ok = "w" in "hello"

--- a/types/check.go
+++ b/types/check.go
@@ -821,7 +821,7 @@ func checkBinaryExpr(b *parser.BinaryExpr, env *Env) (Type, error) {
 		{"*", "/", "%"},
 		{"+", "-"},
 		{"<", "<=", ">", ">="},
-		{"==", "!="},
+                {"==", "!=", "in"},
 		{"&&"},
 		{"||"},
 	} {
@@ -869,12 +869,17 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 		default:
 			return nil, errOperatorMismatch(pos, op, left, right)
 		}
-	case "==", "!=", "<", "<=", ">", ">=":
-		if !unify(left, right, nil) {
-			return nil, errIncompatibleComparison(pos)
-		}
-		return BoolType{}, nil
-	case "&&", "||":
+        case "==", "!=", "<", "<=", ">", ">=":
+                if !unify(left, right, nil) {
+                        return nil, errIncompatibleComparison(pos)
+                }
+                return BoolType{}, nil
+        case "in":
+                if !(unify(left, StringType{}, nil) && unify(right, StringType{}, nil)) {
+                        return nil, errOperatorMismatch(pos, op, left, right)
+                }
+                return BoolType{}, nil
+        case "&&", "||":
 		if !(unify(left, BoolType{}, nil) && unify(right, BoolType{}, nil)) {
 			return nil, errOperatorMismatch(pos, op, left, right)
 		}


### PR DESCRIPTION
## Summary
- add example using `in` for strings
- support `in` operator in parser, type checker, and interpreter
- update existing string example
- add tests covering parser, type checker, and interpreter behaviour

## Testing
- `make test STAGE=parser`
- `make test STAGE=types`
- `make test STAGE=interpreter`


------
https://chatgpt.com/codex/tasks/task_e_6845bfb0270083208a3e6bfc2d6a51c3