### PR TITLE
Update docs for string iteration and indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ print(tags)
 print(nums[1])
 ```
 
+Strings behave like read‐only lists of characters. They can be indexed
+and iterated just like a list:
+
+```mochi
+let text = "hello"
+print(text[1]) // "e"
+
+for ch in text {
+  print(ch)
+}
+```
+
 ### Tests
 
 ```mochi

--- a/SPEC.md
+++ b/SPEC.md
@@ -180,6 +180,17 @@ let scores = {"alice": 1, "bob": 2}
 print(scores["alice"])
 ```
 
+Strings are also indexable and iterable:
+
+```mochi
+let text = "hello"
+print(text[1])
+
+for ch in text {
+  print(ch)
+}
+```
+
 #### Match Expressions
 
 `match` evaluates patterns in order and yields the corresponding result. `_` matches any value.

--- a/docs/features/collections.md
+++ b/docs/features/collections.md
@@ -11,3 +11,16 @@ print(user["name"])
 print(tags)
 print(nums[1])
 ```
+
+Strings can be treated like read-only lists of characters. Use the index
+operator to access individual characters, or iterate over them with a
+`for` loop:
+
+```mochi
+let text = "hello"
+print(text[1])
+
+for ch in text {
+  print(ch)
+}
+```

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -73,6 +73,14 @@ for name in scores {
     print(name, " scored ", score)
 }
 
+// 4.2 String indexing and iteration
+let text = "hello"
+print(text[1]) // "e"
+
+for ch in text {
+    print("char:", ch)
+}
+
 // 5. Test block with expect.
 test "Some math operator" {
     expect 2 + 3 == 5


### PR DESCRIPTION
## Summary
- mention string indexing and iteration in README
- expand cheat sheet with string examples
- document strings as iterable collections
- clarify spec for string indexing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845c773708083209dacef9a42709fef