### PR TITLE
Refactor stream field grammar

### DIFF
--- a/llm/grammar.ebnf
+++ b/llm/grammar.ebnf
@@ -27,10 +27,7 @@ AssignStmt = <ident> "=" Expr .
 OnHandler = "on" <ident> "as" <ident> "{" Statement* "}" .
 IntentDecl = "intent" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}" .
 StreamDecl = "stream" <ident> "{" StreamField* "}" .
-StreamField = StreamNestedField | StreamSimpleField .
-StreamNestedField = <ident> ":" ":" <ident> StructDef .
-StructDef = "{" StreamField* "}" .
-StreamSimpleField = <ident> ":" <ident> .
+StreamField = <ident> ":" TypeRef .
 FunStmt = "fun" <ident> "(" (Param ("," Param)*)? ")" (":" TypeRef)? "{" Statement* "}" .
 ReturnStmt = "return" Expr .
 IfStmt = "if" Expr "{" Statement* "}" (("else" IfStmt) | ("else" "{" Statement* "}"))? .

--- a/llm/index.html
+++ b/llm/index.html
@@ -159,22 +159,7 @@ Diagram(Choice(0, Sequence(Terminal("stream"), NonTerminal("ident"), Terminal("{
 
 <h1 id="StreamField">StreamField</h1>
 <script>
-Diagram(Choice(0, Sequence(NonTerminal("StreamNestedField", {href:"#StreamNestedField"})), Sequence(NonTerminal("StreamSimpleField", {href:"#StreamSimpleField"})))).addTo();
-</script>
-
-<h1 id="StreamNestedField">StreamNestedField</h1>
-<script>
-Diagram(Choice(0, Sequence(NonTerminal("ident"), Terminal(":"), NonTerminal("StructDef", {href:"#StructDef"})))).addTo();
-</script>
-
-<h1 id="StructDef">StructDef</h1>
-<script>
-Diagram(Choice(0, Sequence(Terminal("{"), ZeroOrMore(NonTerminal("StreamField", {href:"#StreamField"})), Terminal("}")))).addTo();
-</script>
-
-<h1 id="StreamSimpleField">StreamSimpleField</h1>
-<script>
-Diagram(Choice(0, Sequence(NonTerminal("ident"), Terminal(":"), NonTerminal("ident")))).addTo();
+Diagram(Choice(0, Sequence(NonTerminal("ident"), Terminal(":"), NonTerminal("TypeRef", {href:"#TypeRef"})))).addTo();
 </script>
 
 <h1 id="FunStmt">FunStmt</h1>

--- a/llm/llm.latest.md
+++ b/llm/llm.latest.md
@@ -508,29 +508,15 @@ type Literal struct {
 // --- Stream / Struct ---
 
 type StreamDecl struct {
-	Pos    lexer.Position
-	Name   string         `parser:"'stream' @Ident"`
-	Fields []*StreamField `parser:"'{' @@* '}'"`
+        Pos    lexer.Position
+        Name   string         `parser:"'stream' @Ident"`
+        Fields []*StreamField `parser:"'{' @@* '}'"`
 }
 
 type StreamField struct {
-	Nested *StreamNestedField `parser:"@@"`
-	Simple *StreamSimpleField `parser:"| @@"`
-}
-
-type StreamSimpleField struct {
-	Name string `parser:"@Ident ':'"`
-	Type string `parser:"@Ident"`
-}
-
-type StreamNestedField struct {
-	Name string     `parser:"@Ident ':'"`
-	Type string     `parser:"':' @Ident"`
-	Body *StructDef `parser:"@@"`
-}
-
-type StructDef struct {
-	Fields []*StreamField `parser:"'{' @@* '}'"`
+        Pos  lexer.Position
+        Name string   `parser:"@Ident ':'"`
+        Type *TypeRef `parser:"@@"`
 }
 
 // --- On Handler ---

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -214,7 +214,7 @@ type BinaryExpr struct {
 
 type BinaryOp struct {
 	Pos   lexer.Position
-    Op    string       `parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | 'in' | '&&' | '||')"`
+	Op    string       `parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | 'in' | '&&' | '||')"`
 	Right *PostfixExpr `parser:"@@"`
 }
 
@@ -371,23 +371,9 @@ type ModelField struct {
 }
 
 type StreamField struct {
-	Nested *StreamNestedField `parser:"@@"`
-	Simple *StreamSimpleField `parser:"| @@"`
-}
-
-type StreamSimpleField struct {
-	Name string `parser:"@Ident ':'"`
-	Type string `parser:"@Ident"`
-}
-
-type StreamNestedField struct {
-	Name string     `parser:"@Ident ':'"`
-	Type string     `parser:"':' @Ident"`
-	Body *StructDef `parser:"@@"`
-}
-
-type StructDef struct {
-	Fields []*StreamField `parser:"'{' @@* '}'"`
+	Pos  lexer.Position
+	Name string   `parser:"@Ident ':'"`
+	Type *TypeRef `parser:"@@"`
 }
 
 // --- On Handler ---


### PR DESCRIPTION
## Summary
- simplify the parser representation for stream fields
- remove nested stream field constructs
- update AST conversion and type checking logic
- refresh generated grammar documentation
- type cast stream event data in interpreter

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6845f61b9960832095e06da60b1201e8