### PR TITLE
Improve Go string indexing

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -888,8 +888,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					val = fmt.Sprintf("%s[%s]", val, key)
 					typ = tt.Value
 				case types.StringType:
-					c.use("_index")
-					val = fmt.Sprintf("_index(%s, %s).(string)", val, key)
+					c.use("_indexString")
+					val = fmt.Sprintf("_indexString(%s, %s)", val, key)
 					typ = types.StringType{}
 				default:
 					c.use("_index")
@@ -1989,6 +1989,17 @@ const (
 		"    }\n" +
 		"}\n"
 
+	helperIndexString = "func _indexString(s string, i int) string {\n" +
+		"    runes := []rune(s)\n" +
+		"    if i < 0 {\n" +
+		"        i += len(runes)\n" +
+		"    }\n" +
+		"    if i < 0 || i >= len(runes) {\n" +
+		"        panic(\"index out of range\")\n" +
+		"    }\n" +
+		"    return string(runes[i])\n" +
+		"}\n"
+
 	helperSlice = "func _slice(v any, start, end int) any {\n" +
 		"    switch s := v.(type) {\n" +
 		"    case []any:\n" +
@@ -2222,15 +2233,16 @@ const (
 )
 
 var helperMap = map[string]string{
-	"_index":     helperIndex,
-	"_slice":     helperSlice,
-	"_iter":      helperIter,
-	"_genText":   helperGenText,
-	"_genEmbed":  helperGenEmbed,
-	"_genStruct": helperGenStruct,
-	"_fetch":     helperFetch,
-	"_toAnyMap":  helperToAnyMap,
-	"_cast":      helperCast,
+	"_index":       helperIndex,
+	"_indexString": helperIndexString,
+	"_slice":       helperSlice,
+	"_iter":        helperIter,
+	"_genText":     helperGenText,
+	"_genEmbed":    helperGenEmbed,
+	"_genStruct":   helperGenStruct,
+	"_fetch":       helperFetch,
+	"_toAnyMap":    helperToAnyMap,
+	"_cast":        helperCast,
 }
 
 func (c *Compiler) use(name string) {

--- a/tests/compiler/valid/string_index.go.out
+++ b/tests/compiler/valid/string_index.go.out
@@ -6,91 +6,17 @@ import (
 
 func main() {
 	var text string = "hello"
-	fmt.Println(_index(text, 1).(string))
+	fmt.Println(_indexString(text, 1))
 }
 
-func _index(v any, k any) any {
-    switch s := v.(type) {
-    case []any:
-        i, ok := k.(int)
-        if !ok {
-            panic("invalid list index")
-        }
-        if i < 0 {
-            i += len(s)
-        }
-        if i < 0 || i >= len(s) {
-            panic("index out of range")
-        }
-        return s[i]
-    case []int:
-        i, ok := k.(int)
-        if !ok {
-            panic("invalid list index")
-        }
-        if i < 0 {
-            i += len(s)
-        }
-        if i < 0 || i >= len(s) {
-            panic("index out of range")
-        }
-        return s[i]
-    case []float64:
-        i, ok := k.(int)
-        if !ok {
-            panic("invalid list index")
-        }
-        if i < 0 {
-            i += len(s)
-        }
-        if i < 0 || i >= len(s) {
-            panic("index out of range")
-        }
-        return s[i]
-    case []string:
-        i, ok := k.(int)
-        if !ok {
-            panic("invalid list index")
-        }
-        if i < 0 {
-            i += len(s)
-        }
-        if i < 0 || i >= len(s) {
-            panic("index out of range")
-        }
-        return s[i]
-    case []bool:
-        i, ok := k.(int)
-        if !ok {
-            panic("invalid list index")
-        }
-        if i < 0 {
-            i += len(s)
-        }
-        if i < 0 || i >= len(s) {
-            panic("index out of range")
-        }
-        return s[i]
-    case string:
-        i, ok := k.(int)
-        if !ok {
-            panic("invalid string index")
-        }
-        runes := []rune(s)
-        if i < 0 {
-            i += len(runes)
-        }
-        if i < 0 || i >= len(runes) {
-            panic("index out of range")
-        }
-        return string(runes[i])
-    case map[string]any:
-        ks, ok := k.(string)
-        if !ok {
-            panic("invalid map key")
-        }
-        return s[ks]
-    default:
-        panic("invalid index target")
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
     }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
 }
+


### PR DESCRIPTION
## Summary
- specialize Go compiler index logic
- add `_indexString` helper
- update golden output for string indexing

## Testing
- `go test ./compile/go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68460b505d208320bae3bfb485cb136a