### PR TITLE
Implement simple compile-time folding for pure calls

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"mochi/interpreter"
 	"mochi/parser"
 	"mochi/types"
 )
@@ -1159,7 +1160,14 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 	}
 }
 
+func (c *Compiler) foldCall(call *parser.CallExpr) (*parser.Literal, bool) {
+	return interpreter.EvalPureCall(call, c.env)
+}
+
 func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
+	if lit, ok := c.foldCall(call); ok {
+		return c.compileLiteral(lit)
+	}
 	args := make([]string, len(call.Args))
 	for i, a := range call.Args {
 		v, err := c.compileExpr(a)

--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"mochi/interpreter"
 	"mochi/parser"
 	"mochi/types"
 )
@@ -840,6 +841,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 }
 
 func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
+	if lit, ok := interpreter.EvalPureCall(call, c.env); ok {
+		return c.compileLiteral(lit)
+	}
 	args := make([]string, len(call.Args))
 	for i, a := range call.Args {
 		v, err := c.compileExpr(a)

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"mochi/interpreter"
 	"mochi/parser"
 	"mochi/types"
 )
@@ -783,6 +784,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 }
 
 func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
+	if lit, ok := interpreter.EvalPureCall(call, c.env); ok {
+		return c.compileLiteral(lit)
+	}
 	args := make([]string, len(call.Args))
 	for i, a := range call.Args {
 		v, err := c.compileExpr(a)

--- a/interpreter/consteval.go
+++ b/interpreter/consteval.go
@@ -1,0 +1,36 @@
+package interpreter
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// EvalPureCall evaluates a pure function call with literal arguments using a temporary interpreter.
+func EvalPureCall(call *parser.CallExpr, env *types.Env) (*parser.Literal, bool) {
+	if call == nil {
+		return nil, false
+	}
+	t, err := env.GetVar(call.Func)
+	if err != nil {
+		return nil, false
+	}
+	ft, ok := t.(types.FuncType)
+	if !ok || !ft.Pure {
+		return nil, false
+	}
+	for _, arg := range call.Args {
+		if !types.IsLiteralExpr(arg) {
+			return nil, false
+		}
+	}
+	interp := New(&parser.Program{}, env.Copy())
+	val, err := interp.EvalExpr(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: &parser.PostfixExpr{Target: &parser.Primary{Call: call}}}}})
+	if err != nil {
+		return nil, false
+	}
+	lit := types.AnyToLiteral(val)
+	if lit == nil {
+		return nil, false
+	}
+	return lit, true
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -191,6 +191,12 @@ func (i *Interpreter) SetProgram(prog *parser.Program) {
 
 func (i *Interpreter) Env() *types.Env { return i.env }
 
+// EvalExpr evaluates a Mochi expression using the interpreter.
+// This is exported for compile-time evaluation of pure expressions.
+func (i *Interpreter) EvalExpr(e *parser.Expr) (any, error) {
+	return i.evalExpr(e)
+}
+
 var (
 	cTest = color.New(color.FgYellow).SprintFunc()
 	cOK   = color.New(color.FgGreen).SprintFunc()

--- a/types/pure.go
+++ b/types/pure.go
@@ -1,0 +1,152 @@
+package types
+
+import "mochi/parser"
+
+// isLiteralExpr returns true if e is a literal expression.
+func IsLiteralExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	return p.Target != nil && p.Target.Lit != nil
+}
+
+// anyToLiteral converts basic Go values to a Mochi literal.
+func AnyToLiteral(v any) *parser.Literal {
+	switch t := v.(type) {
+	case int:
+		return &parser.Literal{Int: &t}
+	case float64:
+		return &parser.Literal{Float: &t}
+	case string:
+		return &parser.Literal{Str: &t}
+	default:
+		return nil
+	}
+}
+
+// isPureCall returns true if call invokes a pure function.
+func isPureCall(call *parser.CallExpr, env *Env) bool {
+	t, err := env.GetVar(call.Func)
+	if err != nil {
+		return false
+	}
+	ft, ok := t.(FuncType)
+	if !ok || !ft.Pure {
+		return false
+	}
+	for _, arg := range call.Args {
+		if !IsLiteralExpr(arg) {
+			return false
+		}
+	}
+	return true
+}
+
+// isPureStmt checks if a statement has no side effects.
+func isPureStmt(s *parser.Statement, env *Env) bool {
+	switch {
+	case s.Let != nil:
+		if s.Let.Value != nil && !isPureExpr(s.Let.Value, env) {
+			return false
+		}
+		env.SetVar(s.Let.Name, AnyType{}, false)
+		return true
+	case s.Return != nil:
+		return isPureExpr(s.Return.Value, env)
+	case s.Expr != nil:
+		return isPureExpr(s.Expr.Expr, env)
+	case s.Fun != nil:
+		return isPureFunction(s.Fun, env)
+	}
+	return false
+}
+
+// isPureExpr recursively checks if expression e has no side effects.
+func isPureExpr(e *parser.Expr, env *Env) bool {
+	if e == nil {
+		return true
+	}
+	if call, ok := callPattern(e); ok {
+		return isPureCall(call, env)
+	}
+	if !isPureUnary(e.Binary.Left, env) {
+		return false
+	}
+	for _, op := range e.Binary.Right {
+		if !isPurePostfix(op.Right, env) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPureUnary(u *parser.Unary, env *Env) bool {
+	if !isPurePostfix(u.Value, env) {
+		return false
+	}
+	return true
+}
+
+func isPurePostfix(p *parser.PostfixExpr, env *Env) bool {
+	if !isPurePrimary(p.Target, env) {
+		return false
+	}
+	for _, op := range p.Ops {
+		if op.Index != nil || op.Cast != nil || op.Call != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func isPurePrimary(p *parser.Primary, env *Env) bool {
+	switch {
+	case p.Lit != nil:
+		return true
+	case p.Call != nil:
+		return isPureCall(p.Call, env)
+	case p.Group != nil:
+		return isPureExpr(p.Group, env)
+	case p.Selector != nil:
+		if len(p.Selector.Tail) == 0 {
+			mutable, err := env.IsMutable(p.Selector.Root)
+			if err == nil && !mutable {
+				return true
+			}
+		}
+		return false
+	case p.FunExpr != nil:
+		return false
+	default:
+		return false
+	}
+}
+
+// isPureFunction analyses a function and determines if it is pure.
+func isPureFunction(fn *parser.FunStmt, env *Env) bool {
+	child := NewEnv(env)
+	for _, p := range fn.Params {
+		if p.Type != nil {
+			child.SetVar(p.Name, resolveTypeRef(p.Type, env), false)
+		} else {
+			child.SetVar(p.Name, AnyType{}, false)
+		}
+	}
+	for _, stmt := range fn.Body {
+		if !isPureStmt(stmt, child) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- detect function purity in type checker
- mark `len` and `str` builtins as pure
- add helpers for purity checks and literal detection
- provide interpreter-based constant evaluation for pure calls
- fold calls with literal arguments during Go, Python and TypeScript compilation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68462f61b1308320972189c70571e703