### PR TITLE
Improve interpreter const-eval

### DIFF
--- a/interpreter/consteval.go
+++ b/interpreter/consteval.go
@@ -24,6 +24,8 @@ func EvalPureCall(call *parser.CallExpr, env *types.Env) (*parser.Literal, bool)
 		}
 	}
 	interp := New(&parser.Program{}, env.Copy())
+	// Avoid recursive const-evaluation when interpreting the call.
+	interp.disablePureEval = true
 	val, err := interp.EvalExpr(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: &parser.PostfixExpr{Target: &parser.Primary{Call: call}}}}})
 	if err != nil {
 		return nil, false


### PR DESCRIPTION
## Summary
- support const-evaluation of pure function calls directly in the interpreter
- avoid recursion by disabling pure evaluation when invoked from `EvalPureCall`

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_684633d1eab483209e2372d231591902