### PR TITLE
Improve argsKey for memoization

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -4,143 +4,143 @@
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 24 | best |
-| Typescript | 671 | +2697.2% |
-| Python | 847 | +3429.0% |
-| mochi (interp) | 91060 | +379316.7% |
+| Typescript | 541 | +2152.9% |
+| Python | 858 | +3477.0% |
+| mochi (interp) | 57831 | +240862.5% |
 
 ## math.fact_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 55 | best |
-| Typescript | 820 | +1390.1% |
-| Python | 2048 | +3623.5% |
-| mochi (interp) | 175726 | +319401.8% |
+| Typescript | 1616 | +2837.6% |
+| Python | 1870 | +3300.6% |
+| mochi (interp) | 360730 | +655772.7% |
 
 ## math.fact_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 254 | best |
-| Typescript | 2293 | +802.8% |
-| Python | 2794 | +1000.0% |
-| mochi (interp) | 243084 | +95602.4% |
+| Mochi | 174 | best |
+| Typescript | 2579 | +1381.9% |
+| Python | 5423 | +3016.5% |
+| mochi (interp) | 530157 | +304587.9% |
 
 ## math.fib_iter.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 10 | best |
-| Typescript | 631 | +6214.4% |
-| Python | 668 | +6579.2% |
-| mochi (interp) | 62232 | +622220.0% |
+| Typescript | 375 | +3654.9% |
+| Python | 539 | +5286.9% |
+| mochi (interp) | 47540 | +475300.0% |
 
 ## math.fib_iter.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 18 | best |
-| Python | 1048 | +5720.8% |
-| Typescript | 1822 | +10021.6% |
-| mochi (interp) | 48935 | +271761.1% |
+| Mochi | 24 | best |
+| Typescript | 603 | +2413.7% |
+| Python | 979 | +3980.1% |
+| mochi (interp) | 80944 | +337166.7% |
 
 ## math.fib_iter.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 26 | best |
-| Typescript | 670 | +2478.6% |
-| Python | 1347 | +5081.0% |
-| mochi (interp) | 111376 | +428269.2% |
+| Typescript | 1186 | +4462.8% |
+| Python | 1332 | +5023.1% |
+| mochi (interp) | 35878 | +137892.3% |
 
 ## math.fib_rec.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 0 | best |
-| Python | 17 | ++Inf% |
-| Typescript | 185 | ++Inf% |
-| mochi (interp) | 910 | ++Inf% |
+| Python | 16 | ++Inf% |
+| Typescript | 32 | ++Inf% |
+| mochi (interp) | 2178 | ++Inf% |
 
 ## math.fib_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 69 | best |
-| Typescript | 1335 | +1835.4% |
-| Python | 1498 | +2070.9% |
-| mochi (interp) | 172237 | +249518.8% |
+| Mochi | 50 | best |
+| Typescript | 732 | +1364.7% |
+| Python | 1465 | +2829.6% |
+| mochi (interp) | 147023 | +293946.0% |
 
 ## math.fib_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 7286 | best |
-| Typescript | 14624 | +100.7% |
-| Python | 186767 | +2463.4% |
-| mochi (interp) | 26887273 | +368926.5% |
+| Mochi | 6568 | best |
+| Typescript | 31825 | +384.5% |
+| Python | 185372 | +2722.4% |
+| mochi (interp) | 24669194 | +375496.7% |
 
 ## math.mul_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 14 | best |
-| Python | 484 | +3359.0% |
-| Typescript | 655 | +4577.5% |
-| mochi (interp) | 24071 | +171835.7% |
+| Mochi | 15 | best |
+| Typescript | 449 | +2891.6% |
+| Python | 479 | +3094.1% |
+| mochi (interp) | 60370 | +402366.7% |
 
 ## math.mul_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 29 | best |
-| Typescript | 711 | +2350.6% |
-| Python | 1107 | +3717.0% |
-| mochi (interp) | 72388 | +249513.8% |
+| Mochi | 17 | best |
+| Typescript | 581 | +3316.1% |
+| Python | 1090 | +6311.2% |
+| mochi (interp) | 38674 | +227394.1% |
 
 ## math.mul_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 25 | best |
-| Typescript | 677 | +2609.6% |
-| Python | 1630 | +6421.1% |
-| mochi (interp) | 44546 | +178084.0% |
+| Typescript | 790 | +3059.8% |
+| Python | 1622 | +6389.6% |
+| mochi (interp) | 37524 | +149996.0% |
 
 ## math.prime_count.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 5 | best |
-| Typescript | 258 | +5051.6% |
-| Python | 275 | +5403.6% |
-| mochi (interp) | 31218 | +624260.0% |
+| Mochi | 4 | best |
+| Typescript | 245 | +6037.4% |
+| Python | 274 | +6747.5% |
+| mochi (interp) | 30631 | +765675.0% |
 
 ## math.prime_count.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 26 | best |
-| Typescript | 460 | +1670.3% |
-| Python | 773 | +2872.4% |
-| mochi (interp) | 37366 | +143615.4% |
+| Typescript | 419 | +1512.3% |
+| Python | 908 | +3391.9% |
+| mochi (interp) | 84033 | +323103.8% |
 
 ## math.prime_count.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 51 | best |
-| Typescript | 897 | +1658.1% |
-| Python | 1336 | +2519.7% |
-| mochi (interp) | 110741 | +217039.2% |
+| Mochi | 50 | best |
+| Typescript | 680 | +1259.9% |
+| Python | 1297 | +2493.2% |
+| mochi (interp) | 52558 | +105016.0% |
 
 ## math.sum_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 9 | best |
-| Typescript | 360 | +3903.8% |
-| Python | 436 | +4745.7% |
-| mochi (interp) | 20180 | +224122.2% |
+| Typescript | 448 | +4873.7% |
+| Python | 473 | +5155.8% |
+| mochi (interp) | 21436 | +238077.8% |
 
 ## math.sum_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 17 | best |
-| Typescript | 640 | +3665.7% |
-| Python | 820 | +4724.3% |
-| mochi (interp) | 29377 | +172705.9% |
+| Typescript | 515 | +2927.9% |
+| Python | 730 | +4194.5% |
+| mochi (interp) | 55329 | +325364.7% |
 
 ## math.sum_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 25 | best |
-| Typescript | 745 | +2880.1% |
-| Python | 1217 | +4767.6% |
-| mochi (interp) | 78922 | +315588.0% |
+| Typescript | 639 | +2454.3% |
+| Python | 1069 | +4174.4% |
+| mochi (interp) | 47280 | +189020.0% |
 


### PR DESCRIPTION
## Summary
- improve memoization key generation by avoiding JSON serialization
- update benchmark outputs

## Testing
- `go test ./...`
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_68463ad76088832095208b6cd5da14a9