### PR TITLE
Add cheatsheet command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Commands:
   build   Compile to binary or other languages
   repl    Start interactive REPL
   serve   Start MCP server
+  cheatsheet  Print language reference
 ```
 
 Examples:

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -39,12 +39,13 @@ var (
 )
 
 type CLI struct {
-	Run     *RunCmd   `arg:"subcommand:run" help:"Run a Mochi source file"`
-	Test    *TestCmd  `arg:"subcommand:test" help:"Run test blocks inside a Mochi source file"`
-	Build   *BuildCmd `arg:"subcommand:build" help:"Compile a Mochi source file"`
-	Repl    *ReplCmd  `arg:"subcommand:repl" help:"Start an interactive REPL session"`
-	Serve   *ServeCmd `arg:"subcommand:serve" help:"Start MCP server over stdio"`
-	Version bool      `arg:"--version" help:"Print version info and exit"`
+	Run        *RunCmd        `arg:"subcommand:run" help:"Run a Mochi source file"`
+	Test       *TestCmd       `arg:"subcommand:test" help:"Run test blocks inside a Mochi source file"`
+	Build      *BuildCmd      `arg:"subcommand:build" help:"Compile a Mochi source file"`
+	Repl       *ReplCmd       `arg:"subcommand:repl" help:"Start an interactive REPL session"`
+	Serve      *ServeCmd      `arg:"subcommand:serve" help:"Start MCP server over stdio"`
+	Cheatsheet *CheatsheetCmd `arg:"subcommand:cheatsheet" help:"Print language cheatsheet"`
+	Version    bool           `arg:"--version" help:"Print version info and exit"`
 }
 
 type RunCmd struct {
@@ -68,6 +69,7 @@ type BuildCmd struct {
 
 type ReplCmd struct{}
 type ServeCmd struct{}
+type CheatsheetCmd struct{}
 
 var (
 	cError = color.New(color.FgRed, color.Bold).SprintFunc()
@@ -82,6 +84,8 @@ func main() {
 	switch {
 	case cli.Version:
 		printVersion()
+	case cli.Cheatsheet != nil:
+		fmt.Print(mcp.Cheatsheet())
 	case cli.Repl != nil:
 		repl := repl.New(os.Stdout, version)
 		repl.Run()

--- a/mcp/cheatsheet.go
+++ b/mcp/cheatsheet.go
@@ -1,0 +1,9 @@
+package mcp
+
+import _ "embed"
+
+//go:embed cheatsheet.mochi
+var cheatsheet string
+
+// Cheatsheet returns the embedded Mochi language cheatsheet.
+func Cheatsheet() string { return cheatsheet }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -151,6 +151,3 @@ func ServeStdio() error {
 	Register(s)
 	return server.ServeStdio(s)
 }
-
-//go:embed cheatsheet.mochi
-var cheatsheet string


### PR DESCRIPTION
## Summary
- add `cheatsheet` command to `mochi`
- share embedded cheatsheet via `mcp.Cheatsheet`
- update CLI help text in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846428cf20483208d7098479ccfbe0f