### PR TITLE
Enable AOT folding in interpreter

### DIFF
--- a/bench/runner.go
+++ b/bench/runner.go
@@ -80,7 +80,7 @@ func Benchmarks(tempDir, mochiBin string) []Bench {
 		cfg := Range{Start: 10, Step: "+10", Count: 3}
 
 		templates := []Template{
-			{Lang: "mochi_interp", Path: path, Suffix: suffix, Command: []string{mochiBin, "run"}},
+			{Lang: "mochi_interp", Path: path, Suffix: suffix, Command: []string{mochiBin, "run", "--aot"}},
 			{Lang: "mochi_go", Path: path, Suffix: suffix, Command: []string{"go", "run"}},
 			{Lang: "mochi_py", Path: path, Suffix: suffix, Command: []string{"python3"}},
 			{Lang: "mochi_ts", Path: path, Suffix: suffix, Command: []string{"deno", "run", "--quiet"}},

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -53,12 +53,14 @@ type RunCmd struct {
 	PrintAST bool   `arg:"--ast" help:"Print parsed AST in Lisp format"`
 	Debug    bool   `arg:"--debug" help:"Enable debug output"`
 	Memoize  bool   `arg:"--memo" help:"Enable memoization of pure functions"`
+	Fold     bool   `arg:"--aot" help:"Fold pure calls before execution"`
 }
 
 type TestCmd struct {
 	File    string `arg:"positional,required" help:"Path to .mochi source file"`
 	Debug   bool   `arg:"--debug" help:"Enable debug output"`
 	Memoize bool   `arg:"--memo" help:"Enable memoization of pure functions"`
+	Fold    bool   `arg:"--aot" help:"Fold pure calls before execution"`
 }
 
 type BuildCmd struct {
@@ -151,6 +153,9 @@ func runFile(cmd *RunCmd) error {
 		printTypeErrors(errs)
 		return fmt.Errorf("aborted due to type errors")
 	}
+	if cmd.Fold {
+		interpreter.FoldPureCalls(prog, env)
+	}
 	memo := cmd.Memoize || os.Getenv("MOCHI_MEMO") == "1" || strings.ToLower(os.Getenv("MOCHI_MEMO")) == "true"
 	interp := interpreter.New(prog, env)
 	interp.SetMemoization(memo)
@@ -182,6 +187,9 @@ func runTests(cmd *TestCmd) error {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		printTypeErrors(errs)
 		return fmt.Errorf("aborted due to type errors")
+	}
+	if cmd.Fold {
+		interpreter.FoldPureCalls(prog, env)
 	}
 	memo := cmd.Memoize || os.Getenv("MOCHI_MEMO") == "1" || strings.ToLower(os.Getenv("MOCHI_MEMO")) == "true"
 	interp := interpreter.New(prog, env)

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -120,14 +120,16 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.indent--
 	c.writeln("}")
 	if needsAsync {
+		c.use("_waitAll")
+	}
+	c.emitRuntime()
+	if needsAsync {
 		c.writeln("await main()")
 		c.writeln("await _waitAll()")
-		c.use("_waitAll")
 	} else {
 		c.writeln("main()")
 	}
 	c.writeln("")
-	c.emitRuntime()
 	return c.buf.Bytes(), nil
 }
 

--- a/interpreter/fold.go
+++ b/interpreter/fold.go
@@ -1,0 +1,161 @@
+package interpreter
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// FoldPureCalls traverses prog and replaces pure function calls with their
+// evaluated literal result. This runs a simple form of ahead-of-time
+// constant folding for the interpreter.
+func FoldPureCalls(prog *parser.Program, env *types.Env) {
+	if prog == nil || env == nil {
+		return
+	}
+	// Register top-level functions so EvalPureCall can resolve them.
+	for _, s := range prog.Statements {
+		if s.Fun != nil {
+			env.SetFunc(s.Fun.Name, s.Fun)
+		}
+	}
+	for _, s := range prog.Statements {
+		foldStmt(s, env)
+	}
+}
+
+func foldStmt(s *parser.Statement, env *types.Env) {
+	switch {
+	case s.Let != nil && s.Let.Value != nil:
+		foldExpr(s.Let.Value, env)
+	case s.Var != nil && s.Var.Value != nil:
+		foldExpr(s.Var.Value, env)
+	case s.Assign != nil:
+		foldExpr(s.Assign.Value, env)
+	case s.Expr != nil:
+		foldExpr(s.Expr.Expr, env)
+	case s.Return != nil:
+		foldExpr(s.Return.Value, env)
+	case s.If != nil:
+		foldExpr(s.If.Cond, env)
+		for _, stmt := range s.If.Then {
+			foldStmt(stmt, env)
+		}
+		for _, stmt := range s.If.Else {
+			foldStmt(stmt, env)
+		}
+	case s.While != nil:
+		foldExpr(s.While.Cond, env)
+		for _, stmt := range s.While.Body {
+			foldStmt(stmt, env)
+		}
+	case s.For != nil:
+		foldExpr(s.For.Source, env)
+		if s.For.RangeEnd != nil {
+			foldExpr(s.For.RangeEnd, env)
+		}
+		for _, stmt := range s.For.Body {
+			foldStmt(stmt, env)
+		}
+	case s.Fun != nil:
+		child := types.NewEnv(env)
+		for _, stmt := range s.Fun.Body {
+			foldStmt(stmt, child)
+		}
+	}
+}
+
+func foldExpr(e *parser.Expr, env *types.Env) {
+	if e == nil {
+		return
+	}
+	foldUnary(e.Binary.Left, env)
+	for _, op := range e.Binary.Right {
+		foldPostfixExpr(op.Right, env)
+	}
+	if call, ok := callPattern(e); ok {
+		if lit, ok := EvalPureCall(call, env); ok {
+			e.Binary.Left = &parser.Unary{Value: &parser.PostfixExpr{Target: &parser.Primary{Lit: lit}}}
+			e.Binary.Right = nil
+		}
+	}
+}
+
+func foldUnary(u *parser.Unary, env *types.Env) {
+	if u == nil {
+		return
+	}
+	foldPostfixExpr(u.Value, env)
+}
+
+func foldPostfixExpr(p *parser.PostfixExpr, env *types.Env) {
+	if p == nil {
+		return
+	}
+	foldPrimary(p.Target, env)
+	for _, op := range p.Ops {
+		if call := op.Call; call != nil {
+			for _, a := range call.Args {
+				foldExpr(a, env)
+			}
+			// Postfix call cannot be folded without a function name
+		} else if idx := op.Index; idx != nil {
+			if idx.Start != nil {
+				foldExpr(idx.Start, env)
+			}
+			if idx.End != nil {
+				foldExpr(idx.End, env)
+			}
+		}
+	}
+}
+
+func foldPrimary(p *parser.Primary, env *types.Env) {
+	if p == nil {
+		return
+	}
+	if p.Call != nil {
+		for _, a := range p.Call.Args {
+			foldExpr(a, env)
+		}
+		if lit, ok := EvalPureCall(p.Call, env); ok {
+			p.Lit = lit
+			p.Call = nil
+		}
+	} else if p.Group != nil {
+		foldExpr(p.Group, env)
+		if lit := extractLiteral(p.Group); lit != nil {
+			p.Lit = lit
+			p.Group = nil
+		}
+	} else if p.FunExpr != nil {
+		child := types.NewEnv(env)
+		if p.FunExpr.ExprBody != nil {
+			foldExpr(p.FunExpr.ExprBody, child)
+		} else {
+			for _, s := range p.FunExpr.BlockBody {
+				foldStmt(s, child)
+			}
+		}
+	}
+}
+
+func extractLiteral(e *parser.Expr) *parser.Literal {
+	if e == nil {
+		return nil
+	}
+	if len(e.Binary.Right) != 0 {
+		return nil
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return nil
+	}
+	if p.Target != nil {
+		return p.Target.Lit
+	}
+	return nil
+}

--- a/tests/compiler/valid/break_continue.ts.out
+++ b/tests/compiler/valid/break_continue.ts.out
@@ -12,11 +12,11 @@ function main(): void {
 		console.log("odd number:", n)
 	}
 }
-main()
-
 function _iter(v: any): any {
   if (v && typeof v === 'object' && !Array.isArray(v) && !(Symbol.iterator in v)) {
     return Object.keys(v);
   }
   return v;
 }
+
+main()

--- a/tests/compiler/valid/for_list_collection.ts.out
+++ b/tests/compiler/valid/for_list_collection.ts.out
@@ -5,11 +5,11 @@ function main(): void {
 		console.log(n)
 	}
 }
-main()
-
 function _iter(v: any): any {
   if (v && typeof v === 'object' && !Array.isArray(v) && !(Symbol.iterator in v)) {
     return Object.keys(v);
   }
   return v;
 }
+
+main()

--- a/tests/compiler/valid/for_string_collection.ts.out
+++ b/tests/compiler/valid/for_string_collection.ts.out
@@ -5,11 +5,11 @@ function main(): void {
 		console.log(ch)
 	}
 }
-main()
-
 function _iter(v: any): any {
   if (v && typeof v === 'object' && !Array.isArray(v) && !(Symbol.iterator in v)) {
     return Object.keys(v);
   }
   return v;
 }
+
+main()

--- a/tests/compiler/valid/generate_echo.ts.out
+++ b/tests/compiler/valid/generate_echo.ts.out
@@ -4,9 +4,9 @@ function main(): void {
 	let poem = _gen_text("echo hello")
 	console.log(poem)
 }
-main()
-
 function _gen_text(prompt: string): string {
   // TODO: integrate with your preferred LLM
   return prompt;
 }
+
+main()

--- a/tests/compiler/valid/generate_embedding.ts.out
+++ b/tests/compiler/valid/generate_embedding.ts.out
@@ -4,8 +4,6 @@ function main(): void {
 	let vec = _gen_embed("hi")
 	console.log(_len(vec))
 }
-main()
-
 function _gen_embed(text: string): number[] {
   // TODO: integrate with your preferred embedding model
   return Array.from(text).map(c => c.charCodeAt(0));
@@ -16,3 +14,5 @@ function _len(v: any): number {
   if (v && typeof v === "object") return Object.keys(v).length;
   return 0;
 }
+
+main()

--- a/tests/compiler/valid/len_builtin.ts.out
+++ b/tests/compiler/valid/len_builtin.ts.out
@@ -3,10 +3,10 @@
 function main(): void {
 	console.log(_len([1, 2, 3]))
 }
-main()
-
 function _len(v: any): number {
   if (Array.isArray(v) || typeof v === "string") return (v as any).length;
   if (v && typeof v === "object") return Object.keys(v).length;
   return 0;
 }
+
+main()

--- a/tests/compiler/valid/stream_on_emit.ts.out
+++ b/tests/compiler/valid/stream_on_emit.ts.out
@@ -14,9 +14,6 @@ async function main(): Promise<void> {
 	sensorStream.register(_handler_0)
 	sensorStream.append({id: "sensor-1", temperature: 22.500000})
 }
-await main()
-await _waitAll()
-
 class Stream {
   name: string;
   handlers: Array<(data: any) => any | Promise<any>> = [];
@@ -41,3 +38,6 @@ const _pending: Promise<any>[] = [];
 async function _waitAll(): Promise<void> {
   await Promise.all(_pending);
 }
+
+await main()
+await _waitAll()

--- a/tests/compiler/valid/two_sum.ts.out
+++ b/tests/compiler/valid/two_sum.ts.out
@@ -17,10 +17,10 @@ function main(): void {
 	console.log(result[0])
 	console.log(result[1])
 }
-main()
-
 function _len(v: any): number {
   if (Array.isArray(v) || typeof v === "string") return (v as any).length;
   if (v && typeof v === "object") return Object.keys(v).length;
   return 0;
 }
+
+main()


### PR DESCRIPTION
## Summary
- add `FoldPureCalls` for ahead-of-time constant folding
- expose folding via `--aot` flag in CLI and use it in benchmarks
- move TS runtime helpers before program execution
- update test outputs for new TypeScript layout

## Testing
- `go test ./compile/ts -update`
- `go test ./...`
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_68464444e6f88320a65863d87dc55eac