### PR TITLE
Add Dart compiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ mochi run examples/hello.mochi
 mochi test examples/math.mochi
 mochi build examples/hello.mochi -o hello
 mochi build --target py examples/hello.mochi -o hello.py
+mochi build --target dart examples/hello.mochi -o hello.dart
 mochi cheatsheet
 ```
 

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -21,6 +21,7 @@ import (
 	_ "mochi/runtime/llm/provider/echo"
 
 	"mochi/ast"
+	"mochi/compile/dart"
 	"mochi/compile/go"
 	"mochi/compile/py"
 	"mochi/compile/ts"
@@ -66,7 +67,7 @@ type TestCmd struct {
 type BuildCmd struct {
 	File   string `arg:"positional,required" help:"Path to .mochi source file"`
 	Out    string `arg:"-o" help:"Output file path"`
-	Target string `arg:"--target" help:"Output language (go|py|ts)"`
+	Target string `arg:"--target" help:"Output language (go|py|ts|dart)"`
 }
 
 type ReplCmd struct{}
@@ -222,6 +223,8 @@ func build(cmd *BuildCmd) error {
 			target = "py"
 		case ".ts":
 			target = "ts"
+		case ".dart":
+			target = "dart"
 		}
 	}
 
@@ -273,6 +276,18 @@ func build(cmd *BuildCmd) error {
 			out = base + ".ts"
 		}
 		code, err := tscode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "dart":
+		if out == "" {
+			out = base + ".dart"
+		}
+		code, err := dartcode.New(env).Compile(prog)
 		if err == nil {
 			err = os.WriteFile(out, code, 0644)
 		}

--- a/compile/dart/compiler.go
+++ b/compile/dart/compiler.go
@@ -1,0 +1,48 @@
+package dartcode
+
+import (
+	"regexp"
+	"strings"
+
+	tscode "mochi/compile/ts"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler translates a Mochi AST into Dart source code. The implementation
+// reuses the TypeScript compiler and then performs a best-effort conversion of
+// the generated TypeScript code into Dart syntax.
+type Compiler struct {
+	ts *tscode.Compiler
+}
+
+// New creates a new Dart compiler instance.
+func New(env *types.Env) *Compiler {
+	return &Compiler{ts: tscode.New(env)}
+}
+
+// Compile returns Dart source code implementing prog.
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	code, err := c.ts.Compile(prog)
+	if err != nil {
+		return nil, err
+	}
+	src := string(code)
+	src = strings.ReplaceAll(src, "Mochi TypeScript compiler", "Mochi Dart compiler")
+	src = strings.ReplaceAll(src, "console.log", "print")
+	src = strings.ReplaceAll(src, "let ", "var ")
+	src = strings.ReplaceAll(src, "const ", "var ")
+	src = strings.ReplaceAll(src, " of ", " in ")
+	src = strings.ReplaceAll(src, ": any", "")
+	src = strings.ReplaceAll(src, ": number", "")
+	src = strings.ReplaceAll(src, ": string", "")
+	src = strings.ReplaceAll(src, ": boolean", "")
+
+	funcRe := regexp.MustCompile(`function ([a-zA-Z_][A-Za-z0-9_]*)\(([^)]*)\)(: [^ {]+)? {`)
+	src = funcRe.ReplaceAllString(src, "dynamic $1($2) {")
+
+	src = strings.ReplaceAll(src, "async function main(): Promise<void> {", "Future<void> main() async {")
+	src = strings.ReplaceAll(src, "function main(): void {", "void main() {")
+	src = strings.ReplaceAll(src, "await main()", "await main()")
+	return []byte(src), nil
+}

--- a/docs/guides/using-mochi.md
+++ b/docs/guides/using-mochi.md
@@ -74,6 +74,7 @@ mochi run examples/hello.mochi
 mochi test examples/math.mochi
 mochi build examples/hello.mochi -o hello
 mochi build --target py examples/hello.mochi -o hello.py
+mochi build --target dart examples/hello.mochi -o hello.dart
 mochi cheatsheet
 ```
 


### PR DESCRIPTION
## Summary
- implement new `dartcode` compiler that converts TypeScript output to Dart
- allow `mochi build` to target `dart`
- document Dart usage in README and guides

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68465484e9fc8320a80dd44d5245dcc7