### PR TITLE
Add experimental C compiler

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -21,6 +21,7 @@ import (
 	_ "mochi/runtime/llm/provider/echo"
 
 	"mochi/ast"
+	ccode "mochi/compile/c"
 	"mochi/compile/go"
 	"mochi/compile/py"
 	"mochi/compile/ts"
@@ -273,6 +274,18 @@ func build(cmd *BuildCmd) error {
 			out = base + ".ts"
 		}
 		code, err := tscode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "c":
+		if out == "" {
+			out = base + ".c"
+		}
+		code, err := ccode.New(env).Compile(prog)
 		if err == nil {
 			err = os.WriteFile(out, code, 0644)
 		}

--- a/compile/c/compiler.go
+++ b/compile/c/compiler.go
@@ -1,0 +1,214 @@
+package ccode
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler translates a Mochi AST into minimal C source code.
+type Compiler struct {
+	buf    bytes.Buffer
+	indent int
+	env    *types.Env
+}
+
+// New creates a new C compiler instance.
+func New(env *types.Env) *Compiler {
+	return &Compiler{env: env}
+}
+
+// Compile returns C source code implementing prog. Only a very small
+// subset of Mochi is supported.
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	c.writeln("#include <stdio.h>")
+	c.writeln("")
+	c.writeln("int main() {")
+	c.indent++
+	for _, stmt := range prog.Statements {
+		if err := c.compileStmt(stmt); err != nil {
+			return nil, err
+		}
+	}
+	c.writeln("return 0;")
+	c.indent--
+	c.writeln("}")
+	return c.buf.Bytes(), nil
+}
+
+func (c *Compiler) compileStmt(s *parser.Statement) error {
+	switch {
+	case s.Let != nil:
+		return c.compileLet(s.Let)
+	case s.Expr != nil:
+		expr, err := c.compileExpr(s.Expr.Expr)
+		if err != nil {
+			return err
+		}
+		c.writeln(expr + ";")
+		return nil
+	default:
+		return fmt.Errorf("unsupported statement")
+	}
+}
+
+func (c *Compiler) compileLet(s *parser.LetStmt) error {
+	typ := "int"
+	if s.Type != nil && s.Type.Simple != nil {
+		switch *s.Type.Simple {
+		case "int":
+			typ = "int"
+		case "float":
+			typ = "double"
+		case "string":
+			typ = "const char*"
+		default:
+			return fmt.Errorf("unsupported type %s", *s.Type.Simple)
+		}
+	}
+	val := "0"
+	if s.Value != nil {
+		v, err := c.compileExpr(s.Value)
+		if err != nil {
+			return err
+		}
+		val = v
+	}
+	c.writeln(fmt.Sprintf("%s %s = %s;", typ, s.Name, val))
+	return nil
+}
+
+func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
+	return c.compileBinaryExpr(e.Binary)
+}
+
+func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
+	expr, err := c.compileUnary(b.Left)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range b.Right {
+		r, err := c.compilePostfix(op.Right)
+		if err != nil {
+			return "", err
+		}
+		expr = fmt.Sprintf("(%s %s %s)", expr, op.Op, r)
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
+	val, err := c.compilePostfix(u.Value)
+	if err != nil {
+		return "", err
+	}
+	for i := len(u.Ops) - 1; i >= 0; i-- {
+		val = fmt.Sprintf("(%s%s)", u.Ops[i], val)
+	}
+	return val, nil
+}
+
+func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
+	expr, err := c.compilePrimary(p.Target)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range p.Ops {
+		if op.Call != nil {
+			callExpr, err := c.compileCallExpr(expr, op.Call)
+			if err != nil {
+				return "", err
+			}
+			expr = callExpr
+			continue
+		}
+		return "", fmt.Errorf("unsupported postfix expression")
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compileCallExpr(name string, call *parser.CallOp) (string, error) {
+	if name == "print" {
+		args := make([]string, len(call.Args))
+		for i, a := range call.Args {
+			v, err := c.compileExpr(a)
+			if err != nil {
+				return "", err
+			}
+			args[i] = v
+		}
+		if len(args) == 1 {
+			return fmt.Sprintf("printf(\"%s\\n\", %s)", "%s", args[0]), nil
+		}
+		format := strings.TrimSpace(strings.Repeat("%s ", len(args)))
+		return fmt.Sprintf("printf(\"%s\\n\", %s)", format, strings.Join(args, ", ")), nil
+	}
+	return "", fmt.Errorf("unsupported call to %s", name)
+}
+
+func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
+	switch {
+	case p.Lit != nil:
+		return c.compileLiteral(p.Lit)
+	case p.Call != nil:
+		return c.compileNamedCall(p.Call)
+	case p.Group != nil:
+		v, err := c.compileExpr(p.Group)
+		if err != nil {
+			return "", err
+		}
+		return "(" + v + ")", nil
+	default:
+		return "", fmt.Errorf("unsupported expression")
+	}
+}
+
+func (c *Compiler) compileNamedCall(call *parser.CallExpr) (string, error) {
+	args := make([]string, len(call.Args))
+	for i, a := range call.Args {
+		v, err := c.compileExpr(a)
+		if err != nil {
+			return "", err
+		}
+		args[i] = v
+	}
+	switch call.Func {
+	case "print":
+		if len(args) == 1 {
+			return fmt.Sprintf("printf(\"%s\\n\", %s)", "%s", args[0]), nil
+		}
+		format := strings.TrimSpace(strings.Repeat("%s ", len(args)))
+		return fmt.Sprintf("printf(\"%s\\n\", %s)", format, strings.Join(args, ", ")), nil
+	default:
+		return "", fmt.Errorf("unsupported function %s", call.Func)
+	}
+}
+
+func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
+	switch {
+	case l.Int != nil:
+		return fmt.Sprintf("%d", *l.Int), nil
+	case l.Float != nil:
+		return fmt.Sprintf("%f", *l.Float), nil
+	case l.Str != nil:
+		return fmt.Sprintf("\"%s\"", *l.Str), nil
+	case l.Bool != nil:
+		if bool(*l.Bool) {
+			return "1", nil
+		}
+		return "0", nil
+	default:
+		return "", fmt.Errorf("unknown literal")
+	}
+}
+
+func (c *Compiler) writeln(s string) {
+	for i := 0; i < c.indent; i++ {
+		c.buf.WriteString("    ")
+	}
+	c.buf.WriteString(s)
+	c.buf.WriteByte('\n')
+}

--- a/compile/c/compiler_test.go
+++ b/compile/c/compiler_test.go
@@ -1,0 +1,50 @@
+package ccode_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	ccode "mochi/compile/c"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestBasic ensures the C compiler can compile a trivial program and run it using gcc.
+func TestBasic(t *testing.T) {
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("gcc not installed")
+	}
+	src := "print(\"hi\")"
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := ccode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	tmp := t.TempDir()
+	srcFile := tmp + "/main.c"
+	if err := os.WriteFile(srcFile, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	exeFile := tmp + "/a.out"
+	cmd := exec.Command("gcc", srcFile, "-o", exeFile)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("gcc failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command(exeFile).CombinedOutput()
+	if err != nil {
+		t.Fatalf("program failed: %v\n%s", err, out)
+	}
+	got := string(out)
+	if got != "hi\n" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce a minimal Mochi to C compiler
- allow `mochi build` to emit `.c` output via new `c` target
- test the C compiler with a trivial program

## Testing
- `go test ./compile/c -run TestBasic -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684655441c98832092a0032ed19d4e55