### PR TITLE
Update docs for v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🍡 Mochi Programming Language
 
+**Current Version: v0.5.0**
+
 **Mochi** is a small, statically typed programming language built for clarity, safety, and expressiveness — whether you're writing tools, processing real-time data, or powering intelligent agents.
 
 Mochi is:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ minimal but expressive.
 This roadmap outlines the language development toward a stable 1.0, with an emphasis on first-class data types, control
 flow, streaming logic, agents, and dataset support.
 
-Current release: v0.3.5. Upcoming 0.3.x versions will focus on generative AI.
+Current release: v0.5.0.
 
 # v0.3.x – Generative AI
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Mochi Programming Language Specification (v0.3.5)
+# Mochi Programming Language Specification (v0.5.0)
 
-This document describes version 0.3.5 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
+This document describes version 0.5.0 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
 
 ## 0. Introduction
 
@@ -532,4 +532,4 @@ GenericType   = Identifier "<" TypeRef { "," TypeRef } ">" .
 FunType       = "fun" "(" [ TypeRef { "," TypeRef } ] ")" [ ":" TypeRef ] .
 ```
 
-This specification outlines the core language as of version 0.3.5. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.
+This specification outlines the core language as of version 0.5.0. Future versions may introduce modules, user-defined types, pattern matching, and asynchronous operations while preserving backward compatibility.


### PR DESCRIPTION
## Summary
- update README with version badge
- bump SPEC to v0.5.0
- note v0.5.0 as current release in ROADMAP

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6846c21db9788320ae213bca6ab5bede