### PR TITLE
Add dataset query syntax

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -369,6 +369,15 @@ func FromPrimary(p *parser.Primary) *Node {
 		}
 		return n
 
+	case p.Query != nil:
+		n := &Node{Kind: "query", Value: p.Query.Var}
+		n.Children = append(n.Children, &Node{Kind: "source", Children: []*Node{FromExpr(p.Query.Source)}})
+		if p.Query.Where != nil {
+			n.Children = append(n.Children, &Node{Kind: "where", Children: []*Node{FromExpr(p.Query.Where)}})
+		}
+		n.Children = append(n.Children, &Node{Kind: "select", Children: []*Node{FromExpr(p.Query.Select)}})
+		return n
+
 	case p.Match != nil:
 		n := &Node{Kind: "match"}
 		n.Children = append(n.Children, FromExpr(p.Match.Target))

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -294,6 +294,14 @@ type FetchExpr struct {
 	With *Expr `parser:"[ 'with' @@ ]"`
 }
 
+type QueryExpr struct {
+	Pos    lexer.Position
+	Var    string `parser:"'from' @Ident 'in'"`
+	Source *Expr  `parser:"@@"`
+	Where  *Expr  `parser:"[ 'where' @@ ]"`
+	Select *Expr  `parser:"'select' @@"`
+}
+
 type MatchExpr struct {
 	Pos    lexer.Position
 	Target *Expr        `parser:"'match' @@ '{'"`
@@ -311,6 +319,7 @@ type Primary struct {
 	FunExpr  *FunExpr       `parser:"@@"`
 	Struct   *StructLiteral `parser:"| @@"`
 	Call     *CallExpr      `parser:"| @@"`
+	Query    *QueryExpr     `parser:"| @@"`
 	Selector *SelectorExpr  `parser:"| @@"`
 	List     *ListLiteral   `parser:"| @@"`
 	Map      *MapLiteral    `parser:"| @@"`

--- a/tests/parser/valid/dataset.golden
+++ b/tests/parser/valid/dataset.golden
@@ -1,0 +1,69 @@
+(program
+  (let people
+    (list
+      (map
+        (entry (selector name) (string Alice))
+        (entry (selector age) (int 30))
+      )
+      (map
+        (entry (selector name) (string Bob))
+        (entry (selector age) (int 15))
+      )
+      (map
+        (entry (selector name) (string Charlie))
+        (entry (selector age) (int 65))
+      )
+      (map
+        (entry (selector name) (string Diana))
+        (entry (selector age) (int 45))
+      )
+    )
+  )
+  (let adults
+    (query person
+      (source (selector people))
+      (where
+        (binary >=
+          (selector age (selector person))
+          (int 18)
+        )
+      )
+      (select
+        (map
+          (entry
+            (selector name)
+            (selector name (selector person))
+          )
+          (entry
+            (selector age)
+            (selector age (selector person))
+          )
+          (entry
+            (selector is_senior)
+            (binary >=
+              (selector age (selector person))
+              (int 60)
+            )
+          )
+        )
+      )
+    )
+  )
+  (for person
+    (in (selector adults))
+    (block
+      (call print
+        (selector name (selector person))
+        (string is)
+        (selector age (selector person))
+        (string "years old.")
+      )
+      (if
+        (selector is_senior (selector person))
+        (block
+          (call print (string " (senior)"))
+        )
+      )
+    )
+  )
+)

--- a/tests/parser/valid/dataset.mochi
+++ b/tests/parser/valid/dataset.mochi
@@ -1,0 +1,24 @@
+// dataset.mochi
+// Define an in-memory dataset using a list of records.
+
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 },
+  { name: "Diana", age: 45 }
+]
+
+let adults = from person in people
+             where person.age >= 18
+             select {
+               name: person.name,
+               age: person.age,
+               is_senior: person.age >= 60
+             }
+
+for person in adults {
+  print(person.name, "is", person.age, "years old.")
+  if person.is_senior {
+    print(" (senior)")
+  }
+}


### PR DESCRIPTION
## Summary
- extend parser with `QueryExpr` to parse dataset queries
- convert `QueryExpr` nodes to AST
- add dataset example and golden output for parser tests

## Testing
- `go test ./parser -run ValidPrograms/dataset -update`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684726205bb08320bf322dbe0df9d580