### PR TITLE
Add query comprehension example and interpreter support

### DIFF
--- a/examples/v0.6/dataset.mochi
+++ b/examples/v0.6/dataset.mochi
@@ -1,0 +1,22 @@
+// dataset.mochi
+// Define an in-memory dataset using a list of records.
+
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 },
+  { name: "Diana", age: 45 }
+]
+
+let adults = from person in people
+             where person.age >= 18
+             select {
+               name: person.name,
+               age: person.age,
+               is_senior: person.age >= 60
+             }
+
+for person in adults {
+  print(person.name, "is", person.age, "years old.",
+        if person.is_senior { " (senior)" } else { "" })
+}


### PR DESCRIPTION
## Summary
- add a new dataset example for v0.6
- support `from ... where ... select ...` query expressions in the interpreter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684728d2974c8320aadea06a26b94b49