### PR TITLE
Fix diagnostic help placeholders

### DIFF
--- a/llm/llm.latest.md
+++ b/llm/llm.latest.md
@@ -2119,8 +2119,9 @@ func curryFuncType(params []Type, ret Type) Type {
 package types
 
 import (
-	"github.com/alecthomas/participle/v2/lexer"
-	"mochi/diagnostic"
+        "fmt"
+        "github.com/alecthomas/participle/v2/lexer"
+        "mochi/diagnostic"
 )
 
 var Errors = map[string]diagnostic.Template{
@@ -2169,7 +2170,10 @@ func errLetMissingTypeOrValue(pos lexer.Position) error {
 }
 
 func errAssignUndeclared(pos lexer.Position, name string) error {
-	return Errors["T001"].New(pos, name)
+        tmpl := Errors["T001"]
+        msg := fmt.Sprintf(tmpl.Message, name)
+        help := fmt.Sprintf(tmpl.Help, name)
+        return diagnostic.New(tmpl.Code, pos, msg, help)
 }
 
 func errUnknownVariable(pos lexer.Position, name string) error {
@@ -2201,7 +2205,10 @@ func errTypeMismatch(pos lexer.Position, expected, actual Type) error {
 }
 
 func errCannotAssign(pos lexer.Position, rhs Type, lhsName string, lhs Type) error {
-	return Errors["T009"].New(pos, rhs, lhsName, lhs)
+        tmpl := Errors["T009"]
+        msg := fmt.Sprintf(tmpl.Message, rhs, lhsName, lhs)
+        help := fmt.Sprintf(tmpl.Help, lhsName)
+        return diagnostic.New(tmpl.Code, pos, msg, help)
 }
 
 func errReturnMismatch(pos lexer.Position, expected, actual Type) error {

--- a/tests/types/errors/assign_type_mismatch.err
+++ b/tests/types/errors/assign_type_mismatch.err
@@ -5,4 +5,4 @@
     | ^
 
 help:
-  Make sure the assigned value is compatible with `%s`.
+  Make sure the assigned value is compatible with `x`.

--- a/tests/types/errors/assign_undeclared_var.err
+++ b/tests/types/errors/assign_undeclared_var.err
@@ -5,4 +5,4 @@
     | ^
 
 help:
-  Declare `%s` first using `let`.
+  Declare `x` first using `let`.

--- a/types/errors.go
+++ b/types/errors.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"github.com/alecthomas/participle/v2/lexer"
 	"mochi/diagnostic"
 )
@@ -58,7 +59,10 @@ func errLetMissingTypeOrValue(pos lexer.Position) error {
 }
 
 func errAssignUndeclared(pos lexer.Position, name string) error {
-	return Errors["T001"].New(pos, name)
+	tmpl := Errors["T001"]
+	msg := fmt.Sprintf(tmpl.Message, name)
+	help := fmt.Sprintf(tmpl.Help, name)
+	return diagnostic.New(tmpl.Code, pos, msg, help)
 }
 
 func errUnknownVariable(pos lexer.Position, name string) error {
@@ -90,7 +94,10 @@ func errTypeMismatch(pos lexer.Position, expected, actual Type) error {
 }
 
 func errCannotAssign(pos lexer.Position, rhs Type, lhsName string, lhs Type) error {
-	return Errors["T009"].New(pos, rhs, lhsName, lhs)
+	tmpl := Errors["T009"]
+	msg := fmt.Sprintf(tmpl.Message, rhs, lhsName, lhs)
+	help := fmt.Sprintf(tmpl.Help, lhsName)
+	return diagnostic.New(tmpl.Code, pos, msg, help)
 }
 
 func errReturnMismatch(pos lexer.Position, expected, actual Type) error {


### PR DESCRIPTION
## Summary
- show variable names in help text for T001 and T009 errors
- update tests
- regenerate llm snapshot

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68472d0529b8832088b5e7a17817131b