### PR TITLE
Add dataset support to Go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -42,10 +42,55 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		}
 		return bytes.TrimSpace(out), nil
 	})
+
+	golden.Run(t, "tests/compiler/go", ".mochi", ".out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("❌ parse error: %w", err)
+		}
+		typeEnv := types.NewEnv(nil)
+		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
+			return nil, fmt.Errorf("❌ type error: %v", errs[0])
+		}
+		c := gocode.New(typeEnv)
+		code, err := c.Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("❌ compile error: %w", err)
+		}
+		dir := t.TempDir()
+		file := filepath.Join(dir, "main.go")
+		if err := os.WriteFile(file, code, 0644); err != nil {
+			return nil, fmt.Errorf("write error: %w", err)
+		}
+		cmd := exec.Command("go", "run", file)
+		cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("❌ go run error: %w\n%s", err, out)
+		}
+		return bytes.TrimSpace(out), nil
+	})
 }
 
 func TestGoCompiler_GoldenOutput(t *testing.T) {
 	golden.Run(t, "tests/compiler/valid", ".mochi", ".go.out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("❌ parse error: %w", err)
+		}
+		typeEnv := types.NewEnv(nil)
+		if errs := types.Check(prog, typeEnv); len(errs) > 0 {
+			return nil, fmt.Errorf("❌ type error: %v", errs[0])
+		}
+		c := gocode.New(typeEnv)
+		code, err := c.Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("❌ compile error: %w", err)
+		}
+		return bytes.TrimSpace(code), nil
+	})
+
+	golden.Run(t, "tests/compiler/go", ".mochi", ".go.out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
 			return nil, fmt.Errorf("❌ parse error: %w", err)

--- a/tests/compiler/go/dataset.go.out
+++ b/tests/compiler/go/dataset.go.out
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+)
+
+type Person struct {
+	Name string `json:"name"`
+	Age int `json:"age"`
+}
+
+func main() {
+	var people []Person = []Person{Person{Name: "Alice", Age: 30}, Person{Name: "Bob", Age: 15}, Person{Name: "Charlie", Age: 65}}
+	var names []string = func() []string {
+	res := []string{}
+	for _, p := range people {
+		if (p.Age >= 18) {
+			res = append(res, p.Name)
+		}
+	}
+	return res
+}()
+	for _, n := range names {
+		fmt.Println(n)
+	}
+}

--- a/tests/compiler/go/dataset.mochi
+++ b/tests/compiler/go/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/go/dataset.out
+++ b/tests/compiler/go/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie


### PR DESCRIPTION
## Summary
- add QueryExpr handling in Go compiler
- infer struct field types in selectors
- run dataset golden tests for Go compiler
- include dataset example tests for Go code generation

## Testing
- `go test ./compile/go -run TestGoCompiler_GoldenOutput -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847354add9c832091a536c9ed7298d3