### PR TITLE
Update docs for dataset queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,27 @@ for ch in text {
 }
 ```
 
+### Dataset Queries
+
+Query lists with SQL-like syntax using `from`, `where`, `sort by`, `skip`, `take` and `select`.
+
+```mochi
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 },
+  { name: "Diana", age: 45 }
+]
+
+let adults = from p in people
+             where p.age >= 18
+             select { name: p.name, age: p.age }
+
+for a in adults {
+  print(a.name, "is", a.age)
+}
+```
+
 ### Tests
 
 ```mochi

--- a/SPEC.md
+++ b/SPEC.md
@@ -443,6 +443,21 @@ let created: Todo = fetch "https://example.com/todos" with {
 }
 ```
 
+### Dataset Queries
+
+`from` expressions iterate over lists with optional filtering, sorting and projection.
+
+```mochi
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+```
+
 ## 6. Functions
 
 Functions are first-class. Parameters are typed, and the return type may be omitted in block-bodied functions if `return` is used. Functions may capture variables from their enclosing scope, forming closures.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -6,6 +6,7 @@ This section outlines each major feature of the Mochi programming language. Each
 - [Control Flow](control-flow.md) covers conditionals, loops and pattern matching.
 - [Functions](functions.md) explains named and anonymous functions plus recursion.
 - [Collections](collections.md) details built-in lists, maps and sets.
+- [Dataset Queries](datasets.md) shows SQL-like queries over lists.
 - [Tests](tests.md) shows the lightweight test framework.
 - [Generative AI](generative-ai.md) demonstrates calling large language models.
 - [HTTP Fetch](http-fetch.md) describes retrieving JSON over the network.

--- a/docs/features/datasets.md
+++ b/docs/features/datasets.md
@@ -1,0 +1,49 @@
+## Dataset Queries
+
+`from` expressions treat lists as simple datasets. Combine optional `where`, `sort by`, `skip`, `take` and `select` clauses to shape the result.
+
+```mochi
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 },
+  { name: "Diana", age: 45 }
+]
+
+let adults = from person in people
+             where person.age >= 18
+             select {
+               name: person.name,
+               age: person.age,
+               is_senior: person.age >= 60
+             }
+
+for person in adults {
+  print(person.name, "is", person.age,
+        if person.is_senior { " (senior)" } else { "" })
+}
+```
+
+Queries can also sort records and limit the results:
+
+```mochi
+let products = [
+  { name: "Laptop", price: 1500 },
+  { name: "Smartphone", price: 900 },
+  { name: "Tablet", price: 600 },
+  { name: "Monitor", price: 300 },
+  { name: "Keyboard", price: 100 },
+  { name: "Mouse", price: 50 },
+  { name: "Headphones", price: 200 }
+]
+
+let top = from p in products
+          sort by -p.price
+          skip 1
+          take 3
+          select p
+
+for item in top {
+  print(item.name, "costs $", item.price)
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ The language overview is split into individual topics for easy navigation:
 - [Control Flow](features/control-flow.md)
 - [Functions](features/functions.md)
 - [Collections](features/collections.md)
+- [Dataset Queries](features/datasets.md)
 - [Tests](features/tests.md)
 - [Generative AI](features/generative-ai.md)
 - [HTTP Fetch](features/http-fetch.md)

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -182,7 +182,19 @@ type Circle {
 let c = Circle { radius: 5 }
 print(c.area())
 
-// 11. HTTP Fetch
+// 11. Dataset Queries
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 }
+]
+
+let adults = from p in people
+             where p.age >= 18
+             select p.name
+print(adults)
+
+// 12. HTTP Fetch
 
 type Todo {
   userId: int
@@ -200,7 +212,7 @@ let created: Todo = fetch "https://example.com/todos" with {
 }
 print(created.id)
 
-// 12. Streams
+// 13. Streams
 
 stream Sensor {
   id: string
@@ -213,7 +225,7 @@ on Sensor as r {
 
 emit Sensor { id: "s1", temperature: 21.3 }
 
-// 13. Agents
+// 14. Agents
 agent Monitor {
   var count: int = 0
 


### PR DESCRIPTION
## Summary
- document dataset query syntax in README
- add dataset features page and link it from docs
- update spec with dataset query section
- expand cheatsheet with dataset query example and renumber sections

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68478ba1b1648320beb9b61a07977ab8