### PR TITLE
Add dataset parser and runtime tests

### DIFF
--- a/tests/interpreter/errors/dataset_skip_non_int.err
+++ b/tests/interpreter/errors/dataset_skip_non_int.err
@@ -1,0 +1,1 @@
+skip expects int, got string

--- a/tests/interpreter/errors/dataset_skip_non_int.mochi
+++ b/tests/interpreter/errors/dataset_skip_non_int.mochi
@@ -1,0 +1,3 @@
+let xs = [1,2,3]
+let result = from x in xs skip "two" select x
+print(result)

--- a/tests/interpreter/errors/dataset_take_non_int.err
+++ b/tests/interpreter/errors/dataset_take_non_int.err
@@ -1,0 +1,1 @@
+take expects int, got string

--- a/tests/interpreter/errors/dataset_take_non_int.mochi
+++ b/tests/interpreter/errors/dataset_take_non_int.mochi
@@ -1,0 +1,3 @@
+let xs = [1,2,3]
+let result = from x in xs take "two" select x
+print(result)

--- a/tests/interpreter/valid/dataset.mochi
+++ b/tests/interpreter/valid/dataset.mochi
@@ -1,0 +1,24 @@
+// dataset.mochi
+// Define an in-memory dataset using a list of records.
+
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 },
+  { name: "Diana", age: 45 }
+]
+
+let adults = from person in people
+             where person.age >= 18
+             select {
+               name: person.name,
+               age: person.age,
+               is_senior: person.age >= 60
+             }
+
+for person in adults {
+  print(person.name, "is", person.age, "years old.")
+  if person.is_senior {
+    print(" (senior)")
+  }
+}

--- a/tests/interpreter/valid/dataset.out
+++ b/tests/interpreter/valid/dataset.out
@@ -1,0 +1,4 @@
+Alice is 30 years old.
+Charlie is 65 years old.
+(senior)
+Diana is 45 years old.

--- a/tests/parser/errors/dataset_unterminated_list.err
+++ b/tests/parser/errors/dataset_unterminated_list.err
@@ -1,0 +1,5 @@
+error[P999]: tests/parser/errors/dataset_unterminated_list.mochi:2:1: unexpected token "<EOF>" (expected "]")
+  --> tests/parser/errors/dataset_unterminated_list.mochi:2:1
+
+help:
+  Parse error occurred. Check syntax near this location.

--- a/tests/parser/errors/dataset_unterminated_list.mochi
+++ b/tests/parser/errors/dataset_unterminated_list.mochi
@@ -1,0 +1,1 @@
+let result = from x in [1, 2, 3

--- a/tests/parser/valid/dataset_group_by.golden
+++ b/tests/parser/valid/dataset_group_by.golden
@@ -1,0 +1,77 @@
+(program
+  (let people
+    (list
+      (map
+        (entry (selector name) (string Alice))
+        (entry (selector age) (int 30))
+        (entry (selector city) (string Paris))
+      )
+      (map
+        (entry (selector name) (string Bob))
+        (entry (selector age) (int 15))
+        (entry (selector city) (string Hanoi))
+      )
+      (map
+        (entry (selector name) (string Charlie))
+        (entry (selector age) (int 65))
+        (entry (selector city) (string Paris))
+      )
+      (map
+        (entry (selector name) (string Diana))
+        (entry (selector age) (int 45))
+        (entry (selector city) (string Hanoi))
+      )
+      (map
+        (entry (selector name) (string Eve))
+        (entry (selector age) (int 70))
+        (entry (selector city) (string Paris))
+      )
+      (map
+        (entry (selector name) (string Frank))
+        (entry (selector age) (int 22))
+        (entry (selector city) (string Hanoi))
+      )
+    )
+  )
+  (let stats
+    (query person
+      (source (selector people))
+      (select
+        (map
+          (entry
+            (selector city)
+            (selector key (selector g))
+          )
+          (entry
+            (selector count)
+            (call count (selector g))
+          )
+          (entry
+            (selector avg_age)
+            (call avg
+              (query p
+                (source (selector g))
+                (select
+                  (selector age (selector p))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  (call print (string "--- People grouped by city ---"))
+  (for s
+    (in (selector stats))
+    (block
+      (call print
+        (selector city (selector s))
+        (string ": count =")
+        (selector count (selector s))
+        (string ", avg_age =")
+        (selector avg_age (selector s))
+      )
+    )
+  )
+)

--- a/tests/parser/valid/dataset_group_by.mochi
+++ b/tests/parser/valid/dataset_group_by.mochi
@@ -1,0 +1,20 @@
+// group-by.mochi
+let people = [
+  { name: "Alice", age: 30, city: "Paris" },
+  { name: "Bob", age: 15, city: "Hanoi" },
+  { name: "Charlie", age: 65, city: "Paris" },
+  { name: "Diana", age: 45, city: "Hanoi" },
+  { name: "Eve", age: 70, city: "Paris" },
+  { name: "Frank", age: 22, city: "Hanoi" }
+]
+let stats = from person in people
+            group by person.city into g
+            select {
+              city: g.key,
+              count: count(g),
+              avg_age: avg(from p in g select p.age)
+            }
+print("--- People grouped by city ---")
+for s in stats {
+  print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}

--- a/tests/types/errors/dataset_where_non_bool.err
+++ b/tests/types/errors/dataset_where_non_bool.err
@@ -1,0 +1,8 @@
+1. error[T008]: type mismatch: expected bool, got int
+  --> tests/types/errors/dataset_where_non_bool.mochi:2:37
+
+  2 | let result = from p in people where 123 select p
+    |                                     ^
+
+help:
+  Change the value to match the expected type.

--- a/tests/types/errors/dataset_where_non_bool.mochi
+++ b/tests/types/errors/dataset_where_non_bool.mochi
@@ -1,0 +1,2 @@
+let people = [{ name: "Alice", age: 30 }]
+let result = from p in people where 123 select p

--- a/tests/types/valid/dataset.golden
+++ b/tests/types/valid/dataset.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/dataset.mochi
+++ b/tests/types/valid/dataset.mochi
@@ -1,0 +1,24 @@
+// dataset.mochi
+// Define an in-memory dataset using a list of records.
+
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 },
+  { name: "Diana", age: 45 }
+]
+
+let adults = from person in people
+             where person.age >= 18
+             select {
+               name: person.name,
+               age: person.age,
+               is_senior: person.age >= 60
+             }
+
+for person in adults {
+  print(person.name, "is", person.age, "years old.")
+  if person.is_senior {
+    print(" (senior)")
+  }
+}

--- a/tests/types/valid/dataset_sort_take_limit.golden
+++ b/tests/types/valid/dataset_sort_take_limit.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/dataset_sort_take_limit.mochi
+++ b/tests/types/valid/dataset_sort_take_limit.mochi
@@ -1,0 +1,24 @@
+// dataset-sort-take-limit.mochi
+// Sort a dataset, skip the first few, and take a limited number of records
+
+let products = [
+  { name: "Laptop", price: 1500 },
+  { name: "Smartphone", price: 900 },
+  { name: "Tablet", price: 600 },
+  { name: "Monitor", price: 300 },
+  { name: "Keyboard", price: 100 },
+  { name: "Mouse", price: 50 },
+  { name: "Headphones", price: 200 }
+]
+
+// Sort by price descending
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/types/valid/group_by.golden
+++ b/tests/types/valid/group_by.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/group_by.mochi
+++ b/tests/types/valid/group_by.mochi
@@ -1,0 +1,20 @@
+// group-by.mochi
+let people = [
+  { name: "Alice", age: 30, city: "Paris" },
+  { name: "Bob", age: 15, city: "Hanoi" },
+  { name: "Charlie", age: 65, city: "Paris" },
+  { name: "Diana", age: 45, city: "Hanoi" },
+  { name: "Eve", age: 70, city: "Paris" },
+  { name: "Frank", age: 22, city: "Hanoi" }
+]
+let stats = from person in people
+            group by person.city into g
+            select {
+              city: g.key,
+              count: count(g),
+              avg_age: avg(from p in g select p.age)
+            }
+print("--- People grouped by city ---")
+for s in stats {
+  print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}


### PR DESCRIPTION
## Summary
- add parser golden tests for `group by`
- add parser error when dataset list isn't closed
- check dataset queries in type checker
- run dataset queries and ensure runtime errors for skip/take

## Testing
- `go test ./... --vet=off -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6847900f947c8320a8ad9fe001562995