### PR TITLE
Add dataset source validation in type checker

### DIFF
--- a/tests/types/errors/query_source_not_list.err
+++ b/tests/types/errors/query_source_not_list.err
@@ -1,0 +1,8 @@
+1. error[T032]: query source must be a list
+  --> tests/types/errors/query_source_not_list.mochi:2:9
+
+  2 | let q = from n in x select n
+    |         ^
+
+help:
+  Use a list value after `in`.

--- a/tests/types/errors/query_source_not_list.mochi
+++ b/tests/types/errors/query_source_not_list.mochi
@@ -1,0 +1,3 @@
+let x = 1
+let q = from n in x select n
+

--- a/types/check.go
+++ b/types/check.go
@@ -1497,13 +1497,15 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 	if err != nil {
 		return nil, err
 	}
-	var elemT Type = AnyType{}
-	switch t := srcT.(type) {
-	case ListType:
-		elemT = t.Elem
-	case GroupType:
-		elemT = t.Elem
-	}
+       var elemT Type
+       switch t := srcT.(type) {
+       case ListType:
+               elemT = t.Elem
+       case GroupType:
+               elemT = t.Elem
+       default:
+               return nil, errQuerySourceList(q.Pos)
+       }
 	child := NewEnv(env)
 	child.SetVar(q.Var, elemT, true)
 	if q.Where != nil {


### PR DESCRIPTION
## Summary
- validate that dataset query sources are lists or groups
- add failing golden test when query source is not a list

## Testing
- `go test ./types -run TestTypeChecker_Errors -update -count=1`
- `go test ./types -count=1`

------
https://chatgpt.com/codex/tasks/task_e_684791777c6c8320b48a4eb7305b3e59