### PR TITLE
Add join query example and parser support

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -372,6 +372,14 @@ func FromPrimary(p *parser.Primary) *Node {
 	case p.Query != nil:
 		n := &Node{Kind: "query", Value: p.Query.Var}
 		n.Children = append(n.Children, &Node{Kind: "source", Children: []*Node{FromExpr(p.Query.Source)}})
+		for _, j := range p.Query.Joins {
+			jn := &Node{Kind: "join", Value: j.Var}
+			jn.Children = append(jn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(j.Src)}})
+			if j.On != nil {
+				jn.Children = append(jn.Children, &Node{Kind: "on", Children: []*Node{FromExpr(j.On)}})
+			}
+			n.Children = append(n.Children, jn)
+		}
 		if p.Query.Where != nil {
 			n.Children = append(n.Children, &Node{Kind: "where", Children: []*Node{FromExpr(p.Query.Where)}})
 		}

--- a/examples/v0.6/join.mochi
+++ b/examples/v0.6/join.mochi
@@ -1,0 +1,29 @@
+// join.mochi
+// Join a list of orders with customers using customerId
+
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 4, total: 80 } // No matching customer
+]
+
+// Inner join: only keep orders with a matching customer
+let result = from o in orders
+             join from c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customerName: c.name,
+               total: o.total
+             }
+
+print("--- Orders with customer info ---")
+for entry in result {
+  print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -298,12 +298,20 @@ type QueryExpr struct {
 	Pos    lexer.Position
 	Var    string         `parser:"'from' @Ident 'in'"`
 	Source *Expr          `parser:"@@"`
+	Joins  []*JoinClause  `parser:"{ @@ }"`
 	Where  *Expr          `parser:"[ 'where' @@ ]"`
 	Group  *GroupByClause `parser:"[ @@ ]"`
 	Sort   *Expr          `parser:"[ 'sort' 'by' @@ ]"`
 	Skip   *Expr          `parser:"[ 'skip' @@ ]"`
 	Take   *Expr          `parser:"[ 'take' @@ ]"`
 	Select *Expr          `parser:"'select' @@"`
+}
+
+type JoinClause struct {
+	Pos lexer.Position
+	Var string `parser:"'join' 'from' @Ident 'in'"`
+	Src *Expr  `parser:"@@"`
+	On  *Expr  `parser:"'on' @@"`
 }
 
 type GroupByClause struct {

--- a/tests/parser/valid/join.golden
+++ b/tests/parser/valid/join.golden
@@ -1,0 +1,86 @@
+(program
+  (let customers
+    (list
+      (map
+        (entry (selector id) (int 1))
+        (entry (selector name) (string Alice))
+      )
+      (map
+        (entry (selector id) (int 2))
+        (entry (selector name) (string Bob))
+      )
+      (map
+        (entry (selector id) (int 3))
+        (entry (selector name) (string Charlie))
+      )
+    )
+  )
+  (let orders
+    (list
+      (map
+        (entry (selector id) (int 100))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 250))
+      )
+      (map
+        (entry (selector id) (int 101))
+        (entry (selector customerId) (int 2))
+        (entry (selector total) (int 125))
+      )
+      (map
+        (entry (selector id) (int 102))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 300))
+      )
+      (map
+        (entry (selector id) (int 103))
+        (entry (selector customerId) (int 4))
+        (entry (selector total) (int 80))
+      )
+    )
+  )
+  (let result
+    (query o
+      (source (selector orders))
+      (join c
+        (source (selector customers))
+        (on
+          (binary ==
+            (selector customerId (selector o))
+            (selector id (selector c))
+          )
+        )
+      )
+      (select
+        (map
+          (entry
+            (selector orderId)
+            (selector id (selector o))
+          )
+          (entry
+            (selector customerName)
+            (selector name (selector c))
+          )
+          (entry
+            (selector total)
+            (selector total (selector o))
+          )
+        )
+      )
+    )
+  )
+  (call print (string "--- Orders with customer info ---"))
+  (for entry
+    (in (selector result))
+    (block
+      (call print
+        (string Order)
+        (selector orderId (selector entry))
+        (string by)
+        (selector customerName (selector entry))
+        (string "- $")
+        (selector total (selector entry))
+      )
+    )
+  )
+)

--- a/tests/parser/valid/join.mochi
+++ b/tests/parser/valid/join.mochi
@@ -1,0 +1,26 @@
+// join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 4, total: 80 } // No matching customer
+]
+
+let result = from o in orders
+             join from c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customerName: c.name,
+               total: o.total
+             }
+
+print("--- Orders with customer info ---")
+for entry in result {
+  print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+}


### PR DESCRIPTION
## Summary
- add join example in examples/v0.6
- support `join` clauses in query parser
- output join nodes in AST
- add parser test for join queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68479a9e20508320b0b78da1c9e5df49