### PR TITLE
Add dataset join type checks and tests

### DIFF
--- a/tests/types/errors/join_on_not_bool.err
+++ b/tests/types/errors/join_on_not_bool.err
@@ -1,0 +1,8 @@
+1. error[T035]: `on` condition must be boolean
+  --> tests/types/errors/join_on_not_bool.mochi:4:29
+
+  4 |         join from y in b on x.id
+    |                             ^
+
+help:
+  Ensure the condition evaluates to true or false.

--- a/tests/types/errors/join_on_not_bool.mochi
+++ b/tests/types/errors/join_on_not_bool.mochi
@@ -1,0 +1,5 @@
+let a = [ { id: 1 }, { id: 2 } ]
+let b = [ { id: 1 }, { id: 2 } ]
+let r = from x in a
+        join from y in b on x.id
+        select x

--- a/tests/types/errors/join_source_not_list.err
+++ b/tests/types/errors/join_source_not_list.err
@@ -1,0 +1,8 @@
+1. error[T034]: join source must be a list
+  --> tests/types/errors/join_source_not_list.mochi:3:14
+
+  3 |              join from y in m on true
+    |              ^
+
+help:
+  Use a list value after `in`.

--- a/tests/types/errors/join_source_not_list.mochi
+++ b/tests/types/errors/join_source_not_list.mochi
@@ -1,0 +1,4 @@
+let m = { a: 1 }
+let result = from x in [1]
+             join from y in m on true
+             select y

--- a/tests/types/valid/join_basic.golden
+++ b/tests/types/valid/join_basic.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/join_basic.mochi
+++ b/tests/types/valid/join_basic.mochi
@@ -1,0 +1,16 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 }
+]
+
+let result = from o in orders
+             join from c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customerName: c.name
+             }

--- a/tests/types/valid/join_multi.golden
+++ b/tests/types/valid/join_multi.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/join_multi.mochi
+++ b/tests/types/valid/join_multi.mochi
@@ -1,0 +1,19 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+
+let orders = [
+  { id: 100, customerId: 1 },
+  { id: 101, customerId: 2 }
+]
+
+let items = [
+  { orderId: 100, sku: "a" },
+  { orderId: 101, sku: "b" }
+]
+
+let result = from o in orders
+             join from c in customers on o.customerId == c.id
+             join from i in items on o.id == i.orderId
+             select { name: c.name, sku: i.sku }

--- a/types/errors.go
+++ b/types/errors.go
@@ -52,6 +52,8 @@ var Errors = map[string]diagnostic.Template{
 	"T031": {Code: "T031", Message: "unknown stream: %s", Help: "Declare the stream before using it."},
 	"T032": {Code: "T032", Message: "query source must be a list", Help: "Use a list value after `in`."},
 	"T033": {Code: "T033", Message: "`where` condition must be boolean", Help: "Ensure the condition evaluates to true or false."},
+	"T034": {Code: "T034", Message: "join source must be a list", Help: "Use a list value after `in`."},
+	"T035": {Code: "T035", Message: "`on` condition must be boolean", Help: "Ensure the condition evaluates to true or false."},
 }
 
 // --- Wrapper Functions ---
@@ -192,4 +194,12 @@ func errQuerySourceList(pos lexer.Position) error {
 
 func errWhereBoolean(pos lexer.Position) error {
 	return Errors["T033"].New(pos)
+}
+
+func errJoinSourceList(pos lexer.Position) error {
+	return Errors["T034"].New(pos)
+}
+
+func errJoinOnBoolean(pos lexer.Position) error {
+	return Errors["T035"].New(pos)
 }


### PR DESCRIPTION
## Summary
- enhance `checkQueryExpr` with join handling
- add join-specific diagnostics in `types/errors.go`
- add golden tests for valid joins and error scenarios

## Testing
- `go test ./types -update --vet=off`
- `go test ./types --vet=off`
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6847a3d0ddf483209885568567e0196e