### PR TITLE
Add cross join support

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -372,6 +372,11 @@ func FromPrimary(p *parser.Primary) *Node {
 	case p.Query != nil:
 		n := &Node{Kind: "query", Value: p.Query.Var}
 		n.Children = append(n.Children, &Node{Kind: "source", Children: []*Node{FromExpr(p.Query.Source)}})
+		for _, f := range p.Query.Froms {
+			fn := &Node{Kind: "from", Value: f.Var}
+			fn.Children = append(fn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(f.Src)}})
+			n.Children = append(n.Children, fn)
+		}
 		for _, j := range p.Query.Joins {
 			jn := &Node{Kind: "join", Value: j.Var}
 			jn.Children = append(jn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(j.Src)}})

--- a/examples/v0.6/cross_join.mochi
+++ b/examples/v0.6/cross_join.mochi
@@ -1,0 +1,31 @@
+// cross_join.mochi
+// Cartesian product of orders and customers
+
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+
+let result = from o in orders
+             from c in customers
+             select {
+               orderId: o.id,
+               orderCustomerId: o.customerId,
+               pairedCustomerName: c.name,
+               orderTotal: o.total
+             }
+
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result {
+  print("Order", entry.orderId,
+        "(customerId:", entry.orderCustomerId,
+        ", total: $", entry.orderTotal,
+        ") paired with", entry.pairedCustomerName)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -298,6 +298,7 @@ type QueryExpr struct {
 	Pos    lexer.Position
 	Var    string         `parser:"'from' @Ident 'in'"`
 	Source *Expr          `parser:"@@"`
+	Froms  []*FromClause  `parser:"{ @@ }"`
 	Joins  []*JoinClause  `parser:"{ @@ }"`
 	Where  *Expr          `parser:"[ 'where' @@ ]"`
 	Group  *GroupByClause `parser:"[ @@ ]"`
@@ -305,6 +306,12 @@ type QueryExpr struct {
 	Skip   *Expr          `parser:"[ 'skip' @@ ]"`
 	Take   *Expr          `parser:"[ 'take' @@ ]"`
 	Select *Expr          `parser:"'select' @@"`
+}
+
+type FromClause struct {
+	Pos lexer.Position
+	Var string `parser:"'from' @Ident 'in'"`
+	Src *Expr  `parser:"@@"`
 }
 
 type JoinClause struct {

--- a/tests/interpreter/valid/cross_join.mochi
+++ b/tests/interpreter/valid/cross_join.mochi
@@ -1,0 +1,26 @@
+// cross_join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+let result = from o in orders
+             from c in customers
+             select {
+               orderId: o.id,
+               orderCustomerId: o.customerId,
+               pairedCustomerName: c.name,
+               orderTotal: o.total
+             }
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result {
+  print("Order", entry.orderId,
+        "(customerId:", entry.orderCustomerId,
+        ", total: $", entry.orderTotal,
+        ") paired with", entry.pairedCustomerName)
+}

--- a/tests/interpreter/valid/cross_join.out
+++ b/tests/interpreter/valid/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/tests/parser/valid/cross_join.golden
+++ b/tests/parser/valid/cross_join.golden
@@ -1,0 +1,81 @@
+(program
+  (let customers
+    (list
+      (map
+        (entry (selector id) (int 1))
+        (entry (selector name) (string Alice))
+      )
+      (map
+        (entry (selector id) (int 2))
+        (entry (selector name) (string Bob))
+      )
+      (map
+        (entry (selector id) (int 3))
+        (entry (selector name) (string Charlie))
+      )
+    )
+  )
+  (let orders
+    (list
+      (map
+        (entry (selector id) (int 100))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 250))
+      )
+      (map
+        (entry (selector id) (int 101))
+        (entry (selector customerId) (int 2))
+        (entry (selector total) (int 125))
+      )
+      (map
+        (entry (selector id) (int 102))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 300))
+      )
+    )
+  )
+  (let result
+    (query o
+      (source (selector orders))
+      (from c
+        (source (selector customers))
+      )
+      (select
+        (map
+          (entry
+            (selector orderId)
+            (selector id (selector o))
+          )
+          (entry
+            (selector orderCustomerId)
+            (selector customerId (selector o))
+          )
+          (entry
+            (selector pairedCustomerName)
+            (selector name (selector c))
+          )
+          (entry
+            (selector orderTotal)
+            (selector total (selector o))
+          )
+        )
+      )
+    )
+  )
+  (call print (string "--- Cross Join: All order-customer pairs ---"))
+  (for entry
+    (in (selector result))
+    (block
+      (call print
+        (string Order)
+        (selector orderId (selector entry))
+        (string "(customerId:")
+        (selector orderCustomerId (selector entry))
+        (string ", total: $")
+        (selector orderTotal (selector entry))
+        (string ") paired with")
+        (selector pairedCustomerName (selector entry))
+      )
+    )
+  )
+)

--- a/tests/parser/valid/cross_join.mochi
+++ b/tests/parser/valid/cross_join.mochi
@@ -1,0 +1,26 @@
+// cross_join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+let result = from o in orders
+             from c in customers
+             select {
+               orderId: o.id,
+               orderCustomerId: o.customerId,
+               pairedCustomerName: c.name,
+               orderTotal: o.total
+             }
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result {
+  print("Order", entry.orderId,
+        "(customerId:", entry.orderCustomerId,
+        ", total: $", entry.orderTotal,
+        ") paired with", entry.pairedCustomerName)
+}

--- a/types/check.go
+++ b/types/check.go
@@ -1509,6 +1509,23 @@ func checkQueryExpr(q *parser.QueryExpr, env *Env, expected Type) (Type, error) 
 	child := NewEnv(env)
 	child.SetVar(q.Var, elemT, true)
 
+	for _, f := range q.Froms {
+		ft, err := checkExpr(f.Src, env)
+		if err != nil {
+			return nil, err
+		}
+		var fe Type
+		switch t := ft.(type) {
+		case ListType:
+			fe = t.Elem
+		case GroupType:
+			fe = t.Elem
+		default:
+			return nil, errJoinSourceList(f.Pos)
+		}
+		child.SetVar(f.Var, fe, true)
+	}
+
 	for _, j := range q.Joins {
 		jt, err := checkExpr(j.Src, env)
 		if err != nil {


### PR DESCRIPTION
## Summary
- add `examples/v0.6/cross_join.mochi`
- extend parser with additional `from` clauses
- handle cross joins in interpreter
- type check cross join sources
- expose cross join in AST conversion
- add golden tests for parsing and interpreting cross join

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847a661a02c8320bc9b802370fbc1b1