### PR TITLE
Add WebAssembly build

### DIFF
--- a/tools/wasm/README.md
+++ b/tools/wasm/README.md
@@ -1,0 +1,23 @@
+# Mochi WASM
+
+This directory contains a small wrapper to run the Mochi interpreter in WebAssembly.
+
+## Building
+
+```
+GOOS=js GOARCH=wasm go build -o mochi.wasm main.go
+```
+
+Copy `wasm_exec.js` next to the generated `mochi.wasm`. You can obtain it from your Go installation or download it directly:
+
+```
+cp $(go env GOROOT)/misc/wasm/wasm_exec.js .
+# or
+curl -o wasm_exec.js https://raw.githubusercontent.com/golang/go/master/misc/wasm/wasm_exec.js
+```
+
+Open `index.html` in a browser and you should see the output of a simple program:
+
+```
+print("hello world")
+```

--- a/tools/wasm/index.html
+++ b/tools/wasm/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Mochi Wasm</title>
+</head>
+<body>
+<pre id="out"></pre>
+<script src="wasm_exec.js"></script>
+<script>
+const go = new Go();
+WebAssembly.instantiateStreaming(fetch("mochi.wasm"), go.importObject).then((result) => {
+    go.run(result.instance);
+    document.getElementById('out').textContent = runMochi('print("hello world")');
+});
+</script>
+</body>
+</html>

--- a/tools/wasm/main.go
+++ b/tools/wasm/main.go
@@ -1,0 +1,50 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"syscall/js"
+
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func runMochi(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return js.ValueOf("missing code")
+	}
+	code := args[0].String()
+
+	prog, err := parser.ParseString(code)
+	if err != nil {
+		return js.ValueOf(err.Error())
+	}
+
+	env := types.NewEnv(nil)
+	var buf bytes.Buffer
+	env.SetWriter(&buf)
+
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		var sb strings.Builder
+		for _, e := range errs {
+			sb.WriteString(e.Error())
+			sb.WriteString("\n")
+		}
+		return js.ValueOf(sb.String())
+	}
+
+	i := interpreter.New(prog, env)
+	if err := i.Run(); err != nil {
+		return js.ValueOf(err.Error())
+	}
+
+	return js.ValueOf(buf.String())
+}
+
+func main() {
+	js.Global().Set("runMochi", js.FuncOf(runMochi))
+	select {}
+}


### PR DESCRIPTION
## Summary
- add minimal wasm wrapper for Mochi interpreter
- provide example `index.html`
- document build steps in `README.md`

## Testing
- `go fmt ./tools/wasm`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847abf0b8b88320a7235b5921785c06