### PR TITLE
Add Jupyter notebook magic

### DIFF
--- a/tools/notebook/README.md
+++ b/tools/notebook/README.md
@@ -1,0 +1,30 @@
+# Mochi Jupyter Extension
+
+This folder provides a small IPython extension that lets you run Mochi code
+inside JupyterLab notebooks using a `%%mochi` cell magic.
+
+## Usage
+
+1. Make sure the `mochi` binary is on your `PATH`.
+   You can build it with `make build` from the repository root or download a
+   release from GitHub.
+2. Add `tools/notebook` to your `PYTHONPATH` or install it with `pip`:
+
+```bash
+pip install -e tools/notebook
+```
+
+3. Load the extension in a notebook:
+
+```python
+%load_ext mochi_magic
+```
+
+Now any cell starting with `%%mochi` will be executed by the Mochi CLI:
+
+```mochi
+%%mochi
+print("hello from Mochi")
+```
+
+The cell output appears below just like regular Python code.

--- a/tools/notebook/__init__.py
+++ b/tools/notebook/__init__.py
@@ -1,0 +1,3 @@
+from .mochi_magic import MochiMagics, load_ipython_extension
+
+__all__ = ["MochiMagics", "load_ipython_extension"]

--- a/tools/notebook/mochi_magic.py
+++ b/tools/notebook/mochi_magic.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import tempfile
+import subprocess
+from IPython.core.magic import Magics, magics_class, cell_magic
+
+
+@magics_class
+class MochiMagics(Magics):
+    """IPython cell magic to execute Mochi code."""
+
+    @cell_magic
+    def mochi(self, line, cell):
+        """Run Mochi code contained in the cell."""
+        with tempfile.NamedTemporaryFile("w", suffix=".mochi", delete=False) as f:
+            f.write(cell)
+            fname = f.name
+        try:
+            cmd = ["mochi", "run", fname]
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            if proc.stdout:
+                sys.stdout.write(proc.stdout)
+            if proc.stderr:
+                sys.stderr.write(proc.stderr)
+            if proc.returncode != 0:
+                raise RuntimeError(f"mochi exited with status {proc.returncode}")
+        finally:
+            os.unlink(fname)
+
+
+def load_ipython_extension(ip):
+    ip.register_magics(MochiMagics)

--- a/tools/notebook/pyproject.toml
+++ b/tools/notebook/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mochi_magic"
+version = "0.1.0"
+description = "Jupyter cell magic for the Mochi language"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = ["ipython"]
+
+[project.entry-points."IPython.extension"]
+mochi_magic = "mochi_magic"
+


### PR DESCRIPTION
## Summary
- provide `tools/notebook` with a small Python extension
- document how to run Mochi code in JupyterLab notebooks

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_6847ac99b48c8320aa49fb554ee9984a