### PR TITLE
Add TinyGo WASM build

### DIFF
--- a/tools/db/default.go
+++ b/tools/db/default.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package db
 
 import (

--- a/tools/db/llm_store.go
+++ b/tools/db/llm_store.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package db
 
 import (

--- a/tools/db/mochi_store.go
+++ b/tools/db/mochi_store.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package db
 
 import (

--- a/tools/db/stub.go
+++ b/tools/db/stub.go
@@ -1,0 +1,73 @@
+//go:build tinygo
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Stub implementations used when building with TinyGo (e.g. for WebAssembly).
+
+type RunModel struct {
+	ID        int64
+	SessionID string
+	Agent     string
+	File      string
+	Source    string
+	Status    string
+	Error     string
+	Duration  time.Duration
+	CreatedAt time.Time
+}
+
+type BuildModel struct {
+	ID        int64
+	SessionID string
+	Agent     string
+	File      string
+	Out       string
+	Target    string
+	Source    string
+	Status    string
+	Error     string
+	Duration  time.Duration
+	CreatedAt time.Time
+}
+
+type GoldenModel struct {
+	ID        int64
+	SessionID string
+	Agent     string
+	Name      string
+	File      string
+	Input     string
+	Output    string
+	Status    string
+	Error     string
+	Duration  time.Duration
+	CreatedAt time.Time
+}
+
+type LLMModel struct {
+	ID        int64
+	SessionID string
+	Agent     string
+	Model     string
+	Request   json.RawMessage
+	Response  json.RawMessage
+	Prompt    string
+	Reply     string
+	PromptTok int
+	ReplyTok  int
+	TotalTok  int
+	Duration  time.Duration
+	Status    string
+	CreatedAt time.Time
+}
+
+func LogRun(ctx context.Context, r *RunModel)       {}
+func LogBuild(ctx context.Context, b *BuildModel)   {}
+func LogGolden(ctx context.Context, g *GoldenModel) {}
+func LogLLM(ctx context.Context, m *LLMModel)       {}

--- a/tools/tinygo_wasm/Makefile
+++ b/tools/tinygo_wasm/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all
+
+all: mochi.wasm
+
+mochi.wasm: main.go
+	@echo "🔧 Building WebAssembly binary..."
+	tinygo build -o mochi.wasm -target wasm ./
+	@echo "✅ Generated mochi.wasm"

--- a/tools/tinygo_wasm/README.md
+++ b/tools/tinygo_wasm/README.md
@@ -1,0 +1,19 @@
+# TinyGo WebAssembly Build
+
+This folder provides a minimal wrapper around the Mochi interpreter that can be
+compiled to WebAssembly using [TinyGo](https://tinygo.org/).
+
+## Requirements
+
+* TinyGo v0.37 or newer
+
+## Building
+
+Run `tinygo build` from this directory:
+
+```bash
+tinygo build -o mochi.wasm -target wasm ./
+```
+
+The resulting `mochi.wasm` exports a single JavaScript function `runMochi(source)`
+which parses, type checks and executes the provided Mochi source code.

--- a/tools/tinygo_wasm/main.go
+++ b/tools/tinygo_wasm/main.go
@@ -1,0 +1,42 @@
+//go:build tinygo
+
+package main
+
+import (
+	"strings"
+	"syscall/js"
+
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func runMochi(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return js.ValueOf("missing source")
+	}
+	src := args[0].String()
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		return js.ValueOf(err.Error())
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		var sb strings.Builder
+		for _, e := range errs {
+			sb.WriteString(e.Error())
+			sb.WriteByte('\n')
+		}
+		return js.ValueOf(sb.String())
+	}
+	interp := interpreter.New(prog, env)
+	if err := interp.Run(); err != nil {
+		return js.ValueOf(err.Error())
+	}
+	return js.ValueOf("ok")
+}
+
+func main() {
+	js.Global().Set("runMochi", js.FuncOf(runMochi))
+	select {}
+}


### PR DESCRIPTION
## Summary
- stub database package when building with TinyGo
- add tinygo_wasm tool with wrapper `main.go`
- document build steps and add Makefile for wasm

## Testing
- `make -C tools/tinygo_wasm`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847aa220bec8320b55c493104741ac4