### PR TITLE
Add left join support

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -377,14 +377,18 @@ func FromPrimary(p *parser.Primary) *Node {
 			fn.Children = append(fn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(f.Src)}})
 			n.Children = append(n.Children, fn)
 		}
-		for _, j := range p.Query.Joins {
-			jn := &Node{Kind: "join", Value: j.Var}
-			jn.Children = append(jn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(j.Src)}})
-			if j.On != nil {
-				jn.Children = append(jn.Children, &Node{Kind: "on", Children: []*Node{FromExpr(j.On)}})
-			}
-			n.Children = append(n.Children, jn)
-		}
+               for _, j := range p.Query.Joins {
+                       kind := "join"
+                       if j.Left != nil {
+                               kind = "left_join"
+                       }
+                       jn := &Node{Kind: kind, Value: j.Var}
+                       jn.Children = append(jn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(j.Src)}})
+                       if j.On != nil {
+                               jn.Children = append(jn.Children, &Node{Kind: "on", Children: []*Node{FromExpr(j.On)}})
+                       }
+                       n.Children = append(n.Children, jn)
+               }
 		if p.Query.Where != nil {
 			n.Children = append(n.Children, &Node{Kind: "where", Children: []*Node{FromExpr(p.Query.Where)}})
 		}

--- a/examples/v0.6/left_join.mochi
+++ b/examples/v0.6/left_join.mochi
@@ -1,0 +1,28 @@
+// left_join.mochi
+// Left join: keep all orders, include customer if available
+
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 4, total: 80 } // No matching customer
+]
+
+let result = from o in orders
+             left join c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customer: c,
+               total: o.total
+             }
+
+print("--- Left Join using syntax ---")
+for entry in result {
+  print("Order", entry.orderId, "customer", entry.customer, "- $", entry.total)
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2105,35 +2105,36 @@ func (i *Interpreter) evalQuery(q *parser.QueryExpr) (any, error) {
 			return nil, fmt.Errorf("join source must be list, got %T", srcVal)
 		}
 
-		jc := j // capture
-		opts.Joins = append(opts.Joins, data.Join{
-			Items: joinList,
-			On: func(left, right any) (bool, error) {
-				setEnv(left)
-				child.SetValue(jc.Var, right, true)
-				cond, err := i.evalExpr(jc.On)
-				if err != nil {
-					return false, err
-				}
-				return truthy(cond), nil
-			},
-			Merge: func(left, right any) (any, error) {
-				m := map[string]any{"__join__": true}
-				if lm, ok := left.(map[string]any); ok && lm["__join__"] == true {
-					for k, v := range lm {
-						if k == "__join__" {
-							continue
-						}
-						m[k] = v
-					}
-				} else {
-					m[q.Var] = left
-				}
-				m[jc.Var] = right
-				return m, nil
-			},
-		})
-	}
+               jc := j // capture
+               opts.Joins = append(opts.Joins, data.Join{
+                       Items: joinList,
+                       On: func(left, right any) (bool, error) {
+                               setEnv(left)
+                               child.SetValue(jc.Var, right, true)
+                               cond, err := i.evalExpr(jc.On)
+                               if err != nil {
+                                       return false, err
+                               }
+                               return truthy(cond), nil
+                       },
+                       Merge: func(left, right any) (any, error) {
+                               m := map[string]any{"__join__": true}
+                               if lm, ok := left.(map[string]any); ok && lm["__join__"] == true {
+                                       for k, v := range lm {
+                                               if k == "__join__" {
+                                                       continue
+                                               }
+                                               m[k] = v
+                                       }
+                               } else {
+                                       m[q.Var] = left
+                               }
+                               m[jc.Var] = right
+                               return m, nil
+                       },
+                       Left: jc.Left != nil,
+               })
+       }
 
 	if q.Where != nil {
 		opts.Where = func(item any) (bool, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -315,10 +315,11 @@ type FromClause struct {
 }
 
 type JoinClause struct {
-	Pos lexer.Position
-	Var string `parser:"'join' 'from' @Ident 'in'"`
-	Src *Expr  `parser:"@@"`
-	On  *Expr  `parser:"'on' @@"`
+        Pos  lexer.Position
+        Left *string `parser:"[ @'left' ]"`
+        Var  string  `parser:"'join' [ 'from' ] @Ident 'in'"`
+        Src  *Expr   `parser:"@@"`
+        On   *Expr   `parser:"'on' @@"`
 }
 
 type GroupByClause struct {

--- a/runtime/data/query.go
+++ b/runtime/data/query.go
@@ -28,9 +28,10 @@ type QueryOptions struct {
 // records should be joined. Merge combines the left and right records
 // into a new item for further processing.
 type Join struct {
-	Items []any
-	On    func(left, right any) (bool, error)
-	Merge func(left, right any) (any, error)
+        Items []any
+        On    func(left, right any) (bool, error)
+        Merge func(left, right any) (any, error)
+        Left  bool
 }
 
 // Query executes a query over src using the provided options.
@@ -40,35 +41,48 @@ func Query(src []any, opt QueryOptions) ([]any, error) {
 	items := append([]any(nil), src...)
 
 	// Apply joins sequentially
-	for _, j := range opt.Joins {
-		joined := make([]any, 0)
-		for _, left := range items {
-			for _, right := range j.Items {
-				keep := true
-				var err error
-				if j.On != nil {
-					keep, err = j.On(left, right)
-					if err != nil {
-						return nil, err
-					}
-				}
-				if !keep {
-					continue
-				}
-				if j.Merge != nil {
-					var merged any
-					merged, err = j.Merge(left, right)
-					if err != nil {
-						return nil, err
-					}
-					joined = append(joined, merged)
-				} else {
-					joined = append(joined, []any{left, right})
-				}
-			}
-		}
-		items = joined
-	}
+       for _, j := range opt.Joins {
+               joined := make([]any, 0)
+               for _, left := range items {
+                       matched := false
+                       for _, right := range j.Items {
+                               keep := true
+                               var err error
+                               if j.On != nil {
+                                       keep, err = j.On(left, right)
+                                       if err != nil {
+                                               return nil, err
+                                       }
+                               }
+                               if !keep {
+                                       continue
+                               }
+                               matched = true
+                               if j.Merge != nil {
+                                       var merged any
+                                       merged, err = j.Merge(left, right)
+                                       if err != nil {
+                                               return nil, err
+                                       }
+                                       joined = append(joined, merged)
+                               } else {
+                                       joined = append(joined, []any{left, right})
+                               }
+                       }
+                       if j.Left && !matched {
+                               if j.Merge != nil {
+                                       merged, err := j.Merge(left, nil)
+                                       if err != nil {
+                                               return nil, err
+                                       }
+                                       joined = append(joined, merged)
+                               } else {
+                                       joined = append(joined, []any{left, nil})
+                               }
+                       }
+               }
+               items = joined
+       }
 
 	// Where filtering
 	if opt.Where != nil {

--- a/tests/interpreter/valid/left_join.mochi
+++ b/tests/interpreter/valid/left_join.mochi
@@ -1,0 +1,19 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 3, total: 80 }
+]
+let result = from o in orders
+             left join c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customer: c,
+               total: o.total
+             }
+print("--- Left Join ---")
+for entry in result {
+  print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+}

--- a/tests/interpreter/valid/left_join.out
+++ b/tests/interpreter/valid/left_join.out
@@ -1,0 +1,3 @@
+--- Left Join ---
+Order 100 customer map[id:1 name:Alice] total 250
+Order 101 customer <nil> total 80

--- a/tests/parser/valid/left_join.golden
+++ b/tests/parser/valid/left_join.golden
@@ -1,0 +1,83 @@
+(program
+  (let customers
+    (list
+      (map
+        (entry (selector id) (int 1))
+        (entry (selector name) (string Alice))
+      )
+      (map
+        (entry (selector id) (int 2))
+        (entry (selector name) (string Bob))
+      )
+      (map
+        (entry (selector id) (int 3))
+        (entry (selector name) (string Charlie))
+      )
+    )
+  )
+  (let orders
+    (list
+      (map
+        (entry (selector id) (int 100))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 250))
+      )
+      (map
+        (entry (selector id) (int 101))
+        (entry (selector customerId) (int 2))
+        (entry (selector total) (int 125))
+      )
+      (map
+        (entry (selector id) (int 102))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 300))
+      )
+      (map
+        (entry (selector id) (int 103))
+        (entry (selector customerId) (int 4))
+        (entry (selector total) (int 80))
+      )
+    )
+  )
+  (let result
+    (query o
+      (source (selector orders))
+      (left_join c
+        (source (selector customers))
+        (on
+          (binary ==
+            (selector customerId (selector o))
+            (selector id (selector c))
+          )
+        )
+      )
+      (select
+        (map
+          (entry
+            (selector orderId)
+            (selector id (selector o))
+          )
+          (entry (selector customer) (selector c))
+          (entry
+            (selector total)
+            (selector total (selector o))
+          )
+        )
+      )
+    )
+  )
+  (call print (string "--- Left Join using syntax ---"))
+  (for entry
+    (in (selector result))
+    (block
+      (call print
+        (string Order)
+        (selector orderId (selector entry))
+        (string customer)
+        (selector customer (selector entry))
+        (string "- $")
+        (selector total (selector entry))
+      )
+    )
+  )
+)

--- a/tests/parser/valid/left_join.mochi
+++ b/tests/parser/valid/left_join.mochi
@@ -1,0 +1,23 @@
+// left_join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 4, total: 80 }
+]
+let result = from o in orders
+             left join c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customer: c,
+               total: o.total
+             }
+print("--- Left Join using syntax ---")
+for entry in result {
+  print("Order", entry.orderId, "customer", entry.customer, "- $", entry.total)
+}

--- a/tests/types/valid/left_join.golden
+++ b/tests/types/valid/left_join.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/left_join.mochi
+++ b/tests/types/valid/left_join.mochi
@@ -1,0 +1,14 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+let orders = [
+  { id: 100, customerId: 1 },
+  { id: 101, customerId: 3 }
+]
+let result = from o in orders
+             left join c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customer: c
+             }


### PR DESCRIPTION
## Summary
- add example for left joins
- support optional `left` keyword in join clause
- implement left join semantics in runtime
- expose `left_join` in AST output
- add parser, type checker and interpreter tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847ab81fc2c8320b3bfd8e9a131f9c7