### PR TITLE
Add right join support

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -377,18 +377,23 @@ func FromPrimary(p *parser.Primary) *Node {
 			fn.Children = append(fn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(f.Src)}})
 			n.Children = append(n.Children, fn)
 		}
-               for _, j := range p.Query.Joins {
-                       kind := "join"
-                       if j.Left != nil {
-                               kind = "left_join"
-                       }
-                       jn := &Node{Kind: kind, Value: j.Var}
-                       jn.Children = append(jn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(j.Src)}})
-                       if j.On != nil {
-                               jn.Children = append(jn.Children, &Node{Kind: "on", Children: []*Node{FromExpr(j.On)}})
-                       }
-                       n.Children = append(n.Children, jn)
-               }
+		for _, j := range p.Query.Joins {
+			kind := "join"
+			if j.Side != nil {
+				switch *j.Side {
+				case "left":
+					kind = "left_join"
+				case "right":
+					kind = "right_join"
+				}
+			}
+			jn := &Node{Kind: kind, Value: j.Var}
+			jn.Children = append(jn.Children, &Node{Kind: "source", Children: []*Node{FromExpr(j.Src)}})
+			if j.On != nil {
+				jn.Children = append(jn.Children, &Node{Kind: "on", Children: []*Node{FromExpr(j.On)}})
+			}
+			n.Children = append(n.Children, jn)
+		}
 		if p.Query.Where != nil {
 			n.Children = append(n.Children, &Node{Kind: "where", Children: []*Node{FromExpr(p.Query.Where)}})
 		}

--- a/examples/v0.6/right_join.mochi
+++ b/examples/v0.6/right_join.mochi
@@ -1,0 +1,31 @@
+// right_join.mochi
+// Right join: keep all customers, include orders if any
+
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" } // No matching order
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+
+let result = from c in customers
+             right join o in orders on o.customerId == c.id
+             select {
+               customerName: c.name,
+               order: o
+             }
+
+print("--- Right Join using syntax ---")
+for entry in result {
+  if entry.order {
+    print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
+  } else {
+    print("Customer", entry.customerName, "has no orders")
+  }
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2105,36 +2105,37 @@ func (i *Interpreter) evalQuery(q *parser.QueryExpr) (any, error) {
 			return nil, fmt.Errorf("join source must be list, got %T", srcVal)
 		}
 
-               jc := j // capture
-               opts.Joins = append(opts.Joins, data.Join{
-                       Items: joinList,
-                       On: func(left, right any) (bool, error) {
-                               setEnv(left)
-                               child.SetValue(jc.Var, right, true)
-                               cond, err := i.evalExpr(jc.On)
-                               if err != nil {
-                                       return false, err
-                               }
-                               return truthy(cond), nil
-                       },
-                       Merge: func(left, right any) (any, error) {
-                               m := map[string]any{"__join__": true}
-                               if lm, ok := left.(map[string]any); ok && lm["__join__"] == true {
-                                       for k, v := range lm {
-                                               if k == "__join__" {
-                                                       continue
-                                               }
-                                               m[k] = v
-                                       }
-                               } else {
-                                       m[q.Var] = left
-                               }
-                               m[jc.Var] = right
-                               return m, nil
-                       },
-                       Left: jc.Left != nil,
-               })
-       }
+		jc := j // capture
+		opts.Joins = append(opts.Joins, data.Join{
+			Items: joinList,
+			On: func(left, right any) (bool, error) {
+				setEnv(left)
+				child.SetValue(jc.Var, right, true)
+				cond, err := i.evalExpr(jc.On)
+				if err != nil {
+					return false, err
+				}
+				return truthy(cond), nil
+			},
+			Merge: func(left, right any) (any, error) {
+				m := map[string]any{"__join__": true}
+				if lm, ok := left.(map[string]any); ok && lm["__join__"] == true {
+					for k, v := range lm {
+						if k == "__join__" {
+							continue
+						}
+						m[k] = v
+					}
+				} else {
+					m[q.Var] = left
+				}
+				m[jc.Var] = right
+				return m, nil
+			},
+			Left:  jc.Side != nil && *jc.Side == "left",
+			Right: jc.Side != nil && *jc.Side == "right",
+		})
+	}
 
 	if q.Where != nil {
 		opts.Where = func(item any) (bool, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -315,11 +315,11 @@ type FromClause struct {
 }
 
 type JoinClause struct {
-        Pos  lexer.Position
-        Left *string `parser:"[ @'left' ]"`
-        Var  string  `parser:"'join' [ 'from' ] @Ident 'in'"`
-        Src  *Expr   `parser:"@@"`
-        On   *Expr   `parser:"'on' @@"`
+	Pos  lexer.Position
+	Side *string `parser:"[ @('left' | 'right') ]"`
+	Var  string  `parser:"'join' [ 'from' ] @Ident 'in'"`
+	Src  *Expr   `parser:"@@"`
+	On   *Expr   `parser:"'on' @@"`
 }
 
 type GroupByClause struct {

--- a/runtime/data/query.go
+++ b/runtime/data/query.go
@@ -28,10 +28,11 @@ type QueryOptions struct {
 // records should be joined. Merge combines the left and right records
 // into a new item for further processing.
 type Join struct {
-        Items []any
-        On    func(left, right any) (bool, error)
-        Merge func(left, right any) (any, error)
-        Left  bool
+	Items []any
+	On    func(left, right any) (bool, error)
+	Merge func(left, right any) (any, error)
+	Left  bool
+	Right bool
 }
 
 // Query executes a query over src using the provided options.
@@ -41,48 +42,89 @@ func Query(src []any, opt QueryOptions) ([]any, error) {
 	items := append([]any(nil), src...)
 
 	// Apply joins sequentially
-       for _, j := range opt.Joins {
-               joined := make([]any, 0)
-               for _, left := range items {
-                       matched := false
-                       for _, right := range j.Items {
-                               keep := true
-                               var err error
-                               if j.On != nil {
-                                       keep, err = j.On(left, right)
-                                       if err != nil {
-                                               return nil, err
-                                       }
-                               }
-                               if !keep {
-                                       continue
-                               }
-                               matched = true
-                               if j.Merge != nil {
-                                       var merged any
-                                       merged, err = j.Merge(left, right)
-                                       if err != nil {
-                                               return nil, err
-                                       }
-                                       joined = append(joined, merged)
-                               } else {
-                                       joined = append(joined, []any{left, right})
-                               }
-                       }
-                       if j.Left && !matched {
-                               if j.Merge != nil {
-                                       merged, err := j.Merge(left, nil)
-                                       if err != nil {
-                                               return nil, err
-                                       }
-                                       joined = append(joined, merged)
-                               } else {
-                                       joined = append(joined, []any{left, nil})
-                               }
-                       }
-               }
-               items = joined
-       }
+	for _, j := range opt.Joins {
+		joined := make([]any, 0)
+		if j.Right {
+			for _, right := range j.Items {
+				matched := false
+				for _, left := range items {
+					keep := true
+					var err error
+					if j.On != nil {
+						keep, err = j.On(left, right)
+						if err != nil {
+							return nil, err
+						}
+					}
+					if !keep {
+						continue
+					}
+					matched = true
+					if j.Merge != nil {
+						var merged any
+						merged, err = j.Merge(left, right)
+						if err != nil {
+							return nil, err
+						}
+						joined = append(joined, merged)
+					} else {
+						joined = append(joined, []any{left, right})
+					}
+				}
+				if j.Right && !matched {
+					if j.Merge != nil {
+						merged, err := j.Merge(nil, right)
+						if err != nil {
+							return nil, err
+						}
+						joined = append(joined, merged)
+					} else {
+						joined = append(joined, []any{nil, right})
+					}
+				}
+			}
+		} else {
+			for _, left := range items {
+				matched := false
+				for _, right := range j.Items {
+					keep := true
+					var err error
+					if j.On != nil {
+						keep, err = j.On(left, right)
+						if err != nil {
+							return nil, err
+						}
+					}
+					if !keep {
+						continue
+					}
+					matched = true
+					if j.Merge != nil {
+						var merged any
+						merged, err = j.Merge(left, right)
+						if err != nil {
+							return nil, err
+						}
+						joined = append(joined, merged)
+					} else {
+						joined = append(joined, []any{left, right})
+					}
+				}
+				if j.Left && !matched {
+					if j.Merge != nil {
+						merged, err := j.Merge(left, nil)
+						if err != nil {
+							return nil, err
+						}
+						joined = append(joined, merged)
+					} else {
+						joined = append(joined, []any{left, nil})
+					}
+				}
+			}
+		}
+		items = joined
+	}
 
 	// Where filtering
 	if opt.Where != nil {

--- a/tests/interpreter/valid/right_join.mochi
+++ b/tests/interpreter/valid/right_join.mochi
@@ -1,0 +1,31 @@
+// right_join.mochi
+// Right join: keep all customers, include orders if any
+
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" } // No matching order
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+
+let result = from c in customers
+             right join o in orders on o.customerId == c.id
+             select {
+               customerName: c.name,
+               order: o
+             }
+
+print("--- Right Join using syntax ---")
+for entry in result {
+  if entry.order {
+    print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
+  } else {
+    print("Customer", entry.customerName, "has no orders")
+  }
+}

--- a/tests/interpreter/valid/right_join.out
+++ b/tests/interpreter/valid/right_join.out
@@ -1,0 +1,4 @@
+--- Right Join using syntax ---
+Customer Alice has order 100 - $ 250
+Customer Bob has order 101 - $ 125
+Customer Alice has order 102 - $ 300

--- a/tests/parser/valid/right_join.golden
+++ b/tests/parser/valid/right_join.golden
@@ -1,0 +1,94 @@
+(program
+  (let customers
+    (list
+      (map
+        (entry (selector id) (int 1))
+        (entry (selector name) (string Alice))
+      )
+      (map
+        (entry (selector id) (int 2))
+        (entry (selector name) (string Bob))
+      )
+      (map
+        (entry (selector id) (int 3))
+        (entry (selector name) (string Charlie))
+      )
+      (map
+        (entry (selector id) (int 4))
+        (entry (selector name) (string Diana))
+      )
+    )
+  )
+  (let orders
+    (list
+      (map
+        (entry (selector id) (int 100))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 250))
+      )
+      (map
+        (entry (selector id) (int 101))
+        (entry (selector customerId) (int 2))
+        (entry (selector total) (int 125))
+      )
+      (map
+        (entry (selector id) (int 102))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 300))
+      )
+    )
+  )
+  (let result
+    (query c
+      (source (selector customers))
+      (right_join o
+        (source (selector orders))
+        (on
+          (binary ==
+            (selector customerId (selector o))
+            (selector id (selector c))
+          )
+        )
+      )
+      (select
+        (map
+          (entry
+            (selector customerName)
+            (selector name (selector c))
+          )
+          (entry (selector order) (selector o))
+        )
+      )
+    )
+  )
+  (call print (string "--- Right Join using syntax ---"))
+  (for entry
+    (in (selector result))
+    (block
+      (if
+        (selector order (selector entry))
+        (block
+          (call print
+            (string Customer)
+            (selector customerName (selector entry))
+            (string "has order")
+            (selector id
+              (selector order (selector entry))
+            )
+            (string "- $")
+            (selector total
+              (selector order (selector entry))
+            )
+          )
+        )
+        (block
+          (call print
+            (string Customer)
+            (selector customerName (selector entry))
+            (string "has no orders")
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/parser/valid/right_join.mochi
+++ b/tests/parser/valid/right_join.mochi
@@ -1,0 +1,31 @@
+// right_join.mochi
+// Right join: keep all customers, include orders if any
+
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" } // No matching order
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+
+let result = from c in customers
+             right join o in orders on o.customerId == c.id
+             select {
+               customerName: c.name,
+               order: o
+             }
+
+print("--- Right Join using syntax ---")
+for entry in result {
+  if entry.order {
+    print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
+  } else {
+    print("Customer", entry.customerName, "has no orders")
+  }
+}


### PR DESCRIPTION
## Summary
- extend query syntax with `right join`
- support right join in AST conversion and interpreter
- update data query engine for right joins
- add example script
- add parser and interpreter tests for right joins

## Testing
- `go test ./parser`
- `go test ./interpreter`


------
https://chatgpt.com/codex/tasks/task_e_6847b0509ff88320af1e95be021e4114