### PR TITLE
Add left join support in compilers

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -1028,13 +1028,17 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			return "", err
 		}
 		joinSrcs[i] = js
-		loops = append(loops, fmt.Sprintf("%s in _iter(%s)", sanitizeName(j.Var), js))
 		on, err := c.compileExpr(j.On)
 		if err != nil {
 			c.env = orig
 			return "", err
 		}
-		condParts = append(condParts, on)
+		if j.Left != nil {
+			loops = append(loops, fmt.Sprintf("%s in ([ %s for %s in _iter(%s) if %s ] or [None])", sanitizeName(j.Var), sanitizeName(j.Var), sanitizeName(j.Var), js, on))
+		} else {
+			loops = append(loops, fmt.Sprintf("%s in _iter(%s)", sanitizeName(j.Var), js))
+			condParts = append(condParts, on)
+		}
 	}
 	if q.Where != nil {
 		w, err := c.compileExpr(q.Where)


### PR DESCRIPTION
## Summary
- support left join in Go compiler via new recursive join loop logic
- add left join handling for TypeScript compiler
- implement left join syntax for Python via comprehension expansion

## Testing
- `make test STAGE=compile/go`
- `make test STAGE=compile/ts`
- `make test STAGE=compile/py`


------
https://chatgpt.com/codex/tasks/task_e_6847afddd8748320a72d4eb658084694