### PR TITLE
Add wasm compiler support

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -24,6 +24,7 @@ import (
 	"mochi/compile/go"
 	"mochi/compile/py"
 	"mochi/compile/ts"
+	"mochi/compile/wasm"
 	"mochi/interpreter"
 	"mochi/mcp"
 	"mochi/parser"
@@ -66,7 +67,7 @@ type TestCmd struct {
 type BuildCmd struct {
 	File   string `arg:"positional,required" help:"Path to .mochi source file"`
 	Out    string `arg:"-o" help:"Output file path"`
-	Target string `arg:"--target" help:"Output language (go|py|ts)"`
+	Target string `arg:"--target" help:"Output language (go|py|ts|wasm)"`
 }
 
 type ReplCmd struct{}
@@ -222,6 +223,8 @@ func build(cmd *BuildCmd) error {
 			target = "py"
 		case ".ts":
 			target = "ts"
+		case ".wasm":
+			target = "wasm"
 		}
 	}
 
@@ -275,6 +278,18 @@ func build(cmd *BuildCmd) error {
 		code, err := tscode.New(env).Compile(prog)
 		if err == nil {
 			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "wasm":
+		if out == "" {
+			out = base + ".wasm"
+		}
+		data, err := wasm.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, data, 0644)
 		}
 		if err != nil {
 			status = "error"

--- a/compile/wasm/compiler.go
+++ b/compile/wasm/compiler.go
@@ -1,0 +1,57 @@
+package wasm
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	gocode "mochi/compile/go"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler translates a Mochi AST into a WebAssembly module.
+//
+// It works by first compiling the program to Go source using the
+// Go compiler package and then invoking the Go toolchain to build
+// the resulting source for the js/wasm target.
+// The resulting WebAssembly binary bytes are returned.
+type Compiler struct {
+	env *types.Env
+}
+
+// New creates a new WASM compiler.
+func New(env *types.Env) *Compiler {
+	return &Compiler{env: env}
+}
+
+// Compile returns a WebAssembly binary that executes prog.
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "mochi-wasm-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	srcPath := filepath.Join(dir, "main.go")
+	code, err := gocode.New(c.env).Compile(prog)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(srcPath, code, 0644); err != nil {
+		return nil, err
+	}
+
+	outPath := filepath.Join(dir, "prog.wasm")
+	cmd := exec.Command("go", "build", "-o", outPath, srcPath)
+	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("go build failed: %w\n%s", err, out)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/compile/wasm/compiler_test.go
+++ b/compile/wasm/compiler_test.go
@@ -1,0 +1,73 @@
+package wasm_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	wasm "mochi/compile/wasm"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestWasmCompiler(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not installed")
+	}
+
+	prog, err := parser.ParseString("print(\"hello wasm\")")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	wasmBytes, err := wasm.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	tmp := t.TempDir()
+	wasmPath := filepath.Join(tmp, "prog.wasm")
+	if err := os.WriteFile(wasmPath, wasmBytes, 0644); err != nil {
+		t.Fatalf("write wasm: %v", err)
+	}
+
+	src := filepath.Join(runtime.GOROOT(), "lib", "wasm", "wasm_exec.js")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read wasm_exec.js: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "wasm_exec.js"), data, 0644); err != nil {
+		t.Fatalf("write wasm_exec.js: %v", err)
+	}
+
+	runJS := filepath.Join(tmp, "run.js")
+	script := `const fs = require('fs');
+require('./wasm_exec.js');
+const go = new globalThis.Go();
+WebAssembly.instantiate(fs.readFileSync('prog.wasm'), go.importObject).then((res) => {
+  go.run(res.instance);
+}).catch(err => { console.error(err); process.exit(1); });`
+	if err := os.WriteFile(runJS, []byte(script), 0644); err != nil {
+		t.Fatalf("write run.js: %v", err)
+	}
+
+	cmd := exec.Command("node", "run.js")
+	cmd.Dir = tmp
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("node run failed: %v\n%s", err, buf.String())
+	}
+
+	if strings.TrimSpace(buf.String()) != "hello wasm" {
+		t.Fatalf("unexpected output: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- implement new `compile/wasm` package that compiles Mochi programs to WebAssembly using the Go compiler
- support `--target wasm` in the CLI build command
- test wasm compilation by running the generated module in Node

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847b374d6c083208b77534288cc9da5