### PR TITLE
Add full outer join

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -385,6 +385,8 @@ func FromPrimary(p *parser.Primary) *Node {
 					kind = "left_join"
 				case "right":
 					kind = "right_join"
+				case "outer":
+					kind = "outer_join"
 				}
 			}
 			jn := &Node{Kind: kind, Value: j.Var}

--- a/examples/v0.6/outer_join.mochi
+++ b/examples/v0.6/outer_join.mochi
@@ -1,0 +1,34 @@
+// outer_join.mochi
+// Full outer join: include all orders and all customers
+
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" } // Has no order
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 5, total: 80 } // Unknown customer
+]
+
+let result = from o in orders
+             outer join c in customers on o.customerId == c.id
+             select {
+               orderId: o?.id,
+               customerId: o?.customerId ?? c?.id,
+               customerName: c?.name ?? "Unknown",
+               total: o?.total ?? null
+             }
+
+print("--- Outer Join using syntax ---")
+for row in result {
+  if row.orderId != null {
+    print("Order", row.orderId, "by", row.customerName, "- $", row.total)
+  } else {
+    print("Customer", row.customerName, "has no orders")
+  }
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2132,8 +2132,8 @@ func (i *Interpreter) evalQuery(q *parser.QueryExpr) (any, error) {
 				m[jc.Var] = right
 				return m, nil
 			},
-			Left:  jc.Side != nil && *jc.Side == "left",
-			Right: jc.Side != nil && *jc.Side == "right",
+			Left:  jc.Side != nil && (*jc.Side == "left" || *jc.Side == "outer"),
+			Right: jc.Side != nil && (*jc.Side == "right" || *jc.Side == "outer"),
 		})
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -316,7 +316,7 @@ type FromClause struct {
 
 type JoinClause struct {
 	Pos  lexer.Position
-	Side *string `parser:"[ @('left' | 'right') ]"`
+	Side *string `parser:"[ @('left' | 'right' | 'outer') ]"`
 	Var  string  `parser:"'join' [ 'from' ] @Ident 'in'"`
 	Src  *Expr   `parser:"@@"`
 	On   *Expr   `parser:"'on' @@"`

--- a/tests/interpreter/valid/outer_join.mochi
+++ b/tests/interpreter/valid/outer_join.mochi
@@ -1,0 +1,33 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" } // Has no order
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 5, total: 80 } // Unknown customer
+]
+
+let result = from o in orders
+             outer join c in customers on o.customerId == c.id
+             select {
+               order: o,
+               customer: c
+             }
+
+print("--- Outer Join using syntax ---")
+for row in result {
+  if row.order {
+    if row.customer {
+      print("Order", row.order.id, "by", row.customer.name, "- $", row.order.total)
+    } else {
+      print("Order", row.order.id, "by", "Unknown", "- $", row.order.total)
+    }
+  } else {
+    print("Customer", row.customer.name, "has no orders")
+  }
+}

--- a/tests/interpreter/valid/outer_join.out
+++ b/tests/interpreter/valid/outer_join.out
@@ -1,0 +1,7 @@
+--- Outer Join using syntax ---
+Order 100 by Alice - $ 250
+Order 101 by Bob - $ 125
+Order 102 by Alice - $ 300
+Order 103 by Unknown - $ 80
+Customer Charlie has no orders
+Customer Diana has no orders

--- a/tests/parser/valid/outer_join.golden
+++ b/tests/parser/valid/outer_join.golden
@@ -1,0 +1,119 @@
+(program
+  (let customers
+    (list
+      (map
+        (entry (selector id) (int 1))
+        (entry (selector name) (string Alice))
+      )
+      (map
+        (entry (selector id) (int 2))
+        (entry (selector name) (string Bob))
+      )
+      (map
+        (entry (selector id) (int 3))
+        (entry (selector name) (string Charlie))
+      )
+      (map
+        (entry (selector id) (int 4))
+        (entry (selector name) (string Diana))
+      )
+    )
+  )
+  (let orders
+    (list
+      (map
+        (entry (selector id) (int 100))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 250))
+      )
+      (map
+        (entry (selector id) (int 101))
+        (entry (selector customerId) (int 2))
+        (entry (selector total) (int 125))
+      )
+      (map
+        (entry (selector id) (int 102))
+        (entry (selector customerId) (int 1))
+        (entry (selector total) (int 300))
+      )
+      (map
+        (entry (selector id) (int 103))
+        (entry (selector customerId) (int 5))
+        (entry (selector total) (int 80))
+      )
+    )
+  )
+  (let result
+    (query o
+      (source (selector orders))
+      (outer_join c
+        (source (selector customers))
+        (on
+          (binary ==
+            (selector customerId (selector o))
+            (selector id (selector c))
+          )
+        )
+      )
+      (select
+        (map
+          (entry (selector order) (selector o))
+          (entry (selector customer) (selector c))
+        )
+      )
+    )
+  )
+  (call print (string "--- Outer Join using syntax ---"))
+  (for row
+    (in (selector result))
+    (block
+      (if
+        (selector order (selector row))
+        (block
+          (if
+            (selector customer (selector row))
+            (block
+              (call print
+                (string Order)
+                (selector id
+                  (selector order (selector row))
+                )
+                (string by)
+                (selector name
+                  (selector customer (selector row))
+                )
+                (string "- $")
+                (selector total
+                  (selector order (selector row))
+                )
+              )
+            )
+            (block
+              (call print
+                (string Order)
+                (selector id
+                  (selector order (selector row))
+                )
+                (string by)
+                (string Unknown)
+                (string "- $")
+                (selector total
+                  (selector order (selector row))
+                )
+              )
+            )
+          )
+        )
+        (block
+          (call print
+            (string Customer)
+            (selector name
+              (selector customer (selector row))
+            )
+            (string "has no orders")
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/parser/valid/outer_join.mochi
+++ b/tests/parser/valid/outer_join.mochi
@@ -1,0 +1,33 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" } // Has no order
+]
+
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 5, total: 80 } // Unknown customer
+]
+
+let result = from o in orders
+             outer join c in customers on o.customerId == c.id
+             select {
+               order: o,
+               customer: c
+             }
+
+print("--- Outer Join using syntax ---")
+for row in result {
+  if row.order {
+    if row.customer {
+      print("Order", row.order.id, "by", row.customer.name, "- $", row.order.total)
+    } else {
+      print("Order", row.order.id, "by", "Unknown", "- $", row.order.total)
+    }
+  } else {
+    print("Customer", row.customer.name, "has no orders")
+  }
+}

--- a/tests/types/valid/outer_join.golden
+++ b/tests/types/valid/outer_join.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/outer_join.mochi
+++ b/tests/types/valid/outer_join.mochi
@@ -1,0 +1,17 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" },
+  { id: 4, name: "Diana" }
+]
+
+let orders = [
+  { id: 100, customerId: 1 },
+  { id: 101, customerId: 2 },
+  { id: 102, customerId: 1 },
+  { id: 103, customerId: 5 }
+]
+
+let result = from o in orders
+             outer join c in customers on o.customerId == c.id
+             select { order: o, customer: c }


### PR DESCRIPTION
## Summary
- support new `outer join` syntax in parser
- implement outer join logic in interpreter and runtime Query
- allow AST convert to emit `outer_join`
- add examples and tests for full outer join

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847b3df8d6c8320a5a87c0c98f1333b