### PR TITLE
Add UNION ALL support

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -258,7 +258,11 @@ func isUnderscoreExpr(e *parser.Expr) bool {
 func FromExpr(e *parser.Expr) *Node {
 	n := FromUnary(e.Binary.Left)
 	for _, op := range e.Binary.Right {
-		n = &Node{Kind: "binary", Value: op.Op, Children: []*Node{n, FromPostfixExpr(op.Right)}}
+		val := op.Op
+		if op.All {
+			val += "_all"
+		}
+		n = &Node{Kind: "binary", Value: val, Children: []*Node{n, FromPostfixExpr(op.Right)}}
 	}
 	return n
 }

--- a/examples/v0.6/union_all.mochi
+++ b/examples/v0.6/union_all.mochi
@@ -1,0 +1,22 @@
+// union_all.mochi
+// Union ALL – include duplicates
+
+let listA = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+
+let listB = [
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+
+// Union all (no deduplication)
+let result = (from x in listA select x)
+             union all
+             (from x in listB select x)
+
+print("--- UNION ALL (with duplicates) ---")
+for x in result {
+  print("Customer", x.id, "-", x.name)
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1029,7 +1029,7 @@ func (i *Interpreter) evalBinaryExpr(b *parser.BinaryExpr) (any, error) {
 		{"==", "!=", "in"},     // equality and membership
 		{"&&"},                 // logical AND
 		{"||"},                 // logical OR
-		{"union"},              // set union (dedup) lowest
+		{"union", "union_all"}, // set unions lowest
 	} {
 		for i := 0; i < len(operators); {
 			op := operators[i].op
@@ -2302,6 +2302,8 @@ func applyBinaryValue(pos lexer.Position, left Value, op string, right Value) (V
 	if left.Tag == TagList && right.Tag == TagList {
 		switch op {
 		case "+":
+			return Value{Tag: TagList, List: append(append([]Value{}, left.List...), right.List...)}, nil
+		case "union_all":
 			return Value{Tag: TagList, List: append(append([]Value{}, left.List...), right.List...)}, nil
 		case "union":
 			merged := append([]Value{}, left.List...)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -215,6 +215,7 @@ type BinaryExpr struct {
 type BinaryOp struct {
 	Pos   lexer.Position
 	Op    string       `parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | 'in' | '&&' | '||' | 'union')"`
+	All   bool         `parser:"[ 'all' ]"`
 	Right *PostfixExpr `parser:"@@"`
 }
 


### PR DESCRIPTION
## Summary
- support `union all` operator in parser and interpreter
- display operator in AST
- add example for UNION ALL query

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6847ca4768dc8320aa962f1661594fda