### PR TITLE
Improve Go compiler type inference for calls

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -915,7 +915,11 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				args[i] = v
 			}
 			val = fmt.Sprintf("%s(%s)", val, strings.Join(args, ", "))
-			typ = c.inferPostfixType(&parser.PostfixExpr{Target: &parser.Primary{Call: nil}})
+			if ft, ok := typ.(types.FuncType); ok {
+				typ = ft.Return
+			} else {
+				typ = types.AnyType{}
+			}
 		case op.Index != nil:
 			idx := op.Index
 			if idx.Colon == nil {


### PR DESCRIPTION
## Summary
- improve type inference in the Go compiler so that function call results keep their return type instead of defaulting to `any`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847e22d1b988320ade6f2f97ccf05bb