### PR TITLE
Improve Python compiler type inference

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -240,12 +240,44 @@ func (c *Compiler) compileLet(s *parser.LetStmt) error {
 		}
 		value = v
 	}
+	if c.env != nil {
+		t, err := c.env.GetVar(s.Name)
+		if err != nil {
+			if s.Value != nil {
+				t = c.inferExprType(s.Value)
+			} else {
+				t = types.AnyType{}
+			}
+			c.env.SetVar(s.Name, t, false)
+		}
+	}
 	c.writeln(fmt.Sprintf("%s = %s", name, value))
 	return nil
 }
 
 func (c *Compiler) compileVar(s *parser.VarStmt) error {
-	return c.compileLet(&parser.LetStmt{Name: s.Name, Value: s.Value})
+	name := sanitizeName(s.Name)
+	value := "None"
+	if s.Value != nil {
+		v, err := c.compileExpr(s.Value)
+		if err != nil {
+			return err
+		}
+		value = v
+	}
+	if c.env != nil {
+		t, err := c.env.GetVar(s.Name)
+		if err != nil {
+			if s.Value != nil {
+				t = c.inferExprType(s.Value)
+			} else {
+				t = types.AnyType{}
+			}
+			c.env.SetVar(s.Name, t, true)
+		}
+	}
+	c.writeln(fmt.Sprintf("%s = %s", name, value))
+	return nil
 }
 
 func (c *Compiler) compileAssign(s *parser.AssignStmt) error {

--- a/compile/py/infer.go
+++ b/compile/py/infer.go
@@ -122,9 +122,28 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 			return types.BoolType{}
 		}
 	case p.Selector != nil:
-		if len(p.Selector.Tail) == 0 && c.env != nil {
+		if c.env != nil {
 			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				return t
+				if len(p.Selector.Tail) == 0 {
+					return t
+				}
+				if st, ok := t.(types.StructType); ok {
+					cur := st
+					for idx, field := range p.Selector.Tail {
+						ft, ok := cur.Fields[field]
+						if !ok {
+							return types.AnyType{}
+						}
+						if idx == len(p.Selector.Tail)-1 {
+							return ft
+						}
+						if next, ok := ft.(types.StructType); ok {
+							cur = next
+						} else {
+							return types.AnyType{}
+						}
+					}
+				}
 			}
 		}
 		return types.AnyType{}


### PR DESCRIPTION
## Summary
- update Python compiler to track variable types for let/var
- enhance selector inference to resolve nested struct fields

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847e2481c5c8320a9a1dcfa352a2986