### PR TITLE
Add query planning scaffolding

### DIFF
--- a/runtime/data/plan.go
+++ b/runtime/data/plan.go
@@ -1,0 +1,85 @@
+package data
+
+import (
+	"fmt"
+	"mochi/parser"
+)
+
+// Plan represents a step in a query execution tree.
+type Plan interface {
+	SQL() (string, []any, error)
+}
+
+// scanPlan is the root for FROM <src> AS <alias>.
+type scanPlan struct {
+	Src   *parser.Expr
+	Alias string
+}
+
+func (p *scanPlan) SQL() (string, []any, error) {
+	return "", nil, fmt.Errorf("scanPlan: SQL generation not implemented")
+}
+
+// selectPlan represents SELECT <expr> FROM <input>.
+type selectPlan struct {
+	Expr  *parser.Expr
+	Input Plan
+}
+
+func (p *selectPlan) SQL() (string, []any, error) {
+	return "", nil, fmt.Errorf("selectPlan: SQL generation not implemented")
+}
+
+// wherePlan filters rows using a boolean expression.
+type wherePlan struct {
+	Cond  *parser.Expr
+	Input Plan
+}
+
+func (p *wherePlan) SQL() (string, []any, error) {
+	return "", nil, fmt.Errorf("wherePlan: SQL generation not implemented")
+}
+
+// joinPlan joins two datasets with an optional ON expression.
+type joinPlan struct {
+	Left     Plan
+	Right    Plan
+	On       *parser.Expr
+	JoinType string // "inner", "left", "right", "outer"
+}
+
+func (p *joinPlan) SQL() (string, []any, error) {
+	return "", nil, fmt.Errorf("joinPlan: SQL generation not implemented")
+}
+
+// groupPlan groups rows by an expression and exposes the group via Name.
+type groupPlan struct {
+	By    *parser.Expr
+	Name  string
+	Input Plan
+}
+
+func (p *groupPlan) SQL() (string, []any, error) {
+	return "", nil, fmt.Errorf("groupPlan: SQL generation not implemented")
+}
+
+// sortPlan orders rows using a key expression.
+type sortPlan struct {
+	Key   *parser.Expr
+	Input Plan
+}
+
+func (p *sortPlan) SQL() (string, []any, error) {
+	return "", nil, fmt.Errorf("sortPlan: SQL generation not implemented")
+}
+
+// limitPlan handles skip/take semantics.
+type limitPlan struct {
+	Skip  *parser.Expr
+	Take  *parser.Expr
+	Input Plan
+}
+
+func (p *limitPlan) SQL() (string, []any, error) {
+	return "", nil, fmt.Errorf("limitPlan: SQL generation not implemented")
+}

--- a/runtime/data/planner.go
+++ b/runtime/data/planner.go
@@ -1,0 +1,54 @@
+package data
+
+import (
+	"fmt"
+	"mochi/parser"
+)
+
+// BuildPlan converts a parsed QueryExpr into a logical plan tree.
+func BuildPlan(q *parser.QueryExpr) (Plan, error) {
+	if q == nil {
+		return nil, fmt.Errorf("nil query expression")
+	}
+
+	var root Plan = &scanPlan{Src: q.Source, Alias: q.Var}
+
+	// additional FROM clauses become cross joins
+	for _, f := range q.Froms {
+		rhs := &scanPlan{Src: f.Src, Alias: f.Var}
+		root = &joinPlan{Left: root, Right: rhs, JoinType: "inner"}
+	}
+
+	// explicit JOIN clauses
+	for _, j := range q.Joins {
+		joinType := "inner"
+		if j.Side != nil {
+			joinType = *j.Side
+		}
+		rhs := &scanPlan{Src: j.Src, Alias: j.Var}
+		root = &joinPlan{Left: root, Right: rhs, On: j.On, JoinType: joinType}
+	}
+
+	if q.Where != nil {
+		root = &wherePlan{Cond: q.Where, Input: root}
+	}
+
+	if q.Group != nil {
+		root = &groupPlan{By: q.Group.Expr, Name: q.Group.Name, Input: root}
+	}
+
+	if q.Sort != nil {
+		root = &sortPlan{Key: q.Sort, Input: root}
+	}
+
+	if q.Skip != nil || q.Take != nil {
+		root = &limitPlan{Skip: q.Skip, Take: q.Take, Input: root}
+	}
+
+	// final projection
+	if q.Select != nil {
+		root = &selectPlan{Expr: q.Select, Input: root}
+	}
+
+	return root, nil
+}


### PR DESCRIPTION
## Summary
- add scaffolding for logical planner and physical planner in `runtime/data`
- implement `BuildPlan` for converting `QueryExpr` to a logical plan

## Testing
- `go vet ./...` *(fails: self-assignment warning)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847e53e117c8320ba77c8dc57f57936