### PR TITLE
Add Go FFI runtime

### DIFF
--- a/runtime/ffi/go/README.md
+++ b/runtime/ffi/go/README.md
@@ -1,0 +1,28 @@
+# Go FFI Runtime
+
+`runtime/ffi/go` exposes a small foreign function interface for calling native Go
+functions from Mochi. Functions are registered under a name and invoked by that
+name at runtime.
+
+```go
+import goffi "mochi/runtime/ffi/go"
+
+func init() {
+    goffi.Register("add", func(a, b int) int { return a + b })
+}
+```
+
+A registered function can later be called dynamically:
+
+```go
+res, err := goffi.Call("add", 2, 3)
+// res == 5
+```
+
+`Call` uses reflection to invoke the function with `[]any` arguments. If the
+function's final return value implements `error`, it is returned from `Call`.
+Otherwise the first return value (or slice of values) is provided.
+
+This package is intentionally minimal and keeps an in-process registry. Mochi's
+interpreter and compilers can translate `ffi("go", name)` expressions into
+`goffi.Call` invocations.

--- a/runtime/ffi/go/ffi.go
+++ b/runtime/ffi/go/ffi.go
@@ -1,0 +1,59 @@
+package goffi
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// registry holds all functions registered for FFI access.
+var registry = map[string]reflect.Value{}
+
+// Register makes a Go function available to Mochi by name.
+// It panics if fn is not a function.
+func Register(name string, fn any) {
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func {
+		panic("goffi: Register expects a function")
+	}
+	registry[name] = v
+}
+
+// Call invokes the function previously registered under name with the given arguments.
+// Arguments and return values are passed as 'any'. If the function's final return value
+// is an error, it is returned.
+func Call(name string, args ...any) (any, error) {
+	fn, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("goffi: unknown function %s", name)
+	}
+
+	if len(args) != fn.Type().NumIn() {
+		return nil, fmt.Errorf("goffi: %s expects %d args, got %d", name, fn.Type().NumIn(), len(args))
+	}
+
+	in := make([]reflect.Value, len(args))
+	for i, a := range args {
+		in[i] = reflect.ValueOf(a)
+	}
+
+	outs := fn.Call(in)
+	switch len(outs) {
+	case 0:
+		return nil, nil
+	case 1:
+		return outs[0].Interface(), nil
+	case 2:
+		if errv := outs[1]; !errv.IsNil() {
+			if err, ok := errv.Interface().(error); ok {
+				return outs[0].Interface(), err
+			}
+		}
+		return outs[0].Interface(), nil
+	default:
+		res := make([]any, len(outs))
+		for i, v := range outs {
+			res[i] = v.Interface()
+		}
+		return res, nil
+	}
+}

--- a/runtime/ffi/go/ffi_test.go
+++ b/runtime/ffi/go/ffi_test.go
@@ -1,0 +1,27 @@
+package goffi_test
+
+import (
+	"fmt"
+	"testing"
+
+	goffi "mochi/runtime/ffi/go"
+)
+
+func TestCall(t *testing.T) {
+	goffi.Register("add", func(a, b int) int { return a + b })
+	res, err := goffi.Call("add", 2, 3)
+	if err != nil {
+		t.Fatalf("call failed: %v", err)
+	}
+	if res.(int) != 5 {
+		t.Fatalf("expected 5, got %v", res)
+	}
+}
+
+func TestCallWithError(t *testing.T) {
+	goffi.Register("fail", func() (int, error) { return 0, fmt.Errorf("boom") })
+	_, err := goffi.Call("fail")
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add runtime/ffi/go with registry-based FFI helpers
- document usage of Go FFI
- test Go FFI behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847e66b5aa4832081fe994aab0eaf98