### PR TITLE
Add TypeScript FFI runtime

### DIFF
--- a/runtime/ffi/ts/README.md
+++ b/runtime/ffi/ts/README.md
@@ -1,0 +1,57 @@
+# TypeScript FFI Runtime
+
+The `runtime/ffi/ts` package provides a minimal foreign function interface for
+running Mochi programs compiled to TypeScript. It exposes a small registry that
+allows host applications to register native TypeScript functions that can be
+invoked from generated Mochi code. The goal is to keep the runtime lightweight
+while making it easy to integrate with existing JavaScript or TypeScript
+libraries.
+
+## Goals
+
+- Allow Mochi code compiled to TypeScript to call host functions in a safe way.
+- Keep the API simple so it works in both Node and Deno environments.
+- Provide a mechanism to asynchronously load additional modules at runtime.
+
+## Usage
+
+```ts
+import { register, call, loadModule } from "./ffi.ts";
+
+// Register a simple function
+register("add", (a: number, b: number) => a + b);
+
+// Dynamically load functions from another module
+await loadModule("./math.ts");
+
+// Call a registered function from Mochi
+const result = await call("add", 1, 2);
+```
+
+All functions return `Promise<any>` so that both synchronous and asynchronous
+handlers are supported. Mochi's TypeScript compiler emits calls to `call()` when
+an `ffi` function is invoked in source code.
+
+## API
+
+### `register(name: string, fn: (...args: any[]) => any)`
+Registers a function under the given name.
+
+### `call(name: string, ...args: any[]): Promise<any>`
+Invokes a registered function. An error is thrown if the name is unknown.
+
+### `loadModule(path: string): Promise<void>`
+Dynamically imports the module at `path`. The module should call `register()`
+to expose its functions.
+
+## Example Module
+
+```ts
+// math.ts
+import { register } from "./ffi.ts";
+
+register("square", (n: number) => n * n);
+```
+
+With this design, Mochi programs can easily access existing TypeScript code
+through a stable FFI layer without pulling in large dependencies.

--- a/runtime/ffi/ts/ffi.ts
+++ b/runtime/ffi/ts/ffi.ts
@@ -1,0 +1,19 @@
+export type FfiFunction = (...args: any[]) => any | Promise<any>;
+
+const registry: Record<string, FfiFunction> = {};
+
+export function register(name: string, fn: FfiFunction): void {
+  registry[name] = fn;
+}
+
+export async function call(name: string, ...args: any[]): Promise<any> {
+  const fn = registry[name];
+  if (!fn) {
+    throw new Error(`unknown ffi function: ${name}`);
+  }
+  return await fn(...args);
+}
+
+export async function loadModule(path: string): Promise<void> {
+  await import(path);
+}


### PR DESCRIPTION
## Summary
- design a minimal FFI system for TypeScript
- document API and usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847e693269083209ccfac1df98fa20a