### PR TITLE
Add Python FFI runtime

### DIFF
--- a/runtime/ffi/python/README.md
+++ b/runtime/ffi/python/README.md
@@ -1,0 +1,37 @@
+# `mochi/runtime/ffi/python`
+
+This package provides a minimal Foreign Function Interface (FFI) for
+invoking Python code from Go.  It is intended for Mochi's interpreter and
+runtime to execute small Python snippets or call functions in existing
+modules without embedding CPython directly.
+
+The implementation shells out to `python3` and exchanges values using
+JSON.  Arguments are marshalled into a JSON array which is made
+available to the Python process via the `MOCHI_ARGS` environment
+variable.  The executed script is expected to output a JSON encoded
+result to `stdout`.
+
+Example usage:
+
+```go
+import "mochi/runtime/ffi/python"
+
+// Call a function from the standard library.
+res, err := python.Call("math", "sqrt", 9)
+if err != nil {
+        log.Fatal(err)
+}
+fmt.Println(res) // 3.0
+```
+
+The helper `Exec` runs an arbitrary code block and returns its result:
+
+```go
+result, _ := python.Exec(`
+return args[0] + args[1]
+`, 2, 3)
+fmt.Println(result) // 5
+```
+
+This lightweight approach avoids cgo dependencies while making it easy
+to leverage Python's vast ecosystem from Mochi programs.

--- a/runtime/ffi/python/python.go
+++ b/runtime/ffi/python/python.go
@@ -1,0 +1,77 @@
+package python
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Call executes fn from the given module with the provided arguments.
+//
+// The arguments are encoded to JSON and exposed to the Python process
+// via the MOCHI_ARGS environment variable. The function's return value
+// must be JSON serialisable and is decoded into an arbitrary Go value.
+func Call(module, fn string, args ...any) (any, error) {
+	src := fmt.Sprintf(`import json, os, importlib, sys
+args = json.loads(os.environ.get("MOCHI_ARGS", "[]"))
+mod = importlib.import_module("%s")
+res = getattr(mod, "%s")(*args)
+json.dump(res, sys.stdout)
+`, module, fn)
+	return run(src, args)
+}
+
+// Exec runs an arbitrary Python code block. The code is wrapped into
+// a function that receives the argument list as `args` and should
+// return the result. The returned value must be JSON serialisable.
+func Exec(code string, args ...any) (any, error) {
+	// indent user code for the wrapper function
+	indented := indent(code, "    ")
+	src := fmt.Sprintf("import json, os, sys\nargs = json.loads(os.environ.get('MOCHI_ARGS', '[]'))\n"+
+		"def __mochi_fn(args):\n%s\nres = __mochi_fn(args)\njson.dump(res, sys.stdout)\n", indented)
+	return run(src, args)
+}
+
+func run(code string, args []any) (any, error) {
+	file, err := os.CreateTemp("", "mochi_py_*.py")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(file.Name())
+	if _, err := file.WriteString(code); err != nil {
+		file.Close()
+		return nil, err
+	}
+	file.Close()
+
+	data, err := json.Marshal(args)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("python3", file.Name())
+	cmd.Env = append(os.Environ(), "MOCHI_ARGS="+string(data))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("python error: %w\n%s", err, out)
+	}
+
+	var result any
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("decode error: %w\noutput: %s", err, out)
+	}
+	return result, nil
+}
+
+func indent(code, prefix string) string {
+	if code == "" {
+		return ""
+	}
+	lines := strings.Split(code, "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}

--- a/runtime/ffi/python/python_test.go
+++ b/runtime/ffi/python/python_test.go
@@ -1,0 +1,31 @@
+package python_test
+
+import (
+	"testing"
+
+	"mochi/runtime/ffi/python"
+)
+
+func TestCallStdlib(t *testing.T) {
+	res, err := python.Call("math", "sqrt", 9)
+	if err != nil {
+		t.Fatalf("call math.sqrt: %v", err)
+	}
+	f, ok := res.(float64)
+	if !ok || f != 3 {
+		t.Fatalf("unexpected result: %v", res)
+	}
+}
+
+func TestExecAdd(t *testing.T) {
+	res, err := python.Exec(`
+return args[0] + args[1]
+`, 2, 3)
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	n, ok := res.(float64)
+	if !ok || n != 5 {
+		t.Fatalf("unexpected result: %v", res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `runtime/ffi/python` to call Python from Mochi
- add simple exec and call helpers using `python3`
- document usage in new README
- test calling standard library and inline code

## Testing
- `go test ./runtime/ffi/python -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847e67f0edc8320b43d64f889d213c9