### PR TITLE
Refactor FFI runtimes

### DIFF
--- a/runtime/ffi/README.md
+++ b/runtime/ffi/README.md
@@ -1,0 +1,25 @@
+# Runtime FFI
+
+This directory contains language specific runtimes used to invoke foreign
+functions from Mochi programs. Each runtime implements a small set of common
+interfaces defined in [`ffi.go`](./ffi.go):
+
+```go
+// Caller invokes a registered function by name.
+type Caller interface {
+    Call(name string, args ...any) (any, error)
+}
+
+// Registerer registers a function for later invocation.
+type Registerer interface {
+    Register(name string, fn any) error
+}
+
+// Loader loads additional modules that may register functions.
+type Loader interface {
+    LoadModule(path string) error
+}
+```
+
+The Go, TypeScript and Python runtimes expose concrete implementations of these
+APIs while also providing package level helpers for convenience.

--- a/runtime/ffi/ffi.go
+++ b/runtime/ffi/ffi.go
@@ -1,0 +1,16 @@
+package ffi
+
+// Caller invokes a registered foreign function by name with arguments.
+type Caller interface {
+	Call(name string, args ...any) (any, error)
+}
+
+// Registerer allows registration of functions for later invocation.
+type Registerer interface {
+	Register(name string, fn any) error
+}
+
+// Loader loads modules that may register additional functions.
+type Loader interface {
+	LoadModule(path string) error
+}

--- a/runtime/ffi/go/ffi.go
+++ b/runtime/ffi/go/ffi.go
@@ -3,26 +3,55 @@ package goffi
 import (
 	"fmt"
 	"reflect"
+
+	"mochi/runtime/ffi"
 )
 
-// registry holds all functions registered for FFI access.
-var registry = map[string]reflect.Value{}
+// Ensure *Runtime implements ffi.Caller and ffi.Registerer.
+var _ ffi.Caller = (*Runtime)(nil)
+var _ ffi.Registerer = (*Runtime)(nil)
+
+// Runtime maintains a registry of Go functions available to Mochi.
+type Runtime struct {
+	registry map[string]reflect.Value
+}
+
+// NewRuntime creates an empty FFI runtime.
+func NewRuntime() *Runtime {
+	return &Runtime{registry: make(map[string]reflect.Value)}
+}
+
+// defaultRuntime is used by package-level helpers.
+var defaultRuntime = NewRuntime()
 
 // Register makes a Go function available to Mochi by name.
 // It panics if fn is not a function.
 func Register(name string, fn any) {
-	v := reflect.ValueOf(fn)
-	if v.Kind() != reflect.Func {
-		panic("goffi: Register expects a function")
+	if err := defaultRuntime.Register(name, fn); err != nil {
+		panic(err)
 	}
-	registry[name] = v
 }
 
 // Call invokes the function previously registered under name with the given arguments.
 // Arguments and return values are passed as 'any'. If the function's final return value
 // is an error, it is returned.
 func Call(name string, args ...any) (any, error) {
-	fn, ok := registry[name]
+	return defaultRuntime.Call(name, args...)
+}
+
+// Register implements ffi.Registerer.
+func (r *Runtime) Register(name string, fn any) error {
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func {
+		return fmt.Errorf("goffi: Register expects a function")
+	}
+	r.registry[name] = v
+	return nil
+}
+
+// Call implements ffi.Caller.
+func (r *Runtime) Call(name string, args ...any) (any, error) {
+	fn, ok := r.registry[name]
 	if !ok {
 		return nil, fmt.Errorf("goffi: unknown function %s", name)
 	}

--- a/runtime/ffi/ts/ffi.ts
+++ b/runtime/ffi/ts/ffi.ts
@@ -1,19 +1,47 @@
 export type FfiFunction = (...args: any[]) => any | Promise<any>;
 
-const registry: Record<string, FfiFunction> = {};
+export interface Caller {
+  call(name: string, ...args: any[]): Promise<any>;
+}
+
+export interface Registerer {
+  register(name: string, fn: FfiFunction): void;
+}
+
+export interface Loader {
+  loadModule(path: string): Promise<void>;
+}
+
+export class Runtime implements Caller, Registerer, Loader {
+  private registry: Record<string, FfiFunction> = {};
+
+  register(name: string, fn: FfiFunction): void {
+    this.registry[name] = fn;
+  }
+
+  async call(name: string, ...args: any[]): Promise<any> {
+    const fn = this.registry[name];
+    if (!fn) {
+      throw new Error(`unknown ffi function: ${name}`);
+    }
+    return await fn(...args);
+  }
+
+  async loadModule(path: string): Promise<void> {
+    await import(path);
+  }
+}
+
+const defaultRuntime = new Runtime();
 
 export function register(name: string, fn: FfiFunction): void {
-  registry[name] = fn;
+  defaultRuntime.register(name, fn);
 }
 
-export async function call(name: string, ...args: any[]): Promise<any> {
-  const fn = registry[name];
-  if (!fn) {
-    throw new Error(`unknown ffi function: ${name}`);
-  }
-  return await fn(...args);
+export function call(name: string, ...args: any[]): Promise<any> {
+  return defaultRuntime.call(name, ...args);
 }
 
-export async function loadModule(path: string): Promise<void> {
-  await import(path);
+export function loadModule(path: string): Promise<void> {
+  return defaultRuntime.loadModule(path);
 }


### PR DESCRIPTION
## Summary
- introduce generic `runtime/ffi` interfaces
- implement `Runtime` types for Go, TypeScript and Python FFI packages
- add README for FFI interfaces

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847e938ba6c832080530c6b6e67093b