### PR TITLE
Add dynamic Attr access in Python FFI

### DIFF
--- a/runtime/ffi/python/README.md
+++ b/runtime/ffi/python/README.md
@@ -33,5 +33,15 @@ return args[0] + args[1]
 fmt.Println(result) // 5
 ```
 
+`Attr` can retrieve variables or call functions dynamically:
+
+```go
+v, _ := python.Attr("math", "pi")
+fmt.Println(v) // 3.141592653589793
+
+res, _ := python.Attr("math", "pow", 2, 3)
+fmt.Println(res) // 8
+```
+
 This lightweight approach avoids cgo dependencies while making it easy
 to leverage Python's vast ecosystem from Mochi programs.

--- a/runtime/ffi/python/python_test.go
+++ b/runtime/ffi/python/python_test.go
@@ -29,3 +29,25 @@ return args[0] + args[1]
 		t.Fatalf("unexpected result: %v", res)
 	}
 }
+
+func TestAttrVariable(t *testing.T) {
+	res, err := python.Attr("math", "pi")
+	if err != nil {
+		t.Fatalf("attr math.pi: %v", err)
+	}
+	f, ok := res.(float64)
+	if !ok || f <= 3.14 || f >= 3.15 { // rough check
+		t.Fatalf("unexpected result: %v", res)
+	}
+}
+
+func TestAttrFunction(t *testing.T) {
+	res, err := python.Attr("math", "pow", 2, 3)
+	if err != nil {
+		t.Fatalf("attr math.pow: %v", err)
+	}
+	n, ok := res.(float64)
+	if !ok || n != 8 {
+		t.Fatalf("unexpected result: %v", res)
+	}
+}


### PR DESCRIPTION
## Summary
- extend Python FFI with `Attr` for dynamic reflection on modules
- call `Attr` from `Call` and ensure args are encoded correctly
- document new helper in README
- test reading variables and calling functions via `Attr`

## Testing
- `go test ./runtime/ffi/python -run .`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68480604d2b08320af9f355f93eb62aa