### PR TITLE
Enhance TS FFI with reflection

### DIFF
--- a/runtime/ffi/ts/ffi.test.ts
+++ b/runtime/ffi/ts/ffi.test.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import path from 'path';
+import { register, call, loadModule } from './ffi';
+
+(async () => {
+  register('add', (a: number, b: number) => a + b);
+  const sum = await call('add', 2, 3);
+  assert.strictEqual(sum, 5);
+
+  register('answer', 42);
+  const ans = await call('answer');
+  assert.strictEqual(ans, 42);
+
+  const dir = __dirname;
+  await loadModule(path.join(dir, 'sample-module.mjs'));
+  const pi = await call('pi');
+  assert.strictEqual(pi, 3.14);
+
+  const sq = await call('square', 4);
+  assert.strictEqual(sq, 16);
+
+  try {
+    await call('pi', 1);
+    assert.fail('expected error');
+  } catch (err: any) {
+    assert.ok((err as Error).message.includes('not callable'));
+  }
+
+  console.log('all tests passed');
+})();

--- a/runtime/ffi/ts/sample-module.mjs
+++ b/runtime/ffi/ts/sample-module.mjs
@@ -1,0 +1,2 @@
+export const pi = 3.14;
+export function square(n) { return n * n; }


### PR DESCRIPTION
## Summary
- allow ffi registry to store any value
- dynamically register all exports when loading a module
- update README with new behaviour and examples
- add tests for TS runtime

## Testing
- `npx --yes ts-node --transpile-only --compiler-options '{"module":"commonjs"}' runtime/ffi/ts/ffi.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684805e6693483209fed9447b338c6b2