### PR TITLE
Add extern declarations support

### DIFF
--- a/examples/v0.6/extern.mochi
+++ b/examples/v0.6/extern.mochi
@@ -1,0 +1,17 @@
+// extern.mochi
+// External bindings — syntax only, with one example per kind
+
+extern type socket
+extern type time
+extern type file
+
+extern var OS: string
+extern var ARGV: list<string>
+
+extern fun now(): time
+extern fun getenv(key: string, default: string): string
+extern fun read_file(path: string): string
+extern fun exists(path: string): bool
+extern fun sin(x: float): float
+extern fun fetch(url: string): string
+extern fun generate_text(prompt: string): string

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -24,33 +24,39 @@ import (
 
 // Interpreter executes Mochi programs using a shared runtime and type environment.
 type Interpreter struct {
-	prog     *parser.Program
-	env      *types.Env
-	types    *types.Env
-	streams  map[string]stream.Stream
-	handlers map[string][]onHandler
-	subs     []stream.Subscriber
-	cancels  []context.CancelFunc
-	wg       *sync.WaitGroup
-	agents   []*agent.Agent
-	memoize  bool
-	memo     map[string]map[string]any
+	prog        *parser.Program
+	env         *types.Env
+	types       *types.Env
+	streams     map[string]stream.Stream
+	handlers    map[string][]onHandler
+	subs        []stream.Subscriber
+	cancels     []context.CancelFunc
+	wg          *sync.WaitGroup
+	agents      []*agent.Agent
+	externTypes map[string]*parser.ExternTypeDecl
+	externVars  map[string]*parser.ExternVarDecl
+	externFuncs map[string]*parser.ExternFunDecl
+	memoize     bool
+	memo        map[string]map[string]any
 }
 
 func New(prog *parser.Program, typesEnv *types.Env) *Interpreter {
 	return &Interpreter{
 		prog: prog,
 		// env:   types.NewEnv(nil),
-		env:      typesEnv,
-		types:    typesEnv,
-		streams:  map[string]stream.Stream{},
-		handlers: map[string][]onHandler{},
-		subs:     []stream.Subscriber{},
-		cancels:  []context.CancelFunc{},
-		wg:       &sync.WaitGroup{},
-		agents:   []*agent.Agent{},
-		memoize:  false,
-		memo:     map[string]map[string]any{},
+		env:         typesEnv,
+		types:       typesEnv,
+		streams:     map[string]stream.Stream{},
+		handlers:    map[string][]onHandler{},
+		subs:        []stream.Subscriber{},
+		cancels:     []context.CancelFunc{},
+		wg:          &sync.WaitGroup{},
+		agents:      []*agent.Agent{},
+		externTypes: map[string]*parser.ExternTypeDecl{},
+		externVars:  map[string]*parser.ExternVarDecl{},
+		externFuncs: map[string]*parser.ExternFunDecl{},
+		memoize:     false,
+		memo:        map[string]map[string]any{},
 	}
 }
 
@@ -380,6 +386,21 @@ func (i *Interpreter) evalStmt(s *parser.Statement) error {
 
 	case s.Type != nil:
 		// type declarations have no runtime effect
+		return nil
+
+	case s.ExternType != nil:
+		// Placeholder for registering external types later
+		i.externTypes[s.ExternType.Name] = s.ExternType
+		return nil
+
+	case s.ExternVar != nil:
+		// Placeholder for registering external variables later
+		i.externVars[s.ExternVar.Name] = s.ExternVar
+		return nil
+
+	case s.ExternFun != nil:
+		// Placeholder for registering external functions later
+		i.externFuncs[s.ExternFun.Name] = s.ExternFun
 		return nil
 
 	case s.Stream != nil:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,7 +23,7 @@ func (b *boolLit) Capture(values []string) error {
 var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Comment", Pattern: `//[^\n]*|/\*([^*]|\*+[^*/])*\*+/`},
 	{Name: "Bool", Pattern: `\b(true|false)\b`},
-	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch)\b`},
+	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch)\b`},
 	{Name: "Ident", Pattern: `[\p{L}\p{So}_][\p{L}\p{So}\p{N}_]*`},
 	{Name: "Float", Pattern: `\d+\.\d+`},
 	{Name: "Int", Pattern: `\d+`},
@@ -40,26 +40,29 @@ type Program struct {
 }
 
 type Statement struct {
-	Pos      lexer.Position
-	Test     *TestBlock    `parser:"@@"`
-	Expect   *ExpectStmt   `parser:"| @@"`
-	Agent    *AgentDecl    `parser:"| @@"`
-	Stream   *StreamDecl   `parser:"| @@"`
-	Model    *ModelDecl    `parser:"| @@"`
-	Type     *TypeDecl     `parser:"| @@"`
-	On       *OnHandler    `parser:"| @@"`
-	Emit     *EmitStmt     `parser:"| @@"`
-	Let      *LetStmt      `parser:"| @@"`
-	Var      *VarStmt      `parser:"| @@"`
-	Assign   *AssignStmt   `parser:"| @@"`
-	Fun      *FunStmt      `parser:"| @@"`
-	Return   *ReturnStmt   `parser:"| @@"`
-	If       *IfStmt       `parser:"| @@"`
-	While    *WhileStmt    `parser:"| @@"`
-	For      *ForStmt      `parser:"| @@"`
-	Break    *BreakStmt    `parser:"| @@"`
-	Continue *ContinueStmt `parser:"| @@"`
-	Expr     *ExprStmt     `parser:"| @@"`
+	Pos        lexer.Position
+	Test       *TestBlock      `parser:"@@"`
+	Expect     *ExpectStmt     `parser:"| @@"`
+	Agent      *AgentDecl      `parser:"| @@"`
+	Stream     *StreamDecl     `parser:"| @@"`
+	Model      *ModelDecl      `parser:"| @@"`
+	Type       *TypeDecl       `parser:"| @@"`
+	ExternType *ExternTypeDecl `parser:"| @@"`
+	ExternVar  *ExternVarDecl  `parser:"| @@"`
+	ExternFun  *ExternFunDecl  `parser:"| @@"`
+	On         *OnHandler      `parser:"| @@"`
+	Emit       *EmitStmt       `parser:"| @@"`
+	Let        *LetStmt        `parser:"| @@"`
+	Var        *VarStmt        `parser:"| @@"`
+	Assign     *AssignStmt     `parser:"| @@"`
+	Fun        *FunStmt        `parser:"| @@"`
+	Return     *ReturnStmt     `parser:"| @@"`
+	If         *IfStmt         `parser:"| @@"`
+	While      *WhileStmt      `parser:"| @@"`
+	For        *ForStmt        `parser:"| @@"`
+	Break      *BreakStmt      `parser:"| @@"`
+	Continue   *ContinueStmt   `parser:"| @@"`
+	Expr       *ExprStmt       `parser:"| @@"`
 }
 
 // --- Test and Expect ---
@@ -188,6 +191,24 @@ type BreakStmt struct {
 
 type ContinueStmt struct {
 	Pos lexer.Position `parser:"'continue'"`
+}
+
+type ExternTypeDecl struct {
+	Pos  lexer.Position
+	Name string `parser:"'extern' 'type' @Ident"`
+}
+
+type ExternVarDecl struct {
+	Pos  lexer.Position
+	Name string   `parser:"'extern' 'var' @Ident ':'"`
+	Type *TypeRef `parser:"@@"`
+}
+
+type ExternFunDecl struct {
+	Pos    lexer.Position
+	Name   string   `parser:"'extern' 'fun' @Ident"`
+	Params []*Param `parser:"'(' [ @@ { ',' @@ } ] ')'"`
+	Return *TypeRef `parser:"[ ':' @@ ]"`
 }
 
 type Param struct {


### PR DESCRIPTION
## Summary
- add `extern.mochi` example for external bindings
- extend parser with `extern` keyword and declarations for types, vars, and functions
- store extern declarations in interpreter for future use

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684831ad8e38832096af59aff9cb223b