### PR TITLE
Add extern object declarations

### DIFF
--- a/examples/v0.6/extern.mochi
+++ b/examples/v0.6/extern.mochi
@@ -4,6 +4,8 @@
 extern type socket
 extern type time
 extern type file
+extern object console
+extern object fs
 
 extern var OS: string
 extern var ARGV: list<string>

--- a/interpreter/errors.go
+++ b/interpreter/errors.go
@@ -40,6 +40,7 @@ var Errors = map[string]diagnostic.Template{
 	"I019": {Code: "I019", Message: "cannot iterate over value of type %s", Help: "Only `list`, `map`, and `string` are iterable in `for ... in` loops."},
 	"I020": {Code: "I020", Message: "cannot cast %T to %s", Help: "Ensure the value matches the expected type."},
 	"I021": {Code: "I021", Message: "missing field `%s` for %s", Help: "Check that all required fields are present."},
+	"I022": {Code: "I022", Message: "extern object not resolved: %s", Help: "Register extern object `%s` before use."},
 }
 
 // --- Variables and Functions ---
@@ -120,4 +121,8 @@ func errCastType(pos lexer.Position, val any, typ types.Type) error {
 
 func errCastMissingField(pos lexer.Position, field, typ string) error {
 	return Errors["I021"].New(pos, field, typ)
+}
+
+func errExternObject(pos lexer.Position, name string) error {
+	return Errors["I022"].New(pos, name, name)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -40,29 +40,30 @@ type Program struct {
 }
 
 type Statement struct {
-	Pos        lexer.Position
-	Test       *TestBlock      `parser:"@@"`
-	Expect     *ExpectStmt     `parser:"| @@"`
-	Agent      *AgentDecl      `parser:"| @@"`
-	Stream     *StreamDecl     `parser:"| @@"`
-	Model      *ModelDecl      `parser:"| @@"`
-	Type       *TypeDecl       `parser:"| @@"`
-	ExternType *ExternTypeDecl `parser:"| @@"`
-	ExternVar  *ExternVarDecl  `parser:"| @@"`
-	ExternFun  *ExternFunDecl  `parser:"| @@"`
-	On         *OnHandler      `parser:"| @@"`
-	Emit       *EmitStmt       `parser:"| @@"`
-	Let        *LetStmt        `parser:"| @@"`
-	Var        *VarStmt        `parser:"| @@"`
-	Assign     *AssignStmt     `parser:"| @@"`
-	Fun        *FunStmt        `parser:"| @@"`
-	Return     *ReturnStmt     `parser:"| @@"`
-	If         *IfStmt         `parser:"| @@"`
-	While      *WhileStmt      `parser:"| @@"`
-	For        *ForStmt        `parser:"| @@"`
-	Break      *BreakStmt      `parser:"| @@"`
-	Continue   *ContinueStmt   `parser:"| @@"`
-	Expr       *ExprStmt       `parser:"| @@"`
+	Pos          lexer.Position
+	Test         *TestBlock        `parser:"@@"`
+	Expect       *ExpectStmt       `parser:"| @@"`
+	Agent        *AgentDecl        `parser:"| @@"`
+	Stream       *StreamDecl       `parser:"| @@"`
+	Model        *ModelDecl        `parser:"| @@"`
+	Type         *TypeDecl         `parser:"| @@"`
+	ExternType   *ExternTypeDecl   `parser:"| @@"`
+	ExternVar    *ExternVarDecl    `parser:"| @@"`
+	ExternFun    *ExternFunDecl    `parser:"| @@"`
+	ExternObject *ExternObjectDecl `parser:"| @@"`
+	On           *OnHandler        `parser:"| @@"`
+	Emit         *EmitStmt         `parser:"| @@"`
+	Let          *LetStmt          `parser:"| @@"`
+	Var          *VarStmt          `parser:"| @@"`
+	Assign       *AssignStmt       `parser:"| @@"`
+	Fun          *FunStmt          `parser:"| @@"`
+	Return       *ReturnStmt       `parser:"| @@"`
+	If           *IfStmt           `parser:"| @@"`
+	While        *WhileStmt        `parser:"| @@"`
+	For          *ForStmt          `parser:"| @@"`
+	Break        *BreakStmt        `parser:"| @@"`
+	Continue     *ContinueStmt     `parser:"| @@"`
+	Expr         *ExprStmt         `parser:"| @@"`
 }
 
 // --- Test and Expect ---
@@ -209,6 +210,10 @@ type ExternFunDecl struct {
 	Name   string   `parser:"'extern' 'fun' @Ident"`
 	Params []*Param `parser:"'(' [ @@ { ',' @@ } ] ')'"`
 	Return *TypeRef `parser:"[ ':' @@ ]"`
+}
+type ExternObjectDecl struct {
+	Pos  lexer.Position
+	Name string `parser:"'extern' 'object' @Ident"`
 }
 
 type Param struct {

--- a/runtime/extern/extern.go
+++ b/runtime/extern/extern.go
@@ -1,0 +1,30 @@
+package extern
+
+import "sync"
+
+var (
+	mu      sync.RWMutex
+	objects = make(map[string]any)
+)
+
+// Register associates an object with a name.
+func Register(name string, obj any) {
+	mu.Lock()
+	objects[name] = obj
+	mu.Unlock()
+}
+
+// Get retrieves a registered object.
+func Get(name string) (any, bool) {
+	mu.RLock()
+	obj, ok := objects[name]
+	mu.RUnlock()
+	return obj, ok
+}
+
+// Reset clears all registered objects.
+func Reset() {
+	mu.Lock()
+	objects = make(map[string]any)
+	mu.Unlock()
+}


### PR DESCRIPTION
## Summary
- extend parser with `extern object` declarations
- track extern objects in interpreter and error if referenced
- manage external objects via new `runtime/extern` package
- update example extern.mochi with object declarations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68483682fbb88320864d8adf07369abf