### PR TITLE
Add extern object runtime checks

### DIFF
--- a/examples/v0.6/extern.mochi
+++ b/examples/v0.6/extern.mochi
@@ -17,3 +17,9 @@ extern fun exists(path: string): bool
 extern fun sin(x: float): float
 extern fun fetch(url: string): string
 extern fun generate_text(prompt: string): string
+
+// Extern objects can be referenced directly.
+// These calls will resolve to host implementations
+// registered via `runtime/extern`.
+
+console.log("running on", OS)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -67,6 +67,15 @@ func (i *Interpreter) SetProgram(prog *parser.Program) {
 	i.prog = prog
 }
 
+func (i *Interpreter) checkExternObjects() error {
+	for name, decl := range i.externObjects {
+		if _, ok := extern.Get(name); !ok {
+			return errExternObject(decl.Pos, name)
+		}
+	}
+	return nil
+}
+
 // SetMemoization enables or disables memoization of pure function calls.
 func (i *Interpreter) SetMemoization(enable bool) {
 	i.memoize = enable
@@ -116,6 +125,9 @@ func formatDuration(d time.Duration) string {
 
 func (i *Interpreter) Run() error {
 	defer i.Close()
+	if err := i.checkExternObjects(); err != nil {
+		return err
+	}
 	/*
 		// Load all shared definitions (let, fun) first
 		for _, stmt := range i.prog.Statements {
@@ -142,6 +154,9 @@ func (i *Interpreter) Run() error {
 
 func (i *Interpreter) Test() error {
 	defer i.Close()
+	if err := i.checkExternObjects(); err != nil {
+		return err
+	}
 	var failures []error
 
 	// Preload all shared declarations (let, fun)


### PR DESCRIPTION
## Summary
- document extern object usage in `extern.mochi`
- check for registered extern objects before running programs

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68483cf8fb888320bcbe82c2d6fc5ae0