### PR TITLE
Refactor extern registry

### DIFF
--- a/runtime/extern/extern.go
+++ b/runtime/extern/extern.go
@@ -2,29 +2,47 @@ package extern
 
 import "sync"
 
-var (
+// Registry manages a collection of registered objects.
+type Registry struct {
 	mu      sync.RWMutex
-	objects = make(map[string]any)
-)
+	objects map[string]any
+}
+
+// NewRegistry creates a new empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{objects: make(map[string]any)}
+}
 
 // Register associates an object with a name.
-func Register(name string, obj any) {
-	mu.Lock()
-	objects[name] = obj
-	mu.Unlock()
+func (r *Registry) Register(name string, obj any) {
+	r.mu.Lock()
+	r.objects[name] = obj
+	r.mu.Unlock()
 }
 
 // Get retrieves a registered object.
-func Get(name string) (any, bool) {
-	mu.RLock()
-	obj, ok := objects[name]
-	mu.RUnlock()
+func (r *Registry) Get(name string) (any, bool) {
+	r.mu.RLock()
+	obj, ok := r.objects[name]
+	r.mu.RUnlock()
 	return obj, ok
 }
 
 // Reset clears all registered objects.
-func Reset() {
-	mu.Lock()
-	objects = make(map[string]any)
-	mu.Unlock()
+func (r *Registry) Reset() {
+	r.mu.Lock()
+	r.objects = make(map[string]any)
+	r.mu.Unlock()
 }
+
+// DefaultRegistry is used when package-level functions are called.
+var DefaultRegistry = NewRegistry()
+
+// Register associates an object with a name using the DefaultRegistry.
+func Register(name string, obj any) { DefaultRegistry.Register(name, obj) }
+
+// Get retrieves a registered object from the DefaultRegistry.
+func Get(name string) (any, bool) { return DefaultRegistry.Get(name) }
+
+// Reset clears all objects from the DefaultRegistry.
+func Reset() { DefaultRegistry.Reset() }


### PR DESCRIPTION
## Summary
- add Registry type for extern objects
- keep default package-level registry for backwards compatibility

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_68483f491e148320b436e6f5abc57045