### PR TITLE
Add load expression and CSV support

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -449,6 +449,14 @@ func FromPrimary(p *parser.Primary) *Node {
 		}
 		return n
 
+	case p.Load != nil:
+		n := &Node{Kind: "load"}
+		n.Children = append(n.Children, &Node{Kind: "string", Value: p.Load.Path})
+		if p.Load.Type != nil {
+			n.Children = append(n.Children, FromTypeRef(p.Load.Type))
+		}
+		return n
+
 	case p.Lit != nil:
 		switch {
 		case p.Lit.Float != nil:

--- a/examples/v0.6/load.mochi
+++ b/examples/v0.6/load.mochi
@@ -1,0 +1,21 @@
+// Define a type for the record structure
+type Person {
+  name: string,
+  age: int
+}
+
+// Load the dataset with type enforcement
+let people = load "people.csv" as Person
+
+// Query only adults
+let adults = from person in people
+             where person.age >= 18
+             select {
+               name: person.name,
+               age: person.age
+             }
+
+// Print each adult
+for person in adults {
+  print(person.name, "is", person.age, "years old")
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1037,6 +1037,29 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		}
 		return mhttp.FetchWith(urlStr, opts)
 
+	case p.Load != nil:
+		rows, err := loadCSV(p.Load.Path)
+		if err != nil {
+			return nil, err
+		}
+		items := make([]any, len(rows))
+		var typ types.Type
+		if p.Load.Type != nil {
+			typ = resolveTypeRef(p.Load.Type, i.types)
+		}
+		for idx, row := range rows {
+			v := any(row)
+			if p.Load.Type != nil {
+				cv, err := castValue(p.Load.Pos, typ, row)
+				if err != nil {
+					return nil, err
+				}
+				v = cv
+			}
+			items[idx] = v
+		}
+		return items, nil
+
 	case p.Generate != nil:
 		reqParams := map[string]any{}
 		var (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,7 +23,7 @@ func (b *boolLit) Capture(values []string) error {
 var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Comment", Pattern: `//[^\n]*|/\*([^*]|\*+[^*/])*\*+/`},
 	{Name: "Bool", Pattern: `\b(true|false)\b`},
-	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch)\b`},
+	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch|load)\b`},
 	{Name: "Ident", Pattern: `[\p{L}\p{So}_][\p{L}\p{So}\p{N}_]*`},
 	{Name: "Float", Pattern: `\d+\.\d+`},
 	{Name: "Int", Pattern: `\d+`},
@@ -321,6 +321,12 @@ type FetchExpr struct {
 	With *Expr `parser:"[ 'with' @@ ]"`
 }
 
+type LoadExpr struct {
+	Pos  lexer.Position
+	Path string   `parser:"'load' @String 'as'"`
+	Type *TypeRef `parser:"@@"`
+}
+
 type QueryExpr struct {
 	Pos    lexer.Position
 	Var    string         `parser:"'from' @Ident 'in'"`
@@ -379,6 +385,7 @@ type Primary struct {
 	Match    *MatchExpr     `parser:"| @@"`
 	Generate *GenerateExpr  `parser:"| @@"`
 	Fetch    *FetchExpr     `parser:"| @@"`
+	Load     *LoadExpr      `parser:"| @@"`
 	Lit      *Literal       `parser:"| @@"`
 	Group    *Expr          `parser:"| '(' @@ ')'"`
 }

--- a/tests/interpreter/valid/load_csv.mochi
+++ b/tests/interpreter/valid/load_csv.mochi
@@ -1,0 +1,12 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = load "../tests/interpreter/valid/people.csv" as Person
+let adults = from p in people
+             where p.age >= 18
+             select { name: p.name, age: p.age }
+for a in adults {
+  print(a.name, a.age)
+}

--- a/tests/interpreter/valid/load_csv.out
+++ b/tests/interpreter/valid/load_csv.out
@@ -1,0 +1,2 @@
+Alice 30
+Charlie 20

--- a/tests/interpreter/valid/people.csv
+++ b/tests/interpreter/valid/people.csv
@@ -1,0 +1,4 @@
+name,age
+Alice,30
+Bob,15
+Charlie,20

--- a/tests/parser/valid/load_expr.golden
+++ b/tests/parser/valid/load_expr.golden
@@ -1,0 +1,9 @@
+(program
+  (type Person
+    (field name (type string))
+    (field age (type int))
+  )
+  (let people
+    (load (string people.csv) (type Person))
+  )
+)

--- a/tests/parser/valid/load_expr.mochi
+++ b/tests/parser/valid/load_expr.mochi
@@ -1,0 +1,6 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = load "people.csv" as Person

--- a/types/check.go
+++ b/types/check.go
@@ -1318,6 +1318,13 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		}
 		return AnyType{}, nil
 
+	case p.Load != nil:
+		var elem Type = AnyType{}
+		if p.Load.Type != nil {
+			elem = resolveTypeRef(p.Load.Type, env)
+		}
+		return ListType{Elem: elem}, nil
+
 	case p.Match != nil:
 		return checkMatchExpr(p.Match, env, expected)
 


### PR DESCRIPTION
## Summary
- support `load` expression for datasets
- implement CSV loader with basic type coercion
- handle new `load` in parser, interpreter and type checker
- test parser and runtime functionality
- add example showing dataset loading

## Testing
- `go test ./parser`
- `go test ./interpreter`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684857c90a488320aeb93d2d3a3e6902