### PR TITLE
Refactor dataset handling

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1013,7 +1013,13 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		return obj, nil
 
 	case p.Query != nil:
-		return i.evalQuery(p.Query)
+		return data.RunQuery(p.Query, i.env, i.dataPlan, func(env *types.Env, e *parser.Expr) (any, error) {
+			old := i.env
+			i.env = env
+			val, err := i.evalExpr(e)
+			i.env = old
+			return val, err
+		})
 
 	case p.Match != nil:
 		return i.evalMatch(p.Match)
@@ -1038,7 +1044,7 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		return mhttp.FetchWith(urlStr, opts)
 
 	case p.Load != nil:
-		rows, err := loadCSV(p.Load.Path)
+		rows, err := data.LoadCSV(p.Load.Path)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/data/csv.go
+++ b/runtime/data/csv.go
@@ -1,0 +1,44 @@
+package data
+
+import (
+	"encoding/csv"
+	"os"
+	"strconv"
+)
+
+// LoadCSV reads a CSV file and returns its rows as a slice of maps.
+func LoadCSV(path string) ([]map[string]any, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	r := csv.NewReader(f)
+	rows, err := r.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	headers := rows[0]
+	out := make([]map[string]any, 0, len(rows)-1)
+	for _, rec := range rows[1:] {
+		m := map[string]any{}
+		for idx, h := range headers {
+			var val string
+			if idx < len(rec) {
+				val = rec[idx]
+			}
+			if iv, err := strconv.Atoi(val); err == nil {
+				m[h] = iv
+			} else if fv, err := strconv.ParseFloat(val, 64); err == nil {
+				m[h] = fv
+			} else {
+				m[h] = val
+			}
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}

--- a/runtime/data/query.go
+++ b/runtime/data/query.go
@@ -1,0 +1,21 @@
+package data
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// RunQuery executes the given query using the specified plan ("memory" or "duckdb").
+// A child environment is created from env for evaluation of embedded expressions.
+func RunQuery(q *parser.QueryExpr, env *types.Env, plan string, eval func(*types.Env, *parser.Expr) (any, error)) ([]any, error) {
+	child := types.NewEnv(env)
+	doEval := func(e *parser.Expr) (any, error) {
+		return eval(child, e)
+	}
+	switch plan {
+	case "duckdb":
+		return EvalQueryDuckDB(q, child, doEval)
+	default:
+		return EvalQuery(q, child, doEval)
+	}
+}


### PR DESCRIPTION
## Summary
- remove dataset query and CSV helpers from interpreter
- add `LoadCSV` and `RunQuery` utilities under `runtime/data`
- call new runtime helpers from interpreter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68485baadf7c8320a992471dfb31e80b