### PR TITLE
Add JSONL loader with options

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -455,6 +455,9 @@ func FromPrimary(p *parser.Primary) *Node {
 		if p.Load.Type != nil {
 			n.Children = append(n.Children, FromTypeRef(p.Load.Type))
 		}
+		if p.Load.With != nil {
+			n.Children = append(n.Children, FromExpr(p.Load.With))
+		}
 		return n
 
 	case p.Lit != nil:

--- a/examples/load_with.mochi
+++ b/examples/load_with.mochi
@@ -1,0 +1,16 @@
+// load_with.mochi
+// Load JSONL file into a typed list with options
+
+extern type Person {
+  name: string,
+  age: int,
+  email: string
+}
+
+let people = load "people.jsonl" as Person with {
+  format: "jsonl"
+}
+
+for p in people {
+  print(p.name, "is", p.age, "years old. Email:", p.email)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -325,6 +325,7 @@ type LoadExpr struct {
 	Pos  lexer.Position
 	Path string   `parser:"'load' @String 'as'"`
 	Type *TypeRef `parser:"@@"`
+	With *Expr    `parser:"[ 'with' @@ ]"`
 }
 
 type QueryExpr struct {

--- a/runtime/data/jsonl.go
+++ b/runtime/data/jsonl.go
@@ -1,0 +1,33 @@
+package data
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
+
+// LoadJSONL reads a JSON lines file and returns its rows as a slice of maps.
+func LoadJSONL(path string) ([]map[string]any, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	out := []map[string]any{}
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/tests/interpreter/valid/load_jsonl.mochi
+++ b/tests/interpreter/valid/load_jsonl.mochi
@@ -1,0 +1,13 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+let people = load "../tests/interpreter/valid/people.jsonl" as Person with { format: "jsonl" }
+let adults = from p in people
+             where p.age >= 18
+             select { name: p.name, email: p.email }
+for a in adults {
+  print(a.name, a.email)
+}

--- a/tests/interpreter/valid/load_jsonl.out
+++ b/tests/interpreter/valid/load_jsonl.out
@@ -1,0 +1,2 @@
+Alice alice@example.com
+Charlie charlie@example.com

--- a/tests/interpreter/valid/people.jsonl
+++ b/tests/interpreter/valid/people.jsonl
@@ -1,0 +1,3 @@
+{"name":"Alice","age":30,"email":"alice@example.com"}
+{"name":"Bob","age":15,"email":"bob@example.com"}
+{"name":"Charlie","age":20,"email":"charlie@example.com"}

--- a/tests/parser/valid/load_with_expr.golden
+++ b/tests/parser/valid/load_with_expr.golden
@@ -1,0 +1,17 @@
+(program
+  (type Person
+    (field name (type string))
+    (field age (type int))
+    (field email (type string))
+  )
+  (let people
+    (load
+      (string people.jsonl)
+      (type Person)
+      (map
+        (entry (selector format) (string jsonl))
+      )
+    )
+  )
+)
+

--- a/tests/parser/valid/load_with_expr.mochi
+++ b/tests/parser/valid/load_with_expr.mochi
@@ -1,0 +1,7 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+let people = load "people.jsonl" as Person with { format: "jsonl" }

--- a/tests/types/valid/load_with.golden
+++ b/tests/types/valid/load_with.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/load_with.mochi
+++ b/tests/types/valid/load_with.mochi
@@ -1,0 +1,7 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+let people = load "people.jsonl" as Person with { format: "jsonl" }


### PR DESCRIPTION
## Summary
- extend `load` syntax to accept `with { ... }` options
- allow interpreter to load JSONL via `format: "jsonl"`
- add `LoadJSONL` helper in runtime
- add example for loading JSONL with options
- test parser, type checker, and interpreter with new functionality

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6848606dbf248320b311f3ceed88e64d