### PR TITLE
Add save expression

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -460,6 +460,15 @@ func FromPrimary(p *parser.Primary) *Node {
 		}
 		return n
 
+	case p.Save != nil:
+		n := &Node{Kind: "save"}
+		n.Children = append(n.Children, FromExpr(p.Save.Src))
+		n.Children = append(n.Children, &Node{Kind: "string", Value: p.Save.Path})
+		if p.Save.With != nil {
+			n.Children = append(n.Children, FromExpr(p.Save.With))
+		}
+		return n
+
 	case p.Lit != nil:
 		switch {
 		case p.Lit.Float != nil:

--- a/examples/v0.6/save.mochi
+++ b/examples/v0.6/save.mochi
@@ -1,0 +1,20 @@
+// save.mochi
+// Save a list of records to both JSONL and CSV formats
+
+let people = [
+  { name: "Alice", age: 30, email: "alice@example.com" },
+  { name: "Bob", age: 25, email: "bob@example.com" }
+]
+
+// Save as JSONL
+save people to "people.jsonl" with {
+  format: "jsonl"
+}
+
+// Save as CSV
+save people to "people.csv" with {
+  format: "csv",
+  header: true,
+  delimiter: ","
+}
+

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,7 +23,7 @@ func (b *boolLit) Capture(values []string) error {
 var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Comment", Pattern: `//[^\n]*|/\*([^*]|\*+[^*/])*\*+/`},
 	{Name: "Bool", Pattern: `\b(true|false)\b`},
-	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch|load)\b`},
+	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch|load|save)\b`},
 	{Name: "Ident", Pattern: `[\p{L}\p{So}_][\p{L}\p{So}\p{N}_]*`},
 	{Name: "Float", Pattern: `\d+\.\d+`},
 	{Name: "Int", Pattern: `\d+`},
@@ -328,6 +328,13 @@ type LoadExpr struct {
 	With *Expr    `parser:"[ 'with' @@ ]"`
 }
 
+type SaveExpr struct {
+	Pos  lexer.Position
+	Src  *Expr  `parser:"'save' @@ 'to'"`
+	Path string `parser:"@String"`
+	With *Expr  `parser:"[ 'with' @@ ]"`
+}
+
 type QueryExpr struct {
 	Pos    lexer.Position
 	Var    string         `parser:"'from' @Ident 'in'"`
@@ -387,6 +394,7 @@ type Primary struct {
 	Generate *GenerateExpr  `parser:"| @@"`
 	Fetch    *FetchExpr     `parser:"| @@"`
 	Load     *LoadExpr      `parser:"| @@"`
+	Save     *SaveExpr      `parser:"| @@"`
 	Lit      *Literal       `parser:"| @@"`
 	Group    *Expr          `parser:"| '(' @@ ')'"`
 }

--- a/runtime/data/csv.go
+++ b/runtime/data/csv.go
@@ -2,7 +2,9 @@ package data
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"os"
+	"sort"
 	"strconv"
 )
 
@@ -41,4 +43,65 @@ func LoadCSV(path string) ([]map[string]any, error) {
 		out = append(out, m)
 	}
 	return out, nil
+}
+
+// SaveCSV writes rows to a CSV file using the given options.
+func SaveCSV(rows []map[string]any, path string, header bool, delim rune) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	if delim != 0 {
+		w.Comma = delim
+	}
+
+	if len(rows) == 0 {
+		if header {
+			w.Write([]string{})
+		}
+		w.Flush()
+		return w.Error()
+	}
+
+	// Determine column order from first row
+	headers := make([]string, 0, len(rows[0]))
+	for k := range rows[0] {
+		headers = append(headers, k)
+	}
+	sort.Strings(headers)
+	if header {
+		if err := w.Write(headers); err != nil {
+			return err
+		}
+	}
+	for _, row := range rows {
+		rec := make([]string, len(headers))
+		for i, h := range headers {
+			if v, ok := row[h]; ok {
+				switch x := v.(type) {
+				case nil:
+				case string:
+					rec[i] = x
+				case int:
+					rec[i] = strconv.Itoa(x)
+				case int64:
+					rec[i] = strconv.FormatInt(x, 10)
+				case float64:
+					rec[i] = strconv.FormatFloat(x, 'f', -1, 64)
+				case bool:
+					rec[i] = strconv.FormatBool(x)
+				default:
+					b, _ := json.Marshal(x)
+					rec[i] = string(b)
+				}
+			}
+		}
+		if err := w.Write(rec); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
 }

--- a/runtime/data/jsonl.go
+++ b/runtime/data/jsonl.go
@@ -31,3 +31,20 @@ func LoadJSONL(path string) ([]map[string]any, error) {
 	}
 	return out, nil
 }
+
+// SaveJSONL writes rows to a JSON lines file.
+func SaveJSONL(rows []map[string]any, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	enc := json.NewEncoder(w)
+	for _, row := range rows {
+		if err := enc.Encode(row); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}

--- a/tests/parser/valid/save_expr.golden
+++ b/tests/parser/valid/save_expr.golden
@@ -1,0 +1,23 @@
+(program
+  (let people
+    (list
+      (map
+        (entry (selector name) (string Alice))
+        (entry (selector age) (int 30))
+        (entry (selector email) (string "alice@example.com"))
+      )
+      (map
+        (entry (selector name) (string Bob))
+        (entry (selector age) (int 25))
+        (entry (selector email) (string "bob@example.com"))
+      )
+    )
+  )
+  (save
+    (selector people)
+    (string people.jsonl)
+    (map
+      (entry (selector format) (string jsonl))
+    )
+  )
+)

--- a/tests/parser/valid/save_expr.mochi
+++ b/tests/parser/valid/save_expr.mochi
@@ -1,0 +1,7 @@
+let people = [
+  { name: "Alice", age: 30, email: "alice@example.com" },
+  { name: "Bob", age: 25, email: "bob@example.com" }
+]
+
+save people to "people.jsonl" with { format: "jsonl" }
+


### PR DESCRIPTION
## Summary
- example of saving data in JSONL or CSV
- support `save` syntax in parser and AST conversion
- implement save handling in interpreter with helper `toMapSlice`
- implement `SaveCSV` and `SaveJSONL` helpers
- add parser test for `save` expression

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684865c181c4832084ae9f34c579e1f8