### PR TITLE
Add stdin/stdout load/save example and support

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -451,7 +451,9 @@ func FromPrimary(p *parser.Primary) *Node {
 
 	case p.Load != nil:
 		n := &Node{Kind: "load"}
-		n.Children = append(n.Children, &Node{Kind: "string", Value: p.Load.Path})
+		if p.Load.Path != nil {
+			n.Children = append(n.Children, &Node{Kind: "string", Value: *p.Load.Path})
+		}
 		if p.Load.Type != nil {
 			n.Children = append(n.Children, FromTypeRef(p.Load.Type))
 		}
@@ -463,7 +465,9 @@ func FromPrimary(p *parser.Primary) *Node {
 	case p.Save != nil:
 		n := &Node{Kind: "save"}
 		n.Children = append(n.Children, FromExpr(p.Save.Src))
-		n.Children = append(n.Children, &Node{Kind: "string", Value: p.Save.Path})
+		if p.Save.Path != nil {
+			n.Children = append(n.Children, &Node{Kind: "string", Value: *p.Save.Path})
+		}
 		if p.Save.With != nil {
 			n.Children = append(n.Children, FromExpr(p.Save.With))
 		}

--- a/examples/v0.6/load_save_stdinout.mochi
+++ b/examples/v0.6/load_save_stdinout.mochi
@@ -1,0 +1,19 @@
+// load_save_stdinout.mochi
+// Read JSONL from stdin, filter, and write JSONL to stdout
+
+ type Person {
+  name: string,
+  age: int
+}
+
+let people = load as Person with {
+  format: "jsonl"
+}
+
+let adults = from p in people
+             where p.age >= 18
+             select p
+
+save adults with {
+  format: "jsonl"
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1062,9 +1062,17 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		)
 		switch format {
 		case "jsonl":
-			rows, err = data.LoadJSONL(p.Load.Path)
+			if p.Load.Path == nil {
+				rows, err = data.LoadJSONLReader(os.Stdin)
+			} else {
+				rows, err = data.LoadJSONL(*p.Load.Path)
+			}
 		default:
-			rows, err = data.LoadCSV(p.Load.Path)
+			if p.Load.Path == nil {
+				rows, err = data.LoadCSVReader(os.Stdin)
+			} else {
+				rows, err = data.LoadCSV(*p.Load.Path)
+			}
 		}
 		if err != nil {
 			return nil, err
@@ -1117,9 +1125,17 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		}
 		switch format {
 		case "jsonl":
-			err = data.SaveJSONL(rows, p.Save.Path)
+			if p.Save.Path == nil {
+				err = data.SaveJSONLWriter(rows, os.Stdout)
+			} else {
+				err = data.SaveJSONL(rows, *p.Save.Path)
+			}
 		default:
-			err = data.SaveCSV(rows, p.Save.Path, header, delim)
+			if p.Save.Path == nil {
+				err = data.SaveCSVWriter(rows, os.Stdout, header, delim)
+			} else {
+				err = data.SaveCSV(rows, *p.Save.Path, header, delim)
+			}
 		}
 		if err != nil {
 			return nil, err

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -323,16 +323,16 @@ type FetchExpr struct {
 
 type LoadExpr struct {
 	Pos  lexer.Position
-	Path string   `parser:"'load' @String 'as'"`
+	Path *string  `parser:"'load' [ @String ] 'as'"`
 	Type *TypeRef `parser:"@@"`
 	With *Expr    `parser:"[ 'with' @@ ]"`
 }
 
 type SaveExpr struct {
 	Pos  lexer.Position
-	Src  *Expr  `parser:"'save' @@ 'to'"`
-	Path string `parser:"@String"`
-	With *Expr  `parser:"[ 'with' @@ ]"`
+	Src  *Expr   `parser:"'save' @@"`
+	Path *string `parser:"[ 'to' @String ]"`
+	With *Expr   `parser:"[ 'with' @@ ]"`
 }
 
 type QueryExpr struct {

--- a/runtime/data/jsonl.go
+++ b/runtime/data/jsonl.go
@@ -3,17 +3,29 @@ package data
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"os"
 )
 
 // LoadJSONL reads a JSON lines file and returns its rows as a slice of maps.
 func LoadJSONL(path string) ([]map[string]any, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
+	var r io.Reader
+	if path == "" || path == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		r = f
 	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
+	return LoadJSONLReader(r)
+}
+
+// LoadJSONLReader reads JSONL data from the provided reader.
+func LoadJSONLReader(r io.Reader) ([]map[string]any, error) {
+	scanner := bufio.NewScanner(r)
 	out := []map[string]any{}
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -32,19 +44,31 @@ func LoadJSONL(path string) ([]map[string]any, error) {
 	return out, nil
 }
 
-// SaveJSONL writes rows to a JSON lines file.
+// SaveJSONL writes rows to a JSON lines file. If path is empty or "-",
+// data is written to stdout.
 func SaveJSONL(rows []map[string]any, path string) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
+	var w io.Writer
+	if path == "" || path == "-" {
+		w = os.Stdout
+	} else {
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		w = f
 	}
-	defer f.Close()
-	w := bufio.NewWriter(f)
-	enc := json.NewEncoder(w)
+	return SaveJSONLWriter(rows, w)
+}
+
+// SaveJSONLWriter writes rows to the provided writer in JSONL format.
+func SaveJSONLWriter(rows []map[string]any, w io.Writer) error {
+	bw := bufio.NewWriter(w)
+	enc := json.NewEncoder(bw)
 	for _, row := range rows {
 		if err := enc.Encode(row); err != nil {
 			return err
 		}
 	}
-	return w.Flush()
+	return bw.Flush()
 }

--- a/tests/parser/valid/load_save_stdinout.golden
+++ b/tests/parser/valid/load_save_stdinout.golden
@@ -1,0 +1,32 @@
+(program
+  (type Person
+    (field name (type string))
+    (field age (type int))
+  )
+  (let people
+    (load
+      (type Person)
+      (map
+        (entry (selector format) (string jsonl))
+      )
+    )
+  )
+  (let adults
+    (query p
+      (source (selector people))
+      (where
+        (binary >=
+          (selector age (selector p))
+          (int 18)
+        )
+      )
+      (select (selector p))
+    )
+  )
+  (save
+    (selector adults)
+    (map
+      (entry (selector format) (string jsonl))
+    )
+  )
+)

--- a/tests/parser/valid/load_save_stdinout.mochi
+++ b/tests/parser/valid/load_save_stdinout.mochi
@@ -1,0 +1,12 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = load as Person with { format: "jsonl" }
+
+let adults = from p in people
+             where p.age >= 18
+             select p
+
+save adults with { format: "jsonl" }


### PR DESCRIPTION
## Summary
- support optional path for `load`/`save` expressions
- add stdin/stdout handling to CSV and JSONL helpers
- handle nil path in interpreter
- add new example using stdin/stdout
- test parser with new syntax

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68486a81ffc08320a8732661bfeaa83c