### PR TITLE
Refactor runtime data package and interpreter

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1013,7 +1013,8 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 		return obj, nil
 
 	case p.Query != nil:
-		return data.RunQuery(p.Query, i.env, i.dataPlan, func(env *types.Env, e *parser.Expr) (any, error) {
+		eng := data.EngineByName(i.dataPlan)
+		return data.RunQuery(p.Query, i.env, eng, func(env *types.Env, e *parser.Expr) (any, error) {
 			old := i.env
 			i.env = env
 			val, err := i.evalExpr(e)

--- a/runtime/data/csv.go
+++ b/runtime/data/csv.go
@@ -4,25 +4,18 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"io"
-	"os"
 	"sort"
 	"strconv"
 )
 
 // LoadCSV reads a CSV file and returns its rows as a slice of maps.
 func LoadCSV(path string) ([]map[string]any, error) {
-	var reader io.Reader
-	if path == "" || path == "-" {
-		reader = os.Stdin
-	} else {
-		f, err := os.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-		reader = f
+	r, closeFn, err := openReader(path)
+	if err != nil {
+		return nil, err
 	}
-	return LoadCSVReader(reader)
+	defer closeFn()
+	return LoadCSVReader(r)
 }
 
 // LoadCSVReader reads CSV data from the provided reader.
@@ -59,18 +52,12 @@ func LoadCSVReader(r io.Reader) ([]map[string]any, error) {
 
 // SaveCSV writes rows to a CSV file using the given options.
 func SaveCSV(rows []map[string]any, path string, header bool, delim rune) error {
-	var writer io.Writer
-	if path == "" || path == "-" {
-		writer = os.Stdout
-	} else {
-		f, err := os.Create(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		writer = f
+	w, closeFn, err := openWriter(path)
+	if err != nil {
+		return err
 	}
-	return SaveCSVWriter(rows, writer, header, delim)
+	defer closeFn()
+	return SaveCSVWriter(rows, w, header, delim)
 }
 
 // SaveCSVWriter writes CSV rows to the provided writer.

--- a/runtime/data/jsonl.go
+++ b/runtime/data/jsonl.go
@@ -4,22 +4,15 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
-	"os"
 )
 
 // LoadJSONL reads a JSON lines file and returns its rows as a slice of maps.
 func LoadJSONL(path string) ([]map[string]any, error) {
-	var r io.Reader
-	if path == "" || path == "-" {
-		r = os.Stdin
-	} else {
-		f, err := os.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-		r = f
+	r, closeFn, err := openReader(path)
+	if err != nil {
+		return nil, err
 	}
+	defer closeFn()
 	return LoadJSONLReader(r)
 }
 
@@ -47,17 +40,11 @@ func LoadJSONLReader(r io.Reader) ([]map[string]any, error) {
 // SaveJSONL writes rows to a JSON lines file. If path is empty or "-",
 // data is written to stdout.
 func SaveJSONL(rows []map[string]any, path string) error {
-	var w io.Writer
-	if path == "" || path == "-" {
-		w = os.Stdout
-	} else {
-		f, err := os.Create(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		w = f
+	w, closeFn, err := openWriter(path)
+	if err != nil {
+		return err
 	}
+	defer closeFn()
 	return SaveJSONLWriter(rows, w)
 }
 

--- a/runtime/data/query.go
+++ b/runtime/data/query.go
@@ -5,17 +5,45 @@ import (
 	"mochi/types"
 )
 
+// Engine executes a query plan.
+type Engine interface {
+	ExecPlan(Plan, *types.Env, func(*parser.Expr) (any, error)) ([]any, error)
+}
+
+// MemoryEngine runs plans using the in-memory interpreter.
+type MemoryEngine struct{}
+
+func (MemoryEngine) ExecPlan(pl Plan, env *types.Env, eval func(*parser.Expr) (any, error)) ([]any, error) {
+	return ExecPlan(pl, env, eval)
+}
+
+// DuckDBEngine runs plans by translating them to SQL for DuckDB.
+type DuckDBEngine struct{}
+
+func (DuckDBEngine) ExecPlan(pl Plan, env *types.Env, eval func(*parser.Expr) (any, error)) ([]any, error) {
+	return ExecPlanDuckDB(pl, env, eval)
+}
+
+// EngineByName returns a query execution engine for name.
+func EngineByName(name string) Engine {
+	switch name {
+	case "duckdb":
+		return DuckDBEngine{}
+	default:
+		return MemoryEngine{}
+	}
+}
+
 // RunQuery executes the given query using the specified plan ("memory" or "duckdb").
 // A child environment is created from env for evaluation of embedded expressions.
-func RunQuery(q *parser.QueryExpr, env *types.Env, plan string, eval func(*types.Env, *parser.Expr) (any, error)) ([]any, error) {
+func RunQuery(q *parser.QueryExpr, env *types.Env, eng Engine, eval func(*types.Env, *parser.Expr) (any, error)) ([]any, error) {
 	child := types.NewEnv(env)
 	doEval := func(e *parser.Expr) (any, error) {
 		return eval(child, e)
 	}
-	switch plan {
-	case "duckdb":
-		return EvalQueryDuckDB(q, child, doEval)
-	default:
-		return EvalQuery(q, child, doEval)
+	plan, err := BuildPlan(q)
+	if err != nil {
+		return nil, err
 	}
+	return eng.ExecPlan(plan, child, doEval)
 }

--- a/runtime/data/queryexpr.go
+++ b/runtime/data/queryexpr.go
@@ -329,28 +329,3 @@ func EvalQuery(q *parser.QueryExpr, env *types.Env, eval func(*parser.Expr) (any
 	}
 	return ExecPlan(plan, env, eval)
 }
-
-func truthy(val any) bool {
-	switch v := val.(type) {
-	case nil:
-		return false
-	case bool:
-		return v
-	case int:
-		return v != 0
-	case int64:
-		return v != 0
-	case float64:
-		return v != 0
-	case string:
-		return v != ""
-	case []any:
-		return len(v) > 0
-	case map[string]any:
-		return len(v) > 0
-	case *Group:
-		return len(v.Items) > 0
-	default:
-		return true
-	}
-}

--- a/runtime/data/util.go
+++ b/runtime/data/util.go
@@ -1,0 +1,61 @@
+package data
+
+import (
+	"io"
+	"os"
+)
+
+// openReader opens path for reading. A nil closer means no need to close.
+func openReader(path string) (io.Reader, func() error, error) {
+	if path == "" || path == "-" {
+		return os.Stdin, func() error { return nil }, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, f.Close, nil
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+// openWriter opens path for writing.
+func openWriter(path string) (io.Writer, func() error, error) {
+	if path == "" || path == "-" {
+		w := nopWriteCloser{os.Stdout}
+		return w, func() error { return nil }, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, f.Close, nil
+}
+
+// truthy evaluates the truthiness of a value following Mochi semantics.
+func truthy(val any) bool {
+	switch v := val.(type) {
+	case nil:
+		return false
+	case bool:
+		return v
+	case int:
+		return v != 0
+	case int64:
+		return v != 0
+	case float64:
+		return v != 0
+	case string:
+		return v != ""
+	case []any:
+		return len(v) > 0
+	case map[string]any:
+		return len(v) > 0
+	case *Group:
+		return len(v.Items) > 0
+	default:
+		return true
+	}
+}


### PR DESCRIPTION
## Summary
- refactor runtime/data to avoid duplication
- add utility helpers for file handling and truthy checks
- introduce query Engine interface with memory and DuckDB implementations
- update RunQuery to accept the new Engine interface
- adapt interpreter to use EngineByName

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68486fd745948320a16d850cd66dca1f