### PR TITLE
Add v0.6.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # 📦 CHANGELOG.md
+## [0.6.1] – 2025-06-11
+
+### Added
+
+* `load` expression for CSV and JSONL files
+* `save` statement for writing datasets
+* STDIN/STDOUT support for load/save
+* Foreign function interface and `extern object`
+* Optional DuckDB query engine
+* `--wasm-toolchain` flag
+
+### Changed
+
+* Compiler type inference improvements
+
+### Fixed
+
+* Build without DuckDB
+* Updated golden tests
+
 ## [0.6.0] – 2025-06-10
 
 ### Added

--- a/releases/v0.6.1.md
+++ b/releases/v0.6.1.md
@@ -1,0 +1,27 @@
+# Jun 2025 (v0.6.1)
+
+Mochi v0.6.1 adds file I/O for datasets, a minimal foreign function interface and optional DuckDB execution for queries.
+
+## Load and Save
+
+Use `load` to read CSV or JSONL data into a typed list and `save` to export results. Paths are optional for piping via standard input and output.
+
+```mochi
+let people = load "people.csv" as Person
+let adults = from p in people where p.age >= 18 select p
+save adults to "adults.jsonl" with { format: "jsonl" }
+```
+
+## Foreign Function Interface
+
+The new `runtime/ffi` package exposes Go, TypeScript and Python runtimes. Programs declare `extern fun` and `extern object` bindings which resolve to registered host implementations.
+
+## DuckDB Query Engine
+
+Dataset queries can execute through DuckDB for larger data sets. Builds without CGO fall back to the in-memory engine.
+
+## Other Changes
+
+- `--wasm-toolchain` flag selects the Go or TinyGo compiler
+- Improved type inference across compilers
+- Fixed DuckDB optional build and updated golden tests


### PR DESCRIPTION
## Summary
- add release notes for v0.6.1
- update CHANGELOG for v0.6.1

## Testing
- `go test ./... --run TestNonexistent`

------
https://chatgpt.com/codex/tasks/task_e_684875c200248320927ad2b9d3864e6e