### PR TITLE
Add JSON/YAML dataset formats

### DIFF
--- a/runtime/data/json.go
+++ b/runtime/data/json.go
@@ -1,0 +1,61 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// LoadJSON reads a JSON file containing either an object or array of objects.
+func LoadJSON(path string) ([]map[string]any, error) {
+	r, closeFn, err := openReader(path)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+	return LoadJSONReader(r)
+}
+
+// LoadJSONReader reads JSON data from r and returns rows.
+func LoadJSONReader(r io.Reader) ([]map[string]any, error) {
+	dec := json.NewDecoder(r)
+	var data any
+	if err := dec.Decode(&data); err != nil {
+		return nil, err
+	}
+	switch v := data.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for _, it := range v {
+			m, ok := it.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("json array element must be object")
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	case map[string]any:
+		return []map[string]any{v}, nil
+	default:
+		return nil, fmt.Errorf("unsupported json value %T", data)
+	}
+}
+
+// SaveJSON writes rows to a JSON file as an array or single object.
+func SaveJSON(rows []map[string]any, path string) error {
+	w, closeFn, err := openWriter(path)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	return SaveJSONWriter(rows, w)
+}
+
+// SaveJSONWriter writes rows to w in JSON format.
+func SaveJSONWriter(rows []map[string]any, w io.Writer) error {
+	enc := json.NewEncoder(w)
+	if len(rows) == 1 {
+		return enc.Encode(rows[0])
+	}
+	return enc.Encode(rows)
+}

--- a/runtime/data/yaml.go
+++ b/runtime/data/yaml.go
@@ -1,0 +1,63 @@
+package data
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadYAML reads a YAML file containing an object or array of objects.
+func LoadYAML(path string) ([]map[string]any, error) {
+	r, closeFn, err := openReader(path)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+	return LoadYAMLReader(r)
+}
+
+// LoadYAMLReader reads YAML data from r and returns rows.
+func LoadYAMLReader(r io.Reader) ([]map[string]any, error) {
+	dec := yaml.NewDecoder(r)
+	var data any
+	if err := dec.Decode(&data); err != nil {
+		return nil, err
+	}
+	switch v := data.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for _, it := range v {
+			m, ok := it.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("yaml array element must be object")
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	case map[string]any:
+		return []map[string]any{v}, nil
+	default:
+		return nil, fmt.Errorf("unsupported yaml value %T", data)
+	}
+}
+
+// SaveYAML writes rows to a YAML file.
+func SaveYAML(rows []map[string]any, path string) error {
+	w, closeFn, err := openWriter(path)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	return SaveYAMLWriter(rows, w)
+}
+
+// SaveYAMLWriter writes rows in YAML format to w.
+func SaveYAMLWriter(rows []map[string]any, w io.Writer) error {
+	enc := yaml.NewEncoder(w)
+	defer enc.Close()
+	if len(rows) == 1 {
+		return enc.Encode(rows[0])
+	}
+	return enc.Encode(rows)
+}

--- a/tests/interpreter/valid/load_yaml.mochi
+++ b/tests/interpreter/valid/load_yaml.mochi
@@ -1,0 +1,13 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+let people = load "../tests/interpreter/valid/people.yaml" as Person with { format: "yaml" }
+let adults = from p in people
+             where p.age >= 18
+             select { name: p.name, email: p.email }
+for a in adults {
+  print(a.name, a.email)
+}

--- a/tests/interpreter/valid/load_yaml.out
+++ b/tests/interpreter/valid/load_yaml.out
@@ -1,0 +1,2 @@
+Alice alice@example.com
+Charlie charlie@example.com

--- a/tests/interpreter/valid/people.yaml
+++ b/tests/interpreter/valid/people.yaml
@@ -1,0 +1,9 @@
+- name: Alice
+  age: 30
+  email: alice@example.com
+- name: Bob
+  age: 15
+  email: bob@example.com
+- name: Charlie
+  age: 20
+  email: charlie@example.com


### PR DESCRIPTION
## Summary
- extend dataset loader/saver with JSON and YAML formats
- allow CSV header and delimiter options for loading
- support TSV via delimiter option
- update interpreter load/save logic for new formats
- add YAML dataset example and tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6848816073b48320b945b459662f1f14