### PR TITLE
Add Python FFI support

### DIFF
--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -203,3 +203,10 @@ func writeArgKey(sb *strings.Builder, v any) {
 		sb.WriteString(fmt.Sprintf("%p", v))
 	}
 }
+
+// pythonValue is a placeholder for a value from a Python module.
+// It defers resolution until used, allowing chains like math.sqrt(x).
+type pythonValue struct {
+	module string
+	attrs  []string
+}

--- a/tests/interpreter/valid/python_math.mochi
+++ b/tests/interpreter/valid/python_math.mochi
@@ -1,0 +1,20 @@
+// math_import_extern_fun.mochi
+import python "math" as math
+
+extern let math.pi: float
+extern let math.e: float
+extern fun math.sqrt(x: float): float
+extern fun math.pow(x: float, y: float): float
+extern fun math.sin(x: float): float
+extern fun math.log(x: float): float
+
+let r = 3.0
+let area = math.pi * math.pow(r, 2.0)
+let root = math.sqrt(49.0)
+let sin45 = math.sin(math.pi / 4.0)
+let log_e = math.log(math.e)
+
+print("Circle area with r =", r, "=>", area)
+print("Square root of 49:", root)
+print("sin(π/4):", sin45)
+print("log(e):", log_e)

--- a/tests/interpreter/valid/python_math.out
+++ b/tests/interpreter/valid/python_math.out
@@ -1,0 +1,4 @@
+Circle area with r = 3 => 28.274333882308138
+Square root of 49: 7
+sin(π/4): 0.7071067811865475
+log(e): 1


### PR DESCRIPTION
## Summary
- support `import` statements and dotted extern names in parser
- integrate python module imports in interpreter using a small runtime
- allow field access and calls on imported Python modules
- extend type checker with basic support for imports and externs
- add test covering math module usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68488cd845e883209a2d444500094916