### PR TITLE
Add Go FFI support

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -2,9 +2,11 @@ package interpreter_test
 
 import (
 	"fmt"
+	"math"
 	"mochi/golden"
 	"mochi/interpreter"
 	"mochi/parser"
+	goffi "mochi/runtime/ffi/go"
 	"mochi/runtime/llm"
 	_ "mochi/runtime/llm/provider/echo"
 	"mochi/types"
@@ -30,6 +32,14 @@ func TestInterpreter_ValidPrograms(t *testing.T) {
 			return nil, fmt.Errorf("❌ type error: %v", typeErrors[0])
 		}
 
+		// register Go math functions for FFI tests
+		goffi.Register("math.Pi", math.Pi)
+		goffi.Register("math.E", math.E)
+		goffi.Register("math.Sqrt", math.Sqrt)
+		goffi.Register("math.Pow", math.Pow)
+		goffi.Register("math.Sin", math.Sin)
+		goffi.Register("math.Log", math.Log)
+
 		out := &strings.Builder{}
 		interp := interpreter.New(prog, typeEnv)
 		interp.Env().SetWriter(out)
@@ -52,6 +62,13 @@ func TestInterpreter_RuntimeErrors(t *testing.T) {
 		if len(typeErrors) > 0 {
 			return nil, fmt.Errorf("❌ type error: %v", typeErrors[0])
 		}
+
+		goffi.Register("math.Pi", math.Pi)
+		goffi.Register("math.E", math.E)
+		goffi.Register("math.Sqrt", math.Sqrt)
+		goffi.Register("math.Pow", math.Pow)
+		goffi.Register("math.Sin", math.Sin)
+		goffi.Register("math.Log", math.Log)
 
 		out := &strings.Builder{}
 		interp := interpreter.New(prog, typeEnv)

--- a/interpreter/ops.go
+++ b/interpreter/ops.go
@@ -9,6 +9,7 @@ import (
 
 	"mochi/parser"
 	"mochi/runtime/agent"
+	goffi "mochi/runtime/ffi/go"
 	pythonffi "mochi/runtime/ffi/python"
 	"mochi/types"
 )
@@ -80,6 +81,22 @@ func (i *Interpreter) applyCallOp(val any, call *parser.CallOp) (any, error) {
 			args[idx] = v
 		}
 		return pythonffi.Attr(pv.module, strings.Join(pv.attrs, "."), args...)
+	}
+
+	if gv, ok := val.(goValue); ok {
+		args := make([]any, len(call.Args))
+		for idx, a := range call.Args {
+			v, err := i.evalExpr(a)
+			if err != nil {
+				return nil, err
+			}
+			args[idx] = v
+		}
+		name := gv.module
+		if len(gv.attrs) > 0 {
+			name += "." + strings.Join(gv.attrs, ".")
+		}
+		return goffi.Call(name, args...)
 	}
 
 	if ai, ok := val.(agentIntent); ok {

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -210,3 +210,11 @@ type pythonValue struct {
 	module string
 	attrs  []string
 }
+
+// goValue is a placeholder for a value from a Go module.
+// Like pythonValue, resolution is deferred until used so chains like
+// math.Sqrt(9) can be constructed.
+type goValue struct {
+	module string
+	attrs  []string
+}

--- a/runtime/ffi/go/ffi.go
+++ b/runtime/ffi/go/ffi.go
@@ -15,12 +15,12 @@ var _ ffi.Loader = (*Runtime)(nil)
 
 // Runtime maintains a registry of Go functions available to Mochi.
 type Runtime struct {
-	registry map[string]reflect.Value
+	registry map[string]any
 }
 
 // NewRuntime creates an empty FFI runtime.
 func NewRuntime() *Runtime {
-	return &Runtime{registry: make(map[string]reflect.Value)}
+	return &Runtime{registry: make(map[string]any)}
 }
 
 // defaultRuntime is used by package-level helpers.
@@ -42,51 +42,53 @@ func Call(name string, args ...any) (any, error) {
 }
 
 // Register implements ffi.Registerer.
-func (r *Runtime) Register(name string, fn any) error {
-	v := reflect.ValueOf(fn)
-	if v.Kind() != reflect.Func {
-		return fmt.Errorf("goffi: Register expects a function")
-	}
-	r.registry[name] = v
+func (r *Runtime) Register(name string, value any) error {
+	r.registry[name] = value
 	return nil
 }
 
 // Call implements ffi.Caller.
 func (r *Runtime) Call(name string, args ...any) (any, error) {
-	fn, ok := r.registry[name]
+	val, ok := r.registry[name]
 	if !ok {
-		return nil, fmt.Errorf("goffi: unknown function %s", name)
+		return nil, fmt.Errorf("goffi: unknown symbol %s", name)
 	}
 
-	if len(args) != fn.Type().NumIn() {
-		return nil, fmt.Errorf("goffi: %s expects %d args, got %d", name, fn.Type().NumIn(), len(args))
-	}
-
-	in := make([]reflect.Value, len(args))
-	for i, a := range args {
-		in[i] = reflect.ValueOf(a)
-	}
-
-	outs := fn.Call(in)
-	switch len(outs) {
-	case 0:
-		return nil, nil
-	case 1:
-		return outs[0].Interface(), nil
-	case 2:
-		if errv := outs[1]; !errv.IsNil() {
-			if err, ok := errv.Interface().(error); ok {
-				return outs[0].Interface(), err
+	rv := reflect.ValueOf(val)
+	if rv.Kind() == reflect.Func {
+		if len(args) != rv.Type().NumIn() {
+			return nil, fmt.Errorf("goffi: %s expects %d args, got %d", name, rv.Type().NumIn(), len(args))
+		}
+		in := make([]reflect.Value, len(args))
+		for i, a := range args {
+			in[i] = reflect.ValueOf(a)
+		}
+		outs := rv.Call(in)
+		switch len(outs) {
+		case 0:
+			return nil, nil
+		case 1:
+			return outs[0].Interface(), nil
+		case 2:
+			if errv := outs[1]; !errv.IsNil() {
+				if err, ok := errv.Interface().(error); ok {
+					return outs[0].Interface(), err
+				}
 			}
+			return outs[0].Interface(), nil
+		default:
+			res := make([]any, len(outs))
+			for i, v := range outs {
+				res[i] = v.Interface()
+			}
+			return res, nil
 		}
-		return outs[0].Interface(), nil
-	default:
-		res := make([]any, len(outs))
-		for i, v := range outs {
-			res[i] = v.Interface()
-		}
-		return res, nil
 	}
+
+	if len(args) != 0 {
+		return nil, fmt.Errorf("goffi: %s is not callable", name)
+	}
+	return val, nil
 }
 
 // LoadModule implements ffi.Loader. The module must be a Go plugin built with

--- a/runtime/ffi/go/ffi_test.go
+++ b/runtime/ffi/go/ffi_test.go
@@ -25,3 +25,14 @@ func TestCallWithError(t *testing.T) {
 		t.Fatalf("expected boom error, got %v", err)
 	}
 }
+
+func TestCallValue(t *testing.T) {
+	goffi.Register("pi", 3.14)
+	res, err := goffi.Call("pi")
+	if err != nil {
+		t.Fatalf("call value failed: %v", err)
+	}
+	if res.(float64) != 3.14 {
+		t.Fatalf("expected 3.14, got %v", res)
+	}
+}

--- a/tests/interpreter/valid/go_math.mochi
+++ b/tests/interpreter/valid/go_math.mochi
@@ -1,0 +1,21 @@
+// math_import_go.mochi
+import go "math" as math
+
+extern let math.Pi: float
+extern let math.E: float
+extern fun math.Sqrt(x: float): float
+extern fun math.Pow(x: float, y: float): float
+extern fun math.Sin(x: float): float
+extern fun math.Log(x: float): float
+
+let r = 3.0
+
+let area = math.Pi * math.Pow(r, 2.0)
+let root = math.Sqrt(49.0)
+let sin45 = math.Sin(math.Pi / 4.0)
+let log_e = math.Log(math.E)
+
+print("Circle area with r =", r, "=>", area)
+print("Square root of 49:", root)
+print("sin(π/4):", sin45)
+print("log(e):", log_e)

--- a/tests/interpreter/valid/go_math.out
+++ b/tests/interpreter/valid/go_math.out
@@ -1,0 +1,4 @@
+Circle area with r = 3 => 28.274333882308138
+Square root of 49: 7
+sin(π/4): 0.7071067811865475
+log(e): 1


### PR DESCRIPTION
## Summary
- extend interpreter with Go FFI support
- support registering functions and values in goffi runtime
- add Go math example and tests
- update interpreter tests to register Go math functions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6848cf46a9dc8320b50c52bc67988331