### PR TITLE
Remove unused Go FFI plugin loader

### DIFF
--- a/runtime/ffi/go/README.md
+++ b/runtime/ffi/go/README.md
@@ -2,8 +2,7 @@
 
 `runtime/ffi/go` exposes a small foreign function interface for calling native Go
 functions from Mochi. Functions are registered under a name and invoked by that
-name at runtime. In addition to manual registration, runtime modules can be
-loaded from Go plugins that expose an `Exports` map.
+name at runtime.
 
 ```go
 import goffi "mochi/runtime/ffi/go"
@@ -11,30 +10,6 @@ import goffi "mochi/runtime/ffi/go"
 func init() {
     goffi.Register("add", func(a, b int) int { return a + b })
 }
-```
-
-Modules built as Go plugins can automatically register functions by exporting an
-`Exports` map. Use `LoadModule` to load the plugin:
-
-```go
-err := goffi.LoadModule("./math.so")
-if err != nil {
-    log.Fatal(err)
-}
-```
-
-The plugin should expose a global variable named `Exports`:
-
-```go
-package main
-
-import goffi "mochi/runtime/ffi/go"
-
-var Exports = map[string]any{
-    "square": func(n int) int { return n * n },
-}
-
-func main() {}
 ```
 
 A registered function can later be called dynamically:

--- a/runtime/ffi/go/ffi.go
+++ b/runtime/ffi/go/ffi.go
@@ -2,7 +2,6 @@ package goffi
 
 import (
 	"fmt"
-	"plugin"
 	"reflect"
 
 	"mochi/runtime/ffi"
@@ -11,7 +10,6 @@ import (
 // Ensure *Runtime implements ffi.Caller and ffi.Registerer.
 var _ ffi.Caller = (*Runtime)(nil)
 var _ ffi.Registerer = (*Runtime)(nil)
-var _ ffi.Loader = (*Runtime)(nil)
 
 // Runtime maintains a registry of Go functions available to Mochi.
 type Runtime struct {
@@ -90,33 +88,3 @@ func (r *Runtime) Call(name string, args ...any) (any, error) {
 	}
 	return val, nil
 }
-
-// LoadModule implements ffi.Loader. The module must be a Go plugin built with
-// -buildmode=plugin that exports a variable named "Exports" of type
-// map[string]any. Each entry in the map is registered under its key.
-func (r *Runtime) LoadModule(path string) error {
-	p, err := plugin.Open(path)
-	if err != nil {
-		return fmt.Errorf("goffi: open plugin %s: %w", path, err)
-	}
-
-	sym, err := p.Lookup("Exports")
-	if err != nil {
-		return fmt.Errorf("goffi: plugin %s missing Exports: %w", path, err)
-	}
-
-	exports, ok := sym.(*map[string]any)
-	if !ok {
-		return fmt.Errorf("goffi: Exports has unexpected type %T", sym)
-	}
-
-	for name, fn := range *exports {
-		if err := r.Register(name, fn); err != nil {
-			return fmt.Errorf("goffi: register %s from %s: %w", name, path, err)
-		}
-	}
-	return nil
-}
-
-// LoadModule opens a plugin using the default runtime.
-func LoadModule(path string) error { return defaultRuntime.LoadModule(path) }


### PR DESCRIPTION
## Summary
- drop LoadModule support from Go FFI runtime
- tidy README documentation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6848ddfa2c988320a9669921cb17be66