### PR TITLE
Remove unused python ffi code

### DIFF
--- a/runtime/ffi/python/README.md
+++ b/runtime/ffi/python/README.md
@@ -17,23 +17,14 @@ Example usage:
 import "mochi/runtime/ffi/python"
 
 // Call a function from the standard library.
-res, err := python.Call("math", "sqrt", 9)
+res, err := python.Attr("math", "sqrt", 9)
 if err != nil {
         log.Fatal(err)
 }
 fmt.Println(res) // 3.0
 ```
 
-The helper `Exec` runs an arbitrary code block and returns its result:
-
-```go
-result, _ := python.Exec(`
-return args[0] + args[1]
-`, 2, 3)
-fmt.Println(result) // 5
-```
-
-`Attr` can retrieve variables or call functions dynamically:
+`Attr` can also retrieve variables or call functions dynamically:
 
 ```go
 v, _ := python.Attr("math", "pi")

--- a/runtime/ffi/python/python.go
+++ b/runtime/ffi/python/python.go
@@ -5,52 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
-
-	"mochi/runtime/ffi"
 )
-
-// Ensure *Runtime implements ffi.Caller.
-var _ ffi.Caller = (*Runtime)(nil)
-
-// Runtime provides access to Python code via subprocess execution.
-type Runtime struct{}
-
-// NewRuntime returns a new Python FFI runtime.
-func NewRuntime() *Runtime { return &Runtime{} }
-
-var defaultRuntime = NewRuntime()
-
-// Invoke calls a Python function "module:function" using the default runtime.
-func Invoke(name string, args ...any) (any, error) {
-	return defaultRuntime.Call(name, args...)
-}
-
-// ExecDefault executes a code snippet using the default runtime.
-func ExecDefault(code string, args ...any) (any, error) {
-	return defaultRuntime.Exec(code, args...)
-}
-
-// Call invokes a Python function specified as "module:function".
-func (r *Runtime) Call(name string, args ...any) (any, error) {
-	parts := strings.SplitN(name, ":", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("python: name must be module:function")
-	}
-	return Call(parts[0], parts[1], args...)
-}
-
-// Exec runs an arbitrary Python code block using this runtime.
-func (r *Runtime) Exec(code string, args ...any) (any, error) {
-	return Exec(code, args...)
-}
-
-// Call executes fn from the given module with the provided arguments.
-// It is a specialised version of Attr that requires the attribute to be
-// callable.
-func Call(module, fn string, args ...any) (any, error) {
-	return Attr(module, fn, args...)
-}
 
 // Attr returns a module attribute. If the attribute is a callable it is
 // invoked with the provided arguments, otherwise the arguments must be empty
@@ -70,17 +25,6 @@ else:
     res = attr
 json.dump(res, sys.stdout)
 `, module, name, module, name)
-	return run(src, args)
-}
-
-// Exec runs an arbitrary Python code block. The code is wrapped into
-// a function that receives the argument list as `args` and should
-// return the result. The returned value must be JSON serialisable.
-func Exec(code string, args ...any) (any, error) {
-	// indent user code for the wrapper function
-	indented := indent(code, "    ")
-	src := fmt.Sprintf("import json, os, sys\nargs = json.loads(os.environ.get('MOCHI_ARGS', '[]'))\n"+
-		"def __mochi_fn(args):\n%s\nres = __mochi_fn(args)\njson.dump(res, sys.stdout)\n", indented)
 	return run(src, args)
 }
 
@@ -116,15 +60,4 @@ func run(code string, args []any) (any, error) {
 		return nil, fmt.Errorf("decode error: %w\noutput: %s", err, out)
 	}
 	return result, nil
-}
-
-func indent(code, prefix string) string {
-	if code == "" {
-		return ""
-	}
-	lines := strings.Split(code, "\n")
-	for i, l := range lines {
-		lines[i] = prefix + l
-	}
-	return strings.Join(lines, "\n")
 }

--- a/runtime/ffi/python/python_test.go
+++ b/runtime/ffi/python/python_test.go
@@ -6,30 +6,6 @@ import (
 	"mochi/runtime/ffi/python"
 )
 
-func TestCallStdlib(t *testing.T) {
-	res, err := python.Call("math", "sqrt", 9)
-	if err != nil {
-		t.Fatalf("call math.sqrt: %v", err)
-	}
-	f, ok := res.(float64)
-	if !ok || f != 3 {
-		t.Fatalf("unexpected result: %v", res)
-	}
-}
-
-func TestExecAdd(t *testing.T) {
-	res, err := python.Exec(`
-return args[0] + args[1]
-`, 2, 3)
-	if err != nil {
-		t.Fatalf("exec: %v", err)
-	}
-	n, ok := res.(float64)
-	if !ok || n != 5 {
-		t.Fatalf("unexpected result: %v", res)
-	}
-}
-
 func TestAttrVariable(t *testing.T) {
 	res, err := python.Attr("math", "pi")
 	if err != nil {


### PR DESCRIPTION
## Summary
- delete unused helpers from python ffi
- update README examples
- trim python ffi tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6848de30117c832081712e4259f8706e