### PR TITLE
Fix Deno availability for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ jobs:
           cache-dependency-path: |
             go.sum
 
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
       - name: Install dependencies
         run: go mod tidy
 

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -10,11 +10,15 @@ import (
 	"mochi/runtime/llm"
 	_ "mochi/runtime/llm/provider/echo"
 	"mochi/types"
+	"os/exec"
 	"strings"
 	"testing"
 )
 
 func TestInterpreter_ValidPrograms(t *testing.T) {
+	if _, err := exec.LookPath("deno"); err != nil {
+		t.Skip("deno not installed")
+	}
 	golden.Run(t, "tests/interpreter/valid", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {


### PR DESCRIPTION
## Summary
- skip interpreter tests when Deno is not installed
- install Deno in the CI workflow before running tests

## Testing
- `go test ./interpreter -run TestInterpreter_ValidPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6848e65c129c83209a8f5d798a474e4a