### PR TITLE
Update docs post v0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Mochi** is a small, statically typed programming language built for clarity, safety, and expressiveness — whether you're writing tools, processing real-time data, or powering intelligent agents.
 
-Current version: **0.5.0**
+Current version: **0.6.1**
 
 Mochi is:
 
@@ -309,7 +309,7 @@ type Person {
   age: int
 }
 
-let people = load "people.csv" as Person
+let people = load "people.yaml" as Person
 
 let adults = from p in people
              where p.age >= 18
@@ -318,6 +318,8 @@ let adults = from p in people
 for a in adults {
   print(a.name, "is", a.age)
 }
+
+save adults to "adults.json"
 ```
 
 ### Joins
@@ -523,6 +525,19 @@ let m = Monitor {}
 emit Sensor { id: "sensor-2", temperature: 30.0 }
 sleep(50)
 print(m.status())
+```
+
+### Foreign Function Interface
+
+Use the `import` keyword to access libraries from other languages. Declare
+`extern` variables and functions to call them directly.
+
+```mochi
+import go "math" as math
+
+extern fun math.Sqrt(x: float): float
+
+print(math.Sqrt(16.0))
 ```
 
 ## MCP Tools

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Mochi Programming Language Specification (v0.5.0)
+# Mochi Programming Language Specification (v0.6.1)
 
-This document describes version 0.5.0 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
+This document describes version 0.6.1 of the **Mochi programming language**. It is inspired by the structure of the [Go language specification](https://golang.org/ref/spec) and aims to formally define the syntax and semantics of Mochi.
 
 ## 0. Introduction
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -12,5 +12,6 @@ This section outlines each major feature of the Mochi programming language. Each
 - [HTTP Fetch](http-fetch.md) describes retrieving JSON over the network.
 - [Union Types](union-types.md) discusses custom data structures with variants.
 - [Streams and Agents](streams.md) introduces event streams and long-lived agents.
+- [Foreign Function Interface](ffi.md) for calling Go, Python and TypeScript code.
 
 These topics build upon the language specification and provide a hands-on tour of Mochi's capabilities.

--- a/docs/features/datasets.md
+++ b/docs/features/datasets.md
@@ -1,6 +1,6 @@
 ## Dataset Queries
 
-`from` expressions treat lists as simple datasets. Combine optional `where`, `sort by`, `skip`, `take` and `select` clauses to shape the result. Use `load` to read a CSV or JSONL file into a typed list.
+`from` expressions treat lists as simple datasets. Combine optional `where`, `sort by`, `skip`, `take` and `select` clauses to shape the result. Use `load` to read CSV, JSON, JSONL or YAML files into a typed list. Results can be written back with `save`.
 
 ```mochi
 type Person {
@@ -8,7 +8,7 @@ type Person {
   age: int
 }
 
-let people = load "people.csv" as Person
+let people = load "people.yaml" as Person
 
 let adults = from person in people
              where person.age >= 18
@@ -22,6 +22,8 @@ for person in adults {
   print(person.name, "is", person.age,
         if person.is_senior { " (senior)" } else { "" })
 }
+
+save adults to "adults.json"
 ```
 
 Queries can also sort records and limit the results:

--- a/docs/features/ffi.md
+++ b/docs/features/ffi.md
@@ -1,0 +1,17 @@
+## Foreign Function Interface
+
+Mochi can call into Go, Python and TypeScript libraries using the `import`
+statement and `extern` declarations. Imported modules expose their values
+through an FFI runtime so Mochi code can invoke them directly.
+
+```mochi
+import python "math" as math
+
+extern fun math.sqrt(x: float): float
+
+print(math.sqrt(49.0))
+```
+
+Modules may be loaded from the host language's package system or from a
+local file. Functions and variables must be declared with `extern` before
+use so the compiler knows their types.

--- a/docs/guides/dataset-queries.md
+++ b/docs/guides/dataset-queries.md
@@ -1,6 +1,6 @@
 # Dataset Queries
 
-Mochi treats lists as in-memory datasets. The `from` expression provides a concise way to filter and transform these collections. Use `load` to read data from CSV or JSONL files.
+Mochi treats lists as in-memory datasets. The `from` expression provides a concise way to filter and transform these collections. Use `load` to read data from CSV, JSON, JSONL or YAML files and `save` to write results.
 
 ## Selecting Data
 
@@ -10,14 +10,16 @@ type Person {
   age: int
 }
 
-let people = load "people.csv" as Person
+let people = load "people.yaml" as Person
 
 let adults = from p in people
              where p.age >= 18
              select {
                name: p.name,
-               age: p.age
-             }
+             age: p.age
+            }
+
+save adults to "adults.json"
 ```
 
 ## Sorting and Limiting

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,5 +21,6 @@ The language overview is split into individual topics for easy navigation:
 - [HTTP Fetch](features/http-fetch.md)
 - [Union Types](features/union-types.md)
 - [Streams and Agents](features/streams.md)
+- [Foreign Function Interface](features/ffi.md)
 
 As the language evolves these docs will expand with more examples, so check back often for updates.


### PR DESCRIPTION
## Summary
- bump README version to 0.6.1 and show saving datasets
- add FFI section to README
- document FFI feature in docs
- update dataset docs with YAML/JSON support and `save`
- bump spec version

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6848f1b8860c83208e502a9c4721f3fa