### PR TITLE
Add v0.6.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # 📦 CHANGELOG.md
+## [0.6.2] – 2025-06-12
+
+### Added
+
+* `import` statement and FFI runtimes for Go, Python and TypeScript
+* Deno FFI runtime for TypeScript
+* JSON and YAML dataset loaders
+
+### Changed
+
+* Consolidated FFI logic under `runtime/ffi`
+
+### Fixed
+
+* Notebook magic path test
+* TypeScript remote import test
+
+
 ## [0.6.1] – 2025-06-11
 
 ### Added

--- a/releases/v0.6.2.md
+++ b/releases/v0.6.2.md
@@ -1,0 +1,28 @@
+# Jun 2025 (v0.6.2)
+
+Mochi v0.6.2 expands the foreign function interface and adds more data loading options.
+
+## Foreign Function Interface
+
+Programs can `import` modules from Go, Python and TypeScript and call them through new FFI runtimes. A Deno runtime enables TypeScript interoperability.
+
+```mochi
+import go "math" as math
+import python "polars" as pl
+
+extern fun math.Sqrt(x: float): float
+extern fun pl.col(name: string): any
+```
+
+## Dataset Loaders
+
+`load` now supports JSON and YAML files in addition to CSV.
+
+```mochi
+let people = load "people.yaml" as Person
+```
+
+## Other Changes
+
+- FFI code moved to `runtime/ffi`
+- Fixed notebook magic path and TypeScript import tests


### PR DESCRIPTION
## Summary
- document 0.6.2 changes in CHANGELOG
- add detailed v0.6.2 release notes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684900c6652c83209b708c1480a8e261