### PR TITLE
Add dataset load/save support to Go compiler

### DIFF
--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -209,3 +209,27 @@ func isUnderscoreExpr(e *parser.Expr) bool {
 	}
 	return false
 }
+
+func simpleStringKey(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return *p.Target.Lit.Str, true
+	}
+	return "", false
+}


### PR DESCRIPTION
## Summary
- support `load` and `save` expressions in the Go compiler
- handle dataset keys correctly in map literals
- add runtime helpers for loading/saving datasets
- extend type inference for load/save

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68490aef5fa8832090936bd72d9a941c