### PR TITLE
Update Mochi syntax highlighting

### DIFF
--- a/mochi-tm/mochi.tmLanguage.json
+++ b/mochi-tm/mochi.tmLanguage.json
@@ -6,7 +6,7 @@
   "patterns": [
     {
       "name": "keyword.control.mochi",
-      "match": "\\b(test|expect|agent|intent|on|stream|emit|type|fun|return|break|continue|let|var|if|else|for|in|generate|match|fetch)\\b"
+      "match": "\b(agent|all|as|break|by|continue|else|emit|except|expect|extern|fetch|for|from|fun|generate|group|if|import|in|intent|intersect|into|join|left|let|load|match|model|object|on|outer|return|right|save|select|skip|sort|stream|take|test|to|type|union|var|where|while|with)\b"
     },
     {
       "name": "storage.type.mochi",
@@ -56,7 +56,7 @@
     },
     {
       "name": "keyword.operator.mochi",
-      "match": "==|!=|<=|>=|&&|\\|\\||=>|\\.\\.|[-+*/%=<>!|{}\\[\\](),.:]"
+        "match": "==|!=|<=|>=|&&|\\|\\||=>|\\.\\.|\\b(union|except|intersect)\\b|[-+*/%=<>!|{}\\[\\](),.:]"
     },
     {
       "name": "punctuation.separator.mochi",

--- a/tools/vscode/syntaxes/mochi.tmLanguage.json
+++ b/tools/vscode/syntaxes/mochi.tmLanguage.json
@@ -6,7 +6,7 @@
   "patterns": [
     {
       "name": "keyword.control.mochi",
-      "match": "\\b(test|expect|agent|intent|on|stream|emit|type|fun|return|break|continue|let|var|if|else|for|in|generate|match|fetch)\\b"
+      "match": "\b(agent|all|as|break|by|continue|else|emit|except|expect|extern|fetch|for|from|fun|generate|group|if|import|in|intent|intersect|into|join|left|let|load|match|model|object|on|outer|return|right|save|select|skip|sort|stream|take|test|to|type|union|var|where|while|with)\b"
     },
     {
       "name": "storage.type.mochi",
@@ -56,7 +56,7 @@
     },
     {
       "name": "keyword.operator.mochi",
-      "match": "==|!=|<=|>=|&&|\\|\\||=>|\\.\\.|[-+*/%=<>!|{}\\[\\](),.:]"
+      "match": "==|!=|<=|>=|&&|\\|\\||=>|\\.\\.|\\b(union|except|intersect)\\b|[-+*/%=<>!|{}\\[\\](),.:]"
     },
     {
       "name": "punctuation.separator.mochi",


### PR DESCRIPTION
## Summary
- expand Mochi keyword list
- support `union`, `except` and `intersect` operators

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68490daa3d348320a578d75d9f411de2