### PR TITLE
Remove unused code and add golden test

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -776,7 +776,7 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 		expr = fmt.Sprintf("(%s %s %s)", expr, op.Op, r)
 		switch op.Op {
 		case "+", "-", "*", "/", "%":
-			leftType = leftType // approximate
+			// The resulting type roughly mirrors the left operand.
 		case "==", "!=", "<", "<=", ">", ">=":
 			leftType = types.BoolType{}
 		}

--- a/tests/types/valid/break_continue.golden
+++ b/tests/types/valid/break_continue.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/break_continue.mochi
+++ b/tests/types/valid/break_continue.mochi
@@ -1,0 +1,11 @@
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+var sum: int = 0
+for n in numbers {
+  if n % 2 == 0 {
+    continue
+  }
+  if n > 7 {
+    break
+  }
+  sum = sum + n
+}


### PR DESCRIPTION
## Summary
- drop leftover self-assignment in Python compiler
- add break/continue golden test for the type checker
- run `go vet` and `go test` with coverage

## Testing
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_684915a190f88320b9926fc33d9d615c