### PR TITLE
Update ts import syntax

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -2361,7 +2361,7 @@ func (c *Compiler) addImport(im *parser.ImportStmt) error {
 	case "go":
 		c.goModules[im.As] = mod
 		c.imports["mochi/runtime/ffi/go"] = true
-	case "ts":
+	case "typescript":
 		c.tsModules[im.As] = mod
 		c.imports["mochi/runtime/ffi/deno"] = true
 	default:

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -45,7 +45,7 @@ func containsStreamCode(stmts []*parser.Statement) bool {
 // collectImports scans statements for TypeScript imports.
 func (c *Compiler) collectImports(stmts []*parser.Statement) {
 	for _, s := range stmts {
-		if s.Import != nil && s.Import.Lang == "ts" {
+		if s.Import != nil && s.Import.Lang == "typescript" {
 			path := strings.Trim(s.Import.Path, "\"")
 			alias := sanitizeName(s.Import.As)
 			c.imports[alias] = path

--- a/runtime/ffi/manager.go
+++ b/runtime/ffi/manager.go
@@ -40,7 +40,7 @@ func (m *Manager) Import(lang, alias, path, repoRoot string) error {
 		m.pyModules[alias] = mod
 	case "go":
 		m.goModules[alias] = mod
-	case "ts":
+	case "typescript":
 		if !strings.HasPrefix(mod, "http://") && !strings.HasPrefix(mod, "https://") && !strings.HasPrefix(mod, "file://") {
 			mod = "file://" + filepath.Join(repoRoot, mod)
 		}

--- a/tests/compiler/ts/math_import_ts.mochi
+++ b/tests/compiler/ts/math_import_ts.mochi
@@ -1,4 +1,4 @@
-import ts "https://deno.land/std@0.224.0/path/mod.ts" as path
+import typescript "https://deno.land/std@0.224.0/path/mod.ts" as path
 
 extern fun path.join(a: string, b: string, c: string): string
 extern fun path.basename(p: string): string

--- a/tests/interpreter/valid/ts_math.mochi
+++ b/tests/interpreter/valid/ts_math.mochi
@@ -1,5 +1,5 @@
 // math_import_ts.mochi
-import ts "./runtime/ffi/deno/math.ts" as math
+import typescript "./runtime/ffi/deno/math.ts" as math
 
 extern let math.PI: float
 extern fun math.pow(x: float, y: float): float


### PR DESCRIPTION
## Summary
- update TypeScript import syntax to `import typescript`
- adjust compilers and runtime FFI manager to handle new keyword
- update existing tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684918f6e5cc8320b0286d72e0cd6e26