### PR TITLE
Add Python libmochi helpers

### DIFF
--- a/tools/libmochi/python/README.md
+++ b/tools/libmochi/python/README.md
@@ -1,0 +1,20 @@
+# libmochi
+
+Python helpers for executing Mochi code.
+
+The `run` function executes a string of Mochi source and returns its standard
+output. `call` lets you define a function in Mochi code and invoke it while
+decoding the JSON result.
+
+```
+pip install -e tools/libmochi/python
+```
+
+```python
+from libmochi import run, call
+
+print(run('print("hello")'))
+print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))
+```
+
+Both helpers expect the `mochi` binary to be available on your `PATH`.

--- a/tools/libmochi/python/libmochi.py
+++ b/tools/libmochi/python/libmochi.py
@@ -1,0 +1,57 @@
+import json
+import os
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from typing import Any
+
+__all__ = ["run", "call"]
+
+
+def _run(code: str, mochi_bin: str = "mochi") -> str:
+    """Execute Mochi source code and return stdout as a string."""
+    with tempfile.NamedTemporaryFile("w", suffix=".mochi", delete=False) as f:
+        f.write(code)
+        fname = f.name
+    try:
+        proc = subprocess.run([mochi_bin, "run", fname], capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError(f"mochi exited with status {proc.returncode}: {proc.stderr}")
+        return proc.stdout
+    finally:
+        os.unlink(fname)
+
+
+def run(code: str, mochi_bin: str = "mochi") -> str:
+    """Execute Mochi source code and return its standard output."""
+    return _run(code, mochi_bin)
+
+
+def call(code: str, func: str, *args: Any, mochi_bin: str = "mochi") -> Any:
+    """Call ``func`` defined in ``code`` with ``args`` and return the result.
+
+    ``code`` should contain the Mochi function definition. The result is
+    obtained by wrapping the call with the ``json`` builtin and decoding the
+    output.
+    """
+    args_literal = ", ".join(_to_mochi(a) for a in args)
+    snippet = f"{code}\njson({func}({args_literal}))\n"
+    out = _run(snippet, mochi_bin)
+    return json.loads(out.strip())
+
+
+def _to_mochi(v: Any) -> str:
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    if isinstance(v, str):
+        return "\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+    if isinstance(v, Sequence) and not isinstance(v, (str, bytes, bytearray)):
+        return "[" + ", ".join(_to_mochi(x) for x in v) + "]"
+    if isinstance(v, dict):
+        items = ", ".join(f'{_to_mochi(k)}: {_to_mochi(val)}' for k, val in v.items())
+        return "{" + items + "}"
+    raise TypeError(f"unsupported value type: {type(v).__name__}")

--- a/tools/libmochi/python/libmochi_test.go
+++ b/tools/libmochi/python/libmochi_test.go
@@ -1,0 +1,51 @@
+package libmochi_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLibMochi(t *testing.T) {
+	tmpDir := t.TempDir()
+	mochiPath := filepath.Join(tmpDir, "mochi")
+
+	buildCmd := exec.Command("go", "build", "-o", mochiPath, "./cmd/mochi")
+	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	buildCmd.Dir = filepath.Join("..", "..", "..")
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	pipCmd := exec.Command("python3", "-m", "pip", "install", "-e", "tools/libmochi/python")
+	pipCmd.Dir = filepath.Join("..", "..", "..")
+	if out, err := pipCmd.CombinedOutput(); err != nil {
+		t.Fatalf("pip install failed: %v\n%s", err, out)
+	} else {
+		t.Log(string(out))
+	}
+
+	script := `from libmochi import run, call
+print(run('print("hi")').strip())
+print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))`
+	runCmd := exec.Command("python3", "-")
+	runCmd.Dir = filepath.Join("..", "..", "..")
+	runCmd.Env = append(os.Environ(), "PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runCmd.Stdin = strings.NewReader(script)
+	out, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("python run failed: %v\n%s", err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("unexpected output: %q", string(out))
+	}
+	if lines[0] != "hi" {
+		t.Fatalf("run() output: %q", lines[0])
+	}
+	if lines[1] != "5" {
+		t.Fatalf("call() output: %q", lines[1])
+	}
+}

--- a/tools/libmochi/python/pyproject.toml
+++ b/tools/libmochi/python/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "libmochi"
+version = "0.1.0"
+description = "Python helpers for executing Mochi code"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[tool.setuptools]
+py-modules = ["libmochi"]


### PR DESCRIPTION
## Summary
- add `tools/libmochi/python` with helper functions for executing Mochi code from Python
- implement tests exercising the new library

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68492403541c83209b69c19885227132