### PR TITLE
Add Deno helper library

### DIFF
--- a/tools/libmochi/typescript/README.md
+++ b/tools/libmochi/typescript/README.md
@@ -1,0 +1,22 @@
+# libmochi for TypeScript/Deno
+
+This library provides a small helper for executing Mochi code from
+TypeScript using Deno's subprocess API. It expects the `mochi`
+executable to be available on the system `PATH` (or a custom path can
+be supplied).
+
+## Usage
+
+```ts
+import { run, runFile } from './mod.ts';
+
+const out = await run('print("hello")');
+console.log(out); // => "hello\n"
+
+const out2 = await runFile('program.mochi');
+```
+
+Both helpers return the captured standard output as a string and throw
+an error if the Mochi process exits with a non‐zero status.
+```
+

--- a/tools/libmochi/typescript/mod.ts
+++ b/tools/libmochi/typescript/mod.ts
@@ -1,0 +1,40 @@
+export interface RunOptions {
+  /** Path to the `mochi` executable. Defaults to `mochi`. */
+  binary?: string;
+  /** Working directory for the process. */
+  cwd?: string;
+  /** Additional environment variables. */
+  env?: Record<string, string>;
+}
+
+async function runCommand(args: string[], opts: RunOptions = {}): Promise<string> {
+  const cmd = new Deno.Command(opts.binary ?? "mochi", {
+    args,
+    cwd: opts.cwd,
+    env: opts.env,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await cmd.output();
+  const outStr = new TextDecoder().decode(stdout);
+  const errStr = new TextDecoder().decode(stderr);
+  if (code !== 0) {
+    throw new Error(errStr || `mochi exited with code ${code}`);
+  }
+  return outStr;
+}
+
+export async function runFile(path: string, opts?: RunOptions): Promise<string> {
+  return await runCommand(["run", path], opts);
+}
+
+export async function run(source: string, opts?: RunOptions): Promise<string> {
+  const file = await Deno.makeTempFile({ suffix: ".mochi" });
+  await Deno.writeTextFile(file, source);
+  try {
+    return await runFile(file, opts);
+  } finally {
+    await Deno.remove(file);
+  }
+}
+

--- a/tools/libmochi/typescript/mod_test.ts
+++ b/tools/libmochi/typescript/mod_test.ts
@@ -1,0 +1,19 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { run, runFile } from "./mod.ts";
+
+Deno.test("run source string", async () => {
+  const out = await run('print("deno")');
+  assertEquals(out.trim(), "deno");
+});
+
+Deno.test("run file", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".mochi" });
+  await Deno.writeTextFile(path, 'print("file")');
+  try {
+    const out = await runFile(path);
+    assertEquals(out.trim(), "file");
+  } finally {
+    await Deno.remove(path);
+  }
+});
+


### PR DESCRIPTION
## Summary
- implement `tools/libmochi/typescript` to run Mochi code under Deno
- document usage and provide basic tests

## Testing
- `go test ./...`
- `deno test mod_test.ts` *(fails: `deno` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492426e3288320811d6382c9f771f4