### PR TITLE
Add FFI-based eval helper for Python lib

### DIFF
--- a/tools/libmochi/python/README.md
+++ b/tools/libmochi/python/README.md
@@ -2,19 +2,22 @@
 
 Python helpers for executing Mochi code.
 
-The `run` function executes a string of Mochi source and returns its standard
-output. `call` lets you define a function in Mochi code and invoke it while
-decoding the JSON result.
+The `run` function executes a string of Mochi source using the `mochi` binary
+and returns its standard output. `call` lets you define a function in Mochi code
+and invoke it while decoding the JSON result.  The `eval` helper does not rely
+on the binary. Instead it launches a small Go program through `go run` to
+interpret the code and returns the captured output.
 
 ```
 pip install -e tools/libmochi/python
 ```
 
 ```python
-from libmochi import run, call
+from libmochi import run, call, eval
 
 print(run('print("hello")'))
 print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))
+print(eval('print("ffi")'))
 ```
 
 Both helpers expect the `mochi` binary to be available on your `PATH`.

--- a/tools/libmochi/python/libmochi_test.go
+++ b/tools/libmochi/python/libmochi_test.go
@@ -27,9 +27,10 @@ func TestLibMochi(t *testing.T) {
 		t.Log(string(out))
 	}
 
-	script := `from libmochi import run, call
+	script := `from libmochi import run, call, eval
 print(run('print("hi")').strip())
-print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))`
+print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))
+print(eval('print("ffi")').strip())`
 	runCmd := exec.Command("python3", "-")
 	runCmd.Dir = filepath.Join("..", "..", "..")
 	runCmd.Env = append(os.Environ(), "PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -39,7 +40,7 @@ print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))`
 		t.Fatalf("python run failed: %v\n%s", err, out)
 	}
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if len(lines) != 2 {
+	if len(lines) != 3 {
 		t.Fatalf("unexpected output: %q", string(out))
 	}
 	if lines[0] != "hi" {
@@ -47,5 +48,8 @@ print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))`
 	}
 	if lines[1] != "5" {
 		t.Fatalf("call() output: %q", lines[1])
+	}
+	if lines[2] != "ffi" {
+		t.Fatalf("eval() output: %q", lines[2])
 	}
 }

--- a/tools/libmochi/python/runner/main.go
+++ b/tools/libmochi/python/runner/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/types"
+)
+
+type result struct {
+	Output string `json:"output"`
+	Error  string `json:"error,omitempty"`
+}
+
+func main() {
+	src := os.Getenv("MOCHI_CODE")
+	if src == "" {
+		fmt.Fprintln(os.Stderr, "MOCHI_CODE not set")
+		os.Exit(1)
+	}
+
+	res := result{}
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		res.Error = err.Error()
+		json.NewEncoder(os.Stdout).Encode(res)
+		return
+	}
+
+	env := types.NewEnv(nil)
+	var out bytes.Buffer
+	env.SetWriter(&out)
+
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		var sb strings.Builder
+		for _, e := range errs {
+			sb.WriteString(e.Error())
+			sb.WriteByte('\n')
+		}
+		res.Error = sb.String()
+		json.NewEncoder(os.Stdout).Encode(res)
+		return
+	}
+
+	interp := interpreter.New(prog, env)
+	if err := interp.Run(); err != nil {
+		res.Error = err.Error()
+		json.NewEncoder(os.Stdout).Encode(res)
+		return
+	}
+
+	res.Output = out.String()
+	json.NewEncoder(os.Stdout).Encode(res)
+}


### PR DESCRIPTION
## Summary
- extend `libmochi` Python module with new `eval` function
- implement small Go runner used by `eval`
- update docs and tests for new helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849296a8b2c8320b6a0b83cc1979f31