### PR TITLE
Fix interpreter tests by installing deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ To hack on the language or contribute:
 ```bash
 git clone https://github.com/mochilang/mochi
 cd mochi
+make install # install Deno for TypeScript tests
 make build
 make test
 ```
@@ -586,6 +587,7 @@ Mochi is open source and happy to have your contributions.
 ```bash
 git clone https://github.com/mochilang/mochi
 cd mochi
+make install # install Deno for TypeScript tests
 make build
 make test
 ```


### PR DESCRIPTION
## Summary
- install deno (`make install`) so interpreter tests run
- document running `make install` before `make test`

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_68495927a91483208d2594113131e754