### PR TITLE
Add module manager and update CLI for module-aware imports

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -29,6 +29,7 @@ import (
 	"mochi/mcp"
 	"mochi/parser"
 	"mochi/repl"
+	"mochi/runtime/mod"
 	"mochi/tools/db"
 	"mochi/types"
 )
@@ -151,6 +152,10 @@ func runFile(cmd *RunCmd) error {
 		return nil
 	}
 	env := types.NewEnv(nil)
+	modRoot, errRoot := mod.FindRoot(filepath.Dir(cmd.File))
+	if errRoot != nil {
+		modRoot = filepath.Dir(cmd.File)
+	}
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		printTypeErrors(errs)
 		return fmt.Errorf("aborted due to type errors")
@@ -159,7 +164,7 @@ func runFile(cmd *RunCmd) error {
 		interpreter.FoldPureCalls(prog, env)
 	}
 	memo := cmd.Memoize || os.Getenv("MOCHI_MEMO") == "1" || strings.ToLower(os.Getenv("MOCHI_MEMO")) == "true"
-	interp := interpreter.New(prog, env)
+	interp := interpreter.New(prog, env, modRoot)
 	interp.SetMemoization(memo)
 	err = interp.Run()
 	status := "ok"
@@ -186,6 +191,10 @@ func runTests(cmd *TestCmd) error {
 		return err
 	}
 	env := types.NewEnv(nil)
+	modRoot, errRoot := mod.FindRoot(filepath.Dir(cmd.File))
+	if errRoot != nil {
+		modRoot = filepath.Dir(cmd.File)
+	}
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		printTypeErrors(errs)
 		return fmt.Errorf("aborted due to type errors")
@@ -194,7 +203,7 @@ func runTests(cmd *TestCmd) error {
 		interpreter.FoldPureCalls(prog, env)
 	}
 	memo := cmd.Memoize || os.Getenv("MOCHI_MEMO") == "1" || strings.ToLower(os.Getenv("MOCHI_MEMO")) == "true"
-	interp := interpreter.New(prog, env)
+	interp := interpreter.New(prog, env, modRoot)
 	interp.SetMemoization(memo)
 	return interp.Test()
 }

--- a/examples/v0.7/hello-mochi/go.mod
+++ b/examples/v0.7/hello-mochi/go.mod
@@ -1,0 +1,3 @@
+module github.com/yourname/hello-mochi
+
+go 1.22

--- a/examples/v0.7/hello-mochi/main.mochi
+++ b/examples/v0.7/hello-mochi/main.mochi
@@ -1,0 +1,8 @@
+// Main program entrypoint
+// Uses local modules under math/
+
+import "math/constants"
+import "math/sqrt"
+
+print("Pi =", constants.pi)
+print("sqrt(49) =", sqrt.sqrt(49))

--- a/examples/v0.7/hello-mochi/math/constants.mochi
+++ b/examples/v0.7/hello-mochi/math/constants.mochi
@@ -1,0 +1,7 @@
+// math/constants.mochi
+// Math constants exported for reuse
+
+let pi = 3.14159
+let e = 2.71828
+
+export { pi, e }

--- a/examples/v0.7/hello-mochi/math/sqrt.mochi
+++ b/examples/v0.7/hello-mochi/math/sqrt.mochi
@@ -1,0 +1,15 @@
+// math/sqrt.mochi
+// Implements a square root function using approximation
+
+fun sqrt(x: float): float {
+  let guess = x / 2.0
+  var result = guess
+
+  for i in 0..5 {
+    result = (result + x / result) / 2.0
+  }
+
+  return result
+}
+
+export { sqrt }

--- a/interpreter/consteval.go
+++ b/interpreter/consteval.go
@@ -2,6 +2,7 @@ package interpreter
 
 import (
 	"mochi/parser"
+	"mochi/runtime/mod"
 	"mochi/types"
 )
 
@@ -23,7 +24,8 @@ func EvalPureCall(call *parser.CallExpr, env *types.Env) (*parser.Literal, bool)
 			return nil, false
 		}
 	}
-	interp := New(&parser.Program{}, env.Copy())
+	modRoot, _ := mod.FindRoot(".")
+	interp := New(&parser.Program{}, env.Copy(), modRoot)
 	val, err := interp.EvalExpr(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: &parser.PostfixExpr{Target: &parser.Primary{Call: call}}}}})
 	if err != nil {
 		return nil, false

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -9,8 +9,10 @@ import (
 	goffi "mochi/runtime/ffi/go"
 	"mochi/runtime/llm"
 	_ "mochi/runtime/llm/provider/echo"
+	"mochi/runtime/mod"
 	"mochi/types"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -45,7 +47,8 @@ func TestInterpreter_ValidPrograms(t *testing.T) {
 		goffi.Register("math.Log", math.Log)
 
 		out := &strings.Builder{}
-		interp := interpreter.New(prog, typeEnv)
+		modRoot, _ := mod.FindRoot(filepath.Dir(src))
+		interp := interpreter.New(prog, typeEnv, modRoot)
 		interp.Env().SetWriter(out)
 		if err := interp.Run(); err != nil {
 			return nil, fmt.Errorf("❌ runtime error: %w", err)
@@ -75,7 +78,8 @@ func TestInterpreter_RuntimeErrors(t *testing.T) {
 		goffi.Register("math.Log", math.Log)
 
 		out := &strings.Builder{}
-		interp := interpreter.New(prog, typeEnv)
+		modRoot, _ := mod.FindRoot(filepath.Dir(src))
+		interp := interpreter.New(prog, typeEnv, modRoot)
 		interp.Env().SetWriter(out)
 		err = interp.Run()
 		if err == nil {

--- a/interpreter/plan_duckdb_test.go
+++ b/interpreter/plan_duckdb_test.go
@@ -8,6 +8,7 @@ import (
 
 	"mochi/interpreter"
 	"mochi/parser"
+	"mochi/runtime/mod"
 	"mochi/types"
 )
 
@@ -17,11 +18,12 @@ func runProgram(t *testing.T, src string, plan string) string {
 		t.Fatalf("parse: %v", err)
 	}
 	env := types.NewEnv(nil)
+	modRoot, _ := mod.FindRoot(".")
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
 	out := &strings.Builder{}
-	interp := interpreter.New(prog, env)
+	interp := interpreter.New(prog, env, modRoot)
 	interp.SetDataPlan(plan)
 	interp.Env().SetWriter(out)
 	if err := interp.Run(); err != nil {

--- a/interpreter/schema_test.go
+++ b/interpreter/schema_test.go
@@ -8,6 +8,7 @@ import (
 	"mochi/interpreter"
 	"mochi/parser"
 	"mochi/runtime/llm"
+	"mochi/runtime/mod"
 	"mochi/types"
 )
 
@@ -55,7 +56,8 @@ let f = generate Foo { prompt: "{}" }`
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	interp := interpreter.New(prog, env)
+	modRoot, _ := mod.FindRoot(".")
+	interp := interpreter.New(prog, env, modRoot)
 	if err := interp.Run(); err != nil {
 		t.Fatalf("run error: %v", err)
 	}
@@ -93,7 +95,8 @@ let result = generate text { tools: [getWeather, calc], prompt: "hi" }`
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	interp := interpreter.New(prog, env)
+	modRoot, _ := mod.FindRoot(".")
+	interp := interpreter.New(prog, env, modRoot)
 	if err := interp.Run(); err != nil {
 		t.Fatalf("run error: %v", err)
 	}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"mochi/interpreter"
 	"mochi/parser"
+	"mochi/runtime/mod"
 	"mochi/types"
 )
 
@@ -109,6 +110,10 @@ func runProgram(ctx context.Context, source string, filename string) (string, er
 
 	// Step 2: Type Check
 	env := types.NewEnv(nil)
+	modRoot, errRoot := mod.FindRoot(".")
+	if errRoot != nil {
+		modRoot, _ = os.Getwd()
+	}
 	typeErrors := types.Check(prog, env)
 	if len(typeErrors) > 0 {
 		fmt.Fprintln(output, "❌ Type Check Failed")
@@ -119,7 +124,7 @@ func runProgram(ctx context.Context, source string, filename string) (string, er
 	}
 
 	// Step 3: Run
-	interp := interpreter.New(prog, env)
+	interp := interpreter.New(prog, env, modRoot)
 	interp.Env().SetWriter(output)
 	if err := interp.Run(); err != nil {
 		fmt.Fprintf(output, "❌ Runtime Error\n\n  → %v\n", err)

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -3,6 +3,7 @@ package repl
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/chzyer/readline"
@@ -10,6 +11,7 @@ import (
 
 	"mochi/interpreter"
 	"mochi/parser"
+	"mochi/runtime/mod"
 	"mochi/types"
 )
 
@@ -25,9 +27,14 @@ func New(out io.Writer, version string) *REPL {
 	env := types.NewEnv(nil)
 	env.SetWriter(out)
 
+	root, err := mod.FindRoot(".")
+	if err != nil {
+		root, _ = os.Getwd()
+	}
+
 	return &REPL{
 		env:     env,
-		interp:  interpreter.New(nil, env),
+		interp:  interpreter.New(nil, env, root),
 		out:     out,
 		version: version,
 	}

--- a/runtime/mod/mod.go
+++ b/runtime/mod/mod.go
@@ -1,0 +1,99 @@
+package mod
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/mod/modfile"
+)
+
+// Module represents a Mochi module identified by a go.mod file.
+type Module struct {
+	// Root is the directory containing go.mod.
+	Root string
+	// Path is the module path declared in go.mod.
+	Path string
+}
+
+var cache struct {
+	sync.Mutex
+	modules map[string]*Module
+}
+
+func init() {
+	cache.modules = map[string]*Module{}
+}
+
+// FindRoot walks parent directories starting at dir until a go.mod file is found.
+func FindRoot(dir string) (string, error) {
+	d := dir
+	for {
+		if _, err := os.Stat(filepath.Join(d, "go.mod")); err == nil {
+			return d, nil
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			break
+		}
+		d = parent
+	}
+	return "", fmt.Errorf("module root not found from %s", dir)
+}
+
+// Load discovers the module starting from dir. The module is cached for
+// subsequent calls.
+func Load(dir string) (*Module, error) {
+	root, err := FindRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	cache.Lock()
+	if m, ok := cache.modules[root]; ok {
+		cache.Unlock()
+		return m, nil
+	}
+	cache.Unlock()
+
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return nil, err
+	}
+	mf, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return nil, err
+	}
+	mod := &Module{Root: root}
+	if mf.Module != nil {
+		mod.Path = mf.Module.Mod.Path
+	}
+
+	cache.Lock()
+	cache.modules[root] = mod
+	cache.Unlock()
+	return mod, nil
+}
+
+// Resolve returns an absolute path for a module-relative import.
+func (m *Module) Resolve(p string) string {
+	return filepath.Join(m.Root, filepath.FromSlash(p))
+}
+
+// Exists reports whether a given module-relative path exists.
+func (m *Module) Exists(p string) bool {
+	_, err := os.Stat(m.Resolve(p))
+	return err == nil
+}
+
+// ReadFile reads a file relative to the module root.
+func (m *Module) ReadFile(p string) ([]byte, error) {
+	return os.ReadFile(m.Resolve(p))
+}
+
+// Open opens a file relative to the module root.
+func (m *Module) Open(p string) (fs.File, error) {
+	return os.Open(m.Resolve(p))
+}

--- a/tools/libmochi/python/runner/main.go
+++ b/tools/libmochi/python/runner/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"mochi/runtime/mod"
 	"os"
 	"strings"
 
@@ -35,6 +36,10 @@ func main() {
 	env := types.NewEnv(nil)
 	var out bytes.Buffer
 	env.SetWriter(&out)
+	modRoot, errRoot := mod.FindRoot(".")
+	if errRoot != nil {
+		modRoot, _ = os.Getwd()
+	}
 
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		var sb strings.Builder
@@ -47,7 +52,7 @@ func main() {
 		return
 	}
 
-	interp := interpreter.New(prog, env)
+	interp := interpreter.New(prog, env, modRoot)
 	if err := interp.Run(); err != nil {
 		res.Error = err.Error()
 		json.NewEncoder(os.Stdout).Encode(res)

--- a/tools/tinygo_wasm/main.go
+++ b/tools/tinygo_wasm/main.go
@@ -8,6 +8,7 @@ import (
 
 	"mochi/interpreter"
 	"mochi/parser"
+	"mochi/runtime/mod"
 	"mochi/types"
 )
 
@@ -21,6 +22,10 @@ func runMochi(this js.Value, args []js.Value) any {
 		return js.ValueOf(err.Error())
 	}
 	env := types.NewEnv(nil)
+	modRoot, errRoot := mod.FindRoot(".")
+	if errRoot != nil {
+		modRoot = "."
+	}
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		var sb strings.Builder
 		for _, e := range errs {
@@ -29,7 +34,7 @@ func runMochi(this js.Value, args []js.Value) any {
 		}
 		return js.ValueOf(sb.String())
 	}
-	interp := interpreter.New(prog, env)
+	interp := interpreter.New(prog, env, modRoot)
 	if err := interp.Run(); err != nil {
 		return js.ValueOf(err.Error())
 	}

--- a/tools/wasm/main.go
+++ b/tools/wasm/main.go
@@ -9,6 +9,7 @@ import (
 
 	"mochi/interpreter"
 	"mochi/parser"
+	"mochi/runtime/mod"
 	"mochi/types"
 )
 
@@ -26,6 +27,10 @@ func runMochi(this js.Value, args []js.Value) any {
 	env := types.NewEnv(nil)
 	var buf bytes.Buffer
 	env.SetWriter(&buf)
+	modRoot, errRoot := mod.FindRoot(".")
+	if errRoot != nil {
+		modRoot = "."
+	}
 
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		var sb strings.Builder
@@ -36,7 +41,7 @@ func runMochi(this js.Value, args []js.Value) any {
 		return js.ValueOf(sb.String())
 	}
 
-	i := interpreter.New(prog, env)
+	i := interpreter.New(prog, env, modRoot)
 	if err := i.Run(); err != nil {
 		return js.ValueOf(err.Error())
 	}


### PR DESCRIPTION
## Summary
- introduce `runtime/mod` for module discovery and path resolution
- update interpreter to accept a module root and use it for imports
- refactor CLI and tools to pass module root to the interpreter
- provide `hello-mochi` example demonstrating new module layout

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68495a9d14b083209c510e2d73f60912