### PR TITLE
Improve FFI docs

### DIFF
--- a/docs/features/ffi.md
+++ b/docs/features/ffi.md
@@ -2,8 +2,9 @@
 
 Mochi can call into Go, Python and TypeScript libraries using the `import`
 statement and `extern` declarations. Imported modules expose their values
-through an FFI runtime so Mochi code can invoke them directly. When `as`
-is omitted, the last path component becomes the module name.
+through language specific FFI runtimes so Mochi code can invoke them
+directly. When `as` is omitted, the last path component becomes the module
+name.
 
 ```mochi
 import python "math" as math
@@ -16,3 +17,36 @@ print(math.sqrt(49.0))
 Modules may be loaded from the host language's package system or from a
 local file. Functions and variables must be declared with `extern` before
 use so the compiler knows their types.
+
+### Calling Go Code
+
+```mochi
+import go "math" as math
+
+extern fun math.Sqrt(x: float): float
+
+print(math.Sqrt(16.0))
+```
+
+### Calling Python Code
+
+```mochi
+import python "math" as math
+
+extern fun math.sqrt(x: float): float
+
+print(math.sqrt(49.0))
+```
+
+### Calling TypeScript Code
+
+```mochi
+import typescript "./runtime/ffi/deno/math.ts" as math
+
+extern fun math.pow(x: float, y: float): float
+
+print(math.pow(2.0, 8.0))
+```
+
+Each runtime has a small host-side library under `runtime/ffi` which
+implements the calls made by Mochi programs.

--- a/runtime/ffi/README.md
+++ b/runtime/ffi/README.md
@@ -1,7 +1,7 @@
 # Runtime FFI
 
 This directory contains language specific runtimes used to invoke foreign
-functions from Mochi programs. Each runtime implements a small set of common
+functions from Mochi programs. Most runtimes expose a small set of common
 interfaces defined in [`ffi.go`](./ffi.go):
 
 ```go
@@ -21,7 +21,7 @@ type Loader interface {
 }
 ```
 
-The Go, TypeScript and Python runtimes expose concrete implementations of these
-APIs while also providing package level helpers for convenience. The Go runtime
-can additionally load functions from modules compiled as plugins exposing an
-`Exports` map.
+The Go and TypeScript runtimes implement these APIs and provide package level
+helpers. The Python runtime offers a simplified `Attr` function for retrieving
+or invoking module attributes. The Go runtime can additionally load functions
+from plugins exposing an `Exports` map.


### PR DESCRIPTION
## Summary
- clarify that Go and TS runtimes implement the FFI interfaces
- document the Python runtime's `Attr` helper
- expand feature docs with examples for Go, Python and TypeScript

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68499a847e088320bf86a7cda2f7dba3