### PR TITLE
Remove unused TS FFI interfaces

### DIFF
--- a/runtime/ffi/ts/ffi.ts
+++ b/runtime/ffi/ts/ffi.ts
@@ -1,19 +1,7 @@
 export type FfiFunction = (...args: any[]) => any | Promise<any>;
 export type FfiValue = any;
 
-export interface Caller {
-  call(name: string, ...args: any[]): Promise<any>;
-}
-
-export interface Registerer {
-  register(name: string, value: FfiValue): void;
-}
-
-export interface Loader {
-  loadModule(path: string): Promise<void>;
-}
-
-export class Runtime implements Caller, Registerer, Loader {
+export class Runtime {
   private registry: Record<string, FfiValue> = {};
 
   register(name: string, value: FfiValue): void {


### PR DESCRIPTION
## Summary
- simplify TypeScript FFI runtime by removing unused interface definitions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849a0e550848320bd7eeab453c9de7d