### PR TITLE
Remove unused code in Python ffi

### DIFF
--- a/runtime/ffi/python/python.go
+++ b/runtime/ffi/python/python.go
@@ -25,16 +25,13 @@ else:
     res = attr
 json.dump(res, sys.stdout)
 `, module, name, module, name)
-	return run(src, args)
-}
 
-func run(code string, args []any) (any, error) {
 	file, err := os.CreateTemp("", "mochi_py_*.py")
 	if err != nil {
 		return nil, err
 	}
 	defer os.Remove(file.Name())
-	if _, err := file.WriteString(code); err != nil {
+	if _, err := file.WriteString(src); err != nil {
 		file.Close()
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- inline the Python `run` helper into the `Attr` function
- remove now-unused helper function

## Testing
- `go vet ./...`
- `go test ./runtime/ffi/... -run TestAttr -v`


------
https://chatgpt.com/codex/tasks/task_e_6849a0d1d5f88320a5730332871d8501