### PR TITLE
Remove unused loader interface

### DIFF
--- a/runtime/ffi/README.md
+++ b/runtime/ffi/README.md
@@ -14,14 +14,8 @@ type Caller interface {
 type Registerer interface {
     Register(name string, fn any) error
 }
-
-// Loader loads additional modules that may register functions.
-type Loader interface {
-    LoadModule(path string) error
-}
 ```
 
 The Go and TypeScript runtimes implement these APIs and provide package level
 helpers. The Python runtime offers a simplified `Attr` function for retrieving
-or invoking module attributes. The Go runtime can additionally load functions
-from plugins exposing an `Exports` map.
+or invoking module attributes.

--- a/runtime/ffi/ffi.go
+++ b/runtime/ffi/ffi.go
@@ -9,8 +9,3 @@ type Caller interface {
 type Registerer interface {
 	Register(name string, fn any) error
 }
-
-// Loader loads modules that may register additional functions.
-type Loader interface {
-	LoadModule(path string) error
-}


### PR DESCRIPTION
## Summary
- remove `Loader` interface from Go FFI
- update FFI docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849a0c596cc8320b4a3d29db3aec578