### PR TITLE
Add doc comment parsing example and support

### DIFF
--- a/examples/v0.7/docs.mochi
+++ b/examples/v0.7/docs.mochi
@@ -1,0 +1,51 @@
+// Package mathutil provides helper functions for math operations.
+// This package includes functions like square, clamp, and average.
+package mathutil
+
+// PI is the mathematical constant \u03c0 (approx. 3.14159).
+let PI = 3.14159
+
+// square returns the square of a number.
+// Example:
+//   square(3) => 9
+fun square(x: float): float {
+  return x * x
+}
+
+// clamp restricts a value to a given min and max range.
+// Example:
+//   clamp(5, 0, 10) => 5
+//   clamp(15, 0, 10) => 10
+fun clamp(value: float, min: float, max: float): float {
+  if value < min {
+    return min
+  } else if value > max {
+    return max
+  }
+  return value
+}
+
+// average computes the mean of a list of floats.
+// If the list is empty, returns 0.
+fun average(nums: list<float>): float {
+  if nums.len == 0 {
+    return 0.0
+  }
+  let sum = 0.0
+  for x in nums {
+    sum = sum + x
+  }
+  return sum / nums.len
+}
+
+// Person represents a simple record with a name and age.
+type Person {
+  // The person's name.
+  name: string,
+
+  // The person's age in years.
+  age: int
+}
+
+// Status represents a state a task can be in.
+type Status = Pending | Done | Failed

--- a/parser/docs.go
+++ b/parser/docs.go
@@ -1,0 +1,67 @@
+package parser
+
+import "strings"
+
+// attachDocs scans src for comment blocks immediately preceding declarations
+// and attaches them to the parsed Program structure.
+func attachDocs(src string, prog *Program) {
+	lineDocs := extractLineDocs(src)
+	if doc, ok := lineDocs[prog.Pos.Line]; ok {
+		prog.PackageDoc = doc
+	}
+	for _, stmt := range prog.Statements {
+		attachStmtDocs(stmt, lineDocs)
+	}
+}
+
+// extractLineDocs returns a map from the first line of a declaration to the
+// comment block that appears directly above it.
+func extractLineDocs(src string) map[int]string {
+	lines := strings.Split(src, "\n")
+	docs := map[int]string{}
+	i := 0
+	for i < len(lines) {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, "//") {
+			block := []string{strings.TrimSpace(strings.TrimPrefix(line, "//"))}
+			j := i + 1
+			for j < len(lines) {
+				t := strings.TrimSpace(lines[j])
+				if strings.HasPrefix(t, "//") {
+					block = append(block, strings.TrimSpace(strings.TrimPrefix(t, "//")))
+					j++
+				} else {
+					break
+				}
+			}
+			if j < len(lines) && strings.TrimSpace(lines[j]) != "" {
+				docs[j+1] = strings.Join(block, "\n")
+			}
+			i = j
+		} else {
+			i++
+		}
+	}
+	return docs
+}
+
+func attachStmtDocs(s *Statement, docs map[int]string) {
+	switch {
+	case s.Fun != nil:
+		if doc, ok := docs[s.Fun.Pos.Line]; ok {
+			s.Fun.Doc = doc
+		}
+	case s.Agent != nil:
+		if doc, ok := docs[s.Agent.Pos.Line]; ok {
+			s.Agent.Doc = doc
+		}
+	case s.Type != nil:
+		if doc, ok := docs[s.Type.Pos.Line]; ok {
+			s.Type.Doc = doc
+		}
+	case s.Stream != nil:
+		if doc, ok := docs[s.Stream.Pos.Line]; ok {
+			s.Stream.Doc = doc
+		}
+	}
+}

--- a/parser/docs_test.go
+++ b/parser/docs_test.go
@@ -1,0 +1,34 @@
+package parser_test
+
+import (
+	"os"
+	"testing"
+
+	"mochi/parser"
+)
+
+func TestParser_DocComments(t *testing.T) {
+	src, err := os.ReadFile("../examples/v0.7/docs.mochi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prog, err := parser.ParseString(string(src))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if prog.PackageDoc == "" {
+		t.Fatalf("expected package doc")
+	}
+	found := false
+	for _, stmt := range prog.Statements {
+		if stmt.Fun != nil && stmt.Fun.Name == "square" {
+			if stmt.Fun.Doc == "" {
+				t.Errorf("missing doc for square")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("square function not found")
+	}
+}

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -20,6 +20,7 @@ func Parse(path string) (*Program, error) {
 	if err != nil {
 		return nil, wrapParseError(path, err)
 	}
+	attachDocs(string(src), prog)
 	return prog, nil
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,7 +38,8 @@ var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 
 type Program struct {
 	Pos        lexer.Position
-	Package    string       `parser:"[ 'package' @Ident ]"`
+	Package    string `parser:"[ 'package' @Ident ]"`
+	PackageDoc string
 	Statements []*Statement `parser:"@@*"`
 }
 
@@ -115,7 +116,8 @@ type ForStmt struct {
 
 type TypeDecl struct {
 	Pos      lexer.Position
-	Name     string         `parser:"'type' @Ident"`
+	Name     string `parser:"'type' @Ident"`
+	Doc      string
 	Members  []*TypeMember  `parser:"[ '{' @@* '}' ]"`
 	Variants []*TypeVariant `parser:"[ '=' @@ { '|' @@ } ]"`
 }
@@ -179,8 +181,9 @@ type AssignStmt struct {
 
 type FunStmt struct {
 	Pos    lexer.Position
-	Export bool         `parser:"[ @'export' ]"`
-	Name   string       `parser:"'fun' @Ident"`
+	Export bool   `parser:"[ @'export' ]"`
+	Name   string `parser:"'fun' @Ident"`
+	Doc    string
 	Params []*Param     `parser:"'(' [ @@ { ',' @@ } ] ')'"`
 	Return *TypeRef     `parser:"[ ':' @@ ]"`
 	Body   []*Statement `parser:"'{' @@* '}'"`
@@ -454,7 +457,8 @@ type Literal struct {
 
 type StreamDecl struct {
 	Pos    lexer.Position
-	Name   string         `parser:"'stream' @Ident"`
+	Name   string `parser:"'stream' @Ident"`
+	Doc    string
 	Fields []*StreamField `parser:"'{' @@* '}'"`
 }
 
@@ -503,7 +507,8 @@ type EmitStmt struct {
 
 type AgentDecl struct {
 	Pos  lexer.Position
-	Name string        `parser:"'agent' @Ident"`
+	Name string `parser:"'agent' @Ident"`
+	Doc  string
 	Body []*AgentBlock `parser:"'{' @@* '}'"`
 }
 
@@ -537,6 +542,7 @@ func ParseString(src string) (*Program, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse error: %w", err)
 	}
+	attachDocs(src, prog)
 	return prog, nil
 }
 


### PR DESCRIPTION
## Summary
- capture doc comments in parser using new helper utilities
- add docs example showing comment usage
- include unit test ensuring comments are attached

## Testing
- `go test ./parser -run TestParser_DocComments -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849a3987a508320994128d5ac0946bf