### PR TITLE
Add v0.6.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # 📦 CHANGELOG.md
+## [0.6.3] – 2025-06-13
+
+### Added
+
+* `package` and `export` keywords for modules
+* Default alias when `import` has no `as`
+* `init` and `get` commands for the CLI
+* Dataset `load` and `save` in Go, Python and TypeScript
+* `libmochi` helpers for Go, Python and TypeScript
+* Parser captures documentation comments
+
+### Changed
+
+* WebAssembly interpreter built on demand
+
+### Fixed
+
+* TypeScript package import declarations
+
 ## [0.6.2] – 2025-06-12
 
 ### Added

--- a/releases/v0.6.3.md
+++ b/releases/v0.6.3.md
@@ -1,0 +1,37 @@
+# Jun 2025 (v0.6.3)
+
+Mochi v0.6.3 introduces packages for organizing code, new CLI utilities and improved dataset handling across compilers.
+
+## Packages
+
+Use `package` declarations to group files and `export` to expose definitions. Imports default to the last path segment when no alias is given.
+
+```mochi
+package mathutils
+
+export fun add(a: int, b: int): int {
+  return a + b
+}
+```
+
+```mochi
+import "mathutils"
+print(mathutils.add(2, 3))
+```
+
+## Dataset I/O
+
+`load` and `save` work uniformly in Go, Python and TypeScript compilers for CSV, JSONL, JSON and YAML files.
+
+## Module Commands
+
+The `mochi` CLI adds `init` to create a new module and `get` to download dependencies.
+
+## Documentation Comments
+
+The parser now attaches preceding line comments to programs and declarations.
+
+## libmochi Libraries
+
+Helpers for Go, Python and TypeScript run Mochi code directly from host applications.
+


### PR DESCRIPTION
## Summary
- update CHANGELOG for v0.6.3
- document new features in `releases/v0.6.3.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6849a6f86e848320be6a3588a43ef10f