### PR TITLE
Add Go FFI package inference

### DIFF
--- a/runtime/ffi/go/infer.go
+++ b/runtime/ffi/go/infer.go
@@ -1,0 +1,69 @@
+package goffi
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/packages"
+
+	ffiinfo "mochi/runtime/ffi/infer"
+)
+
+// Infer loads the Go package at path and returns information about its exported symbols.
+func Infer(path string) (*ffiinfo.ModuleInfo, error) {
+	cfg := &packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedName}
+	pkgs, err := packages.Load(cfg, path)
+	if err != nil {
+		return nil, err
+	}
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("no package found: %s", path)
+	}
+	pkg := pkgs[0]
+
+	info := &ffiinfo.ModuleInfo{Path: pkg.PkgPath}
+	scope := pkg.Types.Scope()
+	for _, name := range scope.Names() {
+		if !ast.IsExported(name) {
+			continue
+		}
+		obj := scope.Lookup(name)
+		switch o := obj.(type) {
+		case *types.Func:
+			info.Functions = append(info.Functions, ffiinfo.FuncInfo{Name: name, Signature: o.Type().String()})
+		case *types.Var:
+			info.Vars = append(info.Vars, ffiinfo.VarInfo{Name: name, Type: o.Type().String()})
+		case *types.Const:
+			info.Consts = append(info.Consts, ffiinfo.ConstInfo{Name: name, Type: o.Type().String(), Value: o.Val().ExactString()})
+		case *types.TypeName:
+			kind := typeKind(o.Type().Underlying())
+			info.Types = append(info.Types, ffiinfo.TypeInfo{Name: name, Kind: kind})
+		}
+	}
+
+	return info, nil
+}
+
+func typeKind(t types.Type) string {
+	switch t.(type) {
+	case *types.Struct:
+		return "struct"
+	case *types.Interface:
+		return "interface"
+	case *types.Slice:
+		return "slice"
+	case *types.Array:
+		return "array"
+	case *types.Map:
+		return "map"
+	case *types.Pointer:
+		return "pointer"
+	case *types.Signature:
+		return "func"
+	case *types.Basic:
+		return "basic"
+	default:
+		return fmt.Sprintf("%T", t)
+	}
+}

--- a/runtime/ffi/go/infer_test.go
+++ b/runtime/ffi/go/infer_test.go
@@ -1,0 +1,61 @@
+package goffi_test
+
+import (
+	"testing"
+
+	goffi "mochi/runtime/ffi/go"
+)
+
+func TestInfer(t *testing.T) {
+	info, err := goffi.Infer("mochi/runtime/ffi/go/testpkg")
+	if err != nil {
+		t.Fatalf("infer failed: %v", err)
+	}
+
+	foundAdd := false
+	for _, f := range info.Functions {
+		if f.Name == "Add" {
+			foundAdd = true
+			break
+		}
+	}
+	if !foundAdd {
+		t.Fatalf("expected Add function in inference results")
+	}
+
+	foundPi := false
+	for _, c := range info.Consts {
+		if c.Name == "Pi" {
+			foundPi = true
+			break
+		}
+	}
+	if !foundPi {
+		t.Fatalf("expected Pi constant")
+	}
+
+	foundAnswer := false
+	for _, v := range info.Vars {
+		if v.Name == "Answer" {
+			foundAnswer = true
+			break
+		}
+	}
+	if !foundAnswer {
+		t.Fatalf("expected Answer variable")
+	}
+
+	foundPoint := false
+	for _, tinfo := range info.Types {
+		if tinfo.Name == "Point" {
+			if tinfo.Kind != "struct" {
+				t.Fatalf("Point kind should be struct, got %s", tinfo.Kind)
+			}
+			foundPoint = true
+			break
+		}
+	}
+	if !foundPoint {
+		t.Fatalf("expected Point type")
+	}
+}

--- a/runtime/ffi/go/testpkg/testpkg.go
+++ b/runtime/ffi/go/testpkg/testpkg.go
@@ -1,0 +1,17 @@
+package testpkg
+
+import "errors"
+
+const Pi = 3.14
+
+var Answer = 42
+
+// Point is a simple struct used for testing.
+type Point struct {
+	X int
+	Y int
+}
+
+func Add(a, b int) int { return a + b }
+
+func Fail() error { return errors.New("boom") }

--- a/runtime/ffi/infer/infer.go
+++ b/runtime/ffi/infer/infer.go
@@ -1,0 +1,35 @@
+package ffiinfo
+
+// ModuleInfo describes the exported symbols of a foreign module.
+type ModuleInfo struct {
+	Path      string
+	Functions []FuncInfo
+	Vars      []VarInfo
+	Consts    []ConstInfo
+	Types     []TypeInfo
+}
+
+// FuncInfo describes an exported function.
+type FuncInfo struct {
+	Name      string
+	Signature string
+}
+
+// VarInfo describes an exported variable.
+type VarInfo struct {
+	Name string
+	Type string
+}
+
+// ConstInfo describes an exported constant.
+type ConstInfo struct {
+	Name  string
+	Type  string
+	Value string
+}
+
+// TypeInfo describes an exported type.
+type TypeInfo struct {
+	Name string
+	Kind string
+}


### PR DESCRIPTION
## Summary
- add generic module info types under runtime/ffi/infer
- implement `goffi.Infer` to reflect exported Go package symbols
- provide tests and sample package for inference

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849ae8b4d408320842e21d101c68602