### PR TITLE
Add Python FFI module inference

### DIFF
--- a/runtime/ffi/python/infer.go
+++ b/runtime/ffi/python/infer.go
@@ -1,0 +1,62 @@
+package python
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	ffiinfo "mochi/runtime/ffi/infer"
+)
+
+// Infer loads the Python module at path and returns information about its
+// exported symbols. Only attributes that do not start with '_' are considered
+// exported. Constants are identified by names consisting solely of uppercase
+// letters.
+func Infer(module string) (*ffiinfo.ModuleInfo, error) {
+	script := fmt.Sprintf(`import json, importlib, inspect, sys, os
+sys.path.insert(0, os.getcwd())
+mod = importlib.import_module("%s")
+info = {"Path": mod.__name__, "Functions": [], "Vars": [], "Consts": [], "Types": []}
+for name in dir(mod):
+    if name.startswith("_"):
+        continue
+    attr = getattr(mod, name)
+    if inspect.isroutine(attr):
+        try:
+            sig = str(inspect.signature(attr))
+        except Exception:
+            sig = ""
+        info["Functions"].append({"Name": name, "Signature": sig})
+    elif inspect.isclass(attr):
+        info["Types"].append({"Name": name, "Kind": "class"})
+    elif name.isupper():
+        info["Consts"].append({"Name": name, "Type": type(attr).__name__, "Value": repr(attr)})
+    else:
+        info["Vars"].append({"Name": name, "Type": type(attr).__name__})
+json.dump(info, sys.stdout)
+`, module)
+
+	file, err := os.CreateTemp("", "mochi_py_infer_*.py")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(file.Name())
+	if _, err := file.WriteString(script); err != nil {
+		file.Close()
+		return nil, err
+	}
+	file.Close()
+
+	cmd := exec.Command("python3", file.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("python error: %w\n%s", err, out)
+	}
+
+	var info ffiinfo.ModuleInfo
+	if err := json.Unmarshal(out, &info); err != nil {
+		return nil, fmt.Errorf("decode error: %w\noutput: %s", err, out)
+	}
+	return &info, nil
+}

--- a/runtime/ffi/python/infer_test.go
+++ b/runtime/ffi/python/infer_test.go
@@ -1,0 +1,61 @@
+package python_test
+
+import (
+	"testing"
+
+	"mochi/runtime/ffi/python"
+)
+
+func TestInfer(t *testing.T) {
+	info, err := python.Infer("testpkg")
+	if err != nil {
+		t.Fatalf("infer failed: %v", err)
+	}
+
+	foundAdd := false
+	for _, f := range info.Functions {
+		if f.Name == "Add" {
+			foundAdd = true
+			break
+		}
+	}
+	if !foundAdd {
+		t.Fatalf("expected Add function in inference results")
+	}
+
+	foundPi := false
+	for _, c := range info.Consts {
+		if c.Name == "PI" {
+			foundPi = true
+			break
+		}
+	}
+	if !foundPi {
+		t.Fatalf("expected PI constant")
+	}
+
+	foundAnswer := false
+	for _, v := range info.Vars {
+		if v.Name == "Answer" {
+			foundAnswer = true
+			break
+		}
+	}
+	if !foundAnswer {
+		t.Fatalf("expected Answer variable")
+	}
+
+	foundPoint := false
+	for _, tinfo := range info.Types {
+		if tinfo.Name == "Point" {
+			if tinfo.Kind != "class" {
+				t.Fatalf("Point kind should be class, got %s", tinfo.Kind)
+			}
+			foundPoint = true
+			break
+		}
+	}
+	if !foundPoint {
+		t.Fatalf("expected Point type")
+	}
+}

--- a/runtime/ffi/python/testpkg/__init__.py
+++ b/runtime/ffi/python/testpkg/__init__.py
@@ -1,0 +1,9 @@
+PI = 3.14
+Answer = 42
+class Point:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+def Add(a, b):
+    return a + b


### PR DESCRIPTION
## Summary
- add `Infer` to runtime/ffi/python to inspect exported symbols of a Python module
- create a small test package for Python FFI
- add tests for module inference

## Testing
- `go test ./runtime/ffi/python -run TestInfer -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849b1b3369c83209bf9de5b977314da