### PR TITLE
Improve Go FFI symbol inference

### DIFF
--- a/runtime/ffi/go/infer.go
+++ b/runtime/ffi/go/infer.go
@@ -1,9 +1,14 @@
 package goffi
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
+	"go/doc"
+	"go/printer"
+	"go/token"
 	"go/types"
+	"strings"
 
 	"golang.org/x/tools/go/packages"
 
@@ -12,7 +17,7 @@ import (
 
 // Infer loads the Go package at path and returns information about its exported symbols.
 func Infer(path string) (*ffiinfo.ModuleInfo, error) {
-	cfg := &packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedName}
+	cfg := &packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedName, Tests: true}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {
 		return nil, err
@@ -21,25 +26,117 @@ func Infer(path string) (*ffiinfo.ModuleInfo, error) {
 		return nil, fmt.Errorf("no package found: %s", path)
 	}
 	pkg := pkgs[0]
+	if cfg.Tests && len(pkgs) > 1 {
+		for _, p := range pkgs {
+			if p.PkgPath == pkg.PkgPath && strings.Contains(p.ID, "[") {
+				pkg = p
+				break
+			}
+		}
+	}
 
-	info := &ffiinfo.ModuleInfo{Path: pkg.PkgPath}
-	scope := pkg.Types.Scope()
-	for _, name := range scope.Names() {
-		if !ast.IsExported(name) {
+	docPkg, err := doc.NewFromFiles(pkg.Fset, pkg.Syntax, pkg.PkgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	qf := types.RelativeTo(pkg.Types)
+
+	info := &ffiinfo.ModuleInfo{
+		Path:      pkg.PkgPath,
+		Doc:       strings.TrimSpace(docPkg.Doc),
+		Examples:  convertExamples(docPkg.Examples, pkg.Fset),
+		Functions: []ffiinfo.FuncInfo{},
+		Vars:      []ffiinfo.VarInfo{},
+		Consts:    []ffiinfo.ConstInfo{},
+		Types:     []ffiinfo.TypeInfo{},
+	}
+
+	for _, f := range docPkg.Funcs {
+		obj, _ := pkg.Types.Scope().Lookup(f.Name).(*types.Func)
+		sig, _ := obj.Type().(*types.Signature)
+		params, results := signatureInfo(sig, qf)
+		info.Functions = append(info.Functions, ffiinfo.FuncInfo{
+			Name:     f.Name,
+			Doc:      strings.TrimSpace(f.Doc),
+			Params:   params,
+			Results:  results,
+			Examples: convertExamples(f.Examples, pkg.Fset),
+		})
+	}
+
+	for _, v := range docPkg.Vars {
+		docStr := strings.TrimSpace(v.Doc)
+		for _, name := range v.Names {
+			if !ast.IsExported(name) {
+				continue
+			}
+			if obj, ok := pkg.Types.Scope().Lookup(name).(*types.Var); ok {
+				info.Vars = append(info.Vars, ffiinfo.VarInfo{
+					Name: name,
+					Type: types.TypeString(obj.Type(), qf),
+					Doc:  docStr,
+				})
+			}
+		}
+	}
+
+	for _, c := range docPkg.Consts {
+		docStr := strings.TrimSpace(c.Doc)
+		for _, name := range c.Names {
+			if !ast.IsExported(name) {
+				continue
+			}
+			if obj, ok := pkg.Types.Scope().Lookup(name).(*types.Const); ok {
+				info.Consts = append(info.Consts, ffiinfo.ConstInfo{
+					Name:  name,
+					Type:  types.TypeString(obj.Type(), qf),
+					Value: obj.Val().String(),
+					Doc:   docStr,
+				})
+			}
+		}
+	}
+
+	for _, t := range docPkg.Types {
+		if !ast.IsExported(t.Name) {
 			continue
 		}
-		obj := scope.Lookup(name)
-		switch o := obj.(type) {
-		case *types.Func:
-			info.Functions = append(info.Functions, ffiinfo.FuncInfo{Name: name, Signature: o.Type().String()})
-		case *types.Var:
-			info.Vars = append(info.Vars, ffiinfo.VarInfo{Name: name, Type: o.Type().String()})
-		case *types.Const:
-			info.Consts = append(info.Consts, ffiinfo.ConstInfo{Name: name, Type: o.Type().String(), Value: o.Val().ExactString()})
-		case *types.TypeName:
-			kind := typeKind(o.Type().Underlying())
-			info.Types = append(info.Types, ffiinfo.TypeInfo{Name: name, Kind: kind})
+		obj, _ := pkg.Types.Scope().Lookup(t.Name).(*types.TypeName)
+		kind := typeKind(obj.Type().Underlying())
+		ti := ffiinfo.TypeInfo{
+			Name:     t.Name,
+			Kind:     kind,
+			Doc:      strings.TrimSpace(t.Doc),
+			Examples: convertExamples(t.Examples, pkg.Fset),
 		}
+
+		if s, ok := obj.Type().Underlying().(*types.Struct); ok {
+			for i := 0; i < s.NumFields(); i++ {
+				f := s.Field(i)
+				ti.Fields = append(ti.Fields, ffiinfo.FieldInfo{
+					Name: f.Name(),
+					Type: types.TypeString(f.Type(), qf),
+					Tag:  s.Tag(i),
+				})
+			}
+		}
+
+		for _, m := range t.Methods {
+			ident := m.Decl.Name
+			obj := pkg.TypesInfo.Defs[ident].(*types.Func)
+			sig := obj.Type().(*types.Signature)
+			params, results := signatureInfo(sig, qf)
+			ti.Methods = append(ti.Methods, ffiinfo.FuncInfo{
+				Name:     m.Name,
+				Doc:      strings.TrimSpace(m.Doc),
+				Params:   params,
+				Results:  results,
+				Examples: convertExamples(m.Examples, pkg.Fset),
+			})
+		}
+
+		info.Types = append(info.Types, ti)
 	}
 
 	return info, nil
@@ -66,4 +163,44 @@ func typeKind(t types.Type) string {
 	default:
 		return fmt.Sprintf("%T", t)
 	}
+}
+
+func signatureInfo(sig *types.Signature, qf types.Qualifier) ([]ffiinfo.ParamInfo, []ffiinfo.ParamInfo) {
+	params := make([]ffiinfo.ParamInfo, 0, sig.Params().Len())
+	for i := 0; i < sig.Params().Len(); i++ {
+		v := sig.Params().At(i)
+		params = append(params, ffiinfo.ParamInfo{
+			Name: v.Name(),
+			Type: types.TypeString(v.Type(), qf),
+		})
+	}
+
+	results := make([]ffiinfo.ParamInfo, 0, sig.Results().Len())
+	for i := 0; i < sig.Results().Len(); i++ {
+		v := sig.Results().At(i)
+		results = append(results, ffiinfo.ParamInfo{
+			Name: v.Name(),
+			Type: types.TypeString(v.Type(), qf),
+		})
+	}
+
+	return params, results
+}
+
+func convertExamples(ex []*doc.Example, fset *token.FileSet) []ffiinfo.ExampleInfo {
+	out := make([]ffiinfo.ExampleInfo, 0, len(ex))
+	for _, e := range ex {
+		var buf bytes.Buffer
+		if e.Code != nil {
+			printer.Fprint(&buf, fset, e.Code)
+		}
+		out = append(out, ffiinfo.ExampleInfo{
+			Name:   e.Name,
+			Suffix: e.Suffix,
+			Doc:    strings.TrimSpace(e.Doc),
+			Code:   buf.String(),
+			Output: e.Output,
+		})
+	}
+	return out
 }

--- a/runtime/ffi/go/testpkg/testpkg.go
+++ b/runtime/ffi/go/testpkg/testpkg.go
@@ -2,16 +2,20 @@ package testpkg
 
 import "errors"
 
+// Pi is the mathematical constant pi.
 const Pi = 3.14
 
+// Answer is the answer to life, the universe, and everything.
 var Answer = 42
 
 // Point is a simple struct used for testing.
 type Point struct {
-	X int
-	Y int
+	X int // X coordinate
+	Y int // Y coordinate
 }
 
+// Add sums a and b.
 func Add(a, b int) int { return a + b }
 
+// Fail always returns an error.
 func Fail() error { return errors.New("boom") }

--- a/runtime/ffi/go/testpkg/testpkg_test.go
+++ b/runtime/ffi/go/testpkg/testpkg_test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "fmt"
+
+func ExampleAdd() {
+	fmt.Println(Add(2, 3))
+	// Output: 5
+}

--- a/runtime/ffi/infer/infer.go
+++ b/runtime/ffi/infer/infer.go
@@ -1,8 +1,11 @@
 package ffiinfo
 
-// ModuleInfo describes the exported symbols of a foreign module.
+// ModuleInfo describes a module's exported symbols and documentation.
 type ModuleInfo struct {
-	Path      string
+	Path     string
+	Doc      string
+	Examples []ExampleInfo
+
 	Functions []FuncInfo
 	Vars      []VarInfo
 	Consts    []ConstInfo
@@ -11,14 +14,18 @@ type ModuleInfo struct {
 
 // FuncInfo describes an exported function.
 type FuncInfo struct {
-	Name      string
-	Signature string
+	Name     string
+	Doc      string
+	Params   []ParamInfo
+	Results  []ParamInfo
+	Examples []ExampleInfo
 }
 
 // VarInfo describes an exported variable.
 type VarInfo struct {
 	Name string
 	Type string
+	Doc  string
 }
 
 // ConstInfo describes an exported constant.
@@ -26,10 +33,34 @@ type ConstInfo struct {
 	Name  string
 	Type  string
 	Value string
+	Doc   string
 }
 
 // TypeInfo describes an exported type.
 type TypeInfo struct {
+	Name     string
+	Kind     string
+	Doc      string
+	Fields   []FieldInfo
+	Methods  []FuncInfo
+	Examples []ExampleInfo
+}
+
+type FieldInfo struct {
 	Name string
-	Kind string
+	Type string
+	Tag  string
+}
+
+type ParamInfo struct {
+	Name string
+	Type string
+}
+
+type ExampleInfo struct {
+	Name   string
+	Suffix string
+	Doc    string
+	Code   string
+	Output string
 }


### PR DESCRIPTION
## Summary
- extend FFI info structures to include docs, parameters, results, examples and more
- enhance Go package inference to pull docs, examples and signatures
- document/export details from test package
- update tests for the richer information

## Testing
- `go test ./runtime/ffi/go -run TestInfer -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849b23ed360832098b0376e6851f862