### PR TITLE
Add Deno FFI inference tests

### DIFF
--- a/runtime/ffi/deno/infer_test.go
+++ b/runtime/ffi/deno/infer_test.go
@@ -1,0 +1,95 @@
+package deno_test
+
+import (
+	"os/exec"
+	"testing"
+
+	deno "mochi/runtime/ffi/deno"
+	ffiinfo "mochi/runtime/ffi/infer"
+)
+
+func TestInfer(t *testing.T) {
+	if _, err := exec.LookPath("deno"); err != nil {
+		t.Skip("deno not installed")
+	}
+
+	info, err := deno.Infer("testpkg.ts")
+	if err != nil {
+		t.Fatalf("infer failed: %v", err)
+	}
+
+	var add ffiinfo.FuncInfo
+	foundAdd := false
+	var failFunc ffiinfo.FuncInfo
+	foundFail := false
+	for _, f := range info.Functions {
+		switch f.Name {
+		case "add":
+			add = f
+			foundAdd = true
+		case "fail":
+			failFunc = f
+			foundFail = true
+		}
+	}
+	if !foundAdd {
+		t.Fatalf("expected add function in inference results")
+	}
+	if len(add.Params) != 2 || add.Params[0].Type != "number" || add.Params[1].Type != "number" {
+		t.Fatalf("add params incorrect: %+v", add.Params)
+	}
+	if len(add.Results) != 1 || add.Results[0].Type != "number" {
+		t.Fatalf("add results incorrect: %+v", add.Results)
+	}
+	if add.Doc == "" {
+		t.Fatalf("add doc missing")
+	}
+	if !foundFail {
+		t.Fatalf("expected fail function")
+	}
+	if len(failFunc.Results) != 1 || failFunc.Results[0].Type != "never" {
+		t.Fatalf("fail results incorrect: %+v", failFunc.Results)
+	}
+
+	foundPi := false
+	for _, c := range info.Consts {
+		if c.Name == "PI" {
+			if c.Doc == "" || c.Type == "" {
+				t.Fatalf("unexpected PI details: %+v", c)
+			}
+			foundPi = true
+			break
+		}
+	}
+	if !foundPi {
+		t.Fatalf("expected PI constant")
+	}
+
+	foundAnswer := false
+	for _, v := range info.Vars {
+		if v.Name == "answer" {
+			if v.Type != "number" {
+				t.Fatalf("unexpected answer type: %s", v.Type)
+			}
+			foundAnswer = true
+			break
+		}
+	}
+	if !foundAnswer {
+		t.Fatalf("expected answer variable")
+	}
+
+	foundPoint := false
+	for _, tinfo := range info.Types {
+		if tinfo.Name == "Point" {
+			if tinfo.Kind != "interface" {
+				t.Fatalf("Point kind should be interface, got %s", tinfo.Kind)
+			}
+			foundPoint = true
+			break
+		}
+	}
+	if !foundPoint {
+		t.Fatalf("expected Point type")
+	}
+}

--- a/runtime/ffi/deno/testpkg.ts
+++ b/runtime/ffi/deno/testpkg.ts
@@ -1,0 +1,27 @@
+/** Pi is the mathematical constant pi. */
+export const PI = 3.14;
+
+/** Answer is the answer to life, the universe, and everything. */
+export let answer = 42;
+
+/** Point represents a point in 2D space. */
+export interface Point {
+  /** X coordinate */
+  x: number;
+  /** Y coordinate */
+  y: number;
+}
+
+/**
+ * add returns the sum of a and b.
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+/**
+ * fail always throws an error.
+ */
+export function fail(): never {
+  throw new Error("boom");
+}


### PR DESCRIPTION
## Summary
- add a TypeScript test module under runtime/ffi/deno
- implement runtime/ffi/deno/infer_test.go to verify Infer detects exported
  functions, variables, constants and types

## Testing
- `go test ./...` *(fails: TestTSCompiler_SubsetPrograms due to deno network access)*

------
https://chatgpt.com/codex/tasks/task_e_6849b8d3a15c832080b79d65c42851c5