### PR TITLE
Add llm CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Commands:
   init    Initialize a new module
   get     Download module dependencies
   repl    Start interactive REPL
+  llm     Send prompt to LLM
   serve   Start MCP server
   cheatsheet  Print language reference
 ```
@@ -202,6 +203,7 @@ mochi build examples/hello.mochi -o hello
 mochi build --target py examples/hello.mochi -o hello.py
 mochi init mymodule
 mochi get
+mochi llm "hello"
 mochi cheatsheet
 ```
 

--- a/docs/guides/using-mochi.md
+++ b/docs/guides/using-mochi.md
@@ -63,6 +63,7 @@ Commands:
   init    Initialize a new module
   get     Download module dependencies
   repl    Start interactive REPL
+  llm     Send prompt to LLM
   serve   Start MCP server
   cheatsheet  Print language reference
 ```
@@ -78,6 +79,7 @@ mochi build examples/hello.mochi -o hello
 mochi build --target py examples/hello.mochi -o hello.py
 mochi init mymodule
 mochi get
+mochi llm "hello"
 mochi cheatsheet
 ```
 


### PR DESCRIPTION
## Summary
- implement `mochi llm` subcommand to send prompts to default LLM
- update README and user guide with new command usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849bd46da548320affaf021f171fd56