### PR TITLE
Fix deno ffi infer test

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -43,6 +43,7 @@ func TestTSCompiler_SubsetPrograms(t *testing.T) {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
 		cmd := exec.Command("deno", "run", "--quiet", file)
+		cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return nil, fmt.Errorf("❌ deno run error: %w\n%s", err, out)
@@ -73,6 +74,7 @@ func TestTSCompiler_SubsetPrograms(t *testing.T) {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
 		cmd := exec.Command("deno", "run", "--quiet", file)
+		cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return nil, fmt.Errorf("❌ deno run error: %w\n%s", err, out)

--- a/runtime/ffi/deno/infer.go
+++ b/runtime/ffi/deno/infer.go
@@ -1,8 +1,10 @@
 package deno
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -13,14 +15,23 @@ import (
 // output into a ModuleInfo structure describing exported symbols.
 func Infer(path string) (*ffiinfo.ModuleInfo, error) {
 	cmd := exec.Command("deno", "doc", "--json", path)
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system")
+	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("deno doc failed: %w\n%s", err, out)
+		return nil, fmt.Errorf("deno doc failed: %w\n%s", err, stderr.String())
 	}
 
 	var nodes []map[string]any
 	if err := json.Unmarshal(out, &nodes); err != nil {
-		return nil, fmt.Errorf("decode error: %w", err)
+		var wrapper struct {
+			Nodes []map[string]any `json:"nodes"`
+		}
+		if err2 := json.Unmarshal(out, &wrapper); err2 != nil {
+			return nil, fmt.Errorf("decode error: %w", err)
+		}
+		nodes = wrapper.Nodes
 	}
 
 	info := &ffiinfo.ModuleInfo{
@@ -106,7 +117,64 @@ func tsType(m map[string]any) string {
 	if m == nil {
 		return ""
 	}
-	if r, ok := m["repr"].(string); ok {
+	r, _ := m["repr"].(string)
+	kind, _ := m["kind"].(string)
+	switch kind {
+	case "array":
+		if elem, ok := m["array"].(map[string]any); ok {
+			t := tsType(elem)
+			if t != "" {
+				return t + "[]"
+			}
+		}
+	case "keyword":
+		if kw, ok := m["keyword"].(string); ok {
+			return kw
+		}
+	case "union":
+		if us, ok := m["union"].([]any); ok {
+			parts := []string{}
+			for _, u := range us {
+				if um, ok := u.(map[string]any); ok {
+					if part := tsType(um); part != "" {
+						parts = append(parts, part)
+					}
+				}
+			}
+			if len(parts) > 0 {
+				return strings.Join(parts, " | ")
+			}
+		}
+	case "literal":
+		if lit, ok := m["literal"].(map[string]any); ok {
+			if lk, ok := lit["kind"].(string); ok {
+				switch lk {
+				case "number":
+					return "number"
+				case "string":
+					return "string"
+				case "boolean":
+					return "boolean"
+				case "bigint":
+					return "bigint"
+				case "null":
+					return "null"
+				case "undefined":
+					return "undefined"
+				}
+			}
+		}
+	case "typeRef":
+		if tr, ok := m["typeRef"].(map[string]any); ok {
+			if r, ok := tr["repr"].(string); ok && r != "" {
+				return r
+			}
+			if name, ok := tr["typeName"].(string); ok {
+				return name
+			}
+		}
+	}
+	if r != "" {
 		return r
 	}
 	return ""

--- a/runtime/infer/infer_test.go
+++ b/runtime/infer/infer_test.go
@@ -118,7 +118,7 @@ func TestInferFullFlow(t *testing.T) {
 	src.WriteString("import go \"mochi/runtime/ffi/go/testpkg\" as testpkg\n")
 	src.WriteString(externs(goInfo))
 	if tsInfo != nil {
-		src.WriteString("import typescript \"../ffi/deno/testpkg.ts\" as testpkgts\n")
+		src.WriteString("import typescript \"./runtime/ffi/deno/testpkg.ts\" as testpkgts\n")
 		src.WriteString(externs(tsInfo))
 	}
 	src.WriteString("print(testmod.add(2,3))\n")


### PR DESCRIPTION
## Summary
- handle literal types from `deno doc`
- set `DENO_TLS_CA_STORE` when invoking Deno
- fix TypeScript test path

## Testing
- `go test ./runtime/infer -run TestInferFullFlow -count=1 -v`
- `go test ./compile/ts -run TestTSCompiler_SubsetPrograms -count=1 -v`
- `go test ./runtime/ffi/deno -run TestRealInfer -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849c35d8c5483208cd8034e39c8696f