### PR TITLE
Add json tags to ffi infer structs

### DIFF
--- a/runtime/ffi/infer/infer.go
+++ b/runtime/ffi/infer/infer.go
@@ -2,65 +2,65 @@ package ffiinfo
 
 // ModuleInfo describes a module's exported symbols and documentation.
 type ModuleInfo struct {
-	Path     string
-	Doc      string
-	Examples []ExampleInfo
+	Path     string        `json:"Path,omitempty"`
+	Doc      string        `json:"Doc,omitempty"`
+	Examples []ExampleInfo `json:"Examples,omitempty"`
 
-	Functions []FuncInfo
-	Vars      []VarInfo
-	Consts    []ConstInfo
-	Types     []TypeInfo
+	Functions []FuncInfo  `json:"Functions,omitempty"`
+	Vars      []VarInfo   `json:"Vars,omitempty"`
+	Consts    []ConstInfo `json:"Consts,omitempty"`
+	Types     []TypeInfo  `json:"Types,omitempty"`
 }
 
 // FuncInfo describes an exported function.
 type FuncInfo struct {
-	Name     string
-	Doc      string
-	Params   []ParamInfo
-	Results  []ParamInfo
-	Examples []ExampleInfo
+	Name     string        `json:"Name,omitempty"`
+	Doc      string        `json:"Doc,omitempty"`
+	Params   []ParamInfo   `json:"Params,omitempty"`
+	Results  []ParamInfo   `json:"Results,omitempty"`
+	Examples []ExampleInfo `json:"Examples,omitempty"`
 }
 
 // VarInfo describes an exported variable.
 type VarInfo struct {
-	Name string
-	Type string
-	Doc  string
+	Name string `json:"Name,omitempty"`
+	Type string `json:"Type,omitempty"`
+	Doc  string `json:"Doc,omitempty"`
 }
 
 // ConstInfo describes an exported constant.
 type ConstInfo struct {
-	Name  string
-	Type  string
-	Value string
-	Doc   string
+	Name  string `json:"Name,omitempty"`
+	Type  string `json:"Type,omitempty"`
+	Value string `json:"Value,omitempty"`
+	Doc   string `json:"Doc,omitempty"`
 }
 
 // TypeInfo describes an exported type.
 type TypeInfo struct {
-	Name     string
-	Kind     string
-	Doc      string
-	Fields   []FieldInfo
-	Methods  []FuncInfo
-	Examples []ExampleInfo
+	Name     string        `json:"Name,omitempty"`
+	Kind     string        `json:"Kind,omitempty"`
+	Doc      string        `json:"Doc,omitempty"`
+	Fields   []FieldInfo   `json:"Fields,omitempty"`
+	Methods  []FuncInfo    `json:"Methods,omitempty"`
+	Examples []ExampleInfo `json:"Examples,omitempty"`
 }
 
 type FieldInfo struct {
-	Name string
-	Type string
-	Tag  string
+	Name string `json:"Name,omitempty"`
+	Type string `json:"Type,omitempty"`
+	Tag  string `json:"Tag,omitempty"`
 }
 
 type ParamInfo struct {
-	Name string
-	Type string
+	Name string `json:"Name,omitempty"`
+	Type string `json:"Type,omitempty"`
 }
 
 type ExampleInfo struct {
-	Name   string
-	Suffix string
-	Doc    string
-	Code   string
-	Output string
+	Name   string `json:"Name,omitempty"`
+	Suffix string `json:"Suffix,omitempty"`
+	Doc    string `json:"Doc,omitempty"`
+	Code   string `json:"Code,omitempty"`
+	Output string `json:"Output,omitempty"`
 }


### PR DESCRIPTION
## Summary
- add `json` tags with `omitempty` to structs in runtime/ffi/infer

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849cbb5c9148320ac7a6c7c9640c37e