### PR TITLE
add runtime/python binary helper

### DIFF
--- a/bench/deps.go
+++ b/bench/deps.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	python "mochi/runtime/python"
 )
 
 // EnsureDeps verifies that Mochi, Deno and Python3 are installed.
@@ -47,7 +49,7 @@ func ensureMochi() (string, error) {
 }
 
 func ensurePython() error {
-	if _, err := exec.LookPath("python3"); err == nil {
+	if _, err := exec.LookPath(python.Binary()); err == nil {
 		return nil
 	}
 	fmt.Println("🐍 Installing Python3...")

--- a/bench/runner.go
+++ b/bench/runner.go
@@ -19,6 +19,7 @@ import (
 	pycode "mochi/compile/py"
 	tscode "mochi/compile/ts"
 	"mochi/parser"
+	python "mochi/runtime/python"
 	"mochi/types"
 )
 
@@ -82,7 +83,7 @@ func Benchmarks(tempDir, mochiBin string) []Bench {
 		templates := []Template{
 			{Lang: "mochi_interp", Path: path, Suffix: suffix, Command: []string{mochiBin, "run", "--aot"}},
 			{Lang: "mochi_go", Path: path, Suffix: suffix, Command: []string{"go", "run"}},
-			{Lang: "mochi_py", Path: path, Suffix: suffix, Command: []string{"python3"}},
+			{Lang: "mochi_py", Path: path, Suffix: suffix, Command: []string{python.Binary()}},
 			{Lang: "mochi_ts", Path: path, Suffix: suffix, Command: []string{"deno", "run", "--quiet"}},
 		}
 

--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -11,12 +11,13 @@ import (
 	pycode "mochi/compile/py"
 	"mochi/golden"
 	"mochi/parser"
+	pyruntime "mochi/runtime/python"
 	"mochi/types"
 )
 
 func TestPyCompiler_SubsetPrograms(t *testing.T) {
-	if _, err := exec.LookPath("python3"); err != nil {
-		t.Skip("python3 not installed")
+	if _, err := exec.LookPath(pyruntime.Binary()); err != nil {
+		t.Skip("python not installed")
 	}
 	golden.Run(t, "tests/compiler/valid", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
@@ -37,7 +38,7 @@ func TestPyCompiler_SubsetPrograms(t *testing.T) {
 		if err := os.WriteFile(file, code, 0644); err != nil {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
-		cmd := exec.Command("python3", file)
+		cmd := pyruntime.Cmd(file)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return nil, fmt.Errorf("❌ python run error: %w\n%s", err, out)
@@ -64,7 +65,7 @@ func TestPyCompiler_SubsetPrograms(t *testing.T) {
 		if err := os.WriteFile(file, code, 0644); err != nil {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
-		cmd := exec.Command("python3", file)
+		cmd := pyruntime.Cmd(file)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return nil, fmt.Errorf("❌ python run error: %w\n%s", err, out)

--- a/runtime/ffi/python/infer.go
+++ b/runtime/ffi/python/infer.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	ffiinfo "mochi/runtime/ffi/infer"
+	pyruntime "mochi/runtime/python"
 )
 
 // Infer loads the given Python module and returns information about its exported symbols.
@@ -102,7 +102,7 @@ json.dump(info, sys.stdout)`
 	}
 	file.Close()
 
-	cmd := exec.Command("python3", file.Name(), module)
+	cmd := pyruntime.Cmd(file.Name(), module)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("python error: %w\n%s", err, out)

--- a/runtime/ffi/python/python.go
+++ b/runtime/ffi/python/python.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+
+	pyruntime "mochi/runtime/python"
 )
 
 // Attr returns a module attribute. If the attribute is a callable it is
@@ -45,7 +46,7 @@ json.dump(res, sys.stdout)
 		return nil, err
 	}
 
-	cmd := exec.Command("python3", file.Name())
+	cmd := pyruntime.Cmd(file.Name())
 	cmd.Env = append(os.Environ(), "MOCHI_ARGS="+string(data))
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/runtime/ffi/python/real_infer_test.go
+++ b/runtime/ffi/python/real_infer_test.go
@@ -6,11 +6,12 @@ import (
 
 	ffiinfo "mochi/runtime/ffi/infer"
 	"mochi/runtime/ffi/python"
+	pyruntime "mochi/runtime/python"
 )
 
 func TestRealInfer(t *testing.T) {
-	if _, err := exec.LookPath("python3"); err != nil {
-		t.Skip("python3 not installed")
+	if _, err := exec.LookPath(pyruntime.Binary()); err != nil {
+		t.Skip("python not installed")
 	}
 
 	info, err := python.Infer("textwrap")

--- a/runtime/python/python.go
+++ b/runtime/python/python.go
@@ -1,0 +1,39 @@
+package python
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+)
+
+var (
+	bin  string
+	once sync.Once
+)
+
+// Binary returns the path to the Python interpreter used by Mochi.
+// It checks the MOCHI_PYTHON environment variable, then searches for
+// "python3" and "python" in PATH. The result is cached for future calls.
+func Binary() string {
+	once.Do(func() {
+		if env := os.Getenv("MOCHI_PYTHON"); env != "" {
+			bin = env
+			return
+		}
+		if path, err := exec.LookPath("python3"); err == nil {
+			bin = path
+			return
+		}
+		if path, err := exec.LookPath("python"); err == nil {
+			bin = path
+			return
+		}
+		bin = "python3"
+	})
+	return bin
+}
+
+// Cmd returns an exec.Cmd for the configured Python interpreter.
+func Cmd(args ...string) *exec.Cmd {
+	return exec.Command(Binary(), args...)
+}

--- a/tools/libmochi/python/libmochi_test.go
+++ b/tools/libmochi/python/libmochi_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	python "mochi/runtime/python"
 )
 
 func TestLibMochi(t *testing.T) {
@@ -19,7 +21,7 @@ func TestLibMochi(t *testing.T) {
 		t.Fatalf("go build failed: %v\n%s", err, out)
 	}
 
-	pipCmd := exec.Command("python3", "-m", "pip", "install", "-e", "tools/libmochi/python")
+	pipCmd := python.Cmd("-m", "pip", "install", "-e", "tools/libmochi/python")
 	pipCmd.Dir = filepath.Join("..", "..", "..")
 	if out, err := pipCmd.CombinedOutput(); err != nil {
 		t.Fatalf("pip install failed: %v\n%s", err, out)
@@ -31,7 +33,7 @@ func TestLibMochi(t *testing.T) {
 print(run('print("hi")').strip())
 print(call('fun add(a:int, b:int): int { return a + b }', 'add', 2, 3))
 print(eval('print("ffi")').strip())`
-	runCmd := exec.Command("python3", "-")
+	runCmd := python.Cmd("-")
 	runCmd.Dir = filepath.Join("..", "..", "..")
 	runCmd.Env = append(os.Environ(), "PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	runCmd.Stdin = strings.NewReader(script)

--- a/tools/notebook/notebook_test.go
+++ b/tools/notebook/notebook_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	python "mochi/runtime/python"
 )
 
 func TestNotebookMagic(t *testing.T) {
@@ -21,7 +23,7 @@ func TestNotebookMagic(t *testing.T) {
 	}
 
 	// ensure ipython is installed
-	pipCmd := exec.Command("python3", "-m", "pip", "install", "ipython")
+	pipCmd := python.Cmd("-m", "pip", "install", "ipython")
 	if out, err := pipCmd.CombinedOutput(); err != nil {
 		t.Fatalf("pip install failed: %v\n%s", err, out)
 	} else {
@@ -39,7 +41,7 @@ mochi_magic.load_ipython_extension(sh)
 with capture_output() as cap:
     sh.run_cell("%%mochi\nprint(\"hello\")")
 print(cap.stdout.strip())`
-	runCmd := exec.Command("python3", "-")
+	runCmd := python.Cmd("-")
 	runCmd.Dir = filepath.Join("..", "..")
 	runCmd.Env = append(os.Environ(), "PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	runCmd.Stdin = strings.NewReader(script)


### PR DESCRIPTION
## Summary
- add helper package `runtime/python` to locate the Python interpreter
- use the helper in FFI runtime, benchmarks and tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849db4f70e48320ab45a638ad8eeb88