### PR TITLE
Refactor Go binary usage

### DIFF
--- a/bench/deps.go
+++ b/bench/deps.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	goexec "mochi/runtime/go"
 )
 
 // EnsureDeps verifies that Mochi, Deno and Python3 are installed.
@@ -37,7 +39,7 @@ func ensureMochi() (string, error) {
 	if err := os.MkdirAll(filepath.Dir(out), 0755); err != nil {
 		return "", err
 	}
-	cmd := exec.Command("go", "build", "-o", out, "./cmd/mochi")
+	cmd := goexec.Command("build", "-o", out, "./cmd/mochi")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -27,6 +26,7 @@ import (
 	goffi "mochi/runtime/ffi/go"
 	ffiinfo "mochi/runtime/ffi/infer"
 	python "mochi/runtime/ffi/python"
+	goexec "mochi/runtime/go"
 
 	"mochi/ast"
 	"mochi/compile/go"
@@ -460,7 +460,7 @@ func build(cmd *BuildCmd) error {
 			if out == "" {
 				out = base
 			}
-			cmd := exec.Command("go", "build", "-o", out, goFile)
+			cmd := goexec.Command("build", "-o", out, goFile)
 			cmd.Env = append(os.Environ(), "GO111MODULE=off")
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
@@ -504,20 +504,20 @@ func initModule(cmd *InitCmd) error {
 	if _, err := os.Stat("go.mod"); err == nil {
 		return fmt.Errorf("go.mod already exists")
 	}
-	c := exec.Command("go", "mod", "init", modPath)
+	c := goexec.Command("mod", "init", modPath)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	return c.Run()
 }
 
 func modGet(cmd *GetCmd) error {
-	c := exec.Command("go", "mod", "tidy")
+	c := goexec.Command("mod", "tidy")
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	if err := c.Run(); err != nil {
 		return err
 	}
-	c = exec.Command("go", "mod", "download")
+	c = goexec.Command("mod", "download")
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	return c.Run()

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	gocode "mochi/compile/go"
 	"mochi/golden"
 	"mochi/parser"
+	goexec "mochi/runtime/go"
 	"mochi/types"
 )
 
@@ -34,7 +34,7 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		if err := os.WriteFile(file, code, 0644); err != nil {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
-		cmd := exec.Command("go", "run", file)
+		cmd := goexec.Command("run", file)
 		cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -62,7 +62,7 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		if err := os.WriteFile(file, code, 0644); err != nil {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
-		cmd := exec.Command("go", "run", file)
+		cmd := goexec.Command("run", file)
 		cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
 		out, err := cmd.CombinedOutput()
 		if err != nil {

--- a/compile/wasm/compiler.go
+++ b/compile/wasm/compiler.go
@@ -8,6 +8,7 @@ import (
 
 	gocode "mochi/compile/go"
 	"mochi/parser"
+	goexec "mochi/runtime/go"
 	"mochi/types"
 )
 
@@ -73,7 +74,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	case ToolchainTinyGo:
 		cmd = exec.Command("tinygo", "build", "-o", outPath, "-target", "wasm", srcPath)
 	default:
-		cmd = exec.Command("go", "build", "-o", outPath, srcPath)
+		cmd = goexec.Command("build", "-o", outPath, srcPath)
 		cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
 	}
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/runtime/ffi/go/auto.go
+++ b/runtime/ffi/go/auto.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
+
+	goexec "mochi/runtime/go"
 )
 
 // AttrAuto retrieves or calls a symbol from a package using `go run` with reflection.
@@ -76,7 +77,7 @@ func main() {
 		return nil, err
 	}
 
-	cmd := exec.Command("go", "run", file.Name())
+	cmd := goexec.Command("run", file.Name())
 	cmd.Env = append(os.Environ(), "MOCHI_ARGS="+string(data))
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/runtime/go/go.go
+++ b/runtime/go/go.go
@@ -1,0 +1,11 @@
+package goexec
+
+import "os/exec"
+
+// Bin specifies the Go binary to use. It defaults to "go".
+var Bin = "go"
+
+// Command returns an exec.Cmd that runs the Go tool with the given arguments.
+func Command(args ...string) *exec.Cmd {
+	return exec.Command(Bin, args...)
+}

--- a/tools/libmochi/go/libmochi_test.go
+++ b/tools/libmochi/go/libmochi_test.go
@@ -2,11 +2,11 @@ package libmochi_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	goexec "mochi/runtime/go"
 	"mochi/tools/libmochi/go"
 )
 
@@ -14,7 +14,7 @@ func TestLibMochi(t *testing.T) {
 	tmpDir := t.TempDir()
 	mochiPath := filepath.Join(tmpDir, "mochi")
 
-	buildCmd := exec.Command("go", "build", "-o", mochiPath, "./cmd/mochi")
+	buildCmd := goexec.Command("build", "-o", mochiPath, "./cmd/mochi")
 	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	buildCmd.Dir = filepath.Join("..", "..", "..")
 	if out, err := buildCmd.CombinedOutput(); err != nil {

--- a/tools/libmochi/python/libmochi_test.go
+++ b/tools/libmochi/python/libmochi_test.go
@@ -6,13 +6,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	goexec "mochi/runtime/go"
 )
 
 func TestLibMochi(t *testing.T) {
 	tmpDir := t.TempDir()
 	mochiPath := filepath.Join(tmpDir, "mochi")
 
-	buildCmd := exec.Command("go", "build", "-o", mochiPath, "./cmd/mochi")
+	buildCmd := goexec.Command("build", "-o", mochiPath, "./cmd/mochi")
 	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	buildCmd.Dir = filepath.Join("..", "..", "..")
 	if out, err := buildCmd.CombinedOutput(); err != nil {

--- a/tools/notebook/notebook_test.go
+++ b/tools/notebook/notebook_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	goexec "mochi/runtime/go"
 )
 
 func TestNotebookMagic(t *testing.T) {
@@ -13,7 +15,7 @@ func TestNotebookMagic(t *testing.T) {
 	mochiPath := filepath.Join(tmpDir, "mochi")
 
 	// build the mochi CLI
-	buildCmd := exec.Command("go", "build", "-o", mochiPath, "./cmd/mochi")
+	buildCmd := goexec.Command("build", "-o", mochiPath, "./cmd/mochi")
 	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	buildCmd.Dir = filepath.Join("..", "..")
 	if out, err := buildCmd.CombinedOutput(); err != nil {

--- a/tools/wasm/wasm_test.go
+++ b/tools/wasm/wasm_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	goexec "mochi/runtime/go"
 )
 
 func TestWasmInterpreter(t *testing.T) {
@@ -15,7 +17,7 @@ func TestWasmInterpreter(t *testing.T) {
 
 	// build wasm
 	wasmPath := filepath.Join(tmp, "mochi.wasm")
-	cmd := exec.Command("go", "build", "-o", wasmPath, ".")
+	cmd := goexec.Command("build", "-o", wasmPath, ".")
 	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("go build failed: %v\n%s", err, out)


### PR DESCRIPTION
## Summary
- add `runtime/go` package to centralize Go binary invocation
- use `goexec.Command` everywhere instead of `exec.Command("go")`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849dbbaaa8c8320bbfc802483038b2c