### PR TITLE
Fix docs example and update modules

### DIFF
--- a/examples/v0.7/docs.mochi
+++ b/examples/v0.7/docs.mochi
@@ -27,21 +27,21 @@ fun clamp(value: float, min: float, max: float): float {
 
 // average computes the mean of a list of floats.
 // If the list is empty, returns 0.
-fun average(nums: list<float>): float {
-  if nums.len == 0 {
-    return 0.0
+  fun average(nums: list<float>): float {
+    if len(nums) == 0 {
+      return 0.0
+    }
+    var sum = 0.0
+    for x in nums {
+      sum = sum + x
+    }
+    return sum / (len(nums) as float)
   }
-  let sum = 0.0
-  for x in nums {
-    sum = sum + x
-  }
-  return sum / nums.len
-}
 
 // Person represents a simple record with a name and age.
 type Person {
   // The person's name.
-  name: string,
+  name: string
 
   // The person's age in years.
   age: int

--- a/examples/v0.7/hello-mochi/main.mochi
+++ b/examples/v0.7/hello-mochi/main.mochi
@@ -1,8 +1,8 @@
 // Main program entrypoint
 // Uses local modules under math/
 
-import "math/constants"
-import "math/sqrt"
+import "./math/constants" as constants
+import "./math/sqrt" as sqrt
 
-print("Pi =", constants.pi)
+print("Pi =", constants.pi())
 print("sqrt(49) =", sqrt.sqrt(49))

--- a/examples/v0.7/hello-mochi/math/constants.mochi
+++ b/examples/v0.7/hello-mochi/math/constants.mochi
@@ -1,7 +1,13 @@
 // math/constants.mochi
 // Math constants exported for reuse
 
-let pi = 3.14159
-let e = 2.71828
+fun pi(): float {
+  return 3.14159
+}
 
-export { pi, e }
+fun e(): float {
+  return 2.71828
+}
+
+export fun pi
+export fun e

--- a/examples/v0.7/hello-mochi/math/sqrt.mochi
+++ b/examples/v0.7/hello-mochi/math/sqrt.mochi
@@ -12,4 +12,4 @@ fun sqrt(x: float): float {
   return result
 }
 
-export { sqrt }
+export fun sqrt


### PR DESCRIPTION
## Summary
- fix averaging example in docs
- export constants via functions
- use explicit relative imports in hello-mochi example

## Testing
- `mochi run examples/v0.7/docs.mochi`
- `mochi run main.mochi` *(fails: import package: open math/constants: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684aafacb66c83208cc88937248c141b