### PR TITLE
Fix stream example for async events

### DIFF
--- a/examples/v0.4/stream.mochi
+++ b/examples/v0.4/stream.mochi
@@ -17,13 +17,17 @@ emit Sensor {
   id: "sensor-1",
   temperature: 22.5
 }
+// allow async handler to run
+sleep(50)
 
 emit Sensor {
   id: "sensor-2",
   temperature: 30.2
 }
+sleep(50)
 
 emit Sensor {
   id: "sensor-3",
   temperature: 18.9
 }
+sleep(50)


### PR DESCRIPTION
## Summary
- allow async event handlers to run in `stream.mochi`

## Testing
- `mochi run examples/v0.4/stream.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684ab24d6b2c832080a39b27ab81de26