### PR TITLE
Add stream Wait support

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1647,6 +1647,13 @@ func (i *Interpreter) Close() {
 	for _, cancel := range i.cancels {
 		cancel()
 	}
+	// Wait for all stream handlers to finish processing events before
+	// shutting everything down.
+	for _, s := range i.streams {
+		if w, ok := s.(interface{ Wait() }); ok {
+			w.Wait()
+		}
+	}
 	i.wg.Wait()
 	for _, s := range i.streams {
 		s.Close()

--- a/runtime/agent/agent.go
+++ b/runtime/agent/agent.go
@@ -60,6 +60,9 @@ func (a *Agent) Start(ctx context.Context) {
 				if h, ok := a.handlers[e.Stream]; ok {
 					h(ctx, e)
 				}
+				if e != nil {
+					e.Ack()
+				}
 			}
 		}
 	}()

--- a/runtime/agent/agent_test.go
+++ b/runtime/agent/agent_test.go
@@ -61,7 +61,7 @@ func TestAgent_BasicFlow(t *testing.T) {
 		t.Fatalf("Emit failed: %v", err)
 	}
 
-	time.Sleep(30 * time.Millisecond) // wait for async delivery
+	s.Wait()
 
 	// Call the intent
 	result, err := a.Call(ctx, "status")


### PR DESCRIPTION
## Summary
- add Wait() to Stream to block until subscribers finish
- track events with WaitGroup and ack when agent handlers finish
- wait for streams to drain in Interpreter.Close
- update agent event loop to ack processed events
- remove sleep from agent test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ab3c49d648320bfd99889e74c5dac