### PR TITLE
Remove obsolete sleep builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,6 @@ agent Monitor {
 
 let m = Monitor {}
 emit Sensor { id: "sensor-2", temperature: 30.0 }
-sleep(50)
 print(m.status())
 ```
 

--- a/docs/features/streams.md
+++ b/docs/features/streams.md
@@ -33,8 +33,6 @@ agent Monitor {
 
 let m = Monitor {}
 emit Sensor { id: "sensor-2", temperature: 30.0 }
-sleep(50)
 print(m.status())
 ```
 
-Events are delivered asynchronously, so `sleep` is used here to allow the handler time to run before calling `status`. For more details about concurrency semantics see the [language specification](../SPEC.md).

--- a/examples/v0.5/agent-stream.mochi
+++ b/examples/v0.5/agent-stream.mochi
@@ -39,9 +39,5 @@ let monitor = TemperatureMonitor {}
 
 // Emit temperature events into the stream
 emit SensorInput { temp: 36.0 }
-// allow async handler to run
-sleep(50)
 emit SensorInput { temp: 38.2 }
-sleep(50)
 emit SensorInput { temp: 39.5 }
-sleep(50)

--- a/examples/v0.5/agent.mochi
+++ b/examples/v0.5/agent.mochi
@@ -37,8 +37,6 @@ emit SensorReading {
   timestamp: now(),
 }
 
-// Give the agent time to process the first event
-sleep(50)
 
 emit SensorReading {
   id: "sensor-2",
@@ -46,8 +44,6 @@ emit SensorReading {
   timestamp: now(),
 }
 
-// Wait for async processing
-sleep(100)
 
 // Call intents (method style)
 let s = monitor.status()

--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -79,25 +79,6 @@ func builtinStr(i *Interpreter, c *parser.CallExpr) (any, error) {
 	return fmt.Sprint(val), nil
 }
 
-func builtinSleep(i *Interpreter, c *parser.CallExpr) (any, error) {
-	if len(c.Args) != 1 {
-		return nil, fmt.Errorf("sleep(x) takes exactly one argument")
-	}
-	val, err := i.evalExpr(c.Args[0])
-	if err != nil {
-		return nil, err
-	}
-	switch v := val.(type) {
-	case int:
-		time.Sleep(time.Duration(v) * time.Millisecond)
-	case int64:
-		time.Sleep(time.Duration(v) * time.Millisecond)
-	case float64:
-		time.Sleep(time.Duration(v * float64(time.Millisecond)))
-	}
-	return nil, nil
-}
-
 func builtinCount(i *Interpreter, c *parser.CallExpr) (any, error) {
 	if len(c.Args) != 1 {
 		return nil, fmt.Errorf("count(x) takes exactly one argument")
@@ -159,7 +140,6 @@ func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallE
 		"now":   builtinNow,
 		"json":  builtinJSON,
 		"str":   builtinStr,
-		"sleep": builtinSleep,
 		"count": builtinCount,
 		"avg":   builtinAvg,
 	}

--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -314,5 +314,4 @@ agent Monitor {
 
 let m = Monitor {}
 emit Sensor { id: "s2", temperature: 30.0 }
-sleep(50)
 print(m.status())

--- a/tests/interpreter/valid/agent_full.mochi
+++ b/tests/interpreter/valid/agent_full.mochi
@@ -35,7 +35,6 @@ emit SensorReading {
   timestamp: now(),
 }
 
-sleep(50)
 
 emit SensorReading {
   id: "sensor-2",
@@ -43,7 +42,6 @@ emit SensorReading {
   timestamp: now(),
 }
 
-sleep(300)
 
 let s = monitor.status()
 print(s)
@@ -51,4 +49,3 @@ print(s)
 let summary = monitor.summary()
 print(summary)
 
-sleep(100)

--- a/tests/parser/valid/agent_full.golden
+++ b/tests/parser/valid/agent_full.golden
@@ -54,9 +54,7 @@
   )
   (let monitor (struct Monitor))
   (unknown)
-  (call sleep (int 50))
   (unknown)
-  (call sleep (int 300))
   (let s
     (call
       (selector status (selector monitor))
@@ -69,5 +67,4 @@
     )
   )
   (call print (selector summary))
-  (call sleep (int 100))
 )

--- a/tests/parser/valid/agent_full.mochi
+++ b/tests/parser/valid/agent_full.mochi
@@ -35,7 +35,6 @@ emit SensorReading {
   timestamp: now(),
 }
 
-sleep(50)
 
 emit SensorReading {
   id: "sensor-2",
@@ -43,7 +42,6 @@ emit SensorReading {
   timestamp: now(),
 }
 
-sleep(300)
 
 let s = monitor.status()
 print(s)
@@ -51,4 +49,3 @@ print(s)
 let summary = monitor.summary()
 print(summary)
 
-sleep(100)

--- a/types/check.go
+++ b/types/check.go
@@ -362,10 +362,6 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: StringType{},
 		Pure:   true,
 	}, false)
-	env.SetVar("sleep", FuncType{
-		Params: []Type{IntType{}},
-		Return: VoidType{},
-	}, false)
 	env.SetVar("count", FuncType{
 		Params: []Type{AnyType{}},
 		Return: IntType{},


### PR DESCRIPTION
## Summary
- drop `sleep` builtin from interpreter and type checker
- update examples, docs, and tests to remove calls to `sleep`

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_684ab856c8588320904e1e7f4846b1e2