### PR TITLE
Fix agent test and local import

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -575,6 +575,11 @@ func (i *Interpreter) evalStmt(s *parser.Statement) error {
 		if _, err := strm.Emit(context.Background(), ev); err != nil {
 			return err
 		}
+		// Wait until all subscribers have processed the event to ensure
+		// deterministic ordering for tests.
+		if w, ok := strm.(interface{ Wait() }); ok {
+			w.Wait()
+		}
 		return nil
 
 	case s.Model != nil:

--- a/tests/interpreter/valid/localpkg/constants.mochi
+++ b/tests/interpreter/valid/localpkg/constants.mochi
@@ -1,5 +1,3 @@
-fun pi(): float {
+export fun pi(): float {
   return 3.14
 }
-
-export fun pi


### PR DESCRIPTION
## Summary
- block until stream events are processed for deterministic agent behaviour
- fix syntax in local import test file

## Testing
- `go test ./interpreter -run TestInterpreter_ValidPrograms/agent_full -v`
- `go test ./interpreter -run TestInterpreter_ValidPrograms/local_import -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ad37904b48320b05e450dcb659e01