### PR TITLE
Add global transaction support across streams

### DIFF
--- a/runtime/stream/README.md
+++ b/runtime/stream/README.md
@@ -106,14 +106,15 @@ Each event appended to the stream is represented by the `Event` struct:
 
 ```go
 type Event struct {
-	Stream string
-	Tx     int64
-	Time   time.Time
-	Data   any
+       Stream string
+       Tx     int64
+       Gtx    int64  // Global transaction ID if a shared counter is used
+       Time   time.Time
+       Data   any
 }
 ```
 
-Every event is assigned a unique `Tx` (transaction ID) and a timestamp upon append. The `Stream` field identifies which logical stream the event belongs to, and `Data` holds arbitrary user content.
+Every event is assigned both a per-stream `Tx` and an optional global `Gtx` that is monotonically increasing across all streams when a shared counter is provided. The `Stream` field identifies which logical stream the event belongs to, and `Data` holds arbitrary user content.
 
 ### Stream Initialization
 


### PR DESCRIPTION
## Summary
- add global transaction counter to interpreter
- expose global transaction ID on runtime stream events
- allow streams to share a counter via `NewWithCounter`
- document `GlobalTx` field in runtime/stream README
- rename `GlobalTx` field to `Gtx`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ad7239c148320b2ed9a9d5d38e54d