### PR TITLE
Switch agent inbox to stream.Stream

### DIFF
--- a/runtime/agent/README.md
+++ b/runtime/agent/README.md
@@ -11,7 +11,7 @@ This package is designed to integrate cleanly with the `mochi` interpreter, stre
 
 ## Features
 
-* In-memory inbox for stream delivery
+* Stream-backed inbox for event delivery
 * Dynamic stream handler registration
 * Named intent registration and execution
 * Mutable state with `Set` and `Get`


### PR DESCRIPTION
## Summary
- change Agent.Inbox from a channel to a `stream.Stream`
- route incoming events through the stream-based mailbox
- close and wait on the inbox when stopping
- note updated inbox implementation in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ae13298648320beb80b301d917f38