### PR TITLE
Stream wait group shared across interpreter

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -335,7 +335,7 @@ func (c *Compiler) compileStreamDecl(s *parser.StreamDecl) error {
 	c.compileStructType(st)
 	varName := unexportName(sanitizeName(s.Name)) + "Stream"
 	c.imports["mochi/runtime/stream"] = true
-	c.writeln(fmt.Sprintf("var %s = stream.New(%q, 64)", varName, s.Name))
+	c.writeln(fmt.Sprintf("var %s = stream.New(%q, 64, nil)", varName, s.Name))
 	c.streams = append(c.streams, varName)
 	return nil
 }
@@ -445,7 +445,7 @@ func (c *Compiler) compileAgentDecl(a *parser.AgentDecl) error {
 	// constructor
 	c.writeln(fmt.Sprintf("func New%s() *%s {", name, name))
 	c.indent++
-	c.writeln(fmt.Sprintf("inst := &%s{Agent: agent.New(agent.Config{Name: %q, BufSize: 16})}", name, a.Name))
+	c.writeln(fmt.Sprintf("inst := &%s{Agent: agent.New(agent.Config{Name: %q, BufSize: 16, WG: nil})}", name, a.Name))
 
 	origEnv := c.env
 	c.env = baseEnv

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -326,7 +326,7 @@ func (i *Interpreter) importPackage(alias, path, filename string) error {
 func (i *Interpreter) newAgentInstance(decl *parser.AgentDecl) (*agentInstance, error) {
 	inst := &agentInstance{
 		decl:  decl,
-		agent: agent.New(agent.Config{Name: decl.Name, BufSize: 16}),
+		agent: agent.New(agent.Config{Name: decl.Name, BufSize: 16, WG: i.wg}),
 		env:   types.NewEnv(i.env),
 	}
 
@@ -520,7 +520,7 @@ func (i *Interpreter) evalStmt(s *parser.Statement) error {
 		return nil
 
 	case s.Stream != nil:
-		i.streams[s.Stream.Name] = stream.NewWithCounter(s.Stream.Name, 64, i.tx)
+		i.streams[s.Stream.Name] = stream.NewWithCounter(s.Stream.Name, 64, i.tx, i.wg)
 		return nil
 
 	case s.On != nil:

--- a/runtime/agent/README.md
+++ b/runtime/agent/README.md
@@ -22,15 +22,17 @@ This package is designed to integrate cleanly with the `mochi` interpreter, stre
 ### 1. Create a Stream
 
 ```go
-s := stream.New("SensorReading", 64)
+wg := &sync.WaitGroup{}
+s := stream.New("SensorReading", 64, wg)
 ```
 
 ### 2. Initialize an Agent
 
 ```go
 a := agent.New(agent.Config{
-	Name:    "Monitor",
-	BufSize: 16,
+        Name:    "Monitor",
+        BufSize: 16,
+        WG:      wg,
 })
 ```
 

--- a/runtime/agent/agent.go
+++ b/runtime/agent/agent.go
@@ -32,6 +32,7 @@ type Agent struct {
 type Config struct {
 	Name    string
 	BufSize int
+	WG      *sync.WaitGroup
 }
 
 // New creates a new Agent with empty state and stream inbox.
@@ -42,7 +43,7 @@ func New(cfg Config) *Agent {
 	}
 	return &Agent{
 		Name:     cfg.Name,
-		Inbox:    stream.New(inboxName+"-inbox", cfg.BufSize),
+		Inbox:    stream.New(inboxName+"-inbox", cfg.BufSize, cfg.WG),
 		state:    make(map[string]Value),
 		handlers: make(map[string]func(context.Context, *stream.Event)),
 		intents:  make(map[string]IntentHandler),

--- a/runtime/agent/agent_test.go
+++ b/runtime/agent/agent_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,13 +14,16 @@ import (
 func TestAgent_BasicFlow(t *testing.T) {
 	ctx := context.Background()
 
+	// Create a shared wait group for deterministic ordering
+	wg := &sync.WaitGroup{}
 	// Create a test stream
-	s := stream.New("SensorReading", 64)
+	s := stream.New("SensorReading", 64, wg)
 
 	// Initialize agent
 	a := agent.New(agent.Config{
 		Name:    "monitor",
 		BufSize: 16,
+		WG:      wg,
 	})
 
 	// Register stream handler

--- a/runtime/stream/README.md
+++ b/runtime/stream/README.md
@@ -23,8 +23,9 @@ import (
 )
 
 func main() {
-	// Create a new stream named "metrics" with a capacity of 128 events.
-	s := stream.New("metrics", 128)
+        // Create a new stream named "metrics" with a capacity of 128 events.
+        wg := &sync.WaitGroup{}
+        s := stream.New("metrics", 128, wg)
 
 	// Append some events to the stream.
 	for i := 0; i < 3; i++ {
@@ -121,7 +122,8 @@ Every event is assigned both a per-stream `Tx` and an optional global `Gtx` that
 A new stream is created with a name and a fixed buffer capacity:
 
 ```go
-stream := stream.New("my-stream", 16)
+wg := &sync.WaitGroup{}
+stream := stream.New("my-stream", 16, wg)
 ```
 
 Internally, the stream maintains a circular buffer (ring) to store events. The core fields are:

--- a/runtime/stream/stream_test.go
+++ b/runtime/stream/stream_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestStream_AppendAndRead(t *testing.T) {
-	s := New("test", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("test", 4, wg).(*stream)
 
 	_, err := s.Emit(context.Background(), "a")
 	require.NoError(t, err)
@@ -27,7 +28,8 @@ func TestStream_AppendAndRead(t *testing.T) {
 }
 
 func TestStream_Get(t *testing.T) {
-	s := New("test", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("test", 4, wg).(*stream)
 
 	ev1, err := s.Emit(context.Background(), "a")
 	require.NoError(t, err)
@@ -44,7 +46,8 @@ func TestStream_Get(t *testing.T) {
 }
 
 func TestStream_SubscriberCursor(t *testing.T) {
-	s := New("test", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("test", 4, wg).(*stream)
 
 	for i := 0; i < 5; i++ {
 		_, err := s.Emit(context.Background(), i)
@@ -60,7 +63,8 @@ func TestStream_SubscriberCursor(t *testing.T) {
 }
 
 func TestStream_Compact(t *testing.T) {
-	s := New("metrics", 16).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("metrics", 16, wg).(*stream)
 
 	sub := s.RegisterSubscriber("reader") // ✅ move this up
 
@@ -88,7 +92,8 @@ func TestStream_Compact(t *testing.T) {
 }
 
 func TestStream_Close(t *testing.T) {
-	s := New("test", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("test", 4, wg).(*stream)
 	sub1 := s.RegisterSubscriber("a")
 	sub2 := s.RegisterSubscriber("b")
 
@@ -120,7 +125,8 @@ func waitForMinCursor(t *testing.T, s *stream, want int64) {
 }
 
 func TestStream_AdvanceCursorNoShrink(t *testing.T) {
-	s := New("metrics", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("metrics", 4, wg).(*stream)
 
 	// Append a few events
 	for i := 0; i < 4; i++ {
@@ -136,7 +142,8 @@ func TestStream_AdvanceCursorNoShrink(t *testing.T) {
 }
 
 func TestStream_SubscriberUpdateCh(t *testing.T) {
-	s := New("test", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("test", 4, wg).(*stream)
 	sub := s.RegisterSubscriber("watcher")
 
 	go func() {
@@ -153,14 +160,16 @@ func TestStream_SubscriberUpdateCh(t *testing.T) {
 }
 
 func TestStream_EmptyRead(t *testing.T) {
-	s := New("empty", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("empty", 4, wg).(*stream)
 	evs, err := s.Read(1, 10)
 	require.NoError(t, err)
 	require.Len(t, evs, 0)
 }
 
 func TestStream_AutoGrowRing(t *testing.T) {
-	s := New("log", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("log", 4, wg).(*stream)
 
 	for i := 0; i < 10; i++ {
 		_, err := s.Emit(context.Background(), i)
@@ -181,7 +190,8 @@ func TestStream_AutoGrowRing(t *testing.T) {
 }
 
 func TestSubscriber_AdvanceToAffectsFirstTx(t *testing.T) {
-	s := New("subtest", 8).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("subtest", 8, wg).(*stream)
 
 	// Append 10 events: ring should auto-grow to prevent overwrite
 	for i := 0; i < 10; i++ {
@@ -205,7 +215,8 @@ func TestSubscriber_AdvanceToAffectsFirstTx(t *testing.T) {
 }
 
 func TestSubscriber_UpdateChReceivesTx(t *testing.T) {
-	s := New("subtest", 8).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("subtest", 8, wg).(*stream)
 	sub := s.RegisterSubscriber("reader")
 
 	_, err := s.Emit(context.Background(), "hello")
@@ -220,7 +231,8 @@ func TestSubscriber_UpdateChReceivesTx(t *testing.T) {
 }
 
 func TestSubscriber_WatchAutoAdvance(t *testing.T) {
-	s := New("test", 8).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("test", 8, wg).(*stream)
 	sub := s.RegisterSubscriber("reader")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -264,7 +276,8 @@ func TestSubscriber_WatchAutoAdvance(t *testing.T) {
 }
 
 func TestSubscriber_CloseStreamShutsDown(t *testing.T) {
-	s := New("subtest", 4).(*stream)
+	wg := &sync.WaitGroup{}
+	s := New("subtest", 4, wg).(*stream)
 	sub := s.RegisterSubscriber("reader")
 
 	s.Close()

--- a/tests/compiler/valid/fold_pure_let.go.out
+++ b/tests/compiler/valid/fold_pure_let.go.out
@@ -13,5 +13,3 @@ func main() {
 	fmt.Println(55)
 	fmt.Println(n)
 }
-
-

--- a/tests/compiler/valid/fun_call.go.out
+++ b/tests/compiler/valid/fun_call.go.out
@@ -11,5 +11,3 @@ func add(a int, b int) int {
 func main() {
 	fmt.Println(5)
 }
-
-

--- a/tests/compiler/valid/join.go.out
+++ b/tests/compiler/valid/join.go.out
@@ -39,4 +39,3 @@ func main() {
 		fmt.Println("Order", entry.OrderId, "by", entry.CustomerName, "- $", entry.Total)
 	}
 }
-

--- a/tests/compiler/valid/stream_on_emit.go.out
+++ b/tests/compiler/valid/stream_on_emit.go.out
@@ -12,7 +12,7 @@ func main() {
 		Temperature float64 `json:"temperature"`
 	}
 	
-	var sensorStream = stream.New("Sensor", 64)
+	var sensorStream = stream.New("Sensor", 64, nil)
 	_done0 := make(chan struct{})
 	sensorStream.Subscribe("handler-0", func(ev *stream.Event) error {
 		s := ev.Data.(Sensor)


### PR DESCRIPTION
## Summary
- share WaitGroup across streams using Interpreter pointer
- pass WG via agent.Config and constructor
- update docs and tests
- regenerate Go compiler golden for stream example
- update all Go compiler golden files via `make update-golden`

## Testing
- `go test ./compile/go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684aee9c8e1083208213e9ceb25e296f