### PR TITLE
Add Go FFI package listing

### DIFF
--- a/runtime/ffi/go/packages.go
+++ b/runtime/ffi/go/packages.go
@@ -1,0 +1,32 @@
+package goffi
+
+import (
+	"go/doc"
+	"golang.org/x/tools/go/packages"
+	"strings"
+)
+
+// PackageInfo contains basic details about a Go package.
+type PackageInfo struct {
+	Path string
+	Doc  string
+}
+
+// Packages returns information about all Go packages visible in the build environment.
+func Packages() ([]PackageInfo, error) {
+	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax}
+	pkgs, err := packages.Load(cfg, "all")
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]PackageInfo, 0, len(pkgs))
+	for _, p := range pkgs {
+		docPkg, err := doc.NewFromFiles(p.Fset, p.Syntax, p.PkgPath)
+		if err != nil {
+			// ignore packages we can't parse
+			continue
+		}
+		infos = append(infos, PackageInfo{Path: p.PkgPath, Doc: strings.TrimSpace(docPkg.Doc)})
+	}
+	return infos, nil
+}

--- a/runtime/ffi/go/packages_test.go
+++ b/runtime/ffi/go/packages_test.go
@@ -1,0 +1,30 @@
+package goffi_test
+
+import (
+	"testing"
+
+	goffi "mochi/runtime/ffi/go"
+)
+
+func TestPackages(t *testing.T) {
+	pkgs, err := goffi.Packages()
+	if err != nil {
+		t.Fatalf("packages failed: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("no packages returned")
+	}
+	found := false
+	for _, p := range pkgs {
+		if p.Path == "fmt" {
+			found = true
+			if p.Doc == "" {
+				t.Fatalf("expected doc for fmt")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("fmt package not found")
+	}
+}


### PR DESCRIPTION
## Summary
- extend `goffi` with a Packages function to list all visible Go packages and their docs
- test package listing functionality

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b13dab83c832092ec1319d96e7865