### PR TITLE
Add package listing to Python FFI

### DIFF
--- a/runtime/ffi/python/packages.go
+++ b/runtime/ffi/python/packages.go
@@ -1,0 +1,54 @@
+package python
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// PackageInfo describes an installed Python package.
+type PackageInfo struct {
+	Name     string `json:"name,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Summary  string `json:"summary,omitempty"`
+	Location string `json:"location,omitempty"`
+}
+
+// Packages returns information about all installed Python packages.
+func Packages() ([]PackageInfo, error) {
+	const pySrc = `import json, importlib.metadata, sys
+pkgs = []
+for dist in importlib.metadata.distributions():
+    md = dist.metadata
+    pkgs.append({
+        "Name": md.get("Name", dist.metadata.get("Name", "")),
+        "Version": dist.version,
+        "Summary": md.get("Summary", ""),
+        "Location": str(dist.locate_file("")),
+    })
+json.dump(pkgs, sys.stdout)`
+
+	file, err := os.CreateTemp("", "mochi_py_pkgs_*.py")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(file.Name())
+	if _, err := file.WriteString(pySrc); err != nil {
+		file.Close()
+		return nil, err
+	}
+	file.Close()
+
+	cmd := exec.Command("python3", file.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("python error: %w\n%s", err, out)
+	}
+
+	var list []PackageInfo
+	if err := json.Unmarshal(out, &list); err != nil {
+		return nil, fmt.Errorf("decode error: %w\noutput: %s", err, out)
+	}
+	return list, nil
+}

--- a/runtime/ffi/python/packages_test.go
+++ b/runtime/ffi/python/packages_test.go
@@ -1,0 +1,33 @@
+package python_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"mochi/runtime/ffi/python"
+)
+
+func TestPackages(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+	pkgs, err := python.Packages()
+	if err != nil {
+		t.Fatalf("packages failed: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("expected at least one package")
+	}
+	found := false
+	for _, p := range pkgs {
+		if p.Name == "pip" {
+			if p.Version == "" {
+				t.Fatalf("pip version missing")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("pip package not found")
+	}
+}


### PR DESCRIPTION
## Summary
- implement `Packages()` to enumerate installed Python packages
- verify behaviour in new test

## Testing
- `go test ./runtime/ffi/... -run Packages -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b14086f208320bfdd1c5ce564739f