### PR TITLE
Add package listing to TS FFI runtime

### DIFF
--- a/runtime/ffi/ts/ffi.test.ts
+++ b/runtime/ffi/ts/ffi.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import path from 'path';
-import { register, call, loadModule } from './ffi';
+import { register, call, loadModule, listPackages } from './ffi';
 
 (async () => {
   register('add', (a: number, b: number) => a + b);
@@ -18,6 +18,11 @@ import { register, call, loadModule } from './ffi';
 
   const sq = await call('square', 4);
   assert.strictEqual(sq, 16);
+
+  const pkgs = listPackages();
+  assert.strictEqual(pkgs.length, 1);
+  const names = pkgs[0].exports.map(e => e.name).sort();
+  assert.deepStrictEqual(names, ['pi', 'square']);
 
   try {
     await call('pi', 1);


### PR DESCRIPTION
## Summary
- extend TS FFI runtime to track loaded modules
- expose `listPackages` API and add `PackageInfo` interface
- test listing via updated `ffi.test.ts`

## Testing
- `make install`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684b141883548320b3d4830935c5b224