### PR TITLE
Add package listing for Deno FFI

### DIFF
--- a/runtime/ffi/deno/packages.go
+++ b/runtime/ffi/deno/packages.go
@@ -1,0 +1,33 @@
+package deno
+
+import (
+	"path/filepath"
+	"runtime"
+
+	ffiinfo "mochi/runtime/ffi/infer"
+)
+
+var pkgDir string
+
+func init() {
+	_, file, _, _ := runtime.Caller(0)
+	pkgDir = filepath.Dir(file)
+}
+
+// Packages scans the Deno FFI directory for .ts modules and returns
+// ModuleInfo details for each.
+func Packages() (map[string]*ffiinfo.ModuleInfo, error) {
+	files, err := filepath.Glob(filepath.Join(pkgDir, "*.ts"))
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]*ffiinfo.ModuleInfo, len(files))
+	for _, f := range files {
+		info, err := Infer(f)
+		if err != nil {
+			return nil, err
+		}
+		out[filepath.Base(f)] = info
+	}
+	return out, nil
+}

--- a/runtime/ffi/deno/packages_test.go
+++ b/runtime/ffi/deno/packages_test.go
@@ -1,0 +1,36 @@
+package deno_test
+
+import (
+	"os/exec"
+	"testing"
+
+	deno "mochi/runtime/ffi/deno"
+)
+
+func TestPackages(t *testing.T) {
+	if _, err := exec.LookPath("deno"); err != nil {
+		t.Skip("deno not installed")
+	}
+
+	pkgs, err := deno.Packages()
+	if err != nil {
+		t.Fatalf("packages: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("no packages found")
+	}
+	mathInfo, ok := pkgs["math.ts"]
+	if !ok {
+		t.Fatalf("expected math.ts package")
+	}
+	found := false
+	for _, fn := range mathInfo.Functions {
+		if fn.Name == "pow" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected pow function in math.ts")
+	}
+}


### PR DESCRIPTION
## Summary
- add `Packages` helper to inspect all TypeScript modules in the Deno FFI
- test that package listing works and contains `math.ts`

## Testing
- `go test ./runtime/ffi/deno -count=1 -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b14260f10832085c6ca71d56f5212