### PR TITLE
Add Go package export utilities

### DIFF
--- a/runtime/ffi/go/export.go
+++ b/runtime/ffi/go/export.go
@@ -1,0 +1,40 @@
+package goffi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"mochi/parser"
+)
+
+// Export writes extern declarations for the Go package at path into dir.
+// The file name mirrors the import path with .mochi extension.
+func Export(path, dir string) error {
+	info, err := Infer(path)
+	if err != nil {
+		return err
+	}
+	alias := parser.AliasFromPath(path)
+	content := fmt.Sprintf("import go %q as %s\n%s", path, alias, info.String())
+	outPath := filepath.Join(dir, path+".mochi")
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, []byte(content), 0o644)
+}
+
+// ExportAll writes extern declarations for all available Go packages into dir.
+// Packages that fail to export are skipped with an error printed to stderr.
+func ExportAll(dir string) error {
+	pkgs, err := Packages()
+	if err != nil {
+		return err
+	}
+	for _, pkg := range pkgs {
+		if err := Export(pkg.Path, dir); err != nil {
+			fmt.Fprintf(os.Stderr, "export %s: %v\n", pkg.Path, err)
+		}
+	}
+	return nil
+}

--- a/tools/library/go/export_all.go
+++ b/tools/library/go/export_all.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"mochi/parser"
+	goffi "mochi/runtime/ffi/go"
+)
+
+func main() {
+	pkgs, err := goffi.Packages()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "list packages: %v\n", err)
+		os.Exit(1)
+	}
+	for _, pkg := range pkgs {
+		info, err := goffi.Infer(pkg.Path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "infer %s: %v\n", pkg.Path, err)
+			continue
+		}
+		alias := parser.AliasFromPath(pkg.Path)
+		content := fmt.Sprintf("import go %q as %s\n%s", pkg.Path, alias, info.String())
+		outPath := filepath.Join("tools", "library", "go", pkg.Path+".mochi")
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "mkdir %s: %v\n", filepath.Dir(outPath), err)
+			continue
+		}
+		if err := os.WriteFile(outPath, []byte(content), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write %s: %v\n", outPath, err)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `Export` and `ExportAll` helpers under runtime/ffi/go
- add `export_all.go` tool to generate Mochi extern files for all Go packages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b6eaac32c83209e42cb2bda58af25