### PR TITLE
Add Python FFI export helpers

### DIFF
--- a/runtime/ffi/python/README.md
+++ b/runtime/ffi/python/README.md
@@ -36,3 +36,16 @@ fmt.Println(res) // 8
 
 This lightweight approach avoids cgo dependencies while making it easy
 to leverage Python's vast ecosystem from Mochi programs.
+
+## Generating extern declarations
+
+`Export` writes Mochi `extern` declarations for a Python module to a file. The
+output can be checked into source control or used by tools.
+
+```go
+err := python.Export("math", "externs")
+// creates externs/math.mochi
+```
+
+`ExportAll` uses the installed package list to export every available module into
+a directory, skipping any failures.

--- a/runtime/ffi/python/export.go
+++ b/runtime/ffi/python/export.go
@@ -1,0 +1,40 @@
+package python
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"mochi/parser"
+)
+
+// Export writes extern declarations for the Python module into dir.
+// The file name mirrors the module name with a .mochi extension.
+func Export(module, dir string) error {
+	info, err := Infer(module)
+	if err != nil {
+		return err
+	}
+	alias := parser.AliasFromPath(module)
+	content := fmt.Sprintf("import python %q as %s\n%s", module, alias, info.String())
+	outPath := filepath.Join(dir, module+".mochi")
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, []byte(content), 0o644)
+}
+
+// ExportAll writes extern declarations for all installed Python packages into dir.
+// Packages that fail to export are skipped with an error printed to stderr.
+func ExportAll(dir string) error {
+	pkgs, err := Packages()
+	if err != nil {
+		return err
+	}
+	for _, pkg := range pkgs {
+		if err := Export(pkg.Name, dir); err != nil {
+			fmt.Fprintf(os.Stderr, "export %s: %v\n", pkg.Name, err)
+		}
+	}
+	return nil
+}

--- a/runtime/ffi/python/export_test.go
+++ b/runtime/ffi/python/export_test.go
@@ -1,0 +1,46 @@
+package python_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/runtime/ffi/python"
+)
+
+func TestExport(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	os.Setenv("PYTHONPATH", wd)
+	defer os.Unsetenv("PYTHONPATH")
+
+	dir, err := os.MkdirTemp("", "py_export_test")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := python.Export("testmod", dir); err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "testmod.mochi")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	text := string(data)
+	if !strings.HasPrefix(text, "import python \"testmod\" as testmod") {
+		t.Fatalf("unexpected header: %s", text)
+	}
+	if !strings.Contains(text, "extern fun testmod.add") {
+		t.Fatalf("missing function declaration")
+	}
+}


### PR DESCRIPTION
## Summary
- allow exporting extern definitions for Python modules
- document export helpers in Python FFI README
- test python export

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b73f1dd5883208ed2c48af972c189