### PR TITLE
Implement GenMochi for leetcode agent

### DIFF
--- a/tools/agent/leetcode/gen.go
+++ b/tools/agent/leetcode/gen.go
@@ -1,0 +1,30 @@
+package leetcode
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"mochi/mcp"
+	"mochi/runtime/llm"
+)
+
+// GenMochi generates Mochi code to solve the given LeetCode problem text.
+func GenMochi(id int, problemText string) (string, error) {
+	prompt := fmt.Sprintf("Mochi cheatsheet:\n%s\n\nLeetCode problem #%d:\n%s\n\nWrite Mochi code to solve this problem. Output Mochi code only.", mcp.Cheatsheet(), id, problemText)
+	resp, err := llm.Chat(context.Background(), []llm.Message{{Role: "user", Content: prompt}})
+	if err != nil {
+		return "", err
+	}
+	return extractMochiCode(resp.Message.Content), nil
+}
+
+var codeBlockRE = regexp.MustCompile("(?s)```(?:mochi)?\\s*(.*?)```")
+
+func extractMochiCode(s string) string {
+	if m := codeBlockRE.FindStringSubmatch(s); len(m) > 1 {
+		return strings.TrimSpace(m[1])
+	}
+	return strings.TrimSpace(s)
+}

--- a/tools/agent/leetcode/gen_test.go
+++ b/tools/agent/leetcode/gen_test.go
@@ -1,0 +1,52 @@
+package leetcode
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mochi/runtime/llm"
+)
+
+var (
+	lastPrompt string
+)
+
+type fakeProvider struct{}
+type fakeConn struct{}
+
+func init() { llm.Register("genfake", fakeProvider{}) }
+
+func (fakeProvider) Open(dsn string, opts llm.Options) (llm.Conn, error) { return &fakeConn{}, nil }
+func (fakeConn) Close() error                                            { return nil }
+func (fakeConn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	if len(req.Messages) > 0 {
+		lastPrompt = req.Messages[len(req.Messages)-1].Content
+	}
+	return &llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "```mochi\nprint(42)\n```"}, Model: "genfake"}, nil
+}
+func (fakeConn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	return nil, nil
+}
+func (fakeConn) Embed(ctx context.Context, req llm.EmbedRequest) (*llm.EmbedResponse, error) {
+	return nil, nil
+}
+
+// TestGenMochi ensures GenMochi builds the correct prompt and extracts code.
+func TestGenMochi(t *testing.T) {
+	llm.Default, _ = llm.Open("genfake", "", llm.Options{})
+	text, err := Download(1)
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	code, err := GenMochi(1, text)
+	if err != nil {
+		t.Fatalf("GenMochi error: %v", err)
+	}
+	if !strings.Contains(lastPrompt, text) {
+		t.Fatalf("prompt missing problem text")
+	}
+	if code != "print(42)" {
+		t.Fatalf("unexpected code: %q", code)
+	}
+}


### PR DESCRIPTION
## Summary
- add GenMochi that generates prompt with cheat sheet and extracts Mochi code
- add unit test using fake LLM provider

## Testing
- `go test ./tools/agent/leetcode -run TestGenMochi -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b79950a508320ab932f7cbb034518