### PR TITLE
Add LeetCode solving agent

### DIFF
--- a/tools/agent/leetcode/agent.go
+++ b/tools/agent/leetcode/agent.go
@@ -1,0 +1,91 @@
+package leetcode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/llm"
+	"mochi/runtime/mod"
+	"mochi/types"
+)
+
+// Solve attempts to generate Mochi code for a LeetCode problem and iterate
+// with the LLM until the inline tests pass. The returned Mochi code is the
+// final version that satisfied all tests or the last attempt if iterations
+// were exhausted.
+func Solve(id int, iterate int) (string, error) {
+	var text string
+	var err error
+
+	// Try downloading the problem a few times in case of transient failures.
+	for i := 0; i < 3; i++ {
+		start := time.Now()
+		text, err = Download(id)
+		dur := time.Since(start)
+		fmt.Printf("download problem #%d step %d took %s\n", id, i+1, dur)
+		if err == nil {
+			break
+		}
+		if i == 2 {
+			return "", err
+		}
+	}
+
+	// Generate initial Mochi solution.
+	start := time.Now()
+	code, err := GenMochi(id, text)
+	dur := time.Since(start)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("initial generation took %s\n", dur)
+
+	for i := 0; i < iterate; i++ {
+		// Run tests defined inside the generated Mochi source.
+		out, testErr := runTests(code)
+		if testErr == nil {
+			fmt.Printf("tests passed on iteration %d\n", i+1)
+			return code, nil
+		}
+		fmt.Printf("iteration %d tests failed: %v\n", i+1, testErr)
+
+		if i == iterate-1 {
+			return code, fmt.Errorf("tests failed after %d iterations", iterate)
+		}
+
+		// Ask the LLM to fix the code using the failing output as context.
+		prompt := fmt.Sprintf("The following Mochi program failed its tests:\n\n%s\n\nError output:\n%s\n\nPlease provide a corrected version of the code only.", code, out)
+		start = time.Now()
+		resp, err := llm.Chat(context.Background(), []llm.Message{{Role: "user", Content: prompt}})
+		dur = time.Since(start)
+		if err != nil {
+			return "", err
+		}
+		fmt.Printf("refinement %d took %s\n", i+1, dur)
+		code = extractMochiCode(resp.Message.Content)
+	}
+
+	return code, nil
+}
+
+// runTests parses the source code and executes all inline tests.
+func runTests(src string) (string, error) {
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		return "", err
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return "", fmt.Errorf("type error: %v", errs[0])
+	}
+	modRoot, _ := mod.FindRoot(".")
+	out := &strings.Builder{}
+	interp := interpreter.New(prog, env, modRoot)
+	interp.Env().SetWriter(out)
+	err = interp.Test()
+	return out.String(), err
+}

--- a/tools/agent/leetcode/agent_test.go
+++ b/tools/agent/leetcode/agent_test.go
@@ -1,0 +1,46 @@
+package leetcode
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mochi/runtime/llm"
+)
+
+type solveProvider struct{}
+
+type solveConn struct{ calls int }
+
+func init() { llm.Register("solvefake", solveProvider{}) }
+
+func (solveProvider) Open(dsn string, opts llm.Options) (llm.Conn, error) { return &solveConn{}, nil }
+func (solveConn) Close() error                                            { return nil }
+func (c *solveConn) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	c.calls++
+	if c.calls == 1 {
+		// first attempt returns faulty code
+		return &llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "```mochi\nfun add(a:int,b:int):int { return a - b }\n\n test \"t\" { expect add(2,3) == 5 }\n```"}, Model: "solvefake"}, nil
+	}
+	// second and subsequent attempts return correct code
+	return &llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "```mochi\nfun add(a:int,b:int):int { return a + b }\n\n test \"t\" { expect add(2,3) == 5 }\n```"}, Model: "solvefake"}, nil
+}
+func (solveConn) ChatStream(ctx context.Context, req llm.ChatRequest) (llm.Stream, error) {
+	return nil, nil
+}
+func (solveConn) Embed(ctx context.Context, req llm.EmbedRequest) (*llm.EmbedResponse, error) {
+	return nil, nil
+}
+
+func TestSolve(t *testing.T) {
+	llm.Default, _ = llm.Open("solvefake", "", llm.Options{})
+	code, err := Solve(1, 2)
+	if err != nil {
+		t.Fatalf("Solve error: %v", err)
+	}
+	if code == "" || !strContains(code, "a + b") {
+		t.Fatalf("unexpected code: %q", code)
+	}
+}
+
+func strContains(s, substr string) bool { return strings.Contains(s, substr) }


### PR DESCRIPTION
## Summary
- add an iterative solver for LeetCode problems
- add a unit test using a fake LLM provider

## Testing
- `go test ./tools/agent/leetcode -run TestSolve -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b7fcdcd048320b42513f60787fe9a