### PR TITLE
Add strings library test

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -13,7 +13,7 @@ import (
 	"mochi/types"
 	"os/exec"
 	"path/filepath"
-	"strings"
+	stdstrings "strings"
 	"testing"
 )
 
@@ -45,8 +45,10 @@ func TestInterpreter_ValidPrograms(t *testing.T) {
 		goffi.Register("math.Pow", math.Pow)
 		goffi.Register("math.Sin", math.Sin)
 		goffi.Register("math.Log", math.Log)
+		goffi.Register("strings.ToUpper", stdstrings.ToUpper)
+		goffi.Register("strings.HasPrefix", stdstrings.HasPrefix)
 
-		out := &strings.Builder{}
+		out := &stdstrings.Builder{}
 		modRoot, _ := mod.FindRoot(filepath.Dir(src))
 		interp := interpreter.New(prog, typeEnv, modRoot)
 		interp.Env().SetWriter(out)
@@ -76,8 +78,10 @@ func TestInterpreter_RuntimeErrors(t *testing.T) {
 		goffi.Register("math.Pow", math.Pow)
 		goffi.Register("math.Sin", math.Sin)
 		goffi.Register("math.Log", math.Log)
+		goffi.Register("strings.ToUpper", stdstrings.ToUpper)
+		goffi.Register("strings.HasPrefix", stdstrings.HasPrefix)
 
-		out := &strings.Builder{}
+		out := &stdstrings.Builder{}
 		modRoot, _ := mod.FindRoot(filepath.Dir(src))
 		interp := interpreter.New(prog, typeEnv, modRoot)
 		interp.Env().SetWriter(out)

--- a/tests/interpreter/valid/strings_basic.mochi
+++ b/tests/interpreter/valid/strings_basic.mochi
@@ -1,0 +1,7 @@
+import go "strings" as strings
+
+extern fun strings.ToUpper(s: string): string
+extern fun strings.HasPrefix(s: string, prefix: string): bool
+
+print(strings.ToUpper("hello"))
+print(strings.HasPrefix("foobar", "foo"))

--- a/tests/interpreter/valid/strings_basic.out
+++ b/tests/interpreter/valid/strings_basic.out
@@ -1,0 +1,2 @@
+HELLO
+true


### PR DESCRIPTION
## Summary
- add a simple test exercising the Go `strings` externs
- register `strings` FFI functions in interpreter tests

## Testing
- `go test ./interpreter -run TestInterpreter_ValidPrograms -count=1 -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b928a28908320b56028039c61b658