### PR TITLE
Remove helperIndex/Len from TS runtime

### DIFF
--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -958,8 +958,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				expr = fmt.Sprintf("%s[%s]", expr, idxExpr)
 				typ = types.StringType{}
 			default:
-				c.use("_index")
-				expr = fmt.Sprintf("_index(%s, %s)", expr, idxExpr)
+				expr = fmt.Sprintf("(%s as any)[%s]", expr, idxExpr)
 				typ = types.AnyType{}
 			}
 		}
@@ -1052,10 +1051,12 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 				return fmt.Sprintf("%s.length", args[0]), nil
 			case types.MapType, types.StructType, types.UnionType:
 				return fmt.Sprintf("Object.keys(%s).length", args[0]), nil
+			default:
+				a := args[0]
+				return fmt.Sprintf("(Array.isArray(%[1]s) || typeof %[1]s === 'string' ? (%[1]s as any).length : (%[1]s && typeof %[1]s === 'object' ? Object.keys(%[1]s).length : 0))", a), nil
 			}
 		}
-		c.use("_len")
-		return fmt.Sprintf("_len(%s)", argStr), nil
+		return fmt.Sprintf("(Array.isArray(%[1]s) || typeof %[1]s === 'string' ? (%[1]s as any).length : (%[1]s && typeof %[1]s === 'object' ? Object.keys(%[1]s).length : 0))", argStr), nil
 	case "str":
 		return fmt.Sprintf("String(%s)", argStr), nil
 	case "count":

--- a/compile/ts/runtime.go
+++ b/compile/ts/runtime.go
@@ -4,32 +4,6 @@ import "sort"
 
 // Runtime helper functions injected into generated programs.
 const (
-	helperIndex = "function _index(v: any, k: any): any {\n" +
-		"  if (Array.isArray(v)) {\n" +
-		"    if (typeof k !== 'number') throw new Error('invalid list index');\n" +
-		"    if (k < 0) k += v.length;\n" +
-		"    if (k < 0 || k >= v.length) throw new Error('index out of range');\n" +
-		"    return v[k];\n" +
-		"  }\n" +
-		"  if (typeof v === 'string') {\n" +
-		"    if (typeof k !== 'number') throw new Error('invalid string index');\n" +
-		"    const chars = Array.from(v);\n" +
-		"    if (k < 0) k += chars.length;\n" +
-		"    if (k < 0 || k >= chars.length) throw new Error('index out of range');\n" +
-		"    return chars[k];\n" +
-		"  }\n" +
-		"  if (v && typeof v === 'object') {\n" +
-		"    return (v as any)[k];\n" +
-		"  }\n" +
-		"  return (v as any)[k];\n" +
-		"}\n"
-
-	helperLen = "function _len(v: any): number {\n" +
-		"  if (Array.isArray(v) || typeof v === \"string\") return (v as any).length;\n" +
-		"  if (v && typeof v === \"object\") return Object.keys(v).length;\n" +
-		"  return 0;\n" +
-		"}\n"
-
 	helperCount = "function _count(v: any): number {\n" +
 		"  if (Array.isArray(v)) return v.length;\n" +
 		"  if (v && typeof v === 'object') {\n" +
@@ -313,8 +287,6 @@ const (
 )
 
 var helperMap = map[string]string{
-	"_index":      helperIndex,
-	"_len":        helperLen,
 	"_count":      helperCount,
 	"_avg":        helperAvg,
 	"_iter":       helperIter,


### PR DESCRIPTION
## Summary
- remove `helperIndex` and `helperLen` helpers
- infer indexing and length directly in the TypeScript compiler

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684bf6b5bfb48320bf5f0f73ca171995