### PR TITLE
Remove helperIndex/iter in Python compiler

### DIFF
--- a/compile/py/runtime.go
+++ b/compile/py/runtime.go
@@ -4,27 +4,6 @@ import "sort"
 
 // Runtime helpers emitted by the Python compiler.
 
-var helperIndex = "def _index(v, k):\n" +
-	"    if isinstance(v, list):\n" +
-	"        if not isinstance(k, int):\n" +
-	"            raise Exception('invalid list index')\n" +
-	"        if k < 0:\n" +
-	"            k += len(v)\n" +
-	"        if k < 0 or k >= len(v):\n" +
-	"            raise Exception('index out of range')\n" +
-	"        return v[k]\n" +
-	"    if isinstance(v, str):\n" +
-	"        if not isinstance(k, int):\n" +
-	"            raise Exception('invalid string index')\n" +
-	"        if k < 0:\n" +
-	"            k += len(v)\n" +
-	"        if k < 0 or k >= len(v):\n" +
-	"            raise Exception('index out of range')\n" +
-	"        return v[k]\n" +
-	"    if isinstance(v, dict):\n" +
-	"        return v[k]\n" +
-	"    return v[k]\n"
-
 var helperGenText = "def _gen_text(prompt, model=None, params=None):\n" +
 	"    # TODO: send prompt to your LLM of choice\n" +
 	"    return prompt\n"
@@ -195,11 +174,6 @@ var helperSave = "def _save(rows, path, opts):\n" +
 var helperToAnyMap = "def _to_any_map(m):\n" +
 	"    return dict(m) if isinstance(m, dict) else dict(m)\n"
 
-var helperIter = "def _iter(v):\n" +
-	"    if isinstance(v, dict):\n" +
-	"        return list(v.keys())\n" +
-	"    return v\n"
-
 var helperUnionAll = "def _union_all(a, b):\n" +
 	"    return list(a) + list(b)\n"
 
@@ -337,7 +311,6 @@ var helperQuery = "def _query(src, joins, opts):\n" +
 	"    return res\n"
 
 var helperMap = map[string]string{
-	"_index":      helperIndex,
 	"_gen_text":   helperGenText,
 	"_gen_embed":  helperGenEmbed,
 	"_gen_struct": helperGenStruct,
@@ -351,7 +324,6 @@ var helperMap = map[string]string{
 	"_load":       helperLoad,
 	"_save":       helperSave,
 	"_to_any_map": helperToAnyMap,
-	"_iter":       helperIter,
 	"_stream":     helperStream,
 	"_wait_all":   helperWaitAll,
 	"_agent":      helperAgent,

--- a/tests/compiler/py/dataset.py.out
+++ b/tests/compiler/py/dataset.py.out
@@ -9,13 +9,9 @@ def main():
 		name: str
 		age: int
 	people = [Person(name="Alice", age=30), Person(name="Bob", age=15), Person(name="Charlie", age=65)]
-	names = [ p.name for p in _iter(people) if (p.age >= 18) ]
+	names = [ p.name for p in people if (p.age >= 18) ]
 	for n in names:
 		print(n)
 
-def _iter(v):
-    if isinstance(v, dict):
-        return list(v.keys())
-    return v
 if __name__ == "__main__":
 	main()

--- a/tests/compiler/py/dataset_sort_take_limit.py.out
+++ b/tests/compiler/py/dataset_sort_take_limit.py.out
@@ -9,14 +9,10 @@ def main():
 		name: str
 		price: int
 	products = [Product(name="Laptop", price=1500), Product(name="Smartphone", price=900), Product(name="Tablet", price=600), Product(name="Monitor", price=300), Product(name="Keyboard", price=100), Product(name="Mouse", price=50), Product(name="Headphones", price=200)]
-	expensive = [ p for p in ((sorted([ p for p in _iter(products) ], key=lambda p: (-p.price)))[1:])[:3] ]
+	expensive = [ p for p in ((sorted([ p for p in products ], key=lambda p: (-p.price)))[1:])[:3] ]
 	print("--- Top products (excluding most expensive) ---")
 	for item in expensive:
 		print(item.name, "costs $", item.price)
 
-def _iter(v):
-    if isinstance(v, dict):
-        return list(v.keys())
-    return v
 if __name__ == "__main__":
 	main()

--- a/tests/compiler/valid/cross_join.py.out
+++ b/tests/compiler/valid/cross_join.py.out
@@ -21,14 +21,10 @@ def main():
 		orderTotal: int
 	customers = [Customer(id=1, name="Alice"), Customer(id=2, name="Bob"), Customer(id=3, name="Charlie")]
 	orders = [Order(id=100, customerId=1, total=250), Order(id=101, customerId=2, total=125), Order(id=102, customerId=1, total=300)]
-	result = [ PairInfo(orderId=o.id, orderCustomerId=o.customerId, pairedCustomerName=c.name, orderTotal=o.total) for o in _iter(orders) for c in _iter(customers) ]
+	result = [ PairInfo(orderId=o.id, orderCustomerId=o.customerId, pairedCustomerName=c.name, orderTotal=o.total) for o in orders for c in customers ]
 	print("--- Cross Join: All order-customer pairs ---")
 	for entry in result:
 		print("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
 
-def _iter(v):
-    if isinstance(v, dict):
-        return list(v.keys())
-    return v
 if __name__ == "__main__":
 	main()

--- a/tests/compiler/valid/join.py.out
+++ b/tests/compiler/valid/join.py.out
@@ -20,14 +20,10 @@ def main():
 		total: int
 	customers = [Customer(id=1, name="Alice"), Customer(id=2, name="Bob"), Customer(id=3, name="Charlie")]
 	orders = [Order(id=100, customerId=1, total=250), Order(id=101, customerId=2, total=125), Order(id=102, customerId=1, total=300), Order(id=103, customerId=4, total=80)]
-	result = [ PairInfo(orderId=o.id, customerName=c.name, total=o.total) for o in _iter(orders) for c in _iter(customers) if (o.customerId == c.id) ]
+	result = [ PairInfo(orderId=o.id, customerName=c.name, total=o.total) for o in orders for c in customers if (o.customerId == c.id) ]
 	print("--- Orders with customer info ---")
 	for entry in result:
 		print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
 
-def _iter(v):
-    if isinstance(v, dict):
-        return list(v.keys())
-    return v
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
## Summary
- drop `_index` and `_iter` helpers from Python runtime
- iterate and index directly in generated Python
- adjust golden outputs for dataset query examples

## Testing
- `go test ./compile/py -run TestPyCompiler_GoldenOutput -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684bf678c3188320a250f8232ae155c6