### PR TITLE
Remove dynamic index/iter helpers

### DIFF
--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -4,92 +4,6 @@ import "sort"
 
 // Runtime helper functions injected into generated programs.
 const (
-	helperIndex = "func _index(v any, k any) any {\n" +
-		"    switch s := v.(type) {\n" +
-		"    case []any:\n" +
-		"        i, ok := k.(int)\n" +
-		"        if !ok {\n" +
-		"            panic(\"invalid list index\")\n" +
-		"        }\n" +
-		"        if i < 0 {\n" +
-		"            i += len(s)\n" +
-		"        }\n" +
-		"        if i < 0 || i >= len(s) {\n" +
-		"            panic(\"index out of range\")\n" +
-		"        }\n" +
-		"        return s[i]\n" +
-		"    case []int:\n" +
-		"        i, ok := k.(int)\n" +
-		"        if !ok {\n" +
-		"            panic(\"invalid list index\")\n" +
-		"        }\n" +
-		"        if i < 0 {\n" +
-		"            i += len(s)\n" +
-		"        }\n" +
-		"        if i < 0 || i >= len(s) {\n" +
-		"            panic(\"index out of range\")\n" +
-		"        }\n" +
-		"        return s[i]\n" +
-		"    case []float64:\n" +
-		"        i, ok := k.(int)\n" +
-		"        if !ok {\n" +
-		"            panic(\"invalid list index\")\n" +
-		"        }\n" +
-		"        if i < 0 {\n" +
-		"            i += len(s)\n" +
-		"        }\n" +
-		"        if i < 0 || i >= len(s) {\n" +
-		"            panic(\"index out of range\")\n" +
-		"        }\n" +
-		"        return s[i]\n" +
-		"    case []string:\n" +
-		"        i, ok := k.(int)\n" +
-		"        if !ok {\n" +
-		"            panic(\"invalid list index\")\n" +
-		"        }\n" +
-		"        if i < 0 {\n" +
-		"            i += len(s)\n" +
-		"        }\n" +
-		"        if i < 0 || i >= len(s) {\n" +
-		"            panic(\"index out of range\")\n" +
-		"        }\n" +
-		"        return s[i]\n" +
-		"    case []bool:\n" +
-		"        i, ok := k.(int)\n" +
-		"        if !ok {\n" +
-		"            panic(\"invalid list index\")\n" +
-		"        }\n" +
-		"        if i < 0 {\n" +
-		"            i += len(s)\n" +
-		"        }\n" +
-		"        if i < 0 || i >= len(s) {\n" +
-		"            panic(\"index out of range\")\n" +
-		"        }\n" +
-		"        return s[i]\n" +
-		"    case string:\n" +
-		"        i, ok := k.(int)\n" +
-		"        if !ok {\n" +
-		"            panic(\"invalid string index\")\n" +
-		"        }\n" +
-		"        runes := []rune(s)\n" +
-		"        if i < 0 {\n" +
-		"            i += len(runes)\n" +
-		"        }\n" +
-		"        if i < 0 || i >= len(runes) {\n" +
-		"            panic(\"index out of range\")\n" +
-		"        }\n" +
-		"        return string(runes[i])\n" +
-		"    case map[string]any:\n" +
-		"        ks, ok := k.(string)\n" +
-		"        if !ok {\n" +
-		"            panic(\"invalid map key\")\n" +
-		"        }\n" +
-		"        return s[ks]\n" +
-		"    default:\n" +
-		"        panic(\"invalid index target\")\n" +
-		"    }\n" +
-		"}\n"
-
 	helperIndexString = "func _indexString(s string, i int) string {\n" +
 		"    runes := []rune(s)\n" +
 		"    if i < 0 {\n" +
@@ -101,63 +15,50 @@ const (
 		"    return string(runes[i])\n" +
 		"}\n"
 
-	helperIter = "func _iter(v any) []any {\n" +
-		"    switch s := v.(type) {\n" +
-		"    case []any:\n" +
-		"        return s\n" +
-		"    case []int:\n" +
-		"        out := make([]any, len(s))\n" +
-		"        for i, v := range s {\n" +
-		"            out[i] = v\n" +
-		"        }\n" +
-		"        return out\n" +
-		"    case []float64:\n" +
-		"        out := make([]any, len(s))\n" +
-		"        for i, v := range s {\n" +
-		"            out[i] = v\n" +
-		"        }\n" +
-		"        return out\n" +
-		"    case []string:\n" +
-		"        out := make([]any, len(s))\n" +
-		"        for i, v := range s {\n" +
-		"            out[i] = v\n" +
-		"        }\n" +
-		"        return out\n" +
-		"    case []bool:\n" +
-		"        out := make([]any, len(s))\n" +
-		"        for i, v := range s {\n" +
-		"            out[i] = v\n" +
-		"        }\n" +
-		"        return out\n" +
-		"    case map[string]any:\n" +
-		"        out := make([]any, 0, len(s))\n" +
-		"        for k := range s {\n" +
-		"            out = append(out, k)\n" +
-		"        }\n" +
-		"        return out\n" +
-		"    case string:\n" +
-		"        runes := []rune(s)\n" +
-		"        out := make([]any, len(runes))\n" +
-		"        for i, r := range runes {\n" +
-		"            out[i] = string(r)\n" +
-		"        }\n" +
-		"        return out\n" +
-		"    default:\n" +
-		"        return nil\n" +
-		"    }\n" +
-		"}\n"
-
 	helperCount = "func _count(v any) int {\n" +
 		"    if g, ok := v.(*data.Group); ok { return len(g.Items) }\n" +
-		"    it := _iter(v)\n" +
-		"    if it == nil { panic(\"count() expects list or group\") }\n" +
-		"    return len(it)\n" +
+		"    switch s := v.(type) {\n" +
+		"    case []any: return len(s)\n" +
+		"    case []int: return len(s)\n" +
+		"    case []float64: return len(s)\n" +
+		"    case []string: return len(s)\n" +
+		"    case []bool: return len(s)\n" +
+		"    case map[string]any: return len(s)\n" +
+		"    case string: return len([]rune(s))\n" +
+		"    default: panic(\"count() expects list or group\")\n" +
+		"    }\n" +
 		"}\n"
 
 	helperAvg = "func _avg(v any) float64 {\n" +
 		"    var items []any\n" +
-		"    if g, ok := v.(*data.Group); ok { items = g.Items } else { items = _iter(v) }\n" +
-		"    if items == nil { panic(\"avg() expects list or group\") }\n" +
+		"    if g, ok := v.(*data.Group); ok { items = g.Items } else {\n" +
+		"        switch s := v.(type) {\n" +
+		"        case []any:\n" +
+		"            items = s\n" +
+		"        case []int:\n" +
+		"            items = make([]any, len(s))\n" +
+		"            for i, v := range s {\n" +
+		"                items[i] = v\n" +
+		"            }\n" +
+		"        case []float64:\n" +
+		"            items = make([]any, len(s))\n" +
+		"            for i, v := range s {\n" +
+		"                items[i] = v\n" +
+		"            }\n" +
+		"        case []string:\n" +
+		"            items = make([]any, len(s))\n" +
+		"            for i, v := range s {\n" +
+		"                items[i] = v\n" +
+		"            }\n" +
+		"        case []bool:\n" +
+		"            items = make([]any, len(s))\n" +
+		"            for i, v := range s {\n" +
+		"                items[i] = v\n" +
+		"            }\n" +
+		"        default:\n" +
+		"            panic(\"avg() expects list or group\")\n" +
+		"        }\n" +
+		"    }\n" +
 		"    if len(items) == 0 { return 0 }\n" +
 		"    var sum float64\n" +
 		"    for _, it := range items {\n" +
@@ -437,9 +338,7 @@ const (
 )
 
 var helperMap = map[string]string{
-	"_index":       helperIndex,
 	"_indexString": helperIndexString,
-	"_iter":        helperIter,
 	"_count":       helperCount,
 	"_avg":         helperAvg,
 	"_genText":     helperGenText,

--- a/tests/compiler/go/avg_builtin.go.out
+++ b/tests/compiler/go/avg_builtin.go.out
@@ -11,8 +11,34 @@ func main() {
 
 func _avg(v any) float64 {
     var items []any
-    if g, ok := v.(*data.Group); ok { items = g.Items } else { items = _iter(v) }
-    if items == nil { panic("avg() expects list or group") }
+    if g, ok := v.(*data.Group); ok { items = g.Items } else {
+        switch s := v.(type) {
+        case []any:
+            items = s
+        case []int:
+            items = make([]any, len(s))
+            for i, v := range s {
+                items[i] = v
+            }
+        case []float64:
+            items = make([]any, len(s))
+            for i, v := range s {
+                items[i] = v
+            }
+        case []string:
+            items = make([]any, len(s))
+            for i, v := range s {
+                items[i] = v
+            }
+        case []bool:
+            items = make([]any, len(s))
+            for i, v := range s {
+                items[i] = v
+            }
+        default:
+            panic("avg() expects list or group")
+        }
+    }
     if len(items) == 0 { return 0 }
     var sum float64
     for _, it := range items {
@@ -23,50 +49,4 @@ func _avg(v any) float64 {
         default: panic("avg() expects numbers") }
     }
     return sum / float64(len(items))
-}
-
-func _iter(v any) []any {
-    switch s := v.(type) {
-    case []any:
-        return s
-    case []int:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case []float64:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case []string:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case []bool:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case map[string]any:
-        out := make([]any, 0, len(s))
-        for k := range s {
-            out = append(out, k)
-        }
-        return out
-    case string:
-        runes := []rune(s)
-        out := make([]any, len(runes))
-        for i, r := range runes {
-            out[i] = string(r)
-        }
-        return out
-    default:
-        return nil
-    }
 }

--- a/tests/compiler/go/count_builtin.go.out
+++ b/tests/compiler/go/count_builtin.go.out
@@ -11,53 +11,14 @@ func main() {
 
 func _count(v any) int {
     if g, ok := v.(*data.Group); ok { return len(g.Items) }
-    it := _iter(v)
-    if it == nil { panic("count() expects list or group") }
-    return len(it)
-}
-
-func _iter(v any) []any {
     switch s := v.(type) {
-    case []any:
-        return s
-    case []int:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case []float64:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case []string:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case []bool:
-        out := make([]any, len(s))
-        for i, v := range s {
-            out[i] = v
-        }
-        return out
-    case map[string]any:
-        out := make([]any, 0, len(s))
-        for k := range s {
-            out = append(out, k)
-        }
-        return out
-    case string:
-        runes := []rune(s)
-        out := make([]any, len(runes))
-        for i, r := range runes {
-            out[i] = string(r)
-        }
-        return out
-    default:
-        return nil
+    case []any: return len(s)
+    case []int: return len(s)
+    case []float64: return len(s)
+    case []string: return len(s)
+    case []bool: return len(s)
+    case map[string]any: return len(s)
+    case string: return len([]rune(s))
+    default: panic("count() expects list or group")
     }
 }


### PR DESCRIPTION
## Summary
- drop `_iter` and `_index` helpers from Go runtime
- tighten compiler loops and indexing to require concrete types
- update built‐ins to work without iteration helper
- regenerate golden outputs for count/avg built-ins

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684bf64ae83083208f5bb01d28ca3324