### PR TITLE
Enable empty map literal initialization

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -488,6 +488,27 @@ func (i *Interpreter) evalStmt(s *parser.Statement) error {
 					return nil
 				}
 				container = cur[key]
+			case map[int]any:
+				var k int
+				switch v := idxVal.(type) {
+				case int:
+					k = v
+				case int64:
+					k = int(v)
+				default:
+					return fmt.Errorf("map key must be int")
+				}
+				if last {
+					cur[k] = val
+					return nil
+				}
+				container = cur[k]
+			case map[any]any:
+				if last {
+					cur[idxVal] = val
+					return nil
+				}
+				container = cur[idxVal]
 			case []any:
 				n, ok := idxVal.(int)
 				if !ok {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -409,13 +409,13 @@ type MatchCase struct {
 
 type Primary struct {
 	Pos      lexer.Position
-	FunExpr  *FunExpr       `parser:"@@"`
-	Struct   *StructLiteral `parser:"| @@"`
+	Struct   *StructLiteral `parser:"@@"`
 	Call     *CallExpr      `parser:"| @@"`
 	Query    *QueryExpr     `parser:"| @@"`
 	Selector *SelectorExpr  `parser:"| @@"`
 	List     *ListLiteral   `parser:"| @@"`
 	Map      *MapLiteral    `parser:"| @@"`
+	FunExpr  *FunExpr       `parser:"| @@"`
 	Match    *MatchExpr     `parser:"| @@"`
 	Generate *GenerateExpr  `parser:"| @@"`
 	Fetch    *FetchExpr     `parser:"| @@"`


### PR DESCRIPTION
## Summary
- prioritize `MapLiteral` over block expressions in the parser so `{}` parses as a map
- support assigning into map[int]any and map[any]any in the interpreter
- emit typed empty maps in Go/Python/TypeScript compilers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c35340a208320a40a5bf92d737a64