### PR TITLE
Fix map membership with empty maps

### DIFF
--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -106,6 +106,18 @@ func anyToValue(v any) Value {
 			m[k] = anyToValue(x)
 		}
 		return Value{Tag: TagMap, Map: m}
+	case map[int]any:
+		m := make(map[string]Value, len(val))
+		for k, x := range val {
+			m[strconv.Itoa(k)] = anyToValue(x)
+		}
+		return Value{Tag: TagMap, Map: m}
+	case map[any]any:
+		m := make(map[string]Value, len(val))
+		for k, x := range val {
+			m[fmt.Sprint(k)] = anyToValue(x)
+		}
+		return Value{Tag: TagMap, Map: m}
 	case closure:
 		return Value{Tag: TagFunc, Func: &val}
 	case *closure:

--- a/tests/interpreter/valid/map_in_operator.mochi
+++ b/tests/interpreter/valid/map_in_operator.mochi
@@ -1,0 +1,3 @@
+let m = {1: "a", 2: "b"}
+print(1 in m)
+print(3 in m)

--- a/tests/interpreter/valid/map_in_operator.out
+++ b/tests/interpreter/valid/map_in_operator.out
@@ -1,0 +1,2 @@
+true
+false

--- a/types/check.go
+++ b/types/check.go
@@ -980,10 +980,23 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 		}
 		return BoolType{}, nil
 	case "in":
-		if !(unify(left, StringType{}, nil) && unify(right, StringType{}, nil)) {
-			return nil, errOperatorMismatch(pos, op, left, right)
+		switch rt := right.(type) {
+		case MapType:
+			if !unify(left, rt.Key, nil) {
+				return nil, errOperatorMismatch(pos, op, left, right)
+			}
+			return BoolType{}, nil
+		case ListType:
+			if !unify(left, rt.Elem, nil) {
+				return nil, errOperatorMismatch(pos, op, left, right)
+			}
+			return BoolType{}, nil
+		default:
+			if !(unify(left, StringType{}, nil) && unify(right, StringType{}, nil)) {
+				return nil, errOperatorMismatch(pos, op, left, right)
+			}
+			return BoolType{}, nil
 		}
-		return BoolType{}, nil
 	case "&&", "||":
 		if !(unify(left, BoolType{}, nil) && unify(right, BoolType{}, nil)) {
 			return nil, errOperatorMismatch(pos, op, left, right)


### PR DESCRIPTION
## Summary
- handle `map[int]any` and `map[any]any` in `anyToValue`
- support `in` operator for lists and maps during interpretation
- teach type checker that `in` works with lists and maps
- add regression test for map membership

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684c49f573448320a07b5f556e2619b0