### PR TITLE
Fix LeetCode regex matching example

### DIFF
--- a/examples/leetcode/10/regular-expression-matching.mochi
+++ b/examples/leetcode/10/regular-expression-matching.mochi
@@ -12,15 +12,23 @@ fun isMatch(s: string, p: string): bool {
       return i == m
     }
     var first = false
-    if i < m && (p[j] == s[i] || p[j] == ".") {
-      first = true
+    if i < m {
+      if p[j] == s[i] || p[j] == "." {
+        first = true
+      }
     }
     var ans = false
-    if j + 1 < n && p[j+1] == "*" {
-      if dfs(i, j+2) {
-        ans = true
-      } else if first && dfs(i+1, j) {
-        ans = true
+    if j + 1 < n {
+      if p[j+1] == "*" {
+        if dfs(i, j+2) {
+          ans = true
+        } else if first && dfs(i+1, j) {
+          ans = true
+        }
+      } else {
+        if first && dfs(i+1, j+1) {
+          ans = true
+        }
       }
     } else {
       if first && dfs(i+1, j+1) {


### PR DESCRIPTION
## Summary
- fix short-circuit logic in examples/leetcode/10/regular-expression-matching.mochi

## Testing
- `go run ./cmd/mochi test examples/leetcode/10/regular-expression-matching.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684c6230ae188320901e49653d535e76