### PR TITLE
Add solution for LeetCode problem 14

### DIFF
--- a/examples/leetcode/14/longest-common-prefix.mochi
+++ b/examples/leetcode/14/longest-common-prefix.mochi
@@ -1,0 +1,41 @@
+fun longestCommonPrefix(strs: list<string>): string {
+  if len(strs) == 0 {
+    return ""
+  }
+  var prefix = strs[0]
+  for i in 1..len(strs) {
+    var j = 0
+    let current = strs[i]
+    while j < len(prefix) && j < len(current) {
+      if prefix[j] != current[j] {
+        break
+      }
+      j = j + 1
+    }
+    prefix = prefix[0:j]
+    if prefix == "" {
+      break
+    }
+  }
+  return prefix
+}
+
+// Test cases from the LeetCode problem statement
+
+test "example 1" {
+  expect longestCommonPrefix(["flower","flow","flight"]) == "fl"
+}
+
+test "example 2" {
+  expect longestCommonPrefix(["dog","racecar","car"]) == ""
+}
+
+// Additional tests
+
+test "single string" {
+  expect longestCommonPrefix(["single"]) == "single"
+}
+
+test "no common prefix" {
+  expect longestCommonPrefix(["a","b","c"]) == ""
+}


### PR DESCRIPTION
## Summary
- add solution for `longest common prefix` in examples/leetcode/14
- include sample tests from LeetCode and a few extra cases

## Testing
- `go run ./cmd/mochi test examples/leetcode/14/longest-common-prefix.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684c625fb4c083209a56e92f31533fbb