### PR TITLE
Add LeetCode example 32 and doc on common errors

### DIFF
--- a/docs/common-language-errors.md
+++ b/docs/common-language-errors.md
@@ -1,0 +1,29 @@
+# Common Language Errors
+
+Mochi reports helpful diagnostics when code is invalid. Here are a few issues beginners often encounter.
+
+## Reassigning Immutable Bindings
+
+Variables declared with `let` cannot be reassigned. Using `var` allows mutation.
+
+```mochi
+let count = 1
+count = count + 1  // compile-time error
+```
+
+As documented in the [variables guide](features/variables.md), attempting to reassign a `let` binding produces a compile-time error.
+
+## Unhandled Fetch Failures
+
+`fetch` requests raise an error if the request fails or the response cannot be decoded. Wrap calls in `try`/`catch` to handle failures.
+
+```mochi
+try {
+  let data = fetch "https://example.com/api" as map<string, string>
+  print(data)
+} catch err {
+  print("request failed", err)
+}
+```
+
+See the [HTTP fetch docs](features/http-fetch.md) for more details.

--- a/examples/leetcode/32/longest-valid-parentheses.mochi
+++ b/examples/leetcode/32/longest-valid-parentheses.mochi
@@ -1,0 +1,54 @@
+fun longestValidParentheses(s: string): int {
+  let n = len(s)
+  var stack = []
+  var best = 0
+  var last = -1
+  for i in 0..n {
+    let c = s[i]
+    if c == "(" {
+      stack = stack + [i]
+    } else {
+      if len(stack) == 0 {
+        last = i
+      } else {
+        stack = stack[0:len(stack)-1]
+        if len(stack) == 0 {
+          let length = i - last
+          if length > best {
+            best = length
+          }
+        } else {
+          let length = i - stack[len(stack)-1]
+          if length > best {
+            best = length
+          }
+        }
+      }
+    }
+  }
+  return best
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect longestValidParentheses("(()") == 2
+}
+
+test "example 2" {
+  expect longestValidParentheses(")()())") == 4
+}
+
+test "example 3" {
+  expect longestValidParentheses("") == 0
+}
+
+// Additional edge cases
+
+test "all open" {
+  expect longestValidParentheses("(((") == 0
+}
+
+test "balanced" {
+  expect longestValidParentheses("()()") == 4
+}


### PR DESCRIPTION
## Summary
- add solution for LeetCode problem 32
- document a few common language errors and how to fix them

## Testing
- `go run ./cmd/mochi test examples/leetcode/32/longest-valid-parentheses.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684c74184854832094cbd2686047df3e