### PR TITLE
Add combination sum II example and error guide

### DIFF
--- a/docs/guides/common-errors.md
+++ b/docs/guides/common-errors.md
@@ -1,0 +1,11 @@
+## Common Language Errors
+
+The Mochi compiler reports clear diagnostics, but some mistakes come up often when writing code.
+
+- Using `=` instead of `==` inside conditions. `=` performs assignment while `==` checks equality.
+- Forgetting to update loop counters which can lead to infinite loops.
+- Returning the wrong type from a function. Ensure the expression after `return` matches the declared return type.
+- Accessing list elements out of bounds. Check `len(list)` when iterating with numeric indices.
+- Reassigning a `let` binding. Use `var` for mutable values.
+
+Carefully reading error messages usually points to the exact line and expression that needs fixing.

--- a/examples/leetcode/40/combination-sum-ii.mochi
+++ b/examples/leetcode/40/combination-sum-ii.mochi
@@ -1,0 +1,43 @@
+fun combinationSum2(candidates: list<int>, target: int): list<list<int>> {
+  let sorted = from c in candidates sort by c select c
+  var result: list<list<int>> = []
+
+  fun dfs(start: int, remain: int, path: list<int>) {
+    if remain == 0 {
+      result = result + [path]
+      return
+    }
+    var i = start
+    while i < len(sorted) {
+      let val = sorted[i]
+      if val > remain {
+        break
+      }
+      if i > start && val == sorted[i-1] {
+        i = i + 1
+        continue
+      }
+      dfs(i + 1, remain - val, path + [val])
+      i = i + 1
+    }
+  }
+
+  dfs(0, target, [])
+  return result
+}
+
+// Test cases from LeetCode problem 40
+
+test "example 1" {
+  expect combinationSum2([10,1,2,7,6,1,5], 8) == [[1,1,6],[1,2,5],[1,7],[2,6]]
+}
+
+test "example 2" {
+  expect combinationSum2([2,5,2,1,2], 5) == [[1,2,2],[5]]
+}
+
+// Additional tests
+
+test "no solution" {
+  expect combinationSum2([3,4,5], 2) == []
+}


### PR DESCRIPTION
## Summary
- add `combination-sum-ii.mochi` solving LeetCode problem 40 with tests
- document common mistakes in `common-errors.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684c74814d588320926e3284476e0116