### PR TITLE
Add README and Makefile for LeetCode examples

### DIFF
--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -1,0 +1,26 @@
+MOCHI_BIN := $(CURDIR)/bin/mochi
+
+.PHONY: mochi run test clean
+
+mochi:
+	@mkdir -p bin
+	@if [ ! -f $(MOCHI_BIN) ]; then \
+		echo "Downloading Mochi binary..."; \
+		curl -L https://github.com/mochilang/mochi/releases/latest/download/mochi -o $(MOCHI_BIN); \
+		chmod +x $(MOCHI_BIN); \
+	else \
+		echo "Using $(MOCHI_BIN)"; \
+	fi
+
+run: mochi
+	@if [ -z "$(ID)" ]; then \
+		echo "Usage: make run ID=<problem number>"; \
+		exit 1; \
+	fi
+	@$(MOCHI_BIN) run $(ID)/*.mochi
+
+test: mochi
+	@$(MOCHI_BIN) test ./...
+
+clean:
+	@rm -rf bin

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -1,0 +1,69 @@
+# Mochi LeetCode Solutions
+
+This directory contains LeetCode problems implemented in the [Mochi programming language](https://github.com/mochilang/mochi).
+
+## Getting Started
+
+You need the `mochi` CLI to run or test the solutions. Download the latest binary or build from source.
+
+### Download prebuilt binary
+
+```bash
+# from this directory
+make mochi
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/mochilang/mochi
+cd mochi
+make install
+make build
+```
+
+The binary will be installed to `~/bin/mochi`. Ensure that directory is on your `PATH`.
+
+## Running a Solution
+
+Run any problem by its folder number:
+
+```bash
+make run ID=1
+```
+
+or directly with the CLI:
+
+```bash
+mochi run 1/two-sum.mochi
+```
+
+## Running Tests
+
+Some solutions include `test` blocks. Execute all tests with:
+
+```bash
+make test
+```
+
+You can also test a single file:
+
+```bash
+mochi test 30/substring-with-concatenation-of-all-words.mochi
+```
+
+## Downloading Problems
+
+`download.mochi` shows how to fetch a problem statement from LeetCode. Run it with:
+
+```bash
+mochi run download.mochi
+```
+
+## Makefile Targets
+
+- `make mochi` – download the latest Mochi binary into `./bin`
+- `make run ID=<n>` – run problem `n`
+- `make test` – run all tests
+- `make clean` – remove the downloaded binary
+


### PR DESCRIPTION
## Summary
- add a README to explain using Mochi with the LeetCode examples
- add a Makefile with helpers to download the `mochi` binary, run solutions and tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684cc7ee59c08320acc4eeae31cac594