### PR TITLE
Add Mochi solution for LeetCode 58

### DIFF
--- a/examples/leetcode/58/length-of-last-word.mochi
+++ b/examples/leetcode/58/length-of-last-word.mochi
@@ -1,0 +1,41 @@
+// Solution for LeetCode problem 58 - Length of Last Word
+//
+// Common Mochi language errors and fixes:
+// 1. Splitting the string then taking the last element fails when there are
+//    trailing spaces. Iterate from the end instead.
+// 2. Mochi does not support negative indices like s[-1]; use an index variable
+//    and decrement it.
+// 3. Remember to declare mutable variables with 'var'.
+
+fun lengthOfLastWord(s: string): int {
+  var i = len(s) - 1
+  while i >= 0 && s[i] == " " {
+    i = i - 1
+  }
+  var length = 0
+  while i >= 0 && s[i] != " " {
+    length = length + 1
+    i = i - 1
+  }
+  return length
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect lengthOfLastWord("Hello World") == 5
+}
+
+test "example 2" {
+  expect lengthOfLastWord("   fly me   to   the moon  ") == 4
+}
+
+test "example 3" {
+  expect lengthOfLastWord("luffy is still joyboy") == 6
+}
+
+// Additional edge case
+
+test "only spaces" {
+  expect lengthOfLastWord("   ") == 0
+}


### PR DESCRIPTION
## Summary
- implement length-of-last-word in examples/leetcode/58
- document common Mochi mistakes for this problem
- add tests covering normal and edge cases

## Testing
- `mochi test examples/leetcode/58/length-of-last-word.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684ccb5731c08320a5edc3128a664dc5