### PR TITLE
Add LeetCode 64 solution

### DIFF
--- a/examples/leetcode/64/minimum-path-sum.mochi
+++ b/examples/leetcode/64/minimum-path-sum.mochi
@@ -1,0 +1,74 @@
+fun minPathSum(grid: list<list<int>>): int {
+  let rows = len(grid)
+  if rows == 0 {
+    return 0
+  }
+  let cols = len(grid[0])
+  var dp: list<list<int>> = []
+  var r = 0
+  while r < rows {
+    var row: list<int> = []
+    var c = 0
+    while c < cols {
+      row = row + [0]
+      c = c + 1
+    }
+    dp = dp + [row]
+    r = r + 1
+  }
+
+  dp[0][0] = grid[0][0]
+  var c = 1
+  while c < cols {
+    dp[0][c] = dp[0][c-1] + grid[0][c]
+    c = c + 1
+  }
+
+  r = 1
+  while r < rows {
+    dp[r][0] = dp[r-1][0] + grid[r][0]
+    var c = 1
+    while c < cols {
+      let top = dp[r-1][c]
+      let left = dp[r][c-1]
+      if top < left {
+        dp[r][c] = top + grid[r][c]
+      } else {
+        dp[r][c] = left + grid[r][c]
+      }
+      c = c + 1
+    }
+    r = r + 1
+  }
+
+  return dp[rows-1][cols-1]
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect minPathSum([
+    [1,3,1],
+    [1,5,1],
+    [4,2,1],
+  ]) == 7
+}
+
+test "example 2" {
+  expect minPathSum([
+    [1,2,3],
+    [4,5,6],
+  ]) == 12
+}
+
+test "single cell" {
+  expect minPathSum([[1]]) == 1
+}
+
+// Common Mochi language errors and fixes:
+// 1. Trying to allocate a 2D list with Python syntax like `[ [0]*cols ]`.
+//    Mochi does not support that. Use loops to build each row instead.
+// 2. Using `++` or `--` to increment variables causes a parse error.
+//    Write `i = i + 1` or `i = i - 1`.
+// 3. Mixing assignment `=` with equality `==` in conditions.
+//    Use `==` for comparisons inside `if` or `while` statements.


### PR DESCRIPTION
## Summary
- implement solution for LC problem 64 Minimum Path Sum
- include tests and list of common Mochi mistakes

## Testing
- `make -C examples/leetcode test MOCHI_BIN=/root/bin/mochi` *(fails: index out of bounds in existing examples)*

------
https://chatgpt.com/codex/tasks/task_e_684cd0b2de3c8320ae51beabe953550a