### PR TITLE
Add LeetCode 73 example

### DIFF
--- a/examples/leetcode/73/set-matrix-zeroes.mochi
+++ b/examples/leetcode/73/set-matrix-zeroes.mochi
@@ -1,0 +1,77 @@
+fun setZeroes(matrix: list<list<int>>): list<list<int>> {
+  let rows = len(matrix)
+  if rows == 0 {
+    return matrix
+  }
+  let cols = len(matrix[0])
+  var zeroRows: set<int> = {}
+  var zeroCols: set<int> = {}
+  var i = 0
+  while i < rows {
+    var j = 0
+    while j < cols {
+      if matrix[i][j] == 0 {
+        zeroRows.add(i)
+        zeroCols.add(j)
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  i = 0
+  while i < rows {
+    var j = 0
+    while j < cols {
+      if (i in zeroRows) || (j in zeroCols) {
+        matrix[i][j] = 0
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return matrix
+}
+
+// Test cases from LeetCode problem 73
+
+test "example 1" {
+  var m = [
+    [1,1,1],
+    [1,0,1],
+    [1,1,1],
+  ]
+  setZeroes(m)
+  expect m == [
+    [1,0,1],
+    [0,0,0],
+    [1,0,1],
+  ]
+}
+
+test "example 2" {
+  var m = [
+    [0,1,2,0],
+    [3,4,5,2],
+    [1,3,1,5],
+  ]
+  setZeroes(m)
+  expect m == [
+    [0,0,0,0],
+    [0,4,5,0],
+    [0,3,1,0],
+  ]
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using Python-style range loops:
+     for i in range(rows) { ... }   // ERROR
+   Fix: use 'for i in 0..rows { ... }' or a while loop.
+2. Mutating a variable declared with 'let':
+     let j = 0
+     j = j + 1        // error[E004]
+   Fix: declare such variables with 'var'.
+3. Accidentally using '=' instead of '==' in comparisons:
+     if matrix[i][j] = 0 { ... }    // ERROR
+   Use '==' for equality checks.
+*/


### PR DESCRIPTION
## Summary
- add `setZeroes` solution for LeetCode 73
- include tests for the new example
- document common Mochi language mistakes

## Testing
- `make test` *(fails: mochi binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_684cd76b429c8320ae52c04e5f074a28