### PR TITLE
Add LeetCode 78 solution in Mochi

### DIFF
--- a/examples/leetcode/78/subsets.mochi
+++ b/examples/leetcode/78/subsets.mochi
@@ -1,0 +1,37 @@
+fun subsets(nums: list<int>): list<list<int>> {
+  var result: list<list<int>> = [[]]
+  for num in nums {
+    var newSets: list<list<int>> = []
+    for subset in result {
+      newSets = newSets + [subset + [num]]
+    }
+    result = result + newSets
+  }
+  return result
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect subsets([1,2,3]) == [
+    [], [1], [2], [1,2], [3], [1,3], [2,3], [1,2,3]
+  ]
+}
+
+test "example 2" {
+  expect subsets([0]) == [[], [0]]
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' for comparison:
+     if len(nums) = 0 { ... }    // ❌ assignment, not comparison
+   Use '==' to compare values.
+2. Reassigning an immutable binding created with 'let':
+     let res = []
+     res = res + [x]             // ❌ cannot modify 'let'
+   Declare with 'var' when mutation is needed.
+3. Attempting Python-style 'append' method on lists:
+     result.append([num])        // ❌ method does not exist
+   Use list concatenation 'result = result + [value]'.
+*/


### PR DESCRIPTION
## Summary
- implement Subsets problem solution
- include sample tests and common Mochi mistakes

## Testing
- `make test` *(fails: `/workspace/mochi/examples/leetcode/bin/mochi: 1: Not: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684cd7c5e8b08320aba244e810a9e96d