### PR TITLE
Fix leetcode Makefile

### DIFF
--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -1,15 +1,39 @@
 MOCHI_BIN := $(CURDIR)/bin/mochi
 
+# Detect OS/ARCH for downloading the correct release asset
+OS  := $(shell uname -s)
+ARCH := $(shell uname -m)
+
+# Normalize values used in Mochi release names
+ifeq ($(OS),Darwin)
+OS := Darwin
+else
+OS := Linux
+endif
+
+ifeq ($(ARCH),x86_64)
+ARCH := x86_64
+else ifeq ($(ARCH),aarch64)
+ARCH := arm64
+else ifeq ($(ARCH),arm64)
+ARCH := arm64
+endif
+
+MOCHI_TAR := mochi_$(OS)_$(ARCH).tar.gz
+MOCHI_URL := https://github.com/mochilang/mochi/releases/latest/download/$(MOCHI_TAR)
+
 .PHONY: mochi run test clean
 
 mochi:
 	@mkdir -p bin
 	@if [ ! -f $(MOCHI_BIN) ]; then \
-		echo "Downloading Mochi binary..."; \
-		curl -L https://github.com/mochilang/mochi/releases/latest/download/mochi -o $(MOCHI_BIN); \
-		chmod +x $(MOCHI_BIN); \
+	echo "Downloading Mochi binary for $(OS)/$(ARCH)..."; \
+	curl -L $(MOCHI_URL) -o bin/$(MOCHI_TAR); \
+	tar -xzf bin/$(MOCHI_TAR) -C bin; \
+	rm -f bin/$(MOCHI_TAR); \
+	chmod +x $(MOCHI_BIN); \
 	else \
-		echo "Using $(MOCHI_BIN)"; \
+	echo "Using $(MOCHI_BIN)"; \
 	fi
 
 run: mochi
@@ -20,7 +44,7 @@ run: mochi
 	@$(MOCHI_BIN) run $(ID)/*.mochi
 
 test: mochi
-	@$(MOCHI_BIN) test ./...
+	@find . -name '*.mochi' -print0 | xargs -0 -n1 $(MOCHI_BIN) test
 
 clean:
 	@rm -rf bin


### PR DESCRIPTION
## Summary
- fix Makefile for examples/leetcode
- download correct binary based on OS/ARCH
- run tests via find/xargs

## Testing
- `go test ./...`
- `make mochi` (in examples/leetcode)
- `make run ID=1` (in examples/leetcode)
- `make test` (fails due to tests, but command runs)

------
https://chatgpt.com/codex/tasks/task_e_684cd57a0cc08320a98ef0396ef3ba18