### PR TITLE
Add LeetCode 77 example

### DIFF
--- a/examples/leetcode/77/combinations.mochi
+++ b/examples/leetcode/77/combinations.mochi
@@ -1,0 +1,43 @@
+fun combine(n: int, k: int): list<list<int>> {
+  var result: list<list<int>> = []
+
+  fun backtrack(start: int, path: list<int>) {
+    if len(path) == k {
+      result = result + [path]
+      return
+    }
+    var i = start
+    while i <= n {
+      backtrack(i + 1, path + [i])
+      i = i + 1
+    }
+  }
+
+  backtrack(1, [])
+  return result
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect combine(4, 2) == [[1,2], [1,3], [1,4], [2,3], [2,4], [3,4]]
+}
+
+test "example 2" {
+  expect combine(1, 1) == [[1]]
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Forgetting to declare a variable as `var` when you intend to modify it.
+   let i = 0
+   i = i + 1        // ❌ cannot reassign immutable binding
+   var i = 0
+   i = i + 1        // ✅ use var for mutable variables
+2. Mixing Python-style `range` with Mochi loops.
+   for i in range(n) { }  // ❌ invalid syntax
+   for i in 0..n { }      // ✅ Mochi range syntax
+3. Using '=' instead of '==' for equality checks.
+   if len(path) = k { }   // ❌ assignment, not comparison
+   if len(path) == k { }  // ✅ correct comparison
+*/


### PR DESCRIPTION
## Summary
- add Mochi solution for LeetCode 77

## Testing
- `~/bin/mochi test examples/leetcode/77/combinations.mochi` *(fails: parse error)*

------
https://chatgpt.com/codex/tasks/task_e_684cd7b7603c8320987b000d6394a480