### PR TITLE
Add release notes for v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # 📦 CHANGELOG.md
+## [0.7.2] – 2025-06-14
+
+### Added
+
+* LeetCode solutions 1–100 with Makefile and Sudoku example
+* `mochi test` now accepts directories with `...`
+* Documentation on common language errors
+
 ## [0.7.1] – 2025-06-13
 
 ### Added

--- a/releases/v0.7.2.md
+++ b/releases/v0.7.2.md
@@ -1,0 +1,16 @@
+# Jun 2025 (v0.7.2)
+
+Mochi v0.7.2 expands the example library and improves the testing workflow.
+
+## CLI
+
+- `mochi test` accepts directories and the `...` wildcard for recursive tests
+
+## Example Library
+
+- Added solutions for LeetCode problems 1–100 with a helper Makefile
+- Sudoku solver showcases backtracking (problem 37)
+
+## Documentation
+
+- Added "Common Language Errors" troubleshooting guide


### PR DESCRIPTION
## Summary
- document v0.7.2 changes in CHANGELOG
- add release notes describing new CLI features, examples and docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684cfaad8a6883208e46cffdc43d2f73