### PR TITLE
Fix leetcode examples 5 and 6

### DIFF
--- a/examples/leetcode/5/longest-palindromic-substring.mochi
+++ b/examples/leetcode/5/longest-palindromic-substring.mochi
@@ -2,7 +2,10 @@ fun expand(s: string, left: int, right: int): int {
   var l = left
   var r = right
   let n = len(s)
-  while l >= 0 && r < n && s[l] == s[r] {
+  while l >= 0 && r < n {
+    if s[l] != s[r] {
+      break
+    }
     l = l - 1
     r = r + 1
   }

--- a/examples/leetcode/6/zigzag-conversion.mochi
+++ b/examples/leetcode/6/zigzag-conversion.mochi
@@ -4,8 +4,10 @@ fun convert(s: string, numRows: int): string {
   }
 
   var rows = []
-  for i in 0..numRows {
+  var i = 0
+  while i < numRows {
     rows = rows + [""]
+    i = i + 1
   }
 
   var curr = 0


### PR DESCRIPTION
## Summary
- fix index check in longest-palindromic-substring
- initialize rows using while-loop in zigzag-conversion

## Testing
- `go run ./cmd/mochi test examples/leetcode/5/longest-palindromic-substring.mochi`
- `go run ./cmd/mochi test examples/leetcode/6/zigzag-conversion.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684d00dc67e48320a9e4e5ea4bec7a5d