### PR TITLE
Fix 3sum-closest example

### DIFF
--- a/examples/leetcode/16/3sum-closest.mochi
+++ b/examples/leetcode/16/3sum-closest.mochi
@@ -14,8 +14,18 @@ fun threeSumClosest(nums: list<int>, target: int): int {
       if sum == target {
         return target
       }
-      let diff = if sum > target { sum - target } else { target - sum }
-      let bestDiff = if best > target { best - target } else { target - best }
+      var diff = 0
+      if sum > target {
+        diff = sum - target
+      } else {
+        diff = target - sum
+      }
+      var bestDiff = 0
+      if best > target {
+        bestDiff = best - target
+      } else {
+        bestDiff = target - best
+      }
       if diff < bestDiff {
         best = sum
       }


### PR DESCRIPTION
## Summary
- update examples/leetcode/16/3sum-closest.mochi to avoid unsupported inline `if` expression
- ensure tests pass for examples 11–20

## Testing
- `~/bin/mochi test examples/leetcode/16`
- `for i in {11..20}; do ~/bin/mochi test examples/leetcode/$i; done`

------
https://chatgpt.com/codex/tasks/task_e_684d02dc75b0832095bffb2a45eef552