### PR TITLE
Fix leetcode examples 31-40

### DIFF
--- a/examples/leetcode/33/search-in-rotated-sorted-array.mochi
+++ b/examples/leetcode/33/search-in-rotated-sorted-array.mochi
@@ -30,11 +30,11 @@ test "example 1" {
 }
 
 test "example 2" {
-  expect search([4,5,6,7,0,1,2], 3) == -1
+  expect search([4,5,6,7,0,1,2], 3) == (-1)
 }
 
 test "example 3" {
-  expect search([1], 0) == -1
+  expect search([1], 0) == (-1)
 }
 
 // Additional edge cases

--- a/examples/leetcode/34/find-first-and-last-position-of-element-in-sorted-array.mochi
+++ b/examples/leetcode/34/find-first-and-last-position-of-element-in-sorted-array.mochi
@@ -20,7 +20,7 @@ fun searchRange(nums: list<int>, target: int): list<int> {
     }
   }
 
-  if start == -1 {
+  if start == (-1) {
     return [-1, -1]
   }
 

--- a/examples/leetcode/37/sudoku-solver.mochi
+++ b/examples/leetcode/37/sudoku-solver.mochi
@@ -1,4 +1,4 @@
-fun solveSudoku(board: list<list<string>>) {
+fun solveSudoku(board: list<list<string>>): list<list<string>> {
   fun isValid(row: int, col: int, ch: string): bool {
     for i in 0..9 {
       if board[row][i] == ch {
@@ -39,6 +39,7 @@ fun solveSudoku(board: list<list<string>>) {
   }
 
   dfs(0, 0)
+  return board
 }
 
 // LeetCode example board
@@ -54,7 +55,7 @@ let board = [
   [".",".",".",".","8",".",".","7","9"],
 ]
 
-solveSudoku(board)
+let board = solveSudoku(board)
 
 // Expected solved board
 let solved = [

--- a/examples/leetcode/39/combination-sum.mochi
+++ b/examples/leetcode/39/combination-sum.mochi
@@ -5,17 +5,17 @@ fun combinationSum(candidates: list<int>, target: int): list<list<int>> {
   fun backtrack(remain: int, start: int, path: list<int>) {
     if remain == 0 {
       result = result + [path]
-      return
-    }
-    var i = start
-    let n = len(sorted)
-    while i < n {
-      let current = sorted[i]
-      if current > remain {
-        break
+    } else {
+      var i = start
+      let n = len(sorted)
+      while i < n {
+        let current = sorted[i]
+        if current > remain {
+          break
+        }
+        backtrack(remain - current, i, path + [current])
+        i = i + 1
       }
-      backtrack(remain - current, i, path + [current])
-      i = i + 1
     }
   }
 

--- a/examples/leetcode/40/combination-sum-ii.mochi
+++ b/examples/leetcode/40/combination-sum-ii.mochi
@@ -6,20 +6,20 @@ fun combinationSum2(candidates: list<int>, target: int): list<list<int>> {
   fun backtrack(remain: int, start: int, path: list<int>) {
     if remain == 0 {
       result = result + [path]
-      return
-    }
-    var i = start
-    while i < n {
-      let current = arr[i]
-      if current > remain {
-        break
-      }
-      if i > start && arr[i] == arr[i-1] {
+    } else {
+      var i = start
+      while i < n {
+        let current = arr[i]
+        if current > remain {
+          break
+        }
+        if i > start && arr[i] == arr[i-1] {
+          i = i + 1
+          continue
+        }
+        backtrack(remain - current, i + 1, path + [current])
         i = i + 1
-        continue
       }
-      backtrack(remain - current, i + 1, path + [current])
-      i = i + 1
     }
   }
 


### PR DESCRIPTION
## Summary
- fix negative literal parsing in tests
- update search range check in problem 34
- return solved board in sudoku solver example
- avoid bare `return` in combination-sum solutions

## Testing
- `./bin/mochi test 31/next-permutation.mochi`
- `./bin/mochi test 32/longest-valid-parentheses.mochi`
- `./bin/mochi test 33/search-in-rotated-sorted-array.mochi`
- `./bin/mochi test 34/find-first-and-last-position-of-element-in-sorted-array.mochi`
- `./bin/mochi test 35/search-insert-position.mochi`
- `./bin/mochi test 36/valid-sudoku.mochi`
- `./bin/mochi test 37/sudoku-solver.mochi`
- `./bin/mochi test 38/count-and-say.mochi`
- `./bin/mochi test 39/combination-sum.mochi`
- `./bin/mochi test 40/combination-sum-ii.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684d076047508320a813e2e49b33c78a