### PR TITLE
Fix LeetCode examples 41-50

### DIFF
--- a/examples/leetcode/41/first-missing-positive.mochi
+++ b/examples/leetcode/41/first-missing-positive.mochi
@@ -1,9 +1,12 @@
 fun firstMissingPositive(nums: list<int>): int {
-  // Approach: place numbers into a set then find the smallest missing
-  var seen: set<int> = {}
+  // Approach: record all positive numbers in a map acting as a set.
+  // The language version bundled with these examples does not
+  // support the `set` type used in some documentation, so we simply
+  // use a map from int to bool for membership checks.
+  var seen: map<int, bool> = {}
   for n in nums {
     if n > 0 {
-      seen.add(n)
+      seen[n] = true
     }
   }
   var i = 1

--- a/examples/leetcode/43/multiply-strings.mochi
+++ b/examples/leetcode/43/multiply-strings.mochi
@@ -20,11 +20,9 @@ fun multiply(num1: string, num2: string): string {
 
   let m = len(num1)
   let n = len(num2)
-  // result can have at most m + n digits
-  var result: list<int> = []
-  for _ in 0..m+n {
-    result = result + [0]
-  }
+  // Use a map of digit position -> value to avoid list concatenation
+  // operations which are not supported in older Mochi binaries.
+  var result: map<int, int> = {}
 
   var i = m
   while i > 0 {
@@ -34,16 +32,30 @@ fun multiply(num1: string, num2: string): string {
     while j > 0 {
       j = j - 1
       let d2 = digits[num2[j]]
-      let sum = d1 * d2 + result[i+j+1]
-      result[i+j+1] = sum % 10
-      result[i+j] = result[i+j] + sum / 10
+      let idx1 = i + j + 1
+      var existing = 0
+      if idx1 in result {
+        existing = result[idx1]
+      }
+      let sum = d1 * d2 + existing
+      result[idx1] = sum % 10
+      let carry = sum / 10
+      let idx0 = i + j
+      var prev = 0
+      if idx0 in result {
+        prev = result[idx0]
+      }
+      result[idx0] = prev + carry
     }
   }
 
   var out = ""
   var k = 0
-  while k < len(result) {
-    let digit = result[k]
+  while k < m + n {
+    var digit = 0
+    if k in result {
+      digit = result[k]
+    }
     if out == "" && digit == 0 {
       // skip leading zeros
     } else {

--- a/examples/leetcode/49/group-anagrams.mochi
+++ b/examples/leetcode/49/group-anagrams.mochi
@@ -2,7 +2,14 @@ fun groupAnagrams(strs: list<string>): list<list<string>> {
   var index: map<string, int> = {}
   var groups: list<list<string>> = []
   for word in strs {
-    let chars = from ch in word sort by ch select ch
+    // Build a list of characters because query sources must be lists.
+    var letters: list<string> = []
+    var i = 0
+    while i < len(word) {
+      letters = letters + [word[i]]
+      i = i + 1
+    }
+    let chars = from ch in letters sort by ch select ch
     var key = ""
     for ch in chars {
       key = key + ch
@@ -22,9 +29,8 @@ fun groupAnagrams(strs: list<string>): list<list<string>> {
 
 test "example 1" {
   let res = groupAnagrams(["eat","tea","tan","ate","nat","bat"])
-  let normalize = fun(g: list<string>): list<string> {
-    return from x in g sort by x select x
-  }
+  let normalize = fun(g: list<string>): list<string> =>
+    from x in g sort by x select x
   let sorted = from g in res select normalize(g)
   let final = from g in sorted sort by g[0] select g
   let expected = [["ate","eat","tea"],["bat"],["nat","tan"]]


### PR DESCRIPTION
## Summary
- update `first-missing-positive` to use a map instead of a set
- rewrite `multiply-strings` without relying on list concatenation
- fix `group-anagrams` function syntax and character handling

## Testing
- `for i in 41 42 43 44 45 46 47 48 49 50; do echo "Testing $i"; examples/leetcode/bin/mochi test examples/leetcode/$i/*; done`

------
https://chatgpt.com/codex/tasks/task_e_684d0772033c8320a7d14f4812f9533e