### PR TITLE
Fix LeetCode examples 61-70

### DIFF
--- a/examples/leetcode/61/rotate-list.mochi
+++ b/examples/leetcode/61/rotate-list.mochi
@@ -7,8 +7,16 @@ fun rotateRight(nums: list<int>, k: int): list<int> {
   if r == 0 {
     return nums
   }
-  let start = n - r
-  return nums[start:n] + nums[0:start]
+
+  // build the rotated list element by element to avoid list concatenation
+  var result: list<int> = []
+  var i = 0
+  while i < n {
+    let idx = (n - r + i) % n
+    result = result + [nums[idx]]
+    i = i + 1
+  }
+  return result
 }
 
 // Test cases based on LeetCode #61: Rotate List

--- a/examples/leetcode/65/valid-number.mochi
+++ b/examples/leetcode/65/valid-number.mochi
@@ -6,8 +6,12 @@ fun isNumber(s: string): bool {
   var i = 0
   let n = len(s)
   // skip leading spaces
-  while i < n && s[i] == " " {
-    i = i + 1
+  while i < n {
+    if s[i] == " " {
+      i = i + 1
+    } else {
+      break
+    }
   }
 
   // optional sign
@@ -34,14 +38,16 @@ fun isNumber(s: string): bool {
       }
       dot = true
     } else if c == "e" || c == "E" {
-      if exp || !num {
+      if exp || (!num) {
         return false
       }
       exp = true
       numAfterExp = false
       // check sign after exponent
-      if i + 1 < n && (s[i+1] == "+" || s[i+1] == "-") {
-        i = i + 1
+      if i + 1 < n {
+        if s[i+1] == "+" || s[i+1] == "-" {
+          i = i + 1
+        }
       }
     } else {
       // check digit
@@ -69,8 +75,12 @@ fun isNumber(s: string): bool {
   }
 
   // skip trailing spaces
-  while i < n && s[i] == " " {
-    i = i + 1
+  while i < n {
+    if s[i] == " " {
+      i = i + 1
+    } else {
+      break
+    }
   }
 
   return num && (!exp || numAfterExp) && i == n

--- a/examples/leetcode/68/text-justification.mochi
+++ b/examples/leetcode/68/text-justification.mochi
@@ -5,9 +5,13 @@ fun fullJustify(words: list<string>, maxWidth: int): list<string> {
     var j = i
     var lineLen = 0
     // find how many words fit into the current line
-    while j < len(words) && lineLen + len(words[j]) + (j - i) <= maxWidth {
-      lineLen = lineLen + len(words[j])
-      j = j + 1
+    while j < len(words) {
+      if lineLen + len(words[j]) + (j - i) <= maxWidth {
+        lineLen = lineLen + len(words[j])
+        j = j + 1
+      } else {
+        break
+      }
     }
 
     var line = ""
@@ -77,10 +81,10 @@ test "example 3" {
   let words = ["Science","is","what","we","understand","well","enough","to","explain","to","a","computer.","Art","is","everything","else","we","do"]
   expect fullJustify(words, 20) == [
     "Science  is  what we",
-    "understand   well",
+    "understand      well",
     "enough to explain to",
-    "a computer.  Art is",
-    "everything else  we",
+    "a  computer.  Art is",
+    "everything  else  we",
     "do                  "
   ]
 }


### PR DESCRIPTION
## Summary
- fix rotate-list to avoid unsupported list concatenation
- handle whitespace loops correctly in valid-number
- avoid index errors in text-justification and update expected output

## Testing
- `~/bin/mochi test examples/leetcode/61/rotate-list.mochi`
- `~/bin/mochi test examples/leetcode/62/unique-paths.mochi`
- `~/bin/mochi test examples/leetcode/63/unique-paths-ii.mochi`
- `~/bin/mochi test examples/leetcode/64/minimum-path-sum.mochi`
- `~/bin/mochi test examples/leetcode/65/valid-number.mochi`
- `~/bin/mochi test examples/leetcode/66/plus-one.mochi`
- `~/bin/mochi test examples/leetcode/67/add-binary.mochi`
- `~/bin/mochi test examples/leetcode/68/text-justification.mochi`
- `~/bin/mochi test examples/leetcode/69/sqrtx.mochi`
- `~/bin/mochi test examples/leetcode/70/climbing-stairs.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684d0d38eef88320a14f1c1e0998bfc0