### PR TITLE
Fix LeetCode examples 71-80

### DIFF
--- a/examples/leetcode/71/simplify-path.mochi
+++ b/examples/leetcode/71/simplify-path.mochi
@@ -5,7 +5,16 @@ fun simplifyPath(path: string): string {
   let n = len(path)
 
   while i <= n {
-    if i == n || path[i] == '/' {
+    if i == n {
+      if part == ".." {
+        if len(stack) > 0 {
+          stack = stack[0:len(stack)-1]
+        }
+      } else if part != "" && part != "." {
+        stack = stack + [part]
+      }
+      part = ""
+    } else if path[i] == "/" {
       if part == ".." {
         if len(stack) > 0 {
           stack = stack[0:len(stack)-1]

--- a/examples/leetcode/73/set-matrix-zeroes.mochi
+++ b/examples/leetcode/73/set-matrix-zeroes.mochi
@@ -4,15 +4,25 @@ fun setZeroes(matrix: list<list<int>>): list<list<int>> {
     return matrix
   }
   let cols = len(matrix[0])
-  var zeroRows: set<int> = {}
-  var zeroCols: set<int> = {}
+  var zeroRows: list<bool> = []
+  var zeroCols: list<bool> = []
+  var r = 0
+  while r < rows {
+    zeroRows = zeroRows + [false]
+    r = r + 1
+  }
+  var c = 0
+  while c < cols {
+    zeroCols = zeroCols + [false]
+    c = c + 1
+  }
   var i = 0
   while i < rows {
     var j = 0
     while j < cols {
       if matrix[i][j] == 0 {
-        zeroRows.add(i)
-        zeroCols.add(j)
+        zeroRows[i] = true
+        zeroCols[j] = true
       }
       j = j + 1
     }
@@ -22,7 +32,7 @@ fun setZeroes(matrix: list<list<int>>): list<list<int>> {
   while i < rows {
     var j = 0
     while j < cols {
-      if (i in zeroRows) || (j in zeroCols) {
+      if zeroRows[i] || zeroCols[j] {
         matrix[i][j] = 0
       }
       j = j + 1

--- a/examples/leetcode/77/combinations.mochi
+++ b/examples/leetcode/77/combinations.mochi
@@ -4,12 +4,12 @@ fun combine(n: int, k: int): list<list<int>> {
   fun backtrack(start: int, path: list<int>) {
     if len(path) == k {
       result = result + [path]
-      return
-    }
-    var i = start
-    while i <= n {
-      backtrack(i + 1, path + [i])
-      i = i + 1
+    } else {
+      var i = start
+      while i <= n {
+        backtrack(i + 1, path + [i])
+        i = i + 1
+      }
     }
   }
 
@@ -21,7 +21,7 @@ fun combine(n: int, k: int): list<list<int>> {
 
 test "example 1" {
   expect combine(4, 2) == [
-    [1,2],[1,3],[1,4],[2,3],[2,4],[3,4]
+    [1,2], [1,3], [1,4], [2,3], [2,4], [3,4]
   ]
 }
 

--- a/examples/leetcode/78/subsets.mochi
+++ b/examples/leetcode/78/subsets.mochi
@@ -2,10 +2,17 @@ fun subsets(nums: list<int>): list<list<int>> {
   var result: list<list<int>> = [[]]
   for num in nums {
     var newSets: list<list<int>> = []
-    for subset in result {
+    var i = 0
+    while i < len(result) {
+      let subset = result[i]
       newSets = newSets + [subset + [num]]
+      i = i + 1
     }
-    result = result + newSets
+    var j = 0
+    while j < len(newSets) {
+      result = result + [newSets[j]]
+      j = j + 1
+    }
   }
   return result
 }

--- a/examples/leetcode/79/word-search.mochi
+++ b/examples/leetcode/79/word-search.mochi
@@ -5,12 +5,16 @@ fun exist(board: list<list<string>>, word: string): bool {
   }
   let n = len(board[0])
   var visited: list<list<bool>> = []
-  for _ in 0..m {
+  var r = 0
+  while r < m {
     var row: list<bool> = []
-    for _ in 0..n {
+    var c = 0
+    while c < n {
       row = row + [false]
+      c = c + 1
     }
     visited = visited + [row]
+    r = r + 1
   }
 
   fun dfs(r: int, c: int, idx: int): bool {


### PR DESCRIPTION
## Summary
- fix out of bounds in `simplify-path`
- use boolean arrays instead of sets in `set-matrix-zeroes`
- rewrite recursion exit logic in `combinations`
- adjust subset generation algorithm
- initialize visited grid with loops in `word-search`

## Testing
- `./bin/mochi test 71/simplify-path.mochi`
- `./bin/mochi test 72/edit-distance.mochi`
- `./bin/mochi test 73/set-matrix-zeroes.mochi`
- `./bin/mochi test 74/search-a-2d-matrix.mochi`
- `./bin/mochi test 75/sort-colors.mochi`
- `./bin/mochi test 76/minimum-window-substring.mochi`
- `./bin/mochi test 77/combinations.mochi`
- `./bin/mochi test 78/subsets.mochi`
- `./bin/mochi test 79/word-search.mochi`
- `./bin/mochi test 80/remove-duplicates-from-sorted-array-ii.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684d0d48b6548320afb6bd737e461aa2