### PR TITLE
Fix histogram bounds check

### DIFF
--- a/examples/leetcode/84/largest-rectangle-in-histogram.mochi
+++ b/examples/leetcode/84/largest-rectangle-in-histogram.mochi
@@ -10,16 +10,20 @@ fun largestRectangleArea(heights: list<int>): int {
   var maxArea = 0
   var i = 0
   while i < n {
-    while len(stack) > 0 && heights[i] < heights[stack[len(stack)-1]] {
-      let h = heights[stack[len(stack)-1]]
-      stack = stack[0:len(stack)-1]
-      var width = i
-      if len(stack) > 0 {
-        width = i - stack[len(stack)-1] - 1
-      }
-      let area = h * width
-      if area > maxArea {
-        maxArea = area
+    while len(stack) > 0 {
+      if heights[i] < heights[stack[len(stack)-1]] {
+        let h = heights[stack[len(stack)-1]]
+        stack = stack[0:len(stack)-1]
+        var width = i
+        if len(stack) > 0 {
+          width = i - stack[len(stack)-1] - 1
+        }
+        let area = h * width
+        if area > maxArea {
+          maxArea = area
+        }
+      } else {
+        break
       }
     }
     stack = stack + [i]


### PR DESCRIPTION
## Summary
- prevent invalid stack index in LeetCode 84 example

## Testing
- `examples/leetcode/bin/mochi test examples/leetcode/84/largest-rectangle-in-histogram.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684d0d5a026c83208a20fcea2ceaa5d3