### PR TITLE
Fix parse errors in leetcode examples

### DIFF
--- a/examples/leetcode/100/same-tree.mochi
+++ b/examples/leetcode/100/same-tree.mochi
@@ -1,3 +1,7 @@
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
 fun isSameTree(p: Tree, q: Tree): bool {
   return match p {
     Leaf => match q {
@@ -10,14 +14,6 @@ fun isSameTree(p: Tree, q: Tree): bool {
     }
   }
 }
-
-// Definition of a binary tree
-// Leaf represents an empty tree
-// Node has left, value, and right subtrees
-
-type Tree =
-  Leaf
-  | Node(left: Tree, value: int, right: Tree)
 
 // Test cases from LeetCode
 

--- a/examples/leetcode/85/maximal-rectangle.mochi
+++ b/examples/leetcode/85/maximal-rectangle.mochi
@@ -16,7 +16,10 @@ fun maximalRectangle(matrix: list<list<string>>): int {
     let n = len(hs)
     var maxArea = 0
     while i <= n {
-      let curr = if i == n { 0 } else { hs[i] }
+      var curr = 0
+      if i < n {
+        curr = hs[i]
+      }
       while len(stack) > 0 && curr < hs[stack[len(stack)-1]] {
         let h = hs[stack[len(stack)-1]]
         stack = stack[0:len(stack)-1]


### PR DESCRIPTION
## Summary
- fix variable initialization in `85/maximal-rectangle.mochi`
- move tree type definition before usage in `100/same-tree.mochi`

## Testing
- `make test` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_684d239d73808320b562505539ccaf70