### PR TITLE
Add basic Datalog logic programming

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -7,6 +7,7 @@ This section outlines each major feature of the Mochi programming language. Each
 - [Functions](functions.md) explains named and anonymous functions plus recursion.
 - [Collections](collections.md) details built-in lists, maps and sets.
 - [Dataset Queries](datasets.md) shows SQL-like queries over lists and loading files.
+- [Logic Programming](logic-programming.md) demonstrates Datalog-style facts and rules.
 - [Tests](tests.md) shows the lightweight test framework.
 - [Generative AI](generative-ai.md) demonstrates calling large language models.
 - [HTTP Fetch](http-fetch.md) describes retrieving JSON over the network.

--- a/docs/features/logic-programming.md
+++ b/docs/features/logic-programming.md
@@ -1,0 +1,31 @@
+## Logic Programming
+
+Mochi includes a tiny Datalog-style engine for expressing and querying facts.
+Facts and rules are declared with the `fact` and `rule` keywords and queried using `query`.
+
+```mochi
+fact parent("Alice", "Bob")
+fact parent("Alice", "Carol")
+fact parent("Bob", "David")
+fact parent("Carol", "Eva")
+
+rule grandparent(x, z):-
+  parent(x, y), parent(y, z)
+
+rule sibling(x, y):-
+  parent(p, x), parent(p, y), x != y
+
+let grandparents = query grandparent(x, z)
+print("Grandparents:")
+for g in grandparents {
+  print(g.x, "is grandparent of", g.z)
+}
+
+let siblings = query sibling(x, y)
+print("Siblings:")
+for s in siblings {
+  print(s.x, "<->", s.y)
+}
+```
+
+Queries return a list of objects keyed by variable name.

--- a/runtime/logic/datalog.go
+++ b/runtime/logic/datalog.go
@@ -1,0 +1,175 @@
+package logic
+
+// Package logic provides a tiny Datalog-style engine used by the interpreter.
+
+// Term represents either a variable or constant value.
+type Term struct {
+	Var   string
+	Val   any
+	IsVar bool
+}
+
+type Predicate struct {
+	Name string
+	Args []Term
+}
+
+type Rule struct {
+	Head Predicate
+	Body []Condition
+}
+
+type Condition struct {
+	Pred *Predicate
+	Neq  *NotEqual
+}
+
+type NotEqual struct {
+	A string
+	B string
+}
+
+// Engine stores facts and rules.
+type Engine struct {
+	Facts map[string][][]any
+	Rules []Rule
+}
+
+func NewEngine() *Engine {
+	return &Engine{Facts: map[string][][]any{}, Rules: []Rule{}}
+}
+
+// AddFact adds a fact to the engine.
+func (e *Engine) AddFact(p Predicate) {
+	tuple := make([]any, len(p.Args))
+	for i, a := range p.Args {
+		if a.IsVar {
+			// variables aren't allowed in facts
+			return
+		}
+		tuple[i] = a.Val
+	}
+	e.Facts[p.Name] = append(e.Facts[p.Name], tuple)
+}
+
+// AddRule registers a rule.
+func (e *Engine) AddRule(r Rule) { e.Rules = append(e.Rules, r) }
+
+// Query derives all rules then returns matches for predicate.
+func (e *Engine) Query(q Predicate) []map[string]any {
+	e.derive()
+	results := []map[string]any{}
+	tuples := e.Facts[q.Name]
+	for _, tup := range tuples {
+		env, ok := unify(q, tup, map[string]any{})
+		if !ok {
+			continue
+		}
+		res := map[string]any{}
+		for _, a := range q.Args {
+			if a.IsVar {
+				res[a.Var] = env[a.Var]
+			}
+		}
+		results = append(results, res)
+	}
+	return results
+}
+
+func (e *Engine) derive() {
+	changed := true
+	for changed {
+		changed = false
+		for _, r := range e.Rules {
+			tuples := applyRule(r, e.Facts)
+			for _, t := range tuples {
+				if !containsTuple(e.Facts[r.Head.Name], t) {
+					e.Facts[r.Head.Name] = append(e.Facts[r.Head.Name], t)
+					changed = true
+				}
+			}
+		}
+	}
+}
+
+func applyRule(r Rule, facts map[string][][]any) [][]any {
+	var results [][]any
+	var backtrack func(int, map[string]any)
+	backtrack = func(i int, env map[string]any) {
+		if i == len(r.Body) {
+			tup := make([]any, len(r.Head.Args))
+			for j, a := range r.Head.Args {
+				if a.IsVar {
+					tup[j] = env[a.Var]
+				} else {
+					tup[j] = a.Val
+				}
+			}
+			results = append(results, tup)
+			return
+		}
+		cond := r.Body[i]
+		if cond.Neq != nil {
+			if env[cond.Neq.A] != env[cond.Neq.B] {
+				backtrack(i+1, env)
+			}
+			return
+		}
+		pred := cond.Pred
+		for _, tup := range facts[pred.Name] {
+			newEnv, ok := unify(*pred, tup, env)
+			if !ok {
+				continue
+			}
+			backtrack(i+1, newEnv)
+		}
+	}
+	backtrack(0, map[string]any{})
+	return results
+}
+
+func unify(pred Predicate, tuple []any, env map[string]any) (map[string]any, bool) {
+	if len(tuple) < len(pred.Args) {
+		return nil, false
+	}
+	newEnv := map[string]any{}
+	for k, v := range env {
+		newEnv[k] = v
+	}
+	for i, a := range pred.Args {
+		val := tuple[i]
+		if a.IsVar {
+			if bound, ok := newEnv[a.Var]; ok {
+				if bound != val {
+					return nil, false
+				}
+			} else {
+				newEnv[a.Var] = val
+			}
+		} else {
+			if a.Val != val {
+				return nil, false
+			}
+		}
+	}
+	return newEnv, true
+}
+
+func containsTuple(list [][]any, t []any) bool {
+	for _, x := range list {
+		if len(x) != len(t) {
+			continue
+		}
+		match := true
+		for i := range x {
+			if x[i] != t[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/interpreter/valid/datalog.mochi
+++ b/tests/interpreter/valid/datalog.mochi
@@ -1,0 +1,22 @@
+fact parent("Alice", "Bob")
+fact parent("Alice", "Carol")
+fact parent("Bob", "David")
+fact parent("Carol", "Eva")
+
+rule grandparent(x, z):-
+  parent(x, y), parent(y, z)
+
+rule sibling(x, y):-
+  parent(p, x), parent(p, y), x != y
+
+let grandparents = query grandparent(x, z)
+print("Grandparents:")
+for g in grandparents {
+  print(g.x, "is grandparent of", g.z)
+}
+
+let siblings = query sibling(x, y)
+print("Siblings:")
+for s in siblings {
+  print(s.x, "<->", s.y)
+}

--- a/tests/interpreter/valid/datalog.out
+++ b/tests/interpreter/valid/datalog.out
@@ -1,0 +1,6 @@
+Grandparents:
+Alice is grandparent of David
+Alice is grandparent of Eva
+Siblings:
+Bob <-> Carol
+Carol <-> Bob

--- a/types/check.go
+++ b/types/check.go
@@ -568,6 +568,12 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type) error {
 		env.SetVar(s.ExternFun.Name(), FuncType{Params: params, Return: ret}, false)
 		return nil
 
+	case s.Fact != nil:
+		return nil
+
+	case s.Rule != nil:
+		return nil
+
 	case s.Assign != nil:
 		rhsType, err := checkExprWithExpected(s.Assign.Value, env, nil)
 		if err != nil {
@@ -1354,6 +1360,9 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 
 	case p.Query != nil:
 		return checkQueryExpr(p.Query, env, expected)
+
+	case p.LogicQuery != nil:
+		return ListType{Elem: MapType{Key: StringType{}, Value: AnyType{}}}, nil
 
 	case p.Fetch != nil:
 		urlT, err := checkExpr(p.Fetch.URL, env)


### PR DESCRIPTION
## Summary
- implement a small Datalog engine
- parse `fact`, `rule` and `query` constructs
- interpret facts, rules and logic queries
- type check logic queries loosely
- document logic programming support and add example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d48b2f1508320ac77c13247742252