### PR TITLE
Add LeetCode 102 example

### DIFF
--- a/examples/leetcode/102/binary-tree-level-order-traversal.mochi
+++ b/examples/leetcode/102/binary-tree-level-order-traversal.mochi
@@ -1,0 +1,88 @@
+// Solution for LeetCode problem 102 - Binary Tree Level Order Traversal
+
+// Binary tree node definition
+// Leaf represents an empty tree
+// Node has left, value, and right children
+
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+// Perform a breadth-first traversal returning values level by level
+fun levelOrder(root: Tree): list<list<int>> {
+  if match root {
+       Leaf => true
+       _ => false
+     } {
+    return []
+  }
+  var result: list<list<int>> = []
+  var queue: list<Tree> = [root]
+  while len(queue) > 0 {
+    var level: list<int> = []
+    var next: list<Tree> = []
+    for node in queue {
+      match node {
+        Leaf => {}
+        Node(l, v, r) => {
+          level = level + [v]
+          match l {
+            Leaf => {}
+            _ => {
+              next = next + [l]
+            }
+          }
+          match r {
+            Leaf => {}
+            _ => {
+              next = next + [r]
+            }
+          }
+        }
+      }
+    }
+    result = result + [level]
+    queue = next
+  }
+  return result
+}
+
+// Test cases based on LeetCode examples
+
+test "example 1" {
+  let tree = Node {
+    left: Node { left: Leaf {}, value: 9, right: Leaf {} },
+    value: 3,
+    right: Node {
+      left: Node { left: Leaf {}, value: 15, right: Leaf {} },
+      value: 20,
+      right: Node { left: Leaf {}, value: 7, right: Leaf {} }
+    }
+  }
+  expect levelOrder(tree) == [[3], [9,20], [15,7]]
+}
+
+test "single node" {
+  expect levelOrder(Node { left: Leaf {}, value: 1, right: Leaf {} }) == [[1]]
+}
+
+test "empty" {
+  expect levelOrder(Leaf {}) == []
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' for comparisons.
+   if node = Leaf { ... }   // ❌ assignment
+   if node == Leaf { ... }  // ✅ comparison
+2. Declaring a list without a type and later appending values.
+   var q = []               // ❌ type unknown
+   var q: list<Tree> = []   // ✅ specify element type
+3. Reassigning an immutable binding.
+   let level = []
+   level = level + [1]      // ❌ cannot assign to 'let'
+   // Fix: use 'var level = []' if mutation is needed.
+4. Using 'null' for empty trees.
+   let t = null             // ❌ undefined value
+   // Fix: use 'Leaf' to represent an empty subtree.
+*/


### PR DESCRIPTION
## Summary
- add `binary-tree-level-order-traversal.mochi` solution
- include example tests and list of common Mochi mistakes

## Testing
- `mochi test examples/leetcode/102/binary-tree-level-order-traversal.mochi` *(fails: 2 test(s) failed)*

------
https://chatgpt.com/codex/tasks/task_e_684da3562c448320af6b55106a064a9d