### PR TITLE
Fix leetcode example syntax

### DIFF
--- a/examples/leetcode/100/same-tree.mochi
+++ b/examples/leetcode/100/same-tree.mochi
@@ -1,5 +1,5 @@
 type Tree =
-  Leaf
+  Leaf {}
   | Node(left: Tree, value: int, right: Tree)
 
 fun isSameTree(p: Tree, q: Tree): bool {
@@ -19,48 +19,48 @@ fun isSameTree(p: Tree, q: Tree): bool {
 
 test "example 1" {
   let p = Node {
-    left: Node { left: Leaf, value: 2, right: Leaf },
+    left: Node { left: Leaf {}, value: 2, right: Leaf {} },
     value: 1,
-    right: Node { left: Leaf, value: 3, right: Leaf }
+    right: Node { left: Leaf {}, value: 3, right: Leaf {} }
   }
   let q = Node {
-    left: Node { left: Leaf, value: 2, right: Leaf },
+    left: Node { left: Leaf {}, value: 2, right: Leaf {} },
     value: 1,
-    right: Node { left: Leaf, value: 3, right: Leaf }
+    right: Node { left: Leaf {}, value: 3, right: Leaf {} }
   }
   expect isSameTree(p, q) == true
 }
 
 test "example 2" {
   let p = Node {
-    left: Node { left: Leaf, value: 2, right: Leaf },
+    left: Node { left: Leaf {}, value: 2, right: Leaf {} },
     value: 1,
-    right: Leaf
+    right: Leaf {}
   }
   let q = Node {
-    left: Leaf,
+    left: Leaf {},
     value: 1,
-    right: Node { left: Leaf, value: 2, right: Leaf }
+    right: Node { left: Leaf {}, value: 2, right: Leaf {} }
   }
   expect isSameTree(p, q) == false
 }
 
 test "example 3" {
   let p = Node {
-    left: Node { left: Leaf, value: 2, right: Leaf },
+    left: Node { left: Leaf {}, value: 2, right: Leaf {} },
     value: 1,
-    right: Node { left: Leaf, value: 1, right: Leaf }
+    right: Node { left: Leaf {}, value: 1, right: Leaf {} }
   }
   let q = Node {
-    left: Node { left: Leaf, value: 1, right: Leaf },
+    left: Node { left: Leaf {}, value: 1, right: Leaf {} },
     value: 1,
-    right: Node { left: Leaf, value: 2, right: Leaf }
+    right: Node { left: Leaf {}, value: 2, right: Leaf {} }
   }
   expect isSameTree(p, q) == false
 }
 
 test "both empty" {
-  expect isSameTree(Leaf, Leaf) == true
+  expect isSameTree(Leaf {}, Leaf {}) == true
 }
 
 /*

--- a/examples/leetcode/94/binary-tree-inorder-traversal.mochi
+++ b/examples/leetcode/94/binary-tree-inorder-traversal.mochi
@@ -15,12 +15,12 @@ fun inorderTraversal(t: Tree): list<int> {
 
 // Example tree: [1,null,2,3]
 let example1 = Node {
-  left: Leaf,
+  left: Leaf {},
   value: 1,
   right: Node {
-    left: Node { left: Leaf, value: 3, right: Leaf },
+    left: Node { left: Leaf {}, value: 3, right: Leaf {} },
     value: 2,
-    right: Leaf
+    right: Leaf {}
   }
 }
 
@@ -31,11 +31,11 @@ test "example 1" {
 }
 
 test "empty" {
-  expect inorderTraversal(Leaf) == []
+  expect inorderTraversal(Leaf {}) == []
 }
 
 test "single node" {
-  expect inorderTraversal(Node { left: Leaf, value: 1, right: Leaf }) == [1]
+  expect inorderTraversal(Node { left: Leaf {}, value: 1, right: Leaf {} }) == [1]
 }
 
 /*

--- a/examples/leetcode/95/unique-binary-search-trees-ii.mochi
+++ b/examples/leetcode/95/unique-binary-search-trees-ii.mochi
@@ -9,7 +9,7 @@ type Tree =
 
 fun build(start: int, end: int): list<Tree> {
   if start > end {
-    return [Empty]
+    return [Empty {}]
   }
   var result: list<Tree> = []
   for i in start..end + 1 {

--- a/examples/leetcode/98/validate-binary-search-tree.mochi
+++ b/examples/leetcode/98/validate-binary-search-tree.mochi
@@ -5,7 +5,7 @@
 // Node has a left child, value, and right child
 
 type Tree =
-  Leaf
+  Leaf {}
   | Node(left: Tree, value: int, right: Tree)
 
 // Optional integer used for lower/upper bounds during validation
@@ -20,10 +20,16 @@ fun isValidBST(root: Tree): bool {
     return match node {
       Leaf => true
       Node(l, v, r) => {
-        if match low { Some(x) => v <= x, None => false } {
+        if match low {
+          Some(x) => v <= x
+          None => false
+        } {
           return false
         }
-        if match high { Some(y) => v >= y, None => false } {
+        if match high {
+          Some(y) => v >= y
+          None => false
+        } {
           return false
         }
         return helper(l, low, Some { value: v }) && helper(r, Some { value: v }, high)
@@ -37,21 +43,21 @@ fun isValidBST(root: Tree): bool {
 
 test "example 1" {
   let tree = Node {
-    left: Node { left: Leaf, value: 1, right: Leaf },
+    left: Node { left: Leaf {}, value: 1, right: Leaf {} },
     value: 2,
-    right: Node { left: Leaf, value: 3, right: Leaf }
+    right: Node { left: Leaf {}, value: 3, right: Leaf {} }
   }
   expect isValidBST(tree) == true
 }
 
 test "example 2" {
   let tree = Node {
-    left: Node { left: Leaf, value: 1, right: Leaf },
+    left: Node { left: Leaf {}, value: 1, right: Leaf {} },
     value: 5,
     right: Node {
-      left: Node { left: Leaf, value: 3, right: Leaf },
+      left: Node { left: Leaf {}, value: 3, right: Leaf {} },
       value: 4,
-      right: Node { left: Leaf, value: 6, right: Leaf }
+      right: Node { left: Leaf {}, value: 6, right: Leaf {} }
     }
   }
   expect isValidBST(tree) == false

--- a/examples/leetcode/99/recover-binary-search-tree.mochi
+++ b/examples/leetcode/99/recover-binary-search-tree.mochi
@@ -4,7 +4,7 @@
 // A tree is either a Leaf or a Node with left/right subtrees
 // and an integer value.
 type Tree =
-  Leaf
+  Leaf {}
   | Node(left: Tree, value: int, right: Tree)
 
 // Inorder traversal returning the list of values
@@ -12,7 +12,7 @@ fun inorder(t: Tree): list<int> {
   var res = []
   fun dfs(n: Tree) {
     match n {
-      Leaf => {}
+      Leaf {} => {}
       Node(l, v, r) => {
         dfs(l)
         res = res + [v]
@@ -33,7 +33,7 @@ fun recoverTree(t: Tree): Tree {
 
   fun build(n: Tree): Tree {
     return match n {
-      Leaf => Leaf
+      Leaf {} => Leaf {}
       Node(l, v, r) => {
         let leftNew = build(l)
         let newVal = sortedVals[idx]
@@ -49,9 +49,9 @@ fun recoverTree(t: Tree): Tree {
 
 // Example tree with two nodes swapped
 let ex = Node {
-  left: Node { left: Leaf, value: 3, right: Leaf },
+  left: Node { left: Leaf {}, value: 3, right: Leaf {} },
   value: 1,
-  right: Node { left: Leaf, value: 4, right: Leaf }
+  right: Node { left: Leaf {}, value: 4, right: Leaf {} }
 }
 
 let fixed = recoverTree(ex)
@@ -59,9 +59,9 @@ expect inorder(fixed) == [1,3,4]
 
 // Another test with swapped leaf values
 let ex2 = Node {
-  left: Node { left: Leaf, value: 2, right: Leaf },
+  left: Node { left: Leaf {}, value: 2, right: Leaf {} },
   value: 4,
-  right: Node { left: Leaf, value: 1, right: Leaf }
+  right: Node { left: Leaf {}, value: 1, right: Leaf {} }
 }
 
 let fixed2 = recoverTree(ex2)


### PR DESCRIPTION
## Summary
- update tree examples to use `Leaf {}`
- fix match syntax in validate-binary-search-tree

## Testing
- `./mochi test examples/leetcode/94 2>&1 | head`


------
https://chatgpt.com/codex/tasks/task_e_684da66fc4ec8320b16a6bb65efe2af2