### PR TITLE
Fix examples around leetcode 101-110

### DIFF
--- a/examples/leetcode/105/construct-binary-tree-from-preorder-and-inorder-traversal.mochi
+++ b/examples/leetcode/105/construct-binary-tree-from-preorder-and-inorder-traversal.mochi
@@ -20,7 +20,7 @@ fun buildTree(preorder: list<int>, inorder: list<int>): Tree {
 
   fun helper(left: int, right: int): Tree {
     if left >= right {
-      return Leaf
+      return Leaf {}
     }
     let rootVal = preorder[preIdx]
     preIdx = preIdx + 1
@@ -69,7 +69,7 @@ test "single node" {
 
 test "empty" {
   let tree = buildTree([], [])
-  expect tree == Leaf
+  expect tree == Leaf {}
 }
 
 /*

--- a/examples/leetcode/106/construct-binary-tree-from-inorder-and-postorder-traversal.mochi
+++ b/examples/leetcode/106/construct-binary-tree-from-inorder-and-postorder-traversal.mochi
@@ -6,7 +6,7 @@ type Tree =
 
 fun buildTree(inorder: list<int>, postorder: list<int>): Tree {
   if len(inorder) == 0 {
-    return Leaf
+    return Leaf {}
   }
 
   let rootVal = postorder[len(postorder) - 1]
@@ -44,12 +44,12 @@ test "example 1" {
   let inorder = [9,3,15,20,7]
   let postorder = [9,15,7,20,3]
   let expected = Node {
-    left: Node { left: Leaf, value: 9, right: Leaf },
+    left: Node { left: Leaf {}, value: 9, right: Leaf {} },
     value: 3,
     right: Node {
-      left: Node { left: Leaf, value: 15, right: Leaf },
+      left: Node { left: Leaf {}, value: 15, right: Leaf {} },
       value: 20,
-      right: Node { left: Leaf, value: 7, right: Leaf }
+      right: Node { left: Leaf {}, value: 7, right: Leaf {} }
     }
   }
   expect isSameTree(buildTree(inorder, postorder), expected) == true
@@ -58,12 +58,12 @@ test "example 1" {
 test "example 2" {
   let inorder = [-1]
   let postorder = [-1]
-  let expected = Node { left: Leaf, value: -1, right: Leaf }
+  let expected = Node { left: Leaf {}, value: -1, right: Leaf {} }
   expect isSameTree(buildTree(inorder, postorder), expected) == true
 }
 
 test "empty" {
-  expect buildTree([], []) == Leaf
+  expect buildTree([], []) == Leaf {}
 }
 
 /*

--- a/examples/leetcode/107/binary-tree-level-order-traversal-ii.mochi
+++ b/examples/leetcode/107/binary-tree-level-order-traversal-ii.mochi
@@ -21,8 +21,14 @@ fun levelOrderBottom(root: Tree): list<list<int>> {
             Leaf => {}
             Node(l, v, r) => {
               level = level + [v]
-              match l { Leaf => {} _ => { next = next + [l] } }
-              match r { Leaf => {} _ => { next = next + [r] } }
+              match l {
+                Leaf => {}
+                _ => { next = next + [l] }
+              }
+              match r {
+                Leaf => {}
+                _ => { next = next + [r] }
+              }
             }
           }
         }

--- a/examples/leetcode/108/convert-sorted-array-to-binary-search-tree.mochi
+++ b/examples/leetcode/108/convert-sorted-array-to-binary-search-tree.mochi
@@ -9,7 +9,7 @@ type Tree =
 
 fun sortedArrayToBST(nums: list<int>): Tree {
   fun helper(lo: int, hi: int): Tree {
-    if lo > hi { return Leaf }
+    if lo > hi { return Leaf {} }
     let mid = (lo + hi) / 2
     return Node {
       left: helper(lo, mid - 1),

--- a/examples/leetcode/109/convert-sorted-list-to-binary-search-tree.mochi
+++ b/examples/leetcode/109/convert-sorted-list-to-binary-search-tree.mochi
@@ -12,7 +12,7 @@ type Tree =
 fun sortedListToBST(nums: list<int>): Tree {
   fun build(lo: int, hi: int): Tree {
     if lo >= hi {
-      return Leaf
+      return Leaf {}
     }
     let mid = (lo + hi) / 2
     return Node {

--- a/examples/leetcode/110/balanced-binary-tree.mochi
+++ b/examples/leetcode/110/balanced-binary-tree.mochi
@@ -9,8 +9,10 @@ type Tree =
   | Node(left: Tree, value: int, right: Tree)
 
 // Determine if a binary tree is height-balanced.
+type BalanceInfo = { h: int, balanced: bool }
+
 fun isBalanced(root: Tree): bool {
-  fun check(t: Tree): { h: int, balanced: bool } {
+  fun check(t: Tree): BalanceInfo {
     return match t {
       Leaf => { h: 0, balanced: true }
       Node(l, _, r) => {
@@ -31,12 +33,12 @@ fun isBalanced(root: Tree): bool {
 
 test "example 1" {
   let tree = Node {
-    left: Node { left: Leaf, value: 9, right: Leaf },
+    left: Node { left: Leaf {}, value: 9, right: Leaf {} },
     value: 3,
     right: Node {
-      left: Node { left: Leaf, value: 15, right: Leaf },
+      left: Node { left: Leaf {}, value: 15, right: Leaf {} },
       value: 20,
-      right: Node { left: Leaf, value: 7, right: Leaf }
+      right: Node { left: Leaf {}, value: 7, right: Leaf {} }
     }
   }
   expect isBalanced(tree) == true
@@ -46,25 +48,25 @@ test "example 2" {
   let tree = Node {
     left: Node {
       left: Node {
-        left: Node { left: Leaf, value: 4, right: Leaf },
+        left: Node { left: Leaf {}, value: 4, right: Leaf {} },
         value: 3,
-        right: Node { left: Leaf, value: 4, right: Leaf }
+        right: Node { left: Leaf {}, value: 4, right: Leaf {} }
       },
       value: 2,
-      right: Node { left: Leaf, value: 3, right: Leaf }
+      right: Node { left: Leaf {}, value: 3, right: Leaf {} }
     },
     value: 1,
-    right: Node { left: Leaf, value: 2, right: Leaf }
+    right: Node { left: Leaf {}, value: 2, right: Leaf {} }
   }
   expect isBalanced(tree) == false
 }
 
 test "single node" {
-  expect isBalanced(Node { left: Leaf, value: 1, right: Leaf }) == true
+  expect isBalanced(Node { left: Leaf {}, value: 1, right: Leaf {} }) == true
 }
 
 test "empty" {
-  expect isBalanced(Leaf) == true
+  expect isBalanced(Leaf {}) == true
 }
 
 /*


### PR DESCRIPTION
## Summary
- correct `Leaf` constructors in several tree problems
- fix namespacing for helper record type
- clean up match branches formatting

## Testing
- `go build ./cmd/mochi`
- `./mochi test examples/leetcode/105/construct-binary-tree-from-preorder-and-inorder-traversal.mochi` *(fails: operator `+` cannot be used on types [int] and [int])*

------
https://chatgpt.com/codex/tasks/task_e_684daf8fc894832081262b456dc02b8e