### PR TITLE
Fix small issues in LeetCode examples

### DIFF
--- a/examples/leetcode/94/binary-tree-inorder-traversal.mochi
+++ b/examples/leetcode/94/binary-tree-inorder-traversal.mochi
@@ -8,7 +8,7 @@ type Tree =
 // Recursively traverse the tree in-order.
 fun inorderTraversal(t: Tree): list<int> {
   return match t {
-    Leaf => []
+    Leaf => [] as list<int>
     Node(l, v, r) => inorderTraversal(l) + [v] + inorderTraversal(r)
   }
 }

--- a/examples/leetcode/98/validate-binary-search-tree.mochi
+++ b/examples/leetcode/98/validate-binary-search-tree.mochi
@@ -17,8 +17,8 @@ type MaybeInt =
 
 fun isValidBST(root: Tree): bool {
   fun helper(node: Tree, low: MaybeInt, high: MaybeInt): bool {
-    return match node {
-      Leaf => true
+    match node {
+      Leaf => { return true }
       Node(l, v, r) => {
         if match low {
           Some(x) => v <= x
@@ -35,6 +35,7 @@ fun isValidBST(root: Tree): bool {
         return helper(l, low, Some { value: v }) && helper(r, Some { value: v }, high)
       }
     }
+    return false
   }
   return helper(root, None, None)
 }


### PR DESCRIPTION
## Summary
- make inorder traversal empty case explicit
- tweak helper function in BST validation

## Testing
- `./bin/mochi test 94/binary-tree-inorder-traversal.mochi` *(fails: operator `+` cannot be used on types [int] and [int])*

------
https://chatgpt.com/codex/tasks/task_e_684dafabeb0c83208c99c876ff375147