### PR TITLE
Fix variable name in Sudoku solver example

### DIFF
--- a/examples/leetcode/37/sudoku-solver.mochi
+++ b/examples/leetcode/37/sudoku-solver.mochi
@@ -55,7 +55,7 @@ let board = [
   [".",".",".",".","8",".",".","7","9"],
 ]
 
-let board = solveSudoku(board)
+let solvedBoard = solveSudoku(board)
 
 // Expected solved board
 let solved = [
@@ -71,5 +71,5 @@ let solved = [
 ]
 
 test "solve" {
-  expect board == solved
+  expect solvedBoard == solved
 }


### PR DESCRIPTION
## Summary
- rename variable to avoid shadowing in example 37

## Testing
- `bin/mochi test 37/sudoku-solver.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684db2efe0cc8320975b0c6bf42c71cd