### PR TITLE
Enable list concatenation type checking

### DIFF
--- a/tests/types/valid/list_concat.golden
+++ b/tests/types/valid/list_concat.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/list_concat.mochi
+++ b/tests/types/valid/list_concat.mochi
@@ -1,0 +1,3 @@
+let a: list<int> = [1]
+let b: list<int> = [2]
+let c = a + b

--- a/types/check.go
+++ b/types/check.go
@@ -961,9 +961,19 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 	if _, ok := right.(AnyType); ok {
 		return AnyType{}, nil
 	}
-	switch op {
-	case "+", "-", "*", "/", "%":
-		switch {
+       if op == "+" || op == "union" || op == "union_all" || op == "except" || op == "intersect" {
+               if llist, ok := left.(ListType); ok {
+                       if rlist, ok := right.(ListType); ok {
+                               if !unify(llist.Elem, rlist.Elem, nil) {
+                                       return nil, errOperatorMismatch(pos, op, left, right)
+                               }
+                               return ListType{Elem: llist.Elem}, nil
+                       }
+               }
+       }
+       switch op {
+       case "+", "-", "*", "/", "%":
+               switch {
 		case (unify(left, IntType{}, nil) || unify(left, Int64Type{}, nil)) &&
 			(unify(right, IntType{}, nil) || unify(right, Int64Type{}, nil)):
 			if _, ok := left.(Int64Type); ok {
@@ -976,10 +986,10 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 		case unify(left, FloatType{}, nil) && unify(right, FloatType{}, nil):
 			return FloatType{}, nil
 		case op == "+" && unify(left, StringType{}, nil) && unify(right, StringType{}, nil):
-			return StringType{}, nil
-		default:
-			return nil, errOperatorMismatch(pos, op, left, right)
-		}
+                       return StringType{}, nil
+               default:
+                       return nil, errOperatorMismatch(pos, op, left, right)
+               }
 	case "==", "!=", "<", "<=", ">", ">=":
 		if !unify(left, right, nil) {
 			return nil, errIncompatibleComparison(pos)


### PR DESCRIPTION
## Summary
- support binary operations on `list<T>` values
- test list concatenation works during type checking

## Testing
- `go test ./types -run TestTypeChecker_Valid -v`
- `make test STAGE=types`

------
https://chatgpt.com/codex/tasks/task_e_684db2c733fc8320be9c66c770e3512d