### PR TITLE
Fix path-sum match

### DIFF
--- a/examples/leetcode/112/path-sum.mochi
+++ b/examples/leetcode/112/path-sum.mochi
@@ -11,8 +11,14 @@ fun hasPathSum(root: Tree, targetSum: int): bool {
     Leaf {} => false
     Node(l, v, r) => {
       let remaining = targetSum - v
-      let leftEmpty = match l { Leaf {} => true _ => false }
-      let rightEmpty = match r { Leaf {} => true _ => false }
+      let leftEmpty = match l {
+        Leaf {} => true
+        _ => false
+      }
+      let rightEmpty = match r {
+        Leaf {} => true
+        _ => false
+      }
       if leftEmpty && rightEmpty {
         remaining == 0
       } else {


### PR DESCRIPTION
## Summary
- fix pattern matching structure in example 112

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684db4dc85188320b658069e098295f0