### PR TITLE
Add Mochi solution for LeetCode 117

### DIFF
--- a/examples/leetcode/117/populating-next-right-pointers-in-each-node-ii.mochi
+++ b/examples/leetcode/117/populating-next-right-pointers-in-each-node-ii.mochi
@@ -1,0 +1,96 @@
+// LeetCode 117 - Populating Next Right Pointers in Each Node II
+
+// Binary tree where each node has left, value, right and a next pointer.
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree, next: Tree)
+
+// Find the first child node starting from 'node' following next pointers.
+fun firstChild(node: Tree): Tree {
+  var curr = node
+  while match curr { Leaf => false _ => true } {
+    match curr {
+      Node(l, _, r, nxt) => {
+        if match l { Leaf => false _ => true } { return l }
+        if match r { Leaf => false _ => true } { return r }
+        curr = nxt
+      }
+      Leaf => {}
+    }
+  }
+  return Leaf {}
+}
+
+// Recursively connect nodes level by level using next pointers.
+fun connect(root: Tree): Tree {
+  fun helper(node: Tree, nxt: Tree): Tree {
+    return match node {
+      Leaf => Leaf {}
+      Node(l, v, r, _) => {
+        let rightNext = firstChild(nxt)
+        let right = helper(r, rightNext)
+        let leftNext = if match r { Leaf => true _ => false } { rightNext } else { firstChild(right) }
+        let left = helper(l, leftNext)
+        return Node { left: left, value: v, right: right, next: nxt }
+      }
+    }
+  }
+  return helper(root, Leaf {})
+}
+
+// Traverse levels using the next pointers to verify connections.
+fun levels(root: Tree): list<list<int>> {
+  var result: list<list<int>> = []
+  var node = root
+  while match node { Leaf => false _ => true } {
+    var level: list<int> = []
+    var curr = node
+    var nextLevel = Leaf {}
+    while match curr { Leaf => false _ => true } {
+      match curr {
+        Node(l, v, _, nxt) => {
+          level = level + [v]
+          if match nextLevel { Leaf => true _ => false } {
+            nextLevel = l
+          }
+          curr = nxt
+        }
+        Leaf => {}
+      }
+    }
+    result = result + [level]
+    node = nextLevel
+  }
+  return result
+}
+
+// Test case based on LeetCode example
+
+test "example" {
+  let tree = Node {
+    left: Node {
+      left: Node { left: Leaf {}, value: 4, right: Leaf {}, next: Leaf {} },
+      value: 2,
+      right: Node { left: Leaf {}, value: 5, right: Leaf {}, next: Leaf {} },
+      next: Leaf {}
+    },
+    value: 1,
+    right: Node {
+      left: Leaf {},
+      value: 3,
+      right: Node { left: Leaf {}, value: 7, right: Leaf {}, next: Leaf {} },
+      next: Leaf {}
+    },
+    next: Leaf {}
+  }
+  let connected = connect(tree)
+  expect levels(connected) == [[1], [2,3], [4,5,7]]
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Attempting to mutate fields directly. Instead, construct a new `Node` with the updated `next` pointer.
+2. Using Python-style `None` instead of the `Leaf` variant for empty nodes.
+3. Forgetting to use `var` when a variable will be reassigned inside loops.
+4. Omitting a case for `Leaf` when pattern matching on trees.
+*/


### PR DESCRIPTION
## Summary
- implement `connect` for populating next right pointers in any binary tree
- include tests and a list of common Mochi pitfalls

## Testing
- `go run ./cmd/mochi -h`


------
https://chatgpt.com/codex/tasks/task_e_684e1748455c8320bc6f3b75962024f4