### PR TITLE
Fix path sum logic

### DIFF
--- a/examples/leetcode/112/path-sum.mochi
+++ b/examples/leetcode/112/path-sum.mochi
@@ -20,10 +20,9 @@ fun hasPathSum(root: Tree, targetSum: int): bool {
         _ => false
       }
       if leftEmpty && rightEmpty {
-        remaining == 0
-      } else {
-        hasPathSum(l, remaining) || hasPathSum(r, remaining)
+        return remaining == 0
       }
+      return hasPathSum(l, remaining) || hasPathSum(r, remaining)
     }
   }
 }


### PR DESCRIPTION
## Summary
- tidy up the path sum example by making the return paths explicit

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e1c1325e08320aa6be340efa029d4