### PR TITLE
Add typed empty list example

### DIFF
--- a/examples/v0.7/empty_list.mochi
+++ b/examples/v0.7/empty_list.mochi
@@ -1,0 +1,6 @@
+// Explicitly cast an empty list to a list of integers
+let emptyInts: list<int> = []
+print(emptyInts)  // => []
+
+let casted = [] as list<int>
+print(casted)


### PR DESCRIPTION
## Summary
- add an example showing how to cast an empty list to a typed list

## Testing
- `go run ./cmd/mochi run examples/v0.7/empty_list.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684e26be98ec83209e9edd379719d436