### PR TITLE
Fix Path Sum II example types

### DIFF
--- a/examples/leetcode/113/path-sum-ii.mochi
+++ b/examples/leetcode/113/path-sum-ii.mochi
@@ -9,7 +9,7 @@ type Tree =
 fun pathSum(root: Tree, targetSum: int): list<list<int>> {
   fun dfs(node: Tree, remaining: int, path: list<int>): list<list<int>> {
     match node {
-      Leaf {} => []
+      Leaf {} => [] as list<list<int>>
       Node(l, v, r) => {
         let newRemaining = remaining - v
         let newPath = path + [v]
@@ -27,7 +27,7 @@ fun pathSum(root: Tree, targetSum: int): list<list<int>> {
       }
     }
   }
-  return dfs(root, targetSum, [])
+  return dfs(root, targetSum, [] as list<int>)
 }
 
 // Tests from LeetCode


### PR DESCRIPTION
## Summary
- fix base case annotations in Path Sum II

## Testing
- `mochi test examples/leetcode/113/path-sum-ii.mochi` *(fails: operator `+` cannot be used on types [int] and [int])*

------
https://chatgpt.com/codex/tasks/task_e_684e23404eb083209c1de502a03e819b