### PR TITLE
Update Leaf syntax in flatten-binary-tree example

### DIFF
--- a/examples/leetcode/114/flatten-binary-tree-to-linked-list.mochi
+++ b/examples/leetcode/114/flatten-binary-tree-to-linked-list.mochi
@@ -5,25 +5,25 @@
 // Node has left/right subtrees and an integer value
 
 type Tree =
-  Leaf {}
+  Leaf
   | Node(left: Tree, value: int, right: Tree)
 
 // Concatenate two right-skewed lists
 fun concat(a: Tree, b: Tree): Tree {
   return match a {
     Leaf => b
-    Node(_, v, r) => Node { left: Leaf {}, value: v, right: concat(r, b) }
+    Node(_, v, r) => Node { left: Leaf, value: v, right: concat(r, b) }
   }
 }
 
 // Flatten a binary tree into a linked list using preorder traversal
 fun flatten(root: Tree): Tree {
   return match root {
-    Leaf => Leaf {}
+    Leaf => Leaf
     Node(l, v, r) => {
       let leftFlat = flatten(l)
       let rightFlat = flatten(r)
-      let head = Node { left: Leaf {}, value: v, right: leftFlat }
+      let head = Node { left: Leaf, value: v, right: leftFlat }
       concat(head, rightFlat)
     }
   }
@@ -42,32 +42,32 @@ fun toList(t: Tree): list<int> {
 test "example 1" {
   let tree = Node {
     left: Node {
-      left: Node { left: Leaf {}, value: 3, right: Leaf {} },
+      left: Node { left: Leaf, value: 3, right: Leaf },
       value: 2,
-      right: Node { left: Leaf {}, value: 4, right: Leaf {} }
+      right: Node { left: Leaf, value: 4, right: Leaf }
     },
     value: 1,
     right: Node {
-      left: Leaf {},
+      left: Leaf,
       value: 5,
-      right: Node { left: Leaf {}, value: 6, right: Leaf {} }
+      right: Node { left: Leaf, value: 6, right: Leaf }
     }
   }
   expect toList(flatten(tree)) == [1,2,3,4,5,6]
 }
 
 test "example 2" {
-  expect toList(flatten(Leaf {})) == []
+  expect toList(flatten(Leaf)) == []
 }
 
 test "single node" {
-  expect toList(flatten(Node { left: Leaf {}, value: 0, right: Leaf {} })) == [0]
+  expect toList(flatten(Node { left: Leaf, value: 0, right: Leaf })) == [0]
 }
 
 /*
 Common Mochi language errors and how to fix them:
 1. Attempting to mutate a Node's fields:
-     node.left = Leaf {}          // error[E004]: fields are immutable
+     node.left = Leaf          // error[E004]: fields are immutable
    Fix: create a new Node value with the desired children.
 2. Using '=' instead of '==' for comparison:
      if x = 1 { }                 // wrong


### PR DESCRIPTION
## Summary
- update the binary tree type to use `Leaf` without braces
- adjust tree construction and tests to the new syntax
- update comments accordingly

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_684e4e3aaa38832088c2f3dba18624ff