### PR TITLE
Add if expressions

### DIFF
--- a/ast/convert.go
+++ b/ast/convert.go
@@ -178,6 +178,16 @@ func fromIfStmt(stmt *parser.IfStmt) *Node {
 	return n
 }
 
+func fromIfExpr(expr *parser.IfExpr) *Node {
+	n := &Node{Kind: "if_expr", Children: []*Node{FromExpr(expr.Cond), FromExpr(expr.Then)}}
+	if expr.ElseIf != nil {
+		n.Children = append(n.Children, fromIfExpr(expr.ElseIf))
+	} else if expr.Else != nil {
+		n.Children = append(n.Children, FromExpr(expr.Else))
+	}
+	return n
+}
+
 func fromWhileStmt(stmt *parser.WhileStmt) *Node {
 	n := &Node{Kind: "while", Children: []*Node{FromExpr(stmt.Cond)}}
 	n.Children = append(n.Children, &Node{Kind: "block", Children: mapStatements(stmt.Body)})
@@ -455,6 +465,9 @@ func FromPrimary(p *parser.Primary) *Node {
 			n.Children = append(n.Children, cn)
 		}
 		return n
+
+	case p.If != nil:
+		return fromIfExpr(p.If)
 
 	case p.Generate != nil:
 		n := &Node{Kind: "generate_text"}

--- a/examples/v0.7/if_expr.mochi
+++ b/examples/v0.7/if_expr.mochi
@@ -1,0 +1,12 @@
+// if_expr.mochi
+// Demonstrates that `if` can return a value
+
+let age = 20
+
+let status = if age >= 18 {
+  "adult"
+} else {
+  "minor"
+}
+
+print("Status:", status)  // => Status: adult

--- a/interpreter/helpers.go
+++ b/interpreter/helpers.go
@@ -148,3 +148,20 @@ func (i *Interpreter) evalMatch(m *parser.MatchExpr) (any, error) {
 	}
 	return nil, nil
 }
+
+func (i *Interpreter) evalIfExpr(e *parser.IfExpr) (any, error) {
+	cond, err := i.evalExpr(e.Cond)
+	if err != nil {
+		return nil, err
+	}
+	if truthy(cond) {
+		return i.evalExpr(e.Then)
+	}
+	if e.ElseIf != nil {
+		return i.evalIfExpr(e.ElseIf)
+	}
+	if e.Else != nil {
+		return i.evalExpr(e.Else)
+	}
+	return nil, nil
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1051,6 +1051,9 @@ func (i *Interpreter) evalPrimary(p *parser.Primary) (any, error) {
 	case p.FunExpr != nil:
 		return closure{Name: "", Fn: p.FunExpr, Env: i.env.Copy(), FullParams: p.FunExpr.Params}, nil
 
+	case p.If != nil:
+		return i.evalIfExpr(p.If)
+
 	case p.Selector != nil:
 		val, err := i.env.GetValue(p.Selector.Root)
 		if err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -441,6 +441,14 @@ type MatchExpr struct {
 	Cases  []*MatchCase `parser:"@@* '}'"`
 }
 
+type IfExpr struct {
+	Pos    lexer.Position
+	Cond   *Expr   `parser:"'if' @@"`
+	Then   *Expr   `parser:"'{' @@ '}'"`
+	ElseIf *IfExpr `parser:"[ 'else' @@"`
+	Else   *Expr   `parser:"| 'else' '{' @@ '}' ]"`
+}
+
 type MatchCase struct {
 	Pos     lexer.Position
 	Pattern *Expr `parser:"@@ '=>'"`
@@ -453,6 +461,7 @@ type Primary struct {
 	Call       *CallExpr       `parser:"| @@"`
 	Query      *QueryExpr      `parser:"| @@"`
 	LogicQuery *LogicQueryExpr `parser:"| @@"`
+	If         *IfExpr         `parser:"| @@"`
 	Selector   *SelectorExpr   `parser:"| @@"`
 	List       *ListLiteral    `parser:"| @@"`
 	Map        *MapLiteral     `parser:"| @@"`


### PR DESCRIPTION
## Summary
- implement `if` expressions in the parser and interpreter
- support AST conversion for new `if_expr` node
- add example demonstrating `if` as an expression

## Testing
- `make test STAGE=parser`
- `make test STAGE=interpreter`


------
https://chatgpt.com/codex/tasks/task_e_684e4dd2c6188320bfdeb126778733c1