### PR TITLE
Fix index check in Surrounded Regions sample

### DIFF
--- a/examples/leetcode/130/surrounded-regions.mochi
+++ b/examples/leetcode/130/surrounded-regions.mochi
@@ -33,17 +33,25 @@ fun solve(board: list<list<string>>): list<list<string>> {
     let c = pos[1]
     if board[r][c] == "O" {
       board[r][c] = "S"
-      if r > 0 && board[r-1][c] == "O" {
-        queue = queue + [[r-1, c]]
+      if r > 0 {
+        if board[r-1][c] == "O" {
+          queue = queue + [[r-1, c]]
+        }
       }
-      if r + 1 < rows && board[r+1][c] == "O" {
-        queue = queue + [[r+1, c]]
+      if r + 1 < rows {
+        if board[r+1][c] == "O" {
+          queue = queue + [[r+1, c]]
+        }
       }
-      if c > 0 && board[r][c-1] == "O" {
-        queue = queue + [[r, c-1]]
+      if c > 0 {
+        if board[r][c-1] == "O" {
+          queue = queue + [[r, c-1]]
+        }
       }
-      if c + 1 < cols && board[r][c+1] == "O" {
-        queue = queue + [[r, c+1]]
+      if c + 1 < cols {
+        if board[r][c+1] == "O" {
+          queue = queue + [[r, c+1]]
+        }
       }
     }
     i = i + 1


### PR DESCRIPTION
## Summary
- prevent out-of-bounds access in `examples/leetcode/130/surrounded-regions.mochi`

## Testing
- `make test STAGE=interpreter`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684e4e61b7fc8320a9afb20cae099d0d