### PR TITLE
Fix leftNext selection in LeetCode 117 example

### DIFF
--- a/examples/leetcode/117/populating-next-right-pointers-in-each-node-ii.mochi
+++ b/examples/leetcode/117/populating-next-right-pointers-in-each-node-ii.mochi
@@ -29,7 +29,10 @@ fun connect(root: Tree): Tree {
       Node(l, v, r, _) => {
         let rightNext = firstChild(nxt)
         let right = helper(r, rightNext)
-        let leftNext = if match r { Leaf => true _ => false } { rightNext } else { firstChild(right) }
+        let leftNext = match r {
+          Leaf => rightNext
+          _ => firstChild(right)
+        }
         let left = helper(l, leftNext)
         return Node { left: left, value: v, right: right, next: nxt }
       }


### PR DESCRIPTION
## Summary
- fix conditional expression in `populating-next-right-pointers-in-each-node-ii.mochi`

## Testing
- `go test ./... -run TestNonExistingPattern`

------
https://chatgpt.com/codex/tasks/task_e_684e513e3d58832097d42d2657905556