### PR TITLE
Fix connect tree example

### DIFF
--- a/examples/leetcode/116/populating-next-right-pointers-in-each-node.mochi
+++ b/examples/leetcode/116/populating-next-right-pointers-in-each-node.mochi
@@ -17,7 +17,7 @@ fun connect(root: Tree): Tree {
         }
         let right = helper(r, rNext)
         let left = helper(l, right)
-        return Node { left: left, value: v, right: right, next: nxt }
+        Node { left: left, value: v, right: right, next: nxt }
       }
     }
   }


### PR DESCRIPTION
## Summary
- fix example code for populating next right pointers: remove stray `return` inside match branch

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_684e514551c083209eb9194b4876a21f