### PR TITLE
Fix path sum example type mismatch

### DIFF
--- a/examples/leetcode/112/path-sum.mochi
+++ b/examples/leetcode/112/path-sum.mochi
@@ -7,7 +7,7 @@ type Tree =
   | Node(left: Tree, value: int, right: Tree)
 
 fun hasPathSum(root: Tree, targetSum: int): bool {
-  return match root {
+  match root {
     Leaf {} => false
     Node(l, v, r) => {
       let remaining = targetSum - v
@@ -20,9 +20,10 @@ fun hasPathSum(root: Tree, targetSum: int): bool {
         _ => false
       }
       if leftEmpty && rightEmpty {
-        return remaining == 0
+        remaining == 0
+      } else {
+        hasPathSum(l, remaining) || hasPathSum(r, remaining)
       }
-      return hasPathSum(l, remaining) || hasPathSum(r, remaining)
     }
   }
 }


### PR DESCRIPTION
## Summary
- avoid using `return` inside match block so all branches yield a `bool`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684e5161c5e48320823c69e589a7daa2