### PR TITLE
Fix query source type error in LeetCode example

### DIFF
--- a/examples/leetcode/3442/maximum-difference-between-even-and-odd-frequency-i.mochi
+++ b/examples/leetcode/3442/maximum-difference-between-even-and-odd-frequency-i.mochi
@@ -1,5 +1,7 @@
 fun maxDiffEvenOdd(s: string): int {
-  let counts = from ch in s
+  // Query sources must be lists, so convert the string into
+  // a list of characters using `chars`.
+  let counts = from ch in chars(s)
                group by ch into g
                select {
                  ch: g.key,


### PR DESCRIPTION
## Summary
- ensure query source is a list in `maximum-difference-between-even-and-odd-frequency-i.mochi`
- add a comment explaining the conversion using `chars`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684e51e2c30c832082e3da68e7c61e3a