### PR TITLE
Add string comparison support

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -242,6 +242,14 @@ for ch in text {
 }
 ```
 
+String comparison operators (`<`, `<=`, `>`, `>=`) compare values
+lexicographically using Unicode code point order. For example:
+
+```mochi
+print("a" < "b")  // true
+print("cat" >= "car")  // true
+```
+
 #### Struct Literals
 
 Values of user-defined types are constructed with struct literal syntax. The field

--- a/interpreter/runtime_utils.go
+++ b/interpreter/runtime_utils.go
@@ -180,6 +180,14 @@ func applyBinaryValue(pos lexer.Position, left Value, op string, right Value) (V
 				return Value{Tag: TagBool, Bool: left.Str == right.Str}, nil
 			case "!=":
 				return Value{Tag: TagBool, Bool: left.Str != right.Str}, nil
+			case "<":
+				return Value{Tag: TagBool, Bool: left.Str < right.Str}, nil
+			case "<=":
+				return Value{Tag: TagBool, Bool: left.Str <= right.Str}, nil
+			case ">":
+				return Value{Tag: TagBool, Bool: left.Str > right.Str}, nil
+			case ">=":
+				return Value{Tag: TagBool, Bool: left.Str >= right.Str}, nil
 			case "in":
 				return Value{Tag: TagBool, Bool: strings.Contains(right.Str, left.Str)}, nil
 			}

--- a/tests/interpreter/valid/string_compare.mochi
+++ b/tests/interpreter/valid/string_compare.mochi
@@ -1,0 +1,4 @@
+print("a" < "b")
+print("a" <= "a")
+print("b" > "a")
+print("b" >= "b")

--- a/tests/interpreter/valid/string_compare.out
+++ b/tests/interpreter/valid/string_compare.out
@@ -1,0 +1,4 @@
+true
+true
+true
+true


### PR DESCRIPTION
## Summary
- support lexical string comparisons in the interpreter
- document string comparison behavior
- test comparison operators on strings

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684e53a0529c8320bbfbd178332a7a3b