### PR TITLE
Fix BST validation example

### DIFF
--- a/examples/leetcode/98/validate-binary-search-tree.mochi
+++ b/examples/leetcode/98/validate-binary-search-tree.mochi
@@ -15,29 +15,25 @@ type MaybeInt =
   None
   | Some(value: int)
 
-fun isValidBST(root: Tree): bool {
-  fun helper(node: Tree, low: MaybeInt, high: MaybeInt): bool {
-    match node {
-      Leaf => { return true }
-      Node(l, v, r) => {
-        if match low {
-          Some(x) => v <= x
-          None => false
-        } {
-          return false
-        }
-        if match high {
-          Some(y) => v >= y
-          None => false
-        } {
-          return false
-        }
-        return helper(l, low, Some { value: v }) && helper(r, Some { value: v }, high)
-      }
-    }
-    return false
+fun helper(node: Tree, low: MaybeInt, high: MaybeInt): bool {
+  return match node {
+    Leaf => true
+    Node(l, v, r) =>
+      (match low {
+        Some(x) => v > x
+        None => true
+      }) &&
+      (match high {
+        Some(y) => v < y
+        None => true
+      }) &&
+      helper(l, low, Some { value: v }) &&
+      helper(r, Some { value: v }, high)
   }
-  return helper(root, None, None)
+}
+
+fun isValidBST(root: Tree): bool {
+  return helper(root, None {}, None {})
 }
 
 // Test cases from LeetCode


### PR DESCRIPTION
## Summary
- fix helper logic in the binary search tree example
- rely only on expressions inside match branches
- use `None {}` when calling `helper`

## Testing
- `go run ./cmd/mochi test examples/leetcode/98/validate-binary-search-tree.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684e544102c48320a8bfc4ef3c2bc867