### PR TITLE
Fix BFS level order example

### DIFF
--- a/examples/leetcode/102/binary-tree-level-order-traversal.mochi
+++ b/examples/leetcode/102/binary-tree-level-order-traversal.mochi
@@ -22,22 +22,13 @@ fun levelOrder(root: Tree): list<list<int>> {
     var level: list<int> = []
     var next: list<Tree> = []
     for node in queue {
-      match node {
-        Leaf => {}
-        Node(l, v, r) => {
-          level = level + [v]
-          match l {
-            Leaf => {}
-            _ => {
-              next = next + [l]
-            }
-          }
-          match r {
-            Leaf => {}
-            _ => {
-              next = next + [r]
-            }
-          }
+      if match node { Leaf => false _ => true } {
+        level = level + [node.value]
+        if match node.left { Leaf => false _ => true } {
+          next = next + [node.left]
+        }
+        if match node.right { Leaf => false _ => true } {
+          next = next + [node.right]
         }
       }
     }


### PR DESCRIPTION
## Summary
- fix `levelOrder` to match nodes by checking fields instead of pattern

## Testing
- `go run ./cmd/mochi test examples/leetcode/102/binary-tree-level-order-traversal.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684e51c3ee108320838e1c0c503b5c4e