### PR TITLE
Fix leaf constructor usage in flatten example

### DIFF
--- a/examples/leetcode/114/flatten-binary-tree-to-linked-list.mochi
+++ b/examples/leetcode/114/flatten-binary-tree-to-linked-list.mochi
@@ -57,7 +57,7 @@ test "example 1" {
 }
 
 test "example 2" {
-  expect toList(flatten(Leaf)) == []
+  expect toList(flatten(Leaf {})) == []
 }
 
 test "single node" {


### PR DESCRIPTION
## Summary
- fix type mismatch in flatten-binary-tree-to-linked-list example

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684e514ec5fc832096c7272e667a02be