### PR TITLE
Fix list + operator

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -932,6 +932,9 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 			case isFloat(leftType) && isFloat(rightType):
 				expr = fmt.Sprintf("(%s %s %s)", expr, op.Op, right)
 				next = types.FloatType{}
+			case op.Op == "+" && isList(leftType) && isList(rightType):
+				expr = fmt.Sprintf("append(%s, %s...)", expr, right)
+				next = leftType
 			case op.Op == "+" && isString(leftType) && isString(rightType):
 				expr = fmt.Sprintf("%s + %s", expr, right)
 				next = types.StringType{}

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -142,6 +142,11 @@ func isString(t types.Type) bool {
 	return ok
 }
 
+func isList(t types.Type) bool {
+	_, ok := t.(types.ListType)
+	return ok
+}
+
 func isAny(t types.Type) bool {
 	_, ok := t.(types.AnyType)
 	return ok

--- a/compile/go/infer.go
+++ b/compile/go/infer.go
@@ -42,6 +42,12 @@ func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
 				}
 			}
 			if op.Op == "+" {
+				if llist, ok := t.(types.ListType); ok {
+					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
+						t = llist
+						continue
+					}
+				}
 				if _, ok := t.(types.StringType); ok {
 					if _, ok := rt.(types.StringType); ok {
 						t = types.StringType{}

--- a/compile/ts/helpers.go
+++ b/compile/ts/helpers.go
@@ -164,6 +164,11 @@ func isString(t types.Type) bool {
 	return ok
 }
 
+func isList(t types.Type) bool {
+	_, ok := t.(types.ListType)
+	return ok
+}
+
 func tsType(t types.Type) string {
 	switch tt := t.(type) {
 	case types.IntType, types.Int64Type, types.FloatType:

--- a/compile/ts/infer.go
+++ b/compile/ts/infer.go
@@ -40,6 +40,12 @@ func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
 				}
 			}
 			if op.Op == "+" {
+				if llist, ok := t.(types.ListType); ok {
+					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
+						t = llist
+						continue
+					}
+				}
 				if _, ok := t.(types.StringType); ok {
 					if _, ok := rt.(types.StringType); ok {
 						t = types.StringType{}


### PR DESCRIPTION
## Summary
- support detecting lists in compilers
- handle list concatenation for `+` in Go and TS codegen

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_684e6a2dba6083209a9d4291585ca239