### PR TITLE
Add LeetCode 149 solution in Mochi

### DIFF
--- a/examples/leetcode/149/max-points-on-a-line.mochi
+++ b/examples/leetcode/149/max-points-on-a-line.mochi
@@ -1,0 +1,101 @@
+// LeetCode #149: Max Points on a Line
+// Below are some common Mochi language errors and how to fix them.
+
+// Error 1: missing ':' before the return type
+// maxPoints(points: list<list<int>>) int { }
+// Fix:
+fun maxPoints(points: list<list<int>>): int {
+  let n = len(points)
+  if n <= 2 {
+    return n
+  }
+  var answer = 0
+  var i = 0
+  while i < n {
+    var slopes: map<string, int> = {}
+    var duplicates = 1
+    var j = i + 1
+    while j < n {
+      let dx = points[j][0] - points[i][0]
+      let dy = points[j][1] - points[i][1]
+      if dx == 0 && dy == 0 {
+        duplicates = duplicates + 1
+      } else {
+        let g = gcd(dx, dy)
+        var sx = dx / g
+        var sy = dy / g
+        if sx == 0 {
+          sy = 1
+        } else if sx < 0 {
+          sx = -sx
+          sy = -sy
+        }
+        let key = str(sx) + "/" + str(sy)
+        if key in slopes {
+          slopes[key] = slopes[key] + 1
+        } else {
+          slopes[key] = 1
+        }
+      }
+      j = j + 1
+    }
+    var localMax = 0
+    for key in slopes {
+      let count = slopes[key]
+      if count > localMax {
+        localMax = count
+      }
+    }
+    if localMax + duplicates > answer {
+      answer = localMax + duplicates
+    }
+    i = i + 1
+  }
+  return answer
+}
+
+fun abs(x: int): int {
+  if x < 0 {
+    return -x
+  }
+  return x
+}
+
+fun gcd(a: int, b: int): int {
+  var x = abs(a)
+  var y = abs(b)
+  while y != 0 {
+    let temp = x % y
+    x = y
+    y = temp
+  }
+  return x
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect maxPoints([[1,1],[2,2],[3,3]]) == 3
+}
+
+test "example 2" {
+  expect maxPoints([[1,1],[3,2],[5,3],[4,1],[2,3],[1,4]]) == 4
+}
+
+test "single point" {
+  expect maxPoints([[0,0]]) == 1
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' in conditions.
+   if dx = 0 { }         // ❌ wrong
+   // Fix: if dx == 0 { }
+2. Reassigning an immutable 'let' variable.
+   let duplicates = 1
+   duplicates = duplicates + 1  // ❌ error
+   // Fix: use `var duplicates` if you need to mutate.
+3. Forgetting the ':' before the return type.
+   maxPoints(points: list<list<int>>) int { }
+   // Fix: fun maxPoints(points: list<list<int>>): int { }
+*/


### PR DESCRIPTION
## Summary
- add example solution for LeetCode problem 149
- demonstrate common Mochi pitfalls in comments

## Testing
- `make -C examples/leetcode test` *(fails: multiple unrelated tests fail)*
- `examples/leetcode/bin/mochi test examples/leetcode/149/max-points-on-a-line.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684e6cc7aa788320bca0495f1af71920