### PR TITLE
Fix Python compiler precedence and reserved names

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -840,43 +840,74 @@ func (c *Compiler) compileExpect(e *parser.ExpectStmt) error {
 func (c *Compiler) compileExpr(e *parser.Expr) (string, error) { return c.compileBinaryExpr(e.Binary) }
 
 func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
-	expr, err := c.compileUnary(b.Left)
+	left, err := c.compileUnary(b.Left)
 	if err != nil {
 		return "", err
 	}
-	leftType := c.inferUnaryType(b.Left)
-	for _, op := range b.Right {
+	exprs := []string{left}
+	ops := make([]string, len(b.Right))
+	for i, op := range b.Right {
 		r, err := c.compilePostfix(op.Right)
 		if err != nil {
 			return "", err
 		}
-		rightType := c.inferPostfixType(op.Right)
-		if op.Op == "/" && isInt(leftType) && isInt(rightType) {
-			expr = fmt.Sprintf("(%s // %s)", expr, r)
-			leftType = types.IntType{}
-			continue
-		}
-		pyOp := op.Op
-		switch op.Op {
+		exprs = append(exprs, r)
+		ops[i] = op.Op
+	}
+
+	levels := [][]string{
+		{"*", "/", "%"},
+		{"+", "-"},
+		{"<", "<=", ">", ">="},
+		{"==", "!=", "in"},
+		{"&&"},
+		{"||"},
+		{"union", "union_all", "except", "intersect"},
+	}
+
+	use := func(name string) string {
+		switch name {
 		case "&&":
-			pyOp = "and"
+			return "and"
 		case "||":
-			pyOp = "or"
-		case "union", "union_all", "except", "intersect":
-			c.use("_" + pyOp)
-			expr = fmt.Sprintf("_%s(%s, %s)", pyOp, expr, r)
-			leftType = types.ListType{Elem: types.AnyType{}}
-			continue
-		}
-		expr = fmt.Sprintf("(%s %s %s)", expr, pyOp, r)
-		switch op.Op {
-		case "+", "-", "*", "/", "%":
-			// The resulting type roughly mirrors the left operand.
-		case "==", "!=", "<", "<=", ">", ">=":
-			leftType = types.BoolType{}
+			return "or"
+		default:
+			return name
 		}
 	}
-	return expr, nil
+
+	contains := func(list []string, s string) bool {
+		for _, v := range list {
+			if v == s {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, level := range levels {
+		for i := 0; i < len(ops); {
+			if !contains(level, ops[i]) {
+				i++
+				continue
+			}
+			if ops[i] == "union" || ops[i] == "union_all" || ops[i] == "except" || ops[i] == "intersect" {
+				c.use("_" + ops[i])
+				exprs[i] = fmt.Sprintf("_%s(%s, %s)", ops[i], exprs[i], exprs[i+1])
+			} else if ops[i] == "/" {
+				exprs[i] = fmt.Sprintf("(%s // %s)", exprs[i], exprs[i+1])
+			} else {
+				exprs[i] = fmt.Sprintf("(%s %s %s)", exprs[i], use(ops[i]), exprs[i+1])
+			}
+			exprs = append(exprs[:i+1], exprs[i+2:]...)
+			ops = append(ops[:i], ops[i+1:]...)
+		}
+	}
+
+	if len(exprs) != 1 {
+		return "", fmt.Errorf("invalid expression")
+	}
+	return exprs[0], nil
 }
 
 func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {

--- a/compile/py/helpers.go
+++ b/compile/py/helpers.go
@@ -11,6 +11,19 @@ import (
 	"mochi/types"
 )
 
+var pyReserved = map[string]struct{}{
+	// Python keywords
+	"False": {}, "None": {}, "True": {}, "and": {}, "as": {}, "assert": {},
+	"async": {}, "await": {}, "break": {}, "class": {}, "continue": {},
+	"def": {}, "del": {}, "elif": {}, "else": {}, "except": {},
+	"finally": {}, "for": {}, "from": {}, "global": {}, "if": {},
+	"import": {}, "in": {}, "is": {}, "lambda": {}, "nonlocal": {},
+	"not": {}, "or": {}, "pass": {}, "raise": {}, "return": {},
+	"try": {}, "while": {}, "with": {}, "yield": {},
+	// Builtins that commonly appear in generated code
+	"sorted": {},
+}
+
 func (c *Compiler) writeln(s string) { c.writeIndent(); c.buf.WriteString(s); c.buf.WriteByte('\n') }
 
 func (c *Compiler) writeIndent() {
@@ -31,7 +44,11 @@ func sanitizeName(name string) string {
 	if b.Len() == 0 || !((b.String()[0] >= 'A' && b.String()[0] <= 'Z') || (b.String()[0] >= 'a' && b.String()[0] <= 'z') || b.String()[0] == '_') {
 		return "_" + b.String()
 	}
-	return b.String()
+	out := b.String()
+	if _, ok := pyReserved[out]; ok {
+		return "_" + out
+	}
+	return out
 }
 
 func unexportName(name string) string {


### PR DESCRIPTION
## Summary
- avoid Python reserved words like `sorted` when generating variable names
- add operator precedence handling in Python compiler

## Testing
- `go test ./...`
- `for i in {11..20}; do for f in examples/leetcode/$i/*.mochi; do go run ./cmd/mochi build --target py "$f" -o tmp.py >/tmp/out.log && python3 tmp.py >/tmp/py.log && echo "$f OK"; done; done`


------
https://chatgpt.com/codex/tasks/task_e_684e6b33eda08320b0432fea746f2756