### PR TITLE
Fix union variant resolution

### DIFF
--- a/tests/types/valid/union_alias.golden
+++ b/tests/types/valid/union_alias.golden
@@ -1,0 +1,1 @@
+✅ Type Check Passed

--- a/tests/types/valid/union_alias.mochi
+++ b/tests/types/valid/union_alias.mochi
@@ -1,0 +1,6 @@
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+let l: Leaf = Leaf {}
+let n: Node = Node { left: l, value: 1, right: l }


### PR DESCRIPTION
## Summary
- recognize union variants as their union type
- test union variants treated as union aliases

## Testing
- `make test STAGE=types`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684e733cc2148320a62b2066e282c101