### PR TITLE
Improve TypeScript equality and operator precedence

### DIFF
--- a/compile/ts/runtime.go
+++ b/compile/ts/runtime.go
@@ -284,6 +284,27 @@ const (
 		"      _writeOutput(path, lines.join('\\n') + '\\n');\n" +
 		"  }\n" +
 		"}\n"
+
+	helperEqual = "function _equal(a: any, b: any): boolean {\n" +
+		"  if (Array.isArray(a) && Array.isArray(b)) {\n" +
+		"    if (a.length !== b.length) return false;\n" +
+		"    for (let i = 0; i < a.length; i++) {\n" +
+		"      if (!_equal(a[i], b[i])) return false;\n" +
+		"    }\n" +
+		"    return true;\n" +
+		"  }\n" +
+		"  if (a && b && typeof a === 'object' && typeof b === 'object') {\n" +
+		"    const ak = Object.keys(a);\n" +
+		"    const bk = Object.keys(b);\n" +
+		"    if (ak.length !== bk.length) return false;\n" +
+		"    for (const k of ak) {\n" +
+		"      if (!(k in b)) return false;\n" +
+		"      if (!_equal((a as any)[k], (b as any)[k])) return false;\n" +
+		"    }\n" +
+		"    return true;\n" +
+		"  }\n" +
+		"  return a === b;\n" +
+		"}\n"
 )
 
 var helperMap = map[string]string{
@@ -295,6 +316,7 @@ var helperMap = map[string]string{
 	"_gen_struct": helperGenStruct,
 	"_fetch":      helperFetch,
 	"_toAnyMap":   helperToAnyMap,
+	"_equal":      helperEqual,
 	"_stream":     helperStream,
 	"_waitAll":    helperWaitAll,
 	"_agent":      helperAgent,


### PR DESCRIPTION
## Summary
- extend TS runtime with `_equal` for deep equality
- use `_equal` from the TS compiler
- rewrite `compileBinaryExpr` to respect operator precedence

## Testing
- `go build ./...`
- `go test ./compile/ts -run TestTSCompiler_SubsetPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_684e747ee99883209e6c083e96c46df1