### PR TITLE
Add new solution for LeetCode 111 example

### DIFF
--- a/examples/leetcode/111/minimum-depth-of-binary-tree.mochi
+++ b/examples/leetcode/111/minimum-depth-of-binary-tree.mochi
@@ -1,36 +1,34 @@
 // LeetCode 111 - Minimum Depth of Binary Tree
 
-// Binary tree definition reused across examples.
+// Binary tree definition shared across the LeetCode examples.
 type Tree =
   Leaf
   | Node(left: Tree, value: int, right: Tree)
 
-// Recursively compute the minimum depth of a binary tree.
+// Recursively compute the minimal number of nodes from the root to
+// the nearest leaf.
 fun minDepth(root: Tree): int {
-  return match root {
+  match root {
     Leaf => 0
     Node(l, _, r) => {
-      let left = minDepth(l)
-      let right = minDepth(r)
-      if left == 0 && right == 0 {
-        return 1
-      }
-      if left == 0 {
-        return right + 1
-      }
-      if right == 0 {
-        return left + 1
-      }
-      if left < right {
-        return left + 1
+      let leftDepth = minDepth(l)
+      let rightDepth = minDepth(r)
+      if leftDepth == 0 && rightDepth == 0 {
+        1
+      } else if leftDepth == 0 {
+        rightDepth + 1
+      } else if rightDepth == 0 {
+        leftDepth + 1
+      } else if leftDepth < rightDepth {
+        leftDepth + 1
       } else {
-        return right + 1
+        rightDepth + 1
       }
     }
   }
 }
 
-// Test cases from LeetCode
+// Test cases from the LeetCode problem statement
 
 test "example 1" {
   let tree = Node {
@@ -64,22 +62,22 @@ test "empty" {
 
 /*
 Common Mochi language errors and how to fix them:
-1. Using '=' instead of '==' for comparisons:
+1. Confusing '=' with '==' in conditional checks:
      if depth = 1 { }
-   // Fix: use '==' to compare values.
-2. Reassigning an immutable binding declared with 'let':
+   // Use '==' for comparisons.
+2. Attempting to reassign a value bound with 'let':
      let d = 0
      d = 1  // error[E004]
-   // Fix: declare with 'var d = 0' if mutation is required.
-3. Using 'null' or 'None' instead of the 'Leaf' constructor:
-     let t = null  // error[I001]
-   // Fix: use 'Leaf' for an empty tree node.
-4. Writing `Leaf` instead of `Leaf {}` when constructing a value:
-     let t = Leaf  // error[T008]
-   // Fix: call the constructor with `Leaf {}`.
-5. Forgetting to return a value from all match branches:
-     fun f(x: int): int {
-       match x { 1 => 1 }
+   // Use 'var' when the variable should change.
+3. Using Python style 'None' instead of the 'Leaf' constructor:
+     let t = None  // error[I001]
+   // Construct an empty tree with 'Leaf {}'.
+4. Forgetting braces when creating a Leaf instance:
+     let t = Leaf   // error[T008]
+   // The correct form is 'Leaf {}'.
+5. Missing a branch when matching on an enum:
+     fun f(t: Tree): int {
+       match t { Node(_, v, _) => v }  // error[T007]
      }
-   // Fix: include all branches and return a value from each.
+   // Provide a case for 'Leaf' as well to return a value.
 */


### PR DESCRIPTION
## Summary
- rewrite `examples/leetcode/111/minimum-depth-of-binary-tree.mochi`
- added new implementation and tests with a section on common Mochi errors

## Testing
- `make -C examples/leetcode test` *(fails: type errors in unrelated examples)*

------
https://chatgpt.com/codex/tasks/task_e_684e792fdc38832088c631bbfc8ae3f2