### PR TITLE
Support optional '=' before struct types

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -134,7 +134,8 @@ let scores: map<string, int> = {"alice": 1}
 ### Type Declarations
 
 User-defined types are introduced with the `type` keyword. A type may define a set of
-named fields forming a struct. Methods may also be declared inside the type block.
+named fields forming a struct. An optional `=` may appear before the struct block.
+Methods may also be declared inside the type block.
 
 ```mochi
 type Person {
@@ -598,7 +599,7 @@ AgentDecl     = "agent" Identifier "{" AgentField* "}" .
 AgentField    = LetStmt | VarStmt | AssignStmt | OnHandler | IntentDecl .
 IntentDecl    = "intent" Identifier "(" [ ParamList ] ")" [ ":" TypeRef ] Block .
 ModelDecl     = "model" Identifier Block .
-TypeDecl      = "type" Identifier [ "{" TypeMember* "}" ] [ "=" TypeVariant { "|" TypeVariant } ] .
+TypeDecl      = "type" Identifier [ [ "=" ] "{" TypeMember* "}" ] [ "=" TypeVariant { "|" TypeVariant } ] .
 TypeMember    = TypeField | FunDecl .
 TypeVariant   = Identifier [ "(" TypeField { "," TypeField } [ "," ]? ")" | "{" TypeField* "}" ] .
 TypeField     = Identifier ":" TypeRef .

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -120,7 +120,7 @@ type TypeDecl struct {
 	Pos      lexer.Position
 	Name     string `parser:"'type' @Ident"`
 	Doc      string
-	Members  []*TypeMember  `parser:"[ '{' @@* '}' ]"`
+	Members  []*TypeMember  `parser:"[ [ '=' ] '{' @@ { [ ',' ] @@ } [ ',' ]? '}' ]"`
 	Variants []*TypeVariant `parser:"[ '=' @@ { '|' @@ } ]"`
 }
 

--- a/tests/parser/valid/type_struct_equals.golden
+++ b/tests/parser/valid/type_struct_equals.golden
@@ -1,0 +1,6 @@
+(program
+  (type BalanceInfo
+    (field h (type int))
+    (field balanced (type bool))
+  )
+)

--- a/tests/parser/valid/type_struct_equals.mochi
+++ b/tests/parser/valid/type_struct_equals.mochi
@@ -1,0 +1,1 @@
+type BalanceInfo = { h: int, balanced: bool }


### PR DESCRIPTION
## Summary
- allow optional '=' token before struct body in type declarations
- document the optional '=' in the spec
- add parser test for struct types defined with '='

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e78d81e108320a8e37de83d47e574