### PR TITLE
Fix LeetCode 112 example

### DIFF
--- a/examples/leetcode/112/path-sum.mochi
+++ b/examples/leetcode/112/path-sum.mochi
@@ -1,30 +1,30 @@
 // LeetCode 112 - Path Sum
 
-// Binary tree definition used by many LeetCode examples.
+// Binary tree definition shared across LeetCode examples.
 type Tree =
   Leaf
   | Node(left: Tree, value: int, right: Tree)
 
-// Determine if the tree has a root-to-leaf path that sums to target.
+fun isLeaf(t: Tree): bool {
+  return match t {
+    Leaf => true
+    _ => false
+  }
+}
+
+// Determine if the tree has a root-to-leaf path that sums to `target`.
 fun hasPathSum(root: Tree, target: int): bool {
-  match root {
-    Leaf => false
-    Node(l, v, r) => {
-      let remaining = target - v
-      let leftLeaf = match l {
-        Leaf => true
-        _ => false
-      }
-      let rightLeaf = match r {
-        Leaf => true
-        _ => false
-      }
-      if leftLeaf && rightLeaf {
-        remaining == 0
-      } else {
-        hasPathSum(l, remaining) || hasPathSum(r, remaining)
-      }
+  fun nodeSum(l: Tree, v: int, r: Tree, remaining: int): bool {
+    let leftLeaf = isLeaf(l)
+    let rightLeaf = isLeaf(r)
+    if leftLeaf && rightLeaf {
+      return remaining == 0
     }
+    return hasPathSum(l, remaining) || hasPathSum(r, remaining)
+  }
+  return match root {
+    Leaf => false
+    Node(l, v, r) => nodeSum(l, v, r, target - v)
   }
 }
 
@@ -83,6 +83,6 @@ Common Mochi language errors and how to fix them:
 1. Matching on a Leaf node with `Leaf {}` instead of `Leaf`.
    Use `match t { Leaf => ... }` when pattern matching.
 2. Using `=` instead of `==` for comparisons inside conditions.
-3. Reassigning a binding declared with `let`; use `var` if it should change.
+3. Forgetting to `return` a value from all branches of a function.
 4. Forgetting to construct an empty tree with `Leaf {}` when creating a value.
 */


### PR DESCRIPTION
## Summary
- reimplement the `examples/leetcode/112/path-sum.mochi` solution from scratch
- add `isLeaf` helper and `nodeSum` internal function
- mention common Mochi errors in comments

## Testing
- `mochi test examples/leetcode/112/path-sum.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684e8156c688832083d9177a597045dd