### PR TITLE
Run leetcode tests and update report

### DIFF
--- a/examples/leetcode/report_error.md
+++ b/examples/leetcode/report_error.md
@@ -1,25 +1,16 @@
 # Failed LeetCode Examples
 
-The following Mochi solutions produced errors when running `mochi test` on 2025-06-15.
+The following Mochi solutions produced errors when running `make test` on 2025-06-15.
 
 ## 124 - Binary Tree Maximum Path Sum
 - **Issue**: interpreter panic during tests (`nil pointer dereference`).
 - **Log snippet**:
 ```text
-panic: runtime error: invalid memory address or nil pointer dereference
-mochi/runtime/ffi.(*Manager).Lookup...
-```
+   [33mtest[0m example 1                      ...panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc7b395]
 
-## 110 - Balanced Binary Tree
-- **Issue**: `error[T014]` – invalid primary expression.
-- **Snippet**:
-```text
-23 |         let diff = if left.height > right.height {
-   |                    ^
+goroutine 1 [running]:
 ```
-
-## 117 - Populating Next Right Pointers in Each Node II
-- **Issue**: test run never completes (likely infinite loop). Timed out after 5s.
 
 ## 138 - Copy List with Random Pointer
 - **Issue**: test run never completes (likely infinite loop). Timed out after 5s.


### PR DESCRIPTION
## Summary
- run `make test` for the leetcode examples
- record failing and hanging solutions in `report_error.md`

## Testing
- `grep -n "TIMEOUT" /tmp/all_test.log`
- `grep -n "FAIL" /tmp/all_test.log`

------
https://chatgpt.com/codex/tasks/task_e_684e8eb9900883209c5566e898c1a4e7