### PR TITLE
Add LeetCode 168 example

### DIFF
--- a/examples/leetcode/168/excel-sheet-column-title.mochi
+++ b/examples/leetcode/168/excel-sheet-column-title.mochi
@@ -1,0 +1,38 @@
+fun convertToTitle(columnNumber: int): string {
+  let letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  var n = columnNumber
+  var result = ""
+  while n > 0 {
+    n = n - 1
+    let idx = n % 26
+    result = letters[idx:idx+1] + result
+    n = n / 26
+  }
+  return result
+}
+
+test "example 1" {
+  expect convertToTitle(1) == "A"
+}
+
+test "example 2" {
+  expect convertToTitle(28) == "AB"
+}
+
+test "example 3" {
+  expect convertToTitle(701) == "ZY"
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Forgetting to subtract 1 before taking the modulus causes off-by-one errors.
+   let idx = columnNumber % 26  // ❌ gives wrong letter for multiples of 26
+   Fix: subtract 1 from n before modulo as shown above.
+2. Using '+=' to append characters to a string.
+   result += ch                  // ❌ not supported
+   Fix: result = result + ch
+3. Trying to mutate a value declared with 'let'.
+   let n = columnNumber
+   n = n - 1                     // ❌ cannot reassign
+   Fix: use 'var n = columnNumber'
+*/


### PR DESCRIPTION
## Summary
- add a new solution for LeetCode problem 168 under `examples/leetcode/168`
- include three tests matching the problem statement
- document common Mochi pitfalls in comments

## Testing
- `./bin/mochi test 168/excel-sheet-column-title.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684e9899c9348320851ac07065258be6