### PR TITLE
Add LeetCode 178 solution

### DIFF
--- a/examples/leetcode/178/rank-scores.mochi
+++ b/examples/leetcode/178/rank-scores.mochi
@@ -1,0 +1,43 @@
+// Solution for LeetCode problem 178 - Rank Scores
+// Given a list of integer scores, return their rankings.
+// Highest score gets rank 1. Equal scores share the same rank.
+
+fun rankScores(scores: list<int>): list<int> {
+  // Step 1: sort scores descending to compute rank order
+  let sorted = from s in scores sort by -s select s
+
+  var rankMap: map<int, int> = {}
+  var rank = 1
+  var hasPrev = false
+  var prev = 0
+
+  for s in sorted {
+    if !hasPrev || s != prev {
+      rankMap[s] = rank
+      prev = s
+      hasPrev = true
+    }
+    rank = rank + 1
+  }
+
+  var result: list<int> = []
+  for s in scores {
+    result = result + [rankMap[s]]
+  }
+  return result
+}
+
+// Basic tests
+
+test "example 1" {
+  expect rankScores([100, 90, 90, 80]) == [1, 2, 2, 4]
+}
+
+test "example 2" {
+  expect rankScores([10, 20, 30]) == [3, 2, 1]
+}
+
+// Common Mochi language errors and how to fix them:
+// 1. Attempting to modify a `let` variable like `sorted`. Use `var` when you need mutation.
+// 2. Using `=` instead of `==` in the `if` condition.
+// 3. Forgetting that lists are zero-indexed when assigning ranks.


### PR DESCRIPTION
## Summary
- implement `rankScores` for LeetCode problem 178
- include tests and common error notes

## Testing
- `~/bin/mochi test examples/leetcode/178/rank-scores.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684e9c9116208320b63d83a7e1745abe