### PR TITLE
Add LeetCode 215 example

### DIFF
--- a/examples/leetcode/215/kth-largest-element-in-an-array.mochi
+++ b/examples/leetcode/215/kth-largest-element-in-an-array.mochi
@@ -1,0 +1,38 @@
+fun findKthLargest(nums: list<int>, k: int): int {
+  let sorted = from x in nums sort by -x select x
+  return sorted[k - 1]
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect findKthLargest([3,2,1,5,6,4], 2) == 5
+}
+
+test "example 2" {
+  expect findKthLargest([3,2,3,1,2,4,5,5,6], 4) == 4
+}
+
+// Additional edge cases
+
+test "single element" {
+  expect findKthLargest([1], 1) == 1
+}
+
+test "with negatives" {
+  expect findKthLargest([-1,-2,-3,-4], 2) == (-2)
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' when comparing values:
+   if k = 1 { }      // ❌ assignment
+   if k == 1 { }     // ✅ comparison
+2. Reassigning an immutable binding declared with 'let':
+   let x = 5
+   x = x + 1          // ❌ cannot modify
+   var x2 = 5         // ✅ declare with 'var' when mutation is needed
+3. Accessing a list out of bounds:
+   nums[len(nums)]    // ❌ index out of range
+   nums[len(nums)-1]  // ✅ last element
+*/


### PR DESCRIPTION
## Summary
- add `findKthLargest` example for LeetCode 215
- include tests and note common Mochi language errors

## Testing
- `./bin/mochi test 215/kth-largest-element-in-an-array.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684ea40992e4832099a1303d1f741303