### PR TITLE
Add LeetCode 216 example

### DIFF
--- a/examples/leetcode/216/combination-sum-iii.mochi
+++ b/examples/leetcode/216/combination-sum-iii.mochi
@@ -1,0 +1,58 @@
+fun combinationSum3(k: int, n: int): list<list<int>> {
+  var result: list<list<int>> = []
+
+  fun backtrack(start: int, remain: int, path: list<int>) {
+    if len(path) == k {
+      if remain == 0 {
+        result = result + [path]
+      }
+    } else if remain > 0 {
+      var i = start
+      while i <= 9 {
+        if i > remain {
+          break
+        }
+        backtrack(i + 1, remain - i, path + [i])
+        i = i + 1
+      }
+    }
+  }
+
+  backtrack(1, n, [])
+  return result
+}
+
+// Tests from the LeetCode problem statement
+
+test "example 1" {
+  expect combinationSum3(3, 7) == [[1,2,4]]
+}
+
+test "example 2" {
+  expect combinationSum3(3, 9) == [[1,2,6],[1,3,5],[2,3,4]]
+}
+
+test "example 3" {
+  expect combinationSum3(4, 1) == []
+}
+
+test "no combination" {
+  expect combinationSum3(3, 2) == []
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Reassigning an immutable binding:
+   let x = 0
+   x = 1  // error[E004]
+   // Fix: declare with 'var' if mutation is needed
+   var y = 0
+   y = 1
+2. Using '=' instead of '==' for comparison:
+   if k = 3 { }
+   // Fix: use '==' to compare
+   if k == 3 { }
+3. Missing type annotation for an empty list:
+   var res = []  // error[E003]
+   var res: list<int> = []  // specify element type
+*/


### PR DESCRIPTION
## Summary
- add solution for LeetCode problem 216
- include tests and common Mochi mistakes

## Testing
- `examples/leetcode/bin/mochi test examples/leetcode/216/combination-sum-iii.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684ea40d5c488320889bc134ae617b8e