### PR TITLE
Add solution for LeetCode 242

### DIFF
--- a/examples/leetcode/242/valid-anagram.mochi
+++ b/examples/leetcode/242/valid-anagram.mochi
@@ -1,0 +1,65 @@
+fun isAnagram(s: string, t: string): bool {
+  if len(s) != len(t) {
+    return false
+  }
+  var counts: map<string, int> = {}
+  var i = 0
+  while i < len(s) {
+    let ch = s[i]
+    if ch in counts {
+      counts[ch] = counts[ch] + 1
+    } else {
+      counts[ch] = 1
+    }
+    i = i + 1
+  }
+  i = 0
+  while i < len(t) {
+    let ch = t[i]
+    if ch in counts {
+      counts[ch] = counts[ch] - 1
+    } else {
+      return false
+    }
+    i = i + 1
+  }
+  for key in counts {
+    if counts[key] != 0 {
+      return false
+    }
+  }
+  return true
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect isAnagram("anagram", "nagaram") == true
+}
+
+test "example 2" {
+  expect isAnagram("rat", "car") == false
+}
+
+// Additional edge cases
+
+test "empty strings" {
+  expect isAnagram("", "") == true
+}
+
+test "different lengths" {
+  expect isAnagram("a", "ab") == false
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Omitting the map type when creating an empty map:
+   var counts = {}                     // ❌ type cannot be inferred
+   var counts: map<string, int> = {}   // ✅ specify key and value types
+2. Updating a map entry without checking for the key first:
+   counts[ch] = counts[ch] + 1         // ❌ fails if `ch` not in map
+   if ch in counts { counts[ch] = counts[ch] + 1 } else { counts[ch] = 1 } // ✅
+3. Using '=' instead of '==' in comparisons:
+   if len(s) = len(t) { }              // ❌ assignment
+   if len(s) == len(t) { }             // ✅ equality check
+*/


### PR DESCRIPTION
## Summary
- implement `isAnagram` in a new example directory
- add tests demonstrating usage and common errors

## Testing
- `examples/leetcode/bin/mochi test examples/leetcode/242/valid-anagram.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684ea8e8626c83209c67d25ea120bfe1