### PR TITLE
Add release notes for v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # 📦 CHANGELOG.md
+## [0.7.3] – 2025-06-15
+
+### Added
+
+* LeetCode solutions 101–240 with improved examples
+* Operator precedence handling in the Go compiler
+* Documentation clarifies string comparison semantics
+
+### Changed
+
+* Rewrote the LRU cache example for clarity
+
+### Fixed
+
+* Python compiler precedence and reserved name handling
+
 ## [0.7.2] – 2025-06-14
 
 ### Added

--- a/releases/v0.7.3.md
+++ b/releases/v0.7.3.md
@@ -1,0 +1,18 @@
+# Jun 2025 (v0.7.3)
+
+Mochi v0.7.3 continues expanding the example library and improves compiler correctness.
+
+## Example Library
+
+- Added solutions for LeetCode problems 101–240
+- Rewrote the LRU cache implementation
+- New sliding window maximum example
+
+## Compilers
+
+- Go compiler now respects operator precedence
+- Fixed Python compiler precedence and reserved names
+
+## Documentation
+
+- Clarified string comparison behavior


### PR DESCRIPTION
## Summary
- add CHANGELOG entry for v0.7.3
- document release in `releases/v0.7.3.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684eaa6a8e388320a7af2e1858c7133d