### PR TITLE
Fix LeetCode 249 example

### DIFF
--- a/examples/leetcode/249/group-shifted-strings.mochi
+++ b/examples/leetcode/249/group-shifted-strings.mochi
@@ -4,6 +4,20 @@
 // steps forward in the alphabet, wrapping around from 'z' to 'a'.
 // We group strings that share the same shifting pattern.
 
+// Convert a single lowercase letter to a number 0-25
+fun ord(ch: string): int {
+  let letters = {
+    "a": 0, "b": 1, "c": 2, "d": 3, "e": 4, "f": 5, "g": 6,
+    "h": 7, "i": 8, "j": 9, "k": 10, "l": 11, "m": 12, "n": 13,
+    "o": 14, "p": 15, "q": 16, "r": 17, "s": 18, "t": 19, "u": 20,
+    "v": 21, "w": 22, "x": 23, "y": 24, "z": 25
+  }
+  if ch in letters {
+    return letters[ch]
+  }
+  return 0
+}
+
 fun patternKey(s: string): string {
   if len(s) == 0 {
     return ""
@@ -13,7 +27,7 @@ fun patternKey(s: string): string {
   var i = 0
   while i < len(s) {
     let diff = (ord(s[i]) - base + 26) % 26
-    key = key + toString(diff) + ","
+    key = key + str(diff) + ","
     i = i + 1
   }
   return key


### PR DESCRIPTION
## Summary
- implement missing `ord` helper
- use `str` for building pattern key
- update tests for problem 249

## Testing
- `go build -o mochi cmd/mochi/main.go`
- `./mochi test examples/leetcode/249/group-shifted-strings.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684eab9f508c8320aa56a0fce017900d