### PR TITLE
Fix LeetCode 250 example

### DIFF
--- a/examples/leetcode/250/count-univalue-subtrees.mochi
+++ b/examples/leetcode/250/count-univalue-subtrees.mochi
@@ -27,9 +27,19 @@ fun countUnivalSubtrees(root: map<string, any>): int {
     let leftUni = dfs(l)
     let rightUni = dfs(r)
 
-    if leftUni && rightUni &&
-       (isLeaf(l) || value(l) == value(node)) &&
-       (isLeaf(r) || value(r) == value(node)) {
+    var isUni = true
+
+    if !isLeaf(l) {
+      if !leftUni { isUni = false }
+      if value(l) != value(node) { isUni = false }
+    }
+
+    if !isLeaf(r) {
+      if !rightUni { isUni = false }
+      if value(r) != value(node) { isUni = false }
+    }
+
+    if isUni {
       count = count + 1
       return true
     }
@@ -100,4 +110,7 @@ Common Mochi language errors and how to fix them:
 3. Accessing fields of Leaf without checking.
    left(Leaf())           // ❌ runtime error
    if !isLeaf(node) { left(node) } // ✅ ensure node is not Leaf
+4. Assuming '&&' or '||' short-circuit.
+   boolA && boolB         // both sides evaluated
+   if boolA { boolB }     // ✅ split the checks
 */


### PR DESCRIPTION
## Summary
- fix `countUnivalSubtrees` so `Leaf` nodes are handled safely
- document short-circuit evaluation gotcha in comment

## Testing
- `~/bin/mochi test examples/leetcode/250/count-univalue-subtrees.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684eaba4b6148320bc25c3e4cd79986f