### PR TITLE
Show file names in `mochi test` output

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -108,6 +108,7 @@ type CheatsheetCmd struct{}
 var (
 	cError = color.New(color.FgRed, color.Bold).SprintFunc()
 	cTitle = color.New(color.FgCyan, color.Bold).SprintFunc()
+	cFile  = color.New(color.FgHiBlue, color.Bold).SprintFunc()
 )
 
 func main() {
@@ -286,6 +287,12 @@ func runTestsInDir(dir string, recursive bool, cmd *TestCmd) error {
 }
 
 func testFile(file string, cmd *TestCmd) error {
+	rel := file
+	if r, err := filepath.Rel(".", file); err == nil {
+		rel = r
+	}
+	fmt.Println(cFile(rel))
+
 	prog, err := parseOrPrintError(file)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- add `cFile` color
- print the test file name before running its tests

## Testing
- `go test ./...`
- `go run ./cmd/mochi test examples/v0.1/test.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684eadf9a42c8320a96ba914c5e80a73