### PR TITLE
Improve Go backend for LeetCode examples

### DIFF
--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -147,6 +147,16 @@ func isList(t types.Type) bool {
 	return ok
 }
 
+func isMap(t types.Type) bool {
+	_, ok := t.(types.MapType)
+	return ok
+}
+
+func isStruct(t types.Type) bool {
+	_, ok := t.(types.StructType)
+	return ok
+}
+
 func isAny(t types.Type) bool {
 	_, ok := t.(types.AnyType)
 	return ok

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -191,6 +191,10 @@ const (
 		"    return out\n" +
 		"}\n"
 
+	helperEqual = "func _equal(a, b any) bool {\n" +
+		"    return reflect.DeepEqual(a, b)\n" +
+		"}\n"
+
 	helperToMapSlice = "func _toMapSlice(v any) ([]map[string]any, bool) {\n" +
 		"    switch rows := v.(type) {\n" +
 		"    case []map[string]any:\n" +
@@ -354,6 +358,7 @@ var helperMap = map[string]string{
 	"_toAnyMap":    helperToAnyMap,
 	"_toAnySlice":  helperToAnySlice,
 	"_cast":        helperCast,
+	"_equal":       helperEqual,
 	"_query":       helperQuery,
 	"_load":        helperLoad,
 	"_save":        helperSave,


### PR DESCRIPTION
## Summary
- add `_equal` runtime helper to support deep equality
- track reflect import and use `_equal` for slice/map/struct comparisons
- declare top level variables when tests follow
- handle recursive nested functions

## Testing
- `go test ./compile/go -run TestGoCompiler_GoldenOutput -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ef0e7269483208ecfc4fb61dbb66b