### PR TITLE
Fix python map cast

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -307,15 +307,16 @@ func (c *Compiler) compileVar(s *parser.VarStmt) error {
 	name := sanitizeName(s.Name)
 	value := "None"
 	if s.Value != nil {
-		if ml := s.Value.Binary.Left.Value.Target.Map; ml != nil && len(ml.Items) == 0 {
-			if c.env != nil {
-				if t, err := c.env.GetVar(s.Name); err == nil {
-					if mt, ok := t.(types.MapType); ok {
-						value = fmt.Sprintf("{} as dict[%s, %s]", pyType(mt.Key), pyType(mt.Value))
-					}
-				}
-			}
-		}
+               if ml := s.Value.Binary.Left.Value.Target.Map; ml != nil && len(ml.Items) == 0 {
+                       if c.env != nil {
+                               if t, err := c.env.GetVar(s.Name); err == nil {
+                                       if mt, ok := t.(types.MapType); ok {
+                                               c.imports["typing"] = "typing"
+                                               value = fmt.Sprintf("typing.cast(dict[%s, %s], {})", pyType(mt.Key), pyType(mt.Value))
+                                       }
+                               }
+                       }
+               }
 		if value == "None" {
 			v, err := c.compileExpr(s.Value)
 			if err != nil {


### PR DESCRIPTION
## Summary
- fix map literal casts in Python compiler

## Testing
- `go test ./compile/py -count=1`

------
https://chatgpt.com/codex/tasks/task_e_684efe9871308320a18a92c642ff8ee1