### PR TITLE
Fix TS compiler precedence

### DIFF
--- a/compile/ts/helpers.go
+++ b/compile/ts/helpers.go
@@ -169,6 +169,16 @@ func isList(t types.Type) bool {
 	return ok
 }
 
+func isMap(t types.Type) bool {
+	_, ok := t.(types.MapType)
+	return ok
+}
+
+func isStruct(t types.Type) bool {
+	_, ok := t.(types.StructType)
+	return ok
+}
+
 func tsType(t types.Type) string {
 	switch tt := t.(type) {
 	case types.IntType, types.Int64Type, types.FloatType:
@@ -197,6 +207,15 @@ func tsType(t types.Type) string {
 func isAny(t types.Type) bool {
 	_, ok := t.(types.AnyType)
 	return ok
+}
+
+func contains(sl []string, s string) bool {
+	for _, v := range sl {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveTypeRef(t *parser.TypeRef) types.Type {

--- a/compile/ts/runtime.go
+++ b/compile/ts/runtime.go
@@ -48,6 +48,21 @@ const (
 		"  return JSON.parse(prompt) as T;\n" +
 		"}\n"
 
+	helperEqual = "function _equal(a: any, b: any): boolean {\n" +
+		"  if (Array.isArray(a) && Array.isArray(b)) {\n" +
+		"    if (a.length !== b.length) return false;\n" +
+		"    for (let i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }\n" +
+		"    return true;\n" +
+		"  }\n" +
+		"  if (a && b && typeof a === 'object' && typeof b === 'object') {\n" +
+		"    const ak = Object.keys(a); const bk = Object.keys(b);\n" +
+		"    if (ak.length !== bk.length) return false;\n" +
+		"    for (const k of ak) { if (!bk.includes(k) || !_equal((a as any)[k], (b as any)[k])) return false; }\n" +
+		"    return true;\n" +
+		"  }\n" +
+		"  return a === b;\n" +
+		"}\n"
+
 	helperFetch = "function _fetch(url: string, opts: any): any {\n" +
 		"  const args: string[] = ['-s'];\n" +
 		"  const method = opts?.method ?? 'GET';\n" +
@@ -293,6 +308,7 @@ var helperMap = map[string]string{
 	"_gen_text":   helperGenText,
 	"_gen_embed":  helperGenEmbed,
 	"_gen_struct": helperGenStruct,
+	"_equal":      helperEqual,
 	"_fetch":      helperFetch,
 	"_toAnyMap":   helperToAnyMap,
 	"_stream":     helperStream,


### PR DESCRIPTION
## Summary
- add equality helper to the TypeScript runtime
- detect lists, maps and structs in TS helper utilities
- implement operator precedence for TS compiler
- use deep equality for complex types

## Testing
- `go test ./compile/ts --vet=off`
- `deno run --quiet /tmp/tmp.ts` for LeetCode examples

------
https://chatgpt.com/codex/tasks/task_e_684efeb9ffd0832080b67ce05e366673