### PR TITLE
Add batch build for LeetCode examples

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -2534,7 +2534,7 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 			child.SetVar(p.Name, resolveTypeRef(p.Type), true)
 		}
 	}
-	sub := &Compiler{imports: c.imports, helpers: c.helpers, env: child}
+       sub := &Compiler{imports: c.imports, helpers: c.helpers, env: child, memo: map[string]*parser.Literal{}}
 	sub.indent = 1
 	if fn.Return != nil {
 		sub.returnType = resolveTypeRef(fn.Return)

--- a/examples/leetcode-out/add-binary.go.out
+++ b/examples/leetcode-out/add-binary.go.out
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func addBinary(a string, b string) string {
+	var digits map[string]int = map[string]int{"0": 0, "1": 1}
+	var i int = len(a)
+	_ = i
+	var j int = len(b)
+	_ = j
+	var carry int = 0
+	_ = carry
+	var out string = ""
+	_ = out
+	for (((i > 0) || (j > 0)) || (carry > 0)) {
+		var x int = 0
+		_ = x
+		if (i > 0) {
+			i = (i - 1)
+			x = digits[_indexString(a, i)]
+		}
+		var y int = 0
+		_ = y
+		if (j > 0) {
+			j = (j - 1)
+			y = digits[_indexString(b, j)]
+		}
+		var sum int = ((x + y) + carry)
+		carry = (sum / 2)
+		var bit int = (sum % 2)
+		out = fmt.Sprint(bit) + out
+	}
+	return out
+}
+
+func example_1() {
+	expect((addBinary("11", "1") == "100"))
+}
+
+func example_2() {
+	expect((addBinary("1010", "1011") == "10101"))
+}
+
+func zero() {
+	expect((addBinary("0", "0") == "0"))
+}
+
+func different_lengths() {
+	expect((addBinary("1", "111") == "1000"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	zero()
+	different_lengths()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/add-two-numbers.go.out
+++ b/examples/leetcode-out/add-two-numbers.go.out
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func addTwoNumbers(l1 []int, l2 []int) []int {
+	var i int = 0
+	_ = i
+	var j int = 0
+	_ = j
+	var carry int = 0
+	_ = carry
+	var result []any = []any{}
+	_ = result
+	for (((i < len(l1)) || (j < len(l2))) || (carry > 0)) {
+		var x int = 0
+		_ = x
+		if (i < len(l1)) {
+			x = l1[i]
+			i = (i + 1)
+		}
+		var y int = 0
+		_ = y
+		if (j < len(l2)) {
+			y = l2[j]
+			j = (j + 1)
+		}
+		var sum int = ((x + y) + carry)
+		var digit int = (sum % 10)
+		carry = (sum / 10)
+		result = append(append([]any{}, result...), _toAnySlice([]int{digit})...)
+	}
+	return _cast[[]int](result)
+}
+
+func example_1() {
+	expect(_equal(addTwoNumbers([]int{2, 4, 3}, []int{5, 6, 4}), []int{7, 0, 8}))
+}
+
+func example_2() {
+	expect(_equal(addTwoNumbers([]int{0}, []int{0}), []int{0}))
+}
+
+func example_3() {
+	expect(_equal(addTwoNumbers([]int{9, 9, 9, 9, 9, 9, 9}, []int{9, 9, 9, 9}), []int{8, 9, 9, 9, 0, 0, 0, 1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/balanced-binary-tree.go.out
+++ b/examples/leetcode-out/balanced-binary-tree.go.out
@@ -1,0 +1,91 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+type Info struct {
+	Height int `json:"height"`
+	Balanced bool `json:"balanced"`
+}
+
+func max(a int, b int) int {
+	if (a > b) {
+		return a
+	} else {
+		return b
+	}
+}
+
+func abs(x int) int {
+	if (x < 0) {
+		return -x
+	} else {
+		return x
+	}
+}
+
+func height(t any) int {
+	return func() int {
+	_t := t
+	switch _t {
+	case Leaf:
+		return 0
+	case Node(l, _, r):
+		return (max(height(l), height(r)) + 1)
+	}
+}()
+}
+
+func balanced(t any) bool {
+	return func() bool {
+	_t := t
+	switch _t {
+	case Leaf:
+		return true
+	case Node(l, _, r):
+		return ((balanced(l) && balanced(r)) && (abs((height(l) - height(r))) <= 1))
+	}
+}()
+}
+
+func isBalanced(root any) bool {
+	return balanced(root)
+}
+
+func example_1() {
+	var tree Node = Node{Left: Node{Left: Leaf{}, Value: 9, Right: Leaf{}}, Value: 3, Right: Node{Left: Node{Left: Leaf{}, Value: 15, Right: Leaf{}}, Value: 20, Right: Node{Left: Leaf{}, Value: 7, Right: Leaf{}}}}
+	expect((isBalanced(tree) == true))
+}
+
+func example_2() {
+	var tree Node = Node{Left: Node{Left: Node{Left: Node{Left: Leaf{}, Value: 4, Right: Leaf{}}, Value: 3, Right: Node{Left: Leaf{}, Value: 4, Right: Leaf{}}}, Value: 2, Right: Node{Left: Leaf{}, Value: 3, Right: Leaf{}}}, Value: 1, Right: Node{Left: Leaf{}, Value: 2, Right: Leaf{}}}
+	expect((isBalanced(tree) == false))
+}
+
+func single_node() {
+	expect((isBalanced(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}) == true))
+}
+
+func empty() {
+	expect((isBalanced(Leaf{}) == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_node()
+	empty()
+}
+

--- a/examples/leetcode-out/basic-calculator.go.out
+++ b/examples/leetcode-out/basic-calculator.go.out
@@ -1,0 +1,99 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func digitValue(c string) int {
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	return digits[c]
+}
+
+func isDigit(c string) bool {
+	return ((c >= "0") && (c <= "9"))
+}
+
+func calculate(s string) int {
+	var i int = 0
+	_ = i
+	var n int = len(s)
+	_ = n
+	var result int = 0
+	_ = result
+	var sign int = 1
+	_ = sign
+	var num int = 0
+	_ = num
+	var stack []int = []int{}
+	_ = stack
+	for (i < n) {
+		var c string = _indexString(s, i)
+		if isDigit(c) {
+			num = ((num * 10) + digitValue(c))
+		} else 		if (c == "+") {
+			result = (result + (sign * num))
+			num = 0
+			sign = 1
+		} else 		if (c == "-") {
+			result = (result + (sign * num))
+			num = 0
+			sign = -1
+		} else 		if (c == "(") {
+			stack = append(append([]int{}, stack...), []int{result}...)
+			stack = append(append([]int{}, stack...), []int{sign}...)
+			result = 0
+			sign = 1
+		} else 		if (c == ")") {
+			result = (result + (sign * num))
+			num = 0
+			var prevSign int = stack[(len(stack) - 1)]
+			stack = stack[0:(len(stack) - 1)]
+			var prevResult int = stack[(len(stack) - 1)]
+			stack = stack[0:(len(stack) - 1)]
+			result = (prevResult + (prevSign * result))
+		}
+		i = (i + 1)
+	}
+	result = (result + (sign * num))
+	return result
+}
+
+func example_1() {
+	expect((calculate("1 + 1") == 2))
+}
+
+func example_2() {
+	expect((calculate(" 2-1 + 2 ") == 3))
+}
+
+func example_3() {
+	expect((calculate("(1+(4+5+2)-3)+(6+8)") == 23))
+}
+
+func nested() {
+	expect((calculate("((2+3)-(1-2))") == 6))
+}
+
+func single_number() {
+	expect((calculate("42") == 42))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	nested()
+	single_number()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/best-time-to-buy-and-sell-stock-ii.go.out
+++ b/examples/leetcode-out/best-time-to-buy-and-sell-stock-ii.go.out
@@ -1,0 +1,40 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxProfit(prices []int) int {
+	var n int = len(prices)
+	var profit int = 0
+	_ = profit
+	var i int = 1
+	_ = i
+	for (i < n) {
+		var diff int = (prices[i] - prices[(i - 1)])
+		if (diff > 0) {
+			profit = (profit + diff)
+		}
+		i = (i + 1)
+	}
+	return profit
+}
+
+func example_1() {
+	expect((maxProfit([]int{7, 1, 5, 3, 6, 4}) == 7))
+}
+
+func example_2() {
+	expect((maxProfit([]int{1, 2, 3, 4, 5}) == 4))
+}
+
+func example_3() {
+	expect((maxProfit([]int{7, 6, 4, 3, 1}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/best-time-to-buy-and-sell-stock-iii.go.out
+++ b/examples/leetcode-out/best-time-to-buy-and-sell-stock-iii.go.out
@@ -1,0 +1,67 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxProfit(prices []int) int {
+	var n int = len(prices)
+	if (n == 0) {
+		return 0
+	}
+	var buy1 int = (0 - prices[0])
+	_ = buy1
+	var sell1 int = 0
+	_ = sell1
+	var buy2 int = (0 - prices[0])
+	_ = buy2
+	var sell2 int = 0
+	_ = sell2
+	var i int = 1
+	_ = i
+	for (i < n) {
+		var price int = prices[i]
+		var b1 int = (0 - price)
+		if (b1 > buy1) {
+			buy1 = b1
+		}
+		var s1 int = (buy1 + price)
+		if (s1 > sell1) {
+			sell1 = s1
+		}
+		var b2 int = (sell1 - price)
+		if (b2 > buy2) {
+			buy2 = b2
+		}
+		var s2 int = (buy2 + price)
+		if (s2 > sell2) {
+			sell2 = s2
+		}
+		i = (i + 1)
+	}
+	return sell2
+}
+
+func example_1() {
+	expect((maxProfit([]int{3, 3, 5, 0, 0, 3, 1, 4}) == 6))
+}
+
+func example_2() {
+	expect((maxProfit([]int{1, 2, 3, 4, 5}) == 4))
+}
+
+func example_3() {
+	expect((maxProfit([]int{7, 6, 4, 3, 1}) == 0))
+}
+
+func single_price() {
+	expect((maxProfit([]int{5}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_price()
+}
+

--- a/examples/leetcode-out/best-time-to-buy-and-sell-stock-iv.go.out
+++ b/examples/leetcode-out/best-time-to-buy-and-sell-stock-iv.go.out
@@ -1,0 +1,91 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxProfit(k int, prices []int) int {
+	var n int = len(prices)
+	if ((n == 0) || (k == 0)) {
+		return 0
+	}
+	if (k >= (n / 2)) {
+		var profit int = 0
+		_ = profit
+		for i := 1; i < n; i++ {
+			var diff int = (prices[i] - prices[(i - 1)])
+			if (diff > 0) {
+				profit = (profit + diff)
+			}
+		}
+		return profit
+	}
+	var buy []int = []int{}
+	_ = buy
+	var sell []int = []int{}
+	_ = sell
+	var idx int = 0
+	_ = idx
+	for (idx < k) {
+		buy = append(append([]int{}, buy...), []int{(0 - prices[0])}...)
+		sell = append(append([]int{}, sell...), []int{0}...)
+		idx = (idx + 1)
+	}
+	var i int = 1
+	_ = i
+	for (i < n) {
+		var price int = prices[i]
+		var b0 int = (0 - price)
+		if (b0 > buy[0]) {
+			buy[0] = b0
+		}
+		var s0 int = (buy[0] + price)
+		if (s0 > sell[0]) {
+			sell[0] = s0
+		}
+		var j int = 1
+		_ = j
+		for (j < k) {
+			var b int = (sell[(j - 1)] - price)
+			if (b > buy[j]) {
+				buy[j] = b
+			}
+			var s int = (buy[j] + price)
+			if (s > sell[j]) {
+				sell[j] = s
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return sell[(k - 1)]
+}
+
+func example_1() {
+	expect((maxProfit(2, []int{2, 4, 1}) == 2))
+}
+
+func example_2() {
+	expect((maxProfit(2, []int{3, 2, 6, 5, 0, 3}) == 7))
+}
+
+func empty_prices() {
+	expect((maxProfit(3, []int{}) == 0))
+}
+
+func unlimited_transactions() {
+	expect((maxProfit(100, []int{1, 2, 3, 4, 5}) == 4))
+}
+
+func zero_k() {
+	expect((maxProfit(0, []int{1, 3, 2, 8}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_prices()
+	unlimited_transactions()
+	zero_k()
+}
+

--- a/examples/leetcode-out/best-time-to-buy-and-sell-stock.go.out
+++ b/examples/leetcode-out/best-time-to-buy-and-sell-stock.go.out
@@ -1,0 +1,57 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxProfit(prices []int) int {
+	if (len(prices) == 0) {
+		return 0
+	}
+	var minPrice int = prices[0]
+	_ = minPrice
+	var maxProfit func([]int) int = 0
+	_ = maxProfit
+	var i int = 1
+	_ = i
+	for (i < len(prices)) {
+		var price int = prices[i]
+		if (price < minPrice) {
+			minPrice = price
+		} else {
+			var profit int = (price - minPrice)
+			if (profit > maxProfit) {
+				maxProfit = profit
+			}
+		}
+		i = (i + 1)
+	}
+	return _cast[int](maxProfit)
+}
+
+func example_1() {
+	expect((maxProfit([]int{7, 1, 5, 3, 6, 4}) == 5))
+}
+
+func example_2() {
+	expect((maxProfit([]int{7, 6, 4, 3, 1}) == 0))
+}
+
+func single_price() {
+	expect((maxProfit([]int{5}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_price()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/binary-tree-inorder-traversal.go.out
+++ b/examples/leetcode-out/binary-tree-inorder-traversal.go.out
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func inorderTraversal(t any) []int {
+	return func() []int {
+	_t := t
+	switch _t {
+	case Leaf:
+		return _cast[[]int]([]any{})
+	case Node(l, v, r):
+		return append(append([]any{}, append(append([]any{}, _toAnySlice(inorderTraversal(l))...), []any{v}...)...), _toAnySlice(inorderTraversal(r))...)
+	}
+}()
+}
+
+func example_1() {
+	expect(_equal(inorderTraversal(example1), []int{1, 3, 2}))
+}
+
+func empty() {
+	expect(_equal(inorderTraversal(Leaf{}), []any{}))
+}
+
+func single_node() {
+	expect(_equal(inorderTraversal(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}), []int{1}))
+}
+
+var example1 Node = Node{Left: Leaf{}, Value: 1, Right: Node{Left: Node{Left: Leaf{}, Value: 3, Right: Leaf{}}, Value: 2, Right: Leaf{}}}
+func main() {
+	example_1()
+	empty()
+	single_node()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/binary-tree-level-order-traversal-ii.go.out
+++ b/examples/leetcode-out/binary-tree-level-order-traversal-ii.go.out
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func levelOrderBottom(root any) [][]int {
+	if func() bool {
+	_t := root
+	switch _t {
+	case Leaf:
+		return true
+	default:
+		return false
+	}
+}() {
+		return _cast[[][]int]([]any{})
+	}
+	var result [][]int = [][]int{}
+	_ = result
+	var queue []any = []any{root}
+	_ = queue
+	for (len(queue) > 0) {
+		var level []int = []int{}
+		_ = level
+		var next []any = []any{}
+		_ = next
+		for _, node := range queue {
+			if func() bool {
+	_t := node
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+				level = append(append([]any{}, _toAnySlice(level)...), []any{node.Value}...)
+				if func() bool {
+	_t := node.Left
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+					next = append(append([]any{}, next...), []any{node.Left}...)
+				}
+				if func() bool {
+	_t := node.Right
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+					next = append(append([]any{}, next...), []any{node.Right}...)
+				}
+			}
+		}
+		result = append(append([][]int{}, [][]int{level}...), result...)
+		queue = next
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(levelOrderBottom(example1), [][]int{[]int{15, 7}, []int{9, 20}, []int{3}}))
+}
+
+func single_node() {
+	expect(_equal(levelOrderBottom(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}), [][]int{[]int{1}}))
+}
+
+func empty() {
+	expect(_equal(levelOrderBottom(Leaf{}), []any{}))
+}
+
+var example1 Node = Node{Left: Node{Left: Leaf{}, Value: 9, Right: Leaf{}}, Value: 3, Right: Node{Left: Node{Left: Leaf{}, Value: 15, Right: Leaf{}}, Value: 20, Right: Node{Left: Leaf{}, Value: 7, Right: Leaf{}}}}
+func main() {
+	example_1()
+	single_node()
+	empty()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/binary-tree-level-order-traversal.go.out
+++ b/examples/leetcode-out/binary-tree-level-order-traversal.go.out
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func levelOrder(root any) [][]int {
+	if func() bool {
+	_t := root
+	switch _t {
+	case Leaf:
+		return true
+	default:
+		return false
+	}
+}() {
+		return _cast[[][]int]([]any{})
+	}
+	var result [][]int = [][]int{}
+	_ = result
+	var queue []any = []any{root}
+	_ = queue
+	for (len(queue) > 0) {
+		var level []int = []int{}
+		_ = level
+		var next []any = []any{}
+		_ = next
+		for _, node := range queue {
+			if func() bool {
+	_t := node
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+				level = append(append([]any{}, _toAnySlice(level)...), []any{node.Value}...)
+				if func() bool {
+	_t := node.Left
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+					next = append(append([]any{}, next...), []any{node.Left}...)
+				}
+				if func() bool {
+	_t := node.Right
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+					next = append(append([]any{}, next...), []any{node.Right}...)
+				}
+			}
+		}
+		result = append(append([][]int{}, result...), [][]int{level}...)
+		queue = next
+	}
+	return result
+}
+
+func example_1() {
+	var tree Node = Node{Left: Node{Left: Leaf{}, Value: 9, Right: Leaf{}}, Value: 3, Right: Node{Left: Node{Left: Leaf{}, Value: 15, Right: Leaf{}}, Value: 20, Right: Node{Left: Leaf{}, Value: 7, Right: Leaf{}}}}
+	expect(_equal(levelOrder(tree), [][]int{[]int{3}, []int{9, 20}, []int{15, 7}}))
+}
+
+func single_node() {
+	expect(_equal(levelOrder(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}), [][]int{[]int{1}}))
+}
+
+func empty() {
+	expect(_equal(levelOrder(Leaf{}), []any{}))
+}
+
+func main() {
+	example_1()
+	single_node()
+	empty()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/binary-tree-postorder-traversal.go.out
+++ b/examples/leetcode-out/binary-tree-postorder-traversal.go.out
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func postorderTraversal(t any) []int {
+	return func() []int {
+	_t := t
+	switch _t {
+	case Leaf:
+		return _cast[[]int]([]any{})
+	case Node(l, v, r):
+		return append(append([]any{}, _toAnySlice(append(append([]int{}, postorderTraversal(l)...), postorderTraversal(r)...))...), []any{v}...)
+	}
+}()
+}
+
+func example_1() {
+	expect(_equal(postorderTraversal(example1), []int{3, 2, 1}))
+}
+
+func single_node() {
+	expect(_equal(postorderTraversal(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}), []int{1}))
+}
+
+func empty() {
+	expect(_equal(postorderTraversal(Leaf{}), []any{}))
+}
+
+var example1 Node = Node{Left: Leaf{}, Value: 1, Right: Node{Left: Node{Left: Leaf{}, Value: 3, Right: Leaf{}}, Value: 2, Right: Leaf{}}}
+func main() {
+	example_1()
+	single_node()
+	empty()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/binary-tree-preorder-traversal.go.out
+++ b/examples/leetcode-out/binary-tree-preorder-traversal.go.out
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func preorderTraversal(t any) []int {
+	return func() any {
+	_t := t
+	switch _t {
+	case Leaf:
+		return _cast[[]int]([]any{})
+	case Node(l, v, r):
+		return append(append([]any{}, append(append([]any{}, []any{v}...), _toAnySlice(preorderTraversal(l))...)...), _toAnySlice(preorderTraversal(r))...)
+	}
+	return nil
+}()
+}
+
+func example_1() {
+	expect(_equal(preorderTraversal(example1), []int{1, 2, 3}))
+}
+
+func empty() {
+	expect(_equal(preorderTraversal(Leaf{}), []any{}))
+}
+
+func single_node() {
+	expect(_equal(preorderTraversal(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}), []int{1}))
+}
+
+var example1 Node = Node{Left: Leaf{}, Value: 1, Right: Node{Left: Node{Left: Leaf{}, Value: 3, Right: Leaf{}}, Value: 2, Right: Leaf{}}}
+func main() {
+	example_1()
+	empty()
+	single_node()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/binary-tree-zigzag-level-order-traversal.go.out
+++ b/examples/leetcode-out/binary-tree-zigzag-level-order-traversal.go.out
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func reverseList(xs []int) []int {
+	var out []int = []int{}
+	_ = out
+	var i int = (len(xs) - 1)
+	_ = i
+	for (i >= 0) {
+		out = append(append([]int{}, out...), []int{xs[i]}...)
+		i = (i - 1)
+	}
+	return out
+}
+
+func zigzagLevelOrder(root any) [][]int {
+	if func() bool {
+	_t := root
+	switch _t {
+	case Leaf:
+		return true
+	default:
+		return false
+	}
+}() {
+		return _cast[[][]int]([]any{})
+	}
+	var result [][]int = [][]int{}
+	_ = result
+	var queue []any = []any{root}
+	_ = queue
+	var level int = 0
+	_ = level
+	for (len(queue) > 0) {
+		var vals []int = []int{}
+		_ = vals
+		var next []any = []any{}
+		_ = next
+		for _, node := range queue {
+			if func() bool {
+	_t := node
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+				vals = append(append([]any{}, _toAnySlice(vals)...), []any{node.Value}...)
+				if func() bool {
+	_t := node.Left
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+					next = append(append([]any{}, next...), []any{node.Left}...)
+				}
+				if func() bool {
+	_t := node.Right
+	switch _t {
+	case Leaf:
+		return false
+	default:
+		return true
+	}
+}() {
+					next = append(append([]any{}, next...), []any{node.Right}...)
+				}
+			}
+		}
+		if ((level % 2) == 1) {
+			vals = reverseList(vals)
+		}
+		result = append(append([][]int{}, result...), [][]int{vals}...)
+		queue = next
+		level = (level + 1)
+	}
+	return result
+}
+
+func example_1() {
+	var tree Node = Node{Left: Node{Left: Leaf{}, Value: 9, Right: Leaf{}}, Value: 3, Right: Node{Left: Node{Left: Leaf{}, Value: 15, Right: Leaf{}}, Value: 20, Right: Node{Left: Leaf{}, Value: 7, Right: Leaf{}}}}
+	expect(_equal(zigzagLevelOrder(tree), [][]int{[]int{3}, []int{20, 9}, []int{15, 7}}))
+}
+
+func single_node() {
+	expect(_equal(zigzagLevelOrder(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}), [][]int{[]int{1}}))
+}
+
+func empty() {
+	expect(_equal(zigzagLevelOrder(Leaf{}), []any{}))
+}
+
+func unbalanced() {
+	var tree Node = Node{Left: Node{Left: Node{Left: Leaf{}, Value: 4, Right: Leaf{}}, Value: 2, Right: Leaf{}}, Value: 1, Right: Node{Left: Leaf{}, Value: 3, Right: Node{Left: Leaf{}, Value: 5, Right: Leaf{}}}}
+	expect(_equal(zigzagLevelOrder(tree), [][]int{[]int{1}, []int{3, 2}, []int{4, 5}}))
+}
+
+func main() {
+	example_1()
+	single_node()
+	empty()
+	unbalanced()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/bitwise-and-of-numbers-range.go.out
+++ b/examples/leetcode-out/bitwise-and-of-numbers-range.go.out
@@ -1,0 +1,54 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func rangeBitwiseAnd(left int, right int) int {
+	var l int = left
+	_ = l
+	var r int = right
+	_ = r
+	var shift int = 0
+	_ = shift
+	for (l < r) {
+		l = (l / 2)
+		r = (r / 2)
+		shift = (shift + 1)
+	}
+	var factor int = 1
+	_ = factor
+	for _ := 0; _ < shift; _++ {
+		factor = (factor * 2)
+	}
+	return (l * factor)
+}
+
+func example_1() {
+	expect((rangeBitwiseAnd(5, 7) == 4))
+}
+
+func example_2() {
+	expect((rangeBitwiseAnd(0, 0) == 0))
+}
+
+func example_3() {
+	expect((rangeBitwiseAnd(1, 2147483647) == 0))
+}
+
+func single_number() {
+	expect((rangeBitwiseAnd(13, 13) == 13))
+}
+
+func power_of_two() {
+	expect((rangeBitwiseAnd(8, 15) == 8))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_number()
+	power_of_two()
+}
+

--- a/examples/leetcode-out/candy.go.out
+++ b/examples/leetcode-out/candy.go.out
@@ -1,0 +1,65 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func candy(ratings []int) int {
+	var n int = len(ratings)
+	if (n == 0) {
+		return 0
+	}
+	var candies []int = []int{}
+	_ = candies
+	var i int = 0
+	_ = i
+	for (i < n) {
+		candies = append(append([]int{}, candies...), []int{1}...)
+		i = (i + 1)
+	}
+	i = 1
+	for (i < n) {
+		if (ratings[i] > ratings[(i - 1)]) {
+			candies[i] = (candies[(i - 1)] + 1)
+		}
+		i = (i + 1)
+	}
+	var j int = (n - 2)
+	_ = j
+	for (j >= 0) {
+		if ((ratings[j] > ratings[(j + 1)]) && (candies[j] <= candies[(j + 1)])) {
+			candies[j] = (candies[(j + 1)] + 1)
+		}
+		j = (j - 1)
+	}
+	var total int = 0
+	_ = total
+	for _, c := range candies {
+		total = (total + c)
+	}
+	return total
+}
+
+func example_1() {
+	expect((candy([]int{1, 0, 2}) == 5))
+}
+
+func example_2() {
+	expect((candy([]int{1, 2, 2}) == 4))
+}
+
+func all_equal() {
+	expect((candy([]int{1, 1, 1}) == 3))
+}
+
+func descending() {
+	expect((candy([]int{5, 4, 3, 2, 1}) == 15))
+}
+
+func main() {
+	example_1()
+	example_2()
+	all_equal()
+	descending()
+}
+

--- a/examples/leetcode-out/character-replacement.go.out
+++ b/examples/leetcode-out/character-replacement.go.out
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+)
+
+func characterReplacement(s string, k int) int {
+	var letters []string = []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"}
+	var n int = len(s)
+	var best int = 0
+	_ = best
+	for i := 0; i < n; i++ {
+		for j := (i + 1); j < (n + 1); j++ {
+			var length int = (j - i)
+			if (length <= best) {
+				continue
+			}
+			var sub string = string([]rune(s)[i:j])
+			for _, ch := range letters {
+				var diff int = 0
+				_ = diff
+				for idx := 0; idx < len(sub); idx++ {
+					var c string = _indexString(sub, idx)
+					if (c != ch) {
+						diff = (diff + 1)
+						if (diff > k) {
+							break
+						}
+					}
+				}
+				if (diff <= k) {
+					best = length
+					break
+				}
+			}
+		}
+	}
+	return best
+}
+
+func main() {
+	fmt.Println(characterReplacement("ABAB", 2))
+	fmt.Println(characterReplacement("AABABBA", 1))
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/climbing-stairs.go.out
+++ b/examples/leetcode-out/climbing-stairs.go.out
@@ -1,0 +1,48 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func climbStairs(n int) int {
+	if (n <= 2) {
+		return n
+	}
+	var first int = 1
+	_ = first
+	var second int = 2
+	_ = second
+	var i int = 3
+	_ = i
+	for (i <= n) {
+		var next int = (first + second)
+		first = second
+		second = next
+		i = (i + 1)
+	}
+	return second
+}
+
+func example_1() {
+	expect((climbStairs(2) == 2))
+}
+
+func example_2() {
+	expect((climbStairs(3) == 3))
+}
+
+func n___4() {
+	expect((climbStairs(4) == 5))
+}
+
+func n___5() {
+	expect((climbStairs(5) == 8))
+}
+
+func main() {
+	example_1()
+	example_2()
+	n___4()
+	n___5()
+}
+

--- a/examples/leetcode-out/combination-sum-iii.go.out
+++ b/examples/leetcode-out/combination-sum-iii.go.out
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func combinationSum3(k int, n int) [][]int {
+	var result [][]int = [][]int{}
+	_ = result
+	var backtrack func(int, int, []int)
+	backtrack = func(start int, remain int, path []int) {
+		if (len(path) == k) {
+			if (remain == 0) {
+				result = append(append([][]int{}, result...), [][]int{path}...)
+			}
+		} else 	if (remain > 0) {
+			var i int = start
+			_ = i
+			for (i <= 9) {
+				if (i > remain) {
+					break
+				}
+				backtrack((i + 1), (remain - i), append(append([]int{}, path...), []int{i}...))
+				i = (i + 1)
+			}
+		}
+}
+	backtrack(1, n, []int{})
+	return result
+}
+
+func example_1() {
+	expect(_equal(combinationSum3(3, 7), [][]int{[]int{1, 2, 4}}))
+}
+
+func example_2() {
+	expect(_equal(combinationSum3(3, 9), [][]int{[]int{1, 2, 6}, []int{1, 3, 5}, []int{2, 3, 4}}))
+}
+
+func example_3() {
+	expect(_equal(combinationSum3(4, 1), []any{}))
+}
+
+func no_combination() {
+	expect(_equal(combinationSum3(3, 2), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	no_combination()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/combinations.go.out
+++ b/examples/leetcode-out/combinations.go.out
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func combine(n int, k int) [][]int {
+	var result [][]int = [][]int{}
+	_ = result
+	var backtrack func(int, []int)
+	backtrack = func(start int, path []int) {
+		if (len(path) == k) {
+			result = append(append([][]int{}, result...), [][]int{path}...)
+		} else {
+			var i int = start
+			_ = i
+			for (i <= n) {
+				backtrack((i + 1), append(append([]int{}, path...), []int{i}...))
+				i = (i + 1)
+			}
+		}
+}
+	backtrack(1, []int{})
+	return result
+}
+
+func example_1() {
+	expect(_equal(combine(4, 2), [][]int{[]int{1, 2}, []int{1, 3}, []int{1, 4}, []int{2, 3}, []int{2, 4}, []int{3, 4}}))
+}
+
+func example_2() {
+	expect(_equal(combine(1, 1), [][]int{[]int{1}}))
+}
+
+func n___3__k___3() {
+	expect(_equal(combine(3, 3), [][]int{[]int{1, 2, 3}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	n___3__k___3()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/combine-two-tables.go.out
+++ b/examples/leetcode-out/combine-two-tables.go.out
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Person struct {
+	PersonId int `json:"personId"`
+	FirstName string `json:"firstName"`
+	LastName string `json:"lastName"`
+}
+
+type Address struct {
+	AddressId int `json:"addressId"`
+	PersonId int `json:"personId"`
+	City string `json:"city"`
+	State string `json:"state"`
+}
+
+type Result struct {
+	FirstName string `json:"firstName"`
+	LastName string `json:"lastName"`
+	City string `json:"city"`
+	State string `json:"state"`
+}
+
+func combineTables(persons []Person, addresses []Address) []Result {
+	var results []any = []any{}
+	_ = results
+	for _, p := range persons {
+		var found bool = false
+		_ = found
+		for _, a := range addresses {
+			if (a.PersonId == p.PersonId) {
+				results = append(append([]any{}, results...), _toAnySlice([]Result{Result{FirstName: p.FirstName, LastName: p.LastName, City: a.City, State: a.State}})...)
+				found = true
+				break
+			}
+		}
+		if !found {
+			results = append(append([]any{}, results...), _toAnySlice([]Result{Result{FirstName: p.FirstName, LastName: p.LastName, City: "", State: ""}})...)
+		}
+	}
+	return _cast[[]Result](results)
+}
+
+func combine_tables() {
+	var expected []Result = []Result{Result{FirstName: "Wang", LastName: "Allen", City: "", State: ""}, Result{FirstName: "Alice", LastName: "Bob", City: "New York City", State: "New York"}, Result{FirstName: "Bob", LastName: "Brown", City: "Leetcode", State: "California"}}
+	expect((fmt.Sprint(combineTables(person, address)) == fmt.Sprint(expected)))
+}
+
+var person []Person = []Person{Person{PersonId: 1, FirstName: "Wang", LastName: "Allen"}, Person{PersonId: 2, FirstName: "Alice", LastName: "Bob"}, Person{PersonId: 3, FirstName: "Bob", LastName: "Brown"}}
+var address []Address = []Address{Address{AddressId: 1, PersonId: 2, City: "New York City", State: "New York"}, Address{AddressId: 2, PersonId: 3, City: "Leetcode", State: "California"}}
+func main() {
+	combine_tables()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/common-errors.go.out
+++ b/examples/leetcode-out/common-errors.go.out
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+}
+

--- a/examples/leetcode-out/compare-version-numbers.go.out
+++ b/examples/leetcode-out/compare-version-numbers.go.out
@@ -1,0 +1,104 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func parseInt(s string) int {
+	var result int = 0
+	_ = result
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	var i int = 0
+	_ = i
+	for (i < len(s)) {
+		var ch string = _indexString(s, i)
+		result = ((result * 10) + digits[ch])
+		i = (i + 1)
+	}
+	return result
+}
+
+func parseVersion(v string) []int {
+	var parts []int = []int{}
+	_ = parts
+	var start int = 0
+	_ = start
+	var i int = 0
+	_ = i
+	for (i < len(v)) {
+		if (_indexString(v, i) == ".") {
+			var segment string = string([]rune(v)[start:i])
+			parts = append(append([]int{}, parts...), []int{parseInt(segment)}...)
+			start = (i + 1)
+		}
+		i = (i + 1)
+	}
+	var segment string = string([]rune(v)[start:len(v)])
+	parts = append(append([]int{}, parts...), []int{parseInt(segment)}...)
+	return parts
+}
+
+func compareVersion(v1 string, v2 string) int {
+	var a1 []int = parseVersion(v1)
+	var a2 []int = parseVersion(v2)
+	var i int = 0
+	_ = i
+	var j int = 0
+	_ = j
+	for ((i < len(a1)) || (j < len(a2))) {
+		var n1 int = 0
+		_ = n1
+		if (i < len(a1)) {
+			n1 = a1[i]
+			i = (i + 1)
+		}
+		var n2 int = 0
+		_ = n2
+		if (j < len(a2)) {
+			n2 = a2[j]
+			j = (j + 1)
+		}
+		if (n1 > n2) {
+			return 1
+		}
+		if (n1 < n2) {
+			return -1
+		}
+	}
+	return 0
+}
+
+func example_1() {
+	expect((compareVersion("1.01", "1.001") == 0))
+}
+
+func example_2() {
+	expect((compareVersion("1.0", "1.0.0") == 0))
+}
+
+func example_3() {
+	expect((compareVersion("0.1", "1.1") == (-1)))
+}
+
+func example_4() {
+	expect((compareVersion("1.0.1", "1") == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	example_4()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/consecutive-numbers.go.out
+++ b/examples/leetcode-out/consecutive-numbers.go.out
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findConsecutive(nums []int) []int {
+	var n int = len(nums)
+	var result []int = []int{}
+	_ = result
+	var i int = 0
+	_ = i
+	for ((i + 2) < n) {
+		if ((nums[i] == nums[(i + 1)]) && (nums[(i + 1)] == nums[(i + 2)])) {
+			if (len(result) == 0) {
+				result = append(append([]int{}, result...), []int{nums[i]}...)
+			} else 			if (result[(len(result) - 1)] != nums[i]) {
+				result = append(append([]int{}, result...), []int{nums[i]}...)
+			}
+		}
+		i = (i + 1)
+	}
+	return result
+}
+
+func example() {
+	expect((fmt.Sprint(findConsecutive([]int{1, 1, 1, 2, 2, 2, 3})) == fmt.Sprint([]int{1, 2})))
+}
+
+func no_triples() {
+	expect((fmt.Sprint(findConsecutive([]int{1, 2, 3, 4})) == fmt.Sprint([]any{})))
+}
+
+func long_sequence() {
+	expect((fmt.Sprint(findConsecutive([]int{4, 4, 4, 4, 4})) == fmt.Sprint([]int{4})))
+}
+
+func main() {
+	example()
+	no_triples()
+	long_sequence()
+}
+

--- a/examples/leetcode-out/construct-binary-tree-from-preorder-and-inorder-traversal.go.out
+++ b/examples/leetcode-out/construct-binary-tree-from-preorder-and-inorder-traversal.go.out
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func buildTree(preorder []int, inorder []int) any {
+	var n int = len(preorder)
+	var idxMap map[int]int = map[int]int{}
+	_ = idxMap
+	for i := 0; i < n; i++ {
+		idxMap[inorder[i]] = i
+	}
+	var preIdx int = 0
+	_ = preIdx
+	var helper = func(lo int, hi int) any {
+		if (lo >= hi) {
+			return Leaf{}
+		}
+		var val int = preorder[preIdx]
+		preIdx = (preIdx + 1)
+		var mid int = idxMap[val]
+		return Node{Left: helper(lo, mid), Value: val, Right: helper((mid + 1), hi)}
+}
+	return helper(0, n)
+}
+
+func preorderTraversal(t any) []int {
+	return _cast[[]int](func() []any {
+	_t := t
+	switch _t {
+	case Leaf:
+		return []any{}
+	case Node(l, v, r):
+		return append(append([]any{}, append(append([]any{}, []any{v}...), _toAnySlice(preorderTraversal(l))...)...), _toAnySlice(preorderTraversal(r))...)
+	}
+}())
+}
+
+func inorderTraversal(t any) []int {
+	return func() any {
+	_t := t
+	switch _t {
+	case Leaf:
+		return []any{}
+	case Node(l, v, r):
+		return append(append([]any{}, append(append([]any{}, _toAnySlice(inorderTraversal(l))...), []any{v}...)...), _toAnySlice(inorderTraversal(r))...)
+	}
+	return nil
+}()
+}
+
+func isLeaf(t any) bool {
+	return func() bool {
+	_t := t
+	switch _t {
+	case Leaf:
+		return true
+	default:
+		return false
+	}
+}()
+}
+
+func example_1() {
+	var preorder []int = []int{3, 9, 20, 15, 7}
+	var inorder []int = []int{9, 3, 15, 20, 7}
+	var tree any = buildTree(preorder, inorder)
+	expect(_equal(preorderTraversal(tree), preorder))
+	expect(_equal(inorderTraversal(tree), inorder))
+}
+
+func single_node() {
+	var preorder []int = []int{1}
+	var inorder []int = []int{1}
+	var tree any = buildTree(preorder, inorder)
+	expect(_equal(preorderTraversal(tree), preorder))
+	expect(_equal(inorderTraversal(tree), inorder))
+}
+
+func empty() {
+	expect((isLeaf(buildTree([]int{}, []int{})) == true))
+}
+
+func main() {
+	example_1()
+	single_node()
+	empty()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/container-with-most-water-alt.go.out
+++ b/examples/leetcode-out/container-with-most-water-alt.go.out
@@ -1,0 +1,55 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxAreaAlt(height []int) int {
+	var left int = 0
+	_ = left
+	var right int = (len(height) - 1)
+	_ = right
+	var best int = 0
+	_ = best
+	for (left < right) {
+		var h int = height[left]
+		_ = h
+		if (height[right] < h) {
+			h = height[right]
+		}
+		var area int = (h * ((right - left)))
+		if (area > best) {
+			best = area
+		}
+		if (height[left] < height[right]) {
+			left = (left + 1)
+		} else {
+			right = (right - 1)
+		}
+	}
+	return best
+}
+
+func example_1() {
+	expect((maxAreaAlt([]int{1, 8, 6, 2, 5, 4, 8, 3, 7}) == 49))
+}
+
+func example_2() {
+	expect((maxAreaAlt([]int{1, 1}) == 1))
+}
+
+func decreasing_heights() {
+	expect((maxAreaAlt([]int{4, 3, 2, 1, 4}) == 16))
+}
+
+func short_array() {
+	expect((maxAreaAlt([]int{1, 2, 1}) == 2))
+}
+
+func main() {
+	example_1()
+	example_2()
+	decreasing_heights()
+	short_array()
+}
+

--- a/examples/leetcode-out/container-with-most-water.go.out
+++ b/examples/leetcode-out/container-with-most-water.go.out
@@ -1,0 +1,66 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxArea(height []int) int {
+	var left int = 0
+	_ = left
+	var right int = (len(height) - 1)
+	_ = right
+	var maxArea func([]int) int = 0
+	_ = maxArea
+	for (left < right) {
+		var width int = (right - left)
+		var h int = 0
+		_ = h
+		if (height[left] < height[right]) {
+			h = height[left]
+		} else {
+			h = height[right]
+		}
+		var area int = (h * width)
+		if (area > maxArea) {
+			maxArea = area
+		}
+		if (height[left] < height[right]) {
+			left = (left + 1)
+		} else {
+			right = (right - 1)
+		}
+	}
+	return _cast[int](maxArea)
+}
+
+func example_1() {
+	expect((maxArea([]int{1, 8, 6, 2, 5, 4, 8, 3, 7}) == 49))
+}
+
+func example_2() {
+	expect((maxArea([]int{1, 1}) == 1))
+}
+
+func decreasing_heights() {
+	expect((maxArea([]int{4, 3, 2, 1, 4}) == 16))
+}
+
+func short_array() {
+	expect((maxArea([]int{1, 2, 1}) == 2))
+}
+
+func main() {
+	example_1()
+	example_2()
+	decreasing_heights()
+	short_array()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/contains-duplicate-ii.go.out
+++ b/examples/leetcode-out/contains-duplicate-ii.go.out
@@ -1,0 +1,61 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func containsNearbyDuplicate(nums []int, k int) bool {
+	var index map[int]int = map[int]int{}
+	_ = index
+	var i int = 0
+	_ = i
+	for (i < len(nums)) {
+		var num int = nums[i]
+		_tmp0 := num
+		_tmp1 := index
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			var j int = index[num]
+			if ((i - j) <= k) {
+				return true
+			}
+		}
+		index[num] = i
+		i = (i + 1)
+	}
+	return false
+}
+
+func example_1() {
+	expect((containsNearbyDuplicate([]int{1, 2, 3, 1}, 3) == true))
+}
+
+func example_2() {
+	expect((containsNearbyDuplicate([]int{1, 0, 1, 1}, 1) == true))
+}
+
+func example_3() {
+	expect((containsNearbyDuplicate([]int{1, 2, 3, 1, 2, 3}, 2) == false))
+}
+
+func no_duplicates() {
+	expect((containsNearbyDuplicate([]int{1, 2, 3, 4, 5}, 3) == false))
+}
+
+func duplicate_at_distance_k() {
+	expect((containsNearbyDuplicate([]int{1, 2, 3, 1}, 2) == false))
+}
+
+func duplicate_with_k_zero() {
+	expect((containsNearbyDuplicate([]int{1, 1}, 0) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	no_duplicates()
+	duplicate_at_distance_k()
+	duplicate_with_k_zero()
+}
+

--- a/examples/leetcode-out/contains-duplicate-iii.go.out
+++ b/examples/leetcode-out/contains-duplicate-iii.go.out
@@ -1,0 +1,68 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func abs(x int) int {
+	if (x < 0) {
+		return -x
+	} else {
+		return x
+	}
+}
+
+func containsNearbyAlmostDuplicate(nums []int, indexDiff int, valueDiff int) bool {
+	if ((indexDiff <= 0) || (valueDiff < 0)) {
+		return false
+	}
+	var i int = 0
+	_ = i
+	for (i < len(nums)) {
+		var j int = (i - 1)
+		_ = j
+		var left int = 0
+		_ = left
+		if ((i - indexDiff) > 0) {
+			left = (i - indexDiff)
+		}
+		j = (i - 1)
+		for (j >= left) {
+			if (abs((nums[i] - nums[j])) <= valueDiff) {
+				return true
+			}
+			j = (j - 1)
+		}
+		i = (i + 1)
+	}
+	return false
+}
+
+func example_1() {
+	expect((containsNearbyAlmostDuplicate([]int{1, 2, 3, 1}, 3, 0) == true))
+}
+
+func example_2() {
+	expect((containsNearbyAlmostDuplicate([]int{1, 0, 1, 1}, 1, 2) == true))
+}
+
+func example_3() {
+	expect((containsNearbyAlmostDuplicate([]int{1, 5, 9, 1, 5, 9}, 2, 3) == false))
+}
+
+func negative_numbers() {
+	expect((containsNearbyAlmostDuplicate([]int{-3, -1, -4, -2}, 2, 1) == true))
+}
+
+func no_pairs() {
+	expect((containsNearbyAlmostDuplicate([]int{1, 2, 3, 4}, 1, 0) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	negative_numbers()
+	no_pairs()
+}
+

--- a/examples/leetcode-out/contains-duplicate.go.out
+++ b/examples/leetcode-out/contains-duplicate.go.out
@@ -1,0 +1,39 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func containsDuplicate(nums []int) bool {
+	var seen map[int]bool = map[int]bool{}
+	_ = seen
+	for _, n := range nums {
+		_tmp0 := n
+		_tmp1 := seen
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			return true
+		}
+		seen[n] = true
+	}
+	return false
+}
+
+func example_1() {
+	expect((containsDuplicate([]int{1, 2, 3, 1}) == true))
+}
+
+func example_2() {
+	expect((containsDuplicate([]int{1, 2, 3, 4}) == false))
+}
+
+func example_3() {
+	expect((containsDuplicate([]int{1, 1, 1, 3, 3, 4, 3, 2, 4, 2}) == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/convert-sorted-list-to-binary-search-tree.go.out
+++ b/examples/leetcode-out/convert-sorted-list-to-binary-search-tree.go.out
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func sortedListToBST(nums []int) any {
+	var build = func(lo int, hi int) any {
+		if (lo >= hi) {
+			return Leaf{}
+		}
+		var mid int = (((lo + hi)) / 2)
+		return Node{Left: build(lo, mid), Value: nums[mid], Right: build((mid + 1), hi)}
+}
+	return build(0, len(nums))
+}
+
+func inorder(t any) []int {
+	return func() any {
+	_t := t
+	switch _t {
+	case Leaf:
+		return []any{}
+	case Node(l, v, r):
+		return append(append([]any{}, append(append([]any{}, _toAnySlice(inorder(l))...), []any{v}...)...), _toAnySlice(inorder(r))...)
+	}
+	return nil
+}()
+}
+
+func example() {
+	var nums []int = []int{-10, -3, 0, 5, 9}
+	var tree any = sortedListToBST(nums)
+	expect(_equal(inorder(tree), nums))
+}
+
+func empty() {
+	expect(_equal(inorder(sortedListToBST([]int{})), []any{}))
+}
+
+func single() {
+	expect(_equal(inorder(sortedListToBST([]int{1})), []int{1}))
+}
+
+func main() {
+	example()
+	empty()
+	single()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/copy-list-with-random-pointer.go.out
+++ b/examples/leetcode-out/copy-list-with-random-pointer.go.out
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Node struct {
+	Val int `json:"val"`
+	Next int `json:"next"`
+	Random int `json:"random"`
+}
+
+func copyRandomList(nodes []Node) []Node {
+	var result []any = []any{}
+	_ = result
+	for _, n := range nodes {
+		result = append(append([]any{}, result...), _toAnySlice([]Node{Node{Val: n.Val, Next: n.Next, Random: n.Random}})...)
+	}
+	return _cast[[]Node](result)
+}
+
+func serialize(nodes []Node) [][]int {
+	var out [][]int = [][]int{}
+	_ = out
+	var i int = 0
+	_ = i
+	for (i < len(nodes)) {
+		var n Node = nodes[i]
+		out = append(append([][]int{}, out...), [][]int{[]int{n.Val, n.Random}}...)
+		i = (i + 1)
+	}
+	return out
+}
+
+func copy_list() {
+	var original []Node = []Node{Node{Val: 7, Next: 1, Random: -1}, Node{Val: 13, Next: 2, Random: 0}, Node{Val: 11, Next: 3, Random: 4}, Node{Val: 10, Next: 4, Random: 2}, Node{Val: 1, Next: -1, Random: 0}}
+	var copied []Node = copyRandomList(original)
+	expect(_equal(serialize(copied), serialize(original)))
+}
+
+func main() {
+	copy_list()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/count-and-say.go.out
+++ b/examples/leetcode-out/count-and-say.go.out
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func countAndSay(n int) string {
+	var term string = "1"
+	_ = term
+	var i int = 1
+	_ = i
+	for (i < n) {
+		var next string = ""
+		_ = next
+		var j int = 0
+		_ = j
+		for (j < len(term)) {
+			var k int = j
+			_ = k
+			for (k < len(term)) {
+				if (_indexString(term, k) == _indexString(term, j)) {
+					k = (k + 1)
+				} else {
+					break
+				}
+			}
+			var count func(any) int = (k - j)
+			next = next + fmt.Sprint(count) + _indexString(term, j)
+			j = k
+		}
+		term = next
+		i = (i + 1)
+	}
+	return term
+}
+
+func n___1() {
+	expect((countAndSay(1) == "1"))
+}
+
+func n___4() {
+	expect((countAndSay(4) == "1211"))
+}
+
+func n___5() {
+	expect((countAndSay(5) == "111221"))
+}
+
+func main() {
+	n___1()
+	n___4()
+	n___5()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/count-complete-tree-nodes.go.out
+++ b/examples/leetcode-out/count-complete-tree-nodes.go.out
@@ -1,0 +1,48 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func countNodes(root any) int {
+	return func() int {
+	_t := root
+	switch _t {
+	case Leaf:
+		return 0
+	case Node(l, _, r):
+		return ((countNodes(l) + countNodes(r)) + 1)
+	}
+}()
+}
+
+func example_1() {
+	expect((countNodes(example1) == 6))
+}
+
+func single_node() {
+	expect((countNodes(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}) == 1))
+}
+
+func empty() {
+	expect((countNodes(Leaf{}) == 0))
+}
+
+var example1 Node = Node{Left: Node{Left: Node{Left: Leaf{}, Value: 4, Right: Leaf{}}, Value: 2, Right: Node{Left: Leaf{}, Value: 5, Right: Leaf{}}}, Value: 1, Right: Node{Left: Node{Left: Leaf{}, Value: 6, Right: Leaf{}}, Value: 3, Right: Leaf{}}}
+func main() {
+	example_1()
+	single_node()
+	empty()
+}
+

--- a/examples/leetcode-out/couples-holding-hands.go.out
+++ b/examples/leetcode-out/couples-holding-hands.go.out
@@ -1,0 +1,62 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func minSwapsCouples(row []int) int {
+	var n int = len(row)
+	var pos map[int]int = map[int]int{}
+	_ = pos
+	var i int = 0
+	_ = i
+	for (i < n) {
+		pos[row[i]] = i
+		i = (i + 1)
+	}
+	var swaps int = 0
+	_ = swaps
+	var j int = 0
+	_ = j
+	for (j < n) {
+		var first int = row[j]
+		var partner int = 0
+		_ = partner
+		if ((first % 2) == 0) {
+			partner = (first + 1)
+		} else {
+			partner = (first - 1)
+		}
+		var second int = row[(j + 1)]
+		if (second != partner) {
+			var partnerIndex int = pos[partner]
+			_ = partnerIndex
+			row[partnerIndex] = second
+			pos[second] = partnerIndex
+			row[(j + 1)] = partner
+			pos[partner] = (j + 1)
+			swaps = (swaps + 1)
+		}
+		j = (j + 2)
+	}
+	return swaps
+}
+
+func example_1() {
+	expect((minSwapsCouples([]int{0, 2, 1, 3}) == 1))
+}
+
+func example_2() {
+	expect((minSwapsCouples([]int{3, 2, 0, 1}) == 0))
+}
+
+func scrambled() {
+	expect((minSwapsCouples([]int{4, 1, 0, 3, 2, 5}) == 2))
+}
+
+func main() {
+	example_1()
+	example_2()
+	scrambled()
+}
+

--- a/examples/leetcode-out/course-schedule-ii.go.out
+++ b/examples/leetcode-out/course-schedule-ii.go.out
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findOrder(numCourses int, prerequisites [][]int) []int {
+	var graph map[int][]int = map[int][]int{}
+	_ = graph
+	var indegree map[int]int = map[int]int{}
+	_ = indegree
+	var i int = 0
+	_ = i
+	for (i < numCourses) {
+		graph[i] = []any{}
+		indegree[i] = 0
+		i = (i + 1)
+	}
+	for _, pair := range prerequisites {
+		var dest int = pair[0]
+		var src int = pair[1]
+		graph[src] = append(append([]int{}, graph[src]...), []int{dest}...)
+		indegree[dest] = (indegree[dest] + 1)
+	}
+	var queue []int = []int{}
+	_ = queue
+	var j int = 0
+	_ = j
+	for (j < numCourses) {
+		if (indegree[j] == 0) {
+			queue = append(append([]int{}, queue...), []int{j}...)
+		}
+		j = (j + 1)
+	}
+	var order []int = []int{}
+	_ = order
+	for (len(queue) > 0) {
+		var next []int = []int{}
+		_ = next
+		for _, course := range queue {
+			order = append(append([]int{}, order...), []int{course}...)
+			for _, neighbor := range graph[course] {
+				indegree[neighbor] = (indegree[neighbor] - 1)
+				if (indegree[neighbor] == 0) {
+					next = append(append([]int{}, next...), []int{neighbor}...)
+				}
+			}
+		}
+		queue = next
+	}
+	if (len(order) == numCourses) {
+		return order
+	}
+	return _cast[[]int]([]any{})
+}
+
+func example_1() {
+	expect(_equal(findOrder(2, [][]int{[]int{1, 0}}), []int{0, 1}))
+}
+
+func example_2() {
+	var order []int = findOrder(4, [][]int{[]int{1, 0}, []int{2, 0}, []int{3, 1}, []int{3, 2}})
+	var valid bool = true
+	_ = valid
+	if (len(order) == 4) {
+		var idx map[int]int = map[int]int{}
+		_ = idx
+		var k int = 0
+		_ = k
+		for (k < len(order)) {
+			idx[order[k]] = k
+			k = (k + 1)
+		}
+		if ((idx[0] > idx[1]) && (idx[0] > idx[2])) {
+			valid = false
+		}
+		if (idx[1] > idx[3]) {
+			valid = false
+		}
+		if (idx[2] > idx[3]) {
+			valid = false
+		}
+	} else {
+		valid = false
+	}
+	expect((valid == true))
+}
+
+func cycle() {
+	expect(_equal(findOrder(2, [][]int{[]int{0, 1}, []int{1, 0}}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	cycle()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/course-schedule.go.out
+++ b/examples/leetcode-out/course-schedule.go.out
@@ -1,0 +1,75 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func canFinish(numCourses int, prerequisites [][]int) bool {
+	var graph [][]int = [][]int{}
+	_ = graph
+	var indegree []int = []int{}
+	_ = indegree
+	for _ := 0; _ < numCourses; _++ {
+		graph = append(append([]any{}, _toAnySlice(graph)...), _toAnySlice([][]any{[]any{}})...)
+		indegree = append(append([]int{}, indegree...), []int{0}...)
+	}
+	for _, pair := range prerequisites {
+		var a int = pair[0]
+		var b int = pair[1]
+		graph[b] = append(append([]int{}, graph[b]...), []int{a}...)
+		indegree[a] = (indegree[a] + 1)
+	}
+	var queue []int = []int{}
+	_ = queue
+	for i := 0; i < numCourses; i++ {
+		if (indegree[i] == 0) {
+			queue = append(append([]int{}, queue...), []int{i}...)
+		}
+	}
+	var visited int = 0
+	_ = visited
+	var idx int = 0
+	_ = idx
+	for (idx < len(queue)) {
+		var course int = queue[idx]
+		idx = (idx + 1)
+		visited = (visited + 1)
+		for _, next := range graph[course] {
+			indegree[next] = (indegree[next] - 1)
+			if (indegree[next] == 0) {
+				queue = append(append([]int{}, queue...), []int{next}...)
+			}
+		}
+	}
+	return (visited == numCourses)
+}
+
+func simple_acyclic() {
+	expect((canFinish(2, [][]int{[]int{1, 0}}) == true))
+}
+
+func simple_cycle() {
+	expect((canFinish(2, [][]int{[]int{1, 0}, []int{0, 1}}) == false))
+}
+
+func long_chain() {
+	expect((canFinish(4, [][]int{[]int{1, 0}, []int{2, 1}, []int{3, 2}}) == true))
+}
+
+func cycle_with_more_courses() {
+	expect((canFinish(3, [][]int{[]int{0, 1}, []int{1, 2}, []int{2, 0}}) == false))
+}
+
+func main() {
+	simple_acyclic()
+	simple_cycle()
+	long_chain()
+	cycle_with_more_courses()
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/customers-who-never-order.go.out
+++ b/examples/leetcode-out/customers-who-never-order.go.out
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Customer struct {
+	Id int `json:"id"`
+	Name string `json:"name"`
+}
+
+type Order struct {
+	Id int `json:"id"`
+	CustomerId int `json:"customerId"`
+}
+
+func customersWithoutOrders(customers []Customer, orders []Order) []string {
+	var result []string = []string{}
+	_ = result
+	for _, c := range customers {
+		var placed bool = false
+		_ = placed
+		for _, o := range orders {
+			if (o.CustomerId == c.Id) {
+				placed = true
+				break
+			}
+		}
+		if !placed {
+			result = append(append([]string{}, result...), []string{c.Name}...)
+		}
+	}
+	return result
+}
+
+func example() {
+	expect(_equal(customersWithoutOrders(customers, orders), []string{"Henry", "Max"}))
+}
+
+func all_customers() {
+	var emptyOrders []any = []any{}
+	expect((fmt.Sprint(customersWithoutOrders(customers, emptyOrders)) == fmt.Sprint([]string{"Joe", "Henry", "Sam", "Max"})))
+}
+
+func none_left() {
+	var allOrders []Order = []Order{Order{Id: 1, CustomerId: 1}, Order{Id: 2, CustomerId: 2}, Order{Id: 3, CustomerId: 3}, Order{Id: 4, CustomerId: 4}}
+	expect(_equal(customersWithoutOrders(customers, allOrders), []any{}))
+}
+
+var customers []Customer = []Customer{Customer{Id: 1, Name: "Joe"}, Customer{Id: 2, Name: "Henry"}, Customer{Id: 3, Name: "Sam"}, Customer{Id: 4, Name: "Max"}}
+var orders []Order = []Order{Order{Id: 1, CustomerId: 3}, Order{Id: 2, CustomerId: 1}}
+func main() {
+	example()
+	all_customers()
+	none_left()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/decode-ways.go.out
+++ b/examples/leetcode-out/decode-ways.go.out
@@ -1,0 +1,81 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func numDecodings(s string) int {
+	var n int = len(s)
+	if (n == 0) {
+		return 0
+	}
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	var dp []int = []int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i <= n) {
+		dp = append(append([]int{}, dp...), []int{0}...)
+		i = (i + 1)
+	}
+	dp[0] = 1
+	if (_indexString(s, 0) != "0") {
+		dp[1] = 1
+	}
+	var idx int = 2
+	_ = idx
+	for (idx <= n) {
+		var one string = _indexString(s, (idx - 1))
+		if (one != "0") {
+			dp[idx] = (dp[idx] + dp[(idx - 1)])
+		}
+		var d1 int = digits[_indexString(s, (idx - 2))]
+		var d2 int = digits[_indexString(s, (idx - 1))]
+		var val int = ((d1 * 10) + d2)
+		if ((val >= 10) && (val <= 26)) {
+			dp[idx] = (dp[idx] + dp[(idx - 2)])
+		}
+		idx = (idx + 1)
+	}
+	return dp[n]
+}
+
+func example_1() {
+	expect((numDecodings("12") == 2))
+}
+
+func example_2() {
+	expect((numDecodings("226") == 3))
+}
+
+func example_3() {
+	expect((numDecodings("06") == 0))
+}
+
+func single_zero() {
+	expect((numDecodings("0") == 0))
+}
+
+func _101() {
+	expect((numDecodings("2101") == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_zero()
+	_101()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/delete-node-in-a-linked-list.go.out
+++ b/examples/leetcode-out/delete-node-in-a-linked-list.go.out
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func deleteNode(values []int, index int) []int {
+	var arr []int = values
+	_ = arr
+	var i int = index
+	_ = i
+	for (i < (len(arr) - 1)) {
+		arr[i] = arr[(i + 1)]
+		i = (i + 1)
+	}
+	return arr[0:(len(arr) - 1)]
+}
+
+func example_1() {
+	expect(_equal(deleteNode([]int{4, 5, 1, 9}, 1), []int{4, 1, 9}))
+}
+
+func example_2() {
+	expect(_equal(deleteNode([]int{4, 5, 1, 9}, 2), []int{4, 5, 9}))
+}
+
+func delete_first() {
+	expect(_equal(deleteNode([]int{1, 2, 3}, 0), []int{2, 3}))
+}
+
+func delete_middle() {
+	expect(_equal(deleteNode([]int{1, 2, 3, 4}, 2), []int{1, 2, 4}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	delete_first()
+	delete_middle()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/department-highest-salary.go.out
+++ b/examples/leetcode-out/department-highest-salary.go.out
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Department struct {
+	Id int `json:"id"`
+	Name string `json:"name"`
+}
+
+type Employee struct {
+	Id int `json:"id"`
+	Name string `json:"name"`
+	Salary int `json:"salary"`
+	DepartmentId int `json:"departmentId"`
+}
+
+type Result struct {
+	Department string `json:"Department"`
+	Employee string `json:"Employee"`
+	Salary int `json:"Salary"`
+}
+
+func departmentHighestSalary(employees []Employee, departments []Department) []Result {
+	var maxSalary map[int]int = map[int]int{}
+	_ = maxSalary
+	for _, e := range employees {
+		var current int = 0
+		_ = current
+		_tmp0 := e.DepartmentId
+		_tmp1 := maxSalary
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			current = maxSalary[e.DepartmentId]
+		}
+		if (e.Salary > current) {
+			maxSalary[e.DepartmentId] = e.Salary
+		}
+	}
+	var results []any = []any{}
+	_ = results
+	for _, d := range departments {
+		_tmp3 := d.Id
+		_tmp4 := maxSalary
+		_, _tmp5 := _tmp4[_tmp3]
+		if _tmp5 {
+			var highest int = maxSalary[d.Id]
+			for _, e := range employees {
+				if ((e.DepartmentId == d.Id) && (e.Salary == highest)) {
+					results = append(append([]any{}, results...), _toAnySlice([]Result{Result{Department: d.Name, Employee: e.Name, Salary: e.Salary}})...)
+				}
+			}
+		}
+	}
+	return _cast[[]Result](results)
+}
+
+func highest_salary() {
+	var expected []Result = []Result{Result{Department: "IT", Employee: "Max", Salary: 90000}, Result{Department: "Sales", Employee: "Henry", Salary: 80000}}
+	expect((fmt.Sprint(departmentHighestSalary(employees, departments)) == fmt.Sprint(expected)))
+}
+
+var departments []Department = []Department{Department{Id: 1, Name: "IT"}, Department{Id: 2, Name: "Sales"}}
+var employees []Employee = []Employee{Employee{Id: 1, Name: "Joe", Salary: 70000, DepartmentId: 1}, Employee{Id: 2, Name: "Henry", Salary: 80000, DepartmentId: 2}, Employee{Id: 3, Name: "Sam", Salary: 60000, DepartmentId: 2}, Employee{Id: 4, Name: "Max", Salary: 90000, DepartmentId: 1}}
+func main() {
+	highest_salary()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/department-top-three-salaries.go.out
+++ b/examples/leetcode-out/department-top-three-salaries.go.out
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Employee struct {
+	Id int `json:"id"`
+	Name string `json:"name"`
+	Salary int `json:"salary"`
+	DepartmentId int `json:"departmentId"`
+}
+
+type Department struct {
+	Id int `json:"id"`
+	Name string `json:"name"`
+}
+
+type Result struct {
+	Department string `json:"Department"`
+	Employee string `json:"Employee"`
+	Salary int `json:"Salary"`
+}
+
+func topThreeSalaries(employees []Employee, departments []Department) []Result {
+	var results []any = []any{}
+	_ = results
+	for _, dept := range departments {
+		var salaries []int = []int{}
+		_ = salaries
+		for _, emp := range employees {
+			if (emp.DepartmentId == dept.Id) {
+				var found bool = false
+				_ = found
+				for _, s := range salaries {
+					if (s == emp.Salary) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					salaries = append(append([]int{}, salaries...), []int{emp.Salary}...)
+				}
+			}
+		}
+		var i1 int = 0
+		_ = i1
+		for (i1 < len(salaries)) {
+			var j int = (i1 + 1)
+			_ = j
+			for (j < len(salaries)) {
+				if (salaries[j] > salaries[i1]) {
+					var t int = salaries[i1]
+					salaries[i1] = salaries[j]
+					salaries[j] = t
+				}
+				j = (j + 1)
+			}
+			i1 = (i1 + 1)
+		}
+		var i int = 0
+		_ = i
+		for ((i < len(salaries)) && (i < 3)) {
+			var sal int = salaries[i]
+			for _, emp := range employees {
+				if ((emp.DepartmentId == dept.Id) && (emp.Salary == sal)) {
+					results = append(append([]any{}, results...), _toAnySlice([]Result{Result{Department: dept.Name, Employee: emp.Name, Salary: sal}})...)
+				}
+			}
+			i = (i + 1)
+		}
+	}
+	return _cast[[]Result](results)
+}
+
+func top_three_salaries() {
+	var res []Result = topThreeSalaries(employees, departments)
+	var names []string = []string{}
+	_ = names
+	for _, r := range res {
+		names = append(append([]string{}, names...), []string{r.Employee}...)
+	}
+	expect((fmt.Sprint(names) == fmt.Sprint([]string{"Max", "Joe", "Randy", "Will", "Henry", "Sam"})))
+}
+
+var employees []Employee = []Employee{Employee{Id: 1, Name: "Joe", Salary: 85000, DepartmentId: 1}, Employee{Id: 2, Name: "Henry", Salary: 80000, DepartmentId: 2}, Employee{Id: 3, Name: "Sam", Salary: 60000, DepartmentId: 2}, Employee{Id: 4, Name: "Max", Salary: 90000, DepartmentId: 1}, Employee{Id: 5, Name: "Janet", Salary: 69000, DepartmentId: 1}, Employee{Id: 6, Name: "Randy", Salary: 85000, DepartmentId: 1}, Employee{Id: 7, Name: "Will", Salary: 70000, DepartmentId: 1}}
+var departments []Department = []Department{Department{Id: 1, Name: "IT"}, Department{Id: 2, Name: "Sales"}}
+func main() {
+	top_three_salaries()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/design-add-and-search-words-data-structure.go.out
+++ b/examples/leetcode-out/design-add-and-search-words-data-structure.go.out
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func Node() map[string]any {
+	return map[string]any{"end": false, "next": _cast[map[string]any](map[any]any{})}
+}
+
+func addWord(root map[string]any, word string) {
+	var node map[string]any = root
+	_ = node
+	for i := 0; i < len(word); i++ {
+		var ch string = _indexString(word, i)
+		var nextMap map[string]any = _cast[map[string]any](node["next"])
+		_ = nextMap
+		var child map[string]any = nil
+		_ = child
+		_tmp0 := ch
+		_tmp1 := nextMap
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			child = _cast[map[string]any](nextMap[ch])
+		} else {
+			child = Node()
+		}
+		if (i == (len(word) - 1)) {
+			child["end"] = true
+		}
+		nextMap[ch] = child
+		node["next"] = nextMap
+		node = child
+	}
+}
+
+func searchHelper(node map[string]any, word string, index int) bool {
+	if (index == len(word)) {
+		return _cast[bool](node["end"])
+	}
+	var ch string = _indexString(word, index)
+	var children map[string]any = _cast[map[string]any](node["next"])
+	_ = children
+	if (ch == ".") {
+		for key := range children {
+			var child map[string]any = _cast[map[string]any](children[key])
+			if searchHelper(child, word, (index + 1)) {
+				return true
+			}
+		}
+		return false
+	}
+	_tmp3 := ch
+	_tmp4 := children
+	_, _tmp5 := _tmp4[_tmp3]
+	if _tmp5 {
+		return searchHelper(_cast[map[string]any](children[ch]), word, (index + 1))
+	}
+	return false
+}
+
+func search(root map[string]any, word string) bool {
+	return searchHelper(root, word, 0)
+}
+
+func example_1() {
+	var wd map[string]any = Node()
+	addWord(wd, "bad")
+	addWord(wd, "dad")
+	addWord(wd, "mad")
+	expect((search(wd, "pad") == false))
+	expect((search(wd, "bad") == true))
+	expect((search(wd, ".ad") == true))
+	expect((search(wd, "b..") == true))
+}
+
+func main() {
+	example_1()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/different-ways-to-add-parentheses.go.out
+++ b/examples/leetcode-out/different-ways-to-add-parentheses.go.out
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func parseInt(s string) int {
+	var result int = 0
+	_ = result
+	var i int = 0
+	_ = i
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	for (i < len(s)) {
+		result = ((result * 10) + digits[_indexString(s, i)])
+		i = (i + 1)
+	}
+	return result
+}
+
+func diffWaysToCompute(expr string) []int {
+	var results []int = []int{}
+	_ = results
+	var i int = 0
+	_ = i
+	for (i < len(expr)) {
+		var ch string = _indexString(expr, i)
+		if (((ch == "+") || (ch == "-")) || (ch == "*")) {
+			var leftPart string = string([]rune(expr)[0:i])
+			var rightPart string = string([]rune(expr)[(i + 1):len(expr)])
+			var leftVals []int = diffWaysToCompute(leftPart)
+			var rightVals []int = diffWaysToCompute(rightPart)
+			for _, a := range leftVals {
+				for _, b := range rightVals {
+					var val int = 0
+					_ = val
+					if (ch == "+") {
+						val = (a + b)
+					} else 					if (ch == "-") {
+						val = (a - b)
+					} else {
+						val = (a * b)
+					}
+					results = append(append([]int{}, results...), []int{val}...)
+				}
+			}
+		}
+		i = (i + 1)
+	}
+	if (len(results) == 0) {
+		results = []int{parseInt(expr)}
+	}
+	return results
+}
+
+func example_1() {
+	var res []int = diffWaysToCompute("2-1-1")
+	var sorted []any = func() []int {
+	items := []int{}
+	for _, x := range res {
+		items = append(items, x)
+	}
+	type pair struct { item int; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		x := it
+		pairs[idx] = pair{item: it, key: x}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []int{}
+	for _, x := range items {
+		res = append(res, x)
+	}
+	return res
+}()
+	var expected []int = []int{0, 2}
+	expect(_equal(sorted, expected))
+}
+
+func example_2() {
+	var res []int = diffWaysToCompute("2*3-4*5")
+	var sorted []any = func() []int {
+	items := []int{}
+	for _, x := range res {
+		items = append(items, x)
+	}
+	type pair struct { item int; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		x := it
+		pairs[idx] = pair{item: it, key: x}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []int{}
+	for _, x := range items {
+		res = append(res, x)
+	}
+	return res
+}()
+	var expected []int = []int{-34, -14, -10, -10, 10}
+	var expSorted []any = func() []int {
+	items := []int{}
+	for _, x := range expected {
+		items = append(items, x)
+	}
+	type pair struct { item int; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		x := it
+		pairs[idx] = pair{item: it, key: x}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []int{}
+	for _, x := range items {
+		res = append(res, x)
+	}
+	return res
+}()
+	expect(_equal(sorted, expSorted))
+}
+
+func single_number() {
+	expect(_equal(diffWaysToCompute("3"), []int{3}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_number()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/distinct-subsequences.go.out
+++ b/examples/leetcode-out/distinct-subsequences.go.out
@@ -1,0 +1,80 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func numDistinct(s string, t string) int {
+	var m int = len(s)
+	var n int = len(t)
+	var dp [][]int = [][]int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i <= m) {
+		var row []int = []int{}
+		_ = row
+		var j int = 0
+		_ = j
+		for (j <= n) {
+			row = append(append([]int{}, row...), []int{0}...)
+			j = (j + 1)
+		}
+		dp = append(append([][]int{}, dp...), [][]int{row}...)
+		i = (i + 1)
+	}
+	i = 0
+	for (i <= m) {
+		dp[i][0] = 1
+		i = (i + 1)
+	}
+	i = 1
+	for (i <= m) {
+		var j int = 1
+		_ = j
+		for (j <= n) {
+			dp[i][j] = dp[(i - 1)][j]
+			if (_indexString(s, (i - 1)) == _indexString(t, (j - 1))) {
+				dp[i][j] = (dp[i][j] + dp[(i - 1)][(j - 1)])
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return dp[m][n]
+}
+
+func example_1() {
+	expect((numDistinct("rabbbit", "rabbit") == 3))
+}
+
+func example_2() {
+	expect((numDistinct("babgbag", "bag") == 5))
+}
+
+func empty_target() {
+	expect((numDistinct("abc", "") == 1))
+}
+
+func no_subsequence() {
+	expect((numDistinct("abc", "abcd") == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_target()
+	no_subsequence()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/divide-two-integers.go.out
+++ b/examples/leetcode-out/divide-two-integers.go.out
@@ -1,0 +1,74 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func divide(dividend int, divisor int) int {
+	if ((dividend == ((-2147483647 - 1))) && (divisor == (-1))) {
+		return 2147483647
+	}
+	var negative bool = false
+	_ = negative
+	if (dividend < 0) {
+		negative = !negative
+		dividend = -dividend
+	}
+	if (divisor < 0) {
+		negative = !negative
+		divisor = -divisor
+	}
+	var quotient int = 0
+	_ = quotient
+	for (dividend >= divisor) {
+		var temp int = divisor
+		_ = temp
+		var multiple int = 1
+		_ = multiple
+		for (dividend >= (temp + temp)) {
+			temp = (temp + temp)
+			multiple = (multiple + multiple)
+		}
+		dividend = (dividend - temp)
+		quotient = (quotient + multiple)
+	}
+	if negative {
+		quotient = -quotient
+	}
+	if (quotient > 2147483647) {
+		return 2147483647
+	}
+	if (quotient < ((-2147483647 - 1))) {
+		return -2147483648
+	}
+	return quotient
+}
+
+func example_1() {
+	expect((divide(10, 3) == 3))
+}
+
+func example_2() {
+	expect((divide(7, -3) == (-2)))
+}
+
+func overflow() {
+	expect((divide(-2147483648, -1) == 2147483647))
+}
+
+func divide_by_1() {
+	expect((divide(12345, 1) == 12345))
+}
+
+func negative_result() {
+	expect((divide(-15, 2) == (-7)))
+}
+
+func main() {
+	example_1()
+	example_2()
+	overflow()
+	divide_by_1()
+	negative_result()
+}
+

--- a/examples/leetcode-out/download.go.out
+++ b/examples/leetcode-out/download.go.out
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+)
+
+func remove_html_tags(text string) string {
+	var i int = 0
+	_ = i
+	var output string = ""
+	_ = output
+	for (i < len(text)) {
+		if (_indexString(text, i) == "<") {
+			var j int = (i + 1)
+			_ = j
+			for ((j < len(text)) && (_indexString(text, j) != ">")) {
+				j = (j + 1)
+			}
+			if (j < len(text)) {
+				i = (j + 1)
+			} else {
+				i = (i + 1)
+			}
+		} else {
+			output = output + _indexString(text, i)
+			i = (i + 1)
+		}
+	}
+	return output
+}
+
+func get_leetcode_problem(problem_id string) string {
+	fmt.Println("=== Step 1: Searching for LeetCode Problem", problem_id, "===")
+	var search_response any = _fetch("https://leetcode.com/graphql/", _toAnyMap(map[string]any{"method": "POST", "headers": map[string]string{"Content-Type": "application/json"}, "body": map[string]any{"operationName": "problemsetQuestionList", "variables": map[string]any{"categorySlug": "", "skip": 0, "limit": 1, "filters": map[string]string{"searchKeywords": problem_id}}, "query": "query problemsetQuestionList($categorySlug: String, $limit: Int, $skip: Int, $filters: QuestionListFilterInput) { problemsetQuestionList: questionList(categorySlug: $categorySlug limit: $limit skip: $skip filters: $filters) { total: totalNum questions: data { frontendQuestionId: questionFrontendId title titleSlug difficulty } } }"}}))
+	fmt.Println("Search result:", search_response)
+	var title_slug string = "maximum-difference-between-even-and-odd-frequency-i"
+	fmt.Println("=== Step 2: Fetching full content using titleSlug:", title_slug, "===")
+	var content_response any = _fetch("https://leetcode.com/graphql/", _toAnyMap(map[string]any{"method": "POST", "headers": map[string]string{"Content-Type": "application/json", "Cookie": "LEETCODE_SESSION=your_session_token_here"}, "body": map[string]any{"operationName": "questionData", "variables": map[string]string{"titleSlug": title_slug}, "query": "query questionData($titleSlug: String!) { question(titleSlug: $titleSlug) { questionId title content difficulty likes dislikes } }"}}))
+	var content_str string = fmt.Sprint(content_response)
+	var cleaned string = remove_html_tags(content_str)
+	return cleaned
+}
+
+func main() {
+	var problem_id string = "3442"
+	var result string = get_leetcode_problem(problem_id)
+	fmt.Println("=== FINAL RESULT: LeetCode Problem", problem_id, "===")
+	fmt.Println(result)
+}
+
+func _fetch(url string, opts map[string]any) any {
+    method := "GET"
+    if opts != nil {
+        if m, ok := opts["method"].(string); ok {
+            method = m
+        }
+    }
+    var body io.Reader
+    if opts != nil {
+        if b, ok := opts["body"]; ok {
+            data, err := json.Marshal(b)
+            if err != nil { panic(err) }
+            body = bytes.NewReader(data)
+        }
+    }
+    u, err := url.Parse(url)
+    if err != nil { panic(err) }
+    if opts != nil {
+        if q, ok := opts["query"]; ok {
+            vals := u.Query()
+            for k, v := range _toAnyMap(q) {
+                vals.Set(k, fmt.Sprint(v))
+            }
+            u.RawQuery = vals.Encode()
+        }
+    }
+    req, err := http.NewRequest(method, u.String(), body)
+    if err != nil { panic(err) }
+    if opts != nil {
+        if hs, ok := opts["headers"]; ok {
+            for k, v := range _toAnyMap(hs) {
+                if s, ok := v.(string); ok {
+                    req.Header.Set(k, s)
+                }
+            }
+        }
+    }
+    client := http.DefaultClient
+    if opts != nil {
+        if t, ok := opts["timeout"]; ok {
+            switch v := t.(type) {
+            case int:
+                client = &http.Client{Timeout: time.Duration(v) * time.Second}
+            case int64:
+                client = &http.Client{Timeout: time.Duration(v) * time.Second}
+            case float64:
+                client = &http.Client{Timeout: time.Duration(v * float64(time.Second))}
+            case float32:
+                client = &http.Client{Timeout: time.Duration(float64(v) * float64(time.Second))}
+            }
+        }
+    }
+    resp, err := client.Do(req)
+    if err != nil { panic(err) }
+    defer resp.Body.Close()
+    data, err := io.ReadAll(resp.Body)
+    if err != nil { panic(err) }
+    var out any
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+
+func _toAnyMap(m any) map[string]any {
+    switch v := m.(type) {
+    case map[string]any:
+        return v
+    case map[string]string:
+        out := make(map[string]any, len(v))
+        for k, vv := range v {
+            out[k] = vv
+        }
+        return out
+    default:
+        return nil
+    }
+}
+

--- a/examples/leetcode-out/download_test.go.out
+++ b/examples/leetcode-out/download_test.go.out
@@ -1,0 +1,60 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func remove_html_tags(text string) string {
+	var i int = 0
+	_ = i
+	var output string = ""
+	_ = output
+	for (i < len(text)) {
+		if (_indexString(text, i) == "<") {
+			var j int = (i + 1)
+			_ = j
+			for ((j < len(text)) && (_indexString(text, j) != ">")) {
+				j = (j + 1)
+			}
+			if (j < len(text)) {
+				i = (j + 1)
+			} else {
+				i = (i + 1)
+			}
+		} else {
+			output = output + _indexString(text, i)
+			i = (i + 1)
+		}
+	}
+	return output
+}
+
+func remove_simple_tags() {
+	expect((remove_html_tags("<p>hello</p>") == "hello"))
+}
+
+func no_tags() {
+	expect((remove_html_tags("just text") == "just text"))
+}
+
+func nested_tags() {
+	expect((remove_html_tags("<div><span>hi</span></div>") == "hi"))
+}
+
+func main() {
+	remove_simple_tags()
+	no_tags()
+	nested_tags()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/dungeon-game.go.out
+++ b/examples/leetcode-out/dungeon-game.go.out
@@ -1,0 +1,100 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func calculateMinimumHP(dungeon [][]int) int {
+	var m int = len(dungeon)
+	if (m == 0) {
+		return 1
+	}
+	var n int = len(dungeon[0])
+	var dp [][]int = [][]int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i < m) {
+		var row []int = []int{}
+		_ = row
+		var j int = 0
+		_ = j
+		for (j < n) {
+			row = append(append([]int{}, row...), []int{0}...)
+			j = (j + 1)
+		}
+		dp = append(append([][]int{}, dp...), [][]int{row}...)
+		i = (i + 1)
+	}
+	var need int = (1 - dungeon[(m - 1)][(n - 1)])
+	_ = need
+	if (need <= 0) {
+		need = 1
+	}
+	dp[(m - 1)][(n - 1)] = need
+	var col int = (n - 2)
+	_ = col
+	for (col >= 0) {
+		need = (dp[(m - 1)][(col + 1)] - dungeon[(m - 1)][col])
+		if (need <= 0) {
+			need = 1
+		}
+		dp[(m - 1)][col] = need
+		col = (col - 1)
+	}
+	var rowi int = (m - 2)
+	_ = rowi
+	for (rowi >= 0) {
+		need = (dp[(rowi + 1)][(n - 1)] - dungeon[rowi][(n - 1)])
+		if (need <= 0) {
+			need = 1
+		}
+		dp[rowi][(n - 1)] = need
+		rowi = (rowi - 1)
+	}
+	i = (m - 2)
+	for (i >= 0) {
+		col = (n - 2)
+		for (col >= 0) {
+			var best int = dp[(i + 1)][col]
+			_ = best
+			if (dp[i][(col + 1)] < best) {
+				best = dp[i][(col + 1)]
+			}
+			need = (best - dungeon[i][col])
+			if (need <= 0) {
+				need = 1
+			}
+			dp[i][col] = need
+			col = (col - 1)
+		}
+		i = (i - 1)
+	}
+	return dp[0][0]
+}
+
+func example_1() {
+	var board [][]int = [][]int{[]int{-2, -3, 3}, []int{-5, -10, 1}, []int{10, 30, -5}}
+	expect((calculateMinimumHP(board) == 7))
+}
+
+func single_cell_positive() {
+	expect((calculateMinimumHP([][]int{[]int{5}}) == 1))
+}
+
+func single_cell_negative() {
+	expect((calculateMinimumHP([][]int{[]int{-5}}) == 6))
+}
+
+func two_by_two() {
+	var board [][]int = [][]int{[]int{1, -2, 3}, []int{2, -2, -2}}
+	expect((calculateMinimumHP(board) == 2))
+}
+
+func main() {
+	example_1()
+	single_cell_positive()
+	single_cell_negative()
+	two_by_two()
+}
+

--- a/examples/leetcode-out/duplicate-emails.go.out
+++ b/examples/leetcode-out/duplicate-emails.go.out
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findDuplicateEmails(emails []string) []string {
+	var counts map[string]int = map[string]int{}
+	_ = counts
+	for _, e := range emails {
+		var c int = 0
+		_ = c
+		_tmp0 := e
+		_tmp1 := counts
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			c = counts[e]
+		}
+		counts[e] = (c + 1)
+	}
+	var result []string = []string{}
+	_ = result
+	for _, e := range emails {
+		if (counts[e] > 1) {
+			var exists bool = false
+			_ = exists
+			for _, r := range result {
+				if (r == e) {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				result = append(append([]string{}, result...), []string{e}...)
+			}
+		}
+	}
+	return result
+}
+
+func example_duplicates() {
+	var emails []string = []string{"a@x.com", "b@y.com", "a@x.com"}
+	expect(_equal(findDuplicateEmails(emails), []string{"a@x.com"}))
+}
+
+func multiple_duplicates() {
+	var emails []string = []string{"a@x.com", "b@y.com", "a@x.com", "b@y.com", "c@z.com", "a@x.com"}
+	expect(_equal(findDuplicateEmails(emails), []string{"a@x.com", "b@y.com"}))
+}
+
+func no_duplicates() {
+	expect(_equal(findDuplicateEmails([]string{"a@x.com", "b@y.com"}), []any{}))
+}
+
+func empty_list() {
+	expect(_equal(findDuplicateEmails([]string{}), []any{}))
+}
+
+func main() {
+	example_duplicates()
+	multiple_duplicates()
+	no_duplicates()
+	empty_list()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/edit-distance.go.out
+++ b/examples/leetcode-out/edit-distance.go.out
@@ -1,0 +1,102 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func minDistance(word1 string, word2 string) int {
+	var m int = len(word1)
+	var n int = len(word2)
+	var dp [][]int = [][]int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i <= m) {
+		var row []int = []int{}
+		_ = row
+		var j int = 0
+		_ = j
+		for (j <= n) {
+			row = append(append([]int{}, row...), []int{0}...)
+			j = (j + 1)
+		}
+		dp = append(append([][]int{}, dp...), [][]int{row}...)
+		i = (i + 1)
+	}
+	i = 0
+	for (i <= m) {
+		dp[i][0] = i
+		i = (i + 1)
+	}
+	var j int = 0
+	_ = j
+	for (j <= n) {
+		dp[0][j] = j
+		j = (j + 1)
+	}
+	i = 1
+	for (i <= m) {
+		j = 1
+		for (j <= n) {
+			if (_indexString(word1, (i - 1)) == _indexString(word2, (j - 1))) {
+				dp[i][j] = dp[(i - 1)][(j - 1)]
+			} else {
+				var insert int = (dp[i][(j - 1)] + 1)
+				var delete int = (dp[(i - 1)][j] + 1)
+				var replace int = (dp[(i - 1)][(j - 1)] + 1)
+				var best int = insert
+				_ = best
+				if (delete < best) {
+					best = delete
+				}
+				if (replace < best) {
+					best = replace
+				}
+				dp[i][j] = best
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return dp[m][n]
+}
+
+func example_1() {
+	expect((minDistance("horse", "ros") == 3))
+}
+
+func example_2() {
+	expect((minDistance("intention", "execution") == 5))
+}
+
+func identical_strings() {
+	expect((minDistance("abc", "abc") == 0))
+}
+
+func empty_second() {
+	expect((minDistance("abc", "") == 3))
+}
+
+func empty_first() {
+	expect((minDistance("", "abc") == 3))
+}
+
+func main() {
+	example_1()
+	example_2()
+	identical_strings()
+	empty_second()
+	empty_first()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/employees-earning-more-than-their-managers.go.out
+++ b/examples/leetcode-out/employees-earning-more-than-their-managers.go.out
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Employee struct {
+	Id int `json:"id"`
+	Name string `json:"name"`
+	Salary int `json:"salary"`
+	ManagerId int `json:"managerId"`
+}
+
+func higherSalaryThanManager(employees []Employee) []string {
+	var result []string = []string{}
+	_ = result
+	for _, e := range employees {
+		if (e.ManagerId != 0) {
+			for _, m := range employees {
+				if (m.Id == e.ManagerId) {
+					if (e.Salary > m.Salary) {
+						result = append(append([]string{}, result...), []string{e.Name}...)
+					}
+					break
+				}
+			}
+		}
+	}
+	return result
+}
+
+func example() {
+	expect(_equal(higherSalaryThanManager(employees), []string{"Joe"}))
+}
+
+var employees []Employee = []Employee{Employee{Id: 1, Name: "Joe", Salary: 70000, ManagerId: 3}, Employee{Id: 2, Name: "Henry", Salary: 80000, ManagerId: 4}, Employee{Id: 3, Name: "Sam", Salary: 60000, ManagerId: 0}, Employee{Id: 4, Name: "Max", Salary: 90000, ManagerId: 0}}
+func main() {
+	example()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/evaluate-reverse-polish-notation.go.out
+++ b/examples/leetcode-out/evaluate-reverse-polish-notation.go.out
@@ -1,0 +1,88 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func parseInt(s string) int {
+	var i int = 0
+	_ = i
+	var sign int = 1
+	_ = sign
+	if ((len(s) > 0) && (((_indexString(s, 0) == "-") || (_indexString(s, 0) == "+")))) {
+		if (_indexString(s, 0) == "-") {
+			sign = -1
+		}
+		i = 1
+	}
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	var result int = 0
+	_ = result
+	for (i < len(s)) {
+		var ch string = _indexString(s, i)
+		result = ((result * 10) + digits[ch])
+		i = (i + 1)
+	}
+	return (result * sign)
+}
+
+func evalRPN(tokens []string) int {
+	var stack []int = []int{}
+	_ = stack
+	for _, tok := range tokens {
+		if ((((tok == "+") || (tok == "-")) || (tok == "*")) || (tok == "/")) {
+			var b int = stack[(len(stack) - 1)]
+			stack = stack[0:(len(stack) - 1)]
+			var a int = stack[(len(stack) - 1)]
+			stack = stack[0:(len(stack) - 1)]
+			if (tok == "+") {
+				stack = append(append([]int{}, stack...), []int{(a + b)}...)
+			} else 			if (tok == "-") {
+				stack = append(append([]int{}, stack...), []int{(a - b)}...)
+			} else 			if (tok == "*") {
+				stack = append(append([]int{}, stack...), []int{(a * b)}...)
+			} else {
+				stack = append(append([]int{}, stack...), []int{(a / b)}...)
+			}
+		} else {
+			var val int = parseInt(tok)
+			stack = append(append([]int{}, stack...), []int{val}...)
+		}
+	}
+	return stack[(len(stack) - 1)]
+}
+
+func example_1() {
+	expect((evalRPN([]string{"2", "1", "+", "3", "*"}) == 9))
+}
+
+func example_2() {
+	expect((evalRPN([]string{"4", "13", "5", "/", "+"}) == 6))
+}
+
+func example_3() {
+	expect((evalRPN([]string{"10", "6", "9", "3", "+", "-11", "*", "/", "*", "17", "+", "5", "+"}) == 22))
+}
+
+func single_number() {
+	expect((evalRPN([]string{"42"}) == 42))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_number()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/example-problem.go.out
+++ b/examples/leetcode-out/example-problem.go.out
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+)
+
+func sumUnique(nums []int) int {
+	var freq map[int]int = map[int]int{}
+	_ = freq
+	var result int = 0
+	_ = result
+	for _, n := range nums {
+		_tmp0 := n
+		_tmp1 := freq
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			freq[n] = (freq[n] + 1)
+			if (freq[n] == 2) {
+				result = (result - n)
+			}
+		} else {
+			freq[n] = 1
+			result = (result + n)
+		}
+	}
+	return result
+}
+
+func main() {
+	fmt.Println(sumUnique([]int{1, 2, 3, 2}))
+	fmt.Println(sumUnique([]int{1, 1, 1, 1, 1}))
+}
+

--- a/examples/leetcode-out/excel-sheet-column-number.go.out
+++ b/examples/leetcode-out/excel-sheet-column-number.go.out
@@ -1,0 +1,45 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func titleToNumber(columnTitle string) int {
+	var values map[string]int = map[string]int{"A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6, "G": 7, "H": 8, "I": 9, "J": 10, "K": 11, "L": 12, "M": 13, "N": 14, "O": 15, "P": 16, "Q": 17, "R": 18, "S": 19, "T": 20, "U": 21, "V": 22, "W": 23, "X": 24, "Y": 25, "Z": 26}
+	var result int = 0
+	_ = result
+	for _, r := range []rune(columnTitle) {
+		ch := string(r)
+		result = ((result * 26) + values[ch])
+	}
+	return result
+}
+
+func example_1() {
+	expect((titleToNumber("A") == 1))
+}
+
+func example_2() {
+	expect((titleToNumber("AB") == 28))
+}
+
+func example_3() {
+	expect((titleToNumber("ZY") == 701))
+}
+
+func single_Z() {
+	expect((titleToNumber("Z") == 26))
+}
+
+func large_input() {
+	expect((titleToNumber("FXSHRXW") == 2147483647))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_Z()
+	large_input()
+}
+

--- a/examples/leetcode-out/excel-sheet-column-title.go.out
+++ b/examples/leetcode-out/excel-sheet-column-title.go.out
@@ -1,0 +1,39 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func convertToTitle(columnNumber int) string {
+	var letters string = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var n int = columnNumber
+	_ = n
+	var result string = ""
+	_ = result
+	for (n > 0) {
+		n = (n - 1)
+		var idx int = (n % 26)
+		result = string([]rune(letters)[idx:(idx + 1)]) + result
+		n = (n / 26)
+	}
+	return result
+}
+
+func example_1() {
+	expect((convertToTitle(1) == "A"))
+}
+
+func example_2() {
+	expect((convertToTitle(28) == "AB"))
+}
+
+func example_3() {
+	expect((convertToTitle(701) == "ZY"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/find-first-and-last-position-of-element-in-sorted-array.go.out
+++ b/examples/leetcode-out/find-first-and-last-position-of-element-in-sorted-array.go.out
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func searchRange(nums []int, target int) []int {
+	var n int = len(nums)
+	var left int = 0
+	_ = left
+	var right int = (n - 1)
+	_ = right
+	var start int = -1
+	_ = start
+	var end int = -1
+	_ = end
+	left = 0
+	right = (n - 1)
+	for (left <= right) {
+		var mid int = (((left + right)) / 2)
+		if (nums[mid] == target) {
+			start = mid
+			right = (mid - 1)
+		} else 		if (nums[mid] < target) {
+			left = (mid + 1)
+		} else {
+			right = (mid - 1)
+		}
+	}
+	if (start == (-1)) {
+		return []int{-1, -1}
+	}
+	left = start
+	right = (n - 1)
+	for (left <= right) {
+		var mid int = (((left + right)) / 2)
+		if (nums[mid] == target) {
+			end = mid
+			left = (mid + 1)
+		} else 		if (nums[mid] < target) {
+			left = (mid + 1)
+		} else {
+			right = (mid - 1)
+		}
+	}
+	return []int{start, end}
+}
+
+func example_1() {
+	expect(_equal(searchRange([]int{5, 7, 7, 8, 8, 10}, 8), []int{3, 4}))
+}
+
+func example_2() {
+	expect(_equal(searchRange([]int{5, 7, 7, 8, 8, 10}, 6), []int{-1, -1}))
+}
+
+func example_3() {
+	expect(_equal(searchRange([]int{}, 0), []int{-1, -1}))
+}
+
+func single_element_match() {
+	expect(_equal(searchRange([]int{1}, 1), []int{0, 0}))
+}
+
+func single_element_missing() {
+	expect(_equal(searchRange([]int{1}, 0), []int{-1, -1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_element_match()
+	single_element_missing()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/find-minimum-in-rotated-sorted-array-ii.go.out
+++ b/examples/leetcode-out/find-minimum-in-rotated-sorted-array-ii.go.out
@@ -1,0 +1,47 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findMin(nums []int) int {
+	var left int = 0
+	_ = left
+	var right int = (len(nums) - 1)
+	_ = right
+	for (left < right) {
+		var mid int = (left + (((right - left)) / 2))
+		if (nums[mid] > nums[right]) {
+			left = (mid + 1)
+		} else 		if (nums[mid] < nums[right]) {
+			right = mid
+		} else {
+			right = (right - 1)
+		}
+	}
+	return nums[left]
+}
+
+func example_1() {
+	expect((findMin([]int{1, 3, 5}) == 1))
+}
+
+func example_2() {
+	expect((findMin([]int{2, 2, 2, 0, 1}) == 0))
+}
+
+func already_sorted() {
+	expect((findMin([]int{1, 2, 3, 4}) == 1))
+}
+
+func rotated_with_duplicates() {
+	expect((findMin([]int{3, 4, 5, 1, 2, 2}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	already_sorted()
+	rotated_with_duplicates()
+}
+

--- a/examples/leetcode-out/find-minimum-in-rotated-sorted-array.go.out
+++ b/examples/leetcode-out/find-minimum-in-rotated-sorted-array.go.out
@@ -1,0 +1,50 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findMin(nums []int) int {
+	var left int = 0
+	_ = left
+	var right int = (len(nums) - 1)
+	_ = right
+	for (left < right) {
+		var mid int = (left + (((right - left)) / 2))
+		if (nums[mid] > nums[right]) {
+			left = (mid + 1)
+		} else {
+			right = mid
+		}
+	}
+	return nums[left]
+}
+
+func example_1() {
+	expect((findMin([]int{3, 4, 5, 1, 2}) == 1))
+}
+
+func example_2() {
+	expect((findMin([]int{4, 5, 6, 7, 0, 1, 2}) == 0))
+}
+
+func example_3() {
+	expect((findMin([]int{11, 13, 15, 17}) == 11))
+}
+
+func single_element() {
+	expect((findMin([]int{5}) == 5))
+}
+
+func two_elements() {
+	expect((findMin([]int{2, 1}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_element()
+	two_elements()
+}
+

--- a/examples/leetcode-out/find-peak-element.go.out
+++ b/examples/leetcode-out/find-peak-element.go.out
@@ -1,0 +1,37 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findPeakElement(nums []int) int {
+	var n int = len(nums)
+	var left int = 0
+	_ = left
+	var right int = (n - 1)
+	_ = right
+	for (left < right) {
+		var mid int = (((left + right)) / 2)
+		if (nums[mid] > nums[(mid + 1)]) {
+			right = mid
+		} else {
+			left = (mid + 1)
+		}
+	}
+	return left
+}
+
+func example_1() {
+	expect((findPeakElement([]int{1, 2, 3, 1}) == 2))
+}
+
+func example_2() {
+	var idx int = findPeakElement([]int{1, 2, 1, 3, 5, 6, 4})
+	expect(((idx == 1) || (idx == 5)))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+

--- a/examples/leetcode-out/find-the-index-of-the-first-occurrence-in-a-string.go.out
+++ b/examples/leetcode-out/find-the-index-of-the-first-occurrence-in-a-string.go.out
@@ -1,0 +1,65 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func strStr(haystack string, needle string) int {
+	var n int = len(haystack)
+	var m int = len(needle)
+	if (m == 0) {
+		return 0
+	}
+	if (m > n) {
+		return -1
+	}
+	for i := 0; i < ((n - m) + 1); i++ {
+		var j int = 0
+		_ = j
+		for (j < m) {
+			if (_indexString(haystack, (i + j)) != _indexString(needle, j)) {
+				break
+			}
+			j = (j + 1)
+		}
+		if (j == m) {
+			return i
+		}
+	}
+	return -1
+}
+
+func example_1() {
+	expect((strStr("sadbutsad", "sad") == 0))
+}
+
+func example_2() {
+	expect((strStr("leetcode", "leeto") == (-1)))
+}
+
+func empty_needle() {
+	expect((strStr("abc", "") == 0))
+}
+
+func needle_at_end() {
+	expect((strStr("hello", "lo") == 3))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_needle()
+	needle_at_end()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/find-the-k-th-character-in-string-game-i.go.out
+++ b/examples/leetcode-out/find-the-k-th-character-in-string-game-i.go.out
@@ -1,0 +1,67 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func kthCharacter(k int) string {
+	var word string = "a"
+	_ = word
+	var letters string = "abcdefghijklmnopqrstuvwxyz"
+	var nextChar = func(ch string) string {
+		for i := 0; i < 26; i++ {
+			if (_indexString(letters, i) == ch) {
+				if (i == (26 - 1)) {
+					return "a"
+				}
+				return _indexString(letters, (i + 1))
+			}
+		}
+		return ch
+}
+	for (len(word) < k) {
+		var extra string = ""
+		_ = extra
+		for _, r := range []rune(word) {
+			ch := string(r)
+			extra = extra + nextChar(ch)
+		}
+		word = word + extra
+	}
+	return _indexString(word, (k - 1))
+}
+
+func example_1() {
+	expect((kthCharacter(5) == "b"))
+}
+
+func example_2() {
+	expect((kthCharacter(10) == "c"))
+}
+
+func k___1() {
+	expect((kthCharacter(1) == "a"))
+}
+
+func k___50() {
+	expect((kthCharacter(50) == "d"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	k___1()
+	k___50()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/first-missing-positive.go.out
+++ b/examples/leetcode-out/first-missing-positive.go.out
@@ -1,0 +1,45 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func firstMissingPositive(nums []int) int {
+	var seen map[int]bool = map[int]bool{}
+	_ = seen
+	for _, n := range nums {
+		if (n > 0) {
+			seen[n] = true
+		}
+	}
+	var i int = 1
+	_ = i
+	for {
+		_tmp0 := i
+		_tmp1 := seen
+		_, _tmp2 := _tmp1[_tmp0]
+		if !(_tmp2) {
+			return i
+		}
+		i = (i + 1)
+	}
+}
+
+func example_1() {
+	expect((firstMissingPositive([]int{1, 2, 0}) == 3))
+}
+
+func example_2() {
+	expect((firstMissingPositive([]int{3, 4, -1, 1}) == 2))
+}
+
+func example_3() {
+	expect((firstMissingPositive([]int{7, 8, 9, 11, 12}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/fraction-to-recurring-decimal.go.out
+++ b/examples/leetcode-out/fraction-to-recurring-decimal.go.out
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func fractionToDecimal(numerator int, denominator int) string {
+	if (denominator == 0) {
+		return ""
+	}
+	if (numerator == 0) {
+		return "0"
+	}
+	var result string = ""
+	_ = result
+	var minus string = _indexString(fmt.Sprint(-1), 0)
+	var negative bool = false
+	_ = negative
+	if ((((numerator < 0) && (denominator > 0))) || (((numerator > 0) && (denominator < 0)))) {
+		negative = true
+	}
+	if (numerator < 0) {
+		numerator = -numerator
+	}
+	if (denominator < 0) {
+		denominator = -denominator
+	}
+	var integerPart int = (numerator / denominator)
+	result = fmt.Sprint(integerPart)
+	var remainder int = (numerator % denominator)
+	_ = remainder
+	if (remainder == 0) {
+		if negative {
+			return minus + result
+		}
+		return result
+	}
+	result = result + "."
+	var mapIndex map[int]int = map[int]int{}
+	_ = mapIndex
+	var decimal string = ""
+	_ = decimal
+	for (remainder != 0) {
+		_tmp0 := remainder
+		_tmp1 := mapIndex
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			var idx int = mapIndex[remainder]
+			var prefix string = string([]rune(decimal)[0:idx])
+			var suffix string = string([]rune(decimal)[idx:len(decimal)])
+			decimal = prefix + "(" + suffix + ")"
+			break
+		}
+		mapIndex[remainder] = len(decimal)
+		remainder = (remainder * 10)
+		var digit int = (remainder / denominator)
+		decimal = decimal + fmt.Sprint(digit)
+		remainder = (remainder % denominator)
+	}
+	result = result + decimal
+	if negative {
+		return minus + result
+	}
+	return result
+}
+
+func example_1() {
+	expect((fractionToDecimal(1, 2) == "0.5"))
+}
+
+func example_2() {
+	expect((fractionToDecimal(2, 1) == "2"))
+}
+
+func example_3() {
+	expect((fractionToDecimal(2, 3) == "0.(6)"))
+}
+
+func negative() {
+	expect((fractionToDecimal(-50, 8) == "-6.25"))
+}
+
+func repeat_zeros() {
+	expect((fractionToDecimal(1, 6) == "0.1(6)"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	negative()
+	repeat_zeros()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/gas-station.go.out
+++ b/examples/leetcode-out/gas-station.go.out
@@ -1,0 +1,49 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func canCompleteCircuit(gas []int, cost []int) int {
+	var n int = len(gas)
+	var total int = 0
+	_ = total
+	var tank int = 0
+	_ = tank
+	var start int = 0
+	_ = start
+	var i int = 0
+	_ = i
+	for (i < n) {
+		total = ((total + gas[i]) - cost[i])
+		tank = ((tank + gas[i]) - cost[i])
+		if (tank < 0) {
+			start = (i + 1)
+			tank = 0
+		}
+		i = (i + 1)
+	}
+	if (total >= 0) {
+		return start
+	}
+	return -1
+}
+
+func example_1() {
+	expect((canCompleteCircuit([]int{1, 2, 3, 4, 5}, []int{3, 4, 5, 1, 2}) == 3))
+}
+
+func example_2() {
+	expect((canCompleteCircuit([]int{2, 3, 4}, []int{3, 4, 3}) == (-1)))
+}
+
+func single_station() {
+	expect((canCompleteCircuit([]int{5}, []int{4}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_station()
+}
+

--- a/examples/leetcode-out/generate-parentheses.go.out
+++ b/examples/leetcode-out/generate-parentheses.go.out
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func generateParenthesis(n int) []string {
+	var result []string = []string{}
+	_ = result
+	var backtrack func(string, int, int)
+	backtrack = func(current string, open int, close int) {
+		if (len(current) == (n * 2)) {
+			result = append(append([]string{}, result...), []string{current}...)
+		} else {
+			if (open < n) {
+				backtrack(current + "(", (open + 1), close)
+			}
+			if (close < open) {
+				backtrack(current + ")", open, (close + 1))
+			}
+		}
+}
+	backtrack("", 0, 0)
+	return result
+}
+
+func example_1() {
+	expect(_equal(generateParenthesis(3), []string{"((()))", "(()())", "(())()", "()(())", "()()()"}))
+}
+
+func example_2() {
+	expect(_equal(generateParenthesis(1), []string{"()"}))
+}
+
+func two_pairs() {
+	expect(_equal(generateParenthesis(2), []string{"(())", "()()"}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	two_pairs()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/gray-code.go.out
+++ b/examples/leetcode-out/gray-code.go.out
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func grayCode(n int) []int {
+	var result []int = []int{0}
+	_ = result
+	var power int = 1
+	_ = power
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var j int = (len(result) - 1)
+		_ = j
+		for (j >= 0) {
+			result = append(append([]int{}, result...), []int{(result[j] + power)}...)
+			j = (j - 1)
+		}
+		power = (power * 2)
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(grayCode(2), []int{0, 1, 3, 2}))
+}
+
+func example_2() {
+	expect(_equal(grayCode(1), []int{0, 1}))
+}
+
+func zero_bits() {
+	expect(_equal(grayCode(0), []int{0}))
+}
+
+func three_bits() {
+	expect(_equal(grayCode(3), []int{0, 1, 3, 2, 6, 7, 5, 4}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	zero_bits()
+	three_bits()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/group-shifted-strings.go.out
+++ b/examples/leetcode-out/group-shifted-strings.go.out
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func ord(ch string) int {
+	var letters map[string]int = map[string]int{"a": 0, "b": 1, "c": 2, "d": 3, "e": 4, "f": 5, "g": 6, "h": 7, "i": 8, "j": 9, "k": 10, "l": 11, "m": 12, "n": 13, "o": 14, "p": 15, "q": 16, "r": 17, "s": 18, "t": 19, "u": 20, "v": 21, "w": 22, "x": 23, "y": 24, "z": 25}
+	_tmp0 := ch
+	_tmp1 := letters
+	_, _tmp2 := _tmp1[_tmp0]
+	if _tmp2 {
+		return letters[ch]
+	}
+	return 0
+}
+
+func patternKey(s string) string {
+	if (len(s) == 0) {
+		return ""
+	}
+	var key string = ""
+	_ = key
+	var base int = ord(_indexString(s, 0))
+	var i int = 0
+	_ = i
+	for (i < len(s)) {
+		var diff int = ((((ord(_indexString(s, i)) - base) + 26)) % 26)
+		key = key + fmt.Sprint(diff) + ","
+		i = (i + 1)
+	}
+	return key
+}
+
+func groupStrings(strings []string) [][]string {
+	var groups map[string][]string = map[string][]string{}
+	_ = groups
+	for _, s := range strings {
+		var k string = patternKey(s)
+		var lst []string = []string{}
+		_ = lst
+		_tmp3 := k
+		_tmp4 := groups
+		_, _tmp5 := _tmp4[_tmp3]
+		if _tmp5 {
+			lst = groups[k]
+		}
+		lst = append(append([]string{}, lst...), []string{s}...)
+		groups[k] = lst
+	}
+	var result [][]string = [][]string{}
+	_ = result
+	for k := range groups {
+		result = append(append([][]string{}, result...), [][]string{groups[k]}...)
+	}
+	return result
+}
+
+func example_1() {
+	var input []string = []string{"abc", "bcd", "acef", "xyz", "az", "ba", "a", "z"}
+	var res [][]string = groupStrings(input)
+	expect((len(res) == 4))
+}
+
+func single() {
+	expect((groupStrings([]string{"a"})[0][0] == "a"))
+}
+
+func empty_list() {
+	var res [][]string = groupStrings([]string{})
+	expect((len(res) == 0))
+}
+
+func main() {
+	example_1()
+	single()
+	empty_list()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/happy-number.go.out
+++ b/examples/leetcode-out/happy-number.go.out
@@ -1,0 +1,56 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isHappy(n int) bool {
+	var seen map[int]bool = map[int]bool{}
+	_ = seen
+	var current int = n
+	_ = current
+	for (current != 1) {
+		_tmp0 := current
+		_tmp1 := seen
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			break
+		}
+		seen[current] = true
+		var sum int = 0
+		_ = sum
+		var x int = current
+		_ = x
+		for (x > 0) {
+			var digit int = (x % 10)
+			sum = (sum + (digit * digit))
+			x = (x / 10)
+		}
+		current = sum
+	}
+	return (current == 1)
+}
+
+func example_1() {
+	expect((isHappy(19) == true))
+}
+
+func example_2() {
+	expect((isHappy(2) == false))
+}
+
+func one_is_happy() {
+	expect((isHappy(1) == true))
+}
+
+func not_happy() {
+	expect((isHappy(3) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	one_is_happy()
+	not_happy()
+}
+

--- a/examples/leetcode-out/house-robber-ii.go.out
+++ b/examples/leetcode-out/house-robber-ii.go.out
@@ -1,0 +1,71 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func robLinear(nums []int, start int, end int) int {
+	var prev1 int = 0
+	_ = prev1
+	var prev2 int = 0
+	_ = prev2
+	var i int = start
+	_ = i
+	for (i <= end) {
+		var pick int = (nums[i] + prev2)
+		var curr int = pick
+		_ = curr
+		if (prev1 > curr) {
+			curr = prev1
+		}
+		prev2 = prev1
+		prev1 = curr
+		i = (i + 1)
+	}
+	return prev1
+}
+
+func rob(nums []int) int {
+	var n int = len(nums)
+	if (n == 0) {
+		return 0
+	}
+	if (n == 1) {
+		return nums[0]
+	}
+	var option1 int = robLinear(nums, 0, (n - 2))
+	var option2 int = robLinear(nums, 1, (n - 1))
+	if (option1 > option2) {
+		return option1
+	}
+	return option2
+}
+
+func example_1() {
+	expect((rob([]int{2, 3, 2}) == 3))
+}
+
+func example_2() {
+	expect((rob([]int{1, 2, 3, 1}) == 4))
+}
+
+func example_3() {
+	expect((rob([]int{1, 2, 3}) == 3))
+}
+
+func single() {
+	expect((rob([]int{5}) == 5))
+}
+
+func empty() {
+	expect((rob([]int{}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single()
+	empty()
+}
+

--- a/examples/leetcode-out/house-robber.go.out
+++ b/examples/leetcode-out/house-robber.go.out
@@ -1,0 +1,65 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func rob(nums []int) int {
+	var n int = len(nums)
+	if (n == 0) {
+		return 0
+	}
+	if (n == 1) {
+		return nums[0]
+	}
+	var prev2 int = nums[0]
+	_ = prev2
+	var prev1 int = nums[0]
+	_ = prev1
+	if (nums[1] > prev1) {
+		prev1 = nums[1]
+	}
+	var i int = 2
+	_ = i
+	for (i < n) {
+		var take int = (prev2 + nums[i])
+		var best int = prev1
+		_ = best
+		if (take > best) {
+			best = take
+		}
+		prev2 = prev1
+		prev1 = best
+		i = (i + 1)
+	}
+	return prev1
+}
+
+func example_1() {
+	expect((rob([]int{1, 2, 3, 1}) == 4))
+}
+
+func example_2() {
+	expect((rob([]int{2, 7, 9, 3, 1}) == 12))
+}
+
+func empty() {
+	expect((rob([]int{}) == 0))
+}
+
+func single_house() {
+	expect((rob([]int{5}) == 5))
+}
+
+func two_houses() {
+	expect((rob([]int{2, 1}) == 2))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty()
+	single_house()
+	two_houses()
+}
+

--- a/examples/leetcode-out/implement-queue-using-stacks.go.out
+++ b/examples/leetcode-out/implement-queue-using-stacks.go.out
@@ -1,0 +1,105 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type MyQueue struct {
+	Ins []int `json:"ins"`
+	Outs []int `json:"outs"`
+}
+
+type PopResult struct {
+	Queue any `json:"queue"`
+	Val int `json:"val"`
+}
+
+func newQueue() MyQueue {
+	return MyQueue{Ins: _cast[[]int]([]any{}), Outs: _cast[[]int]([]any{})}
+}
+
+func push(q MyQueue, x int) MyQueue {
+	var s []int = q.Ins
+	_ = s
+	s = append(append([]int{}, s...), []int{x}...)
+	return MyQueue{Ins: s, Outs: q.Outs}
+}
+
+func ensureOut(q MyQueue) MyQueue {
+	var inStack []int = q.Ins
+	_ = inStack
+	var outStack []int = q.Outs
+	_ = outStack
+	if (len(outStack) == 0) {
+		for (len(inStack) > 0) {
+			var v int = inStack[(len(inStack) - 1)]
+			inStack = inStack[0:(len(inStack) - 1)]
+			outStack = append(append([]int{}, outStack...), []int{v}...)
+		}
+	}
+	return MyQueue{Ins: inStack, Outs: outStack}
+}
+
+func pop(q MyQueue) PopResult {
+	var shifted MyQueue = ensureOut(q)
+	var outStack []int = shifted.Outs
+	_ = outStack
+	var v int = outStack[(len(outStack) - 1)]
+	outStack = outStack[0:(len(outStack) - 1)]
+	var newQ MyQueue = MyQueue{Ins: shifted.Ins, Outs: outStack}
+	return PopResult{Queue: newQ, Val: v}
+}
+
+func peek(q MyQueue) int {
+	var shifted MyQueue = ensureOut(q)
+	return shifted.Outs[(len(shifted.Outs) - 1)]
+}
+
+func empty(q MyQueue) bool {
+	return ((len(q.Ins) == 0) && (len(q.Outs) == 0))
+}
+
+func example() {
+	var q MyQueue = newQueue()
+	_ = q
+	q = push(q, 1)
+	q = push(q, 2)
+	expect((peek(q) == 1))
+	var r1 PopResult = pop(q)
+	q = r1.Queue
+	expect((r1.Val == 1))
+	expect((empty(q) == false))
+}
+
+func multiple_operations() {
+	var q MyQueue = newQueue()
+	_ = q
+	q = push(q, 3)
+	q = push(q, 4)
+	var r1 PopResult = pop(q)
+	q = r1.Queue
+	expect((r1.Val == 3))
+	q = push(q, 5)
+	expect((peek(q) == 4))
+	var r2 PopResult = pop(q)
+	q = r2.Queue
+	expect((r2.Val == 4))
+	var r3 PopResult = pop(q)
+	q = r3.Queue
+	expect((r3.Val == 5))
+	expect((empty(q) == true))
+}
+
+func main() {
+	example()
+	multiple_operations()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/implement-stack-using-queues.go.out
+++ b/examples/leetcode-out/implement-stack-using-queues.go.out
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func NewStack() map[string]any {
+	return _cast[map[string]any](map[string][]int{"q": _cast[[]int]([]any{})})
+}
+
+func push(stack map[string]any, x int) {
+	var q []int = _cast[[]int](stack["q"])
+	_ = q
+	q = append(append([]int{}, q...), []int{x}...)
+	var i int = 0
+	_ = i
+	for (i < (len(q) - 1)) {
+		q = append(append([]int{}, q[1:len(q)]...), []int{q[0]}...)
+		i = (i + 1)
+	}
+	stack["q"] = q
+}
+
+func pop(stack map[string]any) int {
+	var q []int = _cast[[]int](stack["q"])
+	_ = q
+	var v int = q[0]
+	q = q[1:len(q)]
+	stack["q"] = q
+	return v
+}
+
+func top(stack map[string]any) int {
+	var q []int = _cast[[]int](stack["q"])
+	return q[0]
+}
+
+func empty(stack map[string]any) bool {
+	var q []int = _cast[[]int](stack["q"])
+	return (len(q) == 0)
+}
+
+func example() {
+	var st map[string]any = NewStack()
+	push(st, 1)
+	push(st, 2)
+	expect((top(st) == 2))
+	expect((pop(st) == 2))
+	expect((empty(st) == false))
+}
+
+func single_push_pop() {
+	var st map[string]any = NewStack()
+	push(st, 5)
+	expect((pop(st) == 5))
+	expect((empty(st) == true))
+}
+
+func multiple_pushes() {
+	var st map[string]any = NewStack()
+	push(st, 1)
+	push(st, 2)
+	push(st, 3)
+	expect((pop(st) == 3))
+	expect((pop(st) == 2))
+	expect((pop(st) == 1))
+	expect((empty(st) == true))
+}
+
+func main() {
+	example()
+	single_push_pop()
+	multiple_pushes()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/implement-trie-prefix-tree.go.out
+++ b/examples/leetcode-out/implement-trie-prefix-tree.go.out
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func Node() map[string]any {
+	return map[string]any{"children": _cast[map[string]map[string]any](map[any]any{}), "end": false}
+}
+
+func insert(trie map[string]any, word string) {
+	var node map[string]any = trie
+	_ = node
+	var i int = 0
+	_ = i
+	for (i < len(word)) {
+		var ch string = _indexString(word, i)
+		var kids map[string]map[string]any = _cast[map[string]map[string]any](node["children"])
+		_ = kids
+		var child map[string]any = map[string]any{}
+		_ = child
+		_tmp0 := ch
+		_tmp1 := kids
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			child = _cast[map[string]any](kids[ch])
+		} else {
+			child = Node()
+		}
+		if (i == (len(word) - 1)) {
+			child["end"] = true
+		}
+		kids[ch] = child
+		node["children"] = kids
+		node = child
+		i = (i + 1)
+	}
+}
+
+func search(trie map[string]any, word string) bool {
+	var node map[string]any = trie
+	_ = node
+	for _, r := range []rune(word) {
+		ch := string(r)
+		var kids map[string]map[string]any = _cast[map[string]map[string]any](node["children"])
+		_tmp3 := ch
+		_tmp4 := kids
+		_, _tmp5 := _tmp4[_tmp3]
+		if !(_tmp5) {
+			return false
+		}
+		node = kids[ch]
+	}
+	return _cast[bool](node["end"])
+}
+
+func startsWith(trie map[string]any, prefix string) bool {
+	var node map[string]any = trie
+	_ = node
+	for _, r := range []rune(prefix) {
+		ch := string(r)
+		var kids map[string]map[string]any = _cast[map[string]map[string]any](node["children"])
+		_tmp6 := ch
+		_tmp7 := kids
+		_, _tmp8 := _tmp7[_tmp6]
+		if !(_tmp8) {
+			return false
+		}
+		node = kids[ch]
+	}
+	return true
+}
+
+func search_apple() {
+	var t map[string]any = Node()
+	_ = t
+	insert(t, "apple")
+	expect((search(t, "apple") == true))
+}
+
+func search_app() {
+	var t map[string]any = Node()
+	_ = t
+	insert(t, "apple")
+	expect((search(t, "app") == false))
+}
+
+func startsWith_app() {
+	var t map[string]any = Node()
+	_ = t
+	insert(t, "apple")
+	expect((startsWith(t, "app") == true))
+}
+
+func search_app_after_insert() {
+	var t map[string]any = Node()
+	_ = t
+	insert(t, "apple")
+	insert(t, "app")
+	expect((search(t, "app") == true))
+}
+
+func main() {
+	search_apple()
+	search_app()
+	startsWith_app()
+	search_app_after_insert()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/insert-interval.go.out
+++ b/examples/leetcode-out/insert-interval.go.out
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func insert(intervals [][]int, newInterval []int) [][]int {
+	var result [][]int = [][]int{}
+	_ = result
+	var inserted bool = false
+	_ = inserted
+	var start int = newInterval[0]
+	_ = start
+	var end int = newInterval[1]
+	_ = end
+	for _, interval := range intervals {
+		var currStart int = interval[0]
+		var currEnd int = interval[1]
+		if (currEnd < start) {
+			result = append(append([][]int{}, result...), [][]int{interval}...)
+		} else 		if (currStart > end) {
+			if !inserted {
+				result = append(append([][]int{}, result...), [][]int{[]int{start, end}}...)
+				inserted = true
+			}
+			result = append(append([][]int{}, result...), [][]int{interval}...)
+		} else {
+			if (currStart < start) {
+				start = currStart
+			}
+			if (currEnd > end) {
+				end = currEnd
+			}
+		}
+	}
+	if !inserted {
+		result = append(append([][]int{}, result...), [][]int{[]int{start, end}}...)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(insert([][]int{[]int{1, 3}, []int{6, 9}}, []int{2, 5}), [][]int{[]int{1, 5}, []int{6, 9}}))
+}
+
+func example_2() {
+	expect(_equal(insert([][]int{[]int{1, 2}, []int{3, 5}, []int{6, 7}, []int{8, 10}, []int{12, 16}}, []int{4, 8}), [][]int{[]int{1, 2}, []int{3, 10}, []int{12, 16}}))
+}
+
+func empty_list() {
+	expect(_equal(insert([][]int{}, []int{5, 7}), [][]int{[]int{5, 7}}))
+}
+
+func contained_interval() {
+	expect(_equal(insert([][]int{[]int{1, 5}}, []int{2, 3}), [][]int{[]int{1, 5}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_list()
+	contained_interval()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/insertion-sort-list.go.out
+++ b/examples/leetcode-out/insertion-sort-list.go.out
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func insertionSortList(nums []int) []int {
+	var arr []int = nums
+	_ = arr
+	var i int = 1
+	_ = i
+	for (i < len(arr)) {
+		var key int = arr[i]
+		_ = key
+		var j int = (i - 1)
+		_ = j
+		for ((j >= 0) && (arr[j] > key)) {
+			arr[(j + 1)] = arr[j]
+			j = (j - 1)
+		}
+		arr[(j + 1)] = key
+		i = (i + 1)
+	}
+	return arr
+}
+
+func example_1() {
+	expect(_equal(insertionSortList([]int{4, 2, 1, 3}), []int{1, 2, 3, 4}))
+}
+
+func example_2() {
+	expect(_equal(insertionSortList([]int{-1, 5, 3, 4, 0}), []int{-1, 0, 3, 4, 5}))
+}
+
+func already_sorted() {
+	expect(_equal(insertionSortList([]int{1, 2, 3, 4}), []int{1, 2, 3, 4}))
+}
+
+func single_element() {
+	expect(_equal(insertionSortList([]int{1}), []int{1}))
+}
+
+func empty() {
+	expect(_equal(insertionSortList([]int{}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	already_sorted()
+	single_element()
+	empty()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/integer-to-roman.go.out
+++ b/examples/leetcode-out/integer-to-roman.go.out
@@ -1,0 +1,47 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func intToRoman(num int) string {
+	var values []int = []int{1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1}
+	var symbols []string = []string{"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"}
+	var result string = ""
+	_ = result
+	var i int = 0
+	_ = i
+	for (num > 0) {
+		for (num >= values[i]) {
+			result = result + symbols[i]
+			num = (num - values[i])
+		}
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect((intToRoman(3) == "III"))
+}
+
+func example_2() {
+	expect((intToRoman(58) == "LVIII"))
+}
+
+func example_3() {
+	expect((intToRoman(1994) == "MCMXCIV"))
+}
+
+func small_numbers() {
+	expect((intToRoman(4) == "IV"))
+	expect((intToRoman(9) == "IX"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	small_numbers()
+}
+

--- a/examples/leetcode-out/interleaving-string.go.out
+++ b/examples/leetcode-out/interleaving-string.go.out
@@ -1,0 +1,80 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isInterleave(s1 string, s2 string, s3 string) bool {
+	var m int = len(s1)
+	var n int = len(s2)
+	if ((m + n) != len(s3)) {
+		return false
+	}
+	var dp [][]bool = [][]bool{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i <= m) {
+		var row []bool = []bool{}
+		_ = row
+		var j int = 0
+		_ = j
+		for (j <= n) {
+			row = append(append([]bool{}, row...), []bool{false}...)
+			j = (j + 1)
+		}
+		dp = append(append([][]bool{}, dp...), [][]bool{row}...)
+		i = (i + 1)
+	}
+	dp[0][0] = true
+	i = 0
+	for (i <= m) {
+		var j int = 0
+		_ = j
+		for (j <= n) {
+			if (i > 0) {
+				if (dp[(i - 1)][j] && (_indexString(s1, (i - 1)) == _indexString(s3, ((i + j) - 1)))) {
+					dp[i][j] = true
+				}
+			}
+			if (j > 0) {
+				if (dp[i][(j - 1)] && (_indexString(s2, (j - 1)) == _indexString(s3, ((i + j) - 1)))) {
+					dp[i][j] = true
+				}
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return dp[m][n]
+}
+
+func example_1() {
+	expect((isInterleave("aabcc", "dbbca", "aadbbcbcac") == true))
+}
+
+func example_2() {
+	expect((isInterleave("aabcc", "dbbca", "aadbbbaccc") == false))
+}
+
+func empty() {
+	expect((isInterleave("", "", "") == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/intersection-of-two-linked-lists.go.out
+++ b/examples/leetcode-out/intersection-of-two-linked-lists.go.out
@@ -1,0 +1,59 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func getIntersectionNode(next []int, headA int, headB int) int {
+	var a int = headA
+	_ = a
+	var b int = headB
+	_ = b
+	for (a != b) {
+		if (a == (-1)) {
+			a = headB
+		} else {
+			a = next[a]
+		}
+		if (b == (-1)) {
+			b = headA
+		} else {
+			b = next[b]
+		}
+	}
+	return a
+}
+
+func example_1() {
+	var next []int = []int{1, 2, 3, 4, -1, 6, 7, 2}
+	expect((getIntersectionNode(next, 0, 5) == 2))
+}
+
+func example_2() {
+	var next []int = []int{1, 2, 3, 4, -1, 3}
+	expect((getIntersectionNode(next, 0, 5) == 3))
+}
+
+func example_3() {
+	var next []int = []int{1, 2, -1, 4, -1}
+	expect((getIntersectionNode(next, 0, 3) == (-1)))
+}
+
+func same_head() {
+	var next []int = []int{1, 2, 3, -1}
+	expect((getIntersectionNode(next, 0, 0) == 0))
+}
+
+func one_empty() {
+	var next []int = []int{1, -1}
+	expect((getIntersectionNode(next, 0, -1) == (-1)))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	same_head()
+	one_empty()
+}
+

--- a/examples/leetcode-out/isomorphic-strings.go.out
+++ b/examples/leetcode-out/isomorphic-strings.go.out
@@ -1,0 +1,81 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isIsomorphic(s string, t string) bool {
+	var m int = len(s)
+	if (m != len(t)) {
+		return false
+	}
+	var mapST map[string]string = map[string]string{}
+	_ = mapST
+	var mapTS map[string]string = map[string]string{}
+	_ = mapTS
+	var i int = 0
+	_ = i
+	for (i < m) {
+		var c1 string = _indexString(s, i)
+		var c2 string = _indexString(t, i)
+		_tmp0 := c1
+		_tmp1 := mapST
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			if (mapST[c1] != c2) {
+				return false
+			}
+		} else {
+			_tmp3 := c2
+			_tmp4 := mapTS
+			_, _tmp5 := _tmp4[_tmp3]
+			if _tmp5 {
+				return false
+			}
+			mapST[c1] = c2
+			mapTS[c2] = c1
+		}
+		i = (i + 1)
+	}
+	return true
+}
+
+func example_1() {
+	expect((isIsomorphic("egg", "add") == true))
+}
+
+func example_2() {
+	expect((isIsomorphic("foo", "bar") == false))
+}
+
+func example_3() {
+	expect((isIsomorphic("paper", "title") == true))
+}
+
+func single_letter() {
+	expect((isIsomorphic("a", "b") == true))
+}
+
+func mismatch_length() {
+	expect((isIsomorphic("ab", "a") == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_letter()
+	mismatch_length()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/jump-game-ii.go.out
+++ b/examples/leetcode-out/jump-game-ii.go.out
@@ -1,0 +1,52 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func jump(nums []int) int {
+	var n int = len(nums)
+	var jumps int = 0
+	_ = jumps
+	var end int = 0
+	_ = end
+	var farthest int = 0
+	_ = farthest
+	for i := 0; i < n; i++ {
+		if (i > farthest) {
+			return -1
+		}
+		if ((i + nums[i]) > farthest) {
+			farthest = (i + nums[i])
+		}
+		if ((i == end) && (i != (n - 1))) {
+			jumps = (jumps + 1)
+			end = farthest
+		}
+	}
+	return jumps
+}
+
+func example_1() {
+	expect((jump([]int{2, 3, 1, 1, 4}) == 2))
+}
+
+func example_2() {
+	expect((jump([]int{2, 3, 0, 1, 4}) == 2))
+}
+
+func single_element() {
+	expect((jump([]int{0}) == 0))
+}
+
+func two_elements() {
+	expect((jump([]int{1, 2}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+	two_elements()
+}
+

--- a/examples/leetcode-out/jump-game.go.out
+++ b/examples/leetcode-out/jump-game.go.out
@@ -1,0 +1,44 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func canJump(nums []int) bool {
+	var n int = len(nums)
+	var farthest int = 0
+	_ = farthest
+	for i := 0; i < n; i++ {
+		if (i > farthest) {
+			return false
+		}
+		if ((i + nums[i]) > farthest) {
+			farthest = (i + nums[i])
+		}
+	}
+	return true
+}
+
+func example_1() {
+	expect((canJump([]int{2, 3, 1, 1, 4}) == true))
+}
+
+func example_2() {
+	expect((canJump([]int{3, 2, 1, 0, 4}) == false))
+}
+
+func single_element() {
+	expect((canJump([]int{0}) == true))
+}
+
+func with_zeros() {
+	expect((canJump([]int{2, 0, 0}) == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+	with_zeros()
+}
+

--- a/examples/leetcode-out/kth-largest-element-in-an-array.go.out
+++ b/examples/leetcode-out/kth-largest-element-in-an-array.go.out
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findKthLargest(nums []int, k int) int {
+	var sorted []any = func() []int {
+	items := []int{}
+	for _, x := range nums {
+		items = append(items, x)
+	}
+	type pair struct { item int; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		x := it
+		pairs[idx] = pair{item: it, key: -x}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []int{}
+	for _, x := range items {
+		res = append(res, x)
+	}
+	return res
+}()
+	return sorted[(k - 1)]
+}
+
+func example_1() {
+	expect((findKthLargest([]int{3, 2, 1, 5, 6, 4}, 2) == 5))
+}
+
+func example_2() {
+	expect((findKthLargest([]int{3, 2, 3, 1, 2, 4, 5, 5, 6}, 4) == 4))
+}
+
+func single_element() {
+	expect((findKthLargest([]int{1}, 1) == 1))
+}
+
+func with_negatives() {
+	expect((findKthLargest([]int{-1, -2, -3, -4}, 2) == (-2)))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+	with_negatives()
+}
+

--- a/examples/leetcode-out/largest-number.go.out
+++ b/examples/leetcode-out/largest-number.go.out
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func largestNumber(nums []int) string {
+	var strs []string = []string{}
+	_ = strs
+	var i int = 0
+	_ = i
+	for (i < len(nums)) {
+		strs = append(append([]string{}, strs...), []string{fmt.Sprint(nums[i])}...)
+		i = (i + 1)
+	}
+	var j int = 0
+	_ = j
+	for (j < len(strs)) {
+		var k int = (j + 1)
+		_ = k
+		for (k < len(strs)) {
+			var ab string = strs[j] + strs[k]
+			var ba string = strs[k] + strs[j]
+			if (ab < ba) {
+				var tmp string = strs[j]
+				strs[j] = strs[k]
+				strs[k] = tmp
+			}
+			k = (k + 1)
+		}
+		j = (j + 1)
+	}
+	var result string = ""
+	_ = result
+	i = 0
+	for (i < len(strs)) {
+		result = result + strs[i]
+		i = (i + 1)
+	}
+	var pos int = 0
+	_ = pos
+	for ((pos < (len(result) - 1)) && (_indexString(result, pos) == "0")) {
+		pos = (pos + 1)
+	}
+	return string([]rune(result)[pos:len(result)])
+}
+
+func example_1() {
+	expect((largestNumber([]int{10, 2}) == "210"))
+}
+
+func example_2() {
+	expect((largestNumber([]int{3, 30, 34, 5, 9}) == "9534330"))
+}
+
+func multiple_zeros() {
+	expect((largestNumber([]int{0, 0}) == "0"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	multiple_zeros()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/largest-rectangle-in-histogram.go.out
+++ b/examples/leetcode-out/largest-rectangle-in-histogram.go.out
@@ -1,0 +1,74 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func largestRectangleArea(heights []int) int {
+	var n int = len(heights)
+	var stack []int = []int{}
+	_ = stack
+	var maxArea int = 0
+	_ = maxArea
+	var i int = 0
+	_ = i
+	for (i < n) {
+		for (len(stack) > 0) {
+			if (heights[i] < heights[stack[(len(stack) - 1)]]) {
+				var h int = heights[stack[(len(stack) - 1)]]
+				stack = stack[0:(len(stack) - 1)]
+				var width int = i
+				_ = width
+				if (len(stack) > 0) {
+					width = ((i - stack[(len(stack) - 1)]) - 1)
+				}
+				var area int = (h * width)
+				if (area > maxArea) {
+					maxArea = area
+				}
+			} else {
+				break
+			}
+		}
+		stack = append(append([]int{}, stack...), []int{i}...)
+		i = (i + 1)
+	}
+	for (len(stack) > 0) {
+		var h int = heights[stack[(len(stack) - 1)]]
+		stack = stack[0:(len(stack) - 1)]
+		var width int = n
+		_ = width
+		if (len(stack) > 0) {
+			width = ((n - stack[(len(stack) - 1)]) - 1)
+		}
+		var area int = (h * width)
+		if (area > maxArea) {
+			maxArea = area
+		}
+	}
+	return maxArea
+}
+
+func example_1() {
+	expect((largestRectangleArea([]int{2, 1, 5, 6, 2, 3}) == 10))
+}
+
+func example_2() {
+	expect((largestRectangleArea([]int{2, 4}) == 4))
+}
+
+func single_bar() {
+	expect((largestRectangleArea([]int{1}) == 1))
+}
+
+func valley() {
+	expect((largestRectangleArea([]int{2, 1, 2}) == 3))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_bar()
+	valley()
+}
+

--- a/examples/leetcode-out/length-of-last-word.go.out
+++ b/examples/leetcode-out/length-of-last-word.go.out
@@ -1,0 +1,55 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func lengthOfLastWord(s string) int {
+	var i int = (len(s) - 1)
+	_ = i
+	for ((i >= 0) && (_indexString(s, i) == " ")) {
+		i = (i - 1)
+	}
+	var length int = 0
+	_ = length
+	for ((i >= 0) && (_indexString(s, i) != " ")) {
+		length = (length + 1)
+		i = (i - 1)
+	}
+	return length
+}
+
+func example_1() {
+	expect((lengthOfLastWord("Hello World") == 5))
+}
+
+func example_2() {
+	expect((lengthOfLastWord("   fly me   to   the moon  ") == 4))
+}
+
+func example_3() {
+	expect((lengthOfLastWord("luffy is still joyboy") == 6))
+}
+
+func only_spaces() {
+	expect((lengthOfLastWord("   ") == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	only_spaces()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/letter-combinations-of-a-phone-number.go.out
+++ b/examples/leetcode-out/letter-combinations-of-a-phone-number.go.out
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func letterCombinations(digits string) []string {
+	if (len(digits) == 0) {
+		return _cast[[]string]([]any{})
+	}
+	var mapping map[string][]string = map[string][]string{"2": []string{"a", "b", "c"}, "3": []string{"d", "e", "f"}, "4": []string{"g", "h", "i"}, "5": []string{"j", "k", "l"}, "6": []string{"m", "n", "o"}, "7": []string{"p", "q", "r", "s"}, "8": []string{"t", "u", "v"}, "9": []string{"w", "x", "y", "z"}}
+	var result []string = []string{""}
+	_ = result
+	for _, r := range []rune(digits) {
+		d := string(r)
+		_tmp0 := d
+		_tmp1 := mapping
+		_, _tmp2 := _tmp1[_tmp0]
+		if !(_tmp2) {
+			continue
+		}
+		var letters []string = mapping[d]
+		var next []any = func() []string {
+	res := []string{}
+	for _, p := range result {
+		for _, ch := range letters {
+			res = append(res, p + ch)
+		}
+	}
+	return res
+}()
+		result = next
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(letterCombinations("23"), []string{"ad", "ae", "af", "bd", "be", "bf", "cd", "ce", "cf"}))
+}
+
+func example_2() {
+	expect(_equal(letterCombinations(""), []any{}))
+}
+
+func example_3() {
+	expect(_equal(letterCombinations("2"), []string{"a", "b", "c"}))
+}
+
+func single_seven() {
+	expect(_equal(letterCombinations("7"), []string{"p", "q", "r", "s"}))
+}
+
+func mix() {
+	expect(_equal(letterCombinations("79"), []string{"pw", "px", "py", "pz", "qw", "qx", "qy", "qz", "rw", "rx", "ry", "rz", "sw", "sx", "sy", "sz"}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_seven()
+	mix()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/linked-list-cycle-ii.go.out
+++ b/examples/leetcode-out/linked-list-cycle-ii.go.out
@@ -1,0 +1,56 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func detectCycle(next []int) int {
+	if (len(next) == 0) {
+		return -1
+	}
+	var slow int = 0
+	_ = slow
+	var fast int = 0
+	_ = fast
+	for ((fast != (-1)) && (next[fast] != (-1))) {
+		slow = next[slow]
+		fast = next[next[fast]]
+		if (slow == fast) {
+			break
+		}
+	}
+	if ((fast == (-1)) || (next[fast] == (-1))) {
+		return -1
+	}
+	var start int = 0
+	_ = start
+	for (start != slow) {
+		start = next[start]
+		slow = next[slow]
+	}
+	return start
+}
+
+func example_1() {
+	expect((detectCycle([]int{1, 2, 3, 1}) == 1))
+}
+
+func no_cycle() {
+	expect((detectCycle([]int{1, 2, 3, -1}) == (-1)))
+}
+
+func cycle_at_head() {
+	expect((detectCycle([]int{0}) == 0))
+}
+
+func single_node_no_cycle() {
+	expect((detectCycle([]int{-1}) == (-1)))
+}
+
+func main() {
+	example_1()
+	no_cycle()
+	cycle_at_head()
+	single_node_no_cycle()
+}
+

--- a/examples/leetcode-out/linked-list-cycle.go.out
+++ b/examples/leetcode-out/linked-list-cycle.go.out
@@ -1,0 +1,61 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func hasCycle(values []int, pos int) bool {
+	var n int = len(values)
+	var nextIndex = func(i int) int {
+		if (i == (n - 1)) {
+			if (pos >= 0) {
+				return pos
+			} else {
+				return n
+			}
+		} else {
+			return (i + 1)
+		}
+}
+	if ((n == 0) || (pos < 0)) {
+		return false
+	}
+	var slow int = 0
+	_ = slow
+	var fast int = 0
+	_ = fast
+	for {
+		slow = nextIndex(slow)
+		fast = nextIndex(fast)
+		if (fast >= n) {
+			return false
+		}
+		fast = nextIndex(fast)
+		if ((slow >= n) || (fast >= n)) {
+			return false
+		}
+		if (slow == fast) {
+			return true
+		}
+	}
+	return false
+}
+
+func example_1() {
+	expect((hasCycle([]int{3, 2, 0, -4}, 1) == true))
+}
+
+func example_2() {
+	expect((hasCycle([]int{1, 2}, 0) == true))
+}
+
+func example_3() {
+	expect((hasCycle([]int{1}, -1) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/longest-common-prefix.go.out
+++ b/examples/leetcode-out/longest-common-prefix.go.out
@@ -1,0 +1,64 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func longestCommonPrefix(strs []string) string {
+	if (len(strs) == 0) {
+		return ""
+	}
+	var prefix string = strs[0]
+	_ = prefix
+	for i := 1; i < len(strs); i++ {
+		var j int = 0
+		_ = j
+		var current string = strs[i]
+		for ((j < len(prefix)) && (j < len(current))) {
+			if (_indexString(prefix, j) != _indexString(current, j)) {
+				break
+			}
+			j = (j + 1)
+		}
+		prefix = string([]rune(prefix)[0:j])
+		if (prefix == "") {
+			break
+		}
+	}
+	return prefix
+}
+
+func example_1() {
+	expect((longestCommonPrefix([]string{"flower", "flow", "flight"}) == "fl"))
+}
+
+func example_2() {
+	expect((longestCommonPrefix([]string{"dog", "racecar", "car"}) == ""))
+}
+
+func single_string() {
+	expect((longestCommonPrefix([]string{"single"}) == "single"))
+}
+
+func no_common_prefix() {
+	expect((longestCommonPrefix([]string{"a", "b", "c"}) == ""))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_string()
+	no_common_prefix()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/longest-consecutive-sequence.go.out
+++ b/examples/leetcode-out/longest-consecutive-sequence.go.out
@@ -1,0 +1,61 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func longestConsecutive(nums []int) int {
+	var set map[int]bool = map[int]bool{}
+	_ = set
+	for _, n := range nums {
+		set[n] = true
+	}
+	var best int = 0
+	_ = best
+	for n := range set {
+		_tmp0 := (n - 1)
+		_tmp1 := set
+		_, _tmp2 := _tmp1[_tmp0]
+		if !(_tmp2) {
+			var curr int = n
+			_ = curr
+			var length int = 1
+			_ = length
+			_tmp3 := (curr + 1)
+			_tmp4 := set
+			_, _tmp5 := _tmp4[_tmp3]
+			for _tmp5 {
+				curr = (curr + 1)
+				length = (length + 1)
+			}
+			if (length > best) {
+				best = length
+			}
+		}
+	}
+	return best
+}
+
+func example_1() {
+	expect((longestConsecutive([]int{100, 4, 200, 1, 3, 2}) == 4))
+}
+
+func example_2() {
+	expect((longestConsecutive([]int{0, 3, 7, 2, 5, 8, 4, 6, 0, 1}) == 9))
+}
+
+func empty() {
+	expect((longestConsecutive([]int{}) == 0))
+}
+
+func duplicates() {
+	expect((longestConsecutive([]int{1, 2, 0, 1}) == 3))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty()
+	duplicates()
+}
+

--- a/examples/leetcode-out/longest-palindromic-substring.go.out
+++ b/examples/leetcode-out/longest-palindromic-substring.go.out
@@ -1,0 +1,83 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func expand(s string, left int, right int) int {
+	var l int = left
+	_ = l
+	var r int = right
+	_ = r
+	var n int = len(s)
+	for ((l >= 0) && (r < n)) {
+		if (_indexString(s, l) != _indexString(s, r)) {
+			break
+		}
+		l = (l - 1)
+		r = (r + 1)
+	}
+	return ((r - l) - 1)
+}
+
+func longestPalindrome(s string) string {
+	if (len(s) <= 1) {
+		return s
+	}
+	var start int = 0
+	_ = start
+	var end int = 0
+	_ = end
+	var n int = len(s)
+	for i := 0; i < n; i++ {
+		var len1 int = expand(s, i, i)
+		var len2 int = expand(s, i, (i + 1))
+		var l int = len1
+		_ = l
+		if (len2 > len1) {
+			l = len2
+		}
+		if (l > (end - start)) {
+			start = (i - (((l - 1)) / 2))
+			end = (i + (l / 2))
+		}
+	}
+	return string([]rune(s)[start:(end + 1)])
+}
+
+func example_1() {
+	var ans string = longestPalindrome("babad")
+	expect(((ans == "bab") || (ans == "aba")))
+}
+
+func example_2() {
+	expect((longestPalindrome("cbbd") == "bb"))
+}
+
+func single_char() {
+	expect((longestPalindrome("a") == "a"))
+}
+
+func two_chars() {
+	var ans string = longestPalindrome("ac")
+	expect(((ans == "a") || (ans == "c")))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_char()
+	two_chars()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/longest-substring-with-at-most-two-distinct-characters.go.out
+++ b/examples/leetcode-out/longest-substring-with-at-most-two-distinct-characters.go.out
@@ -1,0 +1,87 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func lengthOfLongestSubstringTwoDistinct(s string) int {
+	var left int = 0
+	_ = left
+	var best int = 0
+	_ = best
+	var counts map[string]int = map[string]int{}
+	_ = counts
+	var distinct int = 0
+	_ = distinct
+	var right int = 0
+	_ = right
+	for (right < len(s)) {
+		var ch string = _indexString(s, right)
+		_tmp0 := ch
+		_tmp1 := counts
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			if (counts[ch] == 0) {
+				distinct = (distinct + 1)
+			}
+			counts[ch] = (counts[ch] + 1)
+		} else {
+			counts[ch] = 1
+			distinct = (distinct + 1)
+		}
+		for (distinct > 2) {
+			var leftCh string = _indexString(s, left)
+			counts[leftCh] = (counts[leftCh] - 1)
+			if (counts[leftCh] == 0) {
+				distinct = (distinct - 1)
+			}
+			left = (left + 1)
+		}
+		var length int = ((right - left) + 1)
+		if (length > best) {
+			best = length
+		}
+		right = (right + 1)
+	}
+	return best
+}
+
+func example_1() {
+	expect((lengthOfLongestSubstringTwoDistinct("eceba") == 3))
+}
+
+func example_2() {
+	expect((lengthOfLongestSubstringTwoDistinct("ccaabbb") == 5))
+}
+
+func empty_string() {
+	expect((lengthOfLongestSubstringTwoDistinct("") == 0))
+}
+
+func single_char() {
+	expect((lengthOfLongestSubstringTwoDistinct("aaaa") == 4))
+}
+
+func three_distinct() {
+	expect((lengthOfLongestSubstringTwoDistinct("abcabc") == 2))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_string()
+	single_char()
+	three_distinct()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/longest-substring-without-repeating-characters.go.out
+++ b/examples/leetcode-out/longest-substring-without-repeating-characters.go.out
@@ -1,0 +1,67 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func lengthOfLongestSubstring(s string) int {
+	var n int = len(s)
+	var start int = 0
+	_ = start
+	var best int = 0
+	_ = best
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var j int = start
+		_ = j
+		for (j < i) {
+			if (_indexString(s, j) == _indexString(s, i)) {
+				start = (j + 1)
+				break
+			}
+			j = (j + 1)
+		}
+		var length int = ((i - start) + 1)
+		if (length > best) {
+			best = length
+		}
+		i = (i + 1)
+	}
+	return best
+}
+
+func example_1() {
+	expect((lengthOfLongestSubstring("abcabcbb") == 3))
+}
+
+func example_2() {
+	expect((lengthOfLongestSubstring("bbbbb") == 1))
+}
+
+func example_3() {
+	expect((lengthOfLongestSubstring("pwwkew") == 3))
+}
+
+func empty_string() {
+	expect((lengthOfLongestSubstring("") == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	empty_string()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/lowest-common-ancestor-of-a-binary-search-tree.go.out
+++ b/examples/leetcode-out/lowest-common-ancestor-of-a-binary-search-tree.go.out
@@ -1,0 +1,51 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Node struct {
+	Val int `json:"val"`
+	Left int `json:"left"`
+	Right int `json:"right"`
+}
+
+func lowestCommonAncestor(tree []Node, root int, p int, q int) int {
+	var pNode Node = tree[p]
+	var qNode Node = tree[q]
+	var pVal int = pNode.Val
+	var qVal int = qNode.Val
+	var current int = root
+	_ = current
+	for {
+		var node Node = tree[current]
+		if ((pVal < node.Val) && (qVal < node.Val)) {
+			current = node.Left
+		} else 		if ((pVal > node.Val) && (qVal > node.Val)) {
+			current = node.Right
+		} else {
+			return current
+		}
+	}
+}
+
+func example_1() {
+	expect((lowestCommonAncestor(example, 0, 1, 2) == 0))
+}
+
+func example_2() {
+	expect((lowestCommonAncestor(example, 0, 1, 4) == 1))
+}
+
+func single_node() {
+	var single []Node = []Node{Node{Val: 1, Left: -1, Right: -1}}
+	expect((lowestCommonAncestor(single, 0, 0, 0) == 0))
+}
+
+var example []Node = []Node{Node{Val: 6, Left: 1, Right: 2}, Node{Val: 2, Left: 3, Right: 4}, Node{Val: 8, Left: 5, Right: 6}, Node{Val: 0, Left: -1, Right: -1}, Node{Val: 4, Left: 7, Right: 8}, Node{Val: 7, Left: -1, Right: -1}, Node{Val: 9, Left: -1, Right: -1}, Node{Val: 3, Left: -1, Right: -1}, Node{Val: 5, Left: -1, Right: -1}}
+func main() {
+	example_1()
+	example_2()
+	single_node()
+}
+

--- a/examples/leetcode-out/lowest-common-ancestor-of-a-binary-tree.go.out
+++ b/examples/leetcode-out/lowest-common-ancestor-of-a-binary-tree.go.out
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func lca(lefts []int, rights []int, root int, p int, q int) int {
+	if (root == (-1)) {
+		return (-1)
+	}
+	if ((root == p) || (root == q)) {
+		return root
+	}
+	var leftRes int = lca(lefts, rights, lefts[root], p, q)
+	var rightRes int = lca(lefts, rights, rights[root], p, q)
+	if ((leftRes != (-1)) && (rightRes != (-1))) {
+		return root
+	}
+	if (leftRes != (-1)) {
+		return leftRes
+	}
+	return rightRes
+}
+
+func p_and_q_on_different_sides() {
+	expect((lca(lefts, rights, root, 1, 2) == 0))
+}
+
+func p_is_ancestor_of_q() {
+	expect((lca(lefts, rights, root, 1, 8) == 1))
+}
+
+func same_node() {
+	expect((lca(lefts, rights, root, 1, 1) == 1))
+}
+
+func deep_nodes() {
+	expect((lca(lefts, rights, root, 3, 5) == 0))
+}
+
+func siblings() {
+	expect((lca(lefts, rights, root, 7, 8) == 4))
+}
+
+var lefts []int = _cast[[]int]([]int{1, 3, 5, (-1), 7, (-1), (-1), (-1), (-1)})
+var rights []int = _cast[[]int]([]int{2, 4, 6, (-1), 8, (-1), (-1), (-1), (-1)})
+var values []int = _cast[[]int]([]int{3, 5, 1, 6, 2, 0, 8, 7, 4})
+var root int = 0
+func main() {
+	p_and_q_on_different_sides()
+	p_is_ancestor_of_q()
+	same_node()
+	deep_nodes()
+	siblings()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/lru-cache.go.out
+++ b/examples/leetcode-out/lru-cache.go.out
@@ -1,0 +1,101 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Entry struct {
+	Key int `json:"key"`
+	Val int `json:"val"`
+}
+
+type LRUCache struct {
+	Cap int `json:"cap"`
+	Items []any `json:"items"`
+}
+
+type LookupResult struct {
+	Val int `json:"val"`
+	Cache any `json:"cache"`
+}
+
+func newCache(cap int) LRUCache {
+	return LRUCache{Cap: cap, Items: _cast[[]any]([]any{})}
+}
+
+func find(items []Entry, k int) int {
+	var i int = 0
+	_ = i
+	for (i < len(items)) {
+		var e Entry = items[i]
+		if (e.Key == k) {
+			return i
+		}
+		i = (i + 1)
+	}
+	return -1
+}
+
+func get(cache LRUCache, key int) LookupResult {
+	var idx int = find(cache.Items, key)
+	if (idx == (0 - 1)) {
+		return LookupResult{Val: (0 - 1), Cache: cache}
+	}
+	var entry Entry = cache.Items[idx]
+	var items []Entry = append(append([]Entry{}, append(append([]Entry{}, []Entry{entry}...), cache.Items[0:idx]...)...), cache.Items[(idx + 1):len(cache.Items)]...)
+	_ = items
+	return LookupResult{Val: entry.Val, Cache: LRUCache{Cap: cache.Cap, Items: items}}
+}
+
+func put(cache LRUCache, key int, value int) LRUCache {
+	var items []Entry = cache.Items
+	_ = items
+	var idx int = find(items, key)
+	if (idx != (0 - 1)) {
+		items = append(append([]Entry{}, items[0:idx]...), items[(idx + 1):len(items)]...)
+	}
+	items = append(append([]Entry{}, []Entry{Entry{Key: key, Val: value}}...), items...)
+	if (len(items) > cache.Cap) {
+		items = items[0:cache.Cap]
+	}
+	return LRUCache{Cap: cache.Cap, Items: items}
+}
+
+func example() {
+	var c LRUCache = newCache(2)
+	_ = c
+	var r1 LookupResult = get(c, 1)
+	expect((r1.Val == (0 - 1)))
+	c = r1.Cache
+	c = put(c, 1, 1)
+	c = put(c, 2, 2)
+	var r2 LookupResult = get(c, 1)
+	expect((r2.Val == 1))
+	c = r2.Cache
+	c = put(c, 3, 3)
+	var r3 LookupResult = get(c, 2)
+	expect((r3.Val == (0 - 1)))
+	c = r3.Cache
+	c = put(c, 4, 4)
+	var r4 LookupResult = get(c, 1)
+	expect((r4.Val == (0 - 1)))
+	c = r4.Cache
+	var r5 LookupResult = get(c, 3)
+	expect((r5.Val == 3))
+	c = r5.Cache
+	var r6 LookupResult = get(c, 4)
+	expect((r6.Val == 4))
+}
+
+func main() {
+	example()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/majority-element-ii.go.out
+++ b/examples/leetcode-out/majority-element-ii.go.out
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func majorityElement(nums []int) []int {
+	var n int = len(nums)
+	if (n == 0) {
+		return _cast[[]int]([]any{})
+	}
+	var candidate1 int = 0
+	_ = candidate1
+	var candidate2 int = 0
+	_ = candidate2
+	var count1 int = 0
+	_ = count1
+	var count2 int = 0
+	_ = count2
+	for _, num := range nums {
+		if (num == candidate1) {
+			count1 = (count1 + 1)
+		} else 		if (num == candidate2) {
+			count2 = (count2 + 1)
+		} else 		if (count1 == 0) {
+			candidate1 = num
+			count1 = 1
+		} else 		if (count2 == 0) {
+			candidate2 = num
+			count2 = 1
+		} else {
+			count1 = (count1 - 1)
+			count2 = (count2 - 1)
+		}
+	}
+	var res []int = []int{}
+	_ = res
+	var c1 int = 0
+	_ = c1
+	var c2 int = 0
+	_ = c2
+	for _, num := range nums {
+		if (num == candidate1) {
+			c1 = (c1 + 1)
+		}
+		if (num == candidate2) {
+			c2 = (c2 + 1)
+		}
+	}
+	if (c1 > (n / 3)) {
+		res = append(append([]int{}, res...), []int{candidate1}...)
+	}
+	if (candidate2 != candidate1) {
+		if (c2 > (n / 3)) {
+			res = append(append([]int{}, res...), []int{candidate2}...)
+		}
+	}
+	return res
+}
+
+func example_1() {
+	expect(_equal(majorityElement([]int{3, 2, 3}), []int{3}))
+}
+
+func example_2() {
+	expect(_equal(majorityElement([]int{1}), []int{1}))
+}
+
+func example_3() {
+	expect(_equal(majorityElement([]int{1, 2}), []int{1, 2}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/max-points-on-a-line.go.out
+++ b/examples/leetcode-out/max-points-on-a-line.go.out
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxPoints(points [][]int) int {
+	var n int = len(points)
+	if (n <= 2) {
+		return n
+	}
+	var answer int = 0
+	_ = answer
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var slopes map[string]int = map[string]int{}
+		_ = slopes
+		var duplicates int = 1
+		_ = duplicates
+		var j int = (i + 1)
+		_ = j
+		for (j < n) {
+			var dx int = (points[j][0] - points[i][0])
+			var dy int = (points[j][1] - points[i][1])
+			if ((dx == 0) && (dy == 0)) {
+				duplicates = (duplicates + 1)
+			} else {
+				var g int = gcd(dx, dy)
+				var sx int = (dx / g)
+				_ = sx
+				var sy int = (dy / g)
+				_ = sy
+				if (sx == 0) {
+					sy = 1
+				} else 				if (sx < 0) {
+					sx = -sx
+					sy = -sy
+				}
+				var key string = fmt.Sprint(sx) + "/" + fmt.Sprint(sy)
+				_tmp0 := key
+				_tmp1 := slopes
+				_, _tmp2 := _tmp1[_tmp0]
+				if _tmp2 {
+					slopes[key] = (slopes[key] + 1)
+				} else {
+					slopes[key] = 1
+				}
+			}
+			j = (j + 1)
+		}
+		var localMax int = 0
+		_ = localMax
+		for key := range slopes {
+			var count func(any) int = slopes[key]
+			if (count > localMax) {
+				localMax = count
+			}
+		}
+		if ((localMax + duplicates) > answer) {
+			answer = (localMax + duplicates)
+		}
+		i = (i + 1)
+	}
+	return answer
+}
+
+func abs(x int) int {
+	if (x < 0) {
+		return -x
+	}
+	return x
+}
+
+func gcd(a int, b int) int {
+	var x int = abs(a)
+	_ = x
+	var y int = abs(b)
+	_ = y
+	for (y != 0) {
+		var temp int = (x % y)
+		x = y
+		y = temp
+	}
+	return x
+}
+
+func example_1() {
+	expect((maxPoints([][]int{[]int{1, 1}, []int{2, 2}, []int{3, 3}}) == 3))
+}
+
+func example_2() {
+	expect((maxPoints([][]int{[]int{1, 1}, []int{3, 2}, []int{5, 3}, []int{4, 1}, []int{2, 3}, []int{1, 4}}) == 4))
+}
+
+func single_point() {
+	expect((maxPoints([][]int{[]int{0, 0}}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_point()
+}
+

--- a/examples/leetcode-out/maximal-rectangle.go.out
+++ b/examples/leetcode-out/maximal-rectangle.go.out
@@ -1,0 +1,99 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maximalRectangle(matrix [][]string) int {
+	if (len(matrix) == 0) {
+		return 0
+	}
+	var rows int = len(matrix)
+	var cols int = len(matrix[0])
+	var heights []int = []int{}
+	_ = heights
+	var init int = 0
+	_ = init
+	for (init < cols) {
+		heights = append(append([]int{}, heights...), []int{0}...)
+		init = (init + 1)
+	}
+	var best int = 0
+	_ = best
+	var largestRectangleArea = func(hs []int) int {
+		var stack []int = []int{}
+		_ = stack
+		var i int = 0
+		_ = i
+		var n int = len(hs)
+		var maxArea int = 0
+		_ = maxArea
+		for (i <= n) {
+			var curr int = 0
+			_ = curr
+			if (i < n) {
+				curr = hs[i]
+			}
+			for (len(stack) > 0) {
+				if (curr < hs[stack[(len(stack) - 1)]]) {
+					var h int = hs[stack[(len(stack) - 1)]]
+					stack = stack[0:(len(stack) - 1)]
+					var width int = i
+					_ = width
+					if (len(stack) > 0) {
+						width = ((i - stack[(len(stack) - 1)]) - 1)
+					}
+					var area int = (h * width)
+					if (area > maxArea) {
+						maxArea = area
+					}
+				} else {
+					break
+				}
+			}
+			stack = append(append([]int{}, stack...), []int{i}...)
+			i = (i + 1)
+		}
+		return maxArea
+}
+	var r int = 0
+	_ = r
+	for (r < rows) {
+		var c int = 0
+		_ = c
+		for (c < cols) {
+			if (matrix[r][c] == "1") {
+				heights[c] = (heights[c] + 1)
+			} else {
+				heights[c] = 0
+			}
+			c = (c + 1)
+		}
+		var area int = largestRectangleArea(heights)
+		if (area > best) {
+			best = area
+		}
+		r = (r + 1)
+	}
+	return best
+}
+
+func example_1() {
+	expect((maximalRectangle(matrix1) == 6))
+}
+
+func single_zero() {
+	expect((maximalRectangle([][]string{[]string{"0"}}) == 0))
+}
+
+func single_one() {
+	expect((maximalRectangle([][]string{[]string{"1"}}) == 1))
+}
+
+var matrix1 [][]string = [][]string{[]string{"1", "0", "1", "0", "0"}, []string{"1", "0", "1", "1", "1"}, []string{"1", "1", "1", "1", "1"}, []string{"1", "0", "0", "1", "0"}}
+func main() {
+	example_1()
+	single_zero()
+	single_one()
+}
+

--- a/examples/leetcode-out/maximal-square.go.out
+++ b/examples/leetcode-out/maximal-square.go.out
@@ -1,0 +1,86 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maximalSquare(matrix [][]string) int {
+	var rows int = len(matrix)
+	if (rows == 0) {
+		return 0
+	}
+	var cols int = len(matrix[0])
+	var dp [][]int = [][]int{}
+	_ = dp
+	var r int = 0
+	_ = r
+	for (r < rows) {
+		var row []int = []int{}
+		_ = row
+		var c int = 0
+		_ = c
+		for (c < cols) {
+			row = append(append([]int{}, row...), []int{0}...)
+			c = (c + 1)
+		}
+		dp = append(append([][]int{}, dp...), [][]int{row}...)
+		r = (r + 1)
+	}
+	var maxSide int = 0
+	_ = maxSide
+	r = 0
+	for (r < rows) {
+		var c int = 0
+		_ = c
+		for (c < cols) {
+			if (matrix[r][c] == "1") {
+				if ((r == 0) || (c == 0)) {
+					dp[r][c] = 1
+				} else {
+					var top int = dp[(r - 1)][c]
+					var left int = dp[r][(c - 1)]
+					var diag int = dp[(r - 1)][(c - 1)]
+					var small int = top
+					_ = small
+					if (left < small) {
+						small = left
+					}
+					if (diag < small) {
+						small = diag
+					}
+					dp[r][c] = (small + 1)
+				}
+				if (dp[r][c] > maxSide) {
+					maxSide = dp[r][c]
+				}
+			} else {
+				dp[r][c] = 0
+			}
+			c = (c + 1)
+		}
+		r = (r + 1)
+	}
+	return (maxSide * maxSide)
+}
+
+func example_1() {
+	expect((maximalSquare(example1) == 4))
+}
+
+func example_2() {
+	expect((maximalSquare(example2) == 1))
+}
+
+func single_zero() {
+	expect((maximalSquare(example3) == 0))
+}
+
+var example1 [][]string = [][]string{[]string{"1", "0", "1", "0", "0"}, []string{"1", "0", "1", "1", "1"}, []string{"1", "1", "1", "1", "1"}, []string{"1", "0", "0", "1", "0"}}
+var example2 [][]string = [][]string{[]string{"0", "1"}, []string{"1", "0"}}
+var example3 [][]string = [][]string{[]string{"0"}}
+func main() {
+	example_1()
+	example_2()
+	single_zero()
+}
+

--- a/examples/leetcode-out/maximum-depth-of-binary-tree.go.out
+++ b/examples/leetcode-out/maximum-depth-of-binary-tree.go.out
@@ -1,0 +1,62 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func max(a int, b int) int {
+	if (a > b) {
+		return a
+	} else {
+		return b
+	}
+}
+
+func maxDepth(root any) int {
+	return func() int {
+	_t := root
+	switch _t {
+	case Leaf:
+		return 0
+	case Node(l, _, r):
+		return (max(maxDepth(l), maxDepth(r)) + 1)
+	}
+}()
+}
+
+func example_1() {
+	var tree Node = Node{Left: Node{Left: Leaf{}, Value: 9, Right: Leaf{}}, Value: 3, Right: Node{Left: Node{Left: Leaf{}, Value: 15, Right: Leaf{}}, Value: 20, Right: Node{Left: Leaf{}, Value: 7, Right: Leaf{}}}}
+	expect((maxDepth(tree) == 3))
+}
+
+func example_2() {
+	var tree Node = Node{Left: Leaf{}, Value: 1, Right: Node{Left: Leaf{}, Value: 2, Right: Leaf{}}}
+	expect((maxDepth(tree) == 2))
+}
+
+func single_node() {
+	expect((maxDepth(Node{Left: Leaf{}, Value: 0, Right: Leaf{}}) == 1))
+}
+
+func empty() {
+	expect((maxDepth(Leaf{}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_node()
+	empty()
+}
+

--- a/examples/leetcode-out/maximum-difference-by-remapping-a-digit.go.out
+++ b/examples/leetcode-out/maximum-difference-by-remapping-a-digit.go.out
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxDiff(num int) int {
+	var s string = fmt.Sprint(num)
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	var digitMax string = ""
+	_ = digitMax
+	var i int = 0
+	_ = i
+	for (i < len(s)) {
+		if (_indexString(s, i) != "9") {
+			digitMax = _indexString(s, i)
+			break
+		}
+		i = (i + 1)
+	}
+	var maxVal int = 0
+	_ = maxVal
+	for _, r := range []rune(s) {
+		ch := string(r)
+		var c string = ch
+		_ = c
+		if (c == digitMax) {
+			c = "9"
+		}
+		maxVal = ((maxVal * 10) + digits[c])
+	}
+	var digitMin string = ""
+	_ = digitMin
+	i = 0
+	for (i < len(s)) {
+		if (_indexString(s, i) != "0") {
+			digitMin = _indexString(s, i)
+			break
+		}
+		i = (i + 1)
+	}
+	var minVal int = 0
+	_ = minVal
+	for _, r := range []rune(s) {
+		ch := string(r)
+		var c string = ch
+		_ = c
+		if (c == digitMin) {
+			c = "0"
+		}
+		minVal = ((minVal * 10) + digits[c])
+	}
+	return (maxVal - minVal)
+}
+
+func example_1() {
+	expect((maxDiff(11891) == 99009))
+}
+
+func example_2() {
+	expect((maxDiff(90) == 99))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/maximum-product-subarray.go.out
+++ b/examples/leetcode-out/maximum-product-subarray.go.out
@@ -1,0 +1,70 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func max(a int, b int) int {
+	if (a > b) {
+		return a
+	}
+	return b
+}
+
+func min(a int, b int) int {
+	if (a < b) {
+		return a
+	}
+	return b
+}
+
+func maxProduct(nums []int) int {
+	var n int = len(nums)
+	var maxEnding int = nums[0]
+	_ = maxEnding
+	var minEnding int = nums[0]
+	_ = minEnding
+	var result int = nums[0]
+	_ = result
+	var i int = 1
+	_ = i
+	for (i < n) {
+		var v int = nums[i]
+		if (v < 0) {
+			var temp int = maxEnding
+			maxEnding = minEnding
+			minEnding = temp
+		}
+		maxEnding = max(v, (maxEnding * v))
+		minEnding = min(v, (minEnding * v))
+		if (maxEnding > result) {
+			result = maxEnding
+		}
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect((maxProduct([]int{2, 3, -2, 4}) == 6))
+}
+
+func example_2() {
+	expect((maxProduct([]int{-2, 0, -1}) == 0))
+}
+
+func negatives() {
+	expect((maxProduct([]int{-2, 3, -4}) == 24))
+}
+
+func single() {
+	expect((maxProduct([]int{-2}) == (-2)))
+}
+
+func main() {
+	example_1()
+	example_2()
+	negatives()
+	single()
+}
+

--- a/examples/leetcode-out/maximum-subarray.go.out
+++ b/examples/leetcode-out/maximum-subarray.go.out
@@ -1,0 +1,49 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxSubArray(nums []int) int {
+	var n int = len(nums)
+	var current int = nums[0]
+	_ = current
+	var best int = nums[0]
+	_ = best
+	for i := 1; i < n; i++ {
+		var val int = nums[i]
+		if ((current + val) > val) {
+			current = (current + val)
+		} else {
+			current = val
+		}
+		if (current > best) {
+			best = current
+		}
+	}
+	return best
+}
+
+func example_1() {
+	expect((maxSubArray([]int{-2, 1, -3, 4, -1, 2, 1, -5, 4}) == 6))
+}
+
+func example_2() {
+	expect((maxSubArray([]int{1}) == 1))
+}
+
+func example_3() {
+	expect((maxSubArray([]int{5, 4, -1, 7, 8}) == 23))
+}
+
+func all_negative() {
+	expect((maxSubArray([]int{-3, -2, -5}) == (-2)))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	all_negative()
+}
+

--- a/examples/leetcode-out/merge-k-sorted-lists.go.out
+++ b/examples/leetcode-out/merge-k-sorted-lists.go.out
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func mergeKLists(lists [][]int) []int {
+	var k int = len(lists)
+	var indices []int = []int{}
+	_ = indices
+	var i int = 0
+	_ = i
+	for (i < k) {
+		indices = append(append([]int{}, indices...), []int{0}...)
+		i = (i + 1)
+	}
+	var result []int = []int{}
+	_ = result
+	for {
+		var best int = 0
+		_ = best
+		var bestList int = -1
+		_ = bestList
+		var found bool = false
+		_ = found
+		var j int = 0
+		_ = j
+		for (j < k) {
+			var idx int = indices[j]
+			if (idx < len(lists[j])) {
+				var val int = lists[j][idx]
+				if (!found || (val < best)) {
+					best = val
+					bestList = j
+					found = true
+				}
+			}
+			j = (j + 1)
+		}
+		if !found {
+			break
+		}
+		result = append(append([]int{}, result...), []int{best}...)
+		indices[bestList] = (indices[bestList] + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(mergeKLists([][]int{[]int{1, 4, 5}, []int{1, 3, 4}, []int{2, 6}}), []int{1, 1, 2, 3, 4, 4, 5, 6}))
+}
+
+func example_2() {
+	expect(_equal(mergeKLists([][]int{}), []any{}))
+}
+
+func example_3() {
+	expect(_equal(mergeKLists([][]any{[]any{}}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/merge-sorted-array.go.out
+++ b/examples/leetcode-out/merge-sorted-array.go.out
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func merge(nums1 []int, m int, nums2 []int, n int) []int {
+	var i int = (m - 1)
+	_ = i
+	var j int = (n - 1)
+	_ = j
+	var k int = ((m + n) - 1)
+	_ = k
+	for (j >= 0) {
+		if ((i >= 0) && (nums1[i] > nums2[j])) {
+			nums1[k] = nums1[i]
+			i = (i - 1)
+		} else {
+			nums1[k] = nums2[j]
+			j = (j - 1)
+		}
+		k = (k - 1)
+	}
+	return nums1
+}
+
+func example_1() {
+	expect(_equal(merge([]int{1, 2, 3, 0, 0, 0}, 3, []int{2, 5, 6}, 3), []int{1, 2, 2, 3, 5, 6}))
+}
+
+func example_2() {
+	expect(_equal(merge([]int{1}, 1, []int{}, 0), []int{1}))
+}
+
+func example_3() {
+	expect(_equal(merge([]int{0}, 0, []int{1}, 1), []int{1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/merge-two-sorted-lists.go.out
+++ b/examples/leetcode-out/merge-two-sorted-lists.go.out
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func mergeTwoLists(l1 []int, l2 []int) []int {
+	var i int = 0
+	_ = i
+	var j int = 0
+	_ = j
+	var result []any = []any{}
+	_ = result
+	for ((i < len(l1)) && (j < len(l2))) {
+		if (l1[i] <= l2[j]) {
+			result = append(append([]any{}, result...), _toAnySlice([]int{l1[i]})...)
+			i = (i + 1)
+		} else {
+			result = append(append([]any{}, result...), _toAnySlice([]int{l2[j]})...)
+			j = (j + 1)
+		}
+	}
+	for (i < len(l1)) {
+		result = append(append([]any{}, result...), _toAnySlice([]int{l1[i]})...)
+		i = (i + 1)
+	}
+	for (j < len(l2)) {
+		result = append(append([]any{}, result...), _toAnySlice([]int{l2[j]})...)
+		j = (j + 1)
+	}
+	return _cast[[]int](result)
+}
+
+func example_1() {
+	expect(_equal(mergeTwoLists([]int{1, 2, 4}, []int{1, 3, 4}), []int{1, 1, 2, 3, 4, 4}))
+}
+
+func example_2() {
+	expect(_equal(mergeTwoLists([]int{}, []int{}), []any{}))
+}
+
+func example_3() {
+	expect(_equal(mergeTwoLists([]int{}, []int{0}), []int{0}))
+}
+
+func different_lengths() {
+	expect(_equal(mergeTwoLists([]int{1, 5, 7}, []int{2, 3, 4, 6, 8}), []int{1, 2, 3, 4, 5, 6, 7, 8}))
+}
+
+func one_list_empty() {
+	expect(_equal(mergeTwoLists([]int{1, 2, 3}, []int{}), []int{1, 2, 3}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	different_lengths()
+	one_list_empty()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/min-stack.go.out
+++ b/examples/leetcode-out/min-stack.go.out
@@ -1,0 +1,97 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type MinStack struct {
+	Items []int `json:"items"`
+	Mins []int `json:"mins"`
+}
+
+func newStack() MinStack {
+	return MinStack{Items: _cast[[]int]([]any{}), Mins: _cast[[]int]([]any{})}
+}
+
+func push(s MinStack, x int) MinStack {
+	var items []int = append(append([]int{}, s.Items...), []int{x}...)
+	_ = items
+	var mins []int = s.Mins
+	_ = mins
+	if (len(mins) == 0) {
+		mins = []int{x}
+	} else {
+		var m int = mins[(len(mins) - 1)]
+		if (x <= m) {
+			mins = append(append([]int{}, mins...), []int{x}...)
+		}
+	}
+	return MinStack{Items: items, Mins: mins}
+}
+
+func pop(s MinStack) MinStack {
+	var items []int = s.Items
+	_ = items
+	var mins []int = s.Mins
+	_ = mins
+	var val int = items[(len(items) - 1)]
+	items = items[0:(len(items) - 1)]
+	if (val == mins[(len(mins) - 1)]) {
+		mins = mins[0:(len(mins) - 1)]
+	}
+	return MinStack{Items: items, Mins: mins}
+}
+
+func top(s MinStack) int {
+	return s.Items[(len(s.Items) - 1)]
+}
+
+func getMin(s MinStack) int {
+	return s.Mins[(len(s.Mins) - 1)]
+}
+
+func example() {
+	var s MinStack = newStack()
+	_ = s
+	s = push(s, -2)
+	s = push(s, 0)
+	s = push(s, -3)
+	expect((getMin(s) == (-3)))
+	s = pop(s)
+	expect((top(s) == 0))
+	expect((getMin(s) == (-2)))
+}
+
+func single_element() {
+	var s MinStack = newStack()
+	_ = s
+	s = push(s, 4)
+	expect((top(s) == 4))
+	expect((getMin(s) == 4))
+}
+
+func increasing() {
+	var s MinStack = newStack()
+	_ = s
+	s = push(s, 1)
+	s = push(s, 2)
+	s = push(s, 3)
+	expect((getMin(s) == 1))
+	s = pop(s)
+	expect((getMin(s) == 1))
+}
+
+func main() {
+	example()
+	single_element()
+	increasing()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/minimum-depth-of-binary-tree.go.out
+++ b/examples/leetcode-out/minimum-depth-of-binary-tree.go.out
@@ -1,0 +1,71 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func minDepth(root any) int {
+	var helper = func(left any, right any) int {
+		var leftDepth int = minDepth(left)
+		var rightDepth int = minDepth(right)
+		if ((leftDepth == 0) && (rightDepth == 0)) {
+			return 1
+		}
+		if (leftDepth == 0) {
+			return (rightDepth + 1)
+		}
+		if (rightDepth == 0) {
+			return (leftDepth + 1)
+		}
+		if (leftDepth < rightDepth) {
+			return (leftDepth + 1)
+		}
+		return (rightDepth + 1)
+}
+	return func() int {
+	_t := root
+	switch _t {
+	case Leaf:
+		return 0
+	case Node(l, _, r):
+		return helper(l, r)
+	}
+}()
+}
+
+func example_1() {
+	var tree Node = Node{Left: Node{Left: Leaf{}, Value: 9, Right: Leaf{}}, Value: 3, Right: Node{Left: Node{Left: Leaf{}, Value: 15, Right: Leaf{}}, Value: 20, Right: Node{Left: Leaf{}, Value: 7, Right: Leaf{}}}}
+	expect((minDepth(tree) == 2))
+}
+
+func example_2() {
+	var tree Node = Node{Left: Leaf{}, Value: 2, Right: Node{Left: Leaf{}, Value: 3, Right: Leaf{}}}
+	expect((minDepth(tree) == 2))
+}
+
+func single_node() {
+	expect((minDepth(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}) == 1))
+}
+
+func empty() {
+	expect((minDepth(Leaf{}) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_node()
+	empty()
+}
+

--- a/examples/leetcode-out/minimum-path-sum.go.out
+++ b/examples/leetcode-out/minimum-path-sum.go.out
@@ -1,0 +1,73 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func minPathSum(grid [][]int) int {
+	var rows int = len(grid)
+	if (rows == 0) {
+		return 0
+	}
+	var cols int = len(grid[0])
+	var dp [][]int = [][]int{}
+	_ = dp
+	var r int = 0
+	_ = r
+	for (r < rows) {
+		var row []int = []int{}
+		_ = row
+		var c int = 0
+		_ = c
+		for (c < cols) {
+			row = append(append([]int{}, row...), []int{0}...)
+			c = (c + 1)
+		}
+		dp = append(append([][]int{}, dp...), [][]int{row}...)
+		r = (r + 1)
+	}
+	dp[0][0] = grid[0][0]
+	var c int = 1
+	_ = c
+	for (c < cols) {
+		dp[0][c] = (dp[0][(c - 1)] + grid[0][c])
+		c = (c + 1)
+	}
+	r = 1
+	for (r < rows) {
+		dp[r][0] = (dp[(r - 1)][0] + grid[r][0])
+		var c int = 1
+		_ = c
+		for (c < cols) {
+			var top int = dp[(r - 1)][c]
+			var left int = dp[r][(c - 1)]
+			if (top < left) {
+				dp[r][c] = (top + grid[r][c])
+			} else {
+				dp[r][c] = (left + grid[r][c])
+			}
+			c = (c + 1)
+		}
+		r = (r + 1)
+	}
+	return dp[(rows - 1)][(cols - 1)]
+}
+
+func example_1() {
+	expect((minPathSum([][]int{[]int{1, 3, 1}, []int{1, 5, 1}, []int{4, 2, 1}}) == 7))
+}
+
+func example_2() {
+	expect((minPathSum([][]int{[]int{1, 2, 3}, []int{4, 5, 6}}) == 12))
+}
+
+func single_cell() {
+	expect((minPathSum([][]int{[]int{1}}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_cell()
+}
+

--- a/examples/leetcode-out/minimum-size-subarray-sum.go.out
+++ b/examples/leetcode-out/minimum-size-subarray-sum.go.out
@@ -1,0 +1,57 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func minSubArrayLen(target int, nums []int) int {
+	var n int = len(nums)
+	var left int = 0
+	_ = left
+	var sum int = 0
+	_ = sum
+	var best int = (n + 1)
+	_ = best
+	var right int = 0
+	_ = right
+	for (right < n) {
+		sum = (sum + nums[right])
+		right = (right + 1)
+		for (sum >= target) {
+			var length int = (right - left)
+			if (length < best) {
+				best = length
+			}
+			sum = (sum - nums[left])
+			left = (left + 1)
+		}
+	}
+	if (best == (n + 1)) {
+		return 0
+	}
+	return best
+}
+
+func example_1() {
+	expect((minSubArrayLen(7, []int{2, 3, 1, 2, 4, 3}) == 2))
+}
+
+func example_2() {
+	expect((minSubArrayLen(4, []int{1, 4, 4}) == 1))
+}
+
+func example_3() {
+	expect((minSubArrayLen(11, []int{1, 1, 1, 1, 1, 1, 1, 1}) == 0))
+}
+
+func entire_array() {
+	expect((minSubArrayLen(15, []int{5, 1, 3, 5, 10, 7, 4, 9, 2, 8}) == 2))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	entire_array()
+}
+

--- a/examples/leetcode-out/minimum-window-substring.go.out
+++ b/examples/leetcode-out/minimum-window-substring.go.out
@@ -1,0 +1,108 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func minWindow(s string, t string) string {
+	if (len(t) == 0) {
+		return ""
+	}
+	var need map[string]int = map[string]int{}
+	_ = need
+	for _, r := range []rune(t) {
+		ch := string(r)
+		_tmp0 := ch
+		_tmp1 := need
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			need[ch] = (need[ch] + 1)
+		} else {
+			need[ch] = 1
+		}
+	}
+	var required int = len(need)
+	var have map[string]int = map[string]int{}
+	_ = have
+	var formed int = 0
+	_ = formed
+	var left int = 0
+	_ = left
+	var bestStart int = 0
+	_ = bestStart
+	var bestLen int = (len(s) + 1)
+	_ = bestLen
+	var right int = 0
+	_ = right
+	for (right < len(s)) {
+		var ch string = _indexString(s, right)
+		_tmp3 := ch
+		_tmp4 := need
+		_, _tmp5 := _tmp4[_tmp3]
+		if _tmp5 {
+			_tmp6 := ch
+			_tmp7 := have
+			_, _tmp8 := _tmp7[_tmp6]
+			if _tmp8 {
+				have[ch] = (have[ch] + 1)
+			} else {
+				have[ch] = 1
+			}
+			if (have[ch] == need[ch]) {
+				formed = (formed + 1)
+			}
+		}
+		for ((formed == required) && (left <= right)) {
+			if (((right - left) + 1) < bestLen) {
+				bestLen = ((right - left) + 1)
+				bestStart = left
+			}
+			var leftCh string = _indexString(s, left)
+			_tmp9 := leftCh
+			_tmp10 := need
+			_, _tmp11 := _tmp10[_tmp9]
+			if _tmp11 {
+				have[leftCh] = (have[leftCh] - 1)
+				if (have[leftCh] < need[leftCh]) {
+					formed = (formed - 1)
+				}
+			}
+			left = (left + 1)
+		}
+		right = (right + 1)
+	}
+	if (bestLen == (len(s) + 1)) {
+		return ""
+	}
+	return string([]rune(s)[bestStart:(bestStart + bestLen)])
+}
+
+func example_1() {
+	expect((minWindow("ADOBECODEBANC", "ABC") == "BANC"))
+}
+
+func example_2() {
+	expect((minWindow("a", "a") == "a"))
+}
+
+func example_3() {
+	expect((minWindow("a", "aa") == ""))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/missing-ranges.go.out
+++ b/examples/leetcode-out/missing-ranges.go.out
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func formatRange(start int, end int) string {
+	if (start == end) {
+		return fmt.Sprint(start)
+	}
+	return fmt.Sprint(start) + "->" + fmt.Sprint(end)
+}
+
+func findMissingRanges(nums []int, lower int, upper int) []string {
+	var result []string = []string{}
+	_ = result
+	var prev int = (lower - 1)
+	_ = prev
+	var i int = 0
+	_ = i
+	for (i <= len(nums)) {
+		var curr int = 0
+		_ = curr
+		if (i == len(nums)) {
+			curr = (upper + 1)
+		} else {
+			curr = nums[i]
+		}
+		if ((curr - prev) >= 2) {
+			result = append(append([]string{}, result...), []string{formatRange((prev + 1), (curr - 1))}...)
+		}
+		prev = curr
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(findMissingRanges([]int{0, 1, 3, 50, 75}, 0, 99), []string{"2", "4->49", "51->74", "76->99"}))
+}
+
+func example_2() {
+	expect(_equal(findMissingRanges([]int{}, 1, 1), []string{"1"}))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/multiply-strings.go.out
+++ b/examples/leetcode-out/multiply-strings.go.out
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func multiply(num1 string, num2 string) string {
+	if ((num1 == "0") || (num2 == "0")) {
+		return "0"
+	}
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	var m int = len(num1)
+	var n int = len(num2)
+	var result map[int]int = map[int]int{}
+	_ = result
+	var i int = m
+	_ = i
+	for (i > 0) {
+		i = (i - 1)
+		var d1 int = digits[_indexString(num1, i)]
+		var j int = n
+		_ = j
+		for (j > 0) {
+			j = (j - 1)
+			var d2 int = digits[_indexString(num2, j)]
+			var idx1 int = ((i + j) + 1)
+			var existing int = 0
+			_ = existing
+			_tmp0 := idx1
+			_tmp1 := result
+			_, _tmp2 := _tmp1[_tmp0]
+			if _tmp2 {
+				existing = result[idx1]
+			}
+			var sum int = ((d1 * d2) + existing)
+			result[idx1] = (sum % 10)
+			var carry int = (sum / 10)
+			var idx0 int = (i + j)
+			var prev int = 0
+			_ = prev
+			_tmp3 := idx0
+			_tmp4 := result
+			_, _tmp5 := _tmp4[_tmp3]
+			if _tmp5 {
+				prev = result[idx0]
+			}
+			result[idx0] = (prev + carry)
+		}
+	}
+	var out string = ""
+	_ = out
+	var k int = 0
+	_ = k
+	for (k < (m + n)) {
+		var digit int = 0
+		_ = digit
+		_tmp6 := k
+		_tmp7 := result
+		_, _tmp8 := _tmp7[_tmp6]
+		if _tmp8 {
+			digit = result[k]
+		}
+		if ((out == "") && (digit == 0)) {
+		} else {
+			out = out + fmt.Sprint(digit)
+		}
+		k = (k + 1)
+	}
+	if (out == "") {
+		return "0"
+	}
+	return out
+}
+
+func example_1() {
+	expect((multiply("2", "3") == "6"))
+}
+
+func example_2() {
+	expect((multiply("123", "456") == "56088"))
+}
+
+func leading_zeros() {
+	expect((multiply("0002", "03") == "6"))
+}
+
+func large_numbers() {
+	expect((multiply("999", "999") == "998001"))
+}
+
+func main() {
+	var ok int = 0
+	_ = ok
+	ok = (ok + 1)
+	var y int = 1
+	_ = y
+	y = 2
+	example_1()
+	example_2()
+	leading_zeros()
+	large_numbers()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/n-queens.go.out
+++ b/examples/leetcode-out/n-queens.go.out
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func solveNQueens(n int) [][]string {
+	var results [][]string = [][]string{}
+	_ = results
+	var cols map[int]bool = map[int]bool{}
+	_ = cols
+	var diag1 map[int]bool = map[int]bool{}
+	_ = diag1
+	var diag2 map[int]bool = map[int]bool{}
+	_ = diag2
+	var backtrack func(int, []string)
+	backtrack = func(row int, board []string) {
+		if (row == n) {
+			results = append(append([][]string{}, results...), [][]string{board}...)
+		} else {
+			var c int = 0
+			_ = c
+			for (c < n) {
+				var usedCol bool = false
+				_ = usedCol
+				_tmp0 := c
+				_tmp1 := cols
+				_, _tmp2 := _tmp1[_tmp0]
+				if _tmp2 {
+					usedCol = cols[c]
+				}
+				if usedCol {
+					c = (c + 1)
+					continue
+				}
+				var d1 int = (row - c)
+				var d2 int = (row + c)
+				var usedD1 bool = false
+				_ = usedD1
+				var usedD2 bool = false
+				_ = usedD2
+				_tmp3 := d1
+				_tmp4 := diag1
+				_, _tmp5 := _tmp4[_tmp3]
+				if _tmp5 {
+					usedD1 = diag1[d1]
+				}
+				_tmp6 := d2
+				_tmp7 := diag2
+				_, _tmp8 := _tmp7[_tmp6]
+				if _tmp8 {
+					usedD2 = diag2[d2]
+				}
+				if !((usedD1 || usedD2)) {
+					cols[c] = true
+					diag1[d1] = true
+					diag2[d2] = true
+					var rowStr string = ""
+					_ = rowStr
+					var i int = 0
+					_ = i
+					for (i < n) {
+						if (i == c) {
+							rowStr = rowStr + "Q"
+						} else {
+							rowStr = rowStr + "."
+						}
+						i = (i + 1)
+					}
+					backtrack((row + 1), append(append([]string{}, board...), []string{rowStr}...))
+					cols[c] = false
+					diag1[d1] = false
+					diag2[d2] = false
+				}
+				c = (c + 1)
+			}
+		}
+}
+	backtrack(0, []string{})
+	return results
+}
+
+func n_4() {
+	expect(_equal(result4, expected4))
+}
+
+func n_1() {
+	expect(_equal(solveNQueens(1), [][]string{[]string{"Q"}}))
+}
+
+var result4 [][]string = solveNQueens(4)
+var expected4 [][]string = [][]string{[]string{".Q..", "...Q", "Q...", "..Q."}, []string{"..Q.", "Q...", "...Q", ".Q.."}}
+func main() {
+	n_4()
+	n_1()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/next-permutation.go.out
+++ b/examples/leetcode-out/next-permutation.go.out
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func nextPermutation(nums []int) []int {
+	var i int = (len(nums) - 2)
+	_ = i
+	for ((i >= 0) && (nums[i] >= nums[(i + 1)])) {
+		i = (i - 1)
+	}
+	if (i >= 0) {
+		var j int = (len(nums) - 1)
+		_ = j
+		for (nums[j] <= nums[i]) {
+			j = (j - 1)
+		}
+		var temp int = nums[i]
+		nums[i] = nums[j]
+		nums[j] = temp
+	}
+	var start int = (i + 1)
+	_ = start
+	var end int = (len(nums) - 1)
+	_ = end
+	for (start < end) {
+		var temp int = nums[start]
+		nums[start] = nums[end]
+		nums[end] = temp
+		start = (start + 1)
+		end = (end - 1)
+	}
+	return nums
+}
+
+func example_1() {
+	expect(_equal(nextPermutation([]int{1, 2, 3}), []int{1, 3, 2}))
+}
+
+func example_2() {
+	expect(_equal(nextPermutation([]int{3, 2, 1}), []int{1, 2, 3}))
+}
+
+func example_3() {
+	expect(_equal(nextPermutation([]int{1, 1, 5}), []int{1, 5, 1}))
+}
+
+func single_element() {
+	expect(_equal(nextPermutation([]int{1}), []int{1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_element()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/nth-highest-salary.go.out
+++ b/examples/leetcode-out/nth-highest-salary.go.out
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Employee struct {
+	Id int `json:"id"`
+	Salary int `json:"salary"`
+}
+
+func nthHighestSalary(employees []Employee, n int) int {
+	var uniqList []int = []int{}
+	_ = uniqList
+	for _, e := range employees {
+		var seen bool = false
+		_ = seen
+		for _, s := range uniqList {
+			if (s == e.Salary) {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			uniqList = append(append([]int{}, uniqList...), []int{e.Salary}...)
+		}
+	}
+	var sorted []any = func() []int {
+	items := []int{}
+	for _, v := range uniqList {
+		items = append(items, v)
+	}
+	type pair struct { item int; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		v := it
+		pairs[idx] = pair{item: it, key: -v}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []int{}
+	for _, v := range items {
+		res = append(res, v)
+	}
+	return res
+}()
+	if (n <= len(sorted)) {
+		return sorted[(n - 1)]
+	}
+	return 0
+}
+
+func first_highest() {
+	expect((nthHighestSalary(employees, 1) == 300))
+}
+
+func second_highest() {
+	expect((nthHighestSalary(employees, 2) == 200))
+}
+
+func too_high() {
+	expect((nthHighestSalary(employees, 5) == 0))
+}
+
+var employees []Employee = []Employee{Employee{Id: 1, Salary: 100}, Employee{Id: 2, Salary: 200}, Employee{Id: 3, Salary: 300}, Employee{Id: 4, Salary: 300}}
+func main() {
+	first_highest()
+	second_highest()
+	too_high()
+}
+

--- a/examples/leetcode-out/one-edit-distance.go.out
+++ b/examples/leetcode-out/one-edit-distance.go.out
@@ -1,0 +1,68 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isOneEditDistance(s string, t string) bool {
+	var m int = len(s)
+	var n int = len(t)
+	if (m > n) {
+		return isOneEditDistance(t, s)
+	}
+	if ((n - m) > 1) {
+		return false
+	}
+	var i int = 0
+	_ = i
+	for (i < m) {
+		if (_indexString(s, i) != _indexString(t, i)) {
+			if (m == n) {
+				return (string([]rune(s)[(i + 1):m]) == string([]rune(t)[(i + 1):n]))
+			}
+			return (string([]rune(s)[i:m]) == string([]rune(t)[(i + 1):n]))
+		}
+		i = (i + 1)
+	}
+	return ((n - m) == 1)
+}
+
+func example_1() {
+	expect((isOneEditDistance("ab", "acb") == true))
+}
+
+func example_2() {
+	expect((isOneEditDistance("cab", "ad") == false))
+}
+
+func example_3() {
+	expect((isOneEditDistance("1203", "1213") == true))
+}
+
+func identical() {
+	expect((isOneEditDistance("a", "a") == false))
+}
+
+func insert_at_end() {
+	expect((isOneEditDistance("abc", "abcc") == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	identical()
+	insert_at_end()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/palindrome-linked-list.go.out
+++ b/examples/leetcode-out/palindrome-linked-list.go.out
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isPalindromeList(values []int) bool {
+	var n int = len(values)
+	var i int = 0
+	_ = i
+	var j int = (n - 1)
+	_ = j
+	for (i < j) {
+		if (values[i] != values[j]) {
+			return false
+		}
+		i = (i + 1)
+		j = (j - 1)
+	}
+	return true
+}
+
+func example_1() {
+	expect((isPalindromeList([]int{1, 2, 2, 1}) == true))
+}
+
+func example_2() {
+	expect((isPalindromeList([]int{1, 2}) == false))
+}
+
+func single_element() {
+	expect((isPalindromeList([]int{7}) == true))
+}
+
+func empty_list() {
+	expect((isPalindromeList([]int{}) == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+	empty_list()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/palindrome-number.go.out
+++ b/examples/leetcode-out/palindrome-number.go.out
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isPalindrome(x int) bool {
+	if (x < 0) {
+		return false
+	}
+	var s string = fmt.Sprint(x)
+	var n int = len(s)
+	for i := 0; i < (n / 2); i++ {
+		if (_indexString(s, i) != _indexString(s, ((n - 1) - i))) {
+			return false
+		}
+	}
+	return true
+}
+
+func example_1() {
+	expect((isPalindrome(121) == true))
+}
+
+func example_2() {
+	expect((isPalindrome(-121) == false))
+}
+
+func example_3() {
+	expect((isPalindrome(10) == false))
+}
+
+func zero() {
+	expect((isPalindrome(0) == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	zero()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/palindrome-partitioning-ii.go.out
+++ b/examples/leetcode-out/palindrome-partitioning-ii.go.out
@@ -1,0 +1,97 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func minCut(s string) int {
+	var n int = len(s)
+	if (n <= 1) {
+		return 0
+	}
+	var dp []int = []int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i < n) {
+		dp = append(append([]int{}, dp...), []int{i}...)
+		i = (i + 1)
+	}
+	var isPal [][]bool = [][]bool{}
+	_ = isPal
+	i = 0
+	for (i < n) {
+		var row []bool = []bool{}
+		_ = row
+		var j int = 0
+		_ = j
+		for (j < n) {
+			row = append(append([]bool{}, row...), []bool{false}...)
+			j = (j + 1)
+		}
+		isPal = append(append([][]bool{}, isPal...), [][]bool{row}...)
+		i = (i + 1)
+	}
+	i = 0
+	for (i < n) {
+		var j int = 0
+		_ = j
+		for (j <= i) {
+			if (_indexString(s, j) == _indexString(s, i)) {
+				if ((i - j) <= 1) {
+					isPal[j][i] = true
+				} else 				if isPal[(j + 1)][(i - 1)] {
+					isPal[j][i] = true
+				}
+				if isPal[j][i] {
+					if (j == 0) {
+						dp[i] = 0
+					} else {
+						var candidate int = (dp[(j - 1)] + 1)
+						if (candidate < dp[i]) {
+							dp[i] = candidate
+						}
+					}
+				}
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return dp[(n - 1)]
+}
+
+func example_1() {
+	expect((minCut("aab") == 1))
+}
+
+func example_2() {
+	expect((minCut("a") == 0))
+}
+
+func already_palindrome() {
+	expect((minCut("aba") == 0))
+}
+
+func all_same() {
+	expect((minCut("aaaa") == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	already_palindrome()
+	all_same()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/palindrome-partitioning.go.out
+++ b/examples/leetcode-out/palindrome-partitioning.go.out
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func partition(s string) [][]string {
+	var n int = len(s)
+	var result [][]string = [][]string{}
+	_ = result
+	var isPal = func(left int, right int) bool {
+		var l int = left
+		_ = l
+		var r int = right
+		_ = r
+		for (l < r) {
+			if (_indexString(s, l) != _indexString(s, r)) {
+				return false
+			}
+			l = (l + 1)
+			r = (r - 1)
+		}
+		return true
+}
+	var dfs func(int, []string)
+	dfs = func(start int, path []string) {
+		if (start == n) {
+			result = append(append([][]string{}, result...), [][]string{path}...)
+		} else {
+			var end int = start
+			_ = end
+			for (end < n) {
+				if isPal(start, end) {
+					dfs((end + 1), append(append([]string{}, path...), []string{string([]rune(s)[start:(end + 1)])}...))
+				}
+				end = (end + 1)
+			}
+		}
+}
+	dfs(0, []string{})
+	return result
+}
+
+func example_1() {
+	expect(_equal(partition("aab"), [][]string{[]string{"a", "a", "b"}, []string{"aa", "b"}}))
+}
+
+func example_2() {
+	expect(_equal(partition("a"), [][]string{[]string{"a"}}))
+}
+
+func no_palindrome() {
+	expect(_equal(partition("abc"), [][]string{[]string{"a", "b", "c"}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	no_palindrome()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/partition-list.go.out
+++ b/examples/leetcode-out/partition-list.go.out
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func partition(head []int, x int) []int {
+	var less []int = []int{}
+	_ = less
+	var greater []int = []int{}
+	_ = greater
+	var idx int = 0
+	_ = idx
+	for (idx < len(head)) {
+		var val int = head[idx]
+		if (val < x) {
+			less = append(append([]int{}, less...), []int{val}...)
+		} else {
+			greater = append(append([]int{}, greater...), []int{val}...)
+		}
+		idx = (idx + 1)
+	}
+	var j int = 0
+	_ = j
+	for (j < len(greater)) {
+		var val int = greater[j]
+		less = append(append([]int{}, less...), []int{val}...)
+		j = (j + 1)
+	}
+	return less
+}
+
+func example_1() {
+	expect(_equal(partition([]int{1, 4, 3, 2, 5, 2}, 3), []int{1, 2, 2, 4, 3, 5}))
+}
+
+func example_2() {
+	expect(_equal(partition([]int{2, 1}, 2), []int{1, 2}))
+}
+
+func all_less() {
+	expect(_equal(partition([]int{1, 1, 1}, 5), []int{1, 1, 1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	all_less()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/pascals-triangle-ii.go.out
+++ b/examples/leetcode-out/pascals-triangle-ii.go.out
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func getRow(rowIndex int) []int {
+	var row []int = []int{1}
+	_ = row
+	var i int = 0
+	_ = i
+	for (i < rowIndex) {
+		var next []int = []int{1}
+		_ = next
+		var j int = 1
+		_ = j
+		for (j < len(row)) {
+			next = append(append([]int{}, next...), []int{(row[(j - 1)] + row[j])}...)
+			j = (j + 1)
+		}
+		next = append(append([]int{}, next...), []int{1}...)
+		row = next
+		i = (i + 1)
+	}
+	return row
+}
+
+func example_1() {
+	expect(_equal(getRow(3), []int{1, 3, 3, 1}))
+}
+
+func example_2() {
+	expect(_equal(getRow(0), []int{1}))
+}
+
+func example_3() {
+	expect(_equal(getRow(1), []int{1, 1}))
+}
+
+func row_2() {
+	expect(_equal(getRow(2), []int{1, 2, 1}))
+}
+
+func row_4() {
+	expect(_equal(getRow(4), []int{1, 4, 6, 4, 1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	row_2()
+	row_4()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/pascals-triangle.go.out
+++ b/examples/leetcode-out/pascals-triangle.go.out
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func generateTriangle(numRows int) [][]int {
+	if (numRows <= 0) {
+		return _cast[[][]int]([]any{})
+	}
+	var result [][]int = [][]int{[]int{1}}
+	_ = result
+	var i int = 1
+	_ = i
+	for (i < numRows) {
+		var prev []int = result[(i - 1)]
+		var row []int = []int{1}
+		_ = row
+		var j int = 1
+		_ = j
+		for (j < len(prev)) {
+			row = append(append([]int{}, row...), []int{(prev[(j - 1)] + prev[j])}...)
+			j = (j + 1)
+		}
+		row = append(append([]int{}, row...), []int{1}...)
+		result = append(append([][]int{}, result...), [][]int{row}...)
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(generateTriangle(5), [][]int{[]int{1}, []int{1, 1}, []int{1, 2, 1}, []int{1, 3, 3, 1}, []int{1, 4, 6, 4, 1}}))
+}
+
+func example_2() {
+	expect(_equal(generateTriangle(1), [][]int{[]int{1}}))
+}
+
+func zero_rows() {
+	expect(_equal(generateTriangle(0), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	zero_rows()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/path-sum-ii.go.out
+++ b/examples/leetcode-out/path-sum-ii.go.out
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func pathSum(root any, targetSum int) [][]int {
+	var dfs func(any, int, []int) [][]int
+	dfs = func(node any, remaining int, path []int) [][]int {
+		var handle = func(l any, v int, r any, rem int, p []int) [][]int {
+			var leftEmpty bool = func() bool {
+			_t := l
+			switch _t {
+			case Leaf:
+				return true
+			default:
+				return false
+			}
+		}()
+			var rightEmpty bool = func() bool {
+			_t := r
+			switch _t {
+			case Leaf:
+				return true
+			default:
+				return false
+			}
+		}()
+			var newRemaining int = (rem - v)
+			var newPath []int = append(append([]int{}, p...), []int{v}...)
+			if (leftEmpty && rightEmpty) {
+				if (newRemaining == 0) {
+					return [][]int{newPath}
+				} else {
+					return _cast[[][]int]([]any{})
+				}
+			}
+			return append(append([][]int{}, dfs(l, newRemaining, newPath)...), dfs(r, newRemaining, newPath)...)
+	}
+		return func() [][]int {
+		_t := node
+		switch _t {
+		case Leaf:
+			return _cast[[][]int]([]any{})
+		case Node(l, v, r):
+			return handle(l, v, r, remaining, path)
+		}
+	}()
+}
+	return dfs(root, targetSum, []int{})
+}
+
+func example_1() {
+	var rootLeft Node = Node{Left: Node{Left: Leaf{}, Value: 7, Right: Leaf{}}, Value: 11, Right: Node{Left: Leaf{}, Value: 2, Right: Leaf{}}}
+	var tree Node = Node{Left: Node{Left: rootLeft, Value: 4, Right: Leaf{}}, Value: 5, Right: Node{Left: Node{Left: Leaf{}, Value: 13, Right: Leaf{}}, Value: 8, Right: Node{Left: Node{Left: Leaf{}, Value: 5, Right: Leaf{}}, Value: 4, Right: Node{Left: Leaf{}, Value: 1, Right: Leaf{}}}}}
+	expect(_equal(pathSum(tree, 22), [][]int{[]int{5, 4, 11, 2}, []int{5, 8, 4, 5}}))
+}
+
+func example_2() {
+	var tree Node = Node{Left: Node{Left: Leaf{}, Value: 2, Right: Leaf{}}, Value: 1, Right: Node{Left: Leaf{}, Value: 3, Right: Leaf{}}}
+	expect(_equal(pathSum(tree, 5), []any{}))
+}
+
+func example_3() {
+	var tree Node = Node{Left: Node{Left: Leaf{}, Value: 2, Right: Leaf{}}, Value: 1, Right: Leaf{}}
+	expect(_equal(pathSum(tree, 0), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/permutation-sequence.go.out
+++ b/examples/leetcode-out/permutation-sequence.go.out
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func getPermutation(n int, k int) string {
+	var factVal int = 1
+	_ = factVal
+	for i := 1; i < (n + 1); i++ {
+		factVal = (factVal * i)
+	}
+	var nums []int = []int{}
+	_ = nums
+	var i int = 1
+	_ = i
+	for (i <= n) {
+		nums = append(append([]int{}, nums...), []int{i}...)
+		i = (i + 1)
+	}
+	var k0 int = (k - 1)
+	_ = k0
+	var result string = ""
+	_ = result
+	i = 0
+	for (i < n) {
+		factVal = (factVal / ((n - i)))
+		var idx int = (k0 / factVal)
+		var digit int = nums[idx]
+		result = result + fmt.Sprint(digit)
+		nums = append(append([]int{}, nums[0:idx]...), nums[(idx + 1):len(nums)]...)
+		k0 = (k0 % factVal)
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect((getPermutation(3, 3) == "213"))
+}
+
+func example_2() {
+	expect((getPermutation(4, 9) == "2314"))
+}
+
+func example_3() {
+	expect((getPermutation(3, 1) == "123"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/permutations.go.out
+++ b/examples/leetcode-out/permutations.go.out
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func permute(nums []int) [][]int {
+	var result [][]int = [][]int{}
+	_ = result
+	var backtrack func([]int, []int)
+	backtrack = func(path []int, remaining []int) {
+		if (len(remaining) == 0) {
+			result = append(append([][]int{}, result...), [][]int{path}...)
+		} else {
+			for i := 0; i < len(remaining); i++ {
+				var nextPath []int = append(append([]int{}, path...), []int{remaining[i]}...)
+				var nextRemaining []int = append(append([]int{}, remaining[0:i]...), remaining[(i + 1):len(remaining)]...)
+				backtrack(nextPath, nextRemaining)
+			}
+		}
+}
+	backtrack([]int{}, nums)
+	return result
+}
+
+func example_1() {
+	expect(_equal(permute([]int{1, 2, 3}), [][]int{[]int{1, 2, 3}, []int{1, 3, 2}, []int{2, 1, 3}, []int{2, 3, 1}, []int{3, 1, 2}, []int{3, 2, 1}}))
+}
+
+func example_2() {
+	expect(_equal(permute([]int{0, 1}), [][]int{[]int{0, 1}, []int{1, 0}}))
+}
+
+func example_3() {
+	expect(_equal(permute([]int{1}), [][]int{[]int{1}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/plus-one.go.out
+++ b/examples/leetcode-out/plus-one.go.out
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func plusOne(digits []int) []int {
+	var carry int = 1
+	_ = carry
+	var i int = (len(digits) - 1)
+	_ = i
+	var result []int = digits
+	_ = result
+	for ((i >= 0) && (carry > 0)) {
+		var sum int = (result[i] + carry)
+		_ = sum
+		result[i] = (sum % 10)
+		carry = (sum / 10)
+		i = (i - 1)
+	}
+	if (carry > 0) {
+		return append(append([]int{}, []int{carry}...), result...)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(plusOne([]int{1, 2, 3}), []int{1, 2, 4}))
+}
+
+func example_2() {
+	expect(_equal(plusOne([]int{4, 3, 2, 1}), []int{4, 3, 2, 2}))
+}
+
+func example_3() {
+	expect(_equal(plusOne([]int{9}), []int{1, 0}))
+}
+
+func carry_through_all_digits() {
+	expect(_equal(plusOne([]int{9, 9, 9}), []int{1, 0, 0, 0}))
+}
+
+func zero() {
+	expect(_equal(plusOne([]int{0}), []int{1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	carry_through_all_digits()
+	zero()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/populating-next-right-pointers-in-each-node-ii.go.out
+++ b/examples/leetcode-out/populating-next-right-pointers-in-each-node-ii.go.out
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func connect(lefts []int, rights []int, root int) []int {
+	var nexts []int = []int{}
+	_ = nexts
+	var i int = 0
+	_ = i
+	for (i < len(lefts)) {
+		nexts = append(append([]int{}, nexts...), []int{(-1)}...)
+		i = (i + 1)
+	}
+	var queue []int = []int{}
+	_ = queue
+	if (root != (-1)) {
+		queue = []int{root}
+	}
+	for (len(queue) > 0) {
+		var next []int = []int{}
+		_ = next
+		var prev int = (-1)
+		_ = prev
+		for _, idx := range queue {
+			if (prev != (-1)) {
+				nexts[prev] = idx
+			}
+			prev = idx
+			if (lefts[idx] != (-1)) {
+				next = append(append([]int{}, next...), []int{lefts[idx]}...)
+			}
+			if (rights[idx] != (-1)) {
+				next = append(append([]int{}, next...), []int{rights[idx]}...)
+			}
+		}
+		queue = next
+	}
+	return nexts
+}
+
+func levels(lefts []int, rights []int, values []int, root int) [][]int {
+	var result [][]int = [][]int{}
+	_ = result
+	var queue []int = []int{}
+	_ = queue
+	if (root != (-1)) {
+		queue = []int{root}
+	}
+	for (len(queue) > 0) {
+		var vals []int = []int{}
+		_ = vals
+		var next []int = []int{}
+		_ = next
+		for _, idx := range queue {
+			vals = append(append([]int{}, vals...), []int{values[idx]}...)
+			if (lefts[idx] != (-1)) {
+				next = append(append([]int{}, next...), []int{lefts[idx]}...)
+			}
+			if (rights[idx] != (-1)) {
+				next = append(append([]int{}, next...), []int{rights[idx]}...)
+			}
+		}
+		result = append(append([][]int{}, result...), [][]int{vals}...)
+		queue = next
+	}
+	return result
+}
+
+func example() {
+	var ns []int = connect(exLefts, exRights, exRoot)
+	expect(_equal(levels(exLefts, exRights, exValues, exRoot), [][]int{[]int{1}, []int{2, 3}, []int{4, 5, 7}}))
+	expect(_equal(ns, []int{(-1), 2, (-1), 4, 5, (-1)}))
+}
+
+func single_node() {
+	var lefts []int = _cast[[]int]([]int{(-1)})
+	var rights []int = _cast[[]int]([]int{(-1)})
+	var values []int = _cast[[]int]([]int{1})
+	var root int = 0
+	var ns []int = connect(lefts, rights, root)
+	expect(_equal(levels(lefts, rights, values, root), [][]int{[]int{1}}))
+	expect(_equal(ns, []int{(-1)}))
+}
+
+func empty() {
+	var lefts []int = _cast[[]int]([]any{})
+	var rights []int = _cast[[]int]([]any{})
+	var values []int = _cast[[]int]([]any{})
+	var ns []int = connect(lefts, rights, (-1))
+	expect(_equal(levels(lefts, rights, values, (-1)), []any{}))
+	expect(_equal(ns, []any{}))
+}
+
+var exLefts []int = _cast[[]int]([]int{1, 3, (-1), (-1), (-1), (-1)})
+var exRights []int = _cast[[]int]([]int{2, 4, 5, (-1), (-1), (-1)})
+var exValues []int = _cast[[]int]([]int{1, 2, 3, 4, 5, 7})
+var exRoot int = 0
+func main() {
+	example()
+	single_node()
+	empty()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/power-of-two.go.out
+++ b/examples/leetcode-out/power-of-two.go.out
@@ -1,0 +1,49 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isPowerOfTwo(n int) bool {
+	if (n <= 0) {
+		return false
+	}
+	var num int = n
+	_ = num
+	for (num > 1) {
+		if ((num % 2) != 0) {
+			return false
+		}
+		num = (num / 2)
+	}
+	return true
+}
+
+func example_1() {
+	expect((isPowerOfTwo(1) == true))
+}
+
+func example_2() {
+	expect((isPowerOfTwo(16) == true))
+}
+
+func example_3() {
+	expect((isPowerOfTwo(3) == false))
+}
+
+func zero() {
+	expect((isPowerOfTwo(0) == false))
+}
+
+func negative() {
+	expect((isPowerOfTwo(-2) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	zero()
+	negative()
+}
+

--- a/examples/leetcode-out/powx-n.go.out
+++ b/examples/leetcode-out/powx-n.go.out
@@ -1,0 +1,47 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func myPow(x float64, n int) float64 {
+	if (n == 0) {
+		return 1.000000
+	}
+	if (n < 0) {
+		return (1.000000 / myPow(x, -n))
+	}
+	var base float64 = x
+	_ = base
+	var exp int = n
+	_ = exp
+	var result float64 = 1.000000
+	_ = result
+	for (exp > 0) {
+		if ((exp % 2) == 1) {
+			result = (result * base)
+		}
+		base = (base * base)
+		exp = (exp / 2)
+	}
+	return result
+}
+
+func example_1() {
+	expect((myPow(2.000000, 10) == 1024.000000))
+}
+
+func example_2() {
+	expect((myPow(2.100000, 3) == 9.261000))
+}
+
+func example_3() {
+	expect((myPow(2.000000, -2) == 0.250000))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/product-of-array-except-self.go.out
+++ b/examples/leetcode-out/product-of-array-except-self.go.out
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func productExceptSelf(nums []int) []int {
+	var n int = len(nums)
+	if (n == 0) {
+		return _cast[[]int]([]any{})
+	}
+	var result []int = []int{}
+	_ = result
+	var prefix int = 1
+	_ = prefix
+	var i int = 0
+	_ = i
+	for (i < n) {
+		result = append(append([]int{}, result...), []int{prefix}...)
+		prefix = (prefix * nums[i])
+		i = (i + 1)
+	}
+	var suffix int = 1
+	_ = suffix
+	i = (n - 1)
+	for (i >= 0) {
+		result[i] = (result[i] * suffix)
+		suffix = (suffix * nums[i])
+		i = (i - 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(productExceptSelf([]int{1, 2, 3, 4}), []int{24, 12, 8, 6}))
+}
+
+func example_2() {
+	expect(_equal(productExceptSelf([]int{0, 1, 2, 3}), []int{6, 0, 0, 0}))
+}
+
+func example_3() {
+	expect(_equal(productExceptSelf([]int{-1, 1, 0, -3, 3}), []int{0, 0, 9, 0, 0}))
+}
+
+func single_element() {
+	expect(_equal(productExceptSelf([]int{5}), []int{1}))
+}
+
+func two_zeros() {
+	expect(_equal(productExceptSelf([]int{0, 0}), []int{0, 0}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_element()
+	two_zeros()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/read-n-characters-ii.go.out
+++ b/examples/leetcode-out/read-n-characters-ii.go.out
@@ -1,0 +1,119 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Reader struct {
+	Data string `json:"data"`
+	Index int `json:"index"`
+	Buffer string `json:"buffer"`
+}
+
+type Read4Result struct {
+	Reader any `json:"reader"`
+	Chunk string `json:"chunk"`
+}
+
+type ReadResult struct {
+	Reader any `json:"reader"`
+	Data string `json:"data"`
+	Count int `json:"count"`
+}
+
+func newReader(s string) Reader {
+	return Reader{Data: s, Index: 0, Buffer: ""}
+}
+
+func read4(r Reader) Read4Result {
+	var i int = 0
+	_ = i
+	var chunk string = ""
+	_ = chunk
+	var idx int = r.Index
+	_ = idx
+	for ((i < 4) && (idx < len(r.Data))) {
+		chunk = chunk + _indexString(r.Data, idx)
+		idx = (idx + 1)
+		i = (i + 1)
+	}
+	var newReader func(string) Reader = Reader{Data: r.Data, Index: idx, Buffer: r.Buffer}
+	return Read4Result{Reader: newReader, Chunk: chunk}
+}
+
+func read(reader Reader, n int) ReadResult {
+	var r Reader = reader
+	_ = r
+	var output string = ""
+	_ = output
+	var total int = 0
+	_ = total
+	for ((total < n) && (len(r.Buffer) > 0)) {
+		output = output + _indexString(r.Buffer, 0)
+		r = Reader{Data: r.Data, Index: r.Index, Buffer: string([]rune(r.Buffer)[1:len(r.Buffer)])}
+		total = (total + 1)
+	}
+	for (total < n) {
+		var r4 Read4Result = read4(r)
+		r = r4.Reader
+		var chunk string = r4.Chunk
+		if (len(chunk) == 0) {
+			break
+		}
+		var i int = 0
+		_ = i
+		for ((i < len(chunk)) && (total < n)) {
+			output = output + _indexString(chunk, i)
+			i = (i + 1)
+			total = (total + 1)
+		}
+		r = Reader{Data: r.Data, Index: r.Index, Buffer: string([]rune(chunk)[i:len(chunk)])}
+	}
+	return ReadResult{Reader: r, Data: output, Count: total}
+}
+
+func multiple_calls() {
+	var r Reader = newReader("abc")
+	_ = r
+	var r1 ReadResult = read(r, 1)
+	expect((r1.Data == "a"))
+	r = r1.Reader
+	var r2 ReadResult = read(r, 2)
+	expect((r2.Data == "bc"))
+}
+
+func leftover_handling() {
+	var r Reader = newReader("abcde")
+	_ = r
+	var r1 ReadResult = read(r, 2)
+	expect((r1.Data == "ab"))
+	r = r1.Reader
+	var r2 ReadResult = read(r, 3)
+	expect((r2.Data == "cde"))
+}
+
+func request_past_end() {
+	var r Reader = newReader("abcd")
+	_ = r
+	var r1 ReadResult = read(r, 6)
+	expect((r1.Data == "abcd"))
+	expect((r1.Count == 4))
+}
+
+func main() {
+	multiple_calls()
+	leftover_handling()
+	request_past_end()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/recover-binary-search-tree.go.out
+++ b/examples/leetcode-out/recover-binary-search-tree.go.out
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func inorder(t any) []int {
+	return func() []int {
+	_t := t
+	switch _t {
+	case Leaf:
+		return _cast[[]int]([]any{})
+	case Node(l, v, r):
+		return append(append([]any{}, append(append([]any{}, _toAnySlice(inorder(l))...), []any{v}...)...), _toAnySlice(inorder(r))...)
+	}
+}()
+}
+
+func recoverTree(t any) any {
+	var vals []int = inorder(t)
+	var sortedVals []any = func() []int {
+	items := []int{}
+	for _, x := range vals {
+		items = append(items, x)
+	}
+	type pair struct { item int; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		x := it
+		pairs[idx] = pair{item: it, key: x}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []int{}
+	for _, x := range items {
+		res = append(res, x)
+	}
+	return res
+}()
+	var build = func(lo int, hi int) any {
+		if (lo >= hi) {
+			return Leaf{}
+		}
+		var mid int = (((lo + hi)) / 2)
+		return Node{Left: build(lo, mid), Value: sortedVals[mid], Right: build((mid + 1), hi)}
+}
+	return build(0, len(sortedVals))
+}
+
+func main() {
+	var ex any = Node{Left: Node{Left: Leaf{}, Value: 3, Right: Leaf{}}, Value: 1, Right: Node{Left: Leaf{}, Value: 4, Right: Leaf{}}}
+	var fixed any = recoverTree(ex)
+	expect(_equal(inorder(fixed), []int{1, 3, 4}))
+	var ex2 any = Node{Left: Node{Left: Leaf{}, Value: 2, Right: Leaf{}}, Value: 4, Right: Node{Left: Leaf{}, Value: 1, Right: Leaf{}}}
+	var fixed2 any = recoverTree(ex2)
+	expect(_equal(inorder(fixed2), []int{1, 2, 4}))
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/rectangle-area.go.out
+++ b/examples/leetcode-out/rectangle-area.go.out
@@ -1,0 +1,61 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func max(a int, b int) int {
+	if (a > b) {
+		return a
+	}
+	return b
+}
+
+func min(a int, b int) int {
+	if (a < b) {
+		return a
+	}
+	return b
+}
+
+func computeArea(ax1 int, ay1 int, ax2 int, ay2 int, bx1 int, by1 int, bx2 int, by2 int) int {
+	var areaA int = (((ax2 - ax1)) * ((ay2 - ay1)))
+	var areaB int = (((bx2 - bx1)) * ((by2 - by1)))
+	var overlapWidth int = (min(ax2, bx2) - max(ax1, bx1))
+	var overlapHeight int = (min(ay2, by2) - max(ay1, by1))
+	var overlap int = 0
+	_ = overlap
+	if ((overlapWidth > 0) && (overlapHeight > 0)) {
+		overlap = (overlapWidth * overlapHeight)
+	}
+	return ((areaA + areaB) - overlap)
+}
+
+func example_1() {
+	expect((computeArea(-3, 0, 3, 4, 0, -1, 9, 2) == 45))
+}
+
+func example_2() {
+	expect((computeArea(-2, -2, 2, 2, -2, -2, 2, 2) == 16))
+}
+
+func no_overlap() {
+	expect((computeArea(-1, -1, 1, 1, 2, 2, 3, 3) == 5))
+}
+
+func touching_edges() {
+	expect((computeArea(0, 0, 1, 1, 1, 0, 2, 1) == 2))
+}
+
+func one_inside_another() {
+	expect((computeArea(-2, -2, 2, 2, -1, -1, 1, 1) == 16))
+}
+
+func main() {
+	example_1()
+	example_2()
+	no_overlap()
+	touching_edges()
+	one_inside_another()
+}
+

--- a/examples/leetcode-out/regular-expression-matching.go.out
+++ b/examples/leetcode-out/regular-expression-matching.go.out
@@ -1,0 +1,94 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isMatch(s string, p string) bool {
+	var m int = len(s)
+	var n int = len(p)
+	var memo map[int]bool = map[int]bool{}
+	_ = memo
+	var dfs func(int, int) bool
+	dfs = func(i int, j int) bool {
+		var key int = ((i * ((n + 1))) + j)
+		_tmp0 := key
+		_tmp1 := memo
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			return memo[key]
+		}
+		if (j == n) {
+			return (i == m)
+		}
+		var first bool = false
+		_ = first
+		if (i < m) {
+			if (((_indexString(p, j) == _indexString(s, i))) || ((_indexString(p, j) == "."))) {
+				first = true
+			}
+		}
+		var ans bool = false
+		_ = ans
+		if ((j + 1) < n) {
+			if (_indexString(p, (j + 1)) == "*") {
+				if dfs(i, (j + 2)) {
+					ans = true
+				} else 			if (first && dfs((i + 1), j)) {
+					ans = true
+				}
+			} else {
+				if (first && dfs((i + 1), (j + 1))) {
+					ans = true
+				}
+			}
+		} else {
+			if (first && dfs((i + 1), (j + 1))) {
+				ans = true
+			}
+		}
+		memo[key] = ans
+		return ans
+}
+	return dfs(0, 0)
+}
+
+func example_1() {
+	expect((isMatch("aa", "a") == false))
+}
+
+func example_2() {
+	expect((isMatch("aa", "a*") == true))
+}
+
+func example_3() {
+	expect((isMatch("ab", ".*") == true))
+}
+
+func example_4() {
+	expect((isMatch("aab", "c*a*b") == true))
+}
+
+func example_5() {
+	expect((isMatch("mississippi", "mis*is*p*.") == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	example_4()
+	example_5()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/remove-duplicates-from-sorted-array-ii.go.out
+++ b/examples/leetcode-out/remove-duplicates-from-sorted-array-ii.go.out
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func removeDuplicates(nums []int) int {
+	var n int = len(nums)
+	if (n <= 2) {
+		return n
+	}
+	var write int = 2
+	_ = write
+	var read int = 2
+	_ = read
+	for (read < n) {
+		if (nums[read] != nums[(write - 2)]) {
+			nums[write] = nums[read]
+			write = (write + 1)
+		}
+		read = (read + 1)
+	}
+	return write
+}
+
+func example_1() {
+	var nums []int = []int{1, 1, 1, 2, 2, 3}
+	_ = nums
+	var k int = removeDuplicates(nums)
+	expect((k == 5))
+	expect(_equal(nums[0:k], []int{1, 1, 2, 2, 3}))
+}
+
+func example_2() {
+	var nums []int = []int{0, 0, 1, 1, 1, 1, 2, 3, 3}
+	_ = nums
+	var k int = removeDuplicates(nums)
+	expect((k == 7))
+	expect(_equal(nums[0:k], []int{0, 0, 1, 1, 2, 3, 3}))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/remove-duplicates-from-sorted-list-ii.go.out
+++ b/examples/leetcode-out/remove-duplicates-from-sorted-list-ii.go.out
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func deleteDuplicates(nums []int) []int {
+	var n int = len(nums)
+	var result []int = []int{}
+	_ = result
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var value int = nums[i]
+		var j int = (i + 1)
+		_ = j
+		for (j < n) {
+			if (nums[j] == value) {
+				j = (j + 1)
+			} else {
+				break
+			}
+		}
+		if (j == (i + 1)) {
+			result = append(append([]int{}, result...), []int{value}...)
+		}
+		i = j
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(deleteDuplicates([]int{1, 2, 3, 3, 4, 4, 5}), []int{1, 2, 5}))
+}
+
+func example_2() {
+	expect(_equal(deleteDuplicates([]int{1, 1, 1, 2, 3}), []int{2, 3}))
+}
+
+func empty() {
+	expect(_equal(deleteDuplicates([]int{}), []any{}))
+}
+
+func no_duplicates() {
+	expect(_equal(deleteDuplicates([]int{1, 2, 3}), []int{1, 2, 3}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty()
+	no_duplicates()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/remove-duplicates-from-sorted-list.go.out
+++ b/examples/leetcode-out/remove-duplicates-from-sorted-list.go.out
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func deleteDuplicates(nums []int) []int {
+	var n int = len(nums)
+	if (n == 0) {
+		return _cast[[]int]([]any{})
+	}
+	var result []int = []int{nums[0]}
+	_ = result
+	var i int = 1
+	_ = i
+	for (i < n) {
+		if (nums[i] != result[(len(result) - 1)]) {
+			result = append(append([]int{}, result...), []int{nums[i]}...)
+		}
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(deleteDuplicates([]int{1, 1, 2}), []int{1, 2}))
+}
+
+func example_2() {
+	expect(_equal(deleteDuplicates([]int{1, 1, 2, 3, 3}), []int{1, 2, 3}))
+}
+
+func empty_list() {
+	expect(_equal(deleteDuplicates([]int{}), []any{}))
+}
+
+func single_element() {
+	expect(_equal(deleteDuplicates([]int{0}), []int{0}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_list()
+	single_element()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/remove-element.go.out
+++ b/examples/leetcode-out/remove-element.go.out
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func removeElement(nums []int, val int) int {
+	var k int = 0
+	_ = k
+	var i int = 0
+	_ = i
+	for (i < len(nums)) {
+		if (nums[i] != val) {
+			nums[k] = nums[i]
+			k = (k + 1)
+		}
+		i = (i + 1)
+	}
+	return k
+}
+
+func example_1() {
+	var nums []int = []int{3, 2, 2, 3}
+	_ = nums
+	var k int = removeElement(nums, 3)
+	expect((k == 2))
+	expect(_equal(nums[0:k], []int{2, 2}))
+}
+
+func example_2() {
+	var nums []int = []int{0, 1, 2, 2, 3, 0, 4, 2}
+	_ = nums
+	var k int = removeElement(nums, 2)
+	expect((k == 5))
+	expect(_equal(nums[0:k], []int{0, 1, 3, 0, 4}))
+}
+
+func no_removal() {
+	var nums []int = []int{1, 2, 3}
+	_ = nums
+	var k int = removeElement(nums, 4)
+	expect((k == 3))
+	expect(_equal(nums[0:k], []int{1, 2, 3}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	no_removal()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/remove-linked-list-elements.go.out
+++ b/examples/leetcode-out/remove-linked-list-elements.go.out
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func removeElements(nums []int, val int) []int {
+	var result []int = []int{}
+	_ = result
+	for _, x := range nums {
+		if (x != val) {
+			result = append(append([]int{}, result...), []int{x}...)
+		}
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(removeElements([]int{1, 2, 6, 3, 4, 5, 6}, 6), []int{1, 2, 3, 4, 5}))
+}
+
+func example_2() {
+	expect(_equal(removeElements([]int{}, 1), []any{}))
+}
+
+func example_3() {
+	expect(_equal(removeElements([]int{7, 7, 7, 7}, 7), []any{}))
+}
+
+func no_removals() {
+	expect(_equal(removeElements([]int{1, 2, 3}, 4), []int{1, 2, 3}))
+}
+
+func all_removed() {
+	expect(_equal(removeElements([]int{2, 2, 2}, 2), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	no_removals()
+	all_removed()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/remove-nth-node-from-end-of-list.go.out
+++ b/examples/leetcode-out/remove-nth-node-from-end-of-list.go.out
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func removeNthFromEnd(nums []int, n int) []int {
+	var idx int = (len(nums) - n)
+	var result []any = []any{}
+	_ = result
+	var i int = 0
+	_ = i
+	for (i < len(nums)) {
+		if (i != idx) {
+			result = append(append([]any{}, result...), _toAnySlice([]int{nums[i]})...)
+		}
+		i = (i + 1)
+	}
+	return _cast[[]int](result)
+}
+
+func example_1() {
+	expect(_equal(removeNthFromEnd([]int{1, 2, 3, 4, 5}, 2), []int{1, 2, 3, 5}))
+}
+
+func example_2() {
+	expect(_equal(removeNthFromEnd([]int{1}, 1), []any{}))
+}
+
+func example_3() {
+	expect(_equal(removeNthFromEnd([]int{1, 2}, 1), []int{1}))
+}
+
+func remove_first() {
+	expect(_equal(removeNthFromEnd([]int{7, 8, 9}, 3), []int{8, 9}))
+}
+
+func remove_last() {
+	expect(_equal(removeNthFromEnd([]int{7, 8, 9}, 1), []int{7, 8}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	remove_first()
+	remove_last()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/reorder-list.go.out
+++ b/examples/leetcode-out/reorder-list.go.out
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func reorderList(nums []int) []int {
+	var n int = len(nums)
+	var result []int = []int{}
+	_ = result
+	var i int = 0
+	_ = i
+	var j int = (n - 1)
+	_ = j
+	for (i <= j) {
+		if (i == j) {
+			result = append(append([]int{}, result...), []int{nums[i]}...)
+		} else {
+			result = append(append([]int{}, result...), []int{nums[i], nums[j]}...)
+		}
+		i = (i + 1)
+		j = (j - 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(reorderList([]int{1, 2, 3, 4}), []int{1, 4, 2, 3}))
+}
+
+func example_2() {
+	expect(_equal(reorderList([]int{1, 2, 3, 4, 5}), []int{1, 5, 2, 4, 3}))
+}
+
+func single_element() {
+	expect(_equal(reorderList([]int{1}), []int{1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/restore-ip-addresses.go.out
+++ b/examples/leetcode-out/restore-ip-addresses.go.out
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func restoreIpAddresses(s string) []string {
+	var result []string = []string{}
+	_ = result
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	var backtrack func(int, int, string) int
+	backtrack = func(start int, part int, current string) int {
+		if (part == 4) {
+			if (start == len(s)) {
+				result = append(append([]string{}, result...), []string{string([]rune(current)[1:len(current)])}...)
+			}
+			return 0
+		}
+		for l := 1; l < 4; l++ {
+			if ((start + l) > len(s)) {
+				break
+			}
+			var segment string = string([]rune(s)[start:(start + l)])
+			if ((len(segment) > 1) && (_indexString(segment, 0) == "0")) {
+				continue
+			}
+			var val int = 0
+			_ = val
+			for _, r := range []rune(segment) {
+				ch := string(r)
+				val = ((val * 10) + digits[ch])
+			}
+			if (val > 255) {
+				continue
+			}
+			backtrack((start + l), (part + 1), current + "." + segment)
+		}
+		return 0
+}
+	backtrack(0, 0, "")
+	return result
+}
+
+func example_1() {
+	expect(_equal(restoreIpAddresses("25525511135"), []string{"255.255.11.135", "255.255.111.35"}))
+}
+
+func all_zeros() {
+	expect(_equal(restoreIpAddresses("0000"), []string{"0.0.0.0"}))
+}
+
+func example_2() {
+	expect(_equal(restoreIpAddresses("101023"), []string{"1.0.10.23", "1.0.102.3", "10.1.0.23", "10.10.2.3", "101.0.2.3"}))
+}
+
+func main() {
+	example_1()
+	all_zeros()
+	example_2()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/reverse-integer.go.out
+++ b/examples/leetcode-out/reverse-integer.go.out
@@ -1,0 +1,52 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func reverse(x int) int {
+	var sign int = 1
+	_ = sign
+	var n int = x
+	_ = n
+	if (n < 0) {
+		sign = -1
+		n = -n
+	}
+	var rev int = 0
+	_ = rev
+	for (n != 0) {
+		var digit int = (n % 10)
+		rev = ((rev * 10) + digit)
+		n = (n / 10)
+	}
+	rev = (rev * sign)
+	if ((rev < ((-2147483647 - 1))) || (rev > 2147483647)) {
+		return 0
+	}
+	return rev
+}
+
+func example_1() {
+	expect((reverse(123) == 321))
+}
+
+func example_2() {
+	expect((reverse(-123) == (-321)))
+}
+
+func example_3() {
+	expect((reverse(120) == 21))
+}
+
+func overflow() {
+	expect((reverse(1534236469) == 0))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	overflow()
+}
+

--- a/examples/leetcode-out/reverse-linked-list-ii.go.out
+++ b/examples/leetcode-out/reverse-linked-list-ii.go.out
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func reverseBetween(nums []int, left int, right int) []int {
+	if (left >= right) {
+		return nums
+	}
+	if ((left < 1) || (right > len(nums))) {
+		return nums
+	}
+	var result []int = nums
+	_ = result
+	var i int = (left - 1)
+	_ = i
+	var j int = (right - 1)
+	_ = j
+	for (i < j) {
+		var temp int = result[i]
+		result[i] = result[j]
+		result[j] = temp
+		i = (i + 1)
+		j = (j - 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(reverseBetween([]int{1, 2, 3, 4, 5}, 2, 4), []int{1, 4, 3, 2, 5}))
+}
+
+func left_equals_right() {
+	expect(_equal(reverseBetween([]int{1, 2, 3}, 2, 2), []int{1, 2, 3}))
+}
+
+func main() {
+	example_1()
+	left_equals_right()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/reverse-linked-list.go.out
+++ b/examples/leetcode-out/reverse-linked-list.go.out
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func reverseList(nums []int) []int {
+	var result []int = []int{}
+	_ = result
+	var i int = (len(nums) - 1)
+	_ = i
+	for (i >= 0) {
+		result = append(append([]int{}, result...), []int{nums[i]}...)
+		i = (i - 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(reverseList([]int{1, 2, 3, 4, 5}), []int{5, 4, 3, 2, 1}))
+}
+
+func example_2() {
+	expect(_equal(reverseList([]int{1, 2}), []int{2, 1}))
+}
+
+func single_element() {
+	expect(_equal(reverseList([]int{1}), []int{1}))
+}
+
+func empty_list() {
+	expect(_equal(reverseList([]int{}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+	empty_list()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/reverse-nodes-in-k-group.go.out
+++ b/examples/leetcode-out/reverse-nodes-in-k-group.go.out
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func reverseKGroup(nums []int, k int) []int {
+	var n int = len(nums)
+	if (k <= 1) {
+		return nums
+	}
+	var result []any = []any{}
+	_ = result
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var end int = (i + k)
+		if (end <= n) {
+			var j int = (end - 1)
+			_ = j
+			for (j >= i) {
+				result = append(append([]any{}, result...), _toAnySlice([]int{nums[j]})...)
+				j = (j - 1)
+			}
+		} else {
+			var j int = i
+			_ = j
+			for (j < n) {
+				result = append(append([]any{}, result...), _toAnySlice([]int{nums[j]})...)
+				j = (j + 1)
+			}
+		}
+		i = (i + k)
+	}
+	return _cast[[]int](result)
+}
+
+func example_1() {
+	expect(_equal(reverseKGroup([]int{1, 2, 3, 4, 5}, 2), []int{2, 1, 4, 3, 5}))
+}
+
+func example_2() {
+	expect(_equal(reverseKGroup([]int{1, 2, 3, 4, 5}, 3), []int{3, 2, 1, 4, 5}))
+}
+
+func k_equals_list_length() {
+	expect(_equal(reverseKGroup([]int{1, 2, 3, 4}, 4), []int{4, 3, 2, 1}))
+}
+
+func k_greater_than_length() {
+	expect(_equal(reverseKGroup([]int{1, 2, 3}, 5), []int{1, 2, 3}))
+}
+
+func k_is_one() {
+	expect(_equal(reverseKGroup([]int{1, 2, 3}, 1), []int{1, 2, 3}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	k_equals_list_length()
+	k_greater_than_length()
+	k_is_one()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/reverse-words-in-a-string-ii.go.out
+++ b/examples/leetcode-out/reverse-words-in-a-string-ii.go.out
@@ -1,0 +1,117 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func toList(s string) []string {
+	var out []string = []string{}
+	_ = out
+	for i := 0; i < len(s); i++ {
+		out = append(append([]string{}, out...), []string{_indexString(s, i)}...)
+	}
+	return out
+}
+
+func fromList(arr []string) string {
+	var out string = ""
+	_ = out
+	for _, ch := range arr {
+		out = out + ch
+	}
+	return out
+}
+
+func reverseWords(chars []string) []string {
+	var arr []string = chars
+	_ = arr
+	var left int = 0
+	_ = left
+	var right int = (len(arr) - 1)
+	_ = right
+	for (left < right) {
+		var temp string = arr[left]
+		arr[left] = arr[right]
+		arr[right] = temp
+		left = (left + 1)
+		right = (right - 1)
+	}
+	var start int = 0
+	_ = start
+	var i int = 0
+	_ = i
+	var n int = len(arr)
+	for (i <= n) {
+		if (i == n) {
+			var l int = start
+			_ = l
+			var r int = (i - 1)
+			_ = r
+			for (l < r) {
+				var t string = arr[l]
+				arr[l] = arr[r]
+				arr[r] = t
+				l = (l + 1)
+				r = (r - 1)
+			}
+		} else 		if (arr[i] == " ") {
+			var l int = start
+			_ = l
+			var r int = (i - 1)
+			_ = r
+			for (l < r) {
+				var t string = arr[l]
+				arr[l] = arr[r]
+				arr[r] = t
+				l = (l + 1)
+				r = (r - 1)
+			}
+			start = (i + 1)
+		}
+		i = (i + 1)
+	}
+	return arr
+}
+
+func example_1() {
+	var input []string = toList("the sky is blue")
+	var result []string = reverseWords(input)
+	expect((fromList(result) == "blue is sky the"))
+}
+
+func example_2() {
+	var input []string = toList("hello world")
+	var result []string = reverseWords(input)
+	expect((fromList(result) == "world hello"))
+}
+
+func single_word() {
+	var input []string = toList("hello")
+	var result []string = reverseWords(input)
+	expect((fromList(result) == "hello"))
+}
+
+func trailing_space() {
+	var input []string = toList("a b ")
+	var result []string = reverseWords(input)
+	expect((fromList(result) == " b a"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_word()
+	trailing_space()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/reverse-words-in-a-string.go.out
+++ b/examples/leetcode-out/reverse-words-in-a-string.go.out
@@ -1,0 +1,79 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func reverseWords(s string) string {
+	var i int = (len(s) - 1)
+	_ = i
+	var words []string = []string{}
+	_ = words
+	for (i >= 0) {
+		for ((i >= 0) && (_indexString(s, i) == " ")) {
+			i = (i - 1)
+		}
+		if (i < 0) {
+			break
+		}
+		var j int = i
+		_ = j
+		for ((j >= 0) && (_indexString(s, j) != " ")) {
+			j = (j - 1)
+		}
+		words = append(append([]string{}, words...), []string{string([]rune(s)[(j + 1):(i + 1)])}...)
+		i = j
+	}
+	var result string = ""
+	_ = result
+	var k int = 0
+	_ = k
+	for (k < len(words)) {
+		if (k > 0) {
+			result = result + " "
+		}
+		result = result + words[k]
+		k = (k + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect((reverseWords("the sky is blue") == "blue is sky the"))
+}
+
+func example_2() {
+	expect((reverseWords("  hello world  ") == "world hello"))
+}
+
+func example_3() {
+	expect((reverseWords("a good   example") == "example good a"))
+}
+
+func single_word() {
+	expect((reverseWords("hello") == "hello"))
+}
+
+func only_spaces() {
+	expect((reverseWords("    ") == ""))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_word()
+	only_spaces()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/rising-temperature.go.out
+++ b/examples/leetcode-out/rising-temperature.go.out
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Weather struct {
+	Id int `json:"id"`
+	RecordDate string `json:"recordDate"`
+	Temperature int `json:"temperature"`
+}
+
+func risingTemperature(records []Weather) []int {
+	var result []int = []int{}
+	_ = result
+	var i int = 1
+	_ = i
+	for (i < len(records)) {
+		var today Weather = records[i]
+		var yesterday Weather = records[(i - 1)]
+		if (today.Temperature > yesterday.Temperature) {
+			result = append(append([]int{}, result...), []int{today.Id}...)
+		}
+		i = (i + 1)
+	}
+	return result
+}
+
+func rising_days() {
+	expect(_equal(risingTemperature(sampleWeather), []int{2, 4}))
+}
+
+var sampleWeather []Weather = []Weather{Weather{Id: 1, RecordDate: "2015-01-01", Temperature: 10}, Weather{Id: 2, RecordDate: "2015-01-02", Temperature: 25}, Weather{Id: 3, RecordDate: "2015-01-03", Temperature: 20}, Weather{Id: 4, RecordDate: "2015-01-04", Temperature: 30}}
+func main() {
+	rising_days()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/roman-to-integer.go.out
+++ b/examples/leetcode-out/roman-to-integer.go.out
@@ -1,0 +1,70 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func romanToInt(s string) int {
+	var values map[string]int = map[string]int{"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+	var total int = 0
+	_ = total
+	var i int = 0
+	_ = i
+	var n int = len(s)
+	for (i < n) {
+		var curr int = values[_indexString(s, i)]
+		if ((i + 1) < n) {
+			var next int = values[_indexString(s, (i + 1))]
+			if (curr < next) {
+				total = ((total + next) - curr)
+				i = (i + 2)
+				continue
+			}
+		}
+		total = (total + curr)
+		i = (i + 1)
+	}
+	return total
+}
+
+func example_1() {
+	expect((romanToInt("III") == 3))
+}
+
+func example_2() {
+	expect((romanToInt("LVIII") == 58))
+}
+
+func example_3() {
+	expect((romanToInt("MCMXCIV") == 1994))
+}
+
+func subtractive() {
+	expect((romanToInt("IV") == 4))
+	expect((romanToInt("IX") == 9))
+}
+
+func tens() {
+	expect((romanToInt("XL") == 40))
+	expect((romanToInt("XC") == 90))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	subtractive()
+	tens()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/rotate-array.go.out
+++ b/examples/leetcode-out/rotate-array.go.out
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func rotate(nums []int, k int) []int {
+	var n int = len(nums)
+	if (n == 0) {
+		return nums
+	}
+	var r int = (k % n)
+	if (r == 0) {
+		return nums
+	}
+	return append(append([]int{}, nums[(n - r):len(nums)]...), nums[0:(n - r)]...)
+}
+
+func example_1() {
+	expect(_equal(rotate([]int{1, 2, 3, 4, 5, 6, 7}, 3), []int{5, 6, 7, 1, 2, 3, 4}))
+}
+
+func example_2() {
+	expect(_equal(rotate([]int{-1, -100, 3, 99}, 2), []int{3, 99, -1, -100}))
+}
+
+func k_greater_than_length() {
+	expect(_equal(rotate([]int{1, 2}, 5), []int{2, 1}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	k_greater_than_length()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/rotate-image.go.out
+++ b/examples/leetcode-out/rotate-image.go.out
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func rotate(matrix [][]int) [][]int {
+	var n int = len(matrix)
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var j int = i
+		_ = j
+		for (j < n) {
+			var temp int = matrix[i][j]
+			matrix[i][j] = matrix[j][i]
+			matrix[j][i] = temp
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	i = 0
+	for (i < n) {
+		var left int = 0
+		_ = left
+		var right int = (n - 1)
+		_ = right
+		for (left < right) {
+			var tmp int = matrix[i][left]
+			matrix[i][left] = matrix[i][right]
+			matrix[i][right] = tmp
+			left = (left + 1)
+			right = (right - 1)
+		}
+		i = (i + 1)
+	}
+	return matrix
+}
+
+func example_1() {
+	var m [][]int = [][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}
+	_ = m
+	rotate(m)
+	expect(_equal(m, [][]int{[]int{7, 4, 1}, []int{8, 5, 2}, []int{9, 6, 3}}))
+}
+
+func example_2() {
+	var m [][]int = [][]int{[]int{5, 1, 9, 11}, []int{2, 4, 8, 10}, []int{13, 3, 6, 7}, []int{15, 14, 12, 16}}
+	_ = m
+	rotate(m)
+	expect(_equal(m, [][]int{[]int{15, 13, 2, 5}, []int{14, 3, 4, 1}, []int{12, 6, 8, 9}, []int{16, 7, 10, 11}}))
+}
+
+func single_element() {
+	var m [][]int = [][]int{[]int{1}}
+	_ = m
+	rotate(m)
+	expect(_equal(m, [][]int{[]int{1}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/rotate-list.go.out
+++ b/examples/leetcode-out/rotate-list.go.out
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func rotateRight(nums []int, k int) []int {
+	var n int = len(nums)
+	if (n == 0) {
+		return nums
+	}
+	var r int = (k % n)
+	if (r == 0) {
+		return nums
+	}
+	var result []int = []int{}
+	_ = result
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var idx int = ((((n - r) + i)) % n)
+		result = append(append([]int{}, result...), []int{nums[idx]}...)
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(rotateRight([]int{1, 2, 3, 4, 5}, 2), []int{4, 5, 1, 2, 3}))
+}
+
+func example_2() {
+	expect(_equal(rotateRight([]int{0, 1, 2}, 4), []int{2, 0, 1}))
+}
+
+func k_is_zero() {
+	expect(_equal(rotateRight([]int{1, 2, 3}, 0), []int{1, 2, 3}))
+}
+
+func empty_list() {
+	expect(_equal(rotateRight([]int{}, 5), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	k_is_zero()
+	empty_list()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/search-a-2d-matrix-ii.go.out
+++ b/examples/leetcode-out/search-a-2d-matrix-ii.go.out
@@ -1,0 +1,52 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func searchMatrix(matrix [][]int, target int) bool {
+	var m int = len(matrix)
+	if (m == 0) {
+		return false
+	}
+	var n int = len(matrix[0])
+	var row int = 0
+	_ = row
+	var col int = (n - 1)
+	_ = col
+	for ((row < m) && (col >= 0)) {
+		var value int = matrix[row][col]
+		if (value == target) {
+			return true
+		} else 		if (value > target) {
+			col = (col - 1)
+		} else {
+			row = (row + 1)
+		}
+	}
+	return false
+}
+
+func example_1() {
+	expect((searchMatrix([][]int{[]int{1, 4, 7, 11, 15}, []int{2, 5, 8, 12, 19}, []int{3, 6, 9, 16, 22}, []int{10, 13, 14, 17, 24}, []int{18, 21, 23, 26, 30}}, 5) == true))
+}
+
+func example_2() {
+	expect((searchMatrix([][]int{[]int{1, 4, 7, 11, 15}, []int{2, 5, 8, 12, 19}, []int{3, 6, 9, 16, 22}, []int{10, 13, 14, 17, 24}, []int{18, 21, 23, 26, 30}}, 20) == false))
+}
+
+func single_element_found() {
+	expect((searchMatrix([][]int{[]int{5}}, 5) == true))
+}
+
+func single_element_missing() {
+	expect((searchMatrix([][]int{[]int{5}}, 3) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element_found()
+	single_element_missing()
+}
+

--- a/examples/leetcode-out/search-a-2d-matrix.go.out
+++ b/examples/leetcode-out/search-a-2d-matrix.go.out
@@ -1,0 +1,55 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func searchMatrix(matrix [][]int, target int) bool {
+	var m int = len(matrix)
+	if (m == 0) {
+		return false
+	}
+	var n int = len(matrix[0])
+	var left int = 0
+	_ = left
+	var right int = ((m * n) - 1)
+	_ = right
+	for (left <= right) {
+		var mid int = (left + (((right - left)) / 2))
+		var row int = (mid / n)
+		var col int = (mid % n)
+		var value int = matrix[row][col]
+		if (value == target) {
+			return true
+		} else 		if (value < target) {
+			left = (mid + 1)
+		} else {
+			right = (mid - 1)
+		}
+	}
+	return false
+}
+
+func example_1() {
+	expect((searchMatrix([][]int{[]int{1, 3, 5, 7}, []int{10, 11, 16, 20}, []int{23, 30, 34, 60}}, 3) == true))
+}
+
+func example_2() {
+	expect((searchMatrix([][]int{[]int{1, 3, 5, 7}, []int{10, 11, 16, 20}, []int{23, 30, 34, 60}}, 13) == false))
+}
+
+func single_row() {
+	expect((searchMatrix([][]int{[]int{1, 2, 3, 4}}, 3) == true))
+}
+
+func not_found() {
+	expect((searchMatrix([][]int{[]int{5}}, 1) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_row()
+	not_found()
+}
+

--- a/examples/leetcode-out/search-in-rotated-sorted-array-ii.go.out
+++ b/examples/leetcode-out/search-in-rotated-sorted-array-ii.go.out
@@ -1,0 +1,63 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func search(nums []int, target int) bool {
+	var left int = 0
+	_ = left
+	var right int = (len(nums) - 1)
+	_ = right
+	for (left <= right) {
+		var mid int = (((left + right)) / 2)
+		if (nums[mid] == target) {
+			return true
+		}
+		if (nums[left] == nums[mid]) {
+			left = (left + 1)
+		} else 		if (nums[left] < nums[mid]) {
+			if ((nums[left] <= target) && (target < nums[mid])) {
+				right = (mid - 1)
+			} else {
+				left = (mid + 1)
+			}
+		} else {
+			if ((nums[mid] < target) && (target <= nums[right])) {
+				left = (mid + 1)
+			} else {
+				right = (mid - 1)
+			}
+		}
+	}
+	return false
+}
+
+func example_1() {
+	expect((search([]int{2, 5, 6, 0, 0, 1, 2}, 0) == true))
+}
+
+func example_2() {
+	expect((search([]int{2, 5, 6, 0, 0, 1, 2}, 3) == false))
+}
+
+func all_duplicates() {
+	expect((search([]int{1, 1, 1, 1, 1}, 2) == false))
+}
+
+func single_element() {
+	expect((search([]int{1}, 1) == true))
+}
+
+func empty_array() {
+	expect((search([]int{}, 5) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	all_duplicates()
+	single_element()
+	empty_array()
+}
+

--- a/examples/leetcode-out/search-in-rotated-sorted-array.go.out
+++ b/examples/leetcode-out/search-in-rotated-sorted-array.go.out
@@ -1,0 +1,61 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func search(nums []int, target int) int {
+	var left int = 0
+	_ = left
+	var right int = (len(nums) - 1)
+	_ = right
+	for (left <= right) {
+		var mid int = (((left + right)) / 2)
+		if (nums[mid] == target) {
+			return mid
+		}
+		if (nums[left] <= nums[mid]) {
+			if ((nums[left] <= target) && (target < nums[mid])) {
+				right = (mid - 1)
+			} else {
+				left = (mid + 1)
+			}
+		} else {
+			if ((nums[mid] < target) && (target <= nums[right])) {
+				left = (mid + 1)
+			} else {
+				right = (mid - 1)
+			}
+		}
+	}
+	return -1
+}
+
+func example_1() {
+	expect((search([]int{4, 5, 6, 7, 0, 1, 2}, 0) == 4))
+}
+
+func example_2() {
+	expect((search([]int{4, 5, 6, 7, 0, 1, 2}, 3) == (-1)))
+}
+
+func example_3() {
+	expect((search([]int{1}, 0) == (-1)))
+}
+
+func single_element_found() {
+	expect((search([]int{1}, 1) == 0))
+}
+
+func two_elements() {
+	expect((search([]int{3, 1}, 1) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	single_element_found()
+	two_elements()
+}
+

--- a/examples/leetcode-out/search-insert-position.go.out
+++ b/examples/leetcode-out/search-insert-position.go.out
@@ -1,0 +1,56 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func searchInsert(nums []int, target int) int {
+	var left int = 0
+	_ = left
+	var right int = len(nums)
+	_ = right
+	for (left < right) {
+		var mid int = (((left + right)) / 2)
+		var value int = nums[mid]
+		if (value < target) {
+			left = (mid + 1)
+		} else {
+			right = mid
+		}
+	}
+	return left
+}
+
+func example_1() {
+	expect((searchInsert([]int{1, 3, 5, 6}, 5) == 2))
+}
+
+func example_2() {
+	expect((searchInsert([]int{1, 3, 5, 6}, 2) == 1))
+}
+
+func example_3() {
+	expect((searchInsert([]int{1, 3, 5, 6}, 7) == 4))
+}
+
+func example_4() {
+	expect((searchInsert([]int{1, 3, 5, 6}, 0) == 0))
+}
+
+func single_element_greater() {
+	expect((searchInsert([]int{2}, 1) == 0))
+}
+
+func single_element_smaller() {
+	expect((searchInsert([]int{2}, 3) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	example_4()
+	single_element_greater()
+	single_element_smaller()
+}
+

--- a/examples/leetcode-out/second-highest-salary.go.out
+++ b/examples/leetcode-out/second-highest-salary.go.out
@@ -1,0 +1,59 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type Employee struct {
+	Id int `json:"id"`
+	Salary int `json:"salary"`
+}
+
+func secondHighestSalary(employees []Employee) int {
+	if (len(employees) < 2) {
+		return 0
+	}
+	var firstEmp Employee = employees[0]
+	var first int = firstEmp.Salary
+	_ = first
+	var second int = first
+	_ = second
+	var i int = 1
+	_ = i
+	for (i < len(employees)) {
+		var emp Employee = employees[i]
+		var s int = emp.Salary
+		if (s > first) {
+			second = first
+			first = s
+		} else 		if ((s != first) && (((second == first) || (s > second)))) {
+			second = s
+		}
+		i = (i + 1)
+	}
+	if (second == first) {
+		return 0
+	}
+	return second
+}
+
+func example() {
+	expect((secondHighestSalary(employees) == 200))
+}
+
+func no_second_salary() {
+	expect((secondHighestSalary([]Employee{Employee{Id: 1, Salary: 100}}) == 0))
+}
+
+func duplicates() {
+	var list []Employee = []Employee{Employee{Id: 1, Salary: 100}, Employee{Id: 2, Salary: 100}, Employee{Id: 3, Salary: 100}}
+	expect((secondHighestSalary(list) == 0))
+}
+
+var employees []Employee = []Employee{Employee{Id: 1, Salary: 100}, Employee{Id: 2, Salary: 200}, Employee{Id: 3, Salary: 300}, Employee{Id: 4, Salary: 200}}
+func main() {
+	example()
+	no_second_salary()
+	duplicates()
+}
+

--- a/examples/leetcode-out/set-matrix-zeroes.go.out
+++ b/examples/leetcode-out/set-matrix-zeroes.go.out
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func setZeroes(matrix [][]int) [][]int {
+	var rows int = len(matrix)
+	if (rows == 0) {
+		return matrix
+	}
+	var cols int = len(matrix[0])
+	var zeroRows []bool = []bool{}
+	_ = zeroRows
+	var zeroCols []bool = []bool{}
+	_ = zeroCols
+	var r int = 0
+	_ = r
+	for (r < rows) {
+		zeroRows = append(append([]bool{}, zeroRows...), []bool{false}...)
+		r = (r + 1)
+	}
+	var c int = 0
+	_ = c
+	for (c < cols) {
+		zeroCols = append(append([]bool{}, zeroCols...), []bool{false}...)
+		c = (c + 1)
+	}
+	var i int = 0
+	_ = i
+	for (i < rows) {
+		var j int = 0
+		_ = j
+		for (j < cols) {
+			if (matrix[i][j] == 0) {
+				zeroRows[i] = true
+				zeroCols[j] = true
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	i = 0
+	for (i < rows) {
+		var j int = 0
+		_ = j
+		for (j < cols) {
+			if (zeroRows[i] || zeroCols[j]) {
+				matrix[i][j] = 0
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return matrix
+}
+
+func example_1() {
+	var m [][]int = [][]int{[]int{1, 1, 1}, []int{1, 0, 1}, []int{1, 1, 1}}
+	_ = m
+	setZeroes(m)
+	expect(_equal(m, [][]int{[]int{1, 0, 1}, []int{0, 0, 0}, []int{1, 0, 1}}))
+}
+
+func example_2() {
+	var m [][]int = [][]int{[]int{0, 1, 2, 0}, []int{3, 4, 5, 2}, []int{1, 3, 1, 5}}
+	_ = m
+	setZeroes(m)
+	expect(_equal(m, [][]int{[]int{0, 0, 0, 0}, []int{0, 4, 5, 0}, []int{0, 3, 1, 0}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/shortest-palindrome.go.out
+++ b/examples/leetcode-out/shortest-palindrome.go.out
@@ -1,0 +1,82 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isPalindrome(s string) bool {
+	var i int = 0
+	_ = i
+	var j int = (len(s) - 1)
+	_ = j
+	for (i < j) {
+		if (_indexString(s, i) != _indexString(s, j)) {
+			return false
+		}
+		i = (i + 1)
+		j = (j - 1)
+	}
+	return true
+}
+
+func shortestPalindrome(s string) string {
+	var n int = len(s)
+	var i int = n
+	_ = i
+	for (i > 0) {
+		if isPalindrome(string([]rune(s)[0:i])) {
+			var suffix string = string([]rune(s)[i:n])
+			var rev string = ""
+			_ = rev
+			var k int = (len(suffix) - 1)
+			_ = k
+			for (k >= 0) {
+				rev = rev + _indexString(suffix, k)
+				k = (k - 1)
+			}
+			return rev + s
+		}
+		i = (i - 1)
+	}
+	return s
+}
+
+func example_1() {
+	expect((shortestPalindrome("aacecaaa") == "aaacecaaa"))
+}
+
+func example_2() {
+	expect((shortestPalindrome("abcd") == "dcbabcd"))
+}
+
+func empty() {
+	expect((shortestPalindrome("") == ""))
+}
+
+func already_palindrome() {
+	expect((shortestPalindrome("aba") == "aba"))
+}
+
+func single_char() {
+	expect((shortestPalindrome("a") == "a"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty()
+	already_palindrome()
+	single_char()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/shortest-word-distance-ii.go.out
+++ b/examples/leetcode-out/shortest-word-distance-ii.go.out
@@ -1,0 +1,84 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type WordDistance struct {
+	Index map[string][]int `json:"index"`
+}
+
+func newWordDistance(words []string) WordDistance {
+	var m map[string][]int = map[string][]int{}
+	_ = m
+	var i int = 0
+	_ = i
+	for (i < len(words)) {
+		var w string = words[i]
+		var lst []int = []int{}
+		_ = lst
+		_tmp0 := w
+		_tmp1 := m
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			lst = m[w]
+		}
+		lst = append(append([]int{}, lst...), []int{i}...)
+		m[w] = lst
+		i = (i + 1)
+	}
+	return WordDistance{Index: m}
+}
+
+func min(a int, b int) int {
+	if (a < b) {
+		return a
+	}
+	return b
+}
+
+func shortest(wd WordDistance, word1 string, word2 string) int {
+	var list1 []int = wd.Index[word1]
+	var list2 []int = wd.Index[word2]
+	var i int = 0
+	_ = i
+	var j int = 0
+	_ = j
+	var best int = 1000000000
+	_ = best
+	for ((i < len(list1)) && (j < len(list2))) {
+		var a int = list1[i]
+		var b int = list2[j]
+		var diff int = (a - b)
+		_ = diff
+		if (diff < 0) {
+			diff = -diff
+		}
+		best = min(best, diff)
+		if (a < b) {
+			i = (i + 1)
+		} else {
+			j = (j + 1)
+		}
+	}
+	return best
+}
+
+func example() {
+	var words []string = []string{"practice", "makes", "perfect", "coding", "makes"}
+	var wd WordDistance = newWordDistance(words)
+	expect((shortest(wd, "coding", "practice") == 3))
+	expect((shortest(wd, "makes", "coding") == 1))
+}
+
+func same_word_many_times() {
+	var words []string = []string{"a", "a", "b", "a"}
+	var wd WordDistance = newWordDistance(words)
+	expect((shortest(wd, "a", "b") == 1))
+}
+
+func main() {
+	example()
+	same_word_many_times()
+}
+

--- a/examples/leetcode-out/shortest-word-distance-iii.go.out
+++ b/examples/leetcode-out/shortest-word-distance-iii.go.out
@@ -1,0 +1,75 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func abs(x int) int {
+	if (x < 0) {
+		return -x
+	} else {
+		return x
+	}
+}
+
+func shortestWordDistance(words []string, word1 string, word2 string) int {
+	var index1 int = (-1)
+	_ = index1
+	var index2 int = (-1)
+	_ = index2
+	var minDist int = len(words)
+	_ = minDist
+	var i int = 0
+	_ = i
+	for (i < len(words)) {
+		var w string = words[i]
+		if (w == word1) {
+			if (word1 == word2) {
+				if (index1 != (-1)) {
+					var d int = (i - index1)
+					if (d < minDist) {
+						minDist = d
+					}
+				}
+				index1 = i
+			} else {
+				index1 = i
+				if (index2 != (-1)) {
+					var d int = abs((index1 - index2))
+					if (d < minDist) {
+						minDist = d
+					}
+				}
+			}
+		} else 		if (w == word2) {
+			index2 = i
+			if (index1 != (-1)) {
+				var d int = abs((index1 - index2))
+				if (d < minDist) {
+					minDist = d
+				}
+			}
+		}
+		i = (i + 1)
+	}
+	return minDist
+}
+
+func example_1() {
+	expect((shortestWordDistance([]string{"practice", "makes", "perfect", "coding", "makes"}, "makes", "coding") == 1))
+}
+
+func example_2() {
+	expect((shortestWordDistance([]string{"practice", "makes", "perfect", "coding", "makes"}, "makes", "makes") == 3))
+}
+
+func example_3() {
+	expect((shortestWordDistance([]string{"a", "a", "b", "b"}, "a", "b") == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/shortest-word-distance.go.out
+++ b/examples/leetcode-out/shortest-word-distance.go.out
@@ -1,0 +1,62 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func abs(x int) int {
+	if (x < 0) {
+		return -x
+	} else {
+		return x
+	}
+}
+
+func shortestDistance(words []string, word1 string, word2 string) int {
+	var index1 int = -1
+	_ = index1
+	var index2 int = -1
+	_ = index2
+	var result int = len(words)
+	_ = result
+	var i int = 0
+	_ = i
+	for (i < len(words)) {
+		if (words[i] == word1) {
+			index1 = i
+		}
+		if (words[i] == word2) {
+			index2 = i
+		}
+		if ((index1 >= 0) && (index2 >= 0)) {
+			var dist int = abs((index1 - index2))
+			if (dist < result) {
+				result = dist
+			}
+		}
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	var words []string = []string{"practice", "makes", "perfect", "coding", "makes"}
+	expect((shortestDistance(words, "coding", "practice") == 3))
+}
+
+func example_2() {
+	var words []string = []string{"practice", "makes", "perfect", "coding", "makes"}
+	expect((shortestDistance(words, "makes", "coding") == 1))
+}
+
+func same_adjacent() {
+	var words []string = []string{"a", "b", "a"}
+	expect((shortestDistance(words, "a", "b") == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	same_adjacent()
+}
+

--- a/examples/leetcode-out/simplify-path.go.out
+++ b/examples/leetcode-out/simplify-path.go.out
@@ -1,0 +1,96 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func simplifyPath(path string) string {
+	var stack []string = []string{}
+	_ = stack
+	var part string = ""
+	_ = part
+	var i int = 0
+	_ = i
+	var n int = len(path)
+	for (i <= n) {
+		if (i == n) {
+			if (part == "..") {
+				if (len(stack) > 0) {
+					stack = stack[0:(len(stack) - 1)]
+				}
+			} else 			if ((part != "") && (part != ".")) {
+				stack = append(append([]string{}, stack...), []string{part}...)
+			}
+			part = ""
+		} else 		if (_indexString(path, i) == "/") {
+			if (part == "..") {
+				if (len(stack) > 0) {
+					stack = stack[0:(len(stack) - 1)]
+				}
+			} else 			if ((part != "") && (part != ".")) {
+				stack = append(append([]string{}, stack...), []string{part}...)
+			}
+			part = ""
+		} else {
+			part = part + _indexString(path, i)
+		}
+		i = (i + 1)
+	}
+	var result string = "/"
+	_ = result
+	var j int = 0
+	_ = j
+	for (j < len(stack)) {
+		result = result + stack[j]
+		if (j < (len(stack) - 1)) {
+			result = result + "/"
+		}
+		j = (j + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect((simplifyPath("/home/") == "/home"))
+}
+
+func example_2() {
+	expect((simplifyPath("/../") == "/"))
+}
+
+func example_3() {
+	expect((simplifyPath("/home//foo/") == "/home/foo"))
+}
+
+func complex() {
+	expect((simplifyPath("/a/./b/../../c/") == "/c"))
+}
+
+func dots() {
+	expect((simplifyPath("/a/../../b/../c//.//") == "/c"))
+}
+
+func long() {
+	expect((simplifyPath("/a//b////c/d//././/..") == "/a/b/c"))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	complex()
+	dots()
+	long()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/single-number-ii.go.out
+++ b/examples/leetcode-out/single-number-ii.go.out
@@ -1,0 +1,45 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func singleNumber(nums []int) int {
+	var counts map[int]int = map[int]int{}
+	_ = counts
+	for _, n := range nums {
+		_tmp0 := n
+		_tmp1 := counts
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			counts[n] = (counts[n] + 1)
+		} else {
+			counts[n] = 1
+		}
+	}
+	for _, n := range nums {
+		if (counts[n] == 1) {
+			return n
+		}
+	}
+	return 0
+}
+
+func example_1() {
+	expect((singleNumber([]int{2, 2, 3, 2}) == 3))
+}
+
+func example_2() {
+	expect((singleNumber([]int{0, 1, 0, 1, 0, 1, 99}) == 99))
+}
+
+func negative_numbers() {
+	expect((singleNumber([]int{-2, -2, 1, -2}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	negative_numbers()
+}
+

--- a/examples/leetcode-out/single-number.go.out
+++ b/examples/leetcode-out/single-number.go.out
@@ -1,0 +1,50 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func singleNumber(nums []int) int {
+	var counts map[int]int = map[int]int{}
+	_ = counts
+	for _, n := range nums {
+		_tmp0 := n
+		_tmp1 := counts
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			counts[n] = (counts[n] + 1)
+		} else {
+			counts[n] = 1
+		}
+	}
+	for _, n := range nums {
+		if (counts[n] == 1) {
+			return n
+		}
+	}
+	return 0
+}
+
+func example_1() {
+	expect((singleNumber([]int{2, 2, 1}) == 1))
+}
+
+func example_2() {
+	expect((singleNumber([]int{4, 1, 2, 1, 2}) == 4))
+}
+
+func example_3() {
+	expect((singleNumber([]int{1}) == 1))
+}
+
+func with_negatives() {
+	expect((singleNumber([]int{4, -1, 2, -1, 2}) == 4))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	with_negatives()
+}
+

--- a/examples/leetcode-out/sliding-window-maximum.go.out
+++ b/examples/leetcode-out/sliding-window-maximum.go.out
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func maxSlidingWindow(nums []int, k int) []int {
+	var n int = len(nums)
+	if (n == 0) {
+		return _cast[[]int]([]any{})
+	}
+	var result []int = []int{}
+	_ = result
+	var deque []int = []int{}
+	_ = deque
+	var i int = 0
+	_ = i
+	for (i < n) {
+		for (len(deque) > 0) {
+			var last int = deque[(len(deque) - 1)]
+			if (nums[last] < nums[i]) {
+				deque = deque[0:(len(deque) - 1)]
+			} else {
+				break
+			}
+		}
+		deque = append(append([]int{}, deque...), []int{i}...)
+		if (len(deque) > 0) {
+			if (deque[0] <= (i - k)) {
+				deque = deque[1:len(deque)]
+			}
+		}
+		if ((i + 1) >= k) {
+			result = append(append([]int{}, result...), []int{nums[deque[0]]}...)
+		}
+		i = (i + 1)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(maxSlidingWindow([]int{1, 3, -1, -3, 5, 3, 6, 7}, 3), []int{3, 3, 5, 5, 6, 7}))
+}
+
+func example_2() {
+	expect(_equal(maxSlidingWindow([]int{1}, 1), []int{1}))
+}
+
+func k_equals_array_length() {
+	expect(_equal(maxSlidingWindow([]int{2, 1}, 2), []int{2}))
+}
+
+func all_decreasing() {
+	expect(_equal(maxSlidingWindow([]int{9, 8, 7, 6, 5}, 2), []int{9, 8, 7, 6}))
+}
+
+func window_size_1() {
+	expect(_equal(maxSlidingWindow([]int{4, 2}, 1), []int{4, 2}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	k_equals_array_length()
+	all_decreasing()
+	window_size_1()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/sort-colors.go.out
+++ b/examples/leetcode-out/sort-colors.go.out
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func sortColors(nums []int) []int {
+	var low int = 0
+	_ = low
+	var mid int = 0
+	_ = mid
+	var high int = (len(nums) - 1)
+	_ = high
+	for (mid <= high) {
+		if (nums[mid] == 0) {
+			var temp int = nums[low]
+			nums[low] = nums[mid]
+			nums[mid] = temp
+			low = (low + 1)
+			mid = (mid + 1)
+		} else 		if (nums[mid] == 1) {
+			mid = (mid + 1)
+		} else {
+			var temp int = nums[mid]
+			nums[mid] = nums[high]
+			nums[high] = temp
+			high = (high - 1)
+		}
+	}
+	return nums
+}
+
+func example_1() {
+	expect(_equal(sortColors([]int{2, 0, 2, 1, 1, 0}), []int{0, 0, 1, 1, 2, 2}))
+}
+
+func example_2() {
+	expect(_equal(sortColors([]int{2, 0, 1}), []int{0, 1, 2}))
+}
+
+func single_zero() {
+	expect(_equal(sortColors([]int{0}), []int{0}))
+}
+
+func single_one() {
+	expect(_equal(sortColors([]int{1}), []int{1}))
+}
+
+func single_two() {
+	expect(_equal(sortColors([]int{2}), []int{2}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_zero()
+	single_one()
+	single_two()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/sort-list.go.out
+++ b/examples/leetcode-out/sort-list.go.out
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func mergeSorted(a []int, b []int) []int {
+	var i int = 0
+	_ = i
+	var j int = 0
+	_ = j
+	var result []int = []int{}
+	_ = result
+	for ((i < len(a)) && (j < len(b))) {
+		if (a[i] <= b[j]) {
+			result = append(append([]int{}, result...), []int{a[i]}...)
+			i = (i + 1)
+		} else {
+			result = append(append([]int{}, result...), []int{b[j]}...)
+			j = (j + 1)
+		}
+	}
+	for (i < len(a)) {
+		result = append(append([]int{}, result...), []int{a[i]}...)
+		i = (i + 1)
+	}
+	for (j < len(b)) {
+		result = append(append([]int{}, result...), []int{b[j]}...)
+		j = (j + 1)
+	}
+	return result
+}
+
+func sortList(nums []int) []int {
+	if (len(nums) <= 1) {
+		return nums
+	}
+	var mid int = (len(nums) / 2)
+	var left []int = sortList(nums[0:mid])
+	var right []int = sortList(nums[mid:len(nums)])
+	return mergeSorted(left, right)
+}
+
+func example_1() {
+	expect(_equal(sortList([]int{4, 2, 1, 3}), []int{1, 2, 3, 4}))
+}
+
+func example_2() {
+	expect(_equal(sortList([]int{-1, 5, 3, 4, 0}), []int{-1, 0, 3, 4, 5}))
+}
+
+func single() {
+	expect(_equal(sortList([]int{1}), []int{1}))
+}
+
+func empty() {
+	expect(_equal(sortList([]int{}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single()
+	empty()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/spiral-matrix-ii.go.out
+++ b/examples/leetcode-out/spiral-matrix-ii.go.out
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func generateMatrix(n int) [][]int {
+	var matrix [][]int = [][]int{}
+	_ = matrix
+	var i int = 0
+	_ = i
+	for (i < n) {
+		var row []int = []int{}
+		_ = row
+		var j int = 0
+		_ = j
+		for (j < n) {
+			row = append(append([]int{}, row...), []int{0}...)
+			j = (j + 1)
+		}
+		matrix = append(append([][]int{}, matrix...), [][]int{row}...)
+		i = (i + 1)
+	}
+	var left int = 0
+	_ = left
+	var right int = (n - 1)
+	_ = right
+	var top int = 0
+	_ = top
+	var bottom int = (n - 1)
+	_ = bottom
+	var num int = 1
+	_ = num
+	for ((left <= right) && (top <= bottom)) {
+		for j := left; j < (right + 1); j++ {
+			matrix[top][j] = num
+			num = (num + 1)
+		}
+		top = (top + 1)
+		for i := top; i < (bottom + 1); i++ {
+			matrix[i][right] = num
+			num = (num + 1)
+		}
+		right = (right - 1)
+		if (top <= bottom) {
+			var j int = right
+			_ = j
+			for (j >= left) {
+				matrix[bottom][j] = num
+				num = (num + 1)
+				j = (j - 1)
+			}
+			bottom = (bottom - 1)
+		}
+		if (left <= right) {
+			var i int = bottom
+			_ = i
+			for (i >= top) {
+				matrix[i][left] = num
+				num = (num + 1)
+				i = (i - 1)
+			}
+			left = (left + 1)
+		}
+	}
+	return matrix
+}
+
+func example_1() {
+	expect(_equal(generateMatrix(3), [][]int{[]int{1, 2, 3}, []int{8, 9, 4}, []int{7, 6, 5}}))
+}
+
+func example_2() {
+	expect(_equal(generateMatrix(1), [][]int{[]int{1}}))
+}
+
+func n___4() {
+	expect(_equal(generateMatrix(4), [][]int{[]int{1, 2, 3, 4}, []int{12, 13, 14, 5}, []int{11, 16, 15, 6}, []int{10, 9, 8, 7}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	n___4()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/spiral-matrix.go.out
+++ b/examples/leetcode-out/spiral-matrix.go.out
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func spiralOrder(matrix [][]int) []int {
+	var rows int = len(matrix)
+	if (rows == 0) {
+		return _cast[[]int]([]any{})
+	}
+	var cols int = len(matrix[0])
+	var top int = 0
+	_ = top
+	var bottom int = (rows - 1)
+	_ = bottom
+	var left int = 0
+	_ = left
+	var right int = (cols - 1)
+	_ = right
+	var result []int = []int{}
+	_ = result
+	for ((top <= bottom) && (left <= right)) {
+		var j int = left
+		_ = j
+		for (j <= right) {
+			result = append(append([]int{}, result...), []int{matrix[top][j]}...)
+			j = (j + 1)
+		}
+		top = (top + 1)
+		j = top
+		for (j <= bottom) {
+			result = append(append([]int{}, result...), []int{matrix[j][right]}...)
+			j = (j + 1)
+		}
+		right = (right - 1)
+		if (top <= bottom) {
+			j = right
+			for (j >= left) {
+				result = append(append([]int{}, result...), []int{matrix[bottom][j]}...)
+				j = (j - 1)
+			}
+			bottom = (bottom - 1)
+		}
+		if (left <= right) {
+			j = bottom
+			for (j >= top) {
+				result = append(append([]int{}, result...), []int{matrix[j][left]}...)
+				j = (j - 1)
+			}
+			left = (left + 1)
+		}
+	}
+	return result
+}
+
+func example_1() {
+	var m [][]int = [][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}
+	_ = m
+	expect(_equal(spiralOrder(m), []int{1, 2, 3, 6, 9, 8, 7, 4, 5}))
+}
+
+func example_2() {
+	var m [][]int = [][]int{[]int{1, 2, 3, 4}, []int{5, 6, 7, 8}, []int{9, 10, 11, 12}}
+	_ = m
+	expect(_equal(spiralOrder(m), []int{1, 2, 3, 4, 8, 12, 11, 10, 9, 5, 6, 7}))
+}
+
+func single_row() {
+	var m [][]int = [][]int{[]int{1, 2, 3}}
+	_ = m
+	expect(_equal(spiralOrder(m), []int{1, 2, 3}))
+}
+
+func single_column() {
+	var m [][]int = [][]int{[]int{1}, []int{2}, []int{3}}
+	_ = m
+	expect(_equal(spiralOrder(m), []int{1, 2, 3}))
+}
+
+func empty() {
+	expect(_equal(spiralOrder([][]int{}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_row()
+	single_column()
+	empty()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/sqrtx.go.out
+++ b/examples/leetcode-out/sqrtx.go.out
@@ -1,0 +1,54 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func mySqrt(x int) int {
+	if (x < 2) {
+		return x
+	}
+	var left int = 1
+	_ = left
+	var right int = (x / 2)
+	_ = right
+	var ans int = 0
+	_ = ans
+	for (left <= right) {
+		var mid int = (left + (((right - left)) / 2))
+		var sq int = (mid * mid)
+		if (sq == x) {
+			return mid
+		} else 		if (sq < x) {
+			left = (mid + 1)
+			ans = mid
+		} else {
+			right = (mid - 1)
+		}
+	}
+	return ans
+}
+
+func example_1() {
+	expect((mySqrt(4) == 2))
+}
+
+func example_2() {
+	expect((mySqrt(8) == 2))
+}
+
+func zero() {
+	expect((mySqrt(0) == 0))
+}
+
+func large() {
+	expect((mySqrt(2147395599) == 46339))
+}
+
+func main() {
+	example_1()
+	example_2()
+	zero()
+	large()
+}
+

--- a/examples/leetcode-out/string-to-integer-atoi.go.out
+++ b/examples/leetcode-out/string-to-integer-atoi.go.out
@@ -1,0 +1,85 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func myAtoi(s string) int {
+	var i int = 0
+	_ = i
+	var n int = len(s)
+	for ((i < n) && (_indexString(s, i) == " ")) {
+		i = (i + 1)
+	}
+	var sign int = 1
+	_ = sign
+	if ((i < n) && (((_indexString(s, i) == "+") || (_indexString(s, i) == "-")))) {
+		if (_indexString(s, i) == "-") {
+			sign = -1
+		}
+		i = (i + 1)
+	}
+	var digits map[string]int = map[string]int{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+	var result int = 0
+	_ = result
+	for (i < n) {
+		var ch string = _indexString(s, i)
+		_tmp0 := ch
+		_tmp1 := digits
+		_, _tmp2 := _tmp1[_tmp0]
+		if !(_tmp2) {
+			break
+		}
+		var d int = digits[ch]
+		result = ((result * 10) + d)
+		i = (i + 1)
+	}
+	result = (result * sign)
+	if (result > 2147483647) {
+		return 2147483647
+	}
+	if (result < (-2147483648)) {
+		return -2147483648
+	}
+	return result
+}
+
+func example_1() {
+	expect((myAtoi("42") == 42))
+}
+
+func example_2() {
+	expect((myAtoi("   -42") == (-42)))
+}
+
+func example_3() {
+	expect((myAtoi("4193 with words") == 4193))
+}
+
+func example_4() {
+	expect((myAtoi("words and 987") == 0))
+}
+
+func example_5() {
+	expect((myAtoi("-91283472332") == (-2147483648)))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	example_4()
+	example_5()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/strobogrammatic-number-ii.go.out
+++ b/examples/leetcode-out/strobogrammatic-number-ii.go.out
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findStrobogrammatic(n int) []string {
+	var build func(int, int) []string
+	build = func(len int, total int) []string {
+		if (len == 0) {
+			return []string{""}
+		}
+		if (len == 1) {
+			return []string{"0", "1", "8"}
+		}
+		var mids []string = build((len - 2), total)
+		var result []string = []string{}
+		_ = result
+		for _, s := range mids {
+			if (len != total) {
+				result = append(append([]string{}, result...), []string{"0" + s + "0"}...)
+			}
+			result = append(append([]string{}, result...), []string{"1" + s + "1"}...)
+			result = append(append([]string{}, result...), []string{"6" + s + "9"}...)
+			result = append(append([]string{}, result...), []string{"8" + s + "8"}...)
+			result = append(append([]string{}, result...), []string{"9" + s + "6"}...)
+		}
+		return result
+}
+	return build(n, n)
+}
+
+func n___1() {
+	expect(_equal(findStrobogrammatic(1), []string{"0", "1", "8"}))
+}
+
+func n___2() {
+	expect(_equal(findStrobogrammatic(2), []string{"11", "69", "88", "96"}))
+}
+
+func n___3() {
+	expect(_equal(findStrobogrammatic(3), []string{"101", "609", "808", "906", "111", "619", "818", "916", "181", "689", "888", "986"}))
+}
+
+func main() {
+	n___1()
+	n___2()
+	n___3()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/strobogrammatic-number.go.out
+++ b/examples/leetcode-out/strobogrammatic-number.go.out
@@ -1,0 +1,59 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isStrobogrammatic(num string) bool {
+	var pairs map[string]string = map[string]string{"0": "0", "1": "1", "6": "9", "8": "8", "9": "6"}
+	var left int = 0
+	_ = left
+	var right int = (len(num) - 1)
+	_ = right
+	for (left <= right) {
+		var a string = _indexString(num, left)
+		var b string = _indexString(num, right)
+		_tmp0 := a
+		_tmp1 := pairs
+		_, _tmp2 := _tmp1[_tmp0]
+		if !(_tmp2) {
+			return false
+		}
+		if (pairs[a] != b) {
+			return false
+		}
+		left = (left + 1)
+		right = (right - 1)
+	}
+	return true
+}
+
+func example_1() {
+	expect((isStrobogrammatic("69") == true))
+}
+
+func example_2() {
+	expect((isStrobogrammatic("88") == true))
+}
+
+func example_3() {
+	expect((isStrobogrammatic("962") == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/subsets.go.out
+++ b/examples/leetcode-out/subsets.go.out
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func subsets(nums []int) [][]int {
+	var result [][]int = [][]any{[]any{}}
+	_ = result
+	for _, num := range nums {
+		var newSets [][]int = [][]int{}
+		_ = newSets
+		var i int = 0
+		_ = i
+		for (i < len(result)) {
+			var subset []int = result[i]
+			newSets = append(append([][]int{}, newSets...), [][]int{append(append([]int{}, subset...), []int{num}...)}...)
+			i = (i + 1)
+		}
+		var j int = 0
+		_ = j
+		for (j < len(newSets)) {
+			result = append(append([][]int{}, result...), [][]int{newSets[j]}...)
+			j = (j + 1)
+		}
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(subsets([]int{1, 2, 3}), []any{[]any{}, []int{1}, []int{2}, []int{1, 2}, []int{3}, []int{1, 3}, []int{2, 3}, []int{1, 2, 3}}))
+}
+
+func example_2() {
+	expect(_equal(subsets([]int{0}), []any{[]any{}, []int{0}}))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/sudoku-solver.go.out
+++ b/examples/leetcode-out/sudoku-solver.go.out
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func solveSudoku(board [][]string) [][]string {
+	var isValid = func(row int, col int, ch string) bool {
+		for i := 0; i < 9; i++ {
+			if (board[row][i] == ch) {
+				return false
+			}
+			if (board[i][col] == ch) {
+				return false
+			}
+			var r int = ((((row / 3)) * 3) + (i / 3))
+			var c int = ((((col / 3)) * 3) + (i % 3))
+			if (board[r][c] == ch) {
+				return false
+			}
+		}
+		return true
+}
+	var dfs func(int, int) bool
+	dfs = func(r int, c int) bool {
+		if (r == 9) {
+			return true
+		}
+		if (c == 9) {
+			return dfs((r + 1), 0)
+		}
+		if (board[r][c] != ".") {
+			return dfs(r, (c + 1))
+		}
+		for _, d := range []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"} {
+			if isValid(r, c, d) {
+				board[r][c] = d
+				if dfs(r, (c + 1)) {
+					return true
+				}
+				board[r][c] = "."
+			}
+		}
+		return false
+}
+	dfs(0, 0)
+	return board
+}
+
+func solve() {
+	expect(_equal(solvedBoard, solved))
+}
+
+var board [][]string = [][]string{[]string{"5", "3", ".", ".", "7", ".", ".", ".", "."}, []string{"6", ".", ".", "1", "9", "5", ".", ".", "."}, []string{".", "9", "8", ".", ".", ".", ".", "6", "."}, []string{"8", ".", ".", ".", "6", ".", ".", ".", "3"}, []string{"4", ".", ".", "8", ".", "3", ".", ".", "1"}, []string{"7", ".", ".", ".", "2", ".", ".", ".", "6"}, []string{".", "6", ".", ".", ".", ".", "2", "8", "."}, []string{".", ".", ".", "4", "1", "9", ".", ".", "5"}, []string{".", ".", ".", ".", "8", ".", ".", "7", "9"}}
+var solvedBoard [][]string = solveSudoku(board)
+var solved [][]string = [][]string{[]string{"5", "3", "4", "6", "7", "8", "9", "1", "2"}, []string{"6", "7", "2", "1", "9", "5", "3", "4", "8"}, []string{"1", "9", "8", "3", "4", "2", "5", "6", "7"}, []string{"8", "5", "9", "7", "6", "1", "4", "2", "3"}, []string{"4", "2", "6", "8", "5", "3", "7", "9", "1"}, []string{"7", "1", "3", "9", "2", "4", "8", "5", "6"}, []string{"9", "6", "1", "5", "3", "7", "2", "8", "4"}, []string{"2", "8", "7", "4", "1", "9", "6", "3", "5"}, []string{"3", "4", "5", "2", "8", "6", "1", "7", "9"}}
+func main() {
+	solve()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/summary-ranges.go.out
+++ b/examples/leetcode-out/summary-ranges.go.out
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func summaryRanges(nums []int) []string {
+	var result []string = []string{}
+	_ = result
+	if (len(nums) == 0) {
+		return result
+	}
+	var start int = nums[0]
+	_ = start
+	var prev int = nums[0]
+	_ = prev
+	var i int = 1
+	_ = i
+	for (i < len(nums)) {
+		var n int = nums[i]
+		if (n == (prev + 1)) {
+			prev = n
+		} else {
+			if (start == prev) {
+				result = append(append([]string{}, result...), []string{fmt.Sprint(start)}...)
+			} else {
+				result = append(append([]string{}, result...), []string{fmt.Sprint(start) + "->" + fmt.Sprint(prev)}...)
+			}
+			start = n
+			prev = n
+		}
+		i = (i + 1)
+	}
+	if (start == prev) {
+		result = append(append([]string{}, result...), []string{fmt.Sprint(start)}...)
+	} else {
+		result = append(append([]string{}, result...), []string{fmt.Sprint(start) + "->" + fmt.Sprint(prev)}...)
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(summaryRanges([]int{0, 1, 2, 4, 5, 7}), []string{"0->2", "4->5", "7"}))
+}
+
+func example_2() {
+	expect(_equal(summaryRanges([]int{0, 2, 3, 4, 6, 8, 9}), []string{"0", "2->4", "6", "8->9"}))
+}
+
+func single_element() {
+	expect(_equal(summaryRanges([]int{5}), []string{"5"}))
+}
+
+func empty() {
+	expect(_equal(summaryRanges([]int{}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_element()
+	empty()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/surrounded-regions.go.out
+++ b/examples/leetcode-out/surrounded-regions.go.out
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func solve(board [][]string) [][]string {
+	var rows int = len(board)
+	if (rows == 0) {
+		return board
+	}
+	var cols int = len(board[0])
+	var queue [][]int = [][]int{}
+	_ = queue
+	for r := 0; r < rows; r++ {
+		if (board[r][0] == "O") {
+			queue = append(append([][]int{}, queue...), [][]int{[]int{r, 0}}...)
+		}
+		if ((cols > 1) && (board[r][(cols - 1)] == "O")) {
+			queue = append(append([][]int{}, queue...), [][]int{[]int{r, (cols - 1)}}...)
+		}
+	}
+	for c := 0; c < cols; c++ {
+		if (board[0][c] == "O") {
+			queue = append(append([][]int{}, queue...), [][]int{[]int{0, c}}...)
+		}
+		if ((rows > 1) && (board[(rows - 1)][c] == "O")) {
+			queue = append(append([][]int{}, queue...), [][]int{[]int{(rows - 1), c}}...)
+		}
+	}
+	var i int = 0
+	_ = i
+	for (i < len(queue)) {
+		var pos []int = queue[i]
+		var r int = pos[0]
+		var c int = pos[1]
+		if (board[r][c] == "O") {
+			board[r][c] = "S"
+			if (r > 0) {
+				if (board[(r - 1)][c] == "O") {
+					queue = append(append([][]int{}, queue...), [][]int{[]int{(r - 1), c}}...)
+				}
+			}
+			if ((r + 1) < rows) {
+				if (board[(r + 1)][c] == "O") {
+					queue = append(append([][]int{}, queue...), [][]int{[]int{(r + 1), c}}...)
+				}
+			}
+			if (c > 0) {
+				if (board[r][(c - 1)] == "O") {
+					queue = append(append([][]int{}, queue...), [][]int{[]int{r, (c - 1)}}...)
+				}
+			}
+			if ((c + 1) < cols) {
+				if (board[r][(c + 1)] == "O") {
+					queue = append(append([][]int{}, queue...), [][]int{[]int{r, (c + 1)}}...)
+				}
+			}
+		}
+		i = (i + 1)
+	}
+	for r := 0; r < rows; r++ {
+		for c := 0; c < cols; c++ {
+			if (board[r][c] == "O") {
+				board[r][c] = "X"
+			} else 			if (board[r][c] == "S") {
+				board[r][c] = "O"
+			}
+		}
+	}
+	return board
+}
+
+func example_1() {
+	var board [][]string = [][]string{[]string{"X", "X", "X", "X"}, []string{"X", "O", "O", "X"}, []string{"X", "X", "O", "X"}, []string{"X", "O", "X", "X"}}
+	var expected [][]string = [][]string{[]string{"X", "X", "X", "X"}, []string{"X", "X", "X", "X"}, []string{"X", "X", "X", "X"}, []string{"X", "O", "X", "X"}}
+	expect(_equal(solve(board), expected))
+}
+
+func no_change() {
+	var board [][]string = [][]string{[]string{"X", "X"}, []string{"X", "X"}}
+	expect(_equal(solve(board), board))
+}
+
+func main() {
+	example_1()
+	no_change()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/swap-nodes-in-pairs.go.out
+++ b/examples/leetcode-out/swap-nodes-in-pairs.go.out
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func swapPairs(nums []int) []int {
+	var i int = 0
+	_ = i
+	var result []any = []any{}
+	_ = result
+	for (i < len(nums)) {
+		if ((i + 1) < len(nums)) {
+			result = append(append([]any{}, result...), _toAnySlice([]int{nums[(i + 1)], nums[i]})...)
+		} else {
+			result = append(append([]any{}, result...), _toAnySlice([]int{nums[i]})...)
+		}
+		i = (i + 2)
+	}
+	return _cast[[]int](result)
+}
+
+func example_1() {
+	expect(_equal(swapPairs([]int{1, 2, 3, 4}), []int{2, 1, 4, 3}))
+}
+
+func example_2() {
+	expect(_equal(swapPairs([]int{}), []any{}))
+}
+
+func example_3() {
+	expect(_equal(swapPairs([]int{1}), []int{1}))
+}
+
+func odd_length() {
+	expect(_equal(swapPairs([]int{1, 2, 3}), []int{2, 1, 3}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	odd_length()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/tenth-line.go.out
+++ b/examples/leetcode-out/tenth-line.go.out
@@ -1,0 +1,28 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func tenthLine(lines []string) string {
+	if (len(lines) < 10) {
+		return ""
+	}
+	return lines[9]
+}
+
+func has_tenth_line() {
+	var lines []string = []string{"Line1", "Line2", "Line3", "Line4", "Line5", "Line6", "Line7", "Line8", "Line9", "Line10"}
+	expect((tenthLine(lines) == "Line10"))
+}
+
+func not_enough_lines() {
+	var lines []string = []string{"a", "b", "c"}
+	expect((tenthLine(lines) == ""))
+}
+
+func main() {
+	has_tenth_line()
+	not_enough_lines()
+}
+

--- a/examples/leetcode-out/text-justification.go.out
+++ b/examples/leetcode-out/text-justification.go.out
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func fullJustify(words []string, maxWidth int) []string {
+	var result []string = []string{}
+	_ = result
+	var i int = 0
+	_ = i
+	for (i < len(words)) {
+		var j int = i
+		_ = j
+		var lineLen int = 0
+		_ = lineLen
+		for (j < len(words)) {
+			if (((lineLen + len(words[j])) + ((j - i))) <= maxWidth) {
+				lineLen = (lineLen + len(words[j]))
+				j = (j + 1)
+			} else {
+				break
+			}
+		}
+		var line string = ""
+		_ = line
+		var numWords int = (j - i)
+		if ((j == len(words)) || (numWords == 1)) {
+			var k int = i
+			_ = k
+			for (k < j) {
+				line = line + words[k]
+				if (k < (j - 1)) {
+					line = line + " "
+				}
+				k = (k + 1)
+			}
+			for (len(line) < maxWidth) {
+				line = line + " "
+			}
+		} else {
+			var totalSpaces int = (maxWidth - lineLen)
+			var gaps int = (numWords - 1)
+			var spaceEach int = (totalSpaces / gaps)
+			var extra int = (totalSpaces % gaps)
+			_ = extra
+			var k int = i
+			_ = k
+			for (k < j) {
+				line = line + words[k]
+				if (k < (j - 1)) {
+					var s int = 0
+					_ = s
+					for (s < spaceEach) {
+						line = line + " "
+						s = (s + 1)
+					}
+					if (extra > 0) {
+						line = line + " "
+						extra = (extra - 1)
+					}
+				}
+				k = (k + 1)
+			}
+		}
+		result = append(append([]string{}, result...), []string{line}...)
+		i = j
+	}
+	return result
+}
+
+func example_1() {
+	var words []string = []string{"This", "is", "an", "example", "of", "text", "justification."}
+	expect(_equal(fullJustify(words, 16), []string{"This    is    an", "example  of text", "justification.  "}))
+}
+
+func example_2() {
+	var words []string = []string{"What", "must", "be", "acknowledgment", "shall", "be"}
+	expect(_equal(fullJustify(words, 16), []string{"What   must   be", "acknowledgment  ", "shall be        "}))
+}
+
+func example_3() {
+	var words []string = []string{"Science", "is", "what", "we", "understand", "well", "enough", "to", "explain", "to", "a", "computer.", "Art", "is", "everything", "else", "we", "do"}
+	expect(_equal(fullJustify(words, 20), []string{"Science  is  what we", "understand      well", "enough to explain to", "a  computer.  Art is", "everything  else  we", "do                  "}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/transpose-file.go.out
+++ b/examples/leetcode-out/transpose-file.go.out
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func transpose(rows [][]int) [][]int {
+	if (len(rows) == 0) {
+		return _cast[[][]int]([]any{})
+	}
+	var row_count int = len(rows)
+	var col_count int = len(rows[0])
+	var result [][]int = [][]int{}
+	_ = result
+	var c int = 0
+	_ = c
+	for (c < col_count) {
+		var new_row []int = []int{}
+		_ = new_row
+		var r int = 0
+		_ = r
+		for (r < row_count) {
+			new_row = append(append([]int{}, new_row...), []int{rows[r][c]}...)
+			r = (r + 1)
+		}
+		result = append(append([][]int{}, result...), [][]int{new_row}...)
+		c = (c + 1)
+	}
+	return result
+}
+
+func square_matrix() {
+	expect(_equal(transpose([][]int{[]int{1, 2, 3}, []int{4, 5, 6}, []int{7, 8, 9}}), [][]int{[]int{1, 4, 7}, []int{2, 5, 8}, []int{3, 6, 9}}))
+}
+
+func rectangular_matrix() {
+	expect(_equal(transpose([][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}}), [][]int{[]int{1, 3, 5}, []int{2, 4, 6}}))
+}
+
+func main() {
+	square_matrix()
+	rectangular_matrix()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/trapping-rain-water.go.out
+++ b/examples/leetcode-out/trapping-rain-water.go.out
@@ -1,0 +1,50 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func trap(height []int) int {
+	var left int = 0
+	_ = left
+	var right int = (len(height) - 1)
+	_ = right
+	var left_max int = 0
+	_ = left_max
+	var right_max int = 0
+	_ = right_max
+	var water int = 0
+	_ = water
+	for (left < right) {
+		if (height[left] < height[right]) {
+			if (height[left] >= left_max) {
+				left_max = height[left]
+			} else {
+				water = (water + ((left_max - height[left])))
+			}
+			left = (left + 1)
+		} else {
+			if (height[right] >= right_max) {
+				right_max = height[right]
+			} else {
+				water = (water + ((right_max - height[right])))
+			}
+			right = (right - 1)
+		}
+	}
+	return water
+}
+
+func example_1() {
+	expect((trap([]int{0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1}) == 6))
+}
+
+func example_2() {
+	expect((trap([]int{4, 2, 0, 3, 2, 5}) == 9))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+

--- a/examples/leetcode-out/triangle.go.out
+++ b/examples/leetcode-out/triangle.go.out
@@ -1,0 +1,51 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func minimumTotal(triangle [][]int) int {
+	var n int = len(triangle)
+	if (n == 0) {
+		return 0
+	}
+	var dp []int = triangle[(n - 1)]
+	_ = dp
+	var i int = (n - 2)
+	_ = i
+	for (i >= 0) {
+		var j int = 0
+		_ = j
+		for (j <= i) {
+			var left int = dp[j]
+			var right int = dp[(j + 1)]
+			if (left < right) {
+				dp[j] = (triangle[i][j] + left)
+			} else {
+				dp[j] = (triangle[i][j] + right)
+			}
+			j = (j + 1)
+		}
+		i = (i - 1)
+	}
+	return dp[0]
+}
+
+func example_1() {
+	expect((minimumTotal([][]int{[]int{2}, []int{3, 4}, []int{6, 5, 7}, []int{4, 1, 8, 3}}) == 11))
+}
+
+func example_2() {
+	expect((minimumTotal([][]int{[]int{-10}}) == (-10)))
+}
+
+func single_level() {
+	expect((minimumTotal([][]int{[]int{1}}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_level()
+}
+

--- a/examples/leetcode-out/two-sum-ii-input-array-is-sorted.go.out
+++ b/examples/leetcode-out/two-sum-ii-input-array-is-sorted.go.out
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func twoSum(numbers []int, target int) []int {
+	var left int = 0
+	_ = left
+	var right int = (len(numbers) - 1)
+	_ = right
+	for (left < right) {
+		var sum int = (numbers[left] + numbers[right])
+		if (sum == target) {
+			return []int{(left + 1), (right + 1)}
+		} else 		if (sum < target) {
+			left = (left + 1)
+		} else {
+			right = (right - 1)
+		}
+	}
+	return _cast[[]int]([]any{})
+}
+
+func example_1() {
+	expect(_equal(twoSum([]int{2, 7, 11, 15}, 9), []int{1, 2}))
+}
+
+func example_2() {
+	expect(_equal(twoSum([]int{2, 3, 4}, 6), []int{1, 3}))
+}
+
+func example_3() {
+	expect(_equal(twoSum([]int{-1, 0}, -1), []int{1, 2}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/two-sum-iii-data-structure-design.go.out
+++ b/examples/leetcode-out/two-sum-iii-data-structure-design.go.out
@@ -1,0 +1,82 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type TwoSum struct {
+	Counts map[int]int `json:"counts"`
+}
+
+func newTwoSum() TwoSum {
+	return TwoSum{Counts: _cast[map[int]int](map[any]any{})}
+}
+
+func add(ts TwoSum, number int) TwoSum {
+	var counts map[int]int = ts.Counts
+	_ = counts
+	var current int = 0
+	_ = current
+	_tmp0 := number
+	_tmp1 := counts
+	_, _tmp2 := _tmp1[_tmp0]
+	if _tmp2 {
+		current = counts[number]
+	}
+	counts[number] = (current + 1)
+	return TwoSum{Counts: counts}
+}
+
+func find(ts TwoSum, value int) bool {
+	for key := range ts.Counts {
+		var count func(any) int = ts.Counts[key]
+		var complement int = (value - key)
+		_tmp3 := complement
+		_tmp4 := ts.Counts
+		_, _tmp5 := _tmp4[_tmp3]
+		if _tmp5 {
+			var other int = ts.Counts[complement]
+			if (key != complement) {
+				return true
+			} else {
+				if (other > 1) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func example() {
+	var ts TwoSum = newTwoSum()
+	_ = ts
+	ts = add(ts, 1)
+	ts = add(ts, 3)
+	ts = add(ts, 5)
+	expect((find(ts, 4) == true))
+	expect((find(ts, 7) == false))
+}
+
+func duplicate_numbers() {
+	var ts TwoSum = newTwoSum()
+	_ = ts
+	ts = add(ts, 2)
+	ts = add(ts, 2)
+	expect((find(ts, 4) == true))
+	expect((find(ts, 3) == false))
+}
+
+func main() {
+	example()
+	duplicate_numbers()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode-out/two-sum.go.out
+++ b/examples/leetcode-out/two-sum.go.out
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+)
+
+func twoSum(nums []int, target int) []int {
+	var n int = len(nums)
+	for i := 0; i < n; i++ {
+		for j := (i + 1); j < n; j++ {
+			if ((nums[i] + nums[j]) == target) {
+				return []int{i, j}
+			}
+		}
+	}
+	return []int{-1, -1}
+}
+
+func main() {
+	var result []int = twoSum([]int{2, 7, 11, 15}, 9)
+	fmt.Println(result[0])
+	fmt.Println(result[1])
+}
+

--- a/examples/leetcode-out/unique-binary-search-trees-ii.go.out
+++ b/examples/leetcode-out/unique-binary-search-trees-ii.go.out
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+)
+
+type Tree interface { isTree() }
+type Empty struct {
+}
+func (Empty) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Val int `json:"val"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func build(start int, end int) []any {
+	if (start > end) {
+		return _cast[[]any]([]Empty{Empty{}})
+	}
+	var result []any = []any{}
+	_ = result
+	for i := start; i < (end + 1); i++ {
+		var leftTrees []any = build(start, (i - 1))
+		var rightTrees []any = build((i + 1), end)
+		for _, l := range leftTrees {
+			for _, r := range rightTrees {
+				result = append(append([]any{}, result...), _toAnySlice([]Node{Node{Left: l, Val: i, Right: r}})...)
+			}
+		}
+	}
+	return _cast[[]any](result)
+}
+
+func generateTrees(n int) []any {
+	if (n == 0) {
+		return _cast[[]any]([]any{})
+	}
+	return build(1, n)
+}
+
+func main() {
+	var trees []any = generateTrees(3)
+	fmt.Println(len(trees))
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/unique-binary-search-trees.go.out
+++ b/examples/leetcode-out/unique-binary-search-trees.go.out
@@ -1,0 +1,55 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func numTrees(n int) int {
+	var dp []int = []int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i <= n) {
+		dp = append(append([]int{}, dp...), []int{0}...)
+		i = (i + 1)
+	}
+	dp[0] = 1
+	if (n >= 1) {
+		dp[1] = 1
+	}
+	i = 2
+	for (i <= n) {
+		var j int = 1
+		_ = j
+		for (j <= i) {
+			dp[i] = (dp[i] + (dp[(j - 1)] * dp[(i - j)]))
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return dp[n]
+}
+
+func example_1() {
+	expect((numTrees(3) == 5))
+}
+
+func example_2() {
+	expect((numTrees(1) == 1))
+}
+
+func n___2() {
+	expect((numTrees(2) == 2))
+}
+
+func n___5() {
+	expect((numTrees(5) == 42))
+}
+
+func main() {
+	example_1()
+	example_2()
+	n___2()
+	n___5()
+}
+

--- a/examples/leetcode-out/unique-paths-ii.go.out
+++ b/examples/leetcode-out/unique-paths-ii.go.out
@@ -1,0 +1,77 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func uniquePathsWithObstacles(grid [][]int) int {
+	var m int = len(grid)
+	if (m == 0) {
+		return 0
+	}
+	var n int = len(grid[0])
+	var dp [][]int = [][]int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i < m) {
+		var row []int = []int{}
+		_ = row
+		var j int = 0
+		_ = j
+		for (j < n) {
+			row = append(append([]int{}, row...), []int{0}...)
+			j = (j + 1)
+		}
+		dp = append(append([][]int{}, dp...), [][]int{row}...)
+		i = (i + 1)
+	}
+	if (grid[0][0] == 1) {
+		return 0
+	}
+	dp[0][0] = 1
+	i = 0
+	for (i < m) {
+		var j int = 0
+		_ = j
+		for (j < n) {
+			if (grid[i][j] == 1) {
+				dp[i][j] = 0
+			} else {
+				if (i > 0) {
+					dp[i][j] = (dp[i][j] + dp[(i - 1)][j])
+				}
+				if (j > 0) {
+					dp[i][j] = (dp[i][j] + dp[i][(j - 1)])
+				}
+			}
+			j = (j + 1)
+		}
+		i = (i + 1)
+	}
+	return dp[(m - 1)][(n - 1)]
+}
+
+func example_1() {
+	expect((uniquePathsWithObstacles([][]int{[]int{0, 0, 0}, []int{0, 1, 0}, []int{0, 0, 0}}) == 2))
+}
+
+func example_2() {
+	expect((uniquePathsWithObstacles([][]int{[]int{0, 1}, []int{0, 0}}) == 1))
+}
+
+func obstacle_at_start() {
+	expect((uniquePathsWithObstacles([][]int{[]int{1}}) == 0))
+}
+
+func single_open_cell() {
+	expect((uniquePathsWithObstacles([][]int{[]int{0}}) == 1))
+}
+
+func main() {
+	example_1()
+	example_2()
+	obstacle_at_start()
+	single_open_cell()
+}
+

--- a/examples/leetcode-out/unique-paths.go.out
+++ b/examples/leetcode-out/unique-paths.go.out
@@ -1,0 +1,52 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func uniquePaths(m int, n int) int {
+	var dp []int = []int{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i < n) {
+		dp = append(append([]int{}, dp...), []int{1}...)
+		i = (i + 1)
+	}
+	var row int = 1
+	_ = row
+	for (row < m) {
+		var col int = 1
+		_ = col
+		for (col < n) {
+			dp[col] = (dp[col] + dp[(col - 1)])
+			col = (col + 1)
+		}
+		row = (row + 1)
+	}
+	return dp[(n - 1)]
+}
+
+func example_1() {
+	expect((uniquePaths(3, 7) == 28))
+}
+
+func example_2() {
+	expect((uniquePaths(3, 2) == 3))
+}
+
+func example_3() {
+	expect((uniquePaths(7, 3) == 28))
+}
+
+func example_4() {
+	expect((uniquePaths(3, 3) == 6))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	example_4()
+}
+

--- a/examples/leetcode-out/valid-anagram.go.out
+++ b/examples/leetcode-out/valid-anagram.go.out
@@ -1,0 +1,81 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isAnagram(s string, t string) bool {
+	if (len(s) != len(t)) {
+		return false
+	}
+	var counts map[string]int = map[string]int{}
+	_ = counts
+	var i int = 0
+	_ = i
+	for (i < len(s)) {
+		var ch string = _indexString(s, i)
+		_tmp0 := ch
+		_tmp1 := counts
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			counts[ch] = (counts[ch] + 1)
+		} else {
+			counts[ch] = 1
+		}
+		i = (i + 1)
+	}
+	i = 0
+	for (i < len(t)) {
+		var ch string = _indexString(t, i)
+		_tmp3 := ch
+		_tmp4 := counts
+		_, _tmp5 := _tmp4[_tmp3]
+		if _tmp5 {
+			counts[ch] = (counts[ch] - 1)
+		} else {
+			return false
+		}
+		i = (i + 1)
+	}
+	for key := range counts {
+		if (counts[key] != 0) {
+			return false
+		}
+	}
+	return true
+}
+
+func example_1() {
+	expect((isAnagram("anagram", "nagaram") == true))
+}
+
+func example_2() {
+	expect((isAnagram("rat", "car") == false))
+}
+
+func empty_strings() {
+	expect((isAnagram("", "") == true))
+}
+
+func different_lengths() {
+	expect((isAnagram("a", "ab") == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_strings()
+	different_lengths()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/valid-palindrome.go.out
+++ b/examples/leetcode-out/valid-palindrome.go.out
@@ -1,0 +1,66 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isAlphaNum(ch string) bool {
+	if (("0" <= ch) && (ch <= "9")) {
+		return true
+	}
+	if (("a" <= ch) && (ch <= "z")) {
+		return true
+	}
+	if (("A" <= ch) && (ch <= "Z")) {
+		return true
+	}
+	return false
+}
+
+func toLower(ch string) string {
+	var map map[string]string = map[string]string{"A": "a", "B": "b", "C": "c", "D": "d", "E": "e", "F": "f", "G": "g", "H": "h", "I": "i", "J": "j", "K": "k", "L": "l", "M": "m", "N": "n", "O": "o", "P": "p", "Q": "q", "R": "r", "S": "s", "T": "t", "U": "u", "V": "v", "W": "w", "X": "x", "Y": "y", "Z": "z"}
+	_tmp0 := ch
+	_tmp1 := map
+	_, _tmp2 := _tmp1[_tmp0]
+	if _tmp2 {
+		return map[ch]
+	}
+	return ch
+}
+
+func isPalindrome(s string) bool {
+	var filtered []string = []string{}
+	_ = filtered
+	for _, r := range []rune(s) {
+		ch := string(r)
+		if isAlphaNum(ch) {
+			filtered = append(append([]string{}, filtered...), []string{toLower(ch)}...)
+		}
+	}
+	var n int = len(filtered)
+	for i := 0; i < (n / 2); i++ {
+		if (filtered[i] != filtered[((n - 1) - i)]) {
+			return false
+		}
+	}
+	return true
+}
+
+func example_1() {
+	expect((isPalindrome("A man, a plan, a canal: Panama") == true))
+}
+
+func example_2() {
+	expect((isPalindrome("race a car") == false))
+}
+
+func example_3() {
+	expect((isPalindrome(" ") == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/valid-phone-numbers.go.out
+++ b/examples/leetcode-out/valid-phone-numbers.go.out
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"reflect"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isDigit(ch string) bool {
+	return ((ch >= "0") && (ch <= "9"))
+}
+
+func isValidPhoneNumber(s string) bool {
+	var n int = len(s)
+	if (n == 12) {
+		if ((_indexString(s, 3) != "-") || (_indexString(s, 7) != "-")) {
+			return false
+		}
+		var i int = 0
+		_ = i
+		for (i < n) {
+			if ((i == 3) || (i == 7)) {
+				i = (i + 1)
+				continue
+			}
+			if !isDigit(_indexString(s, i)) {
+				return false
+			}
+			i = (i + 1)
+		}
+		return true
+	}
+	if (n == 14) {
+		if ((((_indexString(s, 0) != "(") || (_indexString(s, 4) != ")")) || (_indexString(s, 5) != " ")) || (_indexString(s, 9) != "-")) {
+			return false
+		}
+		var i int = 0
+		_ = i
+		for (i < n) {
+			if ((((i == 0) || (i == 4)) || (i == 5)) || (i == 9)) {
+				i = (i + 1)
+				continue
+			}
+			if !isDigit(_indexString(s, i)) {
+				return false
+			}
+			i = (i + 1)
+		}
+		return true
+	}
+	return false
+}
+
+func validPhoneNumbers(lines []string) []string {
+	var result []string = []string{}
+	_ = result
+	for _, line := range lines {
+		if isValidPhoneNumber(line) {
+			result = append(append([]string{}, result...), []string{line}...)
+		}
+	}
+	return result
+}
+
+func example() {
+	var input []string = []string{"987-123-4567", "123 456 7890", "(123) 456-7890"}
+	expect(_equal(validPhoneNumbers(input), []string{"987-123-4567", "(123) 456-7890"}))
+}
+
+func main() {
+	example()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/valid-sudoku.go.out
+++ b/examples/leetcode-out/valid-sudoku.go.out
@@ -1,0 +1,77 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isValidSudoku(board [][]string) bool {
+	for r := 0; r < 9; r++ {
+		var seen map[string]bool = map[string]bool{}
+		_ = seen
+		for c := 0; c < 9; c++ {
+			var val string = board[r][c]
+			if (val != ".") {
+				_tmp0 := val
+				_tmp1 := seen
+				_, _tmp2 := _tmp1[_tmp0]
+				if _tmp2 {
+					return false
+				}
+				seen[val] = true
+			}
+		}
+	}
+	for c := 0; c < 9; c++ {
+		var seen map[string]bool = map[string]bool{}
+		_ = seen
+		for r := 0; r < 9; r++ {
+			var val string = board[r][c]
+			if (val != ".") {
+				_tmp3 := val
+				_tmp4 := seen
+				_, _tmp5 := _tmp4[_tmp3]
+				if _tmp5 {
+					return false
+				}
+				seen[val] = true
+			}
+		}
+	}
+	for br := 0; br < 3; br++ {
+		for bc := 0; bc < 3; bc++ {
+			var seen map[string]bool = map[string]bool{}
+			_ = seen
+			for r := 0; r < 3; r++ {
+				for c := 0; c < 3; c++ {
+					var val string = board[((br * 3) + r)][((bc * 3) + c)]
+					if (val != ".") {
+						_tmp6 := val
+						_tmp7 := seen
+						_, _tmp8 := _tmp7[_tmp6]
+						if _tmp8 {
+							return false
+						}
+						seen[val] = true
+					}
+				}
+			}
+		}
+	}
+	return true
+}
+
+func example_1() {
+	expect((isValidSudoku(example1) == true))
+}
+
+func example_2() {
+	expect((isValidSudoku(example2) == false))
+}
+
+var example1 [][]string = [][]string{[]string{"5", "3", ".", ".", "7", ".", ".", ".", "."}, []string{"6", ".", ".", "1", "9", "5", ".", ".", "."}, []string{".", "9", "8", ".", ".", ".", ".", "6", "."}, []string{"8", ".", ".", ".", "6", ".", ".", ".", "3"}, []string{"4", ".", ".", "8", ".", "3", ".", ".", "1"}, []string{"7", ".", ".", ".", "2", ".", ".", ".", "6"}, []string{".", "6", ".", ".", ".", ".", "2", "8", "."}, []string{".", ".", ".", "4", "1", "9", ".", ".", "5"}, []string{".", ".", ".", ".", "8", ".", ".", "7", "9"}}
+var example2 [][]string = [][]string{[]string{"8", "3", ".", ".", "7", ".", ".", ".", "."}, []string{"6", ".", ".", "1", "9", "5", ".", ".", "."}, []string{".", "9", "8", ".", ".", ".", ".", "6", "."}, []string{"8", ".", ".", ".", "6", ".", ".", ".", "3"}, []string{"4", ".", ".", "8", ".", "3", ".", ".", "1"}, []string{"7", ".", ".", ".", "2", ".", ".", ".", "6"}, []string{".", "6", ".", ".", ".", ".", "2", "8", "."}, []string{".", ".", ".", "4", "1", "9", ".", ".", "5"}, []string{".", ".", ".", ".", "8", ".", ".", "7", "9"}}
+func main() {
+	example_1()
+	example_2()
+}
+

--- a/examples/leetcode-out/wildcard-matching.go.out
+++ b/examples/leetcode-out/wildcard-matching.go.out
@@ -1,0 +1,88 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isMatch(s string, p string) bool {
+	var m int = len(s)
+	var n int = len(p)
+	var memo map[int]bool = map[int]bool{}
+	_ = memo
+	var dfs func(int, int) bool
+	dfs = func(i int, j int) bool {
+		var key int = ((i * ((n + 1))) + j)
+		_tmp0 := key
+		_tmp1 := memo
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			return memo[key]
+		}
+		if (j == n) {
+			return (i == m)
+		}
+		var ans bool = false
+		_ = ans
+		if (_indexString(p, j) == "*") {
+			if dfs(i, (j + 1)) {
+				ans = true
+			} else 		if ((i < m) && dfs((i + 1), j)) {
+				ans = true
+			}
+		} else {
+			if ((i < m) && (((_indexString(p, j) == "?") || (_indexString(p, j) == _indexString(s, i))))) {
+				if dfs((i + 1), (j + 1)) {
+					ans = true
+				}
+			}
+		}
+		memo[key] = ans
+		return ans
+}
+	return dfs(0, 0)
+}
+
+func example_1() {
+	expect((isMatch("aa", "a") == false))
+}
+
+func example_2() {
+	expect((isMatch("aa", "*") == true))
+}
+
+func example_3() {
+	expect((isMatch("cb", "?a") == false))
+}
+
+func example_4() {
+	expect((isMatch("adceb", "*a*b") == true))
+}
+
+func empty_pattern() {
+	expect((isMatch("", "") == true))
+}
+
+func only_star() {
+	expect((isMatch("abc", "*") == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+	example_4()
+	empty_pattern()
+	only_star()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/word-break-ii.go.out
+++ b/examples/leetcode-out/word-break-ii.go.out
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func wordBreak(s string, wordDict []string) []string {
+	var dict map[string]bool = map[string]bool{}
+	_ = dict
+	for _, w := range wordDict {
+		dict[w] = true
+	}
+	var n int = len(s)
+	var memo map[int][]string = map[int][]string{}
+	_ = memo
+	var dfs func(int) []string
+	dfs = func(start int) []string {
+		_tmp0 := start
+		_tmp1 := memo
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			return memo[start]
+		}
+		if (start == n) {
+			return []string{""}
+		}
+		var res []string = []string{}
+		_ = res
+		var end int = (start + 1)
+		_ = end
+		for (end <= n) {
+			var word string = string([]rune(s)[start:end])
+			var exists bool = false
+			_ = exists
+			_tmp3 := word
+			_tmp4 := dict
+			_, _tmp5 := _tmp4[_tmp3]
+			if _tmp5 {
+				exists = dict[word]
+			}
+			if exists {
+				var subs []string = dfs(end)
+				for _, sub := range subs {
+					if (len(sub) == 0) {
+						res = append(append([]string{}, res...), []string{word}...)
+					} else {
+						res = append(append([]string{}, res...), []string{word + " " + sub}...)
+					}
+				}
+			}
+			end = (end + 1)
+		}
+		memo[start] = res
+		return res
+}
+	var ans []string = dfs(0)
+	var sorted []any = func() []string {
+	items := []string{}
+	for _, x := range ans {
+		items = append(items, x)
+	}
+	type pair struct { item string; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		x := it
+		pairs[idx] = pair{item: it, key: x}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []string{}
+	for _, x := range items {
+		res = append(res, x)
+	}
+	return res
+}()
+	return _cast[[]string](sorted)
+}
+
+func example_1() {
+	expect(_equal(wordBreak("catsanddog", dict1), []string{"cat sand dog", "cats and dog"}))
+}
+
+func example_2() {
+	expect(_equal(wordBreak("pineapplepenapple", dict2), []string{"pine apple pen apple", "pine applepen apple", "pineapple pen apple"}))
+}
+
+func example_3() {
+	expect(_equal(wordBreak("catsandog", dict1), []any{}))
+}
+
+var dict1 []string = []string{"cat", "cats", "and", "sand", "dog"}
+var dict2 []string = []string{"apple", "pen", "applepen", "pine", "pineapple"}
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+

--- a/examples/leetcode-out/word-break.go.out
+++ b/examples/leetcode-out/word-break.go.out
@@ -1,0 +1,63 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func wordBreak(s string, wordDict []string) bool {
+	var dict map[string]bool = map[string]bool{}
+	_ = dict
+	for _, w := range wordDict {
+		dict[w] = true
+	}
+	var n int = len(s)
+	var dp []bool = []bool{}
+	_ = dp
+	var i int = 0
+	_ = i
+	for (i <= n) {
+		dp = append(append([]bool{}, dp...), []bool{false}...)
+		i = (i + 1)
+	}
+	dp[0] = true
+	var idx int = 1
+	_ = idx
+	for (idx <= n) {
+		var j int = 0
+		_ = j
+		for (j < idx) {
+			if dp[j] {
+				var part string = string([]rune(s)[j:idx])
+				_tmp0 := part
+				_tmp1 := dict
+				_, _tmp2 := _tmp1[_tmp0]
+				if _tmp2 {
+					dp[idx] = true
+					break
+				}
+			}
+			j = (j + 1)
+		}
+		idx = (idx + 1)
+	}
+	return dp[n]
+}
+
+func example_1() {
+	expect((wordBreak("leetcode", []string{"leet", "code"}) == true))
+}
+
+func example_2() {
+	expect((wordBreak("applepenapple", []string{"apple", "pen"}) == true))
+}
+
+func example_3() {
+	expect((wordBreak("catsandog", []string{"cats", "dog", "sand", "and", "cat"}) == false))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/word-frequency.go.out
+++ b/examples/leetcode-out/word-frequency.go.out
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+type WordCount struct {
+	Word string `json:"word"`
+	Count int `json:"count"`
+}
+
+func wordFrequency(lines []string) []WordCount {
+	var counts map[string]int = map[string]int{}
+	_ = counts
+	for _, line := range lines {
+		var i int = 0
+		_ = i
+		var word string = ""
+		_ = word
+		var n int = len(line)
+		for (i <= n) {
+			var ch string = ""
+			_ = ch
+			if (i < n) {
+				ch = _indexString(line, i)
+			} else {
+				ch = " "
+			}
+			if (ch == " ") {
+				if (word != "") {
+					var c int = 0
+					_ = c
+					_tmp0 := word
+					_tmp1 := counts
+					_, _tmp2 := _tmp1[_tmp0]
+					if _tmp2 {
+						c = counts[word]
+					}
+					counts[word] = (c + 1)
+					word = ""
+				}
+			} else {
+				word = word + ch
+			}
+			i = (i + 1)
+		}
+	}
+	var result []any = []any{}
+	_ = result
+	for w := range counts {
+		result = append(append([]any{}, result...), _toAnySlice([]WordCount{WordCount{Word: w, Count: counts[w]}})...)
+	}
+	var alpha []any = func() []any {
+	items := []any{}
+	for _, wc := range result {
+		items = append(items, wc)
+	}
+	type pair struct { item any; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		wc := it
+		pairs[idx] = pair{item: it, key: wc.Word}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []any{}
+	for _, wc := range items {
+		res = append(res, wc)
+	}
+	return res
+}()
+	var sorted []any = func() []any {
+	items := []any{}
+	for _, wc := range alpha {
+		items = append(items, wc)
+	}
+	type pair struct { item any; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		wc := it
+		pairs[idx] = pair{item: it, key: -wc.Count}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []any{}
+	for _, wc := range items {
+		res = append(res, wc)
+	}
+	return res
+}()
+	return _cast[[]WordCount](sorted)
+}
+
+func example() {
+	var lines []string = []string{"the day is sunny the the the sunny is is"}
+	var res []WordCount = wordFrequency(lines)
+	var e0 WordCount = res[0]
+	expect((e0.Word == "the"))
+	expect((e0.Count == 4))
+	var e1 WordCount = res[1]
+	expect((e1.Word == "is"))
+	expect((e1.Count == 3))
+	var e2 WordCount = res[2]
+	expect((e2.Word == "sunny"))
+	expect((e2.Count == 2))
+	var e3 WordCount = res[3]
+	expect((e3.Word == "day"))
+	expect((e3.Count == 1))
+}
+
+func multiple_lines() {
+	var lines []string = []string{"hello world", "hello mochi world"}
+	var res []WordCount = wordFrequency(lines)
+	var a0 WordCount = res[0]
+	expect((a0.Word == "hello"))
+	expect((a0.Count == 2))
+	var a1 WordCount = res[1]
+	expect((a1.Word == "world"))
+	expect((a1.Count == 2))
+	var a2 WordCount = res[2]
+	expect((a2.Word == "mochi"))
+	expect((a2.Count == 1))
+}
+
+func main() {
+	example()
+	multiple_lines()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+
+func _toAnySlice[T any](s []T) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+

--- a/examples/leetcode-out/word-ladder-ii.go.out
+++ b/examples/leetcode-out/word-ladder-ii.go.out
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findLadders(beginWord string, endWord string, wordList []string) [][]string {
+	var dict map[string]bool = map[string]bool{}
+	_ = dict
+	for _, w := range wordList {
+		dict[w] = true
+	}
+	_tmp0 := endWord
+	_tmp1 := dict
+	_, _tmp2 := _tmp1[_tmp0]
+	if !(_tmp2) {
+		return _cast[[][]string]([]any{})
+	}
+	var letters string = "abcdefghijklmnopqrstuvwxyz"
+	var queue []string = []string{beginWord}
+	_ = queue
+	var visited map[string]int = map[string]int{"beginWord": 0}
+	_ = visited
+	var parents map[string][]string = map[string][]string{}
+	_ = parents
+	var step int = 0
+	_ = step
+	var found bool = false
+	_ = found
+	for (len(queue) > 0) {
+		if found {
+			break
+		}
+		step = (step + 1)
+		var next []string = []string{}
+		_ = next
+		for _, word := range queue {
+			var i int = 0
+			_ = i
+			for (i < len(word)) {
+				var j int = 0
+				_ = j
+				for (j < 26) {
+					var ch string = _indexString(letters, j)
+					if (ch != _indexString(word, i)) {
+						var candidate string = string([]rune(word)[0:i]) + ch + string([]rune(word)[(i + 1):len(word)])
+						_tmp3 := candidate
+						_tmp4 := dict
+						_, _tmp5 := _tmp4[_tmp3]
+						if _tmp5 {
+							_tmp6 := candidate
+							_tmp7 := visited
+							_, _tmp8 := _tmp7[_tmp6]
+							if !(_tmp8) {
+								visited[candidate] = step
+								next = append(append([]string{}, next...), []string{candidate}...)
+							}
+							if (visited[candidate] == step) {
+								_tmp9 := candidate
+								_tmp10 := parents
+								_, _tmp11 := _tmp10[_tmp9]
+								if _tmp11 {
+									parents[candidate] = append(append([]string{}, parents[candidate]...), []string{word}...)
+								} else {
+									parents[candidate] = []string{word}
+								}
+							}
+							if (candidate == endWord) {
+								found = true
+							}
+						}
+					}
+					j = (j + 1)
+				}
+				i = (i + 1)
+			}
+		}
+		queue = next
+	}
+	if !found {
+		return _cast[[][]string]([]any{})
+	}
+	var results [][]string = [][]string{}
+	_ = results
+	var rev = func(lst []string) []string {
+		var out []string = []string{}
+		_ = out
+		var i int = (len(lst) - 1)
+		_ = i
+		for (i >= 0) {
+			out = append(append([]string{}, out...), []string{lst[i]}...)
+			i = (i - 1)
+		}
+		return out
+}
+	var backtrack func(string, []string)
+	backtrack = func(word string, path []string) {
+		if (word == beginWord) {
+			results = append(append([][]string{}, results...), [][]string{rev(append(append([]string{}, path...), []string{word}...))}...)
+		} else {
+			var ps []string = parents[word]
+			for _, p := range ps {
+				backtrack(p, append(append([]string{}, path...), []string{word}...))
+			}
+		}
+}
+	backtrack(endWord, []string{})
+	return results
+}
+
+func example_1() {
+	var res [][]string = findLadders("hit", "cog", []string{"hot", "dot", "dog", "lot", "log", "cog"})
+	var sorted []any = func() [][]string {
+	items := [][]string{}
+	for _, r := range res {
+		items = append(items, r)
+	}
+	type pair struct { item []string; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		r := it
+		pairs[idx] = pair{item: it, key: r[2]}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := [][]string{}
+	for _, r := range items {
+		res = append(res, r)
+	}
+	return res
+}()
+	var expected [][]string = [][]string{[]string{"hit", "hot", "dot", "dog", "cog"}, []string{"hit", "hot", "lot", "log", "cog"}}
+	var expSorted []any = func() [][]string {
+	items := [][]string{}
+	for _, r := range expected {
+		items = append(items, r)
+	}
+	type pair struct { item []string; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		r := it
+		pairs[idx] = pair{item: it, key: r[2]}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := [][]string{}
+	for _, r := range items {
+		res = append(res, r)
+	}
+	return res
+}()
+	expect(_equal(sorted, expSorted))
+}
+
+func example_2() {
+	expect(_equal(findLadders("hit", "cog", []string{"hot", "dot", "dog", "lot", "log"}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/word-search-ii.go.out
+++ b/examples/leetcode-out/word-search-ii.go.out
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func exist(board [][]string, word string) bool {
+	var m int = len(board)
+	if (m == 0) {
+		return false
+	}
+	var n int = len(board[0])
+	var visited [][]bool = [][]bool{}
+	_ = visited
+	var r int = 0
+	_ = r
+	for (r < m) {
+		var row []bool = []bool{}
+		_ = row
+		var c int = 0
+		_ = c
+		for (c < n) {
+			row = append(append([]bool{}, row...), []bool{false}...)
+			c = (c + 1)
+		}
+		visited = append(append([][]bool{}, visited...), [][]bool{row}...)
+		r = (r + 1)
+	}
+	var dfs func(int, int, int) bool
+	dfs = func(r int, c int, idx int) bool {
+		if (idx == len(word)) {
+			return true
+		}
+		if ((((r < 0) || (r >= m)) || (c < 0)) || (c >= n)) {
+			return false
+		}
+		if visited[r][c] {
+			return false
+		}
+		if (board[r][c] != _indexString(word, idx)) {
+			return false
+		}
+		visited[r][c] = true
+		if (((dfs((r + 1), c, (idx + 1)) || dfs((r - 1), c, (idx + 1))) || dfs(r, (c + 1), (idx + 1))) || dfs(r, (c - 1), (idx + 1))) {
+			visited[r][c] = false
+			return true
+		}
+		visited[r][c] = false
+		return false
+}
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			if dfs(i, j, 0) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func findWords(board [][]string, words []string) []string {
+	var found []string = []string{}
+	_ = found
+	for _, w := range words {
+		if exist(board, w) {
+			found = append(append([]string{}, found...), []string{w}...)
+		}
+	}
+	return found
+}
+
+func example() {
+	var result []any = func() []string {
+	items := []string{}
+	for _, w := range findWords(board, words) {
+		items = append(items, w)
+	}
+	type pair struct { item string; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		w := it
+		pairs[idx] = pair{item: it, key: w}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := []string{}
+	for _, w := range items {
+		res = append(res, w)
+	}
+	return res
+}()
+	expect(_equal(result, []string{"eat", "oath"}))
+}
+
+var board [][]string = [][]string{[]string{"o", "a", "a", "n"}, []string{"e", "t", "a", "e"}, []string{"i", "h", "k", "r"}, []string{"i", "f", "l", "v"}}
+var words []string = []string{"oath", "pea", "eat", "rain"}
+func main() {
+	example()
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode-out/word-search.go.out
+++ b/examples/leetcode-out/word-search.go.out
@@ -1,0 +1,90 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func exist(board [][]string, word string) bool {
+	var m int = len(board)
+	if (m == 0) {
+		return false
+	}
+	var n int = len(board[0])
+	var visited [][]bool = [][]bool{}
+	_ = visited
+	var r int = 0
+	_ = r
+	for (r < m) {
+		var row []bool = []bool{}
+		_ = row
+		var c int = 0
+		_ = c
+		for (c < n) {
+			row = append(append([]bool{}, row...), []bool{false}...)
+			c = (c + 1)
+		}
+		visited = append(append([][]bool{}, visited...), [][]bool{row}...)
+		r = (r + 1)
+	}
+	var dfs func(int, int, int) bool
+	dfs = func(r int, c int, idx int) bool {
+		if (idx == len(word)) {
+			return true
+		}
+		if ((((r < 0) || (r >= m)) || (c < 0)) || (c >= n)) {
+			return false
+		}
+		if visited[r][c] {
+			return false
+		}
+		if (board[r][c] != _indexString(word, idx)) {
+			return false
+		}
+		visited[r][c] = true
+		if (((dfs((r + 1), c, (idx + 1)) || dfs((r - 1), c, (idx + 1))) || dfs(r, (c + 1), (idx + 1))) || dfs(r, (c - 1), (idx + 1))) {
+			visited[r][c] = false
+			return true
+		}
+		visited[r][c] = false
+		return false
+}
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			if dfs(i, j, 0) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func example_1() {
+	expect((exist(board, "ABCCED") == true))
+}
+
+func example_2() {
+	expect((exist(board, "SEE") == true))
+}
+
+func example_3() {
+	expect((exist(board, "ABCB") == false))
+}
+
+var board [][]string = [][]string{[]string{"A", "B", "C", "E"}, []string{"S", "F", "C", "S"}, []string{"A", "D", "E", "E"}}
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -23,7 +23,7 @@ endif
 MOCHI_TAR := mochi_$(OS)_$(ARCH).tar.gz
 MOCHI_URL := https://github.com/mochilang/mochi/releases/latest/download/$(MOCHI_TAR)
 
-.PHONY: mochi run test clean
+.PHONY: mochi run test compile clean
 
 mochi:
 	@mkdir -p bin
@@ -49,7 +49,15 @@ run: mochi
 	@$(MOCHI_BIN) run $(ID)/*.mochi
 
 test: mochi
-	@find . -name '*.mochi' -print0 | xargs -0 -n1 $(MOCHI_BIN) test
+@find . -name '*.mochi' -print0 | xargs -0 -n1 $(MOCHI_BIN) test
+
+compile: mochi
+	@mkdir -p ../leetcode-out
+	@find . -path ./bin -prune -o -name '*.mochi' -print0 | \
+	while IFS= read -r -d  f; do \
+		base=$(basename $$f .mochi); \
+		$(MOCHI_BIN) build $$f -o ../leetcode-out/$$base.go.out --target go; \
+	done
 
 clean:
 	@rm -rf bin


### PR DESCRIPTION
## Summary
- add `compile` target for LeetCode examples to batch build all solutions to Go
- fix Go compiler panic by initializing memo map for nested compilers
- check in generated Go files under `examples/leetcode-out`

## Testing
- `go version`
- `make -C examples/leetcode mochi`
- `find examples/leetcode -path examples/leetcode/bin -prune -o -name '*.mochi' -print | while read f; do b=$(basename "$f" .mochi); examples/leetcode/bin/mochi build "$f" -o "examples/leetcode-out/$b.go.out" --target go; done`


------
https://chatgpt.com/codex/tasks/task_e_684f01b7be788320a3b297807ede217e