### PR TITLE
Add LeetCode 283 example

### DIFF
--- a/examples/leetcode/283/move-zeroes.mochi
+++ b/examples/leetcode/283/move-zeroes.mochi
@@ -1,0 +1,56 @@
+fun moveZeroes(nums: list<int>): list<int> {
+  var result = nums
+  let n = len(nums)
+  var insert = 0
+  var i = 0
+  while i < n {
+    if nums[i] != 0 {
+      result[insert] = nums[i]
+      insert = insert + 1
+    }
+    i = i + 1
+  }
+  while insert < n {
+    result[insert] = 0
+    insert = insert + 1
+  }
+  return result
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect moveZeroes([0,1,0,3,12]) == [1,3,12,0,0]
+}
+
+test "example 2" {
+  expect moveZeroes([0]) == [0]
+}
+
+// Additional edge cases
+
+test "all zeros" {
+  expect moveZeroes([0,0,0]) == [0,0,0]
+}
+
+test "no zeros" {
+  expect moveZeroes([1,2,3]) == [1,2,3]
+}
+
+test "mixed" {
+  expect moveZeroes([4,0,5,0,6]) == [4,5,6,0,0]
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using 'let' for variables that need to change.
+   let i = 0
+   i = i + 1          // ❌ cannot assign to immutable binding
+   var i = 0          // ✅ use 'var' for a mutable counter
+2. Trying to append using Python style '.append'.
+   result.append(0)   // ❌ lists do not support append
+   result = result + [0]  // ✅ create a new list element
+3. Using negative indexes like Python.
+   nums[-1]            // ❌ invalid index in Mochi
+   nums[len(nums)-1]   // ✅ compute the last index explicitly
+*/


### PR DESCRIPTION
## Summary
- implement `moveZeroes` solution for LeetCode problem 283
- include example tests and tips for common Mochi errors

## Testing
- `go run ./cmd/mochi test examples/leetcode/283/move-zeroes.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684f07e2e8a88320a3b04ea4824c22d6