### PR TITLE
Add LeetCode 286 solution and fix Makefile

### DIFF
--- a/examples/leetcode/286/walls-and-gates.mochi
+++ b/examples/leetcode/286/walls-and-gates.mochi
@@ -1,0 +1,103 @@
+// Solution for LeetCode problem 286 - Walls and Gates
+// The algorithm performs a BFS starting from every gate (0)
+// and fills each empty room (2147483647) with the distance to
+// the nearest gate. Walls (-1) remain unchanged.
+
+fun wallsAndGates(rooms: list<list<int>>): list<list<int>> {
+  let rows = len(rooms)
+  if rows == 0 { return rooms }
+  let cols = len(rooms[0])
+  var queue: list<list<int>> = []
+  for r in 0..rows {
+    for c in 0..cols {
+      if rooms[r][c] == 0 {
+        queue = queue + [[r, c]]
+      }
+    }
+  }
+  var idx = 0
+  while idx < len(queue) {
+    let pos = queue[idx]
+    idx = idx + 1
+    let r = pos[0]
+    let c = pos[1]
+    let dist = rooms[r][c]
+    if r > 0 {
+      if rooms[r-1][c] == 2147483647 {
+        rooms[r-1][c] = dist + 1
+        queue = queue + [[r-1, c]]
+      }
+    }
+    if r + 1 < rows {
+      if rooms[r+1][c] == 2147483647 {
+        rooms[r+1][c] = dist + 1
+        queue = queue + [[r+1, c]]
+      }
+    }
+    if c > 0 {
+      if rooms[r][c-1] == 2147483647 {
+        rooms[r][c-1] = dist + 1
+        queue = queue + [[r, c-1]]
+      }
+    }
+    if c + 1 < cols {
+      if rooms[r][c+1] == 2147483647 {
+        rooms[r][c+1] = dist + 1
+        queue = queue + [[r, c+1]]
+      }
+    }
+  }
+  return rooms
+}
+
+// Test cases from the LeetCode problem statement
+
+test "example" {
+  let INF = 2147483647
+  let rooms = [
+    [INF,-1,0,INF],
+    [INF,INF,INF,-1],
+    [INF,-1,INF,-1],
+    [0,-1,INF,INF]
+  ]
+  let expected = [
+    [3,-1,0,1],
+    [2,2,1,-1],
+    [1,-1,2,-1],
+    [0,-1,3,4]
+  ]
+  expect wallsAndGates(rooms) == expected
+}
+
+test "all walls" {
+  let rooms = [
+    [-1,-1],
+    [-1,-1]
+  ]
+  expect wallsAndGates(rooms) == rooms
+}
+
+test "single gate" {
+  let rooms = [[2147483647,0,2147483647]]
+  let expected = [[1,0,1]]
+  expect wallsAndGates(rooms) == expected
+}
+
+test "empty" {
+  let rooms: list<list<int>> = []
+  expect wallsAndGates(rooms) == rooms
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' when checking values:
+     if rooms[r][c] = 0 { }    // ❌ assignment
+     if rooms[r][c] == 0 { }   // ✅ comparison
+2. Forgetting to declare mutable variables with 'var':
+     let idx = 0
+     idx = idx + 1             // ❌ cannot reassign
+     var idx = 0               // ✅ use 'var' for mutable counters
+3. Mixing int types without explicit values:
+     rooms[r][c] = INF + 1.0   // ❌ INF is int, 1.0 is float
+     rooms[r][c] = INF + 1     // ✅ keep types consistent
+*/

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -49,7 +49,7 @@ run: mochi
 	@$(MOCHI_BIN) run $(ID)/*.mochi
 
 test: mochi
-@find . -name '*.mochi' -print0 | xargs -0 -n1 $(MOCHI_BIN) test
+	@find . -name '*.mochi' -print0 | xargs -0 -n1 $(MOCHI_BIN) test
 
 compile: mochi
 	@mkdir -p ../leetcode-out


### PR DESCRIPTION
## Summary
- implement `wallsAndGates` for LeetCode 286 with tests
- fix Makefile test target indentation so `make` works

## Testing
- `make mochi`
- `./bin/mochi test 286/walls-and-gates.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684f08307ab88320881c372b1eeae39f