### PR TITLE
Run Go outputs for LeetCode 11‑20

### DIFF
--- a/examples/leetcode-out/go-error-11_20.md
+++ b/examples/leetcode-out/go-error-11_20.md
@@ -1,0 +1,45 @@
+# Go execution results for LeetCode problems 11-20
+
+Below are the results of running the generated `.go.out` files for each problem. Programs that ran without output are listed as **success**. Any compile-time errors are included in code fences below their problem.
+
+## Problem 11
+- `container-with-most-water-alt.go.out` – **success**
+- `container-with-most-water.go.out` – **failed**
+
+```
+# command-line-arguments
+/tmp/container-with-most-water.go:12:32: cannot use 0 (untyped int constant) as func([]int) int value in variable declaration
+/tmp/container-with-most-water.go:24:14: invalid operation: area > maxArea (mismatched types int and func([]int) int)
+/tmp/container-with-most-water.go:25:14: cannot use area (variable of type int) as func([]int) int value in assignment
+/tmp/container-with-most-water.go:60:18: undefined: json
+/tmp/container-with-most-water.go:63:15: undefined: json
+```
+
+## Problem 12
+- `integer-to-roman.go.out` – **success** (no output)
+
+## Problem 13
+- `roman-to-integer.go.out` – **success** (no output)
+
+## Problem 14
+- `longest-common-prefix.go.out` – **success** (no output)
+
+## Problem 17
+- `letter-combinations-of-a-phone-number.go.out` – **failed**
+
+```
+# command-line-arguments
+/tmp/letter-combinations-of-a-phone-number.go:27:20: cannot use func() []string{…}() (value of type []string) as []any value in variable declaration
+/tmp/letter-combinations-of-a-phone-number.go:36:12: cannot use next (variable of type []any) as []string value in assignment
+/tmp/letter-combinations-of-a-phone-number.go:70:18: undefined: json
+/tmp/letter-combinations-of-a-phone-number.go:73:15: undefined: json
+```
+
+## Problem 19
+- `remove-nth-node-from-end-of-list.go.out` – **failed**
+
+```
+# command-line-arguments
+/tmp/remove-nth-node-from-end-of-list.go:55:18: undefined: json
+/tmp/remove-nth-node-from-end-of-list.go:58:15: undefined: json
+```


### PR DESCRIPTION
## Summary
- run the `.go.out` files for LeetCode problems 11‑20
- record compile results in `go-error-11_20.md`

## Testing
- `go run` each generated Go file to capture errors

------
https://chatgpt.com/codex/tasks/task_e_684f0dcf95a08320800ff8b9b0036976