### PR TITLE
Fix json import for cast helper

### DIFF
--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -367,6 +367,9 @@ var helperMap = map[string]string{
 
 func (c *Compiler) use(name string) {
 	c.helpers[name] = true
+	if name == "_cast" {
+		c.imports["encoding/json"] = true
+	}
 }
 
 func (c *Compiler) emitRuntime() {


### PR DESCRIPTION
## Summary
- update Go compiler runtime helper `use` to automatically add `encoding/json` whenever the `_cast` helper is required

## Testing
- `go test ./compile/go -run Test`
- `go test ./...` *(fails: `mochi/tools/libmochi/go` and `mochi/tools/libmochi/python`)*

------
https://chatgpt.com/codex/tasks/task_e_684f0de9587c8320bf88629196834f18