### PR TITLE
Enable Go compiler for LeetCode 51‑60

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -565,16 +565,14 @@ func (c *Compiler) compileVar(s *parser.VarStmt) error {
 
 	var typ types.Type = types.AnyType{}
 	if c.env != nil {
-		var err error
-		typ, err = c.env.GetVar(s.Name)
-		if err != nil {
-			if s.Type != nil {
-				typ = resolveTypeRef(s.Type)
-			} else if s.Value != nil {
-				typ = c.inferExprType(s.Value)
-			}
-			c.env.SetVar(s.Name, typ, true)
+		if s.Type != nil {
+			typ = resolveTypeRef(s.Type)
+		} else if s.Value != nil {
+			typ = c.inferExprType(s.Value)
+		} else if t, err := c.env.GetVar(s.Name); err == nil {
+			typ = t
 		}
+		c.env.SetVar(s.Name, typ, true)
 	}
 	typStr := goType(typ)
 
@@ -2534,7 +2532,7 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 			child.SetVar(p.Name, resolveTypeRef(p.Type), true)
 		}
 	}
-       sub := &Compiler{imports: c.imports, helpers: c.helpers, env: child, memo: map[string]*parser.Literal{}}
+	sub := &Compiler{imports: c.imports, helpers: c.helpers, env: child, memo: map[string]*parser.Literal{}}
 	sub.indent = 1
 	if fn.Return != nil {
 		sub.returnType = resolveTypeRef(fn.Return)

--- a/examples/leetcode-out/52/n-queens-ii.go.out
+++ b/examples/leetcode-out/52/n-queens-ii.go.out
@@ -1,0 +1,74 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func totalNQueens(n int) int {
+	var cols []bool = []bool{}
+	_ = cols
+	var i int = 0
+	_ = i
+	for (i < n) {
+		cols = append(append([]bool{}, cols...), []bool{false}...)
+		i = (i + 1)
+	}
+	var diag1 []bool = []bool{}
+	_ = diag1
+	i = 0
+	for (i < ((2 * n))) {
+		diag1 = append(append([]bool{}, diag1...), []bool{false}...)
+		i = (i + 1)
+	}
+	var diag2 []bool = []bool{}
+	_ = diag2
+	i = 0
+	for (i < ((2 * n))) {
+		diag2 = append(append([]bool{}, diag2...), []bool{false}...)
+		i = (i + 1)
+	}
+	var count int = 0
+	_ = count
+	var backtrack func(int)
+	backtrack = func(row int) {
+		if (row == n) {
+			count = (count + 1)
+		} else {
+			for col := 0; col < n; col++ {
+				var d1 int = ((row - col) + n)
+				var d2 int = (row + col)
+				if ((cols[col] || diag1[d1]) || diag2[d2]) {
+					continue
+				}
+				cols[col] = true
+				diag1[d1] = true
+				diag2[d2] = true
+				backtrack((row + 1))
+				cols[col] = false
+				diag1[d1] = false
+				diag2[d2] = false
+			}
+		}
+}
+	backtrack(0)
+	return count
+}
+
+func example_1() {
+	expect((totalNQueens(1) == 1))
+}
+
+func example_2() {
+	expect((totalNQueens(4) == 2))
+}
+
+func example_3() {
+	expect((totalNQueens(5) == 10))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/examples/leetcode-out/56/merge-intervals.go.out
+++ b/examples/leetcode-out/56/merge-intervals.go.out
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func merge(intervals [][]int) [][]int {
+	if (len(intervals) == 0) {
+		return _cast[[][]int]([]any{})
+	}
+	var sorted [][]int = func() [][]int {
+	items := [][]int{}
+	for _, x := range intervals {
+		items = append(items, x)
+	}
+	type pair struct { item []int; key any }
+	pairs := make([]pair, len(items))
+	for idx, it := range items {
+		x := it
+		pairs[idx] = pair{item: it, key: x[0]}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		a, b := pairs[i].key, pairs[j].key
+		switch av := a.(type) {
+		case int:
+			switch bv := b.(type) {
+			case int:
+				return av < bv
+			case float64:
+				return float64(av) < bv
+			}
+		case float64:
+			switch bv := b.(type) {
+			case int:
+				return av < float64(bv)
+			case float64:
+				return av < bv
+			}
+		case string:
+			bs, _ := b.(string)
+			return av < bs
+		}
+		return fmt.Sprint(a) < fmt.Sprint(b)
+	})
+	for idx, p := range pairs {
+		items[idx] = p.item
+	}
+	res := [][]int{}
+	for _, x := range items {
+		res = append(res, x)
+	}
+	return res
+}()
+	var result [][]int = [][]int{}
+	_ = result
+	for _, inter := range sorted {
+		if (len(result) == 0) {
+			result = append(append([][]int{}, result...), [][]int{inter}...)
+		} else 		if (result[(len(result) - 1)][1] < inter[0]) {
+			result = append(append([][]int{}, result...), [][]int{inter}...)
+		} else 		if (inter[1] > result[(len(result) - 1)][1]) {
+			result[(len(result) - 1)][1] = inter[1]
+		}
+	}
+	return result
+}
+
+func example_1() {
+	expect(_equal(merge([][]int{[]int{1, 3}, []int{2, 6}, []int{8, 10}, []int{15, 18}}), [][]int{[]int{1, 6}, []int{8, 10}, []int{15, 18}}))
+}
+
+func example_2() {
+	expect(_equal(merge([][]int{[]int{1, 4}, []int{4, 5}}), [][]int{[]int{1, 5}}))
+}
+
+func single_interval() {
+	expect(_equal(merge([][]int{[]int{1, 4}}), [][]int{[]int{1, 4}}))
+}
+
+func empty_list() {
+	expect(_equal(merge([][]int{}), []any{}))
+}
+
+func main() {
+	example_1()
+	example_2()
+	single_interval()
+	empty_list()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _equal(a, b any) bool {
+    return reflect.DeepEqual(a, b)
+}
+


### PR DESCRIPTION
## Summary
- handle variable declarations that shadow builtins when compiling Go
- improve type inference for query expressions
- add generated Go output for LeetCode problems 52 and 56

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684f71f56e18832090d5951a802d3634