### PR TITLE
Enable go compiler for LeetCode 1–10

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,10 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 10; i++ {
-		if i == 4 {
-			continue // TODO: typing issues
-		}
+       for i := 1; i <= 10; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/examples/leetcode-out/4/median-of-two-sorted-arrays.go.out
+++ b/examples/leetcode-out/4/median-of-two-sorted-arrays.go.out
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func findMedianSortedArrays(nums1 []int, nums2 []int) float64 {
+	var merged []int = []int{}
+	_ = merged
+	var i int = 0
+	_ = i
+	var j int = 0
+	_ = j
+	for ((i < len(nums1)) || (j < len(nums2))) {
+		if (j >= len(nums2)) {
+			merged = append(append([]int{}, merged...), []int{nums1[i]}...)
+			i = (i + 1)
+		} else 		if (i >= len(nums1)) {
+			merged = append(append([]int{}, merged...), []int{nums2[j]}...)
+			j = (j + 1)
+		} else 		if (nums1[i] <= nums2[j]) {
+			merged = append(append([]int{}, merged...), []int{nums1[i]}...)
+			i = (i + 1)
+		} else {
+			merged = append(append([]int{}, merged...), []int{nums2[j]}...)
+			j = (j + 1)
+		}
+	}
+	var total int = len(merged)
+	if ((total % 2) == 1) {
+		return _cast[float64](merged[(total / 2)])
+	}
+	var mid1 int = merged[((total / 2) - 1)]
+	var mid2 int = merged[(total / 2)]
+	return (_cast[float64](((mid1 + mid2))) / 2.000000)
+}
+
+func example_1() {
+	expect((findMedianSortedArrays([]int{1, 3}, []int{2}) == 2.000000))
+}
+
+func example_2() {
+	expect((findMedianSortedArrays([]int{1, 2}, []int{3, 4}) == 2.500000))
+}
+
+func empty_first() {
+	expect((findMedianSortedArrays([]int{}, []int{1}) == 1.000000))
+}
+
+func empty_second() {
+	expect((findMedianSortedArrays([]int{2}, []int{}) == 2.000000))
+}
+
+func main() {
+	example_1()
+	example_2()
+	empty_first()
+	empty_second()
+}
+
+func _cast[T any](v any) T {
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+

--- a/examples/leetcode/4/median-of-two-sorted-arrays.mochi
+++ b/examples/leetcode/4/median-of-two-sorted-arrays.mochi
@@ -1,5 +1,5 @@
 fun findMedianSortedArrays(nums1: list<int>, nums2: list<int>): float {
-  var merged = []
+  var merged: list<int> = []
   var i = 0
   var j = 0
   while i < len(nums1) || j < len(nums2) {


### PR DESCRIPTION
## Summary
- update LeetCode median-of-two-sorted-arrays example with explicit list type
- compile the example into `examples/leetcode-out`
- run LeetCode example 4 in Go compiler tests

## Testing
- `go test ./...`
- `go test ./compile/go -run LeetCodeExamples -v`


------
https://chatgpt.com/codex/tasks/task_e_684f783954348320ae01f41a09c33f84