### PR TITLE
Enable leetcode examples for go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -110,9 +110,6 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	for i := 1; i <= 10; i++ {
-		if i == 4 {
-			continue // TODO: typing issues
-		}
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/examples/leetcode/4/median-of-two-sorted-arrays.mochi
+++ b/examples/leetcode/4/median-of-two-sorted-arrays.mochi
@@ -1,5 +1,5 @@
 fun findMedianSortedArrays(nums1: list<int>, nums2: list<int>): float {
-  var merged = []
+  var merged: list<int> = []
   var i = 0
   var j = 0
   while i < len(nums1) || j < len(nums2) {

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -43,26 +43,26 @@ mochi:
 	fi
 
 run: mochi
-        @if [ -z "$(ID)" ]; then \
-                echo "Usage: make run ID=<problem number>"; \
-                exit 1; \
-        fi
-        @$(MOCHI_BIN) run $(ID)/*.mochi
+	@if [ -z "$(ID)" ]; then \
+	        echo "Usage: make run ID=<problem number>"; \
+	        exit 1; \
+	fi
+	@$(MOCHI_BIN) run $(ID)/*.mochi
 
 run-go: mochi
-        @if [ -z "$(ID)" ]; then \
-                echo "Usage: make run-go ID=<problem number>"; \
-                exit 1; \
-        fi
-        @out_file=$(ls ../leetcode-out/$(ID)/*.go.out 2>/dev/null | head -n 1); \
-        if [ -z "$$out_file" ]; then \
-                echo "No compiled Go output for problem $(ID)."; \
-                exit 1; \
-        fi; \
-        tmp=$$(mktemp /tmp/leetcode-$(ID)-XXXX.go); \
-        cp "$$out_file" "$$tmp"; \
-        go run "$$tmp"; \
-        rm "$$tmp"
+	@if [ -z "$(ID)" ]; then \
+	        echo "Usage: make run-go ID=<problem number>"; \
+	        exit 1; \
+	fi
+	@out_file=$(ls ../leetcode-out/$(ID)/*.go.out 2>/dev/null | head -n 1); \
+	if [ -z "$$out_file" ]; then \
+	        echo "No compiled Go output for problem $(ID)."; \
+	        exit 1; \
+	fi; \
+	tmp=$$(mktemp /tmp/leetcode-$(ID)-XXXX.go); \
+	cp "$$out_file" "$$tmp"; \
+	go run "$$tmp"; \
+	rm "$$tmp"
 
 test: mochi
 	@find . -name '*.mochi' -print0 | xargs -0 -n1 $(MOCHI_BIN) test


### PR DESCRIPTION
## Summary
- update LeetCode example 4 with explicit int list
- run all problems in go compiler tests
- normalize tabs in leetcode Makefile for running solutions

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1 -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684f77db5da88320ac3ae0d719b1d973