### PR TITLE
Update Go compiler for LeetCode examples 11‑15

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 10; i++ {
+	for i := 1; i <= 15; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -192,6 +192,11 @@ const (
 		"}\n"
 
 	helperEqual = "func _equal(a, b any) bool {\n" +
+		"    av := reflect.ValueOf(a)\n" +
+		"    bv := reflect.ValueOf(b)\n" +
+		"    if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice && av.Len() == 0 && bv.Len() == 0 {\n" +
+		"        return true\n" +
+		"    }\n" +
 		"    return reflect.DeepEqual(a, b)\n" +
 		"}\n"
 


### PR DESCRIPTION
## Summary
- handle empty slice equality in Go runtime helper
- test Go compiler with LeetCode examples 11‑15

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1 -v`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684f7da4a6748320a456d6e34f595d51