### PR TITLE
Add LeetCode 307 example

### DIFF
--- a/examples/leetcode/307/range-sum-query-mutable.mochi
+++ b/examples/leetcode/307/range-sum-query-mutable.mochi
@@ -1,0 +1,53 @@
+// LeetCode #307: Range Sum Query - Mutable
+// Below are some common Mochi language errors and how to fix them.
+// 1. Using '=' instead of '==' when comparing values.
+//    if i = right { }      // ❌ assignment
+//    if i == right { }     // ✅ comparison
+// 2. Forgetting 'var' for a mutable list.
+//    let nums = []
+//    nums = nums + [1]     // ❌ cannot modify
+//    var nums = []         // ✅ mutable
+// 3. Off-by-one loop bounds when summing over a range.
+//    while i <= right { }  // ✅ ensure inclusive range
+
+// Data structure storing the numbers
+ type NumArray {
+  nums: list<int>
+ }
+
+fun newNumArray(values: list<int>): NumArray {
+  return NumArray { nums: values }
+}
+
+fun update(arr: NumArray, index: int, val: int): NumArray {
+  var data = arr.nums
+  data[index] = val
+  return NumArray { nums: data }
+}
+
+fun sumRange(arr: NumArray, left: int, right: int): int {
+  var i = left
+  var total = 0
+  while i <= right {
+    total = total + arr.nums[i]
+    i = i + 1
+  }
+  return total
+}
+
+// Tests based on the LeetCode examples
+
+test "example" {
+  var na = newNumArray([1,3,5])
+  expect sumRange(na, 0, 2) == 9
+  na = update(na, 1, 2)
+  expect sumRange(na, 0, 2) == 8
+}
+
+test "update first and last" {
+  var na = newNumArray([2,4,6,8])
+  na = update(na, 0, 1)
+  na = update(na, 3, 5)
+  expect sumRange(na, 0, 3) == 16
+  expect sumRange(na, 1, 2) == 10
+}


### PR DESCRIPTION
## Summary
- add example solution for LeetCode problem 307
- include tests for the mutable range sum query
- document common Mochi mistakes in the source file

## Testing
- `./examples/leetcode/bin/mochi test examples/leetcode/307/range-sum-query-mutable.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684f846c14b083208b02faf1cf4ed6ac