### PR TITLE
Add LeetCode 308 example

### DIFF
--- a/examples/leetcode/308/range-sum-query-2d-mutable.mochi
+++ b/examples/leetcode/308/range-sum-query-2d-mutable.mochi
@@ -1,0 +1,100 @@
+// Solution for LeetCode problem 308 - Range Sum Query 2D - Mutable
+// This implementation avoids union types and pattern matching.
+
+fun buildPrefix(matrix: list<list<int>>): list<list<int>> {
+  let rows = len(matrix)
+  var cols = 0
+  if rows > 0 {
+    cols = len(matrix[0])
+  }
+  var prefix: list<list<int>> = []
+  var i = 0
+  while i <= rows {
+    var row: list<int> = []
+    var j = 0
+    while j <= cols {
+      row = row + [0]
+      j = j + 1
+    }
+    prefix = prefix + [row]
+    i = i + 1
+  }
+
+  i = 1
+  while i <= rows {
+    var j = 1
+    while j <= cols {
+      prefix[i][j] = matrix[i-1][j-1] + prefix[i-1][j] + prefix[i][j-1] - prefix[i-1][j-1]
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return prefix
+}
+
+fun NumMatrix(matrix: list<list<int>>): map<string, any> {
+  let rows = len(matrix)
+  var cols = 0
+  if rows > 0 {
+    cols = len(matrix[0])
+  }
+  return {"rows": rows, "cols": cols, "data": matrix, "prefix": buildPrefix(matrix)}
+}
+
+fun numMatrixUpdate(nm: map<string, any>, row: int, col: int, val: int) {
+  var data = nm["data"] as list<list<int>>
+  let current = data[row][col]
+  let diff = val - current
+  data[row][col] = val
+  nm["data"] = data
+  var prefix = nm["prefix"] as list<list<int>>
+  var i = row + 1
+  while i <= nm["rows"] as int {
+    var j = col + 1
+    while j <= nm["cols"] as int {
+      prefix[i][j] = prefix[i][j] + diff
+      j = j + 1
+    }
+    i = i + 1
+  }
+  nm["prefix"] = prefix
+}
+
+fun numMatrixSumRegion(nm: map<string, any>, row1: int, col1: int, row2: int, col2: int): int {
+  let p = nm["prefix"] as list<list<int>>
+  let a = p[row2+1][col2+1]
+  let b = p[row1][col2+1]
+  let c = p[row2+1][col1]
+  let d = p[row1][col1]
+  return a - b - c + d
+}
+
+// Basic tests from the LeetCode description
+
+test "example" {
+  var nm = NumMatrix([
+    [3,0,1,4,2],
+    [5,6,3,2,1],
+    [1,2,0,1,5],
+    [4,1,0,1,7],
+    [1,0,3,0,5],
+  ])
+  expect numMatrixSumRegion(nm, 2, 1, 4, 3) == 8
+  numMatrixUpdate(nm, 3, 2, 2)
+  expect numMatrixSumRegion(nm, 2, 1, 4, 3) == 10
+}
+
+test "single element" {
+  var nm = NumMatrix([[1]])
+  expect numMatrixSumRegion(nm, 0, 0, 0, 0) == 1
+  numMatrixUpdate(nm, 0, 0, 5)
+  expect numMatrixSumRegion(nm, 0, 0, 0, 0) == 5
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' when comparing values.
+2. Reassigning a value declared with 'let'. Use 'var' for mutable bindings.
+3. Forgetting to update the prefix sums after changing the matrix.
+4. Trying to use union types or 'match'. This example uses only maps and simple loops.
+*/


### PR DESCRIPTION
## Summary
- implement Range Sum Query 2D - Mutable
- add tests for typical use cases
- document common Mochi errors

## Testing
- `go run ./cmd/mochi test examples/leetcode/308/range-sum-query-2d-mutable.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684f847b55108320a5101c1cac3c962c