### PR TITLE
Support LeetCode examples 16-20

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 15; i++ {
+	for i := 1; i <= 20; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- allow comparisons involving `any` in Go compiler
- run LeetCode examples up to problem 20 in compiler tests

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684f885c86648320beb0e381d18c6bf7