### PR TITLE
Extend Go compiler example coverage

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 20; i++ {
+	for i := 1; i <= 25; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- fix Go compiler to handle nested empty list literals using `compileExprHint`
- run LeetCode examples 1-25 by updating test range

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fa10d7378832083fb65dd7215380a