### PR TITLE
Enable more LeetCode examples

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -1302,7 +1302,34 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 	switch op {
 	case "+", "-", "*", "/", "%":
 		if op != "+" && (isAny(leftType) || isAny(rightType)) {
-			return "", types.AnyType{}, fmt.Errorf("operator %q cannot be used on types %s and %s", op, leftType, rightType)
+			switch {
+			case isInt(leftType) && isAny(rightType):
+				c.use("_cast")
+				right = fmt.Sprintf("_cast[int](%s)", right)
+				expr = fmt.Sprintf("(%s %s %s)", left, op, right)
+				next = types.IntType{}
+				return expr, next, nil
+			case isAny(leftType) && isInt(rightType):
+				c.use("_cast")
+				left = fmt.Sprintf("_cast[int](%s)", left)
+				expr = fmt.Sprintf("(%s %s %s)", left, op, right)
+				next = types.IntType{}
+				return expr, next, nil
+			case isFloat(leftType) && isAny(rightType):
+				c.use("_cast")
+				right = fmt.Sprintf("_cast[float64](%s)", right)
+				expr = fmt.Sprintf("(%s %s %s)", left, op, right)
+				next = types.FloatType{}
+				return expr, next, nil
+			case isAny(leftType) && isFloat(rightType):
+				c.use("_cast")
+				left = fmt.Sprintf("_cast[float64](%s)", left)
+				expr = fmt.Sprintf("(%s %s %s)", left, op, right)
+				next = types.FloatType{}
+				return expr, next, nil
+			default:
+				return "", types.AnyType{}, fmt.Errorf("operator %q cannot be used on types %s and %s", op, leftType, rightType)
+			}
 		}
 		switch {
 		case (isInt64(leftType) && (isInt64(rightType) || isInt(rightType))) ||
@@ -1365,6 +1392,26 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 		case op == "+" && isString(leftType) && isString(rightType):
 			expr = fmt.Sprintf("%s + %s", left, right)
 			next = types.StringType{}
+		case op == "+" && isInt(leftType) && isAny(rightType):
+			c.use("_cast")
+			right = fmt.Sprintf("_cast[int](%s)", right)
+			expr = fmt.Sprintf("(%s + %s)", left, right)
+			next = types.IntType{}
+		case op == "+" && isAny(leftType) && isInt(rightType):
+			c.use("_cast")
+			left = fmt.Sprintf("_cast[int](%s)", left)
+			expr = fmt.Sprintf("(%s + %s)", left, right)
+			next = types.IntType{}
+		case op == "+" && isFloat(leftType) && isAny(rightType):
+			c.use("_cast")
+			right = fmt.Sprintf("_cast[float64](%s)", right)
+			expr = fmt.Sprintf("(%s + %s)", left, right)
+			next = types.FloatType{}
+		case op == "+" && isAny(leftType) && isFloat(rightType):
+			c.use("_cast")
+			left = fmt.Sprintf("_cast[float64](%s)", left)
+			expr = fmt.Sprintf("(%s + %s)", left, right)
+			next = types.FloatType{}
 		case op == "+" && isAny(leftType) && isAny(rightType):
 			c.use("_cast")
 			left = fmt.Sprintf("_cast[[]any](%s)", left)

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 30; i++ {
+	for i := 1; i <= 35; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -113,7 +113,7 @@ func TestPyCompiler_LeetCodeExamples(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")
 	}
-	for i := 1; i <= 30; i++ {
+	for i := 1; i <= 35; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- support arithmetic with `any` values in Go compiler
- expand Go and Python compiler tests to run LeetCode examples 31‑35

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fa6310fec8320b2ac9dcc21ce4fc3