### PR TITLE
Add LeetCode 329 example

### DIFF
--- a/examples/leetcode/329/longest-increasing-path-in-a-matrix.mochi
+++ b/examples/leetcode/329/longest-increasing-path-in-a-matrix.mochi
@@ -1,0 +1,123 @@
+// Solution for LeetCode problem 329 - Longest Increasing Path in a Matrix
+// This implementation avoids union types and pattern matching.
+
+fun longestIncreasingPath(matrix: list<list<int>>): int {
+  let m = len(matrix)
+  if m == 0 {
+    return 0
+  }
+  let n = len(matrix[0])
+
+  var memo: list<list<int>> = []
+  var i = 0
+  while i < m {
+    var row: list<int> = []
+    var j = 0
+    while j < n {
+      row = row + [0]
+      j = j + 1
+    }
+    memo = memo + [row]
+    i = i + 1
+  }
+
+  fun dfs(x: int, y: int): int {
+    let cached = memo[x][y]
+    if cached != 0 {
+      return cached
+    }
+    let val = matrix[x][y]
+    var best = 1
+    if x > 0 {
+      if matrix[x-1][y] > val {
+        let candidate = 1 + dfs(x-1, y)
+        if candidate > best {
+          best = candidate
+        }
+      }
+    }
+    if x + 1 < m {
+      if matrix[x+1][y] > val {
+        let candidate = 1 + dfs(x+1, y)
+        if candidate > best {
+          best = candidate
+        }
+      }
+    }
+    if y > 0 {
+      if matrix[x][y-1] > val {
+        let candidate = 1 + dfs(x, y-1)
+        if candidate > best {
+          best = candidate
+        }
+      }
+    }
+    if y + 1 < n {
+      if matrix[x][y+1] > val {
+        let candidate = 1 + dfs(x, y+1)
+        if candidate > best {
+          best = candidate
+        }
+      }
+    }
+    memo[x][y] = best
+    return best
+  }
+
+  var result = 0
+  i = 0
+  while i < m {
+    var j = 0
+    while j < n {
+      let length = dfs(i, j)
+      if length > result {
+        result = length
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return result
+}
+
+// Test cases from the LeetCode problem statement
+
+test "example 1" {
+  let matrix = [
+    [9,9,4],
+    [6,6,8],
+    [2,1,1]
+  ]
+  expect longestIncreasingPath(matrix) == 4
+}
+
+test "example 2" {
+  let matrix = [
+    [3,4,5],
+    [3,2,6],
+    [2,2,1]
+  ]
+  expect longestIncreasingPath(matrix) == 4
+}
+
+test "single cell" {
+  expect longestIncreasingPath([[1]]) == 1
+}
+
+test "empty" {
+  expect longestIncreasingPath([]) == 0
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Forgetting to initialize the memo list before indexing:
+   var memo: list<list<int>>
+   memo[0][0] = 1  // error[I003]: index out of bounds
+   // Fix: build each row in a loop before assigning values.
+2. Reassigning an immutable variable:
+   let best = 1
+   best = 2  // error[E004]: cannot reassign immutable binding
+   // Fix: declare with 'var' when mutation is required.
+3. Trying to use union types or 'match' expressions for control flow.
+   // This solution only uses if/else statements and loops.
+*/


### PR DESCRIPTION
## Summary
- add an example solution for LeetCode problem 329
- show tests and common mistakes in comments

## Testing
- `make test STAGE=parser`
- `go run ./cmd/mochi test examples/leetcode/329/longest-increasing-path-in-a-matrix.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684fa789ee00832092146726ef17fea4