### PR TITLE
Extend Go compiler for more leetcode examples

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 35; i++ {
+	for i := 1; i <= 40; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/compile/go/infer.go
+++ b/compile/go/infer.go
@@ -166,6 +166,38 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 			}
 		}
 		return types.AnyType{}
+	case p.FunExpr != nil:
+		params := make([]types.Type, len(p.FunExpr.Params))
+		for i, par := range p.FunExpr.Params {
+			if par.Type != nil {
+				params[i] = resolveTypeRef(par.Type)
+			} else {
+				params[i] = types.AnyType{}
+			}
+		}
+		var ret types.Type = types.VoidType{}
+		if p.FunExpr.Return != nil {
+			ret = resolveTypeRef(p.FunExpr.Return)
+		} else if p.FunExpr.ExprBody != nil {
+			ret = c.inferExprType(p.FunExpr.ExprBody)
+		} else {
+			ret = types.AnyType{}
+		}
+		return types.FuncType{Params: params, Return: ret}
+	case p.Generate != nil:
+		switch p.Generate.Target {
+		case "text":
+			return types.StringType{}
+		case "embedding":
+			return types.ListType{Elem: types.FloatType{}}
+		default:
+			if c.env != nil {
+				if st, ok := c.env.GetStruct(p.Generate.Target); ok {
+					return st
+				}
+			}
+			return types.AnyType{}
+		}
 	case p.Call != nil:
 		switch p.Call.Func {
 		case "len":

--- a/examples/leetcode/32/longest-valid-parentheses.mochi
+++ b/examples/leetcode/32/longest-valid-parentheses.mochi
@@ -1,6 +1,6 @@
 fun longestValidParentheses(s: string): int {
   let n = len(s)
-  var stack = []
+  var stack: list<int> = []
   var best = 0
   var last = -1
   for i in 0..n {


### PR DESCRIPTION
## Summary
- allow shadowing builtins in `let` declarations
- infer types for function literals and `generate` expressions
- run leetcode examples up to 40
- fix missing type in example 32

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684faa0302d48320a30fc3e5dc9b9435