### PR TITLE
Run leetcode examples 11-15 in TS tests

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -131,7 +131,7 @@ func TestTSCompiler_LeetCodeExamples(t *testing.T) {
 	if err := bench.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
-	for i := 1; i <= 10; i++ {
+       for i := 1; i <= 15; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- extend TS compiler tests to cover leetcode examples 11–15

## Testing
- `go test ./compile/ts -run LeetCodeExamples -count=1`


------
https://chatgpt.com/codex/tasks/task_e_684fb01700a0832097f5c0535de974f1