### PR TITLE
Enable Go compiler for LeetCode 41-50

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 40; i++ {
+	for i := 1; i <= 50; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- handle variable collisions in query generation
- support precise float literals
- extend Go compiler tests to run LeetCode examples 41–50

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples/49 -count=1 -v`
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples/50 -count=1 -v`
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_684fb36f38a0832088dd8dc085879cf4