### PR TITLE
Extend python compiler example coverage

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -652,22 +652,30 @@ func (c *Compiler) compileIf(stmt *parser.IfStmt, kw string) error {
 	c.writeIndent()
 	c.buf.WriteString(fmt.Sprintf("%s %s:\n", kw, cond))
 	c.indent++
-	for _, s := range stmt.Then {
-		if err := c.compileStmt(s); err != nil {
-			return err
+	if len(stmt.Then) == 0 {
+		c.writeln("pass")
+	} else {
+		for _, s := range stmt.Then {
+			if err := c.compileStmt(s); err != nil {
+				return err
+			}
 		}
 	}
 	c.indent--
 	if stmt.ElseIf != nil {
 		return c.compileIf(stmt.ElseIf, "elif")
 	}
-	if len(stmt.Else) > 0 {
+	if stmt.Else != nil {
 		c.writeIndent()
 		c.buf.WriteString("else:\n")
 		c.indent++
-		for _, s := range stmt.Else {
-			if err := c.compileStmt(s); err != nil {
-				return err
+		if len(stmt.Else) == 0 {
+			c.writeln("pass")
+		} else {
+			for _, s := range stmt.Else {
+				if err := c.compileStmt(s); err != nil {
+					return err
+				}
 			}
 		}
 		c.indent--

--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -113,7 +113,7 @@ func TestPyCompiler_LeetCodeExamples(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")
 	}
-	for i := 1; i <= 40; i++ {
+	for i := 1; i <= 45; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- handle empty `if` and `else` blocks when compiling to Python
- run LeetCode examples up through 45 in Python compiler tests

## Testing
- `go test ./compile/py -run LeetCodeExamples -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fb2865ed88320a0fb5c4db08b1ca8