### PR TITLE
Extend LeetCode test set

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 40; i++ {
+	for i := 1; i <= 45; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- cover LeetCode examples up through 45 in Go compiler tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fb33c79a48320b0295264cedec32b