### PR TITLE
Add LeetCode 373 solution

### DIFF
--- a/examples/leetcode/373/find-k-pairs-with-smallest-sums.mochi
+++ b/examples/leetcode/373/find-k-pairs-with-smallest-sums.mochi
@@ -1,0 +1,43 @@
+// Solution for LeetCode problem 373 - Find K Pairs with Smallest Sums
+
+fun kSmallestPairs(nums1: list<int>, nums2: list<int>, k: int): list<list<int>> {
+  var pairs: list<list<int>> = []
+  for a in nums1 {
+    for b in nums2 {
+      pairs = pairs + [[a, b]]
+    }
+  }
+  let sorted = from p in pairs sort by p[0] + p[1] select p
+  if k < len(sorted) {
+    return sorted[0:k]
+  }
+  return sorted
+}
+
+// Test cases based on the LeetCode examples
+
+test "example 1" {
+  expect kSmallestPairs([1,7,11], [2,4,6], 3) == [[1,2],[1,4],[1,6]]
+}
+
+test "example 2" {
+  expect kSmallestPairs([1,1,2], [1,2,3], 2) == [[1,1],[1,1]]
+}
+
+test "example 3" {
+  expect kSmallestPairs([1,2], [3], 3) == [[1,3],[2,3]]
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Confusing assignment with comparison:
+     if k = 0 { }
+   // ❌ This assigns to k. Use '==' to compare.
+2. Creating an empty list without specifying its element type:
+     var pairs = []
+   // ❌ Type cannot be inferred. Use:
+     var pairs: list<list<int>> = []
+3. Forgetting that slices exclude the end index:
+     sorted[0:k+1]  // returns k+1 items
+   // ✅ Use 'sorted[0:k]' to get the first k pairs.
+*/


### PR DESCRIPTION
## Summary
- implement `kSmallestPairs` example in `examples/leetcode/373`
- add tests demonstrating the solution
- include notes on common Mochi language mistakes

## Testing
- `bin/mochi test 373/find-k-pairs-with-smallest-sums.mochi`


------
https://chatgpt.com/codex/tasks/task_e_684fc70c8ef48320b066b739d116e0a1