### PR TITLE
Add Mochi solution for LC375

### DIFF
--- a/examples/leetcode/375/guess-number-higher-or-lower-ii.mochi
+++ b/examples/leetcode/375/guess-number-higher-or-lower-ii.mochi
@@ -1,0 +1,87 @@
+// Solution for LeetCode problem 375 - Guess Number Higher or Lower II
+// Below are some common Mochi language errors and how to fix them.
+
+fun max(a: int, b: int): int {
+  if a > b {
+    return a
+  }
+  return b
+}
+
+fun getMoneyAmount(n: int): int {
+  var dp: list<list<int>> = []
+  var i = 0
+  while i <= n {
+    var row: list<int> = []
+    var j = 0
+    while j <= n {
+      row = row + [0]
+      j = j + 1
+    }
+    dp = dp + [row]
+    i = i + 1
+  }
+
+  var len = 2
+  while len <= n {
+    var start = 1
+    while start <= n - len + 1 {
+      let end = start + len - 1
+      var best = n * n
+      var guess = start
+      while guess <= end {
+        var left = 0
+        if guess - 1 >= start {
+          left = dp[start][guess - 1]
+        }
+        var right = 0
+        if guess + 1 <= end {
+          right = dp[guess + 1][end]
+        }
+        var cost = guess
+        if left > right {
+          cost = cost + left
+        } else {
+          cost = cost + right
+        }
+        if cost < best {
+          best = cost
+        }
+        guess = guess + 1
+      }
+      dp[start][end] = best
+      start = start + 1
+    }
+    len = len + 1
+  }
+  return dp[1][n]
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect getMoneyAmount(10) == 16
+}
+
+test "example 2" {
+  expect getMoneyAmount(1) == 0
+}
+
+test "example 3" {
+  expect getMoneyAmount(2) == 1
+}
+
+// Additional edge cases
+
+test "n equals 3" {
+  expect getMoneyAmount(3) == 2
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' when comparing numbers.
+2. Declaring arrays with 'let' and then trying to modify them.
+   Use 'var dp: list<list<int>> = []' for mutable arrays.
+3. Off-by-one mistakes when indexing. Remember ranges are inclusive.
+4. Introducing union types or `match` when loops and conditionals are enough.
+*/


### PR DESCRIPTION
## Summary
- add solution for LeetCode problem 375
- include built-in tests for the new solution
- document common Mochi mistakes within the file

## Testing
- `make -C examples/leetcode mochi`
- `./examples/leetcode/bin/mochi test examples/leetcode/375/guess-number-higher-or-lower-ii.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684fc72c5e6c8320bdadbe0ea282f590