### PR TITLE
Extend TS tests to leetcode 20

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -131,7 +131,7 @@ func TestTSCompiler_LeetCodeExamples(t *testing.T) {
 	if err := bench.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
-       for i := 1; i <= 15; i++ {
+	for i := 1; i <= 20; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- extend the leetcode integration test range from 15 to 20 in `compile/ts/compiler_test.go`

## Testing
- `go test ./compile/ts -run LeetCodeExamples -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_684fc6720f348320874c7a7ba9e80940