### PR TITLE
Add Go compiler support for LeetCode 46‑50

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"mochi/interpreter"
@@ -2183,7 +2184,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("func() []%s {\n", retElem))
 	if simple {
-		buf.WriteString(fmt.Sprintf("\tres := []%s{}\n", retElem))
+		buf.WriteString(fmt.Sprintf("\t_res := []%s{}\n", retElem))
 	} else {
 		buf.WriteString(fmt.Sprintf("\titems := []%s{}\n", elemGo))
 	}
@@ -2233,7 +2234,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		if cond != "" {
 			if simple {
 				buf.WriteString(fmt.Sprintf(indent+"if %s {\n", cond))
-				buf.WriteString(fmt.Sprintf(indent+"\tres = append(res, %s)\n", sel))
+				buf.WriteString(fmt.Sprintf(indent+"\t_res = append(_res, %s)\n", sel))
 				buf.WriteString(indent + "}\n")
 			} else {
 				buf.WriteString(fmt.Sprintf(indent+"if %s {\n", cond))
@@ -2242,7 +2243,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			}
 		} else {
 			if simple {
-				buf.WriteString(fmt.Sprintf(indent+"res = append(res, %s)\n", sel))
+				buf.WriteString(fmt.Sprintf(indent+"_res = append(_res, %s)\n", sel))
 			} else {
 				buf.WriteString(fmt.Sprintf(indent+"items = append(items, %s)\n", sanitizeName(q.Var)))
 			}
@@ -2255,7 +2256,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		if cond != "" {
 			if simple {
 				buf.WriteString(fmt.Sprintf(indent+"if %s {\n", cond))
-				buf.WriteString(fmt.Sprintf(indent+"\tres = append(res, %s)\n", sel))
+				buf.WriteString(fmt.Sprintf(indent+"\t_res = append(_res, %s)\n", sel))
 				buf.WriteString(indent + "}\n")
 			} else {
 				buf.WriteString(fmt.Sprintf(indent+"if %s {\n", cond))
@@ -2264,7 +2265,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			}
 		} else {
 			if simple {
-				buf.WriteString(fmt.Sprintf(indent+"res = append(res, %s)\n", sel))
+				buf.WriteString(fmt.Sprintf(indent+"_res = append(_res, %s)\n", sel))
 			} else {
 				buf.WriteString(fmt.Sprintf(indent+"items = append(items, %s)\n", sanitizeName(q.Var)))
 			}
@@ -2275,7 +2276,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		if cond != "" {
 			if simple {
 				buf.WriteString(fmt.Sprintf(indent+"if %s {\n", cond))
-				buf.WriteString(fmt.Sprintf(indent+"\tres = append(res, %s)\n", sel))
+				buf.WriteString(fmt.Sprintf(indent+"\t_res = append(_res, %s)\n", sel))
 				buf.WriteString(indent + "}\n")
 			} else {
 				buf.WriteString(fmt.Sprintf(indent+"if %s {\n", cond))
@@ -2284,7 +2285,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			}
 		} else {
 			if simple {
-				buf.WriteString(fmt.Sprintf(indent+"res = append(res, %s)\n", sel))
+				buf.WriteString(fmt.Sprintf(indent+"_res = append(_res, %s)\n", sel))
 			} else {
 				buf.WriteString(fmt.Sprintf(indent+"items = append(items, %s)\n", sanitizeName(q.Var)))
 			}
@@ -2303,7 +2304,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	buf.WriteString(indent + "}\n")
 
 	if simple {
-		buf.WriteString("\treturn res\n")
+		buf.WriteString("\treturn _res\n")
 		buf.WriteString("}()")
 		return buf.String(), nil
 	}
@@ -2359,11 +2360,11 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		buf.WriteString("\t}\n")
 	}
 
-	buf.WriteString(fmt.Sprintf("\tres := []%s{}\n", retElem))
+	buf.WriteString(fmt.Sprintf("\t_res := []%s{}\n", retElem))
 	buf.WriteString(fmt.Sprintf("\tfor _, %s := range items {\n", sanitizeName(q.Var)))
-	buf.WriteString(fmt.Sprintf("\t\tres = append(res, %s)\n", sel))
+	buf.WriteString(fmt.Sprintf("\t\t_res = append(_res, %s)\n", sel))
 	buf.WriteString("\t}\n")
-	buf.WriteString("\treturn res\n")
+	buf.WriteString("\treturn _res\n")
 	buf.WriteString("}()")
 	return buf.String(), nil
 }
@@ -2411,7 +2412,7 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 	case l.Int != nil:
 		return fmt.Sprintf("%d", *l.Int), nil
 	case l.Float != nil:
-		return fmt.Sprintf("%f", *l.Float), nil
+		return strconv.FormatFloat(*l.Float, 'f', -1, 64), nil
 	case l.Str != nil:
 		return fmt.Sprintf("%q", *l.Str), nil
 	case l.Bool != nil:

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 45; i++ {
+	for i := 1; i <= 50; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/tests/compiler/go/dataset.go.out
+++ b/tests/compiler/go/dataset.go.out
@@ -12,13 +12,13 @@ type Person struct {
 func main() {
 	var people []Person = []Person{Person{Name: "Alice", Age: 30}, Person{Name: "Bob", Age: 15}, Person{Name: "Charlie", Age: 65}}
 	var names []string = func() []string {
-	res := []string{}
+	_res := []string{}
 	for _, p := range people {
 		if (p.Age >= 18) {
-			res = append(res, p.Name)
+			_res = append(_res, p.Name)
 		}
 	}
-	return res
+	return _res
 }()
 	for _, n := range names {
 		fmt.Println(n)

--- a/tests/compiler/go/dataset_sort_take_limit.go.out
+++ b/tests/compiler/go/dataset_sort_take_limit.go.out
@@ -59,11 +59,11 @@ func main() {
 	if take < len(items) {
 		items = items[:take]
 	}
-	res := []Product{}
+	_res := []Product{}
 	for _, p := range items {
-		res = append(res, p)
+		_res = append(_res, p)
 	}
-	return res
+	return _res
 }()
 	fmt.Println("--- Top products (excluding most expensive) ---")
 	for _, item := range expensive {

--- a/tests/compiler/go/math_import_py.go.out
+++ b/tests/compiler/go/math_import_py.go.out
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	var r float64 = 3.000000
-	var area float64 = (func() float64 { v, _ := python.Attr("math", "pi"); return v.(float64) }() * func() float64 { v, _ := python.Attr("math", "pow", r, 2.000000); return v.(float64) }())
+	var r float64 = 3
+	var area float64 = (func() float64 { v, _ := python.Attr("math", "pi"); return v.(float64) }() * func() float64 { v, _ := python.Attr("math", "pow", r, 2); return v.(float64) }())
 	fmt.Println("Area:", area)
 }

--- a/tests/compiler/valid/cross_join.go.out
+++ b/tests/compiler/valid/cross_join.go.out
@@ -26,13 +26,13 @@ func main() {
 	var customers []Customer = []Customer{Customer{Id: 1, Name: "Alice"}, Customer{Id: 2, Name: "Bob"}, Customer{Id: 3, Name: "Charlie"}}
 	var orders []Order = []Order{Order{Id: 100, CustomerId: 1, Total: 250}, Order{Id: 101, CustomerId: 2, Total: 125}, Order{Id: 102, CustomerId: 1, Total: 300}}
 	var result []PairInfo = func() []PairInfo {
-	res := []PairInfo{}
+	_res := []PairInfo{}
 	for _, o := range orders {
 		for _, c := range customers {
-			res = append(res, PairInfo{OrderId: o.Id, OrderCustomerId: o.CustomerId, PairedCustomerName: c.Name, OrderTotal: o.Total})
+			_res = append(_res, PairInfo{OrderId: o.Id, OrderCustomerId: o.CustomerId, PairedCustomerName: c.Name, OrderTotal: o.Total})
 		}
 	}
-	return res
+	return _res
 }()
 	fmt.Println("--- Cross Join: All order-customer pairs ---")
 	for _, entry := range result {

--- a/tests/compiler/valid/join.go.out
+++ b/tests/compiler/valid/join.go.out
@@ -25,14 +25,14 @@ func main() {
 	var customers []Customer = []Customer{Customer{Id: 1, Name: "Alice"}, Customer{Id: 2, Name: "Bob"}, Customer{Id: 3, Name: "Charlie"}}
 	var orders []Order = []Order{Order{Id: 100, CustomerId: 1, Total: 250}, Order{Id: 101, CustomerId: 2, Total: 125}, Order{Id: 102, CustomerId: 1, Total: 300}, Order{Id: 103, CustomerId: 4, Total: 80}}
 	var result []PairInfo = func() []PairInfo {
-	res := []PairInfo{}
+	_res := []PairInfo{}
 	for _, o := range orders {
 		for _, c := range customers {
 			if !((o.CustomerId == c.Id)) { continue }
-			res = append(res, PairInfo{OrderId: o.Id, CustomerName: c.Name, Total: o.Total})
+			_res = append(_res, PairInfo{OrderId: o.Id, CustomerName: c.Name, Total: o.Total})
 		}
 	}
-	return res
+	return _res
 }()
 	fmt.Println("--- Orders with customer info ---")
 	for _, entry := range result {

--- a/tests/compiler/valid/stream_on_emit.go.out
+++ b/tests/compiler/valid/stream_on_emit.go.out
@@ -20,7 +20,7 @@ func main() {
 		close(_done0)
 		return nil
 	})
-	_, _ = sensorStream.Emit(context.Background(), Sensor{Id: "sensor-1", Temperature: 22.500000})
+	_, _ = sensorStream.Emit(context.Background(), Sensor{Id: "sensor-1", Temperature: 22.5})
 	<-_done0
 	sensorStream.Close()
 }


### PR DESCRIPTION
## Summary
- format float literals with full precision
- avoid variable name collision in query generation
- test Go compilation of LeetCode 46-50 examples
- update golden outputs after float formatting changes

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1 -v`
- `go test ./compile/go -run TestGoCompiler_GoldenOutput -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fc5c6c4d48320ba9e7a644f02c388