### PR TITLE
Run more LeetCode examples in TS compiler tests

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -131,7 +131,7 @@ func TestTSCompiler_LeetCodeExamples(t *testing.T) {
 	if err := bench.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
-	for i := 1; i <= 20; i++ {
+	for i := 1; i <= 25; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- test the TypeScript compiler using LeetCode examples 1‑25

## Testing
- `go test ./compile/ts -run LeetCodeExamples -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fc993256483208967c72dd6698277