### PR TITLE
Expand Go compiler test set

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 50; i++ {
+	for i := 1; i <= 55; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- extend LeetCode example tests to include problems 51-55

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fcb5cbdd483209f6c85cb36295384