### PR TITLE
Run more leetcode examples in TS tests

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -131,7 +131,7 @@ func TestTSCompiler_LeetCodeExamples(t *testing.T) {
 	if err := bench.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
-	for i := 1; i <= 25; i++ {
+	for i := 1; i <= 30; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- extend LeetCode TypeScript compiler tests to include examples 26‒30

## Testing
- `go test ./compile/ts -run LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fcc35ef748320a97575f43071d61c