### PR TITLE
Add LeetCode 376 example

### DIFF
--- a/examples/leetcode/376/wiggle-subsequence.mochi
+++ b/examples/leetcode/376/wiggle-subsequence.mochi
@@ -1,0 +1,50 @@
+fun wiggleMaxLength(nums: list<int>): int {
+  let n = len(nums)
+  if n < 2 { return n }
+
+  var up = 1
+  var down = 1
+  for i in 1..n {
+    if nums[i] > nums[i-1] {
+      up = down + 1
+    } else if nums[i] < nums[i-1] {
+      down = up + 1
+    }
+  }
+  if up > down {
+    return up
+  }
+  return down
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect wiggleMaxLength([1,7,4,9,2,5]) == 6
+}
+
+test "example 2" {
+  expect wiggleMaxLength([1,17,5,10,13,15,10,5,16,8]) == 7
+}
+
+test "example 3" {
+  expect wiggleMaxLength([1,2,3,4,5,6,7,8,9]) == 2
+}
+
+// Additional edge cases
+
+test "single element" {
+  expect wiggleMaxLength([5]) == 1
+}
+
+test "two equal" {
+  expect wiggleMaxLength([3,3]) == 1
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Missing 'var' keyword when assigning to variables that change.
+2. Using '=' instead of '==' when comparing values in conditions.
+3. Off-by-one errors when iterating over arrays; ranges in Mochi are end-exclusive.
+4. Use '+' to concatenate lists instead of methods like 'push'.
+*/


### PR DESCRIPTION
## Summary
- add a `wiggle-subsequence.mochi` solution for LeetCode 376
- include tests and notes about common Mochi mistakes

## Testing
- `bin/mochi test 376/wiggle-subsequence.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684fc9cc042c83208b47945d86022904