### PR TITLE
Enable LeetCode 31-35 tests for TypeScript

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -131,7 +131,7 @@ func TestTSCompiler_LeetCodeExamples(t *testing.T) {
 	if err := bench.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
-	for i := 1; i <= 30; i++ {
+	for i := 1; i <= 35; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- extend TypeScript compiler test suite to run LeetCode examples 31‑35

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fcdc94c6883208255a6bc8d29b0dd