### PR TITLE
Extend Go compiler tests for leetcode examples 56-60

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 55; i++ {
+	for i := 1; i <= 60; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- run Go compiler tests against leetcode examples up to 60

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fcd76b0b08320b302930d6dfc91e7