### PR TITLE
Add support for more leetcode examples

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 60; i++ {
+	for i := 1; i <= 65; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/compile/go/infer.go
+++ b/compile/go/infer.go
@@ -58,6 +58,19 @@ func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
 			t = types.AnyType{}
 		case "==", "!=", "<", "<=", ">", ">=":
 			t = types.BoolType{}
+		case "&&", "||":
+			if isBool(t) && isBool(rt) {
+				t = types.BoolType{}
+			} else {
+				t = types.AnyType{}
+			}
+		case "in":
+			switch rt.(type) {
+			case types.MapType, types.ListType, types.StringType:
+				t = types.BoolType{}
+			default:
+				t = types.AnyType{}
+			}
 		default:
 			t = types.AnyType{}
 		}


### PR DESCRIPTION
## Summary
- extend compiler test suite to include leetcode problems 61-65
- update inference logic for boolean operators

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_684fd12041288320a65303fcc2f8c04b