### PR TITLE
Extend go compiler tests to cover leetcode 66-70

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 65; i++ {
+	for i := 1; i <= 70; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- compile and run leetcode examples up to problem 70

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fd409139c8320a71a474c3414f257