### PR TITLE
Enable python tests through leetcode 70

### DIFF
--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -113,7 +113,7 @@ func TestPyCompiler_LeetCodeExamples(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")
 	}
-	for i := 1; i <= 65; i++ {
+	for i := 1; i <= 70; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- expand python compiler integration tests to cover leetcode examples 66-70

## Testing
- `go test ./compile/py -run LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fd416089483209c9cdf97456630e7