### PR TITLE
Fix leetcode 398 example

### DIFF
--- a/examples/leetcode/398/random-pick-index.mochi
+++ b/examples/leetcode/398/random-pick-index.mochi
@@ -26,8 +26,7 @@ fun pick(p: RandomPicker, target: int): int {
   if len(matches) == 0 {
     return -1
   }
-  let ts = now()
-  let idx = int(ts % len(matches))
+  let idx = now() % len(matches)
   return matches[idx]
 }
 
@@ -46,7 +45,7 @@ test "single match" {
 
 test "no match" {
   let p = newPicker([1,2])
-  expect pick(p, 3) == -1
+  expect pick(p, 3) == (-1)
 }
 
 /*


### PR DESCRIPTION
## Summary
- fix random-pick-index sample for problem 398
- remove invalid `int` call
- adjust test for no-match case

## Testing
- `make build`
- `/root/bin/mochi test examples/leetcode/398/random-pick-index.mochi`

------
https://chatgpt.com/codex/tasks/task_e_684fe96c8e7883208484f5a7d31ca563