### PR TITLE
Add v0.7.4 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # 📦 CHANGELOG.md
+## [0.7.4] – 2025-06-16
+
+### Added
+
+* LeetCode solutions 241–400 with Python and TypeScript outputs
+* Go versions compiled for problems 361–400
+* Numeric comparisons across integers and floats
+* Slice concatenation support
+* Nested functions and globals in the TypeScript compiler
+* Go compiler arithmetic with `any` and empty literal assignments
+
+### Fixed
+
+* Stable float formatting in the Python compiler
+* Random Pick Index and LeetCode 321 examples
+
 ## [0.7.3] – 2025-06-15
 
 ### Added

--- a/releases/v0.7.4.md
+++ b/releases/v0.7.4.md
@@ -1,0 +1,24 @@
+# Jun 2025 (v0.7.4)
+
+Mochi v0.7.4 finishes the LeetCode example suite and improves runtime and compiler support.
+
+## Example Library
+
+- Added solutions for LeetCode problems 241–400
+- Python and TypeScript outputs generated for problems 1–400
+- Compiled Go versions for problems 361–400
+
+## Runtime
+
+- Numeric comparisons work across integers and floats
+- Slices support concatenation
+
+## Compilers
+
+- Go compiler handles arithmetic with `any` and empty literal assignments
+- TypeScript compiler supports nested functions and global variables
+- Fixed float formatting in the Python compiler
+
+## Examples
+
+- Fixed Random Pick Index and LeetCode 321 solutions


### PR DESCRIPTION
## Summary
- document release v0.7.4
- add changelog entries for v0.7.4

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_684ff1b02eb88320b2bd7a7c382db4de