### PR TITLE
Support typed list literals in Go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 70; i++ {
+	for i := 1; i <= 80; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -194,7 +194,11 @@ const (
 	helperEqual = "func _equal(a, b any) bool {\n" +
 		"    av := reflect.ValueOf(a)\n" +
 		"    bv := reflect.ValueOf(b)\n" +
-		"    if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice && av.Len() == 0 && bv.Len() == 0 {\n" +
+		"    if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {\n" +
+		"        if av.Len() != bv.Len() { return false }\n" +
+		"        for i := 0; i < av.Len(); i++ {\n" +
+		"            if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) { return false }\n" +
+		"        }\n" +
 		"        return true\n" +
 		"    }\n" +
 		"    return reflect.DeepEqual(a, b)\n" +


### PR DESCRIPTION
## Summary
- handle typed list literals using type hints in Go compiler
- enhance `_equal` runtime helper for cross-type slice comparison
- test LeetCode examples up to 80

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ff58d929c8320b69f744108b58063