### PR TITLE
Extend python leetcode tests up to 90

### DIFF
--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -113,7 +113,7 @@ func TestPyCompiler_LeetCodeExamples(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")
 	}
-	for i := 1; i <= 80; i++ {
+	for i := 1; i <= 90; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- run Python compiler tests against LeetCode examples 1-90

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ff87835448320af000ea328c72ca2