### PR TITLE
Extend LeetCode example coverage

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 80; i++ {
+	for i := 1; i <= 90; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- include LeetCode problems 81–90 in Go compiler tests

## Testing
- `go test ./compile/go -run LeetCodeExamples -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ffaa6feb88320b31eacc37738d443