### PR TITLE
Extend Python LeetCode tests

### DIFF
--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -113,7 +113,7 @@ func TestPyCompiler_LeetCodeExamples(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")
 	}
-	for i := 1; i <= 90; i++ {
+	for i := 1; i <= 100; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- cover LeetCode examples 91–100 in Python compiler tests

## Testing
- `go test ./compile/py -run TestPyCompiler_LeetCodeExamples -count=1`


------
https://chatgpt.com/codex/tasks/task_e_684ffb304cf483209eaf312432df7d86