### PR TITLE
Enhance TS compiler

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -131,7 +131,7 @@ func TestTSCompiler_LeetCodeExamples(t *testing.T) {
 	if err := bench.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
-	for i := 1; i <= 60; i++ {
+	for i := 1; i <= 400; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/tests/compiler/valid/match_expr.ts.out
+++ b/tests/compiler/valid/match_expr.ts.out
@@ -4,20 +4,20 @@ let x: number = 2
 
 let label: string = (() => {
 	const _t = x;
-	switch (_t) {
-	case 1:
+	if (_t === 1) {
 		return "one";
-	case 2:
-		return "two";
-	case 3:
-		return "three";
-	default:
-		return "unknown";
 	}
-	return undefined;
+	if (_t === 2) {
+		return "two";
+	}
+	if (_t === 3) {
+		return "three";
+	}
+	return "unknown";
 })()
 
 function main(): void {
 	console.log(label)
 }
 main()
+


### PR DESCRIPTION
## Summary
- support union types in TS compiler
- avoid TypeScript reserved words when emitting identifiers
- update match expression compilation logic
- expand LeetCode test coverage
- update golden output

## Testing
- `go test ./compile/ts -run TestTSCompiler_GoldenOutput -count=1`
- `go test ./...` *(fails: TestTSCompiler_LeetCodeExamples)*

------
https://chatgpt.com/codex/tasks/task_e_684ffdccef2c832092c916dc2b76bf20