### PR TITLE
Update leetcode test range

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 90; i++ {
+    for i := 1; i <= 400; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- expand Go compiler tests to include LeetCode examples up to 400

## Testing
- `go test ./compile/go -run LeetCodeExamples -count=1 -timeout 1s` *(fails: test timed out after 1s)*

------
https://chatgpt.com/codex/tasks/task_e_684ffddabf18832088e15dd3608e553a