### PR TITLE
Add map-based solution for LeetCode 102

### DIFF
--- a/examples/leetcode/102/binary-tree-level-order-traversal.mochi
+++ b/examples/leetcode/102/binary-tree-level-order-traversal.mochi
@@ -1,79 +1,79 @@
 // Solution for LeetCode problem 102 - Binary Tree Level Order Traversal
 
-// Binary tree node definition
-// Leaf represents an empty tree
-// Node has left, value, and right children
+// Binary tree node helpers implemented without union types or pattern matching
+fun Leaf(): map<string, any> {
+  return {"__name": "Leaf"}
+}
 
-type Tree =
-  Leaf
-  | Node(left: Tree, value: int, right: Tree)
+fun Node(left: map<string, any>, value: int, right: map<string, any>): map<string, any> {
+  return {"__name": "Node", "left": left, "value": value, "right": right}
+}
+
+fun isLeaf(t: map<string, any>): bool { return t["__name"] == "Leaf" }
+fun left(t: map<string, any>): map<string, any> { return t["left"] }
+fun right(t: map<string, any>): map<string, any> { return t["right"] }
+fun value(t: map<string, any>): int { return t["value"] as int }
 
 // Perform a breadth-first traversal returning values level by level
-fun levelOrder(root: Tree): list<list<int>> {
-  if match root {
-       Leaf => true
-       _ => false
-     } {
-    return []
-  }
+fun levelOrder(root: map<string, any>): list<list<int>> {
+  if isLeaf(root) { return [] as list<list<int>> }
+
   var result: list<list<int>> = []
-  var queue: list<Tree> = [root]
+  var queue: list<map<string, any>> = [root]
+
   while len(queue) > 0 {
     var level: list<int> = []
-    var next: list<Tree> = []
+    var next: list<map<string, any>> = []
+
     for node in queue {
-      if match node { Leaf => false _ => true } {
-        level = level + [node.value]
-        if match node.left { Leaf => false _ => true } {
-          next = next + [node.left]
-        }
-        if match node.right { Leaf => false _ => true } {
-          next = next + [node.right]
-        }
-      }
+      level = level + [value(node)]
+      if !isLeaf(left(node)) { next = next + [left(node)] }
+      if !isLeaf(right(node)) { next = next + [right(node)] }
     }
+
     result = result + [level]
     queue = next
   }
+
   return result
 }
 
 // Test cases based on LeetCode examples
 
 test "example 1" {
-  let tree = Node {
-    left: Node { left: Leaf {}, value: 9, right: Leaf {} },
-    value: 3,
-    right: Node {
-      left: Node { left: Leaf {}, value: 15, right: Leaf {} },
-      value: 20,
-      right: Node { left: Leaf {}, value: 7, right: Leaf {} }
-    }
-  }
+  let tree = Node(
+    Node(Leaf(), 9, Leaf()),
+    3,
+    Node(
+      Node(Leaf(), 15, Leaf()),
+      20,
+      Node(Leaf(), 7, Leaf())
+    )
+  )
   expect levelOrder(tree) == [[3], [9,20], [15,7]]
 }
 
 test "single node" {
-  expect levelOrder(Node { left: Leaf {}, value: 1, right: Leaf {} }) == [[1]]
+  expect levelOrder(Node(Leaf(), 1, Leaf())) == [[1]]
 }
 
 test "empty" {
-  expect levelOrder(Leaf {}) == []
+  expect levelOrder(Leaf()) == []
 }
 
 /*
 Common Mochi language errors and how to fix them:
 1. Using '=' instead of '==' for comparisons.
-   if node = Leaf { ... }   // ❌ assignment
-   if node == Leaf { ... }  // ✅ comparison
-2. Declaring a list without a type and later appending values.
-   var q = []               // ❌ type unknown
-   var q: list<Tree> = []   // ✅ specify element type
-3. Reassigning an immutable binding.
+   if len(q) = 0 { }        // ❌ assignment
+   if len(q) == 0 { }       // ✅ comparison
+2. Forgetting to give a list its element type.
+   var q = []               // ❌ type cannot be inferred
+   var q: list<int> = []    // ✅ specify list type
+3. Reassigning a variable declared with 'let'.
    let level = []
-   level = level + [1]      // ❌ cannot assign to 'let'
-   // Fix: use 'var level = []' if mutation is needed.
-4. Using 'null' for empty trees.
-   let t = null             // ❌ undefined value
-   // Fix: use 'Leaf' to represent an empty subtree.
+   level = [1]              // ❌ cannot assign
+   var level = []           // ✅ declare with 'var' if mutation is needed
+4. Calling Node or Leaf without parentheses.
+   Node(Leaf, 1, Leaf)      // ❌ not a function call
+   Node(Leaf(), 1, Leaf())  // ✅ include () when calling
 */


### PR DESCRIPTION
## Summary
- rework 102/binary-tree-level-order-traversal to avoid union types and pattern matching
- update tests to use new helpers
- document common Mochi mistakes

## Testing
- `./examples/leetcode/bin/mochi test examples/leetcode/102/binary-tree-level-order-traversal.mochi`

------
https://chatgpt.com/codex/tasks/task_e_685006e6bbc083208da0d83279410583