### PR TITLE
Refactor LeetCode 103 example without union types

### DIFF
--- a/examples/leetcode/103/binary-tree-zigzag-level-order-traversal.mochi
+++ b/examples/leetcode/103/binary-tree-zigzag-level-order-traversal.mochi
@@ -1,12 +1,19 @@
 // LeetCode 103 - Binary Tree Zigzag Level Order Traversal
 
-// Binary tree type shared across tree problems.
-// Leaf represents an empty node.
-// Node has left subtree, integer value, and right subtree.
+// Binary tree helpers implemented without using union types or pattern matching.
 
-type Tree =
-  Leaf
-  | Node(left: Tree, value: int, right: Tree)
+fun Leaf(): map<string, any> {
+  return {"__name": "Leaf"}
+}
+
+fun Node(left: map<string, any>, value: int, right: map<string, any>): map<string, any> {
+  return {"__name": "Node", "left": left, "value": value, "right": right}
+}
+
+fun isLeaf(t: map<string, any>): bool { return t["__name"] == "Leaf" }
+fun left(t: map<string, any>): map<string, any> { return t["left"] }
+fun right(t: map<string, any>): map<string, any> { return t["right"] }
+fun value(t: map<string, any>): int { return t["value"] as int }
 
 // Helper to reverse a list of integers.
 fun reverseList(xs: list<int>): list<int> {
@@ -20,27 +27,25 @@ fun reverseList(xs: list<int>): list<int> {
 }
 
 // Perform a level order traversal alternating direction on each level.
-fun zigzagLevelOrder(root: Tree): list<list<int>> {
-  if match root { Leaf => true _ => false } {
+fun zigzagLevelOrder(root: map<string, any>): list<list<int>> {
+  if isLeaf(root) {
     return []
   }
 
   var result: list<list<int>> = []
-  var queue: list<Tree> = [root]
+  var queue: list<map<string, any>> = [root]
   var level = 0
 
   while len(queue) > 0 {
     var vals: list<int> = []
-    var next: list<Tree> = []
+    var next: list<map<string, any>> = []
     for node in queue {
-      if match node { Leaf => false _ => true } {
-        vals = vals + [node.value]
-        if match node.left { Leaf => false _ => true } {
-          next = next + [node.left]
-        }
-        if match node.right { Leaf => false _ => true } {
-          next = next + [node.right]
-        }
+      if !isLeaf(node) {
+        vals = vals + [value(node)]
+        let l = left(node)
+        let r = right(node)
+        if !isLeaf(l) { next = next + [l] }
+        if !isLeaf(r) { next = next + [r] }
       }
     }
     if level % 2 == 1 {
@@ -57,41 +62,41 @@ fun zigzagLevelOrder(root: Tree): list<list<int>> {
 // Test cases derived from LeetCode
 
 test "example 1" {
-  let tree = Node {
-    left: Node { left: Leaf {}, value: 9, right: Leaf {} },
-    value: 3,
-    right: Node {
-      left: Node { left: Leaf {}, value: 15, right: Leaf {} },
-      value: 20,
-      right: Node { left: Leaf {}, value: 7, right: Leaf {} }
-    }
-  }
+  let tree = Node(
+    Node(Leaf(), 9, Leaf()),
+    3,
+    Node(
+      Node(Leaf(), 15, Leaf()),
+      20,
+      Node(Leaf(), 7, Leaf())
+    )
+  )
   expect zigzagLevelOrder(tree) == [[3], [20, 9], [15, 7]]
 }
 
 test "single node" {
-  expect zigzagLevelOrder(Node { left: Leaf {}, value: 1, right: Leaf {} }) == [[1]]
+  expect zigzagLevelOrder(Node(Leaf(), 1, Leaf())) == [[1]]
 }
 
 test "empty" {
-  expect zigzagLevelOrder(Leaf {}) == []
+  expect zigzagLevelOrder(Leaf()) == []
 }
 
 test "unbalanced" {
-  let tree = Node {
-    left: Node {
-      left: Node { left: Leaf {}, value: 4, right: Leaf {} },
-      value: 2,
-      right: Leaf {}
-    },
-    value: 1,
-    right: Node {
-      left: Leaf {},
-      value: 3,
-      right: Node { left: Leaf {}, value: 5, right: Leaf {} }
-    }
-  }
-  expect zigzagLevelOrder(tree) == [[1], [3, 2], [4, 5]]
+  let tree = Node(
+    Node(
+      Node(Leaf(), 4, Leaf()),
+      2,
+      Leaf()
+    ),
+    1,
+    Node(
+      Leaf(),
+      3,
+      Node(Leaf(), 5, Leaf())
+    )
+  )
+ expect zigzagLevelOrder(tree) == [[1], [3, 2], [4, 5]]
 }
 
 /*
@@ -105,4 +110,7 @@ Common Mochi language errors and how to fix them:
    var queue = []          // ✅ declare with 'var' if it will change
 3. Forgetting to reset `vals` or `next` each loop causes incorrect output.
    Re-initialize them on every iteration as shown above.
+4. Missing parentheses on Leaf() when creating empty children.
+   Node(Leaf, 1, Leaf)  // ❌ not a call
+   Node(Leaf(), 1, Leaf())  // ✅ use Leaf()
 */


### PR DESCRIPTION
## Summary
- rework `examples/leetcode/103/binary-tree-zigzag-level-order-traversal.mochi` to avoid union types and pattern matching
- adjust tests to use `Leaf()` and `Node()` helpers
- note common language mistakes in comments

## Testing
- `go run ./cmd/mochi test examples/leetcode/103/binary-tree-zigzag-level-order-traversal.mochi`

------
https://chatgpt.com/codex/tasks/task_e_685006f0c6308320abb9edf88f1f2c5d