### PR TITLE
Add union pattern matching to Go compiler

### DIFF
--- a/tests/compiler/go/union_match.go.out
+++ b/tests/compiler/go/union_match.go.out
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+)
+
+type Tree interface { isTree() }
+type Leaf struct {
+}
+func (Leaf) isTree() {}
+type Node struct {
+	Left any `json:"left"`
+	Value int `json:"value"`
+	Right any `json:"right"`
+}
+func (Node) isTree() {}
+
+func isLeaf(t any) bool {
+	return func() bool {
+	_t := t
+	if _, ok := _t.(Leaf); ok {
+		return true
+	}
+	return false
+}()
+}
+
+func main() {
+	fmt.Println(isLeaf(Leaf{}))
+	fmt.Println(isLeaf(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}))
+}
+

--- a/tests/compiler/go/union_match.mochi
+++ b/tests/compiler/go/union_match.mochi
@@ -1,0 +1,13 @@
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+fun isLeaf(t: Tree): bool {
+  return match t {
+    Leaf => true
+    _ => false
+  }
+}
+
+print(isLeaf(Leaf {}))
+print(isLeaf(Node { left: Leaf {}, value: 1, right: Leaf {} }))

--- a/tests/compiler/go/union_match.out
+++ b/tests/compiler/go/union_match.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/compiler/valid/match_expr.go.out
+++ b/tests/compiler/valid/match_expr.go.out
@@ -2,22 +2,37 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 )
 
 func main() {
 	var x int = 2
 	var label string = func() string {
 	_t := x
-	switch _t {
-	case 1:
+	if _equal(_t, 1) {
 		return "one"
-	case 2:
-		return "two"
-	case 3:
-		return "three"
-	default:
-		return "unknown"
 	}
+	if _equal(_t, 2) {
+		return "two"
+	}
+	if _equal(_t, 3) {
+		return "three"
+	}
+	return "unknown"
 }()
 	fmt.Println(label)
 }
+
+func _equal(a, b any) bool {
+    av := reflect.ValueOf(a)
+    bv := reflect.ValueOf(b)
+    if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+        if av.Len() != bv.Len() { return false }
+        for i := 0; i < av.Len(); i++ {
+            if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) { return false }
+        }
+        return true
+    }
+    return reflect.DeepEqual(a, b)
+}
+


### PR DESCRIPTION
## Summary
- extend Go compiler to handle union type patterns in `match` expressions
- add new compiler test for union pattern matching
- update golden outputs for `match_expr` test
- move union-match tests to Go-specific folder

## Testing
- `go test ./compile/go -run TestGoCompiler_SubsetPrograms -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68500961f9d08320a13628b0f8ad3961