### PR TITLE
Improve python compiler match expr

### DIFF
--- a/tests/compiler/py/match_underscore.py.out
+++ b/tests/compiler/py/match_underscore.py.out
@@ -5,7 +5,7 @@ import dataclasses
 import typing
 
 def value_of_root(t: Tree) -> int:
-	return (lambda _t=t: (lambda v: v)(_t.value) if isinstance(_t, Node) else 0)()
+	return (lambda _t0=t: (lambda v: v)(_t0.value) if isinstance(_t0, Node) else 0)()
 
 class Tree:
 	pass

--- a/tests/compiler/valid/match_expr.py.out
+++ b/tests/compiler/valid/match_expr.py.out
@@ -6,7 +6,7 @@ label = None
 
 def main():
 	x = 2
-	label = (lambda _t=x: "one" if _t == 1 else "two" if _t == 2 else "three" if _t == 3 else "unknown")()
+	label = (lambda _t0=x: "one" if _t0 == 1 else "two" if _t0 == 2 else "three" if _t0 == 3 else "unknown")()
 	print(label)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add temporary variable counter in Python compiler
- avoid collisions in generated Python match expressions
- update compiler golden files for new output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68500efaaf7c8320aa2af9e91bb34ebf