### PR TITLE
Add union type support for Go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -110,42 +110,47 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	for i := 1; i <= 90; i++ {
-		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
-		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
-		if err != nil {
-			t.Fatalf("glob error: %v", err)
-		}
-		for _, f := range files {
-			name := fmt.Sprintf("%d/%s", i, filepath.Base(f))
-			t.Run(name, func(t *testing.T) {
-				prog, err := parser.Parse(f)
-				if err != nil {
-					t.Fatalf("parse error: %v", err)
-				}
-				typeEnv := types.NewEnv(nil)
-				if errs := types.Check(prog, typeEnv); len(errs) > 0 {
-					t.Fatalf("type error: %v", errs[0])
-				}
-				c := gocode.New(typeEnv)
-				code, err := c.Compile(prog)
-				if err != nil {
-					t.Fatalf("compile error: %v", err)
-				}
-				tmp := t.TempDir()
-				file := filepath.Join(tmp, "main.go")
-				if err := os.WriteFile(file, code, 0644); err != nil {
-					t.Fatalf("write error: %v", err)
-				}
-				cmd := exec.Command("go", "run", file)
-				cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
-				out, err := cmd.CombinedOutput()
-				if err != nil {
-					t.Fatalf("go run error: %v\n%s", err, out)
-				}
-				// Older examples may print results; just ensure the
-				// program executes without error.
-				_ = out
-			})
-		}
+		runExample(t, i)
+	}
+	runExample(t, 102)
+}
+
+func runExample(t *testing.T, i int) {
+	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	for _, f := range files {
+		name := fmt.Sprintf("%d/%s", i, filepath.Base(f))
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(f)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			typeEnv := types.NewEnv(nil)
+			if errs := types.Check(prog, typeEnv); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			c := gocode.New(typeEnv)
+			code, err := c.Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.go")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("go", "run", file)
+			cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("go run error: %v\n%s", err, out)
+			}
+			// Older examples may print results; just ensure the
+			// program executes without error.
+			_ = out
+		})
 	}
 }

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -79,6 +79,8 @@ func goType(t types.Type) string {
 		return fmt.Sprintf("map[%s]%s", goType(tt.Key), goType(tt.Value))
 	case types.StructType:
 		return sanitizeName(tt.Name)
+	case types.UnionType:
+		return sanitizeName(tt.Name)
 	case types.FuncType:
 		params := make([]string, len(tt.Params))
 		for i, p := range tt.Params {
@@ -157,6 +159,11 @@ func isStruct(t types.Type) bool {
 	return ok
 }
 
+func isUnion(t types.Type) bool {
+	_, ok := t.(types.UnionType)
+	return ok
+}
+
 func isAny(t types.Type) bool {
 	_, ok := t.(types.AnyType)
 	return ok
@@ -171,18 +178,18 @@ func contains(ops []string, op string) bool {
 	return false
 }
 
-func resolveTypeRef(t *parser.TypeRef) types.Type {
+func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
 	if t == nil {
 		return types.AnyType{}
 	}
 	if t.Fun != nil {
 		params := make([]types.Type, len(t.Fun.Params))
 		for i, p := range t.Fun.Params {
-			params[i] = resolveTypeRef(p)
+			params[i] = c.resolveTypeRef(p)
 		}
 		var ret types.Type = types.VoidType{}
 		if t.Fun.Return != nil {
-			ret = resolveTypeRef(t.Fun.Return)
+			ret = c.resolveTypeRef(t.Fun.Return)
 		}
 		return types.FuncType{Params: params, Return: ret}
 	}
@@ -192,11 +199,11 @@ func resolveTypeRef(t *parser.TypeRef) types.Type {
 		switch name {
 		case "list":
 			if len(args) == 1 {
-				return types.ListType{Elem: resolveTypeRef(args[0])}
+				return types.ListType{Elem: c.resolveTypeRef(args[0])}
 			}
 		case "map":
 			if len(args) == 2 {
-				return types.MapType{Key: resolveTypeRef(args[0]), Value: resolveTypeRef(args[1])}
+				return types.MapType{Key: c.resolveTypeRef(args[0]), Value: c.resolveTypeRef(args[1])}
 			}
 		}
 		return types.AnyType{}
@@ -212,6 +219,14 @@ func resolveTypeRef(t *parser.TypeRef) types.Type {
 		case "bool":
 			return types.BoolType{}
 		default:
+			if c != nil && c.env != nil {
+				if st, ok := c.env.GetStruct(*t.Simple); ok {
+					return st
+				}
+				if ut, ok := c.env.GetUnion(*t.Simple); ok {
+					return ut
+				}
+			}
 			return types.AnyType{}
 		}
 	}

--- a/tests/compiler/go/union_match.go.out
+++ b/tests/compiler/go/union_match.go.out
@@ -9,13 +9,13 @@ type Leaf struct {
 }
 func (Leaf) isTree() {}
 type Node struct {
-	Left any `json:"left"`
+	Left Tree `json:"left"`
 	Value int `json:"value"`
-	Right any `json:"right"`
+	Right Tree `json:"right"`
 }
 func (Node) isTree() {}
 
-func isLeaf(t any) bool {
+func isLeaf(t Tree) bool {
 	return func() bool {
 	_t := t
 	if _, ok := _t.(Leaf); ok {
@@ -29,4 +29,3 @@ func main() {
 	fmt.Println(isLeaf(Leaf{}))
 	fmt.Println(isLeaf(Node{Left: Leaf{}, Value: 1, Right: Leaf{}}))
 }
-


### PR DESCRIPTION
## Summary
- handle custom union and struct types when resolving type references
- emit union types for Go code generation
- refine match expression compilation to avoid name collisions
- update leetcode example tests to include problem 102
- refresh golden output

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples/102 -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6850131455648320b3aeca7a8dee3fa4