### PR TITLE
Fix Python compiler type resolution

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -615,7 +615,7 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 				c.writeln("pass")
 			} else {
 				for _, f := range v.Fields {
-					typStr := pyType(resolveTypeRef(f.Type))
+					typStr := pyType(c.resolveTypeRef(f.Type))
 					c.writeln(fmt.Sprintf("%s: %s", sanitizeName(f.Name), typStr))
 				}
 			}
@@ -637,7 +637,7 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 		} else {
 			for _, m := range t.Members {
 				if m.Field != nil {
-					typStr := pyType(resolveTypeRef(m.Field.Type))
+					typStr := pyType(c.resolveTypeRef(m.Field.Type))
 					c.writeln(fmt.Sprintf("%s: %s", sanitizeName(m.Field.Name), typStr))
 				}
 			}
@@ -788,7 +788,7 @@ func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 		if i < len(ft.Params) {
 			typ = ft.Params[i]
 		} else if p.Type != nil {
-			typ = resolveTypeRef(p.Type)
+			typ = c.resolveTypeRef(p.Type)
 		}
 		if typ != nil {
 			c.buf.WriteString(": " + pyType(typ))
@@ -801,7 +801,7 @@ func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 	if ft.Return != nil {
 		retType = pyType(ft.Return)
 	} else if fun.Return != nil {
-		retType = pyType(resolveTypeRef(fun.Return))
+		retType = pyType(c.resolveTypeRef(fun.Return))
 	}
 	c.buf.WriteString(") -> " + retType + ":\n")
 	child := types.NewEnv(c.env)
@@ -1120,7 +1120,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 			continue
 		}
 		if op.Cast != nil {
-			typ = resolveTypeRef(op.Cast.Type)
+			typ = c.resolveTypeRef(op.Cast.Type)
 			// Casts are ignored in Python code generation
 			continue
 		}

--- a/compile/py/helpers.go
+++ b/compile/py/helpers.go
@@ -163,18 +163,18 @@ func pyType(t types.Type) string {
 	}
 }
 
-func resolveTypeRef(t *parser.TypeRef) types.Type {
+func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
 	if t == nil {
 		return types.AnyType{}
 	}
 	if t.Fun != nil {
 		params := make([]types.Type, len(t.Fun.Params))
 		for i, p := range t.Fun.Params {
-			params[i] = resolveTypeRef(p)
+			params[i] = c.resolveTypeRef(p)
 		}
 		var ret types.Type = types.VoidType{}
 		if t.Fun.Return != nil {
-			ret = resolveTypeRef(t.Fun.Return)
+			ret = c.resolveTypeRef(t.Fun.Return)
 		}
 		return types.FuncType{Params: params, Return: ret}
 	}
@@ -184,11 +184,11 @@ func resolveTypeRef(t *parser.TypeRef) types.Type {
 		switch name {
 		case "list":
 			if len(args) == 1 {
-				return types.ListType{Elem: resolveTypeRef(args[0])}
+				return types.ListType{Elem: c.resolveTypeRef(args[0])}
 			}
 		case "map":
 			if len(args) == 2 {
-				return types.MapType{Key: resolveTypeRef(args[0]), Value: resolveTypeRef(args[1])}
+				return types.MapType{Key: c.resolveTypeRef(args[0]), Value: c.resolveTypeRef(args[1])}
 			}
 		}
 		return types.AnyType{}
@@ -204,6 +204,14 @@ func resolveTypeRef(t *parser.TypeRef) types.Type {
 		case "bool":
 			return types.BoolType{}
 		default:
+			if c.env != nil {
+				if st, ok := c.env.GetStruct(*t.Simple); ok {
+					return st
+				}
+				if ut, ok := c.env.GetUnion(*t.Simple); ok {
+					return ut
+				}
+			}
 			return types.AnyType{}
 		}
 	}

--- a/compile/py/infer.go
+++ b/compile/py/infer.go
@@ -99,7 +99,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 				t = types.AnyType{}
 			}
 		} else if op.Cast != nil {
-			t = resolveTypeRef(op.Cast.Type)
+			t = c.resolveTypeRef(op.Cast.Type)
 		}
 	}
 	return t

--- a/tests/compiler/py/match_underscore.py.out
+++ b/tests/compiler/py/match_underscore.py.out
@@ -14,9 +14,9 @@ class Leaf(Tree):
 	pass
 @dataclasses.dataclass
 class Node(Tree):
-	left: typing.Any
+	left: Tree
 	value: int
-	right: typing.Any
+	right: Tree
 
 def main():
 	print(value_of_root(Node(left=Leaf(), value=5, right=Leaf())))

--- a/tests/compiler/py/union.py.out
+++ b/tests/compiler/py/union.py.out
@@ -11,9 +11,9 @@ class Leaf(Tree):
 	pass
 @dataclasses.dataclass
 class Node(Tree):
-	left: typing.Any
+	left: Tree
 	value: int
-	right: typing.Any
+	right: Tree
 
 t = Node(left=Leaf(), value=42, right=Leaf())
 


### PR DESCRIPTION
## Summary
- improve type resolution in Python compiler so user-defined types aren't lost
- update generated Python code for union tests

## Testing
- `go test ./compile/py -run TestPyCompiler_SubsetPrograms -run TestPyCompiler_GoldenOutput -run TestPyCompiler_LeetCodeExamples -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68501794e3bc83208ab2ec7be98f1587