### PR TITLE
Enable TS compiler for LeetCode 103

### DIFF
--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -131,7 +131,7 @@ func TestTSCompiler_LeetCodeExamples(t *testing.T) {
 	if err := bench.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
-	for i := 1; i <= 102; i++ {
+	for i := 1; i <= 103; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {


### PR DESCRIPTION
## Summary
- run LeetCode example 103 in TypeScript compiler tests

## Testing
- `go test ./compile/ts -run LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685018300174832082560a24ce0f34d9