### PR TITLE
Enable leetcode example 91 in go compiler tests

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 90; i++ {
+	for i := 1; i <= 91; i++ {
 		runExample(t, i)
 	}
 	runExample(t, 102)


### PR DESCRIPTION
## Summary
- run go compiler tests against leetcode example 91

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1 -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68501b356b5c832085434fb0699b3916