### PR TITLE
Enable Python compiler golden tests for LeetCode

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -829,8 +829,11 @@ func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 	origEnv := c.env
 	c.env = child
 	c.indent++
-	for _, n := range nonlocals {
-		c.writeln("nonlocal " + n)
+	if len(nonlocals) > 0 {
+		sort.Strings(nonlocals)
+		for _, n := range nonlocals {
+			c.writeln("nonlocal " + n)
+		}
 	}
 	for _, s := range fun.Body {
 		if err := c.compileStmt(s); err != nil {
@@ -1674,7 +1677,10 @@ func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tmp := fmt.Sprintf("_t%d", c.tmpCount)
+	tmp := "_t"
+	if c.tmpCount > 0 {
+		tmp = fmt.Sprintf("_t%d", c.tmpCount)
+	}
 	c.tmpCount++
 	var expr string
 	for i, cs := range m.Cases {

--- a/examples/leetcode-out/100/same-tree.py.out
+++ b/examples/leetcode-out/100/same-tree.py.out
@@ -5,7 +5,7 @@ import dataclasses
 import typing
 
 def isSameTree(p: Tree, q: Tree) -> bool:
-	return (lambda _t=p: (lambda _t=q: True if isinstance(_t, Leaf) else False)() if isinstance(_t, Leaf) else (lambda pl, pv, pr: (lambda _t=q: (lambda ql, qv, qr: (((pv == qv) and isSameTree(pl, ql)) and isSameTree(pr, qr)))(_t.left, _t.value, _t.right) if isinstance(_t, Node) else False)())(_t.left, _t.value, _t.right) if isinstance(_t, Node) else None)()
+	return (lambda _t=p: (lambda _t1=q: True if isinstance(_t1, Leaf) else False)() if isinstance(_t, Leaf) else (lambda pl, pv, pr: (lambda _t2=q: (lambda ql, qv, qr: (((pv == qv) and isSameTree(pl, ql)) and isSameTree(pr, qr)))(_t2.left, _t2.value, _t2.right) if isinstance(_t2, Node) else False)())(_t.left, _t.value, _t.right) if isinstance(_t, Node) else None)()
 
 class Tree:
 	pass
@@ -14,9 +14,9 @@ class Leaf(Tree):
 	pass
 @dataclasses.dataclass
 class Node(Tree):
-	left: typing.Any
+	left: Tree
 	value: int
-	right: typing.Any
+	right: Tree
 
 def example_1():
 	p = Node(left=Node(left=Leaf(), value=2, right=Leaf()), value=1, right=Node(left=Leaf(), value=3, right=Leaf()))

--- a/examples/leetcode-out/51/n-queens.py.out
+++ b/examples/leetcode-out/51/n-queens.py.out
@@ -9,10 +9,10 @@ def solveNQueens(n: int) -> list[list[str]]:
 	diag1 = {}
 	diag2 = {}
 	def backtrack(row: int, board: list[str]) -> None:
-		nonlocal results
-		nonlocal diag1
 		nonlocal cols
+		nonlocal diag1
 		nonlocal diag2
+		nonlocal results
 		if (row == n):
 			results = (results + [board])
 		else:

--- a/examples/leetcode-out/52/n-queens-ii.py.out
+++ b/examples/leetcode-out/52/n-queens-ii.py.out
@@ -21,8 +21,8 @@ def totalNQueens(n: int) -> int:
 		i = (i + 1)
 	count = 0
 	def backtrack(row: int) -> None:
-		nonlocal count
 		nonlocal cols
+		nonlocal count
 		nonlocal diag1
 		nonlocal diag2
 		if (row == n):

--- a/examples/leetcode-out/94/binary-tree-inorder-traversal.py.out
+++ b/examples/leetcode-out/94/binary-tree-inorder-traversal.py.out
@@ -14,9 +14,9 @@ class Leaf(Tree):
 	pass
 @dataclasses.dataclass
 class Node(Tree):
-	left: typing.Any
+	left: Tree
 	value: int
-	right: typing.Any
+	right: Tree
 
 example1 = Node(left=Leaf(), value=1, right=Node(left=Node(left=Leaf(), value=3, right=Leaf()), value=2, right=Leaf()))
 

--- a/examples/leetcode-out/95/unique-binary-search-trees-ii.py.out
+++ b/examples/leetcode-out/95/unique-binary-search-trees-ii.py.out
@@ -28,9 +28,9 @@ class Empty(Tree):
 	pass
 @dataclasses.dataclass
 class Node(Tree):
-	left: typing.Any
+	left: Tree
 	val: int
-	right: typing.Any
+	right: Tree
 
 trees = generateTrees(3)
 

--- a/examples/leetcode-out/98/validate-binary-search-tree.py.out
+++ b/examples/leetcode-out/98/validate-binary-search-tree.py.out
@@ -5,7 +5,7 @@ import dataclasses
 import typing
 
 def helper(node: Tree, low: MaybeInt, high: MaybeInt) -> bool:
-	return (lambda _t=node: True if isinstance(_t, Leaf) else (lambda l, v, r: (((((lambda _t=low: (lambda x: (v > x))(_t.value) if isinstance(_t, Some) else True if isinstance(_t, _None) else None)()) and ((lambda _t=high: (lambda y: (v < y))(_t.value) if isinstance(_t, Some) else True if isinstance(_t, _None) else None)())) and helper(l, low, Some(value=v))) and helper(r, Some(value=v), high)))(_t.left, _t.value, _t.right) if isinstance(_t, Node) else None)()
+	return (lambda _t=node: True if isinstance(_t, Leaf) else (lambda l, v, r: (((((lambda _t1=low: (lambda x: (v > x))(_t1.value) if isinstance(_t1, Some) else True if isinstance(_t1, _None) else None)()) and ((lambda _t2=high: (lambda y: (v < y))(_t2.value) if isinstance(_t2, Some) else True if isinstance(_t2, _None) else None)())) and helper(l, low, Some(value=v))) and helper(r, Some(value=v), high)))(_t.left, _t.value, _t.right) if isinstance(_t, Node) else None)()
 
 def isValidBST(root: Tree) -> bool:
 	return helper(root, _None(), _None())
@@ -17,9 +17,9 @@ class Leaf(Tree):
 	pass
 @dataclasses.dataclass
 class Node(Tree):
-	left: typing.Any
+	left: Tree
 	value: int
-	right: typing.Any
+	right: Tree
 
 class MaybeInt:
 	pass

--- a/examples/leetcode-out/99/recover-binary-search-tree.py.out
+++ b/examples/leetcode-out/99/recover-binary-search-tree.py.out
@@ -10,7 +10,7 @@ def inorder(t: Tree) -> list[int]:
 def recoverTree(t: Tree) -> Tree:
 	vals = inorder(t)
 	sortedVals = [ x for x in sorted([ x for x in vals ], key=lambda x: x) ]
-	def build(lo: int, hi: int) -> typing.Any:
+	def build(lo: int, hi: int) -> Tree:
 		if (lo >= hi):
 			return Leaf()
 		mid = (((lo + hi)) // 2)
@@ -24,9 +24,9 @@ class Leaf(Tree):
 	pass
 @dataclasses.dataclass
 class Node(Tree):
-	left: typing.Any
+	left: Tree
 	value: int
-	right: typing.Any
+	right: Tree
 
 ex = Node(left=Node(left=Leaf(), value=3, right=Leaf()), value=1, right=Node(left=Leaf(), value=4, right=Leaf()))
 fixed = recoverTree(ex)

--- a/tests/compiler/py/match_underscore.py.out
+++ b/tests/compiler/py/match_underscore.py.out
@@ -5,7 +5,7 @@ import dataclasses
 import typing
 
 def value_of_root(t: Tree) -> int:
-	return (lambda _t0=t: (lambda v: v)(_t0.value) if isinstance(_t0, Node) else 0)()
+	return (lambda _t=t: (lambda v: v)(_t.value) if isinstance(_t, Node) else 0)()
 
 class Tree:
 	pass

--- a/tests/compiler/valid/match_expr.py.out
+++ b/tests/compiler/valid/match_expr.py.out
@@ -6,7 +6,7 @@ label = None
 
 def main():
 	x = 2
-	label = (lambda _t0=x: "one" if _t0 == 1 else "two" if _t0 == 2 else "three" if _t0 == 3 else "unknown")()
+	label = (lambda _t=x: "one" if _t == 1 else "two" if _t == 2 else "three" if _t == 3 else "unknown")()
 	print(label)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure stable ordering of `nonlocal` declarations in Python compiler
- keep first match temporary variable named `_t`
- verify compiler output for LeetCode solutions 1-100
- update golden outputs for changed examples and tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68501b8ad1488320a1b6689e107d4e9e