### PR TITLE
Add LeetCode 92 to Go compiler tests

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,7 +109,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 91; i++ {
+	for i := 1; i <= 92; i++ {
 		runExample(t, i)
 	}
 	runExample(t, 102)


### PR DESCRIPTION
## Summary
- run example 92 in the Go compiler test suite

## Testing
- `go test ./...`
- `go test ./compile/go -run LeetCodeExamples -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68501e0c850483209dfde27b62c0f230