### PR TITLE
Improve Python compiler type inference

### DIFF
--- a/compile/py/helpers.go
+++ b/compile/py/helpers.go
@@ -126,6 +126,11 @@ func isString(t types.Type) bool {
 	return ok
 }
 
+func isBool(t types.Type) bool {
+	_, ok := t.(types.BoolType)
+	return ok
+}
+
 func isAny(t types.Type) bool {
 	if t == nil {
 		return true
@@ -392,6 +397,30 @@ func identName(e *parser.Expr) (string, bool) {
 	}
 	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
 		return p.Target.Selector.Root, true
+	}
+	return "", false
+}
+
+func simpleStringKey(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return *p.Target.Lit.Str, true
 	}
 	return "", false
 }


### PR DESCRIPTION
## Summary
- infer bool type with `isBool`
- detect simple string map keys
- support more operators and built-in calls in inference
- resolve selector types through unions and full paths

## Testing
- `go test ./compile/py -run TestPyCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68501f16a0688320a7a5c8d37ed472d0