### PR TITLE
Enable LeetCode 92 example in Go tests

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,9 +109,9 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 91; i++ {
-		runExample(t, i)
-	}
+    for i := 1; i <= 92; i++ {
+        runExample(t, i)
+    }
 	runExample(t, 102)
 }
 


### PR DESCRIPTION
## Summary
- expand Go compiler LeetCode test range to include problem 92

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68501fead50c8320b292305057b37ec1