### PR TITLE
Expand leetcode compiler tests

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -109,10 +109,9 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 91; i++ {
+	for i := 1; i <= 400; i++ {
 		runExample(t, i)
 	}
-	runExample(t, 102)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- expand Go compiler test to cover LeetCode examples 1-400

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1` *(fails: command stuck/timeout)*


------
https://chatgpt.com/codex/tasks/task_e_68501e3aa2ec832080afd32cf32be567