### PR TITLE
Enable LeetCode 99 example in Go compiler

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -508,6 +508,13 @@ func primaryUsesVar(p *parser.Primary, name string) bool {
 	if p.FunExpr != nil {
 		return exprUsesVarFun(p.FunExpr, name)
 	}
+	if p.Struct != nil {
+		for _, f := range p.Struct.Fields {
+			if exprUsesVar(f.Value, name) {
+				return true
+			}
+		}
+	}
 	if p.Call != nil {
 		if p.Call.Func == name {
 			return true

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -112,6 +112,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	for i := 1; i <= 94; i++ {
 		runExample(t, i)
 	}
+	runExample(t, 99)
 	runExample(t, 102)
 }
 

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -107,6 +107,20 @@ func equalTypes(a, b types.Type) bool {
 	if _, ok := b.(types.AnyType); ok {
 		return true
 	}
+	if ua, ok := a.(types.UnionType); ok {
+		if sb, ok := b.(types.StructType); ok {
+			if _, ok := ua.Variants[sb.Name]; ok {
+				return true
+			}
+		}
+	}
+	if ub, ok := b.(types.UnionType); ok {
+		if sa, ok := a.(types.StructType); ok {
+			if _, ok := ub.Variants[sa.Name]; ok {
+				return true
+			}
+		}
+	}
 	if isInt64(a) && (isInt64(b) || isInt(b)) {
 		return true
 	}


### PR DESCRIPTION
## Summary
- handle struct literals when scanning variable usage so recursive local
  functions compile correctly
- treat union and variant struct types as compatible when checking types
- include leetcode example 99 in Go compiler tests

## Testing
- `go test ./...` *(fails: TestGoCompiler_LeetCodeExamples/102/binary-tree-level-order-traversal.mochi)*

------
https://chatgpt.com/codex/tasks/task_e_68503d24b39883209c793682574b34b1