### PR TITLE
Fix Go compiler casting for match returns

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -114,6 +114,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	}
 	runExample(t, 99)
 	runExample(t, 102)
+	runExample(t, 105)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- handle casting when match case result type doesn't match overall match type
- ensure return statements cast values from `any`
- add LeetCode example 105 to Go compiler tests

## Testing
- `go test ./compile/go -run LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68504a873d80832084f3f751f3119c6c