### PR TITLE
Fix Go return casting, test leetcode 109

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -622,7 +622,8 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		if err != nil {
 			return err
 		}
-		if c.returnType != nil && !equalTypes(c.returnType, c.inferExprType(s.Return.Value)) {
+		exprType := c.inferExprType(s.Return.Value)
+		if c.returnType != nil && (isAny(exprType) || !equalTypes(c.returnType, exprType)) {
 			c.use("_cast")
 			expr = fmt.Sprintf("_cast[%s](%s)", goType(c.returnType), expr)
 		}

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -112,8 +112,9 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	for i := 1; i <= 94; i++ {
 		runExample(t, i)
 	}
-	runExample(t, 99)
-	runExample(t, 102)
+	for _, i := range []int{99, 102, 109} {
+		runExample(t, i)
+	}
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- cast function return values when inferred type is any
- test the compiler on LeetCode example 109

## Testing
- `make test STAGE=compile/go`

------
https://chatgpt.com/codex/tasks/task_e_68504a9415d88320826a15cbad3e06d5