### PR TITLE
Fix sanitizeName for Go keywords

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -40,7 +40,11 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("❌ go run error: %w\n%s", err, out)
 		}
-		return bytes.TrimSpace(out), nil
+		res := bytes.TrimSpace(out)
+		if res == nil {
+			res = []byte{}
+		}
+		return res, nil
 	})
 
 	golden.Run(t, "tests/compiler/go", ".mochi", ".out", func(src string) ([]byte, error) {
@@ -68,7 +72,11 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("❌ go run error: %w\n%s", err, out)
 		}
-		return bytes.TrimSpace(out), nil
+		res := bytes.TrimSpace(out)
+		if res == nil {
+			res = []byte{}
+		}
+		return res, nil
 	})
 }
 
@@ -114,6 +122,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	}
 	runExample(t, 99)
 	runExample(t, 102)
+	runExample(t, 125)
 }
 
 func runExample(t *testing.T, i int) {

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -34,6 +34,15 @@ func indentBlock(s string, depth int) string {
 }
 
 func sanitizeName(name string) string {
+	keywords := map[string]bool{
+		"break": true, "default": true, "func": true, "interface": true,
+		"select": true, "case": true, "defer": true, "go": true,
+		"map": true, "struct": true, "chan": true, "else": true,
+		"goto": true, "package": true, "switch": true, "const": true,
+		"fallthrough": true, "if": true, "range": true, "type": true,
+		"continue": true, "for": true, "import": true, "return": true,
+		"var": true,
+	}
 	var b strings.Builder
 	for i, r := range name {
 		if r == '_' || ('0' <= r && r <= '9' && i > 0) || ('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z') {
@@ -44,10 +53,14 @@ func sanitizeName(name string) string {
 			b.WriteRune('_')
 		}
 	}
-	if b.Len() == 0 || !((b.String()[0] >= 'A' && b.String()[0] <= 'Z') || (b.String()[0] >= 'a' && b.String()[0] <= 'z') || b.String()[0] == '_') {
-		return "_" + b.String()
+	sanitized := b.String()
+	if sanitized == "" || !((sanitized[0] >= 'A' && sanitized[0] <= 'Z') || (sanitized[0] >= 'a' && sanitized[0] <= 'z') || sanitized[0] == '_') {
+		sanitized = "_" + sanitized
 	}
-	return b.String()
+	if keywords[sanitized] {
+		sanitized = "_" + sanitized
+	}
+	return sanitized
 }
 
 func exportName(name string) string {

--- a/tests/compiler/go/valid_palindrome.go.out
+++ b/tests/compiler/go/valid_palindrome.go.out
@@ -1,0 +1,65 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func isAlphaNum(ch string) bool {
+	if (("0" <= ch) && (ch <= "9")) {
+		return true
+	}
+	if (("a" <= ch) && (ch <= "z")) {
+		return true
+	}
+	if (("A" <= ch) && (ch <= "Z")) {
+		return true
+	}
+	return false
+}
+
+func toLower(ch string) string {
+	var _map map[string]string = map[string]string{"A": "a", "B": "b", "C": "c", "D": "d", "E": "e", "F": "f", "G": "g", "H": "h", "I": "i", "J": "j", "K": "k", "L": "l", "M": "m", "N": "n", "O": "o", "P": "p", "Q": "q", "R": "r", "S": "s", "T": "t", "U": "u", "V": "v", "W": "w", "X": "x", "Y": "y", "Z": "z"}
+	_tmp0 := ch
+	_tmp1 := _map
+	_, _tmp2 := _tmp1[_tmp0]
+	if _tmp2 {
+		return _map[ch]
+	}
+	return ch
+}
+
+func isPalindrome(s string) bool {
+	var filtered []string = []string{}
+	for _, r := range []rune(s) {
+		ch := string(r)
+		if isAlphaNum(ch) {
+			filtered = append(append([]string{}, filtered...), []string{toLower(ch)}...)
+		}
+	}
+	var n int = len(filtered)
+	for i := 0; i < (n / 2); i++ {
+		if (filtered[i] != filtered[((n - 1) - i)]) {
+			return false
+		}
+	}
+	return true
+}
+
+func example_1() {
+	expect((isPalindrome("A man, a plan, a canal: Panama") == true))
+}
+
+func example_2() {
+	expect((isPalindrome("race a car") == false))
+}
+
+func example_3() {
+	expect((isPalindrome(" ") == true))
+}
+
+func main() {
+	example_1()
+	example_2()
+	example_3()
+}
+

--- a/tests/compiler/go/valid_palindrome.mochi
+++ b/tests/compiler/go/valid_palindrome.mochi
@@ -1,0 +1,67 @@
+fun isAlphaNum(ch: string): bool {
+  if "0" <= ch && ch <= "9" {
+    return true
+  }
+  if "a" <= ch && ch <= "z" {
+    return true
+  }
+  if "A" <= ch && ch <= "Z" {
+    return true
+  }
+  return false
+}
+
+fun toLower(ch: string): string {
+  let map = {
+    "A": "a", "B": "b", "C": "c", "D": "d", "E": "e", "F": "f",
+    "G": "g", "H": "h", "I": "i", "J": "j", "K": "k", "L": "l",
+    "M": "m", "N": "n", "O": "o", "P": "p", "Q": "q", "R": "r",
+    "S": "s", "T": "t", "U": "u", "V": "v", "W": "w", "X": "x",
+    "Y": "y", "Z": "z",
+  }
+  if ch in map {
+    return map[ch]
+  }
+  return ch
+}
+
+fun isPalindrome(s: string): bool {
+  var filtered: list<string> = []
+  for ch in s {
+    if isAlphaNum(ch) {
+      filtered = filtered + [toLower(ch)]
+    }
+  }
+  let n = len(filtered)
+  for i in 0..n/2 {
+    if filtered[i] != filtered[n-1-i] {
+      return false
+    }
+  }
+  return true
+}
+
+// Test cases from LeetCode
+
+test "example 1" {
+  expect isPalindrome("A man, a plan, a canal: Panama") == true
+}
+
+test "example 2" {
+  expect isPalindrome("race a car") == false
+}
+
+test "example 3" {
+  expect isPalindrome(" ") == true
+}
+
+// Common Mochi language errors and how to fix them:
+// 1. Reassigning a value declared with `let` will fail.
+//    let n = 0
+//    n = 1            // ❌ use `var n = 0` if mutation is needed
+// 2. Using '=' instead of '==' to compare strings.
+//    if ch = "a" { }  // ❌ assignment
+//    if ch == "a" { } // ✅ comparison
+// 3. Creating an empty list without a type causes a compile error.
+//    var arr = []      // ❌ type cannot be inferred
+//    var arr: list<string> = [] // ✅ specify element type


### PR DESCRIPTION
## Summary
- avoid Go keyword collisions in Go compiler
- handle empty program output in Go compiler tests
- add LeetCode valid palindrome example to tests

## Testing
- `go test ./compile/go -run TestGoCompiler_SubsetPrograms -v`
- `go test ./compile/go -run TestGoCompiler_GoldenOutput/valid_palindrome -v`
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./compile/go`


------
https://chatgpt.com/codex/tasks/task_e_68504aa769c483209cc574768a3fcc4c