### PR TITLE
Support while loops in Go codegen

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -1195,17 +1195,27 @@ func (c *Compiler) compileIf(stmt *parser.IfStmt) error {
 }
 
 func (c *Compiler) compileWhile(stmt *parser.WhileStmt) error {
+	c.writeIndent()
+	if lit, ok := c.evalConstExpr(stmt.Cond); ok && lit.Bool != nil && bool(*lit.Bool) {
+		c.buf.WriteString("for {\n")
+		c.indent++
+		if err := c.compileStmtList(stmt.Body); err != nil {
+			return err
+		}
+		c.indent--
+		c.writeIndent()
+		c.buf.WriteString("}\n")
+		return nil
+	}
+
+	c.buf.WriteString("for {\n")
+	c.indent++
 	cond, err := c.compileExpr(stmt.Cond)
 	if err != nil {
 		return err
 	}
 	c.writeIndent()
-	if lit, ok := c.evalConstExpr(stmt.Cond); ok && lit.Bool != nil && bool(*lit.Bool) {
-		c.buf.WriteString("for {\n")
-	} else {
-		c.buf.WriteString("for " + cond + " {\n")
-	}
-	c.indent++
+	c.buf.WriteString("if !(" + cond + ") { break }\n")
 	if err := c.compileStmtList(stmt.Body); err != nil {
 		return err
 	}

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -115,6 +115,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 99)
 	runExample(t, 102)
 	runExample(t, 105)
+	runExample(t, 128)
 }
 
 func runExample(t *testing.T, i int) {

--- a/tests/compiler/go/matrix_search.go.out
+++ b/tests/compiler/go/matrix_search.go.out
@@ -12,7 +12,8 @@ func searchMatrix(matrix [][]int, target int) bool {
 	var n int = len(matrix[0])
 	var left int = 0
 	var right int = ((m * n) - 1)
-	for (left <= right) {
+	for {
+		if !((left <= right)) { break }
 		var mid int = (left + (((right - left)) / 2))
 		var row int = (mid / n)
 		var col int = (mid % n)

--- a/tests/compiler/valid/while_loop.go.out
+++ b/tests/compiler/valid/while_loop.go.out
@@ -6,8 +6,10 @@ import (
 
 func main() {
 	var i int = 0
-	for (i < 3) {
+	for {
+		if !((i < 3)) { break }
 		fmt.Println(i)
 		i = (i + 1)
 	}
 }
+


### PR DESCRIPTION
## Summary
- fix `while` loop generation in Go compiler so condition evaluates each iteration
- run LeetCode example 128 in compiler tests
- update golden outputs for while loops

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6850562be4788320a3cffc731f7694c9