### PR TITLE
Add while-loop fix & enable leetcode 128 for Go

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -115,6 +115,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 99)
 	runExample(t, 102)
 	runExample(t, 105)
+	runExample(t, 128)
 }
 
 func runExample(t *testing.T, i int) {

--- a/tests/compiler/go/matrix_search.go.out
+++ b/tests/compiler/go/matrix_search.go.out
@@ -12,7 +12,8 @@ func searchMatrix(matrix [][]int, target int) bool {
 	var n int = len(matrix[0])
 	var left int = 0
 	var right int = ((m * n) - 1)
-	for (left <= right) {
+	for {
+		if !((left <= right)) { break }
 		var mid int = (left + (((right - left)) / 2))
 		var row int = (mid / n)
 		var col int = (mid % n)

--- a/tests/compiler/valid/while_loop.go.out
+++ b/tests/compiler/valid/while_loop.go.out
@@ -6,8 +6,10 @@ import (
 
 func main() {
 	var i int = 0
-	for (i < 3) {
+	for {
+		if !((i < 3)) { break }
 		fmt.Println(i)
 		i = (i + 1)
 	}
 }
+


### PR DESCRIPTION
## Summary
- recompile loop condition in `compileWhile` so it's checked each iteration
- run example 128 in Go compiler tests
- update golden Go outputs for new `while` semantics

## Testing
- `go test ./compile/go -run GoldenOutput -count=1`
- `go test ./compile/go -run SubsetPrograms -count=1`
- `go test ./compile/go -run LeetCodeExamples -count=1`
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6850562be4788320a3cffc731f7694c9