### PR TITLE
Fix map literal casting in Go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -115,6 +115,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 99)
 	runExample(t, 102)
 	runExample(t, 105)
+	runExample(t, 124)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- improve `compileExprHint` to support map literals when a map type hint is present
- ensure return statements convert map literals correctly
- run LeetCode example 124 in Go compiler tests

## Testing
- `go test ./compile/go -run TestGoCompiler_GoldenOutput -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685056a9e54483208a61d5cf2dec740a