### PR TITLE
Enable Go compiler to run LeetCode 114

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -635,6 +635,11 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 					c.use("_cast")
 					expr = fmt.Sprintf("_cast[%s](%s)", goType(retT), expr)
 				}
+			} else if mt, ok := retT.(types.MapType); ok {
+				if goType(mt) != goType(exprT) {
+					c.use("_cast")
+					expr = fmt.Sprintf("_cast[%s](%s)", goType(retT), expr)
+				}
 			} else if !equalTypes(retT, exprT) || isAny(exprT) {
 				c.use("_cast")
 				expr = fmt.Sprintf("_cast[%s](%s)", goType(retT), expr)
@@ -2851,7 +2856,7 @@ func (c *Compiler) foldCall(call *parser.CallExpr) (*parser.Literal, bool) {
 // for nested lists.
 func (c *Compiler) compileExprHint(e *parser.Expr, hint types.Type) (string, error) {
 	if lt, ok := hint.(types.ListType); ok {
-		if ll := e.Binary.Left.Value.Target.List; ll != nil {
+		if ll := e.Binary.Left.Value.Target.List; ll != nil && len(e.Binary.Right) == 0 {
 			elems := make([]string, len(ll.Elems))
 			for i, el := range ll.Elems {
 				ev, err := c.compileExprHint(el, lt.Elem)

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -115,6 +115,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 99)
 	runExample(t, 102)
 	runExample(t, 105)
+	runExample(t, 114)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- fix `compileExprHint` so list literals with additional operations compile correctly
- run LeetCode example 114 in Go compiler tests

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples/114 -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685056a020648320acc5aa75c5d8a4e5