### PR TITLE
Fix Go while loop codegen

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -1195,36 +1195,18 @@ func (c *Compiler) compileIf(stmt *parser.IfStmt) error {
 }
 
 func (c *Compiler) compileWhile(stmt *parser.WhileStmt) error {
-	// Special case: constant true condition compiles to an infinite loop.
-	if lit, ok := c.evalConstExpr(stmt.Cond); ok && lit.Bool != nil && bool(*lit.Bool) {
-		c.writeIndent()
-		c.buf.WriteString("for {\n")
-		c.indent++
-		if err := c.compileStmtList(stmt.Body); err != nil {
-			return err
-		}
-		c.indent--
-		c.writeIndent()
-		c.buf.WriteString("}\n")
-		return nil
-	}
-
-	c.writeIndent()
-	c.buf.WriteString("for {\n")
-	c.indent++
-
-	// Evaluate the loop condition at the start of each iteration.
 	cond, err := c.compileExpr(stmt.Cond)
 	if err != nil {
 		return err
 	}
+
 	c.writeIndent()
-	c.buf.WriteString("if !(" + cond + ") {\n")
+	if lit, ok := c.evalConstExpr(stmt.Cond); ok && lit.Bool != nil && bool(*lit.Bool) {
+		c.buf.WriteString("for {\n")
+	} else {
+		c.buf.WriteString("for " + cond + " {\n")
+	}
 	c.indent++
-	c.writeln("break")
-	c.indent--
-	c.writeIndent()
-	c.buf.WriteString("}\n")
 
 	if err := c.compileStmtList(stmt.Body); err != nil {
 		return err

--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -303,7 +303,7 @@ func simpleStringKey(e *parser.Expr) (string, bool) {
 }
 
 func (c *Compiler) newVar() string {
-	name := fmt.Sprintf("_tmp%d", c.tempVarCount)
+	name := fmt.Sprintf("tmp%d", c.tempVarCount)
 	c.tempVarCount++
 	return name
 }


### PR DESCRIPTION
## Summary
- simplify `compileWhile` to use Go's `for` condition form
- generate cleaner temporary variable names

## Testing
- `go test ./...` *(fails: tests did not finish running)*

------
https://chatgpt.com/codex/tasks/task_e_685058d641388320b9de7edccd982ead