### PR TITLE
Improve temp variable naming for Go output

### DIFF
--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -303,7 +303,7 @@ func simpleStringKey(e *parser.Expr) (string, bool) {
 }
 
 func (c *Compiler) newVar() string {
-	name := fmt.Sprintf("_tmp%d", c.tempVarCount)
-	c.tempVarCount++
-	return name
+        name := fmt.Sprintf("tmp%d", c.tempVarCount)
+        c.tempVarCount++
+        return name
 }

--- a/tests/compiler/go/union_inorder.go.out
+++ b/tests/compiler/go/union_inorder.go.out
@@ -22,10 +22,10 @@ func inorder(t Tree) []int {
 	if _, ok := _t.(Leaf); ok {
 		return _cast[[]int]([]any{})
 	}
-	if _tmp0, ok := _t.(Node); ok {
-		l := _tmp0.Left
-		v := _tmp0.Value
-		r := _tmp0.Right
+	if tmp0, ok := _t.(Node); ok {
+		l := tmp0.Left
+		v := tmp0.Value
+		r := tmp0.Right
 		return append(append([]int{}, append(append([]int{}, inorder(l)...), []int{v}...)...), inorder(r)...)
 	}
 	var _zero []int

--- a/tests/compiler/go/while_membership.go.out
+++ b/tests/compiler/go/while_membership.go.out
@@ -12,10 +12,10 @@ func main() {
 	var i int = 1
 	var count int = 0
 	for {
-		_tmp0 := i
-		_tmp1 := set
-		_, _tmp2 := _tmp1[_tmp0]
-		if !(_tmp2) {
+		tmp0 := i
+		tmp1 := set
+		_, tmp2 := tmp1[tmp0]
+		if !(tmp2) {
 			break
 		}
 		i = (i + 1)

--- a/tests/compiler/valid/map_ops.go.out
+++ b/tests/compiler/valid/map_ops.go.out
@@ -8,10 +8,10 @@ func main() {
 	var m map[int]int = map[int]int{}
 	m[1] = 10
 	m[2] = 20
-	_tmp0 := 1
-	_tmp1 := m
-	_, _tmp2 := _tmp1[_tmp0]
-	if _tmp2 {
+	tmp0 := 1
+	tmp1 := m
+	_, tmp2 := tmp1[tmp0]
+	if tmp2 {
 		fmt.Println(m[1])
 	}
 	fmt.Println(m[2])


### PR DESCRIPTION
## Summary
- update Go compiler helper to generate temp variables like `tmp0`
- update golden Go outputs for new temp variable names

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685058d641388320b9de7edccd982ead