### PR TITLE
Add scan builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Slice concatenation support
 * Nested functions and globals in the TypeScript compiler
 * Go compiler arithmetic with `any` and empty literal assignments
+* `scan` builtin for reading interactive input
 
 ### Fixed
 

--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3020,6 +3020,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.imports["mochi/runtime/data"] = true
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
+	case "scan":
+		c.imports["bufio"] = true
+		c.imports["os"] = true
+		c.imports["strings"] = true
+		return "func(){r:=bufio.NewReader(os.Stdin);line,_:=r.ReadString('\n');return strings.TrimRight(line, \"\r\n\") }()", nil
 	case "len":
 		return fmt.Sprintf("len(%s)", argStr), nil
 	case "now":

--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -1235,6 +1235,8 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "avg":
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
+	case "scan":
+		return "input().strip()", nil
 	case "eval":
 		return fmt.Sprintf("eval(%s)", argStr), nil
 	default:

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -1253,6 +1253,8 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "avg":
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
+	case "scan":
+		return "prompt('') ?? ''", nil
 	case "now":
 		// performance.now() returns milliseconds as a float. Multiply
 		// by 1e6 so that `now()` is consistent with Go's UnixNano()

--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -1,8 +1,11 @@
 package interpreter
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -181,6 +184,18 @@ func builtinAvg(i *Interpreter, c *parser.CallExpr) (any, error) {
 	return sum / float64(len(list)), nil
 }
 
+func builtinScan(i *Interpreter, c *parser.CallExpr) (any, error) {
+	if len(c.Args) != 0 {
+		return nil, fmt.Errorf("scan() takes no arguments")
+	}
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
 func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallExpr) (any, error) {
 	return map[string]func(*Interpreter, *parser.CallExpr) (any, error){
 		"print": builtinPrint,
@@ -190,6 +205,7 @@ func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallE
 		"str":   builtinStr,
 		"count": builtinCount,
 		"avg":   builtinAvg,
+		"scan":  builtinScan,
 		"eval":  builtinEval,
 	}
 }


### PR DESCRIPTION
## Summary
- support `scan()` in interpreter and compilers
- list the new builtin in the changelog

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68506699d89c8320a5b4a6b898ff704e