### PR TITLE
Add v0.7.5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 # 📦 CHANGELOG.md
+## [0.7.5] – 2025-06-17
+
+### Added
+
+* Union list and slice assignment in the Go compiler
+* Map literals with type hints
+* Python and TypeScript output for LeetCode 128
+* Palindrome golden test
+
+### Changed
+
+* LeetCode outputs reorganized under language folders
+* Makefile builds run in parallel with extra commands
+
+### Fixed
+
+* Reserved keyword handling in the Go compiler
+* Empty container literals in let statements
+* Pattern match casts, list concatenation and while loops
+
+
 ## [0.7.4] – 2025-06-16
 
 ### Added

--- a/releases/v0.7.5.md
+++ b/releases/v0.7.5.md
@@ -1,0 +1,20 @@
+# Jun 2025 (v0.7.5)
+
+Mochi v0.7.5 refines the Go compiler and reorganizes example outputs for easier maintenance.
+
+## Compilers
+
+- Go compiler supports union lists and slice assignment
+- Map literals accept type hints and empty container values
+- Reserved keywords are sanitized
+- Fixed match casting, list concatenation and while loop handling
+
+## Example Library
+
+- LeetCode outputs moved under language-specific folders
+- Added Python and TypeScript solution for problem 128
+- New palindrome golden test
+
+## Build System
+
+- `Makefile` builds run in parallel with additional commands


### PR DESCRIPTION
## Summary
- add release notes for `v0.7.5`
- document recent changes in `CHANGELOG`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685068245ec08320832ee6111f7d8575