### PR TITLE
Add scan builtin for user input

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -556,7 +556,7 @@ fun makeCounter(): fun(): int {
 
 Mochi provides a small set of built-ins available in all scopes. The most common is `print`, which writes its arguments to standard output and returns `null`.
 
-Other built-ins include `len` for obtaining the length of strings, lists, or maps; `now` which returns the current time as an integer; and `json` for printing values in JSON format.
+Other built-ins include `len` for obtaining the length of strings, lists, or maps; `now` which returns the current time as an integer; `json` for printing values in JSON format; and `scan` for reading a line of input from standard input.
 
 ## 8. Runtime Semantics
 

--- a/examples/v0.7/scan.mochi
+++ b/examples/v0.7/scan.mochi
@@ -1,0 +1,10 @@
+// scan.mochi
+// Read two inputs from the user using built-in functions
+
+print("Enter first input:")
+let input1 = scan()
+
+print("Enter second input:")
+let input2 = scan()
+
+print("You entered:", input1, ",", input2)

--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -1,8 +1,11 @@
 package interpreter
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -82,6 +85,19 @@ func builtinStr(i *Interpreter, c *parser.CallExpr) (any, error) {
 		return nil, err
 	}
 	return fmt.Sprint(val), nil
+}
+
+// builtinScan reads a line from standard input and returns it as a string.
+func builtinScan(i *Interpreter, c *parser.CallExpr) (any, error) {
+	if len(c.Args) != 0 {
+		return nil, fmt.Errorf("scan() takes no arguments")
+	}
+	r := bufio.NewReader(os.Stdin)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
 }
 
 // builtinEval implements eval(code).
@@ -188,6 +204,7 @@ func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallE
 		"now":   builtinNow,
 		"json":  builtinJSON,
 		"str":   builtinStr,
+		"scan":  builtinScan,
 		"count": builtinCount,
 		"avg":   builtinAvg,
 		"eval":  builtinEval,


### PR DESCRIPTION
## Summary
- implement `scan()` builtin for reading user input
- document new builtin in `SPEC.md`
- add example `scan.mochi` demonstrating interactive input

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68506917d350832088c15c45829beff6