### PR TITLE
Add block expression support for Python compiler

### DIFF
--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -113,7 +113,7 @@ func TestPyCompiler_LeetCodeExamples(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")
 	}
-	for i := 1; i <= 116; i++ {
+	for i := 1; i <= 133; i++ {
 		dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
 		files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 		if err != nil {

--- a/compile/py/helpers.go
+++ b/compile/py/helpers.go
@@ -417,6 +417,24 @@ func identName(e *parser.Expr) (string, bool) {
 	return "", false
 }
 
+func funExpr(e *parser.Expr) (*parser.FunExpr, bool) {
+	if e == nil {
+		return nil, false
+	}
+	if len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.FunExpr == nil {
+		return nil, false
+	}
+	return p.Target.FunExpr, true
+}
+
 // collectScopeInfo traverses statements to track locally declared variables and
 // variables that are assigned to. Nested function bodies are ignored since they
 // are handled separately when compiled.


### PR DESCRIPTION
## Summary
- support block function expressions inside match by emitting helper functions
- add `matchCond` and `compileBlockFun` helpers for Python code generation
- extend Python compiler tests to include LeetCode example 133

## Testing
- `go test ./compile/py -run TestPyCompiler_LeetCodeExamples/133 -count=1`
- `go test ./compile/py -run TestPyCompiler_LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850676b9d7c832093af57c8aefcad82