### PR TITLE
Add input builtin and example

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3020,6 +3020,12 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.imports["mochi/runtime/data"] = true
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
+	case "input":
+		c.use("_input")
+		c.imports["bufio"] = true
+		c.imports["os"] = true
+		c.imports["strings"] = true
+		return "_input()", nil
 	case "len":
 		return fmt.Sprintf("len(%s)", argStr), nil
 	case "now":

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -71,6 +71,12 @@ const (
 		"    return sum / float64(len(items))\n" +
 		"}\n"
 
+	helperInput = "func _input() string {\n" +
+		"    r := bufio.NewReader(os.Stdin)\n" +
+		"    s, _ := r.ReadString('\\n')\n" +
+		"    return strings.TrimRight(s, \"\r\n\")\n" +
+		"}\n"
+
 	helperGenText = "func _genText(prompt string, model string, params map[string]any) string {\n" +
 		"    opts := []llm.Option{}\n" +
 		"    if model != \"\" { opts = append(opts, llm.WithModel(model)) }\n" +
@@ -366,6 +372,7 @@ var helperMap = map[string]string{
 	"_indexString": helperIndexString,
 	"_count":       helperCount,
 	"_avg":         helperAvg,
+	"_input":       helperInput,
 	"_genText":     helperGenText,
 	"_genEmbed":    helperGenEmbed,
 	"_genStruct":   helperGenStruct,

--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -1235,6 +1235,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "avg":
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
+	case "input":
+		c.use("_input")
+		return "_input()", nil
 	case "eval":
 		return fmt.Sprintf("eval(%s)", argStr), nil
 	default:

--- a/compile/py/runtime.go
+++ b/compile/py/runtime.go
@@ -40,6 +40,9 @@ var helperAvg = "def _avg(v):\n" +
 	"            raise Exception('avg() expects numbers')\n" +
 	"    return s / len(v)\n"
 
+var helperInput = "def _input():\n" +
+	"    return input()\n"
+
 var helperFetch = "def _fetch(url, opts):\n" +
 	"    import urllib.request, urllib.parse, json\n" +
 	"    method = 'GET'\n" +
@@ -316,6 +319,7 @@ var helperMap = map[string]string{
 	"_gen_struct": helperGenStruct,
 	"_count":      helperCount,
 	"_avg":        helperAvg,
+	"_input":      helperInput,
 	"_union_all":  helperUnionAll,
 	"_union":      helperUnion,
 	"_except":     helperExcept,

--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -1253,6 +1253,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "avg":
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
+	case "input":
+		c.use("_input")
+		return "_input()", nil
 	case "now":
 		// performance.now() returns milliseconds as a float. Multiply
 		// by 1e6 so that `now()` is consistent with Go's UnixNano()

--- a/compile/ts/runtime.go
+++ b/compile/ts/runtime.go
@@ -26,6 +26,11 @@ const (
 		"  return sum / list.length;\n" +
 		"}\n"
 
+	helperInput = "function _input(): string {\n" +
+		"  const v = prompt('')\n" +
+		"  return v === null ? '' : v;\n" +
+		"}\n"
+
 	helperIter = "function _iter(v: any): any {\n" +
 		"  if (v && typeof v === 'object' && !Array.isArray(v) && !(Symbol.iterator in v)) {\n" +
 		"    return Object.keys(v);\n" +
@@ -304,6 +309,7 @@ const (
 var helperMap = map[string]string{
 	"_count":      helperCount,
 	"_avg":        helperAvg,
+	"_input":      helperInput,
 	"_iter":       helperIter,
 	"_gen_text":   helperGenText,
 	"_gen_embed":  helperGenEmbed,

--- a/examples/v0.7/scan.mochi
+++ b/examples/v0.7/scan.mochi
@@ -1,0 +1,10 @@
+// scan.mochi
+// Read two inputs from the user using built-in functions
+
+print("Enter first input:")
+let input1 = input()
+
+print("Enter second input:")
+let input2 = input()
+
+print("You entered:", input1, ",", input2)

--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -1,8 +1,10 @@
 package interpreter
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -82,6 +84,18 @@ func builtinStr(i *Interpreter, c *parser.CallExpr) (any, error) {
 		return nil, err
 	}
 	return fmt.Sprint(val), nil
+}
+
+func builtinInput(i *Interpreter, c *parser.CallExpr) (any, error) {
+	if len(c.Args) != 0 {
+		return nil, fmt.Errorf("input() takes no arguments")
+	}
+	reader := bufio.NewReader(i.env.Reader())
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
 }
 
 // builtinEval implements eval(code).
@@ -188,6 +202,7 @@ func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallE
 		"now":   builtinNow,
 		"json":  builtinJSON,
 		"str":   builtinStr,
+		"input": builtinInput,
 		"count": builtinCount,
 		"avg":   builtinAvg,
 		"eval":  builtinEval,

--- a/types/env.go
+++ b/types/env.go
@@ -29,13 +29,16 @@ type Env struct {
 	models  map[string]ModelSpec         // model aliases
 
 	output io.Writer // default: os.Stdout
+	input  io.Reader // default: os.Stdin
 }
 
 // NewEnv creates a new lexical scope environment.
 func NewEnv(parent *Env) *Env {
 	var out io.Writer = os.Stdout
+	var in io.Reader = os.Stdin
 	if parent != nil {
 		out = parent.output
+		in = parent.input
 	}
 	return &Env{
 		parent:  parent,
@@ -49,6 +52,7 @@ func NewEnv(parent *Env) *Env {
 		funcs:   make(map[string]*parser.FunStmt),
 		models:  make(map[string]ModelSpec),
 		output:  out,
+		input:   in,
 	}
 }
 
@@ -287,4 +291,14 @@ func (e *Env) SetWriter(w io.Writer) {
 // Writer returns the current output writer.
 func (e *Env) Writer() io.Writer {
 	return e.output
+}
+
+// SetReader sets the input source.
+func (e *Env) SetReader(r io.Reader) {
+	e.input = r
+}
+
+// Reader returns the current input reader.
+func (e *Env) Reader() io.Reader {
+	return e.input
 }


### PR DESCRIPTION
## Summary
- add `input` builtin to interpreter and compilers
- allow types.Env to set custom input reader
- support `_input` helper for Go/TS/Python runtime
- provide `examples/v0.7/scan.mochi` demonstrating input usage

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_68506ba3cd788320b40ec2c658f1eddc