### PR TITLE
Add list hint support for Go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -40,7 +40,11 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("❌ go run error: %w\n%s", err, out)
 		}
-		return bytes.TrimSpace(out), nil
+		res := bytes.TrimSpace(out)
+		if res == nil {
+			res = []byte{}
+		}
+		return res, nil
 	})
 
 	golden.Run(t, "tests/compiler/go", ".mochi", ".out", func(src string) ([]byte, error) {
@@ -68,7 +72,11 @@ func TestGoCompiler_SubsetPrograms(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("❌ go run error: %w\n%s", err, out)
 		}
-		return bytes.TrimSpace(out), nil
+		res := bytes.TrimSpace(out)
+		if res == nil {
+			res = []byte{}
+		}
+		return res, nil
 	})
 }
 
@@ -110,6 +118,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
+	runExample(t, 207)
 }
 
 func runExample(t *testing.T, i int) {

--- a/tests/compiler/go/leetcode_207.go.out
+++ b/tests/compiler/go/leetcode_207.go.out
@@ -1,0 +1,67 @@
+package main
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func canFinish(numCourses int, prerequisites [][]int) bool {
+	var graph [][]int = [][]int{}
+	var indegree []int = []int{}
+	for _tmp0 := 0; _tmp0 < numCourses; _tmp0++ {
+		graph = append(append([][]int{}, graph...), [][]int{[]int{}}...)
+		indegree = append(append([]int{}, indegree...), []int{0}...)
+	}
+	for _, pair := range prerequisites {
+		var a int = pair[0]
+		var b int = pair[1]
+		graph[b] = append(append([]int{}, graph[b]...), []int{a}...)
+		indegree[a] = (indegree[a] + 1)
+	}
+	var queue []int = []int{}
+	for i := 0; i < numCourses; i++ {
+		if (indegree[i] == 0) {
+			queue = append(append([]int{}, queue...), []int{i}...)
+		}
+	}
+	var visited int = 0
+	var idx int = 0
+	for {
+		if !((idx < len(queue))) {
+			break
+		}
+		var course int = queue[idx]
+		idx = (idx + 1)
+		visited = (visited + 1)
+		for _, next := range graph[course] {
+			indegree[next] = (indegree[next] - 1)
+			if (indegree[next] == 0) {
+				queue = append(append([]int{}, queue...), []int{next}...)
+			}
+		}
+	}
+	return (visited == numCourses)
+}
+
+func simple_acyclic() {
+	expect((canFinish(2, [][]int{[]int{1, 0}}) == true))
+}
+
+func simple_cycle() {
+	expect((canFinish(2, [][]int{[]int{1, 0}, []int{0, 1}}) == false))
+}
+
+func long_chain() {
+	expect((canFinish(4, [][]int{[]int{1, 0}, []int{2, 1}, []int{3, 2}}) == true))
+}
+
+func cycle_with_more_courses() {
+	expect((canFinish(3, [][]int{[]int{0, 1}, []int{1, 2}, []int{2, 0}}) == false))
+}
+
+func main() {
+	simple_acyclic()
+	simple_cycle()
+	long_chain()
+	cycle_with_more_courses()
+}
+

--- a/tests/compiler/go/leetcode_207.mochi
+++ b/tests/compiler/go/leetcode_207.mochi
@@ -1,0 +1,73 @@
+// LeetCode 207 - Course Schedule
+
+fun canFinish(numCourses: int, prerequisites: list<list<int>>): bool {
+  // build adjacency list and indegree count
+  var graph: list<list<int>> = []
+  var indegree: list<int> = []
+  for _ in 0..numCourses {
+    graph = graph + [[]]
+    indegree = indegree + [0]
+  }
+
+  for pair in prerequisites {
+    let a = pair[0]
+    let b = pair[1]
+    graph[b] = graph[b] + [a]
+    indegree[a] = indegree[a] + 1
+  }
+
+  var queue: list<int> = []
+  for i in 0..numCourses {
+    if indegree[i] == 0 {
+      queue = queue + [i]
+    }
+  }
+
+  var visited = 0
+  var idx = 0
+  while idx < len(queue) {
+    let course = queue[idx]
+    idx = idx + 1
+    visited = visited + 1
+    for next in graph[course] {
+      indegree[next] = indegree[next] - 1
+      if indegree[next] == 0 {
+        queue = queue + [next]
+      }
+    }
+  }
+
+  return visited == numCourses
+}
+
+// Test cases
+
+test "simple acyclic" {
+  expect canFinish(2, [[1,0]]) == true
+}
+
+test "simple cycle" {
+  expect canFinish(2, [[1,0],[0,1]]) == false
+}
+
+test "long chain" {
+  expect canFinish(4, [[1,0],[2,1],[3,2]]) == true
+}
+
+test "cycle with more courses" {
+  expect canFinish(3, [[0,1],[1,2],[2,0]]) == false
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' in comparisons:
+   if indegree[i] = 0 { }    // ❌ assignment
+   if indegree[i] == 0 { }   // ✅ comparison
+2. Declaring an immutable binding and then trying to modify it:
+   let count = 0
+   count = count + 1         // ❌ cannot reassign 'let'
+   var count = 0             // ✅ use 'var' for mutable values
+3. Calling methods like 'queue.push(x)':
+   queue.push(course)        // ❌ method doesn't exist
+   queue = queue + [course]  // ✅ concatenate lists
+*/

--- a/tests/compiler/go/unique_binary_search_trees_ii.go.out
+++ b/tests/compiler/go/unique_binary_search_trees_ii.go.out
@@ -25,7 +25,7 @@ func build(start int, end int) []Tree {
 		var rightTrees []Tree = build((i + 1), end)
 		for _, l := range leftTrees {
 			for _, r := range rightTrees {
-				result = append(append([]Tree{}, result...), _convSlice[Node,Tree]([]Node{Node{Left: l, Val: i, Right: r}})...)
+				result = append(append([]Tree{}, result...), []Tree{Node{Left: l, Val: i, Right: r}}...)
 			}
 		}
 	}
@@ -49,3 +49,4 @@ func _convSlice[T any, U any](s []T) []U {
     for i, v := range s { out[i] = any(v).(U) }
     return out
 }
+


### PR DESCRIPTION
## Summary
- enable typed empty list literals in Go codegen
- handle nil outputs in compiler golden tests
- include LeetCode 207 example in test suite
- update unique_binary_search_trees_ii.go.out golden

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685078e356108320b48575384f0e27c5