### PR TITLE
Add LeetCode 302 support to Go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -110,6 +110,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
+	runExample(t, 302)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- avoid name collisions for test blocks when compiling to Go
- track declared names in Go compiler
- run LeetCode example 302 in compiler tests

## Testing
- `make test STAGE=compile/go`


------
https://chatgpt.com/codex/tasks/task_e_685079d5a5388320876e6551cf5bfc32