### PR TITLE
Add Go compiler support for LeetCode 211 example

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -119,6 +119,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
 	runExample(t, 207)
+	runExample(t, 211)
 }
 
 func runExample(t *testing.T, i int) {

--- a/tests/compiler/go/leetcode_211.go.out
+++ b/tests/compiler/go/leetcode_211.go.out
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func expect(cond bool) {
+	if !cond { panic("expect failed") }
+}
+
+func Node() map[string]any {
+	return map[string]any{"end": false, "next": _cast[map[string]any](map[any]any{})}
+}
+
+func addWord(root map[string]any, word string) {
+	var node map[string]any = root
+	for i := 0; i < len(word); i++ {
+		var ch string = _indexString(word, i)
+		var nextMap map[string]any = _cast[map[string]any](node["next"])
+		var child map[string]any = nil
+		_tmp0 := ch
+		_tmp1 := nextMap
+		_, _tmp2 := _tmp1[_tmp0]
+		if _tmp2 {
+			child = _cast[map[string]any](nextMap[ch])
+		} else {
+			child = Node()
+		}
+		if (i == (len(word) - 1)) {
+			child["end"] = true
+		}
+		nextMap[ch] = child
+		node["next"] = nextMap
+		node = child
+	}
+}
+
+func searchHelper(node map[string]any, word string, index int) bool {
+	if (index == len(word)) {
+		return _cast[bool](node["end"])
+	}
+	var ch string = _indexString(word, index)
+	var children map[string]any = _cast[map[string]any](node["next"])
+	if (ch == ".") {
+		for key := range children {
+			var child map[string]any = _cast[map[string]any](children[key])
+			if searchHelper(child, word, (index + 1)) {
+				return true
+			}
+		}
+		return false
+	}
+	_tmp3 := ch
+	_tmp4 := children
+	_, _tmp5 := _tmp4[_tmp3]
+	if _tmp5 {
+		return searchHelper(_cast[map[string]any](children[ch]), word, (index + 1))
+	}
+	return false
+}
+
+func search(root map[string]any, word string) bool {
+	return searchHelper(root, word, 0)
+}
+
+func example_1() {
+	var wd map[string]any = Node()
+	addWord(wd, "bad")
+	addWord(wd, "dad")
+	addWord(wd, "mad")
+	expect((search(wd, "pad") == false))
+	expect((search(wd, "bad") == true))
+	expect((search(wd, ".ad") == true))
+	expect((search(wd, "b..") == true))
+}
+
+func main() {
+	example_1()
+}
+
+func _cast[T any](v any) T {
+    if m, ok := v.(map[any]any); ok {
+        v = _convertMapAny(m)
+    }
+    data, err := json.Marshal(v)
+    if err != nil { panic(err) }
+    var out T
+    if err := json.Unmarshal(data, &out); err != nil { panic(err) }
+    return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+    out := make(map[string]any, len(m))
+    for k, v := range m {
+        key := fmt.Sprint(k)
+        if sub, ok := v.(map[any]any); ok {
+            out[key] = _convertMapAny(sub)
+        } else {
+            out[key] = v
+        }
+    }
+    return out
+}
+
+func _indexString(s string, i int) string {
+    runes := []rune(s)
+    if i < 0 {
+        i += len(runes)
+    }
+    if i < 0 || i >= len(runes) {
+        panic("index out of range")
+    }
+    return string(runes[i])
+}
+

--- a/tests/compiler/go/leetcode_211.mochi
+++ b/tests/compiler/go/leetcode_211.mochi
@@ -1,0 +1,80 @@
+// Solution for LeetCode problem 211 - Design Add and Search Words Data Structure
+// This implementation avoids union types by representing trie nodes as maps.
+// Each node has an "end" flag and a "next" map of children.
+
+fun Node(): map<string, any> {
+  return {"end": false, "next": {} as map<string, any>}
+}
+
+fun addWord(root: map<string, any>, word: string) {
+  var node = root
+  for i in 0..len(word) {
+    let ch = word[i]
+    var nextMap: map<string, any> = node["next"] as map<string, any>
+    var child: map<string, any>
+    if ch in nextMap {
+      child = nextMap[ch] as map<string, any>
+    } else {
+      child = Node()
+    }
+    if i == len(word) - 1 {
+      child["end"] = true
+    }
+    nextMap[ch] = child
+    node["next"] = nextMap
+    node = child
+  }
+}
+
+fun searchHelper(node: map<string, any>, word: string, index: int): bool {
+  if index == len(word) {
+    return node["end"] as bool
+  }
+  let ch = word[index]
+  var children: map<string, any> = node["next"] as map<string, any>
+  if ch == "." {
+    for key in children {
+      let child = children[key] as map<string, any>
+      if searchHelper(child, word, index + 1) {
+        return true
+      }
+    }
+    return false
+  }
+  if ch in children {
+    return searchHelper(children[ch] as map<string, any>, word, index + 1)
+  }
+  return false
+}
+
+fun search(root: map<string, any>, word: string): bool {
+  return searchHelper(root, word, 0)
+}
+
+// Basic tests from the LeetCode description
+
+test "example 1" {
+  let wd = Node()
+  addWord(wd, "bad")
+  addWord(wd, "dad")
+  addWord(wd, "mad")
+  expect search(wd, "pad") == false
+  expect search(wd, "bad") == true
+  expect search(wd, ".ad") == true
+  expect search(wd, "b..") == true
+}
+
+/*
+Common Mochi language errors and how to fix them:
+1. Using '=' instead of '==' in conditionals.
+   if ch = '.' { }        // ❌ assignment
+   if ch == '.' { }       // ✅ comparison
+2. Attempting to mutate a value declared with 'let'.
+   let node = Node()
+   node["end"] = true      // ❌ cannot modify immutable value
+   var node = Node()       // ✅ declare with 'var' when mutation is needed
+3. Forgetting to initialize maps before use.
+   var children: map<string, any>
+   children["a"] = Node()   // ❌ children is nil
+   var children: map<string, any> = {} // ✅ start with an empty map
+*/


### PR DESCRIPTION
## Summary
- enable compiler test to run LeetCode example 211
- add golden test inputs/outputs for leetcode 211

## Testing
- `go test ./compile/go -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68507f606efc83208ba3d506ef7e7c1d