### PR TITLE
Fix Go test name collisions

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -262,7 +262,7 @@ func (c *Compiler) compileMainFunc(prog *parser.Program) error {
 	}
 	for _, s := range prog.Statements {
 		if s.Test != nil {
-			name := sanitizeName(s.Test.Name)
+			name := "test_" + sanitizeName(s.Test.Name)
 			c.writeln(fmt.Sprintf("%s()", name))
 		}
 	}
@@ -1469,7 +1469,7 @@ func (c *Compiler) compileFunStmt(fun *parser.FunStmt) error {
 }
 
 func (c *Compiler) compileTestBlock(t *parser.TestBlock) error {
-	name := sanitizeName(t.Name)
+	name := "test_" + sanitizeName(t.Name)
 	c.writeIndent()
 	c.buf.WriteString("func " + name + "() {\n")
 	c.indent++

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -126,6 +126,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
 	runExample(t, 207)
+	runExample(t, 378)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- prefix generated Go test functions with `test_` to avoid clashes with program identifiers
- extend Go compiler example tests to cover LeetCode problem 378

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6850b64d50388320b3145776159ef53d