### PR TITLE
Fix Go compiler list hints and add leetcode 317

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -127,6 +127,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
 	runExample(t, 207)
 	runExample(t, 378)
+	runExample(t, 317)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- improve `compileExprHint` to cast using type hints for empty list literals
- use element type when assigning to indexed variables
- test leetcode example 317 in Go compiler suite

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples/317 -count=1`
- `go test ./...` *(fails: go compiler golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6850be4726808320ad28e68ed282e41b