### PR TITLE
Enable Go compiler to handle forward struct refs

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -127,6 +127,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
 	runExample(t, 207)
 	runExample(t, 378)
+	runExample(t, 304)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- allow the type checker to pre-register struct types and check them before other statements
- run LeetCode example 304 in Go compiler tests

## Testing
- `go test ./compile/go -run LeetCodeExamples -count=1`
- `go test ./types -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6850bebcdea88320b4ab886c7467973b