### PR TITLE
Enable leetcode 346 for Go backend

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -2821,7 +2821,11 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 	case l.Int != nil:
 		return fmt.Sprintf("%d", *l.Int), nil
 	case l.Float != nil:
-		return strconv.FormatFloat(*l.Float, 'f', -1, 64), nil
+		s := strconv.FormatFloat(*l.Float, 'f', -1, 64)
+		if !strings.ContainsAny(s, ".eE") && !strings.Contains(s, ".") {
+			s += ".0"
+		}
+		return s, nil
 	case l.Str != nil:
 		return fmt.Sprintf("%q", *l.Str), nil
 	case l.Bool != nil:

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -126,6 +126,7 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
 	runExample(t, 207)
+	runExample(t, 346)
 	runExample(t, 378)
 }
 


### PR DESCRIPTION
## Summary
- ensure float literals keep trailing `.0` in Go output
- run leetcode example 346 in Go compiler tests

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./...` *(fails: TestGoCompiler_GoldenOutput)*

------
https://chatgpt.com/codex/tasks/task_e_6850c46c7cb48320b1dd2d56f2a9b27c