### PR TITLE
Fix casts for int64 & add LeetCode test

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -127,6 +127,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 201)
 	runExample(t, 207)
 	runExample(t, 378)
+	runExample(t, 272)
 }
 
 func runExample(t *testing.T, i int) {

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -202,14 +202,29 @@ const (
 		"        switch vv := v.(type) {\n" +
 		"        case int:\n" +
 		"            return any(vv).(T)\n" +
+		"        case int64:\n" +
+		"            return any(int(vv)).(T)\n" +
 		"        case float64:\n" +
 		"            return any(int(vv)).(T)\n" +
 		"        case float32:\n" +
 		"            return any(int(vv)).(T)\n" +
 		"        }\n" +
+		"    case int64:\n" +
+		"        switch vv := v.(type) {\n" +
+		"        case int:\n" +
+		"            return any(int64(vv)).(T)\n" +
+		"        case int64:\n" +
+		"            return any(vv).(T)\n" +
+		"        case float64:\n" +
+		"            return any(int64(vv)).(T)\n" +
+		"        case float32:\n" +
+		"            return any(int64(vv)).(T)\n" +
+		"        }\n" +
 		"    case float64:\n" +
 		"        switch vv := v.(type) {\n" +
 		"        case int:\n" +
+		"            return any(float64(vv)).(T)\n" +
+		"        case int64:\n" +
 		"            return any(float64(vv)).(T)\n" +
 		"        case float64:\n" +
 		"            return any(vv).(T)\n" +
@@ -219,6 +234,8 @@ const (
 		"    case float32:\n" +
 		"        switch vv := v.(type) {\n" +
 		"        case int:\n" +
+		"            return any(float32(vv)).(T)\n" +
+		"        case int64:\n" +
 		"            return any(float32(vv)).(T)\n" +
 		"        case float64:\n" +
 		"            return any(float32(vv)).(T)\n" +

--- a/tests/compiler/go/leetcode_304.go.out
+++ b/tests/compiler/go/leetcode_304.go.out
@@ -56,7 +56,7 @@ func sumRegion(nm NumMatrix, row1 int, col1 int, row2 int, col2 int) int {
 	return (((s[(row2 + 1)][(col2 + 1)] - s[row1][(col2 + 1)]) - s[(row2 + 1)][col1]) + s[row1][col1])
 }
 
-func example() {
+func test_example() {
 	var nm NumMatrix = newNumMatrix([][]int{[]int{3, 0, 1, 4, 2}, []int{5, 6, 3, 2, 1}, []int{1, 2, 0, 1, 5}, []int{4, 1, 0, 1, 7}, []int{1, 0, 3, 0, 5}})
 	_ = nm
 	expect((sumRegion(nm, 2, 1, 4, 3) == 8))
@@ -65,6 +65,5 @@ func example() {
 }
 
 func main() {
-	example()
+	test_example()
 }
-

--- a/tests/compiler/go/map_any_hint.go.out
+++ b/tests/compiler/go/map_any_hint.go.out
@@ -25,14 +25,29 @@ func _cast[T any](v any) T {
         switch vv := v.(type) {
         case int:
             return any(vv).(T)
+        case int64:
+            return any(int(vv)).(T)
         case float64:
             return any(int(vv)).(T)
         case float32:
             return any(int(vv)).(T)
         }
+    case int64:
+        switch vv := v.(type) {
+        case int:
+            return any(int64(vv)).(T)
+        case int64:
+            return any(vv).(T)
+        case float64:
+            return any(int64(vv)).(T)
+        case float32:
+            return any(int64(vv)).(T)
+        }
     case float64:
         switch vv := v.(type) {
         case int:
+            return any(float64(vv)).(T)
+        case int64:
             return any(float64(vv)).(T)
         case float64:
             return any(vv).(T)
@@ -42,6 +57,8 @@ func _cast[T any](v any) T {
     case float32:
         switch vv := v.(type) {
         case int:
+            return any(float32(vv)).(T)
+        case int64:
             return any(float32(vv)).(T)
         case float64:
             return any(float32(vv)).(T)

--- a/tests/compiler/go/union_inorder.go.out
+++ b/tests/compiler/go/union_inorder.go.out
@@ -44,14 +44,29 @@ func _cast[T any](v any) T {
         switch vv := v.(type) {
         case int:
             return any(vv).(T)
+        case int64:
+            return any(int(vv)).(T)
         case float64:
             return any(int(vv)).(T)
         case float32:
             return any(int(vv)).(T)
         }
+    case int64:
+        switch vv := v.(type) {
+        case int:
+            return any(int64(vv)).(T)
+        case int64:
+            return any(vv).(T)
+        case float64:
+            return any(int64(vv)).(T)
+        case float32:
+            return any(int64(vv)).(T)
+        }
     case float64:
         switch vv := v.(type) {
         case int:
+            return any(float64(vv)).(T)
+        case int64:
             return any(float64(vv)).(T)
         case float64:
             return any(vv).(T)
@@ -61,6 +76,8 @@ func _cast[T any](v any) T {
     case float32:
         switch vv := v.(type) {
         case int:
+            return any(float32(vv)).(T)
+        case int64:
             return any(float32(vv)).(T)
         case float64:
             return any(float32(vv)).(T)


### PR DESCRIPTION
## Summary
- allow `_cast` to handle int64 conversions
- exercise LeetCode 272 in Go compiler tests
- refresh Go golden outputs

## Testing
- `go test ./compile/go --vet=off`
- `go test ./... --vet=off`


------
https://chatgpt.com/codex/tasks/task_e_6850c514e0008320a7b38b6b62fd3c89