### PR TITLE
Add slice type inference for Go compiler

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3067,11 +3067,16 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			at := paramTypes[i]
+			at := c.inferExprType(a)
 			if lt, ok := paramTypes[i].(types.ListType); ok {
-				if et, ok := at.(types.ListType); ok && !isListOfAny(et) && equalTypes(lt.Elem, et.Elem) && goType(lt.Elem) != goType(et.Elem) {
-					c.use("_convSlice")
-					v = fmt.Sprintf("_convSlice[%s,%s](%s)", goType(et.Elem), goType(lt.Elem), v)
+				if et, ok := at.(types.ListType); ok {
+					if isListOfAny(et) && !isListOfAny(lt) {
+						c.use("_convSlice")
+						v = fmt.Sprintf("_convSlice[%s,%s](%s)", goType(et.Elem), goType(lt.Elem), v)
+					} else if !isListOfAny(et) && equalTypes(lt.Elem, et.Elem) && goType(lt.Elem) != goType(et.Elem) {
+						c.use("_convSlice")
+						v = fmt.Sprintf("_convSlice[%s,%s](%s)", goType(et.Elem), goType(lt.Elem), v)
+					}
 				}
 			}
 			args[i] = v

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -128,6 +128,7 @@ func TestGoCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 207)
 	runExample(t, 378)
 	runExample(t, 346)
+	runExample(t, 317)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- fix conversion logic for call arguments in Go backend
- run leetcode example 317 in compiler tests

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850c8e252088320abb5597e9ac1b89b