### PR TITLE
Fix list literal type inference in Go compiler

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3137,6 +3137,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 				return "", err
 			}
 			at := c.inferExprType(a)
+			if a.Binary.Left.Value.Target.List != nil {
+				at = paramTypes[i]
+			}
 			if lt, ok := paramTypes[i].(types.ListType); ok {
 				if et, ok := at.(types.ListType); ok {
 					if isListOfAny(et) && !isListOfAny(lt) {


### PR DESCRIPTION
## Summary
- keep argument type when a list literal is compiled with a type hint
- this prevents unnecessary slice conversions

## Testing
- `go test ./...`
- `make -C examples/leetcode run-go ID=23`

------
https://chatgpt.com/codex/tasks/task_e_6850ef5650588320a1841f4070ac1380