### PR TITLE
Fix Go equality handling for empty literals

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -1537,6 +1537,22 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 				return "", err
 			}
 			rightType = lt
+		} else if (part.Op == "==" || part.Op == "!=") && len(part.Right.Ops) == 0 {
+			if ll := part.Right.Target.List; ll != nil && len(ll.Elems) == 0 && isList(leftType) {
+				lt := leftType.(types.ListType)
+				right, err = c.compilePostfixHint(part.Right, leftType)
+				if err != nil {
+					return "", err
+				}
+				rightType = lt
+			} else if ml := part.Right.Target.Map; ml != nil && len(ml.Items) == 0 && isMap(leftType) {
+				mt := leftType.(types.MapType)
+				right, err = c.compilePostfixHint(part.Right, leftType)
+				if err != nil {
+					return "", err
+				}
+				rightType = mt
+			}
 		}
 		if right == "" {
 			right, err = c.compilePostfix(part.Right)


### PR DESCRIPTION
## Summary
- improve Go compiler so empty list/map literals in `==` and `!=` use the other operand type

## Testing
- `go test ./...`
- `make run-go ID=23` in examples/leetcode

------
https://chatgpt.com/codex/tasks/task_e_6850fba7e2688320998b190aa2a20d93