### PR TITLE
Fix python cast handling

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -1134,7 +1134,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 		}
 		if op.Cast != nil {
 			typ = c.resolveTypeRef(op.Cast.Type)
-			// Casts are ignored in Python code generation
+			expr = c.compileCast(expr, typ)
 			continue
 		}
 	}
@@ -1852,4 +1852,20 @@ func (c *Compiler) compilePackageImport(im *parser.ImportStmt) error {
 	c.writeln(fmt.Sprintf("%s = _import_%s()", alias, alias))
 	c.writeln("")
 	return nil
+}
+
+func (c *Compiler) compileCast(expr string, t types.Type) string {
+	switch t.(type) {
+	case types.IntType, types.Int64Type:
+		return fmt.Sprintf("int(%s)", expr)
+	case types.FloatType:
+		return fmt.Sprintf("float(%s)", expr)
+	case types.StringType:
+		return fmt.Sprintf("str(%s)", expr)
+	case types.BoolType:
+		return fmt.Sprintf("bool(%s)", expr)
+	default:
+		c.imports["typing"] = "typing"
+		return fmt.Sprintf("typing.cast(%s, %s)", pyType(t), expr)
+	}
 }


### PR DESCRIPTION
## Summary
- add `compileCast` helper to Python backend
- convert `as` casts into Python calls like `int()` or `typing.cast`

## Testing
- `go vet ./...`
- `go test ./compile/py -run Test` *(fails: signal interrupt)*


------
https://chatgpt.com/codex/tasks/task_e_6850fc046aa0832098f5bf088fcf545b