### PR TITLE
Fix Go compiler return literal typing

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -617,13 +617,21 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		}
 		c.writeln(expr)
 		return nil
-	case s.Return != nil:
-		expr, err := c.compileExpr(s.Return.Value)
-		if err != nil {
-			return err
-		}
-		retT := c.returnType
-		exprT := c.inferExprTypeHint(s.Return.Value, retT)
+       case s.Return != nil:
+               retT := c.returnType
+               var (
+                       expr string
+                       err  error
+               )
+               if retT != nil && (isEmptyListLiteral(s.Return.Value) || isEmptyMapLiteral(s.Return.Value)) {
+                       expr, err = c.compileExprHint(s.Return.Value, retT)
+               } else {
+                       expr, err = c.compileExpr(s.Return.Value)
+               }
+               if err != nil {
+                       return err
+               }
+               exprT := c.inferExprTypeHint(s.Return.Value, retT)
 		if retT != nil {
 			retGo := goType(retT)
 			exprGo := goType(exprT)
@@ -3008,6 +3016,26 @@ func literalValue(l *parser.Literal) any {
 	default:
 		return nil
 	}
+}
+
+func isEmptyListLiteral(e *parser.Expr) bool {
+       if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+               return false
+       }
+       if ll := e.Binary.Left.Value.Target.List; ll != nil {
+               return len(ll.Elems) == 0
+       }
+       return false
+}
+
+func isEmptyMapLiteral(e *parser.Expr) bool {
+       if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+               return false
+       }
+       if ml := e.Binary.Left.Value.Target.Map; ml != nil {
+               return len(ml.Items) == 0
+       }
+       return false
 }
 
 func (c *Compiler) callKey(call *parser.CallExpr) string {

--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -124,11 +124,12 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-	runExample(t, 201)
-	runExample(t, 207)
-	runExample(t, 378)
-	runExample(t, 346)
-	runExample(t, 317)
+        runExample(t, 201)
+        runExample(t, 207)
+        runExample(t, 378)
+        runExample(t, 346)
+        runExample(t, 317)
+        runExample(t, 267)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- improve Go compiler's handling of return expressions
- only apply type hints for empty list or map literals
- add helper detection functions for empty literals
- run LeetCode example 267 in Go compiler tests

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850fbc05d888320afe512cbdc6644d1