### PR TITLE
Add LeetCode 102 support for Go compiler

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -124,12 +124,13 @@ func TestGoCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestGoCompiler_LeetCodeExamples(t *testing.T) {
-        runExample(t, 201)
-        runExample(t, 207)
-        runExample(t, 378)
-        runExample(t, 346)
-        runExample(t, 317)
-        runExample(t, 267)
+	runExample(t, 102)
+	runExample(t, 201)
+	runExample(t, 207)
+	runExample(t, 378)
+	runExample(t, 346)
+	runExample(t, 317)
+	runExample(t, 267)
 }
 
 func runExample(t *testing.T, i int) {

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -196,6 +196,7 @@ const (
 		"}\n"
 
 	helperCast = "func _cast[T any](v any) T {\n" +
+		"    if tv, ok := v.(T); ok { return tv }\n" +
 		"    var out T\n" +
 		"    switch any(out).(type) {\n" +
 		"    case int:\n" +


### PR DESCRIPTION
## Summary
- handle interface values directly in `_cast` helper
- add LeetCode example 102 to Go compiler tests

## Testing
- `go test ./compile/go -run TestGoCompiler_LeetCodeExamples -v`

------
https://chatgpt.com/codex/tasks/task_e_685101ed95a48320b9bd9d9febf25473