### PR TITLE
Support group-by in python compiler

### DIFF
--- a/compile/py/runtime.go
+++ b/compile/py/runtime.go
@@ -40,6 +40,17 @@ var helperAvg = "def _avg(v):\n" +
 	"            raise Exception('avg() expects numbers')\n" +
 	"    return s / len(v)\n"
 
+var helperGroup = "class Group:\n" +
+	"    def __init__(self, key):\n" +
+	"        self.Key = key\n" +
+	"        self.Items = []\n" +
+	"    @property\n" +
+	"    def key(self):\n" +
+	"        return self.Key\n" +
+	"    @property\n" +
+	"    def values(self):\n" +
+	"        return self.Items\n"
+
 var helperFetch = "def _fetch(url, opts):\n" +
 	"    import urllib.request, urllib.parse, json\n" +
 	"    method = 'GET'\n" +
@@ -316,6 +327,7 @@ var helperMap = map[string]string{
 	"_gen_struct": helperGenStruct,
 	"_count":      helperCount,
 	"_avg":        helperAvg,
+	"_group":      helperGroup,
 	"_union_all":  helperUnionAll,
 	"_union":      helperUnion,
 	"_except":     helperExcept,


### PR DESCRIPTION
## Summary
- add `Group` runtime helper for python target
- handle simple `group by` queries in the Python compiler

## Testing
- `go test ./compile/py -run TestPyCompiler_LeetCodeExamples -count=1`
- `go test ./...` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685102441578832087be82bee9a1ecd9