### PR TITLE
Implement basic IR lowering with VM

### DIFF
--- a/ir/lower.go
+++ b/ir/lower.go
@@ -1,0 +1,132 @@
+package ir
+
+import (
+	"fmt"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+)
+
+// Lower converts a parsed program into VM instructions.
+// It supports a minimal subset of the language: integer literals,
+// basic arithmetic, let-bindings, and print statements.
+func Lower(prog *parser.Program) ([]vm.Instruction, error) {
+	b := builder{}
+	if err := b.program(prog); err != nil {
+		return nil, err
+	}
+	b.emit(vm.OpStop)
+	return b.ins, nil
+}
+
+type builder struct{ ins []vm.Instruction }
+
+func (b *builder) emit(op vm.Opcode) { b.ins = append(b.ins, vm.Instruction{Op: op}) }
+
+func (b *builder) emitConst(v any) { b.ins = append(b.ins, vm.Instruction{Op: vm.OpConst, Value: v}) }
+
+func (b *builder) emitVar(op vm.Opcode, name string) {
+	b.ins = append(b.ins, vm.Instruction{Op: op, Str: name})
+}
+
+func (b *builder) program(p *parser.Program) error {
+	for _, s := range p.Statements {
+		if s.Let != nil {
+			if err := b.expr(s.Let.Value); err != nil {
+				return err
+			}
+			b.emitVar(vm.OpStoreVar, s.Let.Name)
+		} else if s.Expr != nil {
+			if err := b.expr(s.Expr.Expr); err != nil {
+				return err
+			}
+			// Expression results are popped via print or return
+		}
+	}
+	return nil
+}
+
+func (b *builder) expr(e *parser.Expr) error {
+	if e == nil || e.Binary == nil {
+		return nil
+	}
+	if err := b.unary(e.Binary.Left); err != nil {
+		return err
+	}
+	for _, op := range e.Binary.Right {
+		if err := b.postfix(op.Right); err != nil {
+			return err
+		}
+		if err := b.binaryOp(op.Op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *builder) unary(u *parser.Unary) error {
+	if err := b.postfix(u.Value); err != nil {
+		return err
+	}
+	for i := len(u.Ops) - 1; i >= 0; i-- {
+		switch u.Ops[i] {
+		case "-":
+			b.emit(vm.OpNeg)
+		default:
+			return fmt.Errorf("unary op %s not supported", u.Ops[i])
+		}
+	}
+	return nil
+}
+
+func (b *builder) postfix(p *parser.PostfixExpr) error {
+	if err := b.primary(p.Target); err != nil {
+		return err
+	}
+	if len(p.Ops) != 0 {
+		return fmt.Errorf("postfix operations not supported")
+	}
+	return nil
+}
+
+func (b *builder) primary(p *parser.Primary) error {
+	switch {
+	case p == nil:
+		return nil
+	case p.Lit != nil:
+		if p.Lit.Int != nil {
+			b.emitConst(*p.Lit.Int)
+			return nil
+		}
+		return fmt.Errorf("literal type not supported")
+	case p.Selector != nil && len(p.Selector.Tail) == 0:
+		b.emitVar(vm.OpLoadVar, p.Selector.Root)
+		return nil
+	case p.Group != nil:
+		return b.expr(p.Group)
+	case p.Call != nil && p.Call.Func == "print" && len(p.Call.Args) == 1:
+		if err := b.expr(p.Call.Args[0]); err != nil {
+			return err
+		}
+		b.emit(vm.OpPrint)
+		return nil
+	default:
+		return fmt.Errorf("expression not supported")
+	}
+}
+
+func (b *builder) binaryOp(op string) error {
+	switch op {
+	case "+":
+		b.emit(vm.OpAdd)
+	case "-":
+		b.emit(vm.OpSub)
+	case "*":
+		b.emit(vm.OpMul)
+	case "/":
+		b.emit(vm.OpDiv)
+	default:
+		return fmt.Errorf("binary op %s not supported", op)
+	}
+	return nil
+}

--- a/ir/lower_test.go
+++ b/ir/lower_test.go
@@ -1,0 +1,55 @@
+package ir
+
+import (
+	"testing"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+)
+
+func compileSrc(src string) ([]vm.Instruction, error) {
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		return nil, err
+	}
+	return Lower(prog)
+}
+
+func run(src string) (any, error) {
+	ins, err := compileSrc(src)
+	if err != nil {
+		return nil, err
+	}
+	m := vm.New(ins)
+	return m.Run()
+}
+
+func TestLetAndAdd(t *testing.T) {
+	result, err := run("let x = 1 + 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result, got %v", result)
+	}
+}
+
+func TestExprReturn(t *testing.T) {
+	ins, err := compileSrc("1 + 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ins) > 0 {
+		ins[len(ins)-1].Op = vm.OpReturn
+	} else {
+		ins = append(ins, vm.Instruction{Op: vm.OpReturn})
+	}
+	m := vm.New(ins)
+	val, err := m.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != 3 {
+		t.Fatalf("expected 3 got %v", val)
+	}
+}

--- a/runtime/vm/instruction.go
+++ b/runtime/vm/instruction.go
@@ -1,0 +1,8 @@
+package vm
+
+// Instruction represents a single VM instruction.
+type Instruction struct {
+	Op    Opcode
+	Value any    // for OpConst
+	Str   string // for variable name
+}

--- a/runtime/vm/opcode.go
+++ b/runtime/vm/opcode.go
@@ -1,0 +1,18 @@
+package vm
+
+// Opcode represents a single instruction code in the virtual machine.
+type Opcode uint8
+
+const (
+	OpConst Opcode = iota
+	OpAdd
+	OpSub
+	OpMul
+	OpDiv
+	OpNeg
+	OpLoadVar
+	OpStoreVar
+	OpPrint
+	OpReturn
+	OpStop
+)

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1,0 +1,72 @@
+package vm
+
+import "fmt"
+
+// VM executes a sequence of instructions.
+type VM struct {
+	Ins   []Instruction
+	ip    int
+	stack []any
+	vars  map[string]any
+}
+
+// New creates a new VM for the given program.
+func New(ins []Instruction) *VM {
+	return &VM{Ins: ins, vars: map[string]any{}}
+}
+
+// Var retrieves the value of a variable after execution.
+func (v *VM) Var(name string) any { return v.vars[name] }
+
+func (v *VM) push(val any) { v.stack = append(v.stack, val) }
+
+func (v *VM) pop() any {
+	if len(v.stack) == 0 {
+		return nil
+	}
+	val := v.stack[len(v.stack)-1]
+	v.stack = v.stack[:len(v.stack)-1]
+	return val
+}
+
+// Run executes the instructions until OpStop or OpReturn.
+func (v *VM) Run() (any, error) {
+	for v.ip < len(v.Ins) {
+		ins := v.Ins[v.ip]
+		switch ins.Op {
+		case OpConst:
+			v.push(ins.Value)
+		case OpAdd:
+			b := v.pop().(int)
+			a := v.pop().(int)
+			v.push(a + b)
+		case OpSub:
+			b := v.pop().(int)
+			a := v.pop().(int)
+			v.push(a - b)
+		case OpMul:
+			b := v.pop().(int)
+			a := v.pop().(int)
+			v.push(a * b)
+		case OpDiv:
+			b := v.pop().(int)
+			a := v.pop().(int)
+			v.push(a / b)
+		case OpNeg:
+			a := v.pop().(int)
+			v.push(-a)
+		case OpLoadVar:
+			v.push(v.vars[ins.Str])
+		case OpStoreVar:
+			v.vars[ins.Str] = v.pop()
+		case OpPrint:
+			fmt.Println(v.pop())
+		case OpReturn:
+			return v.pop(), nil
+		case OpStop:
+			return nil, nil
+		}
+		v.ip++
+	}
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
- introduce a `runtime/vm` package implementing a simple stack VM
- add `ir` package to lower a subset of Mochi AST to VM instructions
- cover IR lowering with basic unit tests

## Testing
- `go test ./ir ./runtime/vm`
- `go test ./compile/go -run TestGoCompiler_GoldenOutput/map_any_hint -v` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685106a55d0c83209580e23f926e3cdb