### PR TITLE
Enable Python compiler group-by & run LeetCode 267

### DIFF
--- a/compile/py/compiler_test.go
+++ b/compile/py/compiler_test.go
@@ -168,6 +168,8 @@ func TestPyCompiler_LeetCodeExamples(t *testing.T) {
 		runDir(i)
 	}
 
+	// Additional examples that triggered compiler bugs previously.
+	runDir(267)
 	// Example 378 previously failed due to name clashes between tests and
 	// global variables.
 	runDir(378)

--- a/compile/py/infer.go
+++ b/compile/py/infer.go
@@ -313,6 +313,9 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 			}
 			child.SetVar(j.Var, je, true)
 		}
+		if p.Query.Group != nil {
+			child.SetVar(p.Query.Group.Name, types.GroupType{Elem: elemType}, true)
+		}
 		orig := c.env
 		c.env = child
 		elem := c.inferExprType(p.Query.Select)

--- a/compile/py/runtime.go
+++ b/compile/py/runtime.go
@@ -307,6 +307,29 @@ var helperQuery = "def _query(src, joins, opts):\n" +
 	"        res.append(opts['select'](*r))\n" +
 	"    return res\n"
 
+var helperGroupBy = "class _Group:\n" +
+	"    def __init__(self, key):\n" +
+	"        self.key = key\n" +
+	"        self.Items = []\n" +
+	"\n" +
+	"def _group_by(src, key_fn, sel_fn):\n" +
+	"    groups = {}\n" +
+	"    order = []\n" +
+	"    for it in src:\n" +
+	"        key = key_fn(it)\n" +
+	"        ks = str(key)\n" +
+	"        g = groups.get(ks)\n" +
+	"        if not g:\n" +
+	"            g = _Group(key)\n" +
+	"            groups[ks] = g\n" +
+	"            order.append(ks)\n" +
+	"        g.Items.append(it)\n" +
+	"    res = []\n" +
+	"    for ks in order:\n" +
+	"        g = groups[ks]\n" +
+	"        res.append(sel_fn(g))\n" +
+	"    return res\n"
+
 var helperMap = map[string]string{
 	"_gen_text":   helperGenText,
 	"_gen_embed":  helperGenEmbed,
@@ -324,6 +347,7 @@ var helperMap = map[string]string{
 	"_wait_all":   helperWaitAll,
 	"_agent":      helperAgent,
 	"_query":      helperQuery,
+	"_group_by":   helperGroupBy,
 }
 
 func (c *Compiler) use(name string) { c.helpers[name] = true }


### PR DESCRIPTION
## Summary
- support simple `group by` queries in Python compiler
- infer group variable type
- emit `_group_by` runtime helper
- quote simple map keys when compiling
- run LeetCode example 267 in Python compiler tests

## Testing
- `go test ./compile/py -run TestPyCompiler_LeetCodeExamples/267 -count=1 -v`
- `go test ./compile/py ./types ./parser ./interpreter -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68510576157c8320833576cd16cfb0fa