### PR TITLE
Centralize builtin op lookup

### DIFF
--- a/interpreter/instruction_table.go
+++ b/interpreter/instruction_table.go
@@ -1,0 +1,42 @@
+package interpreter
+
+import "github.com/alecthomas/participle/v2/lexer"
+
+// binaryInstr is the function signature for builtin binary operations.
+type binaryInstr func(lexer.Position, Value, Value) (Value, error)
+
+// unaryInstr is the function signature for builtin unary operations.
+type unaryInstr func(lexer.Position, Value) (Value, error)
+
+var (
+	binaryTable map[string]binaryInstr
+	unaryTable  map[string]unaryInstr
+)
+
+func init() {
+	binaryTable = map[string]binaryInstr{
+		"+":         func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "+", r) },
+		"-":         func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "-", r) },
+		"*":         func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "*", r) },
+		"/":         func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "/", r) },
+		"%":         func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "%", r) },
+		"<":         func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "<", r) },
+		"<=":        func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "<=", r) },
+		">":         func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, ">", r) },
+		">=":        func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, ">=", r) },
+		"==":        func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "==", r) },
+		"!=":        func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "!=", r) },
+		"&&":        func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "&&", r) },
+		"||":        func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "||", r) },
+		"in":        func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "in", r) },
+		"union":     func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "union", r) },
+		"union_all": func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "union_all", r) },
+		"except":    func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "except", r) },
+		"intersect": func(pos lexer.Position, l, r Value) (Value, error) { return applyBinaryValue(pos, l, "intersect", r) },
+	}
+
+	unaryTable = map[string]unaryInstr{
+		"-": func(pos lexer.Position, v Value) (Value, error) { return applyUnaryValue(pos, "-", v) },
+		"!": func(pos lexer.Position, v Value) (Value, error) { return applyUnaryValue(pos, "!", v) },
+	}
+}

--- a/interpreter/runtime_utils.go
+++ b/interpreter/runtime_utils.go
@@ -17,7 +17,11 @@ import (
 func applyBinary(pos lexer.Position, left any, op string, right any) (any, error) {
 	lv := anyToValue(left)
 	rv := anyToValue(right)
-	res, err := applyBinaryValue(pos, lv, op, rv)
+	fn, ok := binaryTable[op]
+	if !ok {
+		return nil, errInvalidOperator(pos, op, lv.Tag.String(), rv.Tag.String())
+	}
+	res, err := fn(pos, lv, rv)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +329,11 @@ func applyFloatBinaryValue(pos lexer.Position, l float64, op string, r float64) 
 // applyUnary applies a unary operator on a generic value.
 func applyUnary(pos lexer.Position, op string, val any) (any, error) {
 	v := anyToValue(val)
-	res, err := applyUnaryValue(pos, op, v)
+	fn, ok := unaryTable[op]
+	if !ok {
+		return nil, errUnknownUnaryOperator(pos, op)
+	}
+	res, err := fn(pos, v)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- centralize builtin op functions in a shared instruction table
- route applyBinary/applyUnary through the table

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_68510d059ec4832096f84fe34e2a79b9