### PR TITLE
Add v0.7.6 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 # 📦 CHANGELOG.md
+## [0.7.6] – 2025-06-18
+
+### Added
+
+* Primitive casts in Go and Python compilers
+* Typed empty list assignment and concatenation in Go
+* Map key casts and typed struct field hints
+* Basic group-by in Go and TypeScript
+* `input` builtin for reading lines
+* LeetCode 401 example
+
+### Changed
+
+* Go compiler infers empty literal types in equality
+* Benchmarks regenerated with updated results
+
+### Fixed
+
+* Argument count validation for builtins
+* Forward type declarations in the type checker
+* Float literal handling and return hints in the Go compiler
+* Name conflicts in Python and Go tests
+
+
 ## [0.7.5] – 2025-06-17
 
 ### Added

--- a/releases/v0.7.6.md
+++ b/releases/v0.7.6.md
@@ -1,0 +1,29 @@
+# Jun 2025 (v0.7.6)
+
+Mochi v0.7.6 adds typed collection features, primitive casts and stronger type checking across the compilers.
+
+## Compilers
+
+- Go compiler supports typed empty lists, map key casts and underscore loop variables
+- Primitive casts implemented in Go and Python compilers
+- Group-by operations available in Go and TypeScript
+- Python compiler loads globals after test blocks
+- TypeScript compiler resolves user-defined types
+
+## Runtime
+
+- Cast builtin converts between numeric types
+- New `input` builtin reads a line from standard input
+
+## Type Checker
+
+- Builtin functions validate argument counts
+- Forward type declarations are recognized
+
+## Example Library
+
+- Added solution for LeetCode 401
+
+## Build System
+
+- Benchmark generation fixed with updated results


### PR DESCRIPTION
## Summary
- document changes in `CHANGELOG.md` for v0.7.6
- add release notes markdown for v0.7.6

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68511095ff6c8320a667e296727dc5a9