### PR TITLE
Add C compiler via Cython

### DIFF
--- a/compile/c/compiler.go
+++ b/compile/c/compiler.go
@@ -1,0 +1,53 @@
+package ccode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	pycode "mochi/compile/py"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler translates a Mochi AST into C source code by first compiling to
+// Python and then using Cython's --embed mode to generate C code embedding
+// the Python interpreter.
+type Compiler struct {
+	env *types.Env
+}
+
+// New creates a new C compiler instance.
+func New(env *types.Env) *Compiler { return &Compiler{env: env} }
+
+// Compile returns C source code that executes prog.
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "mochi-c-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	pyPath := filepath.Join(dir, "prog.py")
+	cPath := filepath.Join(dir, "prog.c")
+
+	pyCode, err := pycode.New(c.env).Compile(prog)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(pyPath, pyCode, 0644); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("cython", pyPath, "-3", "--embed", "-o", cPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("cython failed: %w\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(cPath)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/compile/c/compiler_test.go
+++ b/compile/c/compiler_test.go
@@ -1,0 +1,76 @@
+package ccode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ccode "mochi/compile/c"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Test that the C compiler can compile and run the first LeetCode example.
+func TestCCompiler_LeetCode1(t *testing.T) {
+	if _, err := exec.LookPath("cython"); err != nil {
+		t.Skip("cython not installed")
+	}
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("gcc not installed")
+	}
+
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	comp := ccode.New(env)
+	code, err := comp.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	dir := t.TempDir()
+	cfile := filepath.Join(dir, "main.c")
+	if err := os.WriteFile(cfile, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	exe := filepath.Join(dir, "prog")
+
+	incOut, err := exec.Command("python3-config", "--includes").Output()
+	if err != nil {
+		t.Fatalf("python3-config error: %v", err)
+	}
+	ldOut, err := exec.Command("python3-config", "--ldflags").Output()
+	if err != nil {
+		t.Fatalf("python3-config error: %v", err)
+	}
+
+	args := append([]string{"-Os"}, strings.Fields(string(incOut))...)
+	args = append(args, cfile)
+	args = append(args, strings.Fields(string(ldOut))...)
+	args = append(args, "-lpython3.11", "-o", exe)
+
+	cmd := exec.Command("gcc", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("gcc error: %v\n%s", err, out)
+	}
+
+	run := exec.Command(exe)
+	out, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run error: %v\n%s", err, out)
+	}
+
+	got := strings.TrimSpace(string(out))
+	want := "0\n1"
+	if got != want {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add `compile/c` package to compile Mochi to C via Cython
- verify on LeetCode example `examples/leetcode/1`

## Testing
- `go test ./compile/c -run TestCCompiler_LeetCode1 -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685148315e848320ba00dced4a6662ec