### PR TITLE
Add C compiler test and remove CLI target

### DIFF
--- a/compile/Readme.md
+++ b/compile/Readme.md
@@ -8,6 +8,7 @@ Current directories:
 - `py`  – Python source emitter
 - `ts`  – TypeScript/Deno output
 - `wasm` – WebAssembly using the Go backend
+- `c`   – experimental C output
 
 This guide shows how to implement another backend.
 

--- a/compile/c/compiler.go
+++ b/compile/c/compiler.go
@@ -1,0 +1,287 @@
+package ccode
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+type Compiler struct {
+	buf    bytes.Buffer
+	indent int
+	tmp    int
+	env    *types.Env
+}
+
+func New(env *types.Env) *Compiler {
+	return &Compiler{env: env}
+}
+
+func (c *Compiler) writeln(s string) {
+	for i := 0; i < c.indent; i++ {
+		c.buf.WriteByte('\t')
+	}
+	c.buf.WriteString(s)
+	c.buf.WriteByte('\n')
+}
+
+func (c *Compiler) newTemp() string {
+	c.tmp++
+	return fmt.Sprintf("_t%d", c.tmp)
+}
+
+func (c *Compiler) cType(t *parser.TypeRef) string {
+	if t == nil {
+		return "void"
+	}
+	if t.Simple != nil {
+		switch *t.Simple {
+		case "int":
+			return "int"
+		case "float":
+			return "double"
+		case "bool":
+			return "int"
+		}
+	}
+	if t.Generic != nil && t.Generic.Name == "list" {
+		if len(t.Generic.Args) == 1 {
+			elem := c.cType(t.Generic.Args[0])
+			if elem == "int" {
+				return "list_int"
+			}
+		}
+	}
+	return "int"
+}
+
+func (c *Compiler) compileProgram(prog *parser.Program) ([]byte, error) {
+	c.writeln("#include <stdio.h>")
+	c.writeln("#include <stdlib.h>")
+	c.writeln("")
+	c.writeln("typedef struct { int len; int *data; } list_int;")
+	c.writeln("")
+	c.writeln("static list_int list_int_create(int len) {")
+	c.indent++
+	c.writeln("list_int l;")
+	c.writeln("l.len = len;")
+	c.writeln("l.data = (int*)malloc(sizeof(int)*len);")
+	c.writeln("return l;")
+	c.indent--
+	c.writeln("}")
+	c.writeln("")
+	// functions first
+	for _, s := range prog.Statements {
+		if s.Fun != nil {
+			if err := c.compileFun(s.Fun); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		}
+	}
+	// main function
+	c.writeln("int main() {")
+	c.indent++
+	for _, s := range prog.Statements {
+		if s.Fun == nil {
+			if err := c.compileStmt(s); err != nil {
+				return nil, err
+			}
+		}
+	}
+	c.writeln("return 0;")
+	c.indent--
+	c.writeln("}")
+	return c.buf.Bytes(), nil
+}
+
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	return c.compileProgram(prog)
+}
+
+func (c *Compiler) compileFun(fun *parser.FunStmt) error {
+	ret := c.cType(fun.Return)
+	c.buf.WriteString(ret + " ")
+	c.buf.WriteString(fun.Name)
+	c.buf.WriteByte('(')
+	for i, p := range fun.Params {
+		if i > 0 {
+			c.buf.WriteString(", ")
+		}
+		c.buf.WriteString(c.cType(p.Type))
+		c.buf.WriteByte(' ')
+		c.buf.WriteString(p.Name)
+	}
+	c.buf.WriteString("){\n")
+	c.indent++
+	for _, st := range fun.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln("}")
+	return nil
+}
+
+func (c *Compiler) compileStmt(s *parser.Statement) error {
+	switch {
+	case s.Let != nil:
+		name := s.Let.Name
+		typ := "int"
+		if s.Let.Type != nil {
+			typ = c.cType(s.Let.Type)
+		} else if c.env != nil {
+			if t, err := c.env.GetVar(name); err == nil {
+				if lt, ok := t.(types.ListType); ok {
+					if _, ok := lt.Elem.(types.IntType); ok {
+						typ = "list_int"
+					}
+				}
+			}
+		}
+		if s.Let.Value != nil {
+			val := c.compileExpr(s.Let.Value)
+			c.writeln(fmt.Sprintf("%s %s = %s;", typ, name, val))
+		} else {
+			c.writeln(fmt.Sprintf("%s %s;", typ, name))
+		}
+	case s.Return != nil:
+		val := c.compileExpr(s.Return.Value)
+		c.writeln(fmt.Sprintf("return %s;", val))
+	case s.For != nil:
+		return c.compileFor(s.For)
+	case s.If != nil:
+		cond := c.compileExpr(s.If.Cond)
+		c.writeln(fmt.Sprintf("if (%s) {", cond))
+		c.indent++
+		for _, st := range s.If.Then {
+			if err := c.compileStmt(st); err != nil {
+				return err
+			}
+		}
+		c.indent--
+		c.writeln("}")
+	case s.Expr != nil:
+		expr := c.compileExpr(s.Expr.Expr)
+		if expr != "" {
+			c.writeln(fmt.Sprintf("%s;", expr))
+		}
+	default:
+		// unsupported
+	}
+	return nil
+}
+
+func (c *Compiler) compileFor(f *parser.ForStmt) error {
+	start := c.compileExpr(f.Source)
+	end := c.compileExpr(f.RangeEnd)
+	name := f.Name
+	c.writeln(fmt.Sprintf("for (int %s = %s; %s < %s; %s++) {", name, start, name, end, name))
+	c.indent++
+	for _, st := range f.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln("}")
+	return nil
+}
+
+func (c *Compiler) compileExpr(e *parser.Expr) string {
+	if e == nil {
+		return ""
+	}
+	res := c.compileBinary(e.Binary)
+	return res
+}
+
+func (c *Compiler) compileBinary(b *parser.BinaryExpr) string {
+	left := c.compileUnary(b.Left)
+	for _, op := range b.Right {
+		right := c.compilePostfix(op.Right)
+		left = fmt.Sprintf("(%s %s %s)", left, op.Op, right)
+	}
+	return left
+}
+
+func (c *Compiler) compileUnary(u *parser.Unary) string {
+	expr := c.compilePostfix(u.Value)
+	for i := len(u.Ops) - 1; i >= 0; i-- {
+		op := u.Ops[i]
+		if op == "-" {
+			expr = fmt.Sprintf("(-%s)", expr)
+		} else if op == "!" {
+			expr = fmt.Sprintf("(!%s)", expr)
+		}
+	}
+	return expr
+}
+
+func (c *Compiler) compilePostfix(p *parser.PostfixExpr) string {
+	expr := c.compilePrimary(p.Target)
+	for _, op := range p.Ops {
+		if op.Index != nil {
+			idx := c.compileExpr(op.Index.Start)
+			expr = fmt.Sprintf("%s.data[%s]", expr, idx)
+		}
+	}
+	return expr
+}
+
+func (c *Compiler) compilePrimary(p *parser.Primary) string {
+	switch {
+	case p.Lit != nil:
+		return c.compileLiteral(p.Lit)
+	case p.Selector != nil:
+		return c.compileSelector(p.Selector)
+	case p.List != nil:
+		name := c.newTemp()
+		c.writeln(fmt.Sprintf("list_int %s = list_int_create(%d);", name, len(p.List.Elems)))
+		for i, el := range p.List.Elems {
+			v := c.compileExpr(el)
+			c.writeln(fmt.Sprintf("%s.data[%d] = %s;", name, i, v))
+		}
+		return name
+	case p.Call != nil:
+		if p.Call.Func == "len" {
+			arg := c.compileExpr(p.Call.Args[0])
+			return fmt.Sprintf("%s.len", arg)
+		} else if p.Call.Func == "print" {
+			arg := c.compileExpr(p.Call.Args[0])
+			c.writeln(fmt.Sprintf("printf(\"%s\\n\", %s);", "%d", arg))
+			return ""
+		}
+		args := make([]string, len(p.Call.Args))
+		for i, a := range p.Call.Args {
+			args[i] = c.compileExpr(a)
+		}
+		return fmt.Sprintf("%s(%s)", p.Call.Func, strings.Join(args, ", "))
+	case p.Group != nil:
+		return fmt.Sprintf("(%s)", c.compileExpr(p.Group))
+	default:
+		return "0"
+	}
+}
+
+func (c *Compiler) compileLiteral(l *parser.Literal) string {
+	switch {
+	case l.Int != nil:
+		return fmt.Sprintf("%d", *l.Int)
+	case l.Bool != nil:
+		if *l.Bool {
+			return "1"
+		} else {
+			return "0"
+		}
+	}
+	return "0"
+}
+
+func (c *Compiler) compileSelector(s *parser.SelectorExpr) string {
+	return s.Root
+}

--- a/compile/c/compiler_test.go
+++ b/compile/c/compiler_test.go
@@ -1,0 +1,62 @@
+package ccode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ccode "mochi/compile/c"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestCCompiler_TwoSum compiles the LeetCode example to C and runs it.
+func TestCCompiler_TwoSum(t *testing.T) {
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("gcc not installed")
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := ccode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	goldenPath := filepath.Join("..", "..", "tests", "compiler", "valid", "two_sum.c.out")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	gotSrc := strings.TrimSpace(string(code))
+	wantSrc := strings.TrimSpace(string(golden))
+	if gotSrc != wantSrc {
+		t.Fatalf("generated C mismatch\n--- got ---\n%s\n--- want ---\n%s", gotSrc, wantSrc)
+	}
+	dir := t.TempDir()
+	cfile := filepath.Join(dir, "prog.c")
+	if err := os.WriteFile(cfile, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	bin := filepath.Join(dir, "prog")
+	if out, err := exec.Command("gcc", cfile, "-o", bin).CombinedOutput(); err != nil {
+		t.Fatalf("gcc error: %v\n%s", err, out)
+	}
+	out, err := exec.Command(bin).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run error: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	want := "0\n1"
+	if got != want {
+		t.Fatalf("unexpected output\nwant:\n%s\n got:\n%s", want, got)
+	}
+}

--- a/tests/compiler/valid/two_sum.c.out
+++ b/tests/compiler/valid/two_sum.c.out
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct { int len; int *data; } list_int;
+
+static list_int list_int_create(int len) {
+	list_int l;
+	l.len = len;
+	l.data = (int*)malloc(sizeof(int)*len);
+	return l;
+}
+
+list_int twoSum(list_int nums, int target){
+	int n = nums.len;
+	for (int i = 0; i < n; i++) {
+		for (int j = (i + 1); j < n; j++) {
+			if (((nums.data[i] + nums.data[j]) == target)) {
+				list_int _t1 = list_int_create(2);
+				_t1.data[0] = i;
+				_t1.data[1] = j;
+				return _t1;
+			}
+		}
+	}
+	list_int _t2 = list_int_create(2);
+	_t2.data[0] = (-1);
+	_t2.data[1] = (-1);
+	return _t2;
+}
+
+int main() {
+	list_int _t3 = list_int_create(4);
+	_t3.data[0] = 2;
+	_t3.data[1] = 7;
+	_t3.data[2] = 11;
+	_t3.data[3] = 15;
+	list_int result = twoSum(_t3, 9);
+	printf("%d\n", result.data[0]);
+	printf("%d\n", result.data[1]);
+	return 0;
+}


### PR DESCRIPTION
## Summary
- keep CLI build flags limited to go/py/ts/wasm
- verify generated C code for LeetCode example against golden file

## Testing
- `go test ./compile/c -run TestCCompiler_TwoSum -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68514909caf48320a4680ba0f38bb024