### PR TITLE
Move ensure helpers to compile packages

### DIFF
--- a/bench/deps.go
+++ b/bench/deps.go
@@ -5,7 +5,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
+
+	cscode "mochi/compile/cs"
+	dartcode "mochi/compile/dart"
+	pycode "mochi/compile/py"
+	rscode "mochi/compile/rust"
+	swiftcode "mochi/compile/swift"
+	tscode "mochi/compile/ts"
 )
 
 // EnsureDeps verifies that Mochi, Deno and Python3 are installed.
@@ -16,16 +22,22 @@ func EnsureDeps() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := ensurePython(); err != nil {
+	if err := pycode.EnsurePython(); err != nil {
 		return "", err
 	}
-	if err := ensureRust(); err != nil {
+	if err := rscode.EnsureRust(); err != nil {
 		return "", err
 	}
-	if err := ensureDeno(); err != nil {
+	if err := tscode.EnsureDeno(); err != nil {
 		return "", err
 	}
-	if err := ensureDotnet(); err != nil {
+	if err := cscode.EnsureDotnet(); err != nil {
+		return "", err
+	}
+	if err := dartcode.EnsureDart(); err != nil {
+		return "", err
+	}
+	if err := swiftcode.EnsureSwift(); err != nil {
 		return "", err
 	}
 	return mochiBin, nil
@@ -51,117 +63,4 @@ func ensureMochi() (string, error) {
 		return "", err
 	}
 	return out, nil
-}
-
-func ensurePython() error {
-	if _, err := exec.LookPath("python3"); err == nil {
-		return nil
-	}
-	fmt.Println("🐍 Installing Python3...")
-	cmd := exec.Command("apt-get", "update")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	cmd = exec.Command("apt-get", "install", "-y", "python3")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func ensureDeno() error {
-	if _, err := exec.LookPath("deno"); err == nil {
-		return nil
-	}
-	fmt.Println("🦕 Installing Deno...")
-	home := os.Getenv("HOME")
-	if home == "" {
-		home = "/tmp"
-	}
-	installDir := filepath.Join(home, ".deno")
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("curl -fsSL https://deno.land/install.sh | DENO_INSTALL=%s sh", installDir))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	// attempt to move deno to /usr/local/bin
-	denoSrc := filepath.Join(installDir, "bin", "deno")
-	if _, err := os.Stat(denoSrc); err == nil {
-		if err := exec.Command("install", "-m", "755", denoSrc, "/usr/local/bin/deno").Run(); err == nil {
-			return nil
-		}
-		// fallback to HOME/bin
-		dest := filepath.Join(home, "bin", "deno")
-		if err := os.MkdirAll(filepath.Dir(dest), 0755); err == nil {
-			if err := os.Rename(denoSrc, dest); err == nil {
-				return nil
-			}
-		}
-	}
-	return fmt.Errorf("failed to install deno")
-}
-
-// EnsureDeno verifies that the Deno binary is installed and attempts to
-// install it if missing. It is safe to call from tests.
-func EnsureDeno() error {
-	return ensureDeno()
-}
-
-func ensureDart() error {
-	if _, err := exec.LookPath("dart"); err == nil {
-		return nil
-	}
-	fmt.Println("\U0001F3AF Installing Dart...")
-	home := os.Getenv("HOME")
-	if home == "" {
-		home = "/tmp"
-	}
-	installDir := filepath.Join(home, ".dart")
-	if err := os.MkdirAll(installDir, 0755); err != nil {
-		return err
-	}
-	arch := "x64"
-	if runtime.GOARCH == "arm64" {
-		arch = "arm64"
-	}
-	osName := "linux"
-	if runtime.GOOS == "darwin" {
-		osName = "macos"
-	} else if runtime.GOOS != "linux" {
-		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
-	}
-	file := fmt.Sprintf("dartsdk-%s-%s-release.zip", osName, arch)
-	url := fmt.Sprintf("https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/%s", file)
-	zipPath := filepath.Join(installDir, file)
-	cmd := exec.Command("curl", "-fsSL", "-o", zipPath, url)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	cmd = exec.Command("unzip", "-q", zipPath, "-d", installDir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	dartSrc := filepath.Join(installDir, "dart-sdk", "bin", "dart")
-	if err := exec.Command("install", "-m", "755", dartSrc, "/usr/local/bin/dart").Run(); err == nil {
-		return nil
-	}
-	dest := filepath.Join(home, "bin", "dart")
-	if err := os.MkdirAll(filepath.Dir(dest), 0755); err == nil {
-		if err := os.Rename(dartSrc, dest); err == nil {
-			return nil
-		}
-	}
-	return fmt.Errorf("failed to install dart")
-}
-
-// EnsureDart verifies that the Dart binary is installed and attempts to install
-// it if missing. It is safe to call from tests.
-func EnsureDart() error {
-	return ensureDart()
 }

--- a/compile/c/compiler_test.go
+++ b/compile/c/compiler_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	bench "mochi/bench"
 	ccode "mochi/compile/c"
 	"mochi/golden"
 	"mochi/parser"
@@ -18,7 +17,7 @@ import (
 
 // TestCCompiler_TwoSum compiles the LeetCode example to C and runs it.
 func TestCCompiler_TwoSum(t *testing.T) {
-	cc, err := bench.EnsureCC()
+	cc, err := ccode.EnsureCC()
 	if err != nil {
 		t.Skipf("C compiler not installed: %v", err)
 	}
@@ -67,7 +66,7 @@ func TestCCompiler_TwoSum(t *testing.T) {
 }
 
 func TestCCompiler_SubsetPrograms(t *testing.T) {
-	cc, err := bench.EnsureCC()
+	cc, err := ccode.EnsureCC()
 	if err != nil {
 		t.Skipf("C compiler not installed: %v", err)
 	}
@@ -103,7 +102,7 @@ func TestCCompiler_SubsetPrograms(t *testing.T) {
 }
 
 func TestCCompiler_GoldenOutput(t *testing.T) {
-	if _, err := bench.EnsureCC(); err != nil {
+	if _, err := ccode.EnsureCC(); err != nil {
 		t.Skipf("C compiler not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/c", ".mochi", ".c.out", func(src string) ([]byte, error) {

--- a/compile/c/tools.go
+++ b/compile/c/tools.go
@@ -1,4 +1,4 @@
-package bench
+package ccode
 
 import (
 	"fmt"

--- a/compile/cs/tools.go
+++ b/compile/cs/tools.go
@@ -1,4 +1,4 @@
-package bench
+package cscode
 
 import (
 	"fmt"
@@ -8,12 +8,8 @@ import (
 )
 
 // EnsureDotnet verifies that the dotnet CLI is installed and attempts to
-// install it if missing. It is safe to call from tests.
+// install it if missing.
 func EnsureDotnet() error {
-	return ensureDotnet()
-}
-
-func ensureDotnet() error {
 	if _, err := exec.LookPath("dotnet"); err == nil {
 		return nil
 	}

--- a/compile/dart/compiler_test.go
+++ b/compile/dart/compiler_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"mochi/bench"
 	dartcode "mochi/compile/dart"
 	"mochi/golden"
 	"mochi/parser"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestDartCompiler_LeetCodeExample1(t *testing.T) {
-	if err := bench.EnsureDart(); err != nil {
+	if err := dartcode.EnsureDart(); err != nil {
 		t.Skipf("dart not installed: %v", err)
 	}
 	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
@@ -51,7 +50,7 @@ func TestDartCompiler_LeetCodeExample1(t *testing.T) {
 }
 
 func TestDartCompiler_SubsetPrograms(t *testing.T) {
-	if err := bench.EnsureDart(); err != nil {
+	if err := dartcode.EnsureDart(); err != nil {
 		t.Skipf("dart not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/dart", ".mochi", ".out", func(src string) ([]byte, error) {
@@ -90,7 +89,7 @@ func TestDartCompiler_SubsetPrograms(t *testing.T) {
 }
 
 func TestDartCompiler_GoldenOutput(t *testing.T) {
-	if err := bench.EnsureDart(); err != nil {
+	if err := dartcode.EnsureDart(); err != nil {
 		t.Skipf("dart not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/dart", ".mochi", ".dart.out", func(src string) ([]byte, error) {

--- a/compile/dart/tools.go
+++ b/compile/dart/tools.go
@@ -1,0 +1,62 @@
+package dartcode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// EnsureDart verifies that the Dart binary is installed and attempts to install
+// it if missing.
+func EnsureDart() error {
+	if _, err := exec.LookPath("dart"); err == nil {
+		return nil
+	}
+	fmt.Println("🎯 Installing Dart...")
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = "/tmp"
+	}
+	installDir := filepath.Join(home, ".dart")
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return err
+	}
+	arch := "x64"
+	if runtime.GOARCH == "arm64" {
+		arch = "arm64"
+	}
+	osName := "linux"
+	if runtime.GOOS == "darwin" {
+		osName = "macos"
+	} else if runtime.GOOS != "linux" {
+		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+	file := fmt.Sprintf("dartsdk-%s-%s-release.zip", osName, arch)
+	url := fmt.Sprintf("https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/%s", file)
+	zipPath := filepath.Join(installDir, file)
+	cmd := exec.Command("curl", "-fsSL", "-o", zipPath, url)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	cmd = exec.Command("unzip", "-q", zipPath, "-d", installDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	dartSrc := filepath.Join(installDir, "dart-sdk", "bin", "dart")
+	if err := exec.Command("install", "-m", "755", dartSrc, "/usr/local/bin/dart").Run(); err == nil {
+		return nil
+	}
+	dest := filepath.Join(home, "bin", "dart")
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err == nil {
+		if err := os.Rename(dartSrc, dest); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to install dart")
+}

--- a/compile/py/tools.go
+++ b/compile/py/tools.go
@@ -1,0 +1,25 @@
+package pycode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// EnsurePython verifies that python3 is installed and attempts to install it via apt-get if missing.
+func EnsurePython() error {
+	if _, err := exec.LookPath("python3"); err == nil {
+		return nil
+	}
+	fmt.Println("🐍 Installing Python3...")
+	cmd := exec.Command("apt-get", "update")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	cmd = exec.Command("apt-get", "install", "-y", "python3")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"mochi/bench"
 	rscode "mochi/compile/rust"
 	"mochi/golden"
 	"mochi/parser"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestRustCompiler_SubsetPrograms(t *testing.T) {
-	if err := bench.EnsureRust(); err != nil {
+	if err := rscode.EnsureRust(); err != nil {
 		t.Skipf("rust not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/rust", ".mochi", ".out", func(src string) ([]byte, error) {

--- a/compile/rust/tools.go
+++ b/compile/rust/tools.go
@@ -1,4 +1,4 @@
-package bench
+package rscode
 
 import (
 	"fmt"
@@ -6,8 +6,9 @@ import (
 	"os/exec"
 )
 
-// ensureRust checks for the rust toolchain and installs it via rustup if missing.
-func ensureRust() error {
+// EnsureRust verifies that the Rust toolchain is installed and attempts to
+// install it via rustup if missing.
+func EnsureRust() error {
 	if _, err := exec.LookPath("rustc"); err == nil {
 		return nil
 	}
@@ -16,10 +17,4 @@ func ensureRust() error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-// EnsureRust verifies that the Rust toolchain is installed and attempts to
-// install it if missing. It is safe to call from tests.
-func EnsureRust() error {
-	return ensureRust()
 }

--- a/compile/swift/compiler_test.go
+++ b/compile/swift/compiler_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"mochi/bench"
 	swiftcode "mochi/compile/swift"
 	"mochi/golden"
 	"mochi/parser"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestSwiftCompiler_SubsetPrograms(t *testing.T) {
-	if err := bench.EnsureSwift(); err != nil {
+	if err := swiftcode.EnsureSwift(); err != nil {
 		t.Skipf("swift not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/swift", ".mochi", ".out", func(src string) ([]byte, error) {

--- a/compile/swift/tools.go
+++ b/compile/swift/tools.go
@@ -1,4 +1,4 @@
-package bench
+package swiftcode
 
 import (
 	"fmt"
@@ -7,8 +7,8 @@ import (
 	"runtime"
 )
 
-// EnsureSwift verifies that the Swift toolchain is installed. If missing,
-// it attempts a best-effort installation using Homebrew on macOS or apt-get on
+// EnsureSwift verifies that the Swift toolchain is installed. If missing, it
+// attempts a best-effort installation using Homebrew on macOS or apt-get on
 // Linux.
 func EnsureSwift() error {
 	if _, err := exec.LookPath("swiftc"); err == nil {
@@ -38,7 +38,6 @@ func EnsureSwift() error {
 				return nil
 			}
 		}
-		// fallback: try official installer script
 		cmd := exec.Command("bash", "-c", "curl -sSL https://swift.org/install.sh | bash")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/compile/ts/compiler_test.go
+++ b/compile/ts/compiler_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"mochi/bench"
 	tscode "mochi/compile/ts"
 	"mochi/golden"
 	"mochi/parser"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestTSCompiler_SubsetPrograms(t *testing.T) {
-	if err := bench.EnsureDeno(); err != nil {
+	if err := tscode.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/valid", ".mochi", ".out", func(src string) ([]byte, error) {
@@ -135,7 +134,7 @@ func TestTSCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestTSCompiler_LeetCodeExamples(t *testing.T) {
-	if err := bench.EnsureDeno(); err != nil {
+	if err := tscode.EnsureDeno(); err != nil {
 		t.Skipf("deno not installed: %v", err)
 	}
 	for i := 1; i <= 133; i++ {

--- a/compile/ts/tools.go
+++ b/compile/ts/tools.go
@@ -1,0 +1,41 @@
+package tscode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// EnsureDeno verifies that the Deno binary is installed and attempts to install
+// it if missing.
+func EnsureDeno() error {
+	if _, err := exec.LookPath("deno"); err == nil {
+		return nil
+	}
+	fmt.Println("🦕 Installing Deno...")
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = "/tmp"
+	}
+	installDir := filepath.Join(home, ".deno")
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("curl -fsSL https://deno.land/install.sh | DENO_INSTALL=%s sh", installDir))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	denoSrc := filepath.Join(installDir, "bin", "deno")
+	if _, err := os.Stat(denoSrc); err == nil {
+		if err := exec.Command("install", "-m", "755", denoSrc, "/usr/local/bin/deno").Run(); err == nil {
+			return nil
+		}
+		dest := filepath.Join(home, "bin", "deno")
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err == nil {
+			if err := os.Rename(denoSrc, dest); err == nil {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("failed to install deno")
+}


### PR DESCRIPTION
## Summary
- move toolchain installers from bench/ to language-specific compile packages
- call these new helpers in bench deps
- update tests to use the new helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68515c9be3588320b851cb10a6de8b76