### PR TITLE
Move elixir tools into ex compiler

### DIFF
--- a/compile/ex/compiler_test.go
+++ b/compile/ex/compiler_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	elixir "mochi/compile/elixir"
 	excode "mochi/compile/ex"
 	"mochi/golden"
 	"mochi/parser"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestExCompiler_SubsetPrograms(t *testing.T) {
-	if err := elixir.EnsureElixir(); err != nil {
+	if err := excode.EnsureElixir(); err != nil {
 		t.Skipf("elixir not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/ex", ".mochi", ".out", func(src string) ([]byte, error) {

--- a/compile/ex/tools.go
+++ b/compile/ex/tools.go
@@ -1,4 +1,4 @@
-package elixir
+package excode
 
 import (
 	"fmt"


### PR DESCRIPTION
## Summary
- move `compile/elixir` tooling to `compile/ex`
- update tests to use the new package

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685163f17034832098488b9629488001