### PR TITLE
Add basic PHP compiler

### DIFF
--- a/compile/php/compiler.go
+++ b/compile/php/compiler.go
@@ -1,0 +1,325 @@
+package phpcode
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler translates a Mochi AST into PHP source code.
+type Compiler struct {
+	buf    bytes.Buffer
+	indent int
+	env    *types.Env
+}
+
+// New creates a new PHP compiler instance.
+func New(env *types.Env) *Compiler { return &Compiler{env: env} }
+
+// Compile generates PHP code for prog.
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	c.buf.Reset()
+	c.writeln("<?php")
+
+	// functions first
+	for _, s := range prog.Statements {
+		if s.Fun != nil {
+			if err := c.compileFun(s.Fun); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		}
+	}
+
+	// main body
+	for _, s := range prog.Statements {
+		if s.Fun != nil || s.Type != nil || s.Test != nil {
+			continue
+		}
+		if err := c.compileStmt(s); err != nil {
+			return nil, err
+		}
+	}
+	return c.buf.Bytes(), nil
+}
+
+// --- Statements ---
+
+func (c *Compiler) compileStmt(s *parser.Statement) error {
+	switch {
+	case s.Let != nil:
+		return c.compileLet(s.Let)
+	case s.Return != nil:
+		val, err := c.compileExpr(s.Return.Value)
+		if err != nil {
+			return err
+		}
+		c.writeln("return " + val + ";")
+		return nil
+	case s.For != nil:
+		return c.compileFor(s.For)
+	case s.If != nil:
+		return c.compileIf(s.If)
+	case s.Expr != nil:
+		expr, err := c.compileExpr(s.Expr.Expr)
+		if err != nil {
+			return err
+		}
+		if expr != "" {
+			c.writeln(expr + ";")
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+func (c *Compiler) compileFun(fn *parser.FunStmt) error {
+	params := make([]string, len(fn.Params))
+	for i, p := range fn.Params {
+		params[i] = "$" + sanitizeName(p.Name)
+	}
+	c.writeln(fmt.Sprintf("function %s(%s) {", sanitizeName(fn.Name), strings.Join(params, ", ")))
+	c.indent++
+	for _, st := range fn.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln("}")
+	return nil
+}
+
+func (c *Compiler) compileLet(l *parser.LetStmt) error {
+	name := "$" + sanitizeName(l.Name)
+	val := "null"
+	if l.Value != nil {
+		v, err := c.compileExpr(l.Value)
+		if err != nil {
+			return err
+		}
+		val = v
+	}
+	c.writeln(fmt.Sprintf("%s = %s;", name, val))
+	return nil
+}
+
+func (c *Compiler) compileFor(f *parser.ForStmt) error {
+	name := "$" + sanitizeName(f.Name)
+	if f.RangeEnd != nil {
+		start, err := c.compileExpr(f.Source)
+		if err != nil {
+			return err
+		}
+		end, err := c.compileExpr(f.RangeEnd)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("for (%s = %s; %s < %s; %s++) {", name, start, name, end, name))
+	} else {
+		src, err := c.compileExpr(f.Source)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("foreach (%s as %s) {", src, name))
+	}
+	c.indent++
+	for _, st := range f.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln("}")
+	return nil
+}
+
+func (c *Compiler) compileIf(s *parser.IfStmt) error {
+	cond, err := c.compileExpr(s.Cond)
+	if err != nil {
+		return err
+	}
+	c.writeln("if (" + cond + ") {")
+	c.indent++
+	for _, st := range s.Then {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	if s.ElseIf != nil {
+		c.writeln("} else ")
+		return c.compileIf(s.ElseIf)
+	}
+	if len(s.Else) > 0 {
+		c.writeln("} else {")
+		c.indent++
+		for _, st := range s.Else {
+			if err := c.compileStmt(st); err != nil {
+				return err
+			}
+		}
+		c.indent--
+		c.writeln("}")
+	} else {
+		c.writeln("}")
+	}
+	return nil
+}
+
+// --- Expressions ---
+
+func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
+	if e == nil {
+		return "", nil
+	}
+	return c.compileBinary(e.Binary)
+}
+
+func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
+	if b == nil {
+		return "", nil
+	}
+	left, err := c.compileUnary(b.Left)
+	if err != nil {
+		return "", err
+	}
+	expr := left
+	for _, op := range b.Right {
+		right, err := c.compilePostfix(op.Right)
+		if err != nil {
+			return "", err
+		}
+		expr = fmt.Sprintf("(%s %s %s)", expr, op.Op, right)
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
+	if u == nil {
+		return "", nil
+	}
+	val, err := c.compilePostfix(u.Value)
+	if err != nil {
+		return "", err
+	}
+	for i := len(u.Ops) - 1; i >= 0; i-- {
+		val = fmt.Sprintf("%s%s", u.Ops[i], val)
+	}
+	return val, nil
+}
+
+func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
+	expr, err := c.compilePrimary(p.Target)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range p.Ops {
+		if op.Index != nil {
+			idx, err := c.compileExpr(op.Index.Start)
+			if err != nil {
+				return "", err
+			}
+			expr = fmt.Sprintf("%s[%s]", expr, idx)
+		} else if op.Call != nil {
+			call, err := c.compileCallOp(expr, op.Call)
+			if err != nil {
+				return "", err
+			}
+			expr = call
+		}
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compileCallOp(receiver string, call *parser.CallOp) (string, error) {
+	args := make([]string, len(call.Args))
+	for i, a := range call.Args {
+		v, err := c.compileExpr(a)
+		if err != nil {
+			return "", err
+		}
+		args[i] = v
+	}
+	return fmt.Sprintf("%s(%s)", receiver, strings.Join(args, ", ")), nil
+}
+
+func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
+	switch {
+	case p.Lit != nil:
+		return c.compileLiteral(p.Lit)
+	case p.Selector != nil:
+		name := "$" + sanitizeName(p.Selector.Root)
+		if len(p.Selector.Tail) > 0 {
+			name += "->" + strings.Join(p.Selector.Tail, "->")
+		}
+		return name, nil
+	case p.Call != nil:
+		return c.compileCallExpr(p.Call)
+	case p.List != nil:
+		elems := make([]string, len(p.List.Elems))
+		for i, e := range p.List.Elems {
+			v, err := c.compileExpr(e)
+			if err != nil {
+				return "", err
+			}
+			elems[i] = v
+		}
+		return "[" + strings.Join(elems, ", ") + "]", nil
+	case p.Group != nil:
+		inner, err := c.compileExpr(p.Group)
+		if err != nil {
+			return "", err
+		}
+		return "(" + inner + ")", nil
+	default:
+		return "", fmt.Errorf("unsupported expression")
+	}
+}
+
+func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
+	name := call.Func
+	args := make([]string, len(call.Args))
+	for i, a := range call.Args {
+		v, err := c.compileExpr(a)
+		if err != nil {
+			return "", err
+		}
+		args[i] = v
+	}
+	switch name {
+	case "print":
+		if len(args) != 1 {
+			return "", fmt.Errorf("print expects 1 arg")
+		}
+		return fmt.Sprintf("echo %s, PHP_EOL", args[0]), nil
+	case "len":
+		if len(args) != 1 {
+			return "", fmt.Errorf("len expects 1 arg")
+		}
+		return fmt.Sprintf("count(%s)", args[0]), nil
+	default:
+		return fmt.Sprintf("%s(%s)", name, strings.Join(args, ", ")), nil
+	}
+}
+
+func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
+	switch {
+	case l.Int != nil:
+		return strconv.Itoa(*l.Int), nil
+	case l.Float != nil:
+		return strconv.FormatFloat(*l.Float, 'f', -1, 64), nil
+	case l.Bool != nil:
+		if *l.Bool {
+			return "true", nil
+		}
+		return "false", nil
+	case l.Str != nil:
+		return strconv.Quote(*l.Str), nil
+	}
+	return "", fmt.Errorf("unknown literal")
+}

--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -1,0 +1,47 @@
+package phpcode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	phpcode "mochi/compile/php"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestPHPCompiler_LeetCodeExample1(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := phpcode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.php")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("php", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("php run error: %v\n%s", err, out)
+	}
+	got := strings.ReplaceAll(string(out), "\r\n", "\n")
+	if strings.TrimSpace(got) != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}

--- a/compile/php/helpers.go
+++ b/compile/php/helpers.go
@@ -1,0 +1,34 @@
+package phpcode
+
+import "strings"
+
+func (c *Compiler) writeln(s string) {
+	c.writeIndent()
+	c.buf.WriteString(s)
+	c.buf.WriteByte('\n')
+}
+
+func (c *Compiler) writeIndent() {
+	for i := 0; i < c.indent; i++ {
+		c.buf.WriteByte('\t')
+	}
+}
+
+func sanitizeName(name string) string {
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	for i, r := range name {
+		if r == '_' || ('0' <= r && r <= '9' && i > 0) || ('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z') {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	s := b.String()
+	if s == "" || !((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z') || s[0] == '_') {
+		s = "_" + s
+	}
+	return s
+}

--- a/compile/php/tools.go
+++ b/compile/php/tools.go
@@ -1,0 +1,27 @@
+package phpcode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// EnsurePHP ensures the php command is available, attempting installation if missing.
+func EnsurePHP() error {
+	if _, err := exec.LookPath("php"); err == nil {
+		return nil
+	}
+	if _, err := exec.LookPath("apt-get"); err == nil {
+		cmd := exec.Command("apt-get", "update")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		cmd = exec.Command("apt-get", "install", "-y", "php-cli")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+	return fmt.Errorf("php not installed")
+}


### PR DESCRIPTION
## Summary
- implement minimal PHP backend to compile Mochi programs
- add runtime helper and env detection for PHP
- include tests running LeetCode example 1

## Testing
- `go test ./compile/php -run TestPHPCompiler_LeetCodeExample1 -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685164b0d90083208850742c2dc6f991