### PR TITLE
Add full compile target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ mochi infer go fmt
 mochi cheatsheet
 ```
 
+### Build Targets
+
+`mochi build` can emit code for many languages. Use `--target` with one of:
+`c`, `cs`, `dart`, `ex` (Elixir), `erlang`, `go`, `jvm`, `kt` (Kotlin), `lua`,
+`py`, `rb`, `rust`, `swift`, `ts`, or `wasm`.
+
 ## Try It
 
 Send this to Claude or run it in your shell:

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -31,8 +31,19 @@ import (
 	python "mochi/runtime/ffi/python"
 
 	"mochi/ast"
+	"mochi/compile/c"
+	"mochi/compile/cs"
+	"mochi/compile/dart"
+	"mochi/compile/erlang"
+	"mochi/compile/ex"
 	"mochi/compile/go"
+	"mochi/compile/jvm"
+	"mochi/compile/kt"
+	"mochi/compile/lua"
 	"mochi/compile/py"
+	"mochi/compile/rb"
+	"mochi/compile/rust"
+	"mochi/compile/swift"
 	"mochi/compile/ts"
 	"mochi/compile/wasm"
 	"mochi/interpreter"
@@ -82,7 +93,7 @@ type TestCmd struct {
 type BuildCmd struct {
 	File          string `arg:"positional,required" help:"Path to .mochi source file"`
 	Out           string `arg:"-o" help:"Output file path"`
-	Target        string `arg:"--target" help:"Output language (go|py|ts|wasm)"`
+	Target        string `arg:"--target" help:"Output language (c|cs|dart|ex|erlang|go|jvm|kt|lua|py|rb|rust|swift|ts|wasm)"`
 	WasmToolchain string `arg:"--wasm-toolchain" help:"WASM toolchain (go|tinygo)"`
 }
 
@@ -500,6 +511,138 @@ func build(cmd *BuildCmd) error {
 		data, err := wasm.New(env, wasm.WithToolchain(tc)).Compile(prog)
 		if err == nil {
 			err = os.WriteFile(out, data, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "c":
+		if out == "" {
+			out = base + ".c"
+		}
+		code, err := ccode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "cs", "csharp":
+		if out == "" {
+			out = base + ".cs"
+		}
+		code, err := cscode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "dart":
+		if out == "" {
+			out = base + ".dart"
+		}
+		code, err := dartcode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "ex", "elixir":
+		if out == "" {
+			out = base + ".exs"
+		}
+		code, err := excode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "erlang", "erl":
+		if out == "" {
+			out = base + ".erl"
+		}
+		code, err := erlcode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "jvm":
+		if out == "" {
+			out = base + ".jar"
+		}
+		data, err := jvm.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, data, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "kt", "kotlin":
+		if out == "" {
+			out = base + ".kt"
+		}
+		code, err := ktcode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "lua":
+		if out == "" {
+			out = base + ".lua"
+		}
+		code, err := luacode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "rb", "ruby":
+		if out == "" {
+			out = base + ".rb"
+		}
+		code, err := rbcode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "rust", "rs":
+		if out == "" {
+			out = base + ".rs"
+		}
+		code, err := rscode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "swift":
+		if out == "" {
+			out = base + ".swift"
+		}
+		code, err := swiftcode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
 		}
 		if err != nil {
 			status = "error"

--- a/compile/Readme.md
+++ b/compile/Readme.md
@@ -4,11 +4,21 @@ Mochi can translate programs to multiple targets. Each backend lives in `compile
 
 Current directories:
 
-- `go`  – native Go code generation
-- `py`  – Python source emitter
-- `ts`  – TypeScript/Deno output
-- `wasm` – WebAssembly using the Go backend
-- `swift` – minimal Swift output
+- `c`      – C source generation
+- `cs`     – C# source generation
+- `dart`   – Dart emitter
+- `ex`     – Elixir source output
+- `erlang` – Erlang escript output
+- `go`     – native Go code generation
+- `jvm`    – JVM jar via gomobile
+- `kt`     – Kotlin source output
+- `lua`    – Lua emitter
+- `py`     – Python source emitter
+- `rb`     – Ruby source emitter
+- `rust`   – Rust source output
+- `swift`  – minimal Swift output
+- `ts`     – TypeScript/Deno output
+- `wasm`   – WebAssembly using the Go backend
 
 This guide shows how to implement another backend.
 


### PR DESCRIPTION
## Summary
- expose all compiler backends as `--target` options
- document available build targets in README and compile backend guide

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68516689588c8320ad25496c36cb00bf