### PR TITLE
Add while/break/continue support to C# compiler

### DIFF
--- a/compile/cs/compiler.go
+++ b/compile/cs/compiler.go
@@ -126,6 +126,14 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		return c.compileFor(s.For)
 	case s.If != nil:
 		return c.compileIf(s.If)
+	case s.While != nil:
+		return c.compileWhile(s.While)
+	case s.Break != nil:
+		c.writeln("break;")
+		return nil
+	case s.Continue != nil:
+		c.writeln("continue;")
+		return nil
 	default:
 		// ignore other statements in minimal compiler
 	}
@@ -219,6 +227,23 @@ func (c *Compiler) compileIf(stmt *parser.IfStmt) error {
 		}
 		c.indent--
 	}
+	c.writeln("}")
+	return nil
+}
+
+func (c *Compiler) compileWhile(w *parser.WhileStmt) error {
+	cond, err := c.compileExpr(w.Cond)
+	if err != nil {
+		return err
+	}
+	c.writeln("while (" + cond + ") {")
+	c.indent++
+	for _, s := range w.Body {
+		if err := c.compileStmt(s); err != nil {
+			return err
+		}
+	}
+	c.indent--
 	c.writeln("}")
 	return nil
 }

--- a/tests/compiler/cs/break_continue.cs.out
+++ b/tests/compiler/cs/break_continue.cs.out
@@ -7,8 +7,10 @@ public class Program {
 		var numbers = new [] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 		foreach (var n in numbers) {
 			if (((n % 2) == 0)) {
+				continue;
 			}
 			if ((n > 7)) {
+				break;
 			}
 			Console.WriteLine("odd number:", n);
 		}

--- a/tests/compiler/cs/while_loop.cs.out
+++ b/tests/compiler/cs/while_loop.cs.out
@@ -5,5 +5,9 @@ using System.Collections.Generic;
 public class Program {
 	public static void Main() {
 		var i = 0;
+		while ((i < 3)) {
+			Console.WriteLine(i);
+			i = (i + 1);
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- handle `while`, `break` and `continue` statements in the C# backend
- update golden tests for these features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851677fa46483209e72603108bd31a3