### PR TITLE
Enhance Dart compiler with break/continue

### DIFF
--- a/compile/dart/compiler.go
+++ b/compile/dart/compiler.go
@@ -76,6 +76,12 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		return c.compileWhile(s.While)
 	case s.Assign != nil:
 		return c.compileAssign(s.Assign)
+	case s.Break != nil:
+		c.writeln("break;")
+		return nil
+	case s.Continue != nil:
+		c.writeln("continue;")
+		return nil
 	case s.Expr != nil:
 		expr, err := c.compileExpr(s.Expr.Expr)
 		if err != nil {
@@ -335,6 +341,18 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return "", err
 		}
 		return fmt.Sprintf("%s.length", arg), nil
+	}
+	// handle print with multiple arguments
+	if name == "print" && len(call.Args) > 1 {
+		parts := make([]string, len(call.Args))
+		for i, a := range call.Args {
+			v, err := c.compileExpr(a)
+			if err != nil {
+				return "", err
+			}
+			parts[i] = fmt.Sprintf("%s.toString()", v)
+		}
+		return fmt.Sprintf("print([%s].join(' '))", strings.Join(parts, ", ")), nil
 	}
 	args := make([]string, len(call.Args))
 	for i, a := range call.Args {

--- a/tests/compiler/dart/break_continue.dart.out
+++ b/tests/compiler/dart/break_continue.dart.out
@@ -1,0 +1,12 @@
+void main() {
+	var numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+	for (var n in numbers) {
+		if (((n % 2) == 0)) {
+			continue;
+		}
+		if ((n > 7)) {
+			break;
+		}
+		print(["odd number:".toString(), n.toString()].join(' '));
+	}
+}

--- a/tests/compiler/dart/break_continue.mochi
+++ b/tests/compiler/dart/break_continue.mochi
@@ -1,0 +1,11 @@
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+for n in numbers {
+  if n % 2 == 0 {
+    continue
+  }
+  if n > 7 {
+    break
+  }
+  print("odd number:", n)
+}

--- a/tests/compiler/dart/break_continue.out
+++ b/tests/compiler/dart/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7


### PR DESCRIPTION
## Summary
- add support for `break` and `continue` statements in Dart backend
- handle `print` with multiple arguments for Dart
- add new golden test for Dart compiler

## Testing
- `go test ./compile/dart -run TestDartCompiler_SubsetPrograms -v`
- `go test ./compile/dart -run TestDartCompiler_GoldenOutput -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68516795bd60832094449eeb2efba6fc