### PR TITLE
Add EnsureRuby helper

### DIFF
--- a/compile/rb/compiler_test.go
+++ b/compile/rb/compiler_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 func TestRBCompiler_TwoSum(t *testing.T) {
-	if _, err := exec.LookPath("ruby"); err != nil {
-		t.Skip("ruby not installed")
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
 	}
 	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)
@@ -49,8 +49,8 @@ func TestRBCompiler_TwoSum(t *testing.T) {
 }
 
 func TestRBCompiler_SubsetPrograms(t *testing.T) {
-	if _, err := exec.LookPath("ruby"); err != nil {
-		t.Skip("ruby not installed")
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/rb", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)

--- a/compile/rb/tools.go
+++ b/compile/rb/tools.go
@@ -1,0 +1,46 @@
+package rbcode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// EnsureRuby verifies that the Ruby interpreter is installed. If missing,
+// it attempts a best-effort installation using Homebrew on macOS or apt-get on Linux.
+func EnsureRuby() error {
+	if _, err := exec.LookPath("ruby"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "ruby")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				break
+			}
+		}
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "ruby-full")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				break
+			}
+		}
+	}
+	if _, err := exec.LookPath("ruby"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("ruby not installed")
+}


### PR DESCRIPTION
## Summary
- provide EnsureRuby utility to auto-install Ruby if missing
- use EnsureRuby in rb compiler tests

## Testing
- `go test ./compile/rb -run TestRBCompiler -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6851744d75288320916ba91340d770c8