### PR TITLE
Disable wasm interpreter test

### DIFF
--- a/tools/wasm/wasm_test.go
+++ b/tools/wasm/wasm_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- mark TestWasmInterpreter as slow so it's skipped by default

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68517c6163c4832095fb994afa1269f2