### PR TITLE
Mark Go and Kotlin compiler tests as slow

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gocode_test
 
 import (

--- a/compile/kt/compiler_test.go
+++ b/compile/kt/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ktcode_test
 
 import (


### PR DESCRIPTION
## Summary
- mark Go compiler tests with the `slow` build tag
- mark Kotlin compiler tests with the `slow` build tag

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68517d5ca93483209e733bfe536d884c