### PR TITLE
Add basic query support to Erlang compiler

### DIFF
--- a/tests/compiler/erl_simple/dataset.erl.out
+++ b/tests/compiler/erl_simple/dataset.erl.out
@@ -1,0 +1,28 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1]).
+
+main(_) ->
+	ok,
+	people = [#{name => "Alice", age => 30}, #{name => "Bob", age => 15}, #{name => "Charlie", age => 65}],
+	names = [maps:get(name, p) || p <- people, (maps:get(age, p) >= 18)],
+	lists:foreach(fun(n) ->
+		mochi_print([n])
+	end, names).
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_while(Cond, Body) ->
+	case Cond() of
+		true ->
+			Body(),
+			mochi_while(Cond, Body);
+		_ -> ok
+	end.

--- a/tests/compiler/erl_simple/dataset.mochi
+++ b/tests/compiler/erl_simple/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/erl_simple/dataset.out
+++ b/tests/compiler/erl_simple/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie


### PR DESCRIPTION
## Summary
- support simple query expressions in the Erlang compiler
- add new dataset golden test for Erlang compiler

## Testing
- `go test -tags slow ./compile/erlang -run TestErlangCompiler_GoldenOutput -v`
- `go test -tags slow ./compile/erlang -run TestErlangCompiler_SubsetPrograms -v`

------
https://chatgpt.com/codex/tasks/task_e_68517fb56340832092c7618246c4767f