### PR TITLE
Add changelog and release notes for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # 📦 CHANGELOG.md
+## [0.8.0] – 2025-06-19
+
+### Added
+
+* Experimental compiler backends for C, C#, Dart, Erlang, F#, Haskell, Java, Lua, PHP, Ruby, Scala, Swift and Rust
+* Support for variable assignment, while loops, break and continue across the new backends
+* Builtin functions `str`, `input`, `avg` and `count`
+* Map and string iteration in Dart, Java and Rust
+* Basic query operations in Kotlin and Erlang
+* Litebase storage client for the runtime
+* Golden tests for the new compilers
+* LeetCode 402 example
+
+### Changed
+
+* Heavy compiler tests are skipped by default
+* Documentation lists all compile targets
+
+### Fixed
+
+* Kotlin golden tests and F# indentation issues
+
+
 ## [0.7.6] – 2025-06-18
 
 ### Added

--- a/releases/v0.8.0.md
+++ b/releases/v0.8.0.md
@@ -1,0 +1,25 @@
+# Jun 2025 (v0.8.0)
+
+Mochi v0.8.0 introduces many experimental compiler backends and runtime improvements.
+
+## Compilers
+
+- New backends for C, C#, Dart, Erlang, F#, Haskell, Java, Lua, PHP, Ruby, Scala, Swift and Rust
+- Variable assignment, while loops and break/continue across the new backends
+- Builtin functions `str`, `input`, `avg` and `count`
+- Map and string iteration support
+- Query operations added to Kotlin and Erlang
+- Golden tests cover all new compilers
+
+## Runtime
+
+- Litebase storage client for persistent data
+
+## Example Library
+
+- Added solution for LeetCode 402
+
+## Build System
+
+- Heavy compiler tests are skipped by default
+- Documentation lists all supported targets


### PR DESCRIPTION
## Summary
- document new features for v0.8.0 in CHANGELOG
- add detailed release notes under `releases/v0.8.0.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68518395ce108320bd9385c94e53edf4