### PR TITLE
Add basic query support to Ruby compiler

### DIFF
--- a/tests/compiler/rb/dataset.mochi
+++ b/tests/compiler/rb/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/rb/dataset.out
+++ b/tests/compiler/rb/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/rb/dataset_sort_take_limit.mochi
+++ b/tests/compiler/rb/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/rb/dataset_sort_take_limit.out
+++ b/tests/compiler/rb/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- implement simple query expressions and struct handling in Ruby backend
- generate Ruby `Struct` types for type declarations
- add dataset tests for Ruby compiler

## Testing
- `go test -tags slow ./compile/rb -run TestRBCompiler_SubsetPrograms -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685187bbecf88320ab7871e31c5bf2f7