### PR TITLE
Update release docs for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 * Experimental compiler backends for C, C#, Dart, Erlang, F#, Haskell, Java, Lua, PHP, Ruby, Scala, Swift and Rust
 * Support for variable assignment, while loops, break and continue across the new backends
 * Builtin functions `str`, `input`, `avg` and `count`
-* Map and string iteration in Dart, Java and Rust
-* Basic query operations in Kotlin and Erlang
+* Map and string iteration in C, Dart, Java and Rust
+* Basic query operations in Kotlin and Erlang with dataset queries in C# and Ruby
+* Struct support in Ruby, nested functions in Lua and parameter mutation in Swift
+* Membership checks in Elixir and PHP loops
 * Litebase storage client for the runtime
 * Golden tests for the new compilers
 * LeetCode 402 example

--- a/releases/v0.8.0.md
+++ b/releases/v0.8.0.md
@@ -7,8 +7,10 @@ Mochi v0.8.0 introduces many experimental compiler backends and runtime improvem
 - New backends for C, C#, Dart, Erlang, F#, Haskell, Java, Lua, PHP, Ruby, Scala, Swift and Rust
 - Variable assignment, while loops and break/continue across the new backends
 - Builtin functions `str`, `input`, `avg` and `count`
-- Map and string iteration support
-- Query operations added to Kotlin and Erlang
+- Map and string iteration in C, Dart, Java and Rust
+- Dataset queries available in C#, Kotlin, Erlang and Ruby
+- Structs in Ruby, nested functions in Lua and parameter mutation in Swift
+- Membership checks in Elixir and PHP loops
 - Golden tests cover all new compilers
 
 ## Runtime


### PR DESCRIPTION
## Summary
- expand CHANGELOG entry for v0.8.0
- update release notes with details on added features

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_68518bcdf9e08320b6947a2bba0c8813