### PR TITLE
Update Erlang golden test runner

### DIFF
--- a/compile/erlang/compiler_test.go
+++ b/compile/erlang/compiler_test.go
@@ -92,7 +92,7 @@ func TestErlangCompiler_SubsetPrograms(t *testing.T) {
 }
 
 func TestErlangCompiler_GoldenOutput(t *testing.T) {
-	golden.Run(t, "tests/compiler/erl_simple", ".mochi", ".erl.out", func(src string) ([]byte, error) {
+	run := func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
 			return nil, fmt.Errorf("❌ parse error: %w", err)
@@ -107,5 +107,7 @@ func TestErlangCompiler_GoldenOutput(t *testing.T) {
 			return nil, fmt.Errorf("❌ compile error: %w", err)
 		}
 		return bytes.TrimSpace(code), nil
-	})
+	}
+
+	golden.Run(t, "tests/compiler/erl_simple", ".mochi", ".erl.out", run)
 }


### PR DESCRIPTION
## Summary
- refactor Erlang compiler golden test to reuse a runner function

## Testing
- `go test ./... -run '' -tags slow` *(fails: TestDartCompiler_SubsetPrograms, TestExCompiler_GoldenOutput)*

------
https://chatgpt.com/codex/tasks/task_e_685190ae95c883209f1e1c81b9929775