### PR TITLE
Add Haskell golden output files

### DIFF
--- a/compile/hs/compiler_test.go
+++ b/compile/hs/compiler_test.go
@@ -87,3 +87,21 @@ func TestHSCompiler_GoldenSubset(t *testing.T) {
 		return res, nil
 	})
 }
+
+func TestHSCompiler_GoldenOutput(t *testing.T) {
+	golden.Run(t, "tests/compiler/hs", ".mochi", ".hs.out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("\u274c parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("\u274c type error: %v", errs[0])
+		}
+		code, err := hscode.New(env).Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("\u274c compile error: %w", err)
+		}
+		return bytes.TrimSpace(code), nil
+	})
+}

--- a/tests/compiler/hs/count_builtin.hs.out
+++ b/tests/compiler/hs/count_builtin.hs.out
@@ -1,0 +1,18 @@
+module Main where
+
+import Data.Maybe (fromMaybe)
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+
+main :: IO ()
+main = do
+    print (length [1, 2, 3])

--- a/tests/compiler/hs/fun_call.hs.out
+++ b/tests/compiler/hs/fun_call.hs.out
@@ -1,0 +1,21 @@
+module Main where
+
+import Data.Maybe (fromMaybe)
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+
+add a b = fromMaybe ((a + b)) $
+    Nothing
+
+main :: IO ()
+main = do
+    print (add 2 3)

--- a/tests/compiler/hs/grouped_expr.hs.out
+++ b/tests/compiler/hs/grouped_expr.hs.out
@@ -1,0 +1,19 @@
+module Main where
+
+import Data.Maybe (fromMaybe)
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+
+main :: IO ()
+main = do
+    let value = (((1 + 2)) * 3)
+    print value

--- a/tests/compiler/hs/len_builtin.hs.out
+++ b/tests/compiler/hs/len_builtin.hs.out
@@ -1,0 +1,18 @@
+module Main where
+
+import Data.Maybe (fromMaybe)
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+
+main :: IO ()
+main = do
+    print (length [1, 2, 3])

--- a/tests/compiler/hs/list_for_loop.hs.out
+++ b/tests/compiler/hs/list_for_loop.hs.out
@@ -1,0 +1,19 @@
+module Main where
+
+import Data.Maybe (fromMaybe)
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+
+main :: IO ()
+main = do
+    let names = ["Alice", "Bob"]
+    mapM_ (\n -> putStrLn (show n)) names

--- a/tests/compiler/hs/str_builtin.hs.out
+++ b/tests/compiler/hs/str_builtin.hs.out
@@ -1,0 +1,18 @@
+module Main where
+
+import Data.Maybe (fromMaybe)
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+
+main :: IO ()
+main = do
+    putStrLn (show 123)


### PR DESCRIPTION
## Summary
- generate `.hs.out` files for Haskell compiler tests
- verify Haskell code generation with a new golden test

## Testing
- `go test ./compile/hs -tags slow -run TestHSCompiler_GoldenOutput -update`
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_685190ce4dcc83209ac2c974baf7183c