### PR TITLE
Add Swift compiler golden outputs

### DIFF
--- a/tests/compiler/valid/break_continue.swift.out
+++ b/tests/compiler/valid/break_continue.swift.out
@@ -1,0 +1,15 @@
+import Foundation
+
+func main() {
+	let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+	for n in numbers {
+		if n % 2 == 0 {
+			continue
+		}
+		if n > 7 {
+			break
+		}
+		print("odd number:", n)
+	}
+}
+main()

--- a/tests/compiler/valid/fold_pure_let.swift.out
+++ b/tests/compiler/valid/fold_pure_let.swift.out
@@ -1,0 +1,14 @@
+import Foundation
+
+func sum(_ n: Int) -> Int {
+	var n = n
+	
+	return n * (n + 1) / 2
+}
+
+func main() {
+	let n = 10
+	print(sum(n))
+	print(n)
+}
+main()

--- a/tests/compiler/valid/for_list_collection.swift.out
+++ b/tests/compiler/valid/for_list_collection.swift.out
@@ -1,0 +1,8 @@
+import Foundation
+
+func main() {
+	for n in [1, 2, 3] {
+		print(n)
+	}
+}
+main()

--- a/tests/compiler/valid/for_loop.swift.out
+++ b/tests/compiler/valid/for_loop.swift.out
@@ -1,0 +1,8 @@
+import Foundation
+
+func main() {
+	for i in 1..<4 {
+		print(i)
+	}
+}
+main()

--- a/tests/compiler/valid/for_string_collection.swift.out
+++ b/tests/compiler/valid/for_string_collection.swift.out
@@ -1,0 +1,8 @@
+import Foundation
+
+func main() {
+	for ch in "hi" {
+		print(ch)
+	}
+}
+main()

--- a/tests/compiler/valid/fun_call.swift.out
+++ b/tests/compiler/valid/fun_call.swift.out
@@ -1,0 +1,13 @@
+import Foundation
+
+func add(_ a: Int, _ b: Int) -> Int {
+	var a = a
+	var b = b
+	
+	return a + b
+}
+
+func main() {
+	print(add(2, 3))
+}
+main()

--- a/tests/compiler/valid/grouped_expr.swift.out
+++ b/tests/compiler/valid/grouped_expr.swift.out
@@ -1,0 +1,7 @@
+import Foundation
+
+func main() {
+	let value = (1 + 2) * 3
+	print(value)
+}
+main()

--- a/tests/compiler/valid/if_else.swift.out
+++ b/tests/compiler/valid/if_else.swift.out
@@ -1,0 +1,11 @@
+import Foundation
+
+func main() {
+	let x = 5
+	if x > 3 {
+		print("big")
+	} else {
+		print("small")
+	}
+}
+main()

--- a/tests/compiler/valid/len_builtin.swift.out
+++ b/tests/compiler/valid/len_builtin.swift.out
@@ -1,0 +1,6 @@
+import Foundation
+
+func main() {
+	print([1, 2, 3].count)
+}
+main()

--- a/tests/compiler/valid/let_and_print.swift.out
+++ b/tests/compiler/valid/let_and_print.swift.out
@@ -1,0 +1,8 @@
+import Foundation
+
+func main() {
+	let a = 10
+	let b: Int = 20
+	print(a + b)
+}
+main()

--- a/tests/compiler/valid/list_index.swift.out
+++ b/tests/compiler/valid/list_index.swift.out
@@ -1,0 +1,7 @@
+import Foundation
+
+func main() {
+	let xs = [10, 20, 30]
+	print(xs[1])
+}
+main()

--- a/tests/compiler/valid/list_set.swift.out
+++ b/tests/compiler/valid/list_set.swift.out
@@ -1,0 +1,8 @@
+import Foundation
+
+func main() {
+	var nums = [1, 2]
+	nums[1] = 3
+	print(nums[1])
+}
+main()

--- a/tests/compiler/valid/print_hello.swift.out
+++ b/tests/compiler/valid/print_hello.swift.out
@@ -1,0 +1,6 @@
+import Foundation
+
+func main() {
+	print("hello")
+}
+main()

--- a/tests/compiler/valid/stream_on_emit.swift.out
+++ b/tests/compiler/valid/stream_on_emit.swift.out
@@ -1,0 +1,5 @@
+import Foundation
+
+func main() {
+}
+main()

--- a/tests/compiler/valid/string_index.swift.out
+++ b/tests/compiler/valid/string_index.swift.out
@@ -1,0 +1,7 @@
+import Foundation
+
+func main() {
+	let text = "hello"
+	print(text[1])
+}
+main()

--- a/tests/compiler/valid/test_block.swift.out
+++ b/tests/compiler/valid/test_block.swift.out
@@ -1,0 +1,6 @@
+import Foundation
+
+func main() {
+	print("ok")
+}
+main()

--- a/tests/compiler/valid/two_sum.swift.out
+++ b/tests/compiler/valid/two_sum.swift.out
@@ -1,0 +1,23 @@
+import Foundation
+
+func twoSum(_ nums: [Int], _ target: Int) -> [Int] {
+	var nums = nums
+	var target = target
+	
+	let n = nums.count
+	for i in 0..<n {
+		for j in i + 1..<n {
+			if nums[i] + nums[j] == target {
+				return [i, j]
+			}
+		}
+	}
+	return [-1, -1]
+}
+
+func main() {
+	let result = twoSum([2, 7, 11, 15], 9)
+	print(result[0])
+	print(result[1])
+}
+main()

--- a/tests/compiler/valid/var_assignment.swift.out
+++ b/tests/compiler/valid/var_assignment.swift.out
@@ -1,0 +1,8 @@
+import Foundation
+
+func main() {
+	var x = 1
+	x = 2
+	print(x)
+}
+main()

--- a/tests/compiler/valid/while_loop.swift.out
+++ b/tests/compiler/valid/while_loop.swift.out
@@ -1,0 +1,10 @@
+import Foundation
+
+func main() {
+	var i = 0
+	while i < 3 {
+		print(i)
+		i = i + 1
+	}
+}
+main()


### PR DESCRIPTION
## Summary
- add `.swift.out` files for many valid compiler tests

## Testing
- `go test ./compile/swift -tags=slow -run TestSwiftCompiler_GoldenOutput`
- `go test ./... -tags=slow` *(fails: TestDartCompiler_SubsetPrograms, TestExCompiler_GoldenOutput, TestScalaCompiler_SubsetPrograms, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685190e64bf88320bbdccc621a0d7c12