### PR TITLE
Add PHP compiler golden outputs

### DIFF
--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -56,10 +56,10 @@ func TestPHPCompiler_LeetCodeExample1(t *testing.T) {
 }
 
 func TestPHPCompiler_SubsetPrograms(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	golden.Run(t, "tests/compiler/php", ".mochi", ".out", func(src string) ([]byte, error) {
+        if err := phpcode.EnsurePHP(); err != nil {
+                t.Skipf("php not installed: %v", err)
+        }
+        golden.Run(t, "tests/compiler/php", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
 			return nil, fmt.Errorf("❌ parse error: %w", err)
@@ -86,7 +86,25 @@ func TestPHPCompiler_SubsetPrograms(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("❌ php run error: %w\n%s", err, out)
 		}
-		res := strings.ReplaceAll(string(out), "\r\n", "\n")
-		return []byte(strings.TrimSpace(res)), nil
-	})
+                res := strings.ReplaceAll(string(out), "\r\n", "\n")
+                return []byte(strings.TrimSpace(res)), nil
+        })
+}
+
+func TestPHPCompiler_GoldenOutput(t *testing.T) {
+        golden.Run(t, "tests/compiler/php", ".mochi", ".php.out", func(src string) ([]byte, error) {
+                prog, err := parser.Parse(src)
+                if err != nil {
+                        return nil, fmt.Errorf("❌ parse error: %w", err)
+                }
+                env := types.NewEnv(nil)
+                if errs := types.Check(prog, env); len(errs) > 0 {
+                        return nil, fmt.Errorf("❌ type error: %v", errs[0])
+                }
+                code, err := phpcode.New(env).Compile(prog)
+                if err != nil {
+                        return nil, fmt.Errorf("❌ compile error: %w", err)
+                }
+                return bytes.TrimSpace(code), nil
+        })
 }

--- a/tests/compiler/php/avg_builtin.php.out
+++ b/tests/compiler/php/avg_builtin.php.out
@@ -1,0 +1,2 @@
+<?php
+echo (count([1, 2, 3]) ? array_sum([1, 2, 3]) / count([1, 2, 3]) : 0), PHP_EOL;

--- a/tests/compiler/php/break_continue.php.out
+++ b/tests/compiler/php/break_continue.php.out
@@ -1,0 +1,11 @@
+<?php
+$numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+foreach ((is_string($numbers) ? str_split($numbers) : $numbers) as $n) {
+	if ((($n % 2) == 0)) {
+		continue;
+	}
+	if (($n > 7)) {
+		break;
+	}
+	echo "odd number:" . " " . $n, PHP_EOL;
+}

--- a/tests/compiler/php/count_builtin.php.out
+++ b/tests/compiler/php/count_builtin.php.out
@@ -1,0 +1,2 @@
+<?php
+echo (is_array([1, 2, 3]) ? count([1, 2, 3]) : strlen([1, 2, 3])), PHP_EOL;

--- a/tests/compiler/php/fold_pure_let.php.out
+++ b/tests/compiler/php/fold_pure_let.php.out
@@ -1,0 +1,8 @@
+<?php
+function sum($n) {
+	return (($n * (($n + 1))) / 2);
+}
+
+$n = 10;
+echo sum($n), PHP_EOL;
+echo $n, PHP_EOL;

--- a/tests/compiler/php/for_list_collection.php.out
+++ b/tests/compiler/php/for_list_collection.php.out
@@ -1,0 +1,4 @@
+<?php
+foreach ((is_string([1, 2, 3]) ? str_split([1, 2, 3]) : [1, 2, 3]) as $n) {
+	echo $n, PHP_EOL;
+}

--- a/tests/compiler/php/for_loop.php.out
+++ b/tests/compiler/php/for_loop.php.out
@@ -1,0 +1,4 @@
+<?php
+for ($i = 1; $i < 4; $i++) {
+	echo $i, PHP_EOL;
+}

--- a/tests/compiler/php/for_string_collection.php.out
+++ b/tests/compiler/php/for_string_collection.php.out
@@ -1,0 +1,4 @@
+<?php
+foreach ((is_string("hi") ? str_split("hi") : "hi") as $ch) {
+	echo $ch, PHP_EOL;
+}

--- a/tests/compiler/php/fun_call.php.out
+++ b/tests/compiler/php/fun_call.php.out
@@ -1,0 +1,6 @@
+<?php
+function add($a, $b) {
+	return ($a + $b);
+}
+
+echo add(2, 3), PHP_EOL;

--- a/tests/compiler/php/input_builtin.php.out
+++ b/tests/compiler/php/input_builtin.php.out
@@ -1,0 +1,6 @@
+<?php
+echo "Enter first input:", PHP_EOL;
+$input1 = trim(fgets(STDIN));
+echo "Enter second input:", PHP_EOL;
+$input2 = trim(fgets(STDIN));
+echo "You entered:" . " " . $input1 . " " . "," . " " . $input2, PHP_EOL;

--- a/tests/compiler/php/matrix_search.php.out
+++ b/tests/compiler/php/matrix_search.php.out
@@ -1,0 +1,24 @@
+<?php
+function searchMatrix($matrix, $target) {
+	$m = count($matrix);
+	if (($m == 0)) {
+		return false;
+	}
+	$n = count($matrix[0]);
+	while (($left <= $right)) {
+		$mid = (($left + (($right - $left))) / 2);
+		$row = ($mid / $n);
+		$col = ($mid % $n);
+		$value = $matrix[$row][$col];
+		if (($value == $target)) {
+			return true;
+		} else 
+		if (($value < $target)) {
+		} else {
+		}
+	}
+	return false;
+}
+
+echo searchMatrix([[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], 3), PHP_EOL;
+echo searchMatrix([[1, 3, 5, 7], [10, 11, 16, 20], [23, 30, 34, 60]], 13), PHP_EOL;

--- a/tests/compiler/php/str_builtin.php.out
+++ b/tests/compiler/php/str_builtin.php.out
@@ -1,0 +1,2 @@
+<?php
+echo strval(123), PHP_EOL;

--- a/tests/compiler/php/while_membership.php.out
+++ b/tests/compiler/php/while_membership.php.out
@@ -1,0 +1,6 @@
+<?php
+foreach ((is_string([1, 2, 3]) ? str_split([1, 2, 3]) : [1, 2, 3]) as $n) {
+}
+while ((is_array($set) ? (array_key_exists($i, $set) || in_array($i, $set, true)) : (is_string($set) ? strpos($set, strval($i)) !== false : false))) {
+}
+echo $count, PHP_EOL;


### PR DESCRIPTION
## Summary
- add `TestPHPCompiler_GoldenOutput` test
- add generated `*.php.out` files for PHP compiler tests

## Testing
- `go test ./compile/php -tags slow -run TestPHPCompiler_GoldenOutput -count=1`
- `go test ./... -tags slow -run TestPHPCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6851910857088320afe2d082ba3deb42