### PR TITLE
Add union type and match support in Ruby compiler

### DIFF
--- a/compile/rb/helpers.go
+++ b/compile/rb/helpers.go
@@ -1,6 +1,10 @@
 package rbcode
 
-import "strings"
+import (
+	"strings"
+
+	"mochi/parser"
+)
 
 func (c *Compiler) writeln(s string) {
 	c.writeIndent()
@@ -31,4 +35,64 @@ func sanitizeName(name string) string {
 		s = "_" + s
 	}
 	return s
+}
+
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	if p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0 {
+		return true
+	}
+	return false
+}
+
+func callPattern(e *parser.Expr) (*parser.CallExpr, bool) {
+	if e == nil {
+		return nil, false
+	}
+	if len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.Call == nil {
+		return nil, false
+	}
+	return p.Target.Call, true
+}
+
+func identName(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
 }

--- a/tests/compiler/rb/union_match.mochi
+++ b/tests/compiler/rb/union_match.mochi
@@ -1,0 +1,13 @@
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+fun isLeaf(t: Tree): bool {
+  return match t {
+    Leaf => true
+    _ => false
+  }
+}
+
+print(isLeaf(Leaf {}))
+print(isLeaf(Node { left: Leaf {}, value: 1, right: Leaf {} }))

--- a/tests/compiler/rb/union_match.out
+++ b/tests/compiler/rb/union_match.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/compiler/rb/union_match.rb.out
+++ b/tests/compiler/rb/union_match.rb.out
@@ -1,0 +1,21 @@
+module Tree; end
+Leaf = Struct.new(keyword_init: true) do
+	include Tree
+end
+Node = Struct.new(:left, :value, :right, keyword_init: true) do
+	include Tree
+end
+
+def isLeaf(t)
+	return (begin
+	_t0 = t
+	if _t0.is_a?(Leaf)
+		true
+	else
+		false
+	end
+end)
+end
+
+puts([isLeaf(Leaf.new())].join(" "))
+puts([isLeaf(Node.new(left: Leaf.new(), value: 1, right: Leaf.new()))].join(" "))


### PR DESCRIPTION
## Summary
- support union types in Ruby compiler
- handle match expressions
- add helpers for pattern matching
- test union_match across Go and Ruby compilers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851a2116ea88320b1f2a5e7e22ccc17