### PR TITLE
Add dataset sort/take query support to Erlang compiler

### DIFF
--- a/tests/compiler/erl_simple/dataset_sort_take_limit.erl.out
+++ b/tests/compiler/erl_simple/dataset_sort_take_limit.erl.out
@@ -1,0 +1,57 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1]).
+
+main(_) ->
+        ok,
+        products = [#{name => "Laptop", price => 1500}, #{name => "Smartphone", price => 900}, #{name => "Tablet", price => 600}, #{name => "Monitor", price => 300}, #{name => "Keyboard", price => 100}, #{name => "Mouse", price => 50}, #{name => "Headphones", price => 200}],
+        expensive = (fun() ->
+                Items = [p || p <- products],
+                Pairs = [{-maps:get(price, p), p} || p <- Items],
+                SPairs = lists:sort(fun({A,_},{B,_}) -> A =< B end, Pairs),
+                Sorted = [ V || {_, V} <- SPairs ],
+                Skipped = (case 1 of
+                        N when N > 0 -> lists:nthtail(N, Sorted);
+                        _ -> Sorted
+                end),
+                Taken = lists:sublist(Skipped, 3),
+                [p || p <- Taken]
+        end)(),
+        mochi_print(["--- Top products (excluding most expensive) ---"]),
+        lists:foreach(fun(item) ->
+                mochi_print([maps:get(name, item), "costs $", maps:get(price, item)])
+        end, expensive).
+
+mochi_print(Args) ->
+        Strs = [ mochi_format(A) || A <- Args ],
+        io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+        Sum = lists:foldl(fun(X, Acc) ->
+                case X of
+                        I when is_integer(I) -> Acc + I;
+                        F when is_float(F) -> Acc + F;
+                        _ -> erlang:error(badarg) end
+                end, 0, L),
+                Sum / length(L)
+        .
+mochi_avg(_) -> erlang:error(badarg).
+
+mochi_while(Cond, Body) ->
+        case Cond() of
+                true ->
+                        Body(),
+                        mochi_while(Cond, Body);
+                _ -> ok
+        end.

--- a/tests/compiler/erl_simple/dataset_sort_take_limit.mochi
+++ b/tests/compiler/erl_simple/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/erl_simple/dataset_sort_take_limit.out
+++ b/tests/compiler/erl_simple/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- support `sort`, `skip`, and `take` clauses in Erlang compiler queries
- port `dataset_sort_take_limit` test from Go compiler to Erlang suite

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851a5a879248320a7c3a48038068967