### PR TITLE
Fix Kotlin tools to ensure Java runtime

### DIFF
--- a/compile/kt/tools.go
+++ b/compile/kt/tools.go
@@ -5,11 +5,18 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+
+	javacode "mochi/compile/java"
 )
 
 // EnsureKotlin verifies that the Kotlin compiler is installed. If missing,
 // it attempts a best-effort installation using Homebrew on macOS or apt-get on Linux.
 func EnsureKotlin() error {
+	if _, err := exec.LookPath("java"); err != nil {
+		if err := javacode.EnsureJavac(); err != nil {
+			return err
+		}
+	}
 	if _, err := exec.LookPath("kotlinc"); err == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- guarantee `java` runtime present when Kotlin tests run

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6851a7796a508320815b4e8ec093eed2