### PR TITLE
Add union match support in Lua compiler

### DIFF
--- a/compile/lua/helpers.go
+++ b/compile/lua/helpers.go
@@ -1,6 +1,10 @@
 package luacode
 
-import "strings"
+import (
+	"strings"
+
+	"mochi/parser"
+)
 
 func (c *Compiler) writeln(s string) {
 	c.writeIndent()
@@ -38,4 +42,64 @@ func sanitizeName(name string) string {
 		return "_" + res
 	}
 	return res
+}
+
+func callPattern(e *parser.Expr) (*parser.CallExpr, bool) {
+	if e == nil {
+		return nil, false
+	}
+	if len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.Call == nil {
+		return nil, false
+	}
+	return p.Target.Call, true
+}
+
+func identName(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
+}
+
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	if p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0 {
+		return true
+	}
+	return false
 }

--- a/tests/compiler/lua/union_match.lua.out
+++ b/tests/compiler/lua/union_match.lua.out
@@ -1,0 +1,10 @@
+function isLeaf(t)
+	return (function()
+	local _t0 = t
+	if _t0.__name == "Leaf" then return true end
+	return false
+end)()
+end
+
+print(isLeaf({__name="Leaf"}))
+print(isLeaf({__name="Node", left={__name="Leaf"}, value=1, right={__name="Leaf"}}))

--- a/tests/compiler/lua/union_match.mochi
+++ b/tests/compiler/lua/union_match.mochi
@@ -1,0 +1,13 @@
+type Tree =
+  Leaf
+  | Node(left: Tree, value: int, right: Tree)
+
+fun isLeaf(t: Tree): bool {
+  return match t {
+    Leaf => true
+    _ => false
+  }
+}
+
+print(isLeaf(Leaf {}))
+print(isLeaf(Node { left: Leaf {}, value: 1, right: Leaf {} }))

--- a/tests/compiler/lua/union_match.out
+++ b/tests/compiler/lua/union_match.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- handle typed struct literals in Lua compiler
- implement `match` expression for union types
- support pattern helper functions
- add `union_match` golden test for Lua compiler

## Testing
- `go test ./compile/lua -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_6851a5c534448320b481bd144b302a9c