### PR TITLE
Add Lua compiler precedence handling

### DIFF
--- a/tests/compiler/lua/matrix_search.lua.out
+++ b/tests/compiler/lua/matrix_search.lua.out
@@ -1,0 +1,34 @@
+function __div(a, b)
+	if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+		return a // b
+	end
+	return a / b
+end
+
+function searchMatrix(matrix, target)
+	local m = #matrix
+	if (m == 0) then
+		return false
+	end
+	local n = #matrix[(0)+1]
+	local left = 0
+	local right = ((m * n) - 1)
+	while (left <= right) do
+		local mid = (left + __div(((right - left)), 2))
+		local row = __div(mid, n)
+		local col = (mid % n)
+		local value = matrix[(row)+1][(col)+1]
+		if (value == target) then
+			return true
+		elseif (value < target) then
+			left = (mid + 1)
+		else
+			right = (mid - 1)
+		end
+		::__continue0::
+	end
+	return false
+end
+
+print(searchMatrix({{1, 3, 5, 7}, {10, 11, 16, 20}, {23, 30, 34, 60}}, 3))
+print(searchMatrix({{1, 3, 5, 7}, {10, 11, 16, 20}, {23, 30, 34, 60}}, 13))

--- a/tests/compiler/lua/matrix_search.mochi
+++ b/tests/compiler/lua/matrix_search.mochi
@@ -1,0 +1,26 @@
+fun searchMatrix(matrix: list<list<int>>, target: int): bool {
+  let m = len(matrix)
+  if m == 0 {
+    return false
+  }
+  let n = len(matrix[0])
+  var left = 0
+  var right = m * n - 1
+  while left <= right {
+    let mid = left + (right - left) / 2
+    let row = mid / n
+    let col = mid % n
+    let value = matrix[row][col]
+    if value == target {
+      return true
+    } else if value < target {
+      left = mid + 1
+    } else {
+      right = mid - 1
+    }
+  }
+  return false
+}
+
+print(searchMatrix([[1,3,5,7],[10,11,16,20],[23,30,34,60]], 3))
+print(searchMatrix([[1,3,5,7],[10,11,16,20],[23,30,34,60]], 13))

--- a/tests/compiler/lua/matrix_search.out
+++ b/tests/compiler/lua/matrix_search.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- implement operator precedence for the Lua compiler
- add runtime-aware integer division helper
- cover new `matrix_search` case from Go tests

## Testing
- `go test ./compile/lua -tags slow -run TestLuaCompiler_GoldenOutput -count=1`
- `go test ./compile/lua -tags slow -run TestLuaCompiler_SubsetPrograms -count=1` *(fails: lua run error)*
- `go test ./... -tags slow -count=1` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6851a20de89c832098525fb49567b888