### PR TITLE
Ensure Kotlin tests install java

### DIFF
--- a/compile/java/tools.go
+++ b/compile/java/tools.go
@@ -44,3 +44,22 @@ func EnsureJavac() error {
 	}
 	return fmt.Errorf("javac not found")
 }
+
+// EnsureJava verifies that the Java runtime can actually execute. Some
+// systems, notably macOS, may provide a placeholder `java` binary that exits
+// with an error if no JRE is installed. This function attempts to run
+// `java -version` and falls back to EnsureJavac if it fails. It returns an
+// error if the runtime remains unavailable.
+func EnsureJava() error {
+	cmd := exec.Command("java", "-version")
+	if err := cmd.Run(); err == nil {
+		return nil
+	}
+	if err := EnsureJavac(); err != nil {
+		return err
+	}
+	if err := exec.Command("java", "-version").Run(); err != nil {
+		return fmt.Errorf("java runtime not found")
+	}
+	return nil
+}

--- a/compile/kt/tools.go
+++ b/compile/kt/tools.go
@@ -12,10 +12,12 @@ import (
 // EnsureKotlin verifies that the Kotlin compiler is installed. If missing,
 // it attempts a best-effort installation using Homebrew on macOS or apt-get on Linux.
 func EnsureKotlin() error {
-	if _, err := exec.LookPath("java"); err != nil {
-		if err := javacode.EnsureJavac(); err != nil {
-			return err
-		}
+	// Ensure the Java runtime is available since Kotlin relies on it for
+	// execution. On macOS the `java` binary may exist but fail to run if a
+	// JRE is not installed, so we use javacode.EnsureJava which performs a
+	// sanity check and installs a JDK if needed.
+	if err := javacode.EnsureJava(); err != nil {
+		return err
 	}
 	if _, err := exec.LookPath("kotlinc"); err == nil {
 		return nil


### PR DESCRIPTION
## Summary
- extend Kotlin tool installation to verify Java runtime is usable
- add `EnsureJava` helper for running `java -version`

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851aa2ec19c8320a043edd482d9ec75