### PR TITLE
Install java for Kotlin support

### DIFF
--- a/compile/kt/tools.go
+++ b/compile/kt/tools.go
@@ -13,6 +13,27 @@ import (
 // it attempts a best-effort installation using Homebrew on macOS or apt-get on Linux.
 func EnsureKotlin() error {
 	if _, err := exec.LookPath("java"); err != nil {
+		switch runtime.GOOS {
+		case "darwin":
+			if _, err := exec.LookPath("brew"); err == nil {
+				cmd := exec.Command("brew", "install", "openjdk")
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				_ = cmd.Run()
+			}
+		case "linux":
+			if _, err := exec.LookPath("apt-get"); err == nil {
+				cmd := exec.Command("apt-get", "update")
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err == nil {
+					cmd = exec.Command("apt-get", "install", "-y", "openjdk-17-jdk")
+					cmd.Stdout = os.Stdout
+					cmd.Stderr = os.Stderr
+					_ = cmd.Run()
+				}
+			}
+		}
 		if err := javacode.EnsureJavac(); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- ensure `java` is installed on macOS using `brew`
- ensure `java` is installed on Linux using `apt-get`

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_6851ab4478a4832099eacaddd44ac0aa