### PR TITLE
Fix scala test runner detection

### DIFF
--- a/compile/scala/compiler_test.go
+++ b/compile/scala/compiler_test.go
@@ -47,6 +47,8 @@ func TestScalaCompiler_SubsetPrograms(t *testing.T) {
 		if _, err := exec.LookPath("scala-cli"); err == nil {
 			scalaCmd = "scala-cli"
 			args = []string{"run", file}
+		} else if out, err := exec.Command("scala", "-version").CombinedOutput(); err == nil && bytes.Contains(out, []byte("Scala CLI")) {
+			args = []string{"run", file}
 		}
 		out, err := exec.Command(scalaCmd, args...).CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
## Summary
- adjust Scala runtime command detection in tests

## Testing
- `go test ./compile/scala -tags slow -run TestScalaCompiler_SubsetPrograms -c`

------
https://chatgpt.com/codex/tasks/task_e_6851aa88d194832086eeb91c1aacd8b4