### PR TITLE
Add dataset queries to Lua compiler

### DIFF
--- a/tests/compiler/lua/dataset.lua.out
+++ b/tests/compiler/lua/dataset.lua.out
@@ -1,0 +1,42 @@
+function __iter(obj)
+	if type(obj) == 'table' then
+		if obj[1] ~= nil or #obj > 0 then
+			local i = 0
+			local n = #obj
+			return function()
+				i = i + 1
+				if i <= n then return i, obj[i] end
+			end
+		else
+			return pairs(obj)
+		end
+	elseif type(obj) == 'string' then
+		local i = 0
+		local n = #obj
+		return function()
+			i = i + 1
+			if i <= n then return i, string.sub(obj, i, i) end
+		end
+	else
+		return function() return nil end
+	end
+end
+
+local people = {{name="Alice", age=30}, {name="Bob", age=15}, {name="Charlie", age=65}}
+local names = (function()
+	local items = {}
+	for _, p in ipairs(people) do
+		if (p.age >= 18) then
+			table.insert(items, p)
+		end
+	end
+	local _res = {}
+	for _, p in ipairs(items) do
+		table.insert(_res, p.name)
+	end
+	return _res
+end)()
+for _, n in __iter(names) do
+	print(n)
+	::__continue0::
+end

--- a/tests/compiler/lua/dataset.mochi
+++ b/tests/compiler/lua/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/lua/dataset.out
+++ b/tests/compiler/lua/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/lua/dataset_sort_take_limit.lua.out
+++ b/tests/compiler/lua/dataset_sort_take_limit.lua.out
@@ -1,0 +1,56 @@
+function __iter(obj)
+	if type(obj) == 'table' then
+		if obj[1] ~= nil or #obj > 0 then
+			local i = 0
+			local n = #obj
+			return function()
+				i = i + 1
+				if i <= n then return i, obj[i] end
+			end
+		else
+			return pairs(obj)
+		end
+	elseif type(obj) == 'string' then
+		local i = 0
+		local n = #obj
+		return function()
+			i = i + 1
+			if i <= n then return i, string.sub(obj, i, i) end
+		end
+	else
+		return function() return nil end
+	end
+end
+
+local products = {{name="Laptop", price=1500}, {name="Smartphone", price=900}, {name="Tablet", price=600}, {name="Monitor", price=300}, {name="Keyboard", price=100}, {name="Mouse", price=50}, {name="Headphones", price=200}}
+local expensive = (function()
+	local items = {}
+	for _, p in ipairs(products) do
+		table.insert(items, p)
+	end
+	table.sort(items, function(a, b)
+		local p = a
+		local _ka = -p.price
+		p = b
+		local _kb = -p.price
+		return (_ka) < (_kb)
+	end)
+	if 1 < #items then
+		items = {table.unpack(items, (1)+1)}
+	else
+		items = {}
+	end
+	if 3 < #items then
+		items = {table.unpack(items, 1, 3)}
+	end
+	local _res = {}
+	for _, p in ipairs(items) do
+		table.insert(_res, p)
+	end
+	return _res
+end)()
+print("--- Top products (excluding most expensive) ---")
+for _, item in __iter(expensive) do
+	print(item.name, "costs $", item.price)
+	::__continue0::
+end

--- a/tests/compiler/lua/dataset_sort_take_limit.mochi
+++ b/tests/compiler/lua/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/lua/dataset_sort_take_limit.out
+++ b/tests/compiler/lua/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- implement `compileQueryExpr` in the Lua compiler
- allow query expressions in primary expressions
- add dataset query tests for the Lua backend

## Testing
- `go test ./compile/lua -tags slow -run TestLuaCompiler_GoldenOutput -update`
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6851ae957c38832088ba3af734030bf8