### PR TITLE
Add simple query support to Lua compiler

### DIFF
--- a/tests/compiler/lua/dataset.lua.out
+++ b/tests/compiler/lua/dataset.lua.out
@@ -1,0 +1,38 @@
+function __iter(obj)
+	if type(obj) == 'table' then
+		if obj[1] ~= nil or #obj > 0 then
+			local i = 0
+			local n = #obj
+			return function()
+				i = i + 1
+				if i <= n then return i, obj[i] end
+			end
+		else
+			return pairs(obj)
+		end
+	elseif type(obj) == 'string' then
+		local i = 0
+		local n = #obj
+		return function()
+			i = i + 1
+			if i <= n then return i, string.sub(obj, i, i) end
+		end
+	else
+		return function() return nil end
+	end
+end
+
+local people = {{name="Alice", age=30}, {name="Bob", age=15}, {name="Charlie", age=65}}
+local names = (function()
+	local _res = {}
+	for _, p in __iter(people) do
+		if (p.age >= 18) then
+			table.insert(_res, p.name)
+		end
+	end
+	return _res
+end)()
+for _, n in __iter(names) do
+	print(n)
+	::__continue0::
+end

--- a/tests/compiler/lua/dataset.mochi
+++ b/tests/compiler/lua/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/lua/dataset.out
+++ b/tests/compiler/lua/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie


### PR DESCRIPTION
## Summary
- implement `compileQueryExpr` for the Lua backend
- support `QueryExpr` in primary expression compilation
- add dataset query test for Lua compiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851ae9f2ffc8320824f2d616a6bade2