### PR TITLE
Add dataset query support in rust compiler

### DIFF
--- a/tests/compiler/rust/dataset.mochi
+++ b/tests/compiler/rust/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/rust/dataset.out
+++ b/tests/compiler/rust/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/rust/dataset.rs.out
+++ b/tests/compiler/rust/dataset.rs.out
@@ -1,0 +1,21 @@
+#[derive(Clone, Debug)]
+struct Person {
+    name: String,
+    age: i32,
+}
+
+fn main() {
+    let mut people = vec![Person { name: "Alice".to_string(), age: 30 }, Person { name: "Bob".to_string(), age: 15 }, Person { name: "Charlie".to_string(), age: 65 }];
+    let mut names = {
+    let mut _res = Vec::new();
+    for p in people {
+        if p.age >= 18 {
+            _res.push(p.name);
+        }
+    }
+    _res
+};
+    for n in names {
+        println!("{}", n);
+    }
+}


### PR DESCRIPTION
## Summary
- extend Rust compiler to emit struct declarations and basic query loops
- wire type info so struct literals convert string fields
- add dataset golden test for Rust backend

## Testing
- `go test -tags slow ./compile/rust -run TestRustCompiler_GoldenOutput/dataset -update`
- `go test -tags slow ./compile/rust -run TestRustCompiler_SubsetPrograms/dataset`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851b9a3b35083209cee342ad4d4f0bb