### PR TITLE
Add Zig compiler wrapper

### DIFF
--- a/compile/zig/compiler.go
+++ b/compile/zig/compiler.go
@@ -1,0 +1,48 @@
+package zigcode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	ccode "mochi/compile/c"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler uses the C backend and zig cc to build a native binary.
+type Compiler struct {
+	env *types.Env
+}
+
+// New creates a new zig compiler instance.
+func New(env *types.Env) *Compiler { return &Compiler{env: env} }
+
+// Compile returns a native binary that executes prog using zig cc.
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	zig, err := EnsureZig()
+	if err != nil {
+		return nil, err
+	}
+	csrc, err := ccode.New(c.env).Compile(prog)
+	if err != nil {
+		return nil, err
+	}
+	dir, err := os.MkdirTemp("", "mochi-zig-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	cfile := filepath.Join(dir, "prog.c")
+	if err := os.WriteFile(cfile, csrc, 0644); err != nil {
+		return nil, err
+	}
+	bin := filepath.Join(dir, "prog")
+	cmd := exec.Command(zig, "cc", cfile, "-O3", "-o", bin)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("zig cc error: %w\n%s", err, out)
+	}
+	return os.ReadFile(bin)
+}

--- a/compile/zig/compiler_test.go
+++ b/compile/zig/compiler_test.go
@@ -1,0 +1,51 @@
+//go:build slow
+
+package zigcode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	zigcode "mochi/compile/zig"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestZigCompiler_TwoSum compiles the LeetCode example using zig cc and runs it.
+func TestZigCompiler_TwoSum(t *testing.T) {
+	zig, err := zigcode.EnsureZig()
+	if err != nil {
+		t.Skipf("zig not installed: %v", err)
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	binBytes, err := zigcode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "prog")
+	if err := os.WriteFile(bin, binBytes, 0755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	cmd := exec.Command(bin)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run error: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+	_ = zig // avoid unused variable if build tags skip test
+}

--- a/compile/zig/tools.go
+++ b/compile/zig/tools.go
@@ -1,0 +1,14 @@
+package zigcode
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// EnsureZig verifies that the Zig compiler is installed.
+func EnsureZig() (string, error) {
+	if path, err := exec.LookPath("zig"); err == nil {
+		return path, nil
+	}
+	return "", fmt.Errorf("zig compiler not found")
+}


### PR DESCRIPTION
## Summary
- add `compile/zig` backend that uses the C compiler and `zig cc`
- provide helper to locate Zig
- include slow test compiling `two-sum` with Zig and verifying output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852134109688320943221b8fa1b447b