### PR TITLE
Add minimal Racket backend

### DIFF
--- a/compile/rkt/compiler.go
+++ b/compile/rkt/compiler.go
@@ -1,0 +1,312 @@
+package rktcode
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler translates Mochi AST into Racket source code.
+type Compiler struct {
+	buf    bytes.Buffer
+	indent int
+	env    *types.Env
+}
+
+func New(env *types.Env) *Compiler {
+	return &Compiler{env: env}
+}
+
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	c.writeln("#lang racket")
+	c.writeln("")
+	// function declarations first
+	for _, s := range prog.Statements {
+		if s.Fun != nil {
+			if err := c.compileFun(s.Fun); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		}
+	}
+	// main body
+	for _, s := range prog.Statements {
+		if s.Fun == nil && s.Type == nil && s.Test == nil {
+			if err := c.compileStmt(s); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return c.buf.Bytes(), nil
+}
+
+func (c *Compiler) compileFun(fn *parser.FunStmt) error {
+	name := sanitizeName(fn.Name)
+	c.writeIndent()
+	c.buf.WriteString("(define (" + name)
+	for _, p := range fn.Params {
+		c.buf.WriteString(" " + sanitizeName(p.Name))
+	}
+	c.buf.WriteString(")\n")
+	c.indent++
+	c.writeln("(let/ec return")
+	c.indent++
+	for _, st := range fn.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.writeln("(return (void))") // default return when none hit
+	c.indent--
+	c.writeln(")")
+	c.indent--
+	c.writeln(")")
+	return nil
+}
+
+func (c *Compiler) compileStmt(s *parser.Statement) error {
+	switch {
+	case s.Let != nil:
+		return c.compileLet(s.Let)
+	case s.Return != nil:
+		val, err := c.compileExpr(s.Return.Value)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("(return %s)", val))
+		return nil
+	case s.For != nil:
+		return c.compileFor(s.For)
+	case s.If != nil:
+		return c.compileIf(s.If)
+	case s.Expr != nil:
+		expr, err := c.compileExpr(s.Expr.Expr)
+		if err != nil {
+			return err
+		}
+		c.writeln(expr)
+		return nil
+	default:
+		return fmt.Errorf("unsupported statement")
+	}
+}
+
+func (c *Compiler) compileLet(l *parser.LetStmt) error {
+	val := "(void)"
+	if l.Value != nil {
+		expr, err := c.compileExpr(l.Value)
+		if err != nil {
+			return err
+		}
+		val = expr
+	}
+	c.writeln(fmt.Sprintf("(define %s %s)", sanitizeName(l.Name), val))
+	return nil
+}
+
+func (c *Compiler) compileFor(f *parser.ForStmt) error {
+	name := sanitizeName(f.Name)
+	if f.RangeEnd != nil {
+		start, err := c.compileExpr(f.Source)
+		if err != nil {
+			return err
+		}
+		end, err := c.compileExpr(f.RangeEnd)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("(for ([%s (in-range %s %s)])", name, start, end))
+	} else {
+		src, err := c.compileExpr(f.Source)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("(for ([%s %s])", name, src))
+	}
+	c.indent++
+	for _, st := range f.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln(")")
+	return nil
+}
+
+func (c *Compiler) compileIf(s *parser.IfStmt) error {
+	if s.ElseIf != nil || len(s.Else) > 0 {
+		return fmt.Errorf("else not supported")
+	}
+	cond, err := c.compileExpr(s.Cond)
+	if err != nil {
+		return err
+	}
+	c.writeln(fmt.Sprintf("(when %s", cond))
+	c.indent++
+	for _, st := range s.Then {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln(")")
+	return nil
+}
+
+// --- Expressions ---
+
+func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
+	if e == nil {
+		return "", nil
+	}
+	return c.compileBinary(e.Binary)
+}
+
+func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
+	if b == nil {
+		return "", nil
+	}
+	val, err := c.compileUnary(b.Left)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range b.Right {
+		rhs, err := c.compilePostfix(op.Right)
+		if err != nil {
+			return "", err
+		}
+		switch op.Op {
+		case "+":
+			val = fmt.Sprintf("(+ %s %s)", val, rhs)
+		case "-":
+			val = fmt.Sprintf("(- %s %s)", val, rhs)
+		case "*":
+			val = fmt.Sprintf("(* %s %s)", val, rhs)
+		case "/":
+			val = fmt.Sprintf("(/ %s %s)", val, rhs)
+		case "==":
+			val = fmt.Sprintf("(= %s %s)", val, rhs)
+		case "!=":
+			val = fmt.Sprintf("(not (= %s %s))", val, rhs)
+		default:
+			return "", fmt.Errorf("unsupported op %s", op.Op)
+		}
+	}
+	return val, nil
+}
+
+func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
+	val, err := c.compilePostfix(u.Value)
+	if err != nil {
+		return "", err
+	}
+	for i := len(u.Ops) - 1; i >= 0; i-- {
+		switch u.Ops[i] {
+		case "-":
+			val = fmt.Sprintf("(- %s)", val)
+		case "!":
+			val = fmt.Sprintf("(not %s)", val)
+		default:
+			return "", fmt.Errorf("unsupported unary op %s", u.Ops[i])
+		}
+	}
+	return val, nil
+}
+
+func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
+	val, err := c.compilePrimary(p.Target)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range p.Ops {
+		if op.Call != nil {
+			args := make([]string, len(op.Call.Args))
+			for i, a := range op.Call.Args {
+				v, err := c.compileExpr(a)
+				if err != nil {
+					return "", err
+				}
+				args[i] = v
+			}
+			val = fmt.Sprintf("(%s %s)", val, strings.Join(args, " "))
+		} else if op.Index != nil {
+			idx, err := c.compileExpr(op.Index.Start)
+			if err != nil {
+				return "", err
+			}
+			val = fmt.Sprintf("(list-ref %s %s)", val, idx)
+		}
+	}
+	return val, nil
+}
+
+func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
+	switch {
+	case p.Lit != nil:
+		return c.compileLiteral(p.Lit)
+	case p.List != nil:
+		elems := make([]string, len(p.List.Elems))
+		for i, e := range p.List.Elems {
+			v, err := c.compileExpr(e)
+			if err != nil {
+				return "", err
+			}
+			elems[i] = v
+		}
+		return "(list " + strings.Join(elems, " ") + ")", nil
+	case p.Call != nil:
+		return c.compileCallExpr(p.Call)
+	case p.Selector != nil:
+		return sanitizeName(p.Selector.Root), nil
+	case p.Group != nil:
+		expr, err := c.compileExpr(p.Group)
+		if err != nil {
+			return "", err
+		}
+		return "(" + expr + ")", nil
+	default:
+		return "", fmt.Errorf("unsupported primary")
+	}
+}
+
+func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
+	name := sanitizeName(call.Func)
+	switch call.Func {
+	case "len":
+		name = "length"
+	case "print":
+		name = "displayln"
+	}
+	args := make([]string, len(call.Args))
+	for i, a := range call.Args {
+		v, err := c.compileExpr(a)
+		if err != nil {
+			return "", err
+		}
+		args[i] = v
+	}
+	return fmt.Sprintf("(%s %s)", name, strings.Join(args, " ")), nil
+}
+
+func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
+	switch {
+	case l.Int != nil:
+		return strconv.Itoa(*l.Int), nil
+	case l.Float != nil:
+		return strconv.FormatFloat(*l.Float, 'f', -1, 64), nil
+	case l.Bool != nil:
+		if bool(*l.Bool) {
+			return "true", nil
+		}
+		return "false", nil
+	case l.Str != nil:
+		return strconv.Quote(*l.Str), nil
+	default:
+		return "", fmt.Errorf("empty literal")
+	}
+}

--- a/compile/rkt/compiler_test.go
+++ b/compile/rkt/compiler_test.go
@@ -1,0 +1,49 @@
+//go:build slow
+
+package rktcode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	rktcode "mochi/compile/rkt"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestRacketCompiler_TwoSum(t *testing.T) {
+	if _, err := exec.LookPath("racket"); err != nil {
+		t.Skip("racket not installed")
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := rktcode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.rkt")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("racket", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("racket run error: %v\n%s", err, out)
+	}
+	res := bytes.TrimSpace(out)
+	if string(res) != "0\n1" {
+		t.Fatalf("unexpected output: %q", res)
+	}
+}

--- a/compile/rkt/helpers.go
+++ b/compile/rkt/helpers.go
@@ -1,0 +1,34 @@
+package rktcode
+
+import "strings"
+
+func (c *Compiler) writeln(s string) {
+	c.writeIndent()
+	c.buf.WriteString(s)
+	c.buf.WriteByte('\n')
+}
+
+func (c *Compiler) writeIndent() {
+	for i := 0; i < c.indent; i++ {
+		c.buf.WriteByte('\t')
+	}
+}
+
+func sanitizeName(name string) string {
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	for i, r := range name {
+		if r == '_' || ('0' <= r && r <= '9' && i > 0) || ('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z') {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	s := b.String()
+	if s == "" || !((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z') || s[0] == '_') {
+		s = "_" + s
+	}
+	return s
+}

--- a/compile/rkt/tools.go
+++ b/compile/rkt/tools.go
@@ -1,0 +1,8 @@
+package rktcode
+
+import "os/exec"
+
+func EnsureRacket() error {
+	_, err := exec.LookPath("racket")
+	return err
+}


### PR DESCRIPTION
## Summary
- add a basic Racket compiler
- add slow-build test for the `two-sum` example
- include helpers for code generation and runtime checks
- remove README mention of Racket backend (not needed yet)

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852137b9cd88320803fcb0fd8926c60