### PR TITLE
Fix Scheme compiler test and revert CLI

### DIFF
--- a/compile/scheme/compiler.go
+++ b/compile/scheme/compiler.go
@@ -1,0 +1,369 @@
+package schemecode
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Compiler translates a Mochi AST into Scheme source code (minimal subset).
+type Compiler struct {
+	buf    bytes.Buffer
+	indent int
+	env    *types.Env
+}
+
+// New creates a new Scheme compiler instance.
+func New(env *types.Env) *Compiler { return &Compiler{env: env} }
+
+func (c *Compiler) writeIndent() {
+	for i := 0; i < c.indent; i++ {
+		c.buf.WriteByte('\t')
+	}
+}
+
+func (c *Compiler) writeln(s string) {
+	c.writeIndent()
+	c.buf.WriteString(s)
+	c.buf.WriteByte('\n')
+}
+
+// Compile converts the given program to Scheme source code.
+func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	c.buf.Reset()
+
+	// Function declarations
+	for _, s := range prog.Statements {
+		if s.Fun != nil {
+			if err := c.compileFun(s.Fun); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		}
+	}
+
+	// Main body
+	for _, s := range prog.Statements {
+		if s.Fun != nil {
+			continue
+		}
+		if err := c.compileStmt(s); err != nil {
+			return nil, err
+		}
+	}
+	return c.buf.Bytes(), nil
+}
+
+func (c *Compiler) compileFun(fn *parser.FunStmt) error {
+	params := make([]string, len(fn.Params))
+	for i, p := range fn.Params {
+		params[i] = sanitizeName(p.Name)
+	}
+	c.writeln(fmt.Sprintf("(define (%s %s)", sanitizeName(fn.Name), strings.Join(params, " ")))
+	c.indent++
+	c.writeln("(call/cc (lambda (return)")
+	c.indent++
+	for _, st := range fn.Body {
+		if err := c.compileStmt(st); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln("))")
+	c.indent--
+	c.writeln(")")
+	return nil
+}
+
+func (c *Compiler) compileStmt(s *parser.Statement) error {
+	switch {
+	case s.Let != nil:
+		expr, err := c.compileExpr(s.Let.Value)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("(define %s %s)", sanitizeName(s.Let.Name), expr))
+	case s.Var != nil:
+		expr := "()"
+		if s.Var.Value != nil {
+			v, err := c.compileExpr(s.Var.Value)
+			if err != nil {
+				return err
+			}
+			expr = v
+		}
+		c.writeln(fmt.Sprintf("(define %s %s)", sanitizeName(s.Var.Name), expr))
+	case s.Assign != nil:
+		rhs, err := c.compileExpr(s.Assign.Value)
+		if err != nil {
+			return err
+		}
+		lhs := sanitizeName(s.Assign.Name)
+		for _, idx := range s.Assign.Index {
+			ie, err := c.compileExpr(idx.Start)
+			if err != nil {
+				return err
+			}
+			lhs = fmt.Sprintf("(list-ref %s %s)", lhs, ie)
+		}
+		c.writeln(fmt.Sprintf("(set! %s %s)", lhs, rhs))
+	case s.Return != nil:
+		expr, err := c.compileExpr(s.Return.Value)
+		if err != nil {
+			return err
+		}
+		c.writeln(fmt.Sprintf("(return %s)", expr))
+	case s.Expr != nil:
+		expr, err := c.compileExpr(s.Expr.Expr)
+		if err != nil {
+			return err
+		}
+		c.writeln(expr)
+	case s.For != nil:
+		return c.compileFor(s.For)
+	case s.If != nil:
+		return c.compileSimpleIf(s.If)
+	default:
+		// ignore unsupported statements
+	}
+	return nil
+}
+
+func (c *Compiler) compileFor(st *parser.ForStmt) error {
+	name := sanitizeName(st.Name)
+	start, err := c.compileExpr(st.Source)
+	if err != nil {
+		return err
+	}
+	end, err := c.compileExpr(st.RangeEnd)
+	if err != nil {
+		return err
+	}
+	c.writeln(fmt.Sprintf("(let loop ((%s %s))", name, start))
+	c.indent++
+	c.writeln(fmt.Sprintf("(if (< %s %s)", name, end))
+	c.indent++
+	c.writeln("(begin")
+	c.indent++
+	for _, s := range st.Body {
+		if err := c.compileStmt(s); err != nil {
+			return err
+		}
+	}
+	c.writeln(fmt.Sprintf("(loop (+ %s 1))", name))
+	c.indent--
+	c.writeln(")")
+	c.indent--
+	c.writeln("'())")
+	c.indent--
+	c.writeln(")")
+	return nil
+}
+
+func (c *Compiler) compileSimpleIf(st *parser.IfStmt) error {
+	cond, err := c.compileExpr(st.Cond)
+	if err != nil {
+		return err
+	}
+	c.writeln(fmt.Sprintf("(if %s", cond))
+	c.indent++
+	c.writeln("(begin")
+	c.indent++
+	for _, s := range st.Then {
+		if err := c.compileStmt(s); err != nil {
+			return err
+		}
+	}
+	c.indent--
+	c.writeln(")")
+	if len(st.Else) > 0 {
+		c.writeln("(begin")
+		c.indent++
+		for _, s := range st.Else {
+			if err := c.compileStmt(s); err != nil {
+				return err
+			}
+		}
+		c.indent--
+		c.writeln(")")
+	} else {
+		c.writeln("'()")
+	}
+	c.indent--
+	c.writeln(")")
+	return nil
+}
+
+func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
+	if e == nil {
+		return "()", nil
+	}
+	return c.compileBinary(e.Binary)
+}
+
+func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
+	left, err := c.compileUnary(b.Left)
+	if err != nil {
+		return "", err
+	}
+	expr := left
+	for _, op := range b.Right {
+		right, err := c.compilePostfix(op.Right)
+		if err != nil {
+			return "", err
+		}
+		switch op.Op {
+		case "+", "-", "*", "/":
+			expr = fmt.Sprintf("(%s %s %s)", op.Op, expr, right)
+		case "==":
+			expr = fmt.Sprintf("(= %s %s)", expr, right)
+		case "!=":
+			expr = fmt.Sprintf("(not (= %s %s))", expr, right)
+		case "<", "<=", ">", ">=":
+			expr = fmt.Sprintf("(%s %s %s)", op.Op, expr, right)
+		default:
+			expr = fmt.Sprintf("(%s %s %s)", op.Op, expr, right)
+		}
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
+	expr, err := c.compilePostfix(u.Value)
+	if err != nil {
+		return "", err
+	}
+	for i := len(u.Ops) - 1; i >= 0; i-- {
+		op := u.Ops[i]
+		if op == "-" {
+			expr = fmt.Sprintf("(- %s)", expr)
+		} else if op == "!" {
+			expr = fmt.Sprintf("(not %s)", expr)
+		}
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
+	expr, err := c.compilePrimary(p.Target)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range p.Ops {
+		if op.Index != nil {
+			idx, err := c.compileExpr(op.Index.Start)
+			if err != nil {
+				return "", err
+			}
+			expr = fmt.Sprintf("(list-ref %s %s)", expr, idx)
+			continue
+		}
+		if op.Call != nil {
+			args := make([]string, len(op.Call.Args))
+			for i, a := range op.Call.Args {
+				v, err := c.compileExpr(a)
+				if err != nil {
+					return "", err
+				}
+				args[i] = v
+			}
+			expr = fmt.Sprintf("(%s %s)", expr, strings.Join(args, " "))
+			continue
+		}
+	}
+	return expr, nil
+}
+
+func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
+	switch {
+	case p.Lit != nil:
+		if p.Lit.Int != nil {
+			return strconv.Itoa(*p.Lit.Int), nil
+		}
+		if p.Lit.Bool != nil {
+			if *p.Lit.Bool {
+				return "#t", nil
+			}
+			return "#f", nil
+		}
+		if p.Lit.Str != nil {
+			return strconv.Quote(*p.Lit.Str), nil
+		}
+	case p.List != nil:
+		elems := make([]string, len(p.List.Elems))
+		for i, e := range p.List.Elems {
+			v, err := c.compileExpr(e)
+			if err != nil {
+				return "", err
+			}
+			elems[i] = v
+		}
+		return "(list " + strings.Join(elems, " ") + ")", nil
+	case p.Selector != nil:
+		if len(p.Selector.Tail) == 0 {
+			return sanitizeName(p.Selector.Root), nil
+		}
+	case p.Group != nil:
+		expr, err := c.compileExpr(p.Group)
+		if err != nil {
+			return "", err
+		}
+		return "(" + expr + ")", nil
+	case p.Call != nil:
+		return c.compileCall(p.Call, "")
+	}
+	return sanitizeName(p.Selector.Root), nil
+}
+
+func (c *Compiler) compileCall(call *parser.CallExpr, recv string) (string, error) {
+	args := make([]string, len(call.Args))
+	for i, a := range call.Args {
+		v, err := c.compileExpr(a)
+		if err != nil {
+			return "", err
+		}
+		args[i] = v
+	}
+	switch call.Func {
+	case "len":
+		if len(args) != 1 {
+			return "", fmt.Errorf("len expects 1 arg")
+		}
+		return fmt.Sprintf("(length %s)", args[0]), nil
+	case "print":
+		if len(args) != 1 {
+			return "", fmt.Errorf("print expects 1 arg")
+		}
+		return fmt.Sprintf("(begin (display %s) (newline))", args[0]), nil
+	}
+	if recv != "" {
+		return fmt.Sprintf("(%s %s %s)", recv, call.Func, strings.Join(args, " ")), nil
+	}
+	return fmt.Sprintf("(%s %s)", sanitizeName(call.Func), strings.Join(args, " ")), nil
+}
+
+func sanitizeName(name string) string {
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	for i, r := range name {
+		if r == '_' || ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || ('0' <= r && r <= '9' && i > 0) {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	s := b.String()
+	if s == "" {
+		return "_"
+	}
+	if !(s[0] >= 'a' && s[0] <= 'z' || s[0] >= 'A' && s[0] <= 'Z' || s[0] == '_') {
+		s = "_" + s
+	}
+	return s
+}

--- a/compile/scheme/compiler_test.go
+++ b/compile/scheme/compiler_test.go
@@ -1,0 +1,50 @@
+//go:build slow
+
+package schemecode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	schemecode "mochi/compile/scheme"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestSchemeCompiler_TwoSum compiles the LeetCode example to Scheme and runs it.
+func TestSchemeCompiler_TwoSum(t *testing.T) {
+	if _, err := exec.LookPath("chibi-scheme"); err != nil {
+		t.Skip("chibi-scheme not installed")
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := schemecode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.scm")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("chibi-scheme", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("scheme run error: %v\n%s", err, out)
+	}
+	got := bytes.TrimSpace(out)
+	if string(got) != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Scheme compiler test cleanup
- remove CLI integration for the Scheme compiler

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68521470fb9883209708077c6ffe9015