### PR TITLE
Add v0.8.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # 📦 CHANGELOG.md
+## [0.8.2] – 2025-06-18
+
+### Added
+
+* Minimal compilers for Clojure, COBOL, Fortran, OCaml, Pascal, Prolog, Scheme, Racket and Zig
+* Cross join and sort/skip/take queries in C#, Dart, Elixir and Erlang
+* Negative string indexing and slicing in Java, Swift and Lua
+* Map literals and membership checks in Java, Scala and Swift
+* `str`, `input`, `count` and `avg` builtins across more backends
+* Build command handles every compiler target
+* Benchmarks compile C output
+* Golden tests for all compilers
+
+### Changed
+
+* CLI no longer references the removed Clojure integration
+
+### Fixed
+
+* Scala test runner detection
+* Lua integer division uses `//` when possible
+
 ## [0.8.0] – 2025-06-19
 
 ### Added

--- a/releases/v0.8.2.md
+++ b/releases/v0.8.2.md
@@ -1,0 +1,19 @@
+# Jun 2025 (v0.8.2)
+
+Mochi v0.8.2 expands the set of experimental compilers and aligns features across languages. Build tooling and benchmarks now recognize every backend with a new wave of golden tests.
+
+## Compilers
+
+- New minimal backends for Clojure, COBOL, Fortran, OCaml, Pascal, Prolog, Scheme, Racket and Zig
+- Cross join and sort/skip/take query operations in C#, Dart, Elixir and Erlang
+- Negative string indexing and slicing supported in Java, Swift and Lua
+- Map literals and membership checks in Java, Scala and Swift
+- Union types, casting and local functions in Ruby and Scala
+- `input`, `str`, `count` and `avg` builtins across Kotlin, Swift and C#
+- Extensive golden tests covering all backends
+
+## Build System
+
+- `mochi build` handles every compiler target
+- Benchmarks can compile C output
+


### PR DESCRIPTION
## Summary
- document v0.8.2 changes in CHANGELOG
- add release notes for v0.8.2

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68521b7052408320b90b04bf02e65215