### PR TITLE
Add break/continue to Erlang compiler

### DIFF
--- a/tests/compiler/erl_simple/avg_builtin.erl.out
+++ b/tests/compiler/erl_simple/avg_builtin.erl.out
@@ -37,10 +37,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/break_continue.erl.out
+++ b/tests/compiler/erl_simple/break_continue.erl.out
@@ -1,17 +1,18 @@
 #!/usr/bin/env escript
 -module(main).
--export([main/1, prepend/2]).
-
-prepend(level, result) ->
-	try
-		result = lists:append([level], result),
-		throw({return, result})
-	catch
-		throw:{return, V} -> V
-	end.
+-export([main/1]).
 
 main(_) ->
-	mochi_print([prepend([1, 2], [[3], [4]])]).
+	numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9],
+	mochi_foreach(fun(n) ->
+		if ((n % 2) == 0) ->
+			throw(mochi_continue)
+		end,
+		if (n > 7) ->
+			throw(mochi_break)
+		end,
+		mochi_print(["odd number:", n])
+	end, numbers).
 
 mochi_print(Args) ->
 	Strs = [ mochi_format(A) || A <- Args ],

--- a/tests/compiler/erl_simple/break_continue.mochi
+++ b/tests/compiler/erl_simple/break_continue.mochi
@@ -1,0 +1,11 @@
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+for n in numbers {
+  if n % 2 == 0 {
+    continue
+  }
+  if n > 7 {
+    break
+  }
+  print("odd number:", n)
+}

--- a/tests/compiler/erl_simple/break_continue.out
+++ b/tests/compiler/erl_simple/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7

--- a/tests/compiler/erl_simple/count_builtin.erl.out
+++ b/tests/compiler/erl_simple/count_builtin.erl.out
@@ -37,10 +37,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/cross_join.erl.out
+++ b/tests/compiler/erl_simple/cross_join.erl.out
@@ -10,7 +10,7 @@ main(_) ->
 	orders = [#{id => 100, customerId => 1, total => 250}, #{id => 101, customerId => 2, total => 125}, #{id => 102, customerId => 1, total => 300}],
 	result = [#{orderId => maps:get(id, o), orderCustomerId => maps:get(customerId, o), pairedCustomerName => maps:get(name, c), orderTotal => maps:get(total, o)} || o <- orders, c <- customers],
 	mochi_print(["--- Cross Join: All order-customer pairs ---"]),
-	lists:foreach(fun(entry) ->
+	mochi_foreach(fun(entry) ->
 		mochi_print(["Order", maps:get(orderId, entry), "(customerId:", maps:get(orderCustomerId, entry), ", total: $", maps:get(orderTotal, entry), ") paired with", maps:get(pairedCustomerName, entry)])
 	end, result).
 
@@ -46,10 +46,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/dataset.erl.out
+++ b/tests/compiler/erl_simple/dataset.erl.out
@@ -6,7 +6,7 @@ main(_) ->
 	ok,
 	people = [#{name => "Alice", age => 30}, #{name => "Bob", age => 15}, #{name => "Charlie", age => 65}],
 	names = [maps:get(name, p) || p <- people, (maps:get(age, p) >= 18)],
-	lists:foreach(fun(n) ->
+	mochi_foreach(fun(n) ->
 		mochi_print([n])
 	end, names).
 
@@ -42,10 +42,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/dataset_sort_take_limit.erl.out
+++ b/tests/compiler/erl_simple/dataset_sort_take_limit.erl.out
@@ -20,7 +20,7 @@ main(_) ->
 	[p || p <- Taken]
 end)(),
 	mochi_print(["--- Top products (excluding most expensive) ---"]),
-	lists:foreach(fun(item) ->
+	mochi_foreach(fun(item) ->
 		mochi_print([maps:get(name, item), "costs $", maps:get(price, item)])
 	end, expensive).
 
@@ -56,10 +56,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/if_else.erl.out
+++ b/tests/compiler/erl_simple/if_else.erl.out
@@ -53,10 +53,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/input_builtin.erl.out
+++ b/tests/compiler/erl_simple/input_builtin.erl.out
@@ -41,10 +41,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/map_any_hint.erl.out
+++ b/tests/compiler/erl_simple/map_any_hint.erl.out
@@ -52,6 +52,17 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_get(M, K) when is_list(M), is_integer(K) -> lists:nth(K + 1, M);
 mochi_get(M, K) when is_map(M) -> maps:get(K, M);
 mochi_get(_, _) -> erlang:error(badarg).
@@ -59,7 +70,10 @@ mochi_get(_, _) -> erlang:error(badarg).
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/str_builtin.erl.out
+++ b/tests/compiler/erl_simple/str_builtin.erl.out
@@ -37,10 +37,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/two-sum.erl.out
+++ b/tests/compiler/erl_simple/two-sum.erl.out
@@ -5,8 +5,8 @@
 twoSum(nums, target) ->
 	try
 		n = length(nums),
-		lists:foreach(fun(i) ->
-			lists:foreach(fun(j) ->
+		mochi_foreach(fun(i) ->
+			mochi_foreach(fun(j) ->
 				if ((lists:nth(i + 1, nums) + lists:nth(j + 1, nums)) == target) ->
 					throw({return, [i, j]})
 				end
@@ -54,10 +54,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.

--- a/tests/compiler/erl_simple/while_loop.erl.out
+++ b/tests/compiler/erl_simple/while_loop.erl.out
@@ -6,7 +6,7 @@ main(_) ->
 	i = 0,
 	mochi_while(fun() -> (i < 3) end, fun() ->
 		mochi_print([i]),
-		ok
+		i = (i + 1)
 	end).
 
 mochi_print(Args) ->
@@ -41,10 +41,24 @@ mochi_avg(L) when is_list(L) ->
 	.
 mochi_avg(_) -> erlang:error(badarg).
 
+mochi_foreach(F, L) ->
+	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+	try F(H) catch
+		throw:mochi_continue -> ok;
+		throw:mochi_break -> throw(mochi_break)
+	end,
+	mochi_foreach_loop(F, T).
+
 mochi_while(Cond, Body) ->
 	case Cond() of
 		true ->
-			Body(),
+			try Body() catch
+				throw:mochi_continue -> ok;
+				throw:mochi_break -> ok
+			end,
 			mochi_while(Cond, Body);
 		_ -> ok
 	end.


### PR DESCRIPTION
## Summary
- implement `break` and `continue` handling in Erlang compiler
- add runtime helpers `mochi_foreach` and update `mochi_while`
- update Erlang golden files and add new test `break_continue`

## Testing
- `go test ./compile/erlang -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68521cf15a608320962841674825f5f6