### PR TITLE
Add macOS COBOL tool install support

### DIFF
--- a/compile/cobol/tools.go
+++ b/compile/cobol/tools.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // EnsureCOBOL ensures the cobc compiler is installed.
@@ -11,21 +12,34 @@ func EnsureCOBOL() error {
 	if _, err := exec.LookPath("cobc"); err == nil {
 		return nil
 	}
-	if _, err := exec.LookPath("apt-get"); err == nil {
-		cmd := exec.Command("apt-get", "update")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return err
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "gnu-cobol")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("cobc"); err == nil {
+				return nil
+			}
 		}
-		cmd = exec.Command("apt-get", "install", "-y", "gnucobol")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return err
-		}
-		if _, err := exec.LookPath("cobc"); err == nil {
-			return nil
+	default:
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "gnucobol")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			if _, err := exec.LookPath("cobc"); err == nil {
+				return nil
+			}
 		}
 	}
 	return fmt.Errorf("cobc not installed")


### PR DESCRIPTION
## Summary
- detect `brew` on macOS in COBOL tool installer
- fallback to apt-get on Linux

## Testing
- `go test ./compile/cobol -run TestEnsureCOBOL -v`
- `make lint` *(fails: many errcheck/staticcheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_68521e6cc6788320bd2cec6e3f1c9d4f