### PR TITLE
Add Erlang tool installation helper

### DIFF
--- a/compile/erlang/compiler_test.go
+++ b/compile/erlang/compiler_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestErlangCompiler_LeetCode1(t *testing.T) {
 	t.Skip("disabled in current environment")
-	if _, err := exec.LookPath("escript"); err != nil {
-		t.Skip("escript not installed")
+	if err := erlcode.EnsureErlang(); err != nil {
+		t.Skipf("erlang not installed: %v", err)
 	}
 	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)
@@ -53,8 +53,8 @@ func TestErlangCompiler_LeetCode1(t *testing.T) {
 }
 
 func TestErlangCompiler_SubsetPrograms(t *testing.T) {
-	if _, err := exec.LookPath("escript"); err != nil {
-		t.Skip("escript not installed")
+	if err := erlcode.EnsureErlang(); err != nil {
+		t.Skipf("erlang not installed: %v", err)
 	}
 	golden.Run(t, "tests/compiler/erl_simple", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)

--- a/compile/erlang/tools.go
+++ b/compile/erlang/tools.go
@@ -1,0 +1,55 @@
+package erlcode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// EnsureErlang verifies that the Erlang toolchain is installed. It attempts a
+// best-effort installation using apt-get on Linux or Homebrew on macOS.
+// Tests can call this to skip if installation fails.
+func EnsureErlang() error { return ensureErlang() }
+
+func ensureErlang() error {
+	if _, err := exec.LookPath("escript"); err == nil {
+		return nil
+	}
+	if _, err := exec.LookPath("erl"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "erlang")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "erlang")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	}
+	if _, err := exec.LookPath("escript"); err == nil {
+		return nil
+	}
+	if _, err := exec.LookPath("erl"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("erlang not installed")
+}


### PR DESCRIPTION
## Summary
- add `EnsureErlang` helper to install escript/erl if missing
- use `EnsureErlang` in Erlang compiler tests

## Testing
- `go test ./... --vet=off -run TestErlangCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68523afa20048320a8c0e44a9f200df7