### PR TITLE
Add macOS support for Haskell tools

### DIFF
--- a/compile/hs/tools.go
+++ b/compile/hs/tools.go
@@ -4,24 +4,43 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	rruntime "runtime"
 )
 
-// EnsureHaskell ensures ghc/runhaskell is installed, installing via apt if possible.
+// EnsureHaskell verifies that ghc/runhaskell is installed. It attempts a
+// best-effort installation using apt-get on Linux or Homebrew on macOS.
 func EnsureHaskell() error {
 	if _, err := exec.LookPath("runhaskell"); err == nil {
 		return nil
 	}
-	if _, err := exec.LookPath("apt-get"); err == nil {
-		cmd := exec.Command("apt-get", "update")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return err
+	switch rruntime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "ghc")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				break
+			}
 		}
-		cmd = exec.Command("apt-get", "install", "-y", "ghc")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		return cmd.Run()
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "ghc")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				break
+			}
+		}
+	}
+	if _, err := exec.LookPath("runhaskell"); err == nil {
+		return nil
 	}
 	return fmt.Errorf("ghc not installed")
 }


### PR DESCRIPTION
## Summary
- enhance `EnsureHaskell` to install via Homebrew on macOS in addition to apt-get
- alias runtime import to avoid naming conflict

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68523b4a86188320a890ba956f949f29