### PR TITLE
Add macOS support for Racket tool

### DIFF
--- a/compile/rkt/tools.go
+++ b/compile/rkt/tools.go
@@ -4,24 +4,43 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // EnsureRacket verifies that the Racket binary is installed. If missing,
-// it attempts a best-effort installation via apt-get.
+// it attempts a best-effort installation using apt-get on Linux or
+// Homebrew on macOS.
 // It is safe to call from tests.
 func EnsureRacket() error {
 	if _, err := exec.LookPath("racket"); err == nil {
 		return nil
 	}
-	fmt.Println("🔧 Installing Racket...")
-	cmd := exec.Command("apt-get", "update")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
+	switch runtime.GOOS {
+	case "linux":
+		fmt.Println("🔧 Installing Racket via apt-get...")
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "racket")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		fmt.Println("🍺 Installing Racket via Homebrew...")
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "racket")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
-	cmd = exec.Command("apt-get", "install", "-y", "racket")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if _, err := exec.LookPath("racket"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("racket not found")
 }


### PR DESCRIPTION
## Summary
- support installing Racket on macOS via Homebrew
- update docs in EnsureRacket

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68523bc8f61c83208ef8517f9f58337e