### PR TITLE
Add cross-platform Python installer

### DIFF
--- a/compile/py/tools.go
+++ b/compile/py/tools.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // EnsurePython installs Python3 if missing. Useful for benchmarks and tests.
@@ -11,15 +12,32 @@ func EnsurePython() error {
 	if _, err := exec.LookPath("python3"); err == nil {
 		return nil
 	}
-	fmt.Println("\U0001F40D Installing Python3...")
-	cmd := exec.Command("apt-get", "update")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("\U0001F40D Installing Python3 via Homebrew...")
+			cmd := exec.Command("brew", "install", "python")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("\U0001F40D Installing Python3...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "python3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
-	cmd = exec.Command("apt-get", "install", "-y", "python3")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if _, err := exec.LookPath("python3"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("python3 not found")
 }


### PR DESCRIPTION
## Summary
- install Python3 via Homebrew on macOS
- keep apt-get path on Linux

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_68523bb019288320b6e7be6fcb00fbdf