### PR TITLE
Add SWIPL tools helper and update Prolog tests

### DIFF
--- a/compile/pl/compiler_test.go
+++ b/compile/pl/compiler_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestPrologCompiler_LeetCode1(t *testing.T) {
-	if _, err := exec.LookPath("swipl"); err != nil {
-		t.Skip("swipl not installed")
+	if err := plcode.EnsureSWIPL(); err != nil {
+		t.Skipf("swipl not installed: %v", err)
 	}
 	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)

--- a/compile/pl/tools.go
+++ b/compile/pl/tools.go
@@ -1,0 +1,47 @@
+package plcode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// EnsureSWIPL verifies that the SWI-Prolog interpreter is installed. If missing,
+// it attempts a best-effort installation using apt-get on Linux or Homebrew on
+// macOS.
+func EnsureSWIPL() error {
+	if _, err := exec.LookPath("swipl"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "swi-prolog")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "swi-prolog")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	}
+	if _, err := exec.LookPath("swipl"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("swipl not found")
+}


### PR DESCRIPTION
## Summary
- add tools.go for Prolog compiler with best-effort installation of swipl
- update Prolog compiler tests to use EnsureSWIPL helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68523ba0b7508320bd98d70007afd913