### PR TITLE
Add Ruby tooling support

### DIFF
--- a/compile/rb/compiler_test.go
+++ b/compile/rb/compiler_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestRBCompiler_TwoSum(t *testing.T) {
 	t.Skip("disabled in current environment")
-	if _, err := exec.LookPath("ruby"); err != nil {
-		t.Skip("ruby not installed")
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
 	}
 	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)
@@ -55,10 +55,10 @@ func TestRBCompiler_TwoSum(t *testing.T) {
 }
 
 func TestRBCompiler_SubsetPrograms(t *testing.T) {
-	if _, err := exec.LookPath("ruby"); err != nil {
-		t.Skip("ruby not installed")
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
 	}
-        golden.Run(t, "tests/compiler/rb", ".mochi", ".out", func(src string) ([]byte, error) {
+	golden.Run(t, "tests/compiler/rb", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
 			return nil, err
@@ -85,23 +85,23 @@ func TestRBCompiler_SubsetPrograms(t *testing.T) {
 			return nil, fmt.Errorf("ruby run error: %w\n%s", err, out)
 		}
 		return bytes.TrimSpace(out), nil
-        })
+	})
 }
 
 func TestRBCompiler_GoldenOutput(t *testing.T) {
-        golden.Run(t, "tests/compiler/rb", ".mochi", ".rb.out", func(src string) ([]byte, error) {
-                prog, err := parser.Parse(src)
-                if err != nil {
-                        return nil, err
-                }
-                env := types.NewEnv(nil)
-                if errs := types.Check(prog, env); len(errs) > 0 {
-                        return nil, errs[0]
-                }
-                code, err := rbcode.New(env).Compile(prog)
-                if err != nil {
-                        return nil, err
-                }
-                return bytes.TrimSpace(code), nil
-        })
+	golden.Run(t, "tests/compiler/rb", ".mochi", ".rb.out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, err
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, errs[0]
+		}
+		code, err := rbcode.New(env).Compile(prog)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.TrimSpace(code), nil
+	})
 }

--- a/compile/rb/tools.go
+++ b/compile/rb/tools.go
@@ -1,0 +1,47 @@
+package rbcode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// EnsureRuby verifies that the ruby binary is installed. If missing, it
+// attempts a best-effort installation using apt-get on Linux or Homebrew on
+// macOS.
+func EnsureRuby() error {
+	if _, err := exec.LookPath("ruby"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "ruby-full")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "ruby")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	}
+	if _, err := exec.LookPath("ruby"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("ruby not installed")
+}


### PR DESCRIPTION
## Summary
- provide `EnsureRuby` installer for macOS and Linux
- use `EnsureRuby` in Ruby compiler tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68523bba17548320bf69dc28c3ed6bce