### PR TITLE
Add macOS scheme support

### DIFF
--- a/compile/scheme/tools.go
+++ b/compile/scheme/tools.go
@@ -4,25 +4,35 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
-// EnsureScheme checks for chibi-scheme and tries to install it via apt if missing.
+// EnsureScheme verifies that chibi-scheme is installed. On Linux it attempts a
+// best-effort installation using apt-get, while on macOS it tries Homebrew.
 func EnsureScheme() (string, error) {
 	if path, err := exec.LookPath("chibi-scheme"); err == nil {
 		return path, nil
 	}
-	if _, err := exec.LookPath("apt-get"); err == nil {
-		cmd := exec.Command("apt-get", "update")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return "", err
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "chibi-scheme")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
 		}
-		cmd = exec.Command("apt-get", "install", "-y", "chibi-scheme")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return "", err
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return "", err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "chibi-scheme")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
 		}
 	}
 	if path, err := exec.LookPath("chibi-scheme"); err == nil {


### PR DESCRIPTION
## Summary
- update Scheme toolchain helper to use Homebrew on macOS
- clean up code formatting and comments

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68523be817a48320b858943d41b015b7