### PR TITLE
Improve Rust installer

### DIFF
--- a/compile/rust/tools.go
+++ b/compile/rust/tools.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // EnsureRust verifies that the Rust toolchain is installed and attempts to
@@ -17,6 +18,32 @@ func ensureRust() error {
 		return nil
 	}
 	fmt.Println("\U0001F980 Installing Rust...")
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "rustc", "cargo")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "rust")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	}
 	cmd := exec.Command("sh", "-c", "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary
- handle rust setup via `apt-get` on Linux and `brew` on macOS before falling back to rustup script

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68523bd33aa48320a04a41344224e196