### PR TITLE
Add python alias for build target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,7 +404,7 @@
 
 ### Added
 
-* Python compiler via `mochi build --target py` or `.py` output
+* Python compiler via `mochi build --target python` (or `py`) or `.py` output
 * Build command auto-detects target language from extension
 * Benchmarks auto-install Mochi, Deno and Python
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ mochi run examples/hello.mochi
 mochi test examples/math.mochi
 mochi test examples/leetcode/...
 mochi build examples/hello.mochi -o hello
-mochi build --target py examples/hello.mochi -o hello.py
+mochi build --target python examples/hello.mochi -o hello.py
 mochi init mymodule
 mochi get
 mochi llm "hello"

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -99,7 +99,7 @@ type TestCmd struct {
 type BuildCmd struct {
 	File          string `arg:"positional,required" help:"Path to .mochi source file"`
 	Out           string `arg:"-o" help:"Output file path"`
-	Target        string `arg:"--target" help:"Output language (c|cs|dart|erlang|ex|fs|go|hs|java|jvm|kt|lua|php|py|rb|rust|scala|swift|ts|wasm|st)"`
+	Target        string `arg:"--target" help:"Output language (c|cs|dart|erlang|ex|fs|go|hs|java|jvm|kt|lua|php|py|python|rb|rust|scala|swift|ts|wasm|st)"`
 	WasmToolchain string `arg:"--wasm-toolchain" help:"WASM toolchain (go|tinygo)"`
 }
 
@@ -636,7 +636,7 @@ func build(cmd *BuildCmd) error {
 			status = "error"
 			msg = err.Error()
 		}
-	case "py":
+	case "python", "py":
 		if out == "" {
 			out = base + ".py"
 		}

--- a/docs/guides/using-mochi.md
+++ b/docs/guides/using-mochi.md
@@ -77,7 +77,7 @@ Examples:
 mochi run examples/hello.mochi
 mochi test examples/math.mochi
 mochi build examples/hello.mochi -o hello
-mochi build --target py examples/hello.mochi -o hello.py
+mochi build --target python examples/hello.mochi -o hello.py
 mochi init mymodule
 mochi get
 mochi llm "hello"

--- a/releases/v0.2.10.md
+++ b/releases/v0.2.10.md
@@ -4,10 +4,10 @@ This update introduces multi-language code generation improvements, enhanced ben
 
 ## Python Code Generation
 
-Mochi now supports code generation to Python. Programs can be compiled using either the `--target py` flag or by specifying a `.py` output file:
+Mochi now supports code generation to Python. Programs can be compiled using either the `--target python` (or `py`) flag or by specifying a `.py` output file:
 
 ```bash
-$ mochi build main.mochi --target py -o main.py
+$ mochi build main.mochi --target python -o main.py
 ```
 
 The generated Python code preserves the original structure and behavior of the Mochi source. Output is verified using golden file tests to ensure consistent results across releases. This new backend enables Mochi programs to run in Python environments and facilitates integration into Python-based workflows.


### PR DESCRIPTION
## Summary
- allow `mochi build --target python`
- document python alias in README and guides
- update changelog and release notes

## Testing
- `go test ./compile/py -tags slow -run TestPyCompiler_GoldenOutput -count=1` *(fails: failed to read golden files)*
- `go test ./compile/go -tags slow -run TestGoCompiler_GoldenOutput -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68523f31ed088320a852f6903f49757d