### PR TITLE
Add Racket compiler target

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ mochi test examples/math.mochi
 mochi test examples/leetcode/...
 mochi build examples/hello.mochi -o hello
 mochi build --target py examples/hello.mochi -o hello.py
+mochi build --target rkt examples/hello.mochi -o hello.rkt
 mochi init mymodule
 mochi get
 mochi llm "hello"

--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -46,6 +46,7 @@ import (
 	phpcode "mochi/compile/php"
 	pycode "mochi/compile/py"
 	rbcode "mochi/compile/rb"
+	rktcode "mochi/compile/rkt"
 	rscode "mochi/compile/rust"
 	scalacode "mochi/compile/scala"
 	stcode "mochi/compile/st"
@@ -99,7 +100,7 @@ type TestCmd struct {
 type BuildCmd struct {
 	File          string `arg:"positional,required" help:"Path to .mochi source file"`
 	Out           string `arg:"-o" help:"Output file path"`
-	Target        string `arg:"--target" help:"Output language (c|cs|dart|erlang|ex|fs|go|hs|java|jvm|kt|lua|php|py|rb|rust|scala|swift|ts|wasm|st)"`
+	Target        string `arg:"--target" help:"Output language (c|cs|dart|erlang|ex|fs|go|hs|java|jvm|kt|lua|php|py|rkt|rb|rust|scala|swift|ts|wasm|st)"`
 	WasmToolchain string `arg:"--wasm-toolchain" help:"WASM toolchain (go|tinygo)"`
 }
 
@@ -442,6 +443,8 @@ func build(cmd *BuildCmd) error {
 			target = "go"
 		case ".py":
 			target = "py"
+		case ".rkt":
+			target = "rkt"
 		case ".ts":
 			target = "ts"
 		case ".wasm":
@@ -641,6 +644,18 @@ func build(cmd *BuildCmd) error {
 			out = base + ".py"
 		}
 		code, err := pycode.New(env).Compile(prog)
+		if err == nil {
+			err = os.WriteFile(out, code, 0644)
+		}
+		if err != nil {
+			status = "error"
+			msg = err.Error()
+		}
+	case "rkt":
+		if out == "" {
+			out = base + ".rkt"
+		}
+		code, err := rktcode.New(env).Compile(prog)
 		if err == nil {
 			err = os.WriteFile(out, code, 0644)
 		}

--- a/compile/Readme.md
+++ b/compile/Readme.md
@@ -15,6 +15,7 @@ Current directories:
 - `kt`      – Kotlin source emitter
 - `lua`     – Lua source emitter
 - `py`      – Python source emitter
+- `rkt`     – Racket source emitter
 - `rb`      – Ruby source emitter
 - `rust`    – Rust source emitter
 - `st`      – GNU Smalltalk output


### PR DESCRIPTION
## Summary
- enable `mochi build` to generate Racket source
- document Racket compiler backend
- show example usage in README

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_68523f370470832094e90705ab1bd715