### PR TITLE
Add ruby cross join triple support

### DIFF
--- a/tests/compiler/rb/cross_join.rb.out
+++ b/tests/compiler/rb/cross_join.rb.out
@@ -14,7 +14,7 @@ result = (begin
 		end
 	end
 	_res
-end
+end)
 puts(["--- Cross Join: All order-customer pairs ---"].join(" "))
 for entry in result
 	puts(["Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName].join(" "))

--- a/tests/compiler/rb/cross_join_triple.mochi
+++ b/tests/compiler/rb/cross_join_triple.mochi
@@ -1,0 +1,11 @@
+let nums = [1, 2]
+let letters = ["A", "B"]
+let bools = [true, false]
+let combos = from n in nums
+             from l in letters
+             from b in bools
+             select {n: n, l: l, b: b}
+print("--- Cross Join of three lists ---")
+for c in combos {
+  print(c.n, c.l, c.b)
+}

--- a/tests/compiler/rb/cross_join_triple.out
+++ b/tests/compiler/rb/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false

--- a/tests/compiler/rb/cross_join_triple.rb.out
+++ b/tests/compiler/rb/cross_join_triple.rb.out
@@ -1,0 +1,21 @@
+require 'ostruct'
+
+nums = [1, 2]
+letters = ["A", "B"]
+bools = [true, false]
+combos = (begin
+	_res = []
+	for n in nums
+		for l in letters
+			for b in bools
+				_res << OpenStruct.new(n: n, l: l, b: b)
+			end
+		end
+	end
+	_res
+end)
+puts(["--- Cross Join of three lists ---"].join(" "))
+for c in combos
+	puts([c.n, c.l, c.b].join(" "))
+end
+


### PR DESCRIPTION
## Summary
- fix Ruby query compilation to close cross join blocks
- output maps with `OpenStruct` when all keys are identifiers
- handle map selectors via bracket syntax when type known
- support empty map literals
- add golden tests for Ruby cross join triple

## Testing
- `go test ./compile/rb -tags slow -run TestRBCompiler_GoldenOutput -count=1 -v`
- `go test ./compile/rb -tags slow -run TestRBCompiler_SubsetPrograms -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68523f34f7288320ba2bce0a5512b593