### PR TITLE
Add install helper for Deno

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ bench: install build-mochi ## Run Mochi benchmarks
 	@echo "🏃 Running benchmarks..."
 	@$(GO) run ./cmd/mochi-bench
 
+install: ## Install external tools (Deno)
+	@echo "🦕 Installing Deno if needed..."
+	@$(GO) run ./tools/install.go
+
 # --------------------------
 # Maintenance
 # --------------------------

--- a/tools/install.go
+++ b/tools/install.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"mochi/compile/ts"
+)
+
+func main() {
+	if err := tscode.EnsureDeno(); err != nil {
+		fmt.Println("failed to install Deno:", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add small helper to install Deno
- wire helper in Makefile `install` target

## Testing
- `go test ./... -run TestTSCompiler_GoldenOutput -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68523f4801748320bb5d45dacc9128dd