### PR TITLE
Add Erlang cross join triple test

### DIFF
--- a/compile/erlang/compiler.go
+++ b/compile/erlang/compiler.go
@@ -409,6 +409,17 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			// If the key is a simple selector like `n`, treat it as
+			// an atom instead of a variable name.
+			if sel := it.Key.Binary; sel != nil && sel.Left != nil && len(sel.Right) == 0 {
+				u := sel.Left
+				if len(u.Ops) == 0 && u.Value != nil {
+					p := u.Value
+					if len(p.Ops) == 0 && p.Target != nil && p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+						k = p.Target.Selector.Root
+					}
+				}
+			}
 			v, err := c.compileExpr(it.Value)
 			if err != nil {
 				return "", err

--- a/tests/compiler/erl_simple/cross_join_triple.erl.out
+++ b/tests/compiler/erl_simple/cross_join_triple.erl.out
@@ -1,0 +1,66 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1]).
+
+main(_) ->
+        nums = [1, 2],
+        letters = ["A", "B"],
+        bools = [true, false],
+        combos = [#{n => N, l => L, b => B} || N <- nums, L <- letters, B <- bools],
+        mochi_print(["--- Cross Join of three lists ---"]),
+        mochi_foreach(fun(c) ->
+                mochi_print([maps:get(n, c), maps:get(l, c), maps:get(b, c)])
+        end, combos).
+
+mochi_print(Args) ->
+        Strs = [ mochi_format(A) || A <- Args ],
+        io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_input() ->
+        case io:get_line("") of
+                eof -> "";
+                Line -> string:trim(Line)
+        end.
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+        Sum = lists:foldl(fun(X, Acc) ->
+                case X of
+                        I when is_integer(I) -> Acc + I;
+                        F when is_float(F) -> Acc + F;
+                        _ -> erlang:error(badarg) end
+                end, 0, L),
+        Sum / length(L).
+mochi_avg(_) -> erlang:error(badarg).
+
+mochi_foreach(F, L) ->
+        try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+
+mochi_foreach_loop(_, []) -> ok;
+mochi_foreach_loop(F, [H|T]) ->
+        try F(H) catch
+                throw:mochi_continue -> ok;
+                throw:mochi_break -> throw(mochi_break)
+        end,
+        mochi_foreach_loop(F, T).
+
+mochi_while(Cond, Body) ->
+        case Cond() of
+                true ->
+                        try Body() catch
+                                throw:mochi_continue -> ok;
+                                throw:mochi_break -> ok
+                        end,
+                        mochi_while(Cond, Body);
+                _ -> ok
+        end.

--- a/tests/compiler/erl_simple/cross_join_triple.mochi
+++ b/tests/compiler/erl_simple/cross_join_triple.mochi
@@ -1,0 +1,11 @@
+let nums = [1, 2]
+let letters = ["A", "B"]
+let bools = [true, false]
+let combos = from n in nums
+             from l in letters
+             from b in bools
+             select {n: n, l: l, b: b}
+print("--- Cross Join of three lists ---")
+for c in combos {
+  print(c.n, c.l, c.b)
+}

--- a/tests/compiler/erl_simple/cross_join_triple.out
+++ b/tests/compiler/erl_simple/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false


### PR DESCRIPTION
## Summary
- support simple selector map keys in Erlang compiler
- add golden test for `cross_join_triple` to Erlang compiler

## Testing
- `go run /tmp/typecheck.go tests/compiler/erl_simple/cross_join_triple.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68523f0eafd48320bdef677308356237