### PR TITLE
Fix Scheme compiler grouped expressions

### DIFF
--- a/compile/scheme/compiler.go
+++ b/compile/scheme/compiler.go
@@ -312,7 +312,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return "(" + expr + ")", nil
+		return expr, nil
 	case p.Call != nil:
 		return c.compileCall(p.Call, "")
 	}

--- a/compile/scheme/compiler_test.go
+++ b/compile/scheme/compiler_test.go
@@ -41,7 +41,7 @@ func TestSchemeCompiler_TwoSum(t *testing.T) {
 	if err := os.WriteFile(file, code, 0644); err != nil {
 		t.Fatalf("write error: %v", err)
 	}
-	cmd := exec.Command("chibi-scheme", file)
+	cmd := exec.Command("chibi-scheme", "-m", "chibi", file)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("scheme run error: %v\n%s", err, out)
@@ -75,7 +75,7 @@ func TestSchemeCompiler_SubsetPrograms(t *testing.T) {
 		if err := os.WriteFile(file, code, 0644); err != nil {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
-		cmd := exec.Command("chibi-scheme", file)
+		cmd := exec.Command("chibi-scheme", "-m", "chibi", file)
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}

--- a/tests/compiler/scheme/grouped_expr.scm.out
+++ b/tests/compiler/scheme/grouped_expr.scm.out
@@ -1,2 +1,2 @@
-(define value (* ((+ 1 2)) 3))
+(define value (* (+ 1 2) 3))
 (begin (display value) (newline))


### PR DESCRIPTION
## Summary
- fix grouped expression handling in Scheme compiler
- use `-m chibi` when invoking `chibi-scheme` in tests
- update golden output for grouped expression

## Testing
- `go test ./compile/scheme -run TestSchemeCompiler_SubsetPrograms -tags slow`
- `go test ./compile/scheme -run TestSchemeCompiler_GoldenOutput -tags slow`
- `go test ./compile/scheme -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852552cd3bc83208a441798844ef395