### PR TITLE
Add C# compiler runtime tests

### DIFF
--- a/compile/cs/README.md
+++ b/compile/cs/README.md
@@ -108,7 +108,7 @@ The produced code is standard C# and can be executed with `dotnet run` or compil
 
 ## Tests
 
-Golden tests verify that the emitted code matches the expected `.cs.out` files. They are tagged `slow` and can be run with:
+Golden tests verify that the emitted code matches the expected `.cs.out` files. The suite also compiles and executes the programs in `tests/compiler/cs` using `dotnet run` to ensure they behave correctly. All tests are tagged `slow` because they invoke the .NET toolchain. Run them with:
 
 ```bash
 go test ./compile/cs -tags slow

--- a/compile/cs/compiler_test.go
+++ b/compile/cs/compiler_test.go
@@ -5,6 +5,10 @@ package cscode_test
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	cscode "mochi/compile/cs"
@@ -13,8 +17,57 @@ import (
 	"mochi/types"
 )
 
+func TestCSCompiler_SubsetPrograms(t *testing.T) {
+	if err := cscode.EnsureDotnet(); err != nil {
+		t.Skipf("dotnet not installed: %v", err)
+	}
+	if err := exec.Command("dotnet", "--version").Run(); err != nil {
+		t.Skipf("dotnet not runnable: %v", err)
+	}
+	golden.Run(t, "tests/compiler/cs", ".mochi", ".out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("❌ parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("❌ type error: %v", errs[0])
+		}
+		code, err := cscode.New(env).Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("❌ compile error: %w", err)
+		}
+		dir := t.TempDir()
+		projDir := filepath.Join(dir, "app")
+		if err := os.MkdirAll(projDir, 0755); err != nil {
+			return nil, fmt.Errorf("mkdir: %w", err)
+		}
+		csproj := `<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net7.0</TargetFramework></PropertyGroup></Project>`
+		if err := os.WriteFile(filepath.Join(projDir, "app.csproj"), []byte(csproj), 0644); err != nil {
+			return nil, fmt.Errorf("write csproj: %w", err)
+		}
+		file := filepath.Join(projDir, "Program.cs")
+		if err := os.WriteFile(file, code, 0644); err != nil {
+			return nil, fmt.Errorf("write error: %w", err)
+		}
+		cmd := exec.Command("dotnet", "run", "--project", projDir, "--no-restore")
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("❌ dotnet run error: %w\n%s", err, out)
+		}
+		res := bytes.TrimSpace(out)
+		if res == nil {
+			res = []byte{}
+		}
+		return res, nil
+	})
+}
+
 func TestCSCompiler_GoldenOutput(t *testing.T) {
-	golden.Run(t, "tests/compiler/cs", ".mochi", ".cs.out", func(src string) ([]byte, error) {
+	compile := func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
 			return nil, fmt.Errorf("❌ parse error: %w", err)
@@ -28,5 +81,8 @@ func TestCSCompiler_GoldenOutput(t *testing.T) {
 			return nil, fmt.Errorf("❌ compile error: %w", err)
 		}
 		return bytes.TrimSpace(code), nil
-	})
+	}
+
+	golden.Run(t, "tests/compiler/valid", ".mochi", ".cs.out", compile)
+	golden.Run(t, "tests/compiler/cs", ".mochi", ".cs.out", compile)
 }


### PR DESCRIPTION
## Summary
- run compiler golden tests for the C# target
- execute compiled programs with `dotnet run`
- document the new tests in the C# backend README

## Testing
- `go test ./...` *(fails: operation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68525559308c8320a84fbee37af3eadf