### PR TITLE
Add rust compiler tests for valid programs

### DIFF
--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -60,6 +60,105 @@ func TestRustCompiler_SubsetPrograms(t *testing.T) {
 	})
 }
 
+func TestRustCompiler_ValidPrograms(t *testing.T) {
+	if err := rscode.EnsureRust(); err != nil {
+		t.Skipf("rust not installed: %v", err)
+	}
+
+	files := []string{
+		"break_continue",
+		"fold_pure_let",
+		"for_list_collection",
+		"for_loop",
+		"for_string_collection",
+		"fun_call",
+		"fun_expr_in_let",
+		"grouped_expr",
+		"if_else",
+		"len_builtin",
+		"let_and_print",
+		"list_index",
+		"list_set",
+		"map_index",
+		"match_expr",
+		"print_hello",
+		"two_sum",
+		"var_assignment",
+		"while_loop",
+	}
+
+	for _, name := range files {
+		src := filepath.Join("tests", "compiler", "valid", name+".mochi")
+		t.Run(name, func(t *testing.T) {
+			runRustProgram(t, src)
+		})
+	}
+}
+
+func runRustProgram(t *testing.T, src string) {
+	root := findRoot(t)
+	path := filepath.Join(root, src)
+	prog, err := parser.Parse(path)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := rscode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.rs")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	exe := filepath.Join(dir, "main")
+	if out, err := exec.Command("rustc", file, "-O", "-o", exe).CombinedOutput(); err != nil {
+		t.Fatalf("rustc error: %v\n%s", err, out)
+	}
+	cmd := exec.Command(exe)
+	if data, err := os.ReadFile(strings.TrimSuffix(path, ".mochi") + ".in"); err == nil {
+		cmd.Stdin = bytes.NewReader(data)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run error: %v\n%s", err, out)
+	}
+	got := bytes.TrimSpace(out)
+	wantPath := strings.TrimSuffix(path, ".mochi") + ".out"
+	want, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("failed to read golden: %v", err)
+	}
+	want = bytes.TrimSpace(want)
+	if !bytes.Equal(got, want) {
+		t.Errorf("unexpected output for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", path, got, want)
+	}
+}
+
+func findRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
 func TestRustCompiler_GoldenOutput(t *testing.T) {
 	golden.Run(t, "tests/compiler/rust", ".mochi", ".rs.out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)


### PR DESCRIPTION
## Summary
- extend rust compiler tests to run a subset of `tests/compiler/valid`
- introduce helper to compile and run Rust code for these files

## Testing
- `go test ./compile/rust -run TestRustCompiler_ValidPrograms -tags slow -count=1 -v`
- `go test ./compile/rust -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_685255bf0c7483209f9c1a2fc7da0857