### PR TITLE
Add Pascal for-in support

### DIFF
--- a/compile/pas/helpers.go
+++ b/compile/pas/helpers.go
@@ -1,6 +1,9 @@
 package pascode
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func (c *Compiler) writeln(s string) {
 	c.writeIndent()
@@ -40,4 +43,10 @@ func sanitizeName(name string) string {
 		return "_" + res
 	}
 	return res
+}
+
+func (c *Compiler) newVar() string {
+	name := fmt.Sprintf("_tmp%d", c.tempVarCount)
+	c.tempVarCount++
+	return name
 }

--- a/tests/compiler/pas/break_continue.mochi
+++ b/tests/compiler/pas/break_continue.mochi
@@ -1,0 +1,11 @@
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+for n in numbers {
+  if n % 2 == 0 {
+    continue
+  }
+  if n > 7 {
+    break
+  }
+  print("odd number:", n)
+}

--- a/tests/compiler/pas/break_continue.out
+++ b/tests/compiler/pas/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7

--- a/tests/compiler/pas/break_continue.pas.out
+++ b/tests/compiler/pas/break_continue.pas.out
@@ -1,0 +1,26 @@
+program main;
+{$mode objfpc}
+uses SysUtils;
+
+type TIntArray = array of integer;
+
+var
+	n: integer;
+	numbers: TIntArray;
+
+begin
+	numbers := [1, 2, 3, 4, 5, 6, 7, 8, 9];
+	for _tmp0 := 0 to Length(numbers) - 1 do
+	begin
+		n := numbers[_tmp0];
+		if n mod 2 = 0 then
+		begin
+			continue;
+		end;
+		if n > 7 then
+		begin
+			break;
+		end;
+		writeln("odd number:", n);
+	end;
+end.


### PR DESCRIPTION
## Summary
- allow pascal compiler to generate unique temporary variable names
- support modulo and not equal operators
- handle `for` loops over lists
- add golden test for pascal break/continue loop

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68525635cdc88320ba368540f8a14347