### PR TITLE
Enhance Pascal compiler and tests

### DIFF
--- a/compile/pas/helpers.go
+++ b/compile/pas/helpers.go
@@ -48,5 +48,9 @@ func sanitizeName(name string) string {
 func (c *Compiler) newVar() string {
 	name := fmt.Sprintf("_tmp%d", c.tempVarCount)
 	c.tempVarCount++
+	if c.tempVars == nil {
+		c.tempVars = make(map[string]bool)
+	}
+	c.tempVars[name] = true
 	return name
 }

--- a/tests/compiler/pas/break_continue.out
+++ b/tests/compiler/pas/break_continue.out
@@ -1,4 +1,4 @@
-odd number: 1
-odd number: 3
-odd number: 5
-odd number: 7
+odd number:1
+odd number:3
+odd number:5
+odd number:7

--- a/tests/compiler/pas/break_continue.pas.out
+++ b/tests/compiler/pas/break_continue.pas.out
@@ -10,9 +10,8 @@ var
 
 begin
 	numbers := [1, 2, 3, 4, 5, 6, 7, 8, 9];
-	for _tmp0 := 0 to Length(numbers) - 1 do
+	for n in numbers do
 	begin
-		n := numbers[_tmp0];
 		if n mod 2 = 0 then
 		begin
 			continue;
@@ -21,6 +20,6 @@ begin
 		begin
 			break;
 		end;
-		writeln("odd number:", n);
+		writeln('odd number:', n);
 	end;
 end.


### PR DESCRIPTION
## Summary
- track temporary variables in Pascal compiler
- emit Pascal for-range loops using `for … in` and add single-quoted string literals
- update Pascal golden output
- update runtime golden output

## Testing
- `go test ./compile/pas -run . -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68528026a3008320912c035b1ff81951