### PR TITLE
Add literal patterns to F# compiler

### DIFF
--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -460,6 +460,9 @@ func (c *Compiler) compilePattern(e *parser.Expr) (string, error) {
 	if id, ok := identName(e); ok {
 		return sanitizeName(id), nil
 	}
+	if lit := extractLiteral(e); lit != nil {
+		return c.compileLiteral(lit)
+	}
 	return "", fmt.Errorf("unsupported pattern")
 }
 
@@ -946,4 +949,22 @@ func intLiteral(e *parser.Expr) (int, bool) {
 		v = -v
 	}
 	return v, true
+}
+
+func extractLiteral(e *parser.Expr) *parser.Literal {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return nil
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return nil
+	}
+	if p.Target != nil {
+		return p.Target.Lit
+	}
+	return nil
 }

--- a/tests/compiler/valid/match_expr.fs.out
+++ b/tests/compiler/valid/match_expr.fs.out
@@ -1,0 +1,10 @@
+open System
+
+let x = 2
+let label = (match x with
+ | 1 -> "one"
+ | 2 -> "two"
+ | 3 -> "three"
+ | _ -> "unknown"
+)
+printfn "%A" label


### PR DESCRIPTION
## Summary
- add literal pattern support to the F# backend
- regenerate golden output for `match_expr`

## Testing
- `go test ./compile/fs -tags slow -run TestFSCompiler_GoldenOutput/match_expr -v`
- `go test ./compile/fs -tags slow -run TestFSCompiler_GoldenOutput -count=1`
- `go test ./compile/fs -tags slow -run TestFSCompiler_SubsetPrograms -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68528258e6f0832085a85ec21d14e90a