### PR TITLE
Add Ruby compiler golden test coverage

### DIFF
--- a/compile/rb/compiler_test.go
+++ b/compile/rb/compiler_test.go
@@ -88,6 +88,67 @@ func TestRBCompiler_SubsetPrograms(t *testing.T) {
 	})
 }
 
+func TestRBCompiler_ValidPrograms(t *testing.T) {
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	pattern := filepath.Join(root, "tests", "compiler", "valid", "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	skip := map[string]bool{
+		"generate_echo":      true,
+		"generate_embedding": true,
+		"join":               true,
+		"stream_on_emit":     true,
+	}
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		if skip[name] {
+			continue
+		}
+		wantPath := filepath.Join(root, "tests", "compiler", "valid", name+".out")
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := rbcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.rb")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("ruby", file)
+			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("ruby run error: %v\n%s", err, out)
+			}
+			got := bytes.TrimSpace(out)
+			want, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read golden error: %v", err)
+			}
+			want = bytes.TrimSpace(want)
+			if !bytes.Equal(got, want) {
+				t.Errorf("golden mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", name, got, want)
+			}
+		})
+	}
+}
+
 func TestRBCompiler_GoldenOutput(t *testing.T) {
 	golden.Run(t, "tests/compiler/rb", ".mochi", ".rb.out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
@@ -104,4 +165,23 @@ func TestRBCompiler_GoldenOutput(t *testing.T) {
 		}
 		return bytes.TrimSpace(code), nil
 	})
+}
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found (not in Go module)")
+	return ""
 }


### PR DESCRIPTION
## Summary
- test Ruby compiler against `tests/compiler/valid`
- skip programs using unsupported features
- helper to locate repo root for tests

## Testing
- `go test ./...`
- `go test -tags=slow ./compile/rb`

------
https://chatgpt.com/codex/tasks/task_e_685282785dac8320be465aced7491796