### PR TITLE
Fix Java test stdin handling

### DIFF
--- a/compile/java/compiler_test.go
+++ b/compile/java/compiler_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	javacode "mochi/compile/java"
@@ -41,7 +42,11 @@ func TestJavaCompiler_SubsetPrograms(t *testing.T) {
 		if out, err := exec.Command("javac", file).CombinedOutput(); err != nil {
 			return nil, fmt.Errorf("❌ javac error: %w\n%s", err, out)
 		}
-		out, err := exec.Command("java", "-cp", dir, "Main").CombinedOutput()
+		cmd := exec.Command("java", "-cp", dir, "Main")
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return nil, fmt.Errorf("❌ java run error: %w\n%s", err, out)
 		}


### PR DESCRIPTION
## Summary
- fix Java compiler golden tests to pass stdin to compiled program

## Testing
- `go test ./compile/java -tags slow -run TestJavaCompiler_SubsetPrograms/avg_builtin -v`
- `go test ./compile/java -tags slow -run TestJavaCompiler_SubsetPrograms/input_builtin -v`
- `go test ./compile/java -tags slow -run GoldenOutput -v | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68528262f76083209122b6ab59c8c1e6