### PR TITLE
Add v0.8.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # 📦 CHANGELOG.md
+## [0.8.3] – 2025-06-18
+
+### Added
+
+* CLI exposes all compiler targets and accepts `python` alias
+* Basic Zig backend with golden tests
+* READMEs for every experimental compiler backend
+* Cross-platform installation helpers for many languages
+* Union types, match expressions and closures across backends
+* Golden tests expanded for C, COBOL, Pascal, Prolog, Fortran and more
+
+### Changed
+
+* Python golden outputs removed from other compilers
+* C++ backend gains range loop support
+* Improved dotnet and Rust setup on macOS and Linux
+
+### Fixed
+
+* C compiler average function and list concatenation
+* Assignment handling in Clojure backend
+* Erlang boolean literals
+* Ruby query printing
+* Smalltalk backend compilation
+
 ## [0.8.2] – 2025-06-18
 
 ### Added

--- a/releases/v0.8.3.md
+++ b/releases/v0.8.3.md
@@ -1,0 +1,31 @@
+# Jun 2025 (v0.8.3)
+
+Mochi v0.8.3 finalizes documentation for every experimental compiler backend and improves installation helpers across operating systems. Numerous language features have been added with expanded golden tests.
+
+## Compilers
+
+- CLI exposes all compiler targets and accepts `python` as an alias
+- Basic Zig backend and dedicated READMEs for all languages
+- Union types, match expressions and closures in Rust, Kotlin and Lua
+- While loops and break/continue statements across Scheme, Smalltalk and F#
+- Cross join queries, struct support and list slicing in various backends
+- Golden tests added for C, COBOL, Pascal, Prolog, Fortran, OCaml and more
+
+## Tooling
+
+- Cross-platform installation scripts for COBOL, Fortran, Haskell, Erlang, Pascal, Lua and others
+- C++ backend supports range loops
+- Improved dotnet and Rust setup on Linux and macOS
+
+## Tests
+
+- Non-Python compilers exclude Python golden outputs
+- Additional closure and dataset query tests
+
+## Fixes
+
+- Corrected average calculation and list concatenation in the C backend
+- Assignment handling fixed in the Clojure compiler
+- Boolean literals corrected in Erlang output
+- Query printing fixed in the Ruby backend
+- Smalltalk backend compilation issues resolved


### PR DESCRIPTION
## Summary
- document new compiler features and fixes for v0.8.3
- add changelog entry for v0.8.3

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685289af94a48320ac8f47d930da3128