### PR TITLE
Document Erlang golden tests

### DIFF
--- a/compile/erlang/README.md
+++ b/compile/erlang/README.md
@@ -60,6 +60,9 @@ Run them with:
 go test ./compile/erlang -tags slow
 ```
 
+Golden files live under `tests/compiler/erl_simple` and `tests/compiler/erl`.
+Updating them can be done with `go test -tags slow -update ./compile/erlang`.
+
 `EnsureErlang` attempts to install Erlang via `apt-get` or Homebrew when tests are
 executed:
 


### PR DESCRIPTION
## Summary
- document locations of Erlang golden tests in backend README

## Testing
- `go test ./compile/erlang -tags slow -run TestErlangCompiler_GoldenOutput`

------
https://chatgpt.com/codex/tasks/task_e_68528a1d713c8320abc9cd7be5416742