### PR TITLE
Add Rust cross join triple golden test

### DIFF
--- a/tests/compiler/rust/cross_join_triple.mochi
+++ b/tests/compiler/rust/cross_join_triple.mochi
@@ -1,0 +1,17 @@
+type Combo {
+  n: int
+  l: string
+  b: bool
+}
+
+let nums = [1, 2]
+let letters = ["A", "B"]
+let bools = [true, false]
+let combos = from n in nums
+             from l in letters
+             from b in bools
+             select Combo { n: n, l: str(l), b: b }
+print("--- Cross Join of three lists ---")
+for c in combos {
+  print(c.n, c.l, c.b)
+}

--- a/tests/compiler/rust/cross_join_triple.out
+++ b/tests/compiler/rust/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false

--- a/tests/compiler/rust/cross_join_triple.rs.out
+++ b/tests/compiler/rust/cross_join_triple.rs.out
@@ -1,0 +1,28 @@
+#[derive(Clone, Debug)]
+struct Combo {
+    n: i32,
+    l: String,
+    b: bool,
+}
+
+fn main() {
+    let mut nums = vec![1, 2];
+    let mut letters = vec!["A", "B"];
+    let mut bools = vec![true, false];
+    let mut combos = {
+    let mut _res = Vec::new();
+    for n in nums.clone() {
+        for l in letters.clone() {
+            for b in bools.clone() {
+                _res.push(Combo { n: n, l: format!("{}", l), b: b });
+            }
+        }
+    }
+    _res
+};
+    println!("{}", "--- Cross Join of three lists ---");
+    for c in combos {
+        println!("{} {} {}", c.n, c.l, c.b);
+    }
+}
+


### PR DESCRIPTION
## Summary
- expand Rust golden tests with a new `cross_join_triple` case

## Testing
- `go test ./compile/rust -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68528a4d8fa48320b93bfdbec322d86e