### PR TITLE
Enable C backend two-sum test

### DIFF
--- a/compile/c/compiler_test.go
+++ b/compile/c/compiler_test.go
@@ -19,7 +19,6 @@ import (
 
 // TestCCompiler_TwoSum compiles the LeetCode example to C and runs it.
 func TestCCompiler_TwoSum(t *testing.T) {
-	t.Skip("disabled in current environment")
 	cc, err := ccode.EnsureCC()
 	if err != nil {
 		t.Skipf("C compiler not installed: %v", err)


### PR DESCRIPTION
## Summary
- remove skip from `TestCCompiler_TwoSum`

## Testing
- `go test -tags slow ./compile/c -run TestCCompiler_TwoSum -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852929319bc8320a6813eec03ce0d76