### PR TITLE
Add Clojure two-sum test

### DIFF
--- a/compile/clj/compiler_test.go
+++ b/compile/clj/compiler_test.go
@@ -17,6 +17,41 @@ import (
 	"mochi/types"
 )
 
+func TestClojureCompiler_TwoSum(t *testing.T) {
+	if err := cljcode.EnsureClojure(); err != nil {
+		t.Skipf("clojure not installed: %v", err)
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := cljcode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.clj")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("clojure", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clojure run error: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	want := "0\n1"
+	if got != want {
+		t.Fatalf("unexpected output\nwant:\n%s\n got:\n%s", want, got)
+	}
+}
+
 func TestClojureCompiler_SubsetPrograms(t *testing.T) {
 	if err := cljcode.EnsureClojure(); err != nil {
 		t.Skipf("clojure not installed: %v", err)


### PR DESCRIPTION
## Summary
- add integration test compiling LeetCode two-sum to Clojure

## Testing
- `go test ./compile/clj -tags slow -run TestClojureCompiler_TwoSum -count=1`
- `go test ./compile/clj -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685292bb89dc8320b1e70acb5fcb2bb3