### PR TITLE
Enable Dart example test

### DIFF
--- a/compile/dart/compiler_test.go
+++ b/compile/dart/compiler_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestDartCompiler_LeetCodeExample1(t *testing.T) {
-	t.Skip("disabled in current environment")
 	if err := dartcode.EnsureDart(); err != nil {
 		t.Skipf("dart not installed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- enable the Dart LeetCode example test

## Testing
- `go test -v ./compile/dart -run TestDartCompiler_LeetCodeExample1 -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685292c7016883209836e65cf55835e8