### PR TITLE
Enable Haskell compiler example test

### DIFF
--- a/compile/hs/compiler_test.go
+++ b/compile/hs/compiler_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestHSCompiler_LeetCodeExample1(t *testing.T) {
-	t.Skip("disabled in current environment")
 	if err := hscode.EnsureHaskell(); err != nil {
 		t.Skipf("haskell not installed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- enable the LeetCode two-sum example test for the Haskell backend

## Testing
- `go test ./compile/hs -tags slow`
- `runhaskell /tmp/two-sum.hs`

------
https://chatgpt.com/codex/tasks/task_e_685292d49f308320aa888308cfe7875c