### PR TITLE
Enable Lua two-sum test

### DIFF
--- a/compile/lua/compiler_test.go
+++ b/compile/lua/compiler_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestLuaCompiler_LeetCodeExample1(t *testing.T) {
-	t.Skip("disabled in current environment")
 	if err := luacode.EnsureLua(); err != nil {
 		t.Skipf("lua not installed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- run Lua compiler test for leetcode `two-sum`

## Testing
- `go test -tags slow ./compile/lua -run TestLuaCompiler_LeetCodeExample1 -v`

------
https://chatgpt.com/codex/tasks/task_e_685292de44bc832099fe54320815dc16