### PR TITLE
Ensure Ruby compiler runs Two Sum example

### DIFF
--- a/compile/rb/README.md
+++ b/compile/rb/README.md
@@ -80,6 +80,22 @@ mochi build --target rb main.mochi -o main.rb
 ruby main.rb
 ```
 
+### Example: LeetCode Two Sum
+
+To compile and run the `two-sum` example located in `examples/leetcode/1`, use:
+
+```bash
+mochi build --target rb examples/leetcode/1/two-sum.mochi -o two-sum.rb
+ruby two-sum.rb
+```
+
+The program prints the indices of the elements that sum to the target:
+
+```
+0
+1
+```
+
 `tools.go` provides `EnsureRuby` which attempts to install Ruby on Linux or macOS if it is missing:
 
 ```go

--- a/compile/rb/compiler_test.go
+++ b/compile/rb/compiler_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestRBCompiler_TwoSum(t *testing.T) {
-	t.Skip("disabled in current environment")
 	if err := rbcode.EnsureRuby(); err != nil {
 		t.Skipf("ruby not installed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- enable Ruby compiler test for the leetcode two-sum example
- document how to compile and run the example in the Ruby backend README

## Testing
- `go test -tags slow ./compile/rb -run TestRBCompiler_TwoSum -count=1 -v`
- `go test -tags slow ./compile/rb -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685292ed0f3883209bda3f25f83ba1b6