### PR TITLE
Improve Swift compiler parameter handling

### DIFF
--- a/tests/compiler/swift/closure.swift.out
+++ b/tests/compiler/swift/closure.swift.out
@@ -1,7 +1,7 @@
 import Foundation
 
 func makeAdder(_ n: Int) -> (Int) -> Int {
-	var n = n
+	let n = n
 	
 	return { (x: Int) -> Int in
 		return x + n

--- a/tests/compiler/swift/if_else.swift.out
+++ b/tests/compiler/swift/if_else.swift.out
@@ -1,7 +1,7 @@
 import Foundation
 
 func foo(_ n: Int) -> Int {
-	var n = n
+	let n = n
 	
 	if n < 0 {
 		return -1

--- a/tests/compiler/swift/list_prepend.swift.out
+++ b/tests/compiler/swift/list_prepend.swift.out
@@ -1,7 +1,7 @@
 import Foundation
 
 func prepend(_ level: [Int], _ result: [[Int]]) -> [[Int]] {
-	var level = level
+	let level = level
 	var result = result
 	
 	result = [level] + result

--- a/tests/compiler/swift/matrix_search.swift.out
+++ b/tests/compiler/swift/matrix_search.swift.out
@@ -1,8 +1,8 @@
 import Foundation
 
 func searchMatrix(_ matrix: [[Int]], _ target: Int) -> Bool {
-	var matrix = matrix
-	var target = target
+	let matrix = matrix
+	let target = target
 	
 	let m = matrix.count
 	if m == 0 {

--- a/tests/compiler/swift/simple_fn.swift.out
+++ b/tests/compiler/swift/simple_fn.swift.out
@@ -1,7 +1,7 @@
 import Foundation
 
 func id(_ x: Int) -> Int {
-	var x = x
+	let x = x
 	
 	return x
 }

--- a/tests/compiler/swift/two_sum.swift.out
+++ b/tests/compiler/swift/two_sum.swift.out
@@ -1,8 +1,8 @@
 import Foundation
 
 func twoSum(_ nums: [Int], _ target: Int) -> [Int] {
-	var nums = nums
-	var target = target
+	let nums = nums
+	let target = target
 	
 	let n = nums.count
 	for i in 0..<n {


### PR DESCRIPTION
## Summary
- allow Swift codegen to use `let` for parameters that aren't mutated
- update Swift backend golden tests to reflect the new output

## Testing
- `go test ./compile/swift -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68529300751c83209efb252d5e8cdb5b