### PR TITLE
Enable automatic Zig install for tests

### DIFF
--- a/compile/zig/README.md
+++ b/compile/zig/README.md
@@ -233,10 +233,13 @@ func EnsureZig() (string, error) {
         if path, err := exec.LookPath("zig"); err == nil {
                 return path, nil
         }
-        if _, err := os.Stat("../../zig-x86_64-linux-0.14.1/zig"); err == nil {
-                return "../../zig-x86_64-linux-0.14.1/zig", nil
+        dir := filepath.Join(os.TempDir(), "zig-0.12.0")
+        bin := filepath.Join(dir, "zig")
+        if _, err := os.Stat(bin); err == nil {
+                return bin, nil
         }
-        return "", fmt.Errorf("zig not installed")
+        // download and install Zig if missing
+        // (see tools.go for full implementation)
 }
 ```
 【F:compile/zig/tools.go†L1-L17】

--- a/compile/zig/tools.go
+++ b/compile/zig/tools.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 )
 
 // EnsureZig verifies that the Zig compiler is installed.
@@ -11,8 +13,45 @@ func EnsureZig() (string, error) {
 	if path, err := exec.LookPath("zig"); err == nil {
 		return path, nil
 	}
-	if _, err := os.Stat("../../zig-x86_64-linux-0.14.1/zig"); err == nil {
-		return "../../zig-x86_64-linux-0.14.1/zig", nil
+
+	dir := filepath.Join(os.TempDir(), "zig-0.12.0")
+	bin := filepath.Join(dir, "zig")
+	if _, err := os.Stat(bin); err == nil {
+		return bin, nil
 	}
-	return "", fmt.Errorf("zig not installed")
+
+	fmt.Println("\U0001F98E Installing Zig 0.12.0...")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+
+	var url string
+	switch runtime.GOOS {
+	case "linux":
+		if runtime.GOARCH == "arm64" || runtime.GOARCH == "aarch64" {
+			url = "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz"
+		} else {
+			url = "https://ziglang.org/download/0.12.0/zig-linux-x86_64-0.12.0.tar.xz"
+		}
+	case "darwin":
+		if runtime.GOARCH == "arm64" {
+			url = "https://ziglang.org/download/0.12.0/zig-macos-aarch64-0.12.0.tar.xz"
+		} else {
+			url = "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz"
+		}
+	default:
+		return "", fmt.Errorf("unsupported platform: %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	tarPath := filepath.Join(dir, "zig.tar.xz")
+	if out, err := exec.Command("curl", "-fsSL", "-o", tarPath, url).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("download zig: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("tar", "-C", dir, "--strip-components=1", "-xf", tarPath).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("extract zig: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(bin); err != nil {
+		return "", fmt.Errorf("zig not installed")
+	}
+	return bin, nil
 }


### PR DESCRIPTION
## Summary
- improve Zig tool helper to download Zig 0.12.0 automatically
- update README snippet to match new `EnsureZig` logic

## Testing
- `go test ./compile/zig -run TestZigCompiler_TwoSum -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_68529302a7c48320b9b7c26f5fd4f79b