### PR TITLE
Fix Smalltalk backend expression statements

### DIFF
--- a/compile/st/compiler.go
+++ b/compile/st/compiler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"mochi/parser"
@@ -139,7 +138,7 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 			return err
 		}
 		if expr != "" {
-			c.writeln(expr)
+			c.writeln(expr + ".")
 		}
 	}
 	return nil
@@ -327,14 +326,14 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		args[i] = "(" + v + ")"
+		args[i] = v
 	}
 	switch name {
 	case "print":
 		if len(args) != 1 {
 			return "", fmt.Errorf("print expects 1 arg")
 		}
-		return fmt.Sprintf("Transcript show: %s printString; cr", args[0]), nil
+		return fmt.Sprintf("%s displayOn: Transcript. Transcript cr", args[0]), nil
 	case "len":
 		if len(args) != 1 {
 			return "", fmt.Errorf("len expects 1 arg")
@@ -347,10 +346,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		parts := []string{"Main", name + ":"}
 		for i, p := range params {
+			arg := fmt.Sprintf("(%s)", args[i])
 			if i == 0 {
-				parts = append(parts, args[0])
+				parts = append(parts, arg)
 			} else {
-				parts = append(parts, fmt.Sprintf("%s: %s", p, args[i]))
+				parts = append(parts, fmt.Sprintf("%s: %s", p, arg))
 			}
 		}
 		return strings.Join(parts, " "), nil
@@ -379,7 +379,8 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 		}
 		return "false", nil
 	case l.Str != nil:
-		return strconv.Quote(*l.Str), nil
+		s := strings.ReplaceAll(*l.Str, "'", "''")
+		return "'" + s + "'", nil
 	}
 	return "", fmt.Errorf("unknown literal")
 }

--- a/tests/compiler/st/for_loop.st.out
+++ b/tests/compiler/st/for_loop.st.out
@@ -2,6 +2,6 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !!
 1 to: 4 - 1 do: [:i |
-	Transcript show: (i) printString; cr
+	i displayOn: Transcript. Transcript cr.
 ]
 .

--- a/tests/compiler/st/if_else.st.out
+++ b/tests/compiler/st/if_else.st.out
@@ -3,8 +3,8 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 !!
 x := 5.
 ((x > 3)) ifTrue: [
-	Transcript show: ("big") printString; cr
+	'big' displayOn: Transcript. Transcript cr.
 ] ifFalse: [
-	Transcript show: ("small") printString; cr
+	'small' displayOn: Transcript. Transcript cr.
 ]
 .

--- a/tests/compiler/st/let_and_print.st.out
+++ b/tests/compiler/st/let_and_print.st.out
@@ -3,4 +3,4 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 !!
 a := 10.
 b := 20.
-Transcript show: ((a + b)) printString; cr
+(a + b) displayOn: Transcript. Transcript cr.

--- a/tests/compiler/st/list_index.st.out
+++ b/tests/compiler/st/list_index.st.out
@@ -2,4 +2,4 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !!
 xs := Array with: 10 with: 20 with: 30.
-Transcript show: ((xs at: 1 + 1)) printString; cr
+(xs at: 1 + 1) displayOn: Transcript. Transcript cr.

--- a/tests/compiler/st/two_sum.st.out
+++ b/tests/compiler/st/two_sum.st.out
@@ -2,7 +2,7 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 twoSum: nums target: target | i j n |
-	n := (nums) size.
+	n := nums size.
 	0 to: n - 1 do: [:i |
 		(i + 1) to: n - 1 do: [:j |
 			((((nums at: i + 1) + (nums at: j + 1)) = target)) ifTrue: [
@@ -18,5 +18,5 @@ twoSum: nums target: target | i j n |
 
 !!
 result := Main twoSum: (Array with: 2 with: 7 with: 11 with: 15) target: (9).
-Transcript show: ((result at: 0 + 1)) printString; cr
-Transcript show: ((result at: 1 + 1)) printString; cr
+(result at: 0 + 1) displayOn: Transcript. Transcript cr.
+(result at: 1 + 1) displayOn: Transcript. Transcript cr.

--- a/tests/compiler/st/while_loop.st.out
+++ b/tests/compiler/st/while_loop.st.out
@@ -3,7 +3,7 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 !!
 i := 0.
 [(i < 3)] whileTrue: [
-	Transcript show: (i) printString; cr
+	i displayOn: Transcript. Transcript cr.
 	i := (i + 1).
 ]
 .


### PR DESCRIPTION
## Summary
- ensure Smalltalk compiler emits trailing dots for expression statements
- quote string literals using single quotes
- update `print` implementation and function call formatting
- refresh Smalltalk golden test outputs

## Testing
- `go test ./compile/st -tags=slow -run SubsetPrograms -count=1 -v`
- `go test ./compile/st -tags=slow -run GoldenOutput -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_685292fcb14c8320b3f2aea3e01c3d31