### PR TITLE
Enable early return in Prolog backend

### DIFF
--- a/compile/pl/compiler_test.go
+++ b/compile/pl/compiler_test.go
@@ -21,7 +21,6 @@ func TestPrologCompiler_LeetCode1(t *testing.T) {
 	if err := plcode.EnsureSWIPL(); err != nil {
 		t.Skipf("swipl not installed: %v", err)
 	}
-	t.Skip("two-sum example not yet supported")
 	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)
 	if err != nil {

--- a/tests/compiler/pl/if_else.pl.out
+++ b/tests/compiler/pl/if_else.pl.out
@@ -1,24 +1,33 @@
 :- style_check(-singleton).
-	foo(N, Res) :-
-	(N < 0 ->
-		_V0 is -(1),
-		Res = _V0, !
-	;
-		(N =:= 0 ->
-			Res = 0, !
+		foo(N, Res) :-
+			catch(
+				(
+		(N < 0 ->
+			_V0 is -(1),
+			throw(return(_V0))
 		;
-			Res = 1, !
+			(N =:= 0 ->
+				throw(return(0))
+			;
+				throw(return(1))
+			)
 		)
-	)
-	.
+					,
+					true
+				)
+				, return(_V1),
+					Res = _V1
+				)
+			.
 
 	main :-
-	_V1 is -(2),
-	foo(_V1, _V2),
-	writeln(_V2),
-	foo(0, _V3),
+	_V2 is -(2),
+	foo(_V2, _V3),
 	writeln(_V3),
-	foo(3, _V4),
-	writeln(_V4)
+	foo(0, _V4),
+	writeln(_V4),
+	foo(3, _V5),
+	writeln(_V5)
 	.
 :- initialization(main, main).
+


### PR DESCRIPTION
## Summary
- allow functions compiled to Prolog to exit early via `throw/1` and `catch/3`
- update `return` compilation logic
- unskip the LeetCode two-sum test and refresh golden output
- document the new mechanism in the Prolog backend README

## Testing
- `go test ./compile/pl -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685292e744388320887948a598e18f59