### PR TITLE
Add LeetCode test and variable type tracking in C backend

### DIFF
--- a/compile/c/leetcode_test.go
+++ b/compile/c/leetcode_test.go
@@ -1,0 +1,68 @@
+package ccode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ccode "mochi/compile/c"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func runLeet(t *testing.T, id int) {
+	t.Helper()
+	cc, err := ccode.EnsureCC()
+	if err != nil {
+		t.Skipf("C compiler not installed: %v", err)
+	}
+	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(id))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	for _, f := range files {
+		name := fmt.Sprintf("%d/%s", id, filepath.Base(f))
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(f)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			c := ccode.New(env)
+			code, err := c.Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			cfile := filepath.Join(tmp, "main.c")
+			if err := os.WriteFile(cfile, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			exe := filepath.Join(tmp, "main")
+			if out, err := exec.Command(cc, cfile, "-o", exe).CombinedOutput(); err != nil {
+				t.Fatalf("cc error: %v\n%s", err, out)
+			}
+			cmd := exec.Command(exe)
+			if data, err := os.ReadFile(strings.TrimSuffix(f, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("run error: %v\n%s", err, out)
+			} else {
+				_ = out
+			}
+		})
+	}
+}
+
+func TestCCompiler_LeetCodeExamples(t *testing.T) {
+	runLeet(t, 1)
+}


### PR DESCRIPTION
## Summary
- track local variable types in the C compiler so list operations work
- add helper test to compile and run LeetCode examples by ID
- verify LeetCode problem 1 compiles and runs with the C backend

## Testing
- `go test ./compile/c -run TestCCompiler_LeetCodeExamples -tags slow -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68529ec439b483208298d465c2ef3513