### PR TITLE
Add Clojure LeetCode example helper and operator fixes

### DIFF
--- a/compile/clj/compiler.go
+++ b/compile/clj/compiler.go
@@ -273,17 +273,24 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 	}
 	expr := left
 	for _, op := range b.Right {
-               rhs, err := c.compilePostfix(op.Right)
-               if err != nil {
-                       return "", err
-               }
-                opName := op.Op
-                if opName == "%" {
-                        opName = "mod"
-                }
-                expr = fmt.Sprintf("(%s %s %s)", opName, expr, rhs)
-       }
-       return expr, nil
+		rhs, err := c.compilePostfix(op.Right)
+		if err != nil {
+			return "", err
+		}
+		opName := op.Op
+		switch opName {
+		case "%":
+			opName = "mod"
+		case "&&":
+			opName = "and"
+		case "||":
+			opName = "or"
+		case "!=":
+			opName = "not="
+		}
+		expr = fmt.Sprintf("(%s %s %s)", opName, expr, rhs)
+	}
+	return expr, nil
 }
 
 func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
@@ -293,7 +300,11 @@ func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
 	}
 	for i := len(u.Ops) - 1; i >= 0; i-- {
 		op := u.Ops[i]
-		expr = fmt.Sprintf("(%s %s)", op, expr)
+		name := op
+		if name == "!" {
+			name = "not"
+		}
+		expr = fmt.Sprintf("(%s %s)", name, expr)
 	}
 	return expr, nil
 }

--- a/compile/clj/compiler_test.go
+++ b/compile/clj/compiler_test.go
@@ -109,3 +109,52 @@ func TestClojureCompiler_GoldenOutput(t *testing.T) {
 		return bytes.TrimSpace(code), nil
 	})
 }
+
+// runLeetExample compiles the Mochi LeetCode solution for the given ID and runs
+// the generated Clojure code. Any output is ignored; the test only checks that
+// the program executes without error.
+func runLeetExample(t *testing.T, id int) {
+	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(id))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	for _, f := range files {
+		name := fmt.Sprintf("%d/%s", id, filepath.Base(f))
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(f)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			c := cljcode.New(env)
+			code, err := c.Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.clj")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("clojure", file)
+			if data, err := os.ReadFile(strings.TrimSuffix(f, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("clojure run error: %v\n%s", err, out)
+			}
+		})
+	}
+}
+
+func TestClojureCompiler_LeetCodeExamples(t *testing.T) {
+	if err := cljcode.EnsureClojure(); err != nil {
+		t.Skipf("clojure not installed: %v", err)
+	}
+	runLeetExample(t, 1)
+}


### PR DESCRIPTION
## Summary
- add helper test to compile and run Clojure LeetCode programs by ID
- support logical/not operators in Clojure compiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68529ec99f788320b71e520ae5506965