### PR TITLE
Fix Dart compiler precedence and add leetcode tests

### DIFF
--- a/compile/dart/leetcode_test.go
+++ b/compile/dart/leetcode_test.go
@@ -1,0 +1,81 @@
+//go:build slow
+
+package dartcode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dartcode "mochi/compile/dart"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// compileAndRunLeetCode compiles the Mochi solution for the given problem ID and
+// executes the generated Dart code, returning stdout.
+func compileAndRunLeetCode(t *testing.T, id string) string {
+	t.Helper()
+	root := findRoot(t)
+	dir := filepath.Join(root, "examples", "leetcode", id)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var src string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".mochi") {
+			src = filepath.Join(dir, e.Name())
+			break
+		}
+	}
+	if src == "" {
+		t.Fatalf("no mochi source for id %s", id)
+	}
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := dartcode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "main.dart")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("dart", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dart run error: %v\n%s", err, out)
+	}
+	return strings.ReplaceAll(string(out), "\r\n", "\n")
+}
+
+func TestLeetCode1(t *testing.T) {
+	if err := dartcode.EnsureDart(); err != nil {
+		t.Skipf("dart not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "1"))
+	if got != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode2(t *testing.T) {
+	if err := dartcode.EnsureDart(); err != nil {
+		t.Skipf("dart not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "2"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- fix binary operator precedence in the Dart compiler by applying precedence rules
- add helper to compile and run LeetCode solutions
- test Dart compilation for LeetCode problems 1 and 2

## Testing
- `go test ./...`
- `go test ./compile/dart -tags slow -run TestLeetCode1 -v`
- `go test ./compile/dart -tags slow -run TestLeetCode2 -v`


------
https://chatgpt.com/codex/tasks/task_e_68529ed8447c8320bc19e3beb6272516