### PR TITLE
Add Elixir compiler tests for LeetCode examples

### DIFF
--- a/compile/ex/compiler_test.go
+++ b/compile/ex/compiler_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -69,4 +70,50 @@ func TestExCompiler_GoldenOutput(t *testing.T) {
 		}
 		return bytes.TrimSpace(code), nil
 	})
+}
+
+func runExample(t *testing.T, id int) {
+	dir := filepath.Join("..", "..", "examples", "leetcode", strconv.Itoa(id))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	for _, f := range files {
+		name := fmt.Sprintf("%d/%s", id, filepath.Base(f))
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(f)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := excode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.exs")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("elixir", file)
+			if data, err := os.ReadFile(strings.TrimSuffix(f, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("elixir run error: %v\n%s", err, out)
+			}
+			_ = out
+		})
+	}
+}
+
+func TestExCompiler_LeetCode1(t *testing.T) {
+	if err := excode.EnsureElixir(); err != nil {
+		t.Skipf("elixir not installed: %v", err)
+	}
+	runExample(t, 1)
 }


### PR DESCRIPTION
## Summary
- support map indexing in the Elixir backend
- add helper to run LeetCode examples in tests
- test compiling LeetCode problem 1 using the Elixir backend

## Testing
- `go test ./... -run TestExCompiler_LeetCode1 -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68529edd6da483209fd4ea2e9eeae1fa