### PR TITLE
Add LeetCode helper for Fortran backend tests

### DIFF
--- a/compile/fortran/compiler_test.go
+++ b/compile/fortran/compiler_test.go
@@ -17,40 +17,7 @@ import (
 )
 
 func TestFortranCompiler_TwoSum(t *testing.T) {
-	gfortran, err := ftncode.EnsureFortran()
-	if err != nil {
-		t.Skipf("gfortran not installed: %v", err)
-	}
-	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := ftncode.New().Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	dir := t.TempDir()
-	ffile := filepath.Join(dir, "prog.f90")
-	if err := os.WriteFile(ffile, code, 0644); err != nil {
-		t.Fatalf("write error: %v", err)
-	}
-	exe := filepath.Join(dir, "prog")
-	if out, err := exec.Command(gfortran, ffile, "-o", exe).CombinedOutput(); err != nil {
-		t.Fatalf("gfortran error: %v\n%s", err, out)
-	}
-	out, err := exec.Command(exe).CombinedOutput()
-	if err != nil {
-		t.Fatalf("run error: %v\n%s", err, out)
-	}
-	lines := bytes.Fields(out)
-	if len(lines) != 2 || string(lines[0]) != "0" || string(lines[1]) != "1" {
-		t.Fatalf("unexpected output: %s", out)
-	}
+	runFortranLeetExample(t, "1")
 }
 
 func TestFortranCompiler_GoldenOutput(t *testing.T) {
@@ -108,4 +75,83 @@ func TestFortranCompiler_SubsetPrograms(t *testing.T) {
 		fields := bytes.Fields(out)
 		return bytes.Join(fields, []byte("\n")), nil
 	})
+}
+
+// runFortranLeetExample compiles and executes the Mochi LeetCode example with
+// the given ID. The example directory is expected to contain a single `.mochi`
+// source file whose output is printed to stdout. For the two-sum problem
+// (leetcode/1) the expected output is `0\n1`.
+func runFortranLeetExample(t *testing.T, id string) {
+	gfortran, err := ftncode.EnsureFortran()
+	if err != nil {
+		t.Skipf("gfortran not installed: %v", err)
+	}
+	root := findRoot(t)
+	dir := filepath.Join(root, "examples", "leetcode", id)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir error: %v", err)
+	}
+	var src string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".mochi" {
+			src = filepath.Join(dir, e.Name())
+			break
+		}
+	}
+	if src == "" {
+		t.Fatalf("no .mochi file found in %s", dir)
+	}
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := ftncode.New().Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	tmp := t.TempDir()
+	ffile := filepath.Join(tmp, "prog.f90")
+	if err := os.WriteFile(ffile, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	exe := filepath.Join(tmp, "prog")
+	if out, err := exec.Command(gfortran, ffile, "-o", exe).CombinedOutput(); err != nil {
+		t.Fatalf("gfortran error: %v\n%s", err, out)
+	}
+	out, err := exec.Command(exe).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run error: %v\n%s", err, out)
+	}
+	fields := bytes.Fields(out)
+	got := string(bytes.Join(fields, []byte("\n")))
+	if id == "1" {
+		if got != "0\n1" {
+			t.Fatalf("unexpected output: %q", got)
+		}
+	}
+}
+
+// findRoot returns the repository root directory by locating go.mod.
+func findRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
 }


### PR DESCRIPTION
## Summary
- add `runFortranLeetExample` helper
- use helper in `TestFortranCompiler_TwoSum`

## Testing
- `go test ./compile/fortran -run TwoSum -tags slow`
- `go test ./compile/fortran -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68529ee0a418832099b2ccbbb9775363