### PR TITLE
Add Haskell LeetCode runner test

### DIFF
--- a/compile/hs/compiler.go
+++ b/compile/hs/compiler.go
@@ -39,12 +39,17 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.writeln("main :: IO ()")
 	c.writeln("main = do")
 	c.indent++
+	mainStmts := 0
 	for _, s := range prog.Statements {
 		if s.Fun == nil && s.Type == nil && s.Test == nil {
 			if err := c.compileMainStmt(s); err != nil {
 				return nil, err
 			}
+			mainStmts++
 		}
+	}
+	if mainStmts == 0 {
+		c.writeln("return ()")
 	}
 	c.indent--
 


### PR DESCRIPTION
## Summary
- support empty programs in Haskell backend by emitting `return ()` for an empty `main`
- add `runExample` helper and new `TestHSCompiler_LeetCodeExamples`

## Testing
- `go test ./compile/hs -run LeetCodeExamples -tags slow -count=1 -v`
- `go test ./compile/hs -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68529ee503ac8320bc259ac69698d969