### PR TITLE
Add helper to run Kotlin LeetCode examples

### DIFF
--- a/compile/kt/compiler.go
+++ b/compile/kt/compiler.go
@@ -577,6 +577,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			}
 			elems = append(elems, ce)
 		}
+		if len(elems) == 0 {
+			return "mutableListOf()", nil
+		}
 		return "listOf(" + joinArgs(elems) + ")", nil
 	case p.Map != nil:
 		items := []string{}


### PR DESCRIPTION
## Summary
- support empty list literals in the Kotlin backend
- add `runKTProgram` and `runKTLeetExample` helpers for tests
- test compiling and running LeetCode example 1

## Testing
- `go test ./compile/kt -run LeetCode -tags slow -count=1`
- `go test ./... -tags slow -run LeetCode -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68529eea96a08320a82e39ad8a98bcfc