### PR TITLE
Add Lua LeetCode run helper

### DIFF
--- a/compile/lua/compiler_test.go
+++ b/compile/lua/compiler_test.go
@@ -147,3 +147,51 @@ func TestLuaCompiler_GoldenOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestLuaCompiler_LeetCodeExamples(t *testing.T) {
+	if err := luacode.EnsureLua(); err != nil {
+		t.Skipf("lua not installed: %v", err)
+	}
+	runLeetCode(t, 1)
+	runLeetCode(t, 2)
+}
+
+func runLeetCode(t *testing.T, id int) {
+	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(id))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	for _, src := range files {
+		name := fmt.Sprintf("%d/%s", id, filepath.Base(src))
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			c := luacode.New(env)
+			code, err := c.Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.lua")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("lua", file)
+			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("lua run error: %v\n%s", err, out)
+			}
+			_ = out
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- test Lua compilation/running of LeetCode solutions
- add helper to run examples

## Testing
- `go test -tags slow ./compile/lua -run TestLuaCompiler_LeetCodeExamples -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68529eec24348320a05b7f95d51575cd