### PR TITLE
Add OCaml LeetCode example runner

### DIFF
--- a/compile/ocaml/compiler.go
+++ b/compile/ocaml/compiler.go
@@ -173,7 +173,11 @@ func (c *Compiler) compileFor(f *parser.ForStmt, ex string) error {
 			}
 		}
 		c.indent--
-		c.writeln(fmt.Sprintf(") %s;", src))
+		if ex == "" {
+			c.writeln(fmt.Sprintf(") %s;;", src))
+		} else {
+			c.writeln(fmt.Sprintf(") %s;", src))
+		}
 		return nil
 	}
 	start, err := c.compileExpr(f.Source)
@@ -192,7 +196,11 @@ func (c *Compiler) compileFor(f *parser.ForStmt, ex string) error {
 		}
 	}
 	c.indent--
-	c.writeln("done;")
+	if ex == "" {
+		c.writeln("done;;")
+	} else {
+		c.writeln("done;")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- handle top-level `for` loops correctly in the OCaml backend
- add helper for running LeetCode examples
- test compiling and running `leetcode/1`

## Testing
- `go test ./compile/ocaml -tags slow -run LeetCodeExamples -v`

------
https://chatgpt.com/codex/tasks/task_e_68529eef3a48832096c558b440289ab0