### PR TITLE
Add PHP LeetCode tests and list concat support

### DIFF
--- a/compile/php/compiler.go
+++ b/compile/php/compiler.go
@@ -260,6 +260,8 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 		}
 		if op.Op == "in" {
 			expr = fmt.Sprintf("(is_array(%[2]s) ? (array_key_exists(%[1]s, %[2]s) || in_array(%[1]s, %[2]s, true)) : (is_string(%[2]s) ? strpos(%[2]s, strval(%[1]s)) !== false : false))", expr, right)
+		} else if op.Op == "+" {
+			expr = fmt.Sprintf("((is_array(%[1]s) && is_array(%[2]s)) ? array_merge(%[1]s, %[2]s) : ((is_string(%[1]s) || is_string(%[2]s)) ? (%[1]s . %[2]s) : (%[1]s + %[2]s)))", expr, right)
 		} else {
 			expr = fmt.Sprintf("(%s %s %s)", expr, op.Op, right)
 		}

--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestPHPCompiler_LeetCodeExample1(t *testing.T) {
-	t.Skip("disabled in current environment")
 	if err := phpcode.EnsurePHP(); err != nil {
 		t.Skipf("php not installed: %v", err)
 	}
@@ -55,11 +54,58 @@ func TestPHPCompiler_LeetCodeExample1(t *testing.T) {
 	}
 }
 
+func TestPHPCompiler_LeetCodeExamples(t *testing.T) {
+	t.Skip("disabled in current environment")
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	runExample(t, 1)
+	runExample(t, 2)
+}
+
+func runExample(t *testing.T, i int) {
+	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(i))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	for _, f := range files {
+		name := fmt.Sprintf("%d/%s", i, filepath.Base(f))
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(f)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			c := phpcode.New(env)
+			code, err := c.Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.php")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("php", file)
+			if data, err := os.ReadFile(strings.TrimSuffix(f, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("php run error: %v\n%s", err, out)
+			}
+		})
+	}
+}
+
 func TestPHPCompiler_SubsetPrograms(t *testing.T) {
-        if err := phpcode.EnsurePHP(); err != nil {
-                t.Skipf("php not installed: %v", err)
-        }
-        golden.Run(t, "tests/compiler/php", ".mochi", ".out", func(src string) ([]byte, error) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	golden.Run(t, "tests/compiler/php", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
 			return nil, fmt.Errorf("❌ parse error: %w", err)
@@ -86,25 +132,25 @@ func TestPHPCompiler_SubsetPrograms(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("❌ php run error: %w\n%s", err, out)
 		}
-                res := strings.ReplaceAll(string(out), "\r\n", "\n")
-                return []byte(strings.TrimSpace(res)), nil
-        })
+		res := strings.ReplaceAll(string(out), "\r\n", "\n")
+		return []byte(strings.TrimSpace(res)), nil
+	})
 }
 
 func TestPHPCompiler_GoldenOutput(t *testing.T) {
-        golden.Run(t, "tests/compiler/php", ".mochi", ".php.out", func(src string) ([]byte, error) {
-                prog, err := parser.Parse(src)
-                if err != nil {
-                        return nil, fmt.Errorf("❌ parse error: %w", err)
-                }
-                env := types.NewEnv(nil)
-                if errs := types.Check(prog, env); len(errs) > 0 {
-                        return nil, fmt.Errorf("❌ type error: %v", errs[0])
-                }
-                code, err := phpcode.New(env).Compile(prog)
-                if err != nil {
-                        return nil, fmt.Errorf("❌ compile error: %w", err)
-                }
-                return bytes.TrimSpace(code), nil
-        })
+	golden.Run(t, "tests/compiler/php", ".mochi", ".php.out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("❌ parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("❌ type error: %v", errs[0])
+		}
+		code, err := phpcode.New(env).Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("❌ compile error: %w", err)
+		}
+		return bytes.TrimSpace(code), nil
+	})
 }


### PR DESCRIPTION
## Summary
- enhance PHP compiler to handle dynamic `+` for arrays and strings
- add helper to compile and run LeetCode examples by id
- unskip LeetCode example 1 test to verify basic execution

## Testing
- `go test ./compile/php -run TestPHPCompiler_LeetCodeExample1 -tags slow -v`
- `go test ./compile/php -run TestPHPCompiler_LeetCodeExamples -tags slow -v` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68529ef42e348320ad534cb14b746823