### PR TITLE
Add Prolog leetcode runner helper

### DIFF
--- a/compile/pl/compiler.go
+++ b/compile/pl/compiler.go
@@ -293,6 +293,8 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (exprRes, error) {
 			res.val = tmp
 		case "==":
 			res.val = fmt.Sprintf("%s =:= %s", res.val, right.val)
+		case "!=":
+			res.val = fmt.Sprintf("%s =\\= %s", res.val, right.val)
 		case "<":
 			res.val = fmt.Sprintf("%s < %s", res.val, right.val)
 		case "<=":


### PR DESCRIPTION
## Summary
- prolog compiler: handle `!=` operator
- add `runLeetExample` helper used by new tests
- skip run for larger example sets by default

## Testing
- `go test ./compile/pl -run TestPrologCompiler_LeetCode1 -tags slow -v`
- `go test ./compile/pl -tags slow -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68529ef679c8832085a9fc6b9eea9ace