### PR TITLE
Enhance Java compiler for LeetCode examples

### DIFF
--- a/compile/java/compiler_test.go
+++ b/compile/java/compiler_test.go
@@ -133,3 +133,10 @@ func TestJavaCompiler_LeetCodeExample1(t *testing.T) {
 	}
 	runLeetExample(t, 1)
 }
+
+func TestJavaCompiler_LeetCodeExample2(t *testing.T) {
+	if err := javacode.EnsureJavac(); err != nil {
+		t.Skipf("javac not installed: %v", err)
+	}
+	runLeetExample(t, 2)
+}


### PR DESCRIPTION
## Summary
- support list concatenation in the Java compiler
- add `_concat` helper runtime function
- run LeetCode examples 1 and 2 in Java tests

## Testing
- `go test ./compile/java -run TestJavaCompiler_LeetCodeExample2 -tags slow -count=1`
- `go test ./compile/java -run TestJavaCompiler_LeetCodeExample -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852a73ef37883208b7cb0492f321453