### PR TITLE
Enable C backend for leetcode 2

### DIFF
--- a/compile/c/README.md
+++ b/compile/c/README.md
@@ -52,3 +52,7 @@ go test ./compile/c -tags slow
 ```
 
 They compile example programs from `tests/compiler/c` and compare the results.【F:compile/c/compiler_test.go†L71-L108】
+
+The separate `leetcode_test.go` file compiles and executes the first two
+LeetCode solutions under `examples/leetcode/1` and `examples/leetcode/2`
+using the C backend.

--- a/compile/c/compiler.go
+++ b/compile/c/compiler.go
@@ -425,6 +425,26 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 				case types.FloatType:
 					typ = "double"
 				}
+			} else {
+				if isListListExpr(s.Var.Value, c.env) {
+					typ = "list_list_int"
+				} else if isListIntExpr(s.Var.Value, c.env) {
+					typ = "list_int"
+				} else if isStringExpr(s.Var.Value, c.env) {
+					typ = "char*"
+				} else if isFloatArg(s.Var.Value, c.env) {
+					typ = "double"
+				}
+			}
+		} else {
+			if isListListExpr(s.Var.Value, nil) {
+				typ = "list_list_int"
+			} else if isListIntExpr(s.Var.Value, nil) {
+				typ = "list_int"
+			} else if isStringExpr(s.Var.Value, nil) {
+				typ = "char*"
+			} else if isFloatArg(s.Var.Value, nil) {
+				typ = "double"
 			}
 		}
 		if s.Var.Value != nil {
@@ -1093,6 +1113,9 @@ func isListIntPrimary(p *parser.Primary, env *types.Env) bool {
 						if _, ok := lt.Elem.(types.IntType); ok {
 							return true
 						}
+					}
+					if _, ok := t.(types.IntType); ok {
+						return true
 					}
 				}
 			}

--- a/compile/c/leetcode_test.go
+++ b/compile/c/leetcode_test.go
@@ -64,5 +64,7 @@ func runLeet(t *testing.T, id int) {
 }
 
 func TestCCompiler_LeetCodeExamples(t *testing.T) {
-	runLeet(t, 1)
+	for i := 1; i <= 2; i++ {
+		runLeet(t, i)
+	}
 }


### PR DESCRIPTION
## Summary
- allow the C backend tests to compile leetcode problems 1 and 2
- infer list types from int variables for list literals
- document leetcode tests in the C backend README

## Testing
- `go test ./compile/c`


------
https://chatgpt.com/codex/tasks/task_e_6852a723d2d08320b582110c03192013