### PR TITLE
Remove Cobol helper command

### DIFF
--- a/compile/cobol/README.md
+++ b/compile/cobol/README.md
@@ -68,6 +68,14 @@ cobc -free -x two-sum.cob -o two-sum
 ./two-sum    # prints "0" and then "1"
 ```
 
+The compiler tests include a helper that compiles and executes the first two
+LeetCode examples using the COBOL backend. Run the tests with the `slow` build
+tag to try it out:
+
+```bash
+go test ./compile/cobol -tags slow -run LeetCode
+```
+
 `EnsureCOBOL` attempts to install the GNU COBOL toolchain automatically when
 running tests, but you may need to install it manually before using `cobc`
 directly.

--- a/compile/cobol/compiler_test.go
+++ b/compile/cobol/compiler_test.go
@@ -179,7 +179,6 @@ func TestCobolCompiler_GoldenOutput(t *testing.T) {
 // programs from the examples directory. The helper runs all Mochi files under
 // examples/leetcode/<id> using the COBOL backend.
 func TestCobolCompiler_LeetCodeExamples(t *testing.T) {
-	t.Skip("disabled in current environment")
 	if err := cobolcode.EnsureCOBOL(); err != nil {
 		t.Skipf("cobol not installed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- drop `leetcode-cobol` command
- document how to run the LeetCode tests with COBOL
- enable `TestCobolCompiler_LeetCodeExamples` for slow builds

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852a72826a08320993c123d2b09cbc0