### PR TITLE
Add apt-based dotnet install

### DIFF
--- a/compile/cs/tools.go
+++ b/compile/cs/tools.go
@@ -35,12 +35,14 @@ func ensureDotnet() error {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()
-			cmd = exec.Command("apt-get", "install", "-y", "dotnet-sdk-7.0")
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			_ = cmd.Run()
-			if _, err := exec.LookPath("dotnet"); err == nil {
-				return nil
+			for _, pkg := range []string{"dotnet-sdk-8.0", "dotnet-sdk-7.0", "dotnet-sdk-6.0"} {
+				cmd = exec.Command("apt-get", "install", "-y", pkg)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				_ = cmd.Run()
+				if _, err := exec.LookPath("dotnet"); err == nil {
+					return nil
+				}
 			}
 		}
 	}

--- a/compile/fs/tools.go
+++ b/compile/fs/tools.go
@@ -33,12 +33,14 @@ func ensureDotnet() error {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()
-			cmd = exec.Command("apt-get", "install", "-y", "dotnet-sdk-7.0")
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			_ = cmd.Run()
-			if _, err := exec.LookPath("dotnet"); err == nil {
-				return nil
+			for _, pkg := range []string{"dotnet-sdk-8.0", "dotnet-sdk-7.0", "dotnet-sdk-6.0"} {
+				cmd = exec.Command("apt-get", "install", "-y", pkg)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				_ = cmd.Run()
+				if _, err := exec.LookPath("dotnet"); err == nil {
+					return nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- update dotnet setup logic for F# and C# compilers to try apt packages for versions 8.0, 7.0, and 6.0
- test FS LeetCode build now succeeds

## Testing
- `go test ./compile/fs -run TestFSCompiler_LeetCode1 -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_6852a73924ac8320b55f59fc05425290