### PR TITLE
Extend OCaml example tests

### DIFF
--- a/compile/ocaml/compiler_test.go
+++ b/compile/ocaml/compiler_test.go
@@ -120,6 +120,7 @@ func TestOCamlCompiler_GoldenOutput(t *testing.T) {
 
 func TestOCamlCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 1)
+	runExample(t, 2)
 }
 
 func runExample(t *testing.T, i int) {

--- a/tests/compiler/ocaml/two_sum.ml.out
+++ b/tests/compiler/ocaml/two_sum.ml.out
@@ -6,7 +6,7 @@ let rec twoSum nums target =
       for j = i + 1 to n - 1 do
         if (List.nth nums i) + (List.nth nums j) = target then begin
           raise (Return_0 [i; j])
-        end
+        end;
       done;
     done;
     raise (Return_0 [-1; -1])


### PR DESCRIPTION
## Summary
- add second LeetCode example to OCaml compiler tests
- fix OCaml backend handling of list concatenation and modulo
- emit semicolons for `if` statements when needed
- update golden output

## Testing
- `go test ./compile/ocaml -tags slow -run TestOCamlCompiler_LeetCodeExamples -count=1`
- `go test ./compile/ocaml -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852a744d18c83208d23f4bbdef1fa49