### PR TITLE
Enable Prolog backend to run LeetCode 1 and 2

### DIFF
--- a/compile/pl/compiler_test.go
+++ b/compile/pl/compiler_test.go
@@ -51,6 +51,39 @@ func TestPrologCompiler_LeetCode1(t *testing.T) {
 	}
 }
 
+func TestPrologCompiler_LeetCode2(t *testing.T) {
+	if err := plcode.EnsureSWIPL(); err != nil {
+		t.Skipf("swipl not installed: %v", err)
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "2", "add-two-numbers.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := plcode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.pl")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("swipl", "-q", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("swipl error: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
 // runLeetExample compiles the Mochi solution for the given LeetCode ID to
 // Prolog and executes the generated program. The test fails if compilation or
 // execution returns an error.


### PR DESCRIPTION
## Summary
- extend Prolog compiler with support for mutable vars and `while`
- handle arithmetic, logical ops and list concatenation
- add tests for LeetCode problem 2

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852a75265408320a6bc0b22d150cc8c