### PR TITLE
Extend Racket backend for leetcode 2

### DIFF
--- a/compile/rkt/compiler_test.go
+++ b/compile/rkt/compiler_test.go
@@ -114,6 +114,7 @@ func TestRacketCompiler_LeetCodeExamples(t *testing.T) {
 		t.Skipf("racket not installed: %v", err)
 	}
 	runRacketLeetExample(t, 1)
+	runRacketLeetExample(t, 2)
 }
 
 func runRacketLeetExample(t *testing.T, id int) {


### PR DESCRIPTION
## Summary
- add more binary operators to Racket compiler
- fix `compileWhile` paren bug
- run leetcode example 2 in Racket tests

## Testing
- `go test ./compile/rkt -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852a75e209c832086d9a929b8b810e2