### PR TITLE
Add Scala LeetCode example 2 test

### DIFF
--- a/compile/scala/compiler_test.go
+++ b/compile/scala/compiler_test.go
@@ -23,6 +23,12 @@ func TestScalaCompiler_LeetCodeExample1(t *testing.T) {
 	runLeetExample(t, 1)
 }
 
+// TestScalaCompiler_LeetCodeExample2 compiles the add-two-numbers example and
+// verifies the generated Scala program runs without errors.
+func TestScalaCompiler_LeetCodeExample2(t *testing.T) {
+	runLeetExample(t, 2)
+}
+
 func TestScalaCompiler_SubsetPrograms(t *testing.T) {
 	if err := scalacode.EnsureScala(); err != nil {
 		t.Skipf("scala not installed: %v", err)


### PR DESCRIPTION
## Summary
- expand Scala compiler tests to run LeetCode problem 2
- remove Scala-specific Makefile target from the LeetCode examples (reverted)

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852a7639f388320a3167538e1450a26