### PR TITLE
Add var/while support to Zig compiler

### DIFF
--- a/compile/zig/README.md
+++ b/compile/zig/README.md
@@ -183,6 +183,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 
 ### Helpers
 
+Variable declarations with `var` are now supported. Empty list values create a
+`std.ArrayList` for dynamic appends. Assignments of the form `list = list + [x]`
+translate to `list.append(x)`, and `while` statements map directly to Zig's
+`while` syntax.
+
 List literals are emitted as fixed-size arrays or references when used in return
 expressions. Reserved words are prefixed with `_` by `sanitizeName`:
 

--- a/compile/zig/compiler_test.go
+++ b/compile/zig/compiler_test.go
@@ -16,7 +16,7 @@ import (
 	"mochi/types"
 )
 
-func TestZigCompiler_TwoSum(t *testing.T) {
+func TestZigCompiler_LeetCode1to2(t *testing.T) {
 	out, err := runExample(t, 1)
 	if err != nil {
 		t.Fatalf("run error: %v", err)
@@ -25,6 +25,11 @@ func TestZigCompiler_TwoSum(t *testing.T) {
 	want := "0\n1"
 	if got != want {
 		t.Fatalf("unexpected output\nwant:\n%s\n got:\n%s", want, got)
+	}
+
+	_, err = runExample(t, 2)
+	if err != nil {
+		t.Fatalf("run error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend Zig backend to handle `var` declarations, assignments and `while` loops
- translate `list = list + [x]` to `ArrayList.append`
- ignore test/expect blocks when compiling to Zig
- adjust README with new capabilities
- run Zig tests for LeetCode problems 1 and 2

## Testing
- `go test ./compile/zig -tags slow -run TestZigCompiler_LeetCode1to2 -v`

------
https://chatgpt.com/codex/tasks/task_e_6852a772e0d483209f0b7aa787d54fce