### PR TITLE
Add Ruby example tests without Makefile

### DIFF
--- a/compile/rb/README.md
+++ b/compile/rb/README.md
@@ -96,6 +96,17 @@ The program prints the indices of the elements that sum to the target:
 1
 ```
 
+### Example: LeetCode Add Two Numbers
+
+To compile and run the `add-two-numbers` example located in `examples/leetcode/2`, use:
+
+```bash
+mochi build --target rb examples/leetcode/2/add-two-numbers.mochi -o add-two-numbers.rb
+ruby add-two-numbers.rb
+```
+
+This prints the resulting list digits on separate lines.
+
 `tools.go` provides `EnsureRuby` which attempts to install Ruby on Linux or macOS if it is missing:
 
 ```go

--- a/compile/rb/compiler_test.go
+++ b/compile/rb/compiler_test.go
@@ -82,8 +82,9 @@ func TestRBCompiler_LeetCodeExamples(t *testing.T) {
 	if err := rbcode.EnsureRuby(); err != nil {
 		t.Skipf("ruby not installed: %v", err)
 	}
-	runLeetExample(t, 1)
-	runLeetExample(t, 2)
+	for i := 1; i <= 2; i++ {
+		runLeetExample(t, i)
+	}
 }
 
 func TestRBCompiler_SubsetPrograms(t *testing.T) {


### PR DESCRIPTION
## Summary
- revert Makefile run-rb entry and docs
- show how to run the Ruby add-two-numbers example manually
- loop through LeetCode problems 1-2 in `TestRBCompiler_LeetCodeExamples`

## Testing
- `go test ./compile/rb -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852a75ae0908320ac5b5e499bdbc479