### PR TITLE
Add Erlang example tests

### DIFF
--- a/compile/erlang/compiler_test.go
+++ b/compile/erlang/compiler_test.go
@@ -17,6 +17,47 @@ import (
 	"mochi/types"
 )
 
+func TestErlangCompiler_TwoSum(t *testing.T) {
+	if err := erlcode.EnsureErlang(); err != nil {
+		t.Skipf("erlang not installed: %v", err)
+	}
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := erlcode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.erl")
+	if err := os.WriteFile(file, code, 0755); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	out, err := exec.Command("escript", file).CombinedOutput()
+	if err != nil {
+		t.Fatalf("escript error: %v\n%s", err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	var filtered []string
+	for _, line := range lines {
+		if strings.Contains(line, "Warning") || strings.HasPrefix(line, "/tmp") {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	got := strings.Join(filtered, "\n")
+	if got != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
 func TestErlangCompiler_LeetCode1(t *testing.T) {
 	if err := erlcode.EnsureErlang(); err != nil {
 		t.Skipf("erlang not installed: %v", err)


### PR DESCRIPTION
## Summary
- revert Erlang entries in the leetcode Makefile and README
- add a TwoSum test for the Erlang backend and run leetcode examples 1 and 2

## Testing
- `go test ./compile/erlang -run TwoSum -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6852a730c4ac8320a950e2dacde75cdb