### PR TITLE
Add C++ LeetCode test helper and revert CLI changes

### DIFF
--- a/compile/cpp/compiler_test.go
+++ b/compile/cpp/compiler_test.go
@@ -26,6 +26,10 @@ func TestCPPCompiler_AddTwoNumbers(t *testing.T) {
 	runCPPLeetExample(t, 2)
 }
 
+func TestCPPCompiler_LeetCodeExamples(t *testing.T) {
+	runCPPLeetRange(t, 1, 2)
+}
+
 func TestCPPCompiler_SubsetPrograms(t *testing.T) {
 	cpp, err := cppcode.EnsureCPP()
 	if err != nil {
@@ -151,5 +155,12 @@ func runCPPLeetExample(t *testing.T, id int) {
 				_ = out
 			}
 		})
+	}
+}
+
+// runCPPLeetRange executes all LeetCode example directories from start to end.
+func runCPPLeetRange(t *testing.T, start, end int) {
+	for i := start; i <= end; i++ {
+		runCPPLeetExample(t, i)
 	}
 }

--- a/compile/rust/compiler.go
+++ b/compile/rust/compiler.go
@@ -629,7 +629,6 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			return fmt.Sprintf("%s::%s { %s }", sanitizeName(unionName), sanitizeName(p.Struct.Name), strings.Join(parts, ", ")), nil
 		}
 		return fmt.Sprintf("%s { %s }", sanitizeName(p.Struct.Name), strings.Join(parts, ", ")), nil
-		return fmt.Sprintf("%s { %s }", sanitizeName(p.Struct.Name), strings.Join(parts, ", ")), nil
 	case p.Query != nil:
 		return c.compileQueryExpr(p.Query)
 	case p.Match != nil:

--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -99,6 +99,9 @@ func TestRustCompiler_ValidPrograms(t *testing.T) {
 	t.Run("leetcode_1", func(t *testing.T) {
 		runRustLeet(t, 1)
 	})
+	t.Run("leetcode_2", func(t *testing.T) {
+		runRustLeet(t, 2)
+	})
 }
 
 func runRustProgram(t *testing.T, src string) {


### PR DESCRIPTION
## Summary
- remove unfinished `leetcode` CLI integration
- run LeetCode examples 1 through 2 in C++ compiler tests

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/mochi`


------
https://chatgpt.com/codex/tasks/task_e_6852a729cff883209248e59ed6cfefd7