### PR TITLE
Add PHP LeetCode sample tests

### DIFF
--- a/compile/php/README.md
+++ b/compile/php/README.md
@@ -252,11 +252,15 @@ php main.php
 ```
 
 For example, to run the [two-sum](../../examples/leetcode/1/two-sum.mochi)
-LeetCode solution you can compile and execute it directly:
+or [add-two-numbers](../../examples/leetcode/2/add-two-numbers.mochi)
+LeetCode solutions you can compile and execute them directly:
 
 ```bash
 mochi build --target php ../../examples/leetcode/1/two-sum.mochi -o two-sum.php
 php two-sum.php
+
+mochi build --target php ../../examples/leetcode/2/add-two-numbers.mochi -o add-two-numbers.php
+php add-two-numbers.php
 ```
 
 ## Tests

--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -55,7 +55,6 @@ func TestPHPCompiler_LeetCodeExample1(t *testing.T) {
 }
 
 func TestPHPCompiler_LeetCodeExamples(t *testing.T) {
-	t.Skip("disabled in current environment")
 	if err := phpcode.EnsurePHP(); err != nil {
 		t.Skipf("php not installed: %v", err)
 	}

--- a/examples/leetcode-out/php/1/two-sum.php
+++ b/examples/leetcode-out/php/1/two-sum.php
@@ -1,0 +1,16 @@
+<?php
+function twoSum($nums, $target) {
+	$n = count($nums);
+	for ($i = 0; $i < $n; $i++) {
+		for ($j = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))); $j < $n; $j++) {
+			if ((((is_array($nums[$i]) && is_array($nums[$j])) ? array_merge($nums[$i], $nums[$j]) : ((is_string($nums[$i]) || is_string($nums[$j])) ? ($nums[$i] . $nums[$j]) : ($nums[$i] + $nums[$j]))) == $target)) {
+				return [$i, $j];
+			}
+		}
+	}
+	return [-1, -1];
+}
+
+$result = twoSum([2, 7, 11, 15], 9);
+echo $result[0], PHP_EOL;
+echo $result[1], PHP_EOL;

--- a/examples/leetcode-out/php/2/add-two-numbers.php
+++ b/examples/leetcode-out/php/2/add-two-numbers.php
@@ -1,0 +1,25 @@
+<?php
+function addTwoNumbers($l1, $l2) {
+	$i = 0;
+	$j = 0;
+	$carry = 0;
+	$result = [];
+	while (((((($i < count($l1)) || $j) < count($l2)) || $carry) > 0)) {
+		$x = 0;
+		if (($i < count($l1))) {
+			$x = $l1[$i];
+			$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+		}
+		$y = 0;
+		if (($j < count($l2))) {
+			$y = $l2[$j];
+			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+		}
+		$sum = ((is_array(((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y)))) && is_array($carry)) ? array_merge(((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y))), $carry) : ((is_string(((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y)))) || is_string($carry)) ? (((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y))) . $carry) : (((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y))) + $carry)));
+		$digit = ($sum % 10);
+		$carry = ($sum / 10);
+		$result = ((is_array($result) && is_array([$digit])) ? array_merge($result, [$digit]) : ((is_string($result) || is_string([$digit])) ? ($result . [$digit]) : ($result + [$digit])));
+	}
+	return $result;
+}
+


### PR DESCRIPTION
## Summary
- enable PHP compiler tests to compile LeetCode problems 1 and 2
- revert Makefile and README edits that added PHP helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852a74e7b048320bcbe5867e82680a4