### PR TITLE
Add Rust LeetCode range test

### DIFF
--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -99,6 +99,9 @@ func TestRustCompiler_ValidPrograms(t *testing.T) {
 	t.Run("leetcode_1", func(t *testing.T) {
 		runRustLeet(t, 1)
 	})
+	t.Run("leetcode_2", func(t *testing.T) {
+		runRustLeet(t, 2)
+	})
 }
 
 func runRustProgram(t *testing.T, src string) {


### PR DESCRIPTION
## Summary
- extend Rust compiler tests to run LeetCode examples 1 and 2
- revert changes to example Makefile and README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852a760e67c83209fa0e7238e56ac1e