### PR TITLE
Enable Clojure test/expect support

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -82,6 +82,8 @@ if name == "print" {
 ```
 【F:compile/clj/compiler.go†L286-L291】
 
+Test blocks are compiled to functions named `test_<name>` and executed after the main program. Inside these functions `expect` statements become simple assertions via Clojure's `assert` form.
+
 ## Tooling
 
 Tests require the Clojure CLI tool. `EnsureClojure` tries to install it using `apt-get` or Homebrew if missing:
@@ -111,6 +113,10 @@ go test ./compile/clj -tags slow
 ```
 
 They compare the execution output of generated programs in `tests/compiler/clj` with predefined golden files.
+
+The test suite also compiles and runs the example LeetCode solutions in
+`examples/leetcode/1` and `examples/leetcode/2` to verify that these programs
+execute correctly using the Clojure backend.
 
 ## Status
 

--- a/compile/clj/compiler_test.go
+++ b/compile/clj/compiler_test.go
@@ -157,4 +157,5 @@ func TestClojureCompiler_LeetCodeExamples(t *testing.T) {
 		t.Skipf("clojure not installed: %v", err)
 	}
 	runLeetExample(t, 1)
+	runLeetExample(t, 2)
 }

--- a/tests/compiler/clj/mod_operator.clj.out
+++ b/tests/compiler/clj/mod_operator.clj.out
@@ -1,6 +1,6 @@
 (loop [i 1]
   (when (< i 5)
-    (if (== (mod i 2) 0)
+    (when (= (mod i 2) 0)
       (println i)
     )
     (recur (inc i)))


### PR DESCRIPTION
## Summary
- support `test` blocks and `expect` statements in the Clojure compiler
- improve binary operator handling for equality and lists
- fix `if` statement generation and integer division
- update golden output for `mod_operator`
- document test/expect support in the Clojure backend README

## Testing
- `go test ./compile/clj -run LeetCodeExamples -tags slow -v`
- `go test ./compile/clj -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6852a726610c83208d7773c8eaf0fb5f