### PR TITLE
Add leetcode-runner CLI and simplify Makefile

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -1,0 +1,378 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/alexflint/go-arg"
+
+	ccode "mochi/compile/c"
+	cljcode "mochi/compile/clj"
+	cobolcode "mochi/compile/cobol"
+	cppcode "mochi/compile/cpp"
+	cscode "mochi/compile/cs"
+	dartcode "mochi/compile/dart"
+	erlcode "mochi/compile/erlang"
+	excode "mochi/compile/ex"
+	ftncode "mochi/compile/fortran"
+	fscode "mochi/compile/fs"
+	gocode "mochi/compile/go"
+	hscode "mochi/compile/hs"
+	javacode "mochi/compile/java"
+	jvmcode "mochi/compile/jvm"
+	ktcode "mochi/compile/kt"
+	luacode "mochi/compile/lua"
+	mlcode "mochi/compile/ocaml"
+	pascode "mochi/compile/pas"
+	phpcode "mochi/compile/php"
+	plcode "mochi/compile/pl"
+	pycode "mochi/compile/py"
+	rbcode "mochi/compile/rb"
+	rktcode "mochi/compile/rkt"
+	rscode "mochi/compile/rust"
+	scalacode "mochi/compile/scala"
+	schemecode "mochi/compile/scheme"
+	stcode "mochi/compile/st"
+	swiftcode "mochi/compile/swift"
+	tscode "mochi/compile/ts"
+	wasmcode "mochi/compile/wasm"
+	zigcode "mochi/compile/zig"
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/mod"
+	"mochi/types"
+)
+
+// CLI defines subcommands for building and running LeetCode solutions.
+type CLI struct {
+	Build *BuildCmd `arg:"subcommand:build" help:"Compile solutions"`
+	Run   *RunCmd   `arg:"subcommand:run" help:"Run solutions with interpreter"`
+	Test  *TestCmd  `arg:"subcommand:test" help:"Run test blocks"`
+}
+
+type BuildCmd struct {
+	ID   int      `arg:"-i,--id" help:"Single problem id"`
+	From int      `arg:"--from" help:"Start id"`
+	To   int      `arg:"--to" help:"End id"`
+	Lang []string `arg:"-l,--lang,separate" help:"Target language (repeatable)"`
+	All  bool     `arg:"--all" help:"Build for all languages"`
+	Run  bool     `arg:"--run" help:"Execute compiled code"`
+}
+
+type RunCmd struct {
+	ID int `arg:"positional,required" help:"Problem id"`
+}
+
+type TestCmd struct {
+	ID int `arg:"positional" help:"Problem id (default all)"`
+}
+
+func main() {
+	var cli CLI
+	arg.MustParse(&cli)
+
+	switch {
+	case cli.Build != nil:
+		if err := cli.Build.RunBuild(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	case cli.Run != nil:
+		if err := runProblem(cli.Run.ID); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	case cli.Test != nil:
+		if err := runTests(cli.Test.ID); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	default:
+		arg.MustParse(&cli).WriteHelp(os.Stdout)
+	}
+}
+
+func (c *BuildCmd) ids() []int {
+	if c.ID > 0 {
+		return []int{c.ID}
+	}
+	from := c.From
+	to := c.To
+	if from == 0 && to == 0 {
+		return nil
+	}
+	if from == 0 {
+		from = 1
+	}
+	if to == 0 {
+		to = from
+	}
+	var ids []int
+	for i := from; i <= to; i++ {
+		ids = append(ids, i)
+	}
+	return ids
+}
+
+func (c *BuildCmd) languages() []string {
+	if c.All {
+		return allCompileLanguages()
+	}
+	if len(c.Lang) == 0 {
+		return []string{"go"}
+	}
+	return c.Lang
+}
+
+func (c *BuildCmd) RunBuild() error {
+	ids := c.ids()
+	if len(ids) == 0 {
+		return fmt.Errorf("no ids specified")
+	}
+	langs := c.languages()
+
+	for _, id := range ids {
+		dir := filepath.Join("examples", "leetcode", strconv.Itoa(id))
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skip %d: %v\n", id, err)
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".mochi") {
+				continue
+			}
+			src := filepath.Join(dir, e.Name())
+			for _, lang := range langs {
+				if err := buildOne(src, lang, c.Run); err != nil {
+					fmt.Fprintf(os.Stderr, "%v\n", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func buildOne(src, lang string, run bool) error {
+	prog, err := parser.Parse(src)
+	if err != nil {
+		return fmt.Errorf("%s: %v", src, err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return fmt.Errorf("%s: %v", src, errs[0])
+	}
+	modRoot, _ := mod.FindRoot(filepath.Dir(src))
+
+	base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+	outDir := filepath.Join("examples", "leetcode-out", lang, filepath.Base(filepath.Dir(src)))
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		return err
+	}
+	outFile := filepath.Join(outDir, base+"."+lang)
+	var data []byte
+	switch lang {
+	case "go":
+		data, err = gocode.New(env).Compile(prog)
+	case "py":
+		data, err = pycode.New(env).Compile(prog)
+	case "ts":
+		data, err = tscode.New(env, modRoot).Compile(prog)
+	case "cpp":
+		data, err = cppcode.New(env).Compile(prog)
+	case "c":
+		data, err = ccode.New(env).Compile(prog)
+	case "clj":
+		data, err = cljcode.New(env).Compile(prog)
+	case "cobol":
+		data, err = cobolcode.New(env).Compile(prog)
+	case "cs":
+		data, err = cscode.New(env).Compile(prog)
+	case "dart":
+		data, err = dartcode.New(env).Compile(prog)
+	case "erlang":
+		data, err = erlcode.New(env).Compile(prog)
+	case "ex":
+		data, err = excode.New(env).Compile(prog)
+	case "fortran":
+		data, err = ftncode.New().Compile(prog)
+	case "fs":
+		data, err = fscode.New(env).Compile(prog)
+	case "hs":
+		data, err = hscode.New(env).Compile(prog)
+	case "java":
+		data, err = javacode.New(env).Compile(prog)
+	case "jvm":
+		data, err = jvmcode.New(env).Compile(prog)
+	case "kt":
+		data, err = ktcode.New(env).Compile(prog)
+	case "lua":
+		data, err = luacode.New(env).Compile(prog)
+	case "ocaml":
+		data, err = mlcode.New(env).Compile(prog)
+	case "pas":
+		data, err = pascode.New(env).Compile(prog)
+	case "php":
+		data, err = phpcode.New(env).Compile(prog)
+	case "pl":
+		data, err = plcode.New(env).Compile(prog)
+	case "rb":
+		data, err = rbcode.New(env).Compile(prog)
+	case "rkt":
+		data, err = rktcode.New(env).Compile(prog)
+	case "rust":
+		data, err = rscode.New(env).Compile(prog)
+	case "scala":
+		data, err = scalacode.New(env).Compile(prog)
+	case "scheme":
+		data, err = schemecode.New(env).Compile(prog)
+	case "st":
+		data, err = stcode.New(env).Compile(prog)
+	case "swift":
+		data, err = swiftcode.New(env).Compile(prog)
+	case "wasm":
+		data, err = wasmcode.New(env).Compile(prog)
+	case "zig":
+		data, err = zigcode.New(env).Compile(prog)
+	default:
+		return fmt.Errorf("unsupported language: %s", lang)
+	}
+	if err != nil {
+		return fmt.Errorf("compile %s to %s: %v", src, lang, err)
+	}
+	if err := os.WriteFile(outFile, data, 0644); err != nil {
+		return err
+	}
+	fmt.Printf("generated %s\n", outFile)
+	if run {
+		return runOutput(outFile, lang)
+	}
+	return nil
+}
+
+func runOutput(file, lang string) error {
+	switch lang {
+	case "go":
+		cmd := exec.Command("go", "run", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	case "py":
+		cmd := exec.Command("python3", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	case "ts":
+		cmd := exec.Command("deno", "run", "--allow-all", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	case "cpp":
+		exe := strings.TrimSuffix(file, ".cpp")
+		if out, err := exec.Command("g++", file, "-std=c++17", "-o", exe).CombinedOutput(); err != nil {
+			return fmt.Errorf("g++: %v\n%s", err, string(out))
+		}
+		cmd := exec.Command(exe)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	default:
+		return fmt.Errorf("no runner for %s", lang)
+	}
+}
+
+func runProblem(id int) error {
+	dir := filepath.Join("examples", "leetcode", strconv.Itoa(id))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		if err := runFile(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runFile(file string) error {
+	prog, err := parser.Parse(file)
+	if err != nil {
+		return err
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return fmt.Errorf("%s: %v", file, errs[0])
+	}
+	modRoot, _ := mod.FindRoot(filepath.Dir(file))
+	interp := interpreter.New(prog, env, modRoot)
+	return interp.Run()
+}
+
+func runTests(id int) error {
+	var files []string
+	if id > 0 {
+		dir := filepath.Join("examples", "leetcode", strconv.Itoa(id))
+		fsys := os.DirFS(dir)
+		fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			if strings.HasSuffix(path, ".mochi") {
+				files = append(files, filepath.Join(dir, path))
+			}
+			return nil
+		})
+	} else {
+		fs.WalkDir(os.DirFS("examples/leetcode"), ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			if strings.HasSuffix(path, ".mochi") {
+				files = append(files, filepath.Join("examples/leetcode", path))
+			}
+			return nil
+		})
+	}
+	for _, f := range files {
+		if err := testFile(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func testFile(file string) error {
+	prog, err := parser.Parse(file)
+	if err != nil {
+		return err
+	}
+	env := types.NewEnv(nil)
+	modRoot, _ := mod.FindRoot(filepath.Dir(file))
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return fmt.Errorf("%s: %v", file, errs[0])
+	}
+	interp := interpreter.New(prog, env, modRoot)
+	return interp.Test()
+}
+
+func allCompileLanguages() []string {
+	entries, err := os.ReadDir("compile")
+	if err != nil {
+		return []string{"go"}
+	}
+	langs := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			langs = append(langs, e.Name())
+		}
+	}
+	sort.Strings(langs)
+	return langs
+}

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -1,156 +1,34 @@
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
 
-MOCHI_BIN := $(CURDIR)/bin/mochi
-MOCHI_ROOT := $(abspath $(CURDIR)/../..)
+MOCHI_ROOT := $(abspath ../..)
+RUNNER := $(MOCHI_ROOT)/cmd/leetcode-runner
 
-OS  := $(shell uname -s)
-ARCH := $(shell uname -m)
+.PHONY: run build range test clean help
 
-ifeq ($(OS),Darwin)
-	OS := Darwin
-else
-	OS := Linux
-endif
+run: ## Run a problem. Usage: make run ID=<n>
+@if [ -z "$(ID)" ]; then echo "❌ Usage: make run ID=<n>"; exit 1; fi
+@go run $(RUNNER) run $(ID)
 
-ifeq ($(ARCH),x86_64)
-	ARCH := x86_64
-else ifeq ($(ARCH),aarch64)
-	ARCH := arm64
-else ifeq ($(ARCH),arm64)
-	ARCH := arm64
-endif
+build: ## Build and run one problem in language. Usage: make build ID=<n> LANG=go
+@if [ -z "$(ID)" ]; then echo "❌ Usage: make build ID=<n> LANG=<lang>"; exit 1; fi
+@go run $(RUNNER) build --id $(ID) $(if $(LANG),--lang $(LANG)) --run
 
-MOCHI_TAR := mochi_$(OS)_$(ARCH).tar.gz
-MOCHI_URL := https://github.com/mochilang/mochi/releases/latest/download/$(MOCHI_TAR)
+range: ## Build problems in range. Usage: make range FROM=1 TO=100 LANG=go
+@go run $(RUNNER) build --from $(FROM) --to $(TO) $(if $(LANG),--lang $(LANG)) --run
 
-.PHONY: mochi run run-go run-cpp test compile build-one build-all clean help
+test: ## Run tests for all problems
+@go run $(RUNNER) test
 
-# ────────────────────────────────────────────────────────────────
-# 💡 Shared shell function for compiling one .mochi file
-define build_one_lang
-	start=$$(date +%s%N); \
-	dir=$$(dirname "$1"); \
-	base=$$(basename "$1" .mochi); \
-	out_dir=../leetcode-out/$2/$$dir; \
-	out_file=$$out_dir/$$base.$2; \
-	mkdir -p "$$out_dir"; \
-	success=true; \
-	if $(MOCHI_BIN) build "$1" -o "$$out_file" --target $2 > /dev/null 2>&1; then \
-                case "$2" in \
-                        go) go run "$$out_file" > /dev/null 2>&1 || success=false ;; \
-                        py) python3 "$$out_file" > /dev/null 2>&1 || success=false ;; \
-                        ts) deno run --allow-all "$$out_file" > /dev/null 2>&1 || success=false ;; \
-                        cpp) \ 
-                                bin="$$out_dir/$$base"; \
-                                g++ "$$out_file" -std=c++17 -o "$$bin" > /dev/null 2>&1 && "$$bin" > /dev/null 2>&1 || success=false ;; \
-                esac; \
-	else \
-		echo "❌ Compile failed: $1 → $2" >&2; \
-		success=false; \
-	fi; \
-	end=$$(date +%s%N); \
-	dur_ms=$$(( (end - start)/1000000 )); \
-	if $$success; then \
-		printf "✅ \033[1m%s\033[0m → $2 compiled & ran in %d ms\n" "$1" "$$dur_ms"; \
-	else \
-		printf "❌ \033[1m%s\033[0m → $2 failed\n" "$1"; \
-	fi
-endef
+clean:
+@rm -rf ../leetcode-out
+@echo "🧹 Cleaned build outputs"
 
-# ────────────────────────────────────────────────────────────────
-mochi: ## Build or download the Mochi binary
-	@mkdir -p bin
-	@if [ ! -f $(MOCHI_BIN) ]; then \
-		echo "Building Mochi from source..."; \
-		cd $(MOCHI_ROOT) && go build -o $(CURDIR)/bin/mochi ./cmd/mochi; \
-	fi
-	@if [ ! -f $(MOCHI_BIN) ]; then \
-		echo "Downloading Mochi binary for $(OS)/$(ARCH)..."; \
-		curl -L $(MOCHI_URL) -o bin/$(MOCHI_TAR); \
-		tar -xzf bin/$(MOCHI_TAR) -C bin; \
-		rm -f bin/$(MOCHI_TAR); \
-		chmod +x $(MOCHI_BIN); \
-	else \
-		echo "Using $(MOCHI_BIN)"; \
-	fi
+help:
+@echo ""
+@echo "📦 \033[1mMochi LeetCode Makefile\033[0m"
+@echo "Usage: make [target] [VAR=val]"
+@echo ""
+@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
+awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
-run: mochi ## Run a .mochi file. Usage: make run ID=<problem>
-	@if [ -z "$(ID)" ]; then echo "❌ Usage: make run ID=<problem>"; exit 1; fi
-	@$(MOCHI_BIN) run $(ID)/*.mochi
-
-run-go: mochi ## Compile and run Go version of problem. Usage: make run-go ID=<problem>
-	@if [ -z "$(ID)" ]; then echo "❌ Usage: make run-go ID=<problem>"; exit 1; fi
-	@file=$$(ls $(ID)/*.mochi | head -n 1); \
-	base=$$(basename "$$file" .mochi); \
-	out=../leetcode-out/$(ID)/$$base.go; \
-	mkdir -p ../leetcode-out/$(ID); \
-	echo "🔧 Compiling $$file to $$out..."; \
-	if ! $(MOCHI_BIN) build "$$file" -o "$$out" --target go; then \
-	echo "❌ Compilation failed."; exit 1; fi; \
-	go run "$$out"
-
-run-cpp: mochi ## Compile and run C++ version of problem. Usage: make run-cpp ID=<problem>
-	@if [ -z "$(ID)" ]; then echo "❌ Usage: make run-cpp ID=<problem>"; exit 1; fi
-	@file=$$(ls $(ID)/*.mochi | head -n 1); \
-	base=$$(basename "$$file" .mochi); \
-	out_dir=../leetcode-out/cpp/$(ID); \
-	out=$$out_dir/$$base.cpp; \
-	mkdir -p "$$out_dir"; \
-	echo "🔧 Compiling $$file to $$out..."; \
-	if ! $(MOCHI_BIN) build "$$file" -o "$$out" --target cpp; then \
-	echo "❌ Compilation failed."; exit 1; fi; \
-	g++ "$$out" -std=c++17 -o "$$out_dir/$$base"; \
-	"$$out_dir/$$base"
-
-
-build-one: mochi ## Compile one .mochi to a language. Usage: make build-one ID=123 LANG=go|py|ts|cpp
-	@if [ -z "$(ID)" ] || [ -z "$(LANG)" ]; then \
-	echo "❌ Usage: make build-one ID=123 LANG=go|py|ts|cpp"; exit 1; fi
-	@file=$$(ls $(ID)/*.mochi | head -n 1); \
-	$(call build_one_lang,$$file,$(LANG))
-
-build-all: mochi ## Compile all problems from FROM to TO in parallel. Usage: make build-all [FROM=1] [TO=400] [JOBS=6]
-	@FROM=$${FROM:-1}; TO=$${TO:-400}; JOBS=$${JOBS:-6}; \
-	pids=(); \
-	sem() { \
-		while [ "$${#pids[@]}" -ge $$JOBS ]; do \
-			wait -n "${pids[@]}" 2>/dev/null || break; \
-			new_pids=(); \
-			for pid in "$${pids[@]}"; do \
-				if kill -0 $$pid 2>/dev/null; then new_pids+=($$pid); fi; \
-			done; \
-			pids=($${new_pids[@]}); \
-		done; \
-	}; \
-	for i in $$(seq $$FROM $$TO); do \
-		if [ -d "$$i" ]; then \
-			for file in $$(find "$$i" -name '*.mochi' 2>/dev/null); do \
-for lang in go py ts cpp; do \
-					( $(call build_one_lang,$$file,$$lang) ) & \
-					pids+=($$!); \
-					sem; \
-				done; \
-			done; \
-		fi; \
-	done; \
-	for pid in "$${pids[@]}"; do wait $$pid; done
-
-
-
-test: mochi ## Run all tests
-	@find . -name '*.mochi' -print0 | xargs -0 -n1 $(MOCHI_BIN) test
-
-compile: build-all ## (Alias) Compile all problems
-
-clean: ## Remove binaries and build outputs
-	@rm -rf bin ../leetcode-out
-	@echo "🧹 Cleaned bin/ and ../leetcode-out/"
-
-help: ## Show help message
-	@echo ""
-	@echo "📦 \033[1mMochi LeetCode Makefile\033[0m"
-	@echo "Usage: make [target] [VAR=val]"
-	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
## Summary
- add `cmd/leetcode-runner` tool for compiling/running LeetCode solutions
- replace per-language targets in `examples/leetcode/Makefile` with calls to the new CLI
- extend runner to compile every backend under `compile/`

## Testing
- `gofmt -w cmd/leetcode-runner/main.go`
- `gofmt -w examples/leetcode/Makefile` *(fails: illegal characters)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852ac48d4a88320b8470ced8e06f847