### PR TITLE
Add C# LeetCode compile support

### DIFF
--- a/compile/cs/compiler_test.go
+++ b/compile/cs/compiler_test.go
@@ -96,6 +96,16 @@ func TestCSCompiler_LeetCodeExample1(t *testing.T) {
 	runLeetCode(t, 1, "0\n1")
 }
 
+func TestCSCompiler_LeetCodeExample2(t *testing.T) {
+	if err := cscode.EnsureDotnet(); err != nil {
+		t.Skipf("dotnet not installed: %v", err)
+	}
+	if err := exec.Command("dotnet", "--version").Run(); err != nil {
+		t.Skipf("dotnet not runnable: %v", err)
+	}
+	runLeetCode(t, 2, "")
+}
+
 func runLeetCode(t *testing.T, id int, want string) {
 	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(id))
 	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))

--- a/tests/compiler/cs/matrix_search.cs.out
+++ b/tests/compiler/cs/matrix_search.cs.out
@@ -12,7 +12,7 @@ public class Program {
 		var left = 0;
 		var right = ((m * n) - 1);
 		while ((left <= right)) {
-			var mid = ((left + ((right - left))) / 2);
+			var mid = (left + (((right - left)) / 2));
 			var row = (mid / n);
 			var col = (mid % n);
 			var value = matrix[row][col];

--- a/tests/compiler/cs/test_block.cs.out
+++ b/tests/compiler/cs/test_block.cs.out
@@ -3,7 +3,13 @@ using System;
 using System.Collections.Generic;
 
 public class Program {
+	static void test_addition_works() {
+		var x = (1 + 2);
+		if (!((x == 3))) throw new Exception("expect failed");
+	}
+	
 	public static void Main() {
 		Console.WriteLine("ok");
+		test_addition_works();
 	}
 }

--- a/tests/compiler/cs/typed_list_negative.cs.out
+++ b/tests/compiler/cs/typed_list_negative.cs.out
@@ -4,8 +4,16 @@ using System.Collections.Generic;
 using System.Text.Json;
 
 public class Program {
+	static void test_values() {
+		if (!((xs[0] == ((-1))))) throw new Exception("expect failed");
+		if (!((xs[1] == 0))) throw new Exception("expect failed");
+		if (!((xs[2] == 1))) throw new Exception("expect failed");
+		Console.WriteLine("done");
+	}
+	
 	public static void Main() {
 		var xs = _cast<int[]>(new [] { ((-1)), 0, 1 });
+		test_values();
 	}
 	static T _cast<T>(dynamic v) {
 		if (v is T tv) return tv;


### PR DESCRIPTION
## Summary
- support `test` and `expect` blocks in the C# backend
- generate test methods and call them from `Main`
- update C# golden files for new test support
- revert Makefile changes

## Testing
- `go test ./compile/cs -run TestCSCompiler_GoldenOutput -tags slow -v`
- `go test ./compile/cs -run TestCSCompiler_LeetCodeExample -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_6852a72c6084832098e0e9db23a26ac6