### PR TITLE
Update C backend leetcode tests

### DIFF
--- a/compile/c/README.md
+++ b/compile/c/README.md
@@ -53,6 +53,6 @@ go test ./compile/c -tags slow
 
 They compile example programs from `tests/compiler/c` and compare the results.【F:compile/c/compiler_test.go†L71-L108】
 
-The separate `leetcode_test.go` file compiles and executes the first two
-LeetCode solutions under `examples/leetcode/1` and `examples/leetcode/2`
-using the C backend.
+The separate `leetcode_test.go` file compiles and executes the first three
+LeetCode solutions under `examples/leetcode/1`, `examples/leetcode/2` and
+`examples/leetcode/3` using the C backend.

--- a/compile/c/leetcode_test.go
+++ b/compile/c/leetcode_test.go
@@ -64,7 +64,7 @@ func runLeet(t *testing.T, id int) {
 }
 
 func TestCCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 2; i++ {
+	for i := 1; i <= 3; i++ {
 		runLeet(t, i)
 	}
 }


### PR DESCRIPTION
## Summary
- update compile/c tests to cover first three leetcode problems
- document new coverage in C backend readme

## Testing
- `go test ./compile/c -tags slow -run TestCCompiler_LeetCodeExamples -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852bb12cf248320b62e7baf25bf2d20