### PR TITLE
Add Dart compilation tests for LeetCode 1-3

### DIFF
--- a/compile/dart/compiler_test.go
+++ b/compile/dart/compiler_test.go
@@ -23,6 +23,7 @@ func TestDartCompiler_LeetCodeExamples(t *testing.T) {
 	}
 	runLeetExample(t, 1, "0\n1")
 	runLeetExample(t, 2, "")
+	runLeetExample(t, 3, "")
 }
 
 func TestDartCompiler_SubsetPrograms(t *testing.T) {

--- a/compile/dart/leetcode_test.go
+++ b/compile/dart/leetcode_test.go
@@ -79,3 +79,13 @@ func TestLeetCode2(t *testing.T) {
 		t.Fatalf("unexpected output: %q", got)
 	}
 }
+
+func TestLeetCode3(t *testing.T) {
+	if err := dartcode.EnsureDart(); err != nil {
+		t.Skipf("dart not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "3"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- run first three LeetCode examples in Dart compiler test
- extend leetcode tests to include problem 3

## Testing
- `go test ./compile/dart -tags slow -run LeetCode -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852bb7d6dbc8320a1289ee37c84b333