### PR TITLE
Add Elixir support for LeetCode runner

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -282,6 +282,14 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "ex":
+		if err := excode.EnsureElixir(); err != nil {
+			return fmt.Errorf("elixir not available: %v", err)
+		}
+		cmd := exec.Command("elixir", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/compile/ex/compiler_test.go
+++ b/compile/ex/compiler_test.go
@@ -124,3 +124,10 @@ func TestExCompiler_LeetCode2(t *testing.T) {
 	}
 	runExample(t, 2)
 }
+
+func TestExCompiler_LeetCode3(t *testing.T) {
+	if err := excode.EnsureElixir(); err != nil {
+		t.Skipf("elixir not installed: %v", err)
+	}
+	runExample(t, 3)
+}

--- a/compile/ex/leetcode_test.go
+++ b/compile/ex/leetcode_test.go
@@ -80,6 +80,16 @@ func TestLeetCode2(t *testing.T) {
 	}
 }
 
+func TestLeetCode3(t *testing.T) {
+	if err := excode.EnsureElixir(); err != nil {
+		t.Skipf("elixir not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "3"))
+	if got != "3" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
 func findRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -4,11 +4,15 @@ SHELL := /bin/bash
 MOCHI_ROOT := $(abspath ../..)
 RUNNER := $(MOCHI_ROOT)/cmd/leetcode-runner
 
-.PHONY: run build range test clean help
+.PHONY: run build range test clean help run-ex
 
 run: ## Run a problem. Usage: make run ID=<n>
 @if [ -z "$(ID)" ]; then echo "❌ Usage: make run ID=<n>"; exit 1; fi
 @go run $(RUNNER) run $(ID)
+
+run-ex: ## Build and run problem in Elixir. Usage: make run-ex ID=<n>
+@if [ -z "$(ID)" ]; then echo "❌ Usage: make run-ex ID=<n>"; exit 1; fi
+@go run $(RUNNER) build --id $(ID) --lang ex --run
 
 build: ## Build and run one problem in language. Usage: make build ID=<n> LANG=go
 @if [ -z "$(ID)" ]; then echo "❌ Usage: make build ID=<n> LANG=<lang>"; exit 1; fi

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -64,8 +64,7 @@ mochi run download.mochi
 
 - `make mochi` – download the latest Mochi binary into `./bin`
 - `make run ID=<n>` – run problem `n`
-- `make run-go ID=<n>` – execute the compiled Go solution for problem `n`
-- `make run-cpp ID=<n>` – execute the compiled C++ solution for problem `n`
+- `make run-ex ID=<n>` – compile and run the Elixir solution for problem `n`
 - `make compile` – generate Go, Python, TypeScript and C++ files into `../leetcode-out`
 - `make test` – run all tests
 - `make clean` – remove the downloaded binary


### PR DESCRIPTION
## Summary
- enable execution of Elixir output in `leetcode-runner`
- cover LeetCode problem 3 in Elixir compiler tests
- expose `run-ex` in the LeetCode examples Makefile and docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852bb94fecc8320bcb1ce35a38b8eec