### PR TITLE
Add F# runtime support

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -282,6 +282,14 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "fs":
+		if err := fscode.EnsureDotnet(); err != nil {
+			return err
+		}
+		cmd := exec.Command("dotnet", "fsi", "--quiet", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -104,3 +104,11 @@ mochi build --target fs program.mochi -o program.fs
 
 The emitted code is intended to be executed with `dotnet fsi` or included in larger F# projects.
 
+## Running LeetCode Examples
+
+To compile and execute the sample LeetCode solutions for problems 1-3 in F#, use `leetcode-runner`:
+
+```bash
+go run ./cmd/leetcode-runner --from 1 --to 3 -l fs --run
+```
+


### PR DESCRIPTION
## Summary
- run compiled `.fs` files using `dotnet fsi`
- document how to run LeetCode examples in F#

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852bbabb8e48320acdf66dd3a4e8eea