### PR TITLE
Enable LeetCode Java runner

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -282,6 +282,18 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "java":
+		if err := javacode.EnsureJavac(); err != nil {
+			return err
+		}
+		dir := filepath.Dir(file)
+		if out, err := exec.Command("javac", file).CombinedOutput(); err != nil {
+			return fmt.Errorf("javac: %v\n%s", err, string(out))
+		}
+		cmd := exec.Command("java", "-cp", dir, "Main")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}


### PR DESCRIPTION
## Summary
- add Java execution support to `leetcode-runner`
- scope compiler env to functions and include parameter types
- improve Java backend for `len` on strings
- avoid treating indexed lists as lists in `+` expressions

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 3 -l java --run`

------
https://chatgpt.com/codex/tasks/task_e_6852bbcec0c8832084d653b6f56c5340