### PR TITLE
Add Lua compilation test for LeetCode 3

### DIFF
--- a/compile/lua/README.md
+++ b/compile/lua/README.md
@@ -264,6 +264,9 @@ The golden tests compile programs in `tests/compiler/lua` and execute them with 
 go test ./compile/lua -tags slow
 ```
 
+The `LeetCodeExamples` test additionally compiles and runs the first three
+solutions under `examples/leetcode` to verify basic program execution.
+
 ## Notes
 
 The Lua backend supports most core language features but skips advanced LLM helpers and external objects. Query expressions handle simple joins and common clauses. The emphasis is on readability and portability of the emitted Lua code.

--- a/compile/lua/compiler_test.go
+++ b/compile/lua/compiler_test.go
@@ -149,11 +149,12 @@ func TestLuaCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestLuaCompiler_LeetCodeExamples(t *testing.T) {
-        if err := luacode.EnsureLua(); err != nil {
-                t.Skipf("lua not installed: %v", err)
-        }
-        runLeetCode(t, 1, "0\n1")
-        runLeetCode(t, 2, "")
+	if err := luacode.EnsureLua(); err != nil {
+		t.Skipf("lua not installed: %v", err)
+	}
+	runLeetCode(t, 1, "0\n1")
+	runLeetCode(t, 2, "")
+	runLeetCode(t, 3, "")
 }
 
 func runLeetCode(t *testing.T, id int, want string) {
@@ -187,16 +188,16 @@ func runLeetCode(t *testing.T, id int, want string) {
 			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 				cmd.Stdin = bytes.NewReader(data)
 			}
-                        out, err := cmd.CombinedOutput()
-                        if err != nil {
-                                t.Fatalf("lua run error: %v\n%s", err, out)
-                        }
-                        if want != "" {
-                                got := strings.TrimSpace(string(out))
-                                if got != want {
-                                        t.Fatalf("unexpected output\nwant:\n%s\n got:\n%s", want, got)
-                                }
-                        }
-                })
-        }
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("lua run error: %v\n%s", err, out)
+			}
+			if want != "" {
+				got := strings.TrimSpace(string(out))
+				if got != want {
+					t.Fatalf("unexpected output\nwant:\n%s\n got:\n%s", want, got)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- run the third LeetCode example with the Lua backend
- document that the first three problems are compiled in Lua tests

## Testing
- `go test -tags slow ./compile/lua -run LeetCode -count=1`
- `go test -tags slow ./compile/lua -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852bf8690ac832093d69a81470ce67a