### PR TITLE
Support OCaml LeetCode runner

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -282,6 +282,24 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "ocaml":
+		if err := mlcode.EnsureOCaml(); err != nil {
+			return err
+		}
+		exe := strings.TrimSuffix(file, filepath.Ext(file))
+		args := []string{"-o", exe}
+		if filepath.Ext(file) != ".ml" {
+			args = append([]string{"-impl", file}, args...)
+		} else {
+			args = append([]string{file}, args...)
+		}
+		if out, err := exec.Command("ocamlc", args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("ocamlc: %v\n%s", err, string(out))
+		}
+		cmd := exec.Command(exe)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/compile/ocaml/compiler_test.go
+++ b/compile/ocaml/compiler_test.go
@@ -121,6 +121,7 @@ func TestOCamlCompiler_GoldenOutput(t *testing.T) {
 func TestOCamlCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 1)
 	runExample(t, 2)
+	runExample(t, 3)
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- add OCaml execution path to the leetcode-runner
- run example 3 in OCaml compiler tests

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 3 --lang ocaml --run`
- `go test ./compile/ocaml -tags slow -run TestOCamlCompiler_LeetCodeExamples -count=1`
- `go test ./... -run TestOCamlCompiler_LeetCodeExamples -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6852bf94cb608320920a3b633f737774