### PR TITLE
Extend rb tests to LeetCode #3

### DIFF
--- a/compile/rb/README.md
+++ b/compile/rb/README.md
@@ -107,6 +107,17 @@ ruby add-two-numbers.rb
 
 This prints the resulting list digits on separate lines.
 
+### Example: LeetCode Longest Substring Without Repeating Characters
+
+To compile and run the `longest-substring-without-repeating-characters` example located in `examples/leetcode/3`, use:
+
+```bash
+mochi build --target rb examples/leetcode/3/longest-substring-without-repeating-characters.mochi -o longest.rb
+ruby longest.rb
+```
+
+The program defines the function and unit tests but running the compiled Ruby simply evaluates without output.
+
 `tools.go` provides `EnsureRuby` which attempts to install Ruby on Linux or macOS if it is missing:
 
 ```go

--- a/compile/rb/compiler_test.go
+++ b/compile/rb/compiler_test.go
@@ -82,7 +82,7 @@ func TestRBCompiler_LeetCodeExamples(t *testing.T) {
 	if err := rbcode.EnsureRuby(); err != nil {
 		t.Skipf("ruby not installed: %v", err)
 	}
-	for i := 1; i <= 2; i++ {
+	for i := 1; i <= 3; i++ {
 		runLeetExample(t, i)
 	}
 }


### PR DESCRIPTION
## Summary
- test Ruby backend with LeetCode problems 1–3
- document how to compile problem 3 in the Ruby compiler guide

## Testing
- `go test ./compile/rb -tags slow -run LeetCode -count=1`
- `go test ./... -run ^$ -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852bfd3122c8320a651b476005d89ae