### PR TITLE
Enable Rust compiler to handle LeetCode examples 1-3

### DIFF
--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -102,6 +102,9 @@ func TestRustCompiler_ValidPrograms(t *testing.T) {
 	t.Run("leetcode_2", func(t *testing.T) {
 		runRustLeet(t, 2)
 	})
+	t.Run("leetcode_3", func(t *testing.T) {
+		runRustLeet(t, 3)
+	})
 }
 
 func runRustProgram(t *testing.T, src string) {

--- a/compile/rust/runtime.go
+++ b/compile/rust/runtime.go
@@ -18,6 +18,13 @@ const (
 		"    m.contains_key(k)\n" +
 		"}\n"
 
+	helperConcat = "fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {\n" +
+		"    let mut res = Vec::with_capacity(a.len() + b.len());\n" +
+		"    res.extend_from_slice(a);\n" +
+		"    res.extend_from_slice(b);\n" +
+		"    res\n" +
+		"}\n"
+
 	helperInput = "fn _input() -> String {\n" +
 		"    use std::io::Read;\n" +
 		"    let mut s = String::new();\n" +
@@ -31,6 +38,7 @@ var helperMap = map[string]string{
 	"_avg":    helperAvg,
 	"_in_map": helperInMap,
 	"_input":  helperInput,
+	"_concat": helperConcat,
 }
 
 func (c *Compiler) use(name string) { c.helpers[name] = true }


### PR DESCRIPTION
## Summary
- add environment handling for function parameters in rust compiler
- support list concatenation and string indexing
- ignore test/expect statements during compilation
- run LeetCode example 3 in rust tests

## Testing
- `go test -tags=slow ./compile/rust -run ValidPrograms -v -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6852bfe60120832094ed848ee972004f