### PR TITLE
Add Scheme string indexing and LeetCode3

### DIFF
--- a/compile/scheme/README.md
+++ b/compile/scheme/README.md
@@ -250,6 +250,11 @@ func TestSchemeCompiler_LeetCode1(t *testing.T) {
 func TestSchemeCompiler_LeetCode2(t *testing.T) {
         runLeetExample(t, 2)
 }
+
+// TestSchemeCompiler_LeetCode3 runs the longest-substring example.
+func TestSchemeCompiler_LeetCode3(t *testing.T) {
+        runLeetExample(t, 3)
+}
 ```
 
 Execute them with the `slow` tag as they invoke an external interpreter:

--- a/compile/scheme/compiler_test.go
+++ b/compile/scheme/compiler_test.go
@@ -70,6 +70,11 @@ func TestSchemeCompiler_LeetCode2(t *testing.T) {
 	runLeetExample(t, 2)
 }
 
+// TestSchemeCompiler_LeetCode3 compiles the longest-substring example and runs it.
+func TestSchemeCompiler_LeetCode3(t *testing.T) {
+	runLeetExample(t, 3)
+}
+
 func TestSchemeCompiler_SubsetPrograms(t *testing.T) {
 	if _, err := schemecode.EnsureScheme(); err != nil {
 		t.Skipf("chibi-scheme not installed: %v", err)


### PR DESCRIPTION
## Summary
- update Scheme compiler to track simple variable types within a function
- emit `string-ref` when indexing string variables
- extend tests to compile/run LeetCode problem 3
- document new test in Scheme backend README

## Testing
- `go test ./...`
- `go test ./compile/scheme -run Leet -tags slow -v`


------
https://chatgpt.com/codex/tasks/task_e_6852c000f7c88320bb158b808fc6f2c7