### PR TITLE
Add Swift support to LeetCode runner

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -282,6 +282,18 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "swift":
+		if err := swiftcode.EnsureSwift(); err != nil {
+			return err
+		}
+		exe := strings.TrimSuffix(file, ".swift")
+		if out, err := exec.Command("swiftc", file, "-o", exe).CombinedOutput(); err != nil {
+			return fmt.Errorf("swiftc: %v\n%s", err, string(out))
+		}
+		cmd := exec.Command(exe)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -38,6 +38,17 @@ or directly with the CLI:
 mochi run 1/two-sum.mochi
 ```
 
+## Running Problems in Swift
+
+You can compile and run a range of problems using a different target
+language. For example, to build and execute the first three problems in
+Swift:
+
+```bash
+make range FROM=1 TO=3 LANG=swift
+```
+
+
 ## Running Tests
 
 Some solutions include `test` blocks. Execute all tests with:


### PR DESCRIPTION
## Summary
- enable running compiled Swift code via `swiftc`
- document running problems 1-3 in Swift in the LeetCode README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852c02ac3f0832093c2ff1f73ee818e