### PR TITLE
Add Zig break support

### DIFF
--- a/compile/zig/README.md
+++ b/compile/zig/README.md
@@ -186,7 +186,7 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 Variable declarations with `var` are now supported. Empty list values create a
 `std.ArrayList` for dynamic appends. Assignments of the form `list = list + [x]`
 translate to `list.append(x)`, and `while` statements map directly to Zig's
-`while` syntax.
+`while` syntax. `break` and `continue` pass through unchanged.
 
 List literals are emitted as fixed-size arrays or references when used in return
 expressions. Reserved words are prefixed with `_` by `sanitizeName`:

--- a/compile/zig/compiler.go
+++ b/compile/zig/compiler.go
@@ -171,6 +171,10 @@ func (c *Compiler) compileStmt(s *parser.Statement, inFun bool) error {
 		c.writeln("}")
 	case s.While != nil:
 		return c.compileWhile(s.While)
+	case s.Break != nil:
+		c.writeln("break;")
+	case s.Continue != nil:
+		c.writeln("continue;")
 	case s.Expr != nil:
 		v, err := c.compileExpr(s.Expr.Expr, false)
 		if err != nil {

--- a/compile/zig/compiler_test.go
+++ b/compile/zig/compiler_test.go
@@ -16,7 +16,7 @@ import (
 	"mochi/types"
 )
 
-func TestZigCompiler_LeetCode1to2(t *testing.T) {
+func TestZigCompiler_LeetCode1to3(t *testing.T) {
 	out, err := runExample(t, 1)
 	if err != nil {
 		t.Fatalf("run error: %v", err)
@@ -28,6 +28,11 @@ func TestZigCompiler_LeetCode1to2(t *testing.T) {
 	}
 
 	_, err = runExample(t, 2)
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	_, err = runExample(t, 3)
 	if err != nil {
 		t.Fatalf("run error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- handle `break` and `continue` in the Zig compiler
- update README for break/continue
- extend Zig integration test to run leetcode sample 3

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852c035f8048320b91d4690d335cfcf