### PR TITLE
Extend Pascal backend test coverage

### DIFF
--- a/compile/pas/compiler_test.go
+++ b/compile/pas/compiler_test.go
@@ -129,6 +129,7 @@ func TestPascalCompiler_LeetCodeExamples(t *testing.T) {
 	}
 	runExample(t, 1)
 	runExample(t, 2)
+	runExample(t, 3)
 }
 
 // runExample compiles all Mochi files in the given LeetCode problem

--- a/compile/pas/tools.go
+++ b/compile/pas/tools.go
@@ -22,7 +22,10 @@ func EnsureFPC() (string, error) {
 			if err := cmd.Run(); err != nil {
 				return "", err
 			}
-			cmd = exec.Command("apt-get", "install", "-y", "fp-compiler")
+			// Install the full Free Pascal suite which provides the
+			// compiler and required runtime units. Using the "fpc"
+			// meta-package ensures a consistent setup across systems.
+			cmd = exec.Command("apt-get", "install", "-y", "fpc")
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {

--- a/tests/compiler/pas/break_continue.pas.out
+++ b/tests/compiler/pas/break_continue.pas.out
@@ -9,14 +9,14 @@ var
 	numbers: TIntArray;
 
 begin
-	numbers := [1, 2, 3, 4, 5, 6, 7, 8, 9];
+	numbers := TIntArray([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 	for n in numbers do
 	begin
-		if n mod 2 = 0 then
+		if (n mod 2 = 0) then
 		begin
 			continue;
 		end;
-		if n > 7 then
+		if (n > 7) then
 		begin
 			break;
 		end;

--- a/tests/compiler/pas/if_else.pas.out
+++ b/tests/compiler/pas/if_else.pas.out
@@ -6,11 +6,11 @@ type TIntArray = array of integer;
 
 function foo(n: integer): integer;
 begin
-	if n < 0 then
+	if (n < 0) then
 	begin
 		result := -1;
 		exit;
-	end else if n = 0 then
+	end else if (n = 0) then
 	begin
 		result := 0;
 		exit;

--- a/tests/compiler/pas/two_sum.pas.out
+++ b/tests/compiler/pas/two_sum.pas.out
@@ -15,14 +15,14 @@ begin
 	begin
 		for j := i + 1 to n - 1 do
 		begin
-			if nums[i] + nums[j] = target then
+			if (nums[i] + nums[j] = target) then
 			begin
-				result := [i, j];
+				result := TIntArray([i, j]);
 				exit;
 			end;
 		end;
 	end;
-	result := [-1, -1];
+	result := TIntArray([-1, -1]);
 	exit;
 end;
 
@@ -30,7 +30,7 @@ var
 	_result: TIntArray;
 
 begin
-	_result := twoSum([2, 7, 11, 15], 9);
+	_result := twoSum(TIntArray([2, 7, 11, 15]), 9);
 	writeln(_result[0]);
 	writeln(_result[1]);
 end.

--- a/tests/compiler/pas/while_loop.pas.out
+++ b/tests/compiler/pas/while_loop.pas.out
@@ -9,7 +9,7 @@ var
 
 begin
 	i := 0;
-	while i < 3 do
+	while (i < 3) do
 	begin
 		writeln(i);
 		i := i + 1;


### PR DESCRIPTION
## Summary
- run LeetCode example 3 when testing the Pascal backend
- ensure full Free Pascal suite is installed when tests run
- handle Pascal list literals and concatenation
- update golden outputs

## Testing
- `go test ./compile/pas -run LeetCodeExamples -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852bfa22aa88320ac52bfdc6fe90344