### PR TITLE
Enable PHP compiler test for LeetCode #3

### DIFF
--- a/compile/php/README.md
+++ b/compile/php/README.md
@@ -200,7 +200,7 @@ func sanitizeName(name string) string {
 ## PHP installation helper
 
 `tools.go` offers `EnsurePHP` which attempts to install the PHP CLI via
-`apt-get` on Linux or Homebrew on macOS when missing:
+`apt-get`, `apk`, or Homebrew when missing:
 
 ```go
 // EnsurePHP ensures the php command is available, attempting installation if missing.
@@ -240,7 +240,7 @@ func EnsurePHP() error {
         return fmt.Errorf("php not installed")
 }
 ```
-【F:compile/php/tools.go†L10-L44】
+【F:compile/php/tools.go†L10-L52】
 
 ## Building
 
@@ -251,8 +251,9 @@ mochi build --target php main.mochi -o main.php
 php main.php
 ```
 
-For example, to run the [two-sum](../../examples/leetcode/1/two-sum.mochi)
-or [add-two-numbers](../../examples/leetcode/2/add-two-numbers.mochi)
+For example, to run the [two-sum](../../examples/leetcode/1/two-sum.mochi),
+[add-two-numbers](../../examples/leetcode/2/add-two-numbers.mochi),
+or [longest-substring-without-repeating-characters](../../examples/leetcode/3/longest-substring-without-repeating-characters.mochi)
 LeetCode solutions you can compile and execute them directly:
 
 ```bash
@@ -261,6 +262,9 @@ php two-sum.php
 
 mochi build --target php ../../examples/leetcode/2/add-two-numbers.mochi -o add-two-numbers.php
 php add-two-numbers.php
+
+mochi build --target php ../../examples/leetcode/3/longest-substring-without-repeating-characters.mochi -o longest-substring.php
+php longest-substring.php
 ```
 
 ## Tests

--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -60,6 +60,7 @@ func TestPHPCompiler_LeetCodeExamples(t *testing.T) {
 	}
 	runExample(t, 1)
 	runExample(t, 2)
+	runExample(t, 3)
 }
 
 func runExample(t *testing.T, i int) {

--- a/compile/php/tools.go
+++ b/compile/php/tools.go
@@ -28,6 +28,14 @@ func EnsurePHP() error {
 				break
 			}
 		}
+		if _, err := exec.LookPath("apk"); err == nil {
+			cmd := exec.Command("apk", "add", "--no-cache", "php-cli")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				break
+			}
+		}
 	case "darwin":
 		if _, err := exec.LookPath("brew"); err == nil {
 			cmd := exec.Command("brew", "install", "php")


### PR DESCRIPTION
## Summary
- run LeetCode example 3 in the PHP compiler tests
- document running the longest substring example in the PHP backend README
- support automatic PHP installation via apk on Alpine Linux

## Testing
- `go test ./compile/php -tags slow -run TestPHPCompiler_LeetCodeExamples -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6852bfad6f3c83208cb30883d8ff3e4a