### PR TITLE
Add LeetCode 3 test for Elixir backend

### DIFF
--- a/compile/ex/leetcode_test.go
+++ b/compile/ex/leetcode_test.go
@@ -80,6 +80,16 @@ func TestLeetCode2(t *testing.T) {
 	}
 }
 
+func TestLeetCode3(t *testing.T) {
+	if err := excode.EnsureElixir(); err != nil {
+		t.Skipf("elixir not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "3"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
 func findRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Summary
- extend Elixir backend tests to compile and run LeetCode problem 3

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852d12374e88320b3c8597a2b612983