### PR TITLE
Add Java runner for LeetCode examples

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -296,6 +296,22 @@ func runOutput(file, lang string) error {
 		runCmd.Stdout = os.Stdout
 		runCmd.Stderr = os.Stderr
 		return runCmd.Run()
+	case "java":
+		if err := javacode.EnsureJavac(); err != nil {
+			return err
+		}
+		dir := filepath.Dir(file)
+		cmd := exec.Command("javac", filepath.Base(file))
+		cmd.Dir = dir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		runCmd := exec.Command("java", "-cp", dir, "Main")
+		runCmd.Stdout = os.Stdout
+		runCmd.Stderr = os.Stderr
+		return runCmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -14,6 +14,10 @@ build: ## Build and run one problem in language. Usage: make build ID=<n> LANG=g
 @if [ -z "$(ID)" ]; then echo "❌ Usage: make build ID=<n> LANG=<lang>"; exit 1; fi
 @go run $(RUNNER) build --id $(ID) $(if $(LANG),--lang $(LANG)) --run
 
+run-java: ## Execute the compiled Java solution for problem n. Usage: make run-java ID=<n>
+@if [ -z "$(ID)" ]; then echo "❌ Usage: make run-java ID=<n>"; exit 1; fi
+@go run $(RUNNER) build --id $(ID) --lang java --run
+
 range: ## Build problems in range. Usage: make range FROM=1 TO=100 LANG=go
 @go run $(RUNNER) build --from $(FROM) --to $(TO) $(if $(LANG),--lang $(LANG)) --run
 

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -66,6 +66,7 @@ mochi run download.mochi
 - `make run ID=<n>` – run problem `n`
 - `make run-go ID=<n>` – execute the compiled Go solution for problem `n`
 - `make run-cpp ID=<n>` – execute the compiled C++ solution for problem `n`
+- `make run-java ID=<n>` – execute the compiled Java solution for problem `n`
 - `make compile` – generate Go, Python, TypeScript and C++ files into `../leetcode-out`
 - `make range FROM=1 TO=10 LANG=scala` – build problems in a range using the Scala backend
 - `make test` – run all tests


### PR DESCRIPTION
## Summary
- support running generated Java code in `leetcode-runner`
- track parameter types in Java compiler for helpers
- improve list and string handling for Java backend
- add Java make target and docs

## Testing
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/leetcode-runner build --from 1 --to 3 --lang java --run`

------
https://chatgpt.com/codex/tasks/task_e_6852d1a98c08832091ddce466cce0d2d