### PR TITLE
Add v0.8.5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # 📦 CHANGELOG.md
+## [0.8.5] – 2025-06-18
+
+### Added
+
+* LeetCode example tests for problems 1–3 across all compilers
+* Build command supports all targets at once
+* Improved .NET and PHP installation scripts
+
+### Changed
+
+* Compilers gain variable assignment, while loops and break/continue support
+* List and string operations expanded in Rust, Scheme, Java and others
+
+### Fixed
+
+* Fortran and Pascal compiler issues
+* Prolog if-block handling and C# golden outputs
+
 ## [0.8.4] – 2025-06-18
 
 ### Added

--- a/releases/v0.8.5.md
+++ b/releases/v0.8.5.md
@@ -1,0 +1,16 @@
+# Jun 2025 (v0.8.5)
+
+Mochi v0.8.5 focuses on running the first three LeetCode examples across all experimental compilers. Many backends gain new language features and assorted fixes to support these tests.
+
+## Compilers
+
+- Variable assignment, while loops and break/continue added in several languages
+- String indexing and list concatenation supported in Rust, Scheme and Java
+- Vector and list operations expanded for C++ and PHP
+- Option to build all targets at once and better .NET installation
+- Numerous fixes for Fortran, Pascal, Prolog and C# compilers
+
+## Tests
+
+- LeetCode example suites enabled for C, C++, C#, COBOL, Dart, Erlang, Fortran, Haskell, Java, Kotlin, Lua, Pascal, PHP, Prolog, Racket, Ruby, Rust, Scala, Scheme, Swift and Zig
+


### PR DESCRIPTION
## Summary
- document the v0.8.5 release
- log new features in CHANGELOG

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_6852d403771c8320b5a907790af640de