### PR TITLE
Enable Swift leetcode examples 1-3

### DIFF
--- a/compile/swift/README.md
+++ b/compile/swift/README.md
@@ -200,6 +200,22 @@ swiftc main.swift -o main
 
 `EnsureSwift` can be used by tests or scripts to install the toolchain automatically.
 
+To experiment, try compiling the first three [LeetCode](../../examples/leetcode) examples:
+
+```bash
+mochi build --target swift ../../examples/leetcode/1/two-sum.mochi -o two-sum.swift
+swiftc two-sum.swift -o two-sum
+./two-sum
+
+mochi build --target swift ../../examples/leetcode/2/add-two-numbers.mochi -o add-two-numbers.swift
+swiftc add-two-numbers.swift -o add-two-numbers
+./add-two-numbers
+
+mochi build --target swift ../../examples/leetcode/3/longest-substring-without-repeating-characters.mochi -o longest.swift
+swiftc longest.swift -o longest
+./longest
+```
+
 ## Tests
 
 The golden tests are tagged `slow` because they compile and run the generated Swift code:

--- a/compile/swift/compiler_test.go
+++ b/compile/swift/compiler_test.go
@@ -83,6 +83,13 @@ func TestSwiftCompiler_LeetCodeExample2(t *testing.T) {
 	runLeetExample(t, 2, "")
 }
 
+func TestSwiftCompiler_LeetCodeExample3(t *testing.T) {
+	if err := swiftcode.EnsureSwift(); err != nil {
+		t.Skipf("swift not installed: %v", err)
+	}
+	runLeetExample(t, 3, "")
+}
+
 func runLeetExample(t *testing.T, id int, want string) {
 	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(id))
 	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))


### PR DESCRIPTION
## Summary
- improve Swift compiler variable typing
- infer empty collection types from function return type
- wire up function environment scopes
- document compiling leetcode examples
- test Swift leetcode example 3

## Testing
- `go test ./compile/swift -run LeetCodeExample1 -tags slow`
- `go test ./compile/swift -run LeetCodeExample2 -tags slow`
- `go test ./compile/swift -run LeetCodeExample3 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6852d2f1ec7c8320a624ecf46d9ab7d3