### PR TITLE
Handle missing gnu-smalltalk gracefully

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -282,6 +282,14 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "st":
+		if err := stcode.EnsureSmalltalk(); err != nil {
+			return err
+		}
+		cmd := exec.Command("gst", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/compile/st/README.md
+++ b/compile/st/README.md
@@ -258,7 +258,10 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 
 ## Tools
 
-`EnsureSmalltalk` checks for the `gst` executable and attempts installation via `apt-get` or Homebrew when running on Linux or macOS:
+`EnsureSmalltalk` checks for the `gst` executable and attempts installation via
+`apt-get` or Homebrew when running on Linux or macOS. If installation fails
+(for example if the `gnu-smalltalk` package is unavailable) a warning is printed
+and the tool simply reports that `gst` is missing:
 
 ```go
 func EnsureSmalltalk() error {

--- a/compile/st/tools.go
+++ b/compile/st/tools.go
@@ -26,7 +26,7 @@ func EnsureSmalltalk() error {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {
-				return err
+				fmt.Println("⚠️  apt-get could not install gnu-smalltalk")
 			}
 		}
 	case "darwin":


### PR DESCRIPTION
## Summary
- handle `apt-get` install failure in `EnsureSmalltalk`
- document that `gnu-smalltalk` may be unavailable

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852c00ea44883208297d8419d618377