### PR TITLE
Extend Ruby tests to LeetCode 1-5

### DIFF
--- a/compile/rb/README.md
+++ b/compile/rb/README.md
@@ -118,6 +118,28 @@ ruby longest.rb
 
 The program defines the function and unit tests but running the compiled Ruby simply evaluates without output.
 
+### Example: LeetCode Median of Two Sorted Arrays
+
+To compile and run the `median-of-two-sorted-arrays` example located in `examples/leetcode/4`, use:
+
+```bash
+mochi build --target rb examples/leetcode/4/median-of-two-sorted-arrays.mochi -o median.rb
+ruby median.rb
+```
+
+This file only contains unit tests so there is no output when the program runs.
+
+### Example: LeetCode Longest Palindromic Substring
+
+To compile and run the `longest-palindromic-substring` example located in `examples/leetcode/5`, use:
+
+```bash
+mochi build --target rb examples/leetcode/5/longest-palindromic-substring.mochi -o palindrome.rb
+ruby palindrome.rb
+```
+
+Like the previous example this program just evaluates the test cases.
+
 `tools.go` provides `EnsureRuby` which attempts to install Ruby on Linux or macOS if it is missing:
 
 ```go

--- a/compile/rb/compiler_test.go
+++ b/compile/rb/compiler_test.go
@@ -82,7 +82,7 @@ func TestRBCompiler_LeetCodeExamples(t *testing.T) {
 	if err := rbcode.EnsureRuby(); err != nil {
 		t.Skipf("ruby not installed: %v", err)
 	}
-	for i := 1; i <= 3; i++ {
+	for i := 1; i <= 5; i++ {
 		runLeetExample(t, i)
 	}
 }

--- a/compile/rb/helpers.go
+++ b/compile/rb/helpers.go
@@ -6,6 +6,17 @@ import (
 	"mochi/parser"
 )
 
+var rbReserved = map[string]struct{}{
+	// Ruby keywords
+	"BEGIN": {}, "END": {}, "alias": {}, "and": {}, "begin": {}, "break": {},
+	"case": {}, "class": {}, "def": {}, "defined?": {}, "do": {}, "else": {},
+	"elsif": {}, "end": {}, "ensure": {}, "false": {}, "for": {}, "if": {},
+	"in": {}, "module": {}, "next": {}, "nil": {}, "not": {}, "or": {},
+	"redo": {}, "rescue": {}, "retry": {}, "return": {}, "self": {},
+	"super": {}, "then": {}, "true": {}, "undef": {}, "unless": {},
+	"until": {}, "when": {}, "while": {}, "yield": {},
+}
+
 func (c *Compiler) writeln(s string) {
 	c.writeIndent()
 	c.buf.WriteString(s)
@@ -33,6 +44,9 @@ func sanitizeName(name string) string {
 	s := b.String()
 	if s == "" || !((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z') || s[0] == '_') {
 		s = "_" + s
+	}
+	if _, ok := rbReserved[s]; ok {
+		return "_" + s
 	}
 	return s
 }


### PR DESCRIPTION
## Summary
- run Ruby backend tests for LeetCode problems 1-5
- document Ruby compilation examples for problems 4 and 5
- avoid Ruby keyword collisions in generated code

## Testing
- `go test ./compile/rb -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852d97931ec8320a8f649cd897f8fcb