### PR TITLE
Add Kotlin LeetCode runner

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -312,6 +312,22 @@ func runOutput(file, lang string) error {
 		runCmd.Stdout = os.Stdout
 		runCmd.Stderr = os.Stderr
 		return runCmd.Run()
+	case "kt":
+		if err := ktcode.EnsureKotlin(); err != nil {
+			return err
+		}
+		dir := filepath.Dir(file)
+		jar := filepath.Join(dir, strings.TrimSuffix(filepath.Base(file), ".kt")+".jar")
+		cmd := exec.Command("kotlinc", file, "-include-runtime", "-d", jar)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		runCmd := exec.Command("java", "-jar", jar)
+		runCmd.Stdout = os.Stdout
+		runCmd.Stderr = os.Stderr
+		return runCmd.Run()
 	case "fortran":
 		gfortran, err := ftncode.EnsureFortran()
 		if err != nil {


### PR DESCRIPTION
## Summary
- support executing compiled Kotlin code in `leetcode-runner`
- verify with Kotlin compiler tests

## Testing
- `go test ./compile/kt -tags slow -run TestKTCompiler_LeetCodeExamples -v`

------
https://chatgpt.com/codex/tasks/task_e_6852d96a1a648320b3ab5b82f6981bc6