### PR TITLE
Add C++ slice support and run first five LeetCode problems

### DIFF
--- a/compile/cpp/compiler.go
+++ b/compile/cpp/compiler.go
@@ -330,8 +330,21 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) string {
 	expr := c.compilePrimary(p.Target)
 	for _, op := range p.Ops {
 		if op.Index != nil {
-			idx := c.compileExpr(op.Index.Start)
-			expr = fmt.Sprintf("%s[%s]", expr, idx)
+			// Handle simple index or slice
+			if op.Index.Colon == nil {
+				idx := c.compileExpr(op.Index.Start)
+				expr = fmt.Sprintf("%s[%s]", expr, idx)
+			} else {
+				start := "0"
+				if op.Index.Start != nil {
+					start = c.compileExpr(op.Index.Start)
+				}
+				end := fmt.Sprintf("%s.size()", expr)
+				if op.Index.End != nil {
+					end = c.compileExpr(op.Index.End)
+				}
+				expr = fmt.Sprintf("%s.substr(%s, %s - %s)", expr, start, end, start)
+			}
 		}
 	}
 	return expr

--- a/compile/cpp/compiler_test.go
+++ b/compile/cpp/compiler_test.go
@@ -27,7 +27,7 @@ func TestCPPCompiler_AddTwoNumbers(t *testing.T) {
 }
 
 func TestCPPCompiler_LeetCodeExamples(t *testing.T) {
-	runCPPLeetRange(t, 1, 3)
+	runCPPLeetRange(t, 1, 5)
 }
 
 func TestCPPCompiler_SubsetPrograms(t *testing.T) {


### PR DESCRIPTION
## Summary
- support string slicing in the C++ backend
- extend C++ integration test to compile LeetCode problems 1-5

## Testing
- `go test ./compile/cpp -run LeetCodeExamples -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852d95194788320a09136082163c91c