### PR TITLE
Add Fortran features for LeetCode examples

### DIFF
--- a/compile/fortran/compiler_test.go
+++ b/compile/fortran/compiler_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestFortranCompiler_LeetExamples(t *testing.T) {
-	for i := 1; i <= 3; i++ {
+	for i := 1; i <= 5; i++ {
 		runFortranLeetExample(t, fmt.Sprint(i))
 	}
 }


### PR DESCRIPTION
## Summary
- improve Fortran compiler with float literals and casts
- support slice expressions for lists and strings
- allow functions to return floats and accept float params
- extend Fortran example tests to problems 1-5

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852d95f90888320b79acd5b8732b668