### PR TITLE
Enable Racket backend for more leetcode examples

### DIFF
--- a/compile/rkt/compiler_test.go
+++ b/compile/rkt/compiler_test.go
@@ -116,6 +116,8 @@ func TestRacketCompiler_LeetCodeExamples(t *testing.T) {
 	runRacketLeetExample(t, 1)
 	runRacketLeetExample(t, 2)
 	runRacketLeetExample(t, 3)
+	runRacketLeetExample(t, 4)
+	runRacketLeetExample(t, 5)
 }
 
 func runRacketLeetExample(t *testing.T, id int) {

--- a/tests/compiler/rkt/for_list_collection.rkt.out
+++ b/tests/compiler/rkt/for_list_collection.rkt.out
@@ -1,6 +1,9 @@
 #lang racket
+(require racket/list)
+
+(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (for ([n (list 1 2 3)])
 	(displayln n)
 )
-

--- a/tests/compiler/rkt/for_loop.rkt.out
+++ b/tests/compiler/rkt/for_loop.rkt.out
@@ -1,6 +1,9 @@
 #lang racket
+(require racket/list)
+
+(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (for ([i (in-range 1 4)])
 	(displayln i)
 )
-

--- a/tests/compiler/rkt/if_else.rkt.out
+++ b/tests/compiler/rkt/if_else.rkt.out
@@ -1,4 +1,8 @@
 #lang racket
+(require racket/list)
+
+(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define x 2)
 (if (= x 1)
@@ -14,4 +18,3 @@
 		)
 	)
 )
-

--- a/tests/compiler/rkt/let_and_print.rkt.out
+++ b/tests/compiler/rkt/let_and_print.rkt.out
@@ -1,6 +1,9 @@
 #lang racket
+(require racket/list)
+
+(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define a 10)
 (define b 20)
 (displayln (+ a b))
-

--- a/tests/compiler/rkt/string_for_loop.rkt.out
+++ b/tests/compiler/rkt/string_for_loop.rkt.out
@@ -1,4 +1,8 @@
 #lang racket
+(require racket/list)
+
+(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (for ([ch "cat"])
 	(displayln ch)

--- a/tests/compiler/rkt/two_sum.rkt.out
+++ b/tests/compiler/rkt/two_sum.rkt.out
@@ -1,11 +1,15 @@
 #lang racket
+(require racket/list)
+
+(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define (twoSum nums target)
 	(let/ec return
 		(define n (length nums))
 		(for ([i (in-range 0 n)])
 			(for ([j (in-range (+ i 1) n)])
-				(if (= (+ (list-ref nums i) (list-ref nums j)) target)
+				(if (= (+ (idx nums i) (idx nums j)) target)
 					(begin
 						(return (list i j))
 					)
@@ -19,6 +23,5 @@
 )
 
 (define result (twoSum (list 2 7 11 15) 9))
-(displayln (list-ref result 0))
-(displayln (list-ref result 1))
-
+(displayln (idx result 0))
+(displayln (idx result 1))


### PR DESCRIPTION
## Summary
- extend Racket compiler with helper functions to handle indexing, slices and type casts
- update compiler tests to run leetcode examples 1-5
- refresh golden Racket outputs

## Testing
- `go test ./compile/rkt -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852d97c344c832088300f2101963c42