### PR TITLE
Add clojure float support and extend tests

### DIFF
--- a/compile/clj/compiler_test.go
+++ b/compile/clj/compiler_test.go
@@ -159,4 +159,6 @@ func TestClojureCompiler_LeetCodeExamples(t *testing.T) {
 	runLeetExample(t, 1)
 	runLeetExample(t, 2)
 	runLeetExample(t, 3)
+	runLeetExample(t, 4)
+	runLeetExample(t, 5)
 }


### PR DESCRIPTION
## Summary
- handle float literals and casts in Clojure backend
- switch to `/` when operands include floats
- run LeetCode examples 1-5 in Clojure tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852d94e3bb083208b08be636e145dd9