### PR TITLE
Add F# cast & slice support, run LC 1-5

### DIFF
--- a/compile/fs/compiler_test.go
+++ b/compile/fs/compiler_test.go
@@ -219,4 +219,6 @@ func TestFSCompiler_LeetCodeExamples(t *testing.T) {
 	runLeetExample(t, 1)
 	runLeetExample(t, 2)
 	runLeetExample(t, 3)
+	runLeetExample(t, 4)
+	runLeetExample(t, 5)
 }


### PR DESCRIPTION
## Summary
- support cast expressions and slicing in F# backend
- sanitize reserved words like `end`
- extend LeetCode example tests to run problems 1-5

## Testing
- `go test ./...`
- `go test ./compile/fs -tags slow -run TestFSCompiler_LeetCodeExamples -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6852d961e34883209ff71f514610284a