### PR TITLE
Extend Scheme compiler features

### DIFF
--- a/compile/scheme/README.md
+++ b/compile/scheme/README.md
@@ -255,6 +255,16 @@ func TestSchemeCompiler_LeetCode2(t *testing.T) {
 func TestSchemeCompiler_LeetCode3(t *testing.T) {
         runLeetExample(t, 3)
 }
+
+// TestSchemeCompiler_LeetCode4 runs the median-of-two-sorted-arrays example.
+func TestSchemeCompiler_LeetCode4(t *testing.T) {
+        runLeetExample(t, 4)
+}
+
+// TestSchemeCompiler_LeetCode5 runs the longest-palindromic-substring example.
+func TestSchemeCompiler_LeetCode5(t *testing.T) {
+        runLeetExample(t, 5)
+}
 ```
 
 Execute them with the `slow` tag as they invoke an external interpreter:

--- a/compile/scheme/compiler_test.go
+++ b/compile/scheme/compiler_test.go
@@ -75,6 +75,16 @@ func TestSchemeCompiler_LeetCode3(t *testing.T) {
 	runLeetExample(t, 3)
 }
 
+// TestSchemeCompiler_LeetCode4 compiles the median-of-two-sorted-arrays example and runs it.
+func TestSchemeCompiler_LeetCode4(t *testing.T) {
+	runLeetExample(t, 4)
+}
+
+// TestSchemeCompiler_LeetCode5 compiles the longest-palindromic-substring example and runs it.
+func TestSchemeCompiler_LeetCode5(t *testing.T) {
+	runLeetExample(t, 5)
+}
+
 func TestSchemeCompiler_SubsetPrograms(t *testing.T) {
 	if _, err := schemecode.EnsureScheme(); err != nil {
 		t.Skipf("chibi-scheme not installed: %v", err)


### PR DESCRIPTION
## Summary
- allow floats and casts in Scheme compiler
- handle `let` statements in Scheme scope
- add LeetCode examples 4-5 to Scheme tests

## Testing
- `go test ./compile/scheme -run LeetCode -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6852d9833b948320b3665e6a024ee86c