### PR TITLE
Extend Zig compiler tests

### DIFF
--- a/compile/zig/README.md
+++ b/compile/zig/README.md
@@ -211,11 +211,10 @@ zig build-exe main.zig -O ReleaseSafe -femit-bin=main
 
 ## Tests
 
-`compiler_test.go` runs a golden test using the real Zig compiler. It compiles a
-Mochi example and compares the output:
+`compiler_test.go` runs a golden test using the real Zig compiler. It compiles several LeetCode examples and compares the output:
 
 ```go
-func TestZigCompiler_TwoSum(t *testing.T) {
+func TestZigCompiler_LeetCode1to5(t *testing.T) {
         zigc, err := zigcode.EnsureZig()
         if err != nil {
                 t.Skipf("zig compiler not installed: %v", err)

--- a/compile/zig/compiler.go
+++ b/compile/zig/compiler.go
@@ -311,7 +311,14 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr, asReturn bool) (string, e
 		if err != nil {
 			return "", err
 		}
-		expr = fmt.Sprintf("(%s %s %s)", expr, op.Op, right)
+		opStr := op.Op
+		switch opStr {
+		case "&&":
+			opStr = "and"
+		case "||":
+			opStr = "or"
+		}
+		expr = fmt.Sprintf("(%s %s %s)", expr, opStr, right)
 	}
 	return expr, nil
 }

--- a/compile/zig/compiler_test.go
+++ b/compile/zig/compiler_test.go
@@ -16,7 +16,7 @@ import (
 	"mochi/types"
 )
 
-func TestZigCompiler_LeetCode1to3(t *testing.T) {
+func TestZigCompiler_LeetCode1to5(t *testing.T) {
 	out, err := runExample(t, 1)
 	if err != nil {
 		t.Fatalf("run error: %v", err)
@@ -33,6 +33,16 @@ func TestZigCompiler_LeetCode1to3(t *testing.T) {
 	}
 
 	_, err = runExample(t, 3)
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	_, err = runExample(t, 4)
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	_, err = runExample(t, 5)
 	if err != nil {
 		t.Fatalf("run error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- cover LeetCode problems 1-5 for the Zig backend
- update Zig backend to use `and`/`or` operators
- document the updated test in the Zig backend README

## Testing
- `go test -tags slow ./compile/zig -run LeetCode -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6852d98f3fcc8320b6f5422db377312c