### PR TITLE
Enable PHP runner for Mochi LeetCode solutions

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -325,6 +325,14 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "php":
+		if err := phpcode.EnsurePHP(); err != nil {
+			return err
+		}
+		cmd := exec.Command("php", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -61,6 +61,8 @@ func TestPHPCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(t, 1)
 	runExample(t, 2)
 	runExample(t, 3)
+	runExample(t, 4)
+	runExample(t, 5)
 }
 
 func runExample(t *testing.T, i int) {

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -18,6 +18,10 @@ run-java: ## Execute the compiled Java solution for problem n. Usage: make run-j
 @if [ -z "$(ID)" ]; then echo "❌ Usage: make run-java ID=<n>"; exit 1; fi
 @go run $(RUNNER) build --id $(ID) --lang java --run
 
+run-php: ## Execute the compiled PHP solution for problem n. Usage: make run-php ID=<n>
+@if [ -z "$(ID)" ]; then echo "❌ Usage: make run-php ID=<n>"; exit 1; fi
+@go run $(RUNNER) build --id $(ID) --lang php --run
+
 range: ## Build problems in range. Usage: make range FROM=1 TO=100 LANG=go
 @go run $(RUNNER) build --from $(FROM) --to $(TO) $(if $(LANG),--lang $(LANG)) --run
 

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -67,8 +67,17 @@ mochi run download.mochi
 - `make run-go ID=<n>` – execute the compiled Go solution for problem `n`
 - `make run-cpp ID=<n>` – execute the compiled C++ solution for problem `n`
 - `make run-java ID=<n>` – execute the compiled Java solution for problem `n`
+- `make run-php ID=<n>` – execute the compiled PHP solution for problem `n`
 - `make compile` – generate Go, Python, TypeScript and C++ files into `../leetcode-out`
 - `make range FROM=1 TO=10 LANG=scala` – build problems in a range using the Scala backend
 - `make test` – run all tests
 - `make clean` – remove the downloaded binary
+
+### Run First Five Problems in PHP
+
+Compile and execute problems 1 through 5 using the PHP backend:
+
+```bash
+make range FROM=1 TO=5 LANG=php
+```
 


### PR DESCRIPTION
## Summary
- allow `leetcode-runner` to execute generated PHP code
- add `run-php` target in examples Makefile
- document running PHP solutions, including range 1..5
- expand compiler tests to cover the first five LeetCode problems in PHP

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852d97413948320aac7d16436bf37c5