### PR TITLE
Add OCaml features for leetcode examples 1-5

### DIFF
--- a/compile/ocaml/compiler_test.go
+++ b/compile/ocaml/compiler_test.go
@@ -119,8 +119,9 @@ func TestOCamlCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestOCamlCompiler_LeetCodeExamples(t *testing.T) {
-	runExample(t, 1)
-	runExample(t, 2)
+	for i := 1; i <= 5; i++ {
+		runExample(t, i)
+	}
 }
 
 func runExample(t *testing.T, i int) {


### PR DESCRIPTION
## Summary
- handle float literals, casts and `/` for floats in OCaml backend
- support string slicing/indexing and sanitize OCaml keywords
- record parameter types when compiling functions
- extend OCaml tests to run LeetCode examples 1..5

## Testing
- `go test ./compile/ocaml -tags slow -run LeetCodeExamples -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852d96f86908320932595a00ab8cb1e