### PR TITLE
Extend Lua compiler to run tests

### DIFF
--- a/compile/lua/compiler_test.go
+++ b/compile/lua/compiler_test.go
@@ -155,6 +155,8 @@ func TestLuaCompiler_LeetCodeExamples(t *testing.T) {
 	runLeetCode(t, 1, "0\n1")
 	runLeetCode(t, 2, "")
 	runLeetCode(t, 3, "")
+	runLeetCode(t, 4, "")
+	runLeetCode(t, 5, "")
 }
 
 func runLeetCode(t *testing.T, id int, want string) {


### PR DESCRIPTION
## Summary
- compile and run `test` blocks in Lua backend
- note the new capability in Lua docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852d96c30748320ae8a37f5a856c7e2