### PR TITLE
Add Dart runner and extend LeetCode coverage

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -282,6 +282,14 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "dart":
+		if err := dartcode.EnsureDart(); err != nil {
+			return err
+		}
+		cmd := exec.Command("dart", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	case "scala":
 		dir := filepath.Dir(file)
 		cmd := exec.Command("scalac", filepath.Base(file))

--- a/compile/dart/leetcode_test.go
+++ b/compile/dart/leetcode_test.go
@@ -89,3 +89,23 @@ func TestLeetCode3(t *testing.T) {
 		t.Fatalf("unexpected output: %q", got)
 	}
 }
+
+func TestLeetCode4(t *testing.T) {
+	if err := dartcode.EnsureDart(); err != nil {
+		t.Skipf("dart not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "4"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode5(t *testing.T) {
+	if err := dartcode.EnsureDart(); err != nil {
+		t.Skipf("dart not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "5"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- allow dart programs to be executed by `leetcode-runner`
- keep variable types flexible in Dart codegen
- support slicing in Dart compiler
- test Dart backend with LeetCode problems 1-5

## Testing
- `go test ./compile/dart -run TestLeetCode -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6852d9567c188320b35453facddb8753