### PR TITLE
Extend COBOL tests to LeetCode 5

### DIFF
--- a/compile/cobol/README.md
+++ b/compile/cobol/README.md
@@ -68,13 +68,16 @@ cobc -free -x two-sum.cob -o two-sum
 ./two-sum    # prints "0" and then "1"
 ```
 
-The compiler tests include a helper that compiles and executes the first three
+The compiler tests include a helper that compiles and executes the first five
 LeetCode examples using the COBOL backend. Run the tests with the `slow` build
 tag to try it out:
 
 ```bash
 go test ./compile/cobol -tags slow -run LeetCode
 ```
+
+Programs that contain `test` blocks will have the results captured and emitted
+in the generated COBOL output.
 
 `EnsureCOBOL` attempts to install the GNU COBOL toolchain automatically when
 running tests, but you may need to install it manually before using `cobc`

--- a/compile/cobol/compiler_test.go
+++ b/compile/cobol/compiler_test.go
@@ -209,6 +209,14 @@ func TestCobolCompiler_LeetCodeExamples(t *testing.T) {
 					if string(got) != "0\n1" {
 						t.Fatalf("unexpected output: %s", got)
 					}
+				} else {
+					str := string(out)
+					if !strings.Contains(str, "ok") {
+						t.Fatalf("no test output: %s", str)
+					}
+					if strings.Contains(str, "fail") {
+						t.Fatalf("test failed: %s", str)
+					}
 				}
 			})
 		}
@@ -217,4 +225,6 @@ func TestCobolCompiler_LeetCodeExamples(t *testing.T) {
 	runExample(1)
 	runExample(2)
 	runExample(3)
+	runExample(4)
+	runExample(5)
 }


### PR DESCRIPTION
## Summary
- run COBOL compiler tests on LeetCode examples 1–5
- update README to note the first five examples are covered
- embed test results when compiling Mochi programs to COBOL

## Testing
- `go test ./compile/cobol -run LeetCode -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852d94f55408320a9cb5e39003dba28