### PR TITLE
Add missing Haskell defaults and update goldens

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -325,6 +325,14 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "hs":
+		if err := hscode.EnsureHaskell(); err != nil {
+			return err
+		}
+		cmd := exec.Command("runhaskell", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/compile/hs/README.md
+++ b/compile/hs/README.md
@@ -67,6 +67,15 @@ toolchain. Run them with:
 go test ./compile/hs -tags slow
 ```
 
+## LeetCode Examples
+
+The `leetcode-runner` command can build and execute the first few
+LeetCode solutions using the Haskell backend:
+
+```bash
+go run ./cmd/leetcode-runner build --from 1 --to 5 --lang hs --run
+```
+
 ## Notes
 
 The Haskell backend currently supports a limited subset of Mochi: function

--- a/compile/hs/compiler.go
+++ b/compile/hs/compiler.go
@@ -178,6 +178,8 @@ func zeroValue(t types.Type) string {
 		return "False"
 	case types.ListType:
 		return "[]"
+	case types.FuncType, types.AnyType:
+		return "undefined"
 	default:
 		return "()"
 	}

--- a/tests/compiler/hs/closure.hs.out
+++ b/tests/compiler/hs/closure.hs.out
@@ -27,8 +27,8 @@ _input :: IO String
 _input = getLine
 
 
-makeAdder n = fromMaybe ((\x -> (x + n))) $
-    Nothing
+makeAdder n = fromMaybe (undefined) $
+    Just ((\x -> (x + n)))
 
 main :: IO ()
 main = do

--- a/tests/compiler/hs/fun_call.hs.out
+++ b/tests/compiler/hs/fun_call.hs.out
@@ -27,8 +27,8 @@ _input :: IO String
 _input = getLine
 
 
-add a b = fromMaybe ((a + b)) $
-    Nothing
+add a b = fromMaybe (0) $
+    Just ((a + b))
 
 main :: IO ()
 main = do


### PR DESCRIPTION
## Summary
- update golden outputs for the Haskell backend
- add `FuncType` handling in `zeroValue` so generated Haskell compiles

## Testing
- `go test ./compile/hs -tags slow -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852d9652b8c832091297a8b89bbaf0d