### PR TITLE
Add Scala slice support and leetcode tests 1-5

### DIFF
--- a/compile/scala/compiler.go
+++ b/compile/scala/compiler.go
@@ -394,11 +394,31 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 	}
 	for _, op := range p.Ops {
 		if op.Index != nil {
-			idx, err := c.compileExpr(op.Index.Start)
-			if err != nil {
-				return "", err
+			if op.Index.Colon != nil {
+				start := "0"
+				if op.Index.Start != nil {
+					s, err := c.compileExpr(op.Index.Start)
+					if err != nil {
+						return "", err
+					}
+					start = s
+				}
+				end := fmt.Sprintf("%s.length", expr)
+				if op.Index.End != nil {
+					e, err := c.compileExpr(op.Index.End)
+					if err != nil {
+						return "", err
+					}
+					end = e
+				}
+				expr = fmt.Sprintf("%s.slice(%s, %s)", expr, start, end)
+			} else {
+				idx, err := c.compileExpr(op.Index.Start)
+				if err != nil {
+					return "", err
+				}
+				expr = fmt.Sprintf("%s(%s)", expr, idx)
 			}
-			expr = fmt.Sprintf("%s(%s)", expr, idx)
 			continue
 		}
 		if op.Call != nil {

--- a/compile/scala/compiler_test.go
+++ b/compile/scala/compiler_test.go
@@ -17,22 +17,12 @@ import (
 	"mochi/types"
 )
 
-// TestScalaCompiler_LeetCodeExample1 compiles the LeetCode two-sum example
-// and verifies the generated Scala program runs as expected.
-func TestScalaCompiler_LeetCodeExample1(t *testing.T) {
-	runLeetExample(t, 1)
-}
-
-// TestScalaCompiler_LeetCodeExample2 compiles the add-two-numbers example and
-// verifies the generated Scala program runs without errors.
-func TestScalaCompiler_LeetCodeExample2(t *testing.T) {
-	runLeetExample(t, 2)
-}
-
-// TestScalaCompiler_LeetCodeExample3 compiles the longest-substring example
-// and ensures the generated Scala code runs correctly.
-func TestScalaCompiler_LeetCodeExample3(t *testing.T) {
-	runLeetExample(t, 3)
+// TestScalaCompiler_LeetCodeExamples compiles and runs the first five LeetCode
+// examples using the Scala backend.
+func TestScalaCompiler_LeetCodeExamples(t *testing.T) {
+	for i := 1; i <= 5; i++ {
+		runLeetExample(t, i)
+	}
 }
 
 func TestScalaCompiler_SubsetPrograms(t *testing.T) {


### PR DESCRIPTION
## Summary
- support slice syntax in Scala compiler
- add Scala tests for leetcode examples 4 and 5
- combine Scala LeetCode tests into one function

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852d980cd1c8320a31bf7aefc2c323c