### PR TITLE
Extend Rust compiler leetcode coverage

### DIFF
--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -105,6 +105,12 @@ func TestRustCompiler_ValidPrograms(t *testing.T) {
 	t.Run("leetcode_3", func(t *testing.T) {
 		runRustLeet(t, 3)
 	})
+	t.Run("leetcode_4", func(t *testing.T) {
+		runRustLeet(t, 4)
+	})
+	t.Run("leetcode_5", func(t *testing.T) {
+		runRustLeet(t, 5)
+	})
 }
 
 func runRustProgram(t *testing.T, src string) {


### PR DESCRIPTION
## Summary
- run rust leetcode tests for problems 1-5
- handle string slices and casts in Rust backend
- support float literals and string return conversions

## Testing
- `go vet ./...`
- `go test -tags slow ./compile/rust -run ValidPrograms -v`

------
https://chatgpt.com/codex/tasks/task_e_6852d97e9f248320b2a0c57ef7a360e1