### PR TITLE
Add Dart outputs for LeetCode 1-5

### DIFF
--- a/examples/leetcode-out/dart/1/two-sum.dart
+++ b/examples/leetcode-out/dart/1/two-sum.dart
@@ -1,0 +1,17 @@
+dynamic twoSum(nums, target) {
+	dynamic n = nums.length;
+	for (var i = 0; i < n; i++) {
+		for (var j = (i + 1); j < n; j++) {
+			if (((nums[i] + nums[j]) == target)) {
+				return [i, j];
+			}
+		}
+	}
+	return [-1, -1];
+}
+
+void main() {
+	dynamic result = twoSum([2, 7, 11, 15], 9);
+	print(result[0]);
+	print(result[1]);
+}

--- a/examples/leetcode-out/dart/2/add-two-numbers.dart
+++ b/examples/leetcode-out/dart/2/add-two-numbers.dart
@@ -1,0 +1,26 @@
+dynamic addTwoNumbers(l1, l2) {
+	dynamic i = 0;
+	dynamic j = 0;
+	dynamic carry = 0;
+	dynamic result = [];
+	while ((((i < l1.length) || (j < l2.length)) || (carry > 0))) {
+		dynamic x = 0;
+		if ((i < l1.length)) {
+			x = l1[i];
+			i = (i + 1);
+		}
+		dynamic y = 0;
+		if ((j < l2.length)) {
+			y = l2[j];
+			j = (j + 1);
+		}
+		dynamic sum = ((x + y) + carry);
+		dynamic digit = (sum % 10);
+		carry = (sum ~/ 10);
+		result = (result + [digit]);
+	}
+	return result;
+}
+
+void main() {
+}

--- a/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
+++ b/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
@@ -1,0 +1,25 @@
+dynamic lengthOfLongestSubstring(s) {
+	dynamic n = s.length;
+	dynamic start = 0;
+	dynamic best = 0;
+	dynamic i = 0;
+	while ((i < n)) {
+		dynamic j = start;
+		while ((j < i)) {
+			if ((s[j] == s[i])) {
+				start = (j + 1);
+				break;
+			}
+			j = (j + 1);
+		}
+		dynamic length = ((i - start) + 1);
+		if ((length > best)) {
+			best = length;
+		}
+		i = (i + 1);
+	}
+	return best;
+}
+
+void main() {
+}

--- a/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
+++ b/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
@@ -1,0 +1,32 @@
+dynamic findMedianSortedArrays(nums1, nums2) {
+	dynamic merged = [];
+	dynamic i = 0;
+	dynamic j = 0;
+	while (((i < nums1.length) || (j < nums2.length))) {
+		if ((j >= nums2.length)) {
+			merged = (merged + [nums1[i]]);
+			i = (i + 1);
+		} else 
+		if ((i >= nums1.length)) {
+			merged = (merged + [nums2[j]]);
+			j = (j + 1);
+		} else 
+		if ((nums1[i] <= nums2[j])) {
+			merged = (merged + [nums1[i]]);
+			i = (i + 1);
+		} else {
+			merged = (merged + [nums2[j]]);
+			j = (j + 1);
+		}
+	}
+	dynamic total = merged.length;
+	if (((total % 2) == 1)) {
+		return merged[(total ~/ 2)];
+	}
+	dynamic mid1 = merged[((total ~/ 2) - 1)];
+	dynamic mid2 = merged[(total ~/ 2)];
+	return (((mid1 + mid2)) ~/ 2);
+}
+
+void main() {
+}

--- a/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
+++ b/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
@@ -1,0 +1,38 @@
+dynamic expand(s, left, right) {
+	dynamic l = left;
+	dynamic r = right;
+	dynamic n = s.length;
+	while (((l >= 0) && (r < n))) {
+		if ((s[l] != s[r])) {
+			break;
+		}
+		l = (l - 1);
+		r = (r + 1);
+	}
+	return ((r - l) - 1);
+}
+
+dynamic longestPalindrome(s) {
+	if ((s.length <= 1)) {
+		return s;
+	}
+	dynamic start = 0;
+	dynamic end = 0;
+	dynamic n = s.length;
+	for (var i = 0; i < n; i++) {
+		dynamic len1 = expand(s, i, i);
+		dynamic len2 = expand(s, i, (i + 1));
+		dynamic l = len1;
+		if ((len2 > len1)) {
+			l = len2;
+		}
+		if ((l > (end - start))) {
+			start = (i - (((l - 1)) ~/ 2));
+			end = (i + (l ~/ 2));
+		}
+	}
+	return s.sublist(start, (end + 1));
+}
+
+void main() {
+}

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -67,7 +67,7 @@ mochi run download.mochi
 - `make run-go ID=<n>` – execute the compiled Go solution for problem `n`
 - `make run-cpp ID=<n>` – execute the compiled C++ solution for problem `n`
 - `make run-java ID=<n>` – execute the compiled Java solution for problem `n`
-- `make compile` – generate Go, Python, TypeScript and C++ files into `../leetcode-out`
+- `make compile` – generate Go, Python, TypeScript, Dart and C++ files into `../leetcode-out`
 - `make range FROM=1 TO=10 LANG=scala` – build problems in a range using the Scala backend
 - `make test` – run all tests
 - `make clean` – remove the downloaded binary


### PR DESCRIPTION
## Summary
- compile LeetCode problems 1-5 to Dart
- record generated Dart code under `examples/leetcode-out/dart`
- document Dart output in the LeetCode README

## Testing
- `go test ./compile/dart -run TestLeetCode -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6852e3115e2c8320a601cc5f3451d6ab