### PR TITLE
Add Zig runner for LeetCode examples

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -358,6 +358,19 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "zig":
+		zigc, err := zigcode.EnsureZig()
+		if err != nil {
+			return err
+		}
+		exe := strings.TrimSuffix(file, ".zig")
+		if out, err := exec.Command(zigc, "build-exe", file, "-O", "ReleaseSafe", "-femit-bin="+exe).CombinedOutput(); err != nil {
+			return fmt.Errorf("zig build: %v\n%s", err, out)
+		}
+		cmd := exec.Command(exe)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	default:
 		return fmt.Errorf("no runner for %s", lang)
 	}

--- a/examples/leetcode-out/zig/1/two-sum.zig
+++ b/examples/leetcode-out/zig/1/two-sum.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+
+fn twoSum(nums: []const i32, target: i32) [2]i32 {
+	const n = nums.len;
+	for (0 .. n) |i| {
+		for ((i + 1) .. n) |j| {
+			if (((nums[i] + nums[j]) == target)) {
+				return [_]i32{@as(i32,@intCast(i)), @as(i32,@intCast(j))};
+			}
+		}
+	}
+	return [_]i32{@as(i32,@intCast(-1)), @as(i32,@intCast(-1))};
+}
+
+pub fn main() void {
+	const result = twoSum(&[_]i32{@as(i32,@intCast(2)), @as(i32,@intCast(7)), @as(i32,@intCast(11)), @as(i32,@intCast(15))}, 9);
+	std.debug.print("{}\n", .{result[0]});
+	std.debug.print("{}\n", .{result[1]});
+}

--- a/examples/leetcode-out/zig/2/add-two-numbers.zig
+++ b/examples/leetcode-out/zig/2/add-two-numbers.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+fn addTwoNumbers(l1: []const i32, l2: []const i32) [2]i32 {
+	var i = 0;
+	var j = 0;
+	var carry = 0;
+	var result = std.ArrayList(i32).init(std.heap.page_allocator);
+	while ((((((i < l1.len) or j) < l2.len) or carry) > 0)) {
+		var x = 0;
+		if ((i < l1.len)) {
+			x = l1[i];
+			i = (i + 1);
+		}
+		var y = 0;
+		if ((j < l2.len)) {
+			y = l2[j];
+			j = (j + 1);
+		}
+		const sum = ((x + y) + carry);
+		const digit = (sum % 10);
+		carry = (sum / 10);
+		try result.append(@as(i32,@intCast(digit)));
+	}
+	return result;
+}
+
+pub fn main() void {
+}

--- a/examples/leetcode-out/zig/3/longest-substring-without-repeating-characters.zig
+++ b/examples/leetcode-out/zig/3/longest-substring-without-repeating-characters.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+fn lengthOfLongestSubstring(s: []const u8) [2]i32 {
+	const n = s.len;
+	var start = 0;
+	var best = 0;
+	var i = 0;
+	while ((i < n)) {
+		var j = start;
+		while ((j < i)) {
+			if ((s[j] == s[i])) {
+				start = (j + 1);
+				break;
+			}
+			j = (j + 1);
+		}
+		const length = ((i - start) + 1);
+		if ((length > best)) {
+			best = length;
+		}
+		i = (i + 1);
+	}
+	return best;
+}
+
+pub fn main() void {
+}

--- a/examples/leetcode-out/zig/4/median-of-two-sorted-arrays.zig
+++ b/examples/leetcode-out/zig/4/median-of-two-sorted-arrays.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+
+fn findMedianSortedArrays(nums1: []const i32, nums2: []const i32) [2]i32 {
+	var merged = std.ArrayList(i32).init(std.heap.page_allocator);
+	var i = 0;
+	var j = 0;
+	while ((((i < nums1.len) or j) < nums2.len)) {
+		if ((j >= nums2.len)) {
+			try merged.append(@as(i32,@intCast(nums1[i])));
+			i = (i + 1);
+		} else 		if ((i >= nums1.len)) {
+			try merged.append(@as(i32,@intCast(nums2[j])));
+			j = (j + 1);
+		} else 		if ((nums1[i] <= nums2[j])) {
+			try merged.append(@as(i32,@intCast(nums1[i])));
+			i = (i + 1);
+		} else {
+			try merged.append(@as(i32,@intCast(nums2[j])));
+			j = (j + 1);
+		}
+	}
+	const total = merged.len;
+	if (((total % 2) == 1)) {
+		return merged[(total / 2)];
+	}
+	const mid1 = merged[((total / 2) - 1)];
+	const mid2 = merged[(total / 2)];
+	return (((mid1 + mid2)) / 2);
+}
+
+pub fn main() void {
+}

--- a/examples/leetcode-out/zig/5/longest-palindromic-substring.zig
+++ b/examples/leetcode-out/zig/5/longest-palindromic-substring.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+fn expand(s: []const u8, left: i32, right: i32) [2]i32 {
+	var l = left;
+	var r = right;
+	const n = s.len;
+	while ((((l >= 0) and r) < n)) {
+		if ((s[l] != s[r])) {
+			break;
+		}
+		l = (l - 1);
+		r = (r + 1);
+	}
+	return ((r - l) - 1);
+}
+
+fn longestPalindrome(s: []const u8) [2]i32 {
+	if ((s.len <= 1)) {
+		return s;
+	}
+	var start = 0;
+	var end = 0;
+	const n = s.len;
+	for (0 .. n) |i| {
+		const len1 = expand(s, i, i);
+		const len2 = expand(s, i, (i + 1));
+		var l = len1;
+		if ((len2 > len1)) {
+			l = len2;
+		}
+		if (((l > end) - start)) {
+			start = ((i - ((l - 1))) / 2);
+			end = ((i + l) / 2);
+		}
+	}
+	return s[start];
+}
+
+pub fn main() void {
+}

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -67,7 +67,7 @@ mochi run download.mochi
 - `make run-go ID=<n>` – execute the compiled Go solution for problem `n`
 - `make run-cpp ID=<n>` – execute the compiled C++ solution for problem `n`
 - `make run-java ID=<n>` – execute the compiled Java solution for problem `n`
-- `make compile` – generate Go, Python, TypeScript and C++ files into `../leetcode-out`
+- `make compile` – generate Go, Python, TypeScript, C++ and Zig files into `../leetcode-out`
 - `make range FROM=1 TO=10 LANG=scala` – build problems in a range using the Scala backend
 - `make test` – run all tests
 - `make clean` – remove the downloaded binary


### PR DESCRIPTION
## Summary
- support executing compiled Zig programs in `leetcode-runner`
- generate Zig solutions for LeetCode problems 1-5
- document Zig output generation in README

## Testing
- `go test ./compile/zig -tags slow -run TestZigCompiler_LeetCode1to5 -count=1`
- `go test ./... -tags slow` *(fails: took too long)*

------
https://chatgpt.com/codex/tasks/task_e_6852e35019a48320884fce186e3c077b