### PR TITLE
Add Erlang LeetCode runner

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -290,6 +290,14 @@ func runOutput(file, lang string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "erlang":
+		if err := erlcode.EnsureErlang(); err != nil {
+			return err
+		}
+		cmd := exec.Command("escript", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	case "scala":
 		dir := filepath.Dir(file)
 		cmd := exec.Command("scalac", filepath.Base(file))

--- a/examples/leetcode-out/erlang/1/two-sum.erlang
+++ b/examples/leetcode-out/erlang/1/two-sum.erlang
@@ -1,0 +1,78 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1, twoSum/2]).
+
+twoSum(Nums, Target) ->
+	try
+		N = length(Nums),
+		mochi_foreach(fun(I) ->
+			mochi_foreach(fun(J) ->
+								case ((lists:nth(I + 1, Nums) + lists:nth(J + 1, Nums)) == Target) of
+					true ->
+						throw({return, [I, J]})
+										; _ -> ok
+				end
+			end, lists:seq((I + 1), (N)-1))
+		end, lists:seq(0, (N)-1)),
+		throw({return, [-1, -1]})
+	catch
+		throw:{return, V} -> V
+	end.
+
+main(_) ->
+	Result = twoSum([2, 7, 11, 15], 9),
+	mochi_print([lists:nth(0 + 1, Result)]),
+	mochi_print([lists:nth(1 + 1, Result)]).
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_input() ->
+	case io:get_line("") of
+		eof -> "";
+		Line -> string:trim(Line)
+	end.
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+	Sum = lists:foldl(fun(X, Acc) ->
+		case X of
+			I when is_integer(I) -> Acc + I;
+			F when is_float(F) -> Acc + F;
+			_ -> erlang:error(badarg) end
+		end, 0, L),
+		Sum / length(L);
+	mochi_avg(_) -> erlang:error(badarg).
+	
+	mochi_foreach(F, L) ->
+		try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+	
+	mochi_foreach_loop(_, []) -> ok;
+	mochi_foreach_loop(F, [H|T]) ->
+		try F(H) catch
+			throw:mochi_continue -> ok;
+			throw:mochi_break -> throw(mochi_break)
+		end,
+		mochi_foreach_loop(F, T).
+	
+	mochi_while(Cond, Body) ->
+		case Cond() of
+			true ->
+				try Body() catch
+					throw:mochi_continue -> ok;
+					throw:mochi_break -> ok
+				end,
+				mochi_while(Cond, Body);
+			_ -> ok
+		end.

--- a/examples/leetcode-out/erlang/2/add-two-numbers.erlang
+++ b/examples/leetcode-out/erlang/2/add-two-numbers.erlang
@@ -1,0 +1,92 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1, addTwoNumbers/2]).
+
+addTwoNumbers(L1, L2) ->
+	try
+		I = 0,
+		J = 0,
+		Carry = 0,
+		Result = [],
+		mochi_while(fun() -> (((I < length(L1)) or (J < length(L2))) or (Carry > 0)) end, fun() ->
+			X = 0,
+						case (I < length(L1)) of
+				true ->
+					X_1 = lists:nth(I + 1, L1),
+					I_1 = (I + 1)
+								; _ -> ok
+			end,
+			Y = 0,
+						case (J < length(L2)) of
+				true ->
+					Y_1 = lists:nth(J + 1, L2),
+					J_1 = (J + 1)
+								; _ -> ok
+			end,
+			Sum = ((X_1 + Y_1) + Carry),
+			Digit = (Sum % 10),
+			Carry_1 = (Sum / 10),
+			Result_1 = lists:append(Result, [Digit])
+		end),
+		throw({return, Result_1})
+	catch
+		throw:{return, V} -> V
+	end.
+
+main(_) ->
+	ok,
+	ok,
+	ok.
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_input() ->
+	case io:get_line("") of
+		eof -> "";
+		Line -> string:trim(Line)
+	end.
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+	Sum = lists:foldl(fun(X, Acc) ->
+		case X of
+			I when is_integer(I) -> Acc + I;
+			F when is_float(F) -> Acc + F;
+			_ -> erlang:error(badarg) end
+		end, 0, L),
+		Sum / length(L);
+	mochi_avg(_) -> erlang:error(badarg).
+	
+	mochi_foreach(F, L) ->
+		try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+	
+	mochi_foreach_loop(_, []) -> ok;
+	mochi_foreach_loop(F, [H|T]) ->
+		try F(H) catch
+			throw:mochi_continue -> ok;
+			throw:mochi_break -> throw(mochi_break)
+		end,
+		mochi_foreach_loop(F, T).
+	
+	mochi_while(Cond, Body) ->
+		case Cond() of
+			true ->
+				try Body() catch
+					throw:mochi_continue -> ok;
+					throw:mochi_break -> ok
+				end,
+				mochi_while(Cond, Body);
+			_ -> ok
+		end.

--- a/examples/leetcode-out/erlang/3/longest-substring-without-repeating-characters.erlang
+++ b/examples/leetcode-out/erlang/3/longest-substring-without-repeating-characters.erlang
@@ -1,0 +1,92 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1, lengthOfLongestSubstring/1]).
+
+lengthOfLongestSubstring(S) ->
+	try
+		N = length(S),
+		Start = 0,
+		Best = 0,
+		I = 0,
+		mochi_while(fun() -> (I < N) end, fun() ->
+			J = Start,
+			mochi_while(fun() -> (J < I) end, fun() ->
+								case (lists:nth(J + 1, S) == lists:nth(I + 1, S)) of
+					true ->
+						Start_1 = (J + 1),
+						throw(mochi_break)
+										; _ -> ok
+				end,
+				J_1 = (J + 1)
+			end),
+			Length = ((I - Start_1) + 1),
+						case (Length > Best) of
+				true ->
+					Best_1 = Length
+								; _ -> ok
+			end,
+			I_1 = (I + 1)
+		end),
+		throw({return, Best_1})
+	catch
+		throw:{return, V} -> V
+	end.
+
+main(_) ->
+	ok,
+	ok,
+	ok,
+	ok.
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_input() ->
+	case io:get_line("") of
+		eof -> "";
+		Line -> string:trim(Line)
+	end.
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+	Sum = lists:foldl(fun(X, Acc) ->
+		case X of
+			I when is_integer(I) -> Acc + I;
+			F when is_float(F) -> Acc + F;
+			_ -> erlang:error(badarg) end
+		end, 0, L),
+		Sum / length(L);
+	mochi_avg(_) -> erlang:error(badarg).
+	
+	mochi_foreach(F, L) ->
+		try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+	
+	mochi_foreach_loop(_, []) -> ok;
+	mochi_foreach_loop(F, [H|T]) ->
+		try F(H) catch
+			throw:mochi_continue -> ok;
+			throw:mochi_break -> throw(mochi_break)
+		end,
+		mochi_foreach_loop(F, T).
+	
+	mochi_while(Cond, Body) ->
+		case Cond() of
+			true ->
+				try Body() catch
+					throw:mochi_continue -> ok;
+					throw:mochi_break -> ok
+				end,
+				mochi_while(Cond, Body);
+			_ -> ok
+		end.

--- a/examples/leetcode-out/erlang/4/median-of-two-sorted-arrays.erlang
+++ b/examples/leetcode-out/erlang/4/median-of-two-sorted-arrays.erlang
@@ -1,0 +1,100 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1, findMedianSortedArrays/2]).
+
+findMedianSortedArrays(Nums1, Nums2) ->
+	try
+		Merged = [],
+		I = 0,
+		J = 0,
+		mochi_while(fun() -> ((I < length(Nums1)) or (J < length(Nums2))) end, fun() ->
+						case (J >= length(Nums2)) of
+				true ->
+					Merged_1 = lists:append(Merged, [lists:nth(I + 1, Nums1)]),
+					I_1 = (I + 1)
+								; _ ->
+					case (I_1 >= length(Nums1)) of
+						true ->
+							Merged_2 = lists:append(Merged_1, [lists:nth(J + 1, Nums2)]),
+							J_1 = (J + 1)
+												; _ ->
+							case (lists:nth(I_1 + 1, Nums1) <= lists:nth(J_1 + 1, Nums2)) of
+								true ->
+									Merged_3 = lists:append(Merged_2, [lists:nth(I_1 + 1, Nums1)]),
+									I_2 = (I_1 + 1)
+																; _ ->
+									Merged_4 = lists:append(Merged_3, [lists:nth(J_1 + 1, Nums2)]),
+									J_2 = (J_1 + 1)
+							end					end			end
+		end),
+		Total = length(Merged_4),
+				case ((Total % 2) == 1) of
+			true ->
+				throw({return, lists:nth((Total / 2) + 1, Merged_4)})
+						; _ -> ok
+		end,
+		Mid1 = lists:nth(((Total / 2) - 1) + 1, Merged_4),
+		Mid2 = lists:nth((Total / 2) + 1, Merged_4),
+		throw({return, ((Mid1 + Mid2) / 2)})
+	catch
+		throw:{return, V} -> V
+	end.
+
+main(_) ->
+	ok,
+	ok,
+	ok,
+	ok.
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_input() ->
+	case io:get_line("") of
+		eof -> "";
+		Line -> string:trim(Line)
+	end.
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+	Sum = lists:foldl(fun(X, Acc) ->
+		case X of
+			I when is_integer(I) -> Acc + I;
+			F when is_float(F) -> Acc + F;
+			_ -> erlang:error(badarg) end
+		end, 0, L),
+		Sum / length(L);
+	mochi_avg(_) -> erlang:error(badarg).
+	
+	mochi_foreach(F, L) ->
+		try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+	
+	mochi_foreach_loop(_, []) -> ok;
+	mochi_foreach_loop(F, [H|T]) ->
+		try F(H) catch
+			throw:mochi_continue -> ok;
+			throw:mochi_break -> throw(mochi_break)
+		end,
+		mochi_foreach_loop(F, T).
+	
+	mochi_while(Cond, Body) ->
+		case Cond() of
+			true ->
+				try Body() catch
+					throw:mochi_continue -> ok;
+					throw:mochi_break -> ok
+				end,
+				mochi_while(Cond, Body);
+			_ -> ok
+		end.

--- a/examples/leetcode-out/erlang/5/longest-palindromic-substring.erlang
+++ b/examples/leetcode-out/erlang/5/longest-palindromic-substring.erlang
@@ -1,0 +1,112 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1, expand/3, longestPalindrome/1]).
+
+expand(S, Left, Right) ->
+	try
+		L = Left,
+		R = Right,
+		N = length(S),
+		mochi_while(fun() -> ((L >= 0) and (R < N)) end, fun() ->
+						case (lists:nth(L + 1, S) /= lists:nth(R + 1, S)) of
+				true ->
+					throw(mochi_break)
+								; _ -> ok
+			end,
+			L_1 = (L - 1),
+			R_1 = (R + 1)
+		end),
+		throw({return, ((R_1 - L_1) - 1)})
+	catch
+		throw:{return, V} -> V
+	end.
+
+longestPalindrome(S_1) ->
+	try
+				case (length(S_1) <= 1) of
+			true ->
+				throw({return, S_1})
+						; _ -> ok
+		end,
+		Start = 0,
+		End = 0,
+		N_1 = length(S_1),
+		mochi_foreach(fun(I) ->
+			Len1 = expand(S_1, I, I),
+			Len2 = expand(S_1, I, (I + 1)),
+			L_2 = Len1,
+						case (Len2 > Len1) of
+				true ->
+					L_3 = Len2
+								; _ -> ok
+			end,
+						case (L_3 > (End - Start)) of
+				true ->
+					Start_1 = (I - ((L_3 - 1) / 2)),
+					End_1 = (I + (L_3 / 2))
+								; _ -> ok
+			end
+		end, lists:seq(0, (N_1)-1)),
+		throw({return, lists:nth(Start_1 + 1, S_1)})
+	catch
+		throw:{return, V} -> V
+	end.
+
+main(_) ->
+	ok,
+	ok,
+	ok,
+	ok.
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_input() ->
+	case io:get_line("") of
+		eof -> "";
+		Line -> string:trim(Line)
+	end.
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+	Sum = lists:foldl(fun(X, Acc) ->
+		case X of
+			I when is_integer(I) -> Acc + I;
+			F when is_float(F) -> Acc + F;
+			_ -> erlang:error(badarg) end
+		end, 0, L),
+		Sum / length(L);
+	mochi_avg(_) -> erlang:error(badarg).
+	
+	mochi_foreach(F, L) ->
+		try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+	
+	mochi_foreach_loop(_, []) -> ok;
+	mochi_foreach_loop(F, [H|T]) ->
+		try F(H) catch
+			throw:mochi_continue -> ok;
+			throw:mochi_break -> throw(mochi_break)
+		end,
+		mochi_foreach_loop(F, T).
+	
+	mochi_while(Cond, Body) ->
+		case Cond() of
+			true ->
+				try Body() catch
+					throw:mochi_continue -> ok;
+					throw:mochi_break -> ok
+				end,
+				mochi_while(Cond, Body);
+			_ -> ok
+		end.


### PR DESCRIPTION
## Summary
- add Erlang execution support to `leetcode-runner`
- generate Erlang solutions for problems 1‑5

## Testing
- `go run ./cmd/leetcode-runner build --id 1 --lang erlang --run`
- `escript examples/leetcode-out/erlang/1/two-sum.erlang`


------
https://chatgpt.com/codex/tasks/task_e_6852e3146524832098fae84d5603fccf