### PR TITLE
Add Clojure outputs for LeetCode 1-5

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -115,7 +115,7 @@ go test ./compile/clj -tags slow
 They compare the execution output of generated programs in `tests/compiler/clj` with predefined golden files.
 
 The test suite also compiles and runs the example LeetCode solutions in
-`examples/leetcode/1` through `examples/leetcode/3` to verify that these programs
+`examples/leetcode/1` through `examples/leetcode/5` to verify that these programs
 execute correctly using the Clojure backend.
 
 ## Status

--- a/examples/leetcode-out/clj/1/two-sum.clj
+++ b/examples/leetcode-out/clj/1/two-sum.clj
@@ -1,0 +1,25 @@
+(defn twoSum [nums target]
+  (try
+    (def n (count nums))
+    (loop [i 0]
+      (when (< i n)
+        (loop [j (+ i 1)]
+          (when (< j n)
+            (when (= (+ (nth nums i) (nth nums j)) target)
+              (throw (ex-info "return" {:value [i j]}))
+            )
+            (recur (inc j)))
+        )
+        (recur (inc i)))
+    )
+    (throw (ex-info "return" {:value [(- 1) (- 1)]}))
+  (catch clojure.lang.ExceptionInfo e
+    (if (= (.getMessage e) "return")
+      (:value (ex-data e))
+    (throw e)))
+  )
+)
+
+(def result (twoSum [2 7 11 15] 9))
+(println (nth result 0))
+(println (nth result 1))

--- a/examples/leetcode-out/clj/2/add-two-numbers.clj
+++ b/examples/leetcode-out/clj/2/add-two-numbers.clj
@@ -1,0 +1,53 @@
+(defn addTwoNumbers [l1 l2]
+  (try
+    (def i 0)
+    (def j 0)
+    (def carry 0)
+    (def result [])
+    (try
+      (loop []
+        (when (or (or (< i (count l1)) (< j (count l2))) (> carry 0))
+          (def x 0)
+          (when (< i (count l1))
+            (def x (nth l1 i))
+            (def i (+ i 1))
+          )
+          (def y 0)
+          (when (< j (count l2))
+            (def y (nth l2 j))
+            (def j (+ j 1))
+          )
+          (def sum (+ (+ x y) carry))
+          (def digit (mod sum 10))
+          (def carry (quot sum 10))
+          (def result (vec (concat result [digit])))
+          (recur)
+        )
+      )
+    (catch clojure.lang.ExceptionInfo e
+      (when-not (= (.getMessage e) "break") (throw e))
+    )
+  )
+  (throw (ex-info "return" {:value result}))
+(catch clojure.lang.ExceptionInfo e
+  (if (= (.getMessage e) "return")
+    (:value (ex-data e))
+  (throw e)))
+)
+)
+
+(defn test_example_1 []
+(assert (= (addTwoNumbers [2 4 3] [5 6 4]) [7 0 8]))
+)
+
+(defn test_example_2 []
+(assert (= (addTwoNumbers [0] [0]) [0]))
+)
+
+(defn test_example_3 []
+(assert (= (addTwoNumbers [9 9 9 9 9 9 9] [9 9 9 9]) [8 9 9 9 0 0 0 1]))
+)
+
+(test_example_1)
+(test_example_2)
+(test_example_3)

--- a/examples/leetcode-out/clj/3/longest-substring-without-repeating-characters.clj
+++ b/examples/leetcode-out/clj/3/longest-substring-without-repeating-characters.clj
@@ -1,0 +1,65 @@
+(defn lengthOfLongestSubstring [s]
+  (try
+    (def n (count s))
+    (def start 0)
+    (def best 0)
+    (def i 0)
+    (try
+      (loop []
+        (when (< i n)
+          (def j start)
+          (try
+            (loop []
+              (when (< j i)
+                (when (= (nth s j) (nth s i))
+                  (def start (+ j 1))
+                  (throw (ex-info "break" {}))
+                )
+                (def j (+ j 1))
+                (recur)
+              )
+            )
+          (catch clojure.lang.ExceptionInfo e
+            (when-not (= (.getMessage e) "break") (throw e))
+          )
+        )
+        (def length (+ (- i start) 1))
+        (when (> length best)
+          (def best length)
+        )
+        (def i (+ i 1))
+        (recur)
+      )
+    )
+  (catch clojure.lang.ExceptionInfo e
+    (when-not (= (.getMessage e) "break") (throw e))
+  )
+)
+(throw (ex-info "return" {:value best}))
+(catch clojure.lang.ExceptionInfo e
+(if (= (.getMessage e) "return")
+  (:value (ex-data e))
+(throw e)))
+)
+)
+
+(defn test_example_1 []
+(assert (= (lengthOfLongestSubstring "abcabcbb") 3))
+)
+
+(defn test_example_2 []
+(assert (= (lengthOfLongestSubstring "bbbbb") 1))
+)
+
+(defn test_example_3 []
+(assert (= (lengthOfLongestSubstring "pwwkew") 3))
+)
+
+(defn test_empty_string []
+(assert (= (lengthOfLongestSubstring "") 0))
+)
+
+(test_example_1)
+(test_example_2)
+(test_example_3)
+(test_empty_string)

--- a/examples/leetcode-out/clj/4/median-of-two-sorted-arrays.clj
+++ b/examples/leetcode-out/clj/4/median-of-two-sorted-arrays.clj
@@ -1,0 +1,74 @@
+(defn findMedianSortedArrays [nums1 nums2]
+  (try
+    (def merged [])
+    (def i 0)
+    (def j 0)
+    (try
+      (loop []
+        (when (or (< i (count nums1)) (< j (count nums2)))
+          (if (>= j (count nums2))
+            (do
+              (def merged (vec (concat merged [(nth nums1 i)])))
+              (def i (+ i 1))
+            )
+          
+          (if (>= i (count nums1))
+            (do
+              (def merged (vec (concat merged [(nth nums2 j)])))
+              (def j (+ j 1))
+            )
+          
+          (if (<= (nth nums1 i) (nth nums2 j))
+            (do
+              (def merged (vec (concat merged [(nth nums1 i)])))
+              (def i (+ i 1))
+            )
+          
+          (do
+            (def merged (vec (concat merged [(nth nums2 j)])))
+            (def j (+ j 1))
+          )
+          )
+          )
+          )
+          (recur)
+        )
+      )
+    (catch clojure.lang.ExceptionInfo e
+      (when-not (= (.getMessage e) "break") (throw e))
+    )
+  )
+  (def total (count merged))
+  (when (= (mod total 2) 1)
+    (throw (ex-info "return" {:value (double (nth merged (quot total 2)))}))
+  )
+  (def mid1 (nth merged (- (quot total 2) 1)))
+  (def mid2 (nth merged (quot total 2)))
+  (throw (ex-info "return" {:value (/ (double (+ mid1 mid2)) 2.0)}))
+(catch clojure.lang.ExceptionInfo e
+  (if (= (.getMessage e) "return")
+    (:value (ex-data e))
+  (throw e)))
+)
+)
+
+(defn test_example_1 []
+(assert (= (findMedianSortedArrays [1 3] [2]) 2.0))
+)
+
+(defn test_example_2 []
+(assert (= (findMedianSortedArrays [1 2] [3 4]) 2.5))
+)
+
+(defn test_empty_first []
+(assert (= (findMedianSortedArrays [] [1]) 1.0))
+)
+
+(defn test_empty_second []
+(assert (= (findMedianSortedArrays [2] []) 2.0))
+)
+
+(test_example_1)
+(test_example_2)
+(test_empty_first)
+(test_empty_second)

--- a/examples/leetcode-out/clj/5/longest-palindromic-substring.clj
+++ b/examples/leetcode-out/clj/5/longest-palindromic-substring.clj
@@ -1,0 +1,80 @@
+(defn expand [s left right]
+  (try
+    (def l left)
+    (def r right)
+    (def n (count s))
+    (try
+      (loop []
+        (when (and (>= l 0) (< r n))
+          (when (not= (nth s l) (nth s r))
+            (throw (ex-info "break" {}))
+          )
+          (def l (- l 1))
+          (def r (+ r 1))
+          (recur)
+        )
+      )
+    (catch clojure.lang.ExceptionInfo e
+      (when-not (= (.getMessage e) "break") (throw e))
+    )
+  )
+  (throw (ex-info "return" {:value (- (- r l) 1)}))
+(catch clojure.lang.ExceptionInfo e
+  (if (= (.getMessage e) "return")
+    (:value (ex-data e))
+  (throw e)))
+)
+)
+
+(defn longestPalindrome [s]
+(try
+  (when (<= (count s) 1)
+    (throw (ex-info "return" {:value s}))
+  )
+  (def start 0)
+  (def end 0)
+  (def n (count s))
+  (loop [i 0]
+    (when (< i n)
+      (def len1 (expand s i i))
+      (def len2 (expand s i (+ i 1)))
+      (def l len1)
+      (when (> len2 len1)
+        (def l len2)
+      )
+      (when (> l (- end start))
+        (def start (- i (quot (- l 1) 2)))
+        (def end (+ i (quot l 2)))
+      )
+      (recur (inc i)))
+  )
+  (throw (ex-info "return" {:value (subs s start (+ end 1))}))
+(catch clojure.lang.ExceptionInfo e
+  (if (= (.getMessage e) "return")
+    (:value (ex-data e))
+  (throw e)))
+)
+)
+
+(defn test_example_1 []
+(def ans (longestPalindrome "babad"))
+(assert (or (= ans "bab") (= ans "aba")))
+)
+
+(defn test_example_2 []
+(assert (= (longestPalindrome "cbbd") "bb"))
+)
+
+(defn test_single_char []
+(assert (= (longestPalindrome "a") "a"))
+)
+
+(defn test_two_chars []
+(def ans (longestPalindrome "ac"))
+(assert (or (= ans "a") (= ans "c")))
+)
+
+(test_example_1)
+(test_example_2)
+(test_single_char)
+(test_two_chars)

--- a/tests/compiler/clj/while_loop.clj.out
+++ b/tests/compiler/clj/while_loop.clj.out
@@ -1,5 +1,13 @@
 (def i 0)
-(while (< i 3)
-  (println i)
-  (def i (+ i 1))
+(try
+  (loop []
+    (when (< i 3)
+      (println i)
+      (def i (+ i 1))
+      (recur)
+    )
+  )
+(catch clojure.lang.ExceptionInfo e
+  (when-not (= (.getMessage e) "break") (throw e))
+)
 )


### PR DESCRIPTION
## Summary
- improve Clojure compiler: support `else if` chains, slices and parentheses cleanup
- update docs to mention problems 1‒5
- regenerate golden output for while loops
- add generated Clojure solutions for LeetCode problems 1‒5

## Testing
- `go test ./compile/clj -tags slow -run .`
- `timeout 5s clojure examples/leetcode-out/clj/5/longest-palindromic-substring.clj; echo status:$?`

------
https://chatgpt.com/codex/tasks/task_e_6852e308f8408320ac5ae5b208009163