### PR TITLE
Add Scala output for LeetCode examples and support floats

### DIFF
--- a/compile/scala/compiler.go
+++ b/compile/scala/compiler.go
@@ -458,6 +458,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		if p.Lit.Int != nil {
 			return strconv.Itoa(*p.Lit.Int), nil
 		}
+		if p.Lit.Float != nil {
+			return strconv.FormatFloat(*p.Lit.Float, 'f', -1, 64), nil
+		}
 		if p.Lit.Bool != nil {
 			if bool(*p.Lit.Bool) {
 				return "true", nil

--- a/examples/leetcode-out/scala/1/two-sum.scala
+++ b/examples/leetcode-out/scala/1/two-sum.scala
@@ -1,0 +1,19 @@
+object Main {
+	def twoSum(nums: List[Int], target: Int): List[Int] = {
+		val n = nums.length
+		for (i <- 0 until n) {
+			for (j <- (i + 1) until n) {
+				if (((nums(i) + nums(j)) == target)) {
+					return List(i, j)
+				}
+			}
+		}
+		return List((-1), (-1))
+	}
+	
+	def main(args: Array[String]): Unit = {
+		val result = twoSum(List(2, 7, 11, 15), 9)
+		println(result(0))
+		println(result(1))
+	}
+}

--- a/examples/leetcode-out/scala/2/add-two-numbers.scala
+++ b/examples/leetcode-out/scala/2/add-two-numbers.scala
@@ -1,0 +1,28 @@
+object Main {
+	def addTwoNumbers(l1: List[Int], l2: List[Int]): List[Int] = {
+		var i = 0
+		var j = 0
+		var carry = 0
+		var result: List[Int] = List()
+		while ((((i < l1.length) || (j < l2.length)) || (carry > 0))) {
+			var x = 0
+			if ((i < l1.length)) {
+				x = l1(i)
+				i = (i + 1)
+			}
+			var y = 0
+			if ((j < l2.length)) {
+				y = l2(j)
+				j = (j + 1)
+			}
+			val sum = ((x + y) + carry)
+			val digit = (sum % 10)
+			carry = (sum / 10)
+			result = (result ++ List(digit))
+		}
+		return result
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/3/longest-substring-without-repeating-characters.scala
+++ b/examples/leetcode-out/scala/3/longest-substring-without-repeating-characters.scala
@@ -1,0 +1,26 @@
+object Main {
+	def lengthOfLongestSubstring(s: String): Int = {
+		val n = s.length
+		var start = 0
+		var best = 0
+		var i = 0
+		while ((i < n)) {
+			var j = start
+			while ((j < i)) {
+				if ((s(j) == s(i))) {
+					start = (j + 1)
+				}
+				j = (j + 1)
+			}
+			val length = ((i - start) + 1)
+			if ((length > best)) {
+				best = length
+			}
+			i = (i + 1)
+		}
+		return best
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/4/median-of-two-sorted-arrays.scala
+++ b/examples/leetcode-out/scala/4/median-of-two-sorted-arrays.scala
@@ -1,0 +1,32 @@
+object Main {
+	def findMedianSortedArrays(nums1: List[Int], nums2: List[Int]): Double = {
+		var merged: List[Int] = List()
+		var i = 0
+		var j = 0
+		while (((i < nums1.length) || (j < nums2.length))) {
+			if ((j >= nums2.length)) {
+				merged = (merged ++ List(nums1(i)))
+				i = (i + 1)
+			} else 			if ((i >= nums1.length)) {
+				merged = (merged ++ List(nums2(j)))
+				j = (j + 1)
+			} else 			if ((nums1(i) <= nums2(j))) {
+				merged = (merged ++ List(nums1(i)))
+				i = (i + 1)
+			} else {
+				merged = (merged ++ List(nums2(j)))
+				j = (j + 1)
+			}
+		}
+		val total = merged.length
+		if (((total % 2) == 1)) {
+			return merged((total / 2)).asInstanceOf[Double]
+		}
+		val mid1 = merged(((total / 2) - 1))
+		val mid2 = merged((total / 2))
+		return (((mid1 + mid2)).asInstanceOf[Double] / 2)
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
+++ b/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
@@ -1,0 +1,39 @@
+object Main {
+	def expand(s: String, left: Int, right: Int): Int = {
+		var l = left
+		var r = right
+		val n = s.length
+		while (((l >= 0) && (r < n))) {
+			if ((s(l) != s(r))) {
+			}
+			l = (l - 1)
+			r = (r + 1)
+		}
+		return ((r - l) - 1)
+	}
+	
+	def longestPalindrome(s: String): String = {
+		if ((s.length <= 1)) {
+			return s
+		}
+		var start = 0
+		var end = 0
+		val n = s.length
+		for (i <- 0 until n) {
+			val len1 = expand(s, i, i)
+			val len2 = expand(s, i, (i + 1))
+			var l = len1
+			if ((len2 > len1)) {
+				l = len2
+			}
+			if ((l > (end - start))) {
+				start = (i - (((l - 1)) / 2))
+				end = (i + (l / 2))
+			}
+		}
+		return s.slice(start, (end + 1))
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}


### PR DESCRIPTION
## Summary
- support floating point literals in Scala backend
- generate Scala code for LeetCode problems 1-5

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 5 --lang scala --run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852e3383db883208c4185330d1a0080