### PR TITLE
Add Lua support for LeetCode examples

### DIFF
--- a/compile/lua/compiler.go
+++ b/compile/lua/compiler.go
@@ -309,6 +309,15 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 				case "/":
 					c.helpers["div"] = true
 					expr = fmt.Sprintf("__div(%s, %s)", l, r)
+				case "+":
+					c.helpers["add"] = true
+					expr = fmt.Sprintf("__add(%s, %s)", l, r)
+				case "==":
+					c.helpers["eq"] = true
+					expr = fmt.Sprintf("__eq(%s, %s)", l, r)
+				case "!=":
+					c.helpers["eq"] = true
+					expr = fmt.Sprintf("not __eq(%s, %s)", l, r)
 				default:
 					expr = fmt.Sprintf("(%s %s %s)", l, opstr, r)
 				}
@@ -761,7 +770,11 @@ func (c *Compiler) compileLiteral(lit *parser.Literal) (string, error) {
 	case lit.Int != nil:
 		return strconv.Itoa(*lit.Int), nil
 	case lit.Float != nil:
-		return strconv.FormatFloat(*lit.Float, 'f', -1, 64), nil
+		s := strconv.FormatFloat(*lit.Float, 'f', -1, 64)
+		if !strings.ContainsAny(s, ".eE") && !strings.Contains(s, ".") {
+			s += ".0"
+		}
+		return s, nil
 	case lit.Str != nil:
 		return strconv.Quote(*lit.Str), nil
 	case lit.Bool != nil:
@@ -916,6 +929,41 @@ func (c *Compiler) emitHelpers() {
 		c.indent--
 		c.writeln("end")
 		c.writeln("return a / b")
+		c.indent--
+		c.writeln("end")
+		c.writeln("")
+	}
+	if c.helpers["add"] {
+		c.writeln("function __add(a, b)")
+		c.indent++
+		c.writeln("if type(a) == 'table' and type(b) == 'table' then")
+		c.indent++
+		c.writeln("local out = {}")
+		c.writeln("for i = 1, #a do out[#out+1] = a[i] end")
+		c.writeln("for i = 1, #b do out[#out+1] = b[i] end")
+		c.writeln("return out")
+		c.indent--
+		c.writeln("end")
+		c.writeln("return a + b")
+		c.indent--
+		c.writeln("end")
+		c.writeln("")
+	}
+	if c.helpers["eq"] {
+		c.writeln("function __eq(a, b)")
+		c.indent++
+		c.writeln("if type(a) ~= type(b) then return false end")
+		c.writeln("if type(a) ~= 'table' then return a == b end")
+		c.writeln("if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then")
+		c.indent++
+		c.writeln("if #a ~= #b then return false end")
+		c.writeln("for i = 1, #a do if not __eq(a[i], b[i]) then return false end end")
+		c.writeln("return true")
+		c.indent--
+		c.writeln("end")
+		c.writeln("for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end")
+		c.writeln("for k, _ in pairs(b) do if a[k] == nil then return false end end")
+		c.writeln("return true")
 		c.indent--
 		c.writeln("end")
 		c.writeln("")

--- a/examples/leetcode-out/lua/1/two-sum.lua
+++ b/examples/leetcode-out/lua/1/two-sum.lua
@@ -1,0 +1,70 @@
+function __print(...)
+	local args = {...}
+	for i, a in ipairs(args) do
+		if i > 1 then io.write(' ') end
+		io.write(tostring(a))
+	end
+	io.write('\n')
+end
+
+function __add(a, b)
+	if type(a) == 'table' and type(b) == 'table' then
+		local out = {}
+		for i = 1, #a do out[#out+1] = a[i] end
+		for i = 1, #b do out[#out+1] = b[i] end
+		return out
+	end
+	return a + b
+end
+
+function __eq(a, b)
+	if type(a) ~= type(b) then return false end
+	if type(a) ~= 'table' then return a == b end
+	if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+		if #a ~= #b then return false end
+		for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+		return true
+	end
+	for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+	for k, _ in pairs(b) do if a[k] == nil then return false end end
+	return true
+end
+
+function __index(obj, i)
+	if type(obj) == 'string' then
+		return __indexString(obj, i)
+	elseif type(obj) == 'table' then
+		return obj[(i)+1]
+	else
+		error('cannot index')
+	end
+end
+
+function __indexString(s, i)
+	local len = #s
+	if i < 0 then
+		i = len + i + 1
+	else
+		i = i + 1
+	end
+	if i < 1 or i > len then error('index out of range') end
+	return string.sub(s, i, i)
+end
+
+function twoSum(nums, target)
+	local n = #nums
+	for i = 0, (n)-1 do
+		for j = __add(i, 1), (n)-1 do
+			if __eq(__add(__index(nums, i), __index(nums, j)), target) then
+				return {i, j}
+			end
+			::__continue1::
+		end
+		::__continue0::
+	end
+	return {-1, -1}
+end
+
+local result = twoSum({2, 7, 11, 15}, 9)
+__print(__index(result, 0))
+__print(__index(result, 1))

--- a/examples/leetcode-out/lua/2/add-two-numbers.lua
+++ b/examples/leetcode-out/lua/2/add-two-numbers.lua
@@ -1,0 +1,91 @@
+function __div(a, b)
+	if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+		return a // b
+	end
+	return a / b
+end
+
+function __add(a, b)
+	if type(a) == 'table' and type(b) == 'table' then
+		local out = {}
+		for i = 1, #a do out[#out+1] = a[i] end
+		for i = 1, #b do out[#out+1] = b[i] end
+		return out
+	end
+	return a + b
+end
+
+function __eq(a, b)
+	if type(a) ~= type(b) then return false end
+	if type(a) ~= 'table' then return a == b end
+	if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+		if #a ~= #b then return false end
+		for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+		return true
+	end
+	for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+	for k, _ in pairs(b) do if a[k] == nil then return false end end
+	return true
+end
+
+function __index(obj, i)
+	if type(obj) == 'string' then
+		return __indexString(obj, i)
+	elseif type(obj) == 'table' then
+		return obj[(i)+1]
+	else
+		error('cannot index')
+	end
+end
+
+function __indexString(s, i)
+	local len = #s
+	if i < 0 then
+		i = len + i + 1
+	else
+		i = i + 1
+	end
+	if i < 1 or i > len then error('index out of range') end
+	return string.sub(s, i, i)
+end
+
+function addTwoNumbers(l1, l2)
+	local i = 0
+	local j = 0
+	local carry = 0
+	local result = {}
+	while (((i < #l1) or (j < #l2)) or (carry > 0)) do
+		local x = 0
+		if (i < #l1) then
+			x = __index(l1, i)
+			i = __add(i, 1)
+		end
+		local y = 0
+		if (j < #l2) then
+			y = __index(l2, j)
+			j = __add(j, 1)
+		end
+		local sum = __add(__add(x, y), carry)
+		local digit = (sum % 10)
+		carry = __div(sum, 10)
+		result = __add(result, {digit})
+		::__continue0::
+	end
+	return result
+end
+
+function test_example_1()
+	if not (__eq(addTwoNumbers({2, 4, 3}, {5, 6, 4}), {7, 0, 8})) then error('expect failed') end
+end
+
+function test_example_2()
+	if not (__eq(addTwoNumbers({0}, {0}), {0})) then error('expect failed') end
+end
+
+function test_example_3()
+	if not (__eq(addTwoNumbers({9, 9, 9, 9, 9, 9, 9}, {9, 9, 9, 9}), {8, 9, 9, 9, 0, 0, 0, 1})) then error('expect failed') end
+end
+
+test_example_1()
+test_example_2()
+test_example_3()

--- a/examples/leetcode-out/lua/3/longest-substring-without-repeating-characters.lua
+++ b/examples/leetcode-out/lua/3/longest-substring-without-repeating-characters.lua
@@ -1,0 +1,89 @@
+function __add(a, b)
+	if type(a) == 'table' and type(b) == 'table' then
+		local out = {}
+		for i = 1, #a do out[#out+1] = a[i] end
+		for i = 1, #b do out[#out+1] = b[i] end
+		return out
+	end
+	return a + b
+end
+
+function __eq(a, b)
+	if type(a) ~= type(b) then return false end
+	if type(a) ~= 'table' then return a == b end
+	if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+		if #a ~= #b then return false end
+		for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+		return true
+	end
+	for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+	for k, _ in pairs(b) do if a[k] == nil then return false end end
+	return true
+end
+
+function __index(obj, i)
+	if type(obj) == 'string' then
+		return __indexString(obj, i)
+	elseif type(obj) == 'table' then
+		return obj[(i)+1]
+	else
+		error('cannot index')
+	end
+end
+
+function __indexString(s, i)
+	local len = #s
+	if i < 0 then
+		i = len + i + 1
+	else
+		i = i + 1
+	end
+	if i < 1 or i > len then error('index out of range') end
+	return string.sub(s, i, i)
+end
+
+function lengthOfLongestSubstring(s)
+	local n = #s
+	local start = 0
+	local best = 0
+	local i = 0
+	while (i < n) do
+		local j = start
+		while (j < i) do
+			if __eq(__index(s, j), __index(s, i)) then
+				start = __add(j, 1)
+				break
+			end
+			j = __add(j, 1)
+			::__continue1::
+		end
+		local length = __add((i - start), 1)
+		if (length > best) then
+			best = length
+		end
+		i = __add(i, 1)
+		::__continue0::
+	end
+	return best
+end
+
+function test_example_1()
+	if not (__eq(lengthOfLongestSubstring("abcabcbb"), 3)) then error('expect failed') end
+end
+
+function test_example_2()
+	if not (__eq(lengthOfLongestSubstring("bbbbb"), 1)) then error('expect failed') end
+end
+
+function test_example_3()
+	if not (__eq(lengthOfLongestSubstring("pwwkew"), 3)) then error('expect failed') end
+end
+
+function test_empty_string()
+	if not (__eq(lengthOfLongestSubstring(""), 0)) then error('expect failed') end
+end
+
+test_example_1()
+test_example_2()
+test_example_3()
+test_empty_string()

--- a/examples/leetcode-out/lua/4/median-of-two-sorted-arrays.lua
+++ b/examples/leetcode-out/lua/4/median-of-two-sorted-arrays.lua
@@ -1,0 +1,100 @@
+function __div(a, b)
+	if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+		return a // b
+	end
+	return a / b
+end
+
+function __add(a, b)
+	if type(a) == 'table' and type(b) == 'table' then
+		local out = {}
+		for i = 1, #a do out[#out+1] = a[i] end
+		for i = 1, #b do out[#out+1] = b[i] end
+		return out
+	end
+	return a + b
+end
+
+function __eq(a, b)
+	if type(a) ~= type(b) then return false end
+	if type(a) ~= 'table' then return a == b end
+	if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+		if #a ~= #b then return false end
+		for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+		return true
+	end
+	for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+	for k, _ in pairs(b) do if a[k] == nil then return false end end
+	return true
+end
+
+function __index(obj, i)
+	if type(obj) == 'string' then
+		return __indexString(obj, i)
+	elseif type(obj) == 'table' then
+		return obj[(i)+1]
+	else
+		error('cannot index')
+	end
+end
+
+function __indexString(s, i)
+	local len = #s
+	if i < 0 then
+		i = len + i + 1
+	else
+		i = i + 1
+	end
+	if i < 1 or i > len then error('index out of range') end
+	return string.sub(s, i, i)
+end
+
+function findMedianSortedArrays(nums1, nums2)
+	local merged = {}
+	local i = 0
+	local j = 0
+	while ((i < #nums1) or (j < #nums2)) do
+		if (j >= #nums2) then
+			merged = __add(merged, {__index(nums1, i)})
+			i = __add(i, 1)
+		elseif (i >= #nums1) then
+			merged = __add(merged, {__index(nums2, j)})
+			j = __add(j, 1)
+		elseif (__index(nums1, i) <= __index(nums2, j)) then
+			merged = __add(merged, {__index(nums1, i)})
+			i = __add(i, 1)
+		else
+			merged = __add(merged, {__index(nums2, j)})
+			j = __add(j, 1)
+		end
+		::__continue0::
+	end
+	local total = #merged
+	if __eq((total % 2), 1) then
+		return __index(merged, __div(total, 2))
+	end
+	local mid1 = __index(merged, (__div(total, 2) - 1))
+	local mid2 = __index(merged, __div(total, 2))
+	return __div((__add(mid1, mid2)), 2.0)
+end
+
+function test_example_1()
+	if not (__eq(findMedianSortedArrays({1, 3}, {2}), 2.0)) then error('expect failed') end
+end
+
+function test_example_2()
+	if not (__eq(findMedianSortedArrays({1, 2}, {3, 4}), 2.5)) then error('expect failed') end
+end
+
+function test_empty_first()
+	if not (__eq(findMedianSortedArrays({}, {1}), 1.0)) then error('expect failed') end
+end
+
+function test_empty_second()
+	if not (__eq(findMedianSortedArrays({2}, {}), 2.0)) then error('expect failed') end
+end
+
+test_example_1()
+test_example_2()
+test_empty_first()
+test_empty_second()

--- a/examples/leetcode-out/lua/5/longest-palindromic-substring.lua
+++ b/examples/leetcode-out/lua/5/longest-palindromic-substring.lua
@@ -1,0 +1,138 @@
+function __div(a, b)
+	if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+		return a // b
+	end
+	return a / b
+end
+
+function __add(a, b)
+	if type(a) == 'table' and type(b) == 'table' then
+		local out = {}
+		for i = 1, #a do out[#out+1] = a[i] end
+		for i = 1, #b do out[#out+1] = b[i] end
+		return out
+	end
+	return a + b
+end
+
+function __eq(a, b)
+	if type(a) ~= type(b) then return false end
+	if type(a) ~= 'table' then return a == b end
+	if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+		if #a ~= #b then return false end
+		for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+		return true
+	end
+	for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+	for k, _ in pairs(b) do if a[k] == nil then return false end end
+	return true
+end
+
+function __index(obj, i)
+	if type(obj) == 'string' then
+		return __indexString(obj, i)
+	elseif type(obj) == 'table' then
+		return obj[(i)+1]
+	else
+		error('cannot index')
+	end
+end
+
+function __indexString(s, i)
+	local len = #s
+	if i < 0 then
+		i = len + i + 1
+	else
+		i = i + 1
+	end
+	if i < 1 or i > len then error('index out of range') end
+	return string.sub(s, i, i)
+end
+
+function __slice(obj, i, j)
+	if i == nil then i = 0 end
+	if type(obj) == 'string' then
+		local len = #obj
+		if j == nil then j = len end
+		if i < 0 then i = len + i end
+		if j < 0 then j = len + j end
+		if i < 0 then i = 0 end
+		if j > len then j = len end
+		return string.sub(obj, i+1, j)
+	elseif type(obj) == 'table' then
+		local len = #obj
+		if j == nil then j = len end
+		if i < 0 then i = len + i end
+		if j < 0 then j = len + j end
+		if i < 0 then i = 0 end
+		if j > len then j = len end
+		local out = {}
+		for k = i+1, j do
+			out[#out+1] = obj[k]
+		end
+		return out
+	else
+		return {}
+	end
+end
+
+function expand(s, left, right)
+	local l = left
+	local r = right
+	local n = #s
+	while ((l >= 0) and (r < n)) do
+		if not __eq(__index(s, l), __index(s, r)) then
+			break
+		end
+		l = (l - 1)
+		r = __add(r, 1)
+		::__continue0::
+	end
+	return ((r - l) - 1)
+end
+
+function longestPalindrome(s)
+	if (#s <= 1) then
+		return s
+	end
+	local start = 0
+	local _end = 0
+	local n = #s
+	for i = 0, (n)-1 do
+		local len1 = expand(s, i, i)
+		local len2 = expand(s, i, __add(i, 1))
+		local l = len1
+		if (len2 > len1) then
+			l = len2
+		end
+		if (l > (_end - start)) then
+			start = (i - __div(((l - 1)), 2))
+			_end = __add(i, __div(l, 2))
+		end
+		::__continue1::
+	end
+	return __slice(s, start, __add(_end, 1))
+end
+
+function test_example_1()
+	local ans = longestPalindrome("babad")
+	if not ((__eq(ans, "bab") or __eq(ans, "aba"))) then error('expect failed') end
+end
+
+function test_example_2()
+	if not (__eq(longestPalindrome("cbbd"), "bb")) then error('expect failed') end
+end
+
+function test_single_char()
+	if not (__eq(longestPalindrome("a"), "a")) then error('expect failed') end
+end
+
+function test_two_chars()
+	local ans = longestPalindrome("ac")
+	if not ((__eq(ans, "a") or __eq(ans, "c"))) then error('expect failed') end
+end
+
+test_example_1()
+test_example_2()
+test_single_char()
+test_two_chars()


### PR DESCRIPTION
## Summary
- improve Lua compiler to handle list operations and equality
- ensure floats retain `.0` suffix when needed
- compile LeetCode problems 1–5 to Lua

## Testing
- `go test ./compile/lua -run LeetCodeExamples -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852e822892c832091c26f1206123717