### PR TITLE
Enable Smalltalk compilation for leetcode solutions 1‑5

### DIFF
--- a/compile/st/compiler.go
+++ b/compile/st/compiler.go
@@ -88,9 +88,15 @@ func collectVars(stmts []*parser.Statement) []string {
 			if s.Let != nil {
 				set[s.Let.Name] = true
 			}
+			if s.Var != nil {
+				set[s.Var.Name] = true
+			}
 			if s.For != nil {
 				set[s.For.Name] = true
 				visit(s.For.Body)
+			}
+			if s.While != nil {
+				visit(s.While.Body)
 			}
 			if s.If != nil {
 				visit(s.If.Then)
@@ -118,6 +124,16 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 			return err
 		}
 		c.writeln(fmt.Sprintf("%s := %s.", s.Let.Name, val))
+	case s.Var != nil:
+		val := "nil"
+		if s.Var.Value != nil {
+			v, err := c.compileExpr(s.Var.Value)
+			if err != nil {
+				return err
+			}
+			val = v
+		}
+		c.writeln(fmt.Sprintf("%s := %s.", s.Var.Name, val))
 	case s.Return != nil:
 		val, err := c.compileExpr(s.Return.Value)
 		if err != nil {
@@ -238,42 +254,42 @@ func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 }
 
 func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
-        left, err := c.compileUnary(b.Left)
-        if err != nil {
-                return "", err
-        }
-        expr := left
-        leftList := isListUnary(b.Left, c.env)
-        leftStr := isStringUnary(b.Left, c.env)
-        for _, op := range b.Right {
-                right, err := c.compilePostfix(op.Right)
-                if err != nil {
-                        return "", err
-                }
-                rlist := isListPostfix(op.Right, c.env)
-                rstr := isStringPostfix(op.Right, c.env)
-                switch op.Op {
-                case "+":
-                        if leftList || rlist {
-                                expr = fmt.Sprintf("(%s , %s)", expr, right)
-                                leftList = true
-                                leftStr = false
-                        } else if leftStr || rstr {
-                                expr = fmt.Sprintf("(%s , %s)", expr, right)
-                                leftStr = true
-                                leftList = false
-                        } else {
-                                expr = fmt.Sprintf("(%s + %s)", expr, right)
-                                leftList = false
-                                leftStr = false
-                        }
-                default:
-                        expr = fmt.Sprintf("(%s %s %s)", expr, mapOp(op.Op), right)
-                        leftList = false
-                        leftStr = false
-                }
-        }
-        return expr, nil
+	left, err := c.compileUnary(b.Left)
+	if err != nil {
+		return "", err
+	}
+	expr := left
+	leftList := isListUnary(b.Left, c.env)
+	leftStr := isStringUnary(b.Left, c.env)
+	for _, op := range b.Right {
+		right, err := c.compilePostfix(op.Right)
+		if err != nil {
+			return "", err
+		}
+		rlist := isListPostfix(op.Right, c.env)
+		rstr := isStringPostfix(op.Right, c.env)
+		switch op.Op {
+		case "+":
+			if leftList || rlist {
+				expr = fmt.Sprintf("(%s , %s)", expr, right)
+				leftList = true
+				leftStr = false
+			} else if leftStr || rstr {
+				expr = fmt.Sprintf("(%s , %s)", expr, right)
+				leftStr = true
+				leftList = false
+			} else {
+				expr = fmt.Sprintf("(%s + %s)", expr, right)
+				leftList = false
+				leftStr = false
+			}
+		default:
+			expr = fmt.Sprintf("(%s %s %s)", expr, mapOp(op.Op), right)
+			leftList = false
+			leftStr = false
+		}
+	}
+	return expr, nil
 }
 
 func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
@@ -296,40 +312,40 @@ func (c *Compiler) compileUnary(u *parser.Unary) (string, error) {
 }
 
 func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
-        expr, err := c.compilePrimary(p.Target)
-        if err != nil {
-                return "", err
-        }
-        for _, op := range p.Ops {
-                if op.Index != nil {
-                        if op.Index.Colon != nil {
-                                start := "1"
-                                if op.Index.Start != nil {
-                                        s, err := c.compileExpr(op.Index.Start)
-                                        if err != nil {
-                                                return "", err
-                                        }
-                                        start = fmt.Sprintf("(%s + 1)", s)
-                                }
-                                end := fmt.Sprintf("%s size", expr)
-                                if op.Index.End != nil {
-                                        e, err := c.compileExpr(op.Index.End)
-                                        if err != nil {
-                                                return "", err
-                                        }
-                                        end = e
-                                }
-                                expr = fmt.Sprintf("(%s copyFrom: %s to: %s)", expr, start, end)
-                        } else {
-                                idx, err := c.compileExpr(op.Index.Start)
-                                if err != nil {
-                                        return "", err
-                                }
-                                expr = fmt.Sprintf("(%s at: %s + 1)", expr, idx)
-                        }
-                }
-        }
-        return expr, nil
+	expr, err := c.compilePrimary(p.Target)
+	if err != nil {
+		return "", err
+	}
+	for _, op := range p.Ops {
+		if op.Index != nil {
+			if op.Index.Colon != nil {
+				start := "1"
+				if op.Index.Start != nil {
+					s, err := c.compileExpr(op.Index.Start)
+					if err != nil {
+						return "", err
+					}
+					start = fmt.Sprintf("(%s + 1)", s)
+				}
+				end := fmt.Sprintf("%s size", expr)
+				if op.Index.End != nil {
+					e, err := c.compileExpr(op.Index.End)
+					if err != nil {
+						return "", err
+					}
+					end = e
+				}
+				expr = fmt.Sprintf("(%s copyFrom: %s to: %s)", expr, start, end)
+			} else {
+				idx, err := c.compileExpr(op.Index.Start)
+				if err != nil {
+					return "", err
+				}
+				expr = fmt.Sprintf("(%s at: %s + 1)", expr, idx)
+			}
+		}
+	}
+	return expr, nil
 }
 
 func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
@@ -337,6 +353,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 	case p.Lit != nil:
 		return c.compileLiteral(p.Lit)
 	case p.List != nil:
+		if len(p.List.Elems) == 0 {
+			return "Array new", nil
+		}
 		elems := make([]string, len(p.List.Elems))
 		for i, e := range p.List.Elems {
 			v, err := c.compileExpr(e)
@@ -401,19 +420,19 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 }
 
 func mapOp(op string) string {
-        switch op {
-        case "==":
-                return "="
-        case "!=":
-                return "~="
-        case "%":
-                return "\\"
-        case "&&":
-                return "&"
-        case "||":
-                return "|"
-        }
-        return op
+	switch op {
+	case "==":
+		return "="
+	case "!=":
+		return "~="
+	case "%":
+		return "\\"
+	case "&&":
+		return "&"
+	case "||":
+		return "|"
+	}
+	return op
 }
 
 func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
@@ -431,53 +450,53 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 		s := strings.ReplaceAll(*l.Str, "'", "''")
 		return "'" + s + "'", nil
 	}
-        return "", fmt.Errorf("unknown literal")
+	return "", fmt.Errorf("unknown literal")
 }
 
 func isListUnary(u *parser.Unary, env *types.Env) bool {
-        if u == nil || len(u.Ops) != 0 {
-                return false
-        }
-        return isListPostfix(u.Value, env)
+	if u == nil || len(u.Ops) != 0 {
+		return false
+	}
+	return isListPostfix(u.Value, env)
 }
 
 func isListPostfix(p *parser.PostfixExpr, env *types.Env) bool {
-        if p == nil || len(p.Ops) != 0 {
-                return false
-        }
-        if p.Target.List != nil {
-                return true
-        }
-        if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 && env != nil {
-                if t, err := env.GetVar(p.Target.Selector.Root); err == nil {
-                        if _, ok := t.(types.ListType); ok {
-                                return true
-                        }
-                }
-        }
-        return false
+	if p == nil || len(p.Ops) != 0 {
+		return false
+	}
+	if p.Target.List != nil {
+		return true
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 && env != nil {
+		if t, err := env.GetVar(p.Target.Selector.Root); err == nil {
+			if _, ok := t.(types.ListType); ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func isStringUnary(u *parser.Unary, env *types.Env) bool {
-        if u == nil || len(u.Ops) != 0 {
-                return false
-        }
-        return isStringPostfix(u.Value, env)
+	if u == nil || len(u.Ops) != 0 {
+		return false
+	}
+	return isStringPostfix(u.Value, env)
 }
 
 func isStringPostfix(p *parser.PostfixExpr, env *types.Env) bool {
-        if p == nil || len(p.Ops) != 0 {
-                return false
-        }
-        if p.Target.Lit != nil && p.Target.Lit.Str != nil {
-                return true
-        }
-        if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 && env != nil {
-                if t, err := env.GetVar(p.Target.Selector.Root); err == nil {
-                        if _, ok := t.(types.StringType); ok {
-                                return true
-                        }
-                }
-        }
-        return false
+	if p == nil || len(p.Ops) != 0 {
+		return false
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return true
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 && env != nil {
+		if t, err := env.GetVar(p.Target.Selector.Root); err == nil {
+			if _, ok := t.(types.StringType); ok {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/examples/leetcode-out/st/1/two-sum.st
+++ b/examples/leetcode-out/st/1/two-sum.st
@@ -1,0 +1,22 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+twoSum: nums target: target | i j n |
+	n := nums size.
+	0 to: n - 1 do: [:i |
+		(i + 1) to: n - 1 do: [:j |
+			((((nums at: i + 1) + (nums at: j + 1)) = target)) ifTrue: [
+				^ Array with: i with: j
+			]
+			.
+		]
+		.
+	]
+	.
+	^ Array with: -1 with: -1
+!
+
+!!
+result := Main twoSum: (Array with: 2 with: 7 with: 11 with: 15) target: (9).
+(result at: 0 + 1) displayOn: Transcript. Transcript cr.
+(result at: 1 + 1) displayOn: Transcript. Transcript cr.

--- a/examples/leetcode-out/st/2/add-two-numbers.st
+++ b/examples/leetcode-out/st/2/add-two-numbers.st
@@ -1,0 +1,31 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+addTwoNumbers: l1 l2: l2 | carry digit i j result sum x y |
+	i := 0.
+	j := 0.
+	carry := 0.
+	result := Array new.
+	[(((((i < l1 size) | j) < l2 size) | carry) > 0)] whileTrue: [
+		x := 0.
+		((i < l1 size)) ifTrue: [
+			x := (l1 at: i + 1).
+			i := (i + 1).
+		]
+		.
+		y := 0.
+		((j < l2 size)) ifTrue: [
+			y := (l2 at: j + 1).
+			j := (j + 1).
+		]
+		.
+		sum := ((x + y) + carry).
+		digit := (sum \ 10).
+		carry := (sum / 10).
+		result := (result , Array with: digit).
+	]
+	.
+	^ result
+!
+
+!!

--- a/examples/leetcode-out/st/3/longest-substring-without-repeating-characters.st
+++ b/examples/leetcode-out/st/3/longest-substring-without-repeating-characters.st
@@ -1,0 +1,30 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+lengthOfLongestSubstring: s | best i j length n start |
+	n := s size.
+	start := 0.
+	best := 0.
+	i := 0.
+	[(i < n)] whileTrue: [
+		j := start.
+		[(j < i)] whileTrue: [
+			(((s at: j + 1) = (s at: i + 1))) ifTrue: [
+				start := (j + 1).
+			]
+			.
+			j := (j + 1).
+		]
+		.
+		length := ((i - start) + 1).
+		((length > best)) ifTrue: [
+			best := length.
+		]
+		.
+		i := (i + 1).
+	]
+	.
+	^ best
+!
+
+!!

--- a/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
+++ b/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
@@ -1,0 +1,26 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+findMedianSortedArrays: nums1 nums2: nums2 | i j merged mid1 mid2 total |
+	merged := Array new.
+	i := 0.
+	j := 0.
+	[(((i < nums1 size) | j) < nums2 size)] whileTrue: [
+		((j >= nums2 size)) ifTrue: [
+			merged := (merged , Array with: (nums1 at: i + 1)).
+			i := (i + 1).
+		]
+		.
+	]
+	.
+	total := merged size.
+	(((total \ 2) = 1)) ifTrue: [
+		^ (merged at: (total / 2) + 1)
+	]
+	.
+	mid1 := (merged at: ((total / 2) - 1) + 1).
+	mid2 := (merged at: (total / 2) + 1).
+	^ (((mid1 + mid2)) / 2.000000)
+!
+
+!!

--- a/examples/leetcode-out/st/5/longest-palindromic-substring.st
+++ b/examples/leetcode-out/st/5/longest-palindromic-substring.st
@@ -1,0 +1,46 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+expand: s left: left right: right | l n r |
+	l := left.
+	r := right.
+	n := s size.
+	[(((l >= 0) & r) < n)] whileTrue: [
+		(((s at: l + 1) ~= (s at: r + 1))) ifTrue: [
+		]
+		.
+		l := (l - 1).
+		r := (r + 1).
+	]
+	.
+	^ ((r - l) - 1)
+!
+
+!Main class methodsFor: 'mochi'!
+longestPalindrome: s | end i l len1 len2 n start |
+	((s size <= 1)) ifTrue: [
+		^ s
+	]
+	.
+	start := 0.
+	end := 0.
+	n := s size.
+	0 to: n - 1 do: [:i |
+		len1 := Main expand: (s) left: (i) right: (i).
+		len2 := Main expand: (s) left: (i) right: ((i + 1)).
+		l := len1.
+		((len2 > len1)) ifTrue: [
+			l := len2.
+		]
+		.
+		(((l > end) - start)) ifTrue: [
+			start := ((i - ((l - 1))) / 2).
+			end := ((i + l) / 2).
+		]
+		.
+	]
+	.
+	^ (s copyFrom: (start + 1) to: (end + 1))
+!
+
+!!


### PR DESCRIPTION
## Summary
- support `var` declarations in the Smalltalk backend
- collect variables inside `while` blocks
- handle empty list literals
- provide precompiled Smalltalk output for leetcode problems 1‑5

## Testing
- `go test -tags slow ./compile/st`
- `go test ./...`
- `go run ./cmd/leetcode-runner build --from 1 --to 5 --lang st --run`


------
https://chatgpt.com/codex/tasks/task_e_6852ec5ec4508320b037e82d663ae602