### PR TITLE
Add Swift slice support

### DIFF
--- a/examples/leetcode-out/swift/5/longest-palindromic-substring.swift
+++ b/examples/leetcode-out/swift/5/longest-palindromic-substring.swift
@@ -8,6 +8,19 @@ func _indexString(_ s: String, _ i: Int) -> String {
 	return String(chars[idx])
 }
 
+func _sliceString(_ s: String, _ i: Int, _ j: Int) -> String {
+	var start = i
+	var end = j
+	let chars = Array(s)
+	let n = chars.count
+	if start < 0 { start += n }
+	if end < 0 { end += n }
+	if start < 0 { start = 0 }
+	if end > n { end = n }
+	if end < start { end = start }
+	return String(chars[start..<end])
+}
+
 func expand(_ s: String, _ left: Int, _ right: Int) -> Int {
 	let s = s
 	let left = left
@@ -47,7 +60,7 @@ func longestPalindrome(_ s: String) -> String {
 			end = i + l / 2
 		}
 	}
-	return _indexString(s, start)
+	return _sliceString(s, start, end + 1)
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- enable string slicing in Swift backend
- regenerate longest palindromic substring solution

## Testing
- `go test ./...`
- `go run ./cmd/leetcode-runner build --from 1 --to 5 --lang swift --run`

------
https://chatgpt.com/codex/tasks/task_e_6852ed2214508320960e2e67a106500d