### PR TITLE
Fix OCaml compiler for LeetCode

### DIFF
--- a/compile/ocaml/compiler.go
+++ b/compile/ocaml/compiler.go
@@ -330,6 +330,10 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 				oper = "@"
 			} else if isStringExpr(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: op.Right}}}, c.env) {
 				oper = "^"
+				// convert char from String.get to string for concatenation
+				if strings.HasPrefix(r, "(String.get ") {
+					r = fmt.Sprintf("(String.make 1 %s)", r)
+				}
 			}
 		} else if oper == "/" {
 			if isFloatExpr(&parser.Expr{Binary: &parser.BinaryExpr{Left: &parser.Unary{Value: op.Right}}}, c.env) || isFloatExpr(&parser.Expr{Binary: b}, c.env) {

--- a/examples/leetcode-out/ocaml/5/longest-palindromic-substring.ml
+++ b/examples/leetcode-out/ocaml/5/longest-palindromic-substring.ml
@@ -29,11 +29,17 @@ let rec longestPalindrome s =
       if len2 > len1 then begin
         l := len2;
       end;
-      if !l > !_end - !start then begin
-        start := i - (!l - 1) / 2;
-        _end := i + !l / 2;
+      if !l > (!_end - !start) then begin
+        start := i - ((!l - 1) / 2);
+        _end := i + (!l / 2);
       end;
     done;
-    raise (Return_1 ((String.sub s !start (!_end + 1 - !start))))
+    let res = ref "" in
+    let k = ref !start in
+    while !k <= !_end do
+      res := !res ^ (String.make 1 (String.get s !k));
+      k := !k + 1;
+    done;
+    raise (Return_1 (!res))
   with Return_1 v -> v
 


### PR DESCRIPTION
## Summary
- handle char concatenation in OCaml backend
- regenerate OCaml solution for LeetCode problem 5

## Testing
- `go test ./compile/ocaml -tags slow -run TestOCamlCompiler_LeetCodeExamples -count=1`
- `go run ./cmd/leetcode-runner build --from 1 --to 5 --lang ocaml --run`
- `go run ./cmd/leetcode-runner test`

------
https://chatgpt.com/codex/tasks/task_e_6852f013819483208a328b471bcb9b3b