### PR TITLE
Add Fortran run support

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -178,6 +178,8 @@ func buildOne(src, lang string, run bool) error {
 	ext := "." + lang
 	if lang == "ocaml" {
 		ext = ".ml"
+	} else if lang == "fortran" {
+		ext = ".f90"
 	}
 	outFile := filepath.Join(outDir, base+ext)
 	var data []byte
@@ -361,6 +363,19 @@ func runOutput(file, lang string) error {
 			return err
 		}
 		cmd := exec.Command("elixir", file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	case "fortran":
+		gfortran, err := ftncode.EnsureFortran()
+		if err != nil {
+			return err
+		}
+		exe := strings.TrimSuffix(file, filepath.Ext(file))
+		if out, err := exec.Command(gfortran, file, "-o", exe).CombinedOutput(); err != nil {
+			return fmt.Errorf("gfortran: %v\n%s", err, out)
+		}
+		cmd := exec.Command(exe)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()

--- a/examples/leetcode-out/fortran/1/two-sum.f90
+++ b/examples/leetcode-out/fortran/1/two-sum.f90
@@ -1,0 +1,29 @@
+program main
+  implicit none
+  integer :: result(2)
+  result = twoSum((/2, 7, 11, 15/), 9)
+  print *, result(0 + 1)
+  print *, result(1 + 1)
+contains
+  function twoSum(nums, target) result(res)
+    implicit none
+    integer, intent(in) :: nums(:)
+    integer, intent(in) :: target
+    integer :: n
+    integer :: i
+    integer :: j
+    integer :: res(2)
+    n = size(nums)
+    do i = 0, n - 1
+      do j = (i + 1), n - 1
+        if (((nums(i + 1) + nums(j + 1)) == target)) then
+          res = (/i, j/)
+          return
+        end if
+      end do
+    end do
+    res = (/(-1), (-1)/)
+    return
+  end function twoSum
+  
+end program main


### PR DESCRIPTION
## Summary
- support running generated Fortran files in `leetcode-runner`
- produce `.f90` output when building LeetCode solutions
- check in generated Fortran code for problem 1

## Testing
- `go test ./...` *(fails: TestCCompiler_LeetCodeExamples)*
- `go run ./cmd/leetcode-runner build --from 1 --to 5 --lang fortran --run`

------
https://chatgpt.com/codex/tasks/task_e_6852f00338c08320a2735effd60842d4