### PR TITLE
Add release notes for v0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 # 📦 CHANGELOG.md
+## [0.8.6] – 2025-06-18
+
+### Added
+
+* Float and slice support across many compilers
+* Dart, Kotlin, Racket and Erlang runners
+* Compiled LeetCode examples for problems 1–5
+* Improved Smalltalk installer
+
+### Changed
+
+* Combined Scala tests and ensure tools before running
+
+### Fixed
+
+* Lua compiler errors and Elixir group expressions
+* Float literal handling and unused variables
 ## [0.8.5] – 2025-06-18
 
 ### Added

--- a/releases/v0.8.6.md
+++ b/releases/v0.8.6.md
@@ -1,0 +1,16 @@
+# Jun 2025 (v0.8.6)
+
+Mochi v0.8.6 expands LeetCode coverage to the first five problems across most experimental compilers. Many backends add float and slice features along with assorted fixes and new runners.
+
+## Compilers
+
+- Float literals, string slicing and casts implemented in C, C++, Fortran, Kotlin, OCaml, Scheme, Racket and Swift
+- Dart, Kotlin, Racket and Erlang runners added
+- Generated solutions for problems 1–5 in C, C++, C#, Java, Haskell, PHP, Ruby, Swift, Zig and others
+- Smalltalk installer improvements
+
+## Tests
+
+- LeetCode example suites expanded through problem 5 for all languages
+- Scala tests consolidated and tool checks enforced before running
+- Lua and Elixir compiler fixes for the new examples


### PR DESCRIPTION
## Summary
- document next version in CHANGELOG and releases

## Testing
- `go test ./...` *(fails: TestCCompiler_LeetCodeExamples)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0696580832085ddd9c26f2d6c55