### PR TITLE
Add Scala leetcode tests and outputs

### DIFF
--- a/compile/scala/compiler.go
+++ b/compile/scala/compiler.go
@@ -458,6 +458,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		if p.Lit.Int != nil {
 			return strconv.Itoa(*p.Lit.Int), nil
 		}
+		if p.Lit.Float != nil {
+			return strconv.FormatFloat(*p.Lit.Float, 'f', -1, 64), nil
+		}
 		if p.Lit.Bool != nil {
 			if bool(*p.Lit.Bool) {
 				return "true", nil

--- a/compile/scala/leetcode_test.go
+++ b/compile/scala/leetcode_test.go
@@ -1,0 +1,135 @@
+package scalacode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	scalacode "mochi/compile/scala"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// compileAndRunLeetCode compiles the Mochi solution for the given problem ID and
+// executes the generated Scala code, returning stdout.
+func compileAndRunLeetCode(t *testing.T, id string) string {
+	t.Helper()
+	root := findRoot(t)
+	dir := filepath.Join(root, "examples", "leetcode", id)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var src string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".mochi") {
+			src = filepath.Join(dir, e.Name())
+			break
+		}
+	}
+	if src == "" {
+		t.Fatalf("no mochi source for id %s", id)
+	}
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := scalacode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "Main.scala")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	scalacCmd := exec.Command("scalac", filepath.Base(file))
+	scalacCmd.Dir = tmp
+	out, err := scalacCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("scalac error: %v\n%s", err, out)
+	}
+	cmd := exec.Command("scala", "Main")
+	cmd.Dir = tmp
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("scala run error: %v\n%s", err, out)
+	}
+	return strings.ReplaceAll(string(out), "\r\n", "\n")
+}
+
+func TestLeetCode1(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "1"))
+	if got != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode2(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "2"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode3(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "3"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode4(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "4"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode5(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "5"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func findRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}

--- a/examples/leetcode-out/scala/1/two-sum.scala
+++ b/examples/leetcode-out/scala/1/two-sum.scala
@@ -1,0 +1,19 @@
+object Main {
+	def twoSum(nums: List[Int], target: Int): List[Int] = {
+		val n = nums.length
+		for (i <- 0 until n) {
+			for (j <- (i + 1) until n) {
+				if (((nums(i) + nums(j)) == target)) {
+					return List(i, j)
+				}
+			}
+		}
+		return List((-1), (-1))
+	}
+	
+	def main(args: Array[String]): Unit = {
+		val result = twoSum(List(2, 7, 11, 15), 9)
+		println(result(0))
+		println(result(1))
+	}
+}

--- a/examples/leetcode-out/scala/2/add-two-numbers.scala
+++ b/examples/leetcode-out/scala/2/add-two-numbers.scala
@@ -1,0 +1,28 @@
+object Main {
+	def addTwoNumbers(l1: List[Int], l2: List[Int]): List[Int] = {
+		var i = 0
+		var j = 0
+		var carry = 0
+		var result: List[Int] = List()
+		while ((((i < l1.length) || (j < l2.length)) || (carry > 0))) {
+			var x = 0
+			if ((i < l1.length)) {
+				x = l1(i)
+				i = (i + 1)
+			}
+			var y = 0
+			if ((j < l2.length)) {
+				y = l2(j)
+				j = (j + 1)
+			}
+			val sum = ((x + y) + carry)
+			val digit = (sum % 10)
+			carry = (sum / 10)
+			result = (result ++ List(digit))
+		}
+		return result
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/3/longest-substring-without-repeating-characters.scala
+++ b/examples/leetcode-out/scala/3/longest-substring-without-repeating-characters.scala
@@ -1,0 +1,26 @@
+object Main {
+	def lengthOfLongestSubstring(s: String): Int = {
+		val n = s.length
+		var start = 0
+		var best = 0
+		var i = 0
+		while ((i < n)) {
+			var j = start
+			while ((j < i)) {
+				if ((s(j) == s(i))) {
+					start = (j + 1)
+				}
+				j = (j + 1)
+			}
+			val length = ((i - start) + 1)
+			if ((length > best)) {
+				best = length
+			}
+			i = (i + 1)
+		}
+		return best
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/4/median-of-two-sorted-arrays.scala
+++ b/examples/leetcode-out/scala/4/median-of-two-sorted-arrays.scala
@@ -1,0 +1,32 @@
+object Main {
+	def findMedianSortedArrays(nums1: List[Int], nums2: List[Int]): Double = {
+		var merged: List[Int] = List()
+		var i = 0
+		var j = 0
+		while (((i < nums1.length) || (j < nums2.length))) {
+			if ((j >= nums2.length)) {
+				merged = (merged ++ List(nums1(i)))
+				i = (i + 1)
+			} else 			if ((i >= nums1.length)) {
+				merged = (merged ++ List(nums2(j)))
+				j = (j + 1)
+			} else 			if ((nums1(i) <= nums2(j))) {
+				merged = (merged ++ List(nums1(i)))
+				i = (i + 1)
+			} else {
+				merged = (merged ++ List(nums2(j)))
+				j = (j + 1)
+			}
+		}
+		val total = merged.length
+		if (((total % 2) == 1)) {
+			return merged((total / 2)).asInstanceOf[Double]
+		}
+		val mid1 = merged(((total / 2) - 1))
+		val mid2 = merged((total / 2))
+		return (((mid1 + mid2)).asInstanceOf[Double] / 2)
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
+++ b/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
@@ -1,0 +1,45 @@
+object Main {
+	def expand(s: String, left: Int, right: Int): Int = {
+		var l = left
+		var r = right
+		val n = s.length
+		while (((l >= 0) && (r < n))) {
+			if ((s(l) != s(r))) {
+			}
+			l = (l - 1)
+			r = (r + 1)
+		}
+		return ((r - l) - 1)
+	}
+	
+	def longestPalindrome(s: String): String = {
+		if ((s.length <= 1)) {
+			return s
+		}
+		var start = 0
+		var end = 0
+		val n = s.length
+		for (i <- 0 until n) {
+			val len1 = expand(s, i, i)
+			val len2 = expand(s, i, (i + 1))
+			var l = len1
+			if ((len2 > len1)) {
+				l = len2
+			}
+			if ((l > ((end - start)))) {
+				start = (i - ((((l - 1)) / 2)))
+				end = (i + ((l / 2)))
+			}
+		}
+		var res = ""
+		var k = start
+		while ((k <= end)) {
+			res = (res + s(k))
+			k = (k + 1)
+		}
+		return res
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}


### PR DESCRIPTION
## Summary
- support float literals in Scala backend
- add Scala LeetCode tests for problems 1-5
- generate Scala solutions for problems 1-5

## Testing
- `go test ./compile/scala -run TestLeetCode -count=1`
- `go test ./...` *(fails: TestCCompiler_LeetCodeExamples)*

------
https://chatgpt.com/codex/tasks/task_e_6852f026bebc832089a0200df0f0ed65