### PR TITLE
Add Clojure LeetCode runner improvements

### DIFF
--- a/examples/leetcode/5/longest-palindromic-substring.mochi
+++ b/examples/leetcode/5/longest-palindromic-substring.mochi
@@ -31,13 +31,7 @@ export fun longestPalindrome(s: string): string {
       end = i + (l / 2)
     }
   }
-  var res = ""
-  var k = start
-  while k <= end {
-    res = res + s[k]
-    k = k + 1
-  }
-  return res
+  return s[start:end+1]
 }
 
 test "example 1" {


### PR DESCRIPTION
## Summary
- improve Clojure backend: string concatenation heuristic
- ignore unsupported casts instead of failing
- simplify longest palindrome example using slicing

## Testing
- `go test ./compile/clj -run TestClojureCompiler_LeetCodeExamples -tags slow -v`
- `go run cmd/leetcode-runner/main.go build --from 1 --to 5 --lang clj`

------
https://chatgpt.com/codex/tasks/task_e_6852eff1e12083208237f7f4e4df781f