### PR TITLE
Add Pascal LeetCode outputs

### DIFF
--- a/compile/pas/helpers.go
+++ b/compile/pas/helpers.go
@@ -71,6 +71,17 @@ func isListLiteral(e *parser.Expr) bool {
 	return u.Value.Target.List != nil
 }
 
+func isStringLiteral(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) > 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if u == nil || u.Value == nil || u.Value.Target == nil {
+		return false
+	}
+	return u.Value.Target.Lit != nil && u.Value.Target.Lit.Str != nil
+}
+
 func (c *Compiler) isListExpr(e *parser.Expr) bool {
 	if isListLiteral(e) {
 		return true

--- a/examples/leetcode-out/pas/1/two-sum.pas
+++ b/examples/leetcode-out/pas/1/two-sum.pas
@@ -1,0 +1,36 @@
+program main;
+{$mode objfpc}
+uses SysUtils;
+
+type TIntArray = array of integer;
+
+function twoSum(nums: TIntArray; target: integer): TIntArray;
+var
+	i: integer;
+	j: integer;
+	n: integer;
+begin
+	n := Length(nums);
+	for i := 0 to n - 1 do
+	begin
+		for j := i + 1 to n - 1 do
+		begin
+			if (nums[i] + nums[j] = target) then
+			begin
+				result := TIntArray([i, j]);
+				exit;
+			end;
+		end;
+	end;
+	result := TIntArray([-1, -1]);
+	exit;
+end;
+
+var
+	_result: TIntArray;
+
+begin
+	_result := twoSum(TIntArray([2, 7, 11, 15]), 9);
+	writeln(_result[0]);
+	writeln(_result[1]);
+end.

--- a/examples/leetcode-out/pas/2/add-two-numbers.pas
+++ b/examples/leetcode-out/pas/2/add-two-numbers.pas
@@ -1,0 +1,46 @@
+program main;
+{$mode objfpc}
+uses SysUtils;
+
+type TIntArray = array of integer;
+
+function addTwoNumbers(l1: TIntArray; l2: TIntArray): TIntArray;
+var
+	carry: integer;
+	digit: integer;
+	i: integer;
+	j: integer;
+	_result: TIntArray;
+	sum: integer;
+	x: integer;
+	y: integer;
+begin
+	i := 0;
+	j := 0;
+	carry := 0;
+	_result := TIntArray([]);
+	while (((i < Length(l1)) or (j < Length(l2))) or (carry > 0)) do
+	begin
+		x := 0;
+		if (i < Length(l1)) then
+		begin
+			x := l1[i];
+			i := i + 1;
+		end;
+		y := 0;
+		if (j < Length(l2)) then
+		begin
+			y := l2[j];
+			j := j + 1;
+		end;
+		sum := x + y + carry;
+		digit := sum mod 10;
+		carry := sum div 10;
+		_result := Concat(_result, TIntArray([digit]));
+	end;
+	result := _result;
+	exit;
+end;
+
+begin
+end.

--- a/examples/leetcode-out/pas/3/longest-substring-without-repeating-characters.pas
+++ b/examples/leetcode-out/pas/3/longest-substring-without-repeating-characters.pas
@@ -1,0 +1,44 @@
+program main;
+{$mode objfpc}
+uses SysUtils;
+
+type TIntArray = array of integer;
+
+function lengthOfLongestSubstring(s: string): integer;
+var
+	best: integer;
+	i: integer;
+	j: integer;
+	_length: integer;
+	n: integer;
+	start: integer;
+begin
+	n := Length(s);
+	start := 0;
+	best := 0;
+	i := 0;
+	while (i < n) do
+	begin
+		j := start;
+		while (j < i) do
+		begin
+			if (s[j] = s[i]) then
+			begin
+				start := j + 1;
+				break;
+			end;
+			j := j + 1;
+		end;
+		_length := i - start + 1;
+		if (_length > best) then
+		begin
+			best := _length;
+		end;
+		i := i + 1;
+	end;
+	result := best;
+	exit;
+end;
+
+begin
+end.

--- a/examples/leetcode-out/pas/4/median-of-two-sorted-arrays.pas
+++ b/examples/leetcode-out/pas/4/median-of-two-sorted-arrays.pas
@@ -1,0 +1,52 @@
+program main;
+{$mode objfpc}
+uses SysUtils;
+
+type TIntArray = array of integer;
+
+function findMedianSortedArrays(nums1: TIntArray; nums2: TIntArray): double;
+var
+	i: integer;
+	j: integer;
+	merged: TIntArray;
+	mid1: integer;
+	mid2: integer;
+	total: integer;
+begin
+	merged := TIntArray([]);
+	i := 0;
+	j := 0;
+	while ((i < Length(nums1)) or (j < Length(nums2))) do
+	begin
+		if (j >= Length(nums2)) then
+		begin
+			merged := Concat(merged, TIntArray([nums1[i]]));
+			i := i + 1;
+		end else if (i >= Length(nums1)) then
+		begin
+			merged := Concat(merged, TIntArray([nums2[j]]));
+			j := j + 1;
+		end else if (nums1[i] <= nums2[j]) then
+		begin
+			merged := Concat(merged, TIntArray([nums1[i]]));
+			i := i + 1;
+		end else
+		begin
+			merged := Concat(merged, TIntArray([nums2[j]]));
+			j := j + 1;
+		end;
+	end;
+	total := Length(merged);
+	if (total mod 2 = 1) then
+	begin
+		result := Double(merged[total div 2]);
+		exit;
+	end;
+	mid1 := merged[total div 2 - 1];
+	mid2 := merged[total div 2];
+	result := Double(mid1 + mid2) / 2;
+	exit;
+end;
+
+begin
+end.

--- a/examples/leetcode-out/pas/5/longest-palindromic-substring.pas
+++ b/examples/leetcode-out/pas/5/longest-palindromic-substring.pas
@@ -1,0 +1,76 @@
+program main;
+{$mode objfpc}
+uses SysUtils;
+
+type TIntArray = array of integer;
+
+function expand(s: string; left: integer; right: integer): integer;
+var
+	l: integer;
+	n: integer;
+	r: integer;
+begin
+	l := left;
+	r := right;
+	n := Length(s);
+	while ((l >= 0) and (r < n)) do
+	begin
+		if (s[l] <> s[r]) then
+		begin
+			break;
+		end;
+		l := l - 1;
+		r := r + 1;
+	end;
+	result := r - l - 1;
+	exit;
+end;
+
+function longestPalindrome(s: string): string;
+var
+	_end: integer;
+	i: integer;
+	k: integer;
+	l: integer;
+	len1: integer;
+	len2: integer;
+	n: integer;
+	res: string;
+	start: integer;
+begin
+	if (Length(s) <= 1) then
+	begin
+		result := s;
+		exit;
+	end;
+	start := 0;
+	_end := 0;
+	n := Length(s);
+	for i := 0 to n - 1 do
+	begin
+		len1 := expand(s, i, i);
+		len2 := expand(s, i, i + 1);
+		l := len1;
+		if (len2 > len1) then
+		begin
+			l := len2;
+		end;
+		if (l > _end - start) then
+		begin
+			start := i - l - 1 div 2;
+			_end := i + l div 2;
+		end;
+	end;
+	res := '';
+	k := start;
+	while (k <= _end) do
+	begin
+		res := res + s[k];
+		k := k + 1;
+	end;
+	result := res;
+	exit;
+end;
+
+begin
+end.


### PR DESCRIPTION
## Summary
- support Pascal testless compilation in compiler
- handle floats, casts, and grouped expressions
- generate Pascal code for LeetCode problems 1–5

## Testing
- `go run cmd/leetcode-runner/main.go build --from 1 --to 5 --lang pas`
- `for i in 1 2 3 4 5; do fpc examples/leetcode-out/pas/$i/*.pas; done`


------
https://chatgpt.com/codex/tasks/task_e_6852f0169da883208cdc189dbd0dd200