### PR TITLE
Add fs leetcode outputs and fix fs index compilation

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -179,6 +179,9 @@ func buildOne(src, lang string, run bool) error {
 	if lang == "ocaml" {
 		ext = ".ml"
 	}
+	if lang == "fs" {
+		ext = ".fsx"
+	}
 	outFile := filepath.Join(outDir, base+ext)
 	var data []byte
 	switch lang {

--- a/examples/leetcode-out/fs/1/two-sum.fsx
+++ b/examples/leetcode-out/fs/1/two-sum.fsx
@@ -1,0 +1,17 @@
+open System
+
+exception Return_twoSum of int[]
+let twoSum (nums: int[]) (target: int) : int[] =
+    try
+        let n = nums.Length
+        for i = 0 to n - 1 do
+            for j = (i + 1) to n - 1 do
+                if ((nums.[i] + nums.[j]) = target) then
+                    raise (Return_twoSum ([|i; j|]))
+        raise (Return_twoSum ([|(-1); (-1)|]))
+        failwith "unreachable"
+    with Return_twoSum v -> v
+
+let result = twoSum [|2; 7; 11; 15|] 9
+printfn "%A" result.[0]
+printfn "%A" result.[1]

--- a/examples/leetcode-out/fs/2/add-two-numbers.fsx
+++ b/examples/leetcode-out/fs/2/add-two-numbers.fsx
@@ -1,0 +1,26 @@
+open System
+
+exception Return_addTwoNumbers of int[]
+let addTwoNumbers (l1: int[]) (l2: int[]) : int[] =
+    try
+        let mutable i = 0
+        let mutable j = 0
+        let mutable carry = 0
+        let mutable result = [||]
+        while (((i < l1.Length) || (j < l2.Length)) || (carry > 0)) do
+            let mutable x = 0
+            if (i < l1.Length) then
+                x <- l1.[i]
+                i <- (i + 1)
+            let mutable y = 0
+            if (j < l2.Length) then
+                y <- l2.[j]
+                j <- (j + 1)
+            let sum = ((x + y) + carry)
+            let digit = (sum % 10)
+            carry <- (sum / 10)
+            result <- Array.append result [|digit|]
+        raise (Return_addTwoNumbers (result))
+        failwith "unreachable"
+    with Return_addTwoNumbers v -> v
+

--- a/examples/leetcode-out/fs/3/longest-substring-without-repeating-characters.fsx
+++ b/examples/leetcode-out/fs/3/longest-substring-without-repeating-characters.fsx
@@ -1,0 +1,34 @@
+open System
+exception BreakException of int
+exception ContinueException of int
+
+exception Return_lengthOfLongestSubstring of int
+let lengthOfLongestSubstring (s: string) : int =
+    try
+        let n = s.Length
+        let mutable start = 0
+        let mutable best = 0
+        let mutable i = 0
+        try
+            while (i < n) do
+                try
+                    let mutable j = start
+                    try
+                        while (j < i) do
+                            try
+                                if ((string s.[(if j < 0 then s.Length + j else j)]) = (string s.[(if i < 0 then s.Length + i else i)])) then
+                                    start <- (j + 1)
+                                    raise (BreakException 1)
+                                j <- (j + 1)
+                            with ContinueException n when n = 1 -> ()
+                    with BreakException n when n = 1 -> ()
+                    let length = ((i - start) + 1)
+                    if (length > best) then
+                        best <- length
+                    i <- (i + 1)
+                with ContinueException n when n = 0 -> ()
+        with BreakException n when n = 0 -> ()
+        raise (Return_lengthOfLongestSubstring (best))
+        failwith "unreachable"
+    with Return_lengthOfLongestSubstring v -> v
+

--- a/examples/leetcode-out/fs/4/median-of-two-sorted-arrays.fsx
+++ b/examples/leetcode-out/fs/4/median-of-two-sorted-arrays.fsx
@@ -1,0 +1,30 @@
+open System
+
+exception Return_findMedianSortedArrays of float
+let findMedianSortedArrays (nums1: int[]) (nums2: int[]) : float =
+    try
+        let mutable merged = [||]
+        let mutable i = 0
+        let mutable j = 0
+        while ((i < nums1.Length) || (j < nums2.Length)) do
+            if (j >= nums2.Length) then
+                merged <- Array.append merged [|nums1.[i]|]
+                i <- (i + 1)
+            elif (i >= nums1.Length) then
+                merged <- Array.append merged [|nums2.[j]|]
+                j <- (j + 1)
+            elif (nums1.[i] <= nums2.[j]) then
+                merged <- Array.append merged [|nums1.[i]|]
+                i <- (i + 1)
+            else
+                merged <- Array.append merged [|nums2.[j]|]
+                j <- (j + 1)
+        let total = merged.Length
+        if ((total % 2) = 1) then
+            raise (Return_findMedianSortedArrays ((float merged.[(total / 2)])))
+        let mid1 = merged.[((total / 2) - 1)]
+        let mid2 = merged.[(total / 2)]
+        raise (Return_findMedianSortedArrays (((float ((mid1 + mid2))) / 2.000000)))
+        failwith "unreachable"
+    with Return_findMedianSortedArrays v -> v
+

--- a/examples/leetcode-out/fs/5/longest-palindromic-substring.fsx
+++ b/examples/leetcode-out/fs/5/longest-palindromic-substring.fsx
@@ -1,0 +1,49 @@
+open System
+exception BreakException of int
+exception ContinueException of int
+
+exception Return_expand of int
+let expand (s: string) (left: int) (right: int) : int =
+    try
+        let mutable l = left
+        let mutable r = right
+        let n = s.Length
+        try
+            while ((l >= 0) && (r < n)) do
+                try
+                    if ((string s.[(if l < 0 then s.Length + l else l)]) <> (string s.[(if r < 0 then s.Length + r else r)])) then
+                        raise (BreakException 0)
+                    l <- (l - 1)
+                    r <- (r + 1)
+                with ContinueException n when n = 0 -> ()
+        with BreakException n when n = 0 -> ()
+        raise (Return_expand (((r - l) - 1)))
+        failwith "unreachable"
+    with Return_expand v -> v
+
+exception Return_longestPalindrome of string
+let longestPalindrome (s: string) : string =
+    try
+        if (s.Length <= 1) then
+            raise (Return_longestPalindrome (s))
+        let mutable start = 0
+        let mutable _end = 0
+        let n = s.Length
+        for i = 0 to n - 1 do
+            let len1 = expand s i i
+            let len2 = expand s i (i + 1)
+            let mutable l = len1
+            if (len2 > len1) then
+                l <- len2
+            if (l > ((_end - start))) then
+                start <- (i - ((((l - 1)) / 2)))
+                _end <- (i + ((l / 2)))
+        let mutable res = ""
+        let mutable k = start
+        while (k <= _end) do
+            res <- (res + (string s.[(if k < 0 then s.Length + k else k)]))
+            k <- (k + 1)
+        raise (Return_longestPalindrome (res))
+        failwith "unreachable"
+    with Return_longestPalindrome v -> v
+


### PR DESCRIPTION
## Summary
- fix fs compiler to cast char indexing to string
- store function declarations for param type checks
- output `.fsx` extension in leetcode-runner
- generate F# solutions for LeetCode problems 1-5

## Testing
- `go test ./compile/fs -run TestFSCompiler_LeetCodeExamples -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852f0058a608320ac0ec013faf03f78