### PR TITLE
Compile LeetCode examples to Rust

### DIFF
--- a/cmd/leetcode-runner/main.go
+++ b/cmd/leetcode-runner/main.go
@@ -178,6 +178,8 @@ func buildOne(src, lang string, run bool) error {
 	ext := "." + lang
 	if lang == "ocaml" {
 		ext = ".ml"
+	} else if lang == "rust" {
+		ext = ".rs"
 	}
 	outFile := filepath.Join(outDir, base+ext)
 	var data []byte
@@ -494,7 +496,7 @@ func runOutput(file, lang string) error {
 		if err := rscode.EnsureRust(); err != nil {
 			return err
 		}
-		exe := strings.TrimSuffix(file, ".rs")
+		exe := strings.TrimSuffix(file, filepath.Ext(file))
 		if out, err := exec.Command("rustc", file, "-O", "-o", exe).CombinedOutput(); err != nil {
 			return fmt.Errorf("rustc: %v\n%s", err, out)
 		}

--- a/examples/leetcode-out/rust/1/two-sum.rs
+++ b/examples/leetcode-out/rust/1/two-sum.rs
@@ -1,0 +1,18 @@
+fn twoSum(nums: Vec<i32>, target: i32) -> Vec<i32> {
+    let mut n = nums.len() as i32;
+    for i in 0..n {
+        for j in i + 1..n {
+            if nums[(i) as usize] + nums[(j) as usize] == target {
+                return vec![i, j];
+            }
+        }
+    }
+    return vec![-1, -1];
+}
+
+fn main() {
+    let mut result = twoSum(vec![2, 7, 11, 15], 9);
+    println!("{}", result[(0) as usize]);
+    println!("{}", result[(1) as usize]);
+}
+

--- a/examples/leetcode-out/rust/2/add-two-numbers.rs
+++ b/examples/leetcode-out/rust/2/add-two-numbers.rs
@@ -1,0 +1,33 @@
+fn addTwoNumbers(l1: Vec<i32>, l2: Vec<i32>) -> Vec<i32> {
+    let mut i = 0;
+    let mut j = 0;
+    let mut carry = 0;
+    let mut result = vec![];
+    while i < l1.len() as i32 || j < l2.len() as i32 || carry > 0 {
+        let mut x = 0;
+        if i < l1.len() as i32 {
+            x = l1[(i) as usize];
+            i = i + 1;
+        }
+        let mut y = 0;
+        if j < l2.len() as i32 {
+            y = l2[(j) as usize];
+            j = j + 1;
+        }
+        let mut sum = x + y + carry;
+        let mut digit = sum % 10;
+        carry = sum / 10;
+        result = _concat(&result, &vec![digit]);
+    }
+    return result;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/3/longest-substring-without-repeating-characters.rs
+++ b/examples/leetcode-out/rust/3/longest-substring-without-repeating-characters.rs
@@ -1,0 +1,26 @@
+fn lengthOfLongestSubstring(s: &str) -> i32 {
+    let mut n = s.len() as i32;
+    let mut start = 0;
+    let mut best = 0;
+    let mut i = 0;
+    while i < n {
+        let mut j = start;
+        while j < i {
+            if s.chars().nth((j) as usize).unwrap() == s.chars().nth((i) as usize).unwrap() {
+                start = j + 1;
+                break;
+            }
+            j = j + 1;
+        }
+        let mut length = i - start + 1;
+        if length > best {
+            best = length;
+        }
+        i = i + 1;
+    }
+    return best;
+}
+
+fn main() {
+}
+

--- a/examples/leetcode-out/rust/4/median-of-two-sorted-arrays.rs
+++ b/examples/leetcode-out/rust/4/median-of-two-sorted-arrays.rs
@@ -1,0 +1,39 @@
+fn findMedianSortedArrays(nums1: Vec<i32>, nums2: Vec<i32>) -> f64 {
+    let mut merged = vec![];
+    let mut i = 0;
+    let mut j = 0;
+    while i < nums1.len() as i32 || j < nums2.len() as i32 {
+        if j >= nums2.len() as i32 {
+            merged = _concat(&merged, &vec![nums1[(i) as usize]]);
+            i = i + 1;
+        } else 
+        if i >= nums1.len() as i32 {
+            merged = _concat(&merged, &vec![nums2[(j) as usize]]);
+            j = j + 1;
+        } else 
+        if nums1[(i) as usize] <= nums2[(j) as usize] {
+            merged = _concat(&merged, &vec![nums1[(i) as usize]]);
+            i = i + 1;
+        } else {
+            merged = _concat(&merged, &vec![nums2[(j) as usize]]);
+            j = j + 1;
+        }
+    }
+    let mut total = merged.len() as i32;
+    if total % 2 == 1 {
+        return (merged[(total / 2) as usize] as f64);
+    }
+    let mut mid1 = merged[(total / 2 - 1) as usize];
+    let mut mid2 = merged[(total / 2) as usize];
+    return ((mid1 + mid2) as f64) / 2.0;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/5/longest-palindromic-substring.rs
+++ b/examples/leetcode-out/rust/5/longest-palindromic-substring.rs
@@ -1,0 +1,45 @@
+fn expand(s: &str, left: i32, right: i32) -> i32 {
+    let mut l = left;
+    let mut r = right;
+    let mut n = s.len() as i32;
+    while l >= 0 && r < n {
+        if s.chars().nth((l) as usize).unwrap() != s.chars().nth((r) as usize).unwrap() {
+            break;
+        }
+        l = l - 1;
+        r = r + 1;
+    }
+    return r - l - 1;
+}
+
+fn longestPalindrome(s: &str) -> String {
+    if s.len() as i32 <= 1 {
+        return s.to_string();
+    }
+    let mut start = 0;
+    let mut end = 0;
+    let mut n = s.len() as i32;
+    for i in 0..n {
+        let mut len1 = expand(s, i, i);
+        let mut len2 = expand(s, i, i + 1);
+        let mut l = len1;
+        if len2 > len1 {
+            l = len2;
+        }
+        if l > (end - start) {
+            start = i - ((l - 1) / 2);
+            end = i + (l / 2);
+        }
+    }
+    let mut res = "".to_string();
+    let mut k = start;
+    while k <= end {
+        res = format!("{}{}", res, s.chars().nth((k) as usize).unwrap());
+        k = k + 1;
+    }
+    return res;
+}
+
+fn main() {
+}
+


### PR DESCRIPTION
## Summary
- fix `leetcode-runner` to write `.rs` files for Rust
- improve Rust compiler's handling of strings
- generate Rust solutions for LeetCode problems 1-5
- allow running Rust output even if the file extension isn't `.rs`

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 5 -l rust --run`
- `go run ./cmd/mochi test examples/leetcode/2/add-two-numbers.mochi`
- `go run ./cmd/mochi test examples/leetcode/3/longest-substring-without-repeating-characters.mochi`
- `go run ./cmd/mochi test examples/leetcode/4/median-of-two-sorted-arrays.mochi`
- `go run ./cmd/mochi test examples/leetcode/5/longest-palindromic-substring.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6852f02414248320a7d54d55c38bea96