### PR TITLE
Add slow build tags for compile tests

### DIFF
--- a/compile/c/leetcode_test.go
+++ b/compile/c/leetcode_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ccode_test
 
 import (

--- a/compile/pas/compiler_test.go
+++ b/compile/pas/compiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pascode_test
 
 import (

--- a/compile/scala/leetcode_test.go
+++ b/compile/scala/leetcode_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scalacode_test
 
 import (


### PR DESCRIPTION
## Summary
- mark the missing compiler tests with the `slow` build tag

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852f803180c8320b44f1f57b3ffc774