### PR TITLE
Add v0.8.6 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # 📦 CHANGELOG.md
+## [0.8.6] – 2025-06-19
+
+### Added
+
+* LeetCode examples 1–5 compile across all experimental compilers
+* New runners for Kotlin, Swift, Dart, Racket and Erlang
+* String slicing and concatenation in C, C++, Fortran, F#, Lua and more
+* Float and cast support in Scheme, Clojure, Fortran and others
+
+### Changed
+
+* Golden outputs refreshed and output naming unified
+* `leetcode-runner` validates toolchains and allows custom SWI-Prolog path
+
+### Fixed
+
+* F# string indexing and Clojure concatenation issues
+* Java underscore handling and COBOL generation bugs
+* Erlang branch formatting and assorted compiler errors
+
 ## [0.8.5] – 2025-06-18
 
 ### Added

--- a/releases/v0.8.6.md
+++ b/releases/v0.8.6.md
@@ -1,0 +1,25 @@
+# Jun 2025 (v0.8.6)
+
+Mochi v0.8.6 brings the first five LeetCode examples to every experimental compiler. New language features and runners make these programs compile and run across the entire project.
+
+## Compilers
+
+- Added string slicing and concatenation in C, C++, Fortran, F#, Lua and more
+- Float and cast support for Scheme, Clojure, F#, Fortran and others
+- New runners for Kotlin, Swift, Dart, Racket and Erlang
+- Pascal, OCaml, Ruby, Java, Scala and Zig outputs for LeetCode 1–5
+- Updated C#, PHP and Smalltalk solutions
+
+## Tooling
+
+- `leetcode-runner` verifies toolchain availability before execution
+- SWI-Prolog path can be configured when running examples
+
+## Tests
+
+- Generated and updated golden outputs for LeetCode problems 1–5 across all languages
+
+## Fixes
+
+- Corrected F# string indexing, Java underscore handling and COBOL generation
+- Resolved Clojure string concatenation, Erlang branch formatting and other compiler issues


### PR DESCRIPTION
## Summary
- start changelog for v0.8.6
- document v0.8.6 in `releases/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852f7e83a108320925df8a8c836e402