### PR TITLE
Compile leetcode 1-10 to Swift

### DIFF
--- a/examples/leetcode-out/swift/10/regular-expression-matching.swift
+++ b/examples/leetcode-out/swift/10/regular-expression-matching.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+func _indexString(_ s: String, _ i: Int) -> String {
+	var idx = i
+	let chars = Array(s)
+	if idx < 0 { idx += chars.count }
+	if idx < 0 || idx >= chars.count { fatalError("index out of range") }
+	return String(chars[idx])
+}
+
+func isMatch(_ s: String, _ p: String) -> Bool {
+	let s = s
+	let p = p
+	
+	let m: Int = s.count
+	let n: Int = p.count
+	var memo: [Int: Bool] = [:]
+	func dfs(_ i: Int, _ j: Int) -> Bool {
+		let i = i
+		let j = j
+		
+		let key: Int = i * (n + 1) + j
+		if memo[key] != nil {
+			return memo[key]!
+		}
+		if j == n {
+			return i == m
+		}
+		var first: Bool = false
+		if i < m {
+			if (_indexString(p, j) == _indexString(s, i)) || (_indexString(p, j) == ".") {
+				first = true
+			}
+		}
+		var ans: Bool = false
+		if j + 1 < n {
+			if _indexString(p, j + 1) == "*" {
+				if dfs(i, j + 2) {
+					ans = true
+				} else 				if first && dfs(i + 1, j) {
+					ans = true
+				}
+			} else {
+				if first && dfs(i + 1, j + 1) {
+					ans = true
+				}
+			}
+		} else {
+			if first && dfs(i + 1, j + 1) {
+				ans = true
+			}
+		}
+		memo[key] = ans
+		return ans
+	}
+	return dfs(0, 0)
+}
+
+func main() {
+}
+main()

--- a/examples/leetcode-out/swift/6/zigzag-conversion.swift
+++ b/examples/leetcode-out/swift/6/zigzag-conversion.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+func convert(_ s: String, _ numRows: Int) -> String {
+	let s = s
+	let numRows = numRows
+	
+	if numRows <= 1 || numRows >= s.count {
+		return s
+	}
+	var rows: [String] = []
+	var i: Int = 0
+	while i < numRows {
+		rows = rows + [""]
+		i = i + 1
+	}
+	var curr: Int = 0
+	var step: Int = 1
+	for ch_ch in s {
+		let ch = String(ch_ch)
+		rows[curr] = rows[curr] + ch
+		if curr == 0 {
+			step = 1
+		} else 		if curr == numRows - 1 {
+			step = -1
+		}
+		curr = curr + step
+	}
+	var result: String = ""
+	for row in rows {
+		result = result + row
+	}
+	return result
+}
+
+func main() {
+}
+main()

--- a/examples/leetcode-out/swift/7/reverse-integer.swift
+++ b/examples/leetcode-out/swift/7/reverse-integer.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+func reverse(_ x: Int) -> Int {
+	let x = x
+	
+	var sign: Int = 1
+	var n: Int = x
+	if n < 0 {
+		sign = -1
+		n = -n
+	}
+	var rev: Int = 0
+	while n != 0 {
+		let digit: Int = n % 10
+		rev = rev * 10 + digit
+		n = n / 10
+	}
+	rev = rev * sign
+	if rev < (-2147483647 - 1) || rev > 2147483647 {
+		return 0
+	}
+	return rev
+}
+
+func main() {
+}
+main()

--- a/examples/leetcode-out/swift/8/string-to-integer-atoi.swift
+++ b/examples/leetcode-out/swift/8/string-to-integer-atoi.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+func _indexString(_ s: String, _ i: Int) -> String {
+	var idx = i
+	let chars = Array(s)
+	if idx < 0 { idx += chars.count }
+	if idx < 0 || idx >= chars.count { fatalError("index out of range") }
+	return String(chars[idx])
+}
+
+func myAtoi(_ s: String) -> Int {
+	let s = s
+	
+	var i: Int = 0
+	let n: Int = s.count
+	while i < n && _indexString(s, i) == " " {
+		i = i + 1
+	}
+	var sign: Int = 1
+	if i < n && (_indexString(s, i) == "+" || _indexString(s, i) == "-") {
+		if _indexString(s, i) == "-" {
+			sign = -1
+		}
+		i = i + 1
+	}
+	let digits: [String: Int] = ["0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9]
+	var result: Int = 0
+	while i < n {
+		let ch: String = _indexString(s, i)
+		if !(digits[ch] != nil) {
+			break
+		}
+		let d: Int = digits[ch]!
+		result = result * 10 + d
+		i = i + 1
+	}
+	result = result * sign
+	if result > 2147483647 {
+		return 2147483647
+	}
+	if result < (-2147483648) {
+		return -2147483648
+	}
+	return result
+}
+
+func main() {
+}
+main()

--- a/examples/leetcode-out/swift/9/palindrome-number.swift
+++ b/examples/leetcode-out/swift/9/palindrome-number.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+func _indexString(_ s: String, _ i: Int) -> String {
+	var idx = i
+	let chars = Array(s)
+	if idx < 0 { idx += chars.count }
+	if idx < 0 || idx >= chars.count { fatalError("index out of range") }
+	return String(chars[idx])
+}
+
+func isPalindrome(_ x: Int) -> Bool {
+	let x = x
+	
+	if x < 0 {
+		return false
+	}
+	let s: String = String(x)
+	let n: Int = s.count
+	for i in 0..<n / 2 {
+		if _indexString(s, i) != _indexString(s, n - 1 - i) {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+}
+main()

--- a/examples/leetcode/6/zigzag-conversion.mochi
+++ b/examples/leetcode/6/zigzag-conversion.mochi
@@ -3,7 +3,7 @@ fun convert(s: string, numRows: int): string {
     return s
   }
 
-  var rows = []
+  var rows: list<string> = []
   var i = 0
   while i < numRows {
     rows = rows + [""]


### PR DESCRIPTION
## Summary
- track local variable types in the Swift compiler
- infer expression types to emit better Swift types
- support nested functions and improved for‑loops
- add explicit type annotation for zigzag conversion example
- generate Swift code for LeetCode problems 6-10

## Testing
- `swiftc examples/leetcode-out/swift/6/zigzag-conversion.swift -o /tmp/zz && /tmp/zz`
- `for i in 7 8 9 10; do swiftc examples/leetcode-out/swift/$i/*.swift -o /tmp/t$i && /tmp/t$i; done`


------
https://chatgpt.com/codex/tasks/task_e_6852f8a737e0832088d2dbc25ead8a64