### PR TITLE
Add partial Pascal map support

### DIFF
--- a/examples/leetcode-out/pas/10/regular-expression-matching.pas
+++ b/examples/leetcode-out/pas/10/regular-expression-matching.pas
@@ -1,0 +1,78 @@
+program main;
+{$mode objfpc}
+uses SysUtils, fgl;
+
+type TIntArray = array of integer;
+
+function isMatch(s: string; p: string): boolean;
+var
+	m: integer;
+	memo: integer;
+	n: integer;
+begin
+	m := Length(s);
+	n := Length(p);
+	var _tmp0: specialize TFPGMap<string, integer>;
+	_tmp0 := specialize TFPGMap<string, integer>.Create;
+	memo := _tmp0;
+	function dfs(i: integer; j: integer): boolean;
+	var
+		ans: integer;
+		first: integer;
+		key: integer;
+	begin
+		key := i * n + 1 + j;
+		if (key in memo) then
+		begin
+			result := memo[key];
+			exit;
+		end;
+		if (j = n) then
+		begin
+			result := (i = m);
+			exit;
+		end;
+		first := False;
+		if (i < m) then
+		begin
+			if ((p[j] = s[i]) or (p[j] = '.')) then
+			begin
+				first := True;
+			end;
+		end;
+		ans := False;
+		if (j + 1 < n) then
+		begin
+			if (p[j + 1] = '*') then
+			begin
+				if dfs(i, j + 2) then
+				begin
+					ans := True;
+				end else if (first and dfs(i + 1, j)) then
+				begin
+					ans := True;
+				end;
+			end else
+			begin
+				if (first and dfs(i + 1, j + 1)) then
+				begin
+					ans := True;
+				end;
+			end;
+		end else
+		begin
+			if (first and dfs(i + 1, j + 1)) then
+			begin
+				ans := True;
+			end;
+		end;
+		memo[key] := ans;
+		result := ans;
+		exit;
+	end;
+	result := dfs(0, 0);
+	exit;
+end;
+
+begin
+end.

--- a/examples/leetcode-out/pas/6/zigzag-conversion.pas
+++ b/examples/leetcode-out/pas/6/zigzag-conversion.pas
@@ -1,0 +1,53 @@
+program main;
+{$mode objfpc}
+uses SysUtils, fgl;
+
+type TIntArray = array of integer;
+
+function convert(s: string; numRows: integer): string;
+var
+	ch: integer;
+	curr: integer;
+	i: integer;
+	_result: string;
+	row: integer;
+	rows: TIntArray;
+	step: integer;
+begin
+	if ((numRows <= 1) or (numRows >= Length(s))) then
+	begin
+		result := s;
+		exit;
+	end;
+	rows := TIntArray([]);
+	i := 0;
+	while (i < numRows) do
+	begin
+		rows := Concat(rows, TIntArray(['']));
+		i := i + 1;
+	end;
+	curr := 0;
+	step := 1;
+	for ch in s do
+	begin
+		rows[curr] := rows[curr] + ch;
+		if (curr = 0) then
+		begin
+			step := 1;
+		end else if (curr = numRows - 1) then
+		begin
+			step := -1;
+		end;
+		curr := curr + step;
+	end;
+	_result := '';
+	for row in rows do
+	begin
+		_result := _result + row;
+	end;
+	result := _result;
+	exit;
+end;
+
+begin
+end.

--- a/examples/leetcode-out/pas/7/reverse-integer.pas
+++ b/examples/leetcode-out/pas/7/reverse-integer.pas
@@ -1,0 +1,39 @@
+program main;
+{$mode objfpc}
+uses SysUtils, fgl;
+
+type TIntArray = array of integer;
+
+function reverse(x: integer): integer;
+var
+	digit: integer;
+	n: integer;
+	rev: integer;
+	sign: integer;
+begin
+	sign := 1;
+	n := x;
+	if (n < 0) then
+	begin
+		sign := -1;
+		n := -n;
+	end;
+	rev := 0;
+	while (n <> 0) do
+	begin
+		digit := n mod 10;
+		rev := rev * 10 + digit;
+		n := n div 10;
+	end;
+	rev := rev * sign;
+	if ((rev < -2147483647 - 1) or (rev > 2147483647)) then
+	begin
+		result := 0;
+		exit;
+	end;
+	result := rev;
+	exit;
+end;
+
+begin
+end.

--- a/examples/leetcode-out/pas/8/string-to-integer-atoi.pas
+++ b/examples/leetcode-out/pas/8/string-to-integer-atoi.pas
@@ -1,0 +1,73 @@
+program main;
+{$mode objfpc}
+uses SysUtils, fgl;
+
+type TIntArray = array of integer;
+
+function myAtoi(s: string): integer;
+var
+	ch: integer;
+	d: integer;
+	digits: integer;
+	i: integer;
+	n: integer;
+	_result: integer;
+	sign: integer;
+begin
+	i := 0;
+	n := Length(s);
+	while ((i < n) and (s[i] = ' ')) do
+	begin
+		i := i + 1;
+	end;
+	sign := 1;
+	if ((i < n) and ((s[i] = '+') or (s[i] = '-'))) then
+	begin
+		if (s[i] = '-') then
+		begin
+			sign := -1;
+		end;
+		i := i + 1;
+	end;
+	var _tmp0: specialize TFPGMap<string, integer>;
+	_tmp0 := specialize TFPGMap<string, integer>.Create;
+	_tmp0.AddOrSetData('0', 0);
+	_tmp0.AddOrSetData('1', 1);
+	_tmp0.AddOrSetData('2', 2);
+	_tmp0.AddOrSetData('3', 3);
+	_tmp0.AddOrSetData('4', 4);
+	_tmp0.AddOrSetData('5', 5);
+	_tmp0.AddOrSetData('6', 6);
+	_tmp0.AddOrSetData('7', 7);
+	_tmp0.AddOrSetData('8', 8);
+	_tmp0.AddOrSetData('9', 9);
+	digits := _tmp0;
+	_result := 0;
+	while (i < n) do
+	begin
+		ch := s[i];
+		if not (ch in digits) then
+		begin
+			break;
+		end;
+		d := digits[ch];
+		_result := _result * 10 + d;
+		i := i + 1;
+	end;
+	_result := _result * sign;
+	if (_result > 2147483647) then
+	begin
+		result := 2147483647;
+		exit;
+	end;
+	if (_result < -2147483648) then
+	begin
+		result := -2147483648;
+		exit;
+	end;
+	result := _result;
+	exit;
+end;
+
+begin
+end.

--- a/examples/leetcode-out/pas/9/palindrome-number.pas
+++ b/examples/leetcode-out/pas/9/palindrome-number.pas
@@ -1,0 +1,33 @@
+program main;
+{$mode objfpc}
+uses SysUtils, fgl;
+
+type TIntArray = array of integer;
+
+function isPalindrome(x: integer): boolean;
+var
+	i: integer;
+	n: integer;
+	s: integer;
+begin
+	if (x < 0) then
+	begin
+		result := False;
+		exit;
+	end;
+	s := str(x);
+	n := Length(s);
+	for i := 0 to n div 2 - 1 do
+	begin
+		if (s[i] <> s[n - 1 - i]) then
+		begin
+			result := False;
+			exit;
+		end;
+	end;
+	result := True;
+	exit;
+end;
+
+begin
+end.

--- a/tests/compiler/pas/break_continue.pas.out
+++ b/tests/compiler/pas/break_continue.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 

--- a/tests/compiler/pas/for_loop.pas.out
+++ b/tests/compiler/pas/for_loop.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 

--- a/tests/compiler/pas/if_else.pas.out
+++ b/tests/compiler/pas/if_else.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 

--- a/tests/compiler/pas/reserved_keyword_var.pas.out
+++ b/tests/compiler/pas/reserved_keyword_var.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 

--- a/tests/compiler/pas/simple_fn.pas.out
+++ b/tests/compiler/pas/simple_fn.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 

--- a/tests/compiler/pas/two_sum.pas.out
+++ b/tests/compiler/pas/two_sum.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 

--- a/tests/compiler/pas/var_assignment.pas.out
+++ b/tests/compiler/pas/var_assignment.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 

--- a/tests/compiler/pas/while_loop.pas.out
+++ b/tests/compiler/pas/while_loop.pas.out
@@ -1,6 +1,6 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
 type TIntArray = array of integer;
 


### PR DESCRIPTION
## Summary
- extend Pascal compiler with basic map support
- update golden outputs for `fgl` import
- generate Pascal code for LeetCode problems 6-10

## Testing
- `go test ./compile/pas`
- `go run ./cmd/leetcode-runner build --from=6 --to=10 -l pas`

------
https://chatgpt.com/codex/tasks/task_e_6852f8824cb883209f5952976a55e413