### PR TITLE
Add Scala mutable list support for LeetCode 1-6

### DIFF
--- a/compile/scala/leetcode_test.go
+++ b/compile/scala/leetcode_test.go
@@ -117,6 +117,16 @@ func TestLeetCode5(t *testing.T) {
 	}
 }
 
+func TestLeetCode6(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "6"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
 func findRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/examples/leetcode-out/scala/1/two-sum.scala
+++ b/examples/leetcode-out/scala/1/two-sum.scala
@@ -1,18 +1,18 @@
 object Main {
-	def twoSum(nums: List[Int], target: Int): List[Int] = {
+	def twoSum(nums: scala.collection.mutable.ArrayBuffer[Int], target: Int): scala.collection.mutable.ArrayBuffer[Int] = {
 		val n = nums.length
 		for (i <- 0 until n) {
 			for (j <- (i + 1) until n) {
 				if (((nums(i) + nums(j)) == target)) {
-					return List(i, j)
+					return scala.collection.mutable.ArrayBuffer(i, j)
 				}
 			}
 		}
-		return List((-1), (-1))
+		return scala.collection.mutable.ArrayBuffer((-1), (-1))
 	}
 	
 	def main(args: Array[String]): Unit = {
-		val result = twoSum(List(2, 7, 11, 15), 9)
+		val result = twoSum(scala.collection.mutable.ArrayBuffer(2, 7, 11, 15), 9)
 		println(result(0))
 		println(result(1))
 	}

--- a/examples/leetcode-out/scala/2/add-two-numbers.scala
+++ b/examples/leetcode-out/scala/2/add-two-numbers.scala
@@ -1,9 +1,9 @@
 object Main {
-	def addTwoNumbers(l1: List[Int], l2: List[Int]): List[Int] = {
+	def addTwoNumbers(l1: scala.collection.mutable.ArrayBuffer[Int], l2: scala.collection.mutable.ArrayBuffer[Int]): scala.collection.mutable.ArrayBuffer[Int] = {
 		var i = 0
 		var j = 0
 		var carry = 0
-		var result: List[Int] = List()
+		var result: scala.collection.mutable.ArrayBuffer[Int] = scala.collection.mutable.ArrayBuffer()
 		while ((((i < l1.length) || (j < l2.length)) || (carry > 0))) {
 			var x = 0
 			if ((i < l1.length)) {
@@ -18,7 +18,7 @@ object Main {
 			val sum = ((x + y) + carry)
 			val digit = (sum % 10)
 			carry = (sum / 10)
-			result = (result ++ List(digit))
+			result = (result ++ scala.collection.mutable.ArrayBuffer(digit))
 		}
 		return result
 	}

--- a/examples/leetcode-out/scala/4/median-of-two-sorted-arrays.scala
+++ b/examples/leetcode-out/scala/4/median-of-two-sorted-arrays.scala
@@ -1,20 +1,20 @@
 object Main {
-	def findMedianSortedArrays(nums1: List[Int], nums2: List[Int]): Double = {
-		var merged: List[Int] = List()
+	def findMedianSortedArrays(nums1: scala.collection.mutable.ArrayBuffer[Int], nums2: scala.collection.mutable.ArrayBuffer[Int]): Double = {
+		var merged: scala.collection.mutable.ArrayBuffer[Int] = scala.collection.mutable.ArrayBuffer()
 		var i = 0
 		var j = 0
 		while (((i < nums1.length) || (j < nums2.length))) {
 			if ((j >= nums2.length)) {
-				merged = (merged ++ List(nums1(i)))
+				merged = (merged ++ scala.collection.mutable.ArrayBuffer(nums1(i)))
 				i = (i + 1)
 			} else 			if ((i >= nums1.length)) {
-				merged = (merged ++ List(nums2(j)))
+				merged = (merged ++ scala.collection.mutable.ArrayBuffer(nums2(j)))
 				j = (j + 1)
 			} else 			if ((nums1(i) <= nums2(j))) {
-				merged = (merged ++ List(nums1(i)))
+				merged = (merged ++ scala.collection.mutable.ArrayBuffer(nums1(i)))
 				i = (i + 1)
 			} else {
-				merged = (merged ++ List(nums2(j)))
+				merged = (merged ++ scala.collection.mutable.ArrayBuffer(nums2(j)))
 				j = (j + 1)
 			}
 		}

--- a/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
+++ b/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
@@ -31,13 +31,7 @@ object Main {
 				end = (i + ((l / 2)))
 			}
 		}
-		var res = ""
-		var k = start
-		while ((k <= end)) {
-			res = (res + s(k))
-			k = (k + 1)
-		}
-		return res
+		return s.slice(start, (end + 1))
 	}
 	
 	def main(args: Array[String]): Unit = {

--- a/examples/leetcode-out/scala/6/zigzag-conversion.scala
+++ b/examples/leetcode-out/scala/6/zigzag-conversion.scala
@@ -1,0 +1,32 @@
+object Main {
+	def convert(s: String, numRows: Int): String = {
+		if (((numRows <= 1) || (numRows >= s.length))) {
+			return s
+		}
+		var rows: scala.collection.mutable.ArrayBuffer[String] = scala.collection.mutable.ArrayBuffer()
+		var i = 0
+		while ((i < numRows)) {
+			rows = (rows ++ scala.collection.mutable.ArrayBuffer(""))
+			i = (i + 1)
+		}
+		var curr = 0
+		var step = 1
+		for (ch <- s) {
+			rows(curr) = (rows(curr) + ch)
+			if ((curr == 0)) {
+				step = 1
+			} else 			if ((curr == (numRows - 1))) {
+				step = (-1)
+			}
+			curr = (curr + step)
+		}
+		var result = ""
+		for (row <- rows) {
+			result = (result + row)
+		}
+		return result
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode/6/zigzag-conversion.mochi
+++ b/examples/leetcode/6/zigzag-conversion.mochi
@@ -3,7 +3,7 @@ fun convert(s: string, numRows: int): string {
     return s
   }
 
-  var rows = []
+  var rows: list<string> = []
   var i = 0
   while i < numRows {
     rows = rows + [""]


### PR DESCRIPTION
## Summary
- compile Scala lists as `ArrayBuffer` to enable mutation
- infer element types for empty list variables
- add leetcode problem 6 Scala test
- update zigzag conversion example with type annotation
- regenerate Scala outputs for LeetCode problems 1-6

## Testing
- `go test ./compile/scala -tags slow -run TestLeetCode -count=1`
- `go test ./... -tags slow -run TestLeetCode6 -count=1`
- `go run ./cmd/leetcode-runner build --id 6 --lang scala --run`


------
https://chatgpt.com/codex/tasks/task_e_6852fb29b9ac8320ba3762be21570898