### PR TITLE
Add Racket map features and compile LeetCode 1-10

### DIFF
--- a/compile/rkt/compiler_test.go
+++ b/compile/rkt/compiler_test.go
@@ -113,11 +113,9 @@ func TestRacketCompiler_LeetCodeExamples(t *testing.T) {
 	if err := rktcode.EnsureRacket(); err != nil {
 		t.Skipf("racket not installed: %v", err)
 	}
-	runRacketLeetExample(t, 1)
-	runRacketLeetExample(t, 2)
-	runRacketLeetExample(t, 3)
-	runRacketLeetExample(t, 4)
-	runRacketLeetExample(t, 5)
+	for i := 1; i <= 10; i++ {
+		runRacketLeetExample(t, i)
+	}
 }
 
 func runRacketLeetExample(t *testing.T, id int) {

--- a/examples/leetcode-out/rkt/1/two-sum.rkt
+++ b/examples/leetcode-out/rkt/1/two-sum.rkt
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define (twoSum nums target)

--- a/examples/leetcode-out/rkt/10/regular-expression-matching.rkt
+++ b/examples/leetcode-out/rkt/10/regular-expression-matching.rkt
@@ -1,0 +1,87 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
+
+(define (isMatch s p)
+	(let/ec return
+		(define m (length s))
+		(define n (length p))
+		(define memo (make-hash (list )))
+		(define (dfs i j)
+			(let/ec return
+				(define key (+ (* i ((+ n 1))) j))
+				(if (hash-has-key? memo key)
+					(begin
+						(return (idx memo key))
+					)
+					(void)
+				)
+				(if (= j n)
+					(begin
+						(return (= i m))
+					)
+					(void)
+				)
+				(define first false)
+				(if (< i m)
+					(begin
+						(if (or ((= (idx p j) (idx s i))) ((= (idx p j) ".")))
+							(begin
+								(set! first true)
+							)
+							(void)
+						)
+					)
+					(void)
+				)
+				(define ans false)
+				(if (< (+ j 1) n)
+					(begin
+						(if (= (idx p (+ j 1)) "*")
+							(begin
+								(if (dfs i (+ j 2))
+									(begin
+										(set! ans true)
+									)
+									(if (and first (dfs (+ i 1) j))
+										(begin
+											(set! ans true)
+										)
+										(void)
+									)
+								)
+							)
+							(begin
+								(if (and first (dfs (+ i 1) (+ j 1)))
+									(begin
+										(set! ans true)
+									)
+									(void)
+								)
+							)
+						)
+					)
+					(begin
+						(if (and first (dfs (+ i 1) (+ j 1)))
+							(begin
+								(set! ans true)
+							)
+							(void)
+						)
+					)
+				)
+				(set! memo (if (hash? memo) (hash-set memo key ans) (list-set memo key ans)))
+				(return ans)
+				(return (void))
+			)
+		)
+		(return (dfs 0 0))
+		(return (void))
+	)
+)
+

--- a/examples/leetcode-out/rkt/2/add-two-numbers.rkt
+++ b/examples/leetcode-out/rkt/2/add-two-numbers.rkt
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define (addTwoNumbers l1 l2)

--- a/examples/leetcode-out/rkt/3/longest-substring-without-repeating-characters.rkt
+++ b/examples/leetcode-out/rkt/3/longest-substring-without-repeating-characters.rkt
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define (lengthOfLongestSubstring s)

--- a/examples/leetcode-out/rkt/4/median-of-two-sorted-arrays.rkt
+++ b/examples/leetcode-out/rkt/4/median-of-two-sorted-arrays.rkt
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define (findMedianSortedArrays nums1 nums2)

--- a/examples/leetcode-out/rkt/5/longest-palindromic-substring.rkt
+++ b/examples/leetcode-out/rkt/5/longest-palindromic-substring.rkt
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define (expand s left right)
@@ -57,15 +60,7 @@
 					(void)
 				)
 			)
-			(define res "")
-			(define k start)
-			(let loop ()
-				(when (<= k end)
-					(set! res (+ res (idx s k)))
-					(set! k (+ k 1))
-					(loop))
-			)
-			(return res)
+			(return (slice s start (+ end 1)))
 			(return (void))
 		)
 	)

--- a/examples/leetcode-out/rkt/6/zigzag-conversion.rkt
+++ b/examples/leetcode-out/rkt/6/zigzag-conversion.rkt
@@ -1,0 +1,51 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
+
+(define (convert s numRows)
+	(let/ec return
+		(if (or (<= numRows 1) (>= numRows (length s)))
+			(begin
+				(return s)
+			)
+			(void)
+		)
+		(define rows (list ))
+		(define i 0)
+		(let loop ()
+			(when (< i numRows)
+				(set! rows (+ rows (list "")))
+				(set! i (+ i 1))
+				(loop))
+		)
+		(define curr 0)
+		(define step 1)
+		(for ([ch s])
+			(set! rows (if (hash? rows) (hash-set rows curr (+ (idx rows curr) ch)) (list-set rows curr (+ (idx rows curr) ch))))
+			(if (= curr 0)
+				(begin
+					(set! step 1)
+				)
+				(if (= curr (- numRows 1))
+					(begin
+						(set! step (- 1))
+					)
+					(void)
+				)
+			)
+			(set! curr (+ curr step))
+		)
+		(define result "")
+		(for ([row rows])
+			(set! result (+ result row))
+		)
+		(return result)
+		(return (void))
+	)
+)
+

--- a/examples/leetcode-out/rkt/7/reverse-integer.rkt
+++ b/examples/leetcode-out/rkt/7/reverse-integer.rkt
@@ -1,0 +1,40 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
+
+(define (reverse x)
+	(let/ec return
+		(define sign 1)
+		(define n x)
+		(if (< n 0)
+			(begin
+				(set! sign (- 1))
+				(set! n (- n))
+			)
+			(void)
+		)
+		(define rev 0)
+		(let loop ()
+			(when (not (= n 0))
+				(define digit (modulo n 10))
+				(set! rev (+ (* rev 10) digit))
+				(set! n (/ n 10))
+				(loop))
+		)
+		(set! rev (* rev sign))
+		(if (or (< rev ((- (- 2147483647) 1))) (> rev 2147483647))
+			(begin
+				(return 0)
+			)
+			(void)
+		)
+		(return rev)
+		(return (void))
+	)
+)
+

--- a/examples/leetcode-out/rkt/8/string-to-integer-atoi.rkt
+++ b/examples/leetcode-out/rkt/8/string-to-integer-atoi.rkt
@@ -1,0 +1,67 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
+
+(define (myAtoi s)
+	(let/ec return
+		(define i 0)
+		(define n (length s))
+		(let loop ()
+			(when (and (< i n) (= (idx s i) " "))
+				(set! i (+ i 1))
+				(loop))
+		)
+		(define sign 1)
+		(if (and (< i n) ((or (= (idx s i) "+") (= (idx s i) "-"))))
+			(begin
+				(if (= (idx s i) "-")
+					(begin
+						(set! sign (- 1))
+					)
+					(void)
+				)
+				(set! i (+ i 1))
+			)
+			(void)
+		)
+		(define digits (make-hash (list (cons "0" 0) (cons "1" 1) (cons "2" 2) (cons "3" 3) (cons "4" 4) (cons "5" 5) (cons "6" 6) (cons "7" 7) (cons "8" 8) (cons "9" 9))))
+		(define result 0)
+		(let/ec brk0
+			(let loop0 ()
+				(when (< i n)
+					(define ch (idx s i))
+					(if (not ((hash-has-key? digits ch)))
+						(begin
+							(brk0 (void))
+						)
+						(void)
+					)
+					(define d (idx digits ch))
+					(set! result (+ (* result 10) d))
+					(set! i (+ i 1))
+					(loop0))
+				)
+			)
+			(set! result (* result sign))
+			(if (> result 2147483647)
+				(begin
+					(return 2147483647)
+				)
+				(void)
+			)
+			(if (< result ((- 2147483648)))
+				(begin
+					(return (- 2147483648))
+				)
+				(void)
+			)
+			(return result)
+			(return (void))
+		)
+	)
+	

--- a/examples/leetcode-out/rkt/9/palindrome-number.rkt
+++ b/examples/leetcode-out/rkt/9/palindrome-number.rkt
@@ -1,0 +1,32 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
+(define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
+
+(define (isPalindrome x)
+	(let/ec return
+		(if (< x 0)
+			(begin
+				(return false)
+			)
+			(void)
+		)
+		(define s (format "~a" x))
+		(define n (length s))
+		(for ([i (in-range 0 (/ n 2))])
+			(if (not (= (idx s i) (idx s (- (- n 1) i))))
+				(begin
+					(return false)
+				)
+				(void)
+			)
+		)
+		(return true)
+		(return (void))
+	)
+)
+

--- a/tests/compiler/rkt/for_list_collection.rkt.out
+++ b/tests/compiler/rkt/for_list_collection.rkt.out
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (for ([n (list 1 2 3)])

--- a/tests/compiler/rkt/for_loop.rkt.out
+++ b/tests/compiler/rkt/for_loop.rkt.out
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (for ([i (in-range 1 4)])

--- a/tests/compiler/rkt/if_else.rkt.out
+++ b/tests/compiler/rkt/if_else.rkt.out
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define x 2)

--- a/tests/compiler/rkt/let_and_print.rkt.out
+++ b/tests/compiler/rkt/let_and_print.rkt.out
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define a 10)

--- a/tests/compiler/rkt/string_for_loop.rkt.out
+++ b/tests/compiler/rkt/string_for_loop.rkt.out
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (for ([ch "cat"])

--- a/tests/compiler/rkt/two_sum.rkt.out
+++ b/tests/compiler/rkt/two_sum.rkt.out
@@ -1,7 +1,10 @@
 #lang racket
 (require racket/list)
 
-(define (idx x i) (if (string? x) (string-ref x i) (list-ref x i)))
+(define (idx x i)
+  (cond [(string? x) (string-ref x i)]
+        [(hash? x) (hash-ref x i)]
+        [else (list-ref x i)]))
 (define (slice x s e) (if (string? x) (substring x s e) (take (drop x s) (- e s))))
 
 (define (twoSum nums target)


### PR DESCRIPTION
## Summary
- extend Racket backend with map support, indexing assignment, and nested functions
- handle `str()` calls and `in` operator
- update tests and golden files
- generate LeetCode examples 1-10 for Racket

## Testing
- `go test ./compile/rkt -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852f88f28708320bc56df8365c347bc