### PR TITLE
Add OCaml support for LeetCode #6 and handle string mutation

### DIFF
--- a/compile/ocaml/compiler_test.go
+++ b/compile/ocaml/compiler_test.go
@@ -119,7 +119,7 @@ func TestOCamlCompiler_GoldenOutput(t *testing.T) {
 }
 
 func TestOCamlCompiler_LeetCodeExamples(t *testing.T) {
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 6; i++ {
 		runExample(t, i)
 	}
 }

--- a/examples/leetcode-out/ocaml/5/longest-palindromic-substring.ml
+++ b/examples/leetcode-out/ocaml/5/longest-palindromic-substring.ml
@@ -34,12 +34,6 @@ let rec longestPalindrome s =
         _end := i + (!l / 2);
       end;
     done;
-    let res = ref "" in
-    let k = ref !start in
-    while !k <= !_end do
-      res := !res ^ (String.make 1 (String.get s !k));
-      k := !k + 1;
-    done;
-    raise (Return_1 (!res))
+    raise (Return_1 ((String.sub s !start (!_end + 1 - !start))))
   with Return_1 v -> v
 

--- a/examples/leetcode-out/ocaml/6/zigzag-conversion.ml
+++ b/examples/leetcode-out/ocaml/6/zigzag-conversion.ml
@@ -1,0 +1,34 @@
+exception Return_0 of string
+let rec convert s numRows =
+  try
+    if numRows <= 1 || numRows >= String.length s then begin
+      raise (Return_0 (s))
+    end;
+    let rows = ref [] in
+    let i = ref 0 in
+    while !i < numRows do
+      rows := !rows @ [""];
+      i := !i + 1;
+    done;
+    let curr = ref 0 in
+    let step = ref 1 in
+    String.iter (fun ch ->
+      let tmp_1 = Array.of_list !rows in
+      tmp_1.(!curr) <- (List.nth !rows !curr) ^ (String.make 1 ch);
+      rows := Array.to_list tmp_1;
+      if !curr = 0 then begin
+        step := 1;
+      end else begin
+        if !curr = numRows - 1 then begin
+          step := -1;
+        end;
+      end;
+      curr := !curr + !step;
+    ) s;
+    let result = ref "" in
+    List.iter (fun row ->
+      result := !result ^ row;
+    ) !rows;
+    raise (Return_0 (!result))
+  with Return_0 v -> v
+


### PR DESCRIPTION
## Summary
- improve OCaml backend: track char loop vars and allow list index assignment
- extend example tests to run problems 1..6
- regenerate OCaml outputs including new solution for LeetCode 6

## Testing
- `go test ./compile/ocaml -run TestOCamlCompiler_LeetCodeExamples -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6852fbfdf97c83208acc3abeaec4f410