### PR TITLE
Add Scala compilation for LeetCode 1-10

### DIFF
--- a/compile/scala/leetcode_test.go
+++ b/compile/scala/leetcode_test.go
@@ -117,6 +117,56 @@ func TestLeetCode5(t *testing.T) {
 	}
 }
 
+func TestLeetCode6(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "6"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode7(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "7"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode8(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "8"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode9(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "9"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode10(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "10"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
 func findRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/examples/leetcode-out/scala/10/regular-expression-matching.scala
+++ b/examples/leetcode-out/scala/10/regular-expression-matching.scala
@@ -1,0 +1,46 @@
+object Main {
+	def isMatch(s: String, p: String): Boolean = {
+		val m = s.length
+		val n = p.length
+		var memo: scala.collection.mutable.Map[Int, Boolean] = scala.collection.mutable.Map()
+		def dfs(i: Int, j: Int): Boolean = {
+			val key = ((i * ((n + 1))) + j)
+			if (memo.contains(key)) {
+				return memo(key)
+			}
+			if ((j == n)) {
+				return (i == m)
+			}
+			var first = false
+			if ((i < m)) {
+				if ((((p(j) == s(i))) || ((p(j) == ".")))) {
+					first = true
+				}
+			}
+			var ans = false
+			if (((j + 1) < n)) {
+				if ((p((j + 1)) == "*")) {
+					if (dfs(i, (j + 2))) {
+						ans = true
+					} else 					if ((first && dfs((i + 1), j))) {
+						ans = true
+					}
+				} else {
+					if ((first && dfs((i + 1), (j + 1)))) {
+						ans = true
+					}
+				}
+			} else {
+				if ((first && dfs((i + 1), (j + 1)))) {
+					ans = true
+				}
+			}
+			memo(key) = ans
+			return ans
+		}
+		return dfs(0, 0)
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
+++ b/examples/leetcode-out/scala/5/longest-palindromic-substring.scala
@@ -31,13 +31,7 @@ object Main {
 				end = (i + ((l / 2)))
 			}
 		}
-		var res = ""
-		var k = start
-		while ((k <= end)) {
-			res = (res + s(k))
-			k = (k + 1)
-		}
-		return res
+		return s.slice(start, (end + 1))
 	}
 	
 	def main(args: Array[String]): Unit = {

--- a/examples/leetcode-out/scala/6/zigzag-conversion.scala
+++ b/examples/leetcode-out/scala/6/zigzag-conversion.scala
@@ -1,0 +1,32 @@
+object Main {
+	def convert(s: String, numRows: Int): String = {
+		if (((numRows <= 1) || (numRows >= s.length))) {
+			return s
+		}
+		var rows: scala.collection.mutable.ArrayBuffer[String] = scala.collection.mutable.ArrayBuffer()
+		var i = 0
+		while ((i < numRows)) {
+			rows = (rows ++ List(""))
+			i = (i + 1)
+		}
+		var curr = 0
+		var step = 1
+		for (ch <- s) {
+			rows(curr) = (rows(curr) + ch)
+			if ((curr == 0)) {
+				step = 1
+			} else 			if ((curr == (numRows - 1))) {
+				step = (-1)
+			}
+			curr = (curr + step)
+		}
+		var result = ""
+		for (row <- rows) {
+			result = (result + row)
+		}
+		return result
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/7/reverse-integer.scala
+++ b/examples/leetcode-out/scala/7/reverse-integer.scala
@@ -1,0 +1,24 @@
+object Main {
+	def reverse(x: Int): Int = {
+		var sign = 1
+		var n = x
+		if ((n < 0)) {
+			sign = (-1)
+			n = (-n)
+		}
+		var rev = 0
+		while ((n != 0)) {
+			val digit = (n % 10)
+			rev = ((rev * 10) + digit)
+			n = (n / 10)
+		}
+		rev = (rev * sign)
+		if (((rev < (((-2147483647) - 1))) || (rev > 2147483647))) {
+			return 0
+		}
+		return rev
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/8/string-to-integer-atoi.scala
+++ b/examples/leetcode-out/scala/8/string-to-integer-atoi.scala
@@ -1,0 +1,37 @@
+object Main {
+	def myAtoi(s: String): Int = {
+		var i = 0
+		val n = s.length
+		while (((i < n) && (s(i) == " "))) {
+			i = (i + 1)
+		}
+		var sign = 1
+		if (((i < n) && (((s(i) == "+") || (s(i) == "-"))))) {
+			if ((s(i) == "-")) {
+				sign = (-1)
+			}
+			i = (i + 1)
+		}
+		val digits = scala.collection.mutable.Map('0' -> 0, '1' -> 1, '2' -> 2, '3' -> 3, '4' -> 4, '5' -> 5, '6' -> 6, '7' -> 7, '8' -> 8, '9' -> 9)
+		var result = 0
+		while ((i < n)) {
+			val ch = s(i)
+			if ((!(digits.contains(ch)))) {
+			}
+			val d = digits(ch)
+			result = ((result * 10) + d)
+			i = (i + 1)
+		}
+		result = (result * sign)
+		if ((result > 2147483647)) {
+			return 2147483647
+		}
+		if ((result < ((-2147483648)))) {
+			return (-2147483648)
+		}
+		return result
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}

--- a/examples/leetcode-out/scala/9/palindrome-number.scala
+++ b/examples/leetcode-out/scala/9/palindrome-number.scala
@@ -1,0 +1,18 @@
+object Main {
+	def isPalindrome(x: Int): Boolean = {
+		if ((x < 0)) {
+			return false
+		}
+		val s = x.toString()
+		val n = s.length
+		for (i <- 0 until (n / 2)) {
+			if ((s(i) != s(((n - 1) - i)))) {
+				return false
+			}
+		}
+		return true
+	}
+	
+	def main(args: Array[String]): Unit = {
+	}
+}


### PR DESCRIPTION
## Summary
- handle nested functions and infer list type in Scala backend
- fix map literal keys for char usage
- expand Scala LeetCode tests to problems 1-10
- regenerate Scala solutions for LeetCode problems 1-10

## Testing
- `go test ./compile/scala -tags=slow -run TestLeetCode -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852fb256fc88320b6351b95eefd21b6