### PR TITLE
Enable Smalltalk leetcode outputs

### DIFF
--- a/examples/leetcode-out/st/1/two-sum.st
+++ b/examples/leetcode-out/st/1/two-sum.st
@@ -13,7 +13,7 @@ twoSum: nums target: target | i j n |
 		.
 	]
 	.
-	^ Array with: -1 with: -1
+	^ Array with: (0 - 1) with: (0 - 1)
 !
 
 !!

--- a/examples/leetcode-out/st/2/add-two-numbers.st
+++ b/examples/leetcode-out/st/2/add-two-numbers.st
@@ -6,7 +6,7 @@ addTwoNumbers: l1 l2: l2 | carry digit i j result sum x y |
 	j := 0.
 	carry := 0.
 	result := Array new.
-	[(((((i < l1 size) | j) < l2 size) | carry) > 0)] whileTrue: [
+	[(((i < l1 size) | (j < l2 size)) | (carry > 0))] whileTrue: [
 		x := 0.
 		((i < l1 size)) ifTrue: [
 			x := (l1 at: i + 1).

--- a/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
+++ b/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
@@ -5,7 +5,7 @@ findMedianSortedArrays: nums1 nums2: nums2 | i j merged mid1 mid2 total |
 	merged := Array new.
 	i := 0.
 	j := 0.
-	[(((i < nums1 size) | j) < nums2 size)] whileTrue: [
+	[((i < nums1 size) | (j < nums2 size))] whileTrue: [
 		((j >= nums2 size)) ifTrue: [
 			merged := (merged , Array with: (nums1 at: i + 1)).
 			i := (i + 1).

--- a/examples/leetcode-out/st/5/longest-palindromic-substring.st
+++ b/examples/leetcode-out/st/5/longest-palindromic-substring.st
@@ -5,7 +5,7 @@ expand: s left: left right: right | l n r |
 	l := left.
 	r := right.
 	n := s size.
-	[(((l >= 0) & r) < n)] whileTrue: [
+	[((l >= 0) & (r < n))] whileTrue: [
 		(((s at: l + 1) ~= (s at: r + 1))) ifTrue: [
 		]
 		.
@@ -17,7 +17,7 @@ expand: s left: left right: right | l n r |
 !
 
 !Main class methodsFor: 'mochi'!
-longestPalindrome: s | end i k l len1 len2 n res start |
+longestPalindrome: s | end i l len1 len2 n start |
 	((s size <= 1)) ifTrue: [
 		^ s
 	]
@@ -40,14 +40,7 @@ longestPalindrome: s | end i k l len1 len2 n res start |
 		.
 	]
 	.
-	res := ''.
-	k := start.
-	[(k <= end)] whileTrue: [
-		res := (res + (s at: k + 1)).
-		k := (k + 1).
-	]
-	.
-	^ res
+	^ (s copyFrom: (start + 1) to: (end + 1))
 !
 
 !!

--- a/examples/leetcode-out/st/6/zigzag-conversion.st
+++ b/examples/leetcode-out/st/6/zigzag-conversion.st
@@ -1,0 +1,35 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+convert: s numRows: numRows | ch curr i result row rows step |
+	(((numRows <= 1) | (numRows >= s size))) ifTrue: [
+		^ s
+	]
+	.
+	rows := Array new.
+	i := 0.
+	[(i < numRows)] whileTrue: [
+		rows := (rows , Array with: '').
+		i := (i + 1).
+	]
+	.
+	curr := 0.
+	step := 1.
+	s do: [:ch |
+		rows at: curr + 1 put: ((rows at: curr + 1) + ch).
+		((curr = 0)) ifTrue: [
+			step := 1.
+		]
+		.
+		curr := (curr + step).
+	]
+	.
+	result := ''.
+	rows do: [:row |
+		result := (result + row).
+	]
+	.
+	^ result
+!
+
+!!

--- a/examples/leetcode-out/st/7/reverse-integer.st
+++ b/examples/leetcode-out/st/7/reverse-integer.st
@@ -1,0 +1,27 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+reverse: x | digit n rev sign |
+	sign := 1.
+	n := x.
+	((n < 0)) ifTrue: [
+		sign := (0 - 1).
+		n := (0 - n).
+	]
+	.
+	rev := 0.
+	[(n ~= 0)] whileTrue: [
+		digit := (n \ 10).
+		rev := ((rev * 10) + digit).
+		n := (n / 10).
+	]
+	.
+	rev := (rev * sign).
+	(((rev < (((0 - 2147483647) - 1))) | (rev > 2147483647))) ifTrue: [
+		^ 0
+	]
+	.
+	^ rev
+!
+
+!!

--- a/examples/leetcode-out/st/8/string-to-integer-atoi.st
+++ b/examples/leetcode-out/st/8/string-to-integer-atoi.st
@@ -1,0 +1,44 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+myAtoi: s | ch d digits i n result sign |
+	i := 0.
+	n := s size.
+	[((i < n) & ((s at: i + 1) = ' '))] whileTrue: [
+		i := (i + 1).
+	]
+	.
+	sign := 1.
+	(((i < n) & ((((s at: i + 1) = '+') | ((s at: i + 1) = '-'))))) ifTrue: [
+		(((s at: i + 1) = '-')) ifTrue: [
+			sign := (0 - 1).
+		]
+		.
+		i := (i + 1).
+	]
+	.
+	digits := Dictionary newFrom: { '0' -> 0 . '1' -> 1 . '2' -> 2 . '3' -> 3 . '4' -> 4 . '5' -> 5 . '6' -> 6 . '7' -> 7 . '8' -> 8 . '9' -> 9 }.
+	result := 0.
+	[(i < n)] whileTrue: [
+		ch := (s at: i + 1).
+		((((digits includes: ch))) not) ifTrue: [
+		]
+		.
+		d := (digits at: ch + 1).
+		result := ((result * 10) + d).
+		i := (i + 1).
+	]
+	.
+	result := (result * sign).
+	((result > 2147483647)) ifTrue: [
+		^ 2147483647
+	]
+	.
+	((result < ((0 - 2147483648)))) ifTrue: [
+		^ (0 - 2147483648)
+	]
+	.
+	^ result
+!
+
+!!


### PR DESCRIPTION
## Summary
- enhance the Smalltalk backend to support collection loops and map literals
- add membership and precedence handling for binary expressions
- handle unary negation and indexed assignment for lists
- regenerate leetcode problem outputs 1-8 for Smalltalk

## Testing
- `go test ./compile/st -run TestSTCompiler_LeetCodeExample1 -tags slow -count=1`
- `go run ./cmd/leetcode-runner build --from 1 --to 8 --lang st --run`

------
https://chatgpt.com/codex/tasks/task_e_6852fb5fb55c8320a01689964e04dd04