### PR TITLE
Expand F# support for LeetCode problems 1–8

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -79,7 +79,7 @@ The F# tests are tagged `slow` because they invoke the .NET toolchain. Run them 
 go test ./compile/fs -tags slow
 ```
 
-This command compiles the subset programs in `tests/compiler/fs` and also runs the example solutions for LeetCode problems 1–3 to ensure the generated F# code behaves correctly.
+This command compiles the subset programs in `tests/compiler/fs` and also runs the example solutions for LeetCode problems 1–8 to ensure the generated F# code behaves correctly.
 
 
 The tests compile Mochi sources from `tests/compiler/fs` and execute them with `dotnet fsi`:

--- a/compile/fs/compiler_test.go
+++ b/compile/fs/compiler_test.go
@@ -221,4 +221,7 @@ func TestFSCompiler_LeetCodeExamples(t *testing.T) {
 	runLeetExample(t, 3)
 	runLeetExample(t, 4)
 	runLeetExample(t, 5)
+	runLeetExample(t, 6)
+	runLeetExample(t, 7)
+	runLeetExample(t, 8)
 }

--- a/examples/leetcode-out/fs/6/zigzag-conversion.fsx
+++ b/examples/leetcode-out/fs/6/zigzag-conversion.fsx
@@ -1,0 +1,29 @@
+open System
+
+exception Return_convert of string
+let convert (s: string) (numRows: int) : string =
+    try
+        if ((numRows <= 1) || (numRows >= s.Length)) then
+            raise (Return_convert (s))
+        let mutable rows = [||]
+        let mutable i = 0
+        while (i < numRows) do
+            rows <- Array.append rows [|""|]
+            i <- (i + 1)
+        let mutable curr = 0
+        let mutable step = 1
+        for ch in s do
+            let ch = string ch
+            rows.[curr] <- (rows.[curr] + ch)
+            if (curr = 0) then
+                step <- 1
+            elif (curr = (numRows - 1)) then
+                step <- (-1)
+            curr <- (curr + step)
+        let mutable result = ""
+        for row in rows do
+            result <- (result + row)
+        raise (Return_convert (result))
+        failwith "unreachable"
+    with Return_convert v -> v
+

--- a/examples/leetcode-out/fs/7/reverse-integer.fsx
+++ b/examples/leetcode-out/fs/7/reverse-integer.fsx
@@ -1,0 +1,22 @@
+open System
+
+exception Return_reverse of int
+let reverse (x: int) : int =
+    try
+        let mutable sign = 1
+        let mutable n = x
+        if (n < 0) then
+            sign <- (-1)
+            n <- (-n)
+        let mutable rev = 0
+        while (n <> 0) do
+            let digit = (n % 10)
+            rev <- ((rev * 10) + digit)
+            n <- (n / 10)
+        rev <- (rev * sign)
+        if ((rev < (((-2147483647) - 1))) || (rev > 2147483647)) then
+            raise (Return_reverse (0))
+        raise (Return_reverse (rev))
+        failwith "unreachable"
+    with Return_reverse v -> v
+

--- a/examples/leetcode-out/fs/8/string-to-integer-atoi.fsx
+++ b/examples/leetcode-out/fs/8/string-to-integer-atoi.fsx
@@ -1,0 +1,38 @@
+open System
+exception BreakException of int
+exception ContinueException of int
+
+exception Return_myAtoi of int
+let myAtoi (s: string) : int =
+    try
+        let mutable i = 0
+        let n = s.Length
+        while ((i < n) && ((string s.[(if i < 0 then s.Length + i else i)]) = " ")) do
+            i <- (i + 1)
+        let mutable sign = 1
+        if ((i < n) && ((((string s.[(if i < 0 then s.Length + i else i)]) = "+") || ((string s.[(if i < 0 then s.Length + i else i)]) = "-")))) then
+            if ((string s.[(if i < 0 then s.Length + i else i)]) = "-") then
+                sign <- (-1)
+            i <- (i + 1)
+        let digits = Map.ofList [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6); ("7", 7); ("8", 8); ("9", 9)]
+        let mutable result = 0
+        try
+            while (i < n) do
+                try
+                    let ch = (string s.[(if i < 0 then s.Length + i else i)])
+                    if (not (Map.containsKey ch digits)) then
+                        raise (BreakException 0)
+                    let d = digits.[ch]
+                    result <- ((result * 10) + d)
+                    i <- (i + 1)
+                with ContinueException n when n = 0 -> ()
+        with BreakException n when n = 0 -> ()
+        result <- (result * sign)
+        if (result > 2147483647) then
+            raise (Return_myAtoi (2147483647))
+        if (result < ((-2147483648))) then
+            raise (Return_myAtoi ((-2147483648)))
+        raise (Return_myAtoi (result))
+        failwith "unreachable"
+    with Return_myAtoi v -> v
+


### PR DESCRIPTION
## Summary
- extend the F# compiler with map literal support and map/string helpers
- handle unary `!` and string iteration in the F# backend
- run LeetCode examples up to problem 8
- add generated F# solutions for problems 6–8

## Testing
- `go test ./compile/fs -tags slow -run TestFSCompiler_LeetCodeExamples -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852fbd7e0348320af1c9b338239b00b