### PR TITLE
Add Smalltalk leetcode support

### DIFF
--- a/examples/leetcode-out/st/1/two-sum.st
+++ b/examples/leetcode-out/st/1/two-sum.st
@@ -13,7 +13,7 @@ twoSum: nums target: target | i j n |
 		.
 	]
 	.
-	^ Array with: -1 with: -1
+	^ Array with: (1 negated) with: (1 negated)
 !
 
 !!

--- a/examples/leetcode-out/st/10/regular-expression-matching.st
+++ b/examples/leetcode-out/st/10/regular-expression-matching.st
@@ -1,0 +1,53 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+isMatch: s p: p | ans dfs first key m memo n |
+	m := s size.
+	n := p size.
+	memo := Dictionary new.
+	dfs := [:i :j | | ans first key dfs |
+		key := ((i * ((n + 1))) + j).
+		((memo includes: key)) ifTrue: [
+			^ (memo at: key + 1)
+		]
+		.
+		((j = n)) ifTrue: [
+			^ (i = m)
+		]
+		.
+		first := false.
+		((i < m)) ifTrue: [
+			(((((p at: j + 1) = (s at: i + 1))) | (((p at: j + 1) = '.')))) ifTrue: [
+				first := true.
+			]
+			.
+		]
+		.
+		ans := false.
+		(((j + 1) < n)) ifTrue: [
+			(((p at: (j + 1) + 1) = '*')) ifTrue: [
+				(Main dfs: (i) j: ((j + 2))) ifTrue: [
+					ans := true.
+				]
+				.
+			] ifFalse: [
+				((first & Main dfs: ((i + 1)) j: ((j + 1)))) ifTrue: [
+					ans := true.
+				]
+				.
+			]
+			.
+		] ifFalse: [
+			((first & Main dfs: ((i + 1)) j: ((j + 1)))) ifTrue: [
+				ans := true.
+			]
+			.
+		]
+		.
+		memo at: key + 1 put: ans.
+		^ ans
+	].
+	^ Main dfs: (0) j: (0)
+!
+
+!!

--- a/examples/leetcode-out/st/5/longest-palindromic-substring.st
+++ b/examples/leetcode-out/st/5/longest-palindromic-substring.st
@@ -17,7 +17,7 @@ expand: s left: left right: right | l n r |
 !
 
 !Main class methodsFor: 'mochi'!
-longestPalindrome: s | end i k l len1 len2 n res start |
+longestPalindrome: s | end i l len1 len2 n start |
 	((s size <= 1)) ifTrue: [
 		^ s
 	]
@@ -40,14 +40,7 @@ longestPalindrome: s | end i k l len1 len2 n res start |
 		.
 	]
 	.
-	res := ''.
-	k := start.
-	[(k <= end)] whileTrue: [
-		res := (res + (s at: k + 1)).
-		k := (k + 1).
-	]
-	.
-	^ res
+	^ (s copyFrom: (start + 1) to: (end + 1))
 !
 
 !!

--- a/examples/leetcode-out/st/6/zigzag-conversion.st
+++ b/examples/leetcode-out/st/6/zigzag-conversion.st
@@ -1,0 +1,35 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+convert: s numRows: numRows | ch curr i result row rows step |
+	((((numRows <= 1) | numRows) >= s size)) ifTrue: [
+		^ s
+	]
+	.
+	rows := Array new.
+	i := 0.
+	[(i < numRows)] whileTrue: [
+		rows := (rows , Array with: '').
+		i := (i + 1).
+	]
+	.
+	curr := 0.
+	step := 1.
+	s do: [:ch |
+		rows at: curr + 1 put: ((rows at: curr + 1) + ch).
+		((curr = 0)) ifTrue: [
+			step := 1.
+		]
+		.
+		curr := (curr + step).
+	]
+	.
+	result := ''.
+	rows do: [:row |
+		result := (result + row).
+	]
+	.
+	^ result
+!
+
+!!

--- a/examples/leetcode-out/st/7/reverse-integer.st
+++ b/examples/leetcode-out/st/7/reverse-integer.st
@@ -1,0 +1,27 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+reverse: x | digit n rev sign |
+	sign := 1.
+	n := x.
+	((n < 0)) ifTrue: [
+		sign := (1 negated).
+		n := (n negated).
+	]
+	.
+	rev := 0.
+	[(n ~= 0)] whileTrue: [
+		digit := (n \ 10).
+		rev := ((rev * 10) + digit).
+		n := (n / 10).
+	]
+	.
+	rev := (rev * sign).
+	((((rev < (((2147483647 negated) - 1))) | rev) > 2147483647)) ifTrue: [
+		^ 0
+	]
+	.
+	^ rev
+!
+
+!!

--- a/examples/leetcode-out/st/8/string-to-integer-atoi.st
+++ b/examples/leetcode-out/st/8/string-to-integer-atoi.st
@@ -1,0 +1,44 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+myAtoi: s | ch d digits i n result sign |
+	i := 0.
+	n := s size.
+	[(((i < n) & (s at: i + 1)) = ' ')] whileTrue: [
+		i := (i + 1).
+	]
+	.
+	sign := 1.
+	(((i < n) & (((((s at: i + 1) = '+') | (s at: i + 1)) = '-')))) ifTrue: [
+		(((s at: i + 1) = '-')) ifTrue: [
+			sign := (1 negated).
+		]
+		.
+		i := (i + 1).
+	]
+	.
+	digits := Dictionary from: {'0' -> 0. '1' -> 1. '2' -> 2. '3' -> 3. '4' -> 4. '5' -> 5. '6' -> 6. '7' -> 7. '8' -> 8. '9' -> 9}.
+	result := 0.
+	[(i < n)] whileTrue: [
+		ch := (s at: i + 1).
+		((((digits includes: ch))) not) ifTrue: [
+		]
+		.
+		d := (digits at: ch + 1).
+		result := ((result * 10) + d).
+		i := (i + 1).
+	]
+	.
+	result := (result * sign).
+	((result > 2147483647)) ifTrue: [
+		^ 2147483647
+	]
+	.
+	((result < ((2147483648 negated)))) ifTrue: [
+		^ (2147483648 negated)
+	]
+	.
+	^ result
+!
+
+!!

--- a/examples/leetcode-out/st/9/palindrome-number.st
+++ b/examples/leetcode-out/st/9/palindrome-number.st
@@ -1,0 +1,21 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'mochi'!
+isPalindrome: x | i n s |
+	((x < 0)) ifTrue: [
+		^ false
+	]
+	.
+	s := (x printString).
+	n := s size.
+	0 to: (n / 2) - 1 do: [:i |
+		(((s at: i + 1) ~= (s at: ((n - 1) - i) + 1))) ifTrue: [
+			^ false
+		]
+		.
+	]
+	.
+	^ true
+!
+
+!!


### PR DESCRIPTION
## Summary
- support collection loops and nested functions in Smalltalk backend
- handle maps, membership checks and unary minus
- implement `str()` builtin, indexing and map literals
- generate Smalltalk solutions for LeetCode problems 1-10

## Testing
- `go run cmd/leetcode-runner/main.go build --from 1 --to 10 --lang st --run`

------
https://chatgpt.com/codex/tasks/task_e_6852fb58bc2c8320b1b123df99c70552