### PR TITLE
Add F# nested function support and run LeetCode 1-10

### DIFF
--- a/compile/fs/compiler_test.go
+++ b/compile/fs/compiler_test.go
@@ -224,4 +224,6 @@ func TestFSCompiler_LeetCodeExamples(t *testing.T) {
 	runLeetExample(t, 6)
 	runLeetExample(t, 7)
 	runLeetExample(t, 8)
+	runLeetExample(t, 9)
+	runLeetExample(t, 10)
 }

--- a/examples/leetcode-out/fs/10/regular-expression-matching.fsx
+++ b/examples/leetcode-out/fs/10/regular-expression-matching.fsx
@@ -1,0 +1,42 @@
+open System
+
+exception Return_dfs of bool
+
+exception Return_isMatch of bool
+let isMatch (s: string) (p: string) : bool =
+    try
+        let m = s.Length
+        let n = p.Length
+        let mutable memo = Map.ofList []
+        let rec dfs (i: int) (j: int) : bool =
+            try
+                let key = ((i * ((n + 1))) + j)
+                if Map.containsKey key memo then
+                    raise (Return_dfs (memo.[key]))
+                if (j = n) then
+                    raise (Return_dfs ((i = m)))
+                let mutable first = false
+                if (i < m) then
+                    if ((((string p.[(if j < 0 then p.Length + j else j)]) = (string s.[(if i < 0 then s.Length + i else i)]))) || (((string p.[(if j < 0 then p.Length + j else j)]) = "."))) then
+                        first <- true
+                let mutable ans = false
+                if ((j + 1) < n) then
+                    if ((string p.[(if (j + 1) < 0 then p.Length + (j + 1) else (j + 1))]) = "*") then
+                        if dfs i (j + 2) then
+                            ans <- true
+                        elif (first && dfs (i + 1) j) then
+                            ans <- true
+                    else
+                        if (first && dfs (i + 1) (j + 1)) then
+                            ans <- true
+                else
+                    if (first && dfs (i + 1) (j + 1)) then
+                        ans <- true
+                memo <- Map.add key ans memo
+                raise (Return_dfs (ans))
+                failwith "unreachable"
+            with Return_dfs v -> v
+        raise (Return_isMatch (dfs 0 0))
+        failwith "unreachable"
+    with Return_isMatch v -> v
+

--- a/examples/leetcode-out/fs/9/palindrome-number.fsx
+++ b/examples/leetcode-out/fs/9/palindrome-number.fsx
@@ -1,0 +1,16 @@
+open System
+
+exception Return_isPalindrome of bool
+let isPalindrome (x: int) : bool =
+    try
+        if (x < 0) then
+            raise (Return_isPalindrome (false))
+        let s = (string x)
+        let n = s.Length
+        for i = 0 to (n / 2) - 1 do
+            if (s.[i] <> s.[((n - 1) - i)]) then
+                raise (Return_isPalindrome (false))
+        raise (Return_isPalindrome (true))
+        failwith "unreachable"
+    with Return_isPalindrome v -> v
+


### PR DESCRIPTION
## Summary
- handle nested functions in the F# compiler
- keep outer locals when descending into nested functions
- generate immutable map updates with `Map.add`
- add LeetCode problems 9–10 to the F# test suite
- generate F# outputs for LeetCode 9 and 10

## Testing
- `go test ./compile/fs -tags slow -run TestFSCompiler_LeetCodeExamples -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68530cb8e3c88320a3e6a9ad4908dc79