### PR TITLE
Expand Fortran backend for LeetCode 1‑5

### DIFF
--- a/examples/leetcode-out/fortran/3/longest-substring-without-repeating-characters.f90
+++ b/examples/leetcode-out/fortran/3/longest-substring-without-repeating-characters.f90
@@ -1,0 +1,73 @@
+program main
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_example_3()
+  call test_empty_string()
+contains
+  function lengthOfLongestSubstring(s) result(res)
+    implicit none
+    integer :: res
+    character(len=*), intent(in) :: s
+    integer :: j
+    integer :: length
+    integer :: n
+    integer :: start
+    integer :: best
+    integer :: i
+    n = len(s)
+    start = 0
+    best = 0
+    i = 0
+    do while ((i < n))
+      j = start
+      do while ((j < i))
+        if ((s(j + 1:j + 1) == s(i + 1:i + 1))) then
+          start = (j + 1)
+          exit
+        end if
+        j = (j + 1)
+      end do
+      length = ((i - start) + 1)
+      if ((length > best)) then
+        best = length
+      end if
+      i = (i + 1)
+    end do
+    res = best
+    return
+  end function lengthOfLongestSubstring
+  
+  subroutine test_example_1()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('abcabcbb') == 3)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
+  
+  subroutine test_example_2()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('bbbbb') == 1)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
+  
+  subroutine test_example_3()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('pwwkew') == 3)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_3
+  
+  subroutine test_empty_string()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('') == 0)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_empty_string
+  
+end program main

--- a/examples/leetcode-out/fortran/4/median-of-two-sorted-arrays.f90
+++ b/examples/leetcode-out/fortran/4/median-of-two-sorted-arrays.f90
@@ -1,0 +1,80 @@
+program main
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_empty_first()
+  call test_empty_second()
+contains
+  function findMedianSortedArrays(nums1, nums2) result(res)
+    implicit none
+    real :: res
+    integer, intent(in) :: nums1(:)
+    integer, intent(in) :: nums2(:)
+    integer, allocatable :: merged(:)
+    integer :: total
+    integer :: mid1
+    integer :: mid2
+    integer :: i
+    integer :: j
+    allocate(merged(0))
+    i = 0
+    j = 0
+    do while (((i < size(nums1)) .or. (j < size(nums2))))
+      if ((j >= size(nums2))) then
+        merged = (/ merged, (/nums1(i + 1)/) /)
+        i = (i + 1)
+      else if ((i >= size(nums1))) then
+        merged = (/ merged, (/nums2(j + 1)/) /)
+        j = (j + 1)
+      else if ((nums1(i + 1) <= nums2(j + 1))) then
+        merged = (/ merged, (/nums1(i + 1)/) /)
+        i = (i + 1)
+      else
+        merged = (/ merged, (/nums2(j + 1)/) /)
+        j = (j + 1)
+      end if
+    end do
+    total = size(merged)
+    if ((mod(total, 2) == 1)) then
+      res = real(merged((total / 2) + 1))
+      return
+    end if
+    mid1 = merged(((total / 2) - 1) + 1)
+    mid2 = merged((total / 2) + 1)
+    res = (real(((mid1 + mid2))) / 2)
+    return
+  end function findMedianSortedArrays
+  
+  subroutine test_example_1()
+    implicit none
+    if (.not. (findMedianSortedArrays((/1, 3/), (/2/)) == 2)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
+  
+  subroutine test_example_2()
+    implicit none
+    if (.not. (findMedianSortedArrays((/1, 2/), (/3, 4/)) == 2.5)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
+  
+  subroutine test_empty_first()
+    implicit none
+    if (.not. (findMedianSortedArrays(reshape([0], [0]), (/1/)) == 1)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_empty_first
+  
+  subroutine test_empty_second()
+    implicit none
+    if (.not. (findMedianSortedArrays((/2/), reshape([0], [0])) == 2)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_empty_second
+  
+end program main

--- a/examples/leetcode-out/fortran/5/longest-palindromic-substring.f90
+++ b/examples/leetcode-out/fortran/5/longest-palindromic-substring.f90
@@ -1,0 +1,101 @@
+program main
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_single_char()
+  call test_two_chars()
+contains
+  function expand(s, left, right) result(res)
+    implicit none
+    integer :: res
+    character(len=*), intent(in) :: s
+    integer, intent(in) :: left
+    integer, intent(in) :: right
+    integer :: l
+    integer :: r
+    integer :: n
+    l = left
+    r = right
+    n = len(s)
+    do while (((l >= 0) .and. (r < n)))
+      if ((s(l + 1:l + 1) /= s(r + 1:r + 1))) then
+        exit
+      end if
+      l = (l - 1)
+      r = (r + 1)
+    end do
+    res = ((r - l) - 1)
+    return
+  end function expand
+  
+  function longestPalindrome(s) result(res)
+    implicit none
+    character(:), allocatable :: res
+    character(len=*), intent(in) :: s
+    integer :: len2
+    integer :: l
+    integer :: i
+    integer :: start
+    integer :: end
+    integer :: n
+    integer :: len1
+    if ((len(s) <= 1)) then
+      res = s
+      return
+    end if
+    start = 0
+    end = 0
+    n = len(s)
+    do i = 0, n - 1
+      len1 = expand(s, i, i)
+      len2 = expand(s, i, (i + 1))
+      l = len1
+      if ((len2 > len1)) then
+        l = len2
+      end if
+      if ((l > ((end - start)))) then
+        start = (i - ((((l - 1)) / 2)))
+        end = (i + ((l / 2)))
+      end if
+    end do
+    res = s(start + 1:(end + 1))
+    return
+  end function longestPalindrome
+  
+  subroutine test_example_1()
+    implicit none
+    character(:), allocatable :: ans
+    ans = longestPalindrome('babad')
+    if (.not. (((ans == 'bab') .or. (ans == 'aba')))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
+  
+  subroutine test_example_2()
+    implicit none
+    if (.not. (longestPalindrome('cbbd') == 'bb')) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
+  
+  subroutine test_single_char()
+    implicit none
+    if (.not. (longestPalindrome('a') == 'a')) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_single_char
+  
+  subroutine test_two_chars()
+    implicit none
+    character(:), allocatable :: ans
+    ans = longestPalindrome('ac')
+    if (.not. (((ans == 'a') .or. (ans == 'c')))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_two_chars
+  
+end program main


### PR DESCRIPTION
## Summary
- improve Fortran compiler to handle additional features
- declare variables in test blocks
- handle list and string result types
- allow empty list literals
- generate Fortran code for LeetCode problems 1‑5

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 5 --lang fortran --run`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685310e892f48320976c5b654d248d40