### PR TITLE
Add continue support in Clojure backend

### DIFF
--- a/tests/compiler/clj/break_continue.clj.out
+++ b/tests/compiler/clj/break_continue.clj.out
@@ -1,0 +1,22 @@
+(def numbers [1 2 3 4 5 6 7 8 9])
+(loop [_tmp0 (seq numbers)]
+  (when _tmp0
+    (let [n (first _tmp0)]
+      (try
+        (when (= (mod n 2) 0)
+          (throw (ex-info "continue" {}))
+        )
+        (when (> n 7)
+          (throw (ex-info "break" {}))
+        )
+        (println "odd number:" n)
+        (recur (next _tmp0))
+      (catch clojure.lang.ExceptionInfo e
+        (cond
+          (= (.getMessage e) "continue") (recur (next _tmp0))
+          (= (.getMessage e) "break") nil
+          :else (throw e))
+        )
+      )
+    )
+  )

--- a/tests/compiler/clj/break_continue.mochi
+++ b/tests/compiler/clj/break_continue.mochi
@@ -1,0 +1,11 @@
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+for n in numbers {
+  if n % 2 == 0 {
+    continue
+  }
+  if n > 7 {
+    break
+  }
+  print("odd number:", n)
+}

--- a/tests/compiler/clj/break_continue.out
+++ b/tests/compiler/clj/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7

--- a/tests/compiler/clj/for_loop.clj.out
+++ b/tests/compiler/clj/for_loop.clj.out
@@ -1,5 +1,13 @@
 (loop [i 1]
   (when (< i 4)
-    (println i)
-    (recur (inc i)))
-)
+    (try
+      (println i)
+      (recur (inc i))
+    (catch clojure.lang.ExceptionInfo e
+      (cond
+        (= (.getMessage e) "continue") (recur (inc i))
+        (= (.getMessage e) "break") nil
+        :else (throw e))
+      )
+    )
+  )

--- a/tests/compiler/clj/mod_operator.clj.out
+++ b/tests/compiler/clj/mod_operator.clj.out
@@ -1,7 +1,15 @@
 (loop [i 1]
   (when (< i 5)
-    (when (= (mod i 2) 0)
-      (println i)
+    (try
+      (when (= (mod i 2) 0)
+        (println i)
+      )
+      (recur (inc i))
+    (catch clojure.lang.ExceptionInfo e
+      (cond
+        (= (.getMessage e) "continue") (recur (inc i))
+        (= (.getMessage e) "break") nil
+        :else (throw e))
+      )
     )
-    (recur (inc i)))
-)
+  )

--- a/tests/compiler/clj/string_for_loop.clj.out
+++ b/tests/compiler/clj/string_for_loop.clj.out
@@ -1,3 +1,15 @@
-(doseq [ch "cat"]
-  (println ch)
-)
+(loop [_tmp0 (seq "cat")]
+  (when _tmp0
+    (let [ch (first _tmp0)]
+      (try
+        (println ch)
+        (recur (next _tmp0))
+      (catch clojure.lang.ExceptionInfo e
+        (cond
+          (= (.getMessage e) "continue") (recur (next _tmp0))
+          (= (.getMessage e) "break") nil
+          :else (throw e))
+        )
+      )
+    )
+  )

--- a/tests/compiler/clj/while_loop.clj.out
+++ b/tests/compiler/clj/while_loop.clj.out
@@ -1,13 +1,16 @@
 (def i 0)
-(try
-  (loop []
-    (when (< i 3)
+(loop []
+  (when (< i 3)
+    (try
       (println i)
       (def i (+ i 1))
       (recur)
+    (catch clojure.lang.ExceptionInfo e
+      (cond
+        (= (.getMessage e) "continue") (recur)
+        (= (.getMessage e) "break") nil
+        :else (throw e))
+      )
     )
   )
-(catch clojure.lang.ExceptionInfo e
-  (when-not (= (.getMessage e) "break") (throw e))
-)
 )


### PR DESCRIPTION
## Summary
- extend Clojure compiler with `continue` handling
- generate temporary variables for loops
- update `for` and `while` compilation logic
- add golden test for `break_continue` and update existing Clojure golden files

## Testing
- `go test ./compile/clj -tags slow -run TestClojureCompiler_GoldenOutput`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68535f0a01648320bcb297459eda670d