### PR TITLE
Add Kotlin cross join support

### DIFF
--- a/tests/compiler/kt/cross_join.kt.out
+++ b/tests/compiler/kt/cross_join.kt.out
@@ -1,0 +1,22 @@
+data class Customer(val id: Int, val name: String)
+data class Order(val id: Int, val customerId: Int, val total: Int)
+data class PairInfo(val orderId: Int, val orderCustomerId: Int, val pairedCustomerName: String, val orderTotal: Int)
+
+fun main() {
+        val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+        val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
+        val result = run {
+                val _src = orders
+                val _res = mutableListOf<PairInfo>()
+                for (o in _src) {
+                        for (c in customers) {
+                                _res.add(PairInfo(orderId = o.id, orderCustomerId = o.customerId, pairedCustomerName = c.name, orderTotal = o.total))
+                        }
+                }
+                _res
+        }
+        println("--- Cross Join: All order-customer pairs ---")
+        for (entry in result) {
+                println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
+        }
+}

--- a/tests/compiler/kt/cross_join.mochi
+++ b/tests/compiler/kt/cross_join.mochi
@@ -1,0 +1,44 @@
+// cross_join.mochi
+type Customer {
+  id: int
+  name: string
+}
+
+type Order {
+  id: int
+  customerId: int
+  total: int
+}
+
+type PairInfo {
+  orderId: int
+  orderCustomerId: int
+  pairedCustomerName: string
+  orderTotal: int
+}
+
+let customers = [
+  Customer { id: 1, name: "Alice" },
+  Customer { id: 2, name: "Bob" },
+  Customer { id: 3, name: "Charlie" }
+]
+let orders = [
+  Order { id: 100, customerId: 1, total: 250 },
+  Order { id: 101, customerId: 2, total: 125 },
+  Order { id: 102, customerId: 1, total: 300 }
+]
+let result = from o in orders
+             from c in customers
+             select PairInfo {
+               orderId: o.id,
+               orderCustomerId: o.customerId,
+               pairedCustomerName: c.name,
+               orderTotal: o.total
+             }
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result {
+  print("Order", entry.orderId,
+        "(customerId:", entry.orderCustomerId,
+        ", total: $", entry.orderTotal,
+        ") paired with", entry.pairedCustomerName)
+}

--- a/tests/compiler/kt/cross_join.out
+++ b/tests/compiler/kt/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/tests/compiler/kt/cross_join_triple.kt.out
+++ b/tests/compiler/kt/cross_join_triple.kt.out
@@ -1,0 +1,21 @@
+fun main() {
+        val nums = listOf(1, 2)
+        val letters = listOf("A", "B")
+        val bools = listOf(true, false)
+        val combos = run {
+                val _src = nums
+                val _res = mutableListOf<Map<String, Any>>()
+                for (n in _src) {
+                        for (l in letters) {
+                                for (b in bools) {
+                                        _res.add(mapOf("n" to n, "l" to l, "b" to b))
+                                }
+                        }
+                }
+                _res
+        }
+        println("--- Cross Join of three lists ---")
+        for (c in combos) {
+                println(c["n"], c["l"], c["b"])
+        }
+}

--- a/tests/compiler/kt/cross_join_triple.mochi
+++ b/tests/compiler/kt/cross_join_triple.mochi
@@ -1,0 +1,11 @@
+let nums = [1, 2]
+let letters = ["A", "B"]
+let bools = [true, false]
+let combos = from n in nums
+             from l in letters
+             from b in bools
+             select {n: n, l: l, b: b}
+print("--- Cross Join of three lists ---")
+for c in combos {
+  print(c.n, c.l, c.b)
+}

--- a/tests/compiler/kt/cross_join_triple.out
+++ b/tests/compiler/kt/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false


### PR DESCRIPTION
## Summary
- support simple cross joins in the Kotlin backend
- add Kotlin golden tests for cross joins

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68535f8945ec83208a32d5a2016fa674