### PR TITLE
Fix scheme list loop output

### DIFF
--- a/compile/scheme/compiler_test.go
+++ b/compile/scheme/compiler_test.go
@@ -85,6 +85,21 @@ func TestSchemeCompiler_LeetCode5(t *testing.T) {
 	runLeetExample(t, 5)
 }
 
+// TestSchemeCompiler_LeetCode6 compiles the zigzag-conversion example and runs it.
+func TestSchemeCompiler_LeetCode6(t *testing.T) {
+	runLeetExample(t, 6)
+}
+
+// TestSchemeCompiler_LeetCode7 compiles the reverse-integer example and runs it.
+func TestSchemeCompiler_LeetCode7(t *testing.T) {
+	runLeetExample(t, 7)
+}
+
+// TestSchemeCompiler_LeetCode8 compiles the string-to-integer example and runs it.
+func TestSchemeCompiler_LeetCode8(t *testing.T) {
+	runLeetExample(t, 8)
+}
+
 func TestSchemeCompiler_SubsetPrograms(t *testing.T) {
 	if _, err := schemecode.EnsureScheme(); err != nil {
 		t.Skipf("chibi-scheme not installed: %v", err)


### PR DESCRIPTION
## Summary
- fix extra paren in scheme compiler's for-loop list iteration

## Testing
- `go test ./compile/scheme -tags slow -run TestSchemeCompiler_LeetCode6 -count=1`
- `go test ./compile/scheme -tags slow -run TestSchemeCompiler_LeetCode8 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6852fc5ce0c48320b13e1ca13ca1fed9