### PR TITLE
Add type inference helpers for F# backend

### DIFF
--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -981,70 +981,32 @@ func (c *Compiler) isListExpr(e *parser.Expr) bool {
 	if e == nil {
 		return false
 	}
-	return c.isListBinary(e.Binary)
-}
-
-func (c *Compiler) isListBinary(b *parser.BinaryExpr) bool {
-	if b == nil {
-		return false
-	}
-	if len(b.Right) == 0 {
-		return c.isListUnary(b.Left)
-	}
-	// only handle simple a + b case
-	if len(b.Right) == 1 && b.Right[0].Op == "+" {
-		return c.isListUnary(b.Left) && c.isListPostfix(b.Right[0].Right)
-	}
-	return false
+	_, ok := c.inferExprType(e).(types.ListType)
+	return ok
 }
 
 func (c *Compiler) isListUnary(u *parser.Unary) bool {
 	if u == nil {
 		return false
 	}
-	return c.isListPostfix(u.Value)
+	_, ok := c.inferUnaryType(u).(types.ListType)
+	return ok
 }
 
 func (c *Compiler) isListPostfix(p *parser.PostfixExpr) bool {
 	if p == nil {
 		return false
 	}
-	res := c.isListPrimary(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil || op.Call != nil {
-			res = false
-		}
-		if op.Cast != nil {
-			typ := op.Cast.Type
-			if typ.Generic != nil && typ.Generic.Name == "list" && len(typ.Generic.Args) == 1 {
-				res = true
-			} else {
-				res = false
-			}
-		}
-	}
-	return res
+	_, ok := c.inferPostfixType(p).(types.ListType)
+	return ok
 }
 
 func (c *Compiler) isListPrimary(p *parser.Primary) bool {
-	switch {
-	case p == nil:
-		return false
-	case p.List != nil:
-		return true
-	case p.Group != nil:
-		return c.isListExpr(p.Group)
-	case p.Selector != nil && len(p.Selector.Tail) == 0:
-		typ, err := c.env.GetVar(p.Selector.Root)
-		if err == nil {
-			if _, ok := typ.(types.ListType); ok {
-				return true
-			}
-		}
-		return false
-	default:
+	if p == nil {
 		return false
 	}
+	_, ok := c.inferPrimaryType(p).(types.ListType)
+	return ok
 }
 
 func isUnderscoreExpr(e *parser.Expr) bool {
@@ -1099,159 +1061,64 @@ func (c *Compiler) isStringExpr(e *parser.Expr) bool {
 	if e == nil {
 		return false
 	}
-	return c.isStringBinary(e.Binary)
-}
-
-func (c *Compiler) isStringBinary(b *parser.BinaryExpr) bool {
-	if b == nil {
-		return false
-	}
-	if len(b.Right) == 0 {
-		return c.isStringUnary(b.Left)
-	}
-	if len(b.Right) == 1 && b.Right[0].Op == "+" {
-		return c.isStringUnary(b.Left) && c.isStringPostfix(b.Right[0].Right)
-	}
-	return false
+	_, ok := c.inferExprType(e).(types.StringType)
+	return ok
 }
 
 func (c *Compiler) isStringUnary(u *parser.Unary) bool {
 	if u == nil {
 		return false
 	}
-	return c.isStringPostfix(u.Value)
+	_, ok := c.inferUnaryType(u).(types.StringType)
+	return ok
 }
 
 func (c *Compiler) isStringPostfix(p *parser.PostfixExpr) bool {
 	if p == nil {
 		return false
 	}
-	res := c.isStringPrimary(p.Target)
-	for _, op := range p.Ops {
-		if op.Call != nil {
-			res = false
-		} else if op.Index != nil {
-			if op.Index.Colon != nil {
-				// slicing preserves string-ness
-				res = res
-			} else {
-				// indexing a string yields a string
-				if res {
-					res = true
-				} else {
-					res = false
-				}
-			}
-		}
-		if op.Cast != nil {
-			typ := op.Cast.Type
-			if typ.Simple != nil && *typ.Simple == "string" {
-				res = true
-			} else {
-				res = false
-			}
-		}
-	}
-	return res
+	_, ok := c.inferPostfixType(p).(types.StringType)
+	return ok
 }
 
 func (c *Compiler) isStringPrimary(p *parser.Primary) bool {
-	switch {
-	case p == nil:
-		return false
-	case p.Lit != nil && p.Lit.Str != nil:
-		return true
-	case p.Group != nil:
-		return c.isStringExpr(p.Group)
-	case p.Selector != nil && len(p.Selector.Tail) == 0:
-		typ, err := c.env.GetVar(p.Selector.Root)
-		if err == nil {
-			if _, ok := typ.(types.StringType); ok {
-				return true
-			}
-		}
-		for i := len(funcStack) - 1; i >= 0; i-- {
-			if fn, ok := c.env.GetFunc(funcStack[i]); ok {
-				for _, param := range fn.Params {
-					if param.Name == p.Selector.Root && param.Type != nil && param.Type.Simple != nil && *param.Type.Simple == "string" {
-						return true
-					}
-				}
-			}
-		}
-		return false
-	default:
+	if p == nil {
 		return false
 	}
+	_, ok := c.inferPrimaryType(p).(types.StringType)
+	return ok
 }
 
 func (c *Compiler) isMapExpr(e *parser.Expr) bool {
 	if e == nil {
 		return false
 	}
-	return c.isMapBinary(e.Binary)
-}
-
-func (c *Compiler) isMapBinary(b *parser.BinaryExpr) bool {
-	if b == nil {
-		return false
-	}
-	if len(b.Right) == 0 {
-		return c.isMapUnary(b.Left)
-	}
-	return false
+	_, ok := c.inferExprType(e).(types.MapType)
+	return ok
 }
 
 func (c *Compiler) isMapUnary(u *parser.Unary) bool {
 	if u == nil {
 		return false
 	}
-	return c.isMapPostfix(u.Value)
+	_, ok := c.inferUnaryType(u).(types.MapType)
+	return ok
 }
 
 func (c *Compiler) isMapPostfix(p *parser.PostfixExpr) bool {
 	if p == nil {
 		return false
 	}
-	res := c.isMapPrimary(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil || op.Call != nil {
-			res = false
-		}
-		if op.Cast != nil {
-			typ := op.Cast.Type
-			if typ.Generic != nil && typ.Generic.Name == "map" && len(typ.Generic.Args) == 2 {
-				res = true
-			} else {
-				res = false
-			}
-		}
-	}
-	return res
+	_, ok := c.inferPostfixType(p).(types.MapType)
+	return ok
 }
 
 func (c *Compiler) isMapPrimary(p *parser.Primary) bool {
-	switch {
-	case p == nil:
-		return false
-	case p.Map != nil:
-		return true
-	case p.Group != nil:
-		return c.isMapExpr(p.Group)
-	case p.Selector != nil && len(p.Selector.Tail) == 0:
-		if c.locals[p.Selector.Root] {
-			return true
-		}
-		typ, err := c.env.GetVar(p.Selector.Root)
-		if err == nil {
-			if _, ok := typ.(types.MapType); ok {
-				return true
-			}
-		}
-		return false
-	default:
+	if p == nil {
 		return false
 	}
+	_, ok := c.inferPrimaryType(p).(types.MapType)
+	return ok
 }
 
 func intLiteral(e *parser.Expr) (int, bool) {

--- a/compile/fs/helpers.go
+++ b/compile/fs/helpers.go
@@ -1,0 +1,141 @@
+package fscode
+
+import (
+	"reflect"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+func equalTypes(a, b types.Type) bool {
+	if _, ok := a.(types.AnyType); ok {
+		return true
+	}
+	if _, ok := b.(types.AnyType); ok {
+		return true
+	}
+	if la, ok := a.(types.ListType); ok {
+		if lb, ok := b.(types.ListType); ok {
+			return equalTypes(la.Elem, lb.Elem)
+		}
+	}
+	if ma, ok := a.(types.MapType); ok {
+		if mb, ok := b.(types.MapType); ok {
+			return equalTypes(ma.Key, mb.Key) && equalTypes(ma.Value, mb.Value)
+		}
+	}
+	if ua, ok := a.(types.UnionType); ok {
+		if sb, ok := b.(types.StructType); ok {
+			if _, ok := ua.Variants[sb.Name]; ok {
+				return true
+			}
+		}
+	}
+	if ub, ok := b.(types.UnionType); ok {
+		if sa, ok := a.(types.StructType); ok {
+			if _, ok := ub.Variants[sa.Name]; ok {
+				return true
+			}
+		}
+	}
+	if isInt64(a) && (isInt64(b) || isInt(b)) {
+		return true
+	}
+	if isInt64(b) && (isInt64(a) || isInt(a)) {
+		return true
+	}
+	if isInt(a) && isInt(b) {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func isInt64(t types.Type) bool  { _, ok := t.(types.Int64Type); return ok }
+func isInt(t types.Type) bool    { _, ok := t.(types.IntType); return ok }
+func isFloat(t types.Type) bool  { _, ok := t.(types.FloatType); return ok }
+func isBool(t types.Type) bool   { _, ok := t.(types.BoolType); return ok }
+func isString(t types.Type) bool { _, ok := t.(types.StringType); return ok }
+func isList(t types.Type) bool   { _, ok := t.(types.ListType); return ok }
+func isMap(t types.Type) bool    { _, ok := t.(types.MapType); return ok }
+func isStruct(t types.Type) bool { _, ok := t.(types.StructType); return ok }
+func isUnion(t types.Type) bool  { _, ok := t.(types.UnionType); return ok }
+func isAny(t types.Type) bool    { _, ok := t.(types.AnyType); return ok }
+
+func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
+	if t == nil {
+		return types.AnyType{}
+	}
+	if t.Fun != nil {
+		params := make([]types.Type, len(t.Fun.Params))
+		for i, p := range t.Fun.Params {
+			params[i] = c.resolveTypeRef(p)
+		}
+		var ret types.Type = types.VoidType{}
+		if t.Fun.Return != nil {
+			ret = c.resolveTypeRef(t.Fun.Return)
+		}
+		return types.FuncType{Params: params, Return: ret}
+	}
+	if t.Generic != nil {
+		name := t.Generic.Name
+		args := t.Generic.Args
+		switch name {
+		case "list":
+			if len(args) == 1 {
+				return types.ListType{Elem: c.resolveTypeRef(args[0])}
+			}
+		case "map":
+			if len(args) == 2 {
+				return types.MapType{Key: c.resolveTypeRef(args[0]), Value: c.resolveTypeRef(args[1])}
+			}
+		}
+		return types.AnyType{}
+	}
+	if t.Simple != nil {
+		switch *t.Simple {
+		case "int":
+			return types.IntType{}
+		case "float":
+			return types.FloatType{}
+		case "string":
+			return types.StringType{}
+		case "bool":
+			return types.BoolType{}
+		default:
+			if c != nil && c.env != nil {
+				if st, ok := c.env.GetStruct(*t.Simple); ok {
+					return st
+				}
+				if ut, ok := c.env.GetUnion(*t.Simple); ok {
+					return ut
+				}
+			}
+			return types.AnyType{}
+		}
+	}
+	return types.AnyType{}
+}
+
+func simpleStringKey(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return *p.Target.Lit.Str, true
+	}
+	return "", false
+}

--- a/compile/fs/infer.go
+++ b/compile/fs/infer.go
@@ -1,0 +1,427 @@
+package fscode
+
+import (
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
+	if e == nil {
+		return types.AnyType{}
+	}
+	return c.inferBinaryType(e.Binary)
+}
+
+// inferExprTypeHint infers the type of an expression using a hint.
+// This is primarily used for literals that would otherwise default to
+// `any`, such as empty list literals. The hint is applied recursively
+// for nested lists.
+func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
+	if e == nil {
+		return types.AnyType{}
+	}
+	if lt, ok := hint.(types.ListType); ok {
+		if e.Binary != nil && len(e.Binary.Right) == 0 {
+			if ll := e.Binary.Left.Value.Target.List; ll != nil {
+				// If the list literal is empty, use the hint directly.
+				if len(ll.Elems) == 0 {
+					return types.ListType{Elem: lt.Elem}
+				}
+				elem := c.inferExprTypeHint(ll.Elems[0], lt.Elem)
+				for _, el := range ll.Elems[1:] {
+					t := c.inferExprTypeHint(el, lt.Elem)
+					if !equalTypes(elem, t) {
+						elem = types.AnyType{}
+						break
+					}
+				}
+				return types.ListType{Elem: elem}
+			}
+		}
+	}
+	return c.inferExprType(e)
+}
+
+func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
+	if b == nil {
+		return types.AnyType{}
+	}
+	t := c.inferUnaryType(b.Left)
+	for _, op := range b.Right {
+		rt := c.inferPostfixType(op.Right)
+		switch op.Op {
+		case "+", "-", "*", "/", "%":
+			if isInt64(t) {
+				if isInt64(rt) || isInt(rt) {
+					t = types.Int64Type{}
+					continue
+				}
+			}
+			if _, ok := t.(types.IntType); ok {
+				if _, ok := rt.(types.IntType); ok {
+					t = types.IntType{}
+					continue
+				}
+			}
+			if _, ok := t.(types.FloatType); ok {
+				if _, ok := rt.(types.FloatType); ok {
+					t = types.FloatType{}
+					continue
+				}
+			}
+			if op.Op == "+" {
+				if llist, ok := t.(types.ListType); ok {
+					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
+						t = llist
+						continue
+					}
+				}
+				if _, ok := t.(types.StringType); ok {
+					if _, ok := rt.(types.StringType); ok {
+						t = types.StringType{}
+						continue
+					}
+				}
+			}
+			t = types.AnyType{}
+		case "==", "!=", "<", "<=", ">", ">=":
+			t = types.BoolType{}
+		case "&&", "||":
+			if isBool(t) && isBool(rt) {
+				t = types.BoolType{}
+			} else {
+				t = types.AnyType{}
+			}
+		case "in":
+			switch rt.(type) {
+			case types.MapType, types.ListType, types.StringType:
+				t = types.BoolType{}
+			default:
+				t = types.AnyType{}
+			}
+		default:
+			t = types.AnyType{}
+		}
+	}
+	return t
+}
+
+func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+	if u == nil {
+		return types.AnyType{}
+	}
+	return c.inferPostfixType(u.Value)
+}
+
+func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	t := c.inferPrimaryType(p.Target)
+	for _, op := range p.Ops {
+		if op.Index != nil && op.Index.Colon == nil {
+			switch tt := t.(type) {
+			case types.ListType:
+				t = tt.Elem
+			case types.MapType:
+				t = tt.Value
+			case types.StringType:
+				t = types.StringType{}
+			default:
+				t = types.AnyType{}
+			}
+		} else if op.Index != nil {
+			switch tt := t.(type) {
+			case types.ListType:
+				t = tt
+			case types.StringType:
+				t = types.StringType{}
+			default:
+				t = types.AnyType{}
+			}
+		} else if op.Call != nil {
+			if ft, ok := t.(types.FuncType); ok {
+				t = ft.Return
+			} else {
+				t = types.AnyType{}
+			}
+		} else if op.Cast != nil {
+			t = c.resolveTypeRef(op.Cast.Type)
+		}
+	}
+	return t
+}
+
+func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	switch {
+	case p.Lit != nil:
+		switch {
+		case p.Lit.Int != nil:
+			return types.IntType{}
+		case p.Lit.Float != nil:
+			return types.FloatType{}
+		case p.Lit.Str != nil:
+			return types.StringType{}
+		case p.Lit.Bool != nil:
+			return types.BoolType{}
+		}
+	case p.Selector != nil:
+		if c.env != nil {
+			if len(p.Selector.Tail) > 0 {
+				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
+				if t, err := c.env.GetVar(full); err == nil {
+					return t
+				}
+			}
+			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
+				if len(p.Selector.Tail) == 0 {
+					return t
+				}
+				if st, ok := t.(types.StructType); ok {
+					cur := st
+					for idx, field := range p.Selector.Tail {
+						ft, ok := cur.Fields[field]
+						if !ok {
+							return types.AnyType{}
+						}
+						if idx == len(p.Selector.Tail)-1 {
+							return ft
+						}
+						if next, ok := ft.(types.StructType); ok {
+							cur = next
+						} else {
+							return types.AnyType{}
+						}
+					}
+				}
+				if ut, ok := t.(types.UnionType); ok {
+					if ft, ok := unionFieldPathType(ut, p.Selector.Tail); ok {
+						return ft
+					}
+				}
+			}
+		}
+		return types.AnyType{}
+	case p.Struct != nil:
+		if c.env != nil {
+			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
+				return st
+			}
+		}
+		return types.AnyType{}
+	case p.FunExpr != nil:
+		params := make([]types.Type, len(p.FunExpr.Params))
+		for i, par := range p.FunExpr.Params {
+			if par.Type != nil {
+				params[i] = c.resolveTypeRef(par.Type)
+			} else {
+				params[i] = types.AnyType{}
+			}
+		}
+		var ret types.Type = types.VoidType{}
+		if p.FunExpr.Return != nil {
+			ret = c.resolveTypeRef(p.FunExpr.Return)
+		} else if p.FunExpr.ExprBody != nil {
+			ret = c.inferExprType(p.FunExpr.ExprBody)
+		} else {
+			ret = types.AnyType{}
+		}
+		return types.FuncType{Params: params, Return: ret}
+	case p.Generate != nil:
+		switch p.Generate.Target {
+		case "text":
+			return types.StringType{}
+		case "embedding":
+			return types.ListType{Elem: types.FloatType{}}
+		default:
+			if c.env != nil {
+				if st, ok := c.env.GetStruct(p.Generate.Target); ok {
+					return st
+				}
+			}
+			return types.AnyType{}
+		}
+	case p.Call != nil:
+		switch p.Call.Func {
+		case "len":
+			return types.IntType{}
+		case "str":
+			return types.StringType{}
+		case "count":
+			return types.IntType{}
+		case "avg":
+			return types.FloatType{}
+		case "now":
+			return types.Int64Type{}
+		default:
+			if c.env != nil {
+				if t, err := c.env.GetVar(p.Call.Func); err == nil {
+					if ft, ok := t.(types.FuncType); ok {
+						return ft.Return
+					}
+				}
+			}
+			return types.AnyType{}
+		}
+	case p.Group != nil:
+		return c.inferExprType(p.Group)
+	case p.List != nil:
+		var elemType types.Type = types.AnyType{}
+		if len(p.List.Elems) > 0 {
+			elemType = c.inferExprType(p.List.Elems[0])
+			for _, e := range p.List.Elems[1:] {
+				t := c.inferExprType(e)
+				if !equalTypes(elemType, t) {
+					elemType = types.AnyType{}
+					break
+				}
+			}
+		}
+		return types.ListType{Elem: elemType}
+	case p.Load != nil:
+		var elem types.Type = types.MapType{Key: types.StringType{}, Value: types.AnyType{}}
+		if p.Load.Type != nil {
+			elem = c.resolveTypeRef(p.Load.Type)
+			if st, ok := c.env.GetStruct(*p.Load.Type.Simple); elem == (types.AnyType{}) && ok {
+				elem = st
+			}
+		}
+		return types.ListType{Elem: elem}
+	case p.Save != nil:
+		return types.VoidType{}
+	case p.Query != nil:
+		// Infer type with query variables in scope
+		srcType := c.inferExprType(p.Query.Source)
+		var elemType types.Type = types.AnyType{}
+		if lt, ok := srcType.(types.ListType); ok {
+			elemType = lt.Elem
+		}
+		child := types.NewEnv(c.env)
+		child.SetVar(p.Query.Var, elemType, true)
+		for _, f := range p.Query.Froms {
+			ft := c.inferExprType(f.Src)
+			var fe types.Type = types.AnyType{}
+			if lt, ok := ft.(types.ListType); ok {
+				fe = lt.Elem
+			}
+			child.SetVar(f.Var, fe, true)
+		}
+		for _, j := range p.Query.Joins {
+			jt := c.inferExprType(j.Src)
+			var je types.Type = types.AnyType{}
+			if lt, ok := jt.(types.ListType); ok {
+				je = lt.Elem
+			}
+			child.SetVar(j.Var, je, true)
+		}
+		orig := c.env
+		c.env = child
+		elem := c.inferExprType(p.Query.Select)
+		c.env = orig
+		return types.ListType{Elem: elem}
+	case p.Map != nil:
+		var keyType types.Type = types.AnyType{}
+		var valType types.Type = types.AnyType{}
+		if len(p.Map.Items) > 0 {
+			if _, ok := simpleStringKey(p.Map.Items[0].Key); ok {
+				keyType = types.StringType{}
+			} else {
+				keyType = c.inferExprType(p.Map.Items[0].Key)
+			}
+			valType = c.inferExprType(p.Map.Items[0].Value)
+			for _, it := range p.Map.Items[1:] {
+				var kt types.Type
+				if _, ok := simpleStringKey(it.Key); ok {
+					kt = types.StringType{}
+				} else {
+					kt = c.inferExprType(it.Key)
+				}
+				vt := c.inferExprType(it.Value)
+				if !equalTypes(keyType, kt) {
+					keyType = types.AnyType{}
+				}
+				if !equalTypes(valType, vt) {
+					valType = types.AnyType{}
+				}
+			}
+		}
+		return types.MapType{Key: keyType, Value: valType}
+	case p.Match != nil:
+		var rType types.Type
+		for _, cs := range p.Match.Cases {
+			t := c.inferExprType(cs.Result)
+			if rType == nil {
+				rType = t
+			} else if !equalTypes(rType, t) {
+				rType = types.AnyType{}
+			}
+		}
+		if rType == nil {
+			rType = types.AnyType{}
+		}
+		return rType
+	}
+	return types.AnyType{}
+}
+
+func resultType(op string, left, right types.Type) types.Type {
+	switch op {
+	case "+", "-", "*", "/", "%":
+		if _, ok := left.(types.IntType); ok {
+			if _, ok := right.(types.IntType); ok {
+				return types.IntType{}
+			}
+		}
+		if _, ok := left.(types.FloatType); ok {
+			if _, ok := right.(types.FloatType); ok {
+				return types.FloatType{}
+			}
+		}
+		if op == "+" {
+			if _, ok := left.(types.StringType); ok {
+				if _, ok := right.(types.StringType); ok {
+					return types.StringType{}
+				}
+			}
+		}
+		return types.AnyType{}
+	case "==", "!=", "<", "<=", ">", ">=":
+		return types.BoolType{}
+	default:
+		return types.AnyType{}
+	}
+}
+
+// unionFieldPathType attempts to resolve a field path across all variants of a union.
+// It returns the type if every variant has the field path with the same type.
+func unionFieldPathType(ut types.UnionType, tail []string) (types.Type, bool) {
+	var result types.Type
+	for _, variant := range ut.Variants {
+		cur := types.Type(variant)
+		for _, field := range tail {
+			st, ok := cur.(types.StructType)
+			if !ok {
+				return nil, false
+			}
+			ft, ok := st.Fields[field]
+			if !ok {
+				return nil, false
+			}
+			cur = ft
+		}
+		if result == nil {
+			result = cur
+		} else if !equalTypes(result, cur) {
+			return nil, false
+		}
+	}
+	if result == nil {
+		return nil, false
+	}
+	return result, true
+}


### PR DESCRIPTION
## Summary
- add F# compiler type inference adapted from the Go backend
- expose helper functions for resolving types
- use inferred types when checking list, string and map expressions

## Testing
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853766fdf848320a49ded5bfaa72c46