### PR TITLE
Elixir runtime helpers emitted as needed

### DIFF
--- a/compile/ex/README.md
+++ b/compile/ex/README.md
@@ -47,13 +47,16 @@ case "print":
 case "len":
     return fmt.Sprintf("length(%s)", argStr), nil
 case "count":
-    return fmt.Sprintf("Enum.count(%s)", argStr), nil
+    c.use("_count")
+    return fmt.Sprintf("_count(%s)", argStr), nil
 case "avg":
-    return fmt.Sprintf("if Enum.count(%[1]s) == 0, do: 0, else: Enum.sum(%[1]s) / Enum.count(%[1]s)", argStr), nil
+    c.use("_avg")
+    return fmt.Sprintf("_avg(%s)", argStr), nil
 case "str":
     return fmt.Sprintf("to_string(%s)", argStr), nil
 case "input":
-    return "String.trim(IO.gets(\"\"))", nil
+    c.use("_input")
+    return "_input()", nil
 }
 ```
 

--- a/compile/ex/runtime.go
+++ b/compile/ex/runtime.go
@@ -1,0 +1,15 @@
+package excode
+
+const (
+	helperInput = "defp _input() do\n  String.trim(IO.gets(\"\"))\nend\n"
+
+	helperCount = "defp _count(v) do\n  cond do\n    is_list(v) -> length(v)\n    is_map(v) and Map.has_key?(v, :Items) -> length(v[:Items])\n    true -> raise \"count() expects list or group\"\n  end\nend\n"
+
+	helperAvg = "defp _avg(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :Items) -> v[:Items]\n    is_list(v) -> v\n    true -> raise \"avg() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    Enum.sum(list) / Enum.count(list)\n  end\nend\n"
+)
+
+var helperMap = map[string]string{
+	"_input": helperInput,
+	"_count": helperCount,
+	"_avg":   helperAvg,
+}


### PR DESCRIPTION
## Summary
- track helper usage in the Elixir compiler
- emit `_input`, `_count`, and `_avg` helper functions only when referenced
- document helper behaviour in Elixir compiler README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68537eb637a48320831ba047f4963969