### PR TITLE
Add basic Haskell backend fixes and docs

### DIFF
--- a/compile/hs/compiler.go
+++ b/compile/hs/compiler.go
@@ -402,7 +402,11 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 		} else if op.Op == "/" && c.postfixIsInt(op.Right) {
 			expr = fmt.Sprintf("(div %s %s)", expr, r)
 		} else {
-			expr = fmt.Sprintf("(%s %s %s)", expr, op.Op, r)
+			opSym := op.Op
+			if opSym == "!=" {
+				opSym = "/="
+			}
+			expr = fmt.Sprintf("(%s %s %s)", expr, opSym, r)
 		}
 	}
 	return expr, nil

--- a/examples/leetcode/Makefile
+++ b/examples/leetcode/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 MOCHI_ROOT := $(abspath ../..)
 RUNNER := $(MOCHI_ROOT)/cmd/leetcode-runner
 
-.PHONY: run build range test clean help run-rkt
+.PHONY: run build range test clean help run-rkt run-hs
 
 run: ## Run a problem. Usage: make run ID=<n>
 @if [ -z "$(ID)" ]; then echo "❌ Usage: make run ID=<n>"; exit 1; fi
@@ -21,6 +21,10 @@ run-java: ## Execute the compiled Java solution for problem n. Usage: make run-j
 run-rkt: ## Execute the compiled Racket solution for problem n. Usage: make run-rkt ID=<n>
 @if [ -z "$(ID)" ]; then echo "❌ Usage: make run-rkt ID=<n>"; exit 1; fi
 @go run $(RUNNER) build --id $(ID) --lang rkt --run
+
+run-hs: ## Execute the compiled Haskell solution for problem n. Usage: make run-hs ID=<n>
+@if [ -z "$(ID)" ]; then echo "❌ Usage: make run-hs ID=<n>"; exit 1; fi
+@go run $(RUNNER) build --id $(ID) --lang hs --run
 
 range: ## Build problems in range. Usage: make range FROM=1 TO=100 LANG=go
 @go run $(RUNNER) build --from $(FROM) --to $(TO) $(if $(LANG),--lang $(LANG)) --run

--- a/examples/leetcode/README.md
+++ b/examples/leetcode/README.md
@@ -68,7 +68,8 @@ mochi run download.mochi
 - `make run-cpp ID=<n>` – execute the compiled C++ solution for problem `n`
 - `make run-java ID=<n>` – execute the compiled Java solution for problem `n`
 - `make run-rkt ID=<n>` – execute the compiled Racket solution for problem `n`
-- `make compile` – generate Go, Python, TypeScript, Dart, C++, and Racket files into `../leetcode-out`
+- `make run-hs ID=<n>` – execute the compiled Haskell solution for problem `n`
+- `make compile` – generate Go, Python, TypeScript, Dart, C++, Haskell, and Racket files into `../leetcode-out`
 - `make range FROM=1 TO=10 LANG=scala` – build problems in a range using the Scala backend
 - `make test` – run all tests
 - `make clean` – remove the downloaded binary


### PR DESCRIPTION
## Summary
- minor fix for `!=` operator in Haskell backend
- document and expose Haskell compilation in LeetCode examples
- new `run-hs` target in LeetCode Makefile

## Testing
- `go test ./compile/hs -tags slow -run TestHSCompiler_LeetCodeExample1 -count=1`
- `go test ./compile/hs -tags slow -run TestHSCompiler_LeetCodeExamples -count=1`
- `go test ./compile/hs -tags slow -run TestHSCompiler_GoldenSubset -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6853809759488320939793411029c3dd