### PR TITLE
Fix Dart backend output for LeetCode examples

### DIFF
--- a/examples/leetcode-out/dart/1/two-sum.dart
+++ b/examples/leetcode-out/dart/1/two-sum.dart
@@ -1,5 +1,5 @@
-dynamic twoSum(nums, target) {
-	dynamic n = nums.length;
+List<int> twoSum(List<int> nums, int target) {
+	int n = nums.length;
 	for (var i = 0; i < n; i++) {
 		for (var j = (i + 1); j < n; j++) {
 			if (((nums[i] + nums[j]) == target)) {
@@ -11,7 +11,7 @@ dynamic twoSum(nums, target) {
 }
 
 void main() {
-	dynamic result = twoSum([2, 7, 11, 15], 9);
+	List<int> result = twoSum([2, 7, 11, 15], 9);
 	print(result[0]);
 	print(result[1]);
 }

--- a/examples/leetcode-out/dart/10/regular-expression-matching.dart
+++ b/examples/leetcode-out/dart/10/regular-expression-matching.dart
@@ -1,45 +1,59 @@
-dynamic isMatch(s, p) {
-	dynamic m = s.length;
-	dynamic n = p.length;
-	dynamic memo = {};
-	dynamic dfs(i, j) {
-		dynamic key = ((i * ((n + 1))) + j);
-		if ((memo.contains(key))) {
-			return memo[key];
+bool isMatch(String s, String p) {
+	int m = s.length;
+	int n = p.length;
+	List<List<bool>> dp = [];
+	int i = 0;
+	while ((i <= m)) {
+		List<bool> row = [];
+		int j = 0;
+		while ((j <= n)) {
+			row = (row + [false]);
+			j = (j + 1);
 		}
-		if ((j == n)) {
-			return (i == m);
-		}
-		dynamic first = false;
-		if ((i < m)) {
-			if ((((p[j] == s[i])) || ((p[j] == ".")))) {
-				first = true;
+		dp = (dp + [row]);
+		i = (i + 1);
+	}
+	dp[m][n] = true;
+	var i2 = m;
+	while ((i2 >= 0)) {
+		var j2 = (n - 1);
+		while ((j2 >= 0)) {
+			bool first = false;
+			if ((i2 < m)) {
+				if ((((_indexString(p, j2) == _indexString(s, i2))) || ((_indexString(p, j2) == ".")))) {
+					first = true;
+				}
 			}
-		}
-		dynamic ans = false;
-		if (((j + 1) < n)) {
-			if ((p[(j + 1)] == "*")) {
-				if (dfs(i, (j + 2))) {
-					ans = true;
-				} else 
-				if ((first && dfs((i + 1), j))) {
-					ans = true;
+			if ((((j2 + 1) < n) && (_indexString(p, (j2 + 1)) == "*"))) {
+				if ((dp[i2][(j2 + 2)] || ((first && dp[(i2 + 1)][j2])))) {
+					dp[i2][j2] = true;
+				} else {
+					dp[i2][j2] = false;
 				}
 			} else {
-				if ((first && dfs((i + 1), (j + 1)))) {
-					ans = true;
+				if ((first && dp[(i2 + 1)][(j2 + 1)])) {
+					dp[i2][j2] = true;
+				} else {
+					dp[i2][j2] = false;
 				}
 			}
-		} else {
-			if ((first && dfs((i + 1), (j + 1)))) {
-				ans = true;
-			}
+			j2 = (j2 - 1);
 		}
-		memo[key] = ans;
-		return ans;
+		i2 = (i2 - 1);
 	}
-	return dfs(0, 0);
+	return dp[0][0];
 }
 
 void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
 }

--- a/examples/leetcode-out/dart/2/add-two-numbers.dart
+++ b/examples/leetcode-out/dart/2/add-two-numbers.dart
@@ -1,21 +1,21 @@
-dynamic addTwoNumbers(l1, l2) {
-	dynamic i = 0;
-	dynamic j = 0;
-	dynamic carry = 0;
-	dynamic result = [];
+List<int> addTwoNumbers(List<int> l1, List<int> l2) {
+	int i = 0;
+	int j = 0;
+	int carry = 0;
+	List<int> result = [];
 	while ((((i < l1.length) || (j < l2.length)) || (carry > 0))) {
-		dynamic x = 0;
+		int x = 0;
 		if ((i < l1.length)) {
 			x = l1[i];
 			i = (i + 1);
 		}
-		dynamic y = 0;
+		int y = 0;
 		if ((j < l2.length)) {
 			y = l2[j];
 			j = (j + 1);
 		}
-		dynamic sum = ((x + y) + carry);
-		dynamic digit = (sum % 10);
+		var sum = ((x + y) + carry);
+		var digit = (sum % 10);
 		carry = (sum ~/ 10);
 		result = (result + [digit]);
 	}

--- a/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
+++ b/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
@@ -1,18 +1,18 @@
-dynamic lengthOfLongestSubstring(s) {
-	dynamic n = s.length;
-	dynamic start = 0;
-	dynamic best = 0;
-	dynamic i = 0;
+int lengthOfLongestSubstring(String s) {
+	int n = s.length;
+	int start = 0;
+	int best = 0;
+	int i = 0;
 	while ((i < n)) {
-		dynamic j = start;
+		var j = start;
 		while ((j < i)) {
-			if ((s[j] == s[i])) {
+			if ((_indexString(s, j) == _indexString(s, i))) {
 				start = (j + 1);
 				break;
 			}
 			j = (j + 1);
 		}
-		dynamic length = ((i - start) + 1);
+		var length = ((i - start) + 1);
 		if ((length > best)) {
 			best = length;
 		}
@@ -22,4 +22,15 @@ dynamic lengthOfLongestSubstring(s) {
 }
 
 void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
 }

--- a/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
+++ b/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
@@ -1,7 +1,7 @@
-dynamic findMedianSortedArrays(nums1, nums2) {
-	dynamic merged = [];
-	dynamic i = 0;
-	dynamic j = 0;
+double findMedianSortedArrays(List<int> nums1, List<int> nums2) {
+	List<int> merged = [];
+	int i = 0;
+	int j = 0;
 	while (((i < nums1.length) || (j < nums2.length))) {
 		if ((j >= nums2.length)) {
 			merged = (merged + [nums1[i]]);
@@ -19,13 +19,13 @@ dynamic findMedianSortedArrays(nums1, nums2) {
 			j = (j + 1);
 		}
 	}
-	dynamic total = merged.length;
+	int total = merged.length;
 	if (((total % 2) == 1)) {
-		return merged[(total ~/ 2)];
+		return (merged[(total ~/ 2)]).toDouble();
 	}
-	dynamic mid1 = merged[((total ~/ 2) - 1)];
-	dynamic mid2 = merged[(total ~/ 2)];
-	return (((mid1 + mid2)) ~/ 2);
+	var mid1 = merged[((total ~/ 2) - 1)];
+	var mid2 = merged[(total ~/ 2)];
+	return ((((mid1 + mid2))).toDouble() / 2);
 }
 
 void main() {

--- a/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
+++ b/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
@@ -1,9 +1,9 @@
-dynamic expand(s, left, right) {
-	dynamic l = left;
-	dynamic r = right;
-	dynamic n = s.length;
+int expand(String s, int left, int right) {
+	int l = left;
+	int r = right;
+	int n = s.length;
 	while (((l >= 0) && (r < n))) {
-		if ((s[l] != s[r])) {
+		if ((_indexString(s, l) != _indexString(s, r))) {
 			break;
 		}
 		l = (l - 1);
@@ -12,17 +12,17 @@ dynamic expand(s, left, right) {
 	return ((r - l) - 1);
 }
 
-dynamic longestPalindrome(s) {
+String longestPalindrome(String s) {
 	if ((s.length <= 1)) {
 		return s;
 	}
-	dynamic start = 0;
-	dynamic end = 0;
-	dynamic n = s.length;
+	int start = 0;
+	int end = 0;
+	int n = s.length;
 	for (var i = 0; i < n; i++) {
-		dynamic len1 = expand(s, i, i);
-		dynamic len2 = expand(s, i, (i + 1));
-		dynamic l = len1;
+		int len1 = expand(s, i, i);
+		int len2 = expand(s, i, (i + 1));
+		var l = len1;
 		if ((len2 > len1)) {
 			l = len2;
 		}
@@ -31,14 +31,19 @@ dynamic longestPalindrome(s) {
 			end = (i + ((l ~/ 2)));
 		}
 	}
-	dynamic res = "";
-	dynamic k = start;
-	while ((k <= end)) {
-		res = (res + s[k]);
-		k = (k + 1);
-	}
-	return res;
+	return s.substring(start, (end + 1));
 }
 
 void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
 }

--- a/examples/leetcode-out/dart/6/zigzag-conversion.dart
+++ b/examples/leetcode-out/dart/6/zigzag-conversion.dart
@@ -1,16 +1,18 @@
-dynamic convert(s, numRows) {
+String convert(String s, int numRows) {
 	if (((numRows <= 1) || (numRows >= s.length))) {
 		return s;
 	}
-	dynamic rows = [];
-	dynamic i = 0;
+	List<String> rows = [];
+	int i = 0;
 	while ((i < numRows)) {
 		rows = (rows + [""]);
 		i = (i + 1);
 	}
-	dynamic curr = 0;
-	dynamic step = 1;
-	for (var ch in s) {
+	int curr = 0;
+	int step = 1;
+	var _tmp0 = s;
+	for (var _tmp1 in _tmp0.runes) {
+		var ch = String.fromCharCode(_tmp1);
 		rows[curr] = (rows[curr] + ch);
 		if ((curr == 0)) {
 			step = 1;
@@ -20,7 +22,7 @@ dynamic convert(s, numRows) {
 		}
 		curr = (curr + step);
 	}
-	dynamic result = "";
+	String result = "";
 	for (var row in rows) {
 		result = (result + row);
 	}

--- a/examples/leetcode-out/dart/7/reverse-integer.dart
+++ b/examples/leetcode-out/dart/7/reverse-integer.dart
@@ -1,13 +1,13 @@
-dynamic reverse(x) {
-	dynamic sign = 1;
-	dynamic n = x;
+int reverse(int x) {
+	int sign = 1;
+	int n = x;
 	if ((n < 0)) {
 		sign = -1;
 		n = -n;
 	}
-	dynamic rev = 0;
+	int rev = 0;
 	while ((n != 0)) {
-		dynamic digit = (n % 10);
+		var digit = (n % 10);
 		rev = ((rev * 10) + digit);
 		n = (n ~/ 10);
 	}

--- a/examples/leetcode-out/dart/8/string-to-integer-atoi.dart
+++ b/examples/leetcode-out/dart/8/string-to-integer-atoi.dart
@@ -1,24 +1,57 @@
-dynamic myAtoi(s) {
-	dynamic i = 0;
-	dynamic n = s.length;
-	while (((i < n) && (s[i] == " "))) {
+int digit(String ch) {
+	if ((ch == "0")) {
+		return 0;
+	}
+	if ((ch == "1")) {
+		return 1;
+	}
+	if ((ch == "2")) {
+		return 2;
+	}
+	if ((ch == "3")) {
+		return 3;
+	}
+	if ((ch == "4")) {
+		return 4;
+	}
+	if ((ch == "5")) {
+		return 5;
+	}
+	if ((ch == "6")) {
+		return 6;
+	}
+	if ((ch == "7")) {
+		return 7;
+	}
+	if ((ch == "8")) {
+		return 8;
+	}
+	if ((ch == "9")) {
+		return 9;
+	}
+	return -1;
+}
+
+int myAtoi(String s) {
+	int i = 0;
+	int n = s.length;
+	while (((i < n) && (_indexString(s, i) == _indexString(" ", 0)))) {
 		i = (i + 1);
 	}
-	dynamic sign = 1;
-	if (((i < n) && (((s[i] == "+") || (s[i] == "-"))))) {
-		if ((s[i] == "-")) {
+	int sign = 1;
+	if (((i < n) && (((_indexString(s, i) == _indexString("+", 0)) || (_indexString(s, i) == _indexString("-", 0)))))) {
+		if ((_indexString(s, i) == _indexString("-", 0))) {
 			sign = -1;
 		}
 		i = (i + 1);
 	}
-	dynamic digits = {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9};
-	dynamic result = 0;
+	int result = 0;
 	while ((i < n)) {
-		dynamic ch = s[i];
-		if (!((digits.contains(ch)))) {
+		String ch = s.substring(i, (i + 1));
+		int d = digit(ch);
+		if ((d < 0)) {
 			break;
 		}
-		dynamic d = digits[ch];
 		result = ((result * 10) + d);
 		i = (i + 1);
 	}
@@ -33,4 +66,15 @@ dynamic myAtoi(s) {
 }
 
 void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
 }

--- a/examples/leetcode-out/dart/9/palindrome-number.dart
+++ b/examples/leetcode-out/dart/9/palindrome-number.dart
@@ -1,9 +1,9 @@
-dynamic isPalindrome(x) {
+bool isPalindrome(int x) {
 	if ((x < 0)) {
 		return false;
 	}
-	dynamic s = x.toString();
-	dynamic n = s.length;
+	String s = x.toString();
+	int n = s.length;
 	for (var i = 0; i < (n ~/ 2); i++) {
 		if ((s[i] != s[((n - 1) - i)])) {
 			return false;


### PR DESCRIPTION
## Summary
- fix type handling in `compileVar`/`compileLet`
- support cast expressions in Dart backend
- infer float usage to choose `/` vs `~/`
- handle string iteration in `for` loops
- regenerate Dart solutions for LeetCode 1-10

## Testing
- `go build ./...`
- `go run cmd/leetcode-runner/main.go build --from 1 --to 10 --lang dart --run`

------
https://chatgpt.com/codex/tasks/task_e_68538085ab1c8320ac62a90565de5fbc