### PR TITLE
Rebuild Smalltalk outputs with short-circuit fix

### DIFF
--- a/compile/st/compiler.go
+++ b/compile/st/compiler.go
@@ -352,6 +352,14 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 			}
 			leftList = false
 			leftStr = false
+		case "&&":
+			expr = fmt.Sprintf("(%s and: [%s])", expr, right)
+			leftList = false
+			leftStr = false
+		case "||":
+			expr = fmt.Sprintf("(%s or: [%s])", expr, right)
+			leftList = false
+			leftStr = false
 		default:
 			expr = fmt.Sprintf("(%s %s %s)", expr, mapOp(op.Op), right)
 			leftList = false
@@ -513,10 +521,6 @@ func mapOp(op string) string {
 		return "~="
 	case "%":
 		return "\\"
-	case "&&":
-		return "&"
-	case "||":
-		return "|"
 	}
 	return op
 }

--- a/examples/leetcode-out/st/10/regular-expression-matching.st
+++ b/examples/leetcode-out/st/10/regular-expression-matching.st
@@ -25,21 +25,21 @@ isMatch: s p: p | dp first i i2 j j2 m n row |
 		[(j2 >= 0)] whileTrue: [
 			first := false.
 			((i2 < m)) ifTrue: [
-				(((((p at: j2 + 1) = (s at: i2 + 1))) | (((p at: j2 + 1) = '.')))) ifTrue: [
+				(((((p at: j2 + 1) = (s at: i2 + 1))) or: [(((p at: j2 + 1) = '.'))])) ifTrue: [
 					first := true.
 				]
 				.
 			]
 			.
-			(((((j2 + 1) < n) & (p at: (j2 + 1) + 1)) = '*')) ifTrue: [
-				((((dp at: i2 + 1) at: (j2 + 2) + 1) | ((first & ((dp at: (i2 + 1) + 1) at: j2 + 1))))) ifTrue: [
+			(((((j2 + 1) < n) and: [(p at: (j2 + 1) + 1)]) = '*')) ifTrue: [
+				((((dp at: i2 + 1) at: (j2 + 2) + 1) or: [((first and: [((dp at: (i2 + 1) + 1) at: j2 + 1)]))])) ifTrue: [
 					dp at: i2 + 1 put: true.
 				] ifFalse: [
 					dp at: i2 + 1 put: false.
 				]
 				.
 			] ifFalse: [
-				((first & ((dp at: (i2 + 1) + 1) at: (j2 + 1) + 1))) ifTrue: [
+				((first and: [((dp at: (i2 + 1) + 1) at: (j2 + 1) + 1)])) ifTrue: [
 					dp at: i2 + 1 put: true.
 				] ifFalse: [
 					dp at: i2 + 1 put: false.

--- a/examples/leetcode-out/st/2/add-two-numbers.st
+++ b/examples/leetcode-out/st/2/add-two-numbers.st
@@ -6,7 +6,7 @@ addTwoNumbers: l1 l2: l2 | carry digit i j result sum x y |
 	j := 0.
 	carry := 0.
 	result := Array new.
-	[(((((i < l1 size) | j) < l2 size) | carry) > 0)] whileTrue: [
+	[(((((i < l1 size) or: [j]) < l2 size) or: [carry]) > 0)] whileTrue: [
 		x := 0.
 		((i < l1 size)) ifTrue: [
 			x := (l1 at: i + 1).

--- a/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
+++ b/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
@@ -5,7 +5,7 @@ findMedianSortedArrays: nums1 nums2: nums2 | i j merged mid1 mid2 total |
 	merged := Array new.
 	i := 0.
 	j := 0.
-	[(((i < nums1 size) | j) < nums2 size)] whileTrue: [
+	[(((i < nums1 size) or: [j]) < nums2 size)] whileTrue: [
 		((j >= nums2 size)) ifTrue: [
 			merged := (merged , Array with: (nums1 at: i + 1)).
 			i := (i + 1).

--- a/examples/leetcode-out/st/5/longest-palindromic-substring.st
+++ b/examples/leetcode-out/st/5/longest-palindromic-substring.st
@@ -5,7 +5,7 @@ expand: s left: left right: right | l n r |
 	l := left.
 	r := right.
 	n := s size.
-	[(((l >= 0) & r) < n)] whileTrue: [
+	[(((l >= 0) and: [r]) < n)] whileTrue: [
 		(((s at: l + 1) ~= (s at: r + 1))) ifTrue: [
 		]
 		.

--- a/examples/leetcode-out/st/6/zigzag-conversion.st
+++ b/examples/leetcode-out/st/6/zigzag-conversion.st
@@ -2,7 +2,7 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 convert: s numRows: numRows | ch curr i result row rows step |
-	((((numRows <= 1) | numRows) >= s size)) ifTrue: [
+	((((numRows <= 1) or: [numRows]) >= s size)) ifTrue: [
 		^ s
 	]
 	.

--- a/examples/leetcode-out/st/7/reverse-integer.st
+++ b/examples/leetcode-out/st/7/reverse-integer.st
@@ -17,7 +17,7 @@ reverse: x | digit n rev sign |
 	]
 	.
 	rev := (rev * sign).
-	((((rev < (((2147483647 negated) - 1))) | rev) > 2147483647)) ifTrue: [
+	((((rev < (((2147483647 negated) - 1))) or: [rev]) > 2147483647)) ifTrue: [
 		^ 0
 	]
 	.

--- a/examples/leetcode-out/st/8/string-to-integer-atoi.st
+++ b/examples/leetcode-out/st/8/string-to-integer-atoi.st
@@ -1,30 +1,74 @@
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'mochi'!
-myAtoi: s | ch d digits i n result sign |
+digit: ch
+	((ch = '0')) ifTrue: [
+		^ 0
+	]
+	.
+	((ch = '1')) ifTrue: [
+		^ 1
+	]
+	.
+	((ch = '2')) ifTrue: [
+		^ 2
+	]
+	.
+	((ch = '3')) ifTrue: [
+		^ 3
+	]
+	.
+	((ch = '4')) ifTrue: [
+		^ 4
+	]
+	.
+	((ch = '5')) ifTrue: [
+		^ 5
+	]
+	.
+	((ch = '6')) ifTrue: [
+		^ 6
+	]
+	.
+	((ch = '7')) ifTrue: [
+		^ 7
+	]
+	.
+	((ch = '8')) ifTrue: [
+		^ 8
+	]
+	.
+	((ch = '9')) ifTrue: [
+		^ 9
+	]
+	.
+	^ (1 negated)
+!
+
+!Main class methodsFor: 'mochi'!
+myAtoi: s | ch d i n result sign |
 	i := 0.
 	n := s size.
-	[(((i < n) & (s at: i + 1)) = ' ')] whileTrue: [
+	[(((i < n) and: [(s at: i + 1)]) = (' ' at: 0 + 1))] whileTrue: [
 		i := (i + 1).
 	]
 	.
 	sign := 1.
-	(((i < n) & (((((s at: i + 1) = '+') | (s at: i + 1)) = '-')))) ifTrue: [
-		(((s at: i + 1) = '-')) ifTrue: [
+	(((i < n) and: [(((((s at: i + 1) = ('+' at: 0 + 1)) or: [(s at: i + 1)]) = ('-' at: 0 + 1)))])) ifTrue: [
+		(((s at: i + 1) = ('-' at: 0 + 1))) ifTrue: [
 			sign := (1 negated).
 		]
 		.
 		i := (i + 1).
 	]
 	.
-	digits := Dictionary from: {'0' -> 0. '1' -> 1. '2' -> 2. '3' -> 3. '4' -> 4. '5' -> 5. '6' -> 6. '7' -> 7. '8' -> 8. '9' -> 9}.
 	result := 0.
 	[(i < n)] whileTrue: [
-		ch := (s at: i + 1).
-		((((digits includes: ch))) not) ifTrue: [
+		ch := (s copyFrom: (i + 1) to: (i + 1)).
+		d := Main digit: (ch).
+		((d < 0)) ifTrue: [
 		]
 		.
-		d := (digits at: ch + 1).
 		result := ((result * 10) + d).
 		i := (i + 1).
 	]


### PR DESCRIPTION
## Summary
- handle `&&` and `||` with Smalltalk `and:` and `or:` blocks
- regenerate Smalltalk LeetCode examples for problems 1‑10

## Testing
- `go vet ./...` *(warned about fortran and swift)*
- `go run cmd/leetcode-runner/main.go build --from 1 --to 10 --lang st --run`


------
https://chatgpt.com/codex/tasks/task_e_685380c08fe08320835d6d3ac42fdf87