### PR TITLE
Add PHP slicing and int division fixes

### DIFF
--- a/examples/leetcode-out/php/1/two-sum.php
+++ b/examples/leetcode-out/php/1/two-sum.php
@@ -1,6 +1,6 @@
 <?php
 function twoSum($nums, $target) {
-	$n = count($nums);
+	$n = (is_array($nums) ? count($nums) : strlen($nums));
 	for ($i = 0; $i < $n; $i++) {
 		for ($j = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))); $j < $n; $j++) {
 			if ((((is_array($nums[$i]) && is_array($nums[$j])) ? array_merge($nums[$i], $nums[$j]) : ((is_string($nums[$i]) || is_string($nums[$j])) ? ($nums[$i] . $nums[$j]) : ($nums[$i] + $nums[$j]))) == $target)) {

--- a/examples/leetcode-out/php/10/regular-expression-matching.php
+++ b/examples/leetcode-out/php/10/regular-expression-matching.php
@@ -1,8 +1,72 @@
 <?php
 function isMatch($s, $p) {
-	$m = count($s);
-	$n = count($p);
-	$memo = [];
-	return dfs(0, 0);
+	$m = (is_array($s) ? count($s) : strlen($s));
+	$n = (is_array($p) ? count($p) : strlen($p));
+	$dp = [];
+	$i = 0;
+	while (($i <= $m)) {
+		$row = [];
+		$j = 0;
+		while (($j <= $n)) {
+			$row = ((is_array($row) && is_array([false])) ? array_merge($row, [false]) : ((is_string($row) || is_string([false])) ? ($row . [false]) : ($row + [false])));
+			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+		}
+		$dp = ((is_array($dp) && is_array([$row])) ? array_merge($dp, [$row]) : ((is_string($dp) || is_string([$row])) ? ($dp . [$row]) : ($dp + [$row])));
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	$dp[$m][$n] = true;
+	$i2 = $m;
+	while (($i2 >= 0)) {
+		$j2 = ($n - 1);
+		while (($j2 >= 0)) {
+			$first = false;
+			if (($i2 < $m)) {
+				if (((($p[$j2] == $s[$i2])) || (($p[$j2] == ".")))) {
+					$first = true;
+				}
+			}
+			if (((((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1))) < $n) && ($p[((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1)))] == "*"))) {
+				if (($dp[$i2][((is_array($j2) && is_array(2)) ? array_merge($j2, 2) : ((is_string($j2) || is_string(2)) ? ($j2 . 2) : ($j2 + 2)))] || (($first && $dp[((is_array($i2) && is_array(1)) ? array_merge($i2, 1) : ((is_string($i2) || is_string(1)) ? ($i2 . 1) : ($i2 + 1)))][$j2])))) {
+					$dp[$i2][$j2] = true;
+				} else {
+					$dp[$i2][$j2] = false;
+				}
+			} else {
+				if (($first && $dp[((is_array($i2) && is_array(1)) ? array_merge($i2, 1) : ((is_string($i2) || is_string(1)) ? ($i2 . 1) : ($i2 + 1)))][((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1)))])) {
+					$dp[$i2][$j2] = true;
+				} else {
+					$dp[$i2][$j2] = false;
+				}
+			}
+			$j2 = ($j2 - 1);
+		}
+		$i2 = ($i2 - 1);
+	}
+	return $dp[0][0];
 }
 
+function test_example_1() {
+	if (!((isMatch("aa", "a") == false))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((isMatch("aa", "a*") == true))) { throw new Exception('expect failed'); }
+}
+
+function test_example_3() {
+	if (!((isMatch("ab", ".*") == true))) { throw new Exception('expect failed'); }
+}
+
+function test_example_4() {
+	if (!((isMatch("aab", "c*a*b") == true))) { throw new Exception('expect failed'); }
+}
+
+function test_example_5() {
+	if (!((isMatch("mississippi", "mis*is*p*.") == false))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_example_3();
+test_example_4();
+test_example_5();

--- a/examples/leetcode-out/php/2/add-two-numbers.php
+++ b/examples/leetcode-out/php/2/add-two-numbers.php
@@ -4,22 +4,37 @@ function addTwoNumbers($l1, $l2) {
 	$j = 0;
 	$carry = 0;
 	$result = [];
-	while (((((($i < count($l1)) || $j) < count($l2)) || $carry) > 0)) {
+	while (((($i < (is_array($l1) ? count($l1) : strlen($l1))) || ($j < (is_array($l2) ? count($l2) : strlen($l2)))) || ($carry > 0))) {
 		$x = 0;
-		if (($i < count($l1))) {
+		if (($i < (is_array($l1) ? count($l1) : strlen($l1)))) {
 			$x = $l1[$i];
 			$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
 		}
 		$y = 0;
-		if (($j < count($l2))) {
+		if (($j < (is_array($l2) ? count($l2) : strlen($l2)))) {
 			$y = $l2[$j];
 			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
 		}
 		$sum = ((is_array(((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y)))) && is_array($carry)) ? array_merge(((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y))), $carry) : ((is_string(((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y)))) || is_string($carry)) ? (((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y))) . $carry) : (((is_array($x) && is_array($y)) ? array_merge($x, $y) : ((is_string($x) || is_string($y)) ? ($x . $y) : ($x + $y))) + $carry)));
-		$digit = ($sum % 10);
-		$carry = ($sum / 10);
+		$digit = ((is_int($sum) && is_int(10)) ? ($sum % 10) : fmod($sum, 10));
+		$carry = ((is_int($sum) && is_int(10)) ? intdiv($sum, 10) : ($sum / 10));
 		$result = ((is_array($result) && is_array([$digit])) ? array_merge($result, [$digit]) : ((is_string($result) || is_string([$digit])) ? ($result . [$digit]) : ($result + [$digit])));
 	}
 	return $result;
 }
 
+function test_example_1() {
+	if (!((addTwoNumbers([2, 4, 3], [5, 6, 4]) == [7, 0, 8]))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((addTwoNumbers([0], [0]) == [0]))) { throw new Exception('expect failed'); }
+}
+
+function test_example_3() {
+	if (!((addTwoNumbers([9, 9, 9, 9, 9, 9, 9], [9, 9, 9, 9]) == [8, 9, 9, 9, 0, 0, 0, 1]))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_example_3();

--- a/examples/leetcode-out/php/3/longest-substring-without-repeating-characters.php
+++ b/examples/leetcode-out/php/3/longest-substring-without-repeating-characters.php
@@ -1,6 +1,6 @@
 <?php
 function lengthOfLongestSubstring($s) {
-	$n = count($s);
+	$n = (is_array($s) ? count($s) : strlen($s));
 	$start = 0;
 	$best = 0;
 	$i = 0;
@@ -22,3 +22,23 @@ function lengthOfLongestSubstring($s) {
 	return $best;
 }
 
+function test_example_1() {
+	if (!((lengthOfLongestSubstring("abcabcbb") == 3))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((lengthOfLongestSubstring("bbbbb") == 1))) { throw new Exception('expect failed'); }
+}
+
+function test_example_3() {
+	if (!((lengthOfLongestSubstring("pwwkew") == 3))) { throw new Exception('expect failed'); }
+}
+
+function test_empty_string() {
+	if (!((lengthOfLongestSubstring("") == 0))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_example_3();
+test_empty_string();

--- a/examples/leetcode-out/php/4/median-of-two-sorted-arrays.php
+++ b/examples/leetcode-out/php/4/median-of-two-sorted-arrays.php
@@ -3,12 +3,12 @@ function findMedianSortedArrays($nums1, $nums2) {
 	$merged = [];
 	$i = 0;
 	$j = 0;
-	while (((($i < count($nums1)) || $j) < count($nums2))) {
-		if (($j >= count($nums2))) {
+	while ((($i < (is_array($nums1) ? count($nums1) : strlen($nums1))) || ($j < (is_array($nums2) ? count($nums2) : strlen($nums2))))) {
+		if (($j >= (is_array($nums2) ? count($nums2) : strlen($nums2)))) {
 			$merged = ((is_array($merged) && is_array([$nums1[$i]])) ? array_merge($merged, [$nums1[$i]]) : ((is_string($merged) || is_string([$nums1[$i]])) ? ($merged . [$nums1[$i]]) : ($merged + [$nums1[$i]])));
 			$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
 		} else 
-		if (($i >= count($nums1))) {
+		if (($i >= (is_array($nums1) ? count($nums1) : strlen($nums1)))) {
 			$merged = ((is_array($merged) && is_array([$nums2[$j]])) ? array_merge($merged, [$nums2[$j]]) : ((is_string($merged) || is_string([$nums2[$j]])) ? ($merged . [$nums2[$j]]) : ($merged + [$nums2[$j]])));
 			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
 		} else 
@@ -20,12 +20,32 @@ function findMedianSortedArrays($nums1, $nums2) {
 			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
 		}
 	}
-	$total = count($merged);
-	if ((($total % 2) == 1)) {
-		return $merged[($total / 2)];
+	$total = (is_array($merged) ? count($merged) : strlen($merged));
+	if ((((is_int($total) && is_int(2)) ? ($total % 2) : fmod($total, 2)) == 1)) {
+		return $merged[((is_int($total) && is_int(2)) ? intdiv($total, 2) : ($total / 2))];
 	}
-	$mid1 = $merged[(($total / 2) - 1)];
-	$mid2 = $merged[($total / 2)];
-	return ((((is_array($mid1) && is_array($mid2)) ? array_merge($mid1, $mid2) : ((is_string($mid1) || is_string($mid2)) ? ($mid1 . $mid2) : ($mid1 + $mid2)))) / 2);
+	$mid1 = $merged[(((is_int($total) && is_int(2)) ? intdiv($total, 2) : ($total / 2)) - 1)];
+	$mid2 = $merged[((is_int($total) && is_int(2)) ? intdiv($total, 2) : ($total / 2))];
+	return ((is_int((((is_array($mid1) && is_array($mid2)) ? array_merge($mid1, $mid2) : ((is_string($mid1) || is_string($mid2)) ? ($mid1 . $mid2) : ($mid1 + $mid2))))) && is_int(2.0)) ? intdiv((((is_array($mid1) && is_array($mid2)) ? array_merge($mid1, $mid2) : ((is_string($mid1) || is_string($mid2)) ? ($mid1 . $mid2) : ($mid1 + $mid2)))), 2.0) : ((((is_array($mid1) && is_array($mid2)) ? array_merge($mid1, $mid2) : ((is_string($mid1) || is_string($mid2)) ? ($mid1 . $mid2) : ($mid1 + $mid2)))) / 2.0));
 }
 
+function test_example_1() {
+	if (!((findMedianSortedArrays([1, 3], [2]) == 2.0))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((findMedianSortedArrays([1, 2], [3, 4]) == 2.5))) { throw new Exception('expect failed'); }
+}
+
+function test_empty_first() {
+	if (!((findMedianSortedArrays([], [1]) == 1.0))) { throw new Exception('expect failed'); }
+}
+
+function test_empty_second() {
+	if (!((findMedianSortedArrays([2], []) == 2.0))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_empty_first();
+test_empty_second();

--- a/examples/leetcode-out/php/5/longest-palindromic-substring.php
+++ b/examples/leetcode-out/php/5/longest-palindromic-substring.php
@@ -2,8 +2,8 @@
 function expand($s, $left, $right) {
 	$l = $left;
 	$r = $right;
-	$n = count($s);
-	while (((($l >= 0) && $r) < $n)) {
+	$n = (is_array($s) ? count($s) : strlen($s));
+	while ((($l >= 0) && ($r < $n))) {
 		if (($s[$l] != $s[$r])) {
 			break;
 		}
@@ -14,12 +14,12 @@ function expand($s, $left, $right) {
 }
 
 function longestPalindrome($s) {
-	if ((count($s) <= 1)) {
+	if (((is_array($s) ? count($s) : strlen($s)) <= 1)) {
 		return $s;
 	}
 	$start = 0;
 	$end = 0;
-	$n = count($s);
+	$n = (is_array($s) ? count($s) : strlen($s));
 	for ($i = 0; $i < $n; $i++) {
 		$len1 = expand($s, $i, $i);
 		$len2 = expand($s, $i, ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))));
@@ -28,16 +28,32 @@ function longestPalindrome($s) {
 			$l = $len2;
 		}
 		if (($l > (($end - $start)))) {
-			$start = ($i - (((($l - 1)) / 2)));
-			$end = ((is_array($i) && is_array((($l / 2)))) ? array_merge($i, (($l / 2))) : ((is_string($i) || is_string((($l / 2)))) ? ($i . (($l / 2))) : ($i + (($l / 2)))));
+			$start = ($i - (((is_int((($l - 1))) && is_int(2)) ? intdiv((($l - 1)), 2) : ((($l - 1)) / 2))));
+			$end = ((is_array($i) && is_array((((is_int($l) && is_int(2)) ? intdiv($l, 2) : ($l / 2))))) ? array_merge($i, (((is_int($l) && is_int(2)) ? intdiv($l, 2) : ($l / 2)))) : ((is_string($i) || is_string((((is_int($l) && is_int(2)) ? intdiv($l, 2) : ($l / 2))))) ? ($i . (((is_int($l) && is_int(2)) ? intdiv($l, 2) : ($l / 2)))) : ($i + (((is_int($l) && is_int(2)) ? intdiv($l, 2) : ($l / 2))))));
 		}
 	}
-	$res = "";
-	$k = $start;
-	while (($k <= $end)) {
-		$res = ((is_array($res) && is_array($s[$k])) ? array_merge($res, $s[$k]) : ((is_string($res) || is_string($s[$k])) ? ($res . $s[$k]) : ($res + $s[$k])));
-		$k = ((is_array($k) && is_array(1)) ? array_merge($k, 1) : ((is_string($k) || is_string(1)) ? ($k . 1) : ($k + 1)));
-	}
-	return $res;
+	return (is_array($s) ? array_slice($s, $start, (((is_array($end) && is_array(1)) ? array_merge($end, 1) : ((is_string($end) || is_string(1)) ? ($end . 1) : ($end + 1)))) - ($start)) : substr($s, $start, (((is_array($end) && is_array(1)) ? array_merge($end, 1) : ((is_string($end) || is_string(1)) ? ($end . 1) : ($end + 1)))) - ($start)));
 }
 
+function test_example_1() {
+	$ans = longestPalindrome("babad");
+	if (!((($ans == "bab") || ($ans == "aba")))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((longestPalindrome("cbbd") == "bb"))) { throw new Exception('expect failed'); }
+}
+
+function test_single_char() {
+	if (!((longestPalindrome("a") == "a"))) { throw new Exception('expect failed'); }
+}
+
+function test_two_chars() {
+	$ans = longestPalindrome("ac");
+	if (!((($ans == "a") || ($ans == "c")))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_single_char();
+test_two_chars();

--- a/examples/leetcode-out/php/6/zigzag-conversion.php
+++ b/examples/leetcode-out/php/6/zigzag-conversion.php
@@ -1,6 +1,6 @@
 <?php
 function convert($s, $numRows) {
-	if (((($numRows <= 1) || $numRows) >= count($s))) {
+	if ((($numRows <= 1) || ($numRows >= (is_array($s) ? count($s) : strlen($s))))) {
 		return $s;
 	}
 	$rows = [];
@@ -16,7 +16,7 @@ function convert($s, $numRows) {
 		if (($curr == 0)) {
 			$step = 1;
 		} else 
-		if ((($curr == $numRows) - 1)) {
+		if (($curr == ($numRows - 1))) {
 			$step = -1;
 		}
 		$curr = ((is_array($curr) && is_array($step)) ? array_merge($curr, $step) : ((is_string($curr) || is_string($step)) ? ($curr . $step) : ($curr + $step)));
@@ -28,3 +28,18 @@ function convert($s, $numRows) {
 	return $result;
 }
 
+function test_example_1() {
+	if (!((convert("PAYPALISHIRING", 3) == "PAHNAPLSIIGYIR"))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((convert("PAYPALISHIRING", 4) == "PINALSIGYAHRPI"))) { throw new Exception('expect failed'); }
+}
+
+function test_single_row() {
+	if (!((convert("A", 1) == "A"))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_single_row();

--- a/examples/leetcode-out/php/7/reverse-integer.php
+++ b/examples/leetcode-out/php/7/reverse-integer.php
@@ -8,14 +8,34 @@ function reverse($x) {
 	}
 	$rev = 0;
 	while (($n != 0)) {
-		$digit = ($n % 10);
+		$digit = ((is_int($n) && is_int(10)) ? ($n % 10) : fmod($n, 10));
 		$rev = ((is_array(($rev * 10)) && is_array($digit)) ? array_merge(($rev * 10), $digit) : ((is_string(($rev * 10)) || is_string($digit)) ? (($rev * 10) . $digit) : (($rev * 10) + $digit)));
-		$n = ($n / 10);
+		$n = ((is_int($n) && is_int(10)) ? intdiv($n, 10) : ($n / 10));
 	}
 	$rev = ($rev * $sign);
-	if (((($rev < ((-2147483647 - 1))) || $rev) > 2147483647)) {
+	if ((($rev < ((-2147483647 - 1))) || ($rev > 2147483647))) {
 		return 0;
 	}
 	return $rev;
 }
 
+function test_example_1() {
+	if (!((reverse(123) == 321))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((reverse(-123) == (-321)))) { throw new Exception('expect failed'); }
+}
+
+function test_example_3() {
+	if (!((reverse(120) == 21))) { throw new Exception('expect failed'); }
+}
+
+function test_overflow() {
+	if (!((reverse(1534236469) == 0))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_example_3();
+test_overflow();

--- a/examples/leetcode-out/php/8/string-to-integer-atoi.php
+++ b/examples/leetcode-out/php/8/string-to-integer-atoi.php
@@ -1,25 +1,58 @@
 <?php
+function digit($ch) {
+	if (($ch == "0")) {
+		return 0;
+	}
+	if (($ch == "1")) {
+		return 1;
+	}
+	if (($ch == "2")) {
+		return 2;
+	}
+	if (($ch == "3")) {
+		return 3;
+	}
+	if (($ch == "4")) {
+		return 4;
+	}
+	if (($ch == "5")) {
+		return 5;
+	}
+	if (($ch == "6")) {
+		return 6;
+	}
+	if (($ch == "7")) {
+		return 7;
+	}
+	if (($ch == "8")) {
+		return 8;
+	}
+	if (($ch == "9")) {
+		return 9;
+	}
+	return -1;
+}
+
 function myAtoi($s) {
 	$i = 0;
-	$n = count($s);
-	while (((($i < $n) && $s[$i]) == " ")) {
+	$n = (is_array($s) ? count($s) : strlen($s));
+	while ((($i < $n) && ($s[$i] == " "[0]))) {
 		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
 	}
 	$sign = 1;
-	if ((($i < $n) && (((($s[$i] == "+") || $s[$i]) == "-")))) {
-		if (($s[$i] == "-")) {
+	if ((($i < $n) && ((($s[$i] == "+"[0]) || ($s[$i] == "-"[0]))))) {
+		if (($s[$i] == "-"[0])) {
 			$sign = -1;
 		}
 		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
 	}
-	$digits = ["0" => 0, "1" => 1, "2" => 2, "3" => 3, "4" => 4, "5" => 5, "6" => 6, "7" => 7, "8" => 8, "9" => 9];
 	$result = 0;
 	while (($i < $n)) {
-		$ch = $s[$i];
-		if (!((is_array($digits) ? (array_key_exists($ch, $digits) || in_array($ch, $digits, true)) : (is_string($digits) ? strpos($digits, strval($ch)) !== false : false)))) {
+		$ch = (is_array($s) ? array_slice($s, $i, (((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))) - ($i)) : substr($s, $i, (((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))) - ($i)));
+		$d = digit($ch);
+		if (($d < 0)) {
 			break;
 		}
-		$d = $digits[$ch];
 		$result = ((is_array(($result * 10)) && is_array($d)) ? array_merge(($result * 10), $d) : ((is_string(($result * 10)) || is_string($d)) ? (($result * 10) . $d) : (($result * 10) + $d)));
 		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
 	}
@@ -33,3 +66,28 @@ function myAtoi($s) {
 	return $result;
 }
 
+function test_example_1() {
+	if (!((myAtoi("42") == 42))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((myAtoi("   -42") == (-42)))) { throw new Exception('expect failed'); }
+}
+
+function test_example_3() {
+	if (!((myAtoi("4193 with words") == 4193))) { throw new Exception('expect failed'); }
+}
+
+function test_example_4() {
+	if (!((myAtoi("words and 987") == 0))) { throw new Exception('expect failed'); }
+}
+
+function test_example_5() {
+	if (!((myAtoi("-91283472332") == (-2147483648)))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_example_3();
+test_example_4();
+test_example_5();

--- a/examples/leetcode-out/php/9/palindrome-number.php
+++ b/examples/leetcode-out/php/9/palindrome-number.php
@@ -4,8 +4,8 @@ function isPalindrome($x) {
 		return false;
 	}
 	$s = strval($x);
-	$n = count($s);
-	for ($i = 0; $i < ($n / 2); $i++) {
+	$n = (is_array($s) ? count($s) : strlen($s));
+	for ($i = 0; $i < ((is_int($n) && is_int(2)) ? intdiv($n, 2) : ($n / 2)); $i++) {
 		if (($s[$i] != $s[(($n - 1) - $i)])) {
 			return false;
 		}
@@ -13,3 +13,23 @@ function isPalindrome($x) {
 	return true;
 }
 
+function test_example_1() {
+	if (!((isPalindrome(121) == true))) { throw new Exception('expect failed'); }
+}
+
+function test_example_2() {
+	if (!((isPalindrome(-121) == false))) { throw new Exception('expect failed'); }
+}
+
+function test_example_3() {
+	if (!((isPalindrome(10) == false))) { throw new Exception('expect failed'); }
+}
+
+function test_zero() {
+	if (!((isPalindrome(0) == true))) { throw new Exception('expect failed'); }
+}
+
+test_example_1();
+test_example_2();
+test_example_3();
+test_zero();


### PR DESCRIPTION
## Summary
- fix int vs float division in PHP compiler
- support slicing for lists and strings in PHP
- keep decimal point in float literals
- regenerate LeetCode PHP outputs for problems 1-10

## Testing
- `go test -tags slow ./compile/php -run TestPHPCompiler_LeetCodeExamples -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685380abbec08320a13f6741f013f432