### PR TITLE
Enable clj compiler on LC#6

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -115,7 +115,7 @@ go test ./compile/clj -tags slow
 They compare the execution output of generated programs in `tests/compiler/clj` with predefined golden files.
 
 The test suite also compiles and runs the example LeetCode solutions in
-`examples/leetcode/1` through `examples/leetcode/5` to verify that these programs
+`examples/leetcode/1` through `examples/leetcode/6` to verify that these programs
 execute correctly using the Clojure backend.
 
 ## Status

--- a/compile/clj/compiler.go
+++ b/compile/clj/compiler.go
@@ -175,7 +175,12 @@ func (c *Compiler) compileLet(st *parser.LetStmt) error {
 	}
 	c.writeln(fmt.Sprintf("(def %s %s)", sanitizeName(st.Name), expr))
 	if c.env != nil {
-		typ := c.inferExprType(st.Value)
+		var typ types.Type = types.AnyType{}
+		if st.Type != nil {
+			typ = c.resolveTypeRef(st.Type)
+		} else {
+			typ = c.inferExprType(st.Value)
+		}
 		c.env.SetVar(st.Name, typ, true)
 	}
 	return nil
@@ -193,7 +198,9 @@ func (c *Compiler) compileVar(st *parser.VarStmt) error {
 	c.writeln(fmt.Sprintf("(def %s %s)", sanitizeName(st.Name), expr))
 	if c.env != nil {
 		var typ types.Type = types.AnyType{}
-		if st.Value != nil {
+		if st.Type != nil {
+			typ = c.resolveTypeRef(st.Type)
+		} else if st.Value != nil {
 			typ = c.inferExprType(st.Value)
 		}
 		c.env.SetVar(st.Name, typ, true)

--- a/compile/clj/compiler_test.go
+++ b/compile/clj/compiler_test.go
@@ -161,4 +161,5 @@ func TestClojureCompiler_LeetCodeExamples(t *testing.T) {
 	runLeetExample(t, 3)
 	runLeetExample(t, 4)
 	runLeetExample(t, 5)
+	runLeetExample(t, 6)
 }

--- a/examples/leetcode-out/clj/6/zigzag-conversion.clj
+++ b/examples/leetcode-out/clj/6/zigzag-conversion.clj
@@ -1,0 +1,105 @@
+(defn convert [s numRows]
+  (try
+    (when (or (<= numRows 1) (>= numRows (count s)))
+      (throw (ex-info "return" {:value s}))
+    )
+    (def rows [])
+    (def i 0)
+    (loop []
+      (when (< i numRows)
+        (let [r (try
+          (def rows (vec (concat rows [""])))
+          (def i (+ i 1))
+          :next
+        (catch clojure.lang.ExceptionInfo e
+          (cond
+            (= (.getMessage e) "continue") :next
+            (= (.getMessage e) "break") :break
+            :else (throw e))
+          )
+        )]
+      (cond
+        (= r :break) nil
+        (= r :next) (recur)
+      )
+    )
+  )
+)
+(def curr 0)
+(def step 1)
+(loop [_tmp0 (seq s)]
+  (when _tmp0
+    (let [ch (first _tmp0)]
+      (let [r (try
+        (def rows (assoc rows curr (str (nth rows curr) ch)))
+        (if (= curr 0)
+          (do
+            (def step 1)
+          )
+        
+        (when (= curr (- numRows 1))
+          (def step (- 1))
+        )
+        )
+        (def curr (+ curr step))
+        :next
+      (catch clojure.lang.ExceptionInfo e
+        (cond
+          (= (.getMessage e) "continue") :next
+          (= (.getMessage e) "break") :break
+          :else (throw e))
+        )
+      )]
+    (cond
+      (= r :break) nil
+      :else (recur (next _tmp0))
+    )
+  )
+)
+)
+)
+(def result "")
+(loop [_tmp1 (seq rows)]
+(when _tmp1
+(let [row (first _tmp1)]
+  (let [r (try
+    (def result (str result row))
+    :next
+  (catch clojure.lang.ExceptionInfo e
+    (cond
+      (= (.getMessage e) "continue") :next
+      (= (.getMessage e) "break") :break
+      :else (throw e))
+    )
+  )]
+(cond
+  (= r :break) nil
+  :else (recur (next _tmp1))
+)
+)
+)
+)
+)
+(throw (ex-info "return" {:value result}))
+(catch clojure.lang.ExceptionInfo e
+(if (= (.getMessage e) "return")
+(:value (ex-data e))
+(throw e)))
+)
+)
+
+(defn test_example_1 []
+(assert (= (convert "PAYPALISHIRING" 3) "PAHNAPLSIIGYIR"))
+)
+
+(defn test_example_2 []
+(assert (= (convert "PAYPALISHIRING" 4) "PINALSIGYAHRPI"))
+)
+
+(defn test_single_row []
+(assert (= (convert "A" 1) "A"))
+)
+
+(test_example_1)
+(test_example_2)
+(test_single_row)


### PR DESCRIPTION
## Summary
- support typed variables in clj backend
- run LeetCode example 6 in clj tests
- update clj README to mention problems 1–6
- add generated Clojure code for problem 6

## Testing
- `go test ./compile/clj -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68538e9c154083208c56043baacccecd