### PR TITLE
Add rust compiler enhancements and generated LeetCode files

### DIFF
--- a/compile/rust/helpers.go
+++ b/compile/rust/helpers.go
@@ -1,6 +1,9 @@
 package rscode
 
-import "mochi/parser"
+import (
+	"mochi/parser"
+	"mochi/types"
+)
 
 func isUnderscoreExpr(e *parser.Expr) bool {
 	if e == nil {
@@ -57,4 +60,23 @@ func identName(e *parser.Expr) (string, bool) {
 		return p.Target.Selector.Root, true
 	}
 	return "", false
+}
+
+// isStringRoot reports whether the base identifier of a postfix expression is a
+// string variable in the current environment.
+func (c *Compiler) isStringRoot(p *parser.PostfixExpr) bool {
+	if p == nil || p.Target == nil {
+		return false
+	}
+	sel := p.Target.Selector
+	if sel != nil {
+		if c.env != nil {
+			if t, err := c.env.GetVar(sel.Root); err == nil {
+				if _, ok := t.(types.StringType); ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/examples/leetcode-out/rust/6/zigzag-conversion.rs
+++ b/examples/leetcode-out/rust/6/zigzag-conversion.rs
@@ -1,33 +1,35 @@
-fn convert(s: &str, num_rows: i32) -> String {
-    if num_rows <= 1 || num_rows as usize >= s.len() {
+fn convert(s: &str, numRows: i32) -> String {
+    if numRows <= 1 || numRows >= s.len() as i32 {
         return s.to_string();
     }
-    let mut rows: Vec<String> = Vec::new();
+    let mut rows: Vec<String> = vec![];
     let mut i = 0;
-    while i < num_rows {
-        rows = _concat(&rows, &vec![String::new()]);
-        i += 1;
+    while i < numRows {
+        rows = _concat(&rows, &vec!["".to_string()]);
+        i = i + 1;
     }
     let mut curr = 0;
     let mut step = 1;
     for ch_ch in s.chars() {
         let ch = ch_ch.to_string();
-        rows[curr as usize] = format!("{}{}", rows[curr as usize], ch);
+        rows[(curr) as usize] = format!("{}{}", rows[(curr) as usize], ch);
         if curr == 0 {
             step = 1;
-        } else if curr == num_rows - 1 {
+        } else 
+        if curr == numRows - 1 {
             step = -1;
         }
-        curr += step;
+        curr = curr + step;
     }
-    let mut result = String::new();
+    let mut result: String = "".to_string();
     for row in rows {
         result = format!("{}{}", result, row);
     }
-    result
+    return result.to_string();
 }
 
-fn main() {}
+fn main() {
+}
 
 fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
     let mut res = Vec::with_capacity(a.len() + b.len());

--- a/examples/leetcode-out/rust/7/reverse-integer.rs
+++ b/examples/leetcode-out/rust/7/reverse-integer.rs
@@ -1,0 +1,23 @@
+fn reverse(x: i32) -> i32 {
+    let mut sign = 1;
+    let mut n = x;
+    if n < 0 {
+        sign = -1;
+        n = -n;
+    }
+    let mut rev = 0;
+    while n != 0 {
+        let mut digit = n % 10;
+        rev = rev * 10 + digit;
+        n = n / 10;
+    }
+    rev = rev * sign;
+    if rev < (-2147483647 - 1) || rev > 2147483647 {
+        return 0;
+    }
+    return rev;
+}
+
+fn main() {
+}
+


### PR DESCRIPTION
## Summary
- enhance rust compiler to track variable types and detect string roots
- fix indexing logic so list-of-string indices don't use `chars()`
- regenerate LeetCode example outputs for problems 1-7 in rust

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 7 --lang rust --run`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68538ee0cd6483208273ca3a37f328d5