### PR TITLE
Add Kotlin list update support

### DIFF
--- a/examples/leetcode-out/kt/2/add-two-numbers.kt
+++ b/examples/leetcode-out/kt/2/add-two-numbers.kt
@@ -2,7 +2,7 @@ fun addTwoNumbers(l1: List<Int>, l2: List<Int>) : List<Int> {
         var i = 0
         var j = 0
         var carry = 0
-        var result: List<Int> = listOf<Int>()
+        var result: List<Int> = listOf()
         while ((((i < l1.size) || (j < l2.size)) || (carry > 0))) {
                 var x = 0
                 if ((i < l1.size)) {

--- a/examples/leetcode-out/kt/4/median-of-two-sorted-arrays.kt
+++ b/examples/leetcode-out/kt/4/median-of-two-sorted-arrays.kt
@@ -1,5 +1,5 @@
 fun findMedianSortedArrays(nums1: List<Int>, nums2: List<Int>) : Double {
-        var merged: List<Int> = listOf<Int>()
+        var merged: List<Int> = listOf()
         var i = 0
         var j = 0
         while (((i < nums1.size) || (j < nums2.size))) {

--- a/examples/leetcode-out/kt/6/zigzag-conversion.kt
+++ b/examples/leetcode-out/kt/6/zigzag-conversion.kt
@@ -1,0 +1,35 @@
+fun convert(s: String, numRows: Int) : String {
+        if (((numRows <= 1) || (numRows >= s.length))) {
+                return s
+        }
+        var rows: List<String> = listOf()
+        var i = 0
+        while ((i < numRows)) {
+                rows = (rows + listOf(""))
+                i = (i + 1)
+        }
+        var curr = 0
+        var step = 1
+        for (ch in s) {
+                run {
+                        val _tmp = rows.toMutableList()
+                        _tmp[curr] = (rows[curr] + ch)
+                        rows = _tmp
+                }
+                if ((curr == 0)) {
+                        step = 1
+                } else if ((curr == (numRows - 1))) {
+                        step = -1
+                }
+                curr = (curr + step)
+        }
+        var result: String = ""
+        for (row in rows) {
+                result = (result + row)
+        }
+        return result
+}
+
+fun main() {
+}
+


### PR DESCRIPTION
## Summary
- allow empty list literals to compile without default int typing
- track `var` declarations in Kotlin compiler
- generate mutable list updates when assigning into list indices
- regenerate Kotlin LeetCode example for problem 6

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68538ecad3e08320888147c83d3f454b