### PR TITLE
Add clojure outputs for leetcode 1-7

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -115,7 +115,7 @@ go test ./compile/clj -tags slow
 They compare the execution output of generated programs in `tests/compiler/clj` with predefined golden files.
 
 The test suite also compiles and runs the example LeetCode solutions in
-`examples/leetcode/1` through `examples/leetcode/6` to verify that these programs
+`examples/leetcode/1` through `examples/leetcode/7` to verify that these programs
 execute correctly using the Clojure backend.
 
 ## Status

--- a/compile/clj/compiler_test.go
+++ b/compile/clj/compiler_test.go
@@ -160,6 +160,7 @@ func TestClojureCompiler_LeetCodeExamples(t *testing.T) {
 	runLeetExample(t, 2)
 	runLeetExample(t, 3)
 	runLeetExample(t, 4)
-	runLeetExample(t, 5)
-	runLeetExample(t, 6)
+        runLeetExample(t, 5)
+        runLeetExample(t, 6)
+        runLeetExample(t, 7)
 }

--- a/examples/leetcode-out/clj/1/two-sum.clj
+++ b/examples/leetcode-out/clj/1/two-sum.clj
@@ -3,21 +3,49 @@
     (def n (count nums))
     (loop [i 0]
       (when (< i n)
-        (loop [j (+ i 1)]
-          (when (< j n)
-            (when (= (+ (nth nums i) (nth nums j)) target)
-              (throw (ex-info "return" {:value [i j]}))
+        (let [r (try
+          (loop [j (+ i 1)]
+            (when (< j n)
+              (let [r (try
+                (when (= (+ (nth nums i) (nth nums j)) target)
+                  (throw (ex-info "return" {:value [i j]}))
+                )
+                :next
+              (catch clojure.lang.ExceptionInfo e
+                (cond
+                  (= (.getMessage e) "continue") :next
+                  (= (.getMessage e) "break") :break
+                  :else (throw e))
+                )
+              )]
+            (cond
+              (= r :break) nil
+              :else (recur (inc j))
             )
-            (recur (inc j)))
+          )
         )
-        (recur (inc i)))
-    )
-    (throw (ex-info "return" {:value [(- 1) (- 1)]}))
-  (catch clojure.lang.ExceptionInfo e
-    (if (= (.getMessage e) "return")
-      (:value (ex-data e))
-    (throw e)))
+      )
+      :next
+    (catch clojure.lang.ExceptionInfo e
+      (cond
+        (= (.getMessage e) "continue") :next
+        (= (.getMessage e) "break") :break
+        :else (throw e))
+      )
+    )]
+  (cond
+    (= r :break) nil
+    :else (recur (inc i))
   )
+)
+)
+)
+(throw (ex-info "return" {:value [(- 1) (- 1)]}))
+(catch clojure.lang.ExceptionInfo e
+(if (= (.getMessage e) "return")
+(:value (ex-data e))
+(throw e)))
+)
 )
 
 (def result (twoSum [2 7 11 15] 9))

--- a/examples/leetcode-out/clj/2/add-two-numbers.clj
+++ b/examples/leetcode-out/clj/2/add-two-numbers.clj
@@ -4,9 +4,9 @@
     (def j 0)
     (def carry 0)
     (def result [])
-    (try
-      (loop []
-        (when (or (or (< i (count l1)) (< j (count l2))) (> carry 0))
+    (loop []
+      (when (or (or (< i (count l1)) (< j (count l2))) (> carry 0))
+        (let [r (try
           (def x 0)
           (when (< i (count l1))
             (def x (nth l1 i))
@@ -21,18 +21,26 @@
           (def digit (mod sum 10))
           (def carry (quot sum 10))
           (def result (vec (concat result [digit])))
-          (recur)
-        )
+          :next
+        (catch clojure.lang.ExceptionInfo e
+          (cond
+            (= (.getMessage e) "continue") :next
+            (= (.getMessage e) "break") :break
+            :else (throw e))
+          )
+        )]
+      (cond
+        (= r :break) nil
+        (= r :next) (recur)
       )
-    (catch clojure.lang.ExceptionInfo e
-      (when-not (= (.getMessage e) "break") (throw e))
     )
   )
-  (throw (ex-info "return" {:value result}))
+)
+(throw (ex-info "return" {:value result}))
 (catch clojure.lang.ExceptionInfo e
-  (if (= (.getMessage e) "return")
-    (:value (ex-data e))
-  (throw e)))
+(if (= (.getMessage e) "return")
+  (:value (ex-data e))
+(throw e)))
 )
 )
 

--- a/examples/leetcode-out/clj/3/longest-substring-without-repeating-characters.clj
+++ b/examples/leetcode-out/clj/3/longest-substring-without-repeating-characters.clj
@@ -4,41 +4,57 @@
     (def start 0)
     (def best 0)
     (def i 0)
-    (try
-      (loop []
-        (when (< i n)
+    (loop []
+      (when (< i n)
+        (let [r (try
           (def j start)
-          (try
-            (loop []
-              (when (< j i)
+          (loop []
+            (when (< j i)
+              (let [r (try
                 (when (= (nth s j) (nth s i))
                   (def start (+ j 1))
                   (throw (ex-info "break" {}))
                 )
                 (def j (+ j 1))
-                (recur)
-              )
+                :next
+              (catch clojure.lang.ExceptionInfo e
+                (cond
+                  (= (.getMessage e) "continue") :next
+                  (= (.getMessage e) "break") :break
+                  :else (throw e))
+                )
+              )]
+            (cond
+              (= r :break) nil
+              (= r :next) (recur)
             )
-          (catch clojure.lang.ExceptionInfo e
-            (when-not (= (.getMessage e) "break") (throw e))
           )
         )
-        (def length (+ (- i start) 1))
-        (when (> length best)
-          (def best length)
-        )
-        (def i (+ i 1))
-        (recur)
       )
-    )
-  (catch clojure.lang.ExceptionInfo e
-    (when-not (= (.getMessage e) "break") (throw e))
+      (def length (+ (- i start) 1))
+      (when (> length best)
+        (def best length)
+      )
+      (def i (+ i 1))
+      :next
+    (catch clojure.lang.ExceptionInfo e
+      (cond
+        (= (.getMessage e) "continue") :next
+        (= (.getMessage e) "break") :break
+        :else (throw e))
+      )
+    )]
+  (cond
+    (= r :break) nil
+    (= r :next) (recur)
   )
+)
+)
 )
 (throw (ex-info "return" {:value best}))
 (catch clojure.lang.ExceptionInfo e
 (if (= (.getMessage e) "return")
-  (:value (ex-data e))
+(:value (ex-data e))
 (throw e)))
 )
 )

--- a/examples/leetcode-out/clj/4/median-of-two-sorted-arrays.clj
+++ b/examples/leetcode-out/clj/4/median-of-two-sorted-arrays.clj
@@ -3,9 +3,9 @@
     (def merged [])
     (def i 0)
     (def j 0)
-    (try
-      (loop []
-        (when (or (< i (count nums1)) (< j (count nums2)))
+    (loop []
+      (when (or (< i (count nums1)) (< j (count nums2)))
+        (let [r (try
           (if (>= j (count nums2))
             (do
               (def merged (vec (concat merged [(nth nums1 i)])))
@@ -31,24 +31,32 @@
           )
           )
           )
-          (recur)
-        )
+          :next
+        (catch clojure.lang.ExceptionInfo e
+          (cond
+            (= (.getMessage e) "continue") :next
+            (= (.getMessage e) "break") :break
+            :else (throw e))
+          )
+        )]
+      (cond
+        (= r :break) nil
+        (= r :next) (recur)
       )
-    (catch clojure.lang.ExceptionInfo e
-      (when-not (= (.getMessage e) "break") (throw e))
     )
   )
-  (def total (count merged))
-  (when (= (mod total 2) 1)
-    (throw (ex-info "return" {:value (double (nth merged (quot total 2)))}))
-  )
-  (def mid1 (nth merged (- (quot total 2) 1)))
-  (def mid2 (nth merged (quot total 2)))
-  (throw (ex-info "return" {:value (/ (double (+ mid1 mid2)) 2.0)}))
+)
+(def total (count merged))
+(when (= (mod total 2) 1)
+  (throw (ex-info "return" {:value (double (nth merged (quot total 2)))}))
+)
+(def mid1 (nth merged (- (quot total 2) 1)))
+(def mid2 (nth merged (quot total 2)))
+(throw (ex-info "return" {:value (/ (double (+ mid1 mid2)) 2.0)}))
 (catch clojure.lang.ExceptionInfo e
-  (if (= (.getMessage e) "return")
-    (:value (ex-data e))
-  (throw e)))
+(if (= (.getMessage e) "return")
+  (:value (ex-data e))
+(throw e)))
 )
 )
 

--- a/examples/leetcode-out/clj/5/longest-palindromic-substring.clj
+++ b/examples/leetcode-out/clj/5/longest-palindromic-substring.clj
@@ -3,39 +3,48 @@
     (def l left)
     (def r right)
     (def n (count s))
-    (try
-      (loop []
-        (when (and (>= l 0) (< r n))
+    (loop []
+      (when (and (>= l 0) (< r n))
+        (let [r (try
           (when (not= (nth s l) (nth s r))
             (throw (ex-info "break" {}))
           )
           (def l (- l 1))
           (def r (+ r 1))
-          (recur)
-        )
+          :next
+        (catch clojure.lang.ExceptionInfo e
+          (cond
+            (= (.getMessage e) "continue") :next
+            (= (.getMessage e) "break") :break
+            :else (throw e))
+          )
+        )]
+      (cond
+        (= r :break) nil
+        (= r :next) (recur)
       )
-    (catch clojure.lang.ExceptionInfo e
-      (when-not (= (.getMessage e) "break") (throw e))
     )
   )
-  (throw (ex-info "return" {:value (- (- r l) 1)}))
+)
+(throw (ex-info "return" {:value (- (- r l) 1)}))
 (catch clojure.lang.ExceptionInfo e
-  (if (= (.getMessage e) "return")
-    (:value (ex-data e))
-  (throw e)))
+(if (= (.getMessage e) "return")
+  (:value (ex-data e))
+(throw e)))
 )
 )
 
 (defn longestPalindrome [s]
 (try
-  (when (<= (count s) 1)
-    (throw (ex-info "return" {:value s}))
-  )
-  (def start 0)
-  (def end 0)
-  (def n (count s))
-  (loop [i 0]
-    (when (< i n)
+(when (<= (count s) 1)
+  (throw (ex-info "return" {:value s}))
+)
+(def start 0)
+(def end 0)
+(def n (count s))
+(loop [i 0]
+  (when (< i n)
+    (let [r (try
       (def len1 (expand s i i))
       (def len2 (expand s i (+ i 1)))
       (def l len1)
@@ -46,13 +55,26 @@
         (def start (- i (quot (- l 1) 2)))
         (def end (+ i (quot l 2)))
       )
-      (recur (inc i)))
+      :next
+    (catch clojure.lang.ExceptionInfo e
+      (cond
+        (= (.getMessage e) "continue") :next
+        (= (.getMessage e) "break") :break
+        :else (throw e))
+      )
+    )]
+  (cond
+    (= r :break) nil
+    :else (recur (inc i))
   )
-  (throw (ex-info "return" {:value (subs s start (+ end 1))}))
+)
+)
+)
+(throw (ex-info "return" {:value (subs s start (+ end 1))}))
 (catch clojure.lang.ExceptionInfo e
-  (if (= (.getMessage e) "return")
-    (:value (ex-data e))
-  (throw e)))
+(if (= (.getMessage e) "return")
+(:value (ex-data e))
+(throw e)))
 )
 )
 

--- a/examples/leetcode-out/clj/7/reverse-integer.clj
+++ b/examples/leetcode-out/clj/7/reverse-integer.clj
@@ -1,0 +1,62 @@
+(defn reverse [x]
+  (try
+    (def sign 1)
+    (def n x)
+    (when (< n 0)
+      (def sign (- 1))
+      (def n (- n))
+    )
+    (def rev 0)
+    (loop []
+      (when (not= n 0)
+        (let [r (try
+          (def digit (mod n 10))
+          (def rev (+ (* rev 10) digit))
+          (def n (quot n 10))
+          :next
+        (catch clojure.lang.ExceptionInfo e
+          (cond
+            (= (.getMessage e) "continue") :next
+            (= (.getMessage e) "break") :break
+            :else (throw e))
+          )
+        )]
+      (cond
+        (= r :break) nil
+        (= r :next) (recur)
+      )
+    )
+  )
+)
+(def rev (* rev sign))
+(when (or (< rev (- (- 2147483647) 1)) (> rev 2147483647))
+  (throw (ex-info "return" {:value 0}))
+)
+(throw (ex-info "return" {:value rev}))
+(catch clojure.lang.ExceptionInfo e
+(if (= (.getMessage e) "return")
+  (:value (ex-data e))
+(throw e)))
+)
+)
+
+(defn test_example_1 []
+(assert (= (reverse 123) 321))
+)
+
+(defn test_example_2 []
+(assert (= (reverse (- 123)) (- 321)))
+)
+
+(defn test_example_3 []
+(assert (= (reverse 120) 21))
+)
+
+(defn test_overflow []
+(assert (= (reverse 1534236469) 0))
+)
+
+(test_example_1)
+(test_example_2)
+(test_example_3)
+(test_overflow)


### PR DESCRIPTION
## Summary
- regenerate Clojure outputs for leetcode examples and include problem 7
- test LeetCode example 7 from the Clojure backend
- document that examples 1-7 are tested

## Testing
- `make test`
- `go test ./compile/clj -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6853910a0ea48320a632df82a04de5df