### PR TITLE
Add Kotlin output for LeetCode 7 and extend tests

### DIFF
--- a/compile/kt/compiler_test.go
+++ b/compile/kt/compiler_test.go
@@ -62,6 +62,8 @@ func TestKTCompiler_LeetCodeExamples(t *testing.T) {
 	runKTLeetExample(t, 3)
 	runKTLeetExample(t, 4)
 	runKTLeetExample(t, 5)
+	runKTLeetExample(t, 6)
+	runKTLeetExample(t, 7)
 }
 
 func TestKTCompiler_SubsetPrograms(t *testing.T) {

--- a/examples/leetcode-out/kt/7/reverse-integer.kt
+++ b/examples/leetcode-out/kt/7/reverse-integer.kt
@@ -1,0 +1,23 @@
+fun reverse(x: Int) : Int {
+        var sign = 1
+        var n = x
+        if ((n < 0)) {
+                sign = -1
+                n = -n
+        }
+        var rev = 0
+        while ((n != 0)) {
+                val digit = (n % 10)
+                rev = ((rev * 10) + digit)
+                n = (n / 10)
+        }
+        rev = (rev * sign)
+        if (((rev < ((-2147483647 - 1))) || (rev > 2147483647))) {
+                return 0
+        }
+        return rev
+}
+
+fun main() {
+}
+


### PR DESCRIPTION
## Summary
- compile LeetCode problem 7 to Kotlin output
- extend Kotlin compiler tests to cover LeetCode problems 6 and 7

## Testing
- `go test ./compile/kt -run TestKTCompiler_LeetCodeExamples -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6853931820ec8320b5aefef4f64bf5c2