### PR TITLE
Add Rust LeetCode examples 1-8

### DIFF
--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -111,6 +111,15 @@ func TestRustCompiler_ValidPrograms(t *testing.T) {
 	t.Run("leetcode_5", func(t *testing.T) {
 		runRustLeet(t, 5)
 	})
+	t.Run("leetcode_6", func(t *testing.T) {
+		runRustLeet(t, 6)
+	})
+	t.Run("leetcode_7", func(t *testing.T) {
+		runRustLeet(t, 7)
+	})
+	t.Run("leetcode_8", func(t *testing.T) {
+		runRustLeet(t, 8)
+	})
 }
 
 func runRustProgram(t *testing.T, src string) {

--- a/compile/rust/helpers.go
+++ b/compile/rust/helpers.go
@@ -80,3 +80,25 @@ func (c *Compiler) isStringRoot(p *parser.PostfixExpr) bool {
 	}
 	return false
 }
+
+// isStringBase reports whether the target of a postfix expression is a string
+// literal or string variable without any indexing applied.
+func (c *Compiler) isStringBase(p *parser.PostfixExpr) bool {
+	if p == nil || p.Target == nil {
+		return false
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return true
+	}
+	sel := p.Target.Selector
+	if sel != nil && len(sel.Tail) == 0 {
+		if c.env != nil {
+			if t, err := c.env.GetVar(sel.Root); err == nil {
+				if _, ok := t.(types.StringType); ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/examples/leetcode-out/rust/8/string-to-integer-atoi.rs
+++ b/examples/leetcode-out/rust/8/string-to-integer-atoi.rs
@@ -1,0 +1,70 @@
+fn digit(ch: &str) -> i32 {
+    if ch == "0" {
+        return 0;
+    }
+    if ch == "1" {
+        return 1;
+    }
+    if ch == "2" {
+        return 2;
+    }
+    if ch == "3" {
+        return 3;
+    }
+    if ch == "4" {
+        return 4;
+    }
+    if ch == "5" {
+        return 5;
+    }
+    if ch == "6" {
+        return 6;
+    }
+    if ch == "7" {
+        return 7;
+    }
+    if ch == "8" {
+        return 8;
+    }
+    if ch == "9" {
+        return 9;
+    }
+    return -1;
+}
+
+fn myAtoi(s: &str) -> i32 {
+    let mut i = 0;
+    let mut n = s.len() as i32;
+    while i < n && s.chars().nth((i) as usize).unwrap() == " ".chars().nth((0) as usize).unwrap() {
+        i = i + 1;
+    }
+    let mut sign = 1;
+    if i < n && (s.chars().nth((i) as usize).unwrap() == "+".chars().nth((0) as usize).unwrap() || s.chars().nth((i) as usize).unwrap() == "-".chars().nth((0) as usize).unwrap()) {
+        if s.chars().nth((i) as usize).unwrap() == "-".chars().nth((0) as usize).unwrap() {
+            sign = -1;
+        }
+        i = i + 1;
+    }
+    let mut result = 0;
+    while i < n {
+        let mut ch = s[((i) as usize)..((i + 1) as usize)].to_string();
+        let mut d = digit(&ch);
+        if d < 0 {
+            break;
+        }
+        result = result * 10 + d;
+        i = i + 1;
+    }
+    result = result * sign;
+    if result > 2147483647 {
+        return 2147483647;
+    }
+    if result < (-2147483648) {
+        return -2147483648;
+    }
+    return result;
+}
+
+fn main() {
+}
+


### PR DESCRIPTION
## Summary
- extend Rust compiler test coverage to LeetCode problems 6-8
- fix Rust code generation for string indexing and argument passing
- regenerate LeetCode example 8 for Rust

## Testing
- `go test ./compile/rust -tags slow -run TestRustCompiler_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68539322253483208d3eca208b219250