### PR TITLE
Regenerate Rust leetcode output

### DIFF
--- a/examples/leetcode-out/rust/5/longest-palindromic-substring.rs
+++ b/examples/leetcode-out/rust/5/longest-palindromic-substring.rs
@@ -20,8 +20,8 @@ fn longestPalindrome(s: &str) -> String {
     let mut end = 0;
     let mut n = s.len() as i32;
     for i in 0..n {
-        let mut len1 = expand(s, i, i);
-        let mut len2 = expand(s, i, i + 1);
+        let mut len1 = expand(&s, i, i);
+        let mut len2 = expand(&s, i, i + 1);
         let mut l = len1;
         if len2 > len1 {
             l = len2;

--- a/examples/leetcode-out/rust/9/palindrome-number.rs
+++ b/examples/leetcode-out/rust/9/palindrome-number.rs
@@ -1,0 +1,17 @@
+fn isPalindrome(x: i32) -> bool {
+    if x < 0 {
+        return false;
+    }
+    let mut s: String = format!("{}", x);
+    let mut n = s.len() as i32;
+    for i in 0..n / 2 {
+        if s.chars().nth((i) as usize).unwrap() != s.chars().nth((n - 1 - i) as usize).unwrap() {
+            return false;
+        }
+    }
+    return true;
+}
+
+fn main() {
+}
+

--- a/examples/leetcode/9/palindrome-number.mochi
+++ b/examples/leetcode/9/palindrome-number.mochi
@@ -2,7 +2,7 @@ fun isPalindrome(x: int): bool {
   if x < 0 {
     return false
   }
-  let s = str(x)
+  let s: string = str(x)
   let n = len(s)
   for i in 0..n/2 {
     if s[i] != s[n-1-i] {


### PR DESCRIPTION
## Summary
- regenerate `longest-palindromic-substring` Rust solution
- ensure `palindrome-number` uses typed string for Rust generation

## Testing
- `go test ./...`
- `for i in {1..9}; do echo "Testing $i"; go run cmd/leetcode-runner/main.go test $i; done`


------
https://chatgpt.com/codex/tasks/task_e_68539f2daee88320ad51b8faee723591