### PR TITLE
Improve Pascal backend type handling

### DIFF
--- a/examples/leetcode-out/pas/1/two-sum.pas
+++ b/examples/leetcode-out/pas/1/two-sum.pas
@@ -1,10 +1,11 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
-function twoSum(nums: TIntArray; target: integer): TIntArray;
+function twoSum(nums: specialize TArray<integer>; target: integer): specialize TArray<integer>;
 var
 	i: integer;
 	j: integer;
@@ -17,20 +18,20 @@ begin
 		begin
 			if (nums[i] + nums[j] = target) then
 			begin
-				result := TIntArray([i, j]);
+				result := specialize TArray<integer>([i, j]);
 				exit;
 			end;
 		end;
 	end;
-	result := TIntArray([-1, -1]);
+	result := specialize TArray<integer>([-1, -1]);
 	exit;
 end;
 
 var
-	_result: TIntArray;
+	_result: specialize TArray<integer>;
 
 begin
-	_result := twoSum(TIntArray([2, 7, 11, 15]), 9);
+	_result := twoSum(specialize TArray<integer>([2, 7, 11, 15]), 9);
 	writeln(_result[0]);
 	writeln(_result[1]);
 end.

--- a/examples/leetcode-out/pas/10/regular-expression-matching.pas
+++ b/examples/leetcode-out/pas/10/regular-expression-matching.pas
@@ -2,75 +2,76 @@ program main;
 {$mode objfpc}
 uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
 function isMatch(s: string; p: string): boolean;
 var
+	dp: specialize TArray<specialize TArray<boolean>>;
+	first: integer;
+	i: integer;
+	i2: integer;
+	j: integer;
+	j2: integer;
 	m: integer;
-	memo: integer;
 	n: integer;
+	row: specialize TArray<boolean>;
 begin
 	m := Length(s);
 	n := Length(p);
-	var _tmp0: specialize TFPGMap<string, integer>;
-	_tmp0 := specialize TFPGMap<string, integer>.Create;
-	memo := _tmp0;
-	function dfs(i: integer; j: integer): boolean;
-	var
-		ans: integer;
-		first: integer;
-		key: integer;
+	dp := specialize TArray<specialize TArray<boolean>>([]);
+	i := 0;
+	while (i <= m) do
 	begin
-		key := i * n + 1 + j;
-		if (key in memo) then
+		row := specialize TArray<boolean>([]);
+		j := 0;
+		while (j <= n) do
 		begin
-			result := memo[key];
-			exit;
+			row := Concat(row, specialize TArray<boolean>([False]));
+			j := j + 1;
 		end;
-		if (j = n) then
+		dp := Concat(dp, specialize TArray<specialize TArray<boolean>>([row]));
+		i := i + 1;
+	end;
+	dp[m][n] := True;
+	i2 := m;
+	while (i2 >= 0) do
+	begin
+		j2 := n - 1;
+		while (j2 >= 0) do
 		begin
-			result := (i = m);
-			exit;
-		end;
-		first := False;
-		if (i < m) then
-		begin
-			if ((p[j] = s[i]) or (p[j] = '.')) then
+			first := False;
+			if (i2 < m) then
 			begin
-				first := True;
+				if ((p[j2] = s[i2]) or (p[j2] = '.')) then
+				begin
+					first := True;
+				end;
 			end;
-		end;
-		ans := False;
-		if (j + 1 < n) then
-		begin
-			if (p[j + 1] = '*') then
+			if ((j2 + 1 < n) and (p[j2 + 1] = '*')) then
 			begin
-				if dfs(i, j + 2) then
+				if (dp[i2][j2 + 2] or (first and dp[i2 + 1][j2])) then
 				begin
-					ans := True;
-				end else if (first and dfs(i + 1, j)) then
+					dp[i2][j2] := True;
+				end else
 				begin
-					ans := True;
+					dp[i2][j2] := False;
 				end;
 			end else
 			begin
-				if (first and dfs(i + 1, j + 1)) then
+				if (first and dp[i2 + 1][j2 + 1]) then
 				begin
-					ans := True;
+					dp[i2][j2] := True;
+				end else
+				begin
+					dp[i2][j2] := False;
 				end;
 			end;
-		end else
-		begin
-			if (first and dfs(i + 1, j + 1)) then
-			begin
-				ans := True;
-			end;
+			j2 := j2 - 1;
 		end;
-		memo[key] := ans;
-		result := ans;
-		exit;
+		i2 := i2 - 1;
 	end;
-	result := dfs(0, 0);
+	result := dp[0][0];
 	exit;
 end;
 

--- a/examples/leetcode-out/pas/2/add-two-numbers.pas
+++ b/examples/leetcode-out/pas/2/add-two-numbers.pas
@@ -1,16 +1,17 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
-function addTwoNumbers(l1: TIntArray; l2: TIntArray): TIntArray;
+function addTwoNumbers(l1: specialize TArray<integer>; l2: specialize TArray<integer>): specialize TArray<integer>;
 var
 	carry: integer;
 	digit: integer;
 	i: integer;
 	j: integer;
-	_result: TIntArray;
+	_result: specialize TArray<integer>;
 	sum: integer;
 	x: integer;
 	y: integer;
@@ -18,7 +19,7 @@ begin
 	i := 0;
 	j := 0;
 	carry := 0;
-	_result := TIntArray([]);
+	_result := specialize TArray<integer>([]);
 	while (((i < Length(l1)) or (j < Length(l2))) or (carry > 0)) do
 	begin
 		x := 0;
@@ -36,7 +37,7 @@ begin
 		sum := x + y + carry;
 		digit := sum mod 10;
 		carry := sum div 10;
-		_result := Concat(_result, TIntArray([digit]));
+		_result := Concat(_result, specialize TArray<integer>([digit]));
 	end;
 	result := _result;
 	exit;

--- a/examples/leetcode-out/pas/3/longest-substring-without-repeating-characters.pas
+++ b/examples/leetcode-out/pas/3/longest-substring-without-repeating-characters.pas
@@ -1,8 +1,9 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
 function lengthOfLongestSubstring(s: string): integer;
 var

--- a/examples/leetcode-out/pas/4/median-of-two-sorted-arrays.pas
+++ b/examples/leetcode-out/pas/4/median-of-two-sorted-arrays.pas
@@ -1,38 +1,39 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
-function findMedianSortedArrays(nums1: TIntArray; nums2: TIntArray): double;
+function findMedianSortedArrays(nums1: specialize TArray<integer>; nums2: specialize TArray<integer>): double;
 var
 	i: integer;
 	j: integer;
-	merged: TIntArray;
+	merged: specialize TArray<integer>;
 	mid1: integer;
 	mid2: integer;
 	total: integer;
 begin
-	merged := TIntArray([]);
+	merged := specialize TArray<integer>([]);
 	i := 0;
 	j := 0;
 	while ((i < Length(nums1)) or (j < Length(nums2))) do
 	begin
 		if (j >= Length(nums2)) then
 		begin
-			merged := Concat(merged, TIntArray([nums1[i]]));
+			merged := Concat(merged, specialize TArray<integer>([nums1[i]]));
 			i := i + 1;
 		end else if (i >= Length(nums1)) then
 		begin
-			merged := Concat(merged, TIntArray([nums2[j]]));
+			merged := Concat(merged, specialize TArray<integer>([nums2[j]]));
 			j := j + 1;
 		end else if (nums1[i] <= nums2[j]) then
 		begin
-			merged := Concat(merged, TIntArray([nums1[i]]));
+			merged := Concat(merged, specialize TArray<integer>([nums1[i]]));
 			i := i + 1;
 		end else
 		begin
-			merged := Concat(merged, TIntArray([nums2[j]]));
+			merged := Concat(merged, specialize TArray<integer>([nums2[j]]));
 			j := j + 1;
 		end;
 	end;

--- a/examples/leetcode-out/pas/5/longest-palindromic-substring.pas
+++ b/examples/leetcode-out/pas/5/longest-palindromic-substring.pas
@@ -1,8 +1,9 @@
 program main;
 {$mode objfpc}
-uses SysUtils;
+uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
 function expand(s: string; left: integer; right: integer): integer;
 var
@@ -30,12 +31,10 @@ function longestPalindrome(s: string): string;
 var
 	_end: integer;
 	i: integer;
-	k: integer;
 	l: integer;
 	len1: integer;
 	len2: integer;
 	n: integer;
-	res: string;
 	start: integer;
 begin
 	if (Length(s) <= 1) then
@@ -61,14 +60,7 @@ begin
 			_end := i + l div 2;
 		end;
 	end;
-	res := '';
-	k := start;
-	while (k <= _end) do
-	begin
-		res := res + s[k];
-		k := k + 1;
-	end;
-	result := res;
+	result := s[start];
 	exit;
 end;
 

--- a/examples/leetcode-out/pas/6/zigzag-conversion.pas
+++ b/examples/leetcode-out/pas/6/zigzag-conversion.pas
@@ -2,16 +2,17 @@ program main;
 {$mode objfpc}
 uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
 function convert(s: string; numRows: integer): string;
 var
-	ch: integer;
+	ch: char;
 	curr: integer;
 	i: integer;
 	_result: string;
-	row: integer;
-	rows: TIntArray;
+	row: string;
+	rows: specialize TArray<string>;
 	step: integer;
 begin
 	if ((numRows <= 1) or (numRows >= Length(s))) then
@@ -19,11 +20,11 @@ begin
 		result := s;
 		exit;
 	end;
-	rows := TIntArray([]);
+	rows := specialize TArray<string>([]);
 	i := 0;
 	while (i < numRows) do
 	begin
-		rows := Concat(rows, TIntArray(['']));
+		rows := Concat(rows, specialize TArray<string>(['']));
 		i := i + 1;
 	end;
 	curr := 0;

--- a/examples/leetcode-out/pas/7/reverse-integer.pas
+++ b/examples/leetcode-out/pas/7/reverse-integer.pas
@@ -2,7 +2,8 @@ program main;
 {$mode objfpc}
 uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
 function reverse(x: integer): integer;
 var

--- a/examples/leetcode-out/pas/8/string-to-integer-atoi.pas
+++ b/examples/leetcode-out/pas/8/string-to-integer-atoi.pas
@@ -2,13 +2,69 @@ program main;
 {$mode objfpc}
 uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
+
+function digit(ch: string): integer;
+begin
+	if (ch = '0') then
+	begin
+		result := 0;
+		exit;
+	end;
+	if (ch = '1') then
+	begin
+		result := 1;
+		exit;
+	end;
+	if (ch = '2') then
+	begin
+		result := 2;
+		exit;
+	end;
+	if (ch = '3') then
+	begin
+		result := 3;
+		exit;
+	end;
+	if (ch = '4') then
+	begin
+		result := 4;
+		exit;
+	end;
+	if (ch = '5') then
+	begin
+		result := 5;
+		exit;
+	end;
+	if (ch = '6') then
+	begin
+		result := 6;
+		exit;
+	end;
+	if (ch = '7') then
+	begin
+		result := 7;
+		exit;
+	end;
+	if (ch = '8') then
+	begin
+		result := 8;
+		exit;
+	end;
+	if (ch = '9') then
+	begin
+		result := 9;
+		exit;
+	end;
+	result := -1;
+	exit;
+end;
 
 function myAtoi(s: string): integer;
 var
 	ch: integer;
 	d: integer;
-	digits: integer;
 	i: integer;
 	n: integer;
 	_result: integer;
@@ -29,28 +85,15 @@ begin
 		end;
 		i := i + 1;
 	end;
-	var _tmp0: specialize TFPGMap<string, integer>;
-	_tmp0 := specialize TFPGMap<string, integer>.Create;
-	_tmp0.AddOrSetData('0', 0);
-	_tmp0.AddOrSetData('1', 1);
-	_tmp0.AddOrSetData('2', 2);
-	_tmp0.AddOrSetData('3', 3);
-	_tmp0.AddOrSetData('4', 4);
-	_tmp0.AddOrSetData('5', 5);
-	_tmp0.AddOrSetData('6', 6);
-	_tmp0.AddOrSetData('7', 7);
-	_tmp0.AddOrSetData('8', 8);
-	_tmp0.AddOrSetData('9', 9);
-	digits := _tmp0;
 	_result := 0;
 	while (i < n) do
 	begin
 		ch := s[i];
-		if not (ch in digits) then
+		d := digit(ch);
+		if (d < 0) then
 		begin
 			break;
 		end;
-		d := digits[ch];
 		_result := _result * 10 + d;
 		i := i + 1;
 	end;

--- a/examples/leetcode-out/pas/9/palindrome-number.pas
+++ b/examples/leetcode-out/pas/9/palindrome-number.pas
@@ -2,7 +2,8 @@ program main;
 {$mode objfpc}
 uses SysUtils, fgl;
 
-type TIntArray = array of integer;
+type
+	generic TArray<T> = array of T;
 
 function isPalindrome(x: integer): boolean;
 var
@@ -15,7 +16,7 @@ begin
 		result := False;
 		exit;
 	end;
-	s := str(x);
+	s := IntToStr(x);
 	n := Length(s);
 	for i := 0 to n div 2 - 1 do
 	begin


### PR DESCRIPTION
## Summary
- add var type map and inference helpers in Pascal compiler
- track local variable types during function compilation
- refine helper functions to detect map/list types
- regenerate Pascal solutions

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 10 -l pas`
- `go run ./cmd/leetcode-runner build --from 1 --to 10 -l pas --run` *(fails: fpc errors)*

------
https://chatgpt.com/codex/tasks/task_e_685380aa3d9483208872ec09ee718f4e