### PR TITLE
Fix clj compiler golden tests

### DIFF
--- a/tests/compiler/clj/break_continue.clj.out
+++ b/tests/compiler/clj/break_continue.clj.out
@@ -4,7 +4,7 @@
   (def numbers [1 2 3 4 5 6 7 8 9])
   (loop [_tmp0 (seq numbers)]
     (when _tmp0
-      (let [n (first _tmp0)]
+      (let [n (clojure.core/first _tmp0)]
         (let [r (try
           (when (= (mod n 2) 0)
             (throw (ex-info "continue" {}))

--- a/tests/compiler/clj/string_for_loop.clj.out
+++ b/tests/compiler/clj/string_for_loop.clj.out
@@ -3,7 +3,7 @@
 (defn -main []
   (loop [_tmp0 (seq "cat")]
     (when _tmp0
-      (let [ch (first _tmp0)]
+      (let [ch (clojure.core/first _tmp0)]
         (let [r (try
           (println ch)
           :next


### PR DESCRIPTION
## Summary
- update clojure golden output to use `clojure.core/first`

## Testing
- `go test ./compile/clj -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6853d451545883208f77bd31b9458036