### PR TITLE
Fix Dart compiler type tracking

### DIFF
--- a/compile/dart/compiler.go
+++ b/compile/dart/compiler.go
@@ -160,6 +160,9 @@ func (c *Compiler) compileLet(s *parser.LetStmt) error {
 			c.writeln(fmt.Sprintf("dynamic %s = %s;", name, val))
 		}
 	}
+	if c.env != nil && typ != nil && !isAny(typ) {
+		c.env.SetVar(s.Name, typ, false)
+	}
 	return nil
 }
 
@@ -283,6 +286,9 @@ func (c *Compiler) compileVar(s *parser.VarStmt) error {
 		} else {
 			c.writeln(fmt.Sprintf("dynamic %s = %s;", name, val))
 		}
+	}
+	if c.env != nil && typ != nil && !isAny(typ) {
+		c.env.SetVar(s.Name, typ, true)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- improve Dart compiler by recording local variable types in the environment

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853d4d392d08320a9e15a767247cc1f