### PR TITLE
Update F# docs

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -80,7 +80,7 @@ The F# tests are tagged `slow` because they invoke the .NET toolchain. Run them 
 go test ./compile/fs -tags slow
 ```
 
-This command compiles the subset programs in `tests/compiler/fs` and also runs the example solutions for LeetCode problems 1–8 to ensure the generated F# code behaves correctly.
+This command compiles the subset programs in `tests/compiler/fs` and also runs the example solutions for LeetCode problems 1–10 to ensure the generated F# code behaves correctly.
 
 
 The tests compile Mochi sources from `tests/compiler/fs` and execute them with `dotnet fsi`:


### PR DESCRIPTION
## Summary
- clarify that F# compiler tests cover LeetCode problems 1–10

## Testing
- `go test ./compile/fs -tags slow -run LeetCodeExamples -v`

------
https://chatgpt.com/codex/tasks/task_e_6853d4dbab048320af44e116e500ba08