### PR TITLE
Enable Pascal slice support for LeetCode examples

### DIFF
--- a/examples/leetcode-out/pas/10/regular-expression-matching.pas
+++ b/examples/leetcode-out/pas/10/regular-expression-matching.pas
@@ -8,7 +8,7 @@ type
 function isMatch(s: string; p: string): boolean;
 var
 	dp: specialize TArray<specialize TArray<boolean>>;
-	first: integer;
+	first: boolean;
 	i: integer;
 	i2: integer;
 	j: integer;
@@ -16,6 +16,7 @@ var
 	m: integer;
 	n: integer;
 	row: specialize TArray<boolean>;
+	star: boolean;
 begin
 	m := Length(s);
 	n := Length(p);
@@ -43,12 +44,20 @@ begin
 			first := False;
 			if (i2 < m) then
 			begin
-				if ((p[j2] = s[i2]) or (p[j2] = '.')) then
+				if ((p[j2 + 1] = s[i2 + 1]) or (p[j2 + 1] = '.')) then
 				begin
 					first := True;
 				end;
 			end;
-			if ((j2 + 1 < n) and (p[j2 + 1] = '*')) then
+			star := False;
+			if (j2 + 1 < n) then
+			begin
+				if (p[j2 + 1 + 1] = '*') then
+				begin
+					star := True;
+				end;
+			end;
+			if star then
 			begin
 				if (dp[i2][j2 + 2] or (first and dp[i2 + 1][j2])) then
 				begin

--- a/examples/leetcode-out/pas/3/longest-substring-without-repeating-characters.pas
+++ b/examples/leetcode-out/pas/3/longest-substring-without-repeating-characters.pas
@@ -23,7 +23,7 @@ begin
 		j := start;
 		while (j < i) do
 		begin
-			if (s[j] = s[i]) then
+			if (s[j + 1] = s[i + 1]) then
 			begin
 				start := j + 1;
 				break;

--- a/examples/leetcode-out/pas/5/longest-palindromic-substring.pas
+++ b/examples/leetcode-out/pas/5/longest-palindromic-substring.pas
@@ -16,7 +16,7 @@ begin
 	n := Length(s);
 	while ((l >= 0) and (r < n)) do
 	begin
-		if (s[l] <> s[r]) then
+		if (s[l + 1] <> s[r + 1]) then
 		begin
 			break;
 		end;
@@ -60,7 +60,7 @@ begin
 			_end := i + l div 2;
 		end;
 	end;
-	result := s[start];
+	result := Copy(s, start + 1, (_end + 1 - start));
 	exit;
 end;
 

--- a/examples/leetcode-out/pas/8/string-to-integer-atoi.pas
+++ b/examples/leetcode-out/pas/8/string-to-integer-atoi.pas
@@ -63,7 +63,7 @@ end;
 
 function myAtoi(s: string): integer;
 var
-	ch: integer;
+	ch: string;
 	d: integer;
 	i: integer;
 	n: integer;
@@ -72,14 +72,14 @@ var
 begin
 	i := 0;
 	n := Length(s);
-	while ((i < n) and (s[i] = ' ')) do
+	while ((i < n) and (s[i + 1] = ' ')) do
 	begin
 		i := i + 1;
 	end;
 	sign := 1;
-	if ((i < n) and ((s[i] = '+') or (s[i] = '-'))) then
+	if ((i < n) and ((s[i + 1] = '+') or (s[i + 1] = '-'))) then
 	begin
-		if (s[i] = '-') then
+		if (s[i + 1] = '-') then
 		begin
 			sign := -1;
 		end;
@@ -88,7 +88,7 @@ begin
 	_result := 0;
 	while (i < n) do
 	begin
-		ch := s[i];
+		ch := Copy(s, i + 1, (i + 1 - i));
 		d := digit(ch);
 		if (d < 0) then
 		begin

--- a/examples/leetcode-out/pas/9/palindrome-number.pas
+++ b/examples/leetcode-out/pas/9/palindrome-number.pas
@@ -9,7 +9,7 @@ function isPalindrome(x: integer): boolean;
 var
 	i: integer;
 	n: integer;
-	s: integer;
+	s: string;
 begin
 	if (x < 0) then
 	begin
@@ -20,7 +20,7 @@ begin
 	n := Length(s);
 	for i := 0 to n div 2 - 1 do
 	begin
-		if (s[i] <> s[n - 1 - i]) then
+		if (s[i + 1] <> s[n - 1 - i + 1]) then
 		begin
 			result := False;
 			exit;


### PR DESCRIPTION
## Summary
- improve Pascal backend variable type inference
- add helpers for string slice detection and bool literals
- support string slice indexing in Pascal generator
- update generated Pascal solutions for LeetCode problems

## Testing
- `go test ./...`
- `go run ./cmd/leetcode-runner build -l pas --from 1 --to 10 --run`

------
https://chatgpt.com/codex/tasks/task_e_6853d4ec52748320bb1e4e350a94ffdc