### PR TITLE
Add PHP tests for LeetCode 1‑10

### DIFF
--- a/compile/php/README.md
+++ b/compile/php/README.md
@@ -271,6 +271,21 @@ php median.php
 
 mochi build --target php ../../examples/leetcode/5/longest-palindromic-substring.mochi -o palindrome.php
 php palindrome.php
+
+mochi build --target php ../../examples/leetcode/6/zigzag-conversion.mochi -o zigzag-conversion.php
+php zigzag-conversion.php
+
+mochi build --target php ../../examples/leetcode/7/reverse-integer.mochi -o reverse-integer.php
+php reverse-integer.php
+
+mochi build --target php ../../examples/leetcode/8/string-to-integer-atoi.mochi -o atoi.php
+php atoi.php
+
+mochi build --target php ../../examples/leetcode/9/palindrome-number.mochi -o palindrome-number.php
+php palindrome-number.php
+
+mochi build --target php ../../examples/leetcode/10/regular-expression-matching.mochi -o regular-expression-matching.php
+php regular-expression-matching.php
 ```
 
 ## Tests

--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -58,11 +58,16 @@ func TestPHPCompiler_LeetCodeExamples(t *testing.T) {
 	if err := phpcode.EnsurePHP(); err != nil {
 		t.Skipf("php not installed: %v", err)
 	}
-       runExample(t, 1)
-       runExample(t, 2)
-       runExample(t, 3)
-       runExample(t, 4)
-       runExample(t, 5)
+	runExample(t, 1)
+	runExample(t, 2)
+	runExample(t, 3)
+	runExample(t, 4)
+	runExample(t, 5)
+	runExample(t, 6)
+	runExample(t, 7)
+	runExample(t, 8)
+	runExample(t, 9)
+	runExample(t, 10)
 }
 
 func runExample(t *testing.T, i int) {

--- a/compile/php/leetcode_test.go
+++ b/compile/php/leetcode_test.go
@@ -1,0 +1,176 @@
+package phpcode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	phpcode "mochi/compile/php"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func compileAndRunLeetCode(t *testing.T, id string) string {
+	t.Helper()
+	root := findRoot(t)
+	dir := filepath.Join(root, "examples", "leetcode", id)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var src string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".mochi") {
+			src = filepath.Join(dir, e.Name())
+			break
+		}
+	}
+	if src == "" {
+		t.Fatalf("no mochi source for id %s", id)
+	}
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := phpcode.New(env)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "main.php")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("php", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("php run error: %v\n%s", err, out)
+	}
+	return strings.ReplaceAll(string(out), "\r\n", "\n")
+}
+
+func TestLeetCode1(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "1"))
+	if got != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode2(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "2"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode3(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "3"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode4(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "4"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode5(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "5"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode6(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "6"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode7(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "7"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode8(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "8"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode9(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "9"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestLeetCode10(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	got := strings.TrimSpace(compileAndRunLeetCode(t, "10"))
+	if got != "" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func findRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}


### PR DESCRIPTION
## Summary
- verify PHP backend runs LeetCode problems 1‑10
- update README with examples for LeetCode problems 1‑10

## Testing
- `go test ./compile/php -tags slow -run TestLeetCode -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6853d4f4d6c4832095cb827eee7f40fa