### PR TITLE
Extend Fortran leetcode coverage

### DIFF
--- a/compile/fortran/compiler.go
+++ b/compile/fortran/compiler.go
@@ -364,7 +364,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 			if stringVars[name] {
 				c.writeln(fmt.Sprintf("character(:), allocatable :: %s(:)", name))
 			} else {
-				c.writeln(fmt.Sprintf("integer, allocatable :: %s(:)", name))
+				c.writeln(fmt.Sprintf("integer(kind=8), allocatable :: %s(:)", name))
 			}
 			allocs = append(allocs, fmt.Sprintf("allocate(%s(0))", name))
 		}
@@ -378,9 +378,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		} else if floatVars[name] {
 			c.writeln(fmt.Sprintf("real :: %s", name))
 		} else if name == "result" {
-			c.writeln("integer :: result(2)")
+			c.writeln("integer(kind=8) :: result(2)")
 		} else {
-			c.writeln("integer :: " + name)
+			c.writeln("integer(kind=8) :: " + name)
 		}
 	}
 	loopVars := map[string]bool{}
@@ -391,7 +391,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 			if loopStrVars[name] {
 				c.writeln(fmt.Sprintf("character(:), allocatable :: %s", name))
 			} else {
-				c.writeln("integer :: " + name)
+				c.writeln("integer(kind=8) :: " + name)
 			}
 		}
 	}
@@ -446,12 +446,12 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 		c.writeln(fmt.Sprintf("function %s(nums, target) result(%s)", sanitizeName(fn.Name), resVar))
 		c.indent++
 		c.writeln("implicit none")
-		c.writeln("integer, intent(in) :: nums(:)")
-		c.writeln("integer, intent(in) :: target")
-		c.writeln("integer :: n")
-		c.writeln("integer :: i")
-		c.writeln("integer :: j")
-		c.writeln("integer :: res(2)")
+		c.writeln("integer(kind=8), intent(in) :: nums(:)")
+		c.writeln("integer(kind=8), intent(in) :: target")
+		c.writeln("integer(kind=8) :: n")
+		c.writeln("integer(kind=8) :: i")
+		c.writeln("integer(kind=8) :: j")
+		c.writeln("integer(kind=8) :: res(2)")
 		for _, st := range fn.Body {
 			if err := c.compileStmt(st, resVar); err != nil {
 				return err
@@ -469,13 +469,13 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 		c.indent++
 		c.writeln("implicit none")
 		c.writeln("character(len=*), intent(in) :: s")
-		c.writeln("integer, intent(in) :: numRows")
+		c.writeln("integer(kind=8), intent(in) :: numRows")
 		c.writeln("character(:), allocatable :: res")
 		c.writeln("character(len=len(s)), allocatable :: rows(:)")
-		c.writeln("integer :: i")
-		c.writeln("integer :: curr")
-		c.writeln("integer :: step")
-		c.writeln("integer :: i_row")
+		c.writeln("integer(kind=8) :: i")
+		c.writeln("integer(kind=8) :: curr")
+		c.writeln("integer(kind=8) :: step")
+		c.writeln("integer(kind=8) :: i_row")
 		c.writeln("if ((numRows <= 1) .or. (numRows >= len(s))) then")
 		c.indent++
 		c.writeln("res = s")
@@ -527,26 +527,26 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 	c.indent++
 	c.writeln("implicit none")
 	if fn.Return != nil && fn.Return.Generic != nil && fn.Return.Generic.Name == "list" {
-		c.writeln(fmt.Sprintf("integer, allocatable :: %s(:)", resVar))
+		c.writeln(fmt.Sprintf("integer(kind=8), allocatable :: %s(:)", resVar))
 	} else if fn.Return != nil && fn.Return.Simple != nil && *fn.Return.Simple == "float" {
 		c.writeln(fmt.Sprintf("real :: %s", resVar))
 	} else if fn.Return != nil && fn.Return.Simple != nil && *fn.Return.Simple == "string" {
 		c.writeln(fmt.Sprintf("character(:), allocatable :: %s", resVar))
 		c.stringVars[resVar] = true
 	} else {
-		c.writeln(fmt.Sprintf("integer :: %s", resVar))
+		c.writeln(fmt.Sprintf("integer(kind=8) :: %s", resVar))
 	}
 	for _, p := range fn.Params {
 		name := sanitizeName(p.Name)
 		if p.Type != nil && p.Type.Generic != nil && p.Type.Generic.Name == "list" {
-			c.writeln(fmt.Sprintf("integer, intent(in) :: %s(:)", name))
+			c.writeln(fmt.Sprintf("integer(kind=8), intent(in) :: %s(:)", name))
 		} else if p.Type != nil && p.Type.Simple != nil && *p.Type.Simple == "string" {
 			c.writeln(fmt.Sprintf("character(len=*), intent(in) :: %s", name))
 			c.stringVars[name] = true
 		} else if p.Type != nil && p.Type.Simple != nil && *p.Type.Simple == "float" {
 			c.writeln(fmt.Sprintf("real, intent(in) :: %s", name))
 		} else {
-			c.writeln(fmt.Sprintf("integer, intent(in) :: %s", name))
+			c.writeln(fmt.Sprintf("integer(kind=8), intent(in) :: %s", name))
 		}
 	}
 	vars := map[string]bool{}
@@ -582,7 +582,7 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 			if stringVars[name] {
 				c.writeln(fmt.Sprintf("character(:), allocatable :: %s(:)", name))
 			} else {
-				c.writeln(fmt.Sprintf("integer, allocatable :: %s(:)", name))
+				c.writeln(fmt.Sprintf("integer(kind=8), allocatable :: %s(:)", name))
 			}
 			allocs = append(allocs, fmt.Sprintf("allocate(%s(0))", name))
 			vars[name] = true
@@ -597,7 +597,7 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 		} else if floatVars[name] {
 			c.writeln(fmt.Sprintf("real :: %s", name))
 		} else {
-			c.writeln("integer :: " + name)
+			c.writeln("integer(kind=8) :: " + name)
 		}
 	}
 	for _, a := range allocs {
@@ -836,7 +836,7 @@ func (c *Compiler) compileTestBlock(t *parser.TestBlock) error {
 	c.stringVars = stringVars
 	allocs := []string{}
 	for name := range listVars {
-		c.writeln(fmt.Sprintf("integer, allocatable :: %s(:)", name))
+		c.writeln(fmt.Sprintf("integer(kind=8), allocatable :: %s(:)", name))
 		allocs = append(allocs, fmt.Sprintf("allocate(%s(0))", name))
 		vars[name] = true
 	}
@@ -849,7 +849,7 @@ func (c *Compiler) compileTestBlock(t *parser.TestBlock) error {
 		} else if floatVars[name] {
 			c.writeln(fmt.Sprintf("real :: %s", name))
 		} else {
-			c.writeln("integer :: " + name)
+			c.writeln("integer(kind=8) :: " + name)
 		}
 	}
 	for _, a := range allocs {

--- a/compile/fortran/leetcode_test.go
+++ b/compile/fortran/leetcode_test.go
@@ -1,0 +1,103 @@
+//go:build slow
+
+package ftncode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	ftncode "mochi/compile/fortran"
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/mod"
+	"mochi/types"
+)
+
+func runLeet(t *testing.T, id int) {
+	t.Helper()
+	gfortran, err := ftncode.EnsureFortran()
+	if err != nil {
+		t.Skipf("gfortran not installed: %v", err)
+	}
+	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(id))
+	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	for _, f := range files {
+		name := fmt.Sprintf("%d/%s", id, filepath.Base(f))
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(f)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+
+			modRoot, _ := mod.FindRoot(filepath.Dir(f))
+
+			interp := interpreter.New(prog, env, modRoot)
+			if err := interp.Test(); err != nil {
+				t.Fatalf("tests failed: %v", err)
+			}
+
+			interp = interpreter.New(prog, env, modRoot)
+			var wantBuf bytes.Buffer
+			interp.Env().SetWriter(&wantBuf)
+			if err := interp.Run(); err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+
+			code, err := ftncode.New().Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+
+			outDir := filepath.Join("..", "..", "examples", "leetcode-out", "fortran", strconv.Itoa(id))
+			if err := os.MkdirAll(outDir, 0755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			outFile := filepath.Join(outDir, strings.TrimSuffix(filepath.Base(f), ".mochi")+".f90")
+			if err := os.WriteFile(outFile, code, 0644); err != nil {
+				t.Fatalf("write output: %v", err)
+			}
+
+			tmp := t.TempDir()
+			ffile := filepath.Join(tmp, "main.f90")
+			if err := os.WriteFile(ffile, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			exe := filepath.Join(tmp, "main")
+			if out, err := exec.Command(gfortran, ffile, "-o", exe).CombinedOutput(); err != nil {
+				t.Fatalf("gfortran error: %v\n%s", err, out)
+			}
+			cmd := exec.Command(exe)
+			if data, err := os.ReadFile(strings.TrimSuffix(f, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run error: %v\n%s", err, out)
+			}
+			got := bytes.Join(bytes.Fields(out), []byte("\n"))
+			want := bytes.Join(bytes.Fields(wantBuf.Bytes()), []byte("\n"))
+			if !bytes.Equal(got, want) {
+				t.Fatalf("unexpected output\nwant:\n%s\n got:\n%s", want, got)
+			}
+		})
+	}
+}
+
+func TestFortranCompiler_LeetCodeExamples_Output(t *testing.T) {
+	for i := 1; i <= 7; i++ {
+		runLeet(t, i)
+	}
+}

--- a/examples/leetcode-out/fortran/7/reverse-integer.f90
+++ b/examples/leetcode-out/fortran/7/reverse-integer.f90
@@ -1,0 +1,69 @@
+program main
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_example_3()
+  call test_overflow()
+contains
+  function reverse(x) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: x
+    integer(kind=8) :: sign
+    integer(kind=8) :: n
+    integer(kind=8) :: rev
+    integer(kind=8) :: digit
+    sign = 1
+    n = x
+    if ((n < 0)) then
+      sign = (-1)
+      n = (-n)
+    end if
+    rev = 0
+    do while ((n /= 0))
+      digit = mod(n, 10)
+      rev = ((rev * 10) + digit)
+      n = (n / 10)
+    end do
+    rev = (rev * sign)
+    if (((rev < (((-2147483647) - 1))) .or. (rev > 2147483647))) then
+      res = 0
+      return
+    end if
+    res = rev
+    return
+  end function reverse
+  
+  subroutine test_example_1()
+    implicit none
+    if (.not. (reverse(123) == 321)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
+  
+  subroutine test_example_2()
+    implicit none
+    if (.not. (reverse((-123)) == ((-321)))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
+  
+  subroutine test_example_3()
+    implicit none
+    if (.not. (reverse(120) == 21)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_3
+  
+  subroutine test_overflow()
+    implicit none
+    if (.not. (reverse(1534236469) == 0)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_overflow
+  
+end program main


### PR DESCRIPTION
## Summary
- add tests that compile leetcode examples 1-7 with the Fortran backend
- store generated code in `examples/leetcode-out/fortran/7`
- normalize whitespace when comparing outputs
- use 64-bit integers in the Fortran backend to avoid overflow

## Testing
- `go test ./...` *(fails to run in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6853daafe8348320be62f86934d42a95