### PR TITLE
Fix Fortran backend examples

### DIFF
--- a/compile/fortran/README.md
+++ b/compile/fortran/README.md
@@ -153,6 +153,12 @@ gfortran two-sum.f90 -o two-sum
 # 0
 # 1
 ```
+You can also compile and run the second LeetCode example, *add two numbers*:
+```bash
+mochi build --target fortran examples/leetcode/2/add-two-numbers.mochi -o add-two-numbers.f90
+gfortran -ffree-line-length-none add-two-numbers.f90 -o add-two-numbers
+./add-two-numbers
+```
 The tests show the full workflow, including a check for `gfortran` availability
 and execution of the resulting binary:
 ```go

--- a/compile/fortran/compiler.go
+++ b/compile/fortran/compiler.go
@@ -1126,7 +1126,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 	switch {
 	case p.Lit != nil:
 		if p.Lit.Int != nil {
-			return fmt.Sprintf("%d", *p.Lit.Int), nil
+			// Emit 64-bit integer literals to match the default
+			// INTEGER(KIND=8) type used throughout the backend.
+			return fmt.Sprintf("%d_8", *p.Lit.Int), nil
 		}
 		if p.Lit.Float != nil {
 			return fmt.Sprintf("%g", *p.Lit.Float), nil

--- a/compile/fortran/leetcode_test.go
+++ b/compile/fortran/leetcode_test.go
@@ -76,7 +76,8 @@ func runLeet(t *testing.T, id int) {
 				t.Fatalf("write error: %v", err)
 			}
 			exe := filepath.Join(tmp, "main")
-			if out, err := exec.Command(gfortran, ffile, "-o", exe).CombinedOutput(); err != nil {
+			// Allow long lines in the generated Fortran code.
+			if out, err := exec.Command(gfortran, "-ffree-line-length-none", ffile, "-o", exe).CombinedOutput(); err != nil {
 				t.Fatalf("gfortran error: %v\n%s", err, out)
 			}
 			cmd := exec.Command(exe)

--- a/examples/leetcode-out/fortran/1/two-sum.f90
+++ b/examples/leetcode-out/fortran/1/two-sum.f90
@@ -1,28 +1,28 @@
 program main
   implicit none
-  integer :: result(2)
-  result = twoSum((/2, 7, 11, 15/), 9)
-  print *, result(0 + 1)
-  print *, result(1 + 1)
+  integer(kind=8) :: result(2)
+  result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
+  print *, result(0_8 + 1)
+  print *, result(1_8 + 1)
 contains
   function twoSum(nums, target) result(res)
     implicit none
-    integer, intent(in) :: nums(:)
-    integer, intent(in) :: target
-    integer :: n
-    integer :: i
-    integer :: j
-    integer :: res(2)
+    integer(kind=8), intent(in) :: nums(:)
+    integer(kind=8), intent(in) :: target
+    integer(kind=8) :: n
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: res(2)
     n = size(nums)
-    do i = 0, n - 1
-      do j = (i + 1), n - 1
+    do i = 0_8, n - 1
+      do j = (i + 1_8), n - 1
         if (((nums(i + 1) + nums(j + 1)) == target)) then
           res = (/i, j/)
           return
         end if
       end do
     end do
-    res = (/(-1), (-1)/)
+    res = (/(-1_8), (-1_8)/)
     return
   end function twoSum
   

--- a/examples/leetcode-out/fortran/2/add-two-numbers.f90
+++ b/examples/leetcode-out/fortran/2/add-two-numbers.f90
@@ -6,35 +6,35 @@ program main
 contains
   function addTwoNumbers(l1, l2) result(res)
     implicit none
-    integer, allocatable :: res(:)
-    integer, intent(in) :: l1(:)
-    integer, intent(in) :: l2(:)
-    integer, allocatable :: result(:)
-    integer :: carry
-    integer :: digit
-    integer :: i
-    integer :: j
-    integer :: x
-    integer :: y
-    integer :: sum
+    integer(kind=8), allocatable :: res(:)
+    integer(kind=8), intent(in) :: l1(:)
+    integer(kind=8), intent(in) :: l2(:)
+    integer(kind=8), allocatable :: result(:)
+    integer(kind=8) :: i
+    integer(kind=8) :: carry
+    integer(kind=8) :: y
+    integer(kind=8) :: sum
+    integer(kind=8) :: digit
+    integer(kind=8) :: j
+    integer(kind=8) :: x
     allocate(result(0))
-    i = 0
-    j = 0
-    carry = 0
-    do while ((((i < size(l1)) .or. (j < size(l2))) .or. (carry > 0)))
-      x = 0
+    i = 0_8
+    j = 0_8
+    carry = 0_8
+    do while ((((i < size(l1)) .or. (j < size(l2))) .or. (carry > 0_8)))
+      x = 0_8
       if ((i < size(l1))) then
         x = l1(i + 1)
-        i = (i + 1)
+        i = (i + 1_8)
       end if
-      y = 0
+      y = 0_8
       if ((j < size(l2))) then
         y = l2(j + 1)
-        j = (j + 1)
+        j = (j + 1_8)
       end if
       sum = ((x + y) + carry)
-      digit = mod(sum, 10)
-      carry = (sum / 10)
+      digit = mod(sum, 10_8)
+      carry = (sum / 10_8)
       result = (/ result, (/digit/) /)
     end do
     res = result
@@ -43,7 +43,7 @@ contains
   
   subroutine test_example_1()
     implicit none
-    if (.not. (all(addTwoNumbers((/2, 4, 3/), (/5, 6, 4/)) == (/7, 0, 8/)))) then
+    if (.not. (all(addTwoNumbers((/2_8, 4_8, 3_8/), (/5_8, 6_8, 4_8/)) == (/7_8, 0_8, 8_8/)))) then
       print *, 'expect failed'
       stop 1
     end if
@@ -51,7 +51,7 @@ contains
   
   subroutine test_example_2()
     implicit none
-    if (.not. (all(addTwoNumbers((/0/), (/0/)) == (/0/)))) then
+    if (.not. (all(addTwoNumbers((/0_8/), (/0_8/)) == (/0_8/)))) then
       print *, 'expect failed'
       stop 1
     end if
@@ -59,7 +59,7 @@ contains
   
   subroutine test_example_3()
     implicit none
-    if (.not. (all(addTwoNumbers((/9, 9, 9, 9, 9, 9, 9/), (/9, 9, 9, 9/)) == (/8, 9, 9, 9, 0, 0, 0, 1/)))) then
+    if (.not. (all(addTwoNumbers((/9_8, 9_8, 9_8, 9_8, 9_8, 9_8, 9_8/), (/9_8, 9_8, 9_8, 9_8/)) == (/8_8, 9_8, 9_8, 9_8, 0_8, 0_8, 0_8, 1_8/)))) then
       print *, 'expect failed'
       stop 1
     end if


### PR DESCRIPTION
## Summary
- handle 64-bit integer literals in Fortran compiler
- allow long lines when compiling test programs
- regenerate leetcode outputs for problems 1 and 2
- document running the second example in the Fortran README

## Testing
- `go test ./compile/fortran -tags slow -run TestFortranCompiler_LeetCodeExamples_Output/1 -v`
- `go test ./compile/fortran -tags slow -run TestFortranCompiler_LeetCodeExamples_Output/2 -v`


------
https://chatgpt.com/codex/tasks/task_e_68541815f8e48320bbd9403bf1b9c4ff