### PR TITLE
Add v0.8.7 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # 📦 CHANGELOG.md
+## [0.8.7] – 2025-06-19
+
+### Added
+
+* Break and continue support in the Scala compiler
+* COBOL loops with grouped ranges, negative counts and modulo operations
+* Struct casts and new examples in the Ruby backend
+* Dart trailing newline emission and map/list helpers
+* 64-bit literal support for Fortran
+* Smalltalk golden tests and parenthesized expressions
+* Expanded Rust factorial and fibonacci tests
+
+### Changed
+
+* Clojure only includes runtime helpers when needed
+* LeetCode solutions refreshed for Fortran
+
+### Fixed
+
+* Improved printing and loop handling across compilers
 ## [0.8.6] – 2025-06-19
 
 ### Added

--- a/releases/v0.8.7.md
+++ b/releases/v0.8.7.md
@@ -1,0 +1,21 @@
+# Jun 2025 (v0.8.7)
+
+Mochi v0.8.7 polishes the experimental compilers with new language features and
+additional golden tests. Several backends gain better loop handling and improved
+code generation.
+
+## Compilers
+
+- Break and continue support in the Scala backend with updated tests
+- COBOL loops handle grouped ranges, negative counts and modulo operations
+- Ruby adds struct casts and multi-function examples
+- Dart emits a trailing newline and expands map/list operations
+- Fortran supports 64-bit literals and refreshed LeetCode solutions
+- Rust printing improved with factorial and fibonacci tests
+- Smalltalk compiler parenthesizes expressions and gains new tests
+- Clojure includes runtime helpers only when required
+
+## Tests
+
+- New golden tests for Scala, COBOL, Ruby, Dart, Fortran, Rust and Smalltalk
+- Expanded coverage of list, map and float operations across languages


### PR DESCRIPTION
## Summary
- document 0.8.7 release
- note new features in CHANGELOG

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685421eae7e0832081a00b8c5c03fbd0