### PR TITLE
Extend Dart LeetCode compilation

### DIFF
--- a/examples/leetcode-out/dart/1/two-sum.dart
+++ b/examples/leetcode-out/dart/1/two-sum.dart
@@ -1,5 +1,5 @@
-List<int> twoSum(List<int> nums, int target) {
-	int n = nums.length;
+dynamic twoSum(nums, int target) {
+	dynamic n = nums.length;
 	for (var i = 0; i < n; i++) {
 		for (var j = (i + 1); j < n; j++) {
 			if (((nums[i] + nums[j]) == target)) {
@@ -11,7 +11,8 @@ List<int> twoSum(List<int> nums, int target) {
 }
 
 void main() {
-	List<int> result = twoSum([2, 7, 11, 15], 9);
+	dynamic result = twoSum([2, 7, 11, 15], 9);
 	print(result[0]);
 	print(result[1]);
 }
+

--- a/examples/leetcode-out/dart/10/regular-expression-matching.dart
+++ b/examples/leetcode-out/dart/10/regular-expression-matching.dart
@@ -1,45 +1,59 @@
 bool isMatch(String s, String p) {
-	int m = s.length;
-	int n = p.length;
-	List<List<bool>> dp = [];
-	int i = 0;
+	dynamic m = s.length;
+	dynamic n = p.length;
+	dynamic dp = [];
+	dynamic i = 0;
 	while ((i <= m)) {
-		List<bool> row = [];
-		int j = 0;
+		dynamic row = [];
+		dynamic j = 0;
 		while ((j <= n)) {
 			row = (row + [false]);
-			j = (j + 1);
+			j = ((j + 1)).toInt();
 		}
 		dp = (dp + [row]);
-		i = (i + 1);
+		i = ((i + 1)).toInt();
 	}
 	dp[m][n] = true;
-	var i2 = m;
+	dynamic i2 = m;
 	while ((i2 >= 0)) {
-		var j2 = (n - 1);
+		dynamic j2 = (n - 1);
 		while ((j2 >= 0)) {
-			bool first = false;
+			dynamic first = false;
 			if ((i2 < m)) {
 				if ((((_indexString(p, j2) == _indexString(s, i2))) || ((_indexString(p, j2) == ".")))) {
 					first = true;
 				}
 			}
-			if ((((j2 + 1) < n) && (_indexString(p, (j2 + 1)) == "*"))) {
-				if ((dp[i2][(j2 + 2)] || ((first && dp[(i2 + 1)][j2])))) {
-					dp[i2][j2] = true;
-				} else {
-					dp[i2][j2] = false;
-				}
-			} else {
-				if ((first && dp[(i2 + 1)][(j2 + 1)])) {
-					dp[i2][j2] = true;
-				} else {
-					dp[i2][j2] = false;
+			dynamic star = false;
+			if (((j2 + 1) < n)) {
+				if ((_indexString(p, ((j2 + 1)).toInt()) == "*")) {
+					star = true;
 				}
 			}
-			j2 = (j2 - 1);
+			if (star) {
+				dynamic ok = false;
+				if (dp[i2][(j2 + 2)]) {
+					ok = true;
+				} else {
+					if (first) {
+						if (dp[(i2 + 1)][j2]) {
+							ok = true;
+						}
+					}
+				}
+				dp[i2][j2] = ok;
+			} else {
+				dynamic ok = false;
+				if (first) {
+					if (dp[(i2 + 1)][(j2 + 1)]) {
+						ok = true;
+					}
+				}
+				dp[i2][j2] = ok;
+			}
+			j2 = ((j2 - 1)).toInt();
 		}
-		i2 = (i2 - 1);
+		i2 = ((i2 - 1)).toInt();
 	}
 	return dp[0][0];
 }
@@ -57,3 +71,4 @@ String _indexString(String s, int i) {
 	}
 	return String.fromCharCode(runes[i]);
 }
+

--- a/examples/leetcode-out/dart/11/container-with-most-water.dart
+++ b/examples/leetcode-out/dart/11/container-with-most-water.dart
@@ -1,0 +1,28 @@
+int maxArea(height) {
+	dynamic left = 0;
+	dynamic right = (height.length - 1);
+	dynamic maxArea = 0;
+	while ((left < right)) {
+		dynamic width = (right - left);
+		dynamic h = 0;
+		if ((height[left] < height[right])) {
+			h = (height[left]).toInt();
+		} else {
+			h = (height[right]).toInt();
+		}
+		dynamic area = (h * width);
+		if ((area > maxArea)) {
+			maxArea = area;
+		}
+		if ((height[left] < height[right])) {
+			left = ((left + 1)).toInt();
+		} else {
+			right = ((right - 1)).toInt();
+		}
+	}
+	return maxArea;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/12/integer-to-roman.dart
+++ b/examples/leetcode-out/dart/12/integer-to-roman.dart
@@ -1,0 +1,18 @@
+String intToRoman(int num) {
+	dynamic values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
+	dynamic symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"];
+	dynamic result = "";
+	dynamic i = 0;
+	while ((num > 0)) {
+		while ((num >= values[i])) {
+			result = (result + symbols[i]);
+			num = ((num - values[i])).toInt();
+		}
+		i = ((i + 1)).toInt();
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/13/roman-to-integer.dart
+++ b/examples/leetcode-out/dart/13/roman-to-integer.dart
@@ -1,0 +1,35 @@
+int romanToInt(String s) {
+	dynamic values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000};
+	dynamic total = 0;
+	dynamic i = 0;
+	dynamic n = s.length;
+	while ((i < n)) {
+		dynamic curr = values[_indexString(s, i)];
+		if (((i + 1) < n)) {
+			dynamic next = values[_indexString(s, ((i + 1)).toInt())];
+			if ((curr < next)) {
+				total = (((total + next) - curr)).toInt();
+				i = ((i + 2)).toInt();
+				continue;
+			}
+		}
+		total = ((total + curr)).toInt();
+		i = ((i + 1)).toInt();
+	}
+	return total;
+}
+
+void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
+}
+

--- a/examples/leetcode-out/dart/14/longest-common-prefix.dart
+++ b/examples/leetcode-out/dart/14/longest-common-prefix.dart
@@ -1,0 +1,36 @@
+String longestCommonPrefix(strs) {
+	if ((strs.length == 0)) {
+		return "";
+	}
+	dynamic prefix = strs[0];
+	for (var i = 1; i < strs.length; i++) {
+		dynamic j = 0;
+		dynamic current = strs[i];
+		while (((j < prefix.length) && (j < current.length))) {
+			if ((_indexString(prefix, j) != _indexString(current, j))) {
+				break;
+			}
+			j = ((j + 1)).toInt();
+		}
+		prefix = prefix.substring(0, j);
+		if ((prefix == "")) {
+			break;
+		}
+	}
+	return prefix;
+}
+
+void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
+}
+

--- a/examples/leetcode-out/dart/15/three-sum.dart
+++ b/examples/leetcode-out/dart/15/three-sum.dart
@@ -1,0 +1,54 @@
+dynamic threeSum(nums) {
+	dynamic sorted = (() {
+	var _res = [];
+	for (var x in nums) {
+		_res.add(x);
+	}
+	var items = List.from(_res);
+	items.sort((xA, xB) {
+		var x = xA;
+		var keyA = x;
+		x = xB;
+		var keyB = x;
+		return Comparable.compare(keyA, keyB);
+	});
+	_res = items;
+	return _res;
+})();
+	dynamic n = sorted.length;
+	dynamic res = [];
+	dynamic i = 0;
+	while ((i < n)) {
+		if (((i > 0) && (sorted[i] == sorted[(i - 1)]))) {
+			i = ((i + 1)).toInt();
+			continue;
+		}
+		dynamic left = (i + 1);
+		dynamic right = (n - 1);
+		while ((left < right)) {
+			dynamic sum = ((sorted[i] + sorted[left]) + sorted[right]);
+			if ((sum == 0)) {
+				res = (res + [[sorted[i], sorted[left], sorted[right]]]);
+				left = ((left + 1)).toInt();
+				while (((left < right) && (sorted[left] == sorted[(left - 1)]))) {
+					left = ((left + 1)).toInt();
+				}
+				right = ((right - 1)).toInt();
+				while (((left < right) && (sorted[right] == sorted[(right + 1)]))) {
+					right = ((right - 1)).toInt();
+				}
+			} else 
+			if ((sum < 0)) {
+				left = ((left + 1)).toInt();
+			} else {
+				right = ((right - 1)).toInt();
+			}
+		}
+		i = ((i + 1)).toInt();
+	}
+	return res;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/16/3sum-closest.dart
+++ b/examples/leetcode-out/dart/16/3sum-closest.dart
@@ -1,0 +1,55 @@
+int threeSumClosest(nums, int target) {
+	dynamic sorted = (() {
+	var _res = [];
+	for (var n in nums) {
+		_res.add(n);
+	}
+	var items = List.from(_res);
+	items.sort((nA, nB) {
+		var n = nA;
+		var keyA = n;
+		n = nB;
+		var keyB = n;
+		return Comparable.compare(keyA, keyB);
+	});
+	_res = items;
+	return _res;
+})();
+	dynamic n = sorted.length;
+	dynamic best = ((sorted[0] + sorted[1]) + sorted[2]);
+	for (var i = 0; i < n; i++) {
+		dynamic left = (i + 1);
+		dynamic right = (n - 1);
+		while ((left < right)) {
+			dynamic sum = ((sorted[i] + sorted[left]) + sorted[right]);
+			if ((sum == target)) {
+				return target;
+			}
+			dynamic diff = 0;
+			if ((sum > target)) {
+				diff = ((sum - target)).toInt();
+			} else {
+				diff = ((target - sum)).toInt();
+			}
+			dynamic bestDiff = 0;
+			if ((best > target)) {
+				bestDiff = ((best - target)).toInt();
+			} else {
+				bestDiff = ((target - best)).toInt();
+			}
+			if ((diff < bestDiff)) {
+				best = sum;
+			}
+			if ((sum < target)) {
+				left = (left + 1);
+			} else {
+				right = ((right - 1)).toInt();
+			}
+		}
+	}
+	return best;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/17/letter-combinations-of-a-phone-number.dart
+++ b/examples/leetcode-out/dart/17/letter-combinations-of-a-phone-number.dart
@@ -1,0 +1,30 @@
+dynamic letterCombinations(String digits) {
+	if ((digits.length == 0)) {
+		return [];
+	}
+	dynamic mapping = {"2": ["a", "b", "c"], "3": ["d", "e", "f"], "4": ["g", "h", "i"], "5": ["j", "k", "l"], "6": ["m", "n", "o"], "7": ["p", "q", "r", "s"], "8": ["t", "u", "v"], "9": ["w", "x", "y", "z"]};
+	dynamic result = [""];
+	var _tmp0 = digits;
+	for (var _tmp1 in _tmp0.runes) {
+		var d = String.fromCharCode(_tmp1);
+		if (!((mapping.containsKey(d)))) {
+			continue;
+		}
+		dynamic letters = mapping[d];
+		dynamic next = (() {
+	var _res = [];
+	for (var p in result) {
+		for (var ch in letters) {
+			_res.add((p + ch));
+		}
+	}
+	return _res;
+})();
+		result = next;
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/18/four-sum.dart
+++ b/examples/leetcode-out/dart/18/four-sum.dart
@@ -1,0 +1,56 @@
+dynamic fourSum(nums, int target) {
+	dynamic sorted = (() {
+	var _res = [];
+	for (var n in nums) {
+		_res.add(n);
+	}
+	var items = List.from(_res);
+	items.sort((nA, nB) {
+		var n = nA;
+		var keyA = n;
+		n = nB;
+		var keyB = n;
+		return Comparable.compare(keyA, keyB);
+	});
+	_res = items;
+	return _res;
+})();
+	dynamic n = sorted.length;
+	dynamic result = [];
+	for (var i = 0; i < n; i++) {
+		if (((i > 0) && (sorted[i] == sorted[(i - 1)]))) {
+			continue;
+		}
+		for (var j = (i + 1); j < n; j++) {
+			if (((j > (i + 1)) && (sorted[j] == sorted[(j - 1)]))) {
+				continue;
+			}
+			dynamic left = (j + 1);
+			dynamic right = (n - 1);
+			while ((left < right)) {
+				dynamic sum = (((sorted[i] + sorted[j]) + sorted[left]) + sorted[right]);
+				if ((sum == target)) {
+					result = (result + [[sorted[i], sorted[j], sorted[left], sorted[right]]]);
+					left = (left + 1);
+					right = ((right - 1)).toInt();
+					while (((left < right) && (sorted[left] == sorted[(left - 1)]))) {
+						left = (left + 1);
+					}
+					while (((left < right) && (sorted[right] == sorted[(right + 1)]))) {
+						right = ((right - 1)).toInt();
+					}
+				} else 
+				if ((sum < target)) {
+					left = (left + 1);
+				} else {
+					right = ((right - 1)).toInt();
+				}
+			}
+		}
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/19/remove-nth-node-from-end-of-list.dart
+++ b/examples/leetcode-out/dart/19/remove-nth-node-from-end-of-list.dart
@@ -1,0 +1,16 @@
+dynamic removeNthFromEnd(nums, int n) {
+	dynamic idx = (nums.length - n);
+	dynamic result = [];
+	dynamic i = 0;
+	while ((i < nums.length)) {
+		if ((i != idx)) {
+			result = (result + [nums[i]]);
+		}
+		i = ((i + 1)).toInt();
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/2/add-two-numbers.dart
+++ b/examples/leetcode-out/dart/2/add-two-numbers.dart
@@ -1,22 +1,22 @@
-List<int> addTwoNumbers(List<int> l1, List<int> l2) {
-	int i = 0;
-	int j = 0;
-	int carry = 0;
-	List<int> result = [];
+dynamic addTwoNumbers(l1, l2) {
+	dynamic i = 0;
+	dynamic j = 0;
+	dynamic carry = 0;
+	dynamic result = [];
 	while ((((i < l1.length) || (j < l2.length)) || (carry > 0))) {
-		int x = 0;
+		dynamic x = 0;
 		if ((i < l1.length)) {
-			x = l1[i];
-			i = (i + 1);
+			x = (l1[i]).toInt();
+			i = ((i + 1)).toInt();
 		}
-		int y = 0;
+		dynamic y = 0;
 		if ((j < l2.length)) {
-			y = l2[j];
-			j = (j + 1);
+			y = (l2[j]).toInt();
+			j = ((j + 1)).toInt();
 		}
-		var sum = ((x + y) + carry);
-		var digit = (sum % 10);
-		carry = (sum ~/ 10);
+		dynamic sum = ((x + y) + carry);
+		dynamic digit = (sum % 10);
+		carry = ((sum ~/ 10)).toInt();
 		result = (result + [digit]);
 	}
 	return result;
@@ -24,3 +24,4 @@ List<int> addTwoNumbers(List<int> l1, List<int> l2) {
 
 void main() {
 }
+

--- a/examples/leetcode-out/dart/20/valid-parentheses.dart
+++ b/examples/leetcode-out/dart/20/valid-parentheses.dart
@@ -1,0 +1,41 @@
+bool isValid(String s) {
+	dynamic stack = [];
+	dynamic n = s.length;
+	for (var i = 0; i < n; i++) {
+		dynamic c = _indexString(s, (i).toInt());
+		if ((c == "(")) {
+			stack = (stack + [")"]);
+		} else 
+		if ((c == "[")) {
+			stack = (stack + ["]"]);
+		} else 
+		if ((c == "{")) {
+			stack = (stack + ["}"]);
+		} else {
+			if ((stack.length == 0)) {
+				return false;
+			}
+			dynamic top = stack[(stack.length - 1)];
+			if ((top != c)) {
+				return false;
+			}
+			stack = stack.sublist(0, (stack.length - 1));
+		}
+	}
+	return (stack.length == 0);
+}
+
+void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
+}
+

--- a/examples/leetcode-out/dart/21/merge-two-sorted-lists.dart
+++ b/examples/leetcode-out/dart/21/merge-two-sorted-lists.dart
@@ -1,0 +1,27 @@
+dynamic mergeTwoLists(l1, l2) {
+	dynamic i = 0;
+	dynamic j = 0;
+	dynamic result = [];
+	while (((i < l1.length) && (j < l2.length))) {
+		if ((l1[i] <= l2[j])) {
+			result = (result + [l1[i]]);
+			i = ((i + 1)).toInt();
+		} else {
+			result = (result + [l2[j]]);
+			j = ((j + 1)).toInt();
+		}
+	}
+	while ((i < l1.length)) {
+		result = (result + [l1[i]]);
+		i = ((i + 1)).toInt();
+	}
+	while ((j < l2.length)) {
+		result = (result + [l2[j]]);
+		j = ((j + 1)).toInt();
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/22/generate-parentheses.dart
+++ b/examples/leetcode-out/dart/22/generate-parentheses.dart
@@ -1,0 +1,21 @@
+dynamic generateParenthesis(int n) {
+	dynamic result = [];
+	dynamic backtrack(String current, int open, int close) {
+		if ((current.length == (n * 2))) {
+			result = (result + [current]);
+		} else {
+			if ((open < n)) {
+				backtrack((current + "("), (open + 1), close);
+			}
+			if ((close < open)) {
+				backtrack((current + ")"), open, (close + 1));
+			}
+		}
+	}
+	backtrack("", 0, 0);
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/23/merge-k-sorted-lists.dart
+++ b/examples/leetcode-out/dart/23/merge-k-sorted-lists.dart
@@ -1,0 +1,38 @@
+dynamic mergeKLists(lists) {
+	dynamic k = lists.length;
+	dynamic indices = [];
+	dynamic i = 0;
+	while ((i < k)) {
+		indices = (indices + [0]);
+		i = ((i + 1)).toInt();
+	}
+	dynamic result = [];
+	while (true) {
+		dynamic best = 0;
+		dynamic bestList = -1;
+		dynamic found = false;
+		dynamic j = 0;
+		while ((j < k)) {
+			dynamic idx = indices[j];
+			if ((idx < lists[j].length)) {
+				dynamic val = lists[j][idx];
+				if ((!found || (val < best))) {
+					best = val;
+					bestList = j;
+					found = true;
+				}
+			}
+			j = ((j + 1)).toInt();
+		}
+		if (!found) {
+			break;
+		}
+		result = (result + [best]);
+		indices[bestList] = (indices[bestList] + 1);
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/24/swap-nodes-in-pairs.dart
+++ b/examples/leetcode-out/dart/24/swap-nodes-in-pairs.dart
@@ -1,0 +1,17 @@
+dynamic swapPairs(nums) {
+	dynamic i = 0;
+	dynamic result = [];
+	while ((i < nums.length)) {
+		if (((i + 1) < nums.length)) {
+			result = (result + [nums[(i + 1)], nums[i]]);
+		} else {
+			result = (result + [nums[i]]);
+		}
+		i = ((i + 2)).toInt();
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/25/reverse-nodes-in-k-group.dart
+++ b/examples/leetcode-out/dart/25/reverse-nodes-in-k-group.dart
@@ -1,0 +1,30 @@
+dynamic reverseKGroup(nums, int k) {
+	dynamic n = nums.length;
+	if ((k <= 1)) {
+		return nums;
+	}
+	dynamic result = [];
+	dynamic i = 0;
+	while ((i < n)) {
+		dynamic end = (i + k);
+		if ((end <= n)) {
+			dynamic j = (end - 1);
+			while ((j >= i)) {
+				result = (result + [nums[j]]);
+				j = ((j - 1)).toInt();
+			}
+		} else {
+			dynamic j = i;
+			while ((j < n)) {
+				result = (result + [nums[j]]);
+				j = ((j + 1)).toInt();
+			}
+		}
+		i = ((i + k)).toInt();
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/26/remove-duplicates-from-sorted-array.dart
+++ b/examples/leetcode-out/dart/26/remove-duplicates-from-sorted-array.dart
@@ -1,0 +1,21 @@
+int removeDuplicates(nums) {
+	if ((nums.length == 0)) {
+		return 0;
+	}
+	dynamic count = 1;
+	dynamic prev = nums[0];
+	dynamic i = 1;
+	while ((i < nums.length)) {
+		dynamic cur = nums[i];
+		if ((cur != prev)) {
+			count = (count + 1);
+			prev = cur;
+		}
+		i = ((i + 1)).toInt();
+	}
+	return count;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/27/remove-element.dart
+++ b/examples/leetcode-out/dart/27/remove-element.dart
@@ -1,0 +1,16 @@
+int removeElement(nums, int val) {
+	dynamic k = 0;
+	dynamic i = 0;
+	while ((i < nums.length)) {
+		if ((nums[i] != val)) {
+			nums[k] = nums[i];
+			k = ((k + 1)).toInt();
+		}
+		i = ((i + 1)).toInt();
+	}
+	return k;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/28/find-the-index-of-the-first-occurrence-in-a-string.dart
+++ b/examples/leetcode-out/dart/28/find-the-index-of-the-first-occurrence-in-a-string.dart
@@ -1,0 +1,38 @@
+int strStr(String haystack, String needle) {
+	dynamic n = haystack.length;
+	dynamic m = needle.length;
+	if ((m == 0)) {
+		return 0;
+	}
+	if ((m > n)) {
+		return -1;
+	}
+	for (var i = 0; i < ((n - m) + 1); i++) {
+		dynamic j = 0;
+		while ((j < m)) {
+			if ((_indexString(haystack, ((i + j)).toInt()) != _indexString(needle, j))) {
+				break;
+			}
+			j = ((j + 1)).toInt();
+		}
+		if ((j == m)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+void main() {
+}
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
+}
+

--- a/examples/leetcode-out/dart/29/divide-two-integers.dart
+++ b/examples/leetcode-out/dart/29/divide-two-integers.dart
@@ -1,0 +1,39 @@
+int divide(int dividend, int divisor) {
+	if (((dividend == ((-2147483647 - 1))) && (divisor == (-1)))) {
+		return 2147483647;
+	}
+	dynamic negative = false;
+	if ((dividend < 0)) {
+		negative = !negative;
+		dividend = (-dividend).toInt();
+	}
+	if ((divisor < 0)) {
+		negative = !negative;
+		divisor = (-divisor).toInt();
+	}
+	dynamic quotient = 0;
+	while ((dividend >= divisor)) {
+		dynamic temp = divisor;
+		dynamic multiple = 1;
+		while ((dividend >= (temp + temp))) {
+			temp = ((temp + temp)).toInt();
+			multiple = ((multiple + multiple)).toInt();
+		}
+		dividend = ((dividend - temp)).toInt();
+		quotient = ((quotient + multiple)).toInt();
+	}
+	if (negative) {
+		quotient = (-quotient).toInt();
+	}
+	if ((quotient > 2147483647)) {
+		return 2147483647;
+	}
+	if ((quotient < ((-2147483647 - 1)))) {
+		return -2147483648;
+	}
+	return quotient;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
+++ b/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
@@ -1,22 +1,22 @@
 int lengthOfLongestSubstring(String s) {
-	int n = s.length;
-	int start = 0;
-	int best = 0;
-	int i = 0;
+	dynamic n = s.length;
+	dynamic start = 0;
+	dynamic best = 0;
+	dynamic i = 0;
 	while ((i < n)) {
-		var j = start;
+		dynamic j = start;
 		while ((j < i)) {
 			if ((_indexString(s, j) == _indexString(s, i))) {
-				start = (j + 1);
+				start = ((j + 1)).toInt();
 				break;
 			}
-			j = (j + 1);
+			j = ((j + 1)).toInt();
 		}
-		var length = ((i - start) + 1);
+		dynamic length = ((i - start) + 1);
 		if ((length > best)) {
 			best = length;
 		}
-		i = (i + 1);
+		i = ((i + 1)).toInt();
 	}
 	return best;
 }
@@ -34,3 +34,4 @@ String _indexString(String s, int i) {
 	}
 	return String.fromCharCode(runes[i]);
 }
+

--- a/examples/leetcode-out/dart/30/substring-with-concatenation-of-all-words.dart
+++ b/examples/leetcode-out/dart/30/substring-with-concatenation-of-all-words.dart
@@ -1,0 +1,60 @@
+dynamic findSubstring(String s, words) {
+	if ((words.length == 0)) {
+		return [];
+	}
+	dynamic wordLen = words[0].length;
+	dynamic wordCount = words.length;
+	dynamic totalLen = (wordLen * wordCount);
+	if ((s.length < totalLen)) {
+		return [];
+	}
+	dynamic freq = {};
+	for (var w in words) {
+		if ((freq.containsKey(w))) {
+			freq[w] = (freq[w] + 1);
+		} else {
+			freq[w] = 1;
+		}
+	}
+	dynamic result = [];
+	for (var offset = 0; offset < wordLen; offset++) {
+		dynamic left = offset;
+		dynamic count = 0;
+		dynamic seen = {};
+		dynamic j = offset;
+		while (((j + wordLen) <= s.length)) {
+			dynamic word = s.substring(j, (j + wordLen));
+			j = (j + wordLen);
+			if ((freq.containsKey(word))) {
+				if ((seen.containsKey(word))) {
+					seen[word] = (seen[word] + 1);
+				} else {
+					seen[word] = 1;
+				}
+				count = (count + 1);
+				while ((seen[word] > freq[word])) {
+					dynamic lw = s.substring(left, (left + wordLen));
+					seen[lw] = (seen[lw] - 1);
+					left = (left + wordLen);
+					count = (count - 1);
+				}
+				if ((count == wordCount)) {
+					result = (result + [left]);
+					dynamic lw = s.substring(left, (left + wordLen));
+					seen[lw] = (seen[lw] - 1);
+					left = (left + wordLen);
+					count = (count - 1);
+				}
+			} else {
+				seen = {};
+				count = 0;
+				left = j;
+			}
+		}
+	}
+	return result;
+}
+
+void main() {
+}
+

--- a/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
+++ b/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
@@ -1,32 +1,33 @@
-double findMedianSortedArrays(List<int> nums1, List<int> nums2) {
-	List<int> merged = [];
-	int i = 0;
-	int j = 0;
+double findMedianSortedArrays(nums1, nums2) {
+	dynamic merged = [];
+	dynamic i = 0;
+	dynamic j = 0;
 	while (((i < nums1.length) || (j < nums2.length))) {
 		if ((j >= nums2.length)) {
 			merged = (merged + [nums1[i]]);
-			i = (i + 1);
+			i = ((i + 1)).toInt();
 		} else 
 		if ((i >= nums1.length)) {
 			merged = (merged + [nums2[j]]);
-			j = (j + 1);
+			j = ((j + 1)).toInt();
 		} else 
 		if ((nums1[i] <= nums2[j])) {
 			merged = (merged + [nums1[i]]);
-			i = (i + 1);
+			i = ((i + 1)).toInt();
 		} else {
 			merged = (merged + [nums2[j]]);
-			j = (j + 1);
+			j = ((j + 1)).toInt();
 		}
 	}
-	int total = merged.length;
+	dynamic total = merged.length;
 	if (((total % 2) == 1)) {
 		return (merged[(total ~/ 2)]).toDouble();
 	}
-	var mid1 = merged[((total ~/ 2) - 1)];
-	var mid2 = merged[(total ~/ 2)];
+	dynamic mid1 = merged[((total ~/ 2) - 1)];
+	dynamic mid2 = merged[(total ~/ 2)];
 	return ((((mid1 + mid2))).toDouble() / 2);
 }
 
 void main() {
 }
+

--- a/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
+++ b/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
@@ -1,13 +1,13 @@
 int expand(String s, int left, int right) {
-	int l = left;
-	int r = right;
-	int n = s.length;
+	dynamic l = left;
+	dynamic r = right;
+	dynamic n = s.length;
 	while (((l >= 0) && (r < n))) {
 		if ((_indexString(s, l) != _indexString(s, r))) {
 			break;
 		}
-		l = (l - 1);
-		r = (r + 1);
+		l = ((l - 1)).toInt();
+		r = ((r + 1)).toInt();
 	}
 	return ((r - l) - 1);
 }
@@ -16,19 +16,19 @@ String longestPalindrome(String s) {
 	if ((s.length <= 1)) {
 		return s;
 	}
-	int start = 0;
-	int end = 0;
-	int n = s.length;
+	dynamic start = 0;
+	dynamic end = 0;
+	dynamic n = s.length;
 	for (var i = 0; i < n; i++) {
-		int len1 = expand(s, i, i);
-		int len2 = expand(s, i, (i + 1));
-		var l = len1;
+		dynamic len1 = expand(s, i, i);
+		dynamic len2 = expand(s, i, (i + 1));
+		dynamic l = len1;
 		if ((len2 > len1)) {
 			l = len2;
 		}
 		if ((l > ((end - start)))) {
-			start = (i - ((((l - 1)) ~/ 2)));
-			end = (i + ((l ~/ 2)));
+			start = ((i - ((((l - 1)) ~/ 2)))).toInt();
+			end = ((i + ((l ~/ 2)))).toInt();
 		}
 	}
 	return s.substring(start, (end + 1));
@@ -47,3 +47,4 @@ String _indexString(String s, int i) {
 	}
 	return String.fromCharCode(runes[i]);
 }
+

--- a/examples/leetcode-out/dart/6/zigzag-conversion.dart
+++ b/examples/leetcode-out/dart/6/zigzag-conversion.dart
@@ -2,14 +2,14 @@ String convert(String s, int numRows) {
 	if (((numRows <= 1) || (numRows >= s.length))) {
 		return s;
 	}
-	List<String> rows = [];
-	int i = 0;
+	dynamic rows = [];
+	dynamic i = 0;
 	while ((i < numRows)) {
 		rows = (rows + [""]);
-		i = (i + 1);
+		i = ((i + 1)).toInt();
 	}
-	int curr = 0;
-	int step = 1;
+	dynamic curr = 0;
+	dynamic step = 1;
 	var _tmp0 = s;
 	for (var _tmp1 in _tmp0.runes) {
 		var ch = String.fromCharCode(_tmp1);
@@ -18,11 +18,11 @@ String convert(String s, int numRows) {
 			step = 1;
 		} else 
 		if ((curr == (numRows - 1))) {
-			step = -1;
+			step = (-1).toInt();
 		}
-		curr = (curr + step);
+		curr = ((curr + step)).toInt();
 	}
-	String result = "";
+	dynamic result = "";
 	for (var row in rows) {
 		result = (result + row);
 	}
@@ -31,3 +31,4 @@ String convert(String s, int numRows) {
 
 void main() {
 }
+

--- a/examples/leetcode-out/dart/7/reverse-integer.dart
+++ b/examples/leetcode-out/dart/7/reverse-integer.dart
@@ -1,17 +1,17 @@
 int reverse(int x) {
-	int sign = 1;
-	int n = x;
+	dynamic sign = 1;
+	dynamic n = x;
 	if ((n < 0)) {
-		sign = -1;
-		n = -n;
+		sign = (-1).toInt();
+		n = (-n).toInt();
 	}
-	int rev = 0;
+	dynamic rev = 0;
 	while ((n != 0)) {
-		var digit = (n % 10);
-		rev = ((rev * 10) + digit);
-		n = (n ~/ 10);
+		dynamic digit = (n % 10);
+		rev = (((rev * 10) + digit)).toInt();
+		n = ((n ~/ 10)).toInt();
 	}
-	rev = (rev * sign);
+	rev = ((rev * sign)).toInt();
 	if (((rev < ((-2147483647 - 1))) || (rev > 2147483647))) {
 		return 0;
 	}
@@ -20,3 +20,4 @@ int reverse(int x) {
 
 void main() {
 }
+

--- a/examples/leetcode-out/dart/8/string-to-integer-atoi.dart
+++ b/examples/leetcode-out/dart/8/string-to-integer-atoi.dart
@@ -33,29 +33,29 @@ int digit(String ch) {
 }
 
 int myAtoi(String s) {
-	int i = 0;
-	int n = s.length;
+	dynamic i = 0;
+	dynamic n = s.length;
 	while (((i < n) && (_indexString(s, i) == _indexString(" ", 0)))) {
-		i = (i + 1);
+		i = ((i + 1)).toInt();
 	}
-	int sign = 1;
+	dynamic sign = 1;
 	if (((i < n) && (((_indexString(s, i) == _indexString("+", 0)) || (_indexString(s, i) == _indexString("-", 0)))))) {
 		if ((_indexString(s, i) == _indexString("-", 0))) {
-			sign = -1;
+			sign = (-1).toInt();
 		}
-		i = (i + 1);
+		i = ((i + 1)).toInt();
 	}
-	int result = 0;
+	dynamic result = 0;
 	while ((i < n)) {
-		String ch = s.substring(i, (i + 1));
-		int d = digit(ch);
+		dynamic ch = s.substring(i, (i + 1));
+		dynamic d = digit(ch);
 		if ((d < 0)) {
 			break;
 		}
-		result = ((result * 10) + d);
-		i = (i + 1);
+		result = (((result * 10) + d)).toInt();
+		i = ((i + 1)).toInt();
 	}
-	result = (result * sign);
+	result = ((result * sign)).toInt();
 	if ((result > 2147483647)) {
 		return 2147483647;
 	}
@@ -78,3 +78,4 @@ String _indexString(String s, int i) {
 	}
 	return String.fromCharCode(runes[i]);
 }
+

--- a/examples/leetcode-out/dart/9/palindrome-number.dart
+++ b/examples/leetcode-out/dart/9/palindrome-number.dart
@@ -2,10 +2,10 @@ bool isPalindrome(int x) {
 	if ((x < 0)) {
 		return false;
 	}
-	String s = x.toString();
-	int n = s.length;
+	dynamic s = x.toString();
+	dynamic n = s.length;
 	for (var i = 0; i < (n ~/ 2); i++) {
-		if ((s[i] != s[((n - 1) - i)])) {
+		if ((_indexString(s, (i).toInt()) != _indexString(s, (((n - 1) - i)).toInt()))) {
 			return false;
 		}
 	}
@@ -14,3 +14,15 @@ bool isPalindrome(int x) {
 
 void main() {
 }
+
+String _indexString(String s, int i) {
+	var runes = s.runes.toList();
+	if (i < 0) {
+		i += runes.length;
+	}
+	if (i < 0 || i >= runes.length) {
+		throw RangeError('index out of range');
+	}
+	return String.fromCharCode(runes[i]);
+}
+


### PR DESCRIPTION
## Summary
- relax Dart variable declarations to use `dynamic`
- cast assignments to int when needed
- cast string index expressions to `int`
- add helpers for detecting int expressions
- add tests that compile and run LeetCode problems 1-30
- regenerate Dart outputs for LeetCode examples

## Testing
- `go test ./...`
- `go test ./compile/dart -run TestDartLeetCodeExamples -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68543cad24148320a808d352d37a873b