### PR TITLE
Add rust LeetCode outputs and document backend limitations

### DIFF
--- a/compile/rust/README.md
+++ b/compile/rust/README.md
@@ -1,0 +1,13 @@
+# Rust Backend
+
+The Rust backend translates Mochi programs to Rust source code. It is used for experiments and to run solutions on systems where `rustc` is available.
+
+## Unsupported features
+
+The current implementation lacks support for:
+
+- Nested function definitions.
+- Automatic detection of mutable parameters.
+- Map and string index helpers for generic collections.
+
+These limitations cause some LeetCode programs to fail to compile.

--- a/examples/leetcode-out/rust/11/container-with-most-water.rs
+++ b/examples/leetcode-out/rust/11/container-with-most-water.rs
@@ -1,0 +1,28 @@
+fn maxArea(height: Vec<i32>) -> i32 {
+    let mut left = 0;
+    let mut right = height.len() as i32 - 1;
+    let mut maxArea = 0;
+    while left < right {
+        let mut width = right - left;
+        let mut h = 0;
+        if height[left as usize] < height[right as usize] {
+            h = height[left as usize];
+        } else {
+            h = height[right as usize];
+        }
+        let mut area = h * width;
+        if area > maxArea {
+            maxArea = area;
+        }
+        if height[left as usize] < height[right as usize] {
+            left = left + 1;
+        } else {
+            right = right - 1;
+        }
+    }
+    return maxArea;
+}
+
+fn main() {
+}
+

--- a/examples/leetcode-out/rust/15/three-sum.rs
+++ b/examples/leetcode-out/rust/15/three-sum.rs
@@ -1,0 +1,51 @@
+fn threeSum(nums: Vec<i32>) -> Vec<Vec<i32>> {
+    let mut sorted = {
+    let mut _res = Vec::new();
+    for x in nums {
+        _res.push(x);
+    }
+    _res
+};
+    let mut n = sorted.len() as i32;
+    let mut res: Vec<Vec<i32>> = vec![];
+    let mut i = 0;
+    while i < n {
+        if i > 0 && sorted[i as usize] == sorted[(i - 1) as usize] {
+            i = i + 1;
+            continue;
+        }
+        let mut left = i + 1;
+        let mut right = n - 1;
+        while left < right {
+            let mut sum = sorted[i as usize] + sorted[left as usize] + sorted[right as usize];
+            if sum == 0 {
+                res = _concat(&res, &vec![vec![sorted[i as usize], sorted[left as usize], sorted[right as usize]]]);
+                left = left + 1;
+                while left < right && sorted[left as usize] == sorted[(left - 1) as usize] {
+                    left = left + 1;
+                }
+                right = right - 1;
+                while left < right && sorted[right as usize] == sorted[(right + 1) as usize] {
+                    right = right - 1;
+                }
+            } else 
+            if sum < 0 {
+                left = left + 1;
+            } else {
+                right = right - 1;
+            }
+        }
+        i = i + 1;
+    }
+    return res;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/16/3sum-closest.rs
+++ b/examples/leetcode-out/rust/16/3sum-closest.rs
@@ -1,0 +1,46 @@
+fn threeSumClosest(nums: Vec<i32>, target: i32) -> i32 {
+    let mut sorted = {
+    let mut _res = Vec::new();
+    for n in nums {
+        _res.push(n);
+    }
+    _res
+};
+    let mut n = sorted.len() as i32;
+    let mut best = sorted[(0) as usize] + sorted[(1) as usize] + sorted[(2) as usize];
+    for i in 0..n {
+        let mut left = i + 1;
+        let mut right = n - 1;
+        while left < right {
+            let mut sum = sorted[i as usize] + sorted[left as usize] + sorted[right as usize];
+            if sum == target {
+                return target;
+            }
+            let mut diff = 0;
+            if sum > target {
+                diff = sum - target;
+            } else {
+                diff = target - sum;
+            }
+            let mut bestDiff = 0;
+            if best > target {
+                bestDiff = best - target;
+            } else {
+                bestDiff = target - best;
+            }
+            if diff < bestDiff {
+                best = sum;
+            }
+            if sum < target {
+                left = left + 1;
+            } else {
+                right = right - 1;
+            }
+        }
+    }
+    return best;
+}
+
+fn main() {
+}
+

--- a/examples/leetcode-out/rust/18/four-sum.rs
+++ b/examples/leetcode-out/rust/18/four-sum.rs
@@ -1,0 +1,53 @@
+fn fourSum(nums: Vec<i32>, target: i32) -> Vec<Vec<i32>> {
+    let mut sorted = {
+    let mut _res = Vec::new();
+    for n in nums {
+        _res.push(n);
+    }
+    _res
+};
+    let mut n = sorted.len() as i32;
+    let mut result: Vec<Vec<i32>> = vec![];
+    for i in 0..n {
+        if i > 0 && sorted[i as usize] == sorted[(i - 1) as usize] {
+            continue;
+        }
+        for j in i + 1..n {
+            if j > i + 1 && sorted[j as usize] == sorted[(j - 1) as usize] {
+                continue;
+            }
+            let mut left = j + 1;
+            let mut right = n - 1;
+            while left < right {
+                let mut sum = sorted[i as usize] + sorted[j as usize] + sorted[left as usize] + sorted[right as usize];
+                if sum == target {
+                    result = _concat(&result, &vec![vec![sorted[i as usize], sorted[j as usize], sorted[left as usize], sorted[right as usize]]]);
+                    left = left + 1;
+                    right = right - 1;
+                    while left < right && sorted[left as usize] == sorted[(left - 1) as usize] {
+                        left = left + 1;
+                    }
+                    while left < right && sorted[right as usize] == sorted[(right + 1) as usize] {
+                        right = right - 1;
+                    }
+                } else 
+                if sum < target {
+                    left = left + 1;
+                } else {
+                    right = right - 1;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/19/remove-nth-node-from-end-of-list.rs
+++ b/examples/leetcode-out/rust/19/remove-nth-node-from-end-of-list.rs
@@ -1,0 +1,22 @@
+fn removeNthFromEnd(nums: Vec<i32>, n: i32) -> Vec<i32> {
+    let mut idx = nums.len() as i32 - n;
+    let mut result = vec![];
+    let mut i = 0;
+    while i < nums.len() as i32 {
+        if i != idx {
+            result = _concat(&result, &vec![nums[i as usize]]);
+        }
+        i = i + 1;
+    }
+    return result;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/21/merge-two-sorted-lists.rs
+++ b/examples/leetcode-out/rust/21/merge-two-sorted-lists.rs
@@ -1,0 +1,33 @@
+fn mergeTwoLists(l1: Vec<i32>, l2: Vec<i32>) -> Vec<i32> {
+    let mut i = 0;
+    let mut j = 0;
+    let mut result = vec![];
+    while i < l1.len() as i32 && j < l2.len() as i32 {
+        if l1[i as usize] <= l2[j as usize] {
+            result = _concat(&result, &vec![l1[i as usize]]);
+            i = i + 1;
+        } else {
+            result = _concat(&result, &vec![l2[j as usize]]);
+            j = j + 1;
+        }
+    }
+    while i < l1.len() as i32 {
+        result = _concat(&result, &vec![l1[i as usize]]);
+        i = i + 1;
+    }
+    while j < l2.len() as i32 {
+        result = _concat(&result, &vec![l2[j as usize]]);
+        j = j + 1;
+    }
+    return result;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/23/merge-k-sorted-lists.rs
+++ b/examples/leetcode-out/rust/23/merge-k-sorted-lists.rs
@@ -1,0 +1,44 @@
+fn mergeKLists(lists: Vec<Vec<i32>>) -> Vec<i32> {
+    let mut k = lists.len() as i32;
+    let mut indices: Vec<i32> = vec![];
+    let mut i = 0;
+    while i < k {
+        indices = _concat(&indices, &vec![0]);
+        i = i + 1;
+    }
+    let mut result: Vec<i32> = vec![];
+    while true {
+        let mut best = 0;
+        let mut bestList = -1;
+        let mut found = false;
+        let mut j = 0;
+        while j < k {
+            let mut idx = indices[j as usize];
+            if idx < lists[j as usize].len() as i32 {
+                let mut val = lists[j as usize][idx as usize];
+                if !found || val < best {
+                    best = val;
+                    bestList = j;
+                    found = true;
+                }
+            }
+            j = j + 1;
+        }
+        if !found {
+            break;
+        }
+        result = _concat(&result, &vec![best]);
+        indices[bestList as usize] = indices[bestList as usize] + 1;
+    }
+    return result;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/24/swap-nodes-in-pairs.rs
+++ b/examples/leetcode-out/rust/24/swap-nodes-in-pairs.rs
@@ -1,0 +1,23 @@
+fn swapPairs(nums: Vec<i32>) -> Vec<i32> {
+    let mut i = 0;
+    let mut result = vec![];
+    while i < nums.len() as i32 {
+        if i + 1 < nums.len() as i32 {
+            result = _concat(&result, &vec![nums[(i + 1) as usize], nums[i as usize]]);
+        } else {
+            result = _concat(&result, &vec![nums[i as usize]]);
+        }
+        i = i + 2;
+    }
+    return result;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/25/reverse-nodes-in-k-group.rs
+++ b/examples/leetcode-out/rust/25/reverse-nodes-in-k-group.rs
@@ -1,0 +1,36 @@
+fn reverseKGroup(nums: Vec<i32>, k: i32) -> Vec<i32> {
+    let mut n = nums.len() as i32;
+    if k <= 1 {
+        return nums;
+    }
+    let mut result = vec![];
+    let mut i = 0;
+    while i < n {
+        let mut end = i + k;
+        if end <= n {
+            let mut j = end - 1;
+            while j >= i {
+                result = _concat(&result, &vec![nums[j as usize]]);
+                j = j - 1;
+            }
+        } else {
+            let mut j = i;
+            while j < n {
+                result = _concat(&result, &vec![nums[j as usize]]);
+                j = j + 1;
+            }
+        }
+        i = i + k;
+    }
+    return result;
+}
+
+fn main() {
+}
+
+fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut res = Vec::with_capacity(a.len() + b.len());
+    res.extend_from_slice(a);
+    res.extend_from_slice(b);
+    res
+}

--- a/examples/leetcode-out/rust/26/remove-duplicates-from-sorted-array.rs
+++ b/examples/leetcode-out/rust/26/remove-duplicates-from-sorted-array.rs
@@ -1,0 +1,21 @@
+fn removeDuplicates(nums: Vec<i32>) -> i32 {
+    if nums.len() as i32 == 0 {
+        return 0;
+    }
+    let mut count = 1;
+    let mut prev = nums[(0) as usize];
+    let mut i = 1;
+    while i < nums.len() as i32 {
+        let mut cur = nums[i as usize];
+        if cur != prev {
+            count = count + 1;
+            prev = cur;
+        }
+        i = i + 1;
+    }
+    return count;
+}
+
+fn main() {
+}
+

--- a/examples/leetcode-out/rust/28/find-the-index-of-the-first-occurrence-in-a-string.rs
+++ b/examples/leetcode-out/rust/28/find-the-index-of-the-first-occurrence-in-a-string.rs
@@ -1,0 +1,27 @@
+fn strStr(haystack: &str, needle: &str) -> i32 {
+    let mut n = haystack.len() as i32;
+    let mut m = needle.len() as i32;
+    if m == 0 {
+        return 0;
+    }
+    if m > n {
+        return -1;
+    }
+    for i in 0..n - m + 1 {
+        let mut j = 0;
+        while j < m {
+            if haystack.chars().nth((i + j) as usize).unwrap() != needle.chars().nth((j) as usize).unwrap() {
+                break;
+            }
+            j = j + 1;
+        }
+        if j == m {
+            return i;
+        }
+    }
+    return -1;
+}
+
+fn main() {
+}
+


### PR DESCRIPTION
## Summary
- generate Rust solutions for LeetCode examples 1..30 and keep only runnable ones
- document missing Rust backend features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854ca45710c832096b6a54fc23a4af4