### PR TITLE
Extend PHP compiler LeetCode support

### DIFF
--- a/compile/php/README.md
+++ b/compile/php/README.md
@@ -305,3 +305,16 @@ The tests skip automatically if `php` is not installed and rely on
 The PHP backend currently supports a subset of Mochi's features suitable for
 scripts and simple utilities. Complex type handling and advanced runtime
 support are not yet implemented.
+
+### Unsupported features
+
+The PHP compiler is intentionally lightweight. The following Mochi features are
+currently **not supported**:
+
+- modules or imports
+- concurrency primitives
+- generics and complex type inference
+- advanced dataset queries such as joins or grouping
+- skip/take query clauses
+- nested functions that capture variables across scopes
+

--- a/compile/php/compiler_test.go
+++ b/compile/php/compiler_test.go
@@ -58,16 +58,9 @@ func TestPHPCompiler_LeetCodeExamples(t *testing.T) {
 	if err := phpcode.EnsurePHP(); err != nil {
 		t.Skipf("php not installed: %v", err)
 	}
-	runExample(t, 1)
-	runExample(t, 2)
-	runExample(t, 3)
-	runExample(t, 4)
-	runExample(t, 5)
-	runExample(t, 6)
-	runExample(t, 7)
-	runExample(t, 8)
-	runExample(t, 9)
-	runExample(t, 10)
+	for i := 1; i <= 30; i++ {
+		runExample(t, i)
+	}
 }
 
 func runExample(t *testing.T, i int) {

--- a/compile/php/helpers.go
+++ b/compile/php/helpers.go
@@ -59,3 +59,24 @@ func simpleStringKey(e *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+func identName(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
+}

--- a/compile/php/leetcode_test.go
+++ b/compile/php/leetcode_test.go
@@ -1,6 +1,7 @@
 package phpcode_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,93 +67,16 @@ func TestLeetCode1(t *testing.T) {
 	}
 }
 
-func TestLeetCode2(t *testing.T) {
+func TestLeetCodeProblems(t *testing.T) {
 	if err := phpcode.EnsurePHP(); err != nil {
 		t.Skipf("php not installed: %v", err)
 	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "2"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode3(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "3"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode4(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "4"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode5(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "5"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode6(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "6"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode7(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "7"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode8(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "8"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode9(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "9"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
-
-func TestLeetCode10(t *testing.T) {
-	if err := phpcode.EnsurePHP(); err != nil {
-		t.Skipf("php not installed: %v", err)
-	}
-	got := strings.TrimSpace(compileAndRunLeetCode(t, "10"))
-	if got != "" {
-		t.Fatalf("unexpected output: %q", got)
+	for i := 2; i <= 30; i++ {
+		id := fmt.Sprint(i)
+		got := strings.TrimSpace(compileAndRunLeetCode(t, id))
+		if got != "" {
+			t.Fatalf("unexpected output for %s: %q", id, got)
+		}
 	}
 }
 

--- a/examples/leetcode-out/php/1/two-sum.php
+++ b/examples/leetcode-out/php/1/two-sum.php
@@ -1,5 +1,5 @@
 <?php
-function twoSum($nums, $target) {
+function mochi_twoSum($nums, $target) {
 	$n = (is_array($nums) ? count($nums) : strlen($nums));
 	for ($i = 0; $i < $n; $i++) {
 		for ($j = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))); $j < $n; $j++) {
@@ -11,6 +11,6 @@ function twoSum($nums, $target) {
 	return [-1, -1];
 }
 
-$result = twoSum([2, 7, 11, 15], 9);
+$result = mochi_twoSum([2, 7, 11, 15], 9);
 echo $result[0], PHP_EOL;
 echo $result[1], PHP_EOL;

--- a/examples/leetcode-out/php/10/regular-expression-matching.php
+++ b/examples/leetcode-out/php/10/regular-expression-matching.php
@@ -1,5 +1,5 @@
 <?php
-function isMatch($s, $p) {
+function mochi_isMatch($s, $p) {
 	$m = (is_array($s) ? count($s) : strlen($s));
 	$n = (is_array($p) ? count($p) : strlen($p));
 	$dp = [];
@@ -25,18 +25,32 @@ function isMatch($s, $p) {
 					$first = true;
 				}
 			}
-			if (((((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1))) < $n) && ($p[((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1)))] == "*"))) {
-				if (($dp[$i2][((is_array($j2) && is_array(2)) ? array_merge($j2, 2) : ((is_string($j2) || is_string(2)) ? ($j2 . 2) : ($j2 + 2)))] || (($first && $dp[((is_array($i2) && is_array(1)) ? array_merge($i2, 1) : ((is_string($i2) || is_string(1)) ? ($i2 . 1) : ($i2 + 1)))][$j2])))) {
-					$dp[$i2][$j2] = true;
-				} else {
-					$dp[$i2][$j2] = false;
+			$star = false;
+			if ((((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1))) < $n)) {
+				if (($p[((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1)))] == "*")) {
+					$star = true;
 				}
+			}
+			if ($star) {
+				$ok = false;
+				if ($dp[$i2][((is_array($j2) && is_array(2)) ? array_merge($j2, 2) : ((is_string($j2) || is_string(2)) ? ($j2 . 2) : ($j2 + 2)))]) {
+					$ok = true;
+				} else {
+					if ($first) {
+						if ($dp[((is_array($i2) && is_array(1)) ? array_merge($i2, 1) : ((is_string($i2) || is_string(1)) ? ($i2 . 1) : ($i2 + 1)))][$j2]) {
+							$ok = true;
+						}
+					}
+				}
+				$dp[$i2][$j2] = $ok;
 			} else {
-				if (($first && $dp[((is_array($i2) && is_array(1)) ? array_merge($i2, 1) : ((is_string($i2) || is_string(1)) ? ($i2 . 1) : ($i2 + 1)))][((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1)))])) {
-					$dp[$i2][$j2] = true;
-				} else {
-					$dp[$i2][$j2] = false;
+				$ok = false;
+				if ($first) {
+					if ($dp[((is_array($i2) && is_array(1)) ? array_merge($i2, 1) : ((is_string($i2) || is_string(1)) ? ($i2 . 1) : ($i2 + 1)))][((is_array($j2) && is_array(1)) ? array_merge($j2, 1) : ((is_string($j2) || is_string(1)) ? ($j2 . 1) : ($j2 + 1)))]) {
+						$ok = true;
+					}
 				}
+				$dp[$i2][$j2] = $ok;
 			}
 			$j2 = ($j2 - 1);
 		}
@@ -45,28 +59,28 @@ function isMatch($s, $p) {
 	return $dp[0][0];
 }
 
-function test_example_1() {
-	if (!((isMatch("aa", "a") == false))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_isMatch("aa", "a") == false))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((isMatch("aa", "a*") == true))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_isMatch("aa", "a*") == true))) { throw new Exception('expect failed'); }
 }
 
-function test_example_3() {
-	if (!((isMatch("ab", ".*") == true))) { throw new Exception('expect failed'); }
+function mochi_test_example_3() {
+	if (!((mochi_isMatch("ab", ".*") == true))) { throw new Exception('expect failed'); }
 }
 
-function test_example_4() {
-	if (!((isMatch("aab", "c*a*b") == true))) { throw new Exception('expect failed'); }
+function mochi_test_example_4() {
+	if (!((mochi_isMatch("aab", "c*a*b") == true))) { throw new Exception('expect failed'); }
 }
 
-function test_example_5() {
-	if (!((isMatch("mississippi", "mis*is*p*.") == false))) { throw new Exception('expect failed'); }
+function mochi_test_example_5() {
+	if (!((mochi_isMatch("mississippi", "mis*is*p*.") == false))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_example_3();
-test_example_4();
-test_example_5();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_example_4();
+mochi_test_example_5();

--- a/examples/leetcode-out/php/11/container-with-most-water.php
+++ b/examples/leetcode-out/php/11/container-with-most-water.php
@@ -1,0 +1,46 @@
+<?php
+function mochi_maxArea($height) {
+	$left = 0;
+	$right = ((is_array($height) ? count($height) : strlen($height)) - 1);
+	$maxArea = 0;
+	while (($left < $right)) {
+		$width = ($right - $left);
+		$h = 0;
+		if (($height[$left] < $height[$right])) {
+			$h = $height[$left];
+		} else {
+			$h = $height[$right];
+		}
+		$area = ($h * $width);
+		if (($area > $maxArea)) {
+			$maxArea = $area;
+		}
+		if (($height[$left] < $height[$right])) {
+			$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+		} else {
+			$right = ($right - 1);
+		}
+	}
+	return $maxArea;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_maxArea([1, 8, 6, 2, 5, 4, 8, 3, 7]) == 49))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_maxArea([1, 1]) == 1))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_decreasing_heights() {
+	if (!((mochi_maxArea([4, 3, 2, 1, 4]) == 16))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_short_array() {
+	if (!((mochi_maxArea([1, 2, 1]) == 2))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_decreasing_heights();
+mochi_test_short_array();

--- a/examples/leetcode-out/php/12/integer-to-roman.php
+++ b/examples/leetcode-out/php/12/integer-to-roman.php
@@ -1,0 +1,37 @@
+<?php
+function mochi_intToRoman($num) {
+	$values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
+	$symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"];
+	$result = "";
+	$i = 0;
+	while (($num > 0)) {
+		while (($num >= $values[$i])) {
+			$result = ((is_array($result) && is_array($symbols[$i])) ? array_merge($result, $symbols[$i]) : ((is_string($result) || is_string($symbols[$i])) ? ($result . $symbols[$i]) : ($result + $symbols[$i])));
+			$num = ($num - $values[$i]);
+		}
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_intToRoman(3) == "III"))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_intToRoman(58) == "LVIII"))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_intToRoman(1994) == "MCMXCIV"))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_small_numbers() {
+	if (!((mochi_intToRoman(4) == "IV"))) { throw new Exception('expect failed'); }
+	if (!((mochi_intToRoman(9) == "IX"))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_small_numbers();

--- a/examples/leetcode-out/php/13/roman-to-integer.php
+++ b/examples/leetcode-out/php/13/roman-to-integer.php
@@ -1,0 +1,49 @@
+<?php
+function mochi_romanToInt($s) {
+	$values = ["I" => 1, "V" => 5, "X" => 10, "L" => 50, "C" => 100, "D" => 500, "M" => 1000];
+	$total = 0;
+	$i = 0;
+	$n = (is_array($s) ? count($s) : strlen($s));
+	while (($i < $n)) {
+		$curr = $values[$s[$i]];
+		if ((((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))) < $n)) {
+			$next = $values[$s[((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))]];
+			if (($curr < $next)) {
+				$total = (((is_array($total) && is_array($next)) ? array_merge($total, $next) : ((is_string($total) || is_string($next)) ? ($total . $next) : ($total + $next))) - $curr);
+				$i = ((is_array($i) && is_array(2)) ? array_merge($i, 2) : ((is_string($i) || is_string(2)) ? ($i . 2) : ($i + 2)));
+				continue;
+			}
+		}
+		$total = ((is_array($total) && is_array($curr)) ? array_merge($total, $curr) : ((is_string($total) || is_string($curr)) ? ($total . $curr) : ($total + $curr)));
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	return $total;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_romanToInt("III") == 3))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_romanToInt("LVIII") == 58))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_romanToInt("MCMXCIV") == 1994))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_subtractive() {
+	if (!((mochi_romanToInt("IV") == 4))) { throw new Exception('expect failed'); }
+	if (!((mochi_romanToInt("IX") == 9))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_tens() {
+	if (!((mochi_romanToInt("XL") == 40))) { throw new Exception('expect failed'); }
+	if (!((mochi_romanToInt("XC") == 90))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_subtractive();
+mochi_test_tens();

--- a/examples/leetcode-out/php/14/longest-common-prefix.php
+++ b/examples/leetcode-out/php/14/longest-common-prefix.php
@@ -1,0 +1,43 @@
+<?php
+function mochi_longestCommonPrefix($strs) {
+	if (((is_array($strs) ? count($strs) : strlen($strs)) == 0)) {
+		return "";
+	}
+	$prefix = $strs[0];
+	for ($i = 1; $i < (is_array($strs) ? count($strs) : strlen($strs)); $i++) {
+		$j = 0;
+		$current = $strs[$i];
+		while ((($j < (is_array($prefix) ? count($prefix) : strlen($prefix))) && ($j < (is_array($current) ? count($current) : strlen($current))))) {
+			if (($prefix[$j] != $current[$j])) {
+				break;
+			}
+			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+		}
+		$prefix = (is_array($prefix) ? array_slice($prefix, 0, ($j) - (0)) : substr($prefix, 0, ($j) - (0)));
+		if (($prefix == "")) {
+			break;
+		}
+	}
+	return $prefix;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_longestCommonPrefix(["flower", "flow", "flight"]) == "fl"))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_longestCommonPrefix(["dog", "racecar", "car"]) == ""))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_single_string() {
+	if (!((mochi_longestCommonPrefix(["single"]) == "single"))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_no_common_prefix() {
+	if (!((mochi_longestCommonPrefix(["a", "b", "c"]) == ""))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_single_string();
+mochi_test_no_common_prefix();

--- a/examples/leetcode-out/php/15/three-sum.php
+++ b/examples/leetcode-out/php/15/three-sum.php
@@ -1,0 +1,52 @@
+<?php
+function mochi_threeSum($nums) {
+	$sorted = (function($tmp){ sort($tmp); return $tmp; })($nums);
+	$n = (is_array($sorted) ? count($sorted) : strlen($sorted));
+	$res = [];
+	$i = 0;
+	while (($i < $n)) {
+		if ((($i > 0) && ($sorted[$i] == $sorted[($i - 1)]))) {
+			$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+			continue;
+		}
+		$left = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+		$right = ($n - 1);
+		while (($left < $right)) {
+			$sum = ((is_array(((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left])))) && is_array($sorted[$right])) ? array_merge(((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left]))), $sorted[$right]) : ((is_string(((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left])))) || is_string($sorted[$right])) ? (((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left]))) . $sorted[$right]) : (((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left]))) + $sorted[$right])));
+			if (($sum == 0)) {
+				$res = ((is_array($res) && is_array([[$sorted[$i], $sorted[$left], $sorted[$right]]])) ? array_merge($res, [[$sorted[$i], $sorted[$left], $sorted[$right]]]) : ((is_string($res) || is_string([[$sorted[$i], $sorted[$left], $sorted[$right]]])) ? ($res . [[$sorted[$i], $sorted[$left], $sorted[$right]]]) : ($res + [[$sorted[$i], $sorted[$left], $sorted[$right]]])));
+				$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+				while ((($left < $right) && ($sorted[$left] == $sorted[($left - 1)]))) {
+					$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+				}
+				$right = ($right - 1);
+				while ((($left < $right) && ($sorted[$right] == $sorted[((is_array($right) && is_array(1)) ? array_merge($right, 1) : ((is_string($right) || is_string(1)) ? ($right . 1) : ($right + 1)))]))) {
+					$right = ($right - 1);
+				}
+			} else 
+			if (($sum < 0)) {
+				$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+			} else {
+				$right = ($right - 1);
+			}
+		}
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	return $res;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_threeSum([-1, 0, 1, 2, -1, -4]) == [[-1, -1, 2], [-1, 0, 1]]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_threeSum([0, 1, 1]) == []))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_threeSum([0, 0, 0]) == [[0, 0, 0]]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();

--- a/examples/leetcode-out/php/16/3sum-closest.php
+++ b/examples/leetcode-out/php/16/3sum-closest.php
@@ -1,0 +1,53 @@
+<?php
+function mochi_threeSumClosest($nums, $target) {
+	$sorted = (function($tmp){ sort($tmp); return $tmp; })($nums);
+	$n = (is_array($sorted) ? count($sorted) : strlen($sorted));
+	$best = ((is_array(((is_array($sorted[0]) && is_array($sorted[1])) ? array_merge($sorted[0], $sorted[1]) : ((is_string($sorted[0]) || is_string($sorted[1])) ? ($sorted[0] . $sorted[1]) : ($sorted[0] + $sorted[1])))) && is_array($sorted[2])) ? array_merge(((is_array($sorted[0]) && is_array($sorted[1])) ? array_merge($sorted[0], $sorted[1]) : ((is_string($sorted[0]) || is_string($sorted[1])) ? ($sorted[0] . $sorted[1]) : ($sorted[0] + $sorted[1]))), $sorted[2]) : ((is_string(((is_array($sorted[0]) && is_array($sorted[1])) ? array_merge($sorted[0], $sorted[1]) : ((is_string($sorted[0]) || is_string($sorted[1])) ? ($sorted[0] . $sorted[1]) : ($sorted[0] + $sorted[1])))) || is_string($sorted[2])) ? (((is_array($sorted[0]) && is_array($sorted[1])) ? array_merge($sorted[0], $sorted[1]) : ((is_string($sorted[0]) || is_string($sorted[1])) ? ($sorted[0] . $sorted[1]) : ($sorted[0] + $sorted[1]))) . $sorted[2]) : (((is_array($sorted[0]) && is_array($sorted[1])) ? array_merge($sorted[0], $sorted[1]) : ((is_string($sorted[0]) || is_string($sorted[1])) ? ($sorted[0] . $sorted[1]) : ($sorted[0] + $sorted[1]))) + $sorted[2])));
+	for ($i = 0; $i < $n; $i++) {
+		$left = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+		$right = ($n - 1);
+		while (($left < $right)) {
+			$sum = ((is_array(((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left])))) && is_array($sorted[$right])) ? array_merge(((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left]))), $sorted[$right]) : ((is_string(((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left])))) || is_string($sorted[$right])) ? (((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left]))) . $sorted[$right]) : (((is_array($sorted[$i]) && is_array($sorted[$left])) ? array_merge($sorted[$i], $sorted[$left]) : ((is_string($sorted[$i]) || is_string($sorted[$left])) ? ($sorted[$i] . $sorted[$left]) : ($sorted[$i] + $sorted[$left]))) + $sorted[$right])));
+			if (($sum == $target)) {
+				return $target;
+			}
+			$diff = 0;
+			if (($sum > $target)) {
+				$diff = ($sum - $target);
+			} else {
+				$diff = ($target - $sum);
+			}
+			$bestDiff = 0;
+			if (($best > $target)) {
+				$bestDiff = ($best - $target);
+			} else {
+				$bestDiff = ($target - $best);
+			}
+			if (($diff < $bestDiff)) {
+				$best = $sum;
+			}
+			if (($sum < $target)) {
+				$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+			} else {
+				$right = ($right - 1);
+			}
+		}
+	}
+	return $best;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_threeSumClosest([-1, 2, 1, -4], 1) == 2))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_threeSumClosest([0, 0, 0], 1) == 0))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_additional() {
+	if (!((mochi_threeSumClosest([1, 1, 1, 0], -100) == 2))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_additional();

--- a/examples/leetcode-out/php/17/letter-combinations-of-a-phone-number.php
+++ b/examples/leetcode-out/php/17/letter-combinations-of-a-phone-number.php
@@ -1,0 +1,51 @@
+<?php
+function mochi_letterCombinations($digits) {
+	if (((is_array($digits) ? count($digits) : strlen($digits)) == 0)) {
+		return [];
+	}
+	$mapping = ["2" => ["a", "b", "c"], "3" => ["d", "e", "f"], "4" => ["g", "h", "i"], "5" => ["j", "k", "l"], "6" => ["m", "n", "o"], "7" => ["p", "q", "r", "s"], "8" => ["t", "u", "v"], "9" => ["w", "x", "y", "z"]];
+	$result = [""];
+	foreach ((is_string($digits) ? str_split($digits) : $digits) as $d) {
+		if (!((is_array($mapping) ? (array_key_exists($d, $mapping) || in_array($d, $mapping, true)) : (is_string($mapping) ? strpos($mapping, strval($d)) !== false : false)))) {
+			continue;
+		}
+		$letters = $mapping[$d];
+		$next = (function() use ($letters, $result) {
+	$res = [];
+	foreach ((is_string($result) ? str_split($result) : $result) as $p) {
+		foreach ((is_string($letters) ? str_split($letters) : $letters) as $ch) {
+			$res[] = ((is_array($p) && is_array($ch)) ? array_merge($p, $ch) : ((is_string($p) || is_string($ch)) ? ($p . $ch) : ($p + $ch)));
+		}
+	}
+	return $res;
+})();
+		$result = $next;
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_letterCombinations("23") == ["ad", "ae", "af", "bd", "be", "bf", "cd", "ce", "cf"]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_letterCombinations("") == []))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_letterCombinations("2") == ["a", "b", "c"]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_single_seven() {
+	if (!((mochi_letterCombinations("7") == ["p", "q", "r", "s"]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_mix() {
+	if (!((mochi_letterCombinations("79") == ["pw", "px", "py", "pz", "qw", "qx", "qy", "qz", "rw", "rx", "ry", "rz", "sw", "sx", "sy", "sz"]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_single_seven();
+mochi_test_mix();

--- a/examples/leetcode-out/php/18/four-sum.php
+++ b/examples/leetcode-out/php/18/four-sum.php
@@ -1,0 +1,49 @@
+<?php
+function mochi_fourSum($nums, $target) {
+	$sorted = (function($tmp){ sort($tmp); return $tmp; })($nums);
+	$n = (is_array($sorted) ? count($sorted) : strlen($sorted));
+	$result = [];
+	for ($i = 0; $i < $n; $i++) {
+		if ((($i > 0) && ($sorted[$i] == $sorted[($i - 1)]))) {
+			continue;
+		}
+		for ($j = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))); $j < $n; $j++) {
+			if ((($j > ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))) && ($sorted[$j] == $sorted[($j - 1)]))) {
+				continue;
+			}
+			$left = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+			$right = ($n - 1);
+			while (($left < $right)) {
+				$sum = ((is_array(((is_array(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) && is_array($sorted[$left])) ? array_merge(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))), $sorted[$left]) : ((is_string(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) || is_string($sorted[$left])) ? (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) . $sorted[$left]) : (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) + $sorted[$left])))) && is_array($sorted[$right])) ? array_merge(((is_array(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) && is_array($sorted[$left])) ? array_merge(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))), $sorted[$left]) : ((is_string(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) || is_string($sorted[$left])) ? (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) . $sorted[$left]) : (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) + $sorted[$left]))), $sorted[$right]) : ((is_string(((is_array(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) && is_array($sorted[$left])) ? array_merge(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))), $sorted[$left]) : ((is_string(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) || is_string($sorted[$left])) ? (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) . $sorted[$left]) : (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) + $sorted[$left])))) || is_string($sorted[$right])) ? (((is_array(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) && is_array($sorted[$left])) ? array_merge(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))), $sorted[$left]) : ((is_string(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) || is_string($sorted[$left])) ? (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) . $sorted[$left]) : (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) + $sorted[$left]))) . $sorted[$right]) : (((is_array(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) && is_array($sorted[$left])) ? array_merge(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))), $sorted[$left]) : ((is_string(((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j])))) || is_string($sorted[$left])) ? (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) . $sorted[$left]) : (((is_array($sorted[$i]) && is_array($sorted[$j])) ? array_merge($sorted[$i], $sorted[$j]) : ((is_string($sorted[$i]) || is_string($sorted[$j])) ? ($sorted[$i] . $sorted[$j]) : ($sorted[$i] + $sorted[$j]))) + $sorted[$left]))) + $sorted[$right])));
+				if (($sum == $target)) {
+					$result = ((is_array($result) && is_array([[$sorted[$i], $sorted[$j], $sorted[$left], $sorted[$right]]])) ? array_merge($result, [[$sorted[$i], $sorted[$j], $sorted[$left], $sorted[$right]]]) : ((is_string($result) || is_string([[$sorted[$i], $sorted[$j], $sorted[$left], $sorted[$right]]])) ? ($result . [[$sorted[$i], $sorted[$j], $sorted[$left], $sorted[$right]]]) : ($result + [[$sorted[$i], $sorted[$j], $sorted[$left], $sorted[$right]]])));
+					$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+					$right = ($right - 1);
+					while ((($left < $right) && ($sorted[$left] == $sorted[($left - 1)]))) {
+						$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+					}
+					while ((($left < $right) && ($sorted[$right] == $sorted[((is_array($right) && is_array(1)) ? array_merge($right, 1) : ((is_string($right) || is_string(1)) ? ($right . 1) : ($right + 1)))]))) {
+						$right = ($right - 1);
+					}
+				} else 
+				if (($sum < $target)) {
+					$left = ((is_array($left) && is_array(1)) ? array_merge($left, 1) : ((is_string($left) || is_string(1)) ? ($left . 1) : ($left + 1)));
+				} else {
+					$right = ($right - 1);
+				}
+			}
+		}
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_fourSum([1, 0, -1, 0, -2, 2], 0) == [[-2, -1, 1, 2], [-2, 0, 0, 2], [-1, 0, 0, 1]]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_fourSum([2, 2, 2, 2, 2], 8) == [[2, 2, 2, 2]]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();

--- a/examples/leetcode-out/php/19/remove-nth-node-from-end-of-list.php
+++ b/examples/leetcode-out/php/19/remove-nth-node-from-end-of-list.php
@@ -1,0 +1,39 @@
+<?php
+function mochi_removeNthFromEnd($nums, $n) {
+	$idx = ((is_array($nums) ? count($nums) : strlen($nums)) - $n);
+	$result = [];
+	$i = 0;
+	while (($i < (is_array($nums) ? count($nums) : strlen($nums)))) {
+		if (($i != $idx)) {
+			$result = ((is_array($result) && is_array([$nums[$i]])) ? array_merge($result, [$nums[$i]]) : ((is_string($result) || is_string([$nums[$i]])) ? ($result . [$nums[$i]]) : ($result + [$nums[$i]])));
+		}
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_removeNthFromEnd([1, 2, 3, 4, 5], 2) == [1, 2, 3, 5]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_removeNthFromEnd([1], 1) == []))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_removeNthFromEnd([1, 2], 1) == [1]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_remove_first() {
+	if (!((mochi_removeNthFromEnd([7, 8, 9], 3) == [8, 9]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_remove_last() {
+	if (!((mochi_removeNthFromEnd([7, 8, 9], 1) == [7, 8]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_remove_first();
+mochi_test_remove_last();

--- a/examples/leetcode-out/php/2/add-two-numbers.php
+++ b/examples/leetcode-out/php/2/add-two-numbers.php
@@ -1,5 +1,5 @@
 <?php
-function addTwoNumbers($l1, $l2) {
+function mochi_addTwoNumbers($l1, $l2) {
 	$i = 0;
 	$j = 0;
 	$carry = 0;
@@ -23,18 +23,18 @@ function addTwoNumbers($l1, $l2) {
 	return $result;
 }
 
-function test_example_1() {
-	if (!((addTwoNumbers([2, 4, 3], [5, 6, 4]) == [7, 0, 8]))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_addTwoNumbers([2, 4, 3], [5, 6, 4]) == [7, 0, 8]))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((addTwoNumbers([0], [0]) == [0]))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_addTwoNumbers([0], [0]) == [0]))) { throw new Exception('expect failed'); }
 }
 
-function test_example_3() {
-	if (!((addTwoNumbers([9, 9, 9, 9, 9, 9, 9], [9, 9, 9, 9]) == [8, 9, 9, 9, 0, 0, 0, 1]))) { throw new Exception('expect failed'); }
+function mochi_test_example_3() {
+	if (!((mochi_addTwoNumbers([9, 9, 9, 9, 9, 9, 9], [9, 9, 9, 9]) == [8, 9, 9, 9, 0, 0, 0, 1]))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_example_3();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();

--- a/examples/leetcode-out/php/20/valid-parentheses.php
+++ b/examples/leetcode-out/php/20/valid-parentheses.php
@@ -1,0 +1,68 @@
+<?php
+function mochi_isValid($s) {
+	$stack = [];
+	$n = (is_array($s) ? count($s) : strlen($s));
+	for ($i = 0; $i < $n; $i++) {
+		$c = $s[$i];
+		if (($c == "(")) {
+			$stack = ((is_array($stack) && is_array([")"])) ? array_merge($stack, [")"]) : ((is_string($stack) || is_string([")"])) ? ($stack . [")"]) : ($stack + [")"])));
+		} else 
+		if (($c == "[")) {
+			$stack = ((is_array($stack) && is_array(["]"])) ? array_merge($stack, ["]"]) : ((is_string($stack) || is_string(["]"])) ? ($stack . ["]"]) : ($stack + ["]"])));
+		} else 
+		if (($c == "{")) {
+			$stack = ((is_array($stack) && is_array(["}"])) ? array_merge($stack, ["}"]) : ((is_string($stack) || is_string(["}"])) ? ($stack . ["}"]) : ($stack + ["}"])));
+		} else {
+			if (((is_array($stack) ? count($stack) : strlen($stack)) == 0)) {
+				return false;
+			}
+			$top = $stack[((is_array($stack) ? count($stack) : strlen($stack)) - 1)];
+			if (($top != $c)) {
+				return false;
+			}
+			$stack = (is_array($stack) ? array_slice($stack, 0, (((is_array($stack) ? count($stack) : strlen($stack)) - 1)) - (0)) : substr($stack, 0, (((is_array($stack) ? count($stack) : strlen($stack)) - 1)) - (0)));
+		}
+	}
+	return ((is_array($stack) ? count($stack) : strlen($stack)) == 0);
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_isValid("()") == true))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_isValid("()[]{}") == true))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_isValid("(]") == false))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_4() {
+	if (!((mochi_isValid("([)]") == false))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_5() {
+	if (!((mochi_isValid("{[]}") == true))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_empty_string() {
+	if (!((mochi_isValid("") == true))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_single_closing() {
+	if (!((mochi_isValid("]") == false))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_unmatched_open() {
+	if (!((mochi_isValid("((") == false))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_example_4();
+mochi_test_example_5();
+mochi_test_empty_string();
+mochi_test_single_closing();
+mochi_test_unmatched_open();

--- a/examples/leetcode-out/php/21/merge-two-sorted-lists.php
+++ b/examples/leetcode-out/php/21/merge-two-sorted-lists.php
@@ -1,0 +1,50 @@
+<?php
+function mochi_mergeTwoLists($l1, $l2) {
+	$i = 0;
+	$j = 0;
+	$result = [];
+	while ((($i < (is_array($l1) ? count($l1) : strlen($l1))) && ($j < (is_array($l2) ? count($l2) : strlen($l2))))) {
+		if (($l1[$i] <= $l2[$j])) {
+			$result = ((is_array($result) && is_array([$l1[$i]])) ? array_merge($result, [$l1[$i]]) : ((is_string($result) || is_string([$l1[$i]])) ? ($result . [$l1[$i]]) : ($result + [$l1[$i]])));
+			$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+		} else {
+			$result = ((is_array($result) && is_array([$l2[$j]])) ? array_merge($result, [$l2[$j]]) : ((is_string($result) || is_string([$l2[$j]])) ? ($result . [$l2[$j]]) : ($result + [$l2[$j]])));
+			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+		}
+	}
+	while (($i < (is_array($l1) ? count($l1) : strlen($l1)))) {
+		$result = ((is_array($result) && is_array([$l1[$i]])) ? array_merge($result, [$l1[$i]]) : ((is_string($result) || is_string([$l1[$i]])) ? ($result . [$l1[$i]]) : ($result + [$l1[$i]])));
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	while (($j < (is_array($l2) ? count($l2) : strlen($l2)))) {
+		$result = ((is_array($result) && is_array([$l2[$j]])) ? array_merge($result, [$l2[$j]]) : ((is_string($result) || is_string([$l2[$j]])) ? ($result . [$l2[$j]]) : ($result + [$l2[$j]])));
+		$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_mergeTwoLists([1, 2, 4], [1, 3, 4]) == [1, 1, 2, 3, 4, 4]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_mergeTwoLists([], []) == []))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_mergeTwoLists([], [0]) == [0]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_different_lengths() {
+	if (!((mochi_mergeTwoLists([1, 5, 7], [2, 3, 4, 6, 8]) == [1, 2, 3, 4, 5, 6, 7, 8]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_one_list_empty() {
+	if (!((mochi_mergeTwoLists([1, 2, 3], []) == [1, 2, 3]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_different_lengths();
+mochi_test_one_list_empty();

--- a/examples/leetcode-out/php/22/generate-parentheses.php
+++ b/examples/leetcode-out/php/22/generate-parentheses.php
@@ -1,0 +1,35 @@
+<?php
+function mochi_generateParenthesis($n) {
+	$result = [];
+	$backtrack = null;
+	$backtrack = function ($current, $open, $close) use (&$n, &$result, &$backtrack) {
+		if (((is_array($current) ? count($current) : strlen($current)) == ($n * 2))) {
+			$result = ((is_array($result) && is_array([$current])) ? array_merge($result, [$current]) : ((is_string($result) || is_string([$current])) ? ($result . [$current]) : ($result + [$current])));
+		} else {
+			if (($open < $n)) {
+				$backtrack(((is_array($current) && is_array("(")) ? array_merge($current, "(") : ((is_string($current) || is_string("(")) ? ($current . "(") : ($current + "("))), ((is_array($open) && is_array(1)) ? array_merge($open, 1) : ((is_string($open) || is_string(1)) ? ($open . 1) : ($open + 1))), $close);
+			}
+			if (($close < $open)) {
+				$backtrack(((is_array($current) && is_array(")")) ? array_merge($current, ")") : ((is_string($current) || is_string(")")) ? ($current . ")") : ($current + ")"))), $open, ((is_array($close) && is_array(1)) ? array_merge($close, 1) : ((is_string($close) || is_string(1)) ? ($close . 1) : ($close + 1))));
+			}
+		}
+	};
+	$backtrack("", 0, 0);
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_generateParenthesis(3) == ["((()))", "(()())", "(())()", "()(())", "()()()"]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_generateParenthesis(1) == ["()"]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_two_pairs() {
+	if (!((mochi_generateParenthesis(2) == ["(())", "()()"]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_two_pairs();

--- a/examples/leetcode-out/php/23/merge-k-sorted-lists.php
+++ b/examples/leetcode-out/php/23/merge-k-sorted-lists.php
@@ -1,0 +1,51 @@
+<?php
+function mochi_mergeKLists($lists) {
+	$k = (is_array($lists) ? count($lists) : strlen($lists));
+	$indices = [];
+	$i = 0;
+	while (($i < $k)) {
+		$indices = ((is_array($indices) && is_array([0])) ? array_merge($indices, [0]) : ((is_string($indices) || is_string([0])) ? ($indices . [0]) : ($indices + [0])));
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	$result = [];
+	while (true) {
+		$best = 0;
+		$bestList = -1;
+		$found = false;
+		$j = 0;
+		while (($j < $k)) {
+			$idx = $indices[$j];
+			if (($idx < (is_array($lists[$j]) ? count($lists[$j]) : strlen($lists[$j])))) {
+				$val = $lists[$j][$idx];
+				if ((!$found || ($val < $best))) {
+					$best = $val;
+					$bestList = $j;
+					$found = true;
+				}
+			}
+			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+		}
+		if (!$found) {
+			break;
+		}
+		$result = ((is_array($result) && is_array([$best])) ? array_merge($result, [$best]) : ((is_string($result) || is_string([$best])) ? ($result . [$best]) : ($result + [$best])));
+		$indices[$bestList] = ((is_array($indices[$bestList]) && is_array(1)) ? array_merge($indices[$bestList], 1) : ((is_string($indices[$bestList]) || is_string(1)) ? ($indices[$bestList] . 1) : ($indices[$bestList] + 1)));
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_mergeKLists([[1, 4, 5], [1, 3, 4], [2, 6]]) == [1, 1, 2, 3, 4, 4, 5, 6]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_mergeKLists([]) == []))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_mergeKLists([[]]) == []))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();

--- a/examples/leetcode-out/php/24/swap-nodes-in-pairs.php
+++ b/examples/leetcode-out/php/24/swap-nodes-in-pairs.php
@@ -1,0 +1,35 @@
+<?php
+function mochi_swapPairs($nums) {
+	$i = 0;
+	$result = [];
+	while (($i < (is_array($nums) ? count($nums) : strlen($nums)))) {
+		if ((((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))) < (is_array($nums) ? count($nums) : strlen($nums)))) {
+			$result = ((is_array($result) && is_array([$nums[((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))], $nums[$i]])) ? array_merge($result, [$nums[((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))], $nums[$i]]) : ((is_string($result) || is_string([$nums[((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))], $nums[$i]])) ? ($result . [$nums[((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))], $nums[$i]]) : ($result + [$nums[((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))], $nums[$i]])));
+		} else {
+			$result = ((is_array($result) && is_array([$nums[$i]])) ? array_merge($result, [$nums[$i]]) : ((is_string($result) || is_string([$nums[$i]])) ? ($result . [$nums[$i]]) : ($result + [$nums[$i]])));
+		}
+		$i = ((is_array($i) && is_array(2)) ? array_merge($i, 2) : ((is_string($i) || is_string(2)) ? ($i . 2) : ($i + 2)));
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_swapPairs([1, 2, 3, 4]) == [2, 1, 4, 3]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_swapPairs([]) == []))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_swapPairs([1]) == [1]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_odd_length() {
+	if (!((mochi_swapPairs([1, 2, 3]) == [2, 1, 3]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_odd_length();

--- a/examples/leetcode-out/php/25/reverse-nodes-in-k-group.php
+++ b/examples/leetcode-out/php/25/reverse-nodes-in-k-group.php
@@ -1,0 +1,53 @@
+<?php
+function mochi_reverseKGroup($nums, $k) {
+	$n = (is_array($nums) ? count($nums) : strlen($nums));
+	if (($k <= 1)) {
+		return $nums;
+	}
+	$result = [];
+	$i = 0;
+	while (($i < $n)) {
+		$end = ((is_array($i) && is_array($k)) ? array_merge($i, $k) : ((is_string($i) || is_string($k)) ? ($i . $k) : ($i + $k)));
+		if (($end <= $n)) {
+			$j = ($end - 1);
+			while (($j >= $i)) {
+				$result = ((is_array($result) && is_array([$nums[$j]])) ? array_merge($result, [$nums[$j]]) : ((is_string($result) || is_string([$nums[$j]])) ? ($result . [$nums[$j]]) : ($result + [$nums[$j]])));
+				$j = ($j - 1);
+			}
+		} else {
+			$j = $i;
+			while (($j < $n)) {
+				$result = ((is_array($result) && is_array([$nums[$j]])) ? array_merge($result, [$nums[$j]]) : ((is_string($result) || is_string([$nums[$j]])) ? ($result . [$nums[$j]]) : ($result + [$nums[$j]])));
+				$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+			}
+		}
+		$i = ((is_array($i) && is_array($k)) ? array_merge($i, $k) : ((is_string($i) || is_string($k)) ? ($i . $k) : ($i + $k)));
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_reverseKGroup([1, 2, 3, 4, 5], 2) == [2, 1, 4, 3, 5]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_reverseKGroup([1, 2, 3, 4, 5], 3) == [3, 2, 1, 4, 5]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_k_equals_list_length() {
+	if (!((mochi_reverseKGroup([1, 2, 3, 4], 4) == [4, 3, 2, 1]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_k_greater_than_length() {
+	if (!((mochi_reverseKGroup([1, 2, 3], 5) == [1, 2, 3]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_k_is_one() {
+	if (!((mochi_reverseKGroup([1, 2, 3], 1) == [1, 2, 3]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_k_equals_list_length();
+mochi_test_k_greater_than_length();
+mochi_test_k_is_one();

--- a/examples/leetcode-out/php/26/remove-duplicates-from-sorted-array.php
+++ b/examples/leetcode-out/php/26/remove-duplicates-from-sorted-array.php
@@ -1,0 +1,34 @@
+<?php
+function mochi_removeDuplicates($nums) {
+	if (((is_array($nums) ? count($nums) : strlen($nums)) == 0)) {
+		return 0;
+	}
+	$count = 1;
+	$prev = $nums[0];
+	$i = 1;
+	while (($i < (is_array($nums) ? count($nums) : strlen($nums)))) {
+		$cur = $nums[$i];
+		if (($cur != $prev)) {
+			$count = ((is_array($count) && is_array(1)) ? array_merge($count, 1) : ((is_string($count) || is_string(1)) ? ($count . 1) : ($count + 1)));
+			$prev = $cur;
+		}
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	return $count;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_removeDuplicates([1, 1, 2]) == 2))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_removeDuplicates([0, 0, 1, 1, 1, 2, 2, 3, 3, 4]) == 5))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_empty() {
+	if (!((mochi_removeDuplicates([]) == 0))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_empty();

--- a/examples/leetcode-out/php/27/remove-element.php
+++ b/examples/leetcode-out/php/27/remove-element.php
@@ -1,0 +1,38 @@
+<?php
+function mochi_removeElement(&$nums, $val) {
+	$k = 0;
+	$i = 0;
+	while (($i < (is_array($nums) ? count($nums) : strlen($nums)))) {
+		if (($nums[$i] != $val)) {
+			$nums[$k] = $nums[$i];
+			$k = ((is_array($k) && is_array(1)) ? array_merge($k, 1) : ((is_string($k) || is_string(1)) ? ($k . 1) : ($k + 1)));
+		}
+		$i = ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)));
+	}
+	return $k;
+}
+
+function mochi_test_example_1() {
+	$nums = [3, 2, 2, 3];
+	$k = mochi_removeElement($nums, 3);
+	if (!(($k == 2))) { throw new Exception('expect failed'); }
+	if (!(((is_array($nums) ? array_slice($nums, 0, ($k) - (0)) : substr($nums, 0, ($k) - (0))) == [2, 2]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	$nums = [0, 1, 2, 2, 3, 0, 4, 2];
+	$k = mochi_removeElement($nums, 2);
+	if (!(($k == 5))) { throw new Exception('expect failed'); }
+	if (!(((is_array($nums) ? array_slice($nums, 0, ($k) - (0)) : substr($nums, 0, ($k) - (0))) == [0, 1, 3, 0, 4]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_no_removal() {
+	$nums = [1, 2, 3];
+	$k = mochi_removeElement($nums, 4);
+	if (!(($k == 3))) { throw new Exception('expect failed'); }
+	if (!(((is_array($nums) ? array_slice($nums, 0, ($k) - (0)) : substr($nums, 0, ($k) - (0))) == [1, 2, 3]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_no_removal();

--- a/examples/leetcode-out/php/28/find-the-index-of-the-first-occurrence-in-a-string.php
+++ b/examples/leetcode-out/php/28/find-the-index-of-the-first-occurrence-in-a-string.php
@@ -1,0 +1,45 @@
+<?php
+function mochi_strStr($haystack, $needle) {
+	$n = (is_array($haystack) ? count($haystack) : strlen($haystack));
+	$m = (is_array($needle) ? count($needle) : strlen($needle));
+	if (($m == 0)) {
+		return 0;
+	}
+	if (($m > $n)) {
+		return -1;
+	}
+	for ($i = 0; $i < ((is_array(($n - $m)) && is_array(1)) ? array_merge(($n - $m), 1) : ((is_string(($n - $m)) || is_string(1)) ? (($n - $m) . 1) : (($n - $m) + 1))); $i++) {
+		$j = 0;
+		while (($j < $m)) {
+			if (($haystack[((is_array($i) && is_array($j)) ? array_merge($i, $j) : ((is_string($i) || is_string($j)) ? ($i . $j) : ($i + $j)))] != $needle[$j])) {
+				break;
+			}
+			$j = ((is_array($j) && is_array(1)) ? array_merge($j, 1) : ((is_string($j) || is_string(1)) ? ($j . 1) : ($j + 1)));
+		}
+		if (($j == $m)) {
+			return $i;
+		}
+	}
+	return -1;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_strStr("sadbutsad", "sad") == 0))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_strStr("leetcode", "leeto") == (-1)))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_empty_needle() {
+	if (!((mochi_strStr("abc", "") == 0))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_needle_at_end() {
+	if (!((mochi_strStr("hello", "lo") == 3))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_empty_needle();
+mochi_test_needle_at_end();

--- a/examples/leetcode-out/php/29/divide-two-integers.php
+++ b/examples/leetcode-out/php/29/divide-two-integers.php
@@ -1,0 +1,62 @@
+<?php
+function mochi_divide($dividend, $divisor) {
+	if ((($dividend == ((-2147483647 - 1))) && ($divisor == (-1)))) {
+		return 2147483647;
+	}
+	$negative = false;
+	if (($dividend < 0)) {
+		$negative = !$negative;
+		$dividend = -$dividend;
+	}
+	if (($divisor < 0)) {
+		$negative = !$negative;
+		$divisor = -$divisor;
+	}
+	$quotient = 0;
+	while (($dividend >= $divisor)) {
+		$temp = $divisor;
+		$multiple = 1;
+		while (($dividend >= ((is_array($temp) && is_array($temp)) ? array_merge($temp, $temp) : ((is_string($temp) || is_string($temp)) ? ($temp . $temp) : ($temp + $temp))))) {
+			$temp = ((is_array($temp) && is_array($temp)) ? array_merge($temp, $temp) : ((is_string($temp) || is_string($temp)) ? ($temp . $temp) : ($temp + $temp)));
+			$multiple = ((is_array($multiple) && is_array($multiple)) ? array_merge($multiple, $multiple) : ((is_string($multiple) || is_string($multiple)) ? ($multiple . $multiple) : ($multiple + $multiple)));
+		}
+		$dividend = ($dividend - $temp);
+		$quotient = ((is_array($quotient) && is_array($multiple)) ? array_merge($quotient, $multiple) : ((is_string($quotient) || is_string($multiple)) ? ($quotient . $multiple) : ($quotient + $multiple)));
+	}
+	if ($negative) {
+		$quotient = -$quotient;
+	}
+	if (($quotient > 2147483647)) {
+		return 2147483647;
+	}
+	if (($quotient < ((-2147483647 - 1)))) {
+		return -2147483648;
+	}
+	return $quotient;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_divide(10, 3) == 3))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_divide(7, -3) == (-2)))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_overflow() {
+	if (!((mochi_divide(-2147483648, -1) == 2147483647))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_divide_by_1() {
+	if (!((mochi_divide(12345, 1) == 12345))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_negative_result() {
+	if (!((mochi_divide(-15, 2) == (-7)))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_overflow();
+mochi_test_divide_by_1();
+mochi_test_negative_result();

--- a/examples/leetcode-out/php/3/longest-substring-without-repeating-characters.php
+++ b/examples/leetcode-out/php/3/longest-substring-without-repeating-characters.php
@@ -1,5 +1,5 @@
 <?php
-function lengthOfLongestSubstring($s) {
+function mochi_lengthOfLongestSubstring($s) {
 	$n = (is_array($s) ? count($s) : strlen($s));
 	$start = 0;
 	$best = 0;
@@ -22,23 +22,23 @@ function lengthOfLongestSubstring($s) {
 	return $best;
 }
 
-function test_example_1() {
-	if (!((lengthOfLongestSubstring("abcabcbb") == 3))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_lengthOfLongestSubstring("abcabcbb") == 3))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((lengthOfLongestSubstring("bbbbb") == 1))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_lengthOfLongestSubstring("bbbbb") == 1))) { throw new Exception('expect failed'); }
 }
 
-function test_example_3() {
-	if (!((lengthOfLongestSubstring("pwwkew") == 3))) { throw new Exception('expect failed'); }
+function mochi_test_example_3() {
+	if (!((mochi_lengthOfLongestSubstring("pwwkew") == 3))) { throw new Exception('expect failed'); }
 }
 
-function test_empty_string() {
-	if (!((lengthOfLongestSubstring("") == 0))) { throw new Exception('expect failed'); }
+function mochi_test_empty_string() {
+	if (!((mochi_lengthOfLongestSubstring("") == 0))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_example_3();
-test_empty_string();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_empty_string();

--- a/examples/leetcode-out/php/30/substring-with-concatenation-of-all-words.php
+++ b/examples/leetcode-out/php/30/substring-with-concatenation-of-all-words.php
@@ -1,0 +1,73 @@
+<?php
+function mochi_findSubstring($s, $words) {
+	if (((is_array($words) ? count($words) : strlen($words)) == 0)) {
+		return [];
+	}
+	$wordLen = (is_array($words[0]) ? count($words[0]) : strlen($words[0]));
+	$wordCount = (is_array($words) ? count($words) : strlen($words));
+	$totalLen = ($wordLen * $wordCount);
+	if (((is_array($s) ? count($s) : strlen($s)) < $totalLen)) {
+		return [];
+	}
+	$freq = [];
+	foreach ((is_string($words) ? str_split($words) : $words) as $w) {
+		if ((is_array($freq) ? (array_key_exists($w, $freq) || in_array($w, $freq, true)) : (is_string($freq) ? strpos($freq, strval($w)) !== false : false))) {
+			$freq[$w] = ((is_array($freq[$w]) && is_array(1)) ? array_merge($freq[$w], 1) : ((is_string($freq[$w]) || is_string(1)) ? ($freq[$w] . 1) : ($freq[$w] + 1)));
+		} else {
+			$freq[$w] = 1;
+		}
+	}
+	$result = [];
+	for ($offset = 0; $offset < $wordLen; $offset++) {
+		$left = $offset;
+		$count = 0;
+		$seen = [];
+		$j = $offset;
+		while ((((is_array($j) && is_array($wordLen)) ? array_merge($j, $wordLen) : ((is_string($j) || is_string($wordLen)) ? ($j . $wordLen) : ($j + $wordLen))) <= (is_array($s) ? count($s) : strlen($s)))) {
+			$word = (is_array($s) ? array_slice($s, $j, (((is_array($j) && is_array($wordLen)) ? array_merge($j, $wordLen) : ((is_string($j) || is_string($wordLen)) ? ($j . $wordLen) : ($j + $wordLen)))) - ($j)) : substr($s, $j, (((is_array($j) && is_array($wordLen)) ? array_merge($j, $wordLen) : ((is_string($j) || is_string($wordLen)) ? ($j . $wordLen) : ($j + $wordLen)))) - ($j)));
+			$j = ((is_array($j) && is_array($wordLen)) ? array_merge($j, $wordLen) : ((is_string($j) || is_string($wordLen)) ? ($j . $wordLen) : ($j + $wordLen)));
+			if ((is_array($freq) ? (array_key_exists($word, $freq) || in_array($word, $freq, true)) : (is_string($freq) ? strpos($freq, strval($word)) !== false : false))) {
+				if ((is_array($seen) ? (array_key_exists($word, $seen) || in_array($word, $seen, true)) : (is_string($seen) ? strpos($seen, strval($word)) !== false : false))) {
+					$seen[$word] = ((is_array($seen[$word]) && is_array(1)) ? array_merge($seen[$word], 1) : ((is_string($seen[$word]) || is_string(1)) ? ($seen[$word] . 1) : ($seen[$word] + 1)));
+				} else {
+					$seen[$word] = 1;
+				}
+				$count = ((is_array($count) && is_array(1)) ? array_merge($count, 1) : ((is_string($count) || is_string(1)) ? ($count . 1) : ($count + 1)));
+				while (($seen[$word] > $freq[$word])) {
+					$lw = (is_array($s) ? array_slice($s, $left, (((is_array($left) && is_array($wordLen)) ? array_merge($left, $wordLen) : ((is_string($left) || is_string($wordLen)) ? ($left . $wordLen) : ($left + $wordLen)))) - ($left)) : substr($s, $left, (((is_array($left) && is_array($wordLen)) ? array_merge($left, $wordLen) : ((is_string($left) || is_string($wordLen)) ? ($left . $wordLen) : ($left + $wordLen)))) - ($left)));
+					$seen[$lw] = ($seen[$lw] - 1);
+					$left = ((is_array($left) && is_array($wordLen)) ? array_merge($left, $wordLen) : ((is_string($left) || is_string($wordLen)) ? ($left . $wordLen) : ($left + $wordLen)));
+					$count = ($count - 1);
+				}
+				if (($count == $wordCount)) {
+					$result = ((is_array($result) && is_array([$left])) ? array_merge($result, [$left]) : ((is_string($result) || is_string([$left])) ? ($result . [$left]) : ($result + [$left])));
+					$lw = (is_array($s) ? array_slice($s, $left, (((is_array($left) && is_array($wordLen)) ? array_merge($left, $wordLen) : ((is_string($left) || is_string($wordLen)) ? ($left . $wordLen) : ($left + $wordLen)))) - ($left)) : substr($s, $left, (((is_array($left) && is_array($wordLen)) ? array_merge($left, $wordLen) : ((is_string($left) || is_string($wordLen)) ? ($left . $wordLen) : ($left + $wordLen)))) - ($left)));
+					$seen[$lw] = ($seen[$lw] - 1);
+					$left = ((is_array($left) && is_array($wordLen)) ? array_merge($left, $wordLen) : ((is_string($left) || is_string($wordLen)) ? ($left . $wordLen) : ($left + $wordLen)));
+					$count = ($count - 1);
+				}
+			} else {
+				$seen = [];
+				$count = 0;
+				$left = $j;
+			}
+		}
+	}
+	return $result;
+}
+
+function mochi_test_example_1() {
+	if (!((mochi_findSubstring("barfoothefoobarman", ["foo", "bar"]) == [0, 9]))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_2() {
+	if (!((mochi_findSubstring("wordgoodgoodgoodbestword", ["word", "good", "best", "word"]) == []))) { throw new Exception('expect failed'); }
+}
+
+function mochi_test_example_3() {
+	if (!((mochi_findSubstring("barfoofoobarthefoobarman", ["bar", "foo", "the"]) == [6, 9, 12]))) { throw new Exception('expect failed'); }
+}
+
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();

--- a/examples/leetcode-out/php/4/median-of-two-sorted-arrays.php
+++ b/examples/leetcode-out/php/4/median-of-two-sorted-arrays.php
@@ -1,5 +1,5 @@
 <?php
-function findMedianSortedArrays($nums1, $nums2) {
+function mochi_findMedianSortedArrays($nums1, $nums2) {
 	$merged = [];
 	$i = 0;
 	$j = 0;
@@ -29,23 +29,23 @@ function findMedianSortedArrays($nums1, $nums2) {
 	return ((is_int((((is_array($mid1) && is_array($mid2)) ? array_merge($mid1, $mid2) : ((is_string($mid1) || is_string($mid2)) ? ($mid1 . $mid2) : ($mid1 + $mid2))))) && is_int(2.0)) ? intdiv((((is_array($mid1) && is_array($mid2)) ? array_merge($mid1, $mid2) : ((is_string($mid1) || is_string($mid2)) ? ($mid1 . $mid2) : ($mid1 + $mid2)))), 2.0) : ((((is_array($mid1) && is_array($mid2)) ? array_merge($mid1, $mid2) : ((is_string($mid1) || is_string($mid2)) ? ($mid1 . $mid2) : ($mid1 + $mid2)))) / 2.0));
 }
 
-function test_example_1() {
-	if (!((findMedianSortedArrays([1, 3], [2]) == 2.0))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_findMedianSortedArrays([1, 3], [2]) == 2.0))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((findMedianSortedArrays([1, 2], [3, 4]) == 2.5))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_findMedianSortedArrays([1, 2], [3, 4]) == 2.5))) { throw new Exception('expect failed'); }
 }
 
-function test_empty_first() {
-	if (!((findMedianSortedArrays([], [1]) == 1.0))) { throw new Exception('expect failed'); }
+function mochi_test_empty_first() {
+	if (!((mochi_findMedianSortedArrays([], [1]) == 1.0))) { throw new Exception('expect failed'); }
 }
 
-function test_empty_second() {
-	if (!((findMedianSortedArrays([2], []) == 2.0))) { throw new Exception('expect failed'); }
+function mochi_test_empty_second() {
+	if (!((mochi_findMedianSortedArrays([2], []) == 2.0))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_empty_first();
-test_empty_second();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_empty_first();
+mochi_test_empty_second();

--- a/examples/leetcode-out/php/5/longest-palindromic-substring.php
+++ b/examples/leetcode-out/php/5/longest-palindromic-substring.php
@@ -1,5 +1,5 @@
 <?php
-function expand($s, $left, $right) {
+function mochi_expand($s, $left, $right) {
 	$l = $left;
 	$r = $right;
 	$n = (is_array($s) ? count($s) : strlen($s));
@@ -13,7 +13,7 @@ function expand($s, $left, $right) {
 	return (($r - $l) - 1);
 }
 
-function longestPalindrome($s) {
+function mochi_longestPalindrome($s) {
 	if (((is_array($s) ? count($s) : strlen($s)) <= 1)) {
 		return $s;
 	}
@@ -21,8 +21,8 @@ function longestPalindrome($s) {
 	$end = 0;
 	$n = (is_array($s) ? count($s) : strlen($s));
 	for ($i = 0; $i < $n; $i++) {
-		$len1 = expand($s, $i, $i);
-		$len2 = expand($s, $i, ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))));
+		$len1 = mochi_expand($s, $i, $i);
+		$len2 = mochi_expand($s, $i, ((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1))));
 		$l = $len1;
 		if (($len2 > $len1)) {
 			$l = $len2;
@@ -35,25 +35,25 @@ function longestPalindrome($s) {
 	return (is_array($s) ? array_slice($s, $start, (((is_array($end) && is_array(1)) ? array_merge($end, 1) : ((is_string($end) || is_string(1)) ? ($end . 1) : ($end + 1)))) - ($start)) : substr($s, $start, (((is_array($end) && is_array(1)) ? array_merge($end, 1) : ((is_string($end) || is_string(1)) ? ($end . 1) : ($end + 1)))) - ($start)));
 }
 
-function test_example_1() {
-	$ans = longestPalindrome("babad");
+function mochi_test_example_1() {
+	$ans = mochi_longestPalindrome("babad");
 	if (!((($ans == "bab") || ($ans == "aba")))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((longestPalindrome("cbbd") == "bb"))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_longestPalindrome("cbbd") == "bb"))) { throw new Exception('expect failed'); }
 }
 
-function test_single_char() {
-	if (!((longestPalindrome("a") == "a"))) { throw new Exception('expect failed'); }
+function mochi_test_single_char() {
+	if (!((mochi_longestPalindrome("a") == "a"))) { throw new Exception('expect failed'); }
 }
 
-function test_two_chars() {
-	$ans = longestPalindrome("ac");
+function mochi_test_two_chars() {
+	$ans = mochi_longestPalindrome("ac");
 	if (!((($ans == "a") || ($ans == "c")))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_single_char();
-test_two_chars();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_single_char();
+mochi_test_two_chars();

--- a/examples/leetcode-out/php/6/zigzag-conversion.php
+++ b/examples/leetcode-out/php/6/zigzag-conversion.php
@@ -1,5 +1,5 @@
 <?php
-function convert($s, $numRows) {
+function mochi_convert($s, $numRows) {
 	if ((($numRows <= 1) || ($numRows >= (is_array($s) ? count($s) : strlen($s))))) {
 		return $s;
 	}
@@ -28,18 +28,18 @@ function convert($s, $numRows) {
 	return $result;
 }
 
-function test_example_1() {
-	if (!((convert("PAYPALISHIRING", 3) == "PAHNAPLSIIGYIR"))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_convert("PAYPALISHIRING", 3) == "PAHNAPLSIIGYIR"))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((convert("PAYPALISHIRING", 4) == "PINALSIGYAHRPI"))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_convert("PAYPALISHIRING", 4) == "PINALSIGYAHRPI"))) { throw new Exception('expect failed'); }
 }
 
-function test_single_row() {
-	if (!((convert("A", 1) == "A"))) { throw new Exception('expect failed'); }
+function mochi_test_single_row() {
+	if (!((mochi_convert("A", 1) == "A"))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_single_row();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_single_row();

--- a/examples/leetcode-out/php/7/reverse-integer.php
+++ b/examples/leetcode-out/php/7/reverse-integer.php
@@ -1,5 +1,5 @@
 <?php
-function reverse($x) {
+function mochi_reverse($x) {
 	$sign = 1;
 	$n = $x;
 	if (($n < 0)) {
@@ -19,23 +19,23 @@ function reverse($x) {
 	return $rev;
 }
 
-function test_example_1() {
-	if (!((reverse(123) == 321))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_reverse(123) == 321))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((reverse(-123) == (-321)))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_reverse(-123) == (-321)))) { throw new Exception('expect failed'); }
 }
 
-function test_example_3() {
-	if (!((reverse(120) == 21))) { throw new Exception('expect failed'); }
+function mochi_test_example_3() {
+	if (!((mochi_reverse(120) == 21))) { throw new Exception('expect failed'); }
 }
 
-function test_overflow() {
-	if (!((reverse(1534236469) == 0))) { throw new Exception('expect failed'); }
+function mochi_test_overflow() {
+	if (!((mochi_reverse(1534236469) == 0))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_example_3();
-test_overflow();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_overflow();

--- a/examples/leetcode-out/php/8/string-to-integer-atoi.php
+++ b/examples/leetcode-out/php/8/string-to-integer-atoi.php
@@ -1,5 +1,5 @@
 <?php
-function digit($ch) {
+function mochi_digit($ch) {
 	if (($ch == "0")) {
 		return 0;
 	}
@@ -33,7 +33,7 @@ function digit($ch) {
 	return -1;
 }
 
-function myAtoi($s) {
+function mochi_myAtoi($s) {
 	$i = 0;
 	$n = (is_array($s) ? count($s) : strlen($s));
 	while ((($i < $n) && ($s[$i] == " "[0]))) {
@@ -49,7 +49,7 @@ function myAtoi($s) {
 	$result = 0;
 	while (($i < $n)) {
 		$ch = (is_array($s) ? array_slice($s, $i, (((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))) - ($i)) : substr($s, $i, (((is_array($i) && is_array(1)) ? array_merge($i, 1) : ((is_string($i) || is_string(1)) ? ($i . 1) : ($i + 1)))) - ($i)));
-		$d = digit($ch);
+		$d = mochi_digit($ch);
 		if (($d < 0)) {
 			break;
 		}
@@ -66,28 +66,28 @@ function myAtoi($s) {
 	return $result;
 }
 
-function test_example_1() {
-	if (!((myAtoi("42") == 42))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_myAtoi("42") == 42))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((myAtoi("   -42") == (-42)))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_myAtoi("   -42") == (-42)))) { throw new Exception('expect failed'); }
 }
 
-function test_example_3() {
-	if (!((myAtoi("4193 with words") == 4193))) { throw new Exception('expect failed'); }
+function mochi_test_example_3() {
+	if (!((mochi_myAtoi("4193 with words") == 4193))) { throw new Exception('expect failed'); }
 }
 
-function test_example_4() {
-	if (!((myAtoi("words and 987") == 0))) { throw new Exception('expect failed'); }
+function mochi_test_example_4() {
+	if (!((mochi_myAtoi("words and 987") == 0))) { throw new Exception('expect failed'); }
 }
 
-function test_example_5() {
-	if (!((myAtoi("-91283472332") == (-2147483648)))) { throw new Exception('expect failed'); }
+function mochi_test_example_5() {
+	if (!((mochi_myAtoi("-91283472332") == (-2147483648)))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_example_3();
-test_example_4();
-test_example_5();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_example_4();
+mochi_test_example_5();

--- a/examples/leetcode-out/php/9/palindrome-number.php
+++ b/examples/leetcode-out/php/9/palindrome-number.php
@@ -1,5 +1,5 @@
 <?php
-function isPalindrome($x) {
+function mochi_isPalindrome($x) {
 	if (($x < 0)) {
 		return false;
 	}
@@ -13,23 +13,23 @@ function isPalindrome($x) {
 	return true;
 }
 
-function test_example_1() {
-	if (!((isPalindrome(121) == true))) { throw new Exception('expect failed'); }
+function mochi_test_example_1() {
+	if (!((mochi_isPalindrome(121) == true))) { throw new Exception('expect failed'); }
 }
 
-function test_example_2() {
-	if (!((isPalindrome(-121) == false))) { throw new Exception('expect failed'); }
+function mochi_test_example_2() {
+	if (!((mochi_isPalindrome(-121) == false))) { throw new Exception('expect failed'); }
 }
 
-function test_example_3() {
-	if (!((isPalindrome(10) == false))) { throw new Exception('expect failed'); }
+function mochi_test_example_3() {
+	if (!((mochi_isPalindrome(10) == false))) { throw new Exception('expect failed'); }
 }
 
-function test_zero() {
-	if (!((isPalindrome(0) == true))) { throw new Exception('expect failed'); }
+function mochi_test_zero() {
+	if (!((mochi_isPalindrome(0) == true))) { throw new Exception('expect failed'); }
 }
 
-test_example_1();
-test_example_2();
-test_example_3();
-test_zero();
+mochi_test_example_1();
+mochi_test_example_2();
+mochi_test_example_3();
+mochi_test_zero();


### PR DESCRIPTION
## Summary
- generate compiled PHP for LeetCode problems 1–30
- prefix PHP functions to avoid builtin name clashes
- support mutation of list parameters via references
- expand tests to run LeetCode problems 1–30
- note unsupported PHP backend features

## Testing
- `go test ./compile/php -run TestLeetCodeProblems -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68543ccaca108320af3066376c37cda4