### PR TITLE
Add C# query grouping support

### DIFF
--- a/compile/cs/README.md
+++ b/compile/cs/README.md
@@ -133,8 +133,8 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 
 ### Unsupported features
 
-Several LeetCode problems currently fail to compile due to missing support for
-some collection helpers. Operations like `GetRange`, list concatenation using
-`+`, and generic dictionary casts are not generated correctly. Until these
-helpers are implemented, only the first dozen problems compile and run
-successfully.
+The backend is still incomplete. Notable gaps include:
+
+- Join clauses in dataset queries
+- External helpers like `_fetch`, `_load`, `_save` and text generation
+- Generic dictionary casts for complex map types

--- a/compile/cs/compiler.go
+++ b/compile/cs/compiler.go
@@ -239,6 +239,38 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 				c.writeln("return Equals(a, b);")
 				c.indent--
 				c.writeln("}")
+			case "_group":
+				c.writeln("public class _Group {")
+				c.indent++
+				c.writeln("public dynamic key;")
+				c.writeln("public List<dynamic> Items = new List<dynamic>();")
+				c.writeln("public _Group(dynamic k) { key = k; }")
+				c.indent--
+				c.writeln("}")
+			case "_group_by":
+				c.writeln("static List<_Group> _group_by(IEnumerable<dynamic> src, Func<dynamic, dynamic> keyfn) {")
+				c.indent++
+				c.writeln("var groups = new Dictionary<string, _Group>();")
+				c.writeln("var order = new List<string>();")
+				c.writeln("foreach (var it in src) {")
+				c.indent++
+				c.writeln("var key = keyfn(it);")
+				c.writeln("var ks = Convert.ToString(key);")
+				c.writeln("if (!groups.TryGetValue(ks, out var g)) {")
+				c.indent++
+				c.writeln("g = new _Group(key);")
+				c.writeln("groups[ks] = g;")
+				c.writeln("order.Add(ks);")
+				c.indent--
+				c.writeln("}")
+				c.writeln("g.Items.Add(it);")
+				c.indent--
+				c.writeln("}")
+				c.writeln("var res = new List<_Group>();")
+				c.writeln("foreach (var k in order) res.Add(groups[k]);")
+				c.writeln("return res;")
+				c.indent--
+				c.writeln("}")
 			}
 			c.writeln("")
 		}
@@ -791,7 +823,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 
 func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	c.useLinq = true
-	if len(q.Joins) > 0 || q.Group != nil {
+	if len(q.Joins) > 0 {
 		return "", fmt.Errorf("unsupported query expression")
 	}
 	src, err := c.compileExpr(q.Source)
@@ -837,6 +869,26 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		}
 	}
 	v := sanitizeName(q.Var)
+
+	if q.Group != nil && len(q.Froms) == 0 && q.Where == nil && q.Sort == nil && q.Skip == nil && q.Take == nil {
+		keyExpr, err := c.compileExpr(q.Group.Expr)
+		if err != nil {
+			c.env = orig
+			return "", err
+		}
+		genv := types.NewEnv(child)
+		genv.SetVar(q.Group.Name, types.AnyType{}, true)
+		c.env = genv
+		valExpr, err := c.compileExpr(q.Select)
+		if err != nil {
+			c.env = orig
+			return "", err
+		}
+		c.env = orig
+		c.use("_group_by")
+		c.use("_group")
+		return fmt.Sprintf("_group_by(%s, %s => %s).Select(%s => %s).ToList()", src, v, keyExpr, sanitizeName(q.Group.Name), valExpr), nil
+	}
 
 	// handle cross join using nested loops when q.Froms are present
 	if len(q.Froms) > 0 {


### PR DESCRIPTION
## Summary
- extend C# compiler with `_group` and `_group_by` helpers
- generate `group by` queries when no joins or filters are present
- document remaining unsupported features in C# backend README

## Testing
- `go vet ./...` *(fails: self-assignment in other backends)*
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854d9b211348320bd4b8421dde6a571