### PR TITLE
Enhance Haskell backend

### DIFF
--- a/compile/hs/README.md
+++ b/compile/hs/README.md
@@ -74,3 +74,15 @@ definitions, if/else expressions, basic loops, lists, maps and a few built-in
 functions (`len`, `count`, `avg`, `str`, `print`). Map access relies on
 `Data.Map` when needed. Variable names are sanitised to avoid conflicts with
 Haskell keywords.
+
+## Status
+
+While useful for experimentation, the Haskell backend does not yet implement the
+full Mochi language. Unsupported features include:
+
+* `match` expressions and union types
+* Dataset query syntax like `from ... sort by ...`
+* Set literals and related operations
+* `while` loops
+* Generative AI, HTTP fetch and FFI bindings
+* Streams and long-lived agents

--- a/compile/hs/compiler.go
+++ b/compile/hs/compiler.go
@@ -100,13 +100,13 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	header.WriteString(runtime)
 	header.WriteString("\n\n")
 
-        code := append(header.Bytes(), c.buf.Bytes()...)
-        // Ensure the generated file ends with a trailing newline so tools like
-        // runhaskell do not complain about the last line.
-        if len(code) == 0 || code[len(code)-1] != '\n' {
-                code = append(code, '\n')
-        }
-        return code, nil
+	code := append(header.Bytes(), c.buf.Bytes()...)
+	// Ensure the generated file ends with a trailing newline so tools like
+	// runhaskell do not complain about the last line.
+	if len(code) == 0 || code[len(code)-1] != '\n' {
+		code = append(code, '\n')
+	}
+	return code, nil
 }
 
 func (c *Compiler) compileMainStmt(s *parser.Statement) error {
@@ -609,7 +609,12 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 	if len(fn.BlockBody) == 0 {
 		return fmt.Sprintf("(\\%s -> ())", strings.Join(params, " ")), nil
 	}
-	return "", fmt.Errorf("unsupported function expression")
+	expr, err := c.compileStmtExpr(fn.BlockBody, true)
+	if err != nil {
+		return "", err
+	}
+	ret := c.defaultReturn(fn.BlockBody, types.VoidType{})
+	return fmt.Sprintf("(\\%s -> fromMaybe (%s) $ %s)", strings.Join(params, " "), ret, expr), nil
 }
 
 func (c *Compiler) exprIsString(e *parser.Expr) bool {


### PR DESCRIPTION
## Summary
- allow block-bodied lambdas in the Haskell backend
- document which Mochi features are still unsupported by the Haskell backend

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854d9d91fc08320a6e3694a67ec9ec1