### PR TITLE
Add generate/fetch support to Java backend

### DIFF
--- a/compile/java/README.md
+++ b/compile/java/README.md
@@ -243,6 +243,8 @@ The Java backend currently lacks several Mochi features supported by other compi
 - Union types and tagged unions
 - Dataset queries (`from`/`select`, joins, grouping)
 - Dataset loading/saving helpers
-- External helpers like `_genText`, `_fetch` and concurrency primitives
+- Concurrency primitives like streams and agents
+- Foreign imports and extern functions
+- Logic programming constructs (`fact`, `rule`, `query`)
 
 Simple `from` queries used by the LeetCode examples are now supported.


### PR DESCRIPTION
## Summary
- support `generate` and `fetch` expressions in the Java compiler
- stub runtime helpers `_genText`, `_genEmbed`, and `_fetch`
- document additional unsupported features for the Java backend

## Testing
- `go test ./compile/java -run TestJavaCompiler_GoldenOutput -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6854d9dad62083208fe41829f1ce240d