### PR TITLE
Improve Kotlin backend map support

### DIFF
--- a/compile/kt/README.md
+++ b/compile/kt/README.md
@@ -321,4 +321,13 @@ go test ./compile/kt -tags slow
 
 The tests automatically skip when `kotlinc` is unavailable.
 
+## Unsupported Features
+
+The Kotlin backend still lacks several Mochi features that other compilers
+support:
+
+- Advanced dataset queries such as joins and grouping
+- Helpers for loading and saving datasets
+- External helpers like `_genText`, `_fetch` and concurrency primitives
+
 

--- a/compile/kt/compiler.go
+++ b/compile/kt/compiler.go
@@ -153,6 +153,17 @@ func (c *Compiler) compileAssign(stmt *parser.AssignStmt) error {
 				c.writeln("}")
 				return nil
 			}
+			if _, ok := t.(types.MapType); ok {
+				idx := idxStrs[len(idxStrs)-1]
+				c.writeln("run {")
+				c.indent++
+				c.writeln(fmt.Sprintf("val _tmp = %s.toMutableMap()", sanitizeName(stmt.Name)))
+				c.writeln(fmt.Sprintf("_tmp[%s] = %s", idx, rhs))
+				c.writeln(fmt.Sprintf("%s = _tmp", sanitizeName(stmt.Name)))
+				c.indent--
+				c.writeln("}")
+				return nil
+			}
 		}
 	}
 	c.writeln(fmt.Sprintf("%s = %s", lhs, rhs))


### PR DESCRIPTION
## Summary
- handle assignments into `Map` values in the Kotlin compiler
- document remaining unsupported Kotlin features

## Testing
- `go test ./compile/kt -run TestKTCompiler_TwoSum -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6854d9dc94908320ab47be1e6c2c9dd2