### PR TITLE
Support Lua block functions, document gaps

### DIFF
--- a/compile/lua/README.md
+++ b/compile/lua/README.md
@@ -293,3 +293,12 @@ solutions under `examples/leetcode` to verify basic program execution.
 ## Notes
 
 The Lua backend supports most core language features but skips advanced LLM helpers and external objects. Query expressions handle simple joins and common clauses. The emphasis is on readability and portability of the emitted Lua code.
+
+## Unsupported Features
+
+Several Mochi constructs remain unimplemented in the Lua backend:
+
+- HTTP requests using `fetch`
+- Dataset loading and saving with `load`/`save`
+- Query joins and grouping clauses
+- Streams and other concurrency helpers


### PR DESCRIPTION
## Summary
- allow block function expressions in the Lua backend
- list missing Lua features in its README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854d9deefec832089e073764ee5bb10