### PR TITLE
Add Erlang match support

### DIFF
--- a/compile/erlang/README.md
+++ b/compile/erlang/README.md
@@ -75,8 +75,16 @@ func EnsureErlang() error { return ensureErlang() }
 
 ## Notes
 
-The Erlang backend currently supports a subset of Mochi features. Query
+The Erlang backend still implements only a portion of Mochi. Query
 expressions without joins or grouping are translated to Erlang list
-comprehensions; more complex queries return an error. Indexing strings or maps
-emits the `mochi_get/2` helper only when required. The generated code is designed
-for readability rather than speed, mirroring Mochi constructs closely.
+comprehensions; more complex queries return an error. Pattern matching on
+union values is supported via `case` expressions. The following language
+features are not yet handled:
+
+- Joins or grouping inside queries
+- Generative AI helpers like `generate` or `fetch`
+- Dataset operations such as `load` and `save`
+- Logic programming constructs and streams
+
+Generated Erlang favors clarity over speed, mirroring Mochi constructs
+directly.

--- a/compile/erlang/helpers.go
+++ b/compile/erlang/helpers.go
@@ -117,6 +117,54 @@ func isAny(t types.Type) bool {
 	return ok
 }
 
+func callPattern(e *parser.Expr) (*parser.CallExpr, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.Call == nil {
+		return nil, false
+	}
+	return p.Target.Call, true
+}
+
+func identName(e *parser.Expr) (string, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
+}
+
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	return p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0
+}
+
 // atomName returns a valid Erlang atom representing name. If name contains
 // uppercase letters or other characters that are not allowed in unquoted atoms,
 // it is returned quoted.


### PR DESCRIPTION
## Summary
- enable union constructors and match expressions in the Erlang backend
- document remaining unsupported features in Erlang README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854d9cb88b48320bf0adfc40d15f341