### PR TITLE
Add more Prolog features and docs

### DIFF
--- a/compile/pl/runtime.go
+++ b/compile/pl/runtime.go
@@ -33,3 +33,21 @@ const helperContains = "contains(Container, Item, Res) :-\n" +
 	"contains(List, Item, Res) :-\n" +
 	"    string(List), !, string_chars(List, Chars), (member(Item, Chars) -> Res = true ; Res = false).\n" +
 	"contains(List, Item, Res) :- (member(Item, List) -> Res = true ; Res = false).\n\n"
+
+const helperInput = "input(S) :- read_line_to_string(user_input, S).\n\n"
+
+const helperCount = "count(V, R) :-\n" +
+	"    is_dict(V), !, get_dict('Items', V, Items), length(Items, R).\n" +
+	"count(V, R) :-\n" +
+	"    string(V), !, string_chars(V, C), length(C, R).\n" +
+	"count(V, R) :-\n" +
+	"    is_list(V), !, length(V, R).\n" +
+	"count(_, _) :- throw(error('count expects list or group')).\n\n"
+
+const helperAvg = "avg(V, R) :-\n" +
+	"    is_dict(V), !, get_dict('Items', V, Items), avg_list(Items, R).\n" +
+	"avg(V, R) :-\n" +
+	"    is_list(V), !, avg_list(V, R).\n" +
+	"avg(_, _) :- throw(error('avg expects list or group')).\n" +
+	"avg_list([], 0).\n" +
+	"avg_list(L, R) :- sum_list(L, S), length(L, N), N > 0, R is S / N.\n\n"

--- a/tests/compiler/pl/for_loop.pl.out
+++ b/tests/compiler/pl/for_loop.pl.out
@@ -2,7 +2,8 @@
 	main :-
 	_V0 is 4 - 1,
 	forall(between(1, _V0, I), (
-		writeln(I),
+		write(I),
+		nl,
 		true
 	))
 	.

--- a/tests/compiler/pl/if_else.pl.out
+++ b/tests/compiler/pl/if_else.pl.out
@@ -23,10 +23,13 @@
 	main :-
 	_V2 is -(2),
 	foo(_V2, _V3),
-	writeln(_V3),
+	write(_V3),
+	nl,
 	foo(0, _V4),
-	writeln(_V4),
+	write(_V4),
+	nl,
 	foo(3, _V5),
-	writeln(_V5)
+	write(_V5),
+	nl
 	.
 :- initialization(main, main).

--- a/tests/compiler/pl/len_builtin.pl.out
+++ b/tests/compiler/pl/len_builtin.pl.out
@@ -1,6 +1,7 @@
 :- style_check(-singleton).
 	main :-
 	length([1, 2, 3], _V0),
-	writeln(_V0)
+	write(_V0),
+	nl
 	.
 :- initialization(main, main).

--- a/tests/compiler/pl/string_for_loop.pl.out
+++ b/tests/compiler/pl/string_for_loop.pl.out
@@ -8,7 +8,8 @@ to_list(L, L).
 	main :-
 	to_list("cat", _V0),
 	forall(member(Ch, _V0), (
-		writeln(Ch),
+		write(Ch),
+		nl,
 		true
 	))
 	.

--- a/tests/compiler/pl/subtract_expr.pl.out
+++ b/tests/compiler/pl/subtract_expr.pl.out
@@ -1,6 +1,7 @@
 :- style_check(-singleton).
 	main :-
 	_V0 is 5 - 2,
-	writeln(_V0)
+	write(_V0),
+	nl
 	.
 :- initialization(main, main).


### PR DESCRIPTION
## Summary
- allow `print` with multiple arguments
- implement `count`, `avg`, `str` and `input` builtins for Prolog
- emit runtime helpers for new builtins
- document missing features in Prolog README
- update golden outputs for new behaviour

## Testing
- `go test ./compile/pl -tags slow -run TestPrologCompiler_GoldenOutput -v`
- `go test ./... -run TestPrologCompiler_GoldenOutput -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6854d9e8784c8320845d074cbac2e1fd