### PR TITLE
Add Racket set ops and doc unsupported features

### DIFF
--- a/compile/rkt/README.md
+++ b/compile/rkt/README.md
@@ -171,3 +171,14 @@ The Racket backend is intentionally minimal. Conditionals now support simple
 The generated code aims
 for readability over performance and mirrors Mochi constructs closely.
 Loops support `break` and `continue` using `let/ec` and named `let` constructs.
+Binary operators now include `union`, `union_all`, `except` and `intersect` for
+basic list set operations.
+
+Unsupported features currently include:
+
+* Generative `generate` blocks and model definitions
+* Dataset helpers like `fetch`, `load`, `save` and SQL-style query expressions
+* `match` expressions for pattern matching
+* Agents, streams and intents
+* Foreign function interface via `import`
+* Package management and `package` declarations


### PR DESCRIPTION
## Summary
- extend Racket backend with union/except/intersect helpers
- handle `union`, `union_all`, `except` and `intersect` operators
- document remaining unsupported Racket features

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6854d9eeb3b083208fb91431e15028d7