### PR TITLE
Add count builtin for Smalltalk backend

### DIFF
--- a/compile/st/README.md
+++ b/compile/st/README.md
@@ -13,3 +13,10 @@ Compile a program with `mochi build --target st` and run it using `gst`. To run 
 ```bash
 go test ./compile/st -tags slow
 ```
+
+## Notes
+
+The Smalltalk backend currently supports only a subset of Mochi. Features such
+as `break` and `continue` in loops, agents, dataset queries and generative AI
+blocks are not implemented yet. When the `count()` builtin is used, a helper
+method is emitted automatically.


### PR DESCRIPTION
## Summary
- extend Smalltalk compiler with `count()` builtin
- emit helper method when count is used
- document unsupported features in the Smalltalk README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854d9f788788320b6ac6d667efdecb4