### PR TITLE
Add dataset filter support in Swift backend

### DIFF
--- a/compile/swift/README.md
+++ b/compile/swift/README.md
@@ -232,11 +232,13 @@ This backend implements only a subset of Mochi. It handles basic statements, loo
 
 ## Unsupported Features
 
-- The Swift backend does not yet support several language features used by some
-examples:
+The Swift backend still lacks support for a number of language capabilities:
 
-- Complex dataset queries with filtering, grouping, joins or pagination. Only
-  simple ``from ... select`` loops (with optional cross joins) are handled.
-- Structural types such as ``struct`` and enums
+- Advanced dataset queries with grouping, joins, sorting or pagination. Simple
+  ``from ... where ... select`` loops (with optional cross joins) are handled.
+- Structural type declarations with inline methods and enum/union variants
 - Higher-order functions or function values
 - Type inference for empty collections
+- Streams, agents and intent handlers
+- The ``generate`` and ``fetch`` expressions for LLM and HTTP integration
+- Package declarations and the foreign function interface

--- a/compile/swift/compiler.go
+++ b/compile/swift/compiler.go
@@ -733,7 +733,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			elems[i] = v
 		}
 		return "[" + strings.Join(elems, ", ") + "]", nil
-        case p.Map != nil:
+	case p.Map != nil:
 		items := make([]string, len(p.Map.Items))
 		for i, item := range p.Map.Items {
 			k, err := c.compileExpr(item.Key)
@@ -749,10 +749,10 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		if len(items) == 0 {
 			return "[:]", nil
 		}
-                return "[" + strings.Join(items, ", ") + "]", nil
-       case p.Query != nil:
-               return c.compileQueryExpr(p.Query)
-        case p.Struct != nil:
+		return "[" + strings.Join(items, ", ") + "]", nil
+	case p.Query != nil:
+		return c.compileQueryExpr(p.Query)
+	case p.Struct != nil:
 		parts := make([]string, len(p.Struct.Fields))
 		for i, f := range p.Struct.Fields {
 			v, err := c.compileExpr(f.Value)
@@ -850,98 +850,114 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 	bodyStr := c.buf.String()
 	c.buf = oldBuf
 	c.indent = oldIndent
-        result := fmt.Sprintf("{ (%s) -> %s in\n%s}", strings.Join(params, ", "), ret, indentBlock(bodyStr, 1))
-        return result, nil
+	result := fmt.Sprintf("{ (%s) -> %s in\n%s}", strings.Join(params, ", "), ret, indentBlock(bodyStr, 1))
+	return result, nil
 }
 
 func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
-       if len(q.Joins) > 0 || q.Group != nil || q.Where != nil || q.Skip != nil || q.Take != nil {
-               return "", fmt.Errorf("advanced query clauses not supported")
-       }
-       src, err := c.compileExpr(q.Source)
-       if err != nil {
-               return "", err
-       }
+	if len(q.Joins) > 0 || q.Group != nil || q.Skip != nil || q.Take != nil {
+		return "", fmt.Errorf("advanced query clauses not supported")
+	}
+	src, err := c.compileExpr(q.Source)
+	if err != nil {
+		return "", err
+	}
 
-       // special case: simple sort and select by query variable
-       if len(q.Froms) == 0 && q.Sort != nil {
-               orig := c.env
-               child := types.NewEnv(c.env)
-               elem := c.inferExprType(q.Source)
-               if lt, ok := elem.(types.ListType); ok {
-                       elem = lt.Elem
-               }
-               child.SetVar(q.Var, elem, true)
-               c.env = child
-               sortExpr, err := c.compileExpr(q.Sort)
-               if err != nil {
-                       c.env = orig
-                       return "", err
-               }
-               selExpr, err := c.compileExpr(q.Select)
-               c.env = orig
-               if err != nil {
-                       return "", err
-               }
-               if sortExpr == q.Var && selExpr == q.Var {
-                       return fmt.Sprintf("%s.sorted()", src), nil
-               }
-               return "", fmt.Errorf("advanced query clauses not supported")
-       }
+	// special case: simple sort and select by query variable
+	if len(q.Froms) == 0 && q.Sort != nil {
+		orig := c.env
+		child := types.NewEnv(c.env)
+		elem := c.inferExprType(q.Source)
+		if lt, ok := elem.(types.ListType); ok {
+			elem = lt.Elem
+		}
+		child.SetVar(q.Var, elem, true)
+		c.env = child
+		sortExpr, err := c.compileExpr(q.Sort)
+		if err != nil {
+			c.env = orig
+			return "", err
+		}
+		selExpr, err := c.compileExpr(q.Select)
+		c.env = orig
+		if err != nil {
+			return "", err
+		}
+		if sortExpr == q.Var && selExpr == q.Var {
+			return fmt.Sprintf("%s.sorted()", src), nil
+		}
+		return "", fmt.Errorf("advanced query clauses not supported")
+	}
 
-       // simple map with optional cross joins
-       orig := c.env
-       child := types.NewEnv(c.env)
-       elem := c.inferExprType(q.Source)
-       if lt, ok := elem.(types.ListType); ok {
-               elem = lt.Elem
-       }
-       child.SetVar(q.Var, elem, true)
-       fromSrcs := make([]string, len(q.Froms))
-       for i, f := range q.Froms {
-               fs, err := c.compileExpr(f.Src)
-               if err != nil {
-                       return "", err
-               }
-               ft := c.inferExprType(f.Src)
-               var fe types.Type = types.AnyType{}
-               if lt, ok := ft.(types.ListType); ok {
-                       fe = lt.Elem
-               }
-               child.SetVar(f.Var, fe, true)
-               fromSrcs[i] = fs
-       }
-       c.env = child
-       sel, err := c.compileExpr(q.Select)
-       if err != nil {
-               c.env = orig
-               return "", err
-       }
-       elemType := c.inferExprType(q.Select)
-       c.env = orig
-       resType := swiftType(elemType)
-       if resType == "" {
-               resType = "Any"
-       }
+	// simple map with optional cross joins
+	orig := c.env
+	child := types.NewEnv(c.env)
+	elem := c.inferExprType(q.Source)
+	if lt, ok := elem.(types.ListType); ok {
+		elem = lt.Elem
+	}
+	child.SetVar(q.Var, elem, true)
+	fromSrcs := make([]string, len(q.Froms))
+	for i, f := range q.Froms {
+		fs, err := c.compileExpr(f.Src)
+		if err != nil {
+			return "", err
+		}
+		ft := c.inferExprType(f.Src)
+		var fe types.Type = types.AnyType{}
+		if lt, ok := ft.(types.ListType); ok {
+			fe = lt.Elem
+		}
+		child.SetVar(f.Var, fe, true)
+		fromSrcs[i] = fs
+	}
+	c.env = child
+	sel, err := c.compileExpr(q.Select)
+	if err != nil {
+		c.env = orig
+		return "", err
+	}
+	cond := ""
+	if q.Where != nil {
+		cond, err = c.compileExpr(q.Where)
+		if err != nil {
+			c.env = orig
+			return "", err
+		}
+	}
+	elemType := c.inferExprType(q.Select)
+	c.env = orig
+	resType := swiftType(elemType)
+	if resType == "" {
+		resType = "Any"
+	}
 
-       var b strings.Builder
-       b.WriteString("({\n")
-       b.WriteString(fmt.Sprintf("\tvar _res: [%s] = []\n", resType))
-       b.WriteString(fmt.Sprintf("\tfor %s in %s {\n", q.Var, src))
-       indent := "\t\t"
-       for i, f := range q.Froms {
-               b.WriteString(fmt.Sprintf("%sfor %s in %s {\n", indent, f.Var, fromSrcs[i]))
-               indent += "\t"
-       }
-       b.WriteString(fmt.Sprintf("%s_res.append(%s)\n", indent, sel))
-       for range q.Froms {
-               indent = indent[:len(indent)-1]
-               b.WriteString(indent + "}\n")
-       }
-       b.WriteString("\t}\n")
-       b.WriteString("\treturn _res\n")
-       b.WriteString("}())")
-       return b.String(), nil
+	var b strings.Builder
+	b.WriteString("({\n")
+	b.WriteString(fmt.Sprintf("\tvar _res: [%s] = []\n", resType))
+	b.WriteString(fmt.Sprintf("\tfor %s in %s {\n", q.Var, src))
+	indent := "\t\t"
+	for i, f := range q.Froms {
+		b.WriteString(fmt.Sprintf("%sfor %s in %s {\n", indent, f.Var, fromSrcs[i]))
+		indent += "\t"
+	}
+	if cond != "" {
+		b.WriteString(fmt.Sprintf("%sif %s {\n", indent, cond))
+		indent += "\t"
+	}
+	b.WriteString(fmt.Sprintf("%s_res.append(%s)\n", indent, sel))
+	if cond != "" {
+		indent = indent[:len(indent)-1]
+		b.WriteString(indent + "}\n")
+	}
+	for range q.Froms {
+		indent = indent[:len(indent)-1]
+		b.WriteString(indent + "}\n")
+	}
+	b.WriteString("\t}\n")
+	b.WriteString("\treturn _res\n")
+	b.WriteString("}())")
+	return b.String(), nil
 }
 
 func (c *Compiler) isStringPrimary(p *parser.Primary) bool {


### PR DESCRIPTION
## Summary
- enhance Swift compiler with simple `where` filtering for queries
- document additional unsupported features in the Swift backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854d9fbb5b88320819870a29994ae8d