### PR TITLE
Add map literal support for C++ backend

### DIFF
--- a/compile/cpp/README.md
+++ b/compile/cpp/README.md
@@ -193,6 +193,6 @@ This backend covers only a subset of Mochi's features but is useful as an exampl
 
 Some LeetCode solutions use language constructs that the C++ backend can't yet translate. Unsupported features include:
 
-* Map literals and indexing operations
-* Dataset query syntax like `from ... sort by ...`
-* Inferring element types for empty list literals
+* Dataset queries with clauses like `where`, `group by`, `join`, `skip`, `take`, or `sort by`
+* Union type declarations
+* Inferring element types for empty list and map literals


### PR DESCRIPTION
## Summary
- extend C++ compiler with `unordered_map` generation and type inference
- handle empty map literals in variable declarations
- document remaining unsupported features for the C++ backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854e636c8708320857b7d1ed73eab98