### PR TITLE
Add skip/take to Scala backend

### DIFF
--- a/compile/scala/README.md
+++ b/compile/scala/README.md
@@ -272,6 +272,8 @@ The following pieces of Mochi are not yet handled by the Scala backend:
 - concurrent primitives such as `spawn` and channels
 - module system and imports
 - generic types and higher‑order functions
-- advanced dataset queries (joins, grouping, skipping or taking results)
+- advanced dataset queries (joins and grouping)
+- logic queries and AI `generate` blocks
+- data operations like `fetch`, `load` and `save`
 - reflection and macro facilities
 


### PR DESCRIPTION
## Summary
- support `skip` and `take` in Scala query compiler
- document additional unsupported features

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6854e67c9c8c83208a4503df7d662766