### PR TITLE
Add mutable param detection to Rust backend

### DIFF
--- a/compile/rust/README.md
+++ b/compile/rust/README.md
@@ -6,7 +6,8 @@ The Rust backend translates Mochi programs to Rust source code. It is used for e
 
 The current implementation lacks support for:
 
-- Automatic detection of mutable parameters.
+- Methods defined inside `type` declarations are ignored.
+- Generic map types (`map<K, V>`) are not yet handled.
 - Agent and stream declarations (`agent`, `on`, `emit`).
 - Logic programming constructs (`fact`, `rule`, `query`).
 - Data fetching and persistence expressions (`fetch`, `load`, `save`, `generate`).


### PR DESCRIPTION
## Summary
- detect parameter mutation in Rust compiler and mark as `mut`
- support `int64` and generic map types in Rust type mapping
- document additional unsupported Rust backend features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854e689aea08320bbb17e9deeffc7f0