### PR TITLE
Add skip/take support to Scala backend

### DIFF
--- a/compile/scala/README.md
+++ b/compile/scala/README.md
@@ -272,6 +272,8 @@ The following pieces of Mochi are not yet handled by the Scala backend:
 - concurrent primitives such as `spawn` and channels
 - module system and imports
 - generic types and higher‑order functions
-- advanced dataset queries (joins, grouping, skipping or taking results)
+- advanced dataset queries (joins, grouping)
+- load/save expressions and other I/O features
+- HTTP requests and LLM integrations
 - reflection and macro facilities
 

--- a/tests/compiler/scala/dataset_sort_take_limit.mochi
+++ b/tests/compiler/scala/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/scala/dataset_sort_take_limit.out
+++ b/tests/compiler/scala/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/compiler/scala/dataset_sort_take_limit.scala.out
+++ b/tests/compiler/scala/dataset_sort_take_limit.scala.out
@@ -1,0 +1,31 @@
+case class Product(name: String, price: Int)
+
+object Main {
+	def main(args: Array[String]): Unit = {
+		val products = scala.collection.mutable.ArrayBuffer(Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
+		val expensive = (() => {
+	val res1 = scala.collection.mutable.ArrayBuffer[(Any, Any)]()
+	for (p <- products) {
+		res1.append((p, (-p.price)))
+	}
+	var seq2 = res1.sortBy(_._2)(_anyOrdering).map(_._1).toSeq
+	seq2 = seq2.drop(1)
+	seq2 = seq2.take(3)
+	seq2
+})()
+		println("--- Top products (excluding most expensive) ---")
+		val it3 = expensive.iterator
+		while (it3.hasNext) {
+			val item = it3.next()
+			println(item.name, "costs $", item.price)
+		}
+	}
+	
+	def _compare(a: Any, b: Any): Int = (a, b) match {
+		case (x: Int, y: Int) => x.compare(y)
+		case (x: Double, y: Double) => java.lang.Double.compare(x, y)
+		case (x: String, y: String) => x.compareTo(y)
+		case _ => a.toString.compareTo(b.toString)
+	}
+	implicit val _anyOrdering: Ordering[Any] = new Ordering[Any] { def compare(x: Any, y: Any): Int = _compare(x, y) }
+}


### PR DESCRIPTION
## Summary
- extend Scala compiler to handle query `skip` and `take`
- implement selector access in Scala compiler
- document more unsupported features
- add dataset query test for Scala with skip/take

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854e69b38a08320b69dc2de5f860c7a