### PR TITLE
Add match expression support for PHP backend

### DIFF
--- a/compile/php/README.md
+++ b/compile/php/README.md
@@ -305,3 +305,14 @@ The tests skip automatically if `php` is not installed and rely on
 The PHP backend currently supports a subset of Mochi's features suitable for
 scripts and simple utilities. Complex type handling and advanced runtime
 support are not yet implemented.
+
+## Unsupported Features
+
+Many language constructs remain unimplemented in the PHP generator. The current
+limitations include:
+
+- Dataset queries using `from`/`select`, joins or grouping
+- LLM helpers such as `generate` or `fetch`
+- Stream and agent declarations
+- User defined struct and union types
+- Concurrency primitives and external objects

--- a/compile/php/helpers.go
+++ b/compile/php/helpers.go
@@ -59,3 +59,60 @@ func simpleStringKey(e *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	return p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0
+}
+
+func callPattern(e *parser.Expr) (*parser.CallExpr, bool) {
+	if e == nil {
+		return nil, false
+	}
+	if len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target.Call == nil {
+		return nil, false
+	}
+	return p.Target.Call, true
+}
+
+func identName(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
+}

--- a/tests/compiler/php/match_expr.mochi
+++ b/tests/compiler/php/match_expr.mochi
@@ -1,0 +1,9 @@
+fun describe(x: int): string {
+  return match x {
+    0 => "zero"
+    _ => "other"
+  }
+}
+
+print(describe(0))
+print(describe(7))

--- a/tests/compiler/php/match_expr.out
+++ b/tests/compiler/php/match_expr.out
@@ -1,0 +1,2 @@
+zero
+other

--- a/tests/compiler/php/match_expr.php.out
+++ b/tests/compiler/php/match_expr.php.out
@@ -1,0 +1,10 @@
+<?php
+function describe($x) {
+	return (function ($t0) {
+	if ($t0 == 0) { return "zero"; }
+	return "other";
+})($x);
+}
+
+echo describe(0), PHP_EOL;
+echo describe(7), PHP_EOL;


### PR DESCRIPTION
## Summary
- add match expression compilation logic in PHP backend
- document unsupported features in PHP backend
- provide helpers for match patterns
- add new regression test for match expressions

## Testing
- `go test ./compile/php -run TestPHPCompiler_SubsetPrograms/match_expr -tags slow -count=1`
- `go test ./compile/php -run TestPHPCompiler_SubsetPrograms -tags slow -count=1` *(fails: cast_struct, float_literal_precision, list_prepend, math_import_py, matrix_search, slice_remove, typed_list_negative)*


------
https://chatgpt.com/codex/tasks/task_e_6854d9e60d048320ac12d6bab995072d