### PR TITLE
Improve Python backend docs and compiler

### DIFF
--- a/compile/py/README.md
+++ b/compile/py/README.md
@@ -102,6 +102,14 @@ func EnsurePython() error {
 ```
 【F:compile/py/tools.go†L10-L42】
 
+## Unsupported Features
+
+The Python backend does not yet implement every language feature. Known
+limitations include:
+
+* Initializing agents with field values, e.g. `MyAgent { foo: 1 }`
+* `import` statements targeting a language other than Python
+
 ## Notes
 
 The backend supports streams, agents, dataset queries, LLM helpers and more. When asynchronous stream handlers are present, the compiler wraps execution in `_run()` and waits for all pending tasks before exiting.

--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -1301,7 +1301,14 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 		}
 		return fmt.Sprintf("(lambda %s: %s)", strings.Join(params, ", "), expr), nil
 	}
-	return "None", fmt.Errorf("block function expressions not supported")
+
+	name := fmt.Sprintf("_fn%d", c.tmpCount)
+	c.tmpCount++
+	stmt := &parser.FunStmt{Name: name, Params: fn.Params, Return: fn.Return, Body: fn.BlockBody}
+	if err := c.compileFunStmt(stmt); err != nil {
+		return "", err
+	}
+	return name, nil
 }
 
 func (c *Compiler) compileListLiteral(l *parser.ListLiteral) (string, error) {


### PR DESCRIPTION
## Summary
- support block-style fun expressions in Python compiler
- document remaining Python backend limitations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854d9edd4b48320a2d9b24e15918369