### PR TITLE
Add dataset IO support for F# backend

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -118,6 +118,9 @@ Mochi features are not yet available.
 The F# generator currently lacks support for several language constructs:
 
 * Package `import` declarations and `extern` functions
-* HTTP helpers like `fetch` and dataset `load`/`save`
+* HTTP helpers like `fetch`
+* Built-in `test`/`expect` blocks
+* Logic programming constructs (`fact`, `rule`, `query`)
+* Advanced dataset queries such as joins and grouping
 * Streams, agents and LLM `generate` blocks
 

--- a/compile/fs/runtime.go
+++ b/compile/fs/runtime.go
@@ -1,0 +1,47 @@
+package fscode
+
+const (
+	helperLoad = `let _load (path: string option) (opts: Map<string,obj> option) : List<Map<string,obj>> =
+  let format = opts |> Option.bind (Map.tryFind "format") |> Option.map string |> Option.defaultValue "csv"
+  let header = opts |> Option.bind (Map.tryFind "header") |> Option.map unbox<bool> |> Option.defaultValue true
+  let mutable delim = opts |> Option.bind (Map.tryFind "delimiter") |> Option.map (fun v -> (string v).[0]) |> Option.defaultValue ','
+  if format = "tsv" then delim <- '\t'
+  let text =
+    match path with
+    | None | Some "" | Some "-" -> System.Console.In.ReadToEnd()
+    | Some p -> System.IO.File.ReadAllText(p)
+  let lines = text.Trim().Split([|'\n';'\r'|], System.StringSplitOptions.RemoveEmptyEntries)
+  if lines.Length = 0 then [] else
+    let headers =
+      if header then lines.[0].Split(delim)
+      else Array.init (lines.[0].Split(delim).Length) (fun i -> sprintf "c%d" i)
+    let start = if header then 1 else 0
+    [ for i in start .. lines.Length - 1 ->
+        let parts = lines.[i].Split(delim)
+        headers |> Array.mapi (fun j h -> h, if j < parts.Length then box parts.[j] else box "") |> Map.ofArray ]`
+
+	helperSave = `let _save (rows: List<Map<string,obj>>) (path: string option) (opts: Map<string,obj> option) : unit =
+  let format = opts |> Option.bind (Map.tryFind "format") |> Option.map string |> Option.defaultValue "csv"
+  let header = opts |> Option.bind (Map.tryFind "header") |> Option.map unbox<bool> |> Option.defaultValue false
+  let mutable delim = opts |> Option.bind (Map.tryFind "delimiter") |> Option.map (fun v -> (string v).[0]) |> Option.defaultValue ','
+  if format = "tsv" then delim <- '\t'
+  if format <> "csv" then () else
+    let headers = if rows.Length > 0 then rows.[0] |> Map.keys |> Seq.toArray |> Array.sort else [||]
+    let sb = System.Text.StringBuilder()
+    if header then sb.AppendLine(String.concat (string delim) headers) |> ignore
+    for row in rows do
+        let line =
+            headers
+            |> Array.map (fun h -> match Map.tryFind h row with Some v -> string v | None -> "")
+            |> String.concat (string delim)
+        sb.AppendLine(line) |> ignore
+    let out = sb.ToString()
+    match path with
+    | None | Some "" | Some "-" -> System.Console.Out.Write(out)
+    | Some p -> System.IO.File.WriteAllText(p, out)`
+)
+
+var helperMap = map[string]string{
+	"_load": helperLoad,
+	"_save": helperSave,
+}


### PR DESCRIPTION
## Summary
- support `load` and `save` expressions in the F# compiler
- include new runtime helpers `_load` and `_save`
- track helper usage so runtime code is emitted only when needed
- document additional unsupported features in the F# README

## Testing
- `go test ./compile/fs -tags slow -run TestFSCompiler_GoldenOutput`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854edb42a208320a58b51cf4eeb7b2a