### PR TITLE
Add more C++ compiler support

### DIFF
--- a/compile/cpp/README.md
+++ b/compile/cpp/README.md
@@ -195,4 +195,9 @@ Some LeetCode solutions use language constructs that the C++ backend can't yet t
 
 * Dataset queries with clauses like `where`, `group by`, `join`, `skip`, `take`, or `sort by`
 * Union type declarations
-* Inferring element types for empty list and map literals
+* Agents, streams and intents
+* `generate` blocks and model definitions
+* Dataset helpers such as `fetch`, `load`, `save` and SQL-style `from ...` queries
+* `match` expressions for pattern matching
+* Foreign imports and `extern` declarations
+* Package management, tests and `expect` blocks


### PR DESCRIPTION
## Summary
- support inferring element types for empty list/map literals in `let` statements
- document additional unsupported features in the C++ backend

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_6854f7fa535883208eec0c6087a9fcff