### PR TITLE
Add basic fetch/load/save support to Dart backend

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -242,8 +242,10 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 
 ### Unsupported features
 
-- Generative AI helpers such as `generate` and `fetch`
-- Data loading and persistence (`load`, `save`)
+- Generative AI helpers such as `generate`
 - Foreign function interface bindings
 - Streams and long‑lived agents
 - Logic programming constructs (`fact`, `rule`, `query`)
+- Package declarations and module imports
+- Methods defined inside `type` declarations
+- Dataset grouping and outer join clauses in queries


### PR DESCRIPTION
## Summary
- implement `_fetch`, `_load`, `_save` helpers in the Dart compiler
- add compiler hooks for `fetch`, `load`, and `save` expressions
- expose new runtime helpers when used
- document remaining unsupported features in the Dart README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854f80e4ac48320b0727c0704130973