### PR TITLE
Add support for block lambdas in Lua backend

### DIFF
--- a/compile/lua/README.md
+++ b/compile/lua/README.md
@@ -292,7 +292,7 @@ solutions under `examples/leetcode` to verify basic program execution.
 
 ## Notes
 
-The Lua backend supports most core language features but skips advanced LLM helpers and external objects. Query expressions handle simple joins and common clauses. The emphasis is on readability and portability of the emitted Lua code.
+The Lua backend supports most core language features but skips advanced LLM helpers and external objects. Query expressions handle simple `from` clauses along with `where`, `sort`, `skip` and `take`. The emphasis is on readability and portability of the emitted Lua code.
 
 ### Unsupported Features
 
@@ -301,7 +301,8 @@ fail at runtime:
 
 - Regular expression helpers beyond simple `match`
 - Mutating lists while iterating (e.g. `insert`, `remove`)
-- Query clauses like `join`, `skip`, `take` and `order` 
+- Query clauses like `join` or `group`
+- Loading or saving data with `load`/`save`
 - Interaction with external objects
 
 Problems `6`, `10`, `23` and `27` currently do not run correctly when compiled

--- a/compile/lua/compiler.go
+++ b/compile/lua/compiler.go
@@ -826,16 +826,21 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 	for i, p := range fn.Params {
 		params[i] = sanitizeName(p.Name)
 	}
-	if fn.ExprBody == nil {
-		return "", fmt.Errorf("block function expressions not supported")
-	}
 	sub := &Compiler{env: c.env, helpers: c.helpers}
 	sub.indent = 1
-	expr, err := sub.compileExpr(fn.ExprBody)
-	if err != nil {
-		return "", err
+	if fn.ExprBody != nil {
+		expr, err := sub.compileExpr(fn.ExprBody)
+		if err != nil {
+			return "", err
+		}
+		sub.writeln("return " + expr)
+	} else {
+		for _, st := range fn.BlockBody {
+			if err := sub.compileStmt(st); err != nil {
+				return "", err
+			}
+		}
 	}
-	sub.writeln("return " + expr)
 	body := indentBlock(sub.buf.String(), 1)
 	return "function(" + strings.Join(params, ", ") + ")\n" + body + "end", nil
 }


### PR DESCRIPTION
## Summary
- implement block-bodied function expressions in the Lua compiler
- document additional unsupported features in Lua backend README

## Testing
- `go test ./compile/lua -run TestLuaCompiler_LeetCodeExample1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6854f8197fd08320ba138947fb77b62b