### PR TITLE
Add Smalltalk loop control and update docs

### DIFF
--- a/compile/st/README.md
+++ b/compile/st/README.md
@@ -16,7 +16,16 @@ go test ./compile/st -tags slow
 
 ## Notes
 
-The Smalltalk backend currently supports only a subset of Mochi. Features such
-as `break` and `continue` in loops, agents, dataset queries and generative AI
-blocks are not implemented yet. When the `count()` builtin is used, a helper
-method is emitted automatically.
+The Smalltalk backend currently supports only a subset of Mochi. When the
+`count()` builtin is used, a helper method is emitted automatically. Loops now
+handle `break` and `continue` using custom signals.
+
+### Unsupported features
+
+The following language constructs are not yet handled:
+
+- Agents and stream handlers
+- Dataset queries and data operations (`fetch`, `load`, `save`)
+- Generative AI helpers such as `generate`
+- Logic programming (`fact`, `rule`, `query`)
+- Foreign function interface declarations (`extern`)


### PR DESCRIPTION
## Summary
- implement break/continue support in Smalltalk compiler
- track loops for break/continue
- emit BreakSignal and ContinueSignal helpers
- document unsupported features in `compile/st/README.md`

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6854f8733a4c83209b29e231a9cf3ee1