### PR TITLE
Add basic Racket match support

### DIFF
--- a/compile/rkt/README.md
+++ b/compile/rkt/README.md
@@ -173,12 +173,16 @@ for readability over performance and mirrors Mochi constructs closely.
 Loops support `break` and `continue` using `let/ec` and named `let` constructs.
 Binary operators now include `union`, `union_all`, `except` and `intersect` for
 basic list set operations.
+`match` expressions compile directly to Racket's `match` form for simple pattern
+matching.
 
 Unsupported features currently include:
 
 * Generative `generate` blocks and model definitions
 * Dataset helpers like `fetch`, `load`, `save` and SQL-style query expressions
-* `match` expressions for pattern matching
 * Agents, streams and intents
+* Logic programming constructs (`fact`, `rule`, `query`)
+* Concurrency primitives such as `spawn` and channels
 * Foreign function interface via `import`
 * Package management and `package` declarations
+* User-defined type declarations (`struct` and `union`)

--- a/compile/rkt/helpers.go
+++ b/compile/rkt/helpers.go
@@ -1,6 +1,10 @@
 package rktcode
 
-import "strings"
+import (
+	"strings"
+
+	"mochi/parser"
+)
 
 func (c *Compiler) writeln(s string) {
 	c.writeIndent()
@@ -31,4 +35,22 @@ func sanitizeName(name string) string {
 		s = "_" + s
 	}
 	return s
+}
+
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	return p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0
 }


### PR DESCRIPTION
## Summary
- add `(require racket/match)` and compile `match` expressions
- handle `match` in primary expressions and emit patterns
- detect `_` pattern helpers
- document remaining unsupported features

## Testing
- `go vet ./...`
- `go test ./compile/rkt -tags slow -count=1` *(fails: read-syntax expected `)`)*

------
https://chatgpt.com/codex/tasks/task_e_6854f8a5f0488320bb0fbc3b35653a15