### PR TITLE
Add now/json builtins for Java backend

### DIFF
--- a/compile/java/README.md
+++ b/compile/java/README.md
@@ -51,7 +51,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 ```
 【F:compile/java/compiler.go†L21-L58】
 
-Built-in functions like `print`, `len`, `str`, `input`, `count` and `avg` are
+Built-in functions like `print`, `len`, `str`, `input`, `count`, `avg`, `now` and `json` are
 translated directly inside `compilePrimary`:
 
 ```go
@@ -246,5 +246,7 @@ The Java backend currently lacks several Mochi features supported by other compi
 - Concurrency primitives like streams and agents
 - Foreign imports and extern functions
 - Logic programming constructs (`fact`, `rule`, `query`)
+- Test blocks and expectations (`test`, `expect`)
+- Package declarations at the top of the file
 
 Simple `from` queries used by the LeetCode examples are now supported.


### PR DESCRIPTION
## Summary
- support `now()` and `json()` built-ins in Java compiler
- implement minimal JSON printer in emitted runtime
- document new built-ins
- note additional unsupported features in the Java README

## Testing
- `go test ./compile/java -run TestJavaCompiler_GoldenOutput -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68550c79377483208e3fc32fa4622573