### PR TITLE
Update Erlang backend

### DIFF
--- a/compile/erlang/README.md
+++ b/compile/erlang/README.md
@@ -47,8 +47,9 @@ mochi build --target erlang main.mochi -o main.erl
 escript main.erl            # run the program
 ```
 【F:cmd/mochi/main.go†L507-L518】
-The output module is named `main` and exports `main/1` along with any user
-functions defined at the top level.
+The output module is named `main` by default and exports `main/1` along with
+any user functions defined at the top level. When a source file declares a
+`package`, that name is used for the generated module instead of `main`.
 
 ## Tests
 
@@ -83,11 +84,11 @@ features are not yet handled:
 
 - Joins or grouping inside queries
 - Generative AI helpers like `generate` or `fetch`
-- Dataset operations such as `load` and `save`
 - Logic programming constructs and streams
 - Agents and event streams
 - Foreign function imports via `extern`
-- Packages and `import` statements
+- Import statements
+- Test blocks and `expect` statements
 
 Generated Erlang favors clarity over speed, mirroring Mochi constructs
 directly.

--- a/compile/erlang/compiler.go
+++ b/compile/erlang/compiler.go
@@ -122,7 +122,11 @@ func (c *Compiler) writeln(s string) {
 func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.buf.Reset()
 	c.writeln("#!/usr/bin/env escript")
-	c.writeln("-module(main).")
+	mod := "main"
+	if prog.Package != "" {
+		mod = prog.Package
+	}
+	c.writeln(fmt.Sprintf("-module(%s).", mod))
 
 	// collect exported functions
 	exports := []string{"main/1"}
@@ -284,6 +288,15 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		return nil
 	case s.If != nil:
 		return c.compileIf(s.If)
+	case s.Import != nil:
+		// import statements are ignored
+		return nil
+	case s.Test != nil, s.Expect != nil:
+		// testing constructs are not supported yet
+		return nil
+	case s.ExternVar != nil, s.ExternFun != nil, s.ExternType != nil, s.ExternObject != nil:
+		// extern declarations are ignored
+		return nil
 	default:
 		c.buf.WriteString("ok")
 	}


### PR DESCRIPTION
## Summary
- allow package declarations in Erlang backend
- ignore imports, tests and expect statements when compiling
- document new package support and additional unsupported features

## Testing
- `go test ./compile/erlang`
- `go vet ./...` *(fails: self‑assignment warnings in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68550dec27d483208de2f7b429be6d7a