### PR TITLE
Add fetch/load/save stubs for Scala backend

### DIFF
--- a/compile/scala/README.md
+++ b/compile/scala/README.md
@@ -274,6 +274,8 @@ The following pieces of Mochi are not yet handled by the Scala backend:
 - generic types and higher‑order functions
 - advanced dataset queries (joins and grouping)
 - logic queries and AI `generate` blocks
-- data operations like `fetch`, `load` and `save`
 - reflection and macro facilities
+- streams and agents
+- foreign function interface (`extern` imports)
+- error handling with `try`/`catch`
 


### PR DESCRIPTION
## Summary
- implement basic `fetch`, `load` and `save` handling in the Scala compiler
- emit stub helper methods when these operations are used
- list additional unsupported features in Scala backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68550ec533148320a2f4248a58c147e3