### PR TITLE
Add generate support to Dart compiler

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -242,10 +242,10 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 
 ### Unsupported features
 
-- Generative AI helpers such as `generate`
 - Foreign function interface bindings
 - Streams and long‑lived agents
 - Logic programming constructs (`fact`, `rule`, `query`)
 - Package declarations and module imports
 - Methods defined inside `type` declarations
 - Dataset grouping and outer join clauses in queries
+- Model declarations


### PR DESCRIPTION
## Summary
- implement `generate` expressions in the Dart backend
- emit stub `_genText`, `_genEmbed`, and `_genStruct` helpers
- document remaining unsupported features for Dart

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68552f203e308320afe20c99d557fe3d