### PR TITLE
Add group-by support for Elixir backend

### DIFF
--- a/compile/ex/README.md
+++ b/compile/ex/README.md
@@ -197,8 +197,14 @@ go test ./compile/ex -tags slow
 
 ## Unsupported Features
 
-Nested recursive functions are not currently handled when compiling to Elixir.
-Problems relying on them, such as LeetCode 22, fail to run.
+The Elixir backend implements most core language features but still lacks support for several advanced constructs:
 
-Queries using joins or grouping are also unimplemented. Cross join queries now
-support `where` filters as well as `sort`, `skip` and `take` clauses.
+- Nested recursive functions inside other functions. Problems relying on them, such as LeetCode 22, fail to run.
+- Dataset queries with join clauses. Simple `group by` queries are now supported but more complex grouping or aggregation is not yet handled.
+- Agent and stream constructs (`agent`, `on`, `emit`) and logic programming features (`fact`, `rule`, `query`).
+- Data helpers like `fetch`, `load`, `save` and LLM `generate` blocks.
+- Foreign imports and `extern` declarations.
+- Concurrency primitives such as `spawn` and channels.
+- Pattern matching with `match` expressions.
+
+Cross join queries do support `where` filters as well as `sort`, `skip` and `take` clauses.

--- a/compile/ex/runtime.go
+++ b/compile/ex/runtime.go
@@ -6,10 +6,16 @@ const (
 	helperCount = "defp _count(v) do\n  cond do\n    is_list(v) -> length(v)\n    is_map(v) and Map.has_key?(v, :Items) -> length(v[:Items])\n    true -> raise \"count() expects list or group\"\n  end\nend\n"
 
 	helperAvg = "defp _avg(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :Items) -> v[:Items]\n    is_list(v) -> v\n    true -> raise \"avg() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    Enum.sum(list) / Enum.count(list)\n  end\nend\n"
+
+	helperGroup = "defmodule _Group do\n  defstruct key: nil, Items: []\nend\n"
+
+	helperGroupBy = "defp _group_by(src, keyfn) do\n  {groups, order} = Enum.reduce(src, {%{}, []}, fn it, {groups, order} ->\n    key = keyfn.(it)\n    ks = to_string(key)\n    {groups, order} = if Map.has_key?(groups, ks) do\n      {groups, order}\n    else\n      {Map.put(groups, ks, %_Group{key: key}), order ++ [ks]}\n    end\n    groups = Map.update!(groups, ks, fn g -> %{g | Items: g.Items ++ [it]} end)\n    {groups, order}\n  end)\n  Enum.map(order, fn k -> groups[k] end)\nend\n"
 )
 
 var helperMap = map[string]string{
-	"_input": helperInput,
-	"_count": helperCount,
-	"_avg":   helperAvg,
+	"_input":    helperInput,
+	"_count":    helperCount,
+	"_avg":      helperAvg,
+	"_group":    helperGroup,
+	"_group_by": helperGroupBy,
 }


### PR DESCRIPTION
## Summary
- implement simple `group by` query support in the Elixir compiler
- include new runtime helpers `_Group` and `_group_by`
- document unsupported Elixir features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68552f24abbc83208ce34f0bdf47d05c