### PR TITLE
Extend Fortran backend features

### DIFF
--- a/compile/fortran/README.md
+++ b/compile/fortran/README.md
@@ -187,9 +187,14 @@ Despite recent additions like detection of `list<string>` and `list<float>`
 parameters and return values, the Fortran backend remains limited. Missing
 features include:
 
-- `map` types and the `in` membership operator
-- query expressions (`from`/`sort by`/`select`)
-- nested function definitions and struct literals
+- Map types and membership tests for maps. The `in` operator only works for
+  lists and strings.
+- Query expressions (`from`/`sort by`/`select`).
+- Nested function definitions and struct literals.
+- Set operations such as `union`, `except` and `intersect`.
+- Pattern matching with `match` expressions.
+- Agents, streams and logic programming constructs (`fact`, `rule`, `query`).
+- Foreign imports and dataset helpers like `fetch`, `load` and `save`.
 
 While limited, this backend demonstrates how Mochi’s AST can be translated into
 another language and may serve as a starting point for more complete Fortran

--- a/compile/fortran/compiler.go
+++ b/compile/fortran/compiler.go
@@ -994,7 +994,7 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 			return 1
 		case "&&":
 			return 2
-		case "==", "!=", "<", "<=", ">", ">=":
+		case "==", "!=", "<", "<=", ">", ">=", "in":
 			return 3
 		case "+", "-":
 			return 4
@@ -1057,6 +1057,14 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 			expr = fmt.Sprintf("(%s %s %s)", left, op, right)
 		case "!=":
 			expr = fmt.Sprintf("(%s /= %s)", left, right)
+		case "in":
+			if rList {
+				expr = fmt.Sprintf("any(%s == %s)", right, left)
+			} else if rStr {
+				expr = fmt.Sprintf("index(%s, %s) > 0", right, left)
+			} else {
+				return fmt.Errorf("unsupported op %s", op)
+			}
 		case "%":
 			expr = fmt.Sprintf("mod(%s, %s)", left, right)
 		case "&&":
@@ -1179,6 +1187,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 			if op.Cast.Type != nil {
 				if op.Cast.Type.Simple != nil && *op.Cast.Type.Simple == "float" {
 					expr = fmt.Sprintf("real(%s)", expr)
+				} else if op.Cast.Type.Simple != nil && *op.Cast.Type.Simple == "int" {
+					expr = fmt.Sprintf("int(%s)", expr)
 				} else if op.Cast.Type.Generic != nil && op.Cast.Type.Generic.Name == "list" {
 					// no-op for list casts
 					expr = expr


### PR DESCRIPTION
## Summary
- support membership operator `in` for lists and strings
- add `int` type casts in the Fortran backend
- document additional unsupported features in the Fortran README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68552f2808a883209d83405627d4e9dc