### PR TITLE
Support more features in Prolog backend

### DIFF
--- a/compile/pl/README.md
+++ b/compile/pl/README.md
@@ -282,5 +282,5 @@ Mochi language features are not yet implemented:
 - Dataset queries (`from`/`select`, joins and grouping)
 - Structured types such as `struct` and enums
 - Concurrency primitives and external helpers like `_fetch` or `_genText`
-- Expression statements other than `print`
-- Map literals with computed keys
+- Continue statements
+- Import declarations


### PR DESCRIPTION
## Summary
- allow arbitrary expressions as statements in Prolog backend
- permit map literals with computed keys using `dict_create`
- list `continue` and `import` as remaining unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68552f38b63083209b98ef728a436ecc