### PR TITLE
Add dataset helpers to Racket backend

### DIFF
--- a/compile/rkt/README.md
+++ b/compile/rkt/README.md
@@ -175,11 +175,13 @@ Binary operators now include `union`, `union_all`, `except` and `intersect` for
 basic list set operations.
 `match` expressions compile directly to Racket's `match` form for simple pattern
 matching.
+Dataset helpers `_fetch`, `_load` and `_save` handle basic JSON data.
 
 Unsupported features currently include:
 
 * Generative `generate` blocks and model definitions
-* Dataset helpers like `fetch`, `load`, `save` and SQL-style query expressions
+* SQL-style dataset queries (`from`, `join`, etc.)
+* Error handling with `try`/`catch`
 * Agents, streams and intents
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Concurrency primitives such as `spawn` and channels


### PR DESCRIPTION
## Summary
- extend the Racket compiler with `_fetch`, `_load` and `_save` helpers
- emit dataset runtime only when such expressions are used
- note dataset helpers and new unsupported features in docs

## Testing
- `go test ./compile/rkt -tags slow -run TestRacketCompiler_GoldenOutput -count=1` *(fails: unknown escape sequence)*

------
https://chatgpt.com/codex/tasks/task_e_68552f3ee618832097e9508e2d331e73