### PR TITLE
Add map support to Scheme backend

### DIFF
--- a/compile/scheme/README.md
+++ b/compile/scheme/README.md
@@ -288,7 +288,9 @@ The Scheme backend intentionally supports only a small subset of Mochi.  It does
 * union types and methods
 * packages or the foreign function interface
 * streams, agents, or tests
-* maps, sets, and `match` expressions
+* sets and `match` expressions
+* struct types or literals
+* logic programming predicates
 
 These features are recognised by the main Mochi interpreter but are ignored by the Scheme compiler.
 


### PR DESCRIPTION
## Summary
- implement map literals, indexing, and assignment for Scheme target
- inject helper functions `map-get`/`map-set` when needed
- track map variables during compilation
- document newly supported and unsupported features in Scheme README

## Testing
- `go test ./compile/scheme -run TestSchemeCompiler_GoldenOutput -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68552f43e8b08320a842e17a3b4a4b5e