### PR TITLE
Add Swift inline methods support

### DIFF
--- a/compile/swift/README.md
+++ b/compile/swift/README.md
@@ -236,10 +236,11 @@ The Swift backend still lacks support for a number of language capabilities:
 
 - Advanced dataset queries with grouping, joins, sorting or pagination. Simple
   ``from ... where ... select`` loops (with optional cross joins) are handled.
-- Structural type declarations with inline methods
 - Higher-order functions or function values
 - Type inference for empty collections
 - Streams, agents and intent handlers
 - Match expressions for union pattern matching
 - The ``generate`` and ``fetch`` expressions for LLM and HTTP integration
 - Package declarations and the foreign function interface
+- Set collections and related operations
+- Test blocks using ``test`` and ``expect`` statements


### PR DESCRIPTION
## Summary
- implement inline method compilation in Swift backend
- document newly unsupported features and remove outdated note

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68552f4bda708320828807d9d7017ff8