### PR TITLE
Add boolean constant folding and suppress unused variable warnings

### DIFF
--- a/compile/ex/README.md
+++ b/compile/ex/README.md
@@ -200,5 +200,10 @@ go test ./compile/ex -tags slow
 Nested recursive functions are not currently handled when compiling to Elixir.
 Problems relying on them, such as LeetCode 22, fail to run.
 
-Queries using joins or grouping are also unimplemented. Cross join queries now
-support `where` filters as well as `sort`, `skip` and `take` clauses.
+Queries involving joins are still unimplemented. Simple `group by` queries are
+now supported in addition to cross joins with `where`, `sort`, `skip` and `take`
+clauses.
+
+Other language features currently missing from the Elixir backend include the
+`fetch` expression for HTTP requests and all `generate` operations for calling
+LLMs.

--- a/compile/ex/runtime.go
+++ b/compile/ex/runtime.go
@@ -6,10 +6,16 @@ const (
 	helperCount = "defp _count(v) do\n  cond do\n    is_list(v) -> length(v)\n    is_map(v) and Map.has_key?(v, :Items) -> length(v[:Items])\n    true -> raise \"count() expects list or group\"\n  end\nend\n"
 
 	helperAvg = "defp _avg(v) do\n  list = cond do\n    is_map(v) and Map.has_key?(v, :Items) -> v[:Items]\n    is_list(v) -> v\n    true -> raise \"avg() expects list or group\"\n  end\n  if Enum.count(list) == 0 do\n    0\n  else\n    Enum.sum(list) / Enum.count(list)\n  end\nend\n"
+
+	helperGroup = "defmodule _Group do\n  defstruct key: nil, Items: []\nend\n"
+
+	helperGroupBy = "defp _group_by(src, keyfn) do\n  {map, order} = Enum.reduce(src, {%{}, []}, fn it, {g, o} ->\n    key = keyfn.(it)\n    ks = to_string(key)\n    {g, o} = if Map.has_key?(g, ks), do: {g, o}, else: {Map.put(g, ks, %_Group{key: key, Items: []}), o ++ [ks]}\n    g = Map.update!(g, ks, fn grp -> %{grp | Items: grp.Items ++ [it]} end)\n    {g, o}\n  end)\n  Enum.map(order, fn k -> Map.get(map, k) end)\nend\n"
 )
 
 var helperMap = map[string]string{
-	"_input": helperInput,
-	"_count": helperCount,
-	"_avg":   helperAvg,
+	"_input":    helperInput,
+	"_count":    helperCount,
+	"_avg":      helperAvg,
+	"_group":    helperGroup,
+	"_group_by": helperGroupBy,
 }


### PR DESCRIPTION
## Summary
- avoid treating declarations as loop mutations
- mark `let` and assignment targets as used
- constant fold boolean logic to remove Elixir warnings

## Testing
- `go test ./compile/ex -run TestExCompiler_SubsetPrograms/bool_ops -tags slow`
- `go test ./compile/ex -tags slow` *(fails: process errors in break_continue and others)*

------
https://chatgpt.com/codex/tasks/task_e_6854f82adeb08320890ddcd1ae474687