### PR TITLE
Add join tests to default rust suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,17 @@ Explore the [`examples/`](./examples) directory:
 
 Edit one or start fresh. It’s all yours.
 
+## Unsupported Features
+
+Some language constructs are still experimental or missing in the current implementation:
+
+- Advanced dataset query options like `group`, `sort`, `skip` and `take`.
+- Streams and agents are not yet compiled by the Rust backend.
+- Logic programming keywords (`fact`, `rule`, `query`).
+- File and network helpers (`fetch`, `load`, `save`, `generate`).
+- Importing external packages with `import` and calling `extern` functions.
+- `test` and `expect` blocks are ignored when compiling to Rust.
+
 ## Benchmarks
 
 Run:

--- a/compile/rust/README.md
+++ b/compile/rust/README.md
@@ -6,9 +6,11 @@ The Rust backend translates Mochi programs to Rust source code. It is used for e
 
 The current implementation lacks support for:
 
-- Complex dataset queries using grouping, joins or pagination.
+- Advanced dataset queries such as grouping, sorting or pagination.
 - Agent and stream declarations (`agent`, `on`, `emit`).
 - Logic programming constructs (`fact`, `rule`, `query`).
 - Data fetching and persistence expressions (`fetch`, `load`, `save`, `generate`).
+- Package imports and the foreign function interface (`import`, `extern`).
+- `test` and `expect` blocks are ignored.
 
 These limitations cause some programs to fail to compile with the Rust backend.

--- a/compile/rust/compiler_test.go
+++ b/compile/rust/compiler_test.go
@@ -73,6 +73,7 @@ func TestRustCompiler_ValidPrograms(t *testing.T) {
 		"for_string_collection",
 		"fun_call",
 		"cross_join",
+		"rust/join",
 		"fun_expr_in_let",
 		"grouped_expr",
 		"if_else",

--- a/tests/compiler/rust/join.mochi
+++ b/tests/compiler/rust/join.mochi
@@ -1,0 +1,42 @@
+type Customer {
+  id: int
+  name: string
+}
+
+type Order {
+  id: int
+  customerId: int
+  total: int
+}
+
+type PairInfo {
+  orderId: int
+  customerName: string
+  total: int
+}
+
+let customers = [
+  Customer { id: 1, name: "Alice" },
+  Customer { id: 2, name: "Bob" },
+  Customer { id: 3, name: "Charlie" }
+]
+
+let orders = [
+  Order { id: 100, customerId: 1, total: 250 },
+  Order { id: 101, customerId: 2, total: 125 },
+  Order { id: 102, customerId: 1, total: 300 },
+  Order { id: 103, customerId: 4, total: 80 }
+]
+
+let result = from o in orders
+             join from c in customers on o.customerId == c.id
+             select PairInfo {
+               orderId: o.id,
+               customerName: c.name,
+               total: o.total
+             }
+
+print("--- Orders with customer info ---")
+for entry in result {
+  print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+}

--- a/tests/compiler/rust/join.out
+++ b/tests/compiler/rust/join.out
@@ -1,0 +1,4 @@
+--- Orders with customer info ---
+Order 100 by Alice - $ 250
+Order 101 by Bob - $ 125
+Order 102 by Alice - $ 300

--- a/tests/compiler/rust/join.rs.out
+++ b/tests/compiler/rust/join.rs.out
@@ -1,0 +1,38 @@
+#[derive(Clone, Debug)]
+struct Customer {
+    id: i32,
+    name: String,
+}
+
+#[derive(Clone, Debug)]
+struct Order {
+    id: i32,
+    customerId: i32,
+    total: i32,
+}
+
+#[derive(Clone, Debug)]
+struct PairInfo {
+    orderId: i32,
+    customerName: String,
+    total: i32,
+}
+
+fn main() {
+    let mut customers = vec![Customer { id: 1, name: "Alice".to_string() }, Customer { id: 2, name: "Bob".to_string() }, Customer { id: 3, name: "Charlie".to_string() }];
+    let mut orders = vec![Order { id: 100, customerId: 1, total: 250 }, Order { id: 101, customerId: 2, total: 125 }, Order { id: 102, customerId: 1, total: 300 }, Order { id: 103, customerId: 4, total: 80 }];
+    let mut result = {
+    let mut _res = Vec::new();
+    for o in orders.clone() {
+        for c in customers.clone() {
+            if !(o.customerId == c.id) { continue; }
+            _res.push(PairInfo { orderId: o.id, customerName: c.name, total: o.total });
+        }
+    }
+    _res
+};
+    println!("{}", "--- Orders with customer info ---");
+    for entry in result {
+        println!("{} {} {} {} {} {}", "Order", entry.orderId, "by", entry.customerName, "- $", entry.total);
+    }
+}


### PR DESCRIPTION
## Summary
- add `rust/join` program to fast Rust compiler tests to exercise join implementation
- ensure join feature is covered without requiring the slow build tag

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68552f40ac78832090375d55e4654790