### PR TITLE
Add optional helpers to Racket compiler

### DIFF
--- a/compile/rkt/README.md
+++ b/compile/rkt/README.md
@@ -175,11 +175,13 @@ Binary operators now include `union`, `union_all`, `except` and `intersect` for
 basic list set operations.
 `match` expressions compile directly to Racket's `match` form for simple pattern
 matching.
+Dataset helpers `_fetch`, `_load` and `_save` handle basic JSON data.
 
 Unsupported features currently include:
 
 * Generative `generate` blocks and model definitions
-* Dataset helpers like `fetch`, `load`, `save` and SQL-style query expressions
+* SQL-style dataset queries (`from`, `join`, etc.)
+* Error handling with `try`/`catch`
 * Agents, streams and intents
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Concurrency primitives such as `spawn` and channels

--- a/compile/rkt/compiler.go
+++ b/compile/rkt/compiler.go
@@ -10,12 +10,68 @@ import (
 	"mochi/types"
 )
 
+const datasetHelpers = `(define (_fetch url opts)
+  (define opts (or opts (hash)))
+  (define method (hash-ref opts 'method "GET"))
+  (define args (list "curl" "-s" "-X" method))
+  (when (hash-has-key? opts 'headers)
+    (for ([k (hash-keys (hash-ref opts 'headers))])
+      (set! args (append args (list "-H" (format "~a: ~a" k (hash-ref (hash-ref opts 'headers) k)))))))
+  (when (hash-has-key? opts 'query)
+    (define q (hash-ref opts 'query))
+    (define qs (string-join (for/list ([k (hash-keys q)]) (format "~a=~a" k (hash-ref q k))) "&"))
+    (set! url (string-append url (if (regexp-match? #px"\?" url) "&" "?") qs)))
+  (when (hash-has-key? opts 'body)
+    (set! args (append args (list "-d" (jsexpr->string (hash-ref opts 'body))))) )
+  (when (hash-has-key? opts 'timeout)
+    (set! args (append args (list "--max-time" (format "~a" (hash-ref opts 'timeout))))) )
+  (set! args (append args (list url)))
+  (define p (open-input-pipe (string-join args " ")))
+  (define txt (port->string p))
+  (close-input-port p)
+  (string->jsexpr txt))
+
+(define (_load path opts)
+  (define opts (or opts (hash)))
+  (define fmt (hash-ref opts 'format "json"))
+  (define text (if path (call-with-input-file path port->string) (port->string (current-input-port))))
+  (cond [(string=? fmt "jsonl") (for/list ([l (in-lines (open-input-string text))] #:unless (string-blank? l)) (string->jsexpr l))]
+        [(string=? fmt "json") (let ([d (string->jsexpr text)]) (if (list? d) d (list d)))]
+        [else '()]))
+
+(define (_save rows path opts)
+  (define opts (or opts (hash)))
+  (define fmt (hash-ref opts 'format "json"))
+  (define out (if path (open-output-file path #:exists 'replace) (current-output-port)))
+  (cond [(string=? fmt "jsonl") (for ([r rows]) (fprintf out "~a\n" (jsexpr->string r)))]
+        [(string=? fmt "json") (fprintf out "~a" (jsexpr->string rows))])
+  (when path (close-output-port out)))`
+
+const setOpsHelpers = `(define (union-all a b) (append (list->list a) (list->list b)))
+(define (union a b)
+  (let loop ([res (list->list a)] [xs (list->list b)])
+    (if (null? xs) res
+        (let ([x (car xs)])
+          (if (member x res)
+              (loop res (cdr xs))
+              (loop (append res (list x)) (cdr xs)))))) )
+(define (except a b)
+  (for/list ([x (list->list a)] #:unless (member x (list->list b))) x))
+(define (intersect a b)
+  (for/fold ([res '()]) ([x (list->list a)])
+    (if (and (member x (list->list b)) (not (member x res)))
+        (append res (list x))
+        res)))`
+
 // Compiler translates Mochi AST into Racket source code.
 type Compiler struct {
-	buf    bytes.Buffer
-	indent int
-	env    *types.Env
-	loops  []loopCtx
+	buf          bytes.Buffer
+	indent       int
+	env          *types.Env
+	loops        []loopCtx
+	needsDataset bool
+	needsSetOps  bool
+	needsMatch   bool
 }
 
 type loopCtx struct {
@@ -72,7 +128,7 @@ func New(env *types.Env) *Compiler {
 
 func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.writeln("#lang racket")
-	c.writeln("(require racket/list racket/match)")
+	c.writeln(";require-placeholder")
 	c.writeln("")
 	// helpers for indexing and slicing
 	c.writeln("(define (idx x i)")
@@ -88,22 +144,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.writeln("  (let ([n (count x)])")
 	c.writeln("    (if (= n 0) 0")
 	c.writeln("        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))")
-	c.writeln("(define (union-all a b) (append (list->list a) (list->list b)))")
-	c.writeln("(define (union a b)")
-	c.writeln("  (let loop ([res (list->list a)] [xs (list->list b)])")
-	c.writeln("    (if (null? xs) res")
-	c.writeln("        (let ([x (car xs)])")
-	c.writeln("          (if (member x res)")
-	c.writeln("              (loop res (cdr xs))")
-	c.writeln("              (loop (append res (list x)) (cdr xs))))))")
-	c.writeln("(define (except a b)")
-	c.writeln("  (for/list ([x (list->list a)] #:unless (member x (list->list b))) x))")
-	c.writeln("(define (intersect a b)")
-	c.writeln("  (for/fold ([res '()]) ([x (list->list a)])")
-	c.writeln("    (if (and (member x (list->list b)) (not (member x res)))")
-	c.writeln("        (append res (list x))")
-	c.writeln("        res)))")
 	c.writeln("")
+	c.writeln(";dataset-placeholder")
+	c.writeln(";setops-placeholder")
 	// function declarations first
 	for _, s := range prog.Statements {
 		if s.Fun != nil {
@@ -121,7 +164,26 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 			}
 		}
 	}
-	return c.buf.Bytes(), nil
+	code := c.buf.Bytes()
+	header := "(require racket/list)"
+	if c.needsMatch {
+		header += " racket/match"
+	}
+	if c.needsDataset {
+		header += " racket/string json"
+	}
+	code = bytes.Replace(code, []byte(";require-placeholder"), []byte(header), 1)
+	if c.needsDataset {
+		code = bytes.Replace(code, []byte(";dataset-placeholder\n"), []byte(datasetHelpers), 1)
+	} else {
+		code = bytes.Replace(code, []byte(";dataset-placeholder\n"), nil, 1)
+	}
+	if c.needsSetOps {
+		code = bytes.Replace(code, []byte(";setops-placeholder\n"), []byte(setOpsHelpers), 1)
+	} else {
+		code = bytes.Replace(code, []byte(";setops-placeholder\n"), nil, 1)
+	}
+	return code, nil
 }
 
 func (c *Compiler) compileFun(fn *parser.FunStmt) error {
@@ -526,12 +588,16 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 			case "in":
 				expr = fmt.Sprintf("(hash-has-key? %s %s)", r, l)
 			case "union":
+				c.needsSetOps = true
 				expr = fmt.Sprintf("(union %s %s)", l, r)
 			case "union_all":
+				c.needsSetOps = true
 				expr = fmt.Sprintf("(union-all %s %s)", l, r)
 			case "except":
+				c.needsSetOps = true
 				expr = fmt.Sprintf("(except %s %s)", l, r)
 			case "intersect":
+				c.needsSetOps = true
 				expr = fmt.Sprintf("(intersect %s %s)", l, r)
 			default:
 				return "", fmt.Errorf("unsupported op %s", op)
@@ -647,6 +713,12 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		return c.compileCallExpr(p.Call)
 	case p.Match != nil:
 		return c.compileMatchExpr(p.Match)
+	case p.Fetch != nil:
+		return c.compileFetchExpr(p.Fetch)
+	case p.Load != nil:
+		return c.compileLoadExpr(p.Load)
+	case p.Save != nil:
+		return c.compileSaveExpr(p.Save)
 	case p.Selector != nil:
 		return sanitizeName(p.Selector.Root), nil
 	case p.Group != nil:
@@ -713,6 +785,7 @@ func (c *Compiler) compileLiteral(l *parser.Literal) (string, error) {
 }
 
 func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) (string, error) {
+	c.needsMatch = true
 	target, err := c.compileExpr(m.Target)
 	if err != nil {
 		return "", err
@@ -739,4 +812,59 @@ func (c *Compiler) compileMatchPattern(pat *parser.Expr) (string, error) {
 		return "_", nil
 	}
 	return c.compileExpr(pat)
+}
+
+func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
+	c.needsDataset = true
+	url, err := c.compileExpr(f.URL)
+	if err != nil {
+		return "", err
+	}
+	opts := "#f"
+	if f.With != nil {
+		o, err := c.compileExpr(f.With)
+		if err != nil {
+			return "", err
+		}
+		opts = o
+	}
+	return fmt.Sprintf("(_fetch %s %s)", url, opts), nil
+}
+
+func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {
+	c.needsDataset = true
+	path := "#f"
+	if l.Path != nil {
+		path = strconv.Quote(*l.Path)
+	}
+	opts := "#f"
+	if l.With != nil {
+		o, err := c.compileExpr(l.With)
+		if err != nil {
+			return "", err
+		}
+		opts = o
+	}
+	return fmt.Sprintf("(_load %s %s)", path, opts), nil
+}
+
+func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
+	c.needsDataset = true
+	src, err := c.compileExpr(s.Src)
+	if err != nil {
+		return "", err
+	}
+	path := "#f"
+	if s.Path != nil {
+		path = strconv.Quote(*s.Path)
+	}
+	opts := "#f"
+	if s.With != nil {
+		o, err := c.compileExpr(s.With)
+		if err != nil {
+			return "", err
+		}
+		opts = o
+	}
+	return fmt.Sprintf("(_save %s %s %s)", src, path, opts), nil
 }


### PR DESCRIPTION
## Summary
- emit dataset and set operations helpers only when used
- include `racket/match` and dataset modules conditionally
- record feature usage during compilation

## Testing
- `go test ./compile/rkt -tags slow -run TestRacketCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68552f3ee618832097e9508e2d331e73