### PR TITLE
Add simple where clause support for C++ backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Edit one or start fresh. It’s all yours.
 Some language constructs are still experimental or missing in the current implementation:
 
 - Advanced dataset query options like `group`, `sort`, `skip` and `take`.
+- Union type declarations are not yet compiled by the C++ backend.
 - Streams and agents are not yet compiled by the Rust backend.
 - Logic programming keywords (`fact`, `rule`, `query`).
 - File and network helpers (`fetch`, `load`, `save`, `generate`).

--- a/compile/cpp/README.md
+++ b/compile/cpp/README.md
@@ -189,11 +189,13 @@ from `compiler_test.go`.
 
 This backend covers only a subset of Mochi's features but is useful as an example for implementing other targets.
 
+Simple `where` filters in dataset queries are supported, but other clauses remain unimplemented.
+
 ### Unsupported features
 
 Some LeetCode solutions use language constructs that the C++ backend can't yet translate. Unsupported features include:
 
-* Dataset queries with clauses like `where`, `group by`, `join`, `skip`, `take`, or `sort by`
+* Dataset queries with clauses like `group by`, `join`, `skip`, `take`, or `sort by`
 * Union type declarations
 * Agents, streams and intents
 * `generate` blocks and model definitions

--- a/compile/cpp/compiler.go
+++ b/compile/cpp/compiler.go
@@ -727,7 +727,7 @@ func (c *Compiler) writeHelpers() {
 }
 
 func (c *Compiler) compileQuery(q *parser.QueryExpr) (string, error) {
-	if q.Where != nil || q.Group != nil || q.Sort != nil || q.Skip != nil || q.Take != nil || len(q.Joins) != 0 {
+	if q.Group != nil || q.Sort != nil || q.Skip != nil || q.Take != nil || len(q.Joins) != 0 {
 		return "", fmt.Errorf("query not supported")
 	}
 	src := c.compileExpr(q.Source)
@@ -750,7 +750,16 @@ func (c *Compiler) compileQuery(q *parser.QueryExpr) (string, error) {
 		buf.WriteString(indent + "for (auto& " + v + " : " + srcs[i] + ") {\n")
 		indent += "\t"
 	}
+	if q.Where != nil {
+		cond := c.compileExpr(q.Where)
+		buf.WriteString(indent + "if (" + cond + ") {\n")
+		indent += "\t"
+	}
 	buf.WriteString(indent + "_res.push_back(" + sel + ");\n")
+	if q.Where != nil {
+		indent = indent[:len(indent)-1]
+		buf.WriteString(indent + "}\n")
+	}
 	for range vars {
 		indent = indent[:len(indent)-1]
 		buf.WriteString(indent + "}\n")


### PR DESCRIPTION
## Summary
- support `where` filtering in the C++ backend query compiler
- document the new capability and remaining limitations in `compile/cpp/README.md`
- note union type limitations in the main README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685537f6101883209a65c83cae62282d