### PR TITLE
Extend C# backend helpers and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,11 +598,13 @@ Edit one or start fresh. It’s all yours.
 Some language constructs are still experimental or missing in the current implementation:
 
 - Advanced dataset query options like `group`, `sort`, `skip` and `take`.
-- Streams and agents are not yet compiled by the Rust backend.
+- Streams and agents are not yet compiled by the Rust or C# backends.
 - Logic programming keywords (`fact`, `rule`, `query`).
 - File and network helpers (`fetch`, `load`, `save`, `generate`).
 - Importing external packages with `import` and calling `extern` functions.
 - `test` and `expect` blocks are ignored when compiling to Rust.
+- Left, right and outer joins in dataset queries.
+- Model declarations and generic dictionary casts for complex map types are unsupported in the C# backend.
 
 ## Benchmarks
 


### PR DESCRIPTION
## Summary
- implement `_fetch`, `_load` and `_save` helpers for the C# backend
- support `sort`, `skip` and `take` in simple query loops
- add required `using` statements when these helpers are used
- list additional unsupported features in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685537f7e32083208954ac348246d972