### PR TITLE
Add fetch support for F# backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,8 @@ Some language constructs are still experimental or missing in the current implem
 - File and network helpers (`fetch`, `load`, `save`, `generate`).
 - Importing external packages with `import` and calling `extern` functions.
 - `test` and `expect` blocks are ignored when compiling to Rust.
+- Concurrency primitives like `spawn` and channels.
+- Generic types, reflection and macro facilities.
 
 ## Benchmarks
 

--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -118,7 +118,7 @@ Mochi features are not yet available.
 The F# generator currently lacks support for several language constructs:
 
 * Package `import` declarations and `extern` functions
-* HTTP helpers like `fetch`
+* HTTP helpers beyond the basic `fetch` helper
 * Built-in `test` blocks (basic `expect` statements are supported)
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Advanced dataset queries such as joins and grouping

--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -937,6 +937,8 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		return c.compileLoadExpr(p.Load)
 	case p.Save != nil:
 		return c.compileSaveExpr(p.Save)
+	case p.Fetch != nil:
+		return c.compileFetchExpr(p.Fetch)
 	case p.FunExpr != nil:
 		return c.compileFunExpr(p.FunExpr)
 	case p.Query != nil:
@@ -1067,6 +1069,23 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
 	}
 	c.use("_save")
 	return fmt.Sprintf("_save %s %s %s", src, path, opts), nil
+}
+
+func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
+	url, err := c.compileExpr(f.URL)
+	if err != nil {
+		return "", err
+	}
+	opts := "None"
+	if f.With != nil {
+		v, err := c.compileExpr(f.With)
+		if err != nil {
+			return "", err
+		}
+		opts = fmt.Sprintf("Some (%s)", v)
+	}
+	c.use("_fetch")
+	return fmt.Sprintf("_fetch %s %s", url, opts), nil
 }
 
 func (c *Compiler) compileExpect(e *parser.ExpectStmt) error {

--- a/compile/fs/runtime.go
+++ b/compile/fs/runtime.go
@@ -39,9 +39,15 @@ const (
     match path with
     | None | Some "" | Some "-" -> System.Console.Out.Write(out)
     | Some p -> System.IO.File.WriteAllText(p, out)`
+
+	helperFetch = `let _fetch (url: string) (opts: Map<string,obj> option) : Map<string,obj> =
+  use client = new System.Net.Http.HttpClient()
+  let text = client.GetStringAsync(url).Result
+  System.Text.Json.JsonSerializer.Deserialize<Map<string,obj>>(text)`
 )
 
 var helperMap = map[string]string{
-	"_load": helperLoad,
-	"_save": helperSave,
+	"_load":  helperLoad,
+	"_save":  helperSave,
+	"_fetch": helperFetch,
 }


### PR DESCRIPTION
## Summary
- implement `_fetch` helper and use it in the F# compiler
- document new limitations in the F# backend README
- mention concurrency, generics and macros as unsupported in the main README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685537fccbb883209648b37686150ff2