### PR TITLE
Support while loops in Haskell backend

### DIFF
--- a/compile/hs/README.md
+++ b/compile/hs/README.md
@@ -83,6 +83,8 @@ full Mochi language. Unsupported features include:
 * `match` expressions and union types
 * Dataset query syntax like `from ... sort by ...`
 * Set literals and related operations
-* `while` loops
 * Generative AI, HTTP fetch and FFI bindings
 * Streams and long-lived agents
+* `break` and `continue` statements
+* Struct and object types
+* Package imports and module system

--- a/compile/hs/runtime.go
+++ b/compile/hs/runtime.go
@@ -10,6 +10,15 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)


### PR DESCRIPTION
## Summary
- add `whileLoop` helper
- compile `while` statements in the Haskell backend
- document additional unsupported features in `compile/hs/README.md`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855380570a08320b8de96a62fc63be7