### PR TITLE
Add Java struct generation and basic fetch support

### DIFF
--- a/compile/java/README.md
+++ b/compile/java/README.md
@@ -256,5 +256,8 @@ The Java backend currently lacks several Mochi features supported by other compi
 - Import statements
 - LLM helpers (`generate` expressions)
 - HTTP fetch (`fetch`)
+- Anonymous function expressions (`fun` values)
+- Methods declared inside `type` blocks
+- Agent initialization with field values
 
 Simple `from` queries used by the LeetCode examples are now supported.


### PR DESCRIPTION
## Summary
- implement generate struct handling in Java compiler
- add runtime helpers for `_genStruct` and a real `_fetch`
- document additional unsupported Java features

## Testing
- `make fmt`
- `make lint` *(fails: errcheck, unused, etc.)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855380707c88320bf0311795748c24d