### PR TITLE
Add Scala test block support

### DIFF
--- a/compile/scala/README.md
+++ b/compile/scala/README.md
@@ -278,6 +278,6 @@ The following pieces of Mochi are not yet handled by the Scala backend:
 - streams and agents
 - foreign function interface (`extern` imports)
 - error handling with `try`/`catch`
-- built-in `test` blocks and `expect` statements
 - LLM helpers such as `_genText`, `_genEmbed` and `_genStruct`
+- methods defined inside `type` blocks
 

--- a/tests/compiler/valid_scala/test_block.scala.out
+++ b/tests/compiler/valid_scala/test_block.scala.out
@@ -1,5 +1,11 @@
 object Main {
+	def test_addition_works(): Unit = {
+		val x = (1 + 2)
+		assert((x == 3))
+	}
+	
 	def main(args: Array[String]): Unit = {
 		println("ok")
+		test_addition_works()
 	}
 }


### PR DESCRIPTION
## Summary
- implement `test` blocks and `expect` in the Scala backend
- document unsupported type methods in Scala README
- update Scala golden file for `test_block`

## Testing
- `go test ./compile/scala -tags slow -run TestScalaCompiler_GoldenOutput`

------
https://chatgpt.com/codex/tasks/task_e_6855381afcdc83209eba278330da8c7a