### PR TITLE
Add Dart group-by support and update docs

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -247,5 +247,5 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 - Logic programming constructs (`fact`, `rule`, `query`)
 - Package declarations and module imports
 - Methods defined inside `type` declarations
-- Dataset grouping and outer join clauses in queries
+- Left/right/outer join clauses in dataset queries
 - Model declarations

--- a/compile/dart/helpers.go
+++ b/compile/dart/helpers.go
@@ -147,6 +147,8 @@ func dartType(t types.Type) string {
 			val = "dynamic"
 		}
 		return "Map<" + key + ", " + val + ">"
+	case types.GroupType:
+		return "_Group"
 	case types.StructType:
 		return sanitizeName(tt.Name)
 	case types.UnionType:
@@ -273,7 +275,7 @@ func isMap(t types.Type) bool {
 
 func isStruct(t types.Type) bool {
 	switch t.(type) {
-	case types.StructType, types.UnionType:
+	case types.StructType, types.UnionType, types.GroupType:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- implement basic `group by` in the Dart backend
- generate `_Group` class and `_group_by` helper at runtime
- document remaining unsupported Dart features
- list additional unsupported language features in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685537f9862083208004422f160b97ab