### PR TITLE
Add continue support in Prolog compiler

### DIFF
--- a/compile/pl/README.md
+++ b/compile/pl/README.md
@@ -282,5 +282,4 @@ Mochi language features are not yet implemented:
 - Dataset queries (`from`/`select`, joins and grouping)
 - Structured types such as `struct` and enums
 - Concurrency primitives and external helpers like `_fetch` or `_genText`
-- Continue statements
 - Import declarations


### PR DESCRIPTION
## Summary
- handle `continue` statements in Prolog compiler and loops
- document missing language features in Prolog README
- revert README changes to avoid editing main README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855381182dc832086df6b7a86427f87