### PR TITLE
Add Erlang test support

### DIFF
--- a/compile/erlang/README.md
+++ b/compile/erlang/README.md
@@ -88,7 +88,9 @@ features are not yet handled:
 - Agents and event streams
 - Foreign function imports via `extern`
 - Import statements
-- Test blocks and `expect` statements
+- Anonymous function expressions using `fun`
+- Model declarations and dataset helpers
+- Sorting or pagination on queries with multiple sources
 
 Generated Erlang favors clarity over speed, mirroring Mochi constructs
 directly.

--- a/compile/erlang/helpers.go
+++ b/compile/erlang/helpers.go
@@ -3,6 +3,7 @@ package erlcode
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"mochi/parser"
 	"mochi/types"
@@ -184,6 +185,29 @@ func atomName(name string) string {
 		}
 	}
 	return name
+}
+
+// sanitizeName converts name to a valid Erlang atom identifier.
+func sanitizeName(name string) string {
+	if name == "" {
+		return "_"
+	}
+	b := strings.Builder{}
+	for i, r := range name {
+		if r >= 'A' && r <= 'Z' {
+			r = r - 'A' + 'a'
+		}
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9' && i > 0) || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	res := b.String()
+	if res == "" || !((res[0] >= 'a' && res[0] <= 'z') || res[0] == '_') {
+		res = "_" + res
+	}
+	return res
 }
 
 func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {


### PR DESCRIPTION
## Summary
- support `test` blocks and `expect` statements for the Erlang backend
- add runtime helpers for running tests
- note additional unsupported features in Erlang compiler docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855411c679883208245f3f650ef74cc