### PR TITLE
Add break/continue & block lambdas to OCaml backend

### DIFF
--- a/compile/ocaml/README.md
+++ b/compile/ocaml/README.md
@@ -127,8 +127,9 @@ The OCaml backend covers only a small slice of Mochi. Missing pieces include:
 
 - Query expressions such as `from` / `sort by` / `select`
 - Pattern matching and union types
-- Anonymous functions with block bodies
-- Break and continue statements
 - Modules and `import` declarations
+- Struct and enum type declarations
+- `fetch`, `load` and `generate` expressions
+- Agent and model blocks
 - Concurrency primitives like `spawn` and channels
 - Streams, LLM helpers and the foreign function interface

--- a/tests/compiler/ocaml/break_continue.ml.out
+++ b/tests/compiler/ocaml/break_continue.ml.out
@@ -1,0 +1,17 @@
+exception BreakException of int
+exception ContinueException of int
+
+let numbers = [1; 2; 3; 4; 5; 6; 7; 8; 9];;
+try
+  List.iter (fun n ->
+    try
+      if n mod 2 = 0 then begin
+        raise (ContinueException 0)
+      end;
+      if n > 7 then begin
+        raise (BreakException 0)
+      end;
+      print_endline (String.concat " " ["odd number:"; string_of_int (n)]);
+    with ContinueException n when n = 0 -> ()
+  ) numbers;
+with BreakException n when n = 0 -> ();;

--- a/tests/compiler/ocaml/break_continue.mochi
+++ b/tests/compiler/ocaml/break_continue.mochi
@@ -1,0 +1,11 @@
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+for n in numbers {
+  if n % 2 == 0 {
+    continue
+  }
+  if n > 7 {
+    break
+  }
+  print("odd number:", n)
+}

--- a/tests/compiler/ocaml/break_continue.out
+++ b/tests/compiler/ocaml/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7


### PR DESCRIPTION
## Summary
- extend OCaml compiler with loop control support
- allow anonymous functions with block bodies
- update OCaml backend README with remaining unsupported features
- add golden test for break and continue

## Testing
- `go test ./compile/ocaml -run TestOCamlCompiler_GoldenOutput -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6855426638288320b4e4a0b24e97e3f3