### PR TITLE
Add test block support to C backend

### DIFF
--- a/compile/c/README.md
+++ b/compile/c/README.md
@@ -75,10 +75,15 @@ features include:
 - union type declarations and generics
 - logic programming constructs (`fact`, `rule`, `query`)
 - reflection or macro facilities
+- extern object declarations and package exports
+- set literals and set operations
 
 The backend now supports membership checks and `union`/`union all` operations
 for integer and string lists, but map membership and other advanced features
 remain unimplemented.
+
+Test blocks and `expect` statements are now compiled to C functions and
+executed from `main`.
 
 Additional language features like `try`/`catch` error handling and the planned
 `async` keyword are also unimplemented. Problems relying on these features

--- a/tests/compiler/valid/test_block.c.out
+++ b/tests/compiler/valid/test_block.c.out
@@ -4,14 +4,19 @@
 typedef struct { int len; int *data; } list_int;
 
 static list_int list_int_create(int len) {
-	list_int l;
-	l.len = len;
-	l.data = (int*)malloc(sizeof(int)*len);
-	return l;
+        list_int l;
+        l.len = len;
+        l.data = (int*)malloc(sizeof(int)*len);
+        return l;
 }
 
+static void test_addition_works() {
+        int x = (1 + 2);
+        if (!((x == 3))) { fprintf(stderr, "expect failed\n"); exit(1); }
+}
 
 int main() {
-	printf("%s\n", "ok");
-	return 0;
+        printf("%s\n", "ok");
+        test_addition_works();
+        return 0;
 }


### PR DESCRIPTION
## Summary
- implement `expect` statements and `test` blocks in the C compiler
- run test blocks from `main`
- document new unsupported features and note new test support in `compile/c/README.md`
- update C golden file for `test_block` example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685542e0431c83209987aed069916842