### PR TITLE
Add dataset load/save to Clojure backend

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -120,7 +120,7 @@ execute correctly using the Clojure backend.
 
 ## Status
 
-The backend only implements a small subset of Mochi and is mainly a proof of concept. It now supports map literals, basic `group by` queries and built-in helpers like `count`, `avg` and `input`. Query expressions handle filtering, cross joins and pagination via `skip`/`take`. More advanced features such as streaming data sets, agents or LLM helpers are not currently supported.
+The backend only implements a small subset of Mochi and is mainly a proof of concept. It now supports map literals, dataset `load` and `save` helpers for CSV files, basic `group by` queries and built-in helpers like `count`, `avg` and `input`. Query expressions handle filtering, cross joins and pagination via `skip`/`take`. More advanced features such as streaming data sets, agents or LLM helpers are not currently supported.
 
 ### Unsupported Features
 
@@ -128,13 +128,14 @@ The current compiler lacks support for several language constructs commonly used
 in the example programs. In particular:
  - Union types and pattern matching on variants
 - Data set operations beyond simple queries and streaming APIs
-- Dataset `load`/`save` helpers
 - Advanced `group by` or join queries with aggregation
 - Agent helpers and LLM integration
 - Package imports and module system
 - Logic programming facts and rules
 - External declarations and other FFI helpers
 - HTTP fetch and generative AI utilities
+- Anonymous function expressions (`fun` values)
+- Set collections and related operations
 - Streams and event-driven agents
 - Concurrency primitives such as `spawn` and channels
 


### PR DESCRIPTION
## Summary
- implement `_load` and `_save` helpers for the Clojure compiler
- generate helper functions when needed
- support `load` and `save` expressions in the compiler
- document new capability and other unsupported features

## Testing
- `go test ./compile/clj -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685542fe2950832097547eae85055a49