### PR TITLE
Add Dart test block support

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -249,3 +249,5 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 - Methods defined inside `type` declarations
 - Left/right/outer join clauses in dataset queries
 - Model declarations
+- Agent declarations with `intent` blocks
+- Event handling with `on`/`emit`


### PR DESCRIPTION
## Summary
- implement `compileTestBlock` and `compileExpect` for the Dart backend
- emit Dart test functions and invoke them in `main`
- document additional unsupported features

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6855433e88cc83208e56277c16246de7