### PR TITLE
Add Scala backend method & selector support

### DIFF
--- a/compile/scala/README.md
+++ b/compile/scala/README.md
@@ -279,5 +279,5 @@ The following pieces of Mochi are not yet handled by the Scala backend:
 - foreign function interface (`extern` imports)
 - error handling with `try`/`catch`
 - LLM helpers such as `_genText`, `_genEmbed` and `_genStruct`
-- methods defined inside `type` blocks
+- logic programming constructs (`fact`, `rule`)
 


### PR DESCRIPTION
## Summary
- support defining methods in `type` blocks for Scala target
- implement dot selector expressions
- document new unsupported features and remove outdated note

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855436665ec83208d56cfbb278add14