### PR TITLE
Add fetch and input helpers for F#

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -118,11 +118,11 @@ Mochi features are not yet available.
 The F# generator currently lacks support for several language constructs:
 
 * Package `import` declarations and `extern` functions
-* HTTP helpers like `fetch`
 * Foreign function interface (FFI) declarations
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Advanced dataset queries such as joins and grouping
 * Streams, agents and LLM `generate` blocks
 * Concurrency primitives like `spawn` and channels
 * Generic types, reflection and macro facilities
+* JSON helpers like `json` and `to_json`
 

--- a/compile/fs/runtime.go
+++ b/compile/fs/runtime.go
@@ -48,10 +48,24 @@ const (
   with e ->
     printfn "FAIL (%s)" e.Message
     false`
+
+	helperInput = `let _input () : string =
+  match System.Console.ReadLine() with
+  | null -> ""
+  | s -> s.Trim()`
+
+	helperFetch = `let _fetch (url: string) (opts: Map<string,obj> option) : Map<string,obj> =
+  use client = new System.Net.Http.HttpClient()
+  let resp = client.GetAsync(url).Result
+  let status = resp.StatusCode |> int |> box
+  let body = resp.Content.ReadAsStringAsync().Result |> box
+  Map.ofList [("status", status); ("body", body)]`
 )
 
 var helperMap = map[string]string{
 	"_load":     helperLoad,
 	"_save":     helperSave,
 	"_run_test": helperRunTest,
+	"_input":    helperInput,
+	"_fetch":    helperFetch,
 }

--- a/tests/compiler/valid/test_block.fs.out
+++ b/tests/compiler/valid/test_block.fs.out
@@ -1,3 +1,22 @@
 open System
 
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let test_addition_works() =
+    let x = (1 + 2)
+    if not ((x = 3)) then failwith "expect failed"
+
 ignore (printfn "%A" ("ok"))
+let mutable failures = 0
+if not (_run_test "addition works" test_addition_works) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures
+


### PR DESCRIPTION
## Summary
- implement `fetch` expression for F# backend
- add `input()` builtin support
- provide runtime helpers for `_fetch` and `_input`
- document remaining unsupported features
- emit runtime helpers before compiled program and update F# golden tests

## Testing
- `go test ./...`
- `go test ./compile/fs -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68554321478c8320878551173626c1c3