### PR TITLE
Extend Racket backend

### DIFF
--- a/compile/rkt/README.md
+++ b/compile/rkt/README.md
@@ -176,15 +176,25 @@ basic list set operations.
 `match` expressions compile directly to Racket's `match` form for simple pattern
 matching.
 Dataset helpers `_fetch`, `_load` and `_save` handle basic JSON data.
+The `in` operator now works with lists and strings, not just maps, and slice
+assignments like `xs[1:3] = sub` are supported.
+Basic dataset queries support `sort`, `skip` and `take` clauses, and simple
+`struct` type declarations emit Racket structs.
 
 Unsupported features currently include:
 
 * Generative `generate` blocks and model definitions
-* SQL-style dataset queries (`from`, `join`, etc.)
+* Dataset query `group` clauses and join side options
 * Error handling with `try`/`catch`
 * Agents, streams and intents
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Concurrency primitives such as `spawn` and channels
 * Foreign function interface via `import`
 * Package management and `package` declarations
-* User-defined type declarations (`struct` and `union`)
+* Union type declarations
+* LLM helpers like `_genText`, `_genEmbed` and `_genStruct`
+* Multi-dimensional slice assignment or indexing beyond two levels
+* Field selectors like `obj.field`
+* Methods defined inside `type` blocks
+* Export statements via `export`
+* Test blocks and expectations (`test` and `expect`)

--- a/tests/compiler/rkt/break_continue.rkt.out
+++ b/tests/compiler/rkt/break_continue.rkt.out
@@ -19,20 +19,21 @@
 (let/ec brk0
 	(let loop0 ([it numbers])
 		(when (pair? it)
-			(define n (car it))
-			(if (= (modulo n 2) 0)
-				(begin
-					(loop0 (cdr it))
+			(let ([n (car it)])
+				(if (= (modulo n 2) 0)
+					(begin
+						(loop0 (cdr it))
+					)
+					(void)
 				)
-				(void)
-			)
-			(if (> n 7)
-				(begin
-					(brk0 (void))
+				(if (> n 7)
+					(begin
+						(brk0 (void))
+					)
+					(void)
 				)
-				(void)
+				(displayln (format "~a ~a" "odd number:" n))
 			)
-			(displayln (format "~a ~a" "odd number:" n))
 			(loop0 (cdr it)))
 		)
 	)

--- a/tests/compiler/rkt/input_builtin.rkt.out
+++ b/tests/compiler/rkt/input_builtin.rkt.out
@@ -20,4 +20,3 @@
 (displayln "Enter second input:")
 (define input2 (read-line ))
 (displayln (format "~a ~a ~a ~a" "You entered:" input1 "," input2))
-

--- a/tests/compiler/rkt/str_builtin.rkt.out
+++ b/tests/compiler/rkt/str_builtin.rkt.out
@@ -17,4 +17,3 @@
 
 (define x 42)
 (displayln (format "~a" x))
-


### PR DESCRIPTION
## Summary
- compile `if` branches with `begin` unless internal definitions exist
- add detection helpers for internal `define` statements
- document unsupported `export` and testing blocks in README
- update golden test outputs for revised Racket code generation

## Testing
- `go test ./compile/rkt -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68553817aaf08320b1e9097b2808e385