### PR TITLE
Add Dart package import support

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -245,7 +245,7 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 - Foreign function interface bindings
 - Streams and long‑lived agents
 - Logic programming constructs (`fact`, `rule`, `query`)
-- Package declarations and module imports
+- Package declarations (`package` keyword)
 - Methods defined inside `type` declarations
 - Left/right/outer join clauses in dataset queries
 - Model declarations


### PR DESCRIPTION
## Summary
- implement `compilePackageImport` in Dart backend
- call package import handling from `compileStmt`
- track imported packages in compiler state
- document updated unsupported features for Dart

## Testing
- `go test ./compile/dart/...`

------
https://chatgpt.com/codex/tasks/task_e_685556ca2a4883208a0a19d6b5f609cd