### PR TITLE
Add JSON helpers to F# backend

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -117,12 +117,13 @@ Mochi features are not yet available.
 
 The F# generator currently lacks support for several language constructs:
 
-* Package `import` declarations and `extern` functions
+* Package `import` statements, exported functions and any `extern` objects or variables
+* Module exports using `export fun`
 * Foreign function interface (FFI) declarations
+* Extern type declarations
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Advanced dataset queries such as joins and grouping
 * Streams, agents and LLM `generate` blocks
 * Concurrency primitives like `spawn` and channels
 * Generic types, reflection and macro facilities
-* JSON helpers like `json` and `to_json`
 

--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -1025,6 +1025,18 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("avg expects 1 arg")
 		}
 		return fmt.Sprintf("((Array.sum %s) / %s.Length)", args[0], args[0]), nil
+	case "json":
+		if len(args) != 1 {
+			return "", fmt.Errorf("json expects 1 arg")
+		}
+		c.use("_json")
+		return fmt.Sprintf("_json %s", args[0]), nil
+	case "to_json":
+		if len(args) != 1 {
+			return "", fmt.Errorf("to_json expects 1 arg")
+		}
+		c.use("_to_json")
+		return fmt.Sprintf("_to_json %s", args[0]), nil
 	case "input":
 		if len(args) != 0 {
 			return "", fmt.Errorf("input expects no args")

--- a/compile/fs/runtime.go
+++ b/compile/fs/runtime.go
@@ -60,6 +60,32 @@ const (
   let status = resp.StatusCode |> int |> box
   let body = resp.Content.ReadAsStringAsync().Result |> box
   Map.ofList [("status", status); ("body", body)]`
+
+	helperToJson = `let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int
+  | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)`
 )
 
 var helperMap = map[string]string{
@@ -68,4 +94,6 @@ var helperMap = map[string]string{
 	"_run_test": helperRunTest,
 	"_input":    helperInput,
 	"_fetch":    helperFetch,
+	"_to_json":  helperToJson,
+	"_json":     helperToJson,
 }


### PR DESCRIPTION
## Summary
- support `json` and `to_json` builtin functions in the F# compiler
- implement `_to_json`/`_json` runtime helpers
- document currently unsupported features for the F# backend

## Testing
- `go test ./compile/fs -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_685556ea82cc832092f171597f238a74