### PR TITLE
Improve Smalltalk backend

### DIFF
--- a/compile/st/README.md
+++ b/compile/st/README.md
@@ -32,3 +32,6 @@ The following language constructs are not yet handled:
 - Foreign function interface declarations (`extern`)
 - Import and package statements
 - Pattern matching with `match`
+- Union type declarations
+- Set literals and set operations
+- Concurrency primitives like `spawn` and channels


### PR DESCRIPTION
## Summary
- support `avg` and `input` builtins in the Smalltalk backend
- document additional unsupported features in `compile/st/README.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68555770853c8320b4b4e812620fdf80