### PR TITLE
Add basic test block support to Swift backend

### DIFF
--- a/compile/swift/README.md
+++ b/compile/swift/README.md
@@ -236,10 +236,10 @@ The Swift backend still lacks support for a number of language capabilities:
 
 - Advanced dataset queries with grouping, joins, sorting or pagination. Simple
   ``from ... where ... select`` loops (with optional cross joins) are handled.
-- Higher-order functions or function values
 - Type inference for empty collections
 - Streams, agents and intent handlers
 - The ``generate`` and ``fetch`` expressions for LLM and HTTP integration
 - Package declarations and the foreign function interface
 - Set collections and related operations
-- Test blocks using ``test`` and ``expect`` statements
+- Model declarations using ``model`` blocks
+- ``fact`` and ``rule`` statements for logic programming


### PR DESCRIPTION
## Summary
- implement `test` and `expect` handling in the Swift compiler
- generate helper `expect` function only when used
- compile test blocks into Swift functions
- document newly supported/unsupported features in the Swift backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855575c77388320a65c8e4c969d769d