### PR TITLE
Add json support to Haskell backend

### DIFF
--- a/compile/hs/README.md
+++ b/compile/hs/README.md
@@ -71,7 +71,7 @@ go test ./compile/hs -tags slow
 
 The Haskell backend currently supports a limited subset of Mochi: function
 definitions, if/else expressions, basic loops, lists, maps and a few built-in
-functions (`len`, `count`, `avg`, `str`, `print`). Map access relies on
+functions (`len`, `count`, `avg`, `str`, `print`, `now`, `json`). Map access relies on
 `Data.Map` when needed. Variable names are sanitised to avoid conflicts with
 Haskell keywords.
 
@@ -88,6 +88,8 @@ full Mochi language. Unsupported features include:
 * `break` and `continue` statements
 * Struct and object types
 * Package imports and module system
-* Built-in functions `now` and `json`
 * Dataset `load`/`save` operations
 * `test` blocks and expectations
+* Logic programming (`fact`, `rule`, `query`)
+* `try`/`catch` error handling
+* List and string slicing (e.g. `nums[1:3]`)

--- a/compile/hs/compiler.go
+++ b/compile/hs/compiler.go
@@ -17,6 +17,7 @@ type Compiler struct {
 	env      *types.Env
 	usesMap  bool
 	usesTime bool
+	usesJSON bool
 }
 
 func (c *Compiler) hsType(t types.Type) string {
@@ -64,6 +65,7 @@ func New(env *types.Env) *Compiler {
 func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.buf.Reset()
 	c.usesMap = false
+	c.usesJSON = false
 
 	for _, s := range prog.Statements {
 		if s.Fun != nil {
@@ -99,6 +101,10 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	if c.usesMap {
 		header.WriteString("import qualified Data.Map as Map\n")
+	}
+	if c.usesJSON {
+		header.WriteString("import qualified Data.ByteString.Lazy.Char8 as BL\n")
+		header.WriteString("import qualified Data.Aeson as Aeson\n")
 	}
 	header.WriteString("\n")
 	header.WriteString(runtime)
@@ -543,6 +549,10 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		}
 		if p.Call.Func == "str" {
 			return fmt.Sprintf("show %s", strings.Join(args, " ")), nil
+		}
+		if p.Call.Func == "json" {
+			c.usesJSON = true
+			return fmt.Sprintf("_json (%s)", strings.Join(args, " ")), nil
 		}
 		if p.Call.Func == "now" {
 			c.usesTime = true

--- a/compile/hs/runtime.go
+++ b/compile/hs/runtime.go
@@ -35,4 +35,7 @@ _input = getLine
 
 _now :: IO Int
 _now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BL.putStrLn (Aeson.encode v)
 `


### PR DESCRIPTION
## Summary
- add `_json` runtime helper for Haskell backend
- generate imports when JSON helper is used
- support `json()` built-in in Haskell compiler
- document new supported built-ins and more unsupported features

## Testing
- `go test ./... --vet=off -run TestHSCompiler_GoldenSubset -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685557166bd48320b757b8f964582dcd