### PR TITLE
Document unsupported clj features and ignore type/import

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -139,5 +139,8 @@ in the example programs. In particular:
 - Set collections and related operations
 - Streams and event-driven agents
 - Concurrency primitives such as `spawn` and channels
+- Methods declared inside `type` blocks
+- Error handling with `try`/`catch` blocks
+- Reflection or macro facilities
 
 Programs relying on these features fail to compile with the Clojure backend.

--- a/compile/clj/compiler.go
+++ b/compile/clj/compiler.go
@@ -171,6 +171,10 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		return c.compileLet(s.Let)
 	case s.Var != nil:
 		return c.compileVar(s.Var)
+	case s.Import != nil:
+		return nil // imports are ignored by the Clojure backend
+	case s.Type != nil:
+		return c.compileTypeDecl(s.Type)
 	case s.Assign != nil:
 		return c.compileAssign(s.Assign)
 	case s.Return != nil:
@@ -1043,6 +1047,12 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 	buf.Write(sub.buf.Bytes())
 	buf.WriteString(")")
 	return buf.String(), nil
+}
+
+func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
+	// Struct and union declarations are currently ignored but must not
+	// cause a compile error.
+	return nil
 }
 
 func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {


### PR DESCRIPTION
## Summary
- skip import and type statements in the Clojure compiler
- record more unsupported features in the Clojure backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68555c90de148320b192ea846a220498