### PR TITLE
Add Dart method support

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -246,8 +246,8 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 - Streams and long‑lived agents
 - Logic programming constructs (`fact`, `rule`, `query`)
 - Package declarations (`package` keyword)
-- Methods defined inside `type` declarations
 - Left/right/outer join clauses in dataset queries
 - Model declarations
 - Agent declarations with `intent` blocks
 - Event handling with `on`/`emit`
+- `generate` expressions return placeholder values (LLM integration pending)


### PR DESCRIPTION
## Summary
- support methods inside `type` declarations for Dart backend
- document remaining limitations in Dart README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68555ceb0bec83209029fd9e0291a31a