### PR TITLE
Support test blocks in Ruby backend

### DIFF
--- a/compile/rb/README.md
+++ b/compile/rb/README.md
@@ -170,5 +170,5 @@ features include:
   features (`fact`, `rule`, `query`).
 - Packages and foreign function interface declarations (`import`, `extern`).
 - `model` and `stream` declarations are not compiled.
-- Test blocks (`test`, `expect`) are ignored.
+- Concurrency primitives such as `spawn` and channels.
 

--- a/tests/compiler/rb/test_block.mochi
+++ b/tests/compiler/rb/test_block.mochi
@@ -1,0 +1,5 @@
+test "addition works" {
+  let x = 1 + 2
+  expect x == 3
+}
+print("ok")

--- a/tests/compiler/rb/test_block.rb.out
+++ b/tests/compiler/rb/test_block.rb.out
@@ -1,0 +1,7 @@
+def test_addition_works()
+	x = (1 + 2)
+	raise "expect failed" unless (x == 3)
+end
+
+puts(["ok"].join(" "))
+test_addition_works()


### PR DESCRIPTION
## Summary
- add compilation for test blocks and expectations in the Ruby backend
- record the new generated Ruby code for `test_block.mochi`
- note concurrency limitations in Ruby backend docs

## Testing
- `go test ./compile/rb -tags slow -run TestRBCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68555d42b9b48320b5206a5c33d078e7