### PR TITLE
Add selector and test support to Racket backend

### DIFF
--- a/compile/rkt/README.md
+++ b/compile/rkt/README.md
@@ -194,7 +194,6 @@ Unsupported features currently include:
 * Union type declarations
 * LLM helpers like `_genText`, `_genEmbed` and `_genStruct`
 * Multi-dimensional slice assignment or indexing beyond two levels
-* Field selectors like `obj.field`
 * Methods defined inside `type` blocks
 * Export statements via `export`
-* Test blocks and expectations (`test` and `expect`)
+* Extern declarations (`extern var`, `extern fun`, `extern type`, `extern object`)


### PR DESCRIPTION
## Summary
- implement `expect` helper and test block compilation for Racket backend
- support field selectors for map values
- document remaining unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68555d6411908320ab10f31f25be0d83