### PR TITLE
Add generate/fetch support for Erlang backend

### DIFF
--- a/compile/erlang/README.md
+++ b/compile/erlang/README.md
@@ -37,6 +37,8 @@ mochi_count(_) -> erlang:error(badarg).
 Additional helpers implement `mochi_input/0`, `mochi_avg/1`, list iteration
 (`mochi_foreach/2`), optional map/list indexing via `mochi_get/2` and a simple
 `mochi_while/2` loop construct.
+Generative helpers `mochi_gen_text/3`, `mochi_gen_embed/3`, `mochi_gen_struct/4`
+and the HTTP helper `mochi_fetch/2` return stub values for now.
 
 ## Building
 
@@ -83,7 +85,6 @@ union values is supported via `case` expressions. The following language
 features are not yet handled:
 
 - Joins or grouping inside queries
-- Generative AI helpers like `generate` or `fetch`
 - Logic programming constructs and streams
 - Agents and event streams
 - Foreign function imports via `extern`
@@ -92,6 +93,7 @@ features are not yet handled:
 - Sorting or pagination on queries with multiple sources
 - Concurrency primitives like `spawn` and channels
 - Struct and union type declarations
+- Set operations using `union`, `except` or `intersect`
 
 Generated Erlang favors clarity over speed, mirroring Mochi constructs
 directly.

--- a/tests/compiler/erl_simple/generate_echo.erl.out
+++ b/tests/compiler/erl_simple/generate_echo.erl.out
@@ -1,0 +1,80 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1]).
+
+main(_) ->
+	Poem = mochi_gen_text("echo hello", "", undefined),
+	mochi_print([Poem]).
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+mochi_count(X) when is_list(X) -> length(X);
+mochi_count(X) when is_map(X) -> maps:size(X);
+mochi_count(X) when is_binary(X) -> byte_size(X);
+mochi_count(_) -> erlang:error(badarg).
+
+mochi_input() ->
+	case io:get_line("") of
+		eof -> "";
+		Line -> string:trim(Line)
+	end.
+
+mochi_avg([]) -> 0;
+mochi_avg(L) when is_list(L) ->
+	Sum = lists:foldl(fun(X, Acc) ->
+		case X of
+			I when is_integer(I) -> Acc + I;
+			F when is_float(F) -> Acc + F;
+			_ -> erlang:error(badarg) end
+		end, 0, L),
+		Sum / length(L);
+	mochi_avg(_) -> erlang:error(badarg).
+	
+	mochi_foreach(F, L) ->
+		try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+	
+	mochi_foreach_loop(_, []) -> ok;
+	mochi_foreach_loop(F, [H|T]) ->
+		try F(H) catch
+			throw:mochi_continue -> ok;
+			throw:mochi_break -> throw(mochi_break)
+		end,
+		mochi_foreach_loop(F, T).
+	
+	mochi_gen_text(Prompt, _Model, _Params) -> Prompt.
+	
+	mochi_while(Cond, Body) ->
+		case Cond() of
+			true ->
+				try Body() catch
+					throw:mochi_continue -> ok;
+					throw:mochi_break -> ok
+				end,
+				mochi_while(Cond, Body);
+			_ -> ok
+		end.
+	
+	mochi_expect(true) -> ok;
+	mochi_expect(_) -> erlang:error(expect_failed).
+	
+	mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
+	mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
+	mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
+	
+	mochi_run_test(Name, Fun) ->
+		mochi_test_start(Name),
+		Start = erlang:monotonic_time(millisecond),
+		try Fun() of _ ->
+			Duration = erlang:monotonic_time(millisecond) - Start,
+			mochi_test_pass(Duration)
+		catch C:R ->
+			Duration = erlang:monotonic_time(millisecond) - Start,
+			mochi_test_fail({C,R}, Duration)
+		end.

--- a/tests/compiler/erl_simple/generate_echo.mochi
+++ b/tests/compiler/erl_simple/generate_echo.mochi
@@ -1,0 +1,4 @@
+let poem = generate text {
+  prompt: "echo hello"
+}
+print(poem)

--- a/tests/compiler/erl_simple/generate_echo.out
+++ b/tests/compiler/erl_simple/generate_echo.out
@@ -1,0 +1,1 @@
+echo hello


### PR DESCRIPTION
## Summary
- implement `generate` and `fetch` in Erlang compiler
- stub runtime helpers `mochi_fetch`, `mochi_gen_*`
- document helpers in Erlang backend README
- note additional unsupported `union/except/intersect` set ops
- add regression test for `generate` expression

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68555cf4eb908320b26b6a263ac990e1