### PR TITLE
Add v0.8.8 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 # 📦 CHANGELOG.md
+## [0.8.8] – 2025-06-20
+
+### Added
+
+* Dataset `fetch`, `generate`, `load` and `save` across Ruby, Erlang, Elixir,
+  Java and Scheme
+* Method declarations in Ruby and Dart with type methods for Kotlin
+* Test block support for Scala, Java, F#, Zig, Swift and C
+* Negative list indexing in Swift and Scala
+* `sort by` queries in C++ and `where`/`skip`/`take` in F#
+* JSON helpers and a `now` builtin in Haskell, Kotlin, Zig and F#
+* Pagination added to the Rust compiler
+
+### Changed
+
+* F# runtime moved to the preamble
+* Documentation updated for multiple backends
+
+### Fixed
+
+* Minor README corrections and refreshed C++ examples
 ## [0.8.7] – 2025-06-19
 
 ### Added

--- a/releases/v0.8.8.md
+++ b/releases/v0.8.8.md
@@ -1,0 +1,25 @@
+# Jun 2025 (v0.8.8)
+
+Mochi v0.8.8 expands data access operations and test support across the
+experimental compilers. Numerous backends gain new builtins, improved query
+features and additional language constructs.
+
+## Compilers
+
+- Dataset `fetch`, `generate`, `load` and `save` in Ruby, Erlang, Elixir,
+  Java and Scheme
+- Method declarations for Ruby and Dart with type methods in Kotlin
+- Test block support in Scala, Java, F#, Zig, Swift and C
+- Negative list indexing for Swift and Scala
+- `sort by` queries in C++ and `where`/`skip`/`take` in F#
+- JSON helpers and a `now` builtin across Haskell, Kotlin, Zig and F#
+- Pagination added to the Rust backend with string list helpers in C
+- COBOL loops over string variables and typed return values
+- Racket conditional branches and selectors
+- Fortran append builtin and typed list operations
+
+## Tests
+
+- New golden tests for dataset operations, methods and loops across
+  compilers
+- Updated examples for C++, Rust and others


### PR DESCRIPTION
## Summary
- add v0.8.8 release notes
- document new features in CHANGELOG

## Testing
- `go test ./... -run TestVersion -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6855628c89008320a56c34d7a45124e9