### PR TITLE
Enhance Racket backend

### DIFF
--- a/compile/rkt/README.md
+++ b/compile/rkt/README.md
@@ -195,5 +195,5 @@ Unsupported features currently include:
 * LLM helpers like `_genText`, `_genEmbed` and `_genStruct`
 * Multi-dimensional slice assignment or indexing beyond two levels
 * Methods defined inside `type` blocks
-* Export statements via `export`
 * Extern declarations (`extern var`, `extern fun`, `extern type`, `extern object`)
+* Anonymous function expressions with block bodies


### PR DESCRIPTION
## Summary
- allow exported functions and emit `(provide ...)`
- implement anonymous function and if expressions
- document still unsupported features in Racket backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68557e78857883208dc7837d5a84313b