### PR TITLE
Add Smalltalk if expression support

### DIFF
--- a/compile/st/README.md
+++ b/compile/st/README.md
@@ -31,7 +31,9 @@ The following language constructs are not yet handled:
 - Logic programming (`fact`, `rule`, `query`)
 - Foreign function interface declarations (`extern`)
 - Import and package statements
+- Model declarations (`model`) and related LLM helpers
 - Pattern matching with `match`
+- Anonymous function expressions (`fun (...) { ... }` or `fun (...) => expr`)
 - Union type declarations
 - Set literals and set operations
 - Concurrency primitives like `spawn` and channels


### PR DESCRIPTION
## Summary
- support `if` expressions in the Smalltalk compiler
- note additional unsupported constructs in the Smalltalk backend docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68557e813ea883209ab8252b5d9e895b