### PR TITLE
Extend Fortran backend

### DIFF
--- a/compile/fortran/README.md
+++ b/compile/fortran/README.md
@@ -189,6 +189,7 @@ Missing features include:
 
 - Map types and membership tests for maps. The `in` operator only works for
   lists and strings.
+- Map indexing and assignment are not implemented.
 - Query expressions (`from`/`sort by`/`select`).
 - Nested function definitions and struct literals.
 - `union`, `except` and `intersect` only work for `list<int>` and `list<float>` values.
@@ -197,6 +198,7 @@ Missing features include:
 - Agents, streams and logic programming constructs (`fact`, `rule`, `query`).
 - Foreign imports and dataset helpers like `fetch`, `load` and `save`.
 - Anonymous function literals (`fun` expressions) and `if` used as an expression.
+- Only a few built-ins are available (`len`, `append`, `count`, `avg`).
 - Generative `generate` blocks and model declarations.
 
 While limited, this backend demonstrates how Mochi’s AST can be translated into


### PR DESCRIPTION
## Summary
- add `avg` builtin implementation for Fortran compiler
- track when avg helper functions are needed and emit them
- document new unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68557e5f48e083209b173c2b23e7138b