### PR TITLE
Add Zig negative indexing support

### DIFF
--- a/compile/zig/README.md
+++ b/compile/zig/README.md
@@ -263,7 +263,10 @@ LeetCode solutions:
 
 * dataset query expressions (`from ... sort ... select`) used by problems that
   operate over CSV-style input
-* advanced string slicing and indexing
+* advanced string slicing (step values) and indexing on assignment
+* iteration over map key/value pairs
+* functions with multiple return values
+* generic type parameters
 * nested list types beyond one dimension
 * user-defined structs and union types
 * pattern matching with `match` expressions


### PR DESCRIPTION
## Summary
- implement list and string helpers for negative indexing and slicing in Zig backend
- update compilePostfix logic to call these helpers
- document more missing features in Zig README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68558358dbe08320a20a7a4db08e0e91