### PR TITLE
Extend COBOL backend

### DIFF
--- a/compile/cobol/README.md
+++ b/compile/cobol/README.md
@@ -163,6 +163,10 @@ constructs:
 - Function definitions and calls, including nested functions
 - Calls to built-ins `print`, `len`, `add`, `twoSum` and `addTwoNumbers`
 - List concatenation with `+` and indexing (including negative indices)
+- Unary `-` and `!` operators
+- `break` and `continue` within loops
+- `return` statements from functions
+- Generating integer sequences with the `range` helper when bounds are constants
 - Simple `match` expressions with literal patterns
 - `expect` and `test` blocks
 
@@ -198,7 +202,7 @@ unsupported include:
   list, a string literal, or a fixed list variable
 - Range loops with step values other than `1`
 - Slicing expressions like `list[start:end]`
-- Using the `range` helper to generate sequences
+- Using the `range` helper with non-constant bounds
 - Dynamic lists whose length is not known at compile time
 - Struct and model declarations
 - Union type declarations and inline methods

--- a/compile/cobol/compiler.go
+++ b/compile/cobol/compiler.go
@@ -684,6 +684,29 @@ func (c *Compiler) compileCallExpr(n *ast.Node) string {
 		c.writeln(fmt.Sprintf("    COMPUTE %s = FUNCTION LENGTH(%s)", tmp, expr))
 		return tmp
 	}
+	if name == "RANGE" && (len(n.Children) == 1 || len(n.Children) == 2) {
+		start := 0
+		end := 0
+		if len(n.Children) == 1 {
+			end = extractInt(n.Children[0])
+		} else {
+			start = extractInt(n.Children[0])
+			end = extractInt(n.Children[1])
+		}
+		if end < start {
+			end = start
+		}
+		length := end - start
+		res := c.newTemp()
+		c.declare(fmt.Sprintf("01 %s OCCURS %d TIMES PIC 9.", res, length))
+		c.listLens[res] = length
+		idx := 1
+		for i := start; i < end; i++ {
+			c.writeln(fmt.Sprintf("    MOVE %d TO %s(%d)", i, res, idx))
+			idx++
+		}
+		return res
+	}
 	count, ok := c.funcs[name]
 	if name == "ADD" && len(n.Children) == 2 {
 		left := c.expr(n.Children[0])


### PR DESCRIPTION
## Summary
- support `range` helper in COBOL compiler
- document additional language features and clarify unsupported ones

## Testing
- `go test ./compile/cobol -tags slow -run TestCobolCompiler_TwoSum -count=1`
- `go test ./... -run TestNothing -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6855946ba14483209277529df4b47946