### PR TITLE
Add list set ops to Java backend

### DIFF
--- a/compile/java/README.md
+++ b/compile/java/README.md
@@ -259,6 +259,7 @@ The Java backend currently lacks several Mochi features supported by other compi
 - The `eval` builtin function
 - Methods declared inside `type` blocks
 - Agent initialization with field values
-- List set operations (`union`, `union all`, `intersect`, `except`)
+- List set operation `union all`
+- YAML dataset loading/saving
 
 Simple `from` queries used by the LeetCode examples are now supported.


### PR DESCRIPTION
## Summary
- support `union`, `except` and `intersect` for lists in the Java compiler
- document unsupported `union all` and YAML dataset loading in the Java backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68560fa29e408320969ede49b940cdad