### PR TITLE
Add features in Haskell backend

### DIFF
--- a/compile/hs/README.md
+++ b/compile/hs/README.md
@@ -103,9 +103,8 @@ full Mochi language. Unsupported features include:
 * Set literals and related operations
 * Generative AI, HTTP fetch and FFI bindings
 * Streams and long-lived agents
-* `break` and `continue` statements
 * Struct and object types
+* Logic programming with `fact`, `rule` and `query` expressions
 * Package imports and module system
-* Top-level `var` declarations
 * Dataset `load`/`save` operations
 * `test` blocks and expectations

--- a/compile/hs/compiler.go
+++ b/compile/hs/compiler.go
@@ -135,6 +135,16 @@ func (c *Compiler) compileMainStmt(s *parser.Statement) error {
 			}
 			c.writeln(fmt.Sprintf("let %s = %s", sanitizeName(s.Let.Name), val))
 		}
+	case s.Var != nil:
+		val := "()"
+		if s.Var.Value != nil {
+			v, err := c.compileExpr(s.Var.Value)
+			if err != nil {
+				return err
+			}
+			val = v
+		}
+		c.writeln(fmt.Sprintf("let %s = %s", sanitizeName(s.Var.Name), val))
 	case s.Expr != nil:
 		expr, err := c.compileExpr(s.Expr.Expr)
 		if err != nil {
@@ -345,6 +355,12 @@ func (c *Compiler) compileStmtExpr(stmts []*parser.Statement, top bool) (string,
 				val = v
 			}
 			expr = fmt.Sprintf("(let %s = %s in %s)", sanitizeName(s.Var.Name), val, expr)
+		case s.Break != nil:
+			expr = "Just ()"
+			continue
+		case s.Continue != nil:
+			expr = "Nothing"
+			continue
 		case s.Let != nil:
 			val := "()"
 			if s.Let.Value != nil {


### PR DESCRIPTION
## Summary
- support top-level `var` declarations
- handle `break` and `continue` statements in the Haskell backend
- document unsupported logic programming constructs in the Haskell backend README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68560fbfb2d88320a8113d67860f7d91