### PR TITLE
Add package support in Kotlin backend

### DIFF
--- a/compile/kt/README.md
+++ b/compile/kt/README.md
@@ -329,10 +329,13 @@ support:
 - Advanced dataset queries such as joins, grouping and union operations
 - Streams, agents and intent handlers
 - Logic programming constructs (`fact`, `rule`, `query`)
-- Package declarations and the foreign function interface
+- Foreign function interface and cross-language imports
 - Event emission with `emit` statements
-- Extern declarations and foreign imports
+- Extern declarations
 - Concurrency primitives such as `spawn` and channels
 - Error handling with `try`/`catch` blocks
+- Generic types and functions
+- Set collections and related operations
+- Reflection or macro facilities
 
 

--- a/compile/kt/compiler.go
+++ b/compile/kt/compiler.go
@@ -30,6 +30,11 @@ func New(env *types.Env) *Compiler {
 
 // Compile generates Kotlin code for prog.
 func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	if prog.Package != "" {
+		c.writeln("package " + sanitizeName(prog.Package))
+		c.writeln("")
+	}
+
 	for _, s := range prog.Statements {
 		if s.Import != nil && s.Import.Lang == nil {
 			if err := c.compilePackageImport(s.Import); err != nil {


### PR DESCRIPTION
## Summary
- generate `package` declarations when compiling Kotlin code
- document new unsupported features for the Kotlin backend

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_68560fe2ea68832089268e19e572e9e4