### PR TITLE
Add test block support to Scheme backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,8 @@ The experimental Rust compiler does not yet implement every Mochi feature. Missi
 - HTTP and persistence helpers (`fetch`, `load`, `save`, `generate`).
 - Package imports, extern objects and other FFI constructs (`import`, `extern`).
 - Model blocks (`model`) and associated LLM helpers.
+- Concurrency primitives like `spawn` and set operations on lists (`union`, `intersect`).
+- Sets and advanced string slicing.
 
 ## License
 

--- a/compile/scheme/README.md
+++ b/compile/scheme/README.md
@@ -278,6 +278,9 @@ Execute them with the `slow` tag as they invoke an external interpreter:
 go test ./compile/scheme -tags slow
 ```
 
+The compiler also supports Mochi `test` blocks. Each block is emitted as a
+Scheme function and invoked after the main program.
+
 ## Unsupported Features
 
 The Scheme backend intentionally supports only a small subset of Mochi.  It does **not** handle:
@@ -291,7 +294,7 @@ The Scheme backend intentionally supports only a small subset of Mochi.  It does
 * packages or the foreign function interface
 * `import` statements for foreign code
 * `model` declarations
-* streams, agents, or tests
+* streams and agents
 * sets
 * struct type declarations
 * methods inside `type` blocks


### PR DESCRIPTION
## Summary
- support `test` blocks in the Scheme compiler
- mention Scheme test block support in documentation
- document additional Rust backend limitations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68560ff6be848320a22ff45e2467a4f1