### PR TITLE
Add Smalltalk lambda support

### DIFF
--- a/compile/st/README.md
+++ b/compile/st/README.md
@@ -33,7 +33,7 @@ The following language constructs are not yet handled:
 - Import and package statements
 - Model declarations (`model`) and related LLM helpers
 - Pattern matching with `match`
-- Anonymous function expressions (`fun (...) { ... }` or `fun (...) => expr`)
 - Union type declarations
 - Set literals and set operations
 - Concurrency primitives like `spawn` and channels
+- Built-in helpers like `append`, `now`, `json`, and `eval`


### PR DESCRIPTION
## Summary
- support anonymous function expressions in the Smalltalk backend
- list additional unsupported features in the Smalltalk backend docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685610199b1c8320b90369ae75aad7f7