### PR TITLE
Add JSONL support in Lua backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,23 @@ The experimental Rust compiler does not yet implement every Mochi feature. Missi
 - Package imports, extern objects and other FFI constructs (`import`, `extern`).
 - Model blocks (`model`) and associated LLM helpers.
 
+## Unsupported Features (Lua Backend)
+
+The Lua compiler focuses on basic code generation and omits several advanced features:
+
+- Regex helpers beyond simple `match`.
+- Modifying lists while iterating (`insert`, `remove`).
+- Query grouping and joins with `left`, `right` or `outer` sides.
+- Logic programming constructs and logic queries.
+- Foreign function interface and interaction with external objects.
+- `try`/`catch` error handling.
+- Set collections (`set<T>`).
+- Model and stream declarations.
+- Methods inside `type` blocks.
+- Reflection and macro facilities.
+- Concurrency primitives such as `spawn`, `stream`, `agent` and related helpers.
+- Module imports and package declarations.
+
 ## License
 
 Mochi is open source under the [MIT License](./LICENSE).

--- a/compile/lua/README.md
+++ b/compile/lua/README.md
@@ -316,8 +316,7 @@ fail at runtime:
   are not available
 - Module imports and package declarations
 
-`load` and `save` support JSON, YAML and CSV formats. Other formats like JSONL
-are not implemented.
+`load` and `save` support JSON, JSONL, YAML and CSV formats.
 
 Problems `6`, `10`, `23` and `27` currently do not run correctly when compiled
 to Lua.

--- a/compile/lua/compiler.go
+++ b/compile/lua/compiler.go
@@ -1491,6 +1491,17 @@ func (c *Compiler) emitHelpers() {
 		c.writeln("if not ok then error('yaml library not found') end")
 		c.writeln("res = yaml.load(data)")
 		c.indent--
+		c.writeln("elseif fmt == 'jsonl' then")
+		c.indent++
+		c.writeln("local ok, json = pcall(require, 'json')")
+		c.writeln("if not ok then error('json library not found') end")
+		c.writeln("res = {}")
+		c.writeln("for line in string.gmatch(data, '[^\\n]+') do")
+		c.indent++
+		c.writeln("table.insert(res, json.decode(line))")
+		c.indent--
+		c.writeln("end")
+		c.indent--
 		c.writeln("elseif fmt == 'csv' then")
 		c.indent++
 		c.writeln("res = {}")
@@ -1533,6 +1544,18 @@ func (c *Compiler) emitHelpers() {
 		c.writeln("if not ok then ok, yaml = pcall(require, 'lyaml') end")
 		c.writeln("if not ok then error('yaml library not found') end")
 		c.writeln("if yaml.dump then data = yaml.dump(rows) else data = yaml.encode(rows) end")
+		c.indent--
+		c.writeln("elseif fmt == 'jsonl' then")
+		c.indent++
+		c.writeln("local ok, json = pcall(require, 'json')")
+		c.writeln("if not ok then error('json library not found') end")
+		c.writeln("local lines = {}")
+		c.writeln("for _, row in ipairs(rows) do")
+		c.indent++
+		c.writeln("table.insert(lines, json.encode(row))")
+		c.indent--
+		c.writeln("end")
+		c.writeln("data = table.concat(lines, '\n')")
 		c.indent--
 		c.writeln("elseif fmt == 'csv' then")
 		c.indent++


### PR DESCRIPTION
## Summary
- extend Lua compiler to load and save JSONL
- document Lua backend limitations
- list Lua backend unsupported features in top-level README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68560fb0af2883208170a8b783c5c984