### PR TITLE
Improve Ruby backend inference

### DIFF
--- a/compile/rb/compiler.go
+++ b/compile/rb/compiler.go
@@ -132,6 +132,15 @@ func (c *Compiler) compileLet(l *parser.LetStmt) error {
 		}
 		val = v
 	}
+	if c.env != nil {
+		var typ types.Type = types.AnyType{}
+		if l.Type != nil {
+			typ = c.resolveTypeRef(l.Type)
+		} else if l.Value != nil {
+			typ = c.inferExprType(l.Value)
+		}
+		c.env.SetVar(l.Name, typ, false)
+	}
 	c.writeln(fmt.Sprintf("%s = %s", sanitizeName(l.Name), val))
 	return nil
 }
@@ -144,6 +153,17 @@ func (c *Compiler) compileVar(v *parser.VarStmt) error {
 			return err
 		}
 		val = e
+	}
+	if c.env != nil {
+		var typ types.Type = types.AnyType{}
+		if v.Type != nil {
+			typ = c.resolveTypeRef(v.Type)
+		} else if v.Value != nil {
+			typ = c.inferExprType(v.Value)
+		} else if t, err := c.env.GetVar(v.Name); err == nil {
+			typ = t
+		}
+		c.env.SetVar(v.Name, typ, true)
 	}
 	c.writeln(fmt.Sprintf("%s = %s", sanitizeName(v.Name), val))
 	return nil

--- a/compile/rb/helpers.go
+++ b/compile/rb/helpers.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"mochi/parser"
+	"mochi/types"
 )
 
 var rbReserved = map[string]struct{}{
@@ -127,4 +128,59 @@ func isStringLiteral(e *parser.Expr) bool {
 		return false
 	}
 	return p.Target != nil && p.Target.Lit != nil && p.Target.Lit.Str != nil
+}
+
+func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
+	if t == nil {
+		return types.AnyType{}
+	}
+	if t.Fun != nil {
+		params := make([]types.Type, len(t.Fun.Params))
+		for i, p := range t.Fun.Params {
+			params[i] = c.resolveTypeRef(p)
+		}
+		var ret types.Type = types.VoidType{}
+		if t.Fun.Return != nil {
+			ret = c.resolveTypeRef(t.Fun.Return)
+		}
+		return types.FuncType{Params: params, Return: ret}
+	}
+	if t.Generic != nil {
+		name := t.Generic.Name
+		args := t.Generic.Args
+		switch name {
+		case "list":
+			if len(args) == 1 {
+				return types.ListType{Elem: c.resolveTypeRef(args[0])}
+			}
+		case "map":
+			if len(args) == 2 {
+				return types.MapType{Key: c.resolveTypeRef(args[0]), Value: c.resolveTypeRef(args[1])}
+			}
+		}
+		return types.AnyType{}
+	}
+	if t.Simple != nil {
+		switch *t.Simple {
+		case "int":
+			return types.IntType{}
+		case "float":
+			return types.FloatType{}
+		case "string":
+			return types.StringType{}
+		case "bool":
+			return types.BoolType{}
+		default:
+			if c != nil && c.env != nil {
+				if st, ok := c.env.GetStruct(*t.Simple); ok {
+					return st
+				}
+				if ut, ok := c.env.GetUnion(*t.Simple); ok {
+					return ut
+				}
+			}
+			return types.AnyType{}
+		}
+	}
+	return types.AnyType{}
 }

--- a/compile/rb/infer.go
+++ b/compile/rb/infer.go
@@ -1,0 +1,86 @@
+package rbcode
+
+import (
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+// inferExprType performs minimal type inference used by the code generator.
+// It distinguishes literals, lists, maps and known variable references.
+func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
+	if e == nil {
+		return types.AnyType{}
+	}
+	if id, ok := identName(e); ok && c.env != nil {
+		if t, err := c.env.GetVar(id); err == nil {
+			return t
+		}
+	}
+	return c.inferPostfixType(e.Binary.Left)
+}
+
+func (c *Compiler) inferPostfixType(u *parser.Unary) types.Type {
+	if u == nil {
+		return types.AnyType{}
+	}
+	t := c.inferPrimaryType(u.Value.Target)
+	for _, op := range u.Value.Ops {
+		if op.Cast != nil {
+			t = c.resolveTypeRef(op.Cast.Type)
+		}
+	}
+	return t
+}
+
+func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	switch {
+	case p.Lit != nil:
+		switch {
+		case p.Lit.Str != nil:
+			return types.StringType{}
+		case p.Lit.Int != nil:
+			return types.IntType{}
+		case p.Lit.Float != nil:
+			return types.FloatType{}
+		case p.Lit.Bool != nil:
+			return types.BoolType{}
+		}
+	case p.List != nil:
+		return types.ListType{Elem: types.AnyType{}}
+	case p.Map != nil:
+		return types.MapType{Key: types.AnyType{}, Value: types.AnyType{}}
+	case p.Selector != nil:
+		if c.env != nil {
+			if len(p.Selector.Tail) > 0 {
+				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
+				if t, err := c.env.GetVar(full); err == nil {
+					return t
+				}
+			}
+			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
+				return t
+			}
+		}
+	}
+	return types.AnyType{}
+}
+
+func isList(t types.Type) bool {
+	_, ok := t.(types.ListType)
+	return ok
+}
+
+func isMap(t types.Type) bool {
+	_, ok := t.(types.MapType)
+	return ok
+}
+
+func isString(t types.Type) bool {
+	_, ok := t.(types.StringType)
+	return ok
+}


### PR DESCRIPTION
## Summary
- support simple type inference in Ruby backend
- update compiler to register variable types
- map TypeRef instances to `types.Type` for Ruby

## Testing
- `go test ./compile/rb -tags slow -run TestRBCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6856169d63b08320a93cbd1b850c36c6