### PR TITLE
Improve Haskell backend with basic type inference

### DIFF
--- a/compile/hs/compiler.go
+++ b/compile/hs/compiler.go
@@ -212,8 +212,19 @@ func (c *Compiler) compileFun(fun *parser.FunStmt) error {
 			}
 		}
 	}
+	if ft.Params == nil {
+		ft.Params = make([]types.Type, len(fun.Params))
+		for i, p := range fun.Params {
+			if p.Type != nil {
+				ft.Params[i] = c.resolveTypeRef(p.Type)
+			}
+		}
+	}
 	if ft.Return == nil && fun.Return != nil {
-		ft.Return = types.AnyType{}
+		ft.Return = c.resolveTypeRef(fun.Return)
+	}
+	if ft.Return == nil {
+		ft.Return = c.inferReturnType(fun.Body)
 	}
 	if ft.Return == nil {
 		ft.Return = types.VoidType{}

--- a/compile/hs/helpers.go
+++ b/compile/hs/helpers.go
@@ -1,6 +1,12 @@
 package hscode
 
-import "strings"
+import (
+	"reflect"
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
 
 func (c *Compiler) writeln(s string) {
 	c.writeIndent()
@@ -32,3 +38,80 @@ func sanitizeName(name string) string {
 	}
 	return s
 }
+
+func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
+	if t == nil {
+		return types.AnyType{}
+	}
+	if t.Fun != nil {
+		params := make([]types.Type, len(t.Fun.Params))
+		for i, p := range t.Fun.Params {
+			params[i] = c.resolveTypeRef(p)
+		}
+		var ret types.Type = types.VoidType{}
+		if t.Fun.Return != nil {
+			ret = c.resolveTypeRef(t.Fun.Return)
+		}
+		return types.FuncType{Params: params, Return: ret}
+	}
+	if t.Generic != nil {
+		switch t.Generic.Name {
+		case "list":
+			if len(t.Generic.Args) == 1 {
+				return types.ListType{Elem: c.resolveTypeRef(t.Generic.Args[0])}
+			}
+		case "map":
+			if len(t.Generic.Args) == 2 {
+				return types.MapType{Key: c.resolveTypeRef(t.Generic.Args[0]), Value: c.resolveTypeRef(t.Generic.Args[1])}
+			}
+		}
+		return types.AnyType{}
+	}
+	if t.Simple != nil {
+		switch *t.Simple {
+		case "int":
+			return types.IntType{}
+		case "float":
+			return types.FloatType{}
+		case "string":
+			return types.StringType{}
+		case "bool":
+			return types.BoolType{}
+		default:
+			if c != nil && c.env != nil {
+				if st, ok := c.env.GetStruct(*t.Simple); ok {
+					return st
+				}
+				if ut, ok := c.env.GetUnion(*t.Simple); ok {
+					return ut
+				}
+			}
+			return types.AnyType{}
+		}
+	}
+	return types.AnyType{}
+}
+
+func equalTypes(a, b types.Type) bool {
+	if _, ok := a.(types.AnyType); ok {
+		return true
+	}
+	if _, ok := b.(types.AnyType); ok {
+		return true
+	}
+	if isInt64(a) && (isInt64(b) || isInt(b)) {
+		return true
+	}
+	if isInt64(b) && (isInt64(a) || isInt(a)) {
+		return true
+	}
+	if isInt(a) && isInt(b) {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func isInt64(t types.Type) bool  { _, ok := t.(types.Int64Type); return ok }
+func isInt(t types.Type) bool    { _, ok := t.(types.IntType); return ok }
+func isFloat(t types.Type) bool  { _, ok := t.(types.FloatType); return ok }
+func isString(t types.Type) bool { _, ok := t.(types.StringType); return ok }

--- a/compile/hs/infer.go
+++ b/compile/hs/infer.go
@@ -1,0 +1,217 @@
+package hscode
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
+	if e == nil {
+		return types.AnyType{}
+	}
+	return c.inferBinaryType(e.Binary)
+}
+
+func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
+	if b == nil {
+		return types.AnyType{}
+	}
+	t := c.inferUnaryType(b.Left)
+	for _, op := range b.Right {
+		rt := c.inferPostfixType(op.Right)
+		switch op.Op {
+		case "+", "-", "*", "/", "%":
+			if isInt64(t) {
+				if isInt64(rt) || isInt(rt) {
+					t = types.Int64Type{}
+					continue
+				}
+			}
+			if isInt(t) && isInt(rt) {
+				t = types.IntType{}
+				continue
+			}
+			if isFloat(t) && isFloat(rt) {
+				t = types.FloatType{}
+				continue
+			}
+			if op.Op == "+" {
+				if llist, ok := t.(types.ListType); ok {
+					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
+						t = llist
+						continue
+					}
+				}
+				if isString(t) && isString(rt) {
+					t = types.StringType{}
+					continue
+				}
+			}
+			t = types.AnyType{}
+		case "==", "!=", "<", "<=", ">", ">=":
+			t = types.BoolType{}
+		default:
+			t = types.AnyType{}
+		}
+	}
+	return t
+}
+
+func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+	if u == nil {
+		return types.AnyType{}
+	}
+	return c.inferPostfixType(u.Value)
+}
+
+func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	t := c.inferPrimaryType(p.Target)
+	for _, op := range p.Ops {
+		if op.Index != nil && op.Index.Colon == nil {
+			switch tt := t.(type) {
+			case types.ListType:
+				t = tt.Elem
+			case types.MapType:
+				t = tt.Value
+			case types.StringType:
+				t = types.StringType{}
+			default:
+				t = types.AnyType{}
+			}
+		} else if op.Index != nil {
+			switch tt := t.(type) {
+			case types.ListType:
+				t = tt
+			case types.StringType:
+				t = types.StringType{}
+			default:
+				t = types.AnyType{}
+			}
+		} else if op.Call != nil {
+			if ft, ok := t.(types.FuncType); ok {
+				t = ft.Return
+			} else {
+				t = types.AnyType{}
+			}
+		} else if op.Cast != nil {
+			t = c.resolveTypeRef(op.Cast.Type)
+		}
+	}
+	return t
+}
+
+func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	switch {
+	case p.Lit != nil:
+		switch {
+		case p.Lit.Int != nil:
+			return types.IntType{}
+		case p.Lit.Float != nil:
+			return types.FloatType{}
+		case p.Lit.Str != nil:
+			return types.StringType{}
+		case p.Lit.Bool != nil:
+			return types.BoolType{}
+		}
+	case p.Selector != nil:
+		if c.env != nil {
+			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
+				if len(p.Selector.Tail) == 0 {
+					return t
+				}
+				if st, ok := t.(types.StructType); ok {
+					cur := st
+					for idx, field := range p.Selector.Tail {
+						ft, ok := cur.Fields[field]
+						if !ok {
+							return types.AnyType{}
+						}
+						if idx == len(p.Selector.Tail)-1 {
+							return ft
+						}
+						if next, ok := ft.(types.StructType); ok {
+							cur = next
+						} else {
+							return types.AnyType{}
+						}
+					}
+				}
+			}
+		}
+		return types.AnyType{}
+	case p.Struct != nil:
+		if c.env != nil {
+			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
+				return st
+			}
+		}
+		return types.AnyType{}
+	case p.Call != nil:
+		switch p.Call.Func {
+		case "len", "count":
+			return types.IntType{}
+		case "str":
+			return types.StringType{}
+		case "avg":
+			return types.FloatType{}
+		case "now":
+			return types.Int64Type{}
+		default:
+			if c.env != nil {
+				if t, err := c.env.GetVar(p.Call.Func); err == nil {
+					if ft, ok := t.(types.FuncType); ok {
+						return ft.Return
+					}
+				}
+			}
+			return types.AnyType{}
+		}
+	case p.Group != nil:
+		return c.inferExprType(p.Group)
+	case p.List != nil:
+		var elemType types.Type = types.AnyType{}
+		if len(p.List.Elems) > 0 {
+			elemType = c.inferExprType(p.List.Elems[0])
+			for _, e := range p.List.Elems[1:] {
+				t := c.inferExprType(e)
+				if !equalTypes(elemType, t) {
+					elemType = types.AnyType{}
+					break
+				}
+			}
+		}
+		return types.ListType{Elem: elemType}
+	case p.Map != nil:
+		var keyType types.Type = types.AnyType{}
+		var valType types.Type = types.AnyType{}
+		if len(p.Map.Items) > 0 {
+			keyType = c.inferExprType(p.Map.Items[0].Key)
+			valType = c.inferExprType(p.Map.Items[0].Value)
+			for _, it := range p.Map.Items[1:] {
+				kt := c.inferExprType(it.Key)
+				vt := c.inferExprType(it.Value)
+				if !equalTypes(keyType, kt) {
+					keyType = types.AnyType{}
+				}
+				if !equalTypes(valType, vt) {
+					valType = types.AnyType{}
+				}
+			}
+		}
+		return types.MapType{Key: keyType, Value: valType}
+	}
+	return types.AnyType{}
+}
+
+func (c *Compiler) inferReturnType(stmts []*parser.Statement) types.Type {
+	if len(stmts) == 1 && stmts[0].Return != nil {
+		return c.inferExprType(stmts[0].Return.Value)
+	}
+	return types.VoidType{}
+}


### PR DESCRIPTION
## Summary
- implement simple type inference for the Haskell compiler
- add helpers for resolving type references and comparing types
- use inferred and declared types when emitting function signatures

## Testing
- `go test ./compile/hs -c`

------
https://chatgpt.com/codex/tasks/task_e_6856168ae98483209bc36e0da0ec9ecb