### PR TITLE
Deduplicate runtime helpers in F# compiler

### DIFF
--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -1745,8 +1745,14 @@ func (c *Compiler) emitRuntime() {
 		names = append(names, n)
 	}
 	sort.Strings(names)
+	seen := map[string]bool{}
 	for _, n := range names {
-		for _, line := range strings.Split(helperMap[n], "\n") {
+		src := helperMap[n]
+		if seen[src] {
+			continue
+		}
+		seen[src] = true
+		for _, line := range strings.Split(src, "\n") {
 			c.preamble.WriteString(line)
 			c.preamble.WriteByte('\n')
 		}


### PR DESCRIPTION
## Summary
- avoid emitting duplicate runtime helpers

## Testing
- `go test ./compile/fs -list Test -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68561b8021dc83208611661022a7b59d