### PR TITLE
fix fs runtime helper tracking

### DIFF
--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -1358,6 +1358,9 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) (string, error) {
 	if err := sub.compileFunStmt(fs); err != nil {
 		return "", err
 	}
+	for h := range sub.helpers {
+		c.helpers[h] = true
+	}
 	c.tmp = sub.tmp
 	c.loopTmp = sub.loopTmp
 	c.funTmp = sub.funTmp


### PR DESCRIPTION
## Summary
- propagate runtime helper usage from nested functions in the F# backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68562cd950c48320b8adaabcefd95365