### PR TITLE
Improve Java compiler runtime emission

### DIFF
--- a/compile/java/compiler.go
+++ b/compile/java/compiler.go
@@ -81,7 +81,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		c.writeln("}")
 	}
 
-	c.emitRuntime()
+	if len(c.helpers) > 0 {
+		c.emitRuntime()
+	}
 
 	c.indent--
 	c.writeln("}")


### PR DESCRIPTION
## Summary
- only emit Java runtime helpers when they are actually required

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_68562cdb3f908320af3140f85aad43f3