### PR TITLE
Refactor Ruby group_by runtime helper

### DIFF
--- a/compile/rb/runtime.go
+++ b/compile/rb/runtime.go
@@ -158,20 +158,12 @@ end`
 end`
 
 	helperGroupBy = `def _group_by(src, keyfn)
-  groups = {}
-  order = []
-  src.each do |it|
-    key = keyfn.call(it)
-    ks = key.to_s
-    g = groups[ks]
-    unless g
-      g = _Group.new(key)
-      groups[ks] = g
-      order << ks
-    end
-    g.Items << it
-  end
-  order.map { |k| groups[k] }
+grouped = src.group_by { |it| keyfn.call(it) }
+grouped.map do |k, items|
+g = _Group.new(k)
+g.Items.concat(items)
+g
+end
 end`
 )
 

--- a/tests/compiler/rb/group_by.rb.out
+++ b/tests/compiler/rb/group_by.rb.out
@@ -8,20 +8,12 @@ class _Group
   end
 end
 def _group_by(src, keyfn)
-  groups = {}
-  order = []
-  src.each do |it|
-    key = keyfn.call(it)
-    ks = key.to_s
-    g = groups[ks]
-    unless g
-      g = _Group.new(key)
-      groups[ks] = g
-      order << ks
-    end
-    g.Items << it
-  end
-  order.map { |k| groups[k] }
+grouped = src.group_by { |it| keyfn.call(it) }
+grouped.map do |k, items|
+g = _Group.new(k)
+g.Items.concat(items)
+g
+end
 end
 
 xs = [1, 1, 2]


### PR DESCRIPTION
## Summary
- simplify Ruby `_group_by` by using `group_by` and `concat`
- update `group_by` golden output to match new helper implementation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68562ce7aff08320b2b900cb1316e2d6