### PR TITLE
Refactor Rust compiler helpers

### DIFF
--- a/tests/compiler/rust/avg_builtin.rs.out
+++ b/tests/compiler/rust/avg_builtin.rs.out
@@ -1,10 +1,4 @@
 fn main() {
-    println!("{}", _avg(&vec![1, 2, 3]));
+    println!("{}", { let v = &vec![1, 2, 3]; if v.is_empty() { 0.0 } else { let mut sum = 0.0; for &it in v { sum += it.into(); } sum / v.len() as f64 } });
 }
 
-fn _avg<T: Into<f64> + Copy>(v: &[T]) -> f64 {
-    if v.is_empty() { return 0.0 }
-    let mut sum = 0.0;
-    for &it in v { sum += it.into(); }
-    sum / v.len() as f64
-}

--- a/tests/compiler/rust/count_builtin.rs.out
+++ b/tests/compiler/rust/count_builtin.rs.out
@@ -1,7 +1,4 @@
 fn main() {
-    println!("{}", _count(&vec![1, 2, 3]));
+    println!("{}", vec![1, 2, 3].len() as i32);
 }
 
-fn _count<T>(v: &[T]) -> i32 {
-    v.len() as i32
-}

--- a/tests/compiler/rust/input_builtin.rs.out
+++ b/tests/compiler/rust/input_builtin.rs.out
@@ -1,14 +1,8 @@
 fn main() {
     println!("{}", "Enter first input:");
-    let mut input1 = _input();
+    let mut input1 = { use std::io::Read; let mut s = String::new(); std::io::stdin().read_line(&mut s).unwrap(); s.trim().to_string() };
     println!("{}", "Enter second input:");
-    let mut input2 = _input();
+    let mut input2 = { use std::io::Read; let mut s = String::new(); std::io::stdin().read_line(&mut s).unwrap(); s.trim().to_string() };
     println!("{} {} {} {}", "You entered:", input1, ",", input2);
 }
 
-fn _input() -> String {
-    use std::io::Read;
-    let mut s = String::new();
-    std::io::stdin().read_line(&mut s).unwrap();
-    s.trim().to_string()
-}

--- a/tests/compiler/rust/list_concat.rs.out
+++ b/tests/compiler/rust/list_concat.rs.out
@@ -1,10 +1,4 @@
 fn main() {
-    println!("[{}]", _concat(&vec![1, 2], &vec![3, 4]).iter().map(|v| format!("{}", v)).collect::<Vec<_>>().join(" "));
+    println!("[{}]", { let a = &vec![1, 2]; let b = &vec![3, 4]; let mut res = Vec::with_capacity(a.len() + b.len()); res.extend_from_slice(a); res.extend_from_slice(b); res }.iter().map(|v| format!("{}", v)).collect::<Vec<_>>().join(" "));
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
-}

--- a/tests/compiler/rust/string_index.rs.out
+++ b/tests/compiler/rust/string_index.rs.out
@@ -1,12 +1,5 @@
 fn main() {
     let mut text = "hello".to_string();
-    println!("{}", _index_string(&text, 1));
+    println!("{}", { let s = &text; let mut idx = 1; let chars: Vec<char> = s.chars().collect(); if idx < 0 { idx += chars.len() as i64; } if idx < 0 || idx >= chars.len() as i64 { panic!("index out of range"); } chars[idx as usize].to_string() });
 }
 
-fn _index_string(s: &str, i: i64) -> String {
-    let mut idx = i;
-    let chars: Vec<char> = s.chars().collect();
-    if idx < 0 { idx += chars.len() as i64; }
-    if idx < 0 || idx >= chars.len() as i64 { panic!("index out of range"); }
-    chars[idx as usize].to_string()
-}

--- a/tests/compiler/rust/string_negative_index.rs.out
+++ b/tests/compiler/rust/string_negative_index.rs.out
@@ -1,12 +1,5 @@
 fn main() {
     let mut text = "hello".to_string();
-    println!("{}", _index_string(&text, -1));
+    println!("{}", { let s = &text; let mut idx = -1; let chars: Vec<char> = s.chars().collect(); if idx < 0 { idx += chars.len() as i64; } if idx < 0 || idx >= chars.len() as i64 { panic!("index out of range"); } chars[idx as usize].to_string() });
 }
 
-fn _index_string(s: &str, i: i64) -> String {
-    let mut idx = i;
-    let chars: Vec<char> = s.chars().collect();
-    if idx < 0 { idx += chars.len() as i64; }
-    if idx < 0 || idx >= chars.len() as i64 { panic!("index out of range"); }
-    chars[idx as usize].to_string()
-}


### PR DESCRIPTION
## Summary
- reduce runtime helper usage in Rust backend
- inline builtin operations directly in output
- update affected golden files

## Testing
- `go test -tags slow ./compile/rust -run TestRustCompiler_GoldenOutput`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68562ce8ed608320b228010e36ab26d7