### PR TITLE
Improve Kotlin runtime dataset handling

### DIFF
--- a/compile/kt/README.md
+++ b/compile/kt/README.md
@@ -337,5 +337,7 @@ support:
 - Generic types and functions
 - Set collections and related operations
 - Reflection or macro facilities
+- YAML dataset loading and saving
+- Full LLM integration for `_genText`, `_genEmbed` and `_genStruct`
 
 


### PR DESCRIPTION
## Summary
- extend Kotlin runtime _load/_save for JSON and JSONL formats
- document additional missing capabilities

## Testing
- `make fmt`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68563b8d66388320b63c83d06cddd4e5