### PR TITLE
Add Scala package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,23 @@ The Racket code generator implements a small subset of Mochi. Missing features i
 - Extern declarations (`extern var`, `extern fun`, `extern type`, `extern object`)
 - Destructuring bindings in `let` and `var` statements
 
+## Unsupported Features (Scala Backend)
+
+The Scala backend covers only a subset of Mochi. Missing capabilities include:
+
+- Concurrency primitives like `spawn` and channels
+- Module system and imports (except Python FFI)
+- Generic type parameters and higher-order functions
+- Advanced dataset queries such as joins and grouping
+- Logic queries and logic programming constructs (`fact`, `rule`)
+- Reflection and macro facilities
+- Streams, agents and intent handlers (`emit`, `on`)
+- Error handling with `try`/`catch`
+- Model declarations
+- Extern variable, type and object declarations
+- Package imports and export declarations
+- The `eval` builtin function
+
 ## License
 
 Mochi is open source under the [MIT License](./LICENSE).

--- a/compile/scala/README.md
+++ b/compile/scala/README.md
@@ -287,6 +287,6 @@ The following pieces of Mochi are not yet handled by the Scala backend:
 - event emission and intent handlers (`emit`, `on`)
 - model declarations
 - extern variable, type and object declarations
-- package declarations
+- package imports and export declarations
 - the `eval` builtin function
 

--- a/compile/scala/compiler.go
+++ b/compile/scala/compiler.go
@@ -127,6 +127,10 @@ func New(env *types.Env) *Compiler {
 
 // Compile generates Scala code for prog.
 func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
+	if prog.Package != "" {
+		c.writeln("package " + sanitizeName(prog.Package))
+		c.writeln("")
+	}
 	for _, s := range prog.Statements {
 		if s.Type != nil {
 			if err := c.compileTypeDecl(s.Type); err != nil {


### PR DESCRIPTION
## Summary
- support `package` declarations in Scala backend
- document Scala backend limitations in the main README
- update Scala backend README list of unsupported features

## Testing
- `go test ./compile/scala -tags slow -run TestScalaCompiler_SubsetPrograms -count=1` *(fails: apt repository blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68565502f40c83208186fb31f64b2b11