### PR TITLE
Add Lua builtins and update README

### DIFF
--- a/compile/lua/README.md
+++ b/compile/lua/README.md
@@ -296,7 +296,7 @@ fail at runtime:
 - Model and stream declarations
 - Methods declared inside `type` blocks
 - Reflection and macro facilities
-- The `eval` builtin function
+- The `json` builtin function
 
 - Concurrency primitives such as `spawn`, `stream`, `agent` and related features
   are not available

--- a/compile/lua/compiler.go
+++ b/compile/lua/compiler.go
@@ -600,6 +600,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "avg":
 		c.helpers["avg"] = true
 		return fmt.Sprintf("__avg(%s)", argStr), nil
+	case "now":
+		return "os.time()*1000000000", nil
+	case "json":
+		c.helpers["json"] = true
+		return fmt.Sprintf("__json(%s)", argStr), nil
+	case "eval":
+		c.helpers["eval"] = true
+		if len(args) == 1 {
+			return fmt.Sprintf("__eval(%s)", args[0]), nil
+		}
+		return fmt.Sprintf("__eval(%s)", argStr), nil
 	default:
 		return fmt.Sprintf("%s(%s)", name, argStr), nil
 	}

--- a/compile/lua/runtime.go
+++ b/compile/lua/runtime.go
@@ -122,6 +122,18 @@ const (
 		"    return sum / #items\n" +
 		"end\n"
 
+	helperJson = "function __json(v)\n" +
+		"    local ok, json = pcall(require, 'json')\n" +
+		"    if not ok then error('json library not found') end\n" +
+		"    print(json.encode(v))\n" +
+		"end\n"
+
+	helperEval = "function __eval(code)\n" +
+		"    local f, err = load(code)\n" +
+		"    if not f then error(err) end\n" +
+		"    return f()\n" +
+		"end\n"
+
 	helperIndex = "function __index(obj, i)\n" +
 		"    if type(obj) == 'string' then\n" +
 		"        return __indexString(obj, i)\n" +
@@ -329,6 +341,8 @@ var helperMap = map[string]string{
 	"input":       helperInput,
 	"count":       helperCount,
 	"avg":         helperAvg,
+	"json":        helperJson,
+	"eval":        helperEval,
 	"index":       helperIndex,
 	"indexString": helperIndexString,
 	"slice":       helperSlice,


### PR DESCRIPTION
## Summary
- implement `now`, `json`, and `eval` builtins for Lua compiler
- provide runtime helpers for the new builtins
- list `json` as an unsupported feature instead of `eval`

## Testing
- `go test ./compile/lua -run TestLuaCompiler_SubsetPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6856550df01083208cea36e67f5d914a