### PR TITLE
Add v0.8.9 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # 📦 CHANGELOG.md
+## [0.8.9] – 2025-06-21
+
+### Added
+
+* Sort builtin for Rust and join queries in Ruby
+* Imports and multi-dimensional indexing in Racket
+* Package declarations and Python FFI imports for Scala
+* Map loops, len and reduce builtin in Zig
+* Python agent initialization with fields
+* Group queries in Lua with struct support for the C backend
+* List slicing and negative indexing in COBOL
+* JSON helpers and reduce builtin for Kotlin
+* Type method support with generic map casting in C#
+* Block-bodied lambdas in Racket and list ops in Scheme
+* Inline avg builtin for Fortran
+* Reduce builtin in C++ and Prolog test blocks
+
+### Changed
+
+* Runtime helpers are deduplicated and inlined across languages
+
+### Fixed
+
+* Method handling corrected in the Clojure compiler
+
 ## [0.8.8] – 2025-06-20
 
 ### Added

--- a/releases/v0.8.9.md
+++ b/releases/v0.8.9.md
@@ -1,0 +1,27 @@
+# Jun 2025 (v0.8.9)
+
+Mochi v0.8.9 extends dataset features and improves runtime helpers across the experimental compilers. Many backends gain new builtins, package support and type inference enhancements.
+
+## Compilers
+
+- Sort builtin in Rust with updated documentation
+- Join queries for Ruby
+- Import handling and multi-dimensional indexing in Racket
+- Package declarations and Python FFI imports for Scala
+- Map loops, length checks and reduce builtin for Zig
+- Agent initialization with fields in Python
+- Group query support in Lua
+- List slicing and negative indexing for COBOL
+- Struct support in the C backend and reduce builtin in C++
+- JSON helpers and reduce builtin for Kotlin
+- Type method support with generic map casting in C#
+- Block-bodied lambdas in Racket with list operations in Scheme
+- Inline average builtin for Fortran
+
+## Tests
+
+- Prolog backend adds test block syntax
+
+## Fixes
+
+- Corrected method handling in the Clojure compiler


### PR DESCRIPTION
## Summary
- document release notes for v0.8.9
- update CHANGELOG with new entry

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68566aa60a5083209da4fcfb4a2266a0