### PR TITLE
Extend COBOL backend slice support

### DIFF
--- a/compile/cobol/README.md
+++ b/compile/cobol/README.md
@@ -167,6 +167,7 @@ constructs:
 - List concatenation with `+` and indexing (including negative indices)
 - Basic string slicing with constant start and end indices
 - List slicing with variable start and end indices
+- String and list slicing with open-ended ranges
 - Simple `match` expressions with literal patterns
 - `expect` and `test` blocks
 
@@ -202,7 +203,7 @@ unsupported include:
   list, a string literal, or a fixed list variable
 - Iteration over map key/value pairs
 - Range loops with step values other than `1`
-- List slicing with open-ended ranges (omitting the start or end index)
+- Bitwise and exponentiation operators
 - Negative indices are only supported when specified as integer literals
 - Using the `range` helper to generate sequences
 - Dynamic lists whose length is not known at compile time

--- a/compile/cobol/compiler.go
+++ b/compile/cobol/compiler.go
@@ -747,19 +747,26 @@ func (c *Compiler) expr(n *ast.Node) string {
 						endNode = ch.Children[0]
 					}
 				}
-				if startNode == nil || endNode == nil {
-					c.writeln("    *> unsupported slice")
-					return "0"
+				startExpr := "0"
+				endExpr := ""
+				if startNode != nil {
+					startExpr = c.expr(startNode)
 				}
-				startExpr := c.expr(startNode)
-				endExpr := c.expr(endNode)
-				if !isSimpleExpr(startNode) {
+				if endNode != nil {
+					endExpr = c.expr(endNode)
+				} else {
+					tmp := c.newTemp()
+					c.declare("01 " + tmp + " PIC S9.")
+					c.writeln(fmt.Sprintf("    COMPUTE %s = FUNCTION LENGTH(%s)", tmp, arr))
+					endExpr = tmp
+				}
+				if startNode != nil && !isSimpleExpr(startNode) {
 					tmp := c.newTemp()
 					c.declare("01 " + tmp + " PIC S9.")
 					c.writeln(fmt.Sprintf("    COMPUTE %s = %s", tmp, startExpr))
 					startExpr = tmp
 				}
-				if !isSimpleExpr(endNode) {
+				if endNode != nil && !isSimpleExpr(endNode) {
 					tmp := c.newTemp()
 					c.declare("01 " + tmp + " PIC S9.")
 					c.writeln(fmt.Sprintf("    COMPUTE %s = %s", tmp, endExpr))


### PR DESCRIPTION
## Summary
- support open-ended slice ranges in the COBOL backend
- document the new capability and add notes about unsupported bitwise/exponent operators

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68567b9f28388320899135c1006a985f