### PR TITLE
Add Dart agent support

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -244,13 +244,14 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 - Set operations with `union`, `union all`, `except` and `intersect`
 - Built‑ins like `fetch`, `load`, `save` and placeholder `generate`
 - Stream declarations and event handling with `on`/`emit`
+- Agent declarations with `intent` blocks
 
 ### Unsupported features
 
 - Foreign function interface bindings
-- Long‑lived agents with `intent` blocks
 - Logic programming constructs (`fact`, `rule`, `query`)
 - Model declarations
 - `generate` expressions return placeholder values (LLM integration pending)
 - Concurrency primitives like `spawn` and channels
 - Reflection or macro facilities
+- Cross-language imports (e.g. `import python "math" as m`)

--- a/compile/dart/runtime.go
+++ b/compile/dart/runtime.go
@@ -49,6 +49,24 @@ const (
 		"    void register(void Function(T) handler) { handlers.add(handler); }\n" +
 		"}\n" +
 		"void _waitAll() {}\n"
+	helperAgent = "class _Agent {\n" +
+		"    String name;\n" +
+		"    Map<String, Function> intents = {};\n" +
+		"    Map<String, dynamic> state = {};\n" +
+		"    _Agent(this.name);\n" +
+		"    void start() {}\n" +
+		"    void on(_Stream<dynamic> s, Function handler) { s.register((ev) { var res = handler(ev); if (res is Future) res.then((_){}); }); }\n" +
+		"    void registerIntent(String name, Function handler) { intents[name] = handler; }\n" +
+		"    Future<dynamic> call(String name, List<dynamic> args) async {\n" +
+		"        var fn = intents[name];\n" +
+		"        if (fn == null) throw Exception('unknown intent: $name');\n" +
+		"        var res = Function.apply(fn, args);\n" +
+		"        if (res is Future) res = await res;\n" +
+		"        return res;\n" +
+		"    }\n" +
+		"    void set(String name, dynamic value) { state[name] = value; }\n" +
+		"    dynamic get(String name) => state[name];\n" +
+		"}\n"
 	helperGroup = "class _Group {\n" +
 		"    dynamic key;\n" +
 		"    List<dynamic> Items = [];\n" +
@@ -254,6 +272,7 @@ var helperMap = map[string]string{
 	"_except":      helperExcept,
 	"_intersect":   helperIntersect,
 	"_Stream":      helperStream,
+	"_Agent":       helperAgent,
 	"_Group":       helperGroup,
 	"_group_by":    helperGroupBy,
 	"_fetch":       helperFetch,


### PR DESCRIPTION
## Summary
- support agent declarations in the Dart backend
- provide `_Agent` helper runtime for Dart
- document newly supported and unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68567ba2d09c832080fbd8287933ea80