### PR TITLE
Add YAML dataset support to C# backend

### DIFF
--- a/compile/cs/README.md
+++ b/compile/cs/README.md
@@ -146,6 +146,22 @@ This script attempts platform‑specific installation via Homebrew or `apt-get` 
 
 The C# backend focuses on fundamental features: functions, control flow, structs, unions and query expressions. Recent updates added support for package declarations, set operations on lists, helper functions for printing JSON or getting the current timestamp, and basic stream handling with `on`/`emit` blocks. Advanced Mochi capabilities such as long‑lived agents and extern objects are not yet implemented in this generator.
 
+### Supported features
+
+- Variable and function declarations
+- Control flow with `if`, `for`, `while`, `break` and `continue`
+- Struct and union types with pattern matching using `match`
+- Lists and maps with indexing, slicing and membership checks
+- Dataset queries with `from`, `where`, `select`, `sort by`, `skip` and `take`
+- Cross joins via multiple `from` clauses
+- Set operations on lists: `union`, `union all`, `except`, `intersect`
+- Built‑ins `print`, `len`, `count`, `avg`, `now` and `json`
+- HTTP requests using `fetch`
+- Dataset helpers `_load` and `_save` supporting CSV, TSV, JSON, JSONL and YAML
+- Package declarations and imports
+- Basic stream handling with `on` and `emit`
+- Placeholder generative helpers `_genText`, `_genEmbed` and `_genStruct`
+
 ### Unsupported features
 
 - The backend is still incomplete. Notable gaps include:
@@ -153,9 +169,12 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Agent declarations and intent blocks
 - Logic programming constructs (`fact`, `rule`, `query`)
 - Foreign function interface and extern objects
-- YAML dataset loading/saving
 - Full LLM integration for `_genText` and `_genStruct`
 - Concurrency primitives like `spawn` and channels
 - `try`/`catch` error handling
 - Agent initialization with field values
 - The `eval` builtin function
+- Reflection or macro facilities
+- Generic type parameters and methods inside `type` blocks
+- Asynchronous `async`/`await` constructs
+- Nested function declarations inside other functions

--- a/compile/cs/compiler.go
+++ b/compile/cs/compiler.go
@@ -62,6 +62,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		c.writeln("using System.Linq;")
 	}
 	c.writeln("using System.Text.Json;")
+	if c.helpers["_load"] || c.helpers["_save"] {
+		c.writeln("using YamlDotNet.Serialization;")
+	}
 	c.writeln("")
 	if prog.Package != "" {
 		c.writeln("namespace " + sanitizeName(prog.Package) + " {")
@@ -1150,6 +1153,7 @@ func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {
 		opts = v
 	}
 	c.use("_load")
+	c.useLinq = true
 	expr := fmt.Sprintf("_load(%s, %s)", path, opts)
 	if l.Type != nil && l.Type.Simple != nil {
 		typ := csType(l.Type)
@@ -1179,6 +1183,7 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
 		opts = v
 	}
 	c.use("_save")
+	c.useLinq = true
 	return fmt.Sprintf("_save(%s, %s, %s)", src, path, opts), nil
 }
 

--- a/compile/cs/compiler_test.go
+++ b/compile/cs/compiler_test.go
@@ -43,7 +43,10 @@ func TestCSCompiler_SubsetPrograms(t *testing.T) {
 		if err := os.MkdirAll(projDir, 0755); err != nil {
 			return nil, fmt.Errorf("mkdir: %w", err)
 		}
-		csproj := `<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>`
+		csproj := `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+  <ItemGroup><PackageReference Include="YamlDotNet" Version="13.3.1" /></ItemGroup>
+</Project>`
 		if err := os.WriteFile(filepath.Join(projDir, "app.csproj"), []byte(csproj), 0644); err != nil {
 			return nil, fmt.Errorf("write csproj: %w", err)
 		}
@@ -131,7 +134,10 @@ func runLeetCode(t *testing.T, id int, want string) {
 	if err := os.MkdirAll(proj, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	csproj := `<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>`
+	csproj := `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+  <ItemGroup><PackageReference Include="YamlDotNet" Version="13.3.1" /></ItemGroup>
+</Project>`
 	if err := os.WriteFile(filepath.Join(proj, "app.csproj"), []byte(csproj), 0644); err != nil {
 		t.Fatalf("write csproj: %v", err)
 	}

--- a/compile/cs/runtime.go
+++ b/compile/cs/runtime.go
@@ -273,6 +273,20 @@ func (c *Compiler) emitRuntime() {
 				c.indent++
 				c.writeln("return JsonSerializer.Deserialize<List<dynamic>>(text);")
 				c.indent--
+				c.writeln("case \"yaml\":")
+				c.indent++
+				c.writeln("var deser = new DeserializerBuilder().Build();")
+				c.writeln("var obj = deser.Deserialize<object>(new StringReader(text));")
+				c.writeln("if (obj is IList<object> lst) return lst.Cast<dynamic>().ToList();")
+				c.writeln("if (obj is IDictionary<object, object> m) {")
+				c.indent++
+				c.writeln("var d = new Dictionary<string, object>();")
+				c.writeln("foreach (var kv in m) d[Convert.ToString(kv.Key)] = kv.Value;")
+				c.writeln("return new List<dynamic> { d };")
+				c.indent--
+				c.writeln("}")
+				c.writeln("return new List<dynamic>();")
+				c.indent--
 				c.writeln("case \"tsv\":")
 				c.indent++
 				c.writeln("delim = '\t'; goto default;")
@@ -317,6 +331,14 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("case \"json\":")
 				c.indent++
 				c.writeln("File.WriteAllText(path, JsonSerializer.Serialize(rows));")
+				c.writeln("break;")
+				c.indent--
+				c.writeln("case \"yaml\":")
+				c.indent++
+				c.writeln("var ser = new SerializerBuilder().Build();")
+				c.writeln("var list = rows.ToList();")
+				c.writeln("var data = list.Count == 1 ? list[0] : (object)list;")
+				c.writeln("File.WriteAllText(path, ser.Serialize(data));")
 				c.writeln("break;")
 				c.indent--
 				c.writeln("case \"tsv\":")


### PR DESCRIPTION
## Summary
- support YAML format in `_load` and `_save` helpers for the C# target
- require `YamlDotNet` package in C# compiler tests
- expose YAML helpers via `using YamlDotNet.Serialization`
- update unsupported feature list for the C# backend
- **document supported features in the C# backend README**

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68567ba14e68832097c94f1a3cd7d342