### PR TITLE
Add extern object and now builtin support for F# backend

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -120,19 +120,22 @@ Mochi features are not yet available.
 * Pattern matching and conditional statements
 * Lists and maps with indexing and slicing
 * Query expressions with `where`, `sort`, `skip` and `take`
-* Built-in helpers: `len`, `count`, `avg`, `print`, `input`, `json`, `to_json`, `load`, `save`, `fetch`
+* Built-in helpers: `len`, `count`, `avg`, `now`, `print`, `input`, `json`, `to_json`, `load`, `save`, `fetch`
 * Record and union type declarations
 * Methods declared inside `type` blocks
 * Package imports using `import` and exported functions via `export fun`
 * Extern variable and function declarations
 * Extern type aliases
+* Extern object declarations
 
 ### Unsupported features
 
 The F# generator still lacks support for several language constructs:
 
-* Extern object declarations
 * Foreign function interface (FFI) calls
+* Generative AI helpers (`_genText`, `_genEmbed`, `_genStruct`)
+* YAML dataset support in `_load`/`_save`
+* `eval` builtin function
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Advanced dataset queries such as joins and grouping
 * Streams, agents and LLM `generate` blocks

--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -507,7 +507,12 @@ func (c *Compiler) compileExternType(et *parser.ExternTypeDecl) error {
 }
 
 func (c *Compiler) compileExternObject(eo *parser.ExternObjectDecl) error {
-	c.writeln("// extern object " + sanitizeName(eo.Name))
+	name := sanitizeName(eo.Name)
+	c.use("_extern")
+	c.writeln(fmt.Sprintf("let %s = _extern_get \"%s\"", name, eo.Name))
+	if c.env != nil {
+		c.env.SetVar(eo.Name, types.AnyType{}, true)
+	}
 	return nil
 }
 
@@ -1304,6 +1309,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("avg expects 1 arg")
 		}
 		return fmt.Sprintf("((Array.sum %s) / %s.Length)", args[0], args[0]), nil
+	case "now":
+		if len(args) != 0 {
+			return "", fmt.Errorf("now expects no args")
+		}
+		return "System.DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000000L", nil
 	case "json":
 		if len(args) != 1 {
 			return "", fmt.Errorf("json expects 1 arg")

--- a/compile/fs/infer.go
+++ b/compile/fs/infer.go
@@ -169,6 +169,8 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 			return types.StringType{}
 		case "avg":
 			return types.FloatType{}
+		case "now":
+			return types.Int64Type{}
 		default:
 			if c.env != nil {
 				if t, err := c.env.GetVar(p.Call.Func); err == nil {

--- a/compile/fs/runtime.go
+++ b/compile/fs/runtime.go
@@ -84,8 +84,15 @@ const (
       |> fun s -> "[" + s + "]"
   | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
 
-let _json (v: obj) : unit =
+        let _json (v: obj) : unit =
   printfn "%s" (_to_json v)`
+
+	helperExtern = `let externObjects = System.Collections.Generic.Dictionary<string,obj>()
+let register_extern (name: string) (obj: obj) : unit = externObjects[name] <- obj
+let _extern_get (name: string) : obj =
+  match externObjects.TryGetValue(name) with
+  | true, v -> v
+  | _ -> failwith ("extern object not registered: " + name)`
 )
 
 var helperMap = map[string]string{
@@ -95,4 +102,5 @@ var helperMap = map[string]string{
 	"_input":        helperInput,
 	"_fetch":        helperFetch,
 	"_json_helpers": helperToJson,
+	"_extern":       helperExtern,
 }


### PR DESCRIPTION
## Summary
- extend F# compiler: handle `extern object` declarations via `_extern_get`
- implement `now()` builtin
- keep type inference in sync
- provide F# runtime helper for extern registry
- document new support and note remaining gaps

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68567baac5d48320ba57c6300779592f