### PR TITLE
Add Scheme builtin functions

### DIFF
--- a/compile/scheme/README.md
+++ b/compile/scheme/README.md
@@ -299,9 +299,8 @@ The Scheme backend intentionally supports only a small subset of Mochi.  It does
 * concurrency primitives like `spawn`
 * advanced string slicing
 * list slicing and collection methods like `push` or `keys`
-* built-in helpers such as `count`, `avg`, `input` or `str`
 * logic programming predicates
-* dataset set operations like `union` or `intersect`
+* `load` and `save` only support JSON or JSONL formats, not CSV or YAML
 
 These features are recognised by the main Mochi interpreter but are ignored by the Scheme compiler.
 

--- a/compile/scheme/compiler.go
+++ b/compile/scheme/compiler.go
@@ -997,6 +997,30 @@ func (c *Compiler) compileCall(call *parser.CallExpr, recv string) (string, erro
 		}
 		parts = append(parts, "(newline)")
 		return "(begin " + strings.Join(parts, " ") + ")", nil
+	case "str":
+		if len(args) != 1 {
+			return "", fmt.Errorf("str expects 1 arg")
+		}
+		return fmt.Sprintf("(format \"~a\" %s)", args[0]), nil
+	case "count":
+		if len(args) != 1 {
+			return "", fmt.Errorf("count expects 1 arg")
+		}
+		root := rootNameExpr(call.Args[0])
+		if c.varType(root) == "string" || c.isStringExpr(call.Args[0]) {
+			return fmt.Sprintf("(string-length %s)", args[0]), nil
+		}
+		return fmt.Sprintf("(length %s)", args[0]), nil
+	case "avg":
+		if len(args) != 1 {
+			return "", fmt.Errorf("avg expects 1 arg")
+		}
+		return fmt.Sprintf("(let ((lst %s)) (if (null? lst) 0 (/ (apply + lst) (length lst))))", args[0]), nil
+	case "input":
+		if len(args) != 0 {
+			return "", fmt.Errorf("input expects no args")
+		}
+		return "(read-line)", nil
 	}
 	if recv != "" {
 		return fmt.Sprintf("(%s %s %s)", recv, call.Func, strings.Join(args, " ")), nil


### PR DESCRIPTION
## Summary
- support `str`, `count`, `avg` and `input` in the Scheme backend
- document remaining unsupported features and note JSON-only dataset helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68567db3603c8320a9e73f2f4bb97f32