### PR TITLE
Add extern object support in F# backend

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -126,18 +126,20 @@ Mochi features are not yet available.
 * Package imports using `import` and exported functions via `export fun`
 * Extern variable and function declarations
 * Extern type aliases
+* Extern object declarations
 
 ### Unsupported features
 
 The F# generator still lacks support for several language constructs:
 
-* Extern object declarations
 * Foreign function interface (FFI) calls
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Advanced dataset queries such as joins and grouping
 * Streams, agents and LLM `generate` blocks
 * Concurrency primitives like `spawn` and channels
 * Generic types, reflection and macro facilities
+* Error handling with `try`/`catch`
+* Asynchronous functions (`async`/`await`)
 * `model` declarations and agent initialization
 * Package declarations using `package`
 

--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -507,7 +507,19 @@ func (c *Compiler) compileExternType(et *parser.ExternTypeDecl) error {
 }
 
 func (c *Compiler) compileExternObject(eo *parser.ExternObjectDecl) error {
-	c.writeln("// extern object " + sanitizeName(eo.Name))
+	name := sanitizeName(eo.Name)
+	c.use("_extern")
+	c.writeln(fmt.Sprintf("let %s : obj =", name))
+	c.indent++
+	c.writeln(fmt.Sprintf("match Extern.tryGet %q with", eo.Name))
+	c.indent++
+	c.writeln("| Some v -> v")
+	c.writeln(fmt.Sprintf("| None -> failwith \"extern object not registered: %s\"", eo.Name))
+	c.indent--
+	c.indent--
+	if c.env != nil {
+		c.env.SetVar(eo.Name, types.AnyType{}, true)
+	}
 	return nil
 }
 

--- a/compile/fs/runtime.go
+++ b/compile/fs/runtime.go
@@ -86,6 +86,20 @@ const (
 
 let _json (v: obj) : unit =
   printfn "%s" (_to_json v)`
+
+	helperExtern = `module Extern =
+  open System.Collections.Generic
+  let registry = Dictionary<string,obj>()
+  let register (name: string) (v: obj) : unit =
+    registry[name] <- v
+  let tryGet (name: string) : obj option =
+    match registry.TryGetValue(name) with
+    | true, v -> Some v
+    | _ -> None
+  let get (name: string) : obj =
+    match tryGet name with
+    | Some v -> v
+    | None -> failwith (sprintf "extern object not registered: %s" name)`
 )
 
 var helperMap = map[string]string{
@@ -95,4 +109,5 @@ var helperMap = map[string]string{
 	"_input":        helperInput,
 	"_fetch":        helperFetch,
 	"_json_helpers": helperToJson,
+	"_extern":       helperExtern,
 }


### PR DESCRIPTION
## Summary
- implement extern object declarations in F# compiler
- add new F# runtime helper for extern object registry
- document extern objects as supported and list more unsupported features

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68567dd881ec83208af7c325a10e81d8