### PR TITLE
Expand C backend support

### DIFF
--- a/compile/c/README.md
+++ b/compile/c/README.md
@@ -90,6 +90,9 @@ features include:
  - methods declared inside `type` blocks
  - functions with multiple return values
  - map membership operations
+ - extern type declarations
+ - variadic functions
+ - closures that capture surrounding variables
 
 The backend now supports membership checks and `union`/`union all` operations
 for integer, float, and string lists, along with slicing and printing of string

--- a/compile/c/compiler.go
+++ b/compile/c/compiler.go
@@ -162,6 +162,14 @@ func (c *Compiler) compileProgram(prog *parser.Program) ([]byte, error) {
 		}
 	}
 	for _, s := range prog.Statements {
+		if s.Import != nil {
+			// import statements are ignored in the C backend
+			continue
+		}
+		if s.ExternType != nil {
+			// extern type declarations have no effect
+			continue
+		}
 		if s.Fun != nil {
 			if err := c.compileFun(s.Fun); err != nil {
 				return nil, err
@@ -448,6 +456,15 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		c.writeln("break;")
 	case s.Continue != nil:
 		c.writeln("continue;")
+	case s.Import != nil:
+		// imports are ignored at code generation time
+		return nil
+	case s.ExternType != nil:
+		// extern type declarations have no runtime effect
+		return nil
+	case s.ExternObject != nil:
+		// extern objects are not supported yet
+		return nil
 	default:
 		// unsupported
 	}


### PR DESCRIPTION
## Summary
- skip `import` and `extern type` declarations in C compilation
- ignore more statement types in C backend
- document additional unsupported C features

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68567dee0380832086054903d9a1cabb