### PR TITLE
Add load/save to Haskell backend

### DIFF
--- a/compile/hs/README.md
+++ b/compile/hs/README.md
@@ -1,112 +1,58 @@
 # Haskell Backend
 
-The Haskell backend converts Mochi programs into plain Haskell source code. It is
-useful for experimenting with the language or running Mochi code on systems where
-GHC is available. The backend only implements a small subset of Mochi features
-but is sufficient for many scripts and simple utilities.
+The Haskell backend translates Mochi programs into regular Haskell source code. It is primarily intended for experimentation or running Mochi on systems that already have the GHC toolchain installed. Only a small subset of the language is implemented but it suffices for many scripts and utilities.
 
-The compiler performs simple type inference to reduce occurrences of the
-unit type in generated code.
 ## Files
 
-- `compiler.go` – walks the Mochi AST and produces Haskell code
-- `compiler_test.go` – golden tests verifying the generated code executes
-  correctly
-- `helpers.go` – helper functions for indentation and name sanitisation
-- `runtime.go` – small runtime helpers inserted into generated programs
+- `compiler.go` – main code generator walking the AST
+- `compiler_test.go` – golden tests verifying generated code executes correctly
+- `helpers.go` – helper utilities for indentation and naming
+- `runtime.go` – minimal runtime helpers inserted on demand
 - `tools.go` – ensures `runhaskell`/`ghc` are available for tests
-
-## Runtime Helpers
-
-The file `runtime.go` defines a few Haskell utilities that are embedded on
- demand when code generation requires them:
-
-```haskell
-forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
-forLoop start end f = go start
-  where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
-
-whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
-whileLoop cond body = go ()
-  where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
-
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
-
-_indexString :: String -> Int -> String
-_indexString s i =
-  let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
-
-_input :: IO String
-_input = getLine
-
-_now :: IO Int
-_now = fmap round getPOSIXTime
-
-_json :: Aeson.ToJSON a => a -> IO ()
-_json v = BSL.putStrLn (Aeson.encode v)
-```
-【F:compile/hs/runtime.go†L1-L40】
-
-These helpers provide basic looping, averaging and safe string indexing
-functionality.
 
 ## Building
 
-Compile a Mochi source file to Haskell using `mochi build` with the `hs`
-target (or by giving the output file a `.hs` extension):
+Compile a Mochi program to Haskell using the build command:
 
 ```bash
 mochi build --target hs main.mochi -o main.hs
 ```
 
-The resulting `main.hs` can be executed with `runhaskell` or compiled with `ghc`
-just like any other Haskell program.
+The resulting `main.hs` can be executed with `runhaskell` or compiled with `ghc` just like any other Haskell program.
+
+## Supported Features
+
+The backend implements a small but practical subset of Mochi:
+
+- Function definitions and variable bindings
+- Basic expressions including `if`/`else` and arithmetic operators
+- `for` loops over ranges or lists and `while` loops
+- Lists and maps with literals and indexing
+- Builtin helpers: `len`, `count`, `avg`, `str`, `print`, `input`, `now`, `json`, `load` and `save`
+
+## Unsupported Features
+
+Several language constructs remain unimplemented:
+
+- `match` expressions and union types
+- Dataset query syntax like `from ... sort by ...`
+- Set literals and related operations
+- Generative AI, HTTP fetch and FFI bindings
+- Streams and long-lived agents
+- Struct and object types
+- Logic programming with `fact`, `rule` and `query` expressions
+- Package imports and module system
+- Concurrency primitives like `spawn` and channels
+- Reflection or macro facilities
+- Extern object declarations and package exports
+- Functions with multiple return values
+- Map membership operations
+- `test` blocks and expectations
 
 ## Tests
 
-Golden tests under `tests/compiler/hs` check both the produced Haskell code and
-its runtime behaviour. They are tagged `slow` as they invoke the Haskell
-toolchain. Run them with:
+Golden tests under `tests/compiler/hs` check both the produced Haskell code and its runtime behaviour. They are tagged `slow` because the Haskell toolchain is invoked:
 
 ```bash
 go test ./compile/hs -tags slow
 ```
-
-## Notes
-
-The Haskell backend currently supports a limited subset of Mochi: function
-definitions, if/else expressions, basic loops, lists, maps and a handful of
-built-in functions (`len`, `count`, `avg`, `str`, `print`, `now`, `json`). Map
-access relies on `Data.Map` when needed. Variable names are sanitised to avoid
-conflicts with Haskell keywords.
-
-## Status
-
-While useful for experimentation, the Haskell backend does not yet implement the
-full Mochi language. Unsupported features include:
-
-* `match` expressions and union types
-* Dataset query syntax like `from ... sort by ...`
-* Set literals and related operations
-* Generative AI, HTTP fetch and FFI bindings
-* Streams and long-lived agents
-* Struct and object types
-* Logic programming with `fact`, `rule` and `query` expressions
-* Package imports and module system
-* Dataset `load`/`save` operations
-* `test` blocks and expectations

--- a/compile/hs/runtime.go
+++ b/compile/hs/runtime.go
@@ -38,4 +38,50 @@ _now = fmap round getPOSIXTime
 
 _json :: Aeson.ToJSON a => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
 `


### PR DESCRIPTION
## Summary
- implement `_load` and `_save` helpers for the Haskell backend
- add compile support for `load` and `save` expressions
- document remaining unsupported features in the Haskell README
- reorganize Haskell backend README and describe supported features

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68567dd064508320ba7b2b219cd64a69