### PR TITLE
Add eval builtin support in Java backend

### DIFF
--- a/compile/java/README.md
+++ b/compile/java/README.md
@@ -1,206 +1,31 @@
 # Java Backend
 
-The Java backend compiles Mochi programs to plain Java source code. Generated files
-contain a `Main` class with a static `main` method if top-level statements are
-present.
+The Java backend generates plain Java source from Mochi programs. The emitted
+code contains a simple `Main` class with a `main` method when top-level
+statements are present.
 
 ## Files
 
-- `compiler.go` – main code generator walking the AST
-- `compiler_test.go` – golden tests executing generated programs
-- `helpers.go` – helper for sanitising identifiers
-- `tools.go` – utility ensuring `javac` is available
+- `compiler.go` – code generator walking the Mochi AST
+- `compiler_test.go` – golden tests that build and run the output
+- `helpers.go` – identifier sanitisation helpers
+- `tools.go` – utility that ensures `javac` is installed
 
-## Compilation
+## Supported Features
 
-The `Compile` method constructs the Java class, emits any function definitions
-then writes the body for `main`:
-
-```go
-// Compile generates Java code for prog.
-func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
-        if prog.Package != "" {
-                c.writeln("package " + sanitizeName(prog.Package) + ";")
-                c.writeln("")
-        }
-        c.writeln("public class Main {")
-        c.indent++
-        // collect function declarations and main statements
-        for _, s := range prog.Statements {
-                if s.Fun != nil {
-                        if err := c.compileFun(s.Fun); err != nil {
-                                return nil, err
-                        }
-                        c.writeln("")
-                        continue
-                }
-                c.mainStmts = append(c.mainStmts, s)
-        }
-        if len(c.mainStmts) > 0 {
-                c.writeln("public static void main(String[] args) {")
-                c.indent++
-                for _, s := range c.mainStmts {
-                        if err := c.compileStmt(s); err != nil {
-                                return nil, err
-                        }
-                }
-                c.indent--
-                c.writeln("}")
-        }
-        c.emitRuntime()
-        c.indent--
-        c.writeln("}")
-        return c.buf.Bytes(), nil
-}
-```
-【F:compile/java/compiler.go†L28-L76】
-
-Built-in functions like `print`, `len`, `str`, `input`, `count`, `avg`, `now` and `json` are
-translated directly inside `compilePrimary`:
-
-```go
-name := sanitizeName(p.Call.Func)
-if name == "print" {
-        if len(args) == 1 {
-                return "System.out.println(" + args[0] + ")", nil
-        }
-        expr := args[0]
-        for i := 1; i < len(args); i++ {
-                expr += " + \" \" + " + args[i]
-        }
-        return "System.out.println(" + expr + ")", nil
-}
-if name == "len" && len(args) == 1 {
-        return args[0] + ".length", nil
-}
-if name == "str" && len(args) == 1 {
-        return "String.valueOf(" + args[0] + ")", nil
-}
-if name == "input" && len(args) == 0 {
-        c.helpers["_input"] = true
-        return "_input()", nil
-}
-if name == "count" && len(args) == 1 {
-        if c.isMapExprByExpr(p.Call.Args[0]) {
-                return args[0] + ".size()", nil
-        }
-        if c.isStringExprByExpr(p.Call.Args[0]) {
-                return args[0] + ".length()", nil
-        }
-        return args[0] + ".length", nil
-}
-if name == "avg" && len(args) == 1 {
-        return fmt.Sprintf("(int) java.util.Arrays.stream(%s).average().orElse(0)", args[0]), nil
-}
-```
-【F:compile/java/compiler.go†L510-L548】
-
-Runtime helpers are injected only when referenced. The `emitRuntime` method
-currently defines `_input` and `_indexString` when required:
-
-```go
-func (c *Compiler) emitRuntime() {
-        if c.helpers["_input"] {
-                c.writeln("")
-                c.writeln("static java.util.Scanner _scanner = new java.util.Scanner(System.in);")
-                c.writeln("static String _input() {")
-                c.indent++
-                c.writeln("return _scanner.nextLine();")
-                c.indent--
-                c.writeln("}")
-        }
-        if c.helpers["_indexString"] {
-                c.writeln("")
-                c.writeln("static String _indexString(String s, int i) {")
-                c.indent++
-                c.writeln("char[] runes = s.toCharArray();")
-                c.writeln("if (i < 0) i += runes.length;")
-                c.writeln("if (i < 0 || i >= runes.length) throw new RuntimeException(\"index out of range\");")
-                c.writeln("return String.valueOf(runes[i]);")
-                c.indent--
-                c.writeln("}")
-        }
-}
-```
-【F:compile/java/compiler.go†L631-L674】
-
-Type references are resolved to Java types via `javaType`. Lists currently map to
-primitive arrays and maps use `java.util.Map` with boxed types:
-
-```go
-func (c *Compiler) javaType(t types.Type) string {
-        switch tt := t.(type) {
-        case types.IntType, types.Int64Type:
-                return "int"
-        case types.FloatType:
-                return "double"
-        case types.BoolType:
-                return "boolean"
-        case types.StringType:
-                return "String"
-        case types.ListType:
-                // only support list<int> -> int[] for now
-                return c.javaType(tt.Elem) + "[]"
-        case types.MapType:
-                key := c.javaType(tt.Key)
-                val := c.javaType(tt.Value)
-                key = boxedType(key)
-                val = boxedType(val)
-                return "java.util.Map<" + key + ", " + val + ">"
-        default:
-                return "Object"
-        }
-}
-```
-【F:compile/java/compiler.go†L582-L603】
-
-`tools.go` exposes `EnsureJavac` which attempts to install a Java compiler when
-missing. It supports apt-get on Linux and Homebrew on macOS:
-
-```go
-// EnsureJavac verifies that the Java compiler is installed. If missing, it attempts
-// a best-effort installation using apt-get on Linux or Homebrew on macOS.
-func EnsureJavac() error {
-        if _, err := exec.LookPath("javac"); err == nil {
-                return nil
-        }
-        switch runtime.GOOS {
-        case "linux":
-                if _, err := exec.LookPath("apt-get"); err == nil {
-                        cmd := exec.Command("apt-get", "update")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        if err := cmd.Run(); err != nil {
-                                return err
-                        }
-                        cmd = exec.Command("apt-get", "install", "-y", "openjdk-17-jdk")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        if err := cmd.Run(); err == nil {
-                                return nil
-                        }
-                }
-        case "darwin":
-                if _, err := exec.LookPath("brew"); err == nil {
-                        cmd := exec.Command("brew", "install", "openjdk")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        if err := cmd.Run(); err == nil {
-                                return nil
-                        }
-                }
-        }
-        if _, err := exec.LookPath("javac"); err == nil {
-                return nil
-        }
-        return fmt.Errorf("javac not found")
-}
-```
-【F:compile/java/tools.go†L1-L46】
+- Function declarations and top-level statements
+- Control flow with `if`, `for` and `while`
+- Primitive types (`int`, `float`, `bool`, `string`)
+- Lists and maps
+- Basic expressions and assignments
+- Built-ins `print`, `len`, `str`, `input`, `count`, `avg`, `now`, `json` and `eval`
+- List operations `concat`, `union`, `except`, `intersect` and `slice`
+- HTTP requests via `fetch`
+- Dataset helpers `load` and `save`
+- Generative `generate` blocks for text, embeddings and structs
+- Test blocks with `expect`
 
 ## Building
-
-Use the `mochi` CLI to compile a source file to Java:
 
 ```bash
 mochi build --target java main.mochi -o Main.java
@@ -210,21 +35,16 @@ java Main
 
 ## Tests
 
-Golden tests compile and run programs under both `tests/compiler/java` and
-`tests/compiler/valid`. They are marked with the `slow` build tag as they invoke
-`javac` and `java`:
-
 ```bash
 go test ./compile/java -tags slow
 ```
-
-The tests automatically skip if no Java compiler is detected.
-The `LeetCodeExamples` test attempts to compile the first thirty solutions in
-`examples/leetcode`. Programs using unsupported features are reported as skipped.
+The tests skip automatically if `javac` is not available and attempt to compile
+a selection of LeetCode solutions.
 
 ## Unsupported Features
 
-The Java backend currently lacks several Mochi features supported by other compilers:
+The Java backend currently lacks many Mochi features supported by other
+compilers:
 
 - Pattern matching expressions
 - Union types and tagged unions
@@ -237,10 +57,10 @@ The Java backend currently lacks several Mochi features supported by other compi
 - Reflection or macro facilities
 - Extern variable, type and object declarations
 - Event emission and intent handlers (`emit`, `on`)
-- The `eval` builtin function
 - Methods declared inside `type` blocks
 - Agent initialization with field values
 - List set operation `union all`
 - YAML dataset loading/saving
+- Destructuring bindings in `let` and `var` statements
 
 Simple `from` queries used by the LeetCode examples are now supported.

--- a/compile/java/compiler.go
+++ b/compile/java/compiler.go
@@ -972,6 +972,10 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			c.helpers["_json"] = true
 			return "_json(" + args[0] + ")", nil
 		}
+		if name == "eval" && len(args) == 1 {
+			c.helpers["_eval"] = true
+			return "_eval(" + args[0] + ")", nil
+		}
 		if c.env != nil {
 			if _, ok := c.env.GetFunc(p.Call.Func); !ok {
 				if t, err := c.env.GetVar(p.Call.Func); err == nil {
@@ -1440,6 +1444,23 @@ func (c *Compiler) emitRuntime() {
 		c.writeln("static void expect(boolean cond) {")
 		c.indent++
 		c.writeln("if (!cond) throw new RuntimeException(\"expect failed\");")
+		c.indent--
+		c.writeln("}")
+	}
+	if c.helpers["_eval"] {
+		c.writeln("")
+		c.writeln("static Object _eval(String code) {")
+		c.indent++
+		c.writeln("try {")
+		c.indent++
+		c.writeln("javax.script.ScriptEngine eng = new javax.script.ScriptEngineManager().getEngineByName(\"javascript\");")
+		c.writeln("return eng.eval(code);")
+		c.indent--
+		c.writeln("} catch (Exception e) {")
+		c.indent++
+		c.writeln("throw new RuntimeException(e);")
+		c.indent--
+		c.writeln("}")
 		c.indent--
 		c.writeln("}")
 	}


### PR DESCRIPTION
## Summary
- implement `eval` builtin for Java compiler
- generate runtime helper for executing JavaScript code with `javax.script` engine
- document current unsupported features and note destructuring
- reorganize Java backend README with high level overview and supported features

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68567dcd90d0832096c09d9454386f16