### PR TITLE
Add IO-aware loops to Haskell backend

### DIFF
--- a/compile/hs/README.md
+++ b/compile/hs/README.md
@@ -87,18 +87,25 @@ toolchain. Run them with:
 go test ./compile/hs -tags slow
 ```
 
-## Notes
+## Supported Features
 
-The Haskell backend currently supports a limited subset of Mochi: function
-definitions, if/else expressions, basic loops, lists, maps and a handful of
-built-in functions (`len`, `count`, `avg`, `str`, `print`, `now`, `json`). Map
-access relies on `Data.Map` when needed. Variable names are sanitised to avoid
-conflicts with Haskell keywords.
+The backend covers a modest portion of the language that is sufficient for
+simple scripts:
 
-## Status
+* Function definitions and calls
+* If/else expressions
+* Range and collection `for` loops
+* `while` loops
+* Lists and maps (using `Data.Map` when needed)
+* Basic built-ins: `len`, `count`, `avg`, `str`, `print`, `input`, `now`, `json`
 
-While useful for experimentation, the Haskell backend does not yet implement the
-full Mochi language. Unsupported features include:
+Runtime helpers such as `_now` and `_json` are only embedded when the program
+uses them. Loops executed in `main` use `forLoopIO`/`whileLoopIO` so side effects
+run correctly.
+
+## Unsupported Features
+
+Most of Mochi is not yet available:
 
 * `match` expressions and union types
 * Dataset query syntax like `from ... sort by ...`
@@ -110,3 +117,7 @@ full Mochi language. Unsupported features include:
 * Package imports and module system
 * Dataset `load`/`save` operations
 * `test` blocks and expectations
+* Concurrency primitives like `spawn` and channels
+* Error handling with `try`/`catch`
+* Asynchronous functions (`async`/`await`)
+* Generic type parameters and reflection features

--- a/compile/hs/runtime.go
+++ b/compile/hs/runtime.go
@@ -1,6 +1,6 @@
 package hscode
 
-const runtime = `
+const runtimeBase = `
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
@@ -8,15 +8,6 @@ forLoop start end f = go start
             case f i of
               Just v -> Just v
               Nothing -> go (i + 1)
-         | otherwise = Nothing
-
-whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
-whileLoop cond body = go ()
-  where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
          | otherwise = Nothing
 
 avg :: Real a => [a] -> Double
@@ -32,10 +23,47 @@ _indexString s i =
 
 _input :: IO String
 _input = getLine
+`
 
+const runtimeIO = `
+forLoopIO :: Int -> Int -> (Int -> IO (Maybe a)) -> IO (Maybe a)
+forLoopIO start end f = go start
+  where
+    go i | i < end = do
+            r <- f i
+            case r of
+              Just v -> pure (Just v)
+              Nothing -> go (i + 1)
+         | otherwise = pure Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+whileLoopIO :: IO Bool -> IO (Maybe a) -> IO (Maybe a)
+whileLoopIO cond body = go
+  where
+    go = do
+      c <- cond
+      if c then do
+            r <- body
+            case r of
+              Just v -> pure (Just v)
+              Nothing -> go
+         else pure Nothing
+`
+
+const runtimeTime = `
 _now :: IO Int
 _now = fmap round getPOSIXTime
+`
 
+const runtimeJSON = `
 _json :: Aeson.ToJSON a => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 `

--- a/tests/compiler/hs/for_loop.hs.out
+++ b/tests/compiler/hs/for_loop.hs.out
@@ -26,7 +26,38 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+forLoopIO :: Int -> Int -> (Int -> IO (Maybe a)) -> IO (Maybe a)
+forLoopIO start end f = go start
+  where
+    go i | i < end = do
+            r <- f i
+            case r of
+              Just v -> pure (Just v)
+              Nothing -> go (i + 1)
+         | otherwise = pure Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+whileLoopIO :: IO Bool -> IO (Maybe a) -> IO (Maybe a)
+whileLoopIO cond body = go
+  where
+    go = do
+      c <- cond
+      if c then do
+            r <- body
+            case r of
+              Just v -> pure (Just v)
+              Nothing -> go
+         else pure Nothing
+
 
 main :: IO ()
 main = do
-    let _ = forLoop 1 4 (\i -> Nothing <$ (print (i))) in return ()
+    forLoopIO 1 4 (\i -> Nothing <$ (print (i))) >> return ()


### PR DESCRIPTION
## Summary
- support side-effecting loops in the Haskell backend
- embed additional runtime helpers only when required
- document supported and unsupported features in the Haskell backend README
- update golden output for `for_loop`

## Testing
- `go test ./compile/hs -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68567bae1d848320bdc7a85723ab69c5