### PR TITLE
Implement extern object support in C backend

### DIFF
--- a/compile/c/README.md
+++ b/compile/c/README.md
@@ -84,12 +84,13 @@ features include:
 - union type declarations and generics
 - logic programming constructs (`fact`, `rule`, `query`)
 - reflection or macro facilities
-- extern object declarations and package exports
+ - package exports (extern objects are now supported)
 - nested list types other than `list<list<int>>`
 - set literals and set operations
  - methods declared inside `type` blocks
  - functions with multiple return values
  - map membership operations
+ - iterating over maps with `for` loops
  - extern type declarations
  - variadic functions
  - closures that capture surrounding variables


### PR DESCRIPTION
## Summary
- handle `extern object` declarations in the C compiler
- detect missing extern objects at runtime
- document new limitations and mark extern objects as supported

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_68568c2e4ba8832091483e0ea9962ce1