### PR TITLE
Add struct constructors to Clojure backend

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -132,6 +132,7 @@ The current implementation focuses on a minimal subset of Mochi. It supports:
 - Indexing and slicing for lists, strings and maps
 - Simple `match` expressions on constants and struct literals with field access
 - `break` and `continue` statements
+- Struct constructors for user-defined types
 
 ### Unsupported Features
 
@@ -151,7 +152,8 @@ in the example programs. In particular:
 - List collection methods such as `push`
 - Streams and event-driven agents
 - Concurrency primitives such as `spawn` and channels
-- Struct declarations are ignored and union types are not emitted
+- Union types are not emitted
+- Async execution with `async`/`await`
 - Error handling with `try`/`catch` blocks
 - Reflection or macro facilities
 - Package and `export` statements for modules

--- a/compile/clj/helpers.go
+++ b/compile/clj/helpers.go
@@ -195,3 +195,26 @@ func isIdentExpr(e *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+// isListPushCall returns the variable name and argument if the expression is a
+// simple list.push(x) call.
+func isListPushCall(e *parser.Expr) (string, *parser.Expr, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return "", nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", nil, false
+	}
+	p := u.Value
+	if p.Target.Selector == nil || len(p.Target.Selector.Tail) != 1 {
+		return "", nil, false
+	}
+	if p.Target.Selector.Tail[0] != "push" {
+		return "", nil, false
+	}
+	if len(p.Ops) != 1 || p.Ops[0].Call == nil || len(p.Ops[0].Call.Args) != 1 {
+		return "", nil, false
+	}
+	return p.Target.Selector.Root, p.Ops[0].Call.Args[0], true
+}

--- a/tests/compiler/clj/method.clj.out
+++ b/tests/compiler/clj/method.clj.out
@@ -1,5 +1,9 @@
 (ns main)
 
+(defn Circle [radius]
+  {:__name "Circle" :radius radius}
+)
+
 (defn Circle_area [self]
   (let [radius (:radius self)]
     (try


### PR DESCRIPTION
## Summary
- implement struct constructors in the Clojure compiler
- recognize `list.push` in expression statements
- document struct constructor support and new unsupported async feature
- update Clojure golden file

## Testing
- `go test ./compile/clj -run TestClojureCompiler_GoldenOutput -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68568c39f0b48320a191d143824f9595