### PR TITLE
Add membership checks to C++ backend

### DIFF
--- a/compile/cpp/README.md
+++ b/compile/cpp/README.md
@@ -223,6 +223,7 @@ Dataset queries support `where`, `skip`, `take`, `sort by` and basic `group by` 
 * Built‑in functions `print`, `len` and `str`
 * Dataset queries with filtering, sorting, pagination and simple grouping
 * List operators `union`, `except` and `intersect`
+* Membership tests using `in`
 
 ### Unsupported features
 
@@ -242,5 +243,5 @@ Some LeetCode solutions use language constructs that the C++ backend can't yet t
 * Generic type parameters and methods inside `type` blocks
 * Nested function declarations inside other functions
 * Iteration over map key/value pairs
-* Map membership operations using `in`
 * Asynchronous `async`/`await` constructs
+* Built-in functions `json`, `now`, `count` and `avg`

--- a/compile/cpp/compiler.go
+++ b/compile/cpp/compiler.go
@@ -561,6 +561,23 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) string {
 			typ = "string"
 			continue
 		}
+		if op.Op == "in" {
+			if strings.HasPrefix(rtyp, "vector<") {
+				expr = fmt.Sprintf("(find(%s.begin(), %s.end(), %s) != %s.end())", rhs, rhs, expr, rhs)
+				typ = "bool"
+				continue
+			}
+			if strings.HasPrefix(rtyp, "unordered_map<") {
+				expr = fmt.Sprintf("(%s.count(%s) != 0)", rhs, expr)
+				typ = "bool"
+				continue
+			}
+			if rtyp == "string" {
+				expr = fmt.Sprintf("(%s.find(%s) != string::npos)", rhs, expr)
+				typ = "bool"
+				continue
+			}
+		}
 		if op.Op == "union" {
 			c.helpers["union"] = true
 			expr = fmt.Sprintf("_union(%s, %s)", expr, rhs)

--- a/compile/cpp/inference.go
+++ b/compile/cpp/inference.go
@@ -267,7 +267,7 @@ func guessBinaryResultType(ltyp, op, rtyp string) string {
 			return "int"
 		}
 		return ltyp
-	case "==", "!=", "<", ">", "<=", ">=", "&&", "||":
+	case "==", "!=", "<", ">", "<=", ">=", "&&", "||", "in":
 		return "bool"
 	}
 	return ltyp


### PR DESCRIPTION
## Summary
- implement `in` operator for C++ code generation
- infer boolean result type for membership
- document new capability and note remaining unsupported built-ins in the C++ README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68568c3eb2a48320b0bee7eb1c2c6f75