### PR TITLE
Add dataset helpers to Pascal backend

### DIFF
--- a/compile/pas/README.md
+++ b/compile/pas/README.md
@@ -145,6 +145,7 @@ constructs:
 - Struct types and simple record literals
 - Function definitions and calls
 - List and map literals with indexing
+- Dataset helpers `fetch`, `load` and `save`
 - Package declarations and importing of local packages
 
 ## Unsupported features
@@ -157,8 +158,9 @@ supported include:
 - Agents, streams and the `emit` keyword
 - Generative model blocks (`generate` and `model`)
 - The foreign function interface (`import`/`extern`)
-- Dataset helpers (`fetch`, `load`, `save`)
 - Logic programming constructs (`fact`, `rule`, `query`)
 - Anonymous function literals (`fun` expressions)
 - Methods on types
 - Function types and first-class functions
+- List slicing with `[start:end]` ranges
+- Set operations (`union`, `except`, `intersect`)


### PR DESCRIPTION
## Summary
- implement `_fetch`, `_load`, `_save` helpers for Pascal code generation
- register helpers and emit runtime functions
- import needed units in generated Pascal code
- document the new capability and mention newly discovered unsupported features

## Testing
- `go test ./compile/pas`

------
https://chatgpt.com/codex/tasks/task_e_68568c5d006c8320855fc23547f34485