### PR TITLE
Update Fortran compiler golden tests

### DIFF
--- a/compile/fortran/README.md
+++ b/compile/fortran/README.md
@@ -15,12 +15,16 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 ## Supported features
 
 - `let` bindings for integers, floats, strings and lists
-- `if` statements
+- `if` statements and expressions
 - `for` loops over numeric ranges
+- `while` loops
+- `break` and `continue`
+- `test` blocks and `expect` statements
 - function definitions returning integers, floats, strings or lists
 - list operations: `union`, `except` and `intersect` on integer, float and string lists
 - built-ins: `len`, `append`, `count`, `avg`, `str`, `now`
 - printing via `print()`
+- `package` and `export` declarations (ignored during code generation)
 
 ## Unsupported features
 
@@ -32,8 +36,9 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 - pattern matching with `match`
 - agents, streams and logic programming constructs (`fact`, `rule`, `query`)
 - foreign imports and dataset helpers (`fetch`, `load`, `save`)
-- anonymous functions and `if` used as an expression
-- package and `export` declarations
+- anonymous functions
+- import statements and extern declarations
+- event handlers (`on`) and `emit` statements
 - type declarations using `type` blocks
 - generative blocks and model declarations
 - any other built-ins not listed above


### PR DESCRIPTION
## Summary
- fix whitespace handling around helper functions in Fortran compiler
- add `blank()` helper for writing empty lines

## Testing
- `go test ./compile/fortran -tags slow -run TestFortranCompiler_GoldenOutput -v`

------
https://chatgpt.com/codex/tasks/task_e_68568c4e16a88320bc316beca9f32f33