### PR TITLE
Add eval builtin to C# compiler

### DIFF
--- a/compile/cs/README.md
+++ b/compile/cs/README.md
@@ -161,6 +161,7 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Package declarations and imports
 - Basic stream handling with `on` and `emit`
 - Placeholder generative helpers `_genText`, `_genEmbed` and `_genStruct`
+- Test blocks with `expect`
 
 ### Unsupported features
 
@@ -174,7 +175,8 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Concurrency primitives like `spawn` and channels
 - `try`/`catch` error handling
 - Agent initialization with field values
-- The `eval` builtin function
 - Reflection or macro facilities
 - Generic type parameters and methods inside `type` blocks
 - Asynchronous `async`/`await` constructs
+- Set collections (`set<T>`) and related operations
+- Destructuring bindings in `let` and `var` statements

--- a/compile/cs/runtime.go
+++ b/compile/cs/runtime.go
@@ -358,6 +358,13 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("}")
 				c.indent--
 				c.writeln("}")
+			case "_eval":
+				c.writeln("static dynamic _eval(string code) {")
+				c.indent++
+				c.writeln("var dt = new System.Data.DataTable();")
+				c.writeln("return dt.Compute(code, string.Empty);")
+				c.indent--
+				c.writeln("}")
 			case "_genText":
 				c.writeln("static string _genText(string prompt, string model, Dictionary<string, object> p) {")
 				c.indent++


### PR DESCRIPTION
## Summary
- implement `eval` builtin in the C# backend
- detect `eval` calls during program scanning and add required using
- generate `_eval` helper in runtime using `DataTable.Compute`
- document new support and list additional unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68569dbbc7608320b92f0075f36c9a44