### PR TITLE
Improve C# backend unsupported feature reporting

### DIFF
--- a/compile/cs/README.md
+++ b/compile/cs/README.md
@@ -156,6 +156,7 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Cross joins via multiple `from` clauses
 - Set operations on lists: `union`, `union all`, `except`, `intersect`
 - Built‑ins `print`, `len`, `count`, `avg`, `now` and `json`
+- User input via `input`
 - HTTP requests using `fetch`
 - Dataset helpers `_load` and `_save` supporting CSV, TSV, JSON, JSONL and YAML
 - Package declarations and imports
@@ -178,3 +179,6 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Reflection or macro facilities
 - Generic type parameters and methods inside `type` blocks
 - Asynchronous `async`/`await` constructs
+- Cross-language `import` statements
+- Extern variable, function and type declarations
+- Set collections and the `_waitAll` helper

--- a/compile/cs/compiler.go
+++ b/compile/cs/compiler.go
@@ -492,8 +492,14 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 			return c.compilePackageImport(alias, s.Import.Path, s.Pos.Filename)
 		}
 		return fmt.Errorf("foreign imports not supported")
+	case s.Agent != nil:
+		return fmt.Errorf("agent declarations are not supported")
+	case s.ExternType != nil, s.ExternVar != nil, s.ExternFun != nil, s.ExternObject != nil:
+		return fmt.Errorf("extern declarations are not supported")
+	case s.Fact != nil, s.Rule != nil:
+		return fmt.Errorf("logic programming is not supported")
 	default:
-		// ignore other statements in minimal compiler
+		return fmt.Errorf("unsupported statement")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- flag agent, extern and logic statements as unsupported in the C# compiler
- document `input` builtin in C# README
- list additional unsupported features in C# README

## Testing
- `go test ./compile/cs -run TestDummy`

------
https://chatgpt.com/codex/tasks/task_e_68569de749008320b4f0ca42b8f11134