### PR TITLE
Add C++ map iteration and update docs

### DIFF
--- a/compile/cpp/README.md
+++ b/compile/cpp/README.md
@@ -242,6 +242,9 @@ Some LeetCode solutions use language constructs that the C++ backend can't yet t
 * Reflection or macro facilities
 * Generic type parameters and methods inside `type` blocks
 * Nested function declarations inside other functions
-* Iteration over map key/value pairs
 * Asynchronous `async`/`await` constructs
 * Built-in functions `json`, `now`, `count` and `avg`
+* Error handling with `try`/`catch`
+* Variadic functions
+* Functions with multiple return values
+* Closures that capture surrounding variables


### PR DESCRIPTION
## Summary
- handle map iteration in C++ backend
- document new unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68569dddb34883209307d0640b2c2ec7