### PR TITLE
Add Fortran import support and update docs

### DIFF
--- a/compile/fortran/README.md
+++ b/compile/fortran/README.md
@@ -25,6 +25,7 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 - built-ins: `len`, `append`, `count`, `avg`, `str`, `now`
 - printing via `print()`
 - `package` and `export` declarations (ignored during code generation)
+- `import` statements emit Fortran `include` lines
 
 ## Unsupported features
 
@@ -37,7 +38,9 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 - agents, streams and logic programming constructs (`fact`, `rule`, `query`)
 - foreign imports and dataset helpers (`fetch`, `load`, `save`)
 - anonymous functions
-- import statements and extern declarations
+- extern declarations
+- slice assignments like `xs[0:1] = sub`
+- range loops with step values other than `1`
 - event handlers (`on`) and `emit` statements
 - type declarations using `type` blocks
 - generative blocks and model declarations

--- a/compile/fortran/compiler.go
+++ b/compile/fortran/compiler.go
@@ -87,8 +87,8 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 			funs = append(funs, s.Fun)
 		case s.Test != nil:
 			tests = append(tests, s.Test)
-		case s.Import != nil, s.ExternType != nil, s.ExternVar != nil, s.ExternFun != nil, s.ExternObject != nil:
-			// ignore foreign imports and extern declarations
+		case s.ExternType != nil, s.ExternVar != nil, s.ExternFun != nil, s.ExternObject != nil:
+			// ignore extern declarations
 		default:
 			mainStmts = append(mainStmts, s)
 		}
@@ -542,8 +542,13 @@ func (c *Compiler) compileStmt(s *parser.Statement, retVar string) error {
 		c.writeln("exit")
 	case s.Continue != nil:
 		c.writeln("cycle")
-	case s.Import != nil, s.ExternType != nil, s.ExternVar != nil, s.ExternFun != nil, s.ExternObject != nil:
-		// ignore import and extern declarations
+	case s.Import != nil:
+		if s.Import.Lang == nil || *s.Import.Lang == "fortran" {
+			path := strings.Trim(s.Import.Path, "\"")
+			c.writeln(fmt.Sprintf("include '%s'", path))
+		}
+	case s.ExternType != nil, s.ExternVar != nil, s.ExternFun != nil, s.ExternObject != nil:
+		// ignore extern declarations
 	case s.Expr != nil:
 		if call, ok := printCall(s.Expr.Expr); ok {
 			args := make([]string, len(call.Args))

--- a/tests/compiler/fortran/import_stmt.f90.out
+++ b/tests/compiler/fortran/import_stmt.f90.out
@@ -1,0 +1,5 @@
+program main
+  implicit none
+  include 'mylib.f90'
+  print *, 42_8
+end program main

--- a/tests/compiler/fortran/import_stmt.mochi
+++ b/tests/compiler/fortran/import_stmt.mochi
@@ -1,0 +1,3 @@
+import "mylib.f90"
+
+print(42)


### PR DESCRIPTION
## Summary
- support `import` statements in the Fortran backend by emitting `include` lines
- document the new feature and mention more unsupported functionality
- add a small test for Fortran import handling

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856abb9c3948320a24c681dae022263