### PR TITLE
Add range() support to Zig backend

### DIFF
--- a/compile/zig/README.md
+++ b/compile/zig/README.md
@@ -279,16 +279,17 @@ LeetCode solutions:
   operate over CSV-style input
 * advanced string slicing (step values) and indexing on assignment
 * iteration over map key/value pairs (only key iteration is implemented)
-* Python-style loops like `for i in range(n)`
 * functions with multiple return values
 * generic type parameters
 * nested list types beyond one dimension
 * user-defined structs and union types
+* struct literals
 * built-in helpers like `fetch`, `load`, `save` and `generate`
 * logic programming constructs (`fact`, `rule`, `query`)
 * concurrency features such as streams or `spawn`
 * anonymous function expressions (`fun` values)
 * foreign imports and `extern` declarations
+* automatic language imports (`import python "..." auto`)
 * agent declarations and `on` handlers
 * intent functions within agents
 * extern object declarations


### PR DESCRIPTION
## Summary
- extend Zig compiler to compile `for` loops using `range()`
- document additional unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856abc564208320ab1d1fcbbb4ccf21