### PR TITLE
Add sorting with joins, document unsupported features

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,11 +610,15 @@ implemented across all backends:
 * Agent declarations and intent blocks with persistent state
 * Agent initialization with field values
 * Right and outer joins in dataset queries
+* Sorting or pagination when joins are used
 * Destructuring bindings in `let` and `var` statements
 * YAML dataset loading and saving
 * Agent and stream constructs (`agent`, `on`, `emit`)
 * Model declarations (`model` blocks)
+* Full LLM integration for `generate` blocks
 * Dataset queries with outer joins or complex aggregation
+* The `eval` builtin function
+* Generic methods inside `type` blocks
 * Pattern matching on union variants
 * Nested recursive functions inside other functions
 * Foreign imports and `extern` declarations

--- a/compile/cs/README.md
+++ b/compile/cs/README.md
@@ -154,6 +154,7 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Lists and maps with indexing, slicing and membership checks
 - Dataset queries with `from`, `where`, `select`, `sort by`, `skip` and `take`
 - Cross joins via multiple `from` clauses
+- Sorting and pagination with joins
 - Set operations on lists: `union`, `union all`, `except`, `intersect`
 - Built‑ins `print`, `len`, `count`, `avg`, `now` and `json`
 - HTTP requests using `fetch`
@@ -167,8 +168,7 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 
 - The backend is still incomplete. Notable gaps include:
  - Outer joins in dataset queries
-- Sorting, pagination or grouping when joins are used
-- Agent declarations and intent blocks
+ - Agent declarations and intent blocks
 - Logic programming constructs (`fact`, `rule`, `query`)
 - Foreign function interface and extern objects
 - Full LLM integration for `_genText` and `_genStruct`

--- a/compile/cs/compiler.go
+++ b/compile/cs/compiler.go
@@ -1066,6 +1066,15 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			buf.WriteString(indent + "}\n")
 		}
 		buf.WriteString("\t}\n")
+		if sortExpr != "" {
+			buf.WriteString(fmt.Sprintf("\t_res = _res.OrderBy(%s => %s).ToList();\n", v, sortExpr))
+		}
+		if skipExpr != "" {
+			buf.WriteString(fmt.Sprintf("\t_res = _res.Skip(%s).ToList();\n", skipExpr))
+		}
+		if takeExpr != "" {
+			buf.WriteString(fmt.Sprintf("\t_res = _res.Take(%s).ToList();\n", takeExpr))
+		}
 		buf.WriteString("\treturn _res;\n")
 		buf.WriteString("})()")
 		return buf.String(), nil


### PR DESCRIPTION
## Summary
- support sorting and pagination when query joins are present
- document new limitations in README
- update C# backend docs for new feature

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856b2700acc832088a531e0340902b4