### PR TITLE
Add extern type support to C backend

### DIFF
--- a/compile/c/README.md
+++ b/compile/c/README.md
@@ -34,6 +34,7 @@ Additional features include:
 - test blocks and `expect` statements compiled as helper functions
 - `if` expressions for conditional values
 - anonymous `fun` expressions (without captured variables) compiled to static functions
+- `extern type` declarations mapped to opaque C structs
 
 ## Building
 
@@ -74,26 +75,30 @@ features include:
 
 - `map` types
 - query expressions such as `from`/`sort by`/`select`
- - enum and union definitions
+- enum and union definitions
 - agent-related constructs (`agent`, `stream`, `intent`)
 - generative `generate` blocks and model definitions
 - dataset helpers such as `fetch`, `load`, `save` and SQL-style `from ...` queries
- - full pattern matching with `match` (simple constant matches are supported)
+- full pattern matching with `match` (simple constant matches are supported)
 - foreign function interface via `import` and package declarations
 - concurrency primitives like `spawn` and channels
 - union type declarations and generics
 - logic programming constructs (`fact`, `rule`, `query`)
 - reflection or macro facilities
- - package exports (extern objects are now supported)
+- package exports (extern objects are now supported)
 - nested list types other than `list<list<int>>`
 - set literals and set operations
- - methods declared inside `type` blocks
- - functions with multiple return values
- - map membership operations
- - iterating over maps with `for` loops
- - extern type declarations
- - variadic functions
- - closures that capture surrounding variables
+- methods declared inside `type` blocks
+- functions with multiple return values
+- map membership operations
+- iterating over maps with `for` loops
+- variadic functions
+- closures that capture surrounding variables
+- agent initialization with field values
+- destructuring bindings in `let` and `var` statements
+- YAML dataset loading and saving
+- right and outer joins in dataset queries
+- nested recursive functions inside other functions
 
 The backend now supports membership checks and `union`/`union all` operations
 for integer, float, and string lists, along with slicing and printing of string


### PR DESCRIPTION
## Summary
- handle `extern type` declarations in C compiler
- document new capability and note other missing features in `compile/c/README.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856b25a88e48320aafd85361c83237a