### PR TITLE
Add JSON/YAML dataset support for Clojure backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,13 @@ implemented across all backends:
 * Pattern matching on union variants
 * Nested recursive functions inside other functions
 * Foreign imports and `extern` declarations
+* Functions with multiple return values
+* Variadic functions
+* Methods declared inside `type` blocks
+* Closures capturing surrounding variables
+* Enum and additional union type declarations
+* Map membership checks and iterating over maps in `for` loops
+* Extern type declarations
 
 ## Benchmarks
 

--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -123,7 +123,7 @@ execute correctly using the Clojure backend.
 The current implementation focuses on a minimal subset of Mochi. It supports:
 
 - Map literals
-- Dataset helpers `load` and `save` for CSV files
+- Dataset helpers `load` and `save` for CSV, JSON, JSONL and YAML files
 - Simple `import` statements for Clojure namespaces
 - Basic `group by` queries
 - Built‑in helpers such as `count`, `avg`, `now`, `input`, `json` and `keys`

--- a/compile/clj/runtime.go
+++ b/compile/clj/runtime.go
@@ -80,6 +80,23 @@ const (
                (slurp path))]
     (cond
       (= fmt "csv") (_parse_csv text header delim)
+      (= fmt "tsv") (_parse_csv text header "\t")
+      (= fmt "json")
+        (let [data (clojure.data.json/read-str text :key-fn keyword)]
+          (cond
+            (map? data) [data]
+            (sequential? data) (vec data)
+            :else []))
+      (= fmt "jsonl")
+        (->> (clojure.string/split-lines text)
+             (remove clojure.string/blank?)
+             (mapv #(clojure.data.json/read-str % :key-fn keyword)))
+      (= fmt "yaml")
+        (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
+          (cond
+            (instance? java.util.Map y) [(into {} y)]
+            (instance? java.util.List y) (mapv #(into {} %) y)
+            :else []))
       :else [])) )
 `
 
@@ -87,16 +104,39 @@ const (
   (let [fmt (get opts :format "csv")
         header (get opts :header false)
         delim (first (or (get opts :delimiter ",") ","))
-        headers (if (seq rows) (sort (keys (first rows))) [])
-        lines (concat
-                (when header [(clojure.string/join delim headers)])
-                (map (fn [r]
-                       (clojure.string/join delim (map #(str (get r % "")) headers)))
-                     rows))
-        out (str (clojure.string/join "\n" lines) "\n")]
-    (if (or (nil? path) (= path "") (= path "-"))
-      (print out)
-      (spit path out))) )
+        headers (if (seq rows) (sort (keys (first rows))) [])]
+    (cond
+      (= fmt "csv")
+        (let [lines (concat
+                      (when header [(clojure.string/join delim headers)])
+                      (map (fn [r]
+                             (clojure.string/join delim (map #(str (get r % "")) headers)))
+                           rows))
+              out (str (clojure.string/join "\n" lines) "\n")]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print out)
+            (spit path out)))
+      (= fmt "tsv")
+        (_save rows path (assoc opts :format "csv" :delimiter "\t"))
+      (= fmt "json")
+        (let [out (clojure.data.json/write-str rows)]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print out)
+            (spit path out)))
+      (= fmt "jsonl")
+        (let [out (clojure.string/join "\n" (map #(clojure.data.json/write-str %) rows))]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print (str out "\n"))
+            (spit path (str out "\n"))))
+      (= fmt "yaml")
+        (let [yaml (org.yaml.snakeyaml.Yaml.)
+              out (.dump yaml (clojure.walk/keywordize-keys
+                             (if (= 1 (count rows)) (first rows) rows)))]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print out)
+            (spit path out)))
+      :else
+        nil)) )
 `
 
 	helperEscapeJSON = `(defn _escape_json [s]


### PR DESCRIPTION
## Summary
- extend `_load` and `_save` helpers in the Clojure backend to handle JSON, JSONL, TSV and YAML
- document new dataset formats in `compile/clj/README.md`
- list additional unsupported language features in the main `README.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856b299ccf48320ba576feb97c8fc9c