### PR TITLE
Add method support in Erlang backend

### DIFF
--- a/compile/erlang/README.md
+++ b/compile/erlang/README.md
@@ -90,7 +90,8 @@ func EnsureErlang() error { return ensureErlang() }
 - concurrency primitives like `spawn` and channels
 - `generate` helpers return placeholder data
 - imports targeting languages other than Erlang
-- methods declared inside type blocks
 - reflection or macro facilities
+- error handling with `try`/`catch`
+- advanced HTTP `fetch` options beyond simple GET
 
 Generated Erlang favors clarity over speed, mirroring Mochi constructs directly.

--- a/tests/compiler/erl/method.erl.out
+++ b/tests/compiler/erl/method.erl.out
@@ -1,0 +1,35 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1]).
+
+-record(circle, {radius}).
+circle_area(Self) ->
+	try
+		A = ((3.14 * Self#circle.radius) * Self#circle.radius),
+		mochi_print(["Calculating area:", A]),
+		throw({return, A})
+	catch
+		throw:{return, V} -> V
+	end.
+
+circle_describe(Self) ->
+	try
+		mochi_print(["Circle with radius", Self#circle.radius])
+	catch
+		throw:{return, V} -> V
+	end.
+
+
+main(_) ->
+	C = #{radius => 5},
+	circle_describe(C),
+	mochi_print(["Area is", circle_area(C)]).
+
+mochi_print(Args) ->
+	Strs = [ mochi_format(A) || A <- Args ],
+	io:format("~s~n", [lists:flatten(Strs)]).
+
+mochi_format(X) when is_integer(X) -> integer_to_list(X);
+mochi_format(X) when is_float(X) -> float_to_list(X);
+mochi_format(X) when is_list(X) -> X;
+mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).

--- a/tests/compiler/erl/method.mochi
+++ b/tests/compiler/erl/method.mochi
@@ -1,0 +1,17 @@
+type Circle {
+  radius: float
+
+  fun area(): float {
+    let a = 3.14 * radius * radius
+    print("Calculating area:", a)
+    return a
+  }
+
+  fun describe() {
+    print("Circle with radius", radius)
+  }
+}
+
+let c = Circle { radius: 5.0 }
+c.describe()
+print("Area is", c.area())

--- a/tests/compiler/erl/method.out
+++ b/tests/compiler/erl/method.out
@@ -1,0 +1,3 @@
+Circle with radius 5
+Calculating area: 78.5
+Area is 78.5


### PR DESCRIPTION
## Summary
- implement method declaration and calls for Erlang backend
- generate code for methods inside type blocks
- handle method invocation in the compiler
- document remaining unsupported features
- add Erlang compiler test for methods

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856b2c3ef14832083cf1e9c150355e1