### PR TITLE
Implement eval and JSON support in F# backend

### DIFF
--- a/compile/fs/README.md
+++ b/compile/fs/README.md
@@ -120,7 +120,8 @@ Mochi features are not yet available.
 * Pattern matching and conditional statements
 * Lists and maps with indexing and slicing
 * Query expressions with `where`, `sort`, `skip` and `take`
-* Built-in helpers: `len`, `count`, `avg`, `now`, `print`, `input`, `json`, `to_json`, `load`, `save`, `fetch`, `_genText`, `_genEmbed`, `_genStruct`
+* Built-in helpers: `len`, `count`, `avg`, `now`, `print`, `input`, `json`, `to_json`, `load`, `save`, `fetch`, `eval`, `_genText`, `_genEmbed`, `_genStruct`
+* Dataset helpers `_load` and `_save` support CSV, TSV, JSON and JSONL formats
 * Record and union type declarations
 * Methods declared inside `type` blocks
 * Package imports using `import` and exported functions via `export fun`
@@ -134,7 +135,6 @@ The F# generator still lacks support for several language constructs:
 
 * Foreign function interface (FFI) calls
 * YAML dataset support in `_load`/`_save`
-* `eval` builtin function
 * Logic programming constructs (`fact`, `rule`, `query`)
 * Advanced dataset queries such as joins and grouping
 * Set operations like `union`, `union all`, `except` and `intersect`
@@ -145,4 +145,7 @@ The F# generator still lacks support for several language constructs:
 * Generic types, reflection and macro facilities
 * `model` declarations and agent initialization
 * Package declarations using `package`
+* Destructuring bindings in `let`/`var` statements
+* Iterating over maps with `for` loops
+* Functions with multiple return values
 

--- a/compile/fs/compiler.go
+++ b/compile/fs/compiler.go
@@ -1328,6 +1328,12 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		c.use("_json_helpers")
 		return fmt.Sprintf("_to_json %s", args[0]), nil
+	case "eval":
+		if len(args) != 1 {
+			return "", fmt.Errorf("eval expects 1 arg")
+		}
+		c.use("_eval")
+		return fmt.Sprintf("_eval %s", args[0]), nil
 	case "input":
 		if len(args) != 0 {
 			return "", fmt.Errorf("input expects no args")

--- a/compile/fs/runtime.go
+++ b/compile/fs/runtime.go
@@ -10,35 +10,85 @@ const (
     match path with
     | None | Some "" | Some "-" -> System.Console.In.ReadToEnd()
     | Some p -> System.IO.File.ReadAllText(p)
-  let lines = text.Trim().Split([|'\n';'\r'|], System.StringSplitOptions.RemoveEmptyEntries)
-  if lines.Length = 0 then [] else
-    let headers =
-      if header then lines.[0].Split(delim)
-      else Array.init (lines.[0].Split(delim).Length) (fun i -> sprintf "c%d" i)
-    let start = if header then 1 else 0
-    [ for i in start .. lines.Length - 1 ->
-        let parts = lines.[i].Split(delim)
-        headers |> Array.mapi (fun j h -> h, if j < parts.Length then box parts.[j] else box "") |> Map.ofArray ]`
+  let parse_json (s: string) =
+    let doc = System.Text.Json.JsonDocument.Parse(s)
+    let rec toObj (e: System.Text.Json.JsonElement) : obj =
+      match e.ValueKind with
+      | System.Text.Json.JsonValueKind.String -> box (e.GetString())
+      | System.Text.Json.JsonValueKind.Number ->
+        let mutable i = 0L
+        if e.TryGetInt64(&i) then box i else box (e.GetDouble())
+      | System.Text.Json.JsonValueKind.True
+      | System.Text.Json.JsonValueKind.False -> box (e.GetBoolean())
+      | System.Text.Json.JsonValueKind.Array -> e.EnumerateArray() |> Seq.map toObj |> Seq.toArray |> box
+      | System.Text.Json.JsonValueKind.Object ->
+        e.EnumerateObject()
+        |> Seq.map (fun p -> p.Name, toObj p.Value)
+        |> Map.ofSeq
+        |> box
+      | _ -> null
+    if doc.RootElement.ValueKind = System.Text.Json.JsonValueKind.Array then
+      [ for el in doc.RootElement.EnumerateArray() ->
+          el.EnumerateObject() |> Seq.map (fun p -> p.Name, toObj p.Value) |> Map.ofSeq ]
+    else
+      [ doc.RootElement.EnumerateObject() |> Seq.map (fun p -> p.Name, toObj p.Value) |> Map.ofSeq ]
+  match format with
+  | "json" -> parse_json text
+  | "jsonl" ->
+      text.Split([|'\n';'\r'|], System.StringSplitOptions.RemoveEmptyEntries)
+      |> Array.map parse_json
+      |> Array.collect id
+      |> Array.toList
+  | _ ->
+      let lines = text.Trim().Split([|'\n';'\r'|], System.StringSplitOptions.RemoveEmptyEntries)
+      if lines.Length = 0 then [] else
+        let headers =
+          if header then lines.[0].Split(delim)
+          else Array.init (lines.[0].Split(delim).Length) (fun i -> sprintf "c%d" i)
+        let start = if header then 1 else 0
+        [ for i in start .. lines.Length - 1 ->
+            let parts = lines.[i].Split(delim)
+            headers |> Array.mapi (fun j h -> h, if j < parts.Length then box parts.[j] else box "") |> Map.ofArray ]`
 
 	helperSave = `let _save (rows: List<Map<string,obj>>) (path: string option) (opts: Map<string,obj> option) : unit =
   let format = opts |> Option.bind (Map.tryFind "format") |> Option.map string |> Option.defaultValue "csv"
   let header = opts |> Option.bind (Map.tryFind "header") |> Option.map unbox<bool> |> Option.defaultValue false
   let mutable delim = opts |> Option.bind (Map.tryFind "delimiter") |> Option.map (fun v -> (string v).[0]) |> Option.defaultValue ','
   if format = "tsv" then delim <- '\t'
-  if format <> "csv" then () else
-    let headers = if rows.Length > 0 then rows.[0] |> Map.keys |> Seq.toArray |> Array.sort else [||]
-    let sb = System.Text.StringBuilder()
-    if header then sb.AppendLine(String.concat (string delim) headers) |> ignore
-    for row in rows do
-        let line =
-            headers
-            |> Array.map (fun h -> match Map.tryFind h row with Some v -> string v | None -> "")
-            |> String.concat (string delim)
-        sb.AppendLine(line) |> ignore
-    let out = sb.ToString()
-    match path with
-    | None | Some "" | Some "-" -> System.Console.Out.Write(out)
-    | Some p -> System.IO.File.WriteAllText(p, out)`
+  let toDict (m: Map<string,obj>) =
+    let d = System.Collections.Generic.Dictionary<string,obj>()
+    for KeyValue(k,v) in m do d[k] <- v
+    d
+  match format with
+  | "json" ->
+      let data = rows |> List.map toDict
+      let text =
+        if data.Length = 1 then System.Text.Json.JsonSerializer.Serialize(data.Head)
+        else System.Text.Json.JsonSerializer.Serialize(data)
+      match path with
+      | None | Some "" | Some "-" -> System.Console.Out.Write(text)
+      | Some p -> System.IO.File.WriteAllText(p, text)
+  | "jsonl" ->
+      let lines = rows |> List.map (fun m -> System.Text.Json.JsonSerializer.Serialize(toDict m))
+      let out = String.concat "\n" lines + "\n"
+      match path with
+      | None | Some "" | Some "-" -> System.Console.Out.Write(out)
+      | Some p -> System.IO.File.WriteAllText(p, out)
+  | _ when format <> "csv" -> ()
+  | _ ->
+      let headers = if rows.Length > 0 then rows.[0] |> Map.keys |> Seq.toArray |> Array.sort else [||]
+      let sb = System.Text.StringBuilder()
+      if header then sb.AppendLine(String.concat (string delim) headers) |> ignore
+      for row in rows do
+          let line =
+              headers
+              |> Array.map (fun h -> match Map.tryFind h row with Some v -> string v | None -> "")
+              |> String.concat (string delim)
+          sb.AppendLine(line) |> ignore
+      let out = sb.ToString()
+      match path with
+      | None | Some "" | Some "-" -> System.Console.Out.Write(out)
+      | Some p -> System.IO.File.WriteAllText(p, out)`
 	helperRunTest = `let _run_test (name: string) (f: unit -> unit) : bool =
   printf "%s ... " name
   try
@@ -71,6 +121,10 @@ const (
 	helperGenStruct = `let _genStruct<'T> (prompt: string) (model: string) (params: Map<string,obj> option) : 'T =
   // TODO: integrate with an LLM and parse JSON
   System.Text.Json.JsonSerializer.Deserialize<'T>(prompt)`
+
+	helperEval = `let _eval (code: string) : obj =
+  let dt = new System.Data.DataTable()
+  dt.Compute(code, "")`
 
 	helperToJson = `let rec _to_json (v: obj) : string =
   match v with
@@ -112,6 +166,7 @@ var helperMap = map[string]string{
 	"_run_test":     helperRunTest,
 	"_input":        helperInput,
 	"_fetch":        helperFetch,
+	"_eval":         helperEval,
 	"_genText":      helperGenText,
 	"_genEmbed":     helperGenEmbed,
 	"_genStruct":    helperGenStruct,


### PR DESCRIPTION
## Summary
- extend `_load` and `_save` helpers to handle JSON/JSONL
- add `_eval` builtin helper and compile support
- update F# feature documentation and highlight remaining gaps

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856b2cfc3308320964c23f62aff2093