### PR TITLE
Add now() and json() support to Dart compiler

### DIFF
--- a/compile/dart/README.md
+++ b/compile/dart/README.md
@@ -243,6 +243,7 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 - Left/right/outer joins in dataset queries
 - Set operations with `union`, `union all`, `except` and `intersect`
 - Built‑ins like `fetch`, `load`, `save` (CSV/JSON/YAML) and placeholder `generate`
+- `json` printing and `now` timestamp helpers
 - Stream declarations and event handling with `on`/`emit`
 - Agent declarations with `intent` blocks
 - Model declarations
@@ -261,3 +262,7 @@ The Dart backend currently covers most core Mochi constructs, including union ty
 - Closures capturing surrounding variables
 - Error handling with `try`/`catch` blocks
 - Asynchronous functions (`async`/`await`)
+- Generic type parameters and functions
+- Set collections (`set<T>`) and related operations
+- Destructuring bindings in `let` and `var` statements
+- Waiting for asynchronous stream handlers with `_waitAll`

--- a/compile/dart/compiler.go
+++ b/compile/dart/compiler.go
@@ -791,6 +791,20 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.imports["dart:io"] = true
 		return "stdin.readLineSync() ?? ''", nil
 	}
+	// handle now()
+	if name == "now" && len(call.Args) == 0 {
+		return "DateTime.now().microsecondsSinceEpoch * 1000", nil
+	}
+	// handle json()
+	if name == "json" && len(call.Args) == 1 {
+		arg, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return "", err
+		}
+		c.imports["dart:convert"] = true
+		c.use("_json")
+		return fmt.Sprintf("_json(%s)", arg), nil
+	}
 	// handle print with multiple arguments
 	if name == "print" && len(call.Args) > 1 {
 		parts := make([]string, len(call.Args))

--- a/compile/dart/runtime.go
+++ b/compile/dart/runtime.go
@@ -289,6 +289,9 @@ const (
 		"    // TODO: parse model output into a struct\n" +
 		"    return null as T;\n" +
 		"}\n"
+	helperJson = "void _json(dynamic v) {\n" +
+		"    print(jsonEncode(v));\n" +
+		"}\n"
 )
 
 var helperMap = map[string]string{
@@ -308,6 +311,7 @@ var helperMap = map[string]string{
 	"_genText":     helperGenText,
 	"_genEmbed":    helperGenEmbed,
 	"_genStruct":   helperGenStruct,
+	"_json":        helperJson,
 }
 
 func (c *Compiler) use(name string) {


### PR DESCRIPTION
## Summary
- implement `now()` and `json()` builtins in Dart compiler
- provide runtime helper for `_json`
- document additional supported and unsupported features in Dart backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856b2aef1348320809e7289587dbfb9