### PR TITLE
Add json builtin to C++ backend

### DIFF
--- a/compile/cpp/README.md
+++ b/compile/cpp/README.md
@@ -243,7 +243,7 @@ Some LeetCode solutions use language constructs that the C++ backend can't yet t
 * Nested function declarations inside other functions
 * Iteration over map key/value pairs
 * Asynchronous `async`/`await` constructs
-* Built-in function `json`
 * Error handling with `try`/`catch`
+* Logic `fact` and `rule` declarations
 * Package declarations and `export` statements
 * YAML dataset loading and saving


### PR DESCRIPTION
## Summary
- implement `json()` for C++ compiler
- document new unsupported logic declarations

## Testing
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856c059bf208320be26b0eee3d1df6d