### PR TITLE
Add map membership check in Zig backend

### DIFF
--- a/compile/zig/README.md
+++ b/compile/zig/README.md
@@ -302,7 +302,7 @@ LeetCode solutions:
 * asynchronous functions (`async`/`await`)
 * the `eval` builtin function
 * YAML dataset loading and saving
-* map membership checks using `in`
+* range loops using the `range(start, end, step)` helper
 * built-in helpers like `fetch`, `load`, `save` and `generate`
 * logic programming constructs (`fact`, `rule`, `query`)
 * concurrency features such as streams or `spawn`

--- a/compile/zig/compiler.go
+++ b/compile/zig/compiler.go
@@ -757,7 +757,9 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr, asReturn bool) (string, e
 			continue
 		}
 		if opStr == "in" {
-			if c.isStringListPostfix(op.Right) {
+			if c.isMapPostfix(op.Right) {
+				expr = fmt.Sprintf("%s.contains(%s)", right, expr)
+			} else if c.isStringListPostfix(op.Right) {
 				c.needsInListString = true
 				expr = fmt.Sprintf("_contains_list_string(%s, %s)", right, expr)
 			} else {


### PR DESCRIPTION
## Summary
- support `key in map` for Zig code generation
- document newly unsupported range loops

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856c48c0f3c83209f78cb727f5acc51