### PR TITLE
Add now() and json() support to C backend

### DIFF
--- a/compile/c/README.md
+++ b/compile/c/README.md
@@ -24,7 +24,7 @@ Further helpers like `_count`, `_avg`, `_input`, `_str` and `_index_string` are 
 
 The backend supports basic language features including variable declarations, `for`/`while` loops, conditionals and function definitions. Lists of integers, floats, strings and nested integer lists are handled using the `list_int`, `list_float`, `list_string` and `list_list_int` types. When compiling `for` loops over ranges or collections the generator emits plain C loops.【F:compile/c/compiler.go†L452-L527】
 
-Builtin functions such as `print`, `len`, `count`, `avg`, `input` and `str` are translated to the appropriate helper calls or C library functions.【F:compile/c/compiler.go†L629-L757】
+Builtin functions such as `print`, `len`, `count`, `avg`, `input`, `str`, `now` and `json` are translated to the appropriate helper calls or C library functions.【F:compile/c/compiler.go†L629-L757】
 Extern variable and function declarations are emitted verbatim as C `extern` statements and registered in the type environment.
 
 Additional features include:
@@ -100,6 +100,8 @@ features include:
 - nested recursive functions inside other functions
 - `export` statements
 - constructing union variant values or matching on them
+- automatic language imports (`import python "..." auto`)
+- extern object declarations
 
 The backend now supports membership checks and `union`/`union all` operations
 for integer, float, and string lists, along with slicing and printing of string

--- a/compile/c/runtime.go
+++ b/compile/c/runtime.go
@@ -246,6 +246,36 @@ static list_list_int list_list_int_create(int len) {
     return buf;
 }
 `
+	helperNow = `static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+`
+	helperJSON = `static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+`
 	helperIndexString = `static char* _index_string(char* s, int i) {
     int len = strlen(s);
     if (i < 0) i += len;
@@ -420,6 +450,12 @@ func (c *Compiler) emitRuntime() {
 	}
 	if c.needsStr {
 		c.buf.WriteString(helperStr)
+	}
+	if c.needsNow {
+		c.buf.WriteString(helperNow)
+	}
+	if c.needsJSON {
+		c.buf.WriteString(helperJSON)
 	}
 	if c.needsIndexString {
 		c.buf.WriteString(helperIndexString)


### PR DESCRIPTION
## Summary
- implement `now()` and `json()` helpers in the C compiler
- emit new runtime helpers `_now` and `_json_*`
- document the new built-ins in the C backend README
- list additional unsupported features discovered

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856c3f631a48320b18aac10f1b74c75