### PR TITLE
Add match expression support for Java backend

### DIFF
--- a/compile/java/README.md
+++ b/compile/java/README.md
@@ -24,6 +24,7 @@ statements are present.
 - Dataset helpers `load` and `save`
 - Generative `generate` blocks for text, embeddings and structs
 - Test blocks with `expect`
+- Pattern matching expressions with `match`
 
 ## Building
 
@@ -43,10 +44,8 @@ a selection of LeetCode solutions.
 
 ## Unsupported Features
 
-The Java backend currently lacks many Mochi features supported by other
+- The Java backend currently lacks many Mochi features supported by other
 compilers:
-
-- Pattern matching expressions
 - Union types and tagged unions
 - Dataset queries (`from`/`select`, joins, grouping)
 - Concurrency primitives like streams, agents, `spawn` and channels
@@ -63,5 +62,6 @@ compilers:
 - Error handling with `try`/`catch` blocks
 - YAML dataset loading/saving
 - Destructuring bindings in `let` and `var` statements
+- Conditional expressions using `if`/`else`
 
 Simple `from` queries used by the LeetCode examples are now supported.

--- a/compile/java/helpers.go
+++ b/compile/java/helpers.go
@@ -1,6 +1,7 @@
 package javacode
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -90,4 +91,44 @@ func indentBlock(s string, depth int) string {
 		lines[i] = prefix + line
 	}
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func isUnderscoreExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	if p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0 {
+		return true
+	}
+	return false
+}
+
+func (c *Compiler) newVar() string {
+	name := fmt.Sprintf("_tmp%d", c.tempVarCount)
+	c.tempVarCount++
+	return name
+}
+
+func zeroValue(typ string) string {
+	switch typ {
+	case "int":
+		return "0"
+	case "double":
+		return "0.0"
+	case "boolean":
+		return "false"
+	default:
+		return "null"
+	}
 }


### PR DESCRIPTION
## Summary
- support `match` expressions in the Java compiler
- track temporary variables for code generation
- add helpers for underscores and zero values
- document new capabilities and unsupported features

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_6856c44dcae88320b91cd1a6e8cc2bf5