### PR TITLE
Extend Clojure backend features

### DIFF
--- a/compile/clj/README.md
+++ b/compile/clj/README.md
@@ -149,7 +149,6 @@ in the example programs. In particular:
 - External declarations and other FFI helpers
 - Generic types and functions
 - Destructuring bindings in `let` and `var` statements
-- Model declarations
 - Set collections and related operations
 - Streams and event-driven agents
 - Concurrency primitives such as `spawn` and channels
@@ -158,6 +157,6 @@ in the example programs. In particular:
 - Error handling with `try`/`catch` blocks
 - Reflection or macro facilities
 - Package and `export` statements for modules
-- `emit` statements for streams
+- Runtime evaluation with `eval`
 
 Programs relying on these features fail to compile with the Clojure backend.

--- a/compile/clj/helpers.go
+++ b/compile/clj/helpers.go
@@ -79,6 +79,17 @@ func isMap(t types.Type) bool {
 	return ok
 }
 
+func unexportName(name string) string {
+	if name == "" {
+		return ""
+	}
+	r := []rune(name)
+	if r[0] >= 'A' && r[0] <= 'Z' {
+		r[0] = r[0] - 'A' + 'a'
+	}
+	return string(r)
+}
+
 func isStruct(t types.Type) bool {
 	switch t.(type) {
 	case types.StructType, types.UnionType:

--- a/compile/clj/runtime.go
+++ b/compile/clj/runtime.go
@@ -195,6 +195,17 @@ const (
 	helperFetch = `(defn _fetch [url opts]
   (let [txt (slurp url)]
     (clojure.data.json/read-str txt :key-fn keyword))`
+
+	helperStream = `(defn _stream [name]
+  {:name name :handlers (atom []) :events (atom [])})
+(defn _stream_append [s data]
+  (swap! (:events s) conj data)
+  (doseq [h @(:handlers s)] (h data))
+  data)
+(defn _stream_register [s handler]
+  (swap! (:handlers s) conj handler))`
+
+	helperModels = `(def ^:dynamic _models (atom {}))`
 )
 
 var helperMap = map[string]string{
@@ -220,6 +231,8 @@ var helperMap = map[string]string{
 	"_gen_embed":   helperGenEmbed,
 	"_gen_struct":  helperGenStruct,
 	"_fetch":       helperFetch,
+	"_stream":      helperStream,
+	"_models":      helperModels,
 }
 
 var helperOrder = []string{
@@ -245,6 +258,8 @@ var helperOrder = []string{
 	"_gen_embed",
 	"_gen_struct",
 	"_fetch",
+	"_stream",
+	"_models",
 }
 
 // helperDeps lists transitive helper dependencies.


### PR DESCRIPTION
## Summary
- support `stream` declarations and `emit` statements in the Clojure backend
- allow model declarations via global `_models`
- expose `_stream` and `_models` helpers in Clojure runtime
- document remaining unsupported features

## Testing
- `go test ./compile/clj -run TestClojureCompiler_TwoSum -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_6856c4003f508320b166d684965c6f55