### PR TITLE
Add slice assignment support in Fortran backend

### DIFF
--- a/compile/fortran/README.md
+++ b/compile/fortran/README.md
@@ -26,6 +26,7 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 - printing via `print()`
 - `package` and `export` declarations (ignored during code generation)
 - `import` statements emit Fortran `include` lines
+- slice assignments like `xs[0:1] = sub`
 
 ## Unsupported features
 
@@ -39,11 +40,13 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 - foreign imports and dataset helpers (`fetch`, `load`, `save`)
 - anonymous functions
 - extern declarations
-- slice assignments like `xs[0:1] = sub`
 - range loops with step values other than `1`
 - event handlers (`on`) and `emit` statements
 - type declarations using `type` blocks
 - generative blocks and model declarations
+- asynchronous functions (`async`/`await`)
+- set collections (`set<T>`) and related operations
+- concurrency primitives like `spawn` and channels
 - any other built-ins not listed above
 
 While limited, this backend shows how Mochi's AST can target another language and may serve as a basis for more comprehensive Fortran support.


### PR DESCRIPTION
## Summary
- implement slice assignment handling and index clamping in the Fortran backend
- track list parameters correctly
- document new capability and add missing unsupported features

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856c4763eb4832082b1f455b54e1792