### PR TITLE
Add v0.8.10 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,32 @@
 # 📦 CHANGELOG.md
+## [0.8.10] – 2025-06-22
+
+### Added
+
+* Agent support for C# and Dart
+* Right join in Ruby with left/right joins in C# and join helpers in Erlang
+* Query sorting, pagination and advanced join operations in Clojure
+* CSV, JSON and YAML dataset helpers in Elixir, Kotlin and Dart
+* Extern declarations for Kotlin, Rust and the C backend
+* Now and JSON builtins across C, C++, Dart and Swift
+* Eval builtins in Ruby and C#
+* Fetch expression support in Swift and new fetch options in Erlang
+* Step range loops for Zig with constant and descending ranges in COBOL
+* Multi-dimensional slice assignments in Racket and Fortran
+* Open-ended slices, print/call statements and abs builtin for COBOL
+* Map membership and struct support in Zig with map-key iteration in C++
+* Union/extern type support in the C backend and union_all in Java
+* Push/keys builtins in Scheme and generative dataset helpers in F#
+* Logic programming support for Prolog and an input builtin in OCaml
+
+### Changed
+
+* Compiler codebases reorganized with smaller files and runtime helpers
+
+### Fixed
+
+* Average builtin and Pascal temporary variable issues resolved
+* Fortran golden tests corrected
 ## [0.8.9] – 2025-06-21
 
 ### Added

--- a/releases/v0.8.10.md
+++ b/releases/v0.8.10.md
@@ -1,0 +1,34 @@
+# Jun 2025 (v0.8.10)
+
+Mochi v0.8.10 refactors the experimental compilers while expanding dataset and query capabilities. Numerous backends gain new builtins, extern features and join operations with updated documentation and golden tests.
+
+## Compilers
+
+- Agent support added to C# and Dart
+- Right join for Ruby with left/right joins in C# and join support in Erlang
+- Query sorting, pagination and advanced joins in Clojure
+- CSV, JSON and YAML dataset helpers across Elixir, Kotlin and Dart
+- Extern declarations implemented for Kotlin, Rust and the C backend
+- Now and JSON builtins across C, C++, Dart and Swift
+- Eval builtins for Ruby and C#
+- Fetch expression support in Swift and method options for Erlang fetch
+- Range loops with step in Zig and constant or descending ranges in COBOL
+- Multi-dimensional slice assignment in Racket and slice assignments in Fortran
+- Open-ended slices, print/call statements and abs builtin in COBOL
+- Map membership and struct support in Zig
+- Group by support in Rust with map key iteration in C++
+- Union and extern type support in the C backend with union_all in Java
+- Push and keys builtins in Scheme and generative helpers in F#
+- Logic programming added to the Prolog backend
+- Input builtin for OCaml
+
+## Tests
+
+- Scala backend gains new built-in tests
+- Scheme backend supports running tests
+- Dart and Pascal golden files updated with Fortran fixes
+
+## Fixes
+
+- Average builtin corrected with Pascal temporary variable fix
+


### PR DESCRIPTION
## Summary
- document changes in CHANGELOG for v0.8.10
- add release notes file for v0.8.10

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856d260e72c83208e4d8b6214bc16e4