### PR TITLE
Add basic cloud library

### DIFF
--- a/lib/cloud/bucket.mochi
+++ b/lib/cloud/bucket.mochi
@@ -1,0 +1,41 @@
+package cloud
+
+/// Bucket is an in-memory object store identified by a name.
+type Bucket {
+  name: string,
+  objects: map<string, any>
+}
+
+/// bucket creates a new Bucket with the given name.
+fun bucket(name: string): Bucket {
+  return Bucket { name: name, objects: {} }
+}
+
+/// Store or overwrite a value under the given key.
+fun Bucket.put(b: Bucket, key: string, value: any) {
+  b.objects[key] = value
+}
+
+/// Retrieve a value by key or null if missing.
+fun Bucket.get(b: Bucket, key: string): any {
+  if key in b.objects {
+    return b.objects[key]
+  }
+  return null
+}
+
+/// Delete a key if present.
+fun Bucket.delete(b: Bucket, key: string) {
+  if key in b.objects {
+    delete(b.objects, key)
+  }
+}
+
+/// List all keys stored in the bucket.
+fun Bucket.list(b: Bucket): list<string> {
+  var keys: list<string> = []
+  for k in b.objects {
+    keys = keys + [k]
+  }
+  return keys
+}

--- a/lib/cloud/cloud.mochi
+++ b/lib/cloud/cloud.mochi
@@ -1,0 +1,5 @@
+package cloud
+
+import "./bucket.mochi" as bucket
+import "./queue.mochi" as queue
+import "./topic.mochi" as topic

--- a/lib/cloud/queue.mochi
+++ b/lib/cloud/queue.mochi
@@ -1,0 +1,32 @@
+package cloud
+
+/// Queue is an in-memory FIFO queue.
+type Queue {
+  name: string,
+  items: list<any>
+}
+
+/// queue creates a new Queue with the given name.
+fun queue(name: string): Queue {
+  return Queue { name: name, items: [] }
+}
+
+/// push adds a value to the end of the queue.
+fun Queue.push(q: Queue, value: any) {
+  q.items = q.items + [value]
+}
+
+/// pop removes and returns the first value or null if empty.
+fun Queue.pop(q: Queue): any {
+  if len(q.items) == 0 {
+    return null
+  }
+  let value = q.items[0]
+  q.items = q.items[1:len(q.items)]
+  return value
+}
+
+/// len returns the number of pending items.
+fun Queue.len(q: Queue): int {
+  return len(q.items)
+}

--- a/lib/cloud/topic.mochi
+++ b/lib/cloud/topic.mochi
@@ -1,0 +1,24 @@
+package cloud
+
+/// Topic implements a simple publish/subscribe channel.
+type Topic {
+  name: string,
+  subscribers: list<fun(any): void>
+}
+
+/// topic creates a new Topic.
+fun topic(name: string): Topic {
+  return Topic { name: name, subscribers: [] }
+}
+
+/// publish sends a value to all subscribers.
+fun Topic.publish(t: Topic, msg: any) {
+  for sub in t.subscribers {
+    sub(msg)
+  }
+}
+
+/// subscribe registers a handler to receive published values.
+fun Topic.subscribe(t: Topic, handler: fun(any): void) {
+  t.subscribers = t.subscribers + [handler]
+}


### PR DESCRIPTION
## Summary
- add a new cloud library under `lib/cloud`
- implement in-memory Bucket, Queue, and Topic types

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856f405253883209972de148f12f56f