### PR TITLE
Add Cloudflare library

### DIFF
--- a/lib/cloud/cloudflare/cron/cron.mochi
+++ b/lib/cloud/cloudflare/cron/cron.mochi
@@ -1,0 +1,12 @@
+// Cron trigger for scheduled invocations
+
+type Trigger {
+  schedule: string
+}
+
+fun every(cronExp: string): Trigger {
+  return Trigger { schedule: cronExp }
+}
+
+export type Trigger
+export fun every

--- a/lib/cloud/cloudflare/d1/d1.mochi
+++ b/lib/cloud/cloudflare/d1/d1.mochi
@@ -1,0 +1,12 @@
+// Cloudflare D1 database
+
+type Database {
+  name: string
+}
+
+fun new(name: string): Database {
+  return Database { name: name }
+}
+
+export type Database
+export fun new

--- a/lib/cloud/cloudflare/kv/kv.mochi
+++ b/lib/cloud/cloudflare/kv/kv.mochi
@@ -1,0 +1,12 @@
+// Cloudflare KV storage
+
+type KV {
+  name: string
+}
+
+fun new(name: string): KV {
+  return KV { name: name }
+}
+
+export type KV
+export fun new

--- a/lib/cloud/cloudflare/mod.mochi
+++ b/lib/cloud/cloudflare/mod.mochi
@@ -1,0 +1,16 @@
+// Cloudflare cloud infrastructure library
+// Provides resource constructors for workers, storage, and triggers.
+
+import "./worker/worker" as worker
+import "./kv/kv" as kv
+import "./r2/r2" as r2
+import "./queue/queue" as queue
+import "./d1/d1" as d1
+import "./cron/cron" as cron
+
+export worker
+export kv
+export r2
+export queue
+export d1
+export cron

--- a/lib/cloud/cloudflare/queue/queue.mochi
+++ b/lib/cloud/cloudflare/queue/queue.mochi
@@ -1,0 +1,12 @@
+// Cloudflare Queue service
+
+type Queue {
+  name: string
+}
+
+fun new(name: string): Queue {
+  return Queue { name: name }
+}
+
+export type Queue
+export fun new

--- a/lib/cloud/cloudflare/r2/r2.mochi
+++ b/lib/cloud/cloudflare/r2/r2.mochi
@@ -1,0 +1,12 @@
+// Cloudflare R2 object storage
+
+type Bucket {
+  name: string
+}
+
+fun new(name: string): Bucket {
+  return Bucket { name: name }
+}
+
+export type Bucket
+export fun new

--- a/lib/cloud/cloudflare/worker/worker.mochi
+++ b/lib/cloud/cloudflare/worker/worker.mochi
@@ -1,0 +1,111 @@
+import "../kv/kv" as kv
+import "../r2/r2" as r2
+import "../queue/queue" as queue
+import "../d1/d1" as d1
+import "../cron/cron" as cron
+
+// Union describing all possible bindings for a worker
+// Each variant holds a reference to the resource
+
+type Binding =
+  KVBinding(store: kv.KV)
+  | R2Binding(bucket: r2.Bucket)
+  | QueueBinding(q: queue.Queue)
+  | D1Binding(db: d1.Database)
+
+// Worker represents a Cloudflare worker with optional triggers and bindings
+
+type Worker {
+  name: string
+  code: string
+  routes: list<string>
+  crons: list<cron.Trigger>
+  bindings: list<Binding>
+}
+
+// Create a new worker from a name and code path
+fun new(name: string, code: string): Worker {
+  return Worker {
+    name: name,
+    code: code,
+    routes: [] as list<string>,
+    crons: [] as list<cron.Trigger>,
+    bindings: [] as list<Binding>
+  }
+}
+
+// Add an HTTP route to the worker
+fun route(w: Worker, path: string): Worker {
+  return Worker {
+    name: w.name,
+    code: w.code,
+    routes: w.routes + [path],
+    crons: w.crons,
+    bindings: w.bindings
+  }
+}
+
+// Attach a cron trigger to the worker
+fun onCron(w: Worker, t: cron.Trigger): Worker {
+  return Worker {
+    name: w.name,
+    code: w.code,
+    routes: w.routes,
+    crons: w.crons + [t],
+    bindings: w.bindings
+  }
+}
+
+// Bind a KV store to the worker
+fun bindKV(w: Worker, store: kv.KV): Worker {
+  return Worker {
+    name: w.name,
+    code: w.code,
+    routes: w.routes,
+    crons: w.crons,
+    bindings: w.bindings + [KVBinding(store: store)]
+  }
+}
+
+// Bind an R2 bucket to the worker
+fun bindR2(w: Worker, bucket: r2.Bucket): Worker {
+  return Worker {
+    name: w.name,
+    code: w.code,
+    routes: w.routes,
+    crons: w.crons,
+    bindings: w.bindings + [R2Binding(bucket: bucket)]
+  }
+}
+
+// Bind a queue to the worker
+fun bindQueue(w: Worker, q: queue.Queue): Worker {
+  return Worker {
+    name: w.name,
+    code: w.code,
+    routes: w.routes,
+    crons: w.crons,
+    bindings: w.bindings + [QueueBinding(q: q)]
+  }
+}
+
+// Bind a D1 database to the worker
+fun bindD1(w: Worker, db: d1.Database): Worker {
+  return Worker {
+    name: w.name,
+    code: w.code,
+    routes: w.routes,
+    crons: w.crons,
+    bindings: w.bindings + [D1Binding(db: db)]
+  }
+}
+
+export type Worker
+export type Binding
+export fun new
+export fun route
+export fun onCron
+export fun bindKV
+export fun bindR2
+export fun bindQueue
+export fun bindD1

--- a/tests/interpreter/valid/cloudflare_worker.mochi
+++ b/tests/interpreter/valid/cloudflare_worker.mochi
@@ -1,0 +1,26 @@
+import "../../lib/cloud/cloudflare/worker/worker" as worker
+import "../../lib/cloud/cloudflare/kv/kv" as kv
+import "../../lib/cloud/cloudflare/r2/r2" as r2
+import "../../lib/cloud/cloudflare/queue/queue" as queue
+import "../../lib/cloud/cloudflare/d1/d1" as d1
+import "../../lib/cloud/cloudflare/cron/cron" as cron
+
+test "worker bindings" {
+  let w = worker.new("api", "index.js")
+  let store = kv.new("cache")
+  let bucket = r2.new("assets")
+  let q = queue.new("jobs")
+  let db = d1.new("main")
+  let trig = cron.every("0 * * * *")
+
+  var w1 = worker.bindKV(w, store)
+  w1 = worker.bindR2(w1, bucket)
+  w1 = worker.bindQueue(w1, q)
+  w1 = worker.bindD1(w1, db)
+  w1 = worker.onCron(w1, trig)
+  w1 = worker.route(w1, "/api/*")
+
+  expect len(w1.bindings) == 4
+  expect w1.routes[0] == "/api/*"
+  expect w1.crons[0].schedule == "0 * * * *"
+}


### PR DESCRIPTION
## Summary
- add Cloudflare cloud library with worker, kv, r2, queue, d1, and cron resources
- provide root module re-exporting submodules
- add integration tests for worker bindings

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856fe2ae1208320ab094d2945eea9e1