### PR TITLE
Add Azure cloud library in Mochi

### DIFF
--- a/lib/cloud/azure/README.md
+++ b/lib/cloud/azure/README.md
@@ -1,0 +1,19 @@
+# Azure Cloud Library
+
+This package provides a small set of Azure cloud helpers written entirely in Mochi.
+Resources are organized by category under `compute`, `storage` and `network`.
+Each module exposes simple types and functions to model common operations.
+
+## Example
+
+```mochi
+import "lib/cloud/azure/compute/vm" as vm
+import "lib/cloud/azure/network/vnet" as net
+
+let machine = vm.create("demo", "ubuntu-lts", "B1s", "eastus")
+machine.start()
+let vnet = net.create("demo-net", "eastus")
+vnet.attach(machine)
+```
+
+These modules only simulate behaviour but mirror the structure of actual Azure services, providing an ergonomic API for experimentation.

--- a/lib/cloud/azure/azure.mochi
+++ b/lib/cloud/azure/azure.mochi
@@ -1,0 +1,9 @@
+package azure
+
+import "./compute/vm" as compute
+import "./storage/container" as storage
+import "./network/vnet" as network
+
+export let compute = compute
+export let storage = storage
+export let network = network

--- a/lib/cloud/azure/compute/vm.mochi
+++ b/lib/cloud/azure/compute/vm.mochi
@@ -1,0 +1,24 @@
+package azure.compute
+
+type VM {
+  name: string
+  image: string
+  size: string
+  region: string
+
+  fun start() {
+    print("Starting VM", name)
+  }
+
+  fun stop() {
+    print("Stopping VM", name)
+  }
+}
+
+fun create(name: string, image: string, size: string, region: string): VM {
+  print("Creating VM", name, "with", image, size, "in", region)
+  return VM { name: name, image: image, size: size, region: region }
+}
+
+export type VM
+export fun create

--- a/lib/cloud/azure/network/vnet.mochi
+++ b/lib/cloud/azure/network/vnet.mochi
@@ -1,0 +1,20 @@
+import "../compute/vm" as compute
+
+package azure.network
+
+type VNet {
+  name: string
+  region: string
+
+  fun attach(vm: compute.VM) {
+    print("Attaching VM", vm.name, "to network", name)
+  }
+}
+
+fun create(name: string, region: string): VNet {
+  print("Creating network", name, "in", region)
+  return VNet { name: name, region: region }
+}
+
+export type VNet
+export fun create

--- a/lib/cloud/azure/storage/container.mochi
+++ b/lib/cloud/azure/storage/container.mochi
@@ -1,0 +1,24 @@
+package azure.storage
+
+type Container {
+  name: string
+  resourceGroup: string
+  region: string
+
+  fun upload(path: string, data: string) {
+    print("Uploading", path, "to", name)
+  }
+
+  fun download(path: string): string {
+    print("Downloading", path, "from", name)
+    return "data:" + path
+  }
+}
+
+fun create(name: string, group: string, region: string): Container {
+  print("Creating container", name, "in", region)
+  return Container { name: name, resourceGroup: group, region: region }
+}
+
+export type Container
+export fun create

--- a/tests/interpreter/valid/azure_demo.mochi
+++ b/tests/interpreter/valid/azure_demo.mochi
@@ -1,0 +1,15 @@
+import "lib/cloud/azure/compute/vm" as vm
+import "lib/cloud/azure/network/vnet" as vnet
+import "lib/cloud/azure/storage/container" as storage
+
+let machine = vm.create("demo", "ubuntu-lts", "B1s", "eastus")
+machine.start()
+
+let net = vnet.create("demo-net", "eastus")
+net.attach(machine)
+
+let cont = storage.create("files", "rg", "eastus")
+cont.upload("hello.txt", "Hello")
+let msg = cont.download("hello.txt")
+print(msg)
+

--- a/tests/interpreter/valid/azure_demo.out
+++ b/tests/interpreter/valid/azure_demo.out
@@ -1,0 +1,9 @@
+Creating VM demo with ubuntu-lts B1s in eastus
+Starting VM demo
+Creating network demo-net in eastus
+Attaching VM demo to network demo-net
+Creating container files in eastus
+Uploading hello.txt to files
+Downloading hello.txt from files
+data:hello.txt
+


### PR DESCRIPTION
## Summary
- create Azure cloud helper library under `lib/cloud/azure`
- implement compute VM, storage container and network VNet modules in pure Mochi
- document usage in `lib/cloud/azure/README.md`
- add interpreter test demonstrating the library

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857033e527883208efb71f3ad1737fb