### PR TITLE
Add Mochi gcloud library

### DIFF
--- a/lib/cloud/gcloud/README.md
+++ b/lib/cloud/gcloud/README.md
@@ -1,0 +1,13 @@
+# GCloud Mochi Library
+
+This package provides a small wrapper around Google Cloud REST APIs.
+Create a `Client` and use subpackages like `storage`, `pubsub`, and `functions`
+to interact with services.
+
+````mochi
+import "lib/cloud/gcloud" as gcloud
+import "lib/cloud/gcloud/storage" as storage
+
+let gc = gcloud.client("my-project", "TOKEN")
+let bucket = storage.create(gc, "my-bucket")
+````

--- a/lib/cloud/gcloud/functions/functions.mochi
+++ b/lib/cloud/gcloud/functions/functions.mochi
@@ -1,0 +1,12 @@
+package functions
+
+import ".." as gcloud
+
+/// Call a deployed Cloud Function.
+export fun call(c: gcloud.Client, name: string, data: string): any {
+  return fetch gcloud.Client.serviceEndpoint(c, "functions", "/v1/projects/" + c.project + "/locations/" + c.region + "/functions/" + name + ":call") with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { data: data }
+  }
+}

--- a/lib/cloud/gcloud/gcloud.mochi
+++ b/lib/cloud/gcloud/gcloud.mochi
@@ -1,0 +1,32 @@
+package gcloud
+
+type Client {
+  project: string,
+  token: string,
+  region: string,
+}
+
+/// Create a new Google Cloud client.
+export fun client(project: string, token: string, region: string = "us-central1"): Client {
+  return Client { project: project, token: token, region: region }
+}
+
+/// Authorization header for requests.
+export fun Client.authHeader(c: Client): map<string,string> {
+  return { "Authorization": "Bearer " + c.token }
+}
+
+/// Construct a service endpoint URL.
+export fun Client.serviceEndpoint(c: Client, service: string, path: string): string {
+  var host = "https://"
+  if service == "storage" {
+    host = host + "storage.googleapis.com"
+  } else if service == "pubsub" {
+    host = host + "pubsub.googleapis.com"
+  } else if service == "functions" {
+    host = host + c.region + "-cloudfunctions.googleapis.com"
+  } else {
+    host = host + service
+  }
+  return host + path
+}

--- a/lib/cloud/gcloud/pubsub/pubsub.mochi
+++ b/lib/cloud/gcloud/pubsub/pubsub.mochi
@@ -1,0 +1,50 @@
+package pubsub
+
+import ".." as gcloud
+
+/// Pub/Sub topic representation.
+type Topic { name: string }
+
+/// Subscription representation.
+type Subscription { name: string }
+
+/// Create a new topic.
+export fun create_topic(c: gcloud.Client, name: string): Topic {
+  fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/topics/" + name) with {
+    method: "PUT",
+    headers: gcloud.Client.authHeader(c)
+  }
+  return Topic { name: name }
+}
+
+/// Publish messages to a topic.
+export fun publish(c: gcloud.Client, topic: string, messages: list<map<string,string>>) {
+  fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/topics/" + topic + ":publish") with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { messages: messages }
+  }
+}
+
+/// Create a subscription for a topic.
+export fun create_subscription(c: gcloud.Client, name: string, topic: string): Subscription {
+  fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/subscriptions/" + name) with {
+    method: "PUT",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { topic: "projects/" + c.project + "/topics/" + topic }
+  }
+  return Subscription { name: name }
+}
+
+/// Pull messages from a subscription.
+export fun pull(c: gcloud.Client, subscription: string, max_messages: int = 1): list<any> {
+  var resp = fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/subscriptions/" + subscription + ":pull") with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { maxMessages: max_messages }
+  } as map<string, any>
+  if "receivedMessages" in resp {
+    return resp.receivedMessages as list<any>
+  }
+  return []
+}

--- a/lib/cloud/gcloud/storage/storage.mochi
+++ b/lib/cloud/gcloud/storage/storage.mochi
@@ -1,0 +1,40 @@
+package storage
+
+import ".." as gcloud
+
+/// Storage bucket representation.
+type Bucket { name: string }
+
+/// Create a new bucket in the configured project.
+export fun create(c: gcloud.Client, name: string): Bucket {
+  fetch gcloud.Client.serviceEndpoint(c, "storage", "/storage/v1/b?project=" + c.project) with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { name: name }
+  }
+  return Bucket { name: name }
+}
+
+/// Upload an object to a bucket.
+export fun upload(c: gcloud.Client, bucket: string, object: string, data: string) {
+  fetch gcloud.Client.serviceEndpoint(c, "storage", "/upload/storage/v1/b/" + bucket + "/o?uploadType=media&name=" + object) with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c),
+    body: data
+  }
+}
+
+/// Download an object from a bucket.
+export fun download(c: gcloud.Client, bucket: string, object: string): string {
+  return fetch gcloud.Client.serviceEndpoint(c, "storage", "/storage/v1/b/" + bucket + "/o/" + object + "?alt=media") with {
+    headers: gcloud.Client.authHeader(c)
+  } as string
+}
+
+/// Delete an object from a bucket.
+export fun delete(c: gcloud.Client, bucket: string, object: string) {
+  fetch gcloud.Client.serviceEndpoint(c, "storage", "/storage/v1/b/" + bucket + "/o/" + object) with {
+    method: "DELETE",
+    headers: gcloud.Client.authHeader(c)
+  }
+}

--- a/tests/interpreter/valid/gcloud_endpoint.mochi
+++ b/tests/interpreter/valid/gcloud_endpoint.mochi
@@ -1,0 +1,4 @@
+import "lib/cloud/gcloud" as gcloud
+
+let c = gcloud.client("demo", "tkn")
+print(gcloud.Client.serviceEndpoint(c, "storage", "/test"))

--- a/tests/interpreter/valid/gcloud_endpoint.out
+++ b/tests/interpreter/valid/gcloud_endpoint.out
@@ -1,0 +1,1 @@
+https://storage.googleapis.com/test


### PR DESCRIPTION
## Summary
- add gcloud client and helpers
- add storage, pubsub, and functions modules
- document the new library
- provide a simple interpreter test for the helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68570333766c8320b5749bac9b4ef93b