### PR TITLE
Add basic terraform cloud library

### DIFF
--- a/lib/cloud/terraform/compute/function.mochi
+++ b/lib/cloud/terraform/compute/function.mochi
@@ -1,0 +1,15 @@
+package compute
+
+type Function {
+  name: string
+  runtime: string
+  handler: string
+
+  fun to_map(): map<string, string> {
+    return { kind: "function", name: name, runtime: runtime, handler: handler }
+  }
+}
+
+export fun function(name: string, runtime: string, handler: string): Function {
+  return Function { name: name, runtime: runtime, handler: handler }
+}

--- a/lib/cloud/terraform/main.mochi
+++ b/lib/cloud/terraform/main.mochi
@@ -1,0 +1,33 @@
+package terraform
+
+import "./compute/function" as compute
+import "./storage/bucket" as storage
+import "./network/queue" as network
+
+type Stack {
+  resources: list<any>
+
+  fun add(r: any) {
+    resources = resources + [r]
+  }
+
+  fun to_list(): list<any> {
+    return resources
+  }
+}
+
+export fun new_stack(): Stack {
+  return Stack { resources: [] }
+}
+
+export fun function(name: string, runtime: string, handler: string) {
+  return compute.function(name, runtime, handler)
+}
+
+export fun bucket(name: string, versioned: bool) {
+  return storage.bucket(name, versioned)
+}
+
+export fun queue(name: string, visibility_timeout: int) {
+  return network.queue(name, visibility_timeout)
+}

--- a/lib/cloud/terraform/network/queue.mochi
+++ b/lib/cloud/terraform/network/queue.mochi
@@ -1,0 +1,14 @@
+package network
+
+type Queue {
+  name: string
+  visibility_timeout: int
+
+  fun to_map(): map<string, any> {
+    return { kind: "queue", name: name, visibility_timeout: visibility_timeout }
+  }
+}
+
+export fun queue(name: string, visibility_timeout: int): Queue {
+  return Queue { name: name, visibility_timeout: visibility_timeout }
+}

--- a/lib/cloud/terraform/storage/bucket.mochi
+++ b/lib/cloud/terraform/storage/bucket.mochi
@@ -1,0 +1,14 @@
+package storage
+
+type Bucket {
+  name: string
+  versioned: bool
+
+  fun to_map(): map<string, any> {
+    return { kind: "bucket", name: name, versioned: versioned }
+  }
+}
+
+export fun bucket(name: string, versioned: bool): Bucket {
+  return Bucket { name: name, versioned: versioned }
+}

--- a/tests/interpreter/valid/cloud_stack.mochi
+++ b/tests/interpreter/valid/cloud_stack.mochi
@@ -1,0 +1,14 @@
+import "lib/cloud/terraform" as tf
+
+let stack = tf.new_stack()
+let fn = tf.function("hello", "python3.11", "main.handler")
+let bucket = tf.bucket("files", true)
+let queue = tf.queue("tasks", 30)
+
+stack.add(fn.to_map())
+stack.add(bucket.to_map())
+stack.add(queue.to_map())
+
+for r in stack.to_list() {
+  print(r.kind, r.name)
+}

--- a/tests/interpreter/valid/cloud_stack.out
+++ b/tests/interpreter/valid/cloud_stack.out
@@ -1,0 +1,3 @@
+function hello
+bucket files
+queue tasks


### PR DESCRIPTION
## Summary
- implement `lib/cloud/terraform` with simple Stack and helpers
- add compute, storage and network subpackages
- add example interpreter test for using the new library

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685703578ee083209838428a8c02961a