### PR TITLE
Add TinyGo WASM playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,6 +286,8 @@ dist/
 node_modules/
 bin/
 tools/libmochi/typescript/mochi.wasm.gz
+tools/playground/mochi.wasm
+tools/playground/wasm_exec.js
 **/*.egg-info/
 **/__pycache__/
 *.class

--- a/tools/playground/Makefile
+++ b/tools/playground/Makefile
@@ -1,0 +1,41 @@
+.DEFAULT_GOAL := help
+
+WASM := mochi.wasm
+
+.PHONY: build wasm_exec.js serve clean test deploy-cloudflare deploy-gh-pages help
+
+build: $(WASM) wasm_exec.js ## Build WebAssembly binary and copy wasm_exec.js
+
+$(WASM): main.go
+	@echo "🔧 Building WebAssembly binary..."
+	tinygo build -o $(WASM) -target wasm ./
+	@echo "✅ Generated $(WASM)"
+
+wasm_exec.js:
+@echo "🔧 Copying wasm_exec.js..."
+cp $(shell go env GOROOT)/lib/wasm/wasm_exec.js .
+@echo "✅ Copied wasm_exec.js"
+
+serve: build ## Serve playground at http://localhost:8080
+	@echo "🌐 Starting local server on port 8080..."
+	python3 -m http.server 8080
+
+clean: ## Remove generated files
+        @rm -f $(WASM) wasm_exec.js
+        @echo "🧹 Cleaned build artifacts"
+
+deploy-cloudflare: build ## Deploy playground to Cloudflare Pages
+	wrangler pages publish . --project-name mochi-playground
+
+deploy-gh-pages: build ## Deploy playground to GitHub Pages
+	git subtree push --prefix tools/playground origin gh-pages
+
+test: ## Run playground tests with the slow tag
+        go test -tags slow ./...
+
+help: ## Show this help message
+	@echo ""
+	@echo "Mochi Playground Makefile"
+	@echo "-------------------------"
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\\033[36m%-15s\\033[0m %s\\n", $$1, $$2}'

--- a/tools/playground/README.md
+++ b/tools/playground/README.md
@@ -1,0 +1,31 @@
+# Mochi Playground
+
+This directory contains a small web-based playground to run Mochi code directly in the browser. The runtime is compiled to WebAssembly using the TinyGo compiler so all execution happens inside the `mochi.wasm` module.
+
+## Building
+
+Install [TinyGo](https://tinygo.org/) and run:
+
+```bash
+make build
+```
+
+This compiles `mochi.wasm` and copies `wasm_exec.js` from your Go installation.
+You can then start a simple HTTP server with:
+
+```bash
+make serve
+```
+
+Open `index.html` in a browser and start experimenting. The styling uses Tailwind CSS classes inspired by the [shadcn](https://ui.shadcn.com) design system.
+
+## Deployment
+
+The playground can be deployed as a static site using Cloudflare Pages or GitHub Pages:
+
+```bash
+make deploy-cloudflare   # publish to Cloudflare Pages
+make deploy-gh-pages     # publish to GitHub Pages
+```
+
+It is currently available at <https://play.mochi-lang.org> using Cloudflare Pages.

--- a/tools/playground/index.html
+++ b/tools/playground/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Mochi Playground</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+<div class="container mx-auto max-w-2xl py-8">
+  <h1 class="text-2xl font-semibold mb-4">Mochi Playground</h1>
+  <textarea id="code" class="w-full h-48 p-2 border rounded mb-4 font-mono" spellcheck="false">print("hello wasm")</textarea>
+  <button id="run" class="bg-black text-white px-4 py-2 rounded">Run</button>
+  <pre id="output" class="bg-gray-900 text-green-400 p-4 mt-4 rounded"></pre>
+</div>
+<script src="wasm_exec.js"></script>
+<script>
+const go = new Go();
+WebAssembly.instantiateStreaming(fetch("mochi.wasm"), go.importObject).then((res) => {
+    go.run(res.instance);
+    document.getElementById("run").onclick = () => {
+        const src = document.getElementById("code").value;
+        const out = runMochi(src);
+        document.getElementById("output").textContent = out;
+    };
+});
+</script>
+</body>
+</html>

--- a/tools/playground/main.go
+++ b/tools/playground/main.go
@@ -1,0 +1,50 @@
+//go:build tinygo
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"syscall/js"
+
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/mod"
+	"mochi/types"
+)
+
+func runMochi(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return js.ValueOf("missing source")
+	}
+	src := args[0].String()
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		return js.ValueOf(err.Error())
+	}
+	env := types.NewEnv(nil)
+	var buf bytes.Buffer
+	env.SetWriter(&buf)
+	modRoot, errRoot := mod.FindRoot(".")
+	if errRoot != nil {
+		modRoot = "."
+	}
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		var sb strings.Builder
+		for _, e := range errs {
+			sb.WriteString(e.Error())
+			sb.WriteByte('\n')
+		}
+		return js.ValueOf(sb.String())
+	}
+	interp := interpreter.New(prog, env, modRoot)
+	if err := interp.Run(); err != nil {
+		return js.ValueOf(err.Error())
+	}
+	return js.ValueOf(buf.String())
+}
+
+func main() {
+	js.Global().Set("runMochi", js.FuncOf(runMochi))
+	select {}
+}

--- a/tools/playground/playground_test.go
+++ b/tools/playground/playground_test.go
@@ -1,0 +1,68 @@
+//go:build slow
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPlaygroundWasm(t *testing.T) {
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("tinygo not installed")
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not installed")
+	}
+
+	tmp := t.TempDir()
+
+	wasmPath := filepath.Join(tmp, "mochi.wasm")
+	buildCmd := exec.Command("tinygo", "build", "-o", wasmPath, "-target", "wasm", "./")
+	buildCmd.Dir = filepath.Join("tools", "playground")
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("tinygo build failed: %v\n%s", err, out)
+	}
+
+	src := filepath.Join(runtime.GOROOT(), "lib", "wasm", "wasm_exec.js")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read wasm_exec.js: %v", err)
+	}
+	wasmExec := filepath.Join(tmp, "wasm_exec.js")
+	if err := os.WriteFile(wasmExec, data, 0644); err != nil {
+		t.Fatalf("write wasm_exec.js: %v", err)
+	}
+
+	runJS := filepath.Join(tmp, "run.js")
+	script := `const fs = require('fs');
+require('./wasm_exec.js');
+const go = new globalThis.Go();
+WebAssembly.instantiate(fs.readFileSync('mochi.wasm'), go.importObject).then((res) => {
+  go.run(res.instance);
+  const out = globalThis.runMochi('print("hello playground")');
+  console.log(out);
+}).catch(err => { console.error(err); process.exit(1); });`
+	if err := os.WriteFile(runJS, []byte(script), 0644); err != nil {
+		t.Fatalf("write run.js: %v", err)
+	}
+
+	nodeCmd := exec.Command("node", "run.js")
+	nodeCmd.Dir = tmp
+	var buf bytes.Buffer
+	nodeCmd.Stdout = &buf
+	nodeCmd.Stderr = &buf
+	if err := nodeCmd.Run(); err != nil {
+		t.Fatalf("node run failed: %v\n%s", err, buf.String())
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != "hello playground" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a simple playground using TinyGo compiled WASM runtime
- style with Tailwind CSS inspired by shadcn
- document how to build the playground and mention Cloudflare Pages site
- test running the TinyGo WASM module
- add Makefile with commands for building and serving
- ignore generated wasm artifacts
- add Cloudflare/GitHub Pages deploy targets in Makefile

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856fb61344c8320a020fa674270be26