### PR TITLE
Add cloud tests and Makefile

### DIFF
--- a/cmd/cloud-server/main.go
+++ b/cmd/cloud-server/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"mochi/runtime/cloud"
+)
+
+func main() {
+	addr := flag.String("addr", ":7777", "listen address")
+	flag.Parse()
+	srv := cloud.NewServer()
+	log.Printf("listening on %s", *addr)
+	if err := http.ListenAndServe(*addr, srv.Handler()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/lib/cloud/Makefile
+++ b/lib/cloud/Makefile
@@ -1,0 +1,25 @@
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+MOCHI := go run ../../cmd/mochi/main.go
+SERVER := go run ../../cmd/cloud-server/main.go
+PORT ?= 7777
+
+.PHONY: test server help
+
+## Run the in-memory cloud server
+server:
+	$(SERVER) -addr :$(PORT)
+
+## Run Mochi tests against the local server
+test:
+	$(SERVER) -addr :$(PORT) & \
+	pid=$$!; \
+	sleep 0.5; \
+	$(MOCHI) test ./cloud_test.mochi; \
+	kill $$pid
+
+## Show available commands
+help:
+	@echo "Commands:";
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS=":"}; {printf "  %-10s %s\n", $$1, $$2}'

--- a/lib/cloud/README.md
+++ b/lib/cloud/README.md
@@ -1,0 +1,32 @@
+# Cloud Library
+
+This package provides simple building blocks for cloud-style applications.
+Resources are accessed over HTTP and use JSON for requests and responses.
+
+Supported primitives:
+
+- **Bucket** – store and retrieve objects by key.
+- **Queue** – push and pop messages.
+
+Each resource is created with a base URL pointing at a server that implements
+its API. Headers can be provided for authentication.
+
+These modules are implemented entirely in Mochi to keep the syntax concise
+and familiar.
+
+## Planned objects
+
+The initial release only includes the Bucket and Queue clients. The following
+objects are planned for future versions:
+
+- [ ] Function
+- [ ] Topic
+- [ ] Table
+- [ ] Counter
+- [ ] Schedule
+- [ ] Secret
+- [ ] FileSystem
+- [ ] API
+
+These placeholders represent the set of cloud primitives we would like to
+support over time. Contributions are welcome.

--- a/lib/cloud/bucket.mochi
+++ b/lib/cloud/bucket.mochi
@@ -1,0 +1,53 @@
+package cloud
+
+/// Bucket client bound to a specific service endpoint.
+type Bucket {
+  base_url: string,
+  name: string,
+  headers: map<string,string>
+}
+
+/// Create a bucket client for the given name.
+export fun bucket(name: string, base_url: string, headers: map<string,string>): Bucket {
+  return Bucket { base_url: base_url, name: name, headers: headers }
+}
+
+/// Internal helper to build endpoint URLs.
+fun bucket_url(b: Bucket, path: string): string {
+  return b.base_url + "/v1/buckets/" + b.name + path
+}
+
+/// Retrieve an object by key.
+export fun bucket_get(b: Bucket, key: string): any {
+  return fetch bucket_url(b, "/object") with {
+    query: { key: key },
+    headers: b.headers
+  }
+}
+
+/// Store or overwrite an object.
+export fun bucket_put(b: Bucket, key: string, value: any): any {
+  return fetch bucket_url(b, "/object") with {
+    method: "POST",
+    query: { key: key },
+    headers: b.headers,
+    body: value
+  }
+}
+
+/// Delete an object.
+export fun bucket_delete(b: Bucket, key: string): any {
+  return fetch bucket_url(b, "/object") with {
+    method: "DELETE",
+    query: { key: key },
+    headers: b.headers
+  }
+}
+
+/// List objects with optional prefix filtering.
+export fun bucket_list(b: Bucket, prefix: string): list<string> {
+  return fetch bucket_url(b, "/list") with {
+    query: { prefix: prefix },
+    headers: b.headers
+  } as list<string>
+}

--- a/lib/cloud/cloud_test.mochi
+++ b/lib/cloud/cloud_test.mochi
@@ -1,0 +1,21 @@
+import "lib/cloud" as cloud
+
+let base = "http://localhost:7777"
+
+// basic round-trip for bucket
+
+test "bucket" {
+  let b = cloud.bucket("test", base, {})
+  cloud.bucket_put(b, "foo", {v: 1})
+  let obj = cloud.bucket_get(b, "foo")
+  expect obj.v == 1
+}
+
+// push and pop for queue
+
+test "queue" {
+  let q = cloud.queue("jobs", base, {})
+  cloud.queue_push(q, {msg: "hi"})
+  let res = cloud.queue_pop(q)
+  expect res.msg == "hi"
+}

--- a/lib/cloud/queue.mochi
+++ b/lib/cloud/queue.mochi
@@ -1,0 +1,34 @@
+package cloud
+
+/// Queue client for simple message delivery.
+type Queue {
+  base_url: string,
+  name: string,
+  headers: map<string,string>
+}
+
+/// Create a queue client.
+export fun queue(name: string, base_url: string, headers: map<string,string>): Queue {
+  return Queue { base_url: base_url, name: name, headers: headers }
+}
+
+/// Internal helper for endpoint URLs.
+fun queue_url(q: Queue, path: string): string {
+  return q.base_url + "/v1/queues/" + q.name + path
+}
+
+/// Push a message onto the queue.
+export fun queue_push(q: Queue, msg: any): any {
+  return fetch queue_url(q, "/push") with {
+    method: "POST",
+    headers: q.headers,
+    body: msg
+  }
+}
+
+/// Pop the next message from the queue.
+export fun queue_pop(q: Queue): any {
+  return fetch queue_url(q, "/pop") with {
+    headers: q.headers
+  }
+}

--- a/runtime/cloud/server.go
+++ b/runtime/cloud/server.go
@@ -1,0 +1,208 @@
+package cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// Bucket defines the behavior for storing objects.
+type Bucket interface {
+	Get(key string) (any, bool)
+	Put(key string, v any)
+	Delete(key string)
+	List(prefix string) []string
+}
+
+// Queue defines a simple FIFO message queue.
+type Queue interface {
+	Push(msg any)
+	Pop() (any, bool)
+}
+
+// Server implements an in-memory bucket and queue service.
+type Server struct {
+	mu      sync.Mutex
+	buckets map[string]map[string]any
+	queues  map[string][]any
+}
+
+// Bucket returns a Bucket instance for the given name backed by the server.
+func (s *Server) Bucket(name string) Bucket {
+	return &memBucket{s: s, name: name}
+}
+
+// Queue returns a Queue instance for the given name backed by the server.
+func (s *Server) Queue(name string) Queue {
+	return &memQueue{s: s, name: name}
+}
+
+// NewServer returns a new in-memory Server.
+func NewServer() *Server {
+	return &Server{
+		buckets: make(map[string]map[string]any),
+		queues:  make(map[string][]any),
+	}
+}
+
+type memBucket struct {
+	s    *Server
+	name string
+}
+
+func (b *memBucket) Get(key string) (any, bool) {
+	b.s.mu.Lock()
+	defer b.s.mu.Unlock()
+	bucket, ok := b.s.buckets[b.name]
+	if !ok {
+		return nil, false
+	}
+	val, ok := bucket[key]
+	return val, ok
+}
+
+func (b *memBucket) Put(key string, v any) {
+	b.s.mu.Lock()
+	defer b.s.mu.Unlock()
+	bucket, ok := b.s.buckets[b.name]
+	if !ok {
+		bucket = map[string]any{}
+		b.s.buckets[b.name] = bucket
+	}
+	bucket[key] = v
+}
+
+func (b *memBucket) Delete(key string) {
+	b.s.mu.Lock()
+	defer b.s.mu.Unlock()
+	if bucket, ok := b.s.buckets[b.name]; ok {
+		delete(bucket, key)
+	}
+}
+
+func (b *memBucket) List(prefix string) []string {
+	b.s.mu.Lock()
+	defer b.s.mu.Unlock()
+	bucket, ok := b.s.buckets[b.name]
+	if !ok {
+		return nil
+	}
+	keys := []string{}
+	for k := range bucket {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+type memQueue struct {
+	s    *Server
+	name string
+}
+
+func (q *memQueue) Push(msg any) {
+	q.s.mu.Lock()
+	defer q.s.mu.Unlock()
+	q.s.queues[q.name] = append(q.s.queues[q.name], msg)
+}
+
+func (q *memQueue) Pop() (any, bool) {
+	q.s.mu.Lock()
+	defer q.s.mu.Unlock()
+	qq := q.s.queues[q.name]
+	if len(qq) == 0 {
+		return nil, false
+	}
+	msg := qq[0]
+	q.s.queues[q.name] = qq[1:]
+	return msg, true
+}
+
+// Handler returns an http.Handler exposing the cloud API.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/buckets/", s.handleBucket)
+	mux.HandleFunc("/v1/queues/", s.handleQueue)
+	return mux
+}
+
+func (s *Server) handleBucket(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/v1/buckets/"), "/")
+	if len(parts) < 2 {
+		http.Error(w, "bad bucket path", http.StatusNotFound)
+		return
+	}
+	name := parts[0]
+	action := parts[1]
+	b := s.Bucket(name)
+	key := r.URL.Query().Get("key")
+	switch action {
+	case "object":
+		switch r.Method {
+		case http.MethodGet:
+			val, ok := b.Get(key)
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(w).Encode(val)
+		case http.MethodPost:
+			var v any
+			if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			b.Put(key, v)
+			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case http.MethodDelete:
+			b.Delete(key)
+			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	case "list":
+		prefix := r.URL.Query().Get("prefix")
+		json.NewEncoder(w).Encode(b.List(prefix))
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+	}
+}
+
+func (s *Server) handleQueue(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/v1/queues/"), "/")
+	if len(parts) < 2 {
+		http.Error(w, "bad queue path", http.StatusNotFound)
+		return
+	}
+	name := parts[0]
+	action := parts[1]
+	q := s.Queue(name)
+	switch action {
+	case "push":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var msg any
+		if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		q.Push(msg)
+		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	case "pop":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if msg, ok := q.Pop(); ok {
+			json.NewEncoder(w).Encode(msg)
+		} else {
+			json.NewEncoder(w).Encode(nil)
+		}
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+	}
+}

--- a/runtime/cloud/server_test.go
+++ b/runtime/cloud/server_test.go
@@ -1,0 +1,112 @@
+package cloud
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/mod"
+	"mochi/types"
+)
+
+func TestServer_BucketQueueHTTP(t *testing.T) {
+	srv := NewServer()
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/buckets/test/object?key=a", "application/json", strings.NewReader(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	res, err := http.Get(ts.URL + "/v1/buckets/test/object?key=a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if obj["x"].(float64) != 1 {
+		t.Fatalf("unexpected object: %v", obj)
+	}
+
+	_, err = http.Post(ts.URL+"/v1/queues/q/push", "application/json", strings.NewReader(`"hello"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err = http.Get(ts.URL + "/v1/queues/q/pop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ = io.ReadAll(res.Body)
+	res.Body.Close()
+	var msg string
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if msg != "hello" {
+		t.Fatalf("unexpected msg: %s", msg)
+	}
+}
+
+func TestServer_MochiIntegration(t *testing.T) {
+	srv := NewServer()
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	src := `import "lib/cloud" as cloud
+let b = cloud.bucket("files", "` + ts.URL + `", {})
+cloud.bucket_put(b, "foo", {v:1})
+json(cloud.bucket_get(b, "foo"))
+let q = cloud.queue("q", "` + ts.URL + `", {})
+cloud.queue_push(q, {msg:"hi"})
+json(cloud.queue_pop(q))`
+
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	abs, _ := filepath.Abs("..")
+	modRoot, _ := mod.FindRoot(abs)
+	out := &strings.Builder{}
+	interp := interpreter.New(prog, env, modRoot)
+	interp.Env().SetWriter(out)
+	if err := interp.Run(); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "\"v\": 1") || !strings.Contains(s, "\"msg\": \"hi\"") {
+		t.Fatalf("unexpected output:\n%s", s)
+	}
+}
+
+func TestServerInterfaces(t *testing.T) {
+	srv := NewServer()
+	b := srv.Bucket("x")
+	b.Put("k", 1)
+	if v, ok := b.Get("k"); !ok || v.(int) != 1 {
+		t.Fatalf("unexpected bucket get: %v %v", v, ok)
+	}
+	if keys := b.List("k"); len(keys) != 1 || keys[0] != "k" {
+		t.Fatalf("unexpected list: %v", keys)
+	}
+	q := srv.Queue("q")
+	q.Push("m")
+	if v, ok := q.Pop(); !ok || v.(string) != "m" {
+		t.Fatalf("unexpected pop: %v %v", v, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- add a standalone runtime server command
- add Makefile for lib/cloud with helper commands
- create mochitest verifying bucket and queue operations

## Testing
- `go test ./runtime/cloud` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6856f795bd9c83208805ba03744ff99d