### PR TITLE
Add basic Docker library

### DIFF
--- a/lib/cloud/docker/README.md
+++ b/lib/cloud/docker/README.md
@@ -1,0 +1,21 @@
+# Docker Cloud Library for Mochi
+
+This library provides a minimal toolkit for orchestrating Docker
+images and containers directly from Mochi scripts. It exposes simple
+APIs for defining images and running containers. Each object type is
+defined in its own folder for clarity.
+
+## Usage
+
+```mochi
+import "lib/cloud/docker" as docker
+
+let img = docker.image("my-image", ".")
+img.build()
+
+let ctr = docker.container("my-container", img, ["-p", "80:80"])
+ctr.run()
+```
+
+The library only prints the Docker commands, making it safe to use in
+environments without the Docker CLI installed.

--- a/lib/cloud/docker/containers/container.mochi
+++ b/lib/cloud/docker/containers/container.mochi
@@ -1,0 +1,23 @@
+package cloud/docker/containers
+
+import "../images/image" as images
+
+type Container {
+  name: string,
+  image: images.Image,
+  args: list<string>
+}
+
+/// Create a new container based on an image.
+fun container(name: string, image: images.Image, args: list<string> = []): Container {
+  return Container { name: name, image: image, args: args }
+}
+
+/// Run the container. This just prints the command used.
+fun Container.run(c: Container) {
+  let cmd = "docker run --name " + c.name + " " + c.image.name
+  for arg in c.args {
+    cmd = cmd + " " + arg
+  }
+  print(cmd)
+}

--- a/lib/cloud/docker/images/image.mochi
+++ b/lib/cloud/docker/images/image.mochi
@@ -1,0 +1,16 @@
+package cloud/docker/images
+
+type Image {
+  name: string,
+  context: string
+}
+
+/// Create a new docker image reference.
+fun image(name: string, context: string = "."): Image {
+  return Image { name: name, context: context }
+}
+
+/// Build the docker image. This just prints the command used.
+fun Image.build(img: Image) {
+  print("docker build -t" , img.name , img.context)
+}

--- a/lib/cloud/docker/mod.mochi
+++ b/lib/cloud/docker/mod.mochi
@@ -1,0 +1,4 @@
+package cloud/docker
+
+export * from "./images/image"
+export * from "./containers/container"

--- a/tests/interpreter/valid/docker_basic.mochi
+++ b/tests/interpreter/valid/docker_basic.mochi
@@ -1,0 +1,7 @@
+import "../../lib/cloud/docker" as docker
+
+let img = docker.image("test", "./app")
+img.build()
+
+let ctr = docker.container("myctr", img, ["-d"])
+ctr.run()

--- a/tests/interpreter/valid/docker_basic.out
+++ b/tests/interpreter/valid/docker_basic.out
@@ -1,0 +1,2 @@
+docker build -t test ./app
+docker run --name myctr test -d


### PR DESCRIPTION
## Summary
- add new library at `lib/cloud/docker` with image and container objects
- expose functions to print docker commands instead of running them
- document usage in README
- add integration test verifying docker command output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685705abcaf083209aa80c255910532d