### PR TITLE
Add pure Mochi k8s library

### DIFF
--- a/lib/cloud/k8s/README.md
+++ b/lib/cloud/k8s/README.md
@@ -1,0 +1,30 @@
+# k8s Mochi Library
+
+This library provides helper functions to generate basic Kubernetes resources directly from Mochi code. Each resource type lives in its own package under this directory.
+
+## Packages
+
+- `cluster` – manage a collection of manifests
+- `deployment` – create Deployment manifests
+- `service` – create Service manifests
+- `configmap` – create ConfigMap manifests
+- `namespace` – create Namespace manifests
+
+## Usage
+
+Import the desired packages and compose resources. Example:
+
+```mochi
+import "lib/cloud/k8s/cluster" as cluster
+import "lib/cloud/k8s/deployment" as deployment
+import "lib/cloud/k8s/service" as service
+
+let c = cluster.new("demo")
+let d = deployment.new("web", "nginx:latest", 2)
+cluster.add(c, d)
+let s = service.new("web", 80, 80)
+cluster.add(c, s)
+print(cluster.manifest(c))
+```
+
+Running the above will print the combined YAML manifest for the cluster.

--- a/lib/cloud/k8s/cluster/cluster.mochi
+++ b/lib/cloud/k8s/cluster/cluster.mochi
@@ -1,0 +1,31 @@
+package cluster
+
+type Cluster {
+  name: string,
+  resources: list<string>
+}
+
+fun new(name: string): Cluster {
+  return Cluster { name: name, resources: [] }
+}
+
+fun add(c: Cluster, manifest: string): void {
+  c.resources = c.resources + [manifest]
+}
+
+fun manifest(c: Cluster): string {
+  var result = ""
+  var first = true
+  for r in c.resources {
+    if !first {
+      result = result + "\n---\n"
+    }
+    result = result + r
+    first = false
+  }
+  return result
+}
+
+fun apply(c: Cluster) {
+  print(manifest(c))
+}

--- a/lib/cloud/k8s/configmap/configmap.mochi
+++ b/lib/cloud/k8s/configmap/configmap.mochi
@@ -1,0 +1,22 @@
+package configmap
+
+fun map_to_yaml(data: map<string,string>, indent: string): string {
+  var result = ""
+  var first = true
+  for k in keys(data) {
+    if !first { result = result + "\n" }
+    result = result + indent + k + ": " + data[k]
+    first = false
+  }
+  return result
+}
+
+/// Kubernetes ConfigMap resource
+fun new(name: string, data: map<string,string>): string {
+  return "apiVersion: v1\n" +
+         "kind: ConfigMap\n" +
+         "metadata:\n" +
+         "  name: " + name + "\n" +
+         "data:\n" +
+         map_to_yaml(data, "  ") + "\n"
+}

--- a/lib/cloud/k8s/deployment/deployment.mochi
+++ b/lib/cloud/k8s/deployment/deployment.mochi
@@ -1,0 +1,22 @@
+package deployment
+
+/// Kubernetes Deployment resource
+fun new(name: string, image: string, replicas: int = 1): string {
+  return "apiVersion: apps/v1\n" +
+         "kind: Deployment\n" +
+         "metadata:\n" +
+         "  name: " + name + "\n" +
+         "spec:\n" +
+         "  replicas: " + str(replicas) + "\n" +
+         "  selector:\n" +
+         "    matchLabels:\n" +
+         "      app: " + name + "\n" +
+         "  template:\n" +
+         "    metadata:\n" +
+         "      labels:\n" +
+         "        app: " + name + "\n" +
+         "    spec:\n" +
+         "      containers:\n" +
+         "        - name: " + name + "\n" +
+         "          image: " + image + "\n"
+}

--- a/lib/cloud/k8s/namespace/namespace.mochi
+++ b/lib/cloud/k8s/namespace/namespace.mochi
@@ -1,0 +1,9 @@
+package namespace
+
+/// Kubernetes Namespace resource
+fun new(name: string): string {
+  return "apiVersion: v1\n" +
+         "kind: Namespace\n" +
+         "metadata:\n" +
+         "  name: " + name + "\n"
+}

--- a/lib/cloud/k8s/service/service.mochi
+++ b/lib/cloud/k8s/service/service.mochi
@@ -1,0 +1,15 @@
+package service
+
+/// Kubernetes Service resource
+fun new(name: string, port: int, target_port: int): string {
+  return "apiVersion: v1\n" +
+         "kind: Service\n" +
+         "metadata:\n" +
+         "  name: " + name + "\n" +
+         "spec:\n" +
+         "  selector:\n" +
+         "    app: " + name + "\n" +
+         "  ports:\n" +
+         "    - port: " + str(port) + "\n" +
+         "      targetPort: " + str(target_port) + "\n"
+}

--- a/tests/cloud/k8s/k8s_cluster.mochi
+++ b/tests/cloud/k8s/k8s_cluster.mochi
@@ -1,0 +1,13 @@
+import "lib/cloud/k8s/cluster" as cluster
+import "lib/cloud/k8s/deployment" as deployment
+import "lib/cloud/k8s/service" as service
+import "lib/cloud/k8s/configmap" as configmap
+
+let c = cluster.new("demo")
+let d = deployment.new("web", "nginx:latest", 2)
+cluster.add(c, d)
+let s = service.new("web", 80, 80)
+cluster.add(c, s)
+let conf = configmap.new("app-cfg", {"ENV": "prod"})
+cluster.add(c, conf)
+print(cluster.manifest(c))

--- a/tests/cloud/k8s/k8s_cluster.out
+++ b/tests/cloud/k8s/k8s_cluster.out
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:latest
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  selector:
+    app: web
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-cfg
+data:
+  ENV: prod
+


### PR DESCRIPTION
## Summary
- implement a new Kubernetes helper library in `lib/cloud/k8s`
- support cluster, deployment, service, configmap and namespace
- add documentation and example usage
- test YAML generation under `tests/cloud/k8s`
- move tests out of the interpreter folder

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685705b8ccdc8320b3307bbf4081176a