### PR TITLE
Generate terraform config

### DIFF
--- a/cloud/terraform_test.go
+++ b/cloud/terraform_test.go
@@ -1,0 +1,34 @@
+package cloud_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/golden"
+	"mochi/interpreter"
+	"mochi/parser"
+	"mochi/runtime/mod"
+	"mochi/types"
+)
+
+func TestTerraformExamples(t *testing.T) {
+	golden.Run(t, "tests/cloud/terraform", ".mochi", ".out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, err
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, errs[0]
+		}
+		modRoot, _ := mod.FindRoot(filepath.Dir(src))
+		interp := interpreter.New(prog, env, modRoot)
+		out := &strings.Builder{}
+		interp.Env().SetWriter(out)
+		if err := interp.Run(); err != nil {
+			return nil, err
+		}
+		return []byte(out.String()), nil
+	})
+}

--- a/lib/cloud/terraform/compute/container.mochi
+++ b/lib/cloud/terraform/compute/container.mochi
@@ -1,0 +1,20 @@
+package compute
+
+type Container {
+  name: string
+  image: string
+  cpu: int
+  memory: int
+}
+
+export fun container(name: string, image: string, cpu: int, memory: int): Container {
+  return Container { name: name, image: image, cpu: cpu, memory: memory }
+}
+
+export fun to_tf(c: Container): string {
+  return "resource \"container\" \"" + c.name + "\" {\n" +
+         "  image = \"" + c.image + "\"\n" +
+         "  cpu = " + str(c.cpu) + "\n" +
+         "  memory = " + str(c.memory) + "\n" +
+         "}\n"
+}

--- a/lib/cloud/terraform/compute/function.mochi
+++ b/lib/cloud/terraform/compute/function.mochi
@@ -1,0 +1,18 @@
+package compute
+
+type Function {
+  name: string
+  runtime: string
+  handler: string
+}
+
+export fun function(name: string, runtime: string, handler: string): Function {
+  return Function { name: name, runtime: runtime, handler: handler }
+}
+
+export fun to_tf(f: Function): string {
+  return "resource \"function\" \"" + f.name + "\" {\n" +
+         "  runtime = \"" + f.runtime + "\"\n" +
+         "  handler = \"" + f.handler + "\"\n" +
+         "}\n"
+}

--- a/lib/cloud/terraform/main.mochi
+++ b/lib/cloud/terraform/main.mochi
@@ -1,0 +1,62 @@
+package terraform
+
+import "./compute/function" as compute
+import "./compute/container" as compute_container
+import "./storage/bucket" as storage
+import "./storage/table" as storage_table
+import "./network/queue" as network
+import "./network/topic" as network_topic
+
+type Stack {
+  resources: list<string>
+}
+
+export fun new_stack(): Stack {
+  return Stack { resources: [] }
+}
+
+fun join_strings(items: list<string>, sep: string): string {
+  var out = ""
+  var first = true
+  for it in items {
+    if first {
+      out = it
+      first = false
+    } else {
+      out = out + sep + it
+    }
+  }
+  return out
+}
+
+export fun synthesize(s: Stack): string {
+  return join_strings(s.resources, "\n")
+}
+
+export fun add(s: Stack, cfg: string): Stack {
+  return Stack { resources: s.resources + [cfg] }
+}
+
+export fun function(name: string, runtime: string, handler: string): string {
+  return compute.to_tf(compute.function(name, runtime, handler))
+}
+
+export fun bucket(name: string, versioned: bool): string {
+  return storage.to_tf(storage.bucket(name, versioned))
+}
+
+export fun queue(name: string, visibility_timeout: int): string {
+  return network.to_tf(network.queue(name, visibility_timeout))
+}
+
+export fun container(name: string, image: string, cpu: int, memory: int): string {
+  return compute_container.to_tf(compute_container.container(name, image, cpu, memory))
+}
+
+export fun table(name: string, partition_key: string, sort_key: string): string {
+  return storage_table.to_tf(storage_table.table(name, partition_key, sort_key))
+}
+
+export fun topic(name: string, subscribers: int): string {
+  return network_topic.to_tf(network_topic.topic(name, subscribers))
+}

--- a/lib/cloud/terraform/network/queue.mochi
+++ b/lib/cloud/terraform/network/queue.mochi
@@ -1,0 +1,16 @@
+package network
+
+type Queue {
+  name: string
+  visibility_timeout: int
+}
+
+export fun queue(name: string, visibility_timeout: int): Queue {
+  return Queue { name: name, visibility_timeout: visibility_timeout }
+}
+
+export fun to_tf(q: Queue): string {
+  return "resource \"queue\" \"" + q.name + "\" {\n" +
+         "  visibility_timeout = " + str(q.visibility_timeout) + "\n" +
+         "}\n"
+}

--- a/lib/cloud/terraform/network/topic.mochi
+++ b/lib/cloud/terraform/network/topic.mochi
@@ -1,0 +1,16 @@
+package network
+
+type Topic {
+  name: string
+  subscribers: int
+}
+
+export fun topic(name: string, subscribers: int): Topic {
+  return Topic { name: name, subscribers: subscribers }
+}
+
+export fun to_tf(t: Topic): string {
+  return "resource \"topic\" \"" + t.name + "\" {\n" +
+         "  subscribers = " + str(t.subscribers) + "\n" +
+         "}\n"
+}

--- a/lib/cloud/terraform/storage/bucket.mochi
+++ b/lib/cloud/terraform/storage/bucket.mochi
@@ -1,0 +1,16 @@
+package storage
+
+type Bucket {
+  name: string
+  versioned: bool
+}
+
+export fun bucket(name: string, versioned: bool): Bucket {
+  return Bucket { name: name, versioned: versioned }
+}
+
+export fun to_tf(b: Bucket): string {
+  return "resource \"bucket\" \"" + b.name + "\" {\n" +
+         "  versioned = " + str(b.versioned) + "\n" +
+         "}\n"
+}

--- a/lib/cloud/terraform/storage/table.mochi
+++ b/lib/cloud/terraform/storage/table.mochi
@@ -1,0 +1,18 @@
+package storage
+
+type Table {
+  name: string
+  partition_key: string
+  sort_key: string
+}
+
+export fun table(name: string, partition_key: string, sort_key: string): Table {
+  return Table { name: name, partition_key: partition_key, sort_key: sort_key }
+}
+
+export fun to_tf(t: Table): string {
+  return "resource \"table\" \"" + t.name + "\" {\n" +
+         "  partition_key = \"" + t.partition_key + "\"\n" +
+         "  sort_key = \"" + t.sort_key + "\"\n" +
+         "}\n"
+}

--- a/tests/cloud/terraform/basic_stack.mochi
+++ b/tests/cloud/terraform/basic_stack.mochi
@@ -1,0 +1,18 @@
+import "lib/cloud/terraform" as tf
+
+var stack = tf.new_stack()
+let fn = tf.function("hello", "python3.11", "main.handler")
+let bucket = tf.bucket("files", true)
+let queue = tf.queue("tasks", 30)
+let container = tf.container("svc", "registry/app:latest", 512, 1024)
+let topic = tf.topic("events", 5)
+let table = tf.table("users", "id", "ts")
+
+stack = tf.add(stack, fn)
+stack = tf.add(stack, bucket)
+stack = tf.add(stack, queue)
+stack = tf.add(stack, container)
+stack = tf.add(stack, topic)
+stack = tf.add(stack, table)
+
+print(tf.synthesize(stack))

--- a/tests/cloud/terraform/basic_stack.out
+++ b/tests/cloud/terraform/basic_stack.out
@@ -1,0 +1,27 @@
+resource "function" "hello" {
+  runtime = "python3.11"
+  handler = "main.handler"
+}
+
+resource "bucket" "files" {
+  versioned = true
+}
+
+resource "queue" "tasks" {
+  visibility_timeout = 30
+}
+
+resource "container" "svc" {
+  image = "registry/app:latest"
+  cpu = 512
+  memory = 1024
+}
+
+resource "topic" "events" {
+  subscribers = 5
+}
+
+resource "table" "users" {
+  partition_key = "id"
+  sort_key = "ts"
+}


### PR DESCRIPTION
## Summary
- adjust Terraform library to output resource strings
- revise `Stack` helpers to join config and handle adds immutably
- update library exports for containers, topics, tables
- expand Terraform example and golden output
- add Go test harness for Terraform examples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685703578ee083209838428a8c02961a