### PR TITLE
Add gcloud runtime and move tests

### DIFF
--- a/lib/cloud/gcloud/README.md
+++ b/lib/cloud/gcloud/README.md
@@ -1,0 +1,13 @@
+# GCloud Mochi Library
+
+This library offers a tiny Google Cloud wrapper using Mochi's `fetch` statement.
+It communicates with the API helpers implemented in `runtime/cloud/gcloud`.
+Create a `Client` then use the storage, pubsub, and functions submodules.
+
+````mochi
+import "lib/cloud/gcloud" as gcloud
+import "lib/cloud/gcloud/storage" as storage
+
+let gc = gcloud.client("my-project", "TOKEN")
+let bucket = storage.create(gc, "my-bucket")
+````

--- a/lib/cloud/gcloud/functions/functions.mochi
+++ b/lib/cloud/gcloud/functions/functions.mochi
@@ -1,0 +1,12 @@
+package functions
+
+import ".." as gcloud
+
+/// Call a deployed Cloud Function.
+export fun call(c: gcloud.Client, name: string, data: string): any {
+  return fetch gcloud.Client.serviceEndpoint(c, "functions", "/v1/projects/" + c.project + "/locations/" + c.region + "/functions/" + name + ":call") with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { data: data }
+  }
+}

--- a/lib/cloud/gcloud/gcloud.mochi
+++ b/lib/cloud/gcloud/gcloud.mochi
@@ -1,0 +1,32 @@
+package gcloud
+
+type Client {
+  project: string,
+  token: string,
+  region: string,
+}
+
+/// Create a new Google Cloud client.
+export fun client(project: string, token: string, region: string = "us-central1"): Client {
+  return Client { project: project, token: token, region: region }
+}
+
+/// Authorization header for requests.
+export fun Client.authHeader(c: Client): map<string,string> {
+  return { "Authorization": "Bearer " + c.token }
+}
+
+/// Construct a service endpoint URL.
+export fun Client.serviceEndpoint(c: Client, service: string, path: string): string {
+  var host = "https://"
+  if service == "storage" {
+    host = host + "storage.googleapis.com"
+  } else if service == "pubsub" {
+    host = host + "pubsub.googleapis.com"
+  } else if service == "functions" {
+    host = host + c.region + "-cloudfunctions.googleapis.com"
+  } else {
+    host = host + service
+  }
+  return host + path
+}

--- a/lib/cloud/gcloud/pubsub/pubsub.mochi
+++ b/lib/cloud/gcloud/pubsub/pubsub.mochi
@@ -1,0 +1,50 @@
+package pubsub
+
+import ".." as gcloud
+
+/// Pub/Sub topic representation.
+type Topic { name: string }
+
+/// Subscription representation.
+type Subscription { name: string }
+
+/// Create a new topic.
+export fun create_topic(c: gcloud.Client, name: string): Topic {
+  fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/topics/" + name) with {
+    method: "PUT",
+    headers: gcloud.Client.authHeader(c)
+  }
+  return Topic { name: name }
+}
+
+/// Publish messages to a topic.
+export fun publish(c: gcloud.Client, topic: string, messages: list<map<string,string>>) {
+  fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/topics/" + topic + ":publish") with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { messages: messages }
+  }
+}
+
+/// Create a subscription for a topic.
+export fun create_subscription(c: gcloud.Client, name: string, topic: string): Subscription {
+  fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/subscriptions/" + name) with {
+    method: "PUT",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { topic: "projects/" + c.project + "/topics/" + topic }
+  }
+  return Subscription { name: name }
+}
+
+/// Pull messages from a subscription.
+export fun pull(c: gcloud.Client, subscription: string, max_messages: int = 1): list<any> {
+  var resp = fetch gcloud.Client.serviceEndpoint(c, "pubsub", "/v1/projects/" + c.project + "/subscriptions/" + subscription + ":pull") with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { maxMessages: max_messages }
+  } as map<string, any>
+  if "receivedMessages" in resp {
+    return resp.receivedMessages as list<any>
+  }
+  return []
+}

--- a/lib/cloud/gcloud/storage/storage.mochi
+++ b/lib/cloud/gcloud/storage/storage.mochi
@@ -1,0 +1,40 @@
+package storage
+
+import ".." as gcloud
+
+/// Storage bucket representation.
+type Bucket { name: string }
+
+/// Create a new bucket in the configured project.
+export fun create(c: gcloud.Client, name: string): Bucket {
+  fetch gcloud.Client.serviceEndpoint(c, "storage", "/storage/v1/b?project=" + c.project) with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c) + { "Content-Type": "application/json" },
+    body: { name: name }
+  }
+  return Bucket { name: name }
+}
+
+/// Upload an object to a bucket.
+export fun upload(c: gcloud.Client, bucket: string, object: string, data: string) {
+  fetch gcloud.Client.serviceEndpoint(c, "storage", "/upload/storage/v1/b/" + bucket + "/o?uploadType=media&name=" + object) with {
+    method: "POST",
+    headers: gcloud.Client.authHeader(c),
+    body: data
+  }
+}
+
+/// Download an object from a bucket.
+export fun download(c: gcloud.Client, bucket: string, object: string): string {
+  return fetch gcloud.Client.serviceEndpoint(c, "storage", "/storage/v1/b/" + bucket + "/o/" + object + "?alt=media") with {
+    headers: gcloud.Client.authHeader(c)
+  } as string
+}
+
+/// Delete an object from a bucket.
+export fun delete(c: gcloud.Client, bucket: string, object: string) {
+  fetch gcloud.Client.serviceEndpoint(c, "storage", "/storage/v1/b/" + bucket + "/o/" + object) with {
+    method: "DELETE",
+    headers: gcloud.Client.authHeader(c)
+  }
+}

--- a/runtime/cloud/gcloud/README.md
+++ b/runtime/cloud/gcloud/README.md
@@ -1,0 +1,5 @@
+# runtime/cloud/gcloud
+
+This package provides minimal helpers for interacting with Google Cloud services using Go. It mirrors the functionality exposed in `lib/cloud/gcloud` so Mochi programs compiled to Go can leverage the same API surface.
+
+The package offers a `Client` type and helpers for Storage, Pub/Sub, and Cloud Functions. All operations are implemented using the public REST endpoints.

--- a/runtime/cloud/gcloud/functions.go
+++ b/runtime/cloud/gcloud/functions.go
@@ -1,0 +1,10 @@
+package gcloud
+
+// CallFunction invokes a deployed Cloud Function.
+func (c Client) CallFunction(name string, data string) (any, error) {
+	url := c.ServiceEndpoint("functions", "/v1/projects/"+c.Project+"/locations/"+c.Region+"/functions/"+name+":call")
+	body := map[string]any{"data": data}
+	var resp any
+	err := c.fetch("POST", url, mergeHeaders(c.AuthHeader(), map[string]string{"Content-Type": "application/json"}), body, &resp)
+	return resp, err
+}

--- a/runtime/cloud/gcloud/gcloud.go
+++ b/runtime/cloud/gcloud/gcloud.go
@@ -1,0 +1,74 @@
+package gcloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Client provides authenticated access to Google Cloud services.
+type Client struct {
+	Project string
+	Token   string
+	Region  string
+}
+
+// NewClient returns a new Client.
+func NewClient(project, token, region string) Client {
+	if region == "" {
+		region = "us-central1"
+	}
+	return Client{Project: project, Token: token, Region: region}
+}
+
+// AuthHeader returns the authorization header for a client.
+func (c Client) AuthHeader() map[string]string {
+	return map[string]string{"Authorization": "Bearer " + c.Token}
+}
+
+// ServiceEndpoint builds the fully qualified service URL.
+func (c Client) ServiceEndpoint(service, path string) string {
+	host := "https://"
+	switch service {
+	case "storage":
+		host += "storage.googleapis.com"
+	case "pubsub":
+		host += "pubsub.googleapis.com"
+	case "functions":
+		host += fmt.Sprintf("%s-cloudfunctions.googleapis.com", c.Region)
+	default:
+		host += service
+	}
+	return host + path
+}
+
+// fetch performs an HTTP request with the provided options and decodes the JSON response into out if given.
+func (c Client) fetch(method, url string, headers map[string]string, body any, out any) error {
+	var r io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		r = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, url, r)
+	if err != nil {
+		return err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/runtime/cloud/gcloud/pubsub.go
+++ b/runtime/cloud/gcloud/pubsub.go
@@ -1,0 +1,52 @@
+package gcloud
+
+// Topic represents a Pub/Sub topic.
+type Topic struct{ Name string }
+
+// Subscription represents a Pub/Sub subscription.
+type Subscription struct{ Name string }
+
+// CreateTopic creates a topic.
+func (c Client) CreateTopic(name string) (Topic, error) {
+	url := c.ServiceEndpoint("pubsub", "/v1/projects/"+c.Project+"/topics/"+name)
+	err := c.fetch("PUT", url, c.AuthHeader(), nil, nil)
+	if err != nil {
+		return Topic{}, err
+	}
+	return Topic{Name: name}, nil
+}
+
+// Publish publishes messages to a topic.
+func (c Client) Publish(topic string, messages []map[string]string) error {
+	url := c.ServiceEndpoint("pubsub", "/v1/projects/"+c.Project+"/topics/"+topic+":publish")
+	body := map[string]any{"messages": messages}
+	return c.fetch("POST", url, mergeHeaders(c.AuthHeader(), map[string]string{"Content-Type": "application/json"}), body, nil)
+}
+
+// CreateSubscription creates a subscription to a topic.
+func (c Client) CreateSubscription(name, topic string) (Subscription, error) {
+	url := c.ServiceEndpoint("pubsub", "/v1/projects/"+c.Project+"/subscriptions/"+name)
+	body := map[string]any{"topic": "projects/" + c.Project + "/topics/" + topic}
+	err := c.fetch("PUT", url, mergeHeaders(c.AuthHeader(), map[string]string{"Content-Type": "application/json"}), body, nil)
+	if err != nil {
+		return Subscription{}, err
+	}
+	return Subscription{Name: name}, nil
+}
+
+// Pull retrieves messages from a subscription.
+func (c Client) Pull(subscription string, max int) ([]any, error) {
+	url := c.ServiceEndpoint("pubsub", "/v1/projects/"+c.Project+"/subscriptions/"+subscription+":pull")
+	if max <= 0 {
+		max = 1
+	}
+	body := map[string]any{"maxMessages": max}
+	var resp struct {
+		ReceivedMessages []any `json:"receivedMessages"`
+	}
+	err := c.fetch("POST", url, mergeHeaders(c.AuthHeader(), map[string]string{"Content-Type": "application/json"}), body, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp.ReceivedMessages, nil
+}

--- a/runtime/cloud/gcloud/server.go
+++ b/runtime/cloud/gcloud/server.go
@@ -1,0 +1,137 @@
+package gcloud
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// Server exposes a minimal HTTP API for Mochi fetch calls.
+type Server struct{ Client Client }
+
+// NewServer creates a new Server with the provided client.
+func NewServer(c Client) *Server { return &Server{Client: c} }
+
+// Register installs HTTP handlers on the given mux under /gcloud/.
+func (s *Server) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/gcloud/storage/create", s.handleCreateBucket)
+	mux.HandleFunc("/gcloud/storage/upload", s.handleUpload)
+	mux.HandleFunc("/gcloud/storage/download", s.handleDownload)
+	mux.HandleFunc("/gcloud/storage/delete", s.handleDelete)
+	mux.HandleFunc("/gcloud/pubsub/createTopic", s.handleCreateTopic)
+	mux.HandleFunc("/gcloud/pubsub/publish", s.handlePublish)
+	mux.HandleFunc("/gcloud/pubsub/createSubscription", s.handleCreateSubscription)
+	mux.HandleFunc("/gcloud/pubsub/pull", s.handlePull)
+	mux.HandleFunc("/gcloud/functions/call", s.handleCallFunction)
+}
+
+func readJSON(r *http.Request, v any) error {
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func writeJSON(w http.ResponseWriter, v any, err error) {
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if v == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	data, e := json.Marshal(v)
+	if e != nil {
+		http.Error(w, e.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+func (s *Server) handleCreateBucket(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Name string }
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	res, err := s.Client.CreateBucket(req.Name)
+	writeJSON(w, res, err)
+}
+func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Bucket, Object, Data string }
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	writeJSON(w, nil, s.Client.Upload(req.Bucket, req.Object, req.Data))
+}
+func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Bucket, Object string }
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	res, err := s.Client.Download(req.Bucket, req.Object)
+	writeJSON(w, res, err)
+}
+func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Bucket, Object string }
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	writeJSON(w, nil, s.Client.Delete(req.Bucket, req.Object))
+}
+func (s *Server) handleCreateTopic(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Name string }
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	res, err := s.Client.CreateTopic(req.Name)
+	writeJSON(w, res, err)
+}
+func (s *Server) handlePublish(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Topic    string
+		Messages []map[string]string
+	}
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	writeJSON(w, nil, s.Client.Publish(req.Topic, req.Messages))
+}
+func (s *Server) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Name, Topic string }
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	res, err := s.Client.CreateSubscription(req.Name, req.Topic)
+	writeJSON(w, res, err)
+}
+func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Subscription string
+		Max          int
+	}
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	res, err := s.Client.Pull(req.Subscription, req.Max)
+	writeJSON(w, res, err)
+}
+func (s *Server) handleCallFunction(w http.ResponseWriter, r *http.Request) {
+	var req struct{ Name, Data string }
+	if err := readJSON(r, &req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	res, err := s.Client.CallFunction(req.Name, req.Data)
+	writeJSON(w, res, err)
+}

--- a/runtime/cloud/gcloud/storage.go
+++ b/runtime/cloud/gcloud/storage.go
@@ -1,0 +1,48 @@
+package gcloud
+
+// Bucket represents a Cloud Storage bucket.
+type Bucket struct{ Name string }
+
+// CreateBucket creates a new bucket.
+func (c Client) CreateBucket(name string) (Bucket, error) {
+	url := c.ServiceEndpoint("storage", "/storage/v1/b?project="+c.Project)
+	err := c.fetch("POST", url, mergeHeaders(c.AuthHeader(), map[string]string{"Content-Type": "application/json"}), map[string]any{"name": name}, nil)
+	if err != nil {
+		return Bucket{}, err
+	}
+	return Bucket{Name: name}, nil
+}
+
+// Upload uploads an object to the bucket.
+func (c Client) Upload(bucket, object, data string) error {
+	url := c.ServiceEndpoint("storage", "/upload/storage/v1/b/"+bucket+"/o?uploadType=media&name="+object)
+	return c.fetch("POST", url, c.AuthHeader(), data, nil)
+}
+
+// Download retrieves an object from the bucket.
+func (c Client) Download(bucket, object string) (string, error) {
+	url := c.ServiceEndpoint("storage", "/storage/v1/b/"+bucket+"/o/"+object+"?alt=media")
+	var out string
+	err := c.fetch("GET", url, c.AuthHeader(), nil, &out)
+	return out, err
+}
+
+// Delete removes an object from the bucket.
+func (c Client) Delete(bucket, object string) error {
+	url := c.ServiceEndpoint("storage", "/storage/v1/b/"+bucket+"/o/"+object)
+	return c.fetch("DELETE", url, c.AuthHeader(), nil, nil)
+}
+
+func mergeHeaders(a, b map[string]string) map[string]string {
+	if len(b) == 0 {
+		return a
+	}
+	out := make(map[string]string, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}

--- a/tests/cloud/gcloud/endpoint.mochi
+++ b/tests/cloud/gcloud/endpoint.mochi
@@ -1,0 +1,4 @@
+import "lib/cloud/gcloud" as gcloud
+
+let c = gcloud.client("demo", "tkn")
+print(gcloud.Client.serviceEndpoint(c, "storage", "/test"))

--- a/tests/cloud/gcloud/endpoint.out
+++ b/tests/cloud/gcloud/endpoint.out
@@ -1,0 +1,1 @@
+https://storage.googleapis.com/test


### PR DESCRIPTION
## Summary
- introduce runtime/cloud/gcloud package
- provide storage, pubsub, and functions helpers and HTTP server
- update lib/cloud/gcloud README
- move gcloud tests under tests/cloud

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68570333766c8320b5749bac9b4ef93b