### PR TITLE
Fix go vet self-assignment

### DIFF
--- a/compile/fortran/compiler.go
+++ b/compile/fortran/compiler.go
@@ -1118,7 +1118,6 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					expr = fmt.Sprintf("int(%s)", expr)
 				} else if op.Cast.Type.Generic != nil && op.Cast.Type.Generic.Name == "list" {
 					// no-op for list casts
-					expr = expr
 				} else {
 					return "", fmt.Errorf("unsupported cast")
 				}


### PR DESCRIPTION
## Summary
- remove a self-assignment detected by go vet in `compile/fortran`

## Testing
- `go vet ./compile/fortran`


------
https://chatgpt.com/codex/tasks/task_e_68579c2aff448320a64c4bc48baa8205