### PR TITLE
Fix go vet issue

### DIFF
--- a/compile/swift/compiler.go
+++ b/compile/swift/compiler.go
@@ -471,7 +471,6 @@ func (c *Compiler) compileFor(f *parser.ForStmt) error {
 			return nil
 		}
 	}
-	return nil
 }
 
 func (c *Compiler) compileIf(ifst *parser.IfStmt) error {


### PR DESCRIPTION
## Summary
- remove unreachable return statement in the Swift compiler

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68579c360a848320b06c4441d331b4b4