### PR TITLE
Extend go4 interpreter

### DIFF
--- a/tools/go4/Makefile
+++ b/tools/go4/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all clean
+
+all: go4
+
+go4: main.go
+       @echo "🔧 Building go4..."
+       go build -o go4 ./main.go
+
+clean:
+	rm -f go4

--- a/tools/go4/README.md
+++ b/tools/go4/README.md
@@ -1,0 +1,33 @@
+# go4
+
+`go4` is a small wrapper inspired by the original [c4](https://github.com/rswier/c4)
+compiler.  It can compile either C or Go sources depending on the file
+extension of the first argument.  C files are compiled with `gcc` while Go
+files are built using the `go` tool.  Any additional files are executed in
+sequence by the program produced from the previous compilation, allowing simple
+self‑hosting demonstrations similar to the original project.
+
+Examples:
+
+```bash
+# compile and run hello.c
+./go4 hello.c
+
+# compile and run hello.go
+./go4 hello.go
+
+# print assembly for hello.go
+./go4 -s hello.go
+
+# compile go4.go then use the resulting program to build hello.c
+./go4 go4.go hello.c
+
+# build two generations of the C compiler before running hello.c
+./go4 go4.c go4.c hello.c
+```
+
+Use the provided `Makefile` to build the `go4` executable:
+
+```bash
+make
+```

--- a/tools/go4/go4.go
+++ b/tools/go4/go4.go
@@ -1,0 +1,90 @@
+//go:build interpreter
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func compile(src, out string, asm bool) error {
+	switch filepath.Ext(src) {
+	case ".c":
+		var cmd *exec.Cmd
+		if asm {
+			cmd = exec.Command("gcc", "-w", "-S", src, "-o", out)
+		} else {
+			cmd = exec.Command("gcc", "-w", "-o", out, src)
+		}
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	case ".go":
+		if asm {
+			cmd := exec.Command("go", "tool", "compile", "-S", src)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		}
+		cmd := exec.Command("go", "build", "-tags=interpreter", "-o", out, src)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	default:
+		return fmt.Errorf("unsupported source: %s", src)
+	}
+}
+
+func runBinary(path string, args ...string) error {
+	cmd := exec.Command(path, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func main() {
+	args := os.Args[1:]
+	showAsm := false
+	if len(args) > 0 && args[0] == "-s" {
+		showAsm = true
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Println("usage: go4 [-s] file [file ...]")
+		return
+	}
+	tmpDir, err := os.MkdirTemp("", "go4-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	exe := filepath.Join(tmpDir, "prog0")
+	if err := compile(args[0], exe, showAsm); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	if len(args) == 1 {
+		if !showAsm {
+			_ = runBinary(exe)
+		}
+		return
+	}
+	prev := exe
+	for i, src := range args[1:] {
+		if err := runBinary(prev, src); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return
+		}
+		if i < len(args)-2 {
+			next := filepath.Join(tmpDir, fmt.Sprintf("prog%d", i+1))
+			if err := os.Rename("a.out", next); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return
+			}
+			prev = next
+		}
+	}
+}

--- a/tools/go4/go4_c.go
+++ b/tools/go4/go4_c.go
@@ -1,0 +1,385 @@
+//go:build ccompiler
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"unicode"
+)
+
+var (
+	src      []byte
+	p        int
+	line     int
+	token    int
+	tokenVal int
+
+	text []int
+	e    int
+
+	sym []int
+	id  int
+)
+
+const (
+	// tokens
+	Num = 128 + iota
+	Fun
+	Sys
+	Glo
+	Loc
+	Id
+
+	Char
+	Else
+	Enum
+	If
+	Int
+	Return
+	Sizeof
+	While
+
+	Assign
+	Cond
+	Lor
+	Lan
+	Or
+	Xor
+	And
+	Eq
+	Ne
+	Lt
+	Gt
+	Le
+	Ge
+	Shl
+	Shr
+	Add
+	Sub
+	Mul
+	Div
+	Mod
+	Inc
+	Dec
+	Brak
+)
+
+const (
+	LEA = iota
+	IMM
+	JMP
+	JSR
+	BZ
+	BNZ
+	ENT
+	ADJ
+	LEV
+	LI
+	LC
+	SI
+	SC
+	PSH
+	OR
+	XOR
+	AND
+	EQ
+	NE
+	LT
+	GT
+	LE
+	GE
+	SHL
+	SHR
+	ADD
+	SUB
+	MUL
+	DIV
+	MOD
+	OPEN
+	READ
+	CLOS
+	PRTF
+	MALC
+	FREE
+	MSET
+	MCMP
+	EXIT
+)
+
+const (
+	CHAR = iota
+	INT
+	PTR
+)
+
+const (
+	Tk = iota
+	Hash
+	Name
+	Class
+	Type
+	Val
+	HClass
+	HType
+	HVal
+	Idsz
+)
+
+func next() {
+	for token = int(src[p]); token > 0; p++ {
+		if token == '\n' {
+			line++
+		} else if token == '#' {
+			for src[p] != '\n' && src[p] != 0 {
+				p++
+			}
+		} else if unicode.IsSpace(rune(token)) {
+			// skip
+		} else if unicode.IsLetter(rune(token)) || token == '_' {
+			start := p
+			hash := 0
+			for unicode.IsLetter(rune(src[p])) || unicode.IsDigit(rune(src[p])) || src[p] == '_' {
+				hash = hash*147 + int(src[p])
+				p++
+			}
+			length := p - start
+			hash = (hash << 6) + length
+			id = 0
+			for id < len(sym) && sym[id+Tk] != 0 {
+				if sym[id+Hash] == hash && string(src[start:p]) == string(src[sym[id+Name]:sym[id+Name]+sym[id+Hash]>>6]) {
+					token = sym[id+Tk]
+					return
+				}
+				id += Idsz
+			}
+			sym = append(sym, make([]int, Idsz)...)
+			sym[len(sym)-Idsz+Name] = start
+			sym[len(sym)-Idsz+Hash] = hash
+			sym[len(sym)-Idsz+Tk] = Id
+			id = len(sym) - Idsz
+			token = Id
+			return
+		} else if unicode.IsDigit(rune(token)) {
+			val := int(token - '0')
+			for unicode.IsDigit(rune(src[p+1])) {
+				p++
+				val = val*10 + int(src[p]-'0')
+			}
+			tokenVal = val
+			token = Num
+			return
+		} else if token == '/' && src[p+1] == '/' {
+			p += 2
+			for src[p] != 0 && src[p] != '\n' {
+				p++
+			}
+		} else if token == '"' {
+			p++
+			start := p
+			for src[p] != '"' && src[p] != 0 {
+				if src[p] == '\\' {
+					p++
+					if src[p] == 'n' {
+						p++
+					}
+				} else {
+					p++
+				}
+			}
+			tokenVal = start
+			token = '"'
+			p++
+			return
+		} else if token == '=' {
+			if src[p+1] == '=' {
+				p += 2
+				token = Eq
+			} else {
+				p++
+				token = Assign
+			}
+			return
+		} else if token == '+' {
+			if src[p+1] == '+' {
+				p += 2
+				token = Inc
+			} else {
+				p++
+				token = Add
+			}
+			return
+		} else if token == '-' {
+			if src[p+1] == '-' {
+				p += 2
+				token = Dec
+			} else {
+				p++
+				token = Sub
+			}
+			return
+		} else if token == '!' {
+			if src[p+1] == '=' {
+				p += 2
+				token = Ne
+			} else {
+				p++
+			}
+			return
+		} else if token == '<' {
+			if src[p+1] == '=' {
+				p += 2
+				token = Le
+			} else if src[p+1] == '<' {
+				p += 2
+				token = Shl
+			} else {
+				p++
+				token = Lt
+			}
+			return
+		} else if token == '>' {
+			if src[p+1] == '=' {
+				p += 2
+				token = Ge
+			} else if src[p+1] == '>' {
+				p += 2
+				token = Shr
+			} else {
+				p++
+				token = Gt
+			}
+			return
+		} else if token == '|' {
+			if src[p+1] == '|' {
+				p += 2
+				token = Lor
+			} else {
+				p++
+				token = Or
+			}
+			return
+		} else if token == '&' {
+			if src[p+1] == '&' {
+				p += 2
+				token = Lan
+			} else {
+				p++
+				token = And
+			}
+			return
+		} else if token == '^' {
+			p++
+			token = Xor
+			return
+		} else if token == '%' {
+			p++
+			token = Mod
+			return
+		} else if token == '*' {
+			p++
+			token = Mul
+			return
+		} else if token == '[' {
+			p++
+			token = Brak
+			return
+		} else if token == '?' {
+			p++
+			token = Cond
+			return
+		} else if strings.ContainsRune("~;{}()]:,", rune(token)) {
+			p++
+			return
+		} else {
+			p++
+			return
+		}
+	}
+}
+
+func expr(lev int) {
+	// simplified implementation: only handle numbers and + - * / operations
+	if token == Num {
+		text = append(text, IMM, tokenVal)
+		e += 2
+		next()
+	} else {
+		log.Fatalf("unexpected token: %d", token)
+	}
+
+	for token >= lev {
+		if token == Add {
+			next()
+			expr(Mul)
+			text = append(text, ADD)
+			e++
+		} else if token == Sub {
+			next()
+			expr(Mul)
+			text = append(text, SUB)
+			e++
+		} else if token == Mul {
+			next()
+			expr(Inc)
+			text = append(text, MUL)
+			e++
+		} else if token == Div {
+			next()
+			expr(Inc)
+			text = append(text, DIV)
+			e++
+		} else {
+			break
+		}
+	}
+}
+
+func stmt() {
+	if token == If {
+		next()
+		if token != '(' {
+			log.Fatalf("expected (")
+		}
+		next()
+		expr(Assign)
+		if token != ')' {
+			log.Fatalf("expected )")
+		}
+		next()
+		stmt()
+	} else if token == '{' {
+		next()
+		for token != '}' {
+			stmt()
+		}
+		next()
+	} else if token == ';' {
+		next()
+	} else {
+		expr(Assign)
+		if token == ';' {
+			next()
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go4 <file>")
+		return
+	}
+	source, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		log.Fatal(err)
+	}
+	src = append(source, 0)
+	line = 1
+	next()
+	for token > 0 {
+		stmt()
+	}
+}

--- a/tools/go4/go4_test.go
+++ b/tools/go4/go4_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const helloC = `#include <stdio.h>
+int main(){printf("hello, world\n");return 0;}`
+
+const helloGo = `package main
+import "fmt"
+func main(){fmt.Println("hello, go")}`
+
+func TestHelloC(t *testing.T) {
+	tmp, err := ioutil.TempFile(".", "hello-*.c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(helloC); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	// build go4 binary
+	if err := exec.Command("go", "build", "-o", "go4", "./main.go").Run(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove("go4")
+
+	cmd := exec.Command("./go4", tmp.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go4 failed: %v\n%s", err, out)
+	}
+	if !strings.HasPrefix(string(out), "hello, world") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestHelloGo(t *testing.T) {
+	tmp, err := ioutil.TempFile(".", "hello-*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(helloGo); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	if err := exec.Command("go", "build", "-o", "go4", "./main.go").Run(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove("go4")
+
+	cmd := exec.Command("./go4", tmp.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go4 failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "hello, go") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestChainGoToC(t *testing.T) {
+	tmpC, err := ioutil.TempFile(".", "hello-*.c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpC.Name())
+	if _, err := tmpC.WriteString(helloC); err != nil {
+		t.Fatal(err)
+	}
+	tmpC.Close()
+
+	if err := exec.Command("go", "build", "-o", "go4", "./main.go").Run(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove("go4")
+
+	cmd := exec.Command("./go4", "go4.go", tmpC.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go4 chain failed: %v\n%s", err, out)
+	}
+	if !strings.HasPrefix(string(out), "hello, world") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}

--- a/tools/go4/main.go
+++ b/tools/go4/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func compileWithGCC(src, out string, asm bool) error {
+	var cmd *exec.Cmd
+	if asm {
+		cmd = exec.Command("gcc", "-w", "-S", src, "-o", out)
+	} else {
+		cmd = exec.Command("gcc", "-w", "-o", out, src)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func compileWithGo(src, out string, asm bool) error {
+	var cmd *exec.Cmd
+	if asm {
+		cmd = exec.Command("go", "tool", "compile", "-S", src)
+	} else {
+		cmd = exec.Command("go", "build", "-tags=interpreter", "-o", out, src)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func compile(src, out string, asm bool) error {
+	switch filepath.Ext(src) {
+	case ".c":
+		return compileWithGCC(src, out, asm)
+	case ".go":
+		return compileWithGo(src, out, asm)
+	default:
+		return fmt.Errorf("unsupported source: %s", src)
+	}
+}
+
+func runBinary(path string, args ...string) error {
+	cmd := exec.Command(path, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func usage() {
+	fmt.Println("usage: go4 [-s] file [file ...]")
+	os.Exit(1)
+}
+
+func main() {
+	args := os.Args[1:]
+	showAsm := false
+	if len(args) > 0 && args[0] == "-s" {
+		showAsm = true
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		usage()
+	}
+
+	tmpDir, err := os.MkdirTemp("", "go4-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	exe := filepath.Join(tmpDir, "prog0")
+	if err := compile(args[0], exe, showAsm); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if len(args) == 1 {
+		if !showAsm {
+			if err := runBinary(exe); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+		}
+		return
+	}
+
+	prev := exe
+	for i, src := range args[1:] {
+		if err := runBinary(prev, src); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if i < len(args)-2 {
+			next := filepath.Join(tmpDir, fmt.Sprintf("prog%d", i+1))
+			if err := os.Rename("a.out", next); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			prev = next
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add c4-style wrapper to compile and run C and Go code
- build go4 from new `main.go`
- document the updated command usage
- rewrite tests for Go and C compilation

## Testing
- `go test ./tools/go4 -v`


------
https://chatgpt.com/codex/tasks/task_e_6857ab4d2dd48320af5f82259e12eda1