### PR TITLE
Add v0.9.0 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # 📦 CHANGELOG.md
+## [0.9.0] – 2025-07-01
+
+### Added
+
+* Official `std/` standard library packages (`math`, `strings`, `time`, `list`, `set`, `uuid`, `fmt`, `test`)
+* CLI autoload support and documentation extraction for standard packages
+
+### Changed
+
+* Explicit `export` requirements for library functions
+* Improved package import paths for `std/` modules
+
+### Fixed
+
+* Minor package import bugs and builtin function errors
+
 ## [0.8.10] – 2025-06-22
 
 ### Added

--- a/releases/v0.9.0.md
+++ b/releases/v0.9.0.md
@@ -1,0 +1,27 @@
+# Jul 2025 (v0.9.0)
+
+Mochi v0.9.0 ships the first official standard library. Core utilities for math,
+strings, time and collections are now provided as regular packages under the
+`std/` namespace. The CLI can autoload these modules and extract documentation
+from them, improving developer ergonomics.
+
+## Standard Library
+
+- `std/` namespace for all built‑in packages
+- New packages: `std/math`, `std/strings`, `std/time`, `std/list`, `std/set`,
+  `std/uuid`, `std/fmt` and `std/test`
+- Functions are explicitly exported and imported by name
+- Documentation embedded in each module and retrievable via the CLI
+
+## Tooling
+
+- CLI autoload support for standard library packages
+- Documentation extraction commands for package modules
+
+## Tests
+
+- Comprehensive tests covering standard library APIs
+
+## Fixes
+
+- Miscellaneous bug fixes in package imports and built‑in functions


### PR DESCRIPTION
## Summary
- add release notes for v0.9.0
- update CHANGELOG for v0.9.0

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685820b25e5083208b0c44f10f383b8e