### PR TITLE
Normalize MLIR golden tests

### DIFF
--- a/compile/mlir/compiler_test.go
+++ b/compile/mlir/compiler_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -299,6 +300,8 @@ func normalizeOutput(t *testing.T, b []byte) []byte {
 	out = strings.ReplaceAll(out, filepath.ToSlash(root), "")
 	out = strings.ReplaceAll(out, "github.com/mochi-lang/mochi/", "")
 	out = strings.ReplaceAll(out, "mochi/tests/", "tests/")
+	tmpRE := regexp.MustCompile(`/tmp/mochi-mlir-[0-9]+`)
+	out = tmpRE.ReplaceAllString(out, "/tmp/mochi-mlir-X")
 	out = strings.TrimSpace(out)
 	return []byte(out)
 }

--- a/tests/compiler/c/arithmetic.mlir.out
+++ b/tests/compiler/c/arithmetic.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-140990071/main.c'
-source_filename = "/tmp/mochi-mlir-140990071/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/avg_builtin.mlir.out
+++ b/tests/compiler/c/avg_builtin.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2803775294/main.c'
-source_filename = "/tmp/mochi-mlir-2803775294/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/bool_ops.mlir.out
+++ b/tests/compiler/c/bool_ops.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-958605674/main.c'
-source_filename = "/tmp/mochi-mlir-958605674/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/break_continue.mlir.out
+++ b/tests/compiler/c/break_continue.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3761869034/main.c'
-source_filename = "/tmp/mochi-mlir-3761869034/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/count_builtin.mlir.out
+++ b/tests/compiler/c/count_builtin.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-497512968/main.c'
-source_filename = "/tmp/mochi-mlir-497512968/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/factorial.mlir.out
+++ b/tests/compiler/c/factorial.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1219252896/main.c'
-source_filename = "/tmp/mochi-mlir-1219252896/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/fibonacci.mlir.out
+++ b/tests/compiler/c/fibonacci.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-129334455/main.c'
-source_filename = "/tmp/mochi-mlir-129334455/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/float_literal_precision.mlir.out
+++ b/tests/compiler/c/float_literal_precision.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-940016507/main.c'
-source_filename = "/tmp/mochi-mlir-940016507/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/float_ops.mlir.out
+++ b/tests/compiler/c/float_ops.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1444706644/main.c'
-source_filename = "/tmp/mochi-mlir-1444706644/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/for_list_collection.mlir.out
+++ b/tests/compiler/c/for_list_collection.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2164098970/main.c'
-source_filename = "/tmp/mochi-mlir-2164098970/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/for_loop.mlir.out
+++ b/tests/compiler/c/for_loop.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-4053340107/main.c'
-source_filename = "/tmp/mochi-mlir-4053340107/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/for_string_collection.mlir.out
+++ b/tests/compiler/c/for_string_collection.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1494023358/main.c'
-source_filename = "/tmp/mochi-mlir-1494023358/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/hello_world.mlir.out
+++ b/tests/compiler/c/hello_world.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-4085463073/main.c'
-source_filename = "/tmp/mochi-mlir-4085463073/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/if_else.mlir.out
+++ b/tests/compiler/c/if_else.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1563657384/main.c'
-source_filename = "/tmp/mochi-mlir-1563657384/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/input_builtin.mlir.out
+++ b/tests/compiler/c/input_builtin.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3194107920/main.c'
-source_filename = "/tmp/mochi-mlir-3194107920/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/int_float_add.mlir.out
+++ b/tests/compiler/c/int_float_add.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2860923160/main.c'
-source_filename = "/tmp/mochi-mlir-2860923160/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/len_builtin.mlir.out
+++ b/tests/compiler/c/len_builtin.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1077893566/main.c'
-source_filename = "/tmp/mochi-mlir-1077893566/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_concat.mlir.out
+++ b/tests/compiler/c/list_concat.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3066123506/main.c'
-source_filename = "/tmp/mochi-mlir-3066123506/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_except.mlir.out
+++ b/tests/compiler/c/list_except.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-559099307/main.c'
-source_filename = "/tmp/mochi-mlir-559099307/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_float_ops.mlir.out
+++ b/tests/compiler/c/list_float_ops.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3893890668/main.c'
-source_filename = "/tmp/mochi-mlir-3893890668/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_index.mlir.out
+++ b/tests/compiler/c/list_index.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2417399290/main.c'
-source_filename = "/tmp/mochi-mlir-2417399290/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_intersect.mlir.out
+++ b/tests/compiler/c/list_intersect.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1025882397/main.c'
-source_filename = "/tmp/mochi-mlir-1025882397/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_slice.mlir.out
+++ b/tests/compiler/c/list_slice.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-4155605639/main.c'
-source_filename = "/tmp/mochi-mlir-4155605639/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_string_param.mlir.out
+++ b/tests/compiler/c/list_string_param.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-4123871219/main.c'
-source_filename = "/tmp/mochi-mlir-4123871219/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_union.mlir.out
+++ b/tests/compiler/c/list_union.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-311735486/main.c'
-source_filename = "/tmp/mochi-mlir-311735486/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/list_union_all.mlir.out
+++ b/tests/compiler/c/list_union_all.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3495269328/main.c'
-source_filename = "/tmp/mochi-mlir-3495269328/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/match_basic.mlir.out
+++ b/tests/compiler/c/match_basic.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1355557692/main.c'
-source_filename = "/tmp/mochi-mlir-1355557692/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/matrix_search.mlir.out
+++ b/tests/compiler/c/matrix_search.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2137641309/main.c'
-source_filename = "/tmp/mochi-mlir-2137641309/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/membership.mlir.out
+++ b/tests/compiler/c/membership.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2217544568/main.c'
-source_filename = "/tmp/mochi-mlir-2217544568/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/now_builtin.mlir.out
+++ b/tests/compiler/c/now_builtin.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-4152866878/main.c'
-source_filename = "/tmp/mochi-mlir-4152866878/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/reserved_keyword_var.mlir.out
+++ b/tests/compiler/c/reserved_keyword_var.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1413401712/main.c'
-source_filename = "/tmp/mochi-mlir-1413401712/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/simple_fn.mlir.out
+++ b/tests/compiler/c/simple_fn.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-729999376/main.c'
-source_filename = "/tmp/mochi-mlir-729999376/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/str_builtin.mlir.out
+++ b/tests/compiler/c/str_builtin.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3146459682/main.c'
-source_filename = "/tmp/mochi-mlir-3146459682/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/string_concat.mlir.out
+++ b/tests/compiler/c/string_concat.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3541334032/main.c'
-source_filename = "/tmp/mochi-mlir-3541334032/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/string_for_loop.mlir.out
+++ b/tests/compiler/c/string_for_loop.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-4219317181/main.c'
-source_filename = "/tmp/mochi-mlir-4219317181/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/string_len.mlir.out
+++ b/tests/compiler/c/string_len.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2746409300/main.c'
-source_filename = "/tmp/mochi-mlir-2746409300/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/string_slice.mlir.out
+++ b/tests/compiler/c/string_slice.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2976830895/main.c'
-source_filename = "/tmp/mochi-mlir-2976830895/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/var_assignment.mlir.out
+++ b/tests/compiler/c/var_assignment.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-740432065/main.c'
-source_filename = "/tmp/mochi-mlir-740432065/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/c/while_loop.mlir.out
+++ b/tests/compiler/c/while_loop.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3166037659/main.c'
-source_filename = "/tmp/mochi-mlir-3166037659/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/break_continue.mlir.out
+++ b/tests/compiler/valid/break_continue.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-881518719/main.c'
-source_filename = "/tmp/mochi-mlir-881518719/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/fold_pure_let.mlir.out
+++ b/tests/compiler/valid/fold_pure_let.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1315017796/main.c'
-source_filename = "/tmp/mochi-mlir-1315017796/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/for_list_collection.mlir.out
+++ b/tests/compiler/valid/for_list_collection.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3307301577/main.c'
-source_filename = "/tmp/mochi-mlir-3307301577/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/for_loop.mlir.out
+++ b/tests/compiler/valid/for_loop.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1279054039/main.c'
-source_filename = "/tmp/mochi-mlir-1279054039/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/for_string_collection.mlir.out
+++ b/tests/compiler/valid/for_string_collection.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2850243155/main.c'
-source_filename = "/tmp/mochi-mlir-2850243155/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/fun_call.mlir.out
+++ b/tests/compiler/valid/fun_call.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2365638956/main.c'
-source_filename = "/tmp/mochi-mlir-2365638956/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/generate_echo.mlir.out
+++ b/tests/compiler/valid/generate_echo.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1367295861/main.c'
-source_filename = "/tmp/mochi-mlir-1367295861/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/grouped_expr.mlir.out
+++ b/tests/compiler/valid/grouped_expr.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1972777032/main.c'
-source_filename = "/tmp/mochi-mlir-1972777032/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/if_else.mlir.out
+++ b/tests/compiler/valid/if_else.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2879187523/main.c'
-source_filename = "/tmp/mochi-mlir-2879187523/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/len_builtin.mlir.out
+++ b/tests/compiler/valid/len_builtin.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2311944803/main.c'
-source_filename = "/tmp/mochi-mlir-2311944803/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/let_and_print.mlir.out
+++ b/tests/compiler/valid/let_and_print.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1773413423/main.c'
-source_filename = "/tmp/mochi-mlir-1773413423/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/list_index.mlir.out
+++ b/tests/compiler/valid/list_index.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2319506965/main.c'
-source_filename = "/tmp/mochi-mlir-2319506965/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/list_set.mlir.out
+++ b/tests/compiler/valid/list_set.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3501880997/main.c'
-source_filename = "/tmp/mochi-mlir-3501880997/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/match_expr.mlir.out
+++ b/tests/compiler/valid/match_expr.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2127019728/main.c'
-source_filename = "/tmp/mochi-mlir-2127019728/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/print_hello.mlir.out
+++ b/tests/compiler/valid/print_hello.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1937388831/main.c'
-source_filename = "/tmp/mochi-mlir-1937388831/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/stream_on_emit.mlir.out
+++ b/tests/compiler/valid/stream_on_emit.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2677398971/main.c'
-source_filename = "/tmp/mochi-mlir-2677398971/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/test_block.mlir.out
+++ b/tests/compiler/valid/test_block.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-1560196561/main.c'
-source_filename = "/tmp/mochi-mlir-1560196561/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/var_assignment.mlir.out
+++ b/tests/compiler/valid/var_assignment.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-3076056024/main.c'
-source_filename = "/tmp/mochi-mlir-3076056024/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 

--- a/tests/compiler/valid/while_loop.mlir.out
+++ b/tests/compiler/valid/while_loop.mlir.out
@@ -1,5 +1,5 @@
-; ModuleID = '/tmp/mochi-mlir-2980983653/main.c'
-source_filename = "/tmp/mochi-mlir-2980983653/main.c"
+; ModuleID = '/tmp/mochi-mlir-X/main.c'
+source_filename = "/tmp/mochi-mlir-X/main.c"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 


### PR DESCRIPTION
## Summary
- normalize temp directory names in MLIR golden tests
- regenerate golden output with stable path prefix

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685848df37f083209161d7cb6481e2c3