### PR TITLE
Add Windows support for compiler ensure tools

### DIFF
--- a/compile/c/tools.go
+++ b/compile/c/tools.go
@@ -48,6 +48,20 @@ func EnsureCC() (string, error) {
 			fmt.Println("🍺 Installing LLVM via Homebrew...")
 			_ = exec.Command("brew", "install", "llvm").Run()
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🔧 Installing GCC via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "mingw")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🔧 Installing GCC via Scoop...")
+			cmd := exec.Command("scoop", "install", "mingw")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if path, err := exec.LookPath("cc"); err == nil {
 		return path, nil

--- a/compile/clj/tools.go
+++ b/compile/clj/tools.go
@@ -42,6 +42,24 @@ func EnsureClojure() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "clojure")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("clojure"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "clojure")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("clojure"); err == nil {
+				return nil
+			}
+		}
 	}
 	if _, err := exec.LookPath("clojure"); err == nil {
 		return nil

--- a/compile/cobol/tools.go
+++ b/compile/cobol/tools.go
@@ -23,6 +23,24 @@ func EnsureCOBOL() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "gnucobol")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("cobc"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "gnucobol")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("cobc"); err == nil {
+				return nil
+			}
+		}
 	default:
 		if _, err := exec.LookPath("apt-get"); err == nil {
 			cmd := exec.Command("apt-get", "update")

--- a/compile/cpp/tools.go
+++ b/compile/cpp/tools.go
@@ -43,6 +43,20 @@ func EnsureCPP() (string, error) {
 			fmt.Println("🍺 Installing LLVM via Homebrew...")
 			_ = exec.Command("brew", "install", "llvm").Run()
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🔧 Installing g++ via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "mingw")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🔧 Installing g++ via Scoop...")
+			cmd := exec.Command("scoop", "install", "mingw")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if path, err := exec.LookPath("g++"); err == nil {
 		return path, nil

--- a/compile/cs/tools.go
+++ b/compile/cs/tools.go
@@ -45,6 +45,24 @@ func ensureDotnet() error {
 				}
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "dotnet-sdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("dotnet"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "dotnet-sdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("dotnet"); err == nil {
+				return nil
+			}
+		}
 	}
 	fmt.Println("🔧 Installing dotnet...")
 	home := os.Getenv("HOME")

--- a/compile/dart/tools.go
+++ b/compile/dart/tools.go
@@ -34,6 +34,25 @@ func ensureDart() error {
 	osName := "linux"
 	if runtime.GOOS == "darwin" {
 		osName = "macos"
+	} else if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "dart-sdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("dart"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "dart-sdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("dart"); err == nil {
+				return nil
+			}
+		}
+		osName = "windows"
 	} else if runtime.GOOS != "linux" {
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}

--- a/compile/erlang/tools.go
+++ b/compile/erlang/tools.go
@@ -44,6 +44,24 @@ func ensureErlang() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "erlang")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("erl"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "erlang")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("erl"); err == nil {
+				return nil
+			}
+		}
 	}
 	if _, err := exec.LookPath("escript"); err == nil {
 		return nil

--- a/compile/ex/tools.go
+++ b/compile/ex/tools.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // EnsureElixir verifies that the Elixir binary is installed and attempts to
@@ -36,6 +37,23 @@ func EnsureElixir() error {
 			return err
 		}
 		return nil
+	}
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "elixir")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "elixir")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
 	}
 	if _, err := exec.LookPath("asdf"); err == nil {
 		exec.Command("asdf", "plugin-add", "--skip-existing", "erlang").Run()

--- a/compile/fortran/tools.go
+++ b/compile/fortran/tools.go
@@ -42,6 +42,24 @@ func EnsureFortran() (string, error) {
 				}
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "mingw")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if path, err := exec.LookPath("gfortran"); err == nil {
+				return path, nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "gcc")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if path, err := exec.LookPath("gfortran"); err == nil {
+				return path, nil
+			}
+		}
 	}
 	if path, err := exec.LookPath("gfortran"); err == nil {
 		return path, nil

--- a/compile/fs/tools.go
+++ b/compile/fs/tools.go
@@ -43,6 +43,24 @@ func ensureDotnet() error {
 				}
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "dotnet-sdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("dotnet"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "dotnet-sdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("dotnet"); err == nil {
+				return nil
+			}
+		}
 	}
 	fmt.Println("🔧 Installing dotnet...")
 	home := os.Getenv("HOME")

--- a/compile/go/tools.go
+++ b/compile/go/tools.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 // EnsureMochi builds the Mochi command and returns its path. It is used by
@@ -19,6 +20,9 @@ func EnsureMochi() (string, error) {
 		return "", fmt.Errorf("HOME not set")
 	}
 	out := filepath.Join(home, "bin", "mochi")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
 	if err := os.MkdirAll(filepath.Dir(out), 0755); err != nil {
 		return "", err
 	}

--- a/compile/hs/tools.go
+++ b/compile/hs/tools.go
@@ -38,6 +38,18 @@ func EnsureHaskell() error {
 				break
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "ghc")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "ghc")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if _, err := exec.LookPath("runhaskell"); err == nil {
 		return nil

--- a/compile/java/tools.go
+++ b/compile/java/tools.go
@@ -38,6 +38,24 @@ func EnsureJavac() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "openjdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("javac"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "openjdk")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("javac"); err == nil {
+				return nil
+			}
+		}
 	}
 	if _, err := exec.LookPath("javac"); err == nil {
 		return nil

--- a/compile/kt/tools.go
+++ b/compile/kt/tools.go
@@ -33,6 +33,18 @@ func EnsureKotlin() error {
 					_ = cmd.Run()
 				}
 			}
+		case "windows":
+			if _, err := exec.LookPath("choco"); err == nil {
+				cmd := exec.Command("choco", "install", "-y", "openjdk")
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				_ = cmd.Run()
+			} else if _, err := exec.LookPath("scoop"); err == nil {
+				cmd := exec.Command("scoop", "install", "openjdk")
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				_ = cmd.Run()
+			}
 		}
 		if err := javacode.EnsureJavac(); err != nil {
 			return err
@@ -69,6 +81,18 @@ func EnsureKotlin() error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "kotlin")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "kotlin")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		}
 	}
 	return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 }

--- a/compile/lua/tools.go
+++ b/compile/lua/tools.go
@@ -42,6 +42,20 @@ func EnsureLua() error {
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🔧 Installing Lua via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "lua")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🔧 Installing Lua via Scoop...")
+			cmd := exec.Command("scoop", "install", "lua")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if _, err := exec.LookPath("lua"); err == nil {
 		return nil

--- a/compile/mlir/tools.go
+++ b/compile/mlir/tools.go
@@ -39,6 +39,18 @@ func EnsureMLIR() error {
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "llvm")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "llvm")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if _, err := exec.LookPath("mlir-translate-19"); err == nil {
 		return ensureClang()

--- a/compile/ocaml/tools.go
+++ b/compile/ocaml/tools.go
@@ -39,6 +39,24 @@ func EnsureOCaml() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "ocaml")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("ocamlc"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "ocaml")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("ocamlc"); err == nil {
+				return nil
+			}
+		}
 	}
 	if _, err := exec.LookPath("ocamlc"); err == nil {
 		return nil

--- a/compile/pas/tools.go
+++ b/compile/pas/tools.go
@@ -41,6 +41,24 @@ func EnsureFPC() (string, error) {
 				return "", err
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "fpc")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if path, err := exec.LookPath("fpc"); err == nil {
+				return path, nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "fpc")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if path, err := exec.LookPath("fpc"); err == nil {
+				return path, nil
+			}
+		}
 	}
 	if path, err := exec.LookPath("fpc"); err == nil {
 		return path, nil

--- a/compile/php/tools.go
+++ b/compile/php/tools.go
@@ -45,6 +45,20 @@ func EnsurePHP() error {
 				break
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "php")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			break
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "php")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			break
+		}
 	}
 	if _, err := exec.LookPath("php"); err == nil {
 		return nil

--- a/compile/pl/tools.go
+++ b/compile/pl/tools.go
@@ -44,6 +44,24 @@ func EnsureSWIPL() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "swi-prolog")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("swipl"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "swipl")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("swipl"); err == nil {
+				return nil
+			}
+		}
 	}
 	if _, err := exec.LookPath("swipl"); err == nil {
 		return nil

--- a/compile/py/tools.go
+++ b/compile/py/tools.go
@@ -35,6 +35,20 @@ func EnsurePython() error {
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🐍 Installing Python via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "python")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🐍 Installing Python via Scoop...")
+			cmd := exec.Command("scoop", "install", "python")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if _, err := exec.LookPath("python3"); err == nil {
 		return nil

--- a/compile/rb/tools.go
+++ b/compile/rb/tools.go
@@ -39,6 +39,24 @@ func EnsureRuby() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "ruby")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("ruby"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "ruby")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("ruby"); err == nil {
+				return nil
+			}
+		}
 	}
 	if _, err := exec.LookPath("ruby"); err == nil {
 		return nil

--- a/compile/rkt/tools.go
+++ b/compile/rkt/tools.go
@@ -38,6 +38,19 @@ func EnsureRacket() error {
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()
 		}
+	case "windows":
+		fmt.Println("🔧 Installing Racket via Chocolatey/Scoop...")
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "racket")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "racket")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if _, err := exec.LookPath("racket"); err == nil {
 		return nil

--- a/compile/rust/tools.go
+++ b/compile/rust/tools.go
@@ -43,6 +43,22 @@ func ensureRust() error {
 				return nil
 			}
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "rust")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "rust")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
 	}
 	cmd := exec.Command("sh", "-c", "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
 	cmd.Stdout = os.Stdout

--- a/compile/scala/tools.go
+++ b/compile/scala/tools.go
@@ -41,6 +41,18 @@ func EnsureScala() error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "scala")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "scala")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		}
 	}
 	return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 }

--- a/compile/scheme/tools.go
+++ b/compile/scheme/tools.go
@@ -34,6 +34,18 @@ func EnsureScheme() (string, error) {
 			cmd.Stderr = os.Stderr
 			_ = cmd.Run()
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "chibi-scheme")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "chibi-scheme")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
 	}
 	if path, err := exec.LookPath("chibi-scheme"); err == nil {
 		return path, nil

--- a/compile/st/tools.go
+++ b/compile/st/tools.go
@@ -42,6 +42,16 @@ func EnsureSmalltalk() error {
 		} else {
 			return fmt.Errorf("brew not found")
 		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🔧 Installing GNU Smalltalk via Chocolatey...")
+			_ = run(exec.Command("choco", "install", "-y", "gnu-smalltalk"))
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🔧 Installing GNU Smalltalk via Scoop...")
+			_ = run(exec.Command("scoop", "install", "gnu-smalltalk"))
+		} else {
+			return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+		}
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}

--- a/compile/swift/tools.go
+++ b/compile/swift/tools.go
@@ -41,6 +41,18 @@ func EnsureSwift() error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "swift")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "swift")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		}
 	}
 	return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 }

--- a/compile/ts/tools.go
+++ b/compile/ts/tools.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 // EnsureDeno verifies that the Deno binary is installed and attempts to
@@ -18,6 +19,23 @@ func ensureDeno() error {
 		return nil
 	}
 	fmt.Println("\U0001F985 Installing Deno...")
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "deno")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "deno")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	}
 	home := os.Getenv("HOME")
 	if home == "" {
 		home = "/tmp"


### PR DESCRIPTION
## Summary
- add Windows installation logic using Chocolatey/Scoop for all compiler ensure helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858490fc4fc8320944628238464c076