### PR TITLE
Add copy-and-patch style JIT prototype

### DIFF
--- a/runtime/jit/cmd/testprog/main.go
+++ b/runtime/jit/cmd/testprog/main.go
@@ -1,0 +1,13 @@
+package main
+import (
+    "fmt"
+    "mochi/runtime/jit"
+)
+func main(){
+    expr := jit.BinOp{Op: "+", Left: jit.IntLit{Val:3}, Right: jit.BinOp{Op:"*", Left: jit.IntLit{Val:4}, Right: jit.IntLit{Val:5}}}
+    fn,err := jit.Compile(expr)
+    fmt.Println("err", err)
+    if err==nil{
+        fmt.Println("result", fn())
+    }
+}

--- a/runtime/jit/exec.go
+++ b/runtime/jit/exec.go
@@ -1,0 +1,14 @@
+package jit
+
+/*
+#include <stdint.h>
+
+typedef int64_t (*fnptr)();
+static int64_t call(fnptr f) { return f(); }
+*/
+import "C"
+import "unsafe"
+
+func exec(code unsafe.Pointer) int64 {
+	return int64(C.call((C.fnptr)(code)))
+}

--- a/runtime/jit/jit.go
+++ b/runtime/jit/jit.go
@@ -1,0 +1,112 @@
+package jit
+
+import (
+	"encoding/binary"
+	"syscall"
+	"unsafe"
+)
+
+// Assembler accumulates machine code fragments using copy-and-patch.
+type Assembler struct {
+	code []byte
+}
+
+// New creates a new Assembler.
+func New() *Assembler {
+	return &Assembler{code: make([]byte, 0, 1024)}
+}
+
+// Code returns the assembled machine code.
+func (a *Assembler) Code() []byte { return a.code }
+
+// EmitRaw appends raw bytes to the code buffer.
+func (a *Assembler) EmitRaw(b []byte) { a.code = append(a.code, b...) }
+
+// --- Stencil based instructions ---
+
+var (
+	movRaxImm  = []byte{0x48, 0xB8, 0, 0, 0, 0, 0, 0, 0, 0}
+	pushRax    = []byte{0x50}
+	popRbx     = []byte{0x5B}
+	addRaxRbx  = []byte{0x48, 0x01, 0xD8}
+	subRaxRbx  = []byte{0x48, 0x29, 0xD8}
+	imulRaxRbx = []byte{0x48, 0x0F, 0xAF, 0xC3}
+	retInsn    = []byte{0xC3}
+)
+
+// MovRaxImm emits `mov rax, imm64`.
+func (a *Assembler) MovRaxImm(v int64) {
+	start := len(a.code)
+	a.EmitRaw(movRaxImm)
+	binary.LittleEndian.PutUint64(a.code[start+2:], uint64(v))
+}
+
+// PushRax emits `push rax`.
+func (a *Assembler) PushRax() { a.EmitRaw(pushRax) }
+
+// PopRbx emits `pop rbx`.
+func (a *Assembler) PopRbx() { a.EmitRaw(popRbx) }
+
+// AddRaxRbx emits `add rax, rbx`.
+func (a *Assembler) AddRaxRbx() { a.EmitRaw(addRaxRbx) }
+
+// SubRaxRbx emits `sub rax, rbx`.
+func (a *Assembler) SubRaxRbx() { a.EmitRaw(subRaxRbx) }
+
+// IMulRaxRbx emits `imul rax, rbx`.
+func (a *Assembler) IMulRaxRbx() { a.EmitRaw(imulRaxRbx) }
+
+// Ret emits `ret`.
+func (a *Assembler) Ret() { a.EmitRaw(retInsn) }
+
+// Finalize allocates executable memory and returns it as a function.
+func (a *Assembler) Finalize() (func() int64, error) {
+	buf := make([]byte, len(a.code))
+	copy(buf, a.code)
+	mem, err := syscall.Mmap(-1, 0, len(buf), syscall.PROT_READ|syscall.PROT_WRITE|syscall.PROT_EXEC, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		return nil, err
+	}
+	copy(mem, buf)
+	m := mem
+	return func() int64 { return exec(unsafe.Pointer(&m[0])) }, nil
+}
+
+// --- Expression AST ---
+
+type Expr interface {
+	compile(a *Assembler)
+}
+
+type IntLit struct{ Val int64 }
+
+func (i IntLit) compile(a *Assembler) { a.MovRaxImm(i.Val) }
+
+type BinOp struct {
+	Op    string
+	Left  Expr
+	Right Expr
+}
+
+func (b BinOp) compile(a *Assembler) {
+	b.Left.compile(a)
+	a.PushRax()
+	b.Right.compile(a)
+	a.PopRbx()
+	switch b.Op {
+	case "+":
+		a.AddRaxRbx()
+	case "-":
+		a.SubRaxRbx()
+	case "*":
+		a.IMulRaxRbx()
+	}
+}
+
+// Compile converts an expression to executable code using copy-and-patch.
+func Compile(e Expr) (func() int64, error) {
+	asm := New()
+	e.compile(asm)
+	asm.Ret()
+	return asm.Finalize()
+}

--- a/runtime/jit/jit_test.go
+++ b/runtime/jit/jit_test.go
@@ -1,0 +1,17 @@
+package jit
+
+import "testing"
+
+func TestCompileSimple(t *testing.T) {
+	expr := BinOp{
+		Op:    "+",
+		Left:  IntLit{Val: 3},
+		Right: BinOp{Op: "*", Left: IntLit{Val: 4}, Right: IntLit{Val: 5}},
+	}
+	asm := New()
+	expr.compile(asm)
+	asm.Ret()
+	if len(asm.Code()) == 0 {
+		t.Fatalf("expected code to be generated")
+	}
+}


### PR DESCRIPTION
## Summary
- implement a very small copy-and-patch JIT under `runtime/jit`
- prototype assembler assembles machine code from stencils
- add a cgo helper to invoke generated code
- include an example program and a basic unit test

## Testing
- `go test ./runtime/jit -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858b997d9d0832087088920a1b93b59