### PR TITLE
Add bmonl encoder/decoder

### DIFF
--- a/runtime/bmon/bmon.go
+++ b/runtime/bmon/bmon.go
@@ -1,0 +1,350 @@
+package bmon
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// Marshal encodes v into BMON bytes.
+func Marshal(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := NewEncoder(&buf).Encode(v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Unmarshal parses a BMON value from data into v.
+// v must be a non-nil pointer.
+func Unmarshal(data []byte, v any) error {
+	return NewDecoder(bytes.NewReader(data)).Decode(v)
+}
+
+// Encoder writes BMON values to an io.Writer.
+type Encoder struct {
+	w *bufio.Writer
+}
+
+// NewEncoder returns a new Encoder.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: bufio.NewWriter(w)}
+}
+
+// Encode writes v to the underlying writer.
+func (e *Encoder) Encode(v any) error {
+	if err := encodeValue(e.w, v); err != nil {
+		return err
+	}
+	return e.w.Flush()
+}
+
+func encodeValue(w *bufio.Writer, v any) error {
+	switch val := v.(type) {
+	case nil:
+		_, err := w.WriteString("_\r\n")
+		return err
+	case string:
+		if _, err := w.WriteString("+" + val + "\r\n"); err != nil {
+			return err
+		}
+		return nil
+	case error:
+		if _, err := w.WriteString("-" + val.Error() + "\r\n"); err != nil {
+			return err
+		}
+		return nil
+	case int:
+		return encodeValue(w, int64(val))
+	case int64:
+		if _, err := w.WriteString(":" + strconv.FormatInt(val, 10) + "\r\n"); err != nil {
+			return err
+		}
+		return nil
+	case float32:
+		return encodeValue(w, float64(val))
+	case float64:
+		if _, err := w.WriteString("," + strconv.FormatFloat(val, 'f', -1, 64) + "\r\n"); err != nil {
+			return err
+		}
+		return nil
+	case bool:
+		if val {
+			_, err := w.WriteString("#t\r\n")
+			return err
+		}
+		_, err := w.WriteString("#f\r\n")
+		return err
+	case time.Time:
+		if _, err := w.WriteString("@" + val.UTC().Format(time.RFC3339) + "\r\n"); err != nil {
+			return err
+		}
+		return nil
+	case []any:
+		if _, err := w.WriteString("*" + strconv.Itoa(len(val)) + "\r\n"); err != nil {
+			return err
+		}
+		for _, it := range val {
+			if err := encodeValue(w, it); err != nil {
+				return err
+			}
+		}
+		return nil
+	case []string:
+		arr := make([]any, len(val))
+		for i, s := range val {
+			arr[i] = s
+		}
+		return encodeValue(w, arr)
+	case []int:
+		arr := make([]any, len(val))
+		for i, s := range val {
+			arr[i] = s
+		}
+		return encodeValue(w, arr)
+	case map[string]any:
+		if _, err := w.WriteString("%" + strconv.Itoa(len(val)) + "\r\n"); err != nil {
+			return err
+		}
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if err := encodeValue(w, k); err != nil {
+				return err
+			}
+			if err := encodeValue(w, val[k]); err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]string:
+		m := make(map[string]any, len(val))
+		for k, v := range val {
+			m[k] = v
+		}
+		return encodeValue(w, m)
+	default:
+		return fmt.Errorf("unsupported type %T", v)
+	}
+}
+
+// Decoder reads BMON values from an io.Reader.
+type Decoder struct {
+	r *bufio.Reader
+}
+
+// NewDecoder returns a new Decoder.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r: bufio.NewReader(r)}
+}
+
+// Decode reads the next BMON value from the stream into v.
+// v must be a non-nil pointer.
+func (d *Decoder) Decode(v any) error {
+	val, err := d.decodeValue()
+	if err != nil {
+		return err
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fmt.Errorf("Decode argument must be non-nil pointer")
+	}
+	rv = rv.Elem()
+	if val == nil {
+		rv.Set(reflect.Zero(rv.Type()))
+	} else {
+		rv.Set(reflect.ValueOf(val))
+	}
+	return nil
+}
+
+func (d *Decoder) decodeValue() (any, error) {
+	prefix, err := d.r.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	switch prefix {
+	case '+':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		return line, nil
+	case '-':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		return errors.New(line), nil
+	case ':':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		return n, nil
+	case ',':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		f, err := strconv.ParseFloat(line, 64)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	case '#':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		return line == "t", nil
+	case '_':
+		if err := d.expectCRLF(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	case '$':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, n+2)
+		if _, err := io.ReadFull(d.r, buf); err != nil {
+			return nil, err
+		}
+		if buf[n] != '\r' || buf[n+1] != '\n' {
+			return nil, fmt.Errorf("invalid blob termination")
+		}
+		return buf[:n], nil
+	case '=':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, n+2)
+		if _, err := io.ReadFull(d.r, buf); err != nil {
+			return nil, err
+		}
+		if buf[n] != '\r' || buf[n+1] != '\n' {
+			return nil, fmt.Errorf("invalid verbatim termination")
+		}
+		return string(buf[:n]), nil
+	case '*':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			return nil, err
+		}
+		arr := make([]any, 0, n)
+		for i := 0; i < n; i++ {
+			v, err := d.decodeValue()
+			if err != nil {
+				return nil, err
+			}
+			arr = append(arr, v)
+		}
+		return arr, nil
+	case '%':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			return nil, err
+		}
+		m := make(map[string]any, n)
+		for i := 0; i < n; i++ {
+			key, err := d.decodeValue()
+			if err != nil {
+				return nil, err
+			}
+			ks, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("map key not string: %T", key)
+			}
+			val, err := d.decodeValue()
+			if err != nil {
+				return nil, err
+			}
+			m[ks] = val
+		}
+		return m, nil
+	case '~':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			return nil, err
+		}
+		arr := make([]any, 0, n)
+		for i := 0; i < n; i++ {
+			v, err := d.decodeValue()
+			if err != nil {
+				return nil, err
+			}
+			arr = append(arr, v)
+		}
+		return arr, nil
+	case '@':
+		line, err := d.readLine()
+		if err != nil {
+			return nil, err
+		}
+		t, err := time.Parse(time.RFC3339, line)
+		if err != nil {
+			return nil, err
+		}
+		return t, nil
+	default:
+		return nil, fmt.Errorf("unknown prefix %q", prefix)
+	}
+}
+
+func (d *Decoder) readLine() (string, error) {
+	line, err := d.r.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	if len(line) < 2 || line[len(line)-2] != '\r' {
+		return "", fmt.Errorf("invalid line ending")
+	}
+	return line[:len(line)-2], nil
+}
+
+func (d *Decoder) expectCRLF() error {
+	b := make([]byte, 2)
+	if _, err := io.ReadFull(d.r, b); err != nil {
+		return err
+	}
+	if b[0] != '\r' || b[1] != '\n' {
+		return fmt.Errorf("expected CRLF")
+	}
+	return nil
+}

--- a/runtime/bmon/bmon_test.go
+++ b/runtime/bmon/bmon_test.go
@@ -1,0 +1,57 @@
+package bmon
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func roundTrip(t *testing.T, v any) any {
+	t.Helper()
+	data, err := Marshal(v)
+	require.NoError(t, err)
+	var out any
+	err = Unmarshal(data, &out)
+	require.NoError(t, err)
+	return out
+}
+
+func TestBmonBasics(t *testing.T) {
+	require.Equal(t, "ok", roundTrip(t, "ok"))
+	require.Equal(t, int64(42), roundTrip(t, int64(42)))
+	require.Equal(t, 3.14, roundTrip(t, 3.14))
+	require.Equal(t, true, roundTrip(t, true))
+	require.Nil(t, roundTrip(t, nil))
+}
+
+func TestBmonArrayAndMap(t *testing.T) {
+	arr := []any{"a", int64(1)}
+	require.Equal(t, arr, roundTrip(t, arr))
+
+	m := map[string]any{"a": int64(1), "b": "two"}
+	out := roundTrip(t, m).(map[string]any)
+	require.Equal(t, m, out)
+}
+
+func TestBmonTime(t *testing.T) {
+	now := time.Date(2025, 6, 23, 1, 2, 3, 0, time.UTC)
+	v := roundTrip(t, now).(time.Time)
+	require.True(t, v.Equal(now))
+}
+
+func TestBmonStreamDecodingMultiple(t *testing.T) {
+	buf := &bytes.Buffer{}
+	enc := NewEncoder(buf)
+	require.NoError(t, enc.Encode(map[string]any{"a": int64(1)}))
+	require.NoError(t, enc.Encode(map[string]any{"b": int64(2)}))
+
+	dec := NewDecoder(bytes.NewReader(buf.Bytes()))
+	var v1 any
+	require.NoError(t, dec.Decode(&v1))
+	require.Equal(t, map[string]any{"a": int64(1)}, v1)
+	var v2 any
+	require.NoError(t, dec.Decode(&v2))
+	require.Equal(t, map[string]any{"b": int64(2)}, v2)
+}

--- a/runtime/bmonl/bmonl.go
+++ b/runtime/bmonl/bmonl.go
@@ -1,0 +1,151 @@
+package bmonl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"mochi/runtime/bmon"
+)
+
+// Marshal encodes rows into BMONL bytes.
+func Marshal(rows []map[string]any) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := NewEncoder(&buf).EncodeAll(rows); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Unmarshal parses data as BMONL into dest which must be a pointer to a slice.
+func Unmarshal(data []byte, dest *[]map[string]any) error {
+	dec := NewDecoder(bytes.NewReader(data))
+	rows, err := dec.DecodeAll()
+	if err != nil {
+		return err
+	}
+	*dest = rows
+	return nil
+}
+
+// Encoder writes rows of maps to an io.Writer in BMONL format.
+type Encoder struct {
+	enc *bmon.Encoder
+}
+
+// NewEncoder returns a new Encoder that writes to w.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{enc: bmon.NewEncoder(w)}
+}
+
+// Encode writes m as a single BMON value.
+func (e *Encoder) Encode(m map[string]any) error {
+	return e.enc.Encode(m)
+}
+
+// EncodeAll writes all rows in order.
+func (e *Encoder) EncodeAll(rows []map[string]any) error {
+	for _, row := range rows {
+		if err := e.Encode(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Decoder reads maps from an io.Reader in BMONL format.
+type Decoder struct {
+	dec *bmon.Decoder
+}
+
+// NewDecoder returns a new Decoder that reads from r.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{dec: bmon.NewDecoder(r)}
+}
+
+// Decode reads the next row from the stream into m.
+func (d *Decoder) Decode(m *map[string]any) error {
+	var v any
+	if err := d.dec.Decode(&v); err != nil {
+		return err
+	}
+	if v == nil {
+		*m = nil
+		return nil
+	}
+	mv, ok := v.(map[string]any)
+	if !ok {
+		return fmt.Errorf("expected map, got %T", v)
+	}
+	*m = mv
+	return nil
+}
+
+// DecodeAll reads all remaining rows from d.
+func (d *Decoder) DecodeAll() ([]map[string]any, error) {
+	var rows []map[string]any
+	for {
+		var m map[string]any
+		if err := d.Decode(&m); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		if m != nil {
+			rows = append(rows, m)
+		}
+	}
+	return rows, nil
+}
+
+// ReadFile reads a BMONL file from path.
+func ReadFile(path string) ([]map[string]any, error) {
+	r, closeFn, err := openReader(path)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+	dec := NewDecoder(r)
+	return dec.DecodeAll()
+}
+
+// WriteFile writes rows to path in BMONL format.
+func WriteFile(rows []map[string]any, path string) error {
+	w, closeFn, err := openWriter(path)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	enc := NewEncoder(w)
+	return enc.EncodeAll(rows)
+}
+
+// helpers
+func openReader(path string) (io.Reader, func() error, error) {
+	if path == "" || path == "-" {
+		return os.Stdin, func() error { return nil }, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, f.Close, nil
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+func openWriter(path string) (io.Writer, func() error, error) {
+	if path == "" || path == "-" {
+		w := nopWriteCloser{os.Stdout}
+		return w, func() error { return nil }, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, f.Close, nil
+}

--- a/runtime/bmonl/bmonl_test.go
+++ b/runtime/bmonl/bmonl_test.go
@@ -1,0 +1,62 @@
+package bmonl
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBmonReadWriteFile(t *testing.T) {
+	rows := []map[string]any{
+		{"a": int64(1)},
+		{"b": "two"},
+	}
+	dir := t.TempDir()
+	file := dir + "/rows.bmonl"
+	require.NoError(t, WriteFile(rows, file))
+	out, err := ReadFile(file)
+	require.NoError(t, err)
+	require.Equal(t, rows, out)
+
+	// Test stdin/stdout with path "-"
+	rfile := dir + "/rows2.bmonl"
+	f, err := os.Create(rfile)
+	require.NoError(t, err)
+	defer f.Close()
+	oldStdout := os.Stdout
+	os.Stdout = f
+	require.NoError(t, WriteFile(rows, "-"))
+	os.Stdout = oldStdout
+	f.Close()
+	out2, err := ReadFile(rfile)
+	require.NoError(t, err)
+	require.Equal(t, rows, out2)
+}
+
+func TestBmonlMarshalUnmarshal(t *testing.T) {
+	rows := []map[string]any{
+		{"a": int64(1)},
+		{"b": "two"},
+	}
+	data, err := Marshal(rows)
+	require.NoError(t, err)
+	var out []map[string]any
+	require.NoError(t, Unmarshal(data, &out))
+	require.Equal(t, rows, out)
+}
+
+func TestBmonlEncodeDecode(t *testing.T) {
+	buf := &bytes.Buffer{}
+	enc := NewEncoder(buf)
+	require.NoError(t, enc.Encode(map[string]any{"a": int64(1)}))
+	require.NoError(t, enc.Encode(map[string]any{"b": int64(2)}))
+
+	dec := NewDecoder(bytes.NewReader(buf.Bytes()))
+	var m1, m2 map[string]any
+	require.NoError(t, dec.Decode(&m1))
+	require.NoError(t, dec.Decode(&m2))
+	require.Equal(t, map[string]any{"a": int64(1)}, m1)
+	require.Equal(t, map[string]any{"b": int64(2)}, m2)
+}


### PR DESCRIPTION
## Summary
- introduce `Marshal`/`Unmarshal` for `.bmonl`
- rename line helpers to `Encoder`/`Decoder`
- keep `ReadFile`/`WriteFile` using the new API
- add unit tests for the new API

## Testing
- `go test ./... --vet=off -run TestBmon -v`

------
https://chatgpt.com/codex/tasks/task_e_6858609bc66c8320a04637b33d8e7ff0