### PR TITLE
Add basic SQL runtime and bindings

### DIFF
--- a/core/database/sql/sql.mochi
+++ b/core/database/sql/sql.mochi
@@ -1,0 +1,38 @@
+package sql
+
+import go "mochi/runtime/database/sql" as gosql
+
+extern type DB
+
+extern fun gosql.Open(driver: string, dsn: string): (DB, error)
+extern fun DB.Close(): error
+extern fun DB.Exec(query: string, args: []any): (int, error)
+extern fun DB.Query(query: string, args: []any): ([]map[string, any], error)
+
+/// open returns a new database connection using the specified driver and DSN.
+/// It panics if the connection cannot be opened.
+export fun open(driver: string, dsn: string): DB {
+  let (db, err) = gosql.Open(driver, dsn)
+  if err != null { panic(err) }
+  return db
+}
+
+/// close terminates the database connection, panicking on error.
+export fun DB.close(db: DB) {
+  let err = db.Close()
+  if err != null { panic(err) }
+}
+
+/// exec runs a statement and returns the number of rows affected.
+export fun DB.exec(db: DB, query: string, args: list<any> = []): int {
+  let (n, err) = db.Exec(query, args)
+  if err != null { panic(err) }
+  return n
+}
+
+/// query executes a statement and returns all rows as a list of maps.
+export fun DB.query(db: DB, query: string, args: list<any> = []): list<map<string, any>> {
+  let (rows, err) = db.Query(query, args)
+  if err != null { panic(err) }
+  return rows
+}

--- a/runtime/database/sql/sql.go
+++ b/runtime/database/sql/sql.go
@@ -1,0 +1,73 @@
+package sql
+
+import (
+	"database/sql"
+	_ "github.com/marcboeker/go-duckdb"
+)
+
+// DB wraps *sql.DB for Mochi runtime use.
+type DB struct {
+	*sql.DB
+}
+
+// Open opens a database using the given driver name and DSN.
+func Open(driver, dsn string) (*DB, error) {
+	db, err := sql.Open(driver, dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{db}, nil
+}
+
+// Close closes the underlying database.
+func (db *DB) Close() error { return db.DB.Close() }
+
+// Exec executes a statement and returns the rows affected.
+func (db *DB) Exec(query string, args []any) (int, error) {
+	res, err := db.DB.Exec(query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// Query runs the query and returns all rows as []map[string]any.
+func (db *DB) Query(query string, args []any) ([]map[string]any, error) {
+	rows, err := db.DB.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []map[string]any
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		m := make(map[string]any, len(cols))
+		for i, c := range cols {
+			v := vals[i]
+			if b, ok := v.([]byte); ok {
+				m[c] = string(b)
+			} else {
+				m[c] = v
+			}
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}

--- a/runtime/database/sql/sql_test.go
+++ b/runtime/database/sql/sql_test.go
@@ -1,0 +1,24 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_Basic(t *testing.T) {
+	db, err := Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec("create table foo(id integer, name text)", nil)
+	require.NoError(t, err)
+
+	_, err = db.Exec("insert into foo values(?, ?)", []any{1, "a"})
+	require.NoError(t, err)
+
+	rows, err := db.Query("select name from foo where id = ?", []any{1})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, "a", rows[0]["name"])
+}


### PR DESCRIPTION
## Summary
- add simple database/sql wrappers in runtime
- expose idiomatic Mochi API in `core/database/sql/sql.mochi`
- cover basic open/query/exec behaviour with tests

## Testing
- `go test ./runtime/database/sql -run TestDB_Basic -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858d4c81ee8832091a740b5ee74d168