### PR TITLE
Add pure Mochi CSV module

### DIFF
--- a/core/encoding/csv/csv.mochi
+++ b/core/encoding/csv/csv.mochi
@@ -1,0 +1,250 @@
+package csv
+
+// Marshal encodes a list of maps into a CSV string.
+export fun marshal(rows: list<map<string, any>>, header: bool, delim: string): string {
+  let d = if len(delim) > 0 { delim[0] } else { ',' }
+  var headers: list<string> = []
+  if count(rows) > 0 {
+    headers = keys(rows[0])
+    headers = _sortStrings(headers)
+  }
+  var lines: list<string> = []
+  if header {
+    lines = lines + [_join(headers, d)]
+  }
+  for row in rows {
+    var parts: list<string> = []
+    var i = 0
+    while i < count(headers) {
+      let h = headers[i]
+      if h in row {
+        let v = row[h]
+        if v == null { parts = parts + [""] }
+        else { parts = parts + [str(v)] }
+      } else {
+        parts = parts + [""]
+      }
+      i = i + 1
+    }
+    lines = lines + [_join(parts, d)]
+  }
+  return _join(lines, '\n')
+}
+
+// Unmarshal parses a CSV string into a list of maps.
+export fun unmarshal(text: string, header: bool, delim: string): list<map<string, any>> {
+  let d = if len(delim) > 0 { delim[0] } else { ',' }
+  let lines = _splitLines(text)
+  if count(lines) == 0 { return [] }
+  var headers: list<string> = []
+  var start = 0
+  if header {
+    headers = _splitLine(lines[0], d)
+    start = 1
+  } else {
+    headers = _splitLine(lines[0], d)
+    var i = count(headers)
+    var j = 0
+    headers = []
+    while j < i {
+      headers = headers + ["c" + str(j)]
+      j = j + 1
+    }
+  }
+  var out: list<map<string, any>> = []
+  var idx = start
+  while idx < count(lines) {
+    if len(lines[idx]) == 0 { idx = idx + 1; continue }
+    let parts = _splitLine(lines[idx], d)
+    var m: map<string, any> = {}
+    var j = 0
+    while j < count(headers) {
+      var val = ""
+      if j < count(parts) { val = parts[j] }
+      m[headers[j]] = _parseValue(val)
+      j = j + 1
+    }
+    out = out + [m]
+    idx = idx + 1
+  }
+  return out
+}
+
+fun _splitLines(text: string): list<string> {
+  var lines: list<string> = []
+  var cur = ""
+  var i = 0
+  while i < len(text) {
+    let ch = text[i]
+    if ch == '\r' {
+      if i + 1 < len(text) && text[i+1] == '\n' { i = i + 1 }
+      lines = lines + [cur]
+      cur = ""
+    } else if ch == '\n' {
+      lines = lines + [cur]
+      cur = ""
+    } else {
+      cur = cur + ch
+    }
+    i = i + 1
+  }
+  lines = lines + [cur]
+  return lines
+}
+
+fun _splitLine(line: string, d: rune): list<string> {
+  var parts: list<string> = []
+  var cur = ""
+  var i = 0
+  while i < len(line) {
+    let ch = line[i]
+    if ch == d {
+      parts = parts + [cur]
+      cur = ""
+    } else {
+      cur = cur + ch
+    }
+    i = i + 1
+  }
+  parts = parts + [cur]
+  return parts
+}
+
+fun _join(parts: list<string>, d: rune): string {
+  var out = ""
+  var i = 0
+  while i < count(parts) {
+    if i > 0 { out = out + d }
+    out = out + parts[i]
+    i = i + 1
+  }
+  return out
+}
+
+fun _parseValue(val: string): any {
+  if len(val) == 0 { return "" }
+  if _isInt(val) { return _parseIntStr(val) }
+  if _isFloat(val) { return _parseFloatStr(val) }
+  return val
+}
+
+fun _isInt(str: string): bool {
+  var i = 0
+  if len(str) > 0 && str[0] == '-' { i = 1 }
+  if i == len(str) { return false }
+  while i < len(str) {
+    let ch = str[i]
+    if ch < '0' || ch > '9' { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun _isFloat(str: string): bool {
+  var i = 0
+  if len(str) > 0 && str[0] == '-' { i = 1 }
+  var dot = false
+  var digits = false
+  while i < len(str) {
+    let ch = str[i]
+    if ch >= '0' && ch <= '9' { digits = true }
+    else if ch == '.' && !dot { dot = true }
+    else { return false }
+    i = i + 1
+  }
+  return digits && dot
+}
+
+fun _parseIntStr(str: string): int {
+  var i = 0
+  var neg = false
+  if len(str) > 0 && str[0] == '-' { neg = true; i = 1 }
+  var n = 0
+  let digits = {
+    '0': 0,
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+    '7': 7,
+    '8': 8,
+    '9': 9,
+  }
+  while i < len(str) { n = n * 10 + digits[str[i]]; i = i + 1 }
+  if neg { n = -n }
+  return n
+}
+
+fun _parseFloatStr(str: string): float {
+  var i = 0
+  var neg = false
+  if len(str) > 0 && str[0] == '-' { neg = true; i = 1 }
+  var intPart = 0
+  while i < len(str) && str[i] != '.' { intPart = intPart * 10 + _parseIntStr(str[i:i+1]); i = i + 1 }
+  var frac = 0.0
+  var scale = 0.1
+  if i < len(str) && str[i] == '.' {
+    i = i + 1
+    while i < len(str) { frac = frac + float(_parseIntStr(str[i:i+1])) * scale; scale = scale / 10.0; i = i + 1 }
+  }
+  var res = float(intPart) + frac
+  if neg { res = -res }
+  return res
+}
+
+fun _sortStrings(xs: list<string>): list<string> {
+  var res: list<string> = []
+  var tmp = xs
+  while count(tmp) > 0 {
+    var min = tmp[0]
+    var idx = 0
+    var i = 1
+    while i < count(tmp) {
+      if tmp[i] < min { min = tmp[i]; idx = i }
+      i = i + 1
+    }
+    res = res + [min]
+    tmp = _removeAt(tmp, idx)
+  }
+  return res
+}
+
+fun _removeAt(xs: list<string>, idx: int): list<string> {
+  var out: list<string> = []
+  var i = 0
+  while i < count(xs) {
+    if i != idx { out = out + [xs[i]] }
+    i = i + 1
+  }
+  return out
+}
+
+test "csv marshal/unmarshal header" {
+  let rows = [
+    {"a": 1, "b": "two", "c": 3.5},
+    {"a": 2, "b": "three", "c": 4.0},
+  ]
+  let data = marshal(rows, true, ",")
+  let out = unmarshal(data, true, ",")
+  expect out == rows
+}
+
+test "csv unmarshal no header" {
+  let data = "1,two\n2,3.5"
+  let out = unmarshal(data, false, ",")
+  expect out == [
+    {"c0": 1, "c1": "two"},
+    {"c0": 2, "c1": 3.5},
+  ]
+}
+
+test "csv custom delimiter" {
+  let rows = [{"x": 1, "y": 2}]
+  let data = marshal(rows, true, ";")
+  expect data == "x;y\n1;2"
+  let out = unmarshal(data, true, ";")
+  expect out == rows
+}
+


### PR DESCRIPTION
## Summary
- implement `core/encoding/csv` in pure Mochi
- add tests for CSV marshal and unmarshal

## Testing
- `go test ./... -run=^$`


------
https://chatgpt.com/codex/tasks/task_e_6858d43562248320bddd166ec862f22d