### PR TITLE
Add basic compare VM golden test

### DIFF
--- a/tests/vm/valid/basic_compare.ir.out
+++ b/tests/vm/valid/basic_compare.ir.out
@@ -1,0 +1,23 @@
+func main (regs=12)
+  // let a = 10 - 3
+  Const        r0 10
+  Const        r1 3
+  Sub          r2, r0, r1
+  Move         r3, r2
+  // let b = 2 + 2
+  Const        r4 2
+  Const        r5 2
+  Add          r6, r4, r5
+  Move         r7, r6
+  // print(a)
+  Print        r3
+  // print(a == 7)
+  Const        r8 7
+  Equal        r9, r3, r8
+  Print        r9
+  // print(b < 5)
+  Const        r10 5
+  Less         r11, r7, r10
+  Print        r11
+  // let a = 10 - 3
+  Return       r0

--- a/tests/vm/valid/basic_compare.mochi
+++ b/tests/vm/valid/basic_compare.mochi
@@ -1,0 +1,5 @@
+let a = 10 - 3
+let b = 2 + 2
+print(a)
+print(a == 7)
+print(b < 5)

--- a/tests/vm/valid/basic_compare.out
+++ b/tests/vm/valid/basic_compare.out
@@ -1,0 +1,3 @@
+7
+true
+true


### PR DESCRIPTION
## Summary
- add a new `basic_compare` example to the VM golden tests

## Testing
- `go test ./tests/vm`


------
https://chatgpt.com/codex/tasks/task_e_68594c7a02388320b08061f2d9d99086