### PR TITLE
Extend VM features and tests

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -18,16 +18,27 @@ The VM supports a small but useful subset of Mochi:
 * Variable definitions and reassignment
 * `if`, `while` and `for` loops over ranges and lists
 * Function definitions and calls with two arguments
-* Built‑ins `len` and `print`
+* Built‑ins `len` and `print` (up to two arguments)
 * List indexing and construction
 
 ## Unsupported features (partial list)
 
 Many of Mochi's features are not yet implemented:
 
-* Short circuit boolean operators and `break`/`continue`
+* Short circuit boolean operators `&&` and `||`
+* `break` and `continue` within loops
 * Structs, pattern matching and user defined types
 * Closures or nested function values
 * External package imports or FFI calls
 
 This VM is intentionally simple and primarily used for experimentation and testing.
+
+## Running tests
+
+Golden tests ensure the VM stays in sync with the main interpreter. Execute:
+
+```
+go test ./tests/vm -run .
+```
+
+Use `-update` to refresh the expected output files when modifying the VM.

--- a/tests/vm/valid/break_continue.ir.out
+++ b/tests/vm/valid/break_continue.ir.out
@@ -1,0 +1,40 @@
+func main (regs=16)
+  // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  Const        r0 [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  Move         r1, r0
+  // for n in numbers {
+  Len          r2, r1
+  Const        r3 0
+L4:
+  Less         r4, r3, r2
+  JumpIfFalse  r4, L0
+  Index        r5, r1, r3
+  Move         r6, r5
+  // if n % 2 == 0 {
+  Const        r7 2
+  Mod          r8, r6, r7
+  Const        r9 0
+  Equal        r10, r8, r9
+  JumpIfFalse  r10, L1
+  // continue
+  Jump         L2
+L1:
+  // if n > 7 {
+  Const        r11 7
+  Less         r12, r11, r6
+  JumpIfFalse  r12, L3
+  // break
+  Jump         L0
+L3:
+  // print("odd number:", n)
+  Const        r13 "odd number:"
+  Print2       r13, r6
+L2:
+  // for n in numbers {
+  Const        r14 1
+  Add          r15, r3, r14
+  Move         r3, r15
+  Jump         L4
+L0:
+  // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  Return       r0

--- a/tests/vm/valid/break_continue.mochi
+++ b/tests/vm/valid/break_continue.mochi
@@ -1,0 +1,11 @@
+let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+for n in numbers {
+  if n % 2 == 0 {
+    continue
+  }
+  if n > 7 {
+    break
+  }
+  print("odd number:", n)
+}

--- a/tests/vm/valid/break_continue.out
+++ b/tests/vm/valid/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7

--- a/tests/vm/valid/short_circuit.ir.out
+++ b/tests/vm/valid/short_circuit.ir.out
@@ -1,0 +1,33 @@
+func main (regs=10)
+  // print(false && boom(1, 2))
+  Const        r0 false
+  Move         r1, r0
+  JumpIfFalse  r1, L0
+  Const        r2 1
+  Const        r3 2
+  Call2        r4, 1, r2, r3
+  Move         r1, r4
+L0:
+  Print        r1
+  // print(true || boom(1, 2))
+  Const        r5 true
+  Move         r6, r5
+  JumpIfTrue   r6, L1
+  Const        r7 1
+  Const        r8 2
+  Call2        r9, 1, r7, r8
+  Move         r6, r9
+L1:
+  Print        r6
+  // fun boom(a: int, b: int): bool {
+  Return       r0
+
+func boom (regs=4)
+  // print("boom")
+  Const        r2 "boom"
+  Print        r2
+  // return true
+  Const        r3 true
+  Return       r3
+  // fun boom(a: int, b: int): bool {
+  Return       r0

--- a/tests/vm/valid/short_circuit.mochi
+++ b/tests/vm/valid/short_circuit.mochi
@@ -1,0 +1,7 @@
+fun boom(a: int, b: int): bool {
+  print("boom")
+  return true
+}
+
+print(false && boom(1, 2))
+print(true || boom(1, 2))

--- a/tests/vm/valid/short_circuit.out
+++ b/tests/vm/valid/short_circuit.out
@@ -1,0 +1,2 @@
+false
+true


### PR DESCRIPTION
## Summary
- add unary not and jump-if-true VM opcodes
- handle short-circuit boolean ops
- support `break` and `continue` in loops
- enable printing two values via new `Print2` opcode
- document print builtin supports two args
- test new features via golden tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68595ae6fa1c83208a9c5f04ea1ceb9c