### PR TITLE
Add list membership op to VM

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -15,8 +15,10 @@ The VM supports a small but useful subset of Mochi:
 * Integer, float, boolean and string constants
 * Arithmetic operations `+`, `-`, `*`, `/`, `%`
 * Comparison operators `==`, `!=`, `<`, `>`, `<=`, `>=`
+* Membership tests using `in`
+* Short circuit boolean operators `&&` and `||`
 * Variable definitions and reassignment
-* `if`, `while` and `for` loops over ranges and lists
+* `if`, `while` and `for` loops with `break` and `continue`
 * Function definitions and calls with two arguments
 * Built‑ins `len` and `print` (up to two arguments)
 * List indexing and construction
@@ -25,8 +27,6 @@ The VM supports a small but useful subset of Mochi:
 
 Many of Mochi's features are not yet implemented:
 
-* Short circuit boolean operators `&&` and `||`
-* `break` and `continue` within loops
 * Structs, pattern matching and user defined types
 * Closures or nested function values
 * External package imports or FFI calls

--- a/tests/vm/valid/membership.ir.out
+++ b/tests/vm/valid/membership.ir.out
@@ -1,0 +1,14 @@
+func main (regs=6)
+  // let nums = [1, 2, 3]
+  Const        r0 [1, 2, 3]
+  Move         r1, r0
+  // print(2 in nums)
+  Const        r2 2
+  In           r3, r2, r1
+  Print        r3
+  // print(4 in nums)
+  Const        r4 4
+  In           r5, r4, r1
+  Print        r5
+  // let nums = [1, 2, 3]
+  Return       r0

--- a/tests/vm/valid/membership.mochi
+++ b/tests/vm/valid/membership.mochi
@@ -1,0 +1,3 @@
+let nums = [1, 2, 3]
+print(2 in nums)
+print(4 in nums)

--- a/tests/vm/valid/membership.out
+++ b/tests/vm/valid/membership.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- update `runtime/vm` docs and support `in` operator
- generate VM code for list membership
- add tests for membership

## Testing
- `go test ./tests/vm -run .`

------
https://chatgpt.com/codex/tasks/task_e_68596615881483209aaf5197e9a2e966