### PR TITLE
Extend JIT list support

### DIFF
--- a/runtime/jit/README.md
+++ b/runtime/jit/README.md
@@ -28,6 +28,7 @@ The JIT currently understands a limited subset of Mochi:
 * Short‑circuit boolean operators `&&` and `||`
 * Unary `-` and `!`
 * Integer list membership `in`
+* Integer list equality `==` and inequality `!=` for list literals
 * Built-in `len` for integer and string literals
 * Simple string literal comparisons and membership checks
 * Float operations using SSE instructions

--- a/runtime/jit/jit.go
+++ b/runtime/jit/jit.go
@@ -393,6 +393,28 @@ func (i IfExpr) isFloat() bool {
 
 func (b BinOp) compile(a *Assembler) {
 	if b.Op == "==" || b.Op == "!=" {
+		if l, lok := b.Left.(ListLit); lok {
+			if r, rok := b.Right.(ListLit); rok {
+				eq := len(l.Elems) == len(r.Elems)
+				if eq {
+					for i := range l.Elems {
+						if l.Elems[i] != r.Elems[i] {
+							eq = false
+							break
+						}
+					}
+				}
+				if b.Op == "!=" {
+					eq = !eq
+				}
+				if eq {
+					a.MovRaxImm(1)
+				} else {
+					a.MovRaxImm(0)
+				}
+				return
+			}
+		}
 		l, lok := b.Left.(StrLit)
 		r, rok := b.Right.(StrLit)
 		if lok && rok {

--- a/runtime/jit/jit_test.go
+++ b/runtime/jit/jit_test.go
@@ -193,3 +193,23 @@ func TestCompileInString(t *testing.T) {
 		t.Fatalf("expected membership false")
 	}
 }
+
+func TestCompileListEquality(t *testing.T) {
+	expr := BinOp{Op: "==", Left: ListLit{Elems: []int64{1, 2}}, Right: ListLit{Elems: []int64{1, 2}}}
+	fn, err := Compile(expr)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if fn() != 1 {
+		t.Fatalf("expected list equality to be true")
+	}
+
+	expr2 := BinOp{Op: "!=", Left: ListLit{Elems: []int64{1}}, Right: ListLit{Elems: []int64{2}}}
+	fn2, err := Compile(expr2)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if fn2() != 1 {
+		t.Fatalf("expected list inequality to be true")
+	}
+}


### PR DESCRIPTION
## Summary
- add equality/inequality handling for integer list literals
- document list equality support
- test list equality and inequality

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68596852ea0083209d6903a1f7441ad9