### PR TITLE
Optimize interpreter performance

### DIFF
--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -220,8 +220,10 @@ func builtinAvg(i *Interpreter, c *parser.CallExpr) (any, error) {
 	return sum / float64(len(list)), nil
 }
 
-func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallExpr) (any, error) {
-	return map[string]func(*Interpreter, *parser.CallExpr) (any, error){
+var builtinFuncMap map[string]func(*Interpreter, *parser.CallExpr) (any, error)
+
+func init() {
+	builtinFuncMap = map[string]func(*Interpreter, *parser.CallExpr) (any, error){
 		"print":  builtinPrint,
 		"len":    builtinLen,
 		"append": builtinAppend,
@@ -233,4 +235,8 @@ func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallE
 		"avg":    builtinAvg,
 		"eval":   builtinEval,
 	}
+}
+
+func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallExpr) (any, error) {
+	return builtinFuncMap
 }


### PR DESCRIPTION
## Summary
- cache builtin function table to avoid map allocations
- add environment pooling helpers for reusing Env objects
- use AcquireEnv/ReleaseEnv in interpreter for loops, if-statements and function calls
- lower inline call threshold

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68596837f34c83208cb32ac21acf786b