### PR TITLE
Add simple function support to JIT

### DIFF
--- a/runtime/jit/README.md
+++ b/runtime/jit/README.md
@@ -34,6 +34,7 @@ The JIT currently understands a limited subset of Mochi:
 * Float operations using SSE instructions
 * Casting between `int` and `float`
 * Basic `if` expressions
+* Simple function definitions and calls with up to two integer arguments
 * Result returned as a single `int64`
 
 ## Unsupported features (partial list)
@@ -41,7 +42,6 @@ The JIT currently understands a limited subset of Mochi:
 Most of the Mochi language is not implemented:
 
 * Loops, variables or assignments
-* Function calls or arguments
 * Strings, maps and complex data structures
 * Structs, pattern matching and user types
 * Closures or nested functions

--- a/runtime/jit/jit_test.go
+++ b/runtime/jit/jit_test.go
@@ -213,3 +213,22 @@ func TestCompileListEquality(t *testing.T) {
 		t.Fatalf("expected list inequality to be true")
 	}
 }
+
+func TestCompileProgramCall(t *testing.T) {
+	fnDef := FunctionDef{
+		Name:   "add",
+		Params: 2,
+		Body:   BinOp{Op: "+", Left: Var{Index: 0}, Right: Var{Index: 1}},
+	}
+	prog := Program{
+		Funcs: []FunctionDef{fnDef},
+		Main:  Call{Name: "add", Args: []Expr{IntLit{Val: 2}, IntLit{Val: 3}}},
+	}
+	fn, err := CompileProgram(prog)
+	if err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	if fn() != 5 {
+		t.Fatalf("expected 5 got %d", fn())
+	}
+}


### PR DESCRIPTION
## Summary
- extend JIT assembler with register/`call` helpers
- support variables and function calls in JIT AST
- add `CompileProgram` for programs with function definitions
- document new capabilities in `runtime/jit` README
- test function calls in the JIT

## Testing
- `go test ./runtime/jit -run TestCompileProgramCall -v`
- `go test ./runtime/jit -v`


------
https://chatgpt.com/codex/tasks/task_e_68596e2c9aac8320a2d73c992d3f14d8