### PR TITLE
Fix REPL prompt output

### DIFF
--- a/repl/tea.go
+++ b/repl/tea.go
@@ -168,7 +168,7 @@ func welcomeString(version string) string {
 func (r *REPL) RunTUI() {
 	m := newTeaModel(r)
 	m.appendOutput(welcomeString(r.version))
-	p := tea.NewProgram(m)
+        p := tea.NewProgram(m, tea.WithAltScreen())
 	if err := p.Start(); err != nil {
 		printf(r.out, "%s failed to start TUI: %v\n", cError("error:"), err)
 	}


### PR DESCRIPTION
## Summary
- use Bubble Tea alt-screen mode so REPL doesn't print duplicate prompts

## Testing
- `go test ./parser`
- `make build-mochi`


------
https://chatgpt.com/codex/tasks/task_e_68597144e25483209895c1924f4f4dc8