### PR TITLE
Fix REPL output of expressions

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -171,6 +171,36 @@ func (i *Interpreter) Run() error {
 	return nil
 }
 
+// RunResult executes the program like Run but returns the value of the last
+// expression statement, if any. Declarations and other statements behave the
+// same as in Run.
+func (i *Interpreter) RunResult() (any, error) {
+	defer i.Close()
+	if err := i.checkExternObjects(); err != nil {
+		return nil, err
+	}
+
+	var result any
+	for idx, stmt := range i.prog.Statements {
+		if stmt.Test != nil {
+			continue
+		}
+		if stmt.Expr != nil && idx == len(i.prog.Statements)-1 {
+			v, err := i.evalExpr(stmt.Expr.Expr)
+			if err != nil {
+				return nil, err
+			}
+			result = v
+			continue
+		}
+		if err := i.evalStmt(stmt); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
 func (i *Interpreter) Test() error {
 	defer i.Close()
 	if err := i.checkExternObjects(); err != nil {

--- a/interpreter/run_result_test.go
+++ b/interpreter/run_result_test.go
@@ -1,0 +1,55 @@
+package interpreter
+
+import (
+	"mochi/parser"
+	"mochi/types"
+	"testing"
+)
+
+func TestRunResult_SingleExpr(t *testing.T) {
+	prog, err := parser.ParseString("1 + 4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	interp := New(prog, env, "")
+	v, err := interp.RunResult()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if v != 5 {
+		t.Fatalf("want 5, got %v", v)
+	}
+}
+
+func TestRunResult_LastExpr(t *testing.T) {
+	prog, err := parser.ParseString("let x = 3\nx + 2")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	interp := New(prog, env, "")
+	v, err := interp.RunResult()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if v != 5 {
+		t.Fatalf("want 5, got %v", v)
+	}
+}
+
+func TestRunResult_NoExpr(t *testing.T) {
+	prog, err := parser.ParseString("let x = 3")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	interp := New(prog, env, "")
+	v, err := interp.RunResult()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if v != nil {
+		t.Fatalf("want nil, got %v", v)
+	}
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -142,8 +142,13 @@ func (r *REPL) Run() {
 		}
 
 		r.interp.SetProgram(prog)
-		if err := r.interp.Run(); err != nil {
+		result, err := r.interp.RunResult()
+		if err != nil {
 			printf(r.out, "%s %v\n", cError("runtime error:"), err)
+			continue
+		}
+		if result != nil {
+			printf(r.out, "%v\n", result)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- return result of last expression with `Interpreter.RunResult`
- show evaluated expression results in REPL
- cover new interpreter method with tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685974b0fbcc832082df05379d5fe0b3