### PR TITLE
Add VM benchmarks and builtins

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -5,142 +5,160 @@
 | --- | ---: | --- |
 | Typescript | 4 | best |
 | Mochi | 9 | +125.0% |
-| Python | 603 | +14975.0% |
-| mochi (interp) | 39603 | +989975.0% |
+| Mochi (vm) | 11 | +175.0% |
+| Python | 602 | +14950.0% |
+| mochi (interp) | 58019 | +1450375.0% |
 
 ## math.fact_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
 | Mochi | 17 | +325.0% |
-| Python | 1214 | +30250.0% |
-| mochi (interp) | 62549 | +1563625.0% |
+| Mochi (vm) | 22 | +450.0% |
+| Python | 1289 | +32125.0% |
+| mochi (interp) | 71918 | +1797850.0% |
 
 ## math.fact_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
-| Mochi | 35 | +775.0% |
-| Python | 1990 | +49650.0% |
-| mochi (interp) | 98844 | +2471000.0% |
+| Mochi (vm) | 27 | +575.0% |
+| Mochi | 59 | +1375.0% |
+| Python | 1904 | +47500.0% |
+| mochi (interp) | 121189 | +3029625.0% |
 
 ## math.fib_iter.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 5 | best |
-| Mochi | 7 | +40.0% |
-| Python | 383 | +7560.0% |
-| mochi (interp) | 11244 | +224780.0% |
+| Typescript | 4 | best |
+| Mochi (vm) | 7 | +75.0% |
+| Mochi | 7 | +75.0% |
+| Python | 387 | +9575.0% |
+| mochi (interp) | 11676 | +291800.0% |
 
 ## math.fib_iter.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
 | Mochi | 13 | +225.0% |
-| Python | 686 | +17050.0% |
-| mochi (interp) | 18851 | +471175.0% |
+| Mochi (vm) | 16 | +300.0% |
+| Python | 665 | +16525.0% |
+| mochi (interp) | 31589 | +789625.0% |
 
 ## math.fib_iter.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
-| Mochi | 23 | +475.0% |
-| Python | 938 | +23350.0% |
-| mochi (interp) | 26286 | +657050.0% |
+| Mochi | 18 | +350.0% |
+| Mochi (vm) | 23 | +475.0% |
+| Python | 980 | +24400.0% |
+| mochi (interp) | 36462 | +911450.0% |
 
 ## math.fib_rec.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
+| Mochi (vm) | 0 | best |
 | Mochi | 0 | best |
 | Python | 11 | ++Inf% |
-| Typescript | 25 | ++Inf% |
-| mochi (interp) | 572 | ++Inf% |
+| Typescript | 23 | ++Inf% |
+| mochi (interp) | 845 | ++Inf% |
 
 ## math.fib_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi | 35 | best |
-| Typescript | 491 | +1302.9% |
-| Python | 1071 | +2960.0% |
-| mochi (interp) | 61214 | +174797.1% |
+| Mochi (vm) | 64 | +82.9% |
+| Typescript | 726 | +1974.3% |
+| Python | 1081 | +2988.6% |
+| mochi (interp) | 92508 | +264208.6% |
 
 ## math.fib_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 4404 | best |
-| Typescript | 9699 | +120.2% |
-| Python | 125516 | +2750.0% |
-| mochi (interp) | 9324336 | +211624.3% |
+| Mochi (vm) | 4390 | best |
+| Mochi | 4408 | +0.4% |
+| Typescript | 10067 | +129.3% |
+| Python | 125994 | +2770.0% |
+| mochi (interp) | 10600380 | +241366.5% |
 
 ## math.mul_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
 | Mochi | 6 | +50.0% |
-| Python | 348 | +8600.0% |
-| mochi (interp) | 8564 | +214000.0% |
+| Mochi (vm) | 8 | +100.0% |
+| Python | 346 | +8550.0% |
+| mochi (interp) | 8059 | +201375.0% |
 
 ## math.mul_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 5 | best |
-| Mochi | 15 | +200.0% |
-| Python | 725 | +14400.0% |
-| mochi (interp) | 11748 | +234860.0% |
+| Typescript | 4 | best |
+| Mochi (vm) | 12 | +200.0% |
+| Mochi | 12 | +200.0% |
+| Python | 730 | +18150.0% |
+| mochi (interp) | 13090 | +327150.0% |
 
 ## math.mul_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 4 | best |
-| Mochi | 22 | +450.0% |
-| Python | 1191 | +29675.0% |
-| mochi (interp) | 16298 | +407350.0% |
+| Typescript | 5 | best |
+| Mochi | 18 | +260.0% |
+| Mochi (vm) | 22 | +340.0% |
+| Python | 1158 | +23060.0% |
+| mochi (interp) | 17743 | +354760.0% |
 
 ## math.prime_count.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
+| Mochi (vm) | 3 | best |
+| Mochi | 3 | best |
 | Typescript | 3 | best |
-| Mochi | 4 | +33.3% |
-| Python | 197 | +6466.7% |
-| mochi (interp) | 5693 | +189666.7% |
+| Python | 202 | +6633.3% |
+| mochi (interp) | 6031 | +200933.3% |
 
 ## math.prime_count.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 4 | best |
-| Mochi | 23 | +475.0% |
-| Python | 544 | +13500.0% |
-| mochi (interp) | 32703 | +817475.0% |
+| Typescript | 3 | best |
+| Mochi (vm) | 19 | +533.3% |
+| Mochi | 19 | +533.3% |
+| Python | 546 | +18100.0% |
+| mochi (interp) | 22520 | +750566.7% |
 
 ## math.prime_count.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 3 | best |
-| Mochi | 45 | +1400.0% |
-| Python | 959 | +31866.7% |
-| mochi (interp) | 28088 | +936166.7% |
+| Typescript | 4 | best |
+| Mochi | 36 | +800.0% |
+| Mochi (vm) | 49 | +1125.0% |
+| Python | 957 | +23825.0% |
+| mochi (interp) | 32290 | +807150.0% |
 
 ## math.sum_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 5 | best |
+| Mochi (vm) | 6 | +20.0% |
 | Mochi | 6 | +20.0% |
-| Python | 364 | +7180.0% |
-| mochi (interp) | 8354 | +166980.0% |
+| Python | 360 | +7100.0% |
+| mochi (interp) | 12303 | +245960.0% |
 
 ## math.sum_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi | 15 | +150.0% |
-| Python | 529 | +8716.7% |
-| mochi (interp) | 12537 | +208850.0% |
+| Typescript | 4 | best |
+| Mochi | 12 | +200.0% |
+| Mochi (vm) | 15 | +275.0% |
+| Python | 524 | +13000.0% |
+| mochi (interp) | 35099 | +877375.0% |
 
 ## math.sum_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi | 22 | +266.7% |
-| Python | 785 | +12983.3% |
-| mochi (interp) | 16963 | +282616.7% |
+| Typescript | 5 | best |
+| Mochi | 18 | +260.0% |
+| Mochi (vm) | 22 | +340.0% |
+| Python | 857 | +17040.0% |
+| mochi (interp) | 17947 | +358840.0% |
 


### PR DESCRIPTION
## Summary
- extend VM with `now()` and `json()` instructions
- allow benchmarks to run using the VM
- regenerate BENCHMARK.md

## Testing
- `go test ./...`
- `go run ./cmd/mochi-bench`

------
https://chatgpt.com/codex/tasks/task_e_685978c2a45483209e0c487f989edbc4