### PR TITLE
Fix benchmark outputs and VM time bug

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -5,160 +5,160 @@
 | --- | ---: | --- |
 | Typescript | 4 | best |
 | Mochi | 9 | +125.0% |
-| Mochi (vm) | 11 | +175.0% |
-| Python | 602 | +14950.0% |
-| mochi (interp) | 58019 | +1450375.0% |
+| Mochi (VM) | 11 | +175.0% |
+| Python | 606 | +15050.0% |
+| Mochi (Interpreter) | 43222 | +1080450.0% |
 
 ## math.fact_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
 | Mochi | 17 | +325.0% |
-| Mochi (vm) | 22 | +450.0% |
-| Python | 1289 | +32125.0% |
-| mochi (interp) | 71918 | +1797850.0% |
+| Mochi (VM) | 19 | +375.0% |
+| Python | 1271 | +31675.0% |
+| Mochi (Interpreter) | 80822 | +2020450.0% |
 
 ## math.fact_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 4 | best |
-| Mochi (vm) | 27 | +575.0% |
-| Mochi | 59 | +1375.0% |
-| Python | 1904 | +47500.0% |
-| mochi (interp) | 121189 | +3029625.0% |
+| Mochi | 28 | best |
+| Mochi (VM) | 35 | +25.0% |
+| Typescript | 40 | +42.9% |
+| Python | 1968 | +6928.6% |
+| Mochi (Interpreter) | 101589 | +362717.9% |
 
 ## math.fib_iter.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
-| Mochi (vm) | 7 | +75.0% |
 | Mochi | 7 | +75.0% |
-| Python | 387 | +9575.0% |
-| mochi (interp) | 11676 | +291800.0% |
+| Mochi (VM) | 9 | +125.0% |
+| Python | 409 | +10125.0% |
+| Mochi (Interpreter) | 11328 | +283100.0% |
 
 ## math.fib_iter.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
 | Mochi | 13 | +225.0% |
-| Mochi (vm) | 16 | +300.0% |
-| Python | 665 | +16525.0% |
-| mochi (interp) | 31589 | +789625.0% |
+| Mochi (VM) | 16 | +300.0% |
+| Python | 686 | +17050.0% |
+| Mochi (Interpreter) | 26982 | +674450.0% |
 
 ## math.fib_iter.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 4 | best |
-| Mochi | 18 | +350.0% |
-| Mochi (vm) | 23 | +475.0% |
-| Python | 980 | +24400.0% |
-| mochi (interp) | 36462 | +911450.0% |
+| Typescript | 5 | best |
+| Mochi | 18 | +260.0% |
+| Mochi (VM) | 23 | +360.0% |
+| Python | 1009 | +20080.0% |
+| Mochi (Interpreter) | 32822 | +656340.0% |
 
 ## math.fib_rec.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (vm) | 0 | best |
+| Mochi (VM) | 0 | best |
 | Mochi | 0 | best |
 | Python | 11 | ++Inf% |
-| Typescript | 23 | ++Inf% |
-| mochi (interp) | 845 | ++Inf% |
+| Typescript | 26 | ++Inf% |
+| Mochi (Interpreter) | 583 | ++Inf% |
 
 ## math.fib_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi | 35 | best |
-| Mochi (vm) | 64 | +82.9% |
-| Typescript | 726 | +1974.3% |
-| Python | 1081 | +2988.6% |
-| mochi (interp) | 92508 | +264208.6% |
+| Mochi | 36 | best |
+| Mochi (VM) | 41 | +13.9% |
+| Typescript | 557 | +1447.2% |
+| Python | 1065 | +2858.3% |
+| Mochi (Interpreter) | 86890 | +241261.1% |
 
 ## math.fib_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (vm) | 4390 | best |
-| Mochi | 4408 | +0.4% |
-| Typescript | 10067 | +129.3% |
-| Python | 125994 | +2770.0% |
-| mochi (interp) | 10600380 | +241366.5% |
+| Mochi | 4375 | best |
+| Mochi (VM) | 4487 | +2.6% |
+| Typescript | 14966 | +242.1% |
+| Python | 128708 | +2841.9% |
+| Mochi (Interpreter) | 10483464 | +239522.0% |
 
 ## math.mul_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 4 | best |
-| Mochi | 6 | +50.0% |
-| Mochi (vm) | 8 | +100.0% |
-| Python | 346 | +8550.0% |
-| mochi (interp) | 8059 | +201375.0% |
+| Typescript | 5 | best |
+| Mochi (VM) | 6 | +20.0% |
+| Mochi | 6 | +20.0% |
+| Python | 347 | +6840.0% |
+| Mochi (Interpreter) | 8455 | +169000.0% |
 
 ## math.mul_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 4 | best |
-| Mochi (vm) | 12 | +200.0% |
-| Mochi | 12 | +200.0% |
-| Python | 730 | +18150.0% |
-| mochi (interp) | 13090 | +327150.0% |
+| Typescript | 5 | best |
+| Mochi | 13 | +160.0% |
+| Mochi (VM) | 15 | +200.0% |
+| Python | 787 | +15640.0% |
+| Mochi (Interpreter) | 13647 | +272840.0% |
 
 ## math.mul_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 5 | best |
 | Mochi | 18 | +260.0% |
-| Mochi (vm) | 22 | +340.0% |
-| Python | 1158 | +23060.0% |
-| mochi (interp) | 17743 | +354760.0% |
+| Mochi (VM) | 22 | +340.0% |
+| Python | 1236 | +24620.0% |
+| Mochi (Interpreter) | 17866 | +357220.0% |
 
 ## math.prime_count.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (vm) | 3 | best |
 | Mochi | 3 | best |
 | Typescript | 3 | best |
-| Python | 202 | +6633.3% |
-| mochi (interp) | 6031 | +200933.3% |
+| Mochi (VM) | 4 | +33.3% |
+| Python | 197 | +6466.7% |
+| Mochi (Interpreter) | 6047 | +201466.7% |
 
 ## math.prime_count.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 3 | best |
-| Mochi (vm) | 19 | +533.3% |
-| Mochi | 19 | +533.3% |
-| Python | 546 | +18100.0% |
-| mochi (interp) | 22520 | +750566.7% |
+| Typescript | 4 | best |
+| Mochi | 19 | +375.0% |
+| Mochi (VM) | 23 | +475.0% |
+| Python | 542 | +13450.0% |
+| Mochi (Interpreter) | 20239 | +505875.0% |
 
 ## math.prime_count.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 4 | best |
-| Mochi | 36 | +800.0% |
-| Mochi (vm) | 49 | +1125.0% |
-| Python | 957 | +23825.0% |
-| mochi (interp) | 32290 | +807150.0% |
+| Typescript | 3 | best |
+| Mochi (VM) | 36 | +1100.0% |
+| Mochi | 67 | +2133.3% |
+| Python | 903 | +30000.0% |
+| Mochi (Interpreter) | 31510 | +1050233.3% |
 
 ## math.sum_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 5 | best |
-| Mochi (vm) | 6 | +20.0% |
-| Mochi | 6 | +20.0% |
-| Python | 360 | +7100.0% |
-| mochi (interp) | 12303 | +245960.0% |
+| Typescript | 4 | best |
+| Mochi (VM) | 8 | +100.0% |
+| Mochi | 11 | +175.0% |
+| Python | 311 | +7675.0% |
+| Mochi (Interpreter) | 8041 | +200925.0% |
 
 ## math.sum_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
+| Mochi (VM) | 12 | +200.0% |
 | Mochi | 12 | +200.0% |
-| Mochi (vm) | 15 | +275.0% |
-| Python | 524 | +13000.0% |
-| mochi (interp) | 35099 | +877375.0% |
+| Python | 521 | +12925.0% |
+| Mochi (Interpreter) | 13635 | +340775.0% |
 
 ## math.sum_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 5 | best |
-| Mochi | 18 | +260.0% |
-| Mochi (vm) | 22 | +340.0% |
-| Python | 857 | +17040.0% |
-| mochi (interp) | 17947 | +358840.0% |
+| Typescript | 6 | best |
+| Mochi | 18 | +200.0% |
+| Mochi (VM) | 22 | +266.7% |
+| Python | 778 | +12866.7% |
+| Mochi (Interpreter) | 37371 | +622750.0% |
 

--- a/bench/out/math_fact_rec_10.c.out
+++ b/bench/out/math_fact_rec_10.c.out
@@ -1,0 +1,113 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fact_rec(int n){
+	if ((n == 0)) {
+		return 1;
+	}
+	return (n * fact_rec((n - 1)));
+}
+
+int main() {
+	int n = 10;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = fact_rec(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fact_rec_10.ir.out
+++ b/bench/out/math_fact_rec_10.ir.out
@@ -1,0 +1,60 @@
+func main (regs=22)
+  // let n = 10
+  Const        r0, 10
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = fact_rec(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun fact_rec(n: int): int {
+func fact_rec (regs=9)
+  // if n == 0 {
+  Const        r1, 0
+  Equal        r2, r0, r1
+  JumpIfFalse  r2, L0
+  // return 1
+  Const        r3, 1
+  Return       r3
+L0:
+  // return n * fact_rec(n - 1)
+  Const        r5, 1
+  Sub          r6, r0, r5
+  Move         r4, r6
+  Call         r7, 1, 1, r4
+  Mul          r8, r0, r7
+  Return       r8
+  Return       r0
+

--- a/bench/out/math_fact_rec_20.c.out
+++ b/bench/out/math_fact_rec_20.c.out
@@ -1,0 +1,113 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fact_rec(int n){
+	if ((n == 0)) {
+		return 1;
+	}
+	return (n * fact_rec((n - 1)));
+}
+
+int main() {
+	int n = 20;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = fact_rec(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fact_rec_20.ir.out
+++ b/bench/out/math_fact_rec_20.ir.out
@@ -1,0 +1,60 @@
+func main (regs=22)
+  // let n = 20
+  Const        r0, 20
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = fact_rec(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun fact_rec(n: int): int {
+func fact_rec (regs=9)
+  // if n == 0 {
+  Const        r1, 0
+  Equal        r2, r0, r1
+  JumpIfFalse  r2, L0
+  // return 1
+  Const        r3, 1
+  Return       r3
+L0:
+  // return n * fact_rec(n - 1)
+  Const        r5, 1
+  Sub          r6, r0, r5
+  Move         r4, r6
+  Call         r7, 1, 1, r4
+  Mul          r8, r0, r7
+  Return       r8
+  Return       r0
+

--- a/bench/out/math_fact_rec_30.c.out
+++ b/bench/out/math_fact_rec_30.c.out
@@ -1,0 +1,113 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fact_rec(int n){
+	if ((n == 0)) {
+		return 1;
+	}
+	return (n * fact_rec((n - 1)));
+}
+
+int main() {
+	int n = 30;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = fact_rec(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fact_rec_30.ir.out
+++ b/bench/out/math_fact_rec_30.ir.out
@@ -1,0 +1,60 @@
+func main (regs=22)
+  // let n = 30
+  Const        r0, 30
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = fact_rec(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun fact_rec(n: int): int {
+func fact_rec (regs=9)
+  // if n == 0 {
+  Const        r1, 0
+  Equal        r2, r0, r1
+  JumpIfFalse  r2, L0
+  // return 1
+  Const        r3, 1
+  Return       r3
+L0:
+  // return n * fact_rec(n - 1)
+  Const        r5, 1
+  Sub          r6, r0, r5
+  Move         r4, r6
+  Call         r7, 1, 1, r4
+  Mul          r8, r0, r7
+  Return       r8
+  Return       r0
+

--- a/bench/out/math_fib_iter_10.c.out
+++ b/bench/out/math_fib_iter_10.c.out
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fib(int n){
+	int a = 0;
+	int b = 1;
+	for (int i = 0; i < n; i++) {
+		int tmp = (a + b);
+		a = b;
+		b = tmp;
+	}
+	return a;
+}
+
+int main() {
+	int n = 10;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = fib(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fib_iter_10.ir.out
+++ b/bench/out/math_fib_iter_10.ir.out
@@ -1,0 +1,72 @@
+func main (regs=22)
+  // let n = 10
+  Const        r0, 10
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = fib(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun fib(n: int): int {
+func fib (regs=12)
+  // var a = 0
+  Const        r1, 0
+  Move         r2, r1
+  // var b = 1
+  Const        r3, 1
+  Move         r4, r3
+  // for i in 0..n {
+  Const        r5, 0
+  Move         r6, r5
+L1:
+  Less         r7, r6, r0
+  JumpIfFalse  r7, L0
+  // let tmp = a + b
+  Add          r8, r2, r4
+  Move         r9, r8
+  // a = b
+  Move         r2, r4
+  // b = tmp
+  Move         r4, r9
+  // for i in 0..n {
+  Const        r10, 1
+  Add          r11, r6, r10
+  Move         r6, r11
+  Jump         L1
+L0:
+  // return a
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_fib_iter_20.c.out
+++ b/bench/out/math_fib_iter_20.c.out
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fib(int n){
+	int a = 0;
+	int b = 1;
+	for (int i = 0; i < n; i++) {
+		int tmp = (a + b);
+		a = b;
+		b = tmp;
+	}
+	return a;
+}
+
+int main() {
+	int n = 20;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = fib(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fib_iter_20.ir.out
+++ b/bench/out/math_fib_iter_20.ir.out
@@ -1,0 +1,72 @@
+func main (regs=22)
+  // let n = 20
+  Const        r0, 20
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = fib(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun fib(n: int): int {
+func fib (regs=12)
+  // var a = 0
+  Const        r1, 0
+  Move         r2, r1
+  // var b = 1
+  Const        r3, 1
+  Move         r4, r3
+  // for i in 0..n {
+  Const        r5, 0
+  Move         r6, r5
+L1:
+  Less         r7, r6, r0
+  JumpIfFalse  r7, L0
+  // let tmp = a + b
+  Add          r8, r2, r4
+  Move         r9, r8
+  // a = b
+  Move         r2, r4
+  // b = tmp
+  Move         r4, r9
+  // for i in 0..n {
+  Const        r10, 1
+  Add          r11, r6, r10
+  Move         r6, r11
+  Jump         L1
+L0:
+  // return a
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_fib_iter_30.c.out
+++ b/bench/out/math_fib_iter_30.c.out
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fib(int n){
+	int a = 0;
+	int b = 1;
+	for (int i = 0; i < n; i++) {
+		int tmp = (a + b);
+		a = b;
+		b = tmp;
+	}
+	return a;
+}
+
+int main() {
+	int n = 30;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = fib(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fib_iter_30.ir.out
+++ b/bench/out/math_fib_iter_30.ir.out
@@ -1,0 +1,72 @@
+func main (regs=22)
+  // let n = 30
+  Const        r0, 30
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = fib(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun fib(n: int): int {
+func fib (regs=12)
+  // var a = 0
+  Const        r1, 0
+  Move         r2, r1
+  // var b = 1
+  Const        r3, 1
+  Move         r4, r3
+  // for i in 0..n {
+  Const        r5, 0
+  Move         r6, r5
+L1:
+  Less         r7, r6, r0
+  JumpIfFalse  r7, L0
+  // let tmp = a + b
+  Add          r8, r2, r4
+  Move         r9, r8
+  // a = b
+  Move         r2, r4
+  // b = tmp
+  Move         r4, r9
+  // for i in 0..n {
+  Const        r10, 1
+  Add          r11, r6, r10
+  Move         r6, r11
+  Jump         L1
+L0:
+  // return a
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_fib_rec_10.c.out
+++ b/bench/out/math_fib_rec_10.c.out
@@ -1,0 +1,109 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fib(int n){
+	if ((n <= 1)) {
+		return n;
+	}
+	return (fib((n - 1)) + fib((n - 2)));
+}
+
+int main() {
+	int n = 10;
+	int start = _now();
+	int result = fib(n);
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fib_rec_10.ir.out
+++ b/bench/out/math_fib_rec_10.ir.out
@@ -1,0 +1,44 @@
+func main (regs=14)
+  // let n = 10
+  Const        r0, 10
+  Move         r1, r0
+  // let start = now()
+  Now          r2
+  Move         r3, r2
+  // let result = fib(n)
+  Move         r4, r1
+  Call         r5, 1, 1, r4
+  Move         r6, r5
+  // let duration = (now() - start) / 1000
+  Now          r7
+  Sub          r8, r7, r3
+  Const        r9, 1000
+  Div          r10, r8, r9
+  Move         r11, r10
+  // let output = {
+  Move         r13, r12
+  // json(output)
+  JSON         r13
+  Return       r0
+
+  // fun fib(n: int): int {
+func fib (regs=12)
+  // if n <= 1 { return n }
+  Const        r1, 1
+  LessEq       r2, r0, r1
+  JumpIfFalse  r2, L0
+  Return       r0
+L0:
+  // return fib(n - 1) + fib(n - 2)
+  Const        r4, 1
+  Sub          r5, r0, r4
+  Move         r3, r5
+  Call         r6, 1, 1, r3
+  Const        r8, 2
+  Sub          r9, r0, r8
+  Move         r7, r9
+  Call         r10, 1, 1, r7
+  Add          r11, r6, r10
+  Return       r11
+  Return       r0
+

--- a/bench/out/math_fib_rec_20.c.out
+++ b/bench/out/math_fib_rec_20.c.out
@@ -1,0 +1,109 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fib(int n){
+	if ((n <= 1)) {
+		return n;
+	}
+	return (fib((n - 1)) + fib((n - 2)));
+}
+
+int main() {
+	int n = 20;
+	int start = _now();
+	int result = fib(n);
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fib_rec_20.ir.out
+++ b/bench/out/math_fib_rec_20.ir.out
@@ -1,0 +1,44 @@
+func main (regs=14)
+  // let n = 20
+  Const        r0, 20
+  Move         r1, r0
+  // let start = now()
+  Now          r2
+  Move         r3, r2
+  // let result = fib(n)
+  Move         r4, r1
+  Call         r5, 1, 1, r4
+  Move         r6, r5
+  // let duration = (now() - start) / 1000
+  Now          r7
+  Sub          r8, r7, r3
+  Const        r9, 1000
+  Div          r10, r8, r9
+  Move         r11, r10
+  // let output = {
+  Move         r13, r12
+  // json(output)
+  JSON         r13
+  Return       r0
+
+  // fun fib(n: int): int {
+func fib (regs=12)
+  // if n <= 1 { return n }
+  Const        r1, 1
+  LessEq       r2, r0, r1
+  JumpIfFalse  r2, L0
+  Return       r0
+L0:
+  // return fib(n - 1) + fib(n - 2)
+  Const        r4, 1
+  Sub          r5, r0, r4
+  Move         r3, r5
+  Call         r6, 1, 1, r3
+  Const        r8, 2
+  Sub          r9, r0, r8
+  Move         r7, r9
+  Call         r10, 1, 1, r7
+  Add          r11, r6, r10
+  Return       r11
+  Return       r0
+

--- a/bench/out/math_fib_rec_30.c.out
+++ b/bench/out/math_fib_rec_30.c.out
@@ -1,0 +1,109 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int fib(int n){
+	if ((n <= 1)) {
+		return n;
+	}
+	return (fib((n - 1)) + fib((n - 2)));
+}
+
+int main() {
+	int n = 30;
+	int start = _now();
+	int result = fib(n);
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_fib_rec_30.ir.out
+++ b/bench/out/math_fib_rec_30.ir.out
@@ -1,0 +1,44 @@
+func main (regs=14)
+  // let n = 30
+  Const        r0, 30
+  Move         r1, r0
+  // let start = now()
+  Now          r2
+  Move         r3, r2
+  // let result = fib(n)
+  Move         r4, r1
+  Call         r5, 1, 1, r4
+  Move         r6, r5
+  // let duration = (now() - start) / 1000
+  Now          r7
+  Sub          r8, r7, r3
+  Const        r9, 1000
+  Div          r10, r8, r9
+  Move         r11, r10
+  // let output = {
+  Move         r13, r12
+  // json(output)
+  JSON         r13
+  Return       r0
+
+  // fun fib(n: int): int {
+func fib (regs=12)
+  // if n <= 1 { return n }
+  Const        r1, 1
+  LessEq       r2, r0, r1
+  JumpIfFalse  r2, L0
+  Return       r0
+L0:
+  // return fib(n - 1) + fib(n - 2)
+  Const        r4, 1
+  Sub          r5, r0, r4
+  Move         r3, r5
+  Call         r6, 1, 1, r3
+  Const        r8, 2
+  Sub          r9, r0, r8
+  Move         r7, r9
+  Call         r10, 1, 1, r7
+  Add          r11, r6, r10
+  Return       r11
+  Return       r0
+

--- a/bench/out/math_mul_loop_10.c.out
+++ b/bench/out/math_mul_loop_10.c.out
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int mul(int n){
+	int result = 1;
+	for (int i = 1; i < n; i++) {
+		result = (result * i);
+	}
+	return result;
+}
+
+int main() {
+	int n = 10;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = mul(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_mul_loop_10.ir.out
+++ b/bench/out/math_mul_loop_10.ir.out
@@ -1,0 +1,65 @@
+func main (regs=22)
+  // let n = 10
+  Const        r0, 10
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = mul(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun mul(n: int): int {
+func mul (regs=9)
+  // var result = 1
+  Const        r1, 1
+  Move         r2, r1
+  // for i in 1..n {
+  Const        r3, 1
+  Move         r4, r3
+L1:
+  Less         r5, r4, r0
+  JumpIfFalse  r5, L0
+  // result = result * i
+  Mul          r6, r2, r4
+  Move         r2, r6
+  // for i in 1..n {
+  Const        r7, 1
+  Add          r8, r4, r7
+  Move         r4, r8
+  Jump         L1
+L0:
+  // return result
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_mul_loop_20.c.out
+++ b/bench/out/math_mul_loop_20.c.out
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int mul(int n){
+	int result = 1;
+	for (int i = 1; i < n; i++) {
+		result = (result * i);
+	}
+	return result;
+}
+
+int main() {
+	int n = 20;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = mul(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_mul_loop_20.ir.out
+++ b/bench/out/math_mul_loop_20.ir.out
@@ -1,0 +1,65 @@
+func main (regs=22)
+  // let n = 20
+  Const        r0, 20
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = mul(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun mul(n: int): int {
+func mul (regs=9)
+  // var result = 1
+  Const        r1, 1
+  Move         r2, r1
+  // for i in 1..n {
+  Const        r3, 1
+  Move         r4, r3
+L1:
+  Less         r5, r4, r0
+  JumpIfFalse  r5, L0
+  // result = result * i
+  Mul          r6, r2, r4
+  Move         r2, r6
+  // for i in 1..n {
+  Const        r7, 1
+  Add          r8, r4, r7
+  Move         r4, r8
+  Jump         L1
+L0:
+  // return result
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_mul_loop_30.c.out
+++ b/bench/out/math_mul_loop_30.c.out
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int mul(int n){
+	int result = 1;
+	for (int i = 1; i < n; i++) {
+		result = (result * i);
+	}
+	return result;
+}
+
+int main() {
+	int n = 30;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = mul(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_mul_loop_30.ir.out
+++ b/bench/out/math_mul_loop_30.ir.out
@@ -1,0 +1,65 @@
+func main (regs=22)
+  // let n = 30
+  Const        r0, 30
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = mul(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun mul(n: int): int {
+func mul (regs=9)
+  // var result = 1
+  Const        r1, 1
+  Move         r2, r1
+  // for i in 1..n {
+  Const        r3, 1
+  Move         r4, r3
+L1:
+  Less         r5, r4, r0
+  JumpIfFalse  r5, L0
+  // result = result * i
+  Mul          r6, r2, r4
+  Move         r2, r6
+  // for i in 1..n {
+  Const        r7, 1
+  Add          r8, r4, r7
+  Move         r4, r8
+  Jump         L1
+L0:
+  // return result
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_prime_count_10.c.out
+++ b/bench/out/math_prime_count_10.c.out
@@ -1,0 +1,125 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int is_prime(int n){
+	if ((n < 2)) {
+		return 0;
+	}
+	for (int i = 2; i < ((n - 1)); i++) {
+		if (((n % i) == 0)) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+int main() {
+	int n = 10;
+	int repeat = 100;
+	int last = 0;
+	int start = _now();
+	for (int r = 0; r < repeat; r++) {
+		int count = 0;
+		for (int i = 2; i < n; i++) {
+			if (is_prime(i)) {
+				count = (count + 1);
+			}
+		}
+		last = count;
+	}
+	int end = _now();
+	int duration = (((end - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_prime_count_10.ir.out
+++ b/bench/out/math_prime_count_10.ir.out
@@ -1,0 +1,102 @@
+func main (regs=32)
+  // let n = 10
+  Const        r0, 10
+  Move         r1, r0
+  // let repeat = 100
+  Const        r2, 100
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for r in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L4:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // var count = 0
+  Const        r11, 0
+  Move         r12, r11
+  // for i in 2..n {
+  Const        r13, 2
+  Move         r14, r13
+L3:
+  Less         r15, r14, r1
+  JumpIfFalse  r15, L1
+  // if is_prime(i) {
+  Move         r16, r14
+  Call         r17, 1, 1, r16
+  JumpIfFalse  r17, L2
+  // count = count + 1
+  Const        r18, 1
+  Add          r19, r12, r18
+  Move         r12, r19
+L2:
+  // for i in 2..n {
+  Const        r20, 1
+  Add          r21, r14, r20
+  Move         r14, r21
+  Jump         L3
+L1:
+  // last = count
+  Move         r5, r12
+  // for r in 0..repeat {
+  Const        r22, 1
+  Add          r23, r9, r22
+  Move         r9, r23
+  Jump         L4
+L0:
+  // let end = now()
+  Now          r24
+  Move         r25, r24
+  // let duration = (end - start) / 1000
+  Sub          r26, r25, r7
+  Const        r27, 1000
+  Div          r28, r26, r27
+  Move         r29, r28
+  // let output = {
+  Move         r31, r30
+  // json(output)
+  JSON         r31
+  Return       r0
+
+  // fun is_prime(n: int): bool {
+func is_prime (regs=16)
+  // if n < 2 { return false }
+  Const        r1, 2
+  Less         r2, r0, r1
+  JumpIfFalse  r2, L0
+  Const        r3, false
+  Return       r3
+L0:
+  // for i in 2..(n - 1) {
+  Const        r4, 2
+  Const        r5, 1
+  Sub          r6, r0, r5
+  Move         r7, r4
+L3:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L1
+  // if n % i == 0 {
+  Mod          r9, r0, r7
+  Const        r10, 0
+  Equal        r11, r9, r10
+  JumpIfFalse  r11, L2
+  // return false
+  Const        r12, false
+  Return       r12
+L2:
+  // for i in 2..(n - 1) {
+  Const        r13, 1
+  Add          r14, r7, r13
+  Move         r7, r14
+  Jump         L3
+L1:
+  // return true
+  Const        r15, true
+  Return       r15
+  Return       r0
+

--- a/bench/out/math_prime_count_20.c.out
+++ b/bench/out/math_prime_count_20.c.out
@@ -1,0 +1,125 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int is_prime(int n){
+	if ((n < 2)) {
+		return 0;
+	}
+	for (int i = 2; i < ((n - 1)); i++) {
+		if (((n % i) == 0)) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+int main() {
+	int n = 20;
+	int repeat = 100;
+	int last = 0;
+	int start = _now();
+	for (int r = 0; r < repeat; r++) {
+		int count = 0;
+		for (int i = 2; i < n; i++) {
+			if (is_prime(i)) {
+				count = (count + 1);
+			}
+		}
+		last = count;
+	}
+	int end = _now();
+	int duration = (((end - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_prime_count_20.ir.out
+++ b/bench/out/math_prime_count_20.ir.out
@@ -1,0 +1,102 @@
+func main (regs=32)
+  // let n = 20
+  Const        r0, 20
+  Move         r1, r0
+  // let repeat = 100
+  Const        r2, 100
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for r in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L4:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // var count = 0
+  Const        r11, 0
+  Move         r12, r11
+  // for i in 2..n {
+  Const        r13, 2
+  Move         r14, r13
+L3:
+  Less         r15, r14, r1
+  JumpIfFalse  r15, L1
+  // if is_prime(i) {
+  Move         r16, r14
+  Call         r17, 1, 1, r16
+  JumpIfFalse  r17, L2
+  // count = count + 1
+  Const        r18, 1
+  Add          r19, r12, r18
+  Move         r12, r19
+L2:
+  // for i in 2..n {
+  Const        r20, 1
+  Add          r21, r14, r20
+  Move         r14, r21
+  Jump         L3
+L1:
+  // last = count
+  Move         r5, r12
+  // for r in 0..repeat {
+  Const        r22, 1
+  Add          r23, r9, r22
+  Move         r9, r23
+  Jump         L4
+L0:
+  // let end = now()
+  Now          r24
+  Move         r25, r24
+  // let duration = (end - start) / 1000
+  Sub          r26, r25, r7
+  Const        r27, 1000
+  Div          r28, r26, r27
+  Move         r29, r28
+  // let output = {
+  Move         r31, r30
+  // json(output)
+  JSON         r31
+  Return       r0
+
+  // fun is_prime(n: int): bool {
+func is_prime (regs=16)
+  // if n < 2 { return false }
+  Const        r1, 2
+  Less         r2, r0, r1
+  JumpIfFalse  r2, L0
+  Const        r3, false
+  Return       r3
+L0:
+  // for i in 2..(n - 1) {
+  Const        r4, 2
+  Const        r5, 1
+  Sub          r6, r0, r5
+  Move         r7, r4
+L3:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L1
+  // if n % i == 0 {
+  Mod          r9, r0, r7
+  Const        r10, 0
+  Equal        r11, r9, r10
+  JumpIfFalse  r11, L2
+  // return false
+  Const        r12, false
+  Return       r12
+L2:
+  // for i in 2..(n - 1) {
+  Const        r13, 1
+  Add          r14, r7, r13
+  Move         r7, r14
+  Jump         L3
+L1:
+  // return true
+  Const        r15, true
+  Return       r15
+  Return       r0
+

--- a/bench/out/math_prime_count_30.c.out
+++ b/bench/out/math_prime_count_30.c.out
@@ -1,0 +1,125 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int is_prime(int n){
+	if ((n < 2)) {
+		return 0;
+	}
+	for (int i = 2; i < ((n - 1)); i++) {
+		if (((n % i) == 0)) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+int main() {
+	int n = 30;
+	int repeat = 100;
+	int last = 0;
+	int start = _now();
+	for (int r = 0; r < repeat; r++) {
+		int count = 0;
+		for (int i = 2; i < n; i++) {
+			if (is_prime(i)) {
+				count = (count + 1);
+			}
+		}
+		last = count;
+	}
+	int end = _now();
+	int duration = (((end - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_prime_count_30.ir.out
+++ b/bench/out/math_prime_count_30.ir.out
@@ -1,0 +1,102 @@
+func main (regs=32)
+  // let n = 30
+  Const        r0, 30
+  Move         r1, r0
+  // let repeat = 100
+  Const        r2, 100
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for r in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L4:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // var count = 0
+  Const        r11, 0
+  Move         r12, r11
+  // for i in 2..n {
+  Const        r13, 2
+  Move         r14, r13
+L3:
+  Less         r15, r14, r1
+  JumpIfFalse  r15, L1
+  // if is_prime(i) {
+  Move         r16, r14
+  Call         r17, 1, 1, r16
+  JumpIfFalse  r17, L2
+  // count = count + 1
+  Const        r18, 1
+  Add          r19, r12, r18
+  Move         r12, r19
+L2:
+  // for i in 2..n {
+  Const        r20, 1
+  Add          r21, r14, r20
+  Move         r14, r21
+  Jump         L3
+L1:
+  // last = count
+  Move         r5, r12
+  // for r in 0..repeat {
+  Const        r22, 1
+  Add          r23, r9, r22
+  Move         r9, r23
+  Jump         L4
+L0:
+  // let end = now()
+  Now          r24
+  Move         r25, r24
+  // let duration = (end - start) / 1000
+  Sub          r26, r25, r7
+  Const        r27, 1000
+  Div          r28, r26, r27
+  Move         r29, r28
+  // let output = {
+  Move         r31, r30
+  // json(output)
+  JSON         r31
+  Return       r0
+
+  // fun is_prime(n: int): bool {
+func is_prime (regs=16)
+  // if n < 2 { return false }
+  Const        r1, 2
+  Less         r2, r0, r1
+  JumpIfFalse  r2, L0
+  Const        r3, false
+  Return       r3
+L0:
+  // for i in 2..(n - 1) {
+  Const        r4, 2
+  Const        r5, 1
+  Sub          r6, r0, r5
+  Move         r7, r4
+L3:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L1
+  // if n % i == 0 {
+  Mod          r9, r0, r7
+  Const        r10, 0
+  Equal        r11, r9, r10
+  JumpIfFalse  r11, L2
+  // return false
+  Const        r12, false
+  Return       r12
+L2:
+  // for i in 2..(n - 1) {
+  Const        r13, 1
+  Add          r14, r7, r13
+  Move         r7, r14
+  Jump         L3
+L1:
+  // return true
+  Const        r15, true
+  Return       r15
+  Return       r0
+

--- a/bench/out/math_sum_loop_10.c.out
+++ b/bench/out/math_sum_loop_10.c.out
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int sum(int n){
+	int total = 0;
+	for (int i = 1; i < n; i++) {
+		total = (total + i);
+	}
+	return total;
+}
+
+int main() {
+	int n = 10;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = sum(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_sum_loop_10.ir.out
+++ b/bench/out/math_sum_loop_10.ir.out
@@ -1,0 +1,65 @@
+func main (regs=22)
+  // let n = 10
+  Const        r0, 10
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = sum(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun sum(n: int): int {
+func sum (regs=9)
+  // var total = 0
+  Const        r1, 0
+  Move         r2, r1
+  // for i in 1..n {
+  Const        r3, 1
+  Move         r4, r3
+L1:
+  Less         r5, r4, r0
+  JumpIfFalse  r5, L0
+  // total = total + i
+  Add          r6, r2, r4
+  Move         r2, r6
+  // for i in 1..n {
+  Const        r7, 1
+  Add          r8, r4, r7
+  Move         r4, r8
+  Jump         L1
+L0:
+  // return total
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_sum_loop_20.c.out
+++ b/bench/out/math_sum_loop_20.c.out
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int sum(int n){
+	int total = 0;
+	for (int i = 1; i < n; i++) {
+		total = (total + i);
+	}
+	return total;
+}
+
+int main() {
+	int n = 20;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = sum(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_sum_loop_20.ir.out
+++ b/bench/out/math_sum_loop_20.ir.out
@@ -1,0 +1,65 @@
+func main (regs=22)
+  // let n = 20
+  Const        r0, 20
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = sum(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun sum(n: int): int {
+func sum (regs=9)
+  // var total = 0
+  Const        r1, 0
+  Move         r2, r1
+  // for i in 1..n {
+  Const        r3, 1
+  Move         r4, r3
+L1:
+  Less         r5, r4, r0
+  JumpIfFalse  r5, L0
+  // total = total + i
+  Add          r6, r2, r4
+  Move         r2, r6
+  // for i in 1..n {
+  Const        r7, 1
+  Add          r8, r4, r7
+  Move         r4, r8
+  Jump         L1
+L0:
+  // return total
+  Return       r2
+  Return       r0
+

--- a/bench/out/math_sum_loop_30.c.out
+++ b/bench/out/math_sum_loop_30.c.out
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { int len; int *data; } list_int;
+static list_int list_int_create(int len) {
+    list_int l;
+    l.len = len;
+    l.data = (int*)malloc(sizeof(int)*len);
+    return l;
+}
+typedef struct { int len; double *data; } list_float;
+static list_float list_float_create(int len) {
+    list_float l;
+    l.len = len;
+    l.data = (double*)malloc(sizeof(double)*len);
+    return l;
+}
+typedef struct { int len; char** data; } list_string;
+static list_string list_string_create(int len) {
+    list_string l;
+    l.len = len;
+    l.data = (char**)malloc(sizeof(char*)*len);
+    return l;
+}
+typedef struct { int len; list_int *data; } list_list_int;
+static list_list_int list_list_int_create(int len) {
+    list_list_int l;
+    l.len = len;
+    l.data = (list_int*)malloc(sizeof(list_int)*len);
+    return l;
+}
+static long long _now() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char* s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_int(v.data[i]); }
+    printf("]");
+}
+static void _json_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_float(v.data[i]); }
+    printf("]");
+}
+static void _json_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_string(v.data[i]); }
+    printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) { if (i > 0) printf(","); _json_list_int(v.data[i]); }
+    printf("]");
+}
+static void _print_list_int(list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%d", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_list_int(list_list_int v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        _print_list_int(v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_float(list_float v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%g", v.data[i]);
+    }
+    printf("]");
+}
+static void _print_list_string(list_string v) {
+    printf("[");
+    for (int i = 0; i < v.len; i++) {
+        if (i > 0) printf(" ");
+        printf("%s", v.data[i]);
+    }
+    printf("]");
+}
+int sum(int n){
+	int total = 0;
+	for (int i = 1; i < n; i++) {
+		total = (total + i);
+	}
+	return total;
+}
+
+int main() {
+	int n = 30;
+	int repeat = 1000;
+	int last = 0;
+	int start = _now();
+	for (int i = 0; i < repeat; i++) {
+		last = sum(n);
+	}
+	int duration = (((_now() - start)) / 1000);
+	int output = 0;
+	_json_int(output);
+	return 0;
+}

--- a/bench/out/math_sum_loop_30.ir.out
+++ b/bench/out/math_sum_loop_30.ir.out
@@ -1,0 +1,65 @@
+func main (regs=22)
+  // let n = 30
+  Const        r0, 30
+  Move         r1, r0
+  // let repeat = 1000
+  Const        r2, 1000
+  Move         r3, r2
+  // var last = 0
+  Const        r4, 0
+  Move         r5, r4
+  // let start = now()
+  Now          r6
+  Move         r7, r6
+  // for i in 0..repeat {
+  Const        r8, 0
+  Move         r9, r8
+L1:
+  Less         r10, r9, r3
+  JumpIfFalse  r10, L0
+  // last = sum(n)
+  Move         r11, r1
+  Call         r12, 1, 1, r11
+  Move         r5, r12
+  // for i in 0..repeat {
+  Const        r13, 1
+  Add          r14, r9, r13
+  Move         r9, r14
+  Jump         L1
+L0:
+  // let duration = (now() - start) / 1000
+  Now          r15
+  Sub          r16, r15, r7
+  Const        r17, 1000
+  Div          r18, r16, r17
+  Move         r19, r18
+  // let output = {
+  Move         r21, r20
+  // json(output)
+  JSON         r21
+  Return       r0
+
+  // fun sum(n: int): int {
+func sum (regs=9)
+  // var total = 0
+  Const        r1, 0
+  Move         r2, r1
+  // for i in 1..n {
+  Const        r3, 1
+  Move         r4, r3
+L1:
+  Less         r5, r4, r0
+  JumpIfFalse  r5, L0
+  // total = total + i
+  Add          r6, r2, r4
+  Move         r2, r6
+  // for i in 1..n {
+  Const        r7, 1
+  Add          r8, r4, r7
+  Move         r4, r8
+  Jump         L1
+L0:
+  // return total
+  Return       r2
+  Return       r0
+

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -823,6 +823,10 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 		return dst
 	}
 
+	if p.Group != nil {
+		return fc.compileExpr(p.Group)
+	}
+
 	if p.Map != nil {
 		if v, ok := constMap(p.Map); ok {
 			dst := fc.newReg()


### PR DESCRIPTION
## Summary
- generate C and IR benchmark outputs
- fix missing `now()` call in VM by supporting grouped expressions
- update benchmark label names
- refresh BENCHMARK.md results

## Testing
- `go run ./cmd/mochi-bench > bench_run.log`


------
https://chatgpt.com/codex/tasks/task_e_68597f71c54483209b4588613b0ac401