### PR TITLE
Fix non-tty REPL output

### DIFF
--- a/cmd/mochi/main.go
+++ b/cmd/mochi/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/charmbracelet/fang"
 	"github.com/fatih/color"
 	_ "github.com/lib/pq"
+	isatty "github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"mochi/runtime/llm"
@@ -1213,7 +1214,11 @@ func newReplCmd() *cobra.Command {
 		Short: "Start an interactive REPL session",
 		Run: func(cmd *cobra.Command, args []string) {
 			r := repl.New(os.Stdout, version)
-			r.RunTUI()
+			if isatty.IsTerminal(os.Stdout.Fd()) && isatty.IsTerminal(os.Stdin.Fd()) {
+				r.RunTUI()
+			} else {
+				r.Run()
+			}
 		},
 	}
 	return c


### PR DESCRIPTION
## Summary
- update `mochi repl` to detect non-TTY environments
- fall back to readline REPL when stdout or stdin isn't a terminal

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6859821812488320982530241b2eeaf4