### PR TITLE
Fix repeated REPL prompts

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -193,6 +193,7 @@ func printHelp(out io.Writer) {
 
 func (r *REPL) setPrompt(base string) {
 	r.rl.SetPrompt(cPrompt(base))
+	r.rl.Refresh()
 }
 
 func printf(w io.Writer, format string, args ...any) {


### PR DESCRIPTION
## Summary
- refresh readline after setting prompt

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859849109b08320b688db76dcc10525