### PR TITLE
Add PyPy and Cython benchmarks

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -3,162 +3,198 @@
 ## math.fact_rec.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 7 | best |
-| Mochi (VM) | 13 | +85.7% |
-| Mochi (Go) | 13 | +85.7% |
-| Python | 844 | +11957.1% |
-| Mochi (Interpreter) | 47824 | +683100.0% |
+| Typescript | 5 | best |
+| Mochi (Go) | 9 | +80.0% |
+| Mochi (VM) | 11 | +120.0% |
+| Python (Cython) | 596 | +11820.0% |
+| Python | 646 | +12820.0% |
+| Python (PyPy) | 5912 | +118140.0% |
+| Mochi (Interpreter) | 35208 | +704060.0% |
 
 ## math.fact_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (VM) | 25 | +316.7% |
-| Mochi (Go) | 25 | +316.7% |
-| Python | 1766 | +29333.3% |
-| Mochi (Interpreter) | 110806 | +1846666.7% |
+| Typescript | 7 | best |
+| Mochi (Go) | 17 | +142.9% |
+| Mochi (VM) | 22 | +214.3% |
+| Python (Cython) | 1253 | +17800.0% |
+| Python | 1266 | +17985.7% |
+| Python (PyPy) | 8595 | +122685.7% |
+| Mochi (Interpreter) | 69610 | +994328.6% |
 
 ## math.fact_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (VM) | 39 | +550.0% |
-| Mochi (Go) | 39 | +550.0% |
-| Python | 2837 | +47183.3% |
-| Mochi (Interpreter) | 150332 | +2505433.3% |
+| Typescript | 4 | best |
+| Mochi (Go) | 28 | +600.0% |
+| Mochi (VM) | 34 | +750.0% |
+| Python | 1975 | +49275.0% |
+| Python (Cython) | 2007 | +50075.0% |
+| Python (PyPy) | 21125 | +528025.0% |
+| Mochi (Interpreter) | 103096 | +2577300.0% |
 
 ## math.fib_iter.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (VM) | 10 | +66.7% |
-| Mochi (Go) | 25 | +316.7% |
-| Python | 569 | +9383.3% |
-| Mochi (Interpreter) | 15827 | +263683.3% |
+| Mochi (Go) | 7 | best |
+| Typescript | 7 | best |
+| Mochi (VM) | 9 | +28.6% |
+| Python (Cython) | 386 | +5414.3% |
+| Python | 412 | +5785.7% |
+| Python (PyPy) | 3102 | +44214.3% |
+| Mochi (Interpreter) | 12568 | +179442.9% |
 
 ## math.fib_iter.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (Go) | 18 | +200.0% |
-| Mochi (VM) | 60 | +900.0% |
-| Python | 977 | +16183.3% |
-| Mochi (Interpreter) | 40355 | +672483.3% |
+| Typescript | 4 | best |
+| Mochi (Go) | 13 | +225.0% |
+| Mochi (VM) | 16 | +300.0% |
+| Python (Cython) | 660 | +16400.0% |
+| Python | 919 | +22875.0% |
+| Python (PyPy) | 3823 | +95475.0% |
+| Mochi (Interpreter) | 27232 | +680700.0% |
 
 ## math.fib_iter.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (VM) | 26 | +333.3% |
-| Mochi (Go) | 26 | +333.3% |
-| Python | 1370 | +22733.3% |
-| Mochi (Interpreter) | 40956 | +682500.0% |
+| Typescript | 4 | best |
+| Mochi (Go) | 18 | +350.0% |
+| Mochi (VM) | 23 | +475.0% |
+| Python (Cython) | 963 | +23975.0% |
+| Python | 964 | +24000.0% |
+| Python (PyPy) | 2616 | +65300.0% |
+| Mochi (Interpreter) | 70441 | +1760925.0% |
 
 ## math.fib_rec.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi (VM) | 0 | best |
 | Mochi (Go) | 0 | best |
-| Python | 15 | ++Inf% |
-| Typescript | 164 | ++Inf% |
-| Mochi (Interpreter) | 910 | ++Inf% |
+| Python | 11 | ++Inf% |
+| Python (Cython) | 11 | ++Inf% |
+| Typescript | 26 | ++Inf% |
+| Python (PyPy) | 51 | ++Inf% |
+| Mochi (Interpreter) | 614 | ++Inf% |
 
 ## math.fib_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (VM) | 49 | best |
-| Mochi (Go) | 49 | best |
-| Typescript | 1019 | +1979.6% |
-| Python | 1487 | +2934.7% |
-| Mochi (Interpreter) | 99874 | +203724.5% |
+| Mochi (Go) | 38 | best |
+| Mochi (VM) | 44 | +15.8% |
+| Typescript | 686 | +1705.3% |
+| Python | 1059 | +2686.8% |
+| Python (Cython) | 1117 | +2839.5% |
+| Python (PyPy) | 9388 | +24605.3% |
+| Mochi (Interpreter) | 95043 | +250013.2% |
 
 ## math.fib_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (VM) | 6135 | best |
-| Mochi (Go) | 8615 | +40.4% |
-| Typescript | 14063 | +129.2% |
-| Python | 178091 | +2802.9% |
-| Mochi (Interpreter) | 13491798 | +219815.2% |
+| Mochi (Go) | 4417 | best |
+| Mochi (VM) | 4551 | +3.0% |
+| Typescript | 10089 | +128.4% |
+| Python (PyPy) | 44362 | +904.3% |
+| Python (Cython) | 126960 | +2774.3% |
+| Python | 133816 | +2929.6% |
+| Mochi (Interpreter) | 10206988 | +230984.2% |
 
 ## math.mul_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (VM) | 9 | best |
-| Mochi (Go) | 9 | best |
-| Typescript | 71 | +688.9% |
-| Python | 479 | +5222.2% |
-| Mochi (Interpreter) | 12304 | +136611.1% |
+| Typescript | 5 | best |
+| Mochi (VM) | 6 | +20.0% |
+| Mochi (Go) | 6 | +20.0% |
+| Python | 347 | +6840.0% |
+| Python (Cython) | 393 | +7760.0% |
+| Python (PyPy) | 2405 | +48000.0% |
+| Mochi (Interpreter) | 25063 | +501160.0% |
 
 ## math.mul_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (Go) | 17 | +183.3% |
-| Mochi (VM) | 58 | +866.7% |
-| Python | 1081 | +17916.7% |
-| Mochi (Interpreter) | 36280 | +604566.7% |
+| Typescript | 4 | best |
+| Mochi (Go) | 12 | +200.0% |
+| Mochi (VM) | 15 | +275.0% |
+| Python | 733 | +18225.0% |
+| Python (Cython) | 744 | +18500.0% |
+| Python (PyPy) | 2329 | +58125.0% |
+| Mochi (Interpreter) | 14803 | +369975.0% |
 
 ## math.mul_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 5 | best |
-| Mochi (VM) | 25 | +400.0% |
-| Mochi (Go) | 25 | +400.0% |
-| Python | 1779 | +35480.0% |
-| Mochi (Interpreter) | 25029 | +500480.0% |
+| Mochi (Go) | 18 | +260.0% |
+| Mochi (VM) | 22 | +340.0% |
+| Python (Cython) | 1165 | +23200.0% |
+| Python | 1216 | +24220.0% |
+| Python (PyPy) | 3939 | +78680.0% |
+| Mochi (Interpreter) | 19207 | +384040.0% |
 
 ## math.prime_count.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (VM) | 4 | best |
-| Mochi (Go) | 4 | best |
-| Typescript | 4 | best |
-| Python | 275 | +6775.0% |
-| Mochi (Interpreter) | 10910 | +272650.0% |
+| Mochi (Go) | 3 | best |
+| Mochi (VM) | 4 | +33.3% |
+| Typescript | 4 | +33.3% |
+| Python (Cython) | 197 | +6466.7% |
+| Python | 199 | +6533.3% |
+| Python (PyPy) | 953 | +31666.7% |
+| Mochi (Interpreter) | 5437 | +181133.3% |
 
 ## math.prime_count.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (VM) | 26 | +333.3% |
-| Mochi (Go) | 26 | +333.3% |
-| Python | 762 | +12600.0% |
-| Mochi (Interpreter) | 32763 | +545950.0% |
+| Typescript | 4 | best |
+| Mochi (Go) | 19 | +375.0% |
+| Mochi (VM) | 36 | +800.0% |
+| Python | 548 | +13600.0% |
+| Python (Cython) | 548 | +13600.0% |
+| Python (PyPy) | 6255 | +156275.0% |
+| Mochi (Interpreter) | 22100 | +552400.0% |
 
 ## math.prime_count.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 4 | best |
-| Mochi (VM) | 50 | +1150.0% |
-| Mochi (Go) | 50 | +1150.0% |
-| Python | 1297 | +32325.0% |
-| Mochi (Interpreter) | 40395 | +1009775.0% |
+| Mochi (VM) | 36 | +800.0% |
+| Mochi (Go) | 36 | +800.0% |
+| Python | 918 | +22850.0% |
+| Python (Cython) | 925 | +23025.0% |
+| Python (PyPy) | 7478 | +186850.0% |
+| Mochi (Interpreter) | 28939 | +723375.0% |
 
 ## math.sum_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 7 | best |
-| Mochi (VM) | 9 | +28.6% |
-| Mochi (Go) | 9 | +28.6% |
-| Python | 469 | +6600.0% |
-| Mochi (Interpreter) | 10841 | +154771.4% |
+| Typescript | 5 | best |
+| Mochi (Go) | 6 | +20.0% |
+| Mochi (VM) | 8 | +60.0% |
+| Python (Cython) | 310 | +6100.0% |
+| Python | 332 | +6540.0% |
+| Python (PyPy) | 2151 | +42920.0% |
+| Mochi (Interpreter) | 8153 | +162960.0% |
 
 ## math.sum_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Typescript | 5 | best |
-| Mochi (Go) | 17 | +240.0% |
-| Mochi (VM) | 28 | +460.0% |
-| Python | 754 | +14980.0% |
-| Mochi (Interpreter) | 34549 | +690880.0% |
+| Mochi (VM) | 12 | +140.0% |
+| Mochi (Go) | 12 | +140.0% |
+| Python (Cython) | 526 | +10420.0% |
+| Python | 528 | +10460.0% |
+| Python (PyPy) | 2339 | +46680.0% |
+| Mochi (Interpreter) | 12608 | +252060.0% |
 
 ## math.sum_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Typescript | 6 | best |
-| Mochi (VM) | 25 | +316.7% |
-| Mochi (Go) | 25 | +316.7% |
-| Python | 1078 | +17866.7% |
-| Mochi (Interpreter) | 24617 | +410183.3% |
+| Typescript | 5 | best |
+| Mochi (VM) | 18 | +260.0% |
+| Mochi (Go) | 18 | +260.0% |
+| Python | 777 | +15440.0% |
+| Python (Cython) | 781 | +15520.0% |
+| Python (PyPy) | 2227 | +44440.0% |
+| Mochi (Interpreter) | 18449 | +368880.0% |
 

--- a/compile/py/tools.go
+++ b/compile/py/tools.go
@@ -55,3 +55,95 @@ func EnsurePython() error {
 	}
 	return fmt.Errorf("python3 not found")
 }
+
+// EnsurePyPy installs PyPy3 if missing. Useful for benchmarks.
+func EnsurePyPy() error {
+	if _, err := exec.LookPath("pypy3"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("\U0001F40D Installing PyPy3...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "pypy3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("🐍 Installing PyPy3 via Homebrew...")
+			cmd := exec.Command("brew", "install", "pypy3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🐍 Installing PyPy via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "pypy3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🐍 Installing PyPy via Scoop...")
+			cmd := exec.Command("scoop", "install", "pypy")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("pypy3"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("pypy3 not found")
+}
+
+// EnsureCython installs Cython if missing. Useful for benchmarks.
+func EnsureCython() error {
+	if _, err := exec.LookPath("cython3"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("\U0001F40D Installing Cython...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "cython3")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("\U0001F40D Installing Cython via Homebrew...")
+			cmd := exec.Command("brew", "install", "cython")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("pip"); err == nil {
+			fmt.Println("\U0001F40D Installing Cython via pip...")
+			cmd := exec.Command("pip", "install", "cython")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("cython3"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("cython3 not found")
+}


### PR DESCRIPTION
## Summary
- add `EnsurePyPy` and `EnsureCython` helpers
- include Python (PyPy) and Python (Cython) in benchmark templates
- update benchmark runner and re-run

## Testing
- `go run ./cmd/mochi-bench > /tmp/bench.log`

------
https://chatgpt.com/codex/tasks/task_e_6859869907c48320a7516ad17a84d4c7