### PR TITLE
Improve call disassembly

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -137,6 +137,20 @@ type Program struct {
 	Funcs []Function
 }
 
+func (p *Program) funcName(idx int) string {
+	if idx < 0 || idx >= len(p.Funcs) {
+		return fmt.Sprintf("%d", idx)
+	}
+	name := p.Funcs[idx].Name
+	if name == "" {
+		if idx == 0 {
+			return "main"
+		}
+		return fmt.Sprintf("fn%d", idx)
+	}
+	return name
+}
+
 // Disassemble returns a human-readable listing of the program instructions.
 // If src is provided, source lines are included as comments.
 func (p *Program) Disassemble(src string) string {
@@ -221,9 +235,9 @@ func (p *Program) Disassemble(src string) string {
 			case OpJSON:
 				fmt.Fprintf(&b, "%s", formatReg(ins.A))
 			case OpCall2:
-				fmt.Fprintf(&b, "%s, %d, %s, %s", formatReg(ins.A), ins.B, formatReg(ins.C), formatReg(ins.D))
+				fmt.Fprintf(&b, "%s, %s, %s, %s", formatReg(ins.A), p.funcName(ins.B), formatReg(ins.C), formatReg(ins.D))
 			case OpCall:
-				fmt.Fprintf(&b, "%s, %d, %d, %s", formatReg(ins.A), ins.B, ins.C, formatReg(ins.D))
+				fmt.Fprintf(&b, "%s, %s, %s", formatReg(ins.A), p.funcName(ins.B), formatRegs(ins.D, ins.C))
 			case OpCallV:
 				fmt.Fprintf(&b, "%s, %s, %d, %s", formatReg(ins.A), formatReg(ins.B), ins.C, formatReg(ins.D))
 			case OpReturn:
@@ -1197,6 +1211,14 @@ func valueToString(v Value) string {
 
 func formatReg(n int) string {
 	return fmt.Sprintf("r%d", n)
+}
+
+func formatRegs(start, n int) string {
+	regs := make([]string, n)
+	for i := 0; i < n; i++ {
+		regs[i] = formatReg(start + i)
+	}
+	return strings.Join(regs, ", ")
 }
 
 func toFloat(v Value) float64 {

--- a/tests/vm/valid/fun_call.ir.out
+++ b/tests/vm/valid/fun_call.ir.out
@@ -4,7 +4,7 @@ func main (regs=5)
   Move         r0, r2
   Const        r3, 3
   Move         r1, r3
-  Call2        r4, 1, r0, r1
+  Call2        r4, add, r0, r1
   Print        r4
   Return       r0
 

--- a/tests/vm/valid/fun_three_args.ir.out
+++ b/tests/vm/valid/fun_three_args.ir.out
@@ -6,7 +6,7 @@ func main (regs=7)
   Move         r1, r4
   Const        r5, 3
   Move         r2, r5
-  Call         r6, 1, 3, r0
+  Call         r6, sum3, r0, r1, r2
   Print        r6
   Return       r0
 

--- a/tests/vm/valid/short_circuit.ir.out
+++ b/tests/vm/valid/short_circuit.ir.out
@@ -7,7 +7,7 @@ func main (regs=14)
   Move         r2, r4
   Const        r5, 2
   Move         r3, r5
-  Call2        r6, 1, r2, r3
+  Call2        r6, boom, r2, r3
   Move         r1, r6
 L0:
   Print        r1
@@ -19,7 +19,7 @@ L0:
   Move         r9, r11
   Const        r12, 2
   Move         r10, r12
-  Call2        r13, 1, r9, r10
+  Call2        r13, boom, r9, r10
   Move         r8, r13
 L1:
   Print        r8

--- a/tests/vm/valid/two-sum.ir.out
+++ b/tests/vm/valid/two-sum.ir.out
@@ -4,7 +4,7 @@ func main (regs=10)
   Move         r0, r2
   Const        r3, 9
   Move         r1, r3
-  Call2        r4, 1, r0, r1
+  Call2        r4, twoSum, r0, r1
   Move         r5, r4
   // print(result[0])
   Const        r6, 0


### PR DESCRIPTION
## Summary
- add Program.funcName helper for translating function indexes
- display function names and argument registers for `OpCall` and `OpCall2`
- update VM golden test outputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68598c34b2a48320ae310218fea02279