### PR TITLE
Add v0.9.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # 📦 CHANGELOG.md
-## [0.9.0] – 2025-07-01
+## [0.9.1] – 2025-06-24
+
+### Added
+
+* Function expressions and generic calls in the VM
+* Function support in the pure Mochi interpreter
+* Simple function support for the JIT
+* Map indexing operations
+
+### Changed
+
+* REPL simplified without Bubble Tea UI and displays evaluation results
+* Human-readable call disassembly in the VM
+* Benchmarks updated with IR and C outputs
+* TypeScript runtime computes globals at runtime
+
+### Fixed
+
+* Corrected IR disassembly comment placement
+* Resolved VM `now` builtin bug
+* Refreshed REPL prompt and output handling
+* Fixed C benchmark outputs and runtime compilation
+
+## [0.9.0] – 2025-06-23
 
 ### Added
 

--- a/releases/v0.9.0.md
+++ b/releases/v0.9.0.md
@@ -1,4 +1,4 @@
-# Jul 2025 (v0.9.0)
+# Jun 2025 (v0.9.0)
 
 Mochi v0.9.0 ships the first official standard library. Core utilities for math,
 strings, time and collections are now provided as regular packages under the

--- a/releases/v0.9.1.md
+++ b/releases/v0.9.1.md
@@ -1,0 +1,23 @@
+# Jun 2025 (v0.9.1)
+
+Mochi v0.9.1 refines the runtime and development tools. The VM now supports
+function expressions, generic calls and map indexing with clearer call
+traces. The JIT handles simple functions while the REPL switches to a
+lightweight terminal interface. Benchmarks and the TypeScript runtime have
+been refreshed along with numerous fixes.
+
+## Runtime
+
+- Function expressions and generic calls in the VM
+- Map indexing operations
+- Human-readable call disassembly
+- `now` builtin bug fixed
+
+## Tooling
+
+- Simple function support for the JIT
+- REPL updated without Bubble Tea TUI and shows evaluation results
+- Benchmarks include IR and C outputs with corrected C runtime results
+- TypeScript runtime computes globals at runtime
+- Tests reorganized under a single folder
+


### PR DESCRIPTION
## Summary
- write changelog entries for v0.9.1
- correct dates for v0.9.0 and v0.9.1
- add release notes document for v0.9.1
- update v0.9.0 release notes date

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859a0f2b2fc8320915b66633d76e319