### PR TITLE
Add numeric bytecode specialization

### DIFF
--- a/tests/vm/valid/basic_compare.ir.out
+++ b/tests/vm/valid/basic_compare.ir.out
@@ -2,21 +2,21 @@ func main (regs=12)
   // let a = 10 - 3
   Const        r0, 10
   Const        r1, 3
-  Sub          r2, r0, r1
+  SubInt       r2, r0, r1
   Move         r3, r2
   // let b = 2 + 2
   Const        r4, 2
   Const        r5, 2
-  Add          r6, r4, r5
+  AddInt       r6, r4, r5
   Move         r7, r6
   // print(a)
   Print        r3
   // print(a == 7)
   Const        r8, 7
-  Equal        r9, r3, r8
+  EqualInt     r9, r3, r8
   Print        r9
   // print(b < 5)
   Const        r10, 5
-  Less         r11, r7, r10
+  LessInt      r11, r7, r10
   Print        r11
   Return       r0

--- a/tests/vm/valid/if_else.ir.out
+++ b/tests/vm/valid/if_else.ir.out
@@ -4,7 +4,7 @@ func main (regs=6)
   Move         r1, r0
   // if x > 3 {
   Const        r2, 3
-  Less         r3, r2, r1
+  LessInt      r3, r2, r1
   JumpIfFalse  r3, L0
   // print("big")
   Const        r4, "big"

--- a/tests/vm/valid/let_and_print.ir.out
+++ b/tests/vm/valid/let_and_print.ir.out
@@ -6,6 +6,6 @@ func main (regs=5)
   Const        r2, 20
   Move         r3, r2
   // print(a + b)
-  Add          r4, r1, r3
+  AddInt       r4, r1, r3
   Print        r4
   Return       r0

--- a/tests/vm/valid/math_ops.ir.out
+++ b/tests/vm/valid/math_ops.ir.out
@@ -2,16 +2,16 @@ func main (regs=9)
   // print(6 * 7)
   Const        r0, 6
   Const        r1, 7
-  Mul          r2, r0, r1
+  MulInt       r2, r0, r1
   Print        r2
   // print(7 / 2)
   Const        r3, 7
   Const        r4, 2
-  Div          r5, r3, r4
+  DivInt       r5, r3, r4
   Print        r5
   // print(7 % 2)
   Const        r6, 7
   Const        r7, 2
-  Mod          r8, r6, r7
+  ModInt       r8, r6, r7
   Print        r8
   Return       r0

--- a/tests/vm/valid/two-sum.ir.out
+++ b/tests/vm/valid/two-sum.ir.out
@@ -29,7 +29,7 @@ L4:
   JumpIfFalse  r6, L0
   // for j in i+1..n {
   Const        r7, 1
-  Add          r8, r5, r7
+  AddInt       r8, r5, r7
   Move         r9, r8
 L3:
   Less         r10, r9, r3

--- a/tests/vm/valid/while_loop.ir.out
+++ b/tests/vm/valid/while_loop.ir.out
@@ -5,13 +5,13 @@ func main (regs=6)
 L1:
   // while i < 3 {
   Const        r2, 3
-  Less         r3, r1, r2
+  LessInt      r3, r1, r2
   JumpIfFalse  r3, L0
   // print(i)
   Print        r1
   // i = i + 1
   Const        r4, 1
-  Add          r5, r1, r4
+  AddInt       r5, r1, r4
   Move         r1, r5
   // while i < 3 {
   Jump         L1


### PR DESCRIPTION
## Summary
- specialize VM bytecode for int and float ops
- track register types during compilation to emit specialized instructions
- update disassembler and execution engine for new ops
- refresh golden test outputs

## Testing
- `go test ./tests/vm -run .`


------
https://chatgpt.com/codex/tasks/task_e_6859ab92eb888320828aece0126a10f2