### PR TITLE
Add CFG inference to VM

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -1,0 +1,186 @@
+package vm
+
+// Type inference across a function's control flow graph. It propagates simple
+// register type tags beyond basic blocks to enable later optimizations.
+
+// typeInfo holds type data for each program point. In[i] is the register tags
+// at the start of instruction i, Out[i] after executing i.
+type typeInfo struct {
+	In  [][]regTag
+	Out [][]regTag
+}
+
+// inferTypes performs a forward data flow analysis to determine register type
+// tags for the given function.
+func inferTypes(fn *Function) *typeInfo {
+	n := len(fn.Code)
+	info := &typeInfo{
+		In:  make([][]regTag, n),
+		Out: make([][]regTag, n),
+	}
+
+	// helper functions
+	copyTags := func(tags []regTag) []regTag {
+		out := make([]regTag, len(tags))
+		copy(out, tags)
+		return out
+	}
+
+	mergeInto := func(dst []regTag, src []regTag) bool {
+		changed := false
+		for i := range dst {
+			s := src[i]
+			d := dst[i]
+			if s == tagUnknown || s == d {
+				continue
+			}
+			if d == tagUnknown {
+				dst[i] = s
+				changed = true
+			} else if d != s {
+				dst[i] = tagUnknown
+				changed = true
+			}
+		}
+		return changed
+	}
+
+	work := []int{0}
+	info.In[0] = make([]regTag, fn.NumRegs)
+
+	for len(work) > 0 {
+		pc := work[0]
+		work = work[1:]
+		in := info.In[pc]
+		out := applyInstr(in, fn.Code[pc])
+		if info.Out[pc] == nil || mergeInto(info.Out[pc], out) {
+			info.Out[pc] = copyTags(out)
+		}
+
+		addEdge := func(next int, tags []regTag) {
+			if next < 0 || next >= n {
+				return
+			}
+			if info.In[next] == nil {
+				info.In[next] = copyTags(tags)
+				work = append(work, next)
+				return
+			}
+			if mergeInto(info.In[next], tags) {
+				work = append(work, next)
+			}
+		}
+
+		ins := fn.Code[pc]
+		switch ins.Op {
+		case OpJump:
+			addEdge(ins.A, out)
+		case OpJumpIfFalse, OpJumpIfTrue:
+			addEdge(ins.B, out)
+			addEdge(pc+1, out)
+		case OpReturn:
+			// no successor
+		default:
+			addEdge(pc+1, out)
+		}
+	}
+
+	return info
+}
+
+// applyInstr updates register tags according to the given instruction.
+func applyInstr(in []regTag, ins Instr) []regTag {
+	out := make([]regTag, len(in))
+	copy(out, in)
+	switch ins.Op {
+	case OpConst:
+		out[ins.A] = valTag(ins.Val)
+	case OpMove:
+		out[ins.A] = in[ins.B]
+	case OpAddInt, OpSubInt, OpMulInt, OpDivInt, OpModInt:
+		out[ins.A] = tagInt
+	case OpAddFloat, OpSubFloat, OpMulFloat, OpDivFloat, OpModFloat:
+		out[ins.A] = tagFloat
+	case OpAdd, OpSub, OpMul, OpDiv, OpMod:
+		if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+			out[ins.A] = tagFloat
+		} else if in[ins.B] == tagInt && in[ins.C] == tagInt {
+			out[ins.A] = tagInt
+		} else {
+			out[ins.A] = tagUnknown
+		}
+	case OpEqual, OpNotEqual, OpEqualInt, OpEqualFloat,
+		OpLess, OpLessEq, OpLessInt, OpLessFloat, OpLessEqInt, OpLessEqFloat,
+		OpIn, OpNot:
+		out[ins.A] = tagBool
+	case OpLen, OpNow:
+		out[ins.A] = tagInt
+	}
+	return out
+}
+
+// optimizeFunc rewrites generic operations with specialized ones based on the
+// inferred type information.
+func optimizeFunc(fn *Function, info *typeInfo) {
+	for pc, ins := range fn.Code {
+		in := info.In[pc]
+		switch ins.Op {
+		case OpAdd:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpAddInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpAddFloat
+			}
+		case OpSub:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpSubInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpSubFloat
+			}
+		case OpMul:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpMulInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpMulFloat
+			}
+		case OpDiv:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpDivInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpDivFloat
+			}
+		case OpMod:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpModInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpModFloat
+			}
+		case OpEqual:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpEqualInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpEqualFloat
+			}
+		case OpLess:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpLessInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpLessFloat
+			}
+		case OpLessEq:
+			if in[ins.B] == tagInt && in[ins.C] == tagInt {
+				fn.Code[pc].Op = OpLessEqInt
+			} else if in[ins.B] == tagFloat || in[ins.C] == tagFloat {
+				fn.Code[pc].Op = OpLessEqFloat
+			}
+		}
+	}
+}
+
+// optimizeProgram performs type inference and rewrites on all functions in the program.
+func optimizeProgram(p *Program) {
+	for i := range p.Funcs {
+		info := inferTypes(&p.Funcs[i])
+		optimizeFunc(&p.Funcs[i], info)
+	}
+}

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -657,7 +657,9 @@ func Compile(p *parser.Program, env *types.Env) (*Program, error) {
 	}
 	main := c.compileMain(p)
 	c.funcs[0] = main
-	return &Program{Funcs: c.funcs}, nil
+	prog := &Program{Funcs: c.funcs}
+	optimizeProgram(prog)
+	return prog, nil
 }
 
 func (c *compiler) compileFun(fn *parser.FunStmt) Function {

--- a/tests/vm/valid/break_continue.ir.out
+++ b/tests/vm/valid/break_continue.ir.out
@@ -6,7 +6,7 @@ func main (regs=16)
   Len          r2, r1
   Const        r3, 0
 L4:
-  Less         r4, r3, r2
+  LessInt      r4, r3, r2
   JumpIfFalse  r4, L0
   Index        r5, r1, r3
   Move         r6, r5
@@ -32,7 +32,7 @@ L3:
 L2:
   // for n in numbers {
   Const        r14, 1
-  Add          r15, r3, r14
+  AddInt       r15, r3, r14
   Move         r3, r15
   Jump         L4
 L0:

--- a/tests/vm/valid/for_list_collection.ir.out
+++ b/tests/vm/valid/for_list_collection.ir.out
@@ -4,7 +4,7 @@ func main (regs=8)
   Len          r1, r0
   Const        r2, 0
 L1:
-  Less         r3, r2, r1
+  LessInt      r3, r2, r1
   JumpIfFalse  r3, L0
   Index        r4, r0, r2
   Move         r5, r4
@@ -12,7 +12,7 @@ L1:
   Print        r5
   // for n in [1,2,3] {
   Const        r6, 1
-  Add          r7, r2, r6
+  AddInt       r7, r2, r6
   Move         r2, r7
   Jump         L1
 L0:

--- a/tests/vm/valid/for_loop.ir.out
+++ b/tests/vm/valid/for_loop.ir.out
@@ -4,13 +4,13 @@ func main (regs=6)
   Const        r1, 4
   Move         r2, r0
 L1:
-  Less         r3, r2, r1
+  LessInt      r3, r2, r1
   JumpIfFalse  r3, L0
   // print(i)
   Print        r2
   // for i in 1..4 {
   Const        r4, 1
-  Add          r5, r2, r4
+  AddInt       r5, r2, r4
   Move         r2, r5
   Jump         L1
 L0:

--- a/tests/vm/valid/two-sum.ir.out
+++ b/tests/vm/valid/two-sum.ir.out
@@ -25,14 +25,14 @@ func twoSum (regs=23)
   Const        r4, 0
   Move         r5, r4
 L4:
-  Less         r6, r5, r3
+  LessInt      r6, r5, r3
   JumpIfFalse  r6, L0
   // for j in i+1..n {
   Const        r7, 1
   AddInt       r8, r5, r7
   Move         r9, r8
 L3:
-  Less         r10, r9, r3
+  LessInt      r10, r9, r3
   JumpIfFalse  r10, L1
   // if nums[i] + nums[j] == target {
   Index        r11, r0, r5
@@ -48,13 +48,13 @@ L3:
 L2:
   // for j in i+1..n {
   Const        r18, 1
-  Add          r19, r9, r18
+  AddInt       r19, r9, r18
   Move         r9, r19
   Jump         L3
 L1:
   // for i in 0..n {
   Const        r20, 1
-  Add          r21, r5, r20
+  AddInt       r21, r5, r20
   Move         r5, r21
   Jump         L4
 L0:


### PR DESCRIPTION
## Summary
- add a new `infer.go` implementing type inference across the bytecode CFG
- rewrite arithmetic/comparison ops based on inferred register types
- run the inference optimisation step after compilation
- update golden IR outputs for optimised opcodes

## Testing
- `go test ./tests/vm`

------
https://chatgpt.com/codex/tasks/task_e_685a04eb49e08320b2c7df3d7966ea88