### PR TITLE
Implement regTag inference across CFG

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -1,0 +1,136 @@
+package vm
+
+// RegTag represents the inferred type of a register.
+type RegTag = regTag
+
+const (
+	TagUnknown RegTag = tagUnknown
+	TagInt     RegTag = tagInt
+	TagFloat   RegTag = tagFloat
+	TagBool    RegTag = tagBool
+)
+
+type Analysis struct {
+	// In holds inferred register tags on entry to each instruction.
+	In [][]RegTag
+	// Dead marks unreachable instructions.
+	Dead []bool
+}
+
+// Infer performs type inference across the control flow graph of fn.
+func Infer(fn *Function) *Analysis {
+	n := len(fn.Code)
+	in := make([][]RegTag, n)
+	visited := make([]bool, n)
+
+	init := make([]RegTag, fn.NumRegs)
+	for i := range init {
+		init[i] = TagUnknown
+	}
+	if n > 0 {
+		in[0] = init
+	}
+
+	work := []int{0}
+	for len(work) > 0 {
+		pc := work[len(work)-1]
+		work = work[:len(work)-1]
+		if pc < 0 || pc >= n {
+			continue
+		}
+		state := in[pc]
+		if state == nil {
+			state = make([]RegTag, fn.NumRegs)
+			for i := range state {
+				state[i] = TagUnknown
+			}
+			in[pc] = state
+		}
+		visited[pc] = true
+
+		out := make([]RegTag, fn.NumRegs)
+		copy(out, state)
+		applyTags(out, fn.Code[pc])
+
+		for _, succ := range successors(fn.Code[pc], pc, n) {
+			if succ < 0 || succ >= n {
+				continue
+			}
+			if in[succ] == nil {
+				tmp := make([]RegTag, fn.NumRegs)
+				copy(tmp, out)
+				in[succ] = tmp
+				work = append(work, succ)
+				continue
+			}
+			if mergeTags(in[succ], out) {
+				work = append(work, succ)
+			}
+		}
+	}
+
+	dead := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if !visited[i] {
+			dead[i] = true
+		}
+	}
+	return &Analysis{In: in, Dead: dead}
+}
+
+func successors(ins Instr, pc, n int) []int {
+	switch ins.Op {
+	case OpJump:
+		return []int{ins.A}
+	case OpJumpIfFalse, OpJumpIfTrue:
+		return []int{pc + 1, ins.B}
+	case OpReturn:
+		return nil
+	default:
+		if pc+1 < n {
+			return []int{pc + 1}
+		}
+		return nil
+	}
+}
+
+func mergeTags(dst, src []RegTag) bool {
+	changed := false
+	for i := range dst {
+		if dst[i] == TagUnknown {
+			if src[i] != TagUnknown {
+				dst[i] = src[i]
+				changed = true
+			}
+		} else if src[i] != TagUnknown && src[i] != dst[i] {
+			dst[i] = TagUnknown
+			changed = true
+		}
+	}
+	return changed
+}
+
+func applyTags(tags []RegTag, ins Instr) {
+	switch ins.Op {
+	case OpConst:
+		tags[ins.A] = valTag(ins.Val)
+	case OpMove:
+		tags[ins.A] = tags[ins.B]
+	case OpAddInt, OpSubInt, OpMulInt, OpDivInt, OpModInt:
+		tags[ins.A] = TagInt
+	case OpAddFloat, OpSubFloat, OpMulFloat, OpDivFloat, OpModFloat:
+		tags[ins.A] = TagFloat
+	case OpAdd, OpSub, OpMul, OpDiv, OpMod:
+		tags[ins.A] = TagUnknown
+	case OpEqual, OpNotEqual, OpEqualInt, OpEqualFloat,
+		OpLess, OpLessEq, OpLessInt, OpLessFloat, OpLessEqInt, OpLessEqFloat,
+		OpIn, OpNot:
+		tags[ins.A] = TagBool
+	case OpLen, OpNow:
+		tags[ins.A] = TagInt
+	case OpJSON, OpPrint, OpPrint2:
+		// no result
+	case OpMakeList, OpIndex, OpSetIndex, OpCall, OpCall2, OpCallV:
+		tags[ins.A] = TagUnknown
+	}
+}

--- a/runtime/vm/infer_test.go
+++ b/runtime/vm/infer_test.go
@@ -1,0 +1,48 @@
+package vm
+
+import (
+	"mochi/parser"
+	"mochi/types"
+	"testing"
+)
+
+func TestInfer_TagPropagation(t *testing.T) {
+	src := `var x = 1
+if x > 0 {
+  x = x + 1
+} else {
+  x = x - 1
+}
+print(x)`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	p, err := Compile(prog, env)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	fn := &p.Funcs[0]
+	res := Infer(fn)
+
+	pc := -1
+	for i, ins := range fn.Code {
+		if ins.Op == OpPrint {
+			pc = i
+			break
+		}
+	}
+	if pc == -1 {
+		t.Fatalf("print not found")
+	}
+	if res.In[pc][1] != TagInt {
+		t.Fatalf("register r1 expected int, got %v", res.In[pc][1])
+	}
+	if res.Dead[pc] {
+		t.Fatalf("print instruction marked dead")
+	}
+}


### PR DESCRIPTION
## Summary
- add `Infer` analysis for VM bytecode to propagate register type tags across control flow
- expose `RegTag` constants
- provide unit test covering tag propagation through a branch

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a04f62e0c8320a1846dfa8cf710cc