### PR TITLE
Add VM stack trace on error

### DIFF
--- a/tests/vm/vm_error_test.go
+++ b/tests/vm/vm_error_test.go
@@ -1,0 +1,44 @@
+package vm_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func TestVM_ErrorStackTrace(t *testing.T) {
+	src := `
+fun g() {
+    let x = 1 / 0
+}
+fun f() {
+    g()
+}
+f()
+`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	m := vm.New(p, &out)
+	if err := m.Run(); err == nil {
+		t.Fatal("expected error")
+	}
+	result := out.String()
+	if !strings.Contains(result, "stack trace:") || !strings.Contains(result, "call graph:") {
+		t.Fatalf("expected stack trace output, got: %s", result)
+	}
+}


### PR DESCRIPTION
## Summary
- extend `runtime/vm` with `StackFrame` and `VMError`
- print call graph and stack trace when the VM exits with an error
- propagate trace information through function calls
- add basic test for error reporting

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a13165d68832096120de243031fc7