### PR TITLE
Implement constant folding for pure calls in VM

### DIFF
--- a/tests/vm/valid/avg_builtin.ir.out
+++ b/tests/vm/valid/avg_builtin.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(avg([1,2,3]))
-  Const        r0, [1, 2, 3]
-  Avg          r1, r0
-  Print        r1
+  Const        r0, 2
+  Print        r0
   Return       r0

--- a/tests/vm/valid/count_builtin.ir.out
+++ b/tests/vm/valid/count_builtin.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(count([1,2,3]))
-  Const        r0, [1, 2, 3]
-  Count        r1, r0
-  Print        r1
+  Const        r0, 3
+  Print        r0
   Return       r0

--- a/tests/vm/valid/len_builtin.ir.out
+++ b/tests/vm/valid/len_builtin.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(len([1,2,3]))
-  Const        r0, [1, 2, 3]
-  Len          r1, r0
-  Print        r1
+  Const        r0, 3
+  Print        r0
   Return       r0

--- a/tests/vm/valid/len_map.ir.out
+++ b/tests/vm/valid/len_map.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(len({"a":1, "b":2}))
-  Const        r0, {"a": 1, "b": 2}
-  Len          r1, r0
-  Print        r1
+  Const        r0, 2
+  Print        r0
   Return       r0

--- a/tests/vm/valid/len_string.ir.out
+++ b/tests/vm/valid/len_string.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(len("mochi"))
-  Const        r0, "mochi"
-  Len          r1, r0
-  Print        r1
+  Const        r0, 5
+  Print        r0
   Return       r0

--- a/tests/vm/valid/str_builtin.ir.out
+++ b/tests/vm/valid/str_builtin.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(str(123))
-  Const        r0, 123
-  Str          r1, r0
-  Print        r1
+  Const        r0, "123"
+  Print        r0
   Return       r0


### PR DESCRIPTION
## Summary
- add memoization map to VM compiler
- support constant evaluation of pure function calls at compile time
- store constant `let` values in environment for later folding
- update IR tests for folded built-in calls

## Testing
- `go test ./tests/vm -run TestVM_IR -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a1ab380f88320964c6743c274015f