### PR TITLE
Enable constant folding of pure functions in VM

### DIFF
--- a/tests/vm/valid/fun_call.ir.out
+++ b/tests/vm/valid/fun_call.ir.out
@@ -1,11 +1,7 @@
-func main (regs=5)
+func main (regs=1)
   // print(add(2, 3))  // 5
-  Const        r2, 2
-  Move         r0, r2
-  Const        r3, 3
-  Move         r1, r3
-  Call2        r4, add, r0, r1
-  Print        r4
+  Const        r0, 5
+  Print        r0
   Return       r0
 
   // fun add(a: int, b: int): int {

--- a/tests/vm/valid/fun_three_args.ir.out
+++ b/tests/vm/valid/fun_three_args.ir.out
@@ -1,13 +1,7 @@
-func main (regs=7)
+func main (regs=1)
   // print(sum3(1, 2, 3))  // 6
-  Const        r3, 1
-  Move         r0, r3
-  Const        r4, 2
-  Move         r1, r4
-  Const        r5, 3
-  Move         r2, r5
-  Call         r6, sum3, r0, r1, r2
-  Print        r6
+  Const        r0, 6
+  Print        r0
   Return       r0
 
   // fun sum3(a: int, b: int, c: int): int {


### PR DESCRIPTION
## Summary
- support compile-time evaluation of pure functions in the VM compiler
- register functions in the type environment so they can be folded
- store constant values from `let` statements for later folding
- update IR golden files for folded calls

## Testing
- `go test ./tests/vm -run TestVM_IR -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a1abe71b0832097a30b7c27808534