### PR TITLE
Add exported function support to Zig backend

### DIFF
--- a/compile/x/zig/README.md
+++ b/compile/x/zig/README.md
@@ -169,6 +169,13 @@ func (c *Compiler) compileIf(stmt *parser.IfStmt) error {
 ```
 【F:compile/zig/compiler.go†L182-L213】
 
+### Functions
+
+Named functions are emitted as Zig `fn` declarations. When a function is marked
+`export` it becomes `pub fn` so it can be imported from other Zig files. Mochi
+also supports anonymous function expressions which compile to inline Zig
+functions and can be assigned to variables or passed as parameters.
+
 ### Built‑ins
 
 `compileCallExpr` implements simple built‑ins like `len` and `print`:
@@ -307,7 +314,6 @@ LeetCode solutions:
 * built-in helpers like `fetch`, `load`, `save` and `generate`
 * logic programming constructs (`fact`, `rule`, `query`)
 * concurrency features such as streams or `spawn`
-* anonymous function expressions (`fun` values)
 * arrow function syntax (`fun(x: int): int => x + 1`)
 * foreign imports and `extern` declarations
 * automatic language imports (`import python "..." auto`)

--- a/compile/x/zig/compiler.go
+++ b/compile/x/zig/compiler.go
@@ -113,7 +113,11 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 	if fn.Return != nil {
 		ret = c.zigType(fn.Return)
 	}
-	c.writeln(fmt.Sprintf("fn %s(%s) %s {", name, strings.Join(params, ", "), ret))
+	prefix := ""
+	if fn.Export {
+		prefix = "pub "
+	}
+	c.writeln(fmt.Sprintf("%sfn %s(%s) %s {", prefix, name, strings.Join(params, ", "), ret))
 	c.indent++
 	for _, st := range fn.Body {
 		if err := c.compileStmt(st, true); err != nil {


### PR DESCRIPTION
## Summary
- allow `export fun` in Zig output via `pub fn`
- document function support in Zig backend

## Testing
- `go test ./... --vet=off -run TestZigCompiler_SubsetPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685a1da072588320882cee8632840bdf