### PR TITLE
Implement folding of pure calls in VM

### DIFF
--- a/tests/vm/valid/len_string.ir.out
+++ b/tests/vm/valid/len_string.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(len("mochi"))
-  Const        r0, "mochi"
-  Len          r1, r0
-  Print        r1
+  Const        r0, 5
+  Print        r0
   Return       r0

--- a/tests/vm/valid/str_builtin.ir.out
+++ b/tests/vm/valid/str_builtin.ir.out
@@ -1,6 +1,5 @@
-func main (regs=2)
+func main (regs=1)
   // print(str(123))
-  Const        r0, 123
-  Str          r1, r0
-  Print        r1
+  Const        r0, "123"
+  Print        r0
   Return       r0


### PR DESCRIPTION
## Summary
- fold pure function calls during VM compilation
- store constant let bindings in the compiler environment
- update golden IR outputs to reflect constant folding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a1f658ca08320955b305d838bb813