### PR TITLE
Add function expression type inference to Scala backend

### DIFF
--- a/compile/x/scala/infer.go
+++ b/compile/x/scala/infer.go
@@ -166,6 +166,24 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 			}
 			return types.AnyType{}
 		}
+	case p.FunExpr != nil:
+		params := make([]types.Type, len(p.FunExpr.Params))
+		for i, par := range p.FunExpr.Params {
+			if par.Type != nil {
+				params[i] = c.resolveTypeRef(par.Type)
+			} else {
+				params[i] = types.AnyType{}
+			}
+		}
+		var ret types.Type = types.VoidType{}
+		if p.FunExpr.Return != nil {
+			ret = c.resolveTypeRef(p.FunExpr.Return)
+		} else if p.FunExpr.ExprBody != nil {
+			ret = c.inferExprType(p.FunExpr.ExprBody)
+		} else {
+			ret = types.AnyType{}
+		}
+		return types.FuncType{Params: params, Return: ret}
 	case p.If != nil:
 		thenType := c.inferExprType(p.If.Then)
 		var elseType types.Type = types.AnyType{}


### PR DESCRIPTION
## Summary
- enhance Scala compiler type inference for `fun` expressions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a1f1a33c48320b8d5a99a7e974fbf