### PR TITLE
Add Lua targets to bench

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -4,111 +4,111 @@
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 3 | best |
-| Mochi (VM) | 9 | +200.0% |
 | Mochi (Go) | 9 | +200.0% |
-| Typescript | 427 | +14133.3% |
-| Python | 671 | +22266.7% |
-| Mochi (Interpreter) | 35273 | +1175666.7% |
+| Mochi (VM) | 19 | +533.3% |
+| Typescript | 379 | +12533.3% |
+| Python | 594 | +19700.0% |
+| Mochi (Interpreter) | 31914 | +1063700.0% |
 
 ## math.fact_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| C | 6 | best |
-| Mochi (Go) | 17 | +183.3% |
-| Mochi (VM) | 22 | +266.7% |
-| Typescript | 671 | +11083.3% |
-| Python | 1213 | +20116.7% |
-| Mochi (Interpreter) | 70946 | +1182333.3% |
+| C | 7 | best |
+| Mochi (Go) | 17 | +142.9% |
+| Mochi (VM) | 22 | +214.3% |
+| Typescript | 552 | +7785.7% |
+| Python | 1212 | +17214.3% |
+| Mochi (Interpreter) | 65981 | +942485.7% |
 
 ## math.fact_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 9 | best |
-| Mochi (VM) | 35 | +288.9% |
-| Mochi (Go) | 84 | +833.3% |
-| Typescript | 1184 | +13055.6% |
-| Python | 2033 | +22488.9% |
-| Mochi (Interpreter) | 119500 | +1327677.8% |
+| Mochi (Go) | 27 | +200.0% |
+| Mochi (VM) | 28 | +211.1% |
+| Typescript | 895 | +9844.4% |
+| Python | 1965 | +21733.3% |
+| Mochi (Interpreter) | 115550 | +1283788.9% |
 
 ## math.fib_iter.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| Mochi (Go) | 7 | best |
-| Mochi (VM) | 9 | +28.6% |
-| C | 70 | +900.0% |
-| Typescript | 331 | +4628.6% |
-| Python | 384 | +5385.7% |
-| Mochi (Interpreter) | 22653 | +323514.3% |
+| C | 3 | best |
+| Mochi (Go) | 7 | +133.3% |
+| Mochi (VM) | 9 | +200.0% |
+| Typescript | 281 | +9266.7% |
+| Python | 385 | +12733.3% |
+| Mochi (Interpreter) | 11095 | +369733.3% |
 
 ## math.fib_iter.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| C | 7 | best |
-| Mochi (VM) | 13 | +85.7% |
-| Mochi (Go) | 13 | +85.7% |
-| Typescript | 418 | +5871.4% |
-| Python | 662 | +9357.1% |
-| Mochi (Interpreter) | 35290 | +504042.9% |
+| C | 6 | best |
+| Mochi (VM) | 13 | +116.7% |
+| Mochi (Go) | 13 | +116.7% |
+| Typescript | 362 | +5933.3% |
+| Python | 759 | +12550.0% |
+| Mochi (Interpreter) | 21788 | +363033.3% |
 
 ## math.fib_iter.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 9 | best |
-| Mochi (VM) | 18 | +100.0% |
 | Mochi (Go) | 18 | +100.0% |
-| Typescript | 579 | +6333.3% |
-| Python | 925 | +10177.8% |
-| Mochi (Interpreter) | 29517 | +327866.7% |
+| Mochi (VM) | 32 | +255.6% |
+| Typescript | 414 | +4500.0% |
+| Python | 922 | +10144.4% |
+| Mochi (Interpreter) | 46060 | +511677.8% |
 
 ## math.fib_rec.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | Mochi (VM) | 0 | best |
 | Mochi (Go) | 0 | best |
-| C | 0 | best |
+| C | 1 | ++Inf% |
 | Python | 11 | ++Inf% |
-| Typescript | 27 | ++Inf% |
-| Mochi (Interpreter) | 643 | ++Inf% |
+| Typescript | 26 | ++Inf% |
+| Mochi (Interpreter) | 1554 | ++Inf% |
 
 ## math.fib_rec.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| C | 15 | best |
-| Mochi (VM) | 35 | +133.3% |
-| Mochi (Go) | 42 | +180.0% |
-| Typescript | 659 | +4293.3% |
-| Python | 1022 | +6713.3% |
-| Mochi (Interpreter) | 68611 | +457306.7% |
+| C | 17 | best |
+| Mochi (VM) | 35 | +105.9% |
+| Mochi (Go) | 36 | +111.8% |
+| Typescript | 608 | +3476.5% |
+| Python | 1081 | +6258.8% |
+| Mochi (Interpreter) | 75687 | +445117.6% |
 
 ## math.fib_rec.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
-| C | 1497 | best |
-| Mochi (Go) | 4454 | +197.5% |
-| Mochi (VM) | 4582 | +206.1% |
-| Typescript | 9601 | +541.3% |
-| Python | 128051 | +8453.8% |
-| Mochi (Interpreter) | 10276905 | +686400.0% |
+| C | 1476 | best |
+| Mochi (Go) | 4370 | +196.1% |
+| Mochi (VM) | 4591 | +211.0% |
+| Typescript | 9784 | +562.9% |
+| Python | 125791 | +8422.4% |
+| Mochi (Interpreter) | 9734677 | +659431.0% |
 
 ## math.mul_loop.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 2 | best |
+| Mochi (VM) | 6 | +200.0% |
 | Mochi (Go) | 6 | +200.0% |
-| Mochi (VM) | 28 | +1300.0% |
-| Typescript | 306 | +15200.0% |
-| Python | 348 | +17300.0% |
-| Mochi (Interpreter) | 23321 | +1165950.0% |
+| Typescript | 235 | +11650.0% |
+| Python | 365 | +18150.0% |
+| Mochi (Interpreter) | 8144 | +407100.0% |
 
 ## math.mul_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 5 | best |
-| Mochi (Go) | 12 | +140.0% |
-| Mochi (VM) | 20 | +300.0% |
-| Typescript | 429 | +8480.0% |
-| Python | 797 | +15840.0% |
-| Mochi (Interpreter) | 14066 | +281220.0% |
+| Mochi (Go) | 13 | +160.0% |
+| Mochi (VM) | 15 | +200.0% |
+| Typescript | 492 | +9740.0% |
+| Python | 845 | +16800.0% |
+| Mochi (Interpreter) | 26260 | +525100.0% |
 
 ## math.mul_loop.30
 | Language | Time (µs) | +/- |
@@ -116,19 +116,19 @@
 | C | 8 | best |
 | Mochi (Go) | 18 | +125.0% |
 | Mochi (VM) | 22 | +175.0% |
-| Typescript | 567 | +6987.5% |
-| Python | 1166 | +14475.0% |
-| Mochi (Interpreter) | 19172 | +239550.0% |
+| Typescript | 470 | +5775.0% |
+| Python | 1183 | +14687.5% |
+| Mochi (Interpreter) | 19090 | +238525.0% |
 
 ## math.prime_count.10
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 1 | best |
-| Mochi (VM) | 3 | +200.0% |
 | Mochi (Go) | 3 | +200.0% |
+| Mochi (VM) | 4 | +300.0% |
+| Typescript | 151 | +15000.0% |
 | Python | 198 | +19700.0% |
-| Mochi (Interpreter) | 5591 | +559000.0% |
-| Typescript | 6215 | +621400.0% |
+| Mochi (Interpreter) | 6123 | +612200.0% |
 
 ## math.prime_count.20
 | Language | Time (µs) | +/- |
@@ -136,19 +136,19 @@
 | C | 8 | best |
 | Mochi (Go) | 19 | +137.5% |
 | Mochi (VM) | 23 | +187.5% |
-| Typescript | 335 | +4087.5% |
+| Typescript | 358 | +4375.0% |
 | Python | 544 | +6700.0% |
-| Mochi (Interpreter) | 22777 | +284612.5% |
+| Mochi (Interpreter) | 16832 | +210300.0% |
 
 ## math.prime_count.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 17 | best |
-| Mochi (VM) | 36 | +111.8% |
 | Mochi (Go) | 36 | +111.8% |
-| Typescript | 389 | +2188.2% |
-| Python | 904 | +5217.6% |
-| Mochi (Interpreter) | 57378 | +337417.6% |
+| Mochi (VM) | 45 | +164.7% |
+| Typescript | 483 | +2741.2% |
+| Python | 955 | +5517.6% |
+| Mochi (Interpreter) | 40307 | +237000.0% |
 
 ## math.sum_loop.10
 | Language | Time (µs) | +/- |
@@ -156,27 +156,27 @@
 | C | 0 | best |
 | Mochi (Go) | 6 | ++Inf% |
 | Mochi (VM) | 8 | ++Inf% |
-| Typescript | 231 | ++Inf% |
-| Python | 308 | ++Inf% |
-| Mochi (Interpreter) | 8549 | ++Inf% |
+| Typescript | 224 | ++Inf% |
+| Python | 311 | ++Inf% |
+| Mochi (Interpreter) | 15131 | ++Inf% |
 
 ## math.sum_loop.20
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 0 | best |
+| Mochi (VM) | 12 | ++Inf% |
 | Mochi (Go) | 12 | ++Inf% |
-| Mochi (VM) | 15 | ++Inf% |
-| Typescript | 386 | ++Inf% |
-| Python | 517 | ++Inf% |
-| Mochi (Interpreter) | 12923 | ++Inf% |
+| Typescript | 362 | ++Inf% |
+| Python | 589 | ++Inf% |
+| Mochi (Interpreter) | 12394 | ++Inf% |
 
 ## math.sum_loop.30
 | Language | Time (µs) | +/- |
 | --- | ---: | --- |
 | C | 0 | best |
+| Mochi (VM) | 18 | ++Inf% |
 | Mochi (Go) | 18 | ++Inf% |
-| Mochi (VM) | 22 | ++Inf% |
-| Typescript | 481 | ++Inf% |
-| Python | 855 | ++Inf% |
-| Mochi (Interpreter) | 18339 | ++Inf% |
+| Typescript | 495 | ++Inf% |
+| Python | 789 | ++Inf% |
+| Mochi (Interpreter) | 22873 | ++Inf% |
 

--- a/bench/out/math_fact_rec_10.lua.out
+++ b/bench/out/math_fact_rec_10.lua.out
@@ -1,0 +1,40 @@
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fact_rec(n)
+	if __eq(n, 0) then
+		return 1
+	end
+	return (n * fact_rec((n - 1)))
+end
+
+local n = 10
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = fact_rec(n)
+	::__continue0::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_fact_rec_20.lua.out
+++ b/bench/out/math_fact_rec_20.lua.out
@@ -1,0 +1,40 @@
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fact_rec(n)
+	if __eq(n, 0) then
+		return 1
+	end
+	return (n * fact_rec((n - 1)))
+end
+
+local n = 20
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = fact_rec(n)
+	::__continue0::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_fact_rec_30.lua.out
+++ b/bench/out/math_fact_rec_30.lua.out
@@ -1,0 +1,40 @@
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fact_rec(n)
+	if __eq(n, 0) then
+		return 1
+	end
+	return (n * fact_rec((n - 1)))
+end
+
+local n = 30
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = fact_rec(n)
+	::__continue0::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_fib_iter_10.lua.out
+++ b/bench/out/math_fib_iter_10.lua.out
@@ -1,0 +1,45 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fib(n)
+	local a = 0
+	local b = 1
+	for i = 0, (n)-1 do
+		local tmp = __add(a, b)
+		a = b
+		b = tmp
+		::__continue0::
+	end
+	return a
+end
+
+local n = 10
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = fib(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_fib_iter_20.lua.out
+++ b/bench/out/math_fib_iter_20.lua.out
@@ -1,0 +1,45 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fib(n)
+	local a = 0
+	local b = 1
+	for i = 0, (n)-1 do
+		local tmp = __add(a, b)
+		a = b
+		b = tmp
+		::__continue0::
+	end
+	return a
+end
+
+local n = 20
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = fib(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_fib_iter_30.lua.out
+++ b/bench/out/math_fib_iter_30.lua.out
@@ -1,0 +1,45 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fib(n)
+	local a = 0
+	local b = 1
+	for i = 0, (n)-1 do
+		local tmp = __add(a, b)
+		a = b
+		b = tmp
+		::__continue0::
+	end
+	return a
+end
+
+local n = 30
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = fib(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_fib_rec_10.lua.out
+++ b/bench/out/math_fib_rec_10.lua.out
@@ -1,0 +1,35 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fib(n)
+	if (n <= 1) then
+		return n
+	end
+	return __add(fib((n - 1)), fib((n - 2)))
+end
+
+local n = 10
+local start = os.time()*1000000000
+local result = fib(n)
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=result})

--- a/bench/out/math_fib_rec_20.lua.out
+++ b/bench/out/math_fib_rec_20.lua.out
@@ -1,0 +1,35 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fib(n)
+	if (n <= 1) then
+		return n
+	end
+	return __add(fib((n - 1)), fib((n - 2)))
+end
+
+local n = 20
+local start = os.time()*1000000000
+local result = fib(n)
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=result})

--- a/bench/out/math_fib_rec_30.lua.out
+++ b/bench/out/math_fib_rec_30.lua.out
@@ -1,0 +1,35 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function fib(n)
+	if (n <= 1) then
+		return n
+	end
+	return __add(fib((n - 1)), fib((n - 2)))
+end
+
+local n = 30
+local start = os.time()*1000000000
+local result = fib(n)
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=result})

--- a/bench/out/math_mul_loop_10.lua.out
+++ b/bench/out/math_mul_loop_10.lua.out
@@ -1,0 +1,30 @@
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function mul(n)
+	local result = 1
+	for i = 1, (n)-1 do
+		result = (result * i)
+		::__continue0::
+	end
+	return result
+end
+
+local n = 10
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = mul(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_mul_loop_20.lua.out
+++ b/bench/out/math_mul_loop_20.lua.out
@@ -1,0 +1,30 @@
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function mul(n)
+	local result = 1
+	for i = 1, (n)-1 do
+		result = (result * i)
+		::__continue0::
+	end
+	return result
+end
+
+local n = 20
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = mul(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_mul_loop_30.lua.out
+++ b/bench/out/math_mul_loop_30.lua.out
@@ -1,0 +1,30 @@
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function mul(n)
+	local result = 1
+	for i = 1, (n)-1 do
+		result = (result * i)
+		::__continue0::
+	end
+	return result
+end
+
+local n = 30
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = mul(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_prime_count_10.lua.out
+++ b/bench/out/math_prime_count_10.lua.out
@@ -1,0 +1,66 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function is_prime(n)
+	if (n < 2) then
+		return false
+	end
+	for i = 2, (((n - 1)))-1 do
+		if __eq((n % i), 0) then
+			return false
+		end
+		::__continue0::
+	end
+	return true
+end
+
+local n = 10
+local _repeat = 100
+local last = 0
+local start = os.time()*1000000000
+for r = 0, (_repeat)-1 do
+	local count = 0
+	for i = 2, (n)-1 do
+		if is_prime(i) then
+			count = __add(count, 1)
+		end
+		::__continue2::
+	end
+	last = count
+	::__continue1::
+end
+local _end = os.time()*1000000000
+local duration = __div(((_end - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_prime_count_20.lua.out
+++ b/bench/out/math_prime_count_20.lua.out
@@ -1,0 +1,66 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function is_prime(n)
+	if (n < 2) then
+		return false
+	end
+	for i = 2, (((n - 1)))-1 do
+		if __eq((n % i), 0) then
+			return false
+		end
+		::__continue0::
+	end
+	return true
+end
+
+local n = 20
+local _repeat = 100
+local last = 0
+local start = os.time()*1000000000
+for r = 0, (_repeat)-1 do
+	local count = 0
+	for i = 2, (n)-1 do
+		if is_prime(i) then
+			count = __add(count, 1)
+		end
+		::__continue2::
+	end
+	last = count
+	::__continue1::
+end
+local _end = os.time()*1000000000
+local duration = __div(((_end - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_prime_count_30.lua.out
+++ b/bench/out/math_prime_count_30.lua.out
@@ -1,0 +1,66 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function is_prime(n)
+	if (n < 2) then
+		return false
+	end
+	for i = 2, (((n - 1)))-1 do
+		if __eq((n % i), 0) then
+			return false
+		end
+		::__continue0::
+	end
+	return true
+end
+
+local n = 30
+local _repeat = 100
+local last = 0
+local start = os.time()*1000000000
+for r = 0, (_repeat)-1 do
+	local count = 0
+	for i = 2, (n)-1 do
+		if is_prime(i) then
+			count = __add(count, 1)
+		end
+		::__continue2::
+	end
+	last = count
+	::__continue1::
+end
+local _end = os.time()*1000000000
+local duration = __div(((_end - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_sum_loop_10.lua.out
+++ b/bench/out/math_sum_loop_10.lua.out
@@ -1,0 +1,42 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function sum(n)
+	local total = 0
+	for i = 1, (n)-1 do
+		total = __add(total, i)
+		::__continue0::
+	end
+	return total
+end
+
+local n = 10
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = sum(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_sum_loop_20.lua.out
+++ b/bench/out/math_sum_loop_20.lua.out
@@ -1,0 +1,42 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function sum(n)
+	local total = 0
+	for i = 1, (n)-1 do
+		total = __add(total, i)
+		::__continue0::
+	end
+	return total
+end
+
+local n = 20
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = sum(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/bench/out/math_sum_loop_30.lua.out
+++ b/bench/out/math_sum_loop_30.lua.out
@@ -1,0 +1,42 @@
+function __add(a, b)
+    if type(a) == 'table' and type(b) == 'table' then
+        local out = {}
+        for i = 1, #a do out[#out+1] = a[i] end
+        for i = 1, #b do out[#out+1] = b[i] end
+        return out
+    elseif type(a) == 'string' or type(b) == 'string' then
+        return tostring(a) .. tostring(b)
+    else
+        return a + b
+    end
+end
+function __div(a, b)
+    if math.type and math.type(a) == 'integer' and math.type(b) == 'integer' then
+        return a // b
+    end
+    return a / b
+end
+function __json(v)
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    print(json.encode(v))
+end
+function sum(n)
+	local total = 0
+	for i = 1, (n)-1 do
+		total = __add(total, i)
+		::__continue0::
+	end
+	return total
+end
+
+local n = 30
+local _repeat = 1000
+local last = 0
+local start = os.time()*1000000000
+for i = 0, (_repeat)-1 do
+	last = sum(n)
+	::__continue1::
+end
+local duration = __div(((os.time()*1000000000 - start)), 1000)
+__json({["duration_us"]=duration, ["output"]=last})

--- a/compile/x/lua/tools.go
+++ b/compile/x/lua/tools.go
@@ -24,11 +24,11 @@ func EnsureLua() error {
 				return err
 			}
 			// try to install lua5.4, fallback to lua5.3
-			cmd = exec.Command("apt-get", "install", "-y", "lua5.4")
+			cmd = exec.Command("apt-get", "install", "-y", "lua5.4", "lua-json")
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {
-				cmd = exec.Command("apt-get", "install", "-y", "lua5.3")
+				cmd = exec.Command("apt-get", "install", "-y", "lua5.3", "lua-json")
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				_ = cmd.Run()
@@ -61,4 +61,54 @@ func EnsureLua() error {
 		return nil
 	}
 	return fmt.Errorf("lua not found")
+}
+
+// EnsureLuaJIT verifies that the LuaJIT interpreter is installed. If missing,
+// it attempts a best-effort installation on Linux or macOS.
+func EnsureLuaJIT() error {
+	if _, err := exec.LookPath("luajit"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("🔧 Installing LuaJIT...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "luajit", "lua-json")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("🍺 Installing LuaJIT via Homebrew...")
+			cmd := exec.Command("brew", "install", "luajit")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🔧 Installing LuaJIT via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "luajit")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🔧 Installing LuaJIT via Scoop...")
+			cmd := exec.Command("scoop", "install", "luajit")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("luajit"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("luajit not found")
 }


### PR DESCRIPTION
## Summary
- support Lua and LuaJIT benchmarks
- install LuaJIT with Lua libraries
- generate Lua benchmark outputs
- rerun benchmark results

## Testing
- `go test ./...` *(fails: mochi/runtime/vm/cmd/interpreter_golden)*
- `go run ./cmd/mochi-bench`

------
https://chatgpt.com/codex/tasks/task_e_685a2b75453c8320b5e22ca99df793c4