### PR TITLE
Add v0.9.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 # 📦 CHANGELOG.md
+## [0.9.2] – 2025-06-25
+
+### Added
+
+* Specialized numeric bytecode with CFG-based register inference
+* Dynamic map literals, membership and iteration
+* Builtins `append`, `str`, `input`, `count`, `avg` with extended `len`
+* Partial application, tail call optimization, unary negation
+* Nested index assignment and list set operations
+* Error stack traces from the VM
+* `vmreport` command and VM test runner
+* Nested functions in C and exported functions in Zig
+* Functions and lambdas in the PL backend
+* Scala infers function expression types
+
+### Changed
+
+* VM enforces variable declaration on assignment
+* Benchmarks updated without PyPy or Cython
+
+### Fixed
+
+* Ruby lambda helpers propagate correctly
+
 ## [0.9.1] – 2025-06-24
 
 ### Added

--- a/releases/v0.9.2.md
+++ b/releases/v0.9.2.md
@@ -1,0 +1,27 @@
+# Jun 2025 (v0.9.2)
+
+Mochi v0.9.2 delivers major VM upgrades with new builtins and optimizations alongside broader compiler support. Debugging tools and tests have also been enhanced.
+
+## Runtime
+
+- Specialized numeric bytecode with CFG-based register inference
+- Dynamic map literals, membership checks and iteration
+- Builtins `append`, `str`, `input`, `count`, `avg` and an extended `len`
+- Partial application, tail call optimization and unary negation
+- Nested index assignment and list set operations
+- Error stack traces from the VM
+- Variable declarations enforced on assignment
+
+## Compilers
+
+- Nested function support in the C backend
+- Exported functions in the Zig backend
+- Functions and lambdas in the PL backend
+- Scala infers function expression types
+
+## Tooling
+
+- `vmreport` command for VM analysis
+- Interpreter golden tests run via the VM
+- Benchmarks updated without PyPy or Cython
+- Ruby lambda helpers propagate correctly


### PR DESCRIPTION
## Summary
- add CHANGELOG entry for v0.9.2
- add release note file for v0.9.2

## Testing
- `go test ./...` *(fails: non-constant format string in interpreter_golden)*

------
https://chatgpt.com/codex/tasks/task_e_685a3fb28308832087b124568dcbc637