### PR TITLE
Fix interpreter_golden go vet error

### DIFF
--- a/runtime/vm/cmd/interpreter_golden/main.go
+++ b/runtime/vm/cmd/interpreter_golden/main.go
@@ -41,7 +41,7 @@ func run(src string) error {
         if len(lines) > 10 {
             msg = strings.Join(lines[:10], "\n") + "\n..."
         }
-        return fmt.Errorf(msg)
+        return fmt.Errorf("%s", msg)
     }
     want, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".out")
     if err != nil {


### PR DESCRIPTION
## Summary
- fix non-constant format string in `interpreter_golden`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a42cb75608320af5fa7b86f01e3b2