### PR TITLE
Improve VM closures

### DIFF
--- a/runtime/vm/ERRORS.md
+++ b/runtime/vm/ERRORS.md
@@ -4,108 +4,44 @@
 
 ```
 runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc020680598 stack=[0xc020680000, 0xc040680000]
+runtime: sp=0xc021700bd0 stack=[0xc021700000, 0xc041700000]
 fatal error: stack overflow
 
 runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f95cdafa288 sp=0x7f95cdafa258 pc=0x72e7e8
+runtime.throw({0x241927f?, 0x6eb6dc?})
+	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f0ef91fa288 sp=0x7f0ef91fa258 pc=0x72eca8
 runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f95cdafa3c0 sp=0x7f95cdafa288 pc=0x714d7b
+	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f0ef91fa3c0 sp=0x7f0ef91fa288 pc=0x71517b
 runtime.morestack()
-...
-```
-
-## tests/interpreter/valid/cast_struct.mochi
-
-```
-golden mismatch:
--- got --
-<nil>
--- want --
-hi
-```
-
-## tests/interpreter/valid/closure.mochi
-
-```
-panic: runtime error: index out of range [10] with length 3
-
-goroutine 1 [running]:
-mochi/runtime/vm.(*VM).call(0xc000253e40?, 0x2?, {0xc000432a80?, 0xc000253ac8?, 0x73097e?})
-	/workspace/mochi/runtime/vm/vm.go:278 +0x3b9f
-mochi/runtime/vm.(*VM).call(0xc000253e40, 0x1f?, {0x0, 0xc000402800?, 0xc0004027e0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).Run(...)
-	/workspace/mochi/runtime/vm/vm.go:267
-main.main()
 ...
 ```
 
 ## tests/interpreter/valid/cross_join.mochi
 
 ```
-golden mismatch:
--- got --
---- Cross Join: All order-customer pairs ---
--- want --
---- Cross Join: All order-customer pairs ---
-Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
-Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
-Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
-Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
-Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
-Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
-Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
-Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
-Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie
+run error: invalid map key
+exit status 1
 ```
 
 ## tests/interpreter/valid/cross_join_triple.mochi
 
 ```
-golden mismatch:
--- got --
---- Cross Join of three lists ---
--- want --
---- Cross Join of three lists ---
-1 A true
-1 A false
-1 B true
-1 B false
-2 A true
-2 A false
-2 B true
-2 B false
+run error: invalid iterator
+exit status 1
 ```
 
 ## tests/interpreter/valid/datalog.mochi
 
 ```
-golden mismatch:
--- got --
-Grandparents:
-Siblings:
--- want --
-Grandparents:
-Alice is grandparent of David
-Alice is grandparent of Eva
-Siblings:
-Bob <-> Carol
-Carol <-> Bob
+run error: invalid iterator
+exit status 1
 ```
 
 ## tests/interpreter/valid/dataset_sort_take_limit.mochi
 
 ```
-golden mismatch:
--- got --
---- Top products (excluding most expensive) ---
--- want --
---- Top products (excluding most expensive) ---
-Smartphone costs $ 900
-Tablet costs $ 600
-Monitor costs $ 300
+run error: invalid map key
+exit status 1
 ```
 
 ## tests/interpreter/valid/eval_builtin.mochi
@@ -131,11 +67,8 @@ echo hello
 ## tests/interpreter/valid/generate_embedding.mochi
 
 ```
-golden mismatch:
--- got --
-0
--- want --
-2
+run error: invalid len operand
+exit status 1
 ```
 
 ## tests/interpreter/valid/generate_model.mochi
@@ -163,80 +96,36 @@ hello
 ## tests/interpreter/valid/generate_struct.mochi
 
 ```
-golden mismatch:
--- got --
-<nil>
--- want --
-Alice
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/go_auto.mochi
 
 ```
-panic: runtime error: index out of range [2] with length 1
-
-goroutine 1 [running]:
-mochi/runtime/vm.(*VM).call(0x23bc6a0?, 0xc000418660?, {0xc0000b4f20?, 0x224a5a0?, 0x73?})
-	/workspace/mochi/runtime/vm/vm.go:278 +0x3b9f
-mochi/runtime/vm.(*VM).call(0xc000235e40, 0xc000235a78?, {0xc0000b4e70, 0xc000235ac8?, 0x73097e?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).call(0xc000235e40, 0x1f?, {0x0, 0xc0003e4840?, 0xc0003e4820?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).Run(...)
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/go_math.mochi
 
 ```
-runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc0456a4598 stack=[0xc0456a4000, 0xc0656a4000]
-fatal error: stack overflow
-
-runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7ffd749e1320 sp=0x7ffd749e12f0 pc=0x72e7e8
-runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7ffd749e1458 sp=0x7ffd749e1320 pc=0x714d7b
-runtime.morestack()
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/group_by.mochi
 
 ```
-golden mismatch:
--- got --
---- People grouped by city ---
--- want --
---- People grouped by city ---
-Paris : count = 3 , avg_age = 55
-Hanoi : count = 3 , avg_age = 27.333333333333332
-```
-
-## tests/interpreter/valid/in_operator.mochi
-
-```
-golden mismatch:
--- got --
-false
-false
--- want --
-true
-false
+run error: invalid map key
+exit status 1
 ```
 
 ## tests/interpreter/valid/inner_join.mochi
 
 ```
-golden mismatch:
--- got --
---- Orders with customer info ---
--- want --
---- Orders with customer info ---
-Order 100 by Alice - $ 250
-Order 101 by Bob - $ 125
-Order 102 by Alice - $ 300
+run error: invalid map key
+exit status 1
 ```
 
 ## tests/interpreter/valid/input_builtin.mochi
@@ -255,90 +144,43 @@ You entered: foo , bar
 ## tests/interpreter/valid/left_join.mochi
 
 ```
-golden mismatch:
--- got --
---- Left Join ---
--- want --
---- Left Join ---
-Order 100 customer map[id:1 name:Alice] total 250
-Order 101 customer <nil> total 80
+run error: invalid map key
+exit status 1
 ```
 
 ## tests/interpreter/valid/load_csv.mochi
 
 ```
-golden mismatch:
--- got --
-
--- want --
-Alice 30
-Charlie 20
+run error: invalid iterator
+exit status 1
 ```
 
 ## tests/interpreter/valid/load_jsonl.mochi
 
 ```
-golden mismatch:
--- got --
-
--- want --
-Alice alice@example.com
-Charlie charlie@example.com
+run error: invalid iterator
+exit status 1
 ```
 
 ## tests/interpreter/valid/load_yaml.mochi
 
 ```
-golden mismatch:
--- got --
-
--- want --
-Alice alice@example.com
-Charlie charlie@example.com
+run error: invalid iterator
+exit status 1
 ```
 
 ## tests/interpreter/valid/local_import.mochi
 
 ```
-runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc0204e0598 stack=[0xc0204e0000, 0xc0404e0000]
-fatal error: stack overflow
-
-runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f0bd4cbb288 sp=0x7f0bd4cbb258 pc=0x72e7e8
-runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f0bd4cbb3c0 sp=0x7f0bd4cbb288 pc=0x714d7b
-runtime.morestack()
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/main.mochi
 
 ```
-panic: runtime error: index out of range [1] with length 1
-
-goroutine 1 [running]:
-mochi/runtime/vm.(*VM).call(0x0?, 0x0?, {0xc0000b5340?, 0x4?, 0xc0004053e0?})
-	/workspace/mochi/runtime/vm/vm.go:278 +0x3b9f
-mochi/runtime/vm.(*VM).call(0xc000235e40, 0xa?, {0xc0000b5290, 0x0?, 0x0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).call(0xc000235e40, 0x1f?, {0x0, 0xc0003e4840?, 0xc0003e4820?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).Run(...)
-...
-```
-
-## tests/interpreter/valid/map_in_operator.mochi
-
-```
-golden mismatch:
--- got --
-false
-false
--- want --
-true
-false
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/match_expr.mochi
@@ -373,135 +215,65 @@ many
 
 ```
 runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc02050c598 stack=[0xc02050c000, 0xc04050c000]
+runtime: sp=0xc022480bd0 stack=[0xc022480000, 0xc042480000]
 fatal error: stack overflow
 
 runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f3bcf7fb288 sp=0x7f3bcf7fb258 pc=0x72e7e8
+runtime.throw({0x241927f?, 0x6eb6dc?})
+	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7ffc92eb4c30 sp=0x7ffc92eb4c00 pc=0x72eca8
 runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f3bcf7fb3c0 sp=0x7f3bcf7fb288 pc=0x714d7b
+	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7ffc92eb4d68 sp=0x7ffc92eb4c30 pc=0x71517b
 runtime.morestack()
 ...
-```
-
-## tests/interpreter/valid/nested_function.mochi
-
-```
-golden mismatch:
--- got --
-<nil>
--- want --
-8
 ```
 
 ## tests/interpreter/valid/outer_join.mochi
 
 ```
-golden mismatch:
--- got --
---- Outer Join using syntax ---
--- want --
---- Outer Join using syntax ---
-Order 100 by Alice - $ 250
-Order 101 by Bob - $ 125
-Order 102 by Alice - $ 300
-Order 103 by Unknown - $ 80
-Customer Charlie has no orders
-Customer Diana has no orders
+run error: invalid map key
+exit status 1
 ```
 
 ## tests/interpreter/valid/package_auto_alias.mochi
 
 ```
-panic: runtime error: index out of range [3] with length 1
-
-goroutine 1 [running]:
-mochi/runtime/vm.(*VM).call(0x0?, 0x0?, {0xc000145340?, 0x4?, 0xc000423350?})
-	/workspace/mochi/runtime/vm/vm.go:278 +0x3b9f
-mochi/runtime/vm.(*VM).call(0xc000253e40, 0xa?, {0xc000145290, 0x0?, 0x0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).call(0xc000253e40, 0x1f?, {0x0, 0xc000402800?, 0xc0004027e0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).Run(...)
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/package_example.mochi
 
 ```
-panic: runtime error: index out of range [3] with length 1
-
-goroutine 1 [running]:
-mochi/runtime/vm.(*VM).call(0x0?, 0x0?, {0xc000145340?, 0x4?, 0xc0004233b0?})
-	/workspace/mochi/runtime/vm/vm.go:278 +0x3b9f
-mochi/runtime/vm.(*VM).call(0xc000253e40, 0xa?, {0xc000145290, 0x0?, 0x0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).call(0xc000253e40, 0x1f?, {0x0, 0xc000402800?, 0xc0004027e0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).Run(...)
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/package_import.mochi
 
 ```
-panic: runtime error: index out of range [3] with length 1
-
-goroutine 1 [running]:
-mochi/runtime/vm.(*VM).call(0x0?, 0x0?, {0xc000145340?, 0x4?, 0xc0004233b0?})
-	/workspace/mochi/runtime/vm/vm.go:278 +0x3b9f
-mochi/runtime/vm.(*VM).call(0xc000253e40, 0xa?, {0xc000145290, 0x0?, 0x0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).call(0xc000253e40, 0x1f?, {0x0, 0xc000402800?, 0xc0004027e0?})
-	/workspace/mochi/runtime/vm/vm.go:471 +0x2d5d
-mochi/runtime/vm.(*VM).Run(...)
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/python_auto.mochi
 
 ```
-runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc020492598 stack=[0xc020492000, 0xc040492000]
-fatal error: stack overflow
-
-runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f8834cfa288 sp=0x7f8834cfa258 pc=0x72e7e8
-runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f8834cfa3c0 sp=0x7f8834cfa288 pc=0x714d7b
-runtime.morestack()
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/python_math.mochi
 
 ```
-runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc045780598 stack=[0xc045780000, 0xc065780000]
-fatal error: stack overflow
-
-runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7fa54628a288 sp=0x7fa54628a258 pc=0x72e7e8
-runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7fa54628a3c0 sp=0x7fa54628a288 pc=0x714d7b
-runtime.morestack()
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/right_join.mochi
 
 ```
-golden mismatch:
--- got --
---- Right Join using syntax ---
--- want --
---- Right Join using syntax ---
-Customer Alice has order 100 - $ 250
-Customer Bob has order 101 - $ 125
-Customer Alice has order 102 - $ 300
+run error: invalid map key
+exit status 1
 ```
 
 ## tests/interpreter/valid/shadow_scope.mochi
@@ -555,17 +327,8 @@ true
 ## tests/interpreter/valid/strings_basic.mochi
 
 ```
-runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc02066a598 stack=[0xc02066a000, 0xc04066a000]
-fatal error: stack overflow
-
-runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f1b42ffa288 sp=0x7f1b42ffa258 pc=0x72e7e8
-runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f1b42ffa3c0 sp=0x7f1b42ffa288 pc=0x714d7b
-runtime.morestack()
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/test_expect_pass.mochi
@@ -574,12 +337,12 @@ runtime.morestack()
 panic: runtime error: index out of range [0] with length 0
 
 goroutine 1 [running]:
-mochi/runtime/vm.(*VM).call(0xc000235e40, 0x1f?, {0x0, 0xc0003e4840?, 0xc0003e4820?})
-	/workspace/mochi/runtime/vm/vm.go:479 +0x383f
-mochi/runtime/vm.(*VM).Run(...)
-	/workspace/mochi/runtime/vm/vm.go:267
+mochi/runtime/vm.(*VM).call(0xc000253e38, 0x7f2a01ce4758?, {0x0, 0x23d60c0?, 0x0?}, {0xc000253db8, 0x1, 0x1})
+	/workspace/mochi/runtime/vm/vm.go:1031 +0xa7d4
+mochi/runtime/vm.(*VM).Run(0xc000253e38)
+	/workspace/mochi/runtime/vm/vm.go:463 +0xa5
 main.main()
-	/workspace/mochi/runtime/vm/cmd/runvm/main.go:37 +0x4ab
+	/workspace/mochi/runtime/vm/cmd/runvm/main.go:37 +0x56b
 exit status 2
 ```
 
@@ -596,42 +359,14 @@ golden mismatch:
 ## tests/interpreter/valid/ts_auto.mochi
 
 ```
-runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc02046a598 stack=[0xc02046a000, 0xc04046a000]
-fatal error: stack overflow
-
-runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f93fd5b6288 sp=0x7f93fd5b6258 pc=0x72e7e8
-runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f93fd5b63c0 sp=0x7f93fd5b6288 pc=0x714d7b
-runtime.morestack()
-...
+run error: invalid index target
+exit status 1
 ```
 
 ## tests/interpreter/valid/ts_math.mochi
 
 ```
-runtime: goroutine stack exceeds 1000000000-byte limit
-runtime: sp=0xc039580598 stack=[0xc039580000, 0xc059580000]
-fatal error: stack overflow
-
-runtime stack:
-runtime.throw({0x2305019?, 0x6eb63c?})
-	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0x7f80abffc288 sp=0x7f80abffc258 pc=0x72e7e8
-runtime.newstack()
-	/usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0x7f80abffc3c0 sp=0x7f80abffc288 pc=0x714d7b
-runtime.morestack()
-...
-```
-
-## tests/interpreter/valid/user_type_literal.mochi
-
-```
-golden mismatch:
--- got --
-<nil>
--- want --
-Bob
+run error: invalid index target
+exit status 1
 ```
 


### PR DESCRIPTION
## Summary
- add support for capturing variables in function literals
- allow nested function declarations in the VM compiler
- update interpreter VM error report

## Testing
- `go build ./runtime/vm/cmd/runvm`
- `go test ./...` *(fails: mochi/tests/vm)*

------
https://chatgpt.com/codex/tasks/task_e_685a433fef0c83208bd400c3e9101150