### PR TITLE
Improve VM string comparisons

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -627,9 +627,25 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 		case OpEqualFloat:
 			fr.regs[ins.A] = Value{Tag: interpreter.TagBool, Bool: toFloat(fr.regs[ins.B]) == toFloat(fr.regs[ins.C])}
 		case OpLess:
-			fr.regs[ins.A] = Value{Tag: interpreter.TagBool, Bool: toFloat(fr.regs[ins.B]) < toFloat(fr.regs[ins.C])}
+			b := fr.regs[ins.B]
+			c := fr.regs[ins.C]
+			var res bool
+			if b.Tag == interpreter.TagStr && c.Tag == interpreter.TagStr {
+				res = b.Str < c.Str
+			} else {
+				res = toFloat(b) < toFloat(c)
+			}
+			fr.regs[ins.A] = Value{Tag: interpreter.TagBool, Bool: res}
 		case OpLessEq:
-			fr.regs[ins.A] = Value{Tag: interpreter.TagBool, Bool: toFloat(fr.regs[ins.B]) <= toFloat(fr.regs[ins.C])}
+			b := fr.regs[ins.B]
+			c := fr.regs[ins.C]
+			var res bool
+			if b.Tag == interpreter.TagStr && c.Tag == interpreter.TagStr {
+				res = b.Str <= c.Str
+			} else {
+				res = toFloat(b) <= toFloat(c)
+			}
+			fr.regs[ins.A] = Value{Tag: interpreter.TagBool, Bool: res}
 		case OpLessInt:
 			fr.regs[ins.A] = Value{Tag: interpreter.TagBool, Bool: fr.regs[ins.B].Int < fr.regs[ins.C].Int}
 		case OpLessFloat:

--- a/tests/vm/valid/string_compare.ir.out
+++ b/tests/vm/valid/string_compare.ir.out
@@ -1,0 +1,22 @@
+func main (regs=12)
+  // print("a" < "b")
+  Const        r0, "a"
+  Const        r1, "b"
+  Less         r2, r0, r1
+  Print        r2
+  // print("a" <= "a")
+  Const        r3, "a"
+  Const        r4, "a"
+  LessEq       r5, r3, r4
+  Print        r5
+  // print("b" > "a")
+  Const        r6, "b"
+  Const        r7, "a"
+  Less         r8, r7, r6
+  Print        r8
+  // print("b" >= "b")
+  Const        r9, "b"
+  Const        r10, "b"
+  LessEq       r11, r10, r9
+  Print        r11
+  Return       r0

--- a/tests/vm/valid/string_compare.mochi
+++ b/tests/vm/valid/string_compare.mochi
@@ -1,0 +1,4 @@
+print("a" < "b")
+print("a" <= "a")
+print("b" > "a")
+print("b" >= "b")

--- a/tests/vm/valid/string_compare.out
+++ b/tests/vm/valid/string_compare.out
@@ -1,0 +1,4 @@
+true
+true
+true
+true


### PR DESCRIPTION
## Summary
- support lexicographic string comparison in runtime/vm
- add golden test for string comparison

## Testing
- `go test ./runtime/vm ./tests/vm -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685a451e9560832091ef25df1e3e55f6