### PR TITLE
Add multi-arg print support to VM

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -130,7 +130,7 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagBool
 	case OpLen, OpNow:
 		tags[ins.A] = TagInt
-	case OpJSON, OpPrint, OpPrint2:
+	case OpJSON, OpPrint, OpPrint2, OpPrintN:
 		// no result
 	case OpInput, OpMakeList, OpIndex, OpSetIndex, OpCall, OpCall2, OpCallV,
 		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpMakeClosure:


### PR DESCRIPTION
## Summary
- extend vm instruction set with `OpPrintN`
- compile `print(...)` with more than two arguments to new opcode
- implement runtime execution and disassembly for `OpPrintN`
- update type inference for new opcode

## Testing
- `go test ./runtime/vm -run TestInfer_TagPropagation -count=1`
- `go test ./tests/vm -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685a482b34f4832080a0aaff4861f9b7