### PR TITLE
Improve VM runner path handling

### DIFF
--- a/runtime/vm/cmd/runvm/main.go
+++ b/runtime/vm/cmd/runvm/main.go
@@ -18,12 +18,11 @@ func main() {
 		os.Exit(1)
 	}
 	src := os.Args[1]
-	if dir := filepath.Dir(src); dir != "." {
-		if err := os.Chdir(dir); err != nil {
-			fmt.Fprintln(os.Stderr, "chdir error:", err)
-			os.Exit(1)
+	if !filepath.IsAbs(src) {
+		abs, err := filepath.Abs(src)
+		if err == nil {
+			src = abs
 		}
-		src = filepath.Base(src)
 	}
 	prog, err := parser.Parse(src)
 	if err != nil {


### PR DESCRIPTION
## Summary
- remove chdir logic in `runvm` command
- ensure test cases in `tests/vm` still pass

## Testing
- `go test ./tests/vm -run .`
- `go test ./runtime/vm -run .`


------
https://chatgpt.com/codex/tasks/task_e_685a61b1c2288320a850c48d1d2a7661