### PR TITLE
Add list op type inference for C# backend

### DIFF
--- a/compile/x/cs/infer.go
+++ b/compile/x/cs/infer.go
@@ -97,6 +97,18 @@ func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
 			default:
 				t = types.AnyType{}
 			}
+		case "union", "union_all", "except", "intersect":
+			if llist, ok := t.(types.ListType); ok {
+				if rlist, ok := rt.(types.ListType); ok {
+					elem := llist.Elem
+					if !equalTypes(elem, rlist.Elem) {
+						elem = types.AnyType{}
+					}
+					t = types.ListType{Elem: elem}
+					continue
+				}
+			}
+			t = types.AnyType{}
 		default:
 			t = types.AnyType{}
 		}


### PR DESCRIPTION
## Summary
- support `union`, `union all`, `except` and `intersect` in C# type inference

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a69d0fd9c83208f4c2cec80e92479