### PR TITLE
Add union all support in F# compiler

### DIFF
--- a/compile/x/fs/compiler.go
+++ b/compile/x/fs/compiler.go
@@ -1009,7 +1009,11 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 		lists = append(lists, c.isListPostfix(part.Right))
 		maps = append(maps, c.isMapPostfix(part.Right))
 		strs = append(strs, c.isStringPostfix(part.Right))
-		ops = append(ops, part.Op)
+		op := part.Op
+		if part.Op == "union" && part.All {
+			op = "union_all"
+		}
+		ops = append(ops, op)
 	}
 
 	levels := [][]string{


### PR DESCRIPTION
## Summary
- enable `union all` handling in the F# backend by checking `BinaryOp.All`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a69e07fd083208aaeec9792b06f65