### PR TITLE
Implement list membership in Java backend

### DIFF
--- a/compile/x/java/compiler.go
+++ b/compile/x/java/compiler.go
@@ -418,6 +418,37 @@ func (c *Compiler) emitRuntime() {
 		c.indent--
 		c.writeln("}")
 	}
+	if c.helpers["_in"] {
+		c.writeln("")
+		c.writeln("static boolean _in(Object item, Object col) {")
+		c.indent++
+		c.writeln("if (col instanceof String s && item instanceof String sub) return s.contains(sub);")
+		c.writeln("if (col instanceof java.util.Map<?,?> m) return m.containsKey(item);")
+		c.writeln("if (col != null && col.getClass().isArray()) {")
+		c.indent++
+		c.writeln("int n = java.lang.reflect.Array.getLength(col);")
+		c.writeln("for (int i = 0; i < n; i++) {")
+		c.indent++
+		c.writeln("if (java.util.Objects.equals(java.lang.reflect.Array.get(col, i), item)) return true;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("return false;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("if (col instanceof Iterable<?> it) {")
+		c.indent++
+		c.writeln("for (Object v : it) {")
+		c.indent++
+		c.writeln("if (java.util.Objects.equals(v, item)) return true;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("return false;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("return false;")
+		c.indent--
+		c.writeln("}")
+	}
 	if c.helpers["_slice"] {
 		c.writeln("")
 		c.writeln("static int[] _slice(int[] arr, int i, int j) {")

--- a/compile/x/java/expressions.go
+++ b/compile/x/java/expressions.go
@@ -96,7 +96,8 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 				expr = fmt.Sprintf("_intersect(%s, %s)", l, r)
 				isList = true
 			case "in":
-				expr = fmt.Sprintf("%s.containsKey(%s)", r, l)
+				c.helpers["_in"] = true
+				expr = fmt.Sprintf("_in(%s, %s)", l, r)
 			default:
 				expr = fmt.Sprintf("(%s %s %s)", l, op, r)
 			}


### PR DESCRIPTION
## Summary
- update Java compiler binary `in` operator to call helper
- add `_in` runtime helper for membership checks in arrays, strings and maps

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a6ba04de483209c6ff33643bb9f8f