### PR TITLE
Enable union all for Kotlin compiler

### DIFF
--- a/compile/x/kt/compiler.go
+++ b/compile/x/kt/compiler.go
@@ -1082,7 +1082,11 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		ops = append(ops, part.Op)
+		op := part.Op
+		if part.Op == "union" && part.All {
+			op = "union_all"
+		}
+		ops = append(ops, op)
 		operands = append(operands, rhs)
 	}
 


### PR DESCRIPTION
## Summary
- support `union all` parsing in Kotlin backend by translating the `BinaryOp.All` flag

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a6ba9def08320b19ba3ab4ff5822c