### PR TITLE
Improve Zig inference for list operators

### DIFF
--- a/compile/x/zig/infer.go
+++ b/compile/x/zig/infer.go
@@ -50,6 +50,33 @@ func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
 			t = types.AnyType{}
 		case "==", "!=", "<", "<=", ">", ">=":
 			t = types.BoolType{}
+		case "&&", "||":
+			if isBool(t) && isBool(rt) {
+				t = types.BoolType{}
+			} else {
+				t = types.AnyType{}
+			}
+		case "in":
+			switch rt.(type) {
+			case types.MapType, types.ListType, types.StringType:
+				t = types.BoolType{}
+			default:
+				t = types.AnyType{}
+			}
+		case "union", "union_all", "except", "intersect":
+			if llist, ok := t.(types.ListType); ok {
+				if rlist, ok := rt.(types.ListType); ok {
+					if equalTypes(llist.Elem, rlist.Elem) {
+						t = llist
+					} else {
+						t = types.ListType{Elem: types.AnyType{}}
+					}
+				} else {
+					t = types.ListType{Elem: types.AnyType{}}
+				}
+			} else {
+				t = types.AnyType{}
+			}
 		default:
 			t = types.AnyType{}
 		}


### PR DESCRIPTION
## Summary
- handle all list operators in Zig type inference

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a6bb80fa4832088143aa6fe8d0993