### PR TITLE
Add VM support for query map keys

### DIFF
--- a/tests/vm/valid/cross_join.ir.out
+++ b/tests/vm/valid/cross_join.ir.out
@@ -1,0 +1,117 @@
+func main (regs=73)
+  // let customers = [
+  Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
+  Move         r1, r0
+  // let orders = [
+  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}]
+  Move         r3, r2
+  // let result = from o in orders
+  Const        r4, []
+  IterPrep     r5, r3
+  Len          r6, r5
+  Const        r7, 0
+L3:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r9, r5, r7
+  Move         r10, r9
+  // from c in customers
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L2:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r15, r11, r13
+  Move         r16, r15
+  // orderId: o.id,
+  Const        r17, "orderId"
+  Const        r18, "id"
+  Index        r19, r10, r18
+  // orderCustomerId: o.customerId,
+  Const        r20, "orderCustomerId"
+  Const        r21, "customerId"
+  Index        r22, r10, r21
+  // pairedCustomerName: c.name,
+  Const        r23, "pairedCustomerName"
+  Const        r24, "name"
+  Index        r25, r16, r24
+  // orderTotal: o.total
+  Const        r26, "orderTotal"
+  Const        r27, "total"
+  Index        r28, r10, r27
+  // orderId: o.id,
+  Move         r29, r17
+  Move         r30, r19
+  // orderCustomerId: o.customerId,
+  Move         r31, r20
+  Move         r32, r22
+  // pairedCustomerName: c.name,
+  Move         r33, r23
+  Move         r34, r25
+  // orderTotal: o.total
+  Move         r35, r26
+  Move         r36, r28
+  // select {
+  MakeMap      r37, 4, r29
+  // let result = from o in orders
+  Append       r38, r4, r37
+  Move         r4, r38
+  // from c in customers
+  Const        r39, 1
+  Add          r40, r13, r39
+  Move         r13, r40
+  Jump         L2
+L1:
+  // let result = from o in orders
+  Const        r41, 1
+  Add          r42, r7, r41
+  Move         r7, r42
+  Jump         L3
+L0:
+  Move         r43, r4
+  // print("--- Cross Join: All order-customer pairs ---")
+  Const        r44, "--- Cross Join: All order-customer pairs ---"
+  Print        r44
+  // for entry in result {
+  IterPrep     r45, r43
+  Len          r46, r45
+  Const        r47, 0
+L5:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L4
+  Index        r49, r45, r47
+  Move         r50, r49
+  // print("Order", entry.orderId,
+  Const        r59, "Order"
+  Move         r51, r59
+  Const        r60, "orderId"
+  Index        r61, r50, r60
+  Move         r52, r61
+  // "(customerId:", entry.orderCustomerId,
+  Const        r62, "(customerId:"
+  Move         r53, r62
+  Const        r63, "orderCustomerId"
+  Index        r64, r50, r63
+  Move         r54, r64
+  // ", total: $", entry.orderTotal,
+  Const        r65, ", total: $"
+  Move         r55, r65
+  Const        r66, "orderTotal"
+  Index        r67, r50, r66
+  Move         r56, r67
+  // ") paired with", entry.pairedCustomerName)
+  Const        r68, ") paired with"
+  Move         r57, r68
+  Const        r69, "pairedCustomerName"
+  Index        r70, r50, r69
+  Move         r58, r70
+  // print("Order", entry.orderId,
+  PrintN       r51, 8, r51
+  // for entry in result {
+  Const        r71, 1
+  Add          r72, r47, r71
+  Move         r47, r72
+  Jump         L5
+L4:
+  Return       r0

--- a/tests/vm/valid/cross_join.mochi
+++ b/tests/vm/valid/cross_join.mochi
@@ -1,0 +1,26 @@
+// cross_join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 }
+]
+let result = from o in orders
+             from c in customers
+             select {
+               orderId: o.id,
+               orderCustomerId: o.customerId,
+               pairedCustomerName: c.name,
+               orderTotal: o.total
+             }
+print("--- Cross Join: All order-customer pairs ---")
+for entry in result {
+  print("Order", entry.orderId,
+        "(customerId:", entry.orderCustomerId,
+        ", total: $", entry.orderTotal,
+        ") paired with", entry.pairedCustomerName)
+}

--- a/tests/vm/valid/cross_join.out
+++ b/tests/vm/valid/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/tests/vm/valid/cross_join_triple.ir.out
+++ b/tests/vm/valid/cross_join_triple.ir.out
@@ -1,0 +1,101 @@
+func main (regs=61)
+  // let nums = [1, 2]
+  Const        r0, [1, 2]
+  Move         r1, r0
+  // let letters = ["A", "B"]
+  Const        r2, ["A", "B"]
+  Move         r3, r2
+  // let bools = [true, false]
+  Const        r4, [true, false]
+  Move         r5, r4
+  // let combos = from n in nums
+  Const        r6, []
+  IterPrep     r7, r1
+  Len          r8, r7
+  Const        r9, 0
+L5:
+  Less         r10, r9, r8
+  JumpIfFalse  r10, L0
+  Index        r11, r7, r9
+  Move         r12, r11
+  // from l in letters
+  IterPrep     r13, r3
+  Len          r14, r13
+  Const        r15, 0
+L4:
+  Less         r16, r15, r14
+  JumpIfFalse  r16, L1
+  Index        r17, r13, r15
+  Move         r18, r17
+  // from b in bools
+  IterPrep     r19, r5
+  Len          r20, r19
+  Const        r21, 0
+L3:
+  Less         r22, r21, r20
+  JumpIfFalse  r22, L2
+  Index        r23, r19, r21
+  Move         r24, r23
+  // select {n: n, l: l, b: b}
+  Const        r25, "n"
+  Const        r26, "l"
+  Const        r27, "b"
+  Move         r28, r25
+  Move         r29, r12
+  Move         r30, r26
+  Move         r31, r18
+  Move         r32, r27
+  Move         r33, r24
+  MakeMap      r34, 3, r28
+  // let combos = from n in nums
+  Append       r35, r6, r34
+  Move         r6, r35
+  // from b in bools
+  Const        r36, 1
+  Add          r37, r21, r36
+  Move         r21, r37
+  Jump         L3
+L2:
+  // from l in letters
+  Const        r38, 1
+  Add          r39, r15, r38
+  Move         r15, r39
+  Jump         L4
+L1:
+  // let combos = from n in nums
+  Const        r40, 1
+  Add          r41, r9, r40
+  Move         r9, r41
+  Jump         L5
+L0:
+  Move         r42, r6
+  // print("--- Cross Join of three lists ---")
+  Const        r43, "--- Cross Join of three lists ---"
+  Print        r43
+  // for c in combos {
+  IterPrep     r44, r42
+  Len          r45, r44
+  Const        r46, 0
+L7:
+  Less         r47, r46, r45
+  JumpIfFalse  r47, L6
+  Index        r48, r44, r46
+  Move         r49, r48
+  // print(c.n, c.l, c.b)
+  Const        r53, "n"
+  Index        r54, r49, r53
+  Move         r50, r54
+  Const        r55, "l"
+  Index        r56, r49, r55
+  Move         r51, r56
+  Const        r57, "b"
+  Index        r58, r49, r57
+  Move         r52, r58
+  PrintN       r50, 3, r50
+  // for c in combos {
+  Const        r59, 1
+  Add          r60, r46, r59
+  Move         r46, r60
+  Jump         L7
+L6:
+  Return       r0

--- a/tests/vm/valid/cross_join_triple.mochi
+++ b/tests/vm/valid/cross_join_triple.mochi
@@ -1,0 +1,11 @@
+let nums = [1, 2]
+let letters = ["A", "B"]
+let bools = [true, false]
+let combos = from n in nums
+             from l in letters
+             from b in bools
+             select {n: n, l: l, b: b}
+print("--- Cross Join of three lists ---")
+for c in combos {
+  print(c.n, c.l, c.b)
+}

--- a/tests/vm/valid/cross_join_triple.out
+++ b/tests/vm/valid/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false


### PR DESCRIPTION
## Summary
- support identifier keys in map literals when compiling VM
- update const evaluation for map keys
- add VM golden tests for dataset queries `cross_join` and `cross_join_triple`

## Testing
- `go test ./tests/vm -run TestVM_ValidPrograms/cross_join`
- `go test ./tests/vm -run TestVM_ValidPrograms/cross_join_triple`
- `go test ./tests/vm -run TestVM_ValidPrograms -count=1`
- `go test ./tests/vm -run TestVM_IR -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685a81b5abd88320b57d0fe5245ef763