### PR TITLE
Add inner and left join support to VM

### DIFF
--- a/tests/vm/valid/inner_join.ir.out
+++ b/tests/vm/valid/inner_join.ir.out
@@ -1,0 +1,102 @@
+func main (regs=68)
+  // let customers = [
+  Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
+  Move         r1, r0
+  // let orders = [
+  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}, {"customerId": 4, "id": 103, "total": 80}]
+  Move         r3, r2
+  // let result = from o in orders
+  Const        r4, []
+  IterPrep     r5, r3
+  Len          r6, r5
+  Const        r7, 0
+L4:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r9, r5, r7
+  Move         r10, r9
+  // join from c in customers on o.customerId == c.id
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L3:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r15, r11, r13
+  Move         r16, r15
+  Const        r17, "customerId"
+  Index        r18, r10, r17
+  Const        r19, "id"
+  Index        r20, r16, r19
+  Equal        r21, r18, r20
+  JumpIfFalse  r21, L2
+  // select { orderId: o.id, customerName: c.name, total: o.total }
+  Const        r22, "orderId"
+  Const        r23, "id"
+  Index        r24, r10, r23
+  Const        r25, "customerName"
+  Const        r26, "name"
+  Index        r27, r16, r26
+  Const        r28, "total"
+  Const        r29, "total"
+  Index        r30, r10, r29
+  Move         r31, r22
+  Move         r32, r24
+  Move         r33, r25
+  Move         r34, r27
+  Move         r35, r28
+  Move         r36, r30
+  MakeMap      r37, 3, r31
+  // let result = from o in orders
+  Append       r38, r4, r37
+  Move         r4, r38
+L2:
+  // join from c in customers on o.customerId == c.id
+  Const        r39, 1
+  Add          r40, r13, r39
+  Move         r13, r40
+  Jump         L3
+L1:
+  // let result = from o in orders
+  Const        r41, 1
+  Add          r42, r7, r41
+  Move         r7, r42
+  Jump         L4
+L0:
+  Move         r43, r4
+  // print("--- Orders with customer info ---")
+  Const        r44, "--- Orders with customer info ---"
+  Print        r44
+  // for entry in result {
+  IterPrep     r45, r43
+  Len          r46, r45
+  Const        r47, 0
+L6:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L5
+  Index        r49, r45, r47
+  Move         r50, r49
+  // print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+  Const        r57, "Order"
+  Move         r51, r57
+  Const        r58, "orderId"
+  Index        r59, r50, r58
+  Move         r52, r59
+  Const        r60, "by"
+  Move         r53, r60
+  Const        r61, "customerName"
+  Index        r62, r50, r61
+  Move         r54, r62
+  Const        r63, "- $"
+  Move         r55, r63
+  Const        r64, "total"
+  Index        r65, r50, r64
+  Move         r56, r65
+  PrintN       r51, 6, r51
+  // for entry in result {
+  Const        r66, 1
+  Add          r67, r47, r66
+  Move         r47, r67
+  Jump         L6
+L5:
+  Return       r0

--- a/tests/vm/valid/inner_join.mochi
+++ b/tests/vm/valid/inner_join.mochi
@@ -1,0 +1,19 @@
+// inner_join.mochi
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Charlie" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 2, total: 125 },
+  { id: 102, customerId: 1, total: 300 },
+  { id: 103, customerId: 4, total: 80 }
+]
+let result = from o in orders
+             join from c in customers on o.customerId == c.id
+             select { orderId: o.id, customerName: c.name, total: o.total }
+print("--- Orders with customer info ---")
+for entry in result {
+  print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+}

--- a/tests/vm/valid/inner_join.out
+++ b/tests/vm/valid/inner_join.out
@@ -1,0 +1,4 @@
+--- Orders with customer info ---
+Order 100 by Alice - $ 250
+Order 101 by Bob - $ 125
+Order 102 by Alice - $ 300

--- a/tests/vm/valid/left_join.ir.out
+++ b/tests/vm/valid/left_join.ir.out
@@ -1,0 +1,135 @@
+func main (regs=83)
+  // let customers = [
+  Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+  Move         r1, r0
+  // let orders = [
+  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 3, "id": 101, "total": 80}]
+  Move         r3, r2
+  // let result = from o in orders
+  Const        r4, []
+  IterPrep     r5, r3
+  Len          r6, r5
+  Const        r7, 0
+L5:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r9, r5, r7
+  Move         r10, r9
+  // left join c in customers on o.customerId == c.id
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+  Const        r14, false
+L3:
+  Less         r15, r13, r12
+  JumpIfFalse  r15, L1
+  Index        r16, r11, r13
+  Move         r17, r16
+  Const        r18, "customerId"
+  Index        r19, r10, r18
+  Const        r20, "id"
+  Index        r21, r17, r20
+  Equal        r22, r19, r21
+  JumpIfFalse  r22, L2
+  Const        r14, true
+  // orderId: o.id,
+  Const        r23, "orderId"
+  Const        r24, "id"
+  Index        r25, r10, r24
+  // customer: c,
+  Const        r26, "customer"
+  // total: o.total
+  Const        r27, "total"
+  Const        r28, "total"
+  Index        r29, r10, r28
+  // orderId: o.id,
+  Move         r30, r23
+  Move         r31, r25
+  // customer: c,
+  Move         r32, r26
+  Move         r33, r17
+  // total: o.total
+  Move         r34, r27
+  Move         r35, r29
+  // select {
+  MakeMap      r36, 3, r30
+  // let result = from o in orders
+  Append       r37, r4, r36
+  Move         r4, r37
+L2:
+  // left join c in customers on o.customerId == c.id
+  Const        r38, 1
+  Add          r39, r13, r38
+  Move         r13, r39
+  Jump         L3
+L1:
+  JumpIfTrue   r14, L4
+  Const        r40, nil
+  Move         r17, r40
+  // orderId: o.id,
+  Const        r41, "orderId"
+  Const        r42, "id"
+  Index        r43, r10, r42
+  // customer: c,
+  Const        r44, "customer"
+  // total: o.total
+  Const        r45, "total"
+  Const        r46, "total"
+  Index        r47, r10, r46
+  // orderId: o.id,
+  Move         r48, r41
+  Move         r49, r43
+  // customer: c,
+  Move         r50, r44
+  Move         r51, r17
+  // total: o.total
+  Move         r52, r45
+  Move         r53, r47
+  // select {
+  MakeMap      r54, 3, r48
+  // let result = from o in orders
+  Append       r55, r4, r54
+  Move         r4, r55
+L4:
+  Const        r56, 1
+  Add          r57, r7, r56
+  Move         r7, r57
+  Jump         L5
+L0:
+  Move         r58, r4
+  // print("--- Left Join ---")
+  Const        r59, "--- Left Join ---"
+  Print        r59
+  // for entry in result {
+  IterPrep     r60, r58
+  Len          r61, r60
+  Const        r62, 0
+L7:
+  Less         r63, r62, r61
+  JumpIfFalse  r63, L6
+  Index        r64, r60, r62
+  Move         r65, r64
+  // print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+  Const        r72, "Order"
+  Move         r66, r72
+  Const        r73, "orderId"
+  Index        r74, r65, r73
+  Move         r67, r74
+  Const        r75, "customer"
+  Move         r68, r75
+  Const        r76, "customer"
+  Index        r77, r65, r76
+  Move         r69, r77
+  Const        r78, "total"
+  Move         r70, r78
+  Const        r79, "total"
+  Index        r80, r65, r79
+  Move         r71, r80
+  PrintN       r66, 6, r66
+  // for entry in result {
+  Const        r81, 1
+  Add          r82, r62, r81
+  Move         r62, r82
+  Jump         L7
+L6:
+  Return       r0

--- a/tests/vm/valid/left_join.mochi
+++ b/tests/vm/valid/left_join.mochi
@@ -1,0 +1,19 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+let orders = [
+  { id: 100, customerId: 1, total: 250 },
+  { id: 101, customerId: 3, total: 80 }
+]
+let result = from o in orders
+             left join c in customers on o.customerId == c.id
+             select {
+               orderId: o.id,
+               customer: c,
+               total: o.total
+             }
+print("--- Left Join ---")
+for entry in result {
+  print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+}

--- a/tests/vm/valid/left_join.out
+++ b/tests/vm/valid/left_join.out
@@ -1,0 +1,3 @@
+--- Left Join ---
+Order 100 customer map[id:1 name:Alice] total 250
+Order 101 customer <nil> total 80


### PR DESCRIPTION
## Summary
- extend `runtime/vm` query compilation logic to handle inner joins with `on` conditions and left joins
- add golden tests for inner and left joins under `tests/vm`

## Testing
- `go test ./tests/vm`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a8889127083209b3fbac72e2a7e3a