### PR TITLE
Add left join support for multi joins

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2386,129 +2386,169 @@ func (fc *funcCompiler) compileFor(f *parser.ForStmt) error {
 // optional WHERE filtering and SELECT projection. Only cross joins are
 // handled and results are accumulated into a list.
 func (fc *funcCompiler) compileQuery(q *parser.QueryExpr) int {
-        dst := fc.newReg()
-        fc.emit(q.Pos, Instr{Op: OpConst, A: dst, Val: Value{Tag: interpreter.TagList, List: []Value{}}})
-        switch {
-        case len(q.Joins) == 1 && len(q.Froms) == 0:
-                fc.compileJoinQuery(q, dst)
-        case len(q.Joins) == 0:
-                fc.compileQueryFrom(q, dst, 0)
-        default:
-                fc.compileQueryFull(q, dst, 0)
-        }
-        return dst
+	dst := fc.newReg()
+	fc.emit(q.Pos, Instr{Op: OpConst, A: dst, Val: Value{Tag: interpreter.TagList, List: []Value{}}})
+	switch {
+	case len(q.Joins) == 1 && len(q.Froms) == 0:
+		fc.compileJoinQuery(q, dst)
+	case len(q.Joins) == 0:
+		fc.compileQueryFrom(q, dst, 0)
+	default:
+		fc.compileQueryFull(q, dst, 0)
+	}
+	return dst
 }
 
 func (fc *funcCompiler) compileQueryFull(q *parser.QueryExpr, dst int, level int) {
-        var name string
-        var src *parser.Expr
-        if level == 0 {
-                name = q.Var
-                src = q.Source
-        } else {
-                from := q.Froms[level-1]
-                name = from.Var
-                src = from.Src
-        }
+	var name string
+	var src *parser.Expr
+	if level == 0 {
+		name = q.Var
+		src = q.Source
+	} else {
+		from := q.Froms[level-1]
+		name = from.Var
+		src = from.Src
+	}
 
-        srcReg := fc.compileExpr(src)
-        listReg := fc.newReg()
-        fc.emit(src.Pos, Instr{Op: OpIterPrep, A: listReg, B: srcReg})
-        lenReg := fc.newReg()
-        fc.emit(src.Pos, Instr{Op: OpLen, A: lenReg, B: listReg})
-        idxReg := fc.newReg()
-        fc.emit(src.Pos, Instr{Op: OpConst, A: idxReg, Val: Value{Tag: interpreter.TagInt, Int: 0}})
-        loopStart := len(fc.fn.Code)
-        condReg := fc.newReg()
-        fc.emit(src.Pos, Instr{Op: OpLess, A: condReg, B: idxReg, C: lenReg})
-        jmp := len(fc.fn.Code)
-        fc.emit(src.Pos, Instr{Op: OpJumpIfFalse, A: condReg})
+	srcReg := fc.compileExpr(src)
+	listReg := fc.newReg()
+	fc.emit(src.Pos, Instr{Op: OpIterPrep, A: listReg, B: srcReg})
+	lenReg := fc.newReg()
+	fc.emit(src.Pos, Instr{Op: OpLen, A: lenReg, B: listReg})
+	idxReg := fc.newReg()
+	fc.emit(src.Pos, Instr{Op: OpConst, A: idxReg, Val: Value{Tag: interpreter.TagInt, Int: 0}})
+	loopStart := len(fc.fn.Code)
+	condReg := fc.newReg()
+	fc.emit(src.Pos, Instr{Op: OpLess, A: condReg, B: idxReg, C: lenReg})
+	jmp := len(fc.fn.Code)
+	fc.emit(src.Pos, Instr{Op: OpJumpIfFalse, A: condReg})
 
-        elemReg := fc.newReg()
-        fc.emit(src.Pos, Instr{Op: OpIndex, A: elemReg, B: listReg, C: idxReg})
-        varReg, ok := fc.vars[name]
-        if !ok {
-                varReg = fc.newReg()
-                fc.vars[name] = varReg
-        }
-        fc.emit(src.Pos, Instr{Op: OpMove, A: varReg, B: elemReg})
+	elemReg := fc.newReg()
+	fc.emit(src.Pos, Instr{Op: OpIndex, A: elemReg, B: listReg, C: idxReg})
+	varReg, ok := fc.vars[name]
+	if !ok {
+		varReg = fc.newReg()
+		fc.vars[name] = varReg
+	}
+	fc.emit(src.Pos, Instr{Op: OpMove, A: varReg, B: elemReg})
 
-        if level < len(q.Froms) {
-                fc.compileQueryFull(q, dst, level+1)
-        } else {
-                fc.compileJoins(q, dst, 0)
-        }
+	if level < len(q.Froms) {
+		fc.compileQueryFull(q, dst, level+1)
+	} else {
+		fc.compileJoins(q, dst, 0)
+	}
 
-        one := fc.newReg()
-        fc.emit(src.Pos, Instr{Op: OpConst, A: one, Val: Value{Tag: interpreter.TagInt, Int: 1}})
-        tmp := fc.newReg()
-        fc.emit(src.Pos, Instr{Op: OpAdd, A: tmp, B: idxReg, C: one})
-        fc.emit(src.Pos, Instr{Op: OpMove, A: idxReg, B: tmp})
-        fc.emit(src.Pos, Instr{Op: OpJump, A: loopStart})
-        end := len(fc.fn.Code)
-        fc.fn.Code[jmp].B = end
+	one := fc.newReg()
+	fc.emit(src.Pos, Instr{Op: OpConst, A: one, Val: Value{Tag: interpreter.TagInt, Int: 1}})
+	tmp := fc.newReg()
+	fc.emit(src.Pos, Instr{Op: OpAdd, A: tmp, B: idxReg, C: one})
+	fc.emit(src.Pos, Instr{Op: OpMove, A: idxReg, B: tmp})
+	fc.emit(src.Pos, Instr{Op: OpJump, A: loopStart})
+	end := len(fc.fn.Code)
+	fc.fn.Code[jmp].B = end
 }
 
 func (fc *funcCompiler) compileJoins(q *parser.QueryExpr, dst int, idx int) {
-        if idx >= len(q.Joins) {
-                if q.Where != nil {
-                        cond := fc.compileExpr(q.Where)
-                        skip := len(fc.fn.Code)
-                        fc.emit(q.Where.Pos, Instr{Op: OpJumpIfFalse, A: cond})
-                        val := fc.compileExpr(q.Select)
-                        tmp := fc.newReg()
-                        fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: dst, C: val})
-                        fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmp})
-                        fc.fn.Code[skip].B = len(fc.fn.Code)
-                } else {
-                        val := fc.compileExpr(q.Select)
-                        tmp := fc.newReg()
-                        fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: dst, C: val})
-                        fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmp})
-                }
-                return
-        }
+	if idx >= len(q.Joins) {
+		if q.Where != nil {
+			cond := fc.compileExpr(q.Where)
+			skip := len(fc.fn.Code)
+			fc.emit(q.Where.Pos, Instr{Op: OpJumpIfFalse, A: cond})
+			val := fc.compileExpr(q.Select)
+			tmp := fc.newReg()
+			fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: dst, C: val})
+			fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmp})
+			fc.fn.Code[skip].B = len(fc.fn.Code)
+		} else {
+			val := fc.compileExpr(q.Select)
+			tmp := fc.newReg()
+			fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: dst, C: val})
+			fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmp})
+		}
+		return
+	}
 
-        join := q.Joins[idx]
-        rightReg := fc.compileExpr(join.Src)
-        rlist := fc.newReg()
-        fc.emit(join.Pos, Instr{Op: OpIterPrep, A: rlist, B: rightReg})
-        rlen := fc.newReg()
-        fc.emit(join.Pos, Instr{Op: OpLen, A: rlen, B: rlist})
-        ri := fc.newReg()
-        fc.emit(join.Pos, Instr{Op: OpConst, A: ri, Val: Value{Tag: interpreter.TagInt, Int: 0}})
-        rstart := len(fc.fn.Code)
-        rcond := fc.newReg()
-        fc.emit(join.Pos, Instr{Op: OpLess, A: rcond, B: ri, C: rlen})
-        rjmp := len(fc.fn.Code)
-        fc.emit(join.Pos, Instr{Op: OpJumpIfFalse, A: rcond})
-        relem := fc.newReg()
-        fc.emit(join.Pos, Instr{Op: OpIndex, A: relem, B: rlist, C: ri})
-        rvar, ok := fc.vars[join.Var]
-        if !ok {
-                rvar = fc.newReg()
-                fc.vars[join.Var] = rvar
-        }
-        fc.emit(join.Pos, Instr{Op: OpMove, A: rvar, B: relem})
+	join := q.Joins[idx]
+	joinType := "inner"
+	if join.Side != nil {
+		joinType = *join.Side
+	}
 
-        if join.On != nil {
-                cond := fc.compileExpr(join.On)
-                skip := len(fc.fn.Code)
-                fc.emit(join.On.Pos, Instr{Op: OpJumpIfFalse, A: cond})
-                fc.compileJoins(q, dst, idx+1)
-                fc.fn.Code[skip].B = len(fc.fn.Code)
-        } else {
-                fc.compileJoins(q, dst, idx+1)
-        }
+	rightReg := fc.compileExpr(join.Src)
+	rlist := fc.newReg()
+	fc.emit(join.Pos, Instr{Op: OpIterPrep, A: rlist, B: rightReg})
+	rlen := fc.newReg()
+	fc.emit(join.Pos, Instr{Op: OpLen, A: rlen, B: rlist})
+	ri := fc.newReg()
+	fc.emit(join.Pos, Instr{Op: OpConst, A: ri, Val: Value{Tag: interpreter.TagInt, Int: 0}})
+	rstart := len(fc.fn.Code)
+	rcond := fc.newReg()
+	fc.emit(join.Pos, Instr{Op: OpLess, A: rcond, B: ri, C: rlen})
+	rjmp := len(fc.fn.Code)
+	fc.emit(join.Pos, Instr{Op: OpJumpIfFalse, A: rcond})
+	relem := fc.newReg()
+	fc.emit(join.Pos, Instr{Op: OpIndex, A: relem, B: rlist, C: ri})
+	rvar, ok := fc.vars[join.Var]
+	if !ok {
+		rvar = fc.newReg()
+		fc.vars[join.Var] = rvar
+	}
+	fc.emit(join.Pos, Instr{Op: OpMove, A: rvar, B: relem})
 
-        one := fc.newReg()
-        fc.emit(join.Pos, Instr{Op: OpConst, A: one, Val: Value{Tag: interpreter.TagInt, Int: 1}})
-        tmp := fc.newReg()
-        fc.emit(join.Pos, Instr{Op: OpAdd, A: tmp, B: ri, C: one})
-        fc.emit(join.Pos, Instr{Op: OpMove, A: ri, B: tmp})
-        fc.emit(join.Pos, Instr{Op: OpJump, A: rstart})
-        end := len(fc.fn.Code)
-        fc.fn.Code[rjmp].B = end
+	if joinType == "left" || joinType == "outer" {
+		matched := fc.newReg()
+		fc.emit(join.Pos, Instr{Op: OpConst, A: matched, Val: Value{Tag: interpreter.TagBool, Bool: false}})
+		if join.On != nil {
+			cond := fc.compileExpr(join.On)
+			skip := len(fc.fn.Code)
+			fc.emit(join.On.Pos, Instr{Op: OpJumpIfFalse, A: cond})
+			fc.emit(join.Pos, Instr{Op: OpConst, A: matched, Val: Value{Tag: interpreter.TagBool, Bool: true}})
+			fc.compileJoins(q, dst, idx+1)
+			fc.fn.Code[skip].B = len(fc.fn.Code)
+		} else {
+			fc.emit(join.Pos, Instr{Op: OpConst, A: matched, Val: Value{Tag: interpreter.TagBool, Bool: true}})
+			fc.compileJoins(q, dst, idx+1)
+		}
+
+		one := fc.newReg()
+		fc.emit(join.Pos, Instr{Op: OpConst, A: one, Val: Value{Tag: interpreter.TagInt, Int: 1}})
+		tmp := fc.newReg()
+		fc.emit(join.Pos, Instr{Op: OpAdd, A: tmp, B: ri, C: one})
+		fc.emit(join.Pos, Instr{Op: OpMove, A: ri, B: tmp})
+		fc.emit(join.Pos, Instr{Op: OpJump, A: rstart})
+		end := len(fc.fn.Code)
+		fc.fn.Code[rjmp].B = end
+
+		check := fc.newReg()
+		fc.emit(join.Pos, Instr{Op: OpMove, A: check, B: matched})
+		skipAdd := len(fc.fn.Code)
+		fc.emit(join.Pos, Instr{Op: OpJumpIfTrue, A: check})
+		nilreg := fc.newReg()
+		fc.emit(join.Pos, Instr{Op: OpConst, A: nilreg, Val: Value{Tag: interpreter.TagNull}})
+		fc.emit(join.Pos, Instr{Op: OpMove, A: rvar, B: nilreg})
+		fc.compileJoins(q, dst, idx+1)
+		fc.fn.Code[skipAdd].B = len(fc.fn.Code)
+	} else {
+		if join.On != nil {
+			cond := fc.compileExpr(join.On)
+			skip := len(fc.fn.Code)
+			fc.emit(join.On.Pos, Instr{Op: OpJumpIfFalse, A: cond})
+			fc.compileJoins(q, dst, idx+1)
+			fc.fn.Code[skip].B = len(fc.fn.Code)
+		} else {
+			fc.compileJoins(q, dst, idx+1)
+		}
+
+		one := fc.newReg()
+		fc.emit(join.Pos, Instr{Op: OpConst, A: one, Val: Value{Tag: interpreter.TagInt, Int: 1}})
+		tmp := fc.newReg()
+		fc.emit(join.Pos, Instr{Op: OpAdd, A: tmp, B: ri, C: one})
+		fc.emit(join.Pos, Instr{Op: OpMove, A: ri, B: tmp})
+		fc.emit(join.Pos, Instr{Op: OpJump, A: rstart})
+		end := len(fc.fn.Code)
+		fc.fn.Code[rjmp].B = end
+	}
 }
 
 func (fc *funcCompiler) compileJoinQuery(q *parser.QueryExpr, dst int) {

--- a/tests/vm/valid/left_join_multi.ir.out
+++ b/tests/vm/valid/left_join_multi.ir.out
@@ -1,0 +1,143 @@
+func main (regs=93)
+  // let customers = [
+  Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+  Move         r1, r0
+  // let orders = [
+  Const        r2, [{"customerId": 1, "id": 100}, {"customerId": 2, "id": 101}]
+  Move         r3, r2
+  // let items = [
+  Const        r4, [{"orderId": 100, "sku": "a"}]
+  Move         r5, r4
+  // let result = from o in orders
+  Const        r6, []
+  IterPrep     r7, r3
+  Len          r8, r7
+  Const        r9, 0
+L7:
+  Less         r10, r9, r8
+  JumpIfFalse  r10, L0
+  Index        r11, r7, r9
+  Move         r12, r11
+  // join from c in customers on o.customerId == c.id
+  IterPrep     r13, r1
+  Len          r14, r13
+  Const        r15, 0
+L6:
+  Less         r16, r15, r14
+  JumpIfFalse  r16, L1
+  Index        r17, r13, r15
+  Move         r18, r17
+  Const        r19, "customerId"
+  Index        r20, r12, r19
+  Const        r21, "id"
+  Index        r22, r18, r21
+  Equal        r23, r20, r22
+  JumpIfFalse  r23, L2
+  // left join i in items on o.id == i.orderId
+  IterPrep     r24, r5
+  Len          r25, r24
+  Const        r26, 0
+L5:
+  Less         r27, r26, r25
+  JumpIfFalse  r27, L3
+  Index        r28, r24, r26
+  Move         r29, r28
+  Const        r30, false
+  Const        r31, "id"
+  Index        r32, r12, r31
+  Const        r33, "orderId"
+  Index        r34, r29, r33
+  Equal        r35, r32, r34
+  JumpIfFalse  r35, L4
+  Const        r30, true
+  // select { orderId: o.id, name: c.name, item: i }
+  Const        r36, "orderId"
+  Const        r37, "id"
+  Index        r38, r12, r37
+  Const        r39, "name"
+  Const        r40, "name"
+  Index        r41, r18, r40
+  Const        r42, "item"
+  Move         r43, r36
+  Move         r44, r38
+  Move         r45, r39
+  Move         r46, r41
+  Move         r47, r42
+  Move         r48, r29
+  MakeMap      r49, 3, r43
+  // let result = from o in orders
+  Append       r50, r6, r49
+  Move         r6, r50
+L4:
+  // left join i in items on o.id == i.orderId
+  Const        r51, 1
+  Add          r52, r26, r51
+  Move         r26, r52
+  Jump         L5
+L3:
+  Move         r53, r30
+  JumpIfTrue   r53, L2
+  Const        r54, nil
+  Move         r29, r54
+  // select { orderId: o.id, name: c.name, item: i }
+  Const        r55, "orderId"
+  Const        r56, "id"
+  Index        r57, r12, r56
+  Const        r58, "name"
+  Const        r59, "name"
+  Index        r60, r18, r59
+  Const        r61, "item"
+  Move         r62, r55
+  Move         r63, r57
+  Move         r64, r58
+  Move         r65, r60
+  Move         r66, r61
+  Move         r67, r29
+  MakeMap      r68, 3, r62
+  // let result = from o in orders
+  Append       r69, r6, r68
+  Move         r6, r69
+L2:
+  // join from c in customers on o.customerId == c.id
+  Const        r70, 1
+  Add          r71, r15, r70
+  Move         r15, r71
+  Jump         L6
+L1:
+  // let result = from o in orders
+  Const        r72, 1
+  Add          r73, r9, r72
+  Move         r9, r73
+  Jump         L7
+L0:
+  Move         r74, r6
+  // print("--- Left Join Multi ---")
+  Const        r75, "--- Left Join Multi ---"
+  Print        r75
+  // for r in result {
+  IterPrep     r76, r74
+  Len          r77, r76
+  Const        r78, 0
+L9:
+  Less         r79, r78, r77
+  JumpIfFalse  r79, L8
+  Index        r80, r76, r78
+  Move         r81, r80
+  // print(r.orderId, r.name, r.item)
+  Const        r85, "orderId"
+  Index        r86, r81, r85
+  Move         r82, r86
+  Const        r87, "name"
+  Index        r88, r81, r87
+  Move         r83, r88
+  Const        r89, "item"
+  Index        r90, r81, r89
+  Move         r84, r90
+  PrintN       r82, 3, r82
+  // for r in result {
+  Const        r91, 1
+  Add          r92, r78, r91
+  Move         r78, r92
+  Jump         L9
+L8:
+  Return       r0

--- a/tests/vm/valid/left_join_multi.mochi
+++ b/tests/vm/valid/left_join_multi.mochi
@@ -1,0 +1,23 @@
+let customers = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" }
+]
+
+let orders = [
+  { id: 100, customerId: 1 },
+  { id: 101, customerId: 2 }
+]
+
+let items = [
+  { orderId: 100, sku: "a" }
+]
+
+let result = from o in orders
+             join from c in customers on o.customerId == c.id
+             left join i in items on o.id == i.orderId
+             select { orderId: o.id, name: c.name, item: i }
+
+print("--- Left Join Multi ---")
+for r in result {
+  print(r.orderId, r.name, r.item)
+}

--- a/tests/vm/valid/left_join_multi.out
+++ b/tests/vm/valid/left_join_multi.out
@@ -1,0 +1,3 @@
+--- Left Join Multi ---
+100 Alice map[orderId:100 sku:a]
+101 Bob <nil>


### PR DESCRIPTION
## Summary
- add support for `left join` inside queries with multiple joins
- generate IR for new left join case
- add golden test `left_join_multi`

## Testing
- `go test ./tests/vm -run .`

------
https://chatgpt.com/codex/tasks/task_e_685a942e3a308320a27e6d6640103043