### PR TITLE
Add dataset sort and limit support to vm

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -46,8 +46,7 @@ experimental VM.  Unsupported areas include:
 * Asynchronous functions (`async`/`await`)
 * Agents, streams and intent blocks with persistent state
 * Agent initialization with field values
-* Dataset queries (`from`, `join`, `group`, `sort`, `take`, etc.)
-  and loading datasets from CSV or YAML files
+* Grouping (`group by`) within dataset queries
 * Right and outer joins or pagination when joins are used
 * Generative AI blocks, model declarations and other LLM helpers
 * HTTP `fetch` expressions

--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -133,7 +133,7 @@ func applyTags(tags []RegTag, ins Instr) {
 	case OpJSON, OpPrint, OpPrint2, OpPrintN:
 		// no result
 	case OpInput, OpMakeList, OpIndex, OpSlice, OpSetIndex, OpCall, OpCall2, OpCallV,
-		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpMakeClosure:
+		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpSort, OpMakeClosure:
 		tags[ins.A] = TagUnknown
 	case OpIterPrep:
 		tags[ins.A] = TagUnknown

--- a/tests/vm/valid/dataset_sort_take_limit.ir.out
+++ b/tests/vm/valid/dataset_sort_take_limit.ir.out
@@ -1,0 +1,75 @@
+func main (regs=43)
+  // let products = [
+  Const        r0, [{"name": "Laptop", "price": 1500}, {"name": "Smartphone", "price": 900}, {"name": "Tablet", "price": 600}, {"name": "Monitor", "price": 300}, {"name": "Keyboard", "price": 100}, {"name": "Mouse", "price": 50}, {"name": "Headphones", "price": 200}]
+  Move         r1, r0
+  // let expensive = from p in products
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
+L1:
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r7, r3, r5
+  Move         r8, r7
+  // sort by -p.price
+  Const        r9, "price"
+  Index        r10, r8, r9
+  Neg          r11, r10
+  Move         r12, r11
+  // let expensive = from p in products
+  Move         r13, r8
+  MakeList     r14, 2, r12
+  Append       r15, r2, r14
+  Move         r2, r15
+  Const        r16, 1
+  Add          r17, r5, r16
+  Move         r5, r17
+  Jump         L1
+L0:
+  // sort by -p.price
+  Sort         18,2,0,0
+  // let expensive = from p in products
+  Move         r2, r18
+  // skip 1
+  Const        r19, 1
+  // let expensive = from p in products
+  Const        r20, nil
+  Slice        r21, r2, r19, r20
+  Move         r2, r21
+  Const        r22, 0
+  // take 3
+  Const        r23, 3
+  // let expensive = from p in products
+  Slice        r24, r2, r22, r23
+  Move         r2, r24
+  Move         r25, r2
+  // print("--- Top products (excluding most expensive) ---")
+  Const        r26, "--- Top products (excluding most expensive) ---"
+  Print        r26
+  // for item in expensive {
+  IterPrep     r27, r25
+  Len          r28, r27
+  Const        r29, 0
+L3:
+  Less         r30, r29, r28
+  JumpIfFalse  r30, L2
+  Index        r31, r27, r29
+  Move         r32, r31
+  // print(item.name, "costs $", item.price)
+  Const        r36, "name"
+  Index        r37, r32, r36
+  Move         r33, r37
+  Const        r38, "costs $"
+  Move         r34, r38
+  Const        r39, "price"
+  Index        r40, r32, r39
+  Move         r35, r40
+  PrintN       r33, 3, r33
+  // for item in expensive {
+  Const        r41, 1
+  Add          r42, r29, r41
+  Move         r29, r42
+  Jump         L3
+L2:
+  Return       r0

--- a/tests/vm/valid/dataset_sort_take_limit.mochi
+++ b/tests/vm/valid/dataset_sort_take_limit.mochi
@@ -1,0 +1,19 @@
+// dataset-sort-take-limit.mochi
+let products = [
+  { name: "Laptop", price: 1500 },
+  { name: "Smartphone", price: 900 },
+  { name: "Tablet", price: 600 },
+  { name: "Monitor", price: 300 },
+  { name: "Keyboard", price: 100 },
+  { name: "Mouse", price: 50 },
+  { name: "Headphones", price: 200 }
+]
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/vm/valid/dataset_sort_take_limit.out
+++ b/tests/vm/valid/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- enhance dataset query capabilities with sort/skip/take
- update VM README to clarify remaining dataset limitations
- add golden test for dataset sorting with skip/take

## Testing
- `go test ./tests/vm -run . -update`

------
https://chatgpt.com/codex/tasks/task_e_685aa308e1988320bfa79970a124dd7d