### PR TITLE
Add dataset load/save support to VM

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -30,6 +30,8 @@ The VM supports a small but useful subset of Mochi:
 * Field access using the `.` operator
 * List and string slicing with `[start:end]` syntax (supports negative indices)
 * Pattern matching
+* Dataset queries (`from`, `join`, `group`, `sort`, `take`, etc.) and
+  loading or saving datasets in CSV, JSON, JSONL or YAML formats
 
 ## Unsupported features
 
@@ -46,8 +48,6 @@ experimental VM.  Unsupported areas include:
 * Asynchronous functions (`async`/`await`)
 * Agents, streams and intent blocks with persistent state
 * Agent initialization with field values
-* Dataset queries (`from`, `join`, `group`, `sort`, `take`, etc.)
-  and loading datasets from CSV or YAML files
 * Right and outer joins or pagination when joins are used
 * Generative AI blocks, model declarations and other LLM helpers
 * HTTP `fetch` expressions

--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -135,6 +135,10 @@ func applyTags(tags []RegTag, ins Instr) {
 	case OpInput, OpMakeList, OpIndex, OpSlice, OpSetIndex, OpCall, OpCall2, OpCallV,
 		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpMakeClosure:
 		tags[ins.A] = TagUnknown
+	case OpLoad:
+		tags[ins.A] = TagUnknown
+	case OpSave:
+		// no result
 	case OpIterPrep:
 		tags[ins.A] = TagUnknown
 	case OpCast:

--- a/tests/vm/valid/load_save_jsonl.ir.out
+++ b/tests/vm/valid/load_save_jsonl.ir.out
@@ -1,0 +1,46 @@
+func main (regs=29)
+  // let people = load "../interpreter/valid/people.jsonl" as Person with { format: "jsonl" }
+  Const        r0, "../interpreter/valid/people.jsonl"
+  Const        r2, {"format": "jsonl"}
+  Move         r1, r2
+  Load         3,0,1,0
+  Move         r4, r3
+  // let adults = from p in people
+  Const        r5, []
+  IterPrep     r6, r4
+  Len          r7, r6
+  Const        r8, 0
+L2:
+  Less         r9, r8, r7
+  JumpIfFalse  r9, L0
+  Index        r10, r6, r8
+  Move         r11, r10
+  // where p.age >= 18
+  Const        r12, "age"
+  Index        r13, r11, r12
+  Const        r14, 18
+  LessEq       r15, r14, r13
+  JumpIfFalse  r15, L1
+  // select { name: p.name }
+  Const        r16, "name"
+  Const        r17, "name"
+  Index        r18, r11, r17
+  Move         r19, r16
+  Move         r20, r18
+  MakeMap      r21, 1, r19
+  // let adults = from p in people
+  Append       r22, r5, r21
+  Move         r5, r22
+L1:
+  Const        r23, 1
+  Add          r24, r8, r23
+  Move         r8, r24
+  Jump         L2
+L0:
+  Move         r25, r5
+  // save adults with { format: "jsonl" }
+  Const        r26, ""
+  Const        r28, {"format": "jsonl"}
+  Move         r27, r28
+  Save         r25, r26, r27
+  Return       r0

--- a/tests/vm/valid/load_save_jsonl.mochi
+++ b/tests/vm/valid/load_save_jsonl.mochi
@@ -1,0 +1,12 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+let people = load "../interpreter/valid/people.jsonl" as Person with { format: "jsonl" }
+let adults = from p in people
+             where p.age >= 18
+             select { name: p.name }
+
+save adults with { format: "jsonl" }

--- a/tests/vm/valid/load_save_jsonl.out
+++ b/tests/vm/valid/load_save_jsonl.out
@@ -1,0 +1,2 @@
+{"name":"Alice"}
+{"name":"Charlie"}

--- a/types/check.go
+++ b/types/check.go
@@ -1559,6 +1559,17 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		}
 		return ListType{Elem: elem}, nil
 
+	case p.Save != nil:
+		if _, err := checkExpr(p.Save.Src, env); err != nil {
+			return nil, err
+		}
+		if p.Save.With != nil {
+			if _, err := checkExpr(p.Save.With, env); err != nil {
+				return nil, err
+			}
+		}
+		return VoidType{}, nil
+
 	case p.Match != nil:
 		return checkMatchExpr(p.Match, env, expected)
 


### PR DESCRIPTION
## Summary
- implement `OpSave` instruction for virtual machine
- compile `save` expressions to `OpSave`
- execute save operations through runtime/data helpers
- infer register tags for load/save ops
- extend type checker with `save` expression
- document dataset query/load/save as supported
- add VM test for loading data and saving to stdout

## Testing
- `go test ./tests/vm -run TestVM_ValidPrograms/load_save_jsonl -update`
- `go test ./tests/vm -run TestVM_IR/load_save_jsonl -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685aa31bc644832083c1ff81e8b9a507