### PR TITLE
Add basic group-by support in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1033,32 +1033,37 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			line = strings.TrimRight(line, "\r\n")
 			fr.regs[ins.A] = Value{Tag: interpreter.TagStr, Str: line}
-		case OpIterPrep:
-			src := fr.regs[ins.B]
-			switch src.Tag {
-			case interpreter.TagList:
-				fr.regs[ins.A] = src
-			case interpreter.TagMap:
-				ks := make([]string, 0, len(src.Map))
-				for k := range src.Map {
-					ks = append(ks, k)
-				}
-				sort.Strings(ks)
-				keys := make([]Value, len(ks))
-				for i, k := range ks {
-					keys[i] = Value{Tag: interpreter.TagStr, Str: k}
-				}
-				fr.regs[ins.A] = Value{Tag: interpreter.TagList, List: keys}
-			case interpreter.TagStr:
-				r := []rune(src.Str)
-				lst := make([]Value, len(r))
-				for i, ch := range r {
-					lst[i] = Value{Tag: interpreter.TagStr, Str: string(ch)}
-				}
-				fr.regs[ins.A] = Value{Tag: interpreter.TagList, List: lst}
-			default:
-				return Value{}, m.newError(fmt.Errorf("invalid iterator"), trace, ins.Line)
-			}
+                case OpIterPrep:
+                        src := fr.regs[ins.B]
+                        switch src.Tag {
+                        case interpreter.TagList:
+                                fr.regs[ins.A] = src
+                        case interpreter.TagMap:
+                                if flag, ok := src.Map["__group__"]; ok && flag.Tag == interpreter.TagBool && flag.Bool {
+                                        items := src.Map["items"]
+                                        fr.regs[ins.A] = items
+                                        break
+                                }
+                                ks := make([]string, 0, len(src.Map))
+                                for k := range src.Map {
+                                        ks = append(ks, k)
+                                }
+                                sort.Strings(ks)
+                                keys := make([]Value, len(ks))
+                                for i, k := range ks {
+                                        keys[i] = Value{Tag: interpreter.TagStr, Str: k}
+                                }
+                                fr.regs[ins.A] = Value{Tag: interpreter.TagList, List: keys}
+                        case interpreter.TagStr:
+                                r := []rune(src.Str)
+                                lst := make([]Value, len(r))
+                                for i, ch := range r {
+                                        lst[i] = Value{Tag: interpreter.TagStr, Str: string(ch)}
+                                }
+                                fr.regs[ins.A] = Value{Tag: interpreter.TagList, List: lst}
+                        default:
+                                return Value{}, m.newError(fmt.Errorf("invalid iterator"), trace, ins.Line)
+                        }
 		case OpLoad:
 			path := fr.regs[ins.B].Str
 			opts := valueToAny(fr.regs[ins.C])
@@ -1135,76 +1140,99 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				return Value{}, m.newError(err, trace, ins.Line)
 			}
 			fr.regs[ins.A] = anyToValue(resAny)
-		case OpCount:
-			lst := fr.regs[ins.B]
-			if lst.Tag != interpreter.TagList {
-				return Value{}, fmt.Errorf("count expects list")
-			}
-			fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: len(lst.List)}
-		case OpAvg:
-			lst := fr.regs[ins.B]
-			if lst.Tag != interpreter.TagList {
-				return Value{}, fmt.Errorf("avg expects list")
-			}
-			if len(lst.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: 0}
-			} else {
-				var sum float64
-				for _, v := range lst.List {
-					sum += toFloat(v)
-				}
-				fr.regs[ins.A] = Value{Tag: interpreter.TagFloat, Float: sum / float64(len(lst.List))}
-			}
-		case OpMin:
-			lst := fr.regs[ins.B]
-			if lst.Tag != interpreter.TagList {
-				return Value{}, fmt.Errorf("min expects list")
-			}
-			if len(lst.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: 0}
-			} else {
-				minVal := toFloat(lst.List[0])
-				isFloat := lst.List[0].Tag == interpreter.TagFloat
-				for _, v := range lst.List[1:] {
-					if v.Tag == interpreter.TagFloat {
-						isFloat = true
-					}
-					f := toFloat(v)
-					if f < minVal {
-						minVal = f
-					}
-				}
-				if isFloat {
-					fr.regs[ins.A] = Value{Tag: interpreter.TagFloat, Float: minVal}
-				} else {
-					fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: int(minVal)}
-				}
-			}
-		case OpMax:
-			lst := fr.regs[ins.B]
-			if lst.Tag != interpreter.TagList {
-				return Value{}, fmt.Errorf("max expects list")
-			}
-			if len(lst.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: 0}
-			} else {
-				maxVal := toFloat(lst.List[0])
-				isFloat := lst.List[0].Tag == interpreter.TagFloat
-				for _, v := range lst.List[1:] {
-					if v.Tag == interpreter.TagFloat {
-						isFloat = true
-					}
-					f := toFloat(v)
-					if f > maxVal {
-						maxVal = f
-					}
-				}
-				if isFloat {
-					fr.regs[ins.A] = Value{Tag: interpreter.TagFloat, Float: maxVal}
-				} else {
-					fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: int(maxVal)}
-				}
-			}
+                case OpCount:
+                        lst := fr.regs[ins.B]
+                        if lst.Tag == interpreter.TagList {
+                                fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: len(lst.List)}
+                                break
+                        }
+                        if lst.Tag == interpreter.TagMap {
+                                if flag, ok := lst.Map["__group__"]; ok && flag.Tag == interpreter.TagBool && flag.Bool {
+                                        items := lst.Map["items"]
+                                        fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: len(items.List)}
+                                        break
+                                }
+                        }
+                        return Value{}, fmt.Errorf("count expects list")
+                case OpAvg:
+                        lst := fr.regs[ins.B]
+                        if lst.Tag == interpreter.TagMap {
+                                if flag, ok := lst.Map["__group__"]; ok && flag.Tag == interpreter.TagBool && flag.Bool {
+                                        lst = lst.Map["items"]
+                                }
+                        }
+                        if lst.Tag != interpreter.TagList {
+                                return Value{}, fmt.Errorf("avg expects list")
+                        }
+                        if len(lst.List) == 0 {
+                                fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: 0}
+                        } else {
+                                var sum float64
+                                for _, v := range lst.List {
+                                        sum += toFloat(v)
+                                }
+                                fr.regs[ins.A] = Value{Tag: interpreter.TagFloat, Float: sum / float64(len(lst.List))}
+                        }
+                case OpMin:
+                        lst := fr.regs[ins.B]
+                        if lst.Tag == interpreter.TagMap {
+                                if flag, ok := lst.Map["__group__"]; ok && flag.Tag == interpreter.TagBool && flag.Bool {
+                                        lst = lst.Map["items"]
+                                }
+                        }
+                        if lst.Tag != interpreter.TagList {
+                                return Value{}, fmt.Errorf("min expects list")
+                        }
+                        if len(lst.List) == 0 {
+                                fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: 0}
+                        } else {
+                                minVal := toFloat(lst.List[0])
+                                isFloat := lst.List[0].Tag == interpreter.TagFloat
+                                for _, v := range lst.List[1:] {
+                                        if v.Tag == interpreter.TagFloat {
+                                                isFloat = true
+                                        }
+                                        f := toFloat(v)
+                                        if f < minVal {
+                                                minVal = f
+                                        }
+                                }
+                                if isFloat {
+                                        fr.regs[ins.A] = Value{Tag: interpreter.TagFloat, Float: minVal}
+                                } else {
+                                        fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: int(minVal)}
+                                }
+                        }
+                case OpMax:
+                        lst := fr.regs[ins.B]
+                        if lst.Tag == interpreter.TagMap {
+                                if flag, ok := lst.Map["__group__"]; ok && flag.Tag == interpreter.TagBool && flag.Bool {
+                                        lst = lst.Map["items"]
+                                }
+                        }
+                        if lst.Tag != interpreter.TagList {
+                                return Value{}, fmt.Errorf("max expects list")
+                        }
+                        if len(lst.List) == 0 {
+                                fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: 0}
+                        } else {
+                                maxVal := toFloat(lst.List[0])
+                                isFloat := lst.List[0].Tag == interpreter.TagFloat
+                                for _, v := range lst.List[1:] {
+                                        if v.Tag == interpreter.TagFloat {
+                                                isFloat = true
+                                        }
+                                        f := toFloat(v)
+                                        if f > maxVal {
+                                                maxVal = f
+                                        }
+                                }
+                                if isFloat {
+                                        fr.regs[ins.A] = Value{Tag: interpreter.TagFloat, Float: maxVal}
+                                } else {
+                                        fr.regs[ins.A] = Value{Tag: interpreter.TagInt, Int: int(maxVal)}
+                                }
+                        }
 		case OpCast:
 			val := valueToAny(fr.regs[ins.B])
 			typ := m.prog.Types[ins.C]
@@ -2407,16 +2435,20 @@ func (fc *funcCompiler) compileFor(f *parser.ForStmt) error {
 // optional WHERE filtering and SELECT projection. Only cross joins are
 // handled and results are accumulated into a list.
 func (fc *funcCompiler) compileQuery(q *parser.QueryExpr) int {
-	dst := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpConst, A: dst, Val: Value{Tag: interpreter.TagList, List: []Value{}}})
-	switch {
-	case len(q.Joins) == 1 && len(q.Froms) == 0:
-		fc.compileJoinQuery(q, dst)
-	case len(q.Joins) == 0:
-		fc.compileQueryFrom(q, dst, 0)
-	default:
-		fc.compileQueryFull(q, dst, 0)
-	}
+        dst := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: dst, Val: Value{Tag: interpreter.TagList, List: []Value{}}})
+        if q.Group != nil && len(q.Froms) == 0 && len(q.Joins) == 0 {
+                fc.compileGroupQuery(q, dst)
+        } else {
+                switch {
+                case len(q.Joins) == 1 && len(q.Froms) == 0:
+                        fc.compileJoinQuery(q, dst)
+                case len(q.Joins) == 0:
+                        fc.compileQueryFrom(q, dst, 0)
+                default:
+                        fc.compileQueryFull(q, dst, 0)
+                }
+        }
 	if q.Sort != nil {
 		sorted := fc.newReg()
 		fc.emit(q.Sort.Pos, Instr{Op: OpSort, A: sorted, B: dst})
@@ -2863,6 +2895,134 @@ func (fc *funcCompiler) compileJoinQuery(q *parser.QueryExpr, dst int) {
 		rend3 := len(fc.fn.Code)
 		fc.fn.Code[rjmp3].B = rend3
 	}
+}
+
+// compileGroupQuery handles simple queries with a single FROM clause and GROUP BY.
+func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
+        srcReg := fc.compileExpr(q.Source)
+        listReg := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpIterPrep, A: listReg, B: srcReg})
+        lenReg := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpLen, A: lenReg, B: listReg})
+        idxReg := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: idxReg, Val: Value{Tag: interpreter.TagInt, Int: 0}})
+
+        groupsMap := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpMakeMap, A: groupsMap, B: 0})
+        groupsList := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: groupsList, Val: Value{Tag: interpreter.TagList, List: []Value{}}})
+
+        loopStart := len(fc.fn.Code)
+        condReg := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpLess, A: condReg, B: idxReg, C: lenReg})
+        jmp := len(fc.fn.Code)
+        fc.emit(q.Pos, Instr{Op: OpJumpIfFalse, A: condReg})
+
+        elemReg := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpIndex, A: elemReg, B: listReg, C: idxReg})
+        varReg, ok := fc.vars[q.Var]
+        if !ok {
+                varReg = fc.newReg()
+                fc.vars[q.Var] = varReg
+        }
+        fc.emit(q.Pos, Instr{Op: OpMove, A: varReg, B: elemReg})
+
+        if q.Where != nil {
+                cond := fc.compileExpr(q.Where)
+                skip := len(fc.fn.Code)
+                fc.emit(q.Where.Pos, Instr{Op: OpJumpIfFalse, A: cond})
+                fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList)
+                fc.fn.Code[skip].B = len(fc.fn.Code)
+        } else {
+                fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList)
+        }
+
+        one := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: one, Val: Value{Tag: interpreter.TagInt, Int: 1}})
+        tmp := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpAdd, A: tmp, B: idxReg, C: one})
+        fc.emit(q.Pos, Instr{Op: OpMove, A: idxReg, B: tmp})
+        fc.emit(q.Pos, Instr{Op: OpJump, A: loopStart})
+        end := len(fc.fn.Code)
+        fc.fn.Code[jmp].B = end
+
+        // iterate groups and produce final results
+        gi := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: gi, Val: Value{Tag: interpreter.TagInt, Int: 0}})
+        glen := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpLen, A: glen, B: groupsList})
+        loop2 := len(fc.fn.Code)
+        cond2 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpLess, A: cond2, B: gi, C: glen})
+        jmp2 := len(fc.fn.Code)
+        fc.emit(q.Pos, Instr{Op: OpJumpIfFalse, A: cond2})
+
+        grp := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpIndex, A: grp, B: groupsList, C: gi})
+        gvar, ok := fc.vars[q.Group.Name]
+        if !ok {
+                gvar = fc.newReg()
+                fc.vars[q.Group.Name] = gvar
+        }
+        fc.emit(q.Pos, Instr{Op: OpMove, A: gvar, B: grp})
+
+        val := fc.compileExpr(q.Select)
+        tmpOut := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpAppend, A: tmpOut, B: dst, C: val})
+        fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmpOut})
+
+        one2 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: one2, Val: Value{Tag: interpreter.TagInt, Int: 1}})
+        tmp2 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpAdd, A: tmp2, B: gi, C: one2})
+        fc.emit(q.Pos, Instr{Op: OpMove, A: gi, B: tmp2})
+        fc.emit(q.Pos, Instr{Op: OpJump, A: loop2})
+        end2 := len(fc.fn.Code)
+        fc.fn.Code[jmp2].B = end2
+}
+
+func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, gmap, glist int) {
+        key := fc.compileExpr(q.Group.Expr)
+        keyStr := fc.newReg()
+        fc.emit(q.Group.Pos, Instr{Op: OpStr, A: keyStr, B: key})
+        exists := fc.newReg()
+        fc.emit(q.Group.Pos, Instr{Op: OpIn, A: exists, B: keyStr, C: gmap})
+        jump := len(fc.fn.Code)
+        fc.emit(q.Group.Pos, Instr{Op: OpJumpIfTrue, A: exists})
+
+        items := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: items, Val: Value{Tag: interpreter.TagList, List: []Value{}}})
+        k1 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: k1, Val: Value{Tag: interpreter.TagStr, Str: "__group__"}})
+        v1 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: v1, Val: Value{Tag: interpreter.TagBool, Bool: true}})
+        k2 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: k2, Val: Value{Tag: interpreter.TagStr, Str: "key"}})
+        v2 := fc.newReg()
+        fc.emit(q.Group.Pos, Instr{Op: OpMove, A: v2, B: key})
+        k3 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: k3, Val: Value{Tag: interpreter.TagStr, Str: "items"}})
+        v3 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpMove, A: v3, B: items})
+        grp := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpMakeMap, A: grp, B: 3, C: k1})
+        fc.emit(q.Pos, Instr{Op: OpSetIndex, A: gmap, B: keyStr, C: grp})
+        tmp := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: glist, C: grp})
+        fc.emit(q.Pos, Instr{Op: OpMove, A: glist, B: tmp})
+
+        end := len(fc.fn.Code)
+        fc.fn.Code[jump].B = end
+
+        itemsKey := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpConst, A: itemsKey, Val: Value{Tag: interpreter.TagStr, Str: "items"}})
+        grp2 := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpIndex, A: grp2, B: gmap, C: keyStr})
+        cur := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpIndex, A: cur, B: grp2, C: itemsKey})
+        newList := fc.newReg()
+        fc.emit(q.Pos, Instr{Op: OpAppend, A: newList, B: cur, C: elemReg})
+        fc.emit(q.Pos, Instr{Op: OpSetIndex, A: grp2, B: itemsKey, C: newList})
 }
 
 // compileQueryFrom recursively emits nested loops for each FROM clause.

--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -1,0 +1,137 @@
+func main (regs=87)
+  // let people = [
+  Const        r0, [{"age": 30, "city": "Paris", "name": "Alice"}, {"age": 15, "city": "Hanoi", "name": "Bob"}, {"age": 65, "city": "Paris", "name": "Charlie"}, {"age": 45, "city": "Hanoi", "name": "Diana"}, {"age": 70, "city": "Paris", "name": "Eve"}, {"age": 22, "city": "Hanoi", "name": "Frank"}]
+  Move         r1, r0
+  // let stats = from person in people
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
+  MakeMap      r6, 0, r0
+  Const        r7, []
+L2:
+  Less         r8, r5, r4
+  JumpIfFalse  r8, L0
+  Index        r9, r3, r5
+  Move         r10, r9
+  // group by person.city into g
+  Const        r11, "city"
+  Index        r12, r10, r11
+  Str          r13, r12
+  In           r14, r13, r6
+  JumpIfTrue   r14, L1
+  // let stats = from person in people
+  Const        r15, []
+  Const        r16, "__group__"
+  Const        r17, true
+  Const        r18, "key"
+  // group by person.city into g
+  Move         r19, r12
+  // let stats = from person in people
+  Const        r20, "items"
+  Move         r21, r15
+  MakeMap      r22, 3, r16
+  SetIndex     r6, r13, r22
+  Append       r23, r7, r22
+  Move         r7, r23
+L1:
+  Const        r24, "items"
+  Index        r25, r6, r13
+  Index        r26, r25, r24
+  Append       r27, r26, r9
+  SetIndex     r25, r24, r27
+  Const        r28, 1
+  Add          r29, r5, r28
+  Move         r5, r29
+  Jump         L2
+L0:
+  Const        r30, 0
+  Len          r31, r7
+L6:
+  Less         r32, r30, r31
+  JumpIfFalse  r32, L3
+  Index        r33, r7, r30
+  Move         r34, r33
+  // city: g.key,
+  Const        r35, "city"
+  Const        r36, "key"
+  Index        r37, r34, r36
+  // count: count(g),
+  Const        r38, "count"
+  Count        r39, r34
+  // avg_age: avg(from p in g select p.age)
+  Const        r40, "avg_age"
+  Const        r41, []
+  IterPrep     r42, r34
+  Len          r43, r42
+  Const        r44, 0
+L5:
+  Less         r45, r44, r43
+  JumpIfFalse  r45, L4
+  Index        r46, r42, r44
+  Move         r47, r46
+  Const        r48, "age"
+  Index        r49, r47, r48
+  Append       r50, r41, r49
+  Move         r41, r50
+  Const        r51, 1
+  Add          r52, r44, r51
+  Move         r44, r52
+  Jump         L5
+L4:
+  Avg          r53, r41
+  // city: g.key,
+  Move         r54, r35
+  Move         r55, r37
+  // count: count(g),
+  Move         r56, r38
+  Move         r57, r39
+  // avg_age: avg(from p in g select p.age)
+  Move         r58, r40
+  Move         r59, r53
+  // select {
+  MakeMap      r60, 3, r54
+  // let stats = from person in people
+  Append       r61, r2, r60
+  Move         r2, r61
+  Const        r62, 1
+  Add          r63, r30, r62
+  Move         r30, r63
+  Jump         L6
+L3:
+  Move         r64, r2
+  // print("--- People grouped by city ---")
+  Const        r65, "--- People grouped by city ---"
+  Print        r65
+  // for s in stats {
+  IterPrep     r66, r64
+  Len          r67, r66
+  Const        r68, 0
+L8:
+  Less         r69, r68, r67
+  JumpIfFalse  r69, L7
+  Index        r70, r66, r68
+  Move         r71, r70
+  // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+  Const        r77, "city"
+  Index        r78, r71, r77
+  Move         r72, r78
+  Const        r79, ": count ="
+  Move         r73, r79
+  Const        r80, "count"
+  Index        r81, r71, r80
+  Move         r74, r81
+  Const        r82, ", avg_age ="
+  Move         r75, r82
+  Const        r83, "avg_age"
+  Index        r84, r71, r83
+  Move         r76, r84
+  PrintN       r72, 5, r72
+  // for s in stats {
+  Const        r85, 1
+  Add          r86, r68, r85
+  Move         r68, r86
+  Jump         L8
+L7:
+  Return       r0
+

--- a/tests/vm/valid/group_by.mochi
+++ b/tests/vm/valid/group_by.mochi
@@ -1,0 +1,20 @@
+// group-by.mochi
+let people = [
+  { name: "Alice", age: 30, city: "Paris" },
+  { name: "Bob", age: 15, city: "Hanoi" },
+  { name: "Charlie", age: 65, city: "Paris" },
+  { name: "Diana", age: 45, city: "Hanoi" },
+  { name: "Eve", age: 70, city: "Paris" },
+  { name: "Frank", age: 22, city: "Hanoi" }
+]
+let stats = from person in people
+            group by person.city into g
+            select {
+              city: g.key,
+              count: count(g),
+              avg_age: avg(from p in g select p.age)
+            }
+print("--- People grouped by city ---")
+for s in stats {
+  print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+}

--- a/tests/vm/valid/group_by.out
+++ b/tests/vm/valid/group_by.out
@@ -1,0 +1,3 @@
+--- People grouped by city ---
+Paris : count = 3 , avg_age = 55
+Hanoi : count = 3 , avg_age = 27.333333333333332


### PR DESCRIPTION
## Summary
- expand `runtime/vm` with minimal GROUP BY support
- allow builtins to operate on group values
- recognise groups in iterator preparation
- add golden test for grouping

## Testing
- `go test ./tests/vm -run .`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685aabfd2fcc8320bc73d6cf55b2d8f9