### PR TITLE
Add load/save support to vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,8 +613,6 @@ implemented across all backends:
 * Right and outer joins in dataset queries
 * Sorting or pagination when joins are used
 * Destructuring bindings in `let` and `var` statements
-* YAML dataset loading and saving
-* CSV dataset loading and saving
 * Agent and stream constructs (`agent`, `on`, `emit`)
 * Generative AI blocks and LLM helper functions
 * Model declarations (`model` blocks)

--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -25,6 +25,7 @@ The VM supports a small but useful subset of Mochi:
 * Function calls with any number of arguments
 * Anonymous function expressions
 * Built‑ins `len`, `print` (up to two arguments), `append`, `str`, `json`, `now`, `input`, `count`, `avg`, `min` and `max`
+* Dataset loading with `load` and saving with `save`
 * List, map and struct construction
 * String indexing to access individual characters
 * Field access using the `.` operator

--- a/tests/vm/valid/load_yaml.ir.out
+++ b/tests/vm/valid/load_yaml.ir.out
@@ -1,0 +1,67 @@
+func main (regs=43)
+  // let people = load "../interpreter/valid/people.yaml" as Person with { format: "yaml" }
+  Const        r0, "../interpreter/valid/people.yaml"
+  Const        r2, {"format": "yaml"}
+  Move         r1, r2
+  Load         3,0,1,0
+  Move         r4, r3
+  // let adults = from p in people
+  Const        r5, []
+  IterPrep     r6, r4
+  Len          r7, r6
+  Const        r8, 0
+L2:
+  Less         r9, r8, r7
+  JumpIfFalse  r9, L0
+  Index        r10, r6, r8
+  Move         r11, r10
+  // where p.age >= 18
+  Const        r12, "age"
+  Index        r13, r11, r12
+  Const        r14, 18
+  LessEq       r15, r14, r13
+  JumpIfFalse  r15, L1
+  // select { name: p.name, email: p.email }
+  Const        r16, "name"
+  Const        r17, "name"
+  Index        r18, r11, r17
+  Const        r19, "email"
+  Const        r20, "email"
+  Index        r21, r11, r20
+  Move         r22, r16
+  Move         r23, r18
+  Move         r24, r19
+  Move         r25, r21
+  MakeMap      r26, 2, r22
+  // let adults = from p in people
+  Append       r27, r5, r26
+  Move         r5, r27
+L1:
+  Const        r28, 1
+  Add          r29, r8, r28
+  Move         r8, r29
+  Jump         L2
+L0:
+  Move         r30, r5
+  // for a in adults {
+  IterPrep     r31, r30
+  Len          r32, r31
+  Const        r33, 0
+L4:
+  Less         r34, r33, r32
+  JumpIfFalse  r34, L3
+  Index        r35, r31, r33
+  Move         r36, r35
+  // print(a.name, a.email)
+  Const        r37, "name"
+  Index        r38, r36, r37
+  Const        r39, "email"
+  Index        r40, r36, r39
+  Print2       r38, r40
+  // for a in adults {
+  Const        r41, 1
+  Add          r42, r33, r41
+  Move         r33, r42
+  Jump         L4
+L3:
+  Return       r0

--- a/tests/vm/valid/load_yaml.mochi
+++ b/tests/vm/valid/load_yaml.mochi
@@ -1,0 +1,13 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+let people = load "../interpreter/valid/people.yaml" as Person with { format: "yaml" }
+let adults = from p in people
+             where p.age >= 18
+             select { name: p.name, email: p.email }
+for a in adults {
+  print(a.name, a.email)
+}

--- a/tests/vm/valid/load_yaml.out
+++ b/tests/vm/valid/load_yaml.out
@@ -1,0 +1,2 @@
+Alice alice@example.com
+Charlie charlie@example.com

--- a/tests/vm/valid/save_jsonl_stdout.ir.out
+++ b/tests/vm/valid/save_jsonl_stdout.ir.out
@@ -1,0 +1,10 @@
+func main (regs=6)
+  // let people = [
+  Const        r0, [{"age": 30, "name": "Alice"}, {"age": 25, "name": "Bob"}]
+  Move         r1, r0
+  // save people to "-" with { format: "jsonl" }
+  Const        r2, "-"
+  Const        r4, {"format": "jsonl"}
+  Move         r3, r4
+  Save         5,1,2,3
+  Return       r0

--- a/tests/vm/valid/save_jsonl_stdout.mochi
+++ b/tests/vm/valid/save_jsonl_stdout.mochi
@@ -1,0 +1,6 @@
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 25 }
+]
+
+save people to "-" with { format: "jsonl" }

--- a/tests/vm/valid/save_jsonl_stdout.out
+++ b/tests/vm/valid/save_jsonl_stdout.out
@@ -1,0 +1,2 @@
+{"age":30,"name":"Alice"}
+{"age":25,"name":"Bob"}

--- a/types/check.go
+++ b/types/check.go
@@ -1559,6 +1559,17 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 		}
 		return ListType{Elem: elem}, nil
 
+	case p.Save != nil:
+		if _, err := checkExpr(p.Save.Src, env); err != nil {
+			return VoidType{}, err
+		}
+		if p.Save.With != nil {
+			if _, err := checkExpr(p.Save.With, env); err != nil {
+				return VoidType{}, err
+			}
+		}
+		return VoidType{}, nil
+
 	case p.Match != nil:
 		return checkMatchExpr(p.Match, env, expected)
 


### PR DESCRIPTION
## Summary
- implement `OpSave` in the VM and compile step
- allow type checker to accept `save` expressions
- write helper functions for dataset saving
- document load/save support in the VM and update README limitations
- add VM tests for YAML loading and JSONL saving

## Testing
- `go test ./tests/vm -run TestVM_ValidPrograms/save_jsonl_stdout`
- `go test ./tests/vm -run TestVM_ValidPrograms/load_yaml`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685aa66e94bc8320991f0dff7a6ac19f