### PR TITLE
Add group-aware operations to VM runtime

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -47,7 +47,6 @@ experimental VM.  Unsupported areas include:
 * Asynchronous functions (`async`/`await`)
 * Agents, streams and intent blocks with persistent state
 * Agent initialization with field values
-* Grouping (`group by`) within dataset queries
 * Right and outer joins or pagination when joins are used
 * Generative AI blocks, model declarations and other LLM helpers
 * HTTP `fetch` expressions


### PR DESCRIPTION
## Summary
- extend `OpLen` and `OpIterPrep` to recognise group objects
- update arithmetic built-ins (`count`, `avg`, `min`, `max`) to work on groups
- remove outdated note from `runtime/vm/README.md`

## Testing
- `go test ./tests/vm -run .`


------
https://chatgpt.com/codex/tasks/task_e_685ab4ec0e888320a1ca747cf1210a4c