### PR TITLE
Add Dart string comparison support

### DIFF
--- a/tests/compiler/dart/string_compare.dart.out
+++ b/tests/compiler/dart/string_compare.dart.out
@@ -1,0 +1,6 @@
+void main() {
+        print(("a".compareTo("b") < 0));
+        print(("a".compareTo("a") <= 0));
+        print(("b".compareTo("a") > 0));
+        print(("b".compareTo("b") >= 0));
+}

--- a/tests/compiler/dart/string_compare.mochi
+++ b/tests/compiler/dart/string_compare.mochi
@@ -1,0 +1,4 @@
+print("a" < "b")
+print("a" <= "a")
+print("b" > "a")
+print("b" >= "b")

--- a/tests/compiler/dart/string_compare.out
+++ b/tests/compiler/dart/string_compare.out
@@ -1,0 +1,4 @@
+true
+true
+true
+true


### PR DESCRIPTION
## Summary
- add string comparison handling in the Dart compiler
- include a new string comparison test for Dart backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ab5caa31883208498e98cff26008d