### PR TITLE
Add v0.9.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 # 📦 CHANGELOG.md
+## [0.9.3] – 2025-06-24T22:34:20+07:00
+
+### Added
+
+* String indexing and concatenation in the VM
+* `min` and `max` builtins
+* Join, multi join and left join dataset queries
+* `sort`, `skip`, `take`, `load`, `save` and `group by` operations
+* List set operators in C, Dart and Elixir
+* List operation inference in the C# compiler
+* Basic query expression compilation with identifier map keys
+* Erlang tests for list operators
+
+### Changed
+
+* Benchmarks refreshed
+
+### Fixed
+
+* Identifier map keys handled correctly in the VM
+
 ## [0.9.2] – 2025-06-25
 
 ### Added

--- a/releases/v0.9.3.md
+++ b/releases/v0.9.3.md
@@ -1,0 +1,26 @@
+# Jun 2025 (v0.9.3)
+
+Released on Tue Jun 24 22:34:20 2025 +0700.
+
+Mochi v0.9.3 extends dataset queries and string capabilities. The VM introduces
+join operations and new builtins while compilers implement list set operators and
+inference improvements.
+
+## Runtime
+
+- String indexing and concatenation
+- `min` and `max` builtins
+- Join queries with multi and left join support
+- `sort`, `skip`, `take`, `load`, `save` and `group by` operations
+- Identifier map key handling and basic query compilation
+
+## Compilers
+
+- List set operators in C, Dart and Elixir
+- List operation inference in the C# compiler
+- Erlang tests for list operators
+
+## Tooling
+
+- Benchmarks refreshed
+- Documentation clarifies unsupported VM features


### PR DESCRIPTION
## Summary
- document v0.9.3 release notes
- update CHANGELOG for v0.9.3

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_685ac686d2a483209b0a0fb269a70e27