### PR TITLE
Improve Clojure string operator codegen

### DIFF
--- a/compile/x/clj/compiler.go
+++ b/compile/x/clj/compiler.go
@@ -675,7 +675,22 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 		return fmt.Sprintf("(%s %s %s)", opName, left, right), leftType
 	case "%":
 		return fmt.Sprintf("(%s %s %s)", opName, left, right), leftType
-	case "==", "!=", "<", "<=", ">", ">=":
+	case "==", "!=":
+		return fmt.Sprintf("(%s %s %s)", opName, left, right), types.BoolType{}
+	case "<", "<=", ">", ">=":
+		if isString(leftType) && isString(rightType) {
+			cmp := fmt.Sprintf("(compare %s %s)", left, right)
+			switch op {
+			case "<":
+				return fmt.Sprintf("(< %s 0)", cmp), types.BoolType{}
+			case "<=":
+				return fmt.Sprintf("(<= %s 0)", cmp), types.BoolType{}
+			case ">":
+				return fmt.Sprintf("(> %s 0)", cmp), types.BoolType{}
+			case ">=":
+				return fmt.Sprintf("(>= %s 0)", cmp), types.BoolType{}
+			}
+		}
 		return fmt.Sprintf("(%s %s %s)", opName, left, right), types.BoolType{}
 	case "&&", "||":
 		return fmt.Sprintf("(%s %s %s)", opName, left, right), types.BoolType{}

--- a/compile/x/clj/compiler_test.go
+++ b/compile/x/clj/compiler_test.go
@@ -21,7 +21,7 @@ func TestClojureCompiler_TwoSum(t *testing.T) {
 	if err := cljcode.EnsureClojure(); err != nil {
 		t.Skipf("clojure not installed: %v", err)
 	}
-	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	src := filepath.Join("..", "..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
@@ -41,6 +41,7 @@ func TestClojureCompiler_TwoSum(t *testing.T) {
 		t.Fatalf("write error: %v", err)
 	}
 	cmd := exec.Command("clojure", file)
+	cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clojure run error: %v\n%s", err, out)
@@ -76,6 +77,7 @@ func TestClojureCompiler_SubsetPrograms(t *testing.T) {
 			return nil, fmt.Errorf("write error: %w", err)
 		}
 		cmd := exec.Command("clojure", file)
+		cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar")
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}
@@ -114,7 +116,7 @@ func TestClojureCompiler_GoldenOutput(t *testing.T) {
 // the generated Clojure code. Any output is ignored; the test only checks that
 // the program executes without error.
 func runLeetExample(t *testing.T, id int) {
-	dir := filepath.Join("..", "..", "examples", "leetcode", fmt.Sprint(id))
+	dir := filepath.Join("..", "..", "..", "examples", "leetcode", fmt.Sprint(id))
 	files, err := filepath.Glob(filepath.Join(dir, "*.mochi"))
 	if err != nil {
 		t.Fatalf("glob error: %v", err)
@@ -141,6 +143,7 @@ func runLeetExample(t *testing.T, id int) {
 				t.Fatalf("write error: %v", err)
 			}
 			cmd := exec.Command("clojure", file)
+			cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar")
 			if data, err := os.ReadFile(strings.TrimSuffix(f, ".mochi") + ".in"); err == nil {
 				cmd.Stdin = bytes.NewReader(data)
 			}

--- a/compile/x/clj/tools.go
+++ b/compile/x/clj/tools.go
@@ -26,7 +26,7 @@ func EnsureClojure() error {
 			if err := cmd.Run(); err != nil {
 				return err
 			}
-			cmd = exec.Command("apt-get", "install", "-y", "clojure")
+			cmd = exec.Command("apt-get", "install", "-y", "clojure", "libdata-json-clojure", "libsnakeyaml-engine-java")
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err == nil {

--- a/tests/compiler/clj/string_compare.clj.out
+++ b/tests/compiler/clj/string_compare.clj.out
@@ -1,0 +1,10 @@
+(ns main)
+
+(defn -main []
+  (println (< (compare "a" "b") 0))
+  (println (<= (compare "a" "a") 0))
+  (println (> (compare "b" "a") 0))
+  (println (>= (compare "b" "b") 0))
+)
+
+(-main)

--- a/tests/compiler/clj/string_compare.mochi
+++ b/tests/compiler/clj/string_compare.mochi
@@ -1,0 +1,4 @@
+print("a" < "b")
+print("a" <= "a")
+print("b" > "a")
+print("b" >= "b")

--- a/tests/compiler/clj/string_compare.out
+++ b/tests/compiler/clj/string_compare.out
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/tests/compiler/clj/string_concat.clj.out
+++ b/tests/compiler/clj/string_concat.clj.out
@@ -1,0 +1,7 @@
+(ns main)
+
+(defn -main []
+  (println (str "hello " "world"))
+)
+
+(-main)

--- a/tests/compiler/clj/string_concat.mochi
+++ b/tests/compiler/clj/string_concat.mochi
@@ -1,0 +1,1 @@
+print("hello " + "world")

--- a/tests/compiler/clj/string_concat.out
+++ b/tests/compiler/clj/string_concat.out
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
## Summary
- handle string comparisons in Clojure backend
- add compiler golden tests for string concatenation and comparisons
- fix example paths in Clojure tests and install runtime deps
- run Clojure tests with appropriate classpath

## Testing
- `go test ./...`
- `go test ./compile/x/clj -tags slow` *(fails: parse error and missing libs)*

------
https://chatgpt.com/codex/tasks/task_e_685ab5b1a59c83208db2d6b2488c719c