### PR TITLE
Add Haskell string concatenation

### DIFF
--- a/tests/compiler/hs/string_concat.hs.out
+++ b/tests/compiler/hs/string_concat.hs.out
@@ -1,0 +1,93 @@
+module Main where
+
+import Data.Maybe (fromMaybe)
+
+
+forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
+forLoop start end f = go start
+  where
+    go i | i < end =
+            case f i of
+              Just v -> Just v
+              Nothing -> go (i + 1)
+         | otherwise = Nothing
+
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
+avg :: Real a => [a] -> Double
+avg xs | null xs = 0
+      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+_indexString :: String -> Int -> String
+_indexString s i =
+  let idx = if i < 0 then i + length s else i
+  in if idx < 0 || idx >= length s
+       then error "index out of range"
+       else [s !! idx]
+
+_input :: IO String
+_input = getLine
+
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+
+main :: IO ()
+main = do
+    putStrLn (("hello " ++ "world"))

--- a/tests/compiler/hs/string_concat.mochi
+++ b/tests/compiler/hs/string_concat.mochi
@@ -1,0 +1,1 @@
+print("hello " + "world")

--- a/tests/compiler/hs/string_concat.out
+++ b/tests/compiler/hs/string_concat.out
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
## Summary
- support string concatenation in Haskell compiler
- add regression tests for Haskell string concatenation

## Testing
- `go test ./compile/x/hs -tags slow -run TestHSCompiler_GoldenOutput/string_concat -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685ac6385a08832089f65760af0c702f