### PR TITLE
Implement string equality for Java compiler

### DIFF
--- a/tests/compiler/java/string_compare.java.out
+++ b/tests/compiler/java/string_compare.java.out
@@ -1,0 +1,6 @@
+public class Main {
+	public static void main(String[] args) {
+		System.out.println(java.util.Objects.equals("a", "a"));
+		System.out.println(!java.util.Objects.equals("a", "b"));
+	}
+}

--- a/tests/compiler/java/string_compare.mochi
+++ b/tests/compiler/java/string_compare.mochi
@@ -1,0 +1,2 @@
+print("a" == "a")
+print("a" != "b")

--- a/tests/compiler/java/string_compare.out
+++ b/tests/compiler/java/string_compare.out
@@ -1,0 +1,2 @@
+true
+true


### PR DESCRIPTION
## Summary
- extend Java compiler to detect string operands
- emit `java.util.Objects.equals` for `==` and `!=` on strings
- add a regression test for string comparison

## Testing
- `go test ./compile/x/java -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685ac63c119c83209130a6281c30748a