### PR TITLE
Add string comparison operators to PHP compiler

### DIFF
--- a/compile/x/php/helpers.go
+++ b/compile/x/php/helpers.go
@@ -2,6 +2,7 @@ package phpcode
 
 import (
 	"mochi/parser"
+	"mochi/types"
 	"strings"
 )
 
@@ -79,4 +80,61 @@ func identName(e *parser.Expr) (string, bool) {
 		return p.Target.Selector.Root, true
 	}
 	return "", false
+}
+
+func (c *Compiler) isStringExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return true
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		if t, err := c.env.GetVar(p.Target.Selector.Root); err == nil {
+			if _, ok := t.(types.StringType); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Compiler) isIntExpr(e *parser.Expr) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Int != nil {
+		return true
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		if t, err := c.env.GetVar(p.Target.Selector.Root); err == nil {
+			switch t.(type) {
+			case types.IntType, types.Int64Type:
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/tests/compiler/php/string_compare.mochi
+++ b/tests/compiler/php/string_compare.mochi
@@ -1,0 +1,4 @@
+print("a" < "b")
+print("a" <= "a")
+print("b" > "a")
+print("b" >= "b")

--- a/tests/compiler/php/string_compare.out
+++ b/tests/compiler/php/string_compare.out
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/tests/compiler/php/string_compare.php.out
+++ b/tests/compiler/php/string_compare.php.out
@@ -1,0 +1,5 @@
+<?php
+echo (strcmp(strval("a"), strval("b")) < 0), PHP_EOL;
+echo (strcmp(strval("a"), strval("a")) <= 0), PHP_EOL;
+echo (strcmp(strval("b"), strval("a")) > 0), PHP_EOL;
+echo (strcmp(strval("b"), strval("b")) >= 0), PHP_EOL;


### PR DESCRIPTION
## Summary
- improve PHP backend string comparisons
- add helper methods for type inference
- test PHP string comparison compiler output

## Testing
- `go test ./compile/x/php -run TestPHPCompiler_GoldenOutput/string_compare -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685ac64679f88320b0a0125b56b4509d