### PR TITLE
Add string slice helper for Rust backend

### DIFF
--- a/compile/x/rust/expressions.go
+++ b/compile/x/rust/expressions.go
@@ -442,25 +442,18 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				} else {
 					end = fmt.Sprintf("%s.len()", expr)
 				}
-				simpleStart := idx.Start != nil
-				if simpleStart {
-					_, simpleStart = identName(idx.Start)
-				}
-				simpleEnd := idx.End != nil
-				if simpleEnd {
-					_, simpleEnd = identName(idx.End)
-				}
 				if c.isStringBase(p) {
-					if simpleStart && simpleEnd {
-						expr = fmt.Sprintf("%s[%s as usize..%s as usize].to_string()", expr, start, end)
-					} else if simpleStart {
-						expr = fmt.Sprintf("%s[%s as usize..(%s) as usize].to_string()", expr, start, end)
-					} else if simpleEnd {
-						expr = fmt.Sprintf("%s[(%s) as usize..%s as usize].to_string()", expr, start, end)
-					} else {
-						expr = fmt.Sprintf("%s[(%s) as usize..(%s) as usize].to_string()", expr, start, end)
-					}
+					c.use("_slice_string")
+					expr = fmt.Sprintf("_slice_string(%s, %s, %s)", expr, start, end)
 				} else {
+					simpleStart := idx.Start != nil
+					if simpleStart {
+						_, simpleStart = identName(idx.Start)
+					}
+					simpleEnd := idx.End != nil
+					if simpleEnd {
+						_, simpleEnd = identName(idx.End)
+					}
 					if simpleStart && simpleEnd {
 						expr = fmt.Sprintf("%s[%s as usize..%s as usize].to_vec()", expr, start, end)
 					} else if simpleStart {

--- a/compile/x/rust/runtime.go
+++ b/compile/x/rust/runtime.go
@@ -11,6 +11,19 @@ const (
 		"    chars[idx as usize].to_string()\n" +
 		"}\n"
 
+	helperSliceString = "fn _slice_string(s: &str, start: i64, end: i64) -> String {\n" +
+		"    let mut sidx = start;\n" +
+		"    let mut eidx = end;\n" +
+		"    let chars: Vec<char> = s.chars().collect();\n" +
+		"    let n = chars.len() as i64;\n" +
+		"    if sidx < 0 { sidx += n; }\n" +
+		"    if eidx < 0 { eidx += n; }\n" +
+		"    if sidx < 0 { sidx = 0; }\n" +
+		"    if eidx > n { eidx = n; }\n" +
+		"    if eidx < sidx { eidx = sidx; }\n" +
+		"    chars[sidx as usize..eidx as usize].iter().collect()\n" +
+		"}\n"
+
 	helperMapGet = "fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {\n" +
 		"    m.get(k).unwrap().clone()\n" +
 		"}\n"
@@ -96,6 +109,7 @@ const (
 
 var helperMap = map[string]string{
 	"_index_string": helperIndexString,
+	"_slice_string": helperSliceString,
 	"_map_get":      helperMapGet,
 	"_count":        helperCount,
 	"_avg":          helperAvg,

--- a/tests/compiler/rust/string_slice.rs.out
+++ b/tests/compiler/rust/string_slice.rs.out
@@ -1,4 +1,16 @@
 fn main() {
-    println!("{}", "hello"[(1) as usize..(4) as usize].to_string());
+    println!("{}", _slice_string("hello", 1, 4));
 }
 
+fn _slice_string(s: &str, start: i64, end: i64) -> String {
+    let mut sidx = start;
+    let mut eidx = end;
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len() as i64;
+    if sidx < 0 { sidx += n; }
+    if eidx < 0 { eidx += n; }
+    if sidx < 0 { sidx = 0; }
+    if eidx > n { eidx = n; }
+    if eidx < sidx { eidx = sidx; }
+    chars[sidx as usize..eidx as usize].iter().collect()
+}


### PR DESCRIPTION
## Summary
- add `_slice_string` helper to Rust runtime and register it
- use `_slice_string` when compiling string slicing expressions
- update Rust golden output for string slicing

## Testing
- `go vet ./...`
- `go test -tags slow ./compile/x/rust -run TestRustCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685ac64d0c548320b70e7ad289eb647a