### PR TITLE
Add string concatenation to Scheme compiler

### DIFF
--- a/compile/x/scheme/compiler.go
+++ b/compile/x/scheme/compiler.go
@@ -502,7 +502,9 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 		}
 		switch op.Op {
 		case "+":
-			if isListUnary(leftAst) || isListPostfix(rightAst) {
+			if c.isStringUnary(leftAst) || c.isStringPostfix(rightAst) {
+				expr = fmt.Sprintf("(string-append %s %s)", expr, right)
+			} else if isListUnary(leftAst) || isListPostfix(rightAst) {
 				expr = fmt.Sprintf("(append %s %s)", expr, right)
 			} else {
 				expr = fmt.Sprintf("(+ %s %s)", expr, right)

--- a/tests/compiler/scheme/string_concat.mochi
+++ b/tests/compiler/scheme/string_concat.mochi
@@ -1,0 +1,1 @@
+print("hello " + "world")

--- a/tests/compiler/scheme/string_concat.out
+++ b/tests/compiler/scheme/string_concat.out
@@ -1,0 +1,1 @@
+hello world

--- a/tests/compiler/scheme/string_concat.scm.out
+++ b/tests/compiler/scheme/string_concat.scm.out
@@ -1,0 +1,1 @@
+(begin (display (string-append "hello " "world")) (newline))


### PR DESCRIPTION
## Summary
- implement `+` for strings in Scheme backend
- add Scheme test for string concatenation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ac650d250832080d922edc4a6ced1