### PR TITLE
Add string and list concatenation to Zig backend

### DIFF
--- a/compile/x/zig/README.md
+++ b/compile/x/zig/README.md
@@ -225,7 +225,8 @@ translate to `list.append(x)`, and `while` statements map directly to Zig's
 temporary counter and `while` loop for the step value. `break` and `continue`
 pass through unchanged. List membership
 checks using the `in` operator compile to helper functions for integer and
-string lists.
+string lists. String and list concatenation with `+` emit calls to
+`_concat_string` or `_concat_list`.
 
 List literals are emitted as fixed-size arrays or references when used in return
 expressions. Reserved words are prefixed with `_` by `sanitizeName`:

--- a/compile/x/zig/builtins.go
+++ b/compile/x/zig/builtins.go
@@ -160,6 +160,30 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("}")
 		c.writeln("")
 	}
+	if c.needsConcatList {
+		c.writeln("fn _concat_list(comptime T: type, a: []const T, b: []const T) []T {")
+		c.indent++
+		c.writeln("var res = std.ArrayList(T).init(std.heap.page_allocator);")
+		c.writeln("defer res.deinit();")
+		c.writeln("for (a) |it| { res.append(it) catch unreachable; }")
+		c.writeln("for (b) |it| { res.append(it) catch unreachable; }")
+		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("")
+	}
+	if c.needsConcatString {
+		c.writeln("fn _concat_string(a: []const u8, b: []const u8) []const u8 {")
+		c.indent++
+		c.writeln("var res = std.ArrayList(u8).init(std.heap.page_allocator);")
+		c.writeln("defer res.deinit();")
+		c.writeln("res.appendSlice(a) catch unreachable;")
+		c.writeln("res.appendSlice(b) catch unreachable;")
+		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("")
+	}
 	if c.needsReduce {
 		c.writeln("fn _reduce(comptime T: type, v: []const T, init: T, f: fn (T, T) T) T {")
 		c.indent++

--- a/tests/compiler/zig/string_concat.mochi
+++ b/tests/compiler/zig/string_concat.mochi
@@ -1,0 +1,1 @@
+print("hello " + "world")

--- a/tests/compiler/zig/string_concat.out
+++ b/tests/compiler/zig/string_concat.out
@@ -1,0 +1,1 @@
+hello world

--- a/tests/compiler/zig/string_concat.zig.out
+++ b/tests/compiler/zig/string_concat.zig.out
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+fn _concat_string(a: []const u8, b: []const u8) []const u8 {
+	var res = std.ArrayList(u8).init(std.heap.page_allocator);
+	defer res.deinit();
+	res.appendSlice(a) catch unreachable;
+	res.appendSlice(b) catch unreachable;
+	return res.toOwnedSlice() catch unreachable;
+}
+
+pub fn main() void {
+	std.debug.print("{s}\n", .{_concat_string("hello ", "world")});
+}


### PR DESCRIPTION
## Summary
- support `_concat_list` and `_concat_string` helpers in the Zig backend
- detect string and list `+` operations when generating Zig code
- document the new helpers
- add test coverage for string concatenation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ac658b95c8320ae6010e0d15247cd