### PR TITLE
Improve Dart string quoting

### DIFF
--- a/compile/x/dart/compiler.go
+++ b/compile/x/dart/compiler.go
@@ -923,11 +923,10 @@ func (c *Compiler) compileLiteral(lit *parser.Literal) (string, error) {
 	case lit.Float != nil:
 		return strconv.FormatFloat(*lit.Float, 'f', -1, 64), nil
 	case lit.Str != nil:
-		s := *lit.Str
-		s = strings.ReplaceAll(s, "\\", "\\\\")
-		s = strings.ReplaceAll(s, "\"", "\\\"")
-		s = strings.ReplaceAll(s, "$", "\\$")
-		return "\"" + s + "\"", nil
+		// Use Go's quoting to handle escape sequences then protect
+		// `$` from Dart interpolation.
+		s := strings.ReplaceAll(*lit.Str, "$", "\\$")
+		return strconv.Quote(s), nil
 	case lit.Bool != nil:
 		if *lit.Bool {
 			return "true", nil

--- a/tests/compiler/dart/string_escape.dart.out
+++ b/tests/compiler/dart/string_escape.dart.out
@@ -1,0 +1,3 @@
+void main() {
+        print("price is \$5\\nnext line");
+}

--- a/tests/compiler/dart/string_escape.mochi
+++ b/tests/compiler/dart/string_escape.mochi
@@ -1,0 +1,1 @@
+print("price is $5\nnext line")

--- a/tests/compiler/dart/string_escape.out
+++ b/tests/compiler/dart/string_escape.out
@@ -1,0 +1,2 @@
+price is $5
+next line


### PR DESCRIPTION
## Summary
- use `strconv.Quote` when emitting Dart string literals and escape `$`
- add new `string_escape` golden test for Dart backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ad46e9a488320844450cd9cb8f77b