### PR TITLE
Enhance runtime/vm for dataset related features

### DIFF
--- a/tests/vm/valid/right_join.ir.out
+++ b/tests/vm/valid/right_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=102)
+func main (regs=87)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}, {"id": 4, "name": "Diana"}]
   Move         r1, r0
@@ -12,171 +12,136 @@ func main (regs=102)
   // right join o in orders on o.customerId == c.id
   IterPrep     r7, r3
   Len          r8, r7
+  Const        r11, 0
+L5:
+  Less         r12, r11, r8
+  JumpIfFalse  r12, L0
+  Index        r13, r7, r11
+  Move         r9, r13
+  Const        r14, false
   // let result = from c in customers
-  Const        r9, 0
-L4:
-  Less         r10, r9, r6
-  JumpIfFalse  r10, L0
-  Index        r11, r5, r9
-  Move         r12, r11
-  // right join o in orders on o.customerId == c.id
-  Const        r13, 0
+  Const        r15, 0
 L3:
-  Less         r14, r13, r8
-  JumpIfFalse  r14, L1
-  Index        r15, r7, r13
-  Move         r16, r15
-  Const        r17, "customerId"
-  Index        r18, r16, r17
-  Const        r19, "id"
-  Index        r20, r12, r19
-  Equal        r21, r18, r20
-  JumpIfFalse  r21, L2
-  // customerName: c.name,
-  Const        r22, "customerName"
-  Const        r23, "name"
-  Index        r24, r12, r23
-  // order: o
-  Const        r25, "order"
-  // customerName: c.name,
-  Move         r26, r22
-  Move         r27, r24
-  // order: o
-  Move         r28, r25
-  Move         r29, r16
-  // select {
-  MakeMap      r30, 2, r26
-  // let result = from c in customers
-  Append       r31, r4, r30
-  Move         r4, r31
-L2:
+  Less         r16, r15, r6
+  JumpIfFalse  r16, L1
+  Index        r17, r5, r15
+  Move         r10, r17
   // right join o in orders on o.customerId == c.id
-  Const        r32, 1
-  Add          r33, r13, r32
-  Move         r13, r33
+  Const        r18, "customerId"
+  Index        r19, r9, r18
+  Const        r20, "id"
+  Index        r21, r10, r20
+  Equal        r22, r19, r21
+  JumpIfFalse  r22, L2
+  Const        r14, true
+  // customerName: c.name,
+  Const        r23, "customerName"
+  Const        r24, "name"
+  Index        r25, r10, r24
+  // order: o
+  Const        r26, "order"
+  // customerName: c.name,
+  Move         r27, r23
+  Move         r28, r25
+  // order: o
+  Move         r29, r26
+  Move         r30, r9
+  // select {
+  MakeMap      r31, 2, r27
+  // let result = from c in customers
+  Append       r32, r4, r31
+  Move         r4, r32
+L2:
+  Const        r33, 1
+  Add          r34, r15, r33
+  Move         r15, r34
   Jump         L3
 L1:
-  // let result = from c in customers
-  Const        r34, 1
-  Add          r35, r9, r34
-  Move         r9, r35
-  Jump         L4
-L0:
   // right join o in orders on o.customerId == c.id
-  Const        r36, 0
-L10:
-  Less         r37, r36, r8
-  JumpIfFalse  r37, L5
-  Index        r38, r7, r36
-  Move         r16, r38
-  Const        r39, false
-  // let result = from c in customers
-  Const        r40, 0
-L8:
-  Less         r41, r40, r6
-  JumpIfFalse  r41, L6
-  Index        r42, r5, r40
-  Move         r12, r42
-  // right join o in orders on o.customerId == c.id
-  Const        r43, "customerId"
-  Index        r44, r16, r43
-  Const        r45, "id"
-  Index        r46, r12, r45
-  Equal        r47, r44, r46
-  JumpIfFalse  r47, L7
-  Const        r39, true
-L7:
-  // let result = from c in customers
-  Const        r48, 1
-  Add          r49, r40, r48
-  Move         r40, r49
-  Jump         L8
-L6:
-  // right join o in orders on o.customerId == c.id
-  Move         r50, r39
-  JumpIfTrue   r50, L9
-  Const        r51, nil
-  Move         r12, r51
+  Move         r35, r14
+  JumpIfTrue   r35, L4
+  Const        r36, nil
+  Move         r10, r36
   // customerName: c.name,
-  Const        r52, "customerName"
-  Const        r53, "name"
-  Index        r54, r12, r53
+  Const        r37, "customerName"
+  Const        r38, "name"
+  Index        r39, r10, r38
   // order: o
-  Const        r55, "order"
+  Const        r40, "order"
   // customerName: c.name,
-  Move         r56, r52
-  Move         r57, r54
+  Move         r41, r37
+  Move         r42, r39
   // order: o
-  Move         r58, r55
-  Move         r59, r16
+  Move         r43, r40
+  Move         r44, r9
   // select {
-  MakeMap      r60, 2, r56
+  MakeMap      r45, 2, r41
   // let result = from c in customers
-  Append       r61, r4, r60
-  Move         r4, r61
-L9:
+  Append       r46, r4, r45
+  Move         r4, r46
+L4:
   // right join o in orders on o.customerId == c.id
-  Const        r62, 1
-  Add          r63, r36, r62
-  Move         r36, r63
-  Jump         L10
-L5:
+  Const        r47, 1
+  Add          r48, r11, r47
+  Move         r11, r48
+  Jump         L5
+L0:
   // let result = from c in customers
-  Move         r64, r4
+  Move         r49, r4
   // print("--- Right Join using syntax ---")
-  Const        r65, "--- Right Join using syntax ---"
-  Print        r65
+  Const        r50, "--- Right Join using syntax ---"
+  Print        r50
   // for entry in result {
-  IterPrep     r66, r64
-  Len          r67, r66
-  Const        r68, 0
-L14:
-  Less         r69, r68, r67
-  JumpIfFalse  r69, L11
-  Index        r70, r66, r68
-  Move         r71, r70
+  IterPrep     r51, r49
+  Len          r52, r51
+  Const        r53, 0
+L9:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L6
+  Index        r55, r51, r53
+  Move         r56, r55
   // if entry.order {
-  Const        r72, "order"
-  Index        r73, r71, r72
-  JumpIfFalse  r73, L12
+  Const        r57, "order"
+  Index        r58, r56, r57
+  JumpIfFalse  r58, L7
   // print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
-  Const        r80, "Customer"
-  Move         r74, r80
-  Const        r81, "customerName"
-  Index        r82, r71, r81
-  Move         r75, r82
-  Const        r83, "has order"
-  Move         r76, r83
-  Const        r84, "order"
-  Index        r85, r71, r84
-  Const        r86, "id"
-  Index        r87, r85, r86
-  Move         r77, r87
-  Const        r88, "- $"
-  Move         r78, r88
-  Const        r89, "order"
-  Index        r90, r71, r89
-  Const        r91, "total"
-  Index        r92, r90, r91
-  Move         r79, r92
-  PrintN       r74, 6, r74
+  Const        r65, "Customer"
+  Move         r59, r65
+  Const        r66, "customerName"
+  Index        r67, r56, r66
+  Move         r60, r67
+  Const        r68, "has order"
+  Move         r61, r68
+  Const        r69, "order"
+  Index        r70, r56, r69
+  Const        r71, "id"
+  Index        r72, r70, r71
+  Move         r62, r72
+  Const        r73, "- $"
+  Move         r63, r73
+  Const        r74, "order"
+  Index        r75, r56, r74
+  Const        r76, "total"
+  Index        r77, r75, r76
+  Move         r64, r77
+  PrintN       r59, 6, r59
   // if entry.order {
-  Jump         L13
-L12:
+  Jump         L8
+L7:
   // print("Customer", entry.customerName, "has no orders")
-  Const        r96, "Customer"
-  Move         r93, r96
-  Const        r97, "customerName"
-  Index        r98, r71, r97
-  Move         r94, r98
-  Const        r99, "has no orders"
-  Move         r95, r99
-  PrintN       r93, 3, r93
-L13:
+  Const        r81, "Customer"
+  Move         r78, r81
+  Const        r82, "customerName"
+  Index        r83, r56, r82
+  Move         r79, r83
+  Const        r84, "has no orders"
+  Move         r80, r84
+  PrintN       r78, 3, r78
+L8:
   // for entry in result {
-  Const        r100, 1
-  Add          r101, r68, r100
-  Move         r68, r101
-  Jump         L14
-L11:
+  Const        r85, 1
+  Add          r86, r53, r85
+  Move         r53, r86
+  Jump         L9
+L6:
   Return       r0

--- a/tests/vm/valid/right_join.out
+++ b/tests/vm/valid/right_join.out
@@ -1,4 +1,4 @@
 --- Right Join using syntax ---
 Customer Alice has order 100 - $ 250
-Customer Alice has order 102 - $ 300
 Customer Bob has order 101 - $ 125
+Customer Alice has order 102 - $ 300


### PR DESCRIPTION
## Summary
- handle right join ordering correctly in vm
- regenerate IR golden for right join

## Testing
- `go test ./tests/vm -run TestVM_IR/right_join -update`
- `go test ./tests/vm -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685accff81b883209e177b807bf9f3b4