### PR TITLE
Add string containment operator for F# backend

### DIFF
--- a/compile/x/fs/compiler.go
+++ b/compile/x/fs/compiler.go
@@ -1060,6 +1060,8 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 				} else if op == "in" {
 					if maps[i+1] {
 						operands[i] = fmt.Sprintf("Map.containsKey %s %s", left, right)
+					} else if strs[i+1] {
+						operands[i] = fmt.Sprintf("%s.Contains(%s)", right, left)
 					} else {
 						operands[i] = fmt.Sprintf("Array.contains %s %s", left, right)
 					}

--- a/tests/compiler/fs/string_in.fs.out
+++ b/tests/compiler/fs/string_in.fs.out
@@ -1,0 +1,4 @@
+open System
+
+ignore (printfn "%A" ("catch".Contains("cat")))
+ignore (printfn "%A" ("catch".Contains("dog")))

--- a/tests/compiler/fs/string_in.mochi
+++ b/tests/compiler/fs/string_in.mochi
@@ -1,0 +1,2 @@
+print("cat" in "catch")
+print("dog" in "catch")

--- a/tests/compiler/fs/string_in.out
+++ b/tests/compiler/fs/string_in.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- enhance F# backend to support `in` for strings
- add `string_in` golden tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ad47753288320913c6535b7a6ea73