### PR TITLE
Enhance dataset load casting in VM

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -25,7 +25,7 @@ The VM supports a small but useful subset of Mochi:
 * Function calls with any number of arguments
 * Anonymous function expressions
 * Built‑ins `len`, `print` (up to two arguments), `append`, `str`, `json`, `now`, `input`, `count`, `avg`, `min` and `max`
-* Dataset loading with `load` and saving with `save`
+* Dataset loading with `load` (optionally casting rows to a type) and saving with `save`
 * List, map and struct construction
 * String indexing to access individual characters
 * Field access using the `.` operator


### PR DESCRIPTION
## Summary
- document that `load` can cast dataset rows to a type
- store desired type when compiling `load`
- cast rows to the provided type at runtime

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ad5f1e6e883208ef1331ee6122839