### PR TITLE
Add release notes for v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # 📦 CHANGELOG.md
+## [0.9.4] – 2025-06-25T00:02:13+07:00
+
+### Added
+
+* Typed dataset loading in the VM
+* Group query left joins with group-by
+* String indexing, slicing, membership and concatenation across languages
+* `upper` and `lower` string builtins
+* `union_all` list operator support
+
+### Changed
+
+* TinyGo build stubs and playground updates
+
+### Fixed
+
+* Right join ordering bug in the VM
+* Prolog and C++ compiler tests
+
 ## [0.9.3] – 2025-06-24T22:34:20+07:00
 
 ### Added

--- a/releases/v0.9.4.md
+++ b/releases/v0.9.4.md
@@ -1,0 +1,26 @@
+# Jun 2025 (v0.9.4)
+
+Released on Wed Jun 25 00:02:13 2025 +0700.
+
+Mochi v0.9.4 expands string handling and query capabilities. The VM adds typed
+loading and better join operations while many compilers gain slicing and
+concatenation features.
+
+## Runtime
+
+- Typed dataset loading
+- Group query left joins
+- Group by with joins
+
+## Compilers
+
+- String indexing, slicing and membership across languages
+- Concatenation with automatic conversions
+- `upper` and `lower` string builtins
+- `union_all` list operator support
+
+## Tooling
+
+- TinyGo build stubs and playground updates
+- Additional string operator tests
+- Fixes for Prolog and C++ compiler tests


### PR DESCRIPTION
## Summary
- document release highlights for v0.9.4
- add entry to CHANGELOG

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ada4235b08320a6ca5ec756506e68