### PR TITLE
Document dataset query support in VM

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -26,6 +26,7 @@ The VM supports a small but useful subset of Mochi:
 * Anonymous function expressions
 * Built‑ins `len`, `print` (up to two arguments), `append`, `str`, `json`, `now`, `input`, `count`, `avg`, `min` and `max`
 * Dataset loading with `load` (optionally casting rows to a type) and saving with `save`
+* Dataset queries using `from`, `join`, `group by`, `sort by`, `skip`, `take` and `select`
 * List, map and struct construction
 * String indexing to access individual characters
 * Field access using the `.` operator


### PR DESCRIPTION
## Summary
- document dataset query support in `runtime/vm/README.md`

## Testing
- `go test ./tests/vm -run ^TestVM_ErrorStackTrace$`
- `go test ./tests/vm -run . -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685adab5ec048320be25efc18e29096b