### PR TITLE
Support negative list indexing in Erlang backend

### DIFF
--- a/compile/x/erlang/compiler.go
+++ b/compile/x/erlang/compiler.go
@@ -907,18 +907,16 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					res = fmt.Sprintf("maps:get(%s, %s)", idx, res)
 					typ = tt.Value
 				case types.ListType:
-					res = fmt.Sprintf("lists:nth(%s + 1, %s)", idx, res)
+					c.needGet = true
+					res = fmt.Sprintf("mochi_get(%s, %s)", res, idx)
 					typ = tt.Elem
 				case types.StringType:
-					res = fmt.Sprintf("lists:nth(%s + 1, %s)", idx, res)
+					c.needGet = true
+					res = fmt.Sprintf("mochi_get(%s, %s)", res, idx)
 					typ = types.StringType{}
 				default:
-					if isStringExpr(op.Index.Start, c.env) {
-						c.needGet = true
-						res = fmt.Sprintf("mochi_get(%s, %s)", res, idx)
-					} else {
-						res = fmt.Sprintf("lists:nth(%s + 1, %s)", idx, res)
-					}
+					c.needGet = true
+					res = fmt.Sprintf("mochi_get(%s, %s)", res, idx)
 					typ = types.AnyType{}
 				}
 			}

--- a/compile/x/erlang/runtime.go
+++ b/compile/x/erlang/runtime.go
@@ -84,7 +84,12 @@ func (c *Compiler) emitRuntime() {
 
 	if c.needGet {
 		c.writeln("")
-		c.writeln("mochi_get(M, K) when is_list(M), is_integer(K) -> lists:nth(K + 1, M);")
+		c.writeln("mochi_get(L, I) when is_list(L), is_integer(I) ->")
+		c.indent++
+		c.writeln("N = length(L),")
+		c.writeln("Idx = case I >= 0 of true -> I + 1; false -> N + I + 1 end,")
+		c.writeln("lists:nth(Idx, L);")
+		c.indent--
 		c.writeln("mochi_get(M, K) when is_map(M) -> maps:get(K, M);")
 		c.writeln("mochi_get(_, _) -> erlang:error(badarg).")
 	}


### PR DESCRIPTION
## Summary
- handle negative list indexes in `mochi_get` runtime helper
- use `mochi_get` for list and string indexing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685adb2e36048320ba09c3cec9401102