### PR TITLE
Update Ruby backend docs for list ops

### DIFF
--- a/compile/x/rb/README.md
+++ b/compile/x/rb/README.md
@@ -157,7 +157,7 @@ The Ruby backend covers a wide slice of Mochi. Implemented functionality include
 - Function definitions and calls
 - Control flow with `if`, `for` and `while`
 - Structs, unions and pattern matching with `match`
-- Lists and maps with indexing and slicing
+- Lists and maps with indexing, slicing, membership checks and concatenation
 - Dataset queries with `from`, `join`, `left join`, `right join`, `where`, `group by`, `sort`, `skip` and `take`
 - Set operations such as `union`, `union all`, `except` and `intersect`
 - Built‑in helpers including `fetch`, `load`, `save` and placeholder LLM generation


### PR DESCRIPTION
## Summary
- clarify support for membership checks and concatenation in Ruby backend docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685adb4fdc188320a40ae358082e3ec7