### PR TITLE
Enable map iteration in F# backend

### DIFF
--- a/compile/x/fs/README.md
+++ b/compile/x/fs/README.md
@@ -120,6 +120,7 @@ Mochi features are not yet available.
 * `for` and `while` loops with `break` and `continue`
 * Pattern matching and conditional statements
 * Lists and maps with indexing and slicing
+* Iterating over maps with `for` loops
 * List concatenation using `+`
 * Membership tests with `in`
 * Query expressions with `where`, `sort`, `skip` and `take`
@@ -149,7 +150,6 @@ The F# generator still lacks support for several language constructs:
 * `model` declarations and agent initialization
 * Package declarations using `package`
 * Destructuring bindings in `let`/`var` statements
-* Iterating over maps with `for` loops
 * Functions with multiple return values
 * Set collections (`set<T>`) and related operations
 * Automatic language imports (`import python "..." auto`)

--- a/tests/compiler/fs/map_iterate.fs.out
+++ b/tests/compiler/fs/map_iterate.fs.out
@@ -1,0 +1,9 @@
+open System
+
+let mutable m: Map<int,bool> = Map.empty
+m <- Map.add 1 true m
+m <- Map.add 2 true m
+let mutable sum = 0
+for k in Map.keys m do
+    sum <- sum + k
+ignore (printfn "%A" (sum))

--- a/tests/compiler/fs/map_iterate.mochi
+++ b/tests/compiler/fs/map_iterate.mochi
@@ -1,0 +1,8 @@
+var m: map<int, bool> = {}
+m[1] = true
+m[2] = true
+var sum = 0
+for k in m {
+  sum = sum + k
+}
+print(sum)


### PR DESCRIPTION
## Summary
- support iterating over maps in `for` loops
- document this new capability
- add regression test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ae29b32a4832091b63a88b5ca37a4