### PR TITLE
Enhance vm data handling

### DIFF
--- a/runtime/vm/ERRORS.md
+++ b/runtime/vm/ERRORS.md
@@ -7,31 +7,10 @@ run error: too many args
 exit status 1
 ```
 
-## tests/interpreter/valid/cross_join.mochi
-
-```
-run error: invalid map key
-exit status 1
-```
-
-## tests/interpreter/valid/cross_join_triple.mochi
-
-```
-run error: invalid iterator
-exit status 1
-```
-
 ## tests/interpreter/valid/datalog.mochi
 
 ```
 run error: invalid iterator
-exit status 1
-```
-
-## tests/interpreter/valid/dataset_sort_take_limit.mochi
-
-```
-run error: invalid map key
 exit status 1
 ```
 
@@ -95,48 +74,6 @@ run error: invalid index target
 exit status 1
 ```
 
-## tests/interpreter/valid/group_by.mochi
-
-```
-run error: invalid map key
-exit status 1
-```
-
-## tests/interpreter/valid/inner_join.mochi
-
-```
-run error: invalid map key
-exit status 1
-```
-
-## tests/interpreter/valid/left_join.mochi
-
-```
-run error: invalid map key
-exit status 1
-```
-
-## tests/interpreter/valid/load_csv.mochi
-
-```
-run error: open ../tests/interpreter/valid/people.csv: no such file or directory
-exit status 1
-```
-
-## tests/interpreter/valid/load_jsonl.mochi
-
-```
-run error: invalid map key
-exit status 1
-```
-
-## tests/interpreter/valid/load_yaml.mochi
-
-```
-run error: invalid map key
-exit status 1
-```
-
 ## tests/interpreter/valid/local_import.mochi
 
 ```
@@ -148,41 +85,6 @@ exit status 1
 
 ```
 run error: invalid index target
-exit status 1
-```
-
-## tests/interpreter/valid/match_expr.mochi
-
-```
-golden mismatch:
--- got --
-<nil>
--- want --
-two
-```
-
-## tests/interpreter/valid/match_full.mochi
-
-```
-golden mismatch:
--- got --
-<nil>
-<nil>
-<nil>
-<nil>
-<nil>
--- want --
-two
-relaxed
-confirmed
-zero
-many
-```
-
-## tests/interpreter/valid/outer_join.mochi
-
-```
-run error: invalid map key
 exit status 1
 ```
 
@@ -221,18 +123,11 @@ run error: invalid index target
 exit status 1
 ```
 
-## tests/interpreter/valid/right_join.mochi
-
-```
-run error: invalid map key
-exit status 1
-```
-
 ## tests/interpreter/valid/short_circuit.mochi
 
 ```
 type error: error[T020]: operator `&&` cannot be used on types bool and void
-  --> short_circuit.mochi:5:13
+  --> /workspace/mochi/tests/interpreter/valid/short_circuit.mochi:5:13
 
   5 | print(false && boom())
     |             ^
@@ -247,16 +142,6 @@ exit status 1
 ```
 run error: invalid index target
 exit status 1
-```
-
-## tests/interpreter/valid/tree_sum.mochi
-
-```
-golden mismatch:
--- got --
-<nil>
--- want --
-3
 ```
 
 ## tests/interpreter/valid/ts_auto.mochi

--- a/runtime/vm/cmd/runvm/main.go
+++ b/runtime/vm/cmd/runvm/main.go
@@ -24,6 +24,22 @@ func main() {
 			src = abs
 		}
 	}
+	if err := os.Chdir(filepath.Dir(src)); err != nil {
+		fmt.Fprintln(os.Stderr, "chdir:", err)
+		os.Exit(1)
+	}
+	root := filepath.Dir(src)
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			break
+		}
+		root = parent
+	}
+	os.Setenv("MOCHI_ROOT", root)
 	prog, err := parser.Parse(src)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "parse error:", err)


### PR DESCRIPTION
## Summary
- support resolving data file paths relative to the repo root
- expose repository root path via `MOCHI_ROOT`
- runvm now sets working directory and env before execution
- regenerate interpreter golden failure list after update

## Testing
- `go test ./tests/vm -run .`
- `go run ./runtime/vm/cmd/interpreter_golden`

------
https://chatgpt.com/codex/tasks/task_e_685ae2de5ddc8320aab2a9abe9cc9d94