### PR TITLE
Add keys and values builtins to Zig backend

### DIFF
--- a/compile/x/zig/README.md
+++ b/compile/x/zig/README.md
@@ -200,6 +200,8 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 }
 ```
 When applied to maps, `len` and `count` use the container's `count()` method.
+The helpers `_map_keys` and `_map_values` build slices of all keys or values
+respectively when the `keys` or `values` builtin is used.
 【F:compile/zig/compiler.go†L624-L698】
 
 ### Struct Types

--- a/compile/x/zig/builtins.go
+++ b/compile/x/zig/builtins.go
@@ -220,6 +220,30 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("}")
 		c.writeln("")
 	}
+	if c.needsMapKeys {
+		c.writeln("fn _map_keys(comptime K: type, comptime V: type, m: std.AutoHashMap(K, V)) []K {")
+		c.indent++
+		c.writeln("var res = std.ArrayList(K).init(std.heap.page_allocator);")
+		c.writeln("defer res.deinit();")
+		c.writeln("var it = m.keyIterator();")
+		c.writeln("while (it.next()) |k_ptr| { res.append(k_ptr.*) catch unreachable; }")
+		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("")
+	}
+	if c.needsMapValues {
+		c.writeln("fn _map_values(comptime K: type, comptime V: type, m: std.AutoHashMap(K, V)) []V {")
+		c.indent++
+		c.writeln("var res = std.ArrayList(V).init(std.heap.page_allocator);")
+		c.writeln("defer res.deinit();")
+		c.writeln("var it = m.valueIterator();")
+		c.writeln("while (it.next()) |v_ptr| { res.append(v_ptr.*) catch unreachable; }")
+		c.writeln("return res.toOwnedSlice() catch unreachable;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("")
+	}
 	if c.needsEqual {
 		c.writeln("fn _equal(a: anytype, b: anytype) bool {")
 		c.indent++


### PR DESCRIPTION
## Summary
- extend Zig compiler builtins for map key/value slices
- generate helper functions `_map_keys` and `_map_values`
- document map helpers in Zig backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ae52dca2c83208aab1f2ebbf4509e