### PR TITLE
Support nested recursive functions in VM

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -54,7 +54,6 @@ experimental VM.  Unsupported areas include:
 * Test blocks
 * Generic methods inside `type` blocks
 * Pattern matching on union variants or enums
-* Nested recursive functions inside other functions
 * Advanced string or list slicing beyond `[start:end]`
 * Functions with multiple return values or variadic parameters
 * Methods declared inside `type` blocks

--- a/tests/vm/valid/nested_function.ir.out
+++ b/tests/vm/valid/nested_function.ir.out
@@ -10,7 +10,7 @@ func main (regs=3)
 func outer (regs=6)
   // fun inner(y: int): int {
   Move         r1, r0
-  MakeClosure  r2, fn2, 1, r1
+  MakeClosure  r2, inner, 1, r1
   // return inner(5)
   Const        r4, 5
   Move         r3, r4
@@ -19,7 +19,7 @@ func outer (regs=6)
   Return       r0
 
   // fun inner(y: int): int {
-func fn2 (regs=3)
+func inner (regs=3)
   // return x + y
   Add          r2, r0, r1
   Return       r2


### PR DESCRIPTION
## Summary
- allow nested recursive functions by compiling named function expressions
- update nested function IR golden output
- document new VM support in runtime/vm README

## Testing
- `go test ./tests/vm -run TestVM_IR/nested_function -update`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685af0a9d2b48320850d58716dd58dec