### PR TITLE
Add upper and lower builtins for Ruby compiler

### DIFF
--- a/compile/x/rb/README.md
+++ b/compile/x/rb/README.md
@@ -21,6 +21,10 @@ case "len", "count":
     expr = fmt.Sprintf("(%s).length", args[0])
 case "str":
     expr = fmt.Sprintf("(%s).to_s", args[0])
+case "upper":
+    expr = fmt.Sprintf("(%s).to_s.upcase", args[0])
+case "lower":
+    expr = fmt.Sprintf("(%s).to_s.downcase", args[0])
 case "avg":
     expr = fmt.Sprintf("((%[1]s).length > 0 ? (%[1]s).sum(0.0) / (%[1]s).length : 0)", args[0])
 case "input":

--- a/compile/x/rb/compiler.go
+++ b/compile/x/rb/compiler.go
@@ -1339,6 +1339,16 @@ func (c *Compiler) compileBuiltinCall(name string, args []string, origArgs []*pa
 			return "", true, fmt.Errorf("str expects 1 arg")
 		}
 		return fmt.Sprintf("(%s).to_s", args[0]), true, nil
+	case "upper":
+		if len(args) != 1 {
+			return "", true, fmt.Errorf("upper expects 1 arg")
+		}
+		return fmt.Sprintf("(%s).to_s.upcase", args[0]), true, nil
+	case "lower":
+		if len(args) != 1 {
+			return "", true, fmt.Errorf("lower expects 1 arg")
+		}
+		return fmt.Sprintf("(%s).to_s.downcase", args[0]), true, nil
 	case "avg":
 		if len(args) != 1 {
 			return "", true, fmt.Errorf("avg expects 1 arg")

--- a/tests/compiler/rb/string_case.mochi
+++ b/tests/compiler/rb/string_case.mochi
@@ -1,0 +1,2 @@
+print(upper("hello"))
+print(lower("WORLD"))

--- a/tests/compiler/rb/string_case.out
+++ b/tests/compiler/rb/string_case.out
@@ -1,0 +1,2 @@
+HELLO
+world

--- a/tests/compiler/rb/string_case.rb.out
+++ b/tests/compiler/rb/string_case.rb.out
@@ -1,0 +1,3 @@
+puts(["hello".upcase].join(" "))
+puts(["WORLD".downcase].join(" "))
+


### PR DESCRIPTION
## Summary
- support `upper` and `lower` built-in functions in the Ruby backend
- document the new built-ins
- test string case operations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685af5b207e883209625ba29449c721f