### PR TITLE
Improve TypeScript compiler struct inference

### DIFF
--- a/compile/ts/infer.go
+++ b/compile/ts/infer.go
@@ -165,6 +165,19 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 			}
 		}
 		return types.AnyType{}
+	case p.Generate != nil:
+		if p.Generate.Target == "text" {
+			return types.StringType{}
+		}
+		if p.Generate.Target == "embedding" {
+			return types.ListType{Elem: types.FloatType{}}
+		}
+		if c.env != nil {
+			if st, ok := c.env.GetStruct(p.Generate.Target); ok {
+				return st
+			}
+		}
+		return types.AnyType{}
 	case p.Call != nil:
 		switch p.Call.Func {
 		case "len":

--- a/tests/compiler/ts/generate_struct.ts.out
+++ b/tests/compiler/ts/generate_struct.ts.out
@@ -4,7 +4,7 @@ type Info = {
 	msg: string;
 }
 
-let info: any = _gen_struct<Info>("{\"msg\": \"hello\"}", null, null)
+let info: Info = _gen_struct<Info>("{\"msg\": \"hello\"}", null, null)
 
 function main(): void {
 	console.log(info.msg)


### PR DESCRIPTION
## Summary
- infer struct types for `generate` expressions in the TS compiler
- update golden file for `generate_struct` test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685afa0995e48320b3883fc3e81e7cc8