### PR TITLE
Add Dart struct generation helpers

### DIFF
--- a/compile/x/dart/helpers.go
+++ b/compile/x/dart/helpers.go
@@ -2,6 +2,7 @@ package dartcode
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"mochi/parser"
@@ -249,7 +250,7 @@ func equalTypes(a, b types.Type) bool {
 	if isInt(a) && isInt(b) {
 		return true
 	}
-	return a == b
+	return reflect.DeepEqual(a, b)
 }
 
 func isInt64(t types.Type) bool {

--- a/compile/x/dart/runtime.go
+++ b/compile/x/dart/runtime.go
@@ -295,9 +295,12 @@ const (
 	helperGenEmbed = "List<double> _genEmbed(String text, String model, Map<String,dynamic>? params) {\n" +
 		"    return text.codeUnits.map((c) => c.toDouble()).toList();\n" +
 		"}\n"
-	helperGenStruct = "T _genStruct<T>(String prompt, String model, Map<String,dynamic>? params) {\n" +
-		"    // TODO: parse model output into a struct\n" +
-		"    return null as T;\n" +
+	helperGenStruct = "Map<String, Function> _structParsers = {};\n" +
+		"T _genStruct<T>(String prompt, String model, Map<String,dynamic>? params) {\n" +
+		"    var data = jsonDecode(prompt) as Map<String, dynamic>;\n" +
+		"    var fn = _structParsers[T.toString()];\n" +
+		"    if (fn == null) throw Exception('unknown struct type $T');\n" +
+		"    return Function.apply(fn, [data]) as T;\n" +
 		"}\n"
 	helperJson = "void _json(dynamic v) {\n" +
 		"    print(jsonEncode(v));\n" +

--- a/tests/compiler/dart/generate_struct.dart.out
+++ b/tests/compiler/dart/generate_struct.dart.out
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+class Info {
+	String msg;
+	Info({required this.msg});
+	factory Info.fromJson(Map<String,dynamic> m) {
+		return Info(msg: m['msg'] as String);
+	}
+}
+_structParsers['Info'] = (m) => Info.fromJson(m);
+
+void main() {
+	Info info = _genStruct<Info>("{\"msg\": \"hello\"}", "", null);
+	print(info.msg);
+}
+
+Map<String, Function> _structParsers = {};
+T _genStruct<T>(String prompt, String model, Map<String,dynamic>? params) {
+    var data = jsonDecode(prompt) as Map<String, dynamic>;
+    var fn = _structParsers[T.toString()];
+    if (fn == null) throw Exception('unknown struct type $T');
+    return Function.apply(fn, [data]) as T;
+}
+
+

--- a/tests/compiler/dart/generate_struct.mochi
+++ b/tests/compiler/dart/generate_struct.mochi
@@ -1,0 +1,8 @@
+type Info {
+  msg: string
+}
+
+let info = generate Info {
+  prompt: "{\"msg\": \"hello\"}"
+}
+print(info.msg)


### PR DESCRIPTION
## Summary
- implement `_structParsers` map and JSON-based `_genStruct` helper for Dart
- emit `fromJson` factory methods for structs
- register struct parsers when compiling type declarations
- fix `equalTypes` to use `reflect.DeepEqual`
- add generate_struct test for Dart backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685afa59b5fc8320a4e642fc578e2b9d