### PR TITLE
Add struct literal support in Prolog backend

### DIFF
--- a/compile/x/pl/README.md
+++ b/compile/x/pl/README.md
@@ -283,6 +283,7 @@ The Prolog backend can compile a subset of Mochi focused on core control flow an
 - `let` and `var` declarations with assignment
 - Arithmetic and comparison operators plus list concatenation with `+`
 - Lists and maps with indexing, slicing and element assignment
+- Struct literals using Prolog dicts with field selectors
 - Membership checks using `in` on lists, strings and maps
 - Built-in functions `len`, `count`, `avg`, `str` and `input`
 - `print` statements
@@ -301,8 +302,7 @@ Mochi language features are not yet implemented:
 
 - Pattern matching expressions and union types
 - Dataset queries (`from`/`select`, joins and grouping)
-- Structured type declarations like `struct` and enums (simple field selectors
-  `a.b` are supported)
+- Enum declarations and variant matching
 - Concurrency primitives and external helpers like `_fetch` or `_genText`
 - Import declarations (currently ignored)
 - Agent and stream features (`agent`, `on`, `emit`)

--- a/compile/x/pl/infer.go
+++ b/compile/x/pl/infer.go
@@ -87,6 +87,13 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 		return types.ListType{Elem: types.AnyType{}}
 	case p.Map != nil:
 		return types.MapType{Key: types.AnyType{}, Value: types.AnyType{}}
+	case p.Struct != nil:
+		if c.env != nil {
+			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
+				return st
+			}
+		}
+		return types.AnyType{}
 	case p.Selector != nil:
 		if c.env != nil {
 			if len(p.Selector.Tail) > 0 {

--- a/tests/compiler/pl/string_index.pl.out
+++ b/tests/compiler/pl/string_index.pl.out
@@ -1,6 +1,6 @@
 :- style_check(-singleton).
 get_item(Container, Key, Val) :-
-    is_dict(Container), !, get_dict(Key, Container, Val).
+    is_dict(Container), !, (string(Key) -> atom_string(A, Key) ; A = Key), get_dict(A, Container, Val).
 get_item(Container, Index, Val) :-
     string(Container), !, string_chars(Container, Chars), nth0(Index, Chars, Val).
 get_item(List, Index, Val) :- nth0(Index, List, Val).


### PR DESCRIPTION
## Summary
- support struct literals in the Prolog compiler
- infer struct types when encountering struct literals
- document struct literal support
- update golden output for `string_index` test

## Testing
- `go test ./compile/x/pl -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_685b00128a2483208f7337c01d694d44