### PR TITLE
Add nested type support to C# backend

### DIFF
--- a/compile/x/cs/README.md
+++ b/compile/x/cs/README.md
@@ -154,6 +154,7 @@ The C# backend focuses on fundamental features: functions, control flow, structs
 - Variable and function declarations
 - Control flow with `if`, `for`, `while`, `break` and `continue`
 - Struct and union types with pattern matching using `match`
+- Nested type declarations inside structs
 - Lists and maps with indexing, slicing and membership checks
 - Dataset queries with `from`, `where`, `select`, `sort by`, `skip` and `take`
 - Cross joins via multiple `from` clauses

--- a/compile/x/cs/compiler.go
+++ b/compile/x/cs/compiler.go
@@ -293,11 +293,11 @@ func (c *Compiler) compileExpect(e *parser.ExpectStmt) error {
 func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 	name := sanitizeName(t.Name)
 	if len(t.Variants) > 0 {
-        iface := fmt.Sprintf("public interface %s { void is%s(); }", name, name)
-        c.writeln(iface)
-        for _, v := range t.Variants {
-                vname := sanitizeName(v.Name)
-                c.writeln(fmt.Sprintf("public struct %s : %s {", vname, name))
+		iface := fmt.Sprintf("public interface %s { void is%s(); }", name, name)
+		c.writeln(iface)
+		for _, v := range t.Variants {
+			vname := sanitizeName(v.Name)
+			c.writeln(fmt.Sprintf("public struct %s : %s {", vname, name))
 			c.indent++
 			for _, f := range v.Fields {
 				typ := csType(f.Type)
@@ -309,12 +309,20 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 		}
 		return nil
 	}
-        c.writeln(fmt.Sprintf("public struct %s {", name))
+	c.writeln(fmt.Sprintf("public struct %s {", name))
 	c.indent++
 	for _, m := range t.Members {
 		if m.Field != nil {
 			typ := csType(m.Field.Type)
 			c.writeln(fmt.Sprintf("public %s %s;", typ, sanitizeName(m.Field.Name)))
+		}
+	}
+	for _, m := range t.Members {
+		if m.Type != nil {
+			if err := c.compileTypeDecl(m.Type); err != nil {
+				return err
+			}
+			c.writeln("")
 		}
 	}
 	for _, m := range t.Members {
@@ -335,7 +343,7 @@ func (c *Compiler) compileStructType(st types.StructType) {
 		return
 	}
 	c.structs[name] = true
-        c.writeln(fmt.Sprintf("public struct %s {", name))
+	c.writeln(fmt.Sprintf("public struct %s {", name))
 	c.indent++
 	for _, fn := range st.Order {
 		ft := st.Fields[fn]

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -127,6 +127,7 @@ type TypeDecl struct {
 type TypeMember struct {
 	Field  *TypeField `parser:"@@"`
 	Method *FunStmt   `parser:"| @@"`
+	Type   *TypeDecl  `parser:"| @@"`
 }
 
 type TypeVariant struct {

--- a/types/check.go
+++ b/types/check.go
@@ -807,81 +807,7 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type) error {
 		return nil
 
 	case s.Type != nil:
-		if len(s.Type.Members) > 0 {
-			fields := map[string]Type{}
-			order := []string{}
-			methods := map[string]Method{}
-			st := StructType{Name: s.Type.Name, Fields: fields, Order: order, Methods: methods}
-			env.SetStruct(s.Type.Name, st)
-			env.types[s.Type.Name] = st
-			// First pass: collect fields
-			for _, m := range s.Type.Members {
-				if m.Field != nil {
-					fields[m.Field.Name] = resolveTypeRef(m.Field.Type, env)
-					order = append(order, m.Field.Name)
-				}
-			}
-			// Second pass: check methods
-			for _, m := range s.Type.Members {
-				if m.Method != nil {
-					params := []Type{}
-					for _, p := range m.Method.Params {
-						if p.Type == nil {
-							return errParamMissingType(m.Method.Pos, p.Name)
-						}
-						params = append(params, resolveTypeRef(p.Type, env))
-					}
-					var ret Type = VoidType{}
-					if m.Method.Return != nil {
-						ret = resolveTypeRef(m.Method.Return, env)
-					}
-					methodEnv := NewEnv(env)
-					for name, t := range fields {
-						methodEnv.SetVar(name, t, true)
-					}
-					for i, p := range m.Method.Params {
-						methodEnv.SetVar(p.Name, params[i], true)
-					}
-					for _, stmt := range m.Method.Body {
-						if err := checkStmt(stmt, methodEnv, ret); err != nil {
-							return err
-						}
-					}
-					pure := isPureFunction(&parser.FunStmt{Params: m.Method.Params, Return: m.Method.Return, Body: m.Method.Body}, methodEnv)
-					methods[m.Method.Name] = Method{Decl: m.Method, Type: FuncType{Params: params, Return: ret, Pure: pure}}
-				}
-			}
-			st.Fields = fields
-			st.Order = order
-			st.Methods = methods
-			env.SetStruct(s.Type.Name, st)
-			env.types[s.Type.Name] = st
-			return nil
-		}
-		if len(s.Type.Variants) > 0 {
-			variants := map[string]StructType{}
-			for _, v := range s.Type.Variants {
-				vf := map[string]Type{}
-				order := []string{}
-				for _, f := range v.Fields {
-					vf[f.Name] = resolveTypeRef(f.Type, env)
-					order = append(order, f.Name)
-				}
-				st := StructType{Name: v.Name, Fields: vf, Order: order}
-				variants[v.Name] = st
-				env.SetStruct(v.Name, st)
-				params := make([]Type, 0, len(v.Fields))
-				for _, f := range v.Fields {
-					params = append(params, resolveTypeRef(f.Type, env))
-				}
-				env.SetFuncType(v.Name, FuncType{Params: params, Return: UnionType{Name: s.Type.Name, Variants: nil}})
-			}
-			ut := UnionType{Name: s.Type.Name, Variants: variants}
-			env.SetUnion(s.Type.Name, ut)
-			env.types[s.Type.Name] = ut
-			return nil
-		}
-		return nil
+		return checkTypeDecl(s.Type, env)
 
 	case s.Model != nil:
 		for _, f := range s.Model.Fields {
@@ -2144,6 +2070,89 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 				}
 			}
 		}
+		return nil
+	}
+	return nil
+}
+
+func checkTypeDecl(t *parser.TypeDecl, env *Env) error {
+	if len(t.Members) > 0 {
+		fields := map[string]Type{}
+		order := []string{}
+		methods := map[string]Method{}
+		st := StructType{Name: t.Name, Fields: fields, Order: order, Methods: methods}
+		env.SetStruct(t.Name, st)
+		env.types[t.Name] = st
+		for _, m := range t.Members {
+			if m.Field != nil {
+				fields[m.Field.Name] = resolveTypeRef(m.Field.Type, env)
+				order = append(order, m.Field.Name)
+			}
+		}
+		for _, m := range t.Members {
+			if m.Type != nil {
+				if err := checkTypeDecl(m.Type, env); err != nil {
+					return err
+				}
+			}
+		}
+		for _, m := range t.Members {
+			if m.Method != nil {
+				params := []Type{}
+				for _, p := range m.Method.Params {
+					if p.Type == nil {
+						return errParamMissingType(m.Method.Pos, p.Name)
+					}
+					params = append(params, resolveTypeRef(p.Type, env))
+				}
+				var ret Type = VoidType{}
+				if m.Method.Return != nil {
+					ret = resolveTypeRef(m.Method.Return, env)
+				}
+				methodEnv := NewEnv(env)
+				for name, t := range fields {
+					methodEnv.SetVar(name, t, true)
+				}
+				for i, p := range m.Method.Params {
+					methodEnv.SetVar(p.Name, params[i], true)
+				}
+				for _, stmt := range m.Method.Body {
+					if err := checkStmt(stmt, methodEnv, ret); err != nil {
+						return err
+					}
+				}
+				pure := isPureFunction(&parser.FunStmt{Params: m.Method.Params, Return: m.Method.Return, Body: m.Method.Body}, methodEnv)
+				methods[m.Method.Name] = Method{Decl: m.Method, Type: FuncType{Params: params, Return: ret, Pure: pure}}
+			}
+		}
+		st.Fields = fields
+		st.Order = order
+		st.Methods = methods
+		env.SetStruct(t.Name, st)
+		env.types[t.Name] = st
+		return nil
+	}
+	if len(t.Variants) > 0 {
+		variants := map[string]StructType{}
+		for _, v := range t.Variants {
+			vf := map[string]Type{}
+			order := []string{}
+			for _, f := range v.Fields {
+				vf[f.Name] = resolveTypeRef(f.Type, env)
+				order = append(order, f.Name)
+			}
+			st := StructType{Name: v.Name, Fields: vf, Order: order}
+			variants[v.Name] = st
+			env.SetStruct(v.Name, st)
+			params := make([]Type, 0, len(v.Fields))
+			for _, f := range v.Fields {
+				params = append(params, resolveTypeRef(f.Type, env))
+			}
+			env.SetFuncType(v.Name, FuncType{Params: params, Return: UnionType{Name: t.Name, Variants: nil}})
+		}
+		ut := UnionType{Name: t.Name, Variants: variants}
+		env.SetUnion(t.Name, ut)
+		env.types[t.Name] = ut
 		return nil
 	}
 	return nil


### PR DESCRIPTION
## Summary
- allow nested type declarations in parser
- factor out type-checking logic for type declarations so it can be used recursively
- support nested types in C# code generation
- document nested type support in the C# backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b270bb38483209396c0083e2cd7df