### PR TITLE
Support nested type declarations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -600,7 +600,7 @@ AgentField    = LetStmt | VarStmt | AssignStmt | OnHandler | IntentDecl .
 IntentDecl    = "intent" Identifier "(" [ ParamList ] ")" [ ":" TypeRef ] Block .
 ModelDecl     = "model" Identifier Block .
 TypeDecl      = "type" Identifier [ [ "=" ] "{" TypeMember* "}" ] [ "=" TypeVariant { "|" TypeVariant } ] .
-TypeMember    = TypeField | FunDecl .
+TypeMember    = TypeField | FunDecl | TypeDecl .
 TypeVariant   = Identifier [ "(" TypeField { "," TypeField } [ "," ]? ")" | "{" TypeField* "}" ] .
 TypeField     = Identifier ":" TypeRef .
 

--- a/ast/convert.go
+++ b/ast/convert.go
@@ -144,6 +144,10 @@ func FromStatement(s *parser.Statement) *Node {
 					Value:    m.Field.Name,
 					Children: []*Node{FromTypeRef(m.Field.Type)},
 				})
+			} else if m.Method != nil {
+				n.Children = append(n.Children, FromStatement(&parser.Statement{Fun: m.Method}))
+			} else if m.Type != nil {
+				n.Children = append(n.Children, FromStatement(&parser.Statement{Type: m.Type}))
 			}
 		}
 		return n

--- a/compile/x/swift/compiler.go
+++ b/compile/x/swift/compiler.go
@@ -258,6 +258,13 @@ func (c *Compiler) compileType(t *parser.TypeRef) string {
 
 func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 	if len(t.Variants) > 0 {
+		for _, m := range t.Members {
+			if m.Type != nil {
+				if err := c.compileTypeDecl(m.Type); err != nil {
+					return err
+				}
+			}
+		}
 		c.writeln(fmt.Sprintf("protocol %s {}", t.Name))
 		for _, v := range t.Variants {
 			c.writeln(fmt.Sprintf("struct %s: %s {", v.Name, t.Name))
@@ -279,6 +286,10 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 			c.writeln(fmt.Sprintf("var %s: %s", m.Field.Name, typ))
 		} else if m.Method != nil {
 			if err := c.compileMethod(t.Name, m.Method); err != nil {
+				return err
+			}
+		} else if m.Type != nil {
+			if err := c.compileTypeDecl(m.Type); err != nil {
 				return err
 			}
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -127,6 +127,7 @@ type TypeDecl struct {
 type TypeMember struct {
 	Field  *TypeField `parser:"@@"`
 	Method *FunStmt   `parser:"| @@"`
+	Type   *TypeDecl  `parser:"| @@"`
 }
 
 type TypeVariant struct {

--- a/tests/compiler/swift/nested_type.mochi
+++ b/tests/compiler/swift/nested_type.mochi
@@ -1,0 +1,9 @@
+type Outer {
+  type Inner {
+    z: int
+  }
+  v: int
+}
+
+let o = Outer { v: 1 }
+print(o.v)

--- a/tests/compiler/swift/nested_type.swift.out
+++ b/tests/compiler/swift/nested_type.swift.out
@@ -1,0 +1,14 @@
+import Foundation
+
+struct Outer {
+	struct Inner {
+		var z: Int
+	}
+	var v: Int
+}
+
+func main() {
+	let o = Outer(v: 1)
+	print(o.v)
+}
+main()

--- a/tests/parser/valid/nested_type.golden
+++ b/tests/parser/valid/nested_type.golden
@@ -1,0 +1,7 @@
+(program
+  (type Outer
+    (type Inner
+      (field z (type int))
+    )
+  )
+)

--- a/tests/parser/valid/nested_type.mochi
+++ b/tests/parser/valid/nested_type.mochi
@@ -1,0 +1,5 @@
+type Outer {
+  type Inner {
+    z: int
+  }
+}


### PR DESCRIPTION
## Summary
- allow nested type declarations in the parser
- include nested types when converting AST to s-expressions
- compile nested types in Swift backend
- document nested type grammar
- add tests for nested type support

## Testing
- `go test ./parser -count=1 -args -update`
- `go test ./compile/x/swift -run TestSwiftCompiler_GoldenOutput -tags slow -count=1 -args -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b26a765a08320aa4e96d176349be6