### PR TITLE
Enable nested type declarations in Prolog backend

### DIFF
--- a/compile/x/pl/compiler.go
+++ b/compile/x/pl/compiler.go
@@ -34,29 +34,34 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	origBuf := c.buf
 	c.buf = body
 
-	// function declarations, facts, rules and tests
-	for _, s := range prog.Statements {
-		if s.Fun != nil {
-			if err := c.compileFun(s.Fun); err != nil {
-				return nil, err
-			}
-			c.writeln("")
-		} else if s.Fact != nil {
-			if err := c.compileFact(s.Fact); err != nil {
-				return nil, err
-			}
-			c.writeln("")
-		} else if s.Rule != nil {
-			if err := c.compileRule(s.Rule); err != nil {
-				return nil, err
-			}
-			c.writeln("")
-		} else if s.Test != nil {
-			if err := c.compileTestBlock(s.Test); err != nil {
-				return nil, err
-			}
-			c.writeln("")
-		}
+       // function declarations, type declarations, facts, rules and tests
+       for _, s := range prog.Statements {
+               if s.Fun != nil {
+                       if err := c.compileFun(s.Fun); err != nil {
+                               return nil, err
+                       }
+                       c.writeln("")
+               } else if s.Fact != nil {
+                       if err := c.compileFact(s.Fact); err != nil {
+                               return nil, err
+                       }
+                       c.writeln("")
+               } else if s.Rule != nil {
+                       if err := c.compileRule(s.Rule); err != nil {
+                               return nil, err
+                       }
+                       c.writeln("")
+               } else if s.Type != nil {
+                       if err := c.compileTypeDecl(s.Type); err != nil {
+                               return nil, err
+                       }
+                       c.writeln("")
+               } else if s.Test != nil {
+                       if err := c.compileTestBlock(s.Test); err != nil {
+                               return nil, err
+                       }
+                       c.writeln("")
+               }
 	}
 
 	tmpBuf := c.buf

--- a/compile/x/pl/statements.go
+++ b/compile/x/pl/statements.go
@@ -203,14 +203,16 @@ func (c *Compiler) compileStmt(s *parser.Statement, ret string) error {
 	case s.Continue != nil:
 		c.writeln("throw(continue)")
 		return nil
-	case s.Expect != nil:
-		return c.compileExpect(s.Expect)
-	case s.If != nil:
-		return c.compileIf(s.If, ret, true)
-	default:
-		return fmt.Errorf("unsupported statement")
-	}
-	return nil
+        case s.Expect != nil:
+                return c.compileExpect(s.Expect)
+        case s.If != nil:
+                return c.compileIf(s.If, ret, true)
+       case s.Type != nil:
+               return c.compileTypeDecl(s.Type)
+        default:
+                return fmt.Errorf("unsupported statement")
+        }
+        return nil
 }
 
 func (c *Compiler) compileFor(f *parser.ForStmt, ret string) error {
@@ -657,16 +659,25 @@ func (c *Compiler) compileTestBlock(t *parser.TestBlock) error {
 }
 
 func pureFunExpr(e *parser.Expr) *parser.FunExpr {
-	if e == nil || len(e.Binary.Right) != 0 {
-		return nil
-	}
-	u := e.Binary.Left
+        if e == nil || len(e.Binary.Right) != 0 {
+                return nil
+        }
+        u := e.Binary.Left
 	if len(u.Ops) != 0 {
 		return nil
 	}
-	p := u.Value
-	if len(p.Ops) != 0 {
-		return nil
-	}
-	return p.Target.FunExpr
+        p := u.Value
+        if len(p.Ops) != 0 {
+                return nil
+        }
+        return p.Target.FunExpr
+}
+
+// compileTypeDecl currently emits no Prolog code as type information is
+// only used during type checking. Supporting the statement ensures that
+// type definitions inside functions do not cause compile errors.
+func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
+        // Methods are ignored since the Prolog backend has no notion of
+        // attaching functions to structs.
+        return nil
 }

--- a/tests/compiler/pl/nested_type_decl.mochi
+++ b/tests/compiler/pl/nested_type_decl.mochi
@@ -1,0 +1,10 @@
+fun wrapper(): int {
+  type Pair {
+    a: int
+    b: int
+  }
+  let p = Pair { a: 1, b: 2 }
+  return p.b
+}
+
+print(wrapper())

--- a/tests/compiler/pl/nested_type_decl.pl.out
+++ b/tests/compiler/pl/nested_type_decl.pl.out
@@ -1,0 +1,23 @@
+:- style_check(-singleton).
+		wrapper(Res) :-
+			catch(
+				(
+		dict_create(_V0, p_pair, [a-1, b-2]),
+		P = _V0
+					,
+					true
+				)
+				, return(_V1),
+					Res = _V1
+				)
+			.
+			wrapper(Res) :-
+			get_dict(b, P, _V2),
+			Res = _V2.
+
+	main :-
+	wrapper(_V3),
+	write(_V3),
+	nl
+	.
+:- initialization(main, main).


### PR DESCRIPTION
## Summary
- allow nested `type` declarations in the Prolog compiler
- no-op implementation for type declarations in Prolog
- add regression test for nested type declaration

## Testing
- `go test ./compile/x/pl -run TestPrologCompiler_GoldenOutput -tags slow -count=1 -update`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b26998fc48320bac2c1ea65709f22