### PR TITLE
Fix parser fieldop duplicate

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -327,7 +327,6 @@ type PostfixOp struct {
 	Index *IndexOp `parser:"| @@"`
 	Field *FieldOp `parser:"| @@"`
 	Cast  *CastOp  `parser:"| @@"`
-	Field *FieldOp `parser:"| @@"`
 }
 
 type FieldOp struct {
@@ -343,11 +342,6 @@ type CastOp struct {
 type CallOp struct {
 	Pos  lexer.Position
 	Args []*Expr `parser:"'(' [ @@ { ',' @@ } ] ')'"`
-}
-
-type FieldOp struct {
-	Pos  lexer.Position
-	Name string `parser:"'.' @Ident"`
 }
 
 type IndexOp struct {


### PR DESCRIPTION
## Summary
- fix duplicate FieldOp struct and field in parser.go

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b3460d2b08320b606c1a70d116be6