### PR TITLE
Move Go compiler type inference to types package

### DIFF
--- a/compile/go/helpers.go
+++ b/compile/go/helpers.go
@@ -238,58 +238,7 @@ func contains(ops []string, op string) bool {
 }
 
 func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
-	if t == nil {
-		return types.AnyType{}
-	}
-	if t.Fun != nil {
-		params := make([]types.Type, len(t.Fun.Params))
-		for i, p := range t.Fun.Params {
-			params[i] = c.resolveTypeRef(p)
-		}
-		var ret types.Type = types.VoidType{}
-		if t.Fun.Return != nil {
-			ret = c.resolveTypeRef(t.Fun.Return)
-		}
-		return types.FuncType{Params: params, Return: ret}
-	}
-	if t.Generic != nil {
-		name := t.Generic.Name
-		args := t.Generic.Args
-		switch name {
-		case "list":
-			if len(args) == 1 {
-				return types.ListType{Elem: c.resolveTypeRef(args[0])}
-			}
-		case "map":
-			if len(args) == 2 {
-				return types.MapType{Key: c.resolveTypeRef(args[0]), Value: c.resolveTypeRef(args[1])}
-			}
-		}
-		return types.AnyType{}
-	}
-	if t.Simple != nil {
-		switch *t.Simple {
-		case "int":
-			return types.IntType{}
-		case "float":
-			return types.FloatType{}
-		case "string":
-			return types.StringType{}
-		case "bool":
-			return types.BoolType{}
-		default:
-			if c != nil && c.env != nil {
-				if st, ok := c.env.GetStruct(*t.Simple); ok {
-					return st
-				}
-				if ut, ok := c.env.GetUnion(*t.Simple); ok {
-					return ut
-				}
-			}
-			return types.AnyType{}
-		}
-	}
-	return types.AnyType{}
+	return types.ResolveTypeRef(t, c.env)
 }
 
 func isUnderscoreExpr(e *parser.Expr) bool {

--- a/compile/go/infer.go
+++ b/compile/go/infer.go
@@ -1,427 +1,47 @@
 package gocode
 
 import (
-	"strings"
-
 	"mochi/parser"
 	"mochi/types"
 )
 
+// inferExprType delegates to types.InferExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	return c.inferBinaryType(e.Binary)
+	return types.InferExprType(e, c.env)
 }
 
-// inferExprTypeHint infers the type of an expression using a hint.
-// This is primarily used for literals that would otherwise default to
-// `any`, such as empty list literals. The hint is applied recursively
-// for nested lists.
+// inferExprTypeHint delegates to types.InferExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	if lt, ok := hint.(types.ListType); ok {
-		if e.Binary != nil && len(e.Binary.Right) == 0 {
-			if ll := e.Binary.Left.Value.Target.List; ll != nil {
-				// If the list literal is empty, use the hint directly.
-				if len(ll.Elems) == 0 {
-					return types.ListType{Elem: lt.Elem}
-				}
-				elem := c.inferExprTypeHint(ll.Elems[0], lt.Elem)
-				for _, el := range ll.Elems[1:] {
-					t := c.inferExprTypeHint(el, lt.Elem)
-					if !equalTypes(elem, t) {
-						elem = types.AnyType{}
-						break
-					}
-				}
-				return types.ListType{Elem: elem}
-			}
-		}
-	}
-	return c.inferExprType(e)
-}
-
-func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
-	if b == nil {
-		return types.AnyType{}
-	}
-	t := c.inferUnaryType(b.Left)
-	for _, op := range b.Right {
-		rt := c.inferPostfixType(op.Right)
-		switch op.Op {
-		case "+", "-", "*", "/", "%":
-			if isInt64(t) {
-				if isInt64(rt) || isInt(rt) {
-					t = types.Int64Type{}
-					continue
-				}
-			}
-			if _, ok := t.(types.IntType); ok {
-				if _, ok := rt.(types.IntType); ok {
-					t = types.IntType{}
-					continue
-				}
-			}
-			if _, ok := t.(types.FloatType); ok {
-				if _, ok := rt.(types.FloatType); ok {
-					t = types.FloatType{}
-					continue
-				}
-			}
-			if op.Op == "+" {
-				if llist, ok := t.(types.ListType); ok {
-					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
-						t = llist
-						continue
-					}
-				}
-				if _, ok := t.(types.StringType); ok {
-					if _, ok := rt.(types.StringType); ok {
-						t = types.StringType{}
-						continue
-					}
-				}
-			}
-			t = types.AnyType{}
-		case "==", "!=", "<", "<=", ">", ">=":
-			t = types.BoolType{}
-		case "&&", "||":
-			if isBool(t) && isBool(rt) {
-				t = types.BoolType{}
-			} else {
-				t = types.AnyType{}
-			}
-		case "in":
-			switch rt.(type) {
-			case types.MapType, types.ListType, types.StringType:
-				t = types.BoolType{}
-			default:
-				t = types.AnyType{}
-			}
-		default:
-			t = types.AnyType{}
-		}
-	}
-	return t
+	return types.InferExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 	if u == nil {
 		return types.AnyType{}
 	}
-	return c.inferPostfixType(u.Value)
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	t := c.inferPrimaryType(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil && op.Index.Colon == nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt.Elem
-			case types.MapType:
-				t = tt.Value
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Index != nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Call != nil {
-			if ft, ok := t.(types.FuncType); ok {
-				t = ft.Return
-			} else {
-				t = types.AnyType{}
-			}
-		} else if op.Cast != nil {
-			t = c.resolveTypeRef(op.Cast.Type)
-		}
-	}
-	return t
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.Selector != nil:
-		if c.env != nil {
-			if len(p.Selector.Tail) > 0 {
-				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
-				if t, err := c.env.GetVar(full); err == nil {
-					return t
-				}
-			}
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				if len(p.Selector.Tail) == 0 {
-					return t
-				}
-				if st, ok := t.(types.StructType); ok {
-					cur := st
-					for idx, field := range p.Selector.Tail {
-						ft, ok := cur.Fields[field]
-						if !ok {
-							return types.AnyType{}
-						}
-						if idx == len(p.Selector.Tail)-1 {
-							return ft
-						}
-						if next, ok := ft.(types.StructType); ok {
-							cur = next
-						} else {
-							return types.AnyType{}
-						}
-					}
-				}
-				if ut, ok := t.(types.UnionType); ok {
-					if ft, ok := unionFieldPathType(ut, p.Selector.Tail); ok {
-						return ft
-					}
-				}
-			}
-		}
-		return types.AnyType{}
-	case p.Struct != nil:
-		if c.env != nil {
-			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
-				return st
-			}
-		}
-		return types.AnyType{}
-	case p.FunExpr != nil:
-		params := make([]types.Type, len(p.FunExpr.Params))
-		for i, par := range p.FunExpr.Params {
-			if par.Type != nil {
-				params[i] = c.resolveTypeRef(par.Type)
-			} else {
-				params[i] = types.AnyType{}
-			}
-		}
-		var ret types.Type = types.VoidType{}
-		if p.FunExpr.Return != nil {
-			ret = c.resolveTypeRef(p.FunExpr.Return)
-		} else if p.FunExpr.ExprBody != nil {
-			ret = c.inferExprType(p.FunExpr.ExprBody)
-		} else {
-			ret = types.AnyType{}
-		}
-		return types.FuncType{Params: params, Return: ret}
-	case p.Generate != nil:
-		switch p.Generate.Target {
-		case "text":
-			return types.StringType{}
-		case "embedding":
-			return types.ListType{Elem: types.FloatType{}}
-		default:
-			if c.env != nil {
-				if st, ok := c.env.GetStruct(p.Generate.Target); ok {
-					return st
-				}
-			}
-			return types.AnyType{}
-		}
-	case p.Call != nil:
-		switch p.Call.Func {
-		case "len":
-			return types.IntType{}
-		case "str":
-			return types.StringType{}
-		case "count":
-			return types.IntType{}
-		case "avg":
-			return types.FloatType{}
-		case "now":
-			return types.Int64Type{}
-		default:
-			if c.env != nil {
-				if t, err := c.env.GetVar(p.Call.Func); err == nil {
-					if ft, ok := t.(types.FuncType); ok {
-						return ft.Return
-					}
-				}
-			}
-			return types.AnyType{}
-		}
-	case p.Group != nil:
-		return c.inferExprType(p.Group)
-	case p.List != nil:
-		var elemType types.Type = types.AnyType{}
-		if len(p.List.Elems) > 0 {
-			elemType = c.inferExprType(p.List.Elems[0])
-			for _, e := range p.List.Elems[1:] {
-				t := c.inferExprType(e)
-				if !equalTypes(elemType, t) {
-					elemType = types.AnyType{}
-					break
-				}
-			}
-		}
-		return types.ListType{Elem: elemType}
-	case p.Load != nil:
-		var elem types.Type = types.MapType{Key: types.StringType{}, Value: types.AnyType{}}
-		if p.Load.Type != nil {
-			elem = c.resolveTypeRef(p.Load.Type)
-			if st, ok := c.env.GetStruct(*p.Load.Type.Simple); elem == (types.AnyType{}) && ok {
-				elem = st
-			}
-		}
-		return types.ListType{Elem: elem}
-	case p.Save != nil:
-		return types.VoidType{}
-	case p.Query != nil:
-		// Infer type with query variables in scope
-		srcType := c.inferExprType(p.Query.Source)
-		var elemType types.Type = types.AnyType{}
-		if lt, ok := srcType.(types.ListType); ok {
-			elemType = lt.Elem
-		}
-		child := types.NewEnv(c.env)
-		child.SetVar(p.Query.Var, elemType, true)
-		for _, f := range p.Query.Froms {
-			ft := c.inferExprType(f.Src)
-			var fe types.Type = types.AnyType{}
-			if lt, ok := ft.(types.ListType); ok {
-				fe = lt.Elem
-			}
-			child.SetVar(f.Var, fe, true)
-		}
-		for _, j := range p.Query.Joins {
-			jt := c.inferExprType(j.Src)
-			var je types.Type = types.AnyType{}
-			if lt, ok := jt.(types.ListType); ok {
-				je = lt.Elem
-			}
-			child.SetVar(j.Var, je, true)
-		}
-		orig := c.env
-		c.env = child
-		elem := c.inferExprType(p.Query.Select)
-		c.env = orig
-		return types.ListType{Elem: elem}
-	case p.Map != nil:
-		var keyType types.Type = types.AnyType{}
-		var valType types.Type = types.AnyType{}
-		if len(p.Map.Items) > 0 {
-			if _, ok := simpleStringKey(p.Map.Items[0].Key); ok {
-				keyType = types.StringType{}
-			} else {
-				keyType = c.inferExprType(p.Map.Items[0].Key)
-			}
-			valType = c.inferExprType(p.Map.Items[0].Value)
-			for _, it := range p.Map.Items[1:] {
-				var kt types.Type
-				if _, ok := simpleStringKey(it.Key); ok {
-					kt = types.StringType{}
-				} else {
-					kt = c.inferExprType(it.Key)
-				}
-				vt := c.inferExprType(it.Value)
-				if !equalTypes(keyType, kt) {
-					keyType = types.AnyType{}
-				}
-				if !equalTypes(valType, vt) {
-					valType = types.AnyType{}
-				}
-			}
-		}
-		return types.MapType{Key: keyType, Value: valType}
-	case p.Match != nil:
-		var rType types.Type
-		for _, cs := range p.Match.Cases {
-			t := c.inferExprType(cs.Result)
-			if rType == nil {
-				rType = t
-			} else if !equalTypes(rType, t) {
-				rType = types.AnyType{}
-			}
-		}
-		if rType == nil {
-			rType = types.AnyType{}
-		}
-		return rType
-	}
-	return types.AnyType{}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {
-	switch op {
-	case "+", "-", "*", "/", "%":
-		if _, ok := left.(types.IntType); ok {
-			if _, ok := right.(types.IntType); ok {
-				return types.IntType{}
-			}
-		}
-		if _, ok := left.(types.FloatType); ok {
-			if _, ok := right.(types.FloatType); ok {
-				return types.FloatType{}
-			}
-		}
-		if op == "+" {
-			if _, ok := left.(types.StringType); ok {
-				if _, ok := right.(types.StringType); ok {
-					return types.StringType{}
-				}
-			}
-		}
-		return types.AnyType{}
-	case "==", "!=", "<", "<=", ">", ">=":
-		return types.BoolType{}
-	default:
-		return types.AnyType{}
-	}
-}
-
-// unionFieldPathType attempts to resolve a field path across all variants of a union.
-// It returns the type if every variant has the field path with the same type.
-func unionFieldPathType(ut types.UnionType, tail []string) (types.Type, bool) {
-	var result types.Type
-	for _, variant := range ut.Variants {
-		cur := types.Type(variant)
-		for _, field := range tail {
-			st, ok := cur.(types.StructType)
-			if !ok {
-				return nil, false
-			}
-			ft, ok := st.Fields[field]
-			if !ok {
-				return nil, false
-			}
-			cur = ft
-		}
-		if result == nil {
-			result = cur
-		} else if !equalTypes(result, cur) {
-			return nil, false
-		}
-	}
-	if result == nil {
-		return nil, false
-	}
-	return result, true
+	return types.ResultType(op, left, right)
 }

--- a/types/infer.go
+++ b/types/infer.go
@@ -1,0 +1,502 @@
+package types
+
+import (
+	"reflect"
+	"strings"
+
+	"mochi/parser"
+)
+
+// ResolveTypeRef exposes resolveTypeRef for external packages.
+func ResolveTypeRef(t *parser.TypeRef, env *Env) Type {
+	return resolveTypeRef(t, env)
+}
+
+// InferExprType returns the static type of expression e using env.
+func InferExprType(e *parser.Expr, env *Env) Type {
+	if e == nil {
+		return AnyType{}
+	}
+	return inferBinaryType(env, e.Binary)
+}
+
+// InferExprTypeHint infers the type of e using a hint for list literals.
+func InferExprTypeHint(e *parser.Expr, hint Type, env *Env) Type {
+	if e == nil {
+		return AnyType{}
+	}
+	if lt, ok := hint.(ListType); ok {
+		if e.Binary != nil && len(e.Binary.Right) == 0 {
+			if ll := e.Binary.Left.Value.Target.List; ll != nil {
+				if len(ll.Elems) == 0 {
+					return ListType{Elem: lt.Elem}
+				}
+				elem := InferExprTypeHint(ll.Elems[0], lt.Elem, env)
+				for _, el := range ll.Elems[1:] {
+					t := InferExprTypeHint(el, lt.Elem, env)
+					if !equalTypes(elem, t) {
+						elem = AnyType{}
+						break
+					}
+				}
+				return ListType{Elem: elem}
+			}
+		}
+	}
+	return InferExprType(e, env)
+}
+
+func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
+	if b == nil {
+		return AnyType{}
+	}
+	t := inferUnaryType(env, b.Left)
+	for _, op := range b.Right {
+		rt := inferPostfixType(env, op.Right)
+		switch op.Op {
+		case "+", "-", "*", "/", "%":
+			if isInt64(t) {
+				if isInt64(rt) || isInt(rt) {
+					t = Int64Type{}
+					continue
+				}
+			}
+			if _, ok := t.(IntType); ok {
+				if _, ok := rt.(IntType); ok {
+					t = IntType{}
+					continue
+				}
+			}
+			if _, ok := t.(FloatType); ok {
+				if _, ok := rt.(FloatType); ok {
+					t = FloatType{}
+					continue
+				}
+			}
+			if op.Op == "+" {
+				if llist, ok := t.(ListType); ok {
+					if rlist, ok := rt.(ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
+						t = llist
+						continue
+					}
+				}
+				if _, ok := t.(StringType); ok {
+					if _, ok := rt.(StringType); ok {
+						t = StringType{}
+						continue
+					}
+				}
+			}
+			t = AnyType{}
+		case "==", "!=", "<", "<=", ">", ">=":
+			t = BoolType{}
+		case "&&", "||":
+			if isBool(t) && isBool(rt) {
+				t = BoolType{}
+			} else {
+				t = AnyType{}
+			}
+		case "in":
+			switch rt.(type) {
+			case MapType, ListType, StringType:
+				t = BoolType{}
+			default:
+				t = AnyType{}
+			}
+		default:
+			t = AnyType{}
+		}
+	}
+	return t
+}
+
+func inferUnaryType(env *Env, u *parser.Unary) Type {
+	if u == nil {
+		return AnyType{}
+	}
+	return inferPostfixType(env, u.Value)
+}
+
+func inferPostfixType(env *Env, p *parser.PostfixExpr) Type {
+	if p == nil {
+		return AnyType{}
+	}
+	t := inferPrimaryType(env, p.Target)
+	for _, op := range p.Ops {
+		if op.Index != nil && op.Index.Colon == nil {
+			switch tt := t.(type) {
+			case ListType:
+				t = tt.Elem
+			case MapType:
+				t = tt.Value
+			case StringType:
+				t = StringType{}
+			default:
+				t = AnyType{}
+			}
+		} else if op.Index != nil {
+			switch tt := t.(type) {
+			case ListType:
+				t = tt
+			case StringType:
+				t = StringType{}
+			default:
+				t = AnyType{}
+			}
+		} else if op.Call != nil {
+			if ft, ok := t.(FuncType); ok {
+				t = ft.Return
+			} else {
+				t = AnyType{}
+			}
+		} else if op.Cast != nil {
+			t = ResolveTypeRef(op.Cast.Type, env)
+		}
+	}
+	return t
+}
+
+func inferPrimaryType(env *Env, p *parser.Primary) Type {
+	if p == nil {
+		return AnyType{}
+	}
+	switch {
+	case p.Lit != nil:
+		switch {
+		case p.Lit.Int != nil:
+			return IntType{}
+		case p.Lit.Float != nil:
+			return FloatType{}
+		case p.Lit.Str != nil:
+			return StringType{}
+		case p.Lit.Bool != nil:
+			return BoolType{}
+		}
+	case p.Selector != nil:
+		if env != nil {
+			if len(p.Selector.Tail) > 0 {
+				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
+				if t, err := env.GetVar(full); err == nil {
+					return t
+				}
+			}
+			if t, err := env.GetVar(p.Selector.Root); err == nil {
+				if len(p.Selector.Tail) == 0 {
+					return t
+				}
+				if st, ok := t.(StructType); ok {
+					cur := st
+					for idx, field := range p.Selector.Tail {
+						ft, ok := cur.Fields[field]
+						if !ok {
+							return AnyType{}
+						}
+						if idx == len(p.Selector.Tail)-1 {
+							return ft
+						}
+						if next, ok := ft.(StructType); ok {
+							cur = next
+						} else {
+							return AnyType{}
+						}
+					}
+				}
+				if ut, ok := t.(UnionType); ok {
+					if ft, ok := unionFieldPathType(ut, p.Selector.Tail); ok {
+						return ft
+					}
+				}
+			}
+		}
+		return AnyType{}
+	case p.Struct != nil:
+		if env != nil {
+			if st, ok := env.GetStruct(p.Struct.Name); ok {
+				return st
+			}
+		}
+		return AnyType{}
+	case p.FunExpr != nil:
+		params := make([]Type, len(p.FunExpr.Params))
+		for i, par := range p.FunExpr.Params {
+			if par.Type != nil {
+				params[i] = ResolveTypeRef(par.Type, env)
+			} else {
+				params[i] = AnyType{}
+			}
+		}
+		var ret Type = VoidType{}
+		if p.FunExpr.Return != nil {
+			ret = ResolveTypeRef(p.FunExpr.Return, env)
+		} else if p.FunExpr.ExprBody != nil {
+			ret = InferExprType(p.FunExpr.ExprBody, env)
+		} else {
+			ret = AnyType{}
+		}
+		return FuncType{Params: params, Return: ret}
+	case p.Generate != nil:
+		switch p.Generate.Target {
+		case "text":
+			return StringType{}
+		case "embedding":
+			return ListType{Elem: FloatType{}}
+		default:
+			if env != nil {
+				if st, ok := env.GetStruct(p.Generate.Target); ok {
+					return st
+				}
+			}
+			return AnyType{}
+		}
+	case p.Call != nil:
+		switch p.Call.Func {
+		case "len":
+			return IntType{}
+		case "str":
+			return StringType{}
+		case "count":
+			return IntType{}
+		case "avg":
+			return FloatType{}
+		case "now":
+			return Int64Type{}
+		default:
+			if env != nil {
+				if t, err := env.GetVar(p.Call.Func); err == nil {
+					if ft, ok := t.(FuncType); ok {
+						return ft.Return
+					}
+				}
+			}
+			return AnyType{}
+		}
+	case p.Group != nil:
+		return InferExprType(p.Group, env)
+	case p.List != nil:
+		var elemType Type = AnyType{}
+		if len(p.List.Elems) > 0 {
+			elemType = InferExprType(p.List.Elems[0], env)
+			for _, e := range p.List.Elems[1:] {
+				t := InferExprType(e, env)
+				if !equalTypes(elemType, t) {
+					elemType = AnyType{}
+					break
+				}
+			}
+		}
+		return ListType{Elem: elemType}
+	case p.Load != nil:
+		var elem Type = MapType{Key: StringType{}, Value: AnyType{}}
+		if p.Load.Type != nil {
+			elem = ResolveTypeRef(p.Load.Type, env)
+			if st, ok := env.GetStruct(*p.Load.Type.Simple); elem == (AnyType{}) && ok {
+				elem = st
+			}
+		}
+		return ListType{Elem: elem}
+	case p.Save != nil:
+		return VoidType{}
+	case p.Query != nil:
+		srcType := InferExprType(p.Query.Source, env)
+		var elemType Type = AnyType{}
+		if lt, ok := srcType.(ListType); ok {
+			elemType = lt.Elem
+		}
+		child := NewEnv(env)
+		child.SetVar(p.Query.Var, elemType, true)
+		for _, f := range p.Query.Froms {
+			ft := InferExprType(f.Src, env)
+			var fe Type = AnyType{}
+			if lt, ok := ft.(ListType); ok {
+				fe = lt.Elem
+			}
+			child.SetVar(f.Var, fe, true)
+		}
+		for _, j := range p.Query.Joins {
+			jt := InferExprType(j.Src, env)
+			var je Type = AnyType{}
+			if lt, ok := jt.(ListType); ok {
+				je = lt.Elem
+			}
+			child.SetVar(j.Var, je, true)
+		}
+		orig := env
+		env = child
+		elem := InferExprType(p.Query.Select, env)
+		env = orig
+		return ListType{Elem: elem}
+	case p.Map != nil:
+		var keyType Type = AnyType{}
+		var valType Type = AnyType{}
+		if len(p.Map.Items) > 0 {
+			if _, ok := simpleStringKey(p.Map.Items[0].Key); ok {
+				keyType = StringType{}
+			} else {
+				keyType = InferExprType(p.Map.Items[0].Key, env)
+			}
+			valType = InferExprType(p.Map.Items[0].Value, env)
+			for _, it := range p.Map.Items[1:] {
+				var kt Type
+				if _, ok := simpleStringKey(it.Key); ok {
+					kt = StringType{}
+				} else {
+					kt = InferExprType(it.Key, env)
+				}
+				vt := InferExprType(it.Value, env)
+				if !equalTypes(keyType, kt) {
+					keyType = AnyType{}
+				}
+				if !equalTypes(valType, vt) {
+					valType = AnyType{}
+				}
+			}
+		}
+		return MapType{Key: keyType, Value: valType}
+	case p.Match != nil:
+		var rType Type
+		for _, cs := range p.Match.Cases {
+			t := InferExprType(cs.Result, env)
+			if rType == nil {
+				rType = t
+			} else if !equalTypes(rType, t) {
+				rType = AnyType{}
+			}
+		}
+		if rType == nil {
+			rType = AnyType{}
+		}
+		return rType
+	}
+	return AnyType{}
+}
+
+// ResultType returns the resulting type of applying op to left and right.
+func ResultType(op string, left, right Type) Type {
+	switch op {
+	case "+", "-", "*", "/", "%":
+		if _, ok := left.(IntType); ok {
+			if _, ok := right.(IntType); ok {
+				return IntType{}
+			}
+		}
+		if _, ok := left.(FloatType); ok {
+			if _, ok := right.(FloatType); ok {
+				return FloatType{}
+			}
+		}
+		if op == "+" {
+			if _, ok := left.(StringType); ok {
+				if _, ok := right.(StringType); ok {
+					return StringType{}
+				}
+			}
+		}
+		return AnyType{}
+	case "==", "!=", "<", "<=", ">", ">=":
+		return BoolType{}
+	default:
+		return AnyType{}
+	}
+}
+
+// unionFieldPathType attempts to resolve a field path across all variants of a union.
+// It returns the type if every variant has the field path with the same type.
+func unionFieldPathType(ut UnionType, tail []string) (Type, bool) {
+	var result Type
+	for _, variant := range ut.Variants {
+		cur := Type(variant)
+		for _, field := range tail {
+			st, ok := cur.(StructType)
+			if !ok {
+				return nil, false
+			}
+			ft, ok := st.Fields[field]
+			if !ok {
+				return nil, false
+			}
+			cur = ft
+		}
+		if result == nil {
+			result = cur
+		} else if !equalTypes(result, cur) {
+			return nil, false
+		}
+	}
+	if result == nil {
+		return nil, false
+	}
+	return result, true
+}
+
+func equalTypes(a, b Type) bool {
+	if _, ok := a.(AnyType); ok {
+		return true
+	}
+	if _, ok := b.(AnyType); ok {
+		return true
+	}
+	if la, ok := a.(ListType); ok {
+		if lb, ok := b.(ListType); ok {
+			return equalTypes(la.Elem, lb.Elem)
+		}
+	}
+	if ma, ok := a.(MapType); ok {
+		if mb, ok := b.(MapType); ok {
+			return equalTypes(ma.Key, mb.Key) && equalTypes(ma.Value, mb.Value)
+		}
+	}
+	if ua, ok := a.(UnionType); ok {
+		if sb, ok := b.(StructType); ok {
+			if _, ok := ua.Variants[sb.Name]; ok {
+				return true
+			}
+		}
+	}
+	if ub, ok := b.(UnionType); ok {
+		if sa, ok := a.(StructType); ok {
+			if _, ok := ub.Variants[sa.Name]; ok {
+				return true
+			}
+		}
+	}
+	if isInt64(a) && (isInt64(b) || isInt(b)) {
+		return true
+	}
+	if isInt64(b) && (isInt64(a) || isInt(a)) {
+		return true
+	}
+	if isInt(a) && isInt(b) {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func isInt64(t Type) bool  { _, ok := t.(Int64Type); return ok }
+func isInt(t Type) bool    { _, ok := t.(IntType); return ok }
+func isFloat(t Type) bool  { _, ok := t.(FloatType); return ok }
+func isBool(t Type) bool   { _, ok := t.(BoolType); return ok }
+func isString(t Type) bool { _, ok := t.(StringType); return ok }
+
+func simpleStringKey(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
+		return *p.Target.Lit.Str, true
+	}
+	return "", false
+}


### PR DESCRIPTION
## Summary
- add `types/infer.go` with reusable type inference helpers
- use `types` inference helpers from the Go compiler
- expose `ResolveTypeRef` via the types package

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b366572a0832094c46e55f62d0410