### PR TITLE
Add simple Mochi code formatter

### DIFF
--- a/tests/fmt/if_else.golden
+++ b/tests/fmt/if_else.golden
@@ -1,0 +1,5 @@
+if x>0 {
+  print("yes")
+} else {
+  print("no")
+}

--- a/tests/fmt/if_else.mochi
+++ b/tests/fmt/if_else.mochi
@@ -1,0 +1,5 @@
+if x>0{
+print("yes")
+}else{
+print("no")
+}

--- a/tests/fmt/nested.golden
+++ b/tests/fmt/nested.golden
@@ -1,0 +1,7 @@
+fun main() {
+  for i in 0..2 {
+    if i%2==0 {
+      print(i)
+    }
+  }
+}

--- a/tests/fmt/nested.mochi
+++ b/tests/fmt/nested.mochi
@@ -1,0 +1,7 @@
+fun main(){
+for i in 0..2{
+if i%2==0{
+print(i)
+}
+}
+}

--- a/tests/fmt/simple_fun.golden
+++ b/tests/fmt/simple_fun.golden
@@ -1,0 +1,4 @@
+fun add(a:int,b:int):int {
+  let x=a+b
+  return x
+}

--- a/tests/fmt/simple_fun.mochi
+++ b/tests/fmt/simple_fun.mochi
@@ -1,0 +1,4 @@
+fun add(a:int,b:int):int{
+let x=a+b
+return x
+}

--- a/tools/fmt/fmt.go
+++ b/tools/fmt/fmt.go
@@ -1,0 +1,51 @@
+package mfmt
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// Format formats Mochi source code using a very small
+// set of heuristics for consistent indentation and braces.
+// It is not a full pretty printer but provides a stable style.
+func Format(src string) string {
+	var out []string
+	indent := 0
+	scanner := bufio.NewScanner(strings.NewReader(src))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			out = append(out, "")
+			continue
+		}
+		if strings.HasPrefix(line, "}") || strings.HasPrefix(line, "]") || strings.HasPrefix(line, ")") {
+			if indent > 0 {
+				indent--
+			}
+		}
+		line = strings.ReplaceAll(line, "}else", "} else")
+		line = strings.ReplaceAll(line, "else{", "else {")
+		line = strings.ReplaceAll(line, "){", ") {")
+		if strings.Contains(line, "{") {
+			line = strings.ReplaceAll(line, "{", " {")
+			line = strings.TrimPrefix(line, " {")
+			line = strings.ReplaceAll(line, "  {", " {")
+		}
+		out = append(out, strings.Repeat("  ", indent)+line)
+		if strings.HasSuffix(line, "{") || strings.HasSuffix(line, "[") || strings.HasSuffix(line, "(") {
+			indent++
+		}
+	}
+	return strings.Join(out, "\n") + "\n"
+}
+
+// FormatFile reads a file and returns the formatted source.
+func FormatFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	formatted := Format(string(data))
+	return []byte(formatted), nil
+}

--- a/tools/fmt/fmt_test.go
+++ b/tools/fmt/fmt_test.go
@@ -1,0 +1,12 @@
+package mfmt
+
+import (
+	"mochi/golden"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	golden.Run(t, "tests/fmt", ".mochi", ".golden", func(src string) ([]byte, error) {
+		return FormatFile(src)
+	})
+}


### PR DESCRIPTION
## Summary
- implement a minimal formatter library under `tools/fmt`
- add golden tests demonstrating canonical formatting

## Testing
- `go test ./tools/fmt -run TestFormat -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b3aa7f78883209b2af7ede5d3a1fa