### PR TITLE
Use shared type inference in Clojure backend

### DIFF
--- a/compile/x/clj/compiler.go
+++ b/compile/x/clj/compiler.go
@@ -297,7 +297,7 @@ func (c *Compiler) compileLet(st *parser.LetStmt) error {
 		if st.Type != nil {
 			typ = c.resolveTypeRef(st.Type)
 		} else {
-			typ = c.inferExprType(st.Value)
+			typ = c.exprType(st.Value)
 		}
 		c.env.SetVar(st.Name, typ, true)
 	}
@@ -319,7 +319,7 @@ func (c *Compiler) compileVar(st *parser.VarStmt) error {
 		if st.Type != nil {
 			typ = c.resolveTypeRef(st.Type)
 		} else if st.Value != nil {
-			typ = c.inferExprType(st.Value)
+			typ = c.exprType(st.Value)
 		}
 		c.env.SetVar(st.Name, typ, true)
 	}
@@ -349,7 +349,7 @@ func (c *Compiler) compileAssign(st *parser.AssignStmt) error {
 	if len(st.Index) == 0 {
 		c.writeln(fmt.Sprintf("(def %s %s)", name, rhs))
 		if c.env != nil {
-			typ := c.inferExprType(st.Value)
+			typ := c.exprType(st.Value)
 			c.env.SetVar(st.Name, typ, true)
 		}
 		return nil
@@ -598,7 +598,7 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 		return "", err
 	}
 	operands := []string{left}
-	typesList := []types.Type{c.inferUnaryType(b.Left)}
+	typesList := []types.Type{c.unaryType(b.Left)}
 	ops := []string{}
 	for _, part := range b.Right {
 		r, err := c.compilePostfix(part.Right)
@@ -610,7 +610,7 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 			op = "union_all"
 		}
 		operands = append(operands, r)
-		typesList = append(typesList, c.inferPostfixType(part.Right))
+		typesList = append(typesList, c.postfixType(part.Right))
 		ops = append(ops, op)
 	}
 
@@ -739,7 +739,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	t := c.inferPrimaryType(p.Target)
+	t := c.primaryType(p.Target)
 	for _, op := range p.Ops {
 		if op.Index != nil {
 			start, err := c.compileExpr(op.Index.Start)

--- a/compile/x/clj/infer.go
+++ b/compile/x/clj/infer.go
@@ -5,301 +5,37 @@ import (
 	"mochi/types"
 )
 
-func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	return c.inferBinaryType(e.Binary)
+// exprType returns the static type of expression e using the compiler's env.
+func (c *Compiler) exprType(e *parser.Expr) types.Type {
+	return types.InferExprType(e, c.env)
 }
 
-func (c *Compiler) inferCallType(call *parser.CallExpr) types.Type {
-	switch call.Func {
-	case "len":
-		return types.IntType{}
-	case "str":
-		return types.StringType{}
-	case "count":
-		return types.IntType{}
-	case "avg":
-		return types.FloatType{}
-	case "now":
-		return types.Int64Type{}
-	case "input":
-		return types.StringType{}
-	case "print", "json":
-		return types.VoidType{}
-	case "keys":
-		return types.ListType{Elem: types.AnyType{}}
-	default:
-		if c.env != nil {
-			if t, err := c.env.GetVar(call.Func); err == nil {
-				if ft, ok := t.(types.FuncType); ok {
-					return ft.Return
-				}
-			}
-		}
-		return types.AnyType{}
-	}
-}
-
-func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
-	if b == nil {
-		return types.AnyType{}
-	}
-	t := c.inferUnaryType(b.Left)
-	for _, op := range b.Right {
-		rt := c.inferPostfixType(op.Right)
-		switch op.Op {
-		case "+", "-", "*", "/", "%":
-			if isInt64(t) {
-				if isInt64(rt) || isInt(rt) {
-					t = types.Int64Type{}
-					continue
-				}
-			}
-			if _, ok := t.(types.IntType); ok {
-				if _, ok := rt.(types.IntType); ok {
-					t = types.IntType{}
-					continue
-				}
-			}
-			if _, ok := t.(types.FloatType); ok {
-				if _, ok := rt.(types.FloatType); ok {
-					t = types.FloatType{}
-					continue
-				}
-			}
-			if op.Op == "+" {
-				if llist, ok := t.(types.ListType); ok {
-					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
-						t = llist
-						continue
-					}
-				}
-				if _, ok := t.(types.StringType); ok {
-					if _, ok := rt.(types.StringType); ok {
-						t = types.StringType{}
-						continue
-					}
-				}
-			}
-			t = types.AnyType{}
-		case "==", "!=", "<", "<=", ">", ">=", "in":
-			t = types.BoolType{}
-		case "union", "union_all", "except", "intersect":
-			if llist, ok := t.(types.ListType); ok {
-				if rlist, ok := rt.(types.ListType); ok {
-					if equalTypes(llist.Elem, rlist.Elem) {
-						t = llist
-					} else {
-						t = types.ListType{Elem: types.AnyType{}}
-					}
-				} else {
-					t = types.ListType{Elem: types.AnyType{}}
-				}
-			} else {
-				t = types.AnyType{}
-			}
-		default:
-			t = types.AnyType{}
-		}
-	}
-	return t
-}
-
-func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+// unaryType infers the type of a unary expression.
+func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 	if u == nil {
 		return types.AnyType{}
 	}
-	return c.inferPostfixType(u.Value)
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
 }
 
-func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+// postfixType infers the type of a postfix expression.
+func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	t := c.inferPrimaryType(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil && op.Index.Colon == nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt.Elem
-			case types.MapType:
-				t = tt.Value
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Index != nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Field != nil {
-			switch tt := t.(type) {
-			case types.StructType:
-				if ft, ok := tt.Fields[op.Field.Name]; ok {
-					t = ft
-				} else {
-					t = types.AnyType{}
-				}
-			case types.MapType:
-				t = tt.Value
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Call != nil {
-			if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 1 {
-				method := p.Target.Selector.Tail[0]
-				switch method {
-				case "keys":
-					t = types.ListType{Elem: types.AnyType{}}
-					continue
-				}
-			}
-			if ft, ok := t.(types.FuncType); ok {
-				t = ft.Return
-			} else {
-				t = types.AnyType{}
-			}
-		} else if op.Cast != nil {
-			t = c.resolveTypeRef(op.Cast.Type)
-		}
-	}
-	return t
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }
 
-func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+// primaryType infers the type of a primary expression.
+func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.Selector != nil:
-		if c.env != nil {
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				if len(p.Selector.Tail) == 0 {
-					return t
-				}
-				if st, ok := t.(types.StructType); ok {
-					cur := st
-					for idx, field := range p.Selector.Tail {
-						ft, ok := cur.Fields[field]
-						if !ok {
-							return types.AnyType{}
-						}
-						if idx == len(p.Selector.Tail)-1 {
-							return ft
-						}
-						if next, ok := ft.(types.StructType); ok {
-							cur = next
-						} else {
-							return types.AnyType{}
-						}
-					}
-				}
-			}
-		}
-		return types.AnyType{}
-	case p.Struct != nil:
-		if c.env != nil {
-			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
-				return st
-			}
-		}
-		return types.AnyType{}
-	case p.FunExpr != nil:
-		params := make([]types.Type, len(p.FunExpr.Params))
-		for i, par := range p.FunExpr.Params {
-			if par.Type != nil {
-				params[i] = c.resolveTypeRef(par.Type)
-			} else {
-				params[i] = types.AnyType{}
-			}
-		}
-		var ret types.Type = types.VoidType{}
-		if p.FunExpr.Return != nil {
-			ret = c.resolveTypeRef(p.FunExpr.Return)
-		} else if p.FunExpr.ExprBody != nil {
-			ret = c.inferExprType(p.FunExpr.ExprBody)
-		} else {
-			ret = types.AnyType{}
-		}
-		return types.FuncType{Params: params, Return: ret}
-	case p.Call != nil:
-		return c.inferCallType(p.Call)
-	case p.Load != nil:
-		var elem types.Type = types.MapType{Key: types.StringType{}, Value: types.StringType{}}
-		if p.Load.Type != nil {
-			elem = c.resolveTypeRef(p.Load.Type)
-		}
-		return types.ListType{Elem: elem}
-	case p.Save != nil:
-		return types.VoidType{}
-	case p.Group != nil:
-		return c.inferExprType(p.Group)
-	case p.List != nil:
-		var elemType types.Type = types.AnyType{}
-		if len(p.List.Elems) > 0 {
-			elemType = c.inferExprType(p.List.Elems[0])
-			for _, e := range p.List.Elems[1:] {
-				t := c.inferExprType(e)
-				if !equalTypes(elemType, t) {
-					elemType = types.AnyType{}
-					break
-				}
-			}
-		}
-		return types.ListType{Elem: elemType}
-	case p.Map != nil:
-		var keyType types.Type = types.AnyType{}
-		var valType types.Type = types.AnyType{}
-		if len(p.Map.Items) > 0 {
-			keyType = c.inferExprType(p.Map.Items[0].Key)
-			valType = c.inferExprType(p.Map.Items[0].Value)
-			for _, it := range p.Map.Items[1:] {
-				kt := c.inferExprType(it.Key)
-				vt := c.inferExprType(it.Value)
-				if !equalTypes(keyType, kt) {
-					keyType = types.AnyType{}
-				}
-				if !equalTypes(valType, vt) {
-					valType = types.AnyType{}
-				}
-			}
-		}
-		return types.MapType{Key: keyType, Value: valType}
-	case p.Query != nil:
-		return types.ListType{Elem: c.inferExprType(p.Query.Select)}
-	case p.Match != nil:
-		var rType types.Type
-		for _, cs := range p.Match.Cases {
-			t := c.inferExprType(cs.Result)
-			if rType == nil {
-				rType = t
-			} else if !equalTypes(rType, t) {
-				rType = types.AnyType{}
-			}
-		}
-		if rType == nil {
-			rType = types.AnyType{}
-		}
-		return rType
-	}
-	return types.AnyType{}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }


### PR DESCRIPTION
## Summary
- remove old Clojure type inference implementation
- call `types.InferExprType` for expression type inference
- rename helper methods to match Go naming style

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b45edcb308320bd2f613ddf0e10a7