### PR TITLE
Move C compiler type inference to shared package

### DIFF
--- a/compile/x/c/compiler.go
+++ b/compile/x/c/compiler.go
@@ -609,7 +609,7 @@ func (c *Compiler) compileLet(stmt *parser.LetStmt) error {
 	if stmt.Type != nil {
 		t = resolveTypeRef(stmt.Type, c.env)
 	} else if stmt.Value != nil {
-		t = c.inferExprType(stmt.Value)
+		t = c.exprType(stmt.Value)
 	}
 	if t == nil {
 		t = types.IntType{}
@@ -672,7 +672,7 @@ func (c *Compiler) compileVar(stmt *parser.VarStmt) error {
 	if stmt.Type != nil {
 		t = resolveTypeRef(stmt.Type, c.env)
 	} else if stmt.Value != nil {
-		t = c.inferExprType(stmt.Value)
+		t = c.exprType(stmt.Value)
 	}
 	if t == nil {
 		t = types.IntType{}
@@ -1654,7 +1654,7 @@ func isStringArg(e *parser.Expr, env *types.Env) bool {
 		return false
 	}
 	c := New(env)
-	_, ok := c.inferExprType(e).(types.StringType)
+	_, ok := c.exprType(e).(types.StringType)
 	return ok
 }
 
@@ -1731,7 +1731,7 @@ func isFloatArg(e *parser.Expr, env *types.Env) bool {
 		return false
 	}
 	c := New(env)
-	_, ok := c.inferExprType(e).(types.FloatType)
+	_, ok := c.exprType(e).(types.FloatType)
 	return ok
 }
 

--- a/compile/x/c/infer.go
+++ b/compile/x/c/infer.go
@@ -5,301 +5,38 @@ import (
 	"mochi/types"
 )
 
-func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	return c.inferBinaryType(e.Binary)
+// exprType delegates to types.InferExprType.
+func (c *Compiler) exprType(e *parser.Expr) types.Type {
+	return types.InferExprType(e, c.env)
 }
 
-func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
-	if b == nil {
-		return types.AnyType{}
-	}
-	t := c.inferUnaryType(b.Left)
-	for _, op := range b.Right {
-		rt := c.inferPostfixType(op.Right)
-		switch op.Op {
-		case "+", "-", "*", "/", "%", "union", "except", "intersect":
-			if isNumber(t) && isNumber(rt) {
-				if isFloat(t) || isFloat(rt) {
-					t = types.FloatType{}
-				} else {
-					t = types.IntType{}
-				}
-				continue
-			}
-			if op.Op == "+" || op.Op == "union" || op.Op == "except" || op.Op == "intersect" {
-				if llist, ok := t.(types.ListType); ok {
-					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
-						t = llist
-						continue
-					}
-				}
-				if isString(t) && isString(rt) {
-					t = types.StringType{}
-					continue
-				}
-			}
-			t = types.AnyType{}
-		case "==", "!=", "<", "<=", ">", ">=":
-			t = types.BoolType{}
-		case "&&", "||":
-			if _, ok := t.(types.BoolType); ok {
-				if _, ok2 := rt.(types.BoolType); ok2 {
-					t = types.BoolType{}
-					continue
-				}
-			}
-			t = types.AnyType{}
-		case "in":
-			switch rt.(type) {
-			case types.MapType, types.ListType, types.StringType:
-				t = types.BoolType{}
-			default:
-				t = types.AnyType{}
-			}
-		default:
-			t = types.AnyType{}
-		}
-	}
-	return t
-}
-
-func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 	if u == nil {
 		return types.AnyType{}
 	}
-	t := c.inferPostfixType(u.Value)
-	for i := len(u.Ops) - 1; i >= 0; i-- {
-		op := u.Ops[i]
-		switch op {
-		case "!":
-			t = types.BoolType{}
-		case "-":
-			if !isNumber(t) {
-				t = types.AnyType{}
-			}
-		}
-	}
-	return t
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
 }
 
-func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	t := c.inferPrimaryType(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil && op.Index.Colon == nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt.Elem
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Index != nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Call != nil {
-			if ft, ok := t.(types.FuncType); ok {
-				t = ft.Return
-			} else {
-				t = types.AnyType{}
-			}
-		} else if op.Cast != nil {
-			t = resolveTypeRef(op.Cast.Type, c.env)
-		}
-	}
-	return t
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }
 
-func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.Selector != nil:
-		if c.env != nil {
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				if len(p.Selector.Tail) == 0 {
-					return t
-				}
-				if st, ok := t.(types.StructType); ok {
-					cur := st
-					for idx, field := range p.Selector.Tail {
-						ft, ok := cur.Fields[field]
-						if !ok {
-							if idx == len(p.Selector.Tail)-1 {
-								if m, okm := cur.Methods[field]; okm {
-									return m.Type
-								}
-							}
-							return types.AnyType{}
-						}
-						if idx == len(p.Selector.Tail)-1 {
-							return ft
-						}
-						if next, ok := ft.(types.StructType); ok {
-							cur = next
-						} else {
-							return types.AnyType{}
-						}
-					}
-				}
-			}
-		}
-		return types.AnyType{}
-	case p.Struct != nil:
-		if c.env != nil {
-			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
-				return st
-			}
-		}
-		return types.AnyType{}
-	case p.FunExpr != nil:
-		params := make([]types.Type, len(p.FunExpr.Params))
-		for i, par := range p.FunExpr.Params {
-			if par.Type != nil {
-				params[i] = resolveTypeRef(par.Type, c.env)
-			} else {
-				params[i] = types.AnyType{}
-			}
-		}
-		var ret types.Type = types.VoidType{}
-		if p.FunExpr.Return != nil {
-			ret = resolveTypeRef(p.FunExpr.Return, c.env)
-		} else if p.FunExpr.ExprBody != nil {
-			ret = c.inferExprType(p.FunExpr.ExprBody)
-		} else {
-			ret = types.AnyType{}
-		}
-		return types.FuncType{Params: params, Return: ret}
-	case p.Call != nil:
-		switch p.Call.Func {
-		case "len", "count":
-			return types.IntType{}
-		case "str", "input":
-			return types.StringType{}
-		case "avg":
-			return types.FloatType{}
-		default:
-			if c.env != nil {
-				if t, err := c.env.GetVar(p.Call.Func); err == nil {
-					if ft, ok := t.(types.FuncType); ok {
-						return ft.Return
-					}
-				}
-			}
-			return types.AnyType{}
-		}
-	case p.If != nil:
-		thenType := c.inferExprType(p.If.Then)
-		var elseType types.Type = types.AnyType{}
-		if p.If.ElseIf != nil {
-			elseType = c.inferPrimaryType(&parser.Primary{If: p.If.ElseIf})
-		} else if p.If.Else != nil {
-			elseType = c.inferExprType(p.If.Else)
-		}
-		if equalTypes(thenType, elseType) {
-			return thenType
-		}
-		if isNumber(thenType) && isNumber(elseType) {
-			if isFloat(thenType) || isFloat(elseType) {
-				return types.FloatType{}
-			}
-			return types.IntType{}
-		}
-		if _, ok := thenType.(types.StringType); ok {
-			if _, ok2 := elseType.(types.StringType); ok2 {
-				return types.StringType{}
-			}
-		}
-		if lt1, ok1 := thenType.(types.ListType); ok1 {
-			if lt2, ok2 := elseType.(types.ListType); ok2 && equalTypes(lt1.Elem, lt2.Elem) {
-				return lt1
-			}
-		}
-		if _, ok := thenType.(types.BoolType); ok {
-			if _, ok2 := elseType.(types.BoolType); ok2 {
-				return types.BoolType{}
-			}
-		}
-		return types.AnyType{}
-	case p.Match != nil:
-		var result types.Type = types.AnyType{}
-		for i, mc := range p.Match.Cases {
-			t := c.inferExprType(mc.Result)
-			if i == 0 {
-				result = t
-				continue
-			}
-			if equalTypes(result, t) {
-				continue
-			}
-			if isNumber(result) && isNumber(t) {
-				if isFloat(result) || isFloat(t) {
-					result = types.FloatType{}
-				} else {
-					result = types.IntType{}
-				}
-				continue
-			}
-			if _, ok := result.(types.StringType); ok {
-				if _, ok2 := t.(types.StringType); ok2 {
-					result = types.StringType{}
-					continue
-				}
-			}
-			if lt1, ok1 := result.(types.ListType); ok1 {
-				if lt2, ok2 := t.(types.ListType); ok2 && equalTypes(lt1.Elem, lt2.Elem) {
-					result = lt1
-					continue
-				}
-			}
-			if _, ok := result.(types.BoolType); ok {
-				if _, ok2 := t.(types.BoolType); ok2 {
-					result = types.BoolType{}
-					continue
-				}
-			}
-			result = types.AnyType{}
-		}
-		return result
-	case p.Group != nil:
-		return c.inferExprType(p.Group)
-	case p.List != nil:
-		var elemType types.Type = types.AnyType{}
-		if len(p.List.Elems) > 0 {
-			elemType = c.inferExprType(p.List.Elems[0])
-			for _, e := range p.List.Elems[1:] {
-				t := c.inferExprType(e)
-				if !equalTypes(elemType, t) {
-					elemType = types.AnyType{}
-					break
-				}
-			}
-		}
-		return types.ListType{Elem: elemType}
-	}
-	return types.AnyType{}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
+}
+
+func resultType(op string, left, right types.Type) types.Type {
+	return types.ResultType(op, left, right)
 }


### PR DESCRIPTION
## Summary
- centralize `if` expression inference in `types`
- replace C compiler inference logic with wrappers using `types`
- rename C compiler helpers to match Go conventions

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_685b45b20b088320ba0165a8ddfaa670