### PR TITLE
refactor lua type inference

### DIFF
--- a/compile/x/lua/helpers.go
+++ b/compile/x/lua/helpers.go
@@ -146,68 +146,7 @@ func isMap(t types.Type) bool    { _, ok := t.(types.MapType); return ok }
 func isAny(t types.Type) bool    { _, ok := t.(types.AnyType); return ok }
 
 func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
-	if t == nil {
-		return types.AnyType{}
-	}
-	if t.Fun != nil {
-		params := make([]types.Type, len(t.Fun.Params))
-		for i, p := range t.Fun.Params {
-			params[i] = c.resolveTypeRef(p)
-		}
-		var ret types.Type = types.VoidType{}
-		if t.Fun.Return != nil {
-			ret = c.resolveTypeRef(t.Fun.Return)
-		}
-		return types.FuncType{Params: params, Return: ret}
-	}
-	if t.Generic != nil {
-		name := t.Generic.Name
-		args := t.Generic.Args
-		switch name {
-		case "list":
-			if len(args) == 1 {
-				return types.ListType{Elem: c.resolveTypeRef(args[0])}
-			}
-		case "map":
-			if len(args) == 2 {
-				return types.MapType{Key: c.resolveTypeRef(args[0]), Value: c.resolveTypeRef(args[1])}
-			}
-		}
-		return types.AnyType{}
-	}
-	if t.Struct != nil {
-		fields := map[string]types.Type{}
-		order := []string{}
-		for _, f := range t.Struct.Fields {
-			fields[f.Name] = c.resolveTypeRef(f.Type)
-			order = append(order, f.Name)
-		}
-		return types.StructType{Name: "", Fields: fields, Order: order}
-	}
-
-	if t.Simple != nil {
-		switch *t.Simple {
-		case "int":
-			return types.IntType{}
-		case "float":
-			return types.FloatType{}
-		case "string":
-			return types.StringType{}
-		case "bool":
-			return types.BoolType{}
-		default:
-			if c != nil && c.env != nil {
-				if st, ok := c.env.GetStruct(*t.Simple); ok {
-					return st
-				}
-				if ut, ok := c.env.GetUnion(*t.Simple); ok {
-					return ut
-				}
-			}
-			return types.AnyType{}
-		}
-	}
-	return types.AnyType{}
+	return types.ResolveTypeRef(t, c.env)
 }
 
 func (c *Compiler) isStringExpr(e *parser.Expr) bool {

--- a/compile/x/lua/infer.go
+++ b/compile/x/lua/infer.go
@@ -5,238 +5,39 @@ import (
 	"mochi/types"
 )
 
-// inferExprType performs basic type inference for expressions.
+// inferExprType delegates to types.InferExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	return c.inferBinaryType(e.Binary)
+	return types.InferExprType(e, c.env)
 }
 
-func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
-	if b == nil {
-		return types.AnyType{}
-	}
-	t := c.inferUnaryType(b.Left)
-	for _, op := range b.Right {
-		rt := c.inferPostfixType(op.Right)
-		switch op.Op {
-		case "+", "-", "*", "/", "%":
-			if isInt64(t) {
-				if isInt64(rt) || isInt(rt) {
-					t = types.Int64Type{}
-					continue
-				}
-			}
-			if _, ok := t.(types.IntType); ok {
-				if _, ok := rt.(types.IntType); ok {
-					t = types.IntType{}
-					continue
-				}
-			}
-			if _, ok := t.(types.FloatType); ok {
-				if _, ok := rt.(types.FloatType); ok {
-					t = types.FloatType{}
-					continue
-				}
-			}
-			if op.Op == "+" {
-				if llist, ok := t.(types.ListType); ok {
-					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
-						t = llist
-						continue
-					}
-				}
-				if _, ok := t.(types.StringType); ok {
-					if _, ok := rt.(types.StringType); ok {
-						t = types.StringType{}
-						continue
-					}
-				}
-			}
-			t = types.AnyType{}
-		case "==", "!=", "<", "<=", ">", ">=":
-			t = types.BoolType{}
-		case "in":
-			switch rt.(type) {
-			case types.MapType, types.ListType, types.StringType:
-				t = types.BoolType{}
-			default:
-				t = types.AnyType{}
-			}
-		default:
-			t = types.AnyType{}
-		}
-	}
-	return t
+// inferExprTypeHint delegates to types.InferExprTypeHint.
+func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
+	return types.InferExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 	if u == nil {
 		return types.AnyType{}
 	}
-	return c.inferPostfixType(u.Value)
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	t := c.inferPrimaryType(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil && op.Index.Colon == nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt.Elem
-			case types.MapType:
-				t = tt.Value
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Index != nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Call != nil {
-			if ft, ok := t.(types.FuncType); ok {
-				t = ft.Return
-			} else {
-				t = types.AnyType{}
-			}
-		} else if op.Cast != nil {
-			t = c.resolveTypeRef(op.Cast.Type)
-		}
-	}
-	return t
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.Selector != nil:
-		if c.env != nil {
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				if len(p.Selector.Tail) == 0 {
-					return t
-				}
-				if st, ok := t.(types.StructType); ok {
-					cur := st
-					for idx, field := range p.Selector.Tail {
-						ft, ok := cur.Fields[field]
-						if !ok {
-							return types.AnyType{}
-						}
-						if idx == len(p.Selector.Tail)-1 {
-							return ft
-						}
-						if next, ok := ft.(types.StructType); ok {
-							cur = next
-						} else {
-							return types.AnyType{}
-						}
-					}
-				}
-			}
-		}
-		return types.AnyType{}
-	case p.Struct != nil:
-		if c.env != nil {
-			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
-				return st
-			}
-		}
-		return types.AnyType{}
-	case p.Call != nil:
-		switch p.Call.Func {
-		case "len":
-			return types.IntType{}
-		case "str":
-			return types.StringType{}
-		case "count":
-			return types.IntType{}
-		case "avg":
-			return types.FloatType{}
-		case "now":
-			return types.Int64Type{}
-		default:
-			if c.env != nil {
-				if t, err := c.env.GetVar(p.Call.Func); err == nil {
-					if ft, ok := t.(types.FuncType); ok {
-						return ft.Return
-					}
-				}
-			}
-			return types.AnyType{}
-		}
-	case p.Group != nil:
-		return c.inferExprType(p.Group)
-	case p.List != nil:
-		var elemType types.Type = types.AnyType{}
-		if len(p.List.Elems) > 0 {
-			elemType = c.inferExprType(p.List.Elems[0])
-			for _, e := range p.List.Elems[1:] {
-				t := c.inferExprType(e)
-				if !equalTypes(elemType, t) {
-					elemType = types.AnyType{}
-					break
-				}
-			}
-		}
-		return types.ListType{Elem: elemType}
-	case p.Map != nil:
-		var keyType types.Type = types.AnyType{}
-		var valType types.Type = types.AnyType{}
-		if len(p.Map.Items) > 0 {
-			keyType = c.inferExprType(p.Map.Items[0].Key)
-			valType = c.inferExprType(p.Map.Items[0].Value)
-			for _, it := range p.Map.Items[1:] {
-				kt := c.inferExprType(it.Key)
-				vt := c.inferExprType(it.Value)
-				if !equalTypes(keyType, kt) {
-					keyType = types.AnyType{}
-				}
-				if !equalTypes(valType, vt) {
-					valType = types.AnyType{}
-				}
-			}
-		}
-		return types.MapType{Key: keyType, Value: valType}
-	case p.Query != nil:
-		return types.ListType{Elem: c.inferExprType(p.Query.Select)}
-	case p.Match != nil:
-		var rType types.Type
-		for _, cs := range p.Match.Cases {
-			t := c.inferExprType(cs.Result)
-			if rType == nil {
-				rType = t
-			} else if !equalTypes(rType, t) {
-				rType = types.AnyType{}
-			}
-		}
-		if rType == nil {
-			rType = types.AnyType{}
-		}
-		return rType
-	}
-	return types.AnyType{}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }


### PR DESCRIPTION
## Summary
- delegate Lua compiler's inference helpers to the types package
- rely on shared `ResolveTypeRef` for type references

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_685b492fd4b08320a0eee0383276043f