### PR TITLE
Refactor dart type inference

### DIFF
--- a/compile/x/dart/compiler.go
+++ b/compile/x/dart/compiler.go
@@ -288,7 +288,7 @@ func (c *Compiler) compileLet(s *parser.LetStmt) error {
 		}
 	}
 	if (typ == nil || isAny(typ)) && s.Value != nil {
-		typ = c.inferExprType(s.Value)
+		typ = c.exprType(s.Value)
 	}
 	var val string
 	if s.Value != nil {
@@ -403,7 +403,7 @@ func (c *Compiler) compileVar(s *parser.VarStmt) error {
 		}
 	}
 	if (typ == nil || isAny(typ)) && s.Value != nil {
-		typ = c.inferExprType(s.Value)
+		typ = c.exprType(s.Value)
 	}
 	var val string
 	if s.Value != nil {
@@ -550,7 +550,7 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 	operands = append(operands, left)
 	floats = append(floats, isFloatUnary(c, b.Left))
 	strings = append(strings, isStringUnary(c, b.Left))
-	typesList = append(typesList, c.inferUnaryType(b.Left))
+	typesList = append(typesList, c.unaryType(b.Left))
 
 	for _, op := range b.Right {
 		right, err := c.compilePostfix(op.Right)
@@ -562,7 +562,7 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 		posts = append(posts, op.Right)
 		floats = append(floats, isFloatPostfix(c, op.Right))
 		strings = append(strings, isStringPostfix(c, op.Right))
-		typesList = append(typesList, c.inferPostfixType(op.Right))
+		typesList = append(typesList, c.postfixType(op.Right))
 	}
 
 	levels := [][]string{
@@ -985,7 +985,7 @@ func (c *Compiler) compileFun(fun *parser.FunStmt) error {
 		if fun.Return != nil {
 			ft.Return = c.resolveTypeRef(fun.Return)
 		} else {
-			ft.Return = c.inferFuncReturn(fun.Body)
+			ft.Return = c.funcReturnType(fun.Body)
 		}
 	}
 
@@ -1049,7 +1049,7 @@ func (c *Compiler) compileMethod(structName string, fun *parser.FunStmt) error {
 		if fun.Return != nil {
 			ft.Return = c.resolveTypeRef(fun.Return)
 		} else {
-			ft.Return = c.inferFuncReturn(fun.Body)
+			ft.Return = c.funcReturnType(fun.Body)
 		}
 	}
 

--- a/compile/x/dart/infer.go
+++ b/compile/x/dart/infer.go
@@ -5,250 +5,51 @@ import (
 	"mochi/types"
 )
 
-func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	return c.inferBinaryType(e.Binary)
+// exprType returns the static type of expression e using the compiler's env.
+func (c *Compiler) exprType(e *parser.Expr) types.Type {
+	return types.InferExprType(e, c.env)
 }
 
-func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
-	if b == nil {
-		return types.AnyType{}
-	}
-	t := c.inferUnaryType(b.Left)
-	for _, op := range b.Right {
-		rt := c.inferPostfixType(op.Right)
-		switch op.Op {
-		case "+", "-", "*", "/", "%":
-			if isInt64(t) {
-				if isInt64(rt) || isInt(rt) {
-					t = types.Int64Type{}
-					continue
-				}
-			}
-			if _, ok := t.(types.IntType); ok {
-				if _, ok := rt.(types.IntType); ok {
-					t = types.IntType{}
-					continue
-				}
-			}
-			if _, ok := t.(types.FloatType); ok {
-				if _, ok := rt.(types.FloatType); ok {
-					t = types.FloatType{}
-					continue
-				}
-			}
-			if op.Op == "+" {
-				if llist, ok := t.(types.ListType); ok {
-					if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
-						t = llist
-						continue
-					}
-				}
-				if _, ok := t.(types.StringType); ok {
-					if _, ok := rt.(types.StringType); ok {
-						t = types.StringType{}
-						continue
-					}
-				}
-			}
-			t = types.AnyType{}
-		case "==", "!=", "<", "<=", ">", ">=":
-			t = types.BoolType{}
-		case "union", "union_all", "except", "intersect":
-			if llist, ok := t.(types.ListType); ok {
-				if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
-					t = llist
-					continue
-				}
-			}
-			t = types.ListType{Elem: types.AnyType{}}
-		default:
-			t = types.AnyType{}
-		}
-	}
-	return t
-}
-
-func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+// unaryType infers the type of a unary expression.
+func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 	if u == nil {
 		return types.AnyType{}
 	}
-	return c.inferPostfixType(u.Value)
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
 }
 
-func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+// postfixType infers the type of a postfix expression.
+func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	t := c.inferPrimaryType(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil && op.Index.Colon == nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt.Elem
-			case types.MapType:
-				t = tt.Value
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Index != nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Call != nil {
-			if ft, ok := t.(types.FuncType); ok {
-				t = ft.Return
-			} else {
-				t = types.AnyType{}
-			}
-		} else if op.Cast != nil {
-			t = c.resolveTypeRef(op.Cast.Type)
-		}
-	}
-	return t
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }
 
-// inferFuncReturn tries to determine the return type of a function by looking
-// at the first return statement in its body. If no return statement is found
-// the function is assumed to return void.
-func (c *Compiler) inferFuncReturn(body []*parser.Statement) types.Type {
+// primaryType infers the type of a primary expression.
+func (c *Compiler) primaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
+}
+
+// funcReturnType determines the return type of the first return statement.
+func (c *Compiler) funcReturnType(body []*parser.Statement) types.Type {
 	for _, s := range body {
 		if s.Return != nil {
-			return c.inferExprType(s.Return.Value)
+			return c.exprType(s.Return.Value)
 		}
 	}
 	return types.VoidType{}
 }
 
-func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
-	if p == nil {
-		return types.AnyType{}
-	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.Selector != nil:
-		if c.env != nil {
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				if len(p.Selector.Tail) == 0 {
-					return t
-				}
-				if st, ok := t.(types.StructType); ok {
-					cur := st
-					for idx, field := range p.Selector.Tail {
-						ft, ok := cur.Fields[field]
-						if !ok {
-							return types.AnyType{}
-						}
-						if idx == len(p.Selector.Tail)-1 {
-							return ft
-						}
-						if next, ok := ft.(types.StructType); ok {
-							cur = next
-						} else {
-							return types.AnyType{}
-						}
-					}
-				}
-			}
-		}
-		return types.AnyType{}
-	case p.Struct != nil:
-		if c.env != nil {
-			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
-				return st
-			}
-		}
-		return types.AnyType{}
-	case p.Call != nil:
-		switch p.Call.Func {
-		case "len":
-			return types.IntType{}
-		case "str":
-			return types.StringType{}
-		case "count":
-			return types.IntType{}
-		case "avg":
-			return types.FloatType{}
-		case "now":
-			return types.Int64Type{}
-		default:
-			if c.env != nil {
-				if t, err := c.env.GetVar(p.Call.Func); err == nil {
-					if ft, ok := t.(types.FuncType); ok {
-						return ft.Return
-					}
-				}
-			}
-			return types.AnyType{}
-		}
-	case p.Group != nil:
-		return c.inferExprType(p.Group)
-	case p.List != nil:
-		var elemType types.Type = types.AnyType{}
-		if len(p.List.Elems) > 0 {
-			elemType = c.inferExprType(p.List.Elems[0])
-			for _, e := range p.List.Elems[1:] {
-				t := c.inferExprType(e)
-				if !equalTypes(elemType, t) {
-					elemType = types.AnyType{}
-					break
-				}
-			}
-		}
-		return types.ListType{Elem: elemType}
-	case p.Map != nil:
-		var keyType types.Type = types.AnyType{}
-		var valType types.Type = types.AnyType{}
-		if len(p.Map.Items) > 0 {
-			keyType = c.inferExprType(p.Map.Items[0].Key)
-			valType = c.inferExprType(p.Map.Items[0].Value)
-			for _, it := range p.Map.Items[1:] {
-				kt := c.inferExprType(it.Key)
-				vt := c.inferExprType(it.Value)
-				if !equalTypes(keyType, kt) {
-					keyType = types.AnyType{}
-				}
-				if !equalTypes(valType, vt) {
-					valType = types.AnyType{}
-				}
-			}
-		}
-		return types.MapType{Key: keyType, Value: valType}
-	case p.Query != nil:
-		return types.ListType{Elem: c.inferExprType(p.Query.Select)}
-	case p.Match != nil:
-		var rType types.Type
-		for _, cs := range p.Match.Cases {
-			t := c.inferExprType(cs.Result)
-			if rType == nil {
-				rType = t
-			} else if !equalTypes(rType, t) {
-				rType = types.AnyType{}
-			}
-		}
-		if rType == nil {
-			rType = types.AnyType{}
-		}
-		return rType
-	}
-	return types.AnyType{}
+func resultType(op string, left, right types.Type) types.Type {
+	return types.ResultType(op, left, right)
 }


### PR DESCRIPTION
## Summary
- delegate Dart type inference to the shared `types` package
- rename compiler helpers to use `exprType`, `unaryType`, `postfixType`, `primaryType`, and `funcReturnType`

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b489300ac832093fe66745c2ba825