### PR TITLE
Refactor kt compiler type inference

### DIFF
--- a/compile/x/kt/helpers.go
+++ b/compile/x/kt/helpers.go
@@ -70,7 +70,7 @@ func isStringUnary(u *parser.Unary, env *types.Env) bool {
 	return isStringPostfix(u.Value, env)
 }
 
-func isStringExpr(e *parser.Expr, env *types.Env) bool {
+func isString(e *parser.Expr, env *types.Env) bool {
 	if e == nil || e.Binary == nil {
 		return false
 	}
@@ -192,7 +192,7 @@ func isListUnary(u *parser.Unary, env *types.Env) bool {
 	return isListPostfix(u.Value, env)
 }
 
-func isListExpr(e *parser.Expr, env *types.Env) bool {
+func isList(e *parser.Expr, env *types.Env) bool {
 	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
 		return false
 	}
@@ -230,7 +230,7 @@ func isMapUnary(u *parser.Unary, env *types.Env) bool {
 	return isMapPostfix(u.Value, env)
 }
 
-func isMapExpr(e *parser.Expr, env *types.Env) bool {
+func isMap(e *parser.Expr, env *types.Env) bool {
 	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
 		return false
 	}

--- a/compile/x/kt/infer.go
+++ b/compile/x/kt/infer.go
@@ -1,0 +1,47 @@
+package ktcode
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// inferExprType delegates to types.InferExprType.
+func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
+	return types.InferExprType(e, c.env)
+}
+
+// inferExprTypeHint delegates to types.InferExprTypeHint.
+func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
+	return types.InferExprTypeHint(e, hint, c.env)
+}
+
+func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+	if u == nil {
+		return types.AnyType{}
+	}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
+}
+
+func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
+}
+
+func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
+}
+
+func resultType(op string, left, right types.Type) types.Type {
+	return types.ResultType(op, left, right)
+}


### PR DESCRIPTION
## Summary
- delegate Kotlin backend type inference to the shared types package
- simplify helper names to match Go conventions
- expose wrappers for future reuse

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b493b2f948320b1f837b440f49ffa