### PR TITLE
Refactor PHP compiler type inference

### DIFF
--- a/compile/x/php/compiler.go
+++ b/compile/x/php/compiler.go
@@ -722,7 +722,7 @@ func (c *Compiler) compileMapLiteral(m *parser.MapLiteral) (string, error) {
 	items := make([]string, len(m.Items))
 	for i, it := range m.Items {
 		var k string
-		if s, ok := simpleStringKey(it.Key); ok {
+		if s, ok := types.SimpleStringKey(it.Key); ok {
 			k = fmt.Sprintf("%q", s)
 		} else {
 			var err error

--- a/compile/x/php/helpers.go
+++ b/compile/x/php/helpers.go
@@ -37,30 +37,6 @@ func sanitizeName(name string) string {
 	return s
 }
 
-func simpleStringKey(e *parser.Expr) (string, bool) {
-	if e == nil {
-		return "", false
-	}
-	if len(e.Binary.Right) != 0 {
-		return "", false
-	}
-	u := e.Binary.Left
-	if len(u.Ops) != 0 {
-		return "", false
-	}
-	p := u.Value
-	if len(p.Ops) != 0 {
-		return "", false
-	}
-	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
-		return p.Target.Selector.Root, true
-	}
-	if p.Target.Lit != nil && p.Target.Lit.Str != nil {
-		return *p.Target.Lit.Str, true
-	}
-	return "", false
-}
-
 func identName(e *parser.Expr) (string, bool) {
 	if e == nil {
 		return "", false

--- a/compile/x/php/infer.go
+++ b/compile/x/php/infer.go
@@ -1,0 +1,47 @@
+package phpcode
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// inferExprType delegates to types.InferExprType.
+func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
+	return types.InferExprType(e, c.env)
+}
+
+// inferExprTypeHint delegates to types.InferExprTypeHint.
+func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
+	return types.InferExprTypeHint(e, hint, c.env)
+}
+
+func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+	if u == nil {
+		return types.AnyType{}
+	}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
+}
+
+func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
+}
+
+func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
+}
+
+func resultType(op string, left, right types.Type) types.Type {
+	return types.ResultType(op, left, right)
+}

--- a/types/infer.go
+++ b/types/infer.go
@@ -340,7 +340,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 		var keyType Type = AnyType{}
 		var valType Type = AnyType{}
 		if len(p.Map.Items) > 0 {
-			if _, ok := simpleStringKey(p.Map.Items[0].Key); ok {
+			if _, ok := SimpleStringKey(p.Map.Items[0].Key); ok {
 				keyType = StringType{}
 			} else {
 				keyType = InferExprType(p.Map.Items[0].Key, env)
@@ -348,7 +348,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			valType = InferExprType(p.Map.Items[0].Value, env)
 			for _, it := range p.Map.Items[1:] {
 				var kt Type
-				if _, ok := simpleStringKey(it.Key); ok {
+				if _, ok := SimpleStringKey(it.Key); ok {
 					kt = StringType{}
 				} else {
 					kt = InferExprType(it.Key, env)
@@ -534,7 +534,9 @@ func isBool(t Type) bool   { _, ok := t.(BoolType); return ok }
 func isString(t Type) bool { _, ok := t.(StringType); return ok }
 func isList(t Type) bool   { _, ok := t.(ListType); return ok }
 
-func simpleStringKey(e *parser.Expr) (string, bool) {
+// SimpleStringKey returns the string value of e if it is a simple
+// string key expression like a bare identifier or string literal.
+func SimpleStringKey(e *parser.Expr) (string, bool) {
 	if e == nil {
 		return "", false
 	}


### PR DESCRIPTION
## Summary
- expose `types.SimpleStringKey` and use it in map inference
- remove duplicate helper from PHP compiler
- add small inference helpers for PHP compiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b4c3c604c8320b2879b227b626676