### PR TITLE
refactor: share Prolog inference

### DIFF
--- a/compile/x/pl/helpers.go
+++ b/compile/x/pl/helpers.go
@@ -146,16 +146,16 @@ func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
 }
 
 func (c *Compiler) isStringExpr(e *parser.Expr) bool {
-	_, ok := c.inferExprType(e).(types.StringType)
+	_, ok := c.exprType(e).(types.StringType)
 	return ok
 }
 
 func (c *Compiler) isStringUnary(u *parser.Unary) bool {
-	_, ok := c.inferUnaryType(u).(types.StringType)
+	_, ok := c.unaryType(u).(types.StringType)
 	return ok
 }
 
 func (c *Compiler) isStringPostfix(p *parser.PostfixExpr) bool {
-	_, ok := c.inferPostfixType(p).(types.StringType)
+	_, ok := c.postfixType(p).(types.StringType)
 	return ok
 }

--- a/compile/x/pl/infer.go
+++ b/compile/x/pl/infer.go
@@ -1,126 +1,23 @@
 package plcode
 
 import (
-	"strings"
-
 	"mochi/parser"
 	"mochi/types"
 )
 
-// inferExprType performs minimal type inference used by the code generator.
-// It distinguishes literals, lists, maps and known variable references.
-func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	if id, ok := identName(e); ok && c.env != nil {
-		if t, err := c.env.GetVar(id); err == nil {
-			return t
-		}
-	}
-	return c.inferUnaryType(e.Binary.Left)
+// exprType delegates to types.TypeOfExpr.
+func (c *Compiler) exprType(e *parser.Expr) types.Type {
+	return types.TypeOfExpr(e, c.env)
 }
 
-func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
-	if p == nil {
-		return types.AnyType{}
-	}
-	t := c.inferPrimaryType(p.Target)
-	for _, op := range p.Ops {
-		if op.Cast != nil {
-			t = c.resolveTypeRef(op.Cast.Type)
-		} else if op.Index != nil && op.Index.Colon == nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt.Elem
-			case types.MapType:
-				t = tt.Value
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Index != nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Call != nil {
-			if ft, ok := t.(types.FuncType); ok {
-				t = ft.Return
-			} else {
-				t = types.AnyType{}
-			}
-		}
-	}
-	return t
+func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
+	return types.TypeOfPostfix(p, c.env)
 }
 
-func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
-	if u == nil {
-		return types.AnyType{}
-	}
-	return c.inferPostfixType(u.Value)
+func (c *Compiler) unaryType(u *parser.Unary) types.Type {
+	return types.TypeOfUnary(u, c.env)
 }
 
-func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
-	if p == nil {
-		return types.AnyType{}
-	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.List != nil:
-		return types.ListType{Elem: types.AnyType{}}
-	case p.Map != nil:
-		return types.MapType{Key: types.AnyType{}, Value: types.AnyType{}}
-	case p.Struct != nil:
-		if c.env != nil {
-			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
-				return st
-			}
-		}
-		return types.AnyType{}
-	case p.Selector != nil:
-		if c.env != nil {
-			if len(p.Selector.Tail) > 0 {
-				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
-				if t, err := c.env.GetVar(full); err == nil {
-					return t
-				}
-			}
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				return t
-			}
-		}
-	}
-	return types.AnyType{}
-}
-
-func isList(t types.Type) bool {
-	_, ok := t.(types.ListType)
-	return ok
-}
-
-func isMap(t types.Type) bool {
-	_, ok := t.(types.MapType)
-	return ok
-}
-
-func isString(t types.Type) bool {
-	_, ok := t.(types.StringType)
-	return ok
+func (c *Compiler) primaryType(p *parser.Primary) types.Type {
+	return types.TypeOfPrimary(p, c.env)
 }

--- a/compile/x/pl/statements.go
+++ b/compile/x/pl/statements.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"mochi/parser"
+	"mochi/types"
 )
 
 // compileBlock compiles a sequence of statements at one indentation level and
@@ -203,16 +204,16 @@ func (c *Compiler) compileStmt(s *parser.Statement, ret string) error {
 	case s.Continue != nil:
 		c.writeln("throw(continue)")
 		return nil
-        case s.Expect != nil:
-                return c.compileExpect(s.Expect)
-        case s.If != nil:
-                return c.compileIf(s.If, ret, true)
-       case s.Type != nil:
-               return c.compileTypeDecl(s.Type)
-        default:
-                return fmt.Errorf("unsupported statement")
-        }
-        return nil
+	case s.Expect != nil:
+		return c.compileExpect(s.Expect)
+	case s.If != nil:
+		return c.compileIf(s.If, ret, true)
+	case s.Type != nil:
+		return c.compileTypeDecl(s.Type)
+	default:
+		return fmt.Errorf("unsupported statement")
+	}
+	return nil
 }
 
 func (c *Compiler) compileFor(f *parser.ForStmt, ret string) error {
@@ -225,7 +226,7 @@ func (c *Compiler) compileFor(f *parser.ForStmt, ret string) error {
 		for _, line := range src.code {
 			c.writeln(line)
 		}
-		if isMap(c.inferExprType(f.Source)) {
+		if types.IsMapType(c.exprType(f.Source)) {
 			c.use("map_keys")
 			c.writeln(fmt.Sprintf("map_keys(%s, %s),", src.val, listVar))
 		} else {
@@ -659,25 +660,25 @@ func (c *Compiler) compileTestBlock(t *parser.TestBlock) error {
 }
 
 func pureFunExpr(e *parser.Expr) *parser.FunExpr {
-        if e == nil || len(e.Binary.Right) != 0 {
-                return nil
-        }
-        u := e.Binary.Left
+	if e == nil || len(e.Binary.Right) != 0 {
+		return nil
+	}
+	u := e.Binary.Left
 	if len(u.Ops) != 0 {
 		return nil
 	}
-        p := u.Value
-        if len(p.Ops) != 0 {
-                return nil
-        }
-        return p.Target.FunExpr
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return nil
+	}
+	return p.Target.FunExpr
 }
 
 // compileTypeDecl currently emits no Prolog code as type information is
 // only used during type checking. Supporting the statement ensures that
 // type definitions inside functions do not cause compile errors.
 func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
-        // Methods are ignored since the Prolog backend has no notion of
-        // attaching functions to structs.
-        return nil
+	// Methods are ignored since the Prolog backend has no notion of
+	// attaching functions to structs.
+	return nil
 }

--- a/types/simpleinfer.go
+++ b/types/simpleinfer.go
@@ -1,0 +1,140 @@
+package types
+
+import (
+	"strings"
+
+	"mochi/parser"
+)
+
+// TypeOfExpr performs a minimal type inference on e using env.
+// It distinguishes literals, lists, maps and known variable references.
+func TypeOfExpr(e *parser.Expr, env *Env) Type {
+	if e == nil {
+		return AnyType{}
+	}
+	if id, ok := exprIdent(e); ok && env != nil {
+		if t, err := env.GetVar(id); err == nil {
+			return t
+		}
+	}
+	return TypeOfUnary(e.Binary.Left, env)
+}
+
+// TypeOfPostfix returns the type of p using minimal inference.
+func TypeOfPostfix(p *parser.PostfixExpr, env *Env) Type {
+	if p == nil {
+		return AnyType{}
+	}
+	t := TypeOfPrimary(p.Target, env)
+	for _, op := range p.Ops {
+		if op.Cast != nil {
+			t = ResolveTypeRef(op.Cast.Type, env)
+		} else if op.Index != nil && op.Index.Colon == nil {
+			switch tt := t.(type) {
+			case ListType:
+				t = tt.Elem
+			case MapType:
+				t = tt.Value
+			case StringType:
+				t = StringType{}
+			default:
+				t = AnyType{}
+			}
+		} else if op.Index != nil {
+			switch tt := t.(type) {
+			case ListType:
+				t = tt
+			case StringType:
+				t = StringType{}
+			default:
+				t = AnyType{}
+			}
+		} else if op.Call != nil {
+			if ft, ok := t.(FuncType); ok {
+				t = ft.Return
+			} else {
+				t = AnyType{}
+			}
+		}
+	}
+	return t
+}
+
+// TypeOfUnary returns the type of u using minimal inference.
+func TypeOfUnary(u *parser.Unary, env *Env) Type {
+	if u == nil {
+		return AnyType{}
+	}
+	return TypeOfPostfix(u.Value, env)
+}
+
+// TypeOfPrimary returns the type of primary expression p using minimal inference.
+func TypeOfPrimary(p *parser.Primary, env *Env) Type {
+	if p == nil {
+		return AnyType{}
+	}
+	switch {
+	case p.Lit != nil:
+		switch {
+		case p.Lit.Str != nil:
+			return StringType{}
+		case p.Lit.Int != nil:
+			return IntType{}
+		case p.Lit.Float != nil:
+			return FloatType{}
+		case p.Lit.Bool != nil:
+			return BoolType{}
+		}
+	case p.List != nil:
+		return ListType{Elem: AnyType{}}
+	case p.Map != nil:
+		return MapType{Key: AnyType{}, Value: AnyType{}}
+	case p.Struct != nil:
+		if env != nil {
+			if st, ok := env.GetStruct(p.Struct.Name); ok {
+				return st
+			}
+		}
+		return AnyType{}
+	case p.Selector != nil:
+		if env != nil {
+			if len(p.Selector.Tail) > 0 {
+				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
+				if t, err := env.GetVar(full); err == nil {
+					return t
+				}
+			}
+			if t, err := env.GetVar(p.Selector.Root); err == nil {
+				return t
+			}
+		}
+	}
+	return AnyType{}
+}
+
+// IsListType reports whether t is a ListType.
+func IsListType(t Type) bool { _, ok := t.(ListType); return ok }
+
+// IsMapType reports whether t is a MapType.
+func IsMapType(t Type) bool { _, ok := t.(MapType); return ok }
+
+// IsStringType reports whether t is a StringType.
+func IsStringType(t Type) bool { _, ok := t.(StringType); return ok }
+
+func exprIdent(e *parser.Expr) (string, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
+}


### PR DESCRIPTION
## Summary
- move minimal inference helpers to types package
- update Prolog compiler to use common helpers
- adopt short function names matching Go conventions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b4c4d56ac832088f8365ce5988036