### PR TITLE
Refactor type inference helpers

### DIFF
--- a/compile/x/rkt/infer.go
+++ b/compile/x/rkt/infer.go
@@ -1,0 +1,47 @@
+package rktcode
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// exprType delegates to types.ExprType.
+func (c *Compiler) exprType(e *parser.Expr) types.Type {
+	return types.ExprType(e, c.env)
+}
+
+// exprTypeHint delegates to types.ExprTypeHint.
+func (c *Compiler) exprTypeHint(e *parser.Expr, hint types.Type) types.Type {
+	return types.ExprTypeHint(e, hint, c.env)
+}
+
+func (c *Compiler) unaryType(u *parser.Unary) types.Type {
+	if u == nil {
+		return types.AnyType{}
+	}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.ExprType(expr, c.env)
+}
+
+func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.ExprType(expr, c.env)
+}
+
+func (c *Compiler) primaryType(p *parser.Primary) types.Type {
+	if p == nil {
+		return types.AnyType{}
+	}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.ExprType(expr, c.env)
+}
+
+func resultType(op string, left, right types.Type) types.Type {
+	return types.ResultType(op, left, right)
+}


### PR DESCRIPTION
## Summary
- move exported expression type helpers into `types`
- deprecate old names
- expose wrappers for the Racket backend using the new helpers

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b4c68810483209ad0048090d56c29