### PR TITLE
Refactor Scala type inference

### DIFF
--- a/compile/x/scala/compiler.go
+++ b/compile/x/scala/compiler.go
@@ -367,7 +367,7 @@ func (c *Compiler) compileLet(st *parser.LetStmt) error {
 	if st.Type != nil {
 		t = c.resolveTypeRef(st.Type)
 	} else if st.Value != nil {
-		t = c.inferExprType(st.Value)
+		t = c.exprType(st.Value)
 	}
 
 	typ := scalaType(t)
@@ -405,7 +405,7 @@ func (c *Compiler) compileVar(st *parser.VarStmt) error {
 	if st.Type != nil {
 		t = c.resolveTypeRef(st.Type)
 	} else if st.Value != nil {
-		t = c.inferExprType(st.Value)
+		t = c.exprType(st.Value)
 	}
 
 	typ := scalaType(t)
@@ -614,7 +614,7 @@ func (c *Compiler) compileFor(st *parser.ForStmt) error {
 			c.loopStack = c.loopStack[:len(c.loopStack)-1]
 			return err
 		}
-		if _, ok := c.inferExprType(st.Source).(types.Int64Type); ok {
+		if _, ok := c.exprType(st.Source).(types.Int64Type); ok {
 			elemType = types.Int64Type{}
 		} else {
 			elemType = types.IntType{}
@@ -639,7 +639,7 @@ func (c *Compiler) compileFor(st *parser.ForStmt) error {
 			c.loopStack = c.loopStack[:len(c.loopStack)-1]
 			return err
 		}
-		srcType := c.inferExprType(st.Source)
+		srcType := c.exprType(st.Source)
 		switch tt := srcType.(type) {
 		case types.ListType:
 			elemType = tt.Elem
@@ -1195,7 +1195,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		c.env = orig
 		return "", err
 	}
-	selType := c.inferExprType(q.Select)
+	selType := c.exprType(q.Select)
 	var cond, sortExpr, skipExpr, takeExpr string
 	if q.Where != nil {
 		cond, err = c.compileExpr(q.Where)

--- a/compile/x/scala/infer.go
+++ b/compile/x/scala/infer.go
@@ -5,280 +5,41 @@ import (
 	"mochi/types"
 )
 
-func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	return c.inferBinaryType(e.Binary)
+// exprType returns the static type of expression e using the compiler's env.
+func (c *Compiler) exprType(e *parser.Expr) types.Type {
+	return types.InferExprType(e, c.env)
 }
 
-func (c *Compiler) inferBinaryType(b *parser.BinaryExpr) types.Type {
-	if b == nil {
-		return types.AnyType{}
-	}
-	t := c.inferUnaryType(b.Left)
-	for _, op := range b.Right {
-		rt := c.inferPostfixType(op.Right)
-		switch op.Op {
-               case "+", "-", "*", "/", "%", "union", "union_all", "except", "intersect":
-                       if isNumber(t) && isNumber(rt) {
-                               if isFloat(t) || isFloat(rt) {
-                                       t = types.FloatType{}
-                               } else {
-                                       t = types.IntType{}
-                               }
-                               continue
-                       }
-                       if op.Op == "+" || op.Op == "union" || op.Op == "union_all" || op.Op == "except" || op.Op == "intersect" {
-                               if llist, ok := t.(types.ListType); ok {
-                                       if rlist, ok := rt.(types.ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
-                                               t = llist
-                                               continue
-                                       }
-                               }
-                               if isString(t) && isString(rt) {
-                                       t = types.StringType{}
-                                       continue
-                               }
-                       }
-                       t = types.AnyType{}
-               case "==", "!=", "<", "<=", ">", ">=":
-                       t = types.BoolType{}
-               case "in":
-                       switch rt.(type) {
-                       case types.MapType, types.ListType, types.StringType:
-                               t = types.BoolType{}
-                       default:
-                               t = types.AnyType{}
-                       }
-               default:
-                       t = types.AnyType{}
-               }
-       }
-       return t
-}
-
-func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
+// unaryType infers the type of a unary expression.
+func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 	if u == nil {
 		return types.AnyType{}
 	}
-	return c.inferPostfixType(u.Value)
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
+	return types.InferExprType(expr, c.env)
 }
 
-func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
+// postfixType infers the type of a postfix expression.
+func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	t := c.inferPrimaryType(p.Target)
-	for _, op := range p.Ops {
-		if op.Index != nil && op.Index.Colon == nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt.Elem
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Index != nil {
-			switch tt := t.(type) {
-			case types.ListType:
-				t = tt
-			case types.StringType:
-				t = types.StringType{}
-			default:
-				t = types.AnyType{}
-			}
-		} else if op.Call != nil {
-			if ft, ok := t.(types.FuncType); ok {
-				t = ft.Return
-			} else {
-				t = types.AnyType{}
-			}
-		} else if op.Cast != nil {
-			t = c.resolveTypeRef(op.Cast.Type)
-		}
-	}
-	return t
+	unary := &parser.Unary{Value: p}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
 }
 
-func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
+// primaryType infers the type of a primary expression.
+func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	if p == nil {
 		return types.AnyType{}
 	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.Selector != nil:
-		if c.env != nil {
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				if len(p.Selector.Tail) == 0 {
-					return t
-				}
-				if st, ok := t.(types.StructType); ok {
-					cur := st
-					for idx, field := range p.Selector.Tail {
-						ft, ok := cur.Fields[field]
-						if !ok {
-							return types.AnyType{}
-						}
-						if idx == len(p.Selector.Tail)-1 {
-							return ft
-						}
-						if next, ok := ft.(types.StructType); ok {
-							cur = next
-						} else {
-							return types.AnyType{}
-						}
-					}
-				}
-			}
-		}
-		return types.AnyType{}
-	case p.Struct != nil:
-		if c.env != nil {
-			if st, ok := c.env.GetStruct(p.Struct.Name); ok {
-				return st
-			}
-		}
-		return types.AnyType{}
-	case p.Call != nil:
-		switch p.Call.Func {
-		case "len", "count":
-			return types.IntType{}
-		case "str", "input":
-			return types.StringType{}
-		case "avg":
-			return types.FloatType{}
-		case "now":
-			return types.Int64Type{}
-		case "to_json":
-			return types.StringType{}
-		default:
-			if c.env != nil {
-				if t, err := c.env.GetVar(p.Call.Func); err == nil {
-					if ft, ok := t.(types.FuncType); ok {
-						return ft.Return
-					}
-				}
-			}
-			return types.AnyType{}
-		}
-	case p.FunExpr != nil:
-		params := make([]types.Type, len(p.FunExpr.Params))
-		for i, par := range p.FunExpr.Params {
-			if par.Type != nil {
-				params[i] = c.resolveTypeRef(par.Type)
-			} else {
-				params[i] = types.AnyType{}
-			}
-		}
-		var ret types.Type = types.VoidType{}
-		if p.FunExpr.Return != nil {
-			ret = c.resolveTypeRef(p.FunExpr.Return)
-		} else if p.FunExpr.ExprBody != nil {
-			ret = c.inferExprType(p.FunExpr.ExprBody)
-		} else {
-			ret = types.AnyType{}
-		}
-		return types.FuncType{Params: params, Return: ret}
-	case p.If != nil:
-		thenType := c.inferExprType(p.If.Then)
-		var elseType types.Type = types.AnyType{}
-		if p.If.ElseIf != nil {
-			elseType = c.inferPrimaryType(&parser.Primary{If: p.If.ElseIf})
-		} else if p.If.Else != nil {
-			elseType = c.inferExprType(p.If.Else)
-		}
-		if equalTypes(thenType, elseType) {
-			return thenType
-		}
-		if isNumber(thenType) && isNumber(elseType) {
-			if isFloat(thenType) || isFloat(elseType) {
-				return types.FloatType{}
-			}
-			return types.IntType{}
-		}
-		if _, ok := thenType.(types.StringType); ok {
-			if _, ok2 := elseType.(types.StringType); ok2 {
-				return types.StringType{}
-			}
-		}
-		if lt1, ok1 := thenType.(types.ListType); ok1 {
-			if lt2, ok2 := elseType.(types.ListType); ok2 && equalTypes(lt1.Elem, lt2.Elem) {
-				return lt1
-			}
-		}
-		if _, ok := thenType.(types.BoolType); ok {
-			if _, ok2 := elseType.(types.BoolType); ok2 {
-				return types.BoolType{}
-			}
-		}
-		return types.AnyType{}
-	case p.Match != nil:
-		var result types.Type = types.AnyType{}
-		for i, mc := range p.Match.Cases {
-			t := c.inferExprType(mc.Result)
-			if i == 0 {
-				result = t
-				continue
-			}
-			if equalTypes(result, t) {
-				continue
-			}
-			if isNumber(result) && isNumber(t) {
-				if isFloat(result) || isFloat(t) {
-					result = types.FloatType{}
-				} else {
-					result = types.IntType{}
-				}
-				continue
-			}
-			if _, ok := result.(types.StringType); ok {
-				if _, ok2 := t.(types.StringType); ok2 {
-					result = types.StringType{}
-					continue
-				}
-			}
-			if lt1, ok1 := result.(types.ListType); ok1 {
-				if lt2, ok2 := t.(types.ListType); ok2 && equalTypes(lt1.Elem, lt2.Elem) {
-					result = lt1
-					continue
-				}
-			}
-			if _, ok := result.(types.BoolType); ok {
-				if _, ok2 := t.(types.BoolType); ok2 {
-					result = types.BoolType{}
-					continue
-				}
-			}
-			result = types.AnyType{}
-		}
-		return result
-	case p.Group != nil:
-		return c.inferExprType(p.Group)
-	case p.List != nil:
-		var elemType types.Type = types.AnyType{}
-		if len(p.List.Elems) > 0 {
-			elemType = c.inferExprType(p.List.Elems[0])
-			for _, e := range p.List.Elems[1:] {
-				t := c.inferExprType(e)
-				if !equalTypes(elemType, t) {
-					elemType = types.AnyType{}
-					break
-				}
-			}
-		}
-		return types.ListType{Elem: elemType}
-	}
-	return types.AnyType{}
+	postfix := &parser.PostfixExpr{Target: p}
+	unary := &parser.Unary{Value: postfix}
+	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
+	return types.InferExprType(expr, c.env)
+}
+
+func resultType(op string, left, right types.Type) types.Type {
+	return types.ResultType(op, left, right)
 }

--- a/types/infer.go
+++ b/types/infer.go
@@ -54,7 +54,7 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 	for _, op := range b.Right {
 		rt := inferPostfixType(env, op.Right)
 		switch op.Op {
-		case "+", "-", "*", "/", "%":
+		case "+", "-", "*", "/", "%", "union", "union_all", "except", "intersect":
 			if isInt64(t) {
 				if isInt64(rt) || isInt(rt) {
 					t = Int64Type{}
@@ -73,7 +73,7 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 					continue
 				}
 			}
-			if op.Op == "+" {
+			if op.Op == "+" || op.Op == "union" || op.Op == "union_all" || op.Op == "except" || op.Op == "intersect" {
 				if llist, ok := t.(ListType); ok {
 					if rlist, ok := rt.(ListType); ok && equalTypes(llist.Elem, rlist.Elem) {
 						t = llist
@@ -259,7 +259,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 		switch p.Call.Func {
 		case "len":
 			return IntType{}
-		case "str":
+		case "str", "input":
 			return StringType{}
 		case "count":
 			return IntType{}
@@ -267,6 +267,8 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			return FloatType{}
 		case "now":
 			return Int64Type{}
+		case "to_json":
+			return StringType{}
 		case "keys":
 			return ListType{Elem: AnyType{}}
 		default:
@@ -429,7 +431,7 @@ func inferIfExprType(ie *parser.IfExpr, env *Env) Type {
 // ResultType returns the resulting type of applying op to left and right.
 func ResultType(op string, left, right Type) Type {
 	switch op {
-	case "+", "-", "*", "/", "%":
+	case "+", "-", "*", "/", "%", "union", "union_all", "except", "intersect":
 		if _, ok := left.(IntType); ok {
 			if _, ok := right.(IntType); ok {
 				return IntType{}
@@ -440,11 +442,20 @@ func ResultType(op string, left, right Type) Type {
 				return FloatType{}
 			}
 		}
-		if op == "+" {
+		if op == "+" || op == "union" || op == "union_all" || op == "except" || op == "intersect" {
 			if _, ok := left.(StringType); ok {
 				if _, ok := right.(StringType); ok {
 					return StringType{}
 				}
+			}
+			if ll, ok := left.(ListType); ok {
+				if rl, ok := right.(ListType); ok {
+					if equalTypes(ll.Elem, rl.Elem) {
+						return ll
+					}
+					return ListType{Elem: AnyType{}}
+				}
+				return ListType{Elem: AnyType{}}
 			}
 		}
 		return AnyType{}


### PR DESCRIPTION
## Summary
- delegate Scala type inference to types package
- extend `types` inference with list set operators and builtins
- rename usages in Scala compiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b4c81a46c83209244d3617c8b2860