### PR TITLE
Move scheme inference helpers to types

### DIFF
--- a/compile/x/scheme/infer.go
+++ b/compile/x/scheme/infer.go
@@ -23,63 +23,69 @@ func (c *Compiler) varType(name string) string {
 }
 
 func (c *Compiler) isStringExpr(e *parser.Expr) bool {
-	if e == nil || e.Binary == nil || e.Binary.Left == nil {
-		return false
+	if types.IsStringExpr(e, c.env) {
+		return true
 	}
-	return c.isStringUnary(e.Binary.Left)
+	root := rootNameExpr(e)
+	return c.varType(root) == "string"
 }
 
 func (c *Compiler) isStringUnary(u *parser.Unary) bool {
-	if u == nil {
-		return false
+	if types.IsStringUnary(u, c.env) {
+		return true
 	}
-	return c.isStringPostfix(u.Value)
+	root := rootNameUnary(u)
+	return c.varType(root) == "string"
 }
 
 func (c *Compiler) isStringPostfix(p *parser.PostfixExpr) bool {
-	if p == nil {
-		return false
-	}
-	if c.isStringPrimary(p.Target) {
+	if types.IsStringPostfix(p, c.env) {
 		return true
 	}
-	if p.Target != nil && p.Target.Selector != nil {
-		return c.varType(p.Target.Selector.Root) == "string"
-	}
-	return false
+	root := rootNamePostfix(p)
+	return c.varType(root) == "string"
 }
 
 func (c *Compiler) isStringPrimary(p *parser.Primary) bool {
-	return p != nil && p.Lit != nil && p.Lit.Str != nil
-}
-
-func (c *Compiler) isMapExpr(e *parser.Expr) bool {
-	if e == nil || e.Binary == nil || e.Binary.Left == nil {
-		return false
-	}
-	return c.isMapUnary(e.Binary.Left)
-}
-
-func (c *Compiler) isMapUnary(u *parser.Unary) bool {
-	if u == nil {
-		return false
-	}
-	return c.isMapPostfix(u.Value)
-}
-
-func (c *Compiler) isMapPostfix(p *parser.PostfixExpr) bool {
-	if p == nil || len(p.Ops) > 0 {
-		return false
-	}
-	if c.isMapPrimary(p.Target) {
+	if types.IsStringPrimary(p, c.env) {
 		return true
 	}
-	if p.Target != nil && p.Target.Selector != nil {
-		return c.varType(p.Target.Selector.Root) == "map"
+	if p != nil && p.Selector != nil {
+		return c.varType(p.Selector.Root) == "string"
 	}
 	return false
 }
 
+func (c *Compiler) isMapExpr(e *parser.Expr) bool {
+	if types.IsMapExpr(e, c.env) {
+		return true
+	}
+	root := rootNameExpr(e)
+	return c.varType(root) == "map"
+}
+
+func (c *Compiler) isMapUnary(u *parser.Unary) bool {
+	if types.IsMapUnary(u, c.env) {
+		return true
+	}
+	root := rootNameUnary(u)
+	return c.varType(root) == "map"
+}
+
+func (c *Compiler) isMapPostfix(p *parser.PostfixExpr) bool {
+	if types.IsMapPostfix(p, c.env) {
+		return true
+	}
+	root := rootNamePostfix(p)
+	return c.varType(root) == "map"
+}
+
 func (c *Compiler) isMapPrimary(p *parser.Primary) bool {
-	return p != nil && p.Map != nil
+	if types.IsMapPrimary(p, c.env) {
+		return true
+	}
+	if p != nil && p.Selector != nil {
+		return c.varType(p.Selector.Root) == "map"
+	}
+	return false
 }

--- a/types/exprkind.go
+++ b/types/exprkind.go
@@ -165,3 +165,55 @@ func IsListPrimary(p *parser.Primary, env *Env) bool {
 	}
 	return false
 }
+
+// IsStringUnary reports whether u resolves to a string expression.
+func IsStringUnary(u *parser.Unary, env *Env) bool {
+	if u == nil {
+		return false
+	}
+	return IsStringPostfix(u.Value, env)
+}
+
+// IsStringPostfix reports whether p resolves to a string expression.
+func IsStringPostfix(p *parser.PostfixExpr, env *Env) bool {
+	if p == nil {
+		return false
+	}
+	if IsStringPrimary(p.Target, env) {
+		return true
+	}
+	if p.Target != nil && p.Target.Selector != nil && env != nil {
+		if typ, err := env.GetVar(p.Target.Selector.Root); err == nil {
+			if _, ok := typ.(StringType); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsMapUnary reports whether u resolves to a map expression.
+func IsMapUnary(u *parser.Unary, env *Env) bool {
+	if u == nil {
+		return false
+	}
+	return IsMapPostfix(u.Value, env)
+}
+
+// IsMapPostfix reports whether p resolves to a map expression.
+func IsMapPostfix(p *parser.PostfixExpr, env *Env) bool {
+	if p == nil || len(p.Ops) > 0 {
+		return false
+	}
+	if IsMapPrimary(p.Target, env) {
+		return true
+	}
+	if p.Target != nil && p.Target.Selector != nil && env != nil {
+		if typ, err := env.GetVar(p.Target.Selector.Root); err == nil {
+			if _, ok := typ.(MapType); ok {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- expose unary/postfix kind checks in `types` for reuse
- update Scheme compiler to use new helpers and keep local overrides

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b4cc5cd6083209b77b00812c412b6