### PR TITLE
refactor: share type inference helpers

### DIFF
--- a/compile/x/swift/typeutil.go
+++ b/compile/x/swift/typeutil.go
@@ -138,27 +138,13 @@ func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
 			}
 		}
 	}
-	prog := &parser.Program{Statements: []*parser.Statement{{Let: &parser.LetStmt{Name: "_tmp", Value: e}}}}
 	env := types.NewEnv(c.env)
 	for name, t := range c.locals {
 		env.SetVar(name, t, true)
 	}
-	if errs := types.Check(prog, env); len(errs) == 0 {
-		if t, err := env.GetVar("_tmp"); err == nil {
-			return t
-		}
-	}
-	return types.AnyType{}
+	return types.CheckExprType(e, env)
 }
 
 func containsAny(t types.Type) bool {
-	switch tt := t.(type) {
-	case types.AnyType:
-		return true
-	case types.ListType:
-		return containsAny(tt.Elem)
-	case types.MapType:
-		return containsAny(tt.Key) || containsAny(tt.Value)
-	}
-	return false
+	return types.ContainsAny(t)
 }

--- a/types/infercheck.go
+++ b/types/infercheck.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"mochi/parser"
+)
+
+// CheckExprType returns the static type of expression e using the full type
+// checker. If type checking fails the result is AnyType.
+func CheckExprType(e *parser.Expr, env *Env) Type {
+	if e == nil {
+		return AnyType{}
+	}
+	prog := &parser.Program{Statements: []*parser.Statement{{Let: &parser.LetStmt{Name: "_tmp", Value: e}}}}
+	child := NewEnv(env)
+	if errs := Check(prog, child); len(errs) == 0 {
+		if t, err := child.GetVar("_tmp"); err == nil {
+			return t
+		}
+	}
+	return AnyType{}
+}
+
+// ContainsAny reports whether t or any of its components is the Any type.
+func ContainsAny(t Type) bool {
+	switch tt := t.(type) {
+	case AnyType:
+		return true
+	case ListType:
+		return ContainsAny(tt.Elem)
+	case MapType:
+		return ContainsAny(tt.Key) || ContainsAny(tt.Value)
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- export expression type inference in `types`
- use new `CheckExprType` in Swift backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b4cd1eb84832086851de64c3758ad