### PR TITLE
refactor(ruby): share type inference

### DIFF
--- a/compile/x/rb/compiler.go
+++ b/compile/x/rb/compiler.go
@@ -397,7 +397,7 @@ func (c *Compiler) compileFor(stmt *parser.ForStmt) error {
 		}
 		if isStringLiteral(stmt.Source) {
 			c.writeln(fmt.Sprintf("for %s in %s.chars", name, src))
-		} else if isMap(c.inferExprType(stmt.Source)) {
+		} else if types.IsMapType(c.inferExprType(stmt.Source)) {
 			c.writeln(fmt.Sprintf("for %s in %s.keys", name, src))
 		} else {
 			c.writeln(fmt.Sprintf("for %s in %s", name, src))
@@ -960,7 +960,7 @@ func (c *Compiler) compileBinaryExpr(b *parser.BinaryExpr) (string, error) {
 			var expr string
 			switch op {
 			case "in":
-				if isMap(rt) {
+				if types.IsMapType(rt) {
 					expr = fmt.Sprintf("(%s.key?(%s))", r, l)
 				} else {
 					expr = fmt.Sprintf("(%s.include?(%s))", r, l)

--- a/compile/x/rb/helpers.go
+++ b/compile/x/rb/helpers.go
@@ -204,56 +204,5 @@ func (c *Compiler) isMapExpr(e *parser.Expr) bool {
 }
 
 func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
-	if t == nil {
-		return types.AnyType{}
-	}
-	if t.Fun != nil {
-		params := make([]types.Type, len(t.Fun.Params))
-		for i, p := range t.Fun.Params {
-			params[i] = c.resolveTypeRef(p)
-		}
-		var ret types.Type = types.VoidType{}
-		if t.Fun.Return != nil {
-			ret = c.resolveTypeRef(t.Fun.Return)
-		}
-		return types.FuncType{Params: params, Return: ret}
-	}
-	if t.Generic != nil {
-		name := t.Generic.Name
-		args := t.Generic.Args
-		switch name {
-		case "list":
-			if len(args) == 1 {
-				return types.ListType{Elem: c.resolveTypeRef(args[0])}
-			}
-		case "map":
-			if len(args) == 2 {
-				return types.MapType{Key: c.resolveTypeRef(args[0]), Value: c.resolveTypeRef(args[1])}
-			}
-		}
-		return types.AnyType{}
-	}
-	if t.Simple != nil {
-		switch *t.Simple {
-		case "int":
-			return types.IntType{}
-		case "float":
-			return types.FloatType{}
-		case "string":
-			return types.StringType{}
-		case "bool":
-			return types.BoolType{}
-		default:
-			if c != nil && c.env != nil {
-				if st, ok := c.env.GetStruct(*t.Simple); ok {
-					return st
-				}
-				if ut, ok := c.env.GetUnion(*t.Simple); ok {
-					return ut
-				}
-			}
-			return types.AnyType{}
-		}
-	}
-	return types.AnyType{}
+	return types.ResolveTypeRef(t, c.env)
 }

--- a/compile/x/rb/infer.go
+++ b/compile/x/rb/infer.go
@@ -1,86 +1,21 @@
 package rbcode
 
 import (
-	"strings"
-
 	"mochi/parser"
 	"mochi/types"
 )
 
-// inferExprType performs minimal type inference used by the code generator.
-// It distinguishes literals, lists, maps and known variable references.
+// inferExprType delegates to types.TypeOfExprBasic.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	if e == nil {
-		return types.AnyType{}
-	}
-	if id, ok := identName(e); ok && c.env != nil {
-		if t, err := c.env.GetVar(id); err == nil {
-			return t
-		}
-	}
-	return c.inferPostfixType(e.Binary.Left)
+	return types.TypeOfExprBasic(e, c.env)
 }
 
+// inferPostfixType delegates to types.TypeOfPostfixBasic.
 func (c *Compiler) inferPostfixType(u *parser.Unary) types.Type {
-	if u == nil {
-		return types.AnyType{}
-	}
-	t := c.inferPrimaryType(u.Value.Target)
-	for _, op := range u.Value.Ops {
-		if op.Cast != nil {
-			t = c.resolveTypeRef(op.Cast.Type)
-		}
-	}
-	return t
+	return types.TypeOfPostfixBasic(u, c.env)
 }
 
+// inferPrimaryType delegates to types.TypeOfPrimaryBasic.
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
-	if p == nil {
-		return types.AnyType{}
-	}
-	switch {
-	case p.Lit != nil:
-		switch {
-		case p.Lit.Str != nil:
-			return types.StringType{}
-		case p.Lit.Int != nil:
-			return types.IntType{}
-		case p.Lit.Float != nil:
-			return types.FloatType{}
-		case p.Lit.Bool != nil:
-			return types.BoolType{}
-		}
-	case p.List != nil:
-		return types.ListType{Elem: types.AnyType{}}
-	case p.Map != nil:
-		return types.MapType{Key: types.AnyType{}, Value: types.AnyType{}}
-	case p.Selector != nil:
-		if c.env != nil {
-			if len(p.Selector.Tail) > 0 {
-				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
-				if t, err := c.env.GetVar(full); err == nil {
-					return t
-				}
-			}
-			if t, err := c.env.GetVar(p.Selector.Root); err == nil {
-				return t
-			}
-		}
-	}
-	return types.AnyType{}
-}
-
-func isList(t types.Type) bool {
-	_, ok := t.(types.ListType)
-	return ok
-}
-
-func isMap(t types.Type) bool {
-	_, ok := t.(types.MapType)
-	return ok
-}
-
-func isString(t types.Type) bool {
-	_, ok := t.(types.StringType)
-	return ok
+	return types.TypeOfPrimaryBasic(p, c.env)
 }

--- a/types/simpleinfer.go
+++ b/types/simpleinfer.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"strings"
+
+	"mochi/parser"
+)
+
+// TypeOfExprBasic performs lightweight type inference for dynamic backends.
+// It distinguishes literals, lists, maps and known variable references.
+func TypeOfExprBasic(e *parser.Expr, env *Env) Type {
+	if e == nil {
+		return AnyType{}
+	}
+	if id, ok := identName(e); ok && env != nil {
+		if t, err := env.GetVar(id); err == nil {
+			return t
+		}
+	}
+	return TypeOfPostfixBasic(e.Binary.Left, env)
+}
+
+// TypeOfPostfixBasic infers the type of a unary expression using simple rules.
+func TypeOfPostfixBasic(u *parser.Unary, env *Env) Type {
+	if u == nil {
+		return AnyType{}
+	}
+	t := TypeOfPrimaryBasic(u.Value.Target, env)
+	for _, op := range u.Value.Ops {
+		if op.Cast != nil {
+			t = ResolveTypeRef(op.Cast.Type, env)
+		}
+	}
+	return t
+}
+
+// TypeOfPrimaryBasic infers the type of a primary expression using simple rules.
+func TypeOfPrimaryBasic(p *parser.Primary, env *Env) Type {
+	if p == nil {
+		return AnyType{}
+	}
+	switch {
+	case p.Lit != nil:
+		switch {
+		case p.Lit.Str != nil:
+			return StringType{}
+		case p.Lit.Int != nil:
+			return IntType{}
+		case p.Lit.Float != nil:
+			return FloatType{}
+		case p.Lit.Bool != nil:
+			return BoolType{}
+		}
+	case p.List != nil:
+		return ListType{Elem: AnyType{}}
+	case p.Map != nil:
+		return MapType{Key: AnyType{}, Value: AnyType{}}
+	case p.Selector != nil:
+		if env != nil {
+			if len(p.Selector.Tail) > 0 {
+				full := p.Selector.Root + "." + strings.Join(p.Selector.Tail, ".")
+				if t, err := env.GetVar(full); err == nil {
+					return t
+				}
+			}
+			if t, err := env.GetVar(p.Selector.Root); err == nil {
+				return t
+			}
+		}
+	}
+	return AnyType{}
+}
+
+// IsListType reports whether t is a list type.
+func IsListType(t Type) bool { _, ok := t.(ListType); return ok }
+
+// IsMapType reports whether t is a map type.
+func IsMapType(t Type) bool { _, ok := t.(MapType); return ok }
+
+// IsStringType reports whether t is a string type.
+func IsStringType(t Type) bool { _, ok := t.(StringType); return ok }


### PR DESCRIPTION
## Summary
- move Ruby type inference helpers into the `types` package
- expose basic inference as `TypeOfExprBasic`, `TypeOfPostfixBasic` and `TypeOfPrimaryBasic`
- provide `IsListType`, `IsMapType`, `IsStringType` helpers
- update Ruby compiler to use shared inference
- delegate type resolution via `types.ResolveTypeRef`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b51f605148320ad9d2e4b35dbb459