### PR TITLE
Add release notes for v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,24 @@
 # 📦 CHANGELOG.md
-## [0.9.5] – 2025-06-25
+## [0.9.5] – 2025-06-25T09:23:00+07:00
 
 ### Added
 
-* Prolog backend supports functions as parameters and return values
+* Relative data paths and `fetch` expression in the VM
+* Map iteration with `keys` builtin across languages
+* Nested struct and type declarations
+* Functions as parameters and return values across backends
+* Prolog backend supports passing and returning functions
+* Linter library integration with the CLI
+
+### Changed
+
+* Consolidated type inference across backends
+
+### Fixed
+
+* Parser type duplication and duplicate builtin cases
+* Map membership bug in the Lua compiler
+* If expression handling in the VM
 
 ## [0.9.4] – 2025-06-25T00:02:13+07:00
 

--- a/releases/v0.9.5.md
+++ b/releases/v0.9.5.md
@@ -1,7 +1,23 @@
 # Jun 2025 (v0.9.5)
 
-Adds first-class function support to the Prolog backend.
+Released on Wed Jun 25 09:23:00 2025 +0700.
+
+Mochi v0.9.5 introduces nested structures and map helpers across the toolchain. The VM adds relative data paths and fetch expressions while compilers gain first-class function support.
+
+## Runtime
+
+- Relative data path support
+- `fetch` expression for dataset lookups
 
 ## Compilers
 
-- Prolog backend supports passing and returning functions.
+- Map iteration and `keys` builtin across languages
+- Nested struct and type declarations
+- Functions as parameters and return values
+- Prolog backend supports passing and returning functions
+- Consolidated type inference across backends
+
+## Tooling
+
+- Linter packaged as a library and used by the CLI
+- Updated benchmarks and golden tests


### PR DESCRIPTION
## Summary
- update `CHANGELOG.md` with entries for v0.9.5
- flesh out release notes in `releases/v0.9.5.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b5e1f15cc832099b9ffb06cbb6dc1