### PR TITLE
Remove deprecated type inference helpers

### DIFF
--- a/compile/go/infer.go
+++ b/compile/go/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/py/infer.go
+++ b/compile/py/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/ts/infer.go
+++ b/compile/ts/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/c/infer.go
+++ b/compile/x/c/infer.go
@@ -5,9 +5,9 @@ import (
 	"mochi/types"
 )
 
-// exprType delegates to types.InferExprType.
+// exprType delegates to types.ExprType.
 func (c *Compiler) exprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
 func (c *Compiler) unaryType(u *parser.Unary) types.Type {
@@ -15,7 +15,7 @@ func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
@@ -24,7 +24,7 @@ func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) primaryType(p *parser.Primary) types.Type {
@@ -34,7 +34,7 @@ func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/clj/infer.go
+++ b/compile/x/clj/infer.go
@@ -7,7 +7,7 @@ import (
 
 // exprType returns the static type of expression e using the compiler's env.
 func (c *Compiler) exprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
 // unaryType infers the type of a unary expression.
@@ -16,7 +16,7 @@ func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 // postfixType infers the type of a postfix expression.
@@ -26,7 +26,7 @@ func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 // primaryType infers the type of a primary expression.
@@ -37,5 +37,5 @@ func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }

--- a/compile/x/cs/infer.go
+++ b/compile/x/cs/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/dart/infer.go
+++ b/compile/x/dart/infer.go
@@ -7,7 +7,7 @@ import (
 
 // exprType returns the static type of expression e using the compiler's env.
 func (c *Compiler) exprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
 // unaryType infers the type of a unary expression.
@@ -16,7 +16,7 @@ func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 // postfixType infers the type of a postfix expression.
@@ -26,7 +26,7 @@ func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 // primaryType infers the type of a primary expression.
@@ -37,7 +37,7 @@ func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 // funcReturnType determines the return type of the first return statement.

--- a/compile/x/erlang/infer.go
+++ b/compile/x/erlang/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// exprType delegates to types.InferExprType.
+// exprType delegates to types.ExprType.
 func (c *Compiler) exprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// exprTypeHint delegates to types.InferExprTypeHint.
+// exprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) exprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) unaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) primaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/ex/infer.go
+++ b/compile/x/ex/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,5 +39,5 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }

--- a/compile/x/hs/infer.go
+++ b/compile/x/hs/infer.go
@@ -5,9 +5,9 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -15,7 +15,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -24,7 +24,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -34,7 +34,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
@@ -43,12 +43,12 @@ func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {
 
 // helper predicates following Go naming conventions
 func (c *Compiler) isStringExpr(e *parser.Expr) bool {
-	_, ok := types.InferExprType(e, c.env).(types.StringType)
+	_, ok := types.ExprType(e, c.env).(types.StringType)
 	return ok
 }
 
 func (c *Compiler) isIntExpr(e *parser.Expr) bool {
-	return isInt(types.InferExprType(e, c.env))
+	return isInt(types.ExprType(e, c.env))
 }
 
 func (c *Compiler) isIntUnary(u *parser.Unary) bool {
@@ -74,7 +74,7 @@ func (c *Compiler) isStringPrimary(p *parser.Primary) bool {
 }
 
 func (c *Compiler) isListExpr(e *parser.Expr) bool {
-	_, ok := types.InferExprType(e, c.env).(types.ListType)
+	_, ok := types.ExprType(e, c.env).(types.ListType)
 	return ok
 }
 

--- a/compile/x/java/infer.go
+++ b/compile/x/java/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// exprType delegates to types.InferExprType.
+// exprType delegates to types.ExprType.
 func (c *Compiler) exprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// exprTypeHint delegates to types.InferExprTypeHint.
+// exprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) exprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) unaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) primaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/kt/infer.go
+++ b/compile/x/kt/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/lua/infer.go
+++ b/compile/x/lua/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,5 +39,5 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }

--- a/compile/x/php/infer.go
+++ b/compile/x/php/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/rust/infer.go
+++ b/compile/x/rust/infer.go
@@ -5,14 +5,14 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -20,7 +20,7 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -29,7 +29,7 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -39,7 +39,7 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/scala/infer.go
+++ b/compile/x/scala/infer.go
@@ -7,7 +7,7 @@ import (
 
 // exprType returns the static type of expression e using the compiler's env.
 func (c *Compiler) exprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
 // unaryType infers the type of a unary expression.
@@ -16,7 +16,7 @@ func (c *Compiler) unaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 // postfixType infers the type of a postfix expression.
@@ -26,7 +26,7 @@ func (c *Compiler) postfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 // primaryType infers the type of a primary expression.
@@ -37,7 +37,7 @@ func (c *Compiler) primaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.InferExprType(expr, c.env)
+	return types.ExprType(expr, c.env)
 }
 
 func resultType(op string, left, right types.Type) types.Type {

--- a/compile/x/zig/infer.go
+++ b/compile/x/zig/infer.go
@@ -5,12 +5,12 @@ import (
 	"mochi/types"
 )
 
-// inferExprType delegates to types.InferExprType.
+// inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.InferExprType(e, c.env)
+	return types.ExprType(e, c.env)
 }
 
-// inferExprTypeHint delegates to types.InferExprTypeHint.
+// inferExprTypeHint delegates to types.ExprTypeHint.
 func (c *Compiler) inferExprTypeHint(e *parser.Expr, hint types.Type) types.Type {
-	return types.InferExprTypeHint(e, hint, c.env)
+	return types.ExprTypeHint(e, hint, c.env)
 }

--- a/types/infer.go
+++ b/types/infer.go
@@ -21,11 +21,6 @@ func ExprType(e *parser.Expr, env *Env) Type {
 	return inferBinaryType(env, e.Binary)
 }
 
-// InferExprType is deprecated. Use ExprType instead.
-func InferExprType(e *parser.Expr, env *Env) Type {
-	return ExprType(e, env)
-}
-
 // ExprTypeHint infers the type of e using a hint for list literals.
 func ExprTypeHint(e *parser.Expr, hint Type, env *Env) Type {
 	if e == nil {
@@ -50,11 +45,6 @@ func ExprTypeHint(e *parser.Expr, hint Type, env *Env) Type {
 		}
 	}
 	return ExprType(e, env)
-}
-
-// InferExprTypeHint is deprecated. Use ExprTypeHint instead.
-func InferExprTypeHint(e *parser.Expr, hint Type, env *Env) Type {
-	return ExprTypeHint(e, hint, env)
 }
 
 func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
@@ -292,7 +282,7 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			return FloatType{}
 		case "reduce":
 			if len(p.Call.Args) == 3 {
-				return InferExprType(p.Call.Args[2], env)
+				return ExprType(p.Call.Args[2], env)
 			}
 			return AnyType{}
 		case "now":
@@ -416,11 +406,6 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 // IfExprType returns the static type of an if-expression.
 func IfExprType(ie *parser.IfExpr, env *Env) Type {
 	return inferIfExprType(ie, env)
-}
-
-// InferIfExprType is deprecated. Use IfExprType instead.
-func InferIfExprType(ie *parser.IfExpr, env *Env) Type {
-	return IfExprType(ie, env)
 }
 
 func inferIfExprType(ie *parser.IfExpr, env *Env) Type {

--- a/types/typeof.go
+++ b/types/typeof.go
@@ -3,14 +3,14 @@ package types
 import "mochi/parser"
 
 // TypeOfExpr returns the static type of expression e using env.
-// It mirrors InferExprType but follows Go naming conventions.
+// It mirrors ExprType but follows Go naming conventions.
 func TypeOfExpr(e *parser.Expr, env *Env) Type {
-	return InferExprType(e, env)
+	return ExprType(e, env)
 }
 
 // TypeOfExprHint infers the type of e using a hint for list literals.
 func TypeOfExprHint(e *parser.Expr, hint Type, env *Env) Type {
-	return InferExprTypeHint(e, hint, env)
+	return ExprTypeHint(e, hint, env)
 }
 
 // TypeOfBinary exposes inferBinaryType.


### PR DESCRIPTION
## Summary
- drop obsolete `Infer*` helpers in `types`
- call `ExprType`/`ExprTypeHint` from compilers

## Testing
- `make lint` *(fails: unused functions)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b5f5a6bb88320b3de911f1c14996d