### PR TITLE
Add left join support to Erlang backend

### DIFF
--- a/compile/x/erlang/README.md
+++ b/compile/x/erlang/README.md
@@ -43,6 +43,7 @@ The backend currently supports:
 - list set operations `union`, `union all`, `except` and `intersect`
 - simple cross joins using multiple `from` clauses
 - simple `group by` without joins or filters
+- single `left join` clauses
 - struct and union type declarations generate Erlang records
 - struct literals now instantiate these records with `#name{field=val}` syntax
 - AI `generate_text`, `generate_embed` and `generate_struct` helpers (placeholders)
@@ -83,7 +84,7 @@ func EnsureErlang() error { return ensureErlang() }
 ## Unsupported Features
 
 - The Erlang backend still implements only part of Mochi. Missing features include:
-- left/right/outer joins inside queries
+- right/outer joins inside queries
 - logic programming constructs and streams
 - agents and event streams
 - intent declarations

--- a/compile/x/erlang/runtime.go
+++ b/compile/x/erlang/runtime.go
@@ -212,6 +212,56 @@ func (c *Compiler) emitRuntime() {
 		c.indent--
 	}
 
+	if c.needLeftJoin {
+		c.writeln("")
+		c.writeln("mochi_left_join_item(A, B, Fun) ->")
+		c.indent++
+		c.writeln("Matches = [ {A, J} || J <- B, Fun(A, J) ],")
+		c.writeln("case Matches of")
+		c.indent++
+		c.writeln("[] -> [{A, undefined}];")
+		c.writeln("_ -> Matches")
+		c.indent--
+		c.writeln("end.")
+		c.indent--
+
+		c.writeln("")
+		c.writeln("mochi_left_join(L, R, Fun) ->")
+		c.indent++
+		c.writeln("lists:flatmap(fun(X) -> mochi_left_join_item(X, R, Fun) end, L).")
+		c.indent--
+	}
+
+	if c.needRightJoin {
+		c.writeln("")
+		c.writeln("mochi_right_join_item(B, A, Fun) ->")
+		c.indent++
+		c.writeln("Matches = [ {I, B} || I <- A, Fun(I, B) ],")
+		c.writeln("case Matches of")
+		c.indent++
+		c.writeln("[] -> [{undefined, B}];")
+		c.writeln("_ -> Matches")
+		c.indent--
+		c.writeln("end.")
+		c.indent--
+
+		c.writeln("")
+		c.writeln("mochi_right_join(L, R, Fun) ->")
+		c.indent++
+		c.writeln("lists:flatmap(fun(Y) -> mochi_right_join_item(Y, L, Fun) end, R).")
+		c.indent--
+	}
+
+	if c.needOuterJoin {
+		c.writeln("")
+		c.writeln("mochi_outer_join(L, R, Fun) ->")
+		c.indent++
+		c.writeln("Left = mochi_left_join(L, R, Fun),")
+		c.writeln("Right = [ P || P = {undefined, _} <- mochi_right_join(L, R, Fun) ],")
+		c.writeln("Left ++ Right.")
+		c.indent--
+	}
+
 	if c.needSetOps {
 		c.writeln("")
 		c.writeln("mochi_union(A, B) -> sets:to_list(sets:union(sets:from_list(A), sets:from_list(B))).")


### PR DESCRIPTION
## Summary
- implement left join helpers in Erlang runtime
- generate left join queries in Erlang compiler
- document capability in Erlang backend README

## Testing
- `go test ./compile/x/erlang -run TestDummy`

------
https://chatgpt.com/codex/tasks/task_e_685b772a4494832083d61305955e8595