### PR TITLE
Add dataset query support for PHP

### DIFF
--- a/compile/x/php/helpers.go
+++ b/compile/x/php/helpers.go
@@ -3,6 +3,7 @@ package phpcode
 import (
 	"mochi/parser"
 	"mochi/types"
+	"sort"
 	"strings"
 )
 
@@ -84,4 +85,24 @@ func (c *Compiler) isMapExpr(e *parser.Expr) bool {
 		}
 	}
 	return false
+}
+
+func (c *Compiler) use(name string) {
+	if c.helpers == nil {
+		c.helpers = map[string]bool{}
+	}
+	c.helpers[name] = true
+}
+
+func (c *Compiler) emitRuntime() {
+	names := make([]string, 0, len(c.helpers))
+	for n := range c.helpers {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if code, ok := helperMap[n]; ok {
+			c.buf.WriteString(code)
+		}
+	}
 }

--- a/compile/x/php/runtime.go
+++ b/compile/x/php/runtime.go
@@ -1,0 +1,112 @@
+package phpcode
+
+// Runtime helpers emitted by the PHP compiler.
+
+const helperQuery = "function _query($src, $joins, $opts) {\n" +
+	"    $items = array_map(fn($v) => [$v], $src);\n" +
+	"    foreach ($joins as $j) {\n" +
+	"        $joined = [];\n" +
+	"        if (!empty($j['right']) && !empty($j['left'])) {\n" +
+	"            $matched = array_fill(0, count($j['items']), false);\n" +
+	"            foreach ($items as $left) {\n" +
+	"                $m = false;\n" +
+	"                foreach ($j['items'] as $ri => $right) {\n" +
+	"                    $keep = true;\n" +
+	"                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }\n" +
+	"                    if (!$keep) continue;\n" +
+	"                    $m = true; $matched[$ri] = true;\n" +
+	"                    $joined[] = array_merge($left, [$right]);\n" +
+	"                }\n" +
+	"                if (!$m) { $joined[] = array_merge($left, [null]); }\n" +
+	"            }\n" +
+	"            foreach ($j['items'] as $ri => $right) {\n" +
+	"                if (!$matched[$ri]) {\n" +
+	"                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];\n" +
+	"                    $joined[] = array_merge($undef, [$right]);\n" +
+	"                }\n" +
+	"            }\n" +
+	"        } elseif (!empty($j['right'])) {\n" +
+	"            foreach ($j['items'] as $right) {\n" +
+	"                $m = false;\n" +
+	"                foreach ($items as $left) {\n" +
+	"                    $keep = true;\n" +
+	"                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }\n" +
+	"                    if (!$keep) continue;\n" +
+	"                    $m = true; $joined[] = array_merge($left, [$right]);\n" +
+	"                }\n" +
+	"                if (!$m) {\n" +
+	"                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];\n" +
+	"                    $joined[] = array_merge($undef, [$right]);\n" +
+	"                }\n" +
+	"            }\n" +
+	"        } else {\n" +
+	"            foreach ($items as $left) {\n" +
+	"                $m = false;\n" +
+	"                foreach ($j['items'] as $right) {\n" +
+	"                    $keep = true;\n" +
+	"                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }\n" +
+	"                    if (!$keep) continue;\n" +
+	"                    $m = true; $joined[] = array_merge($left, [$right]);\n" +
+	"                }\n" +
+	"                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }\n" +
+	"            }\n" +
+	"        }\n" +
+	"        $items = $joined;\n" +
+	"    }\n" +
+	"    if (isset($opts['where'])) {\n" +
+	"        $filtered = [];\n" +
+	"        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }\n" +
+	"        $items = $filtered;\n" +
+	"    }\n" +
+	"    if (isset($opts['sortKey'])) {\n" +
+	"        $pairs = [];\n" +
+	"        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }\n" +
+	"        usort($pairs, function($a, $b) {\n" +
+	"            $ak = $a['key']; $bk = $b['key'];\n" +
+	"            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;\n" +
+	"            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;\n" +
+	"            return strcmp(strval($ak), strval($bk));\n" +
+	"        });\n" +
+	"        $items = array_map(fn($p) => $p['item'], $pairs);\n" +
+	"    }\n" +
+	"    if (array_key_exists('skip', $opts)) {\n" +
+	"        $n = $opts['skip'];\n" +
+	"        $items = $n < count($items) ? array_slice($items, $n) : [];\n" +
+	"    }\n" +
+	"    if (array_key_exists('take', $opts)) {\n" +
+	"        $n = $opts['take'];\n" +
+	"        if ($n < count($items)) $items = array_slice($items, 0, $n);\n" +
+	"    }\n" +
+	"    $res = [];\n" +
+	"    foreach ($items as $r) { $res[] = $opts['select'](...$r); }\n" +
+	"    return $res;\n" +
+	"}\n"
+
+const helperGroupClass = "class _Group {\n" +
+	"    public $key;\n" +
+	"    public $Items;\n" +
+	"    function __construct($key) { $this->key = $key; $this->Items = []; }\n" +
+	"}\n"
+
+const helperGroupBy = "function _group_by($src, $keyfn) {\n" +
+	"    $groups = [];\n" +
+	"    $order = [];\n" +
+	"    foreach ($src as $it) {\n" +
+	"        $key = $keyfn($it);\n" +
+	"        $ks = strval($key);\n" +
+	"        if (!isset($groups[$ks])) {\n" +
+	"            $groups[$ks] = new _Group($key);\n" +
+	"            $order[] = $ks;\n" +
+	"        }\n" +
+	"        $groups[$ks]->Items[] = $it;\n" +
+	"    }\n" +
+	"    $res = [];\n" +
+	"    foreach ($order as $ks) { $res[] = $groups[$ks]; }\n" +
+	"    return $res;\n" +
+	"}\n"
+
+var helperMap = map[string]string{
+	"_query":    helperQuery,
+	"_group":    helperGroupClass,
+	"_group_by": helperGroupBy,
+}


### PR DESCRIPTION
## Summary
- implement runtime helpers for dataset queries in PHP backend
- extend PHP compiler to use `_query` helper for joins and sorting
- emit runtime helpers when needed

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b7798be7083209abf55bb86617515