### PR TITLE
Add dataset query support for Smalltalk compiler

### DIFF
--- a/compile/x/st/README.md
+++ b/compile/x/st/README.md
@@ -29,13 +29,13 @@ The backend implements a minimal subset of Mochi:
 - Built-ins `print`, `len`, `str`, `count`, `avg`, `input`, `now`, `json`,
   `append`, `eval`, and `reduce`
 - List set operations using `union`, `union_all`, `except` and `intersect`
+- Basic dataset queries with `from`, `where`, `sort`, `skip`, `take` and `select`
 
 ### Unsupported features
 
 The following language constructs are not yet handled:
 
 - Agents and stream handlers
-- Dataset queries and data operations (`fetch`, `load`, `save`)
 - Generative AI helpers such as `generate`
 - Logic programming (`fact`, `rule`, `query`)
 - Foreign function interface declarations (`extern`)


### PR DESCRIPTION
## Summary
- implement `compileQueryExpr` for the Smalltalk backend
- add stubbed dataset helpers and support for `load`/`save`
- expose dataset queries as supported in documentation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b77da7e488320b4291c650ae6c844