### PR TITLE
Add Scheme dataset query support

### DIFF
--- a/compile/x/scheme/README.md
+++ b/compile/x/scheme/README.md
@@ -19,12 +19,13 @@ The Scheme backend converts a limited subset of Mochi programs into Scheme sourc
 - Built‑ins: `len`, `count`, `avg`, `str`, `push`, `keys`, `print`, `input`, `_fetch`, `_load`, `_save`
 - List set operators `union`, `union_all`, `except` and `intersect`
 - Struct type declarations and methods
+- Basic dataset queries with filtering, cross joins, pagination and selection
 
 ## Unsupported Features
 
 The backend leaves many Mochi constructs unimplemented, including:
 
-- Dataset query syntax and joins
+- Advanced joins or grouping in dataset queries
 - Generative AI blocks and LLM helpers
 - Error handling with `try`/`catch`
 - Union types and `match` expressions


### PR DESCRIPTION
## Summary
- enable `QueryExpr` compilation for the Scheme backend
- generate Scheme loops for simple dataset queries
- document dataset query support in Scheme backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b77e613c88320b9d7509420557487