### PR TITLE
Add dataset query support to Haskell backend

### DIFF
--- a/compile/x/hs/README.md
+++ b/compile/x/hs/README.md
@@ -26,17 +26,17 @@ The backend implements a small but practical subset of Mochi:
 
 - Function definitions and variable bindings
 - Basic expressions including `if`/`else` and arithmetic operators
- - `for` loops over ranges, lists or maps and `while` loops
+- `for` loops over ranges, lists or maps and `while` loops
 - Lists and maps with literals, indexing and membership
 - Builtin helpers: `len`, `count`, `avg`, `str`, `push`, `keys`, `print`, `input`, `now`, `json`, `load` and `save`
 - User-defined struct types and literals
+- Dataset queries with `from`/`where`, sorting, skipping and taking
 
 ## Unsupported Features
 
 Several language constructs remain unimplemented:
 
 - `match` expressions and union types
-- Dataset query syntax like `from ... sort by ...`
 - Set literals and related operations
 - Generative AI, HTTP fetch and FFI bindings
 - Streams and long-lived agents

--- a/tests/compiler/hs/dataset.hs.out
+++ b/tests/compiler/hs/dataset.hs.out
@@ -1,6 +1,8 @@
-package hscode
+module Main where
 
-const runtime = `
+import Data.Maybe (fromMaybe)
+
+
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
@@ -97,26 +99,16 @@ _save rows path _ =
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
   in _writeOutput path text
-`
 
-const sliceHelpers = `
-_slice :: [a] -> Int -> Int -> [a]
-_slice xs i j =
-  let n = length xs
-      start0 = if i < 0 then i + n else i
-      end0 = if j < 0 then j + n else j
-      start = max 0 start0
-      end = min n end0
-      end' = if end < start then start else end
-  in take (end' - start) (drop start xs)
 
-_sliceString :: String -> Int -> Int -> String
-_sliceString s i j =
-  let n = length s
-      start0 = if i < 0 then i + n else i
-      end0 = if j < 0 then j + n else j
-      start = max 0 start0
-      end = min n end0
-      end' = if end < start then start else end
-  in take (end' - start) (drop start s)
-`
+data Person = Person {
+    name :: String,
+    age :: Int
+} deriving (Show)
+
+
+main :: IO ()
+main = do
+    let people = [Person { name = "Alice", age = 30 }, Person { name = "Bob", age = 15 }, Person { name = "Charlie", age = 65 }]
+    let names = [name (p) | p <- people, (age (p) >= 18)]
+    mapM_ (\n -> print (n)) names

--- a/tests/compiler/hs/dataset.mochi
+++ b/tests/compiler/hs/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/hs/dataset.out
+++ b/tests/compiler/hs/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie


### PR DESCRIPTION
## Summary
- enable Data.Map import by default
- implement dataset query compilation for Haskell
- support `count` on groups
- expose `_group_by` helper runtime
- document dataset queries in Haskell backend README
- add a simple dataset query test
- fix for-loop variable typing and always import runtime deps

## Testing
- `gofmt -w compile/x/hs/compiler.go compile/x/hs/runtime.go`
- `go test ./compile/x/hs -tags slow -run TestHSCompiler_GoldenSubset -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685b775719248320a9894eff8704bdc4