### PR TITLE
Enable Pascal dataset queries

### DIFF
--- a/compile/x/pas/README.md
+++ b/compile/x/pas/README.md
@@ -144,8 +144,9 @@ constructs:
 - `if`, `for` and `while` control flow
 - Struct types and simple record literals
 - Function definitions and calls
-- List and map literals with indexing and slicing
-- Dataset helpers `fetch`, `load` and `save`
+ - List and map literals with indexing and slicing
+ - Dataset helpers `fetch`, `load` and `save`
+ - Basic dataset queries with `from`/`where`/`select`, `skip` and `take`
 - Package declarations and importing of local packages
 
 ## Unsupported features
@@ -154,7 +155,6 @@ The Pascal backend only implements a minimal subset of Mochi. Features not yet
 supported include:
 
 - Union types and `match` expressions
-- Dataset queries (`from`/`where`/`select`)
 - Agents, streams and the `emit` keyword
 - Generative model blocks (`generate` and `model`)
 - The foreign function interface (`import`/`extern`)

--- a/tests/compiler/pas/dataset.mochi
+++ b/tests/compiler/pas/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/pas/dataset.out
+++ b/tests/compiler/pas/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie


### PR DESCRIPTION
## Summary
- fix variable declarations for Pascal compiler
- infer dataset element types when compiling queries
- declare compiler temporaries globally so `fpc` accepts them

## Testing
- `go test ./compile/x/pas -tags slow -run TestPascalCompiler_SubsetPrograms/dataset -v`


------
https://chatgpt.com/codex/tasks/task_e_685b778a512483209df3ad70ed38ec1f