### PR TITLE
Add skip/take to Fortran dataset queries

### DIFF
--- a/compile/x/fortran/README.md
+++ b/compile/x/fortran/README.md
@@ -22,7 +22,7 @@ Run `go test ./compile/fortran -tags slow` to execute the golden tests. They wil
 - `test` blocks and `expect` statements
 - function definitions returning integers, floats, strings or lists
 - list operations: `union`, `union all`, `except` and `intersect` on integer, float and string lists
-- basic dataset queries with `from`/`where`/`select`
+- basic dataset queries with `from`/`where`/`select` and optional `skip`/`take`
 - struct types declared with `type` blocks and simple struct literals
 - built-ins: `len`, `append`, `count`, `avg`, `str`, `now`
 - printing via `print()`


### PR DESCRIPTION
## Summary
- support `skip`/`take` in Fortran dataset queries
- document the new capability in the Fortran backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b8f1cbe388320b33d596bc9a652c1