### PR TITLE
Add advanced dataset query support to Kotlin backend

### DIFF
--- a/compile/x/kt/runtime.go
+++ b/compile/x/kt/runtime.go
@@ -245,7 +245,120 @@ const (
         }
         g.Items.add(it)
     }
-    return order.map { groups[it]!! }
+        return order.map { groups[it]!! }
+}`
+
+	helperQuery = `data class _JoinSpec(
+    val items: List<Any?>,
+    val on: ((Array<Any?>) -> Boolean)? = null,
+    val left: Boolean = false,
+    val right: Boolean = false,
+)
+
+data class _QueryOpts(
+    val selectFn: (Array<Any?>) -> Any?,
+    val where: ((Array<Any?>) -> Boolean)? = null,
+    val sortKey: ((Array<Any?>) -> Any?)? = null,
+    val skip: Int = -1,
+    val take: Int = -1,
+)
+
+fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?> {
+    var items = src.map { arrayOf(it) }.toMutableList()
+    for (j in joins) {
+        val joined = mutableListOf<Array<Any?>>()
+        if (j.right && j.left) {
+            val matched = BooleanArray(j.items.size)
+            for (left in items) {
+                var m = false
+                for ((ri, right) in j.items.withIndex()) {
+                    var keep = true
+                    if (j.on != null) {
+                        keep = j.on.invoke(left + arrayOf(right))
+                    }
+                    if (!keep) continue
+                    m = true
+                    matched[ri] = true
+                    joined.add(left + arrayOf(right))
+                }
+                if (!m) joined.add(left + arrayOf<Any?>(null))
+            }
+            for ((ri, right) in j.items.withIndex()) {
+                if (!matched[ri]) {
+                    val undef = Array(items.firstOrNull()?.size ?: 0) { null }
+                    joined.add(undef + arrayOf(right))
+                }
+            }
+        } else if (j.right) {
+            for (right in j.items) {
+                var m = false
+                for (left in items) {
+                    var keep = true
+                    if (j.on != null) {
+                        keep = j.on.invoke(left + arrayOf(right))
+                    }
+                    if (!keep) continue
+                    m = true
+                    joined.add(left + arrayOf(right))
+                }
+                if (!m) {
+                    val undef = Array(items.firstOrNull()?.size ?: 0) { null }
+                    joined.add(undef + arrayOf(right))
+                }
+            }
+        } else {
+            for (left in items) {
+                var m = false
+                for (right in j.items) {
+                    var keep = true
+                    if (j.on != null) {
+                        keep = j.on.invoke(left + arrayOf(right))
+                    }
+                    if (!keep) continue
+                    m = true
+                    joined.add(left + arrayOf(right))
+                }
+                if (j.left && !m) joined.add(left + arrayOf<Any?>(null))
+            }
+        }
+        items = joined
+    }
+    if (opts.where != null) {
+        items = items.filter { opts.where.invoke(it) }.toMutableList()
+    }
+    if (opts.sortKey != null) {
+        val pairs = items.map { it to opts.sortKey.invoke(it) }.toMutableList()
+        pairs.sortWith { a, b ->
+            val av = a.second
+            val bv = b.second
+            when (av) {
+                is Int -> when (bv) {
+                    is Int -> av.compareTo(bv)
+                    is Double -> av.toDouble().compareTo(bv)
+                    else -> av.toString().compareTo(bv.toString())
+                }
+                is Double -> when (bv) {
+                    is Int -> av.compareTo(bv.toDouble())
+                    is Double -> av.compareTo(bv)
+                    else -> av.toString().compareTo(bv.toString())
+                }
+                is String -> av.compareTo(bv.toString())
+                else -> av.toString().compareTo(bv.toString())
+            }
+        }
+        items = pairs.map { it.first }.toMutableList()
+    }
+    if (opts.skip >= 0) {
+        items = if (opts.skip < items.size) items.drop(opts.skip).toMutableList() else mutableListOf()
+    }
+    if (opts.take >= 0) {
+        if (opts.take < items.size) items = items.take(opts.take).toMutableList()
+    }
+    val res = mutableListOf<Any?>()
+    for (r in items) {
+        res.add(opts.selectFn.invoke(r))
+    }
+    return res
 }`
 
 	helperStream = `class _Stream<T>(val name: String) {
@@ -286,6 +399,7 @@ var helperMap = map[string]string{
 	"_intersect":   helperIntersect,
 	"_Group":       helperGroup,
 	"_group_by":    helperGroupBy,
+	"_query":       helperQuery,
 	"_Stream":      helperStream,
 	"_waitAll":     helperWaitAll,
 }


### PR DESCRIPTION
## Summary
- implement `_query` helper and hook it into the Kotlin runtime
- add `compileAdvancedQueryExpr` in Kotlin compiler for joins and grouping
- use new helper for dataset queries when needed

## Testing
- `go build ./compile/x/kt`
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b8f6111188320a735df9a786d047e