### PR TITLE
Support sorting in Pascal dataset queries

### DIFF
--- a/compile/x/pas/README.md
+++ b/compile/x/pas/README.md
@@ -146,7 +146,7 @@ constructs:
 - Function definitions and calls
  - List and map literals with indexing and slicing
  - Dataset helpers `fetch`, `load` and `save`
- - Basic dataset queries with `from`/`where`/`select`, `skip` and `take`
+ - Basic dataset queries with `from`/`where`/`select`, `sort by`, `skip` and `take`
 - Package declarations and importing of local packages
 
 ## Unsupported features

--- a/tests/compiler/pas/dataset_sort.mochi
+++ b/tests/compiler/pas/dataset_sort.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/pas/dataset_sort.out
+++ b/tests/compiler/pas/dataset_sort.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- improve Pascal backend for dataset queries
- support `sort by` in query compilation
- generate helper `_sortBy` for sorting with variant keys
- include Variants unit and update docs
- add Pascal test for dataset sorting

## Testing
- `go test ./compile/x/pas` *(no tests found)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b8f8f92308320af3859719f24cc5a