### PR TITLE
Add Clojure dataset query tests

### DIFF
--- a/compile/x/clj/README.md
+++ b/compile/x/clj/README.md
@@ -132,7 +132,7 @@ The current implementation focuses on a minimal subset of Mochi. It supports:
 - HTTP `fetch` for retrieving JSON
 - `generate` expressions for text, embeddings and structs
 - Anonymous `fun` expressions
-- Query filtering, cross, inner, left, right and outer joins, and pagination via `skip`/`take`
+- Dataset queries with `from`/`where`/`select`, sorting via `sort by`, cross, inner, left, right and outer joins, and pagination using `skip`/`take`
 - Indexing and slicing for lists, strings and maps
 - Simple `match` expressions on constants and struct literals with field access
 - `break` and `continue` statements

--- a/tests/compiler/clj/dataset.clj.out
+++ b/tests/compiler/clj/dataset.clj.out
@@ -1,0 +1,34 @@
+(ns main)
+
+(defn Person [name age]
+  {:__name "Person" :name name :age age}
+)
+
+
+(defn -main []
+  (def people [{:__name "Person" :name "Alice" :age 30} {:__name "Person" :name "Bob" :age 15} {:__name "Person" :name "Charlie" :age 65}])
+  (def names (vec (->> (for [p people :when (>= (:age p) 18)] (:name p)))))
+  (loop [_tmp0 (seq names)]
+    (when _tmp0
+      (let [n (clojure.core/first _tmp0)]
+        (let [r (try
+          (println n)
+          :next
+        (catch clojure.lang.ExceptionInfo e
+          (cond
+            (= (.getMessage e) "continue") :next
+            (= (.getMessage e) "break") :break
+            :else (throw e))
+          )
+        )]
+      (cond
+        (= r :break) nil
+        :else (recur (next _tmp0))
+      )
+    )
+  )
+)
+)
+)
+
+(-main)

--- a/tests/compiler/clj/dataset.mochi
+++ b/tests/compiler/clj/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/clj/dataset.out
+++ b/tests/compiler/clj/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/clj/dataset_sort_take_limit.clj.out
+++ b/tests/compiler/clj/dataset_sort_take_limit.clj.out
@@ -1,0 +1,35 @@
+(ns main)
+
+(defn Product [name price]
+  {:__name "Product" :name name :price price}
+)
+
+
+(defn -main []
+  (def products [{:__name "Product" :name "Laptop" :price 1500} {:__name "Product" :name "Smartphone" :price 900} {:__name "Product" :name "Tablet" :price 600} {:__name "Product" :name "Monitor" :price 300} {:__name "Product" :name "Keyboard" :price 100} {:__name "Product" :name "Mouse" :price 50} {:__name "Product" :name "Headphones" :price 200}])
+  (def expensive (vec (->> (for [p products] p) (sort-by (fn [p] (- (:price p)))) (drop 1) (take 3))))
+  (println "--- Top products (excluding most expensive) ---")
+  (loop [_tmp0 (seq expensive)]
+    (when _tmp0
+      (let [item (clojure.core/first _tmp0)]
+        (let [r (try
+          (println (:name item) "costs $" (:price item))
+          :next
+        (catch clojure.lang.ExceptionInfo e
+          (cond
+            (= (.getMessage e) "continue") :next
+            (= (.getMessage e) "break") :break
+            :else (throw e))
+          )
+        )]
+      (cond
+        (= r :break) nil
+        :else (recur (next _tmp0))
+      )
+    )
+  )
+)
+)
+)
+
+(-main)

--- a/tests/compiler/clj/dataset_sort_take_limit.mochi
+++ b/tests/compiler/clj/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/clj/dataset_sort_take_limit.out
+++ b/tests/compiler/clj/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- document dataset query capabilities for the Clojure backend
- add dataset query examples to Clojure compiler tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b933ac5e883208be54cc4956c506e