### PR TITLE
Add dataset filter and pagination helpers for Erlang backend

### DIFF
--- a/compile/x/erlang/README.md
+++ b/compile/x/erlang/README.md
@@ -48,7 +48,7 @@ The backend currently supports:
 - struct literals now instantiate these records with `#name{field=val}` syntax
 - AI `generate_text`, `generate_embed` and `generate_struct` helpers (placeholders)
 - test blocks and `expect` statements
-- `load` and `save` for Erlang terms or plain text files
+- `load` and `save` for Erlang terms or plain text files with optional `filter`, `skip` and `take` options
 - HTTP `fetch` using `httpc` with an optional `method` field
 
 ## Building


### PR DESCRIPTION
## Summary
- extend Erlang runtime helpers with `mochi_filter` and `mochi_paginate`
- call the new helpers from `mochi_load`
- document dataset options in Erlang backend README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b9af488108320b8c4d8cf7ab0523a