### PR TITLE
Add PHP dataset query examples

### DIFF
--- a/compile/x/php/README.md
+++ b/compile/x/php/README.md
@@ -20,6 +20,7 @@ The PHP compiler implements a subset of Mochi including:
 - functions and closures
 - lists and maps with indexing and updates
 - built-in helpers: `print`, `len`, `str`, `input`, `count`, `avg`
+- dataset queries with `from`/`where`/`select`, sorting, pagination and joins
 - set operations: `union`, `union all`, `except`, and `intersect`
 - simple test blocks (`test`)
 
@@ -30,7 +31,7 @@ Several advanced language features are not yet available:
 - modules or imports
 - concurrency primitives
 - generics and complex type inference
-- advanced dataset queries such as joins or grouping
+- grouping operations in dataset queries
 - dataset helpers like `fetch`, `load`, `save` and `generate`
 - pattern matching with `match`
 - agent/stream declarations (`agent`, `on`, `emit`)

--- a/tests/compiler/php/dataset.mochi
+++ b/tests/compiler/php/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/php/dataset.out
+++ b/tests/compiler/php/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/php/dataset.php.out
+++ b/tests/compiler/php/dataset.php.out
@@ -1,0 +1,23 @@
+<?php
+class Person {
+	public $name;
+	public $age;
+	public function __construct($fields = []) {
+		$this->name = $fields['name'] ?? null;
+		$this->age = $fields['age'] ?? null;
+	}
+}
+
+$people = [new Person(['name' => "Alice", 'age' => 30]), new Person(['name' => "Bob", 'age' => 15]), new Person(['name' => "Charlie", 'age' => 65])];
+$names = (function() use ($people) {
+	$res = [];
+	foreach ((is_string($people) ? str_split($people) : $people) as $p) {
+		if (($p->age >= 18)) {
+			$res[] = $p->name;
+		}
+	}
+	return $res;
+})();
+foreach ((is_string($names) ? str_split($names) : $names) as $n) {
+	echo $n, PHP_EOL;
+}

--- a/tests/compiler/php/dataset_sort_take_limit.mochi
+++ b/tests/compiler/php/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/php/dataset_sort_take_limit.out
+++ b/tests/compiler/php/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/compiler/php/dataset_sort_take_limit.php.out
+++ b/tests/compiler/php/dataset_sort_take_limit.php.out
@@ -1,0 +1,100 @@
+<?php
+class Product {
+	public $name;
+	public $price;
+	public function __construct($fields = []) {
+		$this->name = $fields['name'] ?? null;
+		$this->price = $fields['price'] ?? null;
+	}
+}
+
+$products = [new Product(['name' => "Laptop", 'price' => 1500]), new Product(['name' => "Smartphone", 'price' => 900]), new Product(['name' => "Tablet", 'price' => 600]), new Product(['name' => "Monitor", 'price' => 300]), new Product(['name' => "Keyboard", 'price' => 100]), new Product(['name' => "Mouse", 'price' => 50]), new Product(['name' => "Headphones", 'price' => 200])];
+$expensive = (function() use ($products) {
+	$_src = $products;
+	return _query($_src, [
+	], [ 'select' => function($p) use ($products) { return $p; }, 'sortKey' => function($p) use ($products) { return (-$p->price); }, 'skip' => 1, 'take' => 3 ]);
+})();
+echo "--- Top products (excluding most expensive) ---", PHP_EOL;
+foreach ((is_string($expensive) ? str_split($expensive) : $expensive) as $item) {
+	echo $item->name . " " . "costs $" . " " . $item->price, PHP_EOL;
+}
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}


### PR DESCRIPTION
## Summary
- expand PHP backend README with dataset query features
- add dataset filter example for PHP compiler
- add pagination/sorting example for PHP compiler

## Testing
- `go test ./compile/x/php -run TestPHPCompiler_GoldenOutput -tags slow` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b07ac148320b447181ba78336fc