### PR TITLE
Add pagination helper to Go backend

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -2305,20 +2305,17 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			buf.WriteString("\t}\n")
 		}
 
-		if skipExpr != "" {
-			buf.WriteString(fmt.Sprintf("\tskip := %s\n", skipExpr))
-			buf.WriteString("\tif skip < len(items) {\n")
-			buf.WriteString("\t\titems = items[skip:]\n")
-			buf.WriteString("\t} else {\n")
-			buf.WriteString("\t\titems = []*data.Group{}\n")
-			buf.WriteString("\t}\n")
-		}
-
-		if takeExpr != "" {
-			buf.WriteString(fmt.Sprintf("\ttake := %s\n", takeExpr))
-			buf.WriteString("\tif take < len(items) {\n")
-			buf.WriteString("\t\titems = items[:take]\n")
-			buf.WriteString("\t}\n")
+		if skipExpr != "" || takeExpr != "" {
+			c.use("_paginate")
+			sk := skipExpr
+			if sk == "" {
+				sk = "-1"
+			}
+			tk := takeExpr
+			if tk == "" {
+				tk = "-1"
+			}
+			buf.WriteString(fmt.Sprintf("\titems = _paginate[*data.Group](items, %s, %s)\n", sk, tk))
 		}
 
 		buf.WriteString(fmt.Sprintf("\t_res := []%s{}\n", retElem))
@@ -2578,20 +2575,17 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		buf.WriteString("\t}\n")
 	}
 
-	if skipExpr != "" {
-		buf.WriteString(fmt.Sprintf("\tskip := %s\n", skipExpr))
-		buf.WriteString("\tif skip < len(items) {\n")
-		buf.WriteString("\t\titems = items[skip:]\n")
-		buf.WriteString("\t} else {\n")
-		buf.WriteString(fmt.Sprintf("\t\titems = []%s{}\n", elemGo))
-		buf.WriteString("\t}\n")
-	}
-
-	if takeExpr != "" {
-		buf.WriteString(fmt.Sprintf("\ttake := %s\n", takeExpr))
-		buf.WriteString("\tif take < len(items) {\n")
-		buf.WriteString("\t\titems = items[:take]\n")
-		buf.WriteString("\t}\n")
+	if skipExpr != "" || takeExpr != "" {
+		c.use("_paginate")
+		sk := skipExpr
+		if sk == "" {
+			sk = "-1"
+		}
+		tk := takeExpr
+		if tk == "" {
+			tk = "-1"
+		}
+		buf.WriteString(fmt.Sprintf("\titems = _paginate[%s](items, %s, %s)\n", elemGo, sk, tk))
 	}
 
 	buf.WriteString(fmt.Sprintf("\t_res := []%s{}\n", retElem))

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -426,6 +426,14 @@ const (
 		"    for i, r := range items { res[i] = opts.selectFn(r...) }\n" +
 		"    return res\n" +
 		"}\n"
+
+	helperPaginate = "func _paginate[T any](src []T, skip, take int) []T {\n" +
+		"    if skip > 0 {\n" +
+		"        if skip < len(src) { src = src[skip:] } else { return []T{} }\n" +
+		"    }\n" +
+		"    if take >= 0 && take < len(src) { src = src[:take] }\n" +
+		"    return src\n" +
+		"}\n"
 )
 
 var helperMap = map[string]string{
@@ -445,6 +453,7 @@ var helperMap = map[string]string{
 	"_convertMapAny": helperConvertMapAny,
 	"_equal":         helperEqual,
 	"_query":         helperQuery,
+	"_paginate":      helperPaginate,
 	"_load":          helperLoad,
 	"_save":          helperSave,
 	"_toMapSlice":    helperToMapSlice,


### PR DESCRIPTION
## Summary
- implement generic `_paginate` runtime helper for Go backend
- use `_paginate` when compiling dataset queries with skip/take

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b9b2406f483208daf913d44462054