### PR TITLE
Add Racket dataset filtering tests

### DIFF
--- a/compile/x/rkt/README.md
+++ b/compile/x/rkt/README.md
@@ -37,7 +37,8 @@ go test ./compile/rkt -tags slow
 - `in` operator for lists and strings
 - Slice assignments, including multi-dimensional slices like `xs[0:1][1:2] = sub`
 - Negative indexing and slicing for strings and lists
-- Dataset queries with `sort`, `skip`, `take` and simple `group by` clauses
+- Dataset queries with filtering via `where`, sorting, pagination with
+  `skip`/`take`, and simple `group by` clauses
 - Simple `struct` type declarations
 - Iteration over map keys
 - Function definitions and calls

--- a/tests/compiler/rkt/dataset.mochi
+++ b/tests/compiler/rkt/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/rkt/dataset.out
+++ b/tests/compiler/rkt/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/rkt/dataset.rkt.out
+++ b/tests/compiler/rkt/dataset.rkt.out
@@ -1,0 +1,46 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (string-ref x idx))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(struct Person (name age) #:transparent)
+
+(define people (list (Person "Alice" 30) (Person "Bob" 15) (Person "Charlie" 65)))
+(define names (let ([_res '()])
+  (for ([p people])
+    (when (>= (hash-ref p "age") 18)
+      (set! _res (append _res (list (hash-ref p "name"))))
+    )
+  )
+  _res)))
+(for ([n (if (hash? names) (hash-keys names) names)])
+	(displayln n)
+)

--- a/tests/compiler/rkt/dataset_sort_take_limit.mochi
+++ b/tests/compiler/rkt/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/rkt/dataset_sort_take_limit.out
+++ b/tests/compiler/rkt/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/compiler/rkt/dataset_sort_take_limit.rkt.out
+++ b/tests/compiler/rkt/dataset_sort_take_limit.rkt.out
@@ -1,0 +1,53 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (string-ref x idx))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(struct Product (name price) #:transparent)
+
+(define products (list (Product "Laptop" 1500) (Product "Smartphone" 900) (Product "Tablet" 600) (Product "Monitor" 300) (Product "Keyboard" 100) (Product "Mouse" 50) (Product "Headphones" 200)))
+(define expensive (let ([_res '()])
+  (for ([p products])
+    (set! _res (append _res (list (cons (- (hash-ref p "price")) p))))
+  )
+  (set! _res (map cdr (sort _res (lambda (a b)
+    (let ([ak (car a)] [bk (car b)])
+      (cond [(and (number? ak) (number? bk)) (< ak bk)]
+            [(and (string? ak) (string? bk)) (string<? ak bk)]
+            [else (string<? (format "~a" ak) (format "~a" bk))])))
+    #:key car)))
+  (set! _res (drop _res 1))
+  (set! _res (take _res 3))
+  _res)))
+(displayln "--- Top products (excluding most expensive) ---")
+(for ([item (if (hash? expensive) (hash-keys expensive) expensive)])
+	(displayln (format "~a ~a ~a" (hash-ref item "name") "costs $" (hash-ref item "price")))
+)


### PR DESCRIPTION
## Summary
- test dataset filtering and pagination for Racket backend
- document dataset filtering and pagination support in the Racket backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b9b0e8f4c8320b397f37e4b5096ee