### PR TITLE
Add dataset pagination helper to Smalltalk backend

### DIFF
--- a/tests/compiler/st/dataset.mochi
+++ b/tests/compiler/st/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/st/dataset.out
+++ b/tests/compiler/st/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/st/dataset.st.out
+++ b/tests/compiler/st/dataset.st.out
@@ -1,0 +1,24 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newPerson: name age: age | dict |
+	dict := Dictionary new.
+	dict at: 'name' put: name.
+	dict at: 'age' put: age.
+	^ dict
+!
+!!
+people := Array with: (Main newPerson: 'Alice' age: 30) with: (Main newPerson: 'Bob' age: 15) with: (Main newPerson: 'Charlie' age: 65).
+names := ((| res |
+res := OrderedCollection new.
+(people) do: [:p |
+	((p at: 'age' >= 18)) ifTrue: [
+		res add: p at: 'name'.
+	]
+]
+res := res asArray.
+res)).
+(names) do: [:n |
+	(n) displayOn: Transcript. Transcript cr.
+]
+.

--- a/tests/compiler/st/dataset_sort_take_limit.mochi
+++ b/tests/compiler/st/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name + " costs $ " + str(item.price))
+}

--- a/tests/compiler/st/dataset_sort_take_limit.out
+++ b/tests/compiler/st/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/compiler/st/dataset_sort_take_limit.st.out
+++ b/tests/compiler/st/dataset_sort_take_limit.st.out
@@ -1,0 +1,26 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newProduct: name price: price | dict |
+	dict := Dictionary new.
+	dict at: 'name' put: name.
+	dict at: 'price' put: price.
+	^ dict
+!
+!!
+products := Array with: (Main newProduct: 'Laptop' price: 1500) with: (Main newProduct: 'Smartphone' price: 900) with: (Main newProduct: 'Tablet' price: 600) with: (Main newProduct: 'Monitor' price: 300) with: (Main newProduct: 'Keyboard' price: 100) with: (Main newProduct: 'Mouse' price: 50) with: (Main newProduct: 'Headphones' price: 200).
+expensive := ((| res |
+res := OrderedCollection new.
+(products) do: [:p |
+	res add: { (p at: 'price' negated) . p }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res := (Main _paginate: res skip: 1 take: 3).
+res)).
+('--- Top products (excluding most expensive) ---') displayOn: Transcript. Transcript cr.
+(expensive) do: [:item |
+	(((((item at: 'name') , (' costs $ '))) , ((item at: 'price' printString)))) displayOn: Transcript. Transcript cr.
+]
+.


### PR DESCRIPTION
## Summary
- support dataset pagination in the Smalltalk compiler
- add dataset query tests for Smalltalk backend

## Testing
- `go test ./... -run ^$`


------
https://chatgpt.com/codex/tasks/task_e_685b9b16bad48320bad23c7ba47ec071