### PR TITLE
Add better map key handling for Swift backend

### DIFF
--- a/compile/x/swift/typeutil.go
+++ b/compile/x/swift/typeutil.go
@@ -120,6 +120,17 @@ func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
 					var val types.Type = types.AnyType{}
 					for i, it := range p.Target.Map.Items {
 						kt := c.inferExprType(it.Key)
+						if id, ok := identName(it.Key); ok {
+							_, defined := c.locals[id]
+							if !defined && c.env != nil {
+								if _, err := c.env.GetVar(id); err == nil {
+									defined = true
+								}
+							}
+							if !defined {
+								kt = types.StringType{}
+							}
+						}
 						vt := c.inferExprType(it.Value)
 						if i == 0 {
 							key = kt


### PR DESCRIPTION
## Summary
- handle map keys that are simple identifiers by quoting them
- treat those keys as strings during type inference
- compile selector expressions on map values into dictionary lookups
- avoid reserved keywords when sorting

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_685b9b186afc832091af909d7c16541f