### PR TITLE
Add dataset filter and pagination helpers for Prolog

### DIFF
--- a/compile/x/pl/README.md
+++ b/compile/x/pl/README.md
@@ -296,6 +296,8 @@ The Prolog backend can compile a subset of Mochi focused on core control flow an
 - Anonymous function literals (`fun` expressions)
 - Passing functions as parameters and return values
 - Dataset queries with optional filtering, sorting and limits
+- Helper predicates `dataset_filter/3` and `dataset_paginate/4` for filtering
+  and paginating row lists
 ## Unsupported Features
 
 The Prolog backend focuses on basic control flow and list operations. Several

--- a/compile/x/pl/compiler.go
+++ b/compile/x/pl/compiler.go
@@ -34,34 +34,34 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	origBuf := c.buf
 	c.buf = body
 
-       // function declarations, type declarations, facts, rules and tests
-       for _, s := range prog.Statements {
-               if s.Fun != nil {
-                       if err := c.compileFun(s.Fun); err != nil {
-                               return nil, err
-                       }
-                       c.writeln("")
-               } else if s.Fact != nil {
-                       if err := c.compileFact(s.Fact); err != nil {
-                               return nil, err
-                       }
-                       c.writeln("")
-               } else if s.Rule != nil {
-                       if err := c.compileRule(s.Rule); err != nil {
-                               return nil, err
-                       }
-                       c.writeln("")
-               } else if s.Type != nil {
-                       if err := c.compileTypeDecl(s.Type); err != nil {
-                               return nil, err
-                       }
-                       c.writeln("")
-               } else if s.Test != nil {
-                       if err := c.compileTestBlock(s.Test); err != nil {
-                               return nil, err
-                       }
-                       c.writeln("")
-               }
+	// function declarations, type declarations, facts, rules and tests
+	for _, s := range prog.Statements {
+		if s.Fun != nil {
+			if err := c.compileFun(s.Fun); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		} else if s.Fact != nil {
+			if err := c.compileFact(s.Fact); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		} else if s.Rule != nil {
+			if err := c.compileRule(s.Rule); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		} else if s.Type != nil {
+			if err := c.compileTypeDecl(s.Type); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		} else if s.Test != nil {
+			if err := c.compileTestBlock(s.Test); err != nil {
+				return nil, err
+			}
+			c.writeln("")
+		}
 	}
 
 	tmpBuf := c.buf
@@ -204,6 +204,18 @@ func (c *Compiler) emitHelpers() {
 	}
 	if c.helpers["map_keys"] {
 		for _, line := range strings.Split(strings.TrimSuffix(helperMapKeys, "\n"), "\n") {
+			c.writeln(line)
+		}
+		c.writeln("")
+	}
+	if c.helpers["dataset_filter"] {
+		for _, line := range strings.Split(strings.TrimSuffix(helperDatasetFilter, "\n"), "\n") {
+			c.writeln(line)
+		}
+		c.writeln("")
+	}
+	if c.helpers["dataset_paginate"] {
+		for _, line := range strings.Split(strings.TrimSuffix(helperDatasetPaginate, "\n"), "\n") {
 			c.writeln(line)
 		}
 		c.writeln("")

--- a/compile/x/pl/expressions.go
+++ b/compile/x/pl/expressions.go
@@ -466,6 +466,45 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (exprRes, error) {
 		c.use("input")
 		code := []string{fmt.Sprintf("input(%s),", tmp)}
 		return exprRes{code: code, val: tmp}, nil
+	case "dataset_filter":
+		if len(call.Args) != 2 {
+			return exprRes{}, fmt.Errorf("dataset_filter expects 2 args")
+		}
+		listArg, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return exprRes{}, err
+		}
+		predArg, err := c.compileExpr(call.Args[1])
+		if err != nil {
+			return exprRes{}, err
+		}
+		tmp := c.newVar()
+		c.use("dataset_filter")
+		code := append(listArg.code, predArg.code...)
+		code = append(code, fmt.Sprintf("dataset_filter(%s, %s, %s),", listArg.val, predArg.val, tmp))
+		return exprRes{code: code, val: tmp}, nil
+	case "dataset_paginate":
+		if len(call.Args) != 3 {
+			return exprRes{}, fmt.Errorf("dataset_paginate expects 3 args")
+		}
+		listArg, err := c.compileExpr(call.Args[0])
+		if err != nil {
+			return exprRes{}, err
+		}
+		skipArg, err := c.compileExpr(call.Args[1])
+		if err != nil {
+			return exprRes{}, err
+		}
+		takeArg, err := c.compileExpr(call.Args[2])
+		if err != nil {
+			return exprRes{}, err
+		}
+		tmp := c.newVar()
+		c.use("dataset_paginate")
+		code := append(listArg.code, skipArg.code...)
+		code = append(code, takeArg.code...)
+		code = append(code, fmt.Sprintf("dataset_paginate(%s, %s, %s, %s),", listArg.val, skipArg.val, takeArg.val, tmp))
+		return exprRes{code: code, val: tmp}, nil
 	default:
 		args := make([]string, len(call.Args))
 		code := []string{}

--- a/compile/x/pl/runtime.go
+++ b/compile/x/pl/runtime.go
@@ -70,3 +70,14 @@ const helperIntersect = "intersect(A, B, R) :- intersect(A, B, [], R).\n" +
 const helperMapKeys = "map_keys(Dict, Keys) :-\n" +
 	"    dict_pairs(Dict, _, Pairs),\n" +
 	"    findall(K, member(K-_, Pairs), Keys).\n\n"
+
+const helperDatasetFilter = "dataset_filter([], _, []).\n" +
+	"dataset_filter([H|T], Pred, [H|R]) :- call(Pred, H), !, dataset_filter(T, Pred, R).\n" +
+	"dataset_filter([_|T], Pred, R) :- dataset_filter(T, Pred, R).\n\n"
+
+const helperDatasetPaginate = "dataset_paginate(List, Skip, Take, Out) :-\n" +
+	"    length(List, Len),\n" +
+	"    (Skip >= Len -> Out = [] ;\n" +
+	"    Start is max(Skip, 0),\n" +
+	"    (Take < 0 -> End = Len ; Temp is Start + Take, (Temp > Len -> End = Len ; End = Temp)),\n" +
+	"    slice(List, Start, End, Out)).\n\n"


### PR DESCRIPTION
## Summary
- implement `dataset_filter/3` and `dataset_paginate/4` helper predicates in Prolog runtime
- emit these helpers when used
- expose them through `dataset_filter` and `dataset_paginate` builtins
- document new helpers in the Prolog backend README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b9b09994c83209d75f35c5c86cff6