### PR TITLE
Add CSV dataset helpers to C++ backend

### DIFF
--- a/compile/x/cpp/README.md
+++ b/compile/x/cpp/README.md
@@ -220,6 +220,7 @@ Dataset queries support `where`, `skip`, `take`, `sort by`, `join` and basic `gr
 * Structs, unions and pattern matching with `match`
 * List and map literals with indexing and slicing
 * Built‑in functions `print`, `len`, `str`, `now` and `input`
+* Dataset helpers `load` and `save` for CSV files
 * Dataset queries with filtering, sorting, pagination and simple grouping
 * List operators `union`, `union all`, `except` and `intersect`
 * Membership tests using `in`
@@ -232,7 +233,7 @@ Some LeetCode solutions use language constructs that the C++ backend can't yet t
 * Dataset queries with advanced grouping
 * Agents, streams and intents
 * `generate` blocks and model definitions
-* Dataset helpers such as `fetch`, `load`, `save` and SQL-style `from ...` queries
+* Dataset helpers such as `fetch` and SQL-style `from ...` queries
 * `logic` queries for Prolog-style reasoning
 * Foreign imports and `extern` declarations
 * Package management, tests and `expect` blocks

--- a/compile/x/cpp/compiler.go
+++ b/compile/x/cpp/compiler.go
@@ -774,6 +774,10 @@ func (c *Compiler) compilePrimary(p *parser.Primary) string {
 		return c.compileMatchExpr(p.Match)
 	case p.FunExpr != nil:
 		return c.compileFunExpr(p.FunExpr)
+	case p.Load != nil:
+		return c.compileLoadExpr(p.Load)
+	case p.Save != nil:
+		return c.compileSaveExpr(p.Save)
 	case p.Query != nil:
 		q, _ := c.compileQuery(p.Query)
 		return q
@@ -951,6 +955,25 @@ func (c *Compiler) compileFunExpr(fn *parser.FunExpr) string {
 		c.buf = oldBuf
 	}
 	return "[=](" + strings.Join(params, ", ") + ") { " + body.String() + " }"
+}
+
+func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) string {
+	path := "\"\""
+	if l.Path != nil {
+		path = strconv.Quote(*l.Path)
+	}
+	c.helpers["load"] = true
+	return fmt.Sprintf("_load(%s)", path)
+}
+
+func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) string {
+	src := c.compileExpr(s.Src)
+	path := "\"\""
+	if s.Path != nil {
+		path = strconv.Quote(*s.Path)
+	}
+	c.helpers["save"] = true
+	return fmt.Sprintf("_save(%s, %s)", src, path)
 }
 
 func (c *Compiler) compileQuery(q *parser.QueryExpr) (string, error) {


### PR DESCRIPTION
## Summary
- implement `_load` and `_save` helpers in C++ runtime
- support `load` and `save` expressions in the C++ compiler
- document CSV load/save support in backend README

## Testing
- `go build ./...`
- `go test ./...` *(fails: interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_685ba274e3d48320972d91b9ab2d8080