### PR TITLE
Add dataset sort for Fortran queries

### DIFF
--- a/tests/compiler/fortran/dataset_sort_take_limit.f90.out
+++ b/tests/compiler/fortran/dataset_sort_take_limit.f90.out
@@ -1,0 +1,64 @@
+program main
+  implicit none
+  type :: Product
+    character(:), allocatable :: name
+    integer(kind=8) :: price
+  end type Product
+  integer(kind=8), allocatable :: products(:)
+  integer(kind=8) :: expensive
+  integer(kind=8) :: item
+  integer(kind=8) :: i_item
+  allocate(products(0))
+  products = (/Product(name='Laptop', price=1500_8), Product(name='Smartphone', price=900_8), Product(name='Tablet', price=600_8), Product(name='Monitor', price=300_8), Product(name='Keyboard', price=100_8), Product(name='Mouse', price=50_8), Product(name='Headphones', price=200_8)/)
+  expensive = lambda_0(products)(1_8 + 1:1_8 + 3_8)
+  print *, '--- Top products (excluding most expensive) ---'
+  do i_item = 0, size(expensive) - 1
+    item = expensive(modulo(i_item, size(expensive)) + 1)
+    print *, item%name, 'costs $', item%price
+  end do
+contains
+  function lambda_0(vsrc) result(res)
+    implicit none
+    integer(kind=8), intent(in) :: vsrc(:)
+    integer(kind=8), allocatable :: res(:)
+    integer(kind=8), allocatable :: tmp(:)
+    integer(kind=8), allocatable :: tmpKey(:)
+    integer(kind=8) :: p
+    integer(kind=8) :: n
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: min_idx
+    integer(kind=8) :: sort_key
+    integer(kind=8) :: swap_key
+    integer(kind=8) :: swap_item
+    allocate(tmp(size(vsrc)))
+    allocate(tmpKey(size(vsrc)))
+    n = 0
+    do i = 1, size(vsrc)
+      p = vsrc(i)
+      sort_key = (-p%price)
+      n = n + 1
+      tmp(n) = p
+      tmpKey(n) = sort_key
+    end do
+    do i = 1, n - 1
+      min_idx = i
+      do j = i + 1, n
+        if (tmpKey(j) < tmpKey(min_idx)) then
+          min_idx = j
+        end if
+      end do
+      if (min_idx /= i) then
+        swap_key = tmpKey(i)
+        tmpKey(i) = tmpKey(min_idx)
+        tmpKey(min_idx) = swap_key
+        swap_item = tmp(i)
+        tmp(i) = tmp(min_idx)
+        tmp(min_idx) = swap_item
+      end if
+    end do
+    allocate(res(n))
+    res = tmp(:n)
+  end function lambda_0
+  
+end program main

--- a/tests/compiler/fortran/dataset_sort_take_limit.mochi
+++ b/tests/compiler/fortran/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/fortran/dataset_sort_take_limit.out
+++ b/tests/compiler/fortran/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- allow `sort by` in Fortran query expressions
- implement simple selection sort for query results
- add dataset_sort_take_limit example and golden files

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ba2818b5c832095b229b6aaafc8b5