### PR TITLE
Add group by support to Ruby query compiler

### DIFF
--- a/compile/x/rb/runtime.go
+++ b/compile/x/rb/runtime.go
@@ -186,7 +186,13 @@ end`
 end`
 
 	helperGroupBy = `def _group_by(src, keyfn)
-grouped = src.group_by { |it| keyfn.call(it) }
+grouped = src.group_by do |it|
+  if it.is_a?(Array)
+    keyfn.call(*it)
+  else
+    keyfn.call(it)
+  end
+end
 grouped.map do |k, items|
 g = MGroup.new(k)
 g.Items.concat(items)


### PR DESCRIPTION
## Summary
- enhance `_group_by` runtime helper to expand array items when computing keys
- extend Ruby `compileQueryExpr` to handle grouped queries via `_query`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bb4a2790c8320826a4887f08ce89c