### PR TITLE
Add dataset sort support to Zig backend

### DIFF
--- a/tests/compiler/zig/dataset.mochi
+++ b/tests/compiler/zig/dataset.mochi
@@ -1,0 +1,24 @@
+// dataset.mochi
+// Define an in-memory dataset using a list of records.
+
+let people = [
+  { name: "Alice", age: 30 },
+  { name: "Bob", age: 15 },
+  { name: "Charlie", age: 65 },
+  { name: "Diana", age: 45 }
+]
+
+let adults = from person in people
+             where person.age >= 18
+             select {
+               name: person.name,
+               age: person.age,
+               is_senior: person.age >= 60
+             }
+
+for person in adults {
+  print(person.name, "is", person.age, "years old.")
+  if person.is_senior {
+    print(" (senior)")
+  }
+}

--- a/tests/compiler/zig/dataset.out
+++ b/tests/compiler/zig/dataset.out
@@ -1,0 +1,4 @@
+Alice is 30 years old.
+Charlie is 65 years old.
+ (senior)
+Diana is 45 years old.

--- a/tests/compiler/zig/dataset.zig.out
+++ b/tests/compiler/zig/dataset.zig.out
@@ -1,0 +1,12 @@
+const std = @import("std");
+
+pub fn main() void {
+	const people: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(name, "Alice") catch unreachable; m.put(age, @as(i32,@intCast(30))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(name, "Bob") catch unreachable; m.put(age, @as(i32,@intCast(15))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(name, "Charlie") catch unreachable; m.put(age, @as(i32,@intCast(65))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(name, "Diana") catch unreachable; m.put(age, @as(i32,@intCast(45))) catch unreachable; break :blk m; }};
+	const adults: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (people) |person| { if (!((person.age >= @as(i32,@intCast(18))))) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(name, person.name) catch unreachable; m.put(age, person.age) catch unreachable; m.put(is_senior, (person.age >= @as(i32,@intCast(60)))) catch unreachable; break :blk m; }) catch unreachable; } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+	for (adults) |person| {
+		std.debug.print("{any} {s} {any} {s}\n", .{person.name, "is", person.age, "years old."});
+		if (person.is_senior) {
+			std.debug.print("{s}\n", .{" (senior)"});
+		}
+	}
+}

--- a/tests/compiler/zig/dataset_sort_take_limit.mochi
+++ b/tests/compiler/zig/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/zig/dataset_sort_take_limit.out
+++ b/tests/compiler/zig/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- support `sort by` clause in Zig dataset queries
- add golden tests for dataset queries with sorting

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bb4e0b8a08320bbd69839c6119d1a