### PR TITLE
Optimize dataset query loops

### DIFF
--- a/runtime/vm/queryutil.go
+++ b/runtime/vm/queryutil.go
@@ -1,0 +1,139 @@
+package vm
+
+import "mochi/parser"
+
+// exprVars collects variable names referenced in expression e.
+func exprVars(e *parser.Expr, vars map[string]struct{}) {
+	if e == nil || e.Binary == nil {
+		return
+	}
+	var scanUnary func(*parser.Unary)
+	var scanPostfix func(*parser.PostfixExpr)
+	var scanPrimary func(*parser.Primary)
+
+	scanUnary = func(u *parser.Unary) {
+		if u == nil {
+			return
+		}
+		scanPostfix(u.Value)
+	}
+	scanPostfix = func(p *parser.PostfixExpr) {
+		if p == nil {
+			return
+		}
+		scanPrimary(p.Target)
+		for _, op := range p.Ops {
+			if op.Index != nil {
+				exprVars(op.Index.Start, vars)
+				exprVars(op.Index.End, vars)
+			}
+			if op.Call != nil {
+				for _, a := range op.Call.Args {
+					exprVars(a, vars)
+				}
+			}
+		}
+	}
+	scanPrimary = func(p *parser.Primary) {
+		if p == nil {
+			return
+		}
+		if p.Selector != nil {
+			vars[p.Selector.Root] = struct{}{}
+		}
+		if p.Group != nil {
+			exprVars(p.Group, vars)
+		}
+		if p.FunExpr != nil {
+			exprVars(p.FunExpr.ExprBody, vars)
+			for _, st := range p.FunExpr.BlockBody {
+				scanStmtVars(st, vars)
+			}
+		}
+		if p.List != nil {
+			for _, el := range p.List.Elems {
+				exprVars(el, vars)
+			}
+		}
+		if p.Map != nil {
+			for _, it := range p.Map.Items {
+				exprVars(it.Key, vars)
+				exprVars(it.Value, vars)
+			}
+		}
+		if p.Call != nil {
+			for _, a := range p.Call.Args {
+				exprVars(a, vars)
+			}
+		}
+	}
+
+	scanUnary(e.Binary.Left)
+	for _, op := range e.Binary.Right {
+		scanPostfix(op.Right)
+	}
+}
+
+func scanStmtVars(s *parser.Statement, vars map[string]struct{}) {
+	if s == nil {
+		return
+	}
+	switch {
+	case s.Let != nil:
+		exprVars(s.Let.Value, vars)
+	case s.Var != nil:
+		exprVars(s.Var.Value, vars)
+	case s.Assign != nil:
+		exprVars(s.Assign.Value, vars)
+	case s.Return != nil:
+		exprVars(s.Return.Value, vars)
+	case s.Expr != nil:
+		exprVars(s.Expr.Expr, vars)
+	case s.For != nil:
+		exprVars(s.For.Source, vars)
+		exprVars(s.For.RangeEnd, vars)
+		for _, st := range s.For.Body {
+			scanStmtVars(st, vars)
+		}
+	case s.While != nil:
+		exprVars(s.While.Cond, vars)
+		for _, st := range s.While.Body {
+			scanStmtVars(st, vars)
+		}
+	case s.If != nil:
+		exprVars(s.If.Cond, vars)
+		for _, st := range s.If.Then {
+			scanStmtVars(st, vars)
+		}
+		if s.If.ElseIf != nil {
+			scanStmtVars(&parser.Statement{If: s.If.ElseIf}, vars)
+		}
+		for _, st := range s.If.Else {
+			scanStmtVars(st, vars)
+		}
+	}
+}
+
+// whereEvalLevel returns the earliest FROM clause index where the query's WHERE
+// predicate can be evaluated. Index 0 refers to the initial source variable.
+func whereEvalLevel(q *parser.QueryExpr) int {
+	if q.Where == nil {
+		return len(q.Froms)
+	}
+	vars := map[string]struct{}{}
+	exprVars(q.Where, vars)
+	positions := map[string]int{q.Var: 0}
+	for i, f := range q.Froms {
+		positions[f.Var] = i + 1
+	}
+	level := 0
+	for v := range vars {
+		if idx, ok := positions[v]; ok && idx > level {
+			level = idx
+		}
+	}
+	if level > len(q.Froms) {
+		level = len(q.Froms)
+	}
+	return level
+}

--- a/tests/vm/valid/cross_join_filter.ir.out
+++ b/tests/vm/valid/cross_join_filter.ir.out
@@ -1,0 +1,81 @@
+func main (regs=47)
+  // let nums = [1, 2, 3]
+  Const        r0, [1, 2, 3]
+  Move         r1, r0
+  // let letters = ["A", "B"]
+  Const        r2, ["A", "B"]
+  Move         r3, r2
+  // let pairs = from n in nums
+  Const        r4, []
+  IterPrep     r5, r1
+  Len          r6, r5
+  Const        r7, 0
+L3:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r9, r5, r7
+  Move         r10, r9
+  // where n % 2 == 0
+  Const        r11, 2
+  Mod          r12, r10, r11
+  Const        r13, 0
+  Equal        r14, r12, r13
+  JumpIfFalse  r14, L1
+  // from l in letters
+  IterPrep     r15, r3
+  Len          r16, r15
+  Const        r17, 0
+L2:
+  Less         r18, r17, r16
+  JumpIfFalse  r18, L1
+  Index        r19, r15, r17
+  Move         r20, r19
+  // select { n: n, l: l }
+  Const        r21, "n"
+  Const        r22, "l"
+  Move         r23, r21
+  Move         r24, r10
+  Move         r25, r22
+  Move         r26, r20
+  MakeMap      r27, 2, r23
+  // let pairs = from n in nums
+  Append       r28, r4, r27
+  Move         r4, r28
+  // from l in letters
+  Const        r29, 1
+  Add          r30, r17, r29
+  Move         r17, r30
+  Jump         L2
+L1:
+  // let pairs = from n in nums
+  Const        r31, 1
+  Add          r32, r7, r31
+  Move         r7, r32
+  Jump         L3
+L0:
+  Move         r33, r4
+  // print("--- Even pairs ---")
+  Const        r34, "--- Even pairs ---"
+  Print        r34
+  // for p in pairs {
+  IterPrep     r35, r33
+  Len          r36, r35
+  Const        r37, 0
+L5:
+  Less         r38, r37, r36
+  JumpIfFalse  r38, L4
+  Index        r39, r35, r37
+  Move         r40, r39
+  // print(p.n, p.l)
+  Const        r41, "n"
+  Index        r42, r40, r41
+  Const        r43, "l"
+  Index        r44, r40, r43
+  Print2       r42, r44
+  // for p in pairs {
+  Const        r45, 1
+  Add          r46, r37, r45
+  Move         r37, r46
+  Jump         L5
+L4:
+  Return       r0

--- a/tests/vm/valid/cross_join_filter.mochi
+++ b/tests/vm/valid/cross_join_filter.mochi
@@ -1,0 +1,10 @@
+let nums = [1, 2, 3]
+let letters = ["A", "B"]
+let pairs = from n in nums
+            from l in letters
+            where n % 2 == 0
+            select { n: n, l: l }
+print("--- Even pairs ---")
+for p in pairs {
+  print(p.n, p.l)
+}

--- a/tests/vm/valid/cross_join_filter.out
+++ b/tests/vm/valid/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B


### PR DESCRIPTION
## Summary
- detect variables referenced by query predicates
- push down WHERE filters in dataset query loops
- test cross join predicate pushdown

## Testing
- `go test ./tests/vm -update`

------
https://chatgpt.com/codex/tasks/task_e_685bce1554e4832083407ebbd706ba6e