### PR TITLE
Add predicate pushdown for Erlang dataset queries

### DIFF
--- a/tests/compiler/erl/dataset.erl.out
+++ b/tests/compiler/erl/dataset.erl.out
@@ -6,7 +6,7 @@
 
 main(_) ->
 	People = [#person{name="Alice", age=30}, #person{name="Bob", age=15}, #person{name="Charlie", age=65}],
-	Names = [P#person.name || P <- People, (P#person.age >= 18)],
+	Names = [P#person.name || P <- [P || P <- People, (P#person.age >= 18)]],
 	mochi_foreach(fun(N) ->
 		mochi_print([N])
 	end, Names).


### PR DESCRIPTION
## Summary
- add helper to gather identifiers used in expressions
- optimize `compileQueryExpr` to push `where` predicates into the source list when only the main variable is referenced
- update Erlang golden output for dataset query

## Testing
- `go test ./...`
- `go test ./compile/x/erlang -tags slow -run TestErlangCompiler_GoldenOutput -update`


------
https://chatgpt.com/codex/tasks/task_e_685bcfe0c704832090dc2c812535b237