### PR TITLE
Haskell backend query optimization

### DIFF
--- a/tests/compiler/hs/dataset.hs.out
+++ b/tests/compiler/hs/dataset.hs.out
@@ -116,5 +116,5 @@ data Person = Person {
 main :: IO ()
 main = do
     let people = [Person { name = "Alice", age = 30 }, Person { name = "Bob", age = 15 }, Person { name = "Charlie", age = 65 }]
-    let names = [name (p) | p <- people, (age (p) >= 18)]
+    let names = [name (p) | p <- filter (\p -> age (p) >= 18) people]
     mapM_ (\n -> putStrLn (n)) names


### PR DESCRIPTION
## Summary
- push down simple `where` predicates in Haskell dataset queries
- update dataset golden file to show optimized comprehension

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bd010b48c832082cefbf4b1025dd3