### PR TITLE
Optimize Kotlin query runtime

### DIFF
--- a/compile/x/kt/runtime.go
+++ b/compile/x/kt/runtime.go
@@ -285,6 +285,9 @@ data class _QueryOpts(
 
 fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?> {
     var items = src.map { arrayOf(it) }.toMutableList()
+    if (opts.where != null) {
+        items = items.filter { opts.where.invoke(it) }.toMutableList()
+    }
     for (j in joins) {
         val joined = mutableListOf<Array<Any?>>()
         if (j.right && j.left) {
@@ -342,6 +345,9 @@ fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?
             }
         }
         items = joined
+        if (opts.where != null) {
+            items = items.filter { opts.where.invoke(it) }.toMutableList()
+        }
     }
     if (opts.where != null) {
         items = items.filter { opts.where.invoke(it) }.toMutableList()

--- a/tests/compiler/kt/join_filter_pag.kt.out
+++ b/tests/compiler/kt/join_filter_pag.kt.out
@@ -50,6 +50,9 @@ data class _QueryOpts(
 
 fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?> {
     var items = src.map { arrayOf(it) }.toMutableList()
+    if (opts.where != null) {
+        items = items.filter { opts.where.invoke(it) }.toMutableList()
+    }
     for (j in joins) {
         val joined = mutableListOf<Array<Any?>>()
         if (j.right && j.left) {
@@ -107,6 +110,9 @@ fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?
             }
         }
         items = joined
+        if (opts.where != null) {
+            items = items.filter { opts.where.invoke(it) }.toMutableList()
+        }
     }
     if (opts.where != null) {
         items = items.filter { opts.where.invoke(it) }.toMutableList()


### PR DESCRIPTION
## Summary
- push down filtering in Kotlin runtime `_query`
- update golden output for Kotlin join/filter/pagination case

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bd0c22690832089999077bba32811