### PR TITLE
Add predicate pushdown to Pascal dataset queries

### DIFF
--- a/tests/compiler/pas/dataset.pas.out
+++ b/tests/compiler/pas/dataset.pas.out
@@ -1,0 +1,41 @@
+program main;
+{$mode objfpc}
+uses SysUtils, fgl, fphttpclient, Classes, Variants;
+
+type
+        generic TArray<T> = array of T;
+        type Person = record
+        name: string;
+        age: integer;
+end;
+
+var
+        _tmp0: Person;
+        _tmp1: Person;
+        _tmp2: Person;
+        _tmp3: specialize TArray<string>;
+        n: string;
+        names: specialize TArray<string>;
+        p: Person;
+        people: specialize TArray<Person>;
+
+begin
+        _tmp0.name := 'Alice';
+        _tmp0.age := 30;
+        _tmp1.name := 'Bob';
+        _tmp1.age := 15;
+        _tmp2.name := 'Charlie';
+        _tmp2.age := 65;
+        people := specialize TArray<Person>([_tmp0, _tmp1, _tmp2]);
+        SetLength(_tmp3, 0);
+        for p in people do
+        begin
+                if not ((p.age >= 18)) then continue;
+                _tmp3 := Concat(_tmp3, [p.name]);
+        end;
+        names := _tmp3;
+        for n in names do
+        begin
+                writeln(n);
+        end;
+end.


### PR DESCRIPTION
## Summary
- push join and where conditions down into loops in the Pascal compiler
- record compiled Pascal code for dataset query

## Testing
- `go test ./... -run TestPascalCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685bd0f2f8108320a2ad437b03a3e0cd