### PR TITLE
Enable predicate pushdown for Prolog queries

### DIFF
--- a/compile/x/pl/vars.go
+++ b/compile/x/pl/vars.go
@@ -1,0 +1,144 @@
+package plcode
+
+import "mochi/parser"
+
+func exprVars(e *parser.Expr) map[string]struct{} {
+	vars := map[string]struct{}{}
+	scanExprVars(e, vars)
+	return vars
+}
+
+func scanExprVars(e *parser.Expr, vars map[string]struct{}) {
+	if e == nil {
+		return
+	}
+	scanUnaryVars(e.Binary.Left, vars)
+	for _, op := range e.Binary.Right {
+		scanPostfixVars(op.Right, vars)
+	}
+}
+
+func scanUnaryVars(u *parser.Unary, vars map[string]struct{}) {
+	if u == nil {
+		return
+	}
+	scanPostfixVars(u.Value, vars)
+}
+
+func scanPostfixVars(p *parser.PostfixExpr, vars map[string]struct{}) {
+	if p == nil {
+		return
+	}
+	scanPrimaryVars(p.Target, vars)
+	for _, op := range p.Ops {
+		if op.Index != nil {
+			scanExprVars(op.Index.Start, vars)
+			scanExprVars(op.Index.End, vars)
+			scanExprVars(op.Index.Step, vars)
+		}
+		if op.Call != nil {
+			for _, a := range op.Call.Args {
+				scanExprVars(a, vars)
+			}
+		}
+	}
+}
+
+func scanPrimaryVars(p *parser.Primary, vars map[string]struct{}) {
+	if p == nil {
+		return
+	}
+	if p.Selector != nil {
+		vars[p.Selector.Root] = struct{}{}
+	}
+	if p.Group != nil {
+		scanExprVars(p.Group, vars)
+	}
+	if p.FunExpr != nil {
+		scanExprVars(p.FunExpr.ExprBody, vars)
+		for _, st := range p.FunExpr.BlockBody {
+			scanStmtVars(st, vars)
+		}
+	}
+	if p.List != nil {
+		for _, e := range p.List.Elems {
+			scanExprVars(e, vars)
+		}
+	}
+	if p.Map != nil {
+		for _, it := range p.Map.Items {
+			scanExprVars(it.Key, vars)
+			scanExprVars(it.Value, vars)
+		}
+	}
+	if p.Call != nil {
+		for _, a := range p.Call.Args {
+			scanExprVars(a, vars)
+		}
+	}
+	if p.Query != nil {
+		scanExprVars(p.Query.Source, vars)
+		for _, f := range p.Query.Froms {
+			scanExprVars(f.Src, vars)
+		}
+		for _, j := range p.Query.Joins {
+			scanExprVars(j.Src, vars)
+			scanExprVars(j.On, vars)
+		}
+		if p.Query.Group != nil {
+			scanExprVars(p.Query.Group.Expr, vars)
+		}
+		scanExprVars(p.Query.Select, vars)
+		scanExprVars(p.Query.Where, vars)
+		scanExprVars(p.Query.Sort, vars)
+		scanExprVars(p.Query.Skip, vars)
+		scanExprVars(p.Query.Take, vars)
+		vars[p.Query.Var] = struct{}{}
+		for _, f := range p.Query.Froms {
+			vars[f.Var] = struct{}{}
+		}
+		if p.Query.Group != nil {
+			vars[p.Query.Group.Name] = struct{}{}
+		}
+	}
+}
+
+func scanStmtVars(s *parser.Statement, vars map[string]struct{}) {
+	if s == nil {
+		return
+	}
+	switch {
+	case s.Let != nil:
+		scanExprVars(s.Let.Value, vars)
+	case s.Var != nil:
+		scanExprVars(s.Var.Value, vars)
+	case s.Assign != nil:
+		scanExprVars(s.Assign.Value, vars)
+	case s.Return != nil:
+		scanExprVars(s.Return.Value, vars)
+	case s.Expr != nil:
+		scanExprVars(s.Expr.Expr, vars)
+	case s.For != nil:
+		scanExprVars(s.For.Source, vars)
+		scanExprVars(s.For.RangeEnd, vars)
+		for _, st := range s.For.Body {
+			scanStmtVars(st, vars)
+		}
+	case s.While != nil:
+		scanExprVars(s.While.Cond, vars)
+		for _, st := range s.While.Body {
+			scanStmtVars(st, vars)
+		}
+	case s.If != nil:
+		scanExprVars(s.If.Cond, vars)
+		for _, st := range s.If.Then {
+			scanStmtVars(st, vars)
+		}
+		if s.If.ElseIf != nil {
+			scanStmtVars(&parser.Statement{If: s.If.ElseIf}, vars)
+		}
+		for _, st := range s.If.Else {
+			scanStmtVars(st, vars)
+		}
+	}
+}

--- a/tests/compiler/pl/dataset.mochi
+++ b/tests/compiler/pl/dataset.mochi
@@ -1,0 +1,18 @@
+type Person {
+  name: string
+  age: int
+}
+
+let people = [
+  Person { name: "Alice", age: 30 },
+  Person { name: "Bob", age: 15 },
+  Person { name: "Charlie", age: 65 }
+]
+
+let names = from p in people
+            where p.age >= 18
+            select p.name
+
+for n in names {
+  print(n)
+}

--- a/tests/compiler/pl/dataset.out
+++ b/tests/compiler/pl/dataset.out
@@ -1,0 +1,2 @@
+Alice
+Charlie

--- a/tests/compiler/pl/dataset.pl.out
+++ b/tests/compiler/pl/dataset.pl.out
@@ -1,0 +1,35 @@
+:- style_check(-singleton).
+to_list(Str, L) :-
+    string(Str), !,
+    string_chars(Str, L).
+to_list(L, L).
+
+
+
+		main :-
+	dict_create(_V0, p_person, [name-"Alice", age-30]),
+	dict_create(_V1, p_person, [name-"Bob", age-15]),
+	dict_create(_V2, p_person, [name-"Charlie", age-65]),
+	People = [_V0, _V1, _V2],
+	to_list(People, _V5),
+	findall(P, (member(P, _V5), get_dict(age, P, _V6), _V6 >= 18), _V7),
+	findall(_V8, (member(P, _V7), get_dict(name, P, _V3), _V8 = _V3), _V9),
+	Names = _V9,
+	to_list(Names, _V10),
+	catch(
+		(
+			member(N, _V10),
+			catch(
+				(
+					write(N),
+					nl,
+					true
+				), continue, true),
+				fail
+				;
+				true
+			)
+			, break, true),
+			true
+		.
+:- initialization(main, main).

--- a/tests/compiler/pl/dataset_sort_take_limit.mochi
+++ b/tests/compiler/pl/dataset_sort_take_limit.mochi
@@ -1,0 +1,27 @@
+// dataset-sort-take-limit.mochi
+
+type Product {
+  name: string
+  price: int
+}
+
+let products = [
+  Product { name: "Laptop", price: 1500 },
+  Product { name: "Smartphone", price: 900 },
+  Product { name: "Tablet", price: 600 },
+  Product { name: "Monitor", price: 300 },
+  Product { name: "Keyboard", price: 100 },
+  Product { name: "Mouse", price: 50 },
+  Product { name: "Headphones", price: 200 }
+]
+
+let expensive = from p in products
+                sort by -p.price
+                skip 1
+                take 3
+                select p
+
+print("--- Top products (excluding most expensive) ---")
+for item in expensive {
+  print(item.name, "costs $", item.price)
+}

--- a/tests/compiler/pl/dataset_sort_take_limit.out
+++ b/tests/compiler/pl/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/compiler/pl/dataset_sort_take_limit.pl.out
+++ b/tests/compiler/pl/dataset_sort_take_limit.pl.out
@@ -1,0 +1,63 @@
+:- style_check(-singleton).
+slice(Str, I, J, Out) :-
+    string(Str), !,
+    Len is J - I,
+    sub_string(Str, I, Len, _, Out).
+slice(List, I, J, Out) :-
+    length(Prefix, I),
+    append(Prefix, Rest, List),
+    Len is J - I,
+    length(Out, Len),
+    append(Out, _, Rest).
+
+
+to_list(Str, L) :-
+    string(Str), !,
+    string_chars(Str, L).
+to_list(L, L).
+
+
+
+		main :-
+	dict_create(_V0, p_product, [name-"Laptop", price-1500]),
+	dict_create(_V1, p_product, [name-"Smartphone", price-900]),
+	dict_create(_V2, p_product, [name-"Tablet", price-600]),
+	dict_create(_V3, p_product, [name-"Monitor", price-300]),
+	dict_create(_V4, p_product, [name-"Keyboard", price-100]),
+	dict_create(_V5, p_product, [name-"Mouse", price-50]),
+	dict_create(_V6, p_product, [name-"Headphones", price-200]),
+	Products = [_V0, _V1, _V2, _V3, _V4, _V5, _V6],
+	to_list(Products, _V9),
+	findall(_V11-_V10, (member(P, _V9), get_dict(price, P, _V7), _V8 is -(_V7), _V11 = _V8, _V10 = P), _V12),
+	keysort(_V12, _V13),
+	findall(V, member(_-V, _V13), _V14),
+	length(_V14, _V15),
+	_V16 is 1 + 3,
+	slice(_V14, 1, _V16, _V17),
+	Expensive = _V17,
+	write("--- Top products (excluding most expensive) ---"),
+	nl,
+	to_list(Expensive, _V18),
+	catch(
+		(
+			member(Item, _V18),
+			catch(
+				(
+					get_dict(name, Item, _V19),
+					write(_V19),
+					write(' '),
+					write("costs $"),
+					write(' '),
+					get_dict(price, Item, _V20),
+					write(_V20),
+					nl,
+					true
+				), continue, true),
+				fail
+				;
+				true
+			)
+			, break, true),
+			true
+		.
+:- initialization(main, main).


### PR DESCRIPTION
## Summary
- push `where` clauses down in Prolog compiler
- scan variable usage for pushdown eligibility
- add dataset query examples and golden outputs for Prolog

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bd0fd96d08320941d75f38ddefb0f