### PR TITLE
Improve Swift query compilation

### DIFF
--- a/tests/compiler/swift/cross_join_filter.mochi
+++ b/tests/compiler/swift/cross_join_filter.mochi
@@ -1,0 +1,10 @@
+let nums = [1, 2, 3]
+let letters = ["A", "B"]
+let pairs = from n in nums
+            from l in letters
+            where n % 2 == 0
+            select { n: n, l: l }
+print("--- Even pairs ---")
+for p in pairs {
+  print(p.n, p.l)
+}

--- a/tests/compiler/swift/cross_join_filter.out
+++ b/tests/compiler/swift/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B

--- a/tests/compiler/swift/cross_join_filter.swift.out
+++ b/tests/compiler/swift/cross_join_filter.swift.out
@@ -1,0 +1,22 @@
+import Foundation
+
+func main() {
+	let nums: [Int] = [1, 2, 3]
+	let letters: [String] = ["A", "B"]
+	let pairs = ({
+	var _res: [[Any: Any]] = []
+	for n in nums {
+		if !(n % 2 == 0) { continue }
+		for l in letters {
+			_res.append([String(describing: n): n, l: l])
+		}
+	}
+	var _items = _res
+	return _items
+}())
+	print("--- Even pairs ---")
+	for p in pairs {
+		print(p["n"]!, p["l"]!)
+	}
+}
+main()


### PR DESCRIPTION
## Summary
- optimize Swift dataset queries with simple predicate pushdown
- track variables used in expressions to determine pushdown point
- add cross-join filter golden test for Swift

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685be3c7095c8320b572fcf989a91562