### PR TITLE
Optimize Smalltalk dataset queries

### DIFF
--- a/tests/compiler/st/dataset.st.out
+++ b/tests/compiler/st/dataset.st.out
@@ -11,10 +11,8 @@ newPerson: name age: age | dict |
 people := Array with: (Main newPerson: 'Alice' age: 30) with: (Main newPerson: 'Bob' age: 15) with: (Main newPerson: 'Charlie' age: 65).
 names := ((| res |
 res := OrderedCollection new.
-(people) do: [:p |
-	((p at: 'age' >= 18)) ifTrue: [
-		res add: p at: 'name'.
-	]
+((people) select: [:p | (p at: 'age' >= 18)]) do: [:p |
+	res add: p at: 'name'.
 ]
 res := res asArray.
 res)).


### PR DESCRIPTION
## Summary
- apply predicate pushdown in the Smalltalk compiler
- update golden output for dataset query

## Testing
- `go test ./compile/x/st -run TestSTCompiler_GoldenOutput/dataset -tags slow`
- `go test ./compile/x/st -tags slow -run Golden`

------
https://chatgpt.com/codex/tasks/task_e_685be3bd09fc83209992f77a0d2f2373