### PR TITLE
Add release notes for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # 📦 CHANGELOG.md
+## [0.10.0] – 2025-06-25T20:05:45+07:00
+
+### Added
+
+* Dataset query sorting, joining, grouping and pagination across backends
+* Distinct queries in Dart with dataset load/save for C++
+* Predicate pushdown in the VM and data planner
+* Compilers push down where filters with skip/take optimization
+
+### Changed
+
+* Improved dataset casting in Kotlin
+
+### Fixed
+
+* PHP query environment capture
+* COBOL print indentation
+
+
 ## [0.9.5] – 2025-06-25T09:23:00+07:00
 
 ### Added

--- a/releases/v0.10.0.md
+++ b/releases/v0.10.0.md
@@ -1,0 +1,23 @@
+# Jun 2025 (v0.10.0)
+
+Released on Wed Jun 25 20:05:45 2025 +0700.
+
+Mochi v0.10.0 optimizes dataset queries and expands query capabilities across the toolchain. Predicates are pushed down to data sources while sorting, grouping and joins gain improved support.
+
+## Runtime
+
+- Where predicate pushdown in the VM
+- Data planner pushes down simple filters
+
+## Compilers
+
+- Dataset load/save support in the C++ backend
+- Sorting, grouping, joins and pagination across many languages
+- Distinct queries in Dart and complex group-by in F#
+- Query predicate pushdown in most backends with skip/take optimization
+- Improved dataset casting in Kotlin
+
+## Fixes
+
+- PHP query environment capture
+- COBOL print indentation updates


### PR DESCRIPTION
## Summary
- document release v0.10.0 with runtime improvements and compiler features
- update CHANGELOG with v0.10.0 entry

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685bfb3082b48320a17870f417dd2014