### PR TITLE
Default run uses VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,4 @@
 # 📦 CHANGELOG.md
-## [0.10.1] – 2025-06-26
-
-### Changed
-
-* `mochi run` now executes programs with the VM by default
-* `--interp` flag runs the old interpreter
-* `--ir` prints VM assembly and exits
-
 ## [0.10.0] – 2025-06-25T20:05:45+07:00
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # 📦 CHANGELOG.md
+## [0.10.1] – 2025-06-26
+
+### Changed
+
+* `mochi run` now executes programs with the VM by default
+* `--interp` flag runs the old interpreter
+* `--ir` prints VM assembly and exits
+
 ## [0.10.0] – 2025-06-25T20:05:45+07:00
 
 ### Added


### PR DESCRIPTION
## Summary
- change `mochi run` to use the VM by default
- support `--ir` to print the VM assembly
- support `--interp` to run with the interpreter
- document CLI change in CHANGELOG

## Testing
- `go fmt ./cmd/...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c002a6f488320aef27ab832d7a4e7