### PR TITLE
Add expect helper for C# backend

### DIFF
--- a/compile/x/cs/compiler.go
+++ b/compile/x/cs/compiler.go
@@ -286,7 +286,8 @@ func (c *Compiler) compileExpect(e *parser.ExpectStmt) error {
 	if err != nil {
 		return err
 	}
-	c.writeln(fmt.Sprintf("if (!(%s)) throw new Exception(\"expect failed\");", expr))
+	c.helpers["_expect"] = true
+	c.writeln(fmt.Sprintf("expect(%s);", expr))
 	return nil
 }
 

--- a/compile/x/cs/runtime.go
+++ b/compile/x/cs/runtime.go
@@ -417,6 +417,12 @@ func (c *Compiler) emitRuntime() {
 				c.writeln("return JsonSerializer.Deserialize<T>(prompt);")
 				c.indent--
 				c.writeln("}")
+			case "_expect":
+				c.writeln("static void expect(bool cond) {")
+				c.indent++
+				c.writeln("if (!cond) throw new Exception(\"expect failed\");")
+				c.indent--
+				c.writeln("}")
 			case "_agent":
 				c.writeln("class _Agent {")
 				c.indent++

--- a/tests/compiler/cs/test_block.cs.out
+++ b/tests/compiler/cs/test_block.cs.out
@@ -9,11 +9,15 @@ using System.Web;
 public class Program {
 	static void test_addition_works() {
 		long x = (1L + 2L);
-		if (!((x == 3L))) throw new Exception("expect failed");
+		expect((x == 3L));
 	}
 	
 	public static void Main() {
 		Console.WriteLine("ok");
 		test_addition_works();
 	}
+	static void expect(bool cond) {
+		if (!cond) throw new Exception("expect failed");
+	}
+	
 }

--- a/tests/compiler/cs/typed_list_negative.cs.out
+++ b/tests/compiler/cs/typed_list_negative.cs.out
@@ -9,9 +9,9 @@ using System.Text.Json;
 
 public class Program {
 	static void test_values() {
-		if (!((_indexList(xs, 0L) == ((-1L))))) throw new Exception("expect failed");
-		if (!((_indexList(xs, 1L) == 0L))) throw new Exception("expect failed");
-		if (!((_indexList(xs, 2L) == 1L))) throw new Exception("expect failed");
+		expect((_indexList(xs, 0L) == ((-1L))));
+		expect((_indexList(xs, 1L) == 0L));
+		expect((_indexList(xs, 2L) == 1L));
 		Console.WriteLine("done");
 	}
 	
@@ -25,6 +25,10 @@ public class Program {
 		if (i < 0) i += list.Count;
 		if (i < 0 || i >= list.Count) throw new Exception("index out of range");
 		return list[(int)i];
+	}
+	
+	static void expect(bool cond) {
+		if (!cond) throw new Exception("expect failed");
 	}
 	
 	static T _cast<T>(dynamic v) {


### PR DESCRIPTION
## Summary
- generate an `expect()` helper for the C# backend
- emit calls to `expect()` for `expect` statements
- update golden outputs for test cases

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bfed313a88320a2cee1f5d25a2a6d