### PR TITLE
Add Dart test block support

### DIFF
--- a/compile/x/dart/runtime.go
+++ b/compile/x/dart/runtime.go
@@ -47,6 +47,25 @@ const (
 		"    }\n" +
 		"    return res;\n" +
 		"}\n"
+	helperFormatDuration = "String _formatDuration(Duration d) {\n" +
+		"    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';\n" +
+		"    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';\n" +
+		"    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';\n" +
+		"}\n"
+	helperRunTest = "bool _runTest(String name, void Function() f) {\n" +
+		"    stdout.write('   test $name ...');\n" +
+		"    var start = DateTime.now();\n" +
+		"    try {\n" +
+		"        f();\n" +
+		"        var d = DateTime.now().difference(start);\n" +
+		"        stdout.writeln(' ok (${_formatDuration(d)})');\n" +
+		"        return true;\n" +
+		"    } catch (e) {\n" +
+		"        var d = DateTime.now().difference(start);\n" +
+		"        stdout.writeln(' fail $e (${_formatDuration(d)})');\n" +
+		"        return false;\n" +
+		"    }\n" +
+		"}\n"
 	helperStream = "class _Stream<T> {\n" +
 		"    String name;\n" +
 		"    List<void Function(T)> handlers = [];\n" +
@@ -330,26 +349,28 @@ const (
 )
 
 var helperMap = map[string]string{
-	"_indexString": helperIndexString,
-	"_unionAll":    helperUnionAll,
-	"_union":       helperUnion,
-	"_except":      helperExcept,
-	"_intersect":   helperIntersect,
-	"_Stream":      helperStream,
-	"_Agent":       helperAgent,
-	"_waitAll":     helperWaitAll,
-	"_Group":       helperGroup,
-	"_group_by":    helperGroupBy,
-	"_fetch":       helperFetch,
-	"_load":        helperLoad,
-	"_save":        helperSave,
-	"_query":       helperQuery,
-	"_genText":     helperGenText,
-	"_genEmbed":    helperGenEmbed,
-	"_genStruct":   helperGenStruct,
-	"_json":        helperJson,
-	"_equal":       helperEqual,
-	"_distinct":    helperDistinct,
+	"_indexString":    helperIndexString,
+	"_unionAll":       helperUnionAll,
+	"_union":          helperUnion,
+	"_except":         helperExcept,
+	"_intersect":      helperIntersect,
+	"_Stream":         helperStream,
+	"_Agent":          helperAgent,
+	"_waitAll":        helperWaitAll,
+	"_Group":          helperGroup,
+	"_group_by":       helperGroupBy,
+	"_fetch":          helperFetch,
+	"_load":           helperLoad,
+	"_save":           helperSave,
+	"_query":          helperQuery,
+	"_genText":        helperGenText,
+	"_genEmbed":       helperGenEmbed,
+	"_genStruct":      helperGenStruct,
+	"_json":           helperJson,
+	"_equal":          helperEqual,
+	"_distinct":       helperDistinct,
+	"_formatDuration": helperFormatDuration,
+	"_runTest":        helperRunTest,
 }
 
 func (c *Compiler) use(name string) {

--- a/tests/compiler/valid/test_block.dart.out
+++ b/tests/compiler/valid/test_block.dart.out
@@ -1,10 +1,36 @@
+import 'dart:io';
+
 void test_addition_works() {
-	int x = (1 + 2);
-	if (!((x == 3))) { throw Exception('expect failed'); }
+        int x = (1 + 2);
+        if (!((x == 3))) { throw Exception('expect failed'); }
 }
 
 void main() {
-	print("ok");
-	test_addition_works();
+        int failures = 0;
+        print("ok");
+        if (!_runTest("addition works", test_addition_works)) failures++;
+        if (failures > 0) {
+                print("\n[FAIL] $failures test(s) failed.");
+        }
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
 }
 


### PR DESCRIPTION
## Summary
- implement test block harness for Dart backend
- provide runtime helpers for running tests
- update Dart test golden output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bfed5f05083209cc1628f4457d716