### PR TITLE
Add test block/expect support to PHP compiler

### DIFF
--- a/tests/compiler/php/typed_list_negative.php.out
+++ b/tests/compiler/php/typed_list_negative.php.out
@@ -1,2 +1,12 @@
 <?php
+function mochi_test_values() {
+	global $xs;
+	if (!(($xs[0] == (-1)))) { throw new Exception('expect failed'); }
+	if (!(($xs[1] == 0))) { throw new Exception('expect failed'); }
+	if (!(($xs[2] == 1))) { throw new Exception('expect failed'); }
+	echo "done", PHP_EOL;
+}
+
 $xs = [(-1), 0, 1];
+mochi_test_values();
+


### PR DESCRIPTION
## Summary
- allow php test blocks to reference globals
- scan expect and test statements for variable captures
- update PHP golden output

## Testing
- `go test ./compile/x/php -run SubsetPrograms/typed_list_negative -tags slow -count=1 -v`
- `go test ./compile/x/php -run GoldenOutput/typed_list_negative -tags slow -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_685bfeec0e808320bbb133ae7ee58801