### PR TITLE
Add test block helper usage for Prolog

### DIFF
--- a/compile/x/pl/README.md
+++ b/compile/x/pl/README.md
@@ -275,6 +275,15 @@ the Prolog interpreter is invoked:
 go test ./compile/pl -tags slow
 ```
 
+## Test Blocks and `expect`
+
+The Prolog backend supports `expect` statements for assertions and `test` blocks
+to group them. Each test block is compiled into a predicate named
+`test_<name>` which runs the block body. Compiled programs call all generated
+test predicates from `main/0`, so running the produced Prolog file executes the
+tests automatically. Failed expectations raise an exception with the message
+`expect failed`.
+
 ## Supported Features
 
 The Prolog backend can compile a subset of Mochi focused on core control flow and list processing. Currently implemented features include:

--- a/compile/x/pl/compiler.go
+++ b/compile/x/pl/compiler.go
@@ -77,11 +77,8 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 			return nil, err
 		}
 	}
-	for _, s := range prog.Statements {
-		if s.Test != nil {
-			name := "test_" + sanitizeAtom(strings.ReplaceAll(s.Test.Name, " ", "_"))
-			c.writeln(fmt.Sprintf("%s,", name))
-		}
+	for _, name := range c.tests {
+		c.writeln(fmt.Sprintf("%s,", name))
 	}
 	b := c.buf.Bytes()
 	if bytes.HasSuffix(b, []byte(",\n")) {


### PR DESCRIPTION
## Summary
- run recorded test predicates when compiling Prolog code
- document how `expect` and test blocks work

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685bfef0eac88320b55e8162f7fa1ee4