### PR TITLE
Add expect helper for Rust backend

### DIFF
--- a/compile/x/rust/README.md
+++ b/compile/x/rust/README.md
@@ -6,7 +6,7 @@ The Rust backend compiles Mochi programs to plain Rust source code. It is a mini
 
 - Variable declarations with `let` and `var`
 - `if`/`else` expressions and `for`/`while` loops
-- User defined functions, simple `fun` expressions and test blocks
+- User defined functions, simple `fun` expressions, test blocks and `expect` statements
 - Lists and maps including indexing, slicing, membership checks and iteration over map keys in `for` loops
 - List concatenation and set operations (`union_all`, `union`, `except`, `intersect`)
 - Builtins like `print`, `len`, `count`, `avg`, `input` and `str`

--- a/compile/x/rust/runtime.go
+++ b/compile/x/rust/runtime.go
@@ -109,6 +109,10 @@ const (
 
 	helperSave = "fn _save<T>(_src: &[T], _path: &str) {\n" +
 		"}\n"
+
+	helperExpect = "fn expect(cond: bool) {\n" +
+		"    if !cond { panic!(\"expect failed\"); }\n" +
+		"}\n"
 )
 
 var helperMap = map[string]string{
@@ -130,6 +134,7 @@ var helperMap = map[string]string{
 	"_fetch":        helperFetch,
 	"_load":         helperLoad,
 	"_save":         helperSave,
+	"expect":        helperExpect,
 }
 
 func (c *Compiler) use(name string) { c.helpers[name] = true }

--- a/compile/x/rust/statements.go
+++ b/compile/x/rust/statements.go
@@ -184,7 +184,8 @@ func (c *Compiler) compileExpect(e *parser.ExpectStmt) error {
 	if err != nil {
 		return err
 	}
-	c.writeln(fmt.Sprintf("assert!(%s);", expr))
+	c.use("expect")
+	c.writeln(fmt.Sprintf("expect(%s);", expr))
 	return nil
 }
 

--- a/tests/compiler/rust/test_block.rs.out
+++ b/tests/compiler/rust/test_block.rs.out
@@ -1,6 +1,6 @@
 fn test_addition_works() {
     let mut x = 1 + 2;
-    assert!(x == 3);
+    expect(x == 3);
 }
 
 fn main() {


### PR DESCRIPTION
## Summary
- update Rust backend README with expect
- implement `expect` runtime helper in Rust backend
- emit `expect` helper when compiling expect statements
- update Rust golden file for test blocks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bfef67310832080cc518d8cd566d7