### PR TITLE
Add Scala expect helper

### DIFF
--- a/compile/x/scala/compiler.go
+++ b/compile/x/scala/compiler.go
@@ -536,7 +536,8 @@ func (c *Compiler) compileExpect(e *parser.ExpectStmt) error {
 	if err != nil {
 		return err
 	}
-	c.writeln(fmt.Sprintf("assert(%s)", expr))
+	c.use("_expect")
+	c.writeln(fmt.Sprintf("expect(%s)", expr))
 	return nil
 }
 

--- a/compile/x/scala/runtime.go
+++ b/compile/x/scala/runtime.go
@@ -197,6 +197,9 @@ implicit val _anyOrdering: Ordering[Any] = new Ordering[Any] { def compare(x: An
         case other => "\"" + other.toString.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
 }`
 	helperJSON   = `def _json(v: Any): Unit = println(_to_json(v))`
+	helperExpect = `def expect(cond: Boolean): Unit = {
+        if (!cond) throw new RuntimeException("expect failed")
+}`
 	helperPyAttr = `def _pyAttr(module: String, name: String, args: Seq[Any]): Any = {
         import scala.sys.process._
         import scala.util.parsing.json.{JSON, JSONArray}
@@ -246,6 +249,7 @@ var helperMap = map[string]string{
 	"_eval":        helperEval,
 	"_to_json":     helperToJSON,
 	"_json":        helperJSON,
+	"_expect":      helperExpect,
 }
 
 func (c *Compiler) use(name string) {


### PR DESCRIPTION
## Summary
- compile Scala expect statements using a runtime helper
- add `expect` helper implementation to the Scala runtime

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bfefb8b3883208b4c1039a227a4f9