### PR TITLE
Fix Mochi syntax error in TPC-H Q21

### DIFF
--- a/tests/dataset/tpc-h/q21.mochi
+++ b/tests/dataset/tpc-h/q21.mochi
@@ -43,13 +43,11 @@ let result =
     o.o_orderstatus == "F" and
     l1.l_receiptdate > l1.l_commitdate and
     n.n_name == "SAUDI ARABIA" and
-    not exists (
-      x in lineitem
+    not exists x in lineitem
       where
         x.l_orderkey == l1.l_orderkey and
         x.l_suppkey != l1.l_suppkey and
         x.l_receiptdate > x.l_commitdate
-    )
   group by s.s_name
   select {
     s_name: s.s_name,


### PR DESCRIPTION
## Summary
- fix `not exists` syntax in `tests/dataset/tpc-h/q21.mochi`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c05e6885083208c8c0d4668736217