### PR TITLE
Fix syntax for exists query in TPC-H q4

### DIFF
--- a/tests/dataset/tpc-h/q4.mochi
+++ b/tests/dataset/tpc-h/q4.mochi
@@ -22,8 +22,10 @@ let date_filtered_orders =
 
 let late_orders =
   from o in date_filtered_orders
-  where exists l in lineitem
+  where exists (
+    l in lineitem
     where l.l_orderkey == o.o_orderkey and l.l_commitdate < l.l_receiptdate
+  )
   select o
 
 let result =


### PR DESCRIPTION
## Summary
- correct the `exists` query syntax in `tests/dataset/tpc-h/q4.mochi`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c05c3f298832081f2c9c62acc848a