### PR TITLE
Fix syntax in TPC-H Q18 test

### DIFF
--- a/tests/dataset/tpc-h/q18.mochi
+++ b/tests/dataset/tpc-h/q18.mochi
@@ -37,7 +37,7 @@ let lineitem = [
 
 let threshold = 200
 
-let result =
+let grouped =
   from c in customer
   join o in orders on o.o_custkey == c.c_custkey
   join l in lineitem on l.l_orderkey == o.o_orderkey
@@ -51,18 +51,32 @@ let result =
     c_comment: c.c_comment,
     n_name: n.n_name
   }
-  having sum(l.l_quantity) > threshold
   select {
     c_name,
     c_custkey,
-    revenue: sum(l.l_extendedprice * (1 - l.l_discount)),
     c_acctbal,
-    n_name,
     c_address,
     c_phone,
-    c_comment
+    c_comment,
+    n_name,
+    quantity: sum(l.l_quantity),
+    revenue: sum(l.l_extendedprice * (1 - l.l_discount))
   }
-  order by revenue desc
+
+let result =
+  from g in grouped
+  where g.quantity > threshold
+  order by g.revenue desc
+  select {
+    c_name: g.c_name,
+    c_custkey: g.c_custkey,
+    revenue: g.revenue,
+    c_acctbal: g.c_acctbal,
+    n_name: g.n_name,
+    c_address: g.c_address,
+    c_phone: g.c_phone,
+    c_comment: g.c_comment
+  }
 
 print result
 


### PR DESCRIPTION
## Summary
- rewrite Q18 dataset query to avoid unsupported `having`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c05e19cb4832084c07aba1a63b934