### PR TITLE
Fix TPCH Q6 syntax

### DIFF
--- a/tests/dataset/tpc-h/q6.md
+++ b/tests/dataset/tpc-h/q6.md
@@ -58,8 +58,7 @@ let lineitem = [
   }
 ]
 
-let result =
-  from l in lineitem
+let result = from l in lineitem
   where
     l.l_shipdate >= "1994-01-01" and
     l.l_shipdate < "1995-01-01" and

--- a/tests/dataset/tpc-h/q6.mochi
+++ b/tests/dataset/tpc-h/q6.mochi
@@ -24,9 +24,7 @@ let lineitem = [
     l_quantity: 5
   }
 ]
-
-let result =
-  from l in lineitem
+let result = from l in lineitem
   where
     l.l_shipdate >= "1994-01-01" and
     l.l_shipdate < "1995-01-01" and


### PR DESCRIPTION
## Summary
- update q6.mochi to keep query on one line
- update q6.md snippet to match

## Testing
- `go test ./...`
- `make build-mochi`
- `/root/bin/mochi run tests/vm/valid/dataset_where_filter.mochi`
- `/root/bin/mochi run tests/vm/valid/group_by_left_join.mochi`
- `/root/bin/mochi run tests/dataset/tpc-h/q6.mochi` *(fails: undefined variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c05c69af88320859ede1d60457d2d