### PR TITLE
Fix q11 Mochi query syntax

### DIFF
--- a/tests/dataset/tpc-h/q11.mochi
+++ b/tests/dataset/tpc-h/q11.mochi
@@ -24,7 +24,7 @@ let filtered =
   join n in nation on n.n_nationkey == s.s_nationkey
   where n.n_name == target_nation
   let value = ps.ps_supplycost * ps.ps_availqty
-  select { ps.ps_partkey, value }
+  select { ps_partkey: ps.ps_partkey, value }
 
 let grouped =
   from x in filtered


### PR DESCRIPTION
## Summary
- fix object literal syntax in tpch q11 example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c05d21e4883208baa1eed9b1017b6