### PR TITLE
Fix Mochi syntax error in q22

### DIFF
--- a/tests/dataset/tpc-h/q22.md
+++ b/tests/dataset/tpc-h/q22.md
@@ -73,8 +73,11 @@ let orders = [
 let valid_codes = ["13", "31", "23", "29", "30", "18", "17"]
 
 let avg_balance =
-  avg(c.c_acctbal for c in customer
-      where c.c_acctbal > 0.0 and substring(c.c_phone, 0, 2) in valid_codes)
+  avg(
+    from c in customer
+    where c.c_acctbal > 0.0 and substring(c.c_phone, 0, 2) in valid_codes
+    select c.c_acctbal
+  )
 
 let eligible_customers =
   from c in customer

--- a/tests/dataset/tpc-h/q22.mochi
+++ b/tests/dataset/tpc-h/q22.mochi
@@ -11,8 +11,11 @@ let orders = [
 let valid_codes = ["13", "31", "23", "29", "30", "18", "17"]
 
 let avg_balance =
-  avg(c.c_acctbal for c in customer
-      where c.c_acctbal > 0.0 and substring(c.c_phone, 0, 2) in valid_codes)
+  avg(
+    from c in customer
+    where c.c_acctbal > 0.0 and substring(c.c_phone, 0, 2) in valid_codes
+    select c.c_acctbal
+  )
 
 let eligible_customers =
   from c in customer


### PR DESCRIPTION
## Summary
- fix query 22 average calculation syntax in both `.mochi` and `.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c05e7684c8320aeb910bd620b60a0