### PR TITLE
Fix syntax errors in cheatsheet

### DIFF
--- a/mcp/cheatsheet.mochi
+++ b/mcp/cheatsheet.mochi
@@ -128,7 +128,7 @@ print("Email: ", p.email)
 
 // Request an embedding vector
 let vec = generate embedding {
-  text: "hello world"
+  text: "hello world",
   normalize: true
 }
 print(len(vec))
@@ -145,7 +145,7 @@ print(mood)
 // 8. Logical operators
 let a = true
 let b = false
-if a && b || !b {
+if a && b || (!b) {
   print("logic works")
 }
 
@@ -231,13 +231,16 @@ print(right)
 
 let outer = from o in orders
             outer join c in customers on o.customerId == c.id
-            select { order: o?.id, customer: c?.name }
+            select { order: o.id, customer: c.name }
 print(outer)
 
 // Group by with aggregation
 let grouped = from p in people
-              group by p.age >= 60 ? "senior" : "adult" into g
-              select { type: g.key, count: count(g) }
+              group by if p.age >= 60 { "senior" } else { "adult" } into g
+              select {
+                kind: g.key,
+                count: count(g)
+              }
 print(grouped)
 
 // Set operations


### PR DESCRIPTION
## Summary
- fix generate embedding example
- adjust logical operators example
- clean up dataset query examples to avoid parser errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c06c6924c8320a2e77d4ec05c92a5