### PR TITLE
Fix Mochi syntax in q2 query

### DIFF
--- a/tests/dataset/tpc-h/q2.md
+++ b/tests/dataset/tpc-h/q2.md
@@ -102,7 +102,7 @@ let europe_nations =
 let europe_suppliers =
   from s in supplier
   join n in europe_nations on s.s_nationkey == n.n_nationkey
-  select { s, n }
+  select { s: s, n: n }
 
 let target_parts =
   from p in part

--- a/tests/dataset/tpc-h/q2.mochi
+++ b/tests/dataset/tpc-h/q2.mochi
@@ -48,7 +48,7 @@ let europe_nations =
 let europe_suppliers =
   from s in supplier
   join n in europe_nations on s.s_nationkey == n.n_nationkey
-  select { s, n }
+  select { s: s, n: n }
 
 let target_parts =
   from p in part


### PR DESCRIPTION
## Summary
- fix inline supplier selection mapping in dataset query

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c05c04fec8320bfb3c364fe4c1b41