### PR TITLE
Fix syntax in TPCH q20 dataset

### DIFF
--- a/tests/dataset/tpc-h/q20.md
+++ b/tests/dataset/tpc-h/q20.md
@@ -100,10 +100,12 @@ let lineitem = [
   }
 ]
 
+let prefix = "forest"
+
 let target_partkeys =
   from ps in partsupp
   join p in part on ps.ps_partkey == p.p_partkey
-  where p.p_name has "forest"
+  where p.p_name has prefix
   let shipped =
     sum(l.l_quantity for l in lineitem
         where l.l_partkey == ps.ps_partkey

--- a/tests/dataset/tpc-h/q20.mochi
+++ b/tests/dataset/tpc-h/q20.mochi
@@ -33,10 +33,12 @@ let lineitem = [
   }
 ]
 
+let prefix = "forest"
+
 let target_partkeys =
   from ps in partsupp
   join p in part on ps.ps_partkey == p.p_partkey
-  where p.p_name has "forest"
+  where p.p_name has prefix
   let shipped =
     sum(l.l_quantity for l in lineitem
         where l.l_partkey == ps.ps_partkey


### PR DESCRIPTION
## Summary
- define `prefix` variable for q20 query
- reference `prefix` in q20 filter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c05e539a48320a1f531b6d25e7341