### PR TITLE
Fix TPCH Q13 syntax

### DIFF
--- a/tests/dataset/tpc-h/q13.md
+++ b/tests/dataset/tpc-h/q13.md
@@ -64,8 +64,13 @@ let per_customer =
   from c in customer
   let order_count =
     count(
-      o for o in orders
-      where o.o_custkey == c.c_custkey and not o.o_comment has "special" and not o.o_comment has "requests"
+      from o in orders
+      where (
+        o.o_custkey == c.c_custkey &&
+        (!("special" in o.o_comment)) &&
+        (!("requests" in o.o_comment))
+      )
+      select o
     )
   select { c_count: order_count }
 

--- a/tests/dataset/tpc-h/q13.mochi
+++ b/tests/dataset/tpc-h/q13.mochi
@@ -14,8 +14,13 @@ let per_customer =
   from c in customer
   let order_count =
     count(
-      o for o in orders
-      where o.o_custkey == c.c_custkey and not o.o_comment has "special" and not o.o_comment has "requests"
+      from o in orders
+      where (
+        o.o_custkey == c.c_custkey &&
+        (!("special" in o.o_comment)) &&
+        (!("requests" in o.o_comment))
+      )
+      select o
     )
   select { c_count: order_count }
 


### PR DESCRIPTION
## Summary
- fix query syntax in TPCH Q13 example

## Testing
- `go run ./cmd/mochi build tests/dataset/tpc-h/q13.mochi` *(fails: parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685c05d6b85c83209ecbaf4e6597e19a