### PR TITLE
Add sum builtin and TPCH Q1 golden test

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3079,6 +3079,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.imports["mochi/runtime/data"] = true
 		c.use("_avg")
 		return fmt.Sprintf("_avg(%s)", argStr), nil
+	case "sum":
+		c.imports["mochi/runtime/data"] = true
+		c.use("_sum")
+		return fmt.Sprintf("_sum(%s)", argStr), nil
 	case "len":
 		return fmt.Sprintf("len(%s)", argStr), nil
 	case "now":
@@ -3370,7 +3374,7 @@ func (c *Compiler) scanPrimaryImports(p *parser.Primary) {
 		if p.Call.Func == "str" {
 			c.imports["fmt"] = true
 		}
-		if p.Call.Func == "count" || p.Call.Func == "avg" {
+		if p.Call.Func == "count" || p.Call.Func == "avg" || p.Call.Func == "sum" {
 			c.imports["mochi/runtime/data"] = true
 		}
 		if p.Call.Func == "now" {

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -85,6 +85,35 @@ const (
 		"    return sum / float64(len(items))\n" +
 		"}\n"
 
+	helperSum = "func _sum(v any) float64 {\n" +
+		"    var items []any\n" +
+		"    if g, ok := v.(*data.Group); ok { items = g.Items } else {\n" +
+		"        switch s := v.(type) {\n" +
+		"        case []any:\n" +
+		"            items = s\n" +
+		"        case []int:\n" +
+		"            items = make([]any, len(s))\n" +
+		"            for i, v := range s { items[i] = v }\n" +
+		"        case []float64:\n" +
+		"            items = make([]any, len(s))\n" +
+		"            for i, v := range s { items[i] = v }\n" +
+		"        case []string, []bool:\n" +
+		"            panic(\"sum() expects numbers\")\n" +
+		"        default:\n" +
+		"            panic(\"sum() expects list or group\")\n" +
+		"        }\n" +
+		"    }\n" +
+		"    var sum float64\n" +
+		"    for _, it := range items {\n" +
+		"        switch n := it.(type) {\n" +
+		"        case int: sum += float64(n)\n" +
+		"        case int64: sum += float64(n)\n" +
+		"        case float64: sum += n\n" +
+		"        default: panic(\"sum() expects numbers\") }\n" +
+		"    }\n" +
+		"    return sum\n" +
+		"}\n"
+
 	helperInput = "func _input() string {\n" +
 		"    var s string\n" +
 		"    fmt.Scanln(&s)\n" +
@@ -441,6 +470,7 @@ var helperMap = map[string]string{
 	"_sliceString":   helperSliceString,
 	"_count":         helperCount,
 	"_avg":           helperAvg,
+	"_sum":           helperSum,
 	"_input":         helperInput,
 	"_genText":       helperGenText,
 	"_genEmbed":      helperGenEmbed,

--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -143,6 +143,8 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagInt
 	case OpAvg:
 		tags[ins.A] = TagFloat
+	case OpSum:
+		tags[ins.A] = TagFloat
 	case OpMin, OpMax:
 		tags[ins.A] = TagUnknown
 	}

--- a/tests/dataset/tpc-h/q1.mochi
+++ b/tests/dataset/tpc-h/q1.mochi
@@ -34,25 +34,21 @@ let result =
   group by {
     returnflag: row.l_returnflag,
     linestatus: row.l_linestatus
-  }
+  } into g
   select {
-    returnflag: row.l_returnflag,
-    linestatus: row.l_linestatus,
-    sum_qty: sum(row.l_quantity),
-    sum_base_price: sum(row.l_extendedprice),
-    sum_disc_price: sum(row.l_extendedprice * (1 - row.l_discount)),
-    sum_charge: sum(row.l_extendedprice * (1 - row.l_discount) * (1 + row.l_tax)),
-    avg_qty: avg(row.l_quantity),
-    avg_price: avg(row.l_extendedprice),
-    avg_disc: avg(row.l_discount),
-    count_order: count()
-  }
-  order by {
-    returnflag: returnflag,
-    linestatus: linestatus
+    returnflag: g.key.returnflag,
+    linestatus: g.key.linestatus,
+    sum_qty: sum(from x in g select x.l_quantity),
+    sum_base_price: sum(from x in g select x.l_extendedprice),
+    sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+    sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+    avg_qty: avg(from x in g select x.l_quantity),
+    avg_price: avg(from x in g select x.l_extendedprice),
+    avg_disc: avg(from x in g select x.l_discount),
+    count_order: count(g)
   }
 
-print result
+json(result)
 
 test "Q1 aggregates revenue and quantity by returnflag + linestatus" {
   expect result == [
@@ -60,12 +56,12 @@ test "Q1 aggregates revenue and quantity by returnflag + linestatus" {
       returnflag: "N",
       linestatus: "O",
       sum_qty: 53,
-      sum_base_price: 3000.0,
-      sum_disc_price: 1000.0 * 0.95 + 2000.0 * 0.90,               // 950 + 1800 = 2750.0
-      sum_charge: 1000.0 * 0.95 * 1.07 + 2000.0 * 0.90 * 1.05,     // 950 * 1.07 + 1800 * 1.05 = 1016.5 + 1890 = 2906.5
-      avg_qty: 53 / 2,
-      avg_price: 3000.0 / 2,
-      avg_disc: (0.05 + 0.10) / 2,
+      sum_base_price: 3000,
+      sum_disc_price: 950.0 + 1800.0,               // 2750.0
+      sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
+      avg_qty: 26.5,
+      avg_price: 1500,
+      avg_disc: 0.07500000000000001,
       count_order: 2
     }
   ]

--- a/tests/dataset/tpc-h/q1.out
+++ b/tests/dataset/tpc-h/q1.out
@@ -1,0 +1,1 @@
+[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]

--- a/tests/vm/valid/tail_recursion.ir.out
+++ b/tests/vm/valid/tail_recursion.ir.out
@@ -1,15 +1,15 @@
 func main (regs=5)
-  // print(sum(10, 0))
+  // print(sum_rec(10, 0))
   Const        r2, 10
   Move         r0, r2
   Const        r3, 0
   Move         r1, r3
-  Call2        r4, sum, r0, r1
+  Call2        r4, sum_rec, r0, r1
   Print        r4
   Return       r0
 
-  // fun sum(n: int, acc: int): int {
-func sum (regs=10)
+  // fun sum_rec(n: int, acc: int): int {
+func sum_rec (regs=10)
   // if n == 0 {
   Const        r2, 0
   Equal        r3, r0, r2
@@ -17,13 +17,13 @@ func sum (regs=10)
   // return acc
   Return       r1
 L0:
-  // return sum(n - 1, acc + n)
+  // return sum_rec(n - 1, acc + n)
   Const        r6, 1
   Sub          r7, r0, r6
   Move         r4, r7
   Add          r8, r1, r0
   Move         r5, r8
-  Call2        r9, sum, r4, r5
+  Call2        r9, sum_rec, r4, r5
   Return       r9
   Return       r0
 

--- a/tests/vm/valid/tail_recursion.mochi
+++ b/tests/vm/valid/tail_recursion.mochi
@@ -1,7 +1,7 @@
-fun sum(n: int, acc: int): int {
+fun sum_rec(n: int, acc: int): int {
   if n == 0 {
     return acc
   }
-  return sum(n - 1, acc + n)
+  return sum_rec(n - 1, acc + n)
 }
-print(sum(10, 0))
+print(sum_rec(10, 0))

--- a/tests/vm/valid/tree_sum.ir.out
+++ b/tests/vm/valid/tree_sum.ir.out
@@ -44,14 +44,14 @@ func main (regs=32)
   // let t = Node {
   MakeMap      r28, 4, r20
   Move         r29, r28
-  // print(sum(t))
+  // print(sum_tree(t))
   Move         r30, r29
-  Call         r31, sum, r30
+  Call         r31, sum_tree, r30
   Print        r31
   Return       r0
 
-  // fun sum(t: Tree): int {
-func sum (regs=23)
+  // fun sum_tree(t: Tree): int {
+func sum_tree (regs=23)
   // Leaf => 0
   Const        r3, "__name"
   Index        r4, r0, r3
@@ -62,7 +62,7 @@ func sum (regs=23)
   Move         r1, r6
   Jump         L1
 L0:
-  // Node(left, value, right) => sum(left) + value + sum(right)
+  // Node(left, value, right) => sum_tree(left) + value + sum_tree(right)
   Const        r8, "__name"
   Index        r9, r0, r8
   Const        r10, "Node"
@@ -75,10 +75,10 @@ L0:
   Const        r15, "right"
   Index        r16, r0, r15
   Move         r17, r12
-  Call         r18, sum, r17
+  Call         r18, sum_tree, r17
   Add          r19, r18, r14
   Move         r20, r16
-  Call         r21, sum, r20
+  Call         r21, sum_tree, r20
   Add          r22, r19, r21
   Move         r1, r22
   Jump         L1

--- a/tests/vm/valid/tree_sum.mochi
+++ b/tests/vm/valid/tree_sum.mochi
@@ -6,10 +6,10 @@ type Tree =
   Leaf
   | Node(left: Tree, value: int, right: Tree)
 
-fun sum(t: Tree): int {
+fun sum_tree(t: Tree): int {
   return match t {
     Leaf => 0
-    Node(left, value, right) => sum(left) + value + sum(right)
+    Node(left, value, right) => sum_tree(left) + value + sum_tree(right)
   }
 }
 
@@ -23,4 +23,4 @@ let t = Node {
   }
 }
 
-print(sum(t))
+print(sum_tree(t))

--- a/tests/vm/vm_test.go
+++ b/tests/vm/vm_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -88,5 +89,47 @@ func TestVM_Fetch(t *testing.T) {
 	}
 	if strings.TrimSpace(out.String()) != "ok" {
 		t.Fatalf("unexpected output: %s", out.String())
+	}
+}
+
+func TestVM_TPCH(t *testing.T) {
+	files, err := filepath.Glob("../dataset/tpc-h/*.out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no tpch test files")
+	}
+	for _, want := range files {
+		src := strings.TrimSuffix(want, ".out") + ".mochi"
+		name := filepath.Base(src)
+		t.Run(name, func(t *testing.T) {
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			p, err := vm.Compile(prog, env)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			var out bytes.Buffer
+			m := vm.New(p, &out)
+			if err := m.Run(); err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+			got := strings.TrimSpace(out.String())
+			data, err := os.ReadFile(want)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			wantStr := strings.TrimSpace(string(data))
+			if got != wantStr {
+				t.Errorf("%s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", name, got, wantStr)
+			}
+		})
 	}
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -57,6 +57,7 @@ var Errors = map[string]diagnostic.Template{
 	"T036": {Code: "T036", Message: "cannot take length of type %s", Help: "Use `len(...)` only on lists, strings, or maps."},
 	"T037": {Code: "T037", Message: "count() expects list or group, got %s", Help: "Pass a list or group to count()."},
 	"T038": {Code: "T038", Message: "avg() expects numeric list or group, got %s", Help: "Ensure the list or group contains numbers."},
+	"T041": {Code: "T041", Message: "sum() expects numeric list or group, got %s", Help: "Ensure the list or group contains numbers."},
 	"T039": {Code: "T039", Message: "function %s expects %d arguments, got %d", Help: "Pass exactly %d arguments to `%s`."},
 	"T040": {Code: "T040", Message: "`if` condition must be boolean", Help: "Ensure the condition evaluates to true or false."},
 }
@@ -219,6 +220,10 @@ func errCountOperand(pos lexer.Position, typ Type) error {
 
 func errAvgOperand(pos lexer.Position, typ Type) error {
 	return Errors["T038"].New(pos, typ)
+}
+
+func errSumOperand(pos lexer.Position, typ Type) error {
+	return Errors["T041"].New(pos, typ)
 }
 
 func errArgCount(pos lexer.Position, name string, expected, actual int) error {


### PR DESCRIPTION
## Summary
- implement `sum` builtin across compiler, runtime, types, and VM
- update query `tests/dataset/tpc-h/q1.mochi`
- add golden output for TPCH Q1 and run it in VM tests
- rename test helper functions that conflicted with new builtin

## Testing
- `go test ./tests/vm -run TestVM_IR -v`
- `go test ./tests/vm -run TestVM_TPCH -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c1324ef0883208ded251c3c370633