### PR TITLE
Fix TPCH Q3 sort and support compound sort keys

### DIFF
--- a/tests/dataset/tpc-h/q3.mochi
+++ b/tests/dataset/tpc-h/q3.mochi
@@ -41,14 +41,16 @@ let order_line_join =
     o_orderdate: o.o_orderdate,
     o_shippriority: o.o_shippriority
   } into g
+  sort by [
+    -sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+    g.key.o_orderdate
+  ]
   select {
     l_orderkey: g.key.o_orderkey,
     revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
     o_orderdate: g.key.o_orderdate,
     o_shippriority: g.key.o_shippriority
   }
-  sort by o_orderdate
-  sort by -revenue
 
 print order_line_join
 


### PR DESCRIPTION
## Summary
- fix Q3 example query to use a single `sort by` clause
- allow `OpSort` keys to be lists for multi-column sorting
- adjust group-by compilation to emit sort pairs when needed

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c2424c508832086bc9012ba1be8e6