### PR TITLE
Fix q3 example and stable sort

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1025,7 +1025,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				return Value{}, m.newError(fmt.Errorf("sort expects list"), trace, ins.Line)
 			}
 			pairs := append([]Value(nil), src.List...)
-			sort.Slice(pairs, func(i, j int) bool {
+			sort.SliceStable(pairs, func(i, j int) bool {
 				return valueLess(pairs[i].List[0], pairs[j].List[0])
 			})
 			out := make([]Value, len(pairs))

--- a/tests/dataset/tpc-h/q3.mochi
+++ b/tests/dataset/tpc-h/q3.mochi
@@ -47,13 +47,21 @@ let order_line_join =
     o_orderdate: g.key.o_orderdate,
     o_shippriority: g.key.o_shippriority
   }
-  sort by o_orderdate
-  sort by -revenue
 
-print order_line_join
+let by_date =
+  from x in order_line_join
+  sort by x.o_orderdate
+  select x
+
+let result =
+  from x in by_date
+  sort by -x.revenue
+  select x
+
+print result
 
 test "Q3 returns revenue per order with correct priority" {
-  expect order_line_join == [
+  expect result == [
     {
       l_orderkey: 100,
       revenue: 1000.0 * 0.95 + 500.0,


### PR DESCRIPTION
## Summary
- update tpch q3 example to use nested sorts
- make VM sorting stable so chained sorts work

## Testing
- `go test ./... --vet=off -run TestTPC -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685c249280748320982df502cdf00cc6