### PR TITLE
Add substring builtin and fix TPCH q22

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2489,6 +2489,15 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpStr, A: dst, B: arg})
 			return dst
+		case "substring":
+			s := fc.compileExpr(p.Call.Args[0])
+			start := fc.compileExpr(p.Call.Args[1])
+			length := fc.compileExpr(p.Call.Args[2])
+			end := fc.newReg()
+			fc.emit(p.Pos, Instr{Op: OpAdd, A: end, B: start, C: length})
+			dst := fc.newReg()
+			fc.emit(p.Pos, Instr{Op: OpSlice, A: dst, B: s, C: start, D: end})
+			return dst
 		case "print":
 			if len(p.Call.Args) == 1 {
 				arg := fc.compileExpr(p.Call.Args[0])

--- a/tests/dataset/tpc-h/q22.mochi
+++ b/tests/dataset/tpc-h/q22.mochi
@@ -13,7 +13,7 @@ let valid_codes = ["13", "31", "23", "29", "30", "18", "17"]
 let avg_balance =
   avg(
     from c in customer
-    where c.c_acctbal > 0.0 and substring(c.c_phone, 0, 2) in valid_codes
+    where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
     select c.c_acctbal
   )
 
@@ -21,9 +21,12 @@ let eligible_customers =
   from c in customer
   let cc = substring(c.c_phone, 0, 2)
   where
-    cc in valid_codes and
-    c.c_acctbal > avg_balance and
-    not exists o in orders where o.o_custkey == c.c_custkey
+    cc in valid_codes &&
+    c.c_acctbal > avg_balance &&
+    not exists (
+      o in orders
+      where o.o_custkey == c.c_custkey
+    )
   select { cntrycode: cc, c_acctbal: c.c_acctbal }
 
 let result =

--- a/types/check.go
+++ b/types/check.go
@@ -398,6 +398,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: StringType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("substring", FuncType{
+		Params: []Type{StringType{}, IntType{}, IntType{}},
+		Return: StringType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("input", FuncType{
 		Params: []Type{},
 		Return: StringType{},
@@ -2018,24 +2023,25 @@ func isNumeric(t Type) bool {
 }
 
 var builtinArity = map[string]int{
-	"now":    0,
-	"input":  0,
-	"json":   1,
-	"str":    1,
-	"upper":  1,
-	"lower":  1,
-	"eval":   1,
-	"len":    1,
-	"count":  1,
-	"avg":    1,
-	"sum":    1,
-	"min":    1,
-	"max":    1,
-	"keys":   1,
-	"values": 1,
-	"reduce": 3,
-	"append": 2,
-	"push":   2,
+	"now":       0,
+	"input":     0,
+	"json":      1,
+	"str":       1,
+	"upper":     1,
+	"lower":     1,
+	"eval":      1,
+	"len":       1,
+	"count":     1,
+	"avg":       1,
+	"sum":       1,
+	"min":       1,
+	"max":       1,
+	"keys":      1,
+	"values":    1,
+	"reduce":    3,
+	"append":    2,
+	"push":      2,
+	"substring": 3,
 }
 
 func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
@@ -2052,6 +2058,26 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 		if name == "eval" {
 			if _, ok := args[0].(StringType); !ok {
 				return errArgTypeMismatch(pos, 0, StringType{}, args[0])
+			}
+		}
+		return nil
+	case "substring":
+		if len(args) != 3 {
+			return errArgCount(pos, name, 3, len(args))
+		}
+		if _, ok := args[0].(StringType); !ok {
+			if _, ok := args[0].(AnyType); !ok {
+				return errArgTypeMismatch(pos, 0, StringType{}, args[0])
+			}
+		}
+		if _, ok := args[1].(IntType); !ok {
+			if _, ok := args[1].(AnyType); !ok {
+				return errArgTypeMismatch(pos, 1, IntType{}, args[1])
+			}
+		}
+		if _, ok := args[2].(IntType); !ok {
+			if _, ok := args[2].(AnyType); !ok {
+				return errArgTypeMismatch(pos, 2, IntType{}, args[2])
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary
- add new `substring` builtin for VM & type checker
- implement codegen for substring using slice op
- update q22 query to use `&&` and `exists (...)` syntax

## Testing
- `go test ./tests/vm -run .`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c24d7948c8320884cb59c84cf25c2