### PR TITLE
Fix tpc-h q17 example

### DIFF
--- a/tests/dataset/tpc-h/q17.mochi
+++ b/tests/dataset/tpc-h/q17.mochi
@@ -13,19 +13,26 @@ let lineitem = [
 let brand = "Brand#23"
 let container = "MED BOX"
 
-let result =
-  from l in lineitem
-  join p in part on p.p_partkey == l.l_partkey
-  where
-    p.p_brand == brand &&
-    p.p_container == container &&
-    l.l_quantity < (
-      let avg_qty = avg(x.l_quantity for x in lineitem where x.l_partkey == p.p_partkey)
-      in 0.2 * avg_qty
-    )
-  select sum(l.l_extendedprice) / 7.0
 
-print result
+let result =
+  sum(
+    from l in lineitem
+    join p in part on p.p_partkey == l.l_partkey
+    where (
+      (p.p_brand == brand) &&
+      (p.p_container == container) &&
+      (l.l_quantity < (
+        0.2 * avg(
+          from x in lineitem
+          where x.l_partkey == p.p_partkey
+          select x.l_quantity
+        )
+      ))
+    )
+    select l.l_extendedprice
+  ) / 7.0
+
+print(result)
 
 test "Q17 returns average yearly revenue for small-quantity orders" {
   let expected = 100.0 / 7.0


### PR DESCRIPTION
## Summary
- rewrite q17 to avoid unsupported `let` expressions and ensure correct operator precedence

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/dataset/tpc-h/q17.mochi`

------
https://chatgpt.com/codex/tasks/task_e_685c24cbb0948320a9d37064cbfede12