### PR TITLE
Add exists builtin and fix TPCH query 4

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -147,5 +147,7 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagFloat
 	case OpMin, OpMax:
 		tags[ins.A] = TagUnknown
+	case OpExists:
+		tags[ins.A] = TagBool
 	}
 }

--- a/tests/dataset/tpc-h/q4.mochi
+++ b/tests/dataset/tpc-h/q4.mochi
@@ -22,9 +22,10 @@ let date_filtered_orders =
 
 let late_orders =
   from o in date_filtered_orders
-  where exists (
-    l in lineitem
+  where exists(
+    from l in lineitem
     where l.l_orderkey == o.o_orderkey and l.l_commitdate < l.l_receiptdate
+    select l
   )
   select o
 

--- a/tests/vm/valid/exists_builtin.ir.out
+++ b/tests/vm/valid/exists_builtin.ir.out
@@ -1,0 +1,50 @@
+func main (regs=27)
+  // print(exists(from x in [1,2,3] where x > 2 select x))
+  Const        r0, []
+  Const        r1, [1, 2, 3]
+  IterPrep     r2, r1
+  Len          r3, r2
+  Const        r4, 0
+L2:
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r6, r2, r4
+  Move         r7, r6
+  Const        r8, 2
+  Less         r9, r8, r7
+  JumpIfFalse  r9, L1
+  Append       r10, r0, r7
+  Move         r0, r10
+L1:
+  Const        r11, 1
+  Add          r12, r4, r11
+  Move         r4, r12
+  Jump         L2
+L0:
+  Exists       r13, r0
+  Print        r13
+  // print(exists(from x in [1,2,3] where x > 4 select x))
+  Const        r14, []
+  Const        r15, [1, 2, 3]
+  IterPrep     r16, r15
+  Len          r17, r16
+  Const        r18, 0
+L5:
+  Less         r19, r18, r17
+  JumpIfFalse  r19, L3
+  Index        r20, r16, r18
+  Move         r7, r20
+  Const        r21, 4
+  Less         r22, r21, r7
+  JumpIfFalse  r22, L4
+  Append       r23, r14, r7
+  Move         r14, r23
+L4:
+  Const        r24, 1
+  Add          r25, r18, r24
+  Move         r18, r25
+  Jump         L5
+L3:
+  Exists       r26, r14
+  Print        r26
+  Return       r0

--- a/tests/vm/valid/exists_builtin.mochi
+++ b/tests/vm/valid/exists_builtin.mochi
@@ -1,0 +1,2 @@
+print(exists(from x in [1,2,3] where x > 2 select x))
+print(exists(from x in [1,2,3] where x > 4 select x))

--- a/tests/vm/valid/exists_builtin.out
+++ b/tests/vm/valid/exists_builtin.out
@@ -1,0 +1,2 @@
+true
+false

--- a/types/check.go
+++ b/types/check.go
@@ -437,6 +437,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: AnyType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("exists", FuncType{
+		Params: []Type{AnyType{}},
+		Return: BoolType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("reduce", FuncType{
 		Params: []Type{AnyType{}, AnyType{}, AnyType{}},
 		Return: AnyType{},
@@ -2036,6 +2041,7 @@ var builtinArity = map[string]int{
 	"sum":       1,
 	"min":       1,
 	"max":       1,
+	"exists":    1,
 	"keys":      1,
 	"values":    1,
 	"reduce":    3,
@@ -2140,6 +2146,16 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 			return nil
 		default:
 			return fmt.Errorf("%s() expects list", name)
+		}
+	case "exists":
+		if len(args) != 1 {
+			return errArgCount(pos, name, 1, len(args))
+		}
+		switch args[0].(type) {
+		case ListType, GroupType, AnyType:
+			return nil
+		default:
+			return fmt.Errorf("exists() expects list")
 		}
 	case "keys", "values":
 		if len(args) != 1 {


### PR DESCRIPTION
## Summary
- implement new `exists` builtin in the VM
- extend typechecker for the builtin
- update TPCH Q4 to use `exists` builtin
- add golden tests exercising `exists`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c26c53948832083a692711eb55278