### PR TITLE
Fix tpch q12 parsing and add 'order by' alias

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -417,7 +417,7 @@ type QueryExpr struct {
 	Joins    []*JoinClause  `parser:"{ @@ }"`
 	Where    *Expr          `parser:"[ 'where' @@ ]"`
 	Group    *GroupByClause `parser:"[ @@ ]"`
-	Sort     *Expr          `parser:"[ 'sort' 'by' @@ ]"`
+	Sort     *Expr          `parser:"[ ( 'sort' | 'order' ) 'by' @@ ]"`
 	Skip     *Expr          `parser:"[ 'skip' @@ ]"`
 	Take     *Expr          `parser:"[ 'take' @@ ]"`
 	Distinct bool           `parser:"'select' @'distinct'?"`

--- a/tests/dataset/tpc-h/q12.mochi
+++ b/tests/dataset/tpc-h/q12.mochi
@@ -15,27 +15,27 @@ let lineitem = [
     l_orderkey: 2,
     l_shipmode: "SHIP",
     l_commitdate: "1994-03-01",
-    l_receiptdate: "1994-02-28", // commitdate > receiptdate → excluded
+    l_receiptdate: "1994-02-28",
     l_shipdate: "1994-02-27"
-  }
+  } // commitdate > receiptdate excluded
 ]
 
 let result =
   from l in lineitem
-  where
-    l.l_shipmode in ["MAIL", "SHIP"] and
-    l.l_commitdate < l.l_receiptdate and
-    l.l_shipdate < l.l_commitdate and
-    l.l_receiptdate >= "1994-01-01" and
-    l.l_receiptdate < "1995-01-01"
   join o in orders on o.o_orderkey == l.l_orderkey
-  group by l.l_shipmode
+  where
+    l.l_shipmode in ["MAIL", "SHIP"] &&
+    l.l_commitdate < l.l_receiptdate &&
+    l.l_shipdate < l.l_commitdate &&
+    l.l_receiptdate >= "1994-01-01" &&
+    l.l_receiptdate < "1995-01-01"
+  group by l.l_shipmode into g
+  sort by l_shipmode
   select {
-    l_shipmode: l.l_shipmode,
-    high_line_count: sum(if o.o_orderpriority in ["1-URGENT", "2-HIGH"] then 1 else 0),
-    low_line_count: sum(if o.o_orderpriority not in ["1-URGENT", "2-HIGH"] then 1 else 0)
+    l_shipmode: g.key,
+    high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
+    low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
   }
-  order by l_shipmode
 
 print result
 


### PR DESCRIPTION
## Summary
- allow `order by` to act as an alias for `sort by`
- clean up tpch q12 example so it parses correctly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c24c165108320ae38fa9240dc8cad