### PR TITLE
Add string.contains support to VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2138,6 +2138,17 @@ func (fc *funcCompiler) compilePostfix(p *parser.PostfixExpr) int {
 		}
 	}
 
+	// string.contains(sub)
+	if len(p.Ops) == 1 && p.Ops[0].Call != nil && p.Target.Selector != nil &&
+		len(p.Target.Selector.Tail) > 0 && p.Target.Selector.Tail[len(p.Target.Selector.Tail)-1] == "contains" {
+		recvSel := &parser.Primary{Selector: &parser.SelectorExpr{Root: p.Target.Selector.Root, Tail: p.Target.Selector.Tail[:len(p.Target.Selector.Tail)-1]}}
+		recv := fc.compilePrimary(recvSel)
+		arg := fc.compileExpr(p.Ops[0].Call.Args[0])
+		dst := fc.newReg()
+		fc.emit(p.Ops[0].Call.Pos, Instr{Op: OpIn, A: dst, B: arg, C: recv})
+		return dst
+	}
+
 	r := fc.compilePrimary(p.Target)
 	for _, op := range p.Ops {
 		if op.Index != nil {

--- a/tests/dataset/tpc-h/q16.mochi
+++ b/tests/dataset/tpc-h/q16.mochi
@@ -36,7 +36,7 @@ let result =
   from s in supplier
   where
     s.s_suppkey not in excluded_suppliers &&
-    s.s_comment not has "Customer" && s.s_comment not has "Complaints"
+    !s.s_comment.contains("Customer") && !s.s_comment.contains("Complaints")
   order by s.s_name
   select {
     s_name: s.s_name,

--- a/tests/vm/valid/string_contains.ir.out
+++ b/tests/vm/valid/string_contains.ir.out
@@ -1,0 +1,13 @@
+func main (regs=6)
+  // let s = "catch"
+  Const        r0, "catch"
+  Move         r1, r0
+  // print(s.contains("cat"))
+  Const        r2, "cat"
+  In           r3, r2, r1
+  Print        r3
+  // print(s.contains("dog"))
+  Const        r4, "dog"
+  In           r5, r4, r1
+  Print        r5
+  Return       r0

--- a/tests/vm/valid/string_contains.mochi
+++ b/tests/vm/valid/string_contains.mochi
@@ -1,0 +1,3 @@
+let s = "catch"
+print(s.contains("cat"))
+print(s.contains("dog"))

--- a/tests/vm/valid/string_contains.out
+++ b/tests/vm/valid/string_contains.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- allow string.contains method calls in vm
- test string.contains usage
- fix tpch q16 query to use contains

## Testing
- `go test ./tests/vm -run TestVM_IR/string_contains -update -count=1`
- `go test ./tests/vm -run . -update -count=1`
- `go test ./tests/vm -run TestVM_TPCH -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c24c9d2208320a62f45c81f4f780f