### PR TITLE
Add exists builtin and update q21

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -24,7 +24,7 @@ The VM supports a small but useful subset of Mochi:
 * Function definitions
 * Function calls with any number of arguments
 * Anonymous function expressions
-* Built‑ins `len`, `print` (up to two arguments), `append`, `str`, `json`, `now`, `input`, `count`, `avg`, `min` and `max`
+* Built‑ins `len`, `print` (up to two arguments), `append`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min` and `max`
 * Dataset loading with `load` (optionally casting rows to a type) and saving with `save`
 * HTTP requests using the `fetch` expression
 * List, map and struct construction
@@ -118,6 +118,7 @@ from the disassembler:
 | `Str` | Convert value B to string | `Str r0, r1` |
 | `Input` | Read line from input | `Input r0` |
 | `Count` | Count elements in list/map B | `Count r0, r1` |
+| `Exists` | True if list/map/string B is non-empty | `Exists r0, r1` |
 | `Avg` | Average of numeric list B | `Avg r0, r1` |
 | `Min` | Minimum value of numeric list B | `Min r0, r1` |
 | `Max` | Maximum value of numeric list B | `Max r0, r1` |

--- a/tests/dataset/tpc-h/q21.mochi
+++ b/tests/dataset/tpc-h/q21.mochi
@@ -40,20 +40,19 @@ let result =
   join o in orders on o.o_orderkey == l1.l_orderkey
   join n in nation on n.n_nationkey == s.s_nationkey
   where
-    o.o_orderstatus == "F" and
-    l1.l_receiptdate > l1.l_commitdate and
-    n.n_name == "SAUDI ARABIA" and
-    not exists x in lineitem
-      where
-        x.l_orderkey == l1.l_orderkey and
-        x.l_suppkey != l1.l_suppkey and
-        x.l_receiptdate > x.l_commitdate
-  group by s.s_name
+    o.o_orderstatus == "F" &&
+    l1.l_receiptdate > l1.l_commitdate &&
+    n.n_name == "SAUDI ARABIA" && (!exists(
+      from x in lineitem
+      where x.l_orderkey == l1.l_orderkey && x.l_suppkey != l1.l_suppkey && x.l_receiptdate > x.l_commitdate
+      select x
+    ))
+  group by s.s_name into g
+  sort by [ -count(g), s.s_name ]
   select {
     s_name: s.s_name,
-    numwait: count()
+    numwait: count(g)
   }
-  order by { numwait desc, s.s_name }
 
 print result
 

--- a/types/check.go
+++ b/types/check.go
@@ -412,6 +412,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: IntType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("exists", FuncType{
+		Params: []Type{AnyType{}},
+		Return: BoolType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("avg", FuncType{
 		Params: []Type{AnyType{}},
 		Return: FloatType{},
@@ -2032,6 +2037,7 @@ var builtinArity = map[string]int{
 	"eval":      1,
 	"len":       1,
 	"count":     1,
+	"exists":    1,
 	"avg":       1,
 	"sum":       1,
 	"min":       1,
@@ -2080,6 +2086,16 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 			return nil
 		default:
 			return errCountOperand(pos, args[0])
+		}
+	case "exists":
+		if len(args) != 1 {
+			return errArgCount(pos, name, 1, len(args))
+		}
+		switch args[0].(type) {
+		case ListType, MapType, StringType, AnyType, GroupType:
+			return nil
+		default:
+			return fmt.Errorf("exists expects list, map or string")
 		}
 	case "avg":
 		if len(args) != 1 {


### PR DESCRIPTION
## Summary
- implement `OpExists` instruction in VM
- expose `exists()` builtin in the type checker
- document the new builtin
- rewrite TPC-H q21 query using supported syntax

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c24d58f70832082c2e102fdc04608