### PR TITLE
Add exists builtin to VM

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -141,6 +141,8 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagUnknown
 	case OpCount:
 		tags[ins.A] = TagInt
+	case OpExists:
+		tags[ins.A] = TagBool
 	case OpAvg:
 		tags[ins.A] = TagFloat
 	case OpSum:

--- a/tests/dataset/tpc-h/q4.mochi
+++ b/tests/dataset/tpc-h/q4.mochi
@@ -22,9 +22,10 @@ let date_filtered_orders =
 
 let late_orders =
   from o in date_filtered_orders
-  where exists (
-    l in lineitem
-    where l.l_orderkey == o.o_orderkey and l.l_commitdate < l.l_receiptdate
+  where exists(
+    from l in lineitem
+    where l.l_orderkey == o.o_orderkey && l.l_commitdate < l.l_receiptdate
+    select l
   )
   select o
 

--- a/tests/vm/valid/exists_builtin.ir.out
+++ b/tests/vm/valid/exists_builtin.ir.out
@@ -1,0 +1,55 @@
+func main (regs=29)
+  // let xs = [1, 2, 3]
+  Const        r0, [1, 2, 3]
+  Move         r1, r0
+  // let res1 = exists(from x in xs where x > 2 select x)
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
+L2:
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r7, r3, r5
+  Move         r8, r7
+  Const        r9, 2
+  Less         r10, r9, r8
+  JumpIfFalse  r10, L1
+  Append       r11, r2, r8
+  Move         r2, r11
+L1:
+  Const        r12, 1
+  Add          r13, r5, r12
+  Move         r5, r13
+  Jump         L2
+L0:
+  Exists       r14, r2
+  Move         r15, r14
+  // let res2 = exists(from x in xs where x > 3 select x)
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, 0
+L5:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L3
+  Index        r21, r17, r19
+  Move         r8, r21
+  Const        r22, 3
+  Less         r23, r22, r8
+  JumpIfFalse  r23, L4
+  Append       r24, r16, r8
+  Move         r16, r24
+L4:
+  Const        r25, 1
+  Add          r26, r19, r25
+  Move         r19, r26
+  Jump         L5
+L3:
+  Exists       r27, r16
+  Move         r28, r27
+  // print(res1)
+  Print        r15
+  // print(res2)
+  Print        r28
+  Return       r0

--- a/tests/vm/valid/exists_builtin.mochi
+++ b/tests/vm/valid/exists_builtin.mochi
@@ -1,0 +1,5 @@
+let xs = [1, 2, 3]
+let res1 = exists(from x in xs where x > 2 select x)
+let res2 = exists(from x in xs where x > 3 select x)
+print(res1)
+print(res2)

--- a/tests/vm/valid/exists_builtin.out
+++ b/tests/vm/valid/exists_builtin.out
@@ -1,0 +1,2 @@
+true
+false

--- a/types/check.go
+++ b/types/check.go
@@ -412,6 +412,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: IntType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("exists", FuncType{
+		Params: []Type{AnyType{}},
+		Return: BoolType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("avg", FuncType{
 		Params: []Type{AnyType{}},
 		Return: FloatType{},
@@ -2032,6 +2037,7 @@ var builtinArity = map[string]int{
 	"eval":      1,
 	"len":       1,
 	"count":     1,
+	"exists":    1,
 	"avg":       1,
 	"sum":       1,
 	"min":       1,
@@ -2072,6 +2078,16 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 			return errLenOperand(pos, args[0])
 		}
 	case "count":
+		if len(args) != 1 {
+			return errArgCount(pos, name, 1, len(args))
+		}
+		switch args[0].(type) {
+		case ListType, GroupType, AnyType:
+			return nil
+		default:
+			return errCountOperand(pos, args[0])
+		}
+	case "exists":
 		if len(args) != 1 {
 			return errArgCount(pos, name, 1, len(args))
 		}


### PR DESCRIPTION
## Summary
- implement `exists` builtin in runtime/vm
- support new opcode for compile, run, disassemble and inference
- teach type checker about `exists`
- fix TPCH q4 query syntax
- add golden tests for `exists` builtin

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c32388f3c8320a391e967583eee9a