### PR TITLE
Fix tpch q5 and add group-by sort test

### DIFF
--- a/tests/dataset/tpc-h/out/q5.ir.out
+++ b/tests/dataset/tpc-h/out/q5.ir.out
@@ -1,0 +1,349 @@
+func main (regs=210)
+  // let region = [
+  Const        r0, [{"r_name": "ASIA", "r_regionkey": 0}, {"r_name": "EUROPE", "r_regionkey": 1}]
+  Move         r1, r0
+  // let nation = [
+  Const        r2, [{"n_name": "JAPAN", "n_nationkey": 10, "n_regionkey": 0}, {"n_name": "INDIA", "n_nationkey": 20, "n_regionkey": 0}, {"n_name": "FRANCE", "n_nationkey": 30, "n_regionkey": 1}]
+  Move         r3, r2
+  // let customer = [
+  Const        r4, [{"c_custkey": 1, "c_nationkey": 10}, {"c_custkey": 2, "c_nationkey": 20}]
+  Move         r5, r4
+  // let supplier = [
+  Const        r6, [{"s_nationkey": 10, "s_suppkey": 100}, {"s_nationkey": 20, "s_suppkey": 200}]
+  Move         r7, r6
+  // let orders = [
+  Const        r8, [{"o_custkey": 1, "o_orderdate": "1994-03-15", "o_orderkey": 1000}, {"o_custkey": 2, "o_orderdate": "1994-06-10", "o_orderkey": 2000}, {"o_custkey": 2, "o_orderdate": "1995-01-01", "o_orderkey": 3000}]
+  Move         r9, r8
+  // let lineitem = [
+  Const        r10, [{"l_discount": 0.05, "l_extendedprice": 1000, "l_orderkey": 1000, "l_suppkey": 100}, {"l_discount": 0.1, "l_extendedprice": 800, "l_orderkey": 2000, "l_suppkey": 200}, {"l_discount": 0.05, "l_extendedprice": 900, "l_orderkey": 3000, "l_suppkey": 200}]
+  Move         r11, r10
+  // from r in region
+  Const        r12, []
+  IterPrep     r13, r1
+  Len          r14, r13
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  IterPrep     r15, r3
+  Len          r16, r15
+  // from r in region
+  Const        r17, 0
+L4:
+  Less         r18, r17, r14
+  JumpIfFalse  r18, L0
+  Index        r19, r13, r17
+  Move         r20, r19
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  Const        r21, 0
+L3:
+  Less         r22, r21, r16
+  JumpIfFalse  r22, L1
+  Index        r23, r15, r21
+  Move         r24, r23
+  Const        r25, "n_regionkey"
+  Index        r26, r24, r25
+  Const        r27, "r_regionkey"
+  Index        r28, r20, r27
+  Equal        r29, r26, r28
+  JumpIfFalse  r29, L2
+  // where r.r_name == "ASIA"
+  Const        r30, "r_name"
+  Index        r31, r20, r30
+  Const        r32, "ASIA"
+  Equal        r33, r31, r32
+  JumpIfFalse  r33, L2
+  // from r in region
+  Append       r34, r12, r24
+  Move         r12, r34
+L2:
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  Const        r35, 1
+  Add          r36, r21, r35
+  Move         r21, r36
+  Jump         L3
+L1:
+  // from r in region
+  Const        r37, 1
+  Add          r38, r17, r37
+  Move         r17, r38
+  Jump         L4
+L0:
+  // let asia_nations =
+  Move         r39, r12
+  // from c in customer
+  Const        r40, []
+  IterPrep     r41, r5
+  Len          r42, r41
+  Const        r43, 0
+L17:
+  Less         r44, r43, r42
+  JumpIfFalse  r44, L5
+  Index        r45, r41, r43
+  Move         r46, r45
+  // join n in asia_nations on c.c_nationkey == n.n_nationkey
+  IterPrep     r47, r39
+  Len          r48, r47
+  Const        r49, 0
+L16:
+  Less         r50, r49, r48
+  JumpIfFalse  r50, L6
+  Index        r51, r47, r49
+  Move         r24, r51
+  Const        r52, "c_nationkey"
+  Index        r53, r46, r52
+  Const        r54, "n_nationkey"
+  Index        r55, r24, r54
+  Equal        r56, r53, r55
+  JumpIfFalse  r56, L7
+  // join o in orders on o.o_custkey == c.c_custkey
+  IterPrep     r57, r9
+  Len          r58, r57
+  Const        r59, 0
+L15:
+  Less         r60, r59, r58
+  JumpIfFalse  r60, L7
+  Index        r61, r57, r59
+  Move         r62, r61
+  Const        r63, "o_custkey"
+  Index        r64, r62, r63
+  Const        r65, "c_custkey"
+  Index        r66, r46, r65
+  Equal        r67, r64, r66
+  JumpIfFalse  r67, L8
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  IterPrep     r68, r11
+  Len          r69, r68
+  Const        r70, 0
+L14:
+  Less         r71, r70, r69
+  JumpIfFalse  r71, L8
+  Index        r72, r68, r70
+  Move         r73, r72
+  Const        r74, "l_orderkey"
+  Index        r75, r73, r74
+  Const        r76, "o_orderkey"
+  Index        r77, r62, r76
+  Equal        r78, r75, r77
+  JumpIfFalse  r78, L9
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  IterPrep     r79, r7
+  Len          r80, r79
+  Const        r81, 0
+L13:
+  Less         r82, r81, r80
+  JumpIfFalse  r82, L9
+  Index        r83, r79, r81
+  Move         r84, r83
+  Const        r85, "s_suppkey"
+  Index        r86, r84, r85
+  Const        r87, "l_suppkey"
+  Index        r88, r73, r87
+  Equal        r89, r86, r88
+  JumpIfFalse  r89, L10
+  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
+  Const        r90, "o_orderdate"
+  Index        r91, r62, r90
+  Const        r92, "1994-01-01"
+  LessEq       r93, r92, r91
+  Move         r94, r93
+  JumpIfFalse  r94, L11
+  Const        r95, "o_orderdate"
+  Index        r96, r62, r95
+  Move         r94, r96
+L11:
+  Const        r97, "1995-01-01"
+  Less         r98, r94, r97
+  Move         r99, r98
+  JumpIfFalse  r99, L12
+  Const        r100, "s_nationkey"
+  Index        r101, r84, r100
+  Move         r99, r101
+L12:
+  Const        r102, "c_nationkey"
+  Index        r103, r46, r102
+  Equal        r104, r99, r103
+  JumpIfFalse  r104, L10
+  // nation: n.n_name,
+  Const        r105, "nation"
+  Const        r106, "n_name"
+  Index        r107, r24, r106
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r108, "revenue"
+  Const        r109, "l_extendedprice"
+  Index        r110, r73, r109
+  Const        r111, 1
+  Const        r112, "l_discount"
+  Index        r113, r73, r112
+  Sub          r114, r111, r113
+  Mul          r115, r110, r114
+  // nation: n.n_name,
+  Move         r116, r105
+  Move         r117, r107
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Move         r118, r108
+  Move         r119, r115
+  // select {
+  MakeMap      r120, 2, r116
+  // from c in customer
+  Append       r121, r40, r120
+  Move         r40, r121
+L10:
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  Const        r122, 1
+  Add          r123, r81, r122
+  Move         r81, r123
+  Jump         L13
+L9:
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  Const        r124, 1
+  Add          r125, r70, r124
+  Move         r70, r125
+  Jump         L14
+L8:
+  // join o in orders on o.o_custkey == c.c_custkey
+  Const        r126, 1
+  Add          r127, r59, r126
+  Move         r59, r127
+  Jump         L15
+L7:
+  // join n in asia_nations on c.c_nationkey == n.n_nationkey
+  Const        r128, 1
+  Add          r129, r49, r128
+  Move         r49, r129
+  Jump         L16
+L6:
+  // from c in customer
+  Const        r130, 1
+  Add          r131, r43, r130
+  Move         r43, r131
+  Jump         L17
+L5:
+  // let local_customer_supplier_orders =
+  Move         r132, r40
+  // from r in local_customer_supplier_orders
+  Const        r133, []
+  IterPrep     r134, r132
+  Len          r135, r134
+  Const        r136, 0
+  MakeMap      r137, 0, r0
+  Const        r138, []
+L20:
+  Less         r139, r136, r135
+  JumpIfFalse  r139, L18
+  Index        r140, r134, r136
+  Move         r20, r140
+  // group by r.nation into g
+  Const        r141, "nation"
+  Index        r142, r20, r141
+  Str          r143, r142
+  In           r144, r143, r137
+  JumpIfTrue   r144, L19
+  // from r in local_customer_supplier_orders
+  Const        r145, []
+  Const        r146, "__group__"
+  Const        r147, true
+  Const        r148, "key"
+  // group by r.nation into g
+  Move         r149, r142
+  // from r in local_customer_supplier_orders
+  Const        r150, "items"
+  Move         r151, r145
+  MakeMap      r152, 3, r146
+  SetIndex     r137, r143, r152
+  Append       r153, r138, r152
+  Move         r138, r153
+L19:
+  Const        r154, "items"
+  Index        r155, r137, r143
+  Index        r156, r155, r154
+  Append       r157, r156, r140
+  SetIndex     r155, r154, r157
+  Const        r158, 1
+  Add          r159, r136, r158
+  Move         r136, r159
+  Jump         L20
+L18:
+  Const        r160, 0
+  Len          r161, r138
+L26:
+  Less         r162, r160, r161
+  JumpIfFalse  r162, L21
+  Index        r163, r138, r160
+  Move         r164, r163
+  // n_name: g.key,
+  Const        r165, "n_name"
+  Const        r166, "key"
+  Index        r167, r164, r166
+  // revenue: sum(from x in g select x.revenue)
+  Const        r168, "revenue"
+  Const        r169, []
+  IterPrep     r170, r164
+  Len          r171, r170
+  Const        r172, 0
+L23:
+  Less         r173, r172, r171
+  JumpIfFalse  r173, L22
+  Index        r174, r170, r172
+  Move         r175, r174
+  Const        r176, "revenue"
+  Index        r177, r175, r176
+  Append       r178, r169, r177
+  Move         r169, r178
+  Const        r179, 1
+  Add          r180, r172, r179
+  Move         r172, r180
+  Jump         L23
+L22:
+  Sum          181,169,0,0
+  // n_name: g.key,
+  Move         r182, r165
+  Move         r183, r167
+  // revenue: sum(from x in g select x.revenue)
+  Move         r184, r168
+  Move         r185, r181
+  // select {
+  MakeMap      r186, 2, r182
+  // sort by -sum(from x in g select x.revenue)
+  Const        r187, []
+  IterPrep     r188, r164
+  Len          r189, r188
+  Const        r190, 0
+L25:
+  Less         r191, r190, r189
+  JumpIfFalse  r191, L24
+  Index        r192, r188, r190
+  Move         r175, r192
+  Const        r193, "revenue"
+  Index        r194, r175, r193
+  Append       r195, r187, r194
+  Move         r187, r195
+  Const        r196, 1
+  Add          r197, r190, r196
+  Move         r190, r197
+  Jump         L25
+L24:
+  Sum          198,187,0,0
+  Neg          r199, r198
+  Move         r200, r199
+  // from r in local_customer_supplier_orders
+  Move         r201, r186
+  MakeList     r202, 2, r200
+  Append       r203, r133, r202
+  Move         r133, r203
+  Const        r204, 1
+  Add          r205, r160, r204
+  Move         r160, r205
+  Jump         L26
+L21:
+  // sort by -sum(from x in g select x.revenue)
+  Sort         206,133,0,0
+  // from r in local_customer_supplier_orders
+  Move         r133, r206
+  // let result =
+  Move         r207, r133
+  // json(result)
+  JSON         r207
+  // expect result == [
+  Const        r208, [{"n_name": "JAPAN", "revenue": 950}, {"n_name": "INDIA", "revenue": 720}]
+  Equal        r209, r207, r208
+  Expect       r209
+  Return       r0
+

--- a/tests/dataset/tpc-h/out/q5.out
+++ b/tests/dataset/tpc-h/out/q5.out
@@ -1,0 +1,1 @@
+[{"n_name":"JAPAN","revenue":950},{"n_name":"INDIA","revenue":720}]

--- a/tests/dataset/tpc-h/q5.mochi
+++ b/tests/dataset/tpc-h/q5.mochi
@@ -52,13 +52,13 @@ let local_customer_supplier_orders =
 let result =
   from r in local_customer_supplier_orders
   group by r.nation into g
+  sort by -sum(from x in g select x.revenue)
   select {
     n_name: g.key,
     revenue: sum(from x in g select x.revenue)
   }
-  sort by -revenue
 
-print result
+json(result)
 
 test "Q5 returns revenue per nation in ASIA with local suppliers" {
   expect result == [

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,0 +1,129 @@
+func main (regs=78)
+  // let items = [
+  Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
+  Move         r1, r0
+  // from i in items
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
+  MakeMap      r6, 0, r0
+  Const        r7, []
+L2:
+  Less         r8, r5, r4
+  JumpIfFalse  r8, L0
+  Index        r9, r3, r5
+  Move         r10, r9
+  // group by i.cat into g
+  Const        r11, "cat"
+  Index        r12, r10, r11
+  Str          r13, r12
+  In           r14, r13, r6
+  JumpIfTrue   r14, L1
+  // from i in items
+  Const        r15, []
+  Const        r16, "__group__"
+  Const        r17, true
+  Const        r18, "key"
+  // group by i.cat into g
+  Move         r19, r12
+  // from i in items
+  Const        r20, "items"
+  Move         r21, r15
+  MakeMap      r22, 3, r16
+  SetIndex     r6, r13, r22
+  Append       r23, r7, r22
+  Move         r7, r23
+L1:
+  Const        r24, "items"
+  Index        r25, r6, r13
+  Index        r26, r25, r24
+  Append       r27, r26, r9
+  SetIndex     r25, r24, r27
+  Const        r28, 1
+  Add          r29, r5, r28
+  Move         r5, r29
+  Jump         L2
+L0:
+  Const        r30, 0
+  Len          r31, r7
+L8:
+  Less         r32, r30, r31
+  JumpIfFalse  r32, L3
+  Index        r33, r7, r30
+  Move         r34, r33
+  // cat: g.key,
+  Const        r35, "cat"
+  Const        r36, "key"
+  Index        r37, r34, r36
+  // total: sum(from x in g select x.val)
+  Const        r38, "total"
+  Const        r39, []
+  IterPrep     r40, r34
+  Len          r41, r40
+  Const        r42, 0
+L5:
+  Less         r43, r42, r41
+  JumpIfFalse  r43, L4
+  Index        r44, r40, r42
+  Move         r45, r44
+  Const        r46, "val"
+  Index        r47, r45, r46
+  Append       r48, r39, r47
+  Move         r39, r48
+  Const        r49, 1
+  Add          r50, r42, r49
+  Move         r42, r50
+  Jump         L5
+L4:
+  Sum          51,39,0,0
+  // cat: g.key,
+  Move         r52, r35
+  Move         r53, r37
+  // total: sum(from x in g select x.val)
+  Move         r54, r38
+  Move         r55, r51
+  // select {
+  MakeMap      r56, 2, r52
+  // sort by -sum(from x in g select x.val)
+  Const        r57, []
+  IterPrep     r58, r34
+  Len          r59, r58
+  Const        r60, 0
+L7:
+  Less         r61, r60, r59
+  JumpIfFalse  r61, L6
+  Index        r62, r58, r60
+  Move         r45, r62
+  Const        r63, "val"
+  Index        r64, r45, r63
+  Append       r65, r57, r64
+  Move         r57, r65
+  Const        r66, 1
+  Add          r67, r60, r66
+  Move         r60, r67
+  Jump         L7
+L6:
+  Sum          68,57,0,0
+  Neg          r69, r68
+  Move         r70, r69
+  // from i in items
+  Move         r71, r56
+  MakeList     r72, 2, r70
+  Append       r73, r2, r72
+  Move         r2, r73
+  Const        r74, 1
+  Add          r75, r30, r74
+  Move         r30, r75
+  Jump         L8
+L3:
+  // sort by -sum(from x in g select x.val)
+  Sort         76,2,0,0
+  // from i in items
+  Move         r2, r76
+  // let grouped =
+  Move         r77, r2
+  // print(grouped)
+  Print        r77
+  Return       r0
+

--- a/tests/vm/valid/group_by_sort.mochi
+++ b/tests/vm/valid/group_by_sort.mochi
@@ -1,0 +1,15 @@
+let items = [
+  { cat: "a", val: 3 },
+  { cat: "a", val: 1 },
+  { cat: "b", val: 5 },
+  { cat: "b", val: 2 }
+]
+let grouped =
+  from i in items
+  group by i.cat into g
+  sort by -sum(from x in g select x.val)
+  select {
+    cat: g.key,
+    total: sum(from x in g select x.val)
+  }
+print(grouped)

--- a/tests/vm/valid/group_by_sort.out
+++ b/tests/vm/valid/group_by_sort.out
@@ -1,0 +1,1 @@
+[map[cat:b total:7] map[cat:a total:4]]


### PR DESCRIPTION
## Summary
- update tpch q5 query so it parses correctly
- add expected q5 output and IR listing
- add runtime/vm test for group-by with sort clause

## Testing
- `go test ./tests/vm -run .`
- `go test ./tests/vm -run TestVM_TPCH`


------
https://chatgpt.com/codex/tasks/task_e_685c3243445c8320a462b2b0f1972547