### PR TITLE
Add order by support to vm and tests

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -417,6 +417,7 @@ type QueryExpr struct {
 	Joins    []*JoinClause  `parser:"{ @@ }"`
 	Where    *Expr          `parser:"[ 'where' @@ ]"`
 	Group    *GroupByClause `parser:"[ @@ ]"`
+	Order    *OrderClause   `parser:"[ @@ ]"`
 	Sort     *Expr          `parser:"[ 'sort' 'by' @@ ]"`
 	Skip     *Expr          `parser:"[ 'skip' @@ ]"`
 	Take     *Expr          `parser:"[ 'take' @@ ]"`
@@ -447,6 +448,12 @@ type GroupByClause struct {
 	Pos   lexer.Position
 	Exprs []*Expr `parser:"'group' 'by' @@ { ',' @@ } 'into'"`
 	Name  string  `parser:"@Ident"`
+}
+
+type OrderClause struct {
+	Pos  lexer.Position
+	Expr *Expr   `parser:"'order' 'by' @@"`
+	Dir  *string `parser:"[ @('asc' | 'desc') ]"`
 }
 
 type MatchExpr struct {

--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -133,7 +133,7 @@ func applyTags(tags []RegTag, ins Instr) {
 	case OpJSON, OpPrint, OpPrint2, OpPrintN:
 		// no result
 	case OpInput, OpMakeList, OpIndex, OpSlice, OpSetIndex, OpCall, OpCall2, OpCallV,
-		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpSort, OpMakeClosure, OpExpect:
+		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpSort, OpSortDesc, OpMakeClosure, OpExpect:
 		tags[ins.A] = TagUnknown
 	case OpIterPrep:
 		tags[ins.A] = TagUnknown

--- a/runtime/vm/queryutil.go
+++ b/runtime/vm/queryutil.go
@@ -137,3 +137,14 @@ func whereEvalLevel(q *parser.QueryExpr) int {
 	}
 	return level
 }
+
+func sortExpr(q *parser.QueryExpr) *parser.Expr {
+	if q.Order != nil {
+		return q.Order.Expr
+	}
+	return q.Sort
+}
+
+func sortDesc(q *parser.QueryExpr) bool {
+	return q.Order != nil && q.Order.Dir != nil && *q.Order.Dir == "desc"
+}

--- a/tests/dataset/tpc-h/q10.mochi
+++ b/tests/dataset/tpc-h/q10.mochi
@@ -44,7 +44,6 @@ let result =
   join l in lineitem on l.l_orderkey == o.o_orderkey
   where l.l_returnflag == "R"
   join n in nation on n.n_nationkey == c.c_nationkey
-  let revenue = l.l_extendedprice * (1 - l.l_discount)
   group by {
     c_custkey: c.c_custkey,
     c_name: c.c_name,
@@ -53,16 +52,16 @@ let result =
     c_phone: c.c_phone,
     c_comment: c.c_comment,
     n_name: n.n_name
-  }
+  } into g
   select {
-    c_custkey,
-    c_name,
-    revenue: sum(revenue),
-    c_acctbal,
-    n_name,
-    c_address,
-    c_phone,
-    c_comment
+    c_custkey: g.key.c_custkey,
+    c_name: g.key.c_name,
+    revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+    c_acctbal: g.key.c_acctbal,
+    n_name: g.key.n_name,
+    c_address: g.key.c_address,
+    c_phone: g.key.c_phone,
+    c_comment: g.key.c_comment
   }
   order by revenue desc
 

--- a/tests/vm/valid/order_by_desc.ir.out
+++ b/tests/vm/valid/order_by_desc.ir.out
@@ -1,0 +1,58 @@
+func main (regs=32)
+  // let products = [
+  Const        r0, [{"name": "Laptop", "price": 1500}, {"name": "Smartphone", "price": 900}, {"name": "Tablet", "price": 600}, {"name": "Monitor", "price": 300}]
+  Move         r1, r0
+  // let sorted = from p in products
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
+L1:
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r7, r3, r5
+  Move         r8, r7
+  // order by p.price desc
+  Const        r9, "price"
+  Index        r10, r8, r9
+  Move         r11, r10
+  // let sorted = from p in products
+  Move         r12, r8
+  MakeList     r13, 2, r11
+  Append       r14, r2, r13
+  Move         r2, r14
+  Const        r15, 1
+  Add          r16, r5, r15
+  Move         r5, r16
+  Jump         L1
+L0:
+  // order by p.price desc
+  SortDesc     17,2,0,0
+  // let sorted = from p in products
+  Move         r2, r17
+  Move         r18, r2
+  // print("--- Products by price descending ---")
+  Const        r19, "--- Products by price descending ---"
+  Print        r19
+  // for item in sorted {
+  IterPrep     r20, r18
+  Len          r21, r20
+  Const        r22, 0
+L3:
+  Less         r23, r22, r21
+  JumpIfFalse  r23, L2
+  Index        r24, r20, r22
+  Move         r25, r24
+  // print(item.name, item.price)
+  Const        r26, "name"
+  Index        r27, r25, r26
+  Const        r28, "price"
+  Index        r29, r25, r28
+  Print2       r27, r29
+  // for item in sorted {
+  Const        r30, 1
+  Add          r31, r22, r30
+  Move         r22, r31
+  Jump         L3
+L2:
+  Return       r0

--- a/tests/vm/valid/order_by_desc.mochi
+++ b/tests/vm/valid/order_by_desc.mochi
@@ -1,0 +1,14 @@
+// order_by_desc.mochi
+let products = [
+  { name: "Laptop", price: 1500 },
+  { name: "Smartphone", price: 900 },
+  { name: "Tablet", price: 600 },
+  { name: "Monitor", price: 300 }
+]
+let sorted = from p in products
+             order by p.price desc
+             select p
+print("--- Products by price descending ---")
+for item in sorted {
+  print(item.name, item.price)
+}

--- a/tests/vm/valid/order_by_desc.out
+++ b/tests/vm/valid/order_by_desc.out
@@ -1,0 +1,5 @@
+--- Products by price descending ---
+Laptop 1500
+Smartphone 900
+Tablet 600
+Monitor 300


### PR DESCRIPTION
## Summary
- support `order by` clause by extending parser and VM
- implement `OpSortDesc` instruction for descending order
- fix TPCH Q10 example to use group/aggregate style
- add order by descending golden test for VM

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c28ae0e108320b03cf843594d9f32