### PR TITLE
Fix TPCH Q7, extend substring semantics

### DIFF
--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -235,7 +235,7 @@ func toInt(v any) (int, bool) {
 
 func builtinSubstring(i *Interpreter, c *parser.CallExpr) (any, error) {
 	if len(c.Args) != 3 {
-		return nil, fmt.Errorf("substring(s, start, end) takes exactly three arguments")
+		return nil, fmt.Errorf("substring(s, start, length) takes exactly three arguments")
 	}
 	val, err := i.evalExpr(c.Args[0])
 	if err != nil {
@@ -249,7 +249,7 @@ func builtinSubstring(i *Interpreter, c *parser.CallExpr) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	endAny, err := i.evalExpr(c.Args[2])
+	lenAny, err := i.evalExpr(c.Args[2])
 	if err != nil {
 		return nil, err
 	}
@@ -257,18 +257,19 @@ func builtinSubstring(i *Interpreter, c *parser.CallExpr) (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("substring() expects int, got %T", startAny)
 	}
-	end, ok := toInt(endAny)
+	length, ok := toInt(lenAny)
 	if !ok {
-		return nil, fmt.Errorf("substring() expects int, got %T", endAny)
+		return nil, fmt.Errorf("substring() expects int, got %T", lenAny)
 	}
 	runes := []rune(str)
 	if start < 0 {
 		start += len(runes)
 	}
-	if end < 0 {
-		end += len(runes)
+	end := start + length
+	if end > len(runes) {
+		end = len(runes)
 	}
-	if start < 0 || end > len(runes) || start > end {
+	if start < 0 || start > end {
 		return nil, fmt.Errorf("invalid substring range")
 	}
 	return string(runes[start:end]), nil

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2513,7 +2513,9 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 		case "substring":
 			str := fc.compileExpr(p.Call.Args[0])
 			start := fc.compileExpr(p.Call.Args[1])
-			end := fc.compileExpr(p.Call.Args[2])
+			length := fc.compileExpr(p.Call.Args[2])
+			end := fc.newReg()
+			fc.emit(p.Pos, Instr{Op: OpAddInt, A: end, B: start, C: length})
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpSlice, A: dst, B: str, C: start, D: end})
 			return dst

--- a/tests/dataset/tpc-h/out/q7.ir.out
+++ b/tests/dataset/tpc-h/out/q7.ir.out
@@ -1,4 +1,4 @@
-func main (regs=222)
+func main (regs=243)
   // let nation = [
   Const        r0, [{"n_name": "FRANCE", "n_nationkey": 1}, {"n_name": "GERMANY", "n_nationkey": 2}]
   Move         r1, r0
@@ -186,162 +186,187 @@ L8:
   Index        r126, r26, r125
   Const        r127, 0
   Const        r128, 4
-  Slice        r129, r126, r127, r128
+  AddInt       r129, r127, r128
+  Slice        r130, r126, r127, r129
   // supp_nation: n1.n_name,
-  Move         r130, r118
-  Move         r131, r120
+  Move         r131, r118
+  Move         r132, r120
   // cust_nation: n2.n_name,
-  Move         r132, r121
-  Move         r133, r123
+  Move         r133, r121
+  Move         r134, r123
   // l_year: substring(l.l_shipdate, 0, 4)
-  Move         r134, r124
-  Move         r135, r129
+  Move         r135, r124
+  Move         r136, r130
   // group by {
-  MakeMap      r136, 3, r130
-  Str          r137, r136
-  In           r138, r137, r19
-  JumpIfTrue   r138, L12
+  MakeMap      r137, 3, r131
+  Str          r138, r137
+  In           r139, r138, r19
+  JumpIfTrue   r139, L12
   // from l in lineitem
-  Const        r139, []
-  Const        r140, "__group__"
-  Const        r141, true
-  Const        r142, "key"
+  Const        r140, []
+  Const        r141, "__group__"
+  Const        r142, true
+  Const        r143, "key"
   // group by {
-  Move         r143, r136
+  Move         r144, r137
   // from l in lineitem
-  Const        r144, "items"
-  Move         r145, r139
-  MakeMap      r146, 3, r140
-  SetIndex     r19, r137, r146
-  Append       r147, r20, r146
-  Move         r20, r147
+  Const        r145, "items"
+  Move         r146, r140
+  MakeMap      r147, 3, r141
+  SetIndex     r19, r138, r147
+  Append       r148, r20, r147
+  Move         r20, r148
 L12:
-  Const        r148, "items"
-  Index        r149, r19, r137
-  Index        r150, r149, r148
-  Append       r151, r150, r117
-  SetIndex     r149, r148, r151
+  Const        r149, "items"
+  Index        r150, r19, r138
+  Index        r151, r150, r149
+  Append       r152, r151, r117
+  SetIndex     r150, r149, r152
 L6:
   // join from n2 in nation on n2.n_nationkey == c.c_nationkey
-  Const        r152, 1
-  Add          r153, r73, r152
-  Move         r73, r153
+  Const        r153, 1
+  Add          r154, r73, r153
+  Move         r73, r154
   Jump         L13
 L5:
   // join from n1 in nation on n1.n_nationkey == s.s_nationkey
-  Const        r154, 1
-  Add          r155, r62, r154
-  Move         r62, r155
+  Const        r155, 1
+  Add          r156, r62, r155
+  Move         r62, r156
   Jump         L14
 L4:
   // join from s in supplier on s.s_suppkey == l.l_suppkey
-  Const        r156, 1
-  Add          r157, r51, r156
-  Move         r51, r157
+  Const        r157, 1
+  Add          r158, r51, r157
+  Move         r51, r158
   Jump         L15
 L3:
   // join from c in customer on c.c_custkey == o.o_custkey
-  Const        r158, 1
-  Add          r159, r40, r158
-  Move         r40, r159
+  Const        r159, 1
+  Add          r160, r40, r159
+  Move         r40, r160
   Jump         L16
 L2:
   // join from o in orders on o.o_orderkey == l.l_orderkey
-  Const        r160, 1
-  Add          r161, r29, r160
-  Move         r29, r161
+  Const        r161, 1
+  Add          r162, r29, r161
+  Move         r29, r162
   Jump         L17
 L1:
   // from l in lineitem
-  Const        r162, 1
-  Add          r163, r23, r162
-  Move         r23, r163
+  Const        r163, 1
+  Add          r164, r23, r163
+  Move         r23, r164
   Jump         L18
 L0:
-  Const        r164, 0
-  Len          r165, r20
+  Const        r165, 0
+  Len          r166, r20
 L22:
-  Less         r166, r164, r165
-  JumpIfFalse  r166, L19
-  Index        r167, r20, r164
-  Move         r168, r167
+  Less         r167, r165, r166
+  JumpIfFalse  r167, L19
+  Index        r168, r20, r165
+  Move         r169, r168
   // supp_nation: g.key.supp_nation,
-  Const        r169, "supp_nation"
-  Const        r170, "key"
-  Index        r171, r168, r170
-  Const        r172, "supp_nation"
-  Index        r173, r171, r172
+  Const        r170, "supp_nation"
+  Const        r171, "key"
+  Index        r172, r169, r171
+  Const        r173, "supp_nation"
+  Index        r174, r172, r173
   // cust_nation: g.key.cust_nation,
-  Const        r174, "cust_nation"
-  Const        r175, "key"
-  Index        r176, r168, r175
-  Const        r177, "cust_nation"
-  Index        r178, r176, r177
+  Const        r175, "cust_nation"
+  Const        r176, "key"
+  Index        r177, r169, r176
+  Const        r178, "cust_nation"
+  Index        r179, r177, r178
   // l_year: g.key.l_year,
-  Const        r179, "l_year"
-  Const        r180, "key"
-  Index        r181, r168, r180
-  Const        r182, "l_year"
-  Index        r183, r181, r182
+  Const        r180, "l_year"
+  Const        r181, "key"
+  Index        r182, r169, r181
+  Const        r183, "l_year"
+  Index        r184, r182, r183
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r184, "revenue"
-  Const        r185, []
-  IterPrep     r186, r168
-  Len          r187, r186
-  Const        r188, 0
+  Const        r185, "revenue"
+  Const        r186, []
+  IterPrep     r187, r169
+  Len          r188, r187
+  Const        r189, 0
 L21:
-  Less         r189, r188, r187
-  JumpIfFalse  r189, L20
-  Index        r190, r186, r188
-  Move         r191, r190
-  Const        r192, "l"
-  Index        r193, r191, r192
-  Const        r194, "l_extendedprice"
-  Index        r195, r193, r194
-  Const        r196, 1
-  Const        r197, "l"
-  Index        r198, r191, r197
-  Const        r199, "l_discount"
-  Index        r200, r198, r199
-  Sub          r201, r196, r200
-  Mul          r202, r195, r201
-  Append       r203, r185, r202
-  Move         r185, r203
-  Const        r204, 1
-  Add          r205, r188, r204
-  Move         r188, r205
+  Less         r190, r189, r188
+  JumpIfFalse  r190, L20
+  Index        r191, r187, r189
+  Move         r192, r191
+  Const        r193, "l"
+  Index        r194, r192, r193
+  Const        r195, "l_extendedprice"
+  Index        r196, r194, r195
+  Const        r197, 1
+  Const        r198, "l"
+  Index        r199, r192, r198
+  Const        r200, "l_discount"
+  Index        r201, r199, r200
+  Sub          r202, r197, r201
+  Mul          r203, r196, r202
+  Append       r204, r186, r203
+  Move         r186, r204
+  Const        r205, 1
+  Add          r206, r189, r205
+  Move         r189, r206
   Jump         L21
 L20:
-  Sum          206,185,0,0
+  Sum          207,186,0,0
   // supp_nation: g.key.supp_nation,
-  Move         r207, r169
-  Move         r208, r173
-  // cust_nation: g.key.cust_nation,
+  Move         r208, r170
   Move         r209, r174
-  Move         r210, r178
-  // l_year: g.key.l_year,
+  // cust_nation: g.key.cust_nation,
+  Move         r210, r175
   Move         r211, r179
-  Move         r212, r183
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  // l_year: g.key.l_year,
+  Move         r212, r180
   Move         r213, r184
-  Move         r214, r206
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Move         r214, r185
+  Move         r215, r207
   // select {
-  MakeMap      r215, 4, r207
+  MakeMap      r216, 4, r208
+  // order by [ g.key.supp_nation, g.key.cust_nation, g.key.l_year ]
+  Const        r217, "key"
+  Index        r218, r169, r217
+  Const        r219, "supp_nation"
+  Index        r220, r218, r219
+  Move         r221, r220
+  Const        r222, "key"
+  Index        r223, r169, r222
+  Const        r224, "cust_nation"
+  Index        r225, r223, r224
+  Move         r226, r225
+  Const        r227, "key"
+  Index        r228, r169, r227
+  Const        r229, "l_year"
+  Index        r230, r228, r229
+  Move         r231, r230
+  MakeList     r232, 3, r221
+  Move         r233, r232
   // from l in lineitem
-  Append       r216, r18, r215
-  Move         r18, r216
-  Const        r217, 1
-  Add          r218, r164, r217
-  Move         r164, r218
+  Move         r234, r216
+  MakeList     r235, 2, r233
+  Append       r236, r18, r235
+  Move         r18, r236
+  Const        r237, 1
+  Add          r238, r165, r237
+  Move         r165, r238
   Jump         L22
 L19:
+  // order by [ g.key.supp_nation, g.key.cust_nation, g.key.l_year ]
+  Sort         239,18,0,0
+  // from l in lineitem
+  Move         r18, r239
   // let result =
-  Move         r219, r18
+  Move         r240, r18
   // json(result)
-  JSON         r219
+  JSON         r240
   // expect result == [
-  Const        r220, [{"cust_nation": "GERMANY", "l_year": "1995", "revenue": 900, "supp_nation": "FRANCE"}]
-  Equal        r221, r219, r220
-  Expect       r221
+  Const        r241, [{"cust_nation": "GERMANY", "l_year": "1995", "revenue": 900, "supp_nation": "FRANCE"}]
+  Equal        r242, r240, r241
+  Expect       r242
   Return       r0
 

--- a/tests/dataset/tpc-h/q7.mochi
+++ b/tests/dataset/tpc-h/q7.mochi
@@ -55,6 +55,7 @@ let result =
     cust_nation: n2.n_name,
     l_year: substring(l.l_shipdate, 0, 4)
   } into g
+  order by [ g.key.supp_nation, g.key.cust_nation, g.key.l_year ]
   select {
     supp_nation: g.key.supp_nation,
     cust_nation: g.key.cust_nation,

--- a/tests/vm/valid/substring_builtin.ir.out
+++ b/tests/vm/valid/substring_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=1)
   // print(substring("mochi", 1, 4))
-  Const        r0, "och"
+  Const        r0, "ochi"
   Print        r0
   Return       r0
 

--- a/tests/vm/valid/substring_builtin.out
+++ b/tests/vm/valid/substring_builtin.out
@@ -1,1 +1,1 @@
-och
+ochi


### PR DESCRIPTION
## Summary
- update substring builtin to take `start` and `length`
- compile `substring` using `OpAddInt` for end index
- add sort clause to TPCH q7 example
- update golden outputs for substring builtin and q7 IR

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c93061ad483208a0bc217ba6a3e62