### PR TITLE
Enhance C++ backend

### DIFF
--- a/compile/x/cpp/compiler.go
+++ b/compile/x/cpp/compiler.go
@@ -912,6 +912,9 @@ func (c *Compiler) compileMapLiteral(m *parser.MapLiteral) string {
 	}
 	for i, it := range m.Items {
 		k := c.compileExpr(it.Key)
+		if name, ok := selectorName(it.Key); ok {
+			k = fmt.Sprintf("string(\"%s\")", name)
+		}
 		v := c.compileExpr(it.Value)
 		items[i] = fmt.Sprintf("{%s, %s}", k, v)
 	}

--- a/compile/x/cpp/runtime.go
+++ b/compile/x/cpp/runtime.go
@@ -139,7 +139,7 @@ var helperCode = map[string][]string{
 		"static string _escape_json(const string& s) {",
 		"\tstring out;",
 		"\tfor (char c : s) {",
-		"\t\tif (c == '\"' || c == '\\') out += '\\';",
+		"\t\tif (c == '\"' || c == '\\\\') out += '\\\\';",
 		"\t\tout += c;",
 		"\t}",
 		"\treturn out;",

--- a/tests/compiler/cpp/tpch_q1.cpp.out
+++ b/tests/compiler/cpp/tpch_q1.cpp.out
@@ -1,0 +1,125 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+template<typename T> auto _count(const T& v) -> decltype(v.size(), int{}) {
+	return (int)v.size();
+}
+template<typename T> auto _count(const T& v) -> decltype(v.Items, int{}) {
+	return (int)v.Items.size();
+}
+
+template<typename T> auto _avg(const T& v) -> decltype(v.size(), double{}) {
+	if (v.size() == 0) return 0;
+	double sum = 0;
+	for (const auto& it : v) sum += it;
+	return sum / v.size();
+}
+template<typename T> auto _avg(const T& v) -> decltype(v.Items, double{}) {
+	return _avg(v.Items);
+}
+
+static string _escape_json(const string& s) {
+	string out;
+	for (char c : s) {
+		if (c == '"' || c == '\\') out += '\\';
+		out += c;
+	}
+	return out;
+}
+template<typename T> string _to_json(const T& v);
+inline string _to_json(const string& s) {
+	string out = "\"";
+	out += _escape_json(s);
+	out += "\"";
+	return out;
+}
+inline string _to_json(const char* s) { return _to_json(string(s)); }
+inline string _to_json(int v) { return to_string(v); }
+inline string _to_json(double v) { stringstream ss; ss << v; return ss.str(); }
+inline string _to_json(bool v) { return v ? "true" : "false"; }
+template<typename T> string _to_json(const vector<T>& v) {
+	string out = "[";
+	for (size_t i=0;i<v.size();i++) { if (i>0) out += ','; out += _to_json(v[i]); }
+	out += ']';
+	return out;
+}
+template<typename K, typename V> string _to_json(const unordered_map<K,V>& m) {
+	string out = "{"; bool first = true;
+	for (const auto& kv : m) {
+		if (!first) out += ','; first = false;
+		out += _to_json(kv.first); out += ':'; out += _to_json(kv.second);
+	}
+	out += '}';
+	return out;
+}
+template<typename T> string _to_json(const T& v) { stringstream ss; ss << v; return _to_json(ss.str()); }
+template<typename T> void _json(const T& v) { cout << _to_json(v) << endl; }
+
+int main() {
+	auto lineitem = vector<unordered_map<string, int>>{unordered_map<string, int>{{string("l_quantity"), 17}, {string("l_extendedprice"), 1000.0}, {string("l_discount"), 0.05}, {string("l_tax"), 0.07}, {string("l_returnflag"), string("N")}, {string("l_linestatus"), string("O")}, {string("l_shipdate"), string("1998-08-01")}}, unordered_map<string, int>{{string("l_quantity"), 36}, {string("l_extendedprice"), 2000.0}, {string("l_discount"), 0.1}, {string("l_tax"), 0.05}, {string("l_returnflag"), string("N")}, {string("l_linestatus"), string("O")}, {string("l_shipdate"), string("1998-09-01")}}, unordered_map<string, int>{{string("l_quantity"), 25}, {string("l_extendedprice"), 1500.0}, {string("l_discount"), 0.0}, {string("l_tax"), 0.08}, {string("l_returnflag"), string("R")}, {string("l_linestatus"), string("F")}, {string("l_shipdate"), string("1998-09-03")}}};
+	auto result = ([&]() -> vector<unordered_map<string, int>> {
+	using ElemT = unordered_map<string, auto>;
+	using KeyT = unordered_map<string, int>;
+	struct Group { KeyT Key; vector<ElemT> Items; };
+	unordered_map<KeyT, Group> groups;
+	vector<KeyT> order;
+	for (auto& row : lineitem) {
+		if (row.l_shipdate <= string("1998-09-02")) {
+			KeyT _k = unordered_map<string, int>{{string("returnflag"), row.l_returnflag}, {string("linestatus"), row.l_linestatus}};
+			if (!groups.count(_k)) { groups[_k] = Group{_k, {}}; order.push_back(_k); }
+			groups[_k].Items.push_back(row);
+		}
+	}
+	vector<Group*> items;
+	for (auto& _k : order) items.push_back(&groups[_k]);
+	vector<unordered_map<string, int>> _res;
+	for (auto* g : items) {
+		_res.push_back(unordered_map<string, int>{{string("returnflag"), g.key.returnflag}, {string("linestatus"), g.key.linestatus}, {string("sum_qty"), sum(([&]() -> vector<auto> {
+	vector<auto> _res;
+	for (auto& x : g) {
+		_res.push_back(x.l_quantity);
+	}
+	return _res;
+})())}, {string("sum_base_price"), sum(([&]() -> vector<auto> {
+	vector<auto> _res;
+	for (auto& x : g) {
+		_res.push_back(x.l_extendedprice);
+	}
+	return _res;
+})())}, {string("sum_disc_price"), sum(([&]() -> vector<auto> {
+	vector<auto> _res;
+	for (auto& x : g) {
+		_res.push_back(x.l_extendedprice * (1 - x.l_discount));
+	}
+	return _res;
+})())}, {string("sum_charge"), sum(([&]() -> vector<auto> {
+	vector<auto> _res;
+	for (auto& x : g) {
+		_res.push_back(x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax));
+	}
+	return _res;
+})())}, {string("avg_qty"), _avg(([&]() -> vector<auto> {
+	vector<auto> _res;
+	for (auto& x : g) {
+		_res.push_back(x.l_quantity);
+	}
+	return _res;
+})())}, {string("avg_price"), _avg(([&]() -> vector<auto> {
+	vector<auto> _res;
+	for (auto& x : g) {
+		_res.push_back(x.l_extendedprice);
+	}
+	return _res;
+})())}, {string("avg_disc"), _avg(([&]() -> vector<auto> {
+	vector<auto> _res;
+	for (auto& x : g) {
+		_res.push_back(x.l_discount);
+	}
+	return _res;
+})())}, {string("count_order"), _count(g)}});
+	}
+	return _res;
+})();
+	_json(result);
+	return 0;
+}

--- a/tests/compiler/cpp/tpch_q1.mochi
+++ b/tests/compiler/cpp/tpch_q1.mochi
@@ -1,0 +1,52 @@
+let lineitem = [
+  {
+    l_quantity: 17,
+    l_extendedprice: 1000.0,
+    l_discount: 0.05,
+    l_tax: 0.07,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-08-01"
+  },
+  {
+    l_quantity: 36,
+    l_extendedprice: 2000.0,
+    l_discount: 0.10,
+    l_tax: 0.05,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-09-01"
+  },
+  {
+    l_quantity: 25,
+    l_extendedprice: 1500.0,
+    l_discount: 0.00,
+    l_tax: 0.08,
+    l_returnflag: "R",
+    l_linestatus: "F",
+    l_shipdate: "1998-09-03"  // excluded
+  }
+]
+
+let result =
+  from row in lineitem
+  where row.l_shipdate <= "1998-09-02"
+  group by {
+    returnflag: row.l_returnflag,
+    linestatus: row.l_linestatus
+  } into g
+  select {
+    returnflag: g.key.returnflag,
+    linestatus: g.key.linestatus,
+    sum_qty: sum(from x in g select x.l_quantity),
+    sum_base_price: sum(from x in g select x.l_extendedprice),
+    sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+    sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+    avg_qty: avg(from x in g select x.l_quantity),
+    avg_price: avg(from x in g select x.l_extendedprice),
+    avg_disc: avg(from x in g select x.l_discount),
+    count_order: count(g)
+  }
+
+json(result)
+

--- a/tests/compiler/cpp/tpch_q1.out
+++ b/tests/compiler/cpp/tpch_q1.out
@@ -1,0 +1,1 @@
+[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]


### PR DESCRIPTION
## Summary
- fix JSON escaping in C++ runtime
- emit string keys for map literals
- add tpch_q1 compiler golden tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c953c1bf48320afb33014f830726f