### PR TITLE
Add min/max helpers for Go backend

### DIFF
--- a/compile/go/compiler.go
+++ b/compile/go/compiler.go
@@ -3083,6 +3083,14 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.imports["mochi/runtime/data"] = true
 		c.use("_sum")
 		return fmt.Sprintf("_sum(%s)", argStr), nil
+	case "min":
+		c.imports["mochi/runtime/data"] = true
+		c.use("_min")
+		return fmt.Sprintf("_min(%s)", argStr), nil
+	case "max":
+		c.imports["mochi/runtime/data"] = true
+		c.use("_max")
+		return fmt.Sprintf("_max(%s)", argStr), nil
 	case "len":
 		return fmt.Sprintf("len(%s)", argStr), nil
 	case "now":

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -114,6 +114,100 @@ const (
 		"    return sum\n" +
 		"}\n"
 
+	helperMin = "func _min(v any) any {\n" +
+		"    if g, ok := v.(*data.Group); ok { v = g.Items }\n" +
+		"    switch s := v.(type) {\n" +
+		"    case []int:\n" +
+		"        if len(s) == 0 { return 0 }\n" +
+		"        m := s[0]\n" +
+		"        for _, n := range s[1:] { if n < m { m = n } }\n" +
+		"        return m\n" +
+		"    case []float64:\n" +
+		"        if len(s) == 0 { return 0.0 }\n" +
+		"        m := s[0]\n" +
+		"        for _, n := range s[1:] { if n < m { m = n } }\n" +
+		"        return m\n" +
+		"    case []any:\n" +
+		"        if len(s) == 0 { return 0 }\n" +
+		"        var m float64\n" +
+		"        var isFloat bool\n" +
+		"        switch n := s[0].(type) {\n" +
+		"        case int: m = float64(n)\n" +
+		"        case int64: m = float64(n)\n" +
+		"        case float64: m = n; isFloat = true\n" +
+		"        default: panic(\"min() expects numbers\") }\n" +
+		"        for _, it := range s[1:] {\n" +
+		"            switch v := it.(type) {\n" +
+		"            case int: if float64(v) < m { m = float64(v) }\n" +
+		"            case int64: if float64(v) < m { m = float64(v) }\n" +
+		"            case float64: if v < m { m = v }; isFloat = true\n" +
+		"            default: panic(\"min() expects numbers\") }\n" +
+		"        }\n" +
+		"        if isFloat { return m }\n" +
+		"        return int(m)\n" +
+		"    default:\n" +
+		"        rv := reflect.ValueOf(v)\n" +
+		"        if rv.Kind() == reflect.Slice {\n" +
+		"            if rv.Len() == 0 { return 0 }\n" +
+		"            m := rv.Index(0).Interface()\n" +
+		"            switch m.(type) {\n" +
+		"            case int, int64, float64:\n" +
+		"                items := make([]any, rv.Len())\n" +
+		"                for i := 0; i < rv.Len(); i++ { items[i] = rv.Index(i).Interface() }\n" +
+		"                return _min(items)\n" +
+		"            }\n" +
+		"        }\n" +
+		"        panic(\"min() expects list or group\")\n" +
+		"    }\n" +
+		"}\n"
+
+	helperMax = "func _max(v any) any {\n" +
+		"    if g, ok := v.(*data.Group); ok { v = g.Items }\n" +
+		"    switch s := v.(type) {\n" +
+		"    case []int:\n" +
+		"        if len(s) == 0 { return 0 }\n" +
+		"        m := s[0]\n" +
+		"        for _, n := range s[1:] { if n > m { m = n } }\n" +
+		"        return m\n" +
+		"    case []float64:\n" +
+		"        if len(s) == 0 { return 0.0 }\n" +
+		"        m := s[0]\n" +
+		"        for _, n := range s[1:] { if n > m { m = n } }\n" +
+		"        return m\n" +
+		"    case []any:\n" +
+		"        if len(s) == 0 { return 0 }\n" +
+		"        var m float64\n" +
+		"        var isFloat bool\n" +
+		"        switch n := s[0].(type) {\n" +
+		"        case int: m = float64(n)\n" +
+		"        case int64: m = float64(n)\n" +
+		"        case float64: m = n; isFloat = true\n" +
+		"        default: panic(\"max() expects numbers\") }\n" +
+		"        for _, it := range s[1:] {\n" +
+		"            switch v := it.(type) {\n" +
+		"            case int: if float64(v) > m { m = float64(v) }\n" +
+		"            case int64: if float64(v) > m { m = float64(v) }\n" +
+		"            case float64: if v > m { m = v }; isFloat = true\n" +
+		"            default: panic(\"max() expects numbers\") }\n" +
+		"        }\n" +
+		"        if isFloat { return m }\n" +
+		"        return int(m)\n" +
+		"    default:\n" +
+		"        rv := reflect.ValueOf(v)\n" +
+		"        if rv.Kind() == reflect.Slice {\n" +
+		"            if rv.Len() == 0 { return 0 }\n" +
+		"            m := rv.Index(0).Interface()\n" +
+		"            switch m.(type) {\n" +
+		"            case int, int64, float64:\n" +
+		"                items := make([]any, rv.Len())\n" +
+		"                for i := 0; i < rv.Len(); i++ { items[i] = rv.Index(i).Interface() }\n" +
+		"                return _max(items)\n" +
+		"            }\n" +
+		"        }\n" +
+		"        panic(\"max() expects list or group\")\n" +
+		"    }\n" +
+		"}\n"
+
 	helperInput = "func _input() string {\n" +
 		"    var s string\n" +
 		"    fmt.Scanln(&s)\n" +
@@ -471,6 +565,8 @@ var helperMap = map[string]string{
 	"_count":         helperCount,
 	"_avg":           helperAvg,
 	"_sum":           helperSum,
+	"_min":           helperMin,
+	"_max":           helperMax,
 	"_input":         helperInput,
 	"_genText":       helperGenText,
 	"_genEmbed":      helperGenEmbed,

--- a/tests/compiler/go/tpch_q1.mochi
+++ b/tests/compiler/go/tpch_q1.mochi
@@ -1,0 +1,68 @@
+let lineitem = [
+  {
+    l_quantity: 17,
+    l_extendedprice: 1000.0,
+    l_discount: 0.05,
+    l_tax: 0.07,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-08-01"
+  },
+  {
+    l_quantity: 36,
+    l_extendedprice: 2000.0,
+    l_discount: 0.10,
+    l_tax: 0.05,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-09-01"
+  },
+  {
+    l_quantity: 25,
+    l_extendedprice: 1500.0,
+    l_discount: 0.00,
+    l_tax: 0.08,
+    l_returnflag: "R",
+    l_linestatus: "F",
+    l_shipdate: "1998-09-03"  // excluded
+  }
+]
+
+let result =
+  from row in lineitem
+  where row.l_shipdate <= "1998-09-02"
+  group by {
+    returnflag: row.l_returnflag,
+    linestatus: row.l_linestatus
+  } into g
+  select {
+    returnflag: g.key.returnflag,
+    linestatus: g.key.linestatus,
+    sum_qty: sum(from x in g select x.l_quantity),
+    sum_base_price: sum(from x in g select x.l_extendedprice),
+    sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+    sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+    avg_qty: avg(from x in g select x.l_quantity),
+    avg_price: avg(from x in g select x.l_extendedprice),
+    avg_disc: avg(from x in g select x.l_discount),
+    count_order: count(g)
+  }
+
+json(result)
+
+test "Q1 aggregates revenue and quantity by returnflag + linestatus" {
+  expect result == [
+    {
+      returnflag: "N",
+      linestatus: "O",
+      sum_qty: 53,
+      sum_base_price: 3000,
+      sum_disc_price: 950.0 + 1800.0,               // 2750.0
+      sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
+      avg_qty: 26.5,
+      avg_price: 1500,
+      avg_disc: 0.07500000000000001,
+      count_order: 2
+    }
+  ]
+}

--- a/tests/compiler/go/tpch_q1.out
+++ b/tests/compiler/go/tpch_q1.out
@@ -1,0 +1,1 @@
+[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]

--- a/tests/compiler/go/tpch_q2.mochi
+++ b/tests/compiler/go/tpch_q2.mochi
@@ -1,0 +1,100 @@
+let region = [
+  { r_regionkey: 1, r_name: "EUROPE" },
+  { r_regionkey: 2, r_name: "ASIA" }
+]
+
+let nation = [
+  { n_nationkey: 10, n_regionkey: 1, n_name: "FRANCE" },
+  { n_nationkey: 20, n_regionkey: 2, n_name: "CHINA" }
+]
+
+let supplier = [
+  {
+    s_suppkey: 100,
+    s_name: "BestSupplier",
+    s_address: "123 Rue",
+    s_nationkey: 10,
+    s_phone: "123",
+    s_acctbal: 1000.0,
+    s_comment: "Fast and reliable"
+  },
+  {
+    s_suppkey: 200,
+    s_name: "AltSupplier",
+    s_address: "456 Way",
+    s_nationkey: 20,
+    s_phone: "456",
+    s_acctbal: 500.0,
+    s_comment: "Slow"
+  }
+]
+
+let part = [
+  { p_partkey: 1000, p_type: "LARGE BRASS", p_size: 15, p_mfgr: "M1" },
+  { p_partkey: 2000, p_type: "SMALL COPPER", p_size: 15, p_mfgr: "M2" }
+]
+
+let partsupp = [
+  { ps_partkey: 1000, ps_suppkey: 100, ps_supplycost: 10.00 },
+  { ps_partkey: 1000, ps_suppkey: 200, ps_supplycost: 15.00 }
+]
+
+let europe_nations =
+  from r in region
+  join n in nation on n.n_regionkey == r.r_regionkey
+  where r.r_name == "EUROPE"
+  select n
+
+let europe_suppliers =
+  from s in supplier
+  join n in europe_nations on s.s_nationkey == n.n_nationkey
+  select { s: s, n: n }
+
+let target_parts =
+  from p in part
+  where p.p_size == 15 && p.p_type == "LARGE BRASS"
+  select p
+
+let target_partsupp =
+  from ps in partsupp
+  join p in target_parts on ps.ps_partkey == p.p_partkey
+  join s in europe_suppliers on ps.ps_suppkey == s.s.s_suppkey
+  select {
+    s_acctbal: s.s.s_acctbal,
+    s_name: s.s.s_name,
+    n_name: s.n.n_name,
+    p_partkey: p.p_partkey,
+    p_mfgr: p.p_mfgr,
+    s_address: s.s.s_address,
+    s_phone: s.s.s_phone,
+    s_comment: s.s.s_comment,
+    ps_supplycost: ps.ps_supplycost
+  }
+
+let costs = from x in target_partsupp select x.ps_supplycost
+
+let min_cost = min(costs)
+
+let result =
+  from x in target_partsupp
+  where x.ps_supplycost == min_cost
+  sort by -x.s_acctbal
+  select x
+
+json(result)
+
+test "Q2 returns only supplier with min cost in Europe for brass part" {
+  expect result == [
+    {
+      s_acctbal: 1000.0,
+      s_name: "BestSupplier",
+      n_name: "FRANCE",
+      p_partkey: 1000,
+      p_mfgr: "M1",
+      s_address: "123 Rue",
+      s_phone: "123",
+      s_comment: "Fast and reliable",
+      ps_supplycost: 10.0
+    }
+  ]
+}

--- a/tests/compiler/go/tpch_q2.out
+++ b/tests/compiler/go/tpch_q2.out
@@ -1,0 +1,1 @@
+[{"n_name":"FRANCE","p_mfgr":"M1","p_partkey":1000,"ps_supplycost":10,"s_acctbal":1000,"s_address":"123 Rue","s_comment":"Fast and reliable","s_name":"BestSupplier","s_phone":"123"}]


### PR DESCRIPTION
## Summary
- support `min` and `max` built-ins in the Go compiler
- add TPC-H Q1 and Q2 programs to Go compiler golden tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c975649dc8320967369f93c97f79f