### PR TITLE
Add exists builtin to VM

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -121,6 +121,7 @@ from the disassembler:
 | `Avg` | Average of numeric list B | `Avg r0, r1` |
 | `Min` | Minimum value of numeric list B | `Min r0, r1` |
 | `Max` | Maximum value of numeric list B | `Max r0, r1` |
+| `Exists` | Check if list/map/string B is non-empty | `Exists r0, r1` |
 | `Cast` | Cast value B to type index C | `Cast r0, r1, 0` |
 | `IterPrep` | Prepare iterable from B | `IterPrep r0, r1` |
 | `Load` | Load dataset from path B with options C | `Load r0, r1, r2` |

--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -147,5 +147,7 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagFloat
 	case OpMin, OpMax:
 		tags[ins.A] = TagUnknown
+	case OpExists:
+		tags[ins.A] = TagBool
 	}
 }

--- a/tests/dataset/tpc-h/q4.mochi
+++ b/tests/dataset/tpc-h/q4.mochi
@@ -17,25 +17,21 @@ let end_date = "1993-08-01"
 
 let date_filtered_orders =
   from o in orders
-  where o.o_orderdate >= start_date and o.o_orderdate < end_date
+  where o.o_orderdate >= start_date && o.o_orderdate < end_date
   select o
 
 let late_orders =
   from o in date_filtered_orders
-  where exists (
-    l in lineitem
-    where l.l_orderkey == o.o_orderkey and l.l_commitdate < l.l_receiptdate
-  )
+  where exists(from l in lineitem where l.l_orderkey == o.o_orderkey && l.l_commitdate < l.l_receiptdate select l)
   select o
 
-let result =
-  from o in late_orders
+let result = from o in late_orders
   group by o.o_orderpriority
   select {
     o_orderpriority: o.o_orderpriority,
     order_count: count()
   }
-  order by o.o_orderpriority
+  sort by o.o_orderpriority
 
 print result
 

--- a/tests/vm/valid/exists_builtin.ir.out
+++ b/tests/vm/valid/exists_builtin.ir.out
@@ -1,0 +1,12 @@
+func main (regs=4)
+  // print(exists([1]))
+  Const        r0, [1]
+  Exists       r1, r0
+  Print        r1
+  // print(exists([]))
+  Const        r2, []
+  Exists       r3, r2
+  Print        r3
+  Return       r0
+
+

--- a/tests/vm/valid/exists_builtin.mochi
+++ b/tests/vm/valid/exists_builtin.mochi
@@ -1,0 +1,2 @@
+print(exists([1]))
+print(exists([]))

--- a/tests/vm/valid/exists_builtin.out
+++ b/tests/vm/valid/exists_builtin.out
@@ -1,0 +1,2 @@
+true
+false

--- a/types/check.go
+++ b/types/check.go
@@ -437,6 +437,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: AnyType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("exists", FuncType{
+		Params: []Type{AnyType{}},
+		Return: BoolType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("reduce", FuncType{
 		Params: []Type{AnyType{}, AnyType{}, AnyType{}},
 		Return: AnyType{},
@@ -2036,6 +2041,7 @@ var builtinArity = map[string]int{
 	"sum":       1,
 	"min":       1,
 	"max":       1,
+	"exists":    1,
 	"keys":      1,
 	"values":    1,
 	"reduce":    3,
@@ -2140,6 +2146,16 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 			return nil
 		default:
 			return fmt.Errorf("%s() expects list", name)
+		}
+	case "exists":
+		if len(args) != 1 {
+			return errArgCount(pos, name, 1, len(args))
+		}
+		switch args[0].(type) {
+		case ListType, MapType, StringType, GroupType, AnyType:
+			return nil
+		default:
+			return fmt.Errorf("exists() expects list, map or string")
 		}
 	case "keys", "values":
 		if len(args) != 1 {

--- a/types/infer.go
+++ b/types/infer.go
@@ -280,6 +280,8 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			return IntType{}
 		case "avg":
 			return FloatType{}
+		case "exists":
+			return BoolType{}
 		case "reduce":
 			if len(p.Call.Args) == 3 {
 				return ExprType(p.Call.Args[2], env)


### PR DESCRIPTION
## Summary
- implement `exists` built‑in in VM and bytecode
- support inference and type checking for new builtin
- document `Exists` instruction
- add golden test for `exists` builtin
- update TPC-H Q4 example query

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c26c86c3083208dfc02d8c03803bd