### PR TITLE
Add multi-key sort support for TPCH Q3

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -3332,9 +3332,22 @@ func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
 	fc.emit(q.Pos, Instr{Op: OpMove, A: gvar, B: grp})
 
 	val := fc.compileExpr(q.Select)
-	tmpOut := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpAppend, A: tmpOut, B: dst, C: val})
-	fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmpOut})
+	if q.Sort != nil {
+		key := fc.compileExpr(q.Sort)
+		kreg := fc.newReg()
+		fc.emit(q.Sort.Pos, Instr{Op: OpMove, A: kreg, B: key})
+		vreg := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpMove, A: vreg, B: val})
+		pair := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpMakeList, A: pair, B: 2, C: kreg})
+		tmpOut := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpAppend, A: tmpOut, B: dst, C: pair})
+		fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmpOut})
+	} else {
+		tmpOut := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpAppend, A: tmpOut, B: dst, C: val})
+		fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmpOut})
+	}
 
 	one2 := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpConst, A: one2, Val: Value{Tag: interpreter.TagInt, Int: 1}})
@@ -3457,9 +3470,22 @@ func (fc *funcCompiler) compileGroupQueryAny(q *parser.QueryExpr, dst int) {
 	fc.emit(q.Pos, Instr{Op: OpMove, A: gvar, B: grp})
 
 	val := fc.compileExpr(q.Select)
-	tmp := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: dst, C: val})
-	fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmp})
+	if q.Sort != nil {
+		key := fc.compileExpr(q.Sort)
+		kreg := fc.newReg()
+		fc.emit(q.Sort.Pos, Instr{Op: OpMove, A: kreg, B: key})
+		vreg := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpMove, A: vreg, B: val})
+		pair := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpMakeList, A: pair, B: 2, C: kreg})
+		tmp := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: dst, C: pair})
+		fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmp})
+	} else {
+		tmp := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: dst, C: val})
+		fc.emit(q.Pos, Instr{Op: OpMove, A: dst, B: tmp})
+	}
 
 	one := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpConst, A: one, Val: Value{Tag: interpreter.TagInt, Int: 1}})
@@ -4358,6 +4384,22 @@ func valueLess(a, b Value) bool {
 	case interpreter.TagStr:
 		if b.Tag == interpreter.TagStr {
 			return a.Str < b.Str
+		}
+	case interpreter.TagList:
+		if b.Tag == interpreter.TagList {
+			n := len(a.List)
+			if len(b.List) < n {
+				n = len(b.List)
+			}
+			for i := 0; i < n; i++ {
+				if valueLess(a.List[i], b.List[i]) {
+					return true
+				}
+				if valueLess(b.List[i], a.List[i]) {
+					return false
+				}
+			}
+			return len(a.List) < len(b.List)
 		}
 	}
 	return fmt.Sprint(valueToAny(a)) < fmt.Sprint(valueToAny(b))

--- a/tests/dataset/tpc-h/out/q3.ir.out
+++ b/tests/dataset/tpc-h/out/q3.ir.out
@@ -1,0 +1,372 @@
+func main (regs=235)
+  // let customer = [
+  Const        r0, [{"c_custkey": 1, "c_mktsegment": "BUILDING"}, {"c_custkey": 2, "c_mktsegment": "AUTOMOBILE"}]
+  Move         r1, r0
+  // let orders = [
+  Const        r2, [{"o_custkey": 1, "o_orderdate": "1995-03-14", "o_orderkey": 100, "o_shippriority": 1}, {"o_custkey": 2, "o_orderdate": "1995-03-10", "o_orderkey": 200, "o_shippriority": 2}]
+  Move         r3, r2
+  // let lineitem = [
+  Const        r4, [{"l_discount": 0.05, "l_extendedprice": 1000, "l_orderkey": 100, "l_shipdate": "1995-03-16"}, {"l_discount": 0, "l_extendedprice": 500, "l_orderkey": 100, "l_shipdate": "1995-03-20"}, {"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 200, "l_shipdate": "1995-03-14"}]
+  Move         r5, r4
+  // let cutoff = "1995-03-15"
+  Const        r6, "1995-03-15"
+  Move         r7, r6
+  // let segment = "BUILDING"
+  Const        r8, "BUILDING"
+  Move         r9, r8
+  // from c in customer
+  Const        r10, []
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L2:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L0
+  Index        r15, r11, r13
+  Move         r16, r15
+  // where c.c_mktsegment == segment
+  Const        r17, "c_mktsegment"
+  Index        r18, r16, r17
+  Equal        r19, r18, r9
+  JumpIfFalse  r19, L1
+  // from c in customer
+  Append       r20, r10, r16
+  Move         r10, r20
+L1:
+  Const        r21, 1
+  Add          r22, r13, r21
+  Move         r13, r22
+  Jump         L2
+L0:
+  // let building_customers =
+  Move         r23, r10
+  // from o in orders
+  Const        r24, []
+  IterPrep     r25, r3
+  Len          r26, r25
+  // join c in building_customers on o.o_custkey == c.c_custkey
+  IterPrep     r27, r23
+  Len          r28, r27
+  // from o in orders
+  Const        r29, 0
+L7:
+  Less         r30, r29, r26
+  JumpIfFalse  r30, L3
+  Index        r31, r25, r29
+  Move         r32, r31
+  // join c in building_customers on o.o_custkey == c.c_custkey
+  Const        r33, 0
+L6:
+  Less         r34, r33, r28
+  JumpIfFalse  r34, L4
+  Index        r35, r27, r33
+  Move         r16, r35
+  Const        r36, "o_custkey"
+  Index        r37, r32, r36
+  Const        r38, "c_custkey"
+  Index        r39, r16, r38
+  Equal        r40, r37, r39
+  JumpIfFalse  r40, L5
+  // where o.o_orderdate < cutoff
+  Const        r41, "o_orderdate"
+  Index        r42, r32, r41
+  Less         r43, r42, r7
+  JumpIfFalse  r43, L5
+  // from o in orders
+  Append       r44, r24, r32
+  Move         r24, r44
+L5:
+  // join c in building_customers on o.o_custkey == c.c_custkey
+  Const        r45, 1
+  Add          r46, r33, r45
+  Move         r33, r46
+  Jump         L6
+L4:
+  // from o in orders
+  Const        r47, 1
+  Add          r48, r29, r47
+  Move         r29, r48
+  Jump         L7
+L3:
+  // let valid_orders =
+  Move         r49, r24
+  // from l in lineitem
+  Const        r50, []
+  IterPrep     r51, r5
+  Len          r52, r51
+  Const        r53, 0
+L10:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L8
+  Index        r55, r51, r53
+  Move         r56, r55
+  // where l.l_shipdate > cutoff
+  Const        r57, "l_shipdate"
+  Index        r58, r56, r57
+  Less         r59, r7, r58
+  JumpIfFalse  r59, L9
+  // from l in lineitem
+  Append       r60, r50, r56
+  Move         r50, r60
+L9:
+  Const        r61, 1
+  Add          r62, r53, r61
+  Move         r53, r62
+  Jump         L10
+L8:
+  // let valid_lineitems =
+  Move         r63, r50
+  // from o in valid_orders
+  Const        r64, []
+  MakeMap      r65, 0, r0
+  Const        r66, []
+  IterPrep     r67, r49
+  Len          r68, r67
+  Const        r69, 0
+L16:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L11
+  Index        r71, r67, r69
+  Move         r32, r71
+  // join l in valid_lineitems on l.l_orderkey == o.o_orderkey
+  IterPrep     r72, r63
+  Len          r73, r72
+  Const        r74, 0
+L15:
+  Less         r75, r74, r73
+  JumpIfFalse  r75, L12
+  Index        r76, r72, r74
+  Move         r56, r76
+  Const        r77, "l_orderkey"
+  Index        r78, r56, r77
+  Const        r79, "o_orderkey"
+  Index        r80, r32, r79
+  Equal        r81, r78, r80
+  JumpIfFalse  r81, L13
+  // from o in valid_orders
+  Const        r82, "o"
+  Move         r83, r32
+  Const        r84, "l"
+  Move         r85, r56
+  MakeMap      r86, 2, r82
+  // o_orderkey: o.o_orderkey,
+  Const        r87, "o_orderkey"
+  Const        r88, "o_orderkey"
+  Index        r89, r32, r88
+  // o_orderdate: o.o_orderdate,
+  Const        r90, "o_orderdate"
+  Const        r91, "o_orderdate"
+  Index        r92, r32, r91
+  // o_shippriority: o.o_shippriority
+  Const        r93, "o_shippriority"
+  Const        r94, "o_shippriority"
+  Index        r95, r32, r94
+  // o_orderkey: o.o_orderkey,
+  Move         r96, r87
+  Move         r97, r89
+  // o_orderdate: o.o_orderdate,
+  Move         r98, r90
+  Move         r99, r92
+  // o_shippriority: o.o_shippriority
+  Move         r100, r93
+  Move         r101, r95
+  // group by {
+  MakeMap      r102, 3, r96
+  Str          r103, r102
+  In           r104, r103, r65
+  JumpIfTrue   r104, L14
+  // from o in valid_orders
+  Const        r105, []
+  Const        r106, "__group__"
+  Const        r107, true
+  Const        r108, "key"
+  // group by {
+  Move         r109, r102
+  // from o in valid_orders
+  Const        r110, "items"
+  Move         r111, r105
+  MakeMap      r112, 3, r106
+  SetIndex     r65, r103, r112
+  Append       r113, r66, r112
+  Move         r66, r113
+L14:
+  Const        r114, "items"
+  Index        r115, r65, r103
+  Index        r116, r115, r114
+  Append       r117, r116, r86
+  SetIndex     r115, r114, r117
+L13:
+  // join l in valid_lineitems on l.l_orderkey == o.o_orderkey
+  Const        r118, 1
+  Add          r119, r74, r118
+  Move         r74, r119
+  Jump         L15
+L12:
+  // from o in valid_orders
+  Const        r120, 1
+  Add          r121, r69, r120
+  Move         r69, r121
+  Jump         L16
+L11:
+  Const        r122, 0
+  Len          r123, r66
+L22:
+  Less         r124, r122, r123
+  JumpIfFalse  r124, L17
+  Index        r125, r66, r122
+  Move         r126, r125
+  // l_orderkey: g.key.o_orderkey,
+  Const        r127, "l_orderkey"
+  Const        r128, "key"
+  Index        r129, r126, r128
+  Const        r130, "o_orderkey"
+  Index        r131, r129, r130
+  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+  Const        r132, "revenue"
+  Const        r133, []
+  IterPrep     r134, r126
+  Len          r135, r134
+  Const        r136, 0
+L19:
+  Less         r137, r136, r135
+  JumpIfFalse  r137, L18
+  Index        r138, r134, r136
+  Move         r139, r138
+  Const        r140, "l"
+  Index        r141, r139, r140
+  Const        r142, "l_extendedprice"
+  Index        r143, r141, r142
+  Const        r144, 1
+  Const        r145, "l"
+  Index        r146, r139, r145
+  Const        r147, "l_discount"
+  Index        r148, r146, r147
+  Sub          r149, r144, r148
+  Mul          r150, r143, r149
+  Append       r151, r133, r150
+  Move         r133, r151
+  Const        r152, 1
+  Add          r153, r136, r152
+  Move         r136, r153
+  Jump         L19
+L18:
+  Sum          154,133,0,0
+  // o_orderdate: g.key.o_orderdate,
+  Const        r155, "o_orderdate"
+  Const        r156, "key"
+  Index        r157, r126, r156
+  Const        r158, "o_orderdate"
+  Index        r159, r157, r158
+  // o_shippriority: g.key.o_shippriority
+  Const        r160, "o_shippriority"
+  Const        r161, "key"
+  Index        r162, r126, r161
+  Const        r163, "o_shippriority"
+  Index        r164, r162, r163
+  // l_orderkey: g.key.o_orderkey,
+  Move         r165, r127
+  Move         r166, r131
+  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+  Move         r167, r132
+  Move         r168, r154
+  // o_orderdate: g.key.o_orderdate,
+  Move         r169, r155
+  Move         r170, r159
+  // o_shippriority: g.key.o_shippriority
+  Move         r171, r160
+  Move         r172, r164
+  // select {
+  MakeMap      r173, 4, r165
+  // sort by [-sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)), g.key.o_orderdate]
+  Const        r174, []
+  IterPrep     r175, r126
+  Len          r176, r175
+  Const        r177, 0
+L21:
+  Less         r178, r177, r176
+  JumpIfFalse  r178, L20
+  Index        r179, r175, r177
+  Move         r139, r179
+  Const        r180, "l"
+  Index        r181, r139, r180
+  Const        r182, "l_extendedprice"
+  Index        r183, r181, r182
+  Const        r184, 1
+  Const        r185, "l"
+  Index        r186, r139, r185
+  Const        r187, "l_discount"
+  Index        r188, r186, r187
+  Sub          r189, r184, r188
+  Mul          r190, r183, r189
+  Append       r191, r174, r190
+  Move         r174, r191
+  Const        r192, 1
+  Add          r193, r177, r192
+  Move         r177, r193
+  Jump         L21
+L20:
+  Sum          194,174,0,0
+  Neg          r195, r194
+  Move         r196, r195
+  Const        r197, "key"
+  Index        r198, r126, r197
+  Const        r199, "o_orderdate"
+  Index        r200, r198, r199
+  Move         r201, r200
+  MakeList     r202, 2, r196
+  Move         r203, r202
+  // from o in valid_orders
+  Move         r204, r173
+  MakeList     r205, 2, r203
+  Append       r206, r64, r205
+  Move         r64, r206
+  Const        r207, 1
+  Add          r208, r122, r207
+  Move         r122, r208
+  Jump         L22
+L17:
+  // sort by [-sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)), g.key.o_orderdate]
+  Sort         209,64,0,0
+  // from o in valid_orders
+  Move         r64, r209
+  // let order_line_join =
+  Move         r210, r64
+  // json(order_line_join)
+  JSON         r210
+  // l_orderkey: 100,
+  Const        r211, "l_orderkey"
+  Const        r212, 100
+  // revenue: 1000.0 * 0.95 + 500.0,
+  Const        r213, "revenue"
+  Const        r214, 1000
+  Const        r215, 0.95
+  MulFloat     r216, r214, r215
+  Const        r217, 500
+  AddFloat     r218, r216, r217
+  // o_orderdate: "1995-03-14",
+  Const        r219, "o_orderdate"
+  Const        r220, "1995-03-14"
+  // o_shippriority: 1
+  Const        r221, "o_shippriority"
+  Const        r222, 1
+  // l_orderkey: 100,
+  Move         r223, r211
+  Move         r224, r212
+  // revenue: 1000.0 * 0.95 + 500.0,
+  Move         r225, r213
+  Move         r226, r218
+  // o_orderdate: "1995-03-14",
+  Move         r227, r219
+  Move         r228, r220
+  // o_shippriority: 1
+  Move         r229, r221
+  Move         r230, r222
+  // {
+  MakeMap      r231, 4, r223
+  Move         r232, r231
+  // expect order_line_join == [
+  MakeList     r233, 1, r232
+  Equal        r234, r210, r233
+  Expect       r234
+  Return       r0
+

--- a/tests/dataset/tpc-h/out/q3.out
+++ b/tests/dataset/tpc-h/out/q3.out
@@ -1,0 +1,1 @@
+[{"l_orderkey":100,"o_orderdate":"1995-03-14","o_shippriority":1,"revenue":1450}]

--- a/tests/dataset/tpc-h/q3.mochi
+++ b/tests/dataset/tpc-h/q3.mochi
@@ -41,16 +41,15 @@ let order_line_join =
     o_orderdate: o.o_orderdate,
     o_shippriority: o.o_shippriority
   } into g
+  sort by [-sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)), g.key.o_orderdate]
   select {
     l_orderkey: g.key.o_orderkey,
     revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
     o_orderdate: g.key.o_orderdate,
     o_shippriority: g.key.o_shippriority
-  }
-  sort by o_orderdate
-  sort by -revenue
+}
 
-print order_line_join
+json(order_line_join)
 
 test "Q3 returns revenue per order with correct priority" {
   expect order_line_join == [


### PR DESCRIPTION
## Summary
- implement lexicographic comparison of list keys for sorting
- allow grouped queries to generate sortable pairs
- add TPCH Q3 program using multi-key sort
- provide golden outputs for Q3

## Testing
- `go test ./tests/vm -run TPCH -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c251db00883209ae14d6024783c73