### PR TITLE
Add v0.10.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # 📦 CHANGELOG.md
+## [0.10.1] – 2025-06-26T08:03:05+07:00
+
+### Added
+
+* Map sorting and HAVING clause support in the VM
+* Aggregate queries with `exists`, `contains` and `substring` builtins
+* Test blocks and `expect` statements across compilers
+* `sum`, `min` and `max` helpers in many backends
+* CLI `run` now defaults to the VM
+
+### Changed
+
+* Improved VM disassembly and C++ JSON escaping
+
+### Fixed
+
+* TPC-H query syntax corrections and Java map key handling
+
 ## [0.10.0] – 2025-06-25T20:05:45+07:00
 
 ### Added

--- a/releases/v0.10.1.md
+++ b/releases/v0.10.1.md
@@ -1,0 +1,28 @@
+# Jun 2025 (v0.10.1)
+
+Released on Thu Jun 26 08:03:05 2025 +0700.
+
+Mochi v0.10.1 expands dataset queries with aggregate features and introduces
+test blocks across languages. Map sorting and additional builtins improve
+the runtime while compilers gain new query helpers.
+
+## Runtime
+
+- Map sort capability for dictionaries
+- HAVING clause and aggregate query support
+- `exists`, `contains` and `substring` builtins
+- Grouping by multiple expressions
+- Improved disassembly and runtime tests
+
+## Compilers
+
+- Test blocks and `expect` statements across backends
+- Aggregate helpers and `sum`/`min`/`max` builtins
+- Python grouping sort and Go query `any` handling
+- C++ JSON escaping fixes for map literals
+- CLI `run` defaults to the VM
+
+## Fixes
+
+- Numerous TPC-H query syntax and dataset corrections
+- Java map key handling in queries


### PR DESCRIPTION
## Summary
- document v0.10.1 release in CHANGELOG
- add release notes file

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c9cd8c72c8320b68c7ae0bd1d5c6e