### PR TITLE
Mark runtime/vm tests as slow

### DIFF
--- a/runtime/vm/infer_test.go
+++ b/runtime/vm/infer_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package vm
 
 import (

--- a/tests/vm/vm_error_test.go
+++ b/tests/vm/vm_error_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package vm_test
 
 import (

--- a/tests/vm/vm_test.go
+++ b/tests/vm/vm_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package vm_test
 
 import (


### PR DESCRIPTION
## Summary
- mark vm tests as slow so they're excluded from normal `go test`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ca21d31c08320b51f83f364078f17