### PR TITLE
Fix tpch q20 prefix logic and add VM test

### DIFF
--- a/tests/dataset/tpc-h/q20.mochi
+++ b/tests/dataset/tpc-h/q20.mochi
@@ -35,17 +35,22 @@ let lineitem = [
 
 let prefix = "forest"
 
+let shipped_94 =
+  from l in lineitem
+  where l.l_shipdate >= "1994-01-01" && l.l_shipdate < "1995-01-01"
+  group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
+  select {
+    partkey: g.key.partkey,
+    suppkey: g.key.suppkey,
+    qty: sum(from x in g select x.l_quantity)
+  }
+
 let target_partkeys =
   from ps in partsupp
   join p in part on ps.ps_partkey == p.p_partkey
-  where p.p_name has prefix
-  let shipped =
-    sum(l.l_quantity for l in lineitem
-        where l.l_partkey == ps.ps_partkey
-        and l.l_suppkey == ps.ps_suppkey
-        and l.l_shipdate >= "1994-01-01"
-        and l.l_shipdate < "1995-01-01")
-  where ps.ps_availqty > 0.5 * shipped
+  join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
+  // check prefix using slicing since startsWith isn't available
+  where p.p_name[0:len(prefix)] == prefix && ps.ps_availqty > 0.5 * s.qty
   select ps.ps_suppkey
 
 let result =

--- a/tests/vm/valid/string_prefix_slice.ir.out
+++ b/tests/vm/valid/string_prefix_slice.ir.out
@@ -1,0 +1,27 @@
+func main (regs=18)
+  // let prefix = "fore"
+  Const        r0, "fore"
+  Move         r1, r0
+  // let s1 = "forest"
+  Const        r2, "forest"
+  Move         r3, r2
+  // print(s1[0:len(prefix)] == prefix)
+  Const        r5, 0
+  Move         r4, r5
+  Const        r7, 4
+  Move         r6, r7
+  Slice        r8, r3, r4, r6
+  Equal        r9, r8, r1
+  Print        r9
+  // let s2 = "desert"
+  Const        r10, "desert"
+  Move         r11, r10
+  // print(s2[0:len(prefix)] == prefix)
+  Const        r13, 0
+  Move         r12, r13
+  Const        r15, 4
+  Move         r14, r15
+  Slice        r16, r11, r12, r14
+  Equal        r17, r16, r1
+  Print        r17
+  Return       r0

--- a/tests/vm/valid/string_prefix_slice.mochi
+++ b/tests/vm/valid/string_prefix_slice.mochi
@@ -1,0 +1,5 @@
+let prefix = "fore"
+let s1 = "forest"
+print(s1[0:len(prefix)] == prefix)
+let s2 = "desert"
+print(s2[0:len(prefix)] == prefix)

--- a/tests/vm/valid/string_prefix_slice.out
+++ b/tests/vm/valid/string_prefix_slice.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- update q20.mochi to compute shipped quantities with a separate grouped query and check prefixes via slicing
- add a VM golden test for prefix checks using slicing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685ca44840c4832084948fd6d1583e7a