### PR TITLE
Fix TPCH q13 sorting

### DIFF
--- a/tests/dataset/tpc-h/q13.mochi
+++ b/tests/dataset/tpc-h/q13.mochi
@@ -27,8 +27,8 @@ let per_customer =
 let grouped =
   from x in per_customer
   group by x.c_count
+  sort by [-count(), -x.c_count]
   select { c_count: x.c_count, custdist: count() }
-  order by { custdist desc, c_count desc }
 
 print grouped
 

--- a/tests/vm/valid/string_in_operator.ir.out
+++ b/tests/vm/valid/string_in_operator.ir.out
@@ -1,0 +1,13 @@
+func main (regs=6)
+  // let s = "catch"
+  Const        r0, "catch"
+  Move         r1, r0
+  // print("cat" in s)
+  Const        r2, "cat"
+  In           r3, r2, r1
+  Print        r3
+  // print("dog" in s)
+  Const        r4, "dog"
+  In           r5, r4, r1
+  Print        r5
+  Return       r0

--- a/tests/vm/valid/string_in_operator.mochi
+++ b/tests/vm/valid/string_in_operator.mochi
@@ -1,0 +1,3 @@
+let s = "catch"
+print("cat" in s)
+print("dog" in s)

--- a/tests/vm/valid/string_in_operator.out
+++ b/tests/vm/valid/string_in_operator.out
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
## Summary
- fix query 13 sorting syntax
- add VM golden test for string membership using `in`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cabb1223c8320a45d3dfb088c1166