### PR TITLE
Add F# compiler golden test for TPCH Q1

### DIFF
--- a/tests/compiler/fs/tpch_q1.fs.out
+++ b/tests/compiler/fs/tpch_q1.fs.out
@@ -1,0 +1,65 @@
+open System
+
+type _Group<'T>(key: obj) =
+  member val key = key with get, set
+  member val Items = System.Collections.Generic.List<'T>() with get
+  member this.size = this.Items.Count
+let _group_by (src: 'T list) (keyfn: 'T -> obj) : _Group<'T> list =
+  let groups = System.Collections.Generic.Dictionary<string,_Group<'T>>()
+  let order = System.Collections.Generic.List<string>()
+  for it in src do
+    let key = keyfn it
+    let ks = string key
+    let mutable g = Unchecked.defaultof<_Group<'T>>
+    if groups.TryGetValue(ks, &g) then ()
+    else
+      g <- _Group<'T>(key)
+      groups[ks] <- g
+      order.Add(ks)
+    g.Items.Add(it)
+  [ for ks in order -> groups[ks] ]
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int
+  | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+
+        let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() =
+    if not ((result = [|Map.ofList [(returnflag, "N"); (linestatus, "O"); (sum_qty, 53); (sum_base_price, 3000); (sum_disc_price, (950.0 + 1800.0)); (sum_charge, (((950.0 * 1.07)) + ((1800.0 * 1.05)))); (avg_qty, 26.5); (avg_price, 1500); (avg_disc, 0.07500000000000001); (count_order, 2)]|])) then failwith "expect failed"
+
+let lineitem = [|Map.ofList [(l_quantity, 17); (l_extendedprice, 1000.0); (l_discount, 0.05); (l_tax, 0.07); (l_returnflag, "N"); (l_linestatus, "O"); (l_shipdate, "1998-08-01")]; Map.ofList [(l_quantity, 36); (l_extendedprice, 2000.0); (l_discount, 0.1); (l_tax, 0.05); (l_returnflag, "N"); (l_linestatus, "O"); (l_shipdate, "1998-09-01")]; Map.ofList [(l_quantity, 25); (l_extendedprice, 1500.0); (l_discount, 0.0); (l_tax, 0.08); (l_returnflag, "R"); (l_linestatus, "F"); (l_shipdate, "1998-09-03")]|]
+let result = [| for g in _group_by [| for row in lineitem do if (row.l_shipdate <= "1998-09-02") then yield row |] (fun row -> Map.ofList [(returnflag, row.l_returnflag); (linestatus, row.l_linestatus)]) do let g = g yield Map.ofList [(returnflag, g.key.returnflag); (linestatus, g.key.linestatus); (sum_qty, sum ([| for x in g do yield x.l_quantity |])); (sum_base_price, sum ([| for x in g do yield x.l_extendedprice |])); (sum_disc_price, sum ([| for x in g do yield (x.l_extendedprice * ((1 - x.l_discount))) |])); (sum_charge, sum ([| for x in g do yield ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))) |])); (avg_qty, ((Array.sum [| for x in g do yield x.l_quantity |]) / [| for x in g do yield x.l_quantity |].Length)); (avg_price, ((Array.sum [| for x in g do yield x.l_extendedprice |]) / [| for x in g do yield x.l_extendedprice |].Length)); (avg_disc, ((Array.sum [| for x in g do yield x.l_discount |]) / [| for x in g do yield x.l_discount |].Length)); (count_order, g.Length)] |]
+ignore (_json result)
+let mutable failures = 0
+if not (_run_test "Q1 aggregates revenue and quantity by returnflag + linestatus" test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/compiler/fs/tpch_q1.mochi
+++ b/tests/compiler/fs/tpch_q1.mochi
@@ -1,0 +1,68 @@
+let lineitem = [
+  {
+    l_quantity: 17,
+    l_extendedprice: 1000.0,
+    l_discount: 0.05,
+    l_tax: 0.07,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-08-01"
+  },
+  {
+    l_quantity: 36,
+    l_extendedprice: 2000.0,
+    l_discount: 0.10,
+    l_tax: 0.05,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-09-01"
+  },
+  {
+    l_quantity: 25,
+    l_extendedprice: 1500.0,
+    l_discount: 0.00,
+    l_tax: 0.08,
+    l_returnflag: "R",
+    l_linestatus: "F",
+    l_shipdate: "1998-09-03"  // excluded
+  }
+]
+
+let result =
+  from row in lineitem
+  where row.l_shipdate <= "1998-09-02"
+  group by {
+    returnflag: row.l_returnflag,
+    linestatus: row.l_linestatus
+  } into g
+  select {
+    returnflag: g.key.returnflag,
+    linestatus: g.key.linestatus,
+    sum_qty: sum(from x in g select x.l_quantity),
+    sum_base_price: sum(from x in g select x.l_extendedprice),
+    sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+    sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+    avg_qty: avg(from x in g select x.l_quantity),
+    avg_price: avg(from x in g select x.l_extendedprice),
+    avg_disc: avg(from x in g select x.l_discount),
+    count_order: count(g)
+  }
+
+json(result)
+
+test "Q1 aggregates revenue and quantity by returnflag + linestatus" {
+  expect result == [
+    {
+      returnflag: "N",
+      linestatus: "O",
+      sum_qty: 53,
+      sum_base_price: 3000,
+      sum_disc_price: 950.0 + 1800.0,               // 2750.0
+      sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
+      avg_qty: 26.5,
+      avg_price: 1500,
+      avg_disc: 0.07500000000000001,
+      count_order: 2
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a new F# golden test using the TPCH Q1 query

## Testing
- `go test ./...`
- `go test ./compile/x/fs -tags slow -run TestFSCompiler_GoldenOutput/tpch_q1 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685cad4f3bf08320a985a070bd991a02