### PR TITLE
Add sum builtin to Lua compiler

### DIFF
--- a/compile/x/lua/compiler.go
+++ b/compile/x/lua/compiler.go
@@ -48,7 +48,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 			if err := c.compileTypeDecl(s.Type); err != nil {
 				return nil, err
 			}
-			c.writeln("")
+			if len(s.Type.Variants) == 0 {
+				c.writeln("")
+			}
 		}
 		if s.Fun != nil {
 			if err := c.compileFun(s.Fun, false); err != nil {

--- a/compile/x/lua/runtime.go
+++ b/compile/x/lua/runtime.go
@@ -147,6 +147,20 @@ const (
 		"    return sum / #items\n" +
 		"end\n"
 
+	helperSum = "function __sum(v)\n" +
+		"    local items\n" +
+		"    if type(v) == 'table' and v.items ~= nil then\n" +
+		"        items = v.items\n" +
+		"    elseif type(v) == 'table' then\n" +
+		"        items = v\n" +
+		"    else\n" +
+		"        error('sum() expects list or group')\n" +
+		"    end\n" +
+		"    local sum = 0\n" +
+		"    for _, it in ipairs(items) do sum = sum + it end\n" +
+		"    return sum\n" +
+		"end\n"
+
 	helperAppend = "function __append(lst, v)\n" +
 		"    local out = {}\n" +
 		"    if lst then for i = 1, #lst do out[#out+1] = lst[i] end end\n" +
@@ -611,6 +625,7 @@ var helperMap = map[string]string{
 	"input":       helperInput,
 	"count":       helperCount,
 	"avg":         helperAvg,
+	"sum":         helperSum,
 	"append":      helperAppend,
 	"reduce":      helperReduce,
 	"json":        helperJson,


### PR DESCRIPTION
## Summary
- implement `sum` helper in Lua runtime
- expose `sum` via helper map
- compile builtin `sum()` calls
- avoid blank lines after variant type declarations

## Testing
- `go test -tags slow ./compile/x/lua -run TestLuaCompiler_SubsetPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685cad57a5388320913ca89c0eaffb8f