### PR TITLE
Move TPC-H Q1 compiler tasks

### DIFF
--- a/compile/x/c/TASKS.md
+++ b/compile/x/c/TASKS.md
@@ -1,0 +1,30 @@
+# Enhancing the C compiler for TPC-H Q1
+
+The current C backend cannot compile dataset queries that use grouping. The implementation stops when encountering a `group by` clause and emits `return 0`.
+
+Relevant code showing the limitation:
+
+```
+// compileQueryExpr generates C code for simple dataset queries. It now
+// supports optional `sort by`, `skip` and `take` clauses in addition to basic
+// `from`/`where`/`select`. Joins and grouping remain unimplemented.
+func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
+    ...
+    // only handle simple queries without joins or grouping
+    if len(q.Froms) > 0 || len(q.Joins) > 0 || q.Group != nil {
+        return "0"
+    }
+}
+```
+(see `compile/x/c/compiler.go` lines 913–965)
+
+To run `tests/dataset/tpc-h/q1.mochi` the following work is required:
+
+- [ ] Implement map/struct generation for objects such as `lineitem` rows.
+- [ ] Add runtime support for grouping rows by arbitrary keys (e.g. pair of strings).
+- [ ] Extend `compileQueryExpr` to generate loops that build groups and compute aggregates.
+- [ ] Emit helper functions for `sum`, `avg`, and `count` over lists of floats and ints.
+- [ ] Add JSON serialization helpers for lists of structs/maps used by the query.
+- [ ] Add golden tests under `tests/compiler/c` covering the new grouping logic.
+
+Until these tasks are complete `mochi build --target c tests/dataset/tpc-h/q1.mochi` results in generated C that simply sets `result` to `0`.


### PR DESCRIPTION
## Summary
- move `tpc_h_q1_compiler_tasks.md` into the C backend folder as `compile/x/c/TASKS.md`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cad36d9d88320930cba79a061452c