### PR TITLE
Add tasks for clojure tpch q1 support

### DIFF
--- a/compile/x/clj/compiler.go
+++ b/compile/x/clj/compiler.go
@@ -1571,7 +1571,7 @@ func (c *Compiler) compileQueryHelper(q *parser.QueryExpr) (string, error) {
 			b.WriteString(" :where " + whereFn)
 		}
 		b.WriteString(" })\n")
-		b.WriteString("      _groups (_group_by _rows (fn [" + allParams + "] " + groupKey + "))\n")
+		b.WriteString("      _groups (_group_by _rows (fn [" + allParams + "] " + groupKey + "))]\n")
 		genv := types.NewEnv(child)
 		genv.SetVar(q.Group.Name, types.GroupType{Elem: types.AnyType{}}, true)
 		c.env = genv

--- a/tpch_q1_clj_tasks.md
+++ b/tpch_q1_clj_tasks.md
@@ -1,0 +1,23 @@
+# Tasks to enable running tpc-h/q1.mochi via Clojure compiler
+
+The current Clojure backend fails to compile and execute `tpch_q1.mochi`. Issues observed:
+
+- Generated Clojure code has unmatched delimiters due to missing closing `]` in `compileQueryHelper` when emitting grouped queries.
+- Runtime helpers such as `_to_json` leave unbalanced parentheses leading to parser errors.
+- Required dependencies like `clojure.data.json` are not included causing `ClassNotFoundException` in some tests.
+
+To fully support tpc-h query execution the following tasks are recommended:
+
+1. **Fix runtime helper definitions**
+   - Review and correct all helper strings in `compile/x/clj/runtime.go` ensuring parentheses balance.
+   - Add regression tests that load each helper into the Clojure reader.
+2. **Close binding vector in grouped queries**
+   - Ensure `compileQueryHelper` writes the closing `]` before the query body and that resulting code compiles.
+3. **Add required namespaces**
+   - Automatically require `clojure.data.json` and `org.yaml.snakeyaml` when helpers `_json`, `_load` or `_save` are used.
+4. **Extend golden tests**
+   - Include `tests/compiler/clj/tpch_q1.mochi` in the suite with Clojure installed to verify compilation and execution.
+5. **CI environment setup**
+   - Update test tooling to install Clojure and required libraries on Linux and macOS to prevent skipping tests.
+
+Implementing these tasks will allow the Clojure compiler to run the tpc-h Q1 example and similar dataset queries.


### PR DESCRIPTION
## Summary
- fix grouped query bracket in Clojure backend
- add doc with tasks required for running tpch/q1.mochi with the Clojure backend

## Testing
- `go test ./compile/x/clj -tags slow -run TestClojureCompiler_TwoSum -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685cad40e2fc832087a664927ee30db8