### PR TITLE
Fix TPC-H q20 and extend VM tests

### DIFF
--- a/tests/dataset/tpc-h/out/q20.ir.out
+++ b/tests/dataset/tpc-h/out/q20.ir.out
@@ -1,0 +1,335 @@
+func main (regs=207)
+  // let nation = [
+  Const        r0, [{"n_name": "CANADA", "n_nationkey": 1}, {"n_name": "GERMANY", "n_nationkey": 2}]
+  Move         r1, r0
+  // let supplier = [
+  Const        r2, [{"s_address": "123 Forest Lane", "s_name": "Maple Supply", "s_nationkey": 1, "s_suppkey": 100}, {"s_address": "456 Iron Str", "s_name": "Berlin Metals", "s_nationkey": 2, "s_suppkey": 200}]
+  Move         r3, r2
+  // let part = [
+  Const        r4, [{"p_name": "forest glade bricks", "p_partkey": 10}, {"p_name": "desert sand paper", "p_partkey": 20}]
+  Move         r5, r4
+  // let partsupp = [
+  Const        r6, [{"ps_availqty": 100, "ps_partkey": 10, "ps_suppkey": 100}, {"ps_availqty": 30, "ps_partkey": 20, "ps_suppkey": 200}]
+  Move         r7, r6
+  // let lineitem = [
+  Const        r8, [{"l_partkey": 10, "l_quantity": 100, "l_shipdate": "1994-05-15", "l_suppkey": 100}, {"l_partkey": 10, "l_quantity": 50, "l_shipdate": "1995-01-01", "l_suppkey": 100}]
+  Move         r9, r8
+  // let prefix = "forest"
+  Const        r10, "forest"
+  Move         r11, r10
+  // from l in lineitem
+  Const        r12, []
+  IterPrep     r13, r9
+  Len          r14, r13
+  Const        r15, 0
+  MakeMap      r16, 0, r0
+  Const        r17, []
+L4:
+  Less         r18, r15, r14
+  JumpIfFalse  r18, L0
+  Index        r19, r13, r15
+  Move         r20, r19
+  // where l.l_shipdate >= "1994-01-01" && l.l_shipdate < "1995-01-01"
+  Const        r21, "l_shipdate"
+  Index        r22, r20, r21
+  Const        r23, "1994-01-01"
+  LessEq       r24, r23, r22
+  Move         r25, r24
+  JumpIfFalse  r25, L1
+  Const        r26, "l_shipdate"
+  Index        r27, r20, r26
+  Move         r25, r27
+L1:
+  Const        r28, "1995-01-01"
+  Less         r29, r25, r28
+  JumpIfFalse  r29, L2
+  // group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
+  Const        r30, "partkey"
+  Const        r31, "l_partkey"
+  Index        r32, r20, r31
+  Const        r33, "suppkey"
+  Const        r34, "l_suppkey"
+  Index        r35, r20, r34
+  Move         r36, r30
+  Move         r37, r32
+  Move         r38, r33
+  Move         r39, r35
+  MakeMap      r40, 2, r36
+  Str          r41, r40
+  In           r42, r41, r16
+  JumpIfTrue   r42, L3
+  // from l in lineitem
+  Const        r43, []
+  Const        r44, "__group__"
+  Const        r45, true
+  Const        r46, "key"
+  // group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
+  Move         r47, r40
+  // from l in lineitem
+  Const        r48, "items"
+  Move         r49, r43
+  MakeMap      r50, 3, r44
+  SetIndex     r16, r41, r50
+  Append       r51, r17, r50
+  Move         r17, r51
+L3:
+  Const        r52, "items"
+  Index        r53, r16, r41
+  Index        r54, r53, r52
+  Append       r55, r54, r19
+  SetIndex     r53, r52, r55
+L2:
+  Const        r56, 1
+  Add          r57, r15, r56
+  Move         r15, r57
+  Jump         L4
+L0:
+  Const        r58, 0
+  Len          r59, r17
+L8:
+  Less         r60, r58, r59
+  JumpIfFalse  r60, L5
+  Index        r61, r17, r58
+  Move         r62, r61
+  // partkey: g.key.partkey,
+  Const        r63, "partkey"
+  Const        r64, "key"
+  Index        r65, r62, r64
+  Const        r66, "partkey"
+  Index        r67, r65, r66
+  // suppkey: g.key.suppkey,
+  Const        r68, "suppkey"
+  Const        r69, "key"
+  Index        r70, r62, r69
+  Const        r71, "suppkey"
+  Index        r72, r70, r71
+  // qty: sum(from x in g select x.l_quantity)
+  Const        r73, "qty"
+  Const        r74, []
+  IterPrep     r75, r62
+  Len          r76, r75
+  Const        r77, 0
+L7:
+  Less         r78, r77, r76
+  JumpIfFalse  r78, L6
+  Index        r79, r75, r77
+  Move         r80, r79
+  Const        r81, "l_quantity"
+  Index        r82, r80, r81
+  Append       r83, r74, r82
+  Move         r74, r83
+  Const        r84, 1
+  Add          r85, r77, r84
+  Move         r77, r85
+  Jump         L7
+L6:
+  Sum          r86, r74
+  // partkey: g.key.partkey,
+  Move         r87, r63
+  Move         r88, r67
+  // suppkey: g.key.suppkey,
+  Move         r89, r68
+  Move         r90, r72
+  // qty: sum(from x in g select x.l_quantity)
+  Move         r91, r73
+  Move         r92, r86
+  // select {
+  MakeMap      r93, 3, r87
+  // from l in lineitem
+  Append       r94, r12, r93
+  Move         r12, r94
+  Const        r95, 1
+  Add          r96, r58, r95
+  Move         r58, r96
+  Jump         L8
+L5:
+  // let shipped_94 =
+  Move         r97, r12
+  // from ps in partsupp
+  Const        r98, []
+  IterPrep     r99, r7
+  Len          r100, r99
+  Const        r101, 0
+L17:
+  Less         r102, r101, r100
+  JumpIfFalse  r102, L9
+  Index        r103, r99, r101
+  Move         r104, r103
+  // join p in part on ps.ps_partkey == p.p_partkey
+  IterPrep     r105, r5
+  Len          r106, r105
+  Const        r107, 0
+L16:
+  Less         r108, r107, r106
+  JumpIfFalse  r108, L10
+  Index        r109, r105, r107
+  Move         r110, r109
+  Const        r111, "ps_partkey"
+  Index        r112, r104, r111
+  Const        r113, "p_partkey"
+  Index        r114, r110, r113
+  Equal        r115, r112, r114
+  JumpIfFalse  r115, L11
+  // join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
+  IterPrep     r116, r97
+  Len          r117, r116
+  Const        r118, 0
+L15:
+  Less         r119, r118, r117
+  JumpIfFalse  r119, L11
+  Index        r120, r116, r118
+  Move         r121, r120
+  Const        r122, "ps_partkey"
+  Index        r123, r104, r122
+  Const        r124, "partkey"
+  Index        r125, r121, r124
+  Equal        r126, r123, r125
+  Move         r127, r126
+  JumpIfFalse  r127, L12
+  Const        r128, "ps_suppkey"
+  Index        r129, r104, r128
+  Move         r127, r129
+L12:
+  Const        r130, "suppkey"
+  Index        r131, r121, r130
+  Equal        r132, r127, r131
+  JumpIfFalse  r132, L13
+  // where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
+  Const        r133, "p_name"
+  Index        r134, r110, r133
+  Const        r135, 0
+  Const        r136, 6
+  Slice        r137, r134, r135, r136
+  Equal        r138, r137, r11
+  Move         r139, r138
+  JumpIfFalse  r139, L14
+  Const        r140, "ps_availqty"
+  Index        r141, r104, r140
+  Move         r139, r141
+L14:
+  Const        r142, 0.5
+  Const        r143, "qty"
+  Index        r144, r121, r143
+  MulFloat     r145, r142, r144
+  LessFloat    r146, r145, r139
+  JumpIfFalse  r146, L13
+  // select ps.ps_suppkey
+  Const        r147, "ps_suppkey"
+  Index        r148, r104, r147
+  // from ps in partsupp
+  Append       r149, r98, r148
+  Move         r98, r149
+L13:
+  // join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
+  Const        r150, 1
+  Add          r151, r118, r150
+  Move         r118, r151
+  Jump         L15
+L11:
+  // join p in part on ps.ps_partkey == p.p_partkey
+  Const        r152, 1
+  Add          r153, r107, r152
+  Move         r107, r153
+  Jump         L16
+L10:
+  // from ps in partsupp
+  Const        r154, 1
+  Add          r155, r101, r154
+  Move         r101, r155
+  Jump         L17
+L9:
+  // let target_partkeys =
+  Move         r156, r98
+  // from s in supplier
+  Const        r157, []
+  IterPrep     r158, r3
+  Len          r159, r158
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  IterPrep     r160, r1
+  Len          r161, r160
+  // from s in supplier
+  Const        r162, 0
+L23:
+  Less         r163, r162, r159
+  JumpIfFalse  r163, L18
+  Index        r164, r158, r162
+  Move         r121, r164
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r165, 0
+L22:
+  Less         r166, r165, r161
+  JumpIfFalse  r166, L19
+  Index        r167, r160, r165
+  Move         r168, r167
+  Const        r169, "n_nationkey"
+  Index        r170, r168, r169
+  Const        r171, "s_nationkey"
+  Index        r172, r121, r171
+  Equal        r173, r170, r172
+  JumpIfFalse  r173, L20
+  // where s.s_suppkey in target_partkeys && n.n_name == "CANADA"
+  Const        r174, "s_suppkey"
+  Index        r175, r121, r174
+  In           r176, r175, r156
+  Move         r177, r176
+  JumpIfFalse  r177, L21
+  Const        r178, "n_name"
+  Index        r179, r168, r178
+  Move         r177, r179
+L21:
+  Const        r180, "CANADA"
+  Equal        r181, r177, r180
+  JumpIfFalse  r181, L20
+  // s_name: s.s_name,
+  Const        r182, "s_name"
+  Const        r183, "s_name"
+  Index        r184, r121, r183
+  // s_address: s.s_address
+  Const        r185, "s_address"
+  Const        r186, "s_address"
+  Index        r187, r121, r186
+  // s_name: s.s_name,
+  Move         r188, r182
+  Move         r189, r184
+  // s_address: s.s_address
+  Move         r190, r185
+  Move         r191, r187
+  // select {
+  MakeMap      r192, 2, r188
+  // order by s.s_name
+  Const        r193, "s_name"
+  Index        r194, r121, r193
+  Move         r195, r194
+  // from s in supplier
+  Move         r196, r192
+  MakeList     r197, 2, r195
+  Append       r198, r157, r197
+  Move         r157, r198
+L20:
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r199, 1
+  Add          r200, r165, r199
+  Move         r165, r200
+  Jump         L22
+L19:
+  // from s in supplier
+  Const        r201, 1
+  Add          r202, r162, r201
+  Move         r162, r202
+  Jump         L23
+L18:
+  // order by s.s_name
+  Sort         203,157,0,0
+  // from s in supplier
+  Move         r157, r203
+  // let result =
+  Move         r204, r157
+  // json(result)
+  JSON         r204
+  // expect result == [
+  Const        r205, [{"s_address": "123 Forest Lane", "s_name": "Maple Supply"}]
+  Equal        r206, r204, r205
+  Expect       r206
+  Return       r0
+
+

--- a/tests/dataset/tpc-h/out/q20.out
+++ b/tests/dataset/tpc-h/out/q20.out
@@ -1,0 +1,1 @@
+[{"s_address":"123 Forest Lane","s_name":"Maple Supply"}]

--- a/tests/dataset/tpc-h/q20.mochi
+++ b/tests/dataset/tpc-h/q20.mochi
@@ -49,22 +49,21 @@ let target_partkeys =
   from ps in partsupp
   join p in part on ps.ps_partkey == p.p_partkey
   join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
-  // check prefix using slicing since startsWith isn't available
-  where p.p_name[0:len(prefix)] == prefix && ps.ps_availqty > 0.5 * s.qty
+  // check prefix using substring to match prefix
+  where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
   select ps.ps_suppkey
 
 let result =
   from s in supplier
-  where s.s_suppkey in target_partkeys
   join n in nation on n.n_nationkey == s.s_nationkey
-  where n.n_name == "CANADA"
+  where s.s_suppkey in target_partkeys && n.n_name == "CANADA"
   order by s.s_name
   select {
     s_name: s.s_name,
     s_address: s.s_address
   }
 
-print result
+json(result)
 
 test "Q20 returns suppliers from CANADA with forest part stock > 50% of 1994 shipments" {
   expect result == [

--- a/tests/vm/valid/in_operator_extended.ir.out
+++ b/tests/vm/valid/in_operator_extended.ir.out
@@ -1,0 +1,61 @@
+func main (regs=33)
+  // let xs = [1, 2, 3]
+  Const        r0, [1, 2, 3]
+  Move         r1, r0
+  // let ys = from x in xs where x % 2 == 1 select x
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
+L2:
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r7, r3, r5
+  Move         r8, r7
+  Const        r9, 2
+  Mod          r10, r8, r9
+  Const        r11, 1
+  Equal        r12, r10, r11
+  JumpIfFalse  r12, L1
+  Append       r13, r2, r8
+  Move         r2, r13
+L1:
+  Const        r14, 1
+  Add          r15, r5, r14
+  Move         r5, r15
+  Jump         L2
+L0:
+  Move         r16, r2
+  // print(1 in ys)
+  Const        r17, 1
+  In           r18, r17, r16
+  Print        r18
+  // print(2 in ys)
+  Const        r19, 2
+  In           r20, r19, r16
+  Print        r20
+  // let m = {a: 1}
+  Const        r21, {"a": 1}
+  Move         r22, r21
+  // print("a" in m)
+  Const        r23, "a"
+  In           r24, r23, r22
+  Print        r24
+  // print("b" in m)
+  Const        r25, "b"
+  In           r26, r25, r22
+  Print        r26
+  // let s = "hello"
+  Const        r27, "hello"
+  Move         r28, r27
+  // print("ell" in s)
+  Const        r29, "ell"
+  In           r30, r29, r28
+  Print        r30
+  // print("foo" in s)
+  Const        r31, "foo"
+  In           r32, r31, r28
+  Print        r32
+  Return       r0
+
+

--- a/tests/vm/valid/in_operator_extended.mochi
+++ b/tests/vm/valid/in_operator_extended.mochi
@@ -1,0 +1,12 @@
+let xs = [1, 2, 3]
+let ys = from x in xs where x % 2 == 1 select x
+print(1 in ys)
+print(2 in ys)
+
+let m = {a: 1}
+print("a" in m)
+print("b" in m)
+
+let s = "hello"
+print("ell" in s)
+print("foo" in s)

--- a/tests/vm/valid/in_operator_extended.out
+++ b/tests/vm/valid/in_operator_extended.out
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false


### PR DESCRIPTION
## Summary
- fix parsing issues in TPC-H query 20 example
- produce JSON output for q20
- add golden output for q20
- add new VM test exercising `in` operator on lists, maps and strings

## Testing
- `go test -tags slow ./tests/vm -run TestVM_ValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685cabb7d3448320af3187349ba58ac3