### PR TITLE
Add Ruby compiler support for tpc-h/q1

### DIFF
--- a/tests/compiler/rb/q1.mochi
+++ b/tests/compiler/rb/q1.mochi
@@ -1,0 +1,68 @@
+let lineitem = [
+  {
+    l_quantity: 17,
+    l_extendedprice: 1000.0,
+    l_discount: 0.05,
+    l_tax: 0.07,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-08-01"
+  },
+  {
+    l_quantity: 36,
+    l_extendedprice: 2000.0,
+    l_discount: 0.10,
+    l_tax: 0.05,
+    l_returnflag: "N",
+    l_linestatus: "O",
+    l_shipdate: "1998-09-01"
+  },
+  {
+    l_quantity: 25,
+    l_extendedprice: 1500.0,
+    l_discount: 0.00,
+    l_tax: 0.08,
+    l_returnflag: "R",
+    l_linestatus: "F",
+    l_shipdate: "1998-09-03"  // excluded
+  }
+]
+
+let result =
+  from row in lineitem
+  where row.l_shipdate <= "1998-09-02"
+  group by {
+    returnflag: row.l_returnflag,
+    linestatus: row.l_linestatus
+  } into g
+  select {
+    returnflag: g.key.returnflag,
+    linestatus: g.key.linestatus,
+    sum_qty: sum(from x in g select x.l_quantity),
+    sum_base_price: sum(from x in g select x.l_extendedprice),
+    sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+    sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+    avg_qty: avg(from x in g select x.l_quantity),
+    avg_price: avg(from x in g select x.l_extendedprice),
+    avg_disc: avg(from x in g select x.l_discount),
+    count_order: count(g)
+  }
+
+json(result)
+
+test "Q1 aggregates revenue and quantity by returnflag + linestatus" {
+  expect result == [
+    {
+      returnflag: "N",
+      linestatus: "O",
+      sum_qty: 53,
+      sum_base_price: 3000,
+      sum_disc_price: 950.0 + 1800.0,               // 2750.0
+      sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
+      avg_qty: 26.5,
+      avg_price: 1500,
+      avg_disc: 0.07500000000000001,
+      count_order: 2
+    }
+  ]
+}

--- a/tests/compiler/rb/q1.out
+++ b/tests/compiler/rb/q1.out
@@ -1,0 +1,1 @@
+[{"returnflag":"N","linestatus":"O","sum_qty":53.0,"sum_base_price":3000.0,"sum_disc_price":2750.0,"sum_charge":2906.5,"avg_qty":26.5,"avg_price":1500.0,"avg_disc":0.07500000000000001,"count_order":2}]

--- a/tests/compiler/rb/q1.rb.out
+++ b/tests/compiler/rb/q1.rb.out
@@ -1,0 +1,193 @@
+require 'ostruct'
+
+class MGroup
+  include Enumerable
+  attr_accessor :key, :Items
+  def initialize(k)
+    @key = k
+    @Items = []
+  end
+  def length
+    @Items.length
+  end
+  def each(&block)
+    @Items.each(&block)
+  end
+end
+def _group_by(src, keyfn)
+grouped = src.group_by do |it|
+  if it.is_a?(Array)
+    keyfn.call(*it)
+  else
+    keyfn.call(it)
+  end
+end
+grouped.map do |k, items|
+g = MGroup.new(k)
+items.each do |it|
+  if it.is_a?(Array) && it.length == 1
+    g.Items << it[0]
+  else
+    g.Items << it
+  end
+end
+g
+end
+end
+def _json(v)
+  require 'json'
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+def _query(src, joins, opts)
+  where_fn = opts['where']
+  items = []
+  if joins.empty?
+    src.each do |v|
+      row = [v]
+      next if where_fn && !where_fn.call(*row)
+      items << row
+    end
+  else
+    items = src.map { |v| [v] }
+    joins.each_with_index do |j, idx|
+      joined = []
+      jitems = j['items']
+      on = j['on']
+      left = j['left']
+      right = j['right']
+      last = idx == joins.length - 1
+      if right && left
+        matched = Array.new(jitems.length, false)
+        items.each do |l|
+          m = false
+          jitems.each_with_index do |r, ri|
+            keep = true
+            keep = on.call(*l, r) if on
+            next unless keep
+            m = true
+            matched[ri] = true
+            row = l + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+          row = l + [nil]
+          if left && !m
+            if last && where_fn && !where_fn.call(*row)
+              # skip
+            else
+              joined << row
+            end
+          end
+        end
+        jitems.each_with_index do |r, ri|
+          next if matched[ri]
+          _undef = Array.new(items[0]&.length || 0, nil)
+          row = _undef + [r]
+          if last && where_fn && !where_fn.call(*row)
+            next
+          end
+          joined << row
+        end
+      elsif right
+        jitems.each do |r|
+          m = false
+          items.each do |l|
+            keep = true
+            keep = on.call(*l, r) if on
+            next unless keep
+            m = true
+            row = l + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+          unless m
+            _undef = Array.new(items[0]&.length || 0, nil)
+            row = _undef + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+        end
+      else
+        items.each do |l|
+          m = false
+          jitems.each do |r|
+            keep = true
+            keep = on.call(*l, r) if on
+            next unless keep
+            m = true
+            row = l + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+          if left && !m
+            row = l + [nil]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+        end
+      end
+      items = joined
+    end
+  end
+  if opts['sortKey']
+    items = items.map { |it| [it, opts['sortKey'].call(*it)] }
+    items.sort_by! { |p| p[1] }
+    items.map!(&:first)
+  end
+  if opts.key?('skip')
+    n = opts['skip']
+    items = n < items.length ? items[n..-1] : []
+  end
+  if opts.key?('take')
+    n = opts['take']
+    items = n < items.length ? items[0...n] : items
+  end
+  res = []
+  items.each { |r| res << opts['select'].call(*r) }
+  res
+end
+def _sum(v)
+  list = nil
+  if v.is_a?(MGroup)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  s = 0.0
+  list.each { |n| s += n.to_f }
+  s
+end
+
+lineitem = [OpenStruct.new(l_quantity: 17, l_extendedprice: 1000.0, l_discount: 0.05, l_tax: 0.07, l_returnflag: "N", l_linestatus: "O", l_shipdate: "1998-08-01"), OpenStruct.new(l_quantity: 36, l_extendedprice: 2000.0, l_discount: 0.1, l_tax: 0.05, l_returnflag: "N", l_linestatus: "O", l_shipdate: "1998-09-01"), OpenStruct.new(l_quantity: 25, l_extendedprice: 1500.0, l_discount: 0.0, l_tax: 0.08, l_returnflag: "R", l_linestatus: "F", l_shipdate: "1998-09-03")]
+result = (begin
+	src = lineitem
+	_rows = _query(src, [
+	], { 'select' => ->(row){ [row] }, 'where' => ->(row){ (row.l_shipdate <= "1998-09-02") } })
+	_groups = _group_by(_rows, ->(row){ OpenStruct.new(returnflag: row.l_returnflag, linestatus: row.l_linestatus) })
+	_res = []
+	for g in _groups
+		_res << OpenStruct.new(returnflag: g.key.returnflag, linestatus: g.key.linestatus, sum_qty: _sum(((g)).map { |x| x.l_quantity }), sum_base_price: _sum(((g)).map { |x| x.l_extendedprice }), sum_disc_price: _sum(((g)).map { |x| (x.l_extendedprice * ((1 - x.l_discount))) }), sum_charge: _sum(((g)).map { |x| ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))) }), avg_qty: ((((g)).map { |x| x.l_quantity }).length > 0 ? (((g)).map { |x| x.l_quantity }).sum(0.0) / (((g)).map { |x| x.l_quantity }).length : 0), avg_price: ((((g)).map { |x| x.l_extendedprice }).length > 0 ? (((g)).map { |x| x.l_extendedprice }).sum(0.0) / (((g)).map { |x| x.l_extendedprice }).length : 0), avg_disc: ((((g)).map { |x| x.l_discount }).length > 0 ? (((g)).map { |x| x.l_discount }).sum(0.0) / (((g)).map { |x| x.l_discount }).length : 0), count_order: (g).length)
+	end
+	_res
+end)
+_json(result)
+raise "expect failed" unless (result == [OpenStruct.new(returnflag: "N", linestatus: "O", sum_qty: 53, sum_base_price: 3000, sum_disc_price: (950.0 + 1800.0), sum_charge: (((950.0 * 1.07)) + ((1800.0 * 1.05))), avg_qty: 26.5, avg_price: 1500, avg_disc: 0.07500000000000001, count_order: 2)])


### PR DESCRIPTION
## Summary
- enhance Ruby runtime with JSON and sum helpers
- make groups Enumerable and fix group_by
- support built-in `sum` and `json` in Ruby backend
- compile test blocks inline
- add tpc-h q1 golden files for Ruby compiler

## Testing
- `go test ./compile/x/rb -tags slow -run TestRBCompiler_SubsetPrograms/q1 -v`
- `go test ./compile/x/rb -tags slow -run TestRBCompiler_SubsetPrograms -v`

------
https://chatgpt.com/codex/tasks/task_e_685cad61483c83208783c27d3e573529