### PR TITLE
Move Java TPCH tasks to compiler directory

### DIFF
--- a/compile/x/java/TASKS.md
+++ b/compile/x/java/TASKS.md
@@ -1,0 +1,19 @@
+# Java Backend TODOs for TPC-H Q1
+
+The current Java compiler backend cannot successfully compile `tests/dataset/tpc-h/q1.mochi`.
+Below is a list of tasks identified while attempting to add support:
+
+1. **Implement numeric aggregate built-ins**
+   - Add generic implementations of `sum`, `avg` and `count` that operate on
+     `java.util.List` or Java arrays.
+   - Update expression lowering to emit calls to these helpers.
+2. **Fix dataset query code generation**
+   - Generated Java for dataset queries ends with incomplete class definitions.
+     Investigate `_query` helper emission for missing closing braces.
+3. **Support group-by aggregates**
+   - Ensure `_group_by` and related helpers work with aggregate functions inside
+     the `select` clause.
+4. **Add golden tests**
+   - Once compilation succeeds, add `tpch_q1.mochi` to `tests/compiler/java` with
+     expected Java output and runtime results.
+


### PR DESCRIPTION
## Summary
- relocate TODO list for Java TPCH support into `compile/x/java/TASKS.md`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cad53ce4083209151f356e1e1edaa