### PR TITLE
Add local-scope test execution for C++ compiler

### DIFF
--- a/tests/compiler/valid/test_block.cpp.out
+++ b/tests/compiler/valid/test_block.cpp.out
@@ -1,13 +1,12 @@
 #include <bits/stdc++.h>
 using namespace std;
 
-static void test_addition_works() {
-        int x = (1 + 2);
-        if (!((x == 3))) { std::cerr << "expect failed\n"; exit(1); }
-}
-
 int main() {
-        std::cout << (string("ok")) << std::endl;
-        test_addition_works();
-        return 0;
+	std::cout << (string("ok")) << std::endl;
+	auto test_addition_works = [&]() {
+		auto x = 1 + 2;
+		if (!(x == 3)) { std::cerr << "expect failed\n"; exit(1); }
+	};
+	test_addition_works();
+	return 0;
 }


### PR DESCRIPTION
## Summary
- allow test blocks to run inside `main` for the C++ backend so they can access top-level variables
- update C++ golden output for `test_block`

## Testing
- `go test ./compile/x/cpp -tags slow -run TestCPPCompiler_GoldenOutput/test_block -count=1`
- `go test ./compile/x/cpp -tags slow -run TestCPPCompiler_GoldenOutput/tpch_q1 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685cad44845c83209e9a05178f59c307