### PR TITLE
Enable TS compiler groups

### DIFF
--- a/compile/ts/runtime.go
+++ b/compile/ts/runtime.go
@@ -70,6 +70,20 @@ const (
 		"  return sum;\n" +
 		"}\n"
 
+	helperJSON = "function _json(v: any): string {\n" +
+		"  function _sort(x: any): any {\n" +
+		"    if (Array.isArray(x)) return x.map(_sort);\n" +
+		"    if (x && typeof x === 'object') {\n" +
+		"      const keys = Object.keys(x).sort();\n" +
+		"      const o: any = {};\n" +
+		"      for (const k of keys) o[k] = _sort(x[k]);\n" +
+		"      return o;\n" +
+		"    }\n" +
+		"    return x;\n" +
+		"  }\n" +
+		"  return JSON.stringify(_sort(v));\n" +
+		"}\n"
+
 	helperMin = "function _min(v: any): number {\n" +
 		"  let list: any[] | null = null;\n" +
 		"  if (Array.isArray(v)) list = v;\n" +
@@ -451,6 +465,7 @@ var helperMap = map[string]string{
 	"_agent":       helperAgent,
 	"_query":       helperQuery,
 	"_dataset":     helperDataset,
+	"_json":        helperJSON,
 }
 
 func (c *Compiler) use(name string) {

--- a/tests/compiler/ts/tpch_q1.ts.out
+++ b/tests/compiler/ts/tpch_q1.ts.out
@@ -6,6 +6,7 @@ function test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus(): v
 
 function main(): void {
 	let lineitem: Array<Record<string, any>> = [{"l_quantity": 17, "l_extendedprice": 1000, "l_discount": 0.05, "l_tax": 0.07, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-08-01"}, {"l_quantity": 36, "l_extendedprice": 2000, "l_discount": 0.1, "l_tax": 0.05, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-09-01"}, {"l_quantity": 25, "l_extendedprice": 1500, "l_discount": 0, "l_tax": 0.08, "l_returnflag": "R", "l_linestatus": "F", "l_shipdate": "1998-09-03"}]
+	;(globalThis as any).lineitem = lineitem
 	let result: Array<Record<string, any>> = (() => {
 	const _src = lineitem;
 	const _map = new Map<string, any>();
@@ -23,49 +24,49 @@ function main(): void {
 	const _res = [];
 	for (const g of _groups) {
 		_res.push({"returnflag": g.key.returnflag, "linestatus": g.key.linestatus, "sum_qty": _sum((() => {
-	const _src = g;
+	const _src = g.items;
 	const _res = [];
 	for (const x of _src) {
 		_res.push(x.l_quantity)
 	}
 	return _res;
 })()), "sum_base_price": _sum((() => {
-	const _src = g;
+	const _src = g.items;
 	const _res = [];
 	for (const x of _src) {
 		_res.push(x.l_extendedprice)
 	}
 	return _res;
 })()), "sum_disc_price": _sum((() => {
-	const _src = g;
+	const _src = g.items;
 	const _res = [];
 	for (const x of _src) {
 		_res.push((x.l_extendedprice * ((1 - x.l_discount))))
 	}
 	return _res;
 })()), "sum_charge": _sum((() => {
-	const _src = g;
+	const _src = g.items;
 	const _res = [];
 	for (const x of _src) {
 		_res.push(((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))))
 	}
 	return _res;
 })()), "avg_qty": _avg((() => {
-	const _src = g;
+	const _src = g.items;
 	const _res = [];
 	for (const x of _src) {
 		_res.push(x.l_quantity)
 	}
 	return _res;
 })()), "avg_price": _avg((() => {
-	const _src = g;
+	const _src = g.items;
 	const _res = [];
 	for (const x of _src) {
 		_res.push(x.l_extendedprice)
 	}
 	return _res;
 })()), "avg_disc": _avg((() => {
-	const _src = g;
+	const _src = g.items;
 	const _res = [];
 	for (const x of _src) {
 		_res.push(x.l_discount)
@@ -75,7 +76,8 @@ function main(): void {
 	}
 	return _res;
 })()
-	console.log(JSON.stringify(result))
+	;(globalThis as any).result = result
+	console.log(_json(result))
 	test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus()
 }
 function _avg(v: any): number {
@@ -115,6 +117,20 @@ function _equal(a: any, b: any): boolean {
   return a === b;
 }
 
+function _json(v: any): string {
+  function _sort(x: any): any {
+    if (Array.isArray(x)) return x.map(_sort);
+    if (x && typeof x === 'object') {
+      const keys = Object.keys(x).sort();
+      const o: any = {};
+      for (const k of keys) o[k] = _sort(x[k]);
+      return o;
+    }
+    return x;
+  }
+  return JSON.stringify(_sort(v));
+}
+
 function _sum(v: any): number {
   let list: any[] | null = null;
   if (Array.isArray(v)) list = v;
@@ -129,4 +145,5 @@ function _sum(v: any): number {
 }
 
 main()
+
 


### PR DESCRIPTION
## Summary
- support iterating over groups in the TypeScript compiler
- expose variables to test blocks via `globalThis`
- ensure JSON output fields have stable order

## Testing
- `go test ./compile/ts -run TestTSCompiler_SubsetPrograms/tpch_q1 -tags slow -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_685cad0c237c8320a1bf3e7a9fb21783