### PR TITLE
Refresh TPCH example outputs

### DIFF
--- a/tests/dataset/tpc-h/TASKS.md
+++ b/tests/dataset/tpc-h/TASKS.md
@@ -1,0 +1,27 @@
+# TPCH Example Issues
+
+The TPCH example programs were re-executed and several files failed to run correctly.
+The following tasks outline the work required to restore passing results.
+
+## q8.mochi
+- Execution fails with `Expect condition failed` after computing the result.
+- Investigate floating point rounding or query logic causing the test to fail.
+- Update the test expectations or query so `print result` matches the expected value.
+
+## q13.mochi
+- Type checker reports `undefined variable: from` around the `count` query.
+- The query inside `count` is split across lines. Wrap the subquery in parentheses
+  (`count(from ... select ...)`) or update the parser to handle the newline.
+
+## q21.mochi
+- Running the program prints the result but the final expectation fails.
+- Verify the dataset and the `exists` subquery logic to ensure `numwait` is
+  computed as expected.
+
+## q22.mochi
+- Parsing fails near the `avg` expression in the `avg_balance` definition.
+- Ensure the query is written as `avg(from ... select ...)` or modify the parser
+  to allow a newline after the opening parenthesis.
+
+Addressing these issues will allow all TPCH examples to run without errors and
+regenerate stable `.out` and `.ir.out` files.

--- a/tests/dataset/tpc-h/out/q1.ir.out
+++ b/tests/dataset/tpc-h/out/q1.ir.out
@@ -369,4 +369,3 @@ L4:
   Equal        r243, r191, r242
   Expect       r243
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q10.ir.out
+++ b/tests/dataset/tpc-h/out/q10.ir.out
@@ -420,4 +420,3 @@ L12:
   Equal        r282, r243, r281
   Expect       r282
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q11.ir.out
+++ b/tests/dataset/tpc-h/out/q11.ir.out
@@ -262,4 +262,3 @@ L16:
   Equal        r158, r156, r157
   Expect       r158
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q11.out
+++ b/tests/dataset/tpc-h/out/q11.out
@@ -1,2 +1,1 @@
 [{"ps_partkey":1000,"value":2000},{"ps_partkey":2000,"value":50}]
-

--- a/tests/dataset/tpc-h/out/q12.ir.out
+++ b/tests/dataset/tpc-h/out/q12.ir.out
@@ -245,4 +245,3 @@ L10:
   Equal        r144, r142, r143
   Expect       r144
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q14.ir.out
+++ b/tests/dataset/tpc-h/out/q14.ir.out
@@ -163,4 +163,3 @@ L9:
   EqualFloat   r102, r89, r101
   Expect       r102
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q15.ir.out
+++ b/tests/dataset/tpc-h/out/q15.ir.out
@@ -287,4 +287,3 @@ L11:
   Equal        r180, r151, r179
   Expect       r180
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q16.ir.out
+++ b/tests/dataset/tpc-h/out/q16.ir.out
@@ -163,4 +163,3 @@ L7:
   Equal        r91, r89, r90
   Expect       r91
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q17.ir.out
+++ b/tests/dataset/tpc-h/out/q17.ir.out
@@ -135,4 +135,3 @@ L0:
   EqualFloat   r73, r68, r72
   Expect       r73
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q18.ir.out
+++ b/tests/dataset/tpc-h/out/q18.ir.out
@@ -363,4 +363,3 @@ L10:
   Equal        r246, r244, r245
   Expect       r246
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q19.ir.out
+++ b/tests/dataset/tpc-h/out/q19.ir.out
@@ -258,4 +258,3 @@ L0:
   EqualFloat   r136, r134, r135
   Expect       r136
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q2.ir.out
+++ b/tests/dataset/tpc-h/out/q2.ir.out
@@ -363,4 +363,3 @@ L23:
   Equal        r219, r217, r218
   Expect       r219
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q20.ir.out
+++ b/tests/dataset/tpc-h/out/q20.ir.out
@@ -331,5 +331,3 @@ L18:
   Equal        r206, r204, r205
   Expect       r206
   Return       r0
-
-

--- a/tests/dataset/tpc-h/out/q21.ir.out
+++ b/tests/dataset/tpc-h/out/q21.ir.out
@@ -262,4 +262,3 @@ L18:
   Equal        r161, r158, r160
   Expect       r161
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q21.out
+++ b/tests/dataset/tpc-h/out/q21.out
@@ -1,3 +1,3 @@
 call graph: main
 stack trace:
-  main:68
+  main:60

--- a/tests/dataset/tpc-h/out/q3.ir.out
+++ b/tests/dataset/tpc-h/out/q3.ir.out
@@ -371,4 +371,3 @@ L17:
   Equal        r234, r210, r233
   Expect       r234
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q4.ir.out
+++ b/tests/dataset/tpc-h/out/q4.ir.out
@@ -195,4 +195,3 @@ L14:
   Equal        r111, r109, r110
   Expect       r111
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q5.ir.out
+++ b/tests/dataset/tpc-h/out/q5.ir.out
@@ -346,4 +346,3 @@ L21:
   Equal        r209, r207, r208
   Expect       r209
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q6.ir.out
+++ b/tests/dataset/tpc-h/out/q6.ir.out
@@ -94,4 +94,3 @@ L0:
   EqualFloat   r50, r42, r49
   Expect       r50
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q7.ir.out
+++ b/tests/dataset/tpc-h/out/q7.ir.out
@@ -357,4 +357,3 @@ L19:
   Equal        r232, r230, r231
   Expect       r232
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q8.ir.out
+++ b/tests/dataset/tpc-h/out/q8.ir.out
@@ -396,4 +396,3 @@ L19:
   Equal        r259, r236, r258
   Expect       r259
   Return       r0
-

--- a/tests/dataset/tpc-h/out/q9.ir.out
+++ b/tests/dataset/tpc-h/out/q9.ir.out
@@ -387,4 +387,3 @@ L17:
   Equal        r257, r232, r256
   Expect       r257
   Return       r0
-

--- a/tools/update_tpch.go
+++ b/tools/update_tpch.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"mochi/parser"
+	mod "mochi/runtime/mod"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("go.mod not found")
+}
+
+func main() {
+	root, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	dir := filepath.Join(root, "tests/dataset/tpc-h")
+	pattern := filepath.Join(dir, "*.mochi")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		fmt.Fprintln(os.Stderr, "no source files")
+		os.Exit(1)
+	}
+
+	outDir := filepath.Join(dir, "out")
+	os.MkdirAll(outDir, 0755)
+
+	for _, src := range files {
+		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		outPath := filepath.Join(outDir, base+".out")
+		irPath := filepath.Join(outDir, base+".ir.out")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: parse error: %v\n", src, err)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "%s: type error: %v\n", src, errs[0])
+			continue
+		}
+		modRoot, errRoot := mod.FindRoot(filepath.Dir(src))
+		if errRoot != nil {
+			modRoot = filepath.Dir(src)
+		}
+		os.Setenv("MOCHI_ROOT", modRoot)
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: compile error: %v\n", src, err)
+			continue
+		}
+
+		var buf bytes.Buffer
+		m := vm.New(p, &buf)
+		runErr := m.Run()
+		outBytes := []byte(strings.TrimSpace(buf.String()))
+		if err := os.WriteFile(outPath, outBytes, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: write out: %v\n", src, err)
+		}
+
+		srcData, err := os.ReadFile(src)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: read src: %v\n", src, err)
+			continue
+		}
+		ir := []byte(strings.TrimSpace(p.Disassemble(string(srcData))))
+		if err := os.WriteFile(irPath, ir, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: write ir: %v\n", src, err)
+		}
+
+		if runErr != nil {
+			fmt.Fprintf(os.Stderr, "%s: run error: %v\n", src, runErr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- regenerate all tpch example outputs with a new helper
- note outstanding issues in tests/dataset/tpc-h/TASKS.md
- provide a tool `update_tpch.go` to reproduce the files

## Testing
- `go test ./tests/vm -tags slow -run TPCH` *(fails: run error: expect condition failed)*

------
https://chatgpt.com/codex/tasks/task_e_685cb9218f7083208f5ffe5838b5cea4