### PR TITLE
Update TPCH tasks and outputs

### DIFF
--- a/tests/dataset/tpc-h/TASKS.md
+++ b/tests/dataset/tpc-h/TASKS.md
@@ -1,7 +1,9 @@
 # TPCH Example Issues
 
-The TPCH example programs were re-executed and several files failed to run correctly.
-The following tasks outline the work required to restore passing results.
+Running `go test -tags slow ./tests/vm -run TestVM_TPCH` shows that several
+queries still fail under the runtime VM.  The items below capture the issues
+that need to be addressed in the VM or query logic so that all TPCH programs
+can execute successfully.
 
 ## q8.mochi
 - Execution fails with `Expect condition failed` after computing the result.
@@ -9,9 +11,8 @@ The following tasks outline the work required to restore passing results.
 - Update the test expectations or query so `print result` matches the expected value.
 
 ## q13.mochi
-- Type checker reports `undefined variable: from` around the `count` query.
-- The query inside `count` is split across lines. Wrap the subquery in parentheses
-  (`count(from ... select ...)`) or update the parser to handle the newline.
+- Query now compiles but the runtime VM fails the final expectation.
+- Investigate the grouping logic to ensure counts match the expected output.
 
 ## q21.mochi
 - Running the program prints the result but the final expectation fails.
@@ -19,9 +20,8 @@ The following tasks outline the work required to restore passing results.
   computed as expected.
 
 ## q22.mochi
-- Parsing fails near the `avg` expression in the `avg_balance` definition.
-- Ensure the query is written as `avg(from ... select ...)` or modify the parser
-  to allow a newline after the opening parenthesis.
+- Parsing still fails around the aggregate and `exists` expression.
+- Review the syntax for aggregate queries and nested `exists` to resolve the error.
 
 Addressing these issues will allow all TPCH examples to run without errors and
 regenerate stable `.out` and `.ir.out` files.

--- a/tests/dataset/tpc-h/out/q13.ir.out
+++ b/tests/dataset/tpc-h/out/q13.ir.out
@@ -1,0 +1,177 @@
+func main (regs=109)
+  // let customer = [
+  Const        r0, [{"c_custkey": 1}, {"c_custkey": 2}, {"c_custkey": 3}]
+  Move         r1, r0
+  // let orders = [
+  Const        r2, [{"o_comment": "fast delivery", "o_custkey": 1, "o_orderkey": 100}, {"o_comment": "no comment", "o_custkey": 1, "o_orderkey": 101}, {"o_comment": "special requests only", "o_custkey": 2, "o_orderkey": 102}]
+  Move         r3, r2
+  // from c in customer
+  Const        r4, []
+  IterPrep     r5, r1
+  Len          r6, r5
+  Const        r7, 0
+L6:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r9, r5, r7
+  Move         r10, r9
+  // c_count: count(
+  Const        r11, "c_count"
+  // from o in orders
+  Const        r12, []
+  IterPrep     r13, r3
+  Len          r14, r13
+  Const        r15, 0
+L5:
+  Less         r16, r15, r14
+  JumpIfFalse  r16, L1
+  Index        r17, r13, r15
+  Move         r18, r17
+  // o.o_custkey == c.c_custkey &&
+  Const        r19, "o_custkey"
+  Index        r20, r18, r19
+  Const        r21, "c_custkey"
+  Index        r22, r10, r21
+  Equal        r23, r20, r22
+  Move         r24, r23
+  JumpIfFalse  r24, L2
+  // (!("special" in o.o_comment)) &&
+  Const        r25, "special"
+  Const        r26, "o_comment"
+  Index        r27, r18, r26
+  In           r28, r25, r27
+  Not          r29, r28
+  // o.o_custkey == c.c_custkey &&
+  Move         r24, r29
+L2:
+  // (!("special" in o.o_comment)) &&
+  Move         r30, r24
+  JumpIfFalse  r30, L3
+  // (!("requests" in o.o_comment))
+  Const        r31, "requests"
+  Const        r32, "o_comment"
+  Index        r33, r18, r32
+  In           r34, r31, r33
+  Not          r35, r34
+  // (!("special" in o.o_comment)) &&
+  Move         r30, r35
+L3:
+  // where (
+  JumpIfFalse  r30, L4
+  // from o in orders
+  Append       r36, r12, r18
+  Move         r12, r36
+L4:
+  Const        r37, 1
+  Add          r38, r15, r37
+  Move         r15, r38
+  Jump         L5
+L1:
+  // c_count: count(
+  Count        r39, r12
+  Move         r40, r11
+  Move         r41, r39
+  // select {
+  MakeMap      r42, 1, r40
+  // from c in customer
+  Append       r43, r4, r42
+  Move         r4, r43
+  Const        r44, 1
+  Add          r45, r7, r44
+  Move         r7, r45
+  Jump         L6
+L0:
+  // let per_customer = (
+  Move         r46, r4
+  // from x in per_customer
+  Const        r47, []
+  IterPrep     r48, r46
+  Len          r49, r48
+  Const        r50, 0
+  MakeMap      r51, 0, r0
+  Const        r52, []
+L9:
+  Less         r53, r50, r49
+  JumpIfFalse  r53, L7
+  Index        r54, r48, r50
+  Move         r55, r54
+  // group by x.c_count into g
+  Const        r56, "c_count"
+  Index        r57, r55, r56
+  Str          r58, r57
+  In           r59, r58, r51
+  JumpIfTrue   r59, L8
+  // from x in per_customer
+  Const        r60, []
+  Const        r61, "__group__"
+  Const        r62, true
+  Const        r63, "key"
+  // group by x.c_count into g
+  Move         r64, r57
+  // from x in per_customer
+  Const        r65, "items"
+  Move         r66, r60
+  MakeMap      r67, 3, r61
+  SetIndex     r51, r58, r67
+  Append       r68, r52, r67
+  Move         r52, r68
+L8:
+  Const        r69, "items"
+  Index        r70, r51, r58
+  Index        r71, r70, r69
+  Append       r72, r71, r54
+  SetIndex     r70, r69, r72
+  Const        r73, 1
+  Add          r74, r50, r73
+  Move         r50, r74
+  Jump         L9
+L7:
+  Const        r75, 0
+  Len          r76, r52
+L11:
+  Less         r77, r75, r76
+  JumpIfFalse  r77, L10
+  Index        r78, r52, r75
+  Move         r79, r78
+  // select { c_count: g.key, custdist: count(g) }
+  Const        r80, "c_count"
+  Const        r81, "key"
+  Index        r82, r79, r81
+  Const        r83, "custdist"
+  Count        r84, r79
+  Move         r85, r80
+  Move         r86, r82
+  Move         r87, r83
+  Move         r88, r84
+  MakeMap      r89, 2, r85
+  // sort by [-count(g), -g.key]
+  Count        r90, r79
+  NegInt       r91, r90
+  Move         r92, r91
+  Const        r93, "key"
+  Index        r94, r79, r93
+  Neg          r95, r94
+  Move         r96, r95
+  MakeList     r97, 2, r92
+  Move         r98, r97
+  // from x in per_customer
+  Move         r99, r89
+  MakeList     r100, 2, r98
+  Append       r101, r47, r100
+  Move         r47, r101
+  Const        r102, 1
+  Add          r103, r75, r102
+  Move         r75, r103
+  Jump         L11
+L10:
+  // sort by [-count(g), -g.key]
+  Sort         104,47,0,0
+  // from x in per_customer
+  Move         r47, r104
+  // let grouped = (
+  Move         r105, r47
+  // expect grouped == [
+  Const        r107, [{"c_count": 2, "custdist": 1}, {"c_count": 0, "custdist": 2}]
+  Equal        r108, r105, r107
+  Expect       r108
+  Return       r0

--- a/tests/dataset/tpc-h/out/q13.out
+++ b/tests/dataset/tpc-h/out/q13.out
@@ -1,0 +1,3 @@
+call graph: main
+stack trace:
+  main:38

--- a/tests/dataset/tpc-h/q13.mochi
+++ b/tests/dataset/tpc-h/q13.mochi
@@ -10,10 +10,10 @@ let orders = [
   { o_orderkey: 102, o_custkey: 2, o_comment: "special requests only" } // excluded
 ]
 
-let per_customer =
+let per_customer = (
   from c in customer
-  let order_count =
-    count(
+  select {
+    c_count: count(
       from o in orders
       where (
         o.o_custkey == c.c_custkey &&
@@ -22,13 +22,15 @@ let per_customer =
       )
       select o
     )
-  select { c_count: order_count }
+  }
+)
 
-let grouped =
+let grouped = (
   from x in per_customer
-  group by x.c_count
-  sort by [-count(), -x.c_count]
-  select { c_count: x.c_count, custdist: count() }
+  group by x.c_count into g
+  sort by [-count(g), -g.key]
+  select { c_count: g.key, custdist: count(g) }
+)
 
 print grouped
 

--- a/tests/dataset/tpc-h/q22.mochi
+++ b/tests/dataset/tpc-h/q22.mochi
@@ -11,30 +11,33 @@ let orders = [
 let valid_codes = ["13", "31", "23", "29", "30", "18", "17"]
 
 let avg_balance =
-  avg(
-    from c in customer
-    where c.c_acctbal > 0.0 and substring(c.c_phone, 0, 2) in valid_codes
-    select c.c_acctbal
-  )
+  avg(from c in customer
+      where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
+      select c.c_acctbal)
 
-let eligible_customers =
+let eligible_customers = (
   from c in customer
-  let cc = substring(c.c_phone, 0, 2)
   where
-    cc in valid_codes and
-    c.c_acctbal > avg_balance and
-    not exists o in orders where o.o_custkey == c.c_custkey
-  select { cntrycode: cc, c_acctbal: c.c_acctbal }
+    substring(c.c_phone, 0, 2) in valid_codes &&
+    c.c_acctbal > avg_balance &&
+    (!exists(
+      from o in orders
+      where o.o_custkey == c.c_custkey
+      select o
+    ))
+  select { cntrycode: substring(c.c_phone, 0, 2), c_acctbal: c.c_acctbal }
+)
 
-let result =
+let result = (
   from c in eligible_customers
-  group by c.cntrycode
+  group by c.cntrycode into g
   select {
-    cntrycode: c.cntrycode,
-    numcust: count(),
-    totacctbal: sum(c.c_acctbal)
+    cntrycode: g.key,
+    numcust: count(g),
+    totacctbal: sum(from x in g select x.c_acctbal)
   }
-  order by c.cntrycode
+  order by g.key
+)
 
 print result
 


### PR DESCRIPTION
## Summary
- refine TPCH tasks listing
- fix q13 and q22 query syntax
- add new VM output for q13

## Testing
- `go test ./...`
- `go test -tags slow ./tests/vm -run TestVM_TPCH -count=1 -v` *(fails: q8.mochi, q13.mochi, q21.mochi)*

------
https://chatgpt.com/codex/tasks/task_e_685cbed564cc83209d33f95995c2e4e1