### PR TITLE
Improve Python query output

### DIFF
--- a/compile/py/compiler.go
+++ b/compile/py/compiler.go
@@ -930,27 +930,6 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	}
 
 	if !hasSide {
-		if q.Group != nil && len(q.Froms) == 0 && len(q.Joins) == 0 && q.Where == nil && q.Sort == nil && q.Skip == nil && q.Take == nil {
-			keyExpr, err := c.compileExpr(q.Group.Exprs[0])
-			if err != nil {
-				c.env = orig
-				return "", err
-			}
-			genv := types.NewEnv(child)
-			genv.SetVar(q.Group.Name, types.GroupType{Elem: elemType}, true)
-			c.env = genv
-			val, err := c.compileExpr(q.Select)
-			if err != nil {
-				c.env = orig
-				return "", err
-			}
-			c.env = orig
-			expr := fmt.Sprintf("[ %s for %s in _group_by(%s, lambda %s: %s) ]", val, sanitizeName(q.Group.Name), src, sanitizeName(q.Var), keyExpr)
-			c.use("_group_by")
-			c.use("_group")
-			return expr, nil
-		}
-
 		if q.Group != nil {
 			keyExpr, err := c.compileExpr(q.Group.Exprs[0])
 			if err != nil {

--- a/tests/dataset/tpc-h/compiler/py/q1.py.out
+++ b/tests/dataset/tpc-h/compiler/py/q1.py.out
@@ -12,8 +12,15 @@ def test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus():
 def main():
 	global lineitem
 	lineitem = [{"l_quantity": 17, "l_extendedprice": 1000, "l_discount": 0.05, "l_tax": 0.07, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-08-01"}, {"l_quantity": 36, "l_extendedprice": 2000, "l_discount": 0.1, "l_tax": 0.05, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-09-01"}, {"l_quantity": 25, "l_extendedprice": 1500, "l_discount": 0, "l_tax": 0.08, "l_returnflag": "R", "l_linestatus": "F", "l_shipdate": "1998-09-03"}]
+	def _q0():
+		_src = lineitem
+		_rows = _query(_src, [], { 'select': lambda row: (row), 'where': lambda row: ((row["l_shipdate"] <= "1998-09-02")) })
+		_groups = _group_by(_rows, lambda row: ({"returnflag": row["l_returnflag"], "linestatus": row["l_linestatus"]}))
+		items = _groups
+		return [ {"returnflag": g.key.returnflag, "linestatus": g.key.linestatus, "sum_qty": sum([ x["l_quantity"] for x in g ]), "sum_base_price": sum([ x["l_extendedprice"] for x in g ]), "sum_disc_price": sum([ (x["l_extendedprice"] * ((1 - x["l_discount"]))) for x in g ]), "sum_charge": sum([ ((x["l_extendedprice"] * ((1 - x["l_discount"]))) * ((1 + x["l_tax"]))) for x in g ]), "avg_qty": _avg([ x["l_quantity"] for x in g ]), "avg_price": _avg([ x["l_extendedprice"] for x in g ]), "avg_disc": _avg([ x["l_discount"] for x in g ]), "count_order": _count(g)} for g in items ]
+	
 	global result
-	result = (lambda _src=lineitem: (lambda _rows=_query(_src, [], { 'select': lambda row: (row), 'where': lambda row: ((row["l_shipdate"] <= "1998-09-02")) }): (lambda _groups=_group_by(_rows, lambda row: ({"returnflag": row["l_returnflag"], "linestatus": row["l_linestatus"]})): [ {"returnflag": g.key.returnflag, "linestatus": g.key.linestatus, "sum_qty": sum([ x["l_quantity"] for x in g ]), "sum_base_price": sum([ x["l_extendedprice"] for x in g ]), "sum_disc_price": sum([ (x["l_extendedprice"] * ((1 - x["l_discount"]))) for x in g ]), "sum_charge": sum([ ((x["l_extendedprice"] * ((1 - x["l_discount"]))) * ((1 + x["l_tax"]))) for x in g ]), "avg_qty": _avg([ x["l_quantity"] for x in g ]), "avg_price": _avg([ x["l_extendedprice"] for x in g ]), "avg_disc": _avg([ x["l_discount"] for x in g ]), "count_order": _count(g)} for g in _groups ])())())()
+	result = _q0()
 	print(json.dumps(result, default=lambda o: vars(o)))
 	test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus()
 


### PR DESCRIPTION
## Summary
- remove special-case branch in `compileQueryExpr`
- always emit helper function for grouped queries
- update golden file for TPC-H Q1 Python output

## Testing
- `go test ./compile/py -run TestPyCompiler_TPCHQ1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_685cc91a9d148320a805894193fe972a