### PR TITLE
Enable Scala backend grouping

### DIFF
--- a/compile/x/scala/TASKS.md
+++ b/compile/x/scala/TASKS.md
@@ -1,8 +1,11 @@
 # Scala Backend Tasks for TPCH Q1
 
-Scala code generation covers basic constructs but grouping logic is missing.
+Scala code generation now supports grouping and aggregation required for the
+first TPC‑H query.
 
-- Compile dataset queries to Scala collections using `.groupBy` and `.map` for aggregation.
-- Define case classes for records like `lineitem` and compute aggregates with `sum`, `avg` and `size`.
-- Emit JSON output with `scala.util.parsing.json` or a minimal serializer.
-- Include a Q1 test in `tests/compiler/scala` once implemented.
+- Dataset queries are compiled to helper calls that perform filtering and
+  grouping, emitting Scala collections.
+- Aggregates such as `sum`, `avg` and `count` are handled when operating over a
+  group.
+- Results are serialised to JSON via a minimal runtime helper.
+- `tests/compiler/scala/tpch_q1.mochi` exercises the new functionality.

--- a/tests/compiler/scala/tpch_q1.scala.out
+++ b/tests/compiler/scala/tpch_q1.scala.out
@@ -5,104 +5,119 @@ object Main {
 	
 	def main(args: Array[String]): Unit = {
 		val lineitem: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map(l_quantity -> 17, l_extendedprice -> 1000, l_discount -> 0.05, l_tax -> 0.07, l_returnflag -> "N", l_linestatus -> "O", l_shipdate -> "1998-08-01"), scala.collection.mutable.Map(l_quantity -> 36, l_extendedprice -> 2000, l_discount -> 0.1, l_tax -> 0.05, l_returnflag -> "N", l_linestatus -> "O", l_shipdate -> "1998-09-01"), scala.collection.mutable.Map(l_quantity -> 25, l_extendedprice -> 1500, l_discount -> 0, l_tax -> 0.08, l_returnflag -> "R", l_linestatus -> "F", l_shipdate -> "1998-09-03"))
-		val result: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = (() => {
+		val result: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = _group_by((() => {
 	val src = lineitem
 	val res = _query(src, Seq(
 	), Map("select" -> (args: Seq[Any]) => {
 	val row = args(0)
-	scala.collection.mutable.Map(returnflag -> g.key.returnflag, linestatus -> g.key.linestatus, sum_qty -> sum((() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_quantity
-	}))
-		res
-	})()), sum_base_price -> sum((() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_extendedprice
-	}))
-		res
-	})()), sum_disc_price -> sum((() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		(x.l_extendedprice * ((1 - x.l_discount)))
-	}))
-		res
-	})()), sum_charge -> sum((() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax)))
-	}))
-		res
-	})()), avg_qty -> ((() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_quantity
-	}))
-		res
-	})().sum / (() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_quantity
-	}))
-		res
-	})().size), avg_price -> ((() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_extendedprice
-	}))
-		res
-	})().sum / (() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_extendedprice
-	}))
-		res
-	})().size), avg_disc -> ((() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_discount
-	}))
-		res
-	})().sum / (() => {
-		val src = g
-		val res = _query(src, Seq(
-		), Map("select" -> (args: Seq[Any]) => {
-		val x = args(0)
-		x.l_discount
-	}))
-		res
-	})().size), count_order -> g.size)
+	row
 }, "where" -> (args: Seq[Any]) => {
 	val row = args(0)
 	(row.l_shipdate <= "1998-09-02")
 }))
 	res
-})()
+})(), (row: Any) => scala.collection.mutable.Map(returnflag -> row.l_returnflag, linestatus -> row.l_linestatus)).map(g => scala.collection.mutable.Map(returnflag -> g.key.returnflag, linestatus -> g.key.linestatus, sum_qty -> sum((() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_quantity
+}))
+	res
+})()), sum_base_price -> sum((() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_extendedprice
+}))
+	res
+})()), sum_disc_price -> sum((() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	(x.l_extendedprice * ((1 - x.l_discount)))
+}))
+	res
+})()), sum_charge -> sum((() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax)))
+}))
+	res
+})()), avg_qty -> ((() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_quantity
+}))
+	res
+})().sum / (() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_quantity
+}))
+	res
+})().size), avg_price -> ((() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_extendedprice
+}))
+	res
+})().sum / (() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_extendedprice
+}))
+	res
+})().size), avg_disc -> ((() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_discount
+}))
+	res
+})().sum / (() => {
+	val src = g
+	val res = _query(src, Seq(
+	), Map("select" -> (args: Seq[Any]) => {
+	val x = args(0)
+	x.l_discount
+}))
+	res
+})().size), count_order -> g.size)).toSeq
 		_json(result)
 		test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus()
 	}
 }
+class _Group(var key: Any) {
+        val Items = scala.collection.mutable.ArrayBuffer[Any]()
+}
+
 def expect(cond: Boolean): Unit = {
         if (!cond) throw new RuntimeException("expect failed")
+}
+
+def _group_by(src: Seq[Any], keyfn: Any => Any): Seq[_Group] = {
+        val groups = scala.collection.mutable.LinkedHashMap[String,_Group]()
+        for (it <- src) {
+                val key = keyfn(it)
+                val ks = key.toString
+                val g = groups.getOrElseUpdate(ks, new _Group(key))
+                g.Items.append(it)
+        }
+        groups.values.toSeq
 }
 
 def _json(v: Any): Unit = println(_to_json(v))


### PR DESCRIPTION
## Summary
- support grouping with filters in the Scala compiler
- refresh tpch Q1 golden output
- document finished tasks for TPCH Q1 Scala backend

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ccaa672f08320921b10e32075ecc6