### PR TITLE
Update tpch VM outputs

### DIFF
--- a/tests/dataset/tpc-h/TASKS.md
+++ b/tests/dataset/tpc-h/TASKS.md
@@ -4,20 +4,9 @@ Each query in this directory has a `.mochi` implementation with inline data and 
 
 ## Current failing queries
 
-Running `TestVM_TPCH` across `q1.mochi` to `q22.mochi` highlighted a number of programs that still fail when executed using the runtime/vm. The following queries either produce incorrect output or encounter errors and should be investigated:
+Running `TestVM_TPCH` across `q1.mochi` to `q22.mochi` now succeeds for all queries except for the following:
 
-* `q2`
-* `q4`
-* `q5`
-* `q7`
-* `q9`
-* `q10`
-* `q14`
-* `q15`
-* `q16`
-* `q19`
-* `q20`
 * `q21` – fails an `expect` condition
 * `q22` – parse error
 
-Resolving these issues will ensure full TPCH coverage under the VM runtime.
+Addressing these two failures will provide full TPCH coverage under the VM runtime.


### PR DESCRIPTION
## Summary
- refresh TPC-H IR output files
- update TASKS.md to list only q21 and q22 as failing

## Testing
- `go test ./tests/vm -run TestVM_TPCH -tags slow -count=1` *(fails: q21 expect condition)*

------
https://chatgpt.com/codex/tasks/task_e_685ccdbb2240832099577b0d19a411ca