### PR TITLE
Add Ruby TPCH Q1 test

### DIFF
--- a/compile/x/fortran/tpch_test.go
+++ b/compile/x/fortran/tpch_test.go
@@ -16,6 +16,6 @@ func TestFortranCompiler_TPCH(t *testing.T) {
 		t.Skipf("fortran not installed: %v", err)
 	}
 	testutil.CompileTPCH(t, "q1", func(env *types.Env, prog *parser.Program) ([]byte, error) {
-		return ftncode.New(env).Compile(prog)
+		return ftncode.New().Compile(prog)
 	})
 }

--- a/compile/x/mlir/tpch_test.go
+++ b/compile/x/mlir/tpch_test.go
@@ -3,6 +3,7 @@
 package mlir_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"mochi/compile/x/mlir"
@@ -25,7 +26,11 @@ func TestMLIRCompiler_TPCH(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	if _, err := mlir.New(env).Compile(prog); err != nil {
+	c, err := mlir.New()
+	if err != nil {
+		t.Skipf("mlir not available: %v", err)
+	}
+	if _, err := c.Compile(prog); err != nil {
 		t.Skipf("TPCH Q1 unsupported: %v", err)
 	}
 }

--- a/compile/x/rb/TASKS.md
+++ b/compile/x/rb/TASKS.md
@@ -1,8 +1,10 @@
 # Ruby Backend Tasks for TPCH Q1
 
-The Ruby backend can compile control flow but not complex dataset operations.
+The Ruby backend now supports running the TPCH Q1 example.
 
-- Implement grouping using `Enumerable#group_by` followed by `map` for aggregation.
-- Map Mochi structs to Ruby `Struct` or classes with attribute accessors.
-- Provide helper methods `sum`, `avg` and `count` over arrays.
-- Serialize results with `JSON.generate` and add tests under `tests/compiler/rb`.
+Implemented features:
+- Grouping and query helpers via `_group_by` and `_query`.
+- Struct values mapped to `OpenStruct` for convenient field access.
+- Helper methods `sum`, `avg`, `count` and `json` for datasets.
+- Golden tests under `tests/dataset/tpc-h/compiler/rb` verify generated code
+  and runtime output.

--- a/compile/x/rb/compiler_test.go
+++ b/compile/x/rb/compiler_test.go
@@ -202,6 +202,54 @@ func TestRBCompiler_GoldenOutput(t *testing.T) {
 	})
 }
 
+func TestRBCompiler_TPCHQ1(t *testing.T) {
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "tpc-h", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := rbcode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	codeWantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "rb", "q1.rb.out")
+	wantCode, err := os.ReadFile(codeWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q1.rb.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", got, bytes.TrimSpace(wantCode))
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.rb")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("ruby", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ruby run error: %v\n%s", err, out)
+	}
+	gotOut := bytes.TrimSpace(out)
+	outWantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "rb", "q1.out")
+	wantOut, err := os.ReadFile(outWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+		t.Errorf("output mismatch for q1.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", gotOut, bytes.TrimSpace(wantOut))
+	}
+}
+
 func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/compile/x/wasm/tpch_test.go
+++ b/compile/x/wasm/tpch_test.go
@@ -3,6 +3,7 @@
 package wasm_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"mochi/compile/x/testutil"

--- a/tests/dataset/tpc-h/compiler/rb/q1.out
+++ b/tests/dataset/tpc-h/compiler/rb/q1.out
@@ -1,0 +1,1 @@
+[{"returnflag":"N","linestatus":"O","sum_qty":53.0,"sum_base_price":3000.0,"sum_disc_price":2750.0,"sum_charge":2906.5,"avg_qty":26.5,"avg_price":1500.0,"avg_disc":0.07500000000000001,"count_order":2}]

--- a/tests/dataset/tpc-h/compiler/rb/q1.rb.out
+++ b/tests/dataset/tpc-h/compiler/rb/q1.rb.out
@@ -1,0 +1,193 @@
+require 'ostruct'
+
+class MGroup
+  include Enumerable
+  attr_accessor :key, :Items
+  def initialize(k)
+    @key = k
+    @Items = []
+  end
+  def length
+    @Items.length
+  end
+  def each(&block)
+    @Items.each(&block)
+  end
+end
+def _group_by(src, keyfn)
+grouped = src.group_by do |it|
+  if it.is_a?(Array)
+    keyfn.call(*it)
+  else
+    keyfn.call(it)
+  end
+end
+grouped.map do |k, items|
+g = MGroup.new(k)
+items.each do |it|
+  if it.is_a?(Array) && it.length == 1
+    g.Items << it[0]
+  else
+    g.Items << it
+  end
+end
+g
+end
+end
+def _json(v)
+  require 'json'
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+def _query(src, joins, opts)
+  where_fn = opts['where']
+  items = []
+  if joins.empty?
+    src.each do |v|
+      row = [v]
+      next if where_fn && !where_fn.call(*row)
+      items << row
+    end
+  else
+    items = src.map { |v| [v] }
+    joins.each_with_index do |j, idx|
+      joined = []
+      jitems = j['items']
+      on = j['on']
+      left = j['left']
+      right = j['right']
+      last = idx == joins.length - 1
+      if right && left
+        matched = Array.new(jitems.length, false)
+        items.each do |l|
+          m = false
+          jitems.each_with_index do |r, ri|
+            keep = true
+            keep = on.call(*l, r) if on
+            next unless keep
+            m = true
+            matched[ri] = true
+            row = l + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+          row = l + [nil]
+          if left && !m
+            if last && where_fn && !where_fn.call(*row)
+              # skip
+            else
+              joined << row
+            end
+          end
+        end
+        jitems.each_with_index do |r, ri|
+          next if matched[ri]
+          _undef = Array.new(items[0]&.length || 0, nil)
+          row = _undef + [r]
+          if last && where_fn && !where_fn.call(*row)
+            next
+          end
+          joined << row
+        end
+      elsif right
+        jitems.each do |r|
+          m = false
+          items.each do |l|
+            keep = true
+            keep = on.call(*l, r) if on
+            next unless keep
+            m = true
+            row = l + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+          unless m
+            _undef = Array.new(items[0]&.length || 0, nil)
+            row = _undef + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+        end
+      else
+        items.each do |l|
+          m = false
+          jitems.each do |r|
+            keep = true
+            keep = on.call(*l, r) if on
+            next unless keep
+            m = true
+            row = l + [r]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+          if left && !m
+            row = l + [nil]
+            if last && where_fn && !where_fn.call(*row)
+              next
+            end
+            joined << row
+          end
+        end
+      end
+      items = joined
+    end
+  end
+  if opts['sortKey']
+    items = items.map { |it| [it, opts['sortKey'].call(*it)] }
+    items.sort_by! { |p| p[1] }
+    items.map!(&:first)
+  end
+  if opts.key?('skip')
+    n = opts['skip']
+    items = n < items.length ? items[n..-1] : []
+  end
+  if opts.key?('take')
+    n = opts['take']
+    items = n < items.length ? items[0...n] : items
+  end
+  res = []
+  items.each { |r| res << opts['select'].call(*r) }
+  res
+end
+def _sum(v)
+  list = nil
+  if v.is_a?(MGroup)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  s = 0.0
+  list.each { |n| s += n.to_f }
+  s
+end
+
+lineitem = [OpenStruct.new(l_quantity: 17, l_extendedprice: 1000.0, l_discount: 0.05, l_tax: 0.07, l_returnflag: "N", l_linestatus: "O", l_shipdate: "1998-08-01"), OpenStruct.new(l_quantity: 36, l_extendedprice: 2000.0, l_discount: 0.1, l_tax: 0.05, l_returnflag: "N", l_linestatus: "O", l_shipdate: "1998-09-01"), OpenStruct.new(l_quantity: 25, l_extendedprice: 1500.0, l_discount: 0.0, l_tax: 0.08, l_returnflag: "R", l_linestatus: "F", l_shipdate: "1998-09-03")]
+result = (begin
+	src = lineitem
+	_rows = _query(src, [
+	], { 'select' => ->(row){ [row] }, 'where' => ->(row){ (row.l_shipdate <= "1998-09-02") } })
+	_groups = _group_by(_rows, ->(row){ OpenStruct.new(returnflag: row.l_returnflag, linestatus: row.l_linestatus) })
+	_res = []
+	for g in _groups
+		_res << OpenStruct.new(returnflag: g.key.returnflag, linestatus: g.key.linestatus, sum_qty: _sum(((g)).map { |x| x.l_quantity }), sum_base_price: _sum(((g)).map { |x| x.l_extendedprice }), sum_disc_price: _sum(((g)).map { |x| (x.l_extendedprice * ((1 - x.l_discount))) }), sum_charge: _sum(((g)).map { |x| ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))) }), avg_qty: ((((g)).map { |x| x.l_quantity }).length > 0 ? (((g)).map { |x| x.l_quantity }).sum(0.0) / (((g)).map { |x| x.l_quantity }).length : 0), avg_price: ((((g)).map { |x| x.l_extendedprice }).length > 0 ? (((g)).map { |x| x.l_extendedprice }).sum(0.0) / (((g)).map { |x| x.l_extendedprice }).length : 0), avg_disc: ((((g)).map { |x| x.l_discount }).length > 0 ? (((g)).map { |x| x.l_discount }).sum(0.0) / (((g)).map { |x| x.l_discount }).length : 0), count_order: (g).length)
+	end
+	_res
+end)
+_json(result)
+raise "expect failed" unless (result == [OpenStruct.new(returnflag: "N", linestatus: "O", sum_qty: 53, sum_base_price: 3000, sum_disc_price: (950.0 + 1800.0), sum_charge: (((950.0 * 1.07)) + ((1800.0 * 1.05))), avg_qty: 26.5, avg_price: 1500, avg_disc: 0.07500000000000001, count_order: 2)])


### PR DESCRIPTION
## Summary
- support dataset TPCH Q1 for Ruby compiler
- add golden files for generated Ruby code and output
- verify TPCH Q1 in ruby compiler tests
- update Ruby compiler task list
- fix build issues in other TPCH tests

## Testing
- `go test ./compile/x/rb -run TPCHQ1 -tags slow -v`
- `go test ./... -run TestRBCompiler_TPCHQ1 -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_685ccaa14b4083209c3e7d1389c0a834