### PR TITLE
Improve Dart TPCH tasks and runtime helpers

### DIFF
--- a/compile/x/dart/TASKS.md
+++ b/compile/x/dart/TASKS.md
@@ -1,9 +1,24 @@
 # Dart Backend Tasks for TPCH Q1
 
 Dart compilation works for small programs but grouping in dataset queries is
-incomplete.
+incomplete. The following items outline the steps required to run
+`tests/dataset/tpc-h/q1.mochi` with the Dart backend.
 
-- Lower `group by` expressions to loops building a `Map` of lists using Dart generics.
-- Provide helper methods on `_Group` for `sum`, `avg` and `count`.
-- Map Mochi structs to Dart classes so `lineitem` rows have typed fields.
-- Serialize results with `dart:convert` and add a golden test under `tests/compiler/dart`.
+1. **Lower `group by` queries**
+   - Build grouping loops that populate a `Map<String, _Group>` preserving the
+     original row order.
+   - Emit calls to the helper functions when aggregates appear in the `select`
+     clause.
+2. **Enhance `_Group`**
+   - Provide instance methods `count`, `sum` and `avg` which delegate to the
+     existing helper functions.
+   - Keep the `key` value and `Items` list accessible for result construction.
+3. **Typed struct generation**
+   - Map Mochi `struct` definitions to Dart classes with typed fields and a
+     `fromJson` constructor.
+   - Use these classes when compiling dataset access so `lineitem` rows are
+     strongly typed.
+4. **Serialisation and testing**
+   - Output results using `jsonEncode` from `dart:convert`.
+   - Add a golden test under `tests/compiler/dart` that compiles and executes
+     `q1.mochi` once the above pieces are in place.

--- a/compile/x/dart/runtime.go
+++ b/compile/x/dart/runtime.go
@@ -52,52 +52,52 @@ const (
 		"    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';\n" +
 		"    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';\n" +
 		"}\n"
-        helperRunTest = "bool _runTest(String name, void Function() f) {\n" +
-                "    stdout.write('   test $name ...');\n" +
-                "    var start = DateTime.now();\n" +
-                "    try {\n" +
-                "        f();\n" +
-                "        var d = DateTime.now().difference(start);\n" +
-                "        stdout.writeln(' ok (${_formatDuration(d)})');\n" +
-                "        return true;\n" +
-                "    } catch (e) {\n" +
-                "        var d = DateTime.now().difference(start);\n" +
-                "        stdout.writeln(' fail $e (${_formatDuration(d)})');\n" +
-                "        return false;\n" +
-                "    }\n" +
-                "}\n"
-        helperCount = "int _count(dynamic v) {\n" +
-                "    if (v is String) return v.runes.length;\n" +
-                "    if (v is List) return v.length;\n" +
-                "    if (v is Map) return v.length;\n" +
-                "    try { var items = (v as dynamic).Items; if (items is List) return items.length; } catch (_) {}\n" +
-                "    try { var items = (v as dynamic).items; if (items is List) return items.length; } catch (_) {}\n" +
-                "    return 0;\n" +
-                "}\n"
-        helperAvg = "double _avg(dynamic v) {\n" +
-                "    List<dynamic>? list;\n" +
-                "    if (v is List) list = v;\n" +
-                "    else if (v is Map && v['items'] is List) list = (v['items'] as List);\n" +
-                "    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);\n" +
-                "    else if (v is _Group) list = v.Items;\n" +
-                "    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }\n" +
-                "    if (list == null || list.isEmpty) return 0;\n" +
-                "    var s = 0.0;\n" +
-                "    for (var n in list) s += (n as num).toDouble();\n" +
-                "    return s / list.length;\n" +
-                "}\n"
-        helperSum = "double _sum(dynamic v) {\n" +
-                "    List<dynamic>? list;\n" +
-                "    if (v is List) list = v;\n" +
-                "    else if (v is Map && v['items'] is List) list = (v['items'] as List);\n" +
-                "    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);\n" +
-                "    else if (v is _Group) list = v.Items;\n" +
-                "    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }\n" +
-                "    if (list == null || list.isEmpty) return 0;\n" +
-                "    var s = 0.0;\n" +
-                "    for (var n in list) s += (n as num).toDouble();\n" +
-                "    return s;\n" +
-                "}\n"
+	helperRunTest = "bool _runTest(String name, void Function() f) {\n" +
+		"    stdout.write('   test $name ...');\n" +
+		"    var start = DateTime.now();\n" +
+		"    try {\n" +
+		"        f();\n" +
+		"        var d = DateTime.now().difference(start);\n" +
+		"        stdout.writeln(' ok (${_formatDuration(d)})');\n" +
+		"        return true;\n" +
+		"    } catch (e) {\n" +
+		"        var d = DateTime.now().difference(start);\n" +
+		"        stdout.writeln(' fail $e (${_formatDuration(d)})');\n" +
+		"        return false;\n" +
+		"    }\n" +
+		"}\n"
+	helperCount = "int _count(dynamic v) {\n" +
+		"    if (v is String) return v.runes.length;\n" +
+		"    if (v is List) return v.length;\n" +
+		"    if (v is Map) return v.length;\n" +
+		"    try { var items = (v as dynamic).Items; if (items is List) return items.length; } catch (_) {}\n" +
+		"    try { var items = (v as dynamic).items; if (items is List) return items.length; } catch (_) {}\n" +
+		"    return 0;\n" +
+		"}\n"
+	helperAvg = "double _avg(dynamic v) {\n" +
+		"    List<dynamic>? list;\n" +
+		"    if (v is List) list = v;\n" +
+		"    else if (v is Map && v['items'] is List) list = (v['items'] as List);\n" +
+		"    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);\n" +
+		"    else if (v is _Group) list = v.Items;\n" +
+		"    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }\n" +
+		"    if (list == null || list.isEmpty) return 0;\n" +
+		"    var s = 0.0;\n" +
+		"    for (var n in list) s += (n as num).toDouble();\n" +
+		"    return s / list.length;\n" +
+		"}\n"
+	helperSum = "double _sum(dynamic v) {\n" +
+		"    List<dynamic>? list;\n" +
+		"    if (v is List) list = v;\n" +
+		"    else if (v is Map && v['items'] is List) list = (v['items'] as List);\n" +
+		"    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);\n" +
+		"    else if (v is _Group) list = v.Items;\n" +
+		"    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }\n" +
+		"    if (list == null || list.isEmpty) return 0;\n" +
+		"    var s = 0.0;\n" +
+		"    for (var n in list) s += (n as num).toDouble();\n" +
+		"    return s;\n" +
+		"}\n"
 	helperStream = "class _Stream<T> {\n" +
 		"    String name;\n" +
 		"    List<void Function(T)> handlers = [];\n" +
@@ -140,6 +140,9 @@ const (
 		"    dynamic key;\n" +
 		"    List<dynamic> Items = [];\n" +
 		"    _Group(this.key);\n" +
+		"    int count() => _count(this);\n" +
+		"    double sum() => _sum(this);\n" +
+		"    double avg() => _avg(this);\n" +
 		"}\n"
 	helperGroupBy = "List<_Group> _group_by(List<dynamic> src, dynamic Function(dynamic) keyfn) {\n" +
 		"    var groups = <String,_Group>{};\n" +
@@ -390,19 +393,19 @@ var helperMap = map[string]string{
 	"_Agent":          helperAgent,
 	"_waitAll":        helperWaitAll,
 	"_Group":          helperGroup,
-        "_group_by":       helperGroupBy,
-        "_fetch":          helperFetch,
-        "_load":           helperLoad,
-        "_save":           helperSave,
-        "_query":          helperQuery,
-        "_count":         helperCount,
-        "_avg":           helperAvg,
-        "_sum":           helperSum,
-        "_genText":        helperGenText,
-        "_genEmbed":       helperGenEmbed,
-        "_genStruct":      helperGenStruct,
-        "_json":           helperJson,
-        "_equal":          helperEqual,
+	"_group_by":       helperGroupBy,
+	"_fetch":          helperFetch,
+	"_load":           helperLoad,
+	"_save":           helperSave,
+	"_query":          helperQuery,
+	"_count":          helperCount,
+	"_avg":            helperAvg,
+	"_sum":            helperSum,
+	"_genText":        helperGenText,
+	"_genEmbed":       helperGenEmbed,
+	"_genStruct":      helperGenStruct,
+	"_json":           helperJson,
+	"_equal":          helperEqual,
 	"_distinct":       helperDistinct,
 	"_formatDuration": helperFormatDuration,
 	"_runTest":        helperRunTest,


### PR DESCRIPTION
## Summary
- expand compiler tasks for the Dart backend
- add `count`, `sum` and `avg` methods to `_Group`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cca6a0d9c8320a5d8af448285053b