### PR TITLE
Update TPCH test outputs

### DIFF
--- a/tests/dataset/tpc-h/TASKS.md
+++ b/tests/dataset/tpc-h/TASKS.md
@@ -4,20 +4,4 @@ Each query in this directory has a `.mochi` implementation with inline data and 
 
 ## Current failing queries
 
-Running `TestVM_TPCH` across `q1.mochi` to `q22.mochi` highlighted a number of programs that still fail when executed using the runtime/vm. The following queries either produce incorrect output or encounter errors and should be investigated:
-
-* `q2`
-* `q4`
-* `q5`
-* `q7`
-* `q9`
-* `q10`
-* `q14`
-* `q15`
-* `q16`
-* `q19`
-* `q20`
-* `q21` – fails an `expect` condition
-* `q22` – parse error
-
-Resolving these issues will ensure full TPCH coverage under the VM runtime.
+Running `TestVM_TPCH` across `q1.mochi` to `q22.mochi` now succeeds for every program except `q22`. All other queries execute correctly using the runtime/vm and match their expected output. Query `q22` still fails to parse and requires investigation. Once fixed, the TPCH suite will have full coverage under the VM runtime.

--- a/tests/dataset/tpc-h/out/q21.ir.out
+++ b/tests/dataset/tpc-h/out/q21.ir.out
@@ -264,4 +264,3 @@ L18:
   Equal        r160, r158, r159
   Expect       r160
   Return       r0
-


### PR DESCRIPTION
## Summary
- regenerate tpch `out` files with `update_tpch`
- note that only q22 fails to parse in `TASKS.md`

## Testing
- `go test ./tests/vm -run TestVM_TPCH -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_685cd68c6cf08320a1dae9bafbd8ec1b