### PR TITLE
Fix tpch q22 and add group iteration test

### DIFF
--- a/tests/dataset/tpc-h/out/q22.ir.out
+++ b/tests/dataset/tpc-h/out/q22.ir.out
@@ -1,0 +1,300 @@
+func main (regs=178)
+  // let customer = [
+  Const        r0, [{"c_acctbal": 600, "c_custkey": 1, "c_phone": "13-123-4567"}, {"c_acctbal": 100, "c_custkey": 2, "c_phone": "31-456-7890"}, {"c_acctbal": 700, "c_custkey": 3, "c_phone": "30-000-0000"}]
+  Move         r1, r0
+  // let orders = [
+  Const        r2, [{"o_custkey": 2, "o_orderkey": 10}]
+  Move         r3, r2
+  // let valid_codes = ["13", "31", "23", "29", "30", "18", "17"]
+  Const        r4, ["13", "31", "23", "29", "30", "18", "17"]
+  Move         r5, r4
+  // from c in customer
+  Const        r6, []
+  IterPrep     r7, r1
+  Len          r8, r7
+  Const        r9, 0
+L3:
+  Less         r10, r9, r8
+  JumpIfFalse  r10, L0
+  Index        r11, r7, r9
+  Move         r12, r11
+  // where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
+  Const        r13, "c_acctbal"
+  Index        r14, r12, r13
+  Const        r15, 0
+  LessFloat    r16, r15, r14
+  Const        r17, "c_phone"
+  Index        r18, r12, r17
+  Const        r19, 0
+  Const        r20, 2
+  Slice        r21, r18, r19, r20
+  In           r22, r21, r5
+  Move         r23, r16
+  JumpIfFalse  r23, L1
+  Move         r23, r22
+L1:
+  JumpIfFalse  r23, L2
+  // select c.c_acctbal
+  Const        r24, "c_acctbal"
+  Index        r25, r12, r24
+  // from c in customer
+  Append       r26, r6, r25
+  Move         r6, r26
+L2:
+  Const        r27, 1
+  Add          r28, r9, r27
+  Move         r9, r28
+  Jump         L3
+L0:
+  // avg(
+  Avg          r29, r6
+  // let avg_balance =
+  Move         r30, r29
+  // from c in customer
+  Const        r31, []
+  IterPrep     r32, r1
+  Len          r33, r32
+  Const        r34, 0
+L11:
+  Less         r35, r34, r33
+  JumpIfFalse  r35, L4
+  Index        r36, r32, r34
+  Move         r12, r36
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  Const        r37, "c_phone"
+  Index        r38, r12, r37
+  Const        r39, 0
+  Const        r40, 2
+  Slice        r41, r38, r39, r40
+  // c.c_acctbal > avg_balance && (!exists(
+  Const        r42, "c_acctbal"
+  Index        r43, r12, r42
+  LessFloat    r44, r30, r43
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  In           r45, r41, r5
+  Move         r46, r45
+  JumpIfFalse  r46, L5
+  Move         r46, r44
+L5:
+  // c.c_acctbal > avg_balance && (!exists(
+  Move         r47, r46
+  JumpIfFalse  r47, L6
+  // from o in orders
+  Const        r48, []
+  IterPrep     r49, r3
+  Len          r50, r49
+  Const        r51, 0
+L9:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L7
+  Index        r53, r49, r51
+  Move         r54, r53
+  // where o.o_custkey == c.c_custkey
+  Const        r55, "o_custkey"
+  Index        r56, r54, r55
+  Const        r57, "c_custkey"
+  Index        r58, r12, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L8
+  // from o in orders
+  Append       r60, r48, r54
+  Move         r48, r60
+L8:
+  Const        r61, 1
+  Add          r62, r51, r61
+  Move         r51, r62
+  Jump         L9
+L7:
+  // c.c_acctbal > avg_balance && (!exists(
+  Exists       63,48,0,0
+  Not          r64, r63
+  Move         r47, r64
+L6:
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  JumpIfFalse  r47, L10
+  // cntrycode: substring(c.c_phone, 0, 2),
+  Const        r65, "cntrycode"
+  Const        r66, "c_phone"
+  Index        r67, r12, r66
+  Const        r68, 0
+  Const        r69, 2
+  Slice        r70, r67, r68, r69
+  // c_acctbal: c.c_acctbal
+  Const        r71, "c_acctbal"
+  Const        r72, "c_acctbal"
+  Index        r73, r12, r72
+  // cntrycode: substring(c.c_phone, 0, 2),
+  Move         r74, r65
+  Move         r75, r70
+  // c_acctbal: c.c_acctbal
+  Move         r76, r71
+  Move         r77, r73
+  // select {
+  MakeMap      r78, 2, r74
+  // from c in customer
+  Append       r79, r31, r78
+  Move         r31, r79
+L10:
+  Const        r80, 1
+  Add          r81, r34, r80
+  Move         r34, r81
+  Jump         L11
+L4:
+  // let eligible_customers =
+  Move         r82, r31
+  // from c in eligible_customers
+  Const        r83, []
+  IterPrep     r84, r82
+  Len          r85, r84
+  Const        r86, 0
+  MakeMap      r87, 0, r0
+  Const        r88, []
+L14:
+  Less         r89, r86, r85
+  JumpIfFalse  r89, L12
+  Index        r90, r84, r86
+  Move         r12, r90
+  // group by c.cntrycode into g
+  Const        r91, "cntrycode"
+  Index        r92, r12, r91
+  Str          r93, r92
+  In           r94, r93, r87
+  JumpIfTrue   r94, L13
+  // from c in eligible_customers
+  Const        r95, []
+  Const        r96, "__group__"
+  Const        r97, true
+  Const        r98, "key"
+  // group by c.cntrycode into g
+  Move         r99, r92
+  // from c in eligible_customers
+  Const        r100, "items"
+  Move         r101, r95
+  MakeMap      r102, 3, r96
+  SetIndex     r87, r93, r102
+  Append       r103, r88, r102
+  Move         r88, r103
+L13:
+  Const        r104, "items"
+  Index        r105, r87, r93
+  Index        r106, r105, r104
+  Append       r107, r106, r90
+  SetIndex     r105, r104, r107
+  Const        r108, 1
+  Add          r109, r86, r108
+  Move         r86, r109
+  Jump         L14
+L12:
+  Const        r110, 0
+  Len          r111, r88
+L16:
+  Less         r112, r110, r111
+  JumpIfFalse  r112, L15
+  Index        r113, r88, r110
+  Move         r114, r113
+  Append       r115, r83, r114
+  Move         r83, r115
+  Const        r116, 1
+  Add          r117, r110, r116
+  Move         r110, r117
+  Jump         L16
+L15:
+  // let groups =
+  Move         r118, r83
+  // var tmp = []
+  Const        r119, []
+  Move         r120, r119
+  // for g in groups {
+  IterPrep     r121, r118
+  Len          r122, r121
+  Const        r123, 0
+L20:
+  Less         r124, r123, r122
+  JumpIfFalse  r124, L17
+  Index        r125, r121, r123
+  Move         r114, r125
+  // var total = 0.0
+  Const        r126, 0
+  Move         r127, r126
+  // for x in g.items {
+  Const        r128, "items"
+  Index        r129, r114, r128
+  IterPrep     r130, r129
+  Len          r131, r130
+  Const        r132, 0
+L19:
+  Less         r133, r132, r131
+  JumpIfFalse  r133, L18
+  Index        r134, r130, r132
+  Move         r135, r134
+  // total = total + x.c_acctbal
+  Const        r136, "c_acctbal"
+  Index        r137, r135, r136
+  AddFloat     r138, r127, r137
+  Move         r127, r138
+  // for x in g.items {
+  Const        r139, 1
+  Add          r140, r132, r139
+  Move         r132, r140
+  Jump         L19
+L18:
+  // let row = { cntrycode: g.key, numcust: count(g), totacctbal: total }
+  Const        r141, "cntrycode"
+  Const        r142, "key"
+  Index        r143, r114, r142
+  Const        r144, "numcust"
+  Count        r145, r114
+  Const        r146, "totacctbal"
+  Move         r147, r141
+  Move         r148, r143
+  Move         r149, r144
+  Move         r150, r145
+  Move         r151, r146
+  Move         r152, r127
+  MakeMap      r153, 3, r147
+  Move         r154, r153
+  // tmp = append(tmp, row)
+  Append       r155, r120, r154
+  Move         r120, r155
+  // for g in groups {
+  Const        r156, 1
+  Add          r157, r123, r156
+  Move         r123, r157
+  Jump         L20
+L17:
+  // from r in tmp
+  Const        r158, []
+  IterPrep     r159, r120
+  Len          r160, r159
+  Const        r161, 0
+L22:
+  Less         r162, r161, r160
+  JumpIfFalse  r162, L21
+  Index        r163, r159, r161
+  Move         r164, r163
+  // sort by r.cntrycode
+  Const        r165, "cntrycode"
+  Index        r166, r164, r165
+  Move         r167, r166
+  // from r in tmp
+  Move         r168, r164
+  MakeList     r169, 2, r167
+  Append       r170, r158, r169
+  Move         r158, r170
+  Const        r171, 1
+  Add          r172, r161, r171
+  Move         r161, r172
+  Jump         L22
+L21:
+  // sort by r.cntrycode
+  Sort         173,158,0,0
+  // from r in tmp
+  Move         r158, r173
+  // let result =
+  Move         r174, r158
+  // expect result == [
+  Const        r176, [{"cntrycode": "13", "numcust": 1, "totacctbal": 600}, {"cntrycode": "30", "numcust": 1, "totacctbal": 700}]
+  Equal        r177, r174, r176
+  Expect       r177
+  Return       r0
+

--- a/tests/dataset/tpc-h/out/q22.out
+++ b/tests/dataset/tpc-h/out/q22.out
@@ -1,0 +1,1 @@
+[map[cntrycode:13 numcust:1 totacctbal:600] map[cntrycode:30 numcust:1 totacctbal:700]]

--- a/tests/dataset/tpc-h/q22.mochi
+++ b/tests/dataset/tpc-h/q22.mochi
@@ -13,30 +13,45 @@ let valid_codes = ["13", "31", "23", "29", "30", "18", "17"]
 let avg_balance =
   avg(
     from c in customer
-    where c.c_acctbal > 0.0 and substring(c.c_phone, 0, 2) in valid_codes
+    where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
     select c.c_acctbal
   )
 
 let eligible_customers =
   from c in customer
-  let cc = substring(c.c_phone, 0, 2)
   where
-    cc in valid_codes and
-    c.c_acctbal > avg_balance and
-    not exists o in orders where o.o_custkey == c.c_custkey
-  select { cntrycode: cc, c_acctbal: c.c_acctbal }
+    substring(c.c_phone, 0, 2) in valid_codes &&
+    c.c_acctbal > avg_balance && (!exists(
+      from o in orders
+      where o.o_custkey == c.c_custkey
+      select o
+    ))
+  select {
+    cntrycode: substring(c.c_phone, 0, 2),
+    c_acctbal: c.c_acctbal
+  }
+
+let groups =
+  from c in eligible_customers
+  group by c.cntrycode into g
+  select g
+
+var tmp = []
+for g in groups {
+  var total = 0.0
+  for x in g.items {
+    total = total + x.c_acctbal
+  }
+  let row = { cntrycode: g.key, numcust: count(g), totacctbal: total }
+  tmp = append(tmp, row)
+}
 
 let result =
-  from c in eligible_customers
-  group by c.cntrycode
-  select {
-    cntrycode: c.cntrycode,
-    numcust: count(),
-    totacctbal: sum(c.c_acctbal)
-  }
-  order by c.cntrycode
+  from r in tmp
+  sort by r.cntrycode
+  select r
 
-print result
+print(result)
 
 test "Q22 returns wealthy inactive customers by phone prefix" {
   // avg_balance = (600 + 100 + 700) / 3 = 466.66

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -1,0 +1,142 @@
+func main (regs=90)
+  // let data = [
+  Const        r0, [{"tag": "a", "val": 1}, {"tag": "a", "val": 2}, {"tag": "b", "val": 3}]
+  Move         r1, r0
+  // let groups = from d in data group by d.tag into g select g
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
+  MakeMap      r6, 0, r0
+  Const        r7, []
+L2:
+  Less         r8, r5, r4
+  JumpIfFalse  r8, L0
+  Index        r9, r3, r5
+  Move         r10, r9
+  Const        r11, "tag"
+  Index        r12, r10, r11
+  Str          r13, r12
+  In           r14, r13, r6
+  JumpIfTrue   r14, L1
+  Const        r15, []
+  Const        r16, "__group__"
+  Const        r17, true
+  Const        r18, "key"
+  Move         r19, r12
+  Const        r20, "items"
+  Move         r21, r15
+  MakeMap      r22, 3, r16
+  SetIndex     r6, r13, r22
+  Append       r23, r7, r22
+  Move         r7, r23
+L1:
+  Const        r24, "items"
+  Index        r25, r6, r13
+  Index        r26, r25, r24
+  Append       r27, r26, r9
+  SetIndex     r25, r24, r27
+  Const        r28, 1
+  Add          r29, r5, r28
+  Move         r5, r29
+  Jump         L2
+L0:
+  Const        r30, 0
+  Len          r31, r7
+L4:
+  Less         r32, r30, r31
+  JumpIfFalse  r32, L3
+  Index        r33, r7, r30
+  Move         r34, r33
+  Append       r35, r2, r34
+  Move         r2, r35
+  Const        r36, 1
+  Add          r37, r30, r36
+  Move         r30, r37
+  Jump         L4
+L3:
+  Move         r38, r2
+  // var tmp = []
+  Const        r39, []
+  Move         r40, r39
+  // for g in groups {
+  IterPrep     r41, r38
+  Len          r42, r41
+  Const        r43, 0
+L8:
+  Less         r44, r43, r42
+  JumpIfFalse  r44, L5
+  Index        r45, r41, r43
+  Move         r34, r45
+  // var total = 0
+  Const        r46, 0
+  Move         r47, r46
+  // for x in g.items {
+  Const        r48, "items"
+  Index        r49, r34, r48
+  IterPrep     r50, r49
+  Len          r51, r50
+  Const        r52, 0
+L7:
+  Less         r53, r52, r51
+  JumpIfFalse  r53, L6
+  Index        r54, r50, r52
+  Move         r55, r54
+  // total = total + x.val
+  Const        r56, "val"
+  Index        r57, r55, r56
+  Add          r58, r47, r57
+  Move         r47, r58
+  // for x in g.items {
+  Const        r59, 1
+  Add          r60, r52, r59
+  Move         r52, r60
+  Jump         L7
+L6:
+  // tmp = append(tmp, {tag: g.key, total: total})
+  Const        r61, "tag"
+  Const        r62, "key"
+  Index        r63, r34, r62
+  Const        r64, "total"
+  Move         r65, r61
+  Move         r66, r63
+  Move         r67, r64
+  Move         r68, r47
+  MakeMap      r69, 2, r65
+  Append       r70, r40, r69
+  Move         r40, r70
+  // for g in groups {
+  Const        r71, 1
+  Add          r72, r43, r71
+  Move         r43, r72
+  Jump         L8
+L5:
+  // let result = from r in tmp sort by r.tag select r
+  Const        r73, []
+  IterPrep     r74, r40
+  Len          r75, r74
+  Const        r76, 0
+L10:
+  Less         r77, r76, r75
+  JumpIfFalse  r77, L9
+  Index        r78, r74, r76
+  Move         r79, r78
+  Const        r80, "tag"
+  Index        r81, r79, r80
+  Move         r82, r81
+  Move         r83, r79
+  MakeList     r84, 2, r82
+  Append       r85, r73, r84
+  Move         r73, r85
+  Const        r86, 1
+  Add          r87, r76, r86
+  Move         r76, r87
+  Jump         L10
+L9:
+  Sort         88,73,0,0
+  Move         r73, r88
+  Move         r89, r73
+  // print(result)
+  Print        r89
+  Return       r0
+

--- a/tests/vm/valid/group_items_iteration.mochi
+++ b/tests/vm/valid/group_items_iteration.mochi
@@ -1,0 +1,16 @@
+let data = [
+  {tag: "a", val: 1},
+  {tag: "a", val: 2},
+  {tag: "b", val: 3}
+]
+let groups = from d in data group by d.tag into g select g
+var tmp = []
+for g in groups {
+  var total = 0
+  for x in g.items {
+    total = total + x.val
+  }
+  tmp = append(tmp, {tag: g.key, total: total})
+}
+let result = from r in tmp sort by r.tag select r
+print(result)

--- a/tests/vm/valid/group_items_iteration.out
+++ b/tests/vm/valid/group_items_iteration.out
@@ -1,0 +1,1 @@
+[map[tag:a total:3] map[tag:b total:3]]


### PR DESCRIPTION
## Summary
- repair TPCH q22 example so it parses and runs
- generate q22 VM output and bytecode listings
- add new VM golden test covering iteration over group items

## Testing
- `go test ./...` *(fails: lua runtime missing json library)*

------
https://chatgpt.com/codex/tasks/task_e_685cd669feac8320bcfb94b935515976