### PR TITLE
Add built-in JSON encoder for Lua backend

### DIFF
--- a/compile/x/lua/TASKS.md
+++ b/compile/x/lua/TASKS.md
@@ -1,8 +1,9 @@
 # Lua Backend Tasks for TPCH Q1
 
-The Lua backend generates basic source but fails when `group by` is used.
+Support for TPCH Q1 is implemented in the Lua backend.
 
-- Implement grouping in the runtime using tables keyed by concatenated values.
-- Provide helper functions `sum`, `avg` and `count` operating on Lua tables.
-- Represent records as tables with string keys for TPCH data.
-- Use a small JSON encoder (e.g., `cjson`) for output and add a golden test under `tests/compiler/lua`.
+- Grouping is handled by `_group_by` which indexes tables by concatenated keys.
+- Helper functions `sum`, `avg` and `count` operate on lists or groups.
+- Records are emitted as tables with string keys for TPCH datasets.
+- A minimal JSON encoder is bundled so tests run without external modules. The
+  golden tests live under `tests/dataset/tpc-h/compiler/lua`.

--- a/compile/x/lua/runtime.go
+++ b/compile/x/lua/runtime.go
@@ -176,26 +176,54 @@ const (
 		"    return acc\n" +
 		"end\n"
 
-	helperJson = "function __json(v)\n" +
-		"    local function sort(x)\n" +
-		"        if type(x) ~= 'table' then return x end\n" +
-		"        if x[1] ~= nil or #x > 0 then\n" +
-		"            local out = {}\n" +
-		"            for i=1,#x do out[i] = sort(x[i]) end\n" +
-		"            return out\n" +
-		"        end\n" +
-		"        local keys = {}\n" +
-		"        for k in pairs(x) do keys[#keys+1] = k end\n" +
-		"        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)\n" +
-		"        local out = {}\n" +
-		"        for _,k in ipairs(keys) do out[k] = sort(x[k]) end\n" +
-		"        return out\n" +
-		"    end\n" +
-		"    local ok, json = pcall(require, 'json')\n" +
-		"    if not ok then ok, json = pcall(require, 'cjson') end\n" +
-		"    if not ok then error('json library not found') end\n" +
-		"    print(json.encode(sort(v)))\n" +
-		"end\n"
+        helperJson = "function __json(v)\n" +
+                "    local function sort(x)\n" +
+                "        if type(x) ~= 'table' then return x end\n" +
+                "        if x[1] ~= nil or #x > 0 then\n" +
+                "            local out = {}\n" +
+                "            for i=1,#x do out[i] = sort(x[i]) end\n" +
+                "            return out\n" +
+                "        end\n" +
+                "        local keys = {}\n" +
+                "        for k in pairs(x) do keys[#keys+1] = k end\n" +
+                "        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)\n" +
+                "        local out = {}\n" +
+                "        for _,k in ipairs(keys) do out[k] = sort(x[k]) end\n" +
+                "        return out\n" +
+                "    end\n" +
+                "    local ok, json = pcall(require, 'json')\n" +
+                "    if not ok then ok, json = pcall(require, 'cjson') end\n" +
+                "    if ok then\n" +
+                "        print(json.encode(sort(v)))\n" +
+                "        return\n" +
+                "    end\n" +
+                "    local function enc(x)\n" +
+                "        local t = type(x)\n" +
+                "        if t == 'nil' then\n" +
+                "            return 'null'\n" +
+                "        elseif t == 'boolean' or t == 'number' then\n" +
+                "            return tostring(x)\n" +
+                "        elseif t == 'string' then\n" +
+                "            return string.format('%q', x)\n" +
+                "        elseif t == 'table' then\n" +
+                "            if x[1] ~= nil or #x > 0 then\n" +
+                "                local parts = {}\n" +
+                "                for i=1,#x do parts[#parts+1] = enc(x[i]) end\n" +
+                "                return '['..table.concat(parts, ',')..']'\n" +
+                "            else\n" +
+                "                local keys = {}\n" +
+                "                for k in pairs(x) do keys[#keys+1] = k end\n" +
+                "                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)\n" +
+                "                local parts = {}\n" +
+                "                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end\n" +
+                "                return '{'..table.concat(parts, ',')..'}'\n" +
+                "            end\n" +
+                "        else\n" +
+                "            return 'null'\n" +
+                "        end\n" +
+                "    end\n" +
+                "    print(enc(sort(v)))\n" +
+                "end\n"
 
 	helperEval = "function __eval(code)\n" +
 		"    local f, err = load(code)\n" +

--- a/tests/dataset/tpc-h/compiler/lua/q1.lua.out
+++ b/tests/dataset/tpc-h/compiler/lua/q1.lua.out
@@ -101,8 +101,36 @@ function __json(v)
     end
     local ok, json = pcall(require, 'json')
     if not ok then ok, json = pcall(require, 'cjson') end
-    if not ok then error('json library not found') end
-    print(json.encode(sort(v)))
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
 end
 function __run_tests(tests)
     local function format_duration(d)

--- a/tests/dataset/tpc-h/compiler/lua/q1.out
+++ b/tests/dataset/tpc-h/compiler/lua/q1.out
@@ -1,2 +1,2 @@
-[{"avg_disc":0.075,"returnflag":"N","sum_charge":2906.5,"sum_disc_price":2750,"sum_base_price":3000,"avg_price":1500,"sum_qty":53,"avg_qty":26.5,"linestatus":"O","count_order":2}]
-   test Q1 aggregates revenue and quantity by returnflag + linestatus ... ok (8.0µs)
+[{"avg_disc":0.075,"avg_price":1500.0,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000.0,"sum_charge":2906.5,"sum_disc_price":2750.0,"sum_qty":53}]
+   test Q1 aggregates revenue and quantity by returnflag + linestatus ... ok (50.0µs)


### PR DESCRIPTION
## Summary
- implement a pure Lua JSON encoder for the runtime
- update TPCH Q1 golden Lua output and results
- revise Lua compiler tasks to reflect completed work

## Testing
- `go test -run TestLuaCompiler_TPCHQ1 -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cda1f5a9c832092a31d3e938f504e