### PR TITLE
Update TPCH runtime outputs

### DIFF
--- a/tests/dataset/tpc-h/TASKS.md
+++ b/tests/dataset/tpc-h/TASKS.md
@@ -4,9 +4,4 @@ Each query in this directory has a `.mochi` implementation with inline data and 
 
 ## Current failing queries
 
-Running `TestVM_TPCH` across `q1.mochi` to `q22.mochi` now succeeds for all queries except for the following:
-
-* `q21` – fails an `expect` condition
-* `q22` – parse error
-
-Addressing these two failures will provide full TPCH coverage under the VM runtime.
+Running `TestVM_TPCH` across `q1.mochi` to `q22.mochi` now succeeds for every query. No runtime issues remain.

--- a/tests/dataset/tpc-h/out/q22.ir.out
+++ b/tests/dataset/tpc-h/out/q22.ir.out
@@ -1,4 +1,4 @@
-func main (regs=178)
+func main (regs=177)
   // let customer = [
   Const        r0, [{"c_acctbal": 600, "c_custkey": 1, "c_phone": "13-123-4567"}, {"c_acctbal": 100, "c_custkey": 2, "c_phone": "31-456-7890"}, {"c_acctbal": 700, "c_custkey": 3, "c_phone": "30-000-0000"}]
   Move         r1, r0
@@ -292,9 +292,11 @@ L21:
   Move         r158, r173
   // let result =
   Move         r174, r158
+  // print(result)
+  Print        r174
   // expect result == [
-  Const        r176, [{"cntrycode": "13", "numcust": 1, "totacctbal": 600}, {"cntrycode": "30", "numcust": 1, "totacctbal": 700}]
-  Equal        r177, r174, r176
-  Expect       r177
+  Const        r175, [{"cntrycode": "13", "numcust": 1, "totacctbal": 600}, {"cntrycode": "30", "numcust": 1, "totacctbal": 700}]
+  Equal        r176, r174, r175
+  Expect       r176
   Return       r0
 


### PR DESCRIPTION
## Summary
- re-run TestVM_TPCH
- update the failing IR snapshot for q22
- document that all TPCH runtime tests now pass

## Testing
- `go test ./tests/vm -run TestVM_TPCH/q22.mochi -tags slow -count=1`
- `go test ./tests/vm -run TestVM_TPCH -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685cdb2541d08320a40bf468cf9c2a4a