### PR TITLE
Rust compiler TPCH Q1 support

### DIFF
--- a/compile/x/rust/TASKS.md
+++ b/compile/x/rust/TASKS.md
@@ -10,3 +10,5 @@ Completed tasks:
 - [x] Generate `struct` definitions for TPCH rows with `serde` `Serialize` implementations.
 - [x] Provide iterator-based helpers for `sum`, `avg` and `count`.
 - [x] Add a golden test in `tests/compiler/rust` once the query compiles successfully.
+- [x] Support iterating over group values and updated builtins to use `_count`, `_avg` and `_sum` helpers.
+- [x] Added TPCH q1 generated code under `tests/dataset/tpc-h/compiler/rust`.

--- a/compile/x/rust/runtime.go
+++ b/compile/x/rust/runtime.go
@@ -39,6 +39,13 @@ const (
 		"    sum / v.len() as f64\n" +
 		"}\n"
 
+	helperSum = "fn _sum<T: Into<f64> + Copy>(v: &[T]) -> f64 {\n" +
+		"    if v.is_empty() { return 0.0 }\n" +
+		"    let mut sum = 0.0;\n" +
+		"    for &it in v { sum += Into::<f64>::into(it); }\n" +
+		"    sum\n" +
+		"}\n"
+
 	helperInMap = "fn _in_map<K: std::cmp::Eq + std::hash::Hash, V>(m: &std::collections::HashMap<K, V>, k: &K) -> bool {\n" +
 		"    m.contains_key(k)\n" +
 		"}\n"
@@ -121,6 +128,7 @@ var helperMap = map[string]string{
 	"_map_get":      helperMapGet,
 	"_count":        helperCount,
 	"_avg":          helperAvg,
+	"_sum":          helperSum,
 	"_in_map":       helperInMap,
 	"_in_string":    helperInString,
 	"_input":        helperInput,

--- a/compile/x/rust/statements.go
+++ b/compile/x/rust/statements.go
@@ -292,7 +292,7 @@ func (c *Compiler) compileTypeDecl(t *parser.TypeDecl) error {
 }
 
 func (c *Compiler) compileFor(stmt *parser.ForStmt) error {
-	start, err := c.compileExpr(stmt.Source)
+	start, err := c.compileIterExpr(stmt.Source)
 	if err != nil {
 		return err
 	}
@@ -338,6 +338,8 @@ func (c *Compiler) compileFor(stmt *parser.ForStmt) error {
 				srcType := c.inferExprType(stmt.Source)
 				if lt, ok := srcType.(types.ListType); ok {
 					c.env.SetVar(stmt.Name, lt.Elem, true)
+				} else if gt, ok := srcType.(types.GroupType); ok {
+					c.env.SetVar(stmt.Name, gt.Elem, true)
 				} else {
 					c.env.SetVar(stmt.Name, types.AnyType{}, true)
 				}

--- a/compile/x/rust/util.go
+++ b/compile/x/rust/util.go
@@ -197,3 +197,16 @@ func usedAliases(e *parser.Expr) map[string]struct{} {
 	walk(node)
 	return aliases
 }
+
+// compileIterExpr compiles an expression that will be iterated over. If the
+// expression yields a group value, its underlying item slice is returned.
+func (c *Compiler) compileIterExpr(e *parser.Expr) (string, error) {
+	expr, err := c.compileExpr(e)
+	if err != nil {
+		return "", err
+	}
+	if _, ok := c.inferExprType(e).(types.GroupType); ok {
+		expr += ".items"
+	}
+	return expr, nil
+}

--- a/tests/compiler/rust/avg_builtin.rs.out
+++ b/tests/compiler/rust/avg_builtin.rs.out
@@ -1,3 +1,10 @@
 fn main() {
-    println!("{}", { let v = &vec![1, 2, 3]; if v.is_empty() { 0.0 } else { let mut sum = 0.0; for &it in v { sum += Into::<f64>::into(it); } sum / v.len() as f64 } });
+    println!("{}", _avg(&vec![1, 2, 3]));
+}
+
+fn _avg<T: Into<f64> + Copy>(v: &[T]) -> f64 {
+    if v.is_empty() { return 0.0 }
+    let mut sum = 0.0;
+    for &it in v { sum += Into::<f64>::into(it); }
+    sum / v.len() as f64
 }

--- a/tests/compiler/rust/count_builtin.rs.out
+++ b/tests/compiler/rust/count_builtin.rs.out
@@ -1,3 +1,7 @@
 fn main() {
-    println!("{}", vec![1, 2, 3].len() as i32);
+    println!("{}", _count(&vec![1, 2, 3]));
+}
+
+fn _count<T>(v: &[T]) -> i32 {
+    v.len() as i32
 }

--- a/tests/compiler/rust/group_by.rs.out
+++ b/tests/compiler/rust/group_by.rs.out
@@ -17,7 +17,7 @@ fn main() {
     let mut _res: Vec<std::collections::HashMap<String, std::boxed::Box<dyn std::any::Any>>> = Vec::new();
     for ks in order {
         let g = groups.get(&ks).unwrap().clone();
-        _res.push(std::collections::HashMap::from([("k".to_string(), g.key), ("c".to_string(), g.len() as i32)]));
+        _res.push(std::collections::HashMap::from([("k".to_string(), g.key), ("c".to_string(), _count(&g))]));
     }
     _res
 }
@@ -25,4 +25,8 @@ fn main() {
     for g in groups {
         println!("{} {}", g.k, g.c);
     }
+}
+
+fn _count<T>(v: &[T]) -> i32 {
+    v.len() as i32
 }

--- a/tests/dataset/tpc-h/compiler/rust/q1.out
+++ b/tests/dataset/tpc-h/compiler/rust/q1.out
@@ -1,0 +1,1 @@
+[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]

--- a/tests/dataset/tpc-h/compiler/rust/q1.rs.out
+++ b/tests/dataset/tpc-h/compiler/rust/q1.rs.out
@@ -1,19 +1,12 @@
-#[derive(Clone, Debug, Default)]
-struct LineItem {
-    l_quantity: i64,
-    l_extendedprice: f64,
-    l_discount: f64,
-    l_tax: f64,
-    l_returnflag: String,
-    l_linestatus: String,
-    l_shipdate: String,
+fn test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {
+    expect(result == vec![std::collections::HashMap::from([("returnflag".to_string(), "N"), ("linestatus".to_string(), "O"), ("sum_qty".to_string(), 53), ("sum_base_price".to_string(), 3000), ("sum_disc_price".to_string(), 950.0 + 1800.0), ("sum_charge".to_string(), (950.0 * 1.07) + (1800.0 * 1.05)), ("avg_qty".to_string(), 26.5), ("avg_price".to_string(), 1500), ("avg_disc".to_string(), 0.07500000000000001), ("count_order".to_string(), 2)])]);
 }
 
 fn main() {
-    let mut lineitem = vec![LineItem { l_quantity: 17, l_extendedprice: 1000.0, l_discount: 0.05, l_tax: 0.07, l_returnflag: "N".to_string(), l_linestatus: "O".to_string(), l_shipdate: "1998-08-01".to_string() }, LineItem { l_quantity: 36, l_extendedprice: 2000.0, l_discount: 0.1, l_tax: 0.05, l_returnflag: "N".to_string(), l_linestatus: "O".to_string(), l_shipdate: "1998-09-01".to_string() }, LineItem { l_quantity: 25, l_extendedprice: 1500.0, l_discount: 0.0, l_tax: 0.08, l_returnflag: "R".to_string(), l_linestatus: "F".to_string(), l_shipdate: "1998-09-03".to_string() }];
+    let mut lineitem = vec![std::collections::HashMap::from([("l_quantity".to_string(), 17), ("l_extendedprice".to_string(), 1000.0), ("l_discount".to_string(), 0.05), ("l_tax".to_string(), 0.07), ("l_returnflag".to_string(), "N"), ("l_linestatus".to_string(), "O"), ("l_shipdate".to_string(), "1998-08-01")]), std::collections::HashMap::from([("l_quantity".to_string(), 36), ("l_extendedprice".to_string(), 2000.0), ("l_discount".to_string(), 0.1), ("l_tax".to_string(), 0.05), ("l_returnflag".to_string(), "N"), ("l_linestatus".to_string(), "O"), ("l_shipdate".to_string(), "1998-09-01")]), std::collections::HashMap::from([("l_quantity".to_string(), 25), ("l_extendedprice".to_string(), 1500.0), ("l_discount".to_string(), 0.0), ("l_tax".to_string(), 0.08), ("l_returnflag".to_string(), "R"), ("l_linestatus".to_string(), "F"), ("l_shipdate".to_string(), "1998-09-03")])];
     let mut result = {
     #[derive(Clone, Debug)]
-    struct Group { key: std::collections::HashMap<String, std::boxed::Box<dyn std::any::Any>>, items: Vec<LineItem> }
+    struct Group { key: std::collections::HashMap<String, std::boxed::Box<dyn std::any::Any>>, items: Vec<std::collections::HashMap<String, std::boxed::Box<dyn std::any::Any>>> }
     let mut groups: std::collections::HashMap<String, Group> = std::collections::HashMap::new();
     let mut order: Vec<String> = Vec::new();
     for row in lineitem.clone() {
@@ -77,6 +70,7 @@ fn main() {
 }
 ;
     json(result);
+    test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus();
 }
 
 fn _avg<T: Into<f64> + Copy>(v: &[T]) -> f64 {
@@ -93,4 +87,7 @@ fn _sum<T: Into<f64> + Copy>(v: &[T]) -> f64 {
     let mut sum = 0.0;
     for &it in v { sum += Into::<f64>::into(it); }
     sum
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
 }


### PR DESCRIPTION
## Summary
- enhance Rust backend with `_sum` helper and group iteration
- update built-in call handling for `count`, `avg` and `sum`
- add compileIterExpr for iterating over groups
- regenerate affected golden files
- provide generated code for dataset `tpc-h/q1.mochi`
- document progress in `TASKS.md`

## Testing
- `LUA_PATH='/usr/share/lua/5.3/?.lua;;' go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cda4a51608320b76bb3420d170d9f