### PR TITLE
Add v0.10.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 # 📦 CHANGELOG.md
+## [0.10.2] – 2025-06-26T12:39:20+07:00
+
+### Added
+
+* `values` builtin with source context stack traces in the VM
+* `sum` helpers and group-by filters across backends
+* Query `let` clause and new TPC-H examples
+
+### Changed
+
+* CLI no longer executes code via the interpreter
+
+### Fixed
+
+* Binary operator precedence bug in the VM
+* TPC-H query corrections and compiler updates
+
 ## [0.10.1] – 2025-06-26T08:03:05+07:00
 
 ### Added

--- a/releases/v0.10.2.md
+++ b/releases/v0.10.2.md
@@ -1,0 +1,27 @@
+# Jun 2025 (v0.10.2)
+
+Released on Thu Jun 26 12:39:20 2025 +0700.
+
+Mochi v0.10.2 extends group query features and improves dataset tooling. The runtime gains richer stack traces and a new `values` builtin while compilers add `sum` helpers and group filtering across languages.
+
+## Runtime
+
+- `values` builtin for retrieving map values
+- Stack traces include source context
+- Fixed binary operator precedence
+
+## Compilers
+
+- `sum` helpers and group-by filtering support in many backends
+- Query `let` clause and TPC-H Q1 support across languages
+- Improved group iteration and example queries
+
+## Tooling
+
+- Isolated install and TPC-H update tools
+- CLI no longer runs via the interpreter
+
+## Fixes
+
+- Numerous TPC-H query and dataset corrections
+- Rust map key handling and other compiler updates


### PR DESCRIPTION
## Summary
- document v0.10.2 features
- add entry to CHANGELOG

## Testing
- `git log -1 --format="%cD" cbcfec7e29f1a4ad7717f8741797c01e35978d69`


------
https://chatgpt.com/codex/tasks/task_e_685cdd2e43d883209d474ca268633eb8