### PR TITLE
Enable Kotlin group_by unwrapping

### DIFF
--- a/compile/x/kt/TASKS.md
+++ b/compile/x/kt/TASKS.md
@@ -1,8 +1,9 @@
 # Kotlin Backend Tasks for TPCH Q1
 
-Dataset queries already map to Kotlin collection operators but grouping with aggregates is incomplete.
+The Kotlin backend now supports running the TPCH Q1 example.
 
-- Extend `_group_by` to handle complex keys and return lists of data classes.
-- Use Kotlin extensions to compute `sum`, `avg` and `count` on grouped values.
-- Ensure data classes for TPCH rows match the query structure.
-- Output JSON via `kotlinx.serialization` and add tests in `tests/compiler/kt`.
+Implemented features:
+- Grouping and query helpers via `_group_by` and `_query`.
+- Helper functions `_sum`, `_avg`, `_count` and `_json` for dataset processing.
+- Golden tests under `tests/dataset/tpc-h/compiler/kt` verify generated code
+  and runtime output.

--- a/compile/x/kt/runtime.go
+++ b/compile/x/kt/runtime.go
@@ -307,7 +307,11 @@ inline fun <reified T> _cast(v: Any?): T {
             groups[ks] = g
             order.add(ks)
         }
-        g.Items.add(it)
+        if (it is Array<*> && it.size == 1) {
+            g.Items.add(it[0])
+        } else {
+            g.Items.add(it)
+        }
     }
         return order.map { groups[it]!! }
 }`

--- a/tests/compiler/kt/group_by.kt.out
+++ b/tests/compiler/kt/group_by.kt.out
@@ -23,7 +23,12 @@ fun _group_by(src: List<Any?>, keyfn: (Any?) -> Any?): List<_Group> {
             groups[ks] = g
             order.add(ks)
         }
-        g.Items.add(it)
+        if (it is Array<*> && it.size == 1) {
+            g.Items.add(it[0])
+        } else {
+            g.Items.add(it)
+        }
     }
         return order.map { groups[it]!! }
 }
+

--- a/tests/dataset/tpc-h/compiler/kt/q1.kt.out
+++ b/tests/dataset/tpc-h/compiler/kt/q1.kt.out
@@ -122,7 +122,11 @@ fun _group_by(src: List<Any?>, keyfn: (Any?) -> Any?): List<_Group> {
             groups[ks] = g
             order.add(ks)
         }
-        g.Items.add(it)
+        if (it is Array<*> && it.size == 1) {
+            g.Items.add(it[0])
+        } else {
+            g.Items.add(it)
+        }
     }
         return order.map { groups[it]!! }
 }
@@ -278,3 +282,4 @@ fun _sum(v: Any?): Double {
     }
     return sum
 }
+


### PR DESCRIPTION
## Summary
- tweak `_group_by` helper for Kotlin compiler to unwrap single-element arrays
- regenerate golden outputs for Kotlin compiler
- document Kotlin backend TPCH Q1 status

## Testing
- `go test ./compile/x/kt -run TestKTCompiler_GoldenOutput -tags=slow -count=1`
- `go test ./compile/x/kt -run TestKTCompiler_TPCHQ1 -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685cda0bbb8083208d743c2a3025ed71