### PR TITLE
Add Clojure JSON load/save support

### DIFF
--- a/compile/x/clj/compiler.go
+++ b/compile/x/clj/compiler.go
@@ -1389,7 +1389,12 @@ func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {
 		opts = v
 	}
 	c.use("_load")
-	return fmt.Sprintf("(_load %s %s)", path, opts), nil
+	expr := fmt.Sprintf("(_load %s %s)", path, opts)
+	if l.Type != nil && l.Type.Simple != nil {
+		name := sanitizeName(*l.Type.Simple)
+		expr = fmt.Sprintf("(mapv %s %s)", name, expr)
+	}
+	return expr, nil
 }
 
 func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {

--- a/tests/compiler/clj/load_save_json.clj.out
+++ b/tests/compiler/clj/load_save_json.clj.out
@@ -1,0 +1,90 @@
+(ns main)
+
+(defn _parse_csv [text header delim]
+  (let [lines (->> (clojure.string/split-lines text)
+                   (remove clojure.string/blank?))
+        headers (if header
+                    (clojure.string/split (first lines) (re-pattern (str delim)))
+                    (map #(str "c" %) (range (count (clojure.string/split (first lines) (re-pattern (str delim)))))))]
+    (mapv (fn [line]
+            (let [parts (clojure.string/split line (re-pattern (str delim)))]
+              (zipmap headers parts)))
+          (drop (if header 1 0) lines))) )
+
+(defn _load [path opts]
+  (let [fmt (get opts :format "csv")
+        header (get opts :header true)
+        delim (first (or (get opts :delimiter ",") ","))
+        text (if (or (nil? path) (= path "") (= path "-"))
+               (slurp *in*)
+               (slurp path))]
+    (cond
+      (= fmt "csv") (_parse_csv text header delim)
+      (= fmt "tsv") (_parse_csv text header "\t")
+      (= fmt "json")
+        (let [data (clojure.data.json/read-str text :key-fn keyword)]
+          (cond
+            (map? data) [data]
+            (sequential? data) (vec data)
+            :else []))
+      (= fmt "jsonl")
+        (->> (clojure.string/split-lines text)
+             (remove clojure.string/blank?)
+             (mapv #(clojure.data.json/read-str % :key-fn keyword)))
+      (= fmt "yaml")
+        (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
+          (cond
+            (instance? java.util.Map y) [(into {} y)]
+            (instance? java.util.List y) (mapv #(into {} %) y)
+            :else []))
+      :else [])) )
+
+(defn _save [rows path opts]
+  (let [fmt (get opts :format "csv")
+        header (get opts :header false)
+        delim (first (or (get opts :delimiter ",") ","))
+        headers (if (seq rows) (sort (keys (first rows))) [])]
+    (cond
+      (= fmt "csv")
+        (let [lines (concat
+                      (when header [(clojure.string/join delim headers)])
+                      (map (fn [r]
+                             (clojure.string/join delim (map #(str (get r % "")) headers)))
+                           rows))
+              out (str (clojure.string/join "\n" lines) "\n")]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print out)
+            (spit path out)))
+      (= fmt "tsv")
+        (_save rows path (assoc opts :format "csv" :delimiter "\t"))
+      (= fmt "json")
+        (let [out (clojure.data.json/write-str rows)]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print out)
+            (spit path out)))
+      (= fmt "jsonl")
+        (let [out (clojure.string/join "\n" (map #(clojure.data.json/write-str %) rows))]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print (str out "\n"))
+            (spit path (str out "\n"))))
+      (= fmt "yaml")
+        (let [yaml (org.yaml.snakeyaml.Yaml.)
+              out (.dump yaml (clojure.walk/keywordize-keys
+                             (if (= 1 (count rows)) (first rows) rows)))]
+          (if (or (nil? path) (= path "") (= path "-"))
+            (print out)
+            (spit path out)))
+      :else
+        nil)) )
+
+(defn Person [name age]
+  {:__name "Person" :name name :age age}
+)
+
+
+(defn -main []
+  (def people (mapv Person (_load "" {:format "json"})))
+  (_save people "" {:format "json"})
+)
+
+(-main)

--- a/tests/compiler/clj/load_save_json.in
+++ b/tests/compiler/clj/load_save_json.in
@@ -1,0 +1,2 @@
+[{"name":"Alice","age":30},{"name":"Bob","age":40}]
+

--- a/tests/compiler/clj/load_save_json.mochi
+++ b/tests/compiler/clj/load_save_json.mochi
@@ -1,0 +1,7 @@
+type Person {
+  name: string
+  age: int
+}
+let people = load as Person with { format: "json" }
+save people with { format: "json" }
+

--- a/tests/compiler/clj/load_save_json.out
+++ b/tests/compiler/clj/load_save_json.out
@@ -1,0 +1,2 @@
+[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 40}]
+


### PR DESCRIPTION
## Summary
- support constructing records when loading typed data in the Clojure backend
- add golden tests for JSON load and save

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cf271d61c8320bd9549fe9207e69e