### PR TITLE
Add PHP JSON load/save support

### DIFF
--- a/compile/x/php/compiler.go
+++ b/compile/x/php/compiler.go
@@ -690,6 +690,10 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		return "(" + inner + ")", nil
 	case p.Query != nil:
 		return c.compileQueryExpr(p.Query)
+	case p.Load != nil:
+		return c.compileLoadExpr(p.Load)
+	case p.Save != nil:
+		return c.compileSaveExpr(p.Save)
 	default:
 		return "", fmt.Errorf("unsupported expression")
 	}
@@ -1449,6 +1453,28 @@ func isCompositeParam(p *parser.Param) bool {
 		}
 	}
 	return false
+}
+
+func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {
+	path := "\"\""
+	if l.Path != nil {
+		path = fmt.Sprintf("%q", *l.Path)
+	}
+	c.use("_load_json")
+	return fmt.Sprintf("_load_json(%s)", path), nil
+}
+
+func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
+	src, err := c.compileExpr(s.Src)
+	if err != nil {
+		return "", err
+	}
+	path := "\"\""
+	if s.Path != nil {
+		path = fmt.Sprintf("%q", *s.Path)
+	}
+	c.use("_save_json")
+	return fmt.Sprintf("_save_json(%s, %s)", src, path), nil
 }
 
 func exprVarSet(e *parser.Expr) map[string]bool {

--- a/compile/x/php/runtime.go
+++ b/compile/x/php/runtime.go
@@ -105,8 +105,26 @@ const helperGroupBy = "function _group_by($src, $keyfn) {\n" +
 	"    return $res;\n" +
 	"}\n"
 
+const helperLoadJSON = "function _load_json($path) {\n" +
+	"    $f = ($path === '' || $path === '-') ? fopen('php://stdin', 'r') : fopen($path, 'r');\n" +
+	"    if (!$f) { throw new Exception('cannot open ' . $path); }\n" +
+	"    $data = stream_get_contents($f);\n" +
+	"    if ($path !== '' && $path !== '-') fclose($f);\n" +
+	"    $val = json_decode($data, true);\n" +
+	"    if ($val === null) return [];\n" +
+	"    if (array_keys($val) !== range(0, count($val) - 1)) { return [$val]; }\n" +
+	"    return $val;\n" +
+	"}\n"
+
+const helperSaveJSON = "function _save_json($rows, $path) {\n" +
+	"    $out = json_encode($rows);\n" +
+	"    if ($path === '' || $path === '-') { fwrite(STDOUT, $out . PHP_EOL); } else { file_put_contents($path, $out); }\n" +
+	"}\n"
+
 var helperMap = map[string]string{
-	"_query":    helperQuery,
-	"_group":    helperGroupClass,
-	"_group_by": helperGroupBy,
+	"_query":     helperQuery,
+	"_group":     helperGroupClass,
+	"_group_by":  helperGroupBy,
+	"_load_json": helperLoadJSON,
+	"_save_json": helperSaveJSON,
 }

--- a/tests/compiler/php/load_save_json.in
+++ b/tests/compiler/php/load_save_json.in
@@ -1,0 +1,1 @@
+[{"name":"Alice","age":30},{"name":"Bob","age":40}]

--- a/tests/compiler/php/load_save_json.mochi
+++ b/tests/compiler/php/load_save_json.mochi
@@ -1,0 +1,6 @@
+ type Person {
+   name: string
+   age: int
+ }
+ let people = load as Person with { format: "json" }
+ save people with { format: "json" }

--- a/tests/compiler/php/load_save_json.out
+++ b/tests/compiler/php/load_save_json.out
@@ -1,0 +1,1 @@
+[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 40}]

--- a/tests/compiler/php/load_save_json.php.out
+++ b/tests/compiler/php/load_save_json.php.out
@@ -1,0 +1,27 @@
+<?php
+class Person {
+	public $name;
+	public $age;
+	public function __construct($fields = []) {
+		$this->name = $fields['name'] ?? null;
+		$this->age = $fields['age'] ?? null;
+	}
+}
+
+$people = _load_json("");
+_save_json($people, "");
+
+function _load_json($path) {
+    $f = ($path === '' || $path === '-') ? fopen('php://stdin', 'r') : fopen($path, 'r');
+    if (!$f) { throw new Exception('cannot open ' . $path); }
+    $data = stream_get_contents($f);
+    if ($path !== '' && $path !== '-') fclose($f);
+    $val = json_decode($data, true);
+    if ($val === null) return [];
+    if (array_keys($val) !== range(0, count($val) - 1)) { return [$val]; }
+    return $val;
+}
+function _save_json($rows, $path) {
+    $out = json_encode($rows);
+    if ($path === '' || $path === '-') { fwrite(STDOUT, $out . PHP_EOL); } else { file_put_contents($path, $out); }
+}


### PR DESCRIPTION
## Summary
- add JSON-based `load` and `save` support for PHP backend
- implement `_load_json` and `_save_json` runtime helpers
- add golden tests for PHP load/save

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cf28d6a5083208e2c720077901719