### PR TITLE
Add JSON load/save for smalltalk

### DIFF
--- a/tests/compiler/st/load_save_json.in
+++ b/tests/compiler/st/load_save_json.in
@@ -1,0 +1,1 @@
+[{"name":"Alice","age":30},{"name":"Bob","age":40}]

--- a/tests/compiler/st/load_save_json.mochi
+++ b/tests/compiler/st/load_save_json.mochi
@@ -1,0 +1,6 @@
+ type Person {
+   name: string
+   age: int
+ }
+ let people = load as Person with { format: "json" }
+ save people with { format: "json" }

--- a/tests/compiler/st/load_save_json.out
+++ b/tests/compiler/st/load_save_json.out
@@ -1,0 +1,1 @@
+[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 40}]

--- a/tests/compiler/st/load_save_json.st.out
+++ b/tests/compiler/st/load_save_json.st.out
@@ -1,0 +1,12 @@
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'types'!
+newPerson: name age: age | dict |
+	dict := Dictionary new.
+	dict at: 'name' put: name.
+	dict at: 'age' put: age.
+	^ dict
+!
+!!
+people := (Main _load: nil opts: Dictionary from: {format -> 'json'}).
+(Main _save: people path: nil opts: Dictionary from: {format -> 'json'}).


### PR DESCRIPTION
## Summary
- support `load`/`save` for JSON in the Smalltalk backend
- generate runtime helpers for loading and saving JSON data
- add golden test for `load`/`save` JSON example

## Testing
- `go test ./compile/x/st -tags slow -run TestSTCompiler_GoldenOutput`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cf29ba8e48320b2a9c653d883d67f