### PR TITLE
Add JSON load/save for Zig

### DIFF
--- a/compile/x/zig/compiler_test.go
+++ b/compile/x/zig/compiler_test.go
@@ -103,7 +103,11 @@ func TestZigCompiler_SubsetPrograms(t *testing.T) {
 		if out, err := exec.Command(zigc, "build-exe", file, "-O", "ReleaseSafe", "-femit-bin="+exe).CombinedOutput(); err != nil {
 			return nil, fmt.Errorf("\u274c zig build error: %w\n%s", err, out)
 		}
-		out, err := exec.Command(exe).CombinedOutput()
+		cmd := exec.Command(exe)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return nil, fmt.Errorf("\u274c run error: %w\n%s", err, out)
 		}

--- a/tests/compiler/zig/load_json.mochi
+++ b/tests/compiler/zig/load_json.mochi
@@ -1,0 +1,14 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+let people = load "tests/compiler/zig/people.json" as Person with {
+  format: "json",
+}
+let adults = from p in people
+             where p.age >= 18
+             select { name: p.name, email: p.email }
+for a in adults {
+  print(a.name, a.email)
+}

--- a/tests/compiler/zig/load_json.out
+++ b/tests/compiler/zig/load_json.out
@@ -1,0 +1,2 @@
+Alice alice@example.com
+Charlie charlie@example.com

--- a/tests/compiler/zig/people.json
+++ b/tests/compiler/zig/people.json
@@ -1,0 +1,1 @@
+[{"name":"Alice","age":30,"email":"alice@example.com"},{"name":"Bob","age":15,"email":"bob@example.com"},{"name":"Charlie","age":20,"email":"charlie@example.com"}]

--- a/tests/compiler/zig/save_json_stdout.mochi
+++ b/tests/compiler/zig/save_json_stdout.mochi
@@ -1,0 +1,9 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+let people = load "tests/compiler/zig/people.json" as Person with {
+  format: "json",
+}
+save people with { format: "json" }

--- a/tests/compiler/zig/save_json_stdout.out
+++ b/tests/compiler/zig/save_json_stdout.out
@@ -1,0 +1,1 @@
+[{"name":"Alice","age":30,"email":"alice@example.com"},{"name":"Bob","age":15,"email":"bob@example.com"},{"name":"Charlie","age":20,"email":"charlie@example.com"}]


### PR DESCRIPTION
## Summary
- support `load` and `save` for JSON in Zig compiler
- emit helpers for reading/writing JSON data
- allow Zig compiler tests to read `.in` files
- add golden tests for loading and saving JSON

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cf29f75e08320a32d1b442f2992fc