### PR TITLE
Add JSON load/save for Prolog

### DIFF
--- a/compile/x/pl/README.md
+++ b/compile/x/pl/README.md
@@ -307,6 +307,7 @@ The Prolog backend can compile a subset of Mochi focused on core control flow an
  - Dataset queries with optional filtering, sorting, joins and limits
 - Helper predicates `dataset_filter/3` and `dataset_paginate/4` for filtering
   and paginating row lists
+- Data loading and persistence helpers `load_data/3` and `save_data/3` for JSON files
 ## Unsupported Features
 
 The Prolog backend focuses on basic control flow and list operations. Several
@@ -323,5 +324,4 @@ Mochi language features are not yet implemented:
 - Model declarations
 - Generative AI helpers (`generate`, `model`)
 - Embedding generation with `generate embedding`
-- Data loading and persistence helpers (`fetch`, `load`, `save`)
 - Package imports and exports

--- a/compile/x/pl/compiler.go
+++ b/compile/x/pl/compiler.go
@@ -235,4 +235,16 @@ func (c *Compiler) emitHelpers() {
 		}
 		c.writeln("")
 	}
+	if c.helpers["load_data"] {
+		for _, line := range strings.Split(strings.TrimSuffix(helperLoad, "\n"), "\n") {
+			c.writeln(line)
+		}
+		c.writeln("")
+	}
+	if c.helpers["save_data"] {
+		for _, line := range strings.Split(strings.TrimSuffix(helperSave, "\n"), "\n") {
+			c.writeln(line)
+		}
+		c.writeln("")
+	}
 }

--- a/tests/compiler/pl/load_json_to_json.mochi
+++ b/tests/compiler/pl/load_json_to_json.mochi
@@ -1,0 +1,11 @@
+type Person {
+  name: string
+  age: int
+  email: string
+}
+
+let people = load "tests/interpreter/valid/people.jsonl" as Person with {
+  format: "jsonl",
+}
+
+save people to "-" with { format: "json" }

--- a/tests/compiler/pl/load_json_to_json.out
+++ b/tests/compiler/pl/load_json_to_json.out
@@ -1,0 +1,5 @@
+[
+  {"age":30, "email":"alice@example.com", "name":"Alice"},
+  {"age":15, "email":"bob@example.com", "name":"Bob"},
+  {"age":20, "email":"charlie@example.com", "name":"Charlie"}
+]

--- a/tests/compiler/pl/load_json_to_json.pl.out
+++ b/tests/compiler/pl/load_json_to_json.pl.out
@@ -1,0 +1,36 @@
+:- style_check(-singleton).
+:- use_module(library(http/json)).
+load_data(Path, Opts, Rows) :-
+    (is_dict(Opts), get_dict(format, Opts, Fmt) -> true ; Fmt = 'json'),
+    (Path == '' ; Path == '-' -> read_string(user_input, _, Text) ; read_file_to_string(Path, Text, [])),
+    (Fmt == 'jsonl' ->
+        split_string(Text, '\n', ' \t\r', Lines0),
+        exclude(=(""), Lines0, Lines),
+        findall(D, (member(L, Lines), open_string(L, S), json_read_dict(S, D), close(S)), Rows)
+    ;
+        open_string(Text, S), json_read_dict(S, Data), close(S),
+        (is_list(Data) -> Rows = Data ; Rows = [Data])
+    ).
+
+
+:- use_module(library(http/json)).
+save_data(Rows, Path, Opts) :-
+    (is_dict(Opts), get_dict(format, Opts, Fmt) -> true ; Fmt = 'json'),
+    (Path == '' ; Path == '-' -> Out = current_output ; open(Path, write, Out)),
+    (Fmt == 'jsonl' ->
+        forall(member(R, Rows), (json_write_dict(Out, R), nl(Out)))
+    ;
+        json_write_dict(Out, Rows)
+    ),
+    (Out == current_output -> flush_output(Out) ; close(Out)).
+
+
+
+	main :-
+	dict_create(_V0, map, [format-"jsonl"]),
+	load_data("tests/interpreter/valid/people.jsonl", _V0, _V1),
+	People = _V1,
+	dict_create(_V2, map, [format-"json"]),
+	save_data(People, "-", _V2)
+	.
+:- initialization(main, main).

--- a/tests/compiler/pl/tpch_q1.pl.out
+++ b/tests/compiler/pl/tpch_q1.pl.out
@@ -23,6 +23,13 @@ avg_list([], 0).
 avg_list(L, R) :- sum_list(L, S), length(L, N), N > 0, R is S / N.
 
 
+sum(V, R) :-
+    is_dict(V), !, get_dict('Items', V, Items), sum_list(Items, R).
+sum(V, R) :-
+    is_list(V), !, sum_list(V, R).
+sum(_, _) :- throw(error('sum expects list or group')).
+
+
 expect(Cond) :- (Cond -> true ; throw(error('expect failed'))).
 
 
@@ -37,6 +44,10 @@ group_insert(Key, Item, [G|Gs], [G|Rs]) :- group_insert(Key, Item, Gs, Rs).
 group_pairs([], Acc, Res) :- reverse(Acc, Res).
 group_pairs([K-V|T], Acc, Res) :- group_insert(K, V, Acc, Acc1), group_pairs(T, Acc1, Res).
 group_by(List, Fn, Groups) :- findall(K-V, (member(V, List), call(Fn, V, K)), Pairs), group_pairs(Pairs, [], Groups).
+
+
+:- use_module(library(http/json)).
+json(V) :- json_write_dict(current_output, V), nl.
 
 
 		p__lambda0(Row, Res) :-
@@ -67,9 +78,9 @@ test_p_q1_aggregates_revenue_and_quantity_by_returnflag_+_linestatus :-
 	to_list(Lineitem, _V62),
 	dataset_filter(_V62, p__lambda0, _V63),
 	group_by(_V63, p__lambda1, _V64),
-	findall(_V65, (member(G, _V64), get_dict(key, G, _V12), get_dict(returnflag, _V12, _V13), get_dict(key, G, _V14), get_dict(linestatus, _V14, _V15), to_list(G, _V17), findall(_V18, (member(X, _V17), get_dict(l_quantity, X, _V16), _V18 = _V16), _V19), call(Sum, _V19, _V20), to_list(G, _V22), findall(_V23, (member(X, _V22), get_dict(l_extendedprice, X, _V21), _V23 = _V21), _V24), call(Sum, _V24, _V25), to_list(G, _V30), findall(_V31, (member(X, _V30), get_dict(l_extendedprice, X, _V26), get_dict(l_discount, X, _V27), _V28 is 1 - _V27, _V29 is _V26 * _V28, _V31 = _V29), _V32), call(Sum, _V32, _V33), to_list(G, _V41), findall(_V42, (member(X, _V41), get_dict(l_extendedprice, X, _V34), get_dict(l_discount, X, _V35), _V36 is 1 - _V35, _V39 is _V34 * _V36, get_dict(l_tax, X, _V37), _V38 is 1 + _V37, _V40 is _V39 * _V38, _V42 = _V40), _V43), call(Sum, _V43, _V44), to_list(G, _V46), findall(_V47, (member(X, _V46), get_dict(l_quantity, X, _V45), _V47 = _V45), _V48), avg(_V48, _V49), to_list(G, _V51), findall(_V52, (member(X, _V51), get_dict(l_extendedprice, X, _V50), _V52 = _V50), _V53), avg(_V53, _V54), to_list(G, _V56), findall(_V57, (member(X, _V56), get_dict(l_discount, X, _V55), _V57 = _V55), _V58), avg(_V58, _V59), count(G, _V60), dict_create(_V61, map, [returnflag-_V13, linestatus-_V15, sum_qty-_V20, sum_base_price-_V25, sum_disc_price-_V33, sum_charge-_V44, avg_qty-_V49, avg_price-_V54, avg_disc-_V59, count_order-_V60]), _V65 = _V61), _V66),
+	findall(_V65, (member(G, _V64), get_dict(key, G, _V12), get_dict(returnflag, _V12, _V13), get_dict(key, G, _V14), get_dict(linestatus, _V14, _V15), to_list(G, _V17), findall(_V18, (member(X, _V17), get_dict(l_quantity, X, _V16), _V18 = _V16), _V19), sum(_V19, _V20), to_list(G, _V22), findall(_V23, (member(X, _V22), get_dict(l_extendedprice, X, _V21), _V23 = _V21), _V24), sum(_V24, _V25), to_list(G, _V30), findall(_V31, (member(X, _V30), get_dict(l_extendedprice, X, _V26), get_dict(l_discount, X, _V27), _V28 is 1 - _V27, _V29 is _V26 * _V28, _V31 = _V29), _V32), sum(_V32, _V33), to_list(G, _V41), findall(_V42, (member(X, _V41), get_dict(l_extendedprice, X, _V34), get_dict(l_discount, X, _V35), _V36 is 1 - _V35, _V39 is _V34 * _V36, get_dict(l_tax, X, _V37), _V38 is 1 + _V37, _V40 is _V39 * _V38, _V42 = _V40), _V43), sum(_V43, _V44), to_list(G, _V46), findall(_V47, (member(X, _V46), get_dict(l_quantity, X, _V45), _V47 = _V45), _V48), avg(_V48, _V49), to_list(G, _V51), findall(_V52, (member(X, _V51), get_dict(l_extendedprice, X, _V50), _V52 = _V50), _V53), avg(_V53, _V54), to_list(G, _V56), findall(_V57, (member(X, _V56), get_dict(l_discount, X, _V55), _V57 = _V55), _V58), avg(_V58, _V59), count(G, _V60), dict_create(_V61, map, [returnflag-_V13, linestatus-_V15, sum_qty-_V20, sum_base_price-_V25, sum_disc_price-_V33, sum_charge-_V44, avg_qty-_V49, avg_price-_V54, avg_disc-_V59, count_order-_V60]), _V65 = _V61), _V66),
 	Result = _V66,
-	call(Json, Result, _V67),
+	json(Result),
 	test_p_q1_aggregates_revenue_and_quantity_by_returnflag_+_linestatus
 	.
 :- initialization(main, main).


### PR DESCRIPTION
## Summary
- add `load_data/3` and `save_data/3` helpers for the Prolog backend
- generate Prolog code for `load` and `save` expressions
- document new helpers in the backend README
- add golden test for loading JSONL and saving JSON
- update `tpch_q1` golden output

## Testing
- `go test ./compile/x/pl -tags slow -run TestPrologCompiler_GoldenOutput -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cf28f270c83209e00053e9a3cc926