### PR TITLE
Implement JSON load/save helpers for Rust

### DIFF
--- a/compile/x/rust/runtime.go
+++ b/compile/x/rust/runtime.go
@@ -110,11 +110,27 @@ const (
 		"    String::new()\n" +
 		"}\n"
 
-	helperLoad = "fn _load<T>(_path: &str, _opts: std::collections::HashMap<String, String>) -> Vec<T> {\n" +
+	helperLoad = "fn _load<T: serde::de::DeserializeOwned>(_path: &str, _opts: std::collections::HashMap<String, String>) -> Vec<T> {\n" +
+		"    use std::io::Read;\n" +
+		"    let mut data = String::new();\n" +
+		"    if _path.is_empty() || _path == \"-\" {\n" +
+		"        std::io::stdin().read_to_string(&mut data).unwrap();\n" +
+		"    } else if let Ok(mut f) = std::fs::File::open(_path) {\n" +
+		"        f.read_to_string(&mut data).unwrap();\n" +
+		"    }\n" +
+		"    if let Ok(v) = serde_json::from_str::<Vec<T>>(&data) { return v; }\n" +
+		"    if let Ok(v) = serde_json::from_str::<T>(&data) { return vec![v]; }\n" +
 		"    Vec::new()\n" +
 		"}\n"
 
-	helperSave = "fn _save<T>(_src: &[T], _path: &str, _opts: std::collections::HashMap<String, String>) {\n" +
+	helperSave = "fn _save<T: serde::Serialize>(_src: &[T], _path: &str, _opts: std::collections::HashMap<String, String>) {\n" +
+		"    if let Ok(text) = serde_json::to_string(_src) {\n" +
+		"        if _path.is_empty() || _path == \"-\" {\n" +
+		"            println!(\"{}\", text);\n" +
+		"        } else {\n" +
+		"            std::fs::write(_path, text).unwrap();\n" +
+		"        }\n" +
+		"    }\n" +
 		"}\n"
 
 	helperExpect = "fn expect(cond: bool) {\n" +

--- a/tests/compiler/rust/load_save_json.rs.out
+++ b/tests/compiler/rust/load_save_json.rs.out
@@ -9,8 +9,24 @@ fn main() {
     _save(people, "out.json", std::collections::HashMap::from([("format".to_string(), "json")]));
 }
 
-fn _load<T>(_path: &str, _opts: std::collections::HashMap<String, String>) -> Vec<T> {
+fn _load<T: serde::de::DeserializeOwned>(_path: &str, _opts: std::collections::HashMap<String, String>) -> Vec<T> {
+    use std::io::Read;
+    let mut data = String::new();
+    if _path.is_empty() || _path == "-" {
+        std::io::stdin().read_to_string(&mut data).unwrap();
+    } else if let Ok(mut f) = std::fs::File::open(_path) {
+        f.read_to_string(&mut data).unwrap();
+    }
+    if let Ok(v) = serde_json::from_str::<Vec<T>>(&data) { return v; }
+    if let Ok(v) = serde_json::from_str::<T>(&data) { return vec![v]; }
     Vec::new()
 }
-fn _save<T>(_src: &[T], _path: &str, _opts: std::collections::HashMap<String, String>) {
+fn _save<T: serde::Serialize>(_src: &[T], _path: &str, _opts: std::collections::HashMap<String, String>) {
+    if let Ok(text) = serde_json::to_string(_src) {
+        if _path.is_empty() || _path == "-" {
+            println!("{}", text);
+        } else {
+            std::fs::write(_path, text).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement JSON `load`/`save` helpers in the Rust runtime
- update golden output for load/save json test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685cfded5c3c83209cbabf4bdc75be9d