### PR TITLE
Improve Fortran json load/save

### DIFF
--- a/compile/x/fortran/helpers.go
+++ b/compile/x/fortran/helpers.go
@@ -19,3 +19,30 @@ func identName(e *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+func loadTypeName(e *parser.Expr) (string, bool) {
+	if e == nil || len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 || u.Value == nil {
+		return "", false
+	}
+	v := u.Value
+	if len(v.Ops) != 0 || v.Target == nil || v.Target.Load == nil {
+		return "", false
+	}
+	if v.Target.Load.Type != nil && v.Target.Load.Type.Simple != nil {
+		return sanitizeName(*v.Target.Load.Type.Simple), true
+	}
+	return "", false
+}
+
+func isBuiltin(name string) bool {
+	switch name {
+	case "int", "float", "string", "bool":
+		return true
+	default:
+		return false
+	}
+}

--- a/tests/compiler/fortran/load_save_json.f90.out
+++ b/tests/compiler/fortran/load_save_json.f90.out
@@ -4,7 +4,8 @@ program main
     character(:), allocatable :: name
     integer(kind=8) :: age
   end type Person
-  integer(kind=8) :: people
+  type(Person), allocatable :: people(:)
+  allocate(people(0))
   people = load_json_Person('')
-  call save_json_int(people, '')
+  call save_json_Person(people, '')
 end program main


### PR DESCRIPTION
## Summary
- add helper to detect load expression type and builtin types
- infer list element structs and track them in compiler
- emit typed arrays for `load` results
- specialize `save_json` calls based on source type
- update golden test for Fortran load/save json

## Testing
- `go test ./compile/x/fortran -run TestFortranCompiler_GoldenOutput -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685cfd257a548320a3587a849d9932c6