### PR TITLE
Add fetch support for OCaml backend

### DIFF
--- a/compile/x/ocaml/README.md
+++ b/compile/x/ocaml/README.md
@@ -39,6 +39,7 @@ mochi build --target ocaml main.mochi -o main.ml
 - built-ins `len`, `print`, `str`, `input`
 - simple `match` expressions with constant patterns
 - dataset queries with `from`/`where`/`select` and optional `skip`, `take` and `sort by`
+- `fetch`, `load` and `save` expressions
 - test blocks and `expect` statements
 
 
@@ -72,7 +73,7 @@ These tests verify both the generated program output and the emitted `.ml` code.
 - Comprehensive pattern matching and union types
 - Modules and `import` declarations
 - Struct and enum type declarations
-- `fetch`, `load` and `generate` expressions
+- `generate` expressions
 - Agent and model blocks
 - Concurrency primitives like `spawn` and channels
  - Streams, LLM helpers and the foreign function interface

--- a/tests/compiler/ocaml/fetch_builtin.json
+++ b/tests/compiler/ocaml/fetch_builtin.json
@@ -1,0 +1,1 @@
+{"message":"hello"}

--- a/tests/compiler/ocaml/fetch_builtin.ml.out
+++ b/tests/compiler/ocaml/fetch_builtin.ml.out
@@ -1,0 +1,66 @@
+let rec _read_all ic =
+  try let line = input_line ic in
+      line ^ "\n" ^ _read_all ic
+  with End_of_file -> "";;
+
+let _read_input path =
+  let ic = match path with
+    | None -> stdin
+    | Some p when p = "" || p = "-" -> stdin
+    | Some p -> open_in p in
+  let txt = _read_all ic in
+  if ic != stdin then close_in ic;
+  txt;;
+
+let _load path _ =
+  let text = _read_input path in
+  match Yojson.Basic.from_string text with
+  | `List items -> items
+  | json -> [json];;
+
+let _save rows path _ =
+  let oc = match path with
+    | None -> stdout
+    | Some p when p = "" || p = "-" -> stdout
+    | Some p -> open_out p in
+  Yojson.Basic.to_channel oc (`List rows);
+  output_char oc '\n';
+  if oc != stdout then close_out oc;;
+
+let _fetch url opts =
+  let method_ =
+    match opts with
+    | None -> "GET"
+    | Some tbl ->
+        (try Yojson.Basic.Util.to_string (Hashtbl.find tbl "method") with Not_found -> "GET") in
+  let url_ref = ref url in
+  let args = ref ["curl"; "-s"; "-X"; method_] in
+  (match opts with
+  | Some tbl ->
+      (try
+        let headers = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "headers") in
+        List.iter (fun (k,v) -> args := !args @ ["-H"; k ^ ": " ^ Yojson.Basic.to_string v]) headers
+      with Not_found -> ());
+      (try
+        let q = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "query") in
+        let qs = String.concat "&" (List.map (fun (k,v) -> k ^ "=" ^ Yojson.Basic.to_string v) q) in
+        let sep = if String.contains !url_ref '?' then '&' else '?' in
+        url_ref := !url_ref ^ (String.make 1 sep) ^ qs
+      with Not_found -> ());
+      (try
+        let body = Hashtbl.find tbl "body" in
+        args := !args @ ["-d"; Yojson.Basic.to_string body]
+      with Not_found -> ());
+      (try
+        let t = Hashtbl.find tbl "timeout" in
+        args := !args @ ["--max-time"; Yojson.Basic.to_string t]
+      with Not_found -> ());
+  | None -> ());
+  args := !args @ [!url_ref];
+  let ic = Unix.open_process_in (String.concat " " !args) in
+  let txt = _read_all ic in
+  close_in ic;
+  Yojson.Basic.from_string txt;;
+
+let data = _fetch "file://tests/compiler/ocaml/fetch_builtin.json" None;;
+_save [data] None (let tbl = Hashtbl.create 1 in Hashtbl.add tbl "format" "json"; tbl);;

--- a/tests/compiler/ocaml/fetch_builtin.mochi
+++ b/tests/compiler/ocaml/fetch_builtin.mochi
@@ -1,0 +1,2 @@
+let data = fetch "file://tests/compiler/ocaml/fetch_builtin.json"
+save [data] with { format: "json" }

--- a/tests/compiler/ocaml/fetch_builtin.out
+++ b/tests/compiler/ocaml/fetch_builtin.out
@@ -1,0 +1,1 @@
+[{"message":"hello"}]


### PR DESCRIPTION
## Summary
- implement `_fetch` helper in OCaml compiler
- compile `fetch` expressions using new helper
- add OCaml golden test for fetching JSON
- document fetch support in OCaml README

## Testing
- `go test ./compile/x/ocaml -run TestOCamlCompiler_GoldenOutput -tags slow` *(fails: type error in unrelated test)*
- `go test ./compile/x/ocaml -run Fetch_builtin -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_685d08a21e788320a3b9babfe77adeb3