### PR TITLE
Add Ruby fetch options support

### DIFF
--- a/compile/x/rb/compiler.go
+++ b/compile/x/rb/compiler.go
@@ -1519,7 +1519,7 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		withStr = w
+		withStr = fmt.Sprintf("(%s).to_h.transform_keys(&:to_s)", w)
 	} else {
 		withStr = "nil"
 	}

--- a/compile/x/rb/compiler_test.go
+++ b/compile/x/rb/compiler_test.go
@@ -39,6 +39,7 @@ func compileAndRun(t *testing.T, src string) (string, error) {
 		return "", err
 	}
 	cmd := exec.Command("ruby", file)
+	cmd.Dir = findRepoRoot(t)
 	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 		cmd.Stdin = bytes.NewReader(data)
 	}
@@ -112,6 +113,7 @@ func TestRBCompiler_SubsetPrograms(t *testing.T) {
 			return nil, err
 		}
 		cmd := exec.Command("ruby", file)
+		cmd.Dir = findRepoRoot(t)
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}
@@ -164,6 +166,7 @@ func TestRBCompiler_ValidPrograms(t *testing.T) {
 				t.Fatalf("write error: %v", err)
 			}
 			cmd := exec.Command("ruby", file)
+			cmd.Dir = findRepoRoot(t)
 			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 				cmd.Stdin = bytes.NewReader(data)
 			}
@@ -235,6 +238,7 @@ func TestRBCompiler_TPCHQ1(t *testing.T) {
 		t.Fatalf("write error: %v", err)
 	}
 	cmd := exec.Command("ruby", file)
+	cmd.Dir = findRepoRoot(t)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("ruby run error: %v\n%s", err, out)

--- a/compile/x/rb/runtime.go
+++ b/compile/x/rb/runtime.go
@@ -8,6 +8,11 @@ const (
   require 'json'
   require 'uri'
   uri = URI(url)
+  if uri.scheme.nil? || uri.scheme == '' || uri.scheme == 'file'
+    path = uri.scheme == 'file' ? uri.path : url
+    data = File.read(path)
+    return JSON.parse(data)
+  end
   method = 'GET'
   headers = {}
   body = nil

--- a/tests/compiler/rb/fetch_options.json
+++ b/tests/compiler/rb/fetch_options.json
@@ -1,0 +1,1 @@
+{"message":"hello options"}

--- a/tests/compiler/rb/fetch_options.mochi
+++ b/tests/compiler/rb/fetch_options.mochi
@@ -1,0 +1,11 @@
+type Msg {
+  message: string
+}
+
+let data: Msg = (fetch "tests/compiler/rb/fetch_options.json" with {
+  method: "GET",
+  headers: {"X-Test": "1"},
+  query: {"q": "1"},
+  timeout: 1.0
+}) as Msg
+print(data.message)

--- a/tests/compiler/rb/fetch_options.out
+++ b/tests/compiler/rb/fetch_options.out
@@ -1,0 +1,1 @@
+hello options

--- a/tests/compiler/rb/fetch_options.rb.out
+++ b/tests/compiler/rb/fetch_options.rb.out
@@ -1,0 +1,41 @@
+require 'ostruct'
+
+def _fetch(url, opts=nil)
+  require 'net/http'
+  require 'json'
+  require 'uri'
+  uri = URI(url)
+  if uri.scheme.nil? || uri.scheme == '' || uri.scheme == 'file'
+    path = uri.scheme == 'file' ? uri.path : url
+    data = File.read(path)
+    return JSON.parse(data)
+  end
+  method = 'GET'
+  headers = {}
+  body = nil
+  timeout = nil
+  if opts
+    method = opts['method'] || method
+    if q = opts['query']
+      q = URI.encode_www_form(q.to_h)
+      uri.query = [uri.query, q].compact.join('&')
+    end
+    body = JSON.generate(opts['body']) if opts['body']
+    if opts['headers']
+      opts['headers'].to_h.each { |k,v| headers[k] = v.to_s }
+    end
+    timeout = opts['timeout']
+  end
+  req = Net::HTTP.const_get(method.capitalize).new(uri)
+  headers.each { |k,v| req[k] = v }
+  req.body = body if body
+  Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: timeout) do |http|
+    resp = http.request(req)
+    return JSON.parse(resp.body)
+  end
+end
+
+Msg = Struct.new(:message, keyword_init: true)
+
+data = Msg.new(**((_fetch("tests/compiler/rb/fetch_options.json", (OpenStruct.new(method: "GET", headers: {"X-Test" => "1"}, query: {"q" => "1"}, timeout: 1.0)).to_h.transform_keys(&:to_s))).to_h.transform_keys(&:to_sym)))
+puts([data.message].join(" "))


### PR DESCRIPTION
## Summary
- support passing option maps to `_fetch` in Ruby backend
- handle file URLs in Ruby runtime
- run ruby compiler tests from repo root
- add golden tests for fetch with options

## Testing
- `go test ./...`
- `go test -tags slow ./compile/x/rb -run TestRBCompiler_SubsetPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685d08a8d9908320ab044fb3774d2a0f