### PR TITLE
Add Scala fetch options support

### DIFF
--- a/compile/x/scala/runtime.go
+++ b/compile/x/scala/runtime.go
@@ -15,7 +15,48 @@ const (
 implicit val _anyOrdering: Ordering[Any] = new Ordering[Any] { def compare(x: Any, y: Any): Int = _compare(x, y) }
 `
 	helperFetch = `def _fetch(url: String, opts: Map[String, Any]): Any = {
-        val src = scala.io.Source.fromURL(url)
+        import java.net.{HttpURLConnection, URL, URLEncoder}
+        import java.io.{BufferedWriter, OutputStreamWriter}
+        var u = url
+        if (opts != null && opts.contains("query")) {
+                val q = opts("query").asInstanceOf[scala.collection.Map[String, Any]]
+                val qs = q.map { case (k, v) =>
+                        URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(String.valueOf(v), "UTF-8")
+                }.mkString("&")
+                val sep = if (u.contains("?")) "&" else "?"
+                u = u + sep + qs
+        }
+        val conn = new URL(u).openConnection().asInstanceOf[HttpURLConnection]
+        var method = "GET"
+        if (opts != null && opts.contains("method")) {
+                method = opts("method").toString
+        }
+        conn.setRequestMethod(method)
+        if (opts != null && opts.contains("headers")) {
+                val hs = opts("headers").asInstanceOf[scala.collection.Map[String, Any]]
+                hs.foreach { case (k, v) => conn.setRequestProperty(k, v.toString) }
+        }
+        if (opts != null && opts.contains("timeout")) {
+                val t = opts("timeout") match {
+                        case i: Int => i.toDouble
+                        case l: Long => l.toDouble
+                        case f: Float => f.toDouble
+                        case d: Double => d
+                        case other => other.toString.toDouble
+                }
+                val ms = (t * 1000).toInt
+                conn.setConnectTimeout(ms)
+                conn.setReadTimeout(ms)
+        }
+        if (opts != null && opts.contains("body")) {
+                conn.setDoOutput(true)
+                val data = _to_json(opts("body"))
+                val w = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream))
+                w.write(data)
+                w.flush()
+                w.close()
+        }
+        val src = scala.io.Source.fromInputStream(conn.getInputStream)
         try {
                 val data = src.mkString
                 scala.util.parsing.json.JSON.parseFull(data).getOrElse(data)

--- a/tests/compiler/scala/fetch_builtin.json
+++ b/tests/compiler/scala/fetch_builtin.json
@@ -1,0 +1,1 @@
+{"message":"hello"}

--- a/tests/compiler/scala/fetch_builtin.mochi
+++ b/tests/compiler/scala/fetch_builtin.mochi
@@ -1,0 +1,6 @@
+type Msg {
+  message: string
+}
+
+let data: Msg = fetch "file://tests/compiler/scala/fetch_builtin.json"
+print(data.message)

--- a/tests/compiler/scala/fetch_builtin.scala.out
+++ b/tests/compiler/scala/fetch_builtin.scala.out
@@ -1,0 +1,57 @@
+case class Msg(message: String)
+
+object Main {
+	def main(args: Array[String]): Unit = {
+		val data = _fetch("file://tests/compiler/scala/fetch_builtin.json", Map[String, Any]())
+		println(data.message)
+	}
+}
+def _fetch(url: String, opts: Map[String, Any]): Any = {
+        import java.net.{HttpURLConnection, URL, URLEncoder}
+        import java.io.{BufferedWriter, OutputStreamWriter}
+        var u = url
+        if (opts != null && opts.contains("query")) {
+                val q = opts("query").asInstanceOf[scala.collection.Map[String, Any]]
+                val qs = q.map { case (k, v) =>
+                        URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(String.valueOf(v), "UTF-8")
+                }.mkString("&")
+                val sep = if (u.contains("?")) "&" else "?"
+                u = u + sep + qs
+        }
+        val conn = new URL(u).openConnection().asInstanceOf[HttpURLConnection]
+        var method = "GET"
+        if (opts != null && opts.contains("method")) {
+                method = opts("method").toString
+        }
+        conn.setRequestMethod(method)
+        if (opts != null && opts.contains("headers")) {
+                val hs = opts("headers").asInstanceOf[scala.collection.Map[String, Any]]
+                hs.foreach { case (k, v) => conn.setRequestProperty(k, v.toString) }
+        }
+        if (opts != null && opts.contains("timeout")) {
+                val t = opts("timeout") match {
+                        case i: Int => i.toDouble
+                        case l: Long => l.toDouble
+                        case f: Float => f.toDouble
+                        case d: Double => d
+                        case other => other.toString.toDouble
+                }
+                val ms = (t * 1000).toInt
+                conn.setConnectTimeout(ms)
+                conn.setReadTimeout(ms)
+        }
+        if (opts != null && opts.contains("body")) {
+                conn.setDoOutput(true)
+                val data = _to_json(opts("body"))
+                val w = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream))
+                w.write(data)
+                w.flush()
+                w.close()
+        }
+        val src = scala.io.Source.fromInputStream(conn.getInputStream)
+        try {
+                val data = src.mkString
+                scala.util.parsing.json.JSON.parseFull(data).getOrElse(data)
+        } finally src.close()
+}
+

--- a/tests/compiler/scala/fetch_options.mochi
+++ b/tests/compiler/scala/fetch_options.mochi
@@ -1,0 +1,8 @@
+let resp = fetch "https://example.com" with {
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  query: {"q": "test"},
+  body: {"x": 1},
+  timeout: 5.0
+}
+print(resp)

--- a/tests/compiler/scala/fetch_options.scala.out
+++ b/tests/compiler/scala/fetch_options.scala.out
@@ -1,0 +1,55 @@
+object Main {
+	def main(args: Array[String]): Unit = {
+		val resp = _fetch("https://example.com", scala.collection.mutable.Map("method" -> "POST", "headers" -> scala.collection.mutable.Map("Content-Type" -> "application/json"), "query" -> scala.collection.mutable.Map("q" -> "test"), "body" -> scala.collection.mutable.Map("x" -> 1), "timeout" -> 5))
+		println(resp)
+	}
+}
+def _fetch(url: String, opts: Map[String, Any]): Any = {
+        import java.net.{HttpURLConnection, URL, URLEncoder}
+        import java.io.{BufferedWriter, OutputStreamWriter}
+        var u = url
+        if (opts != null && opts.contains("query")) {
+                val q = opts("query").asInstanceOf[scala.collection.Map[String, Any]]
+                val qs = q.map { case (k, v) =>
+                        URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(String.valueOf(v), "UTF-8")
+                }.mkString("&")
+                val sep = if (u.contains("?")) "&" else "?"
+                u = u + sep + qs
+        }
+        val conn = new URL(u).openConnection().asInstanceOf[HttpURLConnection]
+        var method = "GET"
+        if (opts != null && opts.contains("method")) {
+                method = opts("method").toString
+        }
+        conn.setRequestMethod(method)
+        if (opts != null && opts.contains("headers")) {
+                val hs = opts("headers").asInstanceOf[scala.collection.Map[String, Any]]
+                hs.foreach { case (k, v) => conn.setRequestProperty(k, v.toString) }
+        }
+        if (opts != null && opts.contains("timeout")) {
+                val t = opts("timeout") match {
+                        case i: Int => i.toDouble
+                        case l: Long => l.toDouble
+                        case f: Float => f.toDouble
+                        case d: Double => d
+                        case other => other.toString.toDouble
+                }
+                val ms = (t * 1000).toInt
+                conn.setConnectTimeout(ms)
+                conn.setReadTimeout(ms)
+        }
+        if (opts != null && opts.contains("body")) {
+                conn.setDoOutput(true)
+                val data = _to_json(opts("body"))
+                val w = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream))
+                w.write(data)
+                w.flush()
+                w.close()
+        }
+        val src = scala.io.Source.fromInputStream(conn.getInputStream)
+        try {
+                val data = src.mkString
+                scala.util.parsing.json.JSON.parseFull(data).getOrElse(data)
+        } finally src.close()
+}
+


### PR DESCRIPTION
## Summary
- implement HTTP fetch options in Scala runtime
- add fetch compiler golden tests for Scala

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d08ae05cc83208ff74585d38d17dc