### PR TITLE
Implement fetch options for rust backend

### DIFF
--- a/compile/x/rust/expressions.go
+++ b/compile/x/rust/expressions.go
@@ -792,8 +792,16 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	opts := "std::collections::HashMap::new()"
+	if f.With != nil {
+		v, err := c.compileExpr(f.With)
+		if err != nil {
+			return "", err
+		}
+		opts = v
+	}
 	c.use("_fetch")
-	return fmt.Sprintf("_fetch(%s)", url), nil
+	return fmt.Sprintf("_fetch(%s, %s)", url, opts), nil
 }
 
 func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {

--- a/compile/x/rust/runtime.go
+++ b/compile/x/rust/runtime.go
@@ -106,7 +106,7 @@ const (
 		"    Vec::new()\n" +
 		"}\n"
 
-	helperFetch = "fn _fetch(_url: &str) -> String {\n" +
+	helperFetch = "fn _fetch(_url: &str, _opts: std::collections::HashMap<String, String>) -> String {\n" +
 		"    String::new()\n" +
 		"}\n"
 

--- a/tests/compiler/rust/fetch_builtin.json
+++ b/tests/compiler/rust/fetch_builtin.json
@@ -1,0 +1,1 @@
+{"message":"hello"}

--- a/tests/compiler/rust/fetch_builtin.mochi
+++ b/tests/compiler/rust/fetch_builtin.mochi
@@ -1,0 +1,6 @@
+type Msg {
+  message: string
+}
+
+let data: Msg = fetch "file://tests/compiler/rust/fetch_builtin.json"
+print(data.message)

--- a/tests/compiler/rust/fetch_builtin.rs.out
+++ b/tests/compiler/rust/fetch_builtin.rs.out
@@ -1,0 +1,13 @@
+#[derive(Clone, Debug, Default)]
+struct Msg {
+    message: String,
+}
+
+fn main() {
+    let mut data: Msg = _fetch("file://tests/compiler/rust/fetch_builtin.json", std::collections::HashMap::new());
+    println!("{}", data.message);
+}
+
+fn _fetch(_url: &str, _opts: std::collections::HashMap<String, String>) -> String {
+    String::new()
+}


### PR DESCRIPTION
## Summary
- add options parameter to Rust `_fetch` runtime helper
- compile fetch expressions with `with` options for Rust
- add Rust golden test for fetching JSON

## Testing
- `go test -tags slow ./compile/x/rust -run TestRustCompiler_GoldenOutput`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d08af18b8832084428ff7d16c52ca