### PR TITLE
Add HTTP fetch example for C++ backend

### DIFF
--- a/compile/x/cpp/README.md
+++ b/compile/x/cpp/README.md
@@ -224,6 +224,7 @@ Dataset queries support `where`, `skip`, `take`, `sort by`, `join` and basic `gr
 * List operators `union`, `union all`, `except` and `intersect`
 * Membership tests using `in`
 * Iterating over map keys with `for k in m`
+* Dataset helpers `fetch`, `load`, `save` for working with JSON and CSV data
 
 ### Unsupported features
 
@@ -232,12 +233,10 @@ Some LeetCode solutions use language constructs that the C++ backend can't yet t
 * Dataset queries with advanced grouping
 * Agents, streams and intents
 * `generate` blocks and model definitions
-* Dataset helpers such as `fetch`, `load`, `save` and SQL-style `from ...` queries
 * `logic` queries for Prolog-style reasoning
 * Foreign imports and `extern` declarations
 * Package management
 * Set literals and operations
-* HTTP `fetch` requests for JSON data
 * Concurrency primitives like `spawn` and channels
 * Reflection or macro facilities
 * Generic type parameters inside `type` blocks

--- a/tests/compiler/cpp/fetch_http.cpp.out
+++ b/tests/compiler/cpp/fetch_http.cpp.out
@@ -1,0 +1,33 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+static unordered_map<string,string> _fetch_parse(const string& s) {
+	unordered_map<string,string> row; size_t i=0;
+	while (i<s.size()) {
+		if (s[i]=='"') {
+			size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
+			i=s.find(':', j); if (i==string::npos) break; i++; while(i<s.size() && isspace(s[i])) i++;
+			string val;
+			if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
+			row[key]=val;
+		} else { i++; }
+	}
+	return row;
+}
+unordered_map<string,string> _fetch(const string& url, const unordered_map<string,any>& opts) {
+	(void)opts;
+	string data;
+	if (url.rfind("file://",0)==0) {
+		ifstream f(url.substr(7)); stringstream ss; ss<<f.rdbuf(); data=ss.str();
+	} else {
+		string cmd="curl -s "+url;
+		FILE* p=popen(cmd.c_str(), "r"); char buf[4096]; while(p && !feof(p)){ size_t n=fread(buf,1,sizeof(buf),p); data.append(buf,n);} if(p) pclose(p);
+	}
+	return _fetch_parse(data);
+}
+
+int main() {
+	unordered_map<string, string> todo = _fetch(string("https://jsonplaceholder.typicode.com/todos/1"), unordered_map<string,any>{});
+	std::cout << (todo[string("title")]) << std::endl;
+	return 0;
+}

--- a/tests/compiler/cpp/fetch_http.mochi
+++ b/tests/compiler/cpp/fetch_http.mochi
@@ -1,0 +1,2 @@
+let todo: map<string, string> = fetch "https://jsonplaceholder.typicode.com/todos/1"
+print(todo["title"])

--- a/tests/compiler/cpp/fetch_http.out
+++ b/tests/compiler/cpp/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem


### PR DESCRIPTION
## Summary
- update C++ backend docs to note dataset helper support
- add `fetch_http` example to exercise HTTP fetch via curl

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d1eeb12448320a14c419dac5b73ea