### PR TITLE
Add async fetch for Dart backend

### DIFF
--- a/tests/compiler/dart/fetch_options.dart.out
+++ b/tests/compiler/dart/fetch_options.dart.out
@@ -2,42 +2,50 @@ import 'dart:io';
 import 'dart:convert';
 
 class Msg {
-	String message;
-	Msg({required this.message});
-	factory Msg.fromJson(Map<String,dynamic> m) {
-		return Msg(message: m['message'] as String);
-	}
+        String message;
+        Msg({required this.message});
+        factory Msg.fromJson(Map<String,dynamic> m) {
+                return Msg(message: m['message'] as String);
+        }
 }
 _structParsers['Msg'] = (m) => Msg.fromJson(m);
 
-void main() {
-	Msg data = _fetch("file://tests/compiler/dart/fetch_options.json", {"method": "GET", "headers": {"User-Agent": "Mochi"}, "query": {"q": "foo"}, "body": {"foo": true}, "timeout": 5});
-	print(data.message);
+Future<void> main() async {
+        Msg data = await _fetch("file://tests/compiler/dart/fetch_options.json", {"method": "GET", "headers": {"User-Agent": "Mochi"}, "query": {"q": "foo"}, "body": {"foo": true}, "timeout": 5});
+        print(data.message);
+        await _waitAll();
 }
 
-dynamic _fetch(String url, Map<String,dynamic>? opts) {
-    var args = ['-s'];
+Future<dynamic> _fetch(String url, Map<String,dynamic>? opts) async {
     var method = opts?['method']?.toString() ?? 'GET';
-    args.addAll(['-X', method]);
+    Uri uri = Uri.parse(url);
+    if (opts?['query'] != null) {
+        var q = (opts!['query'] as Map).map((k,v)=>MapEntry(k.toString(), v.toString()));
+        uri = uri.replace(queryParameters: {...uri.queryParameters, ...q});
+    }
+    var client = HttpClient();
+    if (opts?['timeout'] != null) {
+        var t = Duration(seconds: (opts!['timeout'] is num ? opts['timeout'].round() : int.parse(opts['timeout'].toString())));
+        client.connectionTimeout = t;
+    }
+    var req = await client.openUrl(method, uri);
     if (opts?['headers'] != null) {
         for (var e in (opts!['headers'] as Map).entries) {
-            args.addAll(['-H', '${e.key}: ${e.value}']);
+            req.headers.set(e.key.toString(), e.value.toString());
         }
     }
-    if (opts?['query'] != null) {
-        var qs = Uri(queryParameters: (opts!['query'] as Map).map((k,v)=>MapEntry(k.toString(), v.toString()))).query;
-        var sep = url.contains('?') ? '&' : '?';
-        url = url + sep + qs;
-    }
     if (opts != null && opts.containsKey('body')) {
-        args.addAll(['-d', jsonEncode(opts['body'])]);
+        req.headers.contentType = ContentType('application', 'json', charset: 'utf-8');
+        req.write(jsonEncode(opts['body']));
     }
-    if (opts?['timeout'] != null) {
-        args.addAll(['--max-time', opts!['timeout'].toString()]);
-    }
-    args.add(url);
-    var res = Process.runSync('curl', args);
-    return jsonDecode(res.stdout.toString());
+    var resp = await req.close();
+    var text = await resp.transform(utf8.decoder).join();
+    client.close();
+    return jsonDecode(text);
 }
 
+List<Future<dynamic>> _pending = [];
+Future<void> _waitAll() async {
+    await Future.wait(_pending);
+}
 


### PR DESCRIPTION
## Summary
- extend Dart compiler to detect fetch expressions
- make generated main async when fetch is used
- implement async `_fetch` helper using `HttpClient`
- update Dart fetch example output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d1ef32b6083209eb9ab81913aa41e