### PR TITLE
Add F# fetch HTTP example test

### DIFF
--- a/tests/compiler/fs/fetch_http.fs.out
+++ b/tests/compiler/fs/fetch_http.fs.out
@@ -1,0 +1,67 @@
+open System
+
+let _fetch (url: string) (opts: Map<string,obj> option) : Map<string,obj> =
+  if url.StartsWith("file://") then
+    let path = url.Substring(7)
+    let text = System.IO.File.ReadAllText(path)
+    Map.ofList [("status", box 200); ("body", box text)]
+  else
+    let mutable urlStr = url
+    let meth = opts |> Option.bind (Map.tryFind "method") |> Option.map string |> Option.defaultValue "GET"
+    if opts.IsSome then
+      match Map.tryFind "query" opts.Value with
+      | Some q ->
+          let qs =
+            (q :?> Map<string,obj>)
+            |> Seq.map (fun (KeyValue(k,v)) -> System.Uri.EscapeDataString(k) + "=" + System.Uri.EscapeDataString(string v))
+            |> String.concat "&"
+          let sep = if urlStr.Contains("?") then "&" else "?"
+          urlStr <- urlStr + sep + qs
+      | None -> ()
+    use msg = new System.Net.Http.HttpRequestMessage(new System.Net.Http.HttpMethod(meth), urlStr)
+    if opts.IsSome then
+      match Map.tryFind "body" opts.Value with
+      | Some b ->
+          let json = System.Text.Json.JsonSerializer.Serialize(b)
+          msg.Content <- new System.Net.Http.StringContent(json, System.Text.Encoding.UTF8, "application/json")
+      | None -> ()
+    if opts.IsSome then
+      match Map.tryFind "headers" opts.Value with
+      | Some hs ->
+          for KeyValue(k,v) in (hs :?> Map<string,obj>) do
+            msg.Headers.TryAddWithoutValidation(k, string v) |> ignore
+      | None -> ()
+    use client = new System.Net.Http.HttpClient()
+    if opts.IsSome then
+      match Map.tryFind "timeout" opts.Value with
+      | Some t ->
+          match t with
+          | :? int as i -> client.Timeout <- System.TimeSpan.FromSeconds(float i)
+          | :? int64 as i -> client.Timeout <- System.TimeSpan.FromSeconds(float i)
+          | :? float as f -> client.Timeout <- System.TimeSpan.FromSeconds(f)
+          | :? float32 as f -> client.Timeout <- System.TimeSpan.FromSeconds(float f)
+          | _ -> ()
+      | None -> ()
+    let resp = client.Send(msg).Result
+    let status = resp.StatusCode |> int |> box
+    let body = resp.Content.ReadAsStringAsync().Result |> box
+    Map.ofList [("status", status); ("body", body)]
+
+type Todo =
+    {
+        userId: int;
+        id: int;
+        title: string;
+        completed: bool
+    }
+
+type Todo =
+    {
+        userId: int;
+        id: int;
+        title: string;
+        completed: bool
+    }
+let todo: Todo = _fetch "https://jsonplaceholder.typicode.com/todos/1" None
+ignore (printfn "%A" ("Title:", todo.title))
+ignore (printfn "%A" ("Completed:", todo.completed))

--- a/tests/compiler/fs/fetch_http.mochi
+++ b/tests/compiler/fs/fetch_http.mochi
@@ -1,0 +1,13 @@
+// fetch.mochi
+
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+
+print("Title:", todo.title)
+print("Completed:", todo.completed)


### PR DESCRIPTION
## Summary
- add new F# compiler test fetching from jsonplaceholder

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d1efb943c83209c11228d458e3435