### PR TITLE
Add fetch support in Haskell backend

### DIFF
--- a/compile/x/hs/README.md
+++ b/compile/x/hs/README.md
@@ -40,7 +40,7 @@ Several language constructs remain unimplemented:
 
 - `match` expressions and union types
 - Set literals and related operations
-- Generative AI, HTTP fetch and FFI bindings
+- Generative AI and FFI bindings
 - Streams and long-lived agents
 - Logic programming with `fact`, `rule` and `query` expressions
 - Package imports and module system

--- a/compile/x/hs/runtime.go
+++ b/compile/x/hs/runtime.go
@@ -127,6 +127,16 @@ _sliceString s i j =
   in take (end' - start) (drop start s)
 `
 
+const fetchHelper = `
+_fetch :: String -> Maybe (Map.Map String String) -> IO (Map.Map String String)
+_fetch url _ = do
+  out <- readProcess "curl" ["-s", url] ""
+  pure $ case Aeson.decode (BSL.pack out) of
+    Just (Aeson.Object o) ->
+      Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+    _ -> Map.empty
+`
+
 const loadRuntime = `
 data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
 


### PR DESCRIPTION
## Summary
- extend Haskell compiler backend with HTTP `fetch` support
- generate `_fetch` helper based on `curl`
- include new runtime and imports when `fetch` is used
- update docs to no longer list HTTP fetch as unsupported

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d1efed2b88320b15b633c2380f57e