### PR TITLE
Add Kotlin fetch HTTP test

### DIFF
--- a/tests/compiler/kt/fetch_http.kt.out
+++ b/tests/compiler/kt/fetch_http.kt.out
@@ -1,0 +1,73 @@
+data class Todo(val userId: Int, val id: Int, val title: String, val completed: Boolean)
+
+fun main() {
+        val todo: Todo = _fetch("https://jsonplaceholder.typicode.com/todos/1", null)
+        println(todo.title)
+        println(todo.completed)
+}
+
+fun _fetch(url: String, opts: Map<String, Any>?): Any? {
+    fun encode(x: Any?): String = when (x) {
+        null -> "null"
+        is String -> "\"" + x.replace("\"", "\\\"") + "\""
+        is Int, is Double, is Boolean -> x.toString()
+        is List<*> -> x.joinToString(prefix = "[", postfix = "]") { encode(it) }
+        is Map<*, *> -> x.entries.joinToString(prefix = "{", postfix = "}") { e ->
+            "\"" + e.key.toString().replace("\"", "\\\"") + "\":" + encode(e.value)
+        }
+        else -> "\"" + x.toString().replace("\"", "\\\"") + "\""
+    }
+
+    var full = url
+    val method = opts?.get("method")?.toString() ?: "GET"
+    if (opts?.get("query") is Map<*, *>) {
+        val q = opts["query"] as Map<*, *>
+        val qs = q.entries.joinToString("&") { e ->
+            java.net.URLEncoder.encode(e.key.toString(), java.nio.charset.StandardCharsets.UTF_8) +
+            "=" +
+            java.net.URLEncoder.encode(e.value.toString(), java.nio.charset.StandardCharsets.UTF_8)
+        }
+        val sep = if (full.contains("?")) "&" else "?"
+        full += sep + qs
+    }
+
+    val builder = java.net.http.HttpRequest.newBuilder(java.net.URI.create(full))
+    val body = opts?.get("body")
+    if (body != null) {
+        builder.method(method, java.net.http.HttpRequest.BodyPublishers.ofString(encode(body)))
+    } else {
+        builder.method(method, java.net.http.HttpRequest.BodyPublishers.noBody())
+    }
+    if (opts?.get("headers") is Map<*, *>) {
+        val hs = opts["headers"] as Map<*, *>
+        for ((k, v) in hs) {
+            builder.header(k.toString(), v.toString())
+        }
+    }
+
+    val clientBuilder = java.net.http.HttpClient.newBuilder()
+    if (opts?.get("timeout") != null) {
+        val t = opts["timeout"]
+        val secs = when (t) {
+            is Int -> t.toLong()
+            is Long -> t
+            is Double -> t.toLong()
+            is Float -> t.toLong()
+            else -> null
+        }
+        if (secs != null) {
+            clientBuilder.connectTimeout(java.time.Duration.ofMillis((secs * 1000).toLong()))
+        }
+    }
+    val client = clientBuilder.build()
+
+    return try {
+        val resp = client.send(builder.build(), java.net.http.HttpResponse.BodyHandlers.ofString())
+        val text = resp.body()
+        val eng = javax.script.ScriptEngineManager().getEngineByName("javascript")
+        eng.eval("Java.asJSONCompatible($text)")
+    } catch (e: Exception) {
+        throw RuntimeException(e)
+    }
+}
+

--- a/tests/compiler/kt/fetch_http.mochi
+++ b/tests/compiler/kt/fetch_http.mochi
@@ -1,0 +1,10 @@
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+print(todo.title)
+print(todo.completed)

--- a/tests/compiler/kt/fetch_http.out
+++ b/tests/compiler/kt/fetch_http.out
@@ -1,0 +1,2 @@
+delectus aut autem
+false


### PR DESCRIPTION
## Summary
- add `fetch_http` example for Kotlin backend demonstrating HTTP fetch
- include expected output and generated Kotlin code

## Testing
- `go test ./compile/x/kt -run TestKTCompiler_GoldenOutput -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_685d1f054d9c83209e8fd404a53f8c2b