### PR TITLE
Add fetch support to Smalltalk backend

### DIFF
--- a/compile/x/st/compiler.go
+++ b/compile/x/st/compiler.go
@@ -107,7 +107,11 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.buf.Write(typeCode)
 	c.buf.Write(funCode)
 	c.buf.Write(testCode)
-	if c.needCount || c.needAvg || c.needInput || c.needReduce || c.needBreak || c.needContinue || c.needUnionAll || c.needUnion || c.needExcept || c.needIntersect {
+	if c.needCount || c.needAvg || c.needInput || c.needReduce || c.needBreak ||
+		c.needContinue || c.needUnionAll || c.needUnion || c.needExcept ||
+		c.needIntersect || c.needIndexStr || c.needSliceStr ||
+		c.needContainsStr || c.needDataset || c.needFetch || c.needPaginate ||
+		c.needSum || c.needGroupBy || c.needGroup {
 		c.emitHelpers()
 	}
 	c.writelnNoIndent("!!")

--- a/tests/compiler/st/fetch_http.mochi
+++ b/tests/compiler/st/fetch_http.mochi
@@ -1,0 +1,10 @@
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+print("Title: " + todo.title)
+print("Completed: " + str(todo.completed))

--- a/tests/compiler/st/fetch_http.out
+++ b/tests/compiler/st/fetch_http.out
@@ -1,0 +1,3 @@
+Title: delectus aut autem
+Completed: false
+

--- a/tests/compiler/st/fetch_http.st.out
+++ b/tests/compiler/st/fetch_http.st.out
@@ -1,9 +1,12 @@
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'types'!
-newMsg: message | dict |
+newTodo: userId id: id title: title completed: completed | dict |
 	dict := Dictionary new.
-	dict at: 'message' put: message.
+	dict at: 'userId' put: userId.
+	dict at: 'id' put: id.
+	dict at: 'title' put: title.
+	dict at: 'completed' put: completed.
 	^ dict
 !
 !Main class methodsFor: 'runtime'!
@@ -31,5 +34,6 @@ _fetch: url opts: o
 	^ JSONReader fromJSON: text
 !
 !!
-data := (Main _fetch: 'file://tests/compiler/st/fetch_builtin.json' opts: nil).
-(data at: 'message') displayOn: Transcript. Transcript cr.
+todo := (Main _fetch: 'https://jsonplaceholder.typicode.com/todos/1' opts: nil).
+((('Title: ') , (todo at: 'title'))) displayOn: Transcript. Transcript cr.
+((('Completed: ') , ((todo at: 'completed' printString)))) displayOn: Transcript. Transcript cr.


### PR DESCRIPTION
## Summary
- ensure Smalltalk compiler emits runtime helpers when fetch is used
- update fetch builtin golden output to include helper
- add new `fetch_http` sample exercising HTTP GET from jsonplaceholder

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d1f1b9b28832084e441092af25994