### PR TITLE
Add fetch helper for PHP backend

### DIFF
--- a/compile/x/php/README.md
+++ b/compile/x/php/README.md
@@ -19,7 +19,7 @@ The PHP compiler implements a subset of Mochi including:
 - `if`, `for`, `while` and range loops
 - functions and closures
 - lists and maps with indexing and updates
-- built-in helpers: `print`, `len`, `str`, `input`, `count`, `avg`
+- built-in helpers: `print`, `len`, `str`, `input`, `count`, `avg`, `sum`, `json`, `fetch`, `load`, `save`
 - dataset queries with `from`/`where`/`select`, sorting, pagination and joins
 - grouping operations in dataset queries
 - set operations: `union`, `union all`, `except`, and `intersect`
@@ -32,7 +32,7 @@ Several advanced language features are not yet available:
 - modules or imports
 - concurrency primitives
 - generics and complex type inference
-- dataset helpers like `fetch`, `load`, `save` and `generate`
+- dataset helper `generate`
 - pattern matching with `match`
 - agent/stream declarations (`agent`, `on`, `emit`)
 - foreign function imports

--- a/compile/x/php/compiler.go
+++ b/compile/x/php/compiler.go
@@ -690,6 +690,8 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		return "(" + inner + ")", nil
 	case p.Query != nil:
 		return c.compileQueryExpr(p.Query)
+	case p.Fetch != nil:
+		return c.compileFetchExpr(p.Fetch)
 	case p.Load != nil:
 		return c.compileLoadExpr(p.Load)
 	case p.Save != nil:
@@ -1475,6 +1477,25 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
 	}
 	c.use("_save_json")
 	return fmt.Sprintf("_save_json(%s, %s)", src, path), nil
+}
+
+func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
+	urlStr, err := c.compileExpr(f.URL)
+	if err != nil {
+		return "", err
+	}
+	var withStr string
+	if f.With != nil {
+		w, err := c.compileExpr(f.With)
+		if err != nil {
+			return "", err
+		}
+		withStr = w
+	} else {
+		withStr = "null"
+	}
+	c.use("_fetch")
+	return fmt.Sprintf("_fetch(%s, %s)", urlStr, withStr), nil
 }
 
 func exprVarSet(e *parser.Expr) map[string]bool {

--- a/tests/compiler/php/fetch_http.mochi
+++ b/tests/compiler/php/fetch_http.mochi
@@ -1,0 +1,8 @@
+ type Todo {
+   userId: int
+   id: int
+   title: string
+   completed: bool
+ }
+ let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+ print(todo.title)

--- a/tests/compiler/php/fetch_http.out
+++ b/tests/compiler/php/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem

--- a/tests/compiler/php/fetch_http.php.out
+++ b/tests/compiler/php/fetch_http.php.out
@@ -1,0 +1,37 @@
+<?php
+class Todo {
+	public $userId;
+	public $id;
+	public $title;
+	public $completed;
+	public function __construct($fields = []) {
+		$this->userId = $fields['userId'] ?? null;
+		$this->id = $fields['id'] ?? null;
+		$this->title = $fields['title'] ?? null;
+		$this->completed = $fields['completed'] ?? null;
+	}
+}
+
+$todo = _fetch("https://jsonplaceholder.typicode.com/todos/1", null);
+echo $todo->title, PHP_EOL;
+
+function _fetch($url, $opts = null) {
+    $args = ['-s'];
+    $method = $opts['method'] ?? 'GET';
+    $args[] = '-X'; $args[] = $method;
+    if (isset($opts['headers'])) {
+        foreach ($opts['headers'] as $k => $v) { $args[] = '-H'; $args[] = $k . ': ' . strval($v); }
+    }
+    if (isset($opts['query'])) {
+        $qs = http_build_query($opts['query']);
+        $sep = strpos($url, '?') !== false ? '&' : '?';
+        $url .= $sep . $qs;
+    }
+    if ($opts !== null && array_key_exists('body', $opts)) { $args[] = '-d'; $args[] = json_encode($opts['body']); }
+    if (isset($opts['timeout'])) { $args[] = '--max-time'; $args[] = strval($opts['timeout']); }
+    $args[] = $url;
+    $escaped = array_map('escapeshellarg', $args);
+    $cmd = 'curl ' . implode(' ', $escaped);
+    $data = shell_exec($cmd);
+    return json_decode($data);
+}


### PR DESCRIPTION
## Summary
- implement `fetch` expression in the PHP compiler
- add PHP runtime helper to perform HTTP requests via `curl`
- document new helper support in PHP backend README
- add regression test for fetching data from jsonplaceholder

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d25c07a188320917bc0fb72b5e54c