### PR TITLE
Add structify helper for Ruby fetch

### DIFF
--- a/compile/x/rb/compiler.go
+++ b/compile/x/rb/compiler.go
@@ -1524,7 +1524,9 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 		withStr = "nil"
 	}
 	c.use("_fetch")
-	return fmt.Sprintf("_fetch(%s, %s)", urlStr, withStr), nil
+	c.use("_structify")
+	c.useOpenStruct = true
+	return fmt.Sprintf("_structify(_fetch(%s, %s))", urlStr, withStr), nil
 }
 
 func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {


### PR DESCRIPTION
## Summary
- improve Ruby fetch implementation
- wrap fetch results in OpenStruct via new `_structify` helper

## Testing
- `go test ./compile/x/rb -run TestRBCompiler_SubsetPrograms -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_685d25d41b488320922bc95f489d1e0f