### PR TITLE
Add Swift fetch http example

### DIFF
--- a/tests/compiler/swift/fetch_http.mochi
+++ b/tests/compiler/swift/fetch_http.mochi
@@ -1,0 +1,9 @@
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+print(todo.title)

--- a/tests/compiler/swift/fetch_http.out
+++ b/tests/compiler/swift/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem

--- a/tests/compiler/swift/fetch_http.swift.out
+++ b/tests/compiler/swift/fetch_http.swift.out
@@ -49,12 +49,15 @@ func _fetch(_ urlStr: String, _ opts: [String: Any]?) -> Any {
     return out
 }
 
-struct Msg {
-	var message: String
+struct Todo {
+	var userId: Int
+	var id: Int
+	var title: String
+	var completed: Bool
 }
 
 func main() {
-	let data: Msg = _fetch("file://tests/compiler/swift/fetch_builtin.json", nil)
-	print(data.message)
+	let todo: Todo = _fetch("https://jsonplaceholder.typicode.com/todos/1", nil)
+	print(todo.title)
 }
 main()


### PR DESCRIPTION
## Summary
- update Swift `_fetch` runtime output
- add a new Swift compiler example that fetches from jsonplaceholder

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d26353de08320bfa9d47c6e432785