### PR TITLE
Add simple fetch support for COBOL backend

### DIFF
--- a/types/infer.go
+++ b/types/infer.go
@@ -626,6 +626,8 @@ func NodeType(n *ast.Node, env *Env) Type {
 			elem = NodeType(n.Children[0], env)
 		}
 		return ListType{Elem: elem}
+	case "fetch":
+		return StringType{}
 	case "selector":
 		if env != nil {
 			if t, err := env.GetVar(n.Value.(string)); err == nil {


### PR DESCRIPTION
## Summary
- implement a rudimentary `fetch` expression for the COBOL backend
- mark fetch expressions as returning strings in the lightweight type inference

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c655eb88320ab788181ed78c249