### PR TITLE
Add typed fetch support for Dart

### DIFF
--- a/tests/compiler/dart/fetch_http.dart.out
+++ b/tests/compiler/dart/fetch_http.dart.out
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+class Todo {
+	int userId;
+	int id;
+	String title;
+	bool completed;
+	Todo({required this.userId, required this.id, required this.title, required this.completed});
+	factory Todo.fromJson(Map<String,dynamic> m) {
+		return Todo(userId: m['userId'] as int, id: m['id'] as int, title: m['title'] as String, completed: m['completed'] as bool);
+	}
+}
+_structParsers['Todo'] = (m) => Todo.fromJson(m);
+
+Future<void> main() async {
+	Todo todo = Todo.fromJson((await _fetch("https://jsonplaceholder.typicode.com/todos/1", null)) as Map<String,dynamic>);
+	print(todo.title);
+	await _waitAll();
+}
+
+Future<dynamic> _fetch(String url, Map<String,dynamic>? opts) async {
+    var method = opts?['method']?.toString() ?? 'GET';
+    Uri uri = Uri.parse(url);
+    if (opts?['query'] != null) {
+        var q = (opts!['query'] as Map).map((k,v)=>MapEntry(k.toString(), v.toString()));
+        uri = uri.replace(queryParameters: {...uri.queryParameters, ...q});
+    }
+    var client = HttpClient();
+    if (opts?['timeout'] != null) {
+        var t = Duration(seconds: (opts!['timeout'] is num ? opts['timeout'].round() : int.parse(opts['timeout'].toString())));
+        client.connectionTimeout = t;
+    }
+    var req = await client.openUrl(method, uri);
+    if (opts?['headers'] != null) {
+        for (var e in (opts!['headers'] as Map).entries) {
+            req.headers.set(e.key.toString(), e.value.toString());
+        }
+    }
+    if (opts != null && opts.containsKey('body')) {
+        req.headers.contentType = ContentType('application', 'json', charset: 'utf-8');
+        req.write(jsonEncode(opts['body']));
+    }
+    var resp = await req.close();
+    var text = await resp.transform(utf8.decoder).join();
+    client.close();
+    return jsonDecode(text);
+}
+
+List<Future<dynamic>> _pending = [];
+Future<void> _waitAll() async {
+    await Future.wait(_pending);
+}
+
+

--- a/tests/compiler/dart/fetch_http.mochi
+++ b/tests/compiler/dart/fetch_http.mochi
@@ -1,0 +1,9 @@
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = (fetch "https://jsonplaceholder.typicode.com/todos/1") as Todo
+print(todo.title)

--- a/tests/compiler/dart/fetch_http.out
+++ b/tests/compiler/dart/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem


### PR DESCRIPTION
## Summary
- support casting HTTP fetch results to struct types in Dart compiler
- test typed fetch of JSONPlaceholder API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c69a16c8320ae86bab2345a7ec5