### PR TITLE
Add typed fetch HTTP example for Ruby backend

### DIFF
--- a/tests/compiler/rb/fetch_http.mochi
+++ b/tests/compiler/rb/fetch_http.mochi
@@ -1,0 +1,8 @@
+ type Todo {
+   userId: int
+   id: int
+   title: string
+   completed: bool
+ }
+ let todo: Todo = (fetch "https://jsonplaceholder.typicode.com/todos/1") as Todo
+ print(todo.title)

--- a/tests/compiler/rb/fetch_http.out
+++ b/tests/compiler/rb/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem

--- a/tests/compiler/rb/fetch_http.rb.out
+++ b/tests/compiler/rb/fetch_http.rb.out
@@ -1,0 +1,51 @@
+require 'ostruct'
+
+def _fetch(url, opts=nil)
+  require 'net/http'
+  require 'json'
+  require 'uri'
+  uri = URI(url)
+  if uri.scheme.nil? || uri.scheme == '' || uri.scheme == 'file'
+    path = uri.scheme == 'file' ? uri.path : url
+    data = File.read(path)
+    return _structify(JSON.parse(data))
+  end
+  method = 'GET'
+  headers = {}
+  body = nil
+  timeout = nil
+  if opts
+    method = opts['method'] || method
+    if q = opts['query']
+      q = URI.encode_www_form(q.to_h)
+      uri.query = [uri.query, q].compact.join('&')
+    end
+    body = JSON.generate(opts['body']) if opts['body']
+    if opts['headers']
+      opts['headers'].to_h.each { |k,v| headers[k] = v.to_s }
+    end
+    timeout = opts['timeout']
+  end
+  req = Net::HTTP.const_get(method.capitalize).new(uri)
+  headers.each { |k,v| req[k] = v }
+  req.body = body if body
+  Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: timeout) do |http|
+    resp = http.request(req)
+    return _structify(JSON.parse(resp.body))
+  end
+end
+def _structify(v)
+  case v
+  when Hash
+    OpenStruct.new(v.transform_keys(&:to_sym).transform_values { |vv| _structify(vv) })
+  when Array
+    v.map { |vv| _structify(vv) }
+  else
+    v
+  end
+end
+
+Todo = Struct.new(:userId, :id, :title, :completed, keyword_init: true)
+
+todo = Todo.new(**((_structify(_fetch("https://jsonplaceholder.typicode.com/todos/1", nil))).to_h.transform_keys(&:to_sym)))
+puts([todo.title].join(" "))


### PR DESCRIPTION
## Summary
- add Ruby example that fetches data from jsonplaceholder

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685d2c8268648320b211824adf331486