### PR TITLE
Add typed fetch handling for F# backend

### DIFF
--- a/compile/x/fs/runtime.go
+++ b/compile/x/fs/runtime.go
@@ -151,6 +151,18 @@ const (
     let body = resp.Content.ReadAsStringAsync().Result |> box
     Map.ofList [("status", status); ("body", body)]`
 
+	helperFetchTyped = `let _fetch_json<'T> (url: string) (opts: Map<string,obj> option) : 'T =
+  let res = _fetch url opts
+  let body = Map.find "body" res :?> string
+  System.Text.Json.JsonSerializer.Deserialize<'T>(body)`
+
+	helperCast = `let _cast<'T> (v: obj) : 'T =
+  match v with
+  | :? 'T as t -> t
+  | _ ->
+      let json = System.Text.Json.JsonSerializer.Serialize(v)
+      System.Text.Json.JsonSerializer.Deserialize<'T>(json)`
+
 	helperGenText = `let _genText (prompt: string) (model: string) (params: Map<string,obj> option) : string =
   // TODO: integrate with an LLM
   prompt`
@@ -247,6 +259,8 @@ var helperMap = map[string]string{
 	"_run_test":     helperRunTest,
 	"_input":        helperInput,
 	"_fetch":        helperFetch,
+	"_fetch_json":   helperFetchTyped,
+	"_cast":         helperCast,
 	"_eval":         helperEval,
 	"_genText":      helperGenText,
 	"_genEmbed":     helperGenEmbed,

--- a/tests/compiler/fs/fetch_cast.fs.out
+++ b/tests/compiler/fs/fetch_cast.fs.out
@@ -1,0 +1,72 @@
+open System
+
+let _cast<'T> (v: obj) : 'T =
+  match v with
+  | :? 'T as t -> t
+  | _ ->
+      let json = System.Text.Json.JsonSerializer.Serialize(v)
+      System.Text.Json.JsonSerializer.Deserialize<'T>(json)
+let _fetch (url: string) (opts: Map<string,obj> option) : Map<string,obj> =
+  if url.StartsWith("file://") then
+    let path = url.Substring(7)
+    let text = System.IO.File.ReadAllText(path)
+    Map.ofList [("status", box 200); ("body", box text)]
+  else
+    let mutable urlStr = url
+    let meth = opts |> Option.bind (Map.tryFind "method") |> Option.map string |> Option.defaultValue "GET"
+    if opts.IsSome then
+      match Map.tryFind "query" opts.Value with
+      | Some q ->
+          let qs =
+            (q :?> Map<string,obj>)
+            |> Seq.map (fun (KeyValue(k,v)) -> System.Uri.EscapeDataString(k) + "=" + System.Uri.EscapeDataString(string v))
+            |> String.concat "&"
+          let sep = if urlStr.Contains("?") then "&" else "?"
+          urlStr <- urlStr + sep + qs
+      | None -> ()
+    use msg = new System.Net.Http.HttpRequestMessage(new System.Net.Http.HttpMethod(meth), urlStr)
+    if opts.IsSome then
+      match Map.tryFind "body" opts.Value with
+      | Some b ->
+          let json = System.Text.Json.JsonSerializer.Serialize(b)
+          msg.Content <- new System.Net.Http.StringContent(json, System.Text.Encoding.UTF8, "application/json")
+      | None -> ()
+    if opts.IsSome then
+      match Map.tryFind "headers" opts.Value with
+      | Some hs ->
+          for KeyValue(k,v) in (hs :?> Map<string,obj>) do
+            msg.Headers.TryAddWithoutValidation(k, string v) |> ignore
+      | None -> ()
+    use client = new System.Net.Http.HttpClient()
+    if opts.IsSome then
+      match Map.tryFind "timeout" opts.Value with
+      | Some t ->
+          match t with
+          | :? int as i -> client.Timeout <- System.TimeSpan.FromSeconds(float i)
+          | :? int64 as i -> client.Timeout <- System.TimeSpan.FromSeconds(float i)
+          | :? float as f -> client.Timeout <- System.TimeSpan.FromSeconds(f)
+          | :? float32 as f -> client.Timeout <- System.TimeSpan.FromSeconds(float f)
+          | _ -> ()
+      | None -> ()
+    let resp = client.Send(msg).Result
+    let status = resp.StatusCode |> int |> box
+    let body = resp.Content.ReadAsStringAsync().Result |> box
+    Map.ofList [("status", status); ("body", body)]
+
+type Todo =
+    {
+        userId: int;
+        id: int;
+        title: string;
+        completed: bool
+    }
+
+type Todo =
+    {
+        userId: int;
+        id: int;
+        title: string;
+        completed: bool
+    }
+let todo: Todo = _cast<Todo>((_fetch "https://jsonplaceholder.typicode.com/todos/1" None))
+ignore (printfn "%A" (todo.title))

--- a/tests/compiler/fs/fetch_cast.mochi
+++ b/tests/compiler/fs/fetch_cast.mochi
@@ -1,0 +1,11 @@
+// fetch_cast.mochi
+
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = (fetch "https://jsonplaceholder.typicode.com/todos/1") as Todo
+print(todo.title)


### PR DESCRIPTION
## Summary
- support casting fetch results to typed values in F# compiler
- include runtime helpers `_fetch_json` and `_cast`
- add F# test for typed fetch via `as`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c71d328832094b1bde615d91e67