### PR TITLE
Enable typed fetch for Java backend

### DIFF
--- a/compile/x/java/helpers.go
+++ b/compile/x/java/helpers.go
@@ -56,6 +56,7 @@ func isInt(t types.Type) bool    { _, ok := t.(types.IntType); return ok }
 func isFloat(t types.Type) bool  { _, ok := t.(types.FloatType); return ok }
 func isBool(t types.Type) bool   { _, ok := t.(types.BoolType); return ok }
 func isString(t types.Type) bool { _, ok := t.(types.StringType); return ok }
+func isAny(t types.Type) bool    { _, ok := t.(types.AnyType); return ok }
 
 func simpleStringKey(e *parser.Expr) (string, bool) {
 	if e == nil {


### PR DESCRIPTION
## Summary
- add missing type hint casting logic in `compile/x/java`
- expose `isAny` helper used during type hinting

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c76edd48320816e203dd6ae3488