### PR TITLE
Add type-safe fetch for Kotlin backend

### DIFF
--- a/compile/x/kt/README.md
+++ b/compile/x/kt/README.md
@@ -9,6 +9,7 @@ The Kotlin backend converts Mochi programs into Kotlin source files so they can 
 - Dataset queries use collection operations like `filter`, `sortedBy`, `drop`, `take`, `map` and `_group_by`,
   supporting joins, filtering and pagination.
 - Typed dataset loading converts rows to data classes via `_cast` reflection
+- Typed fetch converts JSON responses to data classes via `_cast`
 - Basic loops (`for`, `while`), conditionals and arithmetic expressions
 - Built‑in helpers including `print`, `len`, `count`, `avg`, `str`, `input`, `json`, and `now`
 - LLM and runtime helpers such as `_genText`, `_genEmbed`, `_genStruct`, `_fetch` and `_eval`

--- a/compile/x/kt/helpers.go
+++ b/compile/x/kt/helpers.go
@@ -248,3 +248,18 @@ func indentBlock(s string, depth int) string {
 	}
 	return strings.Join(lines, "\n") + "\n"
 }
+
+func isFetchExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return false
+	}
+	return p.Target.Fetch != nil
+}

--- a/tests/compiler/kt/fetch_builtin.kt.out
+++ b/tests/compiler/kt/fetch_builtin.kt.out
@@ -1,7 +1,7 @@
 data class Msg(val message: String)
 
 fun main() {
-        val data: Msg = _fetch("file://tests/compiler/kt/fetch_builtin.json", null)
+        val data: Msg = _cast<Msg>(_fetch("file://tests/compiler/kt/fetch_builtin.json", null))
         println(data.message)
 }
 

--- a/tests/compiler/kt/fetch_http.kt.out
+++ b/tests/compiler/kt/fetch_http.kt.out
@@ -1,7 +1,7 @@
 data class Todo(val userId: Int, val id: Int, val title: String, val completed: Boolean)
 
 fun main() {
-        val todo: Todo = _fetch("https://jsonplaceholder.typicode.com/todos/1", null)
+        val todo: Todo = _cast<Todo>(_fetch("https://jsonplaceholder.typicode.com/todos/1", null))
         println(todo.title)
         println(todo.completed)
 }


### PR DESCRIPTION
## Summary
- support typed fetch expressions in Kotlin compiler
- expose `isFetchExpr` helper
- document typed fetch in Kotlin backend readme
- update Kotlin golden files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d2c782b24832098f6d83a4feaef4d