### PR TITLE
Add struct casting for PHP fetch

### DIFF
--- a/tests/compiler/php/fetch_http.mochi
+++ b/tests/compiler/php/fetch_http.mochi
@@ -4,5 +4,5 @@
    title: string
    completed: bool
  }
- let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
- print(todo.title)
+let todo: Todo = (fetch "https://jsonplaceholder.typicode.com/todos/1") as Todo
+print(todo.title)

--- a/tests/compiler/php/fetch_http.php.out
+++ b/tests/compiler/php/fetch_http.php.out
@@ -12,7 +12,7 @@ class Todo {
 	}
 }
 
-$todo = _fetch("https://jsonplaceholder.typicode.com/todos/1", null);
+$todo = new Todo((array)(_fetch("https://jsonplaceholder.typicode.com/todos/1", null)));
 echo $todo->title, PHP_EOL;
 
 function _fetch($url, $opts = null) {


### PR DESCRIPTION
## Summary
- support casting fetch results to structs in PHP backend
- update fetch HTTP example
- update golden outputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c7e981c832084b6042ea53ba4bb