### PR TITLE
Add typed fetch casting for Swift backend

### DIFF
--- a/compile/x/swift/compiler.go
+++ b/compile/x/swift/compiler.go
@@ -695,7 +695,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				}
 			}
 		} else if op.Cast != nil {
-			expr = fmt.Sprintf("%s as! %s", expr, c.compileType(op.Cast.Type))
+			c.use("_cast")
+			expr = fmt.Sprintf("_cast(%s.self, %s)", c.compileType(op.Cast.Type), expr)
 		}
 	}
 	return expr, nil

--- a/tests/compiler/swift/fetch_builtin.swift.out
+++ b/tests/compiler/swift/fetch_builtin.swift.out
@@ -54,7 +54,7 @@ struct Msg {
 }
 
 func main() {
-	let data: Msg = _fetch("file://tests/compiler/swift/fetch_builtin.json", nil)
-	print(data.message)
+        let data: Msg = _cast(Msg.self, _fetch("file://tests/compiler/swift/fetch_builtin.json", nil))
+        print(data.message)
 }
 main()

--- a/tests/compiler/swift/fetch_http.swift.out
+++ b/tests/compiler/swift/fetch_http.swift.out
@@ -57,7 +57,7 @@ struct Todo {
 }
 
 func main() {
-	let todo: Todo = _fetch("https://jsonplaceholder.typicode.com/todos/1", nil)
-	print(todo.title)
+        let todo: Todo = _cast(Todo.self, _fetch("https://jsonplaceholder.typicode.com/todos/1", nil))
+        print(todo.title)
 }
 main()

--- a/tests/compiler/swift/fetch_options.swift.out
+++ b/tests/compiler/swift/fetch_options.swift.out
@@ -54,7 +54,7 @@ struct Msg {
 }
 
 func main() {
-	let data: Msg = _fetch("file://tests/compiler/swift/fetch_builtin.json", ["method": "GET", "headers": ["X-Test": "1"], "body": ["x": 1], "timeout": 1])
-	print(data.message)
+        let data: Msg = _cast(Msg.self, _fetch("file://tests/compiler/swift/fetch_builtin.json", ["method": "GET", "headers": ["X-Test": "1"], "body": ["x": 1], "timeout": 1]))
+        print(data.message)
 }
 main()


### PR DESCRIPTION
## Summary
- implement `_cast` usage for Swift cast expressions
- update Swift compiler tests to expect `_cast` when fetching JSON

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c8f8f5c832085aeebc5501ec97a