### PR TITLE
Add cast helper to Smalltalk backend

### DIFF
--- a/compile/x/st/compiler.go
+++ b/compile/x/st/compiler.go
@@ -35,6 +35,7 @@ type Compiler struct {
 	needSum         bool
 	needGroupBy     bool
 	needGroup       bool
+	needCast        bool
 }
 
 // New creates a new Smalltalk compiler instance.
@@ -738,6 +739,10 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					expr = fmt.Sprintf("(%s at: %s + 1)", expr, idx)
 				}
 			}
+		} else if op.Cast != nil {
+			t := typeName(op.Cast.Type)
+			c.needCast = true
+			expr = fmt.Sprintf("(Main _cast: '%s' value: %s)", t, expr)
 		}
 	}
 	return expr, nil
@@ -1585,6 +1590,13 @@ func (c *Compiler) emitHelpers() {
 		c.writeln("text := stream contents.")
 		c.writeln("stream close.")
 		c.writeln("^ JSONReader fromJSON: text")
+		c.indent--
+		c.writelnNoIndent("!")
+	}
+	if c.needCast {
+		c.writeln("_cast: type value: v")
+		c.indent++
+		c.writeln("^ v")
 		c.indent--
 		c.writelnNoIndent("!")
 	}

--- a/compile/x/st/helpers.go
+++ b/compile/x/st/helpers.go
@@ -1,6 +1,9 @@
 package stcode
 
-import "strings"
+import (
+	"mochi/parser"
+	"strings"
+)
 
 func sanitizeName(name string) string {
 	var b strings.Builder
@@ -15,4 +18,14 @@ func sanitizeName(name string) string {
 		return "_" + b.String()
 	}
 	return b.String()
+}
+
+func typeName(t *parser.TypeRef) string {
+	if t == nil {
+		return ""
+	}
+	if t.Simple != nil {
+		return *t.Simple
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary
- add `needCast` tracking to Smalltalk compiler
- support `as` cast operations in postfix expressions
- generate simple `_cast:` runtime helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c8d55b88320bdcc9c97c354ac84