### PR TITLE
Add typed fetch for Rust backend

### DIFF
--- a/compile/x/rust/expressions.go
+++ b/compile/x/rust/expressions.go
@@ -788,6 +788,10 @@ func (c *Compiler) compileGenerateExpr(g *parser.GenerateExpr) (string, error) {
 }
 
 func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
+	return c.compileFetchExprWithType(f, "std::boxed::Box<dyn std::any::Any>")
+}
+
+func (c *Compiler) compileFetchExprWithType(f *parser.FetchExpr, typ string) (string, error) {
 	url, err := c.compileExpr(f.URL)
 	if err != nil {
 		return "", err
@@ -801,7 +805,7 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 		opts = v
 	}
 	c.use("_fetch")
-	return fmt.Sprintf("_fetch(%s, %s)", url, opts), nil
+	return fmt.Sprintf("_fetch::<%s>(%s, %s)", typ, url, opts), nil
 }
 
 func (c *Compiler) compileLoadExpr(l *parser.LoadExpr) (string, error) {

--- a/compile/x/rust/helpers.go
+++ b/compile/x/rust/helpers.go
@@ -43,6 +43,22 @@ func callPattern(e *parser.Expr) (*parser.CallExpr, bool) {
 	return p.Target.Call, true
 }
 
+// fetchExpr returns the fetch expression if e is a simple fetch expression.
+func fetchExpr(e *parser.Expr) (*parser.FetchExpr, bool) {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target == nil || p.Target.Fetch == nil {
+		return nil, false
+	}
+	return p.Target.Fetch, true
+}
+
 func identName(e *parser.Expr) (string, bool) {
 	if e == nil {
 		return "", false

--- a/compile/x/rust/runtime.go
+++ b/compile/x/rust/runtime.go
@@ -106,8 +106,18 @@ const (
 		"    Vec::new()\n" +
 		"}\n"
 
-	helperFetch = "fn _fetch(_url: &str, _opts: std::collections::HashMap<String, String>) -> String {\n" +
-		"    String::new()\n" +
+	helperFetch = "fn _fetch<T: serde::de::DeserializeOwned>(_url: &str, _opts: std::collections::HashMap<String, String>) -> T {\n" +
+		"    use std::process::Command;\n" +
+		"    let mut data = String::new();\n" +
+		"    if _url.starts_with(\"file://\") {\n" +
+		"        if let Ok(text) = std::fs::read_to_string(&_url[7..]) {\n" +
+		"            data = text;\n" +
+		"        }\n" +
+		"    } else {\n" +
+		"        let out = Command::new(\"curl\").arg(\"-s\").arg(_url).output().unwrap();\n" +
+		"        data = String::from_utf8_lossy(&out.stdout).to_string();\n" +
+		"    }\n" +
+		"    serde_json::from_str::<T>(&data).unwrap()\n" +
 		"}\n"
 
 	helperLoad = "fn _load<T: serde::de::DeserializeOwned>(_path: &str, _opts: std::collections::HashMap<String, String>) -> Vec<T> {\n" +

--- a/tests/compiler/rust/fetch_http.mochi
+++ b/tests/compiler/rust/fetch_http.mochi
@@ -1,0 +1,9 @@
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+print(todo.title)

--- a/tests/compiler/rust/fetch_http.out
+++ b/tests/compiler/rust/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem

--- a/tests/compiler/rust/fetch_http.rs.out
+++ b/tests/compiler/rust/fetch_http.rs.out
@@ -1,0 +1,26 @@
+#[derive(Clone, Debug, Default)]
+struct Todo {
+    userId: i64,
+    id: i64,
+    title: String,
+    completed: bool,
+}
+
+fn main() {
+    let mut todo: Todo = _fetch::<Todo>("https://jsonplaceholder.typicode.com/todos/1", std::collections::HashMap::new());
+    println!("{}", todo.title);
+}
+
+fn _fetch<T: serde::de::DeserializeOwned>(_url: &str, _opts: std::collections::HashMap<String, String>) -> T {
+    use std::process::Command;
+    let mut data = String::new();
+    if _url.starts_with("file://") {
+        if let Ok(text) = std::fs::read_to_string(&_url[7..]) {
+            data = text;
+        }
+    } else {
+        let out = Command::new("curl").arg("-s").arg(_url).output().unwrap();
+        data = String::from_utf8_lossy(&out.stdout).to_string();
+    }
+    serde_json::from_str::<T>(&data).unwrap()
+}


### PR DESCRIPTION
## Summary
- implement generic `_fetch` helper in the Rust runtime
- support compile-time type hints for `fetch` expressions
- add helper to detect fetch expressions
- generate typed calls when assigning fetch results
- add a Rust test using `jsonplaceholder` demonstrating typed fetch

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c85f00c8320a8218f691d9a7632