### PR TITLE
Add typed fetch support for Lua

### DIFF
--- a/compile/x/lua/expressions.go
+++ b/compile/x/lua/expressions.go
@@ -193,6 +193,12 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				args[i] = v
 			}
 			expr = fmt.Sprintf("%s(%s)", expr, strings.Join(args, ", "))
+		} else if op.Cast != nil {
+			if op.Cast.Type.Simple != nil && c.env != nil {
+				if st, ok := c.resolveTypeRef(op.Cast.Type).(types.StructType); ok {
+					expr = fmt.Sprintf("%s.new(%s)", sanitizeName(st.Name), expr)
+				}
+			}
 		}
 	}
 	return expr, nil

--- a/tests/compiler/lua/fetch_http.lua.out
+++ b/tests/compiler/lua/fetch_http.lua.out
@@ -1,0 +1,58 @@
+#!/usr/bin/env lua
+function __fetch(url, opts)
+    local args = {'-s'}
+    local method = 'GET'
+    if opts and opts['method'] then method = tostring(opts['method']) end
+    table.insert(args, '-X')
+    table.insert(args, method)
+    if opts and opts['headers'] then
+        for k,v in pairs(opts['headers']) do
+            table.insert(args, '-H')
+            table.insert(args, k .. ': ' .. tostring(v))
+        end
+    end
+    if opts and opts['query'] then
+        local qs = {}
+        for k,v in pairs(opts['query']) do
+            table.insert(qs, k .. '=' .. tostring(v))
+        end
+        local sep = string.find(url, '?') and '&' or '?'
+        url = url .. sep .. table.concat(qs, '&')
+    end
+    if opts and opts['body'] ~= nil then
+        local ok, json = pcall(require, 'json')
+        if not ok then error('json library not found') end
+        table.insert(args, '-d')
+        table.insert(args, json.encode(opts['body']))
+    end
+    if opts and opts['timeout'] then
+        table.insert(args, '--max-time')
+        table.insert(args, tostring(opts['timeout']))
+    end
+    table.insert(args, url)
+    local cmd = 'curl ' .. table.concat(args, ' ')
+    local f = assert(io.popen(cmd))
+    local data = f:read('*a')
+    f:close()
+    local ok, json = pcall(require, 'json')
+    if not ok then error('json library not found') end
+    return json.decode(data)
+end
+function __print(...)
+    local args = {...}
+    for i, a in ipairs(args) do
+        if i > 1 then io.write(' ') end
+        io.write(tostring(a))
+    end
+    io.write('\n')
+end
+Todo = {}
+Todo.__index = Todo
+function Todo.new(o)
+	o = o or {}
+	setmetatable(o, Todo)
+	return o
+end
+
+todo = Todo.new((__fetch("https://jsonplaceholder.typicode.com/todos/1", nil)))
+__print(todo.title)

--- a/tests/compiler/lua/fetch_http.mochi
+++ b/tests/compiler/lua/fetch_http.mochi
@@ -1,0 +1,9 @@
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = (fetch "https://jsonplaceholder.typicode.com/todos/1") as Todo
+print(todo.title)

--- a/tests/compiler/lua/fetch_http.out
+++ b/tests/compiler/lua/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem


### PR DESCRIPTION
## Summary
- enable `as` casts in Lua backend
- add fetch HTTP example and golden outputs for Lua

## Testing
- `go vet ./...`
- `go test ./compile/x/lua -run TestLuaCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685d2c79a19c8320989de7164d6bf243