### PR TITLE
Add HTTP fetch support to Prolog backend

### DIFF
--- a/compile/x/pl/runtime.go
+++ b/compile/x/pl/runtime.go
@@ -120,15 +120,17 @@ const helperSave = ":- use_module(library(http/json)).\n" +
 	"    ;\n" +
 	"        json_write_dict(Out, Rows)\n" +
 	"    ),\n" +
-        "    (Out == current_output -> flush_output(Out) ; close(Out)).\n\n"
+	"    (Out == current_output -> flush_output(Out) ; close(Out)).\n\n"
 
 const helperFetch = ":- use_module(library(http/json)).\n" +
-        ":- use_module(library(http/http_client)).\n" +
-        "fetch_data(URL, _Opts, Data) :-\n" +
-        "    atom_string(U, URL),\n" +
-        "    ( sub_atom(U, 0, 7, _, 'file://') ->\n" +
-        "        sub_atom(U, 7, _, 0, Path),\n" +
-        "        read_file_to_string(Path, Text, [])\n" +
-        "    ;   setup_call_cleanup(http_open(U, S, []), read_string(S, _, Text), close(S))\n" +
-        "    ),\n" +
-        "    atom_json_dict(Text, Data, []).\n\n"
+	":- use_module(library(process)).\n" +
+	"fetch_data(URL, _Opts, Data) :-\n" +
+	"    atom_string(U, URL),\n" +
+	"    ( sub_atom(U, 0, 7, _, 'file://') ->\n" +
+	"        sub_atom(U, 7, _, 0, Path),\n" +
+	"        read_file_to_string(Path, Text, [])\n" +
+	"    ;   process_create(path(curl), ['-s', U], [stdout(pipe(S))]),\n" +
+	"        read_string(S, _, Text),\n" +
+	"        close(S)\n" +
+	"    ),\n" +
+	"    atom_json_dict(Text, Data, []).\n\n"

--- a/tests/compiler/pl/fetch_http.mochi
+++ b/tests/compiler/pl/fetch_http.mochi
@@ -1,0 +1,9 @@
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+print(todo.title)

--- a/tests/compiler/pl/fetch_http.out
+++ b/tests/compiler/pl/fetch_http.out
@@ -1,0 +1,1 @@
+delectus aut autem

--- a/tests/compiler/pl/fetch_http.pl.out
+++ b/tests/compiler/pl/fetch_http.pl.out
@@ -1,0 +1,24 @@
+:- style_check(-singleton).
+:- use_module(library(http/json)).
+:- use_module(library(process)).
+fetch_data(URL, _Opts, Data) :-
+    atom_string(U, URL),
+    ( sub_atom(U, 0, 7, _, 'file://') ->
+        sub_atom(U, 7, _, 0, Path),
+        read_file_to_string(Path, Text, [])
+    ;   process_create(path(curl), ['-s', U], [stdout(pipe(S))]),
+        read_string(S, _, Text),
+        close(S)
+    ),
+    atom_json_dict(Text, Data, []).
+
+
+
+	main :-
+	fetch_data("https://jsonplaceholder.typicode.com/todos/1", _{}, _V0),
+	Todo = _V0,
+	get_dict(title, Todo, _V1),
+	write(_V1),
+	nl
+	.
+:- initialization(main, main).


### PR DESCRIPTION
## Summary
- support remote HTTP requests in the Prolog runtime via `curl`
- add regression test for fetching from jsonplaceholder

## Testing
- `go test ./compile/x/pl -tags slow -run TestPrologCompiler_GoldenOutput -update -v`
- `go test ./compile/x/pl -tags slow -run TestPrologCompiler_SubsetPrograms -update -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c80d2dc83209a16e17a3721f57b