### PR TITLE
Add typed fetch support for Scala backend

### DIFF
--- a/compile/x/scala/helpers.go
+++ b/compile/x/scala/helpers.go
@@ -261,6 +261,11 @@ func isString(t types.Type) bool {
 	return ok
 }
 
+func isAny(t types.Type) bool {
+	_, ok := t.(types.AnyType)
+	return ok
+}
+
 func seqLambda(params []string, body string) string {
 	var b strings.Builder
 	b.WriteString("(args: Seq[Any]) => {\n")


### PR DESCRIPTION
## Summary
- implement `_cast` runtime helper for Scala target
- use `_cast` for cast operations and when assigning typed values
- apply runtime casts on typed returns
- expose `isAny` helper for Scala compiler

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_685d2c881b3c83209ee52e109b746534