### PR TITLE
Add structified fetch support for Elixir backend

### DIFF
--- a/compile/x/ex/expr.go
+++ b/compile/x/ex/expr.go
@@ -312,8 +312,10 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 		} else if op.Cast != nil {
 			if op.Cast.Type != nil {
 				t := c.resolveTypeRef(op.Cast.Type)
-				if _, ok := t.(types.StructType); ok {
-					res = fmt.Sprintf("Map.new(%s, fn {k, v} -> {String.to_atom(to_string(k)), v} end)", res)
+				if st, ok := t.(types.StructType); ok {
+					c.ensureStruct(st)
+					c.use("_structify")
+					res = fmt.Sprintf("_structify(%s, %s)", sanitizeName(st.Name), res)
 				}
 				typ = t
 			}

--- a/compile/x/ex/runtime.go
+++ b/compile/x/ex/runtime.go
@@ -23,7 +23,7 @@ const (
 
 	helperSave = "defp _save(data, path, opts \\ nil) do\n  rows = _to_map_list(data)\n  format = if opts, do: Map.get(opts, \"format\", \"csv\"), else: \"csv\"\n  header = if opts && Map.has_key?(opts, \"header\"), do: opts[\"header\"], else: false\n  delim = if opts && Map.has_key?(opts, \"delimiter\"), do: String.first(to_string(opts[\"delimiter\"] || \",\")), else: \",\"\n  out = case format do\n    \"json\" -> Jason.encode!(rows)\n    \"jsonl\" -> Enum.map(rows, &Jason.encode!/1) |> Enum.join(\"\\n\") <> \"\\n\"\n    \"tsv\" -> _to_csv(rows, header, \"\t\")\n    _ -> _to_csv(rows, header, delim)\n  end\n  case path do\n    nil -> IO.write(:stdio, out)\n    \"\" -> IO.write(:stdio, out)\n    \"-\" -> IO.write(:stdio, out)\n    _ -> File.write!(path, out)\n  end\nend\n"
 
-	helperFetch = "defp _fetch(url, opts \\ nil) do\n  :inets.start()\n  :ssl.start()\n  method = if opts, do: Map.get(opts, \"method\", \"GET\"), else: \"GET\"\n  headers = if opts && Map.has_key?(opts, \"headers\"), do: Enum.map(opts[\"headers\"], fn {k,v} -> {String.to_charlist(k), String.to_charlist(to_string(v))} end), else: []\n  body = if opts && Map.has_key?(opts, \"body\"), do: Jason.encode!(opts[\"body\"]), else: \"\"\n  query = if opts && Map.has_key?(opts, \"query\"), do: URI.encode_query(opts[\"query\"]), else: nil\n  full = if query, do: url <> \"?\" <> query, else: url\n  timeout = if opts && Map.has_key?(opts, \"timeout\"), do: (t = opts[\"timeout\"]; cond do\n    is_integer(t) -> trunc(t * 1000)\n    is_float(t) -> trunc(t * 1000)\n    true -> nil\n  end), else: nil\n  http_opts = if timeout, do: [timeout: timeout], else: []\n  {{_,_,_}, _, resp} = :httpc.request(String.to_atom(String.upcase(method)), {String.to_charlist(full), headers, 'application/json', String.to_charlist(body)}, [], http_opts) |> elem(1)\n  Jason.decode!(resp)\nend\n"
+	helperFetch = "defp _fetch(url, opts \\ nil) do\n  :inets.start()\n  :ssl.start()\n  method = if opts, do: Map.get(opts, \"method\", \"GET\"), else: \"GET\"\n  headers = if opts && Map.has_key?(opts, \"headers\"), do: Enum.map(opts[\"headers\"], fn {k,v} -> {String.to_charlist(k), String.to_charlist(to_string(v))} end), else: []\n  body = if opts && Map.has_key?(opts, \"body\"), do: Jason.encode!(opts[\"body\"]), else: \"\"\n  query = if opts && Map.has_key?(opts, \"query\"), do: URI.encode_query(opts[\"query\"]), else: nil\n  full = if query, do: url <> \"?\" <> query, else: url\n  timeout = if opts && Map.has_key?(opts, \"timeout\"), do: (t = opts[\"timeout\"]; cond do\n    is_integer(t) -> trunc(t * 1000)\n    is_float(t) -> trunc(t * 1000)\n    true -> nil\n  end), else: nil\n  http_opts = if timeout, do: [timeout: timeout], else: []\n  {{_,_,_}, _, resp} = :httpc.request(String.to_atom(String.upcase(method)), {String.to_charlist(full), headers, 'application/json', String.to_charlist(body)}, [], http_opts) |> elem(1)\n  Jason.decode!(resp, keys: :atoms)\nend\n"
 
 	helperGenText = "defp _gen_text(prompt, _model, _params) do\n  prompt\nend\n"
 
@@ -44,6 +44,8 @@ const (
 	helperSliceString = "defp _slice_string(s, i, j) do\n  chars = String.graphemes(s)\n  n = length(chars)\n  start = if i < 0, do: i + n, else: i\n  finish = if j < 0, do: j + n, else: j\n  start = if start < 0, do: 0, else: start\n  finish = if finish > n, do: n, else: finish\n  finish = if finish < start, do: start, else: finish\n  Enum.slice(chars, start, finish - start) |> Enum.join()\nend\n"
 
 	helperIter = "defp _iter(v) do\n  if is_map(v) do\n    Map.keys(v)\n  else\n    v\n  end\nend\n"
+
+	helperStructify = "defp _structify(mod, v) do\n  cond do\n    is_map(v) ->\n      m = Enum.reduce(v, %{}, fn {k,val}, acc -> Map.put(acc, String.to_atom(to_string(k)), _structify(nil, val)) end)\n      if mod, do: struct(mod, m), else: m\n    is_list(v) -> Enum.map(v, &_structify(nil, &1))\n    true -> v\n  end\nend\n"
 
 	helperQuery = "defp _query(src, joins, opts \\ %{}) do\n" +
 		"  where = Map.get(opts, :where)\n" +
@@ -132,6 +134,7 @@ var helperMap = map[string]string{
 	"_intersect":    helperIntersect,
 	"_index_string": helperIndexString,
 	"_slice_string": helperSliceString,
+	"_structify":    helperStructify,
 	"_iter":         helperIter,
 	"_query":        helperQuery,
 }


### PR DESCRIPTION
## Summary
- support struct definitions when compiling to Elixir
- add `_structify` runtime helper
- decode HTTP responses with atom keys
- cast and assignments to struct types now produce Elixir structs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d2c6df3e48320852c92ede72f4193