### PR TITLE
Add typed fetch support for Clojure backend

### DIFF
--- a/compile/x/clj/compiler.go
+++ b/compile/x/clj/compiler.go
@@ -287,33 +287,59 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 }
 
 func (c *Compiler) compileLet(st *parser.LetStmt) error {
-	expr, err := c.compileExpr(st.Value)
-	if err != nil {
-		return err
-	}
-	c.writeln(fmt.Sprintf("(def %s %s)", sanitizeName(st.Name), expr))
-	if c.env != nil {
-		var typ types.Type = types.AnyType{}
-		if st.Type != nil {
-			typ = c.resolveTypeRef(st.Type)
-		} else {
-			typ = c.exprType(st.Value)
-		}
-		c.env.SetVar(st.Name, typ, true)
-	}
-	return nil
+       expr, err := c.compileExpr(st.Value)
+       if err != nil {
+               return err
+       }
+       if st.Type != nil {
+               t := c.resolveTypeRef(st.Type)
+               switch tt := t.(type) {
+               case types.StructType:
+                       c.use("_cast_struct")
+                       expr = fmt.Sprintf("(_cast_struct %s %s)", sanitizeName(tt.Name), expr)
+               case types.ListType:
+                       if stt, ok := tt.Elem.(types.StructType); ok {
+                               c.use("_cast_struct_list")
+                               expr = fmt.Sprintf("(_cast_struct_list %s %s)", sanitizeName(stt.Name), expr)
+                       }
+               }
+       }
+       c.writeln(fmt.Sprintf("(def %s %s)", sanitizeName(st.Name), expr))
+       if c.env != nil {
+               var typ types.Type = types.AnyType{}
+               if st.Type != nil {
+                       typ = c.resolveTypeRef(st.Type)
+               } else {
+                       typ = c.exprType(st.Value)
+               }
+               c.env.SetVar(st.Name, typ, true)
+       }
+       return nil
 }
 
 func (c *Compiler) compileVar(st *parser.VarStmt) error {
-	expr := "nil"
-	if st.Value != nil {
-		v, err := c.compileExpr(st.Value)
-		if err != nil {
-			return err
-		}
-		expr = v
-	}
-	c.writeln(fmt.Sprintf("(def %s %s)", sanitizeName(st.Name), expr))
+       expr := "nil"
+       if st.Value != nil {
+               v, err := c.compileExpr(st.Value)
+               if err != nil {
+                       return err
+               }
+               expr = v
+       }
+       if st.Type != nil && expr != "nil" {
+               t := c.resolveTypeRef(st.Type)
+               switch tt := t.(type) {
+               case types.StructType:
+                       c.use("_cast_struct")
+                       expr = fmt.Sprintf("(_cast_struct %s %s)", sanitizeName(tt.Name), expr)
+               case types.ListType:
+                       if stt, ok := tt.Elem.(types.StructType); ok {
+                               c.use("_cast_struct_list")
+                               expr = fmt.Sprintf("(_cast_struct_list %s %s)", sanitizeName(stt.Name), expr)
+                       }
+               }
+       }
+       c.writeln(fmt.Sprintf("(def %s %s)", sanitizeName(st.Name), expr))
 	if c.env != nil {
 		var typ types.Type = types.AnyType{}
 		if st.Type != nil {
@@ -869,19 +895,26 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 			}
 			continue
 		}
-		if op.Cast != nil {
-			if op.Cast.Type != nil && op.Cast.Type.Simple != nil {
-				switch *op.Cast.Type.Simple {
-				case "float":
-					expr = fmt.Sprintf("(double %s)", expr)
-				case "int":
-					expr = fmt.Sprintf("(int %s)", expr)
-				default:
-					// ignore other casts as they have no runtime effect
-				}
-			}
-			continue
-		}
+               if op.Cast != nil {
+                        if op.Cast.Type != nil {
+                                t := c.resolveTypeRef(op.Cast.Type)
+                                switch tt := t.(type) {
+                                case types.FloatType:
+                                        expr = fmt.Sprintf("(double %s)", expr)
+                                case types.IntType:
+                                        expr = fmt.Sprintf("(int %s)", expr)
+                                case types.StructType:
+                                        c.use("_cast_struct")
+                                        expr = fmt.Sprintf("(_cast_struct %s %s)", sanitizeName(tt.Name), expr)
+                                case types.ListType:
+                                        if st, ok := tt.Elem.(types.StructType); ok {
+                                                c.use("_cast_struct_list")
+                                                expr = fmt.Sprintf("(_cast_struct_list %s %s)", sanitizeName(st.Name), expr)
+                                        }
+                                }
+                        }
+                        continue
+                }
 	}
 	return expr, nil
 }
@@ -1419,10 +1452,10 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
 }
 
 func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
-	url, err := c.compileExpr(f.URL)
-	if err != nil {
-		return "", err
-	}
+        url, err := c.compileExpr(f.URL)
+        if err != nil {
+                return "", err
+        }
 	opts := "nil"
 	if f.With != nil {
 		v, err := c.compileExpr(f.With)
@@ -1430,9 +1463,12 @@ func (c *Compiler) compileFetchExpr(f *parser.FetchExpr) (string, error) {
 			return "", err
 		}
 		opts = v
-	}
-	c.use("_fetch")
-	return fmt.Sprintf("(_fetch %s %s)", url, opts), nil
+        }
+       c.use("_fetch")
+       if c.imports != nil {
+               c.imports["json"] = "clojure.data.json"
+       }
+       return fmt.Sprintf("(_fetch %s %s)", url, opts), nil
 }
 
 func (c *Compiler) compileQueryHelper(q *parser.QueryExpr) (string, error) {
@@ -1637,16 +1673,19 @@ func (c *Compiler) compileGenerateExpr(g *parser.GenerateExpr) (string, error) {
 	if model == "" {
 		model = "\"\""
 	}
-	if g.Target == "embedding" {
-		c.use("_gen_embed")
-		return fmt.Sprintf("(_gen_embed %s %s %s)", text, model, paramStr), nil
-	}
-	if c.env != nil {
-		if _, ok := c.env.GetStruct(g.Target); ok {
-			c.use("_gen_struct")
-			return fmt.Sprintf("(_gen_struct %s %s %s %s)", sanitizeName(g.Target), prompt, model, paramStr), nil
-		}
-	}
+        if g.Target == "embedding" {
+                c.use("_gen_embed")
+                return fmt.Sprintf("(_gen_embed %s %s %s)", text, model, paramStr), nil
+        }
+        if c.env != nil {
+                if _, ok := c.env.GetStruct(g.Target); ok {
+                        c.use("_gen_struct")
+                       if c.imports != nil {
+                               c.imports["json"] = "clojure.data.json"
+                       }
+                        return fmt.Sprintf("(_gen_struct %s %s %s %s)", sanitizeName(g.Target), prompt, model, paramStr), nil
+                }
+        }
 	c.use("_gen_text")
 	return fmt.Sprintf("(_gen_text %s %s %s)", prompt, model, paramStr), nil
 }

--- a/compile/x/clj/runtime.go
+++ b/compile/x/clj/runtime.go
@@ -194,11 +194,18 @@ const (
 	helperGenEmbed = `(defn _gen_embed [text model params]
   (mapv double (map int text)))`
 
-	helperGenStruct = `(defn _gen_struct [ctor prompt model params]
+        helperGenStruct = `(defn _gen_struct [ctor prompt model params]
   (let [m (clojure.data.json/read-str prompt :key-fn keyword)
         fields (first (:arglists (meta ctor)))
         args (map #(get m %) fields)]
     (apply ctor args)))`
+
+        helperCastStruct = `(defn _cast_struct [ctor m]
+  (let [fields (first (:arglists (meta ctor)))]
+    (apply ctor (map #(get m %) fields))))`
+
+        helperCastStructList = `(defn _cast_struct_list [ctor xs]
+  (mapv #(_cast_struct ctor %) xs))`
 
         helperFetch = `(defn _fetch [url opts]
   (let [method (get opts :method "GET")
@@ -310,9 +317,11 @@ var helperMap = map[string]string{
 	"_intersect":   helperIntersect,
 	"_gen_text":    helperGenText,
 	"_gen_embed":   helperGenEmbed,
-	"_gen_struct":  helperGenStruct,
-	"_fetch":       helperFetch,
-	"_query":       helperQuery,
+        "_gen_struct":  helperGenStruct,
+        "_cast_struct": helperCastStruct,
+        "_cast_struct_list": helperCastStructList,
+        "_fetch":       helperFetch,
+        "_query":       helperQuery,
 }
 
 var helperOrder = []string{
@@ -336,10 +345,12 @@ var helperOrder = []string{
 	"_except",
 	"_intersect",
 	"_gen_text",
-	"_gen_embed",
-	"_gen_struct",
-	"_fetch",
-	"_query",
+        "_gen_embed",
+        "_gen_struct",
+        "_cast_struct",
+        "_cast_struct_list",
+        "_fetch",
+        "_query",
 }
 
 // helperDeps lists transitive helper dependencies.

--- a/tests/compiler/clj/fetch_todo.clj.out
+++ b/tests/compiler/clj/fetch_todo.clj.out
@@ -1,0 +1,47 @@
+(ns main
+  (:require
+    [clojure.data.json :as json]
+  ))
+
+(defn _cast_struct [ctor m]
+  (let [fields (first (:arglists (meta ctor)))]
+    (apply ctor (map #(get m %) fields))))
+(defn _fetch [url opts]
+  (let [method (get opts :method "GET")
+        q      (get opts :query nil)
+        url     (if q
+                   (let [qs (clojure.string/join "&"
+                             (map (fn [[k v]]
+                                    (str (java.net.URLEncoder/encode (name k) "UTF-8")
+                                         "="
+                                         (java.net.URLEncoder/encode (str v) "UTF-8")))
+                                  q))
+                         sep (if (clojure.string/includes? url "?") "&" "?")]
+                     (str url sep qs))
+                   url)
+        builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
+                  (.method method
+                          (if (contains? opts :body)
+                            (java.net.http.HttpRequest$BodyPublishers/ofString
+                              (clojure.data.json/write-str (:body opts)))
+                            (java.net.http.HttpRequest$BodyPublishers/noBody))))]
+    (when-let [hs (:headers opts)]
+      (doseq [[k v] hs]
+        (.header builder (name k) (str v))))
+    (when-let [t (:timeout opts)]
+      (.timeout builder (java.time.Duration/ofSeconds (long t))))
+    (let [client (java.net.http.HttpClient/newHttpClient)
+          resp (.send client (.build builder)
+                      (java.net.http.HttpResponse$BodyHandlers/ofString))]
+      (clojure.data.json/read-str (.body resp) :key-fn keyword))))
+(defn Todo [userId id title completed]
+  {:__name "Todo" :userId userId :id id :title title :completed completed}
+)
+
+
+(defn -main []
+  (def todo (_cast_struct Todo (_fetch "https://jsonplaceholder.typicode.com/todos/1" nil)))
+  (println (:title todo))
+)
+
+(-main)

--- a/tests/compiler/clj/fetch_todo.mochi
+++ b/tests/compiler/clj/fetch_todo.mochi
@@ -1,0 +1,9 @@
+ type Todo {
+   userId: int
+   id: int
+   title: string
+   completed: bool
+ }
+
+ let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+ print(todo.title)

--- a/tests/compiler/clj/fetch_todo.out
+++ b/tests/compiler/clj/fetch_todo.out
@@ -1,0 +1,1 @@
+delectus aut autem


### PR DESCRIPTION
## Summary
- extend Clojure runtime with `_cast_struct` helpers
- emit imports and cast calls when fetching data as structs
- update compiler to cast when variables have struct type
- add example test for fetching a Todo from jsonplaceholder

## Testing
- `go test ./compile/x/clj -run TestClojureCompiler_GoldenOutput -tags slow -count=1` *(fails: golden mismatch)*
- `go test ./compile/x/clj -run TestClojureCompiler_SubsetPrograms -tags slow -update -count=1` *(fails: network unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_685d2c63b43c8320af4fee6f3bc67f7a