### PR TITLE
Add release notes for v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # 📦 CHANGELOG.md
+## [0.10.3] – 2025-06-26T18:37:31+07:00
+
+### Added
+
+* Typed `fetch` builtin with HTTP options and struct casting
+* Dataset load and save support for JSON across languages
+
+### Fixed
+
+* Type inference bug for dataset load generics
+* Pascal string quoting issue and golden file updates
+* Erlang fetch runtime corrections
+
 ## [0.10.2] – 2025-06-26T12:39:20+07:00
 
 ### Added

--- a/releases/v0.10.3.md
+++ b/releases/v0.10.3.md
@@ -1,0 +1,23 @@
+# Jun 2025 (v0.10.3)
+
+Released on Thu Jun 26 18:37:31 2025 +0700.
+
+Mochi v0.10.3 introduces typed dataset fetch and JSON persistence. Many
+compilers now emit typed fetch helpers with HTTP tests while datasets can
+be loaded from and saved to JSON files.
+
+## Runtime
+
+- `fetch` builtin supports HTTP options and struct casting
+- JSON dataset load and save operations
+
+## Compilers
+
+- Typed fetch helpers implemented across languages
+- JSON load/save support for many backends
+
+## Fixes
+
+- Type inference for dataset load generics
+- Pascal string quoting issue and updated golden tests
+- Erlang fetch runtime corrections


### PR DESCRIPTION
## Summary
- document release notes for v0.10.3
- update CHANGELOG

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685d33a3a6488320a0ba1f751a8b8760