### PR TITLE
Add liveness analysis to VM compiler

### DIFF
--- a/runtime/vm/live.go
+++ b/runtime/vm/live.go
@@ -1,0 +1,75 @@
+package vm
+
+// Liveness holds live-in and live-out sets for each instruction of a function.
+type Liveness struct {
+	In  [][]bool
+	Out [][]bool
+}
+
+// Live performs liveness analysis for registers in fn.
+func Live(fn *Function) *Liveness {
+	n := len(fn.Code)
+	in := make([][]bool, n)
+	out := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		in[i] = make([]bool, fn.NumRegs)
+		out[i] = make([]bool, fn.NumRegs)
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for pc := n - 1; pc >= 0; pc-- {
+			ins := fn.Code[pc]
+			// compute out[pc]
+			newOut := make([]bool, fn.NumRegs)
+			for _, succ := range liveSuccs(ins, pc, n) {
+				if succ < 0 || succ >= n {
+					continue
+				}
+				for r, v := range in[succ] {
+					if v {
+						newOut[r] = true
+					}
+				}
+			}
+
+			// compute in[pc]
+			newIn := make([]bool, fn.NumRegs)
+			uses := uses(ins)
+			for _, r := range uses {
+				if r >= 0 && r < fn.NumRegs {
+					newIn[r] = true
+				}
+			}
+			def, hasDef := defReg(ins)
+			for r, v := range newOut {
+				if v {
+					if !hasDef || r != def {
+						newIn[r] = true
+					}
+				}
+			}
+
+			if !equalBoolSlice(newOut, out[pc]) || !equalBoolSlice(newIn, in[pc]) {
+				changed = true
+				out[pc] = newOut
+				in[pc] = newIn
+			}
+		}
+	}
+
+	return &Liveness{In: in, Out: out}
+}
+
+func equalBoolSlice(a, b []bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/runtime/vm/opt.go
+++ b/runtime/vm/opt.go
@@ -1,0 +1,124 @@
+package vm
+
+// liveSuccs returns the successor PCs for an instruction.
+func liveSuccs(ins Instr, pc, n int) []int {
+	switch ins.Op {
+	case OpJump:
+		return []int{ins.A}
+	case OpJumpIfFalse, OpJumpIfTrue:
+		return []int{pc + 1, ins.B}
+	case OpReturn:
+		return nil
+	default:
+		if pc+1 < n {
+			return []int{pc + 1}
+		}
+		return nil
+	}
+}
+
+func makeRange(start, count int) []int {
+	regs := make([]int, count)
+	for i := 0; i < count; i++ {
+		regs[i] = start + i
+	}
+	return regs
+}
+
+// uses returns the source registers read by the instruction.
+func uses(ins Instr) []int {
+	switch ins.Op {
+	case OpMove, OpLen, OpJSON, OpStr, OpNot, OpNeg, OpNegInt, OpNegFloat,
+		OpIterPrep, OpCount, OpExists, OpAvg, OpSum, OpMin, OpMax, OpValues,
+		OpCast:
+		return []int{ins.B}
+	case OpAdd, OpSub, OpMul, OpDiv, OpMod,
+		OpAddInt, OpSubInt, OpMulInt, OpDivInt, OpModInt,
+		OpAddFloat, OpSubFloat, OpMulFloat, OpDivFloat, OpModFloat,
+		OpEqual, OpNotEqual, OpEqualInt, OpEqualFloat,
+		OpLess, OpLessEq, OpLessInt, OpLessFloat, OpLessEqInt, OpLessEqFloat,
+		OpIn, OpAppend, OpUnionAll, OpUnion, OpExcept, OpIntersect:
+		return []int{ins.B, ins.C}
+	case OpIndex:
+		return []int{ins.B, ins.C}
+	case OpSlice:
+		return []int{ins.B, ins.C, ins.D}
+	case OpSetIndex:
+		return []int{ins.A, ins.B, ins.C}
+	case OpMakeList:
+		return makeRange(ins.C, ins.B)
+	case OpMakeMap:
+		return makeRange(ins.C, ins.B*2)
+	case OpPrint:
+		return []int{ins.A}
+	case OpPrint2:
+		return []int{ins.A, ins.B}
+	case OpPrintN:
+		return makeRange(ins.C, ins.B)
+	case OpCall2:
+		return []int{ins.C, ins.D}
+	case OpCall:
+		return makeRange(ins.D, ins.C)
+	case OpCallV:
+		r := makeRange(ins.D, ins.C)
+		return append([]int{ins.B}, r...)
+	case OpReturn:
+		return []int{ins.A}
+	case OpLoad:
+		return []int{ins.B, ins.C}
+	case OpSave:
+		return []int{ins.B, ins.C, ins.D}
+	case OpEval:
+		return []int{ins.B}
+	case OpFetch:
+		return []int{ins.B, ins.C}
+	case OpMakeClosure:
+		return makeRange(ins.D, ins.C)
+	default:
+		return nil
+	}
+}
+
+// defReg returns the destination register of ins if it writes one.
+func defReg(ins Instr) (int, bool) {
+	switch ins.Op {
+	case OpConst, OpMove, OpAdd, OpSub, OpMul, OpDiv, OpMod,
+		OpEqual, OpNotEqual, OpLess, OpLessEq, OpIn,
+		OpLen, OpIndex, OpSlice, OpMakeList, OpMakeMap,
+		OpCall, OpCall2, OpCallV, OpReturn, OpNot,
+		OpNow, OpJSON, OpAppend, OpStr, OpInput,
+		OpCount, OpExists, OpAvg, OpSum, OpMin, OpMax,
+		OpValues, OpCast, OpIterPrep, OpLoad, OpSave,
+		OpEval, OpFetch, OpMakeClosure,
+		OpAddInt, OpAddFloat, OpSubInt, OpSubFloat,
+		OpMulInt, OpMulFloat, OpDivInt, OpDivFloat,
+		OpModInt, OpModFloat, OpEqualInt, OpEqualFloat,
+		OpLessInt, OpLessFloat, OpLessEqInt, OpLessEqFloat,
+		OpNeg, OpNegInt, OpNegFloat, OpUnionAll, OpUnion,
+		OpExcept, OpIntersect, OpSort:
+		return ins.A, true
+	default:
+		return -1, false
+	}
+}
+
+// sideEffect reports whether ins has side effects beyond producing a value.
+func sideEffect(ins Instr) bool {
+	switch ins.Op {
+	case OpPrint, OpPrint2, OpPrintN, OpSetIndex, OpJump, OpJumpIfFalse,
+		OpJumpIfTrue, OpSave, OpLoad, OpEval, OpFetch, OpReturn, OpJSON,
+		OpInput, OpNow, OpCall, OpCall2, OpCallV:
+		return true
+	default:
+		return false
+	}
+}
+
+// regsUsed returns all registers referenced by ins (for max register counting).
+func regsUsed(ins Instr) []int {
+	regs := uses(ins)
+	if r, ok := defReg(ins); ok {
+		regs = append(regs, r)
+	}
+	return regs
+}

--- a/runtime/vm/optimize.go
+++ b/runtime/vm/optimize.go
@@ -1,0 +1,68 @@
+package vm
+
+// optimizeFunction removes dead register writes from fn.
+func optimizeFunction(fn *Function) {
+	for {
+		changed := removeDeadOnce(fn)
+		if !changed {
+			break
+		}
+	}
+	// shrink register count
+	max := fn.NumParams
+	for _, ins := range fn.Code {
+		for _, r := range regsUsed(ins) {
+			if r+1 > max {
+				max = r + 1
+			}
+		}
+	}
+	fn.NumRegs = max
+}
+
+func removeDeadOnce(fn *Function) bool {
+	live := Live(fn)
+	keep := make([]bool, len(fn.Code))
+	changed := false
+	for i, ins := range fn.Code {
+		keep[i] = true
+		if r, ok := defReg(ins); ok {
+			if !live.Out[i][r] && !sideEffect(ins) {
+				keep[i] = false
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return false
+	}
+	newCode := make([]Instr, 0, len(fn.Code))
+	oldToNew := make([]int, len(fn.Code))
+	for i, ins := range fn.Code {
+		if keep[i] {
+			oldToNew[i] = len(newCode)
+			newCode = append(newCode, ins)
+		} else {
+			oldToNew[i] = -1
+		}
+	}
+	for i := range newCode {
+		ins := newCode[i]
+		switch ins.Op {
+		case OpJump:
+			ins.A = oldToNew[ins.A]
+		case OpJumpIfFalse, OpJumpIfTrue:
+			ins.B = oldToNew[ins.B]
+		}
+		newCode[i] = ins
+	}
+	fn.Code = newCode
+	return true
+}
+
+// optimizeProgram applies optimizations to all functions in p.
+func optimizeProgram(p *Program) {
+	for i := range p.Funcs {
+		optimizeFunction(&p.Funcs[i])
+	}
+}

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1633,7 +1633,9 @@ func compileProgram(p *parser.Program, env *types.Env) (*Program, error) {
 		return nil, err
 	}
 	c.funcs[0] = main
-	return &Program{Funcs: c.funcs, Types: c.types}, nil
+	prog := &Program{Funcs: c.funcs, Types: c.types}
+	optimizeProgram(prog)
+	return prog, nil
 }
 
 func (c *compiler) compileFun(fn *parser.FunStmt) (Function, error) {


### PR DESCRIPTION
## Summary
- add liveness analysis pass for VM functions
- track register usage and eliminate dead writes
- shrink function register counts after optimization

## Testing
- `go test ./runtime/vm -run .`
- `go test ./...` *(fails: requires apt packages)*

------
https://chatgpt.com/codex/tasks/task_e_685d57b8fe548320b65e48c63d74406f