### PR TITLE
Improve readability of C++ backend output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 * Typed `fetch` builtin with HTTP options and struct casting
 * Dataset load and save support for JSON across languages
 
+### Changed
+
+* C++ backend now outputs spaces for indentation to improve readability
+* C++ backend embeds original Mochi source as comments atop generated code
+* C++ backend now comments each generated statement with its Mochi source line
+
 ### Fixed
 
 * Type inference bug for dataset load generics

--- a/compile/x/cpp/README.md
+++ b/compile/x/cpp/README.md
@@ -27,6 +27,13 @@ c.writeln("")
 ```
 【F:compile/cpp/compiler.go†L114-L116】
 
+The compiler now emits spaces for indentation instead of tabs. This makes the
+generated C++ source easier to read and consistent with common style guides.
+Additionally, when compiling from a file, the original Mochi source is
+included as `//` comments at the top of the generated C++ output. Each
+generated statement is also preceded by its Mochi source line to make the
+mapping clear.
+
 Type translation is straightforward. Integers become `int`, floats `double`,
 booleans `bool`, strings `string`, and lists map to `std::vector` as shown in
 `cppType`:

--- a/tests/compiler/cpp/arithmetic.cpp.out
+++ b/tests/compiler/cpp/arithmetic.cpp.out
@@ -1,11 +1,24 @@
+// Original Mochi source:
+// print(1 + 2)
+// print(5 - 3)
+// print(4 * 2)
+// print(8 / 2)
+// print(7 % 3)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (1 + 2) << std::endl;
-	std::cout << (5 - 3) << std::endl;
-	std::cout << (4 * 2) << std::endl;
-	std::cout << (8 / 2) << std::endl;
-	std::cout << (7 % 3) << std::endl;
-	return 0;
+    // print(1 + 2)
+    std::cout << (1 + 2) << std::endl;
+    // print(5 - 3)
+    std::cout << (5 - 3) << std::endl;
+    // print(4 * 2)
+    std::cout << (4 * 2) << std::endl;
+    // print(8 / 2)
+    std::cout << (8 / 2) << std::endl;
+    // print(7 % 3)
+    std::cout << (7 % 3) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/avg_builtin.cpp.out
+++ b/tests/compiler/cpp/avg_builtin.cpp.out
@@ -1,17 +1,22 @@
+// Original Mochi source:
+// print(avg([1,2,3]))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename T> auto _avg(const T& v) -> decltype(v.size(), double{}) {
-	if (v.size() == 0) return 0;
-	double sum = 0;
-	for (const auto& it : v) sum += it;
-	return sum / v.size();
+    if (v.size() == 0) return 0;
+    double sum = 0;
+    for (const auto& it : v) sum += it;
+    return sum / v.size();
 }
 template<typename T> auto _avg(const T& v) -> decltype(v.Items, double{}) {
-	return _avg(v.Items);
+    return _avg(v.Items);
 }
 
 int main() {
-	std::cout << (_avg(vector<int>{1, 2, 3})) << std::endl;
-	return 0;
+    // print(avg([1,2,3]))
+    std::cout << (_avg(vector<int>{1, 2, 3})) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/bool_ops.cpp.out
+++ b/tests/compiler/cpp/bool_ops.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// print(true && false)
+// print(true || false)
+// print(!false)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (true && false) << std::endl;
-	std::cout << (true || false) << std::endl;
-	std::cout << (!false) << std::endl;
-	return 0;
+    // print(true && false)
+    std::cout << (true && false) << std::endl;
+    // print(true || false)
+    std::cout << (true || false) << std::endl;
+    // print(!false)
+    std::cout << (!false) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/break_continue.cpp.out
+++ b/tests/compiler/cpp/break_continue.cpp.out
@@ -1,16 +1,37 @@
+// Original Mochi source:
+// let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+// 
+// for n in numbers {
+//   if n % 2 == 0 {
+//     continue
+//   }
+//   if n > 7 {
+//     break
+//   }
+//   print("odd number:", n)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto numbers = vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
-	for (int n : numbers) {
-		if (n % 2 == 0) {
-			continue;
-		}
-		if (n > 7) {
-			break;
-		}
-		std::cout << (string("odd number:")) << " " << (n) << std::endl;
-	}
-	return 0;
+    // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    auto numbers = vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    // for n in numbers {
+    for (int n : numbers) {
+        //   if n % 2 == 0 {
+        if (n % 2 == 0) {
+            //     continue
+            continue;
+        }
+        //   if n > 7 {
+        if (n > 7) {
+            //     break
+            break;
+        }
+        //   print("odd number:", n)
+        std::cout << (string("odd number:")) << " " << (n) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/closure.cpp.out
+++ b/tests/compiler/cpp/closure.cpp.out
@@ -1,12 +1,25 @@
+// Original Mochi source:
+// fun makeAdder(n: int): fun(int): int {
+//   return fun(x: int): int => x + n
+// }
+// 
+// let add10 = makeAdder(10)
+// print(add10(7))  // 17
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun makeAdder(n: int): fun(int): int {
 auto makeAdder(int n){
-	return [=](int x) { return x + n; };
+    //   return fun(x: int): int => x + n
+    return [=](int x) { return x + n; };
 }
 
 int main() {
-	auto add10 = makeAdder(10);
-	std::cout << (add10(7)) << std::endl;
-	return 0;
+    // let add10 = makeAdder(10)
+    auto add10 = makeAdder(10);
+    // print(add10(7))  // 17
+    std::cout << (add10(7)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/count_builtin.cpp.out
+++ b/tests/compiler/cpp/count_builtin.cpp.out
@@ -1,14 +1,19 @@
+// Original Mochi source:
+// print(count([1,2,3]))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename T> auto _count(const T& v) -> decltype(v.size(), int{}) {
-	return (int)v.size();
+    return (int)v.size();
 }
 template<typename T> auto _count(const T& v) -> decltype(v.Items, int{}) {
-	return (int)v.Items.size();
+    return (int)v.Items.size();
 }
 
 int main() {
-	std::cout << (_count(vector<int>{1, 2, 3})) << std::endl;
-	return 0;
+    // print(count([1,2,3]))
+    std::cout << (_count(vector<int>{1, 2, 3})) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/dataset.cpp.out
+++ b/tests/compiler/cpp/dataset.cpp.out
@@ -1,24 +1,51 @@
+// Original Mochi source:
+// type Person {
+//   name: string
+//   age: int
+// }
+// 
+// let people = [
+//   Person { name: "Alice", age: 30 },
+//   Person { name: "Bob", age: 15 },
+//   Person { name: "Charlie", age: 65 }
+// ]
+// 
+// let names = from p in people
+//             where p.age >= 18
+//             select p.name
+// 
+// for n in names {
+//   print(n)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Person {
 struct Person {
-	string name;
-	int age;
+    string name;
+    int age;
 };
 
 int main() {
-	auto people = vector<Person>{Person{string("Alice"), 30}, Person{string("Bob"), 15}, Person{string("Charlie"), 65}};
-	auto names = ([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& p : people) {
-		if (p.age >= 18) {
-			_res.push_back(p.name);
-		}
-	}
-	return _res;
+    // type Person {
+    // let people = [
+    auto people = vector<Person>{Person{string("Alice"), 30}, Person{string("Bob"), 15}, Person{string("Charlie"), 65}};
+    // let names = from p in people
+    auto names = ([&]() -> vector<auto> {
+    vector<auto> _res;
+    for (auto& p : people) {
+        if (p.age >= 18) {
+            _res.push_back(p.name);
+        }
+    }
+    return _res;
 })();
-	for (const string& n : names) {
-		std::cout << (n) << std::endl;
-	}
-	return 0;
+    // for n in names {
+    for (const string& n : names) {
+        //   print(n)
+        std::cout << (n) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/dataset_skip_take.cpp.out
+++ b/tests/compiler/cpp/dataset_skip_take.cpp.out
@@ -1,21 +1,36 @@
+// Original Mochi source:
+// let nums = [1, 2, 3, 4, 5]
+// let sub = from n in nums
+//             skip 1
+//             take 3
+//             select n
+// for n in sub {
+//   print(n)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto nums = vector<int>{1, 2, 3, 4, 5};
-	auto sub = ([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& n : nums) {
-		_res.push_back(n);
-	}
-	int _skip = 1;
-	if (_skip < (int)_res.size()) _res.erase(_res.begin(), _res.begin() + _skip); else _res.clear();
-	int _take = 3;
-	if (_take < (int)_res.size()) _res.resize(_take);
-	return _res;
+    // let nums = [1, 2, 3, 4, 5]
+    auto nums = vector<int>{1, 2, 3, 4, 5};
+    // let sub = from n in nums
+    auto sub = ([&]() -> vector<auto> {
+    vector<auto> _res;
+    for (auto& n : nums) {
+        _res.push_back(n);
+    }
+    int _skip = 1;
+    if (_skip < (int)_res.size()) _res.erase(_res.begin(), _res.begin() + _skip); else _res.clear();
+    int _take = 3;
+    if (_take < (int)_res.size()) _res.resize(_take);
+    return _res;
 })();
-	for (int n : sub) {
-		std::cout << (n) << std::endl;
-	}
-	return 0;
+    // for n in sub {
+    for (int n : sub) {
+        //   print(n)
+        std::cout << (n) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/dataset_sort_by.cpp.out
+++ b/tests/compiler/cpp/dataset_sort_by.cpp.out
@@ -1,21 +1,35 @@
+// Original Mochi source:
+// let nums = [5, 1, 4, 3, 2]
+// let sorted = from n in nums
+//             sort by n
+//             select n
+// for n in sorted {
+//   print(n)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto nums = vector<int>{5, 1, 4, 3, 2};
-	auto sorted = ([&]() -> vector<auto> {
-	vector<pair<auto, auto>> _tmp;
-	for (auto& n : nums) {
-		_tmp.push_back({n, n});
-	}
-	std::sort(_tmp.begin(), _tmp.end(), [](const auto& a, const auto& b){ return a.first < b.first; });
-	vector<auto> _res;
-	_res.reserve(_tmp.size());
-	for (auto& _it : _tmp) _res.push_back(_it.second);
-	return _res;
+    // let nums = [5, 1, 4, 3, 2]
+    auto nums = vector<int>{5, 1, 4, 3, 2};
+    // let sorted = from n in nums
+    auto sorted = ([&]() -> vector<auto> {
+    vector<pair<auto, auto>> _tmp;
+    for (auto& n : nums) {
+        _tmp.push_back({n, n});
+    }
+    std::sort(_tmp.begin(), _tmp.end(), [](const auto& a, const auto& b){ return a.first < b.first; });
+    vector<auto> _res;
+    _res.reserve(_tmp.size());
+    for (auto& _it : _tmp) _res.push_back(_it.second);
+    return _res;
 })();
-	for (int n : sorted) {
-		std::cout << (n) << std::endl;
-	}
-	return 0;
+    // for n in sorted {
+    for (int n : sorted) {
+        //   print(n)
+        std::cout << (n) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/factorial.cpp.out
+++ b/tests/compiler/cpp/factorial.cpp.out
@@ -1,16 +1,36 @@
+// Original Mochi source:
+// fun factorial(n: int): int {
+//   if n <= 1 {
+//     return 1
+//   }
+//   return n * factorial(n - 1)
+// }
+// 
+// print(factorial(0))
+// print(factorial(1))
+// print(factorial(5))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun factorial(n: int): int {
 int factorial(int n){
-	if (n <= 1) {
-		return 1;
-	}
-	return n * factorial(n - 1);
+    //   if n <= 1 {
+    if (n <= 1) {
+        //     return 1
+        return 1;
+    }
+    //   return n * factorial(n - 1)
+    return n * factorial(n - 1);
 }
 
 int main() {
-	std::cout << (factorial(0)) << std::endl;
-	std::cout << (factorial(1)) << std::endl;
-	std::cout << (factorial(5)) << std::endl;
-	return 0;
+    // print(factorial(0))
+    std::cout << (factorial(0)) << std::endl;
+    // print(factorial(1))
+    std::cout << (factorial(1)) << std::endl;
+    // print(factorial(5))
+    std::cout << (factorial(5)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/fetch_builtin.cpp.out
+++ b/tests/compiler/cpp/fetch_builtin.cpp.out
@@ -1,38 +1,86 @@
+// Original Mochi source:
+// type Msg {
+//   message: string
+// }
+// 
+// let opts = {
+//   method: "GET",
+//   headers: {"X-Test": "1"},
+//   query: {"q": "ok"},
+//   body: {"x": 1},
+//   timeout: 1
+// }
+// let data: Msg = fetch "file://tests/compiler/cpp/fetch_builtin.json" with opts
+// print(data.message)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
-static unordered_map<string,string> _fetch_parse(const string& s) {
-	unordered_map<string,string> row; size_t i=0;
-	while (i<s.size()) {
-		if (s[i]=='"') {
-			size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
-			i=s.find(':', j); if (i==string::npos) break; i++; while(i<s.size() && isspace(s[i])) i++;
-			string val;
-			if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
-			row[key]=val;
-		} else { i++; }
-	}
-	return row;
+template<typename T> T _cast(any v);
+template<> inline int _cast<int>(any v) {
+    if (v.type() == typeid(int)) return any_cast<int>(v);
+    if (v.type() == typeid(double)) return int(any_cast<double>(v));
+    if (v.type() == typeid(string)) return stoi(any_cast<string>(v));
+    return 0;
 }
-unordered_map<string,string> _fetch(const string& url, const unordered_map<string,any>& opts) {
-	(void)opts;
-	string data;
-	if (url.rfind("file://",0)==0) {
-		ifstream f(url.substr(7)); stringstream ss; ss<<f.rdbuf(); data=ss.str();
-	} else {
-		string cmd="curl -s "+url;
-		FILE* p=popen(cmd.c_str(), "r"); char buf[4096]; while(p && !feof(p)){ size_t n=fread(buf,1,sizeof(buf),p); data.append(buf,n);} if(p) pclose(p);
-	}
-	return _fetch_parse(data);
+template<> inline double _cast<double>(any v) {
+    if (v.type() == typeid(double)) return any_cast<double>(v);
+    if (v.type() == typeid(int)) return double(any_cast<int>(v));
+    if (v.type() == typeid(string)) return stod(any_cast<string>(v));
+    return 0.0;
+}
+template<> inline bool _cast<bool>(any v) {
+    if (v.type() == typeid(bool)) return any_cast<bool>(v);
+    if (v.type() == typeid(string)) return any_cast<string>(v)=="true";
+    if (v.type() == typeid(int)) return any_cast<int>(v)!=0;
+    return false;
+}
+template<> inline string _cast<string>(any v) {
+    if (v.type() == typeid(string)) return any_cast<string>(v);
+    if (v.type() == typeid(int)) return to_string(any_cast<int>(v));
+    if (v.type() == typeid(double)) { stringstream ss; ss<<any_cast<double>(v); return ss.str(); }
+    if (v.type() == typeid(bool)) return any_cast<bool>(v)?"true":"false";
+    return "";
 }
 
+static unordered_map<string,string> _fetch_parse(const string& s) {
+    unordered_map<string,string> row; size_t i=0;
+    while (i<s.size()) {
+        if (s[i]=='"') {
+            size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
+            i=s.find(':', j); if (i==string::npos) break; i++; while(i<s.size() && isspace(s[i])) i++;
+            string val;
+            if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
+            row[key]=val;
+        } else { i++; }
+    }
+    return row;
+}
+unordered_map<string,string> _fetch(const string& url, const unordered_map<string,any>& opts) {
+    (void)opts;
+    string data;
+    if (url.rfind("file://",0)==0) {
+        ifstream f(url.substr(7)); stringstream ss; ss<<f.rdbuf(); data=ss.str();
+    } else {
+        string cmd="curl -s "+url;
+        FILE* p=popen(cmd.c_str(), "r"); char buf[4096]; while(p && !feof(p)){ size_t n=fread(buf,1,sizeof(buf),p); data.append(buf,n);} if(p) pclose(p);
+    }
+    return _fetch_parse(data);
+}
+
+// type Msg {
 struct Msg {
-	string message;
+    string message;
 };
 
 int main() {
-	auto opts = unordered_map<string, any>{{string("method"), any(string("GET"))}, {string("headers"), any(unordered_map<string, string>{{string("X-Test"), string("1")}})}, {string("query"), any(unordered_map<string, string>{{string("q"), string("ok")}})}, {string("body"), any(unordered_map<string, int>{{string("x"), 1}})}, {string("timeout"), any(1)}};
-	Msg data = _fetch(string("file://tests/compiler/cpp/fetch_builtin.json"), opts);
-	std::cout << (data.message) << std::endl;
-	return 0;
+    // type Msg {
+    // let opts = {
+    auto opts = unordered_map<string, any>{{string("method"), any(string("GET"))}, {string("headers"), any(unordered_map<string, string>{{string("X-Test"), string("1")}})}, {string("query"), any(unordered_map<string, string>{{string("q"), string("ok")}})}, {string("body"), any(unordered_map<string, int>{{string("x"), 1}})}, {string("timeout"), any(1)}};
+    // let data: Msg = fetch "file://tests/compiler/cpp/fetch_builtin.json" with opts
+    Msg data = _cast<Msg>(_fetch(string("file://tests/compiler/cpp/fetch_builtin.json"), opts));
+    // print(data.message)
+    std::cout << (data.message) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/fetch_http.cpp.out
+++ b/tests/compiler/cpp/fetch_http.cpp.out
@@ -1,33 +1,40 @@
+// Original Mochi source:
+// let todo: map<string, string> = fetch "https://jsonplaceholder.typicode.com/todos/1"
+// print(todo["title"])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 static unordered_map<string,string> _fetch_parse(const string& s) {
-	unordered_map<string,string> row; size_t i=0;
-	while (i<s.size()) {
-		if (s[i]=='"') {
-			size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
-			i=s.find(':', j); if (i==string::npos) break; i++; while(i<s.size() && isspace(s[i])) i++;
-			string val;
-			if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
-			row[key]=val;
-		} else { i++; }
-	}
-	return row;
+    unordered_map<string,string> row; size_t i=0;
+    while (i<s.size()) {
+        if (s[i]=='"') {
+            size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
+            i=s.find(':', j); if (i==string::npos) break; i++; while(i<s.size() && isspace(s[i])) i++;
+            string val;
+            if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
+            row[key]=val;
+        } else { i++; }
+    }
+    return row;
 }
 unordered_map<string,string> _fetch(const string& url, const unordered_map<string,any>& opts) {
-	(void)opts;
-	string data;
-	if (url.rfind("file://",0)==0) {
-		ifstream f(url.substr(7)); stringstream ss; ss<<f.rdbuf(); data=ss.str();
-	} else {
-		string cmd="curl -s "+url;
-		FILE* p=popen(cmd.c_str(), "r"); char buf[4096]; while(p && !feof(p)){ size_t n=fread(buf,1,sizeof(buf),p); data.append(buf,n);} if(p) pclose(p);
-	}
-	return _fetch_parse(data);
+    (void)opts;
+    string data;
+    if (url.rfind("file://",0)==0) {
+        ifstream f(url.substr(7)); stringstream ss; ss<<f.rdbuf(); data=ss.str();
+    } else {
+        string cmd="curl -s "+url;
+        FILE* p=popen(cmd.c_str(), "r"); char buf[4096]; while(p && !feof(p)){ size_t n=fread(buf,1,sizeof(buf),p); data.append(buf,n);} if(p) pclose(p);
+    }
+    return _fetch_parse(data);
 }
 
 int main() {
-	unordered_map<string, string> todo = _fetch(string("https://jsonplaceholder.typicode.com/todos/1"), unordered_map<string,any>{});
-	std::cout << (todo[string("title")]) << std::endl;
-	return 0;
+    // let todo: map<string, string> = fetch "https://jsonplaceholder.typicode.com/todos/1"
+    unordered_map<string, string> todo = _fetch(string("https://jsonplaceholder.typicode.com/todos/1"), unordered_map<string,any>{});
+    // print(todo["title"])
+    std::cout << (todo[string("title")]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/field_select_expr.cpp.out
+++ b/tests/compiler/cpp/field_select_expr.cpp.out
@@ -1,16 +1,34 @@
+// Original Mochi source:
+// type Point {
+//   x: int
+//   y: int
+// }
+// 
+// fun make(): Point {
+//   return Point { x: 1, y: 2 }
+// }
+// 
+// print(make().x)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Point {
 struct Point {
-	int x;
-	int y;
+    int x;
+    int y;
 };
 
+// fun make(): Point {
 Point make(){
-	return Point{1, 2};
+    //   return Point { x: 1, y: 2 }
+    return Point{1, 2};
 }
 
 int main() {
-	std::cout << (make().x) << std::endl;
-	return 0;
+    // type Point {
+    // print(make().x)
+    std::cout << (make().x) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/float_ops.cpp.out
+++ b/tests/compiler/cpp/float_ops.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// print(1.2 + 3.4)
+// print(5.0 / 2.0)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (1.2 + 3.4) << std::endl;
-	std::cout << (5.0 / 2.0) << std::endl;
-	return 0;
+    // print(1.2 + 3.4)
+    std::cout << (1.2 + 3.4) << std::endl;
+    // print(5.0 / 2.0)
+    std::cout << (5.0 / 2.0) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/for_list_collection.cpp.out
+++ b/tests/compiler/cpp/for_list_collection.cpp.out
@@ -1,9 +1,17 @@
+// Original Mochi source:
+// for n in [1,2,3] {
+//   print(n)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	for (int n : vector<int>{1, 2, 3}) {
-		std::cout << (n) << std::endl;
-	}
-	return 0;
+    // for n in [1,2,3] {
+    for (int n : vector<int>{1, 2, 3}) {
+        //   print(n)
+        std::cout << (n) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/for_loop.cpp.out
+++ b/tests/compiler/cpp/for_loop.cpp.out
@@ -1,9 +1,17 @@
+// Original Mochi source:
+// for i in 1..4 {
+//   print(i)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	for (int i = 1; i < 4; i++) {
-		std::cout << (i) << std::endl;
-	}
-	return 0;
+    // for i in 1..4 {
+    for (int i = 1; i < 4; i++) {
+        //   print(i)
+        std::cout << (i) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/for_string_collection.cpp.out
+++ b/tests/compiler/cpp/for_string_collection.cpp.out
@@ -1,9 +1,17 @@
+// Original Mochi source:
+// for ch in "hi" {
+//   print(ch)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	for (char ch : string("hi")) {
-		std::cout << (ch) << std::endl;
-	}
-	return 0;
+    // for ch in "hi" {
+    for (char ch : string("hi")) {
+        //   print(ch)
+        std::cout << (ch) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/fun_expr_in_let.cpp.out
+++ b/tests/compiler/cpp/fun_expr_in_let.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// let square = fun(x: int): int => x * x
+// print(square(6))  // 36
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto square = [=](int x) { return x * x; };
-	std::cout << (square(6)) << std::endl;
-	return 0;
+    // let square = fun(x: int): int => x * x
+    auto square = [=](int x) { return x * x; };
+    // print(square(6))  // 36
+    std::cout << (square(6)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/group_by.cpp.out
+++ b/tests/compiler/cpp/group_by.cpp.out
@@ -1,42 +1,56 @@
+// Original Mochi source:
+// let xs = [1, 1, 2]
+// let groups = from x in xs
+//             group by x into g
+//             select { k: g.key, c: count(g) }
+// for g in groups {
+//   print(g.k, g.c)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename Src, typename KeyFunc> auto _group_by(const Src& src, KeyFunc keyfn) {
-	using ElemT = typename std::decay<decltype(*std::begin(src))>::type;
-	using KeyT = decltype(keyfn(*std::begin(src)));
-	struct _Group { KeyT Key; vector<ElemT> Items; };
-	unordered_map<KeyT, _Group> groups;
-	vector<KeyT> order;
-	for (const auto& it : src) {
-		KeyT k = keyfn(it);
-		if (!groups.count(k)) { groups[k] = _Group{k, {}}; order.push_back(k); }
-		groups[k].Items.push_back(it);
-	}
-	vector<_Group> res;
-	for (const auto& k : order) res.push_back(groups[k]);
-	return res;
+    using ElemT = typename std::decay<decltype(*std::begin(src))>::type;
+    using KeyT = decltype(keyfn(*std::begin(src)));
+    struct _Group { KeyT Key; vector<ElemT> Items; };
+    unordered_map<KeyT, _Group> groups;
+    vector<KeyT> order;
+    for (const auto& it : src) {
+        KeyT k = keyfn(it);
+        if (!groups.count(k)) { groups[k] = _Group{k, {}}; order.push_back(k); }
+        groups[k].Items.push_back(it);
+    }
+    vector<_Group> res;
+    for (const auto& k : order) res.push_back(groups[k]);
+    return res;
 }
 
 template<typename T> auto _count(const T& v) -> decltype(v.size(), int{}) {
-	return (int)v.size();
+    return (int)v.size();
 }
 template<typename T> auto _count(const T& v) -> decltype(v.Items, int{}) {
-	return (int)v.Items.size();
+    return (int)v.Items.size();
 }
 
 int main() {
-	auto xs = vector<int>{1, 1, 2};
-	auto groups = ([&]() -> vector<unordered_map<string, int>> {
-	auto _src = xs;
-	auto _groups = _group_by(_src, [&](auto& x){ return x; });
-	vector<unordered_map<string, int>> _res;
-	for (auto& g : _groups) {
-		_res.push_back(unordered_map<string, auto>{{string("k"), g.key}, {string("c"), _count(g)}});
-	}
-	return _res;
+    // let xs = [1, 1, 2]
+    auto xs = vector<int>{1, 1, 2};
+    // let groups = from x in xs
+    auto groups = ([&]() -> vector<unordered_map<string, int>> {
+    auto _src = xs;
+    auto _groups = _group_by(_src, [&](auto& x){ return x; });
+    vector<unordered_map<string, int>> _res;
+    for (auto& g : _groups) {
+        _res.push_back(unordered_map<string, auto>{{string("k"), g.key}, {string("c"), _count(g)}});
+    }
+    return _res;
 })();
-	for (const unordered_map<string, any>& g : groups) {
-		std::cout << (g["k"]) << " " << (g["c"]) << std::endl;
-	}
-	return 0;
+    // for g in groups {
+    for (const unordered_map<string, any>& g : groups) {
+        //   print(g.k, g.c)
+        std::cout << (g["k"]) << " " << (g["c"]) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/hello_world.cpp.out
+++ b/tests/compiler/cpp/hello_world.cpp.out
@@ -1,7 +1,12 @@
+// Original Mochi source:
+// print("Hello, world")
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (string("Hello, world")) << std::endl;
-	return 0;
+    // print("Hello, world")
+    std::cout << (string("Hello, world")) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/if_else.cpp.out
+++ b/tests/compiler/cpp/if_else.cpp.out
@@ -1,19 +1,42 @@
+// Original Mochi source:
+// fun foo(n: int): int {
+//   if n < 0 {
+//     return -1
+//   } else if n == 0 {
+//     return 0
+//   } else {
+//     return 1
+//   }
+// }
+// print(foo(-2))
+// print(foo(0))
+// print(foo(3))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun foo(n: int): int {
 int foo(int n){
-	if (n < 0) {
-		return -1;
-	} else 	if (n == 0) {
-		return 0;
-	} else {
-		return 1;
-	}
+    //   if n < 0 {
+    if (n < 0) {
+        //     return -1
+        return -1;
+    } else     if (n == 0) {
+        //     return 0
+        return 0;
+    } else {
+        //     return 1
+        return 1;
+    }
 }
 
 int main() {
-	std::cout << (foo(-2)) << std::endl;
-	std::cout << (foo(0)) << std::endl;
-	std::cout << (foo(3)) << std::endl;
-	return 0;
+    // print(foo(-2))
+    std::cout << (foo(-2)) << std::endl;
+    // print(foo(0))
+    std::cout << (foo(0)) << std::endl;
+    // print(foo(3))
+    std::cout << (foo(3)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/json_builtin.cpp.out
+++ b/tests/compiler/cpp/json_builtin.cpp.out
@@ -1,51 +1,56 @@
+// Original Mochi source:
+// json({"a": 1})
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 static string _escape_json(const string& s) {
-	string out;
-	for (char c : s) {
-		if (c == '"' || c == '\\') out += '\\';
-		out += c;
-	}
-	return out;
+    string out;
+    for (char c : s) {
+        if (c == '"' || c == '\\') out += '\\';
+        out += c;
+    }
+    return out;
 }
 template<typename T> string _to_json(const T& v);
 inline string _to_json(const string& s) {
-	string out = "\"";
-	out += _escape_json(s);
-	out += "\"";
-	return out;
+    string out = "\"";
+    out += _escape_json(s);
+    out += "\"";
+    return out;
 }
 inline string _to_json(const char* s) { return _to_json(string(s)); }
 inline string _to_json(int v) { return to_string(v); }
 inline string _to_json(double v) { stringstream ss; ss << v; return ss.str(); }
 inline string _to_json(bool v) { return v ? "true" : "false"; }
 inline string _to_json(const any& v) {
-	if (v.type() == typeid(int)) return _to_json(any_cast<int>(v));
-	if (v.type() == typeid(double)) return _to_json(any_cast<double>(v));
-	if (v.type() == typeid(bool)) return _to_json(any_cast<bool>(v));
-	if (v.type() == typeid(string)) return _to_json(any_cast<string>(v));
-	return "null";
+    if (v.type() == typeid(int)) return _to_json(any_cast<int>(v));
+    if (v.type() == typeid(double)) return _to_json(any_cast<double>(v));
+    if (v.type() == typeid(bool)) return _to_json(any_cast<bool>(v));
+    if (v.type() == typeid(string)) return _to_json(any_cast<string>(v));
+    return "null";
 }
 template<typename T> string _to_json(const vector<T>& v) {
-	string out = "[";
-	for (size_t i=0;i<v.size();i++) { if (i>0) out += ','; out += _to_json(v[i]); }
-	out += ']';
-	return out;
+    string out = "[";
+    for (size_t i=0;i<v.size();i++) { if (i>0) out += ','; out += _to_json(v[i]); }
+    out += ']';
+    return out;
 }
 template<typename K, typename V> string _to_json(const unordered_map<K,V>& m) {
-	string out = "{"; bool first = true;
-	for (const auto& kv : m) {
-		if (!first) out += ','; first = false;
-		out += _to_json(kv.first); out += ':'; out += _to_json(kv.second);
-	}
-	out += '}';
-	return out;
+    string out = "{"; bool first = true;
+    for (const auto& kv : m) {
+        if (!first) out += ','; first = false;
+        out += _to_json(kv.first); out += ':'; out += _to_json(kv.second);
+    }
+    out += '}';
+    return out;
 }
 template<typename T> string _to_json(const T& v) { stringstream ss; ss << v; return _to_json(ss.str()); }
 template<typename T> void _json(const T& v) { cout << _to_json(v) << endl; }
 
 int main() {
-	_json(unordered_map<string, int>{{string("a"), 1}});
-	return 0;
+    // json({"a": 1})
+    _json(unordered_map<string, int>{{string("a"), 1}});
+    return 0;
 }

--- a/tests/compiler/cpp/len_builtin.cpp.out
+++ b/tests/compiler/cpp/len_builtin.cpp.out
@@ -1,7 +1,12 @@
+// Original Mochi source:
+// print(len([1,2,3]))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (vector<int>{1, 2, 3}.size()) << std::endl;
-	return 0;
+    // print(len([1,2,3]))
+    std::cout << (vector<int>{1, 2, 3}.size()) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/let_and_print.cpp.out
+++ b/tests/compiler/cpp/let_and_print.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// let a = 10
+// let b: int = 20
+// print(a + b)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto a = 10;
-	int b = 20;
-	std::cout << (a + b) << std::endl;
-	return 0;
+    // let a = 10
+    auto a = 10;
+    // let b: int = 20
+    int b = 20;
+    // print(a + b)
+    std::cout << (a + b) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/list_concat.cpp.out
+++ b/tests/compiler/cpp/list_concat.cpp.out
@@ -1,18 +1,23 @@
+// Original Mochi source:
+// print([1,2] + [3,4])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename T> string _fmtVec(const vector<T>& v) {
-	stringstream ss;
-	ss << '[';
-	for (size_t i = 0; i < v.size(); i++) {
-		if (i > 0) ss << ' ';
-		ss << v[i];
-	}
-	ss << ']';
-	return ss.str();
+    stringstream ss;
+    ss << '[';
+    for (size_t i = 0; i < v.size(); i++) {
+        if (i > 0) ss << ' ';
+        ss << v[i];
+    }
+    ss << ']';
+    return ss.str();
 }
 
 int main() {
-	std::cout << (_fmtVec(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(vector<int>{1, 2}, vector<int>{3, 4}))) << std::endl;
-	return 0;
+    // print([1,2] + [3,4])
+    std::cout << (_fmtVec(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(vector<int>{1, 2}, vector<int>{3, 4}))) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/list_index.cpp.out
+++ b/tests/compiler/cpp/list_index.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// let xs = [10, 20, 30]
+// print(xs[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto xs = vector<int>{10, 20, 30};
-	std::cout << (xs[1]) << std::endl;
-	return 0;
+    // let xs = [10, 20, 30]
+    auto xs = vector<int>{10, 20, 30};
+    // print(xs[1])
+    std::cout << (xs[1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/list_negative_index.cpp.out
+++ b/tests/compiler/cpp/list_negative_index.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// let xs = [10,20,30]
+// print(xs[-1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto xs = vector<int>{10, 20, 30};
-	std::cout << (xs[-1]) << std::endl;
-	return 0;
+    // let xs = [10,20,30]
+    auto xs = vector<int>{10, 20, 30};
+    // print(xs[-1])
+    std::cout << (xs[-1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/list_set.cpp.out
+++ b/tests/compiler/cpp/list_set.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// var nums = [1, 2]
+// nums[1] = 3
+// print(nums[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto nums = vector<int>{1, 2};
-	nums[1] = 3;
-	std::cout << (nums[1]) << std::endl;
-	return 0;
+    // var nums = [1, 2]
+    auto nums = vector<int>{1, 2};
+    // nums[1] = 3
+    nums[1] = 3;
+    // print(nums[1])
+    std::cout << (nums[1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/list_slice.cpp.out
+++ b/tests/compiler/cpp/list_slice.cpp.out
@@ -1,19 +1,28 @@
+// Original Mochi source:
+// let xs = [1,2,3,4][1:3]
+// print(xs[0])
+// print(xs[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename T> vector<T> _slice(const vector<T>& v, int start, int end) {
-	int n = v.size();
-	if (start < 0) start += n;
-	if (end < 0) end += n;
-	if (start < 0) start = 0;
-	if (end > n) end = n;
-	if (end < start) end = start;
-	return vector<T>(v.begin() + start, v.begin() + end);
+    int n = v.size();
+    if (start < 0) start += n;
+    if (end < 0) end += n;
+    if (start < 0) start = 0;
+    if (end > n) end = n;
+    if (end < start) end = start;
+    return vector<T>(v.begin() + start, v.begin() + end);
 }
 
 int main() {
-	auto xs = _slice(vector<int>{1, 2, 3, 4}, 1, 3);
-	std::cout << (xs[0]) << std::endl;
-	std::cout << (xs[1]) << std::endl;
-	return 0;
+    // let xs = [1,2,3,4][1:3]
+    auto xs = _slice(vector<int>{1, 2, 3, 4}, 1, 3);
+    // print(xs[0])
+    std::cout << (xs[0]) << std::endl;
+    // print(xs[1])
+    std::cout << (xs[1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/list_union_all.cpp.out
+++ b/tests/compiler/cpp/list_union_all.cpp.out
@@ -1,26 +1,31 @@
+// Original Mochi source:
+// print([1,2] union all [2,3])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename T> string _fmtVec(const vector<T>& v) {
-	stringstream ss;
-	ss << '[';
-	for (size_t i = 0; i < v.size(); i++) {
-		if (i > 0) ss << ' ';
-		ss << v[i];
-	}
-	ss << ']';
-	return ss.str();
+    stringstream ss;
+    ss << '[';
+    for (size_t i = 0; i < v.size(); i++) {
+        if (i > 0) ss << ' ';
+        ss << v[i];
+    }
+    ss << ']';
+    return ss.str();
 }
 
 template<typename T> vector<T> _union(const vector<T>& a, const vector<T>& b) {
-	vector<T> res = a;
-	for (const auto& it : b) {
-		if (find(res.begin(), res.end(), it) == res.end()) res.push_back(it);
-	}
-	return res;
+    vector<T> res = a;
+    for (const auto& it : b) {
+        if (find(res.begin(), res.end(), it) == res.end()) res.push_back(it);
+    }
+    return res;
 }
 
 int main() {
-	std::cout << (_fmtVec(_union(vector<int>{1, 2}, vector<int>{2, 3}))) << std::endl;
-	return 0;
+    // print([1,2] union all [2,3])
+    std::cout << (_fmtVec(_union(vector<int>{1, 2}, vector<int>{2, 3}))) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/load_save_json.cpp.out
+++ b/tests/compiler/cpp/load_save_json.cpp.out
@@ -1,103 +1,110 @@
+// Original Mochi source:
+// let rows = load as map<string,string> with { format: "json" }
+// save rows to "-" with { format: "json" }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 static string _read_input(const string& path) {
-	if (!path.empty() && path != "-") {
-		ifstream f(path);
-		stringstream ss; ss << f.rdbuf(); return ss.str();
-	}
-	stringstream ss; ss << cin.rdbuf(); return ss.str();
+    if (!path.empty() && path != "-") {
+        ifstream f(path);
+        stringstream ss; ss << f.rdbuf(); return ss.str();
+    }
+    stringstream ss; ss << cin.rdbuf(); return ss.str();
 }
 static vector<string> _split(const string& s, char d) {
-	vector<string> out; string item; stringstream ss(s);
-	while (getline(ss, item, d)) out.push_back(item);
-	return out;
+    vector<string> out; string item; stringstream ss(s);
+    while (getline(ss, item, d)) out.push_back(item);
+    return out;
 }
 static vector<unordered_map<string,string>> _parse_csv(const string& text, bool header, char delim) {
-	vector<unordered_map<string,string>> rows;
-	stringstream ss(text); string line; vector<string> lines;
-	while (getline(ss, line)) { if (!line.empty() && line.back()=='\r') line.pop_back(); lines.push_back(line); }
-	if (lines.empty()) return rows;
-	vector<string> headers; size_t start = 0;
-	if (header) { headers = _split(lines[0], delim); start = 1; } else {
-	headers = _split(lines[0], delim);
-	for (size_t i=0;i<headers.size();i++) headers[i] = string("c")+to_string(i);
-	}
-	for (size_t i=start;i<lines.size();i++) {
-		auto parts = _split(lines[i], delim);
-		unordered_map<string,string> row;
-		for (size_t j=0;j<headers.size();j++) {
-			string val = j<parts.size()?parts[j]:"";
-			row[headers[j]] = val;
-		}
-		rows.push_back(row);
-	}
-	return rows;
+    vector<unordered_map<string,string>> rows;
+    stringstream ss(text); string line; vector<string> lines;
+    while (getline(ss, line)) { if (!line.empty() && line.back()=='\r') line.pop_back(); lines.push_back(line); }
+    if (lines.empty()) return rows;
+    vector<string> headers; size_t start = 0;
+    if (header) { headers = _split(lines[0], delim); start = 1; } else {
+    headers = _split(lines[0], delim);
+    for (size_t i=0;i<headers.size();i++) headers[i] = string("c")+to_string(i);
+    }
+    for (size_t i=start;i<lines.size();i++) {
+        auto parts = _split(lines[i], delim);
+        unordered_map<string,string> row;
+        for (size_t j=0;j<headers.size();j++) {
+            string val = j<parts.size()?parts[j]:"";
+            row[headers[j]] = val;
+        }
+        rows.push_back(row);
+    }
+    return rows;
 }
 static unordered_map<string,string> _parse_json_obj(const string& s) {
-	unordered_map<string,string> row; size_t i=0;
-	while (i<s.size()) {
-		if (s[i]=='"') {
-			size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
-			i=s.find(':', j); if (i==string::npos) break; i++; while (i<s.size() && isspace(s[i])) i++;
-			string val;
-			if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
-			row[key]=val;
-		} else { i++; }
-	}
-	return row;
+    unordered_map<string,string> row; size_t i=0;
+    while (i<s.size()) {
+        if (s[i]=='"') {
+            size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
+            i=s.find(':', j); if (i==string::npos) break; i++; while (i<s.size() && isspace(s[i])) i++;
+            string val;
+            if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
+            row[key]=val;
+        } else { i++; }
+    }
+    return row;
 }
 static vector<unordered_map<string,string>> _parse_jsonl(const string& text) {
-	vector<unordered_map<string,string>> rows; string line; stringstream ss(text);
-	while (getline(ss, line)) { if (!line.empty()) rows.push_back(_parse_json_obj(line)); }
-	return rows;
+    vector<unordered_map<string,string>> rows; string line; stringstream ss(text);
+    while (getline(ss, line)) { if (!line.empty()) rows.push_back(_parse_json_obj(line)); }
+    return rows;
 }
 static vector<unordered_map<string,string>> _parse_json(const string& text) {
-	string t=text; while(!t.empty() && isspace(t.front())) t.erase(t.begin()); while(!t.empty() && isspace(t.back())) t.pop_back();
-	vector<unordered_map<string,string>> rows;
-	if (t.empty()) return rows;
-	if (t[0]=='[') { size_t pos=t.find('{'); while(pos!=string::npos){ size_t end=t.find('}',pos); rows.push_back(_parse_json_obj(t.substr(pos,end-pos+1))); pos=t.find('{',end); } }
-	else if (t[0]=='{') { rows.push_back(_parse_json_obj(t)); }
-	return rows;
+    string t=text; while(!t.empty() && isspace(t.front())) t.erase(t.begin()); while(!t.empty() && isspace(t.back())) t.pop_back();
+    vector<unordered_map<string,string>> rows;
+    if (t.empty()) return rows;
+    if (t[0]=='[') { size_t pos=t.find('{'); while(pos!=string::npos){ size_t end=t.find('}',pos); rows.push_back(_parse_json_obj(t.substr(pos,end-pos+1))); pos=t.find('{',end); } }
+    else if (t[0]=='{') { rows.push_back(_parse_json_obj(t)); }
+    return rows;
 }
 vector<unordered_map<string,string>> _load(const string& path, const unordered_map<string,string>& opts) {
-	string format="csv"; bool header=true; char delim=',';
-	auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
-	it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
-	it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
-	string text=_read_input(path);
-	if (format=="jsonl") return _parse_jsonl(text);
-	if (format=="json") return _parse_json(text);
-	if (format=="tsv") delim='	';
-	return _parse_csv(text, header, delim);
+    string format="csv"; bool header=true; char delim=',';
+    auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
+    it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
+    it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
+    string text=_read_input(path);
+    if (format=="jsonl") return _parse_jsonl(text);
+    if (format=="json") return _parse_json(text);
+    if (format=="tsv") delim='    ';
+    return _parse_csv(text, header, delim);
 }
 
 static void _write_output(const string& path, const string& text) {
-	if (!path.empty() && path != "-") { ofstream f(path); f << text; } else { cout << text; }
+    if (!path.empty() && path != "-") { ofstream f(path); f << text; } else { cout << text; }
 }
 static string _json_sorted(const unordered_map<string,string>& m) {
-	vector<string> keys; for (const auto& kv : m) keys.push_back(kv.first); sort(keys.begin(), keys.end());
-	string out="{"; bool first=true;
-	for(const auto& k:keys){ if(!first) out+=','; first=false; out+=_to_json(k); out+=':'; out+=_to_json(m.at(k)); }
-	out+='}'; return out;
+    vector<string> keys; for (const auto& kv : m) keys.push_back(kv.first); sort(keys.begin(), keys.end());
+    string out="{"; bool first=true;
+    for(const auto& k:keys){ if(!first) out+=','; first=false; out+=_to_json(k); out+=':'; out+=_to_json(m.at(k)); }
+    out+='}'; return out;
 }
 void _save(const vector<unordered_map<string,string>>& src, const string& path, const unordered_map<string,string>& opts) {
-	string format="csv"; bool header=false; char delim=',';
-	auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
-	it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
-	it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
-	string text;
-	if (format=="jsonl") { for(const auto& r:src){ text+=_json_sorted(r)+"
+    string format="csv"; bool header=false; char delim=',';
+    auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
+    it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
+    it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
+    string text;
+    if (format=="jsonl") { for(const auto& r:src){ text+=_json_sorted(r)+"
 "; } }
-	else if (format=="json") { if(src.size()==1) text=_json_sorted(src[0]); else text=_to_json(src); }
-	else { if(format=="tsv") delim='	'; vector<string> headers; if(!src.empty()) for(const auto& kv:src[0]) headers.push_back(kv.first); sort(headers.begin(), headers.end()); if(header && !headers.empty()){ for(size_t i=0;i<headers.size();i++){ if(i>0) text+=delim; text+=headers[i]; } text+='
+    else if (format=="json") { if(src.size()==1) text=_json_sorted(src[0]); else text=_to_json(src); }
+    else { if(format=="tsv") delim='    '; vector<string> headers; if(!src.empty()) for(const auto& kv:src[0]) headers.push_back(kv.first); sort(headers.begin(), headers.end()); if(header && !headers.empty()){ for(size_t i=0;i<headers.size();i++){ if(i>0) text+=delim; text+=headers[i]; } text+='
 '; } for(const auto& r:src){ for(size_t i=0;i<headers.size();i++){ if(i>0) text+=delim; auto it2=r.find(headers[i]); if(it2!=r.end()) text+=it2->second; } text+='
 '; } }
-	_write_output(path, text);
+    _write_output(path, text);
 }
 
 int main() {
-	auto rows = _load("", unordered_map<string, string>{{string("format"), string("json")}});
-	_save(rows, "-", unordered_map<string, string>{{string("format"), string("json")}});
-	return 0;
+    // let rows = load as map<string,string> with { format: "json" }
+    auto rows = _load("", unordered_map<string, string>{{string("format"), string("json")}});
+    // save rows to "-" with { format: "json" }
+    _save(rows, "-", unordered_map<string, string>{{string("format"), string("json")}});
+    return 0;
 }

--- a/tests/compiler/cpp/load_save_jsonl.cpp.out
+++ b/tests/compiler/cpp/load_save_jsonl.cpp.out
@@ -1,103 +1,110 @@
+// Original Mochi source:
+// let rows = load as map<string,string> with { format: "jsonl" }
+// save rows to "-" with { format: "jsonl" }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 static string _read_input(const string& path) {
-	if (!path.empty() && path != "-") {
-		ifstream f(path);
-		stringstream ss; ss << f.rdbuf(); return ss.str();
-	}
-	stringstream ss; ss << cin.rdbuf(); return ss.str();
+    if (!path.empty() && path != "-") {
+        ifstream f(path);
+        stringstream ss; ss << f.rdbuf(); return ss.str();
+    }
+    stringstream ss; ss << cin.rdbuf(); return ss.str();
 }
 static vector<string> _split(const string& s, char d) {
-	vector<string> out; string item; stringstream ss(s);
-	while (getline(ss, item, d)) out.push_back(item);
-	return out;
+    vector<string> out; string item; stringstream ss(s);
+    while (getline(ss, item, d)) out.push_back(item);
+    return out;
 }
 static vector<unordered_map<string,string>> _parse_csv(const string& text, bool header, char delim) {
-	vector<unordered_map<string,string>> rows;
-	stringstream ss(text); string line; vector<string> lines;
-	while (getline(ss, line)) { if (!line.empty() && line.back()=='\r') line.pop_back(); lines.push_back(line); }
-	if (lines.empty()) return rows;
-	vector<string> headers; size_t start = 0;
-	if (header) { headers = _split(lines[0], delim); start = 1; } else {
-	headers = _split(lines[0], delim);
-	for (size_t i=0;i<headers.size();i++) headers[i] = string("c")+to_string(i);
-	}
-	for (size_t i=start;i<lines.size();i++) {
-		auto parts = _split(lines[i], delim);
-		unordered_map<string,string> row;
-		for (size_t j=0;j<headers.size();j++) {
-			string val = j<parts.size()?parts[j]:"";
-			row[headers[j]] = val;
-		}
-		rows.push_back(row);
-	}
-	return rows;
+    vector<unordered_map<string,string>> rows;
+    stringstream ss(text); string line; vector<string> lines;
+    while (getline(ss, line)) { if (!line.empty() && line.back()=='\r') line.pop_back(); lines.push_back(line); }
+    if (lines.empty()) return rows;
+    vector<string> headers; size_t start = 0;
+    if (header) { headers = _split(lines[0], delim); start = 1; } else {
+    headers = _split(lines[0], delim);
+    for (size_t i=0;i<headers.size();i++) headers[i] = string("c")+to_string(i);
+    }
+    for (size_t i=start;i<lines.size();i++) {
+        auto parts = _split(lines[i], delim);
+        unordered_map<string,string> row;
+        for (size_t j=0;j<headers.size();j++) {
+            string val = j<parts.size()?parts[j]:"";
+            row[headers[j]] = val;
+        }
+        rows.push_back(row);
+    }
+    return rows;
 }
 static unordered_map<string,string> _parse_json_obj(const string& s) {
-	unordered_map<string,string> row; size_t i=0;
-	while (i<s.size()) {
-		if (s[i]=='"') {
-			size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
-			i=s.find(':', j); if (i==string::npos) break; i++; while (i<s.size() && isspace(s[i])) i++;
-			string val;
-			if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
-			row[key]=val;
-		} else { i++; }
-	}
-	return row;
+    unordered_map<string,string> row; size_t i=0;
+    while (i<s.size()) {
+        if (s[i]=='"') {
+            size_t j=s.find('"', i+1); if (j==string::npos) break; string key=s.substr(i+1,j-i-1);
+            i=s.find(':', j); if (i==string::npos) break; i++; while (i<s.size() && isspace(s[i])) i++;
+            string val;
+            if (i<s.size() && s[i]=='"') { size_t k=s.find('"', i+1); val=s.substr(i+1,k-i-1); i=k+1; } else { size_t k=i; while (k<s.size() && (isalnum(s[k])||s[k]=='-'||s[k]=='+'||s[k]=='.')) k++; val=s.substr(i,k-i); i=k; }
+            row[key]=val;
+        } else { i++; }
+    }
+    return row;
 }
 static vector<unordered_map<string,string>> _parse_jsonl(const string& text) {
-	vector<unordered_map<string,string>> rows; string line; stringstream ss(text);
-	while (getline(ss, line)) { if (!line.empty()) rows.push_back(_parse_json_obj(line)); }
-	return rows;
+    vector<unordered_map<string,string>> rows; string line; stringstream ss(text);
+    while (getline(ss, line)) { if (!line.empty()) rows.push_back(_parse_json_obj(line)); }
+    return rows;
 }
 static vector<unordered_map<string,string>> _parse_json(const string& text) {
-	string t=text; while(!t.empty() && isspace(t.front())) t.erase(t.begin()); while(!t.empty() && isspace(t.back())) t.pop_back();
-	vector<unordered_map<string,string>> rows;
-	if (t.empty()) return rows;
-	if (t[0]=='[') { size_t pos=t.find('{'); while(pos!=string::npos){ size_t end=t.find('}',pos); rows.push_back(_parse_json_obj(t.substr(pos,end-pos+1))); pos=t.find('{',end); } }
-	else if (t[0]=='{') { rows.push_back(_parse_json_obj(t)); }
-	return rows;
+    string t=text; while(!t.empty() && isspace(t.front())) t.erase(t.begin()); while(!t.empty() && isspace(t.back())) t.pop_back();
+    vector<unordered_map<string,string>> rows;
+    if (t.empty()) return rows;
+    if (t[0]=='[') { size_t pos=t.find('{'); while(pos!=string::npos){ size_t end=t.find('}',pos); rows.push_back(_parse_json_obj(t.substr(pos,end-pos+1))); pos=t.find('{',end); } }
+    else if (t[0]=='{') { rows.push_back(_parse_json_obj(t)); }
+    return rows;
 }
 vector<unordered_map<string,string>> _load(const string& path, const unordered_map<string,string>& opts) {
-	string format="csv"; bool header=true; char delim=',';
-	auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
-	it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
-	it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
-	string text=_read_input(path);
-	if (format=="jsonl") return _parse_jsonl(text);
-	if (format=="json") return _parse_json(text);
-	if (format=="tsv") delim='	';
-	return _parse_csv(text, header, delim);
+    string format="csv"; bool header=true; char delim=',';
+    auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
+    it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
+    it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
+    string text=_read_input(path);
+    if (format=="jsonl") return _parse_jsonl(text);
+    if (format=="json") return _parse_json(text);
+    if (format=="tsv") delim='    ';
+    return _parse_csv(text, header, delim);
 }
 
 static void _write_output(const string& path, const string& text) {
-	if (!path.empty() && path != "-") { ofstream f(path); f << text; } else { cout << text; }
+    if (!path.empty() && path != "-") { ofstream f(path); f << text; } else { cout << text; }
 }
 static string _json_sorted(const unordered_map<string,string>& m) {
-	vector<string> keys; for (const auto& kv : m) keys.push_back(kv.first); sort(keys.begin(), keys.end());
-	string out="{"; bool first=true;
-	for(const auto& k:keys){ if(!first) out+=','; first=false; out+=_to_json(k); out+=':'; out+=_to_json(m.at(k)); }
-	out+='}'; return out;
+    vector<string> keys; for (const auto& kv : m) keys.push_back(kv.first); sort(keys.begin(), keys.end());
+    string out="{"; bool first=true;
+    for(const auto& k:keys){ if(!first) out+=','; first=false; out+=_to_json(k); out+=':'; out+=_to_json(m.at(k)); }
+    out+='}'; return out;
 }
 void _save(const vector<unordered_map<string,string>>& src, const string& path, const unordered_map<string,string>& opts) {
-	string format="csv"; bool header=false; char delim=',';
-	auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
-	it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
-	it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
-	string text;
-	if (format=="jsonl") { for(const auto& r:src){ text+=_json_sorted(r)+"
+    string format="csv"; bool header=false; char delim=',';
+    auto it=opts.find("format"); if(it!=opts.end()) format=it->second;
+    it=opts.find("header"); if(it!=opts.end()) header=(it->second=="true");
+    it=opts.find("delimiter"); if(it!=opts.end() && !it->second.empty()) delim=it->second[0];
+    string text;
+    if (format=="jsonl") { for(const auto& r:src){ text+=_json_sorted(r)+"
 "; } }
-	else if (format=="json") { if(src.size()==1) text=_json_sorted(src[0]); else text=_to_json(src); }
-	else { if(format=="tsv") delim='	'; vector<string> headers; if(!src.empty()) for(const auto& kv:src[0]) headers.push_back(kv.first); sort(headers.begin(), headers.end()); if(header && !headers.empty()){ for(size_t i=0;i<headers.size();i++){ if(i>0) text+=delim; text+=headers[i]; } text+='
+    else if (format=="json") { if(src.size()==1) text=_json_sorted(src[0]); else text=_to_json(src); }
+    else { if(format=="tsv") delim='    '; vector<string> headers; if(!src.empty()) for(const auto& kv:src[0]) headers.push_back(kv.first); sort(headers.begin(), headers.end()); if(header && !headers.empty()){ for(size_t i=0;i<headers.size();i++){ if(i>0) text+=delim; text+=headers[i]; } text+='
 '; } for(const auto& r:src){ for(size_t i=0;i<headers.size();i++){ if(i>0) text+=delim; auto it2=r.find(headers[i]); if(it2!=r.end()) text+=it2->second; } text+='
 '; } }
-	_write_output(path, text);
+    _write_output(path, text);
 }
 
 int main() {
-	auto rows = _load("", unordered_map<string, string>{{string("format"), string("jsonl")}});
-	_save(rows, "-", unordered_map<string, string>{{string("format"), string("jsonl")}});
-	return 0;
+    // let rows = load as map<string,string> with { format: "jsonl" }
+    auto rows = _load("", unordered_map<string, string>{{string("format"), string("jsonl")}});
+    // save rows to "-" with { format: "jsonl" }
+    _save(rows, "-", unordered_map<string, string>{{string("format"), string("jsonl")}});
+    return 0;
 }

--- a/tests/compiler/cpp/map_iterate.cpp.out
+++ b/tests/compiler/cpp/map_iterate.cpp.out
@@ -1,15 +1,33 @@
+// Original Mochi source:
+// var m: map<int, bool> = {}
+// m[1] = true
+// m[2] = true
+// var sum = 0
+// for k in m {
+//   sum = sum + k
+// }
+// print(sum)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	unordered_map<int, bool> m = unordered_map<int, bool>{};
-	m[1] = true;
-	m[2] = true;
-	auto sum = 0;
-	for (const auto& _kv : m) {
-		int k = _kv.first;
-		sum = sum + k;
-	}
-	std::cout << (sum) << std::endl;
-	return 0;
+    // var m: map<int, bool> = {}
+    unordered_map<int, bool> m = unordered_map<int, bool>{};
+    // m[1] = true
+    m[1] = true;
+    // m[2] = true
+    m[2] = true;
+    // var sum = 0
+    auto sum = 0;
+    // for k in m {
+    for (const auto& _kv : m) {
+        int k = _kv.first;
+        //   sum = sum + k
+        sum = sum + k;
+    }
+    // print(sum)
+    std::cout << (sum) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/method.cpp.out
+++ b/tests/compiler/cpp/method.cpp.out
@@ -1,23 +1,54 @@
+// Original Mochi source:
+// type Circle {
+//   radius: float
+// 
+//   fun area(): float {
+//     let a = 3.14 * radius * radius
+//     print("Calculating area:", a)
+//     return a
+//   }
+// 
+//   fun describe() {
+//     print("Circle with radius", radius)
+//   }
+// }
+// 
+// let c = Circle { radius: 5.0 }
+// c.describe()
+// print("Area is", c.area())
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Circle {
 struct Circle {
-	double radius;
+    double radius;
 };
+//   fun area(): float {
 double Circle_area(Circle& self){
-	auto a = 3.14 * self.radius * self.radius;
-	std::cout << (string("Calculating area:")) << " " << (a) << std::endl;
-	return a;
+    //     let a = 3.14 * radius * radius
+    auto a = 3.14 * self.radius * self.radius;
+    //     print("Calculating area:", a)
+    std::cout << (string("Calculating area:")) << " " << (a) << std::endl;
+    //     return a
+    return a;
 }
 
+//   fun describe() {
 void Circle_describe(Circle& self){
-	std::cout << (string("Circle with radius")) << " " << (self.radius) << std::endl;
+    //     print("Circle with radius", radius)
+    std::cout << (string("Circle with radius")) << " " << (self.radius) << std::endl;
 }
 
 
 int main() {
-	auto c = Circle{5.0};
-	Circle_describe(c);
-	std::cout << (string("Area is")) << " " << (Circle_area(c)) << std::endl;
-	return 0;
+    // type Circle {
+    // let c = Circle { radius: 5.0 }
+    auto c = Circle{5.0};
+    // c.describe()
+    Circle_describe(c);
+    // print("Area is", c.area())
+    std::cout << (string("Area is")) << " " << (Circle_area(c)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/nested_types.cpp.out
+++ b/tests/compiler/cpp/nested_types.cpp.out
@@ -1,17 +1,37 @@
+// Original Mochi source:
+// type Address {
+//   street: string
+// }
+// 
+// type Person {
+//   name: string
+//   addr: Address
+// }
+// 
+// let p = Person { name: "Bob", addr: Address { street: "Main" } }
+// print(p.addr.street)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Address {
 struct Address {
-	string street;
+    string street;
 };
 
+// type Person {
 struct Person {
-	string name;
-	Address addr;
+    string name;
+    Address addr;
 };
 
 int main() {
-	auto p = Person{string("Bob"), Address{string("Main")}};
-	std::cout << (p.addr.street) << std::endl;
-	return 0;
+    // type Address {
+    // type Person {
+    // let p = Person { name: "Bob", addr: Address { street: "Main" } }
+    auto p = Person{string("Bob"), Address{string("Main")}};
+    // print(p.addr.street)
+    std::cout << (p.addr.street) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/reduce_builtin.cpp.out
+++ b/tests/compiler/cpp/reduce_builtin.cpp.out
@@ -1,16 +1,25 @@
+// Original Mochi source:
+// let nums = [1, 2, 3, 4]
+// let sum = reduce(nums, fun(acc: int, x: int): int => acc + x, 0)
+// print(sum)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename Src, typename Fn, typename Acc> Acc _reduce(const Src& src, Fn fn, Acc acc) {
-	for (const auto& it : src) {
-		acc = fn(acc, it);
-	}
-	return acc;
+    for (const auto& it : src) {
+        acc = fn(acc, it);
+    }
+    return acc;
 }
 
 int main() {
-	auto nums = vector<int>{1, 2, 3, 4};
-	auto sum = _reduce(nums, [=](int acc, int x) { return acc + x; }, 0);
-	std::cout << (sum) << std::endl;
-	return 0;
+    // let nums = [1, 2, 3, 4]
+    auto nums = vector<int>{1, 2, 3, 4};
+    // let sum = reduce(nums, fun(acc: int, x: int): int => acc + x, 0)
+    auto sum = _reduce(nums, [=](int acc, int x) { return acc + x; }, 0);
+    // print(sum)
+    std::cout << (sum) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/set_ops.cpp.out
+++ b/tests/compiler/cpp/set_ops.cpp.out
@@ -1,47 +1,62 @@
+// Original Mochi source:
+// let a = [1, 2, 3]
+// let b = [3, 4]
+// print(a union b)
+// print(a except b)
+// print(a intersect b)
+// print([1, 2] union [2, 3])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename T> string _fmtVec(const vector<T>& v) {
-	stringstream ss;
-	ss << '[';
-	for (size_t i = 0; i < v.size(); i++) {
-		if (i > 0) ss << ' ';
-		ss << v[i];
-	}
-	ss << ']';
-	return ss.str();
+    stringstream ss;
+    ss << '[';
+    for (size_t i = 0; i < v.size(); i++) {
+        if (i > 0) ss << ' ';
+        ss << v[i];
+    }
+    ss << ']';
+    return ss.str();
 }
 
 template<typename T> vector<T> _union(const vector<T>& a, const vector<T>& b) {
-	vector<T> res = a;
-	for (const auto& it : b) {
-		if (find(res.begin(), res.end(), it) == res.end()) res.push_back(it);
-	}
-	return res;
+    vector<T> res = a;
+    for (const auto& it : b) {
+        if (find(res.begin(), res.end(), it) == res.end()) res.push_back(it);
+    }
+    return res;
 }
 
 template<typename T> vector<T> _except(const vector<T>& a, const vector<T>& b) {
-	vector<T> res;
-	for (const auto& it : a) {
-		if (find(b.begin(), b.end(), it) == b.end()) res.push_back(it);
-	}
-	return res;
+    vector<T> res;
+    for (const auto& it : a) {
+        if (find(b.begin(), b.end(), it) == b.end()) res.push_back(it);
+    }
+    return res;
 }
 
 template<typename T> vector<T> _intersect(const vector<T>& a, const vector<T>& b) {
-	vector<T> res;
-	for (const auto& it : a) {
-		if (find(b.begin(), b.end(), it) != b.end() && find(res.begin(), res.end(), it) == res.end()) res.push_back(it);
-	}
-	return res;
+    vector<T> res;
+    for (const auto& it : a) {
+        if (find(b.begin(), b.end(), it) != b.end() && find(res.begin(), res.end(), it) == res.end()) res.push_back(it);
+    }
+    return res;
 }
 
 int main() {
-	auto a = vector<int>{1, 2, 3};
-	auto b = vector<int>{3, 4};
-	std::cout << (_fmtVec(_union(a, b))) << std::endl;
-	std::cout << (_fmtVec(_except(a, b))) << std::endl;
-	std::cout << (_fmtVec(_intersect(a, b))) << std::endl;
-	std::cout << (_fmtVec(_union(vector<int>{1, 2}, vector<int>{2, 3}))) << std::endl;
-	return 0;
+    // let a = [1, 2, 3]
+    auto a = vector<int>{1, 2, 3};
+    // let b = [3, 4]
+    auto b = vector<int>{3, 4};
+    // print(a union b)
+    std::cout << (_fmtVec(_union(a, b))) << std::endl;
+    // print(a except b)
+    std::cout << (_fmtVec(_except(a, b))) << std::endl;
+    // print(a intersect b)
+    std::cout << (_fmtVec(_intersect(a, b))) << std::endl;
+    // print([1, 2] union [2, 3])
+    std::cout << (_fmtVec(_union(vector<int>{1, 2}, vector<int>{2, 3}))) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/string_concat.cpp.out
+++ b/tests/compiler/cpp/string_concat.cpp.out
@@ -1,7 +1,12 @@
+// Original Mochi source:
+// print("hello " + "world")
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (string("hello ") + string("world")) << std::endl;
-	return 0;
+    // print("hello " + "world")
+    std::cout << (string("hello ") + string("world")) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/string_for_loop.cpp.out
+++ b/tests/compiler/cpp/string_for_loop.cpp.out
@@ -1,9 +1,17 @@
+// Original Mochi source:
+// for ch in "cat" {
+//   print(ch)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	for (char ch : string("cat")) {
-		std::cout << (ch) << std::endl;
-	}
-	return 0;
+    // for ch in "cat" {
+    for (char ch : string("cat")) {
+        //   print(ch)
+        std::cout << (ch) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/cpp/string_index.cpp.out
+++ b/tests/compiler/cpp/string_index.cpp.out
@@ -1,15 +1,22 @@
+// Original Mochi source:
+// let text = "hello"
+// print(text[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 string _indexString(const string& s, int i) {
-	int n = s.size();
-	if (i < 0) i += n;
-	if (i < 0 || i >= n) throw std::out_of_range("index out of range");
-	return string(1, s[i]);
+    int n = s.size();
+    if (i < 0) i += n;
+    if (i < 0 || i >= n) throw std::out_of_range("index out of range");
+    return string(1, s[i]);
 }
 
 int main() {
-	auto text = string("hello");
-	std::cout << (_indexString(text, 1)) << std::endl;
-	return 0;
+    // let text = "hello"
+    auto text = string("hello");
+    // print(text[1])
+    std::cout << (_indexString(text, 1)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/string_negative_index.cpp.out
+++ b/tests/compiler/cpp/string_negative_index.cpp.out
@@ -1,15 +1,22 @@
+// Original Mochi source:
+// let text = "hello"
+// print(text[-1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 string _indexString(const string& s, int i) {
-	int n = s.size();
-	if (i < 0) i += n;
-	if (i < 0 || i >= n) throw std::out_of_range("index out of range");
-	return string(1, s[i]);
+    int n = s.size();
+    if (i < 0) i += n;
+    if (i < 0 || i >= n) throw std::out_of_range("index out of range");
+    return string(1, s[i]);
 }
 
 int main() {
-	auto text = string("hello");
-	std::cout << (_indexString(text, -1)) << std::endl;
-	return 0;
+    // let text = "hello"
+    auto text = string("hello");
+    // print(text[-1])
+    std::cout << (_indexString(text, -1)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/string_slice.cpp.out
+++ b/tests/compiler/cpp/string_slice.cpp.out
@@ -1,17 +1,22 @@
+// Original Mochi source:
+// print("hello"[1:4])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 string _sliceString(const string& s, int start, int end) {
-	int n = s.size();
-	if (start < 0) start += n;
-	if (end < 0) end += n;
-	if (start < 0) start = 0;
-	if (end > n) end = n;
-	if (end < start) end = start;
-	return s.substr(start, end - start);
+    int n = s.size();
+    if (start < 0) start += n;
+    if (end < 0) end += n;
+    if (start < 0) start = 0;
+    if (end > n) end = n;
+    if (end < start) end = start;
+    return s.substr(start, end - start);
 }
 
 int main() {
-	std::cout << (_sliceString(string("hello"), 1, 4)) << std::endl;
-	return 0;
+    // print("hello"[1:4])
+    std::cout << (_sliceString(string("hello"), 1, 4)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/tpch_q1.cpp.out
+++ b/tests/compiler/cpp/tpch_q1.cpp.out
@@ -1,145 +1,220 @@
+// Original Mochi source:
+// let lineitem = [
+//   {
+//     l_quantity: 17,
+//     l_extendedprice: 1000.0,
+//     l_discount: 0.05,
+//     l_tax: 0.07,
+//     l_returnflag: "N",
+//     l_linestatus: "O",
+//     l_shipdate: "1998-08-01"
+//   },
+//   {
+//     l_quantity: 36,
+//     l_extendedprice: 2000.0,
+//     l_discount: 0.10,
+//     l_tax: 0.05,
+//     l_returnflag: "N",
+//     l_linestatus: "O",
+//     l_shipdate: "1998-09-01"
+//   },
+//   {
+//     l_quantity: 25,
+//     l_extendedprice: 1500.0,
+//     l_discount: 0.00,
+//     l_tax: 0.08,
+//     l_returnflag: "R",
+//     l_linestatus: "F",
+//     l_shipdate: "1998-09-03"  // excluded
+//   }
+// ]
+// 
+// let result =
+//   from row in lineitem
+//   where row.l_shipdate <= "1998-09-02"
+//   group by {
+//     returnflag: row.l_returnflag,
+//     linestatus: row.l_linestatus
+//   } into g
+//   select {
+//     returnflag: g.key.returnflag,
+//     linestatus: g.key.linestatus,
+//     sum_qty: sum(from x in g select x.l_quantity),
+//     sum_base_price: sum(from x in g select x.l_extendedprice),
+//     sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+//     sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+//     avg_qty: avg(from x in g select x.l_quantity),
+//     avg_price: avg(from x in g select x.l_extendedprice),
+//     avg_disc: avg(from x in g select x.l_discount),
+//     count_order: count(g)
+//   }
+// 
+// json(result)
+// 
+// test "Q1 aggregates revenue and quantity by returnflag + linestatus" {
+//   expect result == [
+//     {
+//       returnflag: "N",
+//       linestatus: "O",
+//       sum_qty: 53,
+//       sum_base_price: 3000,
+//       sum_disc_price: 950.0 + 1800.0,               // 2750.0
+//       sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
+//       avg_qty: 26.5,
+//       avg_price: 1500,
+//       avg_disc: 0.07500000000000001,
+//       count_order: 2
+//     }
+//   ]
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 template<typename T> auto _count(const T& v) -> decltype(v.size(), int{}) {
-	return (int)v.size();
+    return (int)v.size();
 }
 template<typename T> auto _count(const T& v) -> decltype(v.Items, int{}) {
-	return (int)v.Items.size();
+    return (int)v.Items.size();
 }
 
 template<typename T> auto _sum(const T& v) -> decltype(v.size(), double{}) {
-	double _s = 0;
-	for (const auto& it : v) _s += it;
-	return _s;
+    double _s = 0;
+    for (const auto& it : v) _s += it;
+    return _s;
 }
 template<typename T> auto _sum(const T& v) -> decltype(v.Items, double{}) {
-	return _sum(v.Items);
+    return _sum(v.Items);
 }
 
 template<typename T> auto _avg(const T& v) -> decltype(v.size(), double{}) {
-	if (v.size() == 0) return 0;
-	double sum = 0;
-	for (const auto& it : v) sum += it;
-	return sum / v.size();
+    if (v.size() == 0) return 0;
+    double sum = 0;
+    for (const auto& it : v) sum += it;
+    return sum / v.size();
 }
 template<typename T> auto _avg(const T& v) -> decltype(v.Items, double{}) {
-	return _avg(v.Items);
+    return _avg(v.Items);
 }
 
 static string _escape_json(const string& s) {
-	string out;
-	for (char c : s) {
-		if (c == '"' || c == '\\') out += '\\';
-		out += c;
-	}
-	return out;
+    string out;
+    for (char c : s) {
+        if (c == '"' || c == '\\') out += '\\';
+        out += c;
+    }
+    return out;
 }
 template<typename T> string _to_json(const T& v);
 inline string _to_json(const string& s) {
-	string out = "\"";
-	out += _escape_json(s);
-	out += "\"";
-	return out;
+    string out = "\"";
+    out += _escape_json(s);
+    out += "\"";
+    return out;
 }
 inline string _to_json(const char* s) { return _to_json(string(s)); }
 inline string _to_json(int v) { return to_string(v); }
 inline string _to_json(double v) { stringstream ss; ss << v; return ss.str(); }
 inline string _to_json(bool v) { return v ? "true" : "false"; }
 inline string _to_json(const any& v) {
-	if (v.type() == typeid(int)) return _to_json(any_cast<int>(v));
-	if (v.type() == typeid(double)) return _to_json(any_cast<double>(v));
-	if (v.type() == typeid(bool)) return _to_json(any_cast<bool>(v));
-	if (v.type() == typeid(string)) return _to_json(any_cast<string>(v));
-	return "null";
+    if (v.type() == typeid(int)) return _to_json(any_cast<int>(v));
+    if (v.type() == typeid(double)) return _to_json(any_cast<double>(v));
+    if (v.type() == typeid(bool)) return _to_json(any_cast<bool>(v));
+    if (v.type() == typeid(string)) return _to_json(any_cast<string>(v));
+    return "null";
 }
 template<typename T> string _to_json(const vector<T>& v) {
-	string out = "[";
-	for (size_t i=0;i<v.size();i++) { if (i>0) out += ','; out += _to_json(v[i]); }
-	out += ']';
-	return out;
+    string out = "[";
+    for (size_t i=0;i<v.size();i++) { if (i>0) out += ','; out += _to_json(v[i]); }
+    out += ']';
+    return out;
 }
 template<typename K, typename V> string _to_json(const unordered_map<K,V>& m) {
-	string out = "{"; bool first = true;
-	for (const auto& kv : m) {
-		if (!first) out += ','; first = false;
-		out += _to_json(kv.first); out += ':'; out += _to_json(kv.second);
-	}
-	out += '}';
-	return out;
+    string out = "{"; bool first = true;
+    for (const auto& kv : m) {
+        if (!first) out += ','; first = false;
+        out += _to_json(kv.first); out += ':'; out += _to_json(kv.second);
+    }
+    out += '}';
+    return out;
 }
 template<typename T> string _to_json(const T& v) { stringstream ss; ss << v; return _to_json(ss.str()); }
 template<typename T> void _json(const T& v) { cout << _to_json(v) << endl; }
 
 int main() {
-	auto lineitem = vector<unordered_map<string, int>>{unordered_map<string, any>{{string("l_quantity"), any(17)}, {string("l_extendedprice"), any(1000.0)}, {string("l_discount"), any(0.05)}, {string("l_tax"), any(0.07)}, {string("l_returnflag"), any(string("N"))}, {string("l_linestatus"), any(string("O"))}, {string("l_shipdate"), any(string("1998-08-01"))}}, unordered_map<string, any>{{string("l_quantity"), any(36)}, {string("l_extendedprice"), any(2000.0)}, {string("l_discount"), any(0.1)}, {string("l_tax"), any(0.05)}, {string("l_returnflag"), any(string("N"))}, {string("l_linestatus"), any(string("O"))}, {string("l_shipdate"), any(string("1998-09-01"))}}, unordered_map<string, any>{{string("l_quantity"), any(25)}, {string("l_extendedprice"), any(1500.0)}, {string("l_discount"), any(0.0)}, {string("l_tax"), any(0.08)}, {string("l_returnflag"), any(string("R"))}, {string("l_linestatus"), any(string("F"))}, {string("l_shipdate"), any(string("1998-09-03"))}}};
-	auto result = ([&]() -> vector<unordered_map<string, int>> {
-	using ElemT = unordered_map<string, any>;
-	using KeyT = unordered_map<string, int>;
-	struct Group { KeyT Key; vector<ElemT> Items; };
-	unordered_map<KeyT, Group> groups;
-	vector<KeyT> order;
-	for (auto& row : lineitem) {
-		if (row.l_shipdate <= string("1998-09-02")) {
-			KeyT _k = unordered_map<string, auto>{{string("returnflag"), row.l_returnflag}, {string("linestatus"), row.l_linestatus}};
-			if (!groups.count(_k)) { groups[_k] = Group{_k, {}}; order.push_back(_k); }
-			groups[_k].Items.push_back(row);
-		}
-	}
-	vector<Group*> items;
-	for (auto& _k : order) items.push_back(&groups[_k]);
-	vector<unordered_map<string, int>> _res;
-	for (auto* g : items) {
-		_res.push_back(unordered_map<string, auto>{{string("returnflag"), g.key.returnflag}, {string("linestatus"), g.key.linestatus}, {string("sum_qty"), _sum(([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& x : g) {
-		_res.push_back(x.l_quantity);
-	}
-	return _res;
+    // let lineitem = [
+    auto lineitem = vector<unordered_map<string, int>>{unordered_map<string, any>{{string("l_quantity"), any(17)}, {string("l_extendedprice"), any(1000.0)}, {string("l_discount"), any(0.05)}, {string("l_tax"), any(0.07)}, {string("l_returnflag"), any(string("N"))}, {string("l_linestatus"), any(string("O"))}, {string("l_shipdate"), any(string("1998-08-01"))}}, unordered_map<string, any>{{string("l_quantity"), any(36)}, {string("l_extendedprice"), any(2000.0)}, {string("l_discount"), any(0.1)}, {string("l_tax"), any(0.05)}, {string("l_returnflag"), any(string("N"))}, {string("l_linestatus"), any(string("O"))}, {string("l_shipdate"), any(string("1998-09-01"))}}, unordered_map<string, any>{{string("l_quantity"), any(25)}, {string("l_extendedprice"), any(1500.0)}, {string("l_discount"), any(0.0)}, {string("l_tax"), any(0.08)}, {string("l_returnflag"), any(string("R"))}, {string("l_linestatus"), any(string("F"))}, {string("l_shipdate"), any(string("1998-09-03"))}}};
+    // let result =
+    auto result = ([&]() -> vector<unordered_map<string, int>> {
+    using ElemT = unordered_map<string, any>;
+    using KeyT = unordered_map<string, int>;
+    struct Group { KeyT Key; vector<ElemT> Items; };
+    unordered_map<KeyT, Group> groups;
+    vector<KeyT> order;
+    for (auto& row : lineitem) {
+        if (row.l_shipdate <= string("1998-09-02")) {
+            KeyT _k = unordered_map<string, auto>{{string("returnflag"), row.l_returnflag}, {string("linestatus"), row.l_linestatus}};
+            if (!groups.count(_k)) { groups[_k] = Group{_k, {}}; order.push_back(_k); }
+            groups[_k].Items.push_back(row);
+        }
+    }
+    vector<Group*> items;
+    for (auto& _k : order) items.push_back(&groups[_k]);
+    vector<unordered_map<string, int>> _res;
+    for (auto* g : items) {
+        _res.push_back(unordered_map<string, auto>{{string("returnflag"), g.key.returnflag}, {string("linestatus"), g.key.linestatus}, {string("sum_qty"), _sum(([&]() -> vector<auto> {
+    vector<auto> _res;
+    for (auto& x : g) {
+        _res.push_back(x.l_quantity);
+    }
+    return _res;
 })())}, {string("sum_base_price"), _sum(([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& x : g) {
-		_res.push_back(x.l_extendedprice);
-	}
-	return _res;
+    vector<auto> _res;
+    for (auto& x : g) {
+        _res.push_back(x.l_extendedprice);
+    }
+    return _res;
 })())}, {string("sum_disc_price"), _sum(([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& x : g) {
-		_res.push_back(x.l_extendedprice * (1 - x.l_discount));
-	}
-	return _res;
+    vector<auto> _res;
+    for (auto& x : g) {
+        _res.push_back(x.l_extendedprice * (1 - x.l_discount));
+    }
+    return _res;
 })())}, {string("sum_charge"), _sum(([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& x : g) {
-		_res.push_back(x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax));
-	}
-	return _res;
+    vector<auto> _res;
+    for (auto& x : g) {
+        _res.push_back(x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax));
+    }
+    return _res;
 })())}, {string("avg_qty"), _avg(([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& x : g) {
-		_res.push_back(x.l_quantity);
-	}
-	return _res;
+    vector<auto> _res;
+    for (auto& x : g) {
+        _res.push_back(x.l_quantity);
+    }
+    return _res;
 })())}, {string("avg_price"), _avg(([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& x : g) {
-		_res.push_back(x.l_extendedprice);
-	}
-	return _res;
+    vector<auto> _res;
+    for (auto& x : g) {
+        _res.push_back(x.l_extendedprice);
+    }
+    return _res;
 })())}, {string("avg_disc"), _avg(([&]() -> vector<auto> {
-	vector<auto> _res;
-	for (auto& x : g) {
-		_res.push_back(x.l_discount);
-	}
-	return _res;
+    vector<auto> _res;
+    for (auto& x : g) {
+        _res.push_back(x.l_discount);
+    }
+    return _res;
 })())}, {string("count_order"), _count(g)}});
-	}
-	return _res;
+    }
+    return _res;
 })();
-	_json(result);
-	auto test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus = [&]() {
-		if (!(result == vector<unordered_map<string, string>>{unordered_map<string, any>{{string("returnflag"), any(string("N"))}, {string("linestatus"), any(string("O"))}, {string("sum_qty"), any(53)}, {string("sum_base_price"), any(3000)}, {string("sum_disc_price"), any(950.0 + 1800.0)}, {string("sum_charge"), any((950.0 * 1.07) + (1800.0 * 1.05))}, {string("avg_qty"), any(26.5)}, {string("avg_price"), any(1500)}, {string("avg_disc"), any(0.07500000000000001)}, {string("count_order"), any(2)}}})) { std::cerr << "expect failed\n"; exit(1); }
-	};
-	test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus();
-	return 0;
+    // json(result)
+    _json(result);
+    auto test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus = [&]() {
+        //   expect result == [
+        if (!(result == vector<unordered_map<string, string>>{unordered_map<string, any>{{string("returnflag"), any(string("N"))}, {string("linestatus"), any(string("O"))}, {string("sum_qty"), any(53)}, {string("sum_base_price"), any(3000)}, {string("sum_disc_price"), any(950.0 + 1800.0)}, {string("sum_charge"), any((950.0 * 1.07) + (1800.0 * 1.05))}, {string("avg_qty"), any(26.5)}, {string("avg_price"), any(1500)}, {string("avg_disc"), any(0.07500000000000001)}, {string("count_order"), any(2)}}})) { std::cerr << "expect failed\n"; exit(1); }
+    };
+    test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus();
+    return 0;
 }

--- a/tests/compiler/cpp/two_sum.cpp.out
+++ b/tests/compiler/cpp/two_sum.cpp.out
@@ -1,21 +1,49 @@
+// Original Mochi source:
+// fun twoSum(nums: list<int>, target: int): list<int> {
+//   let n = len(nums)
+//   for i in 0..n {
+//     for j in i+1..n {
+//       if nums[i] + nums[j] == target {
+//         return [i, j]
+//       }
+//     }
+//   }
+//   return [-1, -1]
+// }
+// 
+// let result = twoSum([2,7,11,15], 9)
+// print(result[0])
+// print(result[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun twoSum(nums: list<int>, target: int): list<int> {
 vector<int> twoSum(vector<int> nums, int target){
-	auto n = nums.size();
-	for (int i = 0; i < n; i++) {
-		for (int j = i + 1; j < n; j++) {
-			if (nums[i] + nums[j] == target) {
-				return vector<int>{i, j};
-			}
-		}
-	}
-	return vector<int>{-1, -1};
+    //   let n = len(nums)
+    auto n = nums.size();
+    //   for i in 0..n {
+    for (int i = 0; i < n; i++) {
+        //     for j in i+1..n {
+        for (int j = i + 1; j < n; j++) {
+            //       if nums[i] + nums[j] == target {
+            if (nums[i] + nums[j] == target) {
+                //         return [i, j]
+                return vector<int>{i, j};
+            }
+        }
+    }
+    //   return [-1, -1]
+    return vector<int>{-1, -1};
 }
 
 int main() {
-	auto result = twoSum(vector<int>{2, 7, 11, 15}, 9);
-	std::cout << (result[0]) << std::endl;
-	std::cout << (result[1]) << std::endl;
-	return 0;
+    // let result = twoSum([2,7,11,15], 9)
+    auto result = twoSum(vector<int>{2, 7, 11, 15}, 9);
+    // print(result[0])
+    std::cout << (result[0]) << std::endl;
+    // print(result[1])
+    std::cout << (result[1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/union_inorder.cpp.out
+++ b/tests/compiler/cpp/union_inorder.cpp.out
@@ -1,20 +1,67 @@
+// Original Mochi source:
+// type Tree =
+//   Leaf
+//   | Node(left: Tree, value: int, right: Tree)
+// 
+// fun inorder(t: Tree): list<int> {
+//   return match t {
+//     Leaf => [] as list<int>
+//     Node(l, v, r) => inorder(l) + [v] + inorder(r)
+//   }
+// }
+// 
+// print(inorder(Node { left: Leaf {}, value: 1, right: Node { left: Leaf {}, value: 2, right: Leaf {} } }))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+template<typename T> T _cast(any v);
+template<> inline int _cast<int>(any v) {
+    if (v.type() == typeid(int)) return any_cast<int>(v);
+    if (v.type() == typeid(double)) return int(any_cast<double>(v));
+    if (v.type() == typeid(string)) return stoi(any_cast<string>(v));
+    return 0;
+}
+template<> inline double _cast<double>(any v) {
+    if (v.type() == typeid(double)) return any_cast<double>(v);
+    if (v.type() == typeid(int)) return double(any_cast<int>(v));
+    if (v.type() == typeid(string)) return stod(any_cast<string>(v));
+    return 0.0;
+}
+template<> inline bool _cast<bool>(any v) {
+    if (v.type() == typeid(bool)) return any_cast<bool>(v);
+    if (v.type() == typeid(string)) return any_cast<string>(v)=="true";
+    if (v.type() == typeid(int)) return any_cast<int>(v)!=0;
+    return false;
+}
+template<> inline string _cast<string>(any v) {
+    if (v.type() == typeid(string)) return any_cast<string>(v);
+    if (v.type() == typeid(int)) return to_string(any_cast<int>(v));
+    if (v.type() == typeid(double)) { stringstream ss; ss<<any_cast<double>(v); return ss.str(); }
+    if (v.type() == typeid(bool)) return any_cast<bool>(v)?"true":"false";
+    return "";
+}
+
+// type Tree =
 struct Leaf {
 };
 struct Node {
-	Tree left;
-	int value;
-	Tree right;
+    Tree left;
+    int value;
+    Tree right;
 };
 using Tree = std::variant<Leaf, Node>;
 
+// fun inorder(t: Tree): list<int> {
 vector<int> inorder(Tree t){
-	return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return vector<int>{}; if (std::holds_alternative<Node>(_t0)) { auto _v = std::get<Node>(_t0); auto l = _v.left; auto v = _v.value; auto r = _v.right; return ([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(inorder(l), vector<int>{v}), inorder(r)); }return {}; })();
+    //   return match t {
+    return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return _cast<vector<int>>(vector<int>{}); if (std::holds_alternative<Node>(_t0)) { auto _v = std::get<Node>(_t0); auto l = _v.left; auto v = _v.value; auto r = _v.right; return ([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(inorder(l), vector<int>{v}), inorder(r)); }return {}; })();
 }
 
 int main() {
-	std::cout << (inorder(Node{Leaf{}, 1, Node{Leaf{}, 2, Leaf{}}})) << std::endl;
-	return 0;
+    // type Tree =
+    // print(inorder(Node { left: Leaf {}, value: 1, right: Node { left: Leaf {}, value: 2, right: Leaf {} } }))
+    std::cout << (inorder(Node{Leaf{}, 1, Node{Leaf{}, 2, Leaf{}}})) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/var_assignment.cpp.out
+++ b/tests/compiler/cpp/var_assignment.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// var x = 1
+// x = 2
+// print(x)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto x = 1;
-	x = 2;
-	std::cout << (x) << std::endl;
-	return 0;
+    // var x = 1
+    auto x = 1;
+    // x = 2
+    x = 2;
+    // print(x)
+    std::cout << (x) << std::endl;
+    return 0;
 }

--- a/tests/compiler/cpp/while_loop.cpp.out
+++ b/tests/compiler/cpp/while_loop.cpp.out
@@ -1,11 +1,23 @@
+// Original Mochi source:
+// var i = 0
+// while i < 3 {
+//   print(i)
+//   i = i + 1
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto i = 0;
-	while (i < 3) {
-		std::cout << (i) << std::endl;
-		i = i + 1;
-	}
-	return 0;
+    // var i = 0
+    auto i = 0;
+    // while i < 3 {
+    while (i < 3) {
+        //   print(i)
+        std::cout << (i) << std::endl;
+        //   i = i + 1
+        i = i + 1;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/break_continue.cpp.out
+++ b/tests/compiler/valid/break_continue.cpp.out
@@ -1,16 +1,37 @@
+// Original Mochi source:
+// let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+// 
+// for n in numbers {
+//   if n % 2 == 0 {
+//     continue
+//   }
+//   if n > 7 {
+//     break
+//   }
+//   print("odd number:", n)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto numbers = vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
-	for (int n : numbers) {
-		if (n % 2 == 0) {
-			continue;
-		}
-		if (n > 7) {
-			break;
-		}
-		std::cout << (string("odd number:")) << " " << (n) << std::endl;
-	}
-	return 0;
+    // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    auto numbers = vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    // for n in numbers {
+    for (int n : numbers) {
+        //   if n % 2 == 0 {
+        if (n % 2 == 0) {
+            //     continue
+            continue;
+        }
+        //   if n > 7 {
+        if (n > 7) {
+            //     break
+            break;
+        }
+        //   print("odd number:", n)
+        std::cout << (string("odd number:")) << " " << (n) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/closure.cpp.out
+++ b/tests/compiler/valid/closure.cpp.out
@@ -1,12 +1,25 @@
+// Original Mochi source:
+// fun makeAdder(n: int): fun(int): int {
+//   return fun(x: int): int => x + n
+// }
+// 
+// let add10 = makeAdder(10)
+// print(add10(7))  // 17
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun makeAdder(n: int): fun(int): int {
 auto makeAdder(int n){
-	return [=](int x) { return x + n; };
+    //   return fun(x: int): int => x + n
+    return [=](int x) { return x + n; };
 }
 
 int main() {
-	auto add10 = makeAdder(10);
-	std::cout << (add10(7)) << std::endl;
-	return 0;
+    // let add10 = makeAdder(10)
+    auto add10 = makeAdder(10);
+    // print(add10(7))  // 17
+    std::cout << (add10(7)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/cross_join.cpp.out
+++ b/tests/compiler/valid/cross_join.cpp.out
@@ -1,39 +1,98 @@
+// Original Mochi source:
+// // cross_join.mochi
+// type Customer {
+//   id: int
+//   name: string
+// }
+// 
+// type Order {
+//   id: int
+//   customerId: int
+//   total: int
+// }
+// 
+// type PairInfo {
+//   orderId: int
+//   orderCustomerId: int
+//   pairedCustomerName: string
+//   orderTotal: int
+// }
+// 
+// let customers = [
+//   Customer { id: 1, name: "Alice" },
+//   Customer { id: 2, name: "Bob" },
+//   Customer { id: 3, name: "Charlie" }
+// ]
+// let orders = [
+//   Order { id: 100, customerId: 1, total: 250 },
+//   Order { id: 101, customerId: 2, total: 125 },
+//   Order { id: 102, customerId: 1, total: 300 }
+// ]
+// let result = from o in orders
+//              from c in customers
+//              select PairInfo {
+//                orderId: o.id,
+//                orderCustomerId: o.customerId,
+//                pairedCustomerName: c.name,
+//                orderTotal: o.total
+//              }
+// print("--- Cross Join: All order-customer pairs ---")
+// for entry in result {
+//   print("Order", entry.orderId,
+//         "(customerId:", entry.orderCustomerId,
+//         ", total: $", entry.orderTotal,
+//         ") paired with", entry.pairedCustomerName)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Customer {
 struct Customer {
-	int id;
-	string name;
+    int id;
+    string name;
 };
 
+// type Order {
 struct Order {
-	int id;
-	int customerId;
-	int total;
+    int id;
+    int customerId;
+    int total;
 };
 
+// type PairInfo {
 struct PairInfo {
-	int orderId;
-	int orderCustomerId;
-	string pairedCustomerName;
-	int orderTotal;
+    int orderId;
+    int orderCustomerId;
+    string pairedCustomerName;
+    int orderTotal;
 };
 
 int main() {
-	auto customers = vector<Customer>{Customer{1, string("Alice")}, Customer{2, string("Bob")}, Customer{3, string("Charlie")}};
-	auto orders = vector<Order>{Order{100, 1, 250}, Order{101, 2, 125}, Order{102, 1, 300}};
-	auto result = ([&]() -> vector<PairInfo> {
-	vector<PairInfo> _res;
-	for (auto& o : orders) {
-		for (auto& c : customers) {
-			_res.push_back(PairInfo{o.id, o.customerId, c.name, o.total});
-		}
-	}
-	return _res;
+    // type Customer {
+    // type Order {
+    // type PairInfo {
+    // let customers = [
+    auto customers = vector<Customer>{Customer{1, string("Alice")}, Customer{2, string("Bob")}, Customer{3, string("Charlie")}};
+    // let orders = [
+    auto orders = vector<Order>{Order{100, 1, 250}, Order{101, 2, 125}, Order{102, 1, 300}};
+    // let result = from o in orders
+    auto result = ([&]() -> vector<PairInfo> {
+    vector<PairInfo> _res;
+    for (auto& o : orders) {
+        for (auto& c : customers) {
+            _res.push_back(PairInfo{o.id, o.customerId, c.name, o.total});
+        }
+    }
+    return _res;
 })();
-	std::cout << (string("--- Cross Join: All order-customer pairs ---")) << std::endl;
-	for (const PairInfo& entry : result) {
-		std::cout << (string("Order")) << " " << (entry.orderId) << " " << (string("(customerId:")) << " " << (entry.orderCustomerId) << " " << (string(", total: $")) << " " << (entry.orderTotal) << " " << (string(") paired with")) << " " << (entry.pairedCustomerName) << std::endl;
-	}
-	return 0;
+    // print("--- Cross Join: All order-customer pairs ---")
+    std::cout << (string("--- Cross Join: All order-customer pairs ---")) << std::endl;
+    // for entry in result {
+    for (const PairInfo& entry : result) {
+        //   print("Order", entry.orderId,
+        std::cout << (string("Order")) << " " << (entry.orderId) << " " << (string("(customerId:")) << " " << (entry.orderCustomerId) << " " << (string(", total: $")) << " " << (entry.orderTotal) << " " << (string(") paired with")) << " " << (entry.pairedCustomerName) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/fold_pure_let.cpp.out
+++ b/tests/compiler/valid/fold_pure_let.cpp.out
@@ -1,13 +1,28 @@
+// Original Mochi source:
+// fun sumN(n: int): int {
+//   return n * (n + 1) / 2
+// }
+// 
+// let n = 10
+// print(sumN(n))
+// print(n)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun sumN(n: int): int {
 int sumN(int n){
-	return n * (n + 1) / 2;
+    //   return n * (n + 1) / 2
+    return n * (n + 1) / 2;
 }
 
 int main() {
-	auto n = 10;
-	std::cout << (sumN(n)) << std::endl;
-	std::cout << (n) << std::endl;
-	return 0;
+    // let n = 10
+    auto n = 10;
+    // print(sumN(n))
+    std::cout << (sumN(n)) << std::endl;
+    // print(n)
+    std::cout << (n) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/for_list_collection.cpp.out
+++ b/tests/compiler/valid/for_list_collection.cpp.out
@@ -1,9 +1,17 @@
+// Original Mochi source:
+// for n in [1,2,3] {
+//   print(n)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	for (int n : vector<int>{1, 2, 3}) {
-		std::cout << (n) << std::endl;
-	}
-	return 0;
+    // for n in [1,2,3] {
+    for (int n : vector<int>{1, 2, 3}) {
+        //   print(n)
+        std::cout << (n) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/for_loop.cpp.out
+++ b/tests/compiler/valid/for_loop.cpp.out
@@ -1,9 +1,17 @@
+// Original Mochi source:
+// for i in 1..4 {
+//   print(i)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	for (int i = 1; i < 4; i++) {
-		std::cout << (i) << std::endl;
-	}
-	return 0;
+    // for i in 1..4 {
+    for (int i = 1; i < 4; i++) {
+        //   print(i)
+        std::cout << (i) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/for_string_collection.cpp.out
+++ b/tests/compiler/valid/for_string_collection.cpp.out
@@ -1,9 +1,17 @@
+// Original Mochi source:
+// for ch in "hi" {
+//   print(ch)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	for (char ch : string("hi")) {
-		std::cout << (ch) << std::endl;
-	}
-	return 0;
+    // for ch in "hi" {
+    for (char ch : string("hi")) {
+        //   print(ch)
+        std::cout << (ch) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/fun_call.cpp.out
+++ b/tests/compiler/valid/fun_call.cpp.out
@@ -1,11 +1,22 @@
+// Original Mochi source:
+// fun add(a: int, b: int): int {
+//   return a + b
+// }
+// 
+// print(add(2, 3))  // 5
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun add(a: int, b: int): int {
 int add(int a, int b){
-	return a + b;
+    //   return a + b
+    return a + b;
 }
 
 int main() {
-	std::cout << (add(2, 3)) << std::endl;
-	return 0;
+    // print(add(2, 3))  // 5
+    std::cout << (add(2, 3)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/fun_expr_in_let.cpp.out
+++ b/tests/compiler/valid/fun_expr_in_let.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// let square = fun(x: int): int => x * x
+// print(square(6))  // 36
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto square = [=](int x) { return x * x; };
-	std::cout << (square(6)) << std::endl;
-	return 0;
+    // let square = fun(x: int): int => x * x
+    auto square = [=](int x) { return x * x; };
+    // print(square(6))  // 36
+    std::cout << (square(6)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/generate_echo.cpp.out
+++ b/tests/compiler/valid/generate_echo.cpp.out
@@ -1,8 +1,17 @@
+// Original Mochi source:
+// let poem = generate text {
+//   prompt: "echo hello"
+// }
+// print(poem)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto poem;
-	std::cout << (poem) << std::endl;
-	return 0;
+    // let poem = generate text {
+    auto poem;
+    // print(poem)
+    std::cout << (poem) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/generate_embedding.cpp.out
+++ b/tests/compiler/valid/generate_embedding.cpp.out
@@ -1,8 +1,17 @@
+// Original Mochi source:
+// let vec = generate embedding {
+//   text: "hi"
+// }
+// print(len(vec))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto vec;
-	std::cout << (vec.size()) << std::endl;
-	return 0;
+    // let vec = generate embedding {
+    auto vec;
+    // print(len(vec))
+    std::cout << (vec.size()) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/grouped_expr.cpp.out
+++ b/tests/compiler/valid/grouped_expr.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// let value = (1 + 2) * 3
+// print(value)  // 9
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto value = (1 + 2) * 3;
-	std::cout << (value) << std::endl;
-	return 0;
+    // let value = (1 + 2) * 3
+    auto value = (1 + 2) * 3;
+    // print(value)  // 9
+    std::cout << (value) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/if_else.cpp.out
+++ b/tests/compiler/valid/if_else.cpp.out
@@ -1,12 +1,26 @@
+// Original Mochi source:
+// let x = 5
+// 
+// if x > 3 {
+//   print("big")
+// } else {
+//   print("small")
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto x = 5;
-	if (x > 3) {
-		std::cout << (string("big")) << std::endl;
-	} else {
-		std::cout << (string("small")) << std::endl;
-	}
-	return 0;
+    // let x = 5
+    auto x = 5;
+    // if x > 3 {
+    if (x > 3) {
+        //   print("big")
+        std::cout << (string("big")) << std::endl;
+    } else {
+        //   print("small")
+        std::cout << (string("small")) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/join.cpp.out
+++ b/tests/compiler/valid/join.cpp.out
@@ -1,39 +1,96 @@
+// Original Mochi source:
+// type Customer {
+//   id: int
+//   name: string
+// }
+// 
+// type Order {
+//   id: int
+//   customerId: int
+//   total: int
+// }
+// 
+// type PairInfo {
+//   orderId: int
+//   customerName: string
+//   total: int
+// }
+// 
+// let customers = [
+//   Customer { id: 1, name: "Alice" },
+//   Customer { id: 2, name: "Bob" },
+//   Customer { id: 3, name: "Charlie" }
+// ]
+// 
+// let orders = [
+//   Order { id: 100, customerId: 1, total: 250 },
+//   Order { id: 101, customerId: 2, total: 125 },
+//   Order { id: 102, customerId: 1, total: 300 },
+//   Order { id: 103, customerId: 4, total: 80 }
+// ]
+// 
+// let result = from o in orders
+//              join from c in customers on o.customerId == c.id
+//              select PairInfo {
+//                orderId: o.id,
+//                customerName: c.name,
+//                total: o.total
+//              }
+// 
+// print("--- Orders with customer info ---")
+// for entry in result {
+//   print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Customer {
 struct Customer {
-	int id;
-	string name;
+    int id;
+    string name;
 };
 
+// type Order {
 struct Order {
-	int id;
-	int customerId;
-	int total;
+    int id;
+    int customerId;
+    int total;
 };
 
+// type PairInfo {
 struct PairInfo {
-	int orderId;
-	string customerName;
-	int total;
+    int orderId;
+    string customerName;
+    int total;
 };
 
 int main() {
-	auto customers = vector<Customer>{Customer{1, string("Alice")}, Customer{2, string("Bob")}, Customer{3, string("Charlie")}};
-	auto orders = vector<Order>{Order{100, 1, 250}, Order{101, 2, 125}, Order{102, 1, 300}, Order{103, 4, 80}};
-	auto result = ([&]() -> vector<PairInfo> {
-	vector<PairInfo> _res;
-	for (auto& o : orders) {
-		for (auto& c : customers) {
-			if (!(o.customerId == c.id)) continue;
-			_res.push_back(PairInfo{o.id, c.name, o.total});
-		}
-	}
-	return _res;
+    // type Customer {
+    // type Order {
+    // type PairInfo {
+    // let customers = [
+    auto customers = vector<Customer>{Customer{1, string("Alice")}, Customer{2, string("Bob")}, Customer{3, string("Charlie")}};
+    // let orders = [
+    auto orders = vector<Order>{Order{100, 1, 250}, Order{101, 2, 125}, Order{102, 1, 300}, Order{103, 4, 80}};
+    // let result = from o in orders
+    auto result = ([&]() -> vector<PairInfo> {
+    vector<PairInfo> _res;
+    for (auto& o : orders) {
+        for (auto& c : customers) {
+            if (!(o.customerId == c.id)) continue;
+            _res.push_back(PairInfo{o.id, c.name, o.total});
+        }
+    }
+    return _res;
 })();
-	std::cout << (string("--- Orders with customer info ---")) << std::endl;
-	for (const PairInfo& entry : result) {
-		std::cout << (string("Order")) << " " << (entry.orderId) << " " << (string("by")) << " " << (entry.customerName) << " " << (string("- $")) << " " << (entry.total) << std::endl;
-	}
-	return 0;
+    // print("--- Orders with customer info ---")
+    std::cout << (string("--- Orders with customer info ---")) << std::endl;
+    // for entry in result {
+    for (const PairInfo& entry : result) {
+        //   print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+        std::cout << (string("Order")) << " " << (entry.orderId) << " " << (string("by")) << " " << (entry.customerName) << " " << (string("- $")) << " " << (entry.total) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/join_filter_pag.cpp.out
+++ b/tests/compiler/valid/join_filter_pag.cpp.out
@@ -1,42 +1,78 @@
+// Original Mochi source:
+// type Person { id: int, name: string }
+// type Purchase { id: int, personId: int, total: int }
+// let people = [
+//   Person { id: 1, name: "Alice" },
+//   Person { id: 2, name: "Bob" },
+//   Person { id: 3, name: "Charlie" }
+// ]
+// let purchases = [
+//   Purchase { id: 1, personId: 1, total: 200 },
+//   Purchase { id: 2, personId: 1, total: 50 },
+//   Purchase { id: 3, personId: 2, total: 150 },
+//   Purchase { id: 4, personId: 3, total: 100 },
+//   Purchase { id: 5, personId: 2, total: 250 }
+// ]
+// let result = from p in people
+//              join o in purchases on p.id == o.personId
+//              where o.total > 100
+//              sort by -o.total
+//              skip 1
+//              take 2
+//              select { person: p.name, spent: o.total }
+// for r in result {
+//   print(r.person, r.spent)
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Person { id: int, name: string }
 struct Person {
-	int id;
-	string name;
+    int id;
+    string name;
 };
 
+// type Purchase { id: int, personId: int, total: int }
 struct Purchase {
-	int id;
-	int personId;
-	int total;
+    int id;
+    int personId;
+    int total;
 };
 
 int main() {
-	auto people = vector<Person>{Person{1, string("Alice")}, Person{2, string("Bob")}, Person{3, string("Charlie")}};
-	auto purchases = vector<Purchase>{Purchase{1, 1, 200}, Purchase{2, 1, 50}, Purchase{3, 2, 150}, Purchase{4, 3, 100}, Purchase{5, 2, 250}};
-	auto result = ([&]() -> vector<unordered_map<string, int>> {
-	vector<pair<unordered_map<string, int>, unordered_map<string, int>>> _tmp;
-	for (auto& p : people) {
-		for (auto& o : purchases) {
-			if (!(p.id == o.personId)) continue;
-			if (o.total > 100) {
-				_tmp.push_back({-o.total, unordered_map<string, auto>{{string("person"), p.name}, {string("spent"), o.total}}});
-			}
-		}
-	}
-	std::sort(_tmp.begin(), _tmp.end(), [](const auto& a, const auto& b){ return a.first < b.first; });
-	vector<unordered_map<string, int>> _res;
-	_res.reserve(_tmp.size());
-	for (auto& _it : _tmp) _res.push_back(_it.second);
-	int _skip = 1;
-	if (_skip < (int)_res.size()) _res.erase(_res.begin(), _res.begin() + _skip); else _res.clear();
-	int _take = 2;
-	if (_take < (int)_res.size()) _res.resize(_take);
-	return _res;
+    // type Person { id: int, name: string }
+    // type Purchase { id: int, personId: int, total: int }
+    // let people = [
+    auto people = vector<Person>{Person{1, string("Alice")}, Person{2, string("Bob")}, Person{3, string("Charlie")}};
+    // let purchases = [
+    auto purchases = vector<Purchase>{Purchase{1, 1, 200}, Purchase{2, 1, 50}, Purchase{3, 2, 150}, Purchase{4, 3, 100}, Purchase{5, 2, 250}};
+    // let result = from p in people
+    auto result = ([&]() -> vector<unordered_map<string, int>> {
+    vector<pair<unordered_map<string, int>, unordered_map<string, int>>> _tmp;
+    for (auto& p : people) {
+        for (auto& o : purchases) {
+            if (!(p.id == o.personId)) continue;
+            if (o.total > 100) {
+                _tmp.push_back({-o.total, unordered_map<string, auto>{{string("person"), p.name}, {string("spent"), o.total}}});
+            }
+        }
+    }
+    std::sort(_tmp.begin(), _tmp.end(), [](const auto& a, const auto& b){ return a.first < b.first; });
+    vector<unordered_map<string, int>> _res;
+    _res.reserve(_tmp.size());
+    for (auto& _it : _tmp) _res.push_back(_it.second);
+    int _skip = 1;
+    if (_skip < (int)_res.size()) _res.erase(_res.begin(), _res.begin() + _skip); else _res.clear();
+    int _take = 2;
+    if (_take < (int)_res.size()) _res.resize(_take);
+    return _res;
 })();
-	for (const unordered_map<string, any>& r : result) {
-		std::cout << (r["person"]) << " " << (r["spent"]) << std::endl;
-	}
-	return 0;
+    // for r in result {
+    for (const unordered_map<string, any>& r : result) {
+        //   print(r.person, r.spent)
+        std::cout << (r["person"]) << " " << (r["spent"]) << std::endl;
+    }
+    return 0;
 }

--- a/tests/compiler/valid/len_builtin.cpp.out
+++ b/tests/compiler/valid/len_builtin.cpp.out
@@ -1,7 +1,12 @@
+// Original Mochi source:
+// print(len([1,2,3]))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (vector<int>{1, 2, 3}.size()) << std::endl;
-	return 0;
+    // print(len([1,2,3]))
+    std::cout << (vector<int>{1, 2, 3}.size()) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/let_and_print.cpp.out
+++ b/tests/compiler/valid/let_and_print.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// let a = 10
+// let b: int = 20
+// print(a + b)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto a = 10;
-	int b = 20;
-	std::cout << (a + b) << std::endl;
-	return 0;
+    // let a = 10
+    auto a = 10;
+    // let b: int = 20
+    int b = 20;
+    // print(a + b)
+    std::cout << (a + b) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/list_index.cpp.out
+++ b/tests/compiler/valid/list_index.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// let xs = [10, 20, 30]
+// print(xs[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto xs = vector<int>{10, 20, 30};
-	std::cout << (xs[1]) << std::endl;
-	return 0;
+    // let xs = [10, 20, 30]
+    auto xs = vector<int>{10, 20, 30};
+    // print(xs[1])
+    std::cout << (xs[1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/list_set.cpp.out
+++ b/tests/compiler/valid/list_set.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// var nums = [1, 2]
+// nums[1] = 3
+// print(nums[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto nums = vector<int>{1, 2};
-	nums[1] = 3;
-	std::cout << (nums[1]) << std::endl;
-	return 0;
+    // var nums = [1, 2]
+    auto nums = vector<int>{1, 2};
+    // nums[1] = 3
+    nums[1] = 3;
+    // print(nums[1])
+    std::cout << (nums[1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/local_recursion.cpp.out
+++ b/tests/compiler/valid/local_recursion.cpp.out
@@ -1,24 +1,62 @@
+// Original Mochi source:
+// // Build BST from sorted list using nested recursive function
+// 
+//  type Tree =
+//    Leaf
+//    | Node(left: Tree, value: int, right: Tree)
+// 
+//  fun fromList(nums: list<int>): Tree {
+//    fun helper(lo: int, hi: int): Tree {
+//      if lo >= hi { return Leaf {} }
+//      let mid = (lo + hi) / 2
+//      return Node {
+//        left: helper(lo, mid),
+//        value: nums[mid],
+//        right: helper(mid + 1, hi)
+//      }
+//    }
+//    return helper(0, len(nums))
+//  }
+// 
+//  fun inorder(t: Tree): list<int> {
+//    return match t {
+//      Leaf => []
+//      Node(l, v, r) => inorder(l) + [v] + inorder(r)
+//    }
+//  }
+// 
+//  print(inorder(fromList([-10, -3, 0, 5, 9])))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+//  type Tree =
 struct Leaf {
 };
 struct Node {
-	Tree left;
-	int value;
-	Tree right;
+    Tree left;
+    int value;
+    Tree right;
 };
 using Tree = std::variant<Leaf, Node>;
 
+//  fun fromList(nums: list<int>): Tree {
 Tree fromList(vector<int> nums){
-	return helper(0, nums.size());
+    //    fun helper(lo: int, hi: int): Tree {
+    //    return helper(0, len(nums))
+    return helper(0, nums.size());
 }
 
+//  fun inorder(t: Tree): list<int> {
 vector<int> inorder(Tree t){
-	return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return vector<int>{}; if (std::holds_alternative<Node>(_t0)) { auto _v = std::get<Node>(_t0); auto l = _v.left; auto v = _v.value; auto r = _v.right; return ([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(inorder(l), vector<int>{v}), inorder(r)); }return {}; })();
+    //    return match t {
+    return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return vector<int>{}; if (std::holds_alternative<Node>(_t0)) { auto _v = std::get<Node>(_t0); auto l = _v.left; auto v = _v.value; auto r = _v.right; return ([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(inorder(l), vector<int>{v}), inorder(r)); }return {}; })();
 }
 
 int main() {
-	std::cout << (inorder(fromList(vector<int>{-10, -3, 0, 5, 9}))) << std::endl;
-	return 0;
+    //  type Tree =
+    //  print(inorder(fromList([-10, -3, 0, 5, 9])))
+    std::cout << (inorder(fromList(vector<int>{-10, -3, 0, 5, 9}))) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/map_index.cpp.out
+++ b/tests/compiler/valid/map_index.cpp.out
@@ -1,8 +1,15 @@
+// Original Mochi source:
+// let scores = {"Alice": 10, "Bob": 15}
+// print(scores["Bob"])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto scores = unordered_map<string, int>{{string("Alice"), 10}, {string("Bob"), 15}};
-	std::cout << (scores[string("Bob")]) << std::endl;
-	return 0;
+    // let scores = {"Alice": 10, "Bob": 15}
+    auto scores = unordered_map<string, int>{{string("Alice"), 10}, {string("Bob"), 15}};
+    // print(scores["Bob"])
+    std::cout << (scores[string("Bob")]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/map_iterate.cpp.out
+++ b/tests/compiler/valid/map_iterate.cpp.out
@@ -1,15 +1,33 @@
+// Original Mochi source:
+// var m: map<int, bool> = {}
+// m[1] = true
+// m[2] = true
+// var sum = 0
+// for k in m {
+//   sum = sum + k
+// }
+// print(sum)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	unordered_map<int, bool> m = unordered_map<int, bool>{};
-	m[1] = true;
-	m[2] = true;
-	auto sum = 0;
-	for (const auto& _kv : m) {
-		int k = _kv.first;
-		sum = sum + k;
-	}
-	std::cout << (sum) << std::endl;
-	return 0;
+    // var m: map<int, bool> = {}
+    unordered_map<int, bool> m = unordered_map<int, bool>{};
+    // m[1] = true
+    m[1] = true;
+    // m[2] = true
+    m[2] = true;
+    // var sum = 0
+    auto sum = 0;
+    // for k in m {
+    for (const auto& _kv : m) {
+        int k = _kv.first;
+        //   sum = sum + k
+        sum = sum + k;
+    }
+    // print(sum)
+    std::cout << (sum) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/map_ops.cpp.out
+++ b/tests/compiler/valid/map_ops.cpp.out
@@ -1,14 +1,30 @@
+// Original Mochi source:
+// // Map operations test
+// var m: map<int, int> = {}
+// m[1] = 10
+// m[2] = 20
+// if 1 in m {
+//   print(m[1])
+// }
+// print(m[2])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	unordered_map<int, int> m = unordered_map<int, int>{};
-	m[1] = 10;
-	m[2] = 20;
-	if ((m.count(1) != 0)) {
-		std::cout << (m[1]) << std::endl;
-	}
-	std::cout << (m[2]) << std::endl;
-	return 0;
+    // var m: map<int, int> = {}
+    unordered_map<int, int> m = unordered_map<int, int>{};
+    // m[1] = 10
+    m[1] = 10;
+    // m[2] = 20
+    m[2] = 20;
+    // if 1 in m {
+    if ((m.count(1) != 0)) {
+        //   print(m[1])
+        std::cout << (m[1]) << std::endl;
+    }
+    // print(m[2])
+    std::cout << (m[2]) << std::endl;
+    return 0;
 }
-

--- a/tests/compiler/valid/map_set.cpp.out
+++ b/tests/compiler/valid/map_set.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// var scores = {"a": 1}
+// scores["b"] = 2
+// print(scores["b"])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto scores = unordered_map<string, int>{{string("a"), 1}};
-	scores[string("b")] = 2;
-	std::cout << (scores[string("b")]) << std::endl;
-	return 0;
+    // var scores = {"a": 1}
+    auto scores = unordered_map<string, int>{{string("a"), 1}};
+    // scores["b"] = 2
+    scores[string("b")] = 2;
+    // print(scores["b"])
+    std::cout << (scores[string("b")]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/match_expr.cpp.out
+++ b/tests/compiler/valid/match_expr.cpp.out
@@ -1,9 +1,25 @@
+// Original Mochi source:
+// let x = 2
+// 
+// let label = match x {
+//   1 => "one"
+//   2 => "two"
+//   3 => "three"
+//   _ => "unknown"
+// }
+// 
+// print(label)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto x = 2;
-	auto label = ([&]() { auto _t0 = x; if (_t0 == 1) return string("one"); if (_t0 == 2) return string("two"); if (_t0 == 3) return string("three"); return string("unknown"); })();
-	std::cout << (label) << std::endl;
-	return 0;
+    // let x = 2
+    auto x = 2;
+    // let label = match x {
+    auto label = ([&]() { auto _t0 = x; if (_t0 == 1) return string("one"); if (_t0 == 2) return string("two"); if (_t0 == 3) return string("three"); return string("unknown"); })();
+    // print(label)
+    std::cout << (label) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/print_hello.cpp.out
+++ b/tests/compiler/valid/print_hello.cpp.out
@@ -1,7 +1,12 @@
+// Original Mochi source:
+// print("hello")
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (string("hello")) << std::endl;
-	return 0;
+    // print("hello")
+    std::cout << (string("hello")) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/stream_on_emit.cpp.out
+++ b/tests/compiler/valid/stream_on_emit.cpp.out
@@ -1,6 +1,22 @@
+// Original Mochi source:
+// stream Sensor {
+//   id: string
+//   temperature: float
+// }
+// 
+// on Sensor as s {
+//   print(s.id, s.temperature)
+// }
+// 
+// emit Sensor { id: "sensor-1", temperature: 22.5 }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	return 0;
+    // stream Sensor {
+    // on Sensor as s {
+    // emit Sensor { id: "sensor-1", temperature: 22.5 }
+    return 0;
 }

--- a/tests/compiler/valid/string_index.cpp.out
+++ b/tests/compiler/valid/string_index.cpp.out
@@ -1,15 +1,22 @@
+// Original Mochi source:
+// let text = "hello"
+// print(text[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 string _indexString(const string& s, int i) {
-	int n = s.size();
-	if (i < 0) i += n;
-	if (i < 0 || i >= n) throw std::out_of_range("index out of range");
-	return string(1, s[i]);
+    int n = s.size();
+    if (i < 0) i += n;
+    if (i < 0 || i >= n) throw std::out_of_range("index out of range");
+    return string(1, s[i]);
 }
 
 int main() {
-	auto text = string("hello");
-	std::cout << (_indexString(text, 1)) << std::endl;
-	return 0;
+    // let text = "hello"
+    auto text = string("hello");
+    // print(text[1])
+    std::cout << (_indexString(text, 1)) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/test_block.cpp.out
+++ b/tests/compiler/valid/test_block.cpp.out
@@ -1,12 +1,23 @@
+// Original Mochi source:
+// test "addition works" {
+//   let x = 1 + 2
+//   expect x == 3
+// }
+// print("ok")
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	std::cout << (string("ok")) << std::endl;
-	auto test_addition_works = [&]() {
-		auto x = 1 + 2;
-		if (!(x == 3)) { std::cerr << "expect failed\n"; exit(1); }
-	};
-	test_addition_works();
-	return 0;
+    // print("ok")
+    std::cout << (string("ok")) << std::endl;
+    auto test_addition_works = [&]() {
+        //   let x = 1 + 2
+        auto x = 1 + 2;
+        //   expect x == 3
+        if (!(x == 3)) { std::cerr << "expect failed\n"; exit(1); }
+    };
+    test_addition_works();
+    return 0;
 }

--- a/tests/compiler/valid/two_sum.cpp.out
+++ b/tests/compiler/valid/two_sum.cpp.out
@@ -1,21 +1,49 @@
+// Original Mochi source:
+// fun twoSum(nums: list<int>, target: int): list<int> {
+//   let n = len(nums)
+//   for i in 0..n {
+//     for j in i+1..n {
+//       if nums[i] + nums[j] == target {
+//         return [i, j]
+//       }
+//     }
+//   }
+//   return [-1, -1]
+// }
+// 
+// let result = twoSum([2,7,11,15], 9)
+// print(result[0])
+// print(result[1])
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// fun twoSum(nums: list<int>, target: int): list<int> {
 vector<int> twoSum(vector<int> nums, int target){
-	auto n = nums.size();
-	for (int i = 0; i < n; i++) {
-		for (int j = i + 1; j < n; j++) {
-			if (nums[i] + nums[j] == target) {
-				return vector<int>{i, j};
-			}
-		}
-	}
-	return vector<int>{-1, -1};
+    //   let n = len(nums)
+    auto n = nums.size();
+    //   for i in 0..n {
+    for (int i = 0; i < n; i++) {
+        //     for j in i+1..n {
+        for (int j = i + 1; j < n; j++) {
+            //       if nums[i] + nums[j] == target {
+            if (nums[i] + nums[j] == target) {
+                //         return [i, j]
+                return vector<int>{i, j};
+            }
+        }
+    }
+    //   return [-1, -1]
+    return vector<int>{-1, -1};
 }
 
 int main() {
-	auto result = twoSum(vector<int>{2, 7, 11, 15}, 9);
-	std::cout << (result[0]) << std::endl;
-	std::cout << (result[1]) << std::endl;
-	return 0;
+    // let result = twoSum([2,7,11,15], 9)
+    auto result = twoSum(vector<int>{2, 7, 11, 15}, 9);
+    // print(result[0])
+    std::cout << (result[0]) << std::endl;
+    // print(result[1])
+    std::cout << (result[1]) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/union_inorder.cpp.out
+++ b/tests/compiler/valid/union_inorder.cpp.out
@@ -1,20 +1,67 @@
+// Original Mochi source:
+// type Tree =
+//   Leaf
+//   | Node(left: Tree, value: int, right: Tree)
+// 
+// fun inorder(t: Tree): list<int> {
+//   return match t {
+//     Leaf => [] as list<int>
+//     Node(l, v, r) => inorder(l) + [v] + inorder(r)
+//   }
+// }
+// 
+// print(inorder(Node { left: Leaf {}, value: 1, right: Node { left: Leaf {}, value: 2, right: Leaf {} } }))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+template<typename T> T _cast(any v);
+template<> inline int _cast<int>(any v) {
+    if (v.type() == typeid(int)) return any_cast<int>(v);
+    if (v.type() == typeid(double)) return int(any_cast<double>(v));
+    if (v.type() == typeid(string)) return stoi(any_cast<string>(v));
+    return 0;
+}
+template<> inline double _cast<double>(any v) {
+    if (v.type() == typeid(double)) return any_cast<double>(v);
+    if (v.type() == typeid(int)) return double(any_cast<int>(v));
+    if (v.type() == typeid(string)) return stod(any_cast<string>(v));
+    return 0.0;
+}
+template<> inline bool _cast<bool>(any v) {
+    if (v.type() == typeid(bool)) return any_cast<bool>(v);
+    if (v.type() == typeid(string)) return any_cast<string>(v)=="true";
+    if (v.type() == typeid(int)) return any_cast<int>(v)!=0;
+    return false;
+}
+template<> inline string _cast<string>(any v) {
+    if (v.type() == typeid(string)) return any_cast<string>(v);
+    if (v.type() == typeid(int)) return to_string(any_cast<int>(v));
+    if (v.type() == typeid(double)) { stringstream ss; ss<<any_cast<double>(v); return ss.str(); }
+    if (v.type() == typeid(bool)) return any_cast<bool>(v)?"true":"false";
+    return "";
+}
+
+// type Tree =
 struct Leaf {
 };
 struct Node {
-	Tree left;
-	int value;
-	Tree right;
+    Tree left;
+    int value;
+    Tree right;
 };
 using Tree = std::variant<Leaf, Node>;
 
+// fun inorder(t: Tree): list<int> {
 vector<int> inorder(Tree t){
-	return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return vector<int>{}; if (std::holds_alternative<Node>(_t0)) { auto _v = std::get<Node>(_t0); auto l = _v.left; auto v = _v.value; auto r = _v.right; return ([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(inorder(l), vector<int>{v}), inorder(r)); }return {}; })();
+    //   return match t {
+    return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return _cast<vector<int>>(vector<int>{}); if (std::holds_alternative<Node>(_t0)) { auto _v = std::get<Node>(_t0); auto l = _v.left; auto v = _v.value; auto r = _v.right; return ([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(([&](vector<int> a, vector<int> b){ a.insert(a.end(), b.begin(), b.end()); return a; })(inorder(l), vector<int>{v}), inorder(r)); }return {}; })();
 }
 
 int main() {
-	std::cout << (inorder(Node{Leaf{}, 1, Node{Leaf{}, 2, Leaf{}}})) << std::endl;
-	return 0;
+    // type Tree =
+    // print(inorder(Node { left: Leaf {}, value: 1, right: Node { left: Leaf {}, value: 2, right: Leaf {} } }))
+    std::cout << (inorder(Node{Leaf{}, 1, Node{Leaf{}, 2, Leaf{}}})) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/union_match.cpp.out
+++ b/tests/compiler/valid/union_match.cpp.out
@@ -1,21 +1,43 @@
+// Original Mochi source:
+// type Tree =
+//   Leaf
+//   | Node(left: Tree, value: int, right: Tree)
+// 
+// fun isLeaf(t: Tree): bool {
+//   return match t {
+//     Leaf => true
+//     _ => false
+//   }
+// }
+// 
+// print(isLeaf(Leaf {}))
+// print(isLeaf(Node { left: Leaf {}, value: 1, right: Leaf {} }))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Tree =
 struct Leaf {
 };
 struct Node {
-	Tree left;
-	int value;
-	Tree right;
+    Tree left;
+    int value;
+    Tree right;
 };
 using Tree = std::variant<Leaf, Node>;
 
+// fun isLeaf(t: Tree): bool {
 bool isLeaf(Tree t){
-	return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return true; return false; })();
+    //   return match t {
+    return ([&]() { auto _t0 = t; if (std::holds_alternative<Leaf>(_t0)) return true; return false; })();
 }
 
 int main() {
-	std::cout << (isLeaf(Leaf{})) << std::endl;
-	std::cout << (isLeaf(Node{Leaf{}, 1, Leaf{}})) << std::endl;
-	return 0;
+    // type Tree =
+    // print(isLeaf(Leaf {}))
+    std::cout << (isLeaf(Leaf{})) << std::endl;
+    // print(isLeaf(Node { left: Leaf {}, value: 1, right: Leaf {} }))
+    std::cout << (isLeaf(Node{Leaf{}, 1, Leaf{}})) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/union_slice.cpp.out
+++ b/tests/compiler/valid/union_slice.cpp.out
@@ -1,18 +1,35 @@
+// Original Mochi source:
+// type Foo =
+//   Empty
+//   | Node(child: Foo)
+// 
+// fun listit(): list<Foo> {
+//   return [Empty {}]
+// }
+// 
+// print(len(listit()))
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
+// type Foo =
 struct Empty {
 };
 struct Node {
-	Foo child;
+    Foo child;
 };
 using Foo = std::variant<Empty, Node>;
 
+// fun listit(): list<Foo> {
 vector<Foo> listit(){
-	return vector<Empty>{Empty{}};
+    //   return [Empty {}]
+    return vector<Empty>{Empty{}};
 }
 
 int main() {
-	std::cout << (listit().size()) << std::endl;
-	return 0;
+    // type Foo =
+    // print(len(listit()))
+    std::cout << (listit().size()) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/var_assignment.cpp.out
+++ b/tests/compiler/valid/var_assignment.cpp.out
@@ -1,9 +1,18 @@
+// Original Mochi source:
+// var x = 1
+// x = 2
+// print(x)
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto x = 1;
-	x = 2;
-	std::cout << (x) << std::endl;
-	return 0;
+    // var x = 1
+    auto x = 1;
+    // x = 2
+    x = 2;
+    // print(x)
+    std::cout << (x) << std::endl;
+    return 0;
 }

--- a/tests/compiler/valid/while_loop.cpp.out
+++ b/tests/compiler/valid/while_loop.cpp.out
@@ -1,11 +1,23 @@
+// Original Mochi source:
+// var i = 0
+// while i < 3 {
+//   print(i)
+//   i = i + 1
+// }
+// 
+
 #include <bits/stdc++.h>
 using namespace std;
 
 int main() {
-	auto i = 0;
-	while (i < 3) {
-		std::cout << (i) << std::endl;
-		i = i + 1;
-	}
-	return 0;
+    // var i = 0
+    auto i = 0;
+    // while i < 3 {
+    while (i < 3) {
+        //   print(i)
+        std::cout << (i) << std::endl;
+        //   i = i + 1
+        i = i + 1;
+    }
+    return 0;
 }


### PR DESCRIPTION
## Summary
- replace tab characters with 4 spaces when emitting C++ code
- document new indentation behaviour in the C++ backend README
- note the change in the changelog
- emit the original Mochi source as comments atop generated C++ output
- update C++ golden files
- print Mochi source lines above each generated statement

## Testing
- `go test ./...`
- `go test ./compile/x/cpp -tags slow -run TestCPPCompiler_GoldenOutput -update`


------
https://chatgpt.com/codex/tasks/task_e_685d6c128d888320a671ea65869f78f1