### PR TITLE
Improve Kotlin binary expression formatting

### DIFF
--- a/tests/compiler/kt/arithmetic.kt.out
+++ b/tests/compiler/kt/arithmetic.kt.out
@@ -1,7 +1,12 @@
 fun main() {
-        println((1 + 2))
-        println((5 - 3))
-        println((4 * 2))
-        println((8 / 2))
-        println((7 % 3))
+        // print(1 + 2)
+        println(1 + 2)
+        // print(5 - 3)
+        println(5 - 3)
+        // print(4 * 2)
+        println(4 * 2)
+        // print(8 / 2)
+        println(8 / 2)
+        // print(7 % 3)
+        println(7 % 3)
 }

--- a/tests/compiler/kt/avg_builtin.kt.out
+++ b/tests/compiler/kt/avg_builtin.kt.out
@@ -1,3 +1,4 @@
 fun main() {
+        // print(avg([1,2,3]))
         println(listOf(1, 2, 3).average())
 }

--- a/tests/compiler/kt/bool_ops.kt.out
+++ b/tests/compiler/kt/bool_ops.kt.out
@@ -1,5 +1,8 @@
 fun main() {
-        println((true && false))
-        println((true || false))
+        // print(true && false)
+        println(true && false)
+        // print(true || false)
+        println(true || false)
+        // print(!false)
         println(!false)
 }

--- a/tests/compiler/kt/break_continue.kt.out
+++ b/tests/compiler/kt/break_continue.kt.out
@@ -1,12 +1,23 @@
 fun main() {
+        // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         val numbers = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
+        // for n in numbers {
+        // for n in numbers {
         for (n in numbers) {
-                if (((n % 2) == 0)) {
+                // if n % 2 == 0 {
+                // if n % 2 == 0 {
+                if (n % 2 == 0) {
+                        // continue
                         continue
                 }
-                if ((n > 7)) {
+                // if n > 7 {
+                // if n > 7 {
+                if (n > 7) {
+                        // break
                         break
                 }
+                // print("odd number:", n)
                 println("odd number:", n)
         }
 }

--- a/tests/compiler/kt/count_builtin.kt.out
+++ b/tests/compiler/kt/count_builtin.kt.out
@@ -1,3 +1,4 @@
 fun main() {
+        // print(count([1,2,3]))
         println(listOf(1, 2, 3).size)
 }

--- a/tests/compiler/kt/cross_join.kt.out
+++ b/tests/compiler/kt/cross_join.kt.out
@@ -1,12 +1,21 @@
+// type Customer {
 data class Customer(val id: Int, val name: String)
 
+// type Order {
 data class Order(val id: Int, val customerId: Int, val total: Int)
 
+// type PairInfo {
 data class PairInfo(val orderId: Int, val orderCustomerId: Int, val pairedCustomerName: String, val orderTotal: Int)
 
 fun main() {
+        // let customers = [
+        // let customers = [
         val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+        // let orders = [
+        // let orders = [
         val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
+        // let result = from o in orders
+        // let result = from o in orders
         val result = run {
                 val _src = orders
                 val _res = mutableListOf<PairInfo>()
@@ -17,8 +26,12 @@ fun main() {
                 }
                 _res
         }
+        // print("--- Cross Join: All order-customer pairs ---")
         println("--- Cross Join: All order-customer pairs ---")
+        // for entry in result {
+        // for entry in result {
         for (entry in result) {
+                // print("Order", entry.orderId,
                 println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
         }
 }

--- a/tests/compiler/kt/cross_join_triple.kt.out
+++ b/tests/compiler/kt/cross_join_triple.kt.out
@@ -1,7 +1,15 @@
 fun main() {
+        // let nums = [1, 2]
+        // let nums = [1, 2]
         val nums = listOf(1, 2)
+        // let letters = ["A", "B"]
+        // let letters = ["A", "B"]
         val letters = listOf("A", "B")
+        // let bools = [true, false]
+        // let bools = [true, false]
         val bools = listOf(true, false)
+        // let combos = from n in nums
+        // let combos = from n in nums
         val combos = run {
                 val _src = nums
                 val _res = mutableListOf<MutableMap<String, Any>>()
@@ -14,8 +22,12 @@ fun main() {
                 }
                 _res
         }
+        // print("--- Cross Join of three lists ---")
         println("--- Cross Join of three lists ---")
+        // for c in combos {
+        // for c in combos {
         for (c in combos) {
+                // print(c.n, c.l, c.b)
                 println(c.n, c.l, c.b)
         }
 }

--- a/tests/compiler/kt/dataset.kt.out
+++ b/tests/compiler/kt/dataset.kt.out
@@ -1,14 +1,22 @@
+// type Person {
 data class Person(val name: String, val age: Int)
 
 fun main() {
+        // let people = [
+        // let people = [
         val people = listOf(Person(name = "Alice", age = 30), Person(name = "Bob", age = 15), Person(name = "Charlie", age = 65))
+        // let names = from p in people
+        // let names = from p in people
         val names = run {
                 var res = people
-                res = res.filter { p -> (p.age >= 18) }
+                res = res.filter { p -> p.age >= 18 }
                 res = res.map { p -> p.name }
                 res
         }
+        // for n in names {
+        // for n in names {
         for (n in names) {
+                // print(n)
                 println(n)
         }
 }

--- a/tests/compiler/kt/dataset_sort_take_limit.kt.out
+++ b/tests/compiler/kt/dataset_sort_take_limit.kt.out
@@ -1,7 +1,12 @@
+// type Product {
 data class Product(val name: String, val price: Int)
 
 fun main() {
+        // let products = [
+        // let products = [
         val products = listOf(Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
+        // let expensive = from p in products
+        // let expensive = from p in products
         val expensive = run {
                 var res = products
                 res = res.sortedBy { p -> -p.price }
@@ -10,8 +15,12 @@ fun main() {
                 res = res.map { p -> p }
                 res
         }
+        // print("--- Top products (excluding most expensive) ---")
         println("--- Top products (excluding most expensive) ---")
+        // for item in expensive {
+        // for item in expensive {
         for (item in expensive) {
+                // print(item.name, "costs $", item.price)
                 println(item.name, "costs $", item.price)
         }
 }

--- a/tests/compiler/kt/factorial.kt.out
+++ b/tests/compiler/kt/factorial.kt.out
@@ -1,12 +1,16 @@
+// fun factorial(n: int): int {
 fun factorial(n: Int) : Int {
-        if ((n <= 1)) {
+        if (n <= 1) {
                 return 1
         }
-        return (n * factorial((n - 1)))
+        return n * factorial(n - 1)
 }
 
 fun main() {
+        // print(factorial(0))
         println(factorial(0))
+        // print(factorial(1))
         println(factorial(1))
+        // print(factorial(5))
         println(factorial(5))
 }

--- a/tests/compiler/kt/fetch_builtin.kt.out
+++ b/tests/compiler/kt/fetch_builtin.kt.out
@@ -1,10 +1,43 @@
+// type Msg {
 data class Msg(val message: String)
 
 fun main() {
+        // let data: Msg = fetch "file://tests/compiler/kt/fetch_builtin.json"
+        // let data: Msg = fetch "file://tests/compiler/kt/fetch_builtin.json"
         val data: Msg = _cast<Msg>(_fetch("file://tests/compiler/kt/fetch_builtin.json", null))
+        // print(data.message)
         println(data.message)
 }
 
+import kotlin.reflect.full.primaryConstructor
+
+inline fun <reified T> _cast(v: Any?): T {
+    return when (T::class) {
+        Int::class -> when (v) { is Number -> v.toInt(); is String -> v.toInt(); else -> 0 } as T
+        Double::class -> when (v) { is Number -> v.toDouble(); is String -> v.toDouble(); else -> 0.0 } as T
+        Boolean::class -> when (v) { is Boolean -> v; is String -> v == "true"; else -> false } as T
+        String::class -> v.toString() as T
+        else -> {
+            if (v is Map<*, *>) {
+                val ctor = T::class.primaryConstructor
+                if (ctor != null) {
+                    val args = ctor.parameters.associateWith { p ->
+                        val value = v[p.name]
+                        when (p.type.classifier) {
+                            Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
+                            Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
+                            Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
+                            String::class -> value?.toString()
+                            else -> value
+                        }
+                    }
+                    return ctor.callBy(args)
+                }
+            }
+            v as T
+        }
+    }
+}
 fun _fetch(url: String, opts: Map<String, Any>?): Any? {
     fun encode(x: Any?): String = when (x) {
         null -> "null"
@@ -69,4 +102,3 @@ fun _fetch(url: String, opts: Map<String, Any>?): Any? {
         throw RuntimeException(e)
     }
 }
-

--- a/tests/compiler/kt/fetch_http.kt.out
+++ b/tests/compiler/kt/fetch_http.kt.out
@@ -1,11 +1,45 @@
+// type Todo {
 data class Todo(val userId: Int, val id: Int, val title: String, val completed: Boolean)
 
 fun main() {
+        // let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+        // let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
         val todo: Todo = _cast<Todo>(_fetch("https://jsonplaceholder.typicode.com/todos/1", null))
+        // print(todo.title)
         println(todo.title)
+        // print(todo.completed)
         println(todo.completed)
 }
 
+import kotlin.reflect.full.primaryConstructor
+
+inline fun <reified T> _cast(v: Any?): T {
+    return when (T::class) {
+        Int::class -> when (v) { is Number -> v.toInt(); is String -> v.toInt(); else -> 0 } as T
+        Double::class -> when (v) { is Number -> v.toDouble(); is String -> v.toDouble(); else -> 0.0 } as T
+        Boolean::class -> when (v) { is Boolean -> v; is String -> v == "true"; else -> false } as T
+        String::class -> v.toString() as T
+        else -> {
+            if (v is Map<*, *>) {
+                val ctor = T::class.primaryConstructor
+                if (ctor != null) {
+                    val args = ctor.parameters.associateWith { p ->
+                        val value = v[p.name]
+                        when (p.type.classifier) {
+                            Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
+                            Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
+                            Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
+                            String::class -> value?.toString()
+                            else -> value
+                        }
+                    }
+                    return ctor.callBy(args)
+                }
+            }
+            v as T
+        }
+    }
+}
 fun _fetch(url: String, opts: Map<String, Any>?): Any? {
     fun encode(x: Any?): String = when (x) {
         null -> "null"
@@ -70,4 +104,3 @@ fun _fetch(url: String, opts: Map<String, Any>?): Any? {
         throw RuntimeException(e)
     }
 }
-

--- a/tests/compiler/kt/fibonacci.kt.out
+++ b/tests/compiler/kt/fibonacci.kt.out
@@ -1,12 +1,16 @@
+// fun fib(n: int): int {
 fun fib(n: Int) : Int {
-        if ((n <= 1)) {
+        if (n <= 1) {
                 return n
         }
-        return (fib((n - 1)) + fib((n - 2)))
+        return fib(n - 1) + fib(n - 2)
 }
 
 fun main() {
+        // print(fib(0))
         println(fib(0))
+        // print(fib(1))
         println(fib(1))
+        // print(fib(6))
         println(fib(6))
 }

--- a/tests/compiler/kt/for_list_collection.kt.out
+++ b/tests/compiler/kt/for_list_collection.kt.out
@@ -1,5 +1,8 @@
 fun main() {
+        // for n in [1,2,3] {
+        // for n in [1,2,3] {
         for (n in listOf(1, 2, 3)) {
+                // print(n)
                 println(n)
         }
 }

--- a/tests/compiler/kt/for_loop.kt.out
+++ b/tests/compiler/kt/for_loop.kt.out
@@ -1,5 +1,8 @@
 fun main() {
+        // for i in 1..4 {
+        // for i in 1..4 {
         for (i in 1 until 4) {
+                // print(i)
                 println(i)
         }
 }

--- a/tests/compiler/kt/for_string_collection.kt.out
+++ b/tests/compiler/kt/for_string_collection.kt.out
@@ -1,5 +1,8 @@
 fun main() {
+        // for ch in "hi" {
+        // for ch in "hi" {
         for (ch in "hi") {
+                // print(ch)
                 println(ch)
         }
 }

--- a/tests/compiler/kt/fun_call.kt.out
+++ b/tests/compiler/kt/fun_call.kt.out
@@ -1,7 +1,9 @@
+// fun add(a: int, b: int): int {
 fun add(a: Int, b: Int) : Int {
-        return (a + b)
+        return a + b
 }
 
 fun main() {
+        // print(add(2, 3))  // 5
         println(add(2, 3))
 }

--- a/tests/compiler/kt/group_by.kt.out
+++ b/tests/compiler/kt/group_by.kt.out
@@ -1,7 +1,14 @@
 fun main() {
+        // let xs = [1, 1, 2]
+        // let xs = [1, 1, 2]
         val xs = listOf(1, 1, 2)
+        // let groups = from x in xs
+        // let groups = from x in xs
         val groups = _group_by(xs) { x -> x }.map { g -> mutableMapOf("k" to g.key, "c" to g.size) }
+        // for g in groups {
+        // for g in groups {
         for (g in groups) {
+                // print(g.k, g.c)
                 println(g.k, g.c)
         }
 }
@@ -31,4 +38,3 @@ fun _group_by(src: List<Any?>, keyfn: (Any?) -> Any?): List<_Group> {
     }
         return order.map { groups[it]!! }
 }
-

--- a/tests/compiler/kt/hello_world.kt.out
+++ b/tests/compiler/kt/hello_world.kt.out
@@ -1,3 +1,4 @@
 fun main() {
+        // print("Hello, world")
         println("Hello, world")
 }

--- a/tests/compiler/kt/input_builtin.kt.out
+++ b/tests/compiler/kt/input_builtin.kt.out
@@ -1,7 +1,14 @@
 fun main() {
+        // print("Enter first input:")
         println("Enter first input:")
+        // let input1 = input()
+        // let input1 = input()
         val input1 = readln()
+        // print("Enter second input:")
         println("Enter second input:")
+        // let input2 = input()
+        // let input2 = input()
         val input2 = readln()
+        // print("You entered:", input1, ",", input2)
         println("You entered:", input1, ",", input2)
 }

--- a/tests/compiler/kt/join_filter_pag.kt.out
+++ b/tests/compiler/kt/join_filter_pag.kt.out
@@ -1,17 +1,25 @@
+// type Person { id: int, name: string }
 data class Person(val id: Int, val name: String)
 
+// type Purchase { id: int, personId: int, total: int }
 data class Purchase(val id: Int, val personId: Int, val total: Int)
 
 fun main() {
+        // let people = [
+        // let people = [
         val people = listOf(Person(id = 1, name = "Alice"), Person(id = 2, name = "Bob"), Person(id = 3, name = "Charlie"))
+        // let purchases = [
+        // let purchases = [
         val purchases = listOf(Purchase(id = 1, personId = 1, total = 200), Purchase(id = 2, personId = 1, total = 50), Purchase(id = 3, personId = 2, total = 150), Purchase(id = 4, personId = 3, total = 100), Purchase(id = 5, personId = 2, total = 250))
+        // let result = from p in people
+        // let result = from p in people
         val result = run {
                 val _src = people
                 val _rows = _query(_src, listOf(
                         _JoinSpec(items = purchases, on = { args ->
                         val p = args[0]
                         val o = args[1]
-(p.id == o.personId)
+p.id == o.personId
                         }))
                 ), _QueryOpts(selectFn = { args ->
                         val p = args[0]
@@ -20,7 +28,7 @@ mutableMapOf("person" to p.name, "spent" to o.total)
                         }, where = { args ->
                         val p = args[0]
                         val o = args[1]
-(o.total > 100)
+o.total > 100
                         }, sortKey = { args ->
                         val p = args[0]
                         val o = args[1]
@@ -28,7 +36,10 @@ mutableMapOf("person" to p.name, "spent" to o.total)
                         }, skip = 1, take = 2) )
                 _rows
         }
+        // for r in result {
+        // for r in result {
         for (r in result) {
+                // print(r.person, r.spent)
                 println(r.person, r.spent)
         }
 }

--- a/tests/compiler/kt/json_builtin.kt.out
+++ b/tests/compiler/kt/json_builtin.kt.out
@@ -1,4 +1,5 @@
 fun main() {
+        // json({"a": 1})
         _json(mutableMapOf("a" to 1))
 }
 

--- a/tests/compiler/kt/list_concat.kt.out
+++ b/tests/compiler/kt/list_concat.kt.out
@@ -1,4 +1,5 @@
 fun main() {
+        // print([1,2] + [3,4])
         println(_concat(listOf(1, 2), listOf(3, 4)))
 }
 

--- a/tests/compiler/kt/list_index.kt.out
+++ b/tests/compiler/kt/list_index.kt.out
@@ -1,4 +1,7 @@
 fun main() {
+        // let xs = [10, 20, 30]
+        // let xs = [10, 20, 30]
         val xs = listOf(10, 20, 30)
+        // print(xs[1])
         println(xs[1])
 }

--- a/tests/compiler/kt/load_jsonl_stdin.kt.out
+++ b/tests/compiler/kt/load_jsonl_stdin.kt.out
@@ -1,6 +1,9 @@
+// type Person {
 data class Person(val name: String, val age: Int)
 
 fun main() {
+        // let people = load as Person with {
+        // let people = load as Person with {
         val people = run {
         val _rows = _load(null, mutableMapOf("format" to "jsonl"))
         val _out = mutableListOf<Person>()
@@ -9,6 +12,7 @@ fun main() {
         }
         _out
 }
+        // print(count(people))
         println(people.size)
 }
 

--- a/tests/compiler/kt/load_save_json.kt.out
+++ b/tests/compiler/kt/load_save_json.kt.out
@@ -1,6 +1,9 @@
+// type Person {
 data class Person(val name: String, val age: Int, val email: String)
 
 fun main() {
+        // let people = load as Person with {
+        // let people = load as Person with {
         val people = run {
         val _rows = _load(null, mutableMapOf("format" to "json"))
         val _out = mutableListOf<Person>()
@@ -9,12 +12,15 @@ fun main() {
         }
         _out
 }
+        // let adults = from p in people
+        // let adults = from p in people
         val adults = run {
                 var res = people
-                res = res.filter { p -> (p.age >= 18) }
+                res = res.filter { p -> p.age >= 18 }
                 res = res.map { p -> p }
                 res
         }
+        // save adults with { format: "json" }
         _save(adults, null, mutableMapOf("format" to "json"))
 }
 
@@ -161,4 +167,3 @@ fun _save(src: Any?, path: String?, opts: Map<String, Any>?): Unit {
     }
     if (path == null || path == "-" || path == "") print(text) else java.io.File(path).writeText(text)
 }
-

--- a/tests/compiler/kt/load_yaml.kt.out
+++ b/tests/compiler/kt/load_yaml.kt.out
@@ -1,6 +1,9 @@
+// type Person {
 data class Person(val name: String, val age: Int, val email: String)
 
 fun main() {
+        // let people = load "../tests/interpreter/valid/people.yaml" as Person with { format: "yaml" }
+        // let people = load "../tests/interpreter/valid/people.yaml" as Person with { format: "yaml" }
         val people = run {
         val _rows = _load("../tests/interpreter/valid/people.yaml", mutableMapOf("format" to "yaml"))
         val _out = mutableListOf<Person>()
@@ -9,13 +12,18 @@ fun main() {
         }
         _out
 }
+        // let adults = from p in people
+        // let adults = from p in people
         val adults = run {
                 var res = people
-                res = res.filter { p -> (p.age >= 18) }
+                res = res.filter { p -> p.age >= 18 }
                 res = res.map { p -> mutableMapOf("name" to p.name, "email" to p.email) }
                 res
         }
+        // for a in adults {
+        // for a in adults {
         for (a in adults) {
+                // print(a.name, a.email)
                 println(a.name, a.email)
         }
 }

--- a/tests/compiler/kt/local_recursion.kt.out
+++ b/tests/compiler/kt/local_recursion.kt.out
@@ -1,18 +1,21 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun fromList(nums: list<int>): Tree {
 fun fromList(nums: List<Int>) : Tree {
         fun helper(lo: Int, hi: Int) : Tree {
-                if ((lo >= hi)) {
+                if (lo >= hi) {
                         return Leaf()
                 }
-                val mid = (((lo + hi)) / 2)
-                return Node(left = helper(lo, mid), value = nums[mid], right = helper((mid + 1), hi))
+                val mid = (lo + hi) / 2
+                return Node(left = helper(lo, mid), value = nums[mid], right = helper(mid + 1, hi))
         }
         return helper(0, nums.size)
 }
 
+// fun inorder(t: Tree): list<int> {
 fun inorder(t: Tree) : List<Int> {
         return run {
                 val _t = t
@@ -29,6 +32,7 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
+        // print(inorder(fromList([-10, -3, 0, 5, 9])))
         println(inorder(fromList(listOf(-10, -3, 0, 5, 9))))
 }
 

--- a/tests/compiler/kt/map_index.kt.out
+++ b/tests/compiler/kt/map_index.kt.out
@@ -1,4 +1,7 @@
 fun main() {
+        // let scores = {"Alice": 10, "Bob": 15}
+        // let scores = {"Alice": 10, "Bob": 15}
         val scores = mutableMapOf("Alice" to 10, "Bob" to 15)
+        // print(scores["Bob"])
         println(scores["Bob"])
 }

--- a/tests/compiler/kt/map_iterate.kt.out
+++ b/tests/compiler/kt/map_iterate.kt.out
@@ -1,18 +1,31 @@
 fun main() {
+        // var m: map<int, bool> = {}
+        // var m: map<int, bool> = {}
         var m: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
+        // m[1] = true
+        // m[1] = true
         run {
                 val _tmp = m.toMutableMap()
                 _tmp[1] = true
                 m = _tmp
         }
+        // m[2] = true
+        // m[2] = true
         run {
                 val _tmp = m.toMutableMap()
                 _tmp[2] = true
                 m = _tmp
         }
+        // var sum = 0
+        // var sum = 0
         var sum = 0
+        // for k in m {
+        // for k in m {
         for (k in m.keys) {
-                sum = (sum + k)
+                // sum = sum + k
+                // sum = sum + k
+                sum = sum + k
         }
+        // print(sum)
         println(sum)
 }

--- a/tests/compiler/kt/map_literal.kt.out
+++ b/tests/compiler/kt/map_literal.kt.out
@@ -1,4 +1,7 @@
 fun main() {
+        // let map = {"a": 1}
+        // let map = {"a": 1}
         val map = mutableMapOf("a" to 1)
+        // print(map["a"])
         println(map["a"])
 }

--- a/tests/compiler/kt/match_capture.kt.out
+++ b/tests/compiler/kt/match_capture.kt.out
@@ -1,7 +1,9 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun depth(t: Tree): int {
 fun depth(t: Tree) : Int {
         return run {
                 val _t = t
@@ -10,12 +12,13 @@ fun depth(t: Tree) : Int {
                         _t is Node -> {
                                 val l = _t.left
                                 val r = _t.right
-                                ((depth(l) + depth(r)) + 1)
+                                depth(l) + depth(r) + 1
                         }
                 }
         }
 }
 
 fun main() {
+        // print(depth(Node { left: Leaf {}, value: 0, right: Leaf {} }))
         println(depth(Node(left = Leaf(), value = 0, right = Leaf())))
 }

--- a/tests/compiler/kt/match_underscore.kt.out
+++ b/tests/compiler/kt/match_underscore.kt.out
@@ -1,7 +1,9 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun value_of_root(t: Tree): int {
 fun value_of_root(t: Tree) : Int {
         return run {
                 val _t = t
@@ -16,5 +18,6 @@ fun value_of_root(t: Tree) : Int {
 }
 
 fun main() {
+        // print(value_of_root(Node { left: Leaf {}, value: 5, right: Leaf {} }))
         println(value_of_root(Node(left = Leaf(), value = 5, right = Leaf())))
 }

--- a/tests/compiler/kt/matrix_search.kt.out
+++ b/tests/compiler/kt/matrix_search.kt.out
@@ -1,28 +1,31 @@
+// fun searchMatrix(matrix: list<list<int>>, target: int): bool {
 fun searchMatrix(matrix: List<List<Int>>, target: Int) : Boolean {
         val m = matrix.size
-        if ((m == 0)) {
+        if (m == 0) {
                 return false
         }
         val n = matrix[0].size
         var left = 0
-        var right = ((m * n) - 1)
-        while ((left <= right)) {
-                val mid = (left + (((right - left)) / 2))
-                val row = (mid / n)
-                val col = (mid % n)
+        var right = m * n - 1
+        while (left <= right) {
+                val mid = left + (right - left) / 2
+                val row = mid / n
+                val col = mid % n
                 val value = matrix[row][col]
-                if ((value == target)) {
+                if (value == target) {
                         return true
-                } else if ((value < target)) {
-                        left = (mid + 1)
+                } else if (value < target) {
+                        left = mid + 1
                 } else {
-                        right = (mid - 1)
+                        right = mid - 1
                 }
         }
         return false
 }
 
 fun main() {
+        // print(searchMatrix([[1,3,5,7],[10,11,16,20],[23,30,34,60]], 3))
         println(searchMatrix(listOf(listOf(1, 3, 5, 7), listOf(10, 11, 16, 20), listOf(23, 30, 34, 60)), 3))
+        // print(searchMatrix([[1,3,5,7],[10,11,16,20],[23,30,34,60]], 13))
         println(searchMatrix(listOf(listOf(1, 3, 5, 7), listOf(10, 11, 16, 20), listOf(23, 30, 34, 60)), 13))
 }

--- a/tests/compiler/kt/now_builtin.kt.out
+++ b/tests/compiler/kt/now_builtin.kt.out
@@ -1,3 +1,4 @@
 fun main() {
-        println(((System.currentTimeMillis() * 1000000) > 0))
+        // print(now() > 0)
+        println((System.currentTimeMillis() * 1000000) > 0)
 }

--- a/tests/compiler/kt/str_builtin.kt.out
+++ b/tests/compiler/kt/str_builtin.kt.out
@@ -1,3 +1,4 @@
 fun main() {
+        // print(str(123))
         println(123.toString())
 }

--- a/tests/compiler/kt/string_concat.kt.out
+++ b/tests/compiler/kt/string_concat.kt.out
@@ -1,3 +1,4 @@
 fun main() {
-        println(("hello " + "world"))
+        // print("hello " + "world")
+        println("hello " + "world")
 }

--- a/tests/compiler/kt/string_index.kt.out
+++ b/tests/compiler/kt/string_index.kt.out
@@ -1,5 +1,8 @@
 fun main() {
+        // let text = "hello"
+        // let text = "hello"
         val text = "hello"
+        // print(text[1])
         println(_indexString(text, 1))
 }
 

--- a/tests/compiler/kt/string_negative_index.kt.out
+++ b/tests/compiler/kt/string_negative_index.kt.out
@@ -1,5 +1,8 @@
 fun main() {
+        // let text = "hello"
+        // let text = "hello"
         val text = "hello"
+        // print(text[-1])
         println(_indexString(text, -1))
 }
 

--- a/tests/compiler/kt/string_slice.kt.out
+++ b/tests/compiler/kt/string_slice.kt.out
@@ -1,4 +1,5 @@
 fun main() {
+        // print("hello"[1:4])
         println(_sliceString("hello", 1, 4))
 }
 

--- a/tests/compiler/kt/test_block.kt.out
+++ b/tests/compiler/kt/test_block.kt.out
@@ -1,9 +1,14 @@
+// test "addition works" {
 fun test_addition_works() {
-        val x = (1 + 2)
-        check((x == 3))
+        // let x = 1 + 2
+        // let x = 1 + 2
+        val x = 1 + 2
+        // expect x == 3
+        check(x == 3)
 }
 
 fun main() {
+        // print("ok")
         println("ok")
         test_addition_works()
 }

--- a/tests/compiler/kt/two_sum.kt.out
+++ b/tests/compiler/kt/two_sum.kt.out
@@ -1,8 +1,9 @@
+// fun twoSum(nums: list<int>, target: int): list<int> {
 fun twoSum(nums: List<Int>, target: Int) : List<Int> {
         val n = nums.size
         for (i in 0 until n) {
-                for (j in (i + 1) until n) {
-                        if (((nums[i] + nums[j]) == target)) {
+                for (j in i + 1 until n) {
+                        if (nums[i] + nums[j] == target) {
                                 return listOf(i, j)
                         }
                 }
@@ -11,7 +12,11 @@ fun twoSum(nums: List<Int>, target: Int) : List<Int> {
 }
 
 fun main() {
+        // let result = twoSum([2,7,11,15], 9)
+        // let result = twoSum([2,7,11,15], 9)
         val result = twoSum(listOf(2, 7, 11, 15), 9)
+        // print(result[0])
         println(result[0])
+        // print(result[1])
         println(result[1])
 }

--- a/tests/compiler/kt/type_method.kt.out
+++ b/tests/compiler/kt/type_method.kt.out
@@ -1,11 +1,15 @@
+// type Person {
 data class Person(val name: String) {
         fun greet() : String {
-                return ("hi " + name)
+                return "hi " + name
         }
         
 }
 
 fun main() {
+        // let p = Person { name: "Ada" }
+        // let p = Person { name: "Ada" }
         val p = Person(name = "Ada")
+        // print(p.greet())
         println(p.greet())
 }

--- a/tests/compiler/kt/underscore_for_loop.kt.out
+++ b/tests/compiler/kt/underscore_for_loop.kt.out
@@ -1,17 +1,38 @@
 fun main() {
+        // var c = 0
+        // var c = 0
         var c = 0
+        // for _ in 0..2 {
+        // for _ in 0..2 {
         for (_ in 0 until 2) {
-                c = (c + 1)
+                // c = c + 1
+                // c = c + 1
+                c = c + 1
         }
+        // for _ in [1, 2] {
+        // for _ in [1, 2] {
         for (_ in listOf(1, 2)) {
-                c = (c + 1)
+                // c = c + 1
+                // c = c + 1
+                c = c + 1
         }
+        // for _ in "ab" {
+        // for _ in "ab" {
         for (_ in "ab") {
-                c = (c + 1)
+                // c = c + 1
+                // c = c + 1
+                c = c + 1
         }
+        // var m = {"x": 1, "y": 2}
+        // var m = {"x": 1, "y": 2}
         var m = mutableMapOf("x" to 1, "y" to 2)
+        // for _ in m {
+        // for _ in m {
         for (_ in m.keys) {
-                c = (c + 1)
+                // c = c + 1
+                // c = c + 1
+                c = c + 1
         }
+        // print(c)
         println(c)
 }

--- a/tests/compiler/kt/union_inorder.kt.out
+++ b/tests/compiler/kt/union_inorder.kt.out
@@ -1,7 +1,9 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun inorder(t: Tree): list<int> {
 fun inorder(t: Tree) : List<Int> {
         return run {
                 val _t = t
@@ -18,6 +20,7 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
+        // print(inorder(Node { left: Leaf {}, value: 1, right: Node { left: Leaf {}, value: 2, right: Leaf {} } }))
         println(inorder(Node(left = Leaf(), value = 1, right = Node(left = Leaf(), value = 2, right = Leaf()))))
 }
 

--- a/tests/compiler/kt/union_match.kt.out
+++ b/tests/compiler/kt/union_match.kt.out
@@ -1,7 +1,9 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun isLeaf(t: Tree): bool {
 fun isLeaf(t: Tree) : Boolean {
         return run {
                 val _t = t
@@ -13,6 +15,8 @@ fun isLeaf(t: Tree) : Boolean {
 }
 
 fun main() {
+        // print(isLeaf(Leaf {}))
         println(isLeaf(Leaf()))
+        // print(isLeaf(Node { left: Leaf {}, value: 1, right: Leaf {} }))
         println(isLeaf(Node(left = Leaf(), value = 1, right = Leaf())))
 }

--- a/tests/compiler/kt/union_slice.kt.out
+++ b/tests/compiler/kt/union_slice.kt.out
@@ -1,11 +1,14 @@
+// type Foo =
 sealed interface Foo
 data class Empty() : Foo
 data class Node(val child: Foo) : Foo
 
+// fun listit(): list<Foo> {
 fun listit() : List<Foo> {
         return listOf(Empty())
 }
 
 fun main() {
+        // print(len(listit()))
         println(listit().size)
 }

--- a/tests/compiler/kt/var_assignment.kt.out
+++ b/tests/compiler/kt/var_assignment.kt.out
@@ -1,5 +1,10 @@
 fun main() {
+        // var x = 1
+        // var x = 1
         var x = 1
+        // x = 2
+        // x = 2
         x = 2
+        // print(x)
         println(x)
 }

--- a/tests/compiler/kt/while_loop.kt.out
+++ b/tests/compiler/kt/while_loop.kt.out
@@ -1,7 +1,14 @@
 fun main() {
+        // var i = 0
+        // var i = 0
         var i = 0
-        while ((i < 3)) {
+        // while i < 3 {
+        // while i < 3 {
+        while (i < 3) {
+                // print(i)
                 println(i)
-                i = (i + 1)
+                // i = i + 1
+                // i = i + 1
+                i = i + 1
         }
 }

--- a/tests/compiler/kt/while_membership.kt.out
+++ b/tests/compiler/kt/while_membership.kt.out
@@ -1,17 +1,34 @@
 fun main() {
+        // var set: map<int, bool> = {}
+        // var set: map<int, bool> = {}
         var set: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
+        // for n in [1,2,3] {
+        // for n in [1,2,3] {
         for (n in listOf(1, 2, 3)) {
+                // set[n] = true
+                // set[n] = true
                 run {
                         val _tmp = set.toMutableMap()
                         _tmp[n] = true
                         set = _tmp
                 }
         }
+        // var i = 1
+        // var i = 1
         var i = 1
+        // var count = 0
+        // var count = 0
         var count = 0
+        // while i in set {
+        // while i in set {
         while (set.contains(i)) {
-                i = (i + 1)
-                count = (count + 1)
+                // i = i + 1
+                // i = i + 1
+                i = i + 1
+                // count = count + 1
+                // count = count + 1
+                count = count + 1
         }
+        // print(count)
         println(count)
 }

--- a/tests/compiler/valid/break_continue.kt.out
+++ b/tests/compiler/valid/break_continue.kt.out
@@ -1,13 +1,23 @@
 fun main() {
+        // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         val numbers = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
+        // for n in numbers {
+        // for n in numbers {
         for (n in numbers) {
-                if (((n % 2) == 0)) {
+                // if n % 2 == 0 {
+                // if n % 2 == 0 {
+                if (n % 2 == 0) {
+                        // continue
                         continue
                 }
-                if ((n > 7)) {
+                // if n > 7 {
+                // if n > 7 {
+                if (n > 7) {
+                        // break
                         break
                 }
+                // print("odd number:", n)
                 println("odd number:", n)
         }
 }
-

--- a/tests/compiler/valid/closure.kt.out
+++ b/tests/compiler/valid/closure.kt.out
@@ -1,11 +1,14 @@
+// fun makeAdder(n: int): fun(int): int {
 fun makeAdder(n: Int) : Any {
         return fun(x: Int) : Int {
-                return (x + n)
+                return x + n
 }
 }
 
 fun main() {
+        // let add10 = makeAdder(10)
+        // let add10 = makeAdder(10)
         val add10 = makeAdder(10)
+        // print(add10(7))  // 17
         println(add10(7))
 }
-

--- a/tests/compiler/valid/cross_join.kt.out
+++ b/tests/compiler/valid/cross_join.kt.out
@@ -1,12 +1,21 @@
+// type Customer {
 data class Customer(val id: Int, val name: String)
 
+// type Order {
 data class Order(val id: Int, val customerId: Int, val total: Int)
 
+// type PairInfo {
 data class PairInfo(val orderId: Int, val orderCustomerId: Int, val pairedCustomerName: String, val orderTotal: Int)
 
 fun main() {
+        // let customers = [
+        // let customers = [
         val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+        // let orders = [
+        // let orders = [
         val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
+        // let result = from o in orders
+        // let result = from o in orders
         val result = run {
                 val _src = orders
                 val _res = mutableListOf<PairInfo>()
@@ -17,10 +26,12 @@ fun main() {
                 }
                 _res
         }
+        // print("--- Cross Join: All order-customer pairs ---")
         println("--- Cross Join: All order-customer pairs ---")
+        // for entry in result {
+        // for entry in result {
         for (entry in result) {
+                // print("Order", entry.orderId,
                 println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
         }
 }
-
-

--- a/tests/compiler/valid/fold_pure_let.kt.out
+++ b/tests/compiler/valid/fold_pure_let.kt.out
@@ -1,11 +1,14 @@
+// fun sumN(n: int): int {
 fun sumN(n: Int) : Int {
-        return ((n * ((n + 1))) / 2)
+        return n * (n + 1) / 2
 }
 
 fun main() {
+        // let n = 10
+        // let n = 10
         val n = 10
+        // print(sumN(n))
         println(sumN(n))
+        // print(n)
         println(n)
 }
-
-

--- a/tests/compiler/valid/for_list_collection.kt.out
+++ b/tests/compiler/valid/for_list_collection.kt.out
@@ -1,6 +1,8 @@
 fun main() {
+        // for n in [1,2,3] {
+        // for n in [1,2,3] {
         for (n in listOf(1, 2, 3)) {
+                // print(n)
                 println(n)
         }
 }
-

--- a/tests/compiler/valid/for_loop.kt.out
+++ b/tests/compiler/valid/for_loop.kt.out
@@ -1,6 +1,8 @@
 fun main() {
+        // for i in 1..4 {
+        // for i in 1..4 {
         for (i in 1 until 4) {
+                // print(i)
                 println(i)
         }
 }
-

--- a/tests/compiler/valid/for_string_collection.kt.out
+++ b/tests/compiler/valid/for_string_collection.kt.out
@@ -1,6 +1,8 @@
 fun main() {
+        // for ch in "hi" {
+        // for ch in "hi" {
         for (ch in "hi") {
+                // print(ch)
                 println(ch)
         }
 }
-

--- a/tests/compiler/valid/fun_call.kt.out
+++ b/tests/compiler/valid/fun_call.kt.out
@@ -1,8 +1,9 @@
+// fun add(a: int, b: int): int {
 fun add(a: Int, b: Int) : Int {
-        return (a + b)
+        return a + b
 }
 
 fun main() {
+        // print(add(2, 3))  // 5
         println(add(2, 3))
 }
-

--- a/tests/compiler/valid/fun_expr_in_let.kt.out
+++ b/tests/compiler/valid/fun_expr_in_let.kt.out
@@ -1,7 +1,9 @@
 fun main() {
+        // let square = fun(x: int): int => x * x
+        // let square = fun(x: int): int => x * x
         val square = fun(x: Int) : Int {
-                return (x * x)
+                return x * x
 }
+        // print(square(6))  // 36
         println(square(6))
 }
-

--- a/tests/compiler/valid/generate_echo.kt.out
+++ b/tests/compiler/valid/generate_echo.kt.out
@@ -1,9 +1,11 @@
 fun main() {
+        // let poem = generate text {
+        // let poem = generate text {
         val poem = _genText("echo hello", null, null)
+        // print(poem)
         println(poem)
 }
 
 fun _genText(prompt: String, model: String?, params: Map<String, Any>?): String {
     return prompt
 }
-

--- a/tests/compiler/valid/generate_embedding.kt.out
+++ b/tests/compiler/valid/generate_embedding.kt.out
@@ -1,9 +1,11 @@
 fun main() {
+        // let vec = generate embedding {
+        // let vec = generate embedding {
         val vec = _genEmbed("hi", null, null)
+        // print(len(vec))
         println(vec.size)
 }
 
 fun _genEmbed(text: String, model: String?, params: Map<String, Any>?): List<Double> {
     return text.map { it.code.toDouble() }
 }
-

--- a/tests/compiler/valid/grouped_expr.kt.out
+++ b/tests/compiler/valid/grouped_expr.kt.out
@@ -1,5 +1,7 @@
 fun main() {
-        val value = (((1 + 2)) * 3)
+        // let value = (1 + 2) * 3
+        // let value = (1 + 2) * 3
+        val value = (1 + 2) * 3
+        // print(value)  // 9
         println(value)
 }
-

--- a/tests/compiler/valid/if_else.kt.out
+++ b/tests/compiler/valid/if_else.kt.out
@@ -1,9 +1,14 @@
 fun main() {
+        // let x = 5
+        // let x = 5
         val x = 5
-        if ((x > 3)) {
+        // if x > 3 {
+        // if x > 3 {
+        if (x > 3) {
+                // print("big")
                 println("big")
         } else {
+                // print("small")
                 println("small")
         }
 }
-

--- a/tests/compiler/valid/join.kt.out
+++ b/tests/compiler/valid/join.kt.out
@@ -1,19 +1,28 @@
+// type Customer {
 data class Customer(val id: Int, val name: String)
 
+// type Order {
 data class Order(val id: Int, val customerId: Int, val total: Int)
 
+// type PairInfo {
 data class PairInfo(val orderId: Int, val customerName: String, val total: Int)
 
 fun main() {
+        // let customers = [
+        // let customers = [
         val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+        // let orders = [
+        // let orders = [
         val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 4, total = 80))
+        // let result = from o in orders
+        // let result = from o in orders
         val result = run {
                 val _src = orders
                 val _rows = _query(_src, listOf(
                         _JoinSpec(items = customers, on = { args ->
                         val o = args[0]
                         val c = args[1]
-(o.customerId == c.id)
+o.customerId == c.id
                         }))
                 ), _QueryOpts(selectFn = { args ->
                         val o = args[0]
@@ -22,8 +31,12 @@ PairInfo(orderId = o.id, customerName = c.name, total = o.total)
                         }) )
                 _rows
         }
+        // print("--- Orders with customer info ---")
         println("--- Orders with customer info ---")
+        // for entry in result {
+        // for entry in result {
         for (entry in result) {
+                // print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
                 println("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
         }
 }
@@ -146,4 +159,3 @@ fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?
     }
     return res
 }
-

--- a/tests/compiler/valid/join_filter_pag.kt.out
+++ b/tests/compiler/valid/join_filter_pag.kt.out
@@ -1,17 +1,25 @@
+// type Person { id: int, name: string }
 data class Person(val id: Int, val name: String)
 
+// type Purchase { id: int, personId: int, total: int }
 data class Purchase(val id: Int, val personId: Int, val total: Int)
 
 fun main() {
+        // let people = [
+        // let people = [
         val people = listOf(Person(id = 1, name = "Alice"), Person(id = 2, name = "Bob"), Person(id = 3, name = "Charlie"))
+        // let purchases = [
+        // let purchases = [
         val purchases = listOf(Purchase(id = 1, personId = 1, total = 200), Purchase(id = 2, personId = 1, total = 50), Purchase(id = 3, personId = 2, total = 150), Purchase(id = 4, personId = 3, total = 100), Purchase(id = 5, personId = 2, total = 250))
+        // let result = from p in people
+        // let result = from p in people
         val result = run {
                 val _src = people
                 val _rows = _query(_src, listOf(
                         _JoinSpec(items = purchases, on = { args ->
                         val p = args[0]
                         val o = args[1]
-(p.id == o.personId)
+p.id == o.personId
                         }))
                 ), _QueryOpts(selectFn = { args ->
                         val p = args[0]
@@ -20,7 +28,7 @@ mutableMapOf("person" to p.name, "spent" to o.total)
                         }, where = { args ->
                         val p = args[0]
                         val o = args[1]
-(o.total > 100)
+o.total > 100
                         }, sortKey = { args ->
                         val p = args[0]
                         val o = args[1]
@@ -28,7 +36,10 @@ mutableMapOf("person" to p.name, "spent" to o.total)
                         }, skip = 1, take = 2) )
                 _rows
         }
+        // for r in result {
+        // for r in result {
         for (r in result) {
+                // print(r.person, r.spent)
                 println(r.person, r.spent)
         }
 }
@@ -151,4 +162,3 @@ fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?
     }
     return res
 }
-

--- a/tests/compiler/valid/len_builtin.kt.out
+++ b/tests/compiler/valid/len_builtin.kt.out
@@ -1,4 +1,4 @@
 fun main() {
+        // print(len([1,2,3]))
         println(listOf(1, 2, 3).size)
 }
-

--- a/tests/compiler/valid/let_and_print.kt.out
+++ b/tests/compiler/valid/let_and_print.kt.out
@@ -1,6 +1,10 @@
 fun main() {
+        // let a = 10
+        // let a = 10
         val a = 10
+        // let b: int = 20
+        // let b: int = 20
         val b: Int = 20
-        println((a + b))
+        // print(a + b)
+        println(a + b)
 }
-

--- a/tests/compiler/valid/list_index.kt.out
+++ b/tests/compiler/valid/list_index.kt.out
@@ -1,5 +1,7 @@
 fun main() {
+        // let xs = [10, 20, 30]
+        // let xs = [10, 20, 30]
         val xs = listOf(10, 20, 30)
+        // print(xs[1])
         println(xs[1])
 }
-

--- a/tests/compiler/valid/list_set.kt.out
+++ b/tests/compiler/valid/list_set.kt.out
@@ -1,11 +1,14 @@
 fun main() {
+        // var nums = [1, 2]
+        // var nums = [1, 2]
         var nums = listOf(1, 2)
+        // nums[1] = 3
+        // nums[1] = 3
         run {
                 val _tmp = nums.toMutableList()
                 _tmp[1] = 3
                 nums = _tmp
         }
+        // print(nums[1])
         println(nums[1])
 }
-
-

--- a/tests/compiler/valid/local_recursion.kt.out
+++ b/tests/compiler/valid/local_recursion.kt.out
@@ -1,18 +1,21 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun fromList(nums: list<int>): Tree {
 fun fromList(nums: List<Int>) : Tree {
         fun helper(lo: Int, hi: Int) : Tree {
-                if ((lo >= hi)) {
+                if (lo >= hi) {
                         return Leaf()
                 }
-                val mid = (((lo + hi)) / 2)
-                return Node(left = helper(lo, mid), value = nums[mid], right = helper((mid + 1), hi))
+                val mid = (lo + hi) / 2
+                return Node(left = helper(lo, mid), value = nums[mid], right = helper(mid + 1, hi))
         }
         return helper(0, nums.size)
 }
 
+// fun inorder(t: Tree): list<int> {
 fun inorder(t: Tree) : List<Int> {
         return run {
                 val _t = t
@@ -29,8 +32,8 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
+        // print(inorder(fromList([-10, -3, 0, 5, 9])))
         println(inorder(fromList(listOf(-10, -3, 0, 5, 9))))
 }
 
 fun <T> _concat(a: List<T>, b: List<T>): List<T> = a + b
-

--- a/tests/compiler/valid/map_index.kt.out
+++ b/tests/compiler/valid/map_index.kt.out
@@ -1,5 +1,7 @@
 fun main() {
+        // let scores = {"Alice": 10, "Bob": 15}
+        // let scores = {"Alice": 10, "Bob": 15}
         val scores = mutableMapOf("Alice" to 10, "Bob" to 15)
+        // print(scores["Bob"])
         println(scores["Bob"])
 }
-

--- a/tests/compiler/valid/map_iterate.kt.out
+++ b/tests/compiler/valid/map_iterate.kt.out
@@ -1,20 +1,31 @@
 fun main() {
+        // var m: map<int, bool> = {}
+        // var m: map<int, bool> = {}
         var m: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
+        // m[1] = true
+        // m[1] = true
         run {
                 val _tmp = m.toMutableMap()
                 _tmp[1] = true
                 m = _tmp
         }
+        // m[2] = true
+        // m[2] = true
         run {
                 val _tmp = m.toMutableMap()
                 _tmp[2] = true
                 m = _tmp
         }
+        // var sum = 0
+        // var sum = 0
         var sum = 0
+        // for k in m {
+        // for k in m {
         for (k in m.keys) {
-                sum = (sum + k)
+                // sum = sum + k
+                // sum = sum + k
+                sum = sum + k
         }
+        // print(sum)
         println(sum)
 }
-
-

--- a/tests/compiler/valid/map_ops.kt.out
+++ b/tests/compiler/valid/map_ops.kt.out
@@ -1,19 +1,27 @@
 fun main() {
+        // var m: map<int, int> = {}
+        // var m: map<int, int> = {}
         var m: MutableMap<Int, Int> = mutableMapOf<Any, Any>()
+        // m[1] = 10
+        // m[1] = 10
         run {
                 val _tmp = m.toMutableMap()
                 _tmp[1] = 10
                 m = _tmp
         }
+        // m[2] = 20
+        // m[2] = 20
         run {
                 val _tmp = m.toMutableMap()
                 _tmp[2] = 20
                 m = _tmp
         }
+        // if 1 in m {
+        // if 1 in m {
         if (m.contains(1)) {
+                // print(m[1])
                 println(m[1])
         }
+        // print(m[2])
         println(m[2])
 }
-
-

--- a/tests/compiler/valid/map_set.kt.out
+++ b/tests/compiler/valid/map_set.kt.out
@@ -1,11 +1,14 @@
 fun main() {
+        // var scores = {"a": 1}
+        // var scores = {"a": 1}
         var scores = mutableMapOf("a" to 1)
+        // scores["b"] = 2
+        // scores["b"] = 2
         run {
                 val _tmp = scores.toMutableMap()
                 _tmp["b"] = 2
                 scores = _tmp
         }
+        // print(scores["b"])
         println(scores["b"])
 }
-
-

--- a/tests/compiler/valid/match_expr.kt.out
+++ b/tests/compiler/valid/match_expr.kt.out
@@ -1,5 +1,9 @@
 fun main() {
+        // let x = 2
+        // let x = 2
         val x = 2
+        // let label = match x {
+        // let label = match x {
         val label = run {
                 val _t = x
                 when {
@@ -9,6 +13,6 @@ fun main() {
                         else -> "unknown"
                 }
         }
+        // print(label)
         println(label)
 }
-

--- a/tests/compiler/valid/print_hello.kt.out
+++ b/tests/compiler/valid/print_hello.kt.out
@@ -1,4 +1,4 @@
 fun main() {
+        // print("hello")
         println("hello")
 }
-

--- a/tests/compiler/valid/stream_on_emit.kt.out
+++ b/tests/compiler/valid/stream_on_emit.kt.out
@@ -1,12 +1,19 @@
 fun main() {
+        // stream Sensor {
+        // stream Sensor {
         data class Sensor(val id: String, val temperature: Double)
         
         var _SensorStream = _Stream<Sensor>("Sensor")
+        // on Sensor as s {
+        // on Sensor as s {
         fun _handler_0(ev: Sensor) {
                 val s = ev
+                // print(s.id, s.temperature)
                 println(s.id, s.temperature)
         }
         _SensorStream.register(::_handler_0)
+        // emit Sensor { id: "sensor-1", temperature: 22.5 }
+        // emit Sensor { id: "sensor-1", temperature: 22.5 }
         _SensorStream.append(Sensor(id = "sensor-1", temperature = 22.5))
 }
 
@@ -17,4 +24,3 @@ class _Stream<T>(val name: String) {
     }
     fun register(handler: (T) -> Unit) { handlers.add(handler) }
 }
-

--- a/tests/compiler/valid/string_index.kt.out
+++ b/tests/compiler/valid/string_index.kt.out
@@ -1,5 +1,8 @@
 fun main() {
+        // let text = "hello"
+        // let text = "hello"
         val text = "hello"
+        // print(text[1])
         println(_indexString(text, 1))
 }
 
@@ -10,4 +13,3 @@ fun _indexString(s: String, i: Int): String {
     if (idx < 0 || idx >= arr.size) throw RuntimeException("index out of range")
     return arr[idx].toString()
 }
-

--- a/tests/compiler/valid/test_block.kt.out
+++ b/tests/compiler/valid/test_block.kt.out
@@ -1,11 +1,14 @@
+// test "addition works" {
 fun test_addition_works() {
-        val x = (1 + 2)
-        check((x == 3))
+        // let x = 1 + 2
+        // let x = 1 + 2
+        val x = 1 + 2
+        // expect x == 3
+        check(x == 3)
 }
 
 fun main() {
+        // print("ok")
         println("ok")
         test_addition_works()
 }
-
-

--- a/tests/compiler/valid/two_sum.kt.out
+++ b/tests/compiler/valid/two_sum.kt.out
@@ -1,8 +1,9 @@
+// fun twoSum(nums: list<int>, target: int): list<int> {
 fun twoSum(nums: List<Int>, target: Int) : List<Int> {
         val n = nums.size
         for (i in 0 until n) {
-                for (j in (i + 1) until n) {
-                        if (((nums[i] + nums[j]) == target)) {
+                for (j in i + 1 until n) {
+                        if (nums[i] + nums[j] == target) {
                                 return listOf(i, j)
                         }
                 }
@@ -11,8 +12,11 @@ fun twoSum(nums: List<Int>, target: Int) : List<Int> {
 }
 
 fun main() {
+        // let result = twoSum([2,7,11,15], 9)
+        // let result = twoSum([2,7,11,15], 9)
         val result = twoSum(listOf(2, 7, 11, 15), 9)
+        // print(result[0])
         println(result[0])
+        // print(result[1])
         println(result[1])
 }
-

--- a/tests/compiler/valid/union_inorder.kt.out
+++ b/tests/compiler/valid/union_inorder.kt.out
@@ -1,7 +1,9 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun inorder(t: Tree): list<int> {
 fun inorder(t: Tree) : List<Int> {
         return run {
                 val _t = t
@@ -18,8 +20,8 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
+        // print(inorder(Node { left: Leaf {}, value: 1, right: Node { left: Leaf {}, value: 2, right: Leaf {} } }))
         println(inorder(Node(left = Leaf(), value = 1, right = Node(left = Leaf(), value = 2, right = Leaf()))))
 }
 
 fun <T> _concat(a: List<T>, b: List<T>): List<T> = a + b
-

--- a/tests/compiler/valid/union_match.kt.out
+++ b/tests/compiler/valid/union_match.kt.out
@@ -1,7 +1,9 @@
+// type Tree =
 sealed interface Tree
 data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
+// fun isLeaf(t: Tree): bool {
 fun isLeaf(t: Tree) : Boolean {
         return run {
                 val _t = t
@@ -13,8 +15,8 @@ fun isLeaf(t: Tree) : Boolean {
 }
 
 fun main() {
+        // print(isLeaf(Leaf {}))
         println(isLeaf(Leaf()))
+        // print(isLeaf(Node { left: Leaf {}, value: 1, right: Leaf {} }))
         println(isLeaf(Node(left = Leaf(), value = 1, right = Leaf())))
 }
-
-

--- a/tests/compiler/valid/union_slice.kt.out
+++ b/tests/compiler/valid/union_slice.kt.out
@@ -1,13 +1,14 @@
+// type Foo =
 sealed interface Foo
 data class Empty() : Foo
 data class Node(val child: Foo) : Foo
 
+// fun listit(): list<Foo> {
 fun listit() : List<Foo> {
         return listOf(Empty())
 }
 
 fun main() {
+        // print(len(listit()))
         println(listit().size)
 }
-
-

--- a/tests/compiler/valid/var_assignment.kt.out
+++ b/tests/compiler/valid/var_assignment.kt.out
@@ -1,6 +1,10 @@
 fun main() {
+        // var x = 1
+        // var x = 1
         var x = 1
+        // x = 2
+        // x = 2
         x = 2
+        // print(x)
         println(x)
 }
-

--- a/tests/compiler/valid/while_loop.kt.out
+++ b/tests/compiler/valid/while_loop.kt.out
@@ -1,8 +1,14 @@
 fun main() {
+        // var i = 0
+        // var i = 0
         var i = 0
-        while ((i < 3)) {
+        // while i < 3 {
+        // while i < 3 {
+        while (i < 3) {
+                // print(i)
                 println(i)
-                i = (i + 1)
+                // i = i + 1
+                // i = i + 1
+                i = i + 1
         }
 }
-


### PR DESCRIPTION
## Summary
- tweak Kotlin backend to drop unneeded parentheses around binary expressions
- update Kotlin golden files
- capture original source lines and emit them as comments before generated code

## Testing
- `go test ./compile/x/kt -tags slow -run TestKTCompiler_GoldenOutput -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d6cc157bc8320802ad57792e76f52