### PR TITLE
Add register analysis utilities for VM

### DIFF
--- a/runtime/vm/regopt.go
+++ b/runtime/vm/regopt.go
@@ -1,0 +1,113 @@
+package vm
+
+import "strings"
+
+// Lifetime represents the start and end instruction index for a register.
+type Lifetime struct {
+	Start int // instruction index where register is first used or defined
+	End   int // instruction index of last use
+}
+
+// RegUsage returns a histogram of register usage counts for fn.
+func RegUsage(fn *Function) []int {
+	usage := make([]int, fn.NumRegs)
+	for _, ins := range fn.Code {
+		for _, r := range regsForInstr(ins) {
+			if r >= 0 && r < fn.NumRegs {
+				usage[r]++
+			}
+		}
+	}
+	return usage
+}
+
+// RegLifetimes returns the lifetime for each register in fn.
+func RegLifetimes(fn *Function) []Lifetime {
+	life := make([]Lifetime, fn.NumRegs)
+	for i := range life {
+		life[i] = Lifetime{Start: -1, End: -1}
+	}
+	for pc, ins := range fn.Code {
+		for _, r := range regsForInstr(ins) {
+			if r < 0 || r >= fn.NumRegs {
+				continue
+			}
+			lt := &life[r]
+			if lt.Start == -1 {
+				lt.Start = pc
+			}
+			lt.End = pc
+		}
+	}
+	return life
+}
+
+// InterferenceGraph builds a simple interference graph for the given lifetimes.
+// The result is an adjacency matrix g where g[i][j] is true if lifetimes i and j overlap.
+func InterferenceGraph(lifetimes []Lifetime) [][]bool {
+	n := len(lifetimes)
+	g := make([][]bool, n)
+	for i := range g {
+		g[i] = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if lifetimesOverlap(lifetimes[i], lifetimes[j]) {
+				g[i][j] = true
+				g[j][i] = true
+			}
+		}
+	}
+	return g
+}
+
+// VisualizeRegUsage returns an ASCII visualization of register lifetimes.
+// Each register is shown on its own line with a bar spanning from start to end.
+func VisualizeRegUsage(fn *Function) string {
+	life := RegLifetimes(fn)
+	var out strings.Builder
+	for r, lt := range life {
+		out.WriteString(formatReg(r))
+		out.WriteString(": ")
+		for i := 0; i < len(fn.Code); i++ {
+			if i >= lt.Start && i <= lt.End && lt.Start != -1 {
+				out.WriteRune('#')
+			} else {
+				out.WriteRune('.')
+			}
+		}
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+// lifetimesOverlap returns true if a and b overlap.
+func lifetimesOverlap(a, b Lifetime) bool {
+	if a.Start == -1 || b.Start == -1 {
+		return false
+	}
+	return a.Start <= b.End && b.Start <= a.End
+}
+
+// regsForInstr returns all register indices referenced by ins.
+func regsForInstr(ins Instr) []int {
+	switch ins.Op {
+	case OpJump:
+		// Jump uses only A as target label, not a register
+		return nil
+	}
+	regs := []int{}
+	if ins.A >= 0 {
+		regs = append(regs, ins.A)
+	}
+	if ins.B >= 0 {
+		regs = append(regs, ins.B)
+	}
+	if ins.C >= 0 {
+		regs = append(regs, ins.C)
+	}
+	if ins.D >= 0 {
+		regs = append(regs, ins.D)
+	}
+	return regs
+}

--- a/tools/vmregs/main.go
+++ b/tools/vmregs/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: vmregs <file.mochi>")
+		os.Exit(1)
+	}
+	for _, path := range os.Args[1:] {
+		prog, err := parser.Parse(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "%s: type error: %v\n", path, errs[0])
+			continue
+		}
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: compile error: %v\n", path, err)
+			continue
+		}
+		fmt.Printf("== %s ==\n", path)
+		for i := range p.Funcs {
+			fn := &p.Funcs[i]
+			usage := vm.RegUsage(fn)
+			life := vm.RegLifetimes(fn)
+			graph := vm.InterferenceGraph(life)
+			fmt.Printf("-- function %s (regs=%d) --\n", p.Funcs[i].Name, fn.NumRegs)
+			fmt.Println("usage:", usage)
+			fmt.Println("lifetimes:", life)
+			fmt.Println("interference:")
+			for r, row := range graph {
+				fmt.Printf("r%d:", r)
+				for _, edge := range row {
+					if edge {
+						fmt.Print(" #")
+					} else {
+						fmt.Print(" .")
+					}
+				}
+				fmt.Println()
+			}
+			fmt.Println("diagram:")
+			fmt.Print(vm.VisualizeRegUsage(fn))
+		}
+	}
+}

--- a/tools/vmtrace/main.go
+++ b/tools/vmtrace/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: vmtrace <file.mochi>")
+		os.Exit(1)
+	}
+
+	for _, path := range os.Args[1:] {
+		prog, err := parser.Parse(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			fmt.Fprintf(os.Stderr, "%s: type error: %v\n", path, errs[0])
+			continue
+		}
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: compile error: %v\n", path, err)
+			continue
+		}
+		steps, err := vm.Trace(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: runtime error: %v\n", path, err)
+			continue
+		}
+		for _, s := range steps {
+			fmt.Printf("%s:%d\t%-12s %v\n", s.Func, s.PC, s.Instr.Op, s.Regs)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement register usage histogram, lifetimes and interference graph
- add ASCII visualization of register usage
- add `vmregs` tool to run analysis on Mochi programs
- add Trace utilities and `vmtrace` tool to capture execution with step over

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d7c4447308320b14bf2e0cf4bdc58