### PR TITLE
Add Cosmopolitan Libc tooling

### DIFF
--- a/cmd/mochi-cosmo/main.go
+++ b/cmd/mochi-cosmo/main.go
@@ -1,0 +1,53 @@
+//go:build cosmo
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ccode "mochi/compile/x/c"
+	"mochi/parser"
+	"mochi/tools/cosmo"
+	"mochi/types"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: mochi-cosmo <file.mochi> [output]")
+		os.Exit(1)
+	}
+	input := os.Args[1]
+	out := ""
+	if len(os.Args) > 2 {
+		out = os.Args[2]
+	} else {
+		out = strings.TrimSuffix(filepath.Base(input), filepath.Ext(input))
+	}
+
+	prog, err := parser.Parse(input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parse:", err)
+		os.Exit(1)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, e)
+		}
+		os.Exit(1)
+	}
+
+	code, err := ccode.New(env).Compile(prog)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile:", err)
+		os.Exit(1)
+	}
+
+	if err := cosmo.CompileToFile(string(code), out); err != nil {
+		fmt.Fprintln(os.Stderr, "cosmo:", err)
+		os.Exit(1)
+	}
+}

--- a/runtime/cosmo/Makefile
+++ b/runtime/cosmo/Makefile
@@ -1,0 +1,19 @@
+COSMO_TOOLS := ../../tools/cosmo
+BIN := ../../bin/mochi-cosmo
+
+.PHONY: all build clean linux windows
+
+all: build
+
+build:
+	go build -tags 'cosmo' -o $(BIN) ../../cmd/mochi-cosmo
+	@echo "Built $(BIN)"
+
+linux:
+	GOOS=linux GOARCH=amd64 go build -tags 'cosmo' -o $(BIN)-linux ../../cmd/mochi-cosmo
+
+windows:
+	GOOS=windows GOARCH=amd64 go build -tags 'cosmo' -o $(BIN)-win.exe ../../cmd/mochi-cosmo
+
+clean:
+	rm -f $(BIN) $(BIN)-linux $(BIN)-win.exe

--- a/tools/cosmo/Makefile
+++ b/tools/cosmo/Makefile
@@ -1,0 +1,15 @@
+COSMOCC := cosmocc
+
+.PHONY: run test clean ensure
+
+ensure:
+	go run ./tools.go
+
+run: ensure
+	go run -tags cosmo ./main.go
+
+test: ensure
+	go test -tags cosmo
+
+clean:
+	rm -f bin/cosmocc

--- a/tools/cosmo/README.md
+++ b/tools/cosmo/README.md
@@ -1,0 +1,30 @@
+# Cosmopolitan Libc Integration
+
+This folder demonstrates using [Cosmopolitan Libc](https://justine.lol/cosmopolitan/) from Go. It mirrors `tools/tcc` but relies on the `cosmocc` compiler provided by the Cosmo toolchain.
+
+## 1. Install Cosmo
+
+`tools.go` provides a helper that downloads `cosmocc` when missing. From the repository root run:
+
+```bash
+go run ./tools/cosmo/tools.go
+```
+
+This attempts to fetch `cosmocc` with `curl` or `wget`. Once available, `make run` executes the example and `make test` runs the tests with Cosmo enabled.
+
+## 2. Compile and run C snippets
+
+The library exposes helpers to compile C code using `cosmocc`. `CompileAndRun` writes the program to a temporary file, builds a static binary and executes it.
+
+## 3. `mochi-cosmo`
+
+The command `mochi-cosmo` compiles a `.mochi` source file to C using the built‑in C backend and then uses `cosmocc` to produce a static executable:
+
+```bash
+go build -tags cosmo -o mochi-cosmo ./cmd/mochi-cosmo
+./mochi-cosmo hello.mochi hello
+```
+
+## 4. Tests
+
+Run `go test -tags cosmo` in this directory once `cosmocc` is installed to verify the Cosmo integration.

--- a/tools/cosmo/cosmo.go
+++ b/tools/cosmo/cosmo.go
@@ -1,0 +1,53 @@
+//go:build cosmo
+
+package cosmo
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+// CompileAndRun compiles the provided C snippet with cosmocc and executes the resulting binary.
+// The program's stdout is returned.
+func CompileAndRun(code string) (string, error) {
+	src, err := ioutil.TempFile("", "cosmo-*.c")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(src.Name())
+	if _, err := src.WriteString(code); err != nil {
+		src.Close()
+		return "", err
+	}
+	src.Close()
+	out := src.Name() + ".bin"
+	cmd := exec.Command("cosmocc", "-static", "-o", out, src.Name())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	defer os.Remove(out)
+	runCmd := exec.Command(out)
+	outBytes, err := runCmd.CombinedOutput()
+	return string(outBytes), err
+}
+
+// CompileToFile compiles the C source code and writes the resulting binary to the given output path.
+func CompileToFile(code, output string) error {
+	tmp, err := ioutil.TempFile("", "cosmo-*.c")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(code); err != nil {
+		tmp.Close()
+		return err
+	}
+	tmp.Close()
+	cmd := exec.Command("cosmocc", "-static", "-o", output, tmp.Name())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/tools/cosmo/cosmo_stub.go
+++ b/tools/cosmo/cosmo_stub.go
@@ -1,0 +1,18 @@
+//go:build !cosmo
+
+package cosmo
+
+import "errors"
+
+// CompileAndRun is unavailable when Cosmopolitan is not enabled.
+func CompileAndRun(code string) (string, error) {
+	return "", ErrCosmoUnavailable
+}
+
+// CompileToFile is unavailable when cosmocc is missing.
+func CompileToFile(code, output string) error {
+	return ErrCosmoUnavailable
+}
+
+// ErrCosmoUnavailable indicates the Cosmo toolchain was not found.
+var ErrCosmoUnavailable = errors.New("Cosmopolitan not available; build with tag 'cosmo'")

--- a/tools/cosmo/cosmo_test.go
+++ b/tools/cosmo/cosmo_test.go
@@ -1,0 +1,16 @@
+//go:build cosmo
+
+package cosmo
+
+import "testing"
+
+func TestCompileAndRun(t *testing.T) {
+	out, err := CompileAndRun(`#include <stdio.h>
+int main(){printf("%d", 5*5);return 0;}`)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if out != "25" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}

--- a/tools/cosmo/ensure.go
+++ b/tools/cosmo/ensure.go
@@ -1,0 +1,43 @@
+package cosmo
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// EnsureCosmo verifies that the cosmocc compiler is installed. It attempts a
+// best-effort download using curl or wget if possible.
+func EnsureCosmo() error {
+	if _, err := exec.LookPath("cosmocc"); err == nil {
+		return nil
+	}
+	url := "https://justine.lol/cosmopolitan/cosmocc"
+	binDir := filepath.Join("bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return err
+	}
+	dst := filepath.Join(binDir, "cosmocc")
+	var cmd *exec.Cmd
+	if _, err := exec.LookPath("curl"); err == nil {
+		cmd = exec.Command("curl", "-fLo", dst, url)
+	} else if _, err := exec.LookPath("wget"); err == nil {
+		cmd = exec.Command("wget", "-O", dst, url)
+	}
+	if cmd != nil {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err == nil {
+			_ = os.Chmod(dst, 0o755)
+		}
+	}
+	if p, err := exec.LookPath("cosmocc"); err == nil {
+		if runtime.GOOS != "windows" {
+			return os.Symlink(p, filepath.Join(binDir, "cosmocc"))
+		}
+		return nil
+	}
+	return fmt.Errorf("cosmocc not found")
+}

--- a/tools/cosmo/main.go
+++ b/tools/cosmo/main.go
@@ -1,0 +1,20 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+
+	"mochi/tools/cosmo"
+)
+
+func main() {
+	out, err := cosmo.CompileAndRun(`
+#include <stdio.h>
+int main() { printf("%d", 5 * 5); return 0; }
+`)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(out)
+}

--- a/tools/cosmo/tools.go
+++ b/tools/cosmo/tools.go
@@ -1,0 +1,15 @@
+//go:build ignore
+
+package main
+
+import (
+	"log"
+
+	"mochi/tools/cosmo"
+)
+
+func main() {
+	if err := cosmo.EnsureCosmo(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `tools/cosmo` inspired by `tools/tcc` to compile C via cosmocc
- provide `mochi-cosmo` command and runtime makefile
- document Cosmopolitan usage

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685df3b85c5083208fa98a69824d903b