### PR TITLE
Add Cosmopolitan Libc integration

### DIFF
--- a/cmd/mochi-cosmo/main.go
+++ b/cmd/mochi-cosmo/main.go
@@ -1,0 +1,53 @@
+//go:build cosmo
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ccode "mochi/compile/x/c"
+	"mochi/parser"
+	"mochi/tools/cosmo"
+	"mochi/types"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: mochi-cosmo <file.mochi> [output]")
+		os.Exit(1)
+	}
+	input := os.Args[1]
+	out := ""
+	if len(os.Args) > 2 {
+		out = os.Args[2]
+	} else {
+		out = strings.TrimSuffix(filepath.Base(input), filepath.Ext(input))
+	}
+
+	prog, err := parser.Parse(input)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parse:", err)
+		os.Exit(1)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, e)
+		}
+		os.Exit(1)
+	}
+
+	code, err := ccode.New(env).Compile(prog)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compile:", err)
+		os.Exit(1)
+	}
+
+	if err := cosmo.CompileToFile(string(code), out); err != nil {
+		fmt.Fprintln(os.Stderr, "cosmocc:", err)
+		os.Exit(1)
+	}
+}

--- a/runtime/cosmo/Makefile
+++ b/runtime/cosmo/Makefile
@@ -1,0 +1,22 @@
+COSMO_TOOLS := ../../tools/cosmo
+BIN := ../../bin/mochi-cosmo
+
+.PHONY: all build clean linux windows macos
+
+all: build
+
+build:
+go build -tags cosmo -o $(BIN) ../../cmd/mochi-cosmo
+@echo "Built $(BIN)"
+
+linux:
+GOOS=linux GOARCH=amd64 go build -tags cosmo -o $(BIN)-linux ../../cmd/mochi-cosmo
+
+windows:
+GOOS=windows GOARCH=amd64 go build -tags cosmo -o $(BIN)-win.exe ../../cmd/mochi-cosmo
+
+macos:
+GOOS=darwin GOARCH=amd64 go build -tags cosmo -o $(BIN)-macos ../../cmd/mochi-cosmo
+
+clean:
+rm -f $(BIN) $(BIN)-linux $(BIN)-win.exe $(BIN)-macos

--- a/tools/cosmo/Makefile
+++ b/tools/cosmo/Makefile
@@ -1,0 +1,10 @@
+.PHONY: run test ensure
+
+ensure:
+go run ./tools.go
+
+run:
+go run -tags cosmo ./main.go
+
+test:
+go test -tags cosmo

--- a/tools/cosmo/README.md
+++ b/tools/cosmo/README.md
@@ -1,0 +1,37 @@
+# Cosmopolitan Libc Integration
+
+This package demonstrates how to use [Cosmopolitan Libc](https://justine.lol/cosmopolitan/) from Go.
+It mirrors the TinyCC example under `tools/tcc` but relies on the `cosmocc` compiler to produce
+portable binaries.
+
+## Installing cosmocc
+
+`cosmocc` is a standalone cross compiler distributed as a prebuilt archive.
+The helper `EnsureCosmo` will download the latest release for Linux,
+Windows and macOS automatically when needed.
+Alternatively you can download it manually from
+[the official website](https://justine.lol/cosmopolitan/download.html)
+and place the `cosmocc` binary somewhere in your `PATH`.
+
+```go
+// EnsureCosmo verifies that the cosmocc compiler is installed.
+// It downloads the official archive and extracts the binary when missing.
+func EnsureCosmo() error { /* ... */ }
+```
+
+Once installed you can run the example with:
+
+```bash
+make run
+```
+
+and execute the tests with:
+
+```bash
+make test
+```
+
+## `mochi-cosmo`
+
+The command `mochi-cosmo` works like `mochi-tcc`: it compiles a `.mochi` program to
+C and then uses `cosmocc` to build a native executable.

--- a/tools/cosmo/cosmo.go
+++ b/tools/cosmo/cosmo.go
@@ -1,0 +1,58 @@
+//go:build cosmo
+
+package cosmo
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// CompileAndRun compiles the given C code using cosmocc and
+// returns its standard output.
+func CompileAndRun(code string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "cosmo")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+	src := filepath.Join(tmpDir, "prog.c")
+	if err := os.WriteFile(src, []byte(code), 0644); err != nil {
+		return "", err
+	}
+	exe := filepath.Join(tmpDir, "a.out")
+	cmd := exec.Command("cosmocc", src, "-o", exe, "-static", "-s")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	out, err := exec.Command(exe).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(out)), nil
+}
+
+// CompileToFile compiles the source code to the given output path using cosmocc.
+func CompileToFile(code, out string) error {
+	tmp, err := os.CreateTemp("", "cosmo-*.c")
+	if err != nil {
+		return err
+	}
+	src := tmp.Name()
+	if _, err := tmp.Write([]byte(code)); err != nil {
+		tmp.Close()
+		return err
+	}
+	tmp.Close()
+	defer os.Remove(src)
+	cmd := exec.Command("cosmocc", src, "-o", out, "-static", "-s")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tools/cosmo/cosmo_stub.go
+++ b/tools/cosmo/cosmo_stub.go
@@ -1,0 +1,11 @@
+//go:build !cosmo
+
+package cosmo
+
+import "errors"
+
+// ErrCosmoUnavailable is returned when cosmocc isn't present.
+var ErrCosmoUnavailable = errors.New("Cosmopolitan compiler not available; build with tags 'cosmo'")
+
+func CompileAndRun(code string) (string, error) { return "", ErrCosmoUnavailable }
+func CompileToFile(code, out string) error      { return ErrCosmoUnavailable }

--- a/tools/cosmo/cosmo_test.go
+++ b/tools/cosmo/cosmo_test.go
@@ -1,0 +1,19 @@
+//go:build cosmo
+
+package cosmo
+
+import "testing"
+
+func TestCompileAndRun(t *testing.T) {
+	if err := EnsureCosmo(); err != nil {
+		t.Skipf("cosmocc not available: %v", err)
+	}
+	out, err := CompileAndRun(`#include <stdio.h>
+int main(){printf("%d",25);}`)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if out != "25" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}

--- a/tools/cosmo/ensure.go
+++ b/tools/cosmo/ensure.go
@@ -1,0 +1,100 @@
+package cosmo
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+const cosmoVersion = "4.0.2"
+const cosmoURL = "https://justine.lol/cosmopolitan/cosmocc-" + cosmoVersion + ".zip"
+
+// EnsureCosmo verifies that the cosmocc compiler is installed. If it isn't
+// present in PATH, the prebuilt archive is downloaded and the binary extracted.
+func EnsureCosmo() error {
+	if _, err := exec.LookPath("cosmocc"); err == nil {
+		return nil
+	}
+	fmt.Printf("\U0001F534 Downloading cosmocc %s...\n", cosmoVersion)
+	resp, err := http.Get(cosmoURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %s", resp.Status)
+	}
+	tmpZip, err := os.CreateTemp("", "cosmocc-*.zip")
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(tmpZip, resp.Body); err != nil {
+		tmpZip.Close()
+		return err
+	}
+	tmpZip.Close()
+	defer os.Remove(tmpZip.Name())
+
+	r, err := zip.OpenReader(tmpZip.Name())
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	binName := "cosmocc"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	var extracted string
+	for _, f := range r.File {
+		if filepath.Base(f.Name) == binName {
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+			tmpBin, err := os.CreateTemp("", binName)
+			if err != nil {
+				rc.Close()
+				return err
+			}
+			if _, err := io.Copy(tmpBin, rc); err != nil {
+				rc.Close()
+				tmpBin.Close()
+				return err
+			}
+			rc.Close()
+			tmpBin.Close()
+			if err := os.Chmod(tmpBin.Name(), 0755); err != nil {
+				return err
+			}
+			extracted = tmpBin.Name()
+			break
+		}
+	}
+	if extracted == "" {
+		return fmt.Errorf("%s not found in archive", binName)
+	}
+
+	target := filepath.Join("/usr/local/bin", binName)
+	if err := exec.Command("install", "-m", "755", extracted, target).Run(); err == nil {
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	dest := filepath.Join(home, "bin", binName)
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return err
+	}
+	if err := os.Rename(extracted, dest); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tools/cosmo/main.go
+++ b/tools/cosmo/main.go
@@ -1,0 +1,18 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+
+	"mochi/tools/cosmo"
+)
+
+func main() {
+	out, err := cosmo.CompileAndRun(`#include <stdio.h>
+int main(){printf("%d",5*5);}`)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+}

--- a/tools/cosmo/tools.go
+++ b/tools/cosmo/tools.go
@@ -1,0 +1,15 @@
+//go:build ignore
+
+package main
+
+import (
+	"log"
+
+	"mochi/tools/cosmo"
+)
+
+func main() {
+	if err := cosmo.EnsureCosmo(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `tools/cosmo` mirroring TinyCC integration
- add `mochi-cosmo` command using cosmocc
- include runtime Makefile for building the command
- automatically download cosmocc in `EnsureCosmo`
- allow cross-compilation for macOS

## Testing
- `go test ./... --vet=off`


------
https://chatgpt.com/codex/tasks/task_e_685df3b00d7c8320a4ed8598277fc594