### PR TITLE
Add TinyCC tests for C backend

### DIFF
--- a/compile/x/c/compiler_test.go
+++ b/compile/x/c/compiler_test.go
@@ -23,7 +23,7 @@ func TestCCompiler_TwoSum(t *testing.T) {
 	if err != nil {
 		t.Skipf("C compiler not installed: %v", err)
 	}
-	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+       src := filepath.Join("..", "..", "..", "examples", "leetcode", "1", "two-sum.mochi")
 	prog, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
@@ -37,7 +37,7 @@ func TestCCompiler_TwoSum(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}
-	goldenPath := filepath.Join("..", "..", "tests", "compiler", "valid", "two_sum.c.out")
+       goldenPath := filepath.Join("..", "..", "..", "tests", "compiler", "valid", "two_sum.c.out")
 	golden, err := os.ReadFile(goldenPath)
 	if err != nil {
 		t.Fatalf("read golden: %v", err)

--- a/compile/x/c/tcc_test.go
+++ b/compile/x/c/tcc_test.go
@@ -1,0 +1,60 @@
+//go:build slow && tcc && libtcc
+
+package ccode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ccode "mochi/compile/x/c"
+	"mochi/golden"
+	"mochi/parser"
+	"mochi/tools/tcc"
+	"mochi/types"
+)
+
+// TestTinyCCPrograms compiles example programs with the C backend and
+// executes them using TinyCC. It mirrors the regular C compiler tests
+// but uses the embedded TinyCC library instead of the system toolchain.
+func TestTinyCCPrograms(t *testing.T) {
+	if err := tcc.EnsureTCC(); err != nil {
+		t.Skipf("TinyCC not installed: %v", err)
+	}
+
+	run := func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("\u274c parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("\u274c type error: %v", errs[0])
+		}
+		code, err := ccode.New(env).Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("\u274c compile error: %w", err)
+		}
+		dir := t.TempDir()
+		exe := filepath.Join(dir, "prog")
+		if err := tcc.CompileToFile(string(code), exe); err != nil {
+			return nil, fmt.Errorf("\u274c tcc error: %w", err)
+		}
+		cmd := exec.Command(exe)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("\u274c run error: %w\n%s", err, out)
+		}
+		return bytes.TrimSpace(out), nil
+	}
+
+	golden.Run(t, "tests/compiler/valid", ".mochi", ".out", run)
+	golden.Run(t, "tests/compiler/c", ".mochi", ".out", run)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -316,7 +316,7 @@ type BinaryExpr struct {
 type BinaryOp struct {
 	Pos   lexer.Position
 	Op    string       `parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | 'in' | '&&' | '||' | 'union' | 'except' | 'intersect')"`
-	All   bool         `parser:"[ 'all' ]"`
+       All   bool         `parser:"[ @'all' ]"`
 	Right *PostfixExpr `parser:"@@"`
 }
 


### PR DESCRIPTION
## Summary
- add a TinyCC test suite to run C backend output and compare against golden files
- fix path in `compiler_test.go`
- fix parser so `union all` is parsed correctly

## Testing
- `go test ./compile/x/c -tags "slow tcc libtcc" -run TestTinyCCPrograms/list_union_all -v`
- `go test ./compile/x/c -tags slow -run TestCCompiler_SubsetPrograms/list_union_all -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685df62c891083208522e341bc4894a4