### PR TITLE
Fix TinyCC toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,5 @@ tools/playground/wasm_exec.js
 **/*.egg-info/
 **/__pycache__/
 *.class
+tools/tcc/tcc/
+tools/tcc/tools/

--- a/tools/tcc/Makefile
+++ b/tools/tcc/Makefile
@@ -1,13 +1,16 @@
-TCC_DIR := tcc
+TCC_DIR := tools/tcc/tools/tcc/tcc
 LIB := $(TCC_DIR)/libtcc.a
+BIN := mochi-tcc
 
-.PHONY: libtcc run test clean ensure
+.PHONY: libtcc run test clean ensure mochi-tcc
 
 ensure:
 	go run ./tools.go
 
-libtcc: ensure
-	cd $(TCC_DIR) && ./configure --disable-static --enable-static && make libtcc.a
+$(LIB): ensure
+	cd $(TCC_DIR) && ./configure --enable-static && make libtcc.a
+
+libtcc: $(LIB)
 
 run: $(LIB)
 	go run -tags 'tcc libtcc' ./main.go
@@ -15,5 +18,9 @@ run: $(LIB)
 test: $(LIB)
 	go test -tags 'tcc libtcc'
 
+mochi-tcc: $(LIB)
+	go build -tags 'tcc libtcc' -o $(BIN) ../../cmd/mochi-tcc
+	@echo "Built $(BIN)"
+
 clean:
-	rm -f $(LIB)
+	rm -f $(LIB) $(BIN)

--- a/tools/tcc/README.md
+++ b/tools/tcc/README.md
@@ -75,7 +75,7 @@ C backend and then uses the embedded TinyCC library to produce a native executab
 is built from `cmd/mochi-tcc`:
 
 ```bash
-go build -tags "tcc libtcc" -o mochi-tcc ./cmd/mochi-tcc
+make mochi-tcc
 ./mochi-tcc hello.mochi hello
 ```
 
@@ -101,56 +101,29 @@ Linux or Windows executables.
 
 ## 7. Tools
 
-The tests rely on `EnsureTCC` to check for the TinyCC compiler and attempt to install it if missing:
+The tests rely on `EnsureTCC` to check for TinyCC. The helper first tries common
+package managers and, if that fails, downloads the TinyCC sources and builds
+`libtcc.a` locally:
 
 ```go
-// EnsureTCC verifies that the TinyCC compiler is installed. It attempts a
-// best-effort installation using common package managers on each platform.
 func EnsureTCC() error {
         if _, err := exec.LookPath("tcc"); err == nil {
-                return nil
-        }
-        switch runtime.GOOS {
-        case "darwin":
-                if _, err := exec.LookPath("brew"); err == nil {
-                        cmd := exec.Command("brew", "install", "tinycc")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        _ = cmd.Run()
-                }
-        case "linux":
-                if _, err := exec.LookPath("apt-get"); err == nil {
-                        cmd := exec.Command("apt-get", "update")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        if err := cmd.Run(); err != nil {
-                                return err
-                        }
-                        cmd = exec.Command("apt-get", "install", "-y", "tcc", "libtcc-dev")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        _ = cmd.Run()
-                }
-        case "windows":
-                if _, err := exec.LookPath("choco"); err == nil {
-                        cmd := exec.Command("choco", "install", "-y", "tinycc")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        _ = cmd.Run()
-                } else if _, err := exec.LookPath("scoop"); err == nil {
-                        cmd := exec.Command("scoop", "install", "tinycc")
-                        cmd.Stdout = os.Stdout
-                        cmd.Stderr = os.Stderr
-                        _ = cmd.Run()
+                if _, err := findLib(); err == nil {
+                        return nil
                 }
         }
+        // attempt package managers …
+        // ...
         if _, err := exec.LookPath("tcc"); err == nil {
-                return nil
+                if _, err := findLib(); err == nil {
+                        return nil
+                }
         }
-        return fmt.Errorf("tcc not found")
+        fmt.Println("🔧 Building TinyCC from source…")
+        return buildFromSource()
 }
 ```
-【F:tools/tcc/ensure.go†L10-L46】
+【F:tools/tcc/ensure.go†L17-L167】
 
 ## 8. Tests
 

--- a/tools/tcc/ensure.go
+++ b/tools/tcc/ensure.go
@@ -1,18 +1,31 @@
 package tcc
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/bzip2"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // EnsureTCC verifies that the TinyCC compiler is installed. It attempts a
 // best-effort installation using common package managers on each platform.
 func EnsureTCC() error {
+	// If the TinyCC compiler and static library are already available,
+	// nothing to do.
 	if _, err := exec.LookPath("tcc"); err == nil {
-		return nil
+		if _, err := findLib(); err == nil {
+			return nil
+		}
 	}
+
+	// Attempt installation via common package managers first.
 	switch runtime.GOOS {
 	case "darwin":
 		if _, err := exec.LookPath("brew"); err == nil {
@@ -47,8 +60,109 @@ func EnsureTCC() error {
 			_ = cmd.Run()
 		}
 	}
+
 	if _, err := exec.LookPath("tcc"); err == nil {
-		return nil
+		if _, err := findLib(); err == nil {
+			return nil
+		}
 	}
-	return fmt.Errorf("tcc not found")
+
+	// Package managers failed or missing library: download sources and
+	// build libtcc.a locally.
+	fmt.Println("\U0001F528 Building TinyCC from source...")
+	lib, _ := findLib()
+	srcDir := filepath.Join("tools", "tcc", "tcc")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(srcDir, "configure")); err != nil {
+		// Download and extract archive
+		url := "https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27.tar.bz2"
+		resp, err := http.Get(url)
+		if err != nil {
+			return fmt.Errorf("download tcc: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("download tcc: %s", resp.Status)
+		}
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		br := bzip2.NewReader(bytes.NewReader(data))
+		tr := tar.NewReader(br)
+		var prefix string
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			name := hdr.Name
+			if prefix == "" {
+				if i := strings.IndexByte(name, '/'); i != -1 {
+					prefix = name[:i+1]
+					name = name[i+1:]
+				}
+			} else if strings.HasPrefix(name, prefix) {
+				name = name[len(prefix):]
+			}
+			if name == "" {
+				continue
+			}
+			target := filepath.Join(srcDir, name)
+			if hdr.FileInfo().IsDir() {
+				if err := os.MkdirAll(target, hdr.FileInfo().Mode()); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdr.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+		}
+	}
+
+	// Configure and build libtcc.a
+	cmd := exec.Command("./configure", "--enable-static")
+	cmd.Dir = srcDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	cmd = exec.Command("make", "libtcc.a")
+	cmd.Dir = srcDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	if _, err := os.Stat(lib); err != nil {
+		return fmt.Errorf("libtcc.a not found after build")
+	}
+	return nil
+}
+
+func findLib() (string, error) {
+	path := os.Getenv("TCC_LIB")
+	if path == "" {
+		path = filepath.Join("tools", "tcc", "tcc", "libtcc.a")
+	}
+	if _, err := os.Stat(path); err != nil {
+		return path, err
+	}
+	return path, nil
 }

--- a/tools/tcc/mochi_tcc_test.go
+++ b/tools/tcc/mochi_tcc_test.go
@@ -1,0 +1,34 @@
+//go:build tcc && libtcc
+
+package tcc
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestMochiTCC_Hello(t *testing.T) {
+	if err := EnsureTCC(); err != nil {
+		t.Skipf("TinyCC not installed: %v", err)
+	}
+	bin := filepath.Join(t.TempDir(), "mochi-tcc")
+	cmd := exec.Command("go", "build", "-tags", "tcc libtcc", "-o", bin, "../../cmd/mochi-tcc")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build mochi-tcc: %v\n%s", err, out)
+	}
+	src := filepath.Join("..", "..", "examples", "v0.1", "hello.mochi")
+	exe := filepath.Join(t.TempDir(), "hello")
+	cmd = exec.Command(bin, src, exe)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("mochi-tcc compile: %v\n%s", err, out)
+	}
+	out, err := exec.Command(exe).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run error: %v\n%s", err, out)
+	}
+	if string(bytes.TrimSpace(out)) != "Hello, world" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- extend `EnsureTCC` to download and build TinyCC when not available
- document the new behaviour in tcc README
- ignore local TinyCC build directory
- improve tcc Makefile and add `mochi-tcc` build target
- add test verifying `mochi-tcc` can build and run `hello.mochi`

## Testing
- `go test ./tools/tcc -run TestCompileAndRun -tags 'tcc libtcc'`
- `go test ./tools/tcc -run TestMochiTCC_Hello -tags 'tcc libtcc'`


------
https://chatgpt.com/codex/tasks/task_e_685e103a3d448320b8900f1ef7049679