### PR TITLE
Format fortran compiler output

### DIFF
--- a/compile/x/fortran/compiler.go
+++ b/compile/x/fortran/compiler.go
@@ -304,7 +304,11 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		c.indent--
 	}
 	c.writeln("end program main")
-	return c.buf.Bytes(), nil
+	code := c.buf.Bytes()
+	if formatted, err := formatCode(code); err == nil {
+		code = formatted
+	}
+	return code, nil
 }
 
 func (c *Compiler) compileFun(fn *parser.FunStmt) error {

--- a/compile/x/fortran/format.go
+++ b/compile/x/fortran/format.go
@@ -1,0 +1,27 @@
+package ftncode
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+// formatCode runs `findent` on the generated Fortran source to improve
+// readability. If findent is not available or fails, the input is returned
+// unchanged along with the error.
+func formatCode(src []byte) ([]byte, error) {
+	if _, err := exec.LookPath("findent"); err != nil {
+		return src, err
+	}
+	cmd := exec.Command("findent")
+	cmd.Stdin = bytes.NewReader(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return src, err
+	}
+	res := out.Bytes()
+	if len(res) == 0 || res[len(res)-1] != '\n' {
+		res = append(res, '\n')
+	}
+	return res, nil
+}

--- a/examples/leetcode-out/fortran/1/two-sum.f90
+++ b/examples/leetcode-out/fortran/1/two-sum.f90
@@ -1,29 +1,29 @@
 program main
-  implicit none
-  integer(kind=8) :: result(2)
-  result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
-  print *, result(0_8 + 1)
-  print *, result(1_8 + 1)
+   implicit none
+   integer(kind=8) :: result(2)
+   result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
+   print *, result(0_8 + 1)
+   print *, result(1_8 + 1)
 contains
-  function twoSum(nums, target) result(res)
-    implicit none
-    integer(kind=8), intent(in) :: nums(:)
-    integer(kind=8), intent(in) :: target
-    integer(kind=8) :: n
-    integer(kind=8) :: i
-    integer(kind=8) :: j
-    integer(kind=8) :: res(2)
-    n = size(nums)
-    do i = 0_8, n - 1
-      do j = (i + 1_8), n - 1
-        if (((nums(i + 1) + nums(j + 1)) == target)) then
-          res = (/i, j/)
-          return
-        end if
+   function twoSum(nums, target) result(res)
+      implicit none
+      integer(kind=8), intent(in) :: nums(:)
+      integer(kind=8), intent(in) :: target
+      integer(kind=8) :: n
+      integer(kind=8) :: i
+      integer(kind=8) :: j
+      integer(kind=8) :: res(2)
+      n = size(nums)
+      do i = 0_8, n - 1
+         do j = (i + 1_8), n - 1
+            if (((nums(i + 1) + nums(j + 1)) == target)) then
+               res = (/i, j/)
+               return
+            end if
+         end do
       end do
-    end do
-    res = (/(-1_8), (-1_8)/)
-    return
-  end function twoSum
-  
+      res = (/(-1_8), (-1_8)/)
+      return
+   end function twoSum
+
 end program main

--- a/examples/leetcode-out/fortran/2/add-two-numbers.f90
+++ b/examples/leetcode-out/fortran/2/add-two-numbers.f90
@@ -1,68 +1,68 @@
 program main
-  implicit none
-  call test_example_1()
-  call test_example_2()
-  call test_example_3()
+   implicit none
+   call test_example_1()
+   call test_example_2()
+   call test_example_3()
 contains
-  function addTwoNumbers(l1, l2) result(res)
-    implicit none
-    integer(kind=8), allocatable :: res(:)
-    integer(kind=8), intent(in) :: l1(:)
-    integer(kind=8), intent(in) :: l2(:)
-    integer(kind=8), allocatable :: result(:)
-    integer(kind=8) :: i
-    integer(kind=8) :: carry
-    integer(kind=8) :: y
-    integer(kind=8) :: sum
-    integer(kind=8) :: digit
-    integer(kind=8) :: j
-    integer(kind=8) :: x
-    allocate(result(0))
-    i = 0_8
-    j = 0_8
-    carry = 0_8
-    do while ((((i < size(l1)) .or. (j < size(l2))) .or. (carry > 0_8)))
-      x = 0_8
-      if ((i < size(l1))) then
-        x = l1(i + 1)
-        i = (i + 1_8)
+   function addTwoNumbers(l1, l2) result(res)
+      implicit none
+      integer(kind=8), allocatable :: res(:)
+      integer(kind=8), intent(in) :: l1(:)
+      integer(kind=8), intent(in) :: l2(:)
+      integer(kind=8), allocatable :: result(:)
+      integer(kind=8) :: carry
+      integer(kind=8) :: digit
+      integer(kind=8) :: i
+      integer(kind=8) :: j
+      integer(kind=8) :: sum
+      integer(kind=8) :: x
+      integer(kind=8) :: y
+      allocate(result(0))
+      i = 0_8
+      j = 0_8
+      carry = 0_8
+      do while ((((i < size(l1)) .or. (j < size(l2))) .or. (carry > 0_8)))
+         x = 0_8
+         if ((i < size(l1))) then
+            x = l1(modulo(i, size(l1)) + 1)
+            i = (i + 1_8)
+         end if
+         y = 0_8
+         if ((j < size(l2))) then
+            y = l2(modulo(j, size(l2)) + 1)
+            j = (j + 1_8)
+         end if
+         sum = ((x + y) + carry)
+         digit = mod(sum, 10_8)
+         carry = (sum / 10_8)
+         result = (/ result, (/digit/) /)
+      end do
+      res = result
+      return
+   end function addTwoNumbers
+
+   subroutine test_example_1()
+      implicit none
+      if (.not. (all(addTwoNumbers((/2_8, 4_8, 3_8/), (/5_8, 6_8, 4_8/)) == (/7_8, 0_8, 8_8/)))) then
+         print *, 'expect failed'
+         stop 1
       end if
-      y = 0_8
-      if ((j < size(l2))) then
-        y = l2(j + 1)
-        j = (j + 1_8)
+   end subroutine test_example_1
+
+   subroutine test_example_2()
+      implicit none
+      if (.not. (all(addTwoNumbers((/0_8/), (/0_8/)) == (/0_8/)))) then
+         print *, 'expect failed'
+         stop 1
       end if
-      sum = ((x + y) + carry)
-      digit = mod(sum, 10_8)
-      carry = (sum / 10_8)
-      result = (/ result, (/digit/) /)
-    end do
-    res = result
-    return
-  end function addTwoNumbers
-  
-  subroutine test_example_1()
-    implicit none
-    if (.not. (all(addTwoNumbers((/2_8, 4_8, 3_8/), (/5_8, 6_8, 4_8/)) == (/7_8, 0_8, 8_8/)))) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_1
-  
-  subroutine test_example_2()
-    implicit none
-    if (.not. (all(addTwoNumbers((/0_8/), (/0_8/)) == (/0_8/)))) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_2
-  
-  subroutine test_example_3()
-    implicit none
-    if (.not. (all(addTwoNumbers((/9_8, 9_8, 9_8, 9_8, 9_8, 9_8, 9_8/), (/9_8, 9_8, 9_8, 9_8/)) == (/8_8, 9_8, 9_8, 9_8, 0_8, 0_8, 0_8, 1_8/)))) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_3
-  
+   end subroutine test_example_2
+
+   subroutine test_example_3()
+      implicit none
+      if (.not. (all(addTwoNumbers((/9_8, 9_8, 9_8, 9_8, 9_8, 9_8, 9_8/), (/9_8, 9_8, 9_8, 9_8/)) == (/8_8, 9_8, 9_8, 9_8, 0_8, 0_8, 0_8, 1_8/)))) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_3
+
 end program main

--- a/examples/leetcode-out/fortran/3/longest-substring-without-repeating-characters.f90
+++ b/examples/leetcode-out/fortran/3/longest-substring-without-repeating-characters.f90
@@ -1,73 +1,73 @@
 program main
-  implicit none
-  call test_example_1()
-  call test_example_2()
-  call test_example_3()
-  call test_empty_string()
+   implicit none
+   call test_example_1()
+   call test_example_2()
+   call test_example_3()
+   call test_empty_string()
 contains
-  function lengthOfLongestSubstring(s) result(res)
-    implicit none
-    integer :: res
-    character(len=*), intent(in) :: s
-    integer :: best
-    integer :: i
-    integer :: j
-    integer :: length
-    integer :: n
-    integer :: start
-    n = len(s)
-    start = 0
-    best = 0
-    i = 0
-    do while ((i < n))
-      j = start
-      do while ((j < i))
-        if ((s(j + 1:j + 1) == s(i + 1:i + 1))) then
-          start = (j + 1)
-          exit
-        end if
-        j = (j + 1)
+   function lengthOfLongestSubstring(s) result(res)
+      implicit none
+      integer(kind=8) :: res
+      character(len=*), intent(in) :: s
+      integer(kind=8) :: best
+      integer(kind=8) :: i
+      integer(kind=8) :: j
+      integer(kind=8) :: length
+      integer(kind=8) :: n
+      integer(kind=8) :: start
+      n = len(s)
+      start = 0_8
+      best = 0_8
+      i = 0_8
+      do while ((i < n))
+         j = start
+         do while ((j < i))
+            if ((s(modulo(j, len(s)) + 1:modulo(j, len(s)) + 1) == s(modulo(i, len(s)) + 1:modulo(i, len(s)) + 1))) then
+               start = (j + 1_8)
+               exit
+            end if
+            j = (j + 1_8)
+         end do
+         length = ((i - start) + 1_8)
+         if ((length > best)) then
+            best = length
+         end if
+         i = (i + 1_8)
       end do
-      length = ((i - start) + 1)
-      if ((length > best)) then
-        best = length
+      res = best
+      return
+   end function lengthOfLongestSubstring
+
+   subroutine test_example_1()
+      implicit none
+      if (.not. (lengthOfLongestSubstring('abcabcbb') == 3_8)) then
+         print *, 'expect failed'
+         stop 1
       end if
-      i = (i + 1)
-    end do
-    res = best
-    return
-  end function lengthOfLongestSubstring
-  
-  subroutine test_example_1()
-    implicit none
-    if (.not. (lengthOfLongestSubstring('abcabcbb') == 3)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_1
-  
-  subroutine test_example_2()
-    implicit none
-    if (.not. (lengthOfLongestSubstring('bbbbb') == 1)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_2
-  
-  subroutine test_example_3()
-    implicit none
-    if (.not. (lengthOfLongestSubstring('pwwkew') == 3)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_3
-  
-  subroutine test_empty_string()
-    implicit none
-    if (.not. (lengthOfLongestSubstring('') == 0)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_empty_string
-  
+   end subroutine test_example_1
+
+   subroutine test_example_2()
+      implicit none
+      if (.not. (lengthOfLongestSubstring('bbbbb') == 1_8)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_2
+
+   subroutine test_example_3()
+      implicit none
+      if (.not. (lengthOfLongestSubstring('pwwkew') == 3_8)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_3
+
+   subroutine test_empty_string()
+      implicit none
+      if (.not. (lengthOfLongestSubstring('') == 0_8)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_empty_string
+
 end program main

--- a/examples/leetcode-out/fortran/4/median-of-two-sorted-arrays.f90
+++ b/examples/leetcode-out/fortran/4/median-of-two-sorted-arrays.f90
@@ -1,80 +1,80 @@
 program main
-  implicit none
-  call test_example_1()
-  call test_example_2()
-  call test_empty_first()
-  call test_empty_second()
+   implicit none
+   call test_example_1()
+   call test_example_2()
+   call test_empty_first()
+   call test_empty_second()
 contains
-  function findMedianSortedArrays(nums1, nums2) result(res)
-    implicit none
-    real :: res
-    integer, intent(in) :: nums1(:)
-    integer, intent(in) :: nums2(:)
-    integer, allocatable :: merged(:)
-    integer :: i
-    integer :: j
-    integer :: total
-    integer :: mid1
-    integer :: mid2
-    allocate(merged(0))
-    i = 0
-    j = 0
-    do while (((i < size(nums1)) .or. (j < size(nums2))))
-      if ((j >= size(nums2))) then
-        merged = (/ merged, (/nums1(i + 1)/) /)
-        i = (i + 1)
-      else if ((i >= size(nums1))) then
-        merged = (/ merged, (/nums2(j + 1)/) /)
-        j = (j + 1)
-      else if ((nums1(i + 1) <= nums2(j + 1))) then
-        merged = (/ merged, (/nums1(i + 1)/) /)
-        i = (i + 1)
-      else
-        merged = (/ merged, (/nums2(j + 1)/) /)
-        j = (j + 1)
+   function findMedianSortedArrays(nums1, nums2) result(res)
+      implicit none
+      real :: res
+      integer(kind=8), intent(in) :: nums1(:)
+      integer(kind=8), intent(in) :: nums2(:)
+      integer(kind=8), allocatable :: merged(:)
+      integer(kind=8) :: i
+      integer(kind=8) :: j
+      integer(kind=8) :: mid1
+      integer(kind=8) :: mid2
+      integer(kind=8) :: total
+      allocate(merged(0))
+      i = 0_8
+      j = 0_8
+      do while (((i < size(nums1)) .or. (j < size(nums2))))
+         if ((j >= size(nums2))) then
+            merged = (/ merged, (/nums1(modulo(i, size(nums1)) + 1)/) /)
+            i = (i + 1_8)
+         else if ((i >= size(nums1))) then
+            merged = (/ merged, (/nums2(modulo(j, size(nums2)) + 1)/) /)
+            j = (j + 1_8)
+         else if ((nums1(modulo(i, size(nums1)) + 1) <= nums2(modulo(j, size(nums2)) + 1))) then
+            merged = (/ merged, (/nums1(modulo(i, size(nums1)) + 1)/) /)
+            i = (i + 1_8)
+         else
+            merged = (/ merged, (/nums2(modulo(j, size(nums2)) + 1)/) /)
+            j = (j + 1_8)
+         end if
+      end do
+      total = size(merged)
+      if ((mod(total, 2_8) == 1_8)) then
+         res = real(merged(modulo((total / 2_8), size(merged)) + 1))
+         return
       end if
-    end do
-    total = size(merged)
-    if ((mod(total, 2) == 1)) then
-      res = real(merged((total / 2) + 1))
+      mid1 = merged(modulo(((total / 2_8) - 1_8), size(merged)) + 1)
+      mid2 = merged(modulo((total / 2_8), size(merged)) + 1)
+      res = (real(((mid1 + mid2))) / 2)
       return
-    end if
-    mid1 = merged(((total / 2) - 1) + 1)
-    mid2 = merged((total / 2) + 1)
-    res = (real(((mid1 + mid2))) / 2)
-    return
-  end function findMedianSortedArrays
-  
-  subroutine test_example_1()
-    implicit none
-    if (.not. (findMedianSortedArrays((/1, 3/), (/2/)) == 2)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_1
-  
-  subroutine test_example_2()
-    implicit none
-    if (.not. (findMedianSortedArrays((/1, 2/), (/3, 4/)) == 2.5)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_2
-  
-  subroutine test_empty_first()
-    implicit none
-    if (.not. (findMedianSortedArrays(reshape([0], [0]), (/1/)) == 1)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_empty_first
-  
-  subroutine test_empty_second()
-    implicit none
-    if (.not. (findMedianSortedArrays((/2/), reshape([0], [0])) == 2)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_empty_second
-  
+   end function findMedianSortedArrays
+
+   subroutine test_example_1()
+      implicit none
+      if (.not. (findMedianSortedArrays((/1_8, 3_8/), (/2_8/)) == 2)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_1
+
+   subroutine test_example_2()
+      implicit none
+      if (.not. (findMedianSortedArrays((/1_8, 2_8/), (/3_8, 4_8/)) == 2.5)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_2
+
+   subroutine test_empty_first()
+      implicit none
+      if (.not. (findMedianSortedArrays(reshape([0_8], [0]), (/1_8/)) == 1)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_empty_first
+
+   subroutine test_empty_second()
+      implicit none
+      if (.not. (findMedianSortedArrays((/2_8/), reshape([0_8], [0])) == 2)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_empty_second
+
 end program main

--- a/examples/leetcode-out/fortran/5/longest-palindromic-substring.f90
+++ b/examples/leetcode-out/fortran/5/longest-palindromic-substring.f90
@@ -1,101 +1,101 @@
 program main
-  implicit none
-  call test_example_1()
-  call test_example_2()
-  call test_single_char()
-  call test_two_chars()
+   implicit none
+   call test_example_1()
+   call test_example_2()
+   call test_single_char()
+   call test_two_chars()
 contains
-  function expand(s, left, right) result(res)
-    implicit none
-    integer :: res
-    character(len=*), intent(in) :: s
-    integer, intent(in) :: left
-    integer, intent(in) :: right
-    integer :: l
-    integer :: r
-    integer :: n
-    l = left
-    r = right
-    n = len(s)
-    do while (((l >= 0) .and. (r < n)))
-      if ((s(l + 1:l + 1) /= s(r + 1:r + 1))) then
-        exit
-      end if
-      l = (l - 1)
-      r = (r + 1)
-    end do
-    res = ((r - l) - 1)
-    return
-  end function expand
-  
-  function longestPalindrome(s) result(res)
-    implicit none
-    character(:), allocatable :: res
-    character(len=*), intent(in) :: s
-    integer :: l
-    integer :: i
-    integer :: start
-    integer :: end
-    integer :: n
-    integer :: len1
-    integer :: len2
-    if ((len(s) <= 1)) then
-      res = s
+   function expand(s, left, right) result(res)
+      implicit none
+      integer(kind=8) :: res
+      character(len=*), intent(in) :: s
+      integer(kind=8), intent(in) :: left
+      integer(kind=8), intent(in) :: right
+      integer(kind=8) :: l
+      integer(kind=8) :: n
+      integer(kind=8) :: r
+      l = left
+      r = right
+      n = len(s)
+      do while (((l >= 0_8) .and. (r < n)))
+         if ((s(modulo(l, len(s)) + 1:modulo(l, len(s)) + 1) /= s(modulo(r, len(s)) + 1:modulo(r, len(s)) + 1))) then
+            exit
+         end if
+         l = (l - 1_8)
+         r = (r + 1_8)
+      end do
+      res = ((r - l) - 1_8)
       return
-    end if
-    start = 0
-    end = 0
-    n = len(s)
-    do i = 0, n - 1
-      len1 = expand(s, i, i)
-      len2 = expand(s, i, (i + 1))
-      l = len1
-      if ((len2 > len1)) then
-        l = len2
+   end function expand
+
+   function longestPalindrome(s) result(res)
+      implicit none
+      character(:), allocatable :: res
+      character(len=*), intent(in) :: s
+      integer(kind=8) :: end
+      integer(kind=8) :: i
+      integer(kind=8) :: l
+      integer(kind=8) :: len1
+      integer(kind=8) :: len2
+      integer(kind=8) :: n
+      integer(kind=8) :: start
+      if ((len(s) <= 1_8)) then
+         res = s
+         return
       end if
-      if ((l > ((end - start)))) then
-        start = (i - ((((l - 1)) / 2)))
-        end = (i + ((l / 2)))
+      start = 0_8
+      end = 0_8
+      n = len(s)
+      do i = 0_8, n - 1
+         len1 = expand(s, i, i)
+         len2 = expand(s, i, (i + 1_8))
+         l = len1
+         if ((len2 > len1)) then
+            l = len2
+         end if
+         if ((l > ((end - start)))) then
+            start = (i - ((((l - 1_8)) / 2_8)))
+            end = (i + ((l / 2_8)))
+         end if
+      end do
+      res = s(modulo(start, len(s)) + 1:modulo((end + 1_8), len(s)))
+      return
+   end function longestPalindrome
+
+   subroutine test_example_1()
+      implicit none
+      character(:), allocatable :: ans
+      ans = longestPalindrome('babad')
+      if (.not. (((ans == 'bab') .or. (ans == 'aba')))) then
+         print *, 'expect failed'
+         stop 1
       end if
-    end do
-    res = s(start + 1:(end + 1))
-    return
-  end function longestPalindrome
-  
-  subroutine test_example_1()
-    implicit none
-    character(:), allocatable :: ans
-    ans = longestPalindrome('babad')
-    if (.not. (((ans == 'bab') .or. (ans == 'aba')))) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_1
-  
-  subroutine test_example_2()
-    implicit none
-    if (.not. (longestPalindrome('cbbd') == 'bb')) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_2
-  
-  subroutine test_single_char()
-    implicit none
-    if (.not. (longestPalindrome('a') == 'a')) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_single_char
-  
-  subroutine test_two_chars()
-    implicit none
-    character(:), allocatable :: ans
-    ans = longestPalindrome('ac')
-    if (.not. (((ans == 'a') .or. (ans == 'c')))) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_two_chars
-  
+   end subroutine test_example_1
+
+   subroutine test_example_2()
+      implicit none
+      if (.not. (longestPalindrome('cbbd') == 'bb')) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_2
+
+   subroutine test_single_char()
+      implicit none
+      if (.not. (longestPalindrome('a') == 'a')) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_single_char
+
+   subroutine test_two_chars()
+      implicit none
+      character(:), allocatable :: ans
+      ans = longestPalindrome('ac')
+      if (.not. (((ans == 'a') .or. (ans == 'c')))) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_two_chars
+
 end program main

--- a/examples/leetcode-out/fortran/6/zigzag-conversion.f90
+++ b/examples/leetcode-out/fortran/6/zigzag-conversion.f90
@@ -1,67 +1,67 @@
 program main
-  implicit none
-  call test_example_1()
-  call test_example_2()
-  call test_single_row()
+   implicit none
+   call test_example_1()
+   call test_example_2()
+   call test_single_row()
 contains
-  function convert(s, numRows) result(res)
-    implicit none
-    character(len=*), intent(in) :: s
-    integer, intent(in) :: numRows
-    character(:), allocatable :: res
-    character(len=len(s)), allocatable :: rows(:)
-    integer :: i
-    integer :: curr
-    integer :: step
-    integer :: i_row
-    if ((numRows <= 1) .or. (numRows >= len(s))) then
-      res = s
-      return
-    end if
-    allocate(character(len=len(s)) :: rows(numRows))
-    do i = 1, numRows
-      rows(i) = ''
-    end do
-    curr = 1
-    step = 1
-    do i = 1, len(s)
-      rows(curr) = trim(rows(curr)) // s(i:i)
-      if (curr == 1) then
-        step = 1
-      else if (curr == numRows) then
-        step = -1
+   function convert(s, numRows) result(res)
+      implicit none
+      character(len=*), intent(in) :: s
+      integer(kind=8), intent(in) :: numRows
+      character(:), allocatable :: res
+      character(len=len(s)), allocatable :: rows(:)
+      integer(kind=8) :: i
+      integer(kind=8) :: curr
+      integer(kind=8) :: step
+      integer(kind=8) :: i_row
+      if ((numRows <= 1) .or. (numRows >= len(s))) then
+         res = s
+         return
       end if
-      curr = curr + step
-    end do
-    res = ''
-    do i_row = 1, numRows
-      res = trim(res) // trim(rows(i_row))
-    end do
-    return
-  end function convert
-  
-  subroutine test_example_1()
-    implicit none
-    if (.not. (convert('PAYPALISHIRING', 3) == 'PAHNAPLSIIGYIR')) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_1
-  
-  subroutine test_example_2()
-    implicit none
-    if (.not. (convert('PAYPALISHIRING', 4) == 'PINALSIGYAHRPI')) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_2
-  
-  subroutine test_single_row()
-    implicit none
-    if (.not. (convert('A', 1) == 'A')) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_single_row
-  
+      allocate(character(len=len(s)) :: rows(numRows))
+      do i = 1, numRows
+         rows(i) = ''
+      end do
+      curr = 1
+      step = 1
+      do i = 1, len(s)
+         rows(curr) = trim(rows(curr)) // s(i:i)
+         if (curr == 1) then
+            step = 1
+         else if (curr == numRows) then
+            step = -1
+         end if
+         curr = curr + step
+      end do
+      res = ''
+      do i_row = 1, numRows
+         res = trim(res) // trim(rows(i_row))
+      end do
+      return
+   end function convert
+
+   subroutine test_example_1()
+      implicit none
+      if (.not. (convert('PAYPALISHIRING', 3_8) == 'PAHNAPLSIIGYIR')) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_1
+
+   subroutine test_example_2()
+      implicit none
+      if (.not. (convert('PAYPALISHIRING', 4_8) == 'PINALSIGYAHRPI')) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_2
+
+   subroutine test_single_row()
+      implicit none
+      if (.not. (convert('A', 1_8) == 'A')) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_single_row
+
 end program main

--- a/examples/leetcode-out/fortran/7/reverse-integer.f90
+++ b/examples/leetcode-out/fortran/7/reverse-integer.f90
@@ -1,69 +1,69 @@
 program main
-  implicit none
-  call test_example_1()
-  call test_example_2()
-  call test_example_3()
-  call test_overflow()
+   implicit none
+   call test_example_1()
+   call test_example_2()
+   call test_example_3()
+   call test_overflow()
 contains
-  function reverse(x) result(res)
-    implicit none
-    integer(kind=8) :: res
-    integer(kind=8), intent(in) :: x
-    integer(kind=8) :: sign
-    integer(kind=8) :: n
-    integer(kind=8) :: rev
-    integer(kind=8) :: digit
-    sign = 1
-    n = x
-    if ((n < 0)) then
-      sign = (-1)
-      n = (-n)
-    end if
-    rev = 0
-    do while ((n /= 0))
-      digit = mod(n, 10)
-      rev = ((rev * 10) + digit)
-      n = (n / 10)
-    end do
-    rev = (rev * sign)
-    if (((rev < (((-2147483647) - 1))) .or. (rev > 2147483647))) then
-      res = 0
+   function reverse(x) result(res)
+      implicit none
+      integer(kind=8) :: res
+      integer(kind=8), intent(in) :: x
+      integer(kind=8) :: digit
+      integer(kind=8) :: n
+      integer(kind=8) :: rev
+      integer(kind=8) :: sign
+      sign = 1_8
+      n = x
+      if ((n < 0_8)) then
+         sign = (-1_8)
+         n = (-n)
+      end if
+      rev = 0_8
+      do while ((n /= 0_8))
+         digit = mod(n, 10_8)
+         rev = ((rev * 10_8) + digit)
+         n = (n / 10_8)
+      end do
+      rev = (rev * sign)
+      if (((rev < (((-2147483647_8) - 1_8))) .or. (rev > 2147483647_8))) then
+         res = 0_8
+         return
+      end if
+      res = rev
       return
-    end if
-    res = rev
-    return
-  end function reverse
-  
-  subroutine test_example_1()
-    implicit none
-    if (.not. (reverse(123) == 321)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_1
-  
-  subroutine test_example_2()
-    implicit none
-    if (.not. (reverse((-123)) == ((-321)))) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_2
-  
-  subroutine test_example_3()
-    implicit none
-    if (.not. (reverse(120) == 21)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_example_3
-  
-  subroutine test_overflow()
-    implicit none
-    if (.not. (reverse(1534236469) == 0)) then
-      print *, 'expect failed'
-      stop 1
-    end if
-  end subroutine test_overflow
-  
+   end function reverse
+
+   subroutine test_example_1()
+      implicit none
+      if (.not. (reverse(123_8) == 321_8)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_1
+
+   subroutine test_example_2()
+      implicit none
+      if (.not. (reverse((-123_8)) == ((-321_8)))) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_2
+
+   subroutine test_example_3()
+      implicit none
+      if (.not. (reverse(120_8) == 21_8)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_example_3
+
+   subroutine test_overflow()
+      implicit none
+      if (.not. (reverse(1534236469_8) == 0_8)) then
+         print *, 'expect failed'
+         stop 1
+      end if
+   end subroutine test_overflow
+
 end program main

--- a/tests/compiler/fortran/arithmetic.f90.out
+++ b/tests/compiler/fortran/arithmetic.f90.out
@@ -1,8 +1,8 @@
 program main
-  implicit none
-  print *, (1_8 + 2_8)
-  print *, (5_8 - 3_8)
-  print *, (4_8 * 2_8)
-  print *, (8_8 / 2_8)
-  print *, mod(7_8, 3_8)
+   implicit none
+   print *, (1_8 + 2_8)
+   print *, (5_8 - 3_8)
+   print *, (4_8 * 2_8)
+   print *, (8_8 / 2_8)
+   print *, mod(7_8, 3_8)
 end program main

--- a/tests/compiler/fortran/bool_ops.f90.out
+++ b/tests/compiler/fortran/bool_ops.f90.out
@@ -1,6 +1,6 @@
 program main
-  implicit none
-  print *, (.true. .and. .false.)
-  print *, (.true. .or. .false.)
-  print *, (.not. .false.)
+   implicit none
+   print *, (.true. .and. .false.)
+   print *, (.true. .or. .false.)
+   print *, (.not. .false.)
 end program main

--- a/tests/compiler/fortran/break_continue.f90.out
+++ b/tests/compiler/fortran/break_continue.f90.out
@@ -1,13 +1,13 @@
 program main
-  implicit none
-  integer(kind=8) :: i
-  do i = 0_8, 10_8 - 1
-    if ((mod(i, 2_8) == 0_8)) then
-      cycle
-    end if
-    if ((i > 5_8)) then
-      exit
-    end if
-    print *, i
-  end do
+   implicit none
+   integer(kind=8) :: i
+   do i = 0_8, 10_8 - 1
+      if ((mod(i, 2_8) == 0_8)) then
+         cycle
+      end if
+      if ((i > 5_8)) then
+         exit
+      end if
+      print *, i
+   end do
 end program main

--- a/tests/compiler/fortran/builtin_append.f90.out
+++ b/tests/compiler/fortran/builtin_append.f90.out
@@ -1,7 +1,7 @@
 program main
-  implicit none
-  integer(kind=8), allocatable :: xs(:)
-  allocate(xs(0))
-  xs = (/ (/1_8, 2_8/), 3_8 /)
-  print *, xs(modulo(2_8, size(xs)) + 1)
+   implicit none
+   integer(kind=8), allocatable :: xs(:)
+   allocate(xs(0))
+   xs = (/ (/1_8, 2_8/), 3_8 /)
+   print *, xs(modulo(2_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/builtin_str.f90.out
+++ b/tests/compiler/fortran/builtin_str.f90.out
@@ -1,27 +1,27 @@
 program main
-  implicit none
-  print *, str_int(42_8)
-  print *, str_float(3.5)
-  print *, 'hi'
+   implicit none
+   print *, str_int(42_8)
+   print *, str_float(3.5)
+   print *, 'hi'
 contains
 
-  function str_int(v) result(r)
-    implicit none
-    integer(kind=8), intent(in) :: v
-    character(:), allocatable :: r
-    character(len=32) :: buf
-    write(buf,'(I0)') v
-    allocate(character(len=len_trim(buf)) :: r)
-    r = trim(buf)
-  end function str_int
+   function str_int(v) result(r)
+      implicit none
+      integer(kind=8), intent(in) :: v
+      character(:), allocatable :: r
+      character(len=32) :: buf
+      write(buf,'(I0)') v
+      allocate(character(len=len_trim(buf)) :: r)
+      r = trim(buf)
+   end function str_int
 
-  function str_float(v) result(r)
-    implicit none
-    real, intent(in) :: v
-    character(:), allocatable :: r
-    character(len=64) :: buf
-    write(buf,'(G0)') v
-    allocate(character(len=len_trim(buf)) :: r)
-    r = trim(buf)
-  end function str_float
+   function str_float(v) result(r)
+      implicit none
+      real, intent(in) :: v
+      character(:), allocatable :: r
+      character(len=64) :: buf
+      write(buf,'(G0)') v
+      allocate(character(len=len_trim(buf)) :: r)
+      r = trim(buf)
+   end function str_float
 end program main

--- a/tests/compiler/fortran/dataset_sort_take_limit.f90.out
+++ b/tests/compiler/fortran/dataset_sort_take_limit.f90.out
@@ -1,64 +1,64 @@
 program main
-  implicit none
-  type :: Product
-    character(:), allocatable :: name
-    integer(kind=8) :: price
-  end type Product
-  integer(kind=8), allocatable :: products(:)
-  integer(kind=8) :: expensive
-  integer(kind=8) :: item
-  integer(kind=8) :: i_item
-  allocate(products(0))
-  products = (/Product(name='Laptop', price=1500_8), Product(name='Smartphone', price=900_8), Product(name='Tablet', price=600_8), Product(name='Monitor', price=300_8), Product(name='Keyboard', price=100_8), Product(name='Mouse', price=50_8), Product(name='Headphones', price=200_8)/)
-  expensive = lambda_0(products)(1_8 + 1:1_8 + 3_8)
-  print *, '--- Top products (excluding most expensive) ---'
-  do i_item = 0, size(expensive) - 1
-    item = expensive(modulo(i_item, size(expensive)) + 1)
-    print *, item%name, 'costs $', item%price
-  end do
+   implicit none
+   type :: Product
+      character(:), allocatable :: name
+      integer(kind=8) :: price
+   end type Product
+   integer(kind=8), allocatable :: products(:)
+   integer(kind=8) :: expensive
+   integer(kind=8) :: item
+   integer(kind=8) :: i_item
+   allocate(products(0))
+   products = (/Product(name='Laptop', price=1500_8), Product(name='Smartphone', price=900_8), Product(name='Tablet', price=600_8), Product(name='Monitor', price=300_8), Product(name='Keyboard', price=100_8), Product(name='Mouse', price=50_8), Product(name='Headphones', price=200_8)/)
+   expensive = lambda_0(products)(1_8 + 1:1_8 + 3_8)
+   print *, '--- Top products (excluding most expensive) ---'
+   do i_item = 0, size(expensive) - 1
+      item = expensive(modulo(i_item, size(expensive)) + 1)
+      print *, item%name, 'costs $', item%price
+   end do
 contains
-  function lambda_0(vsrc) result(res)
-    implicit none
-    integer(kind=8), intent(in) :: vsrc(:)
-    integer(kind=8), allocatable :: res(:)
-    integer(kind=8), allocatable :: tmp(:)
-    integer(kind=8), allocatable :: tmpKey(:)
-    integer(kind=8) :: p
-    integer(kind=8) :: n
-    integer(kind=8) :: i
-    integer(kind=8) :: j
-    integer(kind=8) :: min_idx
-    integer(kind=8) :: sort_key
-    integer(kind=8) :: swap_key
-    integer(kind=8) :: swap_item
-    allocate(tmp(size(vsrc)))
-    allocate(tmpKey(size(vsrc)))
-    n = 0
-    do i = 1, size(vsrc)
-      p = vsrc(i)
-      sort_key = (-p%price)
-      n = n + 1
-      tmp(n) = p
-      tmpKey(n) = sort_key
-    end do
-    do i = 1, n - 1
-      min_idx = i
-      do j = i + 1, n
-        if (tmpKey(j) < tmpKey(min_idx)) then
-          min_idx = j
-        end if
+   function lambda_0(vsrc) result(res)
+      implicit none
+      integer(kind=8), intent(in) :: vsrc(:)
+      integer(kind=8), allocatable :: res(:)
+      integer(kind=8), allocatable :: tmp(:)
+      integer(kind=8), allocatable :: tmpKey(:)
+      integer(kind=8) :: p
+      integer(kind=8) :: n
+      integer(kind=8) :: i
+      integer(kind=8) :: j
+      integer(kind=8) :: min_idx
+      integer(kind=8) :: sort_key
+      integer(kind=8) :: swap_key
+      integer(kind=8) :: swap_item
+      allocate(tmp(size(vsrc)))
+      allocate(tmpKey(size(vsrc)))
+      n = 0
+      do i = 1, size(vsrc)
+         p = vsrc(i)
+         sort_key = (-p%price)
+         n = n + 1
+         tmp(n) = p
+         tmpKey(n) = sort_key
       end do
-      if (min_idx /= i) then
-        swap_key = tmpKey(i)
-        tmpKey(i) = tmpKey(min_idx)
-        tmpKey(min_idx) = swap_key
-        swap_item = tmp(i)
-        tmp(i) = tmp(min_idx)
-        tmp(min_idx) = swap_item
-      end if
-    end do
-    allocate(res(n))
-    res = tmp(:n)
-  end function lambda_0
-  
+      do i = 1, n - 1
+         min_idx = i
+         do j = i + 1, n
+            if (tmpKey(j) < tmpKey(min_idx)) then
+               min_idx = j
+            end if
+         end do
+         if (min_idx /= i) then
+            swap_key = tmpKey(i)
+            tmpKey(i) = tmpKey(min_idx)
+            tmpKey(min_idx) = swap_key
+            swap_item = tmp(i)
+            tmp(i) = tmp(min_idx)
+            tmp(min_idx) = swap_item
+         end if
+      end do
+      allocate(res(n))
+      res = tmp(:n)
+   end function lambda_0
+
 end program main

--- a/tests/compiler/fortran/dataset_sort_where.f90.out
+++ b/tests/compiler/fortran/dataset_sort_where.f90.out
@@ -1,65 +1,65 @@
 program main
-  implicit none
-  type :: Item
-    character(:), allocatable :: name
-    integer(kind=8) :: price
-  end type Item
-  integer(kind=8), allocatable :: items(:)
-  integer(kind=8) :: cheap
-  integer(kind=8) :: c
-  integer(kind=8) :: i_c
-  allocate(items(0))
-  items = (/Item(name='A', price=100_8), Item(name='B', price=50_8), Item(name='C', price=200_8), Item(name='D', price=80_8)/)
-  cheap = lambda_0(items)
-  do i_c = 0, size(cheap) - 1
-    c = cheap(modulo(i_c, size(cheap)) + 1)
-    print *, c%name, c%price
-  end do
+   implicit none
+   type :: Item
+      character(:), allocatable :: name
+      integer(kind=8) :: price
+   end type Item
+   integer(kind=8), allocatable :: items(:)
+   integer(kind=8) :: cheap
+   integer(kind=8) :: c
+   integer(kind=8) :: i_c
+   allocate(items(0))
+   items = (/Item(name='A', price=100_8), Item(name='B', price=50_8), Item(name='C', price=200_8), Item(name='D', price=80_8)/)
+   cheap = lambda_0(items)
+   do i_c = 0, size(cheap) - 1
+      c = cheap(modulo(i_c, size(cheap)) + 1)
+      print *, c%name, c%price
+   end do
 contains
-  function lambda_0(vsrc) result(res)
-    implicit none
-    integer(kind=8), intent(in) :: vsrc(:)
-    integer(kind=8), allocatable :: res(:)
-    integer(kind=8), allocatable :: tmp(:)
-    integer(kind=8), allocatable :: tmpKey(:)
-    integer(kind=8) :: it
-    integer(kind=8) :: n
-    integer(kind=8) :: i
-    integer(kind=8) :: j
-    integer(kind=8) :: min_idx
-    integer(kind=8) :: sort_key
-    integer(kind=8) :: swap_key
-    integer(kind=8) :: swap_item
-    allocate(tmp(size(vsrc)))
-    allocate(tmpKey(size(vsrc)))
-    n = 0
-    do i = 1, size(vsrc)
-      it = vsrc(i)
-      if ((it%price < 150_8)) then
-        sort_key = it%price
-        n = n + 1
-        tmp(n) = it
-        tmpKey(n) = sort_key
-      end if
-    end do
-    do i = 1, n - 1
-      min_idx = i
-      do j = i + 1, n
-        if (tmpKey(j) < tmpKey(min_idx)) then
-          min_idx = j
-        end if
+   function lambda_0(vsrc) result(res)
+      implicit none
+      integer(kind=8), intent(in) :: vsrc(:)
+      integer(kind=8), allocatable :: res(:)
+      integer(kind=8), allocatable :: tmp(:)
+      integer(kind=8), allocatable :: tmpKey(:)
+      integer(kind=8) :: it
+      integer(kind=8) :: n
+      integer(kind=8) :: i
+      integer(kind=8) :: j
+      integer(kind=8) :: min_idx
+      integer(kind=8) :: sort_key
+      integer(kind=8) :: swap_key
+      integer(kind=8) :: swap_item
+      allocate(tmp(size(vsrc)))
+      allocate(tmpKey(size(vsrc)))
+      n = 0
+      do i = 1, size(vsrc)
+         it = vsrc(i)
+         if ((it%price < 150_8)) then
+            sort_key = it%price
+            n = n + 1
+            tmp(n) = it
+            tmpKey(n) = sort_key
+         end if
       end do
-      if (min_idx /= i) then
-        swap_key = tmpKey(i)
-        tmpKey(i) = tmpKey(min_idx)
-        tmpKey(min_idx) = swap_key
-        swap_item = tmp(i)
-        tmp(i) = tmp(min_idx)
-        tmp(min_idx) = swap_item
-      end if
-    end do
-    allocate(res(n))
-    res = tmp(:n)
-  end function lambda_0
-  
+      do i = 1, n - 1
+         min_idx = i
+         do j = i + 1, n
+            if (tmpKey(j) < tmpKey(min_idx)) then
+               min_idx = j
+            end if
+         end do
+         if (min_idx /= i) then
+            swap_key = tmpKey(i)
+            tmpKey(i) = tmpKey(min_idx)
+            tmpKey(min_idx) = swap_key
+            swap_item = tmp(i)
+            tmp(i) = tmp(min_idx)
+            tmp(min_idx) = swap_item
+         end if
+      end do
+      allocate(res(n))
+      res = tmp(:n)
+   end function lambda_0
+
 end program main

--- a/tests/compiler/fortran/fetch_builtin.f90.out
+++ b/tests/compiler/fortran/fetch_builtin.f90.out
@@ -1,19 +1,25 @@
 program main
-  implicit none
-  type :: Msg
-    character(:), allocatable :: message
-  end type Msg
-  integer(kind=8) :: v__
-  v__ = mochi_fetch('file://tests/compiler/fortran/fetch_builtin.json')
+   implicit none
+   type :: Msg
+      character(:), allocatable :: message
+   end type Msg
+   character(:), allocatable :: v__
+   v__ = mochi_fetch('file://tests/compiler/fortran/fetch_builtin.json')
 contains
 
-  function mochi_fetch(url) result(r)
-    implicit none
-    character(len=*), intent(in) :: url
-    integer(kind=8) :: r
-    character(len=1024) :: cmd
-    cmd = 'curl -s ' // trim(url)
-    call execute_command_line(cmd)
-    r = 0
-  end function mochi_fetch
+   function mochi_fetch(url) result(r)
+      implicit none
+      character(len=*), intent(in) :: url
+      character(len=:), allocatable :: r
+      character(len=1024) :: cmd
+      integer :: u, n
+      cmd = 'curl -s -o mochi_fetch.tmp ' // trim(url)
+      call execute_command_line(cmd)
+      open(newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
+      inquire(u, size=n)
+      allocate(character(len=n) :: r)
+      read(u) r
+      close(u)
+      call execute_command_line('rm -f mochi_fetch.tmp')
+   end function mochi_fetch
 end program main

--- a/tests/compiler/fortran/fetch_http.f90.out
+++ b/tests/compiler/fortran/fetch_http.f90.out
@@ -1,23 +1,23 @@
 program main
-  implicit none
-  character(:), allocatable :: body
-  body = mochi_fetch('https://jsonplaceholder.typicode.com/todos/1')
-  print *, (len(body) > 0_8)
+   implicit none
+   character(:), allocatable :: body
+   body = mochi_fetch('https://jsonplaceholder.typicode.com/todos/1')
+   print *, (len(body) > 0_8)
 contains
 
-  function mochi_fetch(url) result(r)
-    implicit none
-    character(len=*), intent(in) :: url
-    character(len=:), allocatable :: r
-    character(len=1024) :: cmd
-    integer :: u, n
-    cmd = 'curl -s -o mochi_fetch.tmp ' // trim(url)
-    call execute_command_line(cmd)
-    open(newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
-    inquire(u, size=n)
-    allocate(character(len=n) :: r)
-    read(u) r
-    close(u)
-    call execute_command_line('rm -f mochi_fetch.tmp')
-  end function mochi_fetch
+   function mochi_fetch(url) result(r)
+      implicit none
+      character(len=*), intent(in) :: url
+      character(len=:), allocatable :: r
+      character(len=1024) :: cmd
+      integer :: u, n
+      cmd = 'curl -s -o mochi_fetch.tmp ' // trim(url)
+      call execute_command_line(cmd)
+      open(newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
+      inquire(u, size=n)
+      allocate(character(len=n) :: r)
+      read(u) r
+      close(u)
+      call execute_command_line('rm -f mochi_fetch.tmp')
+   end function mochi_fetch
 end program main

--- a/tests/compiler/fortran/float_ops.f90.out
+++ b/tests/compiler/fortran/float_ops.f90.out
@@ -1,11 +1,11 @@
 program main
-  implicit none
-  real :: x
-  real :: y
-  x = 1.5
-  y = 2.5
-  print *, (x + y)
-  print *, (y - x)
-  print *, (x * y)
-  print *, (y / x)
+   implicit none
+   real :: x
+   real :: y
+   x = 1.5
+   y = 2.5
+   print *, (x + y)
+   print *, (y - x)
+   print *, (x * y)
+   print *, (y / x)
 end program main

--- a/tests/compiler/fortran/for_loop.f90.out
+++ b/tests/compiler/fortran/for_loop.f90.out
@@ -1,7 +1,7 @@
 program main
-  implicit none
-  integer(kind=8) :: i
-  do i = 1_8, 4_8 - 1
-    print *, i
-  end do
+   implicit none
+   integer(kind=8) :: i
+   do i = 1_8, 4_8 - 1
+      print *, i
+   end do
 end program main

--- a/tests/compiler/fortran/fun_expr.f90.out
+++ b/tests/compiler/fortran/fun_expr.f90.out
@@ -1,14 +1,14 @@
 program main
-  implicit none
-  print *, (lambda_0)(2_8, 3_8)
+   implicit none
+   print *, (lambda_0)(2_8, 3_8)
 contains
-  function lambda_0(a, b) result(res)
-    implicit none
-    integer(kind=8) :: res
-    integer(kind=8), intent(in) :: a
-    integer(kind=8), intent(in) :: b
-    res = (a + b)
-    return
-  end function lambda_0
-  
+   function lambda_0(a, b) result(res)
+      implicit none
+      integer(kind=8) :: res
+      integer(kind=8), intent(in) :: a
+      integer(kind=8), intent(in) :: b
+      res = (a + b)
+      return
+   end function lambda_0
+
 end program main

--- a/tests/compiler/fortran/if_else.f90.out
+++ b/tests/compiler/fortran/if_else.f90.out
@@ -1,23 +1,23 @@
 program main
-  implicit none
-  print *, foo((-2_8))
-  print *, foo(0_8)
-  print *, foo(3_8)
+   implicit none
+   print *, foo((-2_8))
+   print *, foo(0_8)
+   print *, foo(3_8)
 contains
-  function foo(n) result(res)
-    implicit none
-    integer(kind=8) :: res
-    integer(kind=8), intent(in) :: n
-    if ((n < 0_8)) then
-      res = (-1_8)
-      return
-    else if ((n == 0_8)) then
-      res = 0_8
-      return
-    else
-      res = 1_8
-      return
-    end if
-  end function foo
-  
+   function foo(n) result(res)
+      implicit none
+      integer(kind=8) :: res
+      integer(kind=8), intent(in) :: n
+      if ((n < 0_8)) then
+         res = (-1_8)
+         return
+      else if ((n == 0_8)) then
+         res = 0_8
+         return
+      else
+         res = 1_8
+         return
+      end if
+   end function foo
+
 end program main

--- a/tests/compiler/fortran/import_stmt.f90.out
+++ b/tests/compiler/fortran/import_stmt.f90.out
@@ -1,5 +1,5 @@
 program main
-  implicit none
-  include 'mylib.f90'
-  print *, 42_8
+   implicit none
+   include 'mylib.f90'
+   print *, 42_8
 end program main

--- a/tests/compiler/fortran/list_append.f90.out
+++ b/tests/compiler/fortran/list_append.f90.out
@@ -1,8 +1,8 @@
 program main
-  implicit none
-  integer(kind=8), allocatable :: xs(:)
-  allocate(xs(0))
-  xs = (/1_8, 2_8/)
-  xs = (/ xs, (/3_8/) /)
-  print *, xs(modulo(2_8, size(xs)) + 1)
+   implicit none
+   integer(kind=8), allocatable :: xs(:)
+   allocate(xs(0))
+   xs = (/1_8, 2_8/)
+   xs = (/ xs, (/3_8/) /)
+   print *, xs(modulo(2_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/list_concat.f90.out
+++ b/tests/compiler/fortran/list_concat.f90.out
@@ -1,4 +1,4 @@
 program main
-  implicit none
-  print *, (/ (/1_8, 2_8/), (/3_8, 4_8/) /)
+   implicit none
+   print *, (/ (/1_8, 2_8/), (/3_8, 4_8/) /)
 end program main

--- a/tests/compiler/fortran/list_index.f90.out
+++ b/tests/compiler/fortran/list_index.f90.out
@@ -1,7 +1,7 @@
 program main
-  implicit none
-  integer(kind=8), allocatable :: xs(:)
-  allocate(xs(0))
-  xs = (/10_8, 20_8, 30_8/)
-  print *, xs(modulo(1_8, size(xs)) + 1)
+   implicit none
+   integer(kind=8), allocatable :: xs(:)
+   allocate(xs(0))
+   xs = (/10_8, 20_8, 30_8/)
+   print *, xs(modulo(1_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/list_slice.f90.out
+++ b/tests/compiler/fortran/list_slice.f90.out
@@ -1,7 +1,7 @@
 program main
-  implicit none
-  integer(kind=8), allocatable :: xs(:)
-  allocate(xs(0))
-  xs = (/1_8, 2_8, 3_8, 4_8/)
-  print *, xs(modulo(1_8, size(xs)) + 1:modulo(3_8, size(xs)))
+   implicit none
+   integer(kind=8), allocatable :: xs(:)
+   allocate(xs(0))
+   xs = (/1_8, 2_8, 3_8, 4_8/)
+   print *, xs(modulo(1_8, size(xs)) + 1:modulo(3_8, size(xs)))
 end program main

--- a/tests/compiler/fortran/list_union_all.f90.out
+++ b/tests/compiler/fortran/list_union_all.f90.out
@@ -1,29 +1,4 @@
 program main
-  implicit none
-  print *, union_int((/1_8, 2_8/), (/2_8, 3_8/))
-contains
-
-  function union_int(a, b) result(r)
-    implicit none
-    integer(kind=8), intent(in) :: a(:)
-    integer(kind=8), intent(in) :: b(:)
-    integer(kind=8), allocatable :: r(:)
-    integer(kind=8), allocatable :: tmp(:)
-    integer(kind=8) :: i
-    integer(kind=8) :: n
-    allocate(tmp(size(a)+size(b)))
-    n = 0
-    do i = 1, size(a)
-      n = n + 1
-      tmp(n) = a(i)
-    end do
-    do i = 1, size(b)
-      if (.not. any(tmp(:n) == b(i))) then
-        n = n + 1
-        tmp(n) = b(i)
-      end if
-    end do
-    allocate(r(n))
-    r = tmp(:n)
-  end function union_int
+   implicit none
+   print *, (/ (/1_8, 2_8/), (/2_8, 3_8/) /)
 end program main

--- a/tests/compiler/fortran/load_save_json.f90.out
+++ b/tests/compiler/fortran/load_save_json.f90.out
@@ -1,11 +1,11 @@
 program main
-  implicit none
-  type :: Person
-    character(:), allocatable :: name
-    integer(kind=8) :: age
-  end type Person
-  type(Person), allocatable :: people(:)
-  allocate(people(0))
-  people = load_json_Person('')
-  call save_json_Person(people, '')
+   implicit none
+   type :: Person
+      character(:), allocatable :: name
+      integer(kind=8) :: age
+   end type Person
+   type(Person), allocatable :: people(:)
+   allocate(people(0))
+   people = load_json_Person('')
+   call save_json_Person(people, '')
 end program main

--- a/tests/compiler/fortran/multi_functions.f90.out
+++ b/tests/compiler/fortran/multi_functions.f90.out
@@ -1,34 +1,34 @@
 program main
-  implicit none
-  print *, add(1_8, 2_8)
-  print *, sub(10_8, 3_8)
-  print *, mul(4_8, 6_8)
+   implicit none
+   print *, add(1_8, 2_8)
+   print *, sub(10_8, 3_8)
+   print *, mul(4_8, 6_8)
 contains
-  function add(x, y) result(res)
-    implicit none
-    integer(kind=8) :: res
-    integer(kind=8), intent(in) :: x
-    integer(kind=8), intent(in) :: y
-    res = (x + y)
-    return
-  end function add
-  
-  function sub(x, y) result(res)
-    implicit none
-    integer(kind=8) :: res
-    integer(kind=8), intent(in) :: x
-    integer(kind=8), intent(in) :: y
-    res = (x - y)
-    return
-  end function sub
-  
-  function mul(x, y) result(res)
-    implicit none
-    integer(kind=8) :: res
-    integer(kind=8), intent(in) :: x
-    integer(kind=8), intent(in) :: y
-    res = (x * y)
-    return
-  end function mul
-  
+   function add(x, y) result(res)
+      implicit none
+      integer(kind=8) :: res
+      integer(kind=8), intent(in) :: x
+      integer(kind=8), intent(in) :: y
+      res = (x + y)
+      return
+   end function add
+
+   function sub(x, y) result(res)
+      implicit none
+      integer(kind=8) :: res
+      integer(kind=8), intent(in) :: x
+      integer(kind=8), intent(in) :: y
+      res = (x - y)
+      return
+   end function sub
+
+   function mul(x, y) result(res)
+      implicit none
+      integer(kind=8) :: res
+      integer(kind=8), intent(in) :: x
+      integer(kind=8), intent(in) :: y
+      res = (x * y)
+      return
+   end function mul
+
 end program main

--- a/tests/compiler/fortran/query_basic.f90.out
+++ b/tests/compiler/fortran/query_basic.f90.out
@@ -1,36 +1,36 @@
 program main
-  implicit none
-  integer(kind=8), allocatable :: xs(:)
-  integer(kind=8) :: ys
-  integer(kind=8) :: v
-  integer(kind=8) :: i_v
-  allocate(xs(0))
-  xs = (/1_8, 10_8, 20_8, 5_8/)
-  ys = lambda_0(xs)
-  do i_v = 0, size(ys) - 1
-    v = ys(modulo(i_v, size(ys)) + 1)
-    print *, v
-  end do
+   implicit none
+   integer(kind=8), allocatable :: xs(:)
+   integer(kind=8) :: ys
+   integer(kind=8) :: v
+   integer(kind=8) :: i_v
+   allocate(xs(0))
+   xs = (/1_8, 10_8, 20_8, 5_8/)
+   ys = lambda_0(xs)
+   do i_v = 0, size(ys) - 1
+      v = ys(modulo(i_v, size(ys)) + 1)
+      print *, v
+   end do
 contains
-  function lambda_0(vsrc) result(res)
-    implicit none
-    integer(kind=8), intent(in) :: vsrc(:)
-    integer(kind=8), allocatable :: res(:)
-    integer(kind=8), allocatable :: tmp(:)
-    integer(kind=8) :: x
-    integer(kind=8) :: n
-    integer(kind=8) :: i
-    allocate(tmp(size(vsrc)))
-    n = 0
-    do i = 1, size(vsrc)
-      x = vsrc(i)
-      if ((x > 9_8)) then
-        n = n + 1
-        tmp(n) = (x + 1_8)
-      end if
-    end do
-    allocate(res(n))
-    res = tmp(:n)
-  end function lambda_0
-  
+   function lambda_0(vsrc) result(res)
+      implicit none
+      integer(kind=8), intent(in) :: vsrc(:)
+      integer(kind=8), allocatable :: res(:)
+      integer(kind=8), allocatable :: tmp(:)
+      integer(kind=8) :: x
+      integer(kind=8) :: n
+      integer(kind=8) :: i
+      allocate(tmp(size(vsrc)))
+      n = 0
+      do i = 1, size(vsrc)
+         x = vsrc(i)
+         if ((x > 9_8)) then
+            n = n + 1
+            tmp(n) = (x + 1_8)
+         end if
+      end do
+      allocate(res(n))
+      res = tmp(:n)
+   end function lambda_0
+
 end program main

--- a/tests/compiler/fortran/simple_fn.f90.out
+++ b/tests/compiler/fortran/simple_fn.f90.out
@@ -1,13 +1,13 @@
 program main
-  implicit none
-  print *, id(123_8)
+   implicit none
+   print *, id(123_8)
 contains
-  function id(x) result(res)
-    implicit none
-    integer(kind=8) :: res
-    integer(kind=8), intent(in) :: x
-    res = x
-    return
-  end function id
-  
+   function id(x) result(res)
+      implicit none
+      integer(kind=8) :: res
+      integer(kind=8), intent(in) :: x
+      res = x
+      return
+   end function id
+
 end program main

--- a/tests/compiler/fortran/string_cmp.f90.out
+++ b/tests/compiler/fortran/string_cmp.f90.out
@@ -1,9 +1,9 @@
 program main
-  implicit none
-  print *, ('a' < 'b')
-  print *, ('a' <= 'a')
-  print *, ('cat' > 'car')
-  print *, ('dog' >= 'dog')
-  print *, ('abc' == 'abc')
-  print *, ('foo' /= 'bar')
+   implicit none
+   print *, ('a' < 'b')
+   print *, ('a' <= 'a')
+   print *, ('cat' > 'car')
+   print *, ('dog' >= 'dog')
+   print *, ('abc' == 'abc')
+   print *, ('foo' /= 'bar')
 end program main

--- a/tests/compiler/fortran/string_concat.f90.out
+++ b/tests/compiler/fortran/string_concat.f90.out
@@ -1,4 +1,4 @@
 program main
-  implicit none
-  print *, (trim('hello ') // trim('world'))
+   implicit none
+   print *, (trim('hello ') // trim('world'))
 end program main

--- a/tests/compiler/fortran/string_for_loop.f90.out
+++ b/tests/compiler/fortran/string_for_loop.f90.out
@@ -1,9 +1,9 @@
 program main
-  implicit none
-  character(:), allocatable :: ch
-  integer(kind=8) :: i_ch
-  do i_ch = 0, len('cat') - 1
-    ch = 'cat'(modulo(i_ch, len('cat')) + 1:modulo(i_ch, len('cat')) + 1)
-    print *, ch
-  end do
+   implicit none
+   character(:), allocatable :: ch
+   integer(kind=8) :: i_ch
+   do i_ch = 0, len('cat') - 1
+      ch = 'cat'(modulo(i_ch, len('cat')) + 1:modulo(i_ch, len('cat')) + 1)
+      print *, ch
+   end do
 end program main

--- a/tests/compiler/fortran/string_in.f90.out
+++ b/tests/compiler/fortran/string_in.f90.out
@@ -1,5 +1,5 @@
 program main
-  implicit none
-  print *, index('catch', 'cat') > 0
-  print *, index('catch', 'dog') > 0
+   implicit none
+   print *, index('catch', 'cat') > 0
+   print *, index('catch', 'dog') > 0
 end program main

--- a/tests/compiler/fortran/string_index.f90.out
+++ b/tests/compiler/fortran/string_index.f90.out
@@ -1,6 +1,6 @@
 program main
-  implicit none
-  character(:), allocatable :: text
-  text = 'hello'
-  print *, text(modulo(1_8, len(text)) + 1:modulo(1_8, len(text)) + 1)
+   implicit none
+   character(:), allocatable :: text
+   text = 'hello'
+   print *, text(modulo(1_8, len(text)) + 1:modulo(1_8, len(text)) + 1)
 end program main

--- a/tests/compiler/fortran/string_len.f90.out
+++ b/tests/compiler/fortran/string_len.f90.out
@@ -1,4 +1,4 @@
 program main
-  implicit none
-  print *, len('hello')
+   implicit none
+   print *, len('hello')
 end program main

--- a/tests/compiler/fortran/string_literal.f90.out
+++ b/tests/compiler/fortran/string_literal.f90.out
@@ -1,4 +1,4 @@
 program main
-  implicit none
-  print *, 'hello'
+   implicit none
+   print *, 'hello'
 end program main

--- a/tests/compiler/fortran/string_negative_index.f90.out
+++ b/tests/compiler/fortran/string_negative_index.f90.out
@@ -1,6 +1,6 @@
 program main
-  implicit none
-  character(:), allocatable :: text
-  text = 'hello'
-  print *, text(modulo((-1_8), len(text)) + 1:modulo((-1_8), len(text)) + 1)
+   implicit none
+   character(:), allocatable :: text
+   text = 'hello'
+   print *, text(modulo((-1_8), len(text)) + 1:modulo((-1_8), len(text)) + 1)
 end program main

--- a/tests/compiler/fortran/string_slice.f90.out
+++ b/tests/compiler/fortran/string_slice.f90.out
@@ -1,6 +1,6 @@
 program main
-  implicit none
-  character(:), allocatable :: text
-  text = 'hello'
-  print *, text(modulo(1_8, len(text)) + 1:modulo(4_8, len(text)))
+   implicit none
+   character(:), allocatable :: text
+   text = 'hello'
+   print *, text(modulo(1_8, len(text)) + 1:modulo(4_8, len(text)))
 end program main

--- a/tests/compiler/fortran/struct_literal.f90.out
+++ b/tests/compiler/fortran/struct_literal.f90.out
@@ -1,10 +1,10 @@
 program main
-  implicit none
-  type :: Point
-    integer(kind=8) :: x
-    integer(kind=8) :: y
-  end type Point
-  type(Point) :: p
-  p = Point(x=1_8, y=2_8)
-  print *, p%x
+   implicit none
+   type :: Point
+      integer(kind=8) :: x
+      integer(kind=8) :: y
+   end type Point
+   type(Point) :: p
+   p = Point(x=1_8, y=2_8)
+   print *, p%x
 end program main

--- a/tests/compiler/fortran/struct_nested.f90.out
+++ b/tests/compiler/fortran/struct_nested.f90.out
@@ -1,18 +1,18 @@
 program main
-  implicit none
-  type :: Point
-    integer(kind=8) :: x
-    integer(kind=8) :: y
-  end type Point
-  type :: Line
-    type(Point) :: start
-    type(Point) :: end
-  end type Line
-  type(Line) :: line
-  type(Point) :: p1
-  type(Point) :: p2
-  p1 = Point(x=0_8, y=0_8)
-  p2 = Point(x=1_8, y=1_8)
-  line = Line(start=p1, end=p2)
-  print *, line%start%x
+   implicit none
+   type :: Point
+      integer(kind=8) :: x
+      integer(kind=8) :: y
+   end type Point
+   type :: Line
+      type(Point) :: start
+      type(Point) :: end
+   end type Line
+   type(Line) :: line
+   type(Point) :: p1
+   type(Point) :: p2
+   p1 = Point(x=0_8, y=0_8)
+   p2 = Point(x=1_8, y=1_8)
+   line = Line(start=p1, end=p2)
+   print *, line%start%x
 end program main

--- a/tests/compiler/fortran/two_sum.f90.out
+++ b/tests/compiler/fortran/two_sum.f90.out
@@ -1,29 +1,29 @@
 program main
-  implicit none
-  integer(kind=8) :: result(2)
-  result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
-  print *, result(0_8 + 1)
-  print *, result(1_8 + 1)
+   implicit none
+   integer(kind=8) :: result(2)
+   result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
+   print *, result(0_8 + 1)
+   print *, result(1_8 + 1)
 contains
-  function twoSum(nums, target) result(res)
-    implicit none
-    integer(kind=8), intent(in) :: nums(:)
-    integer(kind=8), intent(in) :: target
-    integer(kind=8) :: n
-    integer(kind=8) :: i
-    integer(kind=8) :: j
-    integer(kind=8) :: res(2)
-    n = size(nums)
-    do i = 0_8, n - 1
-      do j = (i + 1_8), n - 1
-        if (((nums(i + 1) + nums(j + 1)) == target)) then
-          res = (/i, j/)
-          return
-        end if
+   function twoSum(nums, target) result(res)
+      implicit none
+      integer(kind=8), intent(in) :: nums(:)
+      integer(kind=8), intent(in) :: target
+      integer(kind=8) :: n
+      integer(kind=8) :: i
+      integer(kind=8) :: j
+      integer(kind=8) :: res(2)
+      n = size(nums)
+      do i = 0_8, n - 1
+         do j = (i + 1_8), n - 1
+            if (((nums(i + 1) + nums(j + 1)) == target)) then
+               res = (/i, j/)
+               return
+            end if
+         end do
       end do
-    end do
-    res = (/(-1_8), (-1_8)/)
-    return
-  end function twoSum
-  
+      res = (/(-1_8), (-1_8)/)
+      return
+   end function twoSum
+
 end program main

--- a/tests/compiler/fortran/typed_list_float.f90.out
+++ b/tests/compiler/fortran/typed_list_float.f90.out
@@ -1,7 +1,7 @@
 program main
-  implicit none
-  real, allocatable :: xs(:)
-  allocate(xs(0))
-  xs = (/1.5, 2.5/)
-  print *, xs(modulo(0_8, size(xs)) + 1)
+   implicit none
+   real, allocatable :: xs(:)
+   allocate(xs(0))
+   xs = (/1.5, 2.5/)
+   print *, xs(modulo(0_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/typed_list_negative.f90.out
+++ b/tests/compiler/fortran/typed_list_negative.f90.out
@@ -1,17 +1,17 @@
 program main
-  implicit none
-  integer(kind=8), allocatable :: xs(:)
-  allocate(xs(0))
-  xs = (/((-1_8)), 0_8, 1_8/)
-  call test_values()
+   implicit none
+   integer(kind=8), allocatable :: xs(:)
+   allocate(xs(0))
+   xs = (/((-1_8)), 0_8, 1_8/)
+   call test_values()
 contains
-  subroutine test_values()
-    implicit none
-    if (.not. (all(xs == (/((-1_8)), 0_8, 1_8/)))) then
-      print *, 'expect failed'
-      stop 1
-    end if
-    print *, 'done'
-  end subroutine test_values
-  
+   subroutine test_values()
+      implicit none
+      if (.not. (all(xs == (/((-1_8)), 0_8, 1_8/)))) then
+         print *, 'expect failed'
+         stop 1
+      end if
+      print *, 'done'
+   end subroutine test_values
+
 end program main

--- a/tests/compiler/fortran/typed_list_param.f90.out
+++ b/tests/compiler/fortran/typed_list_param.f90.out
@@ -1,13 +1,13 @@
 program main
-  implicit none
-  print *, first((/'hello', 'world'/))
+   implicit none
+   print *, first((/'hello', 'world'/))
 contains
-  function first(xs) result(res)
-    implicit none
-    character(:), allocatable :: res
-    character(len=*), intent(in) :: xs(:)
-    res = xs(modulo(0_8, len(xs)) + 1:modulo(0_8, len(xs)) + 1)
-    return
-  end function first
-  
+   function first(xs) result(res)
+      implicit none
+      character(:), allocatable :: res
+      character(len=*), intent(in) :: xs(:)
+      res = xs(modulo(0_8, len(xs)) + 1:modulo(0_8, len(xs)) + 1)
+      return
+   end function first
+
 end program main

--- a/tests/compiler/fortran/var_assignment.f90.out
+++ b/tests/compiler/fortran/var_assignment.f90.out
@@ -1,7 +1,7 @@
 program main
-  implicit none
-  integer(kind=8) :: x
-  x = 1_8
-  x = 2_8
-  print *, x
+   implicit none
+   integer(kind=8) :: x
+   x = 1_8
+   x = 2_8
+   print *, x
 end program main

--- a/tests/compiler/fortran/while_loop.f90.out
+++ b/tests/compiler/fortran/while_loop.f90.out
@@ -1,9 +1,9 @@
 program main
-  implicit none
-  integer(kind=8) :: i
-  i = 0_8
-  do while ((i < 3_8))
-    print *, i
-    i = (i + 1_8)
-  end do
+   implicit none
+   integer(kind=8) :: i
+   i = 0_8
+   do while ((i < 3_8))
+      print *, i
+      i = (i + 1_8)
+   end do
 end program main


### PR DESCRIPTION
## Summary
- add `formatCode` helper using `findent`
- run formatting at end of Fortran compilation
- regenerate Fortran test output and sample code

## Testing
- `go test ./compile/x/fortran -tags slow -run GoldenOutput -update`
- `go test ./... -tags slow -run FortranCompiler_GoldenOutput -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685e1100cb28832085d4d1330fa8f5fe