### PR TITLE
Improve Dart compiler output formatting

### DIFF
--- a/compile/x/dart/compiler.go
+++ b/compile/x/dart/compiler.go
@@ -174,7 +174,8 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.buf.Write(bodyBytes)
 	c.emitRuntime()
 	c.buf.WriteByte('\n')
-	return c.buf.Bytes(), nil
+	out := c.buf.Bytes()
+	return FormatDart(out), nil
 }
 
 func (c *Compiler) compileTypeDecls(stmts []*parser.Statement) error {

--- a/examples/leetcode-out/dart/1/two-sum.dart
+++ b/examples/leetcode-out/dart/1/two-sum.dart
@@ -1,5 +1,5 @@
-dynamic twoSum(nums, int target) {
-	dynamic n = nums.length;
+List<int> twoSum(List<int> nums, int target) {
+	int n = nums.length;
 	for (var i = 0; i < n; i++) {
 		for (var j = (i + 1); j < n; j++) {
 			if (((nums[i] + nums[j]) == target)) {
@@ -11,7 +11,7 @@ dynamic twoSum(nums, int target) {
 }
 
 void main() {
-	dynamic result = twoSum([2, 7, 11, 15], 9);
+	List<int> result = twoSum([2, 7, 11, 15], 9);
 	print(result[0]);
 	print(result[1]);
 }

--- a/examples/leetcode-out/dart/10/regular-expression-matching.dart
+++ b/examples/leetcode-out/dart/10/regular-expression-matching.dart
@@ -1,11 +1,13 @@
+import 'dart:io';
+
 bool isMatch(String s, String p) {
-	dynamic m = s.length;
-	dynamic n = p.length;
-	dynamic dp = [];
-	dynamic i = 0;
+	int m = s.length;
+	int n = p.length;
+	List<List<bool>> dp = [];
+	int i = 0;
 	while ((i <= m)) {
-		dynamic row = [];
-		dynamic j = 0;
+		List<bool> row = [];
+		int j = 0;
 		while ((j <= n)) {
 			row = (row + [false]);
 			j = ((j + 1)).toInt();
@@ -14,24 +16,24 @@ bool isMatch(String s, String p) {
 		i = ((i + 1)).toInt();
 	}
 	dp[m][n] = true;
-	dynamic i2 = m;
+	int i2 = m;
 	while ((i2 >= 0)) {
-		dynamic j2 = (n - 1);
+		int j2 = (n - 1);
 		while ((j2 >= 0)) {
-			dynamic first = false;
+			bool first = false;
 			if ((i2 < m)) {
 				if ((((_indexString(p, j2) == _indexString(s, i2))) || ((_indexString(p, j2) == ".")))) {
 					first = true;
 				}
 			}
-			dynamic star = false;
+			bool star = false;
 			if (((j2 + 1) < n)) {
 				if ((_indexString(p, ((j2 + 1)).toInt()) == "*")) {
 					star = true;
 				}
 			}
 			if (star) {
-				dynamic ok = false;
+				bool ok = false;
 				if (dp[i2][(j2 + 2)]) {
 					ok = true;
 				} else {
@@ -43,7 +45,7 @@ bool isMatch(String s, String p) {
 				}
 				dp[i2][j2] = ok;
 			} else {
-				dynamic ok = false;
+				bool ok = false;
 				if (first) {
 					if (dp[(i2 + 1)][(j2 + 1)]) {
 						ok = true;
@@ -58,17 +60,68 @@ bool isMatch(String s, String p) {
 	return dp[0][0];
 }
 
+void test_example_1() {
+	if (!((isMatch("aa", "a") == false))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((isMatch("aa", "a*") == true))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((isMatch("ab", ".*") == true))) { throw Exception('expect failed'); }
+}
+
+void test_example_4() {
+	if (!((isMatch("aab", "c*a*b") == true))) { throw Exception('expect failed'); }
+}
+
+void test_example_5() {
+	if (!((isMatch("mississippi", "mis*is*p*.") == false))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("example 4", test_example_4)) failures++;
+	if (!_runTest("example 5", test_example_5)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/11/container-with-most-water.dart
+++ b/examples/leetcode-out/dart/11/container-with-most-water.dart
@@ -1,16 +1,18 @@
-int maxArea(height) {
-	dynamic left = 0;
-	dynamic right = (height.length - 1);
+import 'dart:io';
+
+int maxArea(List<int> height) {
+	int left = 0;
+	int right = (height.length - 1);
 	dynamic maxArea = 0;
 	while ((left < right)) {
-		dynamic width = (right - left);
-		dynamic h = 0;
+		int width = (right - left);
+		int h = 0;
 		if ((height[left] < height[right])) {
 			h = (height[left]).toInt();
 		} else {
 			h = (height[right]).toInt();
 		}
-		dynamic area = (h * width);
+		int area = (h * width);
 		if ((area > maxArea)) {
 			maxArea = area;
 		}
@@ -23,6 +25,52 @@ int maxArea(height) {
 	return maxArea;
 }
 
-void main() {
+void test_example_1() {
+	if (!((maxArea([1, 8, 6, 2, 5, 4, 8, 3, 7]) == 49))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((maxArea([1, 1]) == 1))) { throw Exception('expect failed'); }
+}
+
+void test_decreasing_heights() {
+	if (!((maxArea([4, 3, 2, 1, 4]) == 16))) { throw Exception('expect failed'); }
+}
+
+void test_short_array() {
+	if (!((maxArea([1, 2, 1]) == 2))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("decreasing heights", test_decreasing_heights)) failures++;
+	if (!_runTest("short array", test_short_array)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/12/integer-to-roman.dart
+++ b/examples/leetcode-out/dart/12/integer-to-roman.dart
@@ -1,8 +1,10 @@
+import 'dart:io';
+
 String intToRoman(int num) {
 	dynamic values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
-	dynamic symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"];
-	dynamic result = "";
-	dynamic i = 0;
+	List<String> symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"];
+	String result = "";
+	int i = 0;
 	while ((num > 0)) {
 		while ((num >= values[i])) {
 			result = (result + symbols[i]);
@@ -13,6 +15,53 @@ String intToRoman(int num) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!((intToRoman(3) == "III"))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((intToRoman(58) == "LVIII"))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((intToRoman(1994) == "MCMXCIV"))) { throw Exception('expect failed'); }
+}
+
+void test_small_numbers() {
+	if (!((intToRoman(4) == "IV"))) { throw Exception('expect failed'); }
+	if (!((intToRoman(9) == "IX"))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("small numbers", test_small_numbers)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/13/roman-to-integer.dart
+++ b/examples/leetcode-out/dart/13/roman-to-integer.dart
@@ -1,12 +1,14 @@
+import 'dart:io';
+
 int romanToInt(String s) {
-	dynamic values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000};
-	dynamic total = 0;
-	dynamic i = 0;
-	dynamic n = s.length;
+	Map<String, int> values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000};
+	int total = 0;
+	int i = 0;
+	int n = s.length;
 	while ((i < n)) {
-		dynamic curr = values[_indexString(s, i)];
+		int curr = values[_indexString(s, i)];
 		if (((i + 1) < n)) {
-			dynamic next = values[_indexString(s, ((i + 1)).toInt())];
+			int next = values[_indexString(s, ((i + 1)).toInt())];
 			if ((curr < next)) {
 				total = (((total + next) - curr)).toInt();
 				i = ((i + 2)).toInt();
@@ -19,17 +21,70 @@ int romanToInt(String s) {
 	return total;
 }
 
+void test_example_1() {
+	if (!((romanToInt("III") == 3))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((romanToInt("LVIII") == 58))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((romanToInt("MCMXCIV") == 1994))) { throw Exception('expect failed'); }
+}
+
+void test_subtractive() {
+	if (!((romanToInt("IV") == 4))) { throw Exception('expect failed'); }
+	if (!((romanToInt("IX") == 9))) { throw Exception('expect failed'); }
+}
+
+void test_tens() {
+	if (!((romanToInt("XL") == 40))) { throw Exception('expect failed'); }
+	if (!((romanToInt("XC") == 90))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("subtractive", test_subtractive)) failures++;
+	if (!_runTest("tens", test_tens)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/14/longest-common-prefix.dart
+++ b/examples/leetcode-out/dart/14/longest-common-prefix.dart
@@ -1,11 +1,13 @@
-String longestCommonPrefix(strs) {
+import 'dart:io';
+
+String longestCommonPrefix(List<String> strs) {
 	if ((strs.length == 0)) {
 		return "";
 	}
-	dynamic prefix = strs[0];
+	String prefix = strs[0];
 	for (var i = 1; i < strs.length; i++) {
-		dynamic j = 0;
-		dynamic current = strs[i];
+		int j = 0;
+		String current = strs[i];
 		while (((j < prefix.length) && (j < current.length))) {
 			if ((_indexString(prefix, j) != _indexString(current, j))) {
 				break;
@@ -20,17 +22,63 @@ String longestCommonPrefix(strs) {
 	return prefix;
 }
 
+void test_example_1() {
+	if (!((longestCommonPrefix(["flower", "flow", "flight"]) == "fl"))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((longestCommonPrefix(["dog", "racecar", "car"]) == ""))) { throw Exception('expect failed'); }
+}
+
+void test_single_string() {
+	if (!((longestCommonPrefix(["single"]) == "single"))) { throw Exception('expect failed'); }
+}
+
+void test_no_common_prefix() {
+	if (!((longestCommonPrefix(["a", "b", "c"]) == ""))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("single string", test_single_string)) failures++;
+	if (!_runTest("no common prefix", test_no_common_prefix)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/15/three-sum.dart
+++ b/examples/leetcode-out/dart/15/three-sum.dart
@@ -1,5 +1,7 @@
-dynamic threeSum(nums) {
-	dynamic sorted = (() {
+import 'dart:io';
+
+List<List<int>> threeSum(List<int> nums) {
+	List<int> sorted = (() {
 	var _res = [];
 	for (var x in nums) {
 		_res.add(x);
@@ -15,16 +17,16 @@ dynamic threeSum(nums) {
 	_res = items;
 	return _res;
 })();
-	dynamic n = sorted.length;
-	dynamic res = [];
-	dynamic i = 0;
+	int n = sorted.length;
+	List<List<int>> res = [];
+	int i = 0;
 	while ((i < n)) {
 		if (((i > 0) && (sorted[i] == sorted[(i - 1)]))) {
 			i = ((i + 1)).toInt();
 			continue;
 		}
-		dynamic left = (i + 1);
-		dynamic right = (n - 1);
+		int left = (i + 1);
+		int right = (n - 1);
 		while ((left < right)) {
 			dynamic sum = ((sorted[i] + sorted[left]) + sorted[right]);
 			if ((sum == 0)) {
@@ -49,6 +51,61 @@ dynamic threeSum(nums) {
 	return res;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(threeSum([-1, 0, 1, 2, -1, -4]), [[-1, -1, 2], [-1, 0, 1]]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(threeSum([0, 1, 1]), []))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(threeSum([0, 0, 0]), [[0, 0, 0]]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/16/3sum-closest.dart
+++ b/examples/leetcode-out/dart/16/3sum-closest.dart
@@ -1,5 +1,7 @@
-int threeSumClosest(nums, int target) {
-	dynamic sorted = (() {
+import 'dart:io';
+
+int threeSumClosest(List<int> nums, int target) {
+	List<int> sorted = (() {
 	var _res = [];
 	for (var n in nums) {
 		_res.add(n);
@@ -15,30 +17,30 @@ int threeSumClosest(nums, int target) {
 	_res = items;
 	return _res;
 })();
-	dynamic n = sorted.length;
-	dynamic best = ((sorted[0] + sorted[1]) + sorted[2]);
+	int n = sorted.length;
+	int best = ((sorted[0] + sorted[1]) + sorted[2]);
 	for (var i = 0; i < n; i++) {
 		dynamic left = (i + 1);
-		dynamic right = (n - 1);
+		int right = (n - 1);
 		while ((left < right)) {
 			dynamic sum = ((sorted[i] + sorted[left]) + sorted[right]);
 			if ((sum == target)) {
 				return target;
 			}
-			dynamic diff = 0;
+			int diff = 0;
 			if ((sum > target)) {
 				diff = ((sum - target)).toInt();
 			} else {
 				diff = ((target - sum)).toInt();
 			}
-			dynamic bestDiff = 0;
+			int bestDiff = 0;
 			if ((best > target)) {
 				bestDiff = ((best - target)).toInt();
 			} else {
 				bestDiff = ((target - best)).toInt();
 			}
 			if ((diff < bestDiff)) {
-				best = sum;
+				best = (sum).toInt();
 			}
 			if ((sum < target)) {
 				left = (left + 1);
@@ -50,6 +52,47 @@ int threeSumClosest(nums, int target) {
 	return best;
 }
 
-void main() {
+void test_example_1() {
+	if (!((threeSumClosest([-1, 2, 1, -4], 1) == 2))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((threeSumClosest([0, 0, 0], 1) == 0))) { throw Exception('expect failed'); }
+}
+
+void test_additional() {
+	if (!((threeSumClosest([1, 1, 1, 0], -100) == 2))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("additional", test_additional)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/17/letter-combinations-of-a-phone-number.dart
+++ b/examples/leetcode-out/dart/17/letter-combinations-of-a-phone-number.dart
@@ -1,17 +1,19 @@
-dynamic letterCombinations(String digits) {
+import 'dart:io';
+
+List<String> letterCombinations(String digits) {
 	if ((digits.length == 0)) {
 		return [];
 	}
-	dynamic mapping = {"2": ["a", "b", "c"], "3": ["d", "e", "f"], "4": ["g", "h", "i"], "5": ["j", "k", "l"], "6": ["m", "n", "o"], "7": ["p", "q", "r", "s"], "8": ["t", "u", "v"], "9": ["w", "x", "y", "z"]};
-	dynamic result = [""];
+	Map<String, List<String>> mapping = {"2": ["a", "b", "c"], "3": ["d", "e", "f"], "4": ["g", "h", "i"], "5": ["j", "k", "l"], "6": ["m", "n", "o"], "7": ["p", "q", "r", "s"], "8": ["t", "u", "v"], "9": ["w", "x", "y", "z"]};
+	List<String> result = [""];
 	var _tmp0 = digits;
 	for (var _tmp1 in _tmp0.runes) {
 		var d = String.fromCharCode(_tmp1);
 		if (!((mapping.containsKey(d)))) {
 			continue;
 		}
-		dynamic letters = mapping[d];
-		dynamic next = (() {
+		List<String> letters = mapping[d];
+		List<String> next = (() {
 	var _res = [];
 	for (var p in result) {
 		for (var ch in letters) {
@@ -25,6 +27,71 @@ dynamic letterCombinations(String digits) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(letterCombinations("23"), ["ad", "ae", "af", "bd", "be", "bf", "cd", "ce", "cf"]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(letterCombinations(""), []))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(letterCombinations("2"), ["a", "b", "c"]))) { throw Exception('expect failed'); }
+}
+
+void test_single_seven() {
+	if (!(_equal(letterCombinations("7"), ["p", "q", "r", "s"]))) { throw Exception('expect failed'); }
+}
+
+void test_mix() {
+	if (!(_equal(letterCombinations("79"), ["pw", "px", "py", "pz", "qw", "qx", "qy", "qz", "rw", "rx", "ry", "rz", "sw", "sx", "sy", "sz"]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("single seven", test_single_seven)) failures++;
+	if (!_runTest("mix", test_mix)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/18/four-sum.dart
+++ b/examples/leetcode-out/dart/18/four-sum.dart
@@ -1,5 +1,7 @@
-dynamic fourSum(nums, int target) {
-	dynamic sorted = (() {
+import 'dart:io';
+
+List<List<int>> fourSum(List<int> nums, int target) {
+	List<int> sorted = (() {
 	var _res = [];
 	for (var n in nums) {
 		_res.add(n);
@@ -15,8 +17,8 @@ dynamic fourSum(nums, int target) {
 	_res = items;
 	return _res;
 })();
-	dynamic n = sorted.length;
-	dynamic result = [];
+	int n = sorted.length;
+	List<List<int>> result = [];
 	for (var i = 0; i < n; i++) {
 		if (((i > 0) && (sorted[i] == sorted[(i - 1)]))) {
 			continue;
@@ -26,7 +28,7 @@ dynamic fourSum(nums, int target) {
 				continue;
 			}
 			dynamic left = (j + 1);
-			dynamic right = (n - 1);
+			int right = (n - 1);
 			while ((left < right)) {
 				dynamic sum = (((sorted[i] + sorted[j]) + sorted[left]) + sorted[right]);
 				if ((sum == target)) {
@@ -51,6 +53,56 @@ dynamic fourSum(nums, int target) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(fourSum([1, 0, -1, 0, -2, 2], 0), [[-2, -1, 1, 2], [-2, 0, 0, 2], [-1, 0, 0, 1]]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(fourSum([2, 2, 2, 2, 2], 8), [[2, 2, 2, 2]]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/19/remove-nth-node-from-end-of-list.dart
+++ b/examples/leetcode-out/dart/19/remove-nth-node-from-end-of-list.dart
@@ -1,7 +1,9 @@
-dynamic removeNthFromEnd(nums, int n) {
-	dynamic idx = (nums.length - n);
-	dynamic result = [];
-	dynamic i = 0;
+import 'dart:io';
+
+List<int> removeNthFromEnd(List<int> nums, int n) {
+	int idx = (nums.length - n);
+	List result = [];
+	int i = 0;
 	while ((i < nums.length)) {
 		if ((i != idx)) {
 			result = (result + [nums[i]]);
@@ -11,6 +13,71 @@ dynamic removeNthFromEnd(nums, int n) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(removeNthFromEnd([1, 2, 3, 4, 5], 2), [1, 2, 3, 5]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(removeNthFromEnd([1], 1), []))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(removeNthFromEnd([1, 2], 1), [1]))) { throw Exception('expect failed'); }
+}
+
+void test_remove_first() {
+	if (!(_equal(removeNthFromEnd([7, 8, 9], 3), [8, 9]))) { throw Exception('expect failed'); }
+}
+
+void test_remove_last() {
+	if (!(_equal(removeNthFromEnd([7, 8, 9], 1), [7, 8]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("remove first", test_remove_first)) failures++;
+	if (!_runTest("remove last", test_remove_last)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/2/add-two-numbers.dart
+++ b/examples/leetcode-out/dart/2/add-two-numbers.dart
@@ -1,15 +1,17 @@
-dynamic addTwoNumbers(l1, l2) {
-	dynamic i = 0;
-	dynamic j = 0;
-	dynamic carry = 0;
-	dynamic result = [];
+import 'dart:io';
+
+List<int> addTwoNumbers(List<int> l1, List<int> l2) {
+	int i = 0;
+	int j = 0;
+	int carry = 0;
+	List<int> result = [];
 	while ((((i < l1.length) || (j < l2.length)) || (carry > 0))) {
-		dynamic x = 0;
+		int x = 0;
 		if ((i < l1.length)) {
 			x = (l1[i]).toInt();
 			i = ((i + 1)).toInt();
 		}
-		dynamic y = 0;
+		int y = 0;
 		if ((j < l2.length)) {
 			y = (l2[j]).toInt();
 			j = ((j + 1)).toInt();
@@ -22,6 +24,61 @@ dynamic addTwoNumbers(l1, l2) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(addTwoNumbers([2, 4, 3], [5, 6, 4]), [7, 0, 8]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(addTwoNumbers([0], [0]), [0]))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(addTwoNumbers([9, 9, 9, 9, 9, 9, 9], [9, 9, 9, 9]), [8, 9, 9, 9, 0, 0, 0, 1]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/20/valid-parentheses.dart
+++ b/examples/leetcode-out/dart/20/valid-parentheses.dart
@@ -1,8 +1,10 @@
+import 'dart:io';
+
 bool isValid(String s) {
-	dynamic stack = [];
-	dynamic n = s.length;
+	List<String> stack = [];
+	int n = s.length;
 	for (var i = 0; i < n; i++) {
-		dynamic c = _indexString(s, (i).toInt());
+		String c = _indexString(s, (i).toInt());
 		if ((c == "(")) {
 			stack = (stack + [")"]);
 		} else 
@@ -15,7 +17,7 @@ bool isValid(String s) {
 			if ((stack.length == 0)) {
 				return false;
 			}
-			dynamic top = stack[(stack.length - 1)];
+			String top = stack[(stack.length - 1)];
 			if ((top != c)) {
 				return false;
 			}
@@ -25,17 +27,83 @@ bool isValid(String s) {
 	return (stack.length == 0);
 }
 
+void test_example_1() {
+	if (!((isValid("()") == true))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((isValid("()[]{}") == true))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((isValid("(]") == false))) { throw Exception('expect failed'); }
+}
+
+void test_example_4() {
+	if (!((isValid("([)]") == false))) { throw Exception('expect failed'); }
+}
+
+void test_example_5() {
+	if (!((isValid("{[]}") == true))) { throw Exception('expect failed'); }
+}
+
+void test_empty_string() {
+	if (!((isValid("") == true))) { throw Exception('expect failed'); }
+}
+
+void test_single_closing() {
+	if (!((isValid("]") == false))) { throw Exception('expect failed'); }
+}
+
+void test_unmatched_open() {
+	if (!((isValid("((") == false))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("example 4", test_example_4)) failures++;
+	if (!_runTest("example 5", test_example_5)) failures++;
+	if (!_runTest("empty string", test_empty_string)) failures++;
+	if (!_runTest("single closing", test_single_closing)) failures++;
+	if (!_runTest("unmatched open", test_unmatched_open)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/21/merge-two-sorted-lists.dart
+++ b/examples/leetcode-out/dart/21/merge-two-sorted-lists.dart
@@ -1,7 +1,9 @@
-dynamic mergeTwoLists(l1, l2) {
-	dynamic i = 0;
-	dynamic j = 0;
-	dynamic result = [];
+import 'dart:io';
+
+List<int> mergeTwoLists(List<int> l1, List<int> l2) {
+	int i = 0;
+	int j = 0;
+	List result = [];
 	while (((i < l1.length) && (j < l2.length))) {
 		if ((l1[i] <= l2[j])) {
 			result = (result + [l1[i]]);
@@ -22,6 +24,71 @@ dynamic mergeTwoLists(l1, l2) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(mergeTwoLists([1, 2, 4], [1, 3, 4]), [1, 1, 2, 3, 4, 4]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(mergeTwoLists([], []), []))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(mergeTwoLists([], [0]), [0]))) { throw Exception('expect failed'); }
+}
+
+void test_different_lengths() {
+	if (!(_equal(mergeTwoLists([1, 5, 7], [2, 3, 4, 6, 8]), [1, 2, 3, 4, 5, 6, 7, 8]))) { throw Exception('expect failed'); }
+}
+
+void test_one_list_empty() {
+	if (!(_equal(mergeTwoLists([1, 2, 3], []), [1, 2, 3]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("different lengths", test_different_lengths)) failures++;
+	if (!_runTest("one list empty", test_one_list_empty)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/22/generate-parentheses.dart
+++ b/examples/leetcode-out/dart/22/generate-parentheses.dart
@@ -1,6 +1,8 @@
-dynamic generateParenthesis(int n) {
-	dynamic result = [];
-	dynamic backtrack(String current, int open, int close) {
+import 'dart:io';
+
+List<String> generateParenthesis(int n) {
+	List<String> result = [];
+	void backtrack(String current, int open, int close) {
 		if ((current.length == (n * 2))) {
 			result = (result + [current]);
 		} else {
@@ -16,6 +18,61 @@ dynamic generateParenthesis(int n) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(generateParenthesis(3), ["((()))", "(()())", "(())()", "()(())", "()()()"]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(generateParenthesis(1), ["()"]))) { throw Exception('expect failed'); }
+}
+
+void test_two_pairs() {
+	if (!(_equal(generateParenthesis(2), ["(())", "()()"]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("two pairs", test_two_pairs)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/23/merge-k-sorted-lists.dart
+++ b/examples/leetcode-out/dart/23/merge-k-sorted-lists.dart
@@ -1,21 +1,23 @@
-dynamic mergeKLists(lists) {
-	dynamic k = lists.length;
-	dynamic indices = [];
-	dynamic i = 0;
+import 'dart:io';
+
+List<int> mergeKLists(List<List<int>> lists) {
+	int k = lists.length;
+	List<int> indices = [];
+	int i = 0;
 	while ((i < k)) {
 		indices = (indices + [0]);
 		i = ((i + 1)).toInt();
 	}
-	dynamic result = [];
+	List<int> result = [];
 	while (true) {
-		dynamic best = 0;
-		dynamic bestList = -1;
-		dynamic found = false;
-		dynamic j = 0;
+		int best = 0;
+		int bestList = -1;
+		bool found = false;
+		int j = 0;
 		while ((j < k)) {
-			dynamic idx = indices[j];
+			int idx = indices[j];
 			if ((idx < lists[j].length)) {
-				dynamic val = lists[j][idx];
+				int val = lists[j][idx];
 				if ((!found || (val < best))) {
 					best = val;
 					bestList = j;
@@ -33,6 +35,61 @@ dynamic mergeKLists(lists) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(mergeKLists([[1, 4, 5], [1, 3, 4], [2, 6]]), [1, 1, 2, 3, 4, 4, 5, 6]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(mergeKLists([]), []))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(mergeKLists([[]]), []))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/24/swap-nodes-in-pairs.dart
+++ b/examples/leetcode-out/dart/24/swap-nodes-in-pairs.dart
@@ -1,6 +1,8 @@
-dynamic swapPairs(nums) {
-	dynamic i = 0;
-	dynamic result = [];
+import 'dart:io';
+
+List<int> swapPairs(List<int> nums) {
+	int i = 0;
+	List result = [];
 	while ((i < nums.length)) {
 		if (((i + 1) < nums.length)) {
 			result = (result + [nums[(i + 1)], nums[i]]);
@@ -12,6 +14,66 @@ dynamic swapPairs(nums) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(swapPairs([1, 2, 3, 4]), [2, 1, 4, 3]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(swapPairs([]), []))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(swapPairs([1]), [1]))) { throw Exception('expect failed'); }
+}
+
+void test_odd_length() {
+	if (!(_equal(swapPairs([1, 2, 3]), [2, 1, 3]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("odd length", test_odd_length)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/25/reverse-nodes-in-k-group.dart
+++ b/examples/leetcode-out/dart/25/reverse-nodes-in-k-group.dart
@@ -1,20 +1,22 @@
-dynamic reverseKGroup(nums, int k) {
-	dynamic n = nums.length;
+import 'dart:io';
+
+List<int> reverseKGroup(List<int> nums, int k) {
+	int n = nums.length;
 	if ((k <= 1)) {
 		return nums;
 	}
-	dynamic result = [];
-	dynamic i = 0;
+	List result = [];
+	int i = 0;
 	while ((i < n)) {
-		dynamic end = (i + k);
+		int end = (i + k);
 		if ((end <= n)) {
-			dynamic j = (end - 1);
+			int j = (end - 1);
 			while ((j >= i)) {
 				result = (result + [nums[j]]);
 				j = ((j - 1)).toInt();
 			}
 		} else {
-			dynamic j = i;
+			int j = i;
 			while ((j < n)) {
 				result = (result + [nums[j]]);
 				j = ((j + 1)).toInt();
@@ -25,6 +27,71 @@ dynamic reverseKGroup(nums, int k) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(reverseKGroup([1, 2, 3, 4, 5], 2), [2, 1, 4, 3, 5]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(reverseKGroup([1, 2, 3, 4, 5], 3), [3, 2, 1, 4, 5]))) { throw Exception('expect failed'); }
+}
+
+void test_k_equals_list_length() {
+	if (!(_equal(reverseKGroup([1, 2, 3, 4], 4), [4, 3, 2, 1]))) { throw Exception('expect failed'); }
+}
+
+void test_k_greater_than_length() {
+	if (!(_equal(reverseKGroup([1, 2, 3], 5), [1, 2, 3]))) { throw Exception('expect failed'); }
+}
+
+void test_k_is_one() {
+	if (!(_equal(reverseKGroup([1, 2, 3], 1), [1, 2, 3]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("k equals list length", test_k_equals_list_length)) failures++;
+	if (!_runTest("k greater than length", test_k_greater_than_length)) failures++;
+	if (!_runTest("k is one", test_k_is_one)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/26/remove-duplicates-from-sorted-array.dart
+++ b/examples/leetcode-out/dart/26/remove-duplicates-from-sorted-array.dart
@@ -1,12 +1,14 @@
-int removeDuplicates(nums) {
+import 'dart:io';
+
+int removeDuplicates(List<int> nums) {
 	if ((nums.length == 0)) {
 		return 0;
 	}
 	dynamic count = 1;
-	dynamic prev = nums[0];
-	dynamic i = 1;
+	int prev = nums[0];
+	int i = 1;
 	while ((i < nums.length)) {
-		dynamic cur = nums[i];
+		int cur = nums[i];
 		if ((cur != prev)) {
 			count = (count + 1);
 			prev = cur;
@@ -16,6 +18,47 @@ int removeDuplicates(nums) {
 	return count;
 }
 
-void main() {
+void test_example_1() {
+	if (!((removeDuplicates([1, 1, 2]) == 2))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((removeDuplicates([0, 0, 1, 1, 1, 2, 2, 3, 3, 4]) == 5))) { throw Exception('expect failed'); }
+}
+
+void test_empty() {
+	if (!((removeDuplicates([]) == 0))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("empty", test_empty)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/27/remove-element.dart
+++ b/examples/leetcode-out/dart/27/remove-element.dart
@@ -1,6 +1,8 @@
-int removeElement(nums, int val) {
-	dynamic k = 0;
-	dynamic i = 0;
+import 'dart:io';
+
+int removeElement(List<int> nums, int val) {
+	int k = 0;
+	int i = 0;
 	while ((i < nums.length)) {
 		if ((nums[i] != val)) {
 			nums[k] = nums[i];
@@ -11,6 +13,70 @@ int removeElement(nums, int val) {
 	return k;
 }
 
-void main() {
+void test_example_1() {
+	List<int> nums = [3, 2, 2, 3];
+	int k = removeElement(nums, 3);
+	if (!((k == 2))) { throw Exception('expect failed'); }
+	if (!(_equal(nums.sublist(0, k), [2, 2]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	List<int> nums = [0, 1, 2, 2, 3, 0, 4, 2];
+	int k = removeElement(nums, 2);
+	if (!((k == 5))) { throw Exception('expect failed'); }
+	if (!(_equal(nums.sublist(0, k), [0, 1, 3, 0, 4]))) { throw Exception('expect failed'); }
+}
+
+void test_no_removal() {
+	List<int> nums = [1, 2, 3];
+	int k = removeElement(nums, 4);
+	if (!((k == 3))) { throw Exception('expect failed'); }
+	if (!(_equal(nums.sublist(0, k), [1, 2, 3]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("no removal", test_no_removal)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/28/find-the-index-of-the-first-occurrence-in-a-string.dart
+++ b/examples/leetcode-out/dart/28/find-the-index-of-the-first-occurrence-in-a-string.dart
@@ -1,6 +1,8 @@
+import 'dart:io';
+
 int strStr(String haystack, String needle) {
-	dynamic n = haystack.length;
-	dynamic m = needle.length;
+	int n = haystack.length;
+	int m = needle.length;
 	if ((m == 0)) {
 		return 0;
 	}
@@ -8,7 +10,7 @@ int strStr(String haystack, String needle) {
 		return -1;
 	}
 	for (var i = 0; i < ((n - m) + 1); i++) {
-		dynamic j = 0;
+		int j = 0;
 		while ((j < m)) {
 			if ((_indexString(haystack, ((i + j)).toInt()) != _indexString(needle, j))) {
 				break;
@@ -22,17 +24,63 @@ int strStr(String haystack, String needle) {
 	return -1;
 }
 
+void test_example_1() {
+	if (!((strStr("sadbutsad", "sad") == 0))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((strStr("leetcode", "leeto") == (-1)))) { throw Exception('expect failed'); }
+}
+
+void test_empty_needle() {
+	if (!((strStr("abc", "") == 0))) { throw Exception('expect failed'); }
+}
+
+void test_needle_at_end() {
+	if (!((strStr("hello", "lo") == 3))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("empty needle", test_empty_needle)) failures++;
+	if (!_runTest("needle at end", test_needle_at_end)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/29/divide-two-integers.dart
+++ b/examples/leetcode-out/dart/29/divide-two-integers.dart
@@ -1,8 +1,10 @@
+import 'dart:io';
+
 int divide(int dividend, int divisor) {
 	if (((dividend == ((-2147483647 - 1))) && (divisor == (-1)))) {
 		return 2147483647;
 	}
-	dynamic negative = false;
+	bool negative = false;
 	if ((dividend < 0)) {
 		negative = !negative;
 		dividend = (-dividend).toInt();
@@ -11,10 +13,10 @@ int divide(int dividend, int divisor) {
 		negative = !negative;
 		divisor = (-divisor).toInt();
 	}
-	dynamic quotient = 0;
+	int quotient = 0;
 	while ((dividend >= divisor)) {
-		dynamic temp = divisor;
-		dynamic multiple = 1;
+		int temp = divisor;
+		int multiple = 1;
 		while ((dividend >= (temp + temp))) {
 			temp = ((temp + temp)).toInt();
 			multiple = ((multiple + multiple)).toInt();
@@ -34,6 +36,57 @@ int divide(int dividend, int divisor) {
 	return quotient;
 }
 
-void main() {
+void test_example_1() {
+	if (!((divide(10, 3) == 3))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((divide(7, -3) == (-2)))) { throw Exception('expect failed'); }
+}
+
+void test_overflow() {
+	if (!((divide(-2147483648, -1) == 2147483647))) { throw Exception('expect failed'); }
+}
+
+void test_divide_by_1() {
+	if (!((divide(12345, 1) == 12345))) { throw Exception('expect failed'); }
+}
+
+void test_negative_result() {
+	if (!((divide(-15, 2) == (-7)))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("overflow", test_overflow)) failures++;
+	if (!_runTest("divide by 1", test_divide_by_1)) failures++;
+	if (!_runTest("negative result", test_negative_result)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
+++ b/examples/leetcode-out/dart/3/longest-substring-without-repeating-characters.dart
@@ -1,10 +1,12 @@
+import 'dart:io';
+
 int lengthOfLongestSubstring(String s) {
-	dynamic n = s.length;
-	dynamic start = 0;
-	dynamic best = 0;
-	dynamic i = 0;
+	int n = s.length;
+	int start = 0;
+	int best = 0;
+	int i = 0;
 	while ((i < n)) {
-		dynamic j = start;
+		int j = start;
 		while ((j < i)) {
 			if ((_indexString(s, j) == _indexString(s, i))) {
 				start = ((j + 1)).toInt();
@@ -12,7 +14,7 @@ int lengthOfLongestSubstring(String s) {
 			}
 			j = ((j + 1)).toInt();
 		}
-		dynamic length = ((i - start) + 1);
+		int length = ((i - start) + 1);
 		if ((length > best)) {
 			best = length;
 		}
@@ -21,17 +23,63 @@ int lengthOfLongestSubstring(String s) {
 	return best;
 }
 
+void test_example_1() {
+	if (!((lengthOfLongestSubstring("abcabcbb") == 3))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((lengthOfLongestSubstring("bbbbb") == 1))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((lengthOfLongestSubstring("pwwkew") == 3))) { throw Exception('expect failed'); }
+}
+
+void test_empty_string() {
+	if (!((lengthOfLongestSubstring("") == 0))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("empty string", test_empty_string)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/30/substring-with-concatenation-of-all-words.dart
+++ b/examples/leetcode-out/dart/30/substring-with-concatenation-of-all-words.dart
@@ -1,14 +1,16 @@
-dynamic findSubstring(String s, words) {
+import 'dart:io';
+
+List<int> findSubstring(String s, List<String> words) {
 	if ((words.length == 0)) {
 		return [];
 	}
-	dynamic wordLen = words[0].length;
-	dynamic wordCount = words.length;
-	dynamic totalLen = (wordLen * wordCount);
+	int wordLen = words[0].length;
+	int wordCount = words.length;
+	int totalLen = (wordLen * wordCount);
 	if ((s.length < totalLen)) {
 		return [];
 	}
-	dynamic freq = {};
+	Map<String, int> freq = {};
 	for (var w in words) {
 		if ((freq.containsKey(w))) {
 			freq[w] = (freq[w] + 1);
@@ -16,14 +18,14 @@ dynamic findSubstring(String s, words) {
 			freq[w] = 1;
 		}
 	}
-	dynamic result = [];
+	List<int> result = [];
 	for (var offset = 0; offset < wordLen; offset++) {
 		dynamic left = offset;
 		dynamic count = 0;
-		dynamic seen = {};
+		Map<String, int> seen = {};
 		dynamic j = offset;
 		while (((j + wordLen) <= s.length)) {
-			dynamic word = s.substring(j, (j + wordLen));
+			String word = s.substring(j, (j + wordLen));
 			j = (j + wordLen);
 			if ((freq.containsKey(word))) {
 				if ((seen.containsKey(word))) {
@@ -33,14 +35,14 @@ dynamic findSubstring(String s, words) {
 				}
 				count = (count + 1);
 				while ((seen[word] > freq[word])) {
-					dynamic lw = s.substring(left, (left + wordLen));
+					String lw = s.substring(left, (left + wordLen));
 					seen[lw] = (seen[lw] - 1);
 					left = (left + wordLen);
 					count = (count - 1);
 				}
 				if ((count == wordCount)) {
 					result = (result + [left]);
-					dynamic lw = s.substring(left, (left + wordLen));
+					String lw = s.substring(left, (left + wordLen));
 					seen[lw] = (seen[lw] - 1);
 					left = (left + wordLen);
 					count = (count - 1);
@@ -55,6 +57,61 @@ dynamic findSubstring(String s, words) {
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!(_equal(findSubstring("barfoothefoobarman", ["foo", "bar"]), [0, 9]))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!(_equal(findSubstring("wordgoodgoodgoodbestword", ["word", "good", "best", "word"]), []))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!(_equal(findSubstring("barfoofoobarthefoobarman", ["bar", "foo", "the"]), [6, 9, 12]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
+++ b/examples/leetcode-out/dart/4/median-of-two-sorted-arrays.dart
@@ -1,7 +1,9 @@
-double findMedianSortedArrays(nums1, nums2) {
-	dynamic merged = [];
-	dynamic i = 0;
-	dynamic j = 0;
+import 'dart:io';
+
+double findMedianSortedArrays(List<int> nums1, List<int> nums2) {
+	List<int> merged = [];
+	int i = 0;
+	int j = 0;
 	while (((i < nums1.length) || (j < nums2.length))) {
 		if ((j >= nums2.length)) {
 			merged = (merged + [nums1[i]]);
@@ -19,15 +21,61 @@ double findMedianSortedArrays(nums1, nums2) {
 			j = ((j + 1)).toInt();
 		}
 	}
-	dynamic total = merged.length;
+	int total = merged.length;
 	if (((total % 2) == 1)) {
 		return (merged[(total ~/ 2)]).toDouble();
 	}
-	dynamic mid1 = merged[((total ~/ 2) - 1)];
-	dynamic mid2 = merged[(total ~/ 2)];
+	int mid1 = merged[((total ~/ 2) - 1)];
+	int mid2 = merged[(total ~/ 2)];
 	return ((((mid1 + mid2))).toDouble() / 2);
 }
 
-void main() {
+void test_example_1() {
+	if (!((findMedianSortedArrays([1, 3], [2]) == 2))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((findMedianSortedArrays([1, 2], [3, 4]) == 2.5))) { throw Exception('expect failed'); }
+}
+
+void test_empty_first() {
+	if (!((findMedianSortedArrays(([] as List<int>), [1]) == 1))) { throw Exception('expect failed'); }
+}
+
+void test_empty_second() {
+	if (!((findMedianSortedArrays([2], ([] as List<int>)) == 2))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("empty first", test_empty_first)) failures++;
+	if (!_runTest("empty second", test_empty_second)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
+++ b/examples/leetcode-out/dart/5/longest-palindromic-substring.dart
@@ -1,7 +1,9 @@
+import 'dart:io';
+
 int expand(String s, int left, int right) {
-	dynamic l = left;
-	dynamic r = right;
-	dynamic n = s.length;
+	int l = left;
+	int r = right;
+	int n = s.length;
 	while (((l >= 0) && (r < n))) {
 		if ((_indexString(s, l) != _indexString(s, r))) {
 			break;
@@ -16,13 +18,13 @@ String longestPalindrome(String s) {
 	if ((s.length <= 1)) {
 		return s;
 	}
-	dynamic start = 0;
-	dynamic end = 0;
-	dynamic n = s.length;
+	int start = 0;
+	int end = 0;
+	int n = s.length;
 	for (var i = 0; i < n; i++) {
-		dynamic len1 = expand(s, i, i);
-		dynamic len2 = expand(s, i, (i + 1));
-		dynamic l = len1;
+		int len1 = expand(s, i, i);
+		int len2 = expand(s, i, (i + 1));
+		int l = len1;
 		if ((len2 > len1)) {
 			l = len2;
 		}
@@ -34,17 +36,65 @@ String longestPalindrome(String s) {
 	return s.substring(start, (end + 1));
 }
 
+void test_example_1() {
+	String ans = longestPalindrome("babad");
+	if (!(((ans == "bab") || (ans == "aba")))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((longestPalindrome("cbbd") == "bb"))) { throw Exception('expect failed'); }
+}
+
+void test_single_char() {
+	if (!((longestPalindrome("a") == "a"))) { throw Exception('expect failed'); }
+}
+
+void test_two_chars() {
+	String ans = longestPalindrome("ac");
+	if (!(((ans == "a") || (ans == "c")))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("single char", test_single_char)) failures++;
+	if (!_runTest("two chars", test_two_chars)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/6/zigzag-conversion.dart
+++ b/examples/leetcode-out/dart/6/zigzag-conversion.dart
@@ -1,15 +1,17 @@
+import 'dart:io';
+
 String convert(String s, int numRows) {
 	if (((numRows <= 1) || (numRows >= s.length))) {
 		return s;
 	}
-	dynamic rows = [];
-	dynamic i = 0;
+	List<String> rows = [];
+	int i = 0;
 	while ((i < numRows)) {
 		rows = (rows + [""]);
 		i = ((i + 1)).toInt();
 	}
-	dynamic curr = 0;
-	dynamic step = 1;
+	int curr = 0;
+	int step = 1;
 	var _tmp0 = s;
 	for (var _tmp1 in _tmp0.runes) {
 		var ch = String.fromCharCode(_tmp1);
@@ -22,13 +24,54 @@ String convert(String s, int numRows) {
 		}
 		curr = ((curr + step)).toInt();
 	}
-	dynamic result = "";
+	String result = "";
 	for (var row in rows) {
 		result = (result + row);
 	}
 	return result;
 }
 
-void main() {
+void test_example_1() {
+	if (!((convert("PAYPALISHIRING", 3) == "PAHNAPLSIIGYIR"))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((convert("PAYPALISHIRING", 4) == "PINALSIGYAHRPI"))) { throw Exception('expect failed'); }
+}
+
+void test_single_row() {
+	if (!((convert("A", 1) == "A"))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("single row", test_single_row)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/7/reverse-integer.dart
+++ b/examples/leetcode-out/dart/7/reverse-integer.dart
@@ -1,13 +1,15 @@
+import 'dart:io';
+
 int reverse(int x) {
-	dynamic sign = 1;
-	dynamic n = x;
+	int sign = 1;
+	int n = x;
 	if ((n < 0)) {
 		sign = (-1).toInt();
 		n = (-n).toInt();
 	}
-	dynamic rev = 0;
+	int rev = 0;
 	while ((n != 0)) {
-		dynamic digit = (n % 10);
+		int digit = (n % 10);
 		rev = (((rev * 10) + digit)).toInt();
 		n = ((n ~/ 10)).toInt();
 	}
@@ -18,6 +20,52 @@ int reverse(int x) {
 	return rev;
 }
 
-void main() {
+void test_example_1() {
+	if (!((reverse(123) == 321))) { throw Exception('expect failed'); }
 }
+
+void test_example_2() {
+	if (!((reverse(-123) == (-321)))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((reverse(120) == 21))) { throw Exception('expect failed'); }
+}
+
+void test_overflow() {
+	if (!((reverse(1534236469) == 0))) { throw Exception('expect failed'); }
+}
+
+void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("overflow", test_overflow)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/8/string-to-integer-atoi.dart
+++ b/examples/leetcode-out/dart/8/string-to-integer-atoi.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 int digit(String ch) {
 	if ((ch == "0")) {
 		return 0;
@@ -33,22 +35,22 @@ int digit(String ch) {
 }
 
 int myAtoi(String s) {
-	dynamic i = 0;
-	dynamic n = s.length;
+	int i = 0;
+	int n = s.length;
 	while (((i < n) && (_indexString(s, i) == _indexString(" ", 0)))) {
 		i = ((i + 1)).toInt();
 	}
-	dynamic sign = 1;
+	int sign = 1;
 	if (((i < n) && (((_indexString(s, i) == _indexString("+", 0)) || (_indexString(s, i) == _indexString("-", 0)))))) {
 		if ((_indexString(s, i) == _indexString("-", 0))) {
 			sign = (-1).toInt();
 		}
 		i = ((i + 1)).toInt();
 	}
-	dynamic result = 0;
+	int result = 0;
 	while ((i < n)) {
-		dynamic ch = s.substring(i, (i + 1));
-		dynamic d = digit(ch);
+		String ch = s.substring(i, (i + 1));
+		int d = digit(ch);
 		if ((d < 0)) {
 			break;
 		}
@@ -65,17 +67,68 @@ int myAtoi(String s) {
 	return result;
 }
 
+void test_example_1() {
+	if (!((myAtoi("42") == 42))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((myAtoi("   -42") == (-42)))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((myAtoi("4193 with words") == 4193))) { throw Exception('expect failed'); }
+}
+
+void test_example_4() {
+	if (!((myAtoi("words and 987") == 0))) { throw Exception('expect failed'); }
+}
+
+void test_example_5() {
+	if (!((myAtoi("-91283472332") == (-2147483648)))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("example 4", test_example_4)) failures++;
+	if (!_runTest("example 5", test_example_5)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 

--- a/examples/leetcode-out/dart/9/palindrome-number.dart
+++ b/examples/leetcode-out/dart/9/palindrome-number.dart
@@ -1,9 +1,11 @@
+import 'dart:io';
+
 bool isPalindrome(int x) {
 	if ((x < 0)) {
 		return false;
 	}
-	dynamic s = x.toString();
-	dynamic n = s.length;
+	String s = x.toString();
+	int n = s.length;
 	for (var i = 0; i < (n ~/ 2); i++) {
 		if ((_indexString(s, (i).toInt()) != _indexString(s, (((n - 1) - i)).toInt()))) {
 			return false;
@@ -12,17 +14,63 @@ bool isPalindrome(int x) {
 	return true;
 }
 
+void test_example_1() {
+	if (!((isPalindrome(121) == true))) { throw Exception('expect failed'); }
+}
+
+void test_example_2() {
+	if (!((isPalindrome(-121) == false))) { throw Exception('expect failed'); }
+}
+
+void test_example_3() {
+	if (!((isPalindrome(10) == false))) { throw Exception('expect failed'); }
+}
+
+void test_zero() {
+	if (!((isPalindrome(0) == true))) { throw Exception('expect failed'); }
+}
+
 void main() {
+	int failures = 0;
+	if (!_runTest("example 1", test_example_1)) failures++;
+	if (!_runTest("example 2", test_example_2)) failures++;
+	if (!_runTest("example 3", test_example_3)) failures++;
+	if (!_runTest("zero", test_zero)) failures++;
+	if (failures > 0) {
+		print("\n[FAIL] $failures test(s) failed.");
+	}
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
 
 String _indexString(String s, int i) {
-	var runes = s.runes.toList();
-	if (i < 0) {
-		i += runes.length;
-	}
-	if (i < 0 || i >= runes.length) {
-		throw RangeError('index out of range');
-	}
-	return String.fromCharCode(runes[i]);
+    var runes = s.runes.toList();
+    if (i < 0) {
+        i += runes.length;
+    }
+    if (i < 0 || i >= runes.length) {
+        throw RangeError('index out of range');
+    }
+    return String.fromCharCode(runes[i]);
 }
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
 


### PR DESCRIPTION
## Summary
- run `dart format` when available to format compiled Dart source
- apply formatting step in the Dart compiler
- regenerate Dart LeetCode examples

## Testing
- `go vet ./...`
- `go run ./cmd/leetcode-runner build --from 1 --to 30 --lang dart`

------
https://chatgpt.com/codex/tasks/task_e_685e1fe763688320a356ecd3cfd9e52d