### PR TITLE
Format Haskell output

### DIFF
--- a/compile/x/hs/compiler.go
+++ b/compile/x/hs/compiler.go
@@ -198,13 +198,13 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	header.WriteString("\n\n")
 
-	code := append(header.Bytes(), c.buf.Bytes()...)
-	// Ensure the generated file ends with a trailing newline so tools like
-	// runhaskell do not complain about the last line.
-	if len(code) == 0 || code[len(code)-1] != '\n' {
-		code = append(code, '\n')
-	}
-	return code, nil
+        code := append(header.Bytes(), c.buf.Bytes()...)
+        // Ensure the generated file ends with a trailing newline so tools like
+        // runhaskell do not complain about the last line.
+        if len(code) == 0 || code[len(code)-1] != '\n' {
+                code = append(code, '\n')
+        }
+        return FormatHS(code), nil
 }
 
 func (c *Compiler) compileMainStmt(s *parser.Statement) error {

--- a/compile/x/hs/tools.go
+++ b/compile/x/hs/tools.go
@@ -1,10 +1,11 @@
 package hscode
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	rruntime "runtime"
+        "bytes"
+        "fmt"
+        "os"
+        "os/exec"
+        rruntime "runtime"
 )
 
 // EnsureHaskell verifies that ghc/runhaskell is installed. It attempts a
@@ -51,8 +52,40 @@ func EnsureHaskell() error {
 			_ = cmd.Run()
 		}
 	}
-	if _, err := exec.LookPath("runhaskell"); err == nil {
-		return nil
-	}
-	return fmt.Errorf("ghc not installed")
+        if _, err := exec.LookPath("runhaskell"); err == nil {
+                return nil
+        }
+        return fmt.Errorf("ghc not installed")
+}
+
+// FormatHS runs `ormolu` or `fourmolu` on the given source code if available.
+// If formatting fails or neither formatter is installed, the input is returned
+// unchanged. A trailing newline is ensured in the returned slice.
+func FormatHS(src []byte) []byte {
+        path, err := exec.LookPath("ormolu")
+        if err != nil {
+                if p, err := exec.LookPath("fourmolu"); err == nil {
+                        path = p
+                } else {
+                        if len(src) > 0 && src[len(src)-1] != '\n' {
+                                src = append(src, '\n')
+                        }
+                        return src
+                }
+        }
+        cmd := exec.Command(path, "--stdin-input-file", "Main.hs")
+        cmd.Stdin = bytes.NewReader(src)
+        var out bytes.Buffer
+        cmd.Stdout = &out
+        if err := cmd.Run(); err == nil {
+                res := out.Bytes()
+                if len(res) == 0 || res[len(res)-1] != '\n' {
+                        res = append(res, '\n')
+                }
+                return res
+        }
+        if len(src) > 0 && src[len(src)-1] != '\n' {
+                src = append(src, '\n')
+        }
+        return src
 }

--- a/examples/leetcode-out/hs/1/two-sum.hs
+++ b/examples/leetcode-out/hs/1/two-sum.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,6 +55,58 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
 
 twoSum :: [Int] -> Int -> [Int]
 twoSum nums target = fromMaybe ([]) $
@@ -33,8 +114,9 @@ twoSum nums target = fromMaybe ([]) $
   where
     n = length nums
 
+result = twoSum [2, 7, 11, 15] 9
+
 main :: IO ()
 main = do
-    let result = twoSum [2, 7, 11, 15] 9
     print ((result !! 0))
     print ((result !! 1))

--- a/examples/leetcode-out/hs/10/regular-expression-matching.hs
+++ b/examples/leetcode-out/hs/10/regular-expression-matching.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,14 +55,94 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 isMatch :: String -> String -> Bool
 isMatch s p = fromMaybe (False) $
-    (let m = length s in (let n = length p in (let dp = [] in (let i = 0 in (let dp = True in (let i2 = m in Just (((dp !! 0) !! 0))))))))
+    (let m = length s in (let n = length p in (let dp = [] in (let i = 0 in case whileLoop (\() -> (i <= m)) (\() -> (let row = [] in (let j = 0 in case whileLoop (\() -> (j <= n)) (\() -> (let row = (row + [False]) in (let j = (j + 1) in Nothing))) of Just v -> Just v; Nothing -> (let dp = (dp + [row]) in (let i = (i + 1) in Nothing))))) of Just v -> Just v; Nothing -> (let dp = True in (let i2 = m in case whileLoop (\() -> (i2 >= 0)) (\() -> (let j2 = (n - 1) in case whileLoop (\() -> (j2 >= 0)) (\() -> (let first = False in case if (i2 < m) then if ((((p !! j2) == (s !! i2))) || (((p !! j2) == "."))) then (let first = True in Nothing) else Nothing else Nothing of Just v -> Just v; Nothing -> (let star = False in case if ((j2 + 1) < n) then if ((p !! (j2 + 1)) == "*") then (let star = True in Nothing) else Nothing else Nothing of Just v -> Just v; Nothing -> case if star then (let ok = False in case if ((dp !! i2) !! (j2 + 2)) then (let ok = True in Nothing) else if first then if ((dp !! (i2 + 1)) !! j2) then (let ok = True in Nothing) else Nothing else Nothing of Just v -> Just v; Nothing -> (let dp = ok in Nothing)) else (let ok = False in case if first then if ((dp !! (i2 + 1)) !! (j2 + 1)) then (let ok = True in Nothing) else Nothing else Nothing of Just v -> Just v; Nothing -> (let dp = ok in Nothing)) of Just v -> Just v; Nothing -> (let j2 = (j2 - 1) in Nothing)))) of Just v -> Just v; Nothing -> (let i2 = (i2 - 1) in Nothing))) of Just v -> Just v; Nothing -> Just (((dp !! 0) !! 0))))))))
   where
     m = length s
     n = length p
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((isMatch "aa" "a" == False))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((isMatch "aa" "a*" == True))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((isMatch "ab" ".*" == True))
+
+test_example_4 :: IO ()
+test_example_4 = do
+    expect ((isMatch "aab" "c*a*b" == True))
+
+test_example_5 :: IO ()
+test_example_5 = do
+    expect ((isMatch "mississippi" "mis*is*p*." == False))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_example_4
+    test_example_5

--- a/examples/leetcode-out/hs/12/integer-to-roman.hs
+++ b/examples/leetcode-out/hs/12/integer-to-roman.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,14 +55,90 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 intToRoman :: Int -> String
 intToRoman num = fromMaybe ("") $
-    (let values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1] in (let symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"] in (let result = "" in (let i = 0 in Just (result)))))
+    (let values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1] in (let symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"] in (let result = "" in (let i = 0 in case whileLoop (\() -> (num > 0)) (\() -> case whileLoop (\() -> (num >= (values !! i))) (\() -> (let result = (result + (symbols !! i)) in (let num = (num - (values !! i)) in Nothing))) of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing)) of Just v -> Just v; Nothing -> Just (result)))))
   where
     values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1]
     symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"]
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((intToRoman 3 == "III"))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((intToRoman 58 == "LVIII"))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((intToRoman 1994 == "MCMXCIV"))
+
+test_small_numbers :: IO ()
+test_small_numbers = do
+    expect ((intToRoman 4 == "IV"))
+    expect ((intToRoman 9 == "IX"))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_small_numbers

--- a/examples/leetcode-out/hs/13/roman-to-integer.hs
+++ b/examples/leetcode-out/hs/13/roman-to-integer.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -13,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -27,13 +55,95 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 romanToInt :: String -> Int
 romanToInt s = fromMaybe (0) $
-    (let values = Map.fromList [("I", 1), ("V", 5), ("X", 10), ("L", 50), ("C", 100), ("D", 500), ("M", 1000)] in (let total = 0 in (let i = 0 in (let n = length s in Just (total)))))
+    (let values = Map.fromList [("I", 1), ("V", 5), ("X", 10), ("L", 50), ("C", 100), ("D", 500), ("M", 1000)] in (let total = 0 in (let i = 0 in (let n = length s in case whileLoop (\() -> (i < n)) (\() -> (let curr = (values !! (s !! i)) in case if ((i + 1) < n) then (let next = (values !! (s !! (i + 1))) in if (curr < next) then (let total = ((total + next) - curr) in (let i = (i + 2) in Nothing)) else Nothing) else Nothing of Just v -> Just v; Nothing -> (let total = (total + curr) in (let i = (i + 1) in Nothing)))) of Just v -> Just v; Nothing -> Just (total)))))
   where
     values = Map.fromList [("I", 1), ("V", 5), ("X", 10), ("L", 50), ("C", 100), ("D", 500), ("M", 1000)]
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((romanToInt "III" == 3))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((romanToInt "LVIII" == 58))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((romanToInt "MCMXCIV" == 1994))
+
+test_subtractive :: IO ()
+test_subtractive = do
+    expect ((romanToInt "IV" == 4))
+    expect ((romanToInt "IX" == 9))
+
+test_tens :: IO ()
+test_tens = do
+    expect ((romanToInt "XL" == 40))
+    expect ((romanToInt "XC" == 90))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_subtractive
+    test_tens

--- a/examples/leetcode-out/hs/14/longest-common-prefix.hs
+++ b/examples/leetcode-out/hs/14/longest-common-prefix.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,106 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start s)
+
 
 longestCommonPrefix :: [String] -> String
 longestCommonPrefix strs = fromMaybe ("") $
-    case if (length strs == 0) then Just ("") else Nothing of Just v -> Just v; Nothing -> (let prefix = (strs !! 0) in case forLoop 1 length strs (\i -> (let j = 0 in (let current = (strs !! i) in (let prefix = (prefix !! 0) in if (prefix == "") then Nothing else Nothing)))) of Just v -> Just v; Nothing -> Just (prefix))
+    case if (length strs == 0) then Just ("") else Nothing of Just v -> Just v; Nothing -> (let prefix = (strs !! 0) in case forLoop 1 length strs (\i -> (let j = 0 in (let current = (strs !! i) in case whileLoop (\() -> (((j < length prefix) && j) < length current)) (\() -> case if ((prefix !! j) /= (current !! j)) then Just () else Nothing of Just v -> Just v; Nothing -> (let j = (j + 1) in Nothing)) of Just v -> Just v; Nothing -> (let prefix = _slice prefix 0 j in if (prefix == "") then Just () else Nothing)))) of Just v -> Just v; Nothing -> Just (prefix))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((longestCommonPrefix ["flower", "flow", "flight"] == "fl"))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((longestCommonPrefix ["dog", "racecar", "car"] == ""))
+
+test_single_string :: IO ()
+test_single_string = do
+    expect ((longestCommonPrefix ["single"] == "single"))
+
+test_no_common_prefix :: IO ()
+test_no_common_prefix = do
+    expect ((longestCommonPrefix ["a", "b", "c"] == ""))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_single_string
+    test_no_common_prefix

--- a/examples/leetcode-out/hs/15/three-sum.hs
+++ b/examples/leetcode-out/hs/15/three-sum.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,14 +55,84 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 threeSum :: [Int] -> [[Int]]
 threeSum nums = fromMaybe ([]) $
-    (let sorted = 0 in (let n = length sorted in (let res = [] in (let i = 0 in Just (res)))))
+    (let sorted = map snd (List.sortOn fst [ ( x, x ) | x <- nums ]) in (let n = length sorted in (let res = [] in (let i = 0 in case whileLoop (\() -> (i < n)) (\() -> case if (((i > 0) && (sorted !! i)) == (sorted !! (i - 1))) then (let i = (i + 1) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let left = (i + 1) in (let right = (n - 1) in case whileLoop (\() -> (left < right)) (\() -> (let sum = (((sorted !! i) + (sorted !! left)) + (sorted !! right)) in if (sum == 0) then (let res = (res + [[(sorted !! i), (sorted !! left), (sorted !! right)]]) in (let left = (left + 1) in case whileLoop (\() -> (((left < right) && (sorted !! left)) == (sorted !! (left - 1)))) (\() -> (let left = (left + 1) in Nothing)) of Just v -> Just v; Nothing -> (let right = (right - 1) in whileLoop (\() -> (((left < right) && (sorted !! right)) == (sorted !! (right + 1)))) (\() -> (let right = (right - 1) in Nothing))))) else if (sum < 0) then (let left = (left + 1) in Nothing) else (let right = (right - 1) in Nothing))) of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing)))) of Just v -> Just v; Nothing -> Just (res)))))
   where
-    sorted = 0
+    sorted = map snd (List.sortOn fst [ ( x, x ) | x <- nums ])
     n = length sorted
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((threeSum [(-1), 0, 1, 2, (-1), (-4)] == [[(-1), (-1), 2], [(-1), 0, 1]]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((threeSum [0, 1, 1] == []))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((threeSum [0, 0, 0] == [[0, 0, 0]]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3

--- a/examples/leetcode-out/hs/16/3sum-closest.hs
+++ b/examples/leetcode-out/hs/16/3sum-closest.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,14 +55,84 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 threeSumClosest :: [Int] -> Int -> Int
 threeSumClosest nums target = fromMaybe (0) $
-    (let sorted = 0 in (let n = length sorted in (let best = (((sorted !! 0) + (sorted !! 1)) + (sorted !! 2)) in case forLoop 0 n (\i -> (let left = (i + 1) in (let right = (n - 1) in Nothing))) of Just v -> Just v; Nothing -> Just (best))))
+    (let sorted = map snd (List.sortOn fst [ ( n, n ) | n <- nums ]) in (let n = length sorted in (let best = (((sorted !! 0) + (sorted !! 1)) + (sorted !! 2)) in case forLoop 0 n (\i -> (let left = (i + 1) in (let right = (n - 1) in whileLoop (\() -> (left < right)) (\() -> (let sum = (((sorted !! i) + (sorted !! left)) + (sorted !! right)) in case if (sum == target) then Just (target) else Nothing of Just v -> Just v; Nothing -> (let diff = 0 in case if (sum > target) then (let diff = (sum - target) in Nothing) else (let diff = (target - sum) in Nothing) of Just v -> Just v; Nothing -> (let bestDiff = 0 in case if (best > target) then (let bestDiff = (best - target) in Nothing) else (let bestDiff = (target - best) in Nothing) of Just v -> Just v; Nothing -> case if (diff < bestDiff) then (let best = sum in Nothing) else Nothing of Just v -> Just v; Nothing -> if (sum < target) then (let left = (left + 1) in Nothing) else (let right = (right - 1) in Nothing)))))))) of Just v -> Just v; Nothing -> Just (best))))
   where
-    sorted = 0
+    sorted = map snd (List.sortOn fst [ ( n, n ) | n <- nums ])
     n = length sorted
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((threeSumClosest [(-1), 2, 1, (-4)] 1 == 2))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((threeSumClosest [0, 0, 0] 1 == 0))
+
+test_additional :: IO ()
+test_additional = do
+    expect ((threeSumClosest [1, 1, 1, 0] (-100) == 2))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_additional

--- a/examples/leetcode-out/hs/17/letter-combinations-of-a-phone-number.hs
+++ b/examples/leetcode-out/hs/17/letter-combinations-of-a-phone-number.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -13,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -27,11 +55,91 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 letterCombinations :: String -> [String]
 letterCombinations digits = fromMaybe ([]) $
-    case if (length digits == 0) then Just ([]) else Nothing of Just v -> Just v; Nothing -> (let mapping = Map.fromList [("2", ["a", "b", "c"]), ("3", ["d", "e", "f"]), ("4", ["g", "h", "i"]), ("5", ["j", "k", "l"]), ("6", ["m", "n", "o"]), ("7", ["p", "q", "r", "s"]), ("8", ["t", "u", "v"]), ("9", ["w", "x", "y", "z"])] in (let result = [""] in case foldr (\d acc -> case case if not ((d in mapping)) then Nothing else Nothing of Just v -> Just v; Nothing -> (let letters = (mapping !! d) in (let next = 0 in (let result = next in Nothing))) of Just v -> Just v; Nothing -> acc) Nothing digits of Just v -> Just v; Nothing -> Just (result)))
+    case if (length digits == 0) then Just ([]) else Nothing of Just v -> Just v; Nothing -> (let mapping = Map.fromList [("2", ["a", "b", "c"]), ("3", ["d", "e", "f"]), ("4", ["g", "h", "i"]), ("5", ["j", "k", "l"]), ("6", ["m", "n", "o"]), ("7", ["p", "q", "r", "s"]), ("8", ["t", "u", "v"]), ("9", ["w", "x", "y", "z"])] in (let result = [""] in case foldr (\d acc -> case case if not (elem d mapping) then Nothing else Nothing of Just v -> Just v; Nothing -> (let letters = (mapping !! d) in (let next = [(p + ch) | p <- result, ch <- letters] in (let result = next in Nothing))) of Just v -> Just v; Nothing -> acc) Nothing digits of Just v -> Just v; Nothing -> Just (result)))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((letterCombinations "23" == ["ad", "ae", "af", "bd", "be", "bf", "cd", "ce", "cf"]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((letterCombinations "" == []))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((letterCombinations "2" == ["a", "b", "c"]))
+
+test_single_seven :: IO ()
+test_single_seven = do
+    expect ((letterCombinations "7" == ["p", "q", "r", "s"]))
+
+test_mix :: IO ()
+test_mix = do
+    expect ((letterCombinations "79" == ["pw", "px", "py", "pz", "qw", "qx", "qy", "qz", "rw", "rx", "ry", "rz", "sw", "sx", "sy", "sz"]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_single_seven
+    test_mix

--- a/examples/leetcode-out/hs/18/four-sum.hs
+++ b/examples/leetcode-out/hs/18/four-sum.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,14 +55,79 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 fourSum :: [Int] -> Int -> [[Int]]
 fourSum nums target = fromMaybe ([]) $
-    (let sorted = 0 in (let n = length sorted in (let result = [] in case forLoop 0 n (\i -> case if (((i > 0) && (sorted !! i)) == (sorted !! (i - 1))) then Nothing else Nothing of Just v -> Just v; Nothing -> forLoop (i + 1) n (\j -> case if ((((j > i) + 1) && (sorted !! j)) == (sorted !! (j - 1))) then Nothing else Nothing of Just v -> Just v; Nothing -> (let left = (j + 1) in (let right = (n - 1) in Nothing)))) of Just v -> Just v; Nothing -> Just (result))))
+    (let sorted = map snd (List.sortOn fst [ ( n, n ) | n <- nums ]) in (let n = length sorted in (let result = [] in case forLoop 0 n (\i -> case if (((i > 0) && (sorted !! i)) == (sorted !! (i - 1))) then Nothing else Nothing of Just v -> Just v; Nothing -> forLoop (i + 1) n (\j -> case if ((((j > i) + 1) && (sorted !! j)) == (sorted !! (j - 1))) then Nothing else Nothing of Just v -> Just v; Nothing -> (let left = (j + 1) in (let right = (n - 1) in whileLoop (\() -> (left < right)) (\() -> (let sum = ((((sorted !! i) + (sorted !! j)) + (sorted !! left)) + (sorted !! right)) in if (sum == target) then (let result = (result + [[(sorted !! i), (sorted !! j), (sorted !! left), (sorted !! right)]]) in (let left = (left + 1) in (let right = (right - 1) in case whileLoop (\() -> (((left < right) && (sorted !! left)) == (sorted !! (left - 1)))) (\() -> (let left = (left + 1) in Nothing)) of Just v -> Just v; Nothing -> whileLoop (\() -> (((left < right) && (sorted !! right)) == (sorted !! (right + 1)))) (\() -> (let right = (right - 1) in Nothing))))) else if (sum < target) then (let left = (left + 1) in Nothing) else (let right = (right - 1) in Nothing))))))) of Just v -> Just v; Nothing -> Just (result))))
   where
-    sorted = 0
+    sorted = map snd (List.sortOn fst [ ( n, n ) | n <- nums ])
     n = length sorted
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((fourSum [1, 0, (-1), 0, (-2), 2] 0 == [[(-2), (-1), 1, 2], [(-2), 0, 0, 2], [(-1), 0, 0, 1]]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((fourSum [2, 2, 2, 2, 2] 8 == [[2, 2, 2, 2]]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2

--- a/examples/leetcode-out/hs/19/remove-nth-node-from-end-of-list.hs
+++ b/examples/leetcode-out/hs/19/remove-nth-node-from-end-of-list.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,13 +55,93 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 removeNthFromEnd :: [Int] -> Int -> [Int]
 removeNthFromEnd nums n = fromMaybe ([]) $
-    (let idx = (length nums - n) in (let result = [] in (let i = 0 in Just (result))))
+    (let idx = (length nums - n) in (let result = [] in (let i = 0 in case whileLoop (\() -> (i < length nums)) (\() -> case if (i /= idx) then (let result = (result + [(nums !! i)]) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing)) of Just v -> Just v; Nothing -> Just (result))))
   where
     idx = (length nums - n)
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((removeNthFromEnd [1, 2, 3, 4, 5] 2 == [1, 2, 3, 5]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((removeNthFromEnd [1] 1 == []))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((removeNthFromEnd [1, 2] 1 == [1]))
+
+test_remove_first :: IO ()
+test_remove_first = do
+    expect ((removeNthFromEnd [7, 8, 9] 3 == [8, 9]))
+
+test_remove_last :: IO ()
+test_remove_last = do
+    expect ((removeNthFromEnd [7, 8, 9] 1 == [7, 8]))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_remove_first
+    test_remove_last

--- a/examples/leetcode-out/hs/2/add-two-numbers.hs
+++ b/examples/leetcode-out/hs/2/add-two-numbers.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,81 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 addTwoNumbers :: [Int] -> [Int] -> [Int]
 addTwoNumbers l1 l2 = fromMaybe ([]) $
-    (let i = 0 in (let j = 0 in (let carry = 0 in (let result = [] in Just (result)))))
+    (let i = 0 in (let j = 0 in (let carry = 0 in (let result = [] in case whileLoop (\() -> (((((i < length l1) || j) < length l2) || carry) > 0)) (\() -> (let x = 0 in case if (i < length l1) then (let x = (l1 !! i) in (let i = (i + 1) in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let y = 0 in case if (j < length l2) then (let y = (l2 !! j) in (let j = (j + 1) in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let sum = ((x + y) + carry) in (let digit = (sum `mod` 10) in (let carry = (div sum 10) in (let result = (result + [digit]) in Nothing))))))) of Just v -> Just v; Nothing -> Just (result)))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((addTwoNumbers [2, 4, 3] [5, 6, 4] == [7, 0, 8]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((addTwoNumbers [0] [0] == [0]))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((addTwoNumbers [9, 9, 9, 9, 9, 9, 9] [9, 9, 9, 9] == [8, 9, 9, 9, 0, 0, 0, 1]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3

--- a/examples/leetcode-out/hs/20/valid-parentheses.hs
+++ b/examples/leetcode-out/hs/20/valid-parentheses.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,126 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start s)
+
 
 isValid :: String -> Bool
 isValid s = fromMaybe (False) $
-    (let stack = [] in (let n = length s in case forLoop 0 n (\i -> (let c = (s !! i) in if (c == "(") then (let stack = (stack + [")"]) in Nothing) else if (c == "[") then (let stack = (stack + ["]"]) in Nothing) else if (c == "{") then (let stack = (stack + ["}"]) in Nothing) else case if (length stack == 0) then Just (False) else Nothing of Just v -> Just v; Nothing -> (let top = (stack !! (length stack - 1)) in case if (top /= c) then Just (False) else Nothing of Just v -> Just v; Nothing -> (let stack = (stack !! 0) in Nothing)))) of Just v -> Just v; Nothing -> Just ((length stack == 0))))
+    (let stack = [] in (let n = length s in case forLoop 0 n (\i -> (let c = (s !! i) in if (c == "(") then (let stack = (stack + [")"]) in Nothing) else if (c == "[") then (let stack = (stack + ["]"]) in Nothing) else if (c == "{") then (let stack = (stack + ["}"]) in Nothing) else case if (length stack == 0) then Just (False) else Nothing of Just v -> Just v; Nothing -> (let top = (stack !! (length stack - 1)) in case if (top /= c) then Just (False) else Nothing of Just v -> Just v; Nothing -> (let stack = _slice stack 0 (length stack - 1) in Nothing)))) of Just v -> Just v; Nothing -> Just ((length stack == 0))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((isValid "()" == True))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((isValid "()[]{}" == True))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((isValid "(]" == False))
+
+test_example_4 :: IO ()
+test_example_4 = do
+    expect ((isValid "([)]" == False))
+
+test_example_5 :: IO ()
+test_example_5 = do
+    expect ((isValid "{[]}" == True))
+
+test_empty_string :: IO ()
+test_empty_string = do
+    expect ((isValid "" == True))
+
+test_single_closing :: IO ()
+test_single_closing = do
+    expect ((isValid "]" == False))
+
+test_unmatched_open :: IO ()
+test_unmatched_open = do
+    expect ((isValid "((" == False))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_example_4
+    test_example_5
+    test_empty_string
+    test_single_closing
+    test_unmatched_open

--- a/examples/leetcode-out/hs/21/merge-two-sorted-lists.hs
+++ b/examples/leetcode-out/hs/21/merge-two-sorted-lists.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,91 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 mergeTwoLists :: [Int] -> [Int] -> [Int]
 mergeTwoLists l1 l2 = fromMaybe ([]) $
-    (let i = 0 in (let j = 0 in (let result = [] in Just (result))))
+    (let i = 0 in (let j = 0 in (let result = [] in case whileLoop (\() -> (((i < length l1) && j) < length l2)) (\() -> if ((l1 !! i) <= (l2 !! j)) then (let result = (result + [(l1 !! i)]) in (let i = (i + 1) in Nothing)) else (let result = (result + [(l2 !! j)]) in (let j = (j + 1) in Nothing))) of Just v -> Just v; Nothing -> case whileLoop (\() -> (i < length l1)) (\() -> (let result = (result + [(l1 !! i)]) in (let i = (i + 1) in Nothing))) of Just v -> Just v; Nothing -> case whileLoop (\() -> (j < length l2)) (\() -> (let result = (result + [(l2 !! j)]) in (let j = (j + 1) in Nothing))) of Just v -> Just v; Nothing -> Just (result))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((mergeTwoLists [1, 2, 4] [1, 3, 4] == [1, 1, 2, 3, 4, 4]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((mergeTwoLists [] [] == []))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((mergeTwoLists [] [0] == [0]))
+
+test_different_lengths :: IO ()
+test_different_lengths = do
+    expect ((mergeTwoLists [1, 5, 7] [2, 3, 4, 6, 8] == [1, 2, 3, 4, 5, 6, 7, 8]))
+
+test_one_list_empty :: IO ()
+test_one_list_empty = do
+    expect ((mergeTwoLists [1, 2, 3] [] == [1, 2, 3]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_different_lengths
+    test_one_list_empty

--- a/examples/leetcode-out/hs/22/generate-parentheses.hs
+++ b/examples/leetcode-out/hs/22/generate-parentheses.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,81 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 generateParenthesis :: Int -> [String]
 generateParenthesis n = fromMaybe ([]) $
-    (let result = [] in case (let _ = backtrack "" 0 0 in Nothing) of Just v -> Just v; Nothing -> Just (result))
+    (let result = [] in (let backtrack = (\current open close -> fromMaybe (()) $ if ((length current == n) * 2) then (let result = (result + [current]) in Nothing) else case if (open < n) then (let _ = backtrack (current + "(") (open + 1) close in Nothing) else Nothing of Just v -> Just v; Nothing -> if (close < open) then (let _ = backtrack (current + ")") open (close + 1) in Nothing) else Nothing) in case (let _ = backtrack "" 0 0 in Nothing) of Just v -> Just v; Nothing -> Just (result)))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((generateParenthesis 3 == ["((()))", "(()())", "(())()", "()(())", "()()()"]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((generateParenthesis 1 == ["()"]))
+
+test_two_pairs :: IO ()
+test_two_pairs = do
+    expect ((generateParenthesis 2 == ["(())", "()()"]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_two_pairs

--- a/examples/leetcode-out/hs/23/merge-k-sorted-lists.hs
+++ b/examples/leetcode-out/hs/23/merge-k-sorted-lists.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,13 +55,83 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 mergeKLists :: [[Int]] -> [Int]
 mergeKLists lists = fromMaybe ([]) $
-    (let k = length lists in (let indices = [] in (let i = 0 in (let result = [] in Just (result)))))
+    (let k = length lists in (let indices = [] in (let i = 0 in case whileLoop (\() -> (i < k)) (\() -> (let indices = (indices + [0]) in (let i = (i + 1) in Nothing))) of Just v -> Just v; Nothing -> (let result = [] in case whileLoop (\() -> True) (\() -> (let best = 0 in (let bestList = (-1) in (let found = False in (let j = 0 in case whileLoop (\() -> (j < k)) (\() -> (let idx = (indices !! j) in case if (idx < length (lists !! j)) then (let val = ((lists !! j) !! idx) in if ((not found || val) < best) then (let best = val in (let bestList = j in (let found = True in Nothing))) else Nothing) else Nothing of Just v -> Just v; Nothing -> (let j = (j + 1) in Nothing))) of Just v -> Just v; Nothing -> case if not found then Just () else Nothing of Just v -> Just v; Nothing -> (let result = (result + [best]) in (let indices = ((indices !! bestList) + 1) in Nothing))))))) of Just v -> Just v; Nothing -> Just (result)))))
   where
     k = length lists
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((mergeKLists [[1, 4, 5], [1, 3, 4], [2, 6]] == [1, 1, 2, 3, 4, 4, 5, 6]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((mergeKLists [] == []))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((mergeKLists [[]] == []))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3

--- a/examples/leetcode-out/hs/24/swap-nodes-in-pairs.hs
+++ b/examples/leetcode-out/hs/24/swap-nodes-in-pairs.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,86 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 swapPairs :: [Int] -> [Int]
 swapPairs nums = fromMaybe ([]) $
-    (let i = 0 in (let result = [] in Just (result)))
+    (let i = 0 in (let result = [] in case whileLoop (\() -> (i < length nums)) (\() -> case if ((i + 1) < length nums) then (let result = (result + [(nums !! (i + 1)), (nums !! i)]) in Nothing) else (let result = (result + [(nums !! i)]) in Nothing) of Just v -> Just v; Nothing -> (let i = (i + 2) in Nothing)) of Just v -> Just v; Nothing -> Just (result)))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((swapPairs [1, 2, 3, 4] == [2, 1, 4, 3]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((swapPairs [] == []))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((swapPairs [1] == [1]))
+
+test_odd_length :: IO ()
+test_odd_length = do
+    expect ((swapPairs [1, 2, 3] == [2, 1, 3]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_odd_length

--- a/examples/leetcode-out/hs/25/reverse-nodes-in-k-group.hs
+++ b/examples/leetcode-out/hs/25/reverse-nodes-in-k-group.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,13 +55,93 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 reverseKGroup :: [Int] -> Int -> [Int]
 reverseKGroup nums k = fromMaybe ([]) $
-    (let n = length nums in case if (k <= 1) then Just (nums) else Nothing of Just v -> Just v; Nothing -> (let result = [] in (let i = 0 in Just (result))))
+    (let n = length nums in case if (k <= 1) then Just (nums) else Nothing of Just v -> Just v; Nothing -> (let result = [] in (let i = 0 in case whileLoop (\() -> (i < n)) (\() -> (let end = (i + k) in case if (end <= n) then (let j = (end - 1) in whileLoop (\() -> (j >= i)) (\() -> (let result = (result + [(nums !! j)]) in (let j = (j - 1) in Nothing)))) else (let j = i in whileLoop (\() -> (j < n)) (\() -> (let result = (result + [(nums !! j)]) in (let j = (j + 1) in Nothing)))) of Just v -> Just v; Nothing -> (let i = (i + k) in Nothing))) of Just v -> Just v; Nothing -> Just (result))))
   where
     n = length nums
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((reverseKGroup [1, 2, 3, 4, 5] 2 == [2, 1, 4, 3, 5]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((reverseKGroup [1, 2, 3, 4, 5] 3 == [3, 2, 1, 4, 5]))
+
+test_k_equals_list_length :: IO ()
+test_k_equals_list_length = do
+    expect ((reverseKGroup [1, 2, 3, 4] 4 == [4, 3, 2, 1]))
+
+test_k_greater_than_length :: IO ()
+test_k_greater_than_length = do
+    expect ((reverseKGroup [1, 2, 3] 5 == [1, 2, 3]))
+
+test_k_is_one :: IO ()
+test_k_is_one = do
+    expect ((reverseKGroup [1, 2, 3] 1 == [1, 2, 3]))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_k_equals_list_length
+    test_k_greater_than_length
+    test_k_is_one

--- a/examples/leetcode-out/hs/26/remove-duplicates-from-sorted-array.hs
+++ b/examples/leetcode-out/hs/26/remove-duplicates-from-sorted-array.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,81 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 removeDuplicates :: [Int] -> Int
 removeDuplicates nums = fromMaybe (0) $
-    case if (length nums == 0) then Just (0) else Nothing of Just v -> Just v; Nothing -> (let count = 1 in (let prev = (nums !! 0) in (let i = 1 in Just (count))))
+    case if (length nums == 0) then Just (0) else Nothing of Just v -> Just v; Nothing -> (let count = 1 in (let prev = (nums !! 0) in (let i = 1 in case whileLoop (\() -> (i < length nums)) (\() -> (let cur = (nums !! i) in case if (cur /= prev) then (let count = (count + 1) in (let prev = cur in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing))) of Just v -> Just v; Nothing -> Just (count))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((removeDuplicates [1, 1, 2] == 2))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((removeDuplicates [0, 0, 1, 1, 1, 2, 2, 3, 3, 4] == 5))
+
+test_empty :: IO ()
+test_empty = do
+    expect ((removeDuplicates [] == 0))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_empty

--- a/examples/leetcode-out/hs/27/remove-element.hs
+++ b/examples/leetcode-out/hs/27/remove-element.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,110 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start s)
+
 
 removeElement :: [Int] -> Int -> Int
 removeElement nums val = fromMaybe (0) $
-    (let k = 0 in (let i = 0 in Just (k)))
+    (let k = 0 in (let i = 0 in case whileLoop (\() -> (i < length nums)) (\() -> case if ((nums !! i) /= val) then (let nums = (nums !! i) in (let k = (k + 1) in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing)) of Just v -> Just v; Nothing -> Just (k)))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    let nums = [3, 2, 2, 3]
+    let k = removeElement nums 3
+    expect ((k == 2))
+    expect ((_slice nums 0 k == [2, 2]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    let nums = [0, 1, 2, 2, 3, 0, 4, 2]
+    let k = removeElement nums 2
+    expect ((k == 5))
+    expect ((_slice nums 0 k == [0, 1, 3, 0, 4]))
+
+test_no_removal :: IO ()
+test_no_removal = do
+    let nums = [1, 2, 3]
+    let k = removeElement nums 4
+    expect ((k == 3))
+    expect ((_slice nums 0 k == [1, 2, 3]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_no_removal

--- a/examples/leetcode-out/hs/28/find-the-index-of-the-first-occurrence-in-a-string.hs
+++ b/examples/leetcode-out/hs/28/find-the-index-of-the-first-occurrence-in-a-string.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,14 +55,89 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 strStr :: String -> String -> Int
 strStr haystack needle = fromMaybe (0) $
-    (let n = length haystack in (let m = length needle in case if (m == 0) then Just (0) else Nothing of Just v -> Just v; Nothing -> case if (m > n) then Just ((-1)) else Nothing of Just v -> Just v; Nothing -> case forLoop 0 ((n - m) + 1) (\i -> (let j = 0 in if (j == m) then Just (i) else Nothing)) of Just v -> Just v; Nothing -> Just ((-1))))
+    (let n = length haystack in (let m = length needle in case if (m == 0) then Just (0) else Nothing of Just v -> Just v; Nothing -> case if (m > n) then Just ((-1)) else Nothing of Just v -> Just v; Nothing -> case forLoop 0 ((n - m) + 1) (\i -> (let j = 0 in case whileLoop (\() -> (j < m)) (\() -> case if ((haystack !! (i + j)) /= (needle !! j)) then Just () else Nothing of Just v -> Just v; Nothing -> (let j = (j + 1) in Nothing)) of Just v -> Just v; Nothing -> if (j == m) then Just (i) else Nothing)) of Just v -> Just v; Nothing -> Just ((-1))))
   where
     n = length haystack
     m = length needle
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((strStr "sadbutsad" "sad" == 0))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((strStr "leetcode" "leeto" == ((-1))))
+
+test_empty_needle :: IO ()
+test_empty_needle = do
+    expect ((strStr "abc" "" == 0))
+
+test_needle_at_end :: IO ()
+test_needle_at_end = do
+    expect ((strStr "hello" "lo" == 3))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_empty_needle
+    test_needle_at_end

--- a/examples/leetcode-out/hs/29/divide-two-integers.hs
+++ b/examples/leetcode-out/hs/29/divide-two-integers.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,91 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 divide :: Int -> Int -> Int
 divide dividend divisor = fromMaybe (0) $
-    case if (((dividend == (((-2147483647) - 1))) && divisor) == ((-1))) then Just (2147483647) else Nothing of Just v -> Just v; Nothing -> (let negative = False in case if (dividend < 0) then (let negative = not negative in (let dividend = (-dividend) in Nothing)) else Nothing of Just v -> Just v; Nothing -> case if (divisor < 0) then (let negative = not negative in (let divisor = (-divisor) in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let quotient = 0 in case if negative then (let quotient = (-quotient) in Nothing) else Nothing of Just v -> Just v; Nothing -> case if (quotient > 2147483647) then Just (2147483647) else Nothing of Just v -> Just v; Nothing -> case if (quotient < (((-2147483647) - 1))) then Just ((-2147483648)) else Nothing of Just v -> Just v; Nothing -> Just (quotient)))
+    case if (((dividend == (((-2147483647) - 1))) && divisor) == ((-1))) then Just (2147483647) else Nothing of Just v -> Just v; Nothing -> (let negative = False in case if (dividend < 0) then (let negative = not negative in (let dividend = (-dividend) in Nothing)) else Nothing of Just v -> Just v; Nothing -> case if (divisor < 0) then (let negative = not negative in (let divisor = (-divisor) in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let quotient = 0 in case whileLoop (\() -> (dividend >= divisor)) (\() -> (let temp = divisor in (let multiple = 1 in case whileLoop (\() -> ((dividend >= temp) + temp)) (\() -> (let temp = (temp + temp) in (let multiple = (multiple + multiple) in Nothing))) of Just v -> Just v; Nothing -> (let dividend = (dividend - temp) in (let quotient = (quotient + multiple) in Nothing))))) of Just v -> Just v; Nothing -> case if negative then (let quotient = (-quotient) in Nothing) else Nothing of Just v -> Just v; Nothing -> case if (quotient > 2147483647) then Just (2147483647) else Nothing of Just v -> Just v; Nothing -> case if (quotient < (((-2147483647) - 1))) then Just ((-2147483648)) else Nothing of Just v -> Just v; Nothing -> Just (quotient)))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((divide 10 3 == 3))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((divide 7 (-3) == ((-2))))
+
+test_overflow :: IO ()
+test_overflow = do
+    expect ((divide (-2147483648) (-1) == 2147483647))
+
+test_divide_by_1 :: IO ()
+test_divide_by_1 = do
+    expect ((divide 12345 1 == 12345))
+
+test_negative_result :: IO ()
+test_negative_result = do
+    expect ((divide (-15) 2 == ((-7))))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_overflow
+    test_divide_by_1
+    test_negative_result

--- a/examples/leetcode-out/hs/3/longest-substring-without-repeating-characters.hs
+++ b/examples/leetcode-out/hs/3/longest-substring-without-repeating-characters.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,13 +55,88 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 lengthOfLongestSubstring :: String -> Int
 lengthOfLongestSubstring s = fromMaybe (0) $
-    (let n = length s in (let start = 0 in (let best = 0 in (let i = 0 in Just (best)))))
+    (let n = length s in (let start = 0 in (let best = 0 in (let i = 0 in case whileLoop (\() -> (i < n)) (\() -> (let j = start in case whileLoop (\() -> (j < i)) (\() -> case if ((s !! j) == (s !! i)) then (let start = (j + 1) in Just ()) else Nothing of Just v -> Just v; Nothing -> (let j = (j + 1) in Nothing)) of Just v -> Just v; Nothing -> (let length = ((i - start) + 1) in case if (length > best) then (let best = length in Nothing) else Nothing of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing)))) of Just v -> Just v; Nothing -> Just (best)))))
   where
     n = length s
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((lengthOfLongestSubstring "abcabcbb" == 3))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((lengthOfLongestSubstring "bbbbb" == 1))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((lengthOfLongestSubstring "pwwkew" == 3))
+
+test_empty_string :: IO ()
+test_empty_string = do
+    expect ((lengthOfLongestSubstring "" == 0))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_empty_string

--- a/examples/leetcode-out/hs/30/substring-with-concatenation-of-all-words.hs
+++ b/examples/leetcode-out/hs/30/substring-with-concatenation-of-all-words.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -13,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -27,11 +55,101 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start s)
+
 
 findSubstring :: String -> [String] -> [Int]
 findSubstring s words = fromMaybe ([]) $
-    case if (length words == 0) then Just ([]) else Nothing of Just v -> Just v; Nothing -> (let wordLen = length (words !! 0) in (let wordCount = length words in (let totalLen = (wordLen * wordCount) in case if (length s < totalLen) then Just ([]) else Nothing of Just v -> Just v; Nothing -> (let freq = Map.fromList [] in case foldr (\w acc -> case if (w in freq) then (let freq = ((freq !! w) + 1) in Nothing) else (let freq = 1 in Nothing) of Just v -> Just v; Nothing -> acc) Nothing words of Just v -> Just v; Nothing -> (let result = [] in case forLoop 0 wordLen (\offset -> (let left = offset in (let count = 0 in (let seen = Map.fromList [] in (let j = offset in Nothing))))) of Just v -> Just v; Nothing -> Just (result))))))
+    case if (length words == 0) then Just ([]) else Nothing of Just v -> Just v; Nothing -> (let wordLen = length (words !! 0) in (let wordCount = length words in (let totalLen = (wordLen * wordCount) in case if (length s < totalLen) then Just ([]) else Nothing of Just v -> Just v; Nothing -> (let freq = Map.fromList [] in case foldr (\w acc -> case if elem w freq then (let freq = ((freq !! w) + 1) in Nothing) else (let freq = 1 in Nothing) of Just v -> Just v; Nothing -> acc) Nothing words of Just v -> Just v; Nothing -> (let result = [] in case forLoop 0 wordLen (\offset -> (let left = offset in (let count = 0 in (let seen = Map.fromList [] in (let j = offset in whileLoop (\() -> ((j + wordLen) <= length s)) (\() -> (let word = _slice s j (j + wordLen) in (let j = (j + wordLen) in if elem word freq then case if elem word seen then (let seen = ((seen !! word) + 1) in Nothing) else (let seen = 1 in Nothing) of Just v -> Just v; Nothing -> (let count = (count + 1) in case whileLoop (\() -> ((seen !! word) > (freq !! word))) (\() -> (let lw = _slice s left (left + wordLen) in (let seen = ((seen !! lw) - 1) in (let left = (left + wordLen) in (let count = (count - 1) in Nothing))))) of Just v -> Just v; Nothing -> if (count == wordCount) then (let result = (result + [left]) in (let lw = _slice s left (left + wordLen) in (let seen = ((seen !! lw) - 1) in (let left = (left + wordLen) in (let count = (count - 1) in Nothing))))) else Nothing) else (let seen = Map.fromList [] in (let count = 0 in (let left = j in Nothing))))))))))) of Just v -> Just v; Nothing -> Just (result))))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((findSubstring "barfoothefoobarman" ["foo", "bar"] == [0, 9]))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((findSubstring "wordgoodgoodgoodbestword" ["word", "good", "best", "word"] == []))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((findSubstring "barfoofoobarthefoobarman" ["bar", "foo", "the"] == [6, 9, 12]))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3

--- a/examples/leetcode-out/hs/4/median-of-two-sorted-arrays.hs
+++ b/examples/leetcode-out/hs/4/median-of-two-sorted-arrays.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,86 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 findMedianSortedArrays :: [Int] -> [Int] -> Double
 findMedianSortedArrays nums1 nums2 = fromMaybe (0.0) $
-    (let merged = [] in (let i = 0 in (let j = 0 in (let total = length merged in case if ((total `mod` 2) == 1) then Just ((merged !! (div total 2))) else Nothing of Just v -> Just v; Nothing -> (let mid1 = (merged !! ((div total 2) - 1)) in (let mid2 = (merged !! (div total 2)) in Just ((((mid1 + mid2)) / 2.0))))))))
+    (let merged = [] in (let i = 0 in (let j = 0 in case whileLoop (\() -> (((i < length nums1) || j) < length nums2)) (\() -> if (j >= length nums2) then (let merged = (merged + [(nums1 !! i)]) in (let i = (i + 1) in Nothing)) else if (i >= length nums1) then (let merged = (merged + [(nums2 !! j)]) in (let j = (j + 1) in Nothing)) else if ((nums1 !! i) <= (nums2 !! j)) then (let merged = (merged + [(nums1 !! i)]) in (let i = (i + 1) in Nothing)) else (let merged = (merged + [(nums2 !! j)]) in (let j = (j + 1) in Nothing))) of Just v -> Just v; Nothing -> (let total = length merged in case if ((total `mod` 2) == 1) then Just ((merged !! (div total 2))) else Nothing of Just v -> Just v; Nothing -> (let mid1 = (merged !! ((div total 2) - 1)) in (let mid2 = (merged !! (div total 2)) in Just ((((mid1 + mid2)) / 2.0))))))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((findMedianSortedArrays [1, 3] [2] == 2.0))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((findMedianSortedArrays [1, 2] [3, 4] == 2.5))
+
+test_empty_first :: IO ()
+test_empty_first = do
+    expect ((findMedianSortedArrays [] [1] == 1.0))
+
+test_empty_second :: IO ()
+test_empty_second = do
+    expect ((findMedianSortedArrays [2] [] == 2.0))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_empty_first
+    test_empty_second

--- a/examples/leetcode-out/hs/5/longest-palindromic-substring.hs
+++ b/examples/leetcode-out/hs/5/longest-palindromic-substring.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,15 +55,112 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start s)
+
 
 expand :: String -> Int -> Int -> Int
 expand s left right = fromMaybe (0) $
-    (let l = left in (let r = right in (let n = length s in Just (((r - l) - 1)))))
+    (let l = left in (let r = right in (let n = length s in case whileLoop (\() -> (((l >= 0) && r) < n)) (\() -> case if ((s !! l) /= (s !! r)) then Just () else Nothing of Just v -> Just v; Nothing -> (let l = (l - 1) in (let r = (r + 1) in Nothing))) of Just v -> Just v; Nothing -> Just (((r - l) - 1)))))
 
 longestPalindrome :: String -> String
 longestPalindrome s = fromMaybe ("") $
-    case if (length s <= 1) then Just (s) else Nothing of Just v -> Just v; Nothing -> (let start = 0 in (let end = 0 in (let n = length s in case forLoop 0 n (\i -> (let len1 = expand s i i in (let len2 = expand s i (i + 1) in (let l = len1 in case if (len2 > len1) then (let l = len2 in Nothing) else Nothing of Just v -> Just v; Nothing -> if (l > ((end - start))) then (let start = (i - ((div ((l - 1)) 2))) in (let end = (i + ((div l 2))) in Nothing)) else Nothing)))) of Just v -> Just v; Nothing -> Just ((s !! start)))))
+    case if (length s <= 1) then Just (s) else Nothing of Just v -> Just v; Nothing -> (let start = 0 in (let end = 0 in (let n = length s in case forLoop 0 n (\i -> (let len1 = expand s i i in (let len2 = expand s i (i + 1) in (let l = len1 in case if (len2 > len1) then (let l = len2 in Nothing) else Nothing of Just v -> Just v; Nothing -> if (l > ((end - start))) then (let start = (i - ((div ((l - 1)) 2))) in (let end = (i + ((div l 2))) in Nothing)) else Nothing)))) of Just v -> Just v; Nothing -> Just (_slice s start (end + 1)))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    let ans = longestPalindrome "babad"
+    expect ((((ans == "bab") || ans) == "aba"))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((longestPalindrome "cbbd" == "bb"))
+
+test_single_char :: IO ()
+test_single_char = do
+    expect ((longestPalindrome "a" == "a"))
+
+test_two_chars :: IO ()
+test_two_chars = do
+    let ans = longestPalindrome "ac"
+    expect ((((ans == "a") || ans) == "c"))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_single_char
+    test_two_chars

--- a/examples/leetcode-out/hs/6/zigzag-conversion.hs
+++ b/examples/leetcode-out/hs/6/zigzag-conversion.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,81 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 convert :: String -> Int -> String
 convert s numRows = fromMaybe ("") $
-    case if (((numRows <= 1) || numRows) >= length s) then Just (s) else Nothing of Just v -> Just v; Nothing -> (let rows = [] in (let i = 0 in (let curr = 0 in (let step = 1 in case foldr (\ch acc -> case (let rows = ((rows !! curr) + ch) in case if (curr == 0) then (let step = 1 in Nothing) else if ((curr == numRows) - 1) then (let step = (-1) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let curr = (curr + step) in Nothing)) of Just v -> Just v; Nothing -> acc) Nothing s of Just v -> Just v; Nothing -> (let result = "" in case foldr (\row acc -> case (let result = (result + row) in Nothing) of Just v -> Just v; Nothing -> acc) Nothing rows of Just v -> Just v; Nothing -> Just (result))))))
+    case if (((numRows <= 1) || numRows) >= length s) then Just (s) else Nothing of Just v -> Just v; Nothing -> (let rows = [] in (let i = 0 in case whileLoop (\() -> (i < numRows)) (\() -> (let rows = (rows + [""]) in (let i = (i + 1) in Nothing))) of Just v -> Just v; Nothing -> (let curr = 0 in (let step = 1 in case foldr (\ch acc -> case (let rows = ((rows !! curr) + ch) in case if (curr == 0) then (let step = 1 in Nothing) else if ((curr == numRows) - 1) then (let step = (-1) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let curr = (curr + step) in Nothing)) of Just v -> Just v; Nothing -> acc) Nothing s of Just v -> Just v; Nothing -> (let result = "" in case foldr (\row acc -> case (let result = (result + row) in Nothing) of Just v -> Just v; Nothing -> acc) Nothing rows of Just v -> Just v; Nothing -> Just (result))))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((convert "PAYPALISHIRING" 3 == "PAHNAPLSIIGYIR"))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((convert "PAYPALISHIRING" 4 == "PINALSIGYAHRPI"))
+
+test_single_row :: IO ()
+test_single_row = do
+    expect ((convert "A" 1 == "A"))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_single_row

--- a/examples/leetcode-out/hs/7/reverse-integer.hs
+++ b/examples/leetcode-out/hs/7/reverse-integer.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,86 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 reverse :: Int -> Int
 reverse x = fromMaybe (0) $
-    (let sign = 1 in (let n = x in case if (n < 0) then (let sign = (-1) in (let n = (-n) in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let rev = 0 in (let rev = (rev * sign) in case if (((rev < (((-2147483647) - 1))) || rev) > 2147483647) then Just (0) else Nothing of Just v -> Just v; Nothing -> Just (rev)))))
+    (let sign = 1 in (let n = x in case if (n < 0) then (let sign = (-1) in (let n = (-n) in Nothing)) else Nothing of Just v -> Just v; Nothing -> (let rev = 0 in case whileLoop (\() -> (n /= 0)) (\() -> (let digit = (n `mod` 10) in (let rev = ((rev * 10) + digit) in (let n = (div n 10) in Nothing)))) of Just v -> Just v; Nothing -> (let rev = (rev * sign) in case if (((rev < (((-2147483647) - 1))) || rev) > 2147483647) then Just (0) else Nothing of Just v -> Just v; Nothing -> Just (rev)))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((reverse 123 == 321))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((reverse (-123) == ((-321))))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((reverse 120 == 21))
+
+test_overflow :: IO ()
+test_overflow = do
+    expect ((reverse 1534236469 == 0))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_overflow

--- a/examples/leetcode-out/hs/8/string-to-integer-atoi.hs
+++ b/examples/leetcode-out/hs/8/string-to-integer-atoi.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,6 +55,82 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+_slice :: [a] -> Int -> Int -> [a]
+_slice xs i j =
+  let n = length xs
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start xs)
+
+_sliceString :: String -> Int -> Int -> String
+_sliceString s i j =
+  let n = length s
+      start0 = if i < 0 then i + n else i
+      end0 = if j < 0 then j + n else j
+      start = max 0 start0
+      end = min n end0
+      end' = if end < start then start else end
+  in take (end' - start) (drop start s)
+
 
 digit :: String -> Int
 digit ch = fromMaybe (0) $
@@ -33,8 +138,32 @@ digit ch = fromMaybe (0) $
 
 myAtoi :: String -> Int
 myAtoi s = fromMaybe (0) $
-    (let i = 0 in (let n = length s in (let sign = 1 in case if ((i < n) && (((((s !! i) == _indexString "+" 0) || (s !! i)) == _indexString "-" 0))) then case if ((s !! i) == _indexString "-" 0) then (let sign = (-1) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let result = 0 in (let result = (result * sign) in case if (result > 2147483647) then Just (2147483647) else Nothing of Just v -> Just v; Nothing -> case if (result < ((-2147483648))) then Just ((-2147483648)) else Nothing of Just v -> Just v; Nothing -> Just (result))))))
+    (let i = 0 in (let n = length s in case whileLoop (\() -> (((i < n) && (s !! i)) == _indexString " " 0)) (\() -> (let i = (i + 1) in Nothing)) of Just v -> Just v; Nothing -> (let sign = 1 in case if ((i < n) && (((((s !! i) == _indexString "+" 0) || (s !! i)) == _indexString "-" 0))) then case if ((s !! i) == _indexString "-" 0) then (let sign = (-1) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let i = (i + 1) in Nothing) else Nothing of Just v -> Just v; Nothing -> (let result = 0 in case whileLoop (\() -> (i < n)) (\() -> (let ch = _slice s i (i + 1) in (let d = digit ch in case if (d < 0) then Just () else Nothing of Just v -> Just v; Nothing -> (let result = ((result * 10) + d) in (let i = (i + 1) in Nothing))))) of Just v -> Just v; Nothing -> (let result = (result * sign) in case if (result > 2147483647) then Just (2147483647) else Nothing of Just v -> Just v; Nothing -> case if (result < ((-2147483648))) then Just ((-2147483648)) else Nothing of Just v -> Just v; Nothing -> Just (result))))))
+
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((myAtoi "42" == 42))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((myAtoi "   -42" == ((-42))))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((myAtoi "4193 with words" == 4193))
+
+test_example_4 :: IO ()
+test_example_4 = do
+    expect ((myAtoi "words and 987" == 0))
+
+test_example_5 :: IO ()
+test_example_5 = do
+    expect ((myAtoi "-91283472332" == ((-2147483648))))
 
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_example_4
+    test_example_5

--- a/examples/leetcode-out/hs/9/palindrome-number.hs
+++ b/examples/leetcode-out/hs/9/palindrome-number.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Map as Map
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
@@ -12,9 +19,31 @@ forLoop start end f = go start
               Nothing -> go (i + 1)
          | otherwise = Nothing
 
+whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
+whileLoop cond body = go ()
+  where
+    go _ | cond () =
+            case body () of
+              Just v -> Just v
+              Nothing -> go ()
+         | otherwise = Nothing
+
 avg :: Real a => [a] -> Double
 avg xs | null xs = 0
       | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+
+data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+
+_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by src keyfn =
+  let go [] m order = (m, order)
+      go (x:xs) m order =
+        let k = keyfn x
+        in case Map.lookup k m of
+             Just is -> go xs (Map.insert k (is ++ [x]) m) order
+             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+      (m, order) = go src Map.empty []
+  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
 
 _indexString :: String -> Int -> String
 _indexString s i =
@@ -26,11 +55,86 @@ _indexString s i =
 _input :: IO String
 _input = getLine
 
+_now :: IO Int
+_now = fmap round getPOSIXTime
+
+_json :: Aeson.ToJSON a => a -> IO ()
+_json v = BSL.putStrLn (Aeson.encode v)
+
+_readInput :: Maybe String -> IO String
+_readInput Nothing = getContents
+_readInput (Just p)
+  | null p || p == "-" = getContents
+  | otherwise = readFile p
+
+_writeOutput :: Maybe String -> String -> IO ()
+_writeOutput mp text = case mp of
+  Nothing -> putStr text
+  Just p | null p || p == "-" -> putStr text
+         | otherwise -> writeFile p text
+
+_split :: Char -> String -> [String]
+_split _ "" = [""]
+_split d s =
+  let (h, t) = break (== d) s
+  in h : case t of
+            []      -> []
+            (_:rest) -> _split d rest
+
+_parseCSV :: String -> Bool -> Char -> [Map.Map String String]
+_parseCSV text header delim =
+  let ls = filter (not . null) (lines text)
+  in if null ls then [] else
+       let heads = if header
+                      then _split delim (head ls)
+                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+           start = if header then 1 else 0
+           row line =
+             let parts = _split delim line
+             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
+                             | j <- [0 .. length heads - 1] ]
+       in map row (drop start ls)
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path _ = do
+  txt <- _readInput path
+  pure (_parseCSV txt True ',')
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path _ =
+  let headers = if null rows then [] else Map.keys (head rows)
+      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+  in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
 
 isPalindrome :: Int -> Bool
 isPalindrome x = fromMaybe (False) $
     case if (x < 0) then Just (False) else Nothing of Just v -> Just v; Nothing -> (let s = show x in (let n = length s in case forLoop 0 (div n 2) (\i -> if ((s !! i) /= (s !! ((n - 1) - i))) then Just (False) else Nothing) of Just v -> Just v; Nothing -> Just (True)))
 
+test_example_1 :: IO ()
+test_example_1 = do
+    expect ((isPalindrome 121 == True))
+
+test_example_2 :: IO ()
+test_example_2 = do
+    expect ((isPalindrome (-121) == False))
+
+test_example_3 :: IO ()
+test_example_3 = do
+    expect ((isPalindrome 10 == False))
+
+test_zero :: IO ()
+test_zero = do
+    expect ((isPalindrome 0 == True))
+
 main :: IO ()
 main = do
-    return ()
+    test_example_1
+    test_example_2
+    test_example_3
+    test_zero

--- a/tests/compiler/hs/arithmetic.hs.out
+++ b/tests/compiler/hs/arithmetic.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/avg_builtin.hs.out
+++ b/tests/compiler/hs/avg_builtin.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/bool_ops.hs.out
+++ b/tests/compiler/hs/bool_ops.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/closure.hs.out
+++ b/tests/compiler/hs/closure.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -110,7 +111,8 @@ _save rows path _ =
 makeAdder :: Int -> (Int -> Int)
 makeAdder n = (\x -> (x + n))
 
+add10 = makeAdder 10
+
 main :: IO ()
 main = do
-    let add10 = makeAdder 10
     print (add10 7)

--- a/tests/compiler/hs/count_builtin.hs.out
+++ b/tests/compiler/hs/count_builtin.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/dataset.hs.out
+++ b/tests/compiler/hs/dataset.hs.out
@@ -1,11 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
+import GHC.Generics (Generic)
 import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
@@ -110,7 +112,8 @@ _save rows path _ =
 data Person = Person {
     name :: String,
     age :: Int
-} deriving (Show)
+} deriving (Show, Generic)
+instance Aeson.FromJSON Person
 
 
 people = [Person { name = "Alice", age = 30 }, Person { name = "Bob", age = 15 }, Person { name = "Charlie", age = 65 }]

--- a/tests/compiler/hs/float_literal_precision.hs.out
+++ b/tests/compiler/hs/float_literal_precision.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/float_ops.hs.out
+++ b/tests/compiler/hs/float_ops.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/for_loop.hs.out
+++ b/tests/compiler/hs/for_loop.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/fun_call.hs.out
+++ b/tests/compiler/hs/fun_call.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/fun_expr_in_let.hs.out
+++ b/tests/compiler/hs/fun_expr_in_let.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+square = (\x -> (x * x))
+
 main :: IO ()
 main = do
-    let square = (\x -> (x * x))
     print (square 6)

--- a/tests/compiler/hs/grouped_expr.hs.out
+++ b/tests/compiler/hs/grouped_expr.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+value = (((1 + 2)) * 3)
+
 main :: IO ()
 main = do
-    let value = (((1 + 2)) * 3)
     print (value)

--- a/tests/compiler/hs/hello_world.hs.out
+++ b/tests/compiler/hs/hello_world.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/if_else.hs.out
+++ b/tests/compiler/hs/if_else.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/input_builtin.hs.out
+++ b/tests/compiler/hs/input_builtin.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,10 +108,12 @@ _save rows path _ =
   in _writeOutput path text
 
 
+input1 = _input
+
+input2 = _input
+
 main :: IO ()
 main = do
     putStrLn ("Enter first input:")
-    input1 <- _input
     putStrLn ("Enter second input:")
-    input2 <- _input
     putStrLn (unwords ["You entered:", input1, ",", input2])

--- a/tests/compiler/hs/len_builtin.hs.out
+++ b/tests/compiler/hs/len_builtin.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/list_for_loop.hs.out
+++ b/tests/compiler/hs/list_for_loop.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+names = ["Alice", "Bob"]
+
 main :: IO ()
 main = do
-    let names = ["Alice", "Bob"]
     mapM_ (\n -> putStrLn (show n)) names

--- a/tests/compiler/hs/list_push.hs.out
+++ b/tests/compiler/hs/list_push.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/load_json_stdin.hs.out
+++ b/tests/compiler/hs/load_json_stdin.hs.out
@@ -1,11 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
+import GHC.Generics (Generic)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Key as Key
 import qualified Data.Vector as V
@@ -85,7 +87,8 @@ _save rows path opts =
 data Person = Person {
     name :: String,
     age :: Int
-} deriving (Show)
+} deriving (Show, Generic)
+instance Aeson.FromJSON Person
 
 
 people = _load Nothing Just (Map.fromList [("format", "json")])

--- a/tests/compiler/hs/map_for_loop.hs.out
+++ b/tests/compiler/hs/map_for_loop.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+scores = Map.fromList [("Alice", 10), ("Bob", 15)]
+
 main :: IO ()
 main = do
-    let scores = Map.fromList [("Alice", 10), ("Bob", 15)]
     mapM_ (\k -> putStrLn (k)) (Map.keys scores)

--- a/tests/compiler/hs/map_index.hs.out
+++ b/tests/compiler/hs/map_index.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+scores = Map.fromList [("Alice", 10), ("Bob", 15)]
+
 main :: IO ()
 main = do
-    let scores = Map.fromList [("Alice", 10), ("Bob", 15)]
     print (fromMaybe (error "missing") (Map.lookup "Bob" scores))

--- a/tests/compiler/hs/map_keys_builtin.hs.out
+++ b/tests/compiler/hs/map_keys_builtin.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+m = Map.fromList [("a", 1), ("b", 2)]
+
 main :: IO ()
 main = do
-    let m = Map.fromList [("a", 1), ("b", 2)]
     print (length (Map.keys m))

--- a/tests/compiler/hs/map_lookup.hs.out
+++ b/tests/compiler/hs/map_lookup.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,8 +108,9 @@ _save rows path _ =
   in _writeOutput path text
 
 
+m = Map.fromList [("a", 1), ("b", 2)]
+
 main :: IO ()
 main = do
-    let m = Map.fromList [("a", 1), ("b", 2)]
     print (fromMaybe (error "missing") (Map.lookup "a" m))
     print (fromMaybe (error "missing") (Map.lookup "b" m))

--- a/tests/compiler/hs/reserved_keyword_var.hs.out
+++ b/tests/compiler/hs/reserved_keyword_var.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+map = Map.fromList [("a", 1)]
+
 main :: IO ()
 main = do
-    let map = Map.fromList [("a", 1)]
     print (fromMaybe (error "missing") (Map.lookup "a" map))

--- a/tests/compiler/hs/save_json_stdout.hs.out
+++ b/tests/compiler/hs/save_json_stdout.hs.out
@@ -1,11 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
+import GHC.Generics (Generic)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Key as Key
 import qualified Data.Vector as V
@@ -85,7 +87,8 @@ _save rows path opts =
 data Person = Person {
     name :: String,
     age :: Int
-} deriving (Show)
+} deriving (Show, Generic)
+instance Aeson.FromJSON Person
 
 
 people = _load Nothing Just (Map.fromList [("format", "json")])

--- a/tests/compiler/hs/str_builtin.hs.out
+++ b/tests/compiler/hs/str_builtin.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/string_concat.hs.out
+++ b/tests/compiler/hs/string_concat.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/string_for_loop.hs.out
+++ b/tests/compiler/hs/string_for_loop.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/string_index.hs.out
+++ b/tests/compiler/hs/string_index.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+text = "hello"
+
 main :: IO ()
 main = do
-    let text = "hello"
     putStrLn (_indexString text 1)

--- a/tests/compiler/hs/string_negative_index.hs.out
+++ b/tests/compiler/hs/string_negative_index.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -107,7 +108,8 @@ _save rows path _ =
   in _writeOutput path text
 
 
+text = "hello"
+
 main :: IO ()
 main = do
-    let text = "hello"
     putStrLn (_indexString text (-1))

--- a/tests/compiler/hs/string_slice.hs.out
+++ b/tests/compiler/hs/string_slice.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/struct_literal.hs.out
+++ b/tests/compiler/hs/struct_literal.hs.out
@@ -1,11 +1,13 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
+import GHC.Generics (Generic)
 import qualified Data.ByteString.Lazy.Char8 as BSL
 
 
@@ -110,16 +112,19 @@ _save rows path _ =
 data Person = Person {
     name :: String,
     age :: Int
-} deriving (Show)
+} deriving (Show, Generic)
+instance Aeson.FromJSON Person
 
 
 data Book = Book {
     title :: String,
     author :: Person
-} deriving (Show)
+} deriving (Show, Generic)
+instance Aeson.FromJSON Book
 
+
+book = Book { title = "Go", author = Person { name = "Bob", age = 42 } }
 
 main :: IO ()
 main = do
-    let book = Book { title = "Go", author = Person { name = "Bob", age = 42 } }
     putStrLn (name (author (book)))

--- a/tests/compiler/hs/test_block.hs.out
+++ b/tests/compiler/hs/test_block.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL

--- a/tests/compiler/hs/tpc_h_q1.hs.out
+++ b/tests/compiler/hs/tpc_h_q1.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -59,30 +60,6 @@ _now = fmap round getPOSIXTime
 
 _json :: Aeson.ToJSON a => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
-
-data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
-
-instance Aeson.ToJSON AnyValue where
-  toJSON (VInt n) = Aeson.toJSON n
-  toJSON (VDouble d) = Aeson.toJSON d
-  toJSON (VString s) = Aeson.toJSON s
-  toJSON (VBool b) = Aeson.toJSON b
-
-_asInt :: AnyValue -> Int
-_asInt (VInt n) = n
-_asInt v = error ("expected int, got " ++ show v)
-
-_asDouble :: AnyValue -> Double
-_asDouble (VDouble d) = d
-_asDouble v = error ("expected double, got " ++ show v)
-
-_asString :: AnyValue -> String
-_asString (VString s) = s
-_asString v = error ("expected string, got " ++ show v)
-
-_asBool :: AnyValue -> Bool
-_asBool (VBool b) = b
-_asBool v = error ("expected bool, got " ++ show v)
 
 _readInput :: Maybe String -> IO String
 _readInput Nothing = getContents

--- a/tests/compiler/hs/two_sum.hs.out
+++ b/tests/compiler/hs/two_sum.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -113,8 +114,9 @@ twoSum nums target = fromMaybe ([]) $
   where
     n = length nums
 
+result = twoSum [2, 7, 11, 15] 9
+
 main :: IO ()
 main = do
-    let result = twoSum [2, 7, 11, 15] 9
     print ((result !! 0))
     print ((result !! 1))

--- a/tests/dataset/tpc-h/compiler/hs/q1.hs.out
+++ b/tests/dataset/tpc-h/compiler/hs/q1.hs.out
@@ -1,9 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Map as Map
-import Data.List (intercalate)
+import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -59,30 +60,6 @@ _now = fmap round getPOSIXTime
 
 _json :: Aeson.ToJSON a => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
-
-data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
-
-instance Aeson.ToJSON AnyValue where
-  toJSON (VInt n) = Aeson.toJSON n
-  toJSON (VDouble d) = Aeson.toJSON d
-  toJSON (VString s) = Aeson.toJSON s
-  toJSON (VBool b) = Aeson.toJSON b
-
-_asInt :: AnyValue -> Int
-_asInt (VInt n) = n
-_asInt v = error ("expected int, got " ++ show v)
-
-_asDouble :: AnyValue -> Double
-_asDouble (VDouble d) = d
-_asDouble v = error ("expected double, got " ++ show v)
-
-_asString :: AnyValue -> String
-_asString (VString s) = s
-_asString v = error ("expected string, got " ++ show v)
-
-_asBool :: AnyValue -> Bool
-_asBool (VBool b) = b
-_asBool v = error ("expected bool, got " ++ show v)
 
 _readInput :: Maybe String -> IO String
 _readInput Nothing = getContents


### PR DESCRIPTION
## Summary
- format generated Haskell code with `ormolu` or `fourmolu`
- regenerate Haskell golden files and example outputs

## Testing
- `go test ./compile/x/hs -tags slow` *(fails: could not find module `Data.Aeson`)*

------
https://chatgpt.com/codex/tasks/task_e_685e22ab45188320b561a1c4b6266490