### PR TITLE
Improve Rust compilation formatting

### DIFF
--- a/compile/x/rust/compiler.go
+++ b/compile/x/rust/compiler.go
@@ -138,5 +138,5 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		c.writeln("")
 	}
 	c.emitRuntime()
-	return c.buf.Bytes(), nil
+	return FormatRust(c.buf.Bytes()), nil
 }

--- a/examples/leetcode-out/rust/1/two-sum.rs
+++ b/examples/leetcode-out/rust/1/two-sum.rs
@@ -1,8 +1,8 @@
-fn twoSum(nums: Vec<i32>, target: i32) -> Vec<i32> {
-    let mut n = nums.len() as i32;
+fn twoSum(nums: Vec<i64>, target: i64) -> Vec<i64> {
+    let mut n = nums.len() as i64;
     for i in 0..n {
         for j in i + 1..n {
-            if nums[(i) as usize] + nums[(j) as usize] == target {
+            if nums[i as usize] + nums[j as usize] == target {
                 return vec![i, j];
             }
         }
@@ -15,4 +15,3 @@ fn main() {
     println!("{}", result[(0) as usize]);
     println!("{}", result[(1) as usize]);
 }
-

--- a/examples/leetcode-out/rust/10/regular-expression-matching.rs
+++ b/examples/leetcode-out/rust/10/regular-expression-matching.rs
@@ -1,0 +1,153 @@
+fn isMatch(s: &str, p: &str) -> bool {
+    let mut m = s.len() as i64;
+    let mut n = p.len() as i64;
+    let mut dp: Vec<Vec<bool>> = vec![];
+    let mut i = 0;
+    while i <= m {
+        let mut row: Vec<bool> = vec![];
+        let mut j = 0;
+        while j <= n {
+            row = {
+                let a = &row;
+                let b = &vec![false];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
+            j = j + 1;
+        }
+        dp = {
+            let a = &dp;
+            let b = &vec![row];
+            let mut res = Vec::with_capacity(a.len() + b.len());
+            res.extend_from_slice(a);
+            res.extend_from_slice(b);
+            res
+        };
+        i = i + 1;
+    }
+    dp[m as usize][n as usize] = true;
+    let mut i2 = m;
+    while i2 >= 0 {
+        let mut j2 = n - 1;
+        while j2 >= 0 {
+            let mut first = false;
+            if i2 < m {
+                if ({
+                    let s = &p;
+                    let mut idx = j2;
+                    let chars: Vec<char> = s.chars().collect();
+                    if idx < 0 {
+                        idx += chars.len() as i64;
+                    }
+                    if idx < 0 || idx >= chars.len() as i64 {
+                        panic!("index out of range");
+                    }
+                    chars[idx as usize].to_string()
+                } == {
+                    let s = &s;
+                    let mut idx = i2;
+                    let chars: Vec<char> = s.chars().collect();
+                    if idx < 0 {
+                        idx += chars.len() as i64;
+                    }
+                    if idx < 0 || idx >= chars.len() as i64 {
+                        panic!("index out of range");
+                    }
+                    chars[idx as usize].to_string()
+                }) || ({
+                    let s = &p;
+                    let mut idx = j2;
+                    let chars: Vec<char> = s.chars().collect();
+                    if idx < 0 {
+                        idx += chars.len() as i64;
+                    }
+                    if idx < 0 || idx >= chars.len() as i64 {
+                        panic!("index out of range");
+                    }
+                    chars[idx as usize].to_string()
+                } == ".")
+                {
+                    first = true;
+                }
+            }
+            let mut star = false;
+            if j2 + 1 < n {
+                if {
+                    let s = &p;
+                    let mut idx = j2 + 1;
+                    let chars: Vec<char> = s.chars().collect();
+                    if idx < 0 {
+                        idx += chars.len() as i64;
+                    }
+                    if idx < 0 || idx >= chars.len() as i64 {
+                        panic!("index out of range");
+                    }
+                    chars[idx as usize].to_string()
+                } == "*"
+                {
+                    star = true;
+                }
+            }
+            if star {
+                let mut ok = false;
+                if dp[i2 as usize][(j2 + 2) as usize] {
+                    ok = true;
+                } else {
+                    if first {
+                        if dp[(i2 + 1) as usize][j2 as usize] {
+                            ok = true;
+                        }
+                    }
+                }
+                dp[i2 as usize][j2 as usize] = ok;
+            } else {
+                let mut ok = false;
+                if first {
+                    if dp[(i2 + 1) as usize][(j2 + 1) as usize] {
+                        ok = true;
+                    }
+                }
+                dp[i2 as usize][j2 as usize] = ok;
+            }
+            j2 = j2 - 1;
+        }
+        i2 = i2 - 1;
+    }
+    return dp[(0) as usize][(0) as usize];
+}
+
+fn test_example_1() {
+    expect(isMatch("aa", "a") == false);
+}
+
+fn test_example_2() {
+    expect(isMatch("aa", "a*") == true);
+}
+
+fn test_example_3() {
+    expect(isMatch("ab", ".*") == true);
+}
+
+fn test_example_4() {
+    expect(isMatch("aab", "c*a*b") == true);
+}
+
+fn test_example_5() {
+    expect(isMatch("mississippi", "mis*is*p*.") == false);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_example_4();
+    test_example_5();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/11/container-with-most-water.rs
+++ b/examples/leetcode-out/rust/11/container-with-most-water.rs
@@ -1,6 +1,6 @@
-fn maxArea(height: Vec<i32>) -> i32 {
+fn maxArea(height: Vec<i64>) -> i64 {
     let mut left = 0;
-    let mut right = height.len() as i32 - 1;
+    let mut right = height.len() as i64 - 1;
     let mut maxArea = 0;
     while left < right {
         let mut width = right - left;
@@ -23,6 +23,31 @@ fn maxArea(height: Vec<i32>) -> i32 {
     return maxArea;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(maxArea(vec![1, 8, 6, 2, 5, 4, 8, 3, 7]) == 49);
 }
 
+fn test_example_2() {
+    expect(maxArea(vec![1, 1]) == 1);
+}
+
+fn test_decreasing_heights() {
+    expect(maxArea(vec![4, 3, 2, 1, 4]) == 16);
+}
+
+fn test_short_array() {
+    expect(maxArea(vec![1, 2, 1]) == 2);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_decreasing_heights();
+    test_short_array();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/12/integer-to-roman.rs
+++ b/examples/leetcode-out/rust/12/integer-to-roman.rs
@@ -1,0 +1,58 @@
+fn intToRoman(mut num: i64) -> String {
+    let mut values = vec![1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
+    let mut symbols = vec![
+        "M".to_string(),
+        "CM".to_string(),
+        "D".to_string(),
+        "CD".to_string(),
+        "C".to_string(),
+        "XC".to_string(),
+        "L".to_string(),
+        "XL".to_string(),
+        "X".to_string(),
+        "IX".to_string(),
+        "V".to_string(),
+        "IV".to_string(),
+        "I".to_string(),
+    ];
+    let mut result = "".to_string();
+    let mut i = 0;
+    while num > 0 {
+        while num >= values[i as usize] {
+            result = format!("{}{}", result, symbols[i as usize]);
+            num = num - values[i as usize];
+        }
+        i = i + 1;
+    }
+    return result.to_string();
+}
+
+fn test_example_1() {
+    expect(intToRoman(3) == "III");
+}
+
+fn test_example_2() {
+    expect(intToRoman(58) == "LVIII");
+}
+
+fn test_example_3() {
+    expect(intToRoman(1994) == "MCMXCIV");
+}
+
+fn test_small_numbers() {
+    expect(intToRoman(4) == "IV");
+    expect(intToRoman(9) == "IX");
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_small_numbers();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/13/roman-to-integer.rs
+++ b/examples/leetcode-out/rust/13/roman-to-integer.rs
@@ -1,0 +1,86 @@
+fn romanToInt(s: &str) -> i64 {
+    let mut values: std::collections::HashMap<String, i64> = std::collections::HashMap::from([
+        ("I".to_string(), 1),
+        ("V".to_string(), 5),
+        ("X".to_string(), 10),
+        ("L".to_string(), 50),
+        ("C".to_string(), 100),
+        ("D".to_string(), 500),
+        ("M".to_string(), 1000),
+    ]);
+    let mut total = 0;
+    let mut i = 0;
+    let mut n = s.len() as i64;
+    while i < n {
+        let mut curr = values[({
+            let s = &s;
+            let mut idx = i;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        }) as usize];
+        if i + 1 < n {
+            let mut next = values[({
+                let s = &s;
+                let mut idx = i + 1;
+                let chars: Vec<char> = s.chars().collect();
+                if idx < 0 {
+                    idx += chars.len() as i64;
+                }
+                if idx < 0 || idx >= chars.len() as i64 {
+                    panic!("index out of range");
+                }
+                chars[idx as usize].to_string()
+            }) as usize];
+            if curr < next {
+                total = total + next - curr;
+                i = i + 2;
+                continue;
+            }
+        }
+        total = total + curr;
+        i = i + 1;
+    }
+    return total;
+}
+
+fn test_example_1() {
+    expect(romanToInt("III") == 3);
+}
+
+fn test_example_2() {
+    expect(romanToInt("LVIII") == 58);
+}
+
+fn test_example_3() {
+    expect(romanToInt("MCMXCIV") == 1994);
+}
+
+fn test_subtractive() {
+    expect(romanToInt("IV") == 4);
+    expect(romanToInt("IX") == 9);
+}
+
+fn test_tens() {
+    expect(romanToInt("XL") == 40);
+    expect(romanToInt("XC") == 90);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_subtractive();
+    test_tens();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/14/longest-common-prefix.rs
+++ b/examples/leetcode-out/rust/14/longest-common-prefix.rs
@@ -1,0 +1,106 @@
+fn longestCommonPrefix(strs: Vec<String>) -> String {
+    if strs.len() as i64 == 0 {
+        return "".to_string();
+    }
+    let mut prefix = strs[(0) as usize];
+    for i in 1..strs.len() as i64 {
+        let mut j = 0;
+        let mut current = strs[i as usize];
+        while j < prefix.len() as i64 && j < current.len() as i64 {
+            if {
+                let s = &prefix;
+                let mut idx = j;
+                let chars: Vec<char> = s.chars().collect();
+                if idx < 0 {
+                    idx += chars.len() as i64;
+                }
+                if idx < 0 || idx >= chars.len() as i64 {
+                    panic!("index out of range");
+                }
+                chars[idx as usize].to_string()
+            } != {
+                let s = &current;
+                let mut idx = j;
+                let chars: Vec<char> = s.chars().collect();
+                if idx < 0 {
+                    idx += chars.len() as i64;
+                }
+                if idx < 0 || idx >= chars.len() as i64 {
+                    panic!("index out of range");
+                }
+                chars[idx as usize].to_string()
+            } {
+                break;
+            }
+            j = j + 1;
+        }
+        prefix = _slice_string(prefix, 0, j);
+        if prefix == "" {
+            break;
+        }
+    }
+    return prefix.to_string();
+}
+
+fn test_example_1() {
+    expect(
+        longestCommonPrefix(vec![
+            "flower".to_string(),
+            "flow".to_string(),
+            "flight".to_string(),
+        ]) == "fl",
+    );
+}
+
+fn test_example_2() {
+    expect(
+        longestCommonPrefix(vec![
+            "dog".to_string(),
+            "racecar".to_string(),
+            "car".to_string(),
+        ]) == "",
+    );
+}
+
+fn test_single_string() {
+    expect(longestCommonPrefix(vec!["single".to_string()]) == "single");
+}
+
+fn test_no_common_prefix() {
+    expect(longestCommonPrefix(vec!["a".to_string(), "b".to_string(), "c".to_string()]) == "");
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_single_string();
+    test_no_common_prefix();
+}
+
+fn _slice_string(s: &str, start: i64, end: i64) -> String {
+    let mut sidx = start;
+    let mut eidx = end;
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len() as i64;
+    if sidx < 0 {
+        sidx += n;
+    }
+    if eidx < 0 {
+        eidx += n;
+    }
+    if sidx < 0 {
+        sidx = 0;
+    }
+    if eidx > n {
+        eidx = n;
+    }
+    if eidx < sidx {
+        eidx = sidx;
+    }
+    chars[sidx as usize..eidx as usize].iter().collect()
+}
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/15/three-sum.rs
+++ b/examples/leetcode-out/rust/15/three-sum.rs
@@ -1,13 +1,18 @@
-fn threeSum(nums: Vec<i32>) -> Vec<Vec<i32>> {
+fn threeSum(nums: Vec<i64>) -> Vec<Vec<i64>> {
     let mut sorted = {
-    let mut _res = Vec::new();
-    for x in nums {
-        _res.push(x);
-    }
-    _res
-};
-    let mut n = sorted.len() as i32;
-    let mut res: Vec<Vec<i32>> = vec![];
+        let mut _pairs = Vec::new();
+        for x in nums {
+            _pairs.push((x, x));
+        }
+        _pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        let mut _res = Vec::new();
+        for p in _pairs {
+            _res.push(p.1);
+        }
+        _res
+    };
+    let mut n = sorted.len() as i64;
+    let mut res: Vec<Vec<i64>> = vec![];
     let mut i = 0;
     while i < n {
         if i > 0 && sorted[i as usize] == sorted[(i - 1) as usize] {
@@ -19,7 +24,18 @@ fn threeSum(nums: Vec<i32>) -> Vec<Vec<i32>> {
         while left < right {
             let mut sum = sorted[i as usize] + sorted[left as usize] + sorted[right as usize];
             if sum == 0 {
-                res = _concat(&res, &vec![vec![sorted[i as usize], sorted[left as usize], sorted[right as usize]]]);
+                res = {
+                    let a = &res;
+                    let b = &vec![vec![
+                        sorted[i as usize],
+                        sorted[left as usize],
+                        sorted[right as usize],
+                    ]];
+                    let mut res = Vec::with_capacity(a.len() + b.len());
+                    res.extend_from_slice(a);
+                    res.extend_from_slice(b);
+                    res
+                };
                 left = left + 1;
                 while left < right && sorted[left as usize] == sorted[(left - 1) as usize] {
                     left = left + 1;
@@ -28,8 +44,7 @@ fn threeSum(nums: Vec<i32>) -> Vec<Vec<i32>> {
                 while left < right && sorted[right as usize] == sorted[(right + 1) as usize] {
                     right = right - 1;
                 }
-            } else 
-            if sum < 0 {
+            } else if sum < 0 {
                 left = left + 1;
             } else {
                 right = right - 1;
@@ -40,12 +55,26 @@ fn threeSum(nums: Vec<i32>) -> Vec<Vec<i32>> {
     return res;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(threeSum(vec![-1, 0, 1, 2, -1, -4]) == vec![vec![-1, -1, 2], vec![-1, 0, 1]]);
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(threeSum(vec![0, 1, 1]) == vec![]);
+}
+
+fn test_example_3() {
+    expect(threeSum(vec![0, 0, 0]) == vec![vec![0, 0, 0]]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/16/3sum-closest.rs
+++ b/examples/leetcode-out/rust/16/3sum-closest.rs
@@ -1,12 +1,17 @@
-fn threeSumClosest(nums: Vec<i32>, target: i32) -> i32 {
+fn threeSumClosest(nums: Vec<i64>, target: i64) -> i64 {
     let mut sorted = {
-    let mut _res = Vec::new();
-    for n in nums {
-        _res.push(n);
-    }
-    _res
-};
-    let mut n = sorted.len() as i32;
+        let mut _pairs = Vec::new();
+        for n in nums {
+            _pairs.push((n, n));
+        }
+        _pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        let mut _res = Vec::new();
+        for p in _pairs {
+            _res.push(p.1);
+        }
+        _res
+    };
+    let mut n = sorted.len() as i64;
     let mut best = sorted[(0) as usize] + sorted[(1) as usize] + sorted[(2) as usize];
     for i in 0..n {
         let mut left = i + 1;
@@ -41,6 +46,26 @@ fn threeSumClosest(nums: Vec<i32>, target: i32) -> i32 {
     return best;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(threeSumClosest(vec![-1, 2, 1, -4], 1) == 2);
 }
 
+fn test_example_2() {
+    expect(threeSumClosest(vec![0, 0, 0], 1) == 0);
+}
+
+fn test_additional() {
+    expect(threeSumClosest(vec![1, 1, 1, 0], -100) == 2);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_additional();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/17/letter-combinations-of-a-phone-number.rs
+++ b/examples/leetcode-out/rust/17/letter-combinations-of-a-phone-number.rs
@@ -1,0 +1,143 @@
+fn letterCombinations(digits: &str) -> Vec<String> {
+    if digits.len() as i64 == 0 {
+        return vec![];
+    }
+    let mut mapping = std::collections::HashMap::from([
+        (
+            "2".to_string(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        ),
+        (
+            "3".to_string(),
+            vec!["d".to_string(), "e".to_string(), "f".to_string()],
+        ),
+        (
+            "4".to_string(),
+            vec!["g".to_string(), "h".to_string(), "i".to_string()],
+        ),
+        (
+            "5".to_string(),
+            vec!["j".to_string(), "k".to_string(), "l".to_string()],
+        ),
+        (
+            "6".to_string(),
+            vec!["m".to_string(), "n".to_string(), "o".to_string()],
+        ),
+        (
+            "7".to_string(),
+            vec![
+                "p".to_string(),
+                "q".to_string(),
+                "r".to_string(),
+                "s".to_string(),
+            ],
+        ),
+        (
+            "8".to_string(),
+            vec!["t".to_string(), "u".to_string(), "v".to_string()],
+        ),
+        (
+            "9".to_string(),
+            vec![
+                "w".to_string(),
+                "x".to_string(),
+                "y".to_string(),
+                "z".to_string(),
+            ],
+        ),
+    ]);
+    let mut result = vec!["".to_string()];
+    for d_ch in digits.chars() {
+        let d = d_ch.to_string();
+        if !(mapping.contains_key(&d)) {
+            continue;
+        }
+        let mut letters = mapping[d as usize];
+        let mut next = {
+            let mut _res = Vec::new();
+            for p in result.clone() {
+                for ch in letters.clone() {
+                    _res.push(p + ch);
+                }
+            }
+            _res
+        };
+        result = next;
+    }
+    return result;
+}
+
+fn test_example_1() {
+    expect(
+        letterCombinations("23")
+            == vec![
+                "ad".to_string(),
+                "ae".to_string(),
+                "af".to_string(),
+                "bd".to_string(),
+                "be".to_string(),
+                "bf".to_string(),
+                "cd".to_string(),
+                "ce".to_string(),
+                "cf".to_string(),
+            ],
+    );
+}
+
+fn test_example_2() {
+    expect(letterCombinations("") == vec![]);
+}
+
+fn test_example_3() {
+    expect(letterCombinations("2") == vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+}
+
+fn test_single_seven() {
+    expect(
+        letterCombinations("7")
+            == vec![
+                "p".to_string(),
+                "q".to_string(),
+                "r".to_string(),
+                "s".to_string(),
+            ],
+    );
+}
+
+fn test_mix() {
+    expect(
+        letterCombinations("79")
+            == vec![
+                "pw".to_string(),
+                "px".to_string(),
+                "py".to_string(),
+                "pz".to_string(),
+                "qw".to_string(),
+                "qx".to_string(),
+                "qy".to_string(),
+                "qz".to_string(),
+                "rw".to_string(),
+                "rx".to_string(),
+                "ry".to_string(),
+                "rz".to_string(),
+                "sw".to_string(),
+                "sx".to_string(),
+                "sy".to_string(),
+                "sz".to_string(),
+            ],
+    );
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_single_seven();
+    test_mix();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/18/four-sum.rs
+++ b/examples/leetcode-out/rust/18/four-sum.rs
@@ -1,13 +1,18 @@
-fn fourSum(nums: Vec<i32>, target: i32) -> Vec<Vec<i32>> {
+fn fourSum(nums: Vec<i64>, target: i64) -> Vec<Vec<i64>> {
     let mut sorted = {
-    let mut _res = Vec::new();
-    for n in nums {
-        _res.push(n);
-    }
-    _res
-};
-    let mut n = sorted.len() as i32;
-    let mut result: Vec<Vec<i32>> = vec![];
+        let mut _pairs = Vec::new();
+        for n in nums {
+            _pairs.push((n, n));
+        }
+        _pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        let mut _res = Vec::new();
+        for p in _pairs {
+            _res.push(p.1);
+        }
+        _res
+    };
+    let mut n = sorted.len() as i64;
+    let mut result: Vec<Vec<i64>> = vec![];
     for i in 0..n {
         if i > 0 && sorted[i as usize] == sorted[(i - 1) as usize] {
             continue;
@@ -19,9 +24,24 @@ fn fourSum(nums: Vec<i32>, target: i32) -> Vec<Vec<i32>> {
             let mut left = j + 1;
             let mut right = n - 1;
             while left < right {
-                let mut sum = sorted[i as usize] + sorted[j as usize] + sorted[left as usize] + sorted[right as usize];
+                let mut sum = sorted[i as usize]
+                    + sorted[j as usize]
+                    + sorted[left as usize]
+                    + sorted[right as usize];
                 if sum == target {
-                    result = _concat(&result, &vec![vec![sorted[i as usize], sorted[j as usize], sorted[left as usize], sorted[right as usize]]]);
+                    result = {
+                        let a = &result;
+                        let b = &vec![vec![
+                            sorted[i as usize],
+                            sorted[j as usize],
+                            sorted[left as usize],
+                            sorted[right as usize],
+                        ]];
+                        let mut res = Vec::with_capacity(a.len() + b.len());
+                        res.extend_from_slice(a);
+                        res.extend_from_slice(b);
+                        res
+                    };
                     left = left + 1;
                     right = right - 1;
                     while left < right && sorted[left as usize] == sorted[(left - 1) as usize] {
@@ -30,8 +50,7 @@ fn fourSum(nums: Vec<i32>, target: i32) -> Vec<Vec<i32>> {
                     while left < right && sorted[right as usize] == sorted[(right + 1) as usize] {
                         right = right - 1;
                     }
-                } else 
-                if sum < target {
+                } else if sum < target {
                     left = left + 1;
                 } else {
                     right = right - 1;
@@ -42,12 +61,24 @@ fn fourSum(nums: Vec<i32>, target: i32) -> Vec<Vec<i32>> {
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(
+        fourSum(vec![1, 0, -1, 0, -2, 2], 0)
+            == vec![vec![-2, -1, 1, 2], vec![-2, 0, 0, 2], vec![-1, 0, 0, 1]],
+    );
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(fourSum(vec![2, 2, 2, 2, 2], 8) == vec![vec![2, 2, 2, 2]]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/19/remove-nth-node-from-end-of-list.rs
+++ b/examples/leetcode-out/rust/19/remove-nth-node-from-end-of-list.rs
@@ -1,22 +1,53 @@
-fn removeNthFromEnd(nums: Vec<i32>, n: i32) -> Vec<i32> {
-    let mut idx = nums.len() as i32 - n;
+fn removeNthFromEnd(nums: Vec<i64>, n: i64) -> Vec<i64> {
+    let mut idx = nums.len() as i64 - n;
     let mut result = vec![];
     let mut i = 0;
-    while i < nums.len() as i32 {
+    while i < nums.len() as i64 {
         if i != idx {
-            result = _concat(&result, &vec![nums[i as usize]]);
+            result = {
+                let a = &result;
+                let b = &vec![nums[i as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
         }
         i = i + 1;
     }
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(removeNthFromEnd(vec![1, 2, 3, 4, 5], 2) == vec![1, 2, 3, 5]);
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(removeNthFromEnd(vec![1], 1) == vec![]);
+}
+
+fn test_example_3() {
+    expect(removeNthFromEnd(vec![1, 2], 1) == vec![1]);
+}
+
+fn test_remove_first() {
+    expect(removeNthFromEnd(vec![7, 8, 9], 3) == vec![8, 9]);
+}
+
+fn test_remove_last() {
+    expect(removeNthFromEnd(vec![7, 8, 9], 1) == vec![7, 8]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_remove_first();
+    test_remove_last();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/2/add-two-numbers.rs
+++ b/examples/leetcode-out/rust/2/add-two-numbers.rs
@@ -1,33 +1,56 @@
-fn addTwoNumbers(l1: Vec<i32>, l2: Vec<i32>) -> Vec<i32> {
+fn addTwoNumbers(l1: Vec<i64>, l2: Vec<i64>) -> Vec<i64> {
     let mut i = 0;
     let mut j = 0;
     let mut carry = 0;
-    let mut result: Vec<i32> = vec![];
-    while i < l1.len() as i32 || j < l2.len() as i32 || carry > 0 {
+    let mut result: Vec<i64> = vec![];
+    while i < l1.len() as i64 || j < l2.len() as i64 || carry > 0 {
         let mut x = 0;
-        if i < l1.len() as i32 {
-            x = l1[(i) as usize];
+        if i < l1.len() as i64 {
+            x = l1[i as usize];
             i = i + 1;
         }
         let mut y = 0;
-        if j < l2.len() as i32 {
-            y = l2[(j) as usize];
+        if j < l2.len() as i64 {
+            y = l2[j as usize];
             j = j + 1;
         }
         let mut sum = x + y + carry;
         let mut digit = sum % 10;
         carry = sum / 10;
-        result = _concat(&result, &vec![digit]);
+        result = {
+            let a = &result;
+            let b = &vec![digit];
+            let mut res = Vec::with_capacity(a.len() + b.len());
+            res.extend_from_slice(a);
+            res.extend_from_slice(b);
+            res
+        };
     }
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(addTwoNumbers(vec![2, 4, 3], vec![5, 6, 4]) == vec![7, 0, 8]);
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(addTwoNumbers(vec![0], vec![0]) == vec![0]);
+}
+
+fn test_example_3() {
+    expect(
+        addTwoNumbers(vec![9, 9, 9, 9, 9, 9, 9], vec![9, 9, 9, 9]) == vec![8, 9, 9, 9, 0, 0, 0, 1],
+    );
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/20/valid-parentheses.rs
+++ b/examples/leetcode-out/rust/20/valid-parentheses.rs
@@ -1,0 +1,105 @@
+fn isValid(s: &str) -> bool {
+    let mut stack: Vec<String> = vec![];
+    let mut n = s.len() as i64;
+    for i in 0..n {
+        let mut c = {
+            let s = &s;
+            let mut idx = i;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        };
+        if c == "(" {
+            stack = {
+                let a = &stack;
+                let b = &vec![")".to_string()];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
+        } else if c == "[" {
+            stack = {
+                let a = &stack;
+                let b = &vec!["]".to_string()];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
+        } else if c == "{" {
+            stack = {
+                let a = &stack;
+                let b = &vec!["}".to_string()];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
+        } else {
+            if stack.len() as i64 == 0 {
+                return false;
+            }
+            let mut top = stack[(stack.len() as i64 - 1) as usize];
+            if top != c {
+                return false;
+            }
+            stack = stack[(0) as usize..(stack.len() as i64 - 1) as usize].to_vec();
+        }
+    }
+    return stack.len() as i64 == 0;
+}
+
+fn test_example_1() {
+    expect(isValid("()") == true);
+}
+
+fn test_example_2() {
+    expect(isValid("()[]{}") == true);
+}
+
+fn test_example_3() {
+    expect(isValid("(]") == false);
+}
+
+fn test_example_4() {
+    expect(isValid("([)]") == false);
+}
+
+fn test_example_5() {
+    expect(isValid("{[]}") == true);
+}
+
+fn test_empty_string() {
+    expect(isValid("") == true);
+}
+
+fn test_single_closing() {
+    expect(isValid("]") == false);
+}
+
+fn test_unmatched_open() {
+    expect(isValid("((") == false);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_example_4();
+    test_example_5();
+    test_empty_string();
+    test_single_closing();
+    test_unmatched_open();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/21/merge-two-sorted-lists.rs
+++ b/examples/leetcode-out/rust/21/merge-two-sorted-lists.rs
@@ -1,33 +1,85 @@
-fn mergeTwoLists(l1: Vec<i32>, l2: Vec<i32>) -> Vec<i32> {
+fn mergeTwoLists(l1: Vec<i64>, l2: Vec<i64>) -> Vec<i64> {
     let mut i = 0;
     let mut j = 0;
     let mut result = vec![];
-    while i < l1.len() as i32 && j < l2.len() as i32 {
+    while i < l1.len() as i64 && j < l2.len() as i64 {
         if l1[i as usize] <= l2[j as usize] {
-            result = _concat(&result, &vec![l1[i as usize]]);
+            result = {
+                let a = &result;
+                let b = &vec![l1[i as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
             i = i + 1;
         } else {
-            result = _concat(&result, &vec![l2[j as usize]]);
+            result = {
+                let a = &result;
+                let b = &vec![l2[j as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
             j = j + 1;
         }
     }
-    while i < l1.len() as i32 {
-        result = _concat(&result, &vec![l1[i as usize]]);
+    while i < l1.len() as i64 {
+        result = {
+            let a = &result;
+            let b = &vec![l1[i as usize]];
+            let mut res = Vec::with_capacity(a.len() + b.len());
+            res.extend_from_slice(a);
+            res.extend_from_slice(b);
+            res
+        };
         i = i + 1;
     }
-    while j < l2.len() as i32 {
-        result = _concat(&result, &vec![l2[j as usize]]);
+    while j < l2.len() as i64 {
+        result = {
+            let a = &result;
+            let b = &vec![l2[j as usize]];
+            let mut res = Vec::with_capacity(a.len() + b.len());
+            res.extend_from_slice(a);
+            res.extend_from_slice(b);
+            res
+        };
         j = j + 1;
     }
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(mergeTwoLists(vec![1, 2, 4], vec![1, 3, 4]) == vec![1, 1, 2, 3, 4, 4]);
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(mergeTwoLists(vec![], vec![]) == vec![]);
+}
+
+fn test_example_3() {
+    expect(mergeTwoLists(vec![], vec![0]) == vec![0]);
+}
+
+fn test_different_lengths() {
+    expect(mergeTwoLists(vec![1, 5, 7], vec![2, 3, 4, 6, 8]) == vec![1, 2, 3, 4, 5, 6, 7, 8]);
+}
+
+fn test_one_list_empty() {
+    expect(mergeTwoLists(vec![1, 2, 3], vec![]) == vec![1, 2, 3]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_different_lengths();
+    test_one_list_empty();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/22/generate-parentheses.rs
+++ b/examples/leetcode-out/rust/22/generate-parentheses.rs
@@ -1,0 +1,57 @@
+fn generateParenthesis(n: i64) -> Vec<String> {
+    let mut result: Vec<String> = vec![];
+    fn backtrack(current: &str, open: i64, close: i64) {
+        if current.len() as i64 == n * 2 {
+            result = {
+                let a = &result;
+                let b = &vec![current];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
+        } else {
+            if open < n {
+                backtrack(format!("{}{}", current, "("), open + 1, close);
+            }
+            if close < open {
+                backtrack(format!("{}{}", current, ")"), open, close + 1);
+            }
+        }
+    }
+    backtrack("", 0, 0);
+    return result;
+}
+
+fn test_example_1() {
+    expect(
+        generateParenthesis(3)
+            == vec![
+                "((()))".to_string(),
+                "(()())".to_string(),
+                "(())()".to_string(),
+                "()(())".to_string(),
+                "()()()".to_string(),
+            ],
+    );
+}
+
+fn test_example_2() {
+    expect(generateParenthesis(1) == vec!["()".to_string()]);
+}
+
+fn test_two_pairs() {
+    expect(generateParenthesis(2) == vec!["(())".to_string(), "()()".to_string()]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_two_pairs();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/23/merge-k-sorted-lists.rs
+++ b/examples/leetcode-out/rust/23/merge-k-sorted-lists.rs
@@ -1,12 +1,19 @@
-fn mergeKLists(lists: Vec<Vec<i32>>) -> Vec<i32> {
-    let mut k = lists.len() as i32;
-    let mut indices: Vec<i32> = vec![];
+fn mergeKLists(lists: Vec<Vec<i64>>) -> Vec<i64> {
+    let mut k = lists.len() as i64;
+    let mut indices: Vec<i64> = vec![];
     let mut i = 0;
     while i < k {
-        indices = _concat(&indices, &vec![0]);
+        indices = {
+            let a = &indices;
+            let b = &vec![0];
+            let mut res = Vec::with_capacity(a.len() + b.len());
+            res.extend_from_slice(a);
+            res.extend_from_slice(b);
+            res
+        };
         i = i + 1;
     }
-    let mut result: Vec<i32> = vec![];
+    let mut result: Vec<i64> = vec![];
     while true {
         let mut best = 0;
         let mut bestList = -1;
@@ -14,7 +21,7 @@ fn mergeKLists(lists: Vec<Vec<i32>>) -> Vec<i32> {
         let mut j = 0;
         while j < k {
             let mut idx = indices[j as usize];
-            if idx < lists[j as usize].len() as i32 {
+            if idx < lists[j as usize].len() as i64 {
                 let mut val = lists[j as usize][idx as usize];
                 if !found || val < best {
                     best = val;
@@ -27,18 +34,41 @@ fn mergeKLists(lists: Vec<Vec<i32>>) -> Vec<i32> {
         if !found {
             break;
         }
-        result = _concat(&result, &vec![best]);
+        result = {
+            let a = &result;
+            let b = &vec![best];
+            let mut res = Vec::with_capacity(a.len() + b.len());
+            res.extend_from_slice(a);
+            res.extend_from_slice(b);
+            res
+        };
         indices[bestList as usize] = indices[bestList as usize] + 1;
     }
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(
+        mergeKLists(vec![vec![1, 4, 5], vec![1, 3, 4], vec![2, 6]]) == vec![1, 1, 2, 3, 4, 4, 5, 6],
+    );
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(mergeKLists(vec![]) == vec![]);
+}
+
+fn test_example_3() {
+    expect(mergeKLists(vec![vec![]]) == vec![]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/24/swap-nodes-in-pairs.rs
+++ b/examples/leetcode-out/rust/24/swap-nodes-in-pairs.rs
@@ -1,23 +1,56 @@
-fn swapPairs(nums: Vec<i32>) -> Vec<i32> {
+fn swapPairs(nums: Vec<i64>) -> Vec<i64> {
     let mut i = 0;
     let mut result = vec![];
-    while i < nums.len() as i32 {
-        if i + 1 < nums.len() as i32 {
-            result = _concat(&result, &vec![nums[(i + 1) as usize], nums[i as usize]]);
+    while i < nums.len() as i64 {
+        if i + 1 < nums.len() as i64 {
+            result = {
+                let a = &result;
+                let b = &vec![nums[(i + 1) as usize], nums[i as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
         } else {
-            result = _concat(&result, &vec![nums[i as usize]]);
+            result = {
+                let a = &result;
+                let b = &vec![nums[i as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
         }
         i = i + 2;
     }
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(swapPairs(vec![1, 2, 3, 4]) == vec![2, 1, 4, 3]);
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(swapPairs(vec![]) == vec![]);
+}
+
+fn test_example_3() {
+    expect(swapPairs(vec![1]) == vec![1]);
+}
+
+fn test_odd_length() {
+    expect(swapPairs(vec![1, 2, 3]) == vec![2, 1, 3]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_odd_length();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/25/reverse-nodes-in-k-group.rs
+++ b/examples/leetcode-out/rust/25/reverse-nodes-in-k-group.rs
@@ -1,5 +1,5 @@
-fn reverseKGroup(nums: Vec<i32>, k: i32) -> Vec<i32> {
-    let mut n = nums.len() as i32;
+fn reverseKGroup(nums: Vec<i64>, k: i64) -> Vec<i64> {
+    let mut n = nums.len() as i64;
     if k <= 1 {
         return nums;
     }
@@ -10,13 +10,27 @@ fn reverseKGroup(nums: Vec<i32>, k: i32) -> Vec<i32> {
         if end <= n {
             let mut j = end - 1;
             while j >= i {
-                result = _concat(&result, &vec![nums[j as usize]]);
+                result = {
+                    let a = &result;
+                    let b = &vec![nums[j as usize]];
+                    let mut res = Vec::with_capacity(a.len() + b.len());
+                    res.extend_from_slice(a);
+                    res.extend_from_slice(b);
+                    res
+                };
                 j = j - 1;
             }
         } else {
             let mut j = i;
             while j < n {
-                result = _concat(&result, &vec![nums[j as usize]]);
+                result = {
+                    let a = &result;
+                    let b = &vec![nums[j as usize]];
+                    let mut res = Vec::with_capacity(a.len() + b.len());
+                    res.extend_from_slice(a);
+                    res.extend_from_slice(b);
+                    res
+                };
                 j = j + 1;
             }
         }
@@ -25,12 +39,36 @@ fn reverseKGroup(nums: Vec<i32>, k: i32) -> Vec<i32> {
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(reverseKGroup(vec![1, 2, 3, 4, 5], 2) == vec![2, 1, 4, 3, 5]);
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(reverseKGroup(vec![1, 2, 3, 4, 5], 3) == vec![3, 2, 1, 4, 5]);
+}
+
+fn test_k_equals_list_length() {
+    expect(reverseKGroup(vec![1, 2, 3, 4], 4) == vec![4, 3, 2, 1]);
+}
+
+fn test_k_greater_than_length() {
+    expect(reverseKGroup(vec![1, 2, 3], 5) == vec![1, 2, 3]);
+}
+
+fn test_k_is_one() {
+    expect(reverseKGroup(vec![1, 2, 3], 1) == vec![1, 2, 3]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_k_equals_list_length();
+    test_k_greater_than_length();
+    test_k_is_one();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/26/remove-duplicates-from-sorted-array.rs
+++ b/examples/leetcode-out/rust/26/remove-duplicates-from-sorted-array.rs
@@ -1,11 +1,11 @@
-fn removeDuplicates(nums: Vec<i32>) -> i32 {
-    if nums.len() as i32 == 0 {
+fn removeDuplicates(nums: Vec<i64>) -> i64 {
+    if nums.len() as i64 == 0 {
         return 0;
     }
     let mut count = 1;
     let mut prev = nums[(0) as usize];
     let mut i = 1;
-    while i < nums.len() as i32 {
+    while i < nums.len() as i64 {
         let mut cur = nums[i as usize];
         if cur != prev {
             count = count + 1;
@@ -16,6 +16,26 @@ fn removeDuplicates(nums: Vec<i32>) -> i32 {
     return count;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(removeDuplicates(vec![1, 1, 2]) == 2);
 }
 
+fn test_example_2() {
+    expect(removeDuplicates(vec![0, 0, 1, 1, 1, 2, 2, 3, 3, 4]) == 5);
+}
+
+fn test_empty() {
+    expect(removeDuplicates(vec![]) == 0);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_empty();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/27/remove-element.rs
+++ b/examples/leetcode-out/rust/27/remove-element.rs
@@ -1,0 +1,45 @@
+fn removeElement(nums: Vec<i64>, val: i64) -> i64 {
+    let mut k = 0;
+    let mut i = 0;
+    while i < nums.len() as i64 {
+        if nums[i as usize] != val {
+            nums[k as usize] = nums[i as usize];
+            k = k + 1;
+        }
+        i = i + 1;
+    }
+    return k;
+}
+
+fn test_example_1() {
+    let mut nums = vec![3, 2, 2, 3];
+    let mut k = removeElement(nums, 3);
+    expect(k == 2);
+    expect(nums[(0) as usize..k as usize].to_vec() == vec![2, 2]);
+}
+
+fn test_example_2() {
+    let mut nums = vec![0, 1, 2, 2, 3, 0, 4, 2];
+    let mut k = removeElement(nums, 2);
+    expect(k == 5);
+    expect(nums[(0) as usize..k as usize].to_vec() == vec![0, 1, 3, 0, 4]);
+}
+
+fn test_no_removal() {
+    let mut nums = vec![1, 2, 3];
+    let mut k = removeElement(nums, 4);
+    expect(k == 3);
+    expect(nums[(0) as usize..k as usize].to_vec() == vec![1, 2, 3]);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_no_removal();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/28/find-the-index-of-the-first-occurrence-in-a-string.rs
+++ b/examples/leetcode-out/rust/28/find-the-index-of-the-first-occurrence-in-a-string.rs
@@ -1,6 +1,6 @@
-fn strStr(haystack: &str, needle: &str) -> i32 {
-    let mut n = haystack.len() as i32;
-    let mut m = needle.len() as i32;
+fn strStr(haystack: &str, needle: &str) -> i64 {
+    let mut n = haystack.len() as i64;
+    let mut m = needle.len() as i64;
     if m == 0 {
         return 0;
     }
@@ -10,7 +10,29 @@ fn strStr(haystack: &str, needle: &str) -> i32 {
     for i in 0..n - m + 1 {
         let mut j = 0;
         while j < m {
-            if haystack.chars().nth((i + j) as usize).unwrap() != needle.chars().nth((j) as usize).unwrap() {
+            if {
+                let s = &haystack;
+                let mut idx = i + j;
+                let chars: Vec<char> = s.chars().collect();
+                if idx < 0 {
+                    idx += chars.len() as i64;
+                }
+                if idx < 0 || idx >= chars.len() as i64 {
+                    panic!("index out of range");
+                }
+                chars[idx as usize].to_string()
+            } != {
+                let s = &needle;
+                let mut idx = j;
+                let chars: Vec<char> = s.chars().collect();
+                if idx < 0 {
+                    idx += chars.len() as i64;
+                }
+                if idx < 0 || idx >= chars.len() as i64 {
+                    panic!("index out of range");
+                }
+                chars[idx as usize].to_string()
+            } {
                 break;
             }
             j = j + 1;
@@ -22,6 +44,31 @@ fn strStr(haystack: &str, needle: &str) -> i32 {
     return -1;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(strStr("sadbutsad", "sad") == 0);
 }
 
+fn test_example_2() {
+    expect(strStr("leetcode", "leeto") == (-1));
+}
+
+fn test_empty_needle() {
+    expect(strStr("abc", "") == 0);
+}
+
+fn test_needle_at_end() {
+    expect(strStr("hello", "lo") == 3);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_empty_needle();
+    test_needle_at_end();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/3/longest-substring-without-repeating-characters.rs
+++ b/examples/leetcode-out/rust/3/longest-substring-without-repeating-characters.rs
@@ -1,12 +1,34 @@
-fn lengthOfLongestSubstring(s: &str) -> i32 {
-    let mut n = s.len() as i32;
+fn lengthOfLongestSubstring(s: &str) -> i64 {
+    let mut n = s.len() as i64;
     let mut start = 0;
     let mut best = 0;
     let mut i = 0;
     while i < n {
         let mut j = start;
         while j < i {
-            if s.chars().nth((j) as usize).unwrap() == s.chars().nth((i) as usize).unwrap() {
+            if {
+                let s = &s;
+                let mut idx = j;
+                let chars: Vec<char> = s.chars().collect();
+                if idx < 0 {
+                    idx += chars.len() as i64;
+                }
+                if idx < 0 || idx >= chars.len() as i64 {
+                    panic!("index out of range");
+                }
+                chars[idx as usize].to_string()
+            } == {
+                let s = &s;
+                let mut idx = i;
+                let chars: Vec<char> = s.chars().collect();
+                if idx < 0 {
+                    idx += chars.len() as i64;
+                }
+                if idx < 0 || idx >= chars.len() as i64 {
+                    panic!("index out of range");
+                }
+                chars[idx as usize].to_string()
+            } {
                 start = j + 1;
                 break;
             }
@@ -21,6 +43,31 @@ fn lengthOfLongestSubstring(s: &str) -> i32 {
     return best;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(lengthOfLongestSubstring("abcabcbb") == 3);
 }
 
+fn test_example_2() {
+    expect(lengthOfLongestSubstring("bbbbb") == 1);
+}
+
+fn test_example_3() {
+    expect(lengthOfLongestSubstring("pwwkew") == 3);
+}
+
+fn test_empty_string() {
+    expect(lengthOfLongestSubstring("") == 0);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_empty_string();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/4/median-of-two-sorted-arrays.rs
+++ b/examples/leetcode-out/rust/4/median-of-two-sorted-arrays.rs
@@ -1,25 +1,51 @@
-fn findMedianSortedArrays(nums1: Vec<i32>, nums2: Vec<i32>) -> f64 {
-    let mut merged: Vec<i32> = vec![];
+fn findMedianSortedArrays(nums1: Vec<i64>, nums2: Vec<i64>) -> f64 {
+    let mut merged: Vec<i64> = vec![];
     let mut i = 0;
     let mut j = 0;
-    while i < nums1.len() as i32 || j < nums2.len() as i32 {
-        if j >= nums2.len() as i32 {
-            merged = _concat(&merged, &vec![nums1[(i) as usize]]);
+    while i < nums1.len() as i64 || j < nums2.len() as i64 {
+        if j >= nums2.len() as i64 {
+            merged = {
+                let a = &merged;
+                let b = &vec![nums1[i as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
             i = i + 1;
-        } else 
-        if i >= nums1.len() as i32 {
-            merged = _concat(&merged, &vec![nums2[(j) as usize]]);
+        } else if i >= nums1.len() as i64 {
+            merged = {
+                let a = &merged;
+                let b = &vec![nums2[j as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
             j = j + 1;
-        } else 
-        if nums1[(i) as usize] <= nums2[(j) as usize] {
-            merged = _concat(&merged, &vec![nums1[(i) as usize]]);
+        } else if nums1[i as usize] <= nums2[j as usize] {
+            merged = {
+                let a = &merged;
+                let b = &vec![nums1[i as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
             i = i + 1;
         } else {
-            merged = _concat(&merged, &vec![nums2[(j) as usize]]);
+            merged = {
+                let a = &merged;
+                let b = &vec![nums2[j as usize]];
+                let mut res = Vec::with_capacity(a.len() + b.len());
+                res.extend_from_slice(a);
+                res.extend_from_slice(b);
+                res
+            };
             j = j + 1;
         }
     }
-    let mut total = merged.len() as i32;
+    let mut total = merged.len() as i64;
     if total % 2 == 1 {
         return (merged[(total / 2) as usize] as f64);
     }
@@ -28,12 +54,31 @@ fn findMedianSortedArrays(nums1: Vec<i32>, nums2: Vec<i32>) -> f64 {
     return ((mid1 + mid2) as f64) / 2.0;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(findMedianSortedArrays(vec![1, 3], vec![2]) == 2.0);
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(findMedianSortedArrays(vec![1, 2], vec![3, 4]) == 2.5);
+}
+
+fn test_empty_first() {
+    expect(findMedianSortedArrays((vec![] as Vec<i64>), vec![1]) == 1.0);
+}
+
+fn test_empty_second() {
+    expect(findMedianSortedArrays(vec![2], (vec![] as Vec<i64>)) == 2.0);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_empty_first();
+    test_empty_second();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/5/longest-palindromic-substring.rs
+++ b/examples/leetcode-out/rust/5/longest-palindromic-substring.rs
@@ -1,9 +1,31 @@
-fn expand(s: &str, left: i32, right: i32) -> i32 {
+fn expand(s: &str, left: i64, right: i64) -> i64 {
     let mut l = left;
     let mut r = right;
-    let mut n = s.len() as i32;
+    let mut n = s.len() as i64;
     while l >= 0 && r < n {
-        if s.chars().nth((l) as usize).unwrap() != s.chars().nth((r) as usize).unwrap() {
+        if {
+            let s = &s;
+            let mut idx = l;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } != {
+            let s = &s;
+            let mut idx = r;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } {
             break;
         }
         l = l - 1;
@@ -13,12 +35,12 @@ fn expand(s: &str, left: i32, right: i32) -> i32 {
 }
 
 fn longestPalindrome(s: &str) -> String {
-    if s.len() as i32 <= 1 {
+    if s.len() as i64 <= 1 {
         return s.to_string();
     }
     let mut start = 0;
     let mut end = 0;
-    let mut n = s.len() as i32;
+    let mut n = s.len() as i64;
     for i in 0..n {
         let mut len1 = expand(&s, i, i);
         let mut len2 = expand(&s, i, i + 1);
@@ -31,9 +53,58 @@ fn longestPalindrome(s: &str) -> String {
             end = i + (l / 2);
         }
     }
-    return s[((start) as usize)..((end + 1) as usize)].to_string().to_string();
+    return _slice_string(s, start, end + 1).to_string();
+}
+
+fn test_example_1() {
+    let mut ans = longestPalindrome("babad");
+    expect(ans == "bab" || ans == "aba");
+}
+
+fn test_example_2() {
+    expect(longestPalindrome("cbbd") == "bb");
+}
+
+fn test_single_char() {
+    expect(longestPalindrome("a") == "a");
+}
+
+fn test_two_chars() {
+    let mut ans = longestPalindrome("ac");
+    expect(ans == "a" || ans == "c");
 }
 
 fn main() {
+    test_example_1();
+    test_example_2();
+    test_single_char();
+    test_two_chars();
 }
 
+fn _slice_string(s: &str, start: i64, end: i64) -> String {
+    let mut sidx = start;
+    let mut eidx = end;
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len() as i64;
+    if sidx < 0 {
+        sidx += n;
+    }
+    if eidx < 0 {
+        eidx += n;
+    }
+    if sidx < 0 {
+        sidx = 0;
+    }
+    if eidx > n {
+        eidx = n;
+    }
+    if eidx < sidx {
+        eidx = sidx;
+    }
+    chars[sidx as usize..eidx as usize].iter().collect()
+}
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/6/zigzag-conversion.rs
+++ b/examples/leetcode-out/rust/6/zigzag-conversion.rs
@@ -1,22 +1,28 @@
-fn convert(s: &str, numRows: i32) -> String {
-    if numRows <= 1 || numRows >= s.len() as i32 {
+fn convert(s: &str, numRows: i64) -> String {
+    if numRows <= 1 || numRows >= s.len() as i64 {
         return s.to_string();
     }
     let mut rows: Vec<String> = vec![];
     let mut i = 0;
     while i < numRows {
-        rows = _concat(&rows, &vec!["".to_string()]);
+        rows = {
+            let a = &rows;
+            let b = &vec!["".to_string()];
+            let mut res = Vec::with_capacity(a.len() + b.len());
+            res.extend_from_slice(a);
+            res.extend_from_slice(b);
+            res
+        };
         i = i + 1;
     }
     let mut curr = 0;
     let mut step = 1;
     for ch_ch in s.chars() {
         let ch = ch_ch.to_string();
-        rows[(curr) as usize] = format!("{}{}", rows[(curr) as usize], ch);
+        rows[curr as usize] = format!("{}{}", rows[curr as usize], ch);
         if curr == 0 {
             step = 1;
-        } else 
-        if curr == numRows - 1 {
+        } else if curr == numRows - 1 {
             step = -1;
         }
         curr = curr + step;
@@ -28,12 +34,26 @@ fn convert(s: &str, numRows: i32) -> String {
     return result.to_string();
 }
 
-fn main() {
+fn test_example_1() {
+    expect(convert("PAYPALISHIRING", 3) == "PAHNAPLSIIGYIR");
 }
 
-fn _concat<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
-    let mut res = Vec::with_capacity(a.len() + b.len());
-    res.extend_from_slice(a);
-    res.extend_from_slice(b);
-    res
+fn test_example_2() {
+    expect(convert("PAYPALISHIRING", 4) == "PINALSIGYAHRPI");
+}
+
+fn test_single_row() {
+    expect(convert("A", 1) == "A");
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_single_row();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
 }

--- a/examples/leetcode-out/rust/7/reverse-integer.rs
+++ b/examples/leetcode-out/rust/7/reverse-integer.rs
@@ -1,4 +1,4 @@
-fn reverse(x: i32) -> i32 {
+fn reverse(x: i64) -> i64 {
     let mut sign = 1;
     let mut n = x;
     if n < 0 {
@@ -18,6 +18,31 @@ fn reverse(x: i32) -> i32 {
     return rev;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(reverse(123) == 321);
 }
 
+fn test_example_2() {
+    expect(reverse(-123) == (-321));
+}
+
+fn test_example_3() {
+    expect(reverse(120) == 21);
+}
+
+fn test_overflow() {
+    expect(reverse(1534236469) == 0);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_overflow();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/8/string-to-integer-atoi.rs
+++ b/examples/leetcode-out/rust/8/string-to-integer-atoi.rs
@@ -1,4 +1,4 @@
-fn digit(ch: &str) -> i32 {
+fn digit(ch: &str) -> i64 {
     if ch == "0" {
         return 0;
     }
@@ -32,22 +32,112 @@ fn digit(ch: &str) -> i32 {
     return -1;
 }
 
-fn myAtoi(s: &str) -> i32 {
+fn myAtoi(s: &str) -> i64 {
     let mut i = 0;
-    let mut n = s.len() as i32;
-    while i < n && s.chars().nth((i) as usize).unwrap() == " ".chars().nth((0) as usize).unwrap() {
+    let mut n = s.len() as i64;
+    while i < n && {
+        let s = &s;
+        let mut idx = i;
+        let chars: Vec<char> = s.chars().collect();
+        if idx < 0 {
+            idx += chars.len() as i64;
+        }
+        if idx < 0 || idx >= chars.len() as i64 {
+            panic!("index out of range");
+        }
+        chars[idx as usize].to_string()
+    } == {
+        let s = &" ";
+        let mut idx = 0;
+        let chars: Vec<char> = s.chars().collect();
+        if idx < 0 {
+            idx += chars.len() as i64;
+        }
+        if idx < 0 || idx >= chars.len() as i64 {
+            panic!("index out of range");
+        }
+        chars[idx as usize].to_string()
+    } {
         i = i + 1;
     }
     let mut sign = 1;
-    if i < n && (s.chars().nth((i) as usize).unwrap() == "+".chars().nth((0) as usize).unwrap() || s.chars().nth((i) as usize).unwrap() == "-".chars().nth((0) as usize).unwrap()) {
-        if s.chars().nth((i) as usize).unwrap() == "-".chars().nth((0) as usize).unwrap() {
+    if i < n
+        && ({
+            let s = &s;
+            let mut idx = i;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } == {
+            let s = &"+";
+            let mut idx = 0;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } || {
+            let s = &s;
+            let mut idx = i;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } == {
+            let s = &"-";
+            let mut idx = 0;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        })
+    {
+        if {
+            let s = &s;
+            let mut idx = i;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } == {
+            let s = &"-";
+            let mut idx = 0;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } {
             sign = -1;
         }
         i = i + 1;
     }
     let mut result = 0;
     while i < n {
-        let mut ch = s[((i) as usize)..((i + 1) as usize)].to_string();
+        let mut ch = _slice_string(s, i, i + 1);
         let mut d = digit(&ch);
         if d < 0 {
             break;
@@ -65,6 +155,58 @@ fn myAtoi(s: &str) -> i32 {
     return result;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(myAtoi("42") == 42);
 }
 
+fn test_example_2() {
+    expect(myAtoi("   -42") == (-42));
+}
+
+fn test_example_3() {
+    expect(myAtoi("4193 with words") == 4193);
+}
+
+fn test_example_4() {
+    expect(myAtoi("words and 987") == 0);
+}
+
+fn test_example_5() {
+    expect(myAtoi("-91283472332") == (-2147483648));
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_example_4();
+    test_example_5();
+}
+
+fn _slice_string(s: &str, start: i64, end: i64) -> String {
+    let mut sidx = start;
+    let mut eidx = end;
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len() as i64;
+    if sidx < 0 {
+        sidx += n;
+    }
+    if eidx < 0 {
+        eidx += n;
+    }
+    if sidx < 0 {
+        sidx = 0;
+    }
+    if eidx > n {
+        eidx = n;
+    }
+    if eidx < sidx {
+        eidx = sidx;
+    }
+    chars[sidx as usize..eidx as usize].iter().collect()
+}
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}

--- a/examples/leetcode-out/rust/9/palindrome-number.rs
+++ b/examples/leetcode-out/rust/9/palindrome-number.rs
@@ -1,17 +1,64 @@
-fn isPalindrome(x: i32) -> bool {
+fn isPalindrome(x: i64) -> bool {
     if x < 0 {
         return false;
     }
     let mut s: String = format!("{}", x);
-    let mut n = s.len() as i32;
+    let mut n = s.len() as i64;
     for i in 0..n / 2 {
-        if s.chars().nth((i) as usize).unwrap() != s.chars().nth((n - 1 - i) as usize).unwrap() {
+        if {
+            let s = &s;
+            let mut idx = i;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } != {
+            let s = &s;
+            let mut idx = n - 1 - i;
+            let chars: Vec<char> = s.chars().collect();
+            if idx < 0 {
+                idx += chars.len() as i64;
+            }
+            if idx < 0 || idx >= chars.len() as i64 {
+                panic!("index out of range");
+            }
+            chars[idx as usize].to_string()
+        } {
             return false;
         }
     }
     return true;
 }
 
-fn main() {
+fn test_example_1() {
+    expect(isPalindrome(121) == true);
 }
 
+fn test_example_2() {
+    expect(isPalindrome(-121) == false);
+}
+
+fn test_example_3() {
+    expect(isPalindrome(10) == false);
+}
+
+fn test_zero() {
+    expect(isPalindrome(0) == true);
+}
+
+fn main() {
+    test_example_1();
+    test_example_2();
+    test_example_3();
+    test_zero();
+}
+
+fn expect(cond: bool) {
+    if !cond {
+        panic!("expect failed");
+    }
+}


### PR DESCRIPTION
## Summary
- add `FormatRust` to run `rustfmt` on generated Rust
- use `FormatRust` in Rust compiler
- regenerate all Rust LeetCode examples

## Testing
- `go test ./...`
- `go run ./cmd/leetcode-runner build --from 1 --to 28 --lang rust`

------
https://chatgpt.com/codex/tasks/task_e_685e22d1f2a083208457846eef8ca79d