### PR TITLE
Improve OCaml code formatting

### DIFF
--- a/tests/compiler/ocaml/bool_ops.ml.out
+++ b/tests/compiler/ocaml/bool_ops.ml.out
@@ -1,3 +1,3 @@
 print_endline (string_of_bool (true && false));;
 print_endline (string_of_bool (true || false));;
-print_endline (string_of_bool (not false));;
+print_endline (string_of_bool (not false))

--- a/tests/compiler/ocaml/break_continue.ml.out
+++ b/tests/compiler/ocaml/break_continue.ml.out
@@ -1,17 +1,15 @@
 exception BreakException of int
 exception ContinueException of int
 
-let numbers = [1; 2; 3; 4; 5; 6; 7; 8; 9];;
+let numbers = [ 1; 2; 3; 4; 5; 6; 7; 8; 9 ];;
+
 try
-  List.iter (fun n ->
-    try
-      if n mod 2 = 0 then begin
-        raise (ContinueException 0)
-      end;
-      if n > 7 then begin
-        raise (BreakException 0)
-      end;
-      print_endline (String.concat " " ["odd number:"; string_of_int (n)]);
-    with ContinueException n when n = 0 -> ()
-  ) numbers;
-with BreakException n when n = 0 -> ();;
+  List.iter
+    (fun n ->
+      try
+        if n mod 2 = 0 then raise (ContinueException 0);
+        if n > 7 then raise (BreakException 0);
+        print_endline (String.concat " " [ "odd number:"; string_of_int n ])
+      with ContinueException n when n = 0 -> ())
+    numbers
+with BreakException n when n = 0 -> ()

--- a/tests/compiler/ocaml/fetch_builtin.ml.out
+++ b/tests/compiler/ocaml/fetch_builtin.ml.out
@@ -1,72 +1,98 @@
 let rec _read_all ic =
-  try let line = input_line ic in
-      line ^ "\n" ^ _read_all ic
-  with End_of_file -> "";;
+  try
+    let line = input_line ic in
+    line ^ "\n" ^ _read_all ic
+  with End_of_file -> ""
 
 let _read_input path =
-  let ic = match path with
+  let ic =
+    match path with
     | None -> stdin
     | Some p when p = "" || p = "-" -> stdin
-    | Some p -> open_in p in
+    | Some p -> open_in p
+  in
   let txt = _read_all ic in
   if ic != stdin then close_in ic;
-  txt;;
+  txt
 
 let _load path _ =
   let text = _read_input path in
   match Yojson.Basic.from_string text with
   | `List items -> items
-  | json -> [json];;
+  | json -> [ json ]
 
 let _save rows path _ =
-  let oc = match path with
+  let oc =
+    match path with
     | None -> stdout
     | Some p when p = "" || p = "-" -> stdout
-    | Some p -> open_out p in
+    | Some p -> open_out p
+  in
   Yojson.Basic.to_channel oc (`List rows);
   output_char oc '\n';
-  if oc != stdout then close_out oc;;
+  if oc != stdout then close_out oc
 
 let _fetch url opts =
   let is_file =
-    (String.length url >= 7 && String.sub url 0 7 = "file://") || not (String.contains url ':') in
-  if is_file then (
-    let path = if String.length url >= 7 && String.sub url 0 7 = "file://" then String.sub url 7 (String.length url - 7) else url in
+    (String.length url >= 7 && String.sub url 0 7 = "file://")
+    || not (String.contains url ':')
+  in
+  if is_file then
+    let path =
+      if String.length url >= 7 && String.sub url 0 7 = "file://" then
+        String.sub url 7 (String.length url - 7)
+      else url
+    in
     let txt = _read_input (Some path) in
-    Yojson.Basic.from_string txt) else (
+    Yojson.Basic.from_string txt
+  else
     let method_ =
       match opts with
       | None -> "GET"
-      | Some tbl ->
-          (try Yojson.Basic.Util.to_string (Hashtbl.find tbl "method") with Not_found -> "GET") in
+      | Some tbl -> (
+          try Yojson.Basic.Util.to_string (Hashtbl.find tbl "method")
+          with Not_found -> "GET")
+    in
     let url_ref = ref url in
-    let args = ref ["curl"; "-s"; "-X"; method_] in
+    let args = ref [ "curl"; "-s"; "-X"; method_ ] in
     (match opts with
-    | Some tbl ->
+    | Some tbl -> (
         (try
-          let headers = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "headers") in
-          List.iter (fun (k,v) -> args := !args @ ["-H"; k ^ ": " ^ Yojson.Basic.to_string v]) headers
-        with Not_found -> ());
+           let headers =
+             Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "headers")
+           in
+           List.iter
+             (fun (k, v) ->
+               args := !args @ [ "-H"; k ^ ": " ^ Yojson.Basic.to_string v ])
+             headers
+         with Not_found -> ());
         (try
-          let q = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "query") in
-          let qs = String.concat "&" (List.map (fun (k,v) -> k ^ "=" ^ Yojson.Basic.to_string v) q) in
-          let sep = if String.contains !url_ref '?' then '&' else '?' in
-          url_ref := !url_ref ^ (String.make 1 sep) ^ qs
-        with Not_found -> ());
+           let q = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "query") in
+           let qs =
+             String.concat "&"
+               (List.map (fun (k, v) -> k ^ "=" ^ Yojson.Basic.to_string v) q)
+           in
+           let sep = if String.contains !url_ref '?' then '&' else '?' in
+           url_ref := !url_ref ^ String.make 1 sep ^ qs
+         with Not_found -> ());
         (try
-          let body = Hashtbl.find tbl "body" in
-          args := !args @ ["-d"; Yojson.Basic.to_string body]
-        with Not_found -> ());
-        (try
+           let body = Hashtbl.find tbl "body" in
+           args := !args @ [ "-d"; Yojson.Basic.to_string body ]
+         with Not_found -> ());
+        try
           let t = Hashtbl.find tbl "timeout" in
-          args := !args @ ["--max-time"; Yojson.Basic.to_string t]
-        with Not_found -> ());
+          args := !args @ [ "--max-time"; Yojson.Basic.to_string t ]
+        with Not_found -> ())
     | None -> ());
-    args := !args @ [!url_ref];
+    args := !args @ [ !url_ref ];
     let ic = Unix.open_process_in (String.concat " " !args) in
     let txt = _read_all ic in
     close_in ic;
-    Yojson.Basic.from_string txt) ;;
+    Yojson.Basic.from_string txt
 
 let data = _fetch "file://tests/compiler/ocaml/fetch_builtin.json" None;;
-_save [data] None (let tbl = Hashtbl.create 1 in Hashtbl.add tbl "format" "json"; tbl);;
+
+_save [ data ] None
+  (let tbl = Hashtbl.create 1 in
+   Hashtbl.add tbl "format" "json";
+   tbl)

--- a/tests/compiler/ocaml/fetch_http.ml.out
+++ b/tests/compiler/ocaml/fetch_http.ml.out
@@ -1,66 +1,98 @@
 let rec _read_all ic =
-  try let line = input_line ic in
-      line ^ "\n" ^ _read_all ic
-  with End_of_file -> "";;
+  try
+    let line = input_line ic in
+    line ^ "\n" ^ _read_all ic
+  with End_of_file -> ""
 
 let _read_input path =
-  let ic = match path with
+  let ic =
+    match path with
     | None -> stdin
     | Some p when p = "" || p = "-" -> stdin
-    | Some p -> open_in p in
+    | Some p -> open_in p
+  in
   let txt = _read_all ic in
   if ic != stdin then close_in ic;
-  txt;;
+  txt
 
 let _load path _ =
   let text = _read_input path in
   match Yojson.Basic.from_string text with
   | `List items -> items
-  | json -> [json];;
+  | json -> [ json ]
 
 let _save rows path _ =
-  let oc = match path with
+  let oc =
+    match path with
     | None -> stdout
     | Some p when p = "" || p = "-" -> stdout
-    | Some p -> open_out p in
+    | Some p -> open_out p
+  in
   Yojson.Basic.to_channel oc (`List rows);
   output_char oc '\n';
-  if oc != stdout then close_out oc;;
+  if oc != stdout then close_out oc
 
 let _fetch url opts =
-  let method_ =
-    match opts with
-    | None -> "GET"
-    | Some tbl ->
-        (try Yojson.Basic.Util.to_string (Hashtbl.find tbl "method") with Not_found -> "GET") in
-  let url_ref = ref url in
-  let args = ref ["curl"; "-s"; "-X"; method_] in
-  (match opts with
-  | Some tbl ->
-      (try
-        let headers = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "headers") in
-        List.iter (fun (k,v) -> args := !args @ ["-H"; k ^ ": " ^ Yojson.Basic.to_string v]) headers
-      with Not_found -> ());
-      (try
-        let q = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "query") in
-        let qs = String.concat "&" (List.map (fun (k,v) -> k ^ "=" ^ Yojson.Basic.to_string v) q) in
-        let sep = if String.contains !url_ref '?' then '&' else '?' in
-        url_ref := !url_ref ^ (String.make 1 sep) ^ qs
-      with Not_found -> ());
-      (try
-        let body = Hashtbl.find tbl "body" in
-        args := !args @ ["-d"; Yojson.Basic.to_string body]
-      with Not_found -> ());
-      (try
-        let t = Hashtbl.find tbl "timeout" in
-        args := !args @ ["--max-time"; Yojson.Basic.to_string t]
-      with Not_found -> ());
-  | None -> ());
-  args := !args @ [!url_ref];
-  let ic = Unix.open_process_in (String.concat " " !args) in
-  let txt = _read_all ic in
-  close_in ic;
-  Yojson.Basic.from_string txt;;
+  let is_file =
+    (String.length url >= 7 && String.sub url 0 7 = "file://")
+    || not (String.contains url ':')
+  in
+  if is_file then
+    let path =
+      if String.length url >= 7 && String.sub url 0 7 = "file://" then
+        String.sub url 7 (String.length url - 7)
+      else url
+    in
+    let txt = _read_input (Some path) in
+    Yojson.Basic.from_string txt
+  else
+    let method_ =
+      match opts with
+      | None -> "GET"
+      | Some tbl -> (
+          try Yojson.Basic.Util.to_string (Hashtbl.find tbl "method")
+          with Not_found -> "GET")
+    in
+    let url_ref = ref url in
+    let args = ref [ "curl"; "-s"; "-X"; method_ ] in
+    (match opts with
+    | Some tbl -> (
+        (try
+           let headers =
+             Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "headers")
+           in
+           List.iter
+             (fun (k, v) ->
+               args := !args @ [ "-H"; k ^ ": " ^ Yojson.Basic.to_string v ])
+             headers
+         with Not_found -> ());
+        (try
+           let q = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "query") in
+           let qs =
+             String.concat "&"
+               (List.map (fun (k, v) -> k ^ "=" ^ Yojson.Basic.to_string v) q)
+           in
+           let sep = if String.contains !url_ref '?' then '&' else '?' in
+           url_ref := !url_ref ^ String.make 1 sep ^ qs
+         with Not_found -> ());
+        (try
+           let body = Hashtbl.find tbl "body" in
+           args := !args @ [ "-d"; Yojson.Basic.to_string body ]
+         with Not_found -> ());
+        try
+          let t = Hashtbl.find tbl "timeout" in
+          args := !args @ [ "--max-time"; Yojson.Basic.to_string t ]
+        with Not_found -> ())
+    | None -> ());
+    args := !args @ [ !url_ref ];
+    let ic = Unix.open_process_in (String.concat " " !args) in
+    let txt = _read_all ic in
+    close_in ic;
+    Yojson.Basic.from_string txt
 
 let data = _fetch "https://jsonplaceholder.typicode.com/todos/1" None;;
-_save [data] None (let tbl = Hashtbl.create 1 in Hashtbl.add tbl "format" "json"; tbl);;
+
+_save [ data ] None
+  (let tbl = Hashtbl.create 1 in
+   Hashtbl.add tbl "format" "json";
+   tbl)

--- a/tests/compiler/ocaml/fetch_typed.ml.out
+++ b/tests/compiler/ocaml/fetch_typed.ml.out
@@ -28,39 +28,45 @@ let _save rows path _ =
   if oc != stdout then close_out oc;;
 
 let _fetch url opts =
-  let method_ =
-    match opts with
-    | None -> "GET"
+  let is_file =
+    (String.length url >= 7 && String.sub url 0 7 = "file://") || not (String.contains url ':') in
+  if is_file then (
+    let path = if String.length url >= 7 && String.sub url 0 7 = "file://" then String.sub url 7 (String.length url - 7) else url in
+    let txt = _read_input (Some path) in
+    Yojson.Basic.from_string txt) else (
+    let method_ =
+      match opts with
+      | None -> "GET"
+      | Some tbl ->
+          (try Yojson.Basic.Util.to_string (Hashtbl.find tbl "method") with Not_found -> "GET") in
+    let url_ref = ref url in
+    let args = ref ["curl"; "-s"; "-X"; method_] in
+    (match opts with
     | Some tbl ->
-        (try Yojson.Basic.Util.to_string (Hashtbl.find tbl "method") with Not_found -> "GET") in
-  let url_ref = ref url in
-  let args = ref ["curl"; "-s"; "-X"; method_] in
-  (match opts with
-  | Some tbl ->
-      (try
-        let headers = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "headers") in
-        List.iter (fun (k,v) -> args := !args @ ["-H"; k ^ ": " ^ Yojson.Basic.to_string v]) headers
-      with Not_found -> ());
-      (try
-        let q = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "query") in
-        let qs = String.concat "&" (List.map (fun (k,v) -> k ^ "=" ^ Yojson.Basic.to_string v) q) in
-        let sep = if String.contains !url_ref '?' then '&' else '?' in
-        url_ref := !url_ref ^ (String.make 1 sep) ^ qs
-      with Not_found -> ());
-      (try
-        let body = Hashtbl.find tbl "body" in
-        args := !args @ ["-d"; Yojson.Basic.to_string body]
-      with Not_found -> ());
-      (try
-        let t = Hashtbl.find tbl "timeout" in
-        args := !args @ ["--max-time"; Yojson.Basic.to_string t]
-      with Not_found -> ());
-  | None -> ());
-  args := !args @ [!url_ref];
-  let ic = Unix.open_process_in (String.concat " " !args) in
-  let txt = _read_all ic in
-  close_in ic;
-  Yojson.Basic.from_string txt;;
+        (try
+          let headers = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "headers") in
+          List.iter (fun (k,v) -> args := !args @ ["-H"; k ^ ": " ^ Yojson.Basic.to_string v]) headers
+        with Not_found -> ());
+        (try
+          let q = Yojson.Basic.Util.to_assoc (Hashtbl.find tbl "query") in
+          let qs = String.concat "&" (List.map (fun (k,v) -> k ^ "=" ^ Yojson.Basic.to_string v) q) in
+          let sep = if String.contains !url_ref '?' then '&' else '?' in
+          url_ref := !url_ref ^ (String.make 1 sep) ^ qs
+        with Not_found -> ());
+        (try
+          let body = Hashtbl.find tbl "body" in
+          args := !args @ ["-d"; Yojson.Basic.to_string body]
+        with Not_found -> ());
+        (try
+          let t = Hashtbl.find tbl "timeout" in
+          args := !args @ ["--max-time"; Yojson.Basic.to_string t]
+        with Not_found -> ());
+    | None -> ());
+    args := !args @ [!url_ref];
+    let ic = Unix.open_process_in (String.concat " " !args) in
+    let txt = _read_all ic in
+    close_in ic;
+    Yojson.Basic.from_string txt) ;;
 
 type Todo = {
   userId: int;

--- a/tests/compiler/ocaml/fun_expr_in_let.ml.out
+++ b/tests/compiler/ocaml/fun_expr_in_let.ml.out
@@ -1,2 +1,3 @@
 let square = fun x -> x * x;;
-print_endline (string_of_int (square 6));;
+
+print_endline (string_of_int (square 6))

--- a/tests/compiler/ocaml/input_builtin.ml.out
+++ b/tests/compiler/ocaml/input_builtin.ml.out
@@ -1,8 +1,11 @@
 let _input () = read_line ();;
 
-print_endline "Enter first input:";;
-let input1 = _input ();;
-print_endline "Enter second input:";;
-let input2 = _input ();;
-print_endline (String.concat " " ["You entered:"; input1; ","; input2]);;
+print_endline "Enter first input:"
 
+let input1 = _input ();;
+
+print_endline "Enter second input:"
+
+let input2 = _input ();;
+
+print_endline (String.concat " " [ "You entered:"; input1; ","; input2 ])

--- a/tests/compiler/ocaml/load_save_json.ml.out
+++ b/tests/compiler/ocaml/load_save_json.ml.out
@@ -1,31 +1,45 @@
 let rec _read_all ic =
-  try let line = input_line ic in
-      line ^ "\n" ^ _read_all ic
-  with End_of_file -> "";;
+  try
+    let line = input_line ic in
+    line ^ "\n" ^ _read_all ic
+  with End_of_file -> ""
 
 let _read_input path =
-  let ic = match path with
+  let ic =
+    match path with
     | None -> stdin
     | Some p when p = "" || p = "-" -> stdin
-    | Some p -> open_in p in
+    | Some p -> open_in p
+  in
   let txt = _read_all ic in
   if ic != stdin then close_in ic;
-  txt;;
+  txt
 
 let _load path _ =
   let text = _read_input path in
   match Yojson.Basic.from_string text with
   | `List items -> items
-  | json -> [json];;
+  | json -> [ json ]
 
 let _save rows path _ =
-  let oc = match path with
+  let oc =
+    match path with
     | None -> stdout
     | Some p when p = "" || p = "-" -> stdout
-    | Some p -> open_out p in
+    | Some p -> open_out p
+  in
   Yojson.Basic.to_channel oc (`List rows);
   output_char oc '\n';
-  if oc != stdout then close_out oc;;
+  if oc != stdout then close_out oc
 
-let rows = _load None (let tbl = Hashtbl.create 1 in Hashtbl.add tbl "format" "json"; tbl);;
-_save rows None (let tbl = Hashtbl.create 1 in Hashtbl.add tbl "format" "json"; tbl);;
+let rows =
+  _load None
+    (let tbl = Hashtbl.create 1 in
+     Hashtbl.add tbl "format" "json";
+     tbl)
+;;
+
+_save rows None
+  (let tbl = Hashtbl.create 1 in
+   Hashtbl.add tbl "format" "json";
+   tbl)

--- a/tests/compiler/ocaml/load_save_json_file.ml.out
+++ b/tests/compiler/ocaml/load_save_json_file.ml.out
@@ -1,31 +1,45 @@
 let rec _read_all ic =
-  try let line = input_line ic in
-      line ^ "\n" ^ _read_all ic
-  with End_of_file -> "";;
+  try
+    let line = input_line ic in
+    line ^ "\n" ^ _read_all ic
+  with End_of_file -> ""
 
 let _read_input path =
-  let ic = match path with
+  let ic =
+    match path with
     | None -> stdin
     | Some p when p = "" || p = "-" -> stdin
-    | Some p -> open_in p in
+    | Some p -> open_in p
+  in
   let txt = _read_all ic in
   if ic != stdin then close_in ic;
-  txt;;
+  txt
 
 let _load path _ =
   let text = _read_input path in
   match Yojson.Basic.from_string text with
   | `List items -> items
-  | json -> [json];;
+  | json -> [ json ]
 
 let _save rows path _ =
-  let oc = match path with
+  let oc =
+    match path with
     | None -> stdout
     | Some p when p = "" || p = "-" -> stdout
-    | Some p -> open_out p in
+    | Some p -> open_out p
+  in
   Yojson.Basic.to_channel oc (`List rows);
   output_char oc '\n';
-  if oc != stdout then close_out oc;;
+  if oc != stdout then close_out oc
 
-let rows = _load (Some "tests/compiler/ocaml/people.json") (let tbl = Hashtbl.create 1 in Hashtbl.add tbl "format" "json"; tbl);;
-_save rows None (let tbl = Hashtbl.create 1 in Hashtbl.add tbl "format" "json"; tbl);;
+let rows =
+  _load (Some "tests/compiler/ocaml/people.json")
+    (let tbl = Hashtbl.create 1 in
+     Hashtbl.add tbl "format" "json";
+     tbl)
+;;
+
+_save rows None
+  (let tbl = Hashtbl.create 1 in
+   Hashtbl.add tbl "format" "json";
+   tbl)

--- a/tests/compiler/ocaml/string_index_concat.ml.out
+++ b/tests/compiler/ocaml/string_index_concat.ml.out
@@ -1,3 +1,3 @@
 let name = "mochi";;
-print_endline ((String.make 1 (String.get name 0)) ^ "!");;
 
+print_endline (String.make 1 (String.get name 0) ^ "!")

--- a/tests/compiler/ocaml/two_sum.ml.out
+++ b/tests/compiler/ocaml/two_sum.ml.out
@@ -1,17 +1,18 @@
 exception Return_0 of int list
+
 let rec twoSum nums target =
   try
     let n = List.length nums in
     for i = 0 to n - 1 do
       for j = i + 1 to n - 1 do
-        if (List.nth nums i) + (List.nth nums j) = target then begin
-          raise (Return_0 ([i; j]))
-        end;
-      done;
+        if List.nth nums i + List.nth nums j = target then
+          raise (Return_0 [ i; j ])
+      done
     done;
-    raise (Return_0 ([-1; -1]))
+    raise (Return_0 [ -1; -1 ])
   with Return_0 v -> v
 
-let result = twoSum [2; 7; 11; 15] 9;;
-print_endline (string_of_int ((List.nth result 0)));;
-print_endline (string_of_int ((List.nth result 1)));;
+let result = twoSum [ 2; 7; 11; 15 ] 9;;
+
+print_endline (string_of_int (List.nth result 0));;
+print_endline (string_of_int (List.nth result 1))

--- a/tests/compiler/ocaml/var_assignment.ml.out
+++ b/tests/compiler/ocaml/var_assignment.ml.out
@@ -1,3 +1,4 @@
 let x = ref 1;;
+
 x := 2;;
-print_endline (string_of_int (!x));;
+print_endline (string_of_int !x)

--- a/tests/compiler/ocaml/var_fun_call.ml.out
+++ b/tests/compiler/ocaml/var_fun_call.ml.out
@@ -1,2 +1,3 @@
 let double = ref (fun x -> x * 2);;
-print_endline (string_of_int (!double 3));;
+
+print_endline (string_of_int (!double 3))

--- a/tests/compiler/ocaml/while_loop.ml.out
+++ b/tests/compiler/ocaml/while_loop.ml.out
@@ -1,5 +1,6 @@
 let i = ref 0;;
+
 while !i < 3 do
-  print_endline (string_of_int (!i));
-  i := !i + 1;
-done;;
+  print_endline (string_of_int !i);
+  i := !i + 1
+done

--- a/tests/compiler/ocaml/while_membership.ml.out
+++ b/tests/compiler/ocaml/while_membership.ml.out
@@ -1,11 +1,18 @@
-let set = ref (let tbl = Hashtbl.create 0 in tbl);;
-List.iter (fun n ->
-  Hashtbl.replace !set n true;
-) [1; 2; 3];;
-let i = ref 1;;
+let set =
+  ref
+    (let tbl = Hashtbl.create 0 in
+     tbl)
+;;
+
+List.iter (fun n -> Hashtbl.replace !set n true) [ 1; 2; 3 ]
+
+let i = ref 1
 let count = ref 0;;
+
 while Hashtbl.mem !set !i do
   i := !i + 1;
-  count := !count + 1;
-done;;
-print_endline (string_of_int (!count));;
+  count := !count + 1
+done
+;;
+
+print_endline (string_of_int !count)

--- a/tests/compiler/valid_ocaml/fold_pure_let.ml.out
+++ b/tests/compiler/valid_ocaml/fold_pure_let.ml.out
@@ -1,9 +1,7 @@
 exception Return_0 of int
-let rec sum n =
-  try
-    raise (Return_0 (n * (n + 1) / 2))
-  with Return_0 v -> v
 
+let rec sum n = try raise (Return_0 (n * (n + 1) / 2)) with Return_0 v -> v
 let n = 10;;
+
 print_endline (string_of_int (sum n));;
-print_endline (string_of_int (n));;
+print_endline (string_of_int n)

--- a/tests/compiler/valid_ocaml/list_index.ml.out
+++ b/tests/compiler/valid_ocaml/list_index.ml.out
@@ -1,2 +1,3 @@
-let xs = [10; 20; 30];;
-print_endline (string_of_int ((List.nth xs 1)));;
+let xs = [ 10; 20; 30 ];;
+
+print_endline (string_of_int (List.nth xs 1))

--- a/tests/compiler/valid_ocaml/list_set.ml.out
+++ b/tests/compiler/valid_ocaml/list_set.ml.out
@@ -1,10 +1,9 @@
 let rec _set_nth lst i v =
   match lst with
   | [] -> []
-  | x::xs ->
-      if i = 0 then v :: xs else x :: _set_nth xs (i - 1) v
+  | x :: xs -> if i = 0 then v :: xs else x :: _set_nth xs (i - 1) v
 
-let nums = ref [1; 2];;
-nums := _set_nth !nums 1 (3);;
-print_endline (string_of_int ((List.nth !nums 1)));;
+let nums = ref [ 1; 2 ];;
 
+nums := _set_nth !nums 1 3;;
+print_endline (string_of_int (List.nth !nums 1))

--- a/tests/compiler/valid_ocaml/list_slice.ml.out
+++ b/tests/compiler/valid_ocaml/list_slice.ml.out
@@ -1,11 +1,12 @@
 let rec _slice lst i len =
   match lst with
   | [] -> []
-  | x::xs ->
+  | x :: xs ->
       if i > 0 then _slice xs (i - 1) len
       else if len = 0 then []
       else x :: _slice xs 0 (len - 1)
 
-let xs = [1; 2; 3; 4];;
-let sub = (_slice xs 1 (3 - 1));;
-print_endline (string_of_int ((List.nth sub 0)));;
+let xs = [ 1; 2; 3; 4 ]
+let sub = _slice xs 1 (3 - 1);;
+
+print_endline (string_of_int (List.nth sub 0))

--- a/tests/compiler/valid_ocaml/map_len.ml.out
+++ b/tests/compiler/valid_ocaml/map_len.ml.out
@@ -1,2 +1,8 @@
-let m = (let tbl = Hashtbl.create 2 in Hashtbl.add tbl "a" 1;Hashtbl.add tbl "b" 2; tbl);;
-print_endline (string_of_int (Hashtbl.length m));;
+let m =
+  let tbl = Hashtbl.create 2 in
+  Hashtbl.add tbl "a" 1;
+  Hashtbl.add tbl "b" 2;
+  tbl
+;;
+
+print_endline (string_of_int (Hashtbl.length m))

--- a/tests/compiler/valid_ocaml/match_expr.ml.out
+++ b/tests/compiler/valid_ocaml/match_expr.ml.out
@@ -1,3 +1,4 @@
-let x = 2;;
-let res = (match x with 1 -> "one" | 2 -> "two" | _ -> "other");;
-print_endline res;;
+let x = 2
+let res = match x with 1 -> "one" | 2 -> "two" | _ -> "other";;
+
+print_endline res


### PR DESCRIPTION
## Summary
- apply `ocamlformat` after OCaml code generation
- regenerate OCaml golden files with formatted output

## Testing
- `go test -tags=slow ./compile/x/ocaml -run TestOCamlCompiler_GoldenOutput -update -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e22b9a99c83208cba0688114ee24e