### PR TITLE
Improve C backend code formatting

### DIFF
--- a/compile/x/c/README.md
+++ b/compile/x/c/README.md
@@ -6,7 +6,7 @@ The C backend generates portable ANSI C source code from Mochi programs. It is p
 
 - `compiler.go` – main code generator walking the AST
 - `compiler_test.go` – golden tests that compile and run generated code
-- `tools.go` – helper to locate or install a system C compiler
+- `tools.go` – helpers for the system C compiler and clang-format
 
 ## Runtime helpers
 
@@ -53,6 +53,7 @@ cc main.c -o main
 ```
 
 `tools.go` provides `EnsureCC` to locate `cc`, `gcc` or `clang` and attempt installation on Linux or macOS if missing. Set the `CC` environment variable to override the compiler used.【F:compile/c/tools.go†L10-L56】
+`FormatC` prettifies generated code using `clang-format` when available. `EnsureClangFormat` can install the formatter if missing.【F:compile/x/c/tools.go†L78-L132】
 
 ## Tests
 

--- a/compile/x/c/compiler.go
+++ b/compile/x/c/compiler.go
@@ -3,7 +3,6 @@ package ccode
 import (
 	"bytes"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -94,16 +93,6 @@ func (c *Compiler) writeIndent() {
 func (c *Compiler) newTemp() string {
 	c.tmp++
 	return fmt.Sprintf("_t%d", c.tmp)
-}
-
-func formatC(src []byte) []byte {
-	cmd := exec.Command("clang-format", "-style=LLVM")
-	cmd.Stdin = bytes.NewReader(src)
-	out, err := cmd.Output()
-	if err != nil {
-		return src
-	}
-	return out
 }
 
 func (c *Compiler) need(key string) {
@@ -323,7 +312,7 @@ func (c *Compiler) compileProgram(prog *parser.Program) ([]byte, error) {
 		c.writeln("")
 	}
 	c.buf.WriteString(body)
-	return formatC(c.buf.Bytes()), nil
+	return FormatC(c.buf.Bytes()), nil
 }
 
 func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {

--- a/compile/x/c/tools.go
+++ b/compile/x/c/tools.go
@@ -1,6 +1,7 @@
 package ccode
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -73,4 +74,77 @@ func EnsureCC() (string, error) {
 		return path, nil
 	}
 	return "", fmt.Errorf("C compiler not found")
+}
+
+// EnsureClangFormat verifies that clang-format is installed. It attempts a
+// best-effort installation using common package managers.
+func EnsureClangFormat() error {
+	if _, err := exec.LookPath("clang-format"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "clang-format")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "clang-format")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "llvm")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "llvm")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("clang-format"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("clang-format not found")
+}
+
+// FormatC runs clang-format on the given source code if available. If the
+// formatter is missing or fails, the input is returned unchanged.
+func FormatC(src []byte) []byte {
+	path, err := exec.LookPath("clang-format")
+	if err != nil {
+		if len(src) > 0 && src[len(src)-1] != '\n' {
+			src = append(src, '\n')
+		}
+		return src
+	}
+	cmd := exec.Command(path, "-style=LLVM")
+	cmd.Stdin = bytes.NewReader(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		res := out.Bytes()
+		if len(res) == 0 || res[len(res)-1] != '\n' {
+			res = append(res, '\n')
+		}
+		return res
+	}
+	if len(src) > 0 && src[len(src)-1] != '\n' {
+		src = append(src, '\n')
+	}
+	return src
 }


### PR DESCRIPTION
## Summary
- add FormatC and EnsureClangFormat helpers
- use FormatC from the C compiler
- document formatter in the C backend README

## Testing
- `go test ./compile/x/c -run TestCCompiler_GoldenOutput -update -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_685e2ac2bec8832088c405090d02fed7