### PR TITLE
Improve COBOL codegen formatting

### DIFF
--- a/compile/x/cobol/compiler.go
+++ b/compile/x/cobol/compiler.go
@@ -80,7 +80,8 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	for _, fn := range c.funcDecls {
 		c.buf.WriteString(fn)
 	}
-	return c.buf.Bytes(), nil
+	out := c.buf.Bytes()
+	return FormatCOBOL(out), nil
 }
 
 func (c *Compiler) compileNode(n *ast.Node) {

--- a/compile/x/cobol/tools.go
+++ b/compile/x/cobol/tools.go
@@ -1,6 +1,7 @@
 package cobolcode
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -61,4 +62,28 @@ func EnsureCOBOL() error {
 		}
 	}
 	return fmt.Errorf("cobc not installed")
+}
+
+// FormatCOBOL runs a formatter on the given source if available. The
+// `cobfmt` tool is tried first. If no formatter is found or formatting
+// fails, the input is returned unchanged with a trailing newline ensured.
+func FormatCOBOL(src []byte) []byte {
+	path, err := exec.LookPath("cobfmt")
+	if err == nil {
+		cmd := exec.Command(path)
+		cmd.Stdin = bytes.NewReader(src)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err == nil {
+			res := out.Bytes()
+			if len(res) == 0 || res[len(res)-1] != '\n' {
+				res = append(res, '\n')
+			}
+			return res
+		}
+	}
+	if len(src) > 0 && src[len(src)-1] != '\n' {
+		src = append(src, '\n')
+	}
+	return src
 }


### PR DESCRIPTION
## Summary
- add `FormatCOBOL` helper that tries `cobfmt` and falls back to a newline
- run the formatter at the end of `Compile`

## Testing
- `go test ./compile/x/cobol -tags slow -run GoldenSource -v`

------
https://chatgpt.com/codex/tasks/task_e_685e2ace15c88320ac4e30201f09f605