### PR TITLE
Improve Fortran formatting

### DIFF
--- a/compile/x/fortran/format.go
+++ b/compile/x/fortran/format.go
@@ -3,16 +3,24 @@ package ftncode
 import (
 	"bytes"
 	"os/exec"
+	"strings"
 )
 
-// formatCode runs `findent` on the generated Fortran source to improve
-// readability. If findent is not available or fails, the input is returned
-// unchanged along with the error.
+// formatCode formats the generated Fortran source using `fprettify` or
+// `findent`. If neither tool is available or formatting fails, the input is
+// returned unchanged with the encountered error.
 func formatCode(src []byte) ([]byte, error) {
-	if _, err := exec.LookPath("findent"); err != nil {
+	tool, err := EnsureFormatter()
+	if err != nil {
 		return src, err
 	}
-	cmd := exec.Command("findent")
+	args := []string{}
+	if strings.Contains(tool, "fprettify") {
+		args = []string{"--indent", "2"}
+	} else if strings.Contains(tool, "findent") {
+		args = []string{"-i2"}
+	}
+	cmd := exec.Command(tool, args...)
 	cmd.Stdin = bytes.NewReader(src)
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/compile/x/fortran/tools.go
+++ b/compile/x/fortran/tools.go
@@ -66,3 +66,72 @@ func EnsureFortran() (string, error) {
 	}
 	return "", fmt.Errorf("gfortran not found")
 }
+
+// EnsureFormatter verifies that a Fortran formatting tool is installed.
+// It prefers fprettify but falls back to findent. If the tools are not found,
+// it attempts a best-effort installation using the system package manager.
+func EnsureFormatter() (string, error) {
+	if path, err := exec.LookPath("fprettify"); err == nil {
+		return path, nil
+	}
+	if path, err := exec.LookPath("findent"); err == nil {
+		return path, nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			cmd = exec.Command("apt-get", "install", "-y", "findent")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+		if _, err := exec.LookPath("pip"); err == nil {
+			cmd := exec.Command("pip", "install", "fprettify")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "findent")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+		if _, err := exec.LookPath("pip3"); err == nil {
+			cmd := exec.Command("pip3", "install", "fprettify")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "findent")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "findent")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+		if _, err := exec.LookPath("pip"); err == nil {
+			cmd := exec.Command("pip", "install", "fprettify")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if path, err := exec.LookPath("fprettify"); err == nil {
+		return path, nil
+	}
+	if path, err := exec.LookPath("findent"); err == nil {
+		return path, nil
+	}
+	return "", fmt.Errorf("no Fortran formatter found")
+}

--- a/tests/compiler/fortran/arithmetic.f90.out
+++ b/tests/compiler/fortran/arithmetic.f90.out
@@ -1,8 +1,8 @@
 program main
-   implicit none
-   print *, (1_8 + 2_8)
-   print *, (5_8 - 3_8)
-   print *, (4_8 * 2_8)
-   print *, (8_8 / 2_8)
-   print *, mod(7_8, 3_8)
+  implicit none
+  print *, (1_8 + 2_8)
+  print *, (5_8 - 3_8)
+  print *, (4_8*2_8)
+  print *, (8_8/2_8)
+  print *, mod(7_8, 3_8)
 end program main

--- a/tests/compiler/fortran/bool_ops.f90.out
+++ b/tests/compiler/fortran/bool_ops.f90.out
@@ -1,6 +1,6 @@
 program main
-   implicit none
-   print *, (.true. .and. .false.)
-   print *, (.true. .or. .false.)
-   print *, (.not. .false.)
+  implicit none
+  print *, (.true. .and. .false.)
+  print *, (.true. .or. .false.)
+  print *, (.not. .false.)
 end program main

--- a/tests/compiler/fortran/break_continue.f90.out
+++ b/tests/compiler/fortran/break_continue.f90.out
@@ -1,13 +1,13 @@
 program main
-   implicit none
-   integer(kind=8) :: i
-   do i = 0_8, 10_8 - 1
-      if ((mod(i, 2_8) == 0_8)) then
-         cycle
-      end if
-      if ((i > 5_8)) then
-         exit
-      end if
-      print *, i
-   end do
+  implicit none
+  integer(kind=8) :: i
+  do i = 0_8, 10_8 - 1
+    if ((mod(i, 2_8) == 0_8)) then
+      cycle
+    end if
+    if ((i > 5_8)) then
+      exit
+    end if
+    print *, i
+  end do
 end program main

--- a/tests/compiler/fortran/builtin_append.f90.out
+++ b/tests/compiler/fortran/builtin_append.f90.out
@@ -1,7 +1,7 @@
 program main
-   implicit none
-   integer(kind=8), allocatable :: xs(:)
-   allocate(xs(0))
-   xs = (/ (/1_8, 2_8/), 3_8 /)
-   print *, xs(modulo(2_8, size(xs)) + 1)
+  implicit none
+  integer(kind=8), allocatable :: xs(:)
+  allocate (xs(0))
+  xs = (/(/1_8, 2_8/), 3_8/)
+  print *, xs(modulo(2_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/builtin_str.f90.out
+++ b/tests/compiler/fortran/builtin_str.f90.out
@@ -1,27 +1,27 @@
 program main
-   implicit none
-   print *, str_int(42_8)
-   print *, str_float(3.5)
-   print *, 'hi'
+  implicit none
+  print *, str_int(42_8)
+  print *, str_float(3.5)
+  print *, 'hi'
 contains
 
-   function str_int(v) result(r)
-      implicit none
-      integer(kind=8), intent(in) :: v
-      character(:), allocatable :: r
-      character(len=32) :: buf
-      write(buf,'(I0)') v
-      allocate(character(len=len_trim(buf)) :: r)
-      r = trim(buf)
-   end function str_int
+  function str_int(v) result(r)
+    implicit none
+    integer(kind=8), intent(in) :: v
+    character(:), allocatable :: r
+    character(len=32) :: buf
+    write (buf, '(I0)') v
+    allocate (character(len=len_trim(buf)) :: r)
+    r = trim(buf)
+  end function str_int
 
-   function str_float(v) result(r)
-      implicit none
-      real, intent(in) :: v
-      character(:), allocatable :: r
-      character(len=64) :: buf
-      write(buf,'(G0)') v
-      allocate(character(len=len_trim(buf)) :: r)
-      r = trim(buf)
-   end function str_float
+  function str_float(v) result(r)
+    implicit none
+    real, intent(in) :: v
+    character(:), allocatable :: r
+    character(len=64) :: buf
+    write (buf, '(G0)') v
+    allocate (character(len=len_trim(buf)) :: r)
+    r = trim(buf)
+  end function str_float
 end program main

--- a/tests/compiler/fortran/dataset_sort_take_limit.f90.out
+++ b/tests/compiler/fortran/dataset_sort_take_limit.f90.out
@@ -1,64 +1,64 @@
 program main
-   implicit none
-   type :: Product
-      character(:), allocatable :: name
-      integer(kind=8) :: price
-   end type Product
-   integer(kind=8), allocatable :: products(:)
-   integer(kind=8) :: expensive
-   integer(kind=8) :: item
-   integer(kind=8) :: i_item
-   allocate(products(0))
-   products = (/Product(name='Laptop', price=1500_8), Product(name='Smartphone', price=900_8), Product(name='Tablet', price=600_8), Product(name='Monitor', price=300_8), Product(name='Keyboard', price=100_8), Product(name='Mouse', price=50_8), Product(name='Headphones', price=200_8)/)
-   expensive = lambda_0(products)(1_8 + 1:1_8 + 3_8)
-   print *, '--- Top products (excluding most expensive) ---'
-   do i_item = 0, size(expensive) - 1
-      item = expensive(modulo(i_item, size(expensive)) + 1)
-      print *, item%name, 'costs $', item%price
-   end do
+  implicit none
+  type :: Product
+    character(:), allocatable :: name
+    integer(kind=8) :: price
+  end type Product
+  integer(kind=8), allocatable :: products(:)
+  integer(kind=8) :: expensive
+  integer(kind=8) :: item
+  integer(kind=8) :: i_item
+  allocate (products(0))
+  products = (/Product(name='Laptop', price=1500_8), Product(name='Smartphone', price=900_8), Product(name='Tablet', price=600_8), Product(name='Monitor', price=300_8), Product(name='Keyboard', price=100_8), Product(name='Mouse', price=50_8), Product(name='Headphones', price=200_8)/)
+  expensive = lambda_0(products) (1_8 + 1:1_8 + 3_8)
+  print *, '--- Top products (excluding most expensive) ---'
+  do i_item = 0, size(expensive) - 1
+    item = expensive(modulo(i_item, size(expensive)) + 1)
+    print *, item%name, 'costs $', item%price
+  end do
 contains
-   function lambda_0(vsrc) result(res)
-      implicit none
-      integer(kind=8), intent(in) :: vsrc(:)
-      integer(kind=8), allocatable :: res(:)
-      integer(kind=8), allocatable :: tmp(:)
-      integer(kind=8), allocatable :: tmpKey(:)
-      integer(kind=8) :: p
-      integer(kind=8) :: n
-      integer(kind=8) :: i
-      integer(kind=8) :: j
-      integer(kind=8) :: min_idx
-      integer(kind=8) :: sort_key
-      integer(kind=8) :: swap_key
-      integer(kind=8) :: swap_item
-      allocate(tmp(size(vsrc)))
-      allocate(tmpKey(size(vsrc)))
-      n = 0
-      do i = 1, size(vsrc)
-         p = vsrc(i)
-         sort_key = (-p%price)
-         n = n + 1
-         tmp(n) = p
-         tmpKey(n) = sort_key
+  function lambda_0(vsrc) result(res)
+    implicit none
+    integer(kind=8), intent(in) :: vsrc(:)
+    integer(kind=8), allocatable :: res(:)
+    integer(kind=8), allocatable :: tmp(:)
+    integer(kind=8), allocatable :: tmpKey(:)
+    integer(kind=8) :: p
+    integer(kind=8) :: n
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: min_idx
+    integer(kind=8) :: sort_key
+    integer(kind=8) :: swap_key
+    integer(kind=8) :: swap_item
+    allocate (tmp(size(vsrc)))
+    allocate (tmpKey(size(vsrc)))
+    n = 0
+    do i = 1, size(vsrc)
+      p = vsrc(i)
+      sort_key = (-p%price)
+      n = n + 1
+      tmp(n) = p
+      tmpKey(n) = sort_key
+    end do
+    do i = 1, n - 1
+      min_idx = i
+      do j = i + 1, n
+        if (tmpKey(j) < tmpKey(min_idx)) then
+          min_idx = j
+        end if
       end do
-      do i = 1, n - 1
-         min_idx = i
-         do j = i + 1, n
-            if (tmpKey(j) < tmpKey(min_idx)) then
-               min_idx = j
-            end if
-         end do
-         if (min_idx /= i) then
-            swap_key = tmpKey(i)
-            tmpKey(i) = tmpKey(min_idx)
-            tmpKey(min_idx) = swap_key
-            swap_item = tmp(i)
-            tmp(i) = tmp(min_idx)
-            tmp(min_idx) = swap_item
-         end if
-      end do
-      allocate(res(n))
-      res = tmp(:n)
-   end function lambda_0
+      if (min_idx /= i) then
+        swap_key = tmpKey(i)
+        tmpKey(i) = tmpKey(min_idx)
+        tmpKey(min_idx) = swap_key
+        swap_item = tmp(i)
+        tmp(i) = tmp(min_idx)
+        tmp(min_idx) = swap_item
+      end if
+    end do
+    allocate (res(n))
+    res = tmp(:n)
+  end function lambda_0
 
 end program main

--- a/tests/compiler/fortran/dataset_sort_where.f90.out
+++ b/tests/compiler/fortran/dataset_sort_where.f90.out
@@ -1,65 +1,65 @@
 program main
-   implicit none
-   type :: Item
-      character(:), allocatable :: name
-      integer(kind=8) :: price
-   end type Item
-   integer(kind=8), allocatable :: items(:)
-   integer(kind=8) :: cheap
-   integer(kind=8) :: c
-   integer(kind=8) :: i_c
-   allocate(items(0))
-   items = (/Item(name='A', price=100_8), Item(name='B', price=50_8), Item(name='C', price=200_8), Item(name='D', price=80_8)/)
-   cheap = lambda_0(items)
-   do i_c = 0, size(cheap) - 1
-      c = cheap(modulo(i_c, size(cheap)) + 1)
-      print *, c%name, c%price
-   end do
+  implicit none
+  type :: Item
+    character(:), allocatable :: name
+    integer(kind=8) :: price
+  end type Item
+  integer(kind=8), allocatable :: items(:)
+  integer(kind=8) :: cheap
+  integer(kind=8) :: c
+  integer(kind=8) :: i_c
+  allocate (items(0))
+  items = (/Item(name='A', price=100_8), Item(name='B', price=50_8), Item(name='C', price=200_8), Item(name='D', price=80_8)/)
+  cheap = lambda_0(items)
+  do i_c = 0, size(cheap) - 1
+    c = cheap(modulo(i_c, size(cheap)) + 1)
+    print *, c%name, c%price
+  end do
 contains
-   function lambda_0(vsrc) result(res)
-      implicit none
-      integer(kind=8), intent(in) :: vsrc(:)
-      integer(kind=8), allocatable :: res(:)
-      integer(kind=8), allocatable :: tmp(:)
-      integer(kind=8), allocatable :: tmpKey(:)
-      integer(kind=8) :: it
-      integer(kind=8) :: n
-      integer(kind=8) :: i
-      integer(kind=8) :: j
-      integer(kind=8) :: min_idx
-      integer(kind=8) :: sort_key
-      integer(kind=8) :: swap_key
-      integer(kind=8) :: swap_item
-      allocate(tmp(size(vsrc)))
-      allocate(tmpKey(size(vsrc)))
-      n = 0
-      do i = 1, size(vsrc)
-         it = vsrc(i)
-         if ((it%price < 150_8)) then
-            sort_key = it%price
-            n = n + 1
-            tmp(n) = it
-            tmpKey(n) = sort_key
-         end if
+  function lambda_0(vsrc) result(res)
+    implicit none
+    integer(kind=8), intent(in) :: vsrc(:)
+    integer(kind=8), allocatable :: res(:)
+    integer(kind=8), allocatable :: tmp(:)
+    integer(kind=8), allocatable :: tmpKey(:)
+    integer(kind=8) :: it
+    integer(kind=8) :: n
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: min_idx
+    integer(kind=8) :: sort_key
+    integer(kind=8) :: swap_key
+    integer(kind=8) :: swap_item
+    allocate (tmp(size(vsrc)))
+    allocate (tmpKey(size(vsrc)))
+    n = 0
+    do i = 1, size(vsrc)
+      it = vsrc(i)
+      if ((it%price < 150_8)) then
+        sort_key = it%price
+        n = n + 1
+        tmp(n) = it
+        tmpKey(n) = sort_key
+      end if
+    end do
+    do i = 1, n - 1
+      min_idx = i
+      do j = i + 1, n
+        if (tmpKey(j) < tmpKey(min_idx)) then
+          min_idx = j
+        end if
       end do
-      do i = 1, n - 1
-         min_idx = i
-         do j = i + 1, n
-            if (tmpKey(j) < tmpKey(min_idx)) then
-               min_idx = j
-            end if
-         end do
-         if (min_idx /= i) then
-            swap_key = tmpKey(i)
-            tmpKey(i) = tmpKey(min_idx)
-            tmpKey(min_idx) = swap_key
-            swap_item = tmp(i)
-            tmp(i) = tmp(min_idx)
-            tmp(min_idx) = swap_item
-         end if
-      end do
-      allocate(res(n))
-      res = tmp(:n)
-   end function lambda_0
+      if (min_idx /= i) then
+        swap_key = tmpKey(i)
+        tmpKey(i) = tmpKey(min_idx)
+        tmpKey(min_idx) = swap_key
+        swap_item = tmp(i)
+        tmp(i) = tmp(min_idx)
+        tmp(min_idx) = swap_item
+      end if
+    end do
+    allocate (res(n))
+    res = tmp(:n)
+  end function lambda_0
 
 end program main

--- a/tests/compiler/fortran/fetch_builtin.f90.out
+++ b/tests/compiler/fortran/fetch_builtin.f90.out
@@ -1,25 +1,25 @@
 program main
-   implicit none
-   type :: Msg
-      character(:), allocatable :: message
-   end type Msg
-   character(:), allocatable :: v__
-   v__ = mochi_fetch('file://tests/compiler/fortran/fetch_builtin.json')
+  implicit none
+  type :: Msg
+    character(:), allocatable :: message
+  end type Msg
+  character(:), allocatable :: v__
+  v__ = mochi_fetch('file://tests/compiler/fortran/fetch_builtin.json')
 contains
 
-   function mochi_fetch(url) result(r)
-      implicit none
-      character(len=*), intent(in) :: url
-      character(len=:), allocatable :: r
-      character(len=1024) :: cmd
-      integer :: u, n
-      cmd = 'curl -s -o mochi_fetch.tmp ' // trim(url)
-      call execute_command_line(cmd)
-      open(newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
-      inquire(u, size=n)
-      allocate(character(len=n) :: r)
-      read(u) r
-      close(u)
-      call execute_command_line('rm -f mochi_fetch.tmp')
-   end function mochi_fetch
+  function mochi_fetch(url) result(r)
+    implicit none
+    character(len=*), intent(in) :: url
+    character(len=:), allocatable :: r
+    character(len=1024) :: cmd
+    integer :: u, n
+    cmd = 'curl -s -o mochi_fetch.tmp '//trim(url)
+    call execute_command_line(cmd)
+    open (newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
+    inquire (u, size=n)
+    allocate (character(len=n) :: r)
+    read (u) r
+    close (u)
+    call execute_command_line('rm -f mochi_fetch.tmp')
+  end function mochi_fetch
 end program main

--- a/tests/compiler/fortran/fetch_http.f90.out
+++ b/tests/compiler/fortran/fetch_http.f90.out
@@ -1,23 +1,23 @@
 program main
-   implicit none
-   character(:), allocatable :: body
-   body = mochi_fetch('https://jsonplaceholder.typicode.com/todos/1')
-   print *, (len(body) > 0_8)
+  implicit none
+  character(:), allocatable :: body
+  body = mochi_fetch('https://jsonplaceholder.typicode.com/todos/1')
+  print *, (len(body) > 0_8)
 contains
 
-   function mochi_fetch(url) result(r)
-      implicit none
-      character(len=*), intent(in) :: url
-      character(len=:), allocatable :: r
-      character(len=1024) :: cmd
-      integer :: u, n
-      cmd = 'curl -s -o mochi_fetch.tmp ' // trim(url)
-      call execute_command_line(cmd)
-      open(newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
-      inquire(u, size=n)
-      allocate(character(len=n) :: r)
-      read(u) r
-      close(u)
-      call execute_command_line('rm -f mochi_fetch.tmp')
-   end function mochi_fetch
+  function mochi_fetch(url) result(r)
+    implicit none
+    character(len=*), intent(in) :: url
+    character(len=:), allocatable :: r
+    character(len=1024) :: cmd
+    integer :: u, n
+    cmd = 'curl -s -o mochi_fetch.tmp '//trim(url)
+    call execute_command_line(cmd)
+    open (newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
+    inquire (u, size=n)
+    allocate (character(len=n) :: r)
+    read (u) r
+    close (u)
+    call execute_command_line('rm -f mochi_fetch.tmp')
+  end function mochi_fetch
 end program main

--- a/tests/compiler/fortran/float_ops.f90.out
+++ b/tests/compiler/fortran/float_ops.f90.out
@@ -1,11 +1,11 @@
 program main
-   implicit none
-   real :: x
-   real :: y
-   x = 1.5
-   y = 2.5
-   print *, (x + y)
-   print *, (y - x)
-   print *, (x * y)
-   print *, (y / x)
+  implicit none
+  real :: x
+  real :: y
+  x = 1.5
+  y = 2.5
+  print *, (x + y)
+  print *, (y - x)
+  print *, (x*y)
+  print *, (y/x)
 end program main

--- a/tests/compiler/fortran/for_loop.f90.out
+++ b/tests/compiler/fortran/for_loop.f90.out
@@ -1,7 +1,7 @@
 program main
-   implicit none
-   integer(kind=8) :: i
-   do i = 1_8, 4_8 - 1
-      print *, i
-   end do
+  implicit none
+  integer(kind=8) :: i
+  do i = 1_8, 4_8 - 1
+    print *, i
+  end do
 end program main

--- a/tests/compiler/fortran/fun_expr.f90.out
+++ b/tests/compiler/fortran/fun_expr.f90.out
@@ -1,14 +1,14 @@
 program main
-   implicit none
-   print *, (lambda_0)(2_8, 3_8)
+  implicit none
+  print *, (lambda_0) (2_8, 3_8)
 contains
-   function lambda_0(a, b) result(res)
-      implicit none
-      integer(kind=8) :: res
-      integer(kind=8), intent(in) :: a
-      integer(kind=8), intent(in) :: b
-      res = (a + b)
-      return
-   end function lambda_0
+  function lambda_0(a, b) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: a
+    integer(kind=8), intent(in) :: b
+    res = (a + b)
+    return
+  end function lambda_0
 
 end program main

--- a/tests/compiler/fortran/if_else.f90.out
+++ b/tests/compiler/fortran/if_else.f90.out
@@ -1,23 +1,23 @@
 program main
-   implicit none
-   print *, foo((-2_8))
-   print *, foo(0_8)
-   print *, foo(3_8)
+  implicit none
+  print *, foo((-2_8))
+  print *, foo(0_8)
+  print *, foo(3_8)
 contains
-   function foo(n) result(res)
-      implicit none
-      integer(kind=8) :: res
-      integer(kind=8), intent(in) :: n
-      if ((n < 0_8)) then
-         res = (-1_8)
-         return
-      else if ((n == 0_8)) then
-         res = 0_8
-         return
-      else
-         res = 1_8
-         return
-      end if
-   end function foo
+  function foo(n) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: n
+    if ((n < 0_8)) then
+      res = (-1_8)
+      return
+    else if ((n == 0_8)) then
+      res = 0_8
+      return
+    else
+      res = 1_8
+      return
+    end if
+  end function foo
 
 end program main

--- a/tests/compiler/fortran/import_stmt.f90.out
+++ b/tests/compiler/fortran/import_stmt.f90.out
@@ -1,5 +1,5 @@
 program main
-   implicit none
-   include 'mylib.f90'
-   print *, 42_8
+  implicit none
+  include 'mylib.f90'
+  print *, 42_8
 end program main

--- a/tests/compiler/fortran/list_append.f90.out
+++ b/tests/compiler/fortran/list_append.f90.out
@@ -1,8 +1,8 @@
 program main
-   implicit none
-   integer(kind=8), allocatable :: xs(:)
-   allocate(xs(0))
-   xs = (/1_8, 2_8/)
-   xs = (/ xs, (/3_8/) /)
-   print *, xs(modulo(2_8, size(xs)) + 1)
+  implicit none
+  integer(kind=8), allocatable :: xs(:)
+  allocate (xs(0))
+  xs = (/1_8, 2_8/)
+  xs = (/xs, (/3_8/)/)
+  print *, xs(modulo(2_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/list_concat.f90.out
+++ b/tests/compiler/fortran/list_concat.f90.out
@@ -1,4 +1,4 @@
 program main
-   implicit none
-   print *, (/ (/1_8, 2_8/), (/3_8, 4_8/) /)
+  implicit none
+  print *, (/(/1_8, 2_8/), (/3_8, 4_8/)/)
 end program main

--- a/tests/compiler/fortran/list_index.f90.out
+++ b/tests/compiler/fortran/list_index.f90.out
@@ -1,7 +1,7 @@
 program main
-   implicit none
-   integer(kind=8), allocatable :: xs(:)
-   allocate(xs(0))
-   xs = (/10_8, 20_8, 30_8/)
-   print *, xs(modulo(1_8, size(xs)) + 1)
+  implicit none
+  integer(kind=8), allocatable :: xs(:)
+  allocate (xs(0))
+  xs = (/10_8, 20_8, 30_8/)
+  print *, xs(modulo(1_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/list_slice.f90.out
+++ b/tests/compiler/fortran/list_slice.f90.out
@@ -1,7 +1,7 @@
 program main
-   implicit none
-   integer(kind=8), allocatable :: xs(:)
-   allocate(xs(0))
-   xs = (/1_8, 2_8, 3_8, 4_8/)
-   print *, xs(modulo(1_8, size(xs)) + 1:modulo(3_8, size(xs)))
+  implicit none
+  integer(kind=8), allocatable :: xs(:)
+  allocate (xs(0))
+  xs = (/1_8, 2_8, 3_8, 4_8/)
+  print *, xs(modulo(1_8, size(xs)) + 1:modulo(3_8, size(xs)))
 end program main

--- a/tests/compiler/fortran/list_union_all.f90.out
+++ b/tests/compiler/fortran/list_union_all.f90.out
@@ -1,4 +1,4 @@
 program main
-   implicit none
-   print *, (/ (/1_8, 2_8/), (/2_8, 3_8/) /)
+  implicit none
+  print *, (/(/1_8, 2_8/), (/2_8, 3_8/)/)
 end program main

--- a/tests/compiler/fortran/load_save_json.f90.out
+++ b/tests/compiler/fortran/load_save_json.f90.out
@@ -1,11 +1,11 @@
 program main
-   implicit none
-   type :: Person
-      character(:), allocatable :: name
-      integer(kind=8) :: age
-   end type Person
-   type(Person), allocatable :: people(:)
-   allocate(people(0))
-   people = load_json_Person('')
-   call save_json_Person(people, '')
+  implicit none
+  type :: Person
+    character(:), allocatable :: name
+    integer(kind=8) :: age
+  end type Person
+  type(Person), allocatable :: people(:)
+  allocate (people(0))
+  people = load_json_Person('')
+  call save_json_Person(people, '')
 end program main

--- a/tests/compiler/fortran/multi_functions.f90.out
+++ b/tests/compiler/fortran/multi_functions.f90.out
@@ -1,34 +1,34 @@
 program main
-   implicit none
-   print *, add(1_8, 2_8)
-   print *, sub(10_8, 3_8)
-   print *, mul(4_8, 6_8)
+  implicit none
+  print *, add(1_8, 2_8)
+  print *, sub(10_8, 3_8)
+  print *, mul(4_8, 6_8)
 contains
-   function add(x, y) result(res)
-      implicit none
-      integer(kind=8) :: res
-      integer(kind=8), intent(in) :: x
-      integer(kind=8), intent(in) :: y
-      res = (x + y)
-      return
-   end function add
+  function add(x, y) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: x
+    integer(kind=8), intent(in) :: y
+    res = (x + y)
+    return
+  end function add
 
-   function sub(x, y) result(res)
-      implicit none
-      integer(kind=8) :: res
-      integer(kind=8), intent(in) :: x
-      integer(kind=8), intent(in) :: y
-      res = (x - y)
-      return
-   end function sub
+  function sub(x, y) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: x
+    integer(kind=8), intent(in) :: y
+    res = (x - y)
+    return
+  end function sub
 
-   function mul(x, y) result(res)
-      implicit none
-      integer(kind=8) :: res
-      integer(kind=8), intent(in) :: x
-      integer(kind=8), intent(in) :: y
-      res = (x * y)
-      return
-   end function mul
+  function mul(x, y) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: x
+    integer(kind=8), intent(in) :: y
+    res = (x*y)
+    return
+  end function mul
 
 end program main

--- a/tests/compiler/fortran/query_basic.f90.out
+++ b/tests/compiler/fortran/query_basic.f90.out
@@ -1,36 +1,36 @@
 program main
-   implicit none
-   integer(kind=8), allocatable :: xs(:)
-   integer(kind=8) :: ys
-   integer(kind=8) :: v
-   integer(kind=8) :: i_v
-   allocate(xs(0))
-   xs = (/1_8, 10_8, 20_8, 5_8/)
-   ys = lambda_0(xs)
-   do i_v = 0, size(ys) - 1
-      v = ys(modulo(i_v, size(ys)) + 1)
-      print *, v
-   end do
+  implicit none
+  integer(kind=8), allocatable :: xs(:)
+  integer(kind=8) :: ys
+  integer(kind=8) :: v
+  integer(kind=8) :: i_v
+  allocate (xs(0))
+  xs = (/1_8, 10_8, 20_8, 5_8/)
+  ys = lambda_0(xs)
+  do i_v = 0, size(ys) - 1
+    v = ys(modulo(i_v, size(ys)) + 1)
+    print *, v
+  end do
 contains
-   function lambda_0(vsrc) result(res)
-      implicit none
-      integer(kind=8), intent(in) :: vsrc(:)
-      integer(kind=8), allocatable :: res(:)
-      integer(kind=8), allocatable :: tmp(:)
-      integer(kind=8) :: x
-      integer(kind=8) :: n
-      integer(kind=8) :: i
-      allocate(tmp(size(vsrc)))
-      n = 0
-      do i = 1, size(vsrc)
-         x = vsrc(i)
-         if ((x > 9_8)) then
-            n = n + 1
-            tmp(n) = (x + 1_8)
-         end if
-      end do
-      allocate(res(n))
-      res = tmp(:n)
-   end function lambda_0
+  function lambda_0(vsrc) result(res)
+    implicit none
+    integer(kind=8), intent(in) :: vsrc(:)
+    integer(kind=8), allocatable :: res(:)
+    integer(kind=8), allocatable :: tmp(:)
+    integer(kind=8) :: x
+    integer(kind=8) :: n
+    integer(kind=8) :: i
+    allocate (tmp(size(vsrc)))
+    n = 0
+    do i = 1, size(vsrc)
+      x = vsrc(i)
+      if ((x > 9_8)) then
+        n = n + 1
+        tmp(n) = (x + 1_8)
+      end if
+    end do
+    allocate (res(n))
+    res = tmp(:n)
+  end function lambda_0
 
 end program main

--- a/tests/compiler/fortran/simple_fn.f90.out
+++ b/tests/compiler/fortran/simple_fn.f90.out
@@ -1,13 +1,13 @@
 program main
-   implicit none
-   print *, id(123_8)
+  implicit none
+  print *, id(123_8)
 contains
-   function id(x) result(res)
-      implicit none
-      integer(kind=8) :: res
-      integer(kind=8), intent(in) :: x
-      res = x
-      return
-   end function id
+  function id(x) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: x
+    res = x
+    return
+  end function id
 
 end program main

--- a/tests/compiler/fortran/string_cmp.f90.out
+++ b/tests/compiler/fortran/string_cmp.f90.out
@@ -1,9 +1,9 @@
 program main
-   implicit none
-   print *, ('a' < 'b')
-   print *, ('a' <= 'a')
-   print *, ('cat' > 'car')
-   print *, ('dog' >= 'dog')
-   print *, ('abc' == 'abc')
-   print *, ('foo' /= 'bar')
+  implicit none
+  print *, ('a' < 'b')
+  print *, ('a' <= 'a')
+  print *, ('cat' > 'car')
+  print *, ('dog' >= 'dog')
+  print *, ('abc' == 'abc')
+  print *, ('foo' /= 'bar')
 end program main

--- a/tests/compiler/fortran/string_concat.f90.out
+++ b/tests/compiler/fortran/string_concat.f90.out
@@ -1,4 +1,4 @@
 program main
-   implicit none
-   print *, (trim('hello ') // trim('world'))
+  implicit none
+  print *, (trim('hello ')//trim('world'))
 end program main

--- a/tests/compiler/fortran/string_for_loop.f90.out
+++ b/tests/compiler/fortran/string_for_loop.f90.out
@@ -1,9 +1,9 @@
 program main
-   implicit none
-   character(:), allocatable :: ch
-   integer(kind=8) :: i_ch
-   do i_ch = 0, len('cat') - 1
-      ch = 'cat'(modulo(i_ch, len('cat')) + 1:modulo(i_ch, len('cat')) + 1)
-      print *, ch
-   end do
+  implicit none
+  character(:), allocatable :: ch
+  integer(kind=8) :: i_ch
+  do i_ch = 0, len('cat') - 1
+    ch = 'cat' (modulo(i_ch, len('cat')) + 1:modulo(i_ch, len('cat')) + 1)
+    print *, ch
+  end do
 end program main

--- a/tests/compiler/fortran/string_in.f90.out
+++ b/tests/compiler/fortran/string_in.f90.out
@@ -1,5 +1,5 @@
 program main
-   implicit none
-   print *, index('catch', 'cat') > 0
-   print *, index('catch', 'dog') > 0
+  implicit none
+  print *, index('catch', 'cat') > 0
+  print *, index('catch', 'dog') > 0
 end program main

--- a/tests/compiler/fortran/string_index.f90.out
+++ b/tests/compiler/fortran/string_index.f90.out
@@ -1,6 +1,6 @@
 program main
-   implicit none
-   character(:), allocatable :: text
-   text = 'hello'
-   print *, text(modulo(1_8, len(text)) + 1:modulo(1_8, len(text)) + 1)
+  implicit none
+  character(:), allocatable :: text
+  text = 'hello'
+  print *, text(modulo(1_8, len(text)) + 1:modulo(1_8, len(text)) + 1)
 end program main

--- a/tests/compiler/fortran/string_len.f90.out
+++ b/tests/compiler/fortran/string_len.f90.out
@@ -1,4 +1,4 @@
 program main
-   implicit none
-   print *, len('hello')
+  implicit none
+  print *, len('hello')
 end program main

--- a/tests/compiler/fortran/string_literal.f90.out
+++ b/tests/compiler/fortran/string_literal.f90.out
@@ -1,4 +1,4 @@
 program main
-   implicit none
-   print *, 'hello'
+  implicit none
+  print *, 'hello'
 end program main

--- a/tests/compiler/fortran/string_negative_index.f90.out
+++ b/tests/compiler/fortran/string_negative_index.f90.out
@@ -1,6 +1,6 @@
 program main
-   implicit none
-   character(:), allocatable :: text
-   text = 'hello'
-   print *, text(modulo((-1_8), len(text)) + 1:modulo((-1_8), len(text)) + 1)
+  implicit none
+  character(:), allocatable :: text
+  text = 'hello'
+  print *, text(modulo((-1_8), len(text)) + 1:modulo((-1_8), len(text)) + 1)
 end program main

--- a/tests/compiler/fortran/string_slice.f90.out
+++ b/tests/compiler/fortran/string_slice.f90.out
@@ -1,6 +1,6 @@
 program main
-   implicit none
-   character(:), allocatable :: text
-   text = 'hello'
-   print *, text(modulo(1_8, len(text)) + 1:modulo(4_8, len(text)))
+  implicit none
+  character(:), allocatable :: text
+  text = 'hello'
+  print *, text(modulo(1_8, len(text)) + 1:modulo(4_8, len(text)))
 end program main

--- a/tests/compiler/fortran/struct_literal.f90.out
+++ b/tests/compiler/fortran/struct_literal.f90.out
@@ -1,10 +1,10 @@
 program main
-   implicit none
-   type :: Point
-      integer(kind=8) :: x
-      integer(kind=8) :: y
-   end type Point
-   type(Point) :: p
-   p = Point(x=1_8, y=2_8)
-   print *, p%x
+  implicit none
+  type :: Point
+    integer(kind=8) :: x
+    integer(kind=8) :: y
+  end type Point
+  type(Point) :: p
+  p = Point(x=1_8, y=2_8)
+  print *, p%x
 end program main

--- a/tests/compiler/fortran/struct_nested.f90.out
+++ b/tests/compiler/fortran/struct_nested.f90.out
@@ -1,18 +1,18 @@
 program main
-   implicit none
-   type :: Point
-      integer(kind=8) :: x
-      integer(kind=8) :: y
-   end type Point
-   type :: Line
-      type(Point) :: start
-      type(Point) :: end
-   end type Line
-   type(Line) :: line
-   type(Point) :: p1
-   type(Point) :: p2
-   p1 = Point(x=0_8, y=0_8)
-   p2 = Point(x=1_8, y=1_8)
-   line = Line(start=p1, end=p2)
-   print *, line%start%x
+  implicit none
+  type :: Point
+    integer(kind=8) :: x
+    integer(kind=8) :: y
+  end type Point
+  type :: Line
+    type(Point) :: start
+    type(Point) :: end
+  end type Line
+  type(Line) :: line
+  type(Point) :: p1
+  type(Point) :: p2
+  p1 = Point(x=0_8, y=0_8)
+  p2 = Point(x=1_8, y=1_8)
+  line = Line(start=p1, end=p2)
+  print *, line%start%x
 end program main

--- a/tests/compiler/fortran/two_sum.f90.out
+++ b/tests/compiler/fortran/two_sum.f90.out
@@ -1,29 +1,29 @@
 program main
-   implicit none
-   integer(kind=8) :: result(2)
-   result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
-   print *, result(0_8 + 1)
-   print *, result(1_8 + 1)
+  implicit none
+  integer(kind=8) :: result(2)
+  result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
+  print *, result(0_8 + 1)
+  print *, result(1_8 + 1)
 contains
-   function twoSum(nums, target) result(res)
-      implicit none
-      integer(kind=8), intent(in) :: nums(:)
-      integer(kind=8), intent(in) :: target
-      integer(kind=8) :: n
-      integer(kind=8) :: i
-      integer(kind=8) :: j
-      integer(kind=8) :: res(2)
-      n = size(nums)
-      do i = 0_8, n - 1
-         do j = (i + 1_8), n - 1
-            if (((nums(i + 1) + nums(j + 1)) == target)) then
-               res = (/i, j/)
-               return
-            end if
-         end do
+  function twoSum(nums, target) result(res)
+    implicit none
+    integer(kind=8), intent(in) :: nums(:)
+    integer(kind=8), intent(in) :: target
+    integer(kind=8) :: n
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: res(2)
+    n = size(nums)
+    do i = 0_8, n - 1
+      do j = (i + 1_8), n - 1
+        if (((nums(i + 1) + nums(j + 1)) == target)) then
+          res = (/i, j/)
+          return
+        end if
       end do
-      res = (/(-1_8), (-1_8)/)
-      return
-   end function twoSum
+    end do
+    res = (/(-1_8), (-1_8)/)
+    return
+  end function twoSum
 
 end program main

--- a/tests/compiler/fortran/typed_list_float.f90.out
+++ b/tests/compiler/fortran/typed_list_float.f90.out
@@ -1,7 +1,7 @@
 program main
-   implicit none
-   real, allocatable :: xs(:)
-   allocate(xs(0))
-   xs = (/1.5, 2.5/)
-   print *, xs(modulo(0_8, size(xs)) + 1)
+  implicit none
+  real, allocatable :: xs(:)
+  allocate (xs(0))
+  xs = (/1.5, 2.5/)
+  print *, xs(modulo(0_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/typed_list_negative.f90.out
+++ b/tests/compiler/fortran/typed_list_negative.f90.out
@@ -1,17 +1,17 @@
 program main
-   implicit none
-   integer(kind=8), allocatable :: xs(:)
-   allocate(xs(0))
-   xs = (/((-1_8)), 0_8, 1_8/)
-   call test_values()
+  implicit none
+  integer(kind=8), allocatable :: xs(:)
+  allocate (xs(0))
+  xs = (/((-1_8)), 0_8, 1_8/)
+  call test_values()
 contains
-   subroutine test_values()
-      implicit none
-      if (.not. (all(xs == (/((-1_8)), 0_8, 1_8/)))) then
-         print *, 'expect failed'
-         stop 1
-      end if
-      print *, 'done'
-   end subroutine test_values
+  subroutine test_values()
+    implicit none
+    if (.not. (all(xs == (/((-1_8)), 0_8, 1_8/)))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+    print *, 'done'
+  end subroutine test_values
 
 end program main

--- a/tests/compiler/fortran/typed_list_param.f90.out
+++ b/tests/compiler/fortran/typed_list_param.f90.out
@@ -1,13 +1,13 @@
 program main
-   implicit none
-   print *, first((/'hello', 'world'/))
+  implicit none
+  print *, first((/'hello', 'world'/))
 contains
-   function first(xs) result(res)
-      implicit none
-      character(:), allocatable :: res
-      character(len=*), intent(in) :: xs(:)
-      res = xs(modulo(0_8, len(xs)) + 1:modulo(0_8, len(xs)) + 1)
-      return
-   end function first
+  function first(xs) result(res)
+    implicit none
+    character(:), allocatable :: res
+    character(len=*), intent(in) :: xs(:)
+    res = xs(modulo(0_8, len(xs)) + 1:modulo(0_8, len(xs)) + 1)
+    return
+  end function first
 
 end program main

--- a/tests/compiler/fortran/var_assignment.f90.out
+++ b/tests/compiler/fortran/var_assignment.f90.out
@@ -1,7 +1,7 @@
 program main
-   implicit none
-   integer(kind=8) :: x
-   x = 1_8
-   x = 2_8
-   print *, x
+  implicit none
+  integer(kind=8) :: x
+  x = 1_8
+  x = 2_8
+  print *, x
 end program main

--- a/tests/compiler/fortran/while_loop.f90.out
+++ b/tests/compiler/fortran/while_loop.f90.out
@@ -1,9 +1,9 @@
 program main
-   implicit none
-   integer(kind=8) :: i
-   i = 0_8
-   do while ((i < 3_8))
-      print *, i
-      i = (i + 1_8)
-   end do
+  implicit none
+  integer(kind=8) :: i
+  i = 0_8
+  do while ((i < 3_8))
+    print *, i
+    i = (i + 1_8)
+  end do
 end program main


### PR DESCRIPTION
## Summary
- support fprettify/findent for formatting Fortran output
- add EnsureFormatter helper
- regenerate Fortran golden files with 2‑space indent

## Testing
- `go test -tags slow ./compile/x/fortran -run TestFortranCompiler_GoldenOutput -update`
- `go test ./...` *(fails: TestLuaCompiler_TPCHQ1 in compile/x/lua)*

------
https://chatgpt.com/codex/tasks/task_e_685e2ad7b3448320ad444e9beba9c10c