### PR TITLE
Improve F# output formatting

### DIFF
--- a/compile/x/fs/compiler.go
+++ b/compile/x/fs/compiler.go
@@ -186,7 +186,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		out = append(out, '\n')
 	}
 	out = append(out, c.buf.Bytes()...)
-	return out, nil
+	return FormatFS(out), nil
 }
 
 func (c *Compiler) compileFunStmt(fn *parser.FunStmt) error {


### PR DESCRIPTION
## Summary
- install Fantomas automatically
- add FormatFS helper and use it in the compiler

## Testing
- `go vet ./...`
- `go test ./...` *(fails: TestLuaCompiler_TPCHQ1)*

------
https://chatgpt.com/codex/tasks/task_e_685e2ad8d3cc832093917b63933ae268