### PR TITLE
Improve Haskell code formatting

### DIFF
--- a/compile/x/hs/tools.go
+++ b/compile/x/hs/tools.go
@@ -1,12 +1,67 @@
 package hscode
 
 import (
-        "bytes"
-        "fmt"
-        "os"
-        "os/exec"
-        rruntime "runtime"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	rruntime "runtime"
 )
+
+// EnsureHSFormatter ensures the ormolu or fourmolu formatter is installed. It
+// attempts installation via apt-get on Linux, Homebrew on macOS or Chocolatey/
+// Scoop on Windows. The function returns nil if a formatter is available.
+func EnsureHSFormatter() error { return ensureHSFormatter() }
+
+func ensureHSFormatter() error {
+	if _, err := exec.LookPath("ormolu"); err == nil {
+		return nil
+	}
+	if _, err := exec.LookPath("fourmolu"); err == nil {
+		return nil
+	}
+	switch rruntime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "ormolu")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "ormolu")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "ormolu")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "ormolu")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("ormolu"); err == nil {
+		return nil
+	}
+	if _, err := exec.LookPath("fourmolu"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("ormolu not installed")
+}
 
 // EnsureHaskell verifies that ghc/runhaskell is installed. It attempts a
 // best-effort installation using apt-get on Linux or Homebrew on macOS.
@@ -52,40 +107,39 @@ func EnsureHaskell() error {
 			_ = cmd.Run()
 		}
 	}
-        if _, err := exec.LookPath("runhaskell"); err == nil {
-                return nil
-        }
-        return fmt.Errorf("ghc not installed")
+	if _, err := exec.LookPath("runhaskell"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("ghc not installed")
 }
 
 // FormatHS runs `ormolu` or `fourmolu` on the given source code if available.
 // If formatting fails or neither formatter is installed, the input is returned
 // unchanged. A trailing newline is ensured in the returned slice.
 func FormatHS(src []byte) []byte {
-        path, err := exec.LookPath("ormolu")
-        if err != nil {
-                if p, err := exec.LookPath("fourmolu"); err == nil {
-                        path = p
-                } else {
-                        if len(src) > 0 && src[len(src)-1] != '\n' {
-                                src = append(src, '\n')
-                        }
-                        return src
-                }
-        }
-        cmd := exec.Command(path, "--stdin-input-file", "Main.hs")
-        cmd.Stdin = bytes.NewReader(src)
-        var out bytes.Buffer
-        cmd.Stdout = &out
-        if err := cmd.Run(); err == nil {
-                res := out.Bytes()
-                if len(res) == 0 || res[len(res)-1] != '\n' {
-                        res = append(res, '\n')
-                }
-                return res
-        }
-        if len(src) > 0 && src[len(src)-1] != '\n' {
-                src = append(src, '\n')
-        }
-        return src
+	if err := ensureHSFormatter(); err != nil {
+		if len(src) > 0 && src[len(src)-1] != '\n' {
+			src = append(src, '\n')
+		}
+		return src
+	}
+	path, err := exec.LookPath("ormolu")
+	if err != nil {
+		path, _ = exec.LookPath("fourmolu")
+	}
+	cmd := exec.Command(path, "--stdin-input-file", "Main.hs")
+	cmd.Stdin = bytes.NewReader(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		res := out.Bytes()
+		if len(res) == 0 || res[len(res)-1] != '\n' {
+			res = append(res, '\n')
+		}
+		return res
+	}
+	if len(src) > 0 && src[len(src)-1] != '\n' {
+		src = append(src, '\n')
+	}
+	return src
 }

--- a/tests/compiler/hs/arithmetic.hs.out
+++ b/tests/compiler/hs/arithmetic.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,13 +114,12 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print ((1 + 2))
-    print ((5 - 3))
-    print ((4 * 2))
-    print ((div 8 2))
-    print ((7 `mod` 3))
+  print ((1 + 2))
+  print ((5 - 3))
+  print ((4 * 2))
+  print ((div 8 2))
+  print ((7 `mod` 3))

--- a/tests/compiler/hs/avg_builtin.hs.out
+++ b/tests/compiler/hs/avg_builtin.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print (avg [1, 2, 3])
+  print (avg [1, 2, 3])

--- a/tests/compiler/hs/bool_ops.hs.out
+++ b/tests/compiler/hs/bool_ops.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print ((True && False))
-    print ((True || False))
-    print (not False)
+  print ((True && False))
+  print ((True || False))
+  print (not False)

--- a/tests/compiler/hs/closure.hs.out
+++ b/tests/compiler/hs/closure.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,8 +114,7 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 makeAdder :: Int -> (Int -> Int)
 makeAdder n = (\x -> (x + n))
@@ -115,4 +123,4 @@ add10 = makeAdder 10
 
 main :: IO ()
 main = do
-    print (add10 7)
+  print (add10 7)

--- a/tests/compiler/hs/count_builtin.hs.out
+++ b/tests/compiler/hs/count_builtin.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print (length [1, 2, 3])
+  print (length [1, 2, 3])

--- a/tests/compiler/hs/dataset.hs.out
+++ b/tests/compiler/hs/dataset.hs.out
@@ -1,57 +1,60 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
-import qualified Data.Aeson as Aeson
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import GHC.Generics (Generic)
-import qualified Data.ByteString.Lazy.Char8 as BSL
-
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -59,7 +62,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -71,30 +74,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -106,20 +115,20 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
+   in _writeOutput path text
 
-
-data Person = Person {
-    name :: String,
+data Person = Person
+  { name :: String,
     age :: Int
-} deriving (Show, Generic)
+  }
+  deriving (Show, Generic)
+
 instance Aeson.FromJSON Person
 
-
-people = [Person { name = "Alice", age = 30 }, Person { name = "Bob", age = 15 }, Person { name = "Charlie", age = 65 }]
+people = [Person {name = "Alice", age = 30}, Person {name = "Bob", age = 15}, Person {name = "Charlie", age = 65}]
 
 names = [name (p) | p <- filter (\p -> (age (p) >= 18)) people]
 
 main :: IO ()
 main = do
-    mapM_ (\n -> putStrLn (n)) names
+  mapM_ (\n -> putStrLn (n)) names

--- a/tests/compiler/hs/float_literal_precision.hs.out
+++ b/tests/compiler/hs/float_literal_precision.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print (9.261000000000001)
+  print (9.261000000000001)

--- a/tests/compiler/hs/float_ops.hs.out
+++ b/tests/compiler/hs/float_ops.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,10 +114,9 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print ((1.2 + 3.4))
-    print ((5.0 / 2.0))
+  print ((1.2 + 3.4))
+  print ((5.0 / 2.0))

--- a/tests/compiler/hs/for_loop.hs.out
+++ b/tests/compiler/hs/for_loop.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    mapM_ (\i -> print (i)) [1..4 - 1]
+  mapM_ (\i -> print (i)) [1 .. 4 - 1]

--- a/tests/compiler/hs/fun_call.hs.out
+++ b/tests/compiler/hs/fun_call.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,12 +114,11 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 add :: Int -> Int -> Int
 add a b = (a + b)
 
 main :: IO ()
 main = do
-    print (add 2 3)
+  print (add 2 3)

--- a/tests/compiler/hs/fun_expr_in_let.hs.out
+++ b/tests/compiler/hs/fun_expr_in_let.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 square = (\x -> (x * x))
 
 main :: IO ()
 main = do
-    print (square 6)
+  print (square 6)

--- a/tests/compiler/hs/grouped_expr.hs.out
+++ b/tests/compiler/hs/grouped_expr.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 value = (((1 + 2)) * 3)
 
 main :: IO ()
 main = do
-    print (value)
+  print (value)

--- a/tests/compiler/hs/hello_world.hs.out
+++ b/tests/compiler/hs/hello_world.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    putStrLn ("Hello, world")
+  putStrLn ("Hello, world")

--- a/tests/compiler/hs/if_else.hs.out
+++ b/tests/compiler/hs/if_else.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,15 +114,15 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 foo :: Int -> Int
-foo n = fromMaybe (0) $
+foo n =
+  fromMaybe (0) $
     if (n < 0) then Just ((-1)) else if (n == 0) then Just (0) else Just (1)
 
 main :: IO ()
 main = do
-    print (foo (-2))
-    print (foo 0)
-    print (foo 3)
+  print (foo (-2))
+  print (foo 0)
+  print (foo 3)

--- a/tests/compiler/hs/input_builtin.hs.out
+++ b/tests/compiler/hs/input_builtin.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,8 +114,7 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 input1 = _input
 
@@ -114,6 +122,6 @@ input2 = _input
 
 main :: IO ()
 main = do
-    putStrLn ("Enter first input:")
-    putStrLn ("Enter second input:")
-    putStrLn (unwords ["You entered:", input1, ",", input2])
+  putStrLn ("Enter first input:")
+  putStrLn ("Enter second input:")
+  putStrLn (unwords ["You entered:", input1, ",", input2])

--- a/tests/compiler/hs/len_builtin.hs.out
+++ b/tests/compiler/hs/len_builtin.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print (length [1, 2, 3])
+  print (length [1, 2, 3])

--- a/tests/compiler/hs/list_for_loop.hs.out
+++ b/tests/compiler/hs/list_for_loop.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 names = ["Alice", "Bob"]
 
 main :: IO ()
 main = do
-    mapM_ (\n -> putStrLn (show n)) names
+  mapM_ (\n -> putStrLn (show n)) names

--- a/tests/compiler/hs/list_push.hs.out
+++ b/tests/compiler/hs/list_push.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    print (([1, 2] ++ [3]))
+  print (([1, 2] ++ [3]))

--- a/tests/compiler/hs/load_json_stdin.hs.out
+++ b/tests/compiler/hs/load_json_stdin.hs.out
@@ -1,19 +1,19 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
-import qualified Data.Aeson as Aeson
-import GHC.Generics (Generic)
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Aeson.Key as Key
-import qualified Data.Vector as V
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
-import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
 
 data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
 
@@ -48,7 +48,7 @@ _parseJSON text =
 
 _valueToMap :: Aeson.Value -> Map.Map String String
 _valueToMap (Aeson.Object o) =
-  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
 _valueToMap _ = Map.empty
 
 _valueToString :: Aeson.Value -> String
@@ -59,7 +59,7 @@ _valueToString _ = ""
 
 _mapToValue :: Map.Map String String -> Aeson.Value
 _mapToValue m =
-  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path opts = do
@@ -72,27 +72,27 @@ _load path opts = do
 _save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
 _save rows path opts =
   let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
-  in case fmt of
-    "json" ->
-      let objs = map _mapToValue rows
-          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
-      in _writeOutput path (BSL.unpack (Aeson.encode val))
-    _ ->
-      let headers = if null rows then [] else Map.keys (head rows)
-          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
-          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-      in _writeOutput path text
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
 
-
-data Person = Person {
-    name :: String,
+data Person = Person
+  { name :: String,
     age :: Int
-} deriving (Show, Generic)
-instance Aeson.FromJSON Person
+  }
+  deriving (Show, Generic)
 
+instance Aeson.FromJSON Person
 
 people = _load Nothing Just (Map.fromList [("format", "json")])
 
 main :: IO ()
 main = do
-    print (length people)
+  print (length people)

--- a/tests/compiler/hs/map_for_loop.hs.out
+++ b/tests/compiler/hs/map_for_loop.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 scores = Map.fromList [("Alice", 10), ("Bob", 15)]
 
 main :: IO ()
 main = do
-    mapM_ (\k -> putStrLn (k)) (Map.keys scores)
+  mapM_ (\k -> putStrLn (k)) (Map.keys scores)

--- a/tests/compiler/hs/map_index.hs.out
+++ b/tests/compiler/hs/map_index.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 scores = Map.fromList [("Alice", 10), ("Bob", 15)]
 
 main :: IO ()
 main = do
-    print (fromMaybe (error "missing") (Map.lookup "Bob" scores))
+  print (fromMaybe (error "missing") (Map.lookup "Bob" scores))

--- a/tests/compiler/hs/map_keys_builtin.hs.out
+++ b/tests/compiler/hs/map_keys_builtin.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 m = Map.fromList [("a", 1), ("b", 2)]
 
 main :: IO ()
 main = do
-    print (length (Map.keys m))
+  print (length (Map.keys m))

--- a/tests/compiler/hs/map_lookup.hs.out
+++ b/tests/compiler/hs/map_lookup.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,12 +114,11 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 m = Map.fromList [("a", 1), ("b", 2)]
 
 main :: IO ()
 main = do
-    print (fromMaybe (error "missing") (Map.lookup "a" m))
-    print (fromMaybe (error "missing") (Map.lookup "b" m))
+  print (fromMaybe (error "missing") (Map.lookup "a" m))
+  print (fromMaybe (error "missing") (Map.lookup "b" m))

--- a/tests/compiler/hs/reserved_keyword_var.hs.out
+++ b/tests/compiler/hs/reserved_keyword_var.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 map = Map.fromList [("a", 1)]
 
 main :: IO ()
 main = do
-    print (fromMaybe (error "missing") (Map.lookup "a" map))
+  print (fromMaybe (error "missing") (Map.lookup "a" map))

--- a/tests/compiler/hs/save_json_stdout.hs.out
+++ b/tests/compiler/hs/save_json_stdout.hs.out
@@ -1,19 +1,19 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
-import qualified Data.Aeson as Aeson
-import GHC.Generics (Generic)
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Aeson.Key as Key
-import qualified Data.Vector as V
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
-import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
 
 data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
 
@@ -48,7 +48,7 @@ _parseJSON text =
 
 _valueToMap :: Aeson.Value -> Map.Map String String
 _valueToMap (Aeson.Object o) =
-  Map.fromList [ (T.unpack (Key.toText k), _valueToString v) | (k,v) <- KeyMap.toList o ]
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
 _valueToMap _ = Map.empty
 
 _valueToString :: Aeson.Value -> String
@@ -59,7 +59,7 @@ _valueToString _ = ""
 
 _mapToValue :: Map.Map String String -> Aeson.Value
 _mapToValue m =
-  Aeson.Object $ KeyMap.fromList [ (Key.fromString k, Aeson.String (T.pack v)) | (k,v) <- Map.toList m ]
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path opts = do
@@ -72,27 +72,27 @@ _load path opts = do
 _save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
 _save rows path opts =
   let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
-  in case fmt of
-    "json" ->
-      let objs = map _mapToValue rows
-          val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
-      in _writeOutput path (BSL.unpack (Aeson.encode val))
-    _ ->
-      let headers = if null rows then [] else Map.keys (head rows)
-          toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
-          text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-      in _writeOutput path text
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
 
-
-data Person = Person {
-    name :: String,
+data Person = Person
+  { name :: String,
     age :: Int
-} deriving (Show, Generic)
-instance Aeson.FromJSON Person
+  }
+  deriving (Show, Generic)
 
+instance Aeson.FromJSON Person
 
 people = _load Nothing Just (Map.fromList [("format", "json")])
 
 main :: IO ()
 main = do
-    _save people Nothing Just (Map.fromList [("format", "json")])
+  _save people Nothing Just (Map.fromList [("format", "json")])

--- a/tests/compiler/hs/str_builtin.hs.out
+++ b/tests/compiler/hs/str_builtin.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    putStrLn (show 123)
+  putStrLn (show 123)

--- a/tests/compiler/hs/string_concat.hs.out
+++ b/tests/compiler/hs/string_concat.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    putStrLn (("hello " ++ "world"))
+  putStrLn (("hello " ++ "world"))

--- a/tests/compiler/hs/string_for_loop.hs.out
+++ b/tests/compiler/hs/string_for_loop.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,9 +114,8 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 main :: IO ()
 main = do
-    mapM_ (\ch -> print (ch)) "cat"
+  mapM_ (\ch -> print (ch)) "cat"

--- a/tests/compiler/hs/string_index.hs.out
+++ b/tests/compiler/hs/string_index.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 text = "hello"
 
 main :: IO ()
 main = do
-    putStrLn (_indexString text 1)
+  putStrLn (_indexString text 1)

--- a/tests/compiler/hs/string_negative_index.hs.out
+++ b/tests/compiler/hs/string_negative_index.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,10 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 text = "hello"
 
 main :: IO ()
 main = do
-    putStrLn (_indexString text (-1))
+  putStrLn (_indexString text (-1))

--- a/tests/compiler/hs/string_slice.hs.out
+++ b/tests/compiler/hs/string_slice.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,7 +114,7 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
+   in _writeOutput path text
 
 _slice :: [a] -> Int -> Int -> [a]
 _slice xs i j =
@@ -115,7 +124,7 @@ _slice xs i j =
       start = max 0 start0
       end = min n end0
       end' = if end < start then start else end
-  in take (end' - start) (drop start xs)
+   in take (end' - start) (drop start xs)
 
 _sliceString :: String -> Int -> Int -> String
 _sliceString s i j =
@@ -125,9 +134,8 @@ _sliceString s i j =
       start = max 0 start0
       end = min n end0
       end' = if end < start then start else end
-  in take (end' - start) (drop start s)
-
+   in take (end' - start) (drop start s)
 
 main :: IO ()
 main = do
-    putStrLn (_sliceString "hello" 1 4)
+  putStrLn (_sliceString "hello" 1 4)

--- a/tests/compiler/hs/struct_literal.hs.out
+++ b/tests/compiler/hs/struct_literal.hs.out
@@ -1,57 +1,60 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.List (intercalate, isPrefixOf)
 import qualified Data.List as List
-import qualified Data.Aeson as Aeson
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import GHC.Generics (Generic)
-import qualified Data.ByteString.Lazy.Char8 as BSL
-
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -59,7 +62,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -71,30 +74,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -106,25 +115,26 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
+   in _writeOutput path text
 
-
-data Person = Person {
-    name :: String,
+data Person = Person
+  { name :: String,
     age :: Int
-} deriving (Show, Generic)
+  }
+  deriving (Show, Generic)
+
 instance Aeson.FromJSON Person
 
-
-data Book = Book {
-    title :: String,
+data Book = Book
+  { title :: String,
     author :: Person
-} deriving (Show, Generic)
+  }
+  deriving (Show, Generic)
+
 instance Aeson.FromJSON Book
 
-
-book = Book { title = "Go", author = Person { name = "Bob", age = 42 } }
+book = Book {title = "Go", author = Person {name = "Bob", age = 42}}
 
 main :: IO ()
 main = do
-    putStrLn (name (author (book)))
+  putStrLn (name (author (book)))

--- a/tests/compiler/hs/test_block.hs.out
+++ b/tests/compiler/hs/test_block.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,19 +114,18 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
+   in _writeOutput path text
 
 expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-
 test_addition_works :: IO ()
 test_addition_works = do
-    let x = (1 + 2)
-    expect ((x == 3))
+  let x = (1 + 2)
+  expect ((x == 3))
 
 main :: IO ()
 main = do
-    putStrLn ("ok")
-    test_addition_works
+  putStrLn ("ok")
+  test_addition_works

--- a/tests/compiler/hs/tpc_h_q1.hs.out
+++ b/tests/compiler/hs/tpc_h_q1.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,22 +114,21 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
+   in _writeOutput path text
 
 expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-
 lineitem = [Map.fromList [("l_quantity", VInt (17)), ("l_extendedprice", VDouble (1000.0)), ("l_discount", VDouble (0.05)), ("l_tax", VDouble (0.07)), ("l_returnflag", VString ("N")), ("l_linestatus", VString ("O")), ("l_shipdate", VString ("1998-08-01"))], Map.fromList [("l_quantity", VInt (36)), ("l_extendedprice", VDouble (2000.0)), ("l_discount", VDouble (0.1)), ("l_tax", VDouble (0.05)), ("l_returnflag", VString ("N")), ("l_linestatus", VString ("O")), ("l_shipdate", VString ("1998-09-01"))], Map.fromList [("l_quantity", VInt (25)), ("l_extendedprice", VDouble (1500.0)), ("l_discount", VDouble (0.0)), ("l_tax", VDouble (0.08)), ("l_returnflag", VString ("R")), ("l_linestatus", VString ("F")), ("l_shipdate", VString ("1998-09-03"))]]
 
-result = [ Map.fromList [("returnflag", VString (fromMaybe (error "missing") (Map.lookup "returnflag" (key (g))))), ("linestatus", VString (fromMaybe (error "missing") (Map.lookup "linestatus" (key (g))))), ("sum_qty", VDouble (sum [fromMaybe (error "missing") (Map.lookup "l_quantity" (x)) | x <- g])), ("sum_base_price", VDouble (sum [fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) | x <- g])), ("sum_disc_price", VDouble (sum [(fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (x))))) | x <- g])), ("sum_charge", VDouble (sum [((fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (x))))) * ((1 + fromMaybe (error "missing") (Map.lookup "l_tax" (x))))) | x <- g])), ("avg_qty", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_quantity" (x)) | x <- g])), ("avg_price", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) | x <- g])), ("avg_disc", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_discount" (x)) | x <- g])), ("count_order", VInt (length (items g)))] | g <- _group_by [(row) | row <- lineitem, (fromMaybe (error "missing") (Map.lookup "l_shipdate" row) <= "1998-09-02")] (\(row) -> Map.fromList [("returnflag", VString (fromMaybe (error "missing") (Map.lookup "l_returnflag" row))), ("linestatus", VString (fromMaybe (error "missing") (Map.lookup "l_linestatus" row)))]), let g = g ]
+result = [Map.fromList [("returnflag", VString (fromMaybe (error "missing") (Map.lookup "returnflag" (key (g))))), ("linestatus", VString (fromMaybe (error "missing") (Map.lookup "linestatus" (key (g))))), ("sum_qty", VDouble (sum [fromMaybe (error "missing") (Map.lookup "l_quantity" (x)) | x <- g])), ("sum_base_price", VDouble (sum [fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) | x <- g])), ("sum_disc_price", VDouble (sum [(fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (x))))) | x <- g])), ("sum_charge", VDouble (sum [((fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (x))))) * ((1 + fromMaybe (error "missing") (Map.lookup "l_tax" (x))))) | x <- g])), ("avg_qty", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_quantity" (x)) | x <- g])), ("avg_price", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) | x <- g])), ("avg_disc", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_discount" (x)) | x <- g])), ("count_order", VInt (length (items g)))] | g <- _group_by [(row) | row <- lineitem, (fromMaybe (error "missing") (Map.lookup "l_shipdate" row) <= "1998-09-02")] (\(row) -> Map.fromList [("returnflag", VString (fromMaybe (error "missing") (Map.lookup "l_returnflag" row))), ("linestatus", VString (fromMaybe (error "missing") (Map.lookup "l_linestatus" row)))]), let g = g]
 
 test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus :: IO ()
 test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus = do
-    expect ((result == [Map.fromList [("returnflag", VString ("N")), ("linestatus", VString ("O")), ("sum_qty", VInt (53)), ("sum_base_price", VInt (3000)), ("sum_disc_price", VDouble ((950.0 + 1800.0))), ("sum_charge", VDouble ((((950.0 * 1.07)) + ((1800.0 * 1.05))))), ("avg_qty", VDouble (26.5)), ("avg_price", VInt (1500)), ("avg_disc", VDouble (0.07500000000000001)), ("count_order", VInt (2))]]))
+  expect ((result == [Map.fromList [("returnflag", VString ("N")), ("linestatus", VString ("O")), ("sum_qty", VInt (53)), ("sum_base_price", VInt (3000)), ("sum_disc_price", VDouble ((950.0 + 1800.0))), ("sum_charge", VDouble ((((950.0 * 1.07)) + ((1800.0 * 1.05))))), ("avg_qty", VDouble (26.5)), ("avg_price", VInt (1500)), ("avg_disc", VDouble (0.07500000000000001)), ("count_order", VInt (2))]]))
 
 main :: IO ()
 main = do
-    _json result
-    test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus
+  _json result
+  test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus

--- a/tests/compiler/hs/two_sum.hs.out
+++ b/tests/compiler/hs/two_sum.hs.out
@@ -1,56 +1,59 @@
 {-# LANGUAGE DeriveGeneric #-}
+
 module Main where
 
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Map as Map
-import Data.List (intercalate, isPrefixOf)
-import qualified Data.List as List
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
-
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 
 forLoop :: Int -> Int -> (Int -> Maybe a) -> Maybe a
 forLoop start end f = go start
   where
-    go i | i < end =
-            case f i of
-              Just v -> Just v
-              Nothing -> go (i + 1)
-         | otherwise = Nothing
+    go i
+      | i < end =
+          case f i of
+            Just v -> Just v
+            Nothing -> go (i + 1)
+      | otherwise = Nothing
 
 whileLoop :: (() -> Bool) -> (() -> Maybe a) -> Maybe a
 whileLoop cond body = go ()
   where
-    go _ | cond () =
-            case body () of
-              Just v -> Just v
-              Nothing -> go ()
-         | otherwise = Nothing
+    go _
+      | cond () =
+          case body () of
+            Just v -> Just v
+            Nothing -> go ()
+      | otherwise = Nothing
 
-avg :: Real a => [a] -> Double
-avg xs | null xs = 0
-      | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
+avg :: (Real a) => [a] -> Double
+avg xs
+  | null xs = 0
+  | otherwise = sum (map realToFrac xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup {key :: k, items :: [a]} deriving (Show)
 
-_group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
+_group_by :: (Ord k) => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =
   let go [] m order = (m, order)
-      go (x:xs) m order =
+      go (x : xs) m order =
         let k = keyfn x
-        in case Map.lookup k m of
-             Just is -> go xs (Map.insert k (is ++ [x]) m) order
-             Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
+         in case Map.lookup k m of
+              Just is -> go xs (Map.insert k (is ++ [x]) m) order
+              Nothing -> go xs (Map.insert k [x] m) (order ++ [k])
       (m, order) = go src Map.empty []
-  in [ MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order ]
+   in [MGroup k (fromMaybe [] (Map.lookup k m)) | k <- order]
 
 _indexString :: String -> Int -> String
 _indexString s i =
   let idx = if i < 0 then i + length s else i
-  in if idx < 0 || idx >= length s
-       then error "index out of range"
-       else [s !! idx]
+   in if idx < 0 || idx >= length s
+        then error "index out of range"
+        else [s !! idx]
 
 _input :: IO String
 _input = getLine
@@ -58,7 +61,7 @@ _input = getLine
 _now :: IO Int
 _now = fmap round getPOSIXTime
 
-_json :: Aeson.ToJSON a => a -> IO ()
+_json :: (Aeson.ToJSON a) => a -> IO ()
 _json v = BSL.putStrLn (Aeson.encode v)
 
 _readInput :: Maybe String -> IO String
@@ -70,30 +73,36 @@ _readInput (Just p)
 _writeOutput :: Maybe String -> String -> IO ()
 _writeOutput mp text = case mp of
   Nothing -> putStr text
-  Just p | null p || p == "-" -> putStr text
-         | otherwise -> writeFile p text
+  Just p
+    | null p || p == "-" -> putStr text
+    | otherwise -> writeFile p text
 
 _split :: Char -> String -> [String]
 _split _ "" = [""]
 _split d s =
   let (h, t) = break (== d) s
-  in h : case t of
-            []      -> []
-            (_:rest) -> _split d rest
+   in h : case t of
+        [] -> []
+        (_ : rest) -> _split d rest
 
 _parseCSV :: String -> Bool -> Char -> [Map.Map String String]
 _parseCSV text header delim =
   let ls = filter (not . null) (lines text)
-  in if null ls then [] else
-       let heads = if header
-                      then _split delim (head ls)
-                      else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
-           start = if header then 1 else 0
-           row line =
-             let parts = _split delim line
-             in Map.fromList [ (heads !! j, if j < length parts then parts !! j else "")
-                             | j <- [0 .. length heads - 1] ]
-       in map row (drop start ls)
+   in if null ls
+        then []
+        else
+          let heads =
+                if header
+                  then _split delim (head ls)
+                  else ["c" ++ show i | i <- [0 .. length (_split delim (head ls)) - 1]]
+              start = if header then 1 else 0
+              row line =
+                let parts = _split delim line
+                 in Map.fromList
+                      [ (heads !! j, if j < length parts then parts !! j else "")
+                        | j <- [0 .. length heads - 1]
+                      ]
+           in map row (drop start ls)
 
 _load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
 _load path _ = do
@@ -105,11 +114,11 @@ _save rows path _ =
   let headers = if null rows then [] else Map.keys (head rows)
       toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
       text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
-
+   in _writeOutput path text
 
 twoSum :: [Int] -> Int -> [Int]
-twoSum nums target = fromMaybe ([]) $
+twoSum nums target =
+  fromMaybe ([]) $
     (let n = length nums in case forLoop 0 n (\i -> forLoop (i + 1) n (\j -> if (((nums !! i) + (nums !! j)) == target) then Just ([i, j]) else Nothing)) of Just v -> Just v; Nothing -> Just ([(-1), (-1)]))
   where
     n = length nums
@@ -118,5 +127,5 @@ result = twoSum [2, 7, 11, 15] 9
 
 main :: IO ()
 main = do
-    print ((result !! 0))
-    print ((result !! 1))
+  print ((result !! 0))
+  print ((result !! 1))


### PR DESCRIPTION
## Summary
- update Haskell tools.go with EnsureHSFormatter
- format generated Haskell code with ormolu when available
- regenerate all Haskell golden outputs

## Testing
- `go test ./compile/x/hs -tags slow -run TestHSCompiler_GoldenOutput -update`

------
https://chatgpt.com/codex/tasks/task_e_685e2add0bb48320b98dc34a1b464a7b