### PR TITLE
Improve Pascal code formatting

### DIFF
--- a/compile/x/pas/tools.go
+++ b/compile/x/pas/tools.go
@@ -67,11 +67,28 @@ func EnsureFPC() (string, error) {
 	return "", fmt.Errorf("fpc not installed")
 }
 
+// EnsurePtop verifies that the ptop formatter is available. If not found,
+// it attempts to install the Free Pascal tools which include ptop. Tests can
+// call this helper to ensure formatting works.
+func EnsurePtop() error {
+	if _, err := exec.LookPath("ptop"); err == nil {
+		return nil
+	}
+	if _, err := EnsureFPC(); err != nil {
+		return err
+	}
+	if _, err := exec.LookPath("ptop"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("ptop not installed")
+}
+
 // FormatPas runs ptop to pretty-print Pascal code if available.
 // Keywords keep their original casing and indentation is set to two spaces.
 func FormatPas(src []byte) []byte {
 	path, err := exec.LookPath("ptop")
 	if err != nil {
+		src = bytes.ReplaceAll(src, []byte("\t"), []byte("  "))
 		if len(src) > 0 && src[len(src)-1] != '\n' {
 			src = append(src, '\n')
 		}


### PR DESCRIPTION
## Summary
- tweak Pascal formatting to still produce readable code without ptop
- provide EnsurePtop for tests and other helpers
- regenerate Pascal examples (no diff)

## Testing
- `go run ./cmd/leetcode-runner build --from 1 --to 10 --lang pas`


------
https://chatgpt.com/codex/tasks/task_e_685e2ae6f670832089512c04dc199b88