### PR TITLE
Improve Scala formatting

### DIFF
--- a/compile/x/scala/compiler.go
+++ b/compile/x/scala/compiler.go
@@ -176,7 +176,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.indent--
 	c.writeln("}")
 	c.emitRuntime()
-	return c.buf.Bytes(), nil
+	return FormatScala(c.buf.Bytes()), nil
 }
 
 func (c *Compiler) compileFun(fn *parser.FunStmt) error {


### PR DESCRIPTION
## Summary
- add `FormatScala` helper to run `scalafmt` when available
- pipe generated Scala code through the formatter

## Testing
- `go test ./compile/x/scala -tags slow -run TestScalaCompiler_GoldenOutput -update`
- `go test ./...` *(fails: mochi/compile/x/lua)*

------
https://chatgpt.com/codex/tasks/task_e_685e2af208308320a13cdf36641eecd4