### PR TITLE
Format Racket output with raco

### DIFF
--- a/compile/x/rkt/compiler.go
+++ b/compile/x/rkt/compiler.go
@@ -3,7 +3,6 @@ package rktcode
 import (
 	"bytes"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -346,7 +345,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	} else {
 		code = bytes.Replace(code, []byte(";json-placeholder\n"), nil, 1)
 	}
-	return formatRkt(code), nil
+	return FormatRacket(code), nil
 }
 
 func (c *Compiler) compileFun(fn *parser.FunStmt) error {
@@ -1511,15 +1510,4 @@ func (c *Compiler) compileIfExpr(e *parser.IfExpr) (string, error) {
 		elseExpr = "(void)"
 	}
 	return fmt.Sprintf("(if %s %s %s)", cond, thenExpr, elseExpr), nil
-}
-
-func formatRkt(src []byte) []byte {
-	cmd := exec.Command("raco", "fmt")
-	cmd.Stdin = bytes.NewReader(src)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err == nil {
-		return out.Bytes()
-	}
-	return src
 }

--- a/compile/x/rkt/tools.go
+++ b/compile/x/rkt/tools.go
@@ -1,6 +1,7 @@
 package rktcode
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -56,4 +57,20 @@ func EnsureRacket() error {
 		return nil
 	}
 	return fmt.Errorf("racket not found")
+}
+
+// FormatRacket runs "raco fmt" on the given source code when available.
+// If the formatter is missing or fails, the input is returned unchanged.
+func FormatRacket(src []byte) []byte {
+	if _, err := exec.LookPath("raco"); err != nil {
+		return src
+	}
+	cmd := exec.Command("raco", "fmt", "--stdin")
+	cmd.Stdin = bytes.NewReader(src)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		return out.Bytes()
+	}
+	return src
 }


### PR DESCRIPTION
## Summary
- add `FormatRacket` helper using `raco fmt`
- use `FormatRacket` in the Racket compiler

## Testing
- `go test ./... -run TestNonexistent`


------
https://chatgpt.com/codex/tasks/task_e_685e2aee5da08320b4510d81e3c977e8