### PR TITLE
Improve Kotlin output formatting

### DIFF
--- a/compile/x/kt/compiler.go
+++ b/compile/x/kt/compiler.go
@@ -1718,7 +1718,7 @@ func (c *Compiler) writeln(s string) {
 
 func (c *Compiler) writeIndent() {
 	for i := 0; i < c.indent; i++ {
-		c.buf.WriteString("        ")
+		c.buf.WriteString("    ")
 	}
 }
 

--- a/compile/x/kt/tools.go
+++ b/compile/x/kt/tools.go
@@ -119,6 +119,7 @@ func FormatKotlin(src []byte) []byte {
 			}
 		}
 	}
+	src = bytes.ReplaceAll(src, []byte("\t"), []byte("    "))
 	if len(src) > 0 && src[len(src)-1] != '\n' {
 		src = append(src, '\n')
 	}

--- a/tests/compiler/kt/arithmetic.kt.out
+++ b/tests/compiler/kt/arithmetic.kt.out
@@ -1,7 +1,7 @@
 fun main() {
-        println((1 + 2))
-        println((5 - 3))
-        println((4 * 2))
-        println((8 / 2))
-        println((7 % 3))
+    println((1 + 2))
+    println((5 - 3))
+    println((4 * 2))
+    println((8 / 2))
+    println((7 % 3))
 }

--- a/tests/compiler/kt/avg_builtin.kt.out
+++ b/tests/compiler/kt/avg_builtin.kt.out
@@ -1,3 +1,3 @@
 fun main() {
-        println(listOf(1, 2, 3).average())
+    println(listOf(1, 2, 3).average())
 }

--- a/tests/compiler/kt/bool_ops.kt.out
+++ b/tests/compiler/kt/bool_ops.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        println((true && false))
-        println((true || false))
-        println(!false)
+    println((true && false))
+    println((true || false))
+    println(!false)
 }

--- a/tests/compiler/kt/break_continue.kt.out
+++ b/tests/compiler/kt/break_continue.kt.out
@@ -1,12 +1,12 @@
 fun main() {
-        val numbers = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
-        for (n in numbers) {
-                if (((n % 2) == 0)) {
-                        continue
-                }
-                if ((n > 7)) {
-                        break
-                }
-                println("odd number:", n)
+    val numbers = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    for (n in numbers) {
+        if (((n % 2) == 0)) {
+            continue
         }
+        if ((n > 7)) {
+            break
+        }
+        println("odd number:", n)
+    }
 }

--- a/tests/compiler/kt/count_builtin.kt.out
+++ b/tests/compiler/kt/count_builtin.kt.out
@@ -1,3 +1,3 @@
 fun main() {
-        println(listOf(1, 2, 3).size)
+    println(listOf(1, 2, 3).size)
 }

--- a/tests/compiler/kt/cross_join.kt.out
+++ b/tests/compiler/kt/cross_join.kt.out
@@ -5,9 +5,9 @@ data class Order(val id: Int, val customerId: Int, val total: Int)
 data class PairInfo(val orderId: Int, val orderCustomerId: Int, val pairedCustomerName: String, val orderTotal: Int)
 
 fun main() {
-        val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
-        val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
-        val result = run {
+    val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+    val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
+    val result = run {
                 val _src = orders
                 val _res = mutableListOf<PairInfo>()
                 for (o in _src) {
@@ -17,8 +17,8 @@ fun main() {
                 }
                 _res
         }
-        println("--- Cross Join: All order-customer pairs ---")
-        for (entry in result) {
-                println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
-        }
+    println("--- Cross Join: All order-customer pairs ---")
+    for (entry in result) {
+        println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
+    }
 }

--- a/tests/compiler/kt/cross_join_triple.kt.out
+++ b/tests/compiler/kt/cross_join_triple.kt.out
@@ -1,8 +1,8 @@
 fun main() {
-        val nums = listOf(1, 2)
-        val letters = listOf("A", "B")
-        val bools = listOf(true, false)
-        val combos = run {
+    val nums = listOf(1, 2)
+    val letters = listOf("A", "B")
+    val bools = listOf(true, false)
+    val combos = run {
                 val _src = nums
                 val _res = mutableListOf<MutableMap<String, Any>>()
                 for (n in _src) {
@@ -14,8 +14,8 @@ fun main() {
                 }
                 _res
         }
-        println("--- Cross Join of three lists ---")
-        for (c in combos) {
-                println(c.n, c.l, c.b)
-        }
+    println("--- Cross Join of three lists ---")
+    for (c in combos) {
+        println(c.n, c.l, c.b)
+    }
 }

--- a/tests/compiler/kt/dataset.kt.out
+++ b/tests/compiler/kt/dataset.kt.out
@@ -1,14 +1,14 @@
 data class Person(val name: String, val age: Int)
 
 fun main() {
-        val people = listOf(Person(name = "Alice", age = 30), Person(name = "Bob", age = 15), Person(name = "Charlie", age = 65))
-        val names = run {
+    val people = listOf(Person(name = "Alice", age = 30), Person(name = "Bob", age = 15), Person(name = "Charlie", age = 65))
+    val names = run {
                 var res = people
                 res = res.filter { p -> (p.age >= 18) }
                 res = res.map { p -> p.name }
                 res
         }
-        for (n in names) {
-                println(n)
-        }
+    for (n in names) {
+        println(n)
+    }
 }

--- a/tests/compiler/kt/dataset_sort_take_limit.kt.out
+++ b/tests/compiler/kt/dataset_sort_take_limit.kt.out
@@ -1,8 +1,8 @@
 data class Product(val name: String, val price: Int)
 
 fun main() {
-        val products = listOf(Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
-        val expensive = run {
+    val products = listOf(Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
+    val expensive = run {
                 var res = products
                 res = res.sortedBy { p -> -p.price }
                 res = res.drop(1)
@@ -10,8 +10,8 @@ fun main() {
                 res = res.map { p -> p }
                 res
         }
-        println("--- Top products (excluding most expensive) ---")
-        for (item in expensive) {
-                println(item.name, "costs $", item.price)
-        }
+    println("--- Top products (excluding most expensive) ---")
+    for (item in expensive) {
+        println(item.name, "costs $", item.price)
+    }
 }

--- a/tests/compiler/kt/factorial.kt.out
+++ b/tests/compiler/kt/factorial.kt.out
@@ -1,12 +1,12 @@
 fun factorial(n: Int) : Int {
-        if ((n <= 1)) {
-                return 1
-        }
-        return (n * factorial((n - 1)))
+    if ((n <= 1)) {
+        return 1
+    }
+    return (n * factorial((n - 1)))
 }
 
 fun main() {
-        println(factorial(0))
-        println(factorial(1))
-        println(factorial(5))
+    println(factorial(0))
+    println(factorial(1))
+    println(factorial(5))
 }

--- a/tests/compiler/kt/fetch_builtin.kt.out
+++ b/tests/compiler/kt/fetch_builtin.kt.out
@@ -1,8 +1,8 @@
 data class Msg(val message: String)
 
 fun main() {
-        val data: Msg = _cast<Msg>(_fetch("file://tests/compiler/kt/fetch_builtin.json", null))
-        println(data.message)
+    val data: Msg = _cast<Msg>(_fetch("file://tests/compiler/kt/fetch_builtin.json", null))
+    println(data.message)
 }
 
 import kotlin.reflect.full.primaryConstructor

--- a/tests/compiler/kt/fetch_http.kt.out
+++ b/tests/compiler/kt/fetch_http.kt.out
@@ -1,9 +1,9 @@
 data class Todo(val userId: Int, val id: Int, val title: String, val completed: Boolean)
 
 fun main() {
-        val todo: Todo = _cast<Todo>(_fetch("https://jsonplaceholder.typicode.com/todos/1", null))
-        println(todo.title)
-        println(todo.completed)
+    val todo: Todo = _cast<Todo>(_fetch("https://jsonplaceholder.typicode.com/todos/1", null))
+    println(todo.title)
+    println(todo.completed)
 }
 
 import kotlin.reflect.full.primaryConstructor

--- a/tests/compiler/kt/fibonacci.kt.out
+++ b/tests/compiler/kt/fibonacci.kt.out
@@ -1,12 +1,12 @@
 fun fib(n: Int) : Int {
-        if ((n <= 1)) {
-                return n
-        }
-        return (fib((n - 1)) + fib((n - 2)))
+    if ((n <= 1)) {
+        return n
+    }
+    return (fib((n - 1)) + fib((n - 2)))
 }
 
 fun main() {
-        println(fib(0))
-        println(fib(1))
-        println(fib(6))
+    println(fib(0))
+    println(fib(1))
+    println(fib(6))
 }

--- a/tests/compiler/kt/for_list_collection.kt.out
+++ b/tests/compiler/kt/for_list_collection.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        for (n in listOf(1, 2, 3)) {
-                println(n)
-        }
+    for (n in listOf(1, 2, 3)) {
+        println(n)
+    }
 }

--- a/tests/compiler/kt/for_loop.kt.out
+++ b/tests/compiler/kt/for_loop.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        for (i in 1 until 4) {
-                println(i)
-        }
+    for (i in 1 until 4) {
+        println(i)
+    }
 }

--- a/tests/compiler/kt/for_string_collection.kt.out
+++ b/tests/compiler/kt/for_string_collection.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        for (ch in "hi") {
-                println(ch)
-        }
+    for (ch in "hi") {
+        println(ch)
+    }
 }

--- a/tests/compiler/kt/fun_call.kt.out
+++ b/tests/compiler/kt/fun_call.kt.out
@@ -1,7 +1,7 @@
 fun add(a: Int, b: Int) : Int {
-        return (a + b)
+    return (a + b)
 }
 
 fun main() {
-        println(add(2, 3))
+    println(add(2, 3))
 }

--- a/tests/compiler/kt/group_by.kt.out
+++ b/tests/compiler/kt/group_by.kt.out
@@ -1,9 +1,9 @@
 fun main() {
-        val xs = listOf(1, 1, 2)
-        val groups = _group_by(xs) { x -> x }.map { g -> mutableMapOf("k" to g.key, "c" to g.size) }
-        for (g in groups) {
-                println(g.k, g.c)
-        }
+    val xs = listOf(1, 1, 2)
+    val groups = _group_by(xs) { x -> x }.map { g -> mutableMapOf("k" to g.key, "c" to g.size) }
+    for (g in groups) {
+        println(g.k, g.c)
+    }
 }
 
 class _Group(var key: Any?) {

--- a/tests/compiler/kt/hello_world.kt.out
+++ b/tests/compiler/kt/hello_world.kt.out
@@ -1,3 +1,3 @@
 fun main() {
-        println("Hello, world")
+    println("Hello, world")
 }

--- a/tests/compiler/kt/input_builtin.kt.out
+++ b/tests/compiler/kt/input_builtin.kt.out
@@ -1,7 +1,7 @@
 fun main() {
-        println("Enter first input:")
-        val input1 = readln()
-        println("Enter second input:")
-        val input2 = readln()
-        println("You entered:", input1, ",", input2)
+    println("Enter first input:")
+    val input1 = readln()
+    println("Enter second input:")
+    val input2 = readln()
+    println("You entered:", input1, ",", input2)
 }

--- a/tests/compiler/kt/join_filter_pag.kt.out
+++ b/tests/compiler/kt/join_filter_pag.kt.out
@@ -3,9 +3,9 @@ data class Person(val id: Int, val name: String)
 data class Purchase(val id: Int, val personId: Int, val total: Int)
 
 fun main() {
-        val people = listOf(Person(id = 1, name = "Alice"), Person(id = 2, name = "Bob"), Person(id = 3, name = "Charlie"))
-        val purchases = listOf(Purchase(id = 1, personId = 1, total = 200), Purchase(id = 2, personId = 1, total = 50), Purchase(id = 3, personId = 2, total = 150), Purchase(id = 4, personId = 3, total = 100), Purchase(id = 5, personId = 2, total = 250))
-        val result = run {
+    val people = listOf(Person(id = 1, name = "Alice"), Person(id = 2, name = "Bob"), Person(id = 3, name = "Charlie"))
+    val purchases = listOf(Purchase(id = 1, personId = 1, total = 200), Purchase(id = 2, personId = 1, total = 50), Purchase(id = 3, personId = 2, total = 150), Purchase(id = 4, personId = 3, total = 100), Purchase(id = 5, personId = 2, total = 250))
+    val result = run {
                 val _src = people
                 val _rows = _query(_src, listOf(
                         _JoinSpec(items = purchases, on = { args ->
@@ -28,9 +28,9 @@ mutableMapOf("person" to p.name, "spent" to o.total)
                         }, skip = 1, take = 2) )
                 _rows
         }
-        for (r in result) {
-                println(r.person, r.spent)
-        }
+    for (r in result) {
+        println(r.person, r.spent)
+    }
 }
 
 data class _JoinSpec(

--- a/tests/compiler/kt/json_builtin.kt.out
+++ b/tests/compiler/kt/json_builtin.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        _json(mutableMapOf("a" to 1))
+    _json(mutableMapOf("a" to 1))
 }
 
 fun _json(v: Any?) {

--- a/tests/compiler/kt/list_concat.kt.out
+++ b/tests/compiler/kt/list_concat.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        println(_concat(listOf(1, 2), listOf(3, 4)))
+    println(_concat(listOf(1, 2), listOf(3, 4)))
 }
 
 fun <T> _concat(a: List<T>, b: List<T>): List<T> = a + b

--- a/tests/compiler/kt/list_index.kt.out
+++ b/tests/compiler/kt/list_index.kt.out
@@ -1,4 +1,4 @@
 fun main() {
-        val xs = listOf(10, 20, 30)
-        println(xs[1])
+    val xs = listOf(10, 20, 30)
+    println(xs[1])
 }

--- a/tests/compiler/kt/load_jsonl_stdin.kt.out
+++ b/tests/compiler/kt/load_jsonl_stdin.kt.out
@@ -1,7 +1,7 @@
 data class Person(val name: String, val age: Int)
 
 fun main() {
-        val people = run {
+    val people = run {
         val _rows = _load(null, mutableMapOf("format" to "jsonl"))
         val _out = mutableListOf<Person>()
         for (r in _rows) {
@@ -9,7 +9,7 @@ fun main() {
         }
         _out
 }
-        println(people.size)
+    println(people.size)
 }
 
 import kotlin.reflect.full.primaryConstructor

--- a/tests/compiler/kt/load_save_json.kt.out
+++ b/tests/compiler/kt/load_save_json.kt.out
@@ -1,7 +1,7 @@
 data class Person(val name: String, val age: Int, val email: String)
 
 fun main() {
-        val people = run {
+    val people = run {
         val _rows = _load(null, mutableMapOf("format" to "json"))
         val _out = mutableListOf<Person>()
         for (r in _rows) {
@@ -9,13 +9,13 @@ fun main() {
         }
         _out
 }
-        val adults = run {
+    val adults = run {
                 var res = people
                 res = res.filter { p -> (p.age >= 18) }
                 res = res.map { p -> p }
                 res
         }
-        _save(adults, null, mutableMapOf("format" to "json"))
+    _save(adults, null, mutableMapOf("format" to "json"))
 }
 
 import kotlin.reflect.full.primaryConstructor

--- a/tests/compiler/kt/load_yaml.kt.out
+++ b/tests/compiler/kt/load_yaml.kt.out
@@ -1,7 +1,7 @@
 data class Person(val name: String, val age: Int, val email: String)
 
 fun main() {
-        val people = run {
+    val people = run {
         val _rows = _load("../tests/interpreter/valid/people.yaml", mutableMapOf("format" to "yaml"))
         val _out = mutableListOf<Person>()
         for (r in _rows) {
@@ -9,15 +9,15 @@ fun main() {
         }
         _out
 }
-        val adults = run {
+    val adults = run {
                 var res = people
                 res = res.filter { p -> (p.age >= 18) }
                 res = res.map { p -> mutableMapOf("name" to p.name, "email" to p.email) }
                 res
         }
-        for (a in adults) {
-                println(a.name, a.email)
-        }
+    for (a in adults) {
+        println(a.name, a.email)
+    }
 }
 
 import kotlin.reflect.full.primaryConstructor

--- a/tests/compiler/kt/local_recursion.kt.out
+++ b/tests/compiler/kt/local_recursion.kt.out
@@ -3,18 +3,18 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun fromList(nums: List<Int>) : Tree {
-        fun helper(lo: Int, hi: Int) : Tree {
-                if ((lo >= hi)) {
-                        return Leaf()
-                }
-                val mid = (((lo + hi)) / 2)
-                return Node(left = helper(lo, mid), value = nums[mid], right = helper((mid + 1), hi))
+    fun helper(lo: Int, hi: Int) : Tree {
+        if ((lo >= hi)) {
+            return Leaf()
         }
-        return helper(0, nums.size)
+        val mid = (((lo + hi)) / 2)
+        return Node(left = helper(lo, mid), value = nums[mid], right = helper((mid + 1), hi))
+    }
+    return helper(0, nums.size)
 }
 
 fun inorder(t: Tree) : List<Int> {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Leaf -> listOf()
@@ -29,7 +29,7 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
-        println(inorder(fromList(listOf(-10, -3, 0, 5, 9))))
+    println(inorder(fromList(listOf(-10, -3, 0, 5, 9))))
 }
 
 fun <T> _concat(a: List<T>, b: List<T>): List<T> = a + b

--- a/tests/compiler/kt/map_index.kt.out
+++ b/tests/compiler/kt/map_index.kt.out
@@ -1,4 +1,4 @@
 fun main() {
-        val scores = mutableMapOf("Alice" to 10, "Bob" to 15)
-        println(scores["Bob"])
+    val scores = mutableMapOf("Alice" to 10, "Bob" to 15)
+    println(scores["Bob"])
 }

--- a/tests/compiler/kt/map_iterate.kt.out
+++ b/tests/compiler/kt/map_iterate.kt.out
@@ -1,18 +1,18 @@
 fun main() {
-        var m: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
-        run {
-                val _tmp = m.toMutableMap()
-                _tmp[1] = true
-                m = _tmp
-        }
-        run {
-                val _tmp = m.toMutableMap()
-                _tmp[2] = true
-                m = _tmp
-        }
-        var sum = 0
-        for (k in m.keys) {
-                sum = (sum + k)
-        }
-        println(sum)
+    var m: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
+    run {
+        val _tmp = m.toMutableMap()
+        _tmp[1] = true
+        m = _tmp
+    }
+    run {
+        val _tmp = m.toMutableMap()
+        _tmp[2] = true
+        m = _tmp
+    }
+    var sum = 0
+    for (k in m.keys) {
+        sum = (sum + k)
+    }
+    println(sum)
 }

--- a/tests/compiler/kt/map_literal.kt.out
+++ b/tests/compiler/kt/map_literal.kt.out
@@ -1,4 +1,4 @@
 fun main() {
-        val map = mutableMapOf("a" to 1)
-        println(map["a"])
+    val map = mutableMapOf("a" to 1)
+    println(map["a"])
 }

--- a/tests/compiler/kt/match_capture.kt.out
+++ b/tests/compiler/kt/match_capture.kt.out
@@ -3,7 +3,7 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun depth(t: Tree) : Int {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Leaf -> 0
@@ -17,5 +17,5 @@ fun depth(t: Tree) : Int {
 }
 
 fun main() {
-        println(depth(Node(left = Leaf(), value = 0, right = Leaf())))
+    println(depth(Node(left = Leaf(), value = 0, right = Leaf())))
 }

--- a/tests/compiler/kt/match_underscore.kt.out
+++ b/tests/compiler/kt/match_underscore.kt.out
@@ -3,7 +3,7 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun value_of_root(t: Tree) : Int {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Node -> {
@@ -16,5 +16,5 @@ fun value_of_root(t: Tree) : Int {
 }
 
 fun main() {
-        println(value_of_root(Node(left = Leaf(), value = 5, right = Leaf())))
+    println(value_of_root(Node(left = Leaf(), value = 5, right = Leaf())))
 }

--- a/tests/compiler/kt/matrix_search.kt.out
+++ b/tests/compiler/kt/matrix_search.kt.out
@@ -1,28 +1,28 @@
 fun searchMatrix(matrix: List<List<Int>>, target: Int) : Boolean {
-        val m = matrix.size
-        if ((m == 0)) {
-                return false
-        }
-        val n = matrix[0].size
-        var left = 0
-        var right = ((m * n) - 1)
-        while ((left <= right)) {
-                val mid = (left + (((right - left)) / 2))
-                val row = (mid / n)
-                val col = (mid % n)
-                val value = matrix[row][col]
-                if ((value == target)) {
-                        return true
-                } else if ((value < target)) {
-                        left = (mid + 1)
-                } else {
-                        right = (mid - 1)
-                }
-        }
+    val m = matrix.size
+    if ((m == 0)) {
         return false
+    }
+    val n = matrix[0].size
+    var left = 0
+    var right = ((m * n) - 1)
+    while ((left <= right)) {
+        val mid = (left + (((right - left)) / 2))
+        val row = (mid / n)
+        val col = (mid % n)
+        val value = matrix[row][col]
+        if ((value == target)) {
+            return true
+        } else if ((value < target)) {
+            left = (mid + 1)
+        } else {
+            right = (mid - 1)
+        }
+    }
+    return false
 }
 
 fun main() {
-        println(searchMatrix(listOf(listOf(1, 3, 5, 7), listOf(10, 11, 16, 20), listOf(23, 30, 34, 60)), 3))
-        println(searchMatrix(listOf(listOf(1, 3, 5, 7), listOf(10, 11, 16, 20), listOf(23, 30, 34, 60)), 13))
+    println(searchMatrix(listOf(listOf(1, 3, 5, 7), listOf(10, 11, 16, 20), listOf(23, 30, 34, 60)), 3))
+    println(searchMatrix(listOf(listOf(1, 3, 5, 7), listOf(10, 11, 16, 20), listOf(23, 30, 34, 60)), 13))
 }

--- a/tests/compiler/kt/now_builtin.kt.out
+++ b/tests/compiler/kt/now_builtin.kt.out
@@ -1,3 +1,3 @@
 fun main() {
-        println(((System.currentTimeMillis() * 1000000) > 0))
+    println(((System.currentTimeMillis() * 1000000) > 0))
 }

--- a/tests/compiler/kt/str_builtin.kt.out
+++ b/tests/compiler/kt/str_builtin.kt.out
@@ -1,3 +1,3 @@
 fun main() {
-        println(123.toString())
+    println(123.toString())
 }

--- a/tests/compiler/kt/string_concat.kt.out
+++ b/tests/compiler/kt/string_concat.kt.out
@@ -1,3 +1,3 @@
 fun main() {
-        println(("hello " + "world"))
+    println(("hello " + "world"))
 }

--- a/tests/compiler/kt/string_index.kt.out
+++ b/tests/compiler/kt/string_index.kt.out
@@ -1,6 +1,6 @@
 fun main() {
-        val text = "hello"
-        println(_indexString(text, 1))
+    val text = "hello"
+    println(_indexString(text, 1))
 }
 
 fun _indexString(s: String, i: Int): String {

--- a/tests/compiler/kt/string_negative_index.kt.out
+++ b/tests/compiler/kt/string_negative_index.kt.out
@@ -1,6 +1,6 @@
 fun main() {
-        val text = "hello"
-        println(_indexString(text, -1))
+    val text = "hello"
+    println(_indexString(text, -1))
 }
 
 fun _indexString(s: String, i: Int): String {

--- a/tests/compiler/kt/string_slice.kt.out
+++ b/tests/compiler/kt/string_slice.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        println(_sliceString("hello", 1, 4))
+    println(_sliceString("hello", 1, 4))
 }
 
 fun _sliceString(s: String, i: Int, j: Int): String {

--- a/tests/compiler/kt/test_block.kt.out
+++ b/tests/compiler/kt/test_block.kt.out
@@ -1,9 +1,9 @@
 fun test_addition_works() {
-        val x = (1 + 2)
-        check((x == 3))
+    val x = (1 + 2)
+    check((x == 3))
 }
 
 fun main() {
-        println("ok")
-        test_addition_works()
+    println("ok")
+    test_addition_works()
 }

--- a/tests/compiler/kt/two_sum.kt.out
+++ b/tests/compiler/kt/two_sum.kt.out
@@ -1,17 +1,17 @@
 fun twoSum(nums: List<Int>, target: Int) : List<Int> {
-        val n = nums.size
-        for (i in 0 until n) {
-                for (j in (i + 1) until n) {
-                        if (((nums[i] + nums[j]) == target)) {
-                                return listOf(i, j)
-                        }
-                }
+    val n = nums.size
+    for (i in 0 until n) {
+        for (j in (i + 1) until n) {
+            if (((nums[i] + nums[j]) == target)) {
+                return listOf(i, j)
+            }
         }
-        return listOf(-1, -1)
+    }
+    return listOf(-1, -1)
 }
 
 fun main() {
-        val result = twoSum(listOf(2, 7, 11, 15), 9)
-        println(result[0])
-        println(result[1])
+    val result = twoSum(listOf(2, 7, 11, 15), 9)
+    println(result[0])
+    println(result[1])
 }

--- a/tests/compiler/kt/type_method.kt.out
+++ b/tests/compiler/kt/type_method.kt.out
@@ -1,11 +1,11 @@
 data class Person(val name: String) {
-        fun greet() : String {
-                return ("hi " + name)
-        }
-        
+    fun greet() : String {
+        return ("hi " + name)
+    }
+    
 }
 
 fun main() {
-        val p = Person(name = "Ada")
-        println(p.greet())
+    val p = Person(name = "Ada")
+    println(p.greet())
 }

--- a/tests/compiler/kt/underscore_for_loop.kt.out
+++ b/tests/compiler/kt/underscore_for_loop.kt.out
@@ -1,17 +1,17 @@
 fun main() {
-        var c = 0
-        for (_ in 0 until 2) {
-                c = (c + 1)
-        }
-        for (_ in listOf(1, 2)) {
-                c = (c + 1)
-        }
-        for (_ in "ab") {
-                c = (c + 1)
-        }
-        var m = mutableMapOf("x" to 1, "y" to 2)
-        for (_ in m.keys) {
-                c = (c + 1)
-        }
-        println(c)
+    var c = 0
+    for (_ in 0 until 2) {
+        c = (c + 1)
+    }
+    for (_ in listOf(1, 2)) {
+        c = (c + 1)
+    }
+    for (_ in "ab") {
+        c = (c + 1)
+    }
+    var m = mutableMapOf("x" to 1, "y" to 2)
+    for (_ in m.keys) {
+        c = (c + 1)
+    }
+    println(c)
 }

--- a/tests/compiler/kt/union_inorder.kt.out
+++ b/tests/compiler/kt/union_inorder.kt.out
@@ -3,7 +3,7 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun inorder(t: Tree) : List<Int> {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Leaf -> (listOf()) as List<Int>
@@ -18,7 +18,7 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
-        println(inorder(Node(left = Leaf(), value = 1, right = Node(left = Leaf(), value = 2, right = Leaf()))))
+    println(inorder(Node(left = Leaf(), value = 1, right = Node(left = Leaf(), value = 2, right = Leaf()))))
 }
 
 fun <T> _concat(a: List<T>, b: List<T>): List<T> = a + b

--- a/tests/compiler/kt/union_match.kt.out
+++ b/tests/compiler/kt/union_match.kt.out
@@ -3,7 +3,7 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun isLeaf(t: Tree) : Boolean {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Leaf -> true
@@ -13,6 +13,6 @@ fun isLeaf(t: Tree) : Boolean {
 }
 
 fun main() {
-        println(isLeaf(Leaf()))
-        println(isLeaf(Node(left = Leaf(), value = 1, right = Leaf())))
+    println(isLeaf(Leaf()))
+    println(isLeaf(Node(left = Leaf(), value = 1, right = Leaf())))
 }

--- a/tests/compiler/kt/union_slice.kt.out
+++ b/tests/compiler/kt/union_slice.kt.out
@@ -3,9 +3,9 @@ data class Empty() : Foo
 data class Node(val child: Foo) : Foo
 
 fun listit() : List<Foo> {
-        return listOf(Empty())
+    return listOf(Empty())
 }
 
 fun main() {
-        println(listit().size)
+    println(listit().size)
 }

--- a/tests/compiler/kt/var_assignment.kt.out
+++ b/tests/compiler/kt/var_assignment.kt.out
@@ -1,5 +1,5 @@
 fun main() {
-        var x = 1
-        x = 2
-        println(x)
+    var x = 1
+    x = 2
+    println(x)
 }

--- a/tests/compiler/kt/while_loop.kt.out
+++ b/tests/compiler/kt/while_loop.kt.out
@@ -1,7 +1,7 @@
 fun main() {
-        var i = 0
-        while ((i < 3)) {
-                println(i)
-                i = (i + 1)
-        }
+    var i = 0
+    while ((i < 3)) {
+        println(i)
+        i = (i + 1)
+    }
 }

--- a/tests/compiler/kt/while_membership.kt.out
+++ b/tests/compiler/kt/while_membership.kt.out
@@ -1,17 +1,17 @@
 fun main() {
-        var set: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
-        for (n in listOf(1, 2, 3)) {
-                run {
-                        val _tmp = set.toMutableMap()
-                        _tmp[n] = true
-                        set = _tmp
-                }
+    var set: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
+    for (n in listOf(1, 2, 3)) {
+        run {
+            val _tmp = set.toMutableMap()
+            _tmp[n] = true
+            set = _tmp
         }
-        var i = 1
-        var count = 0
-        while (set.contains(i)) {
-                i = (i + 1)
-                count = (count + 1)
-        }
-        println(count)
+    }
+    var i = 1
+    var count = 0
+    while (set.contains(i)) {
+        i = (i + 1)
+        count = (count + 1)
+    }
+    println(count)
 }

--- a/tests/compiler/valid/break_continue.kt.out
+++ b/tests/compiler/valid/break_continue.kt.out
@@ -1,13 +1,14 @@
 fun main() {
-        val numbers = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
-        for (n in numbers) {
-                if (((n % 2) == 0)) {
-                        continue
-                }
-                if ((n > 7)) {
-                        break
-                }
-                println("odd number:", n)
+    val numbers = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    for (n in numbers) {
+        if (((n % 2) == 0)) {
+            continue
         }
+        if ((n > 7)) {
+            break
+        }
+        println("odd number:", n)
+    }
 }
+
 

--- a/tests/compiler/valid/closure.kt.out
+++ b/tests/compiler/valid/closure.kt.out
@@ -1,11 +1,12 @@
 fun makeAdder(n: Int) : Any {
-        return fun(x: Int) : Int {
-                return (x + n)
+    return fun(x: Int) : Int {
+            return (x + n)
 }
 }
 
 fun main() {
-        val add10 = makeAdder(10)
-        println(add10(7))
+    val add10 = makeAdder(10)
+    println(add10(7))
 }
+
 

--- a/tests/compiler/valid/cross_join.kt.out
+++ b/tests/compiler/valid/cross_join.kt.out
@@ -5,9 +5,9 @@ data class Order(val id: Int, val customerId: Int, val total: Int)
 data class PairInfo(val orderId: Int, val orderCustomerId: Int, val pairedCustomerName: String, val orderTotal: Int)
 
 fun main() {
-        val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
-        val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
-        val result = run {
+    val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+    val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
+    val result = run {
                 val _src = orders
                 val _res = mutableListOf<PairInfo>()
                 for (o in _src) {
@@ -17,10 +17,10 @@ fun main() {
                 }
                 _res
         }
-        println("--- Cross Join: All order-customer pairs ---")
-        for (entry in result) {
-                println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
-        }
+    println("--- Cross Join: All order-customer pairs ---")
+    for (entry in result) {
+        println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
+    }
 }
 
 

--- a/tests/compiler/valid/fold_pure_let.kt.out
+++ b/tests/compiler/valid/fold_pure_let.kt.out
@@ -1,11 +1,11 @@
 fun sumN(n: Int) : Int {
-        return ((n * ((n + 1))) / 2)
+    return ((n * ((n + 1))) / 2)
 }
 
 fun main() {
-        val n = 10
-        println(sumN(n))
-        println(n)
+    val n = 10
+    println(sumN(n))
+    println(n)
 }
 
 

--- a/tests/compiler/valid/for_list_collection.kt.out
+++ b/tests/compiler/valid/for_list_collection.kt.out
@@ -1,6 +1,7 @@
 fun main() {
-        for (n in listOf(1, 2, 3)) {
-                println(n)
-        }
+    for (n in listOf(1, 2, 3)) {
+        println(n)
+    }
 }
+
 

--- a/tests/compiler/valid/for_loop.kt.out
+++ b/tests/compiler/valid/for_loop.kt.out
@@ -1,6 +1,7 @@
 fun main() {
-        for (i in 1 until 4) {
-                println(i)
-        }
+    for (i in 1 until 4) {
+        println(i)
+    }
 }
+
 

--- a/tests/compiler/valid/for_string_collection.kt.out
+++ b/tests/compiler/valid/for_string_collection.kt.out
@@ -1,6 +1,7 @@
 fun main() {
-        for (ch in "hi") {
-                println(ch)
-        }
+    for (ch in "hi") {
+        println(ch)
+    }
 }
+
 

--- a/tests/compiler/valid/fun_call.kt.out
+++ b/tests/compiler/valid/fun_call.kt.out
@@ -1,8 +1,9 @@
 fun add(a: Int, b: Int) : Int {
-        return (a + b)
+    return (a + b)
 }
 
 fun main() {
-        println(add(2, 3))
+    println(add(2, 3))
 }
+
 

--- a/tests/compiler/valid/fun_expr_in_let.kt.out
+++ b/tests/compiler/valid/fun_expr_in_let.kt.out
@@ -1,7 +1,8 @@
 fun main() {
-        val square = fun(x: Int) : Int {
-                return (x * x)
+    val square = fun(x: Int) : Int {
+            return (x * x)
 }
-        println(square(6))
+    println(square(6))
 }
+
 

--- a/tests/compiler/valid/generate_echo.kt.out
+++ b/tests/compiler/valid/generate_echo.kt.out
@@ -1,6 +1,6 @@
 fun main() {
-        val poem = _genText("echo hello", null, null)
-        println(poem)
+    val poem = _genText("echo hello", null, null)
+    println(poem)
 }
 
 fun _genText(prompt: String, model: String?, params: Map<String, Any>?): String {

--- a/tests/compiler/valid/generate_embedding.kt.out
+++ b/tests/compiler/valid/generate_embedding.kt.out
@@ -1,6 +1,6 @@
 fun main() {
-        val vec = _genEmbed("hi", null, null)
-        println(vec.size)
+    val vec = _genEmbed("hi", null, null)
+    println(vec.size)
 }
 
 fun _genEmbed(text: String, model: String?, params: Map<String, Any>?): List<Double> {

--- a/tests/compiler/valid/grouped_expr.kt.out
+++ b/tests/compiler/valid/grouped_expr.kt.out
@@ -1,5 +1,6 @@
 fun main() {
-        val value = (((1 + 2)) * 3)
-        println(value)
+    val value = (((1 + 2)) * 3)
+    println(value)
 }
+
 

--- a/tests/compiler/valid/if_else.kt.out
+++ b/tests/compiler/valid/if_else.kt.out
@@ -1,9 +1,10 @@
 fun main() {
-        val x = 5
-        if ((x > 3)) {
-                println("big")
-        } else {
-                println("small")
-        }
+    val x = 5
+    if ((x > 3)) {
+        println("big")
+    } else {
+        println("small")
+    }
 }
+
 

--- a/tests/compiler/valid/join.kt.out
+++ b/tests/compiler/valid/join.kt.out
@@ -5,9 +5,9 @@ data class Order(val id: Int, val customerId: Int, val total: Int)
 data class PairInfo(val orderId: Int, val customerName: String, val total: Int)
 
 fun main() {
-        val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
-        val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 4, total = 80))
-        val result = run {
+    val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
+    val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300), Order(id = 103, customerId = 4, total = 80))
+    val result = run {
                 val _src = orders
                 val _rows = _query(_src, listOf(
                         _JoinSpec(items = customers, on = { args ->
@@ -22,10 +22,10 @@ PairInfo(orderId = o.id, customerName = c.name, total = o.total)
                         }) )
                 _rows
         }
-        println("--- Orders with customer info ---")
-        for (entry in result) {
-                println("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
-        }
+    println("--- Orders with customer info ---")
+    for (entry in result) {
+        println("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+    }
 }
 
 data class _JoinSpec(

--- a/tests/compiler/valid/join_filter_pag.kt.out
+++ b/tests/compiler/valid/join_filter_pag.kt.out
@@ -3,9 +3,9 @@ data class Person(val id: Int, val name: String)
 data class Purchase(val id: Int, val personId: Int, val total: Int)
 
 fun main() {
-        val people = listOf(Person(id = 1, name = "Alice"), Person(id = 2, name = "Bob"), Person(id = 3, name = "Charlie"))
-        val purchases = listOf(Purchase(id = 1, personId = 1, total = 200), Purchase(id = 2, personId = 1, total = 50), Purchase(id = 3, personId = 2, total = 150), Purchase(id = 4, personId = 3, total = 100), Purchase(id = 5, personId = 2, total = 250))
-        val result = run {
+    val people = listOf(Person(id = 1, name = "Alice"), Person(id = 2, name = "Bob"), Person(id = 3, name = "Charlie"))
+    val purchases = listOf(Purchase(id = 1, personId = 1, total = 200), Purchase(id = 2, personId = 1, total = 50), Purchase(id = 3, personId = 2, total = 150), Purchase(id = 4, personId = 3, total = 100), Purchase(id = 5, personId = 2, total = 250))
+    val result = run {
                 val _src = people
                 val _rows = _query(_src, listOf(
                         _JoinSpec(items = purchases, on = { args ->
@@ -28,9 +28,9 @@ mutableMapOf("person" to p.name, "spent" to o.total)
                         }, skip = 1, take = 2) )
                 _rows
         }
-        for (r in result) {
-                println(r.person, r.spent)
-        }
+    for (r in result) {
+        println(r.person, r.spent)
+    }
 }
 
 data class _JoinSpec(

--- a/tests/compiler/valid/len_builtin.kt.out
+++ b/tests/compiler/valid/len_builtin.kt.out
@@ -1,4 +1,5 @@
 fun main() {
-        println(listOf(1, 2, 3).size)
+    println(listOf(1, 2, 3).size)
 }
+
 

--- a/tests/compiler/valid/let_and_print.kt.out
+++ b/tests/compiler/valid/let_and_print.kt.out
@@ -1,6 +1,7 @@
 fun main() {
-        val a = 10
-        val b: Int = 20
-        println((a + b))
+    val a = 10
+    val b: Int = 20
+    println((a + b))
 }
+
 

--- a/tests/compiler/valid/list_index.kt.out
+++ b/tests/compiler/valid/list_index.kt.out
@@ -1,5 +1,6 @@
 fun main() {
-        val xs = listOf(10, 20, 30)
-        println(xs[1])
+    val xs = listOf(10, 20, 30)
+    println(xs[1])
 }
+
 

--- a/tests/compiler/valid/list_set.kt.out
+++ b/tests/compiler/valid/list_set.kt.out
@@ -1,11 +1,11 @@
 fun main() {
-        var nums = listOf(1, 2)
-        run {
-                val _tmp = nums.toMutableList()
-                _tmp[1] = 3
-                nums = _tmp
-        }
-        println(nums[1])
+    var nums = listOf(1, 2)
+    run {
+        val _tmp = nums.toMutableList()
+        _tmp[1] = 3
+        nums = _tmp
+    }
+    println(nums[1])
 }
 
 

--- a/tests/compiler/valid/local_recursion.kt.out
+++ b/tests/compiler/valid/local_recursion.kt.out
@@ -3,18 +3,18 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun fromList(nums: List<Int>) : Tree {
-        fun helper(lo: Int, hi: Int) : Tree {
-                if ((lo >= hi)) {
-                        return Leaf()
-                }
-                val mid = (((lo + hi)) / 2)
-                return Node(left = helper(lo, mid), value = nums[mid], right = helper((mid + 1), hi))
+    fun helper(lo: Int, hi: Int) : Tree {
+        if ((lo >= hi)) {
+            return Leaf()
         }
-        return helper(0, nums.size)
+        val mid = (((lo + hi)) / 2)
+        return Node(left = helper(lo, mid), value = nums[mid], right = helper((mid + 1), hi))
+    }
+    return helper(0, nums.size)
 }
 
 fun inorder(t: Tree) : List<Int> {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Leaf -> listOf()
@@ -29,7 +29,7 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
-        println(inorder(fromList(listOf(-10, -3, 0, 5, 9))))
+    println(inorder(fromList(listOf(-10, -3, 0, 5, 9))))
 }
 
 fun <T> _concat(a: List<T>, b: List<T>): List<T> = a + b

--- a/tests/compiler/valid/map_index.kt.out
+++ b/tests/compiler/valid/map_index.kt.out
@@ -1,5 +1,6 @@
 fun main() {
-        val scores = mutableMapOf("Alice" to 10, "Bob" to 15)
-        println(scores["Bob"])
+    val scores = mutableMapOf("Alice" to 10, "Bob" to 15)
+    println(scores["Bob"])
 }
+
 

--- a/tests/compiler/valid/map_iterate.kt.out
+++ b/tests/compiler/valid/map_iterate.kt.out
@@ -1,20 +1,20 @@
 fun main() {
-        var m: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
-        run {
-                val _tmp = m.toMutableMap()
-                _tmp[1] = true
-                m = _tmp
-        }
-        run {
-                val _tmp = m.toMutableMap()
-                _tmp[2] = true
-                m = _tmp
-        }
-        var sum = 0
-        for (k in m.keys) {
-                sum = (sum + k)
-        }
-        println(sum)
+    var m: MutableMap<Int, Boolean> = mutableMapOf<Any, Any>()
+    run {
+        val _tmp = m.toMutableMap()
+        _tmp[1] = true
+        m = _tmp
+    }
+    run {
+        val _tmp = m.toMutableMap()
+        _tmp[2] = true
+        m = _tmp
+    }
+    var sum = 0
+    for (k in m.keys) {
+        sum = (sum + k)
+    }
+    println(sum)
 }
 
 

--- a/tests/compiler/valid/map_ops.kt.out
+++ b/tests/compiler/valid/map_ops.kt.out
@@ -1,19 +1,19 @@
 fun main() {
-        var m: MutableMap<Int, Int> = mutableMapOf<Any, Any>()
-        run {
-                val _tmp = m.toMutableMap()
-                _tmp[1] = 10
-                m = _tmp
-        }
-        run {
-                val _tmp = m.toMutableMap()
-                _tmp[2] = 20
-                m = _tmp
-        }
-        if (m.contains(1)) {
-                println(m[1])
-        }
-        println(m[2])
+    var m: MutableMap<Int, Int> = mutableMapOf<Any, Any>()
+    run {
+        val _tmp = m.toMutableMap()
+        _tmp[1] = 10
+        m = _tmp
+    }
+    run {
+        val _tmp = m.toMutableMap()
+        _tmp[2] = 20
+        m = _tmp
+    }
+    if (m.contains(1)) {
+        println(m[1])
+    }
+    println(m[2])
 }
 
 

--- a/tests/compiler/valid/map_set.kt.out
+++ b/tests/compiler/valid/map_set.kt.out
@@ -1,11 +1,11 @@
 fun main() {
-        var scores = mutableMapOf("a" to 1)
-        run {
-                val _tmp = scores.toMutableMap()
-                _tmp["b"] = 2
-                scores = _tmp
-        }
-        println(scores["b"])
+    var scores = mutableMapOf("a" to 1)
+    run {
+        val _tmp = scores.toMutableMap()
+        _tmp["b"] = 2
+        scores = _tmp
+    }
+    println(scores["b"])
 }
 
 

--- a/tests/compiler/valid/match_expr.kt.out
+++ b/tests/compiler/valid/match_expr.kt.out
@@ -1,6 +1,6 @@
 fun main() {
-        val x = 2
-        val label = run {
+    val x = 2
+    val label = run {
                 val _t = x
                 when {
                         _t == 1 -> "one"
@@ -9,6 +9,7 @@ fun main() {
                         else -> "unknown"
                 }
         }
-        println(label)
+    println(label)
 }
+
 

--- a/tests/compiler/valid/print_hello.kt.out
+++ b/tests/compiler/valid/print_hello.kt.out
@@ -1,4 +1,5 @@
 fun main() {
-        println("hello")
+    println("hello")
 }
+
 

--- a/tests/compiler/valid/stream_on_emit.kt.out
+++ b/tests/compiler/valid/stream_on_emit.kt.out
@@ -1,13 +1,13 @@
 fun main() {
-        data class Sensor(val id: String, val temperature: Double)
-        
-        var _SensorStream = _Stream<Sensor>("Sensor")
-        fun _handler_0(ev: Sensor) {
-                val s = ev
-                println(s.id, s.temperature)
-        }
-        _SensorStream.register(::_handler_0)
-        _SensorStream.append(Sensor(id = "sensor-1", temperature = 22.5))
+    data class Sensor(val id: String, val temperature: Double)
+    
+    var _SensorStream = _Stream<Sensor>("Sensor")
+    fun _handler_0(ev: Sensor) {
+        val s = ev
+        println(s.id, s.temperature)
+    }
+    _SensorStream.register(::_handler_0)
+    _SensorStream.append(Sensor(id = "sensor-1", temperature = 22.5))
 }
 
 class _Stream<T>(val name: String) {

--- a/tests/compiler/valid/string_index.kt.out
+++ b/tests/compiler/valid/string_index.kt.out
@@ -1,6 +1,6 @@
 fun main() {
-        val text = "hello"
-        println(_indexString(text, 1))
+    val text = "hello"
+    println(_indexString(text, 1))
 }
 
 fun _indexString(s: String, i: Int): String {

--- a/tests/compiler/valid/test_block.kt.out
+++ b/tests/compiler/valid/test_block.kt.out
@@ -1,11 +1,11 @@
 fun test_addition_works() {
-        val x = (1 + 2)
-        check((x == 3))
+    val x = (1 + 2)
+    check((x == 3))
 }
 
 fun main() {
-        println("ok")
-        test_addition_works()
+    println("ok")
+    test_addition_works()
 }
 
 

--- a/tests/compiler/valid/two_sum.kt.out
+++ b/tests/compiler/valid/two_sum.kt.out
@@ -1,18 +1,19 @@
 fun twoSum(nums: List<Int>, target: Int) : List<Int> {
-        val n = nums.size
-        for (i in 0 until n) {
-                for (j in (i + 1) until n) {
-                        if (((nums[i] + nums[j]) == target)) {
-                                return listOf(i, j)
-                        }
-                }
+    val n = nums.size
+    for (i in 0 until n) {
+        for (j in (i + 1) until n) {
+            if (((nums[i] + nums[j]) == target)) {
+                return listOf(i, j)
+            }
         }
-        return listOf(-1, -1)
+    }
+    return listOf(-1, -1)
 }
 
 fun main() {
-        val result = twoSum(listOf(2, 7, 11, 15), 9)
-        println(result[0])
-        println(result[1])
+    val result = twoSum(listOf(2, 7, 11, 15), 9)
+    println(result[0])
+    println(result[1])
 }
+
 

--- a/tests/compiler/valid/union_inorder.kt.out
+++ b/tests/compiler/valid/union_inorder.kt.out
@@ -3,7 +3,7 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun inorder(t: Tree) : List<Int> {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Leaf -> (listOf()) as List<Int>
@@ -18,7 +18,7 @@ fun inorder(t: Tree) : List<Int> {
 }
 
 fun main() {
-        println(inorder(Node(left = Leaf(), value = 1, right = Node(left = Leaf(), value = 2, right = Leaf()))))
+    println(inorder(Node(left = Leaf(), value = 1, right = Node(left = Leaf(), value = 2, right = Leaf()))))
 }
 
 fun <T> _concat(a: List<T>, b: List<T>): List<T> = a + b

--- a/tests/compiler/valid/union_match.kt.out
+++ b/tests/compiler/valid/union_match.kt.out
@@ -3,7 +3,7 @@ data class Leaf() : Tree
 data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun isLeaf(t: Tree) : Boolean {
-        return run {
+    return run {
                 val _t = t
                 when {
                         _t is Leaf -> true
@@ -13,8 +13,8 @@ fun isLeaf(t: Tree) : Boolean {
 }
 
 fun main() {
-        println(isLeaf(Leaf()))
-        println(isLeaf(Node(left = Leaf(), value = 1, right = Leaf())))
+    println(isLeaf(Leaf()))
+    println(isLeaf(Node(left = Leaf(), value = 1, right = Leaf())))
 }
 
 

--- a/tests/compiler/valid/union_slice.kt.out
+++ b/tests/compiler/valid/union_slice.kt.out
@@ -3,11 +3,11 @@ data class Empty() : Foo
 data class Node(val child: Foo) : Foo
 
 fun listit() : List<Foo> {
-        return listOf(Empty())
+    return listOf(Empty())
 }
 
 fun main() {
-        println(listit().size)
+    println(listit().size)
 }
 
 

--- a/tests/compiler/valid/var_assignment.kt.out
+++ b/tests/compiler/valid/var_assignment.kt.out
@@ -1,6 +1,7 @@
 fun main() {
-        var x = 1
-        x = 2
-        println(x)
+    var x = 1
+    x = 2
+    println(x)
 }
+
 

--- a/tests/compiler/valid/while_loop.kt.out
+++ b/tests/compiler/valid/while_loop.kt.out
@@ -1,8 +1,9 @@
 fun main() {
-        var i = 0
-        while ((i < 3)) {
-                println(i)
-                i = (i + 1)
-        }
+    var i = 0
+    while ((i < 3)) {
+        println(i)
+        i = (i + 1)
+    }
 }
+
 

--- a/tests/dataset/tpc-h/compiler/kt/q1.kt.out
+++ b/tests/dataset/tpc-h/compiler/kt/q1.kt.out
@@ -1,10 +1,10 @@
 fun test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {
-        check((result == listOf(mutableMapOf("returnflag" to "N", "linestatus" to "O", "sum_qty" to 53, "sum_base_price" to 3000, "sum_disc_price" to (950 + 1800), "sum_charge" to (((950 * 1.07)) + ((1800 * 1.05))), "avg_qty" to 26.5, "avg_price" to 1500, "avg_disc" to 0.07500000000000001, "count_order" to 2))))
+    check((result == listOf(mutableMapOf("returnflag" to "N", "linestatus" to "O", "sum_qty" to 53, "sum_base_price" to 3000, "sum_disc_price" to (950 + 1800), "sum_charge" to (((950 * 1.07)) + ((1800 * 1.05))), "avg_qty" to 26.5, "avg_price" to 1500, "avg_disc" to 0.07500000000000001, "count_order" to 2))))
 }
 
 fun main() {
-        val lineitem = listOf(mutableMapOf("l_quantity" to 17, "l_extendedprice" to 1000, "l_discount" to 0.05, "l_tax" to 0.07, "l_returnflag" to "N", "l_linestatus" to "O", "l_shipdate" to "1998-08-01"), mutableMapOf("l_quantity" to 36, "l_extendedprice" to 2000, "l_discount" to 0.1, "l_tax" to 0.05, "l_returnflag" to "N", "l_linestatus" to "O", "l_shipdate" to "1998-09-01"), mutableMapOf("l_quantity" to 25, "l_extendedprice" to 1500, "l_discount" to 0, "l_tax" to 0.08, "l_returnflag" to "R", "l_linestatus" to "F", "l_shipdate" to "1998-09-03"))
-        val result = run {
+    val lineitem = listOf(mutableMapOf("l_quantity" to 17, "l_extendedprice" to 1000, "l_discount" to 0.05, "l_tax" to 0.07, "l_returnflag" to "N", "l_linestatus" to "O", "l_shipdate" to "1998-08-01"), mutableMapOf("l_quantity" to 36, "l_extendedprice" to 2000, "l_discount" to 0.1, "l_tax" to 0.05, "l_returnflag" to "N", "l_linestatus" to "O", "l_shipdate" to "1998-09-01"), mutableMapOf("l_quantity" to 25, "l_extendedprice" to 1500, "l_discount" to 0, "l_tax" to 0.08, "l_returnflag" to "R", "l_linestatus" to "F", "l_shipdate" to "1998-09-03"))
+    val result = run {
                 val _src = lineitem
                 val _rows = _query(_src, listOf(
                 ), _QueryOpts(selectFn = { args ->
@@ -80,8 +80,8 @@ mutableMapOf("returnflag" to g.key.returnflag, "linestatus" to g.key.linestatus,
                 }
                 _res
         }
-        _json(result)
-        test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus()
+    _json(result)
+    test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus()
 }
 
 class _Group(var key: Any?) {


### PR DESCRIPTION
## Summary
- format Kotlin code using ktfmt if available
- fallback to tab-to-space conversion
- use 4-space indentation
- regenerate Kotlin golden files

## Testing
- `GOFLAGS='-tags=slow' go test ./compile/x/kt -run TestKTCompiler_GoldenOutput -update -v`

------
https://chatgpt.com/codex/tasks/task_e_685e2ae15d04832083fad00c0a5bf7e9