### PR TITLE
Improve Swift compiler formatting

### DIFF
--- a/compile/x/swift/README.md
+++ b/compile/x/swift/README.md
@@ -196,6 +196,9 @@ func EnsureSwift() error {
 ```
 【F:compile/swift/tools.go†L10-L45】
 
+`Format` prettifies generated Swift code using `swift-format` when available. `EnsureSwiftFormat` can install the formatter if missing.
+【F:compile/x/swift/tools.go†L61-L130】
+
 ## Building
 
 Generate Swift code from a Mochi program with:

--- a/compile/x/swift/tools.go
+++ b/compile/x/swift/tools.go
@@ -58,20 +58,73 @@ func EnsureSwift() error {
 	return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 }
 
+// EnsureSwiftFormat verifies that the swift-format tool is installed.
+// It tries a best-effort installation using common package managers.
+func EnsureSwiftFormat() error {
+	if _, err := exec.LookPath("swift-format"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "swift-format")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "swift-format")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "swift-format")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "swift-format")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("swift-format"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("swift-format not found")
+}
+
 // Format attempts to pretty-print Swift code using the official
 // `swift-format` tool. If the tool isn't installed or formatting
 // fails, the input is returned unchanged.
 func Format(code []byte) []byte {
-	fmtPath, err := exec.LookPath("swift-format")
-	if err != nil {
-		return code
+	if err := EnsureSwiftFormat(); err == nil {
+		fmtPath, _ := exec.LookPath("swift-format")
+		cmd := exec.Command(fmtPath, "format", "-")
+		cmd.Stdin = bytes.NewReader(code)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err == nil {
+			res := out.Bytes()
+			if len(res) == 0 || res[len(res)-1] != '\n' {
+				res = append(res, '\n')
+			}
+			return res
+		}
 	}
-	cmd := exec.Command(fmtPath, "format", "-")
-	cmd.Stdin = bytes.NewReader(code)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return code
+	res := bytes.ReplaceAll(code, []byte("\t"), []byte("  "))
+	if len(res) == 0 || res[len(res)-1] != '\n' {
+		res = append(res, '\n')
 	}
-	return out.Bytes()
+	return res
 }

--- a/tests/compiler/swift/load_save_json.swift.out
+++ b/tests/compiler/swift/load_save_json.swift.out
@@ -110,22 +110,22 @@ func _toMapSlice(_ v: Any) -> [[String: Any]] {
     return out
 }
 struct Person {
-	var name: String
-	var age: Int
-	var email: String
+  var name: String
+  var age: Int
+  var email: String
 }
 
 func main() {
-	let people: [Person] = _load(nil, ["format": "json"])
-	let adults: [Person] = ({
-	var _res: [Person] = []
-	for p in people {
-		if !(p.age >= 18) { continue }
-		_res.append(p)
-	}
-	var _items = _res
-	return _items
+  let people: [Person] = _load(nil, ["format": "json"])
+  let adults: [Person] = ({
+  var _res: [Person] = []
+  for p in people {
+    if !(p.age >= 18) { continue }
+    _res.append(p)
+  }
+  var _items = _res
+  return _items
 }())
-	_save(_toMapSlice(adults), nil, ["format": "json"])
+  _save(_toMapSlice(adults), nil, ["format": "json"])
 }
 main()


### PR DESCRIPTION
## Summary
- add `EnsureSwiftFormat` for installing `swift-format`
- fallback when `swift-format` is missing by expanding tabs to spaces
- document formatter helper in the Swift backend README
- regenerate `load_save_json.swift.out`

## Testing
- `go test ./compile/x/swift -tags slow -run TestSwiftCompiler_GoldenOutput -args -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e2ed2988c8320a692281535c81263