### PR TITLE
Improve Zig code formatting and add ensure tool

### DIFF
--- a/compile/x/zig/compiler.go
+++ b/compile/x/zig/compiler.go
@@ -115,10 +115,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.writeExpectFunc()
 	c.writeBuiltins()
 	c.buf.WriteString(body)
-	formatted, err := Format(c.buf.Bytes())
-	if err != nil {
-		return c.buf.Bytes(), nil
-	}
+	formatted := Format(c.buf.Bytes())
 	return formatted, nil
 }
 

--- a/tools/zig/tools.go
+++ b/tools/zig/tools.go
@@ -1,0 +1,15 @@
+//go:build ignore
+
+package main
+
+import (
+	"log"
+
+	zig "mochi/compile/x/zig"
+)
+
+func main() {
+	if _, err := zig.EnsureZig(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- standardize Zig formatter usage
- return formatted code directly in Zig compiler
- provide a helper utility to install the Zig toolchain

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e2ed499bc8320bfdd325436771387