### PR TITLE
Fix liveness for Append, update q1 IR

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -99,9 +99,13 @@ func useDef(ins Instr, n int) (use, def []bool) {
 		addUse(ins.C)
 	case OpNeg, OpNegInt, OpNegFloat, OpNot, OpStr, OpExists,
 		OpLen, OpCount, OpAvg, OpSum, OpMin, OpMax, OpValues,
-		OpCast, OpIterPrep, OpNow, OpAppend:
+		OpCast, OpIterPrep, OpNow:
 		addDef(ins.A)
 		addUse(ins.B)
+	case OpAppend:
+		addDef(ins.A)
+		addUse(ins.B)
+		addUse(ins.C)
 	case OpIndex:
 		addDef(ins.A)
 		addUse(ins.B)

--- a/tests/dataset/tpc-h/out/q1.ir.out
+++ b/tests/dataset/tpc-h/out/q1.ir.out
@@ -307,18 +307,10 @@ L4:
   Const        r199, 3000
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
   Const        r200, "sum_disc_price"
-  Const        r201, 950
-  Const        r202, 1800
-  AddFloat     r203, r201, r202
+  Const        r203, 2750
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
   Const        r204, "sum_charge"
-  Const        r205, 950
-  Const        r206, 1.07
-  MulFloat     r207, r205, r206
-  Const        r208, 1800
-  Const        r209, 1.05
-  MulFloat     r210, r208, r209
-  AddFloat     r211, r207, r210
+  Const        r211, 2906.5
   // avg_qty: 26.5,
   Const        r212, "avg_qty"
   Const        r213, 26.5
@@ -369,3 +361,4 @@ L4:
   Equal        r243, r191, r242
   Expect       r243
   Return       r0
+


### PR DESCRIPTION
## Summary
- correct liveness analysis for `OpAppend` so appended value registers aren't dropped
- regenerate IR output for `tpc-h/q1.mochi`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e304960a48320973d3877db5a5471