### PR TITLE
Fix TPCH q3 IR by updating liveness analysis

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -102,6 +102,9 @@ func useDef(ins Instr, n int) (use, def []bool) {
 		OpCast, OpIterPrep, OpNow, OpAppend:
 		addDef(ins.A)
 		addUse(ins.B)
+		if ins.Op == OpAppend {
+			addUse(ins.C)
+		}
 	case OpIndex:
 		addDef(ins.A)
 		addUse(ins.B)

--- a/tests/dataset/tpc-h/out/q3.ir.out
+++ b/tests/dataset/tpc-h/out/q3.ir.out
@@ -310,10 +310,6 @@ L20:
   Move         r196, r195
   // g.key.o_orderdate
   Const        r197, "key"
-  Index        r198, r126, r197
-  Const        r199, "o_orderdate"
-  Index        r200, r198, r199
-  Move         r201, r200
   // sort by [
   MakeList     r202, 2, r196
   Move         r203, r202
@@ -340,11 +336,7 @@ L17:
   Const        r212, 100
   // revenue: 1000.0 * 0.95 + 500.0,
   Const        r213, "revenue"
-  Const        r214, 1000
-  Const        r215, 0.95
-  MulFloat     r216, r214, r215
-  Const        r217, 500
-  AddFloat     r218, r216, r217
+  Const        r218, 1450
   // o_orderdate: "1995-03-14",
   Const        r219, "o_orderdate"
   Const        r220, "1995-03-14"
@@ -371,3 +363,4 @@ L17:
   Equal        r234, r210, r233
   Expect       r234
   Return       r0
+


### PR DESCRIPTION
## Summary
- track the second operand for `Append` in liveness
- update TPCH q3 IR golden file

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCH/q3 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685e3055111c832084e070974c8aecbc