### PR TITLE
Fix VM optimizer and sort for TPCH q4

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -102,6 +102,9 @@ func useDef(ins Instr, n int) (use, def []bool) {
 		OpCast, OpIterPrep, OpNow, OpAppend:
 		addDef(ins.A)
 		addUse(ins.B)
+		if ins.Op == OpAppend {
+			addUse(ins.C)
+		}
 	case OpIndex:
 		addDef(ins.A)
 		addUse(ins.B)

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1053,11 +1053,18 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			pairs := append([]Value(nil), src.List...)
 			sort.SliceStable(pairs, func(i, j int) bool {
-				return valueLess(pairs[i].List[0], pairs[j].List[0])
+				var ai, aj Value
+				if pairs[i].Tag == interpreter.TagList && len(pairs[i].List) > 0 {
+					ai = pairs[i].List[0]
+				}
+				if pairs[j].Tag == interpreter.TagList && len(pairs[j].List) > 0 {
+					aj = pairs[j].List[0]
+				}
+				return valueLess(ai, aj)
 			})
 			out := make([]Value, len(pairs))
 			for i, p := range pairs {
-				if len(p.List) > 1 {
+				if p.Tag == interpreter.TagList && len(p.List) > 1 {
 					out[i] = p.List[1]
 				} else {
 					out[i] = Value{Tag: interpreter.TagNull}


### PR DESCRIPTION
## Summary
- handle `OpAppend` operand in liveness analysis so values appended are not removed
- simplify `OpSort` to ignore malformed pairs while returning null
- restore TPCH query 4 IR output

## Testing
- `go test -tags slow ./tests/vm -run "TPCH/q4" -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685e305c25688320952d7988c21f5a4d