### PR TITLE
Fix IR disassembly newline handling

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -452,7 +452,10 @@ func (p *Program) Disassemble(src string) string {
 		}
 		b.WriteByte('\n')
 	}
-	return b.String()
+	out := b.String()
+	out = strings.TrimRight(out, "\n")
+	out += "\n"
+	return out
 }
 
 type VM struct {


### PR DESCRIPTION
## Summary
- trim extra trailing newline when disassembling VM programs

## Testing
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685e3a4deaf4832082049c5285c5a30b