### PR TITLE
Fix q4 disassembly

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -431,6 +431,8 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpCount:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
+			case OpExists:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpAvg, OpSum, OpMin, OpMax:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpExpect:

--- a/tests/dataset/tpc-h/out/q4.ir.out
+++ b/tests/dataset/tpc-h/out/q4.ir.out
@@ -90,7 +90,7 @@ L7:
   Jump         L8
 L5:
   // where exists(
-  Exists       53,32,0,0
+  Exists       r53, r32
   JumpIfFalse  r53, L9
   // from o in date_filtered_orders
   Append       r54, r26, r14
@@ -183,7 +183,7 @@ L15:
   Jump         L15
 L14:
   // order by g.key
-  Sort         108,58,0,0
+  Sort         r108, r58
   // from o in late_orders
   Move         r58, r108
   // let result =


### PR DESCRIPTION
## Summary
- print registers for `OpExists` in the VM disassembler
- update TPCH q4 IR golden output

## Testing
- `go test ./tests/vm -run TestVM_TPCH/q4.mochi -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_685e3aba65d08320992539afcb67a421