### PR TITLE
Fix VM disassembly newline

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -452,7 +452,9 @@ func (p *Program) Disassemble(src string) string {
 		}
 		b.WriteByte('\n')
 	}
-	return b.String()
+	out := b.String()
+	out = strings.TrimRight(out, "\n") + "\n"
+	return out
 }
 
 type VM struct {


### PR DESCRIPTION
## Summary
- ensure Disassemble ends with a single newline to avoid blank line in output

## Testing
- `go test ./...`
- `go test ./tests/vm -tags slow -run "TestVM_TPCH/q5.mochi"`

------
https://chatgpt.com/codex/tasks/task_e_685e35b2f1a883209ebcd179d8154520