### PR TITLE
Fix liveness for OpAppend and regenerate Q13 IR

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -99,9 +99,13 @@ func useDef(ins Instr, n int) (use, def []bool) {
 		addUse(ins.C)
 	case OpNeg, OpNegInt, OpNegFloat, OpNot, OpStr, OpExists,
 		OpLen, OpCount, OpAvg, OpSum, OpMin, OpMax, OpValues,
-		OpCast, OpIterPrep, OpNow, OpAppend:
+		OpCast, OpIterPrep, OpNow:
 		addDef(ins.A)
 		addUse(ins.B)
+	case OpAppend:
+		addDef(ins.A)
+		addUse(ins.B)
+		addUse(ins.C)
 	case OpIndex:
 		addDef(ins.A)
 		addUse(ins.B)

--- a/tests/dataset/tpc-h/out/q13.ir.out
+++ b/tests/dataset/tpc-h/out/q13.ir.out
@@ -172,3 +172,4 @@ L10:
   Equal        r102, r100, r101
   Expect       r102
   Return       r0
+


### PR DESCRIPTION
## Summary
- correct liveness analysis for `OpAppend` so that the appended element register
  is marked as used
- regenerate TPCH q13 IR output

## Testing
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/mochi run tests/dataset/tpc-h/q13.mochi`

------
https://chatgpt.com/codex/tasks/task_e_685e3076126083208c27c8d38b68499d