### PR TITLE
Improve Smalltalk formatting

### DIFF
--- a/compile/x/st/format.go
+++ b/compile/x/st/format.go
@@ -3,12 +3,28 @@ package stcode
 import (
 	"bufio"
 	"bytes"
+	"os/exec"
 	"strings"
 )
 
 // format takes generated Smalltalk code and adjusts spacing for readability.
 func format(code []byte) []byte {
-	// convert tabs to four spaces
+	if err := EnsureFormatter(); err == nil {
+		if path, err := exec.LookPath("gst-format"); err == nil {
+			cmd := exec.Command(path)
+			cmd.Stdin = bytes.NewReader(code)
+			var out bytes.Buffer
+			cmd.Stdout = &out
+			if err := cmd.Run(); err == nil {
+				res := out.Bytes()
+				if len(res) == 0 || res[len(res)-1] != '\n' {
+					res = append(res, '\n')
+				}
+				return res
+			}
+		}
+	}
+	// convert tabs to four spaces and trim trailing whitespace
 	s := strings.ReplaceAll(string(code), "\t", "    ")
 	var buf bytes.Buffer
 	scanner := bufio.NewScanner(strings.NewReader(s))

--- a/compile/x/st/tools.go
+++ b/compile/x/st/tools.go
@@ -116,3 +116,19 @@ func buildSmalltalkFromSource() error {
 	}
 	return nil
 }
+
+// EnsureFormatter checks for the gst-format command, attempting to
+// install it via EnsureSmalltalk if missing. It returns an error if the
+// formatter remains unavailable.
+func EnsureFormatter() error {
+	if _, err := exec.LookPath("gst-format"); err == nil {
+		return nil
+	}
+	if err := EnsureSmalltalk(); err != nil {
+		return err
+	}
+	if _, err := exec.LookPath("gst-format"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("gst-format not found")
+}

--- a/examples/leetcode-out/st/1/two-sum.st
+++ b/examples/leetcode-out/st/1/two-sum.st
@@ -2,18 +2,18 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 twoSum: nums target: target | i j n |
-	n := nums size.
-	0 to: n - 1 do: [:i |
-		(i + 1) to: n - 1 do: [:j |
-			((((nums at: i + 1) + (nums at: j + 1)) = target)) ifTrue: [
-				^ Array with: i with: j
-			]
-			.
-		]
-		.
-	]
-	.
-	^ Array with: (1 negated) with: (1 negated)
+    n := (nums) size.
+    0 to: n - 1 do: [:i |
+        (i + 1) to: n - 1 do: [:j |
+            ((((nums at: i + 1) + (nums at: j + 1)) = target)) ifTrue: [
+                ^ Array with: i with: j
+            ]
+            .
+        ]
+        .
+    ]
+    .
+    ^ Array with: (1 negated) with: (1 negated)
 !
 
 !!

--- a/examples/leetcode-out/st/10/regular-expression-matching.st
+++ b/examples/leetcode-out/st/10/regular-expression-matching.st
@@ -1,67 +1,108 @@
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'mochi'!
-isMatch: s p: p | dp first i i2 j j2 m n row star |
-	m := s size.
-	n := p size.
-	dp := Array new.
-	i := 0.
-	[(i <= m)] whileTrue: [
-		row := Array new.
-		j := 0.
-		[(j <= n)] whileTrue: [
-			row := ((row) , (Array with: false)).
-			j := (j + 1).
-		]
-		.
-		dp := ((dp) , (Array with: row)).
-		i := (i + 1).
-	]
-	.
-	dp at: m + 1 put: true.
-	i2 := m.
-	[(i2 >= 0)] whileTrue: [
-		j2 := (n - 1).
-		[(j2 >= 0)] whileTrue: [
-			first := false.
-			((i2 < m)) ifTrue: [
-				(((((p at: j2 + 1) = (s at: i2 + 1))) or: [(((p at: j2 + 1) = '.'))])) ifTrue: [
-					first := true.
-				]
-				.
-			]
-			.
-			star := false.
-			(((j2 + 1) < n)) ifTrue: [
-				(((p at: (j2 + 1) + 1) = '*')) ifTrue: [
-					star := true.
-				]
-				.
-			]
-			.
-			(star) ifTrue: [
-				((((dp at: i2 + 1) at: (j2 + 2) + 1) or: [((first and: [((dp at: (i2 + 1) + 1) at: j2 + 1)]))])) ifTrue: [
-					dp at: i2 + 1 put: true.
-				] ifFalse: [
-					dp at: i2 + 1 put: false.
-				]
-				.
-			] ifFalse: [
-				((first and: [((dp at: (i2 + 1) + 1) at: (j2 + 1) + 1)])) ifTrue: [
-					dp at: i2 + 1 put: true.
-				] ifFalse: [
-					dp at: i2 + 1 put: false.
-				]
-				.
-			]
-			.
-			j2 := (j2 - 1).
-		]
-		.
-		i2 := (i2 - 1).
-	]
-	.
-	^ ((dp at: 0 + 1) at: 0 + 1)
+isMatch: s p: p | dp first i i2 j j2 m n ok row star |
+    m := (s) size.
+    n := (p) size.
+    dp := Array new.
+    i := 0.
+    [(i <= m)] whileTrue: [
+        row := Array new.
+        j := 0.
+        [(j <= n)] whileTrue: [
+            row := ((row) , (Array with: false)).
+            j := (j + 1).
+        ]
+        .
+        dp := ((dp) , (Array with: row)).
+        i := (i + 1).
+    ]
+    .
+    dp at: m + 1 put: true.
+    i2 := m.
+    [(i2 >= 0)] whileTrue: [
+        j2 := (n - 1).
+        [(j2 >= 0)] whileTrue: [
+            first := false.
+            ((i2 < m)) ifTrue: [
+                (((((p at: j2 + 1) = (s at: i2 + 1))) or: [(((p at: j2 + 1) = '.'))])) ifTrue: [
+                    first := true.
+                ]
+                .
+            ]
+            .
+            star := false.
+            (((j2 + 1) < n)) ifTrue: [
+                (((p at: (j2 + 1) + 1) = '*')) ifTrue: [
+                    star := true.
+                ]
+                .
+            ]
+            .
+            (star) ifTrue: [
+                ok := false.
+                (((dp at: i2 + 1) at: (j2 + 2) + 1)) ifTrue: [
+                    ok := true.
+                ] ifFalse: [
+                    (first) ifTrue: [
+                        (((dp at: (i2 + 1) + 1) at: j2 + 1)) ifTrue: [
+                            ok := true.
+                        ]
+                        .
+                    ]
+                    .
+                ]
+                .
+                dp at: i2 + 1 put: ok.
+            ] ifFalse: [
+                ok := false.
+                (first) ifTrue: [
+                    (((dp at: (i2 + 1) + 1) at: (j2 + 1) + 1)) ifTrue: [
+                        ok := true.
+                    ]
+                    .
+                ]
+                .
+                dp at: i2 + 1 put: ok.
+            ]
+            .
+            j2 := (j2 - 1).
+        ]
+        .
+        i2 := (i2 - 1).
+    ]
+    .
+    ^ ((dp at: 0 + 1) at: 0 + 1)
+!
+
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main isMatch: ('aa') p: ('a')) = false)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main isMatch: ('aa') p: ('a*')) = true)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_3
+    (((Main isMatch: ('ab') p: ('.*')) = true)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_4
+    (((Main isMatch: ('aab') p: ('c*a*b')) = true)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_5
+    (((Main isMatch: ('mississippi') p: ('mis*is*p*.')) = false)) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_example_3.
+Main test_example_4.
+Main test_example_5.

--- a/examples/leetcode-out/st/2/add-two-numbers.st
+++ b/examples/leetcode-out/st/2/add-two-numbers.st
@@ -2,30 +2,48 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 addTwoNumbers: l1 l2: l2 | carry digit i j result sum x y |
-	i := 0.
-	j := 0.
-	carry := 0.
-	result := Array new.
-	[(((((i < l1 size) or: [j]) < l2 size) or: [carry]) > 0)] whileTrue: [
-		x := 0.
-		((i < l1 size)) ifTrue: [
-			x := (l1 at: i + 1).
-			i := (i + 1).
-		]
-		.
-		y := 0.
-		((j < l2 size)) ifTrue: [
-			y := (l2 at: j + 1).
-			j := (j + 1).
-		]
-		.
-		sum := ((x + y) + carry).
-		digit := (sum \\ 10).
-		carry := (sum / 10).
-		result := ((result) , (Array with: digit)).
-	]
-	.
-	^ result
+    i := 0.
+    j := 0.
+    carry := 0.
+    result := Array new.
+    [(((((i < (l1) size) or: [j]) < (l2) size) or: [carry]) > 0)] whileTrue: [
+        x := 0.
+        ((i < (l1) size)) ifTrue: [
+            x := (l1 at: i + 1).
+            i := (i + 1).
+        ]
+        .
+        y := 0.
+        ((j < (l2) size)) ifTrue: [
+            y := (l2 at: j + 1).
+            j := (j + 1).
+        ]
+        .
+        sum := ((x + y) + carry).
+        digit := (sum \\ 10).
+        carry := (sum / 10).
+        result := ((result) , (Array with: digit)).
+    ]
+    .
+    ^ result
+!
+
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main addTwoNumbers: (Array with: 2 with: 4 with: 3) l2: (Array with: 5 with: 6 with: 4)) = Array with: 7 with: 0 with: 8)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main addTwoNumbers: (Array with: 0) l2: (Array with: 0)) = Array with: 0)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_3
+    (((Main addTwoNumbers: (Array with: 9 with: 9 with: 9 with: 9 with: 9 with: 9 with: 9) l2: (Array with: 9 with: 9 with: 9 with: 9)) = Array with: 8 with: 9 with: 9 with: 9 with: 0 with: 0 with: 0 with: 1)) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_example_3.

--- a/examples/leetcode-out/st/3/longest-substring-without-repeating-characters.st
+++ b/examples/leetcode-out/st/3/longest-substring-without-repeating-characters.st
@@ -2,29 +2,65 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 lengthOfLongestSubstring: s | best i j length n start |
-	n := s size.
-	start := 0.
-	best := 0.
-	i := 0.
-	[(i < n)] whileTrue: [
-		j := start.
-		[(j < i)] whileTrue: [
-			(((s at: j + 1) = (s at: i + 1))) ifTrue: [
-				start := (j + 1).
-			]
-			.
-			j := (j + 1).
-		]
-		.
-		length := ((i - start) + 1).
-		((length > best)) ifTrue: [
-			best := length.
-		]
-		.
-		i := (i + 1).
-	]
-	.
-	^ best
+    n := (s) size.
+    start := 0.
+    best := 0.
+    i := 0.
+    [
+        [(i < n)] whileTrue: [
+            [
+                j := start.
+                [
+                    [(j < i)] whileTrue: [
+                        [
+                            (((s at: j + 1) = (s at: i + 1))) ifTrue: [
+                                start := (j + 1).
+                                BreakSignal signal
+                            ]
+                            .
+                            j := (j + 1).
+                        ] on: ContinueSignal do: [:ex | ]
+                    ]
+                ] on: BreakSignal do: [:ex | ]
+                .
+                length := ((i - start) + 1).
+                ((length > best)) ifTrue: [
+                    best := length.
+                ]
+                .
+                i := (i + 1).
+            ] on: ContinueSignal do: [:ex | ]
+        ]
+    ] on: BreakSignal do: [:ex | ]
+    .
+    ^ best
 !
 
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main lengthOfLongestSubstring: ('abcabcbb')) = 3)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main lengthOfLongestSubstring: ('bbbbb')) = 1)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_3
+    (((Main lengthOfLongestSubstring: ('pwwkew')) = 3)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_empty_string
+    (((Main lengthOfLongestSubstring: ('')) = 0)) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #BreakSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'runtime'!
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_example_3.
+Main test_empty_string.

--- a/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
+++ b/examples/leetcode-out/st/4/median-of-two-sorted-arrays.st
@@ -2,25 +2,49 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 findMedianSortedArrays: nums1 nums2: nums2 | i j merged mid1 mid2 total |
-	merged := Array new.
-	i := 0.
-	j := 0.
-	[(((i < nums1 size) or: [j]) < nums2 size)] whileTrue: [
-		((j >= nums2 size)) ifTrue: [
-			merged := ((merged) , (Array with: (nums1 at: i + 1))).
-			i := (i + 1).
-		]
-		.
-	]
-	.
-	total := merged size.
-	(((total \\ 2) = 1)) ifTrue: [
-		^ (merged at: (total / 2) + 1)
-	]
-	.
-	mid1 := (merged at: ((total / 2) - 1) + 1).
-	mid2 := (merged at: (total / 2) + 1).
-	^ (((mid1 + mid2)) / 2.000000)
+    merged := Array new.
+    i := 0.
+    j := 0.
+    [(((i < (nums1) size) or: [j]) < (nums2) size)] whileTrue: [
+        ((j >= (nums2) size)) ifTrue: [
+            merged := ((merged) , (Array with: (nums1 at: i + 1))).
+            i := (i + 1).
+        ]
+        .
+    ]
+    .
+    total := (merged) size.
+    (((total \\ 2) = 1)) ifTrue: [
+        ^ (Main _cast: 'float' value: (merged at: (total / 2) + 1))
+    ]
+    .
+    mid1 := (merged at: ((total / 2) - 1) + 1).
+    mid2 := (merged at: (total / 2) + 1).
+    ^ ((Main _cast: 'float' value: ((mid1 + mid2))) / 2.000000)
+!
+
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main findMedianSortedArrays: (Array with: 1 with: 3) nums2: (Array with: 2)) = 2.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main findMedianSortedArrays: (Array with: 1 with: 2) nums2: (Array with: 3 with: 4)) = 2.500000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_empty_first
+    (((Main findMedianSortedArrays: ((Main _cast: '' value: Array new)) nums2: (Array with: 1)) = 1.000000)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_empty_second
+    (((Main findMedianSortedArrays: (Array with: 2) nums2: ((Main _cast: '' value: Array new))) = 2.000000)) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_empty_first.
+Main test_empty_second.

--- a/examples/leetcode-out/st/5/longest-palindromic-substring.st
+++ b/examples/leetcode-out/st/5/longest-palindromic-substring.st
@@ -2,45 +2,79 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 expand: s left: left right: right | l n r |
-	l := left.
-	r := right.
-	n := s size.
-	[(((l >= 0) and: [r]) < n)] whileTrue: [
-		(((s at: l + 1) ~= (s at: r + 1))) ifTrue: [
-		]
-		.
-		l := (l - 1).
-		r := (r + 1).
-	]
-	.
-	^ ((r - l) - 1)
+    l := left.
+    r := right.
+    n := (s) size.
+    [
+        [(((l >= 0) and: [r]) < n)] whileTrue: [
+            [
+                (((s at: l + 1) ~= (s at: r + 1))) ifTrue: [
+                    BreakSignal signal
+                ]
+                .
+                l := (l - 1).
+                r := (r + 1).
+            ] on: ContinueSignal do: [:ex | ]
+        ]
+    ] on: BreakSignal do: [:ex | ]
+    .
+    ^ ((r - l) - 1)
 !
 
 !Main class methodsFor: 'mochi'!
 longestPalindrome: s | end i l len1 len2 n start |
-	((s size <= 1)) ifTrue: [
-		^ s
-	]
-	.
-	start := 0.
-	end := 0.
-	n := s size.
-	0 to: n - 1 do: [:i |
-		len1 := (Main expand: (s) left: (i) right: (i)).
-		len2 := (Main expand: (s) left: (i) right: ((i + 1))).
-		l := len1.
-		((len2 > len1)) ifTrue: [
-			l := len2.
-		]
-		.
-		((l > ((end - start)))) ifTrue: [
-			start := (i - ((((l - 1)) / 2))).
-			end := (i + ((l / 2))).
-		]
-		.
-	]
-	.
-	^ (s copyFrom: (start + 1) to: (end + 1))
+    (((s) size <= 1)) ifTrue: [
+        ^ s
+    ]
+    .
+    start := 0.
+    end := 0.
+    n := (s) size.
+    0 to: n - 1 do: [:i |
+        len1 := (Main expand: (s) left: (i) right: (i)).
+        len2 := (Main expand: (s) left: (i) right: ((i + 1))).
+        l := len1.
+        ((len2 > len1)) ifTrue: [
+            l := len2.
+        ]
+        .
+        ((l > ((end - start)))) ifTrue: [
+            start := (i - ((((l - 1)) / 2))).
+            end := (i + ((l / 2))).
+        ]
+        .
+    ]
+    .
+    ^ (s copyFrom: (start + 1) to: (end + 1))
 !
 
+!Main class methodsFor: 'tests'!
+test_example_1
+    ans := (Main longestPalindrome: ('babad')).
+    ((((ans = 'bab') or: [ans]) = 'aba')) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main longestPalindrome: ('cbbd')) = 'bb')) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_single_char
+    (((Main longestPalindrome: ('a')) = 'a')) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_two_chars
+    ans := (Main longestPalindrome: ('ac')).
+    ((((ans = 'a') or: [ans]) = 'c')) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #BreakSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'runtime'!
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_single_char.
+Main test_two_chars.

--- a/examples/leetcode-out/st/6/zigzag-conversion.st
+++ b/examples/leetcode-out/st/6/zigzag-conversion.st
@@ -2,34 +2,52 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 convert: s numRows: numRows | ch curr i result row rows step |
-	((((numRows <= 1) or: [numRows]) >= s size)) ifTrue: [
-		^ s
-	]
-	.
-	rows := Array new.
-	i := 0.
-	[(i < numRows)] whileTrue: [
-		rows := ((rows) , (Array with: '')).
-		i := (i + 1).
-	]
-	.
-	curr := 0.
-	step := 1.
-	s do: [:ch |
-		rows at: curr + 1 put: ((rows at: curr + 1) + ch).
-		((curr = 0)) ifTrue: [
-			step := 1.
-		]
-		.
-		curr := (curr + step).
-	]
-	.
-	result := ''.
-	rows do: [:row |
-		result := (result + row).
-	]
-	.
-	^ result
+    ((((numRows <= 1) or: [numRows]) >= (s) size)) ifTrue: [
+        ^ s
+    ]
+    .
+    rows := Array new.
+    i := 0.
+    [(i < numRows)] whileTrue: [
+        rows := ((rows) , (Array with: '')).
+        i := (i + 1).
+    ]
+    .
+    curr := 0.
+    step := 1.
+    (s) do: [:ch |
+        rows at: curr + 1 put: ((rows at: curr + 1) + ch).
+        ((curr = 0)) ifTrue: [
+            step := 1.
+        ]
+        .
+        curr := (curr + step).
+    ]
+    .
+    result := ''.
+    (rows) do: [:row |
+        result := (result + row).
+    ]
+    .
+    ^ result
+!
+
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main convert: ('PAYPALISHIRING') numRows: (3)) = 'PAHNAPLSIIGYIR')) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main convert: ('PAYPALISHIRING') numRows: (4)) = 'PINALSIGYAHRPI')) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_single_row
+    (((Main convert: ('A') numRows: (1)) = 'A')) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_single_row.

--- a/examples/leetcode-out/st/7/reverse-integer.st
+++ b/examples/leetcode-out/st/7/reverse-integer.st
@@ -2,26 +2,50 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 reverse: x | digit n rev sign |
-	sign := 1.
-	n := x.
-	((n < 0)) ifTrue: [
-		sign := (1 negated).
-		n := (n negated).
-	]
-	.
-	rev := 0.
-	[(n ~= 0)] whileTrue: [
-		digit := (n \\ 10).
-		rev := ((rev * 10) + digit).
-		n := (n / 10).
-	]
-	.
-	rev := (rev * sign).
-	((((rev < (((2147483647 negated) - 1))) or: [rev]) > 2147483647)) ifTrue: [
-		^ 0
-	]
-	.
-	^ rev
+    sign := 1.
+    n := x.
+    ((n < 0)) ifTrue: [
+        sign := (1 negated).
+        n := (n negated).
+    ]
+    .
+    rev := 0.
+    [(n ~= 0)] whileTrue: [
+        digit := (n \\ 10).
+        rev := ((rev * 10) + digit).
+        n := (n / 10).
+    ]
+    .
+    rev := (rev * sign).
+    ((((rev < (((2147483647 negated) - 1))) or: [rev]) > 2147483647)) ifTrue: [
+        ^ 0
+    ]
+    .
+    ^ rev
+!
+
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main reverse: (123)) = 321)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main reverse: ((123 negated))) = ((321 negated)))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_3
+    (((Main reverse: (120)) = 21)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_overflow
+    (((Main reverse: (1534236469)) = 0)) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_example_3.
+Main test_overflow.

--- a/examples/leetcode-out/st/8/string-to-integer-atoi.st
+++ b/examples/leetcode-out/st/8/string-to-integer-atoi.st
@@ -2,87 +2,133 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 digit: ch
-	((ch = '0')) ifTrue: [
-		^ 0
-	]
-	.
-	((ch = '1')) ifTrue: [
-		^ 1
-	]
-	.
-	((ch = '2')) ifTrue: [
-		^ 2
-	]
-	.
-	((ch = '3')) ifTrue: [
-		^ 3
-	]
-	.
-	((ch = '4')) ifTrue: [
-		^ 4
-	]
-	.
-	((ch = '5')) ifTrue: [
-		^ 5
-	]
-	.
-	((ch = '6')) ifTrue: [
-		^ 6
-	]
-	.
-	((ch = '7')) ifTrue: [
-		^ 7
-	]
-	.
-	((ch = '8')) ifTrue: [
-		^ 8
-	]
-	.
-	((ch = '9')) ifTrue: [
-		^ 9
-	]
-	.
-	^ (1 negated)
+    ((ch = '0')) ifTrue: [
+        ^ 0
+    ]
+    .
+    ((ch = '1')) ifTrue: [
+        ^ 1
+    ]
+    .
+    ((ch = '2')) ifTrue: [
+        ^ 2
+    ]
+    .
+    ((ch = '3')) ifTrue: [
+        ^ 3
+    ]
+    .
+    ((ch = '4')) ifTrue: [
+        ^ 4
+    ]
+    .
+    ((ch = '5')) ifTrue: [
+        ^ 5
+    ]
+    .
+    ((ch = '6')) ifTrue: [
+        ^ 6
+    ]
+    .
+    ((ch = '7')) ifTrue: [
+        ^ 7
+    ]
+    .
+    ((ch = '8')) ifTrue: [
+        ^ 8
+    ]
+    .
+    ((ch = '9')) ifTrue: [
+        ^ 9
+    ]
+    .
+    ^ (1 negated)
 !
 
 !Main class methodsFor: 'mochi'!
 myAtoi: s | ch d i n result sign |
-	i := 0.
-	n := s size.
-	[(((i < n) and: [(s at: i + 1)]) = (' ' at: 0 + 1))] whileTrue: [
-		i := (i + 1).
-	]
-	.
-	sign := 1.
-	(((i < n) and: [(((((s at: i + 1) = ('+' at: 0 + 1)) or: [(s at: i + 1)]) = ('-' at: 0 + 1)))])) ifTrue: [
-		(((s at: i + 1) = ('-' at: 0 + 1))) ifTrue: [
-			sign := (1 negated).
-		]
-		.
-		i := (i + 1).
-	]
-	.
-	result := 0.
-	[(i < n)] whileTrue: [
-		ch := (s copyFrom: (i + 1) to: (i + 1)).
-		d := (Main digit: (ch)).
-		((d < 0)) ifTrue: [
-		]
-		.
-		result := ((result * 10) + d).
-		i := (i + 1).
-	]
-	.
-	result := (result * sign).
-	((result > 2147483647)) ifTrue: [
-		^ 2147483647
-	]
-	.
-	((result < ((2147483648 negated)))) ifTrue: [
-		^ (2147483648 negated)
-	]
-	.
-	^ result
+    i := 0.
+    n := (s) size.
+    [(((i < n) and: [(s at: i + 1)]) = (Main __index_string: ' ' idx: 0))] whileTrue: [
+        i := (i + 1).
+    ]
+    .
+    sign := 1.
+    (((i < n) and: [(((((s at: i + 1) = (Main __index_string: '+' idx: 0)) or: [(s at: i + 1)]) = (Main __index_string: '-' idx: 0)))])) ifTrue: [
+        (((s at: i + 1) = (Main __index_string: '-' idx: 0))) ifTrue: [
+            sign := (1 negated).
+        ]
+        .
+        i := (i + 1).
+    ]
+    .
+    result := 0.
+    [
+        [(i < n)] whileTrue: [
+            [
+                ch := (s copyFrom: (i + 1) to: (i + 1)).
+                d := (Main digit: (ch)).
+                ((d < 0)) ifTrue: [
+                    BreakSignal signal
+                ]
+                .
+                result := ((result * 10) + d).
+                i := (i + 1).
+            ] on: ContinueSignal do: [:ex | ]
+        ]
+    ] on: BreakSignal do: [:ex | ]
+    .
+    result := (result * sign).
+    ((result > 2147483647)) ifTrue: [
+        ^ 2147483647
+    ]
+    .
+    ((result < ((2147483648 negated)))) ifTrue: [
+        ^ (2147483648 negated)
+    ]
+    .
+    ^ result
 !
 
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main myAtoi: ('42')) = 42)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main myAtoi: ('   -42')) = ((42 negated)))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_3
+    (((Main myAtoi: ('4193 with words')) = 4193)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_4
+    (((Main myAtoi: ('words and 987')) = 0)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_5
+    (((Main myAtoi: ('-91283472332')) = ((2147483648 negated)))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #BreakSignal instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'runtime'!
+__index_string: s idx: i
+    | idx n |
+    idx := i.
+    n := s size.
+    idx < 0 ifTrue: [ idx := idx + n ].
+    (idx < 0 or: [ idx >= n ]) ifTrue: [ self error: 'index out of range' ].
+    ^ (s at: idx + 1) asString
+!
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_example_3.
+Main test_example_4.
+Main test_example_5.

--- a/examples/leetcode-out/st/9/palindrome-number.st
+++ b/examples/leetcode-out/st/9/palindrome-number.st
@@ -2,20 +2,44 @@ Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDict
 
 !Main class methodsFor: 'mochi'!
 isPalindrome: x | i n s |
-	((x < 0)) ifTrue: [
-		^ false
-	]
-	.
-	s := (x printString).
-	n := s size.
-	0 to: (n / 2) - 1 do: [:i |
-		(((s at: i + 1) ~= (s at: ((n - 1) - i) + 1))) ifTrue: [
-			^ false
-		]
-		.
-	]
-	.
-	^ true
+    ((x < 0)) ifTrue: [
+        ^ false
+    ]
+    .
+    s := (x printString).
+    n := (s) size.
+    0 to: (n / 2) - 1 do: [:i |
+        (((s at: i + 1) ~= (s at: ((n - 1) - i) + 1))) ifTrue: [
+            ^ false
+        ]
+        .
+    ]
+    .
+    ^ true
+!
+
+!Main class methodsFor: 'tests'!
+test_example_1
+    (((Main isPalindrome: (121)) = true)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_2
+    (((Main isPalindrome: ((121 negated))) = false)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_example_3
+    (((Main isPalindrome: (10)) = false)) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'tests'!
+test_zero
+    (((Main isPalindrome: (0)) = true)) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!
+Main test_example_1.
+Main test_example_2.
+Main test_example_3.
+Main test_zero.


### PR DESCRIPTION
## Summary
- improve Smalltalk backend formatting
- add `EnsureFormatter` helper
- regenerate existing `.st` outputs for LeetCode examples

## Testing
- `go test ./...` *(fails: TestLuaCompiler_TPCHQ1)*

------
https://chatgpt.com/codex/tasks/task_e_685e2ec1a4448320a92a15e81b854524