### PR TITLE
Improve Go formatting tools

### DIFF
--- a/tests/compiler/go/fold_pure_let.go.out
+++ b/tests/compiler/go/fold_pure_let.go.out
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"mochi/runtime/data"
 )
 
 func sum(n int) int {


### PR DESCRIPTION
## Summary
- update Go code formatter to use `go/format` then goimports if available
- include helper to ensure a formatter exists
- regenerate golden Go output for fold_pure_let

## Testing
- `go test ./compile/go -tags slow -run TestGoCompiler_GoldenOutput -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e40ccdfa4832090666bb5c59d7ab7