### PR TITLE
Improve clang-format integration for C backend

### DIFF
--- a/compile/x/c/tools.go
+++ b/compile/x/c/tools.go
@@ -125,6 +125,12 @@ func EnsureClangFormat() error {
 // FormatC runs clang-format on the given source code if available. If the
 // formatter is missing or fails, the input is returned unchanged.
 func FormatC(src []byte) []byte {
+	if err := EnsureClangFormat(); err != nil {
+		if len(src) > 0 && src[len(src)-1] != '\n' {
+			src = append(src, '\n')
+		}
+		return src
+	}
 	path, err := exec.LookPath("clang-format")
 	if err != nil {
 		if len(src) > 0 && src[len(src)-1] != '\n' {


### PR DESCRIPTION
## Summary
- ensure `EnsureClangFormat` is called before running `clang-format`

## Testing
- `go test ./compile/x/c -run TestCCompiler_GoldenOutput -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_685e40f42fe083209cb8903be9de121c