### PR TITLE
Improve COBOL formatting helpers

### DIFF
--- a/compile/x/cobol/tools.go
+++ b/compile/x/cobol/tools.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 // EnsureCOBOL ensures the cobc compiler is installed.
@@ -64,12 +65,62 @@ func EnsureCOBOL() error {
 	return fmt.Errorf("cobc not installed")
 }
 
+// EnsureCobfmt ensures the cobfmt formatter is installed. It attempts a
+// best-effort installation using common package managers.
+func EnsureCobfmt() error {
+	if _, err := exec.LookPath("cobfmt"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			fmt.Println("\U0001F527 Installing cobfmt...")
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "cobfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("\U0001F37A Installing cobfmt via Homebrew...")
+			cmd := exec.Command("brew", "install", "cobfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("\U0001F527 Installing cobfmt via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "cobfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("\U0001F527 Installing cobfmt via Scoop...")
+			cmd := exec.Command("scoop", "install", "cobfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if _, err := exec.LookPath("cobfmt"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("cobfmt not found")
+}
+
 // FormatCOBOL runs a formatter on the given source if available. The
 // `cobfmt` tool is tried first. If no formatter is found or formatting
 // fails, the input is returned unchanged with a trailing newline ensured.
 func FormatCOBOL(src []byte) []byte {
-	path, err := exec.LookPath("cobfmt")
-	if err == nil {
+	if err := EnsureCobfmt(); err == nil {
+		path, _ := exec.LookPath("cobfmt")
 		cmd := exec.Command(path)
 		cmd.Stdin = bytes.NewReader(src)
 		var out bytes.Buffer
@@ -82,8 +133,14 @@ func FormatCOBOL(src []byte) []byte {
 			return res
 		}
 	}
+	src = bytes.ReplaceAll(src, []byte("\t"), []byte("    "))
 	if len(src) > 0 && src[len(src)-1] != '\n' {
 		src = append(src, '\n')
 	}
-	return src
+	// Trim trailing spaces on each line for readability
+	lines := strings.Split(string(src), "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(ln, " \t")
+	}
+	return []byte(strings.Join(lines, "\n"))
 }


### PR DESCRIPTION
## Summary
- ensure cobfmt is installed before formatting COBOL
- add fallback formatting with spaces when cobfmt is unavailable
- trim trailing whitespace in generated COBOL code

## Testing
- `go test ./compile/x/cobol -tags slow -run TestCobolCompiler_GoldenSource/add_fn -update -v`

------
https://chatgpt.com/codex/tasks/task_e_685e4122d8c48320b737ef7e21a9d0cf