### PR TITLE
Improve Clojure formatting

### DIFF
--- a/tests/compiler/clj/arithmetic.clj.out
+++ b/tests/compiler/clj/arithmetic.clj.out
@@ -5,7 +5,6 @@
   (println (- 5 3))
   (println (* 4 2))
   (println (quot 8 2))
-  (println (mod 7 3))
-)
+  (println (mod 7 3)))
 
 (-main)

--- a/tests/compiler/clj/bool_ops.clj.out
+++ b/tests/compiler/clj/bool_ops.clj.out
@@ -3,7 +3,6 @@
 (defn -main []
   (println (and true false))
   (println (or true false))
-  (println (not false))
-)
+  (println (not false)))
 
 (-main)

--- a/tests/compiler/clj/break_continue.clj.out
+++ b/tests/compiler/clj/break_continue.clj.out
@@ -6,29 +6,20 @@
     (when _tmp0
       (let [n (clojure.core/first _tmp0)]
         (let [r (try
-          (when (= (mod n 2) 0)
-            (throw (ex-info "continue" {}))
-          )
-          (when (> n 7)
-            (throw (ex-info "break" {}))
-          )
-          (println "odd number:" n)
-          :next
-        (catch clojure.lang.ExceptionInfo e
+                  (when (= (mod n 2) 0)
+                    (throw (ex-info "continue" {})))
+                  (when (> n 7)
+                    (throw (ex-info "break" {})))
+                  (println "odd number:" n)
+                  :next
+                  (catch clojure.lang.ExceptionInfo e
+                    (cond
+                      (= (.getMessage e) "continue") :next
+                      (= (.getMessage e) "break") :break
+                      :else (throw e))))]
+
           (cond
-            (= (.getMessage e) "continue") :next
-            (= (.getMessage e) "break") :break
-            :else (throw e))
-          )
-        )]
-      (cond
-        (= r :break) nil
-        :else (recur (next _tmp0))
-      )
-    )
-  )
-)
-)
-)
+            (= r :break) nil
+            :else (recur (next _tmp0))))))))
 
 (-main)

--- a/tests/compiler/clj/closure.clj.out
+++ b/tests/compiler/clj/closure.clj.out
@@ -3,24 +3,19 @@
 (defn makeAdder [n]
   (try
     (throw (ex-info "return" {:value (fn [x]
-  (try
-    (throw (ex-info "return" {:value (+ x n)}))
-  (catch clojure.lang.ExceptionInfo e
-    (if (= (.getMessage e) "return")
-      (:value (ex-data e))
-    (throw e)))
-  )
-)}))
-  (catch clojure.lang.ExceptionInfo e
-    (if (= (.getMessage e) "return")
-      (:value (ex-data e))
-    (throw e)))
-  )
-)
+                                       (try
+                                         (throw (ex-info "return" {:value (+ x n)}))
+                                         (catch clojure.lang.ExceptionInfo e
+                                           (if (= (.getMessage e) "return")
+                                             (:value (ex-data e))
+                                             (throw e)))))}))
+    (catch clojure.lang.ExceptionInfo e
+      (if (= (.getMessage e) "return")
+        (:value (ex-data e))
+        (throw e)))))
 
 (defn -main []
   (def add10 (makeAdder 10))
-  (println (add10 7))
-)
+  (println (add10 7)))
 
 (-main)

--- a/tests/compiler/clj/dataset.clj.out
+++ b/tests/compiler/clj/dataset.clj.out
@@ -1,9 +1,7 @@
 (ns main)
 
 (defn Person [name age]
-  {:__name "Person" :name name :age age}
-)
-
+  {:__name "Person" :name name :age age})
 
 (defn -main []
   (def people [{:__name "Person" :name "Alice" :age 30} {:__name "Person" :name "Bob" :age 15} {:__name "Person" :name "Charlie" :age 65}])
@@ -12,23 +10,16 @@
     (when _tmp0
       (let [n (clojure.core/first _tmp0)]
         (let [r (try
-          (println n)
-          :next
-        (catch clojure.lang.ExceptionInfo e
+                  (println n)
+                  :next
+                  (catch clojure.lang.ExceptionInfo e
+                    (cond
+                      (= (.getMessage e) "continue") :next
+                      (= (.getMessage e) "break") :break
+                      :else (throw e))))]
+
           (cond
-            (= (.getMessage e) "continue") :next
-            (= (.getMessage e) "break") :break
-            :else (throw e))
-          )
-        )]
-      (cond
-        (= r :break) nil
-        :else (recur (next _tmp0))
-      )
-    )
-  )
-)
-)
-)
+            (= r :break) nil
+            :else (recur (next _tmp0))))))))
 
 (-main)

--- a/tests/compiler/clj/dataset_sort_take_limit.clj.out
+++ b/tests/compiler/clj/dataset_sort_take_limit.clj.out
@@ -1,9 +1,7 @@
 (ns main)
 
 (defn Product [name price]
-  {:__name "Product" :name name :price price}
-)
-
+  {:__name "Product" :name name :price price})
 
 (defn -main []
   (def products [{:__name "Product" :name "Laptop" :price 1500} {:__name "Product" :name "Smartphone" :price 900} {:__name "Product" :name "Tablet" :price 600} {:__name "Product" :name "Monitor" :price 300} {:__name "Product" :name "Keyboard" :price 100} {:__name "Product" :name "Mouse" :price 50} {:__name "Product" :name "Headphones" :price 200}])
@@ -13,23 +11,16 @@
     (when _tmp0
       (let [item (clojure.core/first _tmp0)]
         (let [r (try
-          (println (:name item) "costs $" (:price item))
-          :next
-        (catch clojure.lang.ExceptionInfo e
+                  (println (:name item) "costs $" (:price item))
+                  :next
+                  (catch clojure.lang.ExceptionInfo e
+                    (cond
+                      (= (.getMessage e) "continue") :next
+                      (= (.getMessage e) "break") :break
+                      :else (throw e))))]
+
           (cond
-            (= (.getMessage e) "continue") :next
-            (= (.getMessage e) "break") :break
-            :else (throw e))
-          )
-        )]
-      (cond
-        (= r :break) nil
-        :else (recur (next _tmp0))
-      )
-    )
-  )
-)
-)
-)
+            (= r :break) nil
+            :else (recur (next _tmp0))))))))
 
 (-main)

--- a/tests/compiler/clj/factorial.clj.out
+++ b/tests/compiler/clj/factorial.clj.out
@@ -3,20 +3,16 @@
 (defn factorial [n]
   (try
     (when (<= n 1)
-      (throw (ex-info "return" {:value 1}))
-    )
+      (throw (ex-info "return" {:value 1})))
     (throw (ex-info "return" {:value (* n (factorial (- n 1)))}))
-  (catch clojure.lang.ExceptionInfo e
-    (if (= (.getMessage e) "return")
-      (:value (ex-data e))
-    (throw e)))
-  )
-)
+    (catch clojure.lang.ExceptionInfo e
+      (if (= (.getMessage e) "return")
+        (:value (ex-data e))
+        (throw e)))))
 
 (defn -main []
   (println (factorial 0))
   (println (factorial 1))
-  (println (factorial 5))
-)
+  (println (factorial 5)))
 
 (-main)

--- a/tests/compiler/clj/fetch_builtin.clj.out
+++ b/tests/compiler/clj/fetch_builtin.clj.out
@@ -1,7 +1,6 @@
 (ns main
   (:require
-    [clojure.data.json :as json]
-  ))
+   [clojure.data.json :as json]))
 
 (defn _cast_struct [ctor m]
   (let [fields (first (:arglists (meta ctor)))]
@@ -10,21 +9,21 @@
   (let [method (get opts :method "GET")
         q      (get opts :query nil)
         url     (if q
-                   (let [qs (clojure.string/join "&"
-                             (map (fn [[k v]]
-                                    (str (java.net.URLEncoder/encode (name k) "UTF-8")
-                                         "="
-                                         (java.net.URLEncoder/encode (str v) "UTF-8")))
-                                  q))
-                         sep (if (clojure.string/includes? url "?") "&" "?")]
-                     (str url sep qs))
-                   url)
+                  (let [qs (clojure.string/join "&"
+                                                (map (fn [[k v]]
+                                                       (str (java.net.URLEncoder/encode (name k) "UTF-8")
+                                                            "="
+                                                            (java.net.URLEncoder/encode (str v) "UTF-8")))
+                                                     q))
+                        sep (if (clojure.string/includes? url "?") "&" "?")]
+                    (str url sep qs))
+                  url)
         builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
                   (.method method
-                          (if (contains? opts :body)
-                            (java.net.http.HttpRequest$BodyPublishers/ofString
+                           (if (contains? opts :body)
+                             (java.net.http.HttpRequest$BodyPublishers/ofString
                               (clojure.data.json/write-str (:body opts)))
-                            (java.net.http.HttpRequest$BodyPublishers/noBody))))]
+                             (java.net.http.HttpRequest$BodyPublishers/noBody))))]
     (when-let [hs (:headers opts)]
       (doseq [[k v] hs]
         (.header builder (name k) (str v))))
@@ -35,13 +34,10 @@
                       (java.net.http.HttpResponse$BodyHandlers/ofString))]
       (clojure.data.json/read-str (.body resp) :key-fn keyword))))
 (defn Msg [message]
-  {:__name "Msg" :message message}
-)
-
+  {:__name "Msg" :message message})
 
 (defn -main []
   (def data (_cast_struct Msg (_fetch "file://tests/compiler/lua/fetch_builtin.json" nil)))
-  (println (:message data))
-)
+  (println (:message data)))
 
 (-main)

--- a/tests/compiler/clj/fetch_options.clj.out
+++ b/tests/compiler/clj/fetch_options.clj.out
@@ -1,27 +1,26 @@
 (ns main
   (:require
-    [clojure.data.json :as json]
-  ))
+   [clojure.data.json :as json]))
 
 (defn _fetch [url opts]
   (let [method (get opts :method "GET")
         q      (get opts :query nil)
         url     (if q
-                   (let [qs (clojure.string/join "&"
-                             (map (fn [[k v]]
-                                    (str (java.net.URLEncoder/encode (name k) "UTF-8")
-                                         "="
-                                         (java.net.URLEncoder/encode (str v) "UTF-8")))
-                                  q))
-                         sep (if (clojure.string/includes? url "?") "&" "?")]
-                     (str url sep qs))
-                   url)
+                  (let [qs (clojure.string/join "&"
+                                                (map (fn [[k v]]
+                                                       (str (java.net.URLEncoder/encode (name k) "UTF-8")
+                                                            "="
+                                                            (java.net.URLEncoder/encode (str v) "UTF-8")))
+                                                     q))
+                        sep (if (clojure.string/includes? url "?") "&" "?")]
+                    (str url sep qs))
+                  url)
         builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
                   (.method method
-                          (if (contains? opts :body)
-                            (java.net.http.HttpRequest$BodyPublishers/ofString
+                           (if (contains? opts :body)
+                             (java.net.http.HttpRequest$BodyPublishers/ofString
                               (clojure.data.json/write-str (:body opts)))
-                            (java.net.http.HttpRequest$BodyPublishers/noBody))))]
+                             (java.net.http.HttpRequest$BodyPublishers/noBody))))]
     (when-let [hs (:headers opts)]
       (doseq [[k v] hs]
         (.header builder (name k) (str v))))
@@ -33,7 +32,6 @@
       (clojure.data.json/read-str (.body resp) :key-fn keyword))))
 (defn -main []
   (def resp (_fetch "https://httpbin.org/anything" {:method "POST" :headers {"Content-Type" "application/json"} :query {:x "1"} :body {"foo" 123}}))
-  (println (:foo (:json resp)))
-)
+  (println (:foo (:json resp))))
 
 (-main)

--- a/tests/compiler/clj/fetch_todo.clj.out
+++ b/tests/compiler/clj/fetch_todo.clj.out
@@ -1,7 +1,6 @@
 (ns main
   (:require
-    [clojure.data.json :as json]
-  ))
+   [clojure.data.json :as json]))
 
 (defn _cast_struct [ctor m]
   (let [fields (first (:arglists (meta ctor)))]
@@ -10,21 +9,21 @@
   (let [method (get opts :method "GET")
         q      (get opts :query nil)
         url     (if q
-                   (let [qs (clojure.string/join "&"
-                             (map (fn [[k v]]
-                                    (str (java.net.URLEncoder/encode (name k) "UTF-8")
-                                         "="
-                                         (java.net.URLEncoder/encode (str v) "UTF-8")))
-                                  q))
-                         sep (if (clojure.string/includes? url "?") "&" "?")]
-                     (str url sep qs))
-                   url)
+                  (let [qs (clojure.string/join "&"
+                                                (map (fn [[k v]]
+                                                       (str (java.net.URLEncoder/encode (name k) "UTF-8")
+                                                            "="
+                                                            (java.net.URLEncoder/encode (str v) "UTF-8")))
+                                                     q))
+                        sep (if (clojure.string/includes? url "?") "&" "?")]
+                    (str url sep qs))
+                  url)
         builder (doto (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))
                   (.method method
-                          (if (contains? opts :body)
-                            (java.net.http.HttpRequest$BodyPublishers/ofString
+                           (if (contains? opts :body)
+                             (java.net.http.HttpRequest$BodyPublishers/ofString
                               (clojure.data.json/write-str (:body opts)))
-                            (java.net.http.HttpRequest$BodyPublishers/noBody))))]
+                             (java.net.http.HttpRequest$BodyPublishers/noBody))))]
     (when-let [hs (:headers opts)]
       (doseq [[k v] hs]
         (.header builder (name k) (str v))))
@@ -35,13 +34,10 @@
                       (java.net.http.HttpResponse$BodyHandlers/ofString))]
       (clojure.data.json/read-str (.body resp) :key-fn keyword))))
 (defn Todo [userId id title completed]
-  {:__name "Todo" :userId userId :id id :title title :completed completed}
-)
-
+  {:__name "Todo" :userId userId :id id :title title :completed completed})
 
 (defn -main []
   (def todo (_cast_struct Todo (_fetch "https://jsonplaceholder.typicode.com/todos/1" nil)))
-  (println (:title todo))
-)
+  (println (:title todo)))
 
 (-main)

--- a/tests/compiler/clj/fibonacci.clj.out
+++ b/tests/compiler/clj/fibonacci.clj.out
@@ -3,20 +3,16 @@
 (defn fib [n]
   (try
     (when (<= n 1)
-      (throw (ex-info "return" {:value n}))
-    )
+      (throw (ex-info "return" {:value n})))
     (throw (ex-info "return" {:value (+ (fib (- n 1)) (fib (- n 2)))}))
-  (catch clojure.lang.ExceptionInfo e
-    (if (= (.getMessage e) "return")
-      (:value (ex-data e))
-    (throw e)))
-  )
-)
+    (catch clojure.lang.ExceptionInfo e
+      (if (= (.getMessage e) "return")
+        (:value (ex-data e))
+        (throw e)))))
 
 (defn -main []
   (println (fib 0))
   (println (fib 1))
-  (println (fib 6))
-)
+  (println (fib 6)))
 
 (-main)

--- a/tests/compiler/clj/field_select.clj.out
+++ b/tests/compiler/clj/field_select.clj.out
@@ -7,13 +7,10 @@
       (nth xs idx))))
 
 (defn Person [name age]
-  {:__name "Person" :name name :age age}
-)
-
+  {:__name "Person" :name name :age age})
 
 (defn -main []
   (def people [{:__name "Person" :name "Alice" :age 30} {:__name "Person" :name "Bob" :age 25}])
-  (println (:name (_indexList people 1)))
-)
+  (println (:name (_indexList people 1))))
 
 (-main)

--- a/tests/compiler/clj/float_ops.clj.out
+++ b/tests/compiler/clj/float_ops.clj.out
@@ -2,7 +2,6 @@
 
 (defn -main []
   (println (+ 1.2 3.4))
-  (println (/ 5.0 2.0))
-)
+  (println (/ 5.0 2.0)))
 
 (-main)

--- a/tests/compiler/clj/for_loop.clj.out
+++ b/tests/compiler/clj/for_loop.clj.out
@@ -4,22 +4,16 @@
   (loop [i 1]
     (when (< i 4)
       (let [r (try
-        (println i)
-        :next
-      (catch clojure.lang.ExceptionInfo e
+                (println i)
+                :next
+                (catch clojure.lang.ExceptionInfo e
+                  (cond
+                    (= (.getMessage e) "continue") :next
+                    (= (.getMessage e) "break") :break
+                    :else (throw e))))]
+
         (cond
-          (= (.getMessage e) "continue") :next
-          (= (.getMessage e) "break") :break
-          :else (throw e))
-        )
-      )]
-    (cond
-      (= r :break) nil
-      :else (recur (inc i))
-    )
-  )
-)
-)
-)
+          (= r :break) nil
+          :else (recur (inc i)))))))
 
 (-main)

--- a/tests/compiler/clj/generate_struct.clj.out
+++ b/tests/compiler/clj/generate_struct.clj.out
@@ -1,7 +1,6 @@
 (ns main
   (:require
-    [clojure.data.json :as json]
-  ))
+   [clojure.data.json :as json]))
 
 (defn _gen_struct [ctor prompt model params]
   (let [m (clojure.data.json/read-str prompt :key-fn keyword)
@@ -9,13 +8,10 @@
         args (map #(get m %) fields)]
     (apply ctor args)))
 (defn Info [msg]
-  {:__name "Info" :msg msg}
-)
-
+  {:__name "Info" :msg msg})
 
 (defn -main []
   (def info (_gen_struct Info "{\"msg\": \"hello\"}" "" nil))
-  (println (:msg info))
-)
+  (println (:msg info)))
 
 (-main)

--- a/tests/compiler/clj/generate_text.clj.out
+++ b/tests/compiler/clj/generate_text.clj.out
@@ -4,7 +4,6 @@
   prompt)
 (defn -main []
   (def poem (_gen_text "echo hello" "" nil))
-  (println poem)
-)
+  (println poem))
 
 (-main)

--- a/tests/compiler/clj/join_where_pushdown.clj.out
+++ b/tests/compiler/clj/join_where_pushdown.clj.out
@@ -8,23 +8,16 @@
     (when _tmp0
       (let [v (clojure.core/first _tmp0)]
         (let [r (try
-          (println v)
-          :next
-        (catch clojure.lang.ExceptionInfo e
+                  (println v)
+                  :next
+                  (catch clojure.lang.ExceptionInfo e
+                    (cond
+                      (= (.getMessage e) "continue") :next
+                      (= (.getMessage e) "break") :break
+                      :else (throw e))))]
+
           (cond
-            (= (.getMessage e) "continue") :next
-            (= (.getMessage e) "break") :break
-            :else (throw e))
-          )
-        )]
-      (cond
-        (= r :break) nil
-        :else (recur (next _tmp0))
-      )
-    )
-  )
-)
-)
-)
+            (= r :break) nil
+            :else (recur (next _tmp0))))))))
 
 (-main)

--- a/tests/compiler/clj/json_builtin.clj.out
+++ b/tests/compiler/clj/json_builtin.clj.out
@@ -13,14 +13,13 @@
     (boolean? v) (str v)
     (sequential? v) (str "[" (clojure.string/join "," (map _to_json v)) "]")
     (map? v) (str "{" (clojure.string/join "," (map (fn [[k val]]
-                                        (str "\"" (_escape_json (name k)) "\":" (_to_json val))) v)) "}")
+                                                      (str "\"" (_escape_json (name k)) "\":" (_to_json val))) v)) "}")
     :else (str "\"" (_escape_json (str v)) "\"")))
 
 (defn _json [v]
   (println (_to_json v)))
 
 (defn -main []
-  (_json {"a" 1})
-)
+  (_json {"a" 1}))
 
 (-main)

--- a/tests/compiler/clj/list_slice.clj.out
+++ b/tests/compiler/clj/list_slice.clj.out
@@ -1,7 +1,6 @@
 (ns main)
 
 (defn -main []
-  (println (subvec [1 2 3 4] 1 3))
-)
+  (println (subvec [1 2 3 4] 1 3)))
 
 (-main)

--- a/tests/compiler/clj/load_csv.clj.out
+++ b/tests/compiler/clj/load_csv.clj.out
@@ -4,12 +4,12 @@
   (let [lines (->> (clojure.string/split-lines text)
                    (remove clojure.string/blank?))
         headers (if header
-                    (clojure.string/split (first lines) (re-pattern (str delim)))
-                    (map #(str "c" %) (range (count (clojure.string/split (first lines) (re-pattern (str delim)))))))]
+                  (clojure.string/split (first lines) (re-pattern (str delim)))
+                  (map #(str "c" %) (range (count (clojure.string/split (first lines) (re-pattern (str delim)))))))]
     (mapv (fn [line]
             (let [parts (clojure.string/split line (re-pattern (str delim)))]
               (zipmap headers parts)))
-          (drop (if header 1 0) lines))) )
+          (drop (if header 1 0) lines))))
 
 (defn _load [path opts]
   (let [fmt (get opts :format "csv")
@@ -22,27 +22,25 @@
       (= fmt "csv") (_parse_csv text header delim)
       (= fmt "tsv") (_parse_csv text header "\t")
       (= fmt "json")
-        (let [data (clojure.data.json/read-str text :key-fn keyword)]
-          (cond
-            (map? data) [data]
-            (sequential? data) (vec data)
-            :else []))
+      (let [data (clojure.data.json/read-str text :key-fn keyword)]
+        (cond
+          (map? data) [data]
+          (sequential? data) (vec data)
+          :else []))
       (= fmt "jsonl")
-        (->> (clojure.string/split-lines text)
-             (remove clojure.string/blank?)
-             (mapv #(clojure.data.json/read-str % :key-fn keyword)))
+      (->> (clojure.string/split-lines text)
+           (remove clojure.string/blank?)
+           (mapv #(clojure.data.json/read-str % :key-fn keyword)))
       (= fmt "yaml")
-        (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
-          (cond
-            (instance? java.util.Map y) [(into {} y)]
-            (instance? java.util.List y) (mapv #(into {} %) y)
-            :else []))
-      :else [])) )
+      (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
+        (cond
+          (instance? java.util.Map y) [(into {} y)]
+          (instance? java.util.List y) (mapv #(into {} %) y)
+          :else []))
+      :else [])))
 
 (defn Person [name age]
-  {:__name "Person" :name name :age age}
-)
-
+  {:__name "Person" :name name :age age})
 
 (defn -main []
   (def people (mapv Person (_load "people.csv" nil)))
@@ -51,23 +49,16 @@
     (when _tmp0
       (let [a (clojure.core/first _tmp0)]
         (let [r (try
-          (println (:name a) (:age a))
-          :next
-        (catch clojure.lang.ExceptionInfo e
+                  (println (:name a) (:age a))
+                  :next
+                  (catch clojure.lang.ExceptionInfo e
+                    (cond
+                      (= (.getMessage e) "continue") :next
+                      (= (.getMessage e) "break") :break
+                      :else (throw e))))]
+
           (cond
-            (= (.getMessage e) "continue") :next
-            (= (.getMessage e) "break") :break
-            :else (throw e))
-          )
-        )]
-      (cond
-        (= r :break) nil
-        :else (recur (next _tmp0))
-      )
-    )
-  )
-)
-)
-)
+            (= r :break) nil
+            :else (recur (next _tmp0))))))))
 
 (-main)

--- a/tests/compiler/clj/load_json.clj.out
+++ b/tests/compiler/clj/load_json.clj.out
@@ -4,12 +4,12 @@
   (let [lines (->> (clojure.string/split-lines text)
                    (remove clojure.string/blank?))
         headers (if header
-                    (clojure.string/split (first lines) (re-pattern (str delim)))
-                    (map #(str "c" %) (range (count (clojure.string/split (first lines) (re-pattern (str delim)))))))]
+                  (clojure.string/split (first lines) (re-pattern (str delim)))
+                  (map #(str "c" %) (range (count (clojure.string/split (first lines) (re-pattern (str delim)))))))]
     (mapv (fn [line]
             (let [parts (clojure.string/split line (re-pattern (str delim)))]
               (zipmap headers parts)))
-          (drop (if header 1 0) lines))) )
+          (drop (if header 1 0) lines))))
 
 (defn _load [path opts]
   (let [fmt (get opts :format "csv")
@@ -22,27 +22,25 @@
       (= fmt "csv") (_parse_csv text header delim)
       (= fmt "tsv") (_parse_csv text header "\t")
       (= fmt "json")
-        (let [data (clojure.data.json/read-str text :key-fn keyword)]
-          (cond
-            (map? data) [data]
-            (sequential? data) (vec data)
-            :else []))
+      (let [data (clojure.data.json/read-str text :key-fn keyword)]
+        (cond
+          (map? data) [data]
+          (sequential? data) (vec data)
+          :else []))
       (= fmt "jsonl")
-        (->> (clojure.string/split-lines text)
-             (remove clojure.string/blank?)
-             (mapv #(clojure.data.json/read-str % :key-fn keyword)))
+      (->> (clojure.string/split-lines text)
+           (remove clojure.string/blank?)
+           (mapv #(clojure.data.json/read-str % :key-fn keyword)))
       (= fmt "yaml")
-        (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
-          (cond
-            (instance? java.util.Map y) [(into {} y)]
-            (instance? java.util.List y) (mapv #(into {} %) y)
-            :else []))
-      :else [])) )
+      (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
+        (cond
+          (instance? java.util.Map y) [(into {} y)]
+          (instance? java.util.List y) (mapv #(into {} %) y)
+          :else []))
+      :else [])))
 
 (defn Person [name age email]
-  {:__name "Person" :name name :age age :email email}
-)
-
+  {:__name "Person" :name name :age age :email email})
 
 (defn -main []
   (def people (mapv Person (_load "people.json" {:format "json"})))
@@ -51,23 +49,16 @@
     (when _tmp0
       (let [a (clojure.core/first _tmp0)]
         (let [r (try
-          (println (:name a) (:email a))
-          :next
-        (catch clojure.lang.ExceptionInfo e
+                  (println (:name a) (:email a))
+                  :next
+                  (catch clojure.lang.ExceptionInfo e
+                    (cond
+                      (= (.getMessage e) "continue") :next
+                      (= (.getMessage e) "break") :break
+                      :else (throw e))))]
+
           (cond
-            (= (.getMessage e) "continue") :next
-            (= (.getMessage e) "break") :break
-            :else (throw e))
-          )
-        )]
-      (cond
-        (= r :break) nil
-        :else (recur (next _tmp0))
-      )
-    )
-  )
-)
-)
-)
+            (= r :break) nil
+            :else (recur (next _tmp0))))))))
 
 (-main)

--- a/tests/compiler/clj/load_save_json.clj.out
+++ b/tests/compiler/clj/load_save_json.clj.out
@@ -4,12 +4,12 @@
   (let [lines (->> (clojure.string/split-lines text)
                    (remove clojure.string/blank?))
         headers (if header
-                    (clojure.string/split (first lines) (re-pattern (str delim)))
-                    (map #(str "c" %) (range (count (clojure.string/split (first lines) (re-pattern (str delim)))))))]
+                  (clojure.string/split (first lines) (re-pattern (str delim)))
+                  (map #(str "c" %) (range (count (clojure.string/split (first lines) (re-pattern (str delim)))))))]
     (mapv (fn [line]
             (let [parts (clojure.string/split line (re-pattern (str delim)))]
               (zipmap headers parts)))
-          (drop (if header 1 0) lines))) )
+          (drop (if header 1 0) lines))))
 
 (defn _load [path opts]
   (let [fmt (get opts :format "csv")
@@ -22,22 +22,22 @@
       (= fmt "csv") (_parse_csv text header delim)
       (= fmt "tsv") (_parse_csv text header "\t")
       (= fmt "json")
-        (let [data (clojure.data.json/read-str text :key-fn keyword)]
-          (cond
-            (map? data) [data]
-            (sequential? data) (vec data)
-            :else []))
+      (let [data (clojure.data.json/read-str text :key-fn keyword)]
+        (cond
+          (map? data) [data]
+          (sequential? data) (vec data)
+          :else []))
       (= fmt "jsonl")
-        (->> (clojure.string/split-lines text)
-             (remove clojure.string/blank?)
-             (mapv #(clojure.data.json/read-str % :key-fn keyword)))
+      (->> (clojure.string/split-lines text)
+           (remove clojure.string/blank?)
+           (mapv #(clojure.data.json/read-str % :key-fn keyword)))
       (= fmt "yaml")
-        (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
-          (cond
-            (instance? java.util.Map y) [(into {} y)]
-            (instance? java.util.List y) (mapv #(into {} %) y)
-            :else []))
-      :else [])) )
+      (let [y (-> text java.io.StringReader. (org.yaml.snakeyaml.Yaml.) .load)]
+        (cond
+          (instance? java.util.Map y) [(into {} y)]
+          (instance? java.util.List y) (mapv #(into {} %) y)
+          :else []))
+      :else [])))
 
 (defn _save [rows path opts]
   (let [fmt (get opts :format "csv")
@@ -46,45 +46,42 @@
         headers (if (seq rows) (sort (keys (first rows))) [])]
     (cond
       (= fmt "csv")
-        (let [lines (concat
-                      (when header [(clojure.string/join delim headers)])
-                      (map (fn [r]
-                             (clojure.string/join delim (map #(str (get r % "")) headers)))
-                           rows))
-              out (str (clojure.string/join "\n" lines) "\n")]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print out)
-            (spit path out)))
+      (let [lines (concat
+                   (when header [(clojure.string/join delim headers)])
+                   (map (fn [r]
+                          (clojure.string/join delim (map #(str (get r % "")) headers)))
+                        rows))
+            out (str (clojure.string/join "\n" lines) "\n")]
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print out)
+          (spit path out)))
       (= fmt "tsv")
-        (_save rows path (assoc opts :format "csv" :delimiter "\t"))
+      (_save rows path (assoc opts :format "csv" :delimiter "\t"))
       (= fmt "json")
-        (let [out (clojure.data.json/write-str rows)]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print out)
-            (spit path out)))
+      (let [out (clojure.data.json/write-str rows)]
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print out)
+          (spit path out)))
       (= fmt "jsonl")
-        (let [out (clojure.string/join "\n" (map #(clojure.data.json/write-str %) rows))]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print (str out "\n"))
-            (spit path (str out "\n"))))
+      (let [out (clojure.string/join "\n" (map #(clojure.data.json/write-str %) rows))]
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print (str out "\n"))
+          (spit path (str out "\n"))))
       (= fmt "yaml")
-        (let [yaml (org.yaml.snakeyaml.Yaml.)
-              out (.dump yaml (clojure.walk/keywordize-keys
+      (let [yaml (org.yaml.snakeyaml.Yaml.)
+            out (.dump yaml (clojure.walk/keywordize-keys
                              (if (= 1 (count rows)) (first rows) rows)))]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print out)
-            (spit path out)))
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print out)
+          (spit path out)))
       :else
-        nil)) )
+      nil)))
 
 (defn Person [name age]
-  {:__name "Person" :name name :age age}
-)
-
+  {:__name "Person" :name name :age age})
 
 (defn -main []
   (def people (mapv Person (_load "" {:format "json"})))
-  (_save people "" {:format "json"})
-)
+  (_save people "" {:format "json"}))
 
 (-main)

--- a/tests/compiler/clj/membership.clj.out
+++ b/tests/compiler/clj/membership.clj.out
@@ -8,7 +8,6 @@
     :else false))
 (defn -main []
   (println (_in 2 [1 2 3]))
-  (println (_in "b" ["a" "b"]))
-)
+  (println (_in "b" ["a" "b"])))
 
 (-main)

--- a/tests/compiler/clj/method.clj.out
+++ b/tests/compiler/clj/method.clj.out
@@ -1,8 +1,7 @@
 (ns main)
 
 (defn Circle [radius]
-  {:__name "Circle" :radius radius}
-)
+  {:__name "Circle" :radius radius})
 
 (defn Circle_area [self]
   (let [radius (:radius self)]
@@ -10,31 +9,23 @@
       (def a (* (* 3.14 radius) radius))
       (println "Calculating area:" a)
       (throw (ex-info "return" {:value a}))
-    (catch clojure.lang.ExceptionInfo e
-      (if (= (.getMessage e) "return")
-        (:value (ex-data e))
-      (throw e)))
-    )
-  )
-)
+      (catch clojure.lang.ExceptionInfo e
+        (if (= (.getMessage e) "return")
+          (:value (ex-data e))
+          (throw e))))))
 
 (defn Circle_describe [self]
   (let [radius (:radius self)]
     (try
       (println "Circle with radius" radius)
-    (catch clojure.lang.ExceptionInfo e
-      (if (= (.getMessage e) "return")
-        (:value (ex-data e))
-      (throw e)))
-    )
-  )
-)
-
+      (catch clojure.lang.ExceptionInfo e
+        (if (= (.getMessage e) "return")
+          (:value (ex-data e))
+          (throw e))))))
 
 (defn -main []
   (def c {:__name "Circle" :radius 5.0})
   (Circle_describe c)
-  (println "Area is" (Circle_area c))
-)
+  (println "Area is" (Circle_area c)))
 
 (-main)

--- a/tests/compiler/clj/mod_operator.clj.out
+++ b/tests/compiler/clj/mod_operator.clj.out
@@ -4,24 +4,17 @@
   (loop [i 1]
     (when (< i 5)
       (let [r (try
-        (when (= (mod i 2) 0)
-          (println i)
-        )
-        :next
-      (catch clojure.lang.ExceptionInfo e
+                (when (= (mod i 2) 0)
+                  (println i))
+                :next
+                (catch clojure.lang.ExceptionInfo e
+                  (cond
+                    (= (.getMessage e) "continue") :next
+                    (= (.getMessage e) "break") :break
+                    :else (throw e))))]
+
         (cond
-          (= (.getMessage e) "continue") :next
-          (= (.getMessage e) "break") :break
-          :else (throw e))
-        )
-      )]
-    (cond
-      (= r :break) nil
-      :else (recur (inc i))
-    )
-  )
-)
-)
-)
+          (= r :break) nil
+          :else (recur (inc i)))))))
 
 (-main)

--- a/tests/compiler/clj/save_json_stdout.clj.out
+++ b/tests/compiler/clj/save_json_stdout.clj.out
@@ -7,40 +7,39 @@
         headers (if (seq rows) (sort (keys (first rows))) [])]
     (cond
       (= fmt "csv")
-        (let [lines (concat
-                      (when header [(clojure.string/join delim headers)])
-                      (map (fn [r]
-                             (clojure.string/join delim (map #(str (get r % "")) headers)))
-                           rows))
-              out (str (clojure.string/join "\n" lines) "\n")]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print out)
-            (spit path out)))
+      (let [lines (concat
+                   (when header [(clojure.string/join delim headers)])
+                   (map (fn [r]
+                          (clojure.string/join delim (map #(str (get r % "")) headers)))
+                        rows))
+            out (str (clojure.string/join "\n" lines) "\n")]
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print out)
+          (spit path out)))
       (= fmt "tsv")
-        (_save rows path (assoc opts :format "csv" :delimiter "\t"))
+      (_save rows path (assoc opts :format "csv" :delimiter "\t"))
       (= fmt "json")
-        (let [out (clojure.data.json/write-str rows)]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print out)
-            (spit path out)))
+      (let [out (clojure.data.json/write-str rows)]
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print out)
+          (spit path out)))
       (= fmt "jsonl")
-        (let [out (clojure.string/join "\n" (map #(clojure.data.json/write-str %) rows))]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print (str out "\n"))
-            (spit path (str out "\n"))))
+      (let [out (clojure.string/join "\n" (map #(clojure.data.json/write-str %) rows))]
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print (str out "\n"))
+          (spit path (str out "\n"))))
       (= fmt "yaml")
-        (let [yaml (org.yaml.snakeyaml.Yaml.)
-              out (.dump yaml (clojure.walk/keywordize-keys
+      (let [yaml (org.yaml.snakeyaml.Yaml.)
+            out (.dump yaml (clojure.walk/keywordize-keys
                              (if (= 1 (count rows)) (first rows) rows)))]
-          (if (or (nil? path) (= path "") (= path "-"))
-            (print out)
-            (spit path out)))
+        (if (or (nil? path) (= path "") (= path "-"))
+          (print out)
+          (spit path out)))
       :else
-        nil)) )
+      nil)))
 
 (defn -main []
   (def people [{:name "Alice" :age 30} {:name "Bob" :age 25}])
-  (_save people "-" {:format "json"})
-)
+  (_save people "-" {:format "json"}))
 
 (-main)

--- a/tests/compiler/clj/set_ops.clj.out
+++ b/tests/compiler/clj/set_ops.clj.out
@@ -12,7 +12,6 @@
   (println (_union a b))
   (println (_except a b))
   (println (_intersect a b))
-  (println (_union [1 2] [2 3]))
-)
+  (println (_union [1 2] [2 3])))
 
 (-main)

--- a/tests/compiler/clj/simple_fn.clj.out
+++ b/tests/compiler/clj/simple_fn.clj.out
@@ -3,15 +3,12 @@
 (defn id [x]
   (try
     (throw (ex-info "return" {:value x}))
-  (catch clojure.lang.ExceptionInfo e
-    (if (= (.getMessage e) "return")
-      (:value (ex-data e))
-    (throw e)))
-  )
-)
+    (catch clojure.lang.ExceptionInfo e
+      (if (= (.getMessage e) "return")
+        (:value (ex-data e))
+        (throw e)))))
 
 (defn -main []
-  (println (id 123))
-)
+  (println (id 123)))
 
 (-main)

--- a/tests/compiler/clj/str_builtin.clj.out
+++ b/tests/compiler/clj/str_builtin.clj.out
@@ -1,7 +1,6 @@
 (ns main)
 
 (defn -main []
-  (println (str 123))
-)
+  (println (str 123)))
 
 (-main)

--- a/tests/compiler/clj/string_case.clj.out
+++ b/tests/compiler/clj/string_case.clj.out
@@ -2,7 +2,6 @@
 
 (defn -main []
   (println (clojure.string/upper-case "hello"))
-  (println (clojure.string/lower-case "WORLD"))
-)
+  (println (clojure.string/lower-case "WORLD")))
 
 (-main)

--- a/tests/compiler/clj/string_compare.clj.out
+++ b/tests/compiler/clj/string_compare.clj.out
@@ -6,7 +6,6 @@
   (println (> (compare "b" "a") 0))
   (println (>= (compare "b" "b") 0))
   (println (= "abc" "abc"))
-  (println (not= "foo" "bar"))
-)
+  (println (not= "foo" "bar")))
 
 (-main)

--- a/tests/compiler/clj/string_concat.clj.out
+++ b/tests/compiler/clj/string_concat.clj.out
@@ -1,7 +1,6 @@
 (ns main)
 
 (defn -main []
-  (println (str "hello " "world"))
-)
+  (println (str "hello " "world")))
 
 (-main)

--- a/tests/compiler/clj/string_for_loop.clj.out
+++ b/tests/compiler/clj/string_for_loop.clj.out
@@ -5,23 +5,16 @@
     (when _tmp0
       (let [ch (clojure.core/first _tmp0)]
         (let [r (try
-          (println ch)
-          :next
-        (catch clojure.lang.ExceptionInfo e
+                  (println ch)
+                  :next
+                  (catch clojure.lang.ExceptionInfo e
+                    (cond
+                      (= (.getMessage e) "continue") :next
+                      (= (.getMessage e) "break") :break
+                      :else (throw e))))]
+
           (cond
-            (= (.getMessage e) "continue") :next
-            (= (.getMessage e) "break") :break
-            :else (throw e))
-          )
-        )]
-      (cond
-        (= r :break) nil
-        :else (recur (next _tmp0))
-      )
-    )
-  )
-)
-)
-)
+            (= r :break) nil
+            :else (recur (next _tmp0))))))))
 
 (-main)

--- a/tests/compiler/clj/string_in.clj.out
+++ b/tests/compiler/clj/string_in.clj.out
@@ -8,7 +8,6 @@
     :else false))
 (defn -main []
   (println (_in "cat" "catch"))
-  (println (_in "dog" "catch"))
-)
+  (println (_in "dog" "catch")))
 
 (-main)

--- a/tests/compiler/clj/string_index.clj.out
+++ b/tests/compiler/clj/string_index.clj.out
@@ -9,7 +9,6 @@
 
 (defn -main []
   (def text "hello")
-  (println (_indexString text 1))
-)
+  (println (_indexString text 1)))
 
 (-main)

--- a/tests/compiler/clj/string_negative_index.clj.out
+++ b/tests/compiler/clj/string_negative_index.clj.out
@@ -9,7 +9,6 @@
 
 (defn -main []
   (def text "hello")
-  (println (_indexString text (- 1)))
-)
+  (println (_indexString text (- 1))))
 
 (-main)

--- a/tests/compiler/clj/string_slice.clj.out
+++ b/tests/compiler/clj/string_slice.clj.out
@@ -1,7 +1,6 @@
 (ns main)
 
 (defn -main []
-  (println (subs "hello" 1 4))
-)
+  (println (subs "hello" 1 4)))
 
 (-main)

--- a/tests/compiler/clj/test_block.clj.out
+++ b/tests/compiler/clj/test_block.clj.out
@@ -8,12 +8,10 @@
 
 (defn test_values []
   (assert (= (_indexList xs 0) 1) "expect failed")
-  (println "done")
-)
+  (println "done"))
 
 (defn -main []
   (def xs [1 2 3])
-  (test_values)
-)
+  (test_values))
 
 (-main)

--- a/tests/compiler/clj/union_all.clj.out
+++ b/tests/compiler/clj/union_all.clj.out
@@ -3,7 +3,6 @@
 (defn _union_all [a b]
   (vec (concat a b)))
 (defn -main []
-  (println (_union_all [1 2] [2 3]))
-)
+  (println (_union_all [1 2] [2 3])))
 
 (-main)

--- a/tests/compiler/clj/var_assignment.clj.out
+++ b/tests/compiler/clj/var_assignment.clj.out
@@ -3,7 +3,6 @@
 (defn -main []
   (def x 1)
   (def x 2)
-  (println x)
-)
+  (println x))
 
 (-main)

--- a/tests/compiler/clj/while_loop.clj.out
+++ b/tests/compiler/clj/while_loop.clj.out
@@ -5,23 +5,17 @@
   (loop []
     (when (< i 3)
       (let [r (try
-        (println i)
-        (def i (+ i 1))
-        :next
-      (catch clojure.lang.ExceptionInfo e
+                (println i)
+                (def i (+ i 1))
+                :next
+                (catch clojure.lang.ExceptionInfo e
+                  (cond
+                    (= (.getMessage e) "continue") :next
+                    (= (.getMessage e) "break") :break
+                    :else (throw e))))]
+
         (cond
-          (= (.getMessage e) "continue") :next
-          (= (.getMessage e) "break") :break
-          :else (throw e))
-        )
-      )]
-    (cond
-      (= r :break) nil
-      (= r :next) (recur)
-    )
-  )
-)
-)
-)
+          (= r :break) nil
+          (= r :next) (recur))))))
 
 (-main)


### PR DESCRIPTION
## Summary
- install `cljfmt` automatically if missing
- ensure a fallback formatter so output remains readable
- regenerate Clojure golden files with improved formatting

## Testing
- `go test -tags slow ./compile/x/clj -run TestClojureCompiler_GoldenOutput -update`

------
https://chatgpt.com/codex/tasks/task_e_685e412d3ed483208fa35745c623f7e0