### PR TITLE
Improve Erlang code formatting and update golden files

### DIFF
--- a/compile/x/erlang/README.md
+++ b/compile/x/erlang/README.md
@@ -81,6 +81,15 @@ func EnsureErlang() error { return ensureErlang() }
 ```
 【F:compile/erlang/tools.go†L10-L13】
 
+`EnsureFormatter` checks for the `erlfmt` formatter and attempts a best-effort
+installation when tests are run:
+
+```go
+// EnsureFormatter verifies that the `erlfmt` tool is installed.
+func EnsureFormatter() error { return ensureErlfmt() }
+```
+【F:compile/erlang/tools.go†L78-L135】
+
 ## Unsupported Features
 
 - The Erlang backend still implements only part of Mochi. Missing features include:

--- a/compile/x/erlang/tools.go
+++ b/compile/x/erlang/tools.go
@@ -1,11 +1,13 @@
 package erlcode
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 // EnsureErlang verifies that the Erlang toolchain is installed. It attempts a
@@ -73,10 +75,70 @@ func ensureErlang() error {
 	return fmt.Errorf("erlang not installed")
 }
 
+// EnsureFormatter verifies that the `erlfmt` tool is installed. It attempts a
+// best-effort installation using common package managers. Tests can call this
+// to skip if installation fails.
+func EnsureFormatter() error { return ensureErlfmt() }
+
+func ensureErlfmt() error {
+	if _, err := exec.LookPath("erlfmt"); err == nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("apt-get"); err == nil {
+			cmd := exec.Command("apt-get", "update")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			cmd = exec.Command("apt-get", "install", "-y", "erlfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			cmd := exec.Command("brew", "install", "erlfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err == nil {
+				return nil
+			}
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			cmd := exec.Command("choco", "install", "-y", "erlfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("erlfmt"); err == nil {
+				return nil
+			}
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			cmd := exec.Command("scoop", "install", "erlfmt")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+			if _, err := exec.LookPath("erlfmt"); err == nil {
+				return nil
+			}
+		}
+	}
+	if _, err := exec.LookPath("erlfmt"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("erlfmt not installed")
+}
+
 // Format attempts to pretty-print Erlang code using the official
 // `erlfmt` tool when available. If formatting fails or the tool isn't
 // installed, the input is returned unchanged with a trailing newline.
 func Format(src []byte) []byte {
+	_ = EnsureFormatter()
 	path, err := exec.LookPath("erlfmt")
 	if err == nil {
 		cmd := exec.Command(path, "-")
@@ -91,8 +153,17 @@ func Format(src []byte) []byte {
 			return res
 		}
 	}
-	if len(src) > 0 && src[len(src)-1] != '\n' {
-		src = append(src, '\n')
+	s := strings.ReplaceAll(string(src), "\t", "    ")
+	var buf bytes.Buffer
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), " \t")
+		buf.WriteString(line)
+		buf.WriteByte('\n')
 	}
-	return src
+	res := buf.Bytes()
+	if len(res) == 0 || res[len(res)-1] != '\n' {
+		res = append(res, '\n')
+	}
+	return res
 }

--- a/tests/compiler/erl/dataset.erl.out
+++ b/tests/compiler/erl/dataset.erl.out
@@ -5,15 +5,15 @@
 -record(person, {name, age}).
 
 main(_) ->
-	People = [#person{name="Alice", age=30}, #person{name="Bob", age=15}, #person{name="Charlie", age=65}],
-	Names = [P#person.name || P <- [P || P <- People, (P#person.age >= 18)]],
-	mochi_foreach(fun(N) ->
-		mochi_print([N])
-	end, Names).
+    People = [#person{name="Alice", age=30}, #person{name="Bob", age=15}, #person{name="Charlie", age=65}],
+    Names = [P#person.name || P <- [P || P <- People, (P#person.age >= 18)]],
+    mochi_foreach(fun(N) ->
+        mochi_print([N])
+    end, Names).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -21,12 +21,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl/dataset_sort_take_limit.erl.out
+++ b/tests/compiler/erl/dataset_sort_take_limit.erl.out
@@ -5,28 +5,28 @@
 -record(product, {name, price}).
 
 main(_) ->
-	Products = [#product{name="Laptop", price=1500}, #product{name="Smartphone", price=900}, #product{name="Tablet", price=600}, #product{name="Monitor", price=300}, #product{name="Keyboard", price=100}, #product{name="Mouse", price=50}, #product{name="Headphones", price=200}],
-	Expensive = (fun() ->
-	Items = [{-P#product.price, P} || P <- Products],
-	Sorted = begin
-		SPairs = lists:sort(fun({A,_},{B,_}) -> A =< B end, Items),
-		[ V || {_, V} <- SPairs ]
-	end,
-	Skipped = (case 1 of
-		N when N > 0 -> lists:nthtail(N, Sorted);
-		_ -> Sorted
-	end),
-	Taken = lists:sublist(Skipped, 3),
-	Taken
+    Products = [#product{name="Laptop", price=1500}, #product{name="Smartphone", price=900}, #product{name="Tablet", price=600}, #product{name="Monitor", price=300}, #product{name="Keyboard", price=100}, #product{name="Mouse", price=50}, #product{name="Headphones", price=200}],
+    Expensive = (fun() ->
+    Items = [{-P#product.price, P} || P <- Products],
+    Sorted = begin
+        SPairs = lists:sort(fun({A,_},{B,_}) -> A =< B end, Items),
+        [ V || {_, V} <- SPairs ]
+    end,
+    Skipped = (case 1 of
+        N when N > 0 -> lists:nthtail(N, Sorted);
+        _ -> Sorted
+    end),
+    Taken = lists:sublist(Skipped, 3),
+    Taken
 end)(),
-	mochi_print(["--- Top products (excluding most expensive) ---"]),
-	mochi_foreach(fun(Item) ->
-		mochi_print([Item#product.name, "costs $", Item#product.price])
-	end, Expensive).
+    mochi_print(["--- Top products (excluding most expensive) ---"]),
+    mochi_foreach(fun(Item) ->
+        mochi_print([Item#product.name, "costs $", Item#product.price])
+    end, Expensive).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -34,12 +34,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl/group_by.erl.out
+++ b/tests/compiler/erl/group_by.erl.out
@@ -3,15 +3,15 @@
 -export([main/1]).
 
 main(_) ->
-	Xs = [1, 1, 2],
-	Groups = [#{k => maps:get(key, G), c => mochi_count(G)} || G <- mochi_group_by(Xs, fun(X) -> X end)],
-	mochi_foreach(fun(G) ->
-		mochi_print([maps:get(k, G), maps:get(c, G)])
-	end, Groups).
+    Xs = [1, 1, 2],
+    Groups = [#{k => maps:get(key, G), c => mochi_count(G)} || G <- mochi_group_by(Xs, fun(X) -> X end)],
+    mochi_foreach(fun(G) ->
+        mochi_print([maps:get(k, G), maps:get(c, G)])
+    end, Groups).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -25,28 +25,28 @@ mochi_count(X) when is_binary(X) -> byte_size(X);
 mochi_count(_) -> erlang:error(badarg).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).
 
 mochi_group_by(Src, KeyFun) ->
-	{Groups, Order} = lists:foldl(fun(It, {G,O}) ->
-		Key = KeyFun(It),
-		KS = lists:flatten(io_lib:format("~p", [Key])),
-		case maps:get(KS, G, undefined) of
-			undefined ->
-				Group = #{key => Key, 'Items' => [It]},
-				{maps:put(KS, Group, G), O ++ [KS]};
-			Group0 ->
-				Items = maps:get('Items', Group0) ++ [It],
-				Group1 = maps:put('Items', Items, Group0),
-				{maps:put(KS, Group1, G), O}
-			end
-		end, {#{}, []}, Src),
-		[ maps:get(K, Groups) || K <- Order ].
+    {Groups, Order} = lists:foldl(fun(It, {G,O}) ->
+        Key = KeyFun(It),
+        KS = lists:flatten(io_lib:format("~p", [Key])),
+        case maps:get(KS, G, undefined) of
+            undefined ->
+                Group = #{key => Key, 'Items' => [It]},
+                {maps:put(KS, Group, G), O ++ [KS]};
+            Group0 ->
+                Items = maps:get('Items', Group0) ++ [It],
+                Group1 = maps:put('Items', Items, Group0),
+                {maps:put(KS, Group1, G), O}
+            end
+        end, {#{}, []}, Src),
+        [ maps:get(K, Groups) || K <- Order ].

--- a/tests/compiler/erl/load_save_json.erl.out
+++ b/tests/compiler/erl/load_save_json.erl.out
@@ -3,115 +3,115 @@
 -export([main/1]).
 
 main(_) ->
-	Rows = mochi_load("", #{format => "json"}),
-	mochi_save(Rows, "", #{format => "json"}).
+    Rows = mochi_load("", #{format => "json"}),
+    mochi_save(Rows, "", #{format => "json"}).
 
 
 mochi_load(Path, Opts) ->
-	case file:read_file(Path) of
-		{ok, Bin} ->
-			Format = case Opts of
-				undefined -> undefined;
-				O -> maps:get(format, O, undefined)
-			end,
-			Ext = filename:extension(Path),
-			Text = binary_to_list(Bin),
-			Data0 = case {Format, Ext} of
-				{"json", _} -> mochi_decode_json(Text);
-				{_, ".json"} -> mochi_decode_json(Text);
-				{_, ".txt"} -> Text;
-				_ -> binary_to_term(Bin)
-			end,
-			Data1 = mochi_filter(Data0, Opts),
-			mochi_paginate(Data1, Opts);
-		_ -> []
-	end.
+    case file:read_file(Path) of
+        {ok, Bin} ->
+            Format = case Opts of
+                undefined -> undefined;
+                O -> maps:get(format, O, undefined)
+            end,
+            Ext = filename:extension(Path),
+            Text = binary_to_list(Bin),
+            Data0 = case {Format, Ext} of
+                {"json", _} -> mochi_decode_json(Text);
+                {_, ".json"} -> mochi_decode_json(Text);
+                {_, ".txt"} -> Text;
+                _ -> binary_to_term(Bin)
+            end,
+            Data1 = mochi_filter(Data0, Opts),
+            mochi_paginate(Data1, Opts);
+        _ -> []
+    end.
 
 mochi_save(Data, Path, Opts) ->
-	Format = case Opts of
-		undefined -> undefined;
-		O -> maps:get(format, O, undefined)
-	end,
-	Ext = filename:extension(Path),
-	Bin = case {Format, Ext} of
-		{"json", _} -> list_to_binary(mochi_to_json(Data));
-		{_, ".json"} -> list_to_binary(mochi_to_json(Data));
-		{_, ".txt"} -> Data;
-		_ -> term_to_binary(Data)
-	end,
-	ok = file:write_file(Path, Bin).
+    Format = case Opts of
+        undefined -> undefined;
+        O -> maps:get(format, O, undefined)
+    end,
+    Ext = filename:extension(Path),
+    Bin = case {Format, Ext} of
+        {"json", _} -> list_to_binary(mochi_to_json(Data));
+        {_, ".json"} -> list_to_binary(mochi_to_json(Data));
+        {_, ".txt"} -> Data;
+        _ -> term_to_binary(Data)
+    end,
+    ok = file:write_file(Path, Bin).
 
 mochi_filter(Data, Opts) when Opts =:= undefined -> Data;
 mochi_filter(Data, Opts) when is_list(Data) ->
-	case maps:get(filter, Opts, undefined) of
-		undefined -> Data;
-		Fun when is_function(Fun,1) -> [ X || X <- Data, Fun(X) ];
-		_ -> Data
-	end;
+    case maps:get(filter, Opts, undefined) of
+        undefined -> Data;
+        Fun when is_function(Fun,1) -> [ X || X <- Data, Fun(X) ];
+        _ -> Data
+    end;
 mochi_filter(Data, _) -> Data.
 
 mochi_paginate(Data, Opts) when Opts =:= undefined -> Data;
 mochi_paginate(Data, Opts) when is_list(Data) ->
-	Skip = maps:get(skip, Opts, 0),
-	Take = maps:get(take, Opts, -1),
-	Skipped = case Skip of
-		N when is_integer(N), N > 0 -> lists:nthtail(N, Data);
-		_ -> Data
-	end,
-	case Take of
-		N when is_integer(N), N >= 0 -> lists:sublist(Skipped, N);
-		_ -> Skipped
-	end;
+    Skip = maps:get(skip, Opts, 0),
+    Take = maps:get(take, Opts, -1),
+    Skipped = case Skip of
+        N when is_integer(N), N > 0 -> lists:nthtail(N, Data);
+        _ -> Data
+    end,
+    case Take of
+        N when is_integer(N), N >= 0 -> lists:sublist(Skipped, N);
+        _ -> Skipped
+    end;
 mochi_paginate(Data, _) -> Data.
 
 mochi_decode_json(Text) ->
-	{Val, _} = mochi_json_value(string:trim(Text)),
-	Val.
+    {Val, _} = mochi_json_value(string:trim(Text)),
+    Val.
 
 mochi_json_value([] = S) -> {[], S};
 mochi_json_value([${}|S]) -> mochi_json_object(S, #{});
 mochi_json_value([$[|S]) -> mochi_json_array(S, []);
 mochi_json_value([$"|S]) ->
-	{Str, R} = mochi_json_string(S, []),
-	{Str, mochi_skip_ws(R)}.
+    {Str, R} = mochi_json_string(S, []),
+    {Str, mochi_skip_ws(R)}.
 mochi_json_value(S) ->
-	{Num, R} = mochi_json_number(S),
-	{Num, mochi_skip_ws(R)}.
+    {Num, R} = mochi_json_number(S),
+    {Num, mochi_skip_ws(R)}.
 
 mochi_json_array([$]|S], Acc) -> {lists:reverse(Acc), mochi_skip_ws(S)};
 mochi_json_array(S, Acc) ->
-	{Val, R0} = mochi_json_value(mochi_skip_ws(S)),
-	R1 = mochi_skip_ws(R0),
-	case R1 of
-		[$,|T] -> mochi_json_array(T, [Val|Acc]);
-		[$]|T] -> {lists:reverse([Val|Acc]), mochi_skip_ws(T)};
-		_ -> {lists:reverse([Val|Acc]), R1}
-	end.
+    {Val, R0} = mochi_json_value(mochi_skip_ws(S)),
+    R1 = mochi_skip_ws(R0),
+    case R1 of
+        [$,|T] -> mochi_json_array(T, [Val|Acc]);
+        [$]|T] -> {lists:reverse([Val|Acc]), mochi_skip_ws(T)};
+        _ -> {lists:reverse([Val|Acc]), R1}
+    end.
 
 mochi_json_object([$}|S], Acc) -> {Acc, mochi_skip_ws(S)};
 mochi_json_object(S, Acc) ->
-	{Key, R0} = mochi_json_string(mochi_skip_ws(S), []),
-	R1 = mochi_skip_ws(R0),
-	[$:|R2] = R1,
-	{Val, R3} = mochi_json_value(mochi_skip_ws(R2)),
-	R4 = mochi_skip_ws(R3),
-	Acc1 = maps:put(Key, Val, Acc),
-	case R4 of
-		[$,|T] -> mochi_json_object(T, Acc1);
-		[$}|T] -> {Acc1, mochi_skip_ws(T)};
-		_ -> {Acc1, R4}
-	end.
+    {Key, R0} = mochi_json_string(mochi_skip_ws(S), []),
+    R1 = mochi_skip_ws(R0),
+    [$:|R2] = R1,
+    {Val, R3} = mochi_json_value(mochi_skip_ws(R2)),
+    R4 = mochi_skip_ws(R3),
+    Acc1 = maps:put(Key, Val, Acc),
+    case R4 of
+        [$,|T] -> mochi_json_object(T, Acc1);
+        [$}|T] -> {Acc1, mochi_skip_ws(T)};
+        _ -> {Acc1, R4}
+    end.
 
 mochi_json_string([$\,C|S], Acc) -> mochi_json_string(S, [C|Acc]);
 mochi_json_string([$"|S], Acc) -> {lists:reverse(Acc), S};
 mochi_json_string([C|S], Acc) -> mochi_json_string(S, [C|Acc]).
 
 mochi_json_number(S) ->
-	{NumStr, Rest} = mochi_take_number(S, []),
-	case string:to_float(NumStr) of
-		{error, _} -> {list_to_integer(NumStr), Rest};
-		{F, _} -> {F, Rest}
-	end.
+    {NumStr, Rest} = mochi_take_number(S, []),
+    case string:to_float(NumStr) of
+        {error, _} -> {list_to_integer(NumStr), Rest};
+        {F, _} -> {F, Rest}
+    end.
 
 mochi_take_number([C|S], Acc) when C >= $0, C =< $9; C == $.; C == $-; C == $+ -> mochi_take_number(S, [C|Acc]);
 mochi_take_number(S, Acc) -> {lists:reverse(Acc), S}.
@@ -121,12 +121,12 @@ mochi_skip_ws(S) -> S.
 
 mochi_escape_json([]) -> [];
 mochi_escape_json([H|T]) ->
-	E = case H of
-		$\\ -> "\\\\";
-		$" -> "\\"";
-		_ -> [H]
-	end,
-	E ++ mochi_escape_json(T).
+    E = case H of
+        $\\ -> "\\\\";
+        $" -> "\\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
 
 mochi_to_json(true) -> "true";
 mochi_to_json(false) -> "false";

--- a/tests/compiler/erl/method.erl.out
+++ b/tests/compiler/erl/method.erl.out
@@ -4,30 +4,30 @@
 
 -record(circle, {radius}).
 circle_area(Self) ->
-	try
-		A = ((3.14 * Self#circle.radius) * Self#circle.radius),
-		mochi_print(["Calculating area:", A]),
-		throw({return, A})
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+        A = ((3.14 * Self#circle.radius) * Self#circle.radius),
+        mochi_print(["Calculating area:", A]),
+        throw({return, A})
+    catch
+        throw:{return, V} -> V
+    end.
 
 circle_describe(Self) ->
-	try
-		mochi_print(["Circle with radius", Self#circle.radius])
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+        mochi_print(["Circle with radius", Self#circle.radius])
+    catch
+        throw:{return, V} -> V
+    end.
 
 
 main(_) ->
-	C = #circle{radius=5},
-	circle_describe(C),
-	mochi_print(["Area is", circle_area(C)]).
+    C = #circle{radius=5},
+    circle_describe(C),
+    mochi_print(["Area is", circle_area(C)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl/outer_join.erl.out
+++ b/tests/compiler/erl/outer_join.erl.out
@@ -3,27 +3,27 @@
 -export([main/1]).
 
 main(_) ->
-	Customers = [#{id => 1, name => "Alice"}, #{id => 2, name => "Bob"}, #{id => 3, name => "Charlie"}, #{id => 4, name => "Diana"}],
-	Orders = [#{id => 100, customerId => 1, total => 250}, #{id => 101, customerId => 2, total => 125}, #{id => 102, customerId => 1, total => 300}, #{id => 103, customerId => 5, total => 80}],
-	Result = [#{order => O, customer => C} || {O, C} <- mochi_outer_join(Orders, Customers, fun(O, C) -> (maps:get(customerId, O) == maps:get(id, C)) end)],
-	mochi_print(["--- Outer Join using syntax ---"]),
-	mochi_foreach(fun(Row) ->
-				case maps:get(order, Row) of
-			true ->
-								case maps:get(customer, Row) of
-					true ->
-						mochi_print(["Order", maps:get(id, maps:get(order, Row)), "by", maps:get(name, maps:get(customer, Row)), "- $", maps:get(total, maps:get(order, Row))]);
-										_ ->
-						mochi_print(["Order", maps:get(id, maps:get(order, Row)), "by", "Unknown", "- $", maps:get(total, maps:get(order, Row))])
-				end;
-						_ ->
-				mochi_print(["Customer", maps:get(name, maps:get(customer, Row)), "has no orders"])
-		end
-	end, Result).
+    Customers = [#{id => 1, name => "Alice"}, #{id => 2, name => "Bob"}, #{id => 3, name => "Charlie"}, #{id => 4, name => "Diana"}],
+    Orders = [#{id => 100, customerId => 1, total => 250}, #{id => 101, customerId => 2, total => 125}, #{id => 102, customerId => 1, total => 300}, #{id => 103, customerId => 5, total => 80}],
+    Result = [#{order => O, customer => C} || {O, C} <- mochi_outer_join(Orders, Customers, fun(O, C) -> (maps:get(customerId, O) == maps:get(id, C)) end)],
+    mochi_print(["--- Outer Join using syntax ---"]),
+    mochi_foreach(fun(Row) ->
+                case maps:get(order, Row) of
+            true ->
+                                case maps:get(customer, Row) of
+                    true ->
+                        mochi_print(["Order", maps:get(id, maps:get(order, Row)), "by", maps:get(name, maps:get(customer, Row)), "- $", maps:get(total, maps:get(order, Row))]);
+                                        _ ->
+                        mochi_print(["Order", maps:get(id, maps:get(order, Row)), "by", "Unknown", "- $", maps:get(total, maps:get(order, Row))])
+                end;
+                        _ ->
+                mochi_print(["Customer", maps:get(name, maps:get(customer, Row)), "has no orders"])
+        end
+    end, Result).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -31,37 +31,37 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).
 
 mochi_left_join_item(A, B, Fun) ->
-	Matches = [ {A, J} || J <- B, Fun(A, J) ],
-	case Matches of
-		[] -> [{A, undefined}];
-		_ -> Matches
-	end.
+    Matches = [ {A, J} || J <- B, Fun(A, J) ],
+    case Matches of
+        [] -> [{A, undefined}];
+        _ -> Matches
+    end.
 
 mochi_left_join(L, R, Fun) ->
-	lists:flatmap(fun(X) -> mochi_left_join_item(X, R, Fun) end, L).
+    lists:flatmap(fun(X) -> mochi_left_join_item(X, R, Fun) end, L).
 
 mochi_right_join_item(B, A, Fun) ->
-	Matches = [ {I, B} || I <- A, Fun(I, B) ],
-	case Matches of
-		[] -> [{undefined, B}];
-		_ -> Matches
-	end.
+    Matches = [ {I, B} || I <- A, Fun(I, B) ],
+    case Matches of
+        [] -> [{undefined, B}];
+        _ -> Matches
+    end.
 
 mochi_right_join(L, R, Fun) ->
-	lists:flatmap(fun(Y) -> mochi_right_join_item(Y, L, Fun) end, R).
+    lists:flatmap(fun(Y) -> mochi_right_join_item(Y, L, Fun) end, R).
 
 mochi_outer_join(L, R, Fun) ->
-	Left = mochi_left_join(L, R, Fun),
-	Right = [ P || P = {undefined, _} <- mochi_right_join(L, R, Fun) ],
-	Left ++ Right.
+    Left = mochi_left_join(L, R, Fun),
+    Right = [ P || P = {undefined, _} <- mochi_right_join(L, R, Fun) ],
+    Left ++ Right.

--- a/tests/compiler/erl/q1.erl.out
+++ b/tests/compiler/erl/q1.erl.out
@@ -3,14 +3,14 @@
 -export([main/1, test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0]).
 
 test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() ->
-	mochi_expect((Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => ((950 * 1.07) + (1800 * 1.05)), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}])).
+    mochi_expect((Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => ((950 * 1.07) + (1800 * 1.05)), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}])).
 
 main(_) ->
-	Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
-	Result = [#{returnflag => maps:get(returnflag, maps:get(key, G)), linestatus => maps:get(linestatus, maps:get(key, G)), sum_qty => mochi_sum([maps:get(l_quantity, X) || X <- G]), sum_base_price => mochi_sum([maps:get(l_extendedprice, X) || X <- G]), sum_disc_price => mochi_sum([(maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) || X <- G]), sum_charge => mochi_sum([((maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) * (1 + maps:get(l_tax, X))) || X <- G]), avg_qty => mochi_avg([maps:get(l_quantity, X) || X <- G]), avg_price => mochi_avg([maps:get(l_extendedprice, X) || X <- G]), avg_disc => mochi_avg([maps:get(l_discount, X) || X <- G]), count_order => mochi_count(G)} || G <- mochi_group_by([Row || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")], fun(Row) -> #{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)} end)],
-	mochi_json(Result)
+    Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
+    Result = [#{returnflag => maps:get(returnflag, maps:get(key, G)), linestatus => maps:get(linestatus, maps:get(key, G)), sum_qty => mochi_sum([maps:get(l_quantity, X) || X <- G]), sum_base_price => mochi_sum([maps:get(l_extendedprice, X) || X <- G]), sum_disc_price => mochi_sum([(maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) || X <- G]), sum_charge => mochi_sum([((maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) * (1 + maps:get(l_tax, X))) || X <- G]), avg_qty => mochi_avg([maps:get(l_quantity, X) || X <- G]), avg_price => mochi_avg([maps:get(l_extendedprice, X) || X <- G]), avg_disc => mochi_avg([maps:get(l_discount, X) || X <- G]), count_order => mochi_count(G)} || G <- mochi_group_by([Row || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")], fun(Row) -> #{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)} end)],
+    mochi_json(Result)
 ,
-	mochi_run_test("Q1 aggregates revenue and quantity by returnflag + linestatus", fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0).
+    mochi_run_test("Q1 aggregates revenue and quantity by returnflag + linestatus", fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0).
 
 mochi_count(X) when is_list(X) -> length(X);
 mochi_count(X) when is_map(X), maps:is_key('Items', X) -> length(maps:get('Items', X));
@@ -21,76 +21,76 @@ mochi_count(_) -> erlang:error(badarg).
 mochi_avg([]) -> 0;
 mochi_avg(M) when is_map(M), maps:is_key('Items', M) -> mochi_avg(maps:get('Items', M));
 mochi_avg(L) when is_list(L) ->
-	Sum = lists:foldl(fun(X, Acc) ->
-		case X of
-			I when is_integer(I) -> Acc + I;
-			F when is_float(F) -> Acc + F;
-			_ -> erlang:error(badarg) end
-		end, 0, L),
-		Sum / length(L);
-	mochi_avg(_) -> erlang:error(badarg).
+    Sum = lists:foldl(fun(X, Acc) ->
+        case X of
+            I when is_integer(I) -> Acc + I;
+            F when is_float(F) -> Acc + F;
+            _ -> erlang:error(badarg) end
+        end, 0, L),
+        Sum / length(L);
+    mochi_avg(_) -> erlang:error(badarg).
 
 mochi_sum([]) -> 0;
 mochi_sum(M) when is_map(M), maps:is_key('Items', M) -> mochi_sum(maps:get('Items', M));
 mochi_sum(L) when is_list(L) ->
-	lists:foldl(fun(X, Acc) ->
-		case X of
-			I when is_integer(I) -> Acc + I;
-			F when is_float(F) -> Acc + F;
-			_ -> erlang:error(badarg) end
-		end, 0, L);
-	mochi_sum(_) -> erlang:error(badarg).
+    lists:foldl(fun(X, Acc) ->
+        case X of
+            I when is_integer(I) -> Acc + I;
+            F when is_float(F) -> Acc + F;
+            _ -> erlang:error(badarg) end
+        end, 0, L);
+    mochi_sum(_) -> erlang:error(badarg).
 
 
 mochi_group_by(Src, KeyFun) ->
-	{Groups, Order} = lists:foldl(fun(It, {G,O}) ->
-		Key = KeyFun(It),
-		KS = lists:flatten(io_lib:format("~p", [Key])),
-		case maps:get(KS, G, undefined) of
-			undefined ->
-				Group = #{key => Key, 'Items' => [It]},
-				{maps:put(KS, Group, G), O ++ [KS]};
-			Group0 ->
-				Items = maps:get('Items', Group0) ++ [It],
-				Group1 = maps:put('Items', Items, Group0),
-				{maps:put(KS, Group1, G), O}
-			end
-		end, {#{}, []}, Src),
-		[ maps:get(K, Groups) || K <- Order ].
-	
-	mochi_escape_json([]) -> [];
-	mochi_escape_json([H|T]) ->
-		E = case H of
-			$\\ -> "\\\\";
-			$" -> "\\"";
-			_ -> [H]
-		end,
-		E ++ mochi_escape_json(T).
-	
-	mochi_to_json(true) -> "true";
-	mochi_to_json(false) -> "false";
-	mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
-	mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
-	mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
-	mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
-	mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
-	
-	mochi_json(V) -> io:format("~s~n", [mochi_to_json(V)]).
-	
-	mochi_expect(true) -> ok;
-	mochi_expect(_) -> erlang:error(expect_failed).
-	
-	mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
-	mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
-	mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
-	
-	mochi_run_test(Name, Fun) ->
-		mochi_test_start(Name),
-		Start = erlang:monotonic_time(millisecond),
-		try Fun() of _ ->
-			Duration = erlang:monotonic_time(millisecond) - Start,
-			mochi_test_pass(Duration)
-		catch C:R ->
-			Duration = erlang:monotonic_time(millisecond) - Start,
-			mochi_test_fail({C,R}, Duration)
-		end.
+    {Groups, Order} = lists:foldl(fun(It, {G,O}) ->
+        Key = KeyFun(It),
+        KS = lists:flatten(io_lib:format("~p", [Key])),
+        case maps:get(KS, G, undefined) of
+            undefined ->
+                Group = #{key => Key, 'Items' => [It]},
+                {maps:put(KS, Group, G), O ++ [KS]};
+            Group0 ->
+                Items = maps:get('Items', Group0) ++ [It],
+                Group1 = maps:put('Items', Items, Group0),
+                {maps:put(KS, Group1, G), O}
+            end
+        end, {#{}, []}, Src),
+        [ maps:get(K, Groups) || K <- Order ].
+
+    mochi_escape_json([]) -> [];
+    mochi_escape_json([H|T]) ->
+        E = case H of
+            $\\ -> "\\\\";
+            $" -> "\\"";
+            _ -> [H]
+        end,
+        E ++ mochi_escape_json(T).
+
+    mochi_to_json(true) -> "true";
+    mochi_to_json(false) -> "false";
+    mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
+    mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
+    mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
+    mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
+    mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
+
+    mochi_json(V) -> io:format("~s~n", [mochi_to_json(V)]).
+
+    mochi_expect(true) -> ok;
+    mochi_expect(_) -> erlang:error(expect_failed).
+
+    mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
+    mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
+    mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
+
+    mochi_run_test(Name, Fun) ->
+        mochi_test_start(Name),
+        Start = erlang:monotonic_time(millisecond),
+        try Fun() of _ ->
+            Duration = erlang:monotonic_time(millisecond) - Start,
+            mochi_test_pass(Duration)
+        catch C:R ->
+            Duration = erlang:monotonic_time(millisecond) - Start,
+            mochi_test_fail({C,R}, Duration)
+        end.

--- a/tests/compiler/erl/right_join.erl.out
+++ b/tests/compiler/erl/right_join.erl.out
@@ -3,22 +3,22 @@
 -export([main/1]).
 
 main(_) ->
-	Customers = [#{id => 1, name => "Alice"}, #{id => 2, name => "Bob"}, #{id => 3, name => "Charlie"}, #{id => 4, name => "Diana"}],
-	Orders = [#{id => 100, customerId => 1, total => 250}, #{id => 101, customerId => 2, total => 125}, #{id => 102, customerId => 1, total => 300}],
-	Result = [#{customerName => maps:get(name, C), order => O} || {C, O} <- mochi_right_join(Customers, Orders, fun(C, O) -> (maps:get(customerId, O) == maps:get(id, C)) end)],
-	mochi_print(["--- Right Join using syntax ---"]),
-	mochi_foreach(fun(Entry) ->
-				case maps:get(order, Entry) of
-			true ->
-				mochi_print(["Customer", maps:get(customerName, Entry), "has order", maps:get(id, maps:get(order, Entry)), "- $", maps:get(total, maps:get(order, Entry))]);
-						_ ->
-				mochi_print(["Customer", maps:get(customerName, Entry), "has no orders"])
-		end
-	end, Result).
+    Customers = [#{id => 1, name => "Alice"}, #{id => 2, name => "Bob"}, #{id => 3, name => "Charlie"}, #{id => 4, name => "Diana"}],
+    Orders = [#{id => 100, customerId => 1, total => 250}, #{id => 101, customerId => 2, total => 125}, #{id => 102, customerId => 1, total => 300}],
+    Result = [#{customerName => maps:get(name, C), order => O} || {C, O} <- mochi_right_join(Customers, Orders, fun(C, O) -> (maps:get(customerId, O) == maps:get(id, C)) end)],
+    mochi_print(["--- Right Join using syntax ---"]),
+    mochi_foreach(fun(Entry) ->
+                case maps:get(order, Entry) of
+            true ->
+                mochi_print(["Customer", maps:get(customerName, Entry), "has order", maps:get(id, maps:get(order, Entry)), "- $", maps:get(total, maps:get(order, Entry))]);
+                        _ ->
+                mochi_print(["Customer", maps:get(customerName, Entry), "has no orders"])
+        end
+    end, Result).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -26,22 +26,22 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).
 
 mochi_right_join_item(B, A, Fun) ->
-	Matches = [ {I, B} || I <- A, Fun(I, B) ],
-	case Matches of
-		[] -> [{undefined, B}];
-		_ -> Matches
-	end.
+    Matches = [ {I, B} || I <- A, Fun(I, B) ],
+    case Matches of
+        [] -> [{undefined, B}];
+        _ -> Matches
+    end.
 
 mochi_right_join(L, R, Fun) ->
-	lists:flatmap(fun(Y) -> mochi_right_join_item(Y, L, Fun) end, R).
+    lists:flatmap(fun(Y) -> mochi_right_join_item(Y, L, Fun) end, R).

--- a/tests/compiler/erl/tpch_q1.erl.out
+++ b/tests/compiler/erl/tpch_q1.erl.out
@@ -3,14 +3,14 @@
 -export([main/1, test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0]).
 
 test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() ->
-	mochi_expect((Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => ((950 * 1.07) + (1800 * 1.05)), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}])).
+    mochi_expect((Result == [#{returnflag => "N", linestatus => "O", sum_qty => 53, sum_base_price => 3000, sum_disc_price => (950 + 1800), sum_charge => ((950 * 1.07) + (1800 * 1.05)), avg_qty => 26.5, avg_price => 1500, avg_disc => 0.07500000000000001, count_order => 2}])).
 
 main(_) ->
-	Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
-	Result = [#{returnflag => maps:get(returnflag, maps:get(key, G)), linestatus => maps:get(linestatus, maps:get(key, G)), sum_qty => mochi_sum([maps:get(l_quantity, X) || X <- G]), sum_base_price => mochi_sum([maps:get(l_extendedprice, X) || X <- G]), sum_disc_price => mochi_sum([(maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) || X <- G]), sum_charge => mochi_sum([((maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) * (1 + maps:get(l_tax, X))) || X <- G]), avg_qty => mochi_avg([maps:get(l_quantity, X) || X <- G]), avg_price => mochi_avg([maps:get(l_extendedprice, X) || X <- G]), avg_disc => mochi_avg([maps:get(l_discount, X) || X <- G]), count_order => mochi_count(G)} || G <- mochi_group_by([Row || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")], fun(Row) -> #{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)} end)],
-	mochi_json(Result)
+    Lineitem = [#{l_quantity => 17, l_extendedprice => 1000, l_discount => 0.05, l_tax => 0.07, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-08-01"}, #{l_quantity => 36, l_extendedprice => 2000, l_discount => 0.1, l_tax => 0.05, l_returnflag => "N", l_linestatus => "O", l_shipdate => "1998-09-01"}, #{l_quantity => 25, l_extendedprice => 1500, l_discount => 0, l_tax => 0.08, l_returnflag => "R", l_linestatus => "F", l_shipdate => "1998-09-03"}],
+    Result = [#{returnflag => maps:get(returnflag, maps:get(key, G)), linestatus => maps:get(linestatus, maps:get(key, G)), sum_qty => mochi_sum([maps:get(l_quantity, X) || X <- G]), sum_base_price => mochi_sum([maps:get(l_extendedprice, X) || X <- G]), sum_disc_price => mochi_sum([(maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) || X <- G]), sum_charge => mochi_sum([((maps:get(l_extendedprice, X) * (1 - maps:get(l_discount, X))) * (1 + maps:get(l_tax, X))) || X <- G]), avg_qty => mochi_avg([maps:get(l_quantity, X) || X <- G]), avg_price => mochi_avg([maps:get(l_extendedprice, X) || X <- G]), avg_disc => mochi_avg([maps:get(l_discount, X) || X <- G]), count_order => mochi_count(G)} || G <- mochi_group_by([Row || Row <- Lineitem, (maps:get(l_shipdate, Row) =< "1998-09-02")], fun(Row) -> #{returnflag => maps:get(l_returnflag, Row), linestatus => maps:get(l_linestatus, Row)} end)],
+    mochi_json(Result)
 ,
-	mochi_run_test("Q1 aggregates revenue and quantity by returnflag + linestatus", fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0).
+    mochi_run_test("Q1 aggregates revenue and quantity by returnflag + linestatus", fun test_q1_aggregates_revenue_and_quantity_by_returnflag___linestatus/0).
 
 mochi_count(X) when is_list(X) -> length(X);
 mochi_count(X) when is_map(X), maps:is_key('Items', X) -> length(maps:get('Items', X));
@@ -21,76 +21,76 @@ mochi_count(_) -> erlang:error(badarg).
 mochi_avg([]) -> 0;
 mochi_avg(M) when is_map(M), maps:is_key('Items', M) -> mochi_avg(maps:get('Items', M));
 mochi_avg(L) when is_list(L) ->
-	Sum = lists:foldl(fun(X, Acc) ->
-		case X of
-			I when is_integer(I) -> Acc + I;
-			F when is_float(F) -> Acc + F;
-			_ -> erlang:error(badarg) end
-		end, 0, L),
-		Sum / length(L);
-	mochi_avg(_) -> erlang:error(badarg).
+    Sum = lists:foldl(fun(X, Acc) ->
+        case X of
+            I when is_integer(I) -> Acc + I;
+            F when is_float(F) -> Acc + F;
+            _ -> erlang:error(badarg) end
+        end, 0, L),
+        Sum / length(L);
+    mochi_avg(_) -> erlang:error(badarg).
 
 mochi_sum([]) -> 0;
 mochi_sum(M) when is_map(M), maps:is_key('Items', M) -> mochi_sum(maps:get('Items', M));
 mochi_sum(L) when is_list(L) ->
-	lists:foldl(fun(X, Acc) ->
-		case X of
-			I when is_integer(I) -> Acc + I;
-			F when is_float(F) -> Acc + F;
-			_ -> erlang:error(badarg) end
-		end, 0, L);
-	mochi_sum(_) -> erlang:error(badarg).
+    lists:foldl(fun(X, Acc) ->
+        case X of
+            I when is_integer(I) -> Acc + I;
+            F when is_float(F) -> Acc + F;
+            _ -> erlang:error(badarg) end
+        end, 0, L);
+    mochi_sum(_) -> erlang:error(badarg).
 
 
 mochi_group_by(Src, KeyFun) ->
-	{Groups, Order} = lists:foldl(fun(It, {G,O}) ->
-		Key = KeyFun(It),
-		KS = lists:flatten(io_lib:format("~p", [Key])),
-		case maps:get(KS, G, undefined) of
-			undefined ->
-				Group = #{key => Key, 'Items' => [It]},
-				{maps:put(KS, Group, G), O ++ [KS]};
-			Group0 ->
-				Items = maps:get('Items', Group0) ++ [It],
-				Group1 = maps:put('Items', Items, Group0),
-				{maps:put(KS, Group1, G), O}
-			end
-		end, {#{}, []}, Src),
-		[ maps:get(K, Groups) || K <- Order ].
-	
-	mochi_escape_json([]) -> [];
-	mochi_escape_json([H|T]) ->
-		E = case H of
-			$\\ -> "\\\\";
-			$" -> "\\"";
-			_ -> [H]
-		end,
-		E ++ mochi_escape_json(T).
-	
-	mochi_to_json(true) -> "true";
-	mochi_to_json(false) -> "false";
-	mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
-	mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
-	mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
-	mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
-	mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
-	
-	mochi_json(V) -> io:format("~s~n", [mochi_to_json(V)]).
-	
-	mochi_expect(true) -> ok;
-	mochi_expect(_) -> erlang:error(expect_failed).
-	
-	mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
-	mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
-	mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
-	
-	mochi_run_test(Name, Fun) ->
-		mochi_test_start(Name),
-		Start = erlang:monotonic_time(millisecond),
-		try Fun() of _ ->
-			Duration = erlang:monotonic_time(millisecond) - Start,
-			mochi_test_pass(Duration)
-		catch C:R ->
-			Duration = erlang:monotonic_time(millisecond) - Start,
-			mochi_test_fail({C,R}, Duration)
-		end.
+    {Groups, Order} = lists:foldl(fun(It, {G,O}) ->
+        Key = KeyFun(It),
+        KS = lists:flatten(io_lib:format("~p", [Key])),
+        case maps:get(KS, G, undefined) of
+            undefined ->
+                Group = #{key => Key, 'Items' => [It]},
+                {maps:put(KS, Group, G), O ++ [KS]};
+            Group0 ->
+                Items = maps:get('Items', Group0) ++ [It],
+                Group1 = maps:put('Items', Items, Group0),
+                {maps:put(KS, Group1, G), O}
+            end
+        end, {#{}, []}, Src),
+        [ maps:get(K, Groups) || K <- Order ].
+
+    mochi_escape_json([]) -> [];
+    mochi_escape_json([H|T]) ->
+        E = case H of
+            $\\ -> "\\\\";
+            $" -> "\\"";
+            _ -> [H]
+        end,
+        E ++ mochi_escape_json(T).
+
+    mochi_to_json(true) -> "true";
+    mochi_to_json(false) -> "false";
+    mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
+    mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
+    mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
+    mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
+    mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
+
+    mochi_json(V) -> io:format("~s~n", [mochi_to_json(V)]).
+
+    mochi_expect(true) -> ok;
+    mochi_expect(_) -> erlang:error(expect_failed).
+
+    mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
+    mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
+    mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
+
+    mochi_run_test(Name, Fun) ->
+        mochi_test_start(Name),
+        Start = erlang:monotonic_time(millisecond),
+        try Fun() of _ ->
+            Duration = erlang:monotonic_time(millisecond) - Start,
+            mochi_test_pass(Duration)
+        catch C:R ->
+            Duration = erlang:monotonic_time(millisecond) - Start,
+            mochi_test_fail({C,R}, Duration)
+        end.

--- a/tests/compiler/erl_simple/arithmetic.erl.out
+++ b/tests/compiler/erl_simple/arithmetic.erl.out
@@ -3,15 +3,15 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([(1 + 2)]),
-	mochi_print([(5 - 3)]),
-	mochi_print([(4 * 2)]),
-	mochi_print([(8 / 2)]),
-	mochi_print([(7 % 3)]).
+    mochi_print([(1 + 2)]),
+    mochi_print([(5 - 3)]),
+    mochi_print([(4 * 2)]),
+    mochi_print([(8 / 2)]),
+    mochi_print([(7 % 3)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/avg_builtin.erl.out
+++ b/tests/compiler/erl_simple/avg_builtin.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_avg([1, 2, 3])]).
+    mochi_print([mochi_avg([1, 2, 3])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -17,11 +17,11 @@ mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 mochi_avg([]) -> 0;
 mochi_avg(M) when is_map(M), maps:is_key('Items', M) -> mochi_avg(maps:get('Items', M));
 mochi_avg(L) when is_list(L) ->
-	Sum = lists:foldl(fun(X, Acc) ->
-		case X of
-			I when is_integer(I) -> Acc + I;
-			F when is_float(F) -> Acc + F;
-			_ -> erlang:error(badarg) end
-		end, 0, L),
-		Sum / length(L);
-	mochi_avg(_) -> erlang:error(badarg).
+    Sum = lists:foldl(fun(X, Acc) ->
+        case X of
+            I when is_integer(I) -> Acc + I;
+            F when is_float(F) -> Acc + F;
+            _ -> erlang:error(badarg) end
+        end, 0, L),
+        Sum / length(L);
+    mochi_avg(_) -> erlang:error(badarg).

--- a/tests/compiler/erl_simple/bool_ops.erl.out
+++ b/tests/compiler/erl_simple/bool_ops.erl.out
@@ -3,13 +3,13 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([(true and false)]),
-	mochi_print([(true or false)]),
-	mochi_print([not false]).
+    mochi_print([(true and false)]),
+    mochi_print([(true or false)]),
+    mochi_print([not false]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/break_continue.erl.out
+++ b/tests/compiler/erl_simple/break_continue.erl.out
@@ -3,24 +3,24 @@
 -export([main/1]).
 
 main(_) ->
-	Numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9],
-	mochi_foreach(fun(N) ->
-				case ((N % 2) == 0) of
-			true ->
-				throw(mochi_continue);
-						_ -> ok
-		end,
-				case (N > 7) of
-			true ->
-				throw(mochi_break);
-						_ -> ok
-		end,
-		mochi_print(["odd number:", N])
-	end, Numbers).
+    Numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    mochi_foreach(fun(N) ->
+                case ((N % 2) == 0) of
+            true ->
+                throw(mochi_continue);
+                        _ -> ok
+        end,
+                case (N > 7) of
+            true ->
+                throw(mochi_break);
+                        _ -> ok
+        end,
+        mochi_print(["odd number:", N])
+    end, Numbers).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -28,12 +28,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl_simple/closure.erl.out
+++ b/tests/compiler/erl_simple/closure.erl.out
@@ -3,25 +3,25 @@
 -export([main/1, 'makeAdder'/1]).
 
 'makeAdder'(N) ->
-	try
-		throw({return, fun(X) ->
-		try
-			throw({return, (X + N)})
-		catch
-			throw:{return, V} -> V
-		end
+    try
+        throw({return, fun(X) ->
+        try
+            throw({return, (X + N)})
+        catch
+            throw:{return, V} -> V
+        end
 end})
-	catch
-		throw:{return, V} -> V
-	end.
+    catch
+        throw:{return, V} -> V
+    end.
 
 main(_) ->
-	Add10 = 'makeAdder'(10),
-	mochi_print([Add10(7)]).
+    Add10 = 'makeAdder'(10),
+    mochi_print([Add10(7)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/count_builtin.erl.out
+++ b/tests/compiler/erl_simple/count_builtin.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_count([1, 2, 3])]).
+    mochi_print([mochi_count([1, 2, 3])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/cross_join.erl.out
+++ b/tests/compiler/erl_simple/cross_join.erl.out
@@ -7,17 +7,17 @@
 -record(pairinfo, {orderid, ordercustomerid, pairedcustomername, ordertotal}).
 
 main(_) ->
-	Customers = [#customer{id=1, name="Alice"}, #customer{id=2, name="Bob"}, #customer{id=3, name="Charlie"}],
-	Orders = [#order{id=100, customerid=1, total=250}, #order{id=101, customerid=2, total=125}, #order{id=102, customerid=1, total=300}],
-	Result = [#pairinfo{orderid=O#order.id, ordercustomerid=O#order.customerid, pairedcustomername=C#customer.name, ordertotal=O#order.total} || O <- Orders, C <- Customers],
-	mochi_print(["--- Cross Join: All order-customer pairs ---"]),
-	mochi_foreach(fun(Entry) ->
-		mochi_print(["Order", Entry#pairinfo.orderid, "(customerId:", Entry#pairinfo.ordercustomerid, ", total: $", Entry#pairinfo.ordertotal, ") paired with", Entry#pairinfo.pairedcustomername])
-	end, Result).
+    Customers = [#customer{id=1, name="Alice"}, #customer{id=2, name="Bob"}, #customer{id=3, name="Charlie"}],
+    Orders = [#order{id=100, customerid=1, total=250}, #order{id=101, customerid=2, total=125}, #order{id=102, customerid=1, total=300}],
+    Result = [#pairinfo{orderid=O#order.id, ordercustomerid=O#order.customerid, pairedcustomername=C#customer.name, ordertotal=O#order.total} || O <- Orders, C <- Customers],
+    mochi_print(["--- Cross Join: All order-customer pairs ---"]),
+    mochi_foreach(fun(Entry) ->
+        mochi_print(["Order", Entry#pairinfo.orderid, "(customerId:", Entry#pairinfo.ordercustomerid, ", total: $", Entry#pairinfo.ordertotal, ") paired with", Entry#pairinfo.pairedcustomername])
+    end, Result).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -25,12 +25,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl_simple/cross_join_triple.erl.out
+++ b/tests/compiler/erl_simple/cross_join_triple.erl.out
@@ -3,18 +3,18 @@
 -export([main/1]).
 
 main(_) ->
-	Nums = [1, 2],
-	Letters = ["A", "B"],
-	Bools = [true, false],
-	Combos = [#{n => N, l => L, b => B} || N <- Nums, L <- Letters, B <- Bools],
-	mochi_print(["--- Cross Join of three lists ---"]),
-	mochi_foreach(fun(C) ->
-		mochi_print([maps:get(n, C), maps:get(l, C), maps:get(b, C)])
-	end, Combos).
+    Nums = [1, 2],
+    Letters = ["A", "B"],
+    Bools = [true, false],
+    Combos = [#{n => N, l => L, b => B} || N <- Nums, L <- Letters, B <- Bools],
+    mochi_print(["--- Cross Join of three lists ---"]),
+    mochi_foreach(fun(C) ->
+        mochi_print([maps:get(n, C), maps:get(l, C), maps:get(b, C)])
+    end, Combos).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -22,12 +22,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl_simple/dataset.erl.out
+++ b/tests/compiler/erl_simple/dataset.erl.out
@@ -5,15 +5,15 @@
 -record(person, {name, age}).
 
 main(_) ->
-	People = [#person{name="Alice", age=30}, #person{name="Bob", age=15}, #person{name="Charlie", age=65}],
-	Names = [P#person.name || P <- [P || P <- People, (P#person.age >= 18)]],
-	mochi_foreach(fun(N) ->
-		mochi_print([N])
-	end, Names).
+    People = [#person{name="Alice", age=30}, #person{name="Bob", age=15}, #person{name="Charlie", age=65}],
+    Names = [P#person.name || P <- [P || P <- People, (P#person.age >= 18)]],
+    mochi_foreach(fun(N) ->
+        mochi_print([N])
+    end, Names).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -21,12 +21,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl_simple/dataset_sort_take_limit.erl.out
+++ b/tests/compiler/erl_simple/dataset_sort_take_limit.erl.out
@@ -5,28 +5,28 @@
 -record(product, {name, price}).
 
 main(_) ->
-	Products = [#product{name="Laptop", price=1500}, #product{name="Smartphone", price=900}, #product{name="Tablet", price=600}, #product{name="Monitor", price=300}, #product{name="Keyboard", price=100}, #product{name="Mouse", price=50}, #product{name="Headphones", price=200}],
-	Expensive = (fun() ->
-	Items = [{-P#product.price, P} || P <- Products],
-	Sorted = begin
-		SPairs = lists:sort(fun({A,_},{B,_}) -> A =< B end, Items),
-		[ V || {_, V} <- SPairs ]
-	end,
-	Skipped = (case 1 of
-		N when N > 0 -> lists:nthtail(N, Sorted);
-		_ -> Sorted
-	end),
-	Taken = lists:sublist(Skipped, 3),
-	Taken
+    Products = [#product{name="Laptop", price=1500}, #product{name="Smartphone", price=900}, #product{name="Tablet", price=600}, #product{name="Monitor", price=300}, #product{name="Keyboard", price=100}, #product{name="Mouse", price=50}, #product{name="Headphones", price=200}],
+    Expensive = (fun() ->
+    Items = [{-P#product.price, P} || P <- Products],
+    Sorted = begin
+        SPairs = lists:sort(fun({A,_},{B,_}) -> A =< B end, Items),
+        [ V || {_, V} <- SPairs ]
+    end,
+    Skipped = (case 1 of
+        N when N > 0 -> lists:nthtail(N, Sorted);
+        _ -> Sorted
+    end),
+    Taken = lists:sublist(Skipped, 3),
+    Taken
 end)(),
-	mochi_print(["--- Top products (excluding most expensive) ---"]),
-	mochi_foreach(fun(Item) ->
-		mochi_print([Item#product.name, "costs $", Item#product.price])
-	end, Expensive).
+    mochi_print(["--- Top products (excluding most expensive) ---"]),
+    mochi_foreach(fun(Item) ->
+        mochi_print([Item#product.name, "costs $", Item#product.price])
+    end, Expensive).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -34,12 +34,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl_simple/fetch_builtin.erl.out
+++ b/tests/compiler/erl_simple/fetch_builtin.erl.out
@@ -5,12 +5,12 @@
 -record(msg, {message}).
 
 main(_) ->
-	Data = mochi_fetch("file://tests/compiler/erl_simple/fetch_builtin.json", undefined),
-	mochi_print([Data#msg.message]).
+    Data = mochi_fetch("file://tests/compiler/erl_simple/fetch_builtin.json", undefined),
+    mochi_print([Data#msg.message]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -19,57 +19,57 @@ mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 
 mochi_fetch(Url, Opts) when Opts =:= undefined ->
-	mochi_fetch(Url, #{});
+    mochi_fetch(Url, #{});
 mochi_fetch(Url, Opts) ->
-	application:ensure_all_started(inets),
-	Method0 = maps:get(method, Opts, get),
-	Method = case Method0 of
-		M when is_atom(M) -> M;
-		M when is_list(M) -> list_to_atom(string:lowercase(M));
-		M when is_binary(M) -> list_to_atom(string:lowercase(binary_to_list(M)));
-		_ -> get
-	end,
-	Query = maps:get(query, Opts, undefined),
-	Url1 = case Query of
-		undefined -> Url;
-		Q ->
-			Pairs = [ K ++ "=" ++ lists:flatten(io_lib:format("~p", [V])) || {K,V} <- maps:to_list(Q) ],
-			Sep = case lists:member($?, Url) of true -> "&"; false -> "?" end,
-			Url ++ Sep ++ string:join(Pairs, "&")
-		end,
-	HeadersMap = maps:get(headers, Opts, #{}),
-	Headers = [ {K, case V of B when is_binary(V) -> binary_to_list(V); _ -> lists:flatten(io_lib:format("~p", [V])) end} || {K,V} <- maps:to_list(HeadersMap) ],
-	BodyOpt = maps:get(body, Opts, undefined),
-	Req = case BodyOpt of
-		undefined -> {Url1, Headers};
-		B -> {Url1, Headers, "application/json", list_to_binary(mochi_to_json(B))}
-	end,
-	TimeoutOpt = maps:get(timeout, Opts, undefined),
-	HTTPOpts = case TimeoutOpt of
-		undefined -> [];
-		T when is_integer(T) -> [{timeout, T * 1000}];
-		T when is_float(T) -> [{timeout, trunc(T * 1000)}];
-		_ -> []
-	end,
-	case string:prefix(Url1, "file://") of
-		true ->
-			{ok, Bin} = file:read_file(string:substr(Url1, 8)),
-			mochi_decode_json(binary_to_list(Bin));
-		_ ->
-			case httpc:request(Method, Req, HTTPOpts, []) of
-				{ok, {{_, 200, _}, _H, Body}} -> mochi_decode_json(binary_to_list(Body));
-				_ -> #{}
-			end
-		end.
+    application:ensure_all_started(inets),
+    Method0 = maps:get(method, Opts, get),
+    Method = case Method0 of
+        M when is_atom(M) -> M;
+        M when is_list(M) -> list_to_atom(string:lowercase(M));
+        M when is_binary(M) -> list_to_atom(string:lowercase(binary_to_list(M)));
+        _ -> get
+    end,
+    Query = maps:get(query, Opts, undefined),
+    Url1 = case Query of
+        undefined -> Url;
+        Q ->
+            Pairs = [ K ++ "=" ++ lists:flatten(io_lib:format("~p", [V])) || {K,V} <- maps:to_list(Q) ],
+            Sep = case lists:member($?, Url) of true -> "&"; false -> "?" end,
+            Url ++ Sep ++ string:join(Pairs, "&")
+        end,
+    HeadersMap = maps:get(headers, Opts, #{}),
+    Headers = [ {K, case V of B when is_binary(V) -> binary_to_list(V); _ -> lists:flatten(io_lib:format("~p", [V])) end} || {K,V} <- maps:to_list(HeadersMap) ],
+    BodyOpt = maps:get(body, Opts, undefined),
+    Req = case BodyOpt of
+        undefined -> {Url1, Headers};
+        B -> {Url1, Headers, "application/json", list_to_binary(mochi_to_json(B))}
+    end,
+    TimeoutOpt = maps:get(timeout, Opts, undefined),
+    HTTPOpts = case TimeoutOpt of
+        undefined -> [];
+        T when is_integer(T) -> [{timeout, T * 1000}];
+        T when is_float(T) -> [{timeout, trunc(T * 1000)}];
+        _ -> []
+    end,
+    case string:prefix(Url1, "file://") of
+        true ->
+            {ok, Bin} = file:read_file(string:substr(Url1, 8)),
+            mochi_decode_json(binary_to_list(Bin));
+        _ ->
+            case httpc:request(Method, Req, HTTPOpts, []) of
+                {ok, {{_, 200, _}, _H, Body}} -> mochi_decode_json(binary_to_list(Body));
+                _ -> #{}
+            end
+        end.
 
 mochi_escape_json([]) -> [];
 mochi_escape_json([H|T]) ->
-	E = case H of
-		$\\ -> "\\\\";
-		$" -> "\\"";
-		_ -> [H]
-	end,
-	E ++ mochi_escape_json(T).
+    E = case H of
+        $\\ -> "\\\\";
+        $" -> "\\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
 
 mochi_to_json(true) -> "true";
 mochi_to_json(false) -> "false";

--- a/tests/compiler/erl_simple/fetch_method.erl.out
+++ b/tests/compiler/erl_simple/fetch_method.erl.out
@@ -3,12 +3,12 @@
 -export([main/1]).
 
 main(_) ->
-	Body = mochi_fetch("https://example.com", #{method => "GET"}),
-	mochi_print([(length(Body) > 0)]).
+    Body = mochi_fetch("https://example.com", #{method => "GET"}),
+    mochi_print([(length(Body) > 0)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -17,57 +17,57 @@ mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 
 mochi_fetch(Url, Opts) when Opts =:= undefined ->
-	mochi_fetch(Url, #{});
+    mochi_fetch(Url, #{});
 mochi_fetch(Url, Opts) ->
-	application:ensure_all_started(inets),
-	Method0 = maps:get(method, Opts, get),
-	Method = case Method0 of
-		M when is_atom(M) -> M;
-		M when is_list(M) -> list_to_atom(string:lowercase(M));
-		M when is_binary(M) -> list_to_atom(string:lowercase(binary_to_list(M)));
-		_ -> get
-	end,
-	Query = maps:get(query, Opts, undefined),
-	Url1 = case Query of
-		undefined -> Url;
-		Q ->
-			Pairs = [ K ++ "=" ++ lists:flatten(io_lib:format("~p", [V])) || {K,V} <- maps:to_list(Q) ],
-			Sep = case lists:member($?, Url) of true -> "&"; false -> "?" end,
-			Url ++ Sep ++ string:join(Pairs, "&")
-		end,
-	HeadersMap = maps:get(headers, Opts, #{}),
-	Headers = [ {K, case V of B when is_binary(V) -> binary_to_list(V); _ -> lists:flatten(io_lib:format("~p", [V])) end} || {K,V} <- maps:to_list(HeadersMap) ],
-	BodyOpt = maps:get(body, Opts, undefined),
-	Req = case BodyOpt of
-		undefined -> {Url1, Headers};
-		B -> {Url1, Headers, "application/json", list_to_binary(mochi_to_json(B))}
-	end,
-	TimeoutOpt = maps:get(timeout, Opts, undefined),
-	HTTPOpts = case TimeoutOpt of
-		undefined -> [];
-		T when is_integer(T) -> [{timeout, T * 1000}];
-		T when is_float(T) -> [{timeout, trunc(T * 1000)}];
-		_ -> []
-	end,
-	case string:prefix(Url1, "file://") of
-		true ->
-			{ok, Bin} = file:read_file(string:substr(Url1, 8)),
-			mochi_decode_json(binary_to_list(Bin));
-		_ ->
-			case httpc:request(Method, Req, HTTPOpts, []) of
-				{ok, {{_, 200, _}, _H, Body}} -> mochi_decode_json(binary_to_list(Body));
-				_ -> #{}
-			end
-		end.
+    application:ensure_all_started(inets),
+    Method0 = maps:get(method, Opts, get),
+    Method = case Method0 of
+        M when is_atom(M) -> M;
+        M when is_list(M) -> list_to_atom(string:lowercase(M));
+        M when is_binary(M) -> list_to_atom(string:lowercase(binary_to_list(M)));
+        _ -> get
+    end,
+    Query = maps:get(query, Opts, undefined),
+    Url1 = case Query of
+        undefined -> Url;
+        Q ->
+            Pairs = [ K ++ "=" ++ lists:flatten(io_lib:format("~p", [V])) || {K,V} <- maps:to_list(Q) ],
+            Sep = case lists:member($?, Url) of true -> "&"; false -> "?" end,
+            Url ++ Sep ++ string:join(Pairs, "&")
+        end,
+    HeadersMap = maps:get(headers, Opts, #{}),
+    Headers = [ {K, case V of B when is_binary(V) -> binary_to_list(V); _ -> lists:flatten(io_lib:format("~p", [V])) end} || {K,V} <- maps:to_list(HeadersMap) ],
+    BodyOpt = maps:get(body, Opts, undefined),
+    Req = case BodyOpt of
+        undefined -> {Url1, Headers};
+        B -> {Url1, Headers, "application/json", list_to_binary(mochi_to_json(B))}
+    end,
+    TimeoutOpt = maps:get(timeout, Opts, undefined),
+    HTTPOpts = case TimeoutOpt of
+        undefined -> [];
+        T when is_integer(T) -> [{timeout, T * 1000}];
+        T when is_float(T) -> [{timeout, trunc(T * 1000)}];
+        _ -> []
+    end,
+    case string:prefix(Url1, "file://") of
+        true ->
+            {ok, Bin} = file:read_file(string:substr(Url1, 8)),
+            mochi_decode_json(binary_to_list(Bin));
+        _ ->
+            case httpc:request(Method, Req, HTTPOpts, []) of
+                {ok, {{_, 200, _}, _H, Body}} -> mochi_decode_json(binary_to_list(Body));
+                _ -> #{}
+            end
+        end.
 
 mochi_escape_json([]) -> [];
 mochi_escape_json([H|T]) ->
-	E = case H of
-		$\\ -> "\\\\";
-		$" -> "\\"";
-		_ -> [H]
-	end,
-	E ++ mochi_escape_json(T).
+    E = case H of
+        $\\ -> "\\\\";
+        $" -> "\\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
 
 mochi_to_json(true) -> "true";
 mochi_to_json(false) -> "false";

--- a/tests/compiler/erl_simple/fibonacci.erl.out
+++ b/tests/compiler/erl_simple/fibonacci.erl.out
@@ -3,25 +3,25 @@
 -export([main/1, fib/1]).
 
 fib(N) ->
-	try
-				case (N =< 1) of
-			true ->
-				throw({return, N});
-						_ -> ok
-		end,
-		throw({return, (fib((N - 1)) + fib((N - 2)))})
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+                case (N =< 1) of
+            true ->
+                throw({return, N});
+                        _ -> ok
+        end,
+        throw({return, (fib((N - 1)) + fib((N - 2)))})
+    catch
+        throw:{return, V} -> V
+    end.
 
 main(_) ->
-	mochi_print([fib(0)]),
-	mochi_print([fib(1)]),
-	mochi_print([fib(6)]).
+    mochi_print([fib(0)]),
+    mochi_print([fib(1)]),
+    mochi_print([fib(6)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/float_ops.erl.out
+++ b/tests/compiler/erl_simple/float_ops.erl.out
@@ -3,12 +3,12 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([(1.2 + 3.4)]),
-	mochi_print([(5 / 2)]).
+    mochi_print([(1.2 + 3.4)]),
+    mochi_print([(5 / 2)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/fun_expr_in_let.erl.out
+++ b/tests/compiler/erl_simple/fun_expr_in_let.erl.out
@@ -3,18 +3,18 @@
 -export([main/1]).
 
 main(_) ->
-	Square = fun(X) ->
-		try
-			throw({return, (X * X)})
-		catch
-			throw:{return, V} -> V
-		end
+    Square = fun(X) ->
+        try
+            throw({return, (X * X)})
+        catch
+            throw:{return, V} -> V
+        end
 end,
-	mochi_print([Square(6)]).
+    mochi_print([Square(6)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/generate_echo.erl.out
+++ b/tests/compiler/erl_simple/generate_echo.erl.out
@@ -3,12 +3,12 @@
 -export([main/1]).
 
 main(_) ->
-	Poem = mochi_gen_text("echo hello", "", undefined),
-	mochi_print([Poem]).
+    Poem = mochi_gen_text("echo hello", "", undefined),
+    mochi_print([Poem]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/if_else.erl.out
+++ b/tests/compiler/erl_simple/if_else.erl.out
@@ -3,29 +3,29 @@
 -export([main/1, foo/1]).
 
 foo(N) ->
-	try
-				case (N < 0) of
-			true ->
-				throw({return, -1});
-						_ ->
-				case (N == 0) of
-					true ->
-						throw({return, 0});
-										_ ->
-						throw({return, 1})
-				end		end
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+                case (N < 0) of
+            true ->
+                throw({return, -1});
+                        _ ->
+                case (N == 0) of
+                    true ->
+                        throw({return, 0});
+                                        _ ->
+                        throw({return, 1})
+                end        end
+    catch
+        throw:{return, V} -> V
+    end.
 
 main(_) ->
-	mochi_print([foo(-2)]),
-	mochi_print([foo(0)]),
-	mochi_print([foo(3)]).
+    mochi_print([foo(-2)]),
+    mochi_print([foo(0)]),
+    mochi_print([foo(3)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/input_builtin.erl.out
+++ b/tests/compiler/erl_simple/input_builtin.erl.out
@@ -3,15 +3,15 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print(["Enter first input:"]),
-	Input1 = mochi_input(),
-	mochi_print(["Enter second input:"]),
-	Input2 = mochi_input(),
-	mochi_print(["You entered:", Input1, ",", Input2]).
+    mochi_print(["Enter first input:"]),
+    Input1 = mochi_input(),
+    mochi_print(["Enter second input:"]),
+    Input2 = mochi_input(),
+    mochi_print(["You entered:", Input1, ",", Input2]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -19,7 +19,7 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_input() ->
-	case io:get_line("") of
-		eof -> "";
-		Line -> string:trim(Line)
-	end.
+    case io:get_line("") of
+        eof -> "";
+        Line -> string:trim(Line)
+    end.

--- a/tests/compiler/erl_simple/json_bool.erl.out
+++ b/tests/compiler/erl_simple/json_bool.erl.out
@@ -3,17 +3,17 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_json(#{flag => true, other => false}).
+    mochi_json(#{flag => true, other => false}).
 
 
 mochi_escape_json([]) -> [];
 mochi_escape_json([H|T]) ->
-	E = case H of
-		$\\ -> "\\\\";
-		$" -> "\\"";
-		_ -> [H]
-	end,
-	E ++ mochi_escape_json(T).
+    E = case H of
+        $\\ -> "\\\\";
+        $" -> "\\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
 
 mochi_to_json(true) -> "true";
 mochi_to_json(false) -> "false";

--- a/tests/compiler/erl_simple/list_concat.erl.out
+++ b/tests/compiler/erl_simple/list_concat.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([lists:append([1, 2], [3, 4])]).
+    mochi_print([lists:append([1, 2], [3, 4])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/list_except.erl.out
+++ b/tests/compiler/erl_simple/list_except.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_except([1, 2, 3], [2])]).
+    mochi_print([mochi_except([1, 2, 3], [2])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/list_index.erl.out
+++ b/tests/compiler/erl_simple/list_index.erl.out
@@ -3,12 +3,12 @@
 -export([main/1]).
 
 main(_) ->
-	Xs = [10, 20, 30],
-	mochi_print([mochi_get(Xs, 1)]).
+    Xs = [10, 20, 30],
+    mochi_print([mochi_get(Xs, 1)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -17,8 +17,8 @@ mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 
 mochi_get(L, I) when is_list(L), is_integer(I) ->
-	N = length(L),
-	Idx = case I >= 0 of true -> I + 1; false -> N + I + 1 end,
-	lists:nth(Idx, L);
+    N = length(L),
+    Idx = case I >= 0 of true -> I + 1; false -> N + I + 1 end,
+    lists:nth(Idx, L);
 mochi_get(M, K) when is_map(M) -> maps:get(K, M);
 mochi_get(_, _) -> erlang:error(badarg).

--- a/tests/compiler/erl_simple/list_intersect.erl.out
+++ b/tests/compiler/erl_simple/list_intersect.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_intersect([1, 2, 3], [2, 4])]).
+    mochi_print([mochi_intersect([1, 2, 3], [2, 4])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/list_prepend.erl.out
+++ b/tests/compiler/erl_simple/list_prepend.erl.out
@@ -3,19 +3,19 @@
 -export([main/1, prepend/2]).
 
 prepend(Level, Result) ->
-	try
-		Result_1 = lists:append([Level], Result),
-		throw({return, Result_1})
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+        Result_1 = lists:append([Level], Result),
+        throw({return, Result_1})
+    catch
+        throw:{return, V} -> V
+    end.
 
 main(_) ->
-	mochi_print([prepend([1, 2], [[3], [4]])]).
+    mochi_print([prepend([1, 2], [[3], [4]])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/list_slice.erl.out
+++ b/tests/compiler/erl_simple/list_slice.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_slice([1, 2, 3, 4], 1, 3)]).
+    mochi_print([mochi_slice([1, 2, 3, 4], 1, 3)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -16,10 +16,10 @@ mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 
 mochi_slice(L, I, J) ->
-	N = length(L),
-	Start0 = case I < 0 of true -> I + N; false -> I end,
-	End0 = case J < 0 of true -> J + N; false -> J end,
-	Start1 = case Start0 < 0 of true -> 0; false -> case Start0 > N of true -> N; false -> Start0 end end,
-	End1 = case End0 > N of true -> N; false -> case End0 < Start1 of true -> Start1; false -> End0 end end,
-	Len = End1 - Start1,
-	lists:sublist(lists:nthtail(Start1, L), Len).
+    N = length(L),
+    Start0 = case I < 0 of true -> I + N; false -> I end,
+    End0 = case J < 0 of true -> J + N; false -> J end,
+    Start1 = case Start0 < 0 of true -> 0; false -> case Start0 > N of true -> N; false -> Start0 end end,
+    End1 = case End0 > N of true -> N; false -> case End0 < Start1 of true -> Start1; false -> End0 end end,
+    Len = End1 - Start1,
+    lists:sublist(lists:nthtail(Start1, L), Len).

--- a/tests/compiler/erl_simple/list_union.erl.out
+++ b/tests/compiler/erl_simple/list_union.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_union([1, 2], [2, 3])]).
+    mochi_print([mochi_union([1, 2], [2, 3])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/list_union_all.erl.out
+++ b/tests/compiler/erl_simple/list_union_all.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([lists:append([1, 2], [2, 3])]).
+    mochi_print([lists:append([1, 2], [2, 3])]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/map_any_hint.erl.out
+++ b/tests/compiler/erl_simple/map_any_hint.erl.out
@@ -3,26 +3,26 @@
 -export([main/1, 'Leaf'/0, 'Node'/3]).
 
 'Leaf'() ->
-	try
-		throw({return, #{"__name" => "Leaf"}})
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+        throw({return, #{"__name" => "Leaf"}})
+    catch
+        throw:{return, V} -> V
+    end.
 
 'Node'(Left, Value, Right) ->
-	try
-		throw({return, #{"__name" => "Node", "left" => Left, "value" => Value, "right" => Right}})
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+        throw({return, #{"__name" => "Node", "left" => Left, "value" => Value, "right" => Right}})
+    catch
+        throw:{return, V} -> V
+    end.
 
 main(_) ->
-	Tree = 'Node'('Leaf'(), 1, 'Leaf'()),
-	mochi_print([maps:get("__name", maps:get("left", Tree))]).
+    Tree = 'Node'('Leaf'(), 1, 'Leaf'()),
+    mochi_print([maps:get("__name", maps:get("left", Tree))]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/map_iterate.erl.out
+++ b/tests/compiler/erl_simple/map_iterate.erl.out
@@ -3,14 +3,14 @@
 -export([main/1]).
 
 main(_) ->
-	M = #{"a" => 1, "b" => 2},
-	mochi_foreach(fun(K) ->
-		mochi_print([K])
-	end, maps:keys(M)).
+    M = #{"a" => 1, "b" => 2},
+    mochi_foreach(fun(K) ->
+        mochi_print([K])
+    end, maps:keys(M)).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -18,12 +18,12 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).

--- a/tests/compiler/erl_simple/str_builtin.erl.out
+++ b/tests/compiler/erl_simple/str_builtin.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_format(123)]).
+    mochi_print([mochi_format(123)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/string_concat.erl.out
+++ b/tests/compiler/erl_simple/string_concat.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([("hello " + "world")]).
+    mochi_print([("hello " + "world")]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);

--- a/tests/compiler/erl_simple/string_index.erl.out
+++ b/tests/compiler/erl_simple/string_index.erl.out
@@ -3,12 +3,12 @@
 -export([main/1]).
 
 main(_) ->
-	Text = "hello",
-	mochi_print([mochi_get(Text, 1)]).
+    Text = "hello",
+    mochi_print([mochi_get(Text, 1)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -17,8 +17,8 @@ mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 
 mochi_get(L, I) when is_list(L), is_integer(I) ->
-	N = length(L),
-	Idx = case I >= 0 of true -> I + 1; false -> N + I + 1 end,
-	lists:nth(Idx, L);
+    N = length(L),
+    Idx = case I >= 0 of true -> I + 1; false -> N + I + 1 end,
+    lists:nth(Idx, L);
 mochi_get(M, K) when is_map(M) -> maps:get(K, M);
 mochi_get(_, _) -> erlang:error(badarg).

--- a/tests/compiler/erl_simple/string_slice.erl.out
+++ b/tests/compiler/erl_simple/string_slice.erl.out
@@ -3,11 +3,11 @@
 -export([main/1]).
 
 main(_) ->
-	mochi_print([mochi_slice("hello", 1, 4)]).
+    mochi_print([mochi_slice("hello", 1, 4)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -16,10 +16,10 @@ mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 
 mochi_slice(L, I, J) ->
-	N = length(L),
-	Start0 = case I < 0 of true -> I + N; false -> I end,
-	End0 = case J < 0 of true -> J + N; false -> J end,
-	Start1 = case Start0 < 0 of true -> 0; false -> case Start0 > N of true -> N; false -> Start0 end end,
-	End1 = case End0 > N of true -> N; false -> case End0 < Start1 of true -> Start1; false -> End0 end end,
-	Len = End1 - Start1,
-	lists:sublist(lists:nthtail(Start1, L), Len).
+    N = length(L),
+    Start0 = case I < 0 of true -> I + N; false -> I end,
+    End0 = case J < 0 of true -> J + N; false -> J end,
+    Start1 = case Start0 < 0 of true -> 0; false -> case Start0 > N of true -> N; false -> Start0 end end,
+    End1 = case End0 > N of true -> N; false -> case End0 < Start1 of true -> Start1; false -> End0 end end,
+    Len = End1 - Start1,
+    lists:sublist(lists:nthtail(Start1, L), Len).

--- a/tests/compiler/erl_simple/two-sum.erl.out
+++ b/tests/compiler/erl_simple/two-sum.erl.out
@@ -3,30 +3,30 @@
 -export([main/1, 'twoSum'/2]).
 
 'twoSum'(Nums, Target) ->
-	try
-		N = length(Nums),
-		mochi_foreach(fun(I) ->
-			mochi_foreach(fun(J) ->
-								case ((mochi_get(Nums, I) + mochi_get(Nums, J)) == Target) of
-					true ->
-						throw({return, [I, J]});
-										_ -> ok
-				end
-			end, lists:seq((I + 1), (N)-1))
-		end, lists:seq(0, (N)-1)),
-		throw({return, [-1, -1]})
-	catch
-		throw:{return, V} -> V
-	end.
+    try
+        N = length(Nums),
+        mochi_foreach(fun(I) ->
+            mochi_foreach(fun(J) ->
+                                case ((mochi_get(Nums, I) + mochi_get(Nums, J)) == Target) of
+                    true ->
+                        throw({return, [I, J]});
+                                        _ -> ok
+                end
+            end, lists:seq((I + 1), (N)-1))
+        end, lists:seq(0, (N)-1)),
+        throw({return, [-1, -1]})
+    catch
+        throw:{return, V} -> V
+    end.
 
 main(_) ->
-	Result = 'twoSum'([2, 7, 11, 15], 9),
-	mochi_print([mochi_get(Result, 0)]),
-	mochi_print([mochi_get(Result, 1)]).
+    Result = 'twoSum'([2, 7, 11, 15], 9),
+    mochi_print([mochi_get(Result, 0)]),
+    mochi_print([mochi_get(Result, 1)]).
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);
@@ -34,19 +34,19 @@ mochi_format(X) when is_list(X) -> X;
 mochi_format(X) -> lists:flatten(io_lib:format("~p", [X])).
 
 mochi_foreach(F, L) ->
-	try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
+    try mochi_foreach_loop(F, L) catch throw:mochi_break -> ok end.
 
 mochi_foreach_loop(_, []) -> ok;
 mochi_foreach_loop(F, [H|T]) ->
-	try F(H) catch
-		throw:mochi_continue -> ok;
-		throw:mochi_break -> throw(mochi_break)
-	end,
-	mochi_foreach_loop(F, T).
+    try F(H) catch
+        throw:mochi_continue -> ok;
+        throw:mochi_break -> throw(mochi_break)
+    end,
+    mochi_foreach_loop(F, T).
 
 mochi_get(L, I) when is_list(L), is_integer(I) ->
-	N = length(L),
-	Idx = case I >= 0 of true -> I + 1; false -> N + I + 1 end,
-	lists:nth(Idx, L);
+    N = length(L),
+    Idx = case I >= 0 of true -> I + 1; false -> N + I + 1 end,
+    lists:nth(Idx, L);
 mochi_get(M, K) when is_map(M) -> maps:get(K, M);
 mochi_get(_, _) -> erlang:error(badarg).

--- a/tests/compiler/erl_simple/while_loop.erl.out
+++ b/tests/compiler/erl_simple/while_loop.erl.out
@@ -3,27 +3,27 @@
 -export([main/1]).
 
 main(_) ->
-	I = 0,
-	Loop = fun Loop(I) ->
-		case (I < 3) of
-			true ->
-				try
-					mochi_print([I]),
-					I_1 = (I + 1)
-					Loop(I_1)
-				catch
-					throw:mochi_continue -> Loop(I_1);
-					throw:mochi_break -> {I_1}
-				end;
-			_ -> {I}
-		end
-	end,
-	{I_1} = Loop(I)
+    I = 0,
+    Loop = fun Loop(I) ->
+        case (I < 3) of
+            true ->
+                try
+                    mochi_print([I]),
+                    I_1 = (I + 1)
+                    Loop(I_1)
+                catch
+                    throw:mochi_continue -> Loop(I_1);
+                    throw:mochi_break -> {I_1}
+                end;
+            _ -> {I}
+        end
+    end,
+    {I_1} = Loop(I)
 .
 
 mochi_print(Args) ->
-	Strs = [ mochi_format(A) || A <- Args ],
-	io:format("~s~n", [lists:flatten(Strs)]).
+    Strs = [ mochi_format(A) || A <- Args ],
+    io:format("~s~n", [lists:flatten(Strs)]).
 
 mochi_format(X) when is_integer(X) -> integer_to_list(X);
 mochi_format(X) when is_float(X) -> float_to_list(X);


### PR DESCRIPTION
## Summary
- improve Erlang `Format` with fallback formatting and new `EnsureFormatter`
- document formatter helper in the README
- regenerate Erlang golden outputs with the new formatter

## Testing
- `go test ./compile/x/erlang -tags slow -update -run TestErlangCompiler_GoldenOutput`
- `go test ./compile/x/erlang -tags slow -run TestErlangCompiler_GoldenOutput`

------
https://chatgpt.com/codex/tasks/task_e_685e414bfb988320869a8b345420c026