### PR TITLE
Improve Fortran formatting

### DIFF
--- a/compile/x/fortran/compiler.go
+++ b/compile/x/fortran/compiler.go
@@ -305,9 +305,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	c.writeln("end program main")
 	code := c.buf.Bytes()
-	if formatted, err := formatCode(code); err == nil {
-		code = formatted
-	}
+	code = Format(code)
 	return code, nil
 }
 

--- a/compile/x/fortran/tools.go
+++ b/compile/x/fortran/tools.go
@@ -135,3 +135,13 @@ func EnsureFormatter() (string, error) {
 	}
 	return "", fmt.Errorf("no Fortran formatter found")
 }
+
+// Ensure verifies that gfortran and a formatting tool are available.
+// It can be called by external tools to set up the environment.
+func Ensure() error {
+	if _, err := EnsureFortran(); err != nil {
+		return err
+	}
+	_, err := EnsureFormatter()
+	return err
+}

--- a/examples/leetcode-out/fortran/1/two-sum.f90
+++ b/examples/leetcode-out/fortran/1/two-sum.f90
@@ -1,29 +1,29 @@
 program main
-   implicit none
-   integer(kind=8) :: result(2)
-   result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
-   print *, result(0_8 + 1)
-   print *, result(1_8 + 1)
+  implicit none
+  integer(kind=8) :: result(2)
+  result = twoSum((/2_8, 7_8, 11_8, 15_8/), 9_8)
+  print *, result(0_8 + 1)
+  print *, result(1_8 + 1)
 contains
-   function twoSum(nums, target) result(res)
-      implicit none
-      integer(kind=8), intent(in) :: nums(:)
-      integer(kind=8), intent(in) :: target
-      integer(kind=8) :: n
-      integer(kind=8) :: i
-      integer(kind=8) :: j
-      integer(kind=8) :: res(2)
-      n = size(nums)
-      do i = 0_8, n - 1
-         do j = (i + 1_8), n - 1
-            if (((nums(i + 1) + nums(j + 1)) == target)) then
-               res = (/i, j/)
-               return
-            end if
-         end do
+  function twoSum(nums, target) result(res)
+    implicit none
+    integer(kind=8), intent(in) :: nums(:)
+    integer(kind=8), intent(in) :: target
+    integer(kind=8) :: n
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: res(2)
+    n = size(nums)
+    do i = 0_8, n - 1
+      do j = (i + 1_8), n - 1
+        if (((nums(i + 1) + nums(j + 1)) == target)) then
+          res = (/i, j/)
+          return
+        end if
       end do
-      res = (/(-1_8), (-1_8)/)
-      return
-   end function twoSum
+    end do
+    res = (/(-1_8), (-1_8)/)
+    return
+  end function twoSum
 
 end program main

--- a/examples/leetcode-out/fortran/2/add-two-numbers.f90
+++ b/examples/leetcode-out/fortran/2/add-two-numbers.f90
@@ -1,68 +1,68 @@
 program main
-   implicit none
-   call test_example_1()
-   call test_example_2()
-   call test_example_3()
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_example_3()
 contains
-   function addTwoNumbers(l1, l2) result(res)
-      implicit none
-      integer(kind=8), allocatable :: res(:)
-      integer(kind=8), intent(in) :: l1(:)
-      integer(kind=8), intent(in) :: l2(:)
-      integer(kind=8), allocatable :: result(:)
-      integer(kind=8) :: carry
-      integer(kind=8) :: digit
-      integer(kind=8) :: i
-      integer(kind=8) :: j
-      integer(kind=8) :: sum
-      integer(kind=8) :: x
-      integer(kind=8) :: y
-      allocate(result(0))
-      i = 0_8
-      j = 0_8
-      carry = 0_8
-      do while ((((i < size(l1)) .or. (j < size(l2))) .or. (carry > 0_8)))
-         x = 0_8
-         if ((i < size(l1))) then
-            x = l1(modulo(i, size(l1)) + 1)
-            i = (i + 1_8)
-         end if
-         y = 0_8
-         if ((j < size(l2))) then
-            y = l2(modulo(j, size(l2)) + 1)
-            j = (j + 1_8)
-         end if
-         sum = ((x + y) + carry)
-         digit = mod(sum, 10_8)
-         carry = (sum / 10_8)
-         result = (/ result, (/digit/) /)
-      end do
-      res = result
-      return
-   end function addTwoNumbers
-
-   subroutine test_example_1()
-      implicit none
-      if (.not. (all(addTwoNumbers((/2_8, 4_8, 3_8/), (/5_8, 6_8, 4_8/)) == (/7_8, 0_8, 8_8/)))) then
-         print *, 'expect failed'
-         stop 1
+  function addTwoNumbers(l1, l2) result(res)
+    implicit none
+    integer(kind=8), allocatable :: res(:)
+    integer(kind=8), intent(in) :: l1(:)
+    integer(kind=8), intent(in) :: l2(:)
+    integer(kind=8), allocatable :: result(:)
+    integer(kind=8) :: carry
+    integer(kind=8) :: digit
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: sum
+    integer(kind=8) :: x
+    integer(kind=8) :: y
+    allocate(result(0))
+    i = 0_8
+    j = 0_8
+    carry = 0_8
+    do while ((((i < size(l1)) .or. (j < size(l2))) .or. (carry > 0_8)))
+      x = 0_8
+      if ((i < size(l1))) then
+        x = l1(modulo(i, size(l1)) + 1)
+        i = (i + 1_8)
       end if
-   end subroutine test_example_1
-
-   subroutine test_example_2()
-      implicit none
-      if (.not. (all(addTwoNumbers((/0_8/), (/0_8/)) == (/0_8/)))) then
-         print *, 'expect failed'
-         stop 1
+      y = 0_8
+      if ((j < size(l2))) then
+        y = l2(modulo(j, size(l2)) + 1)
+        j = (j + 1_8)
       end if
-   end subroutine test_example_2
+      sum = ((x + y) + carry)
+      digit = mod(sum, 10_8)
+      carry = (sum / 10_8)
+      result = (/ result, (/digit/) /)
+    end do
+    res = result
+    return
+  end function addTwoNumbers
 
-   subroutine test_example_3()
-      implicit none
-      if (.not. (all(addTwoNumbers((/9_8, 9_8, 9_8, 9_8, 9_8, 9_8, 9_8/), (/9_8, 9_8, 9_8, 9_8/)) == (/8_8, 9_8, 9_8, 9_8, 0_8, 0_8, 0_8, 1_8/)))) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_3
+  subroutine test_example_1()
+    implicit none
+    if (.not. (all(addTwoNumbers((/2_8, 4_8, 3_8/), (/5_8, 6_8, 4_8/)) == (/7_8, 0_8, 8_8/)))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
+
+  subroutine test_example_2()
+    implicit none
+    if (.not. (all(addTwoNumbers((/0_8/), (/0_8/)) == (/0_8/)))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
+
+  subroutine test_example_3()
+    implicit none
+    if (.not. (all(addTwoNumbers((/9_8, 9_8, 9_8, 9_8, 9_8, 9_8, 9_8/), (/9_8, 9_8, 9_8, 9_8/)) == (/8_8, 9_8, 9_8, 9_8, 0_8, 0_8, 0_8, 1_8/)))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_3
 
 end program main

--- a/examples/leetcode-out/fortran/3/longest-substring-without-repeating-characters.f90
+++ b/examples/leetcode-out/fortran/3/longest-substring-without-repeating-characters.f90
@@ -1,73 +1,73 @@
 program main
-   implicit none
-   call test_example_1()
-   call test_example_2()
-   call test_example_3()
-   call test_empty_string()
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_example_3()
+  call test_empty_string()
 contains
-   function lengthOfLongestSubstring(s) result(res)
-      implicit none
-      integer(kind=8) :: res
-      character(len=*), intent(in) :: s
-      integer(kind=8) :: best
-      integer(kind=8) :: i
-      integer(kind=8) :: j
-      integer(kind=8) :: length
-      integer(kind=8) :: n
-      integer(kind=8) :: start
-      n = len(s)
-      start = 0_8
-      best = 0_8
-      i = 0_8
-      do while ((i < n))
-         j = start
-         do while ((j < i))
-            if ((s(modulo(j, len(s)) + 1:modulo(j, len(s)) + 1) == s(modulo(i, len(s)) + 1:modulo(i, len(s)) + 1))) then
-               start = (j + 1_8)
-               exit
-            end if
-            j = (j + 1_8)
-         end do
-         length = ((i - start) + 1_8)
-         if ((length > best)) then
-            best = length
-         end if
-         i = (i + 1_8)
+  function lengthOfLongestSubstring(s) result(res)
+    implicit none
+    integer(kind=8) :: res
+    character(len=*), intent(in) :: s
+    integer(kind=8) :: best
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: length
+    integer(kind=8) :: n
+    integer(kind=8) :: start
+    n = len(s)
+    start = 0_8
+    best = 0_8
+    i = 0_8
+    do while ((i < n))
+      j = start
+      do while ((j < i))
+        if ((s(modulo(j, len(s)) + 1:modulo(j, len(s)) + 1) == s(modulo(i, len(s)) + 1:modulo(i, len(s)) + 1))) then
+          start = (j + 1_8)
+          exit
+        end if
+        j = (j + 1_8)
       end do
-      res = best
-      return
-   end function lengthOfLongestSubstring
-
-   subroutine test_example_1()
-      implicit none
-      if (.not. (lengthOfLongestSubstring('abcabcbb') == 3_8)) then
-         print *, 'expect failed'
-         stop 1
+      length = ((i - start) + 1_8)
+      if ((length > best)) then
+        best = length
       end if
-   end subroutine test_example_1
+      i = (i + 1_8)
+    end do
+    res = best
+    return
+  end function lengthOfLongestSubstring
 
-   subroutine test_example_2()
-      implicit none
-      if (.not. (lengthOfLongestSubstring('bbbbb') == 1_8)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_2
+  subroutine test_example_1()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('abcabcbb') == 3_8)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
 
-   subroutine test_example_3()
-      implicit none
-      if (.not. (lengthOfLongestSubstring('pwwkew') == 3_8)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_3
+  subroutine test_example_2()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('bbbbb') == 1_8)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
 
-   subroutine test_empty_string()
-      implicit none
-      if (.not. (lengthOfLongestSubstring('') == 0_8)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_empty_string
+  subroutine test_example_3()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('pwwkew') == 3_8)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_3
+
+  subroutine test_empty_string()
+    implicit none
+    if (.not. (lengthOfLongestSubstring('') == 0_8)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_empty_string
 
 end program main

--- a/examples/leetcode-out/fortran/4/median-of-two-sorted-arrays.f90
+++ b/examples/leetcode-out/fortran/4/median-of-two-sorted-arrays.f90
@@ -1,80 +1,80 @@
 program main
-   implicit none
-   call test_example_1()
-   call test_example_2()
-   call test_empty_first()
-   call test_empty_second()
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_empty_first()
+  call test_empty_second()
 contains
-   function findMedianSortedArrays(nums1, nums2) result(res)
-      implicit none
-      real :: res
-      integer(kind=8), intent(in) :: nums1(:)
-      integer(kind=8), intent(in) :: nums2(:)
-      integer(kind=8), allocatable :: merged(:)
-      integer(kind=8) :: i
-      integer(kind=8) :: j
-      integer(kind=8) :: mid1
-      integer(kind=8) :: mid2
-      integer(kind=8) :: total
-      allocate(merged(0))
-      i = 0_8
-      j = 0_8
-      do while (((i < size(nums1)) .or. (j < size(nums2))))
-         if ((j >= size(nums2))) then
-            merged = (/ merged, (/nums1(modulo(i, size(nums1)) + 1)/) /)
-            i = (i + 1_8)
-         else if ((i >= size(nums1))) then
-            merged = (/ merged, (/nums2(modulo(j, size(nums2)) + 1)/) /)
-            j = (j + 1_8)
-         else if ((nums1(modulo(i, size(nums1)) + 1) <= nums2(modulo(j, size(nums2)) + 1))) then
-            merged = (/ merged, (/nums1(modulo(i, size(nums1)) + 1)/) /)
-            i = (i + 1_8)
-         else
-            merged = (/ merged, (/nums2(modulo(j, size(nums2)) + 1)/) /)
-            j = (j + 1_8)
-         end if
-      end do
-      total = size(merged)
-      if ((mod(total, 2_8) == 1_8)) then
-         res = real(merged(modulo((total / 2_8), size(merged)) + 1))
-         return
+  function findMedianSortedArrays(nums1, nums2) result(res)
+    implicit none
+    real :: res
+    integer(kind=8), intent(in) :: nums1(:)
+    integer(kind=8), intent(in) :: nums2(:)
+    integer(kind=8), allocatable :: merged(:)
+    integer(kind=8) :: i
+    integer(kind=8) :: j
+    integer(kind=8) :: mid1
+    integer(kind=8) :: mid2
+    integer(kind=8) :: total
+    allocate(merged(0))
+    i = 0_8
+    j = 0_8
+    do while (((i < size(nums1)) .or. (j < size(nums2))))
+      if ((j >= size(nums2))) then
+        merged = (/ merged, (/nums1(modulo(i, size(nums1)) + 1)/) /)
+        i = (i + 1_8)
+      else if ((i >= size(nums1))) then
+        merged = (/ merged, (/nums2(modulo(j, size(nums2)) + 1)/) /)
+        j = (j + 1_8)
+      else if ((nums1(modulo(i, size(nums1)) + 1) <= nums2(modulo(j, size(nums2)) + 1))) then
+        merged = (/ merged, (/nums1(modulo(i, size(nums1)) + 1)/) /)
+        i = (i + 1_8)
+      else
+        merged = (/ merged, (/nums2(modulo(j, size(nums2)) + 1)/) /)
+        j = (j + 1_8)
       end if
-      mid1 = merged(modulo(((total / 2_8) - 1_8), size(merged)) + 1)
-      mid2 = merged(modulo((total / 2_8), size(merged)) + 1)
-      res = (real(((mid1 + mid2))) / 2)
+    end do
+    total = size(merged)
+    if ((mod(total, 2_8) == 1_8)) then
+      res = real(merged(modulo((total / 2_8), size(merged)) + 1))
       return
-   end function findMedianSortedArrays
+    end if
+    mid1 = merged(modulo(((total / 2_8) - 1_8), size(merged)) + 1)
+    mid2 = merged(modulo((total / 2_8), size(merged)) + 1)
+    res = (real(((mid1 + mid2))) / 2)
+    return
+  end function findMedianSortedArrays
 
-   subroutine test_example_1()
-      implicit none
-      if (.not. (findMedianSortedArrays((/1_8, 3_8/), (/2_8/)) == 2)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_1
+  subroutine test_example_1()
+    implicit none
+    if (.not. (findMedianSortedArrays((/1_8, 3_8/), (/2_8/)) == 2)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
 
-   subroutine test_example_2()
-      implicit none
-      if (.not. (findMedianSortedArrays((/1_8, 2_8/), (/3_8, 4_8/)) == 2.5)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_2
+  subroutine test_example_2()
+    implicit none
+    if (.not. (findMedianSortedArrays((/1_8, 2_8/), (/3_8, 4_8/)) == 2.5)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
 
-   subroutine test_empty_first()
-      implicit none
-      if (.not. (findMedianSortedArrays(reshape([0_8], [0]), (/1_8/)) == 1)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_empty_first
+  subroutine test_empty_first()
+    implicit none
+    if (.not. (findMedianSortedArrays(reshape([0_8], [0]), (/1_8/)) == 1)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_empty_first
 
-   subroutine test_empty_second()
-      implicit none
-      if (.not. (findMedianSortedArrays((/2_8/), reshape([0_8], [0])) == 2)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_empty_second
+  subroutine test_empty_second()
+    implicit none
+    if (.not. (findMedianSortedArrays((/2_8/), reshape([0_8], [0])) == 2)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_empty_second
 
 end program main

--- a/examples/leetcode-out/fortran/5/longest-palindromic-substring.f90
+++ b/examples/leetcode-out/fortran/5/longest-palindromic-substring.f90
@@ -1,101 +1,101 @@
 program main
-   implicit none
-   call test_example_1()
-   call test_example_2()
-   call test_single_char()
-   call test_two_chars()
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_single_char()
+  call test_two_chars()
 contains
-   function expand(s, left, right) result(res)
-      implicit none
-      integer(kind=8) :: res
-      character(len=*), intent(in) :: s
-      integer(kind=8), intent(in) :: left
-      integer(kind=8), intent(in) :: right
-      integer(kind=8) :: l
-      integer(kind=8) :: n
-      integer(kind=8) :: r
-      l = left
-      r = right
-      n = len(s)
-      do while (((l >= 0_8) .and. (r < n)))
-         if ((s(modulo(l, len(s)) + 1:modulo(l, len(s)) + 1) /= s(modulo(r, len(s)) + 1:modulo(r, len(s)) + 1))) then
-            exit
-         end if
-         l = (l - 1_8)
-         r = (r + 1_8)
-      end do
-      res = ((r - l) - 1_8)
+  function expand(s, left, right) result(res)
+    implicit none
+    integer(kind=8) :: res
+    character(len=*), intent(in) :: s
+    integer(kind=8), intent(in) :: left
+    integer(kind=8), intent(in) :: right
+    integer(kind=8) :: l
+    integer(kind=8) :: n
+    integer(kind=8) :: r
+    l = left
+    r = right
+    n = len(s)
+    do while (((l >= 0_8) .and. (r < n)))
+      if ((s(modulo(l, len(s)) + 1:modulo(l, len(s)) + 1) /= s(modulo(r, len(s)) + 1:modulo(r, len(s)) + 1))) then
+        exit
+      end if
+      l = (l - 1_8)
+      r = (r + 1_8)
+    end do
+    res = ((r - l) - 1_8)
+    return
+  end function expand
+
+  function longestPalindrome(s) result(res)
+    implicit none
+    character(:), allocatable :: res
+    character(len=*), intent(in) :: s
+    integer(kind=8) :: end
+    integer(kind=8) :: i
+    integer(kind=8) :: l
+    integer(kind=8) :: len1
+    integer(kind=8) :: len2
+    integer(kind=8) :: n
+    integer(kind=8) :: start
+    if ((len(s) <= 1_8)) then
+      res = s
       return
-   end function expand
-
-   function longestPalindrome(s) result(res)
-      implicit none
-      character(:), allocatable :: res
-      character(len=*), intent(in) :: s
-      integer(kind=8) :: end
-      integer(kind=8) :: i
-      integer(kind=8) :: l
-      integer(kind=8) :: len1
-      integer(kind=8) :: len2
-      integer(kind=8) :: n
-      integer(kind=8) :: start
-      if ((len(s) <= 1_8)) then
-         res = s
-         return
+    end if
+    start = 0_8
+    end = 0_8
+    n = len(s)
+    do i = 0_8, n - 1
+      len1 = expand(s, i, i)
+      len2 = expand(s, i, (i + 1_8))
+      l = len1
+      if ((len2 > len1)) then
+        l = len2
       end if
-      start = 0_8
-      end = 0_8
-      n = len(s)
-      do i = 0_8, n - 1
-         len1 = expand(s, i, i)
-         len2 = expand(s, i, (i + 1_8))
-         l = len1
-         if ((len2 > len1)) then
-            l = len2
-         end if
-         if ((l > ((end - start)))) then
-            start = (i - ((((l - 1_8)) / 2_8)))
-            end = (i + ((l / 2_8)))
-         end if
-      end do
-      res = s(modulo(start, len(s)) + 1:modulo((end + 1_8), len(s)))
-      return
-   end function longestPalindrome
-
-   subroutine test_example_1()
-      implicit none
-      character(:), allocatable :: ans
-      ans = longestPalindrome('babad')
-      if (.not. (((ans == 'bab') .or. (ans == 'aba')))) then
-         print *, 'expect failed'
-         stop 1
+      if ((l > ((end - start)))) then
+        start = (i - ((((l - 1_8)) / 2_8)))
+        end = (i + ((l / 2_8)))
       end if
-   end subroutine test_example_1
+    end do
+    res = s(modulo(start, len(s)) + 1:modulo((end + 1_8), len(s)))
+    return
+  end function longestPalindrome
 
-   subroutine test_example_2()
-      implicit none
-      if (.not. (longestPalindrome('cbbd') == 'bb')) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_2
+  subroutine test_example_1()
+    implicit none
+    character(:), allocatable :: ans
+    ans = longestPalindrome('babad')
+    if (.not. (((ans == 'bab') .or. (ans == 'aba')))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
 
-   subroutine test_single_char()
-      implicit none
-      if (.not. (longestPalindrome('a') == 'a')) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_single_char
+  subroutine test_example_2()
+    implicit none
+    if (.not. (longestPalindrome('cbbd') == 'bb')) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
 
-   subroutine test_two_chars()
-      implicit none
-      character(:), allocatable :: ans
-      ans = longestPalindrome('ac')
-      if (.not. (((ans == 'a') .or. (ans == 'c')))) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_two_chars
+  subroutine test_single_char()
+    implicit none
+    if (.not. (longestPalindrome('a') == 'a')) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_single_char
+
+  subroutine test_two_chars()
+    implicit none
+    character(:), allocatable :: ans
+    ans = longestPalindrome('ac')
+    if (.not. (((ans == 'a') .or. (ans == 'c')))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_two_chars
 
 end program main

--- a/examples/leetcode-out/fortran/6/zigzag-conversion.f90
+++ b/examples/leetcode-out/fortran/6/zigzag-conversion.f90
@@ -1,67 +1,67 @@
 program main
-   implicit none
-   call test_example_1()
-   call test_example_2()
-   call test_single_row()
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_single_row()
 contains
-   function convert(s, numRows) result(res)
-      implicit none
-      character(len=*), intent(in) :: s
-      integer(kind=8), intent(in) :: numRows
-      character(:), allocatable :: res
-      character(len=len(s)), allocatable :: rows(:)
-      integer(kind=8) :: i
-      integer(kind=8) :: curr
-      integer(kind=8) :: step
-      integer(kind=8) :: i_row
-      if ((numRows <= 1) .or. (numRows >= len(s))) then
-         res = s
-         return
-      end if
-      allocate(character(len=len(s)) :: rows(numRows))
-      do i = 1, numRows
-         rows(i) = ''
-      end do
-      curr = 1
-      step = 1
-      do i = 1, len(s)
-         rows(curr) = trim(rows(curr)) // s(i:i)
-         if (curr == 1) then
-            step = 1
-         else if (curr == numRows) then
-            step = -1
-         end if
-         curr = curr + step
-      end do
-      res = ''
-      do i_row = 1, numRows
-         res = trim(res) // trim(rows(i_row))
-      end do
+  function convert(s, numRows) result(res)
+    implicit none
+    character(len=*), intent(in) :: s
+    integer(kind=8), intent(in) :: numRows
+    character(:), allocatable :: res
+    character(len=len(s)), allocatable :: rows(:)
+    integer(kind=8) :: i
+    integer(kind=8) :: curr
+    integer(kind=8) :: step
+    integer(kind=8) :: i_row
+    if ((numRows <= 1) .or. (numRows >= len(s))) then
+      res = s
       return
-   end function convert
-
-   subroutine test_example_1()
-      implicit none
-      if (.not. (convert('PAYPALISHIRING', 3_8) == 'PAHNAPLSIIGYIR')) then
-         print *, 'expect failed'
-         stop 1
+    end if
+    allocate(character(len=len(s)) :: rows(numRows))
+    do i = 1, numRows
+      rows(i) = ''
+    end do
+    curr = 1
+    step = 1
+    do i = 1, len(s)
+      rows(curr) = trim(rows(curr)) // s(i:i)
+      if (curr == 1) then
+        step = 1
+      else if (curr == numRows) then
+        step = -1
       end if
-   end subroutine test_example_1
+      curr = curr + step
+    end do
+    res = ''
+    do i_row = 1, numRows
+      res = trim(res) // trim(rows(i_row))
+    end do
+    return
+  end function convert
 
-   subroutine test_example_2()
-      implicit none
-      if (.not. (convert('PAYPALISHIRING', 4_8) == 'PINALSIGYAHRPI')) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_2
+  subroutine test_example_1()
+    implicit none
+    if (.not. (convert('PAYPALISHIRING', 3_8) == 'PAHNAPLSIIGYIR')) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
 
-   subroutine test_single_row()
-      implicit none
-      if (.not. (convert('A', 1_8) == 'A')) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_single_row
+  subroutine test_example_2()
+    implicit none
+    if (.not. (convert('PAYPALISHIRING', 4_8) == 'PINALSIGYAHRPI')) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
+
+  subroutine test_single_row()
+    implicit none
+    if (.not. (convert('A', 1_8) == 'A')) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_single_row
 
 end program main

--- a/examples/leetcode-out/fortran/7/reverse-integer.f90
+++ b/examples/leetcode-out/fortran/7/reverse-integer.f90
@@ -1,69 +1,69 @@
 program main
-   implicit none
-   call test_example_1()
-   call test_example_2()
-   call test_example_3()
-   call test_overflow()
+  implicit none
+  call test_example_1()
+  call test_example_2()
+  call test_example_3()
+  call test_overflow()
 contains
-   function reverse(x) result(res)
-      implicit none
-      integer(kind=8) :: res
-      integer(kind=8), intent(in) :: x
-      integer(kind=8) :: digit
-      integer(kind=8) :: n
-      integer(kind=8) :: rev
-      integer(kind=8) :: sign
-      sign = 1_8
-      n = x
-      if ((n < 0_8)) then
-         sign = (-1_8)
-         n = (-n)
-      end if
-      rev = 0_8
-      do while ((n /= 0_8))
-         digit = mod(n, 10_8)
-         rev = ((rev * 10_8) + digit)
-         n = (n / 10_8)
-      end do
-      rev = (rev * sign)
-      if (((rev < (((-2147483647_8) - 1_8))) .or. (rev > 2147483647_8))) then
-         res = 0_8
-         return
-      end if
-      res = rev
+  function reverse(x) result(res)
+    implicit none
+    integer(kind=8) :: res
+    integer(kind=8), intent(in) :: x
+    integer(kind=8) :: digit
+    integer(kind=8) :: n
+    integer(kind=8) :: rev
+    integer(kind=8) :: sign
+    sign = 1_8
+    n = x
+    if ((n < 0_8)) then
+      sign = (-1_8)
+      n = (-n)
+    end if
+    rev = 0_8
+    do while ((n /= 0_8))
+      digit = mod(n, 10_8)
+      rev = ((rev * 10_8) + digit)
+      n = (n / 10_8)
+    end do
+    rev = (rev * sign)
+    if (((rev < (((-2147483647_8) - 1_8))) .or. (rev > 2147483647_8))) then
+      res = 0_8
       return
-   end function reverse
+    end if
+    res = rev
+    return
+  end function reverse
 
-   subroutine test_example_1()
-      implicit none
-      if (.not. (reverse(123_8) == 321_8)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_1
+  subroutine test_example_1()
+    implicit none
+    if (.not. (reverse(123_8) == 321_8)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_1
 
-   subroutine test_example_2()
-      implicit none
-      if (.not. (reverse((-123_8)) == ((-321_8)))) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_2
+  subroutine test_example_2()
+    implicit none
+    if (.not. (reverse((-123_8)) == ((-321_8)))) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_2
 
-   subroutine test_example_3()
-      implicit none
-      if (.not. (reverse(120_8) == 21_8)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_example_3
+  subroutine test_example_3()
+    implicit none
+    if (.not. (reverse(120_8) == 21_8)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_example_3
 
-   subroutine test_overflow()
-      implicit none
-      if (.not. (reverse(1534236469_8) == 0_8)) then
-         print *, 'expect failed'
-         stop 1
-      end if
-   end subroutine test_overflow
+  subroutine test_overflow()
+    implicit none
+    if (.not. (reverse(1534236469_8) == 0_8)) then
+      print *, 'expect failed'
+      stop 1
+    end if
+  end subroutine test_overflow
 
 end program main

--- a/tests/compiler/fortran/arithmetic.f90.out
+++ b/tests/compiler/fortran/arithmetic.f90.out
@@ -2,7 +2,7 @@ program main
   implicit none
   print *, (1_8 + 2_8)
   print *, (5_8 - 3_8)
-  print *, (4_8*2_8)
-  print *, (8_8/2_8)
+  print *, (4_8 * 2_8)
+  print *, (8_8 / 2_8)
   print *, mod(7_8, 3_8)
 end program main

--- a/tests/compiler/fortran/builtin_append.f90.out
+++ b/tests/compiler/fortran/builtin_append.f90.out
@@ -1,7 +1,7 @@
 program main
   implicit none
   integer(kind=8), allocatable :: xs(:)
-  allocate (xs(0))
-  xs = (/(/1_8, 2_8/), 3_8/)
+  allocate(xs(0))
+  xs = (/ (/1_8, 2_8/), 3_8 /)
   print *, xs(modulo(2_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/builtin_str.f90.out
+++ b/tests/compiler/fortran/builtin_str.f90.out
@@ -10,8 +10,8 @@ contains
     integer(kind=8), intent(in) :: v
     character(:), allocatable :: r
     character(len=32) :: buf
-    write (buf, '(I0)') v
-    allocate (character(len=len_trim(buf)) :: r)
+    write(buf,'(I0)') v
+    allocate(character(len=len_trim(buf)) :: r)
     r = trim(buf)
   end function str_int
 
@@ -20,8 +20,8 @@ contains
     real, intent(in) :: v
     character(:), allocatable :: r
     character(len=64) :: buf
-    write (buf, '(G0)') v
-    allocate (character(len=len_trim(buf)) :: r)
+    write(buf,'(G0)') v
+    allocate(character(len=len_trim(buf)) :: r)
     r = trim(buf)
   end function str_float
 end program main

--- a/tests/compiler/fortran/dataset_sort_take_limit.f90.out
+++ b/tests/compiler/fortran/dataset_sort_take_limit.f90.out
@@ -8,9 +8,9 @@ program main
   integer(kind=8) :: expensive
   integer(kind=8) :: item
   integer(kind=8) :: i_item
-  allocate (products(0))
+  allocate(products(0))
   products = (/Product(name='Laptop', price=1500_8), Product(name='Smartphone', price=900_8), Product(name='Tablet', price=600_8), Product(name='Monitor', price=300_8), Product(name='Keyboard', price=100_8), Product(name='Mouse', price=50_8), Product(name='Headphones', price=200_8)/)
-  expensive = lambda_0(products) (1_8 + 1:1_8 + 3_8)
+  expensive = lambda_0(products)(1_8 + 1:1_8 + 3_8)
   print *, '--- Top products (excluding most expensive) ---'
   do i_item = 0, size(expensive) - 1
     item = expensive(modulo(i_item, size(expensive)) + 1)
@@ -31,8 +31,8 @@ contains
     integer(kind=8) :: sort_key
     integer(kind=8) :: swap_key
     integer(kind=8) :: swap_item
-    allocate (tmp(size(vsrc)))
-    allocate (tmpKey(size(vsrc)))
+    allocate(tmp(size(vsrc)))
+    allocate(tmpKey(size(vsrc)))
     n = 0
     do i = 1, size(vsrc)
       p = vsrc(i)
@@ -57,7 +57,7 @@ contains
         tmp(min_idx) = swap_item
       end if
     end do
-    allocate (res(n))
+    allocate(res(n))
     res = tmp(:n)
   end function lambda_0
 

--- a/tests/compiler/fortran/dataset_sort_where.f90.out
+++ b/tests/compiler/fortran/dataset_sort_where.f90.out
@@ -8,7 +8,7 @@ program main
   integer(kind=8) :: cheap
   integer(kind=8) :: c
   integer(kind=8) :: i_c
-  allocate (items(0))
+  allocate(items(0))
   items = (/Item(name='A', price=100_8), Item(name='B', price=50_8), Item(name='C', price=200_8), Item(name='D', price=80_8)/)
   cheap = lambda_0(items)
   do i_c = 0, size(cheap) - 1
@@ -30,8 +30,8 @@ contains
     integer(kind=8) :: sort_key
     integer(kind=8) :: swap_key
     integer(kind=8) :: swap_item
-    allocate (tmp(size(vsrc)))
-    allocate (tmpKey(size(vsrc)))
+    allocate(tmp(size(vsrc)))
+    allocate(tmpKey(size(vsrc)))
     n = 0
     do i = 1, size(vsrc)
       it = vsrc(i)
@@ -58,7 +58,7 @@ contains
         tmp(min_idx) = swap_item
       end if
     end do
-    allocate (res(n))
+    allocate(res(n))
     res = tmp(:n)
   end function lambda_0
 

--- a/tests/compiler/fortran/fetch_builtin.f90.out
+++ b/tests/compiler/fortran/fetch_builtin.f90.out
@@ -13,13 +13,13 @@ contains
     character(len=:), allocatable :: r
     character(len=1024) :: cmd
     integer :: u, n
-    cmd = 'curl -s -o mochi_fetch.tmp '//trim(url)
+    cmd = 'curl -s -o mochi_fetch.tmp ' // trim(url)
     call execute_command_line(cmd)
-    open (newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
-    inquire (u, size=n)
-    allocate (character(len=n) :: r)
-    read (u) r
-    close (u)
+    open(newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
+    inquire(u, size=n)
+    allocate(character(len=n) :: r)
+    read(u) r
+    close(u)
     call execute_command_line('rm -f mochi_fetch.tmp')
   end function mochi_fetch
 end program main

--- a/tests/compiler/fortran/fetch_http.f90.out
+++ b/tests/compiler/fortran/fetch_http.f90.out
@@ -11,13 +11,13 @@ contains
     character(len=:), allocatable :: r
     character(len=1024) :: cmd
     integer :: u, n
-    cmd = 'curl -s -o mochi_fetch.tmp '//trim(url)
+    cmd = 'curl -s -o mochi_fetch.tmp ' // trim(url)
     call execute_command_line(cmd)
-    open (newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
-    inquire (u, size=n)
-    allocate (character(len=n) :: r)
-    read (u) r
-    close (u)
+    open(newunit=u, file='mochi_fetch.tmp', access='stream', form='unformatted', action='read')
+    inquire(u, size=n)
+    allocate(character(len=n) :: r)
+    read(u) r
+    close(u)
     call execute_command_line('rm -f mochi_fetch.tmp')
   end function mochi_fetch
 end program main

--- a/tests/compiler/fortran/float_ops.f90.out
+++ b/tests/compiler/fortran/float_ops.f90.out
@@ -6,6 +6,6 @@ program main
   y = 2.5
   print *, (x + y)
   print *, (y - x)
-  print *, (x*y)
-  print *, (y/x)
+  print *, (x * y)
+  print *, (y / x)
 end program main

--- a/tests/compiler/fortran/fun_expr.f90.out
+++ b/tests/compiler/fortran/fun_expr.f90.out
@@ -1,6 +1,6 @@
 program main
   implicit none
-  print *, (lambda_0) (2_8, 3_8)
+  print *, (lambda_0)(2_8, 3_8)
 contains
   function lambda_0(a, b) result(res)
     implicit none

--- a/tests/compiler/fortran/list_append.f90.out
+++ b/tests/compiler/fortran/list_append.f90.out
@@ -1,8 +1,8 @@
 program main
   implicit none
   integer(kind=8), allocatable :: xs(:)
-  allocate (xs(0))
+  allocate(xs(0))
   xs = (/1_8, 2_8/)
-  xs = (/xs, (/3_8/)/)
+  xs = (/ xs, (/3_8/) /)
   print *, xs(modulo(2_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/list_concat.f90.out
+++ b/tests/compiler/fortran/list_concat.f90.out
@@ -1,4 +1,4 @@
 program main
   implicit none
-  print *, (/(/1_8, 2_8/), (/3_8, 4_8/)/)
+  print *, (/ (/1_8, 2_8/), (/3_8, 4_8/) /)
 end program main

--- a/tests/compiler/fortran/list_index.f90.out
+++ b/tests/compiler/fortran/list_index.f90.out
@@ -1,7 +1,7 @@
 program main
   implicit none
   integer(kind=8), allocatable :: xs(:)
-  allocate (xs(0))
+  allocate(xs(0))
   xs = (/10_8, 20_8, 30_8/)
   print *, xs(modulo(1_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/list_slice.f90.out
+++ b/tests/compiler/fortran/list_slice.f90.out
@@ -1,7 +1,7 @@
 program main
   implicit none
   integer(kind=8), allocatable :: xs(:)
-  allocate (xs(0))
+  allocate(xs(0))
   xs = (/1_8, 2_8, 3_8, 4_8/)
   print *, xs(modulo(1_8, size(xs)) + 1:modulo(3_8, size(xs)))
 end program main

--- a/tests/compiler/fortran/list_union_all.f90.out
+++ b/tests/compiler/fortran/list_union_all.f90.out
@@ -1,4 +1,4 @@
 program main
   implicit none
-  print *, (/(/1_8, 2_8/), (/2_8, 3_8/)/)
+  print *, (/ (/1_8, 2_8/), (/2_8, 3_8/) /)
 end program main

--- a/tests/compiler/fortran/load_save_json.f90.out
+++ b/tests/compiler/fortran/load_save_json.f90.out
@@ -5,7 +5,7 @@ program main
     integer(kind=8) :: age
   end type Person
   type(Person), allocatable :: people(:)
-  allocate (people(0))
+  allocate(people(0))
   people = load_json_Person('')
   call save_json_Person(people, '')
 end program main

--- a/tests/compiler/fortran/multi_functions.f90.out
+++ b/tests/compiler/fortran/multi_functions.f90.out
@@ -27,7 +27,7 @@ contains
     integer(kind=8) :: res
     integer(kind=8), intent(in) :: x
     integer(kind=8), intent(in) :: y
-    res = (x*y)
+    res = (x * y)
     return
   end function mul
 

--- a/tests/compiler/fortran/query_basic.f90.out
+++ b/tests/compiler/fortran/query_basic.f90.out
@@ -4,7 +4,7 @@ program main
   integer(kind=8) :: ys
   integer(kind=8) :: v
   integer(kind=8) :: i_v
-  allocate (xs(0))
+  allocate(xs(0))
   xs = (/1_8, 10_8, 20_8, 5_8/)
   ys = lambda_0(xs)
   do i_v = 0, size(ys) - 1
@@ -20,7 +20,7 @@ contains
     integer(kind=8) :: x
     integer(kind=8) :: n
     integer(kind=8) :: i
-    allocate (tmp(size(vsrc)))
+    allocate(tmp(size(vsrc)))
     n = 0
     do i = 1, size(vsrc)
       x = vsrc(i)
@@ -29,7 +29,7 @@ contains
         tmp(n) = (x + 1_8)
       end if
     end do
-    allocate (res(n))
+    allocate(res(n))
     res = tmp(:n)
   end function lambda_0
 

--- a/tests/compiler/fortran/string_concat.f90.out
+++ b/tests/compiler/fortran/string_concat.f90.out
@@ -1,4 +1,4 @@
 program main
   implicit none
-  print *, (trim('hello ')//trim('world'))
+  print *, (trim('hello ') // trim('world'))
 end program main

--- a/tests/compiler/fortran/string_for_loop.f90.out
+++ b/tests/compiler/fortran/string_for_loop.f90.out
@@ -3,7 +3,7 @@ program main
   character(:), allocatable :: ch
   integer(kind=8) :: i_ch
   do i_ch = 0, len('cat') - 1
-    ch = 'cat' (modulo(i_ch, len('cat')) + 1:modulo(i_ch, len('cat')) + 1)
+    ch = 'cat'(modulo(i_ch, len('cat')) + 1:modulo(i_ch, len('cat')) + 1)
     print *, ch
   end do
 end program main

--- a/tests/compiler/fortran/typed_list_float.f90.out
+++ b/tests/compiler/fortran/typed_list_float.f90.out
@@ -1,7 +1,7 @@
 program main
   implicit none
   real, allocatable :: xs(:)
-  allocate (xs(0))
+  allocate(xs(0))
   xs = (/1.5, 2.5/)
   print *, xs(modulo(0_8, size(xs)) + 1)
 end program main

--- a/tests/compiler/fortran/typed_list_negative.f90.out
+++ b/tests/compiler/fortran/typed_list_negative.f90.out
@@ -1,7 +1,7 @@
 program main
   implicit none
   integer(kind=8), allocatable :: xs(:)
-  allocate (xs(0))
+  allocate(xs(0))
   xs = (/((-1_8)), 0_8, 1_8/)
   call test_values()
 contains

--- a/tools/fortran/tools.go
+++ b/tools/fortran/tools.go
@@ -1,0 +1,15 @@
+//go:build ignore
+
+package main
+
+import (
+	"log"
+
+	ftncode "mochi/compile/x/fortran"
+)
+
+func main() {
+	if err := ftncode.Ensure(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- rework Fortran formatter to prefer installed tools without installing
- add an `Ensure` helper in the Fortran tool package
- add helper command under `tools/fortran`
- regenerate all Fortran golden files and examples

## Testing
- `go test ./compile/x/fortran -tags slow -run TestFortranCompiler_GoldenOutput`

------
https://chatgpt.com/codex/tasks/task_e_685e41620a2483209ad3ee4666196563