### PR TITLE
Improve Lua output formatting

### DIFF
--- a/tests/compiler/lua/break_continue.lua.out
+++ b/tests/compiler/lua/break_continue.lua.out
@@ -21,12 +21,12 @@ function __print(...)
 end
 numbers = {1, 2, 3, 4, 5, 6, 7, 8, 9}
 for _, n in ipairs(numbers) do
-	if __eq((n % 2), 0) then
-		goto __continue0
-	end
-	if (n > 7) then
-		break
-	end
-	__print("odd number:", n)
-	::__continue0::
+    if __eq((n % 2), 0) then
+        goto __continue0
+    end
+    if (n > 7) then
+        break
+    end
+    __print("odd number:", n)
+    ::__continue0::
 end

--- a/tests/compiler/lua/cast_struct.lua.out
+++ b/tests/compiler/lua/cast_struct.lua.out
@@ -9,9 +9,9 @@ end
 Todo = {}
 Todo.__index = Todo
 function Todo.new(o)
-	o = o or {}
-	setmetatable(o, Todo)
-	return o
+    o = o or {}
+    setmetatable(o, Todo)
+    return o
 end
 
 todo = Todo.new({["title"]="hi"})

--- a/tests/compiler/lua/closure.lua.out
+++ b/tests/compiler/lua/closure.lua.out
@@ -19,8 +19,8 @@ function __print(...)
     io.write('\n')
 end
 function makeAdder(n)
-	return function(x)
-		return __add(x, n)
+    return function(x)
+        return __add(x, n)
 end
 end
 

--- a/tests/compiler/lua/cross_join.lua.out
+++ b/tests/compiler/lua/cross_join.lua.out
@@ -9,40 +9,40 @@ end
 Customer = {}
 Customer.__index = Customer
 function Customer.new(o)
-	o = o or {}
-	setmetatable(o, Customer)
-	return o
+    o = o or {}
+    setmetatable(o, Customer)
+    return o
 end
 
 Order = {}
 Order.__index = Order
 function Order.new(o)
-	o = o or {}
-	setmetatable(o, Order)
-	return o
+    o = o or {}
+    setmetatable(o, Order)
+    return o
 end
 
 PairInfo = {}
 PairInfo.__index = PairInfo
 function PairInfo.new(o)
-	o = o or {}
-	setmetatable(o, PairInfo)
-	return o
+    o = o or {}
+    setmetatable(o, PairInfo)
+    return o
 end
 
 customers = {{id=1, name="Alice"}, {id=2, name="Bob"}, {id=3, name="Charlie"}}
 orders = {{id=100, customerId=1, total=250}, {id=101, customerId=2, total=125}, {id=102, customerId=1, total=300}}
 result = (function()
-	local _res = {}
-	for _, o in ipairs(orders) do
-		for _, c in ipairs(customers) do
-			_res[#_res+1] = {orderId=o.id, orderCustomerId=o.customerId, pairedCustomerName=c.name, orderTotal=o.total}
-		end
-	end
-	return _res
+    local _res = {}
+    for _, o in ipairs(orders) do
+        for _, c in ipairs(customers) do
+            _res[#_res+1] = {orderId=o.id, orderCustomerId=o.customerId, pairedCustomerName=c.name, orderTotal=o.total}
+        end
+    end
+    return _res
 end)()
 __print("--- Cross Join: All order-customer pairs ---")
 for _, entry in ipairs(result) do
-	__print("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
-	::__continue0::
+    __print("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)
+    ::__continue0::
 end

--- a/tests/compiler/lua/cross_join_triple.lua.out
+++ b/tests/compiler/lua/cross_join_triple.lua.out
@@ -10,18 +10,18 @@ nums = {1, 2}
 letters = {"A", "B"}
 bools = {true, false}
 combos = (function()
-	local _res = {}
-	for _, n in ipairs(nums) do
-		for _, l in ipairs(letters) do
-			for _, b in ipairs(bools) do
-				_res[#_res+1] = {["n"]=n, ["l"]=l, ["b"]=b}
-			end
-		end
-	end
-	return _res
+    local _res = {}
+    for _, n in ipairs(nums) do
+        for _, l in ipairs(letters) do
+            for _, b in ipairs(bools) do
+                _res[#_res+1] = {["n"]=n, ["l"]=l, ["b"]=b}
+            end
+        end
+    end
+    return _res
 end)()
 __print("--- Cross Join of three lists ---")
 for _, c in ipairs(combos) do
-	__print(c.n, c.l, c.b)
-	::__continue0::
+    __print(c.n, c.l, c.b)
+    ::__continue0::
 end

--- a/tests/compiler/lua/dataset.lua.out
+++ b/tests/compiler/lua/dataset.lua.out
@@ -9,22 +9,22 @@ end
 Person = {}
 Person.__index = Person
 function Person.new(o)
-	o = o or {}
-	setmetatable(o, Person)
-	return o
+    o = o or {}
+    setmetatable(o, Person)
+    return o
 end
 
 people = {{name="Alice", age=30}, {name="Bob", age=15}, {name="Charlie", age=65}}
 names = (function()
-	local _res = {}
-	for _, p in ipairs(people) do
-		if (p.age >= 18) then
-			_res[#_res+1] = p.name
-		end
-	end
-	return _res
+    local _res = {}
+    for _, p in ipairs(people) do
+        if (p.age >= 18) then
+            _res[#_res+1] = p.name
+        end
+    end
+    return _res
 end)()
 for _, n in ipairs(names) do
-	__print(n)
-	::__continue0::
+    __print(n)
+    ::__continue0::
 end

--- a/tests/compiler/lua/dataset_sort_take_limit.lua.out
+++ b/tests/compiler/lua/dataset_sort_take_limit.lua.out
@@ -9,37 +9,37 @@ end
 Product = {}
 Product.__index = Product
 function Product.new(o)
-	o = o or {}
-	setmetatable(o, Product)
-	return o
+    o = o or {}
+    setmetatable(o, Product)
+    return o
 end
 
 products = {{name="Laptop", price=1500}, {name="Smartphone", price=900}, {name="Tablet", price=600}, {name="Monitor", price=300}, {name="Keyboard", price=100}, {name="Mouse", price=50}, {name="Headphones", price=200}}
 expensive = (function()
-	local _res = {}
-	for _, p in ipairs(products) do
-		_res[#_res+1] = {__key = -p.price, __val = p}
-	end
-	local items = _res
-	table.sort(items, function(a,b) return a.__key < b.__key end)
-	local tmp = {}
-	for _, it in ipairs(items) do tmp[#tmp+1] = it.__val end
-	items = tmp
-	local skip = 1
-	if skip < #items then
-		for i=1,skip do table.remove(items,1) end
-	else
-		items = {}
-	end
-	local take = 3
-	if take < #items then
-		for i=#items, take+1, -1 do table.remove(items) end
-	end
-	_res = items
-	return _res
+    local _res = {}
+    for _, p in ipairs(products) do
+        _res[#_res+1] = {__key = -p.price, __val = p}
+    end
+    local items = _res
+    table.sort(items, function(a,b) return a.__key < b.__key end)
+    local tmp = {}
+    for _, it in ipairs(items) do tmp[#tmp+1] = it.__val end
+    items = tmp
+    local skip = 1
+    if skip < #items then
+        for i=1,skip do table.remove(items,1) end
+    else
+        items = {}
+    end
+    local take = 3
+    if take < #items then
+        for i=#items, take+1, -1 do table.remove(items) end
+    end
+    _res = items
+    return _res
 end)()
 __print("--- Top products (excluding most expensive) ---")
 for _, item in ipairs(expensive) do
-	__print(item.name, "costs $", item.price)
-	::__continue0::
+    __print(item.name, "costs $", item.price)
+    ::__continue0::
 end

--- a/tests/compiler/lua/factorial.lua.out
+++ b/tests/compiler/lua/factorial.lua.out
@@ -7,10 +7,10 @@ function __print(...)
     io.write('\n')
 end
 function factorial(n)
-	if (n <= 1) then
-		return 1
-	end
-	return (n * factorial((n - 1)))
+    if (n <= 1) then
+        return 1
+    end
+    return (n * factorial((n - 1)))
 end
 
 __print(factorial(0))

--- a/tests/compiler/lua/fetch_builtin.lua.out
+++ b/tests/compiler/lua/fetch_builtin.lua.out
@@ -48,9 +48,9 @@ end
 Msg = {}
 Msg.__index = Msg
 function Msg.new(o)
-	o = o or {}
-	setmetatable(o, Msg)
-	return o
+    o = o or {}
+    setmetatable(o, Msg)
+    return o
 end
 
 data = __fetch("file://tests/compiler/lua/fetch_builtin.json", nil)

--- a/tests/compiler/lua/fetch_http.lua.out
+++ b/tests/compiler/lua/fetch_http.lua.out
@@ -48,9 +48,9 @@ end
 Todo = {}
 Todo.__index = Todo
 function Todo.new(o)
-	o = o or {}
-	setmetatable(o, Todo)
-	return o
+    o = o or {}
+    setmetatable(o, Todo)
+    return o
 end
 
 todo = Todo.new((__fetch("https://jsonplaceholder.typicode.com/todos/1", nil)))

--- a/tests/compiler/lua/fetch_options.lua.out
+++ b/tests/compiler/lua/fetch_options.lua.out
@@ -48,9 +48,9 @@ end
 Msg = {}
 Msg.__index = Msg
 function Msg.new(o)
-	o = o or {}
-	setmetatable(o, Msg)
-	return o
+    o = o or {}
+    setmetatable(o, Msg)
+    return o
 end
 
 data = __fetch("https://example.com", {["method"]="POST", ["headers"]={["Accept"]="application/json"}, ["query"]={["q"]="1"}, ["body"]={["text"]="hi"}, ["timeout"]=10.0})

--- a/tests/compiler/lua/fetch_stmt.lua.out
+++ b/tests/compiler/lua/fetch_stmt.lua.out
@@ -48,9 +48,9 @@ end
 Todo = {}
 Todo.__index = Todo
 function Todo.new(o)
-	o = o or {}
-	setmetatable(o, Todo)
-	return o
+    o = o or {}
+    setmetatable(o, Todo)
+    return o
 end
 
 todo = __fetch("https://jsonplaceholder.typicode.com/todos/1", nil)

--- a/tests/compiler/lua/fibonacci.lua.out
+++ b/tests/compiler/lua/fibonacci.lua.out
@@ -19,10 +19,10 @@ function __print(...)
     io.write('\n')
 end
 function fib(n)
-	if (n <= 1) then
-		return n
-	end
-	return __add(fib((n - 1)), fib((n - 2)))
+    if (n <= 1) then
+        return n
+    end
+    return __add(fib((n - 1)), fib((n - 2)))
 end
 
 __print(fib(0))

--- a/tests/compiler/lua/for_loop.lua.out
+++ b/tests/compiler/lua/for_loop.lua.out
@@ -7,6 +7,6 @@ function __print(...)
     io.write('\n')
 end
 for i = 1, (4)-1 do
-	__print(i)
-	::__continue0::
+    __print(i)
+    ::__continue0::
 end

--- a/tests/compiler/lua/fun_expr_in_let.lua.out
+++ b/tests/compiler/lua/fun_expr_in_let.lua.out
@@ -7,6 +7,6 @@ function __print(...)
     io.write('\n')
 end
 square = function(x)
-		return (x * x)
+        return (x * x)
 end
 __print(square(6))

--- a/tests/compiler/lua/generate_struct.lua.out
+++ b/tests/compiler/lua/generate_struct.lua.out
@@ -17,9 +17,9 @@ end
 Info = {}
 Info.__index = Info
 function Info.new(o)
-	o = o or {}
-	setmetatable(o, Info)
-	return o
+    o = o or {}
+    setmetatable(o, Info)
+    return o
 end
 
 info = __gen_struct("{\"msg\": \"hello\"}", nil, nil)

--- a/tests/compiler/lua/group_by.lua.out
+++ b/tests/compiler/lua/group_by.lua.out
@@ -55,14 +55,14 @@ function __print(...)
 end
 xs = {1, 1, 2}
 groups = (function()
-	local _groups = __group_by(xs, function(x) return x end)
-	local _res = {}
-	for _, g in ipairs(_groups) do
-		_res[#_res+1] = {["k"]=g.key, ["c"]=__count(g)}
-	end
-	return _res
+    local _groups = __group_by(xs, function(x) return x end)
+    local _res = {}
+    for _, g in ipairs(_groups) do
+        _res[#_res+1] = {["k"]=g.key, ["c"]=__count(g)}
+    end
+    return _res
 end)()
 for _, g in ipairs(groups) do
-	__print(g.k, g.c)
-	::__continue0::
+    __print(g.k, g.c)
+    ::__continue0::
 end

--- a/tests/compiler/lua/helper.lua.out
+++ b/tests/compiler/lua/helper.lua.out
@@ -1,3 +1,3 @@
 function double(x)
-	return (x * 2)
+    return (x * 2)
 end

--- a/tests/compiler/lua/higher_order_apply.lua.out
+++ b/tests/compiler/lua/higher_order_apply.lua.out
@@ -19,14 +19,14 @@ function __print(...)
     io.write('\n')
 end
 function inc(x)
-	return __add(x, 1)
+    return __add(x, 1)
 end
 
 function apply(f, x)
-	return f(x)
+    return f(x)
 end
 
 __print(apply(inc, 5))
 __print(apply(function(y)
-		return (y * 2)
+        return (y * 2)
 end, 7))

--- a/tests/compiler/lua/if_else.lua.out
+++ b/tests/compiler/lua/if_else.lua.out
@@ -8,7 +8,7 @@ function __print(...)
 end
 x = 5
 if (x > 3) then
-	__print("big")
+    __print("big")
 else
-	__print("small")
+    __print("small")
 end

--- a/tests/compiler/lua/join_where.lua.out
+++ b/tests/compiler/lua/join_where.lua.out
@@ -168,37 +168,37 @@ end
 Customer = {}
 Customer.__index = Customer
 function Customer.new(o)
-	o = o or {}
-	setmetatable(o, Customer)
-	return o
+    o = o or {}
+    setmetatable(o, Customer)
+    return o
 end
 
 Order = {}
 Order.__index = Order
 function Order.new(o)
-	o = o or {}
-	setmetatable(o, Order)
-	return o
+    o = o or {}
+    setmetatable(o, Order)
+    return o
 end
 
 PairInfo = {}
 PairInfo.__index = PairInfo
 function PairInfo.new(o)
-	o = o or {}
-	setmetatable(o, PairInfo)
-	return o
+    o = o or {}
+    setmetatable(o, PairInfo)
+    return o
 end
 
 customers = {{id=1, name="Alice"}, {id=2, name="Bob"}, {id=3, name="Charlie"}}
 orders = {{id=100, customerId=1, total=250}, {id=101, customerId=2, total=125}, {id=102, customerId=1, total=300}, {id=103, customerId=4, total=80}}
 result = (function()
-	local _src = orders
-	return __query(_src, {
-		{ items = customers, on = function(o, c) return __eq(o.customerId, c.id) end }
-	}, { selectFn = function(o, c) return {orderId=o.id, customerName=c.name, total=o.total} end, where = function(o, c) return (__eq(c.name, "Alice")) end })
+    local _src = orders
+    return __query(_src, {
+        { items = customers, on = function(o, c) return __eq(o.customerId, c.id) end }
+    }, { selectFn = function(o, c) return {orderId=o.id, customerName=c.name, total=o.total} end, where = function(o, c) return (__eq(c.name, "Alice")) end })
 end)()
 __print("--- Orders with customer info ---")
 for _, entry in ipairs(result) do
-	__print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
-	::__continue0::
+    __print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+    ::__continue0::
 end

--- a/tests/compiler/lua/list_prepend.lua.out
+++ b/tests/compiler/lua/list_prepend.lua.out
@@ -19,8 +19,8 @@ function __print(...)
     io.write('\n')
 end
 function prepend(level, result)
-	result = __add({level}, result)
-	return result
+    result = __add({level}, result)
+    return result
 end
 
 __print(prepend({1, 2}, {{3}, {4}}))

--- a/tests/compiler/lua/load_builtin.lua.out
+++ b/tests/compiler/lua/load_builtin.lua.out
@@ -64,9 +64,9 @@ end
 Item = {}
 Item.__index = Item
 function Item.new(o)
-	o = o or {}
-	setmetatable(o, Item)
-	return o
+    o = o or {}
+    setmetatable(o, Item)
+    return o
 end
 
 items = __load(nil, nil)

--- a/tests/compiler/lua/load_jsonl_stdin.lua.out
+++ b/tests/compiler/lua/load_jsonl_stdin.lua.out
@@ -64,9 +64,9 @@ end
 Person = {}
 Person.__index = Person
 function Person.new(o)
-	o = o or {}
-	setmetatable(o, Person)
-	return o
+    o = o or {}
+    setmetatable(o, Person)
+    return o
 end
 
 people = __load(nil, {["format"]="jsonl"})

--- a/tests/compiler/lua/load_save_json.lua.out
+++ b/tests/compiler/lua/load_save_json.lua.out
@@ -82,9 +82,9 @@ end
 Person = {}
 Person.__index = Person
 function Person.new(o)
-	o = o or {}
-	setmetatable(o, Person)
-	return o
+    o = o or {}
+    setmetatable(o, Person)
+    return o
 end
 
 people = __load(nil, {["format"]="json"})

--- a/tests/compiler/lua/load_yaml.lua.out
+++ b/tests/compiler/lua/load_yaml.lua.out
@@ -64,9 +64,9 @@ end
 Item = {}
 Item.__index = Item
 function Item.new(o)
-	o = o or {}
-	setmetatable(o, Item)
-	return o
+    o = o or {}
+    setmetatable(o, Item)
+    return o
 end
 
 items = __load(nil, {["format"]="yaml"})

--- a/tests/compiler/lua/local_recursion.lua.out
+++ b/tests/compiler/lua/local_recursion.lua.out
@@ -48,22 +48,22 @@ function __print(...)
     io.write('\n')
 end
 function fromList(nums)
-	local function helper(lo, hi)
-		if (lo >= hi) then
-			return {__name="Leaf"}
-		end
-		local mid = __div((__add(lo, hi)), 2)
-		return {__name="Node", left=helper(lo, mid), value=__index(nums, mid), right=helper(__add(mid, 1), hi)}
-	end
-	return helper(0, #nums)
+    local function helper(lo, hi)
+        if (lo >= hi) then
+            return {__name="Leaf"}
+        end
+        local mid = __div((__add(lo, hi)), 2)
+        return {__name="Node", left=helper(lo, mid), value=__index(nums, mid), right=helper(__add(mid, 1), hi)}
+    end
+    return helper(0, #nums)
 end
 
 function inorder(t)
-	return (function()
-	local _t0 = t
-	if _t0.__name == "Leaf" then return {} end
-	if _t0.__name == "Node" then return (function(l, v, r) return __add(__add(inorder(l), {v}), inorder(r)) end)(_t0.left, _t0.value, _t0.right) end
-	return nil
+    return (function()
+    local _t0 = t
+    if _t0.__name == "Leaf" then return {} end
+    if _t0.__name == "Node" then return (function(l, v, r) return __add(__add(inorder(l), {v}), inorder(r)) end)(_t0.left, _t0.value, _t0.right) end
+    return nil
 end)()
 end
 

--- a/tests/compiler/lua/map_any_hint.lua.out
+++ b/tests/compiler/lua/map_any_hint.lua.out
@@ -7,11 +7,11 @@ function __print(...)
     io.write('\n')
 end
 function Leaf()
-	return {["__name"]="Leaf"}
+    return {["__name"]="Leaf"}
 end
 
 function Node(left, value, right)
-	return {["__name"]="Node", ["left"]=left, ["value"]=value, ["right"]=right}
+    return {["__name"]="Node", ["left"]=left, ["value"]=value, ["right"]=right}
 end
 
 tree = Node(Leaf(), 1, Leaf())

--- a/tests/compiler/lua/map_ops.lua.out
+++ b/tests/compiler/lua/map_ops.lua.out
@@ -33,6 +33,6 @@ m = {}
 m[1] = 10
 m[2] = 20
 if (m[1] ~= nil) then
-	__print(__index(m, 1))
+    __print(__index(m, 1))
 end
 __print(__index(m, 2))

--- a/tests/compiler/lua/match_capture.lua.out
+++ b/tests/compiler/lua/match_capture.lua.out
@@ -19,11 +19,11 @@ function __print(...)
     io.write('\n')
 end
 function depth(t)
-	return (function()
-	local _t0 = t
-	if _t0.__name == "Leaf" then return 0 end
-	if _t0.__name == "Node" then return (function(l, r) return __add(__add(depth(l), depth(r)), 1) end)(_t0.left, _t0.right) end
-	return nil
+    return (function()
+    local _t0 = t
+    if _t0.__name == "Leaf" then return 0 end
+    if _t0.__name == "Node" then return (function(l, r) return __add(__add(depth(l), depth(r)), 1) end)(_t0.left, _t0.right) end
+    return nil
 end)()
 end
 

--- a/tests/compiler/lua/match_underscore.lua.out
+++ b/tests/compiler/lua/match_underscore.lua.out
@@ -7,10 +7,10 @@ function __print(...)
     io.write('\n')
 end
 function value_of_root(t)
-	return (function()
-	local _t0 = t
-	if _t0.__name == "Node" then return (function(v) return v end)(_t0.value) end
-	return 0
+    return (function()
+    local _t0 = t
+    if _t0.__name == "Node" then return (function(v) return v end)(_t0.value) end
+    return 0
 end)()
 end
 

--- a/tests/compiler/lua/matrix_search.lua.out
+++ b/tests/compiler/lua/matrix_search.lua.out
@@ -61,28 +61,28 @@ function __print(...)
     io.write('\n')
 end
 function searchMatrix(matrix, target)
-	local m = #matrix
-	if __eq(m, 0) then
-		return false
-	end
-	local n = #__index(matrix, 0)
-	local left = 0
-	local right = ((m * n) - 1)
-	while (left <= right) do
-		local mid = __add(left, __div(((right - left)), 2))
-		local row = __div(mid, n)
-		local col = (mid % n)
-		local value = __index(__index(matrix, row), col)
-		if __eq(value, target) then
-			return true
-		elseif (value < target) then
-			left = __add(mid, 1)
-		else
-			right = (mid - 1)
-		end
-		::__continue0::
-	end
-	return false
+    local m = #matrix
+    if __eq(m, 0) then
+        return false
+    end
+    local n = #__index(matrix, 0)
+    local left = 0
+    local right = ((m * n) - 1)
+    while (left <= right) do
+        local mid = __add(left, __div(((right - left)), 2))
+        local row = __div(mid, n)
+        local col = (mid % n)
+        local value = __index(__index(matrix, row), col)
+        if __eq(value, target) then
+            return true
+        elseif (value < target) then
+            left = __add(mid, 1)
+        else
+            right = (mid - 1)
+        end
+        ::__continue0::
+    end
+    return false
 end
 
 __print(searchMatrix({{1, 3, 5, 7}, {10, 11, 16, 20}, {23, 30, 34, 60}}, 3))

--- a/tests/compiler/lua/nested_inner_fn.lua.out
+++ b/tests/compiler/lua/nested_inner_fn.lua.out
@@ -19,10 +19,10 @@ function __print(...)
     io.write('\n')
 end
 function outer(a)
-	local function inner(b)
-		return __add(a, b)
-	end
-	return inner(10)
+    local function inner(b)
+        return __add(a, b)
+    end
+    return inner(10)
 end
 
 __print(outer(5))

--- a/tests/compiler/lua/nested_type_decl.lua.out
+++ b/tests/compiler/lua/nested_type_decl.lua.out
@@ -9,9 +9,9 @@ end
 Person = {}
 Person.__index = Person
 function Person.new(o)
-	o = o or {}
-	setmetatable(o, Person)
-	return o
+    o = o or {}
+    setmetatable(o, Person)
+    return o
 end
 
 __print("ok")

--- a/tests/compiler/lua/package_import.lua.out
+++ b/tests/compiler/lua/package_import.lua.out
@@ -7,14 +7,14 @@ function __print(...)
     io.write('\n')
 end
 local function _import_helper()
-	local _pkg = {}
-	local function double(x)
-		return (x * 2)
-	end
-	_pkg.double = double
-	
-	_pkg.__name = "helper"
-	return _pkg
+    local _pkg = {}
+    local function double(x)
+        return (x * 2)
+    end
+    _pkg.double = double
+    
+    _pkg.__name = "helper"
+    return _pkg
 end
 local helper = _import_helper()
 

--- a/tests/compiler/lua/reduce_builtin.lua.out
+++ b/tests/compiler/lua/reduce_builtin.lua.out
@@ -26,6 +26,6 @@ function __reduce(src, fn, acc)
 end
 nums = {1, 2, 3, 4}
 sum = __reduce(nums, function(acc, x)
-		return __add(acc, x)
+        return __add(acc, x)
 end, 0)
 __print(sum)

--- a/tests/compiler/lua/simple_fn.lua.out
+++ b/tests/compiler/lua/simple_fn.lua.out
@@ -7,7 +7,7 @@ function __print(...)
     io.write('\n')
 end
 function id(x)
-	return x
+    return x
 end
 
 __print(id(123))

--- a/tests/compiler/lua/slice_remove.lua.out
+++ b/tests/compiler/lua/slice_remove.lua.out
@@ -45,7 +45,7 @@ function __slice(obj, i, j)
     end
 end
 function remove(nums, i)
-	return __add(__slice(nums, 0, i), __slice(nums, __add(i, 1), #nums))
+    return __add(__slice(nums, 0, i), __slice(nums, __add(i, 1), #nums))
 end
 
 __print(remove({1, 2, 3, 4}, 1))

--- a/tests/compiler/lua/string_for_loop.lua.out
+++ b/tests/compiler/lua/string_for_loop.lua.out
@@ -8,7 +8,7 @@ function __print(...)
 end
 local _s0 = "cat"
 for _i0 = 1, #_s0 do
-	local ch = string.sub(_s0, _i0, _i0)
-	__print(ch)
-	::__continue0::
+    local ch = string.sub(_s0, _i0, _i0)
+    __print(ch)
+    ::__continue0::
 end

--- a/tests/compiler/lua/two_sum.lua.out
+++ b/tests/compiler/lua/two_sum.lua.out
@@ -55,17 +55,17 @@ function __print(...)
     io.write('\n')
 end
 function twoSum(nums, target)
-	local n = #nums
-	for i = 0, (n)-1 do
-		for j = __add(i, 1), (n)-1 do
-			if __eq(__add(__index(nums, i), __index(nums, j)), target) then
-				return {i, j}
-			end
-			::__continue1::
-		end
-		::__continue0::
-	end
-	return {-1, -1}
+    local n = #nums
+    for i = 0, (n)-1 do
+        for j = __add(i, 1), (n)-1 do
+            if __eq(__add(__index(nums, i), __index(nums, j)), target) then
+                return {i, j}
+            end
+            ::__continue1::
+        end
+        ::__continue0::
+    end
+    return {-1, -1}
 end
 
 result = twoSum({2, 7, 11, 15}, 9)

--- a/tests/compiler/lua/type_method.lua.out
+++ b/tests/compiler/lua/type_method.lua.out
@@ -9,13 +9,13 @@ end
 Person = {}
 Person.__index = Person
 function Person.new(o)
-	o = o or {}
-	setmetatable(o, Person)
-	return o
+    o = o or {}
+    setmetatable(o, Person)
+    return o
 end
 
 function Person:greet()
-	return ("hi " .. self.name)
+    return ("hi " .. self.name)
 end
 
 p = Person.new({name="Ada"})

--- a/tests/compiler/lua/typed_list_negative.lua.out
+++ b/tests/compiler/lua/typed_list_negative.lua.out
@@ -67,14 +67,14 @@ function __run_tests(tests)
     end
 end
 function test_values()
-	if not (__eq(__index(xs, 0), (-1))) then error('expect failed') end
-	if not (__eq(__index(xs, 1), 0)) then error('expect failed') end
-	if not (__eq(__index(xs, 2), 1)) then error('expect failed') end
-	__print("done")
+    if not (__eq(__index(xs, 0), (-1))) then error('expect failed') end
+    if not (__eq(__index(xs, 1), 0)) then error('expect failed') end
+    if not (__eq(__index(xs, 2), 1)) then error('expect failed') end
+    __print("done")
 end
 
 xs = {(-1), 0, 1}
 local __tests = {
-	{name="values", fn=test_values},
+    {name="values", fn=test_values},
 }
 __run_tests(__tests)

--- a/tests/compiler/lua/underscore_for_loop.lua.out
+++ b/tests/compiler/lua/underscore_for_loop.lua.out
@@ -20,21 +20,21 @@ function __print(...)
 end
 c = 0
 for _ = 0, (2)-1 do
-	c = __add(c, 1)
-	::__continue0::
+    c = __add(c, 1)
+    ::__continue0::
 end
 for _ in ipairs({1, 2}) do
-	c = __add(c, 1)
-	::__continue1::
+    c = __add(c, 1)
+    ::__continue1::
 end
 local _s0 = "ab"
 for _i0 = 1, #_s0 do
-	c = __add(c, 1)
-	::__continue2::
+    c = __add(c, 1)
+    ::__continue2::
 end
 m = {["x"]=1, ["y"]=2}
 for _ in pairs(m) do
-	c = __add(c, 1)
-	::__continue3::
+    c = __add(c, 1)
+    ::__continue3::
 end
 __print(c)

--- a/tests/compiler/lua/union_inorder.lua.out
+++ b/tests/compiler/lua/union_inorder.lua.out
@@ -19,11 +19,11 @@ function __print(...)
     io.write('\n')
 end
 function inorder(t)
-	return (function()
-	local _t0 = t
-	if _t0.__name == "Leaf" then return {} end
-	if _t0.__name == "Node" then return (function(l, v, r) return __add(__add(inorder(l), {v}), inorder(r)) end)(_t0.left, _t0.value, _t0.right) end
-	return nil
+    return (function()
+    local _t0 = t
+    if _t0.__name == "Leaf" then return {} end
+    if _t0.__name == "Node" then return (function(l, v, r) return __add(__add(inorder(l), {v}), inorder(r)) end)(_t0.left, _t0.value, _t0.right) end
+    return nil
 end)()
 end
 

--- a/tests/compiler/lua/union_match.lua.out
+++ b/tests/compiler/lua/union_match.lua.out
@@ -7,10 +7,10 @@ function __print(...)
     io.write('\n')
 end
 function isLeaf(t)
-	return (function()
-	local _t0 = t
-	if _t0.__name == "Leaf" then return true end
-	return false
+    return (function()
+    local _t0 = t
+    if _t0.__name == "Leaf" then return true end
+    return false
 end)()
 end
 

--- a/tests/compiler/lua/union_slice.lua.out
+++ b/tests/compiler/lua/union_slice.lua.out
@@ -7,7 +7,7 @@ function __print(...)
     io.write('\n')
 end
 function listit()
-	return {{__name="Empty"}}
+    return {{__name="Empty"}}
 end
 
 __print(#listit())

--- a/tests/compiler/lua/while_loop.lua.out
+++ b/tests/compiler/lua/while_loop.lua.out
@@ -20,7 +20,7 @@ function __print(...)
 end
 i = 0
 while (i < 3) do
-	__print(i)
-	i = __add(i, 1)
-	::__continue0::
+    __print(i)
+    i = __add(i, 1)
+    ::__continue0::
 end

--- a/tests/compiler/lua/while_membership.lua.out
+++ b/tests/compiler/lua/while_membership.lua.out
@@ -20,14 +20,14 @@ function __print(...)
 end
 set = {}
 for _, n in ipairs({1, 2, 3}) do
-	set[n] = true
-	::__continue0::
+    set[n] = true
+    ::__continue0::
 end
 i = 1
 count = 0
 while (set[i] ~= nil) do
-	i = __add(i, 1)
-	count = __add(count, 1)
-	::__continue1::
+    i = __add(i, 1)
+    count = __add(count, 1)
+    ::__continue1::
 end
 __print(count)


### PR DESCRIPTION
## Summary
- add `FormatLua` with Stylua/Luafmt fallback
- call `FormatLua` from the Lua compiler
- regenerate Lua golden files

## Testing
- `go test ./...` *(fails: TestLuaCompiler_TPCHQ1)*
- `go test -tags slow ./compile/x/lua -run TestLuaCompiler_GoldenOutput -args -update`


------
https://chatgpt.com/codex/tasks/task_e_685e416beb2883209a89c5faac766943