### PR TITLE
Improve PHP compiler formatting

### DIFF
--- a/compile/x/php/compiler.go
+++ b/compile/x/php/compiler.go
@@ -3,8 +3,6 @@ package phpcode
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -110,7 +108,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		c.emitRuntime()
 	}
 	code := c.buf.Bytes()
-	return formatPHP(code), nil
+	return FormatPHP(code), nil
 }
 
 // --- Statements ---
@@ -1538,29 +1536,4 @@ func exprVarSet(e *parser.Expr) map[string]bool {
 		res[v] = true
 	}
 	return res
-}
-
-func formatPHP(src []byte) []byte {
-	if err := EnsurePHPCBF(); err != nil {
-		if len(src) > 0 && src[len(src)-1] != '\n' {
-			src = append(src, '\n')
-		}
-		return src
-	}
-	cmd := exec.Command("phpcbf", "-q", "--standard=PSR12", "-")
-	cmd.Stdin = bytes.NewReader(src)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err == nil {
-		res := out.Bytes()
-		if len(res) == 0 || res[len(res)-1] != '\n' {
-			res = append(res, '\n')
-		}
-		return res
-	}
-	if len(src) > 0 && src[len(src)-1] != '\n' {
-		src = append(src, '\n')
-	}
-	return src
 }


### PR DESCRIPTION
## Summary
- refactor PHP compiler to call a shared formatting helper
- implement `FormatPHP` in `tools.go`

## Testing
- `go test ./compile/x/php -run TestPHPCompiler_GoldenOutput -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_685e418b3f0483208b20b0677e685fe8