### PR TITLE
Improve Prolog formatting support

### DIFF
--- a/compile/x/pl/tools.go
+++ b/compile/x/pl/tools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 )
 
@@ -73,24 +74,59 @@ func EnsureSWIPL() error {
 // FormatPL attempts to tidy Prolog source code using SWI-Prolog's
 // `prolog_tidy` library. If SWI-Prolog is unavailable or formatting
 // fails, the input is returned unchanged with a trailing newline.
-func FormatPL(src []byte) []byte {
+// EnsureFormatter verifies that SWI-Prolog is available so generated code can
+// be formatted with the built-in `prolog_tidy` library.
+func EnsureFormatter() (string, error) {
+	if path, err := exec.LookPath("plfmt"); err == nil {
+		return path, nil
+	}
 	if err := EnsureSWIPL(); err == nil {
 		if path, err := exec.LookPath("swipl"); err == nil {
-			cmd := exec.Command(path, "-q", "-t", "halt", "-g", "use_module(library(prolog_tidy)),prolog_tidy:tidy_stream(user_input,user_output)")
-			cmd.Stdin = bytes.NewReader(src)
-			var out bytes.Buffer
-			cmd.Stdout = &out
-			if err := cmd.Run(); err == nil {
-				res := out.Bytes()
-				if len(res) == 0 || res[len(res)-1] != '\n' {
-					res = append(res, '\n')
-				}
-				return res
-			}
+			return path, nil
 		}
 	}
-	if len(src) > 0 && src[len(src)-1] != '\n' {
-		src = append(src, '\n')
+	if path, err := exec.LookPath("swipl"); err == nil {
+		return path, nil
 	}
-	return src
+	return "", fmt.Errorf("plfmt or swipl not found")
+}
+
+// FormatPL tidies Prolog source code using SWI-Prolog's `prolog_tidy` library
+// if available. When SWI-Prolog is missing or formatting fails, it falls back to
+// trimming whitespace so that the compiler output remains readable.
+func FormatPL(src []byte) []byte {
+	if path, err := EnsureFormatter(); err == nil {
+		var cmd *exec.Cmd
+		if filepath.Base(path) == "plfmt" {
+			cmd = exec.Command(path)
+		} else {
+			cmd = exec.Command(path, "-q", "-t", "halt", "-g", "use_module(library(prolog_tidy)),prolog_tidy:tidy_stream(user_input,user_output)")
+		}
+		cmd.Stdin = bytes.NewReader(src)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err == nil {
+			res := out.Bytes()
+			if len(res) == 0 || res[len(res)-1] != '\n' {
+				res = append(res, '\n')
+			}
+			return res
+		}
+	}
+
+	// Simple fallback: trim trailing spaces on each line to improve
+	// readability without changing semantics.
+	lines := bytes.Split(src, []byte{'\n'})
+	var buf bytes.Buffer
+	for i, line := range lines {
+		buf.Write(bytes.TrimRight(line, " \t"))
+		if i < len(lines)-1 || len(line) > 0 {
+			buf.WriteByte('\n')
+		}
+	}
+	res := buf.Bytes()
+	if len(res) == 0 || res[len(res)-1] != '\n' {
+		res = append(res, '\n')
+	}
+	return res
 }


### PR DESCRIPTION
## Summary
- add `EnsureFormatter` helper for the Prolog compiler
- use `plfmt` if available, otherwise fallback to SWI-Prolog's `prolog_tidy`
- fallback to whitespace trimming when no formatter is found

## Testing
- `go vet ./...`
- `go test -tags slow ./compile/x/pl -run TestPrologCompiler_GoldenOutput -update`


------
https://chatgpt.com/codex/tasks/task_e_685e419d09088320b2916e1e0d9f56df