### PR TITLE
Improve rust formatting utilities

### DIFF
--- a/compile/x/rust/compiler_test.go
+++ b/compile/x/rust/compiler_test.go
@@ -18,10 +18,9 @@ import (
 )
 
 func TestRustCompiler_SubsetPrograms(t *testing.T) {
-	if err := rscode.EnsureRust(); err != nil {
+	if err := rscode.Ensure(); err != nil {
 		t.Skipf("rust not installed: %v", err)
 	}
-	_ = rscode.EnsureRustfmt()
 	golden.Run(t, "tests/compiler/rust", ".mochi", ".out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {
@@ -62,7 +61,7 @@ func TestRustCompiler_SubsetPrograms(t *testing.T) {
 }
 
 func TestRustCompiler_ValidPrograms(t *testing.T) {
-	if err := rscode.EnsureRust(); err != nil {
+	if err := rscode.Ensure(); err != nil {
 		t.Skipf("rust not installed: %v", err)
 	}
 
@@ -253,10 +252,9 @@ func findRoot(t *testing.T) string {
 }
 
 func TestRustCompiler_GoldenOutput(t *testing.T) {
-	if err := rscode.EnsureRust(); err != nil {
+	if err := rscode.Ensure(); err != nil {
 		t.Skipf("rust not installed: %v", err)
 	}
-	_ = rscode.EnsureRustfmt()
 	golden.Run(t, "tests/compiler/rust", ".mochi", ".rs.out", func(src string) ([]byte, error) {
 		prog, err := parser.Parse(src)
 		if err != nil {

--- a/compile/x/rust/tools.go
+++ b/compile/x/rust/tools.go
@@ -84,13 +84,19 @@ func ensureRust() error {
 	return cmd.Run()
 }
 
+func Ensure() error {
+	if err := EnsureRust(); err != nil {
+		return err
+	}
+	return EnsureRustfmt()
+}
+
 // FormatRust runs rustfmt on the given source code if available. If rustfmt is
 // missing or fails the formatting step, tabs are expanded to four spaces and a
 // trailing newline is ensured so that the generated code remains readable.
 func FormatRust(src []byte) []byte {
-	path, err := exec.LookPath("rustfmt")
-	if err == nil {
-		cmd := exec.Command(path, "--emit", "stdout")
+	if path, err := exec.LookPath("rustfmt"); err == nil {
+		cmd := exec.Command(path, "--edition", "2021", "--emit", "stdout")
 		cmd.Stdin = bytes.NewReader(src)
 		var out bytes.Buffer
 		cmd.Stdout = &out


### PR DESCRIPTION
## Summary
- add unified `Ensure` to Rust tool helpers
- run rustfmt with edition 2021 when formatting
- update tests to call the new ensure wrapper

## Testing
- `go test ./compile/x/rust -tags slow -run TestRustCompiler_GoldenOutput -update`

------
https://chatgpt.com/codex/tasks/task_e_685e41d20c4c83209d215fcc2aad31fc