### PR TITLE
Improve TS compiler formatting

### DIFF
--- a/compile/ts/compiler.go
+++ b/compile/ts/compiler.go
@@ -1,7 +1,6 @@
 package tscode
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -2426,18 +2425,27 @@ func formatTS(src []byte) []byte {
 		}
 	}
 
-	// Fallback: replace tabs and trim whitespace to keep code readable
+	// Fallback: basic cleanup for readability
 	s := strings.ReplaceAll(string(src), "\t", "  ")
-	var buf bytes.Buffer
-	scanner := bufio.NewScanner(strings.NewReader(s))
-	for scanner.Scan() {
-		line := strings.TrimRight(scanner.Text(), " \t")
-		buf.WriteString(line)
-		buf.WriteByte('\n')
+	lines := strings.Split(s, "\n")
+	var outLines []string
+	lastBlank := false
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		blank := len(strings.TrimSpace(line)) == 0
+		if blank {
+			if lastBlank {
+				continue
+			}
+			lastBlank = true
+		} else {
+			lastBlank = false
+		}
+		outLines = append(outLines, line)
 	}
-	res := buf.Bytes()
-	if len(res) == 0 || res[len(res)-1] != '\n' {
-		res = append(res, '\n')
+	res := strings.Join(outLines, "\n")
+	if !strings.HasSuffix(res, "\n") {
+		res += "\n"
 	}
-	return res
+	return []byte(res)
 }

--- a/compile/ts/tools.go
+++ b/compile/ts/tools.go
@@ -77,3 +77,7 @@ func EnsureFormatter() error {
 // Ensure provides a simple entry point for other packages to verify
 // the TypeScript toolchain is available.
 func Ensure() error { return EnsureFormatter() }
+
+// Format runs the TypeScript formatter on the provided source. It falls back to
+// a basic cleanup if no official formatter is available.
+func Format(src []byte) []byte { return formatTS(src) }

--- a/tools/ts/tools.go
+++ b/tools/ts/tools.go
@@ -1,0 +1,15 @@
+//go:build ignore
+
+package main
+
+import (
+	"log"
+
+	tscode "mochi/compile/ts"
+)
+
+func main() {
+	if err := tscode.Ensure(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- refine `formatTS` fallback cleanup for prettier-less environments
- expose a `Format` helper for TypeScript output
- add a small tool to ensure the TypeScript toolchain

## Testing
- `go test ./compile/ts -tags slow -run TestTSCompiler_GoldenOutput -update`

------
https://chatgpt.com/codex/tasks/task_e_685e435636a483209bf1fd73ff0e8f0b