### PR TITLE
Improve Dart formatting

### DIFF
--- a/tests/compiler/valid/break_continue.dart.out
+++ b/tests/compiler/valid/break_continue.dart.out
@@ -1,13 +1,28 @@
 void main() {
-	List<int> numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-	for (var n in numbers) {
-		if (((n % 2) == 0)) {
-			continue;
-		}
-		if ((n > 7)) {
-			break;
-		}
-		print(["odd number:".toString(), n.toString()].join(' '));
-	}
+  List<int> numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  for (var n in numbers) {
+    if (_equal((n % 2), 0)) {
+      continue;
+    }
+    if ((n > 7)) {
+      break;
+    }
+    print(["odd number:".toString(), n.toString()].join(' '));
+  }
 }
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
 

--- a/tests/compiler/valid/fold_pure_let.dart.out
+++ b/tests/compiler/valid/fold_pure_let.dart.out
@@ -1,10 +1,10 @@
-int sum(int n) {
-	return ((n * ((n + 1))) ~/ 2);
+int sumN(int n) {
+  return ((n * ((n + 1))) ~/ 2);
 }
 
 void main() {
-	int n = 10;
-	print(sum(n));
-	print(n);
+  int n = 10;
+  print(sumN(n));
+  print(n);
 }
 

--- a/tests/compiler/valid/for_list_collection.dart.out
+++ b/tests/compiler/valid/for_list_collection.dart.out
@@ -1,6 +1,6 @@
 void main() {
-	for (var n in [1, 2, 3]) {
-		print(n);
-	}
+  for (var n in [1, 2, 3]) {
+    print(n);
+  }
 }
 

--- a/tests/compiler/valid/for_loop.dart.out
+++ b/tests/compiler/valid/for_loop.dart.out
@@ -1,6 +1,6 @@
 void main() {
-	for (var i = 1; i < 4; i++) {
-		print(i);
-	}
+  for (var i = 1; i < 4; i++) {
+    print(i);
+  }
 }
 

--- a/tests/compiler/valid/for_string_collection.dart.out
+++ b/tests/compiler/valid/for_string_collection.dart.out
@@ -1,8 +1,8 @@
 void main() {
-	var _tmp0 = "hi";
-	for (var _tmp1 in _tmp0.runes) {
-		var ch = String.fromCharCode(_tmp1);
-		print(ch);
-	}
+  var _tmp0 = "hi";
+  for (var _tmp1 in _tmp0.runes) {
+    var ch = String.fromCharCode(_tmp1);
+    print(ch);
+  }
 }
 

--- a/tests/compiler/valid/fun_call.dart.out
+++ b/tests/compiler/valid/fun_call.dart.out
@@ -1,8 +1,8 @@
 int add(int a, int b) {
-	return (a + b);
+  return (a + b);
 }
 
 void main() {
-	print(add(2, 3));
+  print(add(2, 3));
 }
 

--- a/tests/compiler/valid/fun_expr_in_let.dart.out
+++ b/tests/compiler/valid/fun_expr_in_let.dart.out
@@ -1,5 +1,5 @@
 void main() {
-	dynamic square = (x) => (x * x);
-	print(square(6));
+  dynamic square = (x) => (x * x);
+  print(square(6));
 }
 

--- a/tests/compiler/valid/grouped_expr.dart.out
+++ b/tests/compiler/valid/grouped_expr.dart.out
@@ -1,5 +1,5 @@
 void main() {
-	int value = (((1 + 2)) * 3);
-	print(value);
+  int value = (((1 + 2)) * 3);
+  print(value);
 }
 

--- a/tests/compiler/valid/if_else.dart.out
+++ b/tests/compiler/valid/if_else.dart.out
@@ -1,9 +1,9 @@
 void main() {
-	int x = 5;
-	if ((x > 3)) {
-		print("big");
-	} else {
-		print("small");
-	}
+  int x = 5;
+  if ((x > 3)) {
+    print("big");
+  } else {
+    print("small");
+  }
 }
 

--- a/tests/compiler/valid/len_builtin.dart.out
+++ b/tests/compiler/valid/len_builtin.dart.out
@@ -1,4 +1,4 @@
 void main() {
-	print([1, 2, 3].length);
+  print([1, 2, 3].length);
 }
 

--- a/tests/compiler/valid/let_and_print.dart.out
+++ b/tests/compiler/valid/let_and_print.dart.out
@@ -1,6 +1,6 @@
 void main() {
-	int a = 10;
-	int b = 20;
-	print((a + b));
+  int a = 10;
+  int b = 20;
+  print((a + b));
 }
 

--- a/tests/compiler/valid/list_index.dart.out
+++ b/tests/compiler/valid/list_index.dart.out
@@ -1,5 +1,5 @@
 void main() {
-	List<int> xs = [10, 20, 30];
-	print(xs[1]);
+  List<int> xs = [10, 20, 30];
+  print(xs[1]);
 }
 

--- a/tests/compiler/valid/list_set.dart.out
+++ b/tests/compiler/valid/list_set.dart.out
@@ -1,6 +1,6 @@
 void main() {
-	List<int> nums = [1, 2];
-	nums[1] = 3;
-	print(nums[1]);
+  List<int> nums = [1, 2];
+  nums[1] = 3;
+  print(nums[1]);
 }
 

--- a/tests/compiler/valid/local_recursion.dart.out
+++ b/tests/compiler/valid/local_recursion.dart.out
@@ -1,35 +1,35 @@
 abstract class Tree {}
 class Leaf extends Tree {
-	Leaf();
+  Leaf();
 }
 class Node extends Tree {
-	Tree left;
-	int value;
-	Tree right;
-	Node({required this.left, required this.value, required this.right});
+  Tree left;
+  int value;
+  Tree right;
+  Node({required this.left, required this.value, required this.right});
 }
 
 Tree fromList(List<int> nums) {
-	Tree helper(int lo, int hi) {
-		if ((lo >= hi)) {
-			return Leaf();
-		}
-		int mid = (((lo + hi)) ~/ 2);
-		return Node(left: helper(lo, mid), value: nums[mid], right: helper((mid + 1), hi));
-	}
-	return helper(0, nums.length);
+  Tree helper(int lo, int hi) {
+    if ((lo >= hi)) {
+      return Leaf();
+    }
+    int mid = (((lo + hi)) ~/ 2);
+    return Node(left: helper(lo, mid), value: nums[mid], right: helper((mid + 1), hi));
+  }
+  return helper(0, nums.length);
 }
 
 List<int> inorder(Tree t) {
-	return (() {
-	var _t = t;
-	if (_t is Leaf) { return []; }
-	if (_t is Node) { return ((l, v, r) { return ((inorder(l) + [v]) + inorder(r)); })((_t as Node).left, (_t as Node).value, (_t as Node).right); }
-	return null;
+  return (() {
+  var _t = t;
+  if (_t is Leaf) { return []; }
+  if (_t is Node) { return ((l, v, r) { return ((inorder(l) + [v]) + inorder(r)); })((_t as Node).left, (_t as Node).value, (_t as Node).right); }
+  return null;
 })();
 }
 
 void main() {
-	print(inorder(fromList([-10, -3, 0, 5, 9])));
+  print(inorder(fromList([-10, -3, 0, 5, 9])));
 }
 

--- a/tests/compiler/valid/map_index.dart.out
+++ b/tests/compiler/valid/map_index.dart.out
@@ -1,5 +1,5 @@
 void main() {
-	Map<String, int> scores = {"Alice": 10, "Bob": 15};
-	print(scores["Bob"]);
+  Map<String, int> scores = {"Alice": 10, "Bob": 15};
+  print(scores["Bob"]);
 }
 

--- a/tests/compiler/valid/map_ops.dart.out
+++ b/tests/compiler/valid/map_ops.dart.out
@@ -1,10 +1,10 @@
 void main() {
-	Map<int, int> m = {};
-	m[1] = 10;
-	m[2] = 20;
-	if ((m.containsKey(1))) {
-		print(m[1]);
-	}
-	print(m[2]);
+  Map<int, int> m = {};
+  m[1] = 10;
+  m[2] = 20;
+  if ((m.containsKey(1))) {
+    print(m[1]);
+  }
+  print(m[2]);
 }
 

--- a/tests/compiler/valid/map_set.dart.out
+++ b/tests/compiler/valid/map_set.dart.out
@@ -1,6 +1,6 @@
 void main() {
-	Map<String, int> scores = {"a": 1};
-	scores["b"] = 2;
-	print(scores["b"]);
+  Map<String, int> scores = {"a": 1};
+  scores["b"] = 2;
+  print(scores["b"]);
 }
 

--- a/tests/compiler/valid/match_expr.dart.out
+++ b/tests/compiler/valid/match_expr.dart.out
@@ -1,12 +1,12 @@
 void main() {
-	int x = 2;
-	String label = (() {
-	var _t = x;
-	if (_t == 1) { return "one"; }
-	if (_t == 2) { return "two"; }
-	if (_t == 3) { return "three"; }
-	return "unknown";
+  int x = 2;
+  String label = (() {
+  var _t = x;
+  if (_t == 1) { return "one"; }
+  if (_t == 2) { return "two"; }
+  if (_t == 3) { return "three"; }
+  return "unknown";
 })();
-	print(label);
+  print(label);
 }
 

--- a/tests/compiler/valid/print_hello.dart.out
+++ b/tests/compiler/valid/print_hello.dart.out
@@ -1,4 +1,4 @@
 void main() {
-	print("hello");
+  print("hello");
 }
 

--- a/tests/compiler/valid/stream_on_emit.dart.out
+++ b/tests/compiler/valid/stream_on_emit.dart.out
@@ -1,28 +1,44 @@
-void main() {
-	class Sensor {
-		String id;
-		double temperature;
-		Sensor({required this.id, required this.temperature});
-	}
-	
-	var _SensorStream = _Stream<Sensor>('Sensor');
-	void _handler_0(Sensor ev) {
-		var s = ev;
-		print([s.id.toString(), s.temperature.toString()].join(' '));
-	}
-	_SensorStream.register(_handler_0);
-	_SensorStream.append(Sensor({id: "sensor-1", temperature: 22.5}));
+Future<void> main() async {
+  class Sensor {
+    String id;
+    double temperature;
+    Sensor({required this.id, required this.temperature});
+    factory Sensor.fromJson(Map<String,dynamic> m) {
+      return Sensor(id: m['id'] as String, temperature: m['temperature'] as double);
+    }
+  }
+  _structParsers['Sensor'] = (m) => Sensor.fromJson(m);
+  
+  var _SensorStream = _Stream<Sensor>('Sensor');
+  void _handler_0(Sensor ev) {
+    var s = ev;
+    print([s.id.toString(), s.temperature.toString()].join(' '));
+  }
+  _SensorStream.register(_handler_0);
+  _SensorStream.append(Sensor({id: "sensor-1", temperature: 22.5}));
+  await _waitAll();
 }
 
 class _Stream<T> {
     String name;
     List<void Function(T)> handlers = [];
     _Stream(this.name);
-    void append(T data) {
-        for (var h in List.from(handlers)) { h(data); }
+    Future<T> append(T data) {
+        var tasks = <Future<dynamic>>[];
+        for (var h in List.from(handlers)) {
+            var res = h(data);
+            if (res is Future) tasks.add(res);
+        }
+        var f = Future.wait(tasks).then((_) => data);
+        _pending.add(f);
+        return f;
     }
     void register(void Function(T) handler) { handlers.add(handler); }
 }
-void _waitAll() {}
+
+List<Future<dynamic>> _pending = [];
+Future<void> _waitAll() async {
+    await Future.wait(_pending);
+}
 
 

--- a/tests/compiler/valid/string_index.dart.out
+++ b/tests/compiler/valid/string_index.dart.out
@@ -1,6 +1,6 @@
 void main() {
-	String text = "hello";
-	print(_indexString(text, 1));
+  String text = "hello";
+  print(_indexString(text, 1));
 }
 
 String _indexString(String s, int i) {

--- a/tests/compiler/valid/test_block.dart.out
+++ b/tests/compiler/valid/test_block.dart.out
@@ -1,17 +1,17 @@
 import 'dart:io';
 
 void test_addition_works() {
-        int x = (1 + 2);
-        if (!((x == 3))) { throw Exception('expect failed'); }
+  int x = (1 + 2);
+  if (!((x == 3))) { throw Exception('expect failed'); }
 }
 
 void main() {
-        int failures = 0;
-        print("ok");
-        if (!_runTest("addition works", test_addition_works)) failures++;
-        if (failures > 0) {
-                print("\n[FAIL] $failures test(s) failed.");
-        }
+  int failures = 0;
+  print("ok");
+  if (!_runTest("addition works", test_addition_works)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
 }
 
 String _formatDuration(Duration d) {
@@ -19,6 +19,7 @@ String _formatDuration(Duration d) {
     if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
     return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
 }
+
 bool _runTest(String name, void Function() f) {
     stdout.write('   test $name ...');
     var start = DateTime.now();
@@ -33,4 +34,5 @@ bool _runTest(String name, void Function() f) {
         return false;
     }
 }
+
 

--- a/tests/compiler/valid/two_sum.dart.out
+++ b/tests/compiler/valid/two_sum.dart.out
@@ -1,18 +1,18 @@
 List<int> twoSum(List<int> nums, int target) {
-	int n = nums.length;
-	for (var i = 0; i < n; i++) {
-		for (var j = (i + 1); j < n; j++) {
-			if (((nums[i] + nums[j]) == target)) {
-				return [i, j];
-			}
-		}
-	}
-	return [-1, -1];
+  int n = nums.length;
+  for (var i = 0; i < n; i++) {
+    for (var j = (i + 1); j < n; j++) {
+      if (((nums[i] + nums[j]) == target)) {
+        return [i, j];
+      }
+    }
+  }
+  return [-1, -1];
 }
 
 void main() {
-	List<int> result = twoSum([2, 7, 11, 15], 9);
-	print(result[0]);
-	print(result[1]);
+  List<int> result = twoSum([2, 7, 11, 15], 9);
+  print(result[0]);
+  print(result[1]);
 }
 

--- a/tests/compiler/valid/union_inorder.dart.out
+++ b/tests/compiler/valid/union_inorder.dart.out
@@ -1,24 +1,24 @@
 abstract class Tree {}
 class Leaf extends Tree {
-	Leaf();
+  Leaf();
 }
 class Node extends Tree {
-	Tree left;
-	int value;
-	Tree right;
-	Node({required this.left, required this.value, required this.right});
+  Tree left;
+  int value;
+  Tree right;
+  Node({required this.left, required this.value, required this.right});
 }
 
 List<int> inorder(Tree t) {
-	return (() {
-	var _t = t;
-	if (_t is Leaf) { return ([] as List<int>); }
-	if (_t is Node) { return ((l, v, r) { return ((inorder(l) + [v]) + inorder(r)); })((_t as Node).left, (_t as Node).value, (_t as Node).right); }
-	return null;
+  return (() {
+  var _t = t;
+  if (_t is Leaf) { return ([] as List<int>); }
+  if (_t is Node) { return ((l, v, r) { return ((inorder(l) + [v]) + inorder(r)); })((_t as Node).left, (_t as Node).value, (_t as Node).right); }
+  return null;
 })();
 }
 
 void main() {
-	print(inorder(Node(left: Leaf(), value: 1, right: Node(left: Leaf(), value: 2, right: Leaf()))));
+  print(inorder(Node(left: Leaf(), value: 1, right: Node(left: Leaf(), value: 2, right: Leaf()))));
 }
 

--- a/tests/compiler/valid/union_match.dart.out
+++ b/tests/compiler/valid/union_match.dart.out
@@ -1,24 +1,24 @@
 abstract class Tree {}
 class Leaf extends Tree {
-	Leaf();
+  Leaf();
 }
 class Node extends Tree {
-	Tree left;
-	int value;
-	Tree right;
-	Node({required this.left, required this.value, required this.right});
+  Tree left;
+  int value;
+  Tree right;
+  Node({required this.left, required this.value, required this.right});
 }
 
 bool isLeaf(Tree t) {
-	return (() {
-	var _t = t;
-	if (_t is Leaf) { return true; }
-	return false;
+  return (() {
+  var _t = t;
+  if (_t is Leaf) { return true; }
+  return false;
 })();
 }
 
 void main() {
-	print(isLeaf(Leaf()));
-	print(isLeaf(Node(left: Leaf(), value: 1, right: Leaf())));
+  print(isLeaf(Leaf()));
+  print(isLeaf(Node(left: Leaf(), value: 1, right: Leaf())));
 }
 

--- a/tests/compiler/valid/union_slice.dart.out
+++ b/tests/compiler/valid/union_slice.dart.out
@@ -1,17 +1,17 @@
 abstract class Foo {}
 class Empty extends Foo {
-	Empty();
+  Empty();
 }
 class Node extends Foo {
-	Foo child;
-	Node({required this.child});
+  Foo child;
+  Node({required this.child});
 }
 
 List<Foo> listit() {
-	return [Empty()];
+  return [Empty()];
 }
 
 void main() {
-	print(listit().length);
+  print(listit().length);
 }
 

--- a/tests/compiler/valid/var_assignment.dart.out
+++ b/tests/compiler/valid/var_assignment.dart.out
@@ -1,6 +1,6 @@
 void main() {
-	int x = 1;
-	x = 2;
-	print(x);
+  int x = 1;
+  x = 2;
+  print(x);
 }
 

--- a/tests/compiler/valid/while_loop.dart.out
+++ b/tests/compiler/valid/while_loop.dart.out
@@ -1,8 +1,8 @@
 void main() {
-	int i = 0;
-	while ((i < 3)) {
-		print(i);
-		i = ((i + 1)).toInt();
-	}
+  int i = 0;
+  while ((i < 3)) {
+    print(i);
+    i = ((i + 1)).toInt();
+  }
 }
 

--- a/tests/dataset/tpc-h/compiler/dart/q1.dart.out
+++ b/tests/dataset/tpc-h/compiler/dart/q1.dart.out
@@ -2,80 +2,80 @@ import 'dart:io';
 import 'dart:convert';
 
 void test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus() {
-	if (!(_equal(result, [{"returnflag": "N", "linestatus": "O", "sum_qty": 53, "sum_base_price": 3000, "sum_disc_price": (950 + 1800), "sum_charge": (((950 * 1.07)) + ((1800 * 1.05))), "avg_qty": 26.5, "avg_price": 1500, "avg_disc": 0.07500000000000001, "count_order": 2}]))) { throw Exception('expect failed'); }
+  if (!(_equal(result, [{"returnflag": "N", "linestatus": "O", "sum_qty": 53, "sum_base_price": 3000, "sum_disc_price": (950 + 1800), "sum_charge": (((950 * 1.07)) + ((1800 * 1.05))), "avg_qty": 26.5, "avg_price": 1500, "avg_disc": 0.07500000000000001, "count_order": 2}]))) { throw Exception('expect failed'); }
 }
 
 void main() {
-	int failures = 0;
-	List<Map<String, dynamic>> lineitem = [{"l_quantity": 17, "l_extendedprice": 1000, "l_discount": 0.05, "l_tax": 0.07, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-08-01"}, {"l_quantity": 36, "l_extendedprice": 2000, "l_discount": 0.1, "l_tax": 0.05, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-09-01"}, {"l_quantity": 25, "l_extendedprice": 1500, "l_discount": 0, "l_tax": 0.08, "l_returnflag": "R", "l_linestatus": "F", "l_shipdate": "1998-09-03"}];
-	List<Map<String, dynamic>> result = (() {
-	var groups = <String,_Group>{};
-	var order = <String>[];
-	for (var row in lineitem) {
-		var key = {"returnflag": row.l_returnflag, "linestatus": row.l_linestatus};
-		var ks = key.toString();
-		var g = groups[ks];
-		if (g == null) {
-			g = _Group(key);
-			groups[ks] = g;
-			order.add(ks);
-		}
-		g.Items.add(row);
-	}
-	var items = [for (var k in order) groups[k]!];
-	var _res = [];
-	for (var g in items) {
-		_res.add({"returnflag": g.key.returnflag, "linestatus": g.key.linestatus, "sum_qty": _sum((() {
-	var _res = [];
-	for (var x in g) {
-		_res.add(x.l_quantity);
-	}
-	return _res;
+  int failures = 0;
+  List<Map<String, dynamic>> lineitem = [{"l_quantity": 17, "l_extendedprice": 1000, "l_discount": 0.05, "l_tax": 0.07, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-08-01"}, {"l_quantity": 36, "l_extendedprice": 2000, "l_discount": 0.1, "l_tax": 0.05, "l_returnflag": "N", "l_linestatus": "O", "l_shipdate": "1998-09-01"}, {"l_quantity": 25, "l_extendedprice": 1500, "l_discount": 0, "l_tax": 0.08, "l_returnflag": "R", "l_linestatus": "F", "l_shipdate": "1998-09-03"}];
+  List<Map<String, dynamic>> result = (() {
+  var groups = <String,_Group>{};
+  var order = <String>[];
+  for (var row in lineitem) {
+    var key = {"returnflag": row.l_returnflag, "linestatus": row.l_linestatus};
+    var ks = key.toString();
+    var g = groups[ks];
+    if (g == null) {
+      g = _Group(key);
+      groups[ks] = g;
+      order.add(ks);
+    }
+    g.Items.add(row);
+  }
+  var items = [for (var k in order) groups[k]!];
+  var _res = [];
+  for (var g in items) {
+    _res.add({"returnflag": g.key.returnflag, "linestatus": g.key.linestatus, "sum_qty": _sum((() {
+  var _res = [];
+  for (var x in g) {
+    _res.add(x.l_quantity);
+  }
+  return _res;
 })()), "sum_base_price": _sum((() {
-	var _res = [];
-	for (var x in g) {
-		_res.add(x.l_extendedprice);
-	}
-	return _res;
+  var _res = [];
+  for (var x in g) {
+    _res.add(x.l_extendedprice);
+  }
+  return _res;
 })()), "sum_disc_price": _sum((() {
-	var _res = [];
-	for (var x in g) {
-		_res.add((x.l_extendedprice * ((1 - x.l_discount))));
-	}
-	return _res;
+  var _res = [];
+  for (var x in g) {
+    _res.add((x.l_extendedprice * ((1 - x.l_discount))));
+  }
+  return _res;
 })()), "sum_charge": _sum((() {
-	var _res = [];
-	for (var x in g) {
-		_res.add(((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))));
-	}
-	return _res;
+  var _res = [];
+  for (var x in g) {
+    _res.add(((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))));
+  }
+  return _res;
 })()), "avg_qty": _avg((() {
-	var _res = [];
-	for (var x in g) {
-		_res.add(x.l_quantity);
-	}
-	return _res;
+  var _res = [];
+  for (var x in g) {
+    _res.add(x.l_quantity);
+  }
+  return _res;
 })()), "avg_price": _avg((() {
-	var _res = [];
-	for (var x in g) {
-		_res.add(x.l_extendedprice);
-	}
-	return _res;
+  var _res = [];
+  for (var x in g) {
+    _res.add(x.l_extendedprice);
+  }
+  return _res;
 })()), "avg_disc": _avg((() {
-	var _res = [];
-	for (var x in g) {
-		_res.add(x.l_discount);
-	}
-	return _res;
+  var _res = [];
+  for (var x in g) {
+    _res.add(x.l_discount);
+  }
+  return _res;
 })()), "count_order": _count(g)});
-	}
-	return _res;
+  }
+  return _res;
 })();
-	_json(result);
-	if (!_runTest("Q1 aggregates revenue and quantity by returnflag + linestatus", test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus)) failures++;
-	if (failures > 0) {
-		print("\n[FAIL] $failures test(s) failed.");
-	}
+  _json(result);
+  if (!_runTest("Q1 aggregates revenue and quantity by returnflag + linestatus", test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
 }
 
 class _Group {


### PR DESCRIPTION
## Summary
- update FormatDart to use `dart format` when available
- fall back to tab replacement and newline normalization
- add `Ensure` helper for compiler tools
- regenerate Dart golden files with the improved formatter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e4137d2748320a1c3a02f3ab2f362