### PR TITLE
Improve Kotlin formatting

### DIFF
--- a/examples/leetcode-out/kt/3/longest-substring-without-repeating-characters.kt
+++ b/examples/leetcode-out/kt/3/longest-substring-without-repeating-characters.kt
@@ -1,26 +1,27 @@
 fun lengthOfLongestSubstring(s: String) : Int {
-        val n = s.length
-        var start = 0
-        var best = 0
-        var i = 0
-        while ((i < n)) {
-                var j = start
-                while ((j < i)) {
-                        if ((s[j] == s[i])) {
-                                start = (j + 1)
-                                break
-                        }
-                        j = (j + 1)
-                }
-                val length = ((i - start) + 1)
-                if ((length > best)) {
-                        best = length
-                }
-                i = (i + 1)
+    val n = s.length
+    var start = 0
+    var best = 0
+    var i = 0
+    while ((i < n)) {
+        var j = start
+        while ((j < i)) {
+            if ((s[j] == s[i])) {
+                start = (j + 1)
+                break
+            }
+            j = (j + 1)
         }
-        return best
+        val length = ((i - start) + 1)
+        if ((length > best)) {
+            best = length
+        }
+        i = (i + 1)
+    }
+    return best
 }
 
 fun main() {
 }
+
 

--- a/examples/leetcode-out/kt/6/zigzag-conversion.kt
+++ b/examples/leetcode-out/kt/6/zigzag-conversion.kt
@@ -1,35 +1,36 @@
 fun convert(s: String, numRows: Int) : String {
-        if (((numRows <= 1) || (numRows >= s.length))) {
-                return s
+    if (((numRows <= 1) || (numRows >= s.length))) {
+        return s
+    }
+    var rows: List<String> = listOf()
+    var i = 0
+    while ((i < numRows)) {
+        rows = (rows + listOf(""))
+        i = (i + 1)
+    }
+    var curr = 0
+    var step = 1
+    for (ch in s) {
+        run {
+            val _tmp = rows.toMutableList()
+            _tmp[curr] = (rows[curr] + ch)
+            rows = _tmp
         }
-        var rows: List<String> = listOf()
-        var i = 0
-        while ((i < numRows)) {
-                rows = (rows + listOf(""))
-                i = (i + 1)
+        if ((curr == 0)) {
+            step = 1
+        } else if ((curr == (numRows - 1))) {
+            step = -1
         }
-        var curr = 0
-        var step = 1
-        for (ch in s) {
-                run {
-                        val _tmp = rows.toMutableList()
-                        _tmp[curr] = (rows[curr] + ch)
-                        rows = _tmp
-                }
-                if ((curr == 0)) {
-                        step = 1
-                } else if ((curr == (numRows - 1))) {
-                        step = -1
-                }
-                curr = (curr + step)
-        }
-        var result: String = ""
-        for (row in rows) {
-                result = (result + row)
-        }
-        return result
+        curr = (curr + step)
+    }
+    var result: String = ""
+    for (row in rows) {
+        result = (result + row)
+    }
+    return result
 }
 
 fun main() {
 }
+
 

--- a/examples/leetcode-out/kt/7/reverse-integer.kt
+++ b/examples/leetcode-out/kt/7/reverse-integer.kt
@@ -1,23 +1,24 @@
 fun reverse(x: Int) : Int {
-        var sign = 1
-        var n = x
-        if ((n < 0)) {
-                sign = -1
-                n = -n
-        }
-        var rev = 0
-        while ((n != 0)) {
-                val digit = (n % 10)
-                rev = ((rev * 10) + digit)
-                n = (n / 10)
-        }
-        rev = (rev * sign)
-        if (((rev < ((-2147483647 - 1))) || (rev > 2147483647))) {
-                return 0
-        }
-        return rev
+    var sign = 1
+    var n = x
+    if ((n < 0)) {
+        sign = -1
+        n = -n
+    }
+    var rev = 0
+    while ((n != 0)) {
+        val digit = (n % 10)
+        rev = ((rev * 10) + digit)
+        n = (n / 10)
+    }
+    rev = (rev * sign)
+    if (((rev < ((-2147483647 - 1))) || (rev > 2147483647))) {
+        return 0
+    }
+    return rev
 }
 
 fun main() {
 }
+
 

--- a/examples/leetcode-out/kt/8/string-to-integer-atoi.kt
+++ b/examples/leetcode-out/kt/8/string-to-integer-atoi.kt
@@ -1,70 +1,71 @@
 fun digit(ch: String) : Int {
-        if ((ch == "0")) {
-                return 0
-        }
-        if ((ch == "1")) {
-                return 1
-        }
-        if ((ch == "2")) {
-                return 2
-        }
-        if ((ch == "3")) {
-                return 3
-        }
-        if ((ch == "4")) {
-                return 4
-        }
-        if ((ch == "5")) {
-                return 5
-        }
-        if ((ch == "6")) {
-                return 6
-        }
-        if ((ch == "7")) {
-                return 7
-        }
-        if ((ch == "8")) {
-                return 8
-        }
-        if ((ch == "9")) {
-                return 9
-        }
-        return -1
+    if ((ch == "0")) {
+        return 0
+    }
+    if ((ch == "1")) {
+        return 1
+    }
+    if ((ch == "2")) {
+        return 2
+    }
+    if ((ch == "3")) {
+        return 3
+    }
+    if ((ch == "4")) {
+        return 4
+    }
+    if ((ch == "5")) {
+        return 5
+    }
+    if ((ch == "6")) {
+        return 6
+    }
+    if ((ch == "7")) {
+        return 7
+    }
+    if ((ch == "8")) {
+        return 8
+    }
+    if ((ch == "9")) {
+        return 9
+    }
+    return -1
 }
 
 fun myAtoi(s: String) : Int {
-        var i = 0
-        val n = s.length
-        while (((i < n) && (s[i] == " "[0]))) {
-                i = (i + 1)
+    var i = 0
+    val n = s.length
+    while (((i < n) && (s[i] == " "[0]))) {
+        i = (i + 1)
+    }
+    var sign = 1
+    if (((i < n) && (((s[i] == "+"[0]) || (s[i] == "-"[0]))))) {
+        if ((s[i] == "-"[0])) {
+            sign = -1
         }
-        var sign = 1
-        if (((i < n) && (((s[i] == "+"[0]) || (s[i] == "-"[0]))))) {
-                if ((s[i] == "-"[0])) {
-                        sign = -1
-                }
-                i = (i + 1)
+        i = (i + 1)
+    }
+    var result = 0
+    while ((i < n)) {
+        val ch = s.substring(i, (i + 1))
+        val d = digit(ch)
+        if ((d < 0)) {
+            break
         }
-        var result = 0
-        while ((i < n)) {
-                val ch = s.substring(i, (i + 1))
-                val d = digit(ch)
-                if ((d < 0)) {
-                        break
-                }
-                result = ((result * 10) + d)
-                i = (i + 1)
-        }
-        result = (result * sign)
-        if ((result > 2147483647)) {
-                return 2147483647
-        }
-        if ((result < (-2147483648))) {
-                return -2147483648
-        }
-        return result
+        result = ((result * 10) + d)
+        i = (i + 1)
+    }
+    result = (result * sign)
+    if ((result > 2147483647)) {
+        return 2147483647
+    }
+    if ((result < (-2147483648))) {
+        return -2147483648
+    }
+    return result
 }
 
 fun main() {
 }
+
 

--- a/tests/compiler/kt/arithmetic.kt.out
+++ b/tests/compiler/kt/arithmetic.kt.out
@@ -5,3 +5,4 @@ fun main() {
     println((8 / 2))
     println((7 % 3))
 }
+

--- a/tests/compiler/kt/avg_builtin.kt.out
+++ b/tests/compiler/kt/avg_builtin.kt.out
@@ -1,3 +1,4 @@
 fun main() {
     println(listOf(1, 2, 3).average())
 }
+

--- a/tests/compiler/kt/bool_ops.kt.out
+++ b/tests/compiler/kt/bool_ops.kt.out
@@ -3,3 +3,4 @@ fun main() {
     println((true || false))
     println(!false)
 }
+

--- a/tests/compiler/kt/cross_join.kt.out
+++ b/tests/compiler/kt/cross_join.kt.out
@@ -8,15 +8,15 @@ fun main() {
     val customers = listOf(Customer(id = 1, name = "Alice"), Customer(id = 2, name = "Bob"), Customer(id = 3, name = "Charlie"))
     val orders = listOf(Order(id = 100, customerId = 1, total = 250), Order(id = 101, customerId = 2, total = 125), Order(id = 102, customerId = 1, total = 300))
     val result = run {
-                val _src = orders
-                val _res = mutableListOf<PairInfo>()
-                for (o in _src) {
-                        for (c in customers) {
-                                _res.add(PairInfo(orderId = o.id, orderCustomerId = o.customerId, pairedCustomerName = c.name, orderTotal = o.total))
-                        }
-                }
-                _res
+        val _src = orders
+        val _res = mutableListOf<PairInfo>()
+        for (o in _src) {
+            for (c in customers) {
+                _res.add(PairInfo(orderId = o.id, orderCustomerId = o.customerId, pairedCustomerName = c.name, orderTotal = o.total))
+            }
         }
+        _res
+    }
     println("--- Cross Join: All order-customer pairs ---")
     for (entry in result) {
         println("Order", entry.orderId, "(customerId:", entry.orderCustomerId, ", total: $", entry.orderTotal, ") paired with", entry.pairedCustomerName)

--- a/tests/compiler/kt/cross_join_triple.kt.out
+++ b/tests/compiler/kt/cross_join_triple.kt.out
@@ -3,17 +3,17 @@ fun main() {
     val letters = listOf("A", "B")
     val bools = listOf(true, false)
     val combos = run {
-                val _src = nums
-                val _res = mutableListOf<MutableMap<String, Any>>()
-                for (n in _src) {
-                        for (l in letters) {
-                                for (b in bools) {
-                                        _res.add(mutableMapOf("n" to n, "l" to l, "b" to b))
-                                }
-                        }
+        val _src = nums
+        val _res = mutableListOf<MutableMap<String, Any>>()
+        for (n in _src) {
+            for (l in letters) {
+                for (b in bools) {
+                    _res.add(mutableMapOf("n" to n, "l" to l, "b" to b))
                 }
-                _res
+            }
         }
+        _res
+    }
     println("--- Cross Join of three lists ---")
     for (c in combos) {
         println(c.n, c.l, c.b)

--- a/tests/compiler/kt/dataset.kt.out
+++ b/tests/compiler/kt/dataset.kt.out
@@ -3,11 +3,11 @@ data class Person(val name: String, val age: Int)
 fun main() {
     val people = listOf(Person(name = "Alice", age = 30), Person(name = "Bob", age = 15), Person(name = "Charlie", age = 65))
     val names = run {
-                var res = people
-                res = res.filter { p -> (p.age >= 18) }
-                res = res.map { p -> p.name }
-                res
-        }
+        var res = people
+        res = res.filter { p -> (p.age >= 18) }
+        res = res.map { p -> p.name }
+        res
+    }
     for (n in names) {
         println(n)
     }

--- a/tests/compiler/kt/dataset_sort_take_limit.kt.out
+++ b/tests/compiler/kt/dataset_sort_take_limit.kt.out
@@ -3,13 +3,13 @@ data class Product(val name: String, val price: Int)
 fun main() {
     val products = listOf(Product(name = "Laptop", price = 1500), Product(name = "Smartphone", price = 900), Product(name = "Tablet", price = 600), Product(name = "Monitor", price = 300), Product(name = "Keyboard", price = 100), Product(name = "Mouse", price = 50), Product(name = "Headphones", price = 200))
     val expensive = run {
-                var res = products
-                res = res.sortedBy { p -> -p.price }
-                res = res.drop(1)
-                res = res.take(3)
-                res = res.map { p -> p }
-                res
-        }
+        var res = products
+        res = res.sortedBy { p -> -p.price }
+        res = res.drop(1)
+        res = res.take(3)
+        res = res.map { p -> p }
+        res
+    }
     println("--- Top products (excluding most expensive) ---")
     for (item in expensive) {
         println(item.name, "costs $", item.price)

--- a/tests/compiler/kt/fetch_builtin.kt.out
+++ b/tests/compiler/kt/fetch_builtin.kt.out
@@ -18,21 +18,21 @@ inline fun <reified T> _cast(v: Any?): T {
                 val ctor = T::class.primaryConstructor
                 if (ctor != null) {
                     val args = ctor.parameters.associateWith { p ->
-                        val value = v[p.name]
-                        when (p.type.classifier) {
-                            Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
-                            Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
-                            Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
-                            String::class -> value?.toString()
-                            else -> value
-                        }
+                    val value = v[p.name]
+                    when (p.type.classifier) {
+                        Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
+                        Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
+                        Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
+                        String::class -> value?.toString()
+                        else -> value
                     }
-                    return ctor.callBy(args)
                 }
+                return ctor.callBy(args)
             }
-            v as T
         }
+        v as T
     }
+}
 }
 fun _fetch(url: String, opts: Map<String, Any>?): Any? {
     fun encode(x: Any?): String = when (x) {
@@ -41,60 +41,60 @@ fun _fetch(url: String, opts: Map<String, Any>?): Any? {
         is Int, is Double, is Boolean -> x.toString()
         is List<*> -> x.joinToString(prefix = "[", postfix = "]") { encode(it) }
         is Map<*, *> -> x.entries.joinToString(prefix = "{", postfix = "}") { e ->
-            "\"" + e.key.toString().replace("\"", "\\\"") + "\":" + encode(e.value)
-        }
-        else -> "\"" + x.toString().replace("\"", "\\\"") + "\""
+        "\"" + e.key.toString().replace("\"", "\\\"") + "\":" + encode(e.value)
     }
+    else -> "\"" + x.toString().replace("\"", "\\\"") + "\""
+}
 
-    var full = url
-    val method = opts?.get("method")?.toString() ?: "GET"
-    if (opts?.get("query") is Map<*, *>) {
-        val q = opts["query"] as Map<*, *>
-        val qs = q.entries.joinToString("&") { e ->
-            java.net.URLEncoder.encode(e.key.toString(), java.nio.charset.StandardCharsets.UTF_8) +
-            "=" +
-            java.net.URLEncoder.encode(e.value.toString(), java.nio.charset.StandardCharsets.UTF_8)
-        }
-        val sep = if (full.contains("?")) "&" else "?"
-        full += sep + qs
-    }
+var full = url
+val method = opts?.get("method")?.toString() ?: "GET"
+if (opts?.get("query") is Map<*, *>) {
+    val q = opts["query"] as Map<*, *>
+    val qs = q.entries.joinToString("&") { e ->
+    java.net.URLEncoder.encode(e.key.toString(), java.nio.charset.StandardCharsets.UTF_8) +
+    "=" +
+    java.net.URLEncoder.encode(e.value.toString(), java.nio.charset.StandardCharsets.UTF_8)
+}
+val sep = if (full.contains("?")) "&" else "?"
+full += sep + qs
+}
 
-    val builder = java.net.http.HttpRequest.newBuilder(java.net.URI.create(full))
-    val body = opts?.get("body")
-    if (body != null) {
-        builder.method(method, java.net.http.HttpRequest.BodyPublishers.ofString(encode(body)))
-    } else {
-        builder.method(method, java.net.http.HttpRequest.BodyPublishers.noBody())
+val builder = java.net.http.HttpRequest.newBuilder(java.net.URI.create(full))
+val body = opts?.get("body")
+if (body != null) {
+    builder.method(method, java.net.http.HttpRequest.BodyPublishers.ofString(encode(body)))
+} else {
+    builder.method(method, java.net.http.HttpRequest.BodyPublishers.noBody())
+}
+if (opts?.get("headers") is Map<*, *>) {
+    val hs = opts["headers"] as Map<*, *>
+    for ((k, v) in hs) {
+        builder.header(k.toString(), v.toString())
     }
-    if (opts?.get("headers") is Map<*, *>) {
-        val hs = opts["headers"] as Map<*, *>
-        for ((k, v) in hs) {
-            builder.header(k.toString(), v.toString())
-        }
-    }
+}
 
-    val clientBuilder = java.net.http.HttpClient.newBuilder()
-    if (opts?.get("timeout") != null) {
-        val t = opts["timeout"]
-        val secs = when (t) {
-            is Int -> t.toLong()
-            is Long -> t
-            is Double -> t.toLong()
-            is Float -> t.toLong()
-            else -> null
-        }
-        if (secs != null) {
-            clientBuilder.connectTimeout(java.time.Duration.ofMillis((secs * 1000).toLong()))
-        }
+val clientBuilder = java.net.http.HttpClient.newBuilder()
+if (opts?.get("timeout") != null) {
+    val t = opts["timeout"]
+    val secs = when (t) {
+        is Int -> t.toLong()
+        is Long -> t
+        is Double -> t.toLong()
+        is Float -> t.toLong()
+        else -> null
     }
-    val client = clientBuilder.build()
+    if (secs != null) {
+        clientBuilder.connectTimeout(java.time.Duration.ofMillis((secs * 1000).toLong()))
+    }
+}
+val client = clientBuilder.build()
 
-    return try {
-        val resp = client.send(builder.build(), java.net.http.HttpResponse.BodyHandlers.ofString())
-        val text = resp.body()
-        val eng = javax.script.ScriptEngineManager().getEngineByName("javascript")
-        eng.eval("Java.asJSONCompatible($text)")
-    } catch (e: Exception) {
-        throw RuntimeException(e)
-    }
+return try {
+    val resp = client.send(builder.build(), java.net.http.HttpResponse.BodyHandlers.ofString())
+    val text = resp.body()
+    val eng = javax.script.ScriptEngineManager().getEngineByName("javascript")
+    eng.eval("Java.asJSONCompatible($text)")
+} catch (e: Exception) {
+    throw RuntimeException(e)
+}
 }

--- a/tests/compiler/kt/fetch_http.kt.out
+++ b/tests/compiler/kt/fetch_http.kt.out
@@ -19,21 +19,21 @@ inline fun <reified T> _cast(v: Any?): T {
                 val ctor = T::class.primaryConstructor
                 if (ctor != null) {
                     val args = ctor.parameters.associateWith { p ->
-                        val value = v[p.name]
-                        when (p.type.classifier) {
-                            Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
-                            Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
-                            Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
-                            String::class -> value?.toString()
-                            else -> value
-                        }
+                    val value = v[p.name]
+                    when (p.type.classifier) {
+                        Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
+                        Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
+                        Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
+                        String::class -> value?.toString()
+                        else -> value
                     }
-                    return ctor.callBy(args)
                 }
+                return ctor.callBy(args)
             }
-            v as T
         }
+        v as T
     }
+}
 }
 fun _fetch(url: String, opts: Map<String, Any>?): Any? {
     fun encode(x: Any?): String = when (x) {
@@ -42,60 +42,60 @@ fun _fetch(url: String, opts: Map<String, Any>?): Any? {
         is Int, is Double, is Boolean -> x.toString()
         is List<*> -> x.joinToString(prefix = "[", postfix = "]") { encode(it) }
         is Map<*, *> -> x.entries.joinToString(prefix = "{", postfix = "}") { e ->
-            "\"" + e.key.toString().replace("\"", "\\\"") + "\":" + encode(e.value)
-        }
-        else -> "\"" + x.toString().replace("\"", "\\\"") + "\""
+        "\"" + e.key.toString().replace("\"", "\\\"") + "\":" + encode(e.value)
     }
+    else -> "\"" + x.toString().replace("\"", "\\\"") + "\""
+}
 
-    var full = url
-    val method = opts?.get("method")?.toString() ?: "GET"
-    if (opts?.get("query") is Map<*, *>) {
-        val q = opts["query"] as Map<*, *>
-        val qs = q.entries.joinToString("&") { e ->
-            java.net.URLEncoder.encode(e.key.toString(), java.nio.charset.StandardCharsets.UTF_8) +
-            "=" +
-            java.net.URLEncoder.encode(e.value.toString(), java.nio.charset.StandardCharsets.UTF_8)
-        }
-        val sep = if (full.contains("?")) "&" else "?"
-        full += sep + qs
-    }
+var full = url
+val method = opts?.get("method")?.toString() ?: "GET"
+if (opts?.get("query") is Map<*, *>) {
+    val q = opts["query"] as Map<*, *>
+    val qs = q.entries.joinToString("&") { e ->
+    java.net.URLEncoder.encode(e.key.toString(), java.nio.charset.StandardCharsets.UTF_8) +
+    "=" +
+    java.net.URLEncoder.encode(e.value.toString(), java.nio.charset.StandardCharsets.UTF_8)
+}
+val sep = if (full.contains("?")) "&" else "?"
+full += sep + qs
+}
 
-    val builder = java.net.http.HttpRequest.newBuilder(java.net.URI.create(full))
-    val body = opts?.get("body")
-    if (body != null) {
-        builder.method(method, java.net.http.HttpRequest.BodyPublishers.ofString(encode(body)))
-    } else {
-        builder.method(method, java.net.http.HttpRequest.BodyPublishers.noBody())
+val builder = java.net.http.HttpRequest.newBuilder(java.net.URI.create(full))
+val body = opts?.get("body")
+if (body != null) {
+    builder.method(method, java.net.http.HttpRequest.BodyPublishers.ofString(encode(body)))
+} else {
+    builder.method(method, java.net.http.HttpRequest.BodyPublishers.noBody())
+}
+if (opts?.get("headers") is Map<*, *>) {
+    val hs = opts["headers"] as Map<*, *>
+    for ((k, v) in hs) {
+        builder.header(k.toString(), v.toString())
     }
-    if (opts?.get("headers") is Map<*, *>) {
-        val hs = opts["headers"] as Map<*, *>
-        for ((k, v) in hs) {
-            builder.header(k.toString(), v.toString())
-        }
-    }
+}
 
-    val clientBuilder = java.net.http.HttpClient.newBuilder()
-    if (opts?.get("timeout") != null) {
-        val t = opts["timeout"]
-        val secs = when (t) {
-            is Int -> t.toLong()
-            is Long -> t
-            is Double -> t.toLong()
-            is Float -> t.toLong()
-            else -> null
-        }
-        if (secs != null) {
-            clientBuilder.connectTimeout(java.time.Duration.ofMillis((secs * 1000).toLong()))
-        }
+val clientBuilder = java.net.http.HttpClient.newBuilder()
+if (opts?.get("timeout") != null) {
+    val t = opts["timeout"]
+    val secs = when (t) {
+        is Int -> t.toLong()
+        is Long -> t
+        is Double -> t.toLong()
+        is Float -> t.toLong()
+        else -> null
     }
-    val client = clientBuilder.build()
+    if (secs != null) {
+        clientBuilder.connectTimeout(java.time.Duration.ofMillis((secs * 1000).toLong()))
+    }
+}
+val client = clientBuilder.build()
 
-    return try {
-        val resp = client.send(builder.build(), java.net.http.HttpResponse.BodyHandlers.ofString())
-        val text = resp.body()
-        val eng = javax.script.ScriptEngineManager().getEngineByName("javascript")
-        eng.eval("Java.asJSONCompatible($text)")
-    } catch (e: Exception) {
-        throw RuntimeException(e)
-    }
+return try {
+    val resp = client.send(builder.build(), java.net.http.HttpResponse.BodyHandlers.ofString())
+    val text = resp.body()
+    val eng = javax.script.ScriptEngineManager().getEngineByName("javascript")
+    eng.eval("Java.asJSONCompatible($text)")
+} catch (e: Exception) {
+    throw RuntimeException(e)
+}
 }

--- a/tests/compiler/kt/group_by.kt.out
+++ b/tests/compiler/kt/group_by.kt.out
@@ -9,7 +9,7 @@ fun main() {
 class _Group(var key: Any?) {
     val Items = mutableListOf<Any?>()
     val size: Int
-        get() = Items.size
+    get() = Items.size
 }
 fun _group_by(src: List<Any?>, keyfn: (Any?) -> Any?): List<_Group> {
     val groups = mutableMapOf<String, _Group>()
@@ -29,5 +29,5 @@ fun _group_by(src: List<Any?>, keyfn: (Any?) -> Any?): List<_Group> {
             g.Items.add(it)
         }
     }
-        return order.map { groups[it]!! }
+    return order.map { groups[it]!! }
 }

--- a/tests/compiler/kt/join_filter_pag.kt.out
+++ b/tests/compiler/kt/join_filter_pag.kt.out
@@ -6,46 +6,46 @@ fun main() {
     val people = listOf(Person(id = 1, name = "Alice"), Person(id = 2, name = "Bob"), Person(id = 3, name = "Charlie"))
     val purchases = listOf(Purchase(id = 1, personId = 1, total = 200), Purchase(id = 2, personId = 1, total = 50), Purchase(id = 3, personId = 2, total = 150), Purchase(id = 4, personId = 3, total = 100), Purchase(id = 5, personId = 2, total = 250))
     val result = run {
-                val _src = people
-                val _rows = _query(_src, listOf(
-                        _JoinSpec(items = purchases, on = { args ->
-                        val p = args[0]
-                        val o = args[1]
-(p.id == o.personId)
-                        }))
-                ), _QueryOpts(selectFn = { args ->
-                        val p = args[0]
-                        val o = args[1]
-mutableMapOf("person" to p.name, "spent" to o.total)
-                        }, where = { args ->
-                        val p = args[0]
-                        val o = args[1]
+        val _src = people
+        val _rows = _query(_src, listOf(
+        _JoinSpec(items = purchases, on = { args ->
+        val p = args[0]
+        val o = args[1]
+        (p.id == o.personId)
+    }))
+    ), _QueryOpts(selectFn = { args ->
+    val p = args[0]
+    val o = args[1]
+    mutableMapOf("person" to p.name, "spent" to o.total)
+}, where = { args ->
+val p = args[0]
+val o = args[1]
 (o.total > 100)
-                        }, sortKey = { args ->
-                        val p = args[0]
-                        val o = args[1]
+}, sortKey = { args ->
+val p = args[0]
+val o = args[1]
 -o.total
-                        }, skip = 1, take = 2) )
-                _rows
-        }
-    for (r in result) {
-        println(r.person, r.spent)
-    }
+}, skip = 1, take = 2) )
+_rows
+}
+for (r in result) {
+    println(r.person, r.spent)
+}
 }
 
 data class _JoinSpec(
-    val items: List<Any?>,
-    val on: ((Array<Any?>) -> Boolean)? = null,
-    val left: Boolean = false,
-    val right: Boolean = false,
+val items: List<Any?>,
+val on: ((Array<Any?>) -> Boolean)? = null,
+val left: Boolean = false,
+val right: Boolean = false,
 )
 
 data class _QueryOpts(
-    val selectFn: (Array<Any?>) -> Any?,
-    val where: ((Array<Any?>) -> Boolean)? = null,
-    val sortKey: ((Array<Any?>) -> Any?)? = null,
-    val skip: Int = -1,
-    val take: Int = -1,
+val selectFn: (Array<Any?>) -> Any?,
+val where: ((Array<Any?>) -> Boolean)? = null,
+val sortKey: ((Array<Any?>) -> Any?)? = null,
+val skip: Int = -1,
+val take: Int = -1,
 )
 
 fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?> {
@@ -120,34 +120,34 @@ fun _query(src: List<Any?>, joins: List<_JoinSpec>, opts: _QueryOpts): List<Any?
     if (opts.sortKey != null) {
         val pairs = items.map { it to opts.sortKey.invoke(it) }.toMutableList()
         pairs.sortWith { a, b ->
-            val av = a.second
-            val bv = b.second
-            when (av) {
-                is Int -> when (bv) {
-                    is Int -> av.compareTo(bv)
-                    is Double -> av.toDouble().compareTo(bv)
-                    else -> av.toString().compareTo(bv.toString())
-                }
-                is Double -> when (bv) {
-                    is Int -> av.compareTo(bv.toDouble())
-                    is Double -> av.compareTo(bv)
-                    else -> av.toString().compareTo(bv.toString())
-                }
-                is String -> av.compareTo(bv.toString())
+        val av = a.second
+        val bv = b.second
+        when (av) {
+            is Int -> when (bv) {
+                is Int -> av.compareTo(bv)
+                is Double -> av.toDouble().compareTo(bv)
                 else -> av.toString().compareTo(bv.toString())
             }
+            is Double -> when (bv) {
+                is Int -> av.compareTo(bv.toDouble())
+                is Double -> av.compareTo(bv)
+                else -> av.toString().compareTo(bv.toString())
+            }
+            is String -> av.compareTo(bv.toString())
+            else -> av.toString().compareTo(bv.toString())
         }
-        items = pairs.map { it.first }.toMutableList()
     }
-    if (opts.skip >= 0) {
-        items = if (opts.skip < items.size) items.drop(opts.skip).toMutableList() else mutableListOf()
-    }
-    if (opts.take >= 0) {
-        if (opts.take < items.size) items = items.take(opts.take).toMutableList()
-    }
-    val res = mutableListOf<Any?>()
-    for (r in items) {
-        res.add(opts.selectFn.invoke(r))
-    }
-    return res
+    items = pairs.map { it.first }.toMutableList()
+}
+if (opts.skip >= 0) {
+    items = if (opts.skip < items.size) items.drop(opts.skip).toMutableList() else mutableListOf()
+}
+if (opts.take >= 0) {
+    if (opts.take < items.size) items = items.take(opts.take).toMutableList()
+}
+val res = mutableListOf<Any?>()
+for (r in items) {
+    res.add(opts.selectFn.invoke(r))
+}
+return res
 }

--- a/tests/compiler/kt/json_builtin.kt.out
+++ b/tests/compiler/kt/json_builtin.kt.out
@@ -9,9 +9,9 @@ fun _json(v: Any?) {
         is Int, is Double, is Boolean -> x.toString()
         is List<*> -> x.joinToString(prefix = "[", postfix = "]") { encode(it) }
         is Map<*, *> -> x.entries.joinToString(prefix = "{", postfix = "}") { e ->
-            "\"" + e.key.toString().replace("\"", "\\\"") + "\":" + encode(e.value)
-        }
-        else -> \"""${x.toString().replace("\"", "\\\"")}\"""
+        "\"" + e.key.toString().replace("\"", "\\\"") + "\":" + encode(e.value)
     }
-        println(encode(v))
+    else -> \"""${x.toString().replace("\"", "\\\"")}\"""
+}
+println(encode(v))
 }

--- a/tests/compiler/kt/load_jsonl_stdin.kt.out
+++ b/tests/compiler/kt/load_jsonl_stdin.kt.out
@@ -5,10 +5,10 @@ fun main() {
         val _rows = _load(null, mutableMapOf("format" to "jsonl"))
         val _out = mutableListOf<Person>()
         for (r in _rows) {
-                _out.add(_cast<Person>(r))
+            _out.add(_cast<Person>(r))
         }
         _out
-}
+    }
     println(people.size)
 }
 
@@ -25,21 +25,21 @@ inline fun <reified T> _cast(v: Any?): T {
                 val ctor = T::class.primaryConstructor
                 if (ctor != null) {
                     val args = ctor.parameters.associateWith { p ->
-                        val value = v[p.name]
-                        when (p.type.classifier) {
-                            Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
-                            Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
-                            Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
-                            String::class -> value?.toString()
-                            else -> value
-                        }
+                    val value = v[p.name]
+                    when (p.type.classifier) {
+                        Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
+                        Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
+                        Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
+                        String::class -> value?.toString()
+                        else -> value
                     }
-                    return ctor.callBy(args)
                 }
+                return ctor.callBy(args)
             }
-            v as T
         }
+        v as T
     }
+}
 }
 fun _load(path: String?, opts: Map<String, Any>?): List<Map<String, Any>> {
     var format = opts?.get("format") as? String ?: "csv"

--- a/tests/compiler/kt/load_save_json.kt.out
+++ b/tests/compiler/kt/load_save_json.kt.out
@@ -5,16 +5,16 @@ fun main() {
         val _rows = _load(null, mutableMapOf("format" to "json"))
         val _out = mutableListOf<Person>()
         for (r in _rows) {
-                _out.add(_cast<Person>(r))
+            _out.add(_cast<Person>(r))
         }
         _out
-}
+    }
     val adults = run {
-                var res = people
-                res = res.filter { p -> (p.age >= 18) }
-                res = res.map { p -> p }
-                res
-        }
+        var res = people
+        res = res.filter { p -> (p.age >= 18) }
+        res = res.map { p -> p }
+        res
+    }
     _save(adults, null, mutableMapOf("format" to "json"))
 }
 
@@ -31,21 +31,21 @@ inline fun <reified T> _cast(v: Any?): T {
                 val ctor = T::class.primaryConstructor
                 if (ctor != null) {
                     val args = ctor.parameters.associateWith { p ->
-                        val value = v[p.name]
-                        when (p.type.classifier) {
-                            Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
-                            Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
-                            Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
-                            String::class -> value?.toString()
-                            else -> value
-                        }
+                    val value = v[p.name]
+                    when (p.type.classifier) {
+                        Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
+                        Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
+                        Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
+                        String::class -> value?.toString()
+                        else -> value
                     }
-                    return ctor.callBy(args)
                 }
+                return ctor.callBy(args)
             }
-            v as T
         }
+        v as T
     }
+}
 }
 fun _load(path: String?, opts: Map<String, Any>?): List<Map<String, Any>> {
     var format = opts?.get("format") as? String ?: "csv"

--- a/tests/compiler/kt/load_yaml.kt.out
+++ b/tests/compiler/kt/load_yaml.kt.out
@@ -5,16 +5,16 @@ fun main() {
         val _rows = _load("../tests/interpreter/valid/people.yaml", mutableMapOf("format" to "yaml"))
         val _out = mutableListOf<Person>()
         for (r in _rows) {
-                _out.add(_cast<Person>(r))
+            _out.add(_cast<Person>(r))
         }
         _out
-}
+    }
     val adults = run {
-                var res = people
-                res = res.filter { p -> (p.age >= 18) }
-                res = res.map { p -> mutableMapOf("name" to p.name, "email" to p.email) }
-                res
-        }
+        var res = people
+        res = res.filter { p -> (p.age >= 18) }
+        res = res.map { p -> mutableMapOf("name" to p.name, "email" to p.email) }
+        res
+    }
     for (a in adults) {
         println(a.name, a.email)
     }
@@ -33,21 +33,21 @@ inline fun <reified T> _cast(v: Any?): T {
                 val ctor = T::class.primaryConstructor
                 if (ctor != null) {
                     val args = ctor.parameters.associateWith { p ->
-                        val value = v[p.name]
-                        when (p.type.classifier) {
-                            Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
-                            Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
-                            Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
-                            String::class -> value?.toString()
-                            else -> value
-                        }
+                    val value = v[p.name]
+                    when (p.type.classifier) {
+                        Int::class -> when (value) { is Number -> value.toInt(); is String -> value.toInt(); else -> 0 }
+                        Double::class -> when (value) { is Number -> value.toDouble(); is String -> value.toDouble(); else -> 0.0 }
+                        Boolean::class -> when (value) { is Boolean -> value; is String -> value == "true"; else -> false }
+                        String::class -> value?.toString()
+                        else -> value
                     }
-                    return ctor.callBy(args)
                 }
+                return ctor.callBy(args)
             }
-            v as T
         }
+        v as T
     }
+}
 }
 fun _load(path: String?, opts: Map<String, Any>?): List<Map<String, Any>> {
     var format = opts?.get("format") as? String ?: "csv"

--- a/tests/compiler/kt/local_recursion.kt.out
+++ b/tests/compiler/kt/local_recursion.kt.out
@@ -15,17 +15,17 @@ fun fromList(nums: List<Int>) : Tree {
 
 fun inorder(t: Tree) : List<Int> {
     return run {
-                val _t = t
-                when {
-                        _t is Leaf -> listOf()
-                        _t is Node -> {
-                                val l = _t.left
-                                val v = _t.value
-                                val r = _t.right
-                                _concat(_concat(inorder(l), listOf(v)), inorder(r))
-                        }
-                }
+        val _t = t
+        when {
+            _t is Leaf -> listOf()
+            _t is Node -> {
+                val l = _t.left
+                val v = _t.value
+                val r = _t.right
+                _concat(_concat(inorder(l), listOf(v)), inorder(r))
+            }
         }
+    }
 }
 
 fun main() {

--- a/tests/compiler/kt/match_capture.kt.out
+++ b/tests/compiler/kt/match_capture.kt.out
@@ -4,16 +4,16 @@ data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun depth(t: Tree) : Int {
     return run {
-                val _t = t
-                when {
-                        _t is Leaf -> 0
-                        _t is Node -> {
-                                val l = _t.left
-                                val r = _t.right
-                                ((depth(l) + depth(r)) + 1)
-                        }
-                }
+        val _t = t
+        when {
+            _t is Leaf -> 0
+            _t is Node -> {
+                val l = _t.left
+                val r = _t.right
+                ((depth(l) + depth(r)) + 1)
+            }
         }
+    }
 }
 
 fun main() {

--- a/tests/compiler/kt/match_underscore.kt.out
+++ b/tests/compiler/kt/match_underscore.kt.out
@@ -4,15 +4,15 @@ data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun value_of_root(t: Tree) : Int {
     return run {
-                val _t = t
-                when {
-                        _t is Node -> {
-                                val v = _t.value
-                                v
-                        }
-                        else -> 0
-                }
+        val _t = t
+        when {
+            _t is Node -> {
+                val v = _t.value
+                v
+            }
+            else -> 0
         }
+    }
 }
 
 fun main() {

--- a/tests/compiler/kt/type_method.kt.out
+++ b/tests/compiler/kt/type_method.kt.out
@@ -2,7 +2,7 @@ data class Person(val name: String) {
     fun greet() : String {
         return ("hi " + name)
     }
-    
+
 }
 
 fun main() {

--- a/tests/compiler/kt/union_inorder.kt.out
+++ b/tests/compiler/kt/union_inorder.kt.out
@@ -4,17 +4,17 @@ data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun inorder(t: Tree) : List<Int> {
     return run {
-                val _t = t
-                when {
-                        _t is Leaf -> (listOf()) as List<Int>
-                        _t is Node -> {
-                                val l = _t.left
-                                val v = _t.value
-                                val r = _t.right
-                                _concat(_concat(inorder(l), listOf(v)), inorder(r))
-                        }
-                }
+        val _t = t
+        when {
+            _t is Leaf -> (listOf()) as List<Int>
+            _t is Node -> {
+                val l = _t.left
+                val v = _t.value
+                val r = _t.right
+                _concat(_concat(inorder(l), listOf(v)), inorder(r))
+            }
         }
+    }
 }
 
 fun main() {

--- a/tests/compiler/kt/union_match.kt.out
+++ b/tests/compiler/kt/union_match.kt.out
@@ -4,12 +4,12 @@ data class Node(val left: Tree, val value: Int, val right: Tree) : Tree
 
 fun isLeaf(t: Tree) : Boolean {
     return run {
-                val _t = t
-                when {
-                        _t is Leaf -> true
-                        else -> false
-                }
+        val _t = t
+        when {
+            _t is Leaf -> true
+            else -> false
         }
+    }
 }
 
 fun main() {


### PR DESCRIPTION
## Summary
- enhance Kotlin formatter to auto-install ktfmt/ktlint and apply simple indentation fallback
- reformat generated Kotlin outputs for tests and LeetCode examples

## Testing
- `go run /tmp/reformat.kt.go tests/compiler/kt/*.kt.out`
- `go run /tmp/reformat.kt.go $(find examples/leetcode-out/kt -name '*.kt')`
- `gofmt -w compile/x/kt/tools.go`


------
https://chatgpt.com/codex/tasks/task_e_685e417f82d483209440dea8bd54d77b