### PR TITLE
Add JOB query1 example

### DIFF
--- a/tests/dataset/job/TASKS.md
+++ b/tests/dataset/job/TASKS.md
@@ -8,7 +8,7 @@ For every query add two files:
 - `qN.md` documenting the SQL text and describing the expected result
 
 ## Tasks
-- [ ] Add q1.mochi and q1.md
+- [x] Add q1.mochi and q1.md
 - [ ] Add q2.mochi and q2.md
 - [ ] Add q3.mochi and q3.md
 - [ ] Add q4.mochi and q4.md

--- a/tests/dataset/job/q1.md
+++ b/tests/dataset/job/q1.md
@@ -1,0 +1,35 @@
+# JOB Query 1 – Production Companies for Top Movies
+
+The program in [q1.mochi](./q1.mochi) demonstrates a simplified version of the first Join Order Benchmark query. It searches for movies ranked in the IMDB Top 250 whose production company note contains either `(co-production)` or `(presents)` but does not contain `(as Metro-Goldwyn-Mayer Pictures)`. It returns the minimum note, title and year of all qualifying rows.
+
+## SQL
+```sql
+SELECT MIN(mc.note) AS production_note,
+       MIN(t.title) AS movie_title,
+       MIN(t.production_year) AS movie_year
+FROM company_type AS ct,
+     info_type AS it,
+     movie_companies AS mc,
+     movie_info_idx AS mi_idx,
+     title AS t
+WHERE ct.kind = 'production companies'
+  AND it.info = 'top 250 rank'
+  AND mc.note NOT LIKE '%(as Metro-Goldwyn-Mayer Pictures)%'
+  AND (mc.note LIKE '%(co-production)%'
+       OR mc.note LIKE '%(presents)%')
+  AND ct.id = mc.company_type_id
+  AND t.id = mc.movie_id
+  AND t.id = mi_idx.movie_id
+  AND mc.movie_id = mi_idx.movie_id
+  AND it.id = mi_idx.info_type_id;
+```
+
+## Expected Output
+With the sample data only one row satisfies all conditions, so the minimum values correspond to that entry:
+```json
+{
+  "production_note": "ACME (co-production)",
+  "movie_title": "Good Movie",
+  "movie_year": 1995
+}
+```

--- a/tests/dataset/job/q1.mochi
+++ b/tests/dataset/job/q1.mochi
@@ -1,0 +1,52 @@
+let company_type = [
+  { id: 1, kind: "production companies" },
+  { id: 2, kind: "distributors" }
+]
+
+let info_type = [
+  { id: 10, info: "top 250 rank" },
+  { id: 20, info: "bottom 10 rank" }
+]
+
+let title = [
+  { id: 100, title: "Good Movie", production_year: 1995 },
+  { id: 200, title: "Bad Movie", production_year: 2000 }
+]
+
+let movie_companies = [
+  { movie_id: 100, company_type_id: 1, note: "ACME (co-production)" },
+  { movie_id: 200, company_type_id: 1, note: "MGM (as Metro-Goldwyn-Mayer Pictures)" }
+]
+
+let movie_info_idx = [
+  { movie_id: 100, info_type_id: 10 },
+  { movie_id: 200, info_type_id: 20 }
+]
+
+let filtered =
+  from ct in company_type
+  join mc in movie_companies on ct.id == mc.company_type_id
+  join t in title on t.id == mc.movie_id
+  join mi in movie_info_idx on mi.movie_id == t.id
+  join it in info_type on it.id == mi.info_type_id
+  where ct.kind == "production companies" &&
+        it.info == "top 250 rank" &&
+        !mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)") &&
+        (mc.note.contains("(co-production)") || mc.note.contains("(presents)"))
+  select { note: mc.note, title: t.title, year: t.production_year }
+
+let result = {
+  production_note: min(from r in filtered select r.note),
+  movie_title: min(from r in filtered select r.title),
+  movie_year: min(from r in filtered select r.year)
+}
+
+json([result])
+
+test "Q1 returns min note, title and year for top ranked co-production" {
+  expect result == {
+    production_note: "ACME (co-production)",
+    movie_title: "Good Movie",
+    movie_year: 1995
+  }
+}


### PR DESCRIPTION
## Summary
- add Q1 dataset example for Join Order Benchmark
- document the JOB query 1 SQL and expected output
- mark q1 task complete

## Testing
- `make test` *(fails: TestLuaCompiler_TPCHQ1)*

------
https://chatgpt.com/codex/tasks/task_e_685e4986d82c8320963ef371cb129eab