### PR TITLE
Add JOB query 8 example

### DIFF
--- a/tests/dataset/job/TASKS.md
+++ b/tests/dataset/job/TASKS.md
@@ -15,7 +15,7 @@ For every query add two files:
 - [ ] Add q5.mochi and q5.md
 - [ ] Add q6.mochi and q6.md
 - [ ] Add q7.mochi and q7.md
-- [ ] Add q8.mochi and q8.md
+- [x] Add q8.mochi and q8.md
 - [ ] Add q9.mochi and q9.md
 - [ ] Add q10.mochi and q10.md
 - [ ] Add q11.mochi and q11.md

--- a/tests/dataset/job/q8.md
+++ b/tests/dataset/job/q8.md
@@ -1,0 +1,42 @@
+# JOB Query 8 – Japanese Dubbed Movies
+
+[q8.mochi](./q8.mochi) searches a minimal IMDB-like dataset for actresses with
+English voice credits in Japanese releases. The sample data includes one
+matching record.
+
+## SQL
+```sql
+SELECT MIN(an1.name) AS actress_pseudonym,
+       MIN(t.title) AS japanese_movie_dubbed
+FROM aka_name AS an1,
+     cast_info AS ci,
+     company_name AS cn,
+     movie_companies AS mc,
+     name AS n1,
+     role_type AS rt,
+     title AS t
+WHERE ci.note ='(voice: English version)'
+  AND cn.country_code ='[jp]'
+  AND mc.note LIKE '%(Japan)%'
+  AND mc.note NOT LIKE '%(USA)%'
+  AND n1.name LIKE '%Yo%'
+  AND n1.name NOT LIKE '%Yu%'
+  AND rt.role ='actress'
+  AND an1.person_id = n1.id
+  AND n1.id = ci.person_id
+  AND ci.movie_id = t.id
+  AND t.id = mc.movie_id
+  AND mc.company_id = cn.id
+  AND ci.role_id = rt.id
+  AND an1.person_id = ci.person_id
+  AND ci.movie_id = mc.movie_id;
+```
+
+## Expected Output
+Only one row satisfies all filters, so the minimum pseudonym and movie title
+are those values:
+```json
+[
+  { "actress_pseudonym": "Y. S.", "japanese_movie_dubbed": "Dubbed Film" }
+]
+```

--- a/tests/dataset/job/q8.mochi
+++ b/tests/dataset/job/q8.mochi
@@ -1,0 +1,60 @@
+let aka_name = [
+  { person_id: 1, name: "Y. S." }
+]
+
+let cast_info = [
+  { person_id: 1, movie_id: 10, note: "(voice: English version)", role_id: 1000 }
+]
+
+let company_name = [
+  { id: 50, country_code: "[jp]" }
+]
+
+let movie_companies = [
+  { movie_id: 10, company_id: 50, note: "Studio (Japan)" }
+]
+
+let name = [
+  { id: 1, name: "Yoko Ono" },
+  { id: 2, name: "Yuichi" } // filtered out
+]
+
+let role_type = [
+  { id: 1000, role: "actress" }
+]
+
+let title = [
+  { id: 10, title: "Dubbed Film" }
+]
+
+let eligible =
+  from an1 in aka_name
+  join n1 in name on n1.id == an1.person_id
+  join ci in cast_info on ci.person_id == an1.person_id
+  join t in title on t.id == ci.movie_id
+  join mc in movie_companies on mc.movie_id == ci.movie_id
+  join cn in company_name on cn.id == mc.company_id
+  join rt in role_type on rt.id == ci.role_id
+  where ci.note == "(voice: English version)" &&
+        cn.country_code == "[jp]" &&
+        mc.note.contains("(Japan)") &&
+        !(mc.note.contains("(USA)")) &&
+        n1.name.contains("Yo") &&
+        !(n1.name.contains("Yu")) &&
+        rt.role == "actress"
+  select { pseudonym: an1.name, movie_title: t.title }
+
+let result = [
+  {
+    actress_pseudonym: min(from x in eligible select x.pseudonym),
+    japanese_movie_dubbed: min(from x in eligible select x.movie_title)
+  }
+]
+
+print(result)
+
+test "Q8 returns the pseudonym and movie title for Japanese dubbing" {
+  expect result == [
+    { actress_pseudonym: "Y. S.", japanese_movie_dubbed: "Dubbed Film" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Mochi implementation of JOB query 8 and its accompanying docs
- mark q8 as completed in TASKS

## Testing
- `make test` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685e49e1f028832088a69b59b5c86239