### PR TITLE
Add JOB query 9 example

### DIFF
--- a/tests/dataset/job/TASKS.md
+++ b/tests/dataset/job/TASKS.md
@@ -16,7 +16,7 @@ For every query add two files:
 - [ ] Add q6.mochi and q6.md
 - [ ] Add q7.mochi and q7.md
 - [ ] Add q8.mochi and q8.md
-- [ ] Add q9.mochi and q9.md
+ - [x] Add q9.mochi and q9.md
 - [ ] Add q10.mochi and q10.md
 - [ ] Add q11.mochi and q11.md
 - [ ] Add q12.mochi and q12.md

--- a/tests/dataset/job/q9.md
+++ b/tests/dataset/job/q9.md
@@ -1,0 +1,51 @@
+# JOB Query 9
+
+This example implements the JOB query from [`9a.sql`](https://github.com/gregrahn/join-order-benchmark/blob/master/9a.sql). The dataset contains one qualifying voice actress credited in an American production between 2005 and 2015.
+
+## SQL
+```sql
+SELECT MIN(an.name) AS alternative_name,
+       MIN(chn.name) AS character_name,
+       MIN(t.title) AS movie
+FROM aka_name AS an,
+     char_name AS chn,
+     cast_info AS ci,
+     company_name AS cn,
+     movie_companies AS mc,
+     name AS n,
+     role_type AS rt,
+     title AS t
+WHERE ci.note IN ('(voice)',
+                  '(voice: Japanese version)',
+                  '(voice) (uncredited)',
+                  '(voice: English version)')
+  AND cn.country_code ='[us]'
+  AND mc.note IS NOT NULL
+  AND (mc.note LIKE '%(USA)%'
+       OR mc.note LIKE '%(worldwide)%')
+  AND n.gender ='f'
+  AND n.name LIKE '%Ang%'
+  AND rt.role ='actress'
+  AND t.production_year BETWEEN 2005 AND 2015
+  AND ci.movie_id = t.id
+  AND t.id = mc.movie_id
+  AND ci.movie_id = mc.movie_id
+  AND mc.company_id = cn.id
+  AND ci.role_id = rt.id
+  AND n.id = ci.person_id
+  AND chn.id = ci.person_role_id
+  AND an.person_id = n.id
+  AND an.person_id = ci.person_id;
+```
+
+## Expected Output
+Only the actress named *Angelina* with alias *Angela Alias* meets all conditions. She voices the character *Angel* in the movie *My Animated Film*.
+```json
+[
+  {
+    "alternative_name": "Angela Alias",
+    "character_name": "Angel",
+    "movie": "My Animated Film"
+  }
+]
+```

--- a/tests/dataset/job/q9.mochi
+++ b/tests/dataset/job/q9.mochi
@@ -1,0 +1,87 @@
+let aka_name = [
+  { person_id: 1, name: "Angela Alias" },
+  { person_id: 2, name: "Berta" }
+]
+
+let char_name = [
+  { id: 1, name: "Angel" },
+  { id: 2, name: "Villain" }
+]
+
+let cast_info = [
+  { movie_id: 1, person_id: 1, person_role_id: 1, role_id: 1, note: "(voice)" },
+  { movie_id: 2, person_id: 2, person_role_id: 2, role_id: 2, note: "(voice)" }
+]
+
+let company_name = [
+  { id: 10, country_code: "[us]" },
+  { id: 20, country_code: "[uk]" }
+]
+
+let movie_companies = [
+  { movie_id: 1, company_id: 10, note: "Distributor (USA)" },
+  { movie_id: 2, company_id: 20, note: null }
+]
+
+let name = [
+  { id: 1, name: "Angelina", gender: "f" },
+  { id: 2, name: "Bob", gender: "m" }
+]
+
+let role_type = [
+  { id: 1, role: "actress" },
+  { id: 2, role: "actor" }
+]
+
+let title = [
+  { id: 1, title: "My Animated Film", production_year: 2010 },
+  { id: 2, title: "Old Film", production_year: 1990 }
+]
+
+let voice_notes = [
+  "(voice)",
+  "(voice: Japanese version)",
+  "(voice) (uncredited)",
+  "(voice: English version)"
+]
+
+let candidates =
+  from ci in cast_info
+  join t in title on ci.movie_id == t.id
+  join mc in movie_companies on mc.movie_id == ci.movie_id
+  join cn in company_name on cn.id == mc.company_id
+  join rt in role_type on rt.id == ci.role_id
+  join n in name on n.id == ci.person_id
+  join chn in char_name on chn.id == ci.person_role_id
+  join an in aka_name on an.person_id == n.id
+  where ci.note in voice_notes &&
+        cn.country_code == "[us]" &&
+        mc.note != null &&
+        (contains(mc.note, "(USA)") || contains(mc.note, "(worldwide)")) &&
+        n.gender == "f" &&
+        contains(n.name, "Ang") &&
+        rt.role == "actress" &&
+        t.production_year >= 2005 &&
+        t.production_year <= 2015
+  select { an: an, chn: chn, t: t }
+
+let result =
+  from r in candidates
+  group by {} into g
+  select {
+    alternative_name: min(from x in g select x.an.name),
+    character_name: min(from x in g select x.chn.name),
+    movie: min(from x in g select x.t.title)
+  }
+
+print json(result)
+
+test "JOB Q9 finds voice actresses in US movies" {
+  expect result == [
+    {
+      alternative_name: "Angela Alias",
+      character_name: "Angel",
+      movie: "My Animated Film"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add example Mochi program for JOB query 9
- document JOB query 9 SQL
- mark task for q9 as complete

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e49eaa70883209a6d27e255b0071f