### PR TITLE
Add JOB query 11 example

### DIFF
--- a/tests/dataset/job/TASKS.md
+++ b/tests/dataset/job/TASKS.md
@@ -18,7 +18,7 @@ For every query add two files:
 - [ ] Add q8.mochi and q8.md
 - [ ] Add q9.mochi and q9.md
 - [ ] Add q10.mochi and q10.md
-- [ ] Add q11.mochi and q11.md
+ - [x] Add q11.mochi and q11.md
 - [ ] Add q12.mochi and q12.md
 - [ ] Add q13.mochi and q13.md
 - [ ] Add q14.mochi and q14.md

--- a/tests/dataset/job/q11.md
+++ b/tests/dataset/job/q11.md
@@ -1,0 +1,48 @@
+# JOB Query 11 – Non‑Polish Sequel Producers
+
+The program [q11.mochi](./q11.mochi) looks for sequels produced between 1950 and 2000. Companies must have a name containing "Film" or "Warner" and must not be from Poland. Only production companies are considered, the link type must include the word "follow", and the movie must have the keyword "sequel". The `MIN` aggregation over the qualifying rows returns one company name, link type, and title.
+
+## SQL
+```sql
+SELECT MIN(cn.name) AS from_company,
+       MIN(lt.link) AS movie_link_type,
+       MIN(t.title) AS non_polish_sequel_movie
+FROM company_name AS cn,
+     company_type AS ct,
+     keyword AS k,
+     link_type AS lt,
+     movie_companies AS mc,
+     movie_keyword AS mk,
+     movie_link AS ml,
+     title AS t
+WHERE cn.country_code != '[pl]'
+  AND (cn.name LIKE '%Film%'
+       OR cn.name LIKE '%Warner%')
+  AND ct.kind = 'production companies'
+  AND k.keyword = 'sequel'
+  AND lt.link LIKE '%follow%'
+  AND mc.note IS NULL
+  AND t.production_year BETWEEN 1950 AND 2000
+  AND lt.id = ml.link_type_id
+  AND ml.movie_id = t.id
+  AND t.id = mk.movie_id
+  AND mk.keyword_id = k.id
+  AND t.id = mc.movie_id
+  AND mc.company_type_id = ct.id
+  AND mc.company_id = cn.id
+  AND ml.movie_id = mk.movie_id
+  AND ml.movie_id = mc.movie_id
+  AND mk.movie_id = mc.movie_id;
+```
+
+## Expected Output
+One movie satisfies all conditions, so its data forms the aggregated result.
+```json
+[
+  {
+    "from_company": "Big Film Studios",
+    "movie_link_type": "follows",
+    "non_polish_sequel_movie": "Space Adventure II"
+  }
+]
+```

--- a/tests/dataset/job/q11.mochi
+++ b/tests/dataset/job/q11.mochi
@@ -1,0 +1,80 @@
+let company_name = [
+  { id: 1, name: "Big Film Studios", country_code: "[us]" },
+  { id: 2, name: "Polish Film", country_code: "[pl]" }
+]
+
+let company_type = [
+  { id: 1, kind: "production companies" },
+  { id: 2, kind: "other" }
+]
+
+let keyword = [
+  { id: 1, keyword: "sequel" },
+  { id: 2, keyword: "action" }
+]
+
+let link_type = [
+  { id: 1, link: "follows" },
+  { id: 2, link: "related" }
+]
+
+let title = [
+  { id: 10, title: "Space Adventure II", production_year: 1990 },
+  { id: 20, title: "Past Year", production_year: 2010 }
+]
+
+let movie_companies = [
+  { movie_id: 10, company_id: 1, company_type_id: 1, note: null },
+  { movie_id: 20, company_id: 2, company_type_id: 1, note: null }
+]
+
+let movie_keyword = [
+  { movie_id: 10, keyword_id: 1 },
+  { movie_id: 20, keyword_id: 2 }
+]
+
+let movie_link = [
+  { movie_id: 10, link_type_id: 1 }
+]
+
+let rows =
+  from cn in company_name
+  join mc in movie_companies on cn.id == mc.company_id
+  join ct in company_type on ct.id == mc.company_type_id
+  join t in title on t.id == mc.movie_id
+  join mk in movie_keyword on mk.movie_id == t.id
+  join k in keyword on k.id == mk.keyword_id
+  join ml in movie_link on ml.movie_id == t.id
+  join lt in link_type on lt.id == ml.link_type_id
+  where cn.country_code != "[pl]"
+    and (cn.name like "%Film%" or cn.name like "%Warner%")
+    and ct.kind == "production companies"
+    and k.keyword == "sequel"
+    and lt.link like "%follow%"
+    and mc.note == null
+    and t.production_year >= 1950 and t.production_year <= 2000
+  select {
+    from_company: cn.name,
+    movie_link_type: lt.link,
+    non_polish_sequel_movie: t.title
+  }
+
+let result = [
+  {
+    from_company: min(from r in rows select r.from_company),
+    movie_link_type: min(from r in rows select r.movie_link_type),
+    non_polish_sequel_movie: min(from r in rows select r.non_polish_sequel_movie)
+  }
+]
+
+json(result)
+
+test "Q11 finds a non-Polish sequel production" {
+  expect result == [
+    {
+      from_company: "Big Film Studios",
+      movie_link_type: "follows",
+      non_polish_sequel_movie: "Space Adventure II"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement Join Order Benchmark query 11 with sample data and test
- document the SQL text and expected output
- mark q11 task complete

## Testing
- `go test ./... -tags slow -run TestVM_TPCH`

------
https://chatgpt.com/codex/tasks/task_e_685e4a33e12083208504431512c16fd7