### PR TITLE
Add v0.10.4 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
 # 📦 CHANGELOG.md
-## [0.10.4] – 2025-06-27
+## [0.10.4] – 2025-06-27T14:33:48+07:00
 
 ### Added
 
 * Bytecode optimizer now performs constant folding and dead code elimination using liveness analysis
+* Formatter integration across all language backends
+* JOB dataset task list for benchmarking
 
 ### Changed
 
+* Improved VM disassembly and toolchain updates
 * All compiled functions are optimized automatically
+
+### Fixed
+
+* `union_all` parsing bug
+* Append liveness issue
+* Normalized golden outputs
 
 ## [0.10.3] – 2025-06-26T18:37:31+07:00
 

--- a/releases/v0.10.4.md
+++ b/releases/v0.10.4.md
@@ -1,0 +1,23 @@
+# Jun 2025 (v0.10.4)
+
+Released on Fri Jun 27 14:33:48 2025 +0700.
+
+Mochi v0.10.4 introduces an optimizing bytecode pass and unified code formatting across compilers. The runtime gains constant folding, liveness-based dead code elimination and improved disassembly while toolchains ensure formatters are available.
+
+## Runtime
+
+- Bytecode optimizer with constant folding and liveness-based dead code elimination
+- Compiled functions optimized automatically
+- Disassembly improvements for casts, sort operations and existence checks
+- Null index and iterator tolerance with append liveness fixes
+
+## Tooling
+
+- Formatter integration across all language backends
+- Cosmo and tcc toolchain updates
+- JOB dataset task list added
+
+## Fixes
+
+- `union_all` query parsing bug
+- Normalized golden outputs for consistent tests


### PR DESCRIPTION
## Summary
- document new version 0.10.4 in CHANGELOG
- add release notes under `releases/`

## Testing
- `go test ./...` *(fails: `mochi/compile/x/lua`)*

------
https://chatgpt.com/codex/tasks/task_e_685e4a68507c83208bc1a9c05ef20fb0