### PR TITLE
Add JOB query 13 example

### DIFF
--- a/tests/dataset/job/q13.md
+++ b/tests/dataset/job/q13.md
@@ -1,0 +1,45 @@
+# JOB Query 13 – German Movie Rating
+
+[q13.mochi](./q13.mochi) joins the IMDB tables to find the earliest release date, rating and title for German-produced movies. Two movies qualify in the sample data and the minimum values across them are returned.
+
+## SQL
+```sql
+SELECT MIN(mi.info) AS release_date,
+       MIN(miidx.info) AS rating,
+       MIN(t.title) AS german_movie
+FROM company_name AS cn,
+     company_type AS ct,
+     info_type AS it,
+     info_type AS it2,
+     kind_type AS kt,
+     movie_companies AS mc,
+     movie_info AS mi,
+     movie_info_idx AS miidx,
+     title AS t
+WHERE cn.country_code ='[de]'
+  AND ct.kind ='production companies'
+  AND it.info ='rating'
+  AND it2.info ='release dates'
+  AND kt.kind ='movie'
+  AND mi.movie_id = t.id
+  AND it2.id = mi.info_type_id
+  AND kt.id = t.kind_id
+  AND mc.movie_id = t.id
+  AND cn.id = mc.company_id
+  AND ct.id = mc.company_type_id
+  AND miidx.movie_id = t.id
+  AND it.id = miidx.info_type_id
+  AND mi.movie_id = miidx.movie_id
+  AND mi.movie_id = mc.movie_id
+  AND miidx.movie_id = mc.movie_id;
+```
+
+## Expected Output
+The earliest release date among the German movies is `1997-05-10` with rating `6.0` and title `Alpha`.
+```json
+{
+  "release_date": "1997-05-10",
+  "rating": "6.0",
+  "german_movie": "Alpha"
+}
+```

--- a/tests/dataset/job/q13.mochi
+++ b/tests/dataset/job/q13.mochi
@@ -1,0 +1,80 @@
+let company_name = [
+  { id: 1, country_code: "[de]" },
+  { id: 2, country_code: "[us]" }
+]
+
+let company_type = [
+  { id: 1, kind: "production companies" },
+  { id: 2, kind: "distributors" }
+]
+
+let info_type = [
+  { id: 1, info: "rating" },
+  { id: 2, info: "release dates" }
+]
+
+let kind_type = [
+  { id: 1, kind: "movie" },
+  { id: 2, kind: "video" }
+]
+
+let title = [
+  { id: 10, kind_id: 1, title: "Alpha" },
+  { id: 20, kind_id: 1, title: "Beta" },
+  { id: 30, kind_id: 2, title: "Gamma" } // different kind
+]
+
+let movie_companies = [
+  { movie_id: 10, company_id: 1, company_type_id: 1 },
+  { movie_id: 20, company_id: 1, company_type_id: 1 },
+  { movie_id: 30, company_id: 2, company_type_id: 1 } // not German
+]
+
+let movie_info = [
+  { movie_id: 10, info_type_id: 2, info: "1997-05-10" },
+  { movie_id: 20, info_type_id: 2, info: "1998-03-20" },
+  { movie_id: 30, info_type_id: 2, info: "1999-07-30" }
+]
+
+let movie_info_idx = [
+  { movie_id: 10, info_type_id: 1, info: "6.0" },
+  { movie_id: 20, info_type_id: 1, info: "7.5" },
+  { movie_id: 30, info_type_id: 1, info: "5.5" }
+]
+
+let candidates =
+  from cn in company_name
+  join mc in movie_companies on mc.company_id == cn.id
+  join ct in company_type on ct.id == mc.company_type_id
+  join t in title on t.id == mc.movie_id
+  join kt in kind_type on kt.id == t.kind_id
+  join mi in movie_info on mi.movie_id == t.id
+  join it2 in info_type on it2.id == mi.info_type_id
+  join miidx in movie_info_idx on miidx.movie_id == t.id
+  join it in info_type on it.id == miidx.info_type_id
+  where cn.country_code == "[de]" &&
+        ct.kind == "production companies" &&
+        it.info == "rating" &&
+        it2.info == "release dates" &&
+        kt.kind == "movie"
+  select {
+    release_date: mi.info,
+    rating: miidx.info,
+    german_movie: t.title
+  }
+
+let result = {
+  release_date: (from x in candidates sort by x.release_date select x.release_date)[0],
+  rating: (from x in candidates sort by x.rating select x.rating)[0],
+  german_movie: (from x in candidates sort by x.german_movie select x.german_movie)[0]
+}
+
+json(result)
+
+test "Q13 finds earliest German movie info" {
+  expect result == {
+    release_date: "1997-05-10",
+    rating: "6.0",
+    german_movie: "Alpha"
+  }
+}


### PR DESCRIPTION
## Summary
- add Join Order Benchmark q13 example program and docs

## Testing
- `go run ./cmd/mochi test tests/dataset/job/q13.mochi`
- `go test ./... -run TestVM_TPCH -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685e4a7e64d48320aff291ac94735653