### PR TITLE
Add JOB query 16 example

### DIFF
--- a/tests/dataset/job/q16.md
+++ b/tests/dataset/job/q16.md
@@ -1,0 +1,43 @@
+# JOB Query 16 – Character-Named Series Episodes
+
+[q16.mochi](./q16.mochi) implements query 16 from the Join Order Benchmark. The
+program defines a small subset of the IMDB tables. Only one US production has an
+episode number between 50 and 99 whose keyword is `character-name-in-title`, so
+the query returns that actor pseudonym and series title.
+
+## SQL
+```sql
+SELECT MIN(an.name) AS cool_actor_pseudonym,
+       MIN(t.title) AS series_named_after_char
+FROM aka_name AS an,
+     cast_info AS ci,
+     company_name AS cn,
+     keyword AS k,
+     movie_companies AS mc,
+     movie_keyword AS mk,
+     name AS n,
+     title AS t
+WHERE cn.country_code ='[us]'
+  AND k.keyword ='character-name-in-title'
+  AND t.episode_nr >= 50
+  AND t.episode_nr < 100
+  AND an.person_id = n.id
+  AND n.id = ci.person_id
+  AND ci.movie_id = t.id
+  AND t.id = mk.movie_id
+  AND mk.keyword_id = k.id
+  AND t.id = mc.movie_id
+  AND mc.company_id = cn.id
+  AND an.person_id = ci.person_id
+  AND ci.movie_id = mc.movie_id
+  AND ci.movie_id = mk.movie_id
+  AND mc.movie_id = mk.movie_id;
+```
+
+## Expected Output
+With the minimal dataset a single row satisfies all conditions.
+```json
+[
+  { "cool_actor_pseudonym": "Alpha", "series_named_after_char": "Hero Bob" }
+]
+```

--- a/tests/dataset/job/q16.mochi
+++ b/tests/dataset/job/q16.mochi
@@ -1,0 +1,69 @@
+let aka_name = [
+  { person_id: 1, name: "Alpha" },
+  { person_id: 2, name: "Beta" }
+]
+
+let cast_info = [
+  { person_id: 1, movie_id: 101 },
+  { person_id: 2, movie_id: 102 }
+]
+
+let company_name = [
+  { id: 1, country_code: "[us]" },
+  { id: 2, country_code: "[de]" }
+]
+
+let keyword = [
+  { id: 1, keyword: "character-name-in-title" },
+  { id: 2, keyword: "other" }
+]
+
+let movie_companies = [
+  { movie_id: 101, company_id: 1 },
+  { movie_id: 102, company_id: 2 }
+]
+
+let movie_keyword = [
+  { movie_id: 101, keyword_id: 1 },
+  { movie_id: 102, keyword_id: 2 }
+]
+
+let name = [
+  { id: 1 },
+  { id: 2 }
+]
+
+let title = [
+  { id: 101, title: "Hero Bob", episode_nr: 60 },
+  { id: 102, title: "Other Show", episode_nr: 40 }
+]
+
+let rows =
+  from an in aka_name
+  join n in name on n.id == an.person_id
+  join ci in cast_info on ci.person_id == n.id
+  join t in title on t.id == ci.movie_id
+  join mk in movie_keyword on mk.movie_id == t.id
+  join k in keyword on k.id == mk.keyword_id
+  join mc in movie_companies on mc.movie_id == t.id
+  join cn in company_name on cn.id == mc.company_id
+  where cn.country_code == "[us]" &&
+        k.keyword == "character-name-in-title" &&
+        t.episode_nr >= 50 &&
+        t.episode_nr < 100
+  select { pseudonym: an.name, series: t.title }
+
+let result = [
+  {
+    cool_actor_pseudonym: min(from r in rows select r.pseudonym),
+    series_named_after_char: min(from r in rows select r.series)
+  }
+]
+
+json(result)
+
+test "Q16 finds series named after a character between episodes 50 and 99" {
+  expect result == [
+    { cool_actor_pseudonym: "Alpha", series_named_after_char: "Hero Bob" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `q16.mochi` implementing JOB query 16
- document SQL and expected result in `q16.md`

## Testing
- `go run ./cmd/mochi test tests/dataset/job/q16.mochi` *(fails: expect condition failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e4dc035bc832083b33ccb948f5b4f