### PR TITLE
Add JOB query 11

### DIFF
--- a/tests/dataset/job/q11.md
+++ b/tests/dataset/job/q11.md
@@ -1,0 +1,44 @@
+# JOB Query 11 – Non-Polish Sequel Links
+
+[q11.mochi](./q11.mochi) joins several IMDB tables to find sequel movies between 1950 and 2000. The production company must not be from Poland and its name should contain "Film" or "Warner". The movie must have a link type mentioning "follow" and the company entry has a `NULL` note. The query returns the minimal company name, link type and movie title that satisfy all conditions.
+
+## SQL
+```sql
+SELECT MIN(cn.name) AS from_company,
+       MIN(lt.link) AS movie_link_type,
+       MIN(t.title) AS non_polish_sequel_movie
+FROM company_name AS cn,
+     company_type AS ct,
+     keyword AS k,
+     link_type AS lt,
+     movie_companies AS mc,
+     movie_keyword AS mk,
+     movie_link AS ml,
+     title AS t
+WHERE cn.country_code !='[pl]'
+  AND (cn.name LIKE '%Film%'
+       OR cn.name LIKE '%Warner%')
+  AND ct.kind ='production companies'
+  AND k.keyword ='sequel'
+  AND lt.link LIKE '%follow%'
+  AND mc.note IS NULL
+  AND t.production_year BETWEEN 1950 AND 2000
+  AND lt.id = ml.link_type_id
+  AND ml.movie_id = t.id
+  AND t.id = mk.movie_id
+  AND mk.keyword_id = k.id
+  AND t.id = mc.movie_id
+  AND mc.company_type_id = ct.id
+  AND mc.company_id = cn.id
+  AND ml.movie_id = mk.movie_id
+  AND ml.movie_id = mc.movie_id
+  AND mk.movie_id = mc.movie_id;
+```
+
+## Expected Output
+Only the first two movies match all predicates, so the lexicographically smallest values are returned:
+```json
+[
+  {"from_company": "Best Film Co", "movie_link_type": "follow-up", "non_polish_sequel_movie": "Alpha"}
+]
+```

--- a/tests/dataset/job/q11.mochi
+++ b/tests/dataset/job/q11.mochi
@@ -1,0 +1,83 @@
+let company_name = [
+  { id: 1, name: "Best Film Co", country_code: "[us]" },
+  { id: 2, name: "Warner Studios", country_code: "[de]" },
+  { id: 3, name: "Polish Films", country_code: "[pl]" } // excluded
+]
+
+let company_type = [
+  { id: 1, kind: "production companies" },
+  { id: 2, kind: "distributors" }
+]
+
+let keyword = [
+  { id: 1, keyword: "sequel" },
+  { id: 2, keyword: "thriller" }
+]
+
+let link_type = [
+  { id: 1, link: "follow-up" },
+  { id: 2, link: "follows from" },
+  { id: 3, link: "remake" } // ignored
+]
+
+let movie_companies = [
+  { movie_id: 10, company_id: 1, company_type_id: 1, note: null },
+  { movie_id: 20, company_id: 2, company_type_id: 1, note: null },
+  { movie_id: 30, company_id: 3, company_type_id: 1, note: null }
+]
+
+let movie_keyword = [
+  { movie_id: 10, keyword_id: 1 },
+  { movie_id: 20, keyword_id: 1 },
+  { movie_id: 20, keyword_id: 2 },
+  { movie_id: 30, keyword_id: 1 }
+]
+
+let movie_link = [
+  { movie_id: 10, link_type_id: 1 },
+  { movie_id: 20, link_type_id: 2 },
+  { movie_id: 30, link_type_id: 3 }
+]
+
+let title = [
+  { id: 10, production_year: 1960, title: "Alpha" },
+  { id: 20, production_year: 1970, title: "Beta" },
+  { id: 30, production_year: 1985, title: "Polish Movie" }
+]
+
+let matches =
+  from cn in company_name
+  join mc in movie_companies on mc.company_id == cn.id
+  join ct in company_type on ct.id == mc.company_type_id
+  join t in title on t.id == mc.movie_id
+  join mk in movie_keyword on mk.movie_id == t.id
+  join k in keyword on k.id == mk.keyword_id
+  join ml in movie_link on ml.movie_id == t.id
+  join lt in link_type on lt.id == ml.link_type_id
+  where cn.country_code != "[pl]" &&
+        (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+        ct.kind == "production companies" &&
+        k.keyword == "sequel" &&
+        lt.link.contains("follow") &&
+        mc.note == null &&
+        t.production_year >= 1950 && t.production_year <= 2000 &&
+        ml.movie_id == mk.movie_id &&
+        ml.movie_id == mc.movie_id &&
+        mk.movie_id == mc.movie_id
+  select { company: cn.name, link: lt.link, title: t.title }
+
+let result = [
+  {
+    from_company: min(from x in matches select x.company),
+    movie_link_type: min(from x in matches select x.link),
+    non_polish_sequel_movie: min(from x in matches select x.title)
+  }
+]
+
+json(result)
+
+test "Q11 returns min company, link type and title" {
+  expect result == [
+    { from_company: "Best Film Co", movie_link_type: "follow-up", non_polish_sequel_movie: "Alpha" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add query 11 example for the Join Order Benchmark
- document SQL text and expected output

## Testing
- `make test` *(fails: mochi/tools/libmochi/python/runner build failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e50a31ff08320bc6fa8173e255889