### PR TITLE
Improve C++ map inference

### DIFF
--- a/compile/x/cpp/compiler.go
+++ b/compile/x/cpp/compiler.go
@@ -371,6 +371,8 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 				c.helpers["cast"] = true
 				expr = fmt.Sprintf("_cast<%s>(%s)", st.Name, expr)
 			}
+		} else if t := InferCppExprType(s.Let.Value, c.env, c.getVar); t != "" {
+			typ = t
 		}
 		if expr == "" {
 			c.writeln(fmt.Sprintf("%s %s;", typ, s.Let.Name))
@@ -415,6 +417,8 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 				c.helpers["cast"] = true
 				expr = fmt.Sprintf("_cast<%s>(%s)", st.Name, expr)
 			}
+		} else if t := InferCppExprType(s.Var.Value, c.env, c.getVar); t != "" {
+			typ = t
 		}
 		if expr == "" {
 			c.writeln(fmt.Sprintf("%s %s;", typ, s.Var.Name))


### PR DESCRIPTION
## Summary
- update map literal type inference so heterogeneous fields produce `unordered_map<string, any>`
- infer variable types from assigned expressions
- improve field access inference for maps

## Testing
- `go test ./compile/x/cpp -run TestCPPCompiler_TPCH -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_685e69ce100c8320b79007c85f37924a