### PR TITLE
Add Ruby JOB dataset test

### DIFF
--- a/compile/x/rb/compiler.go
+++ b/compile/x/rb/compiler.go
@@ -1242,7 +1242,10 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				}
 				args[i] = v
 			}
-			if builtin, ok, err := c.compileBuiltinCall(expr, args, op.Call.Args); ok {
+			if strings.HasSuffix(expr, ".contains") && len(args) == 1 {
+				expr = strings.TrimSuffix(expr, ".contains")
+				expr = fmt.Sprintf("(%s.include?(%s))", expr, args[0])
+			} else if builtin, ok, err := c.compileBuiltinCall(expr, args, op.Call.Args); ok {
 				if err != nil {
 					return "", err
 				}
@@ -1613,6 +1616,18 @@ func (c *Compiler) compileBuiltinCall(name string, args []string, origArgs []*pa
 		}
 		c.use("_sum")
 		return fmt.Sprintf("_sum(%s)", args[0]), true, nil
+	case "min":
+		if len(args) != 1 {
+			return "", true, fmt.Errorf("min expects 1 arg")
+		}
+		c.use("_min")
+		return fmt.Sprintf("_min(%s)", args[0]), true, nil
+	case "max":
+		if len(args) != 1 {
+			return "", true, fmt.Errorf("max expects 1 arg")
+		}
+		c.use("_max")
+		return fmt.Sprintf("_max(%s)", args[0]), true, nil
 	case "json":
 		if len(args) != 1 {
 			return "", true, fmt.Errorf("json expects 1 arg")

--- a/compile/x/rb/compiler_test.go
+++ b/compile/x/rb/compiler_test.go
@@ -254,6 +254,55 @@ func TestRBCompiler_TPCHQ1(t *testing.T) {
 	}
 }
 
+func TestRBCompiler_JOBQ1(t *testing.T) {
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := rbcode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	codeWantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "rb", "q1.rb.out")
+	wantCode, err := os.ReadFile(codeWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q1.rb.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", got, bytes.TrimSpace(wantCode))
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.rb")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("ruby", file)
+	cmd.Dir = findRepoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ruby run error: %v\n%s", err, out)
+	}
+	gotOut := bytes.TrimSpace(out)
+	outWantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "rb", "q1.out")
+	wantOut, err := os.ReadFile(outWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+		t.Errorf("output mismatch for q1.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", gotOut, bytes.TrimSpace(wantOut))
+	}
+}
+
 func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/compile/x/rb/runtime.go
+++ b/compile/x/rb/runtime.go
@@ -192,6 +192,32 @@ end`
   s
 end`
 
+	helperMin = `def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end`
+
+	helperMax = `def _max(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.max
+end`
+
 	helperEval = `def _eval(code)
   eval(code)
 end`
@@ -382,6 +408,8 @@ var helperMap = map[string]string{
 	"_genEmbed":    helperGenEmbed,
 	"_genStruct":   helperGenStruct,
 	"_json":        helperJSON,
+	"_min":         helperMin,
+	"_max":         helperMax,
 	"_sum":         helperSum,
 	"_eval":        helperEval,
 	"_group":       helperGroup,

--- a/tests/dataset/job/compiler/rb/q1.out
+++ b/tests/dataset/job/compiler/rb/q1.out
@@ -1,0 +1,1 @@
+[{"production_note":"ACME (co-production)","movie_title":"Good Movie","movie_year":1995}]

--- a/tests/dataset/job/compiler/rb/q1.rb.out
+++ b/tests/dataset/job/compiler/rb/q1.rb.out
@@ -1,0 +1,59 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+company_type = [OpenStruct.new(id: 1, kind: "production companies"), OpenStruct.new(id: 2, kind: "distributors")]
+info_type = [OpenStruct.new(id: 10, info: "top 250 rank"), OpenStruct.new(id: 20, info: "bottom 10 rank")]
+title = [OpenStruct.new(id: 100, title: "Good Movie", production_year: 1995), OpenStruct.new(id: 200, title: "Bad Movie", production_year: 2000)]
+movie_companies = [OpenStruct.new(movie_id: 100, company_type_id: 1, note: "ACME (co-production)"), OpenStruct.new(movie_id: 200, company_type_id: 1, note: "MGM (as Metro-Goldwyn-Mayer Pictures)")]
+movie_info_idx = [OpenStruct.new(movie_id: 100, info_type_id: 10), OpenStruct.new(movie_id: 200, info_type_id: 20)]
+filtered = (begin
+  _res = []
+  for ct in company_type
+    for mc in movie_companies
+      if ct.id == mc.company_type_id
+        for t in title
+          if t.id == mc.movie_id
+            for mi in movie_info_idx
+              if mi.movie_id == t.id
+                for it in info_type
+                  if it.id == mi.info_type_id
+                    if (ct.kind == "production companies") && (it.info == "top 250 rank") && !mc.note.include?("(as Metro-Goldwyn-Mayer Pictures)") && (mc.note.include?("(co-production)") || mc.note.include?("(presents)"))
+                      _res << OpenStruct.new(note: mc.note, title: t.title, year: t.production_year)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = OpenStruct.new(production_note: _min(filtered.map { |r| r.note }), movie_title: _min(filtered.map { |r| r.title }), movie_year: _min(filtered.map { |r| r.year }))
+_json([result])
+raise "expect failed" unless result == OpenStruct.new(production_note: "ACME (co-production)", movie_title: "Good Movie", movie_year: 1995)


### PR DESCRIPTION
## Summary
- support `contains` calls in Ruby compiler
- implement `min`/`max` helpers for Ruby runtime
- add golden compilation test for JOB q1
- store generated Ruby and expected output

## Testing
- `go test -tags slow ./compile/x/rb -run JOBQ1 -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e69f603c48320bce17c543cc82c17