### PR TITLE
Add Zig JOB query support

### DIFF
--- a/compile/x/testutil/testutil.go
+++ b/compile/x/testutil/testutil.go
@@ -54,3 +54,28 @@ func CompileTPCH(
 		t.Skipf("TPCH %s unsupported: %v", query, err)
 	}
 }
+
+// CompileJOB parses and type checks the given JOB query and runs the
+// provided compile function. The query should be specified without the
+// file extension, e.g. "q1". The compile function may return generated code
+// which is ignored. If compilation fails, the test is skipped.
+func CompileJOB(
+	t *testing.T,
+	query string,
+	compileFn func(env *types.Env, prog *parser.Program) ([]byte, error),
+) {
+	t.Helper()
+	root := FindRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", query+".mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	if _, err := compileFn(env, prog); err != nil {
+		t.Skipf("JOB %s unsupported: %v", query, err)
+	}
+}

--- a/compile/x/zig/builtins.go
+++ b/compile/x/zig/builtins.go
@@ -43,6 +43,39 @@ func (c *Compiler) writeBuiltins() {
 		c.writeln("}")
 		c.writeln("")
 	}
+	if c.needsMinInt {
+		c.writeln("fn _min_int(v: []const i32) i32 {")
+		c.indent++
+		c.writeln("if (v.len == 0) return 0;")
+		c.writeln("var m: i32 = v[0];")
+		c.writeln("for (v[1..]) |it| { if (it < m) m = it; }")
+		c.writeln("return m;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("")
+	}
+	if c.needsMinFloat {
+		c.writeln("fn _min_float(v: []const f64) f64 {")
+		c.indent++
+		c.writeln("if (v.len == 0) return 0.0;")
+		c.writeln("var m: f64 = v[0];")
+		c.writeln("for (v[1..]) |it| { if (it < m) m = it; }")
+		c.writeln("return m;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("")
+	}
+	if c.needsMinString {
+		c.writeln("fn _min_string(v: []const []const u8) []const u8 {")
+		c.indent++
+		c.writeln("if (v.len == 0) return \"\";")
+		c.writeln("var m: []const u8 = v[0];")
+		c.writeln("for (v[1..]) |it| { if (std.mem.lessThan(u8, it, m)) m = it; }")
+		c.writeln("return m;")
+		c.indent--
+		c.writeln("}")
+		c.writeln("")
+	}
 	if c.needsInListInt {
 		c.writeln("fn _contains_list_int(v: []const i32, item: i32) bool {")
 		c.indent++

--- a/compile/x/zig/job_golden_test.go
+++ b/compile/x/zig/job_golden_test.go
@@ -1,0 +1,43 @@
+//go:build slow
+
+package zigcode_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"mochi/compile/x/testutil"
+	zigcode "mochi/compile/x/zig"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestZigCompiler_JOBQ1_Golden(t *testing.T) {
+	if _, err := zigcode.EnsureZig(); err != nil {
+		t.Skipf("zig not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := zigcode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	wantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "zig", "q1.zig.out")
+	want, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+		t.Errorf("generated code mismatch for q1.zig.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(want))
+	}
+}

--- a/compile/x/zig/job_test.go
+++ b/compile/x/zig/job_test.go
@@ -1,0 +1,21 @@
+//go:build slow
+
+package zigcode_test
+
+import (
+	"testing"
+
+	"mochi/compile/x/testutil"
+	zigcode "mochi/compile/x/zig"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestZigCompiler_JOB(t *testing.T) {
+	if _, err := zigcode.EnsureZig(); err != nil {
+		t.Skipf("zig not installed: %v", err)
+	}
+	testutil.CompileJOB(t, "q1", func(env *types.Env, prog *parser.Program) ([]byte, error) {
+		return zigcode.New(env).Compile(prog)
+	})
+}

--- a/tests/dataset/job/compiler/zig/q1.zig.out
+++ b/tests/dataset/job/compiler/zig/q1.zig.out
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production() void {
+    expect((result == blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(production_note, "ACME (co-production)") catch unreachable; m.put(movie_title, "Good Movie") catch unreachable; m.put(movie_year, @as(i32,@intCast(1995))) catch unreachable; break :blk m; }));
+}
+
+pub fn main() void {
+    const company_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(kind, "production companies") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(kind, "distributors") catch unreachable; break :blk m; }};
+    const info_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(10))) catch unreachable; m.put(info, "top 250 rank") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(20))) catch unreachable; m.put(info, "bottom 10 rank") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(100))) catch unreachable; m.put(title, "Good Movie") catch unreachable; m.put(production_year, @as(i32,@intCast(1995))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(200))) catch unreachable; m.put(title, "Bad Movie") catch unreachable; m.put(production_year, @as(i32,@intCast(2000))) catch unreachable; break :blk m; }};
+    const movie_companies: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(company_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "ACME (co-production)") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(company_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "MGM (as Metro-Goldwyn-Mayer Pictures)") catch unreachable; break :blk m; }};
+    const movie_info_idx: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(info_type_id, @as(i32,@intCast(10))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(info_type_id, @as(i32,@intCast(20))) catch unreachable; break :blk m; }};
+    const filtered: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (company_type) |ct| { for (movie_companies) |mc| { if !((ct.id == mc.company_type_id)) continue; for (title) |t| { if !((t.id == mc.movie_id)) continue; for (movie_info_idx) |mi| { if !((mi.movie_id == t.id)) continue; for (info_type) |it| { if !((it.id == mi.info_type_id)) continue; if !(((std.mem.eql(u8, (std.mem.eql(u8, ct.kind, "production companies") and it.info), "top 250 rank") and (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)"))) and ((mc.note.contains("(co-production)") or mc.note.contains("(presents)"))))) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(note, mc.note) catch unreachable; m.put(title, t.title) catch unreachable; m.put(year, t.production_year) catch unreachable; break :blk m; }) catch unreachable; } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: std.AutoHashMap([]const u8, i32) = blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(production_note, _min_int(blk: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (filtered) |r| { _tmp2.append(r.note) catch unreachable; } var _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk _tmp3; })) catch unreachable; m.put(movie_title, _min_int(blk: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (filtered) |r| { _tmp4.append(r.title) catch unreachable; } var _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk _tmp5; })) catch unreachable; m.put(movie_year, _min_int(blk: { var _tmp6 = std.ArrayList(i32).init(std.heap.page_allocator); for (filtered) |r| { _tmp6.append(r.year) catch unreachable; } var _tmp7 = _tmp6.toOwnedSlice() catch unreachable; break :blk _tmp7; })) catch unreachable; break :blk m; };
+    _json(&[_]std.AutoHashMap([]const u8, i32){result});
+    test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production();
+}


### PR DESCRIPTION
## Summary
- add CompileJOB helper for dataset/job tests
- implement min builtins and join support in Zig backend
- compile dataset/job q1 with Zig in new tests
- store generated Zig code as golden output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e6a0800008320b99e849c14f4e895