### PR TITLE
Add Lua compiler support for JOB Q1

### DIFF
--- a/compile/x/lua/job_q1_test.go
+++ b/compile/x/lua/job_q1_test.go
@@ -1,0 +1,74 @@
+package luacode_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	luacode "mochi/compile/x/lua"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestLuaCompiler_JOBQ1(t *testing.T) {
+	if err := luacode.EnsureLua(); err != nil {
+		t.Skipf("lua not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := luacode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	wantCode, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "lua", "q1.lua.out"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q1.lua.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(wantCode))
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.lua")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("lua", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("lua run error: %v\n%s", err, out)
+	}
+	gotLines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+	if len(gotLines) == 0 {
+		t.Fatalf("no output")
+	}
+	gotJSON := gotLines[0]
+	wantOut, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "lua", "q1.out"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	wantLines := bytes.Split(bytes.TrimSpace(wantOut), []byte("\n"))
+	wantJSON := wantLines[0]
+	var gotVal, wantVal any
+	if err := json.Unmarshal(gotJSON, &gotVal); err != nil {
+		t.Fatalf("parse got json: %v", err)
+	}
+	if err := json.Unmarshal(wantJSON, &wantVal); err != nil {
+		t.Fatalf("parse want json: %v", err)
+	}
+	if !reflect.DeepEqual(gotVal, wantVal) {
+		t.Errorf("output mismatch for q1.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", gotJSON, wantJSON)
+	}
+}

--- a/compile/x/lua/runtime.go
+++ b/compile/x/lua/runtime.go
@@ -162,6 +162,33 @@ const (
 		"    return sum\n" +
 		"end\n"
 
+	helperMin = "function __min(v)\n" +
+		"    local items\n" +
+		"    if type(v) == 'table' and v.items ~= nil then\n" +
+		"        items = v.items\n" +
+		"    elseif type(v) == 'table' then\n" +
+		"        items = v\n" +
+		"    else\n" +
+		"        error('min() expects list or group')\n" +
+		"    end\n" +
+		"    if #items == 0 then return 0 end\n" +
+		"    local m = items[1]\n" +
+		"    if type(m) == 'string' then\n" +
+		"        for i=2,#items do\n" +
+		"            local it = items[i]\n" +
+		"            if type(it) == 'string' and it < m then m = it end\n" +
+		"        end\n" +
+		"        return m\n" +
+		"    else\n" +
+		"        m = tonumber(m)\n" +
+		"        for i=2,#items do\n" +
+		"            local n = tonumber(items[i])\n" +
+		"            if n < m then m = n end\n" +
+		"        end\n" +
+		"        return m\n" +
+		"    end\n" +
+		"end\n"
+
 	helperAppend = "function __append(lst, v)\n" +
 		"    local out = {}\n" +
 		"    if lst then for i = 1, #lst do out[#out+1] = lst[i] end end\n" +
@@ -680,6 +707,7 @@ var helperMap = map[string]string{
 	"count":       helperCount,
 	"avg":         helperAvg,
 	"sum":         helperSum,
+	"min":         helperMin,
 	"append":      helperAppend,
 	"reduce":      helperReduce,
 	"json":        helperJson,

--- a/tests/dataset/job/compiler/lua/q1.lua.out
+++ b/tests/dataset/job/compiler/lua/q1.lua.out
@@ -1,0 +1,315 @@
+function __contains(container, item)
+    if type(container) == 'table' then
+        if container[1] ~= nil or #container > 0 then
+            for _, v in ipairs(container) do
+                if v == item then return true end
+            end
+            return false
+        else
+            return container[item] ~= nil
+        end
+    elseif type(container) == 'string' then
+        return string.find(container, item, 1, true) ~= nil
+    else
+        return false
+    end
+end
+function __eq(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == 'number' then return math.abs(a-b) < 1e-9 end
+    if type(a) ~= 'table' then return a == b end
+    if (a[1] ~= nil or #a > 0) and (b[1] ~= nil or #b > 0) then
+        if #a ~= #b then return false end
+        for i = 1, #a do if not __eq(a[i], b[i]) then return false end end
+        return true
+    end
+    for k, v in pairs(a) do if not __eq(v, b[k]) then return false end end
+    for k, _ in pairs(b) do if a[k] == nil then return false end end
+    return true
+end
+function __json(v)
+    local function sort(x)
+        if type(x) ~= 'table' then return x end
+        if x[1] ~= nil or #x > 0 then
+            local out = {}
+            for i=1,#x do out[i] = sort(x[i]) end
+            return out
+        end
+        local keys = {}
+        for k in pairs(x) do keys[#keys+1] = k end
+        table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+        local out = {}
+        for _,k in ipairs(keys) do out[k] = sort(x[k]) end
+        return out
+    end
+    local ok, json = pcall(require, 'json')
+    if not ok then ok, json = pcall(require, 'cjson') end
+    if ok then
+        print(json.encode(sort(v)))
+        return
+    end
+    local function enc(x)
+        local t = type(x)
+        if t == 'nil' then
+            return 'null'
+        elseif t == 'boolean' or t == 'number' then
+            return tostring(x)
+        elseif t == 'string' then
+            return string.format('%q', x)
+        elseif t == 'table' then
+            if x[1] ~= nil or #x > 0 then
+                local parts = {}
+                for i=1,#x do parts[#parts+1] = enc(x[i]) end
+                return '['..table.concat(parts, ',')..']'
+            else
+                local keys = {}
+                for k in pairs(x) do keys[#keys+1] = k end
+                table.sort(keys, function(a,b) return tostring(a)<tostring(b) end)
+                local parts = {}
+                for _,k in ipairs(keys) do parts[#parts+1] = enc(k)..':'..enc(x[k]) end
+                return '{'..table.concat(parts, ',')..'}'
+            end
+        else
+            return 'null'
+        end
+    end
+    print(enc(sort(v)))
+end
+function __min(v)
+    local items
+    if type(v) == 'table' and v.items ~= nil then
+        items = v.items
+    elseif type(v) == 'table' then
+        items = v
+    else
+        error('min() expects list or group')
+    end
+    if #items == 0 then return 0 end
+    local m = items[1]
+    if type(m) == 'string' then
+        for i=2,#items do
+            local it = items[i]
+            if type(it) == 'string' and it < m then m = it end
+        end
+        return m
+    else
+        m = tonumber(m)
+        for i=2,#items do
+            local n = tonumber(items[i])
+            if n < m then m = n end
+        end
+        return m
+    end
+end
+function __query(src, joins, opts)
+    local whereFn = opts.where
+    local items = {}
+    if #joins == 0 and whereFn then
+        for _, v in ipairs(src) do if whereFn(v) then items[#items+1] = {v} end end
+    else
+        for _, v in ipairs(src) do items[#items+1] = {v} end
+    end
+    for ji, j in ipairs(joins) do
+        local joined = {}
+        local jitems = j.items or {}
+        if j.right and j.left then
+            local matched = {}
+            for _, left in ipairs(items) do
+                local m = false
+                for ri, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true; matched[ri] = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+            for ri, right in ipairs(jitems) do
+                if not matched[ri] then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        elseif j.right then
+            for _, right in ipairs(jitems) do
+                local m = false
+                for _, left in ipairs(items) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if not m then
+                    local undef = {}
+                    if #items > 0 then for _=1,#items[1] do undef[#undef+1]=nil end end
+                    local row = {table.unpack(undef)}
+                    row[#row+1] = right
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        else
+            for _, left in ipairs(items) do
+                local m = false
+                for _, right in ipairs(jitems) do
+                    local keep = true
+                    if j.on then
+                        local args = {table.unpack(left)}
+                        args[#args+1] = right
+                        keep = j.on(table.unpack(args))
+                    end
+                    if keep then
+                        m = true
+                        local row = {table.unpack(left)}
+                        row[#row+1] = right
+                        if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                        else
+                            joined[#joined+1] = row
+                        end
+                    end
+                end
+                if j.left and not m then
+                    local row = {table.unpack(left)}
+                    row[#row+1] = nil
+                    if ji == #joins and whereFn and not whereFn(table.unpack(row)) then
+                    else
+                        joined[#joined+1] = row
+                    end
+                end
+            end
+        end
+        items = joined
+    end
+    if opts.sortKey then
+        local pairs = {}
+        for _, it in ipairs(items) do pairs[#pairs+1] = {item=it, key=opts.sortKey(table.unpack(it))} end
+        table.sort(pairs, function(a,b)
+            local ak, bk = a.key, b.key
+            if type(ak)=='number' and type(bk)=='number' then return ak < bk end
+            if type(ak)=='string' and type(bk)=='string' then return ak < bk end
+            return tostring(ak) < tostring(bk)
+        end)
+        items = {}
+        for i,p in ipairs(pairs) do items[i] = p.item end
+    end
+    if opts.skip ~= nil then
+        local n = opts.skip
+        if n < #items then
+            for i=1,n do table.remove(items,1) end
+        else
+            items = {}
+        end
+    end
+    if opts.take ~= nil then
+        local n = opts.take
+        if n < #items then
+            for i=#items, n+1, -1 do table.remove(items) end
+        end
+    end
+    local res = {}
+    for _, r in ipairs(items) do res[#res+1] = opts.selectFn(table.unpack(r)) end
+    return res
+end
+function __run_tests(tests)
+    local function format_duration(d)
+        if d < 1e-6 then return string.format('%dns', math.floor(d*1e9)) end
+        if d < 1e-3 then return string.format('%.1fµs', d*1e6) end
+        if d < 1 then return string.format('%.1fms', d*1e3) end
+        return string.format('%.2fs', d)
+    end
+    local failures = 0
+    for _, t in ipairs(tests) do
+        io.write('   test ' .. t.name .. ' ...')
+        local start = os.clock()
+        local ok, err = pcall(t.fn)
+        local dur = os.clock() - start
+        if ok then
+            io.write(' ok (' .. format_duration(dur) .. ')\n')
+        else
+            io.write(' fail ' .. tostring(err) .. ' (' .. format_duration(dur) .. ')\n')
+            failures = failures + 1
+        end
+    end
+    if failures > 0 then
+        io.write('\n[FAIL] ' .. failures .. ' test(s) failed.\n')
+    end
+end
+function test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production()
+    if not (__eq(result, {["production_note"]="ACME (co-production)", ["movie_title"]="Good Movie", ["movie_year"]=1995})) then error('expect failed') end
+end
+
+company_type = {{["id"]=1, ["kind"]="production companies"}, {["id"]=2, ["kind"]="distributors"}}
+info_type = {{["id"]=10, ["info"]="top 250 rank"}, {["id"]=20, ["info"]="bottom 10 rank"}}
+title = {{["id"]=100, ["title"]="Good Movie", ["production_year"]=1995}, {["id"]=200, ["title"]="Bad Movie", ["production_year"]=2000}}
+movie_companies = {{["movie_id"]=100, ["company_type_id"]=1, ["note"]="ACME (co-production)"}, {["movie_id"]=200, ["company_type_id"]=1, ["note"]="MGM (as Metro-Goldwyn-Mayer Pictures)"}}
+movie_info_idx = {{["movie_id"]=100, ["info_type_id"]=10}, {["movie_id"]=200, ["info_type_id"]=20}}
+filtered = (function()
+    local _src = company_type
+    return __query(_src, {
+        { items = movie_companies, on = function(ct, mc) return __eq(ct.id, mc.company_type_id) end },
+        { items = title, on = function(ct, mc, t) return __eq(t.id, mc.movie_id) end },
+        { items = movie_info_idx, on = function(ct, mc, t, mi) return __eq(mi.movie_id, t.id) end },
+        { items = info_type, on = function(ct, mc, t, mi, it) return __eq(it.id, mi.info_type_id) end }
+    }, { selectFn = function(ct, mc, t, mi, it) return {["note"]=mc.note, ["title"]=t.title, ["year"]=t.production_year} end, where = function(ct, mc, t, mi, it) return ((((__eq(ct.kind, "production companies") and __eq(it.info, "top 250 rank")) and (not __contains(mc.note, "(as Metro-Goldwyn-Mayer Pictures)"))) and ((__contains(mc.note, "(co-production)") or __contains(mc.note, "(presents)"))))) end })
+end)()
+result = {["production_note"]=__min((function()
+    local _res = {}
+    for _, r in ipairs(filtered) do
+        _res[#_res+1] = r.note
+    end
+    return _res
+end)()), ["movie_title"]=__min((function()
+    local _res = {}
+    for _, r in ipairs(filtered) do
+        _res[#_res+1] = r.title
+    end
+    return _res
+end)()), ["movie_year"]=__min((function()
+    local _res = {}
+    for _, r in ipairs(filtered) do
+        _res[#_res+1] = r.year
+    end
+    return _res
+end)())}
+__json({result})
+local __tests = {
+    {name="Q1 returns min note, title and year for top ranked co-production", fn=test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production},
+}
+__run_tests(__tests)

--- a/tests/dataset/job/compiler/lua/q1.out
+++ b/tests/dataset/job/compiler/lua/q1.out
@@ -1,0 +1,2 @@
+[{"movie_title":"Good Movie","movie_year":1995,"production_note":"ACME (co-production)"}]
+   test Q1 returns min note, title and year for top ranked co-production ... ok (4.0µs)


### PR DESCRIPTION
## Summary
- support `min` aggregations in Lua backend
- handle `.contains()` string methods in Lua code generation
- add Lua golden tests for JOB dataset query 1

## Testing
- `go test ./compile/x/lua -run TestLuaCompiler_JOBQ1 -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e69eabd4c8320aedaeefc5ae5deca