### PR TITLE
Add starts_with support to VM and generate JOB IR

### DIFF
--- a/tests/dataset/job/out/q10.ir.out
+++ b/tests/dataset/job/out/q10.ir.out
@@ -1,0 +1,291 @@
+func main (regs=175)
+  // let char_name = [
+  Const        r0, [{"id": 1, "name": "Ivan"}, {"id": 2, "name": "Alex"}]
+  Move         r1, r0
+  // let cast_info = [
+  Const        r2, [{"movie_id": 10, "note": "Soldier (voice) (uncredited)", "person_role_id": 1, "role_id": 1}, {"movie_id": 11, "note": "(voice)", "person_role_id": 2, "role_id": 1}]
+  Move         r3, r2
+  // let company_name = [
+  Const        r4, [{"country_code": "[ru]", "id": 1}, {"country_code": "[us]", "id": 2}]
+  Move         r5, r4
+  // let company_type = [
+  Const        r6, [{"id": 1}, {"id": 2}]
+  Move         r7, r6
+  // let movie_companies = [
+  Const        r8, [{"company_id": 1, "company_type_id": 1, "movie_id": 10}, {"company_id": 2, "company_type_id": 1, "movie_id": 11}]
+  Move         r9, r8
+  // let role_type = [
+  Const        r10, [{"id": 1, "role": "actor"}, {"id": 2, "role": "director"}]
+  Move         r11, r10
+  // let title = [
+  Const        r12, [{"id": 10, "production_year": 2006, "title": "Vodka Dreams"}, {"id": 11, "production_year": 2004, "title": "Other Film"}]
+  Move         r13, r12
+  // from chn in char_name
+  Const        r14, []
+  IterPrep     r15, r1
+  Len          r16, r15
+  Const        r17, 0
+L18:
+  Less         r18, r17, r16
+  JumpIfFalse  r18, L0
+  Index        r19, r15, r17
+  Move         r20, r19
+  // join ci in cast_info on chn.id == ci.person_role_id
+  IterPrep     r21, r3
+  Len          r22, r21
+  Const        r23, 0
+L17:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L1
+  Index        r25, r21, r23
+  Move         r26, r25
+  Const        r27, "id"
+  Index        r28, r20, r27
+  Const        r29, "person_role_id"
+  Index        r30, r26, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L2
+  // join rt in role_type on rt.id == ci.role_id
+  IterPrep     r32, r11
+  Len          r33, r32
+  Const        r34, 0
+L16:
+  Less         r35, r34, r33
+  JumpIfFalse  r35, L2
+  Index        r36, r32, r34
+  Move         r37, r36
+  Const        r38, "id"
+  Index        r39, r37, r38
+  Const        r40, "role_id"
+  Index        r41, r26, r40
+  Equal        r42, r39, r41
+  JumpIfFalse  r42, L3
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r43, r13
+  Len          r44, r43
+  Const        r45, 0
+L15:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L3
+  Index        r47, r43, r45
+  Move         r48, r47
+  Const        r49, "id"
+  Index        r50, r48, r49
+  Const        r51, "movie_id"
+  Index        r52, r26, r51
+  Equal        r53, r50, r52
+  JumpIfFalse  r53, L4
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r54, r9
+  Len          r55, r54
+  Const        r56, 0
+L14:
+  Less         r57, r56, r55
+  JumpIfFalse  r57, L4
+  Index        r58, r54, r56
+  Move         r59, r58
+  Const        r60, "movie_id"
+  Index        r61, r59, r60
+  Const        r62, "id"
+  Index        r63, r48, r62
+  Equal        r64, r61, r63
+  JumpIfFalse  r64, L5
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r65, r5
+  Len          r66, r65
+  Const        r67, 0
+L13:
+  Less         r68, r67, r66
+  JumpIfFalse  r68, L5
+  Index        r69, r65, r67
+  Move         r70, r69
+  Const        r71, "id"
+  Index        r72, r70, r71
+  Const        r73, "company_id"
+  Index        r74, r59, r73
+  Equal        r75, r72, r74
+  JumpIfFalse  r75, L6
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r76, r7
+  Len          r77, r76
+  Const        r78, 0
+L12:
+  Less         r79, r78, r77
+  JumpIfFalse  r79, L6
+  Index        r80, r76, r78
+  Move         r81, r80
+  Const        r82, "id"
+  Index        r83, r81, r82
+  Const        r84, "company_type_id"
+  Index        r85, r59, r84
+  Equal        r86, r83, r85
+  JumpIfFalse  r86, L7
+  Const        r87, "note"
+  Index        r88, r26, r87
+  // where ci.note.contains("(voice)") &&
+  Const        r89, "(voice)"
+  In           r90, r89, r88
+  // t.production_year > 2005
+  Const        r91, "production_year"
+  Index        r92, r48, r91
+  Const        r93, 2005
+  Less         r94, r93, r92
+  // cn.country_code == "[ru]" &&
+  Const        r95, "country_code"
+  Index        r96, r70, r95
+  Const        r97, "[ru]"
+  Equal        r98, r96, r97
+  // rt.role == "actor" &&
+  Const        r99, "role"
+  Index        r100, r37, r99
+  Const        r101, "actor"
+  Equal        r102, r100, r101
+  // where ci.note.contains("(voice)") &&
+  Move         r103, r90
+  JumpIfFalse  r103, L8
+  Const        r104, "note"
+  Index        r105, r26, r104
+  // ci.note.contains("(uncredited)") &&
+  Const        r106, "(uncredited)"
+  In           r107, r106, r105
+  // where ci.note.contains("(voice)") &&
+  Move         r103, r107
+L8:
+  // ci.note.contains("(uncredited)") &&
+  Move         r108, r103
+  JumpIfFalse  r108, L9
+  Move         r108, r98
+L9:
+  // cn.country_code == "[ru]" &&
+  Move         r109, r108
+  JumpIfFalse  r109, L10
+  Move         r109, r102
+L10:
+  // rt.role == "actor" &&
+  Move         r110, r109
+  JumpIfFalse  r110, L11
+  Move         r110, r94
+L11:
+  // where ci.note.contains("(voice)") &&
+  JumpIfFalse  r110, L7
+  // select { character: chn.name, movie: t.title }
+  Const        r111, "character"
+  Const        r112, "name"
+  Index        r113, r20, r112
+  Const        r114, "movie"
+  Const        r115, "title"
+  Index        r116, r48, r115
+  Move         r117, r111
+  Move         r118, r113
+  Move         r119, r114
+  Move         r120, r116
+  MakeMap      r121, 2, r117
+  // from chn in char_name
+  Append       r122, r14, r121
+  Move         r14, r122
+L7:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r123, 1
+  Add          r124, r78, r123
+  Move         r78, r124
+  Jump         L12
+L6:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r125, 1
+  Add          r126, r67, r125
+  Move         r67, r126
+  Jump         L13
+L5:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r127, 1
+  Add          r128, r56, r127
+  Move         r56, r128
+  Jump         L14
+L4:
+  // join t in title on t.id == ci.movie_id
+  Const        r129, 1
+  Add          r130, r45, r129
+  Move         r45, r130
+  Jump         L15
+L3:
+  // join rt in role_type on rt.id == ci.role_id
+  Const        r131, 1
+  Add          r132, r34, r131
+  Move         r34, r132
+  Jump         L16
+L2:
+  // join ci in cast_info on chn.id == ci.person_role_id
+  Const        r133, 1
+  Add          r134, r23, r133
+  Move         r23, r134
+  Jump         L17
+L1:
+  // from chn in char_name
+  Const        r135, 1
+  Add          r136, r17, r135
+  Move         r17, r136
+  Jump         L18
+L0:
+  // let matches =
+  Move         r137, r14
+  // uncredited_voiced_character: min(from x in matches select x.character),
+  Const        r138, "uncredited_voiced_character"
+  Const        r139, []
+  IterPrep     r140, r137
+  Len          r141, r140
+  Const        r142, 0
+L20:
+  Less         r143, r142, r141
+  JumpIfFalse  r143, L19
+  Index        r144, r140, r142
+  Move         r145, r144
+  Const        r146, "character"
+  Index        r147, r145, r146
+  Append       r148, r139, r147
+  Move         r139, r148
+  Const        r149, 1
+  Add          r150, r142, r149
+  Move         r142, r150
+  Jump         L20
+L19:
+  Min          r151, r139
+  // russian_movie: min(from x in matches select x.movie)
+  Const        r152, "russian_movie"
+  Const        r153, []
+  IterPrep     r154, r137
+  Len          r155, r154
+  Const        r156, 0
+L22:
+  Less         r157, r156, r155
+  JumpIfFalse  r157, L21
+  Index        r158, r154, r156
+  Move         r145, r158
+  Const        r159, "movie"
+  Index        r160, r145, r159
+  Append       r161, r153, r160
+  Move         r153, r161
+  Const        r162, 1
+  Add          r163, r156, r162
+  Move         r156, r163
+  Jump         L22
+L21:
+  Min          r164, r153
+  // uncredited_voiced_character: min(from x in matches select x.character),
+  Move         r165, r138
+  Move         r166, r151
+  // russian_movie: min(from x in matches select x.movie)
+  Move         r167, r152
+  Move         r168, r164
+  // {
+  MakeMap      r169, 2, r165
+  Move         r170, r169
+  // let result = [
+  MakeList     r171, 1, r170
+  Move         r172, r171
+  // json(result)
+  JSON         r172
+  // expect result == [
+  Const        r173, [{"russian_movie": "Vodka Dreams", "uncredited_voiced_character": "Ivan"}]
+  Equal        r174, r172, r173
+  Expect       r174
+  Return       r0

--- a/tests/dataset/job/out/q2.ir.out
+++ b/tests/dataset/job/out/q2.ir.out
@@ -1,0 +1,163 @@
+func main (regs=94)
+  // let company_name = [
+  Const        r0, [{"country_code": "[de]", "id": 1}, {"country_code": "[us]", "id": 2}]
+  Move         r1, r0
+  // let keyword = [
+  Const        r2, [{"id": 1, "keyword": "character-name-in-title"}, {"id": 2, "keyword": "other"}]
+  Move         r3, r2
+  // let movie_companies = [
+  Const        r4, [{"company_id": 1, "movie_id": 100}, {"company_id": 2, "movie_id": 200}]
+  Move         r5, r4
+  // let movie_keyword = [
+  Const        r6, [{"keyword_id": 1, "movie_id": 100}, {"keyword_id": 2, "movie_id": 200}]
+  Move         r7, r6
+  // let title = [
+  Const        r8, [{"id": 100, "title": "Der Film"}, {"id": 200, "title": "Other Movie"}]
+  Move         r9, r8
+  // from cn in company_name
+  Const        r10, []
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L12:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L0
+  Index        r15, r11, r13
+  Move         r16, r15
+  // join mc in movie_companies on mc.company_id == cn.id
+  IterPrep     r17, r5
+  Len          r18, r17
+  Const        r19, 0
+L11:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L1
+  Index        r21, r17, r19
+  Move         r22, r21
+  Const        r23, "company_id"
+  Index        r24, r22, r23
+  Const        r25, "id"
+  Index        r26, r16, r25
+  Equal        r27, r24, r26
+  JumpIfFalse  r27, L2
+  // join t in title on mc.movie_id == t.id
+  IterPrep     r28, r9
+  Len          r29, r28
+  Const        r30, 0
+L10:
+  Less         r31, r30, r29
+  JumpIfFalse  r31, L2
+  Index        r32, r28, r30
+  Move         r33, r32
+  Const        r34, "movie_id"
+  Index        r35, r22, r34
+  Const        r36, "id"
+  Index        r37, r33, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L3
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r39, r7
+  Len          r40, r39
+  Const        r41, 0
+L9:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L3
+  Index        r43, r39, r41
+  Move         r44, r43
+  Const        r45, "movie_id"
+  Index        r46, r44, r45
+  Const        r47, "id"
+  Index        r48, r33, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L4
+  // join k in keyword on mk.keyword_id == k.id
+  IterPrep     r50, r3
+  Len          r51, r50
+  Const        r52, 0
+L8:
+  Less         r53, r52, r51
+  JumpIfFalse  r53, L4
+  Index        r54, r50, r52
+  Move         r55, r54
+  Const        r56, "keyword_id"
+  Index        r57, r44, r56
+  Const        r58, "id"
+  Index        r59, r55, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L5
+  // where cn.country_code == "[de]" &&
+  Const        r61, "country_code"
+  Index        r62, r16, r61
+  Const        r63, "[de]"
+  Equal        r64, r62, r63
+  // k.keyword == "character-name-in-title" &&
+  Const        r65, "keyword"
+  Index        r66, r55, r65
+  Const        r67, "character-name-in-title"
+  Equal        r68, r66, r67
+  // mc.movie_id == mk.movie_id
+  Const        r69, "movie_id"
+  Index        r70, r22, r69
+  Const        r71, "movie_id"
+  Index        r72, r44, r71
+  Equal        r73, r70, r72
+  // where cn.country_code == "[de]" &&
+  Move         r74, r64
+  JumpIfFalse  r74, L6
+  Move         r74, r68
+L6:
+  // k.keyword == "character-name-in-title" &&
+  Move         r75, r74
+  JumpIfFalse  r75, L7
+  Move         r75, r73
+L7:
+  // where cn.country_code == "[de]" &&
+  JumpIfFalse  r75, L5
+  // select t.title
+  Const        r76, "title"
+  Index        r77, r33, r76
+  // from cn in company_name
+  Append       r78, r10, r77
+  Move         r10, r78
+L5:
+  // join k in keyword on mk.keyword_id == k.id
+  Const        r79, 1
+  Add          r80, r52, r79
+  Move         r52, r80
+  Jump         L8
+L4:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r81, 1
+  Add          r82, r41, r81
+  Move         r41, r82
+  Jump         L9
+L3:
+  // join t in title on mc.movie_id == t.id
+  Const        r83, 1
+  Add          r84, r30, r83
+  Move         r30, r84
+  Jump         L10
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r85, 1
+  Add          r86, r19, r85
+  Move         r19, r86
+  Jump         L11
+L1:
+  // from cn in company_name
+  Const        r87, 1
+  Add          r88, r13, r87
+  Move         r13, r88
+  Jump         L12
+L0:
+  // let titles =
+  Move         r89, r10
+  // let result = min(titles)
+  Min          r90, r89
+  Move         r91, r90
+  // json(result)
+  JSON         r91
+  // expect result == "Der Film"
+  Const        r92, "Der Film"
+  Equal        r93, r91, r92
+  Expect       r93
+  Return       r0

--- a/tests/dataset/job/out/q3.ir.out
+++ b/tests/dataset/job/out/q3.ir.out
@@ -1,0 +1,157 @@
+func main (regs=91)
+  // let keyword = [
+  Const        r0, [{"id": 1, "keyword": "amazing sequel"}, {"id": 2, "keyword": "prequel"}]
+  Move         r1, r0
+  // let movie_info = [
+  Const        r2, [{"info": "Germany", "movie_id": 10}, {"info": "Sweden", "movie_id": 30}, {"info": "France", "movie_id": 20}]
+  Move         r3, r2
+  // let movie_keyword = [
+  Const        r4, [{"keyword_id": 1, "movie_id": 10}, {"keyword_id": 1, "movie_id": 30}, {"keyword_id": 1, "movie_id": 20}, {"keyword_id": 2, "movie_id": 10}]
+  Move         r5, r4
+  // let title = [
+  Const        r6, [{"id": 10, "production_year": 2006, "title": "Alpha"}, {"id": 30, "production_year": 2008, "title": "Beta"}, {"id": 20, "production_year": 2009, "title": "Gamma"}]
+  Move         r7, r6
+  // let allowed_infos = [
+  Const        r8, ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]
+  Move         r9, r8
+  // from k in keyword
+  Const        r10, []
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L11:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L0
+  Index        r15, r11, r13
+  Move         r16, r15
+  // join mk in movie_keyword on mk.keyword_id == k.id
+  IterPrep     r17, r5
+  Len          r18, r17
+  Const        r19, 0
+L10:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L1
+  Index        r21, r17, r19
+  Move         r22, r21
+  Const        r23, "keyword_id"
+  Index        r24, r22, r23
+  Const        r25, "id"
+  Index        r26, r16, r25
+  Equal        r27, r24, r26
+  JumpIfFalse  r27, L2
+  // join mi in movie_info on mi.movie_id == mk.movie_id
+  IterPrep     r28, r3
+  Len          r29, r28
+  Const        r30, 0
+L9:
+  Less         r31, r30, r29
+  JumpIfFalse  r31, L2
+  Index        r32, r28, r30
+  Move         r33, r32
+  Const        r34, "movie_id"
+  Index        r35, r33, r34
+  Const        r36, "movie_id"
+  Index        r37, r22, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L3
+  // join t in title on t.id == mi.movie_id
+  IterPrep     r39, r7
+  Len          r40, r39
+  Const        r41, 0
+L8:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L3
+  Index        r43, r39, r41
+  Move         r44, r43
+  Const        r45, "id"
+  Index        r46, r44, r45
+  Const        r47, "movie_id"
+  Index        r48, r33, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L4
+  Const        r50, "keyword"
+  Index        r51, r16, r50
+  // where k.keyword.contains("sequel") &&
+  Const        r52, "sequel"
+  In           r53, r52, r51
+  // t.production_year > 2005 &&
+  Const        r54, "production_year"
+  Index        r55, r44, r54
+  Const        r56, 2005
+  Less         r57, r56, r55
+  // mi.info in allowed_infos &&
+  Const        r58, "info"
+  Index        r59, r33, r58
+  In           r60, r59, r9
+  // mk.movie_id == mi.movie_id
+  Const        r61, "movie_id"
+  Index        r62, r22, r61
+  Const        r63, "movie_id"
+  Index        r64, r33, r63
+  Equal        r65, r62, r64
+  // where k.keyword.contains("sequel") &&
+  Move         r66, r53
+  JumpIfFalse  r66, L5
+  Move         r66, r60
+L5:
+  // mi.info in allowed_infos &&
+  Move         r67, r66
+  JumpIfFalse  r67, L6
+  Move         r67, r57
+L6:
+  // t.production_year > 2005 &&
+  Move         r68, r67
+  JumpIfFalse  r68, L7
+  Move         r68, r65
+L7:
+  // where k.keyword.contains("sequel") &&
+  JumpIfFalse  r68, L4
+  // select t.title
+  Const        r69, "title"
+  Index        r70, r44, r69
+  // from k in keyword
+  Append       r71, r10, r70
+  Move         r10, r71
+L4:
+  // join t in title on t.id == mi.movie_id
+  Const        r72, 1
+  Add          r73, r41, r72
+  Move         r41, r73
+  Jump         L8
+L3:
+  // join mi in movie_info on mi.movie_id == mk.movie_id
+  Const        r74, 1
+  Add          r75, r30, r74
+  Move         r30, r75
+  Jump         L9
+L2:
+  // join mk in movie_keyword on mk.keyword_id == k.id
+  Const        r76, 1
+  Add          r77, r19, r76
+  Move         r19, r77
+  Jump         L10
+L1:
+  // from k in keyword
+  Const        r78, 1
+  Add          r79, r13, r78
+  Move         r13, r79
+  Jump         L11
+L0:
+  // let candidate_titles =
+  Move         r80, r10
+  // let result = [{ movie_title: min(candidate_titles) }]
+  Const        r81, "movie_title"
+  Min          r82, r80
+  Move         r83, r81
+  Move         r84, r82
+  MakeMap      r85, 1, r83
+  Move         r86, r85
+  MakeList     r87, 1, r86
+  Move         r88, r87
+  // json(result)
+  JSON         r88
+  // expect result == [ { movie_title: "Alpha" } ]
+  Const        r89, [{"movie_title": "Alpha"}]
+  Equal        r90, r88, r89
+  Expect       r90
+  Return       r0

--- a/tests/dataset/job/out/q4.ir.out
+++ b/tests/dataset/job/out/q4.ir.out
@@ -1,0 +1,245 @@
+func main (regs=146)
+  // let info_type = [
+  Const        r0, [{"id": 1, "info": "rating"}, {"id": 2, "info": "other"}]
+  Move         r1, r0
+  // let keyword = [
+  Const        r2, [{"id": 1, "keyword": "great sequel"}, {"id": 2, "keyword": "prequel"}]
+  Move         r3, r2
+  // let title = [
+  Const        r4, [{"id": 10, "production_year": 2006, "title": "Alpha Movie"}, {"id": 20, "production_year": 2007, "title": "Beta Film"}, {"id": 30, "production_year": 2004, "title": "Old Film"}]
+  Move         r5, r4
+  // let movie_keyword = [
+  Const        r6, [{"keyword_id": 1, "movie_id": 10}, {"keyword_id": 1, "movie_id": 20}, {"keyword_id": 1, "movie_id": 30}]
+  Move         r7, r6
+  // let movie_info_idx = [
+  Const        r8, [{"info": "6.2", "info_type_id": 1, "movie_id": 10}, {"info": "7.8", "info_type_id": 1, "movie_id": 20}, {"info": "4.5", "info_type_id": 1, "movie_id": 30}]
+  Move         r9, r8
+  // from it in info_type
+  Const        r10, []
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L14:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L0
+  Index        r15, r11, r13
+  Move         r16, r15
+  // join mi in movie_info_idx on it.id == mi.info_type_id
+  IterPrep     r17, r9
+  Len          r18, r17
+  Const        r19, 0
+L13:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L1
+  Index        r21, r17, r19
+  Move         r22, r21
+  Const        r23, "id"
+  Index        r24, r16, r23
+  Const        r25, "info_type_id"
+  Index        r26, r22, r25
+  Equal        r27, r24, r26
+  JumpIfFalse  r27, L2
+  // join t in title on t.id == mi.movie_id
+  IterPrep     r28, r5
+  Len          r29, r28
+  Const        r30, 0
+L12:
+  Less         r31, r30, r29
+  JumpIfFalse  r31, L2
+  Index        r32, r28, r30
+  Move         r33, r32
+  Const        r34, "id"
+  Index        r35, r33, r34
+  Const        r36, "movie_id"
+  Index        r37, r22, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L3
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r39, r7
+  Len          r40, r39
+  Const        r41, 0
+L11:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L3
+  Index        r43, r39, r41
+  Move         r44, r43
+  Const        r45, "movie_id"
+  Index        r46, r44, r45
+  Const        r47, "id"
+  Index        r48, r33, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L4
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r50, r3
+  Len          r51, r50
+  Const        r52, 0
+L10:
+  Less         r53, r52, r51
+  JumpIfFalse  r53, L4
+  Index        r54, r50, r52
+  Move         r55, r54
+  Const        r56, "id"
+  Index        r57, r55, r56
+  Const        r58, "keyword_id"
+  Index        r59, r44, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L5
+  // where it.info == "rating" &&
+  Const        r61, "info"
+  Index        r62, r16, r61
+  // mi.info > "5.0" &&
+  Const        r63, "info"
+  Index        r64, r22, r63
+  Const        r65, "5.0"
+  Less         r66, r65, r64
+  // t.production_year > 2005 &&
+  Const        r67, "production_year"
+  Index        r68, r33, r67
+  Const        r69, 2005
+  Less         r70, r69, r68
+  // where it.info == "rating" &&
+  Const        r71, "rating"
+  Equal        r72, r62, r71
+  // mk.movie_id == mi.movie_id
+  Const        r73, "movie_id"
+  Index        r74, r44, r73
+  Const        r75, "movie_id"
+  Index        r76, r22, r75
+  Equal        r77, r74, r76
+  // where it.info == "rating" &&
+  Move         r78, r72
+  JumpIfFalse  r78, L6
+  Const        r79, "keyword"
+  Index        r80, r55, r79
+  // k.keyword.contains("sequel") &&
+  Const        r81, "sequel"
+  In           r82, r81, r80
+  // where it.info == "rating" &&
+  Move         r78, r82
+L6:
+  // k.keyword.contains("sequel") &&
+  Move         r83, r78
+  JumpIfFalse  r83, L7
+  Move         r83, r66
+L7:
+  // mi.info > "5.0" &&
+  Move         r84, r83
+  JumpIfFalse  r84, L8
+  Move         r84, r70
+L8:
+  // t.production_year > 2005 &&
+  Move         r85, r84
+  JumpIfFalse  r85, L9
+  Move         r85, r77
+L9:
+  // where it.info == "rating" &&
+  JumpIfFalse  r85, L5
+  // select { rating: mi.info, title: t.title }
+  Const        r86, "rating"
+  Const        r87, "info"
+  Index        r88, r22, r87
+  Const        r89, "title"
+  Const        r90, "title"
+  Index        r91, r33, r90
+  Move         r92, r86
+  Move         r93, r88
+  Move         r94, r89
+  Move         r95, r91
+  MakeMap      r96, 2, r92
+  // from it in info_type
+  Append       r97, r10, r96
+  Move         r10, r97
+L5:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r98, 1
+  Add          r99, r52, r98
+  Move         r52, r99
+  Jump         L10
+L4:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r100, 1
+  Add          r101, r41, r100
+  Move         r41, r101
+  Jump         L11
+L3:
+  // join t in title on t.id == mi.movie_id
+  Const        r102, 1
+  Add          r103, r30, r102
+  Move         r30, r103
+  Jump         L12
+L2:
+  // join mi in movie_info_idx on it.id == mi.info_type_id
+  Const        r104, 1
+  Add          r105, r19, r104
+  Move         r19, r105
+  Jump         L13
+L1:
+  // from it in info_type
+  Const        r106, 1
+  Add          r107, r13, r106
+  Move         r13, r107
+  Jump         L14
+L0:
+  // let rows =
+  Move         r108, r10
+  // rating: min(from r in rows select r.rating),
+  Const        r109, "rating"
+  Const        r110, []
+  IterPrep     r111, r108
+  Len          r112, r111
+  Const        r113, 0
+L16:
+  Less         r114, r113, r112
+  JumpIfFalse  r114, L15
+  Index        r115, r111, r113
+  Move         r116, r115
+  Const        r117, "rating"
+  Index        r118, r116, r117
+  Append       r119, r110, r118
+  Move         r110, r119
+  Const        r120, 1
+  Add          r121, r113, r120
+  Move         r113, r121
+  Jump         L16
+L15:
+  Min          r122, r110
+  // movie_title: min(from r in rows select r.title)
+  Const        r123, "movie_title"
+  Const        r124, []
+  IterPrep     r125, r108
+  Len          r126, r125
+  Const        r127, 0
+L18:
+  Less         r128, r127, r126
+  JumpIfFalse  r128, L17
+  Index        r129, r125, r127
+  Move         r116, r129
+  Const        r130, "title"
+  Index        r131, r116, r130
+  Append       r132, r124, r131
+  Move         r124, r132
+  Const        r133, 1
+  Add          r134, r127, r133
+  Move         r127, r134
+  Jump         L18
+L17:
+  Min          r135, r124
+  // rating: min(from r in rows select r.rating),
+  Move         r136, r109
+  Move         r137, r122
+  // movie_title: min(from r in rows select r.title)
+  Move         r138, r123
+  Move         r139, r135
+  // {
+  MakeMap      r140, 2, r136
+  Move         r141, r140
+  // let result = [
+  MakeList     r142, 1, r141
+  Move         r143, r142
+  // json(result)
+  JSON         r143
+  // expect result == [ { rating: "6.2", movie_title: "Alpha Movie" } ]
+  Const        r144, [{"movie_title": "Alpha Movie", "rating": "6.2"}]
+  Equal        r145, r143, r144
+  Expect       r145
+  Return       r0

--- a/tests/dataset/job/out/q5.ir.out
+++ b/tests/dataset/job/out/q5.ir.out
@@ -1,0 +1,190 @@
+func main (regs=109)
+  // let company_type = [
+  Const        r0, [{"ct_id": 1, "kind": "production companies"}, {"ct_id": 2, "kind": "other"}]
+  Move         r1, r0
+  // let info_type = [
+  Const        r2, [{"info": "languages", "it_id": 10}]
+  Move         r3, r2
+  // let title = [
+  Const        r4, [{"production_year": 2010, "t_id": 100, "title": "B Movie"}, {"production_year": 2012, "t_id": 200, "title": "A Film"}, {"production_year": 2000, "t_id": 300, "title": "Old Movie"}]
+  Move         r5, r4
+  // let movie_companies = [
+  Const        r6, [{"company_type_id": 1, "movie_id": 100, "note": "ACME (France) (theatrical)"}, {"company_type_id": 1, "movie_id": 200, "note": "ACME (France) (theatrical)"}, {"company_type_id": 1, "movie_id": 300, "note": "ACME (France) (theatrical)"}]
+  Move         r7, r6
+  // let movie_info = [
+  Const        r8, [{"info": "German", "info_type_id": 10, "movie_id": 100}, {"info": "Swedish", "info_type_id": 10, "movie_id": 200}, {"info": "German", "info_type_id": 10, "movie_id": 300}]
+  Move         r9, r8
+  // from ct in company_type
+  Const        r10, []
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L14:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L0
+  Index        r15, r11, r13
+  Move         r16, r15
+  // join mc in movie_companies on mc.company_type_id == ct.ct_id
+  IterPrep     r17, r7
+  Len          r18, r17
+  Const        r19, 0
+L13:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L1
+  Index        r21, r17, r19
+  Move         r22, r21
+  Const        r23, "company_type_id"
+  Index        r24, r22, r23
+  Const        r25, "ct_id"
+  Index        r26, r16, r25
+  Equal        r27, r24, r26
+  JumpIfFalse  r27, L2
+  // join mi in movie_info on mi.movie_id == mc.movie_id
+  IterPrep     r28, r9
+  Len          r29, r28
+  Const        r30, 0
+L12:
+  Less         r31, r30, r29
+  JumpIfFalse  r31, L2
+  Index        r32, r28, r30
+  Move         r33, r32
+  Const        r34, "movie_id"
+  Index        r35, r33, r34
+  Const        r36, "movie_id"
+  Index        r37, r22, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L3
+  // join it in info_type on it.it_id == mi.info_type_id
+  IterPrep     r39, r3
+  Len          r40, r39
+  Const        r41, 0
+L11:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L3
+  Index        r43, r39, r41
+  Move         r44, r43
+  Const        r45, "it_id"
+  Index        r46, r44, r45
+  Const        r47, "info_type_id"
+  Index        r48, r33, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L4
+  // join t in title on t.t_id == mc.movie_id
+  IterPrep     r50, r5
+  Len          r51, r50
+  Const        r52, 0
+L10:
+  Less         r53, r52, r51
+  JumpIfFalse  r53, L4
+  Index        r54, r50, r52
+  Move         r55, r54
+  Const        r56, "t_id"
+  Index        r57, r55, r56
+  Const        r58, "movie_id"
+  Index        r59, r22, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L5
+  // where ct.kind == "production companies" &&
+  Const        r61, "kind"
+  Index        r62, r16, r61
+  // t.production_year > 2005 &&
+  Const        r63, "production_year"
+  Index        r64, r55, r63
+  Const        r65, 2005
+  Less         r66, r65, r64
+  // where ct.kind == "production companies" &&
+  Const        r67, "production companies"
+  Equal        r68, r62, r67
+  // "(theatrical)" in mc.note &&
+  Const        r69, "(theatrical)"
+  Const        r70, "note"
+  Index        r71, r22, r70
+  In           r72, r69, r71
+  // "(France)" in mc.note &&
+  Const        r73, "(France)"
+  Const        r74, "note"
+  Index        r75, r22, r74
+  In           r76, r73, r75
+  // where ct.kind == "production companies" &&
+  Move         r77, r68
+  JumpIfFalse  r77, L6
+  Move         r77, r72
+L6:
+  // "(theatrical)" in mc.note &&
+  Move         r78, r77
+  JumpIfFalse  r78, L7
+  Move         r78, r76
+L7:
+  // "(France)" in mc.note &&
+  Move         r79, r78
+  JumpIfFalse  r79, L8
+  Move         r79, r66
+L8:
+  // t.production_year > 2005 &&
+  Move         r80, r79
+  JumpIfFalse  r80, L9
+  // (mi.info in [
+  Const        r81, "info"
+  Index        r82, r33, r81
+  Const        r83, ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]
+  In           r84, r82, r83
+  // t.production_year > 2005 &&
+  Move         r80, r84
+L9:
+  // where ct.kind == "production companies" &&
+  JumpIfFalse  r80, L5
+  // select t.title
+  Const        r85, "title"
+  Index        r86, r55, r85
+  // from ct in company_type
+  Append       r87, r10, r86
+  Move         r10, r87
+L5:
+  // join t in title on t.t_id == mc.movie_id
+  Const        r88, 1
+  Add          r89, r52, r88
+  Move         r52, r89
+  Jump         L10
+L4:
+  // join it in info_type on it.it_id == mi.info_type_id
+  Const        r90, 1
+  Add          r91, r41, r90
+  Move         r41, r91
+  Jump         L11
+L3:
+  // join mi in movie_info on mi.movie_id == mc.movie_id
+  Const        r92, 1
+  Add          r93, r30, r92
+  Move         r30, r93
+  Jump         L12
+L2:
+  // join mc in movie_companies on mc.company_type_id == ct.ct_id
+  Const        r94, 1
+  Add          r95, r19, r94
+  Move         r19, r95
+  Jump         L13
+L1:
+  // from ct in company_type
+  Const        r96, 1
+  Add          r97, r13, r96
+  Move         r13, r97
+  Jump         L14
+L0:
+  // let candidate_titles =
+  Move         r98, r10
+  // let result = [ { typical_european_movie: min(candidate_titles) } ]
+  Const        r99, "typical_european_movie"
+  Min          r100, r98
+  Move         r101, r99
+  Move         r102, r100
+  MakeMap      r103, 1, r101
+  Move         r104, r103
+  MakeList     r105, 1, r104
+  Move         r106, r105
+  // json(result)
+  JSON         r106
+  // expect result == [ { typical_european_movie: "A Film" } ]
+  Const        r107, [{"typical_european_movie": "A Film"}]
+  Equal        r108, r106, r107
+  Expect       r108
+  Return       r0

--- a/tests/dataset/job/out/q6.ir.out
+++ b/tests/dataset/job/out/q6.ir.out
@@ -1,0 +1,191 @@
+func main (regs=110)
+  // let cast_info = [
+  Const        r0, [{"movie_id": 1, "person_id": 101}, {"movie_id": 2, "person_id": 102}]
+  Move         r1, r0
+  // let keyword = [
+  Const        r2, [{"id": 100, "keyword": "marvel-cinematic-universe"}, {"id": 200, "keyword": "other"}]
+  Move         r3, r2
+  // let movie_keyword = [
+  Const        r4, [{"keyword_id": 100, "movie_id": 1}, {"keyword_id": 200, "movie_id": 2}]
+  Move         r5, r4
+  // let name = [
+  Const        r6, [{"id": 101, "name": "Downey Robert Jr."}, {"id": 102, "name": "Chris Evans"}]
+  Move         r7, r6
+  // let title = [
+  Const        r8, [{"id": 1, "production_year": 2013, "title": "Iron Man 3"}, {"id": 2, "production_year": 2000, "title": "Old Movie"}]
+  Move         r9, r8
+  // from ci in cast_info
+  Const        r10, []
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L13:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L0
+  Index        r15, r11, r13
+  Move         r16, r15
+  // join mk in movie_keyword on ci.movie_id == mk.movie_id
+  IterPrep     r17, r5
+  Len          r18, r17
+  Const        r19, 0
+L12:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L1
+  Index        r21, r17, r19
+  Move         r22, r21
+  Const        r23, "movie_id"
+  Index        r24, r16, r23
+  Const        r25, "movie_id"
+  Index        r26, r22, r25
+  Equal        r27, r24, r26
+  JumpIfFalse  r27, L2
+  // join k in keyword on mk.keyword_id == k.id
+  IterPrep     r28, r3
+  Len          r29, r28
+  Const        r30, 0
+L11:
+  Less         r31, r30, r29
+  JumpIfFalse  r31, L2
+  Index        r32, r28, r30
+  Move         r33, r32
+  Const        r34, "keyword_id"
+  Index        r35, r22, r34
+  Const        r36, "id"
+  Index        r37, r33, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L3
+  // join n in name on ci.person_id == n.id
+  IterPrep     r39, r7
+  Len          r40, r39
+  Const        r41, 0
+L10:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L3
+  Index        r43, r39, r41
+  Move         r44, r43
+  Const        r45, "person_id"
+  Index        r46, r16, r45
+  Const        r47, "id"
+  Index        r48, r44, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L4
+  // join t in title on ci.movie_id == t.id
+  IterPrep     r50, r9
+  Len          r51, r50
+  Const        r52, 0
+L9:
+  Less         r53, r52, r51
+  JumpIfFalse  r53, L4
+  Index        r54, r50, r52
+  Move         r55, r54
+  Const        r56, "movie_id"
+  Index        r57, r16, r56
+  Const        r58, "id"
+  Index        r59, r55, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L5
+  // k.keyword == "marvel-cinematic-universe" &&
+  Const        r61, "keyword"
+  Index        r62, r33, r61
+  // t.production_year > 2010
+  Const        r63, "production_year"
+  Index        r64, r55, r63
+  Const        r65, 2010
+  Less         r66, r65, r64
+  // k.keyword == "marvel-cinematic-universe" &&
+  Const        r67, "marvel-cinematic-universe"
+  Equal        r68, r62, r67
+  Move         r69, r68
+  JumpIfFalse  r69, L6
+  Const        r70, "name"
+  Index        r71, r44, r70
+  // n.name.contains("Downey") &&
+  Const        r72, "Downey"
+  In           r73, r72, r71
+  // k.keyword == "marvel-cinematic-universe" &&
+  Move         r69, r73
+L6:
+  // n.name.contains("Downey") &&
+  Move         r74, r69
+  JumpIfFalse  r74, L7
+  Const        r75, "name"
+  Index        r76, r44, r75
+  // n.name.contains("Robert") &&
+  Const        r77, "Robert"
+  In           r78, r77, r76
+  // n.name.contains("Downey") &&
+  Move         r74, r78
+L7:
+  // n.name.contains("Robert") &&
+  Move         r79, r74
+  JumpIfFalse  r79, L8
+  Move         r79, r66
+L8:
+  // k.keyword == "marvel-cinematic-universe" &&
+  JumpIfFalse  r79, L5
+  // movie_keyword: k.keyword,
+  Const        r80, "movie_keyword"
+  Const        r81, "keyword"
+  Index        r82, r33, r81
+  // actor_name: n.name,
+  Const        r83, "actor_name"
+  Const        r84, "name"
+  Index        r85, r44, r84
+  // marvel_movie: t.title
+  Const        r86, "marvel_movie"
+  Const        r87, "title"
+  Index        r88, r55, r87
+  // movie_keyword: k.keyword,
+  Move         r89, r80
+  Move         r90, r82
+  // actor_name: n.name,
+  Move         r91, r83
+  Move         r92, r85
+  // marvel_movie: t.title
+  Move         r93, r86
+  Move         r94, r88
+  // select {
+  MakeMap      r95, 3, r89
+  // from ci in cast_info
+  Append       r96, r10, r95
+  Move         r10, r96
+L5:
+  // join t in title on ci.movie_id == t.id
+  Const        r97, 1
+  Add          r98, r52, r97
+  Move         r52, r98
+  Jump         L9
+L4:
+  // join n in name on ci.person_id == n.id
+  Const        r99, 1
+  Add          r100, r41, r99
+  Move         r41, r100
+  Jump         L10
+L3:
+  // join k in keyword on mk.keyword_id == k.id
+  Const        r101, 1
+  Add          r102, r30, r101
+  Move         r30, r102
+  Jump         L11
+L2:
+  // join mk in movie_keyword on ci.movie_id == mk.movie_id
+  Const        r103, 1
+  Add          r104, r19, r103
+  Move         r19, r104
+  Jump         L12
+L1:
+  // from ci in cast_info
+  Const        r105, 1
+  Add          r106, r13, r105
+  Move         r13, r106
+  Jump         L13
+L0:
+  // let result =
+  Move         r107, r10
+  // json(result)
+  JSON         r107
+  // expect result == [
+  Const        r108, [{"actor_name": "Downey Robert Jr.", "marvel_movie": "Iron Man 3", "movie_keyword": "marvel-cinematic-universe"}]
+  Equal        r109, r107, r108
+  Expect       r109
+  Return       r0

--- a/tests/dataset/job/out/q7.ir.out
+++ b/tests/dataset/job/out/q7.ir.out
@@ -1,0 +1,414 @@
+func main (regs=247)
+  // let aka_name = [
+  Const        r0, [{"name": "Anna Mae", "person_id": 1}, {"name": "Chris", "person_id": 2}]
+  Move         r1, r0
+  // let cast_info = [
+  Const        r2, [{"movie_id": 10, "person_id": 1}, {"movie_id": 20, "person_id": 2}]
+  Move         r3, r2
+  // let info_type = [
+  Const        r4, [{"id": 1, "info": "mini biography"}, {"id": 2, "info": "trivia"}]
+  Move         r5, r4
+  // let link_type = [
+  Const        r6, [{"id": 1, "link": "features"}, {"id": 2, "link": "references"}]
+  Move         r7, r6
+  // let movie_link = [
+  Const        r8, [{"link_type_id": 1, "linked_movie_id": 10}, {"link_type_id": 2, "linked_movie_id": 20}]
+  Move         r9, r8
+  // let name = [
+  Const        r10, [{"gender": "m", "id": 1, "name": "Alan Brown", "name_pcode_cf": "B"}, {"gender": "f", "id": 2, "name": "Zoe", "name_pcode_cf": "Z"}]
+  Move         r11, r10
+  // let person_info = [
+  Const        r12, [{"info_type_id": 1, "note": "Volker Boehm", "person_id": 1}, {"info_type_id": 1, "note": "Other", "person_id": 2}]
+  Move         r13, r12
+  // let title = [
+  Const        r14, [{"id": 10, "production_year": 1990, "title": "Feature Film"}, {"id": 20, "production_year": 2000, "title": "Late Film"}]
+  Move         r15, r14
+  // from an in aka_name
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, 0
+L30:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L0
+  Index        r21, r17, r19
+  Move         r22, r21
+  // join n in name on n.id == an.person_id
+  IterPrep     r23, r11
+  Len          r24, r23
+  Const        r25, 0
+L29:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L1
+  Index        r27, r23, r25
+  Move         r28, r27
+  Const        r29, "id"
+  Index        r30, r28, r29
+  Const        r31, "person_id"
+  Index        r32, r22, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join pi in person_info on pi.person_id == an.person_id
+  IterPrep     r34, r13
+  Len          r35, r34
+  Const        r36, 0
+L28:
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L2
+  Index        r38, r34, r36
+  Move         r39, r38
+  Const        r40, "person_id"
+  Index        r41, r39, r40
+  Const        r42, "person_id"
+  Index        r43, r22, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L3
+  // join it in info_type on it.id == pi.info_type_id
+  IterPrep     r45, r5
+  Len          r46, r45
+  Const        r47, 0
+L27:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L3
+  Index        r49, r45, r47
+  Move         r50, r49
+  Const        r51, "id"
+  Index        r52, r50, r51
+  Const        r53, "info_type_id"
+  Index        r54, r39, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L4
+  // join ci in cast_info on ci.person_id == n.id
+  IterPrep     r56, r3
+  Len          r57, r56
+  Const        r58, 0
+L26:
+  Less         r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r60, r56, r58
+  Move         r61, r60
+  Const        r62, "person_id"
+  Index        r63, r61, r62
+  Const        r64, "id"
+  Index        r65, r28, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L5
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r67, r15
+  Len          r68, r67
+  Const        r69, 0
+L25:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L5
+  Index        r71, r67, r69
+  Move         r72, r71
+  Const        r73, "id"
+  Index        r74, r72, r73
+  Const        r75, "movie_id"
+  Index        r76, r61, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L6
+  // join ml in movie_link on ml.linked_movie_id == t.id
+  IterPrep     r78, r9
+  Len          r79, r78
+  Const        r80, 0
+L24:
+  Less         r81, r80, r79
+  JumpIfFalse  r81, L6
+  Index        r82, r78, r80
+  Move         r83, r82
+  Const        r84, "linked_movie_id"
+  Index        r85, r83, r84
+  Const        r86, "id"
+  Index        r87, r72, r86
+  Equal        r88, r85, r87
+  JumpIfFalse  r88, L7
+  // join lt in link_type on lt.id == ml.link_type_id
+  IterPrep     r89, r7
+  Len          r90, r89
+  Const        r91, 0
+L23:
+  Less         r92, r91, r90
+  JumpIfFalse  r92, L7
+  Index        r93, r89, r91
+  Move         r94, r93
+  Const        r95, "id"
+  Index        r96, r94, r95
+  Const        r97, "link_type_id"
+  Index        r98, r83, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L8
+  Const        r100, "name"
+  Index        r101, r22, r100
+  // an.name.contains("a") &&
+  Const        r102, "a"
+  In           r103, r102, r101
+  // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
+  Const        r104, "name_pcode_cf"
+  Index        r105, r28, r104
+  Const        r106, "A"
+  LessEq       r107, r106, r105
+  Const        r108, "name_pcode_cf"
+  Index        r109, r28, r108
+  Const        r110, "F"
+  LessEq       r111, r109, r110
+  // t.production_year >= 1980 && t.production_year <= 1995 &&
+  Const        r112, "production_year"
+  Index        r113, r72, r112
+  Const        r114, 1980
+  LessEq       r115, r114, r113
+  Const        r116, "production_year"
+  Index        r117, r72, r116
+  Const        r118, 1995
+  LessEq       r119, r117, r118
+  // it.info == "mini biography" &&
+  Const        r120, "info"
+  Index        r121, r50, r120
+  Const        r122, "mini biography"
+  Equal        r123, r121, r122
+  // lt.link == "features" &&
+  Const        r124, "link"
+  Index        r125, r94, r124
+  Const        r126, "features"
+  Equal        r127, r125, r126
+  // pi.note == "Volker Boehm" &&
+  Const        r128, "note"
+  Index        r129, r39, r128
+  Const        r130, "Volker Boehm"
+  Equal        r131, r129, r130
+  // pi.person_id == an.person_id &&
+  Const        r132, "person_id"
+  Index        r133, r39, r132
+  Const        r134, "person_id"
+  Index        r135, r22, r134
+  Equal        r136, r133, r135
+  // pi.person_id == ci.person_id &&
+  Const        r137, "person_id"
+  Index        r138, r39, r137
+  Const        r139, "person_id"
+  Index        r140, r61, r139
+  Equal        r141, r138, r140
+  // an.person_id == ci.person_id &&
+  Const        r142, "person_id"
+  Index        r143, r22, r142
+  Const        r144, "person_id"
+  Index        r145, r61, r144
+  Equal        r146, r143, r145
+  // ci.movie_id == ml.linked_movie_id
+  Const        r147, "movie_id"
+  Index        r148, r61, r147
+  Const        r149, "linked_movie_id"
+  Index        r150, r83, r149
+  Equal        r151, r148, r150
+  // an.name.contains("a") &&
+  Move         r152, r103
+  JumpIfFalse  r152, L9
+  Move         r152, r123
+L9:
+  // it.info == "mini biography" &&
+  Move         r153, r152
+  JumpIfFalse  r153, L10
+  Move         r153, r127
+L10:
+  // lt.link == "features" &&
+  Move         r154, r153
+  JumpIfFalse  r154, L11
+  Move         r154, r107
+L11:
+  // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
+  Move         r155, r154
+  JumpIfFalse  r155, L12
+  Move         r155, r111
+L12:
+  Move         r156, r155
+  JumpIfFalse  r156, L13
+  // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
+  Const        r157, "gender"
+  Index        r158, r28, r157
+  Const        r159, "m"
+  Equal        r160, r158, r159
+  Move         r161, r160
+  JumpIfTrue   r161, L14
+  Const        r162, "gender"
+  Index        r163, r28, r162
+  Const        r164, "f"
+  Equal        r165, r163, r164
+  Move         r166, r165
+  JumpIfFalse  r166, L15
+  Const        r167, "name"
+  Index        r168, r28, r167
+  Const        r169, "starts_with"
+  Index        r170, r168, r169
+  Const        r172, "B"
+  Move         r171, r172
+  CallV        r173, r170, 1, r171
+  Move         r166, r173
+L15:
+  Move         r161, r166
+L14:
+  // n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
+  Move         r156, r161
+L13:
+  // (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
+  Move         r174, r156
+  JumpIfFalse  r174, L16
+  Move         r174, r131
+L16:
+  // pi.note == "Volker Boehm" &&
+  Move         r175, r174
+  JumpIfFalse  r175, L17
+  Move         r175, r115
+L17:
+  // t.production_year >= 1980 && t.production_year <= 1995 &&
+  Move         r176, r175
+  JumpIfFalse  r176, L18
+  Move         r176, r119
+L18:
+  Move         r177, r176
+  JumpIfFalse  r177, L19
+  Move         r177, r136
+L19:
+  // pi.person_id == an.person_id &&
+  Move         r178, r177
+  JumpIfFalse  r178, L20
+  Move         r178, r141
+L20:
+  // pi.person_id == ci.person_id &&
+  Move         r179, r178
+  JumpIfFalse  r179, L21
+  Move         r179, r146
+L21:
+  // an.person_id == ci.person_id &&
+  Move         r180, r179
+  JumpIfFalse  r180, L22
+  Move         r180, r151
+L22:
+  // where (
+  JumpIfFalse  r180, L8
+  // select { person_name: n.name, movie_title: t.title }
+  Const        r181, "person_name"
+  Const        r182, "name"
+  Index        r183, r28, r182
+  Const        r184, "movie_title"
+  Const        r185, "title"
+  Index        r186, r72, r185
+  Move         r187, r181
+  Move         r188, r183
+  Move         r189, r184
+  Move         r190, r186
+  MakeMap      r191, 2, r187
+  // from an in aka_name
+  Append       r192, r16, r191
+  Move         r16, r192
+L8:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r193, 1
+  Add          r194, r91, r193
+  Move         r91, r194
+  Jump         L23
+L7:
+  // join ml in movie_link on ml.linked_movie_id == t.id
+  Const        r195, 1
+  Add          r196, r80, r195
+  Move         r80, r196
+  Jump         L24
+L6:
+  // join t in title on t.id == ci.movie_id
+  Const        r197, 1
+  Add          r198, r69, r197
+  Move         r69, r198
+  Jump         L25
+L5:
+  // join ci in cast_info on ci.person_id == n.id
+  Const        r199, 1
+  Add          r200, r58, r199
+  Move         r58, r200
+  Jump         L26
+L4:
+  // join it in info_type on it.id == pi.info_type_id
+  Const        r201, 1
+  Add          r202, r47, r201
+  Move         r47, r202
+  Jump         L27
+L3:
+  // join pi in person_info on pi.person_id == an.person_id
+  Const        r203, 1
+  Add          r204, r36, r203
+  Move         r36, r204
+  Jump         L28
+L2:
+  // join n in name on n.id == an.person_id
+  Const        r205, 1
+  Add          r206, r25, r205
+  Move         r25, r206
+  Jump         L29
+L1:
+  // from an in aka_name
+  Const        r207, 1
+  Add          r208, r19, r207
+  Move         r19, r208
+  Jump         L30
+L0:
+  // let rows =
+  Move         r209, r16
+  // of_person: min(from r in rows select r.person_name),
+  Const        r210, "of_person"
+  Const        r211, []
+  IterPrep     r212, r209
+  Len          r213, r212
+  Const        r214, 0
+L32:
+  Less         r215, r214, r213
+  JumpIfFalse  r215, L31
+  Index        r216, r212, r214
+  Move         r217, r216
+  Const        r218, "person_name"
+  Index        r219, r217, r218
+  Append       r220, r211, r219
+  Move         r211, r220
+  Const        r221, 1
+  Add          r222, r214, r221
+  Move         r214, r222
+  Jump         L32
+L31:
+  Min          r223, r211
+  // biography_movie: min(from r in rows select r.movie_title)
+  Const        r224, "biography_movie"
+  Const        r225, []
+  IterPrep     r226, r209
+  Len          r227, r226
+  Const        r228, 0
+L34:
+  Less         r229, r228, r227
+  JumpIfFalse  r229, L33
+  Index        r230, r226, r228
+  Move         r217, r230
+  Const        r231, "movie_title"
+  Index        r232, r217, r231
+  Append       r233, r225, r232
+  Move         r225, r233
+  Const        r234, 1
+  Add          r235, r228, r234
+  Move         r228, r235
+  Jump         L34
+L33:
+  Min          r236, r225
+  // of_person: min(from r in rows select r.person_name),
+  Move         r237, r210
+  Move         r238, r223
+  // biography_movie: min(from r in rows select r.movie_title)
+  Move         r239, r224
+  Move         r240, r236
+  // {
+  MakeMap      r241, 2, r237
+  Move         r242, r241
+  // let result = [
+  MakeList     r243, 1, r242
+  Move         r244, r243
+  // json(result)
+  JSON         r244
+  // expect result == [
+  Const        r245, [{"biography_movie": "Feature Film", "of_person": "Alan Brown"}]
+  Equal        r246, r244, r245
+  Expect       r246
+  Return       r0

--- a/tests/dataset/job/out/q8.ir.out
+++ b/tests/dataset/job/out/q8.ir.out
@@ -1,0 +1,316 @@
+func main (regs=187)
+  // let aka_name = [
+  Const        r0, [{"name": "Y. S.", "person_id": 1}]
+  Move         r1, r0
+  // let cast_info = [
+  Const        r2, [{"movie_id": 10, "note": "(voice: English version)", "person_id": 1, "role_id": 1000}]
+  Move         r3, r2
+  // let company_name = [
+  Const        r4, [{"country_code": "[jp]", "id": 50}]
+  Move         r5, r4
+  // let movie_companies = [
+  Const        r6, [{"company_id": 50, "movie_id": 10, "note": "Studio (Japan)"}]
+  Move         r7, r6
+  // let name = [
+  Const        r8, [{"id": 1, "name": "Yoko Ono"}, {"id": 2, "name": "Yuichi"}]
+  Move         r9, r8
+  // let role_type = [
+  Const        r10, [{"id": 1000, "role": "actress"}]
+  Move         r11, r10
+  // let title = [
+  Const        r12, [{"id": 10, "title": "Dubbed Film"}]
+  Move         r13, r12
+  // from an1 in aka_name
+  Const        r14, []
+  IterPrep     r15, r1
+  Len          r16, r15
+  Const        r17, 0
+L20:
+  Less         r18, r17, r16
+  JumpIfFalse  r18, L0
+  Index        r19, r15, r17
+  Move         r20, r19
+  // join n1 in name on n1.id == an1.person_id
+  IterPrep     r21, r9
+  Len          r22, r21
+  Const        r23, 0
+L19:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L1
+  Index        r25, r21, r23
+  Move         r26, r25
+  Const        r27, "id"
+  Index        r28, r26, r27
+  Const        r29, "person_id"
+  Index        r30, r20, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L2
+  // join ci in cast_info on ci.person_id == an1.person_id
+  IterPrep     r32, r3
+  Len          r33, r32
+  Const        r34, 0
+L18:
+  Less         r35, r34, r33
+  JumpIfFalse  r35, L2
+  Index        r36, r32, r34
+  Move         r37, r36
+  Const        r38, "person_id"
+  Index        r39, r37, r38
+  Const        r40, "person_id"
+  Index        r41, r20, r40
+  Equal        r42, r39, r41
+  JumpIfFalse  r42, L3
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r43, r13
+  Len          r44, r43
+  Const        r45, 0
+L17:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L3
+  Index        r47, r43, r45
+  Move         r48, r47
+  Const        r49, "id"
+  Index        r50, r48, r49
+  Const        r51, "movie_id"
+  Index        r52, r37, r51
+  Equal        r53, r50, r52
+  JumpIfFalse  r53, L4
+  // join mc in movie_companies on mc.movie_id == ci.movie_id
+  IterPrep     r54, r7
+  Len          r55, r54
+  Const        r56, 0
+L16:
+  Less         r57, r56, r55
+  JumpIfFalse  r57, L4
+  Index        r58, r54, r56
+  Move         r59, r58
+  Const        r60, "movie_id"
+  Index        r61, r59, r60
+  Const        r62, "movie_id"
+  Index        r63, r37, r62
+  Equal        r64, r61, r63
+  JumpIfFalse  r64, L5
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r65, r5
+  Len          r66, r65
+  Const        r67, 0
+L15:
+  Less         r68, r67, r66
+  JumpIfFalse  r68, L5
+  Index        r69, r65, r67
+  Move         r70, r69
+  Const        r71, "id"
+  Index        r72, r70, r71
+  Const        r73, "company_id"
+  Index        r74, r59, r73
+  Equal        r75, r72, r74
+  JumpIfFalse  r75, L6
+  // join rt in role_type on rt.id == ci.role_id
+  IterPrep     r76, r11
+  Len          r77, r76
+  Const        r78, 0
+L14:
+  Less         r79, r78, r77
+  JumpIfFalse  r79, L6
+  Index        r80, r76, r78
+  Move         r81, r80
+  Const        r82, "id"
+  Index        r83, r81, r82
+  Const        r84, "role_id"
+  Index        r85, r37, r84
+  Equal        r86, r83, r85
+  JumpIfFalse  r86, L7
+  // where ci.note == "(voice: English version)" &&
+  Const        r87, "note"
+  Index        r88, r37, r87
+  Const        r89, "(voice: English version)"
+  Equal        r90, r88, r89
+  // cn.country_code == "[jp]" &&
+  Const        r91, "country_code"
+  Index        r92, r70, r91
+  Const        r93, "[jp]"
+  Equal        r94, r92, r93
+  // rt.role == "actress"
+  Const        r95, "role"
+  Index        r96, r81, r95
+  Const        r97, "actress"
+  Equal        r98, r96, r97
+  // where ci.note == "(voice: English version)" &&
+  Move         r99, r90
+  JumpIfFalse  r99, L8
+  Move         r99, r94
+L8:
+  // cn.country_code == "[jp]" &&
+  Move         r100, r99
+  JumpIfFalse  r100, L9
+  Const        r101, "note"
+  Index        r102, r59, r101
+  // mc.note.contains("(Japan)") &&
+  Const        r103, "(Japan)"
+  In           r104, r103, r102
+  // cn.country_code == "[jp]" &&
+  Move         r100, r104
+L9:
+  // mc.note.contains("(Japan)") &&
+  Move         r105, r100
+  JumpIfFalse  r105, L10
+  Const        r106, "note"
+  Index        r107, r59, r106
+  // (!mc.note.contains("(USA)")) &&
+  Const        r108, "(USA)"
+  In           r109, r108, r107
+  Not          r110, r109
+  // mc.note.contains("(Japan)") &&
+  Move         r105, r110
+L10:
+  // (!mc.note.contains("(USA)")) &&
+  Move         r111, r105
+  JumpIfFalse  r111, L11
+  Const        r112, "name"
+  Index        r113, r26, r112
+  // n1.name.contains("Yo") &&
+  Const        r114, "Yo"
+  In           r115, r114, r113
+  // (!mc.note.contains("(USA)")) &&
+  Move         r111, r115
+L11:
+  // n1.name.contains("Yo") &&
+  Move         r116, r111
+  JumpIfFalse  r116, L12
+  Const        r117, "name"
+  Index        r118, r26, r117
+  // (!n1.name.contains("Yu")) &&
+  Const        r119, "Yu"
+  In           r120, r119, r118
+  Not          r121, r120
+  // n1.name.contains("Yo") &&
+  Move         r116, r121
+L12:
+  // (!n1.name.contains("Yu")) &&
+  Move         r122, r116
+  JumpIfFalse  r122, L13
+  Move         r122, r98
+L13:
+  // where ci.note == "(voice: English version)" &&
+  JumpIfFalse  r122, L7
+  // select { pseudonym: an1.name, movie_title: t.title }
+  Const        r123, "pseudonym"
+  Const        r124, "name"
+  Index        r125, r20, r124
+  Const        r126, "movie_title"
+  Const        r127, "title"
+  Index        r128, r48, r127
+  Move         r129, r123
+  Move         r130, r125
+  Move         r131, r126
+  Move         r132, r128
+  MakeMap      r133, 2, r129
+  // from an1 in aka_name
+  Append       r134, r14, r133
+  Move         r14, r134
+L7:
+  // join rt in role_type on rt.id == ci.role_id
+  Const        r135, 1
+  Add          r136, r78, r135
+  Move         r78, r136
+  Jump         L14
+L6:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r137, 1
+  Add          r138, r67, r137
+  Move         r67, r138
+  Jump         L15
+L5:
+  // join mc in movie_companies on mc.movie_id == ci.movie_id
+  Const        r139, 1
+  Add          r140, r56, r139
+  Move         r56, r140
+  Jump         L16
+L4:
+  // join t in title on t.id == ci.movie_id
+  Const        r141, 1
+  Add          r142, r45, r141
+  Move         r45, r142
+  Jump         L17
+L3:
+  // join ci in cast_info on ci.person_id == an1.person_id
+  Const        r143, 1
+  Add          r144, r34, r143
+  Move         r34, r144
+  Jump         L18
+L2:
+  // join n1 in name on n1.id == an1.person_id
+  Const        r145, 1
+  Add          r146, r23, r145
+  Move         r23, r146
+  Jump         L19
+L1:
+  // from an1 in aka_name
+  Const        r147, 1
+  Add          r148, r17, r147
+  Move         r17, r148
+  Jump         L20
+L0:
+  // let eligible =
+  Move         r149, r14
+  // actress_pseudonym: min(from x in eligible select x.pseudonym),
+  Const        r150, "actress_pseudonym"
+  Const        r151, []
+  IterPrep     r152, r149
+  Len          r153, r152
+  Const        r154, 0
+L22:
+  Less         r155, r154, r153
+  JumpIfFalse  r155, L21
+  Index        r156, r152, r154
+  Move         r157, r156
+  Const        r158, "pseudonym"
+  Index        r159, r157, r158
+  Append       r160, r151, r159
+  Move         r151, r160
+  Const        r161, 1
+  Add          r162, r154, r161
+  Move         r154, r162
+  Jump         L22
+L21:
+  Min          r163, r151
+  // japanese_movie_dubbed: min(from x in eligible select x.movie_title)
+  Const        r164, "japanese_movie_dubbed"
+  Const        r165, []
+  IterPrep     r166, r149
+  Len          r167, r166
+  Const        r168, 0
+L24:
+  Less         r169, r168, r167
+  JumpIfFalse  r169, L23
+  Index        r170, r166, r168
+  Move         r157, r170
+  Const        r171, "movie_title"
+  Index        r172, r157, r171
+  Append       r173, r165, r172
+  Move         r165, r173
+  Const        r174, 1
+  Add          r175, r168, r174
+  Move         r168, r175
+  Jump         L24
+L23:
+  Min          r176, r165
+  // actress_pseudonym: min(from x in eligible select x.pseudonym),
+  Move         r177, r150
+  Move         r178, r163
+  // japanese_movie_dubbed: min(from x in eligible select x.movie_title)
+  Move         r179, r164
+  Move         r180, r176
+  // {
+  MakeMap      r181, 2, r177
+  Move         r182, r181
+  // let result = [
+  MakeList     r183, 1, r182
+  Move         r184, r183
+  // print(result)
+  Print        r184
+  // expect result == [
+  Const        r185, [{"actress_pseudonym": "Y. S.", "japanese_movie_dubbed": "Dubbed Film"}]
+  Equal        r186, r184, r185
+  Expect       r186
+  Return       r0

--- a/tests/dataset/job/out/q9.ir.out
+++ b/tests/dataset/job/out/q9.ir.out
@@ -1,0 +1,382 @@
+func main (regs=230)
+  // let aka_name = [
+  Const        r0, [{"name": "A. N. G.", "person_id": 1}, {"name": "J. D.", "person_id": 2}]
+  Move         r1, r0
+  // let char_name = [
+  Const        r2, [{"id": 10, "name": "Angel"}, {"id": 20, "name": "Devil"}]
+  Move         r3, r2
+  // let cast_info = [
+  Const        r4, [{"movie_id": 100, "note": "(voice)", "person_id": 1, "person_role_id": 10, "role_id": 1000}, {"movie_id": 200, "note": "(voice)", "person_id": 2, "person_role_id": 20, "role_id": 1000}]
+  Move         r5, r4
+  // let company_name = [
+  Const        r6, [{"country_code": "[us]", "id": 100}, {"country_code": "[gb]", "id": 200}]
+  Move         r7, r6
+  // let movie_companies = [
+  Const        r8, [{"company_id": 100, "movie_id": 100, "note": "ACME Studios (USA)"}, {"company_id": 200, "movie_id": 200, "note": "Maple Films"}]
+  Move         r9, r8
+  // let name = [
+  Const        r10, [{"gender": "f", "id": 1, "name": "Angela Smith"}, {"gender": "m", "id": 2, "name": "John Doe"}]
+  Move         r11, r10
+  // let role_type = [
+  Const        r12, [{"id": 1000, "role": "actress"}, {"id": 2000, "role": "actor"}]
+  Move         r13, r12
+  // let title = [
+  Const        r14, [{"id": 100, "production_year": 2010, "title": "Famous Film"}, {"id": 200, "production_year": 1999, "title": "Old Movie"}]
+  Move         r15, r14
+  // from an in aka_name
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, 0
+L24:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L0
+  Index        r21, r17, r19
+  Move         r22, r21
+  // join n in name on an.person_id == n.id
+  IterPrep     r23, r11
+  Len          r24, r23
+  Const        r25, 0
+L23:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L1
+  Index        r27, r23, r25
+  Move         r28, r27
+  Const        r29, "person_id"
+  Index        r30, r22, r29
+  Const        r31, "id"
+  Index        r32, r28, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join ci in cast_info on ci.person_id == n.id
+  IterPrep     r34, r5
+  Len          r35, r34
+  Const        r36, 0
+L22:
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L2
+  Index        r38, r34, r36
+  Move         r39, r38
+  Const        r40, "person_id"
+  Index        r41, r39, r40
+  Const        r42, "id"
+  Index        r43, r28, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L3
+  // join chn in char_name on chn.id == ci.person_role_id
+  IterPrep     r45, r3
+  Len          r46, r45
+  Const        r47, 0
+L21:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L3
+  Index        r49, r45, r47
+  Move         r50, r49
+  Const        r51, "id"
+  Index        r52, r50, r51
+  Const        r53, "person_role_id"
+  Index        r54, r39, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L4
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r56, r15
+  Len          r57, r56
+  Const        r58, 0
+L20:
+  Less         r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r60, r56, r58
+  Move         r61, r60
+  Const        r62, "id"
+  Index        r63, r61, r62
+  Const        r64, "movie_id"
+  Index        r65, r39, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L5
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r67, r9
+  Len          r68, r67
+  Const        r69, 0
+L19:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L5
+  Index        r71, r67, r69
+  Move         r72, r71
+  Const        r73, "movie_id"
+  Index        r74, r72, r73
+  Const        r75, "id"
+  Index        r76, r61, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L6
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r78, r7
+  Len          r79, r78
+  Const        r80, 0
+L18:
+  Less         r81, r80, r79
+  JumpIfFalse  r81, L6
+  Index        r82, r78, r80
+  Move         r83, r82
+  Const        r84, "id"
+  Index        r85, r83, r84
+  Const        r86, "company_id"
+  Index        r87, r72, r86
+  Equal        r88, r85, r87
+  JumpIfFalse  r88, L7
+  // join rt in role_type on rt.id == ci.role_id
+  IterPrep     r89, r13
+  Len          r90, r89
+  Const        r91, 0
+L17:
+  Less         r92, r91, r90
+  JumpIfFalse  r92, L7
+  Index        r93, r89, r91
+  Move         r94, r93
+  Const        r95, "id"
+  Index        r96, r94, r95
+  Const        r97, "role_id"
+  Index        r98, r39, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L8
+  // where (ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) &&
+  Const        r100, "note"
+  Index        r101, r39, r100
+  Const        r102, ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]
+  In           r103, r101, r102
+  // t.production_year >= 2005 && t.production_year <= 2015
+  Const        r104, "production_year"
+  Index        r105, r61, r104
+  Const        r106, 2005
+  LessEq       r107, r106, r105
+  Const        r108, "production_year"
+  Index        r109, r61, r108
+  Const        r110, 2015
+  LessEq       r111, r109, r110
+  // cn.country_code == "[us]" &&
+  Const        r112, "country_code"
+  Index        r113, r83, r112
+  Const        r114, "[us]"
+  Equal        r115, r113, r114
+  // n.gender == "f" &&
+  Const        r116, "gender"
+  Index        r117, r28, r116
+  Const        r118, "f"
+  Equal        r119, r117, r118
+  // rt.role == "actress" &&
+  Const        r120, "role"
+  Index        r121, r94, r120
+  Const        r122, "actress"
+  Equal        r123, r121, r122
+  // where (ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) &&
+  Move         r124, r103
+  JumpIfFalse  r124, L9
+  Move         r124, r115
+L9:
+  // cn.country_code == "[us]" &&
+  Move         r125, r124
+  JumpIfFalse  r125, L10
+  Const        r126, "note"
+  Index        r127, r72, r126
+  // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r128, "(USA)"
+  In           r129, r128, r127
+  Move         r130, r129
+  JumpIfTrue   r130, L11
+  Const        r131, "note"
+  Index        r132, r72, r131
+  Const        r133, "(worldwide)"
+  In           r134, r133, r132
+  Move         r130, r134
+L11:
+  // cn.country_code == "[us]" &&
+  Move         r125, r130
+L10:
+  // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Move         r135, r125
+  JumpIfFalse  r135, L12
+  Move         r135, r119
+L12:
+  // n.gender == "f" &&
+  Move         r136, r135
+  JumpIfFalse  r136, L13
+  Const        r137, "name"
+  Index        r138, r28, r137
+  // n.name.contains("Ang") &&
+  Const        r139, "Ang"
+  In           r140, r139, r138
+  // n.gender == "f" &&
+  Move         r136, r140
+L13:
+  // n.name.contains("Ang") &&
+  Move         r141, r136
+  JumpIfFalse  r141, L14
+  Move         r141, r123
+L14:
+  // rt.role == "actress" &&
+  Move         r142, r141
+  JumpIfFalse  r142, L15
+  Move         r142, r107
+L15:
+  // t.production_year >= 2005 && t.production_year <= 2015
+  Move         r143, r142
+  JumpIfFalse  r143, L16
+  Move         r143, r111
+L16:
+  // where (ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) &&
+  JumpIfFalse  r143, L8
+  // select { alt: an.name, character: chn.name, movie: t.title }
+  Const        r144, "alt"
+  Const        r145, "name"
+  Index        r146, r22, r145
+  Const        r147, "character"
+  Const        r148, "name"
+  Index        r149, r50, r148
+  Const        r150, "movie"
+  Const        r151, "title"
+  Index        r152, r61, r151
+  Move         r153, r144
+  Move         r154, r146
+  Move         r155, r147
+  Move         r156, r149
+  Move         r157, r150
+  Move         r158, r152
+  MakeMap      r159, 3, r153
+  // from an in aka_name
+  Append       r160, r16, r159
+  Move         r16, r160
+L8:
+  // join rt in role_type on rt.id == ci.role_id
+  Const        r161, 1
+  Add          r162, r91, r161
+  Move         r91, r162
+  Jump         L17
+L7:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r163, 1
+  Add          r164, r80, r163
+  Move         r80, r164
+  Jump         L18
+L6:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r165, 1
+  Add          r166, r69, r165
+  Move         r69, r166
+  Jump         L19
+L5:
+  // join t in title on t.id == ci.movie_id
+  Const        r167, 1
+  Add          r168, r58, r167
+  Move         r58, r168
+  Jump         L20
+L4:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r169, 1
+  Add          r170, r47, r169
+  Move         r47, r170
+  Jump         L21
+L3:
+  // join ci in cast_info on ci.person_id == n.id
+  Const        r171, 1
+  Add          r172, r36, r171
+  Move         r36, r172
+  Jump         L22
+L2:
+  // join n in name on an.person_id == n.id
+  Const        r173, 1
+  Add          r174, r25, r173
+  Move         r25, r174
+  Jump         L23
+L1:
+  // from an in aka_name
+  Const        r175, 1
+  Add          r176, r19, r175
+  Move         r19, r176
+  Jump         L24
+L0:
+  // let matches =
+  Move         r177, r16
+  // alternative_name: min(from x in matches select x.alt),
+  Const        r178, "alternative_name"
+  Const        r179, []
+  IterPrep     r180, r177
+  Len          r181, r180
+  Const        r182, 0
+L26:
+  Less         r183, r182, r181
+  JumpIfFalse  r183, L25
+  Index        r184, r180, r182
+  Move         r185, r184
+  Const        r186, "alt"
+  Index        r187, r185, r186
+  Append       r188, r179, r187
+  Move         r179, r188
+  Const        r189, 1
+  Add          r190, r182, r189
+  Move         r182, r190
+  Jump         L26
+L25:
+  Min          r191, r179
+  // character_name: min(from x in matches select x.character),
+  Const        r192, "character_name"
+  Const        r193, []
+  IterPrep     r194, r177
+  Len          r195, r194
+  Const        r196, 0
+L28:
+  Less         r197, r196, r195
+  JumpIfFalse  r197, L27
+  Index        r198, r194, r196
+  Move         r185, r198
+  Const        r199, "character"
+  Index        r200, r185, r199
+  Append       r201, r193, r200
+  Move         r193, r201
+  Const        r202, 1
+  Add          r203, r196, r202
+  Move         r196, r203
+  Jump         L28
+L27:
+  Min          r204, r193
+  // movie: min(from x in matches select x.movie)
+  Const        r205, "movie"
+  Const        r206, []
+  IterPrep     r207, r177
+  Len          r208, r207
+  Const        r209, 0
+L30:
+  Less         r210, r209, r208
+  JumpIfFalse  r210, L29
+  Index        r211, r207, r209
+  Move         r185, r211
+  Const        r212, "movie"
+  Index        r213, r185, r212
+  Append       r214, r206, r213
+  Move         r206, r214
+  Const        r215, 1
+  Add          r216, r209, r215
+  Move         r209, r216
+  Jump         L30
+L29:
+  Min          r217, r206
+  // alternative_name: min(from x in matches select x.alt),
+  Move         r218, r178
+  Move         r219, r191
+  // character_name: min(from x in matches select x.character),
+  Move         r220, r192
+  Move         r221, r204
+  // movie: min(from x in matches select x.movie)
+  Move         r222, r205
+  Move         r223, r217
+  // {
+  MakeMap      r224, 3, r218
+  Move         r225, r224
+  // let result = [
+  MakeList     r226, 1, r225
+  Move         r227, r226
+  // json(result)
+  JSON         r227
+  // expect result == [
+  Const        r228, [{"alternative_name": "A. N. G.", "character_name": "Angel", "movie": "Famous Film"}]
+  Equal        r229, r227, r228
+  Expect       r229
+  Return       r0

--- a/tests/dataset/job/q3.mochi
+++ b/tests/dataset/job/q3.mochi
@@ -29,12 +29,13 @@ let allowed_infos = [
 
 let candidate_titles =
   from k in keyword
-  where k.keyword.contains("sequel")
   join mk in movie_keyword on mk.keyword_id == k.id
   join mi in movie_info on mi.movie_id == mk.movie_id
-  where mi.info in allowed_infos
   join t in title on t.id == mi.movie_id
-  where t.production_year > 2005
+  where k.keyword.contains("sequel") &&
+        mi.info in allowed_infos &&
+        t.production_year > 2005 &&
+        mk.movie_id == mi.movie_id
   select t.title
 
 let result = [{ movie_title: min(candidate_titles) }]

--- a/tests/dataset/job/q7.mochi
+++ b/tests/dataset/job/q7.mochi
@@ -48,11 +48,11 @@ let rows =
   join ml in movie_link on ml.linked_movie_id == t.id
   join lt in link_type on lt.id == ml.link_type_id
   where (
-    an.name LIKE "%a%" &&
+    an.name.contains("a") &&
     it.info == "mini biography" &&
     lt.link == "features" &&
     n.name_pcode_cf >= "A" && n.name_pcode_cf <= "F" &&
-    (n.gender == "m" || (n.gender == "f" && n.name LIKE "B%")) &&
+    (n.gender == "m" || (n.gender == "f" && n.name.starts_with("B"))) &&
     pi.note == "Volker Boehm" &&
     t.production_year >= 1980 && t.production_year <= 1995 &&
     pi.person_id == an.person_id &&

--- a/tests/dataset/job/q8.mochi
+++ b/tests/dataset/job/q8.mochi
@@ -38,9 +38,9 @@ let eligible =
   where ci.note == "(voice: English version)" &&
         cn.country_code == "[jp]" &&
         mc.note.contains("(Japan)") &&
-        !(mc.note.contains("(USA)")) &&
+        (!mc.note.contains("(USA)")) &&
         n1.name.contains("Yo") &&
-        !(n1.name.contains("Yu")) &&
+        (!n1.name.contains("Yu")) &&
         rt.role == "actress"
   select { pseudonym: an1.name, movie_title: t.title }
 

--- a/tests/dataset/job/q9.mochi
+++ b/tests/dataset/job/q9.mochi
@@ -49,7 +49,6 @@ let matches =
   join rt in role_type on rt.id == ci.role_id
   where (ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) &&
         cn.country_code == "[us]" &&
-        mc.note != nil &&
         (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
         n.gender == "f" &&
         n.name.contains("Ang") &&


### PR DESCRIPTION
## Summary
- add `starts_with` string helper in the VM compiler
- update JOB dataset programs for parser limitations
- generate `.ir.out` for JOB q2–q10 queries

## Testing
- `go test ./... -run TestVM_JOB -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_685e685f27c48320b4f805e3a6337039