### PR TITLE
Add JOB dataset Go compile test

### DIFF
--- a/compile/go/compiler_test.go
+++ b/compile/go/compiler_test.go
@@ -226,6 +226,53 @@ func TestGoCompiler_TPCHQ1(t *testing.T) {
 	}
 }
 
+func TestGoCompiler_JOBQ1(t *testing.T) {
+	root := findRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := gocode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+
+	codeWantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "go", "q1.go.out")
+	wantCode, err := os.ReadFile(codeWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q1.go.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(wantCode))
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("go", "run", file)
+	cmd.Env = append(os.Environ(), "GO111MODULE=on", "LLM_PROVIDER=echo")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run error: %v\n%s", err, out)
+	}
+	gotOut := bytes.TrimSpace(out)
+	outWantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "go", "q1.out")
+	wantOut, err := os.ReadFile(outWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+		t.Errorf("output mismatch for q1.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", gotOut, bytes.TrimSpace(wantOut))
+	}
+}
+
 func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -127,24 +127,38 @@ const (
 		"        m := s[0]\n" +
 		"        for _, n := range s[1:] { if n < m { m = n } }\n" +
 		"        return m\n" +
+		"    case []string:\n" +
+		"        if len(s) == 0 { return \"\" }\n" +
+		"        m := s[0]\n" +
+		"        for _, n := range s[1:] { if n < m { m = n } }\n" +
+		"        return m\n" +
 		"    case []any:\n" +
 		"        if len(s) == 0 { return 0 }\n" +
-		"        var m float64\n" +
-		"        var isFloat bool\n" +
-		"        switch n := s[0].(type) {\n" +
-		"        case int: m = float64(n)\n" +
-		"        case int64: m = float64(n)\n" +
-		"        case float64: m = n; isFloat = true\n" +
-		"        default: panic(\"min() expects numbers\") }\n" +
-		"        for _, it := range s[1:] {\n" +
-		"            switch v := it.(type) {\n" +
-		"            case int: if float64(v) < m { m = float64(v) }\n" +
-		"            case int64: if float64(v) < m { m = float64(v) }\n" +
-		"            case float64: if v < m { m = v }; isFloat = true\n" +
-		"            default: panic(\"min() expects numbers\") }\n" +
+		"        switch s[0].(type) {\n" +
+		"        case string:\n" +
+		"            m := s[0].(string)\n" +
+		"            for _, it := range s[1:] { v := it.(string); if v < m { m = v } }\n" +
+		"            return m\n" +
+		"        case int, int64, float64:\n" +
+		"            var m float64\n" +
+		"            var isFloat bool\n" +
+		"            switch n := s[0].(type) {\n" +
+		"            case int: m = float64(n)\n" +
+		"            case int64: m = float64(n)\n" +
+		"            case float64: m = n; isFloat = true\n" +
+		"            }\n" +
+		"            for _, it := range s[1:] {\n" +
+		"                switch v := it.(type) {\n" +
+		"                case int: if float64(v) < m { m = float64(v) }\n" +
+		"                case int64: if float64(v) < m { m = float64(v) }\n" +
+		"                case float64: if v < m { m = v }; isFloat = true\n" +
+		"                }\n" +
+		"            }\n" +
+		"            if isFloat { return m }\n" +
+		"            return int(m)\n" +
+		"        default:\n" +
+		"            panic(\"min() expects numbers or strings\")\n" +
 		"        }\n" +
-		"        if isFloat { return m }\n" +
-		"        return int(m)\n" +
 		"    default:\n" +
 		"        rv := reflect.ValueOf(v)\n" +
 		"        if rv.Kind() == reflect.Slice {\n" +

--- a/tests/dataset/job/compiler/go/q1.go.out
+++ b/tests/dataset/job/compiler/go/q1.go.out
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"mochi/runtime/data"
+	"reflect"
+	"strings"
+	"time"
+)
+
+func expect(cond bool) {
+	if !cond {
+		panic("expect failed")
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Milliseconds()))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func printTestStart(name string) {
+	fmt.Printf("   test %-30s ...", name)
+}
+
+func printTestPass(d time.Duration) {
+	fmt.Printf(" ok (%s)\n", formatDuration(d))
+}
+
+func printTestFail(err error, d time.Duration) {
+	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
+}
+
+func test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production() {
+	expect(_equal(result, map[string]any{
+		"production_note": "ACME (co-production)",
+		"movie_title":     "Good Movie",
+		"movie_year":      1995,
+	}))
+}
+
+type Company_typeItem struct {
+	Id   int    `json:"id"`
+	Kind string `json:"kind"`
+}
+
+var company_type []Company_typeItem = []Company_typeItem{Company_typeItem{
+	Id:   1,
+	Kind: "production companies",
+}, Company_typeItem{
+	Id:   2,
+	Kind: "distributors",
+}}
+
+type Info_typeItem struct {
+	Id   int    `json:"id"`
+	Info string `json:"info"`
+}
+
+var info_type []Info_typeItem = []Info_typeItem{Info_typeItem{
+	Id:   10,
+	Info: "top 250 rank",
+}, Info_typeItem{
+	Id:   20,
+	Info: "bottom 10 rank",
+}}
+
+type TitleItem struct {
+	Id              int    `json:"id"`
+	Title           string `json:"title"`
+	Production_year int    `json:"production_year"`
+}
+
+var title []TitleItem = []TitleItem{TitleItem{
+	Id:              100,
+	Title:           "Good Movie",
+	Production_year: 1995,
+}, TitleItem{
+	Id:              200,
+	Title:           "Bad Movie",
+	Production_year: 2000,
+}}
+
+type Movie_companiesItem struct {
+	Movie_id        int    `json:"movie_id"`
+	Company_type_id int    `json:"company_type_id"`
+	Note            string `json:"note"`
+}
+
+var movie_companies []Movie_companiesItem = []Movie_companiesItem{Movie_companiesItem{
+	Movie_id:        100,
+	Company_type_id: 1,
+	Note:            "ACME (co-production)",
+}, Movie_companiesItem{
+	Movie_id:        200,
+	Company_type_id: 1,
+	Note:            "MGM (as Metro-Goldwyn-Mayer Pictures)",
+}}
+
+type Movie_info_idxItem struct {
+	Movie_id     int `json:"movie_id"`
+	Info_type_id int `json:"info_type_id"`
+}
+
+var movie_info_idx []Movie_info_idxItem = []Movie_info_idxItem{Movie_info_idxItem{
+	Movie_id:     100,
+	Info_type_id: 10,
+}, Movie_info_idxItem{
+	Movie_id:     200,
+	Info_type_id: 20,
+}}
+var filtered []map[string]any = func() []map[string]any {
+	_res := []map[string]any{}
+	for _, ct := range company_type {
+		for _, mc := range movie_companies {
+			if !(ct.Id == mc.Company_type_id) {
+				continue
+			}
+			for _, t := range title {
+				if !(t.Id == mc.Movie_id) {
+					continue
+				}
+				for _, mi := range movie_info_idx {
+					if !(mi.Movie_id == t.Id) {
+						continue
+					}
+					for _, it := range info_type {
+						if !(it.Id == mi.Info_type_id) {
+							continue
+						}
+						if (((ct.Kind == "production companies") && (it.Info == "top 250 rank")) && (!strings.Contains(mc.Note, "(as Metro-Goldwyn-Mayer Pictures)"))) && (strings.Contains(mc.Note, "(co-production)") || strings.Contains(mc.Note, "(presents)")) {
+							if (((ct.Kind == "production companies") && (it.Info == "top 250 rank")) && (!strings.Contains(mc.Note, "(as Metro-Goldwyn-Mayer Pictures)"))) && (strings.Contains(mc.Note, "(co-production)") || strings.Contains(mc.Note, "(presents)")) {
+								_res = append(_res, map[string]any{
+									"note":  mc.Note,
+									"title": t.Title,
+									"year":  t.Production_year,
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return _res
+}()
+var result map[string]any = map[string]any{
+	"production_note": _min(func() []any {
+		_res := []any{}
+		for _, r := range filtered {
+			_res = append(_res, r["note"])
+		}
+		return _res
+	}()),
+	"movie_title": _min(func() []any {
+		_res := []any{}
+		for _, r := range filtered {
+			_res = append(_res, r["title"])
+		}
+		return _res
+	}()),
+	"movie_year": _min(func() []any {
+		_res := []any{}
+		for _, r := range filtered {
+			_res = append(_res, r["year"])
+		}
+		return _res
+	}()),
+}
+
+func main() {
+	failures := 0
+	func() { b, _ := json.Marshal([]map[string]any{result}); fmt.Println(string(b)) }()
+	{
+		printTestStart("Q1 returns min note, title and year for top ranked co-production")
+		start := time.Now()
+		var failed error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					failed = fmt.Errorf("%v", r)
+				}
+			}()
+			test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production()
+		}()
+		if failed != nil {
+			failures++
+			printTestFail(failed, time.Since(start))
+		} else {
+			printTestPass(time.Since(start))
+		}
+	}
+	if failures > 0 {
+		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
+	}
+}
+
+func _equal(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for i := 0; i < av.Len(); i++ {
+			if !_equal(av.Index(i).Interface(), bv.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if av.Kind() == reflect.Map && bv.Kind() == reflect.Map {
+		if av.Len() != bv.Len() {
+			return false
+		}
+		for _, k := range av.MapKeys() {
+			bvVal := bv.MapIndex(k)
+			if !bvVal.IsValid() {
+				return false
+			}
+			if !_equal(av.MapIndex(k).Interface(), bvVal.Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	if (av.Kind() == reflect.Int || av.Kind() == reflect.Int64 || av.Kind() == reflect.Float64) &&
+		(bv.Kind() == reflect.Int || bv.Kind() == reflect.Int64 || bv.Kind() == reflect.Float64) {
+		return av.Convert(reflect.TypeOf(float64(0))).Float() == bv.Convert(reflect.TypeOf(float64(0))).Float()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func _min(v any) any {
+	if g, ok := v.(*data.Group); ok {
+		v = g.Items
+	}
+	switch s := v.(type) {
+	case []int:
+		if len(s) == 0 {
+			return 0
+		}
+		m := s[0]
+		for _, n := range s[1:] {
+			if n < m {
+				m = n
+			}
+		}
+		return m
+	case []float64:
+		if len(s) == 0 {
+			return 0.0
+		}
+		m := s[0]
+		for _, n := range s[1:] {
+			if n < m {
+				m = n
+			}
+		}
+		return m
+	case []string:
+		if len(s) == 0 {
+			return ""
+		}
+		m := s[0]
+		for _, n := range s[1:] {
+			if n < m {
+				m = n
+			}
+		}
+		return m
+	case []any:
+		if len(s) == 0 {
+			return 0
+		}
+		switch s[0].(type) {
+		case string:
+			m := s[0].(string)
+			for _, it := range s[1:] {
+				v := it.(string)
+				if v < m {
+					m = v
+				}
+			}
+			return m
+		case int, int64, float64:
+			var m float64
+			var isFloat bool
+			switch n := s[0].(type) {
+			case int:
+				m = float64(n)
+			case int64:
+				m = float64(n)
+			case float64:
+				m = n
+				isFloat = true
+			}
+			for _, it := range s[1:] {
+				switch v := it.(type) {
+				case int:
+					if float64(v) < m {
+						m = float64(v)
+					}
+				case int64:
+					if float64(v) < m {
+						m = float64(v)
+					}
+				case float64:
+					if v < m {
+						m = v
+					}
+					isFloat = true
+				}
+			}
+			if isFloat {
+				return m
+			}
+			return int(m)
+		default:
+			panic("min() expects numbers or strings")
+		}
+	default:
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Slice {
+			if rv.Len() == 0 {
+				return 0
+			}
+			m := rv.Index(0).Interface()
+			switch m.(type) {
+			case int, int64, float64:
+				items := make([]any, rv.Len())
+				for i := 0; i < rv.Len(); i++ {
+					items[i] = rv.Index(i).Interface()
+				}
+				return _min(items)
+			}
+		}
+		panic("min() expects list or group")
+	}
+}

--- a/tests/dataset/job/compiler/go/q1.out
+++ b/tests/dataset/job/compiler/go/q1.out
@@ -1,0 +1,2 @@
+[{"movie_title":"Good Movie","movie_year":1995,"production_note":"ACME (co-production)"}]
+   test Q1 returns min note, title and year for top ranked co-production ... ok (4.0µs)


### PR DESCRIPTION
## Summary
- support chained `contains` on strings in type inference
- compile string `contains` calls to `strings.Contains`
- extend `_min` helper to handle strings
- add JOB query 1 Go compiler golden output
- test Go compiler on JOB query 1

## Testing
- `go test -tags slow ./compile/go -run TestGoCompiler_JOBQ1 -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e6970259c8320b385e6296f7a42f6