### PR TITLE
Add null literal and JOB IR files

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -25,7 +25,7 @@ func (b *boolLit) Capture(values []string) error {
 var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Comment", Pattern: `//[^\n]*|/\*([^*]|\*+[^*/])*\*+/`},
 	{Name: "Bool", Pattern: `\b(true|false)\b`},
-	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|import|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch|load|save|package|export|fact|rule|all)\b`},
+	{Name: "Keyword", Pattern: `\b(test|expect|agent|intent|on|stream|emit|type|fun|extern|import|return|break|continue|let|var|if|else|for|while|in|generate|match|fetch|load|save|package|export|fact|rule|all|null)\b`},
 	{Name: "Ident", Pattern: `[\p{L}\p{So}_][\p{L}\p{So}\p{N}_]*`},
 	{Name: "Float", Pattern: `\d+\.\d+`},
 	{Name: "Int", Pattern: `\d+`},
@@ -316,7 +316,7 @@ type BinaryExpr struct {
 type BinaryOp struct {
 	Pos   lexer.Position
 	Op    string       `parser:"@('==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '%' | 'in' | '&&' | '||' | 'union' | 'except' | 'intersect')"`
-       All   bool         `parser:"[ @'all' ]"`
+	All   bool         `parser:"[ @'all' ]"`
 	Right *PostfixExpr `parser:"@@"`
 }
 
@@ -526,6 +526,7 @@ type Literal struct {
 	Float *float64 `parser:"| @Float"`
 	Bool  *boolLit `parser:"| @('true' | 'false')"`
 	Str   *string  `parser:"| @String"`
+	Null  bool     `parser:"| @'null'"`
 }
 
 // --- Stream / Struct ---

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2438,6 +2438,11 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 			v := Value{Tag: interpreter.TagBool, Bool: bool(*p.Lit.Bool)}
 			fc.emit(p.Pos, Instr{Op: OpConst, A: dst, Val: v})
 			return dst
+		case p.Lit.Null:
+			dst := fc.newReg()
+			v := Value{Tag: interpreter.TagNull}
+			fc.emit(p.Pos, Instr{Op: OpConst, A: dst, Val: v})
+			return dst
 		}
 	}
 
@@ -4304,6 +4309,9 @@ func constPrimary(p *parser.Primary) (Value, bool) {
 		if p.Lit.Str != nil {
 			return Value{Tag: interpreter.TagStr, Str: *p.Lit.Str}, true
 		}
+		if p.Lit.Null {
+			return Value{Tag: interpreter.TagNull}, true
+		}
 	}
 	if p.List != nil {
 		return constList(p.List)
@@ -4324,6 +4332,8 @@ func literalToValue(l *parser.Literal) (Value, bool) {
 		return Value{Tag: interpreter.TagStr, Str: *l.Str}, true
 	case l.Bool != nil:
 		return Value{Tag: interpreter.TagBool, Bool: bool(*l.Bool)}, true
+	case l.Null:
+		return Value{Tag: interpreter.TagNull}, true
 	default:
 		return Value{}, false
 	}

--- a/tests/dataset/job/out/q11.ir.out
+++ b/tests/dataset/job/out/q11.ir.out
@@ -1,0 +1,415 @@
+func main (regs=248)
+  // let company_name = [
+  Const        r0, [{"country_code": "[us]", "id": 1, "name": "Best Film Co"}, {"country_code": "[de]", "id": 2, "name": "Warner Studios"}, {"country_code": "[pl]", "id": 3, "name": "Polish Films"}]
+  Move         r1, r0
+  // let company_type = [
+  Const        r2, [{"id": 1, "kind": "production companies"}, {"id": 2, "kind": "distributors"}]
+  Move         r3, r2
+  // let keyword = [
+  Const        r4, [{"id": 1, "keyword": "sequel"}, {"id": 2, "keyword": "thriller"}]
+  Move         r5, r4
+  // let link_type = [
+  Const        r6, [{"id": 1, "link": "follow-up"}, {"id": 2, "link": "follows from"}, {"id": 3, "link": "remake"}]
+  Move         r7, r6
+  // let movie_companies = [
+  Const        r8, [{"company_id": 1, "company_type_id": 1, "movie_id": 10, "note": nil}, {"company_id": 2, "company_type_id": 1, "movie_id": 20, "note": nil}, {"company_id": 3, "company_type_id": 1, "movie_id": 30, "note": nil}]
+  Move         r9, r8
+  // let movie_keyword = [
+  Const        r10, [{"keyword_id": 1, "movie_id": 10}, {"keyword_id": 1, "movie_id": 20}, {"keyword_id": 2, "movie_id": 20}, {"keyword_id": 1, "movie_id": 30}]
+  Move         r11, r10
+  // let movie_link = [
+  Const        r12, [{"link_type_id": 1, "movie_id": 10}, {"link_type_id": 2, "movie_id": 20}, {"link_type_id": 3, "movie_id": 30}]
+  Move         r13, r12
+  // let title = [
+  Const        r14, [{"id": 10, "production_year": 1960, "title": "Alpha"}, {"id": 20, "production_year": 1970, "title": "Beta"}, {"id": 30, "production_year": 1985, "title": "Polish Movie"}]
+  Move         r15, r14
+  // from cn in company_name
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, 0
+L27:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L0
+  Index        r21, r17, r19
+  Move         r22, r21
+  // join mc in movie_companies on mc.company_id == cn.id
+  IterPrep     r23, r9
+  Len          r24, r23
+  Const        r25, 0
+L26:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L1
+  Index        r27, r23, r25
+  Move         r28, r27
+  Const        r29, "company_id"
+  Index        r30, r28, r29
+  Const        r31, "id"
+  Index        r32, r22, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r34, r3
+  Len          r35, r34
+  Const        r36, 0
+L25:
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L2
+  Index        r38, r34, r36
+  Move         r39, r38
+  Const        r40, "id"
+  Index        r41, r39, r40
+  Const        r42, "company_type_id"
+  Index        r43, r28, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L3
+  // join t in title on t.id == mc.movie_id
+  IterPrep     r45, r15
+  Len          r46, r45
+  Const        r47, 0
+L24:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L3
+  Index        r49, r45, r47
+  Move         r50, r49
+  Const        r51, "id"
+  Index        r52, r50, r51
+  Const        r53, "movie_id"
+  Index        r54, r28, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L4
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r56, r11
+  Len          r57, r56
+  Const        r58, 0
+L23:
+  Less         r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r60, r56, r58
+  Move         r61, r60
+  Const        r62, "movie_id"
+  Index        r63, r61, r62
+  Const        r64, "id"
+  Index        r65, r50, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L5
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r67, r5
+  Len          r68, r67
+  Const        r69, 0
+L22:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L5
+  Index        r71, r67, r69
+  Move         r72, r71
+  Const        r73, "id"
+  Index        r74, r72, r73
+  Const        r75, "keyword_id"
+  Index        r76, r61, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L6
+  // join ml in movie_link on ml.movie_id == t.id
+  IterPrep     r78, r13
+  Len          r79, r78
+  Const        r80, 0
+L21:
+  Less         r81, r80, r79
+  JumpIfFalse  r81, L6
+  Index        r82, r78, r80
+  Move         r83, r82
+  Const        r84, "movie_id"
+  Index        r85, r83, r84
+  Const        r86, "id"
+  Index        r87, r50, r86
+  Equal        r88, r85, r87
+  JumpIfFalse  r88, L7
+  // join lt in link_type on lt.id == ml.link_type_id
+  IterPrep     r89, r7
+  Len          r90, r89
+  Const        r91, 0
+L20:
+  Less         r92, r91, r90
+  JumpIfFalse  r92, L7
+  Index        r93, r89, r91
+  Move         r94, r93
+  Const        r95, "id"
+  Index        r96, r94, r95
+  Const        r97, "link_type_id"
+  Index        r98, r83, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L8
+  // where cn.country_code != "[pl]" &&
+  Const        r100, "country_code"
+  Index        r101, r22, r100
+  // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r102, "production_year"
+  Index        r103, r50, r102
+  Const        r104, 1950
+  LessEq       r105, r104, r103
+  Const        r106, "production_year"
+  Index        r107, r50, r106
+  Const        r108, 2000
+  LessEq       r109, r107, r108
+  // where cn.country_code != "[pl]" &&
+  Const        r110, "[pl]"
+  NotEqual     r111, r101, r110
+  // ct.kind == "production companies" &&
+  Const        r112, "kind"
+  Index        r113, r39, r112
+  Const        r114, "production companies"
+  Equal        r115, r113, r114
+  // k.keyword == "sequel" &&
+  Const        r116, "keyword"
+  Index        r117, r72, r116
+  Const        r118, "sequel"
+  Equal        r119, r117, r118
+  // mc.note == null &&
+  Const        r120, "note"
+  Index        r121, r28, r120
+  Const        r122, nil
+  Equal        r123, r121, r122
+  // ml.movie_id == mk.movie_id &&
+  Const        r124, "movie_id"
+  Index        r125, r83, r124
+  Const        r126, "movie_id"
+  Index        r127, r61, r126
+  Equal        r128, r125, r127
+  // ml.movie_id == mc.movie_id &&
+  Const        r129, "movie_id"
+  Index        r130, r83, r129
+  Const        r131, "movie_id"
+  Index        r132, r28, r131
+  Equal        r133, r130, r132
+  // mk.movie_id == mc.movie_id
+  Const        r134, "movie_id"
+  Index        r135, r61, r134
+  Const        r136, "movie_id"
+  Index        r137, r28, r136
+  Equal        r138, r135, r137
+  // where cn.country_code != "[pl]" &&
+  Move         r139, r111
+  JumpIfFalse  r139, L9
+  Const        r140, "name"
+  Index        r141, r22, r140
+  // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+  Const        r142, "Film"
+  In           r143, r142, r141
+  Move         r144, r143
+  JumpIfTrue   r144, L10
+  Const        r145, "name"
+  Index        r146, r22, r145
+  Const        r147, "Warner"
+  In           r148, r147, r146
+  Move         r144, r148
+L10:
+  // where cn.country_code != "[pl]" &&
+  Move         r139, r144
+L9:
+  // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+  Move         r149, r139
+  JumpIfFalse  r149, L11
+  Move         r149, r115
+L11:
+  // ct.kind == "production companies" &&
+  Move         r150, r149
+  JumpIfFalse  r150, L12
+  Move         r150, r119
+L12:
+  // k.keyword == "sequel" &&
+  Move         r151, r150
+  JumpIfFalse  r151, L13
+  Const        r152, "link"
+  Index        r153, r94, r152
+  // lt.link.contains("follow") &&
+  Const        r154, "follow"
+  In           r155, r154, r153
+  // k.keyword == "sequel" &&
+  Move         r151, r155
+L13:
+  // lt.link.contains("follow") &&
+  Move         r156, r151
+  JumpIfFalse  r156, L14
+  Move         r156, r123
+L14:
+  // mc.note == null &&
+  Move         r157, r156
+  JumpIfFalse  r157, L15
+  Move         r157, r105
+L15:
+  // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Move         r158, r157
+  JumpIfFalse  r158, L16
+  Move         r158, r109
+L16:
+  Move         r159, r158
+  JumpIfFalse  r159, L17
+  Move         r159, r128
+L17:
+  // ml.movie_id == mk.movie_id &&
+  Move         r160, r159
+  JumpIfFalse  r160, L18
+  Move         r160, r133
+L18:
+  // ml.movie_id == mc.movie_id &&
+  Move         r161, r160
+  JumpIfFalse  r161, L19
+  Move         r161, r138
+L19:
+  // where cn.country_code != "[pl]" &&
+  JumpIfFalse  r161, L8
+  // select { company: cn.name, link: lt.link, title: t.title }
+  Const        r162, "company"
+  Const        r163, "name"
+  Index        r164, r22, r163
+  Const        r165, "link"
+  Const        r166, "link"
+  Index        r167, r94, r166
+  Const        r168, "title"
+  Const        r169, "title"
+  Index        r170, r50, r169
+  Move         r171, r162
+  Move         r172, r164
+  Move         r173, r165
+  Move         r174, r167
+  Move         r175, r168
+  Move         r176, r170
+  MakeMap      r177, 3, r171
+  // from cn in company_name
+  Append       r178, r16, r177
+  Move         r16, r178
+L8:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r179, 1
+  Add          r180, r91, r179
+  Move         r91, r180
+  Jump         L20
+L7:
+  // join ml in movie_link on ml.movie_id == t.id
+  Const        r181, 1
+  Add          r182, r80, r181
+  Move         r80, r182
+  Jump         L21
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r183, 1
+  Add          r184, r69, r183
+  Move         r69, r184
+  Jump         L22
+L5:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r185, 1
+  Add          r186, r58, r185
+  Move         r58, r186
+  Jump         L23
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r187, 1
+  Add          r188, r47, r187
+  Move         r47, r188
+  Jump         L24
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r189, 1
+  Add          r190, r36, r189
+  Move         r36, r190
+  Jump         L25
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r191, 1
+  Add          r192, r25, r191
+  Move         r25, r192
+  Jump         L26
+L1:
+  // from cn in company_name
+  Const        r193, 1
+  Add          r194, r19, r193
+  Move         r19, r194
+  Jump         L27
+L0:
+  // let matches =
+  Move         r195, r16
+  // from_company: min(from x in matches select x.company),
+  Const        r196, "from_company"
+  Const        r197, []
+  IterPrep     r198, r195
+  Len          r199, r198
+  Const        r200, 0
+L29:
+  Less         r201, r200, r199
+  JumpIfFalse  r201, L28
+  Index        r202, r198, r200
+  Move         r203, r202
+  Const        r204, "company"
+  Index        r205, r203, r204
+  Append       r206, r197, r205
+  Move         r197, r206
+  Const        r207, 1
+  Add          r208, r200, r207
+  Move         r200, r208
+  Jump         L29
+L28:
+  Min          r209, r197
+  // movie_link_type: min(from x in matches select x.link),
+  Const        r210, "movie_link_type"
+  Const        r211, []
+  IterPrep     r212, r195
+  Len          r213, r212
+  Const        r214, 0
+L31:
+  Less         r215, r214, r213
+  JumpIfFalse  r215, L30
+  Index        r216, r212, r214
+  Move         r203, r216
+  Const        r217, "link"
+  Index        r218, r203, r217
+  Append       r219, r211, r218
+  Move         r211, r219
+  Const        r220, 1
+  Add          r221, r214, r220
+  Move         r214, r221
+  Jump         L31
+L30:
+  Min          r222, r211
+  // non_polish_sequel_movie: min(from x in matches select x.title)
+  Const        r223, "non_polish_sequel_movie"
+  Const        r224, []
+  IterPrep     r225, r195
+  Len          r226, r225
+  Const        r227, 0
+L33:
+  Less         r228, r227, r226
+  JumpIfFalse  r228, L32
+  Index        r229, r225, r227
+  Move         r203, r229
+  Const        r230, "title"
+  Index        r231, r203, r230
+  Append       r232, r224, r231
+  Move         r224, r232
+  Const        r233, 1
+  Add          r234, r227, r233
+  Move         r227, r234
+  Jump         L33
+L32:
+  Min          r235, r224
+  // from_company: min(from x in matches select x.company),
+  Move         r236, r196
+  Move         r237, r209
+  // movie_link_type: min(from x in matches select x.link),
+  Move         r238, r210
+  Move         r239, r222
+  // non_polish_sequel_movie: min(from x in matches select x.title)
+  Move         r240, r223
+  Move         r241, r235
+  // {
+  MakeMap      r242, 3, r236
+  Move         r243, r242
+  // let result = [
+  MakeList     r244, 1, r243
+  Move         r245, r244
+  // json(result)
+  JSON         r245
+  // expect result == [
+  Const        r246, [{"from_company": "Best Film Co", "movie_link_type": "follow-up", "non_polish_sequel_movie": "Alpha"}]
+  Equal        r247, r245, r246
+  Expect       r247
+  Return       r0

--- a/tests/dataset/job/out/q12.ir.out
+++ b/tests/dataset/job/out/q12.ir.out
@@ -1,0 +1,308 @@
+func main (regs=178)
+  // let company_name = [
+  Const        r0, [{"country_code": "[us]", "id": 1, "name": "Best Pictures"}, {"country_code": "[uk]", "id": 2, "name": "Foreign Films"}]
+  Move         r1, r0
+  // let company_type = [
+  Const        r2, [{"id": 10, "kind": "production companies"}, {"id": 20, "kind": "distributors"}]
+  Move         r3, r2
+  // let info_type = [
+  Const        r4, [{"id": 100, "info": "genres"}, {"id": 200, "info": "rating"}]
+  Move         r5, r4
+  // let movie_companies = [
+  Const        r6, [{"company_id": 1, "company_type_id": 10, "movie_id": 1000}, {"company_id": 2, "company_type_id": 10, "movie_id": 2000}]
+  Move         r7, r6
+  // let movie_info = [
+  Const        r8, [{"info": "Drama", "info_type_id": 100, "movie_id": 1000}, {"info": "Horror", "info_type_id": 100, "movie_id": 2000}]
+  Move         r9, r8
+  // let movie_info_idx = [
+  Const        r10, [{"info": 8.3, "info_type_id": 200, "movie_id": 1000}, {"info": 7.5, "info_type_id": 200, "movie_id": 2000}]
+  Move         r11, r10
+  // let title = [
+  Const        r12, [{"id": 1000, "production_year": 2006, "title": "Great Drama"}, {"id": 2000, "production_year": 2007, "title": "Low Rated"}]
+  Move         r13, r12
+  // from cn in company_name
+  Const        r14, []
+  IterPrep     r15, r1
+  Len          r16, r15
+  Const        r17, 0
+L24:
+  Less         r18, r17, r16
+  JumpIfFalse  r18, L0
+  Index        r19, r15, r17
+  Move         r20, r19
+  // join mc in movie_companies on mc.company_id == cn.id
+  IterPrep     r21, r7
+  Len          r22, r21
+  Const        r23, 0
+L23:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L1
+  Index        r25, r21, r23
+  Move         r26, r25
+  Const        r27, "company_id"
+  Index        r28, r26, r27
+  Const        r29, "id"
+  Index        r30, r20, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L2
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r32, r3
+  Len          r33, r32
+  Const        r34, 0
+L22:
+  Less         r35, r34, r33
+  JumpIfFalse  r35, L2
+  Index        r36, r32, r34
+  Move         r37, r36
+  Const        r38, "id"
+  Index        r39, r37, r38
+  Const        r40, "company_type_id"
+  Index        r41, r26, r40
+  Equal        r42, r39, r41
+  JumpIfFalse  r42, L3
+  // join t in title on t.id == mc.movie_id
+  IterPrep     r43, r13
+  Len          r44, r43
+  Const        r45, 0
+L21:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L3
+  Index        r47, r43, r45
+  Move         r48, r47
+  Const        r49, "id"
+  Index        r50, r48, r49
+  Const        r51, "movie_id"
+  Index        r52, r26, r51
+  Equal        r53, r50, r52
+  JumpIfFalse  r53, L4
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r54, r9
+  Len          r55, r54
+  Const        r56, 0
+L20:
+  Less         r57, r56, r55
+  JumpIfFalse  r57, L4
+  Index        r58, r54, r56
+  Move         r59, r58
+  Const        r60, "movie_id"
+  Index        r61, r59, r60
+  Const        r62, "id"
+  Index        r63, r48, r62
+  Equal        r64, r61, r63
+  JumpIfFalse  r64, L5
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r65, r5
+  Len          r66, r65
+  Const        r67, 0
+L19:
+  Less         r68, r67, r66
+  JumpIfFalse  r68, L5
+  Index        r69, r65, r67
+  Move         r70, r69
+  Const        r71, "id"
+  Index        r72, r70, r71
+  Const        r73, "info_type_id"
+  Index        r74, r59, r73
+  Equal        r75, r72, r74
+  JumpIfFalse  r75, L6
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  IterPrep     r76, r11
+  Len          r77, r76
+  Const        r78, 0
+L18:
+  Less         r79, r78, r77
+  JumpIfFalse  r79, L6
+  Index        r80, r76, r78
+  Move         r81, r80
+  Const        r82, "movie_id"
+  Index        r83, r81, r82
+  Const        r84, "id"
+  Index        r85, r48, r84
+  Equal        r86, r83, r85
+  JumpIfFalse  r86, L7
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  IterPrep     r87, r5
+  Len          r88, r87
+  Const        r89, 0
+L17:
+  Less         r90, r89, r88
+  JumpIfFalse  r90, L7
+  Index        r91, r87, r89
+  Move         r92, r91
+  Const        r93, "id"
+  Index        r94, r92, r93
+  Const        r95, "info_type_id"
+  Index        r96, r81, r95
+  Equal        r97, r94, r96
+  JumpIfFalse  r97, L8
+  // cn.country_code == "[us]" &&
+  Const        r98, "country_code"
+  Index        r99, r20, r98
+  // mi_idx.info > 8.0 &&
+  Const        r100, "info"
+  Index        r101, r81, r100
+  Const        r102, 8
+  LessFloat    r103, r102, r101
+  // t.production_year >= 2005 &&
+  Const        r104, "production_year"
+  Index        r105, r48, r104
+  Const        r106, 2005
+  LessEq       r107, r106, r105
+  // t.production_year <= 2008
+  Const        r108, "production_year"
+  Index        r109, r48, r108
+  Const        r110, 2008
+  LessEq       r111, r109, r110
+  // cn.country_code == "[us]" &&
+  Const        r112, "[us]"
+  Equal        r113, r99, r112
+  // ct.kind == "production companies" &&
+  Const        r114, "kind"
+  Index        r115, r37, r114
+  Const        r116, "production companies"
+  Equal        r117, r115, r116
+  // it1.info == "genres" &&
+  Const        r118, "info"
+  Index        r119, r70, r118
+  Const        r120, "genres"
+  Equal        r121, r119, r120
+  // it2.info == "rating" &&
+  Const        r122, "info"
+  Index        r123, r92, r122
+  Const        r124, "rating"
+  Equal        r125, r123, r124
+  // cn.country_code == "[us]" &&
+  Move         r126, r113
+  JumpIfFalse  r126, L9
+  Move         r126, r117
+L9:
+  // ct.kind == "production companies" &&
+  Move         r127, r126
+  JumpIfFalse  r127, L10
+  Move         r127, r121
+L10:
+  // it1.info == "genres" &&
+  Move         r128, r127
+  JumpIfFalse  r128, L11
+  Move         r128, r125
+L11:
+  // it2.info == "rating" &&
+  Move         r129, r128
+  JumpIfFalse  r129, L12
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Const        r130, "info"
+  Index        r131, r59, r130
+  Const        r132, "Drama"
+  Equal        r133, r131, r132
+  Const        r134, "info"
+  Index        r135, r59, r134
+  Const        r136, "Horror"
+  Equal        r137, r135, r136
+  Move         r138, r133
+  JumpIfTrue   r138, L13
+  Move         r138, r137
+L13:
+  // it2.info == "rating" &&
+  Move         r129, r138
+L12:
+  // (mi.info == "Drama" || mi.info == "Horror") &&
+  Move         r139, r129
+  JumpIfFalse  r139, L14
+  Move         r139, r103
+L14:
+  // mi_idx.info > 8.0 &&
+  Move         r140, r139
+  JumpIfFalse  r140, L15
+  Move         r140, r107
+L15:
+  // t.production_year >= 2005 &&
+  Move         r141, r140
+  JumpIfFalse  r141, L16
+  Move         r141, r111
+L16:
+  // cn.country_code == "[us]" &&
+  JumpIfFalse  r141, L8
+  // movie_company: cn.name,
+  Const        r142, "movie_company"
+  Const        r143, "name"
+  Index        r144, r20, r143
+  // rating: mi_idx.info,
+  Const        r145, "rating"
+  Const        r146, "info"
+  Index        r147, r81, r146
+  // drama_horror_movie: t.title
+  Const        r148, "drama_horror_movie"
+  Const        r149, "title"
+  Index        r150, r48, r149
+  // movie_company: cn.name,
+  Move         r151, r142
+  Move         r152, r144
+  // rating: mi_idx.info,
+  Move         r153, r145
+  Move         r154, r147
+  // drama_horror_movie: t.title
+  Move         r155, r148
+  Move         r156, r150
+  // select {
+  MakeMap      r157, 3, r151
+  // from cn in company_name
+  Append       r158, r14, r157
+  Move         r14, r158
+L8:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r159, 1
+  Add          r160, r89, r159
+  Move         r89, r160
+  Jump         L17
+L7:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r161, 1
+  Add          r162, r78, r161
+  Move         r78, r162
+  Jump         L18
+L6:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r163, 1
+  Add          r164, r67, r163
+  Move         r67, r164
+  Jump         L19
+L5:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r165, 1
+  Add          r166, r56, r165
+  Move         r56, r166
+  Jump         L20
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r167, 1
+  Add          r168, r45, r167
+  Move         r45, r168
+  Jump         L21
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r169, 1
+  Add          r170, r34, r169
+  Move         r34, r170
+  Jump         L22
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r171, 1
+  Add          r172, r23, r171
+  Move         r23, r172
+  Jump         L23
+L1:
+  // from cn in company_name
+  Const        r173, 1
+  Add          r174, r17, r173
+  Move         r17, r174
+  Jump         L24
+L0:
+  // let result =
+  Move         r175, r14
+  // json(result)
+  JSON         r175
+  // expect result == [
+  Const        r176, [{"drama_horror_movie": "Great Drama", "movie_company": "Best Pictures", "rating": 8.3}]
+  Equal        r177, r175, r176
+  Expect       r177
+  Return       r0

--- a/tests/dataset/job/out/q13.ir.out
+++ b/tests/dataset/job/out/q13.ir.out
@@ -1,0 +1,391 @@
+func main (regs=242)
+  // let company_name = [
+  Const        r0, [{"country_code": "[de]", "id": 1}, {"country_code": "[us]", "id": 2}]
+  Move         r1, r0
+  // let company_type = [
+  Const        r2, [{"id": 1, "kind": "production companies"}, {"id": 2, "kind": "distributors"}]
+  Move         r3, r2
+  // let info_type = [
+  Const        r4, [{"id": 1, "info": "rating"}, {"id": 2, "info": "release dates"}]
+  Move         r5, r4
+  // let kind_type = [
+  Const        r6, [{"id": 1, "kind": "movie"}, {"id": 2, "kind": "video"}]
+  Move         r7, r6
+  // let title = [
+  Const        r8, [{"id": 10, "kind_id": 1, "title": "Alpha"}, {"id": 20, "kind_id": 1, "title": "Beta"}, {"id": 30, "kind_id": 2, "title": "Gamma"}]
+  Move         r9, r8
+  // let movie_companies = [
+  Const        r10, [{"company_id": 1, "company_type_id": 1, "movie_id": 10}, {"company_id": 1, "company_type_id": 1, "movie_id": 20}, {"company_id": 2, "company_type_id": 1, "movie_id": 30}]
+  Move         r11, r10
+  // let movie_info = [
+  Const        r12, [{"info": "1997-05-10", "info_type_id": 2, "movie_id": 10}, {"info": "1998-03-20", "info_type_id": 2, "movie_id": 20}, {"info": "1999-07-30", "info_type_id": 2, "movie_id": 30}]
+  Move         r13, r12
+  // let movie_info_idx = [
+  Const        r14, [{"info": "6.0", "info_type_id": 1, "movie_id": 10}, {"info": "7.5", "info_type_id": 1, "movie_id": 20}, {"info": "5.5", "info_type_id": 1, "movie_id": 30}]
+  Move         r15, r14
+  // from cn in company_name
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, 0
+L22:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L0
+  Index        r21, r17, r19
+  Move         r22, r21
+  // join mc in movie_companies on mc.company_id == cn.id
+  IterPrep     r23, r11
+  Len          r24, r23
+  Const        r25, 0
+L21:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L1
+  Index        r27, r23, r25
+  Move         r28, r27
+  Const        r29, "company_id"
+  Index        r30, r28, r29
+  Const        r31, "id"
+  Index        r32, r22, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r34, r3
+  Len          r35, r34
+  Const        r36, 0
+L20:
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L2
+  Index        r38, r34, r36
+  Move         r39, r38
+  Const        r40, "id"
+  Index        r41, r39, r40
+  Const        r42, "company_type_id"
+  Index        r43, r28, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L3
+  // join t in title on t.id == mc.movie_id
+  IterPrep     r45, r9
+  Len          r46, r45
+  Const        r47, 0
+L19:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L3
+  Index        r49, r45, r47
+  Move         r50, r49
+  Const        r51, "id"
+  Index        r52, r50, r51
+  Const        r53, "movie_id"
+  Index        r54, r28, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L4
+  // join kt in kind_type on kt.id == t.kind_id
+  IterPrep     r56, r7
+  Len          r57, r56
+  Const        r58, 0
+L18:
+  Less         r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r60, r56, r58
+  Move         r61, r60
+  Const        r62, "id"
+  Index        r63, r61, r62
+  Const        r64, "kind_id"
+  Index        r65, r50, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L5
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r67, r13
+  Len          r68, r67
+  Const        r69, 0
+L17:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L5
+  Index        r71, r67, r69
+  Move         r72, r71
+  Const        r73, "movie_id"
+  Index        r74, r72, r73
+  Const        r75, "id"
+  Index        r76, r50, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L6
+  // join it2 in info_type on it2.id == mi.info_type_id
+  IterPrep     r78, r5
+  Len          r79, r78
+  Const        r80, 0
+L16:
+  Less         r81, r80, r79
+  JumpIfFalse  r81, L6
+  Index        r82, r78, r80
+  Move         r83, r82
+  Const        r84, "id"
+  Index        r85, r83, r84
+  Const        r86, "info_type_id"
+  Index        r87, r72, r86
+  Equal        r88, r85, r87
+  JumpIfFalse  r88, L7
+  // join miidx in movie_info_idx on miidx.movie_id == t.id
+  IterPrep     r89, r15
+  Len          r90, r89
+  Const        r91, 0
+L15:
+  Less         r92, r91, r90
+  JumpIfFalse  r92, L7
+  Index        r93, r89, r91
+  Move         r94, r93
+  Const        r95, "movie_id"
+  Index        r96, r94, r95
+  Const        r97, "id"
+  Index        r98, r50, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L8
+  // join it in info_type on it.id == miidx.info_type_id
+  IterPrep     r100, r5
+  Len          r101, r100
+  Const        r102, 0
+L14:
+  Less         r103, r102, r101
+  JumpIfFalse  r103, L8
+  Index        r104, r100, r102
+  Move         r105, r104
+  Const        r106, "id"
+  Index        r107, r105, r106
+  Const        r108, "info_type_id"
+  Index        r109, r94, r108
+  Equal        r110, r107, r109
+  JumpIfFalse  r110, L9
+  // where cn.country_code == "[de]" &&
+  Const        r111, "country_code"
+  Index        r112, r22, r111
+  Const        r113, "[de]"
+  Equal        r114, r112, r113
+  // ct.kind == "production companies" &&
+  Const        r115, "kind"
+  Index        r116, r39, r115
+  Const        r117, "production companies"
+  Equal        r118, r116, r117
+  // it.info == "rating" &&
+  Const        r119, "info"
+  Index        r120, r105, r119
+  Const        r121, "rating"
+  Equal        r122, r120, r121
+  // it2.info == "release dates" &&
+  Const        r123, "info"
+  Index        r124, r83, r123
+  Const        r125, "release dates"
+  Equal        r126, r124, r125
+  // kt.kind == "movie"
+  Const        r127, "kind"
+  Index        r128, r61, r127
+  Const        r129, "movie"
+  Equal        r130, r128, r129
+  // where cn.country_code == "[de]" &&
+  Move         r131, r114
+  JumpIfFalse  r131, L10
+  Move         r131, r118
+L10:
+  // ct.kind == "production companies" &&
+  Move         r132, r131
+  JumpIfFalse  r132, L11
+  Move         r132, r122
+L11:
+  // it.info == "rating" &&
+  Move         r133, r132
+  JumpIfFalse  r133, L12
+  Move         r133, r126
+L12:
+  // it2.info == "release dates" &&
+  Move         r134, r133
+  JumpIfFalse  r134, L13
+  Move         r134, r130
+L13:
+  // where cn.country_code == "[de]" &&
+  JumpIfFalse  r134, L9
+  // release_date: mi.info,
+  Const        r135, "release_date"
+  Const        r136, "info"
+  Index        r137, r72, r136
+  // rating: miidx.info,
+  Const        r138, "rating"
+  Const        r139, "info"
+  Index        r140, r94, r139
+  // german_movie: t.title
+  Const        r141, "german_movie"
+  Const        r142, "title"
+  Index        r143, r50, r142
+  // release_date: mi.info,
+  Move         r144, r135
+  Move         r145, r137
+  // rating: miidx.info,
+  Move         r146, r138
+  Move         r147, r140
+  // german_movie: t.title
+  Move         r148, r141
+  Move         r149, r143
+  // select {
+  MakeMap      r150, 3, r144
+  // from cn in company_name
+  Append       r151, r16, r150
+  Move         r16, r151
+L9:
+  // join it in info_type on it.id == miidx.info_type_id
+  Const        r152, 1
+  Add          r153, r102, r152
+  Move         r102, r153
+  Jump         L14
+L8:
+  // join miidx in movie_info_idx on miidx.movie_id == t.id
+  Const        r154, 1
+  Add          r155, r91, r154
+  Move         r91, r155
+  Jump         L15
+L7:
+  // join it2 in info_type on it2.id == mi.info_type_id
+  Const        r156, 1
+  Add          r157, r80, r156
+  Move         r80, r157
+  Jump         L16
+L6:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r158, 1
+  Add          r159, r69, r158
+  Move         r69, r159
+  Jump         L17
+L5:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r160, 1
+  Add          r161, r58, r160
+  Move         r58, r161
+  Jump         L18
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r162, 1
+  Add          r163, r47, r162
+  Move         r47, r163
+  Jump         L19
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r164, 1
+  Add          r165, r36, r164
+  Move         r36, r165
+  Jump         L20
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r166, 1
+  Add          r167, r25, r166
+  Move         r25, r167
+  Jump         L21
+L1:
+  // from cn in company_name
+  Const        r168, 1
+  Add          r169, r19, r168
+  Move         r19, r169
+  Jump         L22
+L0:
+  // let candidates =
+  Move         r170, r16
+  // release_date: (from x in candidates sort by x.release_date select x.release_date)[0],
+  Const        r171, "release_date"
+  Const        r172, []
+  IterPrep     r173, r170
+  Len          r174, r173
+  Const        r175, 0
+L24:
+  Less         r176, r175, r174
+  JumpIfFalse  r176, L23
+  Index        r177, r173, r175
+  Move         r178, r177
+  Const        r179, "release_date"
+  Index        r180, r178, r179
+  Const        r181, "release_date"
+  Index        r182, r178, r181
+  Move         r183, r182
+  Move         r184, r180
+  MakeList     r185, 2, r183
+  Append       r186, r172, r185
+  Move         r172, r186
+  Const        r187, 1
+  Add          r188, r175, r187
+  Move         r175, r188
+  Jump         L24
+L23:
+  Sort         r189, r172
+  Move         r172, r189
+  Const        r190, 0
+  Index        r191, r172, r190
+  // rating: (from x in candidates sort by x.rating select x.rating)[0],
+  Const        r192, "rating"
+  Const        r193, []
+  IterPrep     r194, r170
+  Len          r195, r194
+  Const        r196, 0
+L26:
+  Less         r197, r196, r195
+  JumpIfFalse  r197, L25
+  Index        r198, r194, r196
+  Move         r178, r198
+  Const        r199, "rating"
+  Index        r200, r178, r199
+  Const        r201, "rating"
+  Index        r202, r178, r201
+  Move         r203, r202
+  Move         r204, r200
+  MakeList     r205, 2, r203
+  Append       r206, r193, r205
+  Move         r193, r206
+  Const        r207, 1
+  Add          r208, r196, r207
+  Move         r196, r208
+  Jump         L26
+L25:
+  Sort         r209, r193
+  Move         r193, r209
+  Const        r210, 0
+  Index        r211, r193, r210
+  // german_movie: (from x in candidates sort by x.german_movie select x.german_movie)[0]
+  Const        r212, "german_movie"
+  Const        r213, []
+  IterPrep     r214, r170
+  Len          r215, r214
+  Const        r216, 0
+L28:
+  Less         r217, r216, r215
+  JumpIfFalse  r217, L27
+  Index        r218, r214, r216
+  Move         r178, r218
+  Const        r219, "german_movie"
+  Index        r220, r178, r219
+  Const        r221, "german_movie"
+  Index        r222, r178, r221
+  Move         r223, r222
+  Move         r224, r220
+  MakeList     r225, 2, r223
+  Append       r226, r213, r225
+  Move         r213, r226
+  Const        r227, 1
+  Add          r228, r216, r227
+  Move         r216, r228
+  Jump         L28
+L27:
+  Sort         r229, r213
+  Move         r213, r229
+  Const        r230, 0
+  Index        r231, r213, r230
+  // release_date: (from x in candidates sort by x.release_date select x.release_date)[0],
+  Move         r232, r171
+  Move         r233, r191
+  // rating: (from x in candidates sort by x.rating select x.rating)[0],
+  Move         r234, r192
+  Move         r235, r211
+  // german_movie: (from x in candidates sort by x.german_movie select x.german_movie)[0]
+  Move         r236, r212
+  Move         r237, r231
+  // let result = {
+  MakeMap      r238, 3, r232
+  Move         r239, r238
+  // json(result)
+  JSON         r239
+  // expect result == {
+  Const        r240, {"german_movie": "Alpha", "rating": "6.0", "release_date": "1997-05-10"}
+  Equal        r241, r239, r240
+  Expect       r241
+  Return       r0

--- a/tests/dataset/job/out/q14.ir.out
+++ b/tests/dataset/job/out/q14.ir.out
@@ -1,0 +1,407 @@
+func main (regs=223)
+  // let info_type = [
+  Const        r0, [{"id": 1, "info": "countries"}, {"id": 2, "info": "rating"}]
+  Move         r1, r0
+  // let keyword = [
+  Const        r2, [{"id": 1, "keyword": "murder"}, {"id": 2, "keyword": "blood"}, {"id": 3, "keyword": "romance"}]
+  Move         r3, r2
+  // let kind_type = [
+  Const        r4, [{"id": 1, "kind": "movie"}]
+  Move         r5, r4
+  // let title = [
+  Const        r6, [{"id": 1, "kind_id": 1, "production_year": 2012, "title": "A Dark Movie"}, {"id": 2, "kind_id": 1, "production_year": 2013, "title": "Brutal Blood"}, {"id": 3, "kind_id": 1, "production_year": 2008, "title": "Old Film"}]
+  Move         r7, r6
+  // let movie_info = [
+  Const        r8, [{"info": "Sweden", "info_type_id": 1, "movie_id": 1}, {"info": "USA", "info_type_id": 1, "movie_id": 2}, {"info": "USA", "info_type_id": 1, "movie_id": 3}]
+  Move         r9, r8
+  // let movie_info_idx = [
+  Const        r10, [{"info": 7, "info_type_id": 2, "movie_id": 1}, {"info": 7.5, "info_type_id": 2, "movie_id": 2}, {"info": 9.1, "info_type_id": 2, "movie_id": 3}]
+  Move         r11, r10
+  // let movie_keyword = [
+  Const        r12, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}, {"keyword_id": 3, "movie_id": 3}]
+  Move         r13, r12
+  // let allowed_keywords = ["murder", "murder-in-title", "blood", "violence"]
+  Const        r14, ["murder", "murder-in-title", "blood", "violence"]
+  Move         r15, r14
+  // let allowed_countries = [
+  Const        r16, ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German", "USA", "American"]
+  Move         r17, r16
+  // from it1 in info_type
+  Const        r18, []
+  IterPrep     r19, r1
+  Len          r20, r19
+  Const        r21, 0
+L32:
+  Less         r22, r21, r20
+  JumpIfFalse  r22, L0
+  Index        r23, r19, r21
+  Move         r24, r23
+  // from it2 in info_type
+  IterPrep     r25, r1
+  Len          r26, r25
+  Const        r27, 0
+L31:
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L1
+  Index        r29, r25, r27
+  Move         r30, r29
+  // from k in keyword
+  IterPrep     r31, r3
+  Len          r32, r31
+  Const        r33, 0
+L30:
+  Less         r34, r33, r32
+  JumpIfFalse  r34, L2
+  Index        r35, r31, r33
+  Move         r36, r35
+  // from kt in kind_type
+  IterPrep     r37, r5
+  Len          r38, r37
+  Const        r39, 0
+L29:
+  Less         r40, r39, r38
+  JumpIfFalse  r40, L3
+  Index        r41, r37, r39
+  Move         r42, r41
+  // from mi in movie_info
+  IterPrep     r43, r9
+  Len          r44, r43
+  Const        r45, 0
+L28:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L4
+  Index        r47, r43, r45
+  Move         r48, r47
+  // from mi_idx in movie_info_idx
+  IterPrep     r49, r11
+  Len          r50, r49
+  Const        r51, 0
+L27:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L5
+  Index        r53, r49, r51
+  Move         r54, r53
+  // from mk in movie_keyword
+  IterPrep     r55, r13
+  Len          r56, r55
+  Const        r57, 0
+L26:
+  Less         r58, r57, r56
+  JumpIfFalse  r58, L6
+  Index        r59, r55, r57
+  Move         r60, r59
+  // from t in title
+  IterPrep     r61, r7
+  Len          r62, r61
+  Const        r63, 0
+L25:
+  Less         r64, r63, r62
+  JumpIfFalse  r64, L7
+  Index        r65, r61, r63
+  Move         r66, r65
+  // it1.info == "countries" &&
+  Const        r67, "info"
+  Index        r68, r24, r67
+  // mi_idx.info < 8.5 &&
+  Const        r69, "info"
+  Index        r70, r54, r69
+  Const        r71, 8.5
+  LessFloat    r72, r70, r71
+  // t.production_year > 2010 &&
+  Const        r73, "production_year"
+  Index        r74, r66, r73
+  Const        r75, 2010
+  Less         r76, r75, r74
+  // it1.info == "countries" &&
+  Const        r77, "countries"
+  Equal        r78, r68, r77
+  // it2.info == "rating" &&
+  Const        r79, "info"
+  Index        r80, r30, r79
+  Const        r81, "rating"
+  Equal        r82, r80, r81
+  // kt.kind == "movie" &&
+  Const        r83, "kind"
+  Index        r84, r42, r83
+  Const        r85, "movie"
+  Equal        r86, r84, r85
+  // kt.id == t.kind_id &&
+  Const        r87, "id"
+  Index        r88, r42, r87
+  Const        r89, "kind_id"
+  Index        r90, r66, r89
+  Equal        r91, r88, r90
+  // t.id == mi.movie_id &&
+  Const        r92, "id"
+  Index        r93, r66, r92
+  Const        r94, "movie_id"
+  Index        r95, r48, r94
+  Equal        r96, r93, r95
+  // t.id == mk.movie_id &&
+  Const        r97, "id"
+  Index        r98, r66, r97
+  Const        r99, "movie_id"
+  Index        r100, r60, r99
+  Equal        r101, r98, r100
+  // t.id == mi_idx.movie_id &&
+  Const        r102, "id"
+  Index        r103, r66, r102
+  Const        r104, "movie_id"
+  Index        r105, r54, r104
+  Equal        r106, r103, r105
+  // mk.movie_id == mi.movie_id &&
+  Const        r107, "movie_id"
+  Index        r108, r60, r107
+  Const        r109, "movie_id"
+  Index        r110, r48, r109
+  Equal        r111, r108, r110
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r112, "movie_id"
+  Index        r113, r60, r112
+  Const        r114, "movie_id"
+  Index        r115, r54, r114
+  Equal        r116, r113, r115
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r117, "movie_id"
+  Index        r118, r48, r117
+  Const        r119, "movie_id"
+  Index        r120, r54, r119
+  Equal        r121, r118, r120
+  // k.id == mk.keyword_id &&
+  Const        r122, "id"
+  Index        r123, r36, r122
+  Const        r124, "keyword_id"
+  Index        r125, r60, r124
+  Equal        r126, r123, r125
+  // it1.id == mi.info_type_id &&
+  Const        r127, "id"
+  Index        r128, r24, r127
+  Const        r129, "info_type_id"
+  Index        r130, r48, r129
+  Equal        r131, r128, r130
+  // it2.id == mi_idx.info_type_id
+  Const        r132, "id"
+  Index        r133, r30, r132
+  Const        r134, "info_type_id"
+  Index        r135, r54, r134
+  Equal        r136, r133, r135
+  // it1.info == "countries" &&
+  Move         r137, r78
+  JumpIfFalse  r137, L8
+  Move         r137, r82
+L8:
+  // it2.info == "rating" &&
+  Move         r138, r137
+  JumpIfFalse  r138, L9
+  // (k.keyword in allowed_keywords) &&
+  Const        r139, "keyword"
+  Index        r140, r36, r139
+  In           r141, r140, r15
+  // it2.info == "rating" &&
+  Move         r138, r141
+L9:
+  // (k.keyword in allowed_keywords) &&
+  Move         r142, r138
+  JumpIfFalse  r142, L10
+  Move         r142, r86
+L10:
+  // kt.kind == "movie" &&
+  Move         r143, r142
+  JumpIfFalse  r143, L11
+  // (mi.info in allowed_countries) &&
+  Const        r144, "info"
+  Index        r145, r48, r144
+  In           r146, r145, r17
+  // kt.kind == "movie" &&
+  Move         r143, r146
+L11:
+  // (mi.info in allowed_countries) &&
+  Move         r147, r143
+  JumpIfFalse  r147, L12
+  Move         r147, r72
+L12:
+  // mi_idx.info < 8.5 &&
+  Move         r148, r147
+  JumpIfFalse  r148, L13
+  Move         r148, r76
+L13:
+  // t.production_year > 2010 &&
+  Move         r149, r148
+  JumpIfFalse  r149, L14
+  Move         r149, r91
+L14:
+  // kt.id == t.kind_id &&
+  Move         r150, r149
+  JumpIfFalse  r150, L15
+  Move         r150, r96
+L15:
+  // t.id == mi.movie_id &&
+  Move         r151, r150
+  JumpIfFalse  r151, L16
+  Move         r151, r101
+L16:
+  // t.id == mk.movie_id &&
+  Move         r152, r151
+  JumpIfFalse  r152, L17
+  Move         r152, r106
+L17:
+  // t.id == mi_idx.movie_id &&
+  Move         r153, r152
+  JumpIfFalse  r153, L18
+  Move         r153, r111
+L18:
+  // mk.movie_id == mi.movie_id &&
+  Move         r154, r153
+  JumpIfFalse  r154, L19
+  Move         r154, r116
+L19:
+  // mk.movie_id == mi_idx.movie_id &&
+  Move         r155, r154
+  JumpIfFalse  r155, L20
+  Move         r155, r121
+L20:
+  // mi.movie_id == mi_idx.movie_id &&
+  Move         r156, r155
+  JumpIfFalse  r156, L21
+  Move         r156, r126
+L21:
+  // k.id == mk.keyword_id &&
+  Move         r157, r156
+  JumpIfFalse  r157, L22
+  Move         r157, r131
+L22:
+  // it1.id == mi.info_type_id &&
+  Move         r158, r157
+  JumpIfFalse  r158, L23
+  Move         r158, r136
+L23:
+  // where (
+  JumpIfFalse  r158, L24
+  // rating: mi_idx.info,
+  Const        r159, "rating"
+  Const        r160, "info"
+  Index        r161, r54, r160
+  // title: t.title
+  Const        r162, "title"
+  Const        r163, "title"
+  Index        r164, r66, r163
+  // rating: mi_idx.info,
+  Move         r165, r159
+  Move         r166, r161
+  // title: t.title
+  Move         r167, r162
+  Move         r168, r164
+  // select {
+  MakeMap      r169, 2, r165
+  // from it1 in info_type
+  Append       r170, r18, r169
+  Move         r18, r170
+L24:
+  // from t in title
+  Const        r171, 1
+  Add          r172, r63, r171
+  Move         r63, r172
+  Jump         L25
+L7:
+  // from mk in movie_keyword
+  Const        r173, 1
+  Add          r174, r57, r173
+  Move         r57, r174
+  Jump         L26
+L6:
+  // from mi_idx in movie_info_idx
+  Const        r175, 1
+  Add          r176, r51, r175
+  Move         r51, r176
+  Jump         L27
+L5:
+  // from mi in movie_info
+  Const        r177, 1
+  Add          r178, r45, r177
+  Move         r45, r178
+  Jump         L28
+L4:
+  // from kt in kind_type
+  Const        r179, 1
+  Add          r180, r39, r179
+  Move         r39, r180
+  Jump         L29
+L3:
+  // from k in keyword
+  Const        r181, 1
+  Add          r182, r33, r181
+  Move         r33, r182
+  Jump         L30
+L2:
+  // from it2 in info_type
+  Const        r183, 1
+  Add          r184, r27, r183
+  Move         r27, r184
+  Jump         L31
+L1:
+  // from it1 in info_type
+  Const        r185, 1
+  Add          r186, r21, r185
+  Move         r21, r186
+  Jump         L32
+L0:
+  // let matches =
+  Move         r187, r18
+  // rating: min(from x in matches select x.rating),
+  Const        r188, "rating"
+  Const        r189, []
+  IterPrep     r190, r187
+  Len          r191, r190
+  Const        r192, 0
+L34:
+  Less         r193, r192, r191
+  JumpIfFalse  r193, L33
+  Index        r194, r190, r192
+  Move         r195, r194
+  Const        r196, "rating"
+  Index        r197, r195, r196
+  Append       r198, r189, r197
+  Move         r189, r198
+  Const        r199, 1
+  Add          r200, r192, r199
+  Move         r192, r200
+  Jump         L34
+L33:
+  Min          r201, r189
+  // northern_dark_movie: min(from x in matches select x.title)
+  Const        r202, "northern_dark_movie"
+  Const        r203, []
+  IterPrep     r204, r187
+  Len          r205, r204
+  Const        r206, 0
+L36:
+  Less         r207, r206, r205
+  JumpIfFalse  r207, L35
+  Index        r208, r204, r206
+  Move         r195, r208
+  Const        r209, "title"
+  Index        r210, r195, r209
+  Append       r211, r203, r210
+  Move         r203, r211
+  Const        r212, 1
+  Add          r213, r206, r212
+  Move         r206, r213
+  Jump         L36
+L35:
+  Min          r214, r203
+  // rating: min(from x in matches select x.rating),
+  Move         r215, r188
+  Move         r216, r201
+  // northern_dark_movie: min(from x in matches select x.title)
+  Move         r217, r202
+  Move         r218, r214
+  // let result = {
+  MakeMap      r219, 2, r215
+  Move         r220, r219
+  // json(result)
+  JSON         r220
+  // expect result == { rating: 7.0, northern_dark_movie: "A Dark Movie" }
+  Const        r221, {"northern_dark_movie": "A Dark Movie", "rating": 7}
+  Equal        r222, r220, r221
+  Expect       r222
+  Return       r0

--- a/tests/dataset/job/out/q15.ir.out
+++ b/tests/dataset/job/out/q15.ir.out
@@ -1,0 +1,374 @@
+func main (regs=220)
+  // let aka_title = [
+  Const        r0, [{"movie_id": 1}, {"movie_id": 2}]
+  Move         r1, r0
+  // let company_name = [
+  Const        r2, [{"country_code": "[us]", "id": 1}, {"country_code": "[gb]", "id": 2}]
+  Move         r3, r2
+  // let company_type = [
+  Const        r4, [{"id": 10}, {"id": 20}]
+  Move         r5, r4
+  // let info_type = [
+  Const        r6, [{"id": 5, "info": "release dates"}, {"id": 6, "info": "other"}]
+  Move         r7, r6
+  // let keyword = [
+  Const        r8, [{"id": 100}, {"id": 200}]
+  Move         r9, r8
+  // let movie_companies = [
+  Const        r10, [{"company_id": 1, "company_type_id": 10, "movie_id": 1, "note": "release (2005) (worldwide)"}, {"company_id": 2, "company_type_id": 20, "movie_id": 2, "note": "release (1999) (worldwide)"}]
+  Move         r11, r10
+  // let movie_info = [
+  Const        r12, [{"info": "USA: March 2005", "info_type_id": 5, "movie_id": 1, "note": "internet"}, {"info": "USA: May 1999", "info_type_id": 5, "movie_id": 2, "note": "theater"}]
+  Move         r13, r12
+  // let movie_keyword = [
+  Const        r14, [{"keyword_id": 100, "movie_id": 1}, {"keyword_id": 200, "movie_id": 2}]
+  Move         r15, r14
+  // let title = [
+  Const        r16, [{"id": 1, "production_year": 2005, "title": "Example Movie"}, {"id": 2, "production_year": 1999, "title": "Old Movie"}]
+  Move         r17, r16
+  // from t in title
+  Const        r18, []
+  IterPrep     r19, r17
+  Len          r20, r19
+  Const        r21, 0
+L25:
+  Less         r22, r21, r20
+  JumpIfFalse  r22, L0
+  Index        r23, r19, r21
+  Move         r24, r23
+  // join at in aka_title on at.movie_id == t.id
+  IterPrep     r25, r1
+  Len          r26, r25
+  Const        r27, 0
+L24:
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L1
+  Index        r29, r25, r27
+  Move         r30, r29
+  Const        r31, "movie_id"
+  Index        r32, r30, r31
+  Const        r33, "id"
+  Index        r34, r24, r33
+  Equal        r35, r32, r34
+  JumpIfFalse  r35, L2
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r36, r13
+  Len          r37, r36
+  Const        r38, 0
+L23:
+  Less         r39, r38, r37
+  JumpIfFalse  r39, L2
+  Index        r40, r36, r38
+  Move         r41, r40
+  Const        r42, "movie_id"
+  Index        r43, r41, r42
+  Const        r44, "id"
+  Index        r45, r24, r44
+  Equal        r46, r43, r45
+  JumpIfFalse  r46, L3
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r47, r15
+  Len          r48, r47
+  Const        r49, 0
+L22:
+  Less         r50, r49, r48
+  JumpIfFalse  r50, L3
+  Index        r51, r47, r49
+  Move         r52, r51
+  Const        r53, "movie_id"
+  Index        r54, r52, r53
+  Const        r55, "id"
+  Index        r56, r24, r55
+  Equal        r57, r54, r56
+  JumpIfFalse  r57, L4
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r58, r11
+  Len          r59, r58
+  Const        r60, 0
+L21:
+  Less         r61, r60, r59
+  JumpIfFalse  r61, L4
+  Index        r62, r58, r60
+  Move         r63, r62
+  Const        r64, "movie_id"
+  Index        r65, r63, r64
+  Const        r66, "id"
+  Index        r67, r24, r66
+  Equal        r68, r65, r67
+  JumpIfFalse  r68, L5
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r69, r9
+  Len          r70, r69
+  Const        r71, 0
+L20:
+  Less         r72, r71, r70
+  JumpIfFalse  r72, L5
+  Index        r73, r69, r71
+  Move         r74, r73
+  Const        r75, "id"
+  Index        r76, r74, r75
+  Const        r77, "keyword_id"
+  Index        r78, r52, r77
+  Equal        r79, r76, r78
+  JumpIfFalse  r79, L6
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r80, r7
+  Len          r81, r80
+  Const        r82, 0
+L19:
+  Less         r83, r82, r81
+  JumpIfFalse  r83, L6
+  Index        r84, r80, r82
+  Move         r85, r84
+  Const        r86, "id"
+  Index        r87, r85, r86
+  Const        r88, "info_type_id"
+  Index        r89, r41, r88
+  Equal        r90, r87, r89
+  JumpIfFalse  r90, L7
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r91, r3
+  Len          r92, r91
+  Const        r93, 0
+L18:
+  Less         r94, r93, r92
+  JumpIfFalse  r94, L7
+  Index        r95, r91, r93
+  Move         r96, r95
+  Const        r97, "id"
+  Index        r98, r96, r97
+  Const        r99, "company_id"
+  Index        r100, r63, r99
+  Equal        r101, r98, r100
+  JumpIfFalse  r101, L8
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r102, r5
+  Len          r103, r102
+  Const        r104, 0
+L17:
+  Less         r105, r104, r103
+  JumpIfFalse  r105, L8
+  Index        r106, r102, r104
+  Move         r107, r106
+  Const        r108, "id"
+  Index        r109, r107, r108
+  Const        r110, "company_type_id"
+  Index        r111, r63, r110
+  Equal        r112, r109, r111
+  JumpIfFalse  r112, L9
+  // where cn.country_code == "[us]" &&
+  Const        r113, "country_code"
+  Index        r114, r96, r113
+  // t.production_year > 2000
+  Const        r115, "production_year"
+  Index        r116, r24, r115
+  Const        r117, 2000
+  Less         r118, r117, r116
+  // where cn.country_code == "[us]" &&
+  Const        r119, "[us]"
+  Equal        r120, r114, r119
+  // it1.info == "release dates" &&
+  Const        r121, "info"
+  Index        r122, r85, r121
+  Const        r123, "release dates"
+  Equal        r124, r122, r123
+  // where cn.country_code == "[us]" &&
+  Move         r125, r120
+  JumpIfFalse  r125, L10
+  Move         r125, r124
+L10:
+  // it1.info == "release dates" &&
+  Move         r126, r125
+  JumpIfFalse  r126, L11
+  Const        r127, "note"
+  Index        r128, r63, r127
+  // mc.note.contains("200") &&
+  Const        r129, "200"
+  In           r130, r129, r128
+  // it1.info == "release dates" &&
+  Move         r126, r130
+L11:
+  // mc.note.contains("200") &&
+  Move         r131, r126
+  JumpIfFalse  r131, L12
+  Const        r132, "note"
+  Index        r133, r63, r132
+  // mc.note.contains("worldwide") &&
+  Const        r134, "worldwide"
+  In           r135, r134, r133
+  // mc.note.contains("200") &&
+  Move         r131, r135
+L12:
+  // mc.note.contains("worldwide") &&
+  Move         r136, r131
+  JumpIfFalse  r136, L13
+  Const        r137, "note"
+  Index        r138, r41, r137
+  // mi.note.contains("internet") &&
+  Const        r139, "internet"
+  In           r140, r139, r138
+  // mc.note.contains("worldwide") &&
+  Move         r136, r140
+L13:
+  // mi.note.contains("internet") &&
+  Move         r141, r136
+  JumpIfFalse  r141, L14
+  Const        r142, "info"
+  Index        r143, r41, r142
+  // mi.info.contains("USA:") &&
+  Const        r144, "USA:"
+  In           r145, r144, r143
+  // mi.note.contains("internet") &&
+  Move         r141, r145
+L14:
+  // mi.info.contains("USA:") &&
+  Move         r146, r141
+  JumpIfFalse  r146, L15
+  Const        r147, "info"
+  Index        r148, r41, r147
+  // mi.info.contains("200") &&
+  Const        r149, "200"
+  In           r150, r149, r148
+  // mi.info.contains("USA:") &&
+  Move         r146, r150
+L15:
+  // mi.info.contains("200") &&
+  Move         r151, r146
+  JumpIfFalse  r151, L16
+  Move         r151, r118
+L16:
+  // where cn.country_code == "[us]" &&
+  JumpIfFalse  r151, L9
+  // select { release_date: mi.info, internet_movie: t.title }
+  Const        r152, "release_date"
+  Const        r153, "info"
+  Index        r154, r41, r153
+  Const        r155, "internet_movie"
+  Const        r156, "title"
+  Index        r157, r24, r156
+  Move         r158, r152
+  Move         r159, r154
+  Move         r160, r155
+  Move         r161, r157
+  MakeMap      r162, 2, r158
+  // from t in title
+  Append       r163, r18, r162
+  Move         r18, r163
+L9:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r164, 1
+  Add          r165, r104, r164
+  Move         r104, r165
+  Jump         L17
+L8:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r166, 1
+  Add          r167, r93, r166
+  Move         r93, r167
+  Jump         L18
+L7:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r168, 1
+  Add          r169, r82, r168
+  Move         r82, r169
+  Jump         L19
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r170, 1
+  Add          r171, r71, r170
+  Move         r71, r171
+  Jump         L20
+L5:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r172, 1
+  Add          r173, r60, r172
+  Move         r60, r173
+  Jump         L21
+L4:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r174, 1
+  Add          r175, r49, r174
+  Move         r49, r175
+  Jump         L22
+L3:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r176, 1
+  Add          r177, r38, r176
+  Move         r38, r177
+  Jump         L23
+L2:
+  // join at in aka_title on at.movie_id == t.id
+  Const        r178, 1
+  Add          r179, r27, r178
+  Move         r27, r179
+  Jump         L24
+L1:
+  // from t in title
+  Const        r180, 1
+  Add          r181, r21, r180
+  Move         r21, r181
+  Jump         L25
+L0:
+  // let rows =
+  Move         r182, r18
+  // release_date: min(from r in rows select r.release_date),
+  Const        r183, "release_date"
+  Const        r184, []
+  IterPrep     r185, r182
+  Len          r186, r185
+  Const        r187, 0
+L27:
+  Less         r188, r187, r186
+  JumpIfFalse  r188, L26
+  Index        r189, r185, r187
+  Move         r190, r189
+  Const        r191, "release_date"
+  Index        r192, r190, r191
+  Append       r193, r184, r192
+  Move         r184, r193
+  Const        r194, 1
+  Add          r195, r187, r194
+  Move         r187, r195
+  Jump         L27
+L26:
+  Min          r196, r184
+  // internet_movie: min(from r in rows select r.internet_movie)
+  Const        r197, "internet_movie"
+  Const        r198, []
+  IterPrep     r199, r182
+  Len          r200, r199
+  Const        r201, 0
+L29:
+  Less         r202, r201, r200
+  JumpIfFalse  r202, L28
+  Index        r203, r199, r201
+  Move         r190, r203
+  Const        r204, "internet_movie"
+  Index        r205, r190, r204
+  Append       r206, r198, r205
+  Move         r198, r206
+  Const        r207, 1
+  Add          r208, r201, r207
+  Move         r201, r208
+  Jump         L29
+L28:
+  Min          r209, r198
+  // release_date: min(from r in rows select r.release_date),
+  Move         r210, r183
+  Move         r211, r196
+  // internet_movie: min(from r in rows select r.internet_movie)
+  Move         r212, r197
+  Move         r213, r209
+  // {
+  MakeMap      r214, 2, r210
+  Move         r215, r214
+  // let result = [
+  MakeList     r216, 1, r215
+  Move         r217, r216
+  // json(result)
+  JSON         r217
+  // expect result == [
+  Const        r218, [{"internet_movie": "Example Movie", "release_date": "USA: March 2005"}]
+  Equal        r219, r217, r218
+  Expect       r219
+  Return       r0

--- a/tests/dataset/job/out/q16.ir.out
+++ b/tests/dataset/job/out/q16.ir.out
@@ -1,0 +1,305 @@
+func main (regs=185)
+  // let aka_name = [
+  Const        r0, [{"name": "Alpha", "person_id": 1}, {"name": "Beta", "person_id": 2}]
+  Move         r1, r0
+  // let cast_info = [
+  Const        r2, [{"movie_id": 101, "person_id": 1}, {"movie_id": 102, "person_id": 2}]
+  Move         r3, r2
+  // let company_name = [
+  Const        r4, [{"country_code": "[us]", "id": 1}, {"country_code": "[de]", "id": 2}]
+  Move         r5, r4
+  // let keyword = [
+  Const        r6, [{"id": 1, "keyword": "character-name-in-title"}, {"id": 2, "keyword": "other"}]
+  Move         r7, r6
+  // let movie_companies = [
+  Const        r8, [{"company_id": 1, "movie_id": 101}, {"company_id": 2, "movie_id": 102}]
+  Move         r9, r8
+  // let movie_keyword = [
+  Const        r10, [{"keyword_id": 1, "movie_id": 101}, {"keyword_id": 2, "movie_id": 102}]
+  Move         r11, r10
+  // let name = [
+  Const        r12, [{"id": 1}, {"id": 2}]
+  Move         r13, r12
+  // let title = [
+  Const        r14, [{"episode_nr": 60, "id": 101, "title": "Hero Bob"}, {"episode_nr": 40, "id": 102, "title": "Other Show"}]
+  Move         r15, r14
+  // from an in aka_name
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, 0
+L19:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L0
+  Index        r21, r17, r19
+  Move         r22, r21
+  // join n in name on n.id == an.person_id
+  IterPrep     r23, r13
+  Len          r24, r23
+  Const        r25, 0
+L18:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L1
+  Index        r27, r23, r25
+  Move         r28, r27
+  Const        r29, "id"
+  Index        r30, r28, r29
+  Const        r31, "person_id"
+  Index        r32, r22, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join ci in cast_info on ci.person_id == n.id
+  IterPrep     r34, r3
+  Len          r35, r34
+  Const        r36, 0
+L17:
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L2
+  Index        r38, r34, r36
+  Move         r39, r38
+  Const        r40, "person_id"
+  Index        r41, r39, r40
+  Const        r42, "id"
+  Index        r43, r28, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L3
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r45, r15
+  Len          r46, r45
+  Const        r47, 0
+L16:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L3
+  Index        r49, r45, r47
+  Move         r50, r49
+  Const        r51, "id"
+  Index        r52, r50, r51
+  Const        r53, "movie_id"
+  Index        r54, r39, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L4
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r56, r11
+  Len          r57, r56
+  Const        r58, 0
+L15:
+  Less         r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r60, r56, r58
+  Move         r61, r60
+  Const        r62, "movie_id"
+  Index        r63, r61, r62
+  Const        r64, "id"
+  Index        r65, r50, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L5
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r67, r7
+  Len          r68, r67
+  Const        r69, 0
+L14:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L5
+  Index        r71, r67, r69
+  Move         r72, r71
+  Const        r73, "id"
+  Index        r74, r72, r73
+  Const        r75, "keyword_id"
+  Index        r76, r61, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L6
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r78, r9
+  Len          r79, r78
+  Const        r80, 0
+L13:
+  Less         r81, r80, r79
+  JumpIfFalse  r81, L6
+  Index        r82, r78, r80
+  Move         r83, r82
+  Const        r84, "movie_id"
+  Index        r85, r83, r84
+  Const        r86, "id"
+  Index        r87, r50, r86
+  Equal        r88, r85, r87
+  JumpIfFalse  r88, L7
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r89, r5
+  Len          r90, r89
+  Const        r91, 0
+L12:
+  Less         r92, r91, r90
+  JumpIfFalse  r92, L7
+  Index        r93, r89, r91
+  Move         r94, r93
+  Const        r95, "id"
+  Index        r96, r94, r95
+  Const        r97, "company_id"
+  Index        r98, r83, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L8
+  // where cn.country_code == "[us]" &&
+  Const        r100, "country_code"
+  Index        r101, r94, r100
+  // t.episode_nr >= 50 &&
+  Const        r102, "episode_nr"
+  Index        r103, r50, r102
+  Const        r104, 50
+  LessEq       r105, r104, r103
+  // t.episode_nr < 100
+  Const        r106, "episode_nr"
+  Index        r107, r50, r106
+  Const        r108, 100
+  Less         r109, r107, r108
+  // where cn.country_code == "[us]" &&
+  Const        r110, "[us]"
+  Equal        r111, r101, r110
+  // k.keyword == "character-name-in-title" &&
+  Const        r112, "keyword"
+  Index        r113, r72, r112
+  Const        r114, "character-name-in-title"
+  Equal        r115, r113, r114
+  // where cn.country_code == "[us]" &&
+  Move         r116, r111
+  JumpIfFalse  r116, L9
+  Move         r116, r115
+L9:
+  // k.keyword == "character-name-in-title" &&
+  Move         r117, r116
+  JumpIfFalse  r117, L10
+  Move         r117, r105
+L10:
+  // t.episode_nr >= 50 &&
+  Move         r118, r117
+  JumpIfFalse  r118, L11
+  Move         r118, r109
+L11:
+  // where cn.country_code == "[us]" &&
+  JumpIfFalse  r118, L8
+  // select { pseudonym: an.name, series: t.title }
+  Const        r119, "pseudonym"
+  Const        r120, "name"
+  Index        r121, r22, r120
+  Const        r122, "series"
+  Const        r123, "title"
+  Index        r124, r50, r123
+  Move         r125, r119
+  Move         r126, r121
+  Move         r127, r122
+  Move         r128, r124
+  MakeMap      r129, 2, r125
+  // from an in aka_name
+  Append       r130, r16, r129
+  Move         r16, r130
+L8:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r131, 1
+  Add          r132, r91, r131
+  Move         r91, r132
+  Jump         L12
+L7:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r133, 1
+  Add          r134, r80, r133
+  Move         r80, r134
+  Jump         L13
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r135, 1
+  Add          r136, r69, r135
+  Move         r69, r136
+  Jump         L14
+L5:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r137, 1
+  Add          r138, r58, r137
+  Move         r58, r138
+  Jump         L15
+L4:
+  // join t in title on t.id == ci.movie_id
+  Const        r139, 1
+  Add          r140, r47, r139
+  Move         r47, r140
+  Jump         L16
+L3:
+  // join ci in cast_info on ci.person_id == n.id
+  Const        r141, 1
+  Add          r142, r36, r141
+  Move         r36, r142
+  Jump         L17
+L2:
+  // join n in name on n.id == an.person_id
+  Const        r143, 1
+  Add          r144, r25, r143
+  Move         r25, r144
+  Jump         L18
+L1:
+  // from an in aka_name
+  Const        r145, 1
+  Add          r146, r19, r145
+  Move         r19, r146
+  Jump         L19
+L0:
+  // let rows =
+  Move         r147, r16
+  // cool_actor_pseudonym: min(from r in rows select r.pseudonym),
+  Const        r148, "cool_actor_pseudonym"
+  Const        r149, []
+  IterPrep     r150, r147
+  Len          r151, r150
+  Const        r152, 0
+L21:
+  Less         r153, r152, r151
+  JumpIfFalse  r153, L20
+  Index        r154, r150, r152
+  Move         r155, r154
+  Const        r156, "pseudonym"
+  Index        r157, r155, r156
+  Append       r158, r149, r157
+  Move         r149, r158
+  Const        r159, 1
+  Add          r160, r152, r159
+  Move         r152, r160
+  Jump         L21
+L20:
+  Min          r161, r149
+  // series_named_after_char: min(from r in rows select r.series)
+  Const        r162, "series_named_after_char"
+  Const        r163, []
+  IterPrep     r164, r147
+  Len          r165, r164
+  Const        r166, 0
+L23:
+  Less         r167, r166, r165
+  JumpIfFalse  r167, L22
+  Index        r168, r164, r166
+  Move         r155, r168
+  Const        r169, "series"
+  Index        r170, r155, r169
+  Append       r171, r163, r170
+  Move         r163, r171
+  Const        r172, 1
+  Add          r173, r166, r172
+  Move         r166, r173
+  Jump         L23
+L22:
+  Min          r174, r163
+  // cool_actor_pseudonym: min(from r in rows select r.pseudonym),
+  Move         r175, r148
+  Move         r176, r161
+  // series_named_after_char: min(from r in rows select r.series)
+  Move         r177, r162
+  Move         r178, r174
+  // {
+  MakeMap      r179, 2, r175
+  Move         r180, r179
+  // let result = [
+  MakeList     r181, 1, r180
+  Move         r182, r181
+  // json(result)
+  JSON         r182
+  // expect result == [
+  Const        r183, [{"cool_actor_pseudonym": "Alpha", "series_named_after_char": "Hero Bob"}]
+  Equal        r184, r182, r183
+  Expect       r184
+  Return       r0

--- a/tests/dataset/job/out/q17.ir.out
+++ b/tests/dataset/job/out/q17.ir.out
@@ -1,0 +1,262 @@
+func main (regs=154)
+  // let cast_info = [
+  Const        r0, [{"movie_id": 1, "person_id": 1}, {"movie_id": 2, "person_id": 2}]
+  Move         r1, r0
+  // let company_name = [
+  Const        r2, [{"country_code": "[us]", "id": 1}, {"country_code": "[ca]", "id": 2}]
+  Move         r3, r2
+  // let keyword = [
+  Const        r4, [{"id": 10, "keyword": "character-name-in-title"}, {"id": 20, "keyword": "other"}]
+  Move         r5, r4
+  // let movie_companies = [
+  Const        r6, [{"company_id": 1, "movie_id": 1}, {"company_id": 2, "movie_id": 2}]
+  Move         r7, r6
+  // let movie_keyword = [
+  Const        r8, [{"keyword_id": 10, "movie_id": 1}, {"keyword_id": 20, "movie_id": 2}]
+  Move         r9, r8
+  // let name = [
+  Const        r10, [{"id": 1, "name": "Bob Smith"}, {"id": 2, "name": "Alice Jones"}]
+  Move         r11, r10
+  // let title = [
+  Const        r12, [{"id": 1, "title": "Bob's Journey"}, {"id": 2, "title": "Foreign Film"}]
+  Move         r13, r12
+  // from n in name
+  Const        r14, []
+  IterPrep     r15, r11
+  Len          r16, r15
+  Const        r17, 0
+L19:
+  Less         r18, r17, r16
+  JumpIfFalse  r18, L0
+  Index        r19, r15, r17
+  Move         r20, r19
+  // join ci in cast_info on ci.person_id == n.id
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L18:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L1
+  Index        r25, r21, r23
+  Move         r26, r25
+  Const        r27, "person_id"
+  Index        r28, r26, r27
+  Const        r29, "id"
+  Index        r30, r20, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L2
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r32, r13
+  Len          r33, r32
+  Const        r34, 0
+L17:
+  Less         r35, r34, r33
+  JumpIfFalse  r35, L2
+  Index        r36, r32, r34
+  Move         r37, r36
+  Const        r38, "id"
+  Index        r39, r37, r38
+  Const        r40, "movie_id"
+  Index        r41, r26, r40
+  Equal        r42, r39, r41
+  JumpIfFalse  r42, L3
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r43, r9
+  Len          r44, r43
+  Const        r45, 0
+L16:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L3
+  Index        r47, r43, r45
+  Move         r48, r47
+  Const        r49, "movie_id"
+  Index        r50, r48, r49
+  Const        r51, "id"
+  Index        r52, r37, r51
+  Equal        r53, r50, r52
+  JumpIfFalse  r53, L4
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r54, r5
+  Len          r55, r54
+  Const        r56, 0
+L15:
+  Less         r57, r56, r55
+  JumpIfFalse  r57, L4
+  Index        r58, r54, r56
+  Move         r59, r58
+  Const        r60, "id"
+  Index        r61, r59, r60
+  Const        r62, "keyword_id"
+  Index        r63, r48, r62
+  Equal        r64, r61, r63
+  JumpIfFalse  r64, L5
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r65, r7
+  Len          r66, r65
+  Const        r67, 0
+L14:
+  Less         r68, r67, r66
+  JumpIfFalse  r68, L5
+  Index        r69, r65, r67
+  Move         r70, r69
+  Const        r71, "movie_id"
+  Index        r72, r70, r71
+  Const        r73, "id"
+  Index        r74, r37, r73
+  Equal        r75, r72, r74
+  JumpIfFalse  r75, L6
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r76, r3
+  Len          r77, r76
+  Const        r78, 0
+L13:
+  Less         r79, r78, r77
+  JumpIfFalse  r79, L6
+  Index        r80, r76, r78
+  Move         r81, r80
+  Const        r82, "id"
+  Index        r83, r81, r82
+  Const        r84, "company_id"
+  Index        r85, r70, r84
+  Equal        r86, r83, r85
+  JumpIfFalse  r86, L7
+  // where cn.country_code == "[us]" &&
+  Const        r87, "country_code"
+  Index        r88, r81, r87
+  Const        r89, "[us]"
+  Equal        r90, r88, r89
+  // k.keyword == "character-name-in-title" &&
+  Const        r91, "keyword"
+  Index        r92, r59, r91
+  Const        r93, "character-name-in-title"
+  Equal        r94, r92, r93
+  // ci.movie_id == mk.movie_id &&
+  Const        r95, "movie_id"
+  Index        r96, r26, r95
+  Const        r97, "movie_id"
+  Index        r98, r48, r97
+  Equal        r99, r96, r98
+  // ci.movie_id == mc.movie_id &&
+  Const        r100, "movie_id"
+  Index        r101, r26, r100
+  Const        r102, "movie_id"
+  Index        r103, r70, r102
+  Equal        r104, r101, r103
+  // mc.movie_id == mk.movie_id
+  Const        r105, "movie_id"
+  Index        r106, r70, r105
+  Const        r107, "movie_id"
+  Index        r108, r48, r107
+  Equal        r109, r106, r108
+  // where cn.country_code == "[us]" &&
+  Move         r110, r90
+  JumpIfFalse  r110, L8
+  Move         r110, r94
+L8:
+  // k.keyword == "character-name-in-title" &&
+  Move         r111, r110
+  JumpIfFalse  r111, L9
+  Const        r112, "name"
+  Index        r113, r20, r112
+  // n.name.starts_with("B") &&
+  Const        r114, "B"
+  Const        r115, 0
+  Len          r116, r114
+  Slice        r117, r113, r115, r116
+  Equal        r118, r117, r114
+  // k.keyword == "character-name-in-title" &&
+  Move         r111, r118
+L9:
+  // n.name.starts_with("B") &&
+  Move         r119, r111
+  JumpIfFalse  r119, L10
+  Move         r119, r99
+L10:
+  // ci.movie_id == mk.movie_id &&
+  Move         r120, r119
+  JumpIfFalse  r120, L11
+  Move         r120, r104
+L11:
+  // ci.movie_id == mc.movie_id &&
+  Move         r121, r120
+  JumpIfFalse  r121, L12
+  Move         r121, r109
+L12:
+  // where cn.country_code == "[us]" &&
+  JumpIfFalse  r121, L7
+  // select n.name
+  Const        r122, "name"
+  Index        r123, r20, r122
+  // from n in name
+  Append       r124, r14, r123
+  Move         r14, r124
+L7:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r125, 1
+  Add          r126, r78, r125
+  Move         r78, r126
+  Jump         L13
+L6:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r127, 1
+  Add          r128, r67, r127
+  Move         r67, r128
+  Jump         L14
+L5:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r129, 1
+  Add          r130, r56, r129
+  Move         r56, r130
+  Jump         L15
+L4:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r131, 1
+  Add          r132, r45, r131
+  Move         r45, r132
+  Jump         L16
+L3:
+  // join t in title on t.id == ci.movie_id
+  Const        r133, 1
+  Add          r134, r34, r133
+  Move         r34, r134
+  Jump         L17
+L2:
+  // join ci in cast_info on ci.person_id == n.id
+  Const        r135, 1
+  Add          r136, r23, r135
+  Move         r23, r136
+  Jump         L18
+L1:
+  // from n in name
+  Const        r137, 1
+  Add          r138, r17, r137
+  Move         r17, r138
+  Jump         L19
+L0:
+  // let matches =
+  Move         r139, r14
+  // member_in_charnamed_american_movie: min(matches),
+  Const        r140, "member_in_charnamed_american_movie"
+  Min          r141, r139
+  // a1: min(matches)
+  Const        r142, "a1"
+  Min          r143, r139
+  // member_in_charnamed_american_movie: min(matches),
+  Move         r144, r140
+  Move         r145, r141
+  // a1: min(matches)
+  Move         r146, r142
+  Move         r147, r143
+  // {
+  MakeMap      r148, 2, r144
+  Move         r149, r148
+  // let result = [
+  MakeList     r150, 1, r149
+  Move         r151, r150
+  // json(result)
+  JSON         r151
+  // expect result == [
+  Const        r152, [{"a1": "Bob Smith", "member_in_charnamed_american_movie": "Bob Smith"}]
+  Equal        r153, r151, r152
+  Expect       r153
+  Return       r0

--- a/tests/dataset/job/out/q18.ir.out
+++ b/tests/dataset/job/out/q18.ir.out
@@ -1,0 +1,358 @@
+func main (regs=215)
+  // let info_type = [
+  Const        r0, [{"id": 1, "info": "budget"}, {"id": 2, "info": "votes"}, {"id": 3, "info": "rating"}]
+  Move         r1, r0
+  // let name = [
+  Const        r2, [{"gender": "m", "id": 1, "name": "Big Tim"}, {"gender": "m", "id": 2, "name": "Slim Tim"}, {"gender": "f", "id": 3, "name": "Alice"}]
+  Move         r3, r2
+  // let title = [
+  Const        r4, [{"id": 10, "title": "Alpha"}, {"id": 20, "title": "Beta"}, {"id": 30, "title": "Gamma"}]
+  Move         r5, r4
+  // let cast_info = [
+  Const        r6, [{"movie_id": 10, "note": "(producer)", "person_id": 1}, {"movie_id": 20, "note": "(executive producer)", "person_id": 2}, {"movie_id": 30, "note": "(producer)", "person_id": 3}]
+  Move         r7, r6
+  // let movie_info = [
+  Const        r8, [{"info": 90, "info_type_id": 1, "movie_id": 10}, {"info": 120, "info_type_id": 1, "movie_id": 20}, {"info": 110, "info_type_id": 1, "movie_id": 30}]
+  Move         r9, r8
+  // let movie_info_idx = [
+  Const        r10, [{"info": 500, "info_type_id": 2, "movie_id": 10}, {"info": 400, "info_type_id": 2, "movie_id": 20}, {"info": 800, "info_type_id": 2, "movie_id": 30}]
+  Move         r11, r10
+  // from ci in cast_info
+  Const        r12, []
+  IterPrep     r13, r7
+  Len          r14, r13
+  Const        r15, 0
+L22:
+  Less         r16, r15, r14
+  JumpIfFalse  r16, L0
+  Index        r17, r13, r15
+  Move         r18, r17
+  // join n in name on n.id == ci.person_id
+  IterPrep     r19, r3
+  Len          r20, r19
+  Const        r21, 0
+L21:
+  Less         r22, r21, r20
+  JumpIfFalse  r22, L1
+  Index        r23, r19, r21
+  Move         r24, r23
+  Const        r25, "id"
+  Index        r26, r24, r25
+  Const        r27, "person_id"
+  Index        r28, r18, r27
+  Equal        r29, r26, r28
+  JumpIfFalse  r29, L2
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r30, r5
+  Len          r31, r30
+  Const        r32, 0
+L20:
+  Less         r33, r32, r31
+  JumpIfFalse  r33, L2
+  Index        r34, r30, r32
+  Move         r35, r34
+  Const        r36, "id"
+  Index        r37, r35, r36
+  Const        r38, "movie_id"
+  Index        r39, r18, r38
+  Equal        r40, r37, r39
+  JumpIfFalse  r40, L3
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r41, r9
+  Len          r42, r41
+  Const        r43, 0
+L19:
+  Less         r44, r43, r42
+  JumpIfFalse  r44, L3
+  Index        r45, r41, r43
+  Move         r46, r45
+  Const        r47, "movie_id"
+  Index        r48, r46, r47
+  Const        r49, "id"
+  Index        r50, r35, r49
+  Equal        r51, r48, r50
+  JumpIfFalse  r51, L4
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  IterPrep     r52, r11
+  Len          r53, r52
+  Const        r54, 0
+L18:
+  Less         r55, r54, r53
+  JumpIfFalse  r55, L4
+  Index        r56, r52, r54
+  Move         r57, r56
+  Const        r58, "movie_id"
+  Index        r59, r57, r58
+  Const        r60, "id"
+  Index        r61, r35, r60
+  Equal        r62, r59, r61
+  JumpIfFalse  r62, L5
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r63, r1
+  Len          r64, r63
+  Const        r65, 0
+L17:
+  Less         r66, r65, r64
+  JumpIfFalse  r66, L5
+  Index        r67, r63, r65
+  Move         r68, r67
+  Const        r69, "id"
+  Index        r70, r68, r69
+  Const        r71, "info_type_id"
+  Index        r72, r46, r71
+  Equal        r73, r70, r72
+  JumpIfFalse  r73, L6
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  IterPrep     r74, r1
+  Len          r75, r74
+  Const        r76, 0
+L16:
+  Less         r77, r76, r75
+  JumpIfFalse  r77, L6
+  Index        r78, r74, r76
+  Move         r79, r78
+  Const        r80, "id"
+  Index        r81, r79, r80
+  Const        r82, "info_type_id"
+  Index        r83, r57, r82
+  Equal        r84, r81, r83
+  JumpIfFalse  r84, L7
+  // ci.note in ["(producer)", "(executive producer)"] &&
+  Const        r85, "note"
+  Index        r86, r18, r85
+  Const        r87, ["(producer)", "(executive producer)"]
+  In           r88, r86, r87
+  // it1.info == "budget" &&
+  Const        r89, "info"
+  Index        r90, r68, r89
+  Const        r91, "budget"
+  Equal        r92, r90, r91
+  // it2.info == "votes" &&
+  Const        r93, "info"
+  Index        r94, r79, r93
+  Const        r95, "votes"
+  Equal        r96, r94, r95
+  // n.gender == "m" &&
+  Const        r97, "gender"
+  Index        r98, r24, r97
+  Const        r99, "m"
+  Equal        r100, r98, r99
+  // t.id == ci.movie_id &&
+  Const        r101, "id"
+  Index        r102, r35, r101
+  Const        r103, "movie_id"
+  Index        r104, r18, r103
+  Equal        r105, r102, r104
+  // ci.movie_id == mi.movie_id &&
+  Const        r106, "movie_id"
+  Index        r107, r18, r106
+  Const        r108, "movie_id"
+  Index        r109, r46, r108
+  Equal        r110, r107, r109
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r111, "movie_id"
+  Index        r112, r18, r111
+  Const        r113, "movie_id"
+  Index        r114, r57, r113
+  Equal        r115, r112, r114
+  // mi.movie_id == mi_idx.movie_id
+  Const        r116, "movie_id"
+  Index        r117, r46, r116
+  Const        r118, "movie_id"
+  Index        r119, r57, r118
+  Equal        r120, r117, r119
+  // ci.note in ["(producer)", "(executive producer)"] &&
+  Move         r121, r88
+  JumpIfFalse  r121, L8
+  Move         r121, r92
+L8:
+  // it1.info == "budget" &&
+  Move         r122, r121
+  JumpIfFalse  r122, L9
+  Move         r122, r96
+L9:
+  // it2.info == "votes" &&
+  Move         r123, r122
+  JumpIfFalse  r123, L10
+  Move         r123, r100
+L10:
+  // n.gender == "m" &&
+  Move         r124, r123
+  JumpIfFalse  r124, L11
+  Const        r125, "name"
+  Index        r126, r24, r125
+  // n.name.contains("Tim") &&
+  Const        r127, "Tim"
+  In           r128, r127, r126
+  // n.gender == "m" &&
+  Move         r124, r128
+L11:
+  // n.name.contains("Tim") &&
+  Move         r129, r124
+  JumpIfFalse  r129, L12
+  Move         r129, r105
+L12:
+  // t.id == ci.movie_id &&
+  Move         r130, r129
+  JumpIfFalse  r130, L13
+  Move         r130, r110
+L13:
+  // ci.movie_id == mi.movie_id &&
+  Move         r131, r130
+  JumpIfFalse  r131, L14
+  Move         r131, r115
+L14:
+  // ci.movie_id == mi_idx.movie_id &&
+  Move         r132, r131
+  JumpIfFalse  r132, L15
+  Move         r132, r120
+L15:
+  // where (
+  JumpIfFalse  r132, L7
+  // select { budget: mi.info, votes: mi_idx.info, title: t.title }
+  Const        r133, "budget"
+  Const        r134, "info"
+  Index        r135, r46, r134
+  Const        r136, "votes"
+  Const        r137, "info"
+  Index        r138, r57, r137
+  Const        r139, "title"
+  Const        r140, "title"
+  Index        r141, r35, r140
+  Move         r142, r133
+  Move         r143, r135
+  Move         r144, r136
+  Move         r145, r138
+  Move         r146, r139
+  Move         r147, r141
+  MakeMap      r148, 3, r142
+  // from ci in cast_info
+  Append       r149, r12, r148
+  Move         r12, r149
+L7:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r150, 1
+  Add          r151, r76, r150
+  Move         r76, r151
+  Jump         L16
+L6:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r152, 1
+  Add          r153, r65, r152
+  Move         r65, r153
+  Jump         L17
+L5:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r154, 1
+  Add          r155, r54, r154
+  Move         r54, r155
+  Jump         L18
+L4:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r156, 1
+  Add          r157, r43, r156
+  Move         r43, r157
+  Jump         L19
+L3:
+  // join t in title on t.id == ci.movie_id
+  Const        r158, 1
+  Add          r159, r32, r158
+  Move         r32, r159
+  Jump         L20
+L2:
+  // join n in name on n.id == ci.person_id
+  Const        r160, 1
+  Add          r161, r21, r160
+  Move         r21, r161
+  Jump         L21
+L1:
+  // from ci in cast_info
+  Const        r162, 1
+  Add          r163, r15, r162
+  Move         r15, r163
+  Jump         L22
+L0:
+  // let rows =
+  Move         r164, r12
+  // movie_budget: min(from r in rows select r.budget),
+  Const        r165, "movie_budget"
+  Const        r166, []
+  IterPrep     r167, r164
+  Len          r168, r167
+  Const        r169, 0
+L24:
+  Less         r170, r169, r168
+  JumpIfFalse  r170, L23
+  Index        r171, r167, r169
+  Move         r172, r171
+  Const        r173, "budget"
+  Index        r174, r172, r173
+  Append       r175, r166, r174
+  Move         r166, r175
+  Const        r176, 1
+  Add          r177, r169, r176
+  Move         r169, r177
+  Jump         L24
+L23:
+  Min          r178, r166
+  // movie_votes: min(from r in rows select r.votes),
+  Const        r179, "movie_votes"
+  Const        r180, []
+  IterPrep     r181, r164
+  Len          r182, r181
+  Const        r183, 0
+L26:
+  Less         r184, r183, r182
+  JumpIfFalse  r184, L25
+  Index        r185, r181, r183
+  Move         r172, r185
+  Const        r186, "votes"
+  Index        r187, r172, r186
+  Append       r188, r180, r187
+  Move         r180, r188
+  Const        r189, 1
+  Add          r190, r183, r189
+  Move         r183, r190
+  Jump         L26
+L25:
+  Min          r191, r180
+  // movie_title: min(from r in rows select r.title)
+  Const        r192, "movie_title"
+  Const        r193, []
+  IterPrep     r194, r164
+  Len          r195, r194
+  Const        r196, 0
+L28:
+  Less         r197, r196, r195
+  JumpIfFalse  r197, L27
+  Index        r198, r194, r196
+  Move         r172, r198
+  Const        r199, "title"
+  Index        r200, r172, r199
+  Append       r201, r193, r200
+  Move         r193, r201
+  Const        r202, 1
+  Add          r203, r196, r202
+  Move         r196, r203
+  Jump         L28
+L27:
+  Min          r204, r193
+  // movie_budget: min(from r in rows select r.budget),
+  Move         r205, r165
+  Move         r206, r178
+  // movie_votes: min(from r in rows select r.votes),
+  Move         r207, r179
+  Move         r208, r191
+  // movie_title: min(from r in rows select r.title)
+  Move         r209, r192
+  Move         r210, r204
+  // let result = {
+  MakeMap      r211, 3, r205
+  Move         r212, r211
+  // json(result)
+  JSON         r212
+  // expect result == { movie_budget: 90, movie_votes: 400, movie_title: "Alpha" }
+  Const        r213, {"movie_budget": 90, "movie_title": "Alpha", "movie_votes": 400}
+  Equal        r214, r212, r213
+  Expect       r214
+  Return       r0

--- a/tests/dataset/job/out/q19.ir.out
+++ b/tests/dataset/job/out/q19.ir.out
@@ -1,0 +1,470 @@
+func main (regs=275)
+  // let aka_name = [
+  Const        r0, [{"name": "A. Stone", "person_id": 1}, {"name": "J. Doe", "person_id": 2}]
+  Move         r1, r0
+  // let char_name = [
+  Const        r2, [{"id": 1, "name": "Protagonist"}, {"id": 2, "name": "Extra"}]
+  Move         r3, r2
+  // let cast_info = [
+  Const        r4, [{"movie_id": 1, "note": "(voice)", "person_id": 1, "person_role_id": 1, "role_id": 1}, {"movie_id": 2, "note": "Cameo", "person_id": 2, "person_role_id": 2, "role_id": 2}]
+  Move         r5, r4
+  // let company_name = [
+  Const        r6, [{"country_code": "[us]", "id": 10}, {"country_code": "[gb]", "id": 20}]
+  Move         r7, r6
+  // let info_type = [
+  Const        r8, [{"id": 100, "info": "release dates"}]
+  Move         r9, r8
+  // let movie_companies = [
+  Const        r10, [{"company_id": 10, "movie_id": 1, "note": "Studio (USA)"}, {"company_id": 20, "movie_id": 2, "note": "Other (worldwide)"}]
+  Move         r11, r10
+  // let movie_info = [
+  Const        r12, [{"info": "USA: June 2006", "info_type_id": 100, "movie_id": 1}, {"info": "UK: 1999", "info_type_id": 100, "movie_id": 2}]
+  Move         r13, r12
+  // let name = [
+  Const        r14, [{"gender": "f", "id": 1, "name": "Angela Stone"}, {"gender": "m", "id": 2, "name": "Bob Angstrom"}]
+  Move         r15, r14
+  // let role_type = [
+  Const        r16, [{"id": 1, "role": "actress"}, {"id": 2, "role": "actor"}]
+  Move         r17, r16
+  // let title = [
+  Const        r18, [{"id": 1, "production_year": 2006, "title": "Voiced Movie"}, {"id": 2, "production_year": 2010, "title": "Other Movie"}]
+  Move         r19, r18
+  // from an in aka_name
+  Const        r20, []
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L35:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L0
+  Index        r25, r21, r23
+  Move         r26, r25
+  // join n in name on n.id == an.person_id
+  IterPrep     r27, r15
+  Len          r28, r27
+  Const        r29, 0
+L34:
+  Less         r30, r29, r28
+  JumpIfFalse  r30, L1
+  Index        r31, r27, r29
+  Move         r32, r31
+  Const        r33, "id"
+  Index        r34, r32, r33
+  Const        r35, "person_id"
+  Index        r36, r26, r35
+  Equal        r37, r34, r36
+  JumpIfFalse  r37, L2
+  // join ci in cast_info on ci.person_id == an.person_id
+  IterPrep     r38, r5
+  Len          r39, r38
+  Const        r40, 0
+L33:
+  Less         r41, r40, r39
+  JumpIfFalse  r41, L2
+  Index        r42, r38, r40
+  Move         r43, r42
+  Const        r44, "person_id"
+  Index        r45, r43, r44
+  Const        r46, "person_id"
+  Index        r47, r26, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L3
+  // join chn in char_name on chn.id == ci.person_role_id
+  IterPrep     r49, r3
+  Len          r50, r49
+  Const        r51, 0
+L32:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r53, r49, r51
+  Move         r54, r53
+  Const        r55, "id"
+  Index        r56, r54, r55
+  Const        r57, "person_role_id"
+  Index        r58, r43, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
+  // join rt in role_type on rt.id == ci.role_id
+  IterPrep     r60, r17
+  Len          r61, r60
+  Const        r62, 0
+L31:
+  Less         r63, r62, r61
+  JumpIfFalse  r63, L4
+  Index        r64, r60, r62
+  Move         r65, r64
+  Const        r66, "id"
+  Index        r67, r65, r66
+  Const        r68, "role_id"
+  Index        r69, r43, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L5
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r71, r19
+  Len          r72, r71
+  Const        r73, 0
+L30:
+  Less         r74, r73, r72
+  JumpIfFalse  r74, L5
+  Index        r75, r71, r73
+  Move         r76, r75
+  Const        r77, "id"
+  Index        r78, r76, r77
+  Const        r79, "movie_id"
+  Index        r80, r43, r79
+  Equal        r81, r78, r80
+  JumpIfFalse  r81, L6
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r82, r11
+  Len          r83, r82
+  Const        r84, 0
+L29:
+  Less         r85, r84, r83
+  JumpIfFalse  r85, L6
+  Index        r86, r82, r84
+  Move         r87, r86
+  Const        r88, "movie_id"
+  Index        r89, r87, r88
+  Const        r90, "id"
+  Index        r91, r76, r90
+  Equal        r92, r89, r91
+  JumpIfFalse  r92, L7
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r93, r7
+  Len          r94, r93
+  Const        r95, 0
+L28:
+  Less         r96, r95, r94
+  JumpIfFalse  r96, L7
+  Index        r97, r93, r95
+  Move         r98, r97
+  Const        r99, "id"
+  Index        r100, r98, r99
+  Const        r101, "company_id"
+  Index        r102, r87, r101
+  Equal        r103, r100, r102
+  JumpIfFalse  r103, L8
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r104, r13
+  Len          r105, r104
+  Const        r106, 0
+L27:
+  Less         r107, r106, r105
+  JumpIfFalse  r107, L8
+  Index        r108, r104, r106
+  Move         r109, r108
+  Const        r110, "movie_id"
+  Index        r111, r109, r110
+  Const        r112, "id"
+  Index        r113, r76, r112
+  Equal        r114, r111, r113
+  JumpIfFalse  r114, L9
+  // join it in info_type on it.id == mi.info_type_id
+  IterPrep     r115, r9
+  Len          r116, r115
+  Const        r117, 0
+L26:
+  Less         r118, r117, r116
+  JumpIfFalse  r118, L9
+  Index        r119, r115, r117
+  Move         r120, r119
+  Const        r121, "id"
+  Index        r122, r120, r121
+  Const        r123, "info_type_id"
+  Index        r124, r109, r123
+  Equal        r125, r122, r124
+  JumpIfFalse  r125, L10
+  // where ci.note in [
+  Const        r126, "note"
+  Index        r127, r43, r126
+  // t.production_year >= 2005 &&
+  Const        r128, "production_year"
+  Index        r129, r76, r128
+  Const        r130, 2005
+  LessEq       r131, r130, r129
+  // t.production_year <= 2009
+  Const        r132, "production_year"
+  Index        r133, r76, r132
+  Const        r134, 2009
+  LessEq       r135, r133, r134
+  // where ci.note in [
+  Const        r136, ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]
+  In           r137, r127, r136
+  // cn.country_code == "[us]" &&
+  Const        r138, "country_code"
+  Index        r139, r98, r138
+  Const        r140, "[us]"
+  Equal        r141, r139, r140
+  // it.info == "release dates" &&
+  Const        r142, "info"
+  Index        r143, r120, r142
+  Const        r144, "release dates"
+  Equal        r145, r143, r144
+  // mc.note != null &&
+  Const        r146, "note"
+  Index        r147, r87, r146
+  Const        r148, nil
+  NotEqual     r149, r147, r148
+  // mi.info != null &&
+  Const        r150, "info"
+  Index        r151, r109, r150
+  Const        r152, nil
+  NotEqual     r153, r151, r152
+  // n.gender == "f" &&
+  Const        r154, "gender"
+  Index        r155, r32, r154
+  Const        r156, "f"
+  Equal        r157, r155, r156
+  // rt.role == "actress" &&
+  Const        r158, "role"
+  Index        r159, r65, r158
+  Const        r160, "actress"
+  Equal        r161, r159, r160
+  // ] &&
+  Move         r162, r137
+  JumpIfFalse  r162, L11
+  Move         r162, r141
+L11:
+  // cn.country_code == "[us]" &&
+  Move         r163, r162
+  JumpIfFalse  r163, L12
+  Move         r163, r145
+L12:
+  // it.info == "release dates" &&
+  Move         r164, r163
+  JumpIfFalse  r164, L13
+  Move         r164, r149
+L13:
+  // mc.note != null &&
+  Move         r165, r164
+  JumpIfFalse  r165, L14
+  Const        r166, "note"
+  Index        r167, r87, r166
+  // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Const        r168, "(USA)"
+  In           r169, r168, r167
+  Move         r170, r169
+  JumpIfTrue   r170, L15
+  Const        r171, "note"
+  Index        r172, r87, r171
+  Const        r173, "(worldwide)"
+  In           r174, r173, r172
+  Move         r170, r174
+L15:
+  // mc.note != null &&
+  Move         r165, r170
+L14:
+  // (mc.note.contains("(USA)") || mc.note.contains("(worldwide)")) &&
+  Move         r175, r165
+  JumpIfFalse  r175, L16
+  Move         r175, r153
+L16:
+  // mi.info != null &&
+  Move         r176, r175
+  JumpIfFalse  r176, L17
+  Const        r177, "info"
+  Index        r178, r109, r177
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Const        r179, "Japan:"
+  In           r180, r179, r178
+  Move         r181, r180
+  JumpIfFalse  r181, L18
+  Const        r182, "info"
+  Index        r183, r109, r182
+  Const        r184, "200"
+  In           r185, r184, r183
+  Move         r181, r185
+L18:
+  Move         r186, r181
+  JumpIfTrue   r186, L19
+  Const        r187, "info"
+  Index        r188, r109, r187
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Const        r189, "USA:"
+  In           r190, r189, r188
+  Move         r191, r190
+  JumpIfFalse  r191, L20
+  Const        r192, "info"
+  Index        r193, r109, r192
+  Const        r194, "200"
+  In           r195, r194, r193
+  Move         r191, r195
+L20:
+  // ((mi.info.contains("Japan:") && mi.info.contains("200")) ||
+  Move         r186, r191
+L19:
+  // mi.info != null &&
+  Move         r176, r186
+L17:
+  // (mi.info.contains("USA:") && mi.info.contains("200"))) &&
+  Move         r196, r176
+  JumpIfFalse  r196, L21
+  Move         r196, r157
+L21:
+  // n.gender == "f" &&
+  Move         r197, r196
+  JumpIfFalse  r197, L22
+  Const        r198, "name"
+  Index        r199, r32, r198
+  // n.name.contains("Ang") &&
+  Const        r200, "Ang"
+  In           r201, r200, r199
+  // n.gender == "f" &&
+  Move         r197, r201
+L22:
+  // n.name.contains("Ang") &&
+  Move         r202, r197
+  JumpIfFalse  r202, L23
+  Move         r202, r161
+L23:
+  // rt.role == "actress" &&
+  Move         r203, r202
+  JumpIfFalse  r203, L24
+  Move         r203, r131
+L24:
+  // t.production_year >= 2005 &&
+  Move         r204, r203
+  JumpIfFalse  r204, L25
+  Move         r204, r135
+L25:
+  // where ci.note in [
+  JumpIfFalse  r204, L10
+  // select { actress: n.name, movie: t.title }
+  Const        r205, "actress"
+  Const        r206, "name"
+  Index        r207, r32, r206
+  Const        r208, "movie"
+  Const        r209, "title"
+  Index        r210, r76, r209
+  Move         r211, r205
+  Move         r212, r207
+  Move         r213, r208
+  Move         r214, r210
+  MakeMap      r215, 2, r211
+  // from an in aka_name
+  Append       r216, r20, r215
+  Move         r20, r216
+L10:
+  // join it in info_type on it.id == mi.info_type_id
+  Const        r217, 1
+  Add          r218, r117, r217
+  Move         r117, r218
+  Jump         L26
+L9:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r219, 1
+  Add          r220, r106, r219
+  Move         r106, r220
+  Jump         L27
+L8:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r221, 1
+  Add          r222, r95, r221
+  Move         r95, r222
+  Jump         L28
+L7:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r223, 1
+  Add          r224, r84, r223
+  Move         r84, r224
+  Jump         L29
+L6:
+  // join t in title on t.id == ci.movie_id
+  Const        r225, 1
+  Add          r226, r73, r225
+  Move         r73, r226
+  Jump         L30
+L5:
+  // join rt in role_type on rt.id == ci.role_id
+  Const        r227, 1
+  Add          r228, r62, r227
+  Move         r62, r228
+  Jump         L31
+L4:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r229, 1
+  Add          r230, r51, r229
+  Move         r51, r230
+  Jump         L32
+L3:
+  // join ci in cast_info on ci.person_id == an.person_id
+  Const        r231, 1
+  Add          r232, r40, r231
+  Move         r40, r232
+  Jump         L33
+L2:
+  // join n in name on n.id == an.person_id
+  Const        r233, 1
+  Add          r234, r29, r233
+  Move         r29, r234
+  Jump         L34
+L1:
+  // from an in aka_name
+  Const        r235, 1
+  Add          r236, r23, r235
+  Move         r23, r236
+  Jump         L35
+L0:
+  // let matches =
+  Move         r237, r20
+  // voicing_actress: min(from r in matches select r.actress),
+  Const        r238, "voicing_actress"
+  Const        r239, []
+  IterPrep     r240, r237
+  Len          r241, r240
+  Const        r242, 0
+L37:
+  Less         r243, r242, r241
+  JumpIfFalse  r243, L36
+  Index        r244, r240, r242
+  Move         r245, r244
+  Const        r246, "actress"
+  Index        r247, r245, r246
+  Append       r248, r239, r247
+  Move         r239, r248
+  Const        r249, 1
+  Add          r250, r242, r249
+  Move         r242, r250
+  Jump         L37
+L36:
+  Min          r251, r239
+  // voiced_movie: min(from r in matches select r.movie)
+  Const        r252, "voiced_movie"
+  Const        r253, []
+  IterPrep     r254, r237
+  Len          r255, r254
+  Const        r256, 0
+L39:
+  Less         r257, r256, r255
+  JumpIfFalse  r257, L38
+  Index        r258, r254, r256
+  Move         r245, r258
+  Const        r259, "movie"
+  Index        r260, r245, r259
+  Append       r261, r253, r260
+  Move         r253, r261
+  Const        r262, 1
+  Add          r263, r256, r262
+  Move         r256, r263
+  Jump         L39
+L38:
+  Min          r264, r253
+  // voicing_actress: min(from r in matches select r.actress),
+  Move         r265, r238
+  Move         r266, r251
+  // voiced_movie: min(from r in matches select r.movie)
+  Move         r267, r252
+  Move         r268, r264
+  // {
+  MakeMap      r269, 2, r265
+  Move         r270, r269
+  // let result = [
+  MakeList     r271, 1, r270
+  Move         r272, r271
+  // json(result)
+  JSON         r272
+  // expect result == [
+  Const        r273, [{"voiced_movie": "Voiced Movie", "voicing_actress": "Angela Stone"}]
+  Equal        r274, r272, r273
+  Expect       r274
+  Return       r0

--- a/tests/dataset/job/out/q20.ir.out
+++ b/tests/dataset/job/out/q20.ir.out
@@ -1,0 +1,338 @@
+func main (regs=198)
+  // let comp_cast_type = [
+  Const        r0, [{"id": 1, "kind": "cast"}, {"id": 2, "kind": "complete cast"}]
+  Move         r1, r0
+  // let char_name = [
+  Const        r2, [{"id": 1, "name": "Tony Stark"}, {"id": 2, "name": "Sherlock Holmes"}]
+  Move         r3, r2
+  // let complete_cast = [
+  Const        r4, [{"movie_id": 1, "status_id": 2, "subject_id": 1}, {"movie_id": 2, "status_id": 2, "subject_id": 1}]
+  Move         r5, r4
+  // let name = [
+  Const        r6, [{"id": 1, "name": "Robert Downey Jr."}, {"id": 2, "name": "Another Actor"}]
+  Move         r7, r6
+  // let cast_info = [
+  Const        r8, [{"movie_id": 1, "person_id": 1, "person_role_id": 1}, {"movie_id": 2, "person_id": 2, "person_role_id": 2}]
+  Move         r9, r8
+  // let keyword = [
+  Const        r10, [{"id": 10, "keyword": "superhero"}, {"id": 20, "keyword": "romance"}]
+  Move         r11, r10
+  // let movie_keyword = [
+  Const        r12, [{"keyword_id": 10, "movie_id": 1}, {"keyword_id": 20, "movie_id": 2}]
+  Move         r13, r12
+  // let kind_type = [
+  Const        r14, [{"id": 1, "kind": "movie"}]
+  Move         r15, r14
+  // let title = [
+  Const        r16, [{"id": 1, "kind_id": 1, "production_year": 2008, "title": "Iron Man"}, {"id": 2, "kind_id": 1, "production_year": 1940, "title": "Old Hero"}]
+  Move         r17, r16
+  // from cc in complete_cast
+  Const        r18, []
+  IterPrep     r19, r5
+  Len          r20, r19
+  Const        r21, 0
+L27:
+  Less         r22, r21, r20
+  JumpIfFalse  r22, L0
+  Index        r23, r19, r21
+  Move         r24, r23
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  IterPrep     r25, r1
+  Len          r26, r25
+  Const        r27, 0
+L26:
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L1
+  Index        r29, r25, r27
+  Move         r30, r29
+  Const        r31, "id"
+  Index        r32, r30, r31
+  Const        r33, "subject_id"
+  Index        r34, r24, r33
+  Equal        r35, r32, r34
+  JumpIfFalse  r35, L2
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  IterPrep     r36, r1
+  Len          r37, r36
+  Const        r38, 0
+L25:
+  Less         r39, r38, r37
+  JumpIfFalse  r39, L2
+  Index        r40, r36, r38
+  Move         r41, r40
+  Const        r42, "id"
+  Index        r43, r41, r42
+  Const        r44, "status_id"
+  Index        r45, r24, r44
+  Equal        r46, r43, r45
+  JumpIfFalse  r46, L3
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  IterPrep     r47, r9
+  Len          r48, r47
+  Const        r49, 0
+L24:
+  Less         r50, r49, r48
+  JumpIfFalse  r50, L3
+  Index        r51, r47, r49
+  Move         r52, r51
+  Const        r53, "movie_id"
+  Index        r54, r52, r53
+  Const        r55, "movie_id"
+  Index        r56, r24, r55
+  Equal        r57, r54, r56
+  JumpIfFalse  r57, L4
+  // join chn in char_name on chn.id == ci.person_role_id
+  IterPrep     r58, r3
+  Len          r59, r58
+  Const        r60, 0
+L23:
+  Less         r61, r60, r59
+  JumpIfFalse  r61, L4
+  Index        r62, r58, r60
+  Move         r63, r62
+  Const        r64, "id"
+  Index        r65, r63, r64
+  Const        r66, "person_role_id"
+  Index        r67, r52, r66
+  Equal        r68, r65, r67
+  JumpIfFalse  r68, L5
+  // join n in name on n.id == ci.person_id
+  IterPrep     r69, r7
+  Len          r70, r69
+  Const        r71, 0
+L22:
+  Less         r72, r71, r70
+  JumpIfFalse  r72, L5
+  Index        r73, r69, r71
+  Move         r74, r73
+  Const        r75, "id"
+  Index        r76, r74, r75
+  Const        r77, "person_id"
+  Index        r78, r52, r77
+  Equal        r79, r76, r78
+  JumpIfFalse  r79, L6
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  IterPrep     r80, r13
+  Len          r81, r80
+  Const        r82, 0
+L21:
+  Less         r83, r82, r81
+  JumpIfFalse  r83, L6
+  Index        r84, r80, r82
+  Move         r85, r84
+  Const        r86, "movie_id"
+  Index        r87, r85, r86
+  Const        r88, "movie_id"
+  Index        r89, r24, r88
+  Equal        r90, r87, r89
+  JumpIfFalse  r90, L7
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r91, r11
+  Len          r92, r91
+  Const        r93, 0
+L20:
+  Less         r94, r93, r92
+  JumpIfFalse  r94, L7
+  Index        r95, r91, r93
+  Move         r96, r95
+  Const        r97, "id"
+  Index        r98, r96, r97
+  Const        r99, "keyword_id"
+  Index        r100, r85, r99
+  Equal        r101, r98, r100
+  JumpIfFalse  r101, L8
+  // join t in title on t.id == cc.movie_id
+  IterPrep     r102, r17
+  Len          r103, r102
+  Const        r104, 0
+L19:
+  Less         r105, r104, r103
+  JumpIfFalse  r105, L8
+  Index        r106, r102, r104
+  Move         r107, r106
+  Const        r108, "id"
+  Index        r109, r107, r108
+  Const        r110, "movie_id"
+  Index        r111, r24, r110
+  Equal        r112, r109, r111
+  JumpIfFalse  r112, L9
+  // join kt in kind_type on kt.id == t.kind_id
+  IterPrep     r113, r15
+  Len          r114, r113
+  Const        r115, 0
+L18:
+  Less         r116, r115, r114
+  JumpIfFalse  r116, L9
+  Index        r117, r113, r115
+  Move         r118, r117
+  Const        r119, "id"
+  Index        r120, r118, r119
+  Const        r121, "kind_id"
+  Index        r122, r107, r121
+  Equal        r123, r120, r122
+  JumpIfFalse  r123, L10
+  // where cct1.kind == "cast" &&
+  Const        r124, "kind"
+  Index        r125, r30, r124
+  // t.production_year > 1950
+  Const        r126, "production_year"
+  Index        r127, r107, r126
+  Const        r128, 1950
+  Less         r129, r128, r127
+  // where cct1.kind == "cast" &&
+  Const        r130, "cast"
+  Equal        r131, r125, r130
+  // k.keyword in [
+  Const        r132, "keyword"
+  Index        r133, r96, r132
+  Const        r134, ["superhero", "sequel", "second-part", "marvel-comics", "based-on-comic", "tv-special", "fight", "violence"]
+  In           r135, r133, r134
+  // kt.kind == "movie" &&
+  Const        r136, "kind"
+  Index        r137, r118, r136
+  Const        r138, "movie"
+  Equal        r139, r137, r138
+  // where cct1.kind == "cast" &&
+  Move         r140, r131
+  JumpIfFalse  r140, L11
+  Const        r141, "kind"
+  Index        r142, r41, r141
+  // cct2.kind.contains("complete") &&
+  Const        r143, "complete"
+  In           r144, r143, r142
+  // where cct1.kind == "cast" &&
+  Move         r140, r144
+L11:
+  // cct2.kind.contains("complete") &&
+  Move         r145, r140
+  JumpIfFalse  r145, L12
+  Const        r146, "name"
+  Index        r147, r63, r146
+  // (!chn.name.contains("Sherlock")) &&
+  Const        r148, "Sherlock"
+  In           r149, r148, r147
+  Not          r150, r149
+  // cct2.kind.contains("complete") &&
+  Move         r145, r150
+L12:
+  // (!chn.name.contains("Sherlock")) &&
+  Move         r151, r145
+  JumpIfFalse  r151, L13
+  Const        r152, "name"
+  Index        r153, r63, r152
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Const        r154, "Tony Stark"
+  In           r155, r154, r153
+  Move         r156, r155
+  JumpIfTrue   r156, L14
+  Const        r157, "name"
+  Index        r158, r63, r157
+  Const        r159, "Iron Man"
+  In           r160, r159, r158
+  Move         r156, r160
+L14:
+  // (!chn.name.contains("Sherlock")) &&
+  Move         r151, r156
+L13:
+  // (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
+  Move         r161, r151
+  JumpIfFalse  r161, L15
+  Move         r161, r135
+L15:
+  // ] &&
+  Move         r162, r161
+  JumpIfFalse  r162, L16
+  Move         r162, r139
+L16:
+  // kt.kind == "movie" &&
+  Move         r163, r162
+  JumpIfFalse  r163, L17
+  Move         r163, r129
+L17:
+  // where cct1.kind == "cast" &&
+  JumpIfFalse  r163, L10
+  // select t.title
+  Const        r164, "title"
+  Index        r165, r107, r164
+  // from cc in complete_cast
+  Append       r166, r18, r165
+  Move         r18, r166
+L10:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r167, 1
+  Add          r168, r115, r167
+  Move         r115, r168
+  Jump         L18
+L9:
+  // join t in title on t.id == cc.movie_id
+  Const        r169, 1
+  Add          r170, r104, r169
+  Move         r104, r170
+  Jump         L19
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r171, 1
+  Add          r172, r93, r171
+  Move         r93, r172
+  Jump         L20
+L7:
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  Const        r173, 1
+  Add          r174, r82, r173
+  Move         r82, r174
+  Jump         L21
+L6:
+  // join n in name on n.id == ci.person_id
+  Const        r175, 1
+  Add          r176, r71, r175
+  Move         r71, r176
+  Jump         L22
+L5:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r177, 1
+  Add          r178, r60, r177
+  Move         r60, r178
+  Jump         L23
+L4:
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  Const        r179, 1
+  Add          r180, r49, r179
+  Move         r49, r180
+  Jump         L24
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r181, 1
+  Add          r182, r38, r181
+  Move         r38, r182
+  Jump         L25
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r183, 1
+  Add          r184, r27, r183
+  Move         r27, r184
+  Jump         L26
+L1:
+  // from cc in complete_cast
+  Const        r185, 1
+  Add          r186, r21, r185
+  Move         r21, r186
+  Jump         L27
+L0:
+  // let matches =
+  Move         r187, r18
+  // let result = [ { complete_downey_ironman_movie: min(matches) } ]
+  Const        r188, "complete_downey_ironman_movie"
+  Min          r189, r187
+  Move         r190, r188
+  Move         r191, r189
+  MakeMap      r192, 1, r190
+  Move         r193, r192
+  MakeList     r194, 1, r193
+  Move         r195, r194
+  // json(result)
+  JSON         r195
+  // expect result == [ { complete_downey_ironman_movie: "Iron Man" } ]
+  Const        r196, [{"complete_downey_ironman_movie": "Iron Man"}]
+  Equal        r197, r195, r196
+  Expect       r197
+  Return       r0

--- a/tests/dataset/job/q17.mochi
+++ b/tests/dataset/job/q17.mochi
@@ -43,7 +43,7 @@ let matches =
   join cn in company_name on cn.id == mc.company_id
   where cn.country_code == "[us]" &&
         k.keyword == "character-name-in-title" &&
-        n.name LIKE "B%" &&
+        n.name.starts_with("B") &&
         ci.movie_id == mk.movie_id &&
         ci.movie_id == mc.movie_id &&
         mc.movie_id == mk.movie_id

--- a/tests/dataset/job/q20.mochi
+++ b/tests/dataset/job/q20.mochi
@@ -55,7 +55,7 @@ let matches =
   join kt in kind_type on kt.id == t.kind_id
   where cct1.kind == "cast" &&
         cct2.kind.contains("complete") &&
-        !chn.name.contains("Sherlock") &&
+        (!chn.name.contains("Sherlock")) &&
         (chn.name.contains("Tony Stark") || chn.name.contains("Iron Man")) &&
         k.keyword in [
           "superhero", "sequel", "second-part", "marvel-comics",

--- a/types/check.go
+++ b/types/check.go
@@ -1381,6 +1381,8 @@ func checkPrimary(p *parser.Primary, env *Env, expected Type) (Type, error) {
 			return StringType{}, nil
 		case p.Lit.Bool != nil:
 			return BoolType{}, nil
+		case p.Lit.Null:
+			return AnyType{}, nil
 		}
 
 	case p.Selector != nil:

--- a/types/infer.go
+++ b/types/infer.go
@@ -193,6 +193,8 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 			return StringType{}
 		case p.Lit.Bool != nil:
 			return BoolType{}
+		case p.Lit.Null:
+			return AnyType{}
 		}
 	case p.Selector != nil:
 		if env != nil {
@@ -777,6 +779,8 @@ func TypeOfPrimaryBasic(p *parser.Primary, env *Env) Type {
 			return FloatType{}
 		case p.Lit.Bool != nil:
 			return BoolType{}
+		case p.Lit.Null:
+			return AnyType{}
 		}
 	case p.List != nil:
 		return ListType{Elem: AnyType{}}


### PR DESCRIPTION
## Summary
- support `null` literal in parser, type checker and VM
- fix JOB queries q17 and q20 for existing syntax
- generate `.ir.out` files for JOB queries q11–q20

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e6ebb55b883208a7c295a731e04bb