### PR TITLE
Add Racket golden test for JOB dataset query

### DIFF
--- a/compile/x/rkt/job_golden_test.go
+++ b/compile/x/rkt/job_golden_test.go
@@ -1,0 +1,61 @@
+package rktcode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	rktcode "mochi/compile/x/rkt"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestRacketCompiler_JOBQ1 compiles the JOB benchmark query 1 to Racket and
+// verifies both the generated code and runtime output match the golden files.
+func TestRacketCompiler_JOBQ1(t *testing.T) {
+	if err := rktcode.EnsureRacket(); err != nil {
+		t.Skipf("racket not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := rktcode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	wantCode, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "rkt", "q1.rkt.out"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q1.rkt.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(wantCode))
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.rkt")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("racket", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("racket run error: %v\n%s", err, out)
+	}
+	gotOut := bytes.TrimSpace(out)
+	wantOut, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "rkt", "q1.out"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+		t.Errorf("output mismatch for q1.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", gotOut, bytes.TrimSpace(wantOut))
+	}
+}

--- a/tests/dataset/job/compiler/rkt/q1.out
+++ b/tests/dataset/job/compiler/rkt/q1.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Good Movie","movie_year":1995,"production_note":"ACME (co-production)"}]

--- a/tests/dataset/job/compiler/rkt/q1.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q1.rkt.out
@@ -1,0 +1,111 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (_min v)
+  (define lst (if (hash? v) (hash-values v) v))
+  (unless (list? lst) (error "min expects list or group"))
+  (if (null? lst) 0
+      (foldl (lambda (a b)
+               (cond [(and (number? a) (number? b)) (if (< b a) b a)]
+                     [(and (string? a) (string? b)) (if (string<? b a) b a)]
+                     [else a]))
+             (car lst) (cdr lst))))
+(define (_max v)
+  (define lst (if (hash? v) (hash-values v) v))
+  (unless (list? lst) (error "max expects list or group"))
+  (if (null? lst) 0
+      (foldl (lambda (a b)
+               (cond [(and (number? a) (number? b)) (if (> b a) b a)]
+                     [(and (string? a) (string? b)) (if (string>? b a) b a)]
+                     [else a]))
+             (car lst) (cdr lst))))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (if (hash? v)
+      (for/hash ([(k val) (in-hash v)])
+        (values (if (string? k) (string->symbol k) k) val))
+      v))(define (test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production)
+  (unless (equal? result (hash 'production_note "ACME (co-production)" 'movie_title "Good Movie" 'movie_year 1995)) (error "expect failed"))
+)
+
+(define company_type (list (hash 'id 1 'kind "production companies") (hash 'id 2 'kind "distributors")))
+(define info_type (list (hash 'id 10 'info "top 250 rank") (hash 'id 20 'info "bottom 10 rank")))
+(define title (list (hash 'id 100 'title "Good Movie" 'production_year 1995) (hash 'id 200 'title "Bad Movie" 'production_year 2000)))
+(define movie_companies (list (hash 'movie_id 100 'company_type_id 1 'note "ACME (co-production)") (hash 'movie_id 200 'company_type_id 1 'note "MGM (as Metro-Goldwyn-Mayer Pictures)")))
+(define movie_info_idx (list (hash 'movie_id 100 'info_type_id 10) (hash 'movie_id 200 'info_type_id 20)))
+(define filtered (let ([_res '()])
+  (for ([ct company_type])
+    (for ([mc movie_companies])
+      (when (equal? (hash-ref ct 'id) (hash-ref mc 'company_type_id))
+        (for ([t title])
+          (when (equal? (hash-ref t 'id) (hash-ref mc 'movie_id))
+            (for ([mi movie_info_idx])
+              (when (equal? (hash-ref mi 'movie_id) (hash-ref t 'id))
+                (for ([it info_type])
+                  (when (equal? (hash-ref it 'id) (hash-ref mi 'info_type_id))
+                    (when (and (and (and (equal? (hash-ref ct 'kind) "production companies") (equal? (hash-ref it 'info) "top 250 rank")) (not (cond [(hash? (hash-ref mc 'note)) (hash-has-key? (hash-ref mc 'note) "(as Metro-Goldwyn-Mayer Pictures)")] [(string? (hash-ref mc 'note)) (not (false? (string-contains? (hash-ref mc 'note) (format "~a" "(as Metro-Goldwyn-Mayer Pictures)"))))] [else (not (false? (member "(as Metro-Goldwyn-Mayer Pictures)" (hash-ref mc 'note))))]))) (or (cond [(hash? (hash-ref mc 'note)) (hash-has-key? (hash-ref mc 'note) "(co-production)")] [(string? (hash-ref mc 'note)) (not (false? (string-contains? (hash-ref mc 'note) (format "~a" "(co-production)"))))] [else (not (false? (member "(co-production)" (hash-ref mc 'note))))]) (cond [(hash? (hash-ref mc 'note)) (hash-has-key? (hash-ref mc 'note) "(presents)")] [(string? (hash-ref mc 'note)) (not (false? (string-contains? (hash-ref mc 'note) (format "~a" "(presents)"))))] [else (not (false? (member "(presents)" (hash-ref mc 'note))))])))
+                      (set! _res (append _res (list (hash 'note (hash-ref mc 'note) 'title (hash-ref t 'title) 'year (hash-ref t 'production_year)))))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (hash 'production_note (_min (let ([_res '()])
+  (for ([r filtered])
+    (set! _res (append _res (list (hash-ref r 'note))))
+  )
+  _res)) 'movie_title (_min (let ([_res '()])
+  (for ([r filtered])
+    (set! _res (append _res (list (hash-ref r 'title))))
+  )
+  _res)) 'movie_year (_min (let ([_res '()])
+  (for ([r filtered])
+    (set! _res (append _res (list (hash-ref r 'year))))
+  )
+  _res))))
+(displayln (jsexpr->string (to-jsexpr (list result))))
+(test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production)


### PR DESCRIPTION
## Summary
- handle JOB dataset golden files under `tests/dataset/job/compiler/rkt`
- add `CompileJOB` helper for dataset tests
- create `job_golden_test.go` for Racket backend
- remove old duplicated JOB test files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e69fbc59883208e19e115387aaa54