### PR TITLE
Add PHP compiler support for JOB dataset

### DIFF
--- a/compile/x/php/TASKS.md
+++ b/compile/x/php/TASKS.md
@@ -1,10 +1,17 @@
 # PHP Backend Tasks for TPCH Q1
 
-The PHP backend now supports dataset queries used by `tpc-h/q1.mochi`.
+The PHP backend now supports dataset queries used by `tpc-h/q1.mochi` and `job/q1.mochi`.
 
 - Implemented `sum` helper alongside `avg` and `count` using PHP arrays.
 - Added support for `group by` with an optional `where` clause.
 - Added `json` helper which prints `json_encode` output.
 - Fixed runtime emission for `_Group` when grouping.
 - Records are represented as associative arrays and output uses `json_encode`.
-- Golden tests live under `tests/compiler/php`.
+- Selectors on map values now emit array indexing syntax. Unknown variables are
+  assumed to be maps so dataset rows work without explicit types.
+- The string/list `contains` method is translated to the `in` operator logic.
+- Golden tests live under `tests/compiler/php` and cover both TPCH and JOB examples.
+
+## Remaining work
+
+- Extend support to additional JOB queries beyond `q1`.

--- a/compile/x/php/job_test.go
+++ b/compile/x/php/job_test.go
@@ -1,0 +1,61 @@
+//go:build slow
+
+package phpcode_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	phpcode "mochi/compile/x/php"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestPHPCompiler_JOBQ1(t *testing.T) {
+	if err := phpcode.EnsurePHP(); err != nil {
+		t.Skipf("php not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := phpcode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "main.php")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	// compare generated code
+	codeWant, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "php", "q1.php.out"))
+	if err == nil {
+		if string(code) != string(codeWant) {
+			t.Fatalf("generated code mismatch")
+		}
+	}
+	cmd := exec.Command("php", file)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("php run error: %v\n%s", err, out)
+	}
+	got := string(out)
+	wantData, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "php", "q1.out"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	want := string(wantData)
+	if got != want {
+		t.Fatalf("unexpected output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/tests/dataset/job/compiler/php/q1.out
+++ b/tests/dataset/job/compiler/php/q1.out
@@ -1,0 +1,1 @@
+[{"production_note":"ACME (co-production)","movie_title":"Good Movie","movie_year":1995}]

--- a/tests/dataset/job/compiler/php/q1.php.out
+++ b/tests/dataset/job/compiler/php/q1.php.out
@@ -1,0 +1,121 @@
+<?php
+function mochi_test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production() {
+	global $movie_title, $movie_year, $production_note, $result;
+	if (!(($result == ["production_note" => "ACME (co-production)", "movie_title" => "Good Movie", "movie_year" => 1995]))) { throw new Exception('expect failed'); }
+}
+
+$company_type = [["id" => 1, "kind" => "production companies"], ["id" => 2, "kind" => "distributors"]];
+$info_type = [["id" => 10, "info" => "top 250 rank"], ["id" => 20, "info" => "bottom 10 rank"]];
+$title = [["id" => 100, "title" => "Good Movie", "production_year" => 1995], ["id" => 200, "title" => "Bad Movie", "production_year" => 2000]];
+$movie_companies = [["movie_id" => 100, "company_type_id" => 1, "note" => "ACME (co-production)"], ["movie_id" => 200, "company_type_id" => 1, "note" => "MGM (as Metro-Goldwyn-Mayer Pictures)"]];
+$movie_info_idx = [["movie_id" => 100, "info_type_id" => 10], ["movie_id" => 200, "info_type_id" => 20]];
+$filtered = (function() use ($company_type, $info_type, $movie_companies, $movie_info_idx, $title) {
+	$_src = $company_type;
+	return _query($_src, [
+		[ 'items' => $movie_companies, 'on' => function($ct, $mc) use ($company_type, $info_type, $movie_companies, $movie_info_idx, $title) { return ($ct['id'] == $mc['company_type_id']); } ],
+		[ 'items' => $title, 'on' => function($ct, $mc, $t) use ($company_type, $info_type, $movie_companies, $movie_info_idx, $title) { return ($t['id'] == $mc['movie_id']); } ],
+		[ 'items' => $movie_info_idx, 'on' => function($ct, $mc, $t, $mi) use ($company_type, $info_type, $movie_companies, $movie_info_idx, $title) { return ($mi['movie_id'] == $t['id']); } ],
+		[ 'items' => $info_type, 'on' => function($ct, $mc, $t, $mi, $it) use ($company_type, $info_type, $movie_companies, $movie_info_idx, $title) { return ($it['id'] == $mi['info_type_id']); } ]
+	], [ 'select' => function($ct, $mc, $t, $mi, $it) use ($company_type, $info_type, $movie_companies, $movie_info_idx, $title) { return ["note" => $mc['note'], "title" => $t['title'], "year" => $t['production_year']]; }, 'where' => function($ct, $mc, $t, $mi, $it) use ($company_type, $info_type, $movie_companies, $movie_info_idx, $title) { return ((((($ct['kind'] == "production companies") && ($it['info'] == "top 250 rank")) && (!(is_array($mc['note']) ? (array_key_exists("(as Metro-Goldwyn-Mayer Pictures)", $mc['note']) || in_array("(as Metro-Goldwyn-Mayer Pictures)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(as Metro-Goldwyn-Mayer Pictures)")) !== false : false)))) && (((is_array($mc['note']) ? (array_key_exists("(co-production)", $mc['note']) || in_array("(co-production)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(co-production)")) !== false : false)) || (is_array($mc['note']) ? (array_key_exists("(presents)", $mc['note']) || in_array("(presents)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(presents)")) !== false : false)))))); } ]);
+})();
+$result = ["production_note" => min((function() use ($filtered) {
+	$res = [];
+	foreach ((is_string($filtered) ? str_split($filtered) : $filtered) as $r) {
+		$res[] = $r['note'];
+	}
+	return $res;
+})()), "movie_title" => min((function() use ($filtered) {
+	$res = [];
+	foreach ((is_string($filtered) ? str_split($filtered) : $filtered) as $r) {
+		$res[] = $r['title'];
+	}
+	return $res;
+})()), "movie_year" => min((function() use ($filtered) {
+	$res = [];
+	foreach ((is_string($filtered) ? str_split($filtered) : $filtered) as $r) {
+		$res[] = $r['year'];
+	}
+	return $res;
+})())];
+echo json_encode([$result]), PHP_EOL;
+mochi_test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}


### PR DESCRIPTION
## Summary
- support map field access in PHP backend
- add `contains` method handling
- add golden tests for JOB q1
- document new capabilities in `compile/x/php/TASKS.md`

## Testing
- `go test ./compile/x/php -run JOB -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685e69f247348320aa0ad1a01155c585