### PR TITLE
Add JOB IR outputs q21-q33

### DIFF
--- a/tests/dataset/job/out/q21.ir.out
+++ b/tests/dataset/job/out/q21.ir.out
@@ -1,0 +1,426 @@
+func main (regs=251)
+  // let company_name = [
+  Const        r0, [{"country_code": "[us]", "id": 1, "name": "ACME Film Works"}, {"country_code": "[pl]", "id": 2, "name": "Polish Warner"}]
+  Move         r1, r0
+  // let company_type = [
+  Const        r2, [{"id": 1, "kind": "production companies"}, {"id": 2, "kind": "other"}]
+  Move         r3, r2
+  // let keyword = [
+  Const        r4, [{"id": 1, "keyword": "sequel"}, {"id": 2, "keyword": "drama"}]
+  Move         r5, r4
+  // let link_type = [
+  Const        r6, [{"id": 1, "link": "is follow up"}, {"id": 2, "link": "references"}]
+  Move         r7, r6
+  // let title = [
+  Const        r8, [{"id": 10, "production_year": 1975, "title": "Western Return"}, {"id": 20, "production_year": 2015, "title": "Other Movie"}]
+  Move         r9, r8
+  // let movie_companies = [
+  Const        r10, [{"company_id": 1, "company_type_id": 1, "movie_id": 10, "note": nil}, {"company_id": 2, "company_type_id": 1, "movie_id": 20, "note": nil}]
+  Move         r11, r10
+  // let movie_info = [
+  Const        r12, [{"info": "Sweden", "movie_id": 10}, {"info": "USA", "movie_id": 20}]
+  Move         r13, r12
+  // let movie_keyword = [
+  Const        r14, [{"keyword_id": 1, "movie_id": 10}, {"keyword_id": 2, "movie_id": 20}]
+  Move         r15, r14
+  // let movie_link = [
+  Const        r16, [{"link_type_id": 1, "movie_id": 10}, {"link_type_id": 2, "movie_id": 20}]
+  Move         r17, r16
+  // let allowed_countries = ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]
+  Const        r18, ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]
+  Move         r19, r18
+  // from cn in company_name
+  Const        r20, []
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L27:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L0
+  Index        r25, r21, r23
+  Move         r26, r25
+  // join mc in movie_companies on mc.company_id == cn.id
+  IterPrep     r27, r11
+  Len          r28, r27
+  Const        r29, 0
+L26:
+  Less         r30, r29, r28
+  JumpIfFalse  r30, L1
+  Index        r31, r27, r29
+  Move         r32, r31
+  Const        r33, "company_id"
+  Index        r34, r32, r33
+  Const        r35, "id"
+  Index        r36, r26, r35
+  Equal        r37, r34, r36
+  JumpIfFalse  r37, L2
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r38, r3
+  Len          r39, r38
+  Const        r40, 0
+L25:
+  Less         r41, r40, r39
+  JumpIfFalse  r41, L2
+  Index        r42, r38, r40
+  Move         r43, r42
+  Const        r44, "id"
+  Index        r45, r43, r44
+  Const        r46, "company_type_id"
+  Index        r47, r32, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L3
+  // join t in title on t.id == mc.movie_id
+  IterPrep     r49, r9
+  Len          r50, r49
+  Const        r51, 0
+L24:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r53, r49, r51
+  Move         r54, r53
+  Const        r55, "id"
+  Index        r56, r54, r55
+  Const        r57, "movie_id"
+  Index        r58, r32, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r60, r15
+  Len          r61, r60
+  Const        r62, 0
+L23:
+  Less         r63, r62, r61
+  JumpIfFalse  r63, L4
+  Index        r64, r60, r62
+  Move         r65, r64
+  Const        r66, "movie_id"
+  Index        r67, r65, r66
+  Const        r68, "id"
+  Index        r69, r54, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L5
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r71, r5
+  Len          r72, r71
+  Const        r73, 0
+L22:
+  Less         r74, r73, r72
+  JumpIfFalse  r74, L5
+  Index        r75, r71, r73
+  Move         r76, r75
+  Const        r77, "id"
+  Index        r78, r76, r77
+  Const        r79, "keyword_id"
+  Index        r80, r65, r79
+  Equal        r81, r78, r80
+  JumpIfFalse  r81, L6
+  // join ml in movie_link on ml.movie_id == t.id
+  IterPrep     r82, r17
+  Len          r83, r82
+  Const        r84, 0
+L21:
+  Less         r85, r84, r83
+  JumpIfFalse  r85, L6
+  Index        r86, r82, r84
+  Move         r87, r86
+  Const        r88, "movie_id"
+  Index        r89, r87, r88
+  Const        r90, "id"
+  Index        r91, r54, r90
+  Equal        r92, r89, r91
+  JumpIfFalse  r92, L7
+  // join lt in link_type on lt.id == ml.link_type_id
+  IterPrep     r93, r7
+  Len          r94, r93
+  Const        r95, 0
+L20:
+  Less         r96, r95, r94
+  JumpIfFalse  r96, L7
+  Index        r97, r93, r95
+  Move         r98, r97
+  Const        r99, "id"
+  Index        r100, r98, r99
+  Const        r101, "link_type_id"
+  Index        r102, r87, r101
+  Equal        r103, r100, r102
+  JumpIfFalse  r103, L8
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r104, r13
+  Len          r105, r104
+  Const        r106, 0
+L19:
+  Less         r107, r106, r105
+  JumpIfFalse  r107, L8
+  Index        r108, r104, r106
+  Move         r109, r108
+  Const        r110, "movie_id"
+  Index        r111, r109, r110
+  Const        r112, "id"
+  Index        r113, r54, r112
+  Equal        r114, r111, r113
+  JumpIfFalse  r114, L9
+  // where cn.country_code != "[pl]" &&
+  Const        r115, "country_code"
+  Index        r116, r26, r115
+  // t.production_year >= 1950 && t.production_year <= 2000
+  Const        r117, "production_year"
+  Index        r118, r54, r117
+  Const        r119, 1950
+  LessEq       r120, r119, r118
+  Const        r121, "production_year"
+  Index        r122, r54, r121
+  Const        r123, 2000
+  LessEq       r124, r122, r123
+  // where cn.country_code != "[pl]" &&
+  Const        r125, "[pl]"
+  NotEqual     r126, r116, r125
+  // ct.kind == "production companies" &&
+  Const        r127, "kind"
+  Index        r128, r43, r127
+  Const        r129, "production companies"
+  Equal        r130, r128, r129
+  // k.keyword == "sequel" &&
+  Const        r131, "keyword"
+  Index        r132, r76, r131
+  Const        r133, "sequel"
+  Equal        r134, r132, r133
+  // mc.note == null &&
+  Const        r135, "note"
+  Index        r136, r32, r135
+  Const        r137, nil
+  Equal        r138, r136, r137
+  // where cn.country_code != "[pl]" &&
+  Move         r139, r126
+  JumpIfFalse  r139, L10
+  Const        r140, "name"
+  Index        r141, r26, r140
+  // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+  Const        r142, "Film"
+  In           r143, r142, r141
+  Move         r144, r143
+  JumpIfTrue   r144, L11
+  Const        r145, "name"
+  Index        r146, r26, r145
+  Const        r147, "Warner"
+  In           r148, r147, r146
+  Move         r144, r148
+L11:
+  // where cn.country_code != "[pl]" &&
+  Move         r139, r144
+L10:
+  // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+  Move         r149, r139
+  JumpIfFalse  r149, L12
+  Move         r149, r130
+L12:
+  // ct.kind == "production companies" &&
+  Move         r150, r149
+  JumpIfFalse  r150, L13
+  Move         r150, r134
+L13:
+  // k.keyword == "sequel" &&
+  Move         r151, r150
+  JumpIfFalse  r151, L14
+  Const        r152, "link"
+  Index        r153, r98, r152
+  // lt.link.contains("follow") &&
+  Const        r154, "follow"
+  In           r155, r154, r153
+  // k.keyword == "sequel" &&
+  Move         r151, r155
+L14:
+  // lt.link.contains("follow") &&
+  Move         r156, r151
+  JumpIfFalse  r156, L15
+  Move         r156, r138
+L15:
+  // mc.note == null &&
+  Move         r157, r156
+  JumpIfFalse  r157, L16
+  // (mi.info in allowed_countries) &&
+  Const        r158, "info"
+  Index        r159, r109, r158
+  In           r160, r159, r19
+  // mc.note == null &&
+  Move         r157, r160
+L16:
+  // (mi.info in allowed_countries) &&
+  Move         r161, r157
+  JumpIfFalse  r161, L17
+  Move         r161, r120
+L17:
+  // t.production_year >= 1950 && t.production_year <= 2000
+  Move         r162, r161
+  JumpIfFalse  r162, L18
+  Move         r162, r124
+L18:
+  // where cn.country_code != "[pl]" &&
+  JumpIfFalse  r162, L9
+  // company_name: cn.name,
+  Const        r163, "company_name"
+  Const        r164, "name"
+  Index        r165, r26, r164
+  // link_type: lt.link,
+  Const        r166, "link_type"
+  Const        r167, "link"
+  Index        r168, r98, r167
+  // western_follow_up: t.title
+  Const        r169, "western_follow_up"
+  Const        r170, "title"
+  Index        r171, r54, r170
+  // company_name: cn.name,
+  Move         r172, r163
+  Move         r173, r165
+  // link_type: lt.link,
+  Move         r174, r166
+  Move         r175, r168
+  // western_follow_up: t.title
+  Move         r176, r169
+  Move         r177, r171
+  // select {
+  MakeMap      r178, 3, r172
+  // from cn in company_name
+  Append       r179, r20, r178
+  Move         r20, r179
+L9:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r180, 1
+  Add          r181, r106, r180
+  Move         r106, r181
+  Jump         L19
+L8:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r182, 1
+  Add          r183, r95, r182
+  Move         r95, r183
+  Jump         L20
+L7:
+  // join ml in movie_link on ml.movie_id == t.id
+  Const        r184, 1
+  Add          r185, r84, r184
+  Move         r84, r185
+  Jump         L21
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r186, 1
+  Add          r187, r73, r186
+  Move         r73, r187
+  Jump         L22
+L5:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r188, 1
+  Add          r189, r62, r188
+  Move         r62, r189
+  Jump         L23
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r190, 1
+  Add          r191, r51, r190
+  Move         r51, r191
+  Jump         L24
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r192, 1
+  Add          r193, r40, r192
+  Move         r40, r193
+  Jump         L25
+L2:
+  // join mc in movie_companies on mc.company_id == cn.id
+  Const        r194, 1
+  Add          r195, r29, r194
+  Move         r29, r195
+  Jump         L26
+L1:
+  // from cn in company_name
+  Const        r196, 1
+  Add          r197, r23, r196
+  Move         r23, r197
+  Jump         L27
+L0:
+  // let rows =
+  Move         r198, r20
+  // company_name: min(from r in rows select r.company_name),
+  Const        r199, "company_name"
+  Const        r200, []
+  IterPrep     r201, r198
+  Len          r202, r201
+  Const        r203, 0
+L29:
+  Less         r204, r203, r202
+  JumpIfFalse  r204, L28
+  Index        r205, r201, r203
+  Move         r206, r205
+  Const        r207, "company_name"
+  Index        r208, r206, r207
+  Append       r209, r200, r208
+  Move         r200, r209
+  Const        r210, 1
+  Add          r211, r203, r210
+  Move         r203, r211
+  Jump         L29
+L28:
+  Min          r212, r200
+  // link_type: min(from r in rows select r.link_type),
+  Const        r213, "link_type"
+  Const        r214, []
+  IterPrep     r215, r198
+  Len          r216, r215
+  Const        r217, 0
+L31:
+  Less         r218, r217, r216
+  JumpIfFalse  r218, L30
+  Index        r219, r215, r217
+  Move         r206, r219
+  Const        r220, "link_type"
+  Index        r221, r206, r220
+  Append       r222, r214, r221
+  Move         r214, r222
+  Const        r223, 1
+  Add          r224, r217, r223
+  Move         r217, r224
+  Jump         L31
+L30:
+  Min          r225, r214
+  // western_follow_up: min(from r in rows select r.western_follow_up)
+  Const        r226, "western_follow_up"
+  Const        r227, []
+  IterPrep     r228, r198
+  Len          r229, r228
+  Const        r230, 0
+L33:
+  Less         r231, r230, r229
+  JumpIfFalse  r231, L32
+  Index        r232, r228, r230
+  Move         r206, r232
+  Const        r233, "western_follow_up"
+  Index        r234, r206, r233
+  Append       r235, r227, r234
+  Move         r227, r235
+  Const        r236, 1
+  Add          r237, r230, r236
+  Move         r230, r237
+  Jump         L33
+L32:
+  Min          r238, r227
+  // company_name: min(from r in rows select r.company_name),
+  Move         r239, r199
+  Move         r240, r212
+  // link_type: min(from r in rows select r.link_type),
+  Move         r241, r213
+  Move         r242, r225
+  // western_follow_up: min(from r in rows select r.western_follow_up)
+  Move         r243, r226
+  Move         r244, r238
+  // {
+  MakeMap      r245, 3, r239
+  Move         r246, r245
+  // let result = [
+  MakeList     r247, 1, r246
+  Move         r248, r247
+  // json(result)
+  JSON         r248
+  // expect result == [
+  Const        r249, [{"company_name": "ACME Film Works", "link_type": "is follow up", "western_follow_up": "Western Return"}]
+  Equal        r250, r248, r249
+  Expect       r250
+  Return       r0

--- a/tests/dataset/job/out/q22.ir.out
+++ b/tests/dataset/job/out/q22.ir.out
@@ -1,0 +1,701 @@
+func main (regs=411)
+  // let company_name = [
+  Const        r0, [{"country_code": "[de]", "id": 1, "name": "Euro Films"}, {"country_code": "[us]", "id": 2, "name": "US Films"}]
+  Move         r1, r0
+  // let company_type = [
+  Const        r2, [{"id": 1, "kind": "production"}]
+  Move         r3, r2
+  // let info_type = [
+  Const        r4, [{"id": 10, "info": "countries"}, {"id": 20, "info": "rating"}]
+  Move         r5, r4
+  // let keyword = [
+  Const        r6, [{"id": 1, "keyword": "murder"}, {"id": 2, "keyword": "comedy"}]
+  Move         r7, r6
+  // let kind_type = [
+  Const        r8, [{"id": 100, "kind": "movie"}, {"id": 200, "kind": "episode"}]
+  Move         r9, r8
+  // let movie_companies = [
+  Const        r10, [{"company_id": 1, "company_type_id": 1, "movie_id": 10, "note": "release (2009) (worldwide)"}, {"company_id": 2, "company_type_id": 1, "movie_id": 20, "note": "release (2007) (USA)"}]
+  Move         r11, r10
+  // let movie_info = [
+  Const        r12, [{"info": "Germany", "info_type_id": 10, "movie_id": 10}, {"info": "USA", "info_type_id": 10, "movie_id": 20}]
+  Move         r13, r12
+  // let movie_info_idx = [
+  Const        r14, [{"info": 6.5, "info_type_id": 20, "movie_id": 10}, {"info": 7.8, "info_type_id": 20, "movie_id": 20}]
+  Move         r15, r14
+  // let movie_keyword = [
+  Const        r16, [{"keyword_id": 1, "movie_id": 10}, {"keyword_id": 2, "movie_id": 20}]
+  Move         r17, r16
+  // let title = [
+  Const        r18, [{"id": 10, "kind_id": 100, "production_year": 2009, "title": "Violent Western"}, {"id": 20, "kind_id": 100, "production_year": 2007, "title": "Old Western"}]
+  Move         r19, r18
+  // from cn in company_name
+  Const        r20, []
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L54:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L0
+  Index        r25, r21, r23
+  Move         r26, r25
+  // join mc in movie_companies on cn.id == mc.company_id
+  IterPrep     r27, r11
+  Len          r28, r27
+  Const        r29, 0
+L53:
+  Less         r30, r29, r28
+  JumpIfFalse  r30, L1
+  Index        r31, r27, r29
+  Move         r32, r31
+  Const        r33, "id"
+  Index        r34, r26, r33
+  Const        r35, "company_id"
+  Index        r36, r32, r35
+  Equal        r37, r34, r36
+  JumpIfFalse  r37, L2
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r38, r3
+  Len          r39, r38
+  Const        r40, 0
+L52:
+  Less         r41, r40, r39
+  JumpIfFalse  r41, L2
+  Index        r42, r38, r40
+  Move         r43, r42
+  Const        r44, "id"
+  Index        r45, r43, r44
+  Const        r46, "company_type_id"
+  Index        r47, r32, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L3
+  // join t in title on t.id == mc.movie_id
+  IterPrep     r49, r19
+  Len          r50, r49
+  Const        r51, 0
+L51:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r53, r49, r51
+  Move         r54, r53
+  Const        r55, "id"
+  Index        r56, r54, r55
+  Const        r57, "movie_id"
+  Index        r58, r32, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r60, r17
+  Len          r61, r60
+  Const        r62, 0
+L50:
+  Less         r63, r62, r61
+  JumpIfFalse  r63, L4
+  Index        r64, r60, r62
+  Move         r65, r64
+  Const        r66, "movie_id"
+  Index        r67, r65, r66
+  Const        r68, "id"
+  Index        r69, r54, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L5
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r71, r7
+  Len          r72, r71
+  Const        r73, 0
+L49:
+  Less         r74, r73, r72
+  JumpIfFalse  r74, L5
+  Index        r75, r71, r73
+  Move         r76, r75
+  Const        r77, "id"
+  Index        r78, r76, r77
+  Const        r79, "keyword_id"
+  Index        r80, r65, r79
+  Equal        r81, r78, r80
+  JumpIfFalse  r81, L6
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r82, r13
+  Len          r83, r82
+  Const        r84, 0
+L48:
+  Less         r85, r84, r83
+  JumpIfFalse  r85, L6
+  Index        r86, r82, r84
+  Move         r87, r86
+  Const        r88, "movie_id"
+  Index        r89, r87, r88
+  Const        r90, "id"
+  Index        r91, r54, r90
+  Equal        r92, r89, r91
+  JumpIfFalse  r92, L7
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r93, r5
+  Len          r94, r93
+  Const        r95, 0
+L47:
+  Less         r96, r95, r94
+  JumpIfFalse  r96, L7
+  Index        r97, r93, r95
+  Move         r98, r97
+  Const        r99, "id"
+  Index        r100, r98, r99
+  Const        r101, "info_type_id"
+  Index        r102, r87, r101
+  Equal        r103, r100, r102
+  JumpIfFalse  r103, L8
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  IterPrep     r104, r15
+  Len          r105, r104
+  Const        r106, 0
+L46:
+  Less         r107, r106, r105
+  JumpIfFalse  r107, L8
+  Index        r108, r104, r106
+  Move         r109, r108
+  Const        r110, "movie_id"
+  Index        r111, r109, r110
+  Const        r112, "id"
+  Index        r113, r54, r112
+  Equal        r114, r111, r113
+  JumpIfFalse  r114, L9
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  IterPrep     r115, r5
+  Len          r116, r115
+  Const        r117, 0
+L45:
+  Less         r118, r117, r116
+  JumpIfFalse  r118, L9
+  Index        r119, r115, r117
+  Move         r120, r119
+  Const        r121, "id"
+  Index        r122, r120, r121
+  Const        r123, "info_type_id"
+  Index        r124, r109, r123
+  Equal        r125, r122, r124
+  JumpIfFalse  r125, L10
+  // join kt in kind_type on kt.id == t.kind_id
+  IterPrep     r126, r9
+  Len          r127, r126
+  Const        r128, 0
+L44:
+  Less         r129, r128, r127
+  JumpIfFalse  r129, L10
+  Index        r130, r126, r128
+  Move         r131, r130
+  Const        r132, "id"
+  Index        r133, r131, r132
+  Const        r134, "kind_id"
+  Index        r135, r54, r134
+  Equal        r136, r133, r135
+  JumpIfFalse  r136, L11
+  // cn.country_code != "[us]" &&
+  Const        r137, "country_code"
+  Index        r138, r26, r137
+  // mi_idx.info < 7.0 &&
+  Const        r139, "info"
+  Index        r140, r109, r139
+  Const        r141, 7
+  LessFloat    r142, r140, r141
+  // t.production_year > 2008 &&
+  Const        r143, "production_year"
+  Index        r144, r54, r143
+  Const        r145, 2008
+  Less         r146, r145, r144
+  // cn.country_code != "[us]" &&
+  Const        r147, "[us]"
+  NotEqual     r148, r138, r147
+  // it1.info == "countries" &&
+  Const        r149, "info"
+  Index        r150, r98, r149
+  Const        r151, "countries"
+  Equal        r152, r150, r151
+  // it2.info == "rating" &&
+  Const        r153, "info"
+  Index        r154, r120, r153
+  Const        r155, "rating"
+  Equal        r156, r154, r155
+  Const        r157, "note"
+  Index        r158, r32, r157
+  // mc.note.contains("(USA)") == false &&
+  Const        r159, "(USA)"
+  In           r160, r159, r158
+  Const        r161, false
+  Equal        r162, r160, r161
+  // kt.id == t.kind_id &&
+  Const        r163, "id"
+  Index        r164, r131, r163
+  Const        r165, "kind_id"
+  Index        r166, r54, r165
+  Equal        r167, r164, r166
+  // t.id == mi.movie_id &&
+  Const        r168, "id"
+  Index        r169, r54, r168
+  Const        r170, "movie_id"
+  Index        r171, r87, r170
+  Equal        r172, r169, r171
+  // t.id == mk.movie_id &&
+  Const        r173, "id"
+  Index        r174, r54, r173
+  Const        r175, "movie_id"
+  Index        r176, r65, r175
+  Equal        r177, r174, r176
+  // t.id == mi_idx.movie_id &&
+  Const        r178, "id"
+  Index        r179, r54, r178
+  Const        r180, "movie_id"
+  Index        r181, r109, r180
+  Equal        r182, r179, r181
+  // t.id == mc.movie_id &&
+  Const        r183, "id"
+  Index        r184, r54, r183
+  Const        r185, "movie_id"
+  Index        r186, r32, r185
+  Equal        r187, r184, r186
+  // mk.movie_id == mi.movie_id &&
+  Const        r188, "movie_id"
+  Index        r189, r65, r188
+  Const        r190, "movie_id"
+  Index        r191, r87, r190
+  Equal        r192, r189, r191
+  // mk.movie_id == mi_idx.movie_id &&
+  Const        r193, "movie_id"
+  Index        r194, r65, r193
+  Const        r195, "movie_id"
+  Index        r196, r109, r195
+  Equal        r197, r194, r196
+  // mk.movie_id == mc.movie_id &&
+  Const        r198, "movie_id"
+  Index        r199, r65, r198
+  Const        r200, "movie_id"
+  Index        r201, r32, r200
+  Equal        r202, r199, r201
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r203, "movie_id"
+  Index        r204, r87, r203
+  Const        r205, "movie_id"
+  Index        r206, r109, r205
+  Equal        r207, r204, r206
+  // mi.movie_id == mc.movie_id &&
+  Const        r208, "movie_id"
+  Index        r209, r87, r208
+  Const        r210, "movie_id"
+  Index        r211, r32, r210
+  Equal        r212, r209, r211
+  // mc.movie_id == mi_idx.movie_id &&
+  Const        r213, "movie_id"
+  Index        r214, r32, r213
+  Const        r215, "movie_id"
+  Index        r216, r109, r215
+  Equal        r217, r214, r216
+  // k.id == mk.keyword_id &&
+  Const        r218, "id"
+  Index        r219, r76, r218
+  Const        r220, "keyword_id"
+  Index        r221, r65, r220
+  Equal        r222, r219, r221
+  // it1.id == mi.info_type_id &&
+  Const        r223, "id"
+  Index        r224, r98, r223
+  Const        r225, "info_type_id"
+  Index        r226, r87, r225
+  Equal        r227, r224, r226
+  // it2.id == mi_idx.info_type_id &&
+  Const        r228, "id"
+  Index        r229, r120, r228
+  Const        r230, "info_type_id"
+  Index        r231, r109, r230
+  Equal        r232, r229, r231
+  // ct.id == mc.company_type_id &&
+  Const        r233, "id"
+  Index        r234, r43, r233
+  Const        r235, "company_type_id"
+  Index        r236, r32, r235
+  Equal        r237, r234, r236
+  // cn.id == mc.company_id
+  Const        r238, "id"
+  Index        r239, r26, r238
+  Const        r240, "company_id"
+  Index        r241, r32, r240
+  Equal        r242, r239, r241
+  // cn.country_code != "[us]" &&
+  Move         r243, r148
+  JumpIfFalse  r243, L12
+  Move         r243, r152
+L12:
+  // it1.info == "countries" &&
+  Move         r244, r243
+  JumpIfFalse  r244, L13
+  Move         r244, r156
+L13:
+  // it2.info == "rating" &&
+  Move         r245, r244
+  JumpIfFalse  r245, L14
+  // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
+  Const        r246, "keyword"
+  Index        r247, r76, r246
+  Const        r248, "murder"
+  Equal        r249, r247, r248
+  Const        r250, "keyword"
+  Index        r251, r76, r250
+  Const        r252, "murder-in-title"
+  Equal        r253, r251, r252
+  Const        r254, "keyword"
+  Index        r255, r76, r254
+  Const        r256, "blood"
+  Equal        r257, r255, r256
+  Const        r258, "keyword"
+  Index        r259, r76, r258
+  Const        r260, "violence"
+  Equal        r261, r259, r260
+  Move         r262, r249
+  JumpIfTrue   r262, L15
+  Move         r262, r253
+L15:
+  Move         r263, r262
+  JumpIfTrue   r263, L16
+  Move         r263, r257
+L16:
+  Move         r264, r263
+  JumpIfTrue   r264, L17
+  Move         r264, r261
+L17:
+  // it2.info == "rating" &&
+  Move         r245, r264
+L14:
+  // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
+  Move         r265, r245
+  JumpIfFalse  r265, L18
+  // (kt.kind == "movie" || kt.kind == "episode") &&
+  Const        r266, "kind"
+  Index        r267, r131, r266
+  Const        r268, "movie"
+  Equal        r269, r267, r268
+  Const        r270, "kind"
+  Index        r271, r131, r270
+  Const        r272, "episode"
+  Equal        r273, r271, r272
+  Move         r274, r269
+  JumpIfTrue   r274, L19
+  Move         r274, r273
+L19:
+  // (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
+  Move         r265, r274
+L18:
+  // (kt.kind == "movie" || kt.kind == "episode") &&
+  Move         r275, r265
+  JumpIfFalse  r275, L20
+  Move         r275, r162
+L20:
+  // mc.note.contains("(USA)") == false &&
+  Move         r276, r275
+  JumpIfFalse  r276, L21
+  Const        r277, "note"
+  Index        r278, r32, r277
+  // mc.note.contains("(200") &&
+  Const        r279, "(200"
+  In           r280, r279, r278
+  // mc.note.contains("(USA)") == false &&
+  Move         r276, r280
+L21:
+  // mc.note.contains("(200") &&
+  Move         r281, r276
+  JumpIfFalse  r281, L22
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Const        r282, "info"
+  Index        r283, r87, r282
+  Const        r284, "Germany"
+  Equal        r285, r283, r284
+  Const        r286, "info"
+  Index        r287, r87, r286
+  Const        r288, "German"
+  Equal        r289, r287, r288
+  Const        r290, "info"
+  Index        r291, r87, r290
+  Const        r292, "USA"
+  Equal        r293, r291, r292
+  Const        r294, "info"
+  Index        r295, r87, r294
+  Const        r296, "American"
+  Equal        r297, r295, r296
+  Move         r298, r285
+  JumpIfTrue   r298, L23
+  Move         r298, r289
+L23:
+  Move         r299, r298
+  JumpIfTrue   r299, L24
+  Move         r299, r293
+L24:
+  Move         r300, r299
+  JumpIfTrue   r300, L25
+  Move         r300, r297
+L25:
+  // mc.note.contains("(200") &&
+  Move         r281, r300
+L22:
+  // (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
+  Move         r301, r281
+  JumpIfFalse  r301, L26
+  Move         r301, r142
+L26:
+  // mi_idx.info < 7.0 &&
+  Move         r302, r301
+  JumpIfFalse  r302, L27
+  Move         r302, r146
+L27:
+  // t.production_year > 2008 &&
+  Move         r303, r302
+  JumpIfFalse  r303, L28
+  Move         r303, r167
+L28:
+  // kt.id == t.kind_id &&
+  Move         r304, r303
+  JumpIfFalse  r304, L29
+  Move         r304, r172
+L29:
+  // t.id == mi.movie_id &&
+  Move         r305, r304
+  JumpIfFalse  r305, L30
+  Move         r305, r177
+L30:
+  // t.id == mk.movie_id &&
+  Move         r306, r305
+  JumpIfFalse  r306, L31
+  Move         r306, r182
+L31:
+  // t.id == mi_idx.movie_id &&
+  Move         r307, r306
+  JumpIfFalse  r307, L32
+  Move         r307, r187
+L32:
+  // t.id == mc.movie_id &&
+  Move         r308, r307
+  JumpIfFalse  r308, L33
+  Move         r308, r192
+L33:
+  // mk.movie_id == mi.movie_id &&
+  Move         r309, r308
+  JumpIfFalse  r309, L34
+  Move         r309, r197
+L34:
+  // mk.movie_id == mi_idx.movie_id &&
+  Move         r310, r309
+  JumpIfFalse  r310, L35
+  Move         r310, r202
+L35:
+  // mk.movie_id == mc.movie_id &&
+  Move         r311, r310
+  JumpIfFalse  r311, L36
+  Move         r311, r207
+L36:
+  // mi.movie_id == mi_idx.movie_id &&
+  Move         r312, r311
+  JumpIfFalse  r312, L37
+  Move         r312, r212
+L37:
+  // mi.movie_id == mc.movie_id &&
+  Move         r313, r312
+  JumpIfFalse  r313, L38
+  Move         r313, r217
+L38:
+  // mc.movie_id == mi_idx.movie_id &&
+  Move         r314, r313
+  JumpIfFalse  r314, L39
+  Move         r314, r222
+L39:
+  // k.id == mk.keyword_id &&
+  Move         r315, r314
+  JumpIfFalse  r315, L40
+  Move         r315, r227
+L40:
+  // it1.id == mi.info_type_id &&
+  Move         r316, r315
+  JumpIfFalse  r316, L41
+  Move         r316, r232
+L41:
+  // it2.id == mi_idx.info_type_id &&
+  Move         r317, r316
+  JumpIfFalse  r317, L42
+  Move         r317, r237
+L42:
+  // ct.id == mc.company_type_id &&
+  Move         r318, r317
+  JumpIfFalse  r318, L43
+  Move         r318, r242
+L43:
+  // where (
+  JumpIfFalse  r318, L11
+  // select { company: cn.name, rating: mi_idx.info, title: t.title }
+  Const        r319, "company"
+  Const        r320, "name"
+  Index        r321, r26, r320
+  Const        r322, "rating"
+  Const        r323, "info"
+  Index        r324, r109, r323
+  Const        r325, "title"
+  Const        r326, "title"
+  Index        r327, r54, r326
+  Move         r328, r319
+  Move         r329, r321
+  Move         r330, r322
+  Move         r331, r324
+  Move         r332, r325
+  Move         r333, r327
+  MakeMap      r334, 3, r328
+  // from cn in company_name
+  Append       r335, r20, r334
+  Move         r20, r335
+L11:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r336, 1
+  Add          r337, r128, r336
+  Move         r128, r337
+  Jump         L44
+L10:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r338, 1
+  Add          r339, r117, r338
+  Move         r117, r339
+  Jump         L45
+L9:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r340, 1
+  Add          r341, r106, r340
+  Move         r106, r341
+  Jump         L46
+L8:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r342, 1
+  Add          r343, r95, r342
+  Move         r95, r343
+  Jump         L47
+L7:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r344, 1
+  Add          r345, r84, r344
+  Move         r84, r345
+  Jump         L48
+L6:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r346, 1
+  Add          r347, r73, r346
+  Move         r73, r347
+  Jump         L49
+L5:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r348, 1
+  Add          r349, r62, r348
+  Move         r62, r349
+  Jump         L50
+L4:
+  // join t in title on t.id == mc.movie_id
+  Const        r350, 1
+  Add          r351, r51, r350
+  Move         r51, r351
+  Jump         L51
+L3:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r352, 1
+  Add          r353, r40, r352
+  Move         r40, r353
+  Jump         L52
+L2:
+  // join mc in movie_companies on cn.id == mc.company_id
+  Const        r354, 1
+  Add          r355, r29, r354
+  Move         r29, r355
+  Jump         L53
+L1:
+  // from cn in company_name
+  Const        r356, 1
+  Add          r357, r23, r356
+  Move         r23, r357
+  Jump         L54
+L0:
+  // let rows =
+  Move         r358, r20
+  // movie_company: min(from r in rows select r.company),
+  Const        r359, "movie_company"
+  Const        r360, []
+  IterPrep     r361, r358
+  Len          r362, r361
+  Const        r363, 0
+L56:
+  Less         r364, r363, r362
+  JumpIfFalse  r364, L55
+  Index        r365, r361, r363
+  Move         r366, r365
+  Const        r367, "company"
+  Index        r368, r366, r367
+  Append       r369, r360, r368
+  Move         r360, r369
+  Const        r370, 1
+  Add          r371, r363, r370
+  Move         r363, r371
+  Jump         L56
+L55:
+  Min          r372, r360
+  // rating: min(from r in rows select r.rating),
+  Const        r373, "rating"
+  Const        r374, []
+  IterPrep     r375, r358
+  Len          r376, r375
+  Const        r377, 0
+L58:
+  Less         r378, r377, r376
+  JumpIfFalse  r378, L57
+  Index        r379, r375, r377
+  Move         r366, r379
+  Const        r380, "rating"
+  Index        r381, r366, r380
+  Append       r382, r374, r381
+  Move         r374, r382
+  Const        r383, 1
+  Add          r384, r377, r383
+  Move         r377, r384
+  Jump         L58
+L57:
+  Min          r385, r374
+  // western_violent_movie: min(from r in rows select r.title)
+  Const        r386, "western_violent_movie"
+  Const        r387, []
+  IterPrep     r388, r358
+  Len          r389, r388
+  Const        r390, 0
+L60:
+  Less         r391, r390, r389
+  JumpIfFalse  r391, L59
+  Index        r392, r388, r390
+  Move         r366, r392
+  Const        r393, "title"
+  Index        r394, r366, r393
+  Append       r395, r387, r394
+  Move         r387, r395
+  Const        r396, 1
+  Add          r397, r390, r396
+  Move         r390, r397
+  Jump         L60
+L59:
+  Min          r398, r387
+  // movie_company: min(from r in rows select r.company),
+  Move         r399, r359
+  Move         r400, r372
+  // rating: min(from r in rows select r.rating),
+  Move         r401, r373
+  Move         r402, r385
+  // western_violent_movie: min(from r in rows select r.title)
+  Move         r403, r386
+  Move         r404, r398
+  // {
+  MakeMap      r405, 3, r399
+  Move         r406, r405
+  // let result = [
+  MakeList     r407, 1, r406
+  Move         r408, r407
+  // json(result)
+  JSON         r408
+  // expect result == [
+  Const        r409, [{"movie_company": "Euro Films", "rating": 6.5, "western_violent_movie": "Violent Western"}]
+  Equal        r410, r408, r409
+  Expect       r410
+  Return       r0

--- a/tests/dataset/job/out/q23.ir.out
+++ b/tests/dataset/job/out/q23.ir.out
@@ -1,0 +1,425 @@
+func main (regs=255)
+  // let complete_cast = [
+  Const        r0, [{"movie_id": 1, "status_id": 1}, {"movie_id": 2, "status_id": 2}]
+  Move         r1, r0
+  // let comp_cast_type = [
+  Const        r2, [{"id": 1, "kind": "complete+verified"}, {"id": 2, "kind": "partial"}]
+  Move         r3, r2
+  // let company_name = [
+  Const        r4, [{"country_code": "[us]", "id": 1}, {"country_code": "[gb]", "id": 2}]
+  Move         r5, r4
+  // let company_type = [
+  Const        r6, [{"id": 1}, {"id": 2}]
+  Move         r7, r6
+  // let info_type = [
+  Const        r8, [{"id": 1, "info": "release dates"}, {"id": 2, "info": "other"}]
+  Move         r9, r8
+  // let keyword = [
+  Const        r10, [{"id": 1, "keyword": "internet"}, {"id": 2, "keyword": "other"}]
+  Move         r11, r10
+  // let kind_type = [
+  Const        r12, [{"id": 1, "kind": "movie"}, {"id": 2, "kind": "series"}]
+  Move         r13, r12
+  // let movie_companies = [
+  Const        r14, [{"company_id": 1, "company_type_id": 1, "movie_id": 1}, {"company_id": 2, "company_type_id": 2, "movie_id": 2}]
+  Move         r15, r14
+  // let movie_info = [
+  Const        r16, [{"info": "USA: May 2005", "info_type_id": 1, "movie_id": 1, "note": "internet release"}, {"info": "USA: April 1998", "info_type_id": 1, "movie_id": 2, "note": "theater"}]
+  Move         r17, r16
+  // let movie_keyword = [
+  Const        r18, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}]
+  Move         r19, r18
+  // let title = [
+  Const        r20, [{"id": 1, "kind_id": 1, "production_year": 2005, "title": "Web Movie"}, {"id": 2, "kind_id": 1, "production_year": 1998, "title": "Old Movie"}]
+  Move         r21, r20
+  // from cc in complete_cast
+  Const        r22, []
+  IterPrep     r23, r1
+  Len          r24, r23
+  Const        r25, 0
+L30:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L0
+  Index        r27, r23, r25
+  Move         r28, r27
+  // join cct1 in comp_cast_type on cct1.id == cc.status_id
+  IterPrep     r29, r3
+  Len          r30, r29
+  Const        r31, 0
+L29:
+  Less         r32, r31, r30
+  JumpIfFalse  r32, L1
+  Index        r33, r29, r31
+  Move         r34, r33
+  Const        r35, "id"
+  Index        r36, r34, r35
+  Const        r37, "status_id"
+  Index        r38, r28, r37
+  Equal        r39, r36, r38
+  JumpIfFalse  r39, L2
+  // join t in title on t.id == cc.movie_id
+  IterPrep     r40, r21
+  Len          r41, r40
+  Const        r42, 0
+L28:
+  Less         r43, r42, r41
+  JumpIfFalse  r43, L2
+  Index        r44, r40, r42
+  Move         r45, r44
+  Const        r46, "id"
+  Index        r47, r45, r46
+  Const        r48, "movie_id"
+  Index        r49, r28, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L3
+  // join kt in kind_type on kt.id == t.kind_id
+  IterPrep     r51, r13
+  Len          r52, r51
+  Const        r53, 0
+L27:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L3
+  Index        r55, r51, r53
+  Move         r56, r55
+  Const        r57, "id"
+  Index        r58, r56, r57
+  Const        r59, "kind_id"
+  Index        r60, r45, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L4
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r62, r17
+  Len          r63, r62
+  Const        r64, 0
+L26:
+  Less         r65, r64, r63
+  JumpIfFalse  r65, L4
+  Index        r66, r62, r64
+  Move         r67, r66
+  Const        r68, "movie_id"
+  Index        r69, r67, r68
+  Const        r70, "id"
+  Index        r71, r45, r70
+  Equal        r72, r69, r71
+  JumpIfFalse  r72, L5
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r73, r9
+  Len          r74, r73
+  Const        r75, 0
+L25:
+  Less         r76, r75, r74
+  JumpIfFalse  r76, L5
+  Index        r77, r73, r75
+  Move         r78, r77
+  Const        r79, "id"
+  Index        r80, r78, r79
+  Const        r81, "info_type_id"
+  Index        r82, r67, r81
+  Equal        r83, r80, r82
+  JumpIfFalse  r83, L6
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r84, r19
+  Len          r85, r84
+  Const        r86, 0
+L24:
+  Less         r87, r86, r85
+  JumpIfFalse  r87, L6
+  Index        r88, r84, r86
+  Move         r89, r88
+  Const        r90, "movie_id"
+  Index        r91, r89, r90
+  Const        r92, "id"
+  Index        r93, r45, r92
+  Equal        r94, r91, r93
+  JumpIfFalse  r94, L7
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r95, r11
+  Len          r96, r95
+  Const        r97, 0
+L23:
+  Less         r98, r97, r96
+  JumpIfFalse  r98, L7
+  Index        r99, r95, r97
+  Move         r100, r99
+  Const        r101, "id"
+  Index        r102, r100, r101
+  Const        r103, "keyword_id"
+  Index        r104, r89, r103
+  Equal        r105, r102, r104
+  JumpIfFalse  r105, L8
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r106, r15
+  Len          r107, r106
+  Const        r108, 0
+L22:
+  Less         r109, r108, r107
+  JumpIfFalse  r109, L8
+  Index        r110, r106, r108
+  Move         r111, r110
+  Const        r112, "movie_id"
+  Index        r113, r111, r112
+  Const        r114, "id"
+  Index        r115, r45, r114
+  Equal        r116, r113, r115
+  JumpIfFalse  r116, L9
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r117, r5
+  Len          r118, r117
+  Const        r119, 0
+L21:
+  Less         r120, r119, r118
+  JumpIfFalse  r120, L9
+  Index        r121, r117, r119
+  Move         r122, r121
+  Const        r123, "id"
+  Index        r124, r122, r123
+  Const        r125, "company_id"
+  Index        r126, r111, r125
+  Equal        r127, r124, r126
+  JumpIfFalse  r127, L10
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r128, r7
+  Len          r129, r128
+  Const        r130, 0
+L20:
+  Less         r131, r130, r129
+  JumpIfFalse  r131, L10
+  Index        r132, r128, r130
+  Move         r133, r132
+  Const        r134, "id"
+  Index        r135, r133, r134
+  Const        r136, "company_type_id"
+  Index        r137, r111, r136
+  Equal        r138, r135, r137
+  JumpIfFalse  r138, L11
+  // where cct1.kind == "complete+verified" &&
+  Const        r139, "kind"
+  Index        r140, r34, r139
+  // t.production_year > 2000
+  Const        r141, "production_year"
+  Index        r142, r45, r141
+  Const        r143, 2000
+  Less         r144, r143, r142
+  // where cct1.kind == "complete+verified" &&
+  Const        r145, "complete+verified"
+  Equal        r146, r140, r145
+  // cn.country_code == "[us]" &&
+  Const        r147, "country_code"
+  Index        r148, r122, r147
+  Const        r149, "[us]"
+  Equal        r150, r148, r149
+  // it1.info == "release dates" &&
+  Const        r151, "info"
+  Index        r152, r78, r151
+  Const        r153, "release dates"
+  Equal        r154, r152, r153
+  // kt.kind == "movie" &&
+  Const        r155, "kind"
+  Index        r156, r56, r155
+  Const        r157, "movie"
+  Equal        r158, r156, r157
+  // where cct1.kind == "complete+verified" &&
+  Move         r159, r146
+  JumpIfFalse  r159, L12
+  Move         r159, r150
+L12:
+  // cn.country_code == "[us]" &&
+  Move         r160, r159
+  JumpIfFalse  r160, L13
+  Move         r160, r154
+L13:
+  // it1.info == "release dates" &&
+  Move         r161, r160
+  JumpIfFalse  r161, L14
+  Move         r161, r158
+L14:
+  // kt.kind == "movie" &&
+  Move         r162, r161
+  JumpIfFalse  r162, L15
+  Const        r163, "note"
+  Index        r164, r67, r163
+  // mi.note.contains("internet") &&
+  Const        r165, "internet"
+  In           r166, r165, r164
+  // kt.kind == "movie" &&
+  Move         r162, r166
+L15:
+  // mi.note.contains("internet") &&
+  Move         r167, r162
+  JumpIfFalse  r167, L16
+  Const        r168, "info"
+  Index        r169, r67, r168
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Const        r170, "USA:"
+  In           r171, r170, r169
+  Move         r172, r171
+  JumpIfFalse  r172, L17
+  Const        r173, "info"
+  Index        r174, r67, r173
+  Const        r175, "199"
+  In           r176, r175, r174
+  Move         r177, r176
+  JumpIfTrue   r177, L18
+  Const        r178, "info"
+  Index        r179, r67, r178
+  Const        r180, "200"
+  In           r181, r180, r179
+  Move         r177, r181
+L18:
+  Move         r172, r177
+L17:
+  // mi.note.contains("internet") &&
+  Move         r167, r172
+L16:
+  // (mi.info.contains("USA:") && (mi.info.contains("199") || mi.info.contains("200"))) &&
+  Move         r182, r167
+  JumpIfFalse  r182, L19
+  Move         r182, r144
+L19:
+  // where cct1.kind == "complete+verified" &&
+  JumpIfFalse  r182, L11
+  // select { movie_kind: kt.kind, complete_us_internet_movie: t.title }
+  Const        r183, "movie_kind"
+  Const        r184, "kind"
+  Index        r185, r56, r184
+  Const        r186, "complete_us_internet_movie"
+  Const        r187, "title"
+  Index        r188, r45, r187
+  Move         r189, r183
+  Move         r190, r185
+  Move         r191, r186
+  Move         r192, r188
+  MakeMap      r193, 2, r189
+  // from cc in complete_cast
+  Append       r194, r22, r193
+  Move         r22, r194
+L11:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r195, 1
+  Add          r196, r130, r195
+  Move         r130, r196
+  Jump         L20
+L10:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r197, 1
+  Add          r198, r119, r197
+  Move         r119, r198
+  Jump         L21
+L9:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r199, 1
+  Add          r200, r108, r199
+  Move         r108, r200
+  Jump         L22
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r201, 1
+  Add          r202, r97, r201
+  Move         r97, r202
+  Jump         L23
+L7:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r203, 1
+  Add          r204, r86, r203
+  Move         r86, r204
+  Jump         L24
+L6:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r205, 1
+  Add          r206, r75, r205
+  Move         r75, r206
+  Jump         L25
+L5:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r207, 1
+  Add          r208, r64, r207
+  Move         r64, r208
+  Jump         L26
+L4:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r209, 1
+  Add          r210, r53, r209
+  Move         r53, r210
+  Jump         L27
+L3:
+  // join t in title on t.id == cc.movie_id
+  Const        r211, 1
+  Add          r212, r42, r211
+  Move         r42, r212
+  Jump         L28
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.status_id
+  Const        r213, 1
+  Add          r214, r31, r213
+  Move         r31, r214
+  Jump         L29
+L1:
+  // from cc in complete_cast
+  Const        r215, 1
+  Add          r216, r25, r215
+  Move         r25, r216
+  Jump         L30
+L0:
+  // let matches =
+  Move         r217, r22
+  // movie_kind: min(from r in matches select r.movie_kind),
+  Const        r218, "movie_kind"
+  Const        r219, []
+  IterPrep     r220, r217
+  Len          r221, r220
+  Const        r222, 0
+L32:
+  Less         r223, r222, r221
+  JumpIfFalse  r223, L31
+  Index        r224, r220, r222
+  Move         r225, r224
+  Const        r226, "movie_kind"
+  Index        r227, r225, r226
+  Append       r228, r219, r227
+  Move         r219, r228
+  Const        r229, 1
+  Add          r230, r222, r229
+  Move         r222, r230
+  Jump         L32
+L31:
+  Min          r231, r219
+  // complete_us_internet_movie: min(from r in matches select r.complete_us_internet_movie)
+  Const        r232, "complete_us_internet_movie"
+  Const        r233, []
+  IterPrep     r234, r217
+  Len          r235, r234
+  Const        r236, 0
+L34:
+  Less         r237, r236, r235
+  JumpIfFalse  r237, L33
+  Index        r238, r234, r236
+  Move         r225, r238
+  Const        r239, "complete_us_internet_movie"
+  Index        r240, r225, r239
+  Append       r241, r233, r240
+  Move         r233, r241
+  Const        r242, 1
+  Add          r243, r236, r242
+  Move         r236, r243
+  Jump         L34
+L33:
+  Min          r244, r233
+  // movie_kind: min(from r in matches select r.movie_kind),
+  Move         r245, r218
+  Move         r246, r231
+  // complete_us_internet_movie: min(from r in matches select r.complete_us_internet_movie)
+  Move         r247, r232
+  Move         r248, r244
+  // {
+  MakeMap      r249, 2, r245
+  Move         r250, r249
+  // let result = [
+  MakeList     r251, 1, r250
+  Move         r252, r251
+  // json(result)
+  JSON         r252
+  // expect result == [
+  Const        r253, [{"complete_us_internet_movie": "Web Movie", "movie_kind": "movie"}]
+  Equal        r254, r252, r253
+  Expect       r254
+  Return       r0

--- a/tests/dataset/job/out/q24.ir.out
+++ b/tests/dataset/job/out/q24.ir.out
@@ -1,0 +1,662 @@
+func main (regs=369)
+  // let aka_name = [
+  Const        r0, [{"person_id": 1}]
+  Move         r1, r0
+  // let char_name = [
+  Const        r2, [{"id": 1, "name": "Hero Character"}]
+  Move         r3, r2
+  // let cast_info = [
+  Const        r4, [{"movie_id": 1, "note": "(voice)", "person_id": 1, "person_role_id": 1, "role_id": 1}]
+  Move         r5, r4
+  // let company_name = [
+  Const        r6, [{"country_code": "[us]", "id": 1}]
+  Move         r7, r6
+  // let info_type = [
+  Const        r8, [{"id": 1, "info": "release dates"}]
+  Move         r9, r8
+  // let keyword = [
+  Const        r10, [{"id": 1, "keyword": "hero"}]
+  Move         r11, r10
+  // let movie_companies = [
+  Const        r12, [{"company_id": 1, "movie_id": 1}]
+  Move         r13, r12
+  // let movie_info = [
+  Const        r14, [{"info": "Japan: Feb 2015", "info_type_id": 1, "movie_id": 1}]
+  Move         r15, r14
+  // let movie_keyword = [
+  Const        r16, [{"keyword_id": 1, "movie_id": 1}]
+  Move         r17, r16
+  // let name = [
+  Const        r18, [{"gender": "f", "id": 1, "name": "Ann Actress"}]
+  Move         r19, r18
+  // let role_type = [
+  Const        r20, [{"id": 1, "role": "actress"}]
+  Move         r21, r20
+  // let title = [
+  Const        r22, [{"id": 1, "production_year": 2015, "title": "Heroic Adventure"}]
+  Move         r23, r22
+  // from an in aka_name
+  Const        r24, []
+  IterPrep     r25, r1
+  Len          r26, r25
+  Const        r27, 0
+L54:
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L0
+  Index        r29, r25, r27
+  Move         r30, r29
+  // from chn in char_name
+  IterPrep     r31, r3
+  Len          r32, r31
+  Const        r33, 0
+L53:
+  Less         r34, r33, r32
+  JumpIfFalse  r34, L1
+  Index        r35, r31, r33
+  Move         r36, r35
+  // from ci in cast_info
+  IterPrep     r37, r5
+  Len          r38, r37
+  Const        r39, 0
+L52:
+  Less         r40, r39, r38
+  JumpIfFalse  r40, L2
+  Index        r41, r37, r39
+  Move         r42, r41
+  // from cn in company_name
+  IterPrep     r43, r7
+  Len          r44, r43
+  Const        r45, 0
+L51:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L3
+  Index        r47, r43, r45
+  Move         r48, r47
+  // from it in info_type
+  IterPrep     r49, r9
+  Len          r50, r49
+  Const        r51, 0
+L50:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L4
+  Index        r53, r49, r51
+  Move         r54, r53
+  // from k in keyword
+  IterPrep     r55, r11
+  Len          r56, r55
+  Const        r57, 0
+L49:
+  Less         r58, r57, r56
+  JumpIfFalse  r58, L5
+  Index        r59, r55, r57
+  Move         r60, r59
+  // from mc in movie_companies
+  IterPrep     r61, r13
+  Len          r62, r61
+  Const        r63, 0
+L48:
+  Less         r64, r63, r62
+  JumpIfFalse  r64, L6
+  Index        r65, r61, r63
+  Move         r66, r65
+  // from mi in movie_info
+  IterPrep     r67, r15
+  Len          r68, r67
+  Const        r69, 0
+L47:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L7
+  Index        r71, r67, r69
+  Move         r72, r71
+  // from mk in movie_keyword
+  IterPrep     r73, r17
+  Len          r74, r73
+  Const        r75, 0
+L46:
+  Less         r76, r75, r74
+  JumpIfFalse  r76, L8
+  Index        r77, r73, r75
+  Move         r78, r77
+  // from n in name
+  IterPrep     r79, r19
+  Len          r80, r79
+  Const        r81, 0
+L45:
+  Less         r82, r81, r80
+  JumpIfFalse  r82, L9
+  Index        r83, r79, r81
+  Move         r84, r83
+  // from rt in role_type
+  IterPrep     r85, r21
+  Len          r86, r85
+  Const        r87, 0
+L44:
+  Less         r88, r87, r86
+  JumpIfFalse  r88, L10
+  Index        r89, r85, r87
+  Move         r90, r89
+  // from t in title
+  IterPrep     r91, r23
+  Len          r92, r91
+  Const        r93, 0
+L43:
+  Less         r94, r93, r92
+  JumpIfFalse  r94, L11
+  Index        r95, r91, r93
+  Move         r96, r95
+  // ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"] &&
+  Const        r97, "note"
+  Index        r98, r42, r97
+  // t.production_year > 2010 &&
+  Const        r99, "production_year"
+  Index        r100, r96, r99
+  Const        r101, 2010
+  Less         r102, r101, r100
+  // ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"] &&
+  Const        r103, ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]
+  In           r104, r98, r103
+  // cn.country_code == "[us]" &&
+  Const        r105, "country_code"
+  Index        r106, r48, r105
+  Const        r107, "[us]"
+  Equal        r108, r106, r107
+  // it.info == "release dates" &&
+  Const        r109, "info"
+  Index        r110, r54, r109
+  Const        r111, "release dates"
+  Equal        r112, r110, r111
+  // k.keyword in ["hero", "martial-arts", "hand-to-hand-combat"] &&
+  Const        r113, "keyword"
+  Index        r114, r60, r113
+  Const        r115, ["hero", "martial-arts", "hand-to-hand-combat"]
+  In           r116, r114, r115
+  // mi.info != null &&
+  Const        r117, "info"
+  Index        r118, r72, r117
+  Const        r119, nil
+  NotEqual     r120, r118, r119
+  // n.gender == "f" &&
+  Const        r121, "gender"
+  Index        r122, r84, r121
+  Const        r123, "f"
+  Equal        r124, r122, r123
+  // rt.role == "actress" &&
+  Const        r125, "role"
+  Index        r126, r90, r125
+  Const        r127, "actress"
+  Equal        r128, r126, r127
+  // t.id == mi.movie_id &&
+  Const        r129, "id"
+  Index        r130, r96, r129
+  Const        r131, "movie_id"
+  Index        r132, r72, r131
+  Equal        r133, r130, r132
+  // t.id == mc.movie_id &&
+  Const        r134, "id"
+  Index        r135, r96, r134
+  Const        r136, "movie_id"
+  Index        r137, r66, r136
+  Equal        r138, r135, r137
+  // t.id == ci.movie_id &&
+  Const        r139, "id"
+  Index        r140, r96, r139
+  Const        r141, "movie_id"
+  Index        r142, r42, r141
+  Equal        r143, r140, r142
+  // t.id == mk.movie_id &&
+  Const        r144, "id"
+  Index        r145, r96, r144
+  Const        r146, "movie_id"
+  Index        r147, r78, r146
+  Equal        r148, r145, r147
+  // mc.movie_id == ci.movie_id &&
+  Const        r149, "movie_id"
+  Index        r150, r66, r149
+  Const        r151, "movie_id"
+  Index        r152, r42, r151
+  Equal        r153, r150, r152
+  // mc.movie_id == mi.movie_id &&
+  Const        r154, "movie_id"
+  Index        r155, r66, r154
+  Const        r156, "movie_id"
+  Index        r157, r72, r156
+  Equal        r158, r155, r157
+  // mc.movie_id == mk.movie_id &&
+  Const        r159, "movie_id"
+  Index        r160, r66, r159
+  Const        r161, "movie_id"
+  Index        r162, r78, r161
+  Equal        r163, r160, r162
+  // mi.movie_id == ci.movie_id &&
+  Const        r164, "movie_id"
+  Index        r165, r72, r164
+  Const        r166, "movie_id"
+  Index        r167, r42, r166
+  Equal        r168, r165, r167
+  // mi.movie_id == mk.movie_id &&
+  Const        r169, "movie_id"
+  Index        r170, r72, r169
+  Const        r171, "movie_id"
+  Index        r172, r78, r171
+  Equal        r173, r170, r172
+  // ci.movie_id == mk.movie_id &&
+  Const        r174, "movie_id"
+  Index        r175, r42, r174
+  Const        r176, "movie_id"
+  Index        r177, r78, r176
+  Equal        r178, r175, r177
+  // cn.id == mc.company_id &&
+  Const        r179, "id"
+  Index        r180, r48, r179
+  Const        r181, "company_id"
+  Index        r182, r66, r181
+  Equal        r183, r180, r182
+  // it.id == mi.info_type_id &&
+  Const        r184, "id"
+  Index        r185, r54, r184
+  Const        r186, "info_type_id"
+  Index        r187, r72, r186
+  Equal        r188, r185, r187
+  // n.id == ci.person_id &&
+  Const        r189, "id"
+  Index        r190, r84, r189
+  Const        r191, "person_id"
+  Index        r192, r42, r191
+  Equal        r193, r190, r192
+  // rt.id == ci.role_id &&
+  Const        r194, "id"
+  Index        r195, r90, r194
+  Const        r196, "role_id"
+  Index        r197, r42, r196
+  Equal        r198, r195, r197
+  // n.id == an.person_id &&
+  Const        r199, "id"
+  Index        r200, r84, r199
+  Const        r201, "person_id"
+  Index        r202, r30, r201
+  Equal        r203, r200, r202
+  // ci.person_id == an.person_id &&
+  Const        r204, "person_id"
+  Index        r205, r42, r204
+  Const        r206, "person_id"
+  Index        r207, r30, r206
+  Equal        r208, r205, r207
+  // chn.id == ci.person_role_id &&
+  Const        r209, "id"
+  Index        r210, r36, r209
+  Const        r211, "person_role_id"
+  Index        r212, r42, r211
+  Equal        r213, r210, r212
+  // k.id == mk.keyword_id
+  Const        r214, "id"
+  Index        r215, r60, r214
+  Const        r216, "keyword_id"
+  Index        r217, r78, r216
+  Equal        r218, r215, r217
+  // ci.note in ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"] &&
+  Move         r219, r104
+  JumpIfFalse  r219, L12
+  Move         r219, r108
+L12:
+  // cn.country_code == "[us]" &&
+  Move         r220, r219
+  JumpIfFalse  r220, L13
+  Move         r220, r112
+L13:
+  // it.info == "release dates" &&
+  Move         r221, r220
+  JumpIfFalse  r221, L14
+  Move         r221, r116
+L14:
+  // k.keyword in ["hero", "martial-arts", "hand-to-hand-combat"] &&
+  Move         r222, r221
+  JumpIfFalse  r222, L15
+  Move         r222, r120
+L15:
+  // mi.info != null &&
+  Move         r223, r222
+  JumpIfFalse  r223, L16
+  Const        r224, "info"
+  Index        r225, r72, r224
+  // (mi.info.starts_with("Japan:") && mi.info.contains("201") ||
+  Const        r226, "Japan:"
+  Const        r227, 0
+  Len          r228, r226
+  Slice        r229, r225, r227, r228
+  Equal        r230, r229, r226
+  Move         r231, r230
+  JumpIfFalse  r231, L17
+  Const        r232, "info"
+  Index        r233, r72, r232
+  Const        r234, "201"
+  In           r235, r234, r233
+  Move         r231, r235
+L17:
+  Const        r236, "info"
+  Index        r237, r72, r236
+  // mi.info.starts_with("USA:") && mi.info.contains("201")) &&
+  Const        r238, "USA:"
+  Const        r239, 0
+  Len          r240, r238
+  Slice        r241, r237, r239, r240
+  Equal        r242, r241, r238
+  Move         r243, r242
+  JumpIfFalse  r243, L18
+  Const        r244, "info"
+  Index        r245, r72, r244
+  Const        r246, "201"
+  In           r247, r246, r245
+  Move         r243, r247
+L18:
+  // (mi.info.starts_with("Japan:") && mi.info.contains("201") ||
+  Move         r248, r231
+  JumpIfTrue   r248, L19
+  Move         r248, r243
+L19:
+  // mi.info != null &&
+  Move         r223, r248
+L16:
+  // mi.info.starts_with("USA:") && mi.info.contains("201")) &&
+  Move         r249, r223
+  JumpIfFalse  r249, L20
+  Move         r249, r124
+L20:
+  // n.gender == "f" &&
+  Move         r250, r249
+  JumpIfFalse  r250, L21
+  Const        r251, "name"
+  Index        r252, r84, r251
+  // n.name.contains("An") &&
+  Const        r253, "An"
+  In           r254, r253, r252
+  // n.gender == "f" &&
+  Move         r250, r254
+L21:
+  // n.name.contains("An") &&
+  Move         r255, r250
+  JumpIfFalse  r255, L22
+  Move         r255, r128
+L22:
+  // rt.role == "actress" &&
+  Move         r256, r255
+  JumpIfFalse  r256, L23
+  Move         r256, r102
+L23:
+  // t.production_year > 2010 &&
+  Move         r257, r256
+  JumpIfFalse  r257, L24
+  Move         r257, r133
+L24:
+  // t.id == mi.movie_id &&
+  Move         r258, r257
+  JumpIfFalse  r258, L25
+  Move         r258, r138
+L25:
+  // t.id == mc.movie_id &&
+  Move         r259, r258
+  JumpIfFalse  r259, L26
+  Move         r259, r143
+L26:
+  // t.id == ci.movie_id &&
+  Move         r260, r259
+  JumpIfFalse  r260, L27
+  Move         r260, r148
+L27:
+  // t.id == mk.movie_id &&
+  Move         r261, r260
+  JumpIfFalse  r261, L28
+  Move         r261, r153
+L28:
+  // mc.movie_id == ci.movie_id &&
+  Move         r262, r261
+  JumpIfFalse  r262, L29
+  Move         r262, r158
+L29:
+  // mc.movie_id == mi.movie_id &&
+  Move         r263, r262
+  JumpIfFalse  r263, L30
+  Move         r263, r163
+L30:
+  // mc.movie_id == mk.movie_id &&
+  Move         r264, r263
+  JumpIfFalse  r264, L31
+  Move         r264, r168
+L31:
+  // mi.movie_id == ci.movie_id &&
+  Move         r265, r264
+  JumpIfFalse  r265, L32
+  Move         r265, r173
+L32:
+  // mi.movie_id == mk.movie_id &&
+  Move         r266, r265
+  JumpIfFalse  r266, L33
+  Move         r266, r178
+L33:
+  // ci.movie_id == mk.movie_id &&
+  Move         r267, r266
+  JumpIfFalse  r267, L34
+  Move         r267, r183
+L34:
+  // cn.id == mc.company_id &&
+  Move         r268, r267
+  JumpIfFalse  r268, L35
+  Move         r268, r188
+L35:
+  // it.id == mi.info_type_id &&
+  Move         r269, r268
+  JumpIfFalse  r269, L36
+  Move         r269, r193
+L36:
+  // n.id == ci.person_id &&
+  Move         r270, r269
+  JumpIfFalse  r270, L37
+  Move         r270, r198
+L37:
+  // rt.id == ci.role_id &&
+  Move         r271, r270
+  JumpIfFalse  r271, L38
+  Move         r271, r203
+L38:
+  // n.id == an.person_id &&
+  Move         r272, r271
+  JumpIfFalse  r272, L39
+  Move         r272, r208
+L39:
+  // ci.person_id == an.person_id &&
+  Move         r273, r272
+  JumpIfFalse  r273, L40
+  Move         r273, r213
+L40:
+  // chn.id == ci.person_role_id &&
+  Move         r274, r273
+  JumpIfFalse  r274, L41
+  Move         r274, r218
+L41:
+  // where (
+  JumpIfFalse  r274, L42
+  // voiced_char_name: chn.name,
+  Const        r275, "voiced_char_name"
+  Const        r276, "name"
+  Index        r277, r36, r276
+  // voicing_actress_name: n.name,
+  Const        r278, "voicing_actress_name"
+  Const        r279, "name"
+  Index        r280, r84, r279
+  // voiced_action_movie_jap_eng: t.title
+  Const        r281, "voiced_action_movie_jap_eng"
+  Const        r282, "title"
+  Index        r283, r96, r282
+  // voiced_char_name: chn.name,
+  Move         r284, r275
+  Move         r285, r277
+  // voicing_actress_name: n.name,
+  Move         r286, r278
+  Move         r287, r280
+  // voiced_action_movie_jap_eng: t.title
+  Move         r288, r281
+  Move         r289, r283
+  // select {
+  MakeMap      r290, 3, r284
+  // from an in aka_name
+  Append       r291, r24, r290
+  Move         r24, r291
+L42:
+  // from t in title
+  Const        r292, 1
+  Add          r293, r93, r292
+  Move         r93, r293
+  Jump         L43
+L11:
+  // from rt in role_type
+  Const        r294, 1
+  Add          r295, r87, r294
+  Move         r87, r295
+  Jump         L44
+L10:
+  // from n in name
+  Const        r296, 1
+  Add          r297, r81, r296
+  Move         r81, r297
+  Jump         L45
+L9:
+  // from mk in movie_keyword
+  Const        r298, 1
+  Add          r299, r75, r298
+  Move         r75, r299
+  Jump         L46
+L8:
+  // from mi in movie_info
+  Const        r300, 1
+  Add          r301, r69, r300
+  Move         r69, r301
+  Jump         L47
+L7:
+  // from mc in movie_companies
+  Const        r302, 1
+  Add          r303, r63, r302
+  Move         r63, r303
+  Jump         L48
+L6:
+  // from k in keyword
+  Const        r304, 1
+  Add          r305, r57, r304
+  Move         r57, r305
+  Jump         L49
+L5:
+  // from it in info_type
+  Const        r306, 1
+  Add          r307, r51, r306
+  Move         r51, r307
+  Jump         L50
+L4:
+  // from cn in company_name
+  Const        r308, 1
+  Add          r309, r45, r308
+  Move         r45, r309
+  Jump         L51
+L3:
+  // from ci in cast_info
+  Const        r310, 1
+  Add          r311, r39, r310
+  Move         r39, r311
+  Jump         L52
+L2:
+  // from chn in char_name
+  Const        r312, 1
+  Add          r313, r33, r312
+  Move         r33, r313
+  Jump         L53
+L1:
+  // from an in aka_name
+  Const        r314, 1
+  Add          r315, r27, r314
+  Move         r27, r315
+  Jump         L54
+L0:
+  // let matches =
+  Move         r316, r24
+  // voiced_char_name: min(from x in matches select x.voiced_char_name),
+  Const        r317, "voiced_char_name"
+  Const        r318, []
+  IterPrep     r319, r316
+  Len          r320, r319
+  Const        r321, 0
+L56:
+  Less         r322, r321, r320
+  JumpIfFalse  r322, L55
+  Index        r323, r319, r321
+  Move         r324, r323
+  Const        r325, "voiced_char_name"
+  Index        r326, r324, r325
+  Append       r327, r318, r326
+  Move         r318, r327
+  Const        r328, 1
+  Add          r329, r321, r328
+  Move         r321, r329
+  Jump         L56
+L55:
+  Min          r330, r318
+  // voicing_actress_name: min(from x in matches select x.voicing_actress_name),
+  Const        r331, "voicing_actress_name"
+  Const        r332, []
+  IterPrep     r333, r316
+  Len          r334, r333
+  Const        r335, 0
+L58:
+  Less         r336, r335, r334
+  JumpIfFalse  r336, L57
+  Index        r337, r333, r335
+  Move         r324, r337
+  Const        r338, "voicing_actress_name"
+  Index        r339, r324, r338
+  Append       r340, r332, r339
+  Move         r332, r340
+  Const        r341, 1
+  Add          r342, r335, r341
+  Move         r335, r342
+  Jump         L58
+L57:
+  Min          r343, r332
+  // voiced_action_movie_jap_eng: min(from x in matches select x.voiced_action_movie_jap_eng)
+  Const        r344, "voiced_action_movie_jap_eng"
+  Const        r345, []
+  IterPrep     r346, r316
+  Len          r347, r346
+  Const        r348, 0
+L60:
+  Less         r349, r348, r347
+  JumpIfFalse  r349, L59
+  Index        r350, r346, r348
+  Move         r324, r350
+  Const        r351, "voiced_action_movie_jap_eng"
+  Index        r352, r324, r351
+  Append       r353, r345, r352
+  Move         r345, r353
+  Const        r354, 1
+  Add          r355, r348, r354
+  Move         r348, r355
+  Jump         L60
+L59:
+  Min          r356, r345
+  // voiced_char_name: min(from x in matches select x.voiced_char_name),
+  Move         r357, r317
+  Move         r358, r330
+  // voicing_actress_name: min(from x in matches select x.voicing_actress_name),
+  Move         r359, r331
+  Move         r360, r343
+  // voiced_action_movie_jap_eng: min(from x in matches select x.voiced_action_movie_jap_eng)
+  Move         r361, r344
+  Move         r362, r356
+  // {
+  MakeMap      r363, 3, r357
+  Move         r364, r363
+  // let result = [
+  MakeList     r365, 1, r364
+  Move         r366, r365
+  // json(result)
+  JSON         r366
+  // expect result == [
+  Const        r367, [{"voiced_action_movie_jap_eng": "Heroic Adventure", "voiced_char_name": "Hero Character", "voicing_actress_name": "Ann Actress"}]
+  Equal        r368, r366, r367
+  Expect       r368
+  Return       r0

--- a/tests/dataset/job/out/q25.ir.out
+++ b/tests/dataset/job/out/q25.ir.out
@@ -1,0 +1,522 @@
+func main (regs=294)
+  // let cast_info = [
+  Const        r0, [{"movie_id": 1, "note": "(writer)", "person_id": 1}, {"movie_id": 2, "note": "(writer)", "person_id": 2}]
+  Move         r1, r0
+  // let info_type = [
+  Const        r2, [{"id": 1, "info": "genres"}, {"id": 2, "info": "votes"}]
+  Move         r3, r2
+  // let keyword = [
+  Const        r4, [{"id": 1, "keyword": "murder"}, {"id": 2, "keyword": "romance"}]
+  Move         r5, r4
+  // let movie_info = [
+  Const        r6, [{"info": "Horror", "info_type_id": 1, "movie_id": 1}, {"info": "Comedy", "info_type_id": 1, "movie_id": 2}]
+  Move         r7, r6
+  // let movie_info_idx = [
+  Const        r8, [{"info": 100, "info_type_id": 2, "movie_id": 1}, {"info": 50, "info_type_id": 2, "movie_id": 2}]
+  Move         r9, r8
+  // let movie_keyword = [
+  Const        r10, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}]
+  Move         r11, r10
+  // let name = [
+  Const        r12, [{"gender": "m", "id": 1, "name": "Mike"}, {"gender": "f", "id": 2, "name": "Sue"}]
+  Move         r13, r12
+  // let title = [
+  Const        r14, [{"id": 1, "title": "Scary Movie"}, {"id": 2, "title": "Funny Movie"}]
+  Move         r15, r14
+  // let allowed_notes = ["(writer)", "(head writer)", "(written by)", "(story)", "(story editor)"]
+  Const        r16, ["(writer)", "(head writer)", "(written by)", "(story)", "(story editor)"]
+  Move         r17, r16
+  // let allowed_keywords = ["murder", "blood", "gore", "death", "female-nudity"]
+  Const        r18, ["murder", "blood", "gore", "death", "female-nudity"]
+  Move         r19, r18
+  // from ci in cast_info
+  Const        r20, []
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L37:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L0
+  Index        r25, r21, r23
+  Move         r26, r25
+  // from it1 in info_type
+  IterPrep     r27, r3
+  Len          r28, r27
+  Const        r29, 0
+L36:
+  Less         r30, r29, r28
+  JumpIfFalse  r30, L1
+  Index        r31, r27, r29
+  Move         r32, r31
+  // from it2 in info_type
+  IterPrep     r33, r3
+  Len          r34, r33
+  Const        r35, 0
+L35:
+  Less         r36, r35, r34
+  JumpIfFalse  r36, L2
+  Index        r37, r33, r35
+  Move         r38, r37
+  // from k in keyword
+  IterPrep     r39, r5
+  Len          r40, r39
+  Const        r41, 0
+L34:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L3
+  Index        r43, r39, r41
+  Move         r44, r43
+  // from mi in movie_info
+  IterPrep     r45, r7
+  Len          r46, r45
+  Const        r47, 0
+L33:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L4
+  Index        r49, r45, r47
+  Move         r50, r49
+  // from mi_idx in movie_info_idx
+  IterPrep     r51, r9
+  Len          r52, r51
+  Const        r53, 0
+L32:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L5
+  Index        r55, r51, r53
+  Move         r56, r55
+  // from mk in movie_keyword
+  IterPrep     r57, r11
+  Len          r58, r57
+  Const        r59, 0
+L31:
+  Less         r60, r59, r58
+  JumpIfFalse  r60, L6
+  Index        r61, r57, r59
+  Move         r62, r61
+  // from n in name
+  IterPrep     r63, r13
+  Len          r64, r63
+  Const        r65, 0
+L30:
+  Less         r66, r65, r64
+  JumpIfFalse  r66, L7
+  Index        r67, r63, r65
+  Move         r68, r67
+  // from t in title
+  IterPrep     r69, r15
+  Len          r70, r69
+  Const        r71, 0
+L29:
+  Less         r72, r71, r70
+  JumpIfFalse  r72, L8
+  Index        r73, r69, r71
+  Move         r74, r73
+  // (ci.note in allowed_notes) &&
+  Const        r75, "note"
+  Index        r76, r26, r75
+  In           r77, r76, r17
+  // it1.info == "genres" &&
+  Const        r78, "info"
+  Index        r79, r32, r78
+  Const        r80, "genres"
+  Equal        r81, r79, r80
+  // it2.info == "votes" &&
+  Const        r82, "info"
+  Index        r83, r38, r82
+  Const        r84, "votes"
+  Equal        r85, r83, r84
+  // mi.info == "Horror" &&
+  Const        r86, "info"
+  Index        r87, r50, r86
+  Const        r88, "Horror"
+  Equal        r89, r87, r88
+  // n.gender == "m" &&
+  Const        r90, "gender"
+  Index        r91, r68, r90
+  Const        r92, "m"
+  Equal        r93, r91, r92
+  // t.id == mi.movie_id &&
+  Const        r94, "id"
+  Index        r95, r74, r94
+  Const        r96, "movie_id"
+  Index        r97, r50, r96
+  Equal        r98, r95, r97
+  // t.id == mi_idx.movie_id &&
+  Const        r99, "id"
+  Index        r100, r74, r99
+  Const        r101, "movie_id"
+  Index        r102, r56, r101
+  Equal        r103, r100, r102
+  // t.id == ci.movie_id &&
+  Const        r104, "id"
+  Index        r105, r74, r104
+  Const        r106, "movie_id"
+  Index        r107, r26, r106
+  Equal        r108, r105, r107
+  // t.id == mk.movie_id &&
+  Const        r109, "id"
+  Index        r110, r74, r109
+  Const        r111, "movie_id"
+  Index        r112, r62, r111
+  Equal        r113, r110, r112
+  // ci.movie_id == mi.movie_id &&
+  Const        r114, "movie_id"
+  Index        r115, r26, r114
+  Const        r116, "movie_id"
+  Index        r117, r50, r116
+  Equal        r118, r115, r117
+  // ci.movie_id == mi_idx.movie_id &&
+  Const        r119, "movie_id"
+  Index        r120, r26, r119
+  Const        r121, "movie_id"
+  Index        r122, r56, r121
+  Equal        r123, r120, r122
+  // ci.movie_id == mk.movie_id &&
+  Const        r124, "movie_id"
+  Index        r125, r26, r124
+  Const        r126, "movie_id"
+  Index        r127, r62, r126
+  Equal        r128, r125, r127
+  // mi.movie_id == mi_idx.movie_id &&
+  Const        r129, "movie_id"
+  Index        r130, r50, r129
+  Const        r131, "movie_id"
+  Index        r132, r56, r131
+  Equal        r133, r130, r132
+  // mi.movie_id == mk.movie_id &&
+  Const        r134, "movie_id"
+  Index        r135, r50, r134
+  Const        r136, "movie_id"
+  Index        r137, r62, r136
+  Equal        r138, r135, r137
+  // mi_idx.movie_id == mk.movie_id &&
+  Const        r139, "movie_id"
+  Index        r140, r56, r139
+  Const        r141, "movie_id"
+  Index        r142, r62, r141
+  Equal        r143, r140, r142
+  // n.id == ci.person_id &&
+  Const        r144, "id"
+  Index        r145, r68, r144
+  Const        r146, "person_id"
+  Index        r147, r26, r146
+  Equal        r148, r145, r147
+  // it1.id == mi.info_type_id &&
+  Const        r149, "id"
+  Index        r150, r32, r149
+  Const        r151, "info_type_id"
+  Index        r152, r50, r151
+  Equal        r153, r150, r152
+  // it2.id == mi_idx.info_type_id &&
+  Const        r154, "id"
+  Index        r155, r38, r154
+  Const        r156, "info_type_id"
+  Index        r157, r56, r156
+  Equal        r158, r155, r157
+  // k.id == mk.keyword_id
+  Const        r159, "id"
+  Index        r160, r44, r159
+  Const        r161, "keyword_id"
+  Index        r162, r62, r161
+  Equal        r163, r160, r162
+  // (ci.note in allowed_notes) &&
+  Move         r164, r77
+  JumpIfFalse  r164, L9
+  Move         r164, r81
+L9:
+  // it1.info == "genres" &&
+  Move         r165, r164
+  JumpIfFalse  r165, L10
+  Move         r165, r85
+L10:
+  // it2.info == "votes" &&
+  Move         r166, r165
+  JumpIfFalse  r166, L11
+  // (k.keyword in allowed_keywords) &&
+  Const        r167, "keyword"
+  Index        r168, r44, r167
+  In           r169, r168, r19
+  // it2.info == "votes" &&
+  Move         r166, r169
+L11:
+  // (k.keyword in allowed_keywords) &&
+  Move         r170, r166
+  JumpIfFalse  r170, L12
+  Move         r170, r89
+L12:
+  // mi.info == "Horror" &&
+  Move         r171, r170
+  JumpIfFalse  r171, L13
+  Move         r171, r93
+L13:
+  // n.gender == "m" &&
+  Move         r172, r171
+  JumpIfFalse  r172, L14
+  Move         r172, r98
+L14:
+  // t.id == mi.movie_id &&
+  Move         r173, r172
+  JumpIfFalse  r173, L15
+  Move         r173, r103
+L15:
+  // t.id == mi_idx.movie_id &&
+  Move         r174, r173
+  JumpIfFalse  r174, L16
+  Move         r174, r108
+L16:
+  // t.id == ci.movie_id &&
+  Move         r175, r174
+  JumpIfFalse  r175, L17
+  Move         r175, r113
+L17:
+  // t.id == mk.movie_id &&
+  Move         r176, r175
+  JumpIfFalse  r176, L18
+  Move         r176, r118
+L18:
+  // ci.movie_id == mi.movie_id &&
+  Move         r177, r176
+  JumpIfFalse  r177, L19
+  Move         r177, r123
+L19:
+  // ci.movie_id == mi_idx.movie_id &&
+  Move         r178, r177
+  JumpIfFalse  r178, L20
+  Move         r178, r128
+L20:
+  // ci.movie_id == mk.movie_id &&
+  Move         r179, r178
+  JumpIfFalse  r179, L21
+  Move         r179, r133
+L21:
+  // mi.movie_id == mi_idx.movie_id &&
+  Move         r180, r179
+  JumpIfFalse  r180, L22
+  Move         r180, r138
+L22:
+  // mi.movie_id == mk.movie_id &&
+  Move         r181, r180
+  JumpIfFalse  r181, L23
+  Move         r181, r143
+L23:
+  // mi_idx.movie_id == mk.movie_id &&
+  Move         r182, r181
+  JumpIfFalse  r182, L24
+  Move         r182, r148
+L24:
+  // n.id == ci.person_id &&
+  Move         r183, r182
+  JumpIfFalse  r183, L25
+  Move         r183, r153
+L25:
+  // it1.id == mi.info_type_id &&
+  Move         r184, r183
+  JumpIfFalse  r184, L26
+  Move         r184, r158
+L26:
+  // it2.id == mi_idx.info_type_id &&
+  Move         r185, r184
+  JumpIfFalse  r185, L27
+  Move         r185, r163
+L27:
+  // where (
+  JumpIfFalse  r185, L28
+  // budget: mi.info,
+  Const        r186, "budget"
+  Const        r187, "info"
+  Index        r188, r50, r187
+  // votes: mi_idx.info,
+  Const        r189, "votes"
+  Const        r190, "info"
+  Index        r191, r56, r190
+  // writer: n.name,
+  Const        r192, "writer"
+  Const        r193, "name"
+  Index        r194, r68, r193
+  // title: t.title
+  Const        r195, "title"
+  Const        r196, "title"
+  Index        r197, r74, r196
+  // budget: mi.info,
+  Move         r198, r186
+  Move         r199, r188
+  // votes: mi_idx.info,
+  Move         r200, r189
+  Move         r201, r191
+  // writer: n.name,
+  Move         r202, r192
+  Move         r203, r194
+  // title: t.title
+  Move         r204, r195
+  Move         r205, r197
+  // select {
+  MakeMap      r206, 4, r198
+  // from ci in cast_info
+  Append       r207, r20, r206
+  Move         r20, r207
+L28:
+  // from t in title
+  Const        r208, 1
+  Add          r209, r71, r208
+  Move         r71, r209
+  Jump         L29
+L8:
+  // from n in name
+  Const        r210, 1
+  Add          r211, r65, r210
+  Move         r65, r211
+  Jump         L30
+L7:
+  // from mk in movie_keyword
+  Const        r212, 1
+  Add          r213, r59, r212
+  Move         r59, r213
+  Jump         L31
+L6:
+  // from mi_idx in movie_info_idx
+  Const        r214, 1
+  Add          r215, r53, r214
+  Move         r53, r215
+  Jump         L32
+L5:
+  // from mi in movie_info
+  Const        r216, 1
+  Add          r217, r47, r216
+  Move         r47, r217
+  Jump         L33
+L4:
+  // from k in keyword
+  Const        r218, 1
+  Add          r219, r41, r218
+  Move         r41, r219
+  Jump         L34
+L3:
+  // from it2 in info_type
+  Const        r220, 1
+  Add          r221, r35, r220
+  Move         r35, r221
+  Jump         L35
+L2:
+  // from it1 in info_type
+  Const        r222, 1
+  Add          r223, r29, r222
+  Move         r29, r223
+  Jump         L36
+L1:
+  // from ci in cast_info
+  Const        r224, 1
+  Add          r225, r23, r224
+  Move         r23, r225
+  Jump         L37
+L0:
+  // let matches =
+  Move         r226, r20
+  // movie_budget: min(from x in matches select x.budget),
+  Const        r227, "movie_budget"
+  Const        r228, []
+  IterPrep     r229, r226
+  Len          r230, r229
+  Const        r231, 0
+L39:
+  Less         r232, r231, r230
+  JumpIfFalse  r232, L38
+  Index        r233, r229, r231
+  Move         r234, r233
+  Const        r235, "budget"
+  Index        r236, r234, r235
+  Append       r237, r228, r236
+  Move         r228, r237
+  Const        r238, 1
+  Add          r239, r231, r238
+  Move         r231, r239
+  Jump         L39
+L38:
+  Min          r240, r228
+  // movie_votes: min(from x in matches select x.votes),
+  Const        r241, "movie_votes"
+  Const        r242, []
+  IterPrep     r243, r226
+  Len          r244, r243
+  Const        r245, 0
+L41:
+  Less         r246, r245, r244
+  JumpIfFalse  r246, L40
+  Index        r247, r243, r245
+  Move         r234, r247
+  Const        r248, "votes"
+  Index        r249, r234, r248
+  Append       r250, r242, r249
+  Move         r242, r250
+  Const        r251, 1
+  Add          r252, r245, r251
+  Move         r245, r252
+  Jump         L41
+L40:
+  Min          r253, r242
+  // male_writer: min(from x in matches select x.writer),
+  Const        r254, "male_writer"
+  Const        r255, []
+  IterPrep     r256, r226
+  Len          r257, r256
+  Const        r258, 0
+L43:
+  Less         r259, r258, r257
+  JumpIfFalse  r259, L42
+  Index        r260, r256, r258
+  Move         r234, r260
+  Const        r261, "writer"
+  Index        r262, r234, r261
+  Append       r263, r255, r262
+  Move         r255, r263
+  Const        r264, 1
+  Add          r265, r258, r264
+  Move         r258, r265
+  Jump         L43
+L42:
+  Min          r266, r255
+  // violent_movie_title: min(from x in matches select x.title)
+  Const        r267, "violent_movie_title"
+  Const        r268, []
+  IterPrep     r269, r226
+  Len          r270, r269
+  Const        r271, 0
+L45:
+  Less         r272, r271, r270
+  JumpIfFalse  r272, L44
+  Index        r273, r269, r271
+  Move         r234, r273
+  Const        r274, "title"
+  Index        r275, r234, r274
+  Append       r276, r268, r275
+  Move         r268, r276
+  Const        r277, 1
+  Add          r278, r271, r277
+  Move         r271, r278
+  Jump         L45
+L44:
+  Min          r279, r268
+  // movie_budget: min(from x in matches select x.budget),
+  Move         r280, r227
+  Move         r281, r240
+  // movie_votes: min(from x in matches select x.votes),
+  Move         r282, r241
+  Move         r283, r253
+  // male_writer: min(from x in matches select x.writer),
+  Move         r284, r254
+  Move         r285, r266
+  // violent_movie_title: min(from x in matches select x.title)
+  Move         r286, r267
+  Move         r287, r279
+  // {
+  MakeMap      r288, 4, r280
+  Move         r289, r288
+  // let result = [
+  MakeList     r290, 1, r289
+  Move         r291, r290
+  // json(result)
+  JSON         r291
+  // expect result == [
+  Const        r292, [{"male_writer": "Mike", "movie_budget": "Horror", "movie_votes": 100, "violent_movie_title": "Scary Movie"}]
+  Equal        r293, r291, r292
+  Expect       r293
+  Return       r0

--- a/tests/dataset/job/out/q26.ir.out
+++ b/tests/dataset/job/out/q26.ir.out
@@ -1,0 +1,527 @@
+func main (regs=314)
+  // let complete_cast = [
+  Const        r0, [{"movie_id": 1, "status_id": 2, "subject_id": 1}, {"movie_id": 2, "status_id": 2, "subject_id": 1}]
+  Move         r1, r0
+  // let comp_cast_type = [
+  Const        r2, [{"id": 1, "kind": "cast"}, {"id": 2, "kind": "complete"}]
+  Move         r3, r2
+  // let char_name = [
+  Const        r4, [{"id": 1, "name": "Spider-Man"}, {"id": 2, "name": "Villain"}]
+  Move         r5, r4
+  // let cast_info = [
+  Const        r6, [{"movie_id": 1, "person_id": 1, "person_role_id": 1}, {"movie_id": 2, "person_id": 2, "person_role_id": 2}]
+  Move         r7, r6
+  // let info_type = [
+  Const        r8, [{"id": 1, "info": "rating"}]
+  Move         r9, r8
+  // let keyword = [
+  Const        r10, [{"id": 1, "keyword": "superhero"}, {"id": 2, "keyword": "comedy"}]
+  Move         r11, r10
+  // let kind_type = [
+  Const        r12, [{"id": 1, "kind": "movie"}]
+  Move         r13, r12
+  // let movie_info_idx = [
+  Const        r14, [{"info": 8.5, "info_type_id": 1, "movie_id": 1}, {"info": 6.5, "info_type_id": 1, "movie_id": 2}]
+  Move         r15, r14
+  // let movie_keyword = [
+  Const        r16, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}]
+  Move         r17, r16
+  // let name = [
+  Const        r18, [{"id": 1, "name": "Actor One"}, {"id": 2, "name": "Actor Two"}]
+  Move         r19, r18
+  // let title = [
+  Const        r20, [{"id": 1, "kind_id": 1, "production_year": 2005, "title": "Hero Movie"}, {"id": 2, "kind_id": 1, "production_year": 1999, "title": "Old Film"}]
+  Move         r21, r20
+  // let allowed_keywords = [
+  Const        r22, ["superhero", "marvel-comics", "based-on-comic", "tv-special", "fight", "violence", "magnet", "web", "claw", "laser"]
+  Move         r23, r22
+  // from cc in complete_cast
+  Const        r24, []
+  IterPrep     r25, r1
+  Len          r26, r25
+  Const        r27, 0
+L33:
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L0
+  Index        r29, r25, r27
+  Move         r30, r29
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  IterPrep     r31, r3
+  Len          r32, r31
+  Const        r33, 0
+L32:
+  Less         r34, r33, r32
+  JumpIfFalse  r34, L1
+  Index        r35, r31, r33
+  Move         r36, r35
+  Const        r37, "id"
+  Index        r38, r36, r37
+  Const        r39, "subject_id"
+  Index        r40, r30, r39
+  Equal        r41, r38, r40
+  JumpIfFalse  r41, L2
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  IterPrep     r42, r3
+  Len          r43, r42
+  Const        r44, 0
+L31:
+  Less         r45, r44, r43
+  JumpIfFalse  r45, L2
+  Index        r46, r42, r44
+  Move         r47, r46
+  Const        r48, "id"
+  Index        r49, r47, r48
+  Const        r50, "status_id"
+  Index        r51, r30, r50
+  Equal        r52, r49, r51
+  JumpIfFalse  r52, L3
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  IterPrep     r53, r7
+  Len          r54, r53
+  Const        r55, 0
+L30:
+  Less         r56, r55, r54
+  JumpIfFalse  r56, L3
+  Index        r57, r53, r55
+  Move         r58, r57
+  Const        r59, "movie_id"
+  Index        r60, r58, r59
+  Const        r61, "movie_id"
+  Index        r62, r30, r61
+  Equal        r63, r60, r62
+  JumpIfFalse  r63, L4
+  // join chn in char_name on chn.id == ci.person_role_id
+  IterPrep     r64, r5
+  Len          r65, r64
+  Const        r66, 0
+L29:
+  Less         r67, r66, r65
+  JumpIfFalse  r67, L4
+  Index        r68, r64, r66
+  Move         r69, r68
+  Const        r70, "id"
+  Index        r71, r69, r70
+  Const        r72, "person_role_id"
+  Index        r73, r58, r72
+  Equal        r74, r71, r73
+  JumpIfFalse  r74, L5
+  // join n in name on n.id == ci.person_id
+  IterPrep     r75, r19
+  Len          r76, r75
+  Const        r77, 0
+L28:
+  Less         r78, r77, r76
+  JumpIfFalse  r78, L5
+  Index        r79, r75, r77
+  Move         r80, r79
+  Const        r81, "id"
+  Index        r82, r80, r81
+  Const        r83, "person_id"
+  Index        r84, r58, r83
+  Equal        r85, r82, r84
+  JumpIfFalse  r85, L6
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r86, r21
+  Len          r87, r86
+  Const        r88, 0
+L27:
+  Less         r89, r88, r87
+  JumpIfFalse  r89, L6
+  Index        r90, r86, r88
+  Move         r91, r90
+  Const        r92, "id"
+  Index        r93, r91, r92
+  Const        r94, "movie_id"
+  Index        r95, r58, r94
+  Equal        r96, r93, r95
+  JumpIfFalse  r96, L7
+  // join kt in kind_type on kt.id == t.kind_id
+  IterPrep     r97, r13
+  Len          r98, r97
+  Const        r99, 0
+L26:
+  Less         r100, r99, r98
+  JumpIfFalse  r100, L7
+  Index        r101, r97, r99
+  Move         r102, r101
+  Const        r103, "id"
+  Index        r104, r102, r103
+  Const        r105, "kind_id"
+  Index        r106, r91, r105
+  Equal        r107, r104, r106
+  JumpIfFalse  r107, L8
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r108, r17
+  Len          r109, r108
+  Const        r110, 0
+L25:
+  Less         r111, r110, r109
+  JumpIfFalse  r111, L8
+  Index        r112, r108, r110
+  Move         r113, r112
+  Const        r114, "movie_id"
+  Index        r115, r113, r114
+  Const        r116, "id"
+  Index        r117, r91, r116
+  Equal        r118, r115, r117
+  JumpIfFalse  r118, L9
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r119, r11
+  Len          r120, r119
+  Const        r121, 0
+L24:
+  Less         r122, r121, r120
+  JumpIfFalse  r122, L9
+  Index        r123, r119, r121
+  Move         r124, r123
+  Const        r125, "id"
+  Index        r126, r124, r125
+  Const        r127, "keyword_id"
+  Index        r128, r113, r127
+  Equal        r129, r126, r128
+  JumpIfFalse  r129, L10
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  IterPrep     r130, r15
+  Len          r131, r130
+  Const        r132, 0
+L23:
+  Less         r133, r132, r131
+  JumpIfFalse  r133, L10
+  Index        r134, r130, r132
+  Move         r135, r134
+  Const        r136, "movie_id"
+  Index        r137, r135, r136
+  Const        r138, "id"
+  Index        r139, r91, r138
+  Equal        r140, r137, r139
+  JumpIfFalse  r140, L11
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  IterPrep     r141, r9
+  Len          r142, r141
+  Const        r143, 0
+L22:
+  Less         r144, r143, r142
+  JumpIfFalse  r144, L11
+  Index        r145, r141, r143
+  Move         r146, r145
+  Const        r147, "id"
+  Index        r148, r146, r147
+  Const        r149, "info_type_id"
+  Index        r150, r135, r149
+  Equal        r151, r148, r150
+  JumpIfFalse  r151, L12
+  // where cct1.kind == "cast" &&
+  Const        r152, "kind"
+  Index        r153, r36, r152
+  // mi_idx.info > 7.0 &&
+  Const        r154, "info"
+  Index        r155, r135, r154
+  Const        r156, 7
+  LessFloat    r157, r156, r155
+  // t.production_year > 2000
+  Const        r158, "production_year"
+  Index        r159, r91, r158
+  Const        r160, 2000
+  Less         r161, r160, r159
+  // where cct1.kind == "cast" &&
+  Const        r162, "cast"
+  Equal        r163, r153, r162
+  // chn.name != null &&
+  Const        r164, "name"
+  Index        r165, r69, r164
+  Const        r166, nil
+  NotEqual     r167, r165, r166
+  // it2.info == "rating" &&
+  Const        r168, "info"
+  Index        r169, r146, r168
+  Const        r170, "rating"
+  Equal        r171, r169, r170
+  // kt.kind == "movie" &&
+  Const        r172, "kind"
+  Index        r173, r102, r172
+  Const        r174, "movie"
+  Equal        r175, r173, r174
+  // where cct1.kind == "cast" &&
+  Move         r176, r163
+  JumpIfFalse  r176, L13
+  Const        r177, "kind"
+  Index        r178, r47, r177
+  // cct2.kind.contains("complete") &&
+  Const        r179, "complete"
+  In           r180, r179, r178
+  // where cct1.kind == "cast" &&
+  Move         r176, r180
+L13:
+  // cct2.kind.contains("complete") &&
+  Move         r181, r176
+  JumpIfFalse  r181, L14
+  Move         r181, r167
+L14:
+  // chn.name != null &&
+  Move         r182, r181
+  JumpIfFalse  r182, L15
+  Const        r183, "name"
+  Index        r184, r69, r183
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Const        r185, "man"
+  In           r186, r185, r184
+  Move         r187, r186
+  JumpIfTrue   r187, L16
+  Const        r188, "name"
+  Index        r189, r69, r188
+  Const        r190, "Man"
+  In           r191, r190, r189
+  Move         r187, r191
+L16:
+  // chn.name != null &&
+  Move         r182, r187
+L15:
+  // (chn.name.contains("man") || chn.name.contains("Man")) &&
+  Move         r192, r182
+  JumpIfFalse  r192, L17
+  Move         r192, r171
+L17:
+  // it2.info == "rating" &&
+  Move         r193, r192
+  JumpIfFalse  r193, L18
+  // (k.keyword in allowed_keywords) &&
+  Const        r194, "keyword"
+  Index        r195, r124, r194
+  In           r196, r195, r23
+  // it2.info == "rating" &&
+  Move         r193, r196
+L18:
+  // (k.keyword in allowed_keywords) &&
+  Move         r197, r193
+  JumpIfFalse  r197, L19
+  Move         r197, r175
+L19:
+  // kt.kind == "movie" &&
+  Move         r198, r197
+  JumpIfFalse  r198, L20
+  Move         r198, r157
+L20:
+  // mi_idx.info > 7.0 &&
+  Move         r199, r198
+  JumpIfFalse  r199, L21
+  Move         r199, r161
+L21:
+  // where cct1.kind == "cast" &&
+  JumpIfFalse  r199, L12
+  // character: chn.name,
+  Const        r200, "character"
+  Const        r201, "name"
+  Index        r202, r69, r201
+  // rating: mi_idx.info,
+  Const        r203, "rating"
+  Const        r204, "info"
+  Index        r205, r135, r204
+  // actor: n.name,
+  Const        r206, "actor"
+  Const        r207, "name"
+  Index        r208, r80, r207
+  // movie: t.title
+  Const        r209, "movie"
+  Const        r210, "title"
+  Index        r211, r91, r210
+  // character: chn.name,
+  Move         r212, r200
+  Move         r213, r202
+  // rating: mi_idx.info,
+  Move         r214, r203
+  Move         r215, r205
+  // actor: n.name,
+  Move         r216, r206
+  Move         r217, r208
+  // movie: t.title
+  Move         r218, r209
+  Move         r219, r211
+  // select {
+  MakeMap      r220, 4, r212
+  // from cc in complete_cast
+  Append       r221, r24, r220
+  Move         r24, r221
+L12:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r222, 1
+  Add          r223, r143, r222
+  Move         r143, r223
+  Jump         L22
+L11:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r224, 1
+  Add          r225, r132, r224
+  Move         r132, r225
+  Jump         L23
+L10:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r226, 1
+  Add          r227, r121, r226
+  Move         r121, r227
+  Jump         L24
+L9:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r228, 1
+  Add          r229, r110, r228
+  Move         r110, r229
+  Jump         L25
+L8:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r230, 1
+  Add          r231, r99, r230
+  Move         r99, r231
+  Jump         L26
+L7:
+  // join t in title on t.id == ci.movie_id
+  Const        r232, 1
+  Add          r233, r88, r232
+  Move         r88, r233
+  Jump         L27
+L6:
+  // join n in name on n.id == ci.person_id
+  Const        r234, 1
+  Add          r235, r77, r234
+  Move         r77, r235
+  Jump         L28
+L5:
+  // join chn in char_name on chn.id == ci.person_role_id
+  Const        r236, 1
+  Add          r237, r66, r236
+  Move         r66, r237
+  Jump         L29
+L4:
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  Const        r238, 1
+  Add          r239, r55, r238
+  Move         r55, r239
+  Jump         L30
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r240, 1
+  Add          r241, r44, r240
+  Move         r44, r241
+  Jump         L31
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r242, 1
+  Add          r243, r33, r242
+  Move         r33, r243
+  Jump         L32
+L1:
+  // from cc in complete_cast
+  Const        r244, 1
+  Add          r245, r27, r244
+  Move         r27, r245
+  Jump         L33
+L0:
+  // let rows =
+  Move         r246, r24
+  // character_name: min(from r in rows select r.character),
+  Const        r247, "character_name"
+  Const        r248, []
+  IterPrep     r249, r246
+  Len          r250, r249
+  Const        r251, 0
+L35:
+  Less         r252, r251, r250
+  JumpIfFalse  r252, L34
+  Index        r253, r249, r251
+  Move         r254, r253
+  Const        r255, "character"
+  Index        r256, r254, r255
+  Append       r257, r248, r256
+  Move         r248, r257
+  Const        r258, 1
+  Add          r259, r251, r258
+  Move         r251, r259
+  Jump         L35
+L34:
+  Min          r260, r248
+  // rating: min(from r in rows select r.rating),
+  Const        r261, "rating"
+  Const        r262, []
+  IterPrep     r263, r246
+  Len          r264, r263
+  Const        r265, 0
+L37:
+  Less         r266, r265, r264
+  JumpIfFalse  r266, L36
+  Index        r267, r263, r265
+  Move         r254, r267
+  Const        r268, "rating"
+  Index        r269, r254, r268
+  Append       r270, r262, r269
+  Move         r262, r270
+  Const        r271, 1
+  Add          r272, r265, r271
+  Move         r265, r272
+  Jump         L37
+L36:
+  Min          r273, r262
+  // playing_actor: min(from r in rows select r.actor),
+  Const        r274, "playing_actor"
+  Const        r275, []
+  IterPrep     r276, r246
+  Len          r277, r276
+  Const        r278, 0
+L39:
+  Less         r279, r278, r277
+  JumpIfFalse  r279, L38
+  Index        r280, r276, r278
+  Move         r254, r280
+  Const        r281, "actor"
+  Index        r282, r254, r281
+  Append       r283, r275, r282
+  Move         r275, r283
+  Const        r284, 1
+  Add          r285, r278, r284
+  Move         r278, r285
+  Jump         L39
+L38:
+  Min          r286, r275
+  // complete_hero_movie: min(from r in rows select r.movie)
+  Const        r287, "complete_hero_movie"
+  Const        r288, []
+  IterPrep     r289, r246
+  Len          r290, r289
+  Const        r291, 0
+L41:
+  Less         r292, r291, r290
+  JumpIfFalse  r292, L40
+  Index        r293, r289, r291
+  Move         r254, r293
+  Const        r294, "movie"
+  Index        r295, r254, r294
+  Append       r296, r288, r295
+  Move         r288, r296
+  Const        r297, 1
+  Add          r298, r291, r297
+  Move         r291, r298
+  Jump         L41
+L40:
+  Min          r299, r288
+  // character_name: min(from r in rows select r.character),
+  Move         r300, r247
+  Move         r301, r260
+  // rating: min(from r in rows select r.rating),
+  Move         r302, r261
+  Move         r303, r273
+  // playing_actor: min(from r in rows select r.actor),
+  Move         r304, r274
+  Move         r305, r286
+  // complete_hero_movie: min(from r in rows select r.movie)
+  Move         r306, r287
+  Move         r307, r299
+  // {
+  MakeMap      r308, 4, r300
+  Move         r309, r308
+  // let result = [
+  MakeList     r310, 1, r309
+  Move         r311, r310
+  // json(result)
+  JSON         r311
+  // expect result == [
+  Const        r312, [{"character_name": "Spider-Man", "complete_hero_movie": "Hero Movie", "playing_actor": "Actor One", "rating": 8.5}]
+  Equal        r313, r311, r312
+  Expect       r313
+  Return       r0

--- a/tests/dataset/job/out/q27.ir.out
+++ b/tests/dataset/job/out/q27.ir.out
@@ -1,0 +1,653 @@
+func main (regs=381)
+  // let comp_cast_type = [
+  Const        r0, [{"id": 1, "kind": "cast"}, {"id": 2, "kind": "crew"}, {"id": 3, "kind": "complete"}]
+  Move         r1, r0
+  // let complete_cast = [
+  Const        r2, [{"movie_id": 1, "status_id": 3, "subject_id": 1}, {"movie_id": 2, "status_id": 3, "subject_id": 2}]
+  Move         r3, r2
+  // let company_name = [
+  Const        r4, [{"country_code": "[se]", "id": 1, "name": "Best Film"}, {"country_code": "[pl]", "id": 2, "name": "Polish Film"}]
+  Move         r5, r4
+  // let company_type = [
+  Const        r6, [{"id": 1, "kind": "production companies"}, {"id": 2, "kind": "other"}]
+  Move         r7, r6
+  // let keyword = [
+  Const        r8, [{"id": 1, "keyword": "sequel"}, {"id": 2, "keyword": "remake"}]
+  Move         r9, r8
+  // let link_type = [
+  Const        r10, [{"id": 1, "link": "follows"}, {"id": 2, "link": "related"}]
+  Move         r11, r10
+  // let movie_companies = [
+  Const        r12, [{"company_id": 1, "company_type_id": 1, "movie_id": 1, "note": nil}, {"company_id": 2, "company_type_id": 1, "movie_id": 2, "note": "extra"}]
+  Move         r13, r12
+  // let movie_info = [
+  Const        r14, [{"info": "Sweden", "movie_id": 1}, {"info": "USA", "movie_id": 2}]
+  Move         r15, r14
+  // let movie_keyword = [
+  Const        r16, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}]
+  Move         r17, r16
+  // let movie_link = [
+  Const        r18, [{"link_type_id": 1, "movie_id": 1}, {"link_type_id": 2, "movie_id": 2}]
+  Move         r19, r18
+  // let title = [
+  Const        r20, [{"id": 1, "production_year": 1980, "title": "Western Sequel"}, {"id": 2, "production_year": 1999, "title": "Another Movie"}]
+  Move         r21, r20
+  // from cc in complete_cast
+  Const        r22, []
+  IterPrep     r23, r3
+  Len          r24, r23
+  Const        r25, 0
+L49:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L0
+  Index        r27, r23, r25
+  Move         r28, r27
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  IterPrep     r29, r1
+  Len          r30, r29
+  Const        r31, 0
+L48:
+  Less         r32, r31, r30
+  JumpIfFalse  r32, L1
+  Index        r33, r29, r31
+  Move         r34, r33
+  Const        r35, "id"
+  Index        r36, r34, r35
+  Const        r37, "subject_id"
+  Index        r38, r28, r37
+  Equal        r39, r36, r38
+  JumpIfFalse  r39, L2
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  IterPrep     r40, r1
+  Len          r41, r40
+  Const        r42, 0
+L47:
+  Less         r43, r42, r41
+  JumpIfFalse  r43, L2
+  Index        r44, r40, r42
+  Move         r45, r44
+  Const        r46, "id"
+  Index        r47, r45, r46
+  Const        r48, "status_id"
+  Index        r49, r28, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L3
+  // join t in title on t.id == cc.movie_id
+  IterPrep     r51, r21
+  Len          r52, r51
+  Const        r53, 0
+L46:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L3
+  Index        r55, r51, r53
+  Move         r56, r55
+  Const        r57, "id"
+  Index        r58, r56, r57
+  Const        r59, "movie_id"
+  Index        r60, r28, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L4
+  // join ml in movie_link on ml.movie_id == t.id
+  IterPrep     r62, r19
+  Len          r63, r62
+  Const        r64, 0
+L45:
+  Less         r65, r64, r63
+  JumpIfFalse  r65, L4
+  Index        r66, r62, r64
+  Move         r67, r66
+  Const        r68, "movie_id"
+  Index        r69, r67, r68
+  Const        r70, "id"
+  Index        r71, r56, r70
+  Equal        r72, r69, r71
+  JumpIfFalse  r72, L5
+  // join lt in link_type on lt.id == ml.link_type_id
+  IterPrep     r73, r11
+  Len          r74, r73
+  Const        r75, 0
+L44:
+  Less         r76, r75, r74
+  JumpIfFalse  r76, L5
+  Index        r77, r73, r75
+  Move         r78, r77
+  Const        r79, "id"
+  Index        r80, r78, r79
+  Const        r81, "link_type_id"
+  Index        r82, r67, r81
+  Equal        r83, r80, r82
+  JumpIfFalse  r83, L6
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r84, r17
+  Len          r85, r84
+  Const        r86, 0
+L43:
+  Less         r87, r86, r85
+  JumpIfFalse  r87, L6
+  Index        r88, r84, r86
+  Move         r89, r88
+  Const        r90, "movie_id"
+  Index        r91, r89, r90
+  Const        r92, "id"
+  Index        r93, r56, r92
+  Equal        r94, r91, r93
+  JumpIfFalse  r94, L7
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r95, r9
+  Len          r96, r95
+  Const        r97, 0
+L42:
+  Less         r98, r97, r96
+  JumpIfFalse  r98, L7
+  Index        r99, r95, r97
+  Move         r100, r99
+  Const        r101, "id"
+  Index        r102, r100, r101
+  Const        r103, "keyword_id"
+  Index        r104, r89, r103
+  Equal        r105, r102, r104
+  JumpIfFalse  r105, L8
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r106, r13
+  Len          r107, r106
+  Const        r108, 0
+L41:
+  Less         r109, r108, r107
+  JumpIfFalse  r109, L8
+  Index        r110, r106, r108
+  Move         r111, r110
+  Const        r112, "movie_id"
+  Index        r113, r111, r112
+  Const        r114, "id"
+  Index        r115, r56, r114
+  Equal        r116, r113, r115
+  JumpIfFalse  r116, L9
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r117, r7
+  Len          r118, r117
+  Const        r119, 0
+L40:
+  Less         r120, r119, r118
+  JumpIfFalse  r120, L9
+  Index        r121, r117, r119
+  Move         r122, r121
+  Const        r123, "id"
+  Index        r124, r122, r123
+  Const        r125, "company_type_id"
+  Index        r126, r111, r125
+  Equal        r127, r124, r126
+  JumpIfFalse  r127, L10
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r128, r5
+  Len          r129, r128
+  Const        r130, 0
+L39:
+  Less         r131, r130, r129
+  JumpIfFalse  r131, L10
+  Index        r132, r128, r130
+  Move         r133, r132
+  Const        r134, "id"
+  Index        r135, r133, r134
+  Const        r136, "company_id"
+  Index        r137, r111, r136
+  Equal        r138, r135, r137
+  JumpIfFalse  r138, L11
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r139, r15
+  Len          r140, r139
+  Const        r141, 0
+L38:
+  Less         r142, r141, r140
+  JumpIfFalse  r142, L11
+  Index        r143, r139, r141
+  Move         r144, r143
+  Const        r145, "movie_id"
+  Index        r146, r144, r145
+  Const        r147, "id"
+  Index        r148, r56, r147
+  Equal        r149, r146, r148
+  JumpIfFalse  r149, L12
+  // (cct1.kind == "cast" || cct1.kind == "crew") &&
+  Const        r150, "kind"
+  Index        r151, r34, r150
+  Const        r152, "cast"
+  Equal        r153, r151, r152
+  Const        r154, "kind"
+  Index        r155, r34, r154
+  Const        r156, "crew"
+  Equal        r157, r155, r156
+  Move         r158, r153
+  JumpIfTrue   r158, L13
+  Move         r158, r157
+L13:
+  // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Const        r159, "production_year"
+  Index        r160, r56, r159
+  Const        r161, 1950
+  LessEq       r162, r161, r160
+  Const        r163, "production_year"
+  Index        r164, r56, r163
+  Const        r165, 2000
+  LessEq       r166, r164, r165
+  // cct2.kind == "complete" &&
+  Const        r167, "kind"
+  Index        r168, r45, r167
+  Const        r169, "complete"
+  Equal        r170, r168, r169
+  // cn.country_code != "[pl]" &&
+  Const        r171, "country_code"
+  Index        r172, r133, r171
+  Const        r173, "[pl]"
+  NotEqual     r174, r172, r173
+  // ct.kind == "production companies" &&
+  Const        r175, "kind"
+  Index        r176, r122, r175
+  Const        r177, "production companies"
+  Equal        r178, r176, r177
+  // k.keyword == "sequel" &&
+  Const        r179, "keyword"
+  Index        r180, r100, r179
+  Const        r181, "sequel"
+  Equal        r182, r180, r181
+  // mc.note == null &&
+  Const        r183, "note"
+  Index        r184, r111, r183
+  Const        r185, nil
+  Equal        r186, r184, r185
+  // ml.movie_id == mk.movie_id &&
+  Const        r187, "movie_id"
+  Index        r188, r67, r187
+  Const        r189, "movie_id"
+  Index        r190, r89, r189
+  Equal        r191, r188, r190
+  // ml.movie_id == mc.movie_id &&
+  Const        r192, "movie_id"
+  Index        r193, r67, r192
+  Const        r194, "movie_id"
+  Index        r195, r111, r194
+  Equal        r196, r193, r195
+  // mk.movie_id == mc.movie_id &&
+  Const        r197, "movie_id"
+  Index        r198, r89, r197
+  Const        r199, "movie_id"
+  Index        r200, r111, r199
+  Equal        r201, r198, r200
+  // ml.movie_id == mi.movie_id &&
+  Const        r202, "movie_id"
+  Index        r203, r67, r202
+  Const        r204, "movie_id"
+  Index        r205, r144, r204
+  Equal        r206, r203, r205
+  // mk.movie_id == mi.movie_id &&
+  Const        r207, "movie_id"
+  Index        r208, r89, r207
+  Const        r209, "movie_id"
+  Index        r210, r144, r209
+  Equal        r211, r208, r210
+  // mc.movie_id == mi.movie_id &&
+  Const        r212, "movie_id"
+  Index        r213, r111, r212
+  Const        r214, "movie_id"
+  Index        r215, r144, r214
+  Equal        r216, r213, r215
+  // ml.movie_id == cc.movie_id &&
+  Const        r217, "movie_id"
+  Index        r218, r67, r217
+  Const        r219, "movie_id"
+  Index        r220, r28, r219
+  Equal        r221, r218, r220
+  // mk.movie_id == cc.movie_id &&
+  Const        r222, "movie_id"
+  Index        r223, r89, r222
+  Const        r224, "movie_id"
+  Index        r225, r28, r224
+  Equal        r226, r223, r225
+  // mc.movie_id == cc.movie_id &&
+  Const        r227, "movie_id"
+  Index        r228, r111, r227
+  Const        r229, "movie_id"
+  Index        r230, r28, r229
+  Equal        r231, r228, r230
+  // mi.movie_id == cc.movie_id
+  Const        r232, "movie_id"
+  Index        r233, r144, r232
+  Const        r234, "movie_id"
+  Index        r235, r28, r234
+  Equal        r236, r233, r235
+  // (cct1.kind == "cast" || cct1.kind == "crew") &&
+  Move         r237, r158
+  JumpIfFalse  r237, L14
+  Move         r237, r170
+L14:
+  // cct2.kind == "complete" &&
+  Move         r238, r237
+  JumpIfFalse  r238, L15
+  Move         r238, r174
+L15:
+  // cn.country_code != "[pl]" &&
+  Move         r239, r238
+  JumpIfFalse  r239, L16
+  Const        r240, "name"
+  Index        r241, r133, r240
+  // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+  Const        r242, "Film"
+  In           r243, r242, r241
+  Move         r244, r243
+  JumpIfTrue   r244, L17
+  Const        r245, "name"
+  Index        r246, r133, r245
+  Const        r247, "Warner"
+  In           r248, r247, r246
+  Move         r244, r248
+L17:
+  // cn.country_code != "[pl]" &&
+  Move         r239, r244
+L16:
+  // (cn.name.contains("Film") || cn.name.contains("Warner")) &&
+  Move         r249, r239
+  JumpIfFalse  r249, L18
+  Move         r249, r178
+L18:
+  // ct.kind == "production companies" &&
+  Move         r250, r249
+  JumpIfFalse  r250, L19
+  Move         r250, r182
+L19:
+  // k.keyword == "sequel" &&
+  Move         r251, r250
+  JumpIfFalse  r251, L20
+  Const        r252, "link"
+  Index        r253, r78, r252
+  // lt.link.contains("follow") &&
+  Const        r254, "follow"
+  In           r255, r254, r253
+  // k.keyword == "sequel" &&
+  Move         r251, r255
+L20:
+  // lt.link.contains("follow") &&
+  Move         r256, r251
+  JumpIfFalse  r256, L21
+  Move         r256, r186
+L21:
+  // mc.note == null &&
+  Move         r257, r256
+  JumpIfFalse  r257, L22
+  // (mi.info == "Sweden" || mi.info == "Germany" ||
+  Const        r258, "info"
+  Index        r259, r144, r258
+  Const        r260, "Sweden"
+  Equal        r261, r259, r260
+  Const        r262, "info"
+  Index        r263, r144, r262
+  Const        r264, "Germany"
+  Equal        r265, r263, r264
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Const        r266, "info"
+  Index        r267, r144, r266
+  Const        r268, "Swedish"
+  Equal        r269, r267, r268
+  Const        r270, "info"
+  Index        r271, r144, r270
+  Const        r272, "German"
+  Equal        r273, r271, r272
+  // (mi.info == "Sweden" || mi.info == "Germany" ||
+  Move         r274, r261
+  JumpIfTrue   r274, L23
+  Move         r274, r265
+L23:
+  Move         r275, r274
+  JumpIfTrue   r275, L24
+  Move         r275, r269
+L24:
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Move         r276, r275
+  JumpIfTrue   r276, L25
+  Move         r276, r273
+L25:
+  // mc.note == null &&
+  Move         r257, r276
+L22:
+  // mi.info == "Swedish" || mi.info == "German") &&
+  Move         r277, r257
+  JumpIfFalse  r277, L26
+  Move         r277, r162
+L26:
+  // t.production_year >= 1950 && t.production_year <= 2000 &&
+  Move         r278, r277
+  JumpIfFalse  r278, L27
+  Move         r278, r166
+L27:
+  Move         r279, r278
+  JumpIfFalse  r279, L28
+  Move         r279, r191
+L28:
+  // ml.movie_id == mk.movie_id &&
+  Move         r280, r279
+  JumpIfFalse  r280, L29
+  Move         r280, r196
+L29:
+  // ml.movie_id == mc.movie_id &&
+  Move         r281, r280
+  JumpIfFalse  r281, L30
+  Move         r281, r201
+L30:
+  // mk.movie_id == mc.movie_id &&
+  Move         r282, r281
+  JumpIfFalse  r282, L31
+  Move         r282, r206
+L31:
+  // ml.movie_id == mi.movie_id &&
+  Move         r283, r282
+  JumpIfFalse  r283, L32
+  Move         r283, r211
+L32:
+  // mk.movie_id == mi.movie_id &&
+  Move         r284, r283
+  JumpIfFalse  r284, L33
+  Move         r284, r216
+L33:
+  // mc.movie_id == mi.movie_id &&
+  Move         r285, r284
+  JumpIfFalse  r285, L34
+  Move         r285, r221
+L34:
+  // ml.movie_id == cc.movie_id &&
+  Move         r286, r285
+  JumpIfFalse  r286, L35
+  Move         r286, r226
+L35:
+  // mk.movie_id == cc.movie_id &&
+  Move         r287, r286
+  JumpIfFalse  r287, L36
+  Move         r287, r231
+L36:
+  // mc.movie_id == cc.movie_id &&
+  Move         r288, r287
+  JumpIfFalse  r288, L37
+  Move         r288, r236
+L37:
+  // where (
+  JumpIfFalse  r288, L12
+  // company: cn.name,
+  Const        r289, "company"
+  Const        r290, "name"
+  Index        r291, r133, r290
+  // link: lt.link,
+  Const        r292, "link"
+  Const        r293, "link"
+  Index        r294, r78, r293
+  // title: t.title
+  Const        r295, "title"
+  Const        r296, "title"
+  Index        r297, r56, r296
+  // company: cn.name,
+  Move         r298, r289
+  Move         r299, r291
+  // link: lt.link,
+  Move         r300, r292
+  Move         r301, r294
+  // title: t.title
+  Move         r302, r295
+  Move         r303, r297
+  // select {
+  MakeMap      r304, 3, r298
+  // from cc in complete_cast
+  Append       r305, r22, r304
+  Move         r22, r305
+L12:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r306, 1
+  Add          r307, r141, r306
+  Move         r141, r307
+  Jump         L38
+L11:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r308, 1
+  Add          r309, r130, r308
+  Move         r130, r309
+  Jump         L39
+L10:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r310, 1
+  Add          r311, r119, r310
+  Move         r119, r311
+  Jump         L40
+L9:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r312, 1
+  Add          r313, r108, r312
+  Move         r108, r313
+  Jump         L41
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r314, 1
+  Add          r315, r97, r314
+  Move         r97, r315
+  Jump         L42
+L7:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r316, 1
+  Add          r317, r86, r316
+  Move         r86, r317
+  Jump         L43
+L6:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r318, 1
+  Add          r319, r75, r318
+  Move         r75, r319
+  Jump         L44
+L5:
+  // join ml in movie_link on ml.movie_id == t.id
+  Const        r320, 1
+  Add          r321, r64, r320
+  Move         r64, r321
+  Jump         L45
+L4:
+  // join t in title on t.id == cc.movie_id
+  Const        r322, 1
+  Add          r323, r53, r322
+  Move         r53, r323
+  Jump         L46
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r324, 1
+  Add          r325, r42, r324
+  Move         r42, r325
+  Jump         L47
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r326, 1
+  Add          r327, r31, r326
+  Move         r31, r327
+  Jump         L48
+L1:
+  // from cc in complete_cast
+  Const        r328, 1
+  Add          r329, r25, r328
+  Move         r25, r329
+  Jump         L49
+L0:
+  // let matches =
+  Move         r330, r22
+  // producing_company: min(from x in matches select x.company),
+  Const        r331, "producing_company"
+  Const        r332, []
+  IterPrep     r333, r330
+  Len          r334, r333
+  Const        r335, 0
+L51:
+  Less         r336, r335, r334
+  JumpIfFalse  r336, L50
+  Index        r337, r333, r335
+  Move         r338, r337
+  Const        r339, "company"
+  Index        r340, r338, r339
+  Append       r341, r332, r340
+  Move         r332, r341
+  Const        r342, 1
+  Add          r343, r335, r342
+  Move         r335, r343
+  Jump         L51
+L50:
+  Min          r344, r332
+  // link_type: min(from x in matches select x.link),
+  Const        r345, "link_type"
+  Const        r346, []
+  IterPrep     r347, r330
+  Len          r348, r347
+  Const        r349, 0
+L53:
+  Less         r350, r349, r348
+  JumpIfFalse  r350, L52
+  Index        r351, r347, r349
+  Move         r338, r351
+  Const        r352, "link"
+  Index        r353, r338, r352
+  Append       r354, r346, r353
+  Move         r346, r354
+  Const        r355, 1
+  Add          r356, r349, r355
+  Move         r349, r356
+  Jump         L53
+L52:
+  Min          r357, r346
+  // complete_western_sequel: min(from x in matches select x.title)
+  Const        r358, "complete_western_sequel"
+  Const        r359, []
+  IterPrep     r360, r330
+  Len          r361, r360
+  Const        r362, 0
+L55:
+  Less         r363, r362, r361
+  JumpIfFalse  r363, L54
+  Index        r364, r360, r362
+  Move         r338, r364
+  Const        r365, "title"
+  Index        r366, r338, r365
+  Append       r367, r359, r366
+  Move         r359, r367
+  Const        r368, 1
+  Add          r369, r362, r368
+  Move         r362, r369
+  Jump         L55
+L54:
+  Min          r370, r359
+  // producing_company: min(from x in matches select x.company),
+  Move         r371, r331
+  Move         r372, r344
+  // link_type: min(from x in matches select x.link),
+  Move         r373, r345
+  Move         r374, r357
+  // complete_western_sequel: min(from x in matches select x.title)
+  Move         r375, r358
+  Move         r376, r370
+  // let result = {
+  MakeMap      r377, 3, r371
+  Move         r378, r377
+  // json(result)
+  JSON         r378
+  // expect result == {
+  Const        r379, {"complete_western_sequel": "Western Sequel", "link_type": "follows", "producing_company": "Best Film"}
+  Equal        r380, r378, r379
+  Expect       r380
+  Return       r0

--- a/tests/dataset/job/out/q28.ir.out
+++ b/tests/dataset/job/out/q28.ir.out
@@ -1,0 +1,559 @@
+func main (regs=333)
+  // let comp_cast_type = [
+  Const        r0, [{"id": 1, "kind": "crew"}, {"id": 2, "kind": "complete+verified"}, {"id": 3, "kind": "partial"}]
+  Move         r1, r0
+  // let complete_cast = [
+  Const        r2, [{"movie_id": 1, "status_id": 3, "subject_id": 1}, {"movie_id": 2, "status_id": 2, "subject_id": 1}]
+  Move         r3, r2
+  // let company_name = [
+  Const        r4, [{"country_code": "[gb]", "id": 1, "name": "Euro Films Ltd."}, {"country_code": "[us]", "id": 2, "name": "US Studios"}]
+  Move         r5, r4
+  // let company_type = [
+  Const        r6, [{"id": 1}, {"id": 2}]
+  Move         r7, r6
+  // let movie_companies = [
+  Const        r8, [{"company_id": 1, "company_type_id": 1, "movie_id": 1, "note": "production (2005) (UK)"}, {"company_id": 2, "company_type_id": 1, "movie_id": 2, "note": "production (USA)"}]
+  Move         r9, r8
+  // let info_type = [
+  Const        r10, [{"id": 1, "info": "countries"}, {"id": 2, "info": "rating"}]
+  Move         r11, r10
+  // let keyword = [
+  Const        r12, [{"id": 1, "keyword": "blood"}, {"id": 2, "keyword": "romance"}]
+  Move         r13, r12
+  // let kind_type = [
+  Const        r14, [{"id": 1, "kind": "movie"}, {"id": 2, "kind": "episode"}]
+  Move         r15, r14
+  // let movie_info = [
+  Const        r16, [{"info": "Germany", "info_type_id": 1, "movie_id": 1}, {"info": "USA", "info_type_id": 1, "movie_id": 2}]
+  Move         r17, r16
+  // let movie_info_idx = [
+  Const        r18, [{"info": 7.2, "info_type_id": 2, "movie_id": 1}, {"info": 9, "info_type_id": 2, "movie_id": 2}]
+  Move         r19, r18
+  // let movie_keyword = [
+  Const        r20, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}]
+  Move         r21, r20
+  // let title = [
+  Const        r22, [{"id": 1, "kind_id": 1, "production_year": 2005, "title": "Dark Euro Film"}, {"id": 2, "kind_id": 1, "production_year": 2005, "title": "US Film"}]
+  Move         r23, r22
+  // let allowed_keywords = ["murder", "murder-in-title", "blood", "violence"]
+  Const        r24, ["murder", "murder-in-title", "blood", "violence"]
+  Move         r25, r24
+  // let allowed_countries = [
+  Const        r26, ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Danish", "Norwegian", "German", "USA", "American"]
+  Move         r27, r26
+  // from cc in complete_cast
+  Const        r28, []
+  IterPrep     r29, r3
+  Len          r30, r29
+  Const        r31, 0
+L39:
+  Less         r32, r31, r30
+  JumpIfFalse  r32, L0
+  Index        r33, r29, r31
+  Move         r34, r33
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  IterPrep     r35, r1
+  Len          r36, r35
+  Const        r37, 0
+L38:
+  Less         r38, r37, r36
+  JumpIfFalse  r38, L1
+  Index        r39, r35, r37
+  Move         r40, r39
+  Const        r41, "id"
+  Index        r42, r40, r41
+  Const        r43, "subject_id"
+  Index        r44, r34, r43
+  Equal        r45, r42, r44
+  JumpIfFalse  r45, L2
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  IterPrep     r46, r1
+  Len          r47, r46
+  Const        r48, 0
+L37:
+  Less         r49, r48, r47
+  JumpIfFalse  r49, L2
+  Index        r50, r46, r48
+  Move         r51, r50
+  Const        r52, "id"
+  Index        r53, r51, r52
+  Const        r54, "status_id"
+  Index        r55, r34, r54
+  Equal        r56, r53, r55
+  JumpIfFalse  r56, L3
+  // join mc in movie_companies on mc.movie_id == cc.movie_id
+  IterPrep     r57, r9
+  Len          r58, r57
+  Const        r59, 0
+L36:
+  Less         r60, r59, r58
+  JumpIfFalse  r60, L3
+  Index        r61, r57, r59
+  Move         r62, r61
+  Const        r63, "movie_id"
+  Index        r64, r62, r63
+  Const        r65, "movie_id"
+  Index        r66, r34, r65
+  Equal        r67, r64, r66
+  JumpIfFalse  r67, L4
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r68, r5
+  Len          r69, r68
+  Const        r70, 0
+L35:
+  Less         r71, r70, r69
+  JumpIfFalse  r71, L4
+  Index        r72, r68, r70
+  Move         r73, r72
+  Const        r74, "id"
+  Index        r75, r73, r74
+  Const        r76, "company_id"
+  Index        r77, r62, r76
+  Equal        r78, r75, r77
+  JumpIfFalse  r78, L5
+  // join ct in company_type on ct.id == mc.company_type_id
+  IterPrep     r79, r7
+  Len          r80, r79
+  Const        r81, 0
+L34:
+  Less         r82, r81, r80
+  JumpIfFalse  r82, L5
+  Index        r83, r79, r81
+  Move         r84, r83
+  Const        r85, "id"
+  Index        r86, r84, r85
+  Const        r87, "company_type_id"
+  Index        r88, r62, r87
+  Equal        r89, r86, r88
+  JumpIfFalse  r89, L6
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  IterPrep     r90, r21
+  Len          r91, r90
+  Const        r92, 0
+L33:
+  Less         r93, r92, r91
+  JumpIfFalse  r93, L6
+  Index        r94, r90, r92
+  Move         r95, r94
+  Const        r96, "movie_id"
+  Index        r97, r95, r96
+  Const        r98, "movie_id"
+  Index        r99, r34, r98
+  Equal        r100, r97, r99
+  JumpIfFalse  r100, L7
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r101, r13
+  Len          r102, r101
+  Const        r103, 0
+L32:
+  Less         r104, r103, r102
+  JumpIfFalse  r104, L7
+  Index        r105, r101, r103
+  Move         r106, r105
+  Const        r107, "id"
+  Index        r108, r106, r107
+  Const        r109, "keyword_id"
+  Index        r110, r95, r109
+  Equal        r111, r108, r110
+  JumpIfFalse  r111, L8
+  // join mi in movie_info on mi.movie_id == cc.movie_id
+  IterPrep     r112, r17
+  Len          r113, r112
+  Const        r114, 0
+L31:
+  Less         r115, r114, r113
+  JumpIfFalse  r115, L8
+  Index        r116, r112, r114
+  Move         r117, r116
+  Const        r118, "movie_id"
+  Index        r119, r117, r118
+  Const        r120, "movie_id"
+  Index        r121, r34, r120
+  Equal        r122, r119, r121
+  JumpIfFalse  r122, L9
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r123, r11
+  Len          r124, r123
+  Const        r125, 0
+L30:
+  Less         r126, r125, r124
+  JumpIfFalse  r126, L9
+  Index        r127, r123, r125
+  Move         r128, r127
+  Const        r129, "id"
+  Index        r130, r128, r129
+  Const        r131, "info_type_id"
+  Index        r132, r117, r131
+  Equal        r133, r130, r132
+  JumpIfFalse  r133, L10
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
+  IterPrep     r134, r19
+  Len          r135, r134
+  Const        r136, 0
+L29:
+  Less         r137, r136, r135
+  JumpIfFalse  r137, L10
+  Index        r138, r134, r136
+  Move         r139, r138
+  Const        r140, "movie_id"
+  Index        r141, r139, r140
+  Const        r142, "movie_id"
+  Index        r143, r34, r142
+  Equal        r144, r141, r143
+  JumpIfFalse  r144, L11
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  IterPrep     r145, r11
+  Len          r146, r145
+  Const        r147, 0
+L28:
+  Less         r148, r147, r146
+  JumpIfFalse  r148, L11
+  Index        r149, r145, r147
+  Move         r150, r149
+  Const        r151, "id"
+  Index        r152, r150, r151
+  Const        r153, "info_type_id"
+  Index        r154, r139, r153
+  Equal        r155, r152, r154
+  JumpIfFalse  r155, L12
+  // join t in title on t.id == cc.movie_id
+  IterPrep     r156, r23
+  Len          r157, r156
+  Const        r158, 0
+L27:
+  Less         r159, r158, r157
+  JumpIfFalse  r159, L12
+  Index        r160, r156, r158
+  Move         r161, r160
+  Const        r162, "id"
+  Index        r163, r161, r162
+  Const        r164, "movie_id"
+  Index        r165, r34, r164
+  Equal        r166, r163, r165
+  JumpIfFalse  r166, L13
+  // join kt in kind_type on kt.id == t.kind_id
+  IterPrep     r167, r15
+  Len          r168, r167
+  Const        r169, 0
+L26:
+  Less         r170, r169, r168
+  JumpIfFalse  r170, L13
+  Index        r171, r167, r169
+  Move         r172, r171
+  Const        r173, "id"
+  Index        r174, r172, r173
+  Const        r175, "kind_id"
+  Index        r176, r161, r175
+  Equal        r177, r174, r176
+  JumpIfFalse  r177, L14
+  // cct1.kind == "crew" &&
+  Const        r178, "kind"
+  Index        r179, r40, r178
+  // mi_idx.info < 8.5 &&
+  Const        r180, "info"
+  Index        r181, r139, r180
+  Const        r182, 8.5
+  LessFloat    r183, r181, r182
+  // t.production_year > 2000
+  Const        r184, "production_year"
+  Index        r185, r161, r184
+  Const        r186, 2000
+  Less         r187, r186, r185
+  // cct1.kind == "crew" &&
+  Const        r188, "crew"
+  Equal        r189, r179, r188
+  // cct2.kind != "complete+verified" &&
+  Const        r190, "kind"
+  Index        r191, r51, r190
+  Const        r192, "complete+verified"
+  NotEqual     r193, r191, r192
+  // cn.country_code != "[us]" &&
+  Const        r194, "country_code"
+  Index        r195, r73, r194
+  Const        r196, "[us]"
+  NotEqual     r197, r195, r196
+  // it1.info == "countries" &&
+  Const        r198, "info"
+  Index        r199, r128, r198
+  Const        r200, "countries"
+  Equal        r201, r199, r200
+  // it2.info == "rating" &&
+  Const        r202, "info"
+  Index        r203, r150, r202
+  Const        r204, "rating"
+  Equal        r205, r203, r204
+  Const        r206, "note"
+  Index        r207, r62, r206
+  // mc.note.contains("(USA)") == false &&
+  Const        r208, "(USA)"
+  In           r209, r208, r207
+  Const        r210, false
+  Equal        r211, r209, r210
+  // cct1.kind == "crew" &&
+  Move         r212, r189
+  JumpIfFalse  r212, L15
+  Move         r212, r193
+L15:
+  // cct2.kind != "complete+verified" &&
+  Move         r213, r212
+  JumpIfFalse  r213, L16
+  Move         r213, r197
+L16:
+  // cn.country_code != "[us]" &&
+  Move         r214, r213
+  JumpIfFalse  r214, L17
+  Move         r214, r201
+L17:
+  // it1.info == "countries" &&
+  Move         r215, r214
+  JumpIfFalse  r215, L18
+  Move         r215, r205
+L18:
+  // it2.info == "rating" &&
+  Move         r216, r215
+  JumpIfFalse  r216, L19
+  // (k.keyword in allowed_keywords) &&
+  Const        r217, "keyword"
+  Index        r218, r106, r217
+  In           r219, r218, r25
+  // it2.info == "rating" &&
+  Move         r216, r219
+L19:
+  // (k.keyword in allowed_keywords) &&
+  Move         r220, r216
+  JumpIfFalse  r220, L20
+  // (kt.kind in ["movie", "episode"]) &&
+  Const        r221, "kind"
+  Index        r222, r172, r221
+  Const        r223, ["movie", "episode"]
+  In           r224, r222, r223
+  // (k.keyword in allowed_keywords) &&
+  Move         r220, r224
+L20:
+  // (kt.kind in ["movie", "episode"]) &&
+  Move         r225, r220
+  JumpIfFalse  r225, L21
+  Move         r225, r211
+L21:
+  // mc.note.contains("(USA)") == false &&
+  Move         r226, r225
+  JumpIfFalse  r226, L22
+  Const        r227, "note"
+  Index        r228, r62, r227
+  // mc.note.contains("(200") &&
+  Const        r229, "(200"
+  In           r230, r229, r228
+  // mc.note.contains("(USA)") == false &&
+  Move         r226, r230
+L22:
+  // mc.note.contains("(200") &&
+  Move         r231, r226
+  JumpIfFalse  r231, L23
+  // (mi.info in allowed_countries) &&
+  Const        r232, "info"
+  Index        r233, r117, r232
+  In           r234, r233, r27
+  // mc.note.contains("(200") &&
+  Move         r231, r234
+L23:
+  // (mi.info in allowed_countries) &&
+  Move         r235, r231
+  JumpIfFalse  r235, L24
+  Move         r235, r183
+L24:
+  // mi_idx.info < 8.5 &&
+  Move         r236, r235
+  JumpIfFalse  r236, L25
+  Move         r236, r187
+L25:
+  // where (
+  JumpIfFalse  r236, L14
+  // select { company: cn.name, rating: mi_idx.info, title: t.title }
+  Const        r237, "company"
+  Const        r238, "name"
+  Index        r239, r73, r238
+  Const        r240, "rating"
+  Const        r241, "info"
+  Index        r242, r139, r241
+  Const        r243, "title"
+  Const        r244, "title"
+  Index        r245, r161, r244
+  Move         r246, r237
+  Move         r247, r239
+  Move         r248, r240
+  Move         r249, r242
+  Move         r250, r243
+  Move         r251, r245
+  MakeMap      r252, 3, r246
+  // from cc in complete_cast
+  Append       r253, r28, r252
+  Move         r28, r253
+L14:
+  // join kt in kind_type on kt.id == t.kind_id
+  Const        r254, 1
+  Add          r255, r169, r254
+  Move         r169, r255
+  Jump         L26
+L13:
+  // join t in title on t.id == cc.movie_id
+  Const        r256, 1
+  Add          r257, r158, r256
+  Move         r158, r257
+  Jump         L27
+L12:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r258, 1
+  Add          r259, r147, r258
+  Move         r147, r259
+  Jump         L28
+L11:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
+  Const        r260, 1
+  Add          r261, r136, r260
+  Move         r136, r261
+  Jump         L29
+L10:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r262, 1
+  Add          r263, r125, r262
+  Move         r125, r263
+  Jump         L30
+L9:
+  // join mi in movie_info on mi.movie_id == cc.movie_id
+  Const        r264, 1
+  Add          r265, r114, r264
+  Move         r114, r265
+  Jump         L31
+L8:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r266, 1
+  Add          r267, r103, r266
+  Move         r103, r267
+  Jump         L32
+L7:
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  Const        r268, 1
+  Add          r269, r92, r268
+  Move         r92, r269
+  Jump         L33
+L6:
+  // join ct in company_type on ct.id == mc.company_type_id
+  Const        r270, 1
+  Add          r271, r81, r270
+  Move         r81, r271
+  Jump         L34
+L5:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r272, 1
+  Add          r273, r70, r272
+  Move         r70, r273
+  Jump         L35
+L4:
+  // join mc in movie_companies on mc.movie_id == cc.movie_id
+  Const        r274, 1
+  Add          r275, r59, r274
+  Move         r59, r275
+  Jump         L36
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r276, 1
+  Add          r277, r48, r276
+  Move         r48, r277
+  Jump         L37
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r278, 1
+  Add          r279, r37, r278
+  Move         r37, r279
+  Jump         L38
+L1:
+  // from cc in complete_cast
+  Const        r280, 1
+  Add          r281, r31, r280
+  Move         r31, r281
+  Jump         L39
+L0:
+  // let matches =
+  Move         r282, r28
+  // movie_company: min(from x in matches select x.company),
+  Const        r283, "movie_company"
+  Const        r284, []
+  IterPrep     r285, r282
+  Len          r286, r285
+  Const        r287, 0
+L41:
+  Less         r288, r287, r286
+  JumpIfFalse  r288, L40
+  Index        r289, r285, r287
+  Move         r290, r289
+  Const        r291, "company"
+  Index        r292, r290, r291
+  Append       r293, r284, r292
+  Move         r284, r293
+  Const        r294, 1
+  Add          r295, r287, r294
+  Move         r287, r295
+  Jump         L41
+L40:
+  Min          r296, r284
+  // rating: min(from x in matches select x.rating),
+  Const        r297, "rating"
+  Const        r298, []
+  IterPrep     r299, r282
+  Len          r300, r299
+  Const        r301, 0
+L43:
+  Less         r302, r301, r300
+  JumpIfFalse  r302, L42
+  Index        r303, r299, r301
+  Move         r290, r303
+  Const        r304, "rating"
+  Index        r305, r290, r304
+  Append       r306, r298, r305
+  Move         r298, r306
+  Const        r307, 1
+  Add          r308, r301, r307
+  Move         r301, r308
+  Jump         L43
+L42:
+  Min          r309, r298
+  // complete_euro_dark_movie: min(from x in matches select x.title)
+  Const        r310, "complete_euro_dark_movie"
+  Const        r311, []
+  IterPrep     r312, r282
+  Len          r313, r312
+  Const        r314, 0
+L45:
+  Less         r315, r314, r313
+  JumpIfFalse  r315, L44
+  Index        r316, r312, r314
+  Move         r290, r316
+  Const        r317, "title"
+  Index        r318, r290, r317
+  Append       r319, r311, r318
+  Move         r311, r319
+  Const        r320, 1
+  Add          r321, r314, r320
+  Move         r314, r321
+  Jump         L45
+L44:
+  Min          r322, r311
+  // movie_company: min(from x in matches select x.company),
+  Move         r323, r283
+  Move         r324, r296
+  // rating: min(from x in matches select x.rating),
+  Move         r325, r297
+  Move         r326, r309
+  // complete_euro_dark_movie: min(from x in matches select x.title)
+  Move         r327, r310
+  Move         r328, r322
+  // let result = {
+  MakeMap      r329, 3, r323
+  Move         r330, r329
+  // json(result)
+  JSON         r330
+  // expect result == {
+  Const        r331, {"complete_euro_dark_movie": "Dark Euro Film", "movie_company": "Euro Films Ltd.", "rating": 7.2}
+  Equal        r332, r330, r331
+  Expect       r332
+  Return       r0

--- a/tests/dataset/job/out/q29.ir.out
+++ b/tests/dataset/job/out/q29.ir.out
@@ -1,0 +1,909 @@
+func main (regs=500)
+  // let aka_name = [
+  Const        r0, [{"person_id": 1}, {"person_id": 2}]
+  Move         r1, r0
+  // let complete_cast = [
+  Const        r2, [{"movie_id": 1, "status_id": 2, "subject_id": 1}, {"movie_id": 2, "status_id": 2, "subject_id": 1}]
+  Move         r3, r2
+  // let comp_cast_type = [
+  Const        r4, [{"id": 1, "kind": "cast"}, {"id": 2, "kind": "complete+verified"}, {"id": 3, "kind": "other"}]
+  Move         r5, r4
+  // let char_name = [
+  Const        r6, [{"id": 1, "name": "Queen"}, {"id": 2, "name": "Princess"}]
+  Move         r7, r6
+  // let cast_info = [
+  Const        r8, [{"movie_id": 1, "note": "(voice)", "person_id": 1, "person_role_id": 1, "role_id": 1}, {"movie_id": 2, "note": "(voice)", "person_id": 2, "person_role_id": 2, "role_id": 1}]
+  Move         r9, r8
+  // let company_name = [
+  Const        r10, [{"country_code": "[us]", "id": 1}, {"country_code": "[uk]", "id": 2}]
+  Move         r11, r10
+  // let info_type = [
+  Const        r12, [{"id": 1, "info": "release dates"}, {"id": 2, "info": "trivia"}, {"id": 3, "info": "other"}]
+  Move         r13, r12
+  // let keyword = [
+  Const        r14, [{"id": 1, "keyword": "computer-animation"}, {"id": 2, "keyword": "action"}]
+  Move         r15, r14
+  // let movie_companies = [
+  Const        r16, [{"company_id": 1, "movie_id": 1}, {"company_id": 2, "movie_id": 2}]
+  Move         r17, r16
+  // let movie_info = [
+  Const        r18, [{"info": "USA:2004", "info_type_id": 1, "movie_id": 1}, {"info": "USA:1995", "info_type_id": 1, "movie_id": 2}]
+  Move         r19, r18
+  // let movie_keyword = [
+  Const        r20, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}]
+  Move         r21, r20
+  // let name = [
+  Const        r22, [{"gender": "f", "id": 1, "name": "Angela Aniston"}, {"gender": "m", "id": 2, "name": "Bob Brown"}]
+  Move         r23, r22
+  // let person_info = [
+  Const        r24, [{"info_type_id": 2, "person_id": 1}, {"info_type_id": 2, "person_id": 2}]
+  Move         r25, r24
+  // let role_type = [
+  Const        r26, [{"id": 1, "role": "actress"}, {"id": 2, "role": "actor"}]
+  Move         r27, r26
+  // let title = [
+  Const        r28, [{"id": 1, "production_year": 2004, "title": "Shrek 2"}, {"id": 2, "production_year": 1999, "title": "Old Film"}]
+  Move         r29, r28
+  // from an in aka_name
+  Const        r30, []
+  IterPrep     r31, r1
+  Len          r32, r31
+  Const        r33, 0
+L79:
+  Less         r34, r33, r32
+  JumpIfFalse  r34, L0
+  Index        r35, r31, r33
+  Move         r36, r35
+  // from cc in complete_cast
+  IterPrep     r37, r3
+  Len          r38, r37
+  Const        r39, 0
+L78:
+  Less         r40, r39, r38
+  JumpIfFalse  r40, L1
+  Index        r41, r37, r39
+  Move         r42, r41
+  // from cct1 in comp_cast_type
+  IterPrep     r43, r5
+  Len          r44, r43
+  Const        r45, 0
+L77:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L2
+  Index        r47, r43, r45
+  Move         r48, r47
+  // from cct2 in comp_cast_type
+  IterPrep     r49, r5
+  Len          r50, r49
+  Const        r51, 0
+L76:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r53, r49, r51
+  Move         r54, r53
+  // from chn in char_name
+  IterPrep     r55, r7
+  Len          r56, r55
+  Const        r57, 0
+L75:
+  Less         r58, r57, r56
+  JumpIfFalse  r58, L4
+  Index        r59, r55, r57
+  Move         r60, r59
+  // from ci in cast_info
+  IterPrep     r61, r9
+  Len          r62, r61
+  Const        r63, 0
+L74:
+  Less         r64, r63, r62
+  JumpIfFalse  r64, L5
+  Index        r65, r61, r63
+  Move         r66, r65
+  // from cn in company_name
+  IterPrep     r67, r11
+  Len          r68, r67
+  Const        r69, 0
+L73:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L6
+  Index        r71, r67, r69
+  Move         r72, r71
+  // from it in info_type
+  IterPrep     r73, r13
+  Len          r74, r73
+  Const        r75, 0
+L72:
+  Less         r76, r75, r74
+  JumpIfFalse  r76, L7
+  Index        r77, r73, r75
+  Move         r78, r77
+  // from it3 in info_type
+  IterPrep     r79, r13
+  Len          r80, r79
+  Const        r81, 0
+L71:
+  Less         r82, r81, r80
+  JumpIfFalse  r82, L8
+  Index        r83, r79, r81
+  Move         r84, r83
+  // from k in keyword
+  IterPrep     r85, r15
+  Len          r86, r85
+  Const        r87, 0
+L70:
+  Less         r88, r87, r86
+  JumpIfFalse  r88, L9
+  Index        r89, r85, r87
+  Move         r90, r89
+  // from mc in movie_companies
+  IterPrep     r91, r17
+  Len          r92, r91
+  Const        r93, 0
+L69:
+  Less         r94, r93, r92
+  JumpIfFalse  r94, L10
+  Index        r95, r91, r93
+  Move         r96, r95
+  // from mi in movie_info
+  IterPrep     r97, r19
+  Len          r98, r97
+  Const        r99, 0
+L68:
+  Less         r100, r99, r98
+  JumpIfFalse  r100, L11
+  Index        r101, r97, r99
+  Move         r102, r101
+  // from mk in movie_keyword
+  IterPrep     r103, r21
+  Len          r104, r103
+  Const        r105, 0
+L67:
+  Less         r106, r105, r104
+  JumpIfFalse  r106, L12
+  Index        r107, r103, r105
+  Move         r108, r107
+  // from n in name
+  IterPrep     r109, r23
+  Len          r110, r109
+  Const        r111, 0
+L66:
+  Less         r112, r111, r110
+  JumpIfFalse  r112, L13
+  Index        r113, r109, r111
+  Move         r114, r113
+  // from pi in person_info
+  IterPrep     r115, r25
+  Len          r116, r115
+  Const        r117, 0
+L65:
+  Less         r118, r117, r116
+  JumpIfFalse  r118, L14
+  Index        r119, r115, r117
+  Move         r120, r119
+  // from rt in role_type
+  IterPrep     r121, r27
+  Len          r122, r121
+  Const        r123, 0
+L64:
+  Less         r124, r123, r122
+  JumpIfFalse  r124, L15
+  Index        r125, r121, r123
+  Move         r126, r125
+  // from t in title
+  IterPrep     r127, r29
+  Len          r128, r127
+  Const        r129, 0
+L63:
+  Less         r130, r129, r128
+  JumpIfFalse  r130, L16
+  Index        r131, r127, r129
+  Move         r132, r131
+  // cct1.kind == "cast" &&
+  Const        r133, "kind"
+  Index        r134, r48, r133
+  // t.production_year >= 2000 &&
+  Const        r135, "production_year"
+  Index        r136, r132, r135
+  Const        r137, 2000
+  LessEq       r138, r137, r136
+  // t.production_year <= 2010 &&
+  Const        r139, "production_year"
+  Index        r140, r132, r139
+  Const        r141, 2010
+  LessEq       r142, r140, r141
+  // cct1.kind == "cast" &&
+  Const        r143, "cast"
+  Equal        r144, r134, r143
+  // cct2.kind == "complete+verified" &&
+  Const        r145, "kind"
+  Index        r146, r54, r145
+  Const        r147, "complete+verified"
+  Equal        r148, r146, r147
+  // chn.name == "Queen" &&
+  Const        r149, "name"
+  Index        r150, r60, r149
+  Const        r151, "Queen"
+  Equal        r152, r150, r151
+  // cn.country_code == "[us]" &&
+  Const        r153, "country_code"
+  Index        r154, r72, r153
+  Const        r155, "[us]"
+  Equal        r156, r154, r155
+  // it.info == "release dates" &&
+  Const        r157, "info"
+  Index        r158, r78, r157
+  Const        r159, "release dates"
+  Equal        r160, r158, r159
+  // it3.info == "trivia" &&
+  Const        r161, "info"
+  Index        r162, r84, r161
+  Const        r163, "trivia"
+  Equal        r164, r162, r163
+  // k.keyword == "computer-animation" &&
+  Const        r165, "keyword"
+  Index        r166, r90, r165
+  Const        r167, "computer-animation"
+  Equal        r168, r166, r167
+  // n.gender == "f" &&
+  Const        r169, "gender"
+  Index        r170, r114, r169
+  Const        r171, "f"
+  Equal        r172, r170, r171
+  // rt.role == "actress" &&
+  Const        r173, "role"
+  Index        r174, r126, r173
+  Const        r175, "actress"
+  Equal        r176, r174, r175
+  // t.title == "Shrek 2" &&
+  Const        r177, "title"
+  Index        r178, r132, r177
+  Const        r179, "Shrek 2"
+  Equal        r180, r178, r179
+  // t.id == mi.movie_id &&
+  Const        r181, "id"
+  Index        r182, r132, r181
+  Const        r183, "movie_id"
+  Index        r184, r102, r183
+  Equal        r185, r182, r184
+  // t.id == mc.movie_id &&
+  Const        r186, "id"
+  Index        r187, r132, r186
+  Const        r188, "movie_id"
+  Index        r189, r96, r188
+  Equal        r190, r187, r189
+  // t.id == ci.movie_id &&
+  Const        r191, "id"
+  Index        r192, r132, r191
+  Const        r193, "movie_id"
+  Index        r194, r66, r193
+  Equal        r195, r192, r194
+  // t.id == mk.movie_id &&
+  Const        r196, "id"
+  Index        r197, r132, r196
+  Const        r198, "movie_id"
+  Index        r199, r108, r198
+  Equal        r200, r197, r199
+  // t.id == cc.movie_id &&
+  Const        r201, "id"
+  Index        r202, r132, r201
+  Const        r203, "movie_id"
+  Index        r204, r42, r203
+  Equal        r205, r202, r204
+  // mc.movie_id == ci.movie_id &&
+  Const        r206, "movie_id"
+  Index        r207, r96, r206
+  Const        r208, "movie_id"
+  Index        r209, r66, r208
+  Equal        r210, r207, r209
+  // mc.movie_id == mi.movie_id &&
+  Const        r211, "movie_id"
+  Index        r212, r96, r211
+  Const        r213, "movie_id"
+  Index        r214, r102, r213
+  Equal        r215, r212, r214
+  // mc.movie_id == mk.movie_id &&
+  Const        r216, "movie_id"
+  Index        r217, r96, r216
+  Const        r218, "movie_id"
+  Index        r219, r108, r218
+  Equal        r220, r217, r219
+  // mc.movie_id == cc.movie_id &&
+  Const        r221, "movie_id"
+  Index        r222, r96, r221
+  Const        r223, "movie_id"
+  Index        r224, r42, r223
+  Equal        r225, r222, r224
+  // mi.movie_id == ci.movie_id &&
+  Const        r226, "movie_id"
+  Index        r227, r102, r226
+  Const        r228, "movie_id"
+  Index        r229, r66, r228
+  Equal        r230, r227, r229
+  // mi.movie_id == mk.movie_id &&
+  Const        r231, "movie_id"
+  Index        r232, r102, r231
+  Const        r233, "movie_id"
+  Index        r234, r108, r233
+  Equal        r235, r232, r234
+  // mi.movie_id == cc.movie_id &&
+  Const        r236, "movie_id"
+  Index        r237, r102, r236
+  Const        r238, "movie_id"
+  Index        r239, r42, r238
+  Equal        r240, r237, r239
+  // ci.movie_id == mk.movie_id &&
+  Const        r241, "movie_id"
+  Index        r242, r66, r241
+  Const        r243, "movie_id"
+  Index        r244, r108, r243
+  Equal        r245, r242, r244
+  // ci.movie_id == cc.movie_id &&
+  Const        r246, "movie_id"
+  Index        r247, r66, r246
+  Const        r248, "movie_id"
+  Index        r249, r42, r248
+  Equal        r250, r247, r249
+  // mk.movie_id == cc.movie_id &&
+  Const        r251, "movie_id"
+  Index        r252, r108, r251
+  Const        r253, "movie_id"
+  Index        r254, r42, r253
+  Equal        r255, r252, r254
+  // cn.id == mc.company_id &&
+  Const        r256, "id"
+  Index        r257, r72, r256
+  Const        r258, "company_id"
+  Index        r259, r96, r258
+  Equal        r260, r257, r259
+  // it.id == mi.info_type_id &&
+  Const        r261, "id"
+  Index        r262, r78, r261
+  Const        r263, "info_type_id"
+  Index        r264, r102, r263
+  Equal        r265, r262, r264
+  // n.id == ci.person_id &&
+  Const        r266, "id"
+  Index        r267, r114, r266
+  Const        r268, "person_id"
+  Index        r269, r66, r268
+  Equal        r270, r267, r269
+  // rt.id == ci.role_id &&
+  Const        r271, "id"
+  Index        r272, r126, r271
+  Const        r273, "role_id"
+  Index        r274, r66, r273
+  Equal        r275, r272, r274
+  // n.id == an.person_id &&
+  Const        r276, "id"
+  Index        r277, r114, r276
+  Const        r278, "person_id"
+  Index        r279, r36, r278
+  Equal        r280, r277, r279
+  // ci.person_id == an.person_id &&
+  Const        r281, "person_id"
+  Index        r282, r66, r281
+  Const        r283, "person_id"
+  Index        r284, r36, r283
+  Equal        r285, r282, r284
+  // chn.id == ci.person_role_id &&
+  Const        r286, "id"
+  Index        r287, r60, r286
+  Const        r288, "person_role_id"
+  Index        r289, r66, r288
+  Equal        r290, r287, r289
+  // n.id == pi.person_id &&
+  Const        r291, "id"
+  Index        r292, r114, r291
+  Const        r293, "person_id"
+  Index        r294, r120, r293
+  Equal        r295, r292, r294
+  // ci.person_id == pi.person_id &&
+  Const        r296, "person_id"
+  Index        r297, r66, r296
+  Const        r298, "person_id"
+  Index        r299, r120, r298
+  Equal        r300, r297, r299
+  // it3.id == pi.info_type_id &&
+  Const        r301, "id"
+  Index        r302, r84, r301
+  Const        r303, "info_type_id"
+  Index        r304, r120, r303
+  Equal        r305, r302, r304
+  // k.id == mk.keyword_id &&
+  Const        r306, "id"
+  Index        r307, r90, r306
+  Const        r308, "keyword_id"
+  Index        r309, r108, r308
+  Equal        r310, r307, r309
+  // cct1.id == cc.subject_id &&
+  Const        r311, "id"
+  Index        r312, r48, r311
+  Const        r313, "subject_id"
+  Index        r314, r42, r313
+  Equal        r315, r312, r314
+  // cct2.id == cc.status_id
+  Const        r316, "id"
+  Index        r317, r54, r316
+  Const        r318, "status_id"
+  Index        r319, r42, r318
+  Equal        r320, r317, r319
+  // cct1.kind == "cast" &&
+  Move         r321, r144
+  JumpIfFalse  r321, L17
+  Move         r321, r148
+L17:
+  // cct2.kind == "complete+verified" &&
+  Move         r322, r321
+  JumpIfFalse  r322, L18
+  Move         r322, r152
+L18:
+  // chn.name == "Queen" &&
+  Move         r323, r322
+  JumpIfFalse  r323, L19
+  // (ci.note == "(voice)" ||
+  Const        r324, "note"
+  Index        r325, r66, r324
+  Const        r326, "(voice)"
+  Equal        r327, r325, r326
+  // ci.note == "(voice) (uncredited)" ||
+  Const        r328, "note"
+  Index        r329, r66, r328
+  Const        r330, "(voice) (uncredited)"
+  Equal        r331, r329, r330
+  // ci.note == "(voice: English version)") &&
+  Const        r332, "note"
+  Index        r333, r66, r332
+  Const        r334, "(voice: English version)"
+  Equal        r335, r333, r334
+  // (ci.note == "(voice)" ||
+  Move         r336, r327
+  JumpIfTrue   r336, L20
+  Move         r336, r331
+L20:
+  // ci.note == "(voice) (uncredited)" ||
+  Move         r337, r336
+  JumpIfTrue   r337, L21
+  Move         r337, r335
+L21:
+  // chn.name == "Queen" &&
+  Move         r323, r337
+L19:
+  // ci.note == "(voice: English version)") &&
+  Move         r338, r323
+  JumpIfFalse  r338, L22
+  Move         r338, r156
+L22:
+  // cn.country_code == "[us]" &&
+  Move         r339, r338
+  JumpIfFalse  r339, L23
+  Move         r339, r160
+L23:
+  // it.info == "release dates" &&
+  Move         r340, r339
+  JumpIfFalse  r340, L24
+  Move         r340, r164
+L24:
+  // it3.info == "trivia" &&
+  Move         r341, r340
+  JumpIfFalse  r341, L25
+  Move         r341, r168
+L25:
+  // k.keyword == "computer-animation" &&
+  Move         r342, r341
+  JumpIfFalse  r342, L26
+  Const        r343, "info"
+  Index        r344, r102, r343
+  // (mi.info.starts_with("Japan:200") || mi.info.starts_with("USA:200")) &&
+  Const        r345, "Japan:200"
+  Const        r346, 0
+  Len          r347, r345
+  Slice        r348, r344, r346, r347
+  Equal        r349, r348, r345
+  Move         r350, r349
+  JumpIfTrue   r350, L27
+  Const        r351, "info"
+  Index        r352, r102, r351
+  Const        r353, "USA:200"
+  Const        r354, 0
+  Len          r355, r353
+  Slice        r356, r352, r354, r355
+  Equal        r357, r356, r353
+  Move         r350, r357
+L27:
+  // k.keyword == "computer-animation" &&
+  Move         r342, r350
+L26:
+  // (mi.info.starts_with("Japan:200") || mi.info.starts_with("USA:200")) &&
+  Move         r358, r342
+  JumpIfFalse  r358, L28
+  Move         r358, r172
+L28:
+  // n.gender == "f" &&
+  Move         r359, r358
+  JumpIfFalse  r359, L29
+  Const        r360, "name"
+  Index        r361, r114, r360
+  // n.name.contains("An") &&
+  Const        r362, "An"
+  In           r363, r362, r361
+  // n.gender == "f" &&
+  Move         r359, r363
+L29:
+  // n.name.contains("An") &&
+  Move         r364, r359
+  JumpIfFalse  r364, L30
+  Move         r364, r176
+L30:
+  // rt.role == "actress" &&
+  Move         r365, r364
+  JumpIfFalse  r365, L31
+  Move         r365, r180
+L31:
+  // t.title == "Shrek 2" &&
+  Move         r366, r365
+  JumpIfFalse  r366, L32
+  Move         r366, r138
+L32:
+  // t.production_year >= 2000 &&
+  Move         r367, r366
+  JumpIfFalse  r367, L33
+  Move         r367, r142
+L33:
+  // t.production_year <= 2010 &&
+  Move         r368, r367
+  JumpIfFalse  r368, L34
+  Move         r368, r185
+L34:
+  // t.id == mi.movie_id &&
+  Move         r369, r368
+  JumpIfFalse  r369, L35
+  Move         r369, r190
+L35:
+  // t.id == mc.movie_id &&
+  Move         r370, r369
+  JumpIfFalse  r370, L36
+  Move         r370, r195
+L36:
+  // t.id == ci.movie_id &&
+  Move         r371, r370
+  JumpIfFalse  r371, L37
+  Move         r371, r200
+L37:
+  // t.id == mk.movie_id &&
+  Move         r372, r371
+  JumpIfFalse  r372, L38
+  Move         r372, r205
+L38:
+  // t.id == cc.movie_id &&
+  Move         r373, r372
+  JumpIfFalse  r373, L39
+  Move         r373, r210
+L39:
+  // mc.movie_id == ci.movie_id &&
+  Move         r374, r373
+  JumpIfFalse  r374, L40
+  Move         r374, r215
+L40:
+  // mc.movie_id == mi.movie_id &&
+  Move         r375, r374
+  JumpIfFalse  r375, L41
+  Move         r375, r220
+L41:
+  // mc.movie_id == mk.movie_id &&
+  Move         r376, r375
+  JumpIfFalse  r376, L42
+  Move         r376, r225
+L42:
+  // mc.movie_id == cc.movie_id &&
+  Move         r377, r376
+  JumpIfFalse  r377, L43
+  Move         r377, r230
+L43:
+  // mi.movie_id == ci.movie_id &&
+  Move         r378, r377
+  JumpIfFalse  r378, L44
+  Move         r378, r235
+L44:
+  // mi.movie_id == mk.movie_id &&
+  Move         r379, r378
+  JumpIfFalse  r379, L45
+  Move         r379, r240
+L45:
+  // mi.movie_id == cc.movie_id &&
+  Move         r380, r379
+  JumpIfFalse  r380, L46
+  Move         r380, r245
+L46:
+  // ci.movie_id == mk.movie_id &&
+  Move         r381, r380
+  JumpIfFalse  r381, L47
+  Move         r381, r250
+L47:
+  // ci.movie_id == cc.movie_id &&
+  Move         r382, r381
+  JumpIfFalse  r382, L48
+  Move         r382, r255
+L48:
+  // mk.movie_id == cc.movie_id &&
+  Move         r383, r382
+  JumpIfFalse  r383, L49
+  Move         r383, r260
+L49:
+  // cn.id == mc.company_id &&
+  Move         r384, r383
+  JumpIfFalse  r384, L50
+  Move         r384, r265
+L50:
+  // it.id == mi.info_type_id &&
+  Move         r385, r384
+  JumpIfFalse  r385, L51
+  Move         r385, r270
+L51:
+  // n.id == ci.person_id &&
+  Move         r386, r385
+  JumpIfFalse  r386, L52
+  Move         r386, r275
+L52:
+  // rt.id == ci.role_id &&
+  Move         r387, r386
+  JumpIfFalse  r387, L53
+  Move         r387, r280
+L53:
+  // n.id == an.person_id &&
+  Move         r388, r387
+  JumpIfFalse  r388, L54
+  Move         r388, r285
+L54:
+  // ci.person_id == an.person_id &&
+  Move         r389, r388
+  JumpIfFalse  r389, L55
+  Move         r389, r290
+L55:
+  // chn.id == ci.person_role_id &&
+  Move         r390, r389
+  JumpIfFalse  r390, L56
+  Move         r390, r295
+L56:
+  // n.id == pi.person_id &&
+  Move         r391, r390
+  JumpIfFalse  r391, L57
+  Move         r391, r300
+L57:
+  // ci.person_id == pi.person_id &&
+  Move         r392, r391
+  JumpIfFalse  r392, L58
+  Move         r392, r305
+L58:
+  // it3.id == pi.info_type_id &&
+  Move         r393, r392
+  JumpIfFalse  r393, L59
+  Move         r393, r310
+L59:
+  // k.id == mk.keyword_id &&
+  Move         r394, r393
+  JumpIfFalse  r394, L60
+  Move         r394, r315
+L60:
+  // cct1.id == cc.subject_id &&
+  Move         r395, r394
+  JumpIfFalse  r395, L61
+  Move         r395, r320
+L61:
+  // where (
+  JumpIfFalse  r395, L62
+  // voiced_char: chn.name,
+  Const        r396, "voiced_char"
+  Const        r397, "name"
+  Index        r398, r60, r397
+  // voicing_actress: n.name,
+  Const        r399, "voicing_actress"
+  Const        r400, "name"
+  Index        r401, r114, r400
+  // voiced_animation: t.title
+  Const        r402, "voiced_animation"
+  Const        r403, "title"
+  Index        r404, r132, r403
+  // voiced_char: chn.name,
+  Move         r405, r396
+  Move         r406, r398
+  // voicing_actress: n.name,
+  Move         r407, r399
+  Move         r408, r401
+  // voiced_animation: t.title
+  Move         r409, r402
+  Move         r410, r404
+  // select {
+  MakeMap      r411, 3, r405
+  // from an in aka_name
+  Append       r412, r30, r411
+  Move         r30, r412
+L62:
+  // from t in title
+  Const        r413, 1
+  Add          r414, r129, r413
+  Move         r129, r414
+  Jump         L63
+L16:
+  // from rt in role_type
+  Const        r415, 1
+  Add          r416, r123, r415
+  Move         r123, r416
+  Jump         L64
+L15:
+  // from pi in person_info
+  Const        r417, 1
+  Add          r418, r117, r417
+  Move         r117, r418
+  Jump         L65
+L14:
+  // from n in name
+  Const        r419, 1
+  Add          r420, r111, r419
+  Move         r111, r420
+  Jump         L66
+L13:
+  // from mk in movie_keyword
+  Const        r421, 1
+  Add          r422, r105, r421
+  Move         r105, r422
+  Jump         L67
+L12:
+  // from mi in movie_info
+  Const        r423, 1
+  Add          r424, r99, r423
+  Move         r99, r424
+  Jump         L68
+L11:
+  // from mc in movie_companies
+  Const        r425, 1
+  Add          r426, r93, r425
+  Move         r93, r426
+  Jump         L69
+L10:
+  // from k in keyword
+  Const        r427, 1
+  Add          r428, r87, r427
+  Move         r87, r428
+  Jump         L70
+L9:
+  // from it3 in info_type
+  Const        r429, 1
+  Add          r430, r81, r429
+  Move         r81, r430
+  Jump         L71
+L8:
+  // from it in info_type
+  Const        r431, 1
+  Add          r432, r75, r431
+  Move         r75, r432
+  Jump         L72
+L7:
+  // from cn in company_name
+  Const        r433, 1
+  Add          r434, r69, r433
+  Move         r69, r434
+  Jump         L73
+L6:
+  // from ci in cast_info
+  Const        r435, 1
+  Add          r436, r63, r435
+  Move         r63, r436
+  Jump         L74
+L5:
+  // from chn in char_name
+  Const        r437, 1
+  Add          r438, r57, r437
+  Move         r57, r438
+  Jump         L75
+L4:
+  // from cct2 in comp_cast_type
+  Const        r439, 1
+  Add          r440, r51, r439
+  Move         r51, r440
+  Jump         L76
+L3:
+  // from cct1 in comp_cast_type
+  Const        r441, 1
+  Add          r442, r45, r441
+  Move         r45, r442
+  Jump         L77
+L2:
+  // from cc in complete_cast
+  Const        r443, 1
+  Add          r444, r39, r443
+  Move         r39, r444
+  Jump         L78
+L1:
+  // from an in aka_name
+  Const        r445, 1
+  Add          r446, r33, r445
+  Move         r33, r446
+  Jump         L79
+L0:
+  // let matches =
+  Move         r447, r30
+  // voiced_char: min(from x in matches select x.voiced_char),
+  Const        r448, "voiced_char"
+  Const        r449, []
+  IterPrep     r450, r447
+  Len          r451, r450
+  Const        r452, 0
+L81:
+  Less         r453, r452, r451
+  JumpIfFalse  r453, L80
+  Index        r454, r450, r452
+  Move         r455, r454
+  Const        r456, "voiced_char"
+  Index        r457, r455, r456
+  Append       r458, r449, r457
+  Move         r449, r458
+  Const        r459, 1
+  Add          r460, r452, r459
+  Move         r452, r460
+  Jump         L81
+L80:
+  Min          r461, r449
+  // voicing_actress: min(from x in matches select x.voicing_actress),
+  Const        r462, "voicing_actress"
+  Const        r463, []
+  IterPrep     r464, r447
+  Len          r465, r464
+  Const        r466, 0
+L83:
+  Less         r467, r466, r465
+  JumpIfFalse  r467, L82
+  Index        r468, r464, r466
+  Move         r455, r468
+  Const        r469, "voicing_actress"
+  Index        r470, r455, r469
+  Append       r471, r463, r470
+  Move         r463, r471
+  Const        r472, 1
+  Add          r473, r466, r472
+  Move         r466, r473
+  Jump         L83
+L82:
+  Min          r474, r463
+  // voiced_animation: min(from x in matches select x.voiced_animation)
+  Const        r475, "voiced_animation"
+  Const        r476, []
+  IterPrep     r477, r447
+  Len          r478, r477
+  Const        r479, 0
+L85:
+  Less         r480, r479, r478
+  JumpIfFalse  r480, L84
+  Index        r481, r477, r479
+  Move         r455, r481
+  Const        r482, "voiced_animation"
+  Index        r483, r455, r482
+  Append       r484, r476, r483
+  Move         r476, r484
+  Const        r485, 1
+  Add          r486, r479, r485
+  Move         r479, r486
+  Jump         L85
+L84:
+  Min          r487, r476
+  // voiced_char: min(from x in matches select x.voiced_char),
+  Move         r488, r448
+  Move         r489, r461
+  // voicing_actress: min(from x in matches select x.voicing_actress),
+  Move         r490, r462
+  Move         r491, r474
+  // voiced_animation: min(from x in matches select x.voiced_animation)
+  Move         r492, r475
+  Move         r493, r487
+  // {
+  MakeMap      r494, 3, r488
+  Move         r495, r494
+  // let result = [
+  MakeList     r496, 1, r495
+  Move         r497, r496
+  // json(result)
+  JSON         r497
+  // expect result == [
+  Const        r498, [{"voiced_animation": "Shrek 2", "voiced_char": "Queen", "voicing_actress": "Angela Aniston"}]
+  Equal        r499, r497, r498
+  Expect       r499
+  Return       r0

--- a/tests/dataset/job/out/q30.ir.out
+++ b/tests/dataset/job/out/q30.ir.out
@@ -1,0 +1,517 @@
+func main (regs=308)
+  // let comp_cast_type = [
+  Const        r0, [{"id": 1, "kind": "cast"}, {"id": 2, "kind": "complete+verified"}, {"id": 3, "kind": "crew"}]
+  Move         r1, r0
+  // let complete_cast = [
+  Const        r2, [{"movie_id": 1, "status_id": 2, "subject_id": 1}, {"movie_id": 2, "status_id": 2, "subject_id": 3}]
+  Move         r3, r2
+  // let cast_info = [
+  Const        r4, [{"movie_id": 1, "note": "(writer)", "person_id": 10}, {"movie_id": 2, "note": "(actor)", "person_id": 11}]
+  Move         r5, r4
+  // let info_type = [
+  Const        r6, [{"id": 1, "info": "genres"}, {"id": 2, "info": "votes"}]
+  Move         r7, r6
+  // let keyword = [
+  Const        r8, [{"id": 1, "keyword": "murder"}, {"id": 2, "keyword": "comedy"}]
+  Move         r9, r8
+  // let movie_info = [
+  Const        r10, [{"info": "Horror", "info_type_id": 1, "movie_id": 1}, {"info": "Comedy", "info_type_id": 1, "movie_id": 2}]
+  Move         r11, r10
+  // let movie_info_idx = [
+  Const        r12, [{"info": 2000, "info_type_id": 2, "movie_id": 1}, {"info": 150, "info_type_id": 2, "movie_id": 2}]
+  Move         r13, r12
+  // let movie_keyword = [
+  Const        r14, [{"keyword_id": 1, "movie_id": 1}, {"keyword_id": 2, "movie_id": 2}]
+  Move         r15, r14
+  // let name = [
+  Const        r16, [{"gender": "m", "id": 10, "name": "John Writer"}, {"gender": "f", "id": 11, "name": "Jane Actor"}]
+  Move         r17, r16
+  // let title = [
+  Const        r18, [{"id": 1, "production_year": 2005, "title": "Violent Horror"}, {"id": 2, "production_year": 1995, "title": "Old Comedy"}]
+  Move         r19, r18
+  // let violent_keywords = [
+  Const        r20, ["murder", "violence", "blood", "gore", "death", "female-nudity", "hospital"]
+  Move         r21, r20
+  // let writer_notes = [
+  Const        r22, ["(writer)", "(head writer)", "(written by)", "(story)", "(story editor)"]
+  Move         r23, r22
+  // from cc in complete_cast
+  Const        r24, []
+  IterPrep     r25, r3
+  Len          r26, r25
+  Const        r27, 0
+L32:
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L0
+  Index        r29, r25, r27
+  Move         r30, r29
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  IterPrep     r31, r1
+  Len          r32, r31
+  Const        r33, 0
+L31:
+  Less         r34, r33, r32
+  JumpIfFalse  r34, L1
+  Index        r35, r31, r33
+  Move         r36, r35
+  Const        r37, "id"
+  Index        r38, r36, r37
+  Const        r39, "subject_id"
+  Index        r40, r30, r39
+  Equal        r41, r38, r40
+  JumpIfFalse  r41, L2
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  IterPrep     r42, r1
+  Len          r43, r42
+  Const        r44, 0
+L30:
+  Less         r45, r44, r43
+  JumpIfFalse  r45, L2
+  Index        r46, r42, r44
+  Move         r47, r46
+  Const        r48, "id"
+  Index        r49, r47, r48
+  Const        r50, "status_id"
+  Index        r51, r30, r50
+  Equal        r52, r49, r51
+  JumpIfFalse  r52, L3
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  IterPrep     r53, r5
+  Len          r54, r53
+  Const        r55, 0
+L29:
+  Less         r56, r55, r54
+  JumpIfFalse  r56, L3
+  Index        r57, r53, r55
+  Move         r58, r57
+  Const        r59, "movie_id"
+  Index        r60, r58, r59
+  Const        r61, "movie_id"
+  Index        r62, r30, r61
+  Equal        r63, r60, r62
+  JumpIfFalse  r63, L4
+  // join mi in movie_info on mi.movie_id == cc.movie_id
+  IterPrep     r64, r11
+  Len          r65, r64
+  Const        r66, 0
+L28:
+  Less         r67, r66, r65
+  JumpIfFalse  r67, L4
+  Index        r68, r64, r66
+  Move         r69, r68
+  Const        r70, "movie_id"
+  Index        r71, r69, r70
+  Const        r72, "movie_id"
+  Index        r73, r30, r72
+  Equal        r74, r71, r73
+  JumpIfFalse  r74, L5
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
+  IterPrep     r75, r13
+  Len          r76, r75
+  Const        r77, 0
+L27:
+  Less         r78, r77, r76
+  JumpIfFalse  r78, L5
+  Index        r79, r75, r77
+  Move         r80, r79
+  Const        r81, "movie_id"
+  Index        r82, r80, r81
+  Const        r83, "movie_id"
+  Index        r84, r30, r83
+  Equal        r85, r82, r84
+  JumpIfFalse  r85, L6
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  IterPrep     r86, r15
+  Len          r87, r86
+  Const        r88, 0
+L26:
+  Less         r89, r88, r87
+  JumpIfFalse  r89, L6
+  Index        r90, r86, r88
+  Move         r91, r90
+  Const        r92, "movie_id"
+  Index        r93, r91, r92
+  Const        r94, "movie_id"
+  Index        r95, r30, r94
+  Equal        r96, r93, r95
+  JumpIfFalse  r96, L7
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r97, r7
+  Len          r98, r97
+  Const        r99, 0
+L25:
+  Less         r100, r99, r98
+  JumpIfFalse  r100, L7
+  Index        r101, r97, r99
+  Move         r102, r101
+  Const        r103, "id"
+  Index        r104, r102, r103
+  Const        r105, "info_type_id"
+  Index        r106, r69, r105
+  Equal        r107, r104, r106
+  JumpIfFalse  r107, L8
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  IterPrep     r108, r7
+  Len          r109, r108
+  Const        r110, 0
+L24:
+  Less         r111, r110, r109
+  JumpIfFalse  r111, L8
+  Index        r112, r108, r110
+  Move         r113, r112
+  Const        r114, "id"
+  Index        r115, r113, r114
+  Const        r116, "info_type_id"
+  Index        r117, r80, r116
+  Equal        r118, r115, r117
+  JumpIfFalse  r118, L9
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r119, r9
+  Len          r120, r119
+  Const        r121, 0
+L23:
+  Less         r122, r121, r120
+  JumpIfFalse  r122, L9
+  Index        r123, r119, r121
+  Move         r124, r123
+  Const        r125, "id"
+  Index        r126, r124, r125
+  Const        r127, "keyword_id"
+  Index        r128, r91, r127
+  Equal        r129, r126, r128
+  JumpIfFalse  r129, L10
+  // join n in name on n.id == ci.person_id
+  IterPrep     r130, r17
+  Len          r131, r130
+  Const        r132, 0
+L22:
+  Less         r133, r132, r131
+  JumpIfFalse  r133, L10
+  Index        r134, r130, r132
+  Move         r135, r134
+  Const        r136, "id"
+  Index        r137, r135, r136
+  Const        r138, "person_id"
+  Index        r139, r58, r138
+  Equal        r140, r137, r139
+  JumpIfFalse  r140, L11
+  // join t in title on t.id == cc.movie_id
+  IterPrep     r141, r19
+  Len          r142, r141
+  Const        r143, 0
+L21:
+  Less         r144, r143, r142
+  JumpIfFalse  r144, L11
+  Index        r145, r141, r143
+  Move         r146, r145
+  Const        r147, "id"
+  Index        r148, r146, r147
+  Const        r149, "movie_id"
+  Index        r150, r30, r149
+  Equal        r151, r148, r150
+  JumpIfFalse  r151, L12
+  // where (cct1.kind in ["cast", "crew"]) &&
+  Const        r152, "kind"
+  Index        r153, r36, r152
+  Const        r154, ["cast", "crew"]
+  In           r155, r153, r154
+  // t.production_year > 2000
+  Const        r156, "production_year"
+  Index        r157, r146, r156
+  Const        r158, 2000
+  Less         r159, r158, r157
+  // cct2.kind == "complete+verified" &&
+  Const        r160, "kind"
+  Index        r161, r47, r160
+  Const        r162, "complete+verified"
+  Equal        r163, r161, r162
+  // it1.info == "genres" &&
+  Const        r164, "info"
+  Index        r165, r102, r164
+  Const        r166, "genres"
+  Equal        r167, r165, r166
+  // it2.info == "votes" &&
+  Const        r168, "info"
+  Index        r169, r113, r168
+  Const        r170, "votes"
+  Equal        r171, r169, r170
+  // n.gender == "m" &&
+  Const        r172, "gender"
+  Index        r173, r135, r172
+  Const        r174, "m"
+  Equal        r175, r173, r174
+  // where (cct1.kind in ["cast", "crew"]) &&
+  Move         r176, r155
+  JumpIfFalse  r176, L13
+  Move         r176, r163
+L13:
+  // cct2.kind == "complete+verified" &&
+  Move         r177, r176
+  JumpIfFalse  r177, L14
+  // (ci.note in writer_notes) &&
+  Const        r178, "note"
+  Index        r179, r58, r178
+  In           r180, r179, r23
+  // cct2.kind == "complete+verified" &&
+  Move         r177, r180
+L14:
+  // (ci.note in writer_notes) &&
+  Move         r181, r177
+  JumpIfFalse  r181, L15
+  Move         r181, r167
+L15:
+  // it1.info == "genres" &&
+  Move         r182, r181
+  JumpIfFalse  r182, L16
+  Move         r182, r171
+L16:
+  // it2.info == "votes" &&
+  Move         r183, r182
+  JumpIfFalse  r183, L17
+  // (k.keyword in violent_keywords) &&
+  Const        r184, "keyword"
+  Index        r185, r124, r184
+  In           r186, r185, r21
+  // it2.info == "votes" &&
+  Move         r183, r186
+L17:
+  // (k.keyword in violent_keywords) &&
+  Move         r187, r183
+  JumpIfFalse  r187, L18
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Const        r188, "info"
+  Index        r189, r69, r188
+  Const        r190, ["Horror", "Thriller"]
+  In           r191, r189, r190
+  // (k.keyword in violent_keywords) &&
+  Move         r187, r191
+L18:
+  // (mi.info in ["Horror", "Thriller"]) &&
+  Move         r192, r187
+  JumpIfFalse  r192, L19
+  Move         r192, r175
+L19:
+  // n.gender == "m" &&
+  Move         r193, r192
+  JumpIfFalse  r193, L20
+  Move         r193, r159
+L20:
+  // where (cct1.kind in ["cast", "crew"]) &&
+  JumpIfFalse  r193, L12
+  // budget: mi.info,
+  Const        r194, "budget"
+  Const        r195, "info"
+  Index        r196, r69, r195
+  // votes: mi_idx.info,
+  Const        r197, "votes"
+  Const        r198, "info"
+  Index        r199, r80, r198
+  // writer: n.name,
+  Const        r200, "writer"
+  Const        r201, "name"
+  Index        r202, r135, r201
+  // movie: t.title
+  Const        r203, "movie"
+  Const        r204, "title"
+  Index        r205, r146, r204
+  // budget: mi.info,
+  Move         r206, r194
+  Move         r207, r196
+  // votes: mi_idx.info,
+  Move         r208, r197
+  Move         r209, r199
+  // writer: n.name,
+  Move         r210, r200
+  Move         r211, r202
+  // movie: t.title
+  Move         r212, r203
+  Move         r213, r205
+  // select {
+  MakeMap      r214, 4, r206
+  // from cc in complete_cast
+  Append       r215, r24, r214
+  Move         r24, r215
+L12:
+  // join t in title on t.id == cc.movie_id
+  Const        r216, 1
+  Add          r217, r143, r216
+  Move         r143, r217
+  Jump         L21
+L11:
+  // join n in name on n.id == ci.person_id
+  Const        r218, 1
+  Add          r219, r132, r218
+  Move         r132, r219
+  Jump         L22
+L10:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r220, 1
+  Add          r221, r121, r220
+  Move         r121, r221
+  Jump         L23
+L9:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r222, 1
+  Add          r223, r110, r222
+  Move         r110, r223
+  Jump         L24
+L8:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r224, 1
+  Add          r225, r99, r224
+  Move         r99, r225
+  Jump         L25
+L7:
+  // join mk in movie_keyword on mk.movie_id == cc.movie_id
+  Const        r226, 1
+  Add          r227, r88, r226
+  Move         r88, r227
+  Jump         L26
+L6:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == cc.movie_id
+  Const        r228, 1
+  Add          r229, r77, r228
+  Move         r77, r229
+  Jump         L27
+L5:
+  // join mi in movie_info on mi.movie_id == cc.movie_id
+  Const        r230, 1
+  Add          r231, r66, r230
+  Move         r66, r231
+  Jump         L28
+L4:
+  // join ci in cast_info on ci.movie_id == cc.movie_id
+  Const        r232, 1
+  Add          r233, r55, r232
+  Move         r55, r233
+  Jump         L29
+L3:
+  // join cct2 in comp_cast_type on cct2.id == cc.status_id
+  Const        r234, 1
+  Add          r235, r44, r234
+  Move         r44, r235
+  Jump         L30
+L2:
+  // join cct1 in comp_cast_type on cct1.id == cc.subject_id
+  Const        r236, 1
+  Add          r237, r33, r236
+  Move         r33, r237
+  Jump         L31
+L1:
+  // from cc in complete_cast
+  Const        r238, 1
+  Add          r239, r27, r238
+  Move         r27, r239
+  Jump         L32
+L0:
+  // let matches =
+  Move         r240, r24
+  // movie_budget: min(from x in matches select x.budget),
+  Const        r241, "movie_budget"
+  Const        r242, []
+  IterPrep     r243, r240
+  Len          r244, r243
+  Const        r245, 0
+L34:
+  Less         r246, r245, r244
+  JumpIfFalse  r246, L33
+  Index        r247, r243, r245
+  Move         r248, r247
+  Const        r249, "budget"
+  Index        r250, r248, r249
+  Append       r251, r242, r250
+  Move         r242, r251
+  Const        r252, 1
+  Add          r253, r245, r252
+  Move         r245, r253
+  Jump         L34
+L33:
+  Min          r254, r242
+  // movie_votes: min(from x in matches select x.votes),
+  Const        r255, "movie_votes"
+  Const        r256, []
+  IterPrep     r257, r240
+  Len          r258, r257
+  Const        r259, 0
+L36:
+  Less         r260, r259, r258
+  JumpIfFalse  r260, L35
+  Index        r261, r257, r259
+  Move         r248, r261
+  Const        r262, "votes"
+  Index        r263, r248, r262
+  Append       r264, r256, r263
+  Move         r256, r264
+  Const        r265, 1
+  Add          r266, r259, r265
+  Move         r259, r266
+  Jump         L36
+L35:
+  Min          r267, r256
+  // writer: min(from x in matches select x.writer),
+  Const        r268, "writer"
+  Const        r269, []
+  IterPrep     r270, r240
+  Len          r271, r270
+  Const        r272, 0
+L38:
+  Less         r273, r272, r271
+  JumpIfFalse  r273, L37
+  Index        r274, r270, r272
+  Move         r248, r274
+  Const        r275, "writer"
+  Index        r276, r248, r275
+  Append       r277, r269, r276
+  Move         r269, r277
+  Const        r278, 1
+  Add          r279, r272, r278
+  Move         r272, r279
+  Jump         L38
+L37:
+  Min          r280, r269
+  // complete_violent_movie: min(from x in matches select x.movie)
+  Const        r281, "complete_violent_movie"
+  Const        r282, []
+  IterPrep     r283, r240
+  Len          r284, r283
+  Const        r285, 0
+L40:
+  Less         r286, r285, r284
+  JumpIfFalse  r286, L39
+  Index        r287, r283, r285
+  Move         r248, r287
+  Const        r288, "movie"
+  Index        r289, r248, r288
+  Append       r290, r282, r289
+  Move         r282, r290
+  Const        r291, 1
+  Add          r292, r285, r291
+  Move         r285, r292
+  Jump         L40
+L39:
+  Min          r293, r282
+  // movie_budget: min(from x in matches select x.budget),
+  Move         r294, r241
+  Move         r295, r254
+  // movie_votes: min(from x in matches select x.votes),
+  Move         r296, r255
+  Move         r297, r267
+  // writer: min(from x in matches select x.writer),
+  Move         r298, r268
+  Move         r299, r280
+  // complete_violent_movie: min(from x in matches select x.movie)
+  Move         r300, r281
+  Move         r301, r293
+  // {
+  MakeMap      r302, 4, r294
+  Move         r303, r302
+  // let result = [
+  MakeList     r304, 1, r303
+  Move         r305, r304
+  // json(result)
+  JSON         r305
+  // expect result == [
+  Const        r306, [{"complete_violent_movie": "Violent Horror", "movie_budget": "Horror", "movie_votes": 2000, "writer": "John Writer"}]
+  Equal        r307, r305, r306
+  Expect       r307
+  Return       r0

--- a/tests/dataset/job/out/q31.ir.out
+++ b/tests/dataset/job/out/q31.ir.out
@@ -1,0 +1,473 @@
+func main (regs=286)
+  // let cast_info = [
+  Const        r0, [{"movie_id": 1, "note": "(writer)", "person_id": 1}, {"movie_id": 2, "note": "(story)", "person_id": 2}, {"movie_id": 3, "note": "(writer)", "person_id": 3}]
+  Move         r1, r0
+  // let company_name = [
+  Const        r2, [{"id": 1, "name": "Lionsgate Pictures"}, {"id": 2, "name": "Other Studio"}]
+  Move         r3, r2
+  // let info_type = [
+  Const        r4, [{"id": 10, "info": "genres"}, {"id": 20, "info": "votes"}]
+  Move         r5, r4
+  // let keyword = [
+  Const        r6, [{"id": 100, "keyword": "murder"}, {"id": 200, "keyword": "comedy"}]
+  Move         r7, r6
+  // let movie_companies = [
+  Const        r8, [{"company_id": 1, "movie_id": 1}, {"company_id": 1, "movie_id": 2}, {"company_id": 2, "movie_id": 3}]
+  Move         r9, r8
+  // let movie_info = [
+  Const        r10, [{"info": "Horror", "info_type_id": 10, "movie_id": 1}, {"info": "Thriller", "info_type_id": 10, "movie_id": 2}, {"info": "Comedy", "info_type_id": 10, "movie_id": 3}]
+  Move         r11, r10
+  // let movie_info_idx = [
+  Const        r12, [{"info": 1000, "info_type_id": 20, "movie_id": 1}, {"info": 800, "info_type_id": 20, "movie_id": 2}, {"info": 500, "info_type_id": 20, "movie_id": 3}]
+  Move         r13, r12
+  // let movie_keyword = [
+  Const        r14, [{"keyword_id": 100, "movie_id": 1}, {"keyword_id": 100, "movie_id": 2}, {"keyword_id": 200, "movie_id": 3}]
+  Move         r15, r14
+  // let name = [
+  Const        r16, [{"gender": "m", "id": 1, "name": "Arthur"}, {"gender": "m", "id": 2, "name": "Bob"}, {"gender": "f", "id": 3, "name": "Carla"}]
+  Move         r17, r16
+  // let title = [
+  Const        r18, [{"id": 1, "title": "Alpha Horror"}, {"id": 2, "title": "Beta Blood"}, {"id": 3, "title": "Gamma Comedy"}]
+  Move         r19, r18
+  // from ci in cast_info
+  Const        r20, []
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L28:
+  Less         r24, r23, r22
+  JumpIfFalse  r24, L0
+  Index        r25, r21, r23
+  Move         r26, r25
+  // join n in name on n.id == ci.person_id
+  IterPrep     r27, r17
+  Len          r28, r27
+  Const        r29, 0
+L27:
+  Less         r30, r29, r28
+  JumpIfFalse  r30, L1
+  Index        r31, r27, r29
+  Move         r32, r31
+  Const        r33, "id"
+  Index        r34, r32, r33
+  Const        r35, "person_id"
+  Index        r36, r26, r35
+  Equal        r37, r34, r36
+  JumpIfFalse  r37, L2
+  // join t in title on t.id == ci.movie_id
+  IterPrep     r38, r19
+  Len          r39, r38
+  Const        r40, 0
+L26:
+  Less         r41, r40, r39
+  JumpIfFalse  r41, L2
+  Index        r42, r38, r40
+  Move         r43, r42
+  Const        r44, "id"
+  Index        r45, r43, r44
+  Const        r46, "movie_id"
+  Index        r47, r26, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L3
+  // join mi in movie_info on mi.movie_id == t.id
+  IterPrep     r49, r11
+  Len          r50, r49
+  Const        r51, 0
+L25:
+  Less         r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r53, r49, r51
+  Move         r54, r53
+  Const        r55, "movie_id"
+  Index        r56, r54, r55
+  Const        r57, "id"
+  Index        r58, r43, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  IterPrep     r60, r13
+  Len          r61, r60
+  Const        r62, 0
+L24:
+  Less         r63, r62, r61
+  JumpIfFalse  r63, L4
+  Index        r64, r60, r62
+  Move         r65, r64
+  Const        r66, "movie_id"
+  Index        r67, r65, r66
+  Const        r68, "id"
+  Index        r69, r43, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L5
+  // join mk in movie_keyword on mk.movie_id == t.id
+  IterPrep     r71, r15
+  Len          r72, r71
+  Const        r73, 0
+L23:
+  Less         r74, r73, r72
+  JumpIfFalse  r74, L5
+  Index        r75, r71, r73
+  Move         r76, r75
+  Const        r77, "movie_id"
+  Index        r78, r76, r77
+  Const        r79, "id"
+  Index        r80, r43, r79
+  Equal        r81, r78, r80
+  JumpIfFalse  r81, L6
+  // join k in keyword on k.id == mk.keyword_id
+  IterPrep     r82, r7
+  Len          r83, r82
+  Const        r84, 0
+L22:
+  Less         r85, r84, r83
+  JumpIfFalse  r85, L6
+  Index        r86, r82, r84
+  Move         r87, r86
+  Const        r88, "id"
+  Index        r89, r87, r88
+  Const        r90, "keyword_id"
+  Index        r91, r76, r90
+  Equal        r92, r89, r91
+  JumpIfFalse  r92, L7
+  // join mc in movie_companies on mc.movie_id == t.id
+  IterPrep     r93, r9
+  Len          r94, r93
+  Const        r95, 0
+L21:
+  Less         r96, r95, r94
+  JumpIfFalse  r96, L7
+  Index        r97, r93, r95
+  Move         r98, r97
+  Const        r99, "movie_id"
+  Index        r100, r98, r99
+  Const        r101, "id"
+  Index        r102, r43, r101
+  Equal        r103, r100, r102
+  JumpIfFalse  r103, L8
+  // join cn in company_name on cn.id == mc.company_id
+  IterPrep     r104, r3
+  Len          r105, r104
+  Const        r106, 0
+L20:
+  Less         r107, r106, r105
+  JumpIfFalse  r107, L8
+  Index        r108, r104, r106
+  Move         r109, r108
+  Const        r110, "id"
+  Index        r111, r109, r110
+  Const        r112, "company_id"
+  Index        r113, r98, r112
+  Equal        r114, r111, r113
+  JumpIfFalse  r114, L9
+  // join it1 in info_type on it1.id == mi.info_type_id
+  IterPrep     r115, r5
+  Len          r116, r115
+  Const        r117, 0
+L19:
+  Less         r118, r117, r116
+  JumpIfFalse  r118, L9
+  Index        r119, r115, r117
+  Move         r120, r119
+  Const        r121, "id"
+  Index        r122, r120, r121
+  Const        r123, "info_type_id"
+  Index        r124, r54, r123
+  Equal        r125, r122, r124
+  JumpIfFalse  r125, L10
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  IterPrep     r126, r5
+  Len          r127, r126
+  Const        r128, 0
+L18:
+  Less         r129, r128, r127
+  JumpIfFalse  r129, L10
+  Index        r130, r126, r128
+  Move         r131, r130
+  Const        r132, "id"
+  Index        r133, r131, r132
+  Const        r134, "info_type_id"
+  Index        r135, r65, r134
+  Equal        r136, r133, r135
+  JumpIfFalse  r136, L11
+  // where ci.note in [
+  Const        r137, "note"
+  Index        r138, r26, r137
+  Const        r139, ["(writer)", "(head writer)", "(written by)", "(story)", "(story editor)"]
+  In           r140, r138, r139
+  // it1.info == "genres" &&
+  Const        r141, "info"
+  Index        r142, r120, r141
+  Const        r143, "genres"
+  Equal        r144, r142, r143
+  // it2.info == "votes" &&
+  Const        r145, "info"
+  Index        r146, r131, r145
+  Const        r147, "votes"
+  Equal        r148, r146, r147
+  // k.keyword in [
+  Const        r149, "keyword"
+  Index        r150, r87, r149
+  Const        r151, ["murder", "violence", "blood", "gore", "death", "female-nudity", "hospital"]
+  In           r152, r150, r151
+  // mi.info in ["Horror", "Thriller"] &&
+  Const        r153, "info"
+  Index        r154, r54, r153
+  Const        r155, ["Horror", "Thriller"]
+  In           r156, r154, r155
+  // n.gender == "m"
+  Const        r157, "gender"
+  Index        r158, r32, r157
+  Const        r159, "m"
+  Equal        r160, r158, r159
+  // ] &&
+  Move         r161, r140
+  JumpIfFalse  r161, L12
+  Const        r162, "name"
+  Index        r163, r109, r162
+  // cn.name.starts_with("Lionsgate") &&
+  Const        r164, "Lionsgate"
+  Const        r165, 0
+  Len          r166, r164
+  Slice        r167, r163, r165, r166
+  Equal        r168, r167, r164
+  // ] &&
+  Move         r161, r168
+L12:
+  // cn.name.starts_with("Lionsgate") &&
+  Move         r169, r161
+  JumpIfFalse  r169, L13
+  Move         r169, r144
+L13:
+  // it1.info == "genres" &&
+  Move         r170, r169
+  JumpIfFalse  r170, L14
+  Move         r170, r148
+L14:
+  // it2.info == "votes" &&
+  Move         r171, r170
+  JumpIfFalse  r171, L15
+  Move         r171, r152
+L15:
+  // ] &&
+  Move         r172, r171
+  JumpIfFalse  r172, L16
+  Move         r172, r156
+L16:
+  // mi.info in ["Horror", "Thriller"] &&
+  Move         r173, r172
+  JumpIfFalse  r173, L17
+  Move         r173, r160
+L17:
+  // where ci.note in [
+  JumpIfFalse  r173, L11
+  // movie_budget: mi.info,
+  Const        r174, "movie_budget"
+  Const        r175, "info"
+  Index        r176, r54, r175
+  // movie_votes: mi_idx.info,
+  Const        r177, "movie_votes"
+  Const        r178, "info"
+  Index        r179, r65, r178
+  // writer: n.name,
+  Const        r180, "writer"
+  Const        r181, "name"
+  Index        r182, r32, r181
+  // violent_liongate_movie: t.title
+  Const        r183, "violent_liongate_movie"
+  Const        r184, "title"
+  Index        r185, r43, r184
+  // movie_budget: mi.info,
+  Move         r186, r174
+  Move         r187, r176
+  // movie_votes: mi_idx.info,
+  Move         r188, r177
+  Move         r189, r179
+  // writer: n.name,
+  Move         r190, r180
+  Move         r191, r182
+  // violent_liongate_movie: t.title
+  Move         r192, r183
+  Move         r193, r185
+  // select {
+  MakeMap      r194, 4, r186
+  // from ci in cast_info
+  Append       r195, r20, r194
+  Move         r20, r195
+L11:
+  // join it2 in info_type on it2.id == mi_idx.info_type_id
+  Const        r196, 1
+  Add          r197, r128, r196
+  Move         r128, r197
+  Jump         L18
+L10:
+  // join it1 in info_type on it1.id == mi.info_type_id
+  Const        r198, 1
+  Add          r199, r117, r198
+  Move         r117, r199
+  Jump         L19
+L9:
+  // join cn in company_name on cn.id == mc.company_id
+  Const        r200, 1
+  Add          r201, r106, r200
+  Move         r106, r201
+  Jump         L20
+L8:
+  // join mc in movie_companies on mc.movie_id == t.id
+  Const        r202, 1
+  Add          r203, r95, r202
+  Move         r95, r203
+  Jump         L21
+L7:
+  // join k in keyword on k.id == mk.keyword_id
+  Const        r204, 1
+  Add          r205, r84, r204
+  Move         r84, r205
+  Jump         L22
+L6:
+  // join mk in movie_keyword on mk.movie_id == t.id
+  Const        r206, 1
+  Add          r207, r73, r206
+  Move         r73, r207
+  Jump         L23
+L5:
+  // join mi_idx in movie_info_idx on mi_idx.movie_id == t.id
+  Const        r208, 1
+  Add          r209, r62, r208
+  Move         r62, r209
+  Jump         L24
+L4:
+  // join mi in movie_info on mi.movie_id == t.id
+  Const        r210, 1
+  Add          r211, r51, r210
+  Move         r51, r211
+  Jump         L25
+L3:
+  // join t in title on t.id == ci.movie_id
+  Const        r212, 1
+  Add          r213, r40, r212
+  Move         r40, r213
+  Jump         L26
+L2:
+  // join n in name on n.id == ci.person_id
+  Const        r214, 1
+  Add          r215, r29, r214
+  Move         r29, r215
+  Jump         L27
+L1:
+  // from ci in cast_info
+  Const        r216, 1
+  Add          r217, r23, r216
+  Move         r23, r217
+  Jump         L28
+L0:
+  // let matches =
+  Move         r218, r20
+  // movie_budget: min(from r in matches select r.movie_budget),
+  Const        r219, "movie_budget"
+  Const        r220, []
+  IterPrep     r221, r218
+  Len          r222, r221
+  Const        r223, 0
+L30:
+  Less         r224, r223, r222
+  JumpIfFalse  r224, L29
+  Index        r225, r221, r223
+  Move         r226, r225
+  Const        r227, "movie_budget"
+  Index        r228, r226, r227
+  Append       r229, r220, r228
+  Move         r220, r229
+  Const        r230, 1
+  Add          r231, r223, r230
+  Move         r223, r231
+  Jump         L30
+L29:
+  Min          r232, r220
+  // movie_votes: min(from r in matches select r.movie_votes),
+  Const        r233, "movie_votes"
+  Const        r234, []
+  IterPrep     r235, r218
+  Len          r236, r235
+  Const        r237, 0
+L32:
+  Less         r238, r237, r236
+  JumpIfFalse  r238, L31
+  Index        r239, r235, r237
+  Move         r226, r239
+  Const        r240, "movie_votes"
+  Index        r241, r226, r240
+  Append       r242, r234, r241
+  Move         r234, r242
+  Const        r243, 1
+  Add          r244, r237, r243
+  Move         r237, r244
+  Jump         L32
+L31:
+  Min          r245, r234
+  // writer: min(from r in matches select r.writer),
+  Const        r246, "writer"
+  Const        r247, []
+  IterPrep     r248, r218
+  Len          r249, r248
+  Const        r250, 0
+L34:
+  Less         r251, r250, r249
+  JumpIfFalse  r251, L33
+  Index        r252, r248, r250
+  Move         r226, r252
+  Const        r253, "writer"
+  Index        r254, r226, r253
+  Append       r255, r247, r254
+  Move         r247, r255
+  Const        r256, 1
+  Add          r257, r250, r256
+  Move         r250, r257
+  Jump         L34
+L33:
+  Min          r258, r247
+  // violent_liongate_movie: min(from r in matches select r.violent_liongate_movie)
+  Const        r259, "violent_liongate_movie"
+  Const        r260, []
+  IterPrep     r261, r218
+  Len          r262, r261
+  Const        r263, 0
+L36:
+  Less         r264, r263, r262
+  JumpIfFalse  r264, L35
+  Index        r265, r261, r263
+  Move         r226, r265
+  Const        r266, "violent_liongate_movie"
+  Index        r267, r226, r266
+  Append       r268, r260, r267
+  Move         r260, r268
+  Const        r269, 1
+  Add          r270, r263, r269
+  Move         r263, r270
+  Jump         L36
+L35:
+  Min          r271, r260
+  // movie_budget: min(from r in matches select r.movie_budget),
+  Move         r272, r219
+  Move         r273, r232
+  // movie_votes: min(from r in matches select r.movie_votes),
+  Move         r274, r233
+  Move         r275, r245
+  // writer: min(from r in matches select r.writer),
+  Move         r276, r246
+  Move         r277, r258
+  // violent_liongate_movie: min(from r in matches select r.violent_liongate_movie)
+  Move         r278, r259
+  Move         r279, r271
+  // {
+  MakeMap      r280, 4, r272
+  Move         r281, r280
+  // let result = [
+  MakeList     r282, 1, r281
+  Move         r283, r282
+  // json(result)
+  JSON         r283
+  // expect result == [
+  Const        r284, [{"movie_budget": "Horror", "movie_votes": 800, "violent_liongate_movie": "Alpha Horror", "writer": "Arthur"}]
+  Equal        r285, r283, r284
+  Expect       r285
+  Return       r0

--- a/tests/dataset/job/out/q32.ir.out
+++ b/tests/dataset/job/out/q32.ir.out
@@ -1,0 +1,250 @@
+func main (regs=158)
+  // let keyword = [
+  Const        r0, [{"id": 1, "keyword": "10,000-mile-club"}, {"id": 2, "keyword": "character-name-in-title"}]
+  Move         r1, r0
+  // let link_type = [
+  Const        r2, [{"id": 1, "link": "sequel"}, {"id": 2, "link": "remake"}]
+  Move         r3, r2
+  // let movie_keyword = [
+  Const        r4, [{"keyword_id": 1, "movie_id": 100}, {"keyword_id": 2, "movie_id": 200}]
+  Move         r5, r4
+  // let movie_link = [
+  Const        r6, [{"link_type_id": 1, "linked_movie_id": 300, "movie_id": 100}, {"link_type_id": 2, "linked_movie_id": 400, "movie_id": 200}]
+  Move         r7, r6
+  // let title = [
+  Const        r8, [{"id": 100, "title": "Movie A"}, {"id": 200, "title": "Movie B"}, {"id": 300, "title": "Movie C"}, {"id": 400, "title": "Movie D"}]
+  Move         r9, r8
+  // from k in keyword
+  Const        r10, []
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L12:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L0
+  Index        r15, r11, r13
+  Move         r16, r15
+  // join mk in movie_keyword on mk.keyword_id == k.id
+  IterPrep     r17, r5
+  Len          r18, r17
+  Const        r19, 0
+L11:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L1
+  Index        r21, r17, r19
+  Move         r22, r21
+  Const        r23, "keyword_id"
+  Index        r24, r22, r23
+  Const        r25, "id"
+  Index        r26, r16, r25
+  Equal        r27, r24, r26
+  JumpIfFalse  r27, L2
+  // join t1 in title on t1.id == mk.movie_id
+  IterPrep     r28, r9
+  Len          r29, r28
+  Const        r30, 0
+L10:
+  Less         r31, r30, r29
+  JumpIfFalse  r31, L2
+  Index        r32, r28, r30
+  Move         r33, r32
+  Const        r34, "id"
+  Index        r35, r33, r34
+  Const        r36, "movie_id"
+  Index        r37, r22, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L3
+  // join ml in movie_link on ml.movie_id == t1.id
+  IterPrep     r39, r7
+  Len          r40, r39
+  Const        r41, 0
+L9:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L3
+  Index        r43, r39, r41
+  Move         r44, r43
+  Const        r45, "movie_id"
+  Index        r46, r44, r45
+  Const        r47, "id"
+  Index        r48, r33, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L4
+  // join t2 in title on t2.id == ml.linked_movie_id
+  IterPrep     r50, r9
+  Len          r51, r50
+  Const        r52, 0
+L8:
+  Less         r53, r52, r51
+  JumpIfFalse  r53, L4
+  Index        r54, r50, r52
+  Move         r55, r54
+  Const        r56, "id"
+  Index        r57, r55, r56
+  Const        r58, "linked_movie_id"
+  Index        r59, r44, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L5
+  // join lt in link_type on lt.id == ml.link_type_id
+  IterPrep     r61, r3
+  Len          r62, r61
+  Const        r63, 0
+L7:
+  Less         r64, r63, r62
+  JumpIfFalse  r64, L5
+  Index        r65, r61, r63
+  Move         r66, r65
+  Const        r67, "id"
+  Index        r68, r66, r67
+  Const        r69, "link_type_id"
+  Index        r70, r44, r69
+  Equal        r71, r68, r70
+  JumpIfFalse  r71, L6
+  // where k.keyword == "10,000-mile-club"
+  Const        r72, "keyword"
+  Index        r73, r16, r72
+  Const        r74, "10,000-mile-club"
+  Equal        r75, r73, r74
+  JumpIfFalse  r75, L6
+  // select { link_type: lt.link, first_movie: t1.title, second_movie: t2.title }
+  Const        r76, "link_type"
+  Const        r77, "link"
+  Index        r78, r66, r77
+  Const        r79, "first_movie"
+  Const        r80, "title"
+  Index        r81, r33, r80
+  Const        r82, "second_movie"
+  Const        r83, "title"
+  Index        r84, r55, r83
+  Move         r85, r76
+  Move         r86, r78
+  Move         r87, r79
+  Move         r88, r81
+  Move         r89, r82
+  Move         r90, r84
+  MakeMap      r91, 3, r85
+  // from k in keyword
+  Append       r92, r10, r91
+  Move         r10, r92
+L6:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r93, 1
+  Add          r94, r63, r93
+  Move         r63, r94
+  Jump         L7
+L5:
+  // join t2 in title on t2.id == ml.linked_movie_id
+  Const        r95, 1
+  Add          r96, r52, r95
+  Move         r52, r96
+  Jump         L8
+L4:
+  // join ml in movie_link on ml.movie_id == t1.id
+  Const        r97, 1
+  Add          r98, r41, r97
+  Move         r41, r98
+  Jump         L9
+L3:
+  // join t1 in title on t1.id == mk.movie_id
+  Const        r99, 1
+  Add          r100, r30, r99
+  Move         r30, r100
+  Jump         L10
+L2:
+  // join mk in movie_keyword on mk.keyword_id == k.id
+  Const        r101, 1
+  Add          r102, r19, r101
+  Move         r19, r102
+  Jump         L11
+L1:
+  // from k in keyword
+  Const        r103, 1
+  Add          r104, r13, r103
+  Move         r13, r104
+  Jump         L12
+L0:
+  // let joined =
+  Move         r105, r10
+  // link_type: min(from r in joined select r.link_type),
+  Const        r106, "link_type"
+  Const        r107, []
+  IterPrep     r108, r105
+  Len          r109, r108
+  Const        r110, 0
+L14:
+  Less         r111, r110, r109
+  JumpIfFalse  r111, L13
+  Index        r112, r108, r110
+  Move         r113, r112
+  Const        r114, "link_type"
+  Index        r115, r113, r114
+  Append       r116, r107, r115
+  Move         r107, r116
+  Const        r117, 1
+  Add          r118, r110, r117
+  Move         r110, r118
+  Jump         L14
+L13:
+  Min          r119, r107
+  // first_movie: min(from r in joined select r.first_movie),
+  Const        r120, "first_movie"
+  Const        r121, []
+  IterPrep     r122, r105
+  Len          r123, r122
+  Const        r124, 0
+L16:
+  Less         r125, r124, r123
+  JumpIfFalse  r125, L15
+  Index        r126, r122, r124
+  Move         r113, r126
+  Const        r127, "first_movie"
+  Index        r128, r113, r127
+  Append       r129, r121, r128
+  Move         r121, r129
+  Const        r130, 1
+  Add          r131, r124, r130
+  Move         r124, r131
+  Jump         L16
+L15:
+  Min          r132, r121
+  // second_movie: min(from r in joined select r.second_movie)
+  Const        r133, "second_movie"
+  Const        r134, []
+  IterPrep     r135, r105
+  Len          r136, r135
+  Const        r137, 0
+L18:
+  Less         r138, r137, r136
+  JumpIfFalse  r138, L17
+  Index        r139, r135, r137
+  Move         r113, r139
+  Const        r140, "second_movie"
+  Index        r141, r113, r140
+  Append       r142, r134, r141
+  Move         r134, r142
+  Const        r143, 1
+  Add          r144, r137, r143
+  Move         r137, r144
+  Jump         L18
+L17:
+  Min          r145, r134
+  // link_type: min(from r in joined select r.link_type),
+  Move         r146, r106
+  Move         r147, r119
+  // first_movie: min(from r in joined select r.first_movie),
+  Move         r148, r120
+  Move         r149, r132
+  // second_movie: min(from r in joined select r.second_movie)
+  Move         r150, r133
+  Move         r151, r145
+  // let result = {
+  MakeMap      r152, 3, r146
+  Move         r153, r152
+  // json([result])
+  Move         r154, r153
+  MakeList     r155, 1, r154
+  JSON         r155
+  // expect result == {
+  Const        r156, {"first_movie": "Movie A", "link_type": "sequel", "second_movie": "Movie C"}
+  Equal        r157, r153, r156
+  Expect       r157
+  Return       r0

--- a/tests/dataset/job/out/q33.ir.out
+++ b/tests/dataset/job/out/q33.ir.out
@@ -1,0 +1,625 @@
+func main (regs=378)
+  // let company_name = [
+  Const        r0, [{"country_code": "[us]", "id": 1, "name": "US Studio"}, {"country_code": "[gb]", "id": 2, "name": "GB Studio"}]
+  Move         r1, r0
+  // let info_type = [
+  Const        r2, [{"id": 1, "info": "rating"}, {"id": 2, "info": "other"}]
+  Move         r3, r2
+  // let kind_type = [
+  Const        r4, [{"id": 1, "kind": "tv series"}, {"id": 2, "kind": "movie"}]
+  Move         r5, r4
+  // let link_type = [
+  Const        r6, [{"id": 1, "link": "follows"}, {"id": 2, "link": "remake of"}]
+  Move         r7, r6
+  // let movie_companies = [
+  Const        r8, [{"company_id": 1, "movie_id": 10}, {"company_id": 2, "movie_id": 20}]
+  Move         r9, r8
+  // let movie_info_idx = [
+  Const        r10, [{"info": "7.0", "info_type_id": 1, "movie_id": 10}, {"info": "2.5", "info_type_id": 1, "movie_id": 20}]
+  Move         r11, r10
+  // let movie_link = [
+  Const        r12, [{"link_type_id": 1, "linked_movie_id": 20, "movie_id": 10}]
+  Move         r13, r12
+  // let title = [
+  Const        r14, [{"id": 10, "kind_id": 1, "production_year": 2004, "title": "Series A"}, {"id": 20, "kind_id": 1, "production_year": 2006, "title": "Series B"}]
+  Move         r15, r14
+  // from cn1 in company_name
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, 0
+L38:
+  Less         r20, r19, r18
+  JumpIfFalse  r20, L0
+  Index        r21, r17, r19
+  Move         r22, r21
+  // join mc1 in movie_companies on cn1.id == mc1.company_id
+  IterPrep     r23, r9
+  Len          r24, r23
+  Const        r25, 0
+L37:
+  Less         r26, r25, r24
+  JumpIfFalse  r26, L1
+  Index        r27, r23, r25
+  Move         r28, r27
+  Const        r29, "id"
+  Index        r30, r22, r29
+  Const        r31, "company_id"
+  Index        r32, r28, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join t1 in title on t1.id == mc1.movie_id
+  IterPrep     r34, r15
+  Len          r35, r34
+  Const        r36, 0
+L36:
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L2
+  Index        r38, r34, r36
+  Move         r39, r38
+  Const        r40, "id"
+  Index        r41, r39, r40
+  Const        r42, "movie_id"
+  Index        r43, r28, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L3
+  // join mi_idx1 in movie_info_idx on mi_idx1.movie_id == t1.id
+  IterPrep     r45, r11
+  Len          r46, r45
+  Const        r47, 0
+L35:
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L3
+  Index        r49, r45, r47
+  Move         r50, r49
+  Const        r51, "movie_id"
+  Index        r52, r50, r51
+  Const        r53, "id"
+  Index        r54, r39, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L4
+  // join it1 in info_type on it1.id == mi_idx1.info_type_id
+  IterPrep     r56, r3
+  Len          r57, r56
+  Const        r58, 0
+L34:
+  Less         r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r60, r56, r58
+  Move         r61, r60
+  Const        r62, "id"
+  Index        r63, r61, r62
+  Const        r64, "info_type_id"
+  Index        r65, r50, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L5
+  // join kt1 in kind_type on kt1.id == t1.kind_id
+  IterPrep     r67, r5
+  Len          r68, r67
+  Const        r69, 0
+L33:
+  Less         r70, r69, r68
+  JumpIfFalse  r70, L5
+  Index        r71, r67, r69
+  Move         r72, r71
+  Const        r73, "id"
+  Index        r74, r72, r73
+  Const        r75, "kind_id"
+  Index        r76, r39, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L6
+  // join ml in movie_link on ml.movie_id == t1.id
+  IterPrep     r78, r13
+  Len          r79, r78
+  Const        r80, 0
+L32:
+  Less         r81, r80, r79
+  JumpIfFalse  r81, L6
+  Index        r82, r78, r80
+  Move         r83, r82
+  Const        r84, "movie_id"
+  Index        r85, r83, r84
+  Const        r86, "id"
+  Index        r87, r39, r86
+  Equal        r88, r85, r87
+  JumpIfFalse  r88, L7
+  // join t2 in title on t2.id == ml.linked_movie_id
+  IterPrep     r89, r15
+  Len          r90, r89
+  Const        r91, 0
+L31:
+  Less         r92, r91, r90
+  JumpIfFalse  r92, L7
+  Index        r93, r89, r91
+  Move         r94, r93
+  Const        r95, "id"
+  Index        r96, r94, r95
+  Const        r97, "linked_movie_id"
+  Index        r98, r83, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L8
+  // join mi_idx2 in movie_info_idx on mi_idx2.movie_id == t2.id
+  IterPrep     r100, r11
+  Len          r101, r100
+  Const        r102, 0
+L30:
+  Less         r103, r102, r101
+  JumpIfFalse  r103, L8
+  Index        r104, r100, r102
+  Move         r105, r104
+  Const        r106, "movie_id"
+  Index        r107, r105, r106
+  Const        r108, "id"
+  Index        r109, r94, r108
+  Equal        r110, r107, r109
+  JumpIfFalse  r110, L9
+  // join it2 in info_type on it2.id == mi_idx2.info_type_id
+  IterPrep     r111, r3
+  Len          r112, r111
+  Const        r113, 0
+L29:
+  Less         r114, r113, r112
+  JumpIfFalse  r114, L9
+  Index        r115, r111, r113
+  Move         r116, r115
+  Const        r117, "id"
+  Index        r118, r116, r117
+  Const        r119, "info_type_id"
+  Index        r120, r105, r119
+  Equal        r121, r118, r120
+  JumpIfFalse  r121, L10
+  // join kt2 in kind_type on kt2.id == t2.kind_id
+  IterPrep     r122, r5
+  Len          r123, r122
+  Const        r124, 0
+L28:
+  Less         r125, r124, r123
+  JumpIfFalse  r125, L10
+  Index        r126, r122, r124
+  Move         r127, r126
+  Const        r128, "id"
+  Index        r129, r127, r128
+  Const        r130, "kind_id"
+  Index        r131, r94, r130
+  Equal        r132, r129, r131
+  JumpIfFalse  r132, L11
+  // join mc2 in movie_companies on mc2.movie_id == t2.id
+  IterPrep     r133, r9
+  Len          r134, r133
+  Const        r135, 0
+L27:
+  Less         r136, r135, r134
+  JumpIfFalse  r136, L11
+  Index        r137, r133, r135
+  Move         r138, r137
+  Const        r139, "movie_id"
+  Index        r140, r138, r139
+  Const        r141, "id"
+  Index        r142, r94, r141
+  Equal        r143, r140, r142
+  JumpIfFalse  r143, L12
+  // join cn2 in company_name on cn2.id == mc2.company_id
+  IterPrep     r144, r1
+  Len          r145, r144
+  Const        r146, 0
+L26:
+  Less         r147, r146, r145
+  JumpIfFalse  r147, L12
+  Index        r148, r144, r146
+  Move         r149, r148
+  Const        r150, "id"
+  Index        r151, r149, r150
+  Const        r152, "company_id"
+  Index        r153, r138, r152
+  Equal        r154, r151, r153
+  JumpIfFalse  r154, L13
+  // join lt in link_type on lt.id == ml.link_type_id
+  IterPrep     r155, r7
+  Len          r156, r155
+  Const        r157, 0
+L25:
+  Less         r158, r157, r156
+  JumpIfFalse  r158, L13
+  Index        r159, r155, r157
+  Move         r160, r159
+  Const        r161, "id"
+  Index        r162, r160, r161
+  Const        r163, "link_type_id"
+  Index        r164, r83, r163
+  Equal        r165, r162, r164
+  JumpIfFalse  r165, L14
+  // where cn1.country_code == "[us]" &&
+  Const        r166, "country_code"
+  Index        r167, r22, r166
+  // mi_idx2.info < "3.0" &&
+  Const        r168, "info"
+  Index        r169, r105, r168
+  Const        r170, "3.0"
+  Less         r171, r169, r170
+  // t2.production_year >= 2005 && t2.production_year <= 2008
+  Const        r172, "production_year"
+  Index        r173, r94, r172
+  Const        r174, 2005
+  LessEq       r175, r174, r173
+  Const        r176, "production_year"
+  Index        r177, r94, r176
+  Const        r178, 2008
+  LessEq       r179, r177, r178
+  // where cn1.country_code == "[us]" &&
+  Const        r180, "[us]"
+  Equal        r181, r167, r180
+  // it1.info == "rating" &&
+  Const        r182, "info"
+  Index        r183, r61, r182
+  Const        r184, "rating"
+  Equal        r185, r183, r184
+  // it2.info == "rating" &&
+  Const        r186, "info"
+  Index        r187, r116, r186
+  Const        r188, "rating"
+  Equal        r189, r187, r188
+  // kt1.kind == "tv series" &&
+  Const        r190, "kind"
+  Index        r191, r72, r190
+  Const        r192, "tv series"
+  Equal        r193, r191, r192
+  // kt2.kind == "tv series" &&
+  Const        r194, "kind"
+  Index        r195, r127, r194
+  Const        r196, "tv series"
+  Equal        r197, r195, r196
+  // where cn1.country_code == "[us]" &&
+  Move         r198, r181
+  JumpIfFalse  r198, L15
+  Move         r198, r185
+L15:
+  // it1.info == "rating" &&
+  Move         r199, r198
+  JumpIfFalse  r199, L16
+  Move         r199, r189
+L16:
+  // it2.info == "rating" &&
+  Move         r200, r199
+  JumpIfFalse  r200, L17
+  Move         r200, r193
+L17:
+  // kt1.kind == "tv series" &&
+  Move         r201, r200
+  JumpIfFalse  r201, L18
+  Move         r201, r197
+L18:
+  // kt2.kind == "tv series" &&
+  Move         r202, r201
+  JumpIfFalse  r202, L19
+  // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
+  Const        r203, "link"
+  Index        r204, r160, r203
+  Const        r205, "sequel"
+  Equal        r206, r204, r205
+  Const        r207, "link"
+  Index        r208, r160, r207
+  Const        r209, "follows"
+  Equal        r210, r208, r209
+  Const        r211, "link"
+  Index        r212, r160, r211
+  Const        r213, "followed by"
+  Equal        r214, r212, r213
+  Move         r215, r206
+  JumpIfTrue   r215, L20
+  Move         r215, r210
+L20:
+  Move         r216, r215
+  JumpIfTrue   r216, L21
+  Move         r216, r214
+L21:
+  // kt2.kind == "tv series" &&
+  Move         r202, r216
+L19:
+  // (lt.link == "sequel" || lt.link == "follows" || lt.link == "followed by") &&
+  Move         r217, r202
+  JumpIfFalse  r217, L22
+  Move         r217, r171
+L22:
+  // mi_idx2.info < "3.0" &&
+  Move         r218, r217
+  JumpIfFalse  r218, L23
+  Move         r218, r175
+L23:
+  // t2.production_year >= 2005 && t2.production_year <= 2008
+  Move         r219, r218
+  JumpIfFalse  r219, L24
+  Move         r219, r179
+L24:
+  // where cn1.country_code == "[us]" &&
+  JumpIfFalse  r219, L14
+  // first_company: cn1.name,
+  Const        r220, "first_company"
+  Const        r221, "name"
+  Index        r222, r22, r221
+  // second_company: cn2.name,
+  Const        r223, "second_company"
+  Const        r224, "name"
+  Index        r225, r149, r224
+  // first_rating: mi_idx1.info,
+  Const        r226, "first_rating"
+  Const        r227, "info"
+  Index        r228, r50, r227
+  // second_rating: mi_idx2.info,
+  Const        r229, "second_rating"
+  Const        r230, "info"
+  Index        r231, r105, r230
+  // first_movie: t1.title,
+  Const        r232, "first_movie"
+  Const        r233, "title"
+  Index        r234, r39, r233
+  // second_movie: t2.title
+  Const        r235, "second_movie"
+  Const        r236, "title"
+  Index        r237, r94, r236
+  // first_company: cn1.name,
+  Move         r238, r220
+  Move         r239, r222
+  // second_company: cn2.name,
+  Move         r240, r223
+  Move         r241, r225
+  // first_rating: mi_idx1.info,
+  Move         r242, r226
+  Move         r243, r228
+  // second_rating: mi_idx2.info,
+  Move         r244, r229
+  Move         r245, r231
+  // first_movie: t1.title,
+  Move         r246, r232
+  Move         r247, r234
+  // second_movie: t2.title
+  Move         r248, r235
+  Move         r249, r237
+  // select {
+  MakeMap      r250, 6, r238
+  // from cn1 in company_name
+  Append       r251, r16, r250
+  Move         r16, r251
+L14:
+  // join lt in link_type on lt.id == ml.link_type_id
+  Const        r252, 1
+  Add          r253, r157, r252
+  Move         r157, r253
+  Jump         L25
+L13:
+  // join cn2 in company_name on cn2.id == mc2.company_id
+  Const        r254, 1
+  Add          r255, r146, r254
+  Move         r146, r255
+  Jump         L26
+L12:
+  // join mc2 in movie_companies on mc2.movie_id == t2.id
+  Const        r256, 1
+  Add          r257, r135, r256
+  Move         r135, r257
+  Jump         L27
+L11:
+  // join kt2 in kind_type on kt2.id == t2.kind_id
+  Const        r258, 1
+  Add          r259, r124, r258
+  Move         r124, r259
+  Jump         L28
+L10:
+  // join it2 in info_type on it2.id == mi_idx2.info_type_id
+  Const        r260, 1
+  Add          r261, r113, r260
+  Move         r113, r261
+  Jump         L29
+L9:
+  // join mi_idx2 in movie_info_idx on mi_idx2.movie_id == t2.id
+  Const        r262, 1
+  Add          r263, r102, r262
+  Move         r102, r263
+  Jump         L30
+L8:
+  // join t2 in title on t2.id == ml.linked_movie_id
+  Const        r264, 1
+  Add          r265, r91, r264
+  Move         r91, r265
+  Jump         L31
+L7:
+  // join ml in movie_link on ml.movie_id == t1.id
+  Const        r266, 1
+  Add          r267, r80, r266
+  Move         r80, r267
+  Jump         L32
+L6:
+  // join kt1 in kind_type on kt1.id == t1.kind_id
+  Const        r268, 1
+  Add          r269, r69, r268
+  Move         r69, r269
+  Jump         L33
+L5:
+  // join it1 in info_type on it1.id == mi_idx1.info_type_id
+  Const        r270, 1
+  Add          r271, r58, r270
+  Move         r58, r271
+  Jump         L34
+L4:
+  // join mi_idx1 in movie_info_idx on mi_idx1.movie_id == t1.id
+  Const        r272, 1
+  Add          r273, r47, r272
+  Move         r47, r273
+  Jump         L35
+L3:
+  // join t1 in title on t1.id == mc1.movie_id
+  Const        r274, 1
+  Add          r275, r36, r274
+  Move         r36, r275
+  Jump         L36
+L2:
+  // join mc1 in movie_companies on cn1.id == mc1.company_id
+  Const        r276, 1
+  Add          r277, r25, r276
+  Move         r25, r277
+  Jump         L37
+L1:
+  // from cn1 in company_name
+  Const        r278, 1
+  Add          r279, r19, r278
+  Move         r19, r279
+  Jump         L38
+L0:
+  // let rows =
+  Move         r280, r16
+  // first_company: min(from r in rows select r.first_company),
+  Const        r281, "first_company"
+  Const        r282, []
+  IterPrep     r283, r280
+  Len          r284, r283
+  Const        r285, 0
+L40:
+  Less         r286, r285, r284
+  JumpIfFalse  r286, L39
+  Index        r287, r283, r285
+  Move         r288, r287
+  Const        r289, "first_company"
+  Index        r290, r288, r289
+  Append       r291, r282, r290
+  Move         r282, r291
+  Const        r292, 1
+  Add          r293, r285, r292
+  Move         r285, r293
+  Jump         L40
+L39:
+  Min          r294, r282
+  // second_company: min(from r in rows select r.second_company),
+  Const        r295, "second_company"
+  Const        r296, []
+  IterPrep     r297, r280
+  Len          r298, r297
+  Const        r299, 0
+L42:
+  Less         r300, r299, r298
+  JumpIfFalse  r300, L41
+  Index        r301, r297, r299
+  Move         r288, r301
+  Const        r302, "second_company"
+  Index        r303, r288, r302
+  Append       r304, r296, r303
+  Move         r296, r304
+  Const        r305, 1
+  Add          r306, r299, r305
+  Move         r299, r306
+  Jump         L42
+L41:
+  Min          r307, r296
+  // first_rating: min(from r in rows select r.first_rating),
+  Const        r308, "first_rating"
+  Const        r309, []
+  IterPrep     r310, r280
+  Len          r311, r310
+  Const        r312, 0
+L44:
+  Less         r313, r312, r311
+  JumpIfFalse  r313, L43
+  Index        r314, r310, r312
+  Move         r288, r314
+  Const        r315, "first_rating"
+  Index        r316, r288, r315
+  Append       r317, r309, r316
+  Move         r309, r317
+  Const        r318, 1
+  Add          r319, r312, r318
+  Move         r312, r319
+  Jump         L44
+L43:
+  Min          r320, r309
+  // second_rating: min(from r in rows select r.second_rating),
+  Const        r321, "second_rating"
+  Const        r322, []
+  IterPrep     r323, r280
+  Len          r324, r323
+  Const        r325, 0
+L46:
+  Less         r326, r325, r324
+  JumpIfFalse  r326, L45
+  Index        r327, r323, r325
+  Move         r288, r327
+  Const        r328, "second_rating"
+  Index        r329, r288, r328
+  Append       r330, r322, r329
+  Move         r322, r330
+  Const        r331, 1
+  Add          r332, r325, r331
+  Move         r325, r332
+  Jump         L46
+L45:
+  Min          r333, r322
+  // first_movie: min(from r in rows select r.first_movie),
+  Const        r334, "first_movie"
+  Const        r335, []
+  IterPrep     r336, r280
+  Len          r337, r336
+  Const        r338, 0
+L48:
+  Less         r339, r338, r337
+  JumpIfFalse  r339, L47
+  Index        r340, r336, r338
+  Move         r288, r340
+  Const        r341, "first_movie"
+  Index        r342, r288, r341
+  Append       r343, r335, r342
+  Move         r335, r343
+  Const        r344, 1
+  Add          r345, r338, r344
+  Move         r338, r345
+  Jump         L48
+L47:
+  Min          r346, r335
+  // second_movie: min(from r in rows select r.second_movie)
+  Const        r347, "second_movie"
+  Const        r348, []
+  IterPrep     r349, r280
+  Len          r350, r349
+  Const        r351, 0
+L50:
+  Less         r352, r351, r350
+  JumpIfFalse  r352, L49
+  Index        r353, r349, r351
+  Move         r288, r353
+  Const        r354, "second_movie"
+  Index        r355, r288, r354
+  Append       r356, r348, r355
+  Move         r348, r356
+  Const        r357, 1
+  Add          r358, r351, r357
+  Move         r351, r358
+  Jump         L50
+L49:
+  Min          r359, r348
+  // first_company: min(from r in rows select r.first_company),
+  Move         r360, r281
+  Move         r361, r294
+  // second_company: min(from r in rows select r.second_company),
+  Move         r362, r295
+  Move         r363, r307
+  // first_rating: min(from r in rows select r.first_rating),
+  Move         r364, r308
+  Move         r365, r320
+  // second_rating: min(from r in rows select r.second_rating),
+  Move         r366, r321
+  Move         r367, r333
+  // first_movie: min(from r in rows select r.first_movie),
+  Move         r368, r334
+  Move         r369, r346
+  // second_movie: min(from r in rows select r.second_movie)
+  Move         r370, r347
+  Move         r371, r359
+  // {
+  MakeMap      r372, 6, r360
+  Move         r373, r372
+  // let result = [
+  MakeList     r374, 1, r373
+  Move         r375, r374
+  // json(result)
+  JSON         r375
+  // expect result == [
+  Const        r376, [{"first_company": "US Studio", "first_movie": "Series A", "first_rating": "7.0", "second_company": "GB Studio", "second_movie": "Series B", "second_rating": "2.5"}]
+  Equal        r377, r375, r376
+  Expect       r377
+  Return       r0

--- a/tests/dataset/job/q22.mochi
+++ b/tests/dataset/job/q22.mochi
@@ -65,7 +65,7 @@ let rows =
     it2.info == "rating" &&
     (k.keyword == "murder" || k.keyword == "murder-in-title" || k.keyword == "blood" || k.keyword == "violence") &&
     (kt.kind == "movie" || kt.kind == "episode") &&
-    !(mc.note.contains("(USA)")) &&
+    mc.note.contains("(USA)") == false &&
     mc.note.contains("(200") &&
     (mi.info == "Germany" || mi.info == "German" || mi.info == "USA" || mi.info == "American") &&
     mi_idx.info < 7.0 &&

--- a/tests/dataset/job/q26.mochi
+++ b/tests/dataset/job/q26.mochi
@@ -71,7 +71,7 @@ let rows =
   join it2 in info_type on it2.id == mi_idx.info_type_id
   where cct1.kind == "cast" &&
         cct2.kind.contains("complete") &&
-        chn.name != nil &&
+        chn.name != null &&
         (chn.name.contains("man") || chn.name.contains("Man")) &&
         it2.info == "rating" &&
         (k.keyword in allowed_keywords) &&

--- a/tests/dataset/job/q28.mochi
+++ b/tests/dataset/job/q28.mochi
@@ -89,7 +89,7 @@ let matches =
     it2.info == "rating" &&
     (k.keyword in allowed_keywords) &&
     (kt.kind in ["movie", "episode"]) &&
-    !mc.note.contains("(USA)") &&
+    mc.note.contains("(USA)") == false &&
     mc.note.contains("(200") &&
     (mi.info in allowed_countries) &&
     mi_idx.info < 8.5 &&


### PR DESCRIPTION
## Summary
- generate IR for job dataset queries q21-q33
- fix query syntax in q22, q26 and q28 to allow compilation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e723cdff88320ae0e66b553ca0c59