### PR TITLE
Add Erlang job dataset tests

### DIFF
--- a/compile/x/erlang/compiler.go
+++ b/compile/x/erlang/compiler.go
@@ -24,6 +24,8 @@ type Compiler struct {
 	needInput     bool
 	needAvg       bool
 	needSum       bool
+	needMin       bool
+	needMax       bool
 	needForeach   bool
 	needWhile     bool
 	needExpect    bool
@@ -1088,6 +1090,12 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 			case "sum":
 				c.needSum = true
 				res = fmt.Sprintf("mochi_sum(%s)", argStr)
+			case "min":
+				c.needMin = true
+				res = fmt.Sprintf("mochi_min(%s)", argStr)
+			case "max":
+				c.needMax = true
+				res = fmt.Sprintf("mochi_max(%s)", argStr)
 			case "input":
 				c.needInput = true
 				res = "mochi_input()"
@@ -1278,6 +1286,12 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		case "sum":
 			c.needSum = true
 			return fmt.Sprintf("mochi_sum(%s)", argStr), nil
+		case "min":
+			c.needMin = true
+			return fmt.Sprintf("mochi_min(%s)", argStr), nil
+		case "max":
+			c.needMax = true
+			return fmt.Sprintf("mochi_max(%s)", argStr), nil
 		case "input":
 			c.needInput = true
 			return "mochi_input()", nil

--- a/compile/x/erlang/runtime.go
+++ b/compile/x/erlang/runtime.go
@@ -87,6 +87,38 @@ func (c *Compiler) emitRuntime() {
 		c.writeln("")
 	}
 
+	if c.needMin {
+		c.writeln("mochi_min([]) -> 0;")
+		c.writeln("mochi_min(M) when is_map(M) ->")
+		c.indent++
+		c.writeln("case maps:find('Items', M) of")
+		c.indent++
+		c.writeln("{ok, Items} -> mochi_min(Items);")
+		c.writeln("error -> erlang:error(badarg)")
+		c.indent--
+		c.writeln("end;")
+		c.indent--
+		c.writeln("mochi_min(L) when is_list(L) -> lists:min(L);")
+		c.writeln("mochi_min(_) -> erlang:error(badarg).")
+		c.writeln("")
+	}
+
+	if c.needMax {
+		c.writeln("mochi_max([]) -> 0;")
+		c.writeln("mochi_max(M) when is_map(M) ->")
+		c.indent++
+		c.writeln("case maps:find('Items', M) of")
+		c.indent++
+		c.writeln("{ok, Items} -> mochi_max(Items);")
+		c.writeln("error -> erlang:error(badarg)")
+		c.indent--
+		c.writeln("end;")
+		c.indent--
+		c.writeln("mochi_max(L) when is_list(L) -> lists:max(L);")
+		c.writeln("mochi_max(_) -> erlang:error(badarg).")
+		c.writeln("")
+	}
+
 	if c.needForeach {
 		c.writeln("mochi_foreach(F, L) ->")
 		c.indent++

--- a/tests/dataset/job/compiler/erlang/q1.erl.out
+++ b/tests/dataset/job/compiler/erlang/q1.erl.out
@@ -12,10 +12,19 @@ main(_) ->
     Movie_companies = [#{movie_id => 100, company_type_id => 1, note => "ACME (co-production)"}, #{movie_id => 200, company_type_id => 1, note => "MGM (as Metro-Goldwyn-Mayer Pictures)"}],
     Movie_info_idx = [#{movie_id => 100, info_type_id => 10}, #{movie_id => 200, info_type_id => 20}],
     Filtered = [#{note => maps:get(note, Mc), title => maps:get(title, T), year => maps:get(production_year, T)} || Ct <- Company_type, Mc <- Movie_companies, T <- Title, Mi <- Movie_info_idx, It <- Info_type, (maps:get(id, Ct) == maps:get(company_type_id, Mc)), (maps:get(id, T) == maps:get(movie_id, Mc)), (maps:get(movie_id, Mi) == maps:get(id, T)), (maps:get(id, It) == maps:get(info_type_id, Mi)), ((((maps:get(kind, Ct) == "production companies") and (maps:get(info, It) == "top 250 rank")) and not lists:member("(as Metro-Goldwyn-Mayer Pictures)", maps:get(note, Mc))) and (lists:member("(co-production)", maps:get(note, Mc)) or lists:member("(presents)", maps:get(note, Mc))))],
-    Result = #{production_note => min([maps:get(note, R) || R <- Filtered]), movie_title => min([maps:get(title, R) || R <- Filtered]), movie_year => min([maps:get(year, R) || R <- Filtered])},
+    Result = #{production_note => mochi_min([maps:get(note, R) || R <- Filtered]), movie_title => mochi_min([maps:get(title, R) || R <- Filtered]), movie_year => mochi_min([maps:get(year, R) || R <- Filtered])},
     mochi_json([Result])
 ,
     mochi_run_test("Q1 returns min note, title and year for top ranked co-production", fun test_q1_returns_min_note__title_and_year_for_top_ranked_co_production/0).
+
+mochi_min([]) -> 0;
+mochi_min(M) when is_map(M) ->
+    case maps:find('Items', M) of
+        {ok, Items} -> mochi_min(Items);
+        error -> erlang:error(badarg)
+    end;
+mochi_min(L) when is_list(L) -> lists:min(L);
+mochi_min(_) -> erlang:error(badarg).
 
 
 mochi_escape_json([]) -> [];

--- a/tests/dataset/job/compiler/erlang/q2.erl.out
+++ b/tests/dataset/job/compiler/erlang/q2.erl.out
@@ -1,0 +1,65 @@
+#!/usr/bin/env escript
+-module(main).
+-export([main/1, test_q2_finds_earliest_title_for_german_companies_with_character_keyword/0]).
+
+test_q2_finds_earliest_title_for_german_companies_with_character_keyword() ->
+    mochi_expect((Result == "Der Film")).
+
+main(_) ->
+    Company_name = [#{id => 1, country_code => "[de]"}, #{id => 2, country_code => "[us]"}],
+    Keyword = [#{id => 1, keyword => "character-name-in-title"}, #{id => 2, keyword => "other"}],
+    Movie_companies = [#{movie_id => 100, company_id => 1}, #{movie_id => 200, company_id => 2}],
+    Movie_keyword = [#{movie_id => 100, keyword_id => 1}, #{movie_id => 200, keyword_id => 2}],
+    Title = [#{id => 100, title => "Der Film"}, #{id => 200, title => "Other Movie"}],
+    Titles = [maps:get(title, T) || Cn <- Company_name, Mc <- Movie_companies, T <- Title, Mk <- Movie_keyword, K <- Keyword, (maps:get(company_id, Mc) == maps:get(id, Cn)), (maps:get(movie_id, Mc) == maps:get(id, T)), (maps:get(movie_id, Mk) == maps:get(id, T)), (maps:get(keyword_id, Mk) == maps:get(id, K)), (((maps:get(country_code, Cn) == "[de]") and (maps:get(keyword, K) == "character-name-in-title")) and (maps:get(movie_id, Mc) == maps:get(movie_id, Mk)))],
+    Result = mochi_min(Titles),
+    mochi_json(Result)
+,
+    mochi_run_test("Q2 finds earliest title for German companies with character keyword", fun test_q2_finds_earliest_title_for_german_companies_with_character_keyword/0).
+
+mochi_min([]) -> 0;
+mochi_min(M) when is_map(M) ->
+    case maps:find('Items', M) of
+        {ok, Items} -> mochi_min(Items);
+        error -> erlang:error(badarg)
+    end;
+mochi_min(L) when is_list(L) -> lists:min(L);
+mochi_min(_) -> erlang:error(badarg).
+
+
+mochi_escape_json([]) -> [];
+mochi_escape_json([H|T]) ->
+    E = case H of
+        $\\ -> "\\\\";
+        $" -> "\\"";
+        _ -> [H]
+    end,
+    E ++ mochi_escape_json(T).
+
+mochi_to_json(true) -> "true";
+mochi_to_json(false) -> "false";
+mochi_to_json(V) when is_integer(V); is_float(V) -> lists:flatten(io_lib:format("~p", [V]));
+mochi_to_json(V) when is_binary(V) -> "\"" ++ mochi_escape_json(binary_to_list(V)) ++ "\"";
+mochi_to_json(V) when is_list(V), (V =:= [] orelse is_integer(hd(V))) -> "\"" ++ mochi_escape_json(V) ++ "\"";
+mochi_to_json(V) when is_list(V) -> "[" ++ lists:join(",", [mochi_to_json(X) || X <- V]) ++ "]";
+mochi_to_json(V) when is_map(V) -> "{" ++ lists:join(",", ["\"" ++ atom_to_list(K) ++ "\":" ++ mochi_to_json(Val) || {K,Val} <- maps:to_list(V)]) ++ "}".
+
+mochi_json(V) -> io:format("~s~n", [mochi_to_json(V)]).
+
+mochi_expect(true) -> ok;
+mochi_expect(_) -> erlang:error(expect_failed).
+
+mochi_test_start(Name) -> io:format("   test ~s ...", [Name]).
+mochi_test_pass(Dur) -> io:format(" ok (~p)~n", [Dur]).
+mochi_test_fail(Err, Dur) -> io:format(" fail ~p (~p)~n", [Err, Dur]).
+
+mochi_run_test(Name, Fun) ->
+    mochi_test_start(Name),
+    Start = erlang:monotonic_time(millisecond),
+    try Fun() of _ ->
+        Duration = erlang:monotonic_time(millisecond) - Start,
+        mochi_test_pass(Duration)
+    catch C:R ->
+        Duration = erlang:monotonic_time(millisecond) - Start,
+        mochi_test_fail({C,R}, Duration)
+    end.

--- a/tests/dataset/job/compiler/erlang/q2.out
+++ b/tests/dataset/job/compiler/erlang/q2.out
@@ -1,0 +1,1 @@
+"Der Film"


### PR DESCRIPTION
## Summary
- extend Erlang backend with `min`/`max` helpers
- generate Erlang code for JOB q1 and q2
- add golden outputs for JOB queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e7276388883209d65339e01a97625