### PR TITLE
Add stub for Clojure contains and update tasks

### DIFF
--- a/compile/x/clj/TASKS.md
+++ b/compile/x/clj/TASKS.md
@@ -1,10 +1,15 @@
-# Clojure Backend Tasks for TPCH Q1
+# Clojure Backend Tasks
 
-The Clojure compiler currently only supports basic loops and list processing. When
-compiling `q1.mochi` it fails on grouping and struct handling.
+The current backend can parse simple programs but JOB dataset queries still fail to compile. 
+To support the JOB benchmark we need several improvements:
 
-- Lower dataset queries to Clojure's `group-by`, `map` and `reduce` functions.
-- Generate Clojure records for Mochi structs like `lineitem` and emit field accessors.
-- Provide helpers implementing `sum`, `avg` and `count` over grouped sequences.
-- Use a library such as `cheshire` to produce JSON output for the result.
-- Add a golden test in `tests/compiler/clj` after the query compiles.
+- Implement string and list membership helpers. `x.contains(y)` should translate to
+  `clojure.string/includes?` for strings and use the `_in` helper for lists and maps.
+- Validate generated code to ensure balanced parentheses; running cljfmt currently
+  reports "EOF while reading" for q1.
+- Extend the JOB golden tests to compile and execute `q1.mochi` through `q10.mochi`.
+  Generated sources should live under `tests/dataset/job/compiler/clj`.
+- Emit correct JSON output so the tests can compare results.
+
+Once these features are complete the Clojure backend should be able to run the
+first ten JOB queries.


### PR DESCRIPTION
## Summary
- add stub logic in the Clojure backend to recognise `.contains` calls
- document outstanding steps for the JOB queries in `TASKS.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e77dd45c8832096bca2a2f274a6ef