### PR TITLE
Add JOB dataset golden outputs

### DIFF
--- a/compile/x/c/TASKS.md
+++ b/compile/x/c/TASKS.md
@@ -29,3 +29,14 @@ To run `tests/dataset/tpc-h/q1.mochi` the following work is required:
 - [ ] Add golden tests under `tests/compiler/c` covering the new grouping logic.
 
 Until these tasks are complete `mochi build --target c tests/dataset/tpc-h/q1.mochi` results in generated C that simply sets `result` to `0`.
+
+## JOB dataset queries
+
+Attempts to compile the JOB `q1.mochi`–`q10.mochi` programs fail because joins
+and grouping are not supported yet. The backend stops early when `join` clauses
+are present and emits `return 0`. Supporting these queries requires:
+
+- Implementing join processing similar to the Go runtime.
+- Extending grouping and aggregation support beyond simple lists.
+- Emitting helper functions for `min` and other aggregations used in JOB.
+

--- a/tests/dataset/job/out/q10.out
+++ b/tests/dataset/job/out/q10.out
@@ -1,0 +1,1 @@
+[{"russian_movie":"Vodka Dreams","uncredited_voiced_character":"Ivan"}]

--- a/tests/dataset/job/out/q3.out
+++ b/tests/dataset/job/out/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/out/q4.out
+++ b/tests/dataset/job/out/q4.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha Movie","rating":"6.2"}]

--- a/tests/dataset/job/out/q5.out
+++ b/tests/dataset/job/out/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/out/q6.out
+++ b/tests/dataset/job/out/q6.out
@@ -1,0 +1,1 @@
+[{"actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3","movie_keyword":"marvel-cinematic-universe"}]

--- a/tests/dataset/job/out/q7.out
+++ b/tests/dataset/job/out/q7.out
@@ -1,0 +1,1 @@
+[{"biography_movie":"Feature Film","of_person":"Alan Brown"}]

--- a/tests/dataset/job/out/q8.out
+++ b/tests/dataset/job/out/q8.out
@@ -1,0 +1,1 @@
+[map[actress_pseudonym:Y. S. japanese_movie_dubbed:Dubbed Film]]

--- a/tests/dataset/job/out/q9.out
+++ b/tests/dataset/job/out/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]


### PR DESCRIPTION
## Summary
- create golden outputs for JOB queries 3–10
- document missing join and grouping support for JOB in the C compiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e77dafa208320af0f5d3dcdd036b5