### PR TITLE
Add JOB q1-10 golden tests for F# compiler

### DIFF
--- a/compile/x/fs/TASKS.md
+++ b/compile/x/fs/TASKS.md
@@ -6,3 +6,8 @@ The F# compiler focuses on algorithmic examples and lacks dataset grouping suppo
 - Map Mochi records to F# record types with typed fields.
 - Implement inline functions for `sum`, `avg` and `count` over sequences.
 - Serialize results with `System.Text.Json` and add tests under `tests/compiler/fs`.
+- JOB queries q1–q10 currently fail to compile because field name constants like
+  `movie_id` and `person_id` are not emitted. The generated code uses bare
+  identifiers which F# treats as variables. Add helper constants for record
+  fields so the maps are built correctly and ensure the queries pass when run
+  with `dotnet fsi`.

--- a/compile/x/fs/job_test.go
+++ b/compile/x/fs/job_test.go
@@ -4,6 +4,7 @@ package fscode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,40 +27,46 @@ func TestFSCompiler_JOB(t *testing.T) {
 	if home, err := os.UserHomeDir(); err == nil {
 		os.Setenv("PATH", os.Getenv("PATH")+":"+filepath.Join(home, ".dotnet", "tools"))
 	}
+
 	root := testutil.FindRepoRoot(t)
-	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := fscode.New(env).Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	goldenCode := filepath.Join(root, "tests", "dataset", "job", "compiler", "fs", "q1.fs.out")
-	if data, err := os.ReadFile(goldenCode); err == nil {
-		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(data)) {
-			t.Errorf("generated code mismatch for q1.fs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(data))
-		}
-	}
-	dir := t.TempDir()
-	file := filepath.Join(dir, "main.fsx")
-	if err := os.WriteFile(file, code, 0644); err != nil {
-		t.Fatalf("write error: %v", err)
-	}
-	cmd := exec.Command("dotnet", "fsi", "--quiet", file)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("fsi error: %v\n%s", err, out)
-	}
-	goldenOut := filepath.Join(root, "tests", "dataset", "job", "compiler", "fs", "q1.out")
-	if want, err := os.ReadFile(goldenOut); err == nil {
-		if got := strings.TrimSpace(string(out)); got != strings.TrimSpace(string(want)) {
-			t.Errorf("unexpected runtime output\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, strings.TrimSpace(string(want)))
-		}
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := fscode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			goldenCode := filepath.Join(root, "tests", "dataset", "job", "compiler", "fs", q+".fs.out")
+			if data, err := os.ReadFile(goldenCode); err == nil {
+				if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(data)) {
+					t.Errorf("generated code mismatch for %s.fs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(data))
+				}
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.fsx")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			cmd := exec.Command("dotnet", "fsi", "--quiet", file)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("fsi error: %v\n%s", err, out)
+			}
+			goldenOut := filepath.Join(root, "tests", "dataset", "job", "compiler", "fs", q+".out")
+			if want, err := os.ReadFile(goldenOut); err == nil {
+				if got := strings.TrimSpace(string(out)); got != strings.TrimSpace(string(want)) {
+					t.Errorf("unexpected runtime output\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, strings.TrimSpace(string(want)))
+				}
+			}
+		})
 	}
 }

--- a/tests/dataset/job/compiler/fs/q10.fs.out
+++ b/tests/dataset/job/compiler/fs/q10.fs.out
@@ -1,0 +1,84 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let char_name = [|Map.ofList [(id, 1); (name, "Ivan")]; Map.ofList [(id, 2); (name, "Alex")]|]
+let cast_info = [|Map.ofList [(movie_id, 10); (person_role_id, 1); (role_id, 1); (note, "Soldier (voice) (uncredited)")]; Map.ofList [(movie_id, 11); (person_role_id, 2); (role_id, 1); (note, "(voice)")]|]
+let company_name = [|Map.ofList [(id, 1); (country_code, "[ru]")]; Map.ofList [(id, 2); (country_code, "[us]")]|]
+let company_type = [|Map.ofList [(id, 1)]; Map.ofList [(id, 2)]|]
+let movie_companies = [|Map.ofList [(movie_id, 10); (company_id, 1); (company_type_id, 1)]; Map.ofList [(movie_id, 11); (company_id, 2); (company_type_id, 1)]|]
+let role_type = [|Map.ofList [(id, 1); (role, "actor")]; Map.ofList [(id, 2); (role, "director")]|]
+let title = [|Map.ofList [(id, 10); (title, "Vodka Dreams"); (production_year, 2006)]; Map.ofList [(id, 11); (title, "Other Film"); (production_year, 2004)]|]
+let matches = [|
+    for chn in char_name do
+        for ci in cast_info do
+            if (chn.id = ci.person_role_id) then
+                for rt in role_type do
+                    if (rt.id = ci.role_id) then
+                        for t in title do
+                            if (t.id = ci.movie_id) then
+                                for mc in movie_companies do
+                                    if (mc.movie_id = t.id) then
+                                        for cn in company_name do
+                                            if (cn.id = mc.company_id) then
+                                                for ct in company_type do
+                                                    if (ct.id = mc.company_type_id) then
+                                                        if ((((ci.note.contains "(voice)" && ci.note.contains "(uncredited)") && (cn.country_code = "[ru]")) && (rt.role = "actor")) && (t.production_year > 2005)) then
+                                                            yield Map.ofList [(character, chn.name); (movie, t.title)]
+|]
+let result = [|Map.ofList [(uncredited_voiced_character, _min [|
+    for x in matches do
+        yield x.character
+|]); (russian_movie, _min [|
+    for x in matches do
+        yield x.movie
+|])]|]
+ignore (_json result)
+let test_Q10_finds_uncredited_voice_actor_in_Russian_movie() =
+    if not ((result = [|Map.ofList [(uncredited_voiced_character, "Ivan"); (russian_movie, "Vodka Dreams")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q10 finds uncredited voice actor in Russian movie" test_Q10_finds_uncredited_voice_actor_in_Russian_movie) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q2.fs.out
+++ b/tests/dataset/job/compiler/fs/q2.fs.out
@@ -1,0 +1,72 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let company_name = [|Map.ofList [(id, 1); (country_code, "[de]")]; Map.ofList [(id, 2); (country_code, "[us]")]|]
+let keyword = [|Map.ofList [(id, 1); (keyword, "character-name-in-title")]; Map.ofList [(id, 2); (keyword, "other")]|]
+let movie_companies = [|Map.ofList [(movie_id, 100); (company_id, 1)]; Map.ofList [(movie_id, 200); (company_id, 2)]|]
+let movie_keyword = [|Map.ofList [(movie_id, 100); (keyword_id, 1)]; Map.ofList [(movie_id, 200); (keyword_id, 2)]|]
+let title = [|Map.ofList [(id, 100); (title, "Der Film")]; Map.ofList [(id, 200); (title, "Other Movie")]|]
+let titles = [|
+    for cn in company_name do
+        for mc in movie_companies do
+            if (mc.company_id = cn.id) then
+                for t in title do
+                    if (mc.movie_id = t.id) then
+                        for mk in movie_keyword do
+                            if (mk.movie_id = t.id) then
+                                for k in keyword do
+                                    if (mk.keyword_id = k.id) then
+                                        if (((cn.country_code = "[de]") && (k.keyword = "character-name-in-title")) && (mc.movie_id = mk.movie_id)) then
+                                            yield t.title
+|]
+let result = _min titles
+ignore (_json result)
+let test_Q2_finds_earliest_title_for_German_companies_with_character_keyword() =
+    if not ((result = "Der Film")) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q2 finds earliest title for German companies with character keyword" test_Q2_finds_earliest_title_for_German_companies_with_character_keyword) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q3.fs.out
+++ b/tests/dataset/job/compiler/fs/q3.fs.out
@@ -1,0 +1,70 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let keyword = [|Map.ofList [(id, 1); (keyword, "amazing sequel")]; Map.ofList [(id, 2); (keyword, "prequel")]|]
+let movie_info = [|Map.ofList [(movie_id, 10); (info, "Germany")]; Map.ofList [(movie_id, 30); (info, "Sweden")]; Map.ofList [(movie_id, 20); (info, "France")]|]
+let movie_keyword = [|Map.ofList [(movie_id, 10); (keyword_id, 1)]; Map.ofList [(movie_id, 30); (keyword_id, 1)]; Map.ofList [(movie_id, 20); (keyword_id, 1)]; Map.ofList [(movie_id, 10); (keyword_id, 2)]|]
+let title = [|Map.ofList [(id, 10); (title, "Alpha"); (production_year, 2006)]; Map.ofList [(id, 30); (title, "Beta"); (production_year, 2008)]; Map.ofList [(id, 20); (title, "Gamma"); (production_year, 2009)]|]
+let allowed_infos = [|"Sweden"; "Norway"; "Germany"; "Denmark"; "Swedish"; "Denish"; "Norwegian"; "German"|]
+let candidate_titles = [|
+    for k in keyword do
+        for mk in movie_keyword do
+            if (mk.keyword_id = k.id) then
+                for mi in movie_info do
+                    if (mi.movie_id = mk.movie_id) then
+                        for t in title do
+                            if (t.id = mi.movie_id) then
+                                if (((k.keyword.contains "sequel" && Array.contains mi.info allowed_infos) && (t.production_year > 2005)) && (mk.movie_id = mi.movie_id)) then
+                                    yield t.title
+|]
+let result = [|Map.ofList [(movie_title, _min candidate_titles)]|]
+ignore (_json result)
+let test_Q3_returns_lexicographically_smallest_sequel_title() =
+    if not ((result = [|Map.ofList [(movie_title, "Alpha")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q3 returns lexicographically smallest sequel title" test_Q3_returns_lexicographically_smallest_sequel_title) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q4.fs.out
+++ b/tests/dataset/job/compiler/fs/q4.fs.out
@@ -1,0 +1,78 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let info_type = [|Map.ofList [(id, 1); (info, "rating")]; Map.ofList [(id, 2); (info, "other")]|]
+let keyword = [|Map.ofList [(id, 1); (keyword, "great sequel")]; Map.ofList [(id, 2); (keyword, "prequel")]|]
+let title = [|Map.ofList [(id, 10); (title, "Alpha Movie"); (production_year, 2006)]; Map.ofList [(id, 20); (title, "Beta Film"); (production_year, 2007)]; Map.ofList [(id, 30); (title, "Old Film"); (production_year, 2004)]|]
+let movie_keyword = [|Map.ofList [(movie_id, 10); (keyword_id, 1)]; Map.ofList [(movie_id, 20); (keyword_id, 1)]; Map.ofList [(movie_id, 30); (keyword_id, 1)]|]
+let movie_info_idx = [|Map.ofList [(movie_id, 10); (info_type_id, 1); (info, "6.2")]; Map.ofList [(movie_id, 20); (info_type_id, 1); (info, "7.8")]; Map.ofList [(movie_id, 30); (info_type_id, 1); (info, "4.5")]|]
+let rows = [|
+    for it in info_type do
+        for mi in movie_info_idx do
+            if (it.id = mi.info_type_id) then
+                for t in title do
+                    if (t.id = mi.movie_id) then
+                        for mk in movie_keyword do
+                            if (mk.movie_id = t.id) then
+                                for k in keyword do
+                                    if (k.id = mk.keyword_id) then
+                                        if (((((it.info = "rating") && k.keyword.contains "sequel") && (mi.info > "5.0")) && (t.production_year > 2005)) && (mk.movie_id = mi.movie_id)) then
+                                            yield Map.ofList [(rating, mi.info); (title, t.title)]
+|]
+let result = [|Map.ofList [(rating, _min [|
+    for r in rows do
+        yield r.rating
+|]); (movie_title, _min [|
+    for r in rows do
+        yield r.title
+|])]|]
+ignore (_json result)
+let test_Q4_returns_minimum_rating_and_title_for_sequels() =
+    if not ((result = [|Map.ofList [(rating, "6.2"); (movie_title, "Alpha Movie")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q4 returns minimum rating and title for sequels" test_Q4_returns_minimum_rating_and_title_for_sequels) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q5.fs.out
+++ b/tests/dataset/job/compiler/fs/q5.fs.out
@@ -1,0 +1,72 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let company_type = [|Map.ofList [(ct_id, 1); (kind, "production companies")]; Map.ofList [(ct_id, 2); (kind, "other")]|]
+let info_type = [|Map.ofList [(it_id, 10); (info, "languages")]|]
+let title = [|Map.ofList [(t_id, 100); (title, "B Movie"); (production_year, 2010)]; Map.ofList [(t_id, 200); (title, "A Film"); (production_year, 2012)]; Map.ofList [(t_id, 300); (title, "Old Movie"); (production_year, 2000)]|]
+let movie_companies = [|Map.ofList [(movie_id, 100); (company_type_id, 1); (note, "ACME (France) (theatrical)")]; Map.ofList [(movie_id, 200); (company_type_id, 1); (note, "ACME (France) (theatrical)")]; Map.ofList [(movie_id, 300); (company_type_id, 1); (note, "ACME (France) (theatrical)")]|]
+let movie_info = [|Map.ofList [(movie_id, 100); (info, "German"); (info_type_id, 10)]; Map.ofList [(movie_id, 200); (info, "Swedish"); (info_type_id, 10)]; Map.ofList [(movie_id, 300); (info, "German"); (info_type_id, 10)]|]
+let candidate_titles = [|
+    for ct in company_type do
+        for mc in movie_companies do
+            if (mc.company_type_id = ct.ct_id) then
+                for mi in movie_info do
+                    if (mi.movie_id = mc.movie_id) then
+                        for it in info_type do
+                            if (it.it_id = mi.info_type_id) then
+                                for t in title do
+                                    if (t.t_id = mc.movie_id) then
+                                        if (((((ct.kind = "production companies") && Array.contains "(theatrical)" mc.note) && Array.contains "(France)" mc.note) && (t.production_year > 2005)) && (Array.contains mi.info [|"Sweden"; "Norway"; "Germany"; "Denmark"; "Swedish"; "Denish"; "Norwegian"; "German"|])) then
+                                            yield t.title
+|]
+let result = [|Map.ofList [(typical_european_movie, _min candidate_titles)]|]
+ignore (_json result)
+let test_Q5_finds_the_lexicographically_first_qualifying_title() =
+    if not ((result = [|Map.ofList [(typical_european_movie, "A Film")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q5 finds the lexicographically first qualifying title" test_Q5_finds_the_lexicographically_first_qualifying_title) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q6.fs.out
+++ b/tests/dataset/job/compiler/fs/q6.fs.out
@@ -1,0 +1,61 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+
+let cast_info = [|Map.ofList [(movie_id, 1); (person_id, 101)]; Map.ofList [(movie_id, 2); (person_id, 102)]|]
+let keyword = [|Map.ofList [(id, 100); (keyword, "marvel-cinematic-universe")]; Map.ofList [(id, 200); (keyword, "other")]|]
+let movie_keyword = [|Map.ofList [(movie_id, 1); (keyword_id, 100)]; Map.ofList [(movie_id, 2); (keyword_id, 200)]|]
+let name = [|Map.ofList [(id, 101); (name, "Downey Robert Jr.")]; Map.ofList [(id, 102); (name, "Chris Evans")]|]
+let title = [|Map.ofList [(id, 1); (title, "Iron Man 3"); (production_year, 2013)]; Map.ofList [(id, 2); (title, "Old Movie"); (production_year, 2000)]|]
+let result = [|
+    for ci in cast_info do
+        for mk in movie_keyword do
+            if (ci.movie_id = mk.movie_id) then
+                for k in keyword do
+                    if (mk.keyword_id = k.id) then
+                        for n in name do
+                            if (ci.person_id = n.id) then
+                                for t in title do
+                                    if (ci.movie_id = t.id) then
+                                        if ((((k.keyword = "marvel-cinematic-universe") && n.name.contains "Downey") && n.name.contains "Robert") && (t.production_year > 2010)) then
+                                            yield Map.ofList [(movie_keyword, k.keyword); (actor_name, n.name); (marvel_movie, t.title)]
+|]
+ignore (_json result)
+let test_Q6_finds_marvel_movie_with_Robert_Downey() =
+    if not ((result = [|Map.ofList [(movie_keyword, "marvel-cinematic-universe"); (actor_name, "Downey Robert Jr."); (marvel_movie, "Iron Man 3")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q6 finds marvel movie with Robert Downey" test_Q6_finds_marvel_movie_with_Robert_Downey) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q7.fs.out
+++ b/tests/dataset/job/compiler/fs/q7.fs.out
@@ -1,0 +1,87 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let aka_name = [|Map.ofList [(person_id, 1); (name, "Anna Mae")]; Map.ofList [(person_id, 2); (name, "Chris")]|]
+let cast_info = [|Map.ofList [(person_id, 1); (movie_id, 10)]; Map.ofList [(person_id, 2); (movie_id, 20)]|]
+let info_type = [|Map.ofList [(id, 1); (info, "mini biography")]; Map.ofList [(id, 2); (info, "trivia")]|]
+let link_type = [|Map.ofList [(id, 1); (link, "features")]; Map.ofList [(id, 2); (link, "references")]|]
+let movie_link = [|Map.ofList [(linked_movie_id, 10); (link_type_id, 1)]; Map.ofList [(linked_movie_id, 20); (link_type_id, 2)]|]
+let name = [|Map.ofList [(id, 1); (name, "Alan Brown"); (name_pcode_cf, "B"); (gender, "m")]; Map.ofList [(id, 2); (name, "Zoe"); (name_pcode_cf, "Z"); (gender, "f")]|]
+let person_info = [|Map.ofList [(person_id, 1); (info_type_id, 1); (note, "Volker Boehm")]; Map.ofList [(person_id, 2); (info_type_id, 1); (note, "Other")]|]
+let title = [|Map.ofList [(id, 10); (title, "Feature Film"); (production_year, 1990)]; Map.ofList [(id, 20); (title, "Late Film"); (production_year, 2000)]|]
+let rows = [|
+    for an in aka_name do
+        for n in name do
+            if (n.id = an.person_id) then
+                for pi in person_info do
+                    if (pi.person_id = an.person_id) then
+                        for it in info_type do
+                            if (it.id = pi.info_type_id) then
+                                for ci in cast_info do
+                                    if (ci.person_id = n.id) then
+                                        for t in title do
+                                            if (t.id = ci.movie_id) then
+                                                for ml in movie_link do
+                                                    if (ml.linked_movie_id = t.id) then
+                                                        for lt in link_type do
+                                                            if (lt.id = ml.link_type_id) then
+                                                                if (((((((((((((an.name.contains "a" && (it.info = "mini biography")) && (lt.link = "features")) && (n.name_pcode_cf >= "A")) && (n.name_pcode_cf <= "F")) && (((n.gender = "m") || (((n.gender = "f") && n.name.starts_with "B"))))) && (pi.note = "Volker Boehm")) && (t.production_year >= 1980)) && (t.production_year <= 1995)) && (pi.person_id = an.person_id)) && (pi.person_id = ci.person_id)) && (an.person_id = ci.person_id)) && (ci.movie_id = ml.linked_movie_id))) then
+                                                                    yield Map.ofList [(person_name, n.name); (movie_title, t.title)]
+|]
+let result = [|Map.ofList [(of_person, _min [|
+    for r in rows do
+        yield r.person_name
+|]); (biography_movie, _min [|
+    for r in rows do
+        yield r.movie_title
+|])]|]
+ignore (_json result)
+let test_Q7_finds_movie_features_biography_for_person() =
+    if not ((result = [|Map.ofList [(of_person, "Alan Brown"); (biography_movie, "Feature Film")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q7 finds movie features biography for person" test_Q7_finds_movie_features_biography_for_person) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q8.fs.out
+++ b/tests/dataset/job/compiler/fs/q8.fs.out
@@ -1,0 +1,61 @@
+open System
+
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let aka_name = [|Map.ofList [(person_id, 1); (name, "Y. S.")]|]
+let cast_info = [|Map.ofList [(person_id, 1); (movie_id, 10); (note, "(voice: English version)"); (role_id, 1000)]|]
+let company_name = [|Map.ofList [(id, 50); (country_code, "[jp]")]|]
+let movie_companies = [|Map.ofList [(movie_id, 10); (company_id, 50); (note, "Studio (Japan)")]|]
+let name = [|Map.ofList [(id, 1); (name, "Yoko Ono")]; Map.ofList [(id, 2); (name, "Yuichi")]|]
+let role_type = [|Map.ofList [(id, 1000); (role, "actress")]|]
+let title = [|Map.ofList [(id, 10); (title, "Dubbed Film")]|]
+let eligible = [|
+    for an1 in aka_name do
+        for n1 in name do
+            if (n1.id = an1.person_id) then
+                for ci in cast_info do
+                    if (ci.person_id = an1.person_id) then
+                        for t in title do
+                            if (t.id = ci.movie_id) then
+                                for mc in movie_companies do
+                                    if (mc.movie_id = ci.movie_id) then
+                                        for cn in company_name do
+                                            if (cn.id = mc.company_id) then
+                                                for rt in role_type do
+                                                    if (rt.id = ci.role_id) then
+                                                        if (((((((ci.note = "(voice: English version)") && (cn.country_code = "[jp]")) && mc.note.contains "(Japan)") && ((not mc.note.contains "(USA)"))) && n1.name.contains "Yo") && ((not n1.name.contains "Yu"))) && (rt.role = "actress")) then
+                                                            yield Map.ofList [(pseudonym, an1.name); (movie_title, t.title)]
+|]
+let result = [|Map.ofList [(actress_pseudonym, _min [|
+    for x in eligible do
+        yield x.pseudonym
+|]); (japanese_movie_dubbed, _min [|
+    for x in eligible do
+        yield x.movie_title
+|])]|]
+ignore (printfn "%A" (result))
+let test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() =
+    if not ((result = [|Map.ofList [(actress_pseudonym, "Y. S."); (japanese_movie_dubbed, "Dubbed Film")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q8 returns the pseudonym and movie title for Japanese dubbing" test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/compiler/fs/q9.fs.out
+++ b/tests/dataset/job/compiler/fs/q9.fs.out
@@ -1,0 +1,90 @@
+open System
+
+let rec _to_json (v: obj) : string =
+  match v with
+  | null -> "null"
+  | :? string as s ->
+      "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+  | :? bool
+  | :? int | :? int64
+  | :? double -> string v
+  | :? System.Collections.Generic.IDictionary<string,obj> as m ->
+      m
+      |> Seq.map (fun (KeyValue(k,v)) ->
+          "\"" + k.Replace("\"", "\\\"") + "\":" + _to_json v)
+      |> String.concat ","
+      |> fun s -> "{" + s + "}"
+  | :? System.Collections.IEnumerable as e ->
+      e
+      |> Seq.cast<obj>
+      |> Seq.map _to_json
+      |> String.concat ","
+      |> fun s -> "[" + s + "]"
+  | _ -> "\"" + v.ToString().Replace("\\", "\\\\").Replace("\"", "\\\"") + "\""
+let _json (v: obj) : unit =
+  printfn "%s" (_to_json v)
+let _run_test (name: string) (f: unit -> unit) : bool =
+  printf "%s ... " name
+  try
+    f()
+    printfn "PASS"
+    true
+  with e ->
+    printfn "FAIL (%s)" e.Message
+    false
+let inline sum (xs: seq< ^T >) : ^T =
+  Seq.sum xs
+let inline avg (xs: seq< ^T >) : ^T =
+  Seq.average xs
+let inline _min (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.min xs
+let inline _max (xs: seq< ^T >) : ^T when ^T : comparison =
+  Seq.max xs
+let count (xs: seq<'T>) : int =
+  Seq.length xs
+
+let aka_name = [|Map.ofList [(person_id, 1); (name, "A. N. G.")]; Map.ofList [(person_id, 2); (name, "J. D.")]|]
+let char_name = [|Map.ofList [(id, 10); (name, "Angel")]; Map.ofList [(id, 20); (name, "Devil")]|]
+let cast_info = [|Map.ofList [(person_id, 1); (person_role_id, 10); (movie_id, 100); (role_id, 1000); (note, "(voice)")]; Map.ofList [(person_id, 2); (person_role_id, 20); (movie_id, 200); (role_id, 1000); (note, "(voice)")]|]
+let company_name = [|Map.ofList [(id, 100); (country_code, "[us]")]; Map.ofList [(id, 200); (country_code, "[gb]")]|]
+let movie_companies = [|Map.ofList [(movie_id, 100); (company_id, 100); (note, "ACME Studios (USA)")]; Map.ofList [(movie_id, 200); (company_id, 200); (note, "Maple Films")]|]
+let name = [|Map.ofList [(id, 1); (name, "Angela Smith"); (gender, "f")]; Map.ofList [(id, 2); (name, "John Doe"); (gender, "m")]|]
+let role_type = [|Map.ofList [(id, 1000); (role, "actress")]; Map.ofList [(id, 2000); (role, "actor")]|]
+let title = [|Map.ofList [(id, 100); (title, "Famous Film"); (production_year, 2010)]; Map.ofList [(id, 200); (title, "Old Movie"); (production_year, 1999)]|]
+let matches = [|
+    for an in aka_name do
+        for n in name do
+            if (an.person_id = n.id) then
+                for ci in cast_info do
+                    if (ci.person_id = n.id) then
+                        for chn in char_name do
+                            if (chn.id = ci.person_role_id) then
+                                for t in title do
+                                    if (t.id = ci.movie_id) then
+                                        for mc in movie_companies do
+                                            if (mc.movie_id = t.id) then
+                                                for cn in company_name do
+                                                    if (cn.id = mc.company_id) then
+                                                        for rt in role_type do
+                                                            if (rt.id = ci.role_id) then
+                                                                if ((((((((Array.contains ci.note [|"(voice)"; "(voice: Japanese version)"; "(voice) (uncredited)"; "(voice: English version)"|]) && (cn.country_code = "[us]")) && ((mc.note.contains "(USA)" || mc.note.contains "(worldwide)"))) && (n.gender = "f")) && n.name.contains "Ang") && (rt.role = "actress")) && (t.production_year >= 2005)) && (t.production_year <= 2015)) then
+                                                                    yield Map.ofList [(alt, an.name); (character, chn.name); (movie, t.title)]
+|]
+let result = [|Map.ofList [(alternative_name, _min [|
+    for x in matches do
+        yield x.alt
+|]); (character_name, _min [|
+    for x in matches do
+        yield x.character
+|]); (movie, _min [|
+    for x in matches do
+        yield x.movie
+|])]|]
+ignore (_json result)
+let test_Q9_selects_minimal_alternative_name__character_and_movie() =
+    if not ((result = [|Map.ofList [(alternative_name, "A. N. G."); (character_name, "Angel"); (movie, "Famous Film")]|])) then failwith "expect failed"
+
+let mutable failures = 0
+if not (_run_test "Q9 selects minimal alternative name, character and movie" test_Q9_selects_minimal_alternative_name__character_and_movie) then failures <- failures + 1
+if failures > 0 then
+    printfn "\n[FAIL] %d test(s) failed." failures

--- a/tests/dataset/job/out/q10.out
+++ b/tests/dataset/job/out/q10.out
@@ -1,0 +1,1 @@
+[{"russian_movie":"Vodka Dreams","uncredited_voiced_character":"Ivan"}]

--- a/tests/dataset/job/out/q3.out
+++ b/tests/dataset/job/out/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/out/q4.out
+++ b/tests/dataset/job/out/q4.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha Movie","rating":"6.2"}]

--- a/tests/dataset/job/out/q5.out
+++ b/tests/dataset/job/out/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/out/q6.out
+++ b/tests/dataset/job/out/q6.out
@@ -1,0 +1,1 @@
+[{"actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3","movie_keyword":"marvel-cinematic-universe"}]

--- a/tests/dataset/job/out/q7.out
+++ b/tests/dataset/job/out/q7.out
@@ -1,0 +1,1 @@
+[{"biography_movie":"Feature Film","of_person":"Alan Brown"}]

--- a/tests/dataset/job/out/q8.out
+++ b/tests/dataset/job/out/q8.out
@@ -1,0 +1,1 @@
+[map[actress_pseudonym:Y. S. japanese_movie_dubbed:Dubbed Film]]

--- a/tests/dataset/job/out/q9.out
+++ b/tests/dataset/job/out/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]


### PR DESCRIPTION
## Summary
- extend `TestFSCompiler_JOB` to loop over q1–q10
- compile JOB queries 2–10 to F# and add golden files
- capture expected VM output for q3–q10
- note failing JOB support in F# TASKS

## Testing
- `go test ./compile/x/fs -run JOB -tags slow -count=1` *(fails: fsi error)*

------
https://chatgpt.com/codex/tasks/task_e_685e77ef51dc83208b66d04905f453f9