### PR TITLE
Add JOB dataset Haskell compiler tests

### DIFF
--- a/compile/x/hs/TASKS.md
+++ b/compile/x/hs/TASKS.md
@@ -1,8 +1,13 @@
 # Haskell Backend Tasks for TPCH Q1
 
-The Haskell backend supports lists and loops but no grouping of records yet.
+The Haskell backend supports basic lists, maps and loops. Grouping and
+aggregations are still missing which limits support for the full TPCH and JOB
+query suites.
 
 - Introduce `data` declarations for TPCH rows and query results.
 - Compile `group by` using `Data.Map` and `fromListWith` to accumulate groups.
 - Provide folds implementing `sum`, `avg` and `count` on grouped values.
 - Output JSON with `aeson` and add tests in `tests/compiler/hs` once working.
+- Extend the runtime with heterogeneous map helpers so JOB queries `q2`–`q10`
+  compile and run. Currently the generated code fails to type check because
+  `VInt`/`VString` constructors are missing.

--- a/compile/x/hs/compiler.go
+++ b/compile/x/hs/compiler.go
@@ -171,7 +171,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	if len(c.structs) > 0 {
 		header.WriteString("import GHC.Generics (Generic)\n")
 	}
-	if c.usesLoad || c.usesSave || c.usesFetch {
+	if c.usesLoad || c.usesSave || c.usesFetch || c.usesMap {
 		header.WriteString("import qualified Data.Aeson.KeyMap as KeyMap\n")
 		header.WriteString("import qualified Data.Aeson.Key as Key\n")
 		header.WriteString("import qualified Data.Vector as V\n")
@@ -182,7 +182,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	header.WriteString("import qualified Data.ByteString.Lazy.Char8 as BSL\n")
 	header.WriteString("\n")
-	if c.usesLoad || c.usesSave || c.usesFetch {
+	if c.usesLoad || c.usesSave || c.usesFetch || c.usesMap {
 		header.WriteString(loadRuntime)
 	} else {
 		header.WriteString(runtime)
@@ -198,13 +198,13 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	header.WriteString("\n\n")
 
-        code := append(header.Bytes(), c.buf.Bytes()...)
-        // Ensure the generated file ends with a trailing newline so tools like
-        // runhaskell do not complain about the last line.
-        if len(code) == 0 || code[len(code)-1] != '\n' {
-                code = append(code, '\n')
-        }
-        return FormatHS(code), nil
+	code := append(header.Bytes(), c.buf.Bytes()...)
+	// Ensure the generated file ends with a trailing newline so tools like
+	// runhaskell do not complain about the last line.
+	if len(code) == 0 || code[len(code)-1] != '\n' {
+		code = append(code, '\n')
+	}
+	return FormatHS(code), nil
 }
 
 func (c *Compiler) compileMainStmt(s *parser.Statement) error {

--- a/compile/x/hs/job_golden_test.go
+++ b/compile/x/hs/job_golden_test.go
@@ -4,6 +4,7 @@ package hscode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,36 +15,41 @@ import (
 	"mochi/types"
 )
 
-func TestHSCompiler_JOBQ1(t *testing.T) {
+func TestHSCompiler_JOBQueries(t *testing.T) {
 	if err := hscode.EnsureHaskell(); err != nil {
 		t.Skipf("haskell not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
+	for i := 1; i <= 10; i++ {
+		name := fmt.Sprintf("q%d", i)
+		t.Run(name, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "job", name+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := hscode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			codeWantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "hs", name+".hs.out")
+			wantCode, err := os.ReadFile(codeWantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s.hs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", name, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.hs")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
+		})
 	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := hscode.New(env).Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	codeWantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "hs", "q1.hs.out")
-	wantCode, err := os.ReadFile(codeWantPath)
-	if err != nil {
-		t.Fatalf("read golden: %v", err)
-	}
-	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
-		t.Errorf("generated code mismatch for q1.hs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(wantCode))
-	}
-	dir := t.TempDir()
-	file := filepath.Join(dir, "main.hs")
-	if err := os.WriteFile(file, code, 0644); err != nil {
-		t.Fatalf("write error: %v", err)
-	}
-	t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
 }

--- a/tests/dataset/job/compiler/hs/q10.hs.out
+++ b/tests/dataset/job/compiler/hs/q10.hs.out
@@ -1,0 +1,114 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+char_name = [Map.fromList [("id", VInt (1)), ("name", VString ("Ivan"))], Map.fromList [("id", VInt (2)), ("name", VString ("Alex"))]]
+
+cast_info = [Map.fromList [("movie_id", VInt (10)), ("person_role_id", VInt (1)), ("role_id", VInt (1)), ("note", VString ("Soldier (voice) (uncredited)"))], Map.fromList [("movie_id", VInt (11)), ("person_role_id", VInt (2)), ("role_id", VInt (1)), ("note", VString ("(voice)"))]]
+
+company_name = [Map.fromList [("id", VInt (1)), ("country_code", VString ("[ru]"))], Map.fromList [("id", VInt (2)), ("country_code", VString ("[us]"))]]
+
+company_type = [Map.fromList [("id", 1)], Map.fromList [("id", 2)]]
+
+movie_companies = [Map.fromList [("movie_id", 10), ("company_id", 1), ("company_type_id", 1)], Map.fromList [("movie_id", 11), ("company_id", 2), ("company_type_id", 1)]]
+
+role_type = [Map.fromList [("id", VInt (1)), ("role", VString ("actor"))], Map.fromList [("id", VInt (2)), ("role", VString ("director"))]]
+
+title = [Map.fromList [("id", VInt (10)), ("title", VString ("Vodka Dreams")), ("production_year", VInt (2006))], Map.fromList [("id", VInt (11)), ("title", VString ("Other Film")), ("production_year", VInt (2004))]]
+
+matches = [Map.fromList [("character", VString (fromMaybe (error "missing") (Map.lookup "name" chn))), ("movie", VString (fromMaybe (error "missing") (Map.lookup "title" t)))] | chn <- char_name, ci <- cast_info, rt <- role_type, t <- title, mc <- movie_companies, cn <- company_name, ct <- company_type, (fromMaybe (error "missing") (Map.lookup "id" (chn)) == fromMaybe (error "missing") (Map.lookup "person_role_id" (ci))), (fromMaybe (error "missing") (Map.lookup "id" (rt)) == fromMaybe (error "missing") (Map.lookup "role_id" (ci))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (ci))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mc)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (cn)) == fromMaybe (error "missing") (Map.lookup "company_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (ct)) == fromMaybe (error "missing") (Map.lookup "company_type_id" (mc))), (((((((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" ci))) "(voice)" && fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" ci))) "(uncredited)") && fromMaybe (error "missing") (Map.lookup "country_code" cn)) == "[ru]") && fromMaybe (error "missing") (Map.lookup "role" rt)) == "actor") && fromMaybe (error "missing") (Map.lookup "production_year" t)) > 2005)]
+
+result = [Map.fromList [("uncredited_voiced_character", VString (min [fromMaybe (error "missing") (Map.lookup "character" x) | x <- matches])), ("russian_movie", VString (min [fromMaybe (error "missing") (Map.lookup "movie" x) | x <- matches]))]]
+
+test_Q10_finds_uncredited_voice_actor_in_Russian_movie :: IO ()
+test_Q10_finds_uncredited_voice_actor_in_Russian_movie = do
+  expect ((result == [Map.fromList [("uncredited_voiced_character", "Ivan"), ("russian_movie", "Vodka Dreams")]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_Q10_finds_uncredited_voice_actor_in_Russian_movie

--- a/tests/dataset/job/compiler/hs/q2.hs.out
+++ b/tests/dataset/job/compiler/hs/q2.hs.out
@@ -86,25 +86,25 @@ expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-company_type = [Map.fromList [("id", VInt (1)), ("kind", VString ("production companies"))], Map.fromList [("id", VInt (2)), ("kind", VString ("distributors"))]]
+company_name = [Map.fromList [("id", VInt (1)), ("country_code", VString ("[de]"))], Map.fromList [("id", VInt (2)), ("country_code", VString ("[us]"))]]
 
-info_type = [Map.fromList [("id", VInt (10)), ("info", VString ("top 250 rank"))], Map.fromList [("id", VInt (20)), ("info", VString ("bottom 10 rank"))]]
+keyword = [Map.fromList [("id", VInt (1)), ("keyword", VString ("character-name-in-title"))], Map.fromList [("id", VInt (2)), ("keyword", VString ("other"))]]
 
-title = [Map.fromList [("id", VInt (100)), ("title", VString ("Good Movie")), ("production_year", VInt (1995))], Map.fromList [("id", VInt (200)), ("title", VString ("Bad Movie")), ("production_year", VInt (2000))]]
+movie_companies = [Map.fromList [("movie_id", 100), ("company_id", 1)], Map.fromList [("movie_id", 200), ("company_id", 2)]]
 
-movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_type_id", VInt (1)), ("note", VString ("ACME (co-production)"))], Map.fromList [("movie_id", VInt (200)), ("company_type_id", VInt (1)), ("note", VString ("MGM (as Metro-Goldwyn-Mayer Pictures)"))]]
+movie_keyword = [Map.fromList [("movie_id", 100), ("keyword_id", 1)], Map.fromList [("movie_id", 200), ("keyword_id", 2)]]
 
-movie_info_idx = [Map.fromList [("movie_id", 100), ("info_type_id", 10)], Map.fromList [("movie_id", 200), ("info_type_id", 20)]]
+title = [Map.fromList [("id", VInt (100)), ("title", VString ("Der Film"))], Map.fromList [("id", VInt (200)), ("title", VString ("Other Movie"))]]
 
-filtered = [Map.fromList [("note", VString (fromMaybe (error "missing") (Map.lookup "note" mc))), ("title", VString (fromMaybe (error "missing") (Map.lookup "title" t))), ("year", VString (fromMaybe (error "missing") (Map.lookup "production_year" t)))] | ct <- company_type, mc <- movie_companies, t <- title, mi <- movie_info_idx, it <- info_type, (fromMaybe (error "missing") (Map.lookup "id" (ct)) == fromMaybe (error "missing") (Map.lookup "company_type_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (((((fromMaybe (error "missing") (Map.lookup "kind" ct) == "production companies") && fromMaybe (error "missing") (Map.lookup "info" it)) == "top 250 rank") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(as Metro-Goldwyn-Mayer Pictures)")) && ((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(co-production)" || fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(presents)")))]
+titles = [fromMaybe (error "missing") (Map.lookup "title" t) | cn <- company_name, mc <- movie_companies, t <- title, mk <- movie_keyword, k <- keyword, (fromMaybe (error "missing") (Map.lookup "company_id" (mc)) == fromMaybe (error "missing") (Map.lookup "id" (cn))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mc)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mk)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "keyword_id" (mk)) == fromMaybe (error "missing") (Map.lookup "id" (k))), (((((fromMaybe (error "missing") (Map.lookup "country_code" cn) == "[de]") && fromMaybe (error "missing") (Map.lookup "keyword" k)) == "character-name-in-title") && fromMaybe (error "missing") (Map.lookup "movie_id" mc)) == fromMaybe (error "missing") (Map.lookup "movie_id" mk))]
 
-result = Map.fromList [("production_note", VString (min [fromMaybe (error "missing") (Map.lookup "note" r) | r <- filtered])), ("movie_title", VString (min [fromMaybe (error "missing") (Map.lookup "title" r) | r <- filtered])), ("movie_year", VString (min [fromMaybe (error "missing") (Map.lookup "year" r) | r <- filtered]))]
+result = min titles
 
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production :: IO ()
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production = do
-  expect ((result == Map.fromList [("production_note", VString ("ACME (co-production)")), ("movie_title", VString ("Good Movie")), ("movie_year", VInt (1995))]))
+test_Q2_finds_earliest_title_for_German_companies_with_character_keyword :: IO ()
+test_Q2_finds_earliest_title_for_German_companies_with_character_keyword = do
+  expect ((result == "Der Film"))
 
 main :: IO ()
 main = do
-  _json [result]
-  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production
+  _json result
+  test_Q2_finds_earliest_title_for_German_companies_with_character_keyword

--- a/tests/dataset/job/compiler/hs/q3.hs.out
+++ b/tests/dataset/job/compiler/hs/q3.hs.out
@@ -86,25 +86,25 @@ expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-company_type = [Map.fromList [("id", VInt (1)), ("kind", VString ("production companies"))], Map.fromList [("id", VInt (2)), ("kind", VString ("distributors"))]]
+keyword = [Map.fromList [("id", VInt (1)), ("keyword", VString ("amazing sequel"))], Map.fromList [("id", VInt (2)), ("keyword", VString ("prequel"))]]
 
-info_type = [Map.fromList [("id", VInt (10)), ("info", VString ("top 250 rank"))], Map.fromList [("id", VInt (20)), ("info", VString ("bottom 10 rank"))]]
+movie_info = [Map.fromList [("movie_id", VInt (10)), ("info", VString ("Germany"))], Map.fromList [("movie_id", VInt (30)), ("info", VString ("Sweden"))], Map.fromList [("movie_id", VInt (20)), ("info", VString ("France"))]]
 
-title = [Map.fromList [("id", VInt (100)), ("title", VString ("Good Movie")), ("production_year", VInt (1995))], Map.fromList [("id", VInt (200)), ("title", VString ("Bad Movie")), ("production_year", VInt (2000))]]
+movie_keyword = [Map.fromList [("movie_id", 10), ("keyword_id", 1)], Map.fromList [("movie_id", 30), ("keyword_id", 1)], Map.fromList [("movie_id", 20), ("keyword_id", 1)], Map.fromList [("movie_id", 10), ("keyword_id", 2)]]
 
-movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_type_id", VInt (1)), ("note", VString ("ACME (co-production)"))], Map.fromList [("movie_id", VInt (200)), ("company_type_id", VInt (1)), ("note", VString ("MGM (as Metro-Goldwyn-Mayer Pictures)"))]]
+title = [Map.fromList [("id", VInt (10)), ("title", VString ("Alpha")), ("production_year", VInt (2006))], Map.fromList [("id", VInt (30)), ("title", VString ("Beta")), ("production_year", VInt (2008))], Map.fromList [("id", VInt (20)), ("title", VString ("Gamma")), ("production_year", VInt (2009))]]
 
-movie_info_idx = [Map.fromList [("movie_id", 100), ("info_type_id", 10)], Map.fromList [("movie_id", 200), ("info_type_id", 20)]]
+allowed_infos = ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]
 
-filtered = [Map.fromList [("note", VString (fromMaybe (error "missing") (Map.lookup "note" mc))), ("title", VString (fromMaybe (error "missing") (Map.lookup "title" t))), ("year", VString (fromMaybe (error "missing") (Map.lookup "production_year" t)))] | ct <- company_type, mc <- movie_companies, t <- title, mi <- movie_info_idx, it <- info_type, (fromMaybe (error "missing") (Map.lookup "id" (ct)) == fromMaybe (error "missing") (Map.lookup "company_type_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (((((fromMaybe (error "missing") (Map.lookup "kind" ct) == "production companies") && fromMaybe (error "missing") (Map.lookup "info" it)) == "top 250 rank") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(as Metro-Goldwyn-Mayer Pictures)")) && ((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(co-production)" || fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(presents)")))]
+candidate_titles = [fromMaybe (error "missing") (Map.lookup "title" t) | k <- keyword, mk <- movie_keyword, mi <- movie_info, t <- title, (fromMaybe (error "missing") (Map.lookup "keyword_id" (mk)) == fromMaybe (error "missing") (Map.lookup "id" (k))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mk))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mi))), ((((elem (fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "keyword" k))) "sequel" && fromMaybe (error "missing") (Map.lookup "info" mi)) allowed_infos && fromMaybe (error "missing") (Map.lookup "production_year" t)) > 2005) && fromMaybe (error "missing") (Map.lookup "movie_id" mk)) == fromMaybe (error "missing") (Map.lookup "movie_id" mi))]
 
-result = Map.fromList [("production_note", VString (min [fromMaybe (error "missing") (Map.lookup "note" r) | r <- filtered])), ("movie_title", VString (min [fromMaybe (error "missing") (Map.lookup "title" r) | r <- filtered])), ("movie_year", VString (min [fromMaybe (error "missing") (Map.lookup "year" r) | r <- filtered]))]
+result = [Map.fromList [("movie_title", VString (min candidate_titles))]]
 
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production :: IO ()
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production = do
-  expect ((result == Map.fromList [("production_note", VString ("ACME (co-production)")), ("movie_title", VString ("Good Movie")), ("movie_year", VInt (1995))]))
+test_Q3_returns_lexicographically_smallest_sequel_title :: IO ()
+test_Q3_returns_lexicographically_smallest_sequel_title = do
+  expect ((result == [Map.fromList [("movie_title", "Alpha")]]))
 
 main :: IO ()
 main = do
-  _json [result]
-  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production
+  _json result
+  test_Q3_returns_lexicographically_smallest_sequel_title

--- a/tests/dataset/job/compiler/hs/q4.hs.out
+++ b/tests/dataset/job/compiler/hs/q4.hs.out
@@ -86,25 +86,25 @@ expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-company_type = [Map.fromList [("id", VInt (1)), ("kind", VString ("production companies"))], Map.fromList [("id", VInt (2)), ("kind", VString ("distributors"))]]
+info_type = [Map.fromList [("id", VInt (1)), ("info", VString ("rating"))], Map.fromList [("id", VInt (2)), ("info", VString ("other"))]]
 
-info_type = [Map.fromList [("id", VInt (10)), ("info", VString ("top 250 rank"))], Map.fromList [("id", VInt (20)), ("info", VString ("bottom 10 rank"))]]
+keyword = [Map.fromList [("id", VInt (1)), ("keyword", VString ("great sequel"))], Map.fromList [("id", VInt (2)), ("keyword", VString ("prequel"))]]
 
-title = [Map.fromList [("id", VInt (100)), ("title", VString ("Good Movie")), ("production_year", VInt (1995))], Map.fromList [("id", VInt (200)), ("title", VString ("Bad Movie")), ("production_year", VInt (2000))]]
+title = [Map.fromList [("id", VInt (10)), ("title", VString ("Alpha Movie")), ("production_year", VInt (2006))], Map.fromList [("id", VInt (20)), ("title", VString ("Beta Film")), ("production_year", VInt (2007))], Map.fromList [("id", VInt (30)), ("title", VString ("Old Film")), ("production_year", VInt (2004))]]
 
-movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_type_id", VInt (1)), ("note", VString ("ACME (co-production)"))], Map.fromList [("movie_id", VInt (200)), ("company_type_id", VInt (1)), ("note", VString ("MGM (as Metro-Goldwyn-Mayer Pictures)"))]]
+movie_keyword = [Map.fromList [("movie_id", 10), ("keyword_id", 1)], Map.fromList [("movie_id", 20), ("keyword_id", 1)], Map.fromList [("movie_id", 30), ("keyword_id", 1)]]
 
-movie_info_idx = [Map.fromList [("movie_id", 100), ("info_type_id", 10)], Map.fromList [("movie_id", 200), ("info_type_id", 20)]]
+movie_info_idx = [Map.fromList [("movie_id", VInt (10)), ("info_type_id", VInt (1)), ("info", VString ("6.2"))], Map.fromList [("movie_id", VInt (20)), ("info_type_id", VInt (1)), ("info", VString ("7.8"))], Map.fromList [("movie_id", VInt (30)), ("info_type_id", VInt (1)), ("info", VString ("4.5"))]]
 
-filtered = [Map.fromList [("note", VString (fromMaybe (error "missing") (Map.lookup "note" mc))), ("title", VString (fromMaybe (error "missing") (Map.lookup "title" t))), ("year", VString (fromMaybe (error "missing") (Map.lookup "production_year" t)))] | ct <- company_type, mc <- movie_companies, t <- title, mi <- movie_info_idx, it <- info_type, (fromMaybe (error "missing") (Map.lookup "id" (ct)) == fromMaybe (error "missing") (Map.lookup "company_type_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (((((fromMaybe (error "missing") (Map.lookup "kind" ct) == "production companies") && fromMaybe (error "missing") (Map.lookup "info" it)) == "top 250 rank") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(as Metro-Goldwyn-Mayer Pictures)")) && ((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(co-production)" || fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(presents)")))]
+rows = [Map.fromList [("rating", VString (fromMaybe (error "missing") (Map.lookup "info" mi))), ("title", VString (fromMaybe (error "missing") (Map.lookup "title" t)))] | it <- info_type, mi <- movie_info_idx, t <- title, mk <- movie_keyword, k <- keyword, (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mi))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mk)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (k)) == fromMaybe (error "missing") (Map.lookup "keyword_id" (mk))), ((((((((fromMaybe (error "missing") (Map.lookup "info" it) == "rating") && fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "keyword" k))) "sequel") && fromMaybe (error "missing") (Map.lookup "info" mi)) > "5.0") && fromMaybe (error "missing") (Map.lookup "production_year" t)) > 2005) && fromMaybe (error "missing") (Map.lookup "movie_id" mk)) == fromMaybe (error "missing") (Map.lookup "movie_id" mi))]
 
-result = Map.fromList [("production_note", VString (min [fromMaybe (error "missing") (Map.lookup "note" r) | r <- filtered])), ("movie_title", VString (min [fromMaybe (error "missing") (Map.lookup "title" r) | r <- filtered])), ("movie_year", VString (min [fromMaybe (error "missing") (Map.lookup "year" r) | r <- filtered]))]
+result = [Map.fromList [("rating", VString (min [fromMaybe (error "missing") (Map.lookup "rating" r) | r <- rows])), ("movie_title", VString (min [fromMaybe (error "missing") (Map.lookup "title" r) | r <- rows]))]]
 
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production :: IO ()
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production = do
-  expect ((result == Map.fromList [("production_note", VString ("ACME (co-production)")), ("movie_title", VString ("Good Movie")), ("movie_year", VInt (1995))]))
+test_Q4_returns_minimum_rating_and_title_for_sequels :: IO ()
+test_Q4_returns_minimum_rating_and_title_for_sequels = do
+  expect ((result == [Map.fromList [("rating", "6.2"), ("movie_title", "Alpha Movie")]]))
 
 main :: IO ()
 main = do
-  _json [result]
-  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production
+  _json result
+  test_Q4_returns_minimum_rating_and_title_for_sequels

--- a/tests/dataset/job/compiler/hs/q5.hs.out
+++ b/tests/dataset/job/compiler/hs/q5.hs.out
@@ -86,25 +86,25 @@ expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-company_type = [Map.fromList [("id", VInt (1)), ("kind", VString ("production companies"))], Map.fromList [("id", VInt (2)), ("kind", VString ("distributors"))]]
+company_type = [Map.fromList [("ct_id", VInt (1)), ("kind", VString ("production companies"))], Map.fromList [("ct_id", VInt (2)), ("kind", VString ("other"))]]
 
-info_type = [Map.fromList [("id", VInt (10)), ("info", VString ("top 250 rank"))], Map.fromList [("id", VInt (20)), ("info", VString ("bottom 10 rank"))]]
+info_type = [Map.fromList [("it_id", VInt (10)), ("info", VString ("languages"))]]
 
-title = [Map.fromList [("id", VInt (100)), ("title", VString ("Good Movie")), ("production_year", VInt (1995))], Map.fromList [("id", VInt (200)), ("title", VString ("Bad Movie")), ("production_year", VInt (2000))]]
+title = [Map.fromList [("t_id", VInt (100)), ("title", VString ("B Movie")), ("production_year", VInt (2010))], Map.fromList [("t_id", VInt (200)), ("title", VString ("A Film")), ("production_year", VInt (2012))], Map.fromList [("t_id", VInt (300)), ("title", VString ("Old Movie")), ("production_year", VInt (2000))]]
 
-movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_type_id", VInt (1)), ("note", VString ("ACME (co-production)"))], Map.fromList [("movie_id", VInt (200)), ("company_type_id", VInt (1)), ("note", VString ("MGM (as Metro-Goldwyn-Mayer Pictures)"))]]
+movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_type_id", VInt (1)), ("note", VString ("ACME (France) (theatrical)"))], Map.fromList [("movie_id", VInt (200)), ("company_type_id", VInt (1)), ("note", VString ("ACME (France) (theatrical)"))], Map.fromList [("movie_id", VInt (300)), ("company_type_id", VInt (1)), ("note", VString ("ACME (France) (theatrical)"))]]
 
-movie_info_idx = [Map.fromList [("movie_id", 100), ("info_type_id", 10)], Map.fromList [("movie_id", 200), ("info_type_id", 20)]]
+movie_info = [Map.fromList [("movie_id", VInt (100)), ("info", VString ("German")), ("info_type_id", VInt (10))], Map.fromList [("movie_id", VInt (200)), ("info", VString ("Swedish")), ("info_type_id", VInt (10))], Map.fromList [("movie_id", VInt (300)), ("info", VString ("German")), ("info_type_id", VInt (10))]]
 
-filtered = [Map.fromList [("note", VString (fromMaybe (error "missing") (Map.lookup "note" mc))), ("title", VString (fromMaybe (error "missing") (Map.lookup "title" t))), ("year", VString (fromMaybe (error "missing") (Map.lookup "production_year" t)))] | ct <- company_type, mc <- movie_companies, t <- title, mi <- movie_info_idx, it <- info_type, (fromMaybe (error "missing") (Map.lookup "id" (ct)) == fromMaybe (error "missing") (Map.lookup "company_type_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (((((fromMaybe (error "missing") (Map.lookup "kind" ct) == "production companies") && fromMaybe (error "missing") (Map.lookup "info" it)) == "top 250 rank") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(as Metro-Goldwyn-Mayer Pictures)")) && ((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(co-production)" || fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(presents)")))]
+candidate_titles = [fromMaybe (error "missing") (Map.lookup "title" t) | ct <- company_type, mc <- movie_companies, mi <- movie_info, it <- info_type, t <- title, (fromMaybe (error "missing") (Map.lookup "company_type_id" (mc)) == fromMaybe (error "missing") (Map.lookup "ct_id" (ct))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (fromMaybe (error "missing") (Map.lookup "it_id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (fromMaybe (error "missing") (Map.lookup "t_id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (((elem (elem ((fromMaybe (error "missing") (Map.lookup "kind" ct) == "production companies") && "(theatrical)") fromMaybe (error "missing") (Map.lookup "note" mc) && "(France)") fromMaybe (error "missing") (Map.lookup "note" mc) && fromMaybe (error "missing") (Map.lookup "production_year" t)) > 2005) && (elem fromMaybe (error "missing") (Map.lookup "info" mi) ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]))]
 
-result = Map.fromList [("production_note", VString (min [fromMaybe (error "missing") (Map.lookup "note" r) | r <- filtered])), ("movie_title", VString (min [fromMaybe (error "missing") (Map.lookup "title" r) | r <- filtered])), ("movie_year", VString (min [fromMaybe (error "missing") (Map.lookup "year" r) | r <- filtered]))]
+result = [Map.fromList [("typical_european_movie", VString (min candidate_titles))]]
 
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production :: IO ()
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production = do
-  expect ((result == Map.fromList [("production_note", VString ("ACME (co-production)")), ("movie_title", VString ("Good Movie")), ("movie_year", VInt (1995))]))
+test_Q5_finds_the_lexicographically_first_qualifying_title :: IO ()
+test_Q5_finds_the_lexicographically_first_qualifying_title = do
+  expect ((result == [Map.fromList [("typical_european_movie", "A Film")]]))
 
 main :: IO ()
 main = do
-  _json [result]
-  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production
+  _json result
+  test_Q5_finds_the_lexicographically_first_qualifying_title

--- a/tests/dataset/job/compiler/hs/q6.hs.out
+++ b/tests/dataset/job/compiler/hs/q6.hs.out
@@ -86,25 +86,23 @@ expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-company_type = [Map.fromList [("id", VInt (1)), ("kind", VString ("production companies"))], Map.fromList [("id", VInt (2)), ("kind", VString ("distributors"))]]
+cast_info = [Map.fromList [("movie_id", 1), ("person_id", 101)], Map.fromList [("movie_id", 2), ("person_id", 102)]]
 
-info_type = [Map.fromList [("id", VInt (10)), ("info", VString ("top 250 rank"))], Map.fromList [("id", VInt (20)), ("info", VString ("bottom 10 rank"))]]
+keyword = [Map.fromList [("id", VInt (100)), ("keyword", VString ("marvel-cinematic-universe"))], Map.fromList [("id", VInt (200)), ("keyword", VString ("other"))]]
 
-title = [Map.fromList [("id", VInt (100)), ("title", VString ("Good Movie")), ("production_year", VInt (1995))], Map.fromList [("id", VInt (200)), ("title", VString ("Bad Movie")), ("production_year", VInt (2000))]]
+movie_keyword = [Map.fromList [("movie_id", 1), ("keyword_id", 100)], Map.fromList [("movie_id", 2), ("keyword_id", 200)]]
 
-movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_type_id", VInt (1)), ("note", VString ("ACME (co-production)"))], Map.fromList [("movie_id", VInt (200)), ("company_type_id", VInt (1)), ("note", VString ("MGM (as Metro-Goldwyn-Mayer Pictures)"))]]
+name = [Map.fromList [("id", VInt (101)), ("name", VString ("Downey Robert Jr."))], Map.fromList [("id", VInt (102)), ("name", VString ("Chris Evans"))]]
 
-movie_info_idx = [Map.fromList [("movie_id", 100), ("info_type_id", 10)], Map.fromList [("movie_id", 200), ("info_type_id", 20)]]
+title = [Map.fromList [("id", VInt (1)), ("title", VString ("Iron Man 3")), ("production_year", VInt (2013))], Map.fromList [("id", VInt (2)), ("title", VString ("Old Movie")), ("production_year", VInt (2000))]]
 
-filtered = [Map.fromList [("note", VString (fromMaybe (error "missing") (Map.lookup "note" mc))), ("title", VString (fromMaybe (error "missing") (Map.lookup "title" t))), ("year", VString (fromMaybe (error "missing") (Map.lookup "production_year" t)))] | ct <- company_type, mc <- movie_companies, t <- title, mi <- movie_info_idx, it <- info_type, (fromMaybe (error "missing") (Map.lookup "id" (ct)) == fromMaybe (error "missing") (Map.lookup "company_type_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (((((fromMaybe (error "missing") (Map.lookup "kind" ct) == "production companies") && fromMaybe (error "missing") (Map.lookup "info" it)) == "top 250 rank") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(as Metro-Goldwyn-Mayer Pictures)")) && ((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(co-production)" || fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(presents)")))]
+result = [Map.fromList [("movie_keyword", VString (fromMaybe (error "missing") (Map.lookup "keyword" k))), ("actor_name", VString (fromMaybe (error "missing") (Map.lookup "name" n))), ("marvel_movie", VString (fromMaybe (error "missing") (Map.lookup "title" t)))] | ci <- cast_info, mk <- movie_keyword, k <- keyword, n <- name, t <- title, (fromMaybe (error "missing") (Map.lookup "movie_id" (ci)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mk))), (fromMaybe (error "missing") (Map.lookup "keyword_id" (mk)) == fromMaybe (error "missing") (Map.lookup "id" (k))), (fromMaybe (error "missing") (Map.lookup "person_id" (ci)) == fromMaybe (error "missing") (Map.lookup "id" (n))), (fromMaybe (error "missing") (Map.lookup "movie_id" (ci)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (((((fromMaybe (error "missing") (Map.lookup "keyword" k) == "marvel-cinematic-universe") && fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "name" n))) "Downey") && fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "name" n))) "Robert") && fromMaybe (error "missing") (Map.lookup "production_year" t)) > 2010)]
 
-result = Map.fromList [("production_note", VString (min [fromMaybe (error "missing") (Map.lookup "note" r) | r <- filtered])), ("movie_title", VString (min [fromMaybe (error "missing") (Map.lookup "title" r) | r <- filtered])), ("movie_year", VString (min [fromMaybe (error "missing") (Map.lookup "year" r) | r <- filtered]))]
-
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production :: IO ()
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production = do
-  expect ((result == Map.fromList [("production_note", VString ("ACME (co-production)")), ("movie_title", VString ("Good Movie")), ("movie_year", VInt (1995))]))
+test_Q6_finds_marvel_movie_with_Robert_Downey :: IO ()
+test_Q6_finds_marvel_movie_with_Robert_Downey = do
+  expect ((result == [Map.fromList [("movie_keyword", "marvel-cinematic-universe"), ("actor_name", "Downey Robert Jr."), ("marvel_movie", "Iron Man 3")]]))
 
 main :: IO ()
 main = do
-  _json [result]
-  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production
+  _json result
+  test_Q6_finds_marvel_movie_with_Robert_Downey

--- a/tests/dataset/job/compiler/hs/q7.hs.out
+++ b/tests/dataset/job/compiler/hs/q7.hs.out
@@ -1,0 +1,116 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+aka_name = [Map.fromList [("person_id", VInt (1)), ("name", VString ("Anna Mae"))], Map.fromList [("person_id", VInt (2)), ("name", VString ("Chris"))]]
+
+cast_info = [Map.fromList [("person_id", 1), ("movie_id", 10)], Map.fromList [("person_id", 2), ("movie_id", 20)]]
+
+info_type = [Map.fromList [("id", VInt (1)), ("info", VString ("mini biography"))], Map.fromList [("id", VInt (2)), ("info", VString ("trivia"))]]
+
+link_type = [Map.fromList [("id", VInt (1)), ("link", VString ("features"))], Map.fromList [("id", VInt (2)), ("link", VString ("references"))]]
+
+movie_link = [Map.fromList [("linked_movie_id", 10), ("link_type_id", 1)], Map.fromList [("linked_movie_id", 20), ("link_type_id", 2)]]
+
+name = [Map.fromList [("id", VInt (1)), ("name", VString ("Alan Brown")), ("name_pcode_cf", VString ("B")), ("gender", VString ("m"))], Map.fromList [("id", VInt (2)), ("name", VString ("Zoe")), ("name_pcode_cf", VString ("Z")), ("gender", VString ("f"))]]
+
+person_info = [Map.fromList [("person_id", VInt (1)), ("info_type_id", VInt (1)), ("note", VString ("Volker Boehm"))], Map.fromList [("person_id", VInt (2)), ("info_type_id", VInt (1)), ("note", VString ("Other"))]]
+
+title = [Map.fromList [("id", VInt (10)), ("title", VString ("Feature Film")), ("production_year", VInt (1990))], Map.fromList [("id", VInt (20)), ("title", VString ("Late Film")), ("production_year", VInt (2000))]]
+
+rows = [Map.fromList [("person_name", VString (fromMaybe (error "missing") (Map.lookup "name" n))), ("movie_title", VString (fromMaybe (error "missing") (Map.lookup "title" t)))] | an <- aka_name, n <- name, pi <- person_info, it <- info_type, ci <- cast_info, t <- title, ml <- movie_link, lt <- link_type, (fromMaybe (error "missing") (Map.lookup "id" (n)) == fromMaybe (error "missing") (Map.lookup "person_id" (an))), (fromMaybe (error "missing") (Map.lookup "person_id" (pi)) == fromMaybe (error "missing") (Map.lookup "person_id" (an))), (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (pi))), (fromMaybe (error "missing") (Map.lookup "person_id" (ci)) == fromMaybe (error "missing") (Map.lookup "id" (n))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (ci))), (fromMaybe (error "missing") (Map.lookup "linked_movie_id" (ml)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (lt)) == fromMaybe (error "missing") (Map.lookup "link_type_id" (ml))), ((((((((((((((((((((((((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "name" an))) "a" && fromMaybe (error "missing") (Map.lookup "info" it)) == "mini biography") && fromMaybe (error "missing") (Map.lookup "link" lt)) == "features") && fromMaybe (error "missing") (Map.lookup "name_pcode_cf" n)) >= "A") && fromMaybe (error "missing") (Map.lookup "name_pcode_cf" n)) <= "F") && (((fromMaybe (error "missing") (Map.lookup "gender" n) == "m") || (((fromMaybe (error "missing") (Map.lookup "gender" n) == "f") && fromMaybe (error "missing") (Map.lookup "starts_with" (fromMaybe (error "missing") (Map.lookup "name" n))) "B"))))) && fromMaybe (error "missing") (Map.lookup "note" pi)) == "Volker Boehm") && fromMaybe (error "missing") (Map.lookup "production_year" t)) >= 1980) && fromMaybe (error "missing") (Map.lookup "production_year" t)) <= 1995) && fromMaybe (error "missing") (Map.lookup "person_id" pi)) == fromMaybe (error "missing") (Map.lookup "person_id" an)) && fromMaybe (error "missing") (Map.lookup "person_id" pi)) == fromMaybe (error "missing") (Map.lookup "person_id" ci)) && fromMaybe (error "missing") (Map.lookup "person_id" an)) == fromMaybe (error "missing") (Map.lookup "person_id" ci)) && fromMaybe (error "missing") (Map.lookup "movie_id" ci)) == fromMaybe (error "missing") (Map.lookup "linked_movie_id" ml)))]
+
+result = [Map.fromList [("of_person", VString (min [fromMaybe (error "missing") (Map.lookup "person_name" r) | r <- rows])), ("biography_movie", VString (min [fromMaybe (error "missing") (Map.lookup "movie_title" r) | r <- rows]))]]
+
+test_Q7_finds_movie_features_biography_for_person :: IO ()
+test_Q7_finds_movie_features_biography_for_person = do
+  expect ((result == [Map.fromList [("of_person", "Alan Brown"), ("biography_movie", "Feature Film")]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_Q7_finds_movie_features_biography_for_person

--- a/tests/dataset/job/compiler/hs/q8.hs.out
+++ b/tests/dataset/job/compiler/hs/q8.hs.out
@@ -86,25 +86,29 @@ expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-company_type = [Map.fromList [("id", VInt (1)), ("kind", VString ("production companies"))], Map.fromList [("id", VInt (2)), ("kind", VString ("distributors"))]]
+aka_name = [Map.fromList [("person_id", VInt (1)), ("name", VString ("Y. S."))]]
 
-info_type = [Map.fromList [("id", VInt (10)), ("info", VString ("top 250 rank"))], Map.fromList [("id", VInt (20)), ("info", VString ("bottom 10 rank"))]]
+cast_info = [Map.fromList [("person_id", VInt (1)), ("movie_id", VInt (10)), ("note", VString ("(voice: English version)")), ("role_id", VInt (1000))]]
 
-title = [Map.fromList [("id", VInt (100)), ("title", VString ("Good Movie")), ("production_year", VInt (1995))], Map.fromList [("id", VInt (200)), ("title", VString ("Bad Movie")), ("production_year", VInt (2000))]]
+company_name = [Map.fromList [("id", VInt (50)), ("country_code", VString ("[jp]"))]]
 
-movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_type_id", VInt (1)), ("note", VString ("ACME (co-production)"))], Map.fromList [("movie_id", VInt (200)), ("company_type_id", VInt (1)), ("note", VString ("MGM (as Metro-Goldwyn-Mayer Pictures)"))]]
+movie_companies = [Map.fromList [("movie_id", VInt (10)), ("company_id", VInt (50)), ("note", VString ("Studio (Japan)"))]]
 
-movie_info_idx = [Map.fromList [("movie_id", 100), ("info_type_id", 10)], Map.fromList [("movie_id", 200), ("info_type_id", 20)]]
+name = [Map.fromList [("id", VInt (1)), ("name", VString ("Yoko Ono"))], Map.fromList [("id", VInt (2)), ("name", VString ("Yuichi"))]]
 
-filtered = [Map.fromList [("note", VString (fromMaybe (error "missing") (Map.lookup "note" mc))), ("title", VString (fromMaybe (error "missing") (Map.lookup "title" t))), ("year", VString (fromMaybe (error "missing") (Map.lookup "production_year" t)))] | ct <- company_type, mc <- movie_companies, t <- title, mi <- movie_info_idx, it <- info_type, (fromMaybe (error "missing") (Map.lookup "id" (ct)) == fromMaybe (error "missing") (Map.lookup "company_type_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (mc))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mi)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (it)) == fromMaybe (error "missing") (Map.lookup "info_type_id" (mi))), (((((fromMaybe (error "missing") (Map.lookup "kind" ct) == "production companies") && fromMaybe (error "missing") (Map.lookup "info" it)) == "top 250 rank") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(as Metro-Goldwyn-Mayer Pictures)")) && ((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(co-production)" || fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(presents)")))]
+role_type = [Map.fromList [("id", VInt (1000)), ("role", VString ("actress"))]]
 
-result = Map.fromList [("production_note", VString (min [fromMaybe (error "missing") (Map.lookup "note" r) | r <- filtered])), ("movie_title", VString (min [fromMaybe (error "missing") (Map.lookup "title" r) | r <- filtered])), ("movie_year", VString (min [fromMaybe (error "missing") (Map.lookup "year" r) | r <- filtered]))]
+title = [Map.fromList [("id", VInt (10)), ("title", VString ("Dubbed Film"))]]
 
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production :: IO ()
-test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production = do
-  expect ((result == Map.fromList [("production_note", VString ("ACME (co-production)")), ("movie_title", VString ("Good Movie")), ("movie_year", VInt (1995))]))
+eligible = [Map.fromList [("pseudonym", VString (fromMaybe (error "missing") (Map.lookup "name" an1))), ("movie_title", VString (fromMaybe (error "missing") (Map.lookup "title" t)))] | an1 <- aka_name, n1 <- name, ci <- cast_info, t <- title, mc <- movie_companies, cn <- company_name, rt <- role_type, (fromMaybe (error "missing") (Map.lookup "id" (n1)) == fromMaybe (error "missing") (Map.lookup "person_id" (an1))), (fromMaybe (error "missing") (Map.lookup "person_id" (ci)) == fromMaybe (error "missing") (Map.lookup "person_id" (an1))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (ci))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mc)) == fromMaybe (error "missing") (Map.lookup "movie_id" (ci))), (fromMaybe (error "missing") (Map.lookup "id" (cn)) == fromMaybe (error "missing") (Map.lookup "company_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (rt)) == fromMaybe (error "missing") (Map.lookup "role_id" (ci))), (((((((((fromMaybe (error "missing") (Map.lookup "note" ci) == "(voice: English version)") && fromMaybe (error "missing") (Map.lookup "country_code" cn)) == "[jp]") && fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(Japan)") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(USA)")) && fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "name" n1))) "Yo") && (not fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "name" n1))) "Yu")) && fromMaybe (error "missing") (Map.lookup "role" rt)) == "actress")]
+
+result = [Map.fromList [("actress_pseudonym", VString (min [fromMaybe (error "missing") (Map.lookup "pseudonym" x) | x <- eligible])), ("japanese_movie_dubbed", VString (min [fromMaybe (error "missing") (Map.lookup "movie_title" x) | x <- eligible]))]]
+
+test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing :: IO ()
+test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing = do
+  expect ((result == [Map.fromList [("actress_pseudonym", "Y. S."), ("japanese_movie_dubbed", "Dubbed Film")]]))
 
 main :: IO ()
 main = do
-  _json [result]
-  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production
+  print (result)
+  test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing

--- a/tests/dataset/job/compiler/hs/q9.hs.out
+++ b/tests/dataset/job/compiler/hs/q9.hs.out
@@ -1,0 +1,116 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Main where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, isPrefixOf)
+import qualified Data.List as List
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as V
+
+data AnyValue = VInt Int | VDouble Double | VString String | VBool Bool deriving (Show)
+
+instance Aeson.ToJSON AnyValue where
+  toJSON (VInt n) = Aeson.toJSON n
+  toJSON (VDouble d) = Aeson.toJSON d
+  toJSON (VString s) = Aeson.toJSON s
+  toJSON (VBool b) = Aeson.toJSON b
+
+_asInt :: AnyValue -> Int
+_asInt (VInt n) = n
+_asInt v = error ("expected int, got " ++ show v)
+
+_asDouble :: AnyValue -> Double
+_asDouble (VDouble d) = d
+_asDouble v = error ("expected double, got " ++ show v)
+
+_asString :: AnyValue -> String
+_asString (VString s) = s
+_asString v = error ("expected string, got " ++ show v)
+
+_asBool :: AnyValue -> Bool
+_asBool (VBool b) = b
+_asBool v = error ("expected bool, got " ++ show v)
+
+_parseJSON :: String -> [Map.Map String String]
+_parseJSON text =
+  case Aeson.decode (BSL.pack text) of
+    Just (Aeson.Array arr) -> map _valueToMap (V.toList arr)
+    Just v -> [_valueToMap v]
+    Nothing -> []
+
+_valueToMap :: Aeson.Value -> Map.Map String String
+_valueToMap (Aeson.Object o) =
+  Map.fromList [(T.unpack (Key.toText k), _valueToString v) | (k, v) <- KeyMap.toList o]
+_valueToMap _ = Map.empty
+
+_valueToString :: Aeson.Value -> String
+_valueToString (Aeson.String s) = T.unpack s
+_valueToString (Aeson.Number n) = show n
+_valueToString (Aeson.Bool b) = if b then "true" else "false"
+_valueToString _ = ""
+
+_mapToValue :: Map.Map String String -> Aeson.Value
+_mapToValue m =
+  Aeson.Object $ KeyMap.fromList [(Key.fromString k, Aeson.String (T.pack v)) | (k, v) <- Map.toList m]
+
+_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
+_load path opts = do
+  txt <- _readInput path
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+  pure $ case fmt of
+    "json" -> _parseJSON txt
+    _ -> _parseCSV txt True ','
+
+_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
+_save rows path opts =
+  let fmt = fromMaybe "csv" (opts >>= Map.lookup "format")
+   in case fmt of
+        "json" ->
+          let objs = map _mapToValue rows
+              val = if length objs == 1 then head objs else Aeson.Array (V.fromList objs)
+           in _writeOutput path (BSL.unpack (Aeson.encode val))
+        _ ->
+          let headers = if null rows then [] else Map.keys (head rows)
+              toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
+              text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
+           in _writeOutput path text
+
+expect :: Bool -> IO ()
+expect True = pure ()
+expect False = error "expect failed"
+
+aka_name = [Map.fromList [("person_id", VInt (1)), ("name", VString ("A. N. G."))], Map.fromList [("person_id", VInt (2)), ("name", VString ("J. D."))]]
+
+char_name = [Map.fromList [("id", VInt (10)), ("name", VString ("Angel"))], Map.fromList [("id", VInt (20)), ("name", VString ("Devil"))]]
+
+cast_info = [Map.fromList [("person_id", VInt (1)), ("person_role_id", VInt (10)), ("movie_id", VInt (100)), ("role_id", VInt (1000)), ("note", VString ("(voice)"))], Map.fromList [("person_id", VInt (2)), ("person_role_id", VInt (20)), ("movie_id", VInt (200)), ("role_id", VInt (1000)), ("note", VString ("(voice)"))]]
+
+company_name = [Map.fromList [("id", VInt (100)), ("country_code", VString ("[us]"))], Map.fromList [("id", VInt (200)), ("country_code", VString ("[gb]"))]]
+
+movie_companies = [Map.fromList [("movie_id", VInt (100)), ("company_id", VInt (100)), ("note", VString ("ACME Studios (USA)"))], Map.fromList [("movie_id", VInt (200)), ("company_id", VInt (200)), ("note", VString ("Maple Films"))]]
+
+name = [Map.fromList [("id", VInt (1)), ("name", VString ("Angela Smith")), ("gender", VString ("f"))], Map.fromList [("id", VInt (2)), ("name", VString ("John Doe")), ("gender", VString ("m"))]]
+
+role_type = [Map.fromList [("id", VInt (1000)), ("role", VString ("actress"))], Map.fromList [("id", VInt (2000)), ("role", VString ("actor"))]]
+
+title = [Map.fromList [("id", VInt (100)), ("title", VString ("Famous Film")), ("production_year", VInt (2010))], Map.fromList [("id", VInt (200)), ("title", VString ("Old Movie")), ("production_year", VInt (1999))]]
+
+matches = [Map.fromList [("alt", VString (fromMaybe (error "missing") (Map.lookup "name" an))), ("character", VString (fromMaybe (error "missing") (Map.lookup "name" chn))), ("movie", VString (fromMaybe (error "missing") (Map.lookup "title" t)))] | an <- aka_name, n <- name, ci <- cast_info, chn <- char_name, t <- title, mc <- movie_companies, cn <- company_name, rt <- role_type, (fromMaybe (error "missing") (Map.lookup "person_id" (an)) == fromMaybe (error "missing") (Map.lookup "id" (n))), (fromMaybe (error "missing") (Map.lookup "person_id" (ci)) == fromMaybe (error "missing") (Map.lookup "id" (n))), (fromMaybe (error "missing") (Map.lookup "id" (chn)) == fromMaybe (error "missing") (Map.lookup "person_role_id" (ci))), (fromMaybe (error "missing") (Map.lookup "id" (t)) == fromMaybe (error "missing") (Map.lookup "movie_id" (ci))), (fromMaybe (error "missing") (Map.lookup "movie_id" (mc)) == fromMaybe (error "missing") (Map.lookup "id" (t))), (fromMaybe (error "missing") (Map.lookup "id" (cn)) == fromMaybe (error "missing") (Map.lookup "company_id" (mc))), (fromMaybe (error "missing") (Map.lookup "id" (rt)) == fromMaybe (error "missing") (Map.lookup "role_id" (ci))), (((((((((((((elem fromMaybe (error "missing") (Map.lookup "note" ci) ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) && fromMaybe (error "missing") (Map.lookup "country_code" cn)) == "[us]") && ((fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(USA)" || fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "note" mc))) "(worldwide)"))) && fromMaybe (error "missing") (Map.lookup "gender" n)) == "f") && fromMaybe (error "missing") (Map.lookup "contains" (fromMaybe (error "missing") (Map.lookup "name" n))) "Ang") && fromMaybe (error "missing") (Map.lookup "role" rt)) == "actress") && fromMaybe (error "missing") (Map.lookup "production_year" t)) >= 2005) && fromMaybe (error "missing") (Map.lookup "production_year" t)) <= 2015)]
+
+result = [Map.fromList [("alternative_name", VString (min [fromMaybe (error "missing") (Map.lookup "alt" x) | x <- matches])), ("character_name", VString (min [fromMaybe (error "missing") (Map.lookup "character" x) | x <- matches])), ("movie", VString (min [fromMaybe (error "missing") (Map.lookup "movie" x) | x <- matches]))]]
+
+test_Q9_selects_minimal_alternative_name__character_and_movie :: IO ()
+test_Q9_selects_minimal_alternative_name__character_and_movie = do
+  expect ((result == [Map.fromList [("alternative_name", "A. N. G."), ("character_name", "Angel"), ("movie", "Famous Film")]]))
+
+main :: IO ()
+main = do
+  _json result
+  test_Q9_selects_minimal_alternative_name__character_and_movie


### PR DESCRIPTION
## Summary
- update Haskell backend runtime selection when maps are used
- extend JOB golden test to cover q1–q10
- regenerate Haskell output for JOB queries
- note missing heterogeneous map support in TASKS

## Testing
- `go test ./compile/x/hs -run TestHSCompiler_JOBQueries -tags slow -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e77f299d08320b007cdaa735b5d7f