### PR TITLE
Add JOB q1-q10 PHP golden tests

### DIFF
--- a/compile/x/php/TASKS.md
+++ b/compile/x/php/TASKS.md
@@ -1,6 +1,6 @@
 # PHP Backend Tasks for TPCH Q1
 
-The PHP backend now supports dataset queries used by `tpc-h/q1.mochi` and `job/q1.mochi`.
+The PHP backend now supports dataset queries used by `tpc-h/q1.mochi` and `job/q1.mochi` through `job/q10.mochi`.
 
 - Implemented `sum` helper alongside `avg` and `count` using PHP arrays.
 - Added support for `group by` with an optional `where` clause.
@@ -14,4 +14,4 @@ The PHP backend now supports dataset queries used by `tpc-h/q1.mochi` and `job/q
 
 ## Remaining work
 
-- Extend support to additional JOB queries beyond `q1`.
+- Extend support to remaining JOB queries beyond `q10`.

--- a/compile/x/php/compiler.go
+++ b/compile/x/php/compiler.go
@@ -787,8 +787,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(args) == 0 {
 			return "", fmt.Errorf("print expects at least 1 arg")
 		}
-		joined := strings.Join(args, " . \" \" . ")
-		return fmt.Sprintf("echo %s, PHP_EOL", joined), nil
+		joined := strings.Join(args, ", ")
+		c.use("_print")
+		return fmt.Sprintf("_print(%s)", joined), nil
 	case "len":
 		if len(args) != 1 {
 			return "", fmt.Errorf("len expects 1 arg")

--- a/compile/x/php/job_test.go
+++ b/compile/x/php/job_test.go
@@ -3,6 +3,7 @@
 package phpcode_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,48 +15,52 @@ import (
 	"mochi/types"
 )
 
-func TestPHPCompiler_JOBQ1(t *testing.T) {
+func TestPHPCompiler_JOB(t *testing.T) {
 	if err := phpcode.EnsurePHP(); err != nil {
 		t.Skipf("php not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := phpcode.New(env).Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	tmp := t.TempDir()
-	file := filepath.Join(tmp, "main.php")
-	if err := os.WriteFile(file, code, 0644); err != nil {
-		t.Fatalf("write error: %v", err)
-	}
-	// compare generated code
-	codeWant, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "php", "q1.php.out"))
-	if err == nil {
-		if string(code) != string(codeWant) {
-			t.Fatalf("generated code mismatch")
-		}
-	}
-	cmd := exec.Command("php", file)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("php run error: %v\n%s", err, out)
-	}
-	got := string(out)
-	wantData, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "php", "q1.out"))
-	if err != nil {
-		t.Fatalf("read golden: %v", err)
-	}
-	want := string(wantData)
-	if got != want {
-		t.Fatalf("unexpected output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := phpcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.php")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			codeWantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", q+".php.out")
+			if codeWant, err := os.ReadFile(codeWantPath); err == nil {
+				if string(code) != string(codeWant) {
+					t.Fatalf("generated code mismatch")
+				}
+			}
+			cmd := exec.Command("php", file)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("php run error: %v\n%s", err, out)
+			}
+			wantData, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "php", q+".out"))
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			got := string(out)
+			want := string(wantData)
+			if got != want {
+				t.Fatalf("unexpected output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+			}
+		})
 	}
 }

--- a/compile/x/php/runtime.go
+++ b/compile/x/php/runtime.go
@@ -121,6 +121,14 @@ const helperSaveJSON = "function _save_json($rows, $path) {\n" +
 	"    if ($path === '' || $path === '-') { fwrite(STDOUT, $out . PHP_EOL); } else { file_put_contents($path, $out); }\n" +
 	"}\n"
 
+const helperPrint = "function _print(...$args) {\n" +
+	"    $parts = [];\n" +
+	"    foreach ($args as $a) {\n" +
+	"        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }\n" +
+	"    }\n" +
+	"    echo implode(' ', $parts), PHP_EOL;\n" +
+	"}\n"
+
 const helperFetch = "function _fetch($url, $opts = null) {\n" +
 	"    $args = ['-s'];\n" +
 	"    $method = $opts['method'] ?? 'GET';\n" +
@@ -149,4 +157,5 @@ var helperMap = map[string]string{
 	"_fetch":     helperFetch,
 	"_load_json": helperLoadJSON,
 	"_save_json": helperSaveJSON,
+	"_print":     helperPrint,
 }

--- a/tests/dataset/job/compiler/php/q10.out
+++ b/tests/dataset/job/compiler/php/q10.out
@@ -1,0 +1,1 @@
+[{"uncredited_voiced_character":"Ivan","russian_movie":"Vodka Dreams"}]

--- a/tests/dataset/job/compiler/php/q10.php.out
+++ b/tests/dataset/job/compiler/php/q10.php.out
@@ -1,0 +1,119 @@
+<?php
+function mochi_test_Q10_finds_uncredited_voice_actor_in_Russian_movie() {
+	global $result, $russian_movie, $uncredited_voiced_character;
+	if (!(($result == [["uncredited_voiced_character" => "Ivan", "russian_movie" => "Vodka Dreams"]]))) { throw new Exception('expect failed'); }
+}
+
+$char_name = [["id" => 1, "name" => "Ivan"], ["id" => 2, "name" => "Alex"]];
+$cast_info = [["movie_id" => 10, "person_role_id" => 1, "role_id" => 1, "note" => "Soldier (voice) (uncredited)"], ["movie_id" => 11, "person_role_id" => 2, "role_id" => 1, "note" => "(voice)"]];
+$company_name = [["id" => 1, "country_code" => "[ru]"], ["id" => 2, "country_code" => "[us]"]];
+$company_type = [["id" => 1], ["id" => 2]];
+$movie_companies = [["movie_id" => 10, "company_id" => 1, "company_type_id" => 1], ["movie_id" => 11, "company_id" => 2, "company_type_id" => 1]];
+$role_type = [["id" => 1, "role" => "actor"], ["id" => 2, "role" => "director"]];
+$title = [["id" => 10, "title" => "Vodka Dreams", "production_year" => 2006], ["id" => 11, "title" => "Other Film", "production_year" => 2004]];
+$matches = (function() use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) {
+	$_src = $char_name;
+	return _query($_src, [
+		[ 'items' => $cast_info, 'on' => function($chn, $ci) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($chn['id'] == $ci['person_role_id']); } ],
+		[ 'items' => $role_type, 'on' => function($chn, $ci, $rt) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($rt['id'] == $ci['role_id']); } ],
+		[ 'items' => $title, 'on' => function($chn, $ci, $rt, $t) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($t['id'] == $ci['movie_id']); } ],
+		[ 'items' => $movie_companies, 'on' => function($chn, $ci, $rt, $t, $mc) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($mc['movie_id'] == $t['id']); } ],
+		[ 'items' => $company_name, 'on' => function($chn, $ci, $rt, $t, $mc, $cn) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($cn['id'] == $mc['company_id']); } ],
+		[ 'items' => $company_type, 'on' => function($chn, $ci, $rt, $t, $mc, $cn, $ct) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ($ct['id'] == $mc['company_type_id']); } ]
+	], [ 'select' => function($chn, $ci, $rt, $t, $mc, $cn, $ct) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ["character" => $chn['name'], "movie" => $t['title']]; }, 'where' => function($chn, $ci, $rt, $t, $mc, $cn, $ct) use ($cast_info, $char_name, $company_name, $company_type, $movie_companies, $role_type, $title) { return ((((((is_array($ci['note']) ? (array_key_exists("(voice)", $ci['note']) || in_array("(voice)", $ci['note'], true)) : (is_string($ci['note']) ? strpos($ci['note'], strval("(voice)")) !== false : false)) && (is_array($ci['note']) ? (array_key_exists("(uncredited)", $ci['note']) || in_array("(uncredited)", $ci['note'], true)) : (is_string($ci['note']) ? strpos($ci['note'], strval("(uncredited)")) !== false : false))) && ($cn['country_code'] == "[ru]")) && ($rt['role'] == "actor")) && ($t['production_year'] > 2005))); } ]);
+})();
+$result = [["uncredited_voiced_character" => min((function() use ($matches) {
+	$res = [];
+	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
+		$res[] = $x['character'];
+	}
+	return $res;
+})()), "russian_movie" => min((function() use ($matches) {
+	$res = [];
+	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
+		$res[] = $x['movie'];
+	}
+	return $res;
+})())]];
+echo json_encode($result), PHP_EOL;
+mochi_test_Q10_finds_uncredited_voice_actor_in_Russian_movie();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q2.out
+++ b/tests/dataset/job/compiler/php/q2.out
@@ -1,0 +1,1 @@
+"Der Film"

--- a/tests/dataset/job/compiler/php/q2.php.out
+++ b/tests/dataset/job/compiler/php/q2.php.out
@@ -1,0 +1,103 @@
+<?php
+function mochi_test_Q2_finds_earliest_title_for_German_companies_with_character_keyword() {
+	global $result;
+	if (!(($result == "Der Film"))) { throw new Exception('expect failed'); }
+}
+
+$company_name = [["id" => 1, "country_code" => "[de]"], ["id" => 2, "country_code" => "[us]"]];
+$keyword = [["id" => 1, "keyword" => "character-name-in-title"], ["id" => 2, "keyword" => "other"]];
+$movie_companies = [["movie_id" => 100, "company_id" => 1], ["movie_id" => 200, "company_id" => 2]];
+$movie_keyword = [["movie_id" => 100, "keyword_id" => 1], ["movie_id" => 200, "keyword_id" => 2]];
+$title = [["id" => 100, "title" => "Der Film"], ["id" => 200, "title" => "Other Movie"]];
+$titles = (function() use ($company_name, $keyword, $movie_companies, $movie_keyword, $title) {
+	$_src = $company_name;
+	return _query($_src, [
+		[ 'items' => $movie_companies, 'on' => function($cn, $mc) use ($company_name, $keyword, $movie_companies, $movie_keyword, $title) { return ($mc['company_id'] == $cn['id']); } ],
+		[ 'items' => $title, 'on' => function($cn, $mc, $t) use ($company_name, $keyword, $movie_companies, $movie_keyword, $title) { return ($mc['movie_id'] == $t['id']); } ],
+		[ 'items' => $movie_keyword, 'on' => function($cn, $mc, $t, $mk) use ($company_name, $keyword, $movie_companies, $movie_keyword, $title) { return ($mk['movie_id'] == $t['id']); } ],
+		[ 'items' => $keyword, 'on' => function($cn, $mc, $t, $mk, $k) use ($company_name, $keyword, $movie_companies, $movie_keyword, $title) { return ($mk['keyword_id'] == $k['id']); } ]
+	], [ 'select' => function($cn, $mc, $t, $mk, $k) use ($company_name, $keyword, $movie_companies, $movie_keyword, $title) { return $t['title']; }, 'where' => function($cn, $mc, $t, $mk, $k) use ($company_name, $keyword, $movie_companies, $movie_keyword, $title) { return (((($cn['country_code'] == "[de]") && ($k['keyword'] == "character-name-in-title")) && ($mc['movie_id'] == $mk['movie_id']))); } ]);
+})();
+$result = min($titles);
+echo json_encode($result), PHP_EOL;
+mochi_test_Q2_finds_earliest_title_for_German_companies_with_character_keyword();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q3.out
+++ b/tests/dataset/job/compiler/php/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/compiler/php/q3.php.out
+++ b/tests/dataset/job/compiler/php/q3.php.out
@@ -1,0 +1,102 @@
+<?php
+function mochi_test_Q3_returns_lexicographically_smallest_sequel_title() {
+	global $movie_title, $result;
+	if (!(($result == [["movie_title" => "Alpha"]]))) { throw new Exception('expect failed'); }
+}
+
+$keyword = [["id" => 1, "keyword" => "amazing sequel"], ["id" => 2, "keyword" => "prequel"]];
+$movie_info = [["movie_id" => 10, "info" => "Germany"], ["movie_id" => 30, "info" => "Sweden"], ["movie_id" => 20, "info" => "France"]];
+$movie_keyword = [["movie_id" => 10, "keyword_id" => 1], ["movie_id" => 30, "keyword_id" => 1], ["movie_id" => 20, "keyword_id" => 1], ["movie_id" => 10, "keyword_id" => 2]];
+$title = [["id" => 10, "title" => "Alpha", "production_year" => 2006], ["id" => 30, "title" => "Beta", "production_year" => 2008], ["id" => 20, "title" => "Gamma", "production_year" => 2009]];
+$allowed_infos = ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"];
+$candidate_titles = (function() use ($allowed_infos, $keyword, $movie_info, $movie_keyword, $title) {
+	$_src = $keyword;
+	return _query($_src, [
+		[ 'items' => $movie_keyword, 'on' => function($k, $mk) use ($allowed_infos, $keyword, $movie_info, $movie_keyword, $title) { return ($mk['keyword_id'] == $k['id']); } ],
+		[ 'items' => $movie_info, 'on' => function($k, $mk, $mi) use ($allowed_infos, $keyword, $movie_info, $movie_keyword, $title) { return ($mi['movie_id'] == $mk['movie_id']); } ],
+		[ 'items' => $title, 'on' => function($k, $mk, $mi, $t) use ($allowed_infos, $keyword, $movie_info, $movie_keyword, $title) { return ($t['id'] == $mi['movie_id']); } ]
+	], [ 'select' => function($k, $mk, $mi, $t) use ($allowed_infos, $keyword, $movie_info, $movie_keyword, $title) { return $t['title']; }, 'where' => function($k, $mk, $mi, $t) use ($allowed_infos, $keyword, $movie_info, $movie_keyword, $title) { return (((((is_array($k['keyword']) ? (array_key_exists("sequel", $k['keyword']) || in_array("sequel", $k['keyword'], true)) : (is_string($k['keyword']) ? strpos($k['keyword'], strval("sequel")) !== false : false)) && (is_array($allowed_infos) ? (array_key_exists($mi['info'], $allowed_infos) || in_array($mi['info'], $allowed_infos, true)) : (is_string($allowed_infos) ? strpos($allowed_infos, strval($mi['info'])) !== false : false))) && ($t['production_year'] > 2005)) && ($mk['movie_id'] == $mi['movie_id']))); } ]);
+})();
+$result = [["movie_title" => min($candidate_titles)]];
+echo json_encode($result), PHP_EOL;
+mochi_test_Q3_returns_lexicographically_smallest_sequel_title();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q4.out
+++ b/tests/dataset/job/compiler/php/q4.out
@@ -1,0 +1,1 @@
+[{"rating":"6.2","movie_title":"Alpha Movie"}]

--- a/tests/dataset/job/compiler/php/q4.php.out
+++ b/tests/dataset/job/compiler/php/q4.php.out
@@ -1,0 +1,115 @@
+<?php
+function mochi_test_Q4_returns_minimum_rating_and_title_for_sequels() {
+	global $movie_title, $rating, $result;
+	if (!(($result == [["rating" => "6.2", "movie_title" => "Alpha Movie"]]))) { throw new Exception('expect failed'); }
+}
+
+$info_type = [["id" => 1, "info" => "rating"], ["id" => 2, "info" => "other"]];
+$keyword = [["id" => 1, "keyword" => "great sequel"], ["id" => 2, "keyword" => "prequel"]];
+$title = [["id" => 10, "title" => "Alpha Movie", "production_year" => 2006], ["id" => 20, "title" => "Beta Film", "production_year" => 2007], ["id" => 30, "title" => "Old Film", "production_year" => 2004]];
+$movie_keyword = [["movie_id" => 10, "keyword_id" => 1], ["movie_id" => 20, "keyword_id" => 1], ["movie_id" => 30, "keyword_id" => 1]];
+$movie_info_idx = [["movie_id" => 10, "info_type_id" => 1, "info" => "6.2"], ["movie_id" => 20, "info_type_id" => 1, "info" => "7.8"], ["movie_id" => 30, "info_type_id" => 1, "info" => "4.5"]];
+$rows = (function() use ($info_type, $keyword, $movie_info_idx, $movie_keyword, $title) {
+	$_src = $info_type;
+	return _query($_src, [
+		[ 'items' => $movie_info_idx, 'on' => function($it, $mi) use ($info_type, $keyword, $movie_info_idx, $movie_keyword, $title) { return ($it['id'] == $mi['info_type_id']); } ],
+		[ 'items' => $title, 'on' => function($it, $mi, $t) use ($info_type, $keyword, $movie_info_idx, $movie_keyword, $title) { return ($t['id'] == $mi['movie_id']); } ],
+		[ 'items' => $movie_keyword, 'on' => function($it, $mi, $t, $mk) use ($info_type, $keyword, $movie_info_idx, $movie_keyword, $title) { return ($mk['movie_id'] == $t['id']); } ],
+		[ 'items' => $keyword, 'on' => function($it, $mi, $t, $mk, $k) use ($info_type, $keyword, $movie_info_idx, $movie_keyword, $title) { return ($k['id'] == $mk['keyword_id']); } ]
+	], [ 'select' => function($it, $mi, $t, $mk, $k) use ($info_type, $keyword, $movie_info_idx, $movie_keyword, $title) { return ["rating" => $mi['info'], "title" => $t['title']]; }, 'where' => function($it, $mi, $t, $mk, $k) use ($info_type, $keyword, $movie_info_idx, $movie_keyword, $title) { return (((((($it['info'] == "rating") && (is_array($k['keyword']) ? (array_key_exists("sequel", $k['keyword']) || in_array("sequel", $k['keyword'], true)) : (is_string($k['keyword']) ? strpos($k['keyword'], strval("sequel")) !== false : false))) && ($mi['info'] > "5.0")) && ($t['production_year'] > 2005)) && ($mk['movie_id'] == $mi['movie_id']))); } ]);
+})();
+$result = [["rating" => min((function() use ($rows) {
+	$res = [];
+	foreach ((is_string($rows) ? str_split($rows) : $rows) as $r) {
+		$res[] = $r['rating'];
+	}
+	return $res;
+})()), "movie_title" => min((function() use ($rows) {
+	$res = [];
+	foreach ((is_string($rows) ? str_split($rows) : $rows) as $r) {
+		$res[] = $r['title'];
+	}
+	return $res;
+})())]];
+echo json_encode($result), PHP_EOL;
+mochi_test_Q4_returns_minimum_rating_and_title_for_sequels();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q5.out
+++ b/tests/dataset/job/compiler/php/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/compiler/php/q5.php.out
+++ b/tests/dataset/job/compiler/php/q5.php.out
@@ -1,0 +1,103 @@
+<?php
+function mochi_test_Q5_finds_the_lexicographically_first_qualifying_title() {
+	global $result, $typical_european_movie;
+	if (!(($result == [["typical_european_movie" => "A Film"]]))) { throw new Exception('expect failed'); }
+}
+
+$company_type = [["ct_id" => 1, "kind" => "production companies"], ["ct_id" => 2, "kind" => "other"]];
+$info_type = [["it_id" => 10, "info" => "languages"]];
+$title = [["t_id" => 100, "title" => "B Movie", "production_year" => 2010], ["t_id" => 200, "title" => "A Film", "production_year" => 2012], ["t_id" => 300, "title" => "Old Movie", "production_year" => 2000]];
+$movie_companies = [["movie_id" => 100, "company_type_id" => 1, "note" => "ACME (France) (theatrical)"], ["movie_id" => 200, "company_type_id" => 1, "note" => "ACME (France) (theatrical)"], ["movie_id" => 300, "company_type_id" => 1, "note" => "ACME (France) (theatrical)"]];
+$movie_info = [["movie_id" => 100, "info" => "German", "info_type_id" => 10], ["movie_id" => 200, "info" => "Swedish", "info_type_id" => 10], ["movie_id" => 300, "info" => "German", "info_type_id" => 10]];
+$candidate_titles = (function() use ($company_type, $info_type, $movie_companies, $movie_info, $title) {
+	$_src = $company_type;
+	return _query($_src, [
+		[ 'items' => $movie_companies, 'on' => function($ct, $mc) use ($company_type, $info_type, $movie_companies, $movie_info, $title) { return ($mc['company_type_id'] == $ct['ct_id']); } ],
+		[ 'items' => $movie_info, 'on' => function($ct, $mc, $mi) use ($company_type, $info_type, $movie_companies, $movie_info, $title) { return ($mi['movie_id'] == $mc['movie_id']); } ],
+		[ 'items' => $info_type, 'on' => function($ct, $mc, $mi, $it) use ($company_type, $info_type, $movie_companies, $movie_info, $title) { return ($it['it_id'] == $mi['info_type_id']); } ],
+		[ 'items' => $title, 'on' => function($ct, $mc, $mi, $it, $t) use ($company_type, $info_type, $movie_companies, $movie_info, $title) { return ($t['t_id'] == $mc['movie_id']); } ]
+	], [ 'select' => function($ct, $mc, $mi, $it, $t) use ($company_type, $info_type, $movie_companies, $movie_info, $title) { return $t['title']; }, 'where' => function($ct, $mc, $mi, $it, $t) use ($company_type, $info_type, $movie_companies, $movie_info, $title) { return (((((($ct['kind'] == "production companies") && (is_array($mc['note']) ? (array_key_exists("(theatrical)", $mc['note']) || in_array("(theatrical)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(theatrical)")) !== false : false))) && (is_array($mc['note']) ? (array_key_exists("(France)", $mc['note']) || in_array("(France)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(France)")) !== false : false))) && ($t['production_year'] > 2005)) && ((is_array(["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]) ? (array_key_exists($mi['info'], ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]) || in_array($mi['info'], ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"], true)) : (is_string(["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]) ? strpos(["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"], strval($mi['info'])) !== false : false))))); } ]);
+})();
+$result = [["typical_european_movie" => min($candidate_titles)]];
+echo json_encode($result), PHP_EOL;
+mochi_test_Q5_finds_the_lexicographically_first_qualifying_title();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q6.out
+++ b/tests/dataset/job/compiler/php/q6.out
@@ -1,0 +1,1 @@
+[{"movie_keyword":"marvel-cinematic-universe","actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3"}]

--- a/tests/dataset/job/compiler/php/q6.php.out
+++ b/tests/dataset/job/compiler/php/q6.php.out
@@ -1,0 +1,102 @@
+<?php
+function mochi_test_Q6_finds_marvel_movie_with_Robert_Downey() {
+	global $actor_name, $marvel_movie, $movie_keyword, $result;
+	if (!(($result == [["movie_keyword" => "marvel-cinematic-universe", "actor_name" => "Downey Robert Jr.", "marvel_movie" => "Iron Man 3"]]))) { throw new Exception('expect failed'); }
+}
+
+$cast_info = [["movie_id" => 1, "person_id" => 101], ["movie_id" => 2, "person_id" => 102]];
+$keyword = [["id" => 100, "keyword" => "marvel-cinematic-universe"], ["id" => 200, "keyword" => "other"]];
+$movie_keyword = [["movie_id" => 1, "keyword_id" => 100], ["movie_id" => 2, "keyword_id" => 200]];
+$name = [["id" => 101, "name" => "Downey Robert Jr."], ["id" => 102, "name" => "Chris Evans"]];
+$title = [["id" => 1, "title" => "Iron Man 3", "production_year" => 2013], ["id" => 2, "title" => "Old Movie", "production_year" => 2000]];
+$result = (function() use ($cast_info, $keyword, $movie_keyword, $name, $title) {
+	$_src = $cast_info;
+	return _query($_src, [
+		[ 'items' => $movie_keyword, 'on' => function($ci, $mk) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($ci['movie_id'] == $mk['movie_id']); } ],
+		[ 'items' => $keyword, 'on' => function($ci, $mk, $k) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($mk['keyword_id'] == $k['id']); } ],
+		[ 'items' => $name, 'on' => function($ci, $mk, $k, $n) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($ci['person_id'] == $n['id']); } ],
+		[ 'items' => $title, 'on' => function($ci, $mk, $k, $n, $t) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ($ci['movie_id'] == $t['id']); } ]
+	], [ 'select' => function($ci, $mk, $k, $n, $t) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ["movie_keyword" => $k['keyword'], "actor_name" => $n['name'], "marvel_movie" => $t['title']]; }, 'where' => function($ci, $mk, $k, $n, $t) use ($cast_info, $keyword, $movie_keyword, $name, $title) { return ((((($k['keyword'] == "marvel-cinematic-universe") && (is_array($n['name']) ? (array_key_exists("Downey", $n['name']) || in_array("Downey", $n['name'], true)) : (is_string($n['name']) ? strpos($n['name'], strval("Downey")) !== false : false))) && (is_array($n['name']) ? (array_key_exists("Robert", $n['name']) || in_array("Robert", $n['name'], true)) : (is_string($n['name']) ? strpos($n['name'], strval("Robert")) !== false : false))) && ($t['production_year'] > 2010))); } ]);
+})();
+echo json_encode($result), PHP_EOL;
+mochi_test_Q6_finds_marvel_movie_with_Robert_Downey();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q7.out
+++ b/tests/dataset/job/compiler/php/q7.out
@@ -1,0 +1,1 @@
+[{"of_person":"Alan Brown","biography_movie":"Feature Film"}]

--- a/tests/dataset/job/compiler/php/q7.php.out
+++ b/tests/dataset/job/compiler/php/q7.php.out
@@ -1,0 +1,121 @@
+<?php
+function mochi_test_Q7_finds_movie_features_biography_for_person() {
+	global $biography_movie, $of_person, $result;
+	if (!(($result == [["of_person" => "Alan Brown", "biography_movie" => "Feature Film"]]))) { throw new Exception('expect failed'); }
+}
+
+$aka_name = [["person_id" => 1, "name" => "Anna Mae"], ["person_id" => 2, "name" => "Chris"]];
+$cast_info = [["person_id" => 1, "movie_id" => 10], ["person_id" => 2, "movie_id" => 20]];
+$info_type = [["id" => 1, "info" => "mini biography"], ["id" => 2, "info" => "trivia"]];
+$link_type = [["id" => 1, "link" => "features"], ["id" => 2, "link" => "references"]];
+$movie_link = [["linked_movie_id" => 10, "link_type_id" => 1], ["linked_movie_id" => 20, "link_type_id" => 2]];
+$name = [["id" => 1, "name" => "Alan Brown", "name_pcode_cf" => "B", "gender" => "m"], ["id" => 2, "name" => "Zoe", "name_pcode_cf" => "Z", "gender" => "f"]];
+$person_info = [["person_id" => 1, "info_type_id" => 1, "note" => "Volker Boehm"], ["person_id" => 2, "info_type_id" => 1, "note" => "Other"]];
+$title = [["id" => 10, "title" => "Feature Film", "production_year" => 1990], ["id" => 20, "title" => "Late Film", "production_year" => 2000]];
+$rows = (function() use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) {
+	$_src = $aka_name;
+	return _query($_src, [
+		[ 'items' => $name, 'on' => function($an, $n) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($n['id'] == $an['person_id']); } ],
+		[ 'items' => $person_info, 'on' => function($an, $n, $pi) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($pi['person_id'] == $an['person_id']); } ],
+		[ 'items' => $info_type, 'on' => function($an, $n, $pi, $it) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($it['id'] == $pi['info_type_id']); } ],
+		[ 'items' => $cast_info, 'on' => function($an, $n, $pi, $it, $ci) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($ci['person_id'] == $n['id']); } ],
+		[ 'items' => $title, 'on' => function($an, $n, $pi, $it, $ci, $t) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($t['id'] == $ci['movie_id']); } ],
+		[ 'items' => $movie_link, 'on' => function($an, $n, $pi, $it, $ci, $t, $ml) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($ml['linked_movie_id'] == $t['id']); } ],
+		[ 'items' => $link_type, 'on' => function($an, $n, $pi, $it, $ci, $t, $ml, $lt) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ($lt['id'] == $ml['link_type_id']); } ]
+	], [ 'select' => function($an, $n, $pi, $it, $ci, $t, $ml, $lt) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return ["person_name" => $n['name'], "movie_title" => $t['title']]; }, 'where' => function($an, $n, $pi, $it, $ci, $t, $ml, $lt) use ($aka_name, $cast_info, $info_type, $link_type, $movie_link, $name, $person_info, $title) { return (((((((((((((((is_array($an['name']) ? (array_key_exists("a", $an['name']) || in_array("a", $an['name'], true)) : (is_string($an['name']) ? strpos($an['name'], strval("a")) !== false : false)) && ($it['info'] == "mini biography")) && ($lt['link'] == "features")) && ($n['name_pcode_cf'] >= "A")) && ($n['name_pcode_cf'] <= "F")) && ((($n['gender'] == "m") || ((($n['gender'] == "f") && $n['name']['starts_with']("B")))))) && ($pi['note'] == "Volker Boehm")) && ($t['production_year'] >= 1980)) && ($t['production_year'] <= 1995)) && ($pi['person_id'] == $an['person_id'])) && ($pi['person_id'] == $ci['person_id'])) && ($an['person_id'] == $ci['person_id'])) && ($ci['movie_id'] == $ml['linked_movie_id'])))); } ]);
+})();
+$result = [["of_person" => min((function() use ($rows) {
+	$res = [];
+	foreach ((is_string($rows) ? str_split($rows) : $rows) as $r) {
+		$res[] = $r['person_name'];
+	}
+	return $res;
+})()), "biography_movie" => min((function() use ($rows) {
+	$res = [];
+	foreach ((is_string($rows) ? str_split($rows) : $rows) as $r) {
+		$res[] = $r['movie_title'];
+	}
+	return $res;
+})())]];
+echo json_encode($result), PHP_EOL;
+mochi_test_Q7_finds_movie_features_biography_for_person();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q8.out
+++ b/tests/dataset/job/compiler/php/q8.out
@@ -1,0 +1,1 @@
+[{"actress_pseudonym":"Y. S.","japanese_movie_dubbed":"Dubbed Film"}]

--- a/tests/dataset/job/compiler/php/q8.php.out
+++ b/tests/dataset/job/compiler/php/q8.php.out
@@ -1,0 +1,126 @@
+<?php
+function mochi_test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() {
+	global $actress_pseudonym, $japanese_movie_dubbed, $result;
+	if (!(($result == [["actress_pseudonym" => "Y. S.", "japanese_movie_dubbed" => "Dubbed Film"]]))) { throw new Exception('expect failed'); }
+}
+
+$aka_name = [["person_id" => 1, "name" => "Y. S."]];
+$cast_info = [["person_id" => 1, "movie_id" => 10, "note" => "(voice: English version)", "role_id" => 1000]];
+$company_name = [["id" => 50, "country_code" => "[jp]"]];
+$movie_companies = [["movie_id" => 10, "company_id" => 50, "note" => "Studio (Japan)"]];
+$name = [["id" => 1, "name" => "Yoko Ono"], ["id" => 2, "name" => "Yuichi"]];
+$role_type = [["id" => 1000, "role" => "actress"]];
+$title = [["id" => 10, "title" => "Dubbed Film"]];
+$eligible = (function() use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) {
+	$_src = $aka_name;
+	return _query($_src, [
+		[ 'items' => $name, 'on' => function($an1, $n1) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($n1['id'] == $an1['person_id']); } ],
+		[ 'items' => $cast_info, 'on' => function($an1, $n1, $ci) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($ci['person_id'] == $an1['person_id']); } ],
+		[ 'items' => $title, 'on' => function($an1, $n1, $ci, $t) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($t['id'] == $ci['movie_id']); } ],
+		[ 'items' => $movie_companies, 'on' => function($an1, $n1, $ci, $t, $mc) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($mc['movie_id'] == $ci['movie_id']); } ],
+		[ 'items' => $company_name, 'on' => function($an1, $n1, $ci, $t, $mc, $cn) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($cn['id'] == $mc['company_id']); } ],
+		[ 'items' => $role_type, 'on' => function($an1, $n1, $ci, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ($rt['id'] == $ci['role_id']); } ]
+	], [ 'select' => function($an1, $n1, $ci, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return ["pseudonym" => $an1['name'], "movie_title" => $t['title']]; }, 'where' => function($an1, $n1, $ci, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $company_name, $movie_companies, $name, $role_type, $title) { return (((((((($ci['note'] == "(voice: English version)") && ($cn['country_code'] == "[jp]")) && (is_array($mc['note']) ? (array_key_exists("(Japan)", $mc['note']) || in_array("(Japan)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(Japan)")) !== false : false))) && (!(is_array($mc['note']) ? (array_key_exists("(USA)", $mc['note']) || in_array("(USA)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(USA)")) !== false : false)))) && (is_array($n1['name']) ? (array_key_exists("Yo", $n1['name']) || in_array("Yo", $n1['name'], true)) : (is_string($n1['name']) ? strpos($n1['name'], strval("Yo")) !== false : false))) && (!(is_array($n1['name']) ? (array_key_exists("Yu", $n1['name']) || in_array("Yu", $n1['name'], true)) : (is_string($n1['name']) ? strpos($n1['name'], strval("Yu")) !== false : false)))) && ($rt['role'] == "actress"))); } ]);
+})();
+$result = [["actress_pseudonym" => min((function() use ($eligible) {
+	$res = [];
+	foreach ((is_string($eligible) ? str_split($eligible) : $eligible) as $x) {
+		$res[] = $x['pseudonym'];
+	}
+	return $res;
+})()), "japanese_movie_dubbed" => min((function() use ($eligible) {
+	$res = [];
+	foreach ((is_string($eligible) ? str_split($eligible) : $eligible) as $x) {
+		$res[] = $x['movie_title'];
+	}
+	return $res;
+})())]];
+_print($result);
+mochi_test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing();
+
+function _print(...$args) {
+    $parts = [];
+    foreach ($args as $a) {
+        if (is_array($a) || is_object($a)) { $parts[] = json_encode($a); } else { $parts[] = strval($a); }
+    }
+    echo implode(' ', $parts), PHP_EOL;
+}
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}

--- a/tests/dataset/job/compiler/php/q9.out
+++ b/tests/dataset/job/compiler/php/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]

--- a/tests/dataset/job/compiler/php/q9.php.out
+++ b/tests/dataset/job/compiler/php/q9.php.out
@@ -1,0 +1,127 @@
+<?php
+function mochi_test_Q9_selects_minimal_alternative_name__character_and_movie() {
+	global $alternative_name, $character_name, $movie, $result;
+	if (!(($result == [["alternative_name" => "A. N. G.", "character_name" => "Angel", "movie" => "Famous Film"]]))) { throw new Exception('expect failed'); }
+}
+
+$aka_name = [["person_id" => 1, "name" => "A. N. G."], ["person_id" => 2, "name" => "J. D."]];
+$char_name = [["id" => 10, "name" => "Angel"], ["id" => 20, "name" => "Devil"]];
+$cast_info = [["person_id" => 1, "person_role_id" => 10, "movie_id" => 100, "role_id" => 1000, "note" => "(voice)"], ["person_id" => 2, "person_role_id" => 20, "movie_id" => 200, "role_id" => 1000, "note" => "(voice)"]];
+$company_name = [["id" => 100, "country_code" => "[us]"], ["id" => 200, "country_code" => "[gb]"]];
+$movie_companies = [["movie_id" => 100, "company_id" => 100, "note" => "ACME Studios (USA)"], ["movie_id" => 200, "company_id" => 200, "note" => "Maple Films"]];
+$name = [["id" => 1, "name" => "Angela Smith", "gender" => "f"], ["id" => 2, "name" => "John Doe", "gender" => "m"]];
+$role_type = [["id" => 1000, "role" => "actress"], ["id" => 2000, "role" => "actor"]];
+$title = [["id" => 100, "title" => "Famous Film", "production_year" => 2010], ["id" => 200, "title" => "Old Movie", "production_year" => 1999]];
+$matches = (function() use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) {
+	$_src = $aka_name;
+	return _query($_src, [
+		[ 'items' => $name, 'on' => function($an, $n) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($an['person_id'] == $n['id']); } ],
+		[ 'items' => $cast_info, 'on' => function($an, $n, $ci) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($ci['person_id'] == $n['id']); } ],
+		[ 'items' => $char_name, 'on' => function($an, $n, $ci, $chn) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($chn['id'] == $ci['person_role_id']); } ],
+		[ 'items' => $title, 'on' => function($an, $n, $ci, $chn, $t) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($t['id'] == $ci['movie_id']); } ],
+		[ 'items' => $movie_companies, 'on' => function($an, $n, $ci, $chn, $t, $mc) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($mc['movie_id'] == $t['id']); } ],
+		[ 'items' => $company_name, 'on' => function($an, $n, $ci, $chn, $t, $mc, $cn) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($cn['id'] == $mc['company_id']); } ],
+		[ 'items' => $role_type, 'on' => function($an, $n, $ci, $chn, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ($rt['id'] == $ci['role_id']); } ]
+	], [ 'select' => function($an, $n, $ci, $chn, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ["alt" => $an['name'], "character" => $chn['name'], "movie" => $t['title']]; }, 'where' => function($an, $n, $ci, $chn, $t, $mc, $cn, $rt) use ($aka_name, $cast_info, $char_name, $company_name, $movie_companies, $name, $role_type, $title) { return ((((((((((is_array(["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) ? (array_key_exists($ci['note'], ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) || in_array($ci['note'], ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"], true)) : (is_string(["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"]) ? strpos(["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"], strval($ci['note'])) !== false : false))) && ($cn['country_code'] == "[us]")) && (((is_array($mc['note']) ? (array_key_exists("(USA)", $mc['note']) || in_array("(USA)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(USA)")) !== false : false)) || (is_array($mc['note']) ? (array_key_exists("(worldwide)", $mc['note']) || in_array("(worldwide)", $mc['note'], true)) : (is_string($mc['note']) ? strpos($mc['note'], strval("(worldwide)")) !== false : false))))) && ($n['gender'] == "f")) && (is_array($n['name']) ? (array_key_exists("Ang", $n['name']) || in_array("Ang", $n['name'], true)) : (is_string($n['name']) ? strpos($n['name'], strval("Ang")) !== false : false))) && ($rt['role'] == "actress")) && ($t['production_year'] >= 2005)) && ($t['production_year'] <= 2015))); } ]);
+})();
+$result = [["alternative_name" => min((function() use ($matches) {
+	$res = [];
+	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
+		$res[] = $x['alt'];
+	}
+	return $res;
+})()), "character_name" => min((function() use ($matches) {
+	$res = [];
+	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
+		$res[] = $x['character'];
+	}
+	return $res;
+})()), "movie" => min((function() use ($matches) {
+	$res = [];
+	foreach ((is_string($matches) ? str_split($matches) : $matches) as $x) {
+		$res[] = $x['movie'];
+	}
+	return $res;
+})())]];
+echo json_encode($result), PHP_EOL;
+mochi_test_Q9_selects_minimal_alternative_name__character_and_movie();
+
+function _query($src, $joins, $opts) {
+    $items = array_map(fn($v) => [$v], $src);
+    foreach ($joins as $j) {
+        $joined = [];
+        if (!empty($j['right']) && !empty($j['left'])) {
+            $matched = array_fill(0, count($j['items']), false);
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $ri => $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $matched[$ri] = true;
+                    $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) { $joined[] = array_merge($left, [null]); }
+            }
+            foreach ($j['items'] as $ri => $right) {
+                if (!$matched[$ri]) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } elseif (!empty($j['right'])) {
+            foreach ($j['items'] as $right) {
+                $m = false;
+                foreach ($items as $left) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!$m) {
+                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
+                    $joined[] = array_merge($undef, [$right]);
+                }
+            }
+        } else {
+            foreach ($items as $left) {
+                $m = false;
+                foreach ($j['items'] as $right) {
+                    $keep = true;
+                    if (isset($j['on'])) { $args = array_merge($left, [$right]); $keep = $j['on'](...$args); }
+                    if (!$keep) continue;
+                    $m = true; $joined[] = array_merge($left, [$right]);
+                }
+                if (!empty($j['left']) && !$m) { $joined[] = array_merge($left, [null]); }
+            }
+        }
+        $items = $joined;
+    }
+    if (isset($opts['where'])) {
+        $filtered = [];
+        foreach ($items as $r) { if ($opts['where'](...$r)) $filtered[] = $r; }
+        $items = $filtered;
+    }
+    if (isset($opts['sortKey'])) {
+        $pairs = [];
+        foreach ($items as $it) { $pairs[] = ['item' => $it, 'key' => $opts['sortKey'](...$it)]; }
+        usort($pairs, function($a, $b) {
+            $ak = $a['key']; $bk = $b['key'];
+            if (is_int($ak) && is_int($bk)) return $ak <=> $bk;
+            if (is_string($ak) && is_string($bk)) return $ak <=> $bk;
+            return strcmp(strval($ak), strval($bk));
+        });
+        $items = array_map(fn($p) => $p['item'], $pairs);
+    }
+    if (array_key_exists('skip', $opts)) {
+        $n = $opts['skip'];
+        $items = $n < count($items) ? array_slice($items, $n) : [];
+    }
+    if (array_key_exists('take', $opts)) {
+        $n = $opts['take'];
+        if ($n < count($items)) $items = array_slice($items, 0, $n);
+    }
+    $res = [];
+    foreach ($items as $r) { $res[] = $opts['select'](...$r); }
+    return $res;
+}


### PR DESCRIPTION
## Summary
- support printing complex values by emitting `_print` helper
- hook `_print` into the PHP runtime helpers
- extend JOB PHP test to compile and run `q1` through `q10`
- generate golden PHP output for JOB `q1`–`q10`
- document new query coverage in `TASKS.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e77fe3bf88320813d2f0fc84b8fd2