### PR TITLE
Add JOB q1-q10 Ruby compiler tests

### DIFF
--- a/compile/x/rb/TASKS.md
+++ b/compile/x/rb/TASKS.md
@@ -1,14 +1,15 @@
-# Ruby Backend Tasks for TPCH Q1
+# Ruby Backend Tasks
 
-The Ruby backend now supports running the TPCH Q1 example. Dataset queries
-can combine filtering with grouping so more complex benchmarks compile
-successfully.
+The Ruby backend supports running the TPCH Q1 example and now compiles the first
+ten JOB queries. Dataset queries can combine filtering with grouping so more
+complex benchmarks compile successfully.
 
 Implemented features:
 - Grouping and query helpers via `_group_by` and `_query`.
 - Struct values mapped to `OpenStruct` for convenient field access.
 - Helper methods `sum`, `avg`, `count` and `json` for datasets.
 - Golden tests under `tests/dataset/tpc-h/compiler/rb` verify generated code
-  and runtime output.
+  and runtime output. Additional golden tests cover JOB queries `q1`–`q10` under
+  `tests/dataset/job/compiler/rb`.
 - Added `group_by_where.mochi` to `tests/compiler/rb` which exercises grouping
   with a `where` clause using the new helpers.

--- a/compile/x/rb/compiler_test.go
+++ b/compile/x/rb/compiler_test.go
@@ -303,6 +303,58 @@ func TestRBCompiler_JOBQ1(t *testing.T) {
 	}
 }
 
+func TestRBCompiler_JOB(t *testing.T) {
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10"}
+	for _, q := range queries {
+		src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Fatalf("type error: %v", errs[0])
+		}
+		code, err := rbcode.New(env).Compile(prog)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+		wantCodePath := filepath.Join(root, "tests", "dataset", "job", "compiler", "rb", q+".rb.out")
+		wantCode, err := os.ReadFile(wantCodePath)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+			t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", q+".rb.out", got, bytes.TrimSpace(wantCode))
+		}
+
+		dir := t.TempDir()
+		file := filepath.Join(dir, "main.rb")
+		if err := os.WriteFile(file, code, 0644); err != nil {
+			t.Fatalf("write error: %v", err)
+		}
+		cmd := exec.Command("ruby", file)
+		cmd.Dir = findRepoRoot(t)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("ruby run error: %v\n%s", err, out)
+		}
+		gotOut := bytes.TrimSpace(out)
+		wantOutPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "rb", q+".out")
+		wantOut, err := os.ReadFile(wantOutPath)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+			t.Errorf("output mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", q+".out", gotOut, bytes.TrimSpace(wantOut))
+		}
+	}
+}
+
 func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/tests/dataset/job/compiler/rb/q10.out
+++ b/tests/dataset/job/compiler/rb/q10.out
@@ -1,0 +1,1 @@
+[{"uncredited_voiced_character":"Ivan","russian_movie":"Vodka Dreams"}]

--- a/tests/dataset/job/compiler/rb/q10.rb.out
+++ b/tests/dataset/job/compiler/rb/q10.rb.out
@@ -1,0 +1,69 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+char_name = [OpenStruct.new(id: 1, name: "Ivan"), OpenStruct.new(id: 2, name: "Alex")]
+cast_info = [OpenStruct.new(movie_id: 10, person_role_id: 1, role_id: 1, note: "Soldier (voice) (uncredited)"), OpenStruct.new(movie_id: 11, person_role_id: 2, role_id: 1, note: "(voice)")]
+company_name = [OpenStruct.new(id: 1, country_code: "[ru]"), OpenStruct.new(id: 2, country_code: "[us]")]
+company_type = [OpenStruct.new(id: 1), OpenStruct.new(id: 2)]
+movie_companies = [OpenStruct.new(movie_id: 10, company_id: 1, company_type_id: 1), OpenStruct.new(movie_id: 11, company_id: 2, company_type_id: 1)]
+role_type = [OpenStruct.new(id: 1, role: "actor"), OpenStruct.new(id: 2, role: "director")]
+title = [OpenStruct.new(id: 10, title: "Vodka Dreams", production_year: 2006), OpenStruct.new(id: 11, title: "Other Film", production_year: 2004)]
+matches = (begin
+  _res = []
+  for chn in char_name
+    for ci in cast_info
+      if chn.id == ci.person_role_id
+        for rt in role_type
+          if rt.id == ci.role_id
+            for t in title
+              if t.id == ci.movie_id
+                for mc in movie_companies
+                  if mc.movie_id == t.id
+                    for cn in company_name
+                      if cn.id == mc.company_id
+                        for ct in company_type
+                          if ct.id == mc.company_type_id
+                            if ci.note.include?("(voice)") && ci.note.include?("(uncredited)") && (cn.country_code == "[ru]") && (rt.role == "actor") && (t.production_year > 2005)
+                              _res << OpenStruct.new(character: chn.name, movie: t.title)
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = [OpenStruct.new(uncredited_voiced_character: _min(matches.map { |x| x.character }), russian_movie: _min(matches.map { |x| x.movie }))]
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(uncredited_voiced_character: "Ivan", russian_movie: "Vodka Dreams")]

--- a/tests/dataset/job/compiler/rb/q2.out
+++ b/tests/dataset/job/compiler/rb/q2.out
@@ -1,0 +1,1 @@
+"Der Film"

--- a/tests/dataset/job/compiler/rb/q2.rb.out
+++ b/tests/dataset/job/compiler/rb/q2.rb.out
@@ -1,0 +1,59 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+company_name = [OpenStruct.new(id: 1, country_code: "[de]"), OpenStruct.new(id: 2, country_code: "[us]")]
+keyword = [OpenStruct.new(id: 1, keyword: "character-name-in-title"), OpenStruct.new(id: 2, keyword: "other")]
+movie_companies = [OpenStruct.new(movie_id: 100, company_id: 1), OpenStruct.new(movie_id: 200, company_id: 2)]
+movie_keyword = [OpenStruct.new(movie_id: 100, keyword_id: 1), OpenStruct.new(movie_id: 200, keyword_id: 2)]
+title = [OpenStruct.new(id: 100, title: "Der Film"), OpenStruct.new(id: 200, title: "Other Movie")]
+titles = (begin
+  _res = []
+  for cn in company_name
+    for mc in movie_companies
+      if mc.company_id == cn.id
+        for t in title
+          if mc.movie_id == t.id
+            for mk in movie_keyword
+              if mk.movie_id == t.id
+                for k in keyword
+                  if mk.keyword_id == k.id
+                    if (cn.country_code == "[de]") && (k.keyword == "character-name-in-title") && (mc.movie_id == mk.movie_id)
+                      _res << t.title
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = _min(titles)
+_json(result)
+raise "expect failed" unless result == "Der Film"

--- a/tests/dataset/job/compiler/rb/q3.out
+++ b/tests/dataset/job/compiler/rb/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/compiler/rb/q3.rb.out
+++ b/tests/dataset/job/compiler/rb/q3.rb.out
@@ -1,0 +1,55 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+keyword = [OpenStruct.new(id: 1, keyword: "amazing sequel"), OpenStruct.new(id: 2, keyword: "prequel")]
+movie_info = [OpenStruct.new(movie_id: 10, info: "Germany"), OpenStruct.new(movie_id: 30, info: "Sweden"), OpenStruct.new(movie_id: 20, info: "France")]
+movie_keyword = [OpenStruct.new(movie_id: 10, keyword_id: 1), OpenStruct.new(movie_id: 30, keyword_id: 1), OpenStruct.new(movie_id: 20, keyword_id: 1), OpenStruct.new(movie_id: 10, keyword_id: 2)]
+title = [OpenStruct.new(id: 10, title: "Alpha", production_year: 2006), OpenStruct.new(id: 30, title: "Beta", production_year: 2008), OpenStruct.new(id: 20, title: "Gamma", production_year: 2009)]
+allowed_infos = ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"]
+candidate_titles = (begin
+  _res = []
+  for k in keyword
+    for mk in movie_keyword
+      if mk.keyword_id == k.id
+        for mi in movie_info
+          if mi.movie_id == mk.movie_id
+            for t in title
+              if t.id == mi.movie_id
+                if k.keyword.include?("sequel") && allowed_infos.include?(mi.info) && (t.production_year > 2005) && (mk.movie_id == mi.movie_id)
+                  _res << t.title
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = [OpenStruct.new(movie_title: _min(candidate_titles))]
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(movie_title: "Alpha")]

--- a/tests/dataset/job/compiler/rb/q4.out
+++ b/tests/dataset/job/compiler/rb/q4.out
@@ -1,0 +1,1 @@
+[{"rating":"6.2","movie_title":"Alpha Movie"}]

--- a/tests/dataset/job/compiler/rb/q4.rb.out
+++ b/tests/dataset/job/compiler/rb/q4.rb.out
@@ -1,0 +1,59 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+info_type = [OpenStruct.new(id: 1, info: "rating"), OpenStruct.new(id: 2, info: "other")]
+keyword = [OpenStruct.new(id: 1, keyword: "great sequel"), OpenStruct.new(id: 2, keyword: "prequel")]
+title = [OpenStruct.new(id: 10, title: "Alpha Movie", production_year: 2006), OpenStruct.new(id: 20, title: "Beta Film", production_year: 2007), OpenStruct.new(id: 30, title: "Old Film", production_year: 2004)]
+movie_keyword = [OpenStruct.new(movie_id: 10, keyword_id: 1), OpenStruct.new(movie_id: 20, keyword_id: 1), OpenStruct.new(movie_id: 30, keyword_id: 1)]
+movie_info_idx = [OpenStruct.new(movie_id: 10, info_type_id: 1, info: "6.2"), OpenStruct.new(movie_id: 20, info_type_id: 1, info: "7.8"), OpenStruct.new(movie_id: 30, info_type_id: 1, info: "4.5")]
+rows = (begin
+  _res = []
+  for it in info_type
+    for mi in movie_info_idx
+      if it.id == mi.info_type_id
+        for t in title
+          if t.id == mi.movie_id
+            for mk in movie_keyword
+              if mk.movie_id == t.id
+                for k in keyword
+                  if k.id == mk.keyword_id
+                    if (it.info == "rating") && k.keyword.include?("sequel") && (mi.info > "5.0") && (t.production_year > 2005) && (mk.movie_id == mi.movie_id)
+                      _res << OpenStruct.new(rating: mi.info, title: t.title)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = [OpenStruct.new(rating: _min(rows.map { |r| r.rating }), movie_title: _min(rows.map { |r| r.title }))]
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(rating: "6.2", movie_title: "Alpha Movie")]

--- a/tests/dataset/job/compiler/rb/q5.out
+++ b/tests/dataset/job/compiler/rb/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/compiler/rb/q5.rb.out
+++ b/tests/dataset/job/compiler/rb/q5.rb.out
@@ -1,0 +1,59 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+company_type = [OpenStruct.new(ct_id: 1, kind: "production companies"), OpenStruct.new(ct_id: 2, kind: "other")]
+info_type = [OpenStruct.new(it_id: 10, info: "languages")]
+title = [OpenStruct.new(t_id: 100, title: "B Movie", production_year: 2010), OpenStruct.new(t_id: 200, title: "A Film", production_year: 2012), OpenStruct.new(t_id: 300, title: "Old Movie", production_year: 2000)]
+movie_companies = [OpenStruct.new(movie_id: 100, company_type_id: 1, note: "ACME (France) (theatrical)"), OpenStruct.new(movie_id: 200, company_type_id: 1, note: "ACME (France) (theatrical)"), OpenStruct.new(movie_id: 300, company_type_id: 1, note: "ACME (France) (theatrical)")]
+movie_info = [OpenStruct.new(movie_id: 100, info: "German", info_type_id: 10), OpenStruct.new(movie_id: 200, info: "Swedish", info_type_id: 10), OpenStruct.new(movie_id: 300, info: "German", info_type_id: 10)]
+candidate_titles = (begin
+  _res = []
+  for ct in company_type
+    for mc in movie_companies
+      if mc.company_type_id == ct.ct_id
+        for mi in movie_info
+          if mi.movie_id == mc.movie_id
+            for it in info_type
+              if it.it_id == mi.info_type_id
+                for t in title
+                  if t.t_id == mc.movie_id
+                    if (ct.kind == "production companies") && mc.note.include?("(theatrical)") && mc.note.include?("(France)") && (t.production_year > 2005) && ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"].include?(mi.info)
+                      _res << t.title
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = [OpenStruct.new(typical_european_movie: _min(candidate_titles))]
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(typical_european_movie: "A Film")]

--- a/tests/dataset/job/compiler/rb/q6.out
+++ b/tests/dataset/job/compiler/rb/q6.out
@@ -1,0 +1,1 @@
+[{"movie_keyword":"marvel-cinematic-universe","actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3"}]

--- a/tests/dataset/job/compiler/rb/q6.rb.out
+++ b/tests/dataset/job/compiler/rb/q6.rb.out
@@ -1,0 +1,45 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+cast_info = [OpenStruct.new(movie_id: 1, person_id: 101), OpenStruct.new(movie_id: 2, person_id: 102)]
+keyword = [OpenStruct.new(id: 100, keyword: "marvel-cinematic-universe"), OpenStruct.new(id: 200, keyword: "other")]
+movie_keyword = [OpenStruct.new(movie_id: 1, keyword_id: 100), OpenStruct.new(movie_id: 2, keyword_id: 200)]
+name = [OpenStruct.new(id: 101, name: "Downey Robert Jr."), OpenStruct.new(id: 102, name: "Chris Evans")]
+title = [OpenStruct.new(id: 1, title: "Iron Man 3", production_year: 2013), OpenStruct.new(id: 2, title: "Old Movie", production_year: 2000)]
+result = (begin
+  _res = []
+  for ci in cast_info
+    for mk in movie_keyword
+      if ci.movie_id == mk.movie_id
+        for k in keyword
+          if mk.keyword_id == k.id
+            for n in name
+              if ci.person_id == n.id
+                for t in title
+                  if ci.movie_id == t.id
+                    if (k.keyword == "marvel-cinematic-universe") && n.name.include?("Downey") && n.name.include?("Robert") && (t.production_year > 2010)
+                      _res << OpenStruct.new(movie_keyword: k.keyword, actor_name: n.name, marvel_movie: t.title)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(movie_keyword: "marvel-cinematic-universe", actor_name: "Downey Robert Jr.", marvel_movie: "Iron Man 3")]

--- a/tests/dataset/job/compiler/rb/q7.out
+++ b/tests/dataset/job/compiler/rb/q7.out
@@ -1,0 +1,1 @@
+[{"of_person":"Alan Brown","biography_movie":"Feature Film"}]

--- a/tests/dataset/job/compiler/rb/q7.rb.out
+++ b/tests/dataset/job/compiler/rb/q7.rb.out
@@ -1,0 +1,74 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+aka_name = [OpenStruct.new(person_id: 1, name: "Anna Mae"), OpenStruct.new(person_id: 2, name: "Chris")]
+cast_info = [OpenStruct.new(person_id: 1, movie_id: 10), OpenStruct.new(person_id: 2, movie_id: 20)]
+info_type = [OpenStruct.new(id: 1, info: "mini biography"), OpenStruct.new(id: 2, info: "trivia")]
+link_type = [OpenStruct.new(id: 1, link: "features"), OpenStruct.new(id: 2, link: "references")]
+movie_link = [OpenStruct.new(linked_movie_id: 10, link_type_id: 1), OpenStruct.new(linked_movie_id: 20, link_type_id: 2)]
+name = [OpenStruct.new(id: 1, name: "Alan Brown", name_pcode_cf: "B", gender: "m"), OpenStruct.new(id: 2, name: "Zoe", name_pcode_cf: "Z", gender: "f")]
+person_info = [OpenStruct.new(person_id: 1, info_type_id: 1, note: "Volker Boehm"), OpenStruct.new(person_id: 2, info_type_id: 1, note: "Other")]
+title = [OpenStruct.new(id: 10, title: "Feature Film", production_year: 1990), OpenStruct.new(id: 20, title: "Late Film", production_year: 2000)]
+rows = (begin
+  _res = []
+  for an in aka_name
+    for n in name
+      if n.id == an.person_id
+        for pi in person_info
+          if pi.person_id == an.person_id
+            for it in info_type
+              if it.id == pi.info_type_id
+                for ci in cast_info
+                  if ci.person_id == n.id
+                    for t in title
+                      if t.id == ci.movie_id
+                        for ml in movie_link
+                          if ml.linked_movie_id == t.id
+                            for lt in link_type
+                              if lt.id == ml.link_type_id
+                                if an.name.include?("a") && (it.info == "mini biography") && (lt.link == "features") && (n.name_pcode_cf >= "A") && (n.name_pcode_cf <= "F") && ((n.gender == "m") || ((n.gender == "f") && n.name.starts_with.call("B"))) && (pi.note == "Volker Boehm") && (t.production_year >= 1980) && (t.production_year <= 1995) && (pi.person_id == an.person_id) && (pi.person_id == ci.person_id) && (an.person_id == ci.person_id) && (ci.movie_id == ml.linked_movie_id)
+                                  _res << OpenStruct.new(person_name: n.name, movie_title: t.title)
+                                end
+                              end
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = [OpenStruct.new(of_person: _min(rows.map { |r| r.person_name }), biography_movie: _min(rows.map { |r| r.movie_title }))]
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(of_person: "Alan Brown", biography_movie: "Feature Film")]

--- a/tests/dataset/job/compiler/rb/q8.out
+++ b/tests/dataset/job/compiler/rb/q8.out
@@ -1,0 +1,1 @@
+[#<OpenStruct actress_pseudonym="Y. S.", japanese_movie_dubbed="Dubbed Film">]

--- a/tests/dataset/job/compiler/rb/q8.rb.out
+++ b/tests/dataset/job/compiler/rb/q8.rb.out
@@ -1,0 +1,58 @@
+require "ostruct"
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+aka_name = [OpenStruct.new(person_id: 1, name: "Y. S.")]
+cast_info = [OpenStruct.new(person_id: 1, movie_id: 10, note: "(voice: English version)", role_id: 1000)]
+company_name = [OpenStruct.new(id: 50, country_code: "[jp]")]
+movie_companies = [OpenStruct.new(movie_id: 10, company_id: 50, note: "Studio (Japan)")]
+name = [OpenStruct.new(id: 1, name: "Yoko Ono"), OpenStruct.new(id: 2, name: "Yuichi")]
+role_type = [OpenStruct.new(id: 1000, role: "actress")]
+title = [OpenStruct.new(id: 10, title: "Dubbed Film")]
+eligible = (begin
+  _res = []
+  for an1 in aka_name
+    for n1 in name
+      if n1.id == an1.person_id
+        for ci in cast_info
+          if ci.person_id == an1.person_id
+            for t in title
+              if t.id == ci.movie_id
+                for mc in movie_companies
+                  if mc.movie_id == ci.movie_id
+                    for cn in company_name
+                      if cn.id == mc.company_id
+                        for rt in role_type
+                          if rt.id == ci.role_id
+                            if (ci.note == "(voice: English version)") && (cn.country_code == "[jp]") && mc.note.include?("(Japan)") && !mc.note.include?("(USA)") && n1.name.include?("Yo") && !n1.name.include?("Yu") && (rt.role == "actress")
+                              _res << OpenStruct.new(pseudonym: an1.name, movie_title: t.title)
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = [OpenStruct.new(actress_pseudonym: _min(eligible.map { |x| x.pseudonym }), japanese_movie_dubbed: _min(eligible.map { |x| x.movie_title }))]
+puts(result.inspect)
+raise "expect failed" unless result == [OpenStruct.new(actress_pseudonym: "Y. S.", japanese_movie_dubbed: "Dubbed Film")]

--- a/tests/dataset/job/compiler/rb/q9.out
+++ b/tests/dataset/job/compiler/rb/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]

--- a/tests/dataset/job/compiler/rb/q9.rb.out
+++ b/tests/dataset/job/compiler/rb/q9.rb.out
@@ -1,0 +1,74 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+aka_name = [OpenStruct.new(person_id: 1, name: "A. N. G."), OpenStruct.new(person_id: 2, name: "J. D.")]
+char_name = [OpenStruct.new(id: 10, name: "Angel"), OpenStruct.new(id: 20, name: "Devil")]
+cast_info = [OpenStruct.new(person_id: 1, person_role_id: 10, movie_id: 100, role_id: 1000, note: "(voice)"), OpenStruct.new(person_id: 2, person_role_id: 20, movie_id: 200, role_id: 1000, note: "(voice)")]
+company_name = [OpenStruct.new(id: 100, country_code: "[us]"), OpenStruct.new(id: 200, country_code: "[gb]")]
+movie_companies = [OpenStruct.new(movie_id: 100, company_id: 100, note: "ACME Studios (USA)"), OpenStruct.new(movie_id: 200, company_id: 200, note: "Maple Films")]
+name = [OpenStruct.new(id: 1, name: "Angela Smith", gender: "f"), OpenStruct.new(id: 2, name: "John Doe", gender: "m")]
+role_type = [OpenStruct.new(id: 1000, role: "actress"), OpenStruct.new(id: 2000, role: "actor")]
+title = [OpenStruct.new(id: 100, title: "Famous Film", production_year: 2010), OpenStruct.new(id: 200, title: "Old Movie", production_year: 1999)]
+matches = (begin
+  _res = []
+  for an in aka_name
+    for n in name
+      if an.person_id == n.id
+        for ci in cast_info
+          if ci.person_id == n.id
+            for chn in char_name
+              if chn.id == ci.person_role_id
+                for t in title
+                  if t.id == ci.movie_id
+                    for mc in movie_companies
+                      if mc.movie_id == t.id
+                        for cn in company_name
+                          if cn.id == mc.company_id
+                            for rt in role_type
+                              if rt.id == ci.role_id
+                                if ["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"].include?(ci.note) && (cn.country_code == "[us]") && (mc.note.include?("(USA)") || mc.note.include?("(worldwide)")) && (n.gender == "f") && n.name.include?("Ang") && (rt.role == "actress") && (t.production_year >= 2005) && (t.production_year <= 2015)
+                                  _res << OpenStruct.new(alt: an.name, character: chn.name, movie: t.title)
+                                end
+                              end
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+result = [OpenStruct.new(alternative_name: _min(matches.map { |x| x.alt }), character_name: _min(matches.map { |x| x.character }), movie: _min(matches.map { |x| x.movie }))]
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(alternative_name: "A. N. G.", character_name: "Angel", movie: "Famous Film")]

--- a/tests/dataset/job/out/q10.out
+++ b/tests/dataset/job/out/q10.out
@@ -1,0 +1,1 @@
+[{"uncredited_voiced_character":"Ivan","russian_movie":"Vodka Dreams"}]

--- a/tests/dataset/job/out/q3.out
+++ b/tests/dataset/job/out/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/out/q4.out
+++ b/tests/dataset/job/out/q4.out
@@ -1,0 +1,1 @@
+[{"rating":"6.2","movie_title":"Alpha Movie"}]

--- a/tests/dataset/job/out/q5.out
+++ b/tests/dataset/job/out/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/out/q6.out
+++ b/tests/dataset/job/out/q6.out
@@ -1,0 +1,1 @@
+[{"movie_keyword":"marvel-cinematic-universe","actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3"}]

--- a/tests/dataset/job/out/q7.out
+++ b/tests/dataset/job/out/q7.out
@@ -1,0 +1,1 @@
+[{"of_person":"Alan Brown","biography_movie":"Feature Film"}]

--- a/tests/dataset/job/out/q8.out
+++ b/tests/dataset/job/out/q8.out
@@ -1,0 +1,1 @@
+[#<OpenStruct actress_pseudonym="Y. S.", japanese_movie_dubbed="Dubbed Film">]

--- a/tests/dataset/job/out/q9.out
+++ b/tests/dataset/job/out/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]


### PR DESCRIPTION
## Summary
- add JOB q1-q10 golden outputs
- compile and run JOB queries in Ruby tests
- document JOB support in Ruby backend tasks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e78045a308320a82a242506345ee4