### PR TITLE
Add Zig JOB dataset golden tests

### DIFF
--- a/compile/x/zig/TASKS.md
+++ b/compile/x/zig/TASKS.md
@@ -10,3 +10,7 @@ Remaining work
 ---------------
 
 - Add join and sorting support for query expressions.
+- JOB dataset queries q1-q10 compile but the generated Zig code fails to build
+  due to incorrect boolean expression parsing. The parser flattens chained
+  comparisons like `a == b && c == d`, producing invalid Zig code. Update the
+  parser to preserve operator precedence so these queries can run successfully.

--- a/compile/x/zig/job_golden_test.go
+++ b/compile/x/zig/job_golden_test.go
@@ -4,6 +4,7 @@ package zigcode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,30 +15,33 @@ import (
 	"mochi/types"
 )
 
-func TestZigCompiler_JOBQ1_Golden(t *testing.T) {
+func TestZigCompiler_JOB_Golden(t *testing.T) {
 	if _, err := zigcode.EnsureZig(); err != nil {
 		t.Skipf("zig not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := zigcode.New(env).Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	wantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "zig", "q1.zig.out")
-	want, err := os.ReadFile(wantPath)
-	if err != nil {
-		t.Fatalf("read golden: %v", err)
-	}
-	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
-		t.Errorf("generated code mismatch for q1.zig.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(want))
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Fatalf("type error: %v", errs[0])
+		}
+		code, err := zigcode.New(env).Compile(prog)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+		wantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "zig", q+".zig.out")
+		want, err := os.ReadFile(wantPath)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+			t.Errorf("generated code mismatch for %s.zig.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(want))
+		}
 	}
 }

--- a/compile/x/zig/job_test.go
+++ b/compile/x/zig/job_test.go
@@ -3,6 +3,7 @@
 package zigcode_test
 
 import (
+	"fmt"
 	"testing"
 
 	"mochi/compile/x/testutil"
@@ -15,7 +16,10 @@ func TestZigCompiler_JOB(t *testing.T) {
 	if _, err := zigcode.EnsureZig(); err != nil {
 		t.Skipf("zig not installed: %v", err)
 	}
-	testutil.CompileJOB(t, "q1", func(env *types.Env, prog *parser.Program) ([]byte, error) {
-		return zigcode.New(env).Compile(prog)
-	})
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		testutil.CompileJOB(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+			return zigcode.New(env).Compile(prog)
+		})
+	}
 }

--- a/tests/dataset/job/compiler/zig/q10.zig.out
+++ b/tests/dataset/job/compiler/zig/q10.zig.out
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q10_finds_uncredited_voice_actor_in_Russian_movie() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(uncredited_voiced_character, "Ivan") catch unreachable; m.put(russian_movie, "Vodka Dreams") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const char_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(name, "Ivan") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(name, "Alex") catch unreachable; break :blk m; }};
+    const cast_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(person_role_id, @as(i32,@intCast(1))) catch unreachable; m.put(role_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "Soldier (voice) (uncredited)") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(11))) catch unreachable; m.put(person_role_id, @as(i32,@intCast(2))) catch unreachable; m.put(role_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "(voice)") catch unreachable; break :blk m; }};
+    const company_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(country_code, "[ru]") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(country_code, "[us]") catch unreachable; break :blk m; }};
+    const company_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; break :blk m; }};
+    const movie_companies: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(company_id, @as(i32,@intCast(1))) catch unreachable; m.put(company_type_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(11))) catch unreachable; m.put(company_id, @as(i32,@intCast(2))) catch unreachable; m.put(company_type_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }};
+    const role_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(role, "actor") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(role, "director") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(10))) catch unreachable; m.put(title, "Vodka Dreams") catch unreachable; m.put(production_year, @as(i32,@intCast(2006))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(11))) catch unreachable; m.put(title, "Other Film") catch unreachable; m.put(production_year, @as(i32,@intCast(2004))) catch unreachable; break :blk m; }};
+    const matches: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (char_name) |chn| { for (cast_info) |ci| { if !((chn.id == ci.person_role_id)) continue; for (role_type) |rt| { if !((rt.id == ci.role_id)) continue; for (title) |t| { if !((t.id == ci.movie_id)) continue; for (movie_companies) |mc| { if !((mc.movie_id == t.id)) continue; for (company_name) |cn| { if !((cn.id == mc.company_id)) continue; for (company_type) |ct| { if !((ct.id == mc.company_type_id)) continue; if !(((std.mem.eql(u8, (std.mem.eql(u8, ((ci.note.contains("(voice)") and ci.note.contains("(uncredited)")) and cn.country_code), "[ru]") and rt.role), "actor") and t.production_year) > @as(i32,@intCast(2005)))) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(character, chn.name) catch unreachable; m.put(movie, t.title) catch unreachable; break :blk m; }) catch unreachable; } } } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(uncredited_voiced_character, _min_int(blk: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (matches) |x| { _tmp2.append(x.character) catch unreachable; } var _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk _tmp3; })) catch unreachable; m.put(russian_movie, _min_int(blk: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (matches) |x| { _tmp4.append(x.movie) catch unreachable; } var _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk _tmp5; })) catch unreachable; break :blk m; }};
+    _json(result);
+    test_Q10_finds_uncredited_voice_actor_in_Russian_movie();
+}

--- a/tests/dataset/job/compiler/zig/q2.zig.out
+++ b/tests/dataset/job/compiler/zig/q2.zig.out
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q2_finds_earliest_title_for_German_companies_with_character_keyword() void {
+    expect(std.mem.eql(u8, result, "Der Film"));
+}
+
+pub fn main() void {
+    const company_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(country_code, "[de]") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(country_code, "[us]") catch unreachable; break :blk m; }};
+    const keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(keyword, "character-name-in-title") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(keyword, "other") catch unreachable; break :blk m; }};
+    const movie_companies: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(company_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(company_id, @as(i32,@intCast(2))) catch unreachable; break :blk m; }};
+    const movie_keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(2))) catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(100))) catch unreachable; m.put(title, "Der Film") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(200))) catch unreachable; m.put(title, "Other Movie") catch unreachable; break :blk m; }};
+    const titles: []const i32 = blk: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (company_name) |cn| { for (movie_companies) |mc| { if !((mc.company_id == cn.id)) continue; for (title) |t| { if !((mc.movie_id == t.id)) continue; for (movie_keyword) |mk| { if !((mk.movie_id == t.id)) continue; for (keyword) |k| { if !((mk.keyword_id == k.id)) continue; if !(((std.mem.eql(u8, (std.mem.eql(u8, cn.country_code, "[de]") and k.keyword), "character-name-in-title") and mc.movie_id) == mk.movie_id)) continue; _tmp0.append(t.title) catch unreachable; } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: i32 = _min_int(titles);
+    _json(result);
+    test_Q2_finds_earliest_title_for_German_companies_with_character_keyword();
+}

--- a/tests/dataset/job/compiler/zig/q3.zig.out
+++ b/tests/dataset/job/compiler/zig/q3.zig.out
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _contains_list_string(v: []const []const u8, item: []const u8) bool {
+    for (v) |it| { if (std.mem.eql(u8, it, item)) return true; }
+    return false;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q3_returns_lexicographically_smallest_sequel_title() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(movie_title, "Alpha") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(keyword, "amazing sequel") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(keyword, "prequel") catch unreachable; break :blk m; }};
+    const movie_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(info, "Germany") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(30))) catch unreachable; m.put(info, "Sweden") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(20))) catch unreachable; m.put(info, "France") catch unreachable; break :blk m; }};
+    const movie_keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(30))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(20))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(2))) catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(10))) catch unreachable; m.put(title, "Alpha") catch unreachable; m.put(production_year, @as(i32,@intCast(2006))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(30))) catch unreachable; m.put(title, "Beta") catch unreachable; m.put(production_year, @as(i32,@intCast(2008))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(20))) catch unreachable; m.put(title, "Gamma") catch unreachable; m.put(production_year, @as(i32,@intCast(2009))) catch unreachable; break :blk m; }};
+    const allowed_infos: []const []const u8 = &[_][]const u8{"Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"};
+    const candidate_titles: []const i32 = blk: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (keyword) |k| { for (movie_keyword) |mk| { if !((mk.keyword_id == k.id)) continue; for (movie_info) |mi| { if !((mi.movie_id == mk.movie_id)) continue; for (title) |t| { if !((t.id == mi.movie_id)) continue; if !(((((_contains_list_string(allowed_infos, (k.keyword.contains("sequel") and mi.info)) and t.production_year) > @as(i32,@intCast(2005))) and mk.movie_id) == mi.movie_id)) continue; _tmp0.append(t.title) catch unreachable; } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_title, _min_int(candidate_titles)) catch unreachable; break :blk m; }};
+    _json(result);
+    test_Q3_returns_lexicographically_smallest_sequel_title();
+}

--- a/tests/dataset/job/compiler/zig/q4.zig.out
+++ b/tests/dataset/job/compiler/zig/q4.zig.out
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q4_returns_minimum_rating_and_title_for_sequels() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(rating, "6.2") catch unreachable; m.put(movie_title, "Alpha Movie") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const info_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(info, "rating") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(info, "other") catch unreachable; break :blk m; }};
+    const keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(keyword, "great sequel") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(keyword, "prequel") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(10))) catch unreachable; m.put(title, "Alpha Movie") catch unreachable; m.put(production_year, @as(i32,@intCast(2006))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(20))) catch unreachable; m.put(title, "Beta Film") catch unreachable; m.put(production_year, @as(i32,@intCast(2007))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(30))) catch unreachable; m.put(title, "Old Film") catch unreachable; m.put(production_year, @as(i32,@intCast(2004))) catch unreachable; break :blk m; }};
+    const movie_keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(20))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(30))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }};
+    const movie_info_idx: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(info_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(info, "6.2") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(20))) catch unreachable; m.put(info_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(info, "7.8") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(30))) catch unreachable; m.put(info_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(info, "4.5") catch unreachable; break :blk m; }};
+    const rows: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (info_type) |it| { for (movie_info_idx) |mi| { if !((it.id == mi.info_type_id)) continue; for (title) |t| { if !((t.id == mi.movie_id)) continue; for (movie_keyword) |mk| { if !((mk.movie_id == t.id)) continue; for (keyword) |k| { if !((k.id == mk.keyword_id)) continue; if !((((((((std.mem.eql(u8, it.info, "rating") and k.keyword.contains("sequel")) and mi.info) > "5.0") and t.production_year) > @as(i32,@intCast(2005))) and mk.movie_id) == mi.movie_id)) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(rating, mi.info) catch unreachable; m.put(title, t.title) catch unreachable; break :blk m; }) catch unreachable; } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(rating, _min_int(blk: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (rows) |r| { _tmp2.append(r.rating) catch unreachable; } var _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk _tmp3; })) catch unreachable; m.put(movie_title, _min_int(blk: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (rows) |r| { _tmp4.append(r.title) catch unreachable; } var _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk _tmp5; })) catch unreachable; break :blk m; }};
+    _json(result);
+    test_Q4_returns_minimum_rating_and_title_for_sequels();
+}

--- a/tests/dataset/job/compiler/zig/q5.zig.out
+++ b/tests/dataset/job/compiler/zig/q5.zig.out
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _contains_list_string(v: []const []const u8, item: []const u8) bool {
+    for (v) |it| { if (std.mem.eql(u8, it, item)) return true; }
+    return false;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q5_finds_the_lexicographically_first_qualifying_title() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(typical_european_movie, "A Film") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const company_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(ct_id, @as(i32,@intCast(1))) catch unreachable; m.put(kind, "production companies") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(ct_id, @as(i32,@intCast(2))) catch unreachable; m.put(kind, "other") catch unreachable; break :blk m; }};
+    const info_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(it_id, @as(i32,@intCast(10))) catch unreachable; m.put(info, "languages") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(t_id, @as(i32,@intCast(100))) catch unreachable; m.put(title, "B Movie") catch unreachable; m.put(production_year, @as(i32,@intCast(2010))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(t_id, @as(i32,@intCast(200))) catch unreachable; m.put(title, "A Film") catch unreachable; m.put(production_year, @as(i32,@intCast(2012))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(t_id, @as(i32,@intCast(300))) catch unreachable; m.put(title, "Old Movie") catch unreachable; m.put(production_year, @as(i32,@intCast(2000))) catch unreachable; break :blk m; }};
+    const movie_companies: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(company_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "ACME (France) (theatrical)") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(company_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "ACME (France) (theatrical)") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(300))) catch unreachable; m.put(company_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "ACME (France) (theatrical)") catch unreachable; break :blk m; }};
+    const movie_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(info, "German") catch unreachable; m.put(info_type_id, @as(i32,@intCast(10))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(info, "Swedish") catch unreachable; m.put(info_type_id, @as(i32,@intCast(10))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(300))) catch unreachable; m.put(info, "German") catch unreachable; m.put(info_type_id, @as(i32,@intCast(10))) catch unreachable; break :blk m; }};
+    const candidate_titles: []const i32 = blk: { var _tmp0 = std.ArrayList(i32).init(std.heap.page_allocator); for (company_type) |ct| { for (movie_companies) |mc| { if !((mc.company_type_id == ct.ct_id)) continue; for (movie_info) |mi| { if !((mi.movie_id == mc.movie_id)) continue; for (info_type) |it| { if !((it.it_id == mi.info_type_id)) continue; for (title) |t| { if !((t.t_id == mc.movie_id)) continue; if !((((mc.note.contains((mc.note.contains((std.mem.eql(u8, ct.kind, "production companies") and "(theatrical)")) and "(France)")) and t.production_year) > @as(i32,@intCast(2005))) and (_contains_list_string(&[_][]const u8{"Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"}, mi.info)))) continue; _tmp0.append(t.title) catch unreachable; } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(typical_european_movie, _min_int(candidate_titles)) catch unreachable; break :blk m; }};
+    _json(result);
+    test_Q5_finds_the_lexicographically_first_qualifying_title();
+}

--- a/tests/dataset/job/compiler/zig/q6.zig.out
+++ b/tests/dataset/job/compiler/zig/q6.zig.out
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q6_finds_marvel_movie_with_Robert_Downey() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(movie_keyword, "marvel-cinematic-universe") catch unreachable; m.put(actor_name, "Downey Robert Jr.") catch unreachable; m.put(marvel_movie, "Iron Man 3") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const cast_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(1))) catch unreachable; m.put(person_id, @as(i32,@intCast(101))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(2))) catch unreachable; m.put(person_id, @as(i32,@intCast(102))) catch unreachable; break :blk m; }};
+    const keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(100))) catch unreachable; m.put(keyword, "marvel-cinematic-universe") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(200))) catch unreachable; m.put(keyword, "other") catch unreachable; break :blk m; }};
+    const movie_keyword: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(1))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(100))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(2))) catch unreachable; m.put(keyword_id, @as(i32,@intCast(200))) catch unreachable; break :blk m; }};
+    const name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(101))) catch unreachable; m.put(name, "Downey Robert Jr.") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(102))) catch unreachable; m.put(name, "Chris Evans") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(title, "Iron Man 3") catch unreachable; m.put(production_year, @as(i32,@intCast(2013))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(title, "Old Movie") catch unreachable; m.put(production_year, @as(i32,@intCast(2000))) catch unreachable; break :blk m; }};
+    const result: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (cast_info) |ci| { for (movie_keyword) |mk| { if !((ci.movie_id == mk.movie_id)) continue; for (keyword) |k| { if !((mk.keyword_id == k.id)) continue; for (name) |n| { if !((ci.person_id == n.id)) continue; for (title) |t| { if !((ci.movie_id == t.id)) continue; if !(((((std.mem.eql(u8, k.keyword, "marvel-cinematic-universe") and n.name.contains("Downey")) and n.name.contains("Robert")) and t.production_year) > @as(i32,@intCast(2010)))) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_keyword, k.keyword) catch unreachable; m.put(actor_name, n.name) catch unreachable; m.put(marvel_movie, t.title) catch unreachable; break :blk m; }) catch unreachable; } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    _json(result);
+    test_Q6_finds_marvel_movie_with_Robert_Downey();
+}

--- a/tests/dataset/job/compiler/zig/q7.zig.out
+++ b/tests/dataset/job/compiler/zig/q7.zig.out
@@ -1,0 +1,38 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q7_finds_movie_features_biography_for_person() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(of_person, "Alan Brown") catch unreachable; m.put(biography_movie, "Feature Film") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const aka_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(1))) catch unreachable; m.put(name, "Anna Mae") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(2))) catch unreachable; m.put(name, "Chris") catch unreachable; break :blk m; }};
+    const cast_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(1))) catch unreachable; m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(2))) catch unreachable; m.put(movie_id, @as(i32,@intCast(20))) catch unreachable; break :blk m; }};
+    const info_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(info, "mini biography") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(info, "trivia") catch unreachable; break :blk m; }};
+    const link_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(link, "features") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(link, "references") catch unreachable; break :blk m; }};
+    const movie_link: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(linked_movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(link_type_id, @as(i32,@intCast(1))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(linked_movie_id, @as(i32,@intCast(20))) catch unreachable; m.put(link_type_id, @as(i32,@intCast(2))) catch unreachable; break :blk m; }};
+    const name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(name, "Alan Brown") catch unreachable; m.put(name_pcode_cf, "B") catch unreachable; m.put(gender, "m") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(name, "Zoe") catch unreachable; m.put(name_pcode_cf, "Z") catch unreachable; m.put(gender, "f") catch unreachable; break :blk m; }};
+    const person_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(1))) catch unreachable; m.put(info_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "Volker Boehm") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(2))) catch unreachable; m.put(info_type_id, @as(i32,@intCast(1))) catch unreachable; m.put(note, "Other") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(10))) catch unreachable; m.put(title, "Feature Film") catch unreachable; m.put(production_year, @as(i32,@intCast(1990))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(20))) catch unreachable; m.put(title, "Late Film") catch unreachable; m.put(production_year, @as(i32,@intCast(2000))) catch unreachable; break :blk m; }};
+    const rows: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (aka_name) |an| { for (name) |n| { if !((n.id == an.person_id)) continue; for (person_info) |pi| { if !((pi.person_id == an.person_id)) continue; for (info_type) |it| { if !((it.id == pi.info_type_id)) continue; for (cast_info) |ci| { if !((ci.person_id == n.id)) continue; for (title) |t| { if !((t.id == ci.movie_id)) continue; for (movie_link) |ml| { if !((ml.linked_movie_id == t.id)) continue; for (link_type) |lt| { if !((lt.id == ml.link_type_id)) continue; if !((((((((((((((std.mem.eql(u8, ((((((std.mem.eql(u8, (std.mem.eql(u8, (an.name.contains("a") and it.info), "mini biography") and lt.link), "features") and n.name_pcode_cf) >= "A") and n.name_pcode_cf) <= "F") and ((std.mem.eql(u8, n.gender, "m") or ((std.mem.eql(u8, n.gender, "f") and n.name.starts_with("B")))))) and pi.note), "Volker Boehm") and t.production_year) >= @as(i32,@intCast(1980))) and t.production_year) <= @as(i32,@intCast(1995))) and pi.person_id) == an.person_id) and pi.person_id) == ci.person_id) and an.person_id) == ci.person_id) and ci.movie_id) == ml.linked_movie_id))) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_name, n.name) catch unreachable; m.put(movie_title, t.title) catch unreachable; break :blk m; }) catch unreachable; } } } } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(of_person, _min_int(blk: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (rows) |r| { _tmp2.append(r.person_name) catch unreachable; } var _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk _tmp3; })) catch unreachable; m.put(biography_movie, _min_int(blk: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (rows) |r| { _tmp4.append(r.movie_title) catch unreachable; } var _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk _tmp5; })) catch unreachable; break :blk m; }};
+    _json(result);
+    test_Q7_finds_movie_features_biography_for_person();
+}

--- a/tests/dataset/job/compiler/zig/q8.zig.out
+++ b/tests/dataset/job/compiler/zig/q8.zig.out
@@ -1,0 +1,30 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(actress_pseudonym, "Y. S.") catch unreachable; m.put(japanese_movie_dubbed, "Dubbed Film") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const aka_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(1))) catch unreachable; m.put(name, "Y. S.") catch unreachable; break :blk m; }};
+    const cast_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(1))) catch unreachable; m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(note, "(voice: English version)") catch unreachable; m.put(role_id, @as(i32,@intCast(1000))) catch unreachable; break :blk m; }};
+    const company_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(50))) catch unreachable; m.put(country_code, "[jp]") catch unreachable; break :blk m; }};
+    const movie_companies: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(10))) catch unreachable; m.put(company_id, @as(i32,@intCast(50))) catch unreachable; m.put(note, "Studio (Japan)") catch unreachable; break :blk m; }};
+    const name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(name, "Yoko Ono") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(name, "Yuichi") catch unreachable; break :blk m; }};
+    const role_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1000))) catch unreachable; m.put(role, "actress") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(10))) catch unreachable; m.put(title, "Dubbed Film") catch unreachable; break :blk m; }};
+    const eligible: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (aka_name) |an1| { for (name) |n1| { if !((n1.id == an1.person_id)) continue; for (cast_info) |ci| { if !((ci.person_id == an1.person_id)) continue; for (title) |t| { if !((t.id == ci.movie_id)) continue; for (movie_companies) |mc| { if !((mc.movie_id == ci.movie_id)) continue; for (company_name) |cn| { if !((cn.id == mc.company_id)) continue; for (role_type) |rt| { if !((rt.id == ci.role_id)) continue; if !(std.mem.eql(u8, (((((std.mem.eql(u8, (std.mem.eql(u8, ci.note, "(voice: English version)") and cn.country_code), "[jp]") and mc.note.contains("(Japan)")) and (!mc.note.contains("(USA)"))) and n1.name.contains("Yo")) and (!n1.name.contains("Yu"))) and rt.role), "actress")) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(pseudonym, an1.name) catch unreachable; m.put(movie_title, t.title) catch unreachable; break :blk m; }) catch unreachable; } } } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(actress_pseudonym, _min_int(blk: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (eligible) |x| { _tmp2.append(x.pseudonym) catch unreachable; } var _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk _tmp3; })) catch unreachable; m.put(japanese_movie_dubbed, _min_int(blk: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (eligible) |x| { _tmp4.append(x.movie_title) catch unreachable; } var _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk _tmp5; })) catch unreachable; break :blk m; }};
+    std.debug.print("{any}\n", .{result});
+    test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing();
+}

--- a/tests/dataset/job/compiler/zig/q9.zig.out
+++ b/tests/dataset/job/compiler/zig/q9.zig.out
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+fn expect(cond: bool) void {
+    if (!cond) @panic("expect failed");
+}
+
+fn _min_int(v: []const i32) i32 {
+    if (v.len == 0) return 0;
+    var m: i32 = v[0];
+    for (v[1..]) |it| { if (it < m) m = it; }
+    return m;
+}
+
+fn _contains_list_string(v: []const []const u8, item: []const u8) bool {
+    for (v) |it| { if (std.mem.eql(u8, it, item)) return true; }
+    return false;
+}
+
+fn _json(v: anytype) void {
+    var buf = std.ArrayList(u8).init(std.heap.page_allocator);
+    defer buf.deinit();
+    std.json.stringify(v, .{}, buf.writer()) catch unreachable;
+    std.debug.print("{s}\n", .{buf.items});
+}
+
+fn test_Q9_selects_minimal_alternative_name__character_and_movie() void {
+    expect((result == &[_]std.AutoHashMap([]const u8, []const u8){blk: { var m = std.AutoHashMap(i32, []const u8).init(std.heap.page_allocator); m.put(alternative_name, "A. N. G.") catch unreachable; m.put(character_name, "Angel") catch unreachable; m.put(movie, "Famous Film") catch unreachable; break :blk m; }}));
+}
+
+pub fn main() void {
+    const aka_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(1))) catch unreachable; m.put(name, "A. N. G.") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(2))) catch unreachable; m.put(name, "J. D.") catch unreachable; break :blk m; }};
+    const char_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(10))) catch unreachable; m.put(name, "Angel") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(20))) catch unreachable; m.put(name, "Devil") catch unreachable; break :blk m; }};
+    const cast_info: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(1))) catch unreachable; m.put(person_role_id, @as(i32,@intCast(10))) catch unreachable; m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(role_id, @as(i32,@intCast(1000))) catch unreachable; m.put(note, "(voice)") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(person_id, @as(i32,@intCast(2))) catch unreachable; m.put(person_role_id, @as(i32,@intCast(20))) catch unreachable; m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(role_id, @as(i32,@intCast(1000))) catch unreachable; m.put(note, "(voice)") catch unreachable; break :blk m; }};
+    const company_name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(100))) catch unreachable; m.put(country_code, "[us]") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(200))) catch unreachable; m.put(country_code, "[gb]") catch unreachable; break :blk m; }};
+    const movie_companies: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(100))) catch unreachable; m.put(company_id, @as(i32,@intCast(100))) catch unreachable; m.put(note, "ACME Studios (USA)") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(movie_id, @as(i32,@intCast(200))) catch unreachable; m.put(company_id, @as(i32,@intCast(200))) catch unreachable; m.put(note, "Maple Films") catch unreachable; break :blk m; }};
+    const name: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1))) catch unreachable; m.put(name, "Angela Smith") catch unreachable; m.put(gender, "f") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2))) catch unreachable; m.put(name, "John Doe") catch unreachable; m.put(gender, "m") catch unreachable; break :blk m; }};
+    const role_type: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(1000))) catch unreachable; m.put(role, "actress") catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(2000))) catch unreachable; m.put(role, "actor") catch unreachable; break :blk m; }};
+    const title: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(100))) catch unreachable; m.put(title, "Famous Film") catch unreachable; m.put(production_year, @as(i32,@intCast(2010))) catch unreachable; break :blk m; }, blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(id, @as(i32,@intCast(200))) catch unreachable; m.put(title, "Old Movie") catch unreachable; m.put(production_year, @as(i32,@intCast(1999))) catch unreachable; break :blk m; }};
+    const matches: []const std.AutoHashMap([]const u8, i32) = blk: { var _tmp0 = std.ArrayList(std.AutoHashMap([]const u8, i32)).init(std.heap.page_allocator); for (aka_name) |an| { for (name) |n| { if !((an.person_id == n.id)) continue; for (cast_info) |ci| { if !((ci.person_id == n.id)) continue; for (char_name) |chn| { if !((chn.id == ci.person_role_id)) continue; for (title) |t| { if !((t.id == ci.movie_id)) continue; for (movie_companies) |mc| { if !((mc.movie_id == t.id)) continue; for (company_name) |cn| { if !((cn.id == mc.company_id)) continue; for (role_type) |rt| { if !((rt.id == ci.role_id)) continue; if !(((((std.mem.eql(u8, ((std.mem.eql(u8, ((std.mem.eql(u8, ((_contains_list_string(&[_][]const u8{"(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"}, ci.note)) and cn.country_code), "[us]") and ((mc.note.contains("(USA)") or mc.note.contains("(worldwide)")))) and n.gender), "f") and n.name.contains("Ang")) and rt.role), "actress") and t.production_year) >= @as(i32,@intCast(2005))) and t.production_year) <= @as(i32,@intCast(2015)))) continue; _tmp0.append(blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(alt, an.name) catch unreachable; m.put(character, chn.name) catch unreachable; m.put(movie, t.title) catch unreachable; break :blk m; }) catch unreachable; } } } } } } } } var _tmp1 = _tmp0.toOwnedSlice() catch unreachable; break :blk _tmp1; };
+    const result: []const std.AutoHashMap([]const u8, i32) = &[_]std.AutoHashMap([]const u8, i32){blk: { var m = std.AutoHashMap(i32, i32).init(std.heap.page_allocator); m.put(alternative_name, _min_int(blk: { var _tmp2 = std.ArrayList(i32).init(std.heap.page_allocator); for (matches) |x| { _tmp2.append(x.alt) catch unreachable; } var _tmp3 = _tmp2.toOwnedSlice() catch unreachable; break :blk _tmp3; })) catch unreachable; m.put(character_name, _min_int(blk: { var _tmp4 = std.ArrayList(i32).init(std.heap.page_allocator); for (matches) |x| { _tmp4.append(x.character) catch unreachable; } var _tmp5 = _tmp4.toOwnedSlice() catch unreachable; break :blk _tmp5; })) catch unreachable; m.put(movie, _min_int(blk: { var _tmp6 = std.ArrayList(i32).init(std.heap.page_allocator); for (matches) |x| { _tmp6.append(x.movie) catch unreachable; } var _tmp7 = _tmp6.toOwnedSlice() catch unreachable; break :blk _tmp7; })) catch unreachable; break :blk m; }};
+    _json(result);
+    test_Q9_selects_minimal_alternative_name__character_and_movie();
+}


### PR DESCRIPTION
## Summary
- expand Zig job tests to cover queries q1 to q10
- store generated Zig code for each job query
- update Zig JOB golden test to loop over q1-q10
- track remaining parser issue in TASKS

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e781398a88320880151003694c702