### PR TITLE
Add Swift JOB dataset golden tests

### DIFF
--- a/compile/x/swift/TASKS.md
+++ b/compile/x/swift/TASKS.md
@@ -12,3 +12,9 @@ Completed work:
 - `_group_by` now hashes keys using JSON for stable grouping.
 
 Further improvements will expand coverage of dataset queries.
+
+- Added JOB dataset golden tests for queries `q1` to `q10` under `tests/compile/x/swift`.
+- Generated Swift sources stored as `tests/dataset/job/compiler/swift/q*.swift.out`.
+- Running the generated Swift with `swiftc` still fails due to dictionary based
+  record handling; future work should emit proper struct types so the programs
+  compile.

--- a/compile/x/swift/job_golden_test.go
+++ b/compile/x/swift/job_golden_test.go
@@ -4,6 +4,7 @@ package swiftcode_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,30 +15,35 @@ import (
 	"mochi/types"
 )
 
-func TestSwiftCompiler_JOBQ1_Golden(t *testing.T) {
+func TestSwiftCompiler_JOB_Golden(t *testing.T) {
 	if err := swiftcode.EnsureSwift(); err != nil {
 		t.Skipf("swift not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	src := filepath.Join(root, "tests", "dataset", "job", "q1.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := swiftcode.New(env).Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	wantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "swift", "q1.swift.out")
-	want, err := os.ReadFile(wantPath)
-	if err != nil {
-		t.Fatalf("read golden: %v", err)
-	}
-	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
-		t.Errorf("generated code mismatch for q1.swift.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(want))
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := swiftcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "swift", q+".swift.out")
+			want, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+				t.Errorf("generated code mismatch for %s.swift.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(want))
+			}
+		})
 	}
 }

--- a/compile/x/swift/job_test.go
+++ b/compile/x/swift/job_test.go
@@ -1,0 +1,23 @@
+package swiftcode_test
+
+import (
+	"fmt"
+	"testing"
+
+	swiftcode "mochi/compile/x/swift"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestSwiftCompiler_JOB(t *testing.T) {
+	if err := swiftcode.EnsureSwift(); err != nil {
+		t.Skipf("swift not installed: %v", err)
+	}
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		testutil.CompileJOB(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+			return swiftcode.New(env).Compile(prog)
+		})
+	}
+}

--- a/tests/dataset/job/compiler/swift/q10.swift.out
+++ b/tests/dataset/job/compiler/swift/q10.swift.out
@@ -1,0 +1,139 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q10_finds_uncredited_voice_actor_in_Russian_movie() {
+  expect(result == [["uncredited_voiced_character": "Ivan", "russian_movie": "Vodka Dreams"]])
+}
+
+let char_name = [["id": 1, "name": "Ivan"], ["id": 2, "name": "Alex"]]
+let cast_info = [
+  ["movie_id": 10, "person_role_id": 1, "role_id": 1, "note": "Soldier (voice) (uncredited)"],
+  ["movie_id": 11, "person_role_id": 2, "role_id": 1, "note": "(voice)"],
+]
+let company_name = [["id": 1, "country_code": "[ru]"], ["id": 2, "country_code": "[us]"]]
+let company_type: [[String: Int]] = [["id": 1], ["id": 2]]
+let movie_companies: [[String: Int]] = [
+  ["movie_id": 10, "company_id": 1, "company_type_id": 1],
+  ["movie_id": 11, "company_id": 2, "company_type_id": 1],
+]
+let role_type = [["id": 1, "role": "actor"], ["id": 2, "role": "director"]]
+let title = [
+  ["id": 10, "title": "Vodka Dreams", "production_year": 2006],
+  ["id": 11, "title": "Other Film", "production_year": 2004],
+]
+let matches =
+  ({
+    var _res: [[String: Any]] = []
+    for chn in char_name {
+      for ci in cast_info {
+        if !(chn.id == ci.person_role_id) { continue }
+        for rt in role_type {
+          if !(rt.id == ci.role_id) { continue }
+          for t in title {
+            if !(t.id == ci.movie_id) { continue }
+            for mc in movie_companies {
+              if !(mc.movie_id == t.id) { continue }
+              for cn in company_name {
+                if !(cn.id == mc.company_id) { continue }
+                if !(ci["note"]!["contains"]!("(voice)") && ci["note"]!["contains"]!("(uncredited)")
+                  && cn["country_code"]! == "[ru]" && rt["role"]! == "actor"
+                  && t["production_year"]! > 2005)
+                {
+                  continue
+                }
+                for ct in company_type {
+                  if !(ct.id == mc.company_type_id) { continue }
+                  _res.append(["character": chn["name"]!, "movie": t["title"]!])
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = [
+  [
+    "uncredited_voiced_character": _min(
+      ({
+        var _res: [Any] = []
+        for x in matches {
+          _res.append(x["character"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+    "russian_movie": _min(
+      ({
+        var _res: [Any] = []
+        for x in matches {
+          _res.append(x["movie"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+  ]
+]
+func main() {
+  _json(result)
+  test_Q10_finds_uncredited_voice_actor_in_Russian_movie()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q2.swift.out
+++ b/tests/dataset/job/compiler/swift/q2.swift.out
@@ -1,0 +1,104 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q2_finds_earliest_title_for_German_companies_with_character_keyword() {
+  expect(result == "Der Film")
+}
+
+let company_name = [["id": 1, "country_code": "[de]"], ["id": 2, "country_code": "[us]"]]
+let keyword = [["id": 1, "keyword": "character-name-in-title"], ["id": 2, "keyword": "other"]]
+let movie_companies: [[String: Int]] = [
+  ["movie_id": 100, "company_id": 1], ["movie_id": 200, "company_id": 2],
+]
+let movie_keyword: [[String: Int]] = [
+  ["movie_id": 100, "keyword_id": 1], ["movie_id": 200, "keyword_id": 2],
+]
+let title = [["id": 100, "title": "Der Film"], ["id": 200, "title": "Other Movie"]]
+let titles =
+  ({
+    var _res: [Any] = []
+    for cn in company_name {
+      for mc in movie_companies {
+        if !(mc.company_id == cn.id) { continue }
+        for t in title {
+          if !(mc.movie_id == t.id) { continue }
+          for mk in movie_keyword {
+            if !(mk.movie_id == t.id) { continue }
+            for k in keyword {
+              if !(mk.keyword_id == k.id) { continue }
+              if !(cn["country_code"]! == "[de]" && k["keyword"]! == "character-name-in-title"
+                && mc["movie_id"]! == mk["movie_id"]!)
+              {
+                continue
+              }
+              _res.append(t["title"]!)
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = _min(titles)
+func main() {
+  _json(result)
+  test_Q2_finds_earliest_title_for_German_companies_with_character_keyword()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q3.swift.out
+++ b/tests/dataset/job/compiler/swift/q3.swift.out
@@ -1,0 +1,108 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q3_returns_lexicographically_smallest_sequel_title() {
+  expect(result == [["movie_title": "Alpha"]])
+}
+
+let keyword = [["id": 1, "keyword": "amazing sequel"], ["id": 2, "keyword": "prequel"]]
+let movie_info = [
+  ["movie_id": 10, "info": "Germany"], ["movie_id": 30, "info": "Sweden"],
+  ["movie_id": 20, "info": "France"],
+]
+let movie_keyword: [[String: Int]] = [
+  ["movie_id": 10, "keyword_id": 1], ["movie_id": 30, "keyword_id": 1],
+  ["movie_id": 20, "keyword_id": 1], ["movie_id": 10, "keyword_id": 2],
+]
+let title = [
+  ["id": 10, "title": "Alpha", "production_year": 2006],
+  ["id": 30, "title": "Beta", "production_year": 2008],
+  ["id": 20, "title": "Gamma", "production_year": 2009],
+]
+let allowed_infos: [String] = [
+  "Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German",
+]
+let candidate_titles =
+  ({
+    var _res: [Any] = []
+    for k in keyword {
+      for mk in movie_keyword {
+        if !(mk.keyword_id == k.id) { continue }
+        for mi in movie_info {
+          if !(mi.movie_id == mk.movie_id) { continue }
+          for t in title {
+            if !(t.id == mi.movie_id) { continue }
+            if allowed_infos.contains(k["keyword"]!["contains"]!("sequel") && mi["info"]!)
+              && t["production_year"]! > 2005 && mk["movie_id"]! == mi["movie_id"]!
+            {
+              _res.append(t["title"]!)
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = [["movie_title": _min(candidate_titles)]]
+func main() {
+  _json(result)
+  test_Q3_returns_lexicographically_smallest_sequel_title()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q4.swift.out
+++ b/tests/dataset/job/compiler/swift/q4.swift.out
@@ -1,0 +1,133 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q4_returns_minimum_rating_and_title_for_sequels() {
+  expect(result == [["rating": "6.2", "movie_title": "Alpha Movie"]])
+}
+
+let info_type = [["id": 1, "info": "rating"], ["id": 2, "info": "other"]]
+let keyword = [["id": 1, "keyword": "great sequel"], ["id": 2, "keyword": "prequel"]]
+let title = [
+  ["id": 10, "title": "Alpha Movie", "production_year": 2006],
+  ["id": 20, "title": "Beta Film", "production_year": 2007],
+  ["id": 30, "title": "Old Film", "production_year": 2004],
+]
+let movie_keyword: [[String: Int]] = [
+  ["movie_id": 10, "keyword_id": 1], ["movie_id": 20, "keyword_id": 1],
+  ["movie_id": 30, "keyword_id": 1],
+]
+let movie_info_idx = [
+  ["movie_id": 10, "info_type_id": 1, "info": "6.2"],
+  ["movie_id": 20, "info_type_id": 1, "info": "7.8"],
+  ["movie_id": 30, "info_type_id": 1, "info": "4.5"],
+]
+let rows =
+  ({
+    var _res: [[Any: Any]] = []
+    for it in info_type {
+      for mi in movie_info_idx {
+        if !(it.id == mi.info_type_id) { continue }
+        for t in title {
+          if !(t.id == mi.movie_id) { continue }
+          for mk in movie_keyword {
+            if !(mk.movie_id == t.id) { continue }
+            for k in keyword {
+              if !(k.id == mk.keyword_id) { continue }
+              if !(it["info"]! == "rating" && k["keyword"]!["contains"]!("sequel")
+                && mi["info"]! > "5.0" && t["production_year"]! > 2005
+                && mk["movie_id"]! == mi["movie_id"]!)
+              {
+                continue
+              }
+              _res.append(["rating": mi["info"]!, "title": t["title"]!])
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = [
+  [
+    "rating": _min(
+      ({
+        var _res: [Any] = []
+        for r in rows {
+          _res.append(r["rating"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+    "movie_title": _min(
+      ({
+        var _res: [Any] = []
+        for r in rows {
+          _res.append(r["title"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+  ]
+]
+func main() {
+  _json(result)
+  test_Q4_returns_minimum_rating_and_title_for_sequels()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q5.swift.out
+++ b/tests/dataset/job/compiler/swift/q5.swift.out
@@ -1,0 +1,117 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q5_finds_the_lexicographically_first_qualifying_title() {
+  expect(result == [["typical_european_movie": "A Film"]])
+}
+
+let company_type = [["ct_id": 1, "kind": "production companies"], ["ct_id": 2, "kind": "other"]]
+let info_type = [["it_id": 10, "info": "languages"]]
+let title = [
+  ["t_id": 100, "title": "B Movie", "production_year": 2010],
+  ["t_id": 200, "title": "A Film", "production_year": 2012],
+  ["t_id": 300, "title": "Old Movie", "production_year": 2000],
+]
+let movie_companies = [
+  ["movie_id": 100, "company_type_id": 1, "note": "ACME (France) (theatrical)"],
+  ["movie_id": 200, "company_type_id": 1, "note": "ACME (France) (theatrical)"],
+  ["movie_id": 300, "company_type_id": 1, "note": "ACME (France) (theatrical)"],
+]
+let movie_info = [
+  ["movie_id": 100, "info": "German", "info_type_id": 10],
+  ["movie_id": 200, "info": "Swedish", "info_type_id": 10],
+  ["movie_id": 300, "info": "German", "info_type_id": 10],
+]
+let candidate_titles =
+  ({
+    var _res: [Any] = []
+    for ct in company_type {
+      for mc in movie_companies {
+        if !(mc.company_type_id == ct.ct_id) { continue }
+        for mi in movie_info {
+          if !(mi.movie_id == mc.movie_id) { continue }
+          for it in info_type {
+            if !(it.it_id == mi.info_type_id) { continue }
+            for t in title {
+              if !(t.t_id == mc.movie_id) { continue }
+              if !(mc["note"]!.contains(
+                mc["note"]!.contains(ct["kind"]! == "production companies" && "(theatrical)")
+                  && "(France)") && t["production_year"]! > 2005
+                && ([
+                  "Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian",
+                  "German",
+                ].contains(mi["info"]!)))
+              {
+                continue
+              }
+              _res.append(t["title"]!)
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = [["typical_european_movie": _min(candidate_titles)]]
+func main() {
+  _json(result)
+  test_Q5_finds_the_lexicographically_first_qualifying_title()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q6.swift.out
+++ b/tests/dataset/job/compiler/swift/q6.swift.out
@@ -1,0 +1,72 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func test_Q6_finds_marvel_movie_with_Robert_Downey() {
+  expect(
+    result == [
+      [
+        "movie_keyword": "marvel-cinematic-universe", "actor_name": "Downey Robert Jr.",
+        "marvel_movie": "Iron Man 3",
+      ]
+    ])
+}
+
+let cast_info: [[String: Int]] = [
+  ["movie_id": 1, "person_id": 101], ["movie_id": 2, "person_id": 102],
+]
+let keyword = [
+  ["id": 100, "keyword": "marvel-cinematic-universe"], ["id": 200, "keyword": "other"],
+]
+let movie_keyword: [[String: Int]] = [
+  ["movie_id": 1, "keyword_id": 100], ["movie_id": 2, "keyword_id": 200],
+]
+let name = [["id": 101, "name": "Downey Robert Jr."], ["id": 102, "name": "Chris Evans"]]
+let title = [
+  ["id": 1, "title": "Iron Man 3", "production_year": 2013],
+  ["id": 2, "title": "Old Movie", "production_year": 2000],
+]
+let result =
+  ({
+    var _res: [[Any: Any]] = []
+    for ci in cast_info {
+      for mk in movie_keyword {
+        if !(ci.movie_id == mk.movie_id) { continue }
+        for k in keyword {
+          if !(mk.keyword_id == k.id) { continue }
+          for n in name {
+            if !(ci.person_id == n.id) { continue }
+            for t in title {
+              if !(ci.movie_id == t.id) { continue }
+              if !(k["keyword"]! == "marvel-cinematic-universe" && n["name"]!["contains"]!("Downey")
+                && n["name"]!["contains"]!("Robert") && t["production_year"]! > 2010)
+              {
+                continue
+              }
+              _res.append([
+                "movie_keyword": k["keyword"]!, "actor_name": n["name"]!,
+                "marvel_movie": t["title"]!,
+              ])
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+func main() {
+  _json(result)
+  test_Q6_finds_marvel_movie_with_Robert_Downey()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q7.swift.out
+++ b/tests/dataset/job/compiler/swift/q7.swift.out
@@ -1,0 +1,154 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q7_finds_movie_features_biography_for_person() {
+  expect(result == [["of_person": "Alan Brown", "biography_movie": "Feature Film"]])
+}
+
+let aka_name = [["person_id": 1, "name": "Anna Mae"], ["person_id": 2, "name": "Chris"]]
+let cast_info: [[String: Int]] = [
+  ["person_id": 1, "movie_id": 10], ["person_id": 2, "movie_id": 20],
+]
+let info_type = [["id": 1, "info": "mini biography"], ["id": 2, "info": "trivia"]]
+let link_type = [["id": 1, "link": "features"], ["id": 2, "link": "references"]]
+let movie_link: [[String: Int]] = [
+  ["linked_movie_id": 10, "link_type_id": 1], ["linked_movie_id": 20, "link_type_id": 2],
+]
+let name = [
+  ["id": 1, "name": "Alan Brown", "name_pcode_cf": "B", "gender": "m"],
+  ["id": 2, "name": "Zoe", "name_pcode_cf": "Z", "gender": "f"],
+]
+let person_info = [
+  ["person_id": 1, "info_type_id": 1, "note": "Volker Boehm"],
+  ["person_id": 2, "info_type_id": 1, "note": "Other"],
+]
+let title = [
+  ["id": 10, "title": "Feature Film", "production_year": 1990],
+  ["id": 20, "title": "Late Film", "production_year": 2000],
+]
+let rows =
+  ({
+    var _res: [[String: Any]] = []
+    for an in aka_name {
+      for n in name {
+        if !(n.id == an.person_id) { continue }
+        for pi in person_info {
+          if !(pi.person_id == an.person_id) { continue }
+          for it in info_type {
+            if !(it.id == pi.info_type_id) { continue }
+            for ci in cast_info {
+              if !(ci.person_id == n.id) { continue }
+              for t in title {
+                if !(t.id == ci.movie_id) { continue }
+                for ml in movie_link {
+                  if !(ml.linked_movie_id == t.id) { continue }
+                  for lt in link_type {
+                    if !(lt.id == ml.link_type_id) { continue }
+                    if !((an["name"]!["contains"]!("a") && it["info"]! == "mini biography"
+                      && lt["link"]! == "features" && n["name_pcode_cf"]! >= "A"
+                      && n["name_pcode_cf"]! <= "F"
+                      && (n["gender"]! == "m"
+                        || (n["gender"]! == "f" && n["name"]!["starts_with"]!("B")))
+                      && pi["note"]! == "Volker Boehm" && t["production_year"]! >= 1980
+                      && t["production_year"]! <= 1995 && pi["person_id"]! == an["person_id"]!
+                      && pi["person_id"]! == ci["person_id"]!
+                      && an["person_id"]! == ci["person_id"]!
+                      && ci["movie_id"]! == ml["linked_movie_id"]!))
+                    {
+                      continue
+                    }
+                    _res.append(["person_name": n["name"]!, "movie_title": t["title"]!])
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = [
+  [
+    "of_person": _min(
+      ({
+        var _res: [Any] = []
+        for r in rows {
+          _res.append(r["person_name"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+    "biography_movie": _min(
+      ({
+        var _res: [Any] = []
+        for r in rows {
+          _res.append(r["movie_title"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+  ]
+]
+func main() {
+  _json(result)
+  test_Q7_finds_movie_features_biography_for_person()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q8.swift.out
+++ b/tests/dataset/job/compiler/swift/q8.swift.out
@@ -1,0 +1,125 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() {
+  expect(result == [["actress_pseudonym": "Y. S.", "japanese_movie_dubbed": "Dubbed Film"]])
+}
+
+let aka_name = [["person_id": 1, "name": "Y. S."]]
+let cast_info = [
+  ["person_id": 1, "movie_id": 10, "note": "(voice: English version)", "role_id": 1000]
+]
+let company_name = [["id": 50, "country_code": "[jp]"]]
+let movie_companies = [["movie_id": 10, "company_id": 50, "note": "Studio (Japan)"]]
+let name = [["id": 1, "name": "Yoko Ono"], ["id": 2, "name": "Yuichi"]]
+let role_type = [["id": 1000, "role": "actress"]]
+let title = [["id": 10, "title": "Dubbed Film"]]
+let eligible =
+  ({
+    var _res: [[String: Any]] = []
+    for an1 in aka_name {
+      for n1 in name {
+        if !(n1.id == an1.person_id) { continue }
+        for ci in cast_info {
+          if !(ci.person_id == an1.person_id) { continue }
+          for t in title {
+            if !(t.id == ci.movie_id) { continue }
+            for mc in movie_companies {
+              if !(mc.movie_id == ci.movie_id) { continue }
+              for cn in company_name {
+                if !(cn.id == mc.company_id) { continue }
+                for rt in role_type {
+                  if !(rt.id == ci.role_id) { continue }
+                  if !(ci["note"]! == "(voice: English version)" && cn["country_code"]! == "[jp]"
+                    && mc["note"]!["contains"]!("(Japan)") && (!mc["note"]!["contains"]!("(USA)"))
+                    && n1["name"]!["contains"]!("Yo") && (!n1["name"]!["contains"]!("Yu"))
+                    && rt["role"]! == "actress")
+                  {
+                    continue
+                  }
+                  _res.append(["pseudonym": an1["name"]!, "movie_title": t["title"]!])
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = [
+  [
+    "actress_pseudonym": _min(
+      ({
+        var _res: [Any] = []
+        for x in eligible {
+          _res.append(x["pseudonym"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+    "japanese_movie_dubbed": _min(
+      ({
+        var _res: [Any] = []
+        for x in eligible {
+          _res.append(x["movie_title"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+  ]
+]
+func main() {
+  print(result)
+  test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing()
+}
+main()

--- a/tests/dataset/job/compiler/swift/q9.swift.out
+++ b/tests/dataset/job/compiler/swift/q9.swift.out
@@ -1,0 +1,163 @@
+import Foundation
+
+func expect(_ cond: Bool) {
+  if !cond { fatalError("expect failed") }
+}
+
+class _Group {
+  var key: Any
+  var Items: [Any] = []
+  init(_ k: Any) { self.key = k }
+}
+
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
+func _min(_ v: Any) -> Any {
+  var list: [Any]? = nil
+  if let g = v as? _Group {
+    list = g.Items
+  } else if let arr = v as? [Any] {
+    list = arr
+  } else if let arr = v as? [Int] {
+    return arr.min() ?? 0
+  } else if let arr = v as? [Double] {
+    return arr.min() ?? 0.0
+  } else if let arr = v as? [String] {
+    return arr.min() ?? ""
+  }
+  guard let items = list else { fatalError("min() expects list or group") }
+  if items.isEmpty { return 0 }
+  if let s = items[0] as? String {
+    var m = s
+    for it in items.dropFirst() {
+      if let v = it as? String, v < m { m = v }
+    }
+    return m
+  }
+  func toDouble(_ v: Any) -> Double {
+    if let i = v as? Int { return Double(i) }
+    if let d = v as? Double { return d }
+    if let f = v as? Float { return Double(f) }
+    if let i = v as? Int64 { return Double(i) }
+    return 0
+  }
+  var m = toDouble(items[0])
+  var isFloat = items[0] is Double || items[0] is Float
+  for it in items.dropFirst() {
+    if it is Double || it is Float { isFloat = true }
+    let d = toDouble(it)
+    if d < m { m = d }
+  }
+  return isFloat ? m : Int(m)
+}
+
+func test_Q9_selects_minimal_alternative_name__character_and_movie() {
+  expect(
+    result == [["alternative_name": "A. N. G.", "character_name": "Angel", "movie": "Famous Film"]])
+}
+
+let aka_name = [["person_id": 1, "name": "A. N. G."], ["person_id": 2, "name": "J. D."]]
+let char_name = [["id": 10, "name": "Angel"], ["id": 20, "name": "Devil"]]
+let cast_info = [
+  ["person_id": 1, "person_role_id": 10, "movie_id": 100, "role_id": 1000, "note": "(voice)"],
+  ["person_id": 2, "person_role_id": 20, "movie_id": 200, "role_id": 1000, "note": "(voice)"],
+]
+let company_name = [["id": 100, "country_code": "[us]"], ["id": 200, "country_code": "[gb]"]]
+let movie_companies = [
+  ["movie_id": 100, "company_id": 100, "note": "ACME Studios (USA)"],
+  ["movie_id": 200, "company_id": 200, "note": "Maple Films"],
+]
+let name = [
+  ["id": 1, "name": "Angela Smith", "gender": "f"], ["id": 2, "name": "John Doe", "gender": "m"],
+]
+let role_type = [["id": 1000, "role": "actress"], ["id": 2000, "role": "actor"]]
+let title = [
+  ["id": 100, "title": "Famous Film", "production_year": 2010],
+  ["id": 200, "title": "Old Movie", "production_year": 1999],
+]
+let matches =
+  ({
+    var _res: [[String: Any]] = []
+    for an in aka_name {
+      for n in name {
+        if !(an.person_id == n.id) { continue }
+        for ci in cast_info {
+          if !(ci.person_id == n.id) { continue }
+          for chn in char_name {
+            if !(chn.id == ci.person_role_id) { continue }
+            for t in title {
+              if !(t.id == ci.movie_id) { continue }
+              for mc in movie_companies {
+                if !(mc.movie_id == t.id) { continue }
+                for cn in company_name {
+                  if !(cn.id == mc.company_id) { continue }
+                  for rt in role_type {
+                    if !(rt.id == ci.role_id) { continue }
+                    if !(([
+                      "(voice)", "(voice: Japanese version)", "(voice) (uncredited)",
+                      "(voice: English version)",
+                    ].contains(ci["note"]!)) && cn["country_code"]! == "[us]"
+                      && (mc["note"]!["contains"]!("(USA)")
+                        || mc["note"]!["contains"]!("(worldwide)"))
+                      && n["gender"]! == "f" && n["name"]!["contains"]!("Ang")
+                      && rt["role"]! == "actress" && t["production_year"]! >= 2005
+                      && t["production_year"]! <= 2015)
+                    {
+                      continue
+                    }
+                    _res.append([
+                      "alt": an["name"]!, "character": chn["name"]!, "movie": t["title"]!,
+                    ])
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    var _items = _res
+    return _items
+  }())
+let result = [
+  [
+    "alternative_name": _min(
+      ({
+        var _res: [Any] = []
+        for x in matches {
+          _res.append(x["alt"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+    "character_name": _min(
+      ({
+        var _res: [Any] = []
+        for x in matches {
+          _res.append(x["character"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+    "movie": _min(
+      ({
+        var _res: [Any] = []
+        for x in matches {
+          _res.append(x["movie"]!)
+        }
+        var _items = _res
+        return _items
+      }())),
+  ]
+]
+func main() {
+  _json(result)
+  test_Q9_selects_minimal_alternative_name__character_and_movie()
+}
+main()


### PR DESCRIPTION
## Summary
- extend Swift JOB golden tests to cover q1-q10
- add compile-only JOB test running queries 1..10
- generate golden Swift output for dataset/job q2–q10
- document new tasks for Swift backend

## Testing
- `go test ./compile/x/swift -tags slow -run JOB -v`
- `go test ./compile/x/swift -tags slow -count=1` *(fails: golden mismatch in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_685e781195088320a21680a07f895946