### PR TITLE
Add JOB golden tests and extend Racket backend

### DIFF
--- a/compile/x/rkt/helpers.go
+++ b/compile/x/rkt/helpers.go
@@ -54,3 +54,26 @@ func isUnderscoreExpr(e *parser.Expr) bool {
 	}
 	return p.Target.Selector != nil && p.Target.Selector.Root == "_" && len(p.Target.Selector.Tail) == 0
 }
+
+// bareIdent returns the root identifier if the expression is a simple
+// selector with no operations, e.g. `foo` or `bar`.
+func bareIdent(e *parser.Expr) (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if len(e.Binary.Right) != 0 {
+		return "", false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 {
+		return "", false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 {
+		return "", false
+	}
+	if p.Target.Selector != nil && len(p.Target.Selector.Tail) == 0 {
+		return p.Target.Selector.Root, true
+	}
+	return "", false
+}

--- a/compile/x/rkt/job_golden_test.go
+++ b/compile/x/rkt/job_golden_test.go
@@ -1,0 +1,46 @@
+//go:build slow
+
+package rktcode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	rktcode "mochi/compile/x/rkt"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestRacketCompiler_JOB_Golden(t *testing.T) {
+	if err := rktcode.EnsureRacket(); err != nil {
+		t.Skipf("racket not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Fatalf("type error: %v", errs[0])
+		}
+		code, err := rktcode.New(env).Compile(prog)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+		want, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "rkt", q+".rkt.out"))
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+			t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(want))
+		}
+	}
+}

--- a/compile/x/rkt/job_test.go
+++ b/compile/x/rkt/job_test.go
@@ -1,0 +1,25 @@
+//go:build slow
+
+package rktcode_test
+
+import (
+	"fmt"
+	"testing"
+
+	rktcode "mochi/compile/x/rkt"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestRacketCompiler_JOB(t *testing.T) {
+	if err := rktcode.EnsureRacket(); err != nil {
+		t.Skipf("racket not installed: %v", err)
+	}
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		testutil.CompileJOB(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+			return rktcode.New(env).Compile(prog)
+		})
+	}
+}

--- a/tests/dataset/job/compiler/rkt/q1.out
+++ b/tests/dataset/job/compiler/rkt/q1.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Good Movie","movie_year":1995,"production_note":"ACME (co-production)"}]

--- a/tests/dataset/job/compiler/rkt/q1.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q1.rkt.out
@@ -1,0 +1,99 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production)
+  (unless (equal? result (hash "production_note" "ACME (co-production)" "movie_title" "Good Movie" "movie_year" 1995)) (error "expect failed"))
+)
+
+(define company_type (list (hash "id" 1 "kind" "production companies") (hash "id" 2 "kind" "distributors")))
+(define info_type (list (hash "id" 10 "info" "top 250 rank") (hash "id" 20 "info" "bottom 10 rank")))
+(define title (list (hash "id" 100 "title" "Good Movie" "production_year" 1995) (hash "id" 200 "title" "Bad Movie" "production_year" 2000)))
+(define movie_companies (list (hash "movie_id" 100 "company_type_id" 1 "note" "ACME (co-production)") (hash "movie_id" 200 "company_type_id" 1 "note" "MGM (as Metro-Goldwyn-Mayer Pictures)")))
+(define movie_info_idx (list (hash "movie_id" 100 "info_type_id" 10) (hash "movie_id" 200 "info_type_id" 20)))
+(define filtered (let ([_res '()])
+  (for ([ct company_type])
+    (for ([mc movie_companies])
+      (when (equal? (hash-ref ct "id") (hash-ref mc "company_type_id"))
+        (for ([t title])
+          (when (equal? (hash-ref t "id") (hash-ref mc "movie_id"))
+            (for ([mi movie_info_idx])
+              (when (equal? (hash-ref mi "movie_id") (hash-ref t "id"))
+                (for ([it info_type])
+                  (when (equal? (hash-ref it "id") (hash-ref mi "info_type_id"))
+                    (when (and (and (and (equal? (hash-ref ct "kind") "production companies") (equal? (hash-ref it "info") "top 250 rank")) (not (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(as Metro-Goldwyn-Mayer Pictures)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(as Metro-Goldwyn-Mayer Pictures)"))))] [else (not (false? (member "(as Metro-Goldwyn-Mayer Pictures)" (hash-ref mc "note"))))]))) (or (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(co-production)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(co-production)"))))] [else (not (false? (member "(co-production)" (hash-ref mc "note"))))]) (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(presents)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(presents)"))))] [else (not (false? (member "(presents)" (hash-ref mc "note"))))])))
+                      (set! _res (append _res (list (hash "note" (hash-ref mc "note") "title" (hash-ref t "title") "year" (hash-ref t "production_year")))))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (hash "production_note" (min-list (let ([_res '()])
+  (for ([r filtered])
+    (set! _res (append _res (list (hash-ref r "note"))))
+  )
+  _res)) "movie_title" (min-list (let ([_res '()])
+  (for ([r filtered])
+    (set! _res (append _res (list (hash-ref r "title"))))
+  )
+  _res)) "movie_year" (min-list (let ([_res '()])
+  (for ([r filtered])
+    (set! _res (append _res (list (hash-ref r "year"))))
+  )
+  _res))))
+(displayln (jsexpr->string (to-jsexpr (list result))))
+(test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production)

--- a/tests/dataset/job/compiler/rkt/q10.out
+++ b/tests/dataset/job/compiler/rkt/q10.out
@@ -1,0 +1,1 @@
+[{"russian_movie":"Vodka Dreams","uncredited_voiced_character":"Ivan"}]

--- a/tests/dataset/job/compiler/rkt/q10.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q10.rkt.out
@@ -1,0 +1,105 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q10_finds_uncredited_voice_actor_in_Russian_movie)
+  (unless (equal? result (list (hash "uncredited_voiced_character" "Ivan" "russian_movie" "Vodka Dreams"))) (error "expect failed"))
+)
+
+(define char_name (list (hash "id" 1 "name" "Ivan") (hash "id" 2 "name" "Alex")))
+(define cast_info (list (hash "movie_id" 10 "person_role_id" 1 "role_id" 1 "note" "Soldier (voice) (uncredited)") (hash "movie_id" 11 "person_role_id" 2 "role_id" 1 "note" "(voice)")))
+(define company_name (list (hash "id" 1 "country_code" "[ru]") (hash "id" 2 "country_code" "[us]")))
+(define company_type (list (hash "id" 1) (hash "id" 2)))
+(define movie_companies (list (hash "movie_id" 10 "company_id" 1 "company_type_id" 1) (hash "movie_id" 11 "company_id" 2 "company_type_id" 1)))
+(define role_type (list (hash "id" 1 "role" "actor") (hash "id" 2 "role" "director")))
+(define title (list (hash "id" 10 "title" "Vodka Dreams" "production_year" 2006) (hash "id" 11 "title" "Other Film" "production_year" 2004)))
+(define matches (let ([_res '()])
+  (for ([chn char_name])
+    (for ([ci cast_info])
+      (when (equal? (hash-ref chn "id") (hash-ref ci "person_role_id"))
+        (for ([rt role_type])
+          (when (equal? (hash-ref rt "id") (hash-ref ci "role_id"))
+            (for ([t title])
+              (when (equal? (hash-ref t "id") (hash-ref ci "movie_id"))
+                (for ([mc movie_companies])
+                  (when (equal? (hash-ref mc "movie_id") (hash-ref t "id"))
+                    (for ([cn company_name])
+                      (when (equal? (hash-ref cn "id") (hash-ref mc "company_id"))
+                        (for ([ct company_type])
+                          (when (equal? (hash-ref ct "id") (hash-ref mc "company_type_id"))
+                            (when (and (and (and (and (cond [(hash? (hash-ref ci "note")) (hash-has-key? (hash-ref ci "note") "(voice)")] [(string? (hash-ref ci "note")) (not (false? (string-contains? (hash-ref ci "note") (format "~a" "(voice)"))))] [else (not (false? (member "(voice)" (hash-ref ci "note"))))]) (cond [(hash? (hash-ref ci "note")) (hash-has-key? (hash-ref ci "note") "(uncredited)")] [(string? (hash-ref ci "note")) (not (false? (string-contains? (hash-ref ci "note") (format "~a" "(uncredited)"))))] [else (not (false? (member "(uncredited)" (hash-ref ci "note"))))])) (equal? (hash-ref cn "country_code") "[ru]")) (equal? (hash-ref rt "role") "actor")) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 2005) (string->number 2005))]) (if (and la lb) (> la lb) (string>? (format "~a" (hash-ref t "production_year")) (format "~a" 2005)))))
+                              (set! _res (append _res (list (hash "character" (hash-ref chn "name") "movie" (hash-ref t "title")))))
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (list (hash "uncredited_voiced_character" (min-list (let ([_res '()])
+  (for ([x matches])
+    (set! _res (append _res (list (hash-ref x "character"))))
+  )
+  _res)) "russian_movie" (min-list (let ([_res '()])
+  (for ([x matches])
+    (set! _res (append _res (list (hash-ref x "movie"))))
+  )
+  _res)))))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q10_finds_uncredited_voice_actor_in_Russian_movie)

--- a/tests/dataset/job/compiler/rkt/q2.out
+++ b/tests/dataset/job/compiler/rkt/q2.out
@@ -1,0 +1,1 @@
+"Der Film"

--- a/tests/dataset/job/compiler/rkt/q2.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q2.rkt.out
@@ -1,0 +1,87 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q2_finds_earliest_title_for_German_companies_with_character_keyword)
+  (unless (equal? result "Der Film") (error "expect failed"))
+)
+
+(define company_name (list (hash "id" 1 "country_code" "[de]") (hash "id" 2 "country_code" "[us]")))
+(define keyword (list (hash "id" 1 "keyword" "character-name-in-title") (hash "id" 2 "keyword" "other")))
+(define movie_companies (list (hash "movie_id" 100 "company_id" 1) (hash "movie_id" 200 "company_id" 2)))
+(define movie_keyword (list (hash "movie_id" 100 "keyword_id" 1) (hash "movie_id" 200 "keyword_id" 2)))
+(define title (list (hash "id" 100 "title" "Der Film") (hash "id" 200 "title" "Other Movie")))
+(define titles (let ([_res '()])
+  (for ([cn company_name])
+    (for ([mc movie_companies])
+      (when (equal? (hash-ref mc "company_id") (hash-ref cn "id"))
+        (for ([t title])
+          (when (equal? (hash-ref mc "movie_id") (hash-ref t "id"))
+            (for ([mk movie_keyword])
+              (when (equal? (hash-ref mk "movie_id") (hash-ref t "id"))
+                (for ([k keyword])
+                  (when (equal? (hash-ref mk "keyword_id") (hash-ref k "id"))
+                    (when (and (and (equal? (hash-ref cn "country_code") "[de]") (equal? (hash-ref k "keyword") "character-name-in-title")) (equal? (hash-ref mc "movie_id") (hash-ref mk "movie_id")))
+                      (set! _res (append _res (list (hash-ref t "title"))))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (min-list titles))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q2_finds_earliest_title_for_German_companies_with_character_keyword)

--- a/tests/dataset/job/compiler/rkt/q3.out
+++ b/tests/dataset/job/compiler/rkt/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/compiler/rkt/q3.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q3.rkt.out
@@ -1,0 +1,83 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q3_returns_lexicographically_smallest_sequel_title)
+  (unless (equal? result (list (hash "movie_title" "Alpha"))) (error "expect failed"))
+)
+
+(define keyword (list (hash "id" 1 "keyword" "amazing sequel") (hash "id" 2 "keyword" "prequel")))
+(define movie_info (list (hash "movie_id" 10 "info" "Germany") (hash "movie_id" 30 "info" "Sweden") (hash "movie_id" 20 "info" "France")))
+(define movie_keyword (list (hash "movie_id" 10 "keyword_id" 1) (hash "movie_id" 30 "keyword_id" 1) (hash "movie_id" 20 "keyword_id" 1) (hash "movie_id" 10 "keyword_id" 2)))
+(define title (list (hash "id" 10 "title" "Alpha" "production_year" 2006) (hash "id" 30 "title" "Beta" "production_year" 2008) (hash "id" 20 "title" "Gamma" "production_year" 2009)))
+(define allowed_infos (list "Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German"))
+(define candidate_titles (let ([_res '()])
+  (for ([k keyword])
+    (for ([mk movie_keyword])
+      (when (equal? (hash-ref mk "keyword_id") (hash-ref k "id"))
+        (for ([mi movie_info])
+          (when (equal? (hash-ref mi "movie_id") (hash-ref mk "movie_id"))
+            (for ([t title])
+              (when (equal? (hash-ref t "id") (hash-ref mi "movie_id"))
+                (when (and (and (and (cond [(hash? (hash-ref k "keyword")) (hash-has-key? (hash-ref k "keyword") "sequel")] [(string? (hash-ref k "keyword")) (not (false? (string-contains? (hash-ref k "keyword") (format "~a" "sequel"))))] [else (not (false? (member "sequel" (hash-ref k "keyword"))))]) (cond [(hash? allowed_infos) (hash-has-key? allowed_infos (hash-ref mi "info"))] [(string? allowed_infos) (not (false? (string-contains? allowed_infos (format "~a" (hash-ref mi "info")))))] [else (not (false? (member (hash-ref mi "info") allowed_infos)))])) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 2005) (string->number 2005))]) (if (and la lb) (> la lb) (string>? (format "~a" (hash-ref t "production_year")) (format "~a" 2005))))) (equal? (hash-ref mk "movie_id") (hash-ref mi "movie_id")))
+                  (set! _res (append _res (list (hash-ref t "title"))))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (list (hash "movie_title" (min-list candidate_titles))))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q3_returns_lexicographically_smallest_sequel_title)

--- a/tests/dataset/job/compiler/rkt/q4.out
+++ b/tests/dataset/job/compiler/rkt/q4.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha Movie","rating":"6.2"}]

--- a/tests/dataset/job/compiler/rkt/q4.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q4.rkt.out
@@ -1,0 +1,95 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q4_returns_minimum_rating_and_title_for_sequels)
+  (unless (equal? result (list (hash "rating" "6.2" "movie_title" "Alpha Movie"))) (error "expect failed"))
+)
+
+(define info_type (list (hash "id" 1 "info" "rating") (hash "id" 2 "info" "other")))
+(define keyword (list (hash "id" 1 "keyword" "great sequel") (hash "id" 2 "keyword" "prequel")))
+(define title (list (hash "id" 10 "title" "Alpha Movie" "production_year" 2006) (hash "id" 20 "title" "Beta Film" "production_year" 2007) (hash "id" 30 "title" "Old Film" "production_year" 2004)))
+(define movie_keyword (list (hash "movie_id" 10 "keyword_id" 1) (hash "movie_id" 20 "keyword_id" 1) (hash "movie_id" 30 "keyword_id" 1)))
+(define movie_info_idx (list (hash "movie_id" 10 "info_type_id" 1 "info" "6.2") (hash "movie_id" 20 "info_type_id" 1 "info" "7.8") (hash "movie_id" 30 "info_type_id" 1 "info" "4.5")))
+(define rows (let ([_res '()])
+  (for ([it info_type])
+    (for ([mi movie_info_idx])
+      (when (equal? (hash-ref it "id") (hash-ref mi "info_type_id"))
+        (for ([t title])
+          (when (equal? (hash-ref t "id") (hash-ref mi "movie_id"))
+            (for ([mk movie_keyword])
+              (when (equal? (hash-ref mk "movie_id") (hash-ref t "id"))
+                (for ([k keyword])
+                  (when (equal? (hash-ref k "id") (hash-ref mk "keyword_id"))
+                    (when (and (and (and (and (equal? (hash-ref it "info") "rating") (cond [(hash? (hash-ref k "keyword")) (hash-has-key? (hash-ref k "keyword") "sequel")] [(string? (hash-ref k "keyword")) (not (false? (string-contains? (hash-ref k "keyword") (format "~a" "sequel"))))] [else (not (false? (member "sequel" (hash-ref k "keyword"))))])) (let ([la (and (string? (hash-ref mi "info")) (string->number (hash-ref mi "info")))] [lb (and (string? "5.0") (string->number "5.0"))]) (if (and la lb) (> la lb) (string>? (format "~a" (hash-ref mi "info")) (format "~a" "5.0"))))) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 2005) (string->number 2005))]) (if (and la lb) (> la lb) (string>? (format "~a" (hash-ref t "production_year")) (format "~a" 2005))))) (equal? (hash-ref mk "movie_id") (hash-ref mi "movie_id")))
+                      (set! _res (append _res (list (hash "rating" (hash-ref mi "info") "title" (hash-ref t "title")))))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (list (hash "rating" (min-list (let ([_res '()])
+  (for ([r rows])
+    (set! _res (append _res (list (hash-ref r "rating"))))
+  )
+  _res)) "movie_title" (min-list (let ([_res '()])
+  (for ([r rows])
+    (set! _res (append _res (list (hash-ref r "title"))))
+  )
+  _res)))))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q4_returns_minimum_rating_and_title_for_sequels)

--- a/tests/dataset/job/compiler/rkt/q5.out
+++ b/tests/dataset/job/compiler/rkt/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/compiler/rkt/q5.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q5.rkt.out
@@ -1,0 +1,87 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q5_finds_the_lexicographically_first_qualifying_title)
+  (unless (equal? result (list (hash "typical_european_movie" "A Film"))) (error "expect failed"))
+)
+
+(define company_type (list (hash "ct_id" 1 "kind" "production companies") (hash "ct_id" 2 "kind" "other")))
+(define info_type (list (hash "it_id" 10 "info" "languages")))
+(define title (list (hash "t_id" 100 "title" "B Movie" "production_year" 2010) (hash "t_id" 200 "title" "A Film" "production_year" 2012) (hash "t_id" 300 "title" "Old Movie" "production_year" 2000)))
+(define movie_companies (list (hash "movie_id" 100 "company_type_id" 1 "note" "ACME (France) (theatrical)") (hash "movie_id" 200 "company_type_id" 1 "note" "ACME (France) (theatrical)") (hash "movie_id" 300 "company_type_id" 1 "note" "ACME (France) (theatrical)")))
+(define movie_info (list (hash "movie_id" 100 "info" "German" "info_type_id" 10) (hash "movie_id" 200 "info" "Swedish" "info_type_id" 10) (hash "movie_id" 300 "info" "German" "info_type_id" 10)))
+(define candidate_titles (let ([_res '()])
+  (for ([ct company_type])
+    (for ([mc movie_companies])
+      (when (equal? (hash-ref mc "company_type_id") (hash-ref ct "ct_id"))
+        (for ([mi movie_info])
+          (when (equal? (hash-ref mi "movie_id") (hash-ref mc "movie_id"))
+            (for ([it info_type])
+              (when (equal? (hash-ref it "it_id") (hash-ref mi "info_type_id"))
+                (for ([t title])
+                  (when (equal? (hash-ref t "t_id") (hash-ref mc "movie_id"))
+                    (when (and (and (and (and (equal? (hash-ref ct "kind") "production companies") (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(theatrical)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(theatrical)"))))] [else (not (false? (member "(theatrical)" (hash-ref mc "note"))))])) (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(France)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(France)"))))] [else (not (false? (member "(France)" (hash-ref mc "note"))))])) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 2005) (string->number 2005))]) (if (and la lb) (> la lb) (string>? (format "~a" (hash-ref t "production_year")) (format "~a" 2005))))) (cond [(hash? (list "Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German")) (hash-has-key? (list "Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German") (hash-ref mi "info"))] [(string? (list "Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German")) (not (false? (string-contains? (list "Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German") (format "~a" (hash-ref mi "info")))))] [else (not (false? (member (hash-ref mi "info") (list "Sweden" "Norway" "Germany" "Denmark" "Swedish" "Denish" "Norwegian" "German"))))]))
+                      (set! _res (append _res (list (hash-ref t "title"))))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (list (hash "typical_european_movie" (min-list candidate_titles))))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q5_finds_the_lexicographically_first_qualifying_title)

--- a/tests/dataset/job/compiler/rkt/q6.out
+++ b/tests/dataset/job/compiler/rkt/q6.out
@@ -1,0 +1,1 @@
+[{"actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3","movie_keyword":"marvel-cinematic-universe"}]

--- a/tests/dataset/job/compiler/rkt/q6.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q6.rkt.out
@@ -1,0 +1,86 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q6_finds_marvel_movie_with_Robert_Downey)
+  (unless (equal? result (list (hash "movie_keyword" "marvel-cinematic-universe" "actor_name" "Downey Robert Jr." "marvel_movie" "Iron Man 3"))) (error "expect failed"))
+)
+
+(define cast_info (list (hash "movie_id" 1 "person_id" 101) (hash "movie_id" 2 "person_id" 102)))
+(define keyword (list (hash "id" 100 "keyword" "marvel-cinematic-universe") (hash "id" 200 "keyword" "other")))
+(define movie_keyword (list (hash "movie_id" 1 "keyword_id" 100) (hash "movie_id" 2 "keyword_id" 200)))
+(define name (list (hash "id" 101 "name" "Downey Robert Jr.") (hash "id" 102 "name" "Chris Evans")))
+(define title (list (hash "id" 1 "title" "Iron Man 3" "production_year" 2013) (hash "id" 2 "title" "Old Movie" "production_year" 2000)))
+(define result (let ([_res '()])
+  (for ([ci cast_info])
+    (for ([mk movie_keyword])
+      (when (equal? (hash-ref ci "movie_id") (hash-ref mk "movie_id"))
+        (for ([k keyword])
+          (when (equal? (hash-ref mk "keyword_id") (hash-ref k "id"))
+            (for ([n name])
+              (when (equal? (hash-ref ci "person_id") (hash-ref n "id"))
+                (for ([t title])
+                  (when (equal? (hash-ref ci "movie_id") (hash-ref t "id"))
+                    (when (and (and (and (equal? (hash-ref k "keyword") "marvel-cinematic-universe") (cond [(hash? (hash-ref n "name")) (hash-has-key? (hash-ref n "name") "Downey")] [(string? (hash-ref n "name")) (not (false? (string-contains? (hash-ref n "name") (format "~a" "Downey"))))] [else (not (false? (member "Downey" (hash-ref n "name"))))])) (cond [(hash? (hash-ref n "name")) (hash-has-key? (hash-ref n "name") "Robert")] [(string? (hash-ref n "name")) (not (false? (string-contains? (hash-ref n "name") (format "~a" "Robert"))))] [else (not (false? (member "Robert" (hash-ref n "name"))))])) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 2010) (string->number 2010))]) (if (and la lb) (> la lb) (string>? (format "~a" (hash-ref t "production_year")) (format "~a" 2010)))))
+                      (set! _res (append _res (list (hash "movie_keyword" (hash-ref k "keyword") "actor_name" (hash-ref n "name") "marvel_movie" (hash-ref t "title")))))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q6_finds_marvel_movie_with_Robert_Downey)

--- a/tests/dataset/job/compiler/rkt/q7.out
+++ b/tests/dataset/job/compiler/rkt/q7.out
@@ -1,0 +1,1 @@
+[{"biography_movie":"Feature Film","of_person":"Alan Brown"}]

--- a/tests/dataset/job/compiler/rkt/q7.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q7.rkt.out
@@ -1,0 +1,110 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q7_finds_movie_features_biography_for_person)
+  (unless (equal? result (list (hash "of_person" "Alan Brown" "biography_movie" "Feature Film"))) (error "expect failed"))
+)
+
+(define aka_name (list (hash "person_id" 1 "name" "Anna Mae") (hash "person_id" 2 "name" "Chris")))
+(define cast_info (list (hash "person_id" 1 "movie_id" 10) (hash "person_id" 2 "movie_id" 20)))
+(define info_type (list (hash "id" 1 "info" "mini biography") (hash "id" 2 "info" "trivia")))
+(define link_type (list (hash "id" 1 "link" "features") (hash "id" 2 "link" "references")))
+(define movie_link (list (hash "linked_movie_id" 10 "link_type_id" 1) (hash "linked_movie_id" 20 "link_type_id" 2)))
+(define name (list (hash "id" 1 "name" "Alan Brown" "name_pcode_cf" "B" "gender" "m") (hash "id" 2 "name" "Zoe" "name_pcode_cf" "Z" "gender" "f")))
+(define person_info (list (hash "person_id" 1 "info_type_id" 1 "note" "Volker Boehm") (hash "person_id" 2 "info_type_id" 1 "note" "Other")))
+(define title (list (hash "id" 10 "title" "Feature Film" "production_year" 1990) (hash "id" 20 "title" "Late Film" "production_year" 2000)))
+(define rows (let ([_res '()])
+  (for ([an aka_name])
+    (for ([n name])
+      (when (equal? (hash-ref n "id") (hash-ref an "person_id"))
+        (for ([pi person_info])
+          (when (equal? (hash-ref pi "person_id") (hash-ref an "person_id"))
+            (for ([it info_type])
+              (when (equal? (hash-ref it "id") (hash-ref pi "info_type_id"))
+                (for ([ci cast_info])
+                  (when (equal? (hash-ref ci "person_id") (hash-ref n "id"))
+                    (for ([t title])
+                      (when (equal? (hash-ref t "id") (hash-ref ci "movie_id"))
+                        (for ([ml movie_link])
+                          (when (equal? (hash-ref ml "linked_movie_id") (hash-ref t "id"))
+                            (for ([lt link_type])
+                              (when (equal? (hash-ref lt "id") (hash-ref ml "link_type_id"))
+                                (when (and (and (and (and (and (and (and (and (and (and (and (and (cond [(hash? (hash-ref an "name")) (hash-has-key? (hash-ref an "name") "a")] [(string? (hash-ref an "name")) (not (false? (string-contains? (hash-ref an "name") (format "~a" "a"))))] [else (not (false? (member "a" (hash-ref an "name"))))]) (equal? (hash-ref it "info") "mini biography")) (equal? (hash-ref lt "link") "features")) (let ([la (and (string? (hash-ref n "name_pcode_cf")) (string->number (hash-ref n "name_pcode_cf")))] [lb (and (string? "A") (string->number "A"))]) (if (and la lb) (>= la lb) (string>=? (format "~a" (hash-ref n "name_pcode_cf")) (format "~a" "A"))))) (let ([la (and (string? (hash-ref n "name_pcode_cf")) (string->number (hash-ref n "name_pcode_cf")))] [lb (and (string? "F") (string->number "F"))]) (if (and la lb) (<= la lb) (string<=? (format "~a" (hash-ref n "name_pcode_cf")) (format "~a" "F"))))) (or (equal? (hash-ref n "gender") "m") (and (equal? (hash-ref n "gender") "f") ((hash-ref (hash-ref n "name") "starts_with") "B")))) (equal? (hash-ref pi "note") "Volker Boehm")) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 1980) (string->number 1980))]) (if (and la lb) (>= la lb) (string>=? (format "~a" (hash-ref t "production_year")) (format "~a" 1980))))) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 1995) (string->number 1995))]) (if (and la lb) (<= la lb) (string<=? (format "~a" (hash-ref t "production_year")) (format "~a" 1995))))) (equal? (hash-ref pi "person_id") (hash-ref an "person_id"))) (equal? (hash-ref pi "person_id") (hash-ref ci "person_id"))) (equal? (hash-ref an "person_id") (hash-ref ci "person_id"))) (equal? (hash-ref ci "movie_id") (hash-ref ml "linked_movie_id")))
+                                  (set! _res (append _res (list (hash "person_name" (hash-ref n "name") "movie_title" (hash-ref t "title")))))
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (list (hash "of_person" (min-list (let ([_res '()])
+  (for ([r rows])
+    (set! _res (append _res (list (hash-ref r "person_name"))))
+  )
+  _res)) "biography_movie" (min-list (let ([_res '()])
+  (for ([r rows])
+    (set! _res (append _res (list (hash-ref r "movie_title"))))
+  )
+  _res)))))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q7_finds_movie_features_biography_for_person)

--- a/tests/dataset/job/compiler/rkt/q8.out
+++ b/tests/dataset/job/compiler/rkt/q8.out
@@ -1,0 +1,1 @@
+(#hash((actress_pseudonym . Y. S.) (japanese_movie_dubbed . Dubbed Film)))

--- a/tests/dataset/job/compiler/rkt/q8.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q8.rkt.out
@@ -1,0 +1,99 @@
+#lang racket
+(require racket/list)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing)
+  (unless (equal? result (list (hash "actress_pseudonym" "Y. S." "japanese_movie_dubbed" "Dubbed Film"))) (error "expect failed"))
+)
+
+(define aka_name (list (hash "person_id" 1 "name" "Y. S.")))
+(define cast_info (list (hash "person_id" 1 "movie_id" 10 "note" "(voice: English version)" "role_id" 1000)))
+(define company_name (list (hash "id" 50 "country_code" "[jp]")))
+(define movie_companies (list (hash "movie_id" 10 "company_id" 50 "note" "Studio (Japan)")))
+(define name (list (hash "id" 1 "name" "Yoko Ono") (hash "id" 2 "name" "Yuichi")))
+(define role_type (list (hash "id" 1000 "role" "actress")))
+(define title (list (hash "id" 10 "title" "Dubbed Film")))
+(define eligible (let ([_res '()])
+  (for ([an1 aka_name])
+    (for ([n1 name])
+      (when (equal? (hash-ref n1 "id") (hash-ref an1 "person_id"))
+        (for ([ci cast_info])
+          (when (equal? (hash-ref ci "person_id") (hash-ref an1 "person_id"))
+            (for ([t title])
+              (when (equal? (hash-ref t "id") (hash-ref ci "movie_id"))
+                (for ([mc movie_companies])
+                  (when (equal? (hash-ref mc "movie_id") (hash-ref ci "movie_id"))
+                    (for ([cn company_name])
+                      (when (equal? (hash-ref cn "id") (hash-ref mc "company_id"))
+                        (for ([rt role_type])
+                          (when (equal? (hash-ref rt "id") (hash-ref ci "role_id"))
+                            (when (and (and (and (and (and (and (equal? (hash-ref ci "note") "(voice: English version)") (equal? (hash-ref cn "country_code") "[jp]")) (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(Japan)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(Japan)"))))] [else (not (false? (member "(Japan)" (hash-ref mc "note"))))])) (not (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(USA)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(USA)"))))] [else (not (false? (member "(USA)" (hash-ref mc "note"))))]))) (cond [(hash? (hash-ref n1 "name")) (hash-has-key? (hash-ref n1 "name") "Yo")] [(string? (hash-ref n1 "name")) (not (false? (string-contains? (hash-ref n1 "name") (format "~a" "Yo"))))] [else (not (false? (member "Yo" (hash-ref n1 "name"))))])) (not (cond [(hash? (hash-ref n1 "name")) (hash-has-key? (hash-ref n1 "name") "Yu")] [(string? (hash-ref n1 "name")) (not (false? (string-contains? (hash-ref n1 "name") (format "~a" "Yu"))))] [else (not (false? (member "Yu" (hash-ref n1 "name"))))]))) (equal? (hash-ref rt "role") "actress"))
+                              (set! _res (append _res (list (hash "pseudonym" (hash-ref an1 "name") "movie_title" (hash-ref t "title")))))
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (list (hash "actress_pseudonym" (min-list (let ([_res '()])
+  (for ([x eligible])
+    (set! _res (append _res (list (hash-ref x "pseudonym"))))
+  )
+  _res)) "japanese_movie_dubbed" (min-list (let ([_res '()])
+  (for ([x eligible])
+    (set! _res (append _res (list (hash-ref x "movie_title"))))
+  )
+  _res)))))
+(displayln result)
+(test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing)

--- a/tests/dataset/job/compiler/rkt/q9.out
+++ b/tests/dataset/job/compiler/rkt/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]

--- a/tests/dataset/job/compiler/rkt/q9.rkt.out
+++ b/tests/dataset/job/compiler/rkt/q9.rkt.out
@@ -1,0 +1,114 @@
+#lang racket
+(require racket/list json)
+
+(define (idx x i)
+  (cond [(string? x) (let* ([n (string-length x)] [idx (if (< i 0) (+ i n) i)]) (char->integer (string-ref x idx)))]
+        [(hash? x) (hash-ref x i)]
+        [else (let* ([n (length x)] [idx (if (< i 0) (+ i n) i)]) (list-ref x idx))]))
+(define (slice x s e)
+  (if (string? x)
+      (let* ([n (string-length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (substring x start end))
+      (let* ([n (length x)]
+             [start (if (< s 0) (+ s n) s)]
+             [end (if (< e 0) (+ e n) e)]
+             [start (max 0 start)]
+             [end (min n end)]
+             [end (if (< end start) start end)])
+        (take (drop x start) (- end start)))))
+(define (count x)
+  (cond [(string? x) (string-length x)]
+        [(hash? x) (hash-count x)]
+        [else (length x)]))
+(define (avg x)
+  (let ([n (count x)])
+    (if (= n 0) 0
+        (/ (for/fold ([s 0.0]) ([v x]) (+ s (real->double-flonum v))) n))))
+(define (min-list xs)
+  (cond [(null? xs) 0]
+        [(for/and ([v xs]) (number? v)) (apply min xs)]
+        [(for/and ([v xs]) (string? v)) (for/fold ([m (car xs)]) ([v (cdr xs)]) (if (string<? v m) v m))]
+        [else (error "unsupported min operands")]))
+(define (_add a b)
+  (cond [(and (number? a) (number? b)) (+ a b)]
+        [(and (string? a) (string? b)) (string-append a b)]
+        [(and (list? a) (list? b)) (append a b)]
+        [else (error "unsupported + operands")]))
+(define (_div a b)
+  (cond [(and (integer? a) (integer? b)) (quotient a b)]
+        [else (/ a b)]))
+
+(define (expect cond) (unless cond (error "expect failed")))
+(define (to-jsexpr v)
+  (cond [(hash? v)
+         (for/hash ([(k val) (in-hash v)])
+           (values (if (string? k) (string->symbol k) k) (to-jsexpr val)))]
+        [(list? v)
+         (map to-jsexpr v)]
+        [else v]))(define (test_Q9_selects_minimal_alternative_name__character_and_movie)
+  (unless (equal? result (list (hash "alternative_name" "A. N. G." "character_name" "Angel" "movie" "Famous Film"))) (error "expect failed"))
+)
+
+(define aka_name (list (hash "person_id" 1 "name" "A. N. G.") (hash "person_id" 2 "name" "J. D.")))
+(define char_name (list (hash "id" 10 "name" "Angel") (hash "id" 20 "name" "Devil")))
+(define cast_info (list (hash "person_id" 1 "person_role_id" 10 "movie_id" 100 "role_id" 1000 "note" "(voice)") (hash "person_id" 2 "person_role_id" 20 "movie_id" 200 "role_id" 1000 "note" "(voice)")))
+(define company_name (list (hash "id" 100 "country_code" "[us]") (hash "id" 200 "country_code" "[gb]")))
+(define movie_companies (list (hash "movie_id" 100 "company_id" 100 "note" "ACME Studios (USA)") (hash "movie_id" 200 "company_id" 200 "note" "Maple Films")))
+(define name (list (hash "id" 1 "name" "Angela Smith" "gender" "f") (hash "id" 2 "name" "John Doe" "gender" "m")))
+(define role_type (list (hash "id" 1000 "role" "actress") (hash "id" 2000 "role" "actor")))
+(define title (list (hash "id" 100 "title" "Famous Film" "production_year" 2010) (hash "id" 200 "title" "Old Movie" "production_year" 1999)))
+(define matches (let ([_res '()])
+  (for ([an aka_name])
+    (for ([n name])
+      (when (equal? (hash-ref an "person_id") (hash-ref n "id"))
+        (for ([ci cast_info])
+          (when (equal? (hash-ref ci "person_id") (hash-ref n "id"))
+            (for ([chn char_name])
+              (when (equal? (hash-ref chn "id") (hash-ref ci "person_role_id"))
+                (for ([t title])
+                  (when (equal? (hash-ref t "id") (hash-ref ci "movie_id"))
+                    (for ([mc movie_companies])
+                      (when (equal? (hash-ref mc "movie_id") (hash-ref t "id"))
+                        (for ([cn company_name])
+                          (when (equal? (hash-ref cn "id") (hash-ref mc "company_id"))
+                            (for ([rt role_type])
+                              (when (equal? (hash-ref rt "id") (hash-ref ci "role_id"))
+                                (when (and (and (and (and (and (and (and (cond [(hash? (list "(voice)" "(voice: Japanese version)" "(voice) (uncredited)" "(voice: English version)")) (hash-has-key? (list "(voice)" "(voice: Japanese version)" "(voice) (uncredited)" "(voice: English version)") (hash-ref ci "note"))] [(string? (list "(voice)" "(voice: Japanese version)" "(voice) (uncredited)" "(voice: English version)")) (not (false? (string-contains? (list "(voice)" "(voice: Japanese version)" "(voice) (uncredited)" "(voice: English version)") (format "~a" (hash-ref ci "note")))))] [else (not (false? (member (hash-ref ci "note") (list "(voice)" "(voice: Japanese version)" "(voice) (uncredited)" "(voice: English version)"))))]) (equal? (hash-ref cn "country_code") "[us]")) (or (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(USA)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(USA)"))))] [else (not (false? (member "(USA)" (hash-ref mc "note"))))]) (cond [(hash? (hash-ref mc "note")) (hash-has-key? (hash-ref mc "note") "(worldwide)")] [(string? (hash-ref mc "note")) (not (false? (string-contains? (hash-ref mc "note") (format "~a" "(worldwide)"))))] [else (not (false? (member "(worldwide)" (hash-ref mc "note"))))]))) (equal? (hash-ref n "gender") "f")) (cond [(hash? (hash-ref n "name")) (hash-has-key? (hash-ref n "name") "Ang")] [(string? (hash-ref n "name")) (not (false? (string-contains? (hash-ref n "name") (format "~a" "Ang"))))] [else (not (false? (member "Ang" (hash-ref n "name"))))])) (equal? (hash-ref rt "role") "actress")) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 2005) (string->number 2005))]) (if (and la lb) (>= la lb) (string>=? (format "~a" (hash-ref t "production_year")) (format "~a" 2005))))) (let ([la (and (string? (hash-ref t "production_year")) (string->number (hash-ref t "production_year")))] [lb (and (string? 2015) (string->number 2015))]) (if (and la lb) (<= la lb) (string<=? (format "~a" (hash-ref t "production_year")) (format "~a" 2015)))))
+                                  (set! _res (append _res (list (hash "alt" (hash-ref an "name") "character" (hash-ref chn "name") "movie" (hash-ref t "title")))))
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  _res))
+(define result (list (hash "alternative_name" (min-list (let ([_res '()])
+  (for ([x matches])
+    (set! _res (append _res (list (hash-ref x "alt"))))
+  )
+  _res)) "character_name" (min-list (let ([_res '()])
+  (for ([x matches])
+    (set! _res (append _res (list (hash-ref x "character"))))
+  )
+  _res)) "movie" (min-list (let ([_res '()])
+  (for ([x matches])
+    (set! _res (append _res (list (hash-ref x "movie"))))
+  )
+  _res)))))
+(displayln (jsexpr->string (to-jsexpr result)))
+(test_Q9_selects_minimal_alternative_name__character_and_movie)

--- a/tests/dataset/job/out/q10.out
+++ b/tests/dataset/job/out/q10.out
@@ -1,0 +1,1 @@
+[{"russian_movie":"Vodka Dreams","uncredited_voiced_character":"Ivan"}]

--- a/tests/dataset/job/out/q3.out
+++ b/tests/dataset/job/out/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/out/q4.out
+++ b/tests/dataset/job/out/q4.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha Movie","rating":"6.2"}]

--- a/tests/dataset/job/out/q5.out
+++ b/tests/dataset/job/out/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/out/q6.out
+++ b/tests/dataset/job/out/q6.out
@@ -1,0 +1,1 @@
+[{"actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3","movie_keyword":"marvel-cinematic-universe"}]

--- a/tests/dataset/job/out/q7.out
+++ b/tests/dataset/job/out/q7.out
@@ -1,0 +1,1 @@
+[{"biography_movie":"Feature Film","of_person":"Alan Brown"}]

--- a/tests/dataset/job/out/q8.out
+++ b/tests/dataset/job/out/q8.out
@@ -1,0 +1,1 @@
+[map[actress_pseudonym:Y. S. japanese_movie_dubbed:Dubbed Film]]

--- a/tests/dataset/job/out/q9.out
+++ b/tests/dataset/job/out/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]


### PR DESCRIPTION
## Summary
- update Racket compiler helpers to handle map keys and string/number comparisons
- implement `min-list` helper
- add JOB dataset golden outputs for queries q1–q10
- generate Racket code for JOB queries and golden tests
- enable JOB compilation tests for the Racket backend

## Testing
- `go test ./compile/x/rkt -tags slow -run TestRacketCompiler_JOB -count=1`
- `go test ./compile/x/rkt -tags slow -run TestRacketCompiler_JOB_Golden -count=1`
- `go test ./... -tags slow -run TestRacketCompiler_JOB -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685e7806f3248320ad19a4d48d6384a2