### PR TITLE
Add Pascal golden tests for JOB queries

### DIFF
--- a/compile/x/pas/TASKS.md
+++ b/compile/x/pas/TASKS.md
@@ -7,3 +7,17 @@ a small JSON printer is included for test output.
 
 Future improvements could extend coverage to the remaining TPCH queries and
 expand runtime error handling.
+
+## JOB dataset
+
+Initial support for the JOB benchmark was added. The compiler can translate
+`tests/dataset/job/q1.mochi` and `q2.mochi` and the generated source is stored
+under `tests/dataset/job/compiler/pas`. However the resulting Pascal code does
+not yet compile with `fpc` due to incomplete join handling and unstable
+temporary variables.
+
+Remaining tasks:
+
+* Fix join code generation so JOB queries build successfully.
+* Stabilise temporary variable names to avoid missing identifiers.
+* Enable running the JOB Q1 and Q2 programs as part of the golden tests.

--- a/compile/x/pas/job_golden_test.go
+++ b/compile/x/pas/job_golden_test.go
@@ -1,0 +1,48 @@
+//go:build slow
+
+package pascode_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pascode "mochi/compile/x/pas"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestPascalCompiler_JOB_Golden(t *testing.T) {
+	if _, err := pascode.EnsureFPC(); err != nil {
+		t.Skipf("fpc not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	for _, q := range []string{"q1", "q2"} {
+		src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Fatalf("type error: %v", errs[0])
+		}
+		code, err := pascode.New(env).Compile(prog)
+		if err != nil {
+			t.Fatalf("compile error: %v", err)
+		}
+		wantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "pas", q+".pas.out")
+		wantCode, err := os.ReadFile(wantPath)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		got := bytes.TrimSpace(code)
+		if !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+			t.Errorf("generated code mismatch for %s.pas.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q, got, bytes.TrimSpace(wantCode))
+		}
+		// The generated Pascal code does not yet compile cleanly
+		// so runtime execution is skipped for now.
+	}
+}

--- a/tests/dataset/job/compiler/pas/q1.out
+++ b/tests/dataset/job/compiler/pas/q1.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Good Movie","movie_year":1995,"production_note":"ACME (co-production)"}]

--- a/tests/dataset/job/compiler/pas/q1.pas.out
+++ b/tests/dataset/job/compiler/pas/q1.pas.out
@@ -1,0 +1,141 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+procedure test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production;
+
+var
+  _tmp0: specialize TFPGMap<string, integer>;
+begin
+  _tmp0 := specialize TFPGMap<string, integer>.Create;
+  _tmp0.AddOrSetData('production_note', 'ACME (co-production)');
+  _tmp0.AddOrSetData('_tmp0ovie_title', 'Good Movie');
+  _tmp0.AddOrSetData('_tmp0ovie_year', 1995);
+  if not ((_result = _tmp0)) then raise Exception.Create('expect failed');
+end;
+
+var
+  _tmp1: specialize TFPGMap<string, integer>;
+  _tmp10: specialize TFPGMap<string, integer>;
+  _tmp11: specialize TFPGMap<string, integer>;
+  _tmp12: specialize TArray<specialize TFPGMap<string, integer>>;
+  _tmp13: specialize TArray<integer>;
+  _tmp14: specialize TArray<integer>;
+  _tmp15: specialize TArray<integer>;
+  _tmp16: specialize TFPGMap<string, integer>;
+  _tmp2: specialize TFPGMap<string, integer>;
+  _tmp3: specialize TFPGMap<string, integer>;
+  _tmp4: specialize TFPGMap<string, integer>;
+  _tmp5: specialize TFPGMap<string, integer>;
+  _tmp6: specialize TFPGMap<string, integer>;
+  _tmp7: specialize TFPGMap<string, integer>;
+  _tmp8: specialize TFPGMap<string, integer>;
+  _tmp9: specialize TFPGMap<string, integer>;
+  company_type: specialize TArray<specialize TFPGMap<string, integer>>;
+  ct: specialize TFPGMap<string, integer>;
+  filtered: specialize TArray<specialize TFPGMap<string, integer>>;
+  info_type: specialize TArray<specialize TFPGMap<string, integer>>;
+  movie_companies: specialize TArray<specialize TFPGMap<string, integer>>;
+  movie_info_idx: specialize TArray<specialize TFPGMap<string, integer>>;
+  r: specialize TFPGMap<string, integer>;
+  _result: specialize TFPGMap<string, integer>;
+  title: specialize TArray<specialize TFPGMap<string, integer>>;
+
+begin
+  _tmp1 := specialize TFPGMap<string, integer>.Create;
+  _tmp1.AddOrSetData('id', 1);
+  _tmp1.AddOrSetData('kind', 'production co_tmp1panies');
+  _tmp2 := specialize TFPGMap<string, integer>.Create;
+  _tmp2.AddOrSetData('id', 2);
+  _tmp2.AddOrSetData('kind', 'distributors');
+  company_type := specialize TArray<specialize TFPGMap<string, integer>>([_tmp1, _tmp2]);
+  _tmp3 := specialize TFPGMap<string, integer>.Create;
+  _tmp3.AddOrSetData('id', 10);
+  _tmp3.AddOrSetData('info', 'top 250 rank');
+  _tmp4 := specialize TFPGMap<string, integer>.Create;
+  _tmp4.AddOrSetData('id', 20);
+  _tmp4.AddOrSetData('info', 'botto_tmp4 10 rank');
+  info_type := specialize TArray<specialize TFPGMap<string, integer>>([_tmp3, _tmp4]);
+  _tmp5 := specialize TFPGMap<string, integer>.Create;
+  _tmp5.AddOrSetData('id', 100);
+  _tmp5.AddOrSetData('title', 'Good Movie');
+  _tmp5.AddOrSetData('production_year', 1995);
+  _tmp6 := specialize TFPGMap<string, integer>.Create;
+  _tmp6.AddOrSetData('id', 200);
+  _tmp6.AddOrSetData('title', 'Bad Movie');
+  _tmp6.AddOrSetData('production_year', 2000);
+  title := specialize TArray<specialize TFPGMap<string, integer>>([_tmp5, _tmp6]);
+  _tmp7 := specialize TFPGMap<string, integer>.Create;
+  _tmp7.AddOrSetData('_tmp7ovie_id', 100);
+  _tmp7.AddOrSetData('co_tmp7pany_type_id', 1);
+  _tmp7.AddOrSetData('note', 'ACME (co-production)');
+  _tmp8 := specialize TFPGMap<string, integer>.Create;
+  _tmp8.AddOrSetData('_tmp8ovie_id', 200);
+  _tmp8.AddOrSetData('co_tmp8pany_type_id', 1);
+  _tmp8.AddOrSetData('note', 'MGM (as Metro-Goldwyn-Mayer Pictures)');
+  movie_companies := specialize TArray<specialize TFPGMap<string, integer>>([_tmp7, _tmp8]);
+  _tmp9 := specialize TFPGMap<string, integer>.Create;
+  _tmp9.AddOrSetData('_tmp9ovie_id', 100);
+  _tmp9.AddOrSetData('info_type_id', 10);
+  _tmp10 := specialize TFPGMap<string, integer>.Create;
+  _tmp10.AddOrSetData('_tmp10ovie_id', 200);
+  _tmp10.AddOrSetData('info_type_id', 20);
+  movie_info_idx := specialize TArray<specialize TFPGMap<string, integer>>([_tmp9, _tmp10]);
+  _tmp11 := specialize TFPGMap<string, integer>.Create;
+  _tmp11.AddOrSetData('note', _tmp11c.note);
+  _tmp11.AddOrSetData('title', t.title);
+  _tmp11.AddOrSetData('year', t.production_year);
+  SetLength(_tmp12, 0);
+  for ct in company_type do
+    begin
+      for mc in movie_companies do
+        begin
+          if not ((ct.id = mc.company_type_id)) then continue;
+          for t in title do
+            begin
+              if not ((t.id = mc.movie_id)) then continue;
+              for mi in movie_info_idx do
+                begin
+                  if not ((mi.movie_id = t.id)) then continue;
+                  for it in info_type do
+                    begin
+                      if not ((it.id = mi.info_type_id)) then continue;
+                      if not (((((ct.kind = 'production companies') and (it.info = 'top 250 rank'))
+                         and not mc.note.contains('(as Metro-Goldwyn-Mayer Pictures)')) and (mc.note
+                         .contains('(co-production)') or mc.note.contains('(presents)')))) then
+                        continue;
+                      _tmp12 := Concat(_tmp12, [_tmp11]);
+                    end;
+                end;
+            end;
+        end;
+    end;
+  filtered := _tmp12;
+  SetLength(_tmp13, 0);
+  for r in filtered do
+    begin
+      _tmp13 := Concat(_tmp13, [r.note]);
+    end;
+  SetLength(_tmp14, 0);
+  for r in filtered do
+    begin
+      _tmp14 := Concat(_tmp14, [r.title]);
+    end;
+  SetLength(_tmp15, 0);
+  for r in filtered do
+    begin
+      _tmp15 := Concat(_tmp15, [r.year]);
+    end;
+  _tmp16 := specialize TFPGMap<string, integer>.Create;
+  _tmp16.AddOrSetData('production_note', _tmp16in(_t_tmp16p13));
+  _tmp16.AddOrSetData('_tmp16ovie_title', _tmp16in(_t_tmp16p14));
+  _tmp16.AddOrSetData('_tmp16ovie_year', _tmp16in(_t_tmp16p15));
+  _result := _tmp16;
+  json(specialize TArray<specialize TFPGMap<string, integer>>([_result]));
+  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production;
+end.
+

--- a/tests/dataset/job/compiler/pas/q2.out
+++ b/tests/dataset/job/compiler/pas/q2.out
@@ -1,0 +1,1 @@
+"Der Film"

--- a/tests/dataset/job/compiler/pas/q2.pas.out
+++ b/tests/dataset/job/compiler/pas/q2.pas.out
@@ -1,0 +1,100 @@
+program main;
+{$mode objfpc}
+
+uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser;
+
+type
+  generic TArray<T> = array of T;
+
+procedure test_Q2_finds_earliest_title_for_German_companies_with_character_keyword;
+begin
+  if not ((_result = 'Der Film')) then raise Exception.Create('expect failed');
+end;
+
+var
+  _tmp0: specialize TFPGMap<string, integer>;
+  _tmp1: specialize TFPGMap<string, integer>;
+  _tmp10: specialize TArray<integer>;
+  _tmp2: specialize TFPGMap<string, integer>;
+  _tmp3: specialize TFPGMap<string, integer>;
+  _tmp4: specialize TFPGMap<string, integer>;
+  _tmp5: specialize TFPGMap<string, integer>;
+  _tmp6: specialize TFPGMap<string, integer>;
+  _tmp7: specialize TFPGMap<string, integer>;
+  _tmp8: specialize TFPGMap<string, integer>;
+  _tmp9: specialize TFPGMap<string, integer>;
+  cn: specialize TFPGMap<string, integer>;
+  company_name: specialize TArray<specialize TFPGMap<string, integer>>;
+  keyword: specialize TArray<specialize TFPGMap<string, integer>>;
+  movie_companies: specialize TArray<specialize TFPGMap<string, integer>>;
+  movie_keyword: specialize TArray<specialize TFPGMap<string, integer>>;
+  _result: integer;
+  title: specialize TArray<specialize TFPGMap<string, integer>>;
+  titles: specialize TArray<integer>;
+
+begin
+  _tmp0 := specialize TFPGMap<string, integer>.Create;
+  _tmp0.AddOrSetData('id', 1);
+  _tmp0.AddOrSetData('country_code', '[de]');
+  _tmp1 := specialize TFPGMap<string, integer>.Create;
+  _tmp1.AddOrSetData('id', 2);
+  _tmp1.AddOrSetData('country_code', '[us]');
+  company_name := specialize TArray<specialize TFPGMap<string, integer>>([_tmp0, _tmp1]);
+  _tmp2 := specialize TFPGMap<string, integer>.Create;
+  _tmp2.AddOrSetData('id', 1);
+  _tmp2.AddOrSetData('keyword', 'character-na_tmp2e-in-title');
+  _tmp3 := specialize TFPGMap<string, integer>.Create;
+  _tmp3.AddOrSetData('id', 2);
+  _tmp3.AddOrSetData('keyword', 'other');
+  keyword := specialize TArray<specialize TFPGMap<string, integer>>([_tmp2, _tmp3]);
+  _tmp4 := specialize TFPGMap<string, integer>.Create;
+  _tmp4.AddOrSetData('_tmp4ovie_id', 100);
+  _tmp4.AddOrSetData('co_tmp4pany_id', 1);
+  _tmp5 := specialize TFPGMap<string, integer>.Create;
+  _tmp5.AddOrSetData('_tmp5ovie_id', 200);
+  _tmp5.AddOrSetData('co_tmp5pany_id', 2);
+  movie_companies := specialize TArray<specialize TFPGMap<string, integer>>([_tmp4, _tmp5]);
+  _tmp6 := specialize TFPGMap<string, integer>.Create;
+  _tmp6.AddOrSetData('_tmp6ovie_id', 100);
+  _tmp6.AddOrSetData('keyword_id', 1);
+  _tmp7 := specialize TFPGMap<string, integer>.Create;
+  _tmp7.AddOrSetData('_tmp7ovie_id', 200);
+  _tmp7.AddOrSetData('keyword_id', 2);
+  movie_keyword := specialize TArray<specialize TFPGMap<string, integer>>([_tmp6, _tmp7]);
+  _tmp8 := specialize TFPGMap<string, integer>.Create;
+  _tmp8.AddOrSetData('id', 100);
+  _tmp8.AddOrSetData('title', 'Der Fil_tmp8');
+  _tmp9 := specialize TFPGMap<string, integer>.Create;
+  _tmp9.AddOrSetData('id', 200);
+  _tmp9.AddOrSetData('title', 'Other Movie');
+  title := specialize TArray<specialize TFPGMap<string, integer>>([_tmp8, _tmp9]);
+  SetLength(_tmp10, 0);
+  for cn in company_name do
+    begin
+      for mc in movie_companies do
+        begin
+          if not ((mc.company_id = cn.id)) then continue;
+          for t in title do
+            begin
+              if not ((mc.movie_id = t.id)) then continue;
+              for mk in movie_keyword do
+                begin
+                  if not ((mk.movie_id = t.id)) then continue;
+                  for k in keyword do
+                    begin
+                      if not ((mk.keyword_id = k.id)) then continue;
+                      if not ((((cn.country_code = '[de]') and (k.keyword =
+                         'character-name-in-title')) and (mc.movie_id = mk.movie_id))) then continue
+                      ;
+                      _tmp10 := Concat(_tmp10, [t.title]);
+                    end;
+                end;
+            end;
+        end;
+    end;
+  titles := _tmp10;
+  _result := min(titles);
+  json(_result);
+  test_Q2_finds_earliest_title_for_German_companies_with_character_keyword;
+end.
+


### PR DESCRIPTION
## Summary
- create Pascal golden test for JOB queries
- store compiled JOB q1-q2 code
- capture expected outputs
- document pending work for JOB support

## Testing
- `go test ./compile/x/pas -tags slow -run JOB_Golden -count=1 -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e7c268d3c83209e4269740886f5d8