### PR TITLE
Add JOB dataset compilation tests for Java backend

### DIFF
--- a/compile/x/java/TASKS.md
+++ b/compile/x/java/TASKS.md
@@ -1,8 +1,10 @@
 # Java Backend Tasks for TPCH Q1
 
-The Java backend now runs `tests/dataset/tpc-h/q1.mochi` and the generated code
-is checked in `tests/dataset/tpc-h/compiler/java`. Remaining tasks focus on
-improving performance and coverage.
+The Java backend compiles `tests/dataset/tpc-h/q1.mochi` and the generated code
+is checked in `tests/dataset/tpc-h/compiler/java`. Initial golden files were
+added for `dataset/job` queries `q1` and `q2`, however the emitted Java fails to
+build because map field access is not handled correctly. Remaining tasks focus
+on improving dataset support and performance.
 
 1. **Expand numeric helpers** – current implementations of `sum`, `avg` and
    `count` work for lists, arrays and groups. Support for additional numeric

--- a/compile/x/java/job_test.go
+++ b/compile/x/java/job_test.go
@@ -1,0 +1,23 @@
+//go:build slow
+
+package javacode_test
+
+import (
+	"testing"
+
+	javacode "mochi/compile/x/java"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestJavaCompiler_JOB(t *testing.T) {
+	if err := javacode.EnsureJavac(); err != nil {
+		t.Skipf("javac not installed: %v", err)
+	}
+	for _, q := range []string{"q1", "q2"} {
+		testutil.CompileJOB(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+			return javacode.New(env).Compile(prog)
+		})
+	}
+}

--- a/tests/dataset/job/compiler/java/q1.java.out
+++ b/tests/dataset/job/compiler/java/q1.java.out
@@ -1,0 +1,178 @@
+public class Main {
+    static void test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production() {
+        expect((result == new java.util.HashMap<>(java.util.Map.of("production_note", "ACME (co-production)", "movie_title", "Good Movie", "movie_year", 1995))));
+    }
+    
+    static Object[] company_type = new Object[]{new java.util.HashMap<>(java.util.Map.of("id", 1, "kind", "production companies")), new java.util.HashMap<>(java.util.Map.of("id", 2, "kind", "distributors"))};
+    
+    static Object[] info_type = new Object[]{new java.util.HashMap<>(java.util.Map.of("id", 10, "info", "top 250 rank")), new java.util.HashMap<>(java.util.Map.of("id", 20, "info", "bottom 10 rank"))};
+    
+    static Object[] title = new Object[]{new java.util.HashMap<>(java.util.Map.of("id", 100, "title", "Good Movie", "production_year", 1995)), new java.util.HashMap<>(java.util.Map.of("id", 200, "title", "Bad Movie", "production_year", 2000))};
+    
+    static Object[] movie_companies = new Object[]{new java.util.HashMap<>(java.util.Map.of("movie_id", 100, "company_type_id", 1, "note", "ACME (co-production)")), new java.util.HashMap<>(java.util.Map.of("movie_id", 200, "company_type_id", 1, "note", "MGM (as Metro-Goldwyn-Mayer Pictures)"))};
+    
+    static Object[] movie_info_idx = new Object[]{new java.util.HashMap<>(java.util.Map.of("movie_id", 100, "info_type_id", 10)), new java.util.HashMap<>(java.util.Map.of("movie_id", 200, "info_type_id", 20))};
+    
+    static Object[] filtered = (new java.util.function.Supplier<java.util.List<Object>>() {
+    public java.util.List<Object> get() {
+        java.util.List<Object> _src = _toList(company_type);
+        java.util.List<_JoinSpec> _joins = java.util.List.of(
+            new _JoinSpec(_toList(movie_companies), (Object[] a) -> { Object ct = a[0]; Object mc = a[1]; return (ct.id == mc.company_type_id); }, false, false),
+            new _JoinSpec(_toList(title), (Object[] a) -> { Object ct = a[0]; Object mc = a[1]; Object t = a[2]; return (t.id == mc.movie_id); }, false, false),
+            new _JoinSpec(_toList(movie_info_idx), (Object[] a) -> { Object ct = a[0]; Object mc = a[1]; Object t = a[2]; Object mi = a[3]; return (mi.movie_id == t.id); }, false, false),
+            new _JoinSpec(_toList(info_type), (Object[] a) -> { Object ct = a[0]; Object mc = a[1]; Object t = a[2]; Object mi = a[3]; Object it = a[4]; return (it.id == mi.info_type_id); }, false, false)
+        );
+        return _query(_src, _joins, new _QueryOpts((Object[] a) -> { Object ct = a[0]; Object mc = a[1]; Object t = a[2]; Object mi = a[3]; Object it = a[4]; return new java.util.HashMap<>(java.util.Map.of("note", mc.note, "title", t.title, "year", t.production_year)); }, (Object[] a) -> { Object ct = a[0]; Object mc = a[1]; Object t = a[2]; Object mi = a[3]; Object it = a[4]; return ((((ct.kind == "production companies") && (it.info == "top 250 rank")) && (!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)"))) && (mc.note.contains("(co-production)") || mc.note.contains("(presents)"))); }, null, -1, -1));
+    }
+}).get();
+    
+    static java.util.Map<String, Object> result = new java.util.HashMap<>(java.util.Map.of("production_note", min.apply((new java.util.function.Supplier<java.util.List<Object>>() {
+    public java.util.List<Object> get() {
+        java.util.List<Object> _src = _toList(filtered);
+        java.util.List<_JoinSpec> _joins = java.util.List.of(
+        );
+        return _query(_src, _joins, new _QueryOpts((Object[] a) -> { Object r = a[0]; return r.note; }, null, null, -1, -1));
+    }
+}).get()), "movie_title", min.apply((new java.util.function.Supplier<java.util.List<Object>>() {
+    public java.util.List<Object> get() {
+        java.util.List<Object> _src = _toList(filtered);
+        java.util.List<_JoinSpec> _joins = java.util.List.of(
+        );
+        return _query(_src, _joins, new _QueryOpts((Object[] a) -> { Object r = a[0]; return r.title; }, null, null, -1, -1));
+    }
+}).get()), "movie_year", min.apply((new java.util.function.Supplier<java.util.List<Object>>() {
+    public java.util.List<Object> get() {
+        java.util.List<Object> _src = _toList(filtered);
+        java.util.List<_JoinSpec> _joins = java.util.List.of(
+        );
+        return _query(_src, _joins, new _QueryOpts((Object[] a) -> { Object r = a[0]; return r.year; }, null, null, -1, -1));
+    }
+}).get())));
+    
+    public static void main(String[] args) {
+        test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production();
+        _json(new Object[]{result});
+    }
+    
+    static void expect(boolean cond) {
+        if (!cond) throw new RuntimeException("expect failed");
+    }
+    
+    static void _json(Object v) {
+        System.out.println(_toJson(v));
+    }
+    
+    static java.util.List<Object> _toList(Object v) {
+        if (v instanceof java.util.List<?>) return new java.util.ArrayList<>((java.util.List<?>)v);
+        int n = java.lang.reflect.Array.getLength(v);
+        java.util.List<Object> out = new java.util.ArrayList<>(n);
+        for (int i=0;i<n;i++) out.add(java.lang.reflect.Array.get(v,i));
+        return out;
+    }
+    
+    static class _JoinSpec {
+        java.util.List<Object> items;
+        java.util.function.Function<Object[],Boolean> on;
+        boolean left;
+        boolean right;
+        _JoinSpec(java.util.List<Object> items, java.util.function.Function<Object[],Boolean> on, boolean left, boolean right) {
+            this.items=items; this.on=on; this.left=left; this.right=right;
+        }
+    }
+    
+    static class _QueryOpts {
+        java.util.function.Function<Object[],Object> selectFn;
+        java.util.function.Function<Object[],Boolean> where;
+        java.util.function.Function<Object[],Object> sortKey;
+        int skip; int take;
+        _QueryOpts(java.util.function.Function<Object[],Object> s, java.util.function.Function<Object[],Boolean> w, java.util.function.Function<Object[],Object> k, int skip, int take) {
+            this.selectFn=s; this.where=w; this.sortKey=k; this.skip=skip; this.take=take;
+        }
+    }
+    static java.util.List<Object> _query(java.util.List<Object> src, java.util.List<_JoinSpec> joins, _QueryOpts opts) {
+        java.util.List<java.util.List<Object>> items = new java.util.ArrayList<>();
+        for (Object v : src) { java.util.List<Object> r = new java.util.ArrayList<>(); r.add(v); items.add(r); }
+        for (_JoinSpec j : joins) {
+            java.util.List<java.util.List<Object>> joined = new java.util.ArrayList<>();
+            java.util.List<Object> jitems = j.items;
+            if (j.right && j.left) {
+                boolean[] matched = new boolean[jitems.size()];
+                for (java.util.List<Object> left : items) {
+                    boolean m = false;
+                    for (int ri=0; ri<jitems.size(); ri++) {
+                        Object right = jitems.get(ri);
+                        boolean keep = true;
+                        if (j.on != null) {
+                            Object[] args = new Object[left.size()+1];
+                            for (int i=0;i<left.size();i++) args[i]=left.get(i);
+                            args[left.size()] = right;
+                            keep = j.on.apply(args);
+                        }
+                        if (!keep) continue;
+                        m = true; matched[ri] = true;
+                        java.util.List<Object> row = new java.util.ArrayList<>(left);
+                        row.add(right); joined.add(row);
+                    }
+                    if (!m) { java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(null); joined.add(row); }
+                }
+                for (int ri=0; ri<jitems.size(); ri++) {
+                    if (!matched[ri]) { java.util.List<Object> undef = new java.util.ArrayList<>(items.isEmpty()?0:items.get(0).size()); for(int k=0;k<undef.size();k++) undef.set(k,null); undef.add(jitems.get(ri)); joined.add(undef); }
+                }
+            } else if (j.right) {
+                for (Object right : jitems) {
+                    boolean m = false;
+                    for (java.util.List<Object> left : items) {
+                        boolean keep = true;
+                        if (j.on != null) {
+                            Object[] args = new Object[left.size()+1];
+                            for (int i=0;i<left.size();i++) args[i]=left.get(i);
+                            args[left.size()] = right;
+                            keep = j.on.apply(args);
+                        }
+                        if (!keep) continue;
+                        m = true; java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(right); joined.add(row);
+                    }
+                    if (!m) { java.util.List<Object> undef = new java.util.ArrayList<>(items.isEmpty()?0:items.get(0).size()); for(int k=0;k<undef.size();k++) undef.set(k,null); undef.add(right); joined.add(undef); }
+                }
+            } else {
+                for (java.util.List<Object> left : items) {
+                    boolean m = false;
+                    for (Object right : jitems) {
+                        boolean keep = true;
+                        if (j.on != null) {
+                            Object[] args = new Object[left.size()+1];
+                            for (int i=0;i<left.size();i++) args[i]=left.get(i);
+                            args[left.size()] = right;
+                            keep = j.on.apply(args);
+                        }
+                        if (!keep) continue;
+                        m = true; java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(right); joined.add(row);
+                    }
+                    if (j.left && !m) { java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(null); joined.add(row); }
+                }
+            items = joined;
+        }
+        if (opts.where != null) {
+            java.util.List<java.util.List<Object>> filtered = new java.util.ArrayList<>();
+            for (java.util.List<Object> r : items) if (opts.where.apply(r.toArray(new Object[0]))) filtered.add(r);
+            items = filtered;
+        }
+        if (opts.sortKey != null) {
+            class Pair { java.util.List<Object> item; Object key; Pair(java.util.List<Object> i,Object k){item=i;key=k;} }
+            java.util.List<Pair> pairs = new java.util.ArrayList<>();
+            for (java.util.List<Object> it : items) pairs.add(new Pair(it, opts.sortKey.apply(it.toArray(new Object[0]))));
+            pairs.sort((a,b) -> {
+                Object ak=a.key, bk=b.key;
+                if (ak instanceof Number && bk instanceof Number) return Double.compare(((Number)ak).doubleValue(), ((Number)bk).doubleValue());
+                if (ak instanceof String && bk instanceof String) return ((String)ak).compareTo((String)bk);
+                return ak.toString().compareTo(bk.toString());
+            });
+            for (int i=0;i<pairs.size();i++) items.set(i, pairs.get(i).item);
+        }
+        if (opts.skip >= 0) { if (opts.skip < items.size()) items = new java.util.ArrayList<>(items.subList(opts.skip, items.size())); else items = new java.util.ArrayList<>(); }
+        if (opts.take >= 0) { if (opts.take < items.size()) items = new java.util.ArrayList<>(items.subList(0, opts.take)); }
+        java.util.List<Object> res = new java.util.ArrayList<>();
+        for (java.util.List<Object> r : items) res.add(opts.selectFn.apply(r.toArray(new Object[0])));
+        return res;
+    }
+}

--- a/tests/dataset/job/compiler/java/q1.out
+++ b/tests/dataset/job/compiler/java/q1.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Good Movie","movie_year":1995,"production_note":"ACME (co-production)"}]

--- a/tests/dataset/job/compiler/java/q2.java.out
+++ b/tests/dataset/job/compiler/java/q2.java.out
@@ -1,0 +1,157 @@
+public class Main {
+    static void test_Q2_finds_earliest_title_for_German_companies_with_character_keyword() {
+        expect((result == "Der Film"));
+    }
+    
+    static Object[] company_name = new Object[]{new java.util.HashMap<>(java.util.Map.of("id", 1, "country_code", "[de]")), new java.util.HashMap<>(java.util.Map.of("id", 2, "country_code", "[us]"))};
+    
+    static Object[] keyword = new Object[]{new java.util.HashMap<>(java.util.Map.of("id", 1, "keyword", "character-name-in-title")), new java.util.HashMap<>(java.util.Map.of("id", 2, "keyword", "other"))};
+    
+    static Object[] movie_companies = new Object[]{new java.util.HashMap<>(java.util.Map.of("movie_id", 100, "company_id", 1)), new java.util.HashMap<>(java.util.Map.of("movie_id", 200, "company_id", 2))};
+    
+    static Object[] movie_keyword = new Object[]{new java.util.HashMap<>(java.util.Map.of("movie_id", 100, "keyword_id", 1)), new java.util.HashMap<>(java.util.Map.of("movie_id", 200, "keyword_id", 2))};
+    
+    static Object[] title = new Object[]{new java.util.HashMap<>(java.util.Map.of("id", 100, "title", "Der Film")), new java.util.HashMap<>(java.util.Map.of("id", 200, "title", "Other Movie"))};
+    
+    static Object[] titles = (new java.util.function.Supplier<java.util.List<Object>>() {
+    public java.util.List<Object> get() {
+        java.util.List<Object> _src = _toList(company_name);
+        java.util.List<_JoinSpec> _joins = java.util.List.of(
+            new _JoinSpec(_toList(movie_companies), (Object[] a) -> { Object cn = a[0]; Object mc = a[1]; return (mc.company_id == cn.id); }, false, false),
+            new _JoinSpec(_toList(title), (Object[] a) -> { Object cn = a[0]; Object mc = a[1]; Object t = a[2]; return (mc.movie_id == t.id); }, false, false),
+            new _JoinSpec(_toList(movie_keyword), (Object[] a) -> { Object cn = a[0]; Object mc = a[1]; Object t = a[2]; Object mk = a[3]; return (mk.movie_id == t.id); }, false, false),
+            new _JoinSpec(_toList(keyword), (Object[] a) -> { Object cn = a[0]; Object mc = a[1]; Object t = a[2]; Object mk = a[3]; Object k = a[4]; return (mk.keyword_id == k.id); }, false, false)
+        );
+        return _query(_src, _joins, new _QueryOpts((Object[] a) -> { Object cn = a[0]; Object mc = a[1]; Object t = a[2]; Object mk = a[3]; Object k = a[4]; return t.title; }, (Object[] a) -> { Object cn = a[0]; Object mc = a[1]; Object t = a[2]; Object mk = a[3]; Object k = a[4]; return (((cn.country_code == "[de]") && (k.keyword == "character-name-in-title")) && (mc.movie_id == mk.movie_id)); }, null, -1, -1));
+    }
+}).get();
+    
+    static Object result = min.apply(titles);
+    
+    public static void main(String[] args) {
+        test_Q2_finds_earliest_title_for_German_companies_with_character_keyword();
+        _json(result);
+    }
+    
+    static void expect(boolean cond) {
+        if (!cond) throw new RuntimeException("expect failed");
+    }
+    
+    static void _json(Object v) {
+        System.out.println(_toJson(v));
+    }
+    
+    static java.util.List<Object> _toList(Object v) {
+        if (v instanceof java.util.List<?>) return new java.util.ArrayList<>((java.util.List<?>)v);
+        int n = java.lang.reflect.Array.getLength(v);
+        java.util.List<Object> out = new java.util.ArrayList<>(n);
+        for (int i=0;i<n;i++) out.add(java.lang.reflect.Array.get(v,i));
+        return out;
+    }
+    
+    static class _JoinSpec {
+        java.util.List<Object> items;
+        java.util.function.Function<Object[],Boolean> on;
+        boolean left;
+        boolean right;
+        _JoinSpec(java.util.List<Object> items, java.util.function.Function<Object[],Boolean> on, boolean left, boolean right) {
+            this.items=items; this.on=on; this.left=left; this.right=right;
+        }
+    }
+    
+    static class _QueryOpts {
+        java.util.function.Function<Object[],Object> selectFn;
+        java.util.function.Function<Object[],Boolean> where;
+        java.util.function.Function<Object[],Object> sortKey;
+        int skip; int take;
+        _QueryOpts(java.util.function.Function<Object[],Object> s, java.util.function.Function<Object[],Boolean> w, java.util.function.Function<Object[],Object> k, int skip, int take) {
+            this.selectFn=s; this.where=w; this.sortKey=k; this.skip=skip; this.take=take;
+        }
+    }
+    static java.util.List<Object> _query(java.util.List<Object> src, java.util.List<_JoinSpec> joins, _QueryOpts opts) {
+        java.util.List<java.util.List<Object>> items = new java.util.ArrayList<>();
+        for (Object v : src) { java.util.List<Object> r = new java.util.ArrayList<>(); r.add(v); items.add(r); }
+        for (_JoinSpec j : joins) {
+            java.util.List<java.util.List<Object>> joined = new java.util.ArrayList<>();
+            java.util.List<Object> jitems = j.items;
+            if (j.right && j.left) {
+                boolean[] matched = new boolean[jitems.size()];
+                for (java.util.List<Object> left : items) {
+                    boolean m = false;
+                    for (int ri=0; ri<jitems.size(); ri++) {
+                        Object right = jitems.get(ri);
+                        boolean keep = true;
+                        if (j.on != null) {
+                            Object[] args = new Object[left.size()+1];
+                            for (int i=0;i<left.size();i++) args[i]=left.get(i);
+                            args[left.size()] = right;
+                            keep = j.on.apply(args);
+                        }
+                        if (!keep) continue;
+                        m = true; matched[ri] = true;
+                        java.util.List<Object> row = new java.util.ArrayList<>(left);
+                        row.add(right); joined.add(row);
+                    }
+                    if (!m) { java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(null); joined.add(row); }
+                }
+                for (int ri=0; ri<jitems.size(); ri++) {
+                    if (!matched[ri]) { java.util.List<Object> undef = new java.util.ArrayList<>(items.isEmpty()?0:items.get(0).size()); for(int k=0;k<undef.size();k++) undef.set(k,null); undef.add(jitems.get(ri)); joined.add(undef); }
+                }
+            } else if (j.right) {
+                for (Object right : jitems) {
+                    boolean m = false;
+                    for (java.util.List<Object> left : items) {
+                        boolean keep = true;
+                        if (j.on != null) {
+                            Object[] args = new Object[left.size()+1];
+                            for (int i=0;i<left.size();i++) args[i]=left.get(i);
+                            args[left.size()] = right;
+                            keep = j.on.apply(args);
+                        }
+                        if (!keep) continue;
+                        m = true; java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(right); joined.add(row);
+                    }
+                    if (!m) { java.util.List<Object> undef = new java.util.ArrayList<>(items.isEmpty()?0:items.get(0).size()); for(int k=0;k<undef.size();k++) undef.set(k,null); undef.add(right); joined.add(undef); }
+                }
+            } else {
+                for (java.util.List<Object> left : items) {
+                    boolean m = false;
+                    for (Object right : jitems) {
+                        boolean keep = true;
+                        if (j.on != null) {
+                            Object[] args = new Object[left.size()+1];
+                            for (int i=0;i<left.size();i++) args[i]=left.get(i);
+                            args[left.size()] = right;
+                            keep = j.on.apply(args);
+                        }
+                        if (!keep) continue;
+                        m = true; java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(right); joined.add(row);
+                    }
+                    if (j.left && !m) { java.util.List<Object> row = new java.util.ArrayList<>(left); row.add(null); joined.add(row); }
+                }
+            items = joined;
+        }
+        if (opts.where != null) {
+            java.util.List<java.util.List<Object>> filtered = new java.util.ArrayList<>();
+            for (java.util.List<Object> r : items) if (opts.where.apply(r.toArray(new Object[0]))) filtered.add(r);
+            items = filtered;
+        }
+        if (opts.sortKey != null) {
+            class Pair { java.util.List<Object> item; Object key; Pair(java.util.List<Object> i,Object k){item=i;key=k;} }
+            java.util.List<Pair> pairs = new java.util.ArrayList<>();
+            for (java.util.List<Object> it : items) pairs.add(new Pair(it, opts.sortKey.apply(it.toArray(new Object[0]))));
+            pairs.sort((a,b) -> {
+                Object ak=a.key, bk=b.key;
+                if (ak instanceof Number && bk instanceof Number) return Double.compare(((Number)ak).doubleValue(), ((Number)bk).doubleValue());
+                if (ak instanceof String && bk instanceof String) return ((String)ak).compareTo((String)bk);
+                return ak.toString().compareTo(bk.toString());
+            });
+            for (int i=0;i<pairs.size();i++) items.set(i, pairs.get(i).item);
+        }
+        if (opts.skip >= 0) { if (opts.skip < items.size()) items = new java.util.ArrayList<>(items.subList(opts.skip, items.size())); else items = new java.util.ArrayList<>(); }
+        if (opts.take >= 0) { if (opts.take < items.size()) items = new java.util.ArrayList<>(items.subList(0, opts.take)); }
+        java.util.List<Object> res = new java.util.ArrayList<>();
+        for (java.util.List<Object> r : items) res.add(opts.selectFn.apply(r.toArray(new Object[0])));
+        return res;
+    }
+}

--- a/tests/dataset/job/compiler/java/q2.out
+++ b/tests/dataset/job/compiler/java/q2.out
@@ -1,0 +1,1 @@
+"Der Film"


### PR DESCRIPTION
## Summary
- add JOB dataset compilation test for the Java backend
- add golden code and output files for job/q1 and job/q2
- note current limitation in TASKS.md

## Testing
- `go test ./compile/x/java -tags slow -run JOB -v`

------
https://chatgpt.com/codex/tasks/task_e_685e7bf8fb848320a90ca71e0e443e7e