### PR TITLE
Add Scala JOB q2 golden test and compiler tweaks

### DIFF
--- a/compile/x/scala/TASKS.md
+++ b/compile/x/scala/TASKS.md
@@ -1,6 +1,6 @@
-# Scala Backend Tasks for TPCH Q1
+# Scala Backend Tasks
 
-Scala code generation now supports running the `tpc-h/q1.mochi` benchmark.
+Scala code generation now supports running the `tpc-h/q1.mochi` benchmark and JOB queries.
 
 Completed work:
 
@@ -10,3 +10,4 @@ Completed work:
 - Added golden test `TestScalaCompiler_TPCHQ1` checking generated code and runtime output.
 - Generated code lives under `tests/dataset/tpc-h/compiler/scala/q1.scala.out`.
 - Added golden test `TestScalaCompiler_JOBQ1` covering the JOB dataset query.
+- Added golden test `TestScalaCompiler_JOBQ2` covering the JOB dataset query.

--- a/compile/x/scala/compiler.go
+++ b/compile/x/scala/compiler.go
@@ -173,9 +173,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	c.indent--
 	c.writeln("}")
+	c.emitRuntime()
 	c.indent--
 	c.writeln("}")
-	c.emitRuntime()
 	return FormatScala(c.buf.Bytes()), nil
 }
 

--- a/compile/x/scala/helpers.go
+++ b/compile/x/scala/helpers.go
@@ -268,11 +268,11 @@ func isAny(t types.Type) bool {
 
 func seqLambda(params []string, body string) string {
 	var b strings.Builder
-	b.WriteString("(args: Seq[Any]) => {\n")
+	b.WriteString("((args: Seq[Any]) => {\n")
 	for i, p := range params {
 		b.WriteString("\tval " + p + " = args(" + fmt.Sprint(i) + ")\n")
 	}
 	b.WriteString(indentBlock(body, 1))
-	b.WriteString("}")
+	b.WriteString("})")
 	return b.String()
 }

--- a/compile/x/scala/job_q2_golden_test.go
+++ b/compile/x/scala/job_q2_golden_test.go
@@ -1,0 +1,88 @@
+//go:build slow
+
+package scalacode_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	scalacode "mochi/compile/x/scala"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestScalaCompiler_JOBQ2(t *testing.T) {
+	if err := scalacode.EnsureScala(); err != nil {
+		t.Skipf("scala not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "job", "q2.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := scalacode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	wantCode, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "scala", "q2.scala.out"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q2.scala.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(wantCode))
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Main.scala")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	if out, err := exec.Command("scalac", file).CombinedOutput(); err != nil {
+		t.Skipf("scalac error: %v\n%s", err, out)
+		return
+	}
+	scalaCmd := "scala"
+	args := []string{"Main"}
+	if _, err := exec.LookPath("scala-cli"); err == nil {
+		scalaCmd = "scala-cli"
+		args = []string{"run", file}
+	} else if out, err := exec.Command("scala", "-version").CombinedOutput(); err == nil && bytes.Contains(out, []byte("Scala CLI")) {
+		args = []string{"run", file}
+	}
+	out, err := exec.Command(scalaCmd, args...).CombinedOutput()
+	if err != nil {
+		t.Skipf("scala run error: %v\n%s", err, out)
+		return
+	}
+	gotOutLines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+	if len(gotOutLines) == 0 {
+		t.Fatalf("no output")
+	}
+	gotJSON := gotOutLines[0]
+	wantOut, err := os.ReadFile(filepath.Join(root, "tests", "dataset", "job", "compiler", "scala", "q2.out"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	wantLines := bytes.Split(bytes.TrimSpace(wantOut), []byte("\n"))
+	wantJSON := wantLines[0]
+	var gotVal, wantVal any
+	if err := json.Unmarshal(gotJSON, &gotVal); err != nil {
+		t.Fatalf("parse got json: %v", err)
+	}
+	if err := json.Unmarshal(wantJSON, &wantVal); err != nil {
+		t.Fatalf("parse want json: %v", err)
+	}
+	if !reflect.DeepEqual(gotVal, wantVal) {
+		t.Errorf("output mismatch for q2.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", gotJSON, wantJSON)
+	}
+}

--- a/tests/dataset/job/compiler/scala/q1.scala.out
+++ b/tests/dataset/job/compiler/scala/q1.scala.out
@@ -12,160 +12,160 @@ object Main {
         val filtered: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = (() => {
     val src = company_type
     val res = _query(src, Seq(
-        Map("items" -> movie_companies, "on" -> (args: Seq[Any]) => {
+        Map("items" -> movie_companies, "on" -> ((args: Seq[Any]) => {
     val ct = args(0)
     val mc = args(1)
     (ct.id == mc.company_type_id)
-}),
-        Map("items" -> title, "on" -> (args: Seq[Any]) => {
+})),
+        Map("items" -> title, "on" -> ((args: Seq[Any]) => {
     val ct = args(0)
     val mc = args(1)
     val t = args(2)
     (t.id == mc.movie_id)
-}),
-        Map("items" -> movie_info_idx, "on" -> (args: Seq[Any]) => {
+})),
+        Map("items" -> movie_info_idx, "on" -> ((args: Seq[Any]) => {
     val ct = args(0)
     val mc = args(1)
     val t = args(2)
     val mi = args(3)
     (mi.movie_id == t.id)
-}),
-        Map("items" -> info_type, "on" -> (args: Seq[Any]) => {
+})),
+        Map("items" -> info_type, "on" -> ((args: Seq[Any]) => {
     val ct = args(0)
     val mc = args(1)
     val t = args(2)
     val mi = args(3)
     val it = args(4)
     (it.id == mi.info_type_id)
-})
-    ), Map("select" -> (args: Seq[Any]) => {
+}))
+    ), Map("select" -> ((args: Seq[Any]) => {
     val ct = args(0)
     val mc = args(1)
     val t = args(2)
     val mi = args(3)
     val it = args(4)
     scala.collection.mutable.Map("note" -> mc.note, "title" -> t.title, "year" -> t.production_year)
-}, "where" -> (args: Seq[Any]) => {
+}), "where" -> ((args: Seq[Any]) => {
     val ct = args(0)
     val mc = args(1)
     val t = args(2)
     val mi = args(3)
     val it = args(4)
     ((((ct.kind == "production companies") && (it.info == "top 250 rank")) && ((!mc.note.contains("(as Metro-Goldwyn-Mayer Pictures)")))) && ((mc.note.contains("(co-production)") || mc.note.contains("(presents)"))))
-}))
+})))
     res
 })()
         val result: scala.collection.mutable.Map[String, Any] = scala.collection.mutable.Map("production_note" -> min((() => {
     val src = filtered
     val res = _query(src, Seq(
-    ), Map("select" -> (args: Seq[Any]) => {
+    ), Map("select" -> ((args: Seq[Any]) => {
     val r = args(0)
     r.note
-}))
+})))
     res
 })()), "movie_title" -> min((() => {
     val src = filtered
     val res = _query(src, Seq(
-    ), Map("select" -> (args: Seq[Any]) => {
+    ), Map("select" -> ((args: Seq[Any]) => {
     val r = args(0)
     r.title
-}))
+})))
     res
 })()), "movie_year" -> min((() => {
     val src = filtered
     val res = _query(src, Seq(
-    ), Map("select" -> (args: Seq[Any]) => {
+    ), Map("select" -> ((args: Seq[Any]) => {
     val r = args(0)
     r.year
-}))
+})))
     res
 })()))
         _json(scala.collection.mutable.ArrayBuffer(result))
         test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production()
     }
+    def expect(cond: Boolean): Unit = {
+            if (!cond) throw new RuntimeException("expect failed")
+    }
+    
+    def _json(v: Any): Unit = println(_to_json(v))
+    
+    def _query(src: Seq[Any], joins: Seq[Map[String,Any]], opts: Map[String,Any]): Seq[Any] = {
+            var items = src.map(v => Seq[Any](v))
+            for (j <- joins) {
+                    val joined = scala.collection.mutable.ArrayBuffer[Seq[Any]]()
+                    val jitems = j("items").asInstanceOf[Seq[Any]]
+                    val on = j.get("on").map(_.asInstanceOf[Seq[Any] => Boolean])
+                    val left = j.get("left").exists(_.asInstanceOf[Boolean])
+                    val right = j.get("right").exists(_.asInstanceOf[Boolean])
+                    if (left && right) {
+                            val matched = Array.fill(jitems.length)(false)
+                            for (leftRow <- items) {
+                                    var m = false
+                                    for ((rightRow, ri) <- jitems.zipWithIndex) {
+                                            var keep = true
+                                            if (on.isDefined) keep = on.get(leftRow :+ rightRow)
+                                            if (keep) { m = true; matched(ri) = true; joined.append(leftRow :+ rightRow) }
+                                    }
+                                    if (!m) joined.append(leftRow :+ null)
+                            }
+                            for ((rightRow, ri) <- jitems.zipWithIndex) {
+                                    if (!matched(ri)) {
+                                            val undef = if (items.nonEmpty) Seq.fill(items.head.length)(null) else Seq[Any]()
+                                            joined.append(undef :+ rightRow)
+                                    }
+                            }
+                    } else if (right) {
+                            for (rightRow <- jitems) {
+                                    var m = false
+                                    for (leftRow <- items) {
+                                            var keep = true
+                                            if (on.isDefined) keep = on.get(leftRow :+ rightRow)
+                                            if (keep) { m = true; joined.append(leftRow :+ rightRow) }
+                                    }
+                                    if (!m) {
+                                            val undef = if (items.nonEmpty) Seq.fill(items.head.length)(null) else Seq[Any]()
+                                            joined.append(undef :+ rightRow)
+                                    }
+                            }
+                    } else {
+                            for (leftRow <- items) {
+                                    var m = false
+                                    for (rightRow <- jitems) {
+                                            var keep = true
+                                            if (on.isDefined) keep = on.get(leftRow :+ rightRow)
+                                            if (keep) { m = true; joined.append(leftRow :+ rightRow) }
+                                    }
+                                    if (left && !m) joined.append(leftRow :+ null)
+                            }
+                    }
+                    items = joined.toSeq
+            }
+            var it = items
+            opts.get("where").foreach { f =>
+                    val fn = f.asInstanceOf[Seq[Any] => Boolean]
+                    it = it.filter(r => fn(r))
+            }
+            opts.get("sortKey").foreach { f =>
+                    val fn = f.asInstanceOf[Seq[Any] => Any]
+                    it = it.sortBy(r => fn(r))(_anyOrdering)
+            }
+            opts.get("skip").foreach { n => it = it.drop(n.asInstanceOf[Int]) }
+            opts.get("take").foreach { n => it = it.take(n.asInstanceOf[Int]) }
+            val sel = opts("select").asInstanceOf[Seq[Any] => Any]
+            it.map(r => sel(r))
+    }
+    
+    def _to_json(v: Any): String = v match {
+            case null => "null"
+            case s: String => "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+            case b: Boolean => b.toString
+            case i: Int => i.toString
+            case l: Long => l.toString
+            case d: Double => d.toString
+            case m: scala.collection.Map[_, _] =>
+                    m.map{ case (k, v2) => "\"" + k.toString.replace("\"", "\\\"") + "\":" + _to_json(v2) }.mkString("{", ",", "}")
+            case seq: Iterable[_] => seq.map(_to_json).mkString("[", ",", "]")
+            case other => "\"" + other.toString.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+    }
+    
 }
-def expect(cond: Boolean): Unit = {
-        if (!cond) throw new RuntimeException("expect failed")
-}
-
-def _json(v: Any): Unit = println(_to_json(v))
-
-def _query(src: Seq[Any], joins: Seq[Map[String,Any]], opts: Map[String,Any]): Seq[Any] = {
-        var items = src.map(v => Seq[Any](v))
-        for (j <- joins) {
-                val joined = scala.collection.mutable.ArrayBuffer[Seq[Any]]()
-                val jitems = j("items").asInstanceOf[Seq[Any]]
-                val on = j.get("on").map(_.asInstanceOf[Seq[Any] => Boolean])
-                val left = j.get("left").exists(_.asInstanceOf[Boolean])
-                val right = j.get("right").exists(_.asInstanceOf[Boolean])
-                if (left && right) {
-                        val matched = Array.fill(jitems.length)(false)
-                        for (leftRow <- items) {
-                                var m = false
-                                for ((rightRow, ri) <- jitems.zipWithIndex) {
-                                        var keep = true
-                                        if (on.isDefined) keep = on.get(leftRow :+ rightRow)
-                                        if (keep) { m = true; matched(ri) = true; joined.append(leftRow :+ rightRow) }
-                                }
-                                if (!m) joined.append(leftRow :+ null)
-                        }
-                        for ((rightRow, ri) <- jitems.zipWithIndex) {
-                                if (!matched(ri)) {
-                                        val undef = if (items.nonEmpty) Seq.fill(items.head.length)(null) else Seq[Any]()
-                                        joined.append(undef :+ rightRow)
-                                }
-                        }
-                } else if (right) {
-                        for (rightRow <- jitems) {
-                                var m = false
-                                for (leftRow <- items) {
-                                        var keep = true
-                                        if (on.isDefined) keep = on.get(leftRow :+ rightRow)
-                                        if (keep) { m = true; joined.append(leftRow :+ rightRow) }
-                                }
-                                if (!m) {
-                                        val undef = if (items.nonEmpty) Seq.fill(items.head.length)(null) else Seq[Any]()
-                                        joined.append(undef :+ rightRow)
-                                }
-                        }
-                } else {
-                        for (leftRow <- items) {
-                                var m = false
-                                for (rightRow <- jitems) {
-                                        var keep = true
-                                        if (on.isDefined) keep = on.get(leftRow :+ rightRow)
-                                        if (keep) { m = true; joined.append(leftRow :+ rightRow) }
-                                }
-                                if (left && !m) joined.append(leftRow :+ null)
-                        }
-                }
-                items = joined.toSeq
-        }
-        var it = items
-        opts.get("where").foreach { f =>
-                val fn = f.asInstanceOf[Seq[Any] => Boolean]
-                it = it.filter(r => fn(r))
-        }
-        opts.get("sortKey").foreach { f =>
-                val fn = f.asInstanceOf[Seq[Any] => Any]
-                it = it.sortBy(r => fn(r))(_anyOrdering)
-        }
-        opts.get("skip").foreach { n => it = it.drop(n.asInstanceOf[Int]) }
-        opts.get("take").foreach { n => it = it.take(n.asInstanceOf[Int]) }
-        val sel = opts("select").asInstanceOf[Seq[Any] => Any]
-        it.map(r => sel(r))
-}
-
-def _to_json(v: Any): String = v match {
-        case null => "null"
-        case s: String => "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
-        case b: Boolean => b.toString
-        case i: Int => i.toString
-        case l: Long => l.toString
-        case d: Double => d.toString
-        case m: scala.collection.Map[_, _] =>
-                m.map{ case (k, v2) => "\"" + k.toString.replace("\"", "\\\"") + "\":" + _to_json(v2) }.mkString("{", ",", "}")
-        case seq: Iterable[_] => seq.map(_to_json).mkString("[", ",", "]")
-        case other => "\"" + other.toString.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
-}
-

--- a/tests/dataset/job/compiler/scala/q2.out
+++ b/tests/dataset/job/compiler/scala/q2.out
@@ -1,0 +1,1 @@
+"Der Film"

--- a/tests/dataset/job/compiler/scala/q2.scala.out
+++ b/tests/dataset/job/compiler/scala/q2.scala.out
@@ -1,122 +1,66 @@
 object Main {
-    def test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus(): Unit = {
-        expect((result == scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map("returnflag" -> "N", "linestatus" -> "O", "sum_qty" -> 53, "sum_base_price" -> 3000, "sum_disc_price" -> (950 + 1800), "sum_charge" -> (((950 * 1.07)) + ((1800 * 1.05))), "avg_qty" -> 26.5, "avg_price" -> 1500, "avg_disc" -> 0.07500000000000001, "count_order" -> 2))))
+    def test_Q2_finds_earliest_title_for_German_companies_with_character_keyword(): Unit = {
+        expect((result == "Der Film"))
     }
     
     def main(args: Array[String]): Unit = {
-        val lineitem: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map("l_quantity" -> 17, "l_extendedprice" -> 1000, "l_discount" -> 0.05, "l_tax" -> 0.07, "l_returnflag" -> "N", "l_linestatus" -> "O", "l_shipdate" -> "1998-08-01"), scala.collection.mutable.Map("l_quantity" -> 36, "l_extendedprice" -> 2000, "l_discount" -> 0.1, "l_tax" -> 0.05, "l_returnflag" -> "N", "l_linestatus" -> "O", "l_shipdate" -> "1998-09-01"), scala.collection.mutable.Map("l_quantity" -> 25, "l_extendedprice" -> 1500, "l_discount" -> 0, "l_tax" -> 0.08, "l_returnflag" -> "R", "l_linestatus" -> "F", "l_shipdate" -> "1998-09-03"))
-        val result: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = _group_by((() => {
-    val src = lineitem
+        val company_name: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map("id" -> 1, "country_code" -> "[de]"), scala.collection.mutable.Map("id" -> 2, "country_code" -> "[us]"))
+        val keyword: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map("id" -> 1, "keyword" -> "character-name-in-title"), scala.collection.mutable.Map("id" -> 2, "keyword" -> "other"))
+        val movie_companies: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Int]] = scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map("movie_id" -> 100, "company_id" -> 1), scala.collection.mutable.Map("movie_id" -> 200, "company_id" -> 2))
+        val movie_keyword: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Int]] = scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map("movie_id" -> 100, "keyword_id" -> 1), scala.collection.mutable.Map("movie_id" -> 200, "keyword_id" -> 2))
+        val title: scala.collection.mutable.ArrayBuffer[scala.collection.mutable.Map[String, Any]] = scala.collection.mutable.ArrayBuffer(scala.collection.mutable.Map("id" -> 100, "title" -> "Der Film"), scala.collection.mutable.Map("id" -> 200, "title" -> "Other Movie"))
+        val titles: scala.collection.mutable.ArrayBuffer[Any] = (() => {
+    val src = company_name
     val res = _query(src, Seq(
+        Map("items" -> movie_companies, "on" -> ((args: Seq[Any]) => {
+    val cn = args(0)
+    val mc = args(1)
+    (mc.company_id == cn.id)
+})),
+        Map("items" -> title, "on" -> ((args: Seq[Any]) => {
+    val cn = args(0)
+    val mc = args(1)
+    val t = args(2)
+    (mc.movie_id == t.id)
+})),
+        Map("items" -> movie_keyword, "on" -> ((args: Seq[Any]) => {
+    val cn = args(0)
+    val mc = args(1)
+    val t = args(2)
+    val mk = args(3)
+    (mk.movie_id == t.id)
+})),
+        Map("items" -> keyword, "on" -> ((args: Seq[Any]) => {
+    val cn = args(0)
+    val mc = args(1)
+    val t = args(2)
+    val mk = args(3)
+    val k = args(4)
+    (mk.keyword_id == k.id)
+}))
     ), Map("select" -> ((args: Seq[Any]) => {
-    val row = args(0)
-    row
+    val cn = args(0)
+    val mc = args(1)
+    val t = args(2)
+    val mk = args(3)
+    val k = args(4)
+    t.title
 }), "where" -> ((args: Seq[Any]) => {
-    val row = args(0)
-    (row.l_shipdate <= "1998-09-02")
+    val cn = args(0)
+    val mc = args(1)
+    val t = args(2)
+    val mk = args(3)
+    val k = args(4)
+    (((cn.country_code == "[de]") && (k.keyword == "character-name-in-title")) && (mc.movie_id == mk.movie_id))
 })))
     res
-})(), (row: Any) => scala.collection.mutable.Map("returnflag" -> row.l_returnflag, "linestatus" -> row.l_linestatus)).map(g => scala.collection.mutable.Map("returnflag" -> g.key.returnflag, "linestatus" -> g.key.linestatus, "sum_qty" -> sum((() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_quantity
-})))
-    res
-})()), "sum_base_price" -> sum((() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_extendedprice
-})))
-    res
-})()), "sum_disc_price" -> sum((() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    (x.l_extendedprice * ((1 - x.l_discount)))
-})))
-    res
-})()), "sum_charge" -> sum((() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax)))
-})))
-    res
-})()), "avg_qty" -> ((() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_quantity
-})))
-    res
-})().sum / (() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_quantity
-})))
-    res
-})().size), "avg_price" -> ((() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_extendedprice
-})))
-    res
-})().sum / (() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_extendedprice
-})))
-    res
-})().size), "avg_disc" -> ((() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_discount
-})))
-    res
-})().sum / (() => {
-    val src = g
-    val res = _query(src, Seq(
-    ), Map("select" -> ((args: Seq[Any]) => {
-    val x = args(0)
-    x.l_discount
-})))
-    res
-})().size), "count_order" -> g.size)).toSeq
+})()
+        val result = min(titles)
         _json(result)
-        test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus()
+        test_Q2_finds_earliest_title_for_German_companies_with_character_keyword()
     }
-    class _Group(var key: Any) {
-            val Items = scala.collection.mutable.ArrayBuffer[Any]()
-    }
-    
     def expect(cond: Boolean): Unit = {
             if (!cond) throw new RuntimeException("expect failed")
-    }
-    
-    def _group_by(src: Seq[Any], keyfn: Any => Any): Seq[_Group] = {
-            val groups = scala.collection.mutable.LinkedHashMap[String,_Group]()
-            for (it <- src) {
-                    val key = keyfn(it)
-                    val ks = key.toString
-                    val g = groups.getOrElseUpdate(ks, new _Group(key))
-                    g.Items.append(it)
-            }
-            groups.values.toSeq
     }
     
     def _json(v: Any): Unit = println(_to_json(v))


### PR DESCRIPTION
## Summary
- extend Scala backend TASKS
- emit runtime helpers inside `object Main`
- wrap generated lambdas in parentheses for Scala 2
- add golden test for JOB query q2
- update Scala golden files for JOB q1/q2 and TPCH q1

## Testing
- `go test -tags slow ./compile/x/scala -run TestScalaCompiler_JOBQ1 -count=1 -v`
- `go test -tags slow ./compile/x/scala -run TestScalaCompiler_JOBQ2 -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_685e7c4270e4832081ed8787ecf376c7