### PR TITLE
Add JOB dataset tests for C backend

### DIFF
--- a/compile/x/c/TASKS.md
+++ b/compile/x/c/TASKS.md
@@ -40,3 +40,7 @@ are present and emits `return 0`. Supporting these queries requires:
 - Extending grouping and aggregation support beyond simple lists.
 - Emitting helper functions for `min` and other aggregations used in JOB.
 
+- Generated C for JOB queries currently fails to compile, with undefined identifiers
+  and invalid struct initialization. Once join and grouping logic are implemented,
+  ensure the output builds successfully and compare against the existing `.out`
+  results.

--- a/compile/x/c/job_test.go
+++ b/compile/x/c/job_test.go
@@ -1,0 +1,25 @@
+//go:build slow
+
+package ccode_test
+
+import (
+	"fmt"
+	"testing"
+
+	ccode "mochi/compile/x/c"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestCCompiler_JOB(t *testing.T) {
+	if _, err := ccode.EnsureCC(); err != nil {
+		t.Skipf("C compiler not installed: %v", err)
+	}
+	for i := 1; i <= 10; i++ {
+		query := fmt.Sprintf("q%d", i)
+		testutil.CompileJOB(t, query, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+			return ccode.New(env).Compile(prog)
+		})
+	}
+}

--- a/tests/dataset/job/compiler/c/q1.c.out
+++ b/tests/dataset/job/compiler/c/q1.c.out
@@ -1,0 +1,273 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void
+test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production() {
+  map_int_bool _t1 = map_int_bool_create(3);
+  map_int_bool_put(&_t1, production_note, "ACME (co-production)");
+  map_int_bool_put(&_t1, movie_title, "Good Movie");
+  map_int_bool_put(&_t1, movie_year, 1995);
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int id;
+    char *kind;
+  } company_typeItem;
+  typedef struct {
+    int len;
+    company_typeItem *data;
+  } list_company_typeItem;
+  static list_company_typeItem list_company_typeItem_create(int len) {
+    list_company_typeItem l;
+    l.len = len;
+    l.data = (company_typeItem *)malloc(sizeof(company_typeItem) * len);
+    return l;
+  }
+  list_company_typeItem _t2 = list_company_typeItem_create(2);
+  _t2.data[0] = (company_typeItem){.id = 1, .kind = "production companies"};
+  _t2.data[1] = (company_typeItem){.id = 2, .kind = "distributors"};
+  int company_type = _t2;
+  typedef struct {
+    int id;
+    char *info;
+  } info_typeItem;
+  typedef struct {
+    int len;
+    info_typeItem *data;
+  } list_info_typeItem;
+  static list_info_typeItem list_info_typeItem_create(int len) {
+    list_info_typeItem l;
+    l.len = len;
+    l.data = (info_typeItem *)malloc(sizeof(info_typeItem) * len);
+    return l;
+  }
+  list_info_typeItem _t3 = list_info_typeItem_create(2);
+  _t3.data[0] = (info_typeItem){.id = 10, .info = "top 250 rank"};
+  _t3.data[1] = (info_typeItem){.id = 20, .info = "bottom 10 rank"};
+  int info_type = _t3;
+  typedef struct {
+    int id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t4 = list_titleItem_create(2);
+  _t4.data[0] =
+      (titleItem){.id = 100, .title = "Good Movie", .production_year = 1995};
+  _t4.data[1] =
+      (titleItem){.id = 200, .title = "Bad Movie", .production_year = 2000};
+  int title = _t4;
+  typedef struct {
+    int movie_id;
+    int company_type_id;
+    char *note;
+  } movie_companiesItem;
+  typedef struct {
+    int len;
+    movie_companiesItem *data;
+  } list_movie_companiesItem;
+  static list_movie_companiesItem list_movie_companiesItem_create(int len) {
+    list_movie_companiesItem l;
+    l.len = len;
+    l.data = (movie_companiesItem *)malloc(sizeof(movie_companiesItem) * len);
+    return l;
+  }
+  list_movie_companiesItem _t5 = list_movie_companiesItem_create(2);
+  _t5.data[0] = (movie_companiesItem){
+      .movie_id = 100, .company_type_id = 1, .note = "ACME (co-production)"};
+  _t5.data[1] =
+      (movie_companiesItem){.movie_id = 200,
+                            .company_type_id = 1,
+                            .note = "MGM (as Metro-Goldwyn-Mayer Pictures)"};
+  int movie_companies = _t5;
+  typedef struct {
+    int movie_id;
+    int info_type_id;
+  } movie_info_idxItem;
+  typedef struct {
+    int len;
+    movie_info_idxItem *data;
+  } list_movie_info_idxItem;
+  static list_movie_info_idxItem list_movie_info_idxItem_create(int len) {
+    list_movie_info_idxItem l;
+    l.len = len;
+    l.data = (movie_info_idxItem *)malloc(sizeof(movie_info_idxItem) * len);
+    return l;
+  }
+  list_movie_info_idxItem _t6 = list_movie_info_idxItem_create(2);
+  _t6.data[0] = (movie_info_idxItem){.movie_id = 100, .info_type_id = 10};
+  _t6.data[1] = (movie_info_idxItem){.movie_id = 200, .info_type_id = 20};
+  int movie_info_idx = _t6;
+  list_int filtered = 0;
+  map_int_bool _t7 = map_int_bool_create(3);
+  list_int _t8 = list_int_create(filtered.len);
+  int _t9 = 0;
+  for (int _t10 = 0; _t10 < filtered.len; _t10++) {
+    int r = filtered.data[_t10];
+    _t8.data[_t9] = r.note;
+    _t9++;
+  }
+  _t8.len = _t9;
+  map_int_bool_put(&_t7, production_note, min(_t8));
+  list_int _t11 = list_int_create(filtered.len);
+  int _t12 = 0;
+  for (int _t13 = 0; _t13 < filtered.len; _t13++) {
+    int r = filtered.data[_t13];
+    _t11.data[_t12] = r.title;
+    _t12++;
+  }
+  _t11.len = _t12;
+  map_int_bool_put(&_t7, movie_title, min(_t11));
+  list_int _t14 = list_int_create(filtered.len);
+  int _t15 = 0;
+  for (int _t16 = 0; _t16 < filtered.len; _t16++) {
+    int r = filtered.data[_t16];
+    _t14.data[_t15] = r.year;
+    _t15++;
+  }
+  _t14.len = _t15;
+  map_int_bool_put(&_t7, movie_year, min(_t14));
+  int result = _t7;
+  list_int _t17 = list_int_create(1);
+  _t17.data[0] = result;
+  _json_int(_t17);
+  test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q10.c.out
+++ b/tests/dataset/job/compiler/c/q10.c.out
@@ -1,0 +1,315 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void test_Q10_finds_uncredited_voice_actor_in_Russian_movie() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(2);
+  map_int_bool_put(&_t2, uncredited_voiced_character, "Ivan");
+  map_int_bool_put(&_t2, russian_movie, "Vodka Dreams");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int id;
+    char *name;
+  } char_nameItem;
+  typedef struct {
+    int len;
+    char_nameItem *data;
+  } list_char_nameItem;
+  static list_char_nameItem list_char_nameItem_create(int len) {
+    list_char_nameItem l;
+    l.len = len;
+    l.data = (char_nameItem *)malloc(sizeof(char_nameItem) * len);
+    return l;
+  }
+  list_char_nameItem _t3 = list_char_nameItem_create(2);
+  _t3.data[0] = (char_nameItem){.id = 1, .name = "Ivan"};
+  _t3.data[1] = (char_nameItem){.id = 2, .name = "Alex"};
+  int char_name = _t3;
+  typedef struct {
+    int movie_id;
+    int person_role_id;
+    int role_id;
+    char *note;
+  } cast_infoItem;
+  typedef struct {
+    int len;
+    cast_infoItem *data;
+  } list_cast_infoItem;
+  static list_cast_infoItem list_cast_infoItem_create(int len) {
+    list_cast_infoItem l;
+    l.len = len;
+    l.data = (cast_infoItem *)malloc(sizeof(cast_infoItem) * len);
+    return l;
+  }
+  list_cast_infoItem _t4 = list_cast_infoItem_create(2);
+  _t4.data[0] = (cast_infoItem){.movie_id = 10,
+                                .person_role_id = 1,
+                                .role_id = 1,
+                                .note = "Soldier (voice) (uncredited)"};
+  _t4.data[1] = (cast_infoItem){
+      .movie_id = 11, .person_role_id = 2, .role_id = 1, .note = "(voice)"};
+  int cast_info = _t4;
+  typedef struct {
+    int id;
+    char *country_code;
+  } company_nameItem;
+  typedef struct {
+    int len;
+    company_nameItem *data;
+  } list_company_nameItem;
+  static list_company_nameItem list_company_nameItem_create(int len) {
+    list_company_nameItem l;
+    l.len = len;
+    l.data = (company_nameItem *)malloc(sizeof(company_nameItem) * len);
+    return l;
+  }
+  list_company_nameItem _t5 = list_company_nameItem_create(2);
+  _t5.data[0] = (company_nameItem){.id = 1, .country_code = "[ru]"};
+  _t5.data[1] = (company_nameItem){.id = 2, .country_code = "[us]"};
+  int company_name = _t5;
+  typedef struct {
+    int id;
+  } company_typeItem;
+  typedef struct {
+    int len;
+    company_typeItem *data;
+  } list_company_typeItem;
+  static list_company_typeItem list_company_typeItem_create(int len) {
+    list_company_typeItem l;
+    l.len = len;
+    l.data = (company_typeItem *)malloc(sizeof(company_typeItem) * len);
+    return l;
+  }
+  list_company_typeItem _t6 = list_company_typeItem_create(2);
+  _t6.data[0] = (company_typeItem){.id = 1};
+  _t6.data[1] = (company_typeItem){.id = 2};
+  int company_type = _t6;
+  typedef struct {
+    int movie_id;
+    int company_id;
+    int company_type_id;
+  } movie_companiesItem;
+  typedef struct {
+    int len;
+    movie_companiesItem *data;
+  } list_movie_companiesItem;
+  static list_movie_companiesItem list_movie_companiesItem_create(int len) {
+    list_movie_companiesItem l;
+    l.len = len;
+    l.data = (movie_companiesItem *)malloc(sizeof(movie_companiesItem) * len);
+    return l;
+  }
+  list_movie_companiesItem _t7 = list_movie_companiesItem_create(2);
+  _t7.data[0] = (movie_companiesItem){
+      .movie_id = 10, .company_id = 1, .company_type_id = 1};
+  _t7.data[1] = (movie_companiesItem){
+      .movie_id = 11, .company_id = 2, .company_type_id = 1};
+  int movie_companies = _t7;
+  typedef struct {
+    int id;
+    char *role;
+  } role_typeItem;
+  typedef struct {
+    int len;
+    role_typeItem *data;
+  } list_role_typeItem;
+  static list_role_typeItem list_role_typeItem_create(int len) {
+    list_role_typeItem l;
+    l.len = len;
+    l.data = (role_typeItem *)malloc(sizeof(role_typeItem) * len);
+    return l;
+  }
+  list_role_typeItem _t8 = list_role_typeItem_create(2);
+  _t8.data[0] = (role_typeItem){.id = 1, .role = "actor"};
+  _t8.data[1] = (role_typeItem){.id = 2, .role = "director"};
+  int role_type = _t8;
+  typedef struct {
+    int id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t9 = list_titleItem_create(2);
+  _t9.data[0] =
+      (titleItem){.id = 10, .title = "Vodka Dreams", .production_year = 2006};
+  _t9.data[1] =
+      (titleItem){.id = 11, .title = "Other Film", .production_year = 2004};
+  int title = _t9;
+  list_int matches = 0;
+  typedef struct {
+    int uncredited_voiced_character;
+    int russian_movie;
+  } resultItem;
+  typedef struct {
+    int len;
+    resultItem *data;
+  } list_resultItem;
+  static list_resultItem list_resultItem_create(int len) {
+    list_resultItem l;
+    l.len = len;
+    l.data = (resultItem *)malloc(sizeof(resultItem) * len);
+    return l;
+  }
+  list_resultItem _t10 = list_resultItem_create(1);
+  list_string _t11 = list_string_create(matches.len);
+  int _t12 = 0;
+  for (int _t13 = 0; _t13 < matches.len; _t13++) {
+    int x = matches.data[_t13];
+    _t11.data[_t12] = x.character;
+    _t12++;
+  }
+  _t11.len = _t12;
+  list_string _t14 = list_string_create(matches.len);
+  int _t15 = 0;
+  for (int _t16 = 0; _t16 < matches.len; _t16++) {
+    int x = matches.data[_t16];
+    _t14.data[_t15] = x.movie;
+    _t15++;
+  }
+  _t14.len = _t15;
+  _t10.data[0] = (resultItem){.uncredited_voiced_character = min(_t11),
+                              .russian_movie = min(_t14)};
+  int result = _t10;
+  _json_int(result);
+  test_Q10_finds_uncredited_voice_actor_in_Russian_movie();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q2.c.out
+++ b/tests/dataset/job/compiler/c/q2.c.out
@@ -1,0 +1,188 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void
+test_Q2_finds_earliest_title_for_German_companies_with_character_keyword() {
+  if (!((result == "Der Film"))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int id;
+    char *country_code;
+  } company_nameItem;
+  typedef struct {
+    int len;
+    company_nameItem *data;
+  } list_company_nameItem;
+  static list_company_nameItem list_company_nameItem_create(int len) {
+    list_company_nameItem l;
+    l.len = len;
+    l.data = (company_nameItem *)malloc(sizeof(company_nameItem) * len);
+    return l;
+  }
+  list_company_nameItem _t1 = list_company_nameItem_create(2);
+  _t1.data[0] = (company_nameItem){.id = 1, .country_code = "[de]"};
+  _t1.data[1] = (company_nameItem){.id = 2, .country_code = "[us]"};
+  int company_name = _t1;
+  typedef struct {
+    int id;
+    char *keyword;
+  } keywordItem;
+  typedef struct {
+    int len;
+    keywordItem *data;
+  } list_keywordItem;
+  static list_keywordItem list_keywordItem_create(int len) {
+    list_keywordItem l;
+    l.len = len;
+    l.data = (keywordItem *)malloc(sizeof(keywordItem) * len);
+    return l;
+  }
+  list_keywordItem _t2 = list_keywordItem_create(2);
+  _t2.data[0] = (keywordItem){.id = 1, .keyword = "character-name-in-title"};
+  _t2.data[1] = (keywordItem){.id = 2, .keyword = "other"};
+  int keyword = _t2;
+  typedef struct {
+    int movie_id;
+    int company_id;
+  } movie_companiesItem;
+  typedef struct {
+    int len;
+    movie_companiesItem *data;
+  } list_movie_companiesItem;
+  static list_movie_companiesItem list_movie_companiesItem_create(int len) {
+    list_movie_companiesItem l;
+    l.len = len;
+    l.data = (movie_companiesItem *)malloc(sizeof(movie_companiesItem) * len);
+    return l;
+  }
+  list_movie_companiesItem _t3 = list_movie_companiesItem_create(2);
+  _t3.data[0] = (movie_companiesItem){.movie_id = 100, .company_id = 1};
+  _t3.data[1] = (movie_companiesItem){.movie_id = 200, .company_id = 2};
+  int movie_companies = _t3;
+  typedef struct {
+    int movie_id;
+    int keyword_id;
+  } movie_keywordItem;
+  typedef struct {
+    int len;
+    movie_keywordItem *data;
+  } list_movie_keywordItem;
+  static list_movie_keywordItem list_movie_keywordItem_create(int len) {
+    list_movie_keywordItem l;
+    l.len = len;
+    l.data = (movie_keywordItem *)malloc(sizeof(movie_keywordItem) * len);
+    return l;
+  }
+  list_movie_keywordItem _t4 = list_movie_keywordItem_create(2);
+  _t4.data[0] = (movie_keywordItem){.movie_id = 100, .keyword_id = 1};
+  _t4.data[1] = (movie_keywordItem){.movie_id = 200, .keyword_id = 2};
+  int movie_keyword = _t4;
+  typedef struct {
+    int id;
+    char *title;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t5 = list_titleItem_create(2);
+  _t5.data[0] = (titleItem){.id = 100, .title = "Der Film"};
+  _t5.data[1] = (titleItem){.id = 200, .title = "Other Movie"};
+  int title = _t5;
+  list_string titles = 0;
+  int result = min(titles);
+  _json_int(result);
+  test_Q2_finds_earliest_title_for_German_companies_with_character_keyword();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q3.c.out
+++ b/tests/dataset/job/compiler/c/q3.c.out
@@ -1,0 +1,248 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void test_Q3_returns_lexicographically_smallest_sequel_title() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(1);
+  map_int_bool_put(&_t2, movie_title, "Alpha");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int id;
+    char *keyword;
+  } keywordItem;
+  typedef struct {
+    int len;
+    keywordItem *data;
+  } list_keywordItem;
+  static list_keywordItem list_keywordItem_create(int len) {
+    list_keywordItem l;
+    l.len = len;
+    l.data = (keywordItem *)malloc(sizeof(keywordItem) * len);
+    return l;
+  }
+  list_keywordItem _t3 = list_keywordItem_create(2);
+  _t3.data[0] = (keywordItem){.id = 1, .keyword = "amazing sequel"};
+  _t3.data[1] = (keywordItem){.id = 2, .keyword = "prequel"};
+  int keyword = _t3;
+  typedef struct {
+    int movie_id;
+    char *info;
+  } movie_infoItem;
+  typedef struct {
+    int len;
+    movie_infoItem *data;
+  } list_movie_infoItem;
+  static list_movie_infoItem list_movie_infoItem_create(int len) {
+    list_movie_infoItem l;
+    l.len = len;
+    l.data = (movie_infoItem *)malloc(sizeof(movie_infoItem) * len);
+    return l;
+  }
+  list_movie_infoItem _t4 = list_movie_infoItem_create(3);
+  _t4.data[0] = (movie_infoItem){.movie_id = 10, .info = "Germany"};
+  _t4.data[1] = (movie_infoItem){.movie_id = 30, .info = "Sweden"};
+  _t4.data[2] = (movie_infoItem){.movie_id = 20, .info = "France"};
+  int movie_info = _t4;
+  typedef struct {
+    int movie_id;
+    int keyword_id;
+  } movie_keywordItem;
+  typedef struct {
+    int len;
+    movie_keywordItem *data;
+  } list_movie_keywordItem;
+  static list_movie_keywordItem list_movie_keywordItem_create(int len) {
+    list_movie_keywordItem l;
+    l.len = len;
+    l.data = (movie_keywordItem *)malloc(sizeof(movie_keywordItem) * len);
+    return l;
+  }
+  list_movie_keywordItem _t5 = list_movie_keywordItem_create(4);
+  _t5.data[0] = (movie_keywordItem){.movie_id = 10, .keyword_id = 1};
+  _t5.data[1] = (movie_keywordItem){.movie_id = 30, .keyword_id = 1};
+  _t5.data[2] = (movie_keywordItem){.movie_id = 20, .keyword_id = 1};
+  _t5.data[3] = (movie_keywordItem){.movie_id = 10, .keyword_id = 2};
+  int movie_keyword = _t5;
+  typedef struct {
+    int id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t6 = list_titleItem_create(3);
+  _t6.data[0] =
+      (titleItem){.id = 10, .title = "Alpha", .production_year = 2006};
+  _t6.data[1] = (titleItem){.id = 30, .title = "Beta", .production_year = 2008};
+  _t6.data[2] =
+      (titleItem){.id = 20, .title = "Gamma", .production_year = 2009};
+  int title = _t6;
+  list_string _t7 = list_string_create(8);
+  _t7.data[0] = "Sweden";
+  _t7.data[1] = "Norway";
+  _t7.data[2] = "Germany";
+  _t7.data[3] = "Denmark";
+  _t7.data[4] = "Swedish";
+  _t7.data[5] = "Denish";
+  _t7.data[6] = "Norwegian";
+  _t7.data[7] = "German";
+  list_string allowed_infos = _t7;
+  list_string candidate_titles = 0;
+  typedef struct {
+    int movie_title;
+  } resultItem;
+  typedef struct {
+    int len;
+    resultItem *data;
+  } list_resultItem;
+  static list_resultItem list_resultItem_create(int len) {
+    list_resultItem l;
+    l.len = len;
+    l.data = (resultItem *)malloc(sizeof(resultItem) * len);
+    return l;
+  }
+  list_resultItem _t8 = list_resultItem_create(1);
+  _t8.data[0] = (resultItem){.movie_title = min(candidate_titles)};
+  int result = _t8;
+  _json_int(result);
+  test_Q3_returns_lexicographically_smallest_sequel_title();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q4.c.out
+++ b/tests/dataset/job/compiler/c/q4.c.out
@@ -1,0 +1,278 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void test_Q4_returns_minimum_rating_and_title_for_sequels() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(2);
+  map_int_bool_put(&_t2, rating, "6.2");
+  map_int_bool_put(&_t2, movie_title, "Alpha Movie");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int id;
+    char *info;
+  } info_typeItem;
+  typedef struct {
+    int len;
+    info_typeItem *data;
+  } list_info_typeItem;
+  static list_info_typeItem list_info_typeItem_create(int len) {
+    list_info_typeItem l;
+    l.len = len;
+    l.data = (info_typeItem *)malloc(sizeof(info_typeItem) * len);
+    return l;
+  }
+  list_info_typeItem _t3 = list_info_typeItem_create(2);
+  _t3.data[0] = (info_typeItem){.id = 1, .info = "rating"};
+  _t3.data[1] = (info_typeItem){.id = 2, .info = "other"};
+  int info_type = _t3;
+  typedef struct {
+    int id;
+    char *keyword;
+  } keywordItem;
+  typedef struct {
+    int len;
+    keywordItem *data;
+  } list_keywordItem;
+  static list_keywordItem list_keywordItem_create(int len) {
+    list_keywordItem l;
+    l.len = len;
+    l.data = (keywordItem *)malloc(sizeof(keywordItem) * len);
+    return l;
+  }
+  list_keywordItem _t4 = list_keywordItem_create(2);
+  _t4.data[0] = (keywordItem){.id = 1, .keyword = "great sequel"};
+  _t4.data[1] = (keywordItem){.id = 2, .keyword = "prequel"};
+  int keyword = _t4;
+  typedef struct {
+    int id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t5 = list_titleItem_create(3);
+  _t5.data[0] =
+      (titleItem){.id = 10, .title = "Alpha Movie", .production_year = 2006};
+  _t5.data[1] =
+      (titleItem){.id = 20, .title = "Beta Film", .production_year = 2007};
+  _t5.data[2] =
+      (titleItem){.id = 30, .title = "Old Film", .production_year = 2004};
+  int title = _t5;
+  typedef struct {
+    int movie_id;
+    int keyword_id;
+  } movie_keywordItem;
+  typedef struct {
+    int len;
+    movie_keywordItem *data;
+  } list_movie_keywordItem;
+  static list_movie_keywordItem list_movie_keywordItem_create(int len) {
+    list_movie_keywordItem l;
+    l.len = len;
+    l.data = (movie_keywordItem *)malloc(sizeof(movie_keywordItem) * len);
+    return l;
+  }
+  list_movie_keywordItem _t6 = list_movie_keywordItem_create(3);
+  _t6.data[0] = (movie_keywordItem){.movie_id = 10, .keyword_id = 1};
+  _t6.data[1] = (movie_keywordItem){.movie_id = 20, .keyword_id = 1};
+  _t6.data[2] = (movie_keywordItem){.movie_id = 30, .keyword_id = 1};
+  int movie_keyword = _t6;
+  typedef struct {
+    int movie_id;
+    int info_type_id;
+    char *info;
+  } movie_info_idxItem;
+  typedef struct {
+    int len;
+    movie_info_idxItem *data;
+  } list_movie_info_idxItem;
+  static list_movie_info_idxItem list_movie_info_idxItem_create(int len) {
+    list_movie_info_idxItem l;
+    l.len = len;
+    l.data = (movie_info_idxItem *)malloc(sizeof(movie_info_idxItem) * len);
+    return l;
+  }
+  list_movie_info_idxItem _t7 = list_movie_info_idxItem_create(3);
+  _t7.data[0] =
+      (movie_info_idxItem){.movie_id = 10, .info_type_id = 1, .info = "6.2"};
+  _t7.data[1] =
+      (movie_info_idxItem){.movie_id = 20, .info_type_id = 1, .info = "7.8"};
+  _t7.data[2] =
+      (movie_info_idxItem){.movie_id = 30, .info_type_id = 1, .info = "4.5"};
+  int movie_info_idx = _t7;
+  list_int rows = 0;
+  typedef struct {
+    int rating;
+    int movie_title;
+  } resultItem;
+  typedef struct {
+    int len;
+    resultItem *data;
+  } list_resultItem;
+  static list_resultItem list_resultItem_create(int len) {
+    list_resultItem l;
+    l.len = len;
+    l.data = (resultItem *)malloc(sizeof(resultItem) * len);
+    return l;
+  }
+  list_resultItem _t8 = list_resultItem_create(1);
+  list_string _t9 = list_string_create(rows.len);
+  int _t10 = 0;
+  for (int _t11 = 0; _t11 < rows.len; _t11++) {
+    int r = rows.data[_t11];
+    _t9.data[_t10] = r.rating;
+    _t10++;
+  }
+  _t9.len = _t10;
+  list_string _t12 = list_string_create(rows.len);
+  int _t13 = 0;
+  for (int _t14 = 0; _t14 < rows.len; _t14++) {
+    int r = rows.data[_t14];
+    _t12.data[_t13] = r.title;
+    _t13++;
+  }
+  _t12.len = _t13;
+  _t8.data[0] = (resultItem){.rating = min(_t9), .movie_title = min(_t12)};
+  int result = _t8;
+  _json_int(result);
+  test_Q4_returns_minimum_rating_and_title_for_sequels();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q5.c.out
+++ b/tests/dataset/job/compiler/c/q5.c.out
@@ -1,0 +1,266 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void test_Q5_finds_the_lexicographically_first_qualifying_title() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(1);
+  map_int_bool_put(&_t2, typical_european_movie, "A Film");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int ct_id;
+    char *kind;
+  } company_typeItem;
+  typedef struct {
+    int len;
+    company_typeItem *data;
+  } list_company_typeItem;
+  static list_company_typeItem list_company_typeItem_create(int len) {
+    list_company_typeItem l;
+    l.len = len;
+    l.data = (company_typeItem *)malloc(sizeof(company_typeItem) * len);
+    return l;
+  }
+  list_company_typeItem _t3 = list_company_typeItem_create(2);
+  _t3.data[0] = (company_typeItem){.ct_id = 1, .kind = "production companies"};
+  _t3.data[1] = (company_typeItem){.ct_id = 2, .kind = "other"};
+  int company_type = _t3;
+  typedef struct {
+    int it_id;
+    char *info;
+  } info_typeItem;
+  typedef struct {
+    int len;
+    info_typeItem *data;
+  } list_info_typeItem;
+  static list_info_typeItem list_info_typeItem_create(int len) {
+    list_info_typeItem l;
+    l.len = len;
+    l.data = (info_typeItem *)malloc(sizeof(info_typeItem) * len);
+    return l;
+  }
+  list_info_typeItem _t4 = list_info_typeItem_create(1);
+  _t4.data[0] = (info_typeItem){.it_id = 10, .info = "languages"};
+  int info_type = _t4;
+  typedef struct {
+    int t_id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t5 = list_titleItem_create(3);
+  _t5.data[0] =
+      (titleItem){.t_id = 100, .title = "B Movie", .production_year = 2010};
+  _t5.data[1] =
+      (titleItem){.t_id = 200, .title = "A Film", .production_year = 2012};
+  _t5.data[2] =
+      (titleItem){.t_id = 300, .title = "Old Movie", .production_year = 2000};
+  int title = _t5;
+  typedef struct {
+    int movie_id;
+    int company_type_id;
+    char *note;
+  } movie_companiesItem;
+  typedef struct {
+    int len;
+    movie_companiesItem *data;
+  } list_movie_companiesItem;
+  static list_movie_companiesItem list_movie_companiesItem_create(int len) {
+    list_movie_companiesItem l;
+    l.len = len;
+    l.data = (movie_companiesItem *)malloc(sizeof(movie_companiesItem) * len);
+    return l;
+  }
+  list_movie_companiesItem _t6 = list_movie_companiesItem_create(3);
+  _t6.data[0] = (movie_companiesItem){.movie_id = 100,
+                                      .company_type_id = 1,
+                                      .note = "ACME (France) (theatrical)"};
+  _t6.data[1] = (movie_companiesItem){.movie_id = 200,
+                                      .company_type_id = 1,
+                                      .note = "ACME (France) (theatrical)"};
+  _t6.data[2] = (movie_companiesItem){.movie_id = 300,
+                                      .company_type_id = 1,
+                                      .note = "ACME (France) (theatrical)"};
+  int movie_companies = _t6;
+  typedef struct {
+    int movie_id;
+    char *info;
+    int info_type_id;
+  } movie_infoItem;
+  typedef struct {
+    int len;
+    movie_infoItem *data;
+  } list_movie_infoItem;
+  static list_movie_infoItem list_movie_infoItem_create(int len) {
+    list_movie_infoItem l;
+    l.len = len;
+    l.data = (movie_infoItem *)malloc(sizeof(movie_infoItem) * len);
+    return l;
+  }
+  list_movie_infoItem _t7 = list_movie_infoItem_create(3);
+  _t7.data[0] =
+      (movie_infoItem){.movie_id = 100, .info = "German", .info_type_id = 10};
+  _t7.data[1] =
+      (movie_infoItem){.movie_id = 200, .info = "Swedish", .info_type_id = 10};
+  _t7.data[2] =
+      (movie_infoItem){.movie_id = 300, .info = "German", .info_type_id = 10};
+  int movie_info = _t7;
+  list_string candidate_titles = 0;
+  typedef struct {
+    int typical_european_movie;
+  } resultItem;
+  typedef struct {
+    int len;
+    resultItem *data;
+  } list_resultItem;
+  static list_resultItem list_resultItem_create(int len) {
+    list_resultItem l;
+    l.len = len;
+    l.data = (resultItem *)malloc(sizeof(resultItem) * len);
+    return l;
+  }
+  list_resultItem _t8 = list_resultItem_create(1);
+  _t8.data[0] = (resultItem){.typical_european_movie = min(candidate_titles)};
+  int result = _t8;
+  _json_int(result);
+  test_Q5_finds_the_lexicographically_first_qualifying_title();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q6.c.out
+++ b/tests/dataset/job/compiler/c/q6.c.out
@@ -1,0 +1,239 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void test_Q6_finds_marvel_movie_with_Robert_Downey() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(3);
+  map_int_bool_put(&_t2, movie_keyword, "marvel-cinematic-universe");
+  map_int_bool_put(&_t2, actor_name, "Downey Robert Jr.");
+  map_int_bool_put(&_t2, marvel_movie, "Iron Man 3");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int movie_id;
+    int person_id;
+  } cast_infoItem;
+  typedef struct {
+    int len;
+    cast_infoItem *data;
+  } list_cast_infoItem;
+  static list_cast_infoItem list_cast_infoItem_create(int len) {
+    list_cast_infoItem l;
+    l.len = len;
+    l.data = (cast_infoItem *)malloc(sizeof(cast_infoItem) * len);
+    return l;
+  }
+  list_cast_infoItem _t3 = list_cast_infoItem_create(2);
+  _t3.data[0] = (cast_infoItem){.movie_id = 1, .person_id = 101};
+  _t3.data[1] = (cast_infoItem){.movie_id = 2, .person_id = 102};
+  int cast_info = _t3;
+  typedef struct {
+    int id;
+    char *keyword;
+  } keywordItem;
+  typedef struct {
+    int len;
+    keywordItem *data;
+  } list_keywordItem;
+  static list_keywordItem list_keywordItem_create(int len) {
+    list_keywordItem l;
+    l.len = len;
+    l.data = (keywordItem *)malloc(sizeof(keywordItem) * len);
+    return l;
+  }
+  list_keywordItem _t4 = list_keywordItem_create(2);
+  _t4.data[0] =
+      (keywordItem){.id = 100, .keyword = "marvel-cinematic-universe"};
+  _t4.data[1] = (keywordItem){.id = 200, .keyword = "other"};
+  int keyword = _t4;
+  typedef struct {
+    int movie_id;
+    int keyword_id;
+  } movie_keywordItem;
+  typedef struct {
+    int len;
+    movie_keywordItem *data;
+  } list_movie_keywordItem;
+  static list_movie_keywordItem list_movie_keywordItem_create(int len) {
+    list_movie_keywordItem l;
+    l.len = len;
+    l.data = (movie_keywordItem *)malloc(sizeof(movie_keywordItem) * len);
+    return l;
+  }
+  list_movie_keywordItem _t5 = list_movie_keywordItem_create(2);
+  _t5.data[0] = (movie_keywordItem){.movie_id = 1, .keyword_id = 100};
+  _t5.data[1] = (movie_keywordItem){.movie_id = 2, .keyword_id = 200};
+  int movie_keyword = _t5;
+  typedef struct {
+    int id;
+    char *name;
+  } nameItem;
+  typedef struct {
+    int len;
+    nameItem *data;
+  } list_nameItem;
+  static list_nameItem list_nameItem_create(int len) {
+    list_nameItem l;
+    l.len = len;
+    l.data = (nameItem *)malloc(sizeof(nameItem) * len);
+    return l;
+  }
+  list_nameItem _t6 = list_nameItem_create(2);
+  _t6.data[0] = (nameItem){.id = 101, .name = "Downey Robert Jr."};
+  _t6.data[1] = (nameItem){.id = 102, .name = "Chris Evans"};
+  int name = _t6;
+  typedef struct {
+    int id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t7 = list_titleItem_create(2);
+  _t7.data[0] =
+      (titleItem){.id = 1, .title = "Iron Man 3", .production_year = 2013};
+  _t7.data[1] =
+      (titleItem){.id = 2, .title = "Old Movie", .production_year = 2000};
+  int title = _t7;
+  list_int result = 0;
+  _json_int(result);
+  test_Q6_finds_marvel_movie_with_Robert_Downey();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q7.c.out
+++ b/tests/dataset/job/compiler/c/q7.c.out
@@ -1,0 +1,332 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void test_Q7_finds_movie_features_biography_for_person() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(2);
+  map_int_bool_put(&_t2, of_person, "Alan Brown");
+  map_int_bool_put(&_t2, biography_movie, "Feature Film");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int person_id;
+    char *name;
+  } aka_nameItem;
+  typedef struct {
+    int len;
+    aka_nameItem *data;
+  } list_aka_nameItem;
+  static list_aka_nameItem list_aka_nameItem_create(int len) {
+    list_aka_nameItem l;
+    l.len = len;
+    l.data = (aka_nameItem *)malloc(sizeof(aka_nameItem) * len);
+    return l;
+  }
+  list_aka_nameItem _t3 = list_aka_nameItem_create(2);
+  _t3.data[0] = (aka_nameItem){.person_id = 1, .name = "Anna Mae"};
+  _t3.data[1] = (aka_nameItem){.person_id = 2, .name = "Chris"};
+  int aka_name = _t3;
+  typedef struct {
+    int person_id;
+    int movie_id;
+  } cast_infoItem;
+  typedef struct {
+    int len;
+    cast_infoItem *data;
+  } list_cast_infoItem;
+  static list_cast_infoItem list_cast_infoItem_create(int len) {
+    list_cast_infoItem l;
+    l.len = len;
+    l.data = (cast_infoItem *)malloc(sizeof(cast_infoItem) * len);
+    return l;
+  }
+  list_cast_infoItem _t4 = list_cast_infoItem_create(2);
+  _t4.data[0] = (cast_infoItem){.person_id = 1, .movie_id = 10};
+  _t4.data[1] = (cast_infoItem){.person_id = 2, .movie_id = 20};
+  int cast_info = _t4;
+  typedef struct {
+    int id;
+    char *info;
+  } info_typeItem;
+  typedef struct {
+    int len;
+    info_typeItem *data;
+  } list_info_typeItem;
+  static list_info_typeItem list_info_typeItem_create(int len) {
+    list_info_typeItem l;
+    l.len = len;
+    l.data = (info_typeItem *)malloc(sizeof(info_typeItem) * len);
+    return l;
+  }
+  list_info_typeItem _t5 = list_info_typeItem_create(2);
+  _t5.data[0] = (info_typeItem){.id = 1, .info = "mini biography"};
+  _t5.data[1] = (info_typeItem){.id = 2, .info = "trivia"};
+  int info_type = _t5;
+  typedef struct {
+    int id;
+    char *link;
+  } link_typeItem;
+  typedef struct {
+    int len;
+    link_typeItem *data;
+  } list_link_typeItem;
+  static list_link_typeItem list_link_typeItem_create(int len) {
+    list_link_typeItem l;
+    l.len = len;
+    l.data = (link_typeItem *)malloc(sizeof(link_typeItem) * len);
+    return l;
+  }
+  list_link_typeItem _t6 = list_link_typeItem_create(2);
+  _t6.data[0] = (link_typeItem){.id = 1, .link = "features"};
+  _t6.data[1] = (link_typeItem){.id = 2, .link = "references"};
+  int link_type = _t6;
+  typedef struct {
+    int linked_movie_id;
+    int link_type_id;
+  } movie_linkItem;
+  typedef struct {
+    int len;
+    movie_linkItem *data;
+  } list_movie_linkItem;
+  static list_movie_linkItem list_movie_linkItem_create(int len) {
+    list_movie_linkItem l;
+    l.len = len;
+    l.data = (movie_linkItem *)malloc(sizeof(movie_linkItem) * len);
+    return l;
+  }
+  list_movie_linkItem _t7 = list_movie_linkItem_create(2);
+  _t7.data[0] = (movie_linkItem){.linked_movie_id = 10, .link_type_id = 1};
+  _t7.data[1] = (movie_linkItem){.linked_movie_id = 20, .link_type_id = 2};
+  int movie_link = _t7;
+  typedef struct {
+    int id;
+    char *name;
+    char *name_pcode_cf;
+    char *gender;
+  } nameItem;
+  typedef struct {
+    int len;
+    nameItem *data;
+  } list_nameItem;
+  static list_nameItem list_nameItem_create(int len) {
+    list_nameItem l;
+    l.len = len;
+    l.data = (nameItem *)malloc(sizeof(nameItem) * len);
+    return l;
+  }
+  list_nameItem _t8 = list_nameItem_create(2);
+  _t8.data[0] = (nameItem){
+      .id = 1, .name = "Alan Brown", .name_pcode_cf = "B", .gender = "m"};
+  _t8.data[1] =
+      (nameItem){.id = 2, .name = "Zoe", .name_pcode_cf = "Z", .gender = "f"};
+  int name = _t8;
+  typedef struct {
+    int person_id;
+    int info_type_id;
+    char *note;
+  } person_infoItem;
+  typedef struct {
+    int len;
+    person_infoItem *data;
+  } list_person_infoItem;
+  static list_person_infoItem list_person_infoItem_create(int len) {
+    list_person_infoItem l;
+    l.len = len;
+    l.data = (person_infoItem *)malloc(sizeof(person_infoItem) * len);
+    return l;
+  }
+  list_person_infoItem _t9 = list_person_infoItem_create(2);
+  _t9.data[0] = (person_infoItem){
+      .person_id = 1, .info_type_id = 1, .note = "Volker Boehm"};
+  _t9.data[1] =
+      (person_infoItem){.person_id = 2, .info_type_id = 1, .note = "Other"};
+  int person_info = _t9;
+  typedef struct {
+    int id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t10 = list_titleItem_create(2);
+  _t10.data[0] =
+      (titleItem){.id = 10, .title = "Feature Film", .production_year = 1990};
+  _t10.data[1] =
+      (titleItem){.id = 20, .title = "Late Film", .production_year = 2000};
+  int title = _t10;
+  list_int rows = 0;
+  typedef struct {
+    int of_person;
+    int biography_movie;
+  } resultItem;
+  typedef struct {
+    int len;
+    resultItem *data;
+  } list_resultItem;
+  static list_resultItem list_resultItem_create(int len) {
+    list_resultItem l;
+    l.len = len;
+    l.data = (resultItem *)malloc(sizeof(resultItem) * len);
+    return l;
+  }
+  list_resultItem _t11 = list_resultItem_create(1);
+  list_string _t12 = list_string_create(rows.len);
+  int _t13 = 0;
+  for (int _t14 = 0; _t14 < rows.len; _t14++) {
+    int r = rows.data[_t14];
+    _t12.data[_t13] = r.person_name;
+    _t13++;
+  }
+  _t12.len = _t13;
+  list_string _t15 = list_string_create(rows.len);
+  int _t16 = 0;
+  for (int _t17 = 0; _t17 < rows.len; _t17++) {
+    int r = rows.data[_t17];
+    _t15.data[_t16] = r.movie_title;
+    _t16++;
+  }
+  _t15.len = _t16;
+  _t11.data[0] =
+      (resultItem){.of_person = min(_t12), .biography_movie = min(_t15)};
+  int result = _t11;
+  _json_int(result);
+  test_Q7_finds_movie_features_biography_for_person();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q8.c.out
+++ b/tests/dataset/job/compiler/c/q8.c.out
@@ -1,0 +1,306 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void
+test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(2);
+  map_int_bool_put(&_t2, actress_pseudonym, "Y. S.");
+  map_int_bool_put(&_t2, japanese_movie_dubbed, "Dubbed Film");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int person_id;
+    char *name;
+  } aka_nameItem;
+  typedef struct {
+    int len;
+    aka_nameItem *data;
+  } list_aka_nameItem;
+  static list_aka_nameItem list_aka_nameItem_create(int len) {
+    list_aka_nameItem l;
+    l.len = len;
+    l.data = (aka_nameItem *)malloc(sizeof(aka_nameItem) * len);
+    return l;
+  }
+  list_aka_nameItem _t3 = list_aka_nameItem_create(1);
+  _t3.data[0] = (aka_nameItem){.person_id = 1, .name = "Y. S."};
+  int aka_name = _t3;
+  typedef struct {
+    int person_id;
+    int movie_id;
+    char *note;
+    int role_id;
+  } cast_infoItem;
+  typedef struct {
+    int len;
+    cast_infoItem *data;
+  } list_cast_infoItem;
+  static list_cast_infoItem list_cast_infoItem_create(int len) {
+    list_cast_infoItem l;
+    l.len = len;
+    l.data = (cast_infoItem *)malloc(sizeof(cast_infoItem) * len);
+    return l;
+  }
+  list_cast_infoItem _t4 = list_cast_infoItem_create(1);
+  _t4.data[0] = (cast_infoItem){.person_id = 1,
+                                .movie_id = 10,
+                                .note = "(voice: English version)",
+                                .role_id = 1000};
+  int cast_info = _t4;
+  typedef struct {
+    int id;
+    char *country_code;
+  } company_nameItem;
+  typedef struct {
+    int len;
+    company_nameItem *data;
+  } list_company_nameItem;
+  static list_company_nameItem list_company_nameItem_create(int len) {
+    list_company_nameItem l;
+    l.len = len;
+    l.data = (company_nameItem *)malloc(sizeof(company_nameItem) * len);
+    return l;
+  }
+  list_company_nameItem _t5 = list_company_nameItem_create(1);
+  _t5.data[0] = (company_nameItem){.id = 50, .country_code = "[jp]"};
+  int company_name = _t5;
+  typedef struct {
+    int movie_id;
+    int company_id;
+    char *note;
+  } movie_companiesItem;
+  typedef struct {
+    int len;
+    movie_companiesItem *data;
+  } list_movie_companiesItem;
+  static list_movie_companiesItem list_movie_companiesItem_create(int len) {
+    list_movie_companiesItem l;
+    l.len = len;
+    l.data = (movie_companiesItem *)malloc(sizeof(movie_companiesItem) * len);
+    return l;
+  }
+  list_movie_companiesItem _t6 = list_movie_companiesItem_create(1);
+  _t6.data[0] = (movie_companiesItem){
+      .movie_id = 10, .company_id = 50, .note = "Studio (Japan)"};
+  int movie_companies = _t6;
+  typedef struct {
+    int id;
+    char *name;
+  } nameItem;
+  typedef struct {
+    int len;
+    nameItem *data;
+  } list_nameItem;
+  static list_nameItem list_nameItem_create(int len) {
+    list_nameItem l;
+    l.len = len;
+    l.data = (nameItem *)malloc(sizeof(nameItem) * len);
+    return l;
+  }
+  list_nameItem _t7 = list_nameItem_create(2);
+  _t7.data[0] = (nameItem){.id = 1, .name = "Yoko Ono"};
+  _t7.data[1] = (nameItem){.id = 2, .name = "Yuichi"};
+  int name = _t7;
+  typedef struct {
+    int id;
+    char *role;
+  } role_typeItem;
+  typedef struct {
+    int len;
+    role_typeItem *data;
+  } list_role_typeItem;
+  static list_role_typeItem list_role_typeItem_create(int len) {
+    list_role_typeItem l;
+    l.len = len;
+    l.data = (role_typeItem *)malloc(sizeof(role_typeItem) * len);
+    return l;
+  }
+  list_role_typeItem _t8 = list_role_typeItem_create(1);
+  _t8.data[0] = (role_typeItem){.id = 1000, .role = "actress"};
+  int role_type = _t8;
+  typedef struct {
+    int id;
+    char *title;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t9 = list_titleItem_create(1);
+  _t9.data[0] = (titleItem){.id = 10, .title = "Dubbed Film"};
+  int title = _t9;
+  list_int eligible = 0;
+  typedef struct {
+    int actress_pseudonym;
+    int japanese_movie_dubbed;
+  } resultItem;
+  typedef struct {
+    int len;
+    resultItem *data;
+  } list_resultItem;
+  static list_resultItem list_resultItem_create(int len) {
+    list_resultItem l;
+    l.len = len;
+    l.data = (resultItem *)malloc(sizeof(resultItem) * len);
+    return l;
+  }
+  list_resultItem _t10 = list_resultItem_create(1);
+  list_string _t11 = list_string_create(eligible.len);
+  int _t12 = 0;
+  for (int _t13 = 0; _t13 < eligible.len; _t13++) {
+    int x = eligible.data[_t13];
+    _t11.data[_t12] = x.pseudonym;
+    _t12++;
+  }
+  _t11.len = _t12;
+  list_string _t14 = list_string_create(eligible.len);
+  int _t15 = 0;
+  for (int _t16 = 0; _t16 < eligible.len; _t16++) {
+    int x = eligible.data[_t16];
+    _t14.data[_t15] = x.movie_title;
+    _t15++;
+  }
+  _t14.len = _t15;
+  _t10.data[0] = (resultItem){.actress_pseudonym = min(_t11),
+                              .japanese_movie_dubbed = min(_t14)};
+  int result = _t10;
+  _json_int(result);
+  test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing();
+  return 0;
+}

--- a/tests/dataset/job/compiler/c/q9.c.out
+++ b/tests/dataset/job/compiler/c/q9.c.out
@@ -1,0 +1,351 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int len;
+  int *data;
+} list_int;
+static list_int list_int_create(int len) {
+  list_int l;
+  l.len = len;
+  l.data = (int *)malloc(sizeof(int) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  double *data;
+} list_float;
+static list_float list_float_create(int len) {
+  list_float l;
+  l.len = len;
+  l.data = (double *)malloc(sizeof(double) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  char **data;
+} list_string;
+static list_string list_string_create(int len) {
+  list_string l;
+  l.len = len;
+  l.data = (char **)malloc(sizeof(char *) * len);
+  return l;
+}
+typedef struct {
+  int len;
+  list_int *data;
+} list_list_int;
+static list_list_int list_list_int_create(int len) {
+  list_list_int l;
+  l.len = len;
+  l.data = (list_int *)malloc(sizeof(list_int) * len);
+  return l;
+}
+typedef struct {
+  int key;
+  int value;
+} map_int_bool_item;
+static map_int_bool_item *map_int_bool_item_new(int key, int value) {
+  map_int_bool_item *it =
+      (map_int_bool_item *)malloc(sizeof(map_int_bool_item));
+  it->key = key;
+  it->value = value;
+  return it;
+}
+typedef struct {
+  int len;
+  int cap;
+  map_int_bool_item **data;
+} map_int_bool;
+static map_int_bool map_int_bool_create(int cap) {
+  map_int_bool m;
+  m.len = 0;
+  m.cap = cap;
+  m.data = cap ? (map_int_bool_item **)malloc(sizeof(map_int_bool_item *) * cap)
+               : NULL;
+  return m;
+}
+static void map_int_bool_put(map_int_bool *m, int key, int value) {
+  for (int i = 0; i < m->len; i++)
+    if (m->data[i]->key == key) {
+      m->data[i]->value = value;
+      return;
+    }
+  if (m->len >= m->cap) {
+    m->cap = m->cap ? m->cap * 2 : 4;
+    m->data = (map_int_bool_item **)realloc(
+        m->data, sizeof(map_int_bool_item *) * m->cap);
+  }
+  m->data[m->len++] = map_int_bool_item_new(key, value);
+}
+static int map_int_bool_contains(map_int_bool m, int key) {
+  for (int i = 0; i < m.len; i++)
+    if (m.data[i]->key == key)
+      return 1;
+  return 0;
+}
+static void _json_int(int v) { printf("%d", v); }
+static void _json_float(double v) { printf("%g", v); }
+static void _json_string(char *s) { printf("\"%s\"", s); }
+static void _json_list_int(list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_int(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_float(list_float v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_float(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_string(list_string v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_string(v.data[i]);
+  }
+  printf("]");
+}
+static void _json_list_list_int(list_list_int v) {
+  printf("[");
+  for (int i = 0; i < v.len; i++) {
+    if (i > 0)
+      printf(",");
+    _json_list_int(v.data[i]);
+  }
+  printf("]");
+}
+static void test_Q9_selects_minimal_alternative_name__character_and_movie() {
+  list_int _t1 = list_int_create(1);
+  map_int_bool _t2 = map_int_bool_create(3);
+  map_int_bool_put(&_t2, alternative_name, "A. N. G.");
+  map_int_bool_put(&_t2, character_name, "Angel");
+  map_int_bool_put(&_t2, movie, "Famous Film");
+  _t1.data[0] = _t2;
+  if (!((result == _t1))) {
+    fprintf(stderr, "expect failed\n");
+    exit(1);
+  }
+}
+
+int main() {
+  typedef struct {
+    int person_id;
+    char *name;
+  } aka_nameItem;
+  typedef struct {
+    int len;
+    aka_nameItem *data;
+  } list_aka_nameItem;
+  static list_aka_nameItem list_aka_nameItem_create(int len) {
+    list_aka_nameItem l;
+    l.len = len;
+    l.data = (aka_nameItem *)malloc(sizeof(aka_nameItem) * len);
+    return l;
+  }
+  list_aka_nameItem _t3 = list_aka_nameItem_create(2);
+  _t3.data[0] = (aka_nameItem){.person_id = 1, .name = "A. N. G."};
+  _t3.data[1] = (aka_nameItem){.person_id = 2, .name = "J. D."};
+  int aka_name = _t3;
+  typedef struct {
+    int id;
+    char *name;
+  } char_nameItem;
+  typedef struct {
+    int len;
+    char_nameItem *data;
+  } list_char_nameItem;
+  static list_char_nameItem list_char_nameItem_create(int len) {
+    list_char_nameItem l;
+    l.len = len;
+    l.data = (char_nameItem *)malloc(sizeof(char_nameItem) * len);
+    return l;
+  }
+  list_char_nameItem _t4 = list_char_nameItem_create(2);
+  _t4.data[0] = (char_nameItem){.id = 10, .name = "Angel"};
+  _t4.data[1] = (char_nameItem){.id = 20, .name = "Devil"};
+  int char_name = _t4;
+  typedef struct {
+    int person_id;
+    int person_role_id;
+    int movie_id;
+    int role_id;
+    char *note;
+  } cast_infoItem;
+  typedef struct {
+    int len;
+    cast_infoItem *data;
+  } list_cast_infoItem;
+  static list_cast_infoItem list_cast_infoItem_create(int len) {
+    list_cast_infoItem l;
+    l.len = len;
+    l.data = (cast_infoItem *)malloc(sizeof(cast_infoItem) * len);
+    return l;
+  }
+  list_cast_infoItem _t5 = list_cast_infoItem_create(2);
+  _t5.data[0] = (cast_infoItem){.person_id = 1,
+                                .person_role_id = 10,
+                                .movie_id = 100,
+                                .role_id = 1000,
+                                .note = "(voice)"};
+  _t5.data[1] = (cast_infoItem){.person_id = 2,
+                                .person_role_id = 20,
+                                .movie_id = 200,
+                                .role_id = 1000,
+                                .note = "(voice)"};
+  int cast_info = _t5;
+  typedef struct {
+    int id;
+    char *country_code;
+  } company_nameItem;
+  typedef struct {
+    int len;
+    company_nameItem *data;
+  } list_company_nameItem;
+  static list_company_nameItem list_company_nameItem_create(int len) {
+    list_company_nameItem l;
+    l.len = len;
+    l.data = (company_nameItem *)malloc(sizeof(company_nameItem) * len);
+    return l;
+  }
+  list_company_nameItem _t6 = list_company_nameItem_create(2);
+  _t6.data[0] = (company_nameItem){.id = 100, .country_code = "[us]"};
+  _t6.data[1] = (company_nameItem){.id = 200, .country_code = "[gb]"};
+  int company_name = _t6;
+  typedef struct {
+    int movie_id;
+    int company_id;
+    char *note;
+  } movie_companiesItem;
+  typedef struct {
+    int len;
+    movie_companiesItem *data;
+  } list_movie_companiesItem;
+  static list_movie_companiesItem list_movie_companiesItem_create(int len) {
+    list_movie_companiesItem l;
+    l.len = len;
+    l.data = (movie_companiesItem *)malloc(sizeof(movie_companiesItem) * len);
+    return l;
+  }
+  list_movie_companiesItem _t7 = list_movie_companiesItem_create(2);
+  _t7.data[0] = (movie_companiesItem){
+      .movie_id = 100, .company_id = 100, .note = "ACME Studios (USA)"};
+  _t7.data[1] = (movie_companiesItem){
+      .movie_id = 200, .company_id = 200, .note = "Maple Films"};
+  int movie_companies = _t7;
+  typedef struct {
+    int id;
+    char *name;
+    char *gender;
+  } nameItem;
+  typedef struct {
+    int len;
+    nameItem *data;
+  } list_nameItem;
+  static list_nameItem list_nameItem_create(int len) {
+    list_nameItem l;
+    l.len = len;
+    l.data = (nameItem *)malloc(sizeof(nameItem) * len);
+    return l;
+  }
+  list_nameItem _t8 = list_nameItem_create(2);
+  _t8.data[0] = (nameItem){.id = 1, .name = "Angela Smith", .gender = "f"};
+  _t8.data[1] = (nameItem){.id = 2, .name = "John Doe", .gender = "m"};
+  int name = _t8;
+  typedef struct {
+    int id;
+    char *role;
+  } role_typeItem;
+  typedef struct {
+    int len;
+    role_typeItem *data;
+  } list_role_typeItem;
+  static list_role_typeItem list_role_typeItem_create(int len) {
+    list_role_typeItem l;
+    l.len = len;
+    l.data = (role_typeItem *)malloc(sizeof(role_typeItem) * len);
+    return l;
+  }
+  list_role_typeItem _t9 = list_role_typeItem_create(2);
+  _t9.data[0] = (role_typeItem){.id = 1000, .role = "actress"};
+  _t9.data[1] = (role_typeItem){.id = 2000, .role = "actor"};
+  int role_type = _t9;
+  typedef struct {
+    int id;
+    char *title;
+    int production_year;
+  } titleItem;
+  typedef struct {
+    int len;
+    titleItem *data;
+  } list_titleItem;
+  static list_titleItem list_titleItem_create(int len) {
+    list_titleItem l;
+    l.len = len;
+    l.data = (titleItem *)malloc(sizeof(titleItem) * len);
+    return l;
+  }
+  list_titleItem _t10 = list_titleItem_create(2);
+  _t10.data[0] =
+      (titleItem){.id = 100, .title = "Famous Film", .production_year = 2010};
+  _t10.data[1] =
+      (titleItem){.id = 200, .title = "Old Movie", .production_year = 1999};
+  int title = _t10;
+  list_int matches = 0;
+  typedef struct {
+    int alternative_name;
+    int character_name;
+    int movie;
+  } resultItem;
+  typedef struct {
+    int len;
+    resultItem *data;
+  } list_resultItem;
+  static list_resultItem list_resultItem_create(int len) {
+    list_resultItem l;
+    l.len = len;
+    l.data = (resultItem *)malloc(sizeof(resultItem) * len);
+    return l;
+  }
+  list_resultItem _t11 = list_resultItem_create(1);
+  list_string _t12 = list_string_create(matches.len);
+  int _t13 = 0;
+  for (int _t14 = 0; _t14 < matches.len; _t14++) {
+    int x = matches.data[_t14];
+    _t12.data[_t13] = x.alt;
+    _t13++;
+  }
+  _t12.len = _t13;
+  list_string _t15 = list_string_create(matches.len);
+  int _t16 = 0;
+  for (int _t17 = 0; _t17 < matches.len; _t17++) {
+    int x = matches.data[_t17];
+    _t15.data[_t16] = x.character;
+    _t16++;
+  }
+  _t15.len = _t16;
+  list_string _t18 = list_string_create(matches.len);
+  int _t19 = 0;
+  for (int _t20 = 0; _t20 < matches.len; _t20++) {
+    int x = matches.data[_t20];
+    _t18.data[_t19] = x.movie;
+    _t19++;
+  }
+  _t18.len = _t19;
+  _t11.data[0] = (resultItem){.alternative_name = min(_t12),
+                              .character_name = min(_t15),
+                              .movie = min(_t18)};
+  int result = _t11;
+  _json_int(result);
+  test_Q9_selects_minimal_alternative_name__character_and_movie();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add JOB compilation tests for C backend
- generate C output for JOB q1–q10
- note current compile failures in `TASKS.md`

## Testing
- `go test ./compile/x/c -run JOB -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_685e80e8035c8320bbbf3e03076cb4f5