### PR TITLE
Update JOB Go compiler tests

### DIFF
--- a/compile/go/TASKS.md
+++ b/compile/go/TASKS.md
@@ -1,12 +1,13 @@
 # Go Compiler JOB Queries
 
-Some JOB dataset programs do not compile or run correctly.
-The generator script attempted to compile `q1` to `q10` but the
-following queries failed:
+The JOB dataset queries now build using the Go backend, but several
+still fail their embedded tests. Generation results:
 
-- `q3` and `q9` produce Go code with global statements and fail to build.
-- `q5` fails to run due to invalid generated Go syntax.
-- `q7` fails during compilation: boolean `&&` on `bool` and `any` unsupported.
+- `q1`, `q2` and `q6` compile and pass tests.
+- `q3`, `q4`, `q5`, `q8`, `q9` and `q10` compile, but the generated
+  programs report failed expectations.
+- `q7` does not emit a Go file when built.
 
-Remaining queries (`q2`, `q4`, `q6`, `q8`, `q10`) compiled and ran successfully.
-Further work is needed to fix code generation for the failing queries.
+Golden outputs have been updated for the queries that compile. Further
+work is required to make the failing programs pass their tests and to
+determine why `q7` is skipped during compilation.

--- a/compile/go/runtime.go
+++ b/compile/go/runtime.go
@@ -353,6 +353,13 @@ const (
 		"    return out\n" +
 		"}\n"
 
+	helperContains = "func _contains[T comparable](s []T, v T) bool {\n" +
+		"    for _, x := range s {\n" +
+		"        if x == v { return true }\n" +
+		"    }\n" +
+		"    return false\n" +
+		"}\n"
+
 	helperCast = "func _cast[T any](v any) T {\n" +
 		"    if tv, ok := v.(T); ok { return tv }\n" +
 		"    var out T\n" +
@@ -620,6 +627,7 @@ var helperMap = map[string]string{
 	"_toAnyMap":      helperToAnyMap,
 	"_toAnySlice":    helperToAnySlice,
 	"_convSlice":     helperConvSlice,
+	"_contains":      helperContains,
 	"_cast":          helperCast,
 	"_convertMapAny": helperConvertMapAny,
 	"_equal":         helperEqual,

--- a/tests/dataset/job/compiler/go/q1.go.out
+++ b/tests/dataset/job/compiler/go/q1.go.out
@@ -53,26 +53,14 @@ type Company_typeItem struct {
 	Kind string `json:"kind"`
 }
 
-var company_type []Company_typeItem = []Company_typeItem{Company_typeItem{
-	Id:   1,
-	Kind: "production companies",
-}, Company_typeItem{
-	Id:   2,
-	Kind: "distributors",
-}}
+var company_type []Company_typeItem
 
 type Info_typeItem struct {
 	Id   int    `json:"id"`
 	Info string `json:"info"`
 }
 
-var info_type []Info_typeItem = []Info_typeItem{Info_typeItem{
-	Id:   10,
-	Info: "top 250 rank",
-}, Info_typeItem{
-	Id:   20,
-	Info: "bottom 10 rank",
-}}
+var info_type []Info_typeItem
 
 type TitleItem struct {
 	Id              int    `json:"id"`
@@ -80,15 +68,7 @@ type TitleItem struct {
 	Production_year int    `json:"production_year"`
 }
 
-var title []TitleItem = []TitleItem{TitleItem{
-	Id:              100,
-	Title:           "Good Movie",
-	Production_year: 1995,
-}, TitleItem{
-	Id:              200,
-	Title:           "Bad Movie",
-	Production_year: 2000,
-}}
+var title []TitleItem
 
 type Movie_companiesItem struct {
 	Movie_id        int    `json:"movie_id"`
@@ -96,89 +76,116 @@ type Movie_companiesItem struct {
 	Note            string `json:"note"`
 }
 
-var movie_companies []Movie_companiesItem = []Movie_companiesItem{Movie_companiesItem{
-	Movie_id:        100,
-	Company_type_id: 1,
-	Note:            "ACME (co-production)",
-}, Movie_companiesItem{
-	Movie_id:        200,
-	Company_type_id: 1,
-	Note:            "MGM (as Metro-Goldwyn-Mayer Pictures)",
-}}
+var movie_companies []Movie_companiesItem
 
 type Movie_info_idxItem struct {
 	Movie_id     int `json:"movie_id"`
 	Info_type_id int `json:"info_type_id"`
 }
 
-var movie_info_idx []Movie_info_idxItem = []Movie_info_idxItem{Movie_info_idxItem{
-	Movie_id:     100,
-	Info_type_id: 10,
-}, Movie_info_idxItem{
-	Movie_id:     200,
-	Info_type_id: 20,
-}}
-var filtered []map[string]any = func() []map[string]any {
-	_res := []map[string]any{}
-	for _, ct := range company_type {
-		for _, mc := range movie_companies {
-			if !(ct.Id == mc.Company_type_id) {
-				continue
-			}
-			for _, t := range title {
-				if !(t.Id == mc.Movie_id) {
+var movie_info_idx []Movie_info_idxItem
+var filtered []map[string]any
+var result map[string]any
+
+func main() {
+	failures := 0
+	company_type = _cast[[]Company_typeItem]([]Company_typeItem{Company_typeItem{
+		Id:   1,
+		Kind: "production companies",
+	}, Company_typeItem{
+		Id:   2,
+		Kind: "distributors",
+	}})
+	info_type = _cast[[]Info_typeItem]([]Info_typeItem{Info_typeItem{
+		Id:   10,
+		Info: "top 250 rank",
+	}, Info_typeItem{
+		Id:   20,
+		Info: "bottom 10 rank",
+	}})
+	title = _cast[[]TitleItem]([]TitleItem{TitleItem{
+		Id:              100,
+		Title:           "Good Movie",
+		Production_year: 1995,
+	}, TitleItem{
+		Id:              200,
+		Title:           "Bad Movie",
+		Production_year: 2000,
+	}})
+	movie_companies = _cast[[]Movie_companiesItem]([]Movie_companiesItem{Movie_companiesItem{
+		Movie_id:        100,
+		Company_type_id: 1,
+		Note:            "ACME (co-production)",
+	}, Movie_companiesItem{
+		Movie_id:        200,
+		Company_type_id: 1,
+		Note:            "MGM (as Metro-Goldwyn-Mayer Pictures)",
+	}})
+	movie_info_idx = _cast[[]Movie_info_idxItem]([]Movie_info_idxItem{Movie_info_idxItem{
+		Movie_id:     100,
+		Info_type_id: 10,
+	}, Movie_info_idxItem{
+		Movie_id:     200,
+		Info_type_id: 20,
+	}})
+	filtered = func() []map[string]any {
+		_res := []map[string]any{}
+		for _, ct := range company_type {
+			for _, mc := range movie_companies {
+				if !(ct.Id == mc.Company_type_id) {
 					continue
 				}
-				for _, mi := range movie_info_idx {
-					if !(mi.Movie_id == t.Id) {
+				for _, t := range title {
+					if !(t.Id == mc.Movie_id) {
 						continue
 					}
-					for _, it := range info_type {
-						if !(it.Id == mi.Info_type_id) {
+					for _, mi := range movie_info_idx {
+						if !(mi.Movie_id == t.Id) {
 							continue
 						}
-						if (((ct.Kind == "production companies") && (it.Info == "top 250 rank")) && (!strings.Contains(mc.Note, "(as Metro-Goldwyn-Mayer Pictures)"))) && (strings.Contains(mc.Note, "(co-production)") || strings.Contains(mc.Note, "(presents)")) {
+						for _, it := range info_type {
+							if !(it.Id == mi.Info_type_id) {
+								continue
+							}
 							if (((ct.Kind == "production companies") && (it.Info == "top 250 rank")) && (!strings.Contains(mc.Note, "(as Metro-Goldwyn-Mayer Pictures)"))) && (strings.Contains(mc.Note, "(co-production)") || strings.Contains(mc.Note, "(presents)")) {
-								_res = append(_res, map[string]any{
-									"note":  mc.Note,
-									"title": t.Title,
-									"year":  t.Production_year,
-								})
+								if (((ct.Kind == "production companies") && (it.Info == "top 250 rank")) && (!strings.Contains(mc.Note, "(as Metro-Goldwyn-Mayer Pictures)"))) && (strings.Contains(mc.Note, "(co-production)") || strings.Contains(mc.Note, "(presents)")) {
+									_res = append(_res, map[string]any{
+										"note":  mc.Note,
+										"title": t.Title,
+										"year":  t.Production_year,
+									})
+								}
 							}
 						}
 					}
 				}
 			}
 		}
+		return _res
+	}()
+	result = map[string]any{
+		"production_note": _min(func() []any {
+			_res := []any{}
+			for _, r := range filtered {
+				_res = append(_res, r["note"])
+			}
+			return _res
+		}()),
+		"movie_title": _min(func() []any {
+			_res := []any{}
+			for _, r := range filtered {
+				_res = append(_res, r["title"])
+			}
+			return _res
+		}()),
+		"movie_year": _min(func() []any {
+			_res := []any{}
+			for _, r := range filtered {
+				_res = append(_res, r["year"])
+			}
+			return _res
+		}()),
 	}
-	return _res
-}()
-var result map[string]any = map[string]any{
-	"production_note": _min(func() []any {
-		_res := []any{}
-		for _, r := range filtered {
-			_res = append(_res, r["note"])
-		}
-		return _res
-	}()),
-	"movie_title": _min(func() []any {
-		_res := []any{}
-		for _, r := range filtered {
-			_res = append(_res, r["title"])
-		}
-		return _res
-	}()),
-	"movie_year": _min(func() []any {
-		_res := []any{}
-		for _, r := range filtered {
-			_res = append(_res, r["year"])
-		}
-		return _res
-	}()),
-}
-
-func main() {
-	failures := 0
 	func() { b, _ := json.Marshal([]map[string]any{result}); fmt.Println(string(b)) }()
 	{
 		printTestStart("Q1 returns min note, title and year for top ranked co-production")
@@ -202,6 +209,66 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
 }
 
 func _equal(a, b any) bool {

--- a/tests/dataset/job/compiler/go/q1.out
+++ b/tests/dataset/job/compiler/go/q1.out
@@ -1,2 +1,2 @@
 [{"movie_title":"Good Movie","movie_year":1995,"production_note":"ACME (co-production)"}]
-   test Q1 returns min note, title and year for top ranked co-production ... ok (4.0µs)
+   test Q1 returns min note, title and year for top ranked co-production ... ok (5.0µs)

--- a/tests/dataset/job/compiler/go/q10.go.out
+++ b/tests/dataset/job/compiler/go/q10.go.out
@@ -49,13 +49,7 @@ type Char_nameItem struct {
 	Name string `json:"name"`
 }
 
-var char_name []Char_nameItem = []Char_nameItem{Char_nameItem{
-	Id:   1,
-	Name: "Ivan",
-}, Char_nameItem{
-	Id:   2,
-	Name: "Alex",
-}}
+var char_name []Char_nameItem
 
 type Cast_infoItem struct {
 	Movie_id       int    `json:"movie_id"`
@@ -64,36 +58,20 @@ type Cast_infoItem struct {
 	Note           string `json:"note"`
 }
 
-var cast_info []Cast_infoItem = []Cast_infoItem{Cast_infoItem{
-	Movie_id:       10,
-	Person_role_id: 1,
-	Role_id:        1,
-	Note:           "Soldier (voice) (uncredited)",
-}, Cast_infoItem{
-	Movie_id:       11,
-	Person_role_id: 2,
-	Role_id:        1,
-	Note:           "(voice)",
-}}
+var cast_info []Cast_infoItem
 
 type Company_nameItem struct {
 	Id           int    `json:"id"`
 	Country_code string `json:"country_code"`
 }
 
-var company_name []Company_nameItem = []Company_nameItem{Company_nameItem{
-	Id:           1,
-	Country_code: "[ru]",
-}, Company_nameItem{
-	Id:           2,
-	Country_code: "[us]",
-}}
+var company_name []Company_nameItem
 
 type Company_typeItem struct {
 	Id int `json:"id"`
 }
 
-var company_type []Company_typeItem = []Company_typeItem{Company_typeItem{Id: 1}, Company_typeItem{Id: 2}}
+var company_type []Company_typeItem
 
 type Movie_companiesItem struct {
 	Movie_id        int `json:"movie_id"`
@@ -101,28 +79,14 @@ type Movie_companiesItem struct {
 	Company_type_id int `json:"company_type_id"`
 }
 
-var movie_companies []Movie_companiesItem = []Movie_companiesItem{Movie_companiesItem{
-	Movie_id:        10,
-	Company_id:      1,
-	Company_type_id: 1,
-}, Movie_companiesItem{
-	Movie_id:        11,
-	Company_id:      2,
-	Company_type_id: 1,
-}}
+var movie_companies []Movie_companiesItem
 
 type Role_typeItem struct {
 	Id   int    `json:"id"`
 	Role string `json:"role"`
 }
 
-var role_type []Role_typeItem = []Role_typeItem{Role_typeItem{
-	Id:   1,
-	Role: "actor",
-}, Role_typeItem{
-	Id:   2,
-	Role: "director",
-}}
+var role_type []Role_typeItem
 
 type TitleItem struct {
 	Id              int    `json:"id"`
@@ -130,44 +94,99 @@ type TitleItem struct {
 	Production_year int    `json:"production_year"`
 }
 
-var title []TitleItem = []TitleItem{TitleItem{
-	Id:              10,
-	Title:           "Vodka Dreams",
-	Production_year: 2006,
-}, TitleItem{
-	Id:              11,
-	Title:           "Other Film",
-	Production_year: 2004,
-}}
-var matches []map[string]string = func() []map[string]string {
-	_res := []map[string]string{}
-	for _, chn := range char_name {
-		for _, ci := range cast_info {
-			if !(chn.Id == ci.Person_role_id) {
-				continue
-			}
-			for _, rt := range role_type {
-				if !(rt.Id == ci.Role_id) {
+var title []TitleItem
+var matches []map[string]string
+
+type ResultItem struct {
+	Uncredited_voiced_character any `json:"uncredited_voiced_character"`
+	Russian_movie               any `json:"russian_movie"`
+}
+
+var result []ResultItem
+
+func main() {
+	failures := 0
+	char_name = _cast[[]Char_nameItem]([]Char_nameItem{Char_nameItem{
+		Id:   1,
+		Name: "Ivan",
+	}, Char_nameItem{
+		Id:   2,
+		Name: "Alex",
+	}})
+	cast_info = _cast[[]Cast_infoItem]([]Cast_infoItem{Cast_infoItem{
+		Movie_id:       10,
+		Person_role_id: 1,
+		Role_id:        1,
+		Note:           "Soldier (voice) (uncredited)",
+	}, Cast_infoItem{
+		Movie_id:       11,
+		Person_role_id: 2,
+		Role_id:        1,
+		Note:           "(voice)",
+	}})
+	company_name = _cast[[]Company_nameItem]([]Company_nameItem{Company_nameItem{
+		Id:           1,
+		Country_code: "[ru]",
+	}, Company_nameItem{
+		Id:           2,
+		Country_code: "[us]",
+	}})
+	company_type = _cast[[]Company_typeItem]([]Company_typeItem{Company_typeItem{Id: 1}, Company_typeItem{Id: 2}})
+	movie_companies = _cast[[]Movie_companiesItem]([]Movie_companiesItem{Movie_companiesItem{
+		Movie_id:        10,
+		Company_id:      1,
+		Company_type_id: 1,
+	}, Movie_companiesItem{
+		Movie_id:        11,
+		Company_id:      2,
+		Company_type_id: 1,
+	}})
+	role_type = _cast[[]Role_typeItem]([]Role_typeItem{Role_typeItem{
+		Id:   1,
+		Role: "actor",
+	}, Role_typeItem{
+		Id:   2,
+		Role: "director",
+	}})
+	title = _cast[[]TitleItem]([]TitleItem{TitleItem{
+		Id:              10,
+		Title:           "Vodka Dreams",
+		Production_year: 2006,
+	}, TitleItem{
+		Id:              11,
+		Title:           "Other Film",
+		Production_year: 2004,
+	}})
+	matches = func() []map[string]string {
+		_res := []map[string]string{}
+		for _, chn := range char_name {
+			for _, ci := range cast_info {
+				if !(chn.Id == ci.Person_role_id) {
 					continue
 				}
-				for _, t := range title {
-					if !(t.Id == ci.Movie_id) {
+				for _, rt := range role_type {
+					if !(rt.Id == ci.Role_id) {
 						continue
 					}
-					for _, mc := range movie_companies {
-						if !(mc.Movie_id == t.Id) {
+					for _, t := range title {
+						if !(t.Id == ci.Movie_id) {
 							continue
 						}
-						for _, cn := range company_name {
-							if !(cn.Id == mc.Company_id) {
+						for _, mc := range movie_companies {
+							if !(mc.Movie_id == t.Id) {
 								continue
 							}
-							if (((strings.Contains(ci.Note, "(voice)") && strings.Contains(ci.Note, "(uncredited)")) && (cn.Country_code == "[ru]")) && (rt.Role == "actor")) && (t.Production_year > 2005) {
-								for _, ct := range company_type {
-									if !(ct.Id == mc.Company_type_id) {
-										continue
+							for _, cn := range company_name {
+								if !(cn.Id == mc.Company_id) {
+									continue
+								}
+								if (((strings.Contains(ci.Note, "(voice)") && strings.Contains(ci.Note, "(uncredited)")) && (cn.Country_code == "[ru]")) && (rt.Role == "actor")) && (t.Production_year > 2005) {
+									for _, ct := range company_type {
+										if !(ct.Id == mc.Company_type_id) {
+											continue
+										}
+										_res = append(_res, map[string]string{"character": chn.Name, "movie": t.Title})
 									}
-									_res = append(_res, map[string]string{"character": chn.Name, "movie": t.Title})
 								}
 							}
 						}
@@ -175,34 +194,24 @@ var matches []map[string]string = func() []map[string]string {
 				}
 			}
 		}
-	}
-	return _res
-}()
-
-type ResultItem struct {
-	Uncredited_voiced_character any `json:"uncredited_voiced_character"`
-	Russian_movie               any `json:"russian_movie"`
-}
-
-var result []ResultItem = []ResultItem{ResultItem{
-	Uncredited_voiced_character: _min(func() []string {
-		_res := []string{}
-		for _, x := range matches {
-			_res = append(_res, x["character"])
-		}
 		return _res
-	}()),
-	Russian_movie: _min(func() []string {
-		_res := []string{}
-		for _, x := range matches {
-			_res = append(_res, x["movie"])
-		}
-		return _res
-	}()),
-}}
-
-func main() {
-	failures := 0
+	}()
+	result = _cast[[]ResultItem]([]ResultItem{ResultItem{
+		Uncredited_voiced_character: _min(func() []string {
+			_res := []string{}
+			for _, x := range matches {
+				_res = append(_res, x["character"])
+			}
+			return _res
+		}()),
+		Russian_movie: _min(func() []string {
+			_res := []string{}
+			for _, x := range matches {
+				_res = append(_res, x["movie"])
+			}
+			return _res
+		}()),
+	}})
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
 		printTestStart("Q10 finds uncredited voice actor in Russian movie")
@@ -226,6 +235,66 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
 }
 
 func _equal(a, b any) bool {

--- a/tests/dataset/job/compiler/go/q10.out
+++ b/tests/dataset/job/compiler/go/q10.out
@@ -1,4 +1,4 @@
 [{"uncredited_voiced_character":"Ivan","russian_movie":"Vodka Dreams"}]
-   test Q10 finds uncredited voice actor in Russian movie ... fail expect failed (3.0µs)
+   test Q10 finds uncredited voice actor in Russian movie ... fail expect failed (4.0µs)
 
 [FAIL] 1 test(s) failed.

--- a/tests/dataset/job/compiler/go/q2.out
+++ b/tests/dataset/job/compiler/go/q2.out
@@ -1,2 +1,2 @@
 "Der Film"
-   test Q2 finds earliest title for German companies with character keyword ... ok (1.0µs)
+   test Q2 finds earliest title for German companies with character keyword ... ok (2.0µs)

--- a/tests/dataset/job/compiler/go/q3.go.out
+++ b/tests/dataset/job/compiler/go/q3.go.out
@@ -40,16 +40,9 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_Q4_returns_minimum_rating_and_title_for_sequels() {
-	expect(_equal(result, []map[string]string{map[string]string{"rating": "6.2", "movie_title": "Alpha Movie"}}))
+func test_Q3_returns_lexicographically_smallest_sequel_title() {
+	expect(_equal(result, []map[string]string{map[string]string{"movie_title": "Alpha"}}))
 }
-
-type Info_typeItem struct {
-	Id   int    `json:"id"`
-	Info string `json:"info"`
-}
-
-var info_type []Info_typeItem
 
 type KeywordItem struct {
 	Id      int    `json:"id"`
@@ -58,13 +51,12 @@ type KeywordItem struct {
 
 var keyword []KeywordItem
 
-type TitleItem struct {
-	Id              int    `json:"id"`
-	Title           string `json:"title"`
-	Production_year int    `json:"production_year"`
+type Movie_infoItem struct {
+	Movie_id int    `json:"movie_id"`
+	Info     string `json:"info"`
 }
 
-var title []TitleItem
+var movie_info []Movie_infoItem
 
 type Movie_keywordItem struct {
 	Movie_id   int `json:"movie_id"`
@@ -73,17 +65,17 @@ type Movie_keywordItem struct {
 
 var movie_keyword []Movie_keywordItem
 
-type Movie_info_idxItem struct {
-	Movie_id     int    `json:"movie_id"`
-	Info_type_id int    `json:"info_type_id"`
-	Info         string `json:"info"`
+type TitleItem struct {
+	Id              int    `json:"id"`
+	Title           string `json:"title"`
+	Production_year int    `json:"production_year"`
 }
 
-var movie_info_idx []Movie_info_idxItem
-var rows []map[string]string
+var title []TitleItem
+var allowed_infos []string
+var candidate_titles []string
 
 type ResultItem struct {
-	Rating      any `json:"rating"`
 	Movie_title any `json:"movie_title"`
 }
 
@@ -91,79 +83,82 @@ var result []ResultItem
 
 func main() {
 	failures := 0
-	info_type = _cast[[]Info_typeItem]([]Info_typeItem{Info_typeItem{
-		Id:   1,
-		Info: "rating",
-	}, Info_typeItem{
-		Id:   2,
-		Info: "other",
-	}})
 	keyword = _cast[[]KeywordItem]([]KeywordItem{KeywordItem{
 		Id:      1,
-		Keyword: "great sequel",
+		Keyword: "amazing sequel",
 	}, KeywordItem{
 		Id:      2,
 		Keyword: "prequel",
 	}})
+	movie_info = _cast[[]Movie_infoItem]([]Movie_infoItem{Movie_infoItem{
+		Movie_id: 10,
+		Info:     "Germany",
+	}, Movie_infoItem{
+		Movie_id: 30,
+		Info:     "Sweden",
+	}, Movie_infoItem{
+		Movie_id: 20,
+		Info:     "France",
+	}})
+	movie_keyword = _cast[[]Movie_keywordItem]([]Movie_keywordItem{
+		Movie_keywordItem{
+			Movie_id:   10,
+			Keyword_id: 1,
+		},
+		Movie_keywordItem{
+			Movie_id:   30,
+			Keyword_id: 1,
+		},
+		Movie_keywordItem{
+			Movie_id:   20,
+			Keyword_id: 1,
+		},
+		Movie_keywordItem{
+			Movie_id:   10,
+			Keyword_id: 2,
+		},
+	})
 	title = _cast[[]TitleItem]([]TitleItem{TitleItem{
 		Id:              10,
-		Title:           "Alpha Movie",
+		Title:           "Alpha",
 		Production_year: 2006,
 	}, TitleItem{
-		Id:              20,
-		Title:           "Beta Film",
-		Production_year: 2007,
-	}, TitleItem{
 		Id:              30,
-		Title:           "Old Film",
-		Production_year: 2004,
+		Title:           "Beta",
+		Production_year: 2008,
+	}, TitleItem{
+		Id:              20,
+		Title:           "Gamma",
+		Production_year: 2009,
 	}})
-	movie_keyword = _cast[[]Movie_keywordItem]([]Movie_keywordItem{Movie_keywordItem{
-		Movie_id:   10,
-		Keyword_id: 1,
-	}, Movie_keywordItem{
-		Movie_id:   20,
-		Keyword_id: 1,
-	}, Movie_keywordItem{
-		Movie_id:   30,
-		Keyword_id: 1,
-	}})
-	movie_info_idx = _cast[[]Movie_info_idxItem]([]Movie_info_idxItem{Movie_info_idxItem{
-		Movie_id:     10,
-		Info_type_id: 1,
-		Info:         "6.2",
-	}, Movie_info_idxItem{
-		Movie_id:     20,
-		Info_type_id: 1,
-		Info:         "7.8",
-	}, Movie_info_idxItem{
-		Movie_id:     30,
-		Info_type_id: 1,
-		Info:         "4.5",
-	}})
-	rows = func() []map[string]string {
-		_res := []map[string]string{}
-		for _, it := range info_type {
-			for _, mi := range movie_info_idx {
-				if !(it.Id == mi.Info_type_id) {
+	allowed_infos = []string{
+		"Sweden",
+		"Norway",
+		"Germany",
+		"Denmark",
+		"Swedish",
+		"Denish",
+		"Norwegian",
+		"German",
+	}
+	candidate_titles = func() []string {
+		_res := []string{}
+		for _, k := range keyword {
+			for _, mk := range movie_keyword {
+				if !(mk.Keyword_id == k.Id) {
 					continue
 				}
-				for _, t := range title {
-					if !(t.Id == mi.Movie_id) {
+				for _, mi := range movie_info {
+					if !(mi.Movie_id == mk.Movie_id) {
 						continue
 					}
-					for _, mk := range movie_keyword {
-						if !(mk.Movie_id == t.Id) {
+					for _, t := range title {
+						if !(t.Id == mi.Movie_id) {
 							continue
 						}
-						for _, k := range keyword {
-							if !(k.Id == mk.Keyword_id) {
-								continue
-							}
-							if ((((it.Info == "rating") && strings.Contains(k.Keyword, "sequel")) && (mi.Info > "5.0")) && (t.Production_year > 2005)) && (mk.Movie_id == mi.Movie_id) {
-								if ((((it.Info == "rating") && strings.Contains(k.Keyword, "sequel")) && (mi.Info > "5.0")) && (t.Production_year > 2005)) && (mk.Movie_id == mi.Movie_id) {
-									_res = append(_res, map[string]string{"rating": mi.Info, "title": t.Title})
-								}
+						if ((strings.Contains(k.Keyword, "sequel") && _contains[string](allowed_infos, mi.Info)) && (t.Production_year > 2005)) && (mk.Movie_id == mi.Movie_id) {
+							if ((strings.Contains(k.Keyword, "sequel") && _contains[string](allowed_infos, mi.Info)) && (t.Production_year > 2005)) && (mk.Movie_id == mi.Movie_id) {
+								_res = append(_res, t.Title)
 							}
 						}
 					}
@@ -172,25 +167,10 @@ func main() {
 		}
 		return _res
 	}()
-	result = _cast[[]ResultItem]([]ResultItem{ResultItem{
-		Rating: _min(func() []string {
-			_res := []string{}
-			for _, r := range rows {
-				_res = append(_res, r["rating"])
-			}
-			return _res
-		}()),
-		Movie_title: _min(func() []string {
-			_res := []string{}
-			for _, r := range rows {
-				_res = append(_res, r["title"])
-			}
-			return _res
-		}()),
-	}})
+	result = _cast[[]ResultItem]([]ResultItem{ResultItem{Movie_title: _min(candidate_titles)}})
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("Q4 returns minimum rating and title for sequels")
+		printTestStart("Q3 returns lexicographically smallest sequel title")
 		start := time.Now()
 		var failed error
 		func() {
@@ -199,7 +179,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_Q4_returns_minimum_rating_and_title_for_sequels()
+			test_Q3_returns_lexicographically_smallest_sequel_title()
 		}()
 		if failed != nil {
 			failures++
@@ -258,6 +238,15 @@ func _cast[T any](v any) T {
 		panic(err)
 	}
 	return out
+}
+
+func _contains[T comparable](s []T, v T) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func _convertMapAny(m map[any]any) map[string]any {

--- a/tests/dataset/job/compiler/go/q3.out
+++ b/tests/dataset/job/compiler/go/q3.out
@@ -1,0 +1,4 @@
+[{"movie_title":"Alpha"}]
+   test Q3 returns lexicographically smallest sequel title ... fail expect failed (6.0µs)
+
+[FAIL] 1 test(s) failed.

--- a/tests/dataset/job/compiler/go/q4.out
+++ b/tests/dataset/job/compiler/go/q4.out
@@ -1,4 +1,4 @@
 [{"rating":"6.2","movie_title":"Alpha Movie"}]
-   test Q4 returns minimum rating and title for sequels ... fail expect failed (2.0µs)
+   test Q4 returns minimum rating and title for sequels ... fail expect failed (4.0µs)
 
 [FAIL] 1 test(s) failed.

--- a/tests/dataset/job/compiler/go/q5.go.out
+++ b/tests/dataset/job/compiler/go/q5.go.out
@@ -40,129 +40,147 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_Q4_returns_minimum_rating_and_title_for_sequels() {
-	expect(_equal(result, []map[string]string{map[string]string{"rating": "6.2", "movie_title": "Alpha Movie"}}))
+func test_Q5_finds_the_lexicographically_first_qualifying_title() {
+	expect(_equal(result, []map[string]string{map[string]string{"typical_european_movie": "A Film"}}))
 }
 
+type Company_typeItem struct {
+	Ct_id int    `json:"ct_id"`
+	Kind  string `json:"kind"`
+}
+
+var company_type []Company_typeItem
+
 type Info_typeItem struct {
-	Id   int    `json:"id"`
-	Info string `json:"info"`
+	It_id int    `json:"it_id"`
+	Info  string `json:"info"`
 }
 
 var info_type []Info_typeItem
 
-type KeywordItem struct {
-	Id      int    `json:"id"`
-	Keyword string `json:"keyword"`
-}
-
-var keyword []KeywordItem
-
 type TitleItem struct {
-	Id              int    `json:"id"`
+	T_id            int    `json:"t_id"`
 	Title           string `json:"title"`
 	Production_year int    `json:"production_year"`
 }
 
 var title []TitleItem
 
-type Movie_keywordItem struct {
-	Movie_id   int `json:"movie_id"`
-	Keyword_id int `json:"keyword_id"`
+type Movie_companiesItem struct {
+	Movie_id        int    `json:"movie_id"`
+	Company_type_id int    `json:"company_type_id"`
+	Note            string `json:"note"`
 }
 
-var movie_keyword []Movie_keywordItem
+var movie_companies []Movie_companiesItem
 
-type Movie_info_idxItem struct {
+type Movie_infoItem struct {
 	Movie_id     int    `json:"movie_id"`
-	Info_type_id int    `json:"info_type_id"`
 	Info         string `json:"info"`
+	Info_type_id int    `json:"info_type_id"`
 }
 
-var movie_info_idx []Movie_info_idxItem
-var rows []map[string]string
+var movie_info []Movie_infoItem
+var candidate_titles []string
 
 type ResultItem struct {
-	Rating      any `json:"rating"`
-	Movie_title any `json:"movie_title"`
+	Typical_european_movie any `json:"typical_european_movie"`
 }
 
 var result []ResultItem
 
 func main() {
 	failures := 0
-	info_type = _cast[[]Info_typeItem]([]Info_typeItem{Info_typeItem{
-		Id:   1,
-		Info: "rating",
-	}, Info_typeItem{
-		Id:   2,
-		Info: "other",
+	company_type = _cast[[]Company_typeItem]([]Company_typeItem{Company_typeItem{
+		Ct_id: 1,
+		Kind:  "production companies",
+	}, Company_typeItem{
+		Ct_id: 2,
+		Kind:  "other",
 	}})
-	keyword = _cast[[]KeywordItem]([]KeywordItem{KeywordItem{
-		Id:      1,
-		Keyword: "great sequel",
-	}, KeywordItem{
-		Id:      2,
-		Keyword: "prequel",
+	info_type = _cast[[]Info_typeItem]([]Info_typeItem{Info_typeItem{
+		It_id: 10,
+		Info:  "languages",
 	}})
 	title = _cast[[]TitleItem]([]TitleItem{TitleItem{
-		Id:              10,
-		Title:           "Alpha Movie",
-		Production_year: 2006,
+		T_id:            100,
+		Title:           "B Movie",
+		Production_year: 2010,
 	}, TitleItem{
-		Id:              20,
-		Title:           "Beta Film",
-		Production_year: 2007,
+		T_id:            200,
+		Title:           "A Film",
+		Production_year: 2012,
 	}, TitleItem{
-		Id:              30,
-		Title:           "Old Film",
-		Production_year: 2004,
+		T_id:            300,
+		Title:           "Old Movie",
+		Production_year: 2000,
 	}})
-	movie_keyword = _cast[[]Movie_keywordItem]([]Movie_keywordItem{Movie_keywordItem{
-		Movie_id:   10,
-		Keyword_id: 1,
-	}, Movie_keywordItem{
-		Movie_id:   20,
-		Keyword_id: 1,
-	}, Movie_keywordItem{
-		Movie_id:   30,
-		Keyword_id: 1,
+	movie_companies = _cast[[]Movie_companiesItem]([]Movie_companiesItem{Movie_companiesItem{
+		Movie_id:        100,
+		Company_type_id: 1,
+		Note:            "ACME (France) (theatrical)",
+	}, Movie_companiesItem{
+		Movie_id:        200,
+		Company_type_id: 1,
+		Note:            "ACME (France) (theatrical)",
+	}, Movie_companiesItem{
+		Movie_id:        300,
+		Company_type_id: 1,
+		Note:            "ACME (France) (theatrical)",
 	}})
-	movie_info_idx = _cast[[]Movie_info_idxItem]([]Movie_info_idxItem{Movie_info_idxItem{
-		Movie_id:     10,
-		Info_type_id: 1,
-		Info:         "6.2",
-	}, Movie_info_idxItem{
-		Movie_id:     20,
-		Info_type_id: 1,
-		Info:         "7.8",
-	}, Movie_info_idxItem{
-		Movie_id:     30,
-		Info_type_id: 1,
-		Info:         "4.5",
+	movie_info = _cast[[]Movie_infoItem]([]Movie_infoItem{Movie_infoItem{
+		Movie_id:     100,
+		Info:         "German",
+		Info_type_id: 10,
+	}, Movie_infoItem{
+		Movie_id:     200,
+		Info:         "Swedish",
+		Info_type_id: 10,
+	}, Movie_infoItem{
+		Movie_id:     300,
+		Info:         "German",
+		Info_type_id: 10,
 	}})
-	rows = func() []map[string]string {
-		_res := []map[string]string{}
-		for _, it := range info_type {
-			for _, mi := range movie_info_idx {
-				if !(it.Id == mi.Info_type_id) {
+	candidate_titles = func() []string {
+		_res := []string{}
+		for _, ct := range company_type {
+			for _, mc := range movie_companies {
+				if !(mc.Company_type_id == ct.Ct_id) {
 					continue
 				}
-				for _, t := range title {
-					if !(t.Id == mi.Movie_id) {
+				for _, mi := range movie_info {
+					if !(mi.Movie_id == mc.Movie_id) {
 						continue
 					}
-					for _, mk := range movie_keyword {
-						if !(mk.Movie_id == t.Id) {
+					for _, it := range info_type {
+						if !(it.It_id == mi.Info_type_id) {
 							continue
 						}
-						for _, k := range keyword {
-							if !(k.Id == mk.Keyword_id) {
+						for _, t := range title {
+							if !(t.T_id == mc.Movie_id) {
 								continue
 							}
-							if ((((it.Info == "rating") && strings.Contains(k.Keyword, "sequel")) && (mi.Info > "5.0")) && (t.Production_year > 2005)) && (mk.Movie_id == mi.Movie_id) {
-								if ((((it.Info == "rating") && strings.Contains(k.Keyword, "sequel")) && (mi.Info > "5.0")) && (t.Production_year > 2005)) && (mk.Movie_id == mi.Movie_id) {
-									_res = append(_res, map[string]string{"rating": mi.Info, "title": t.Title})
+							if ((((ct.Kind == "production companies") && strings.Contains(mc.Note, "(theatrical)")) && strings.Contains(mc.Note, "(France)")) && (t.Production_year > 2005)) && (_contains[string]([]string{
+								"Sweden",
+								"Norway",
+								"Germany",
+								"Denmark",
+								"Swedish",
+								"Denish",
+								"Norwegian",
+								"German",
+							}, mi.Info)) {
+								if ((((ct.Kind == "production companies") && strings.Contains(mc.Note, "(theatrical)")) && strings.Contains(mc.Note, "(France)")) && (t.Production_year > 2005)) && (_contains[string]([]string{
+									"Sweden",
+									"Norway",
+									"Germany",
+									"Denmark",
+									"Swedish",
+									"Denish",
+									"Norwegian",
+									"German",
+								}, mi.Info)) {
+									_res = append(_res, t.Title)
 								}
 							}
 						}
@@ -172,25 +190,10 @@ func main() {
 		}
 		return _res
 	}()
-	result = _cast[[]ResultItem]([]ResultItem{ResultItem{
-		Rating: _min(func() []string {
-			_res := []string{}
-			for _, r := range rows {
-				_res = append(_res, r["rating"])
-			}
-			return _res
-		}()),
-		Movie_title: _min(func() []string {
-			_res := []string{}
-			for _, r := range rows {
-				_res = append(_res, r["title"])
-			}
-			return _res
-		}()),
-	}})
+	result = _cast[[]ResultItem]([]ResultItem{ResultItem{Typical_european_movie: _min(candidate_titles)}})
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("Q4 returns minimum rating and title for sequels")
+		printTestStart("Q5 finds the lexicographically first qualifying title")
 		start := time.Now()
 		var failed error
 		func() {
@@ -199,7 +202,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_Q4_returns_minimum_rating_and_title_for_sequels()
+			test_Q5_finds_the_lexicographically_first_qualifying_title()
 		}()
 		if failed != nil {
 			failures++
@@ -258,6 +261,15 @@ func _cast[T any](v any) T {
 		panic(err)
 	}
 	return out
+}
+
+func _contains[T comparable](s []T, v T) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func _convertMapAny(m map[any]any) map[string]any {

--- a/tests/dataset/job/compiler/go/q5.out
+++ b/tests/dataset/job/compiler/go/q5.out
@@ -1,0 +1,4 @@
+[{"typical_european_movie":"A Film"}]
+   test Q5 finds the lexicographically first qualifying title ... fail expect failed (5.0µs)
+
+[FAIL] 1 test(s) failed.

--- a/tests/dataset/job/compiler/go/q6.go.out
+++ b/tests/dataset/job/compiler/go/q6.go.out
@@ -52,52 +52,28 @@ type Cast_infoItem struct {
 	Person_id int `json:"person_id"`
 }
 
-var cast_info []Cast_infoItem = []Cast_infoItem{Cast_infoItem{
-	Movie_id:  1,
-	Person_id: 101,
-}, Cast_infoItem{
-	Movie_id:  2,
-	Person_id: 102,
-}}
+var cast_info []Cast_infoItem
 
 type KeywordItem struct {
 	Id      int    `json:"id"`
 	Keyword string `json:"keyword"`
 }
 
-var keyword []KeywordItem = []KeywordItem{KeywordItem{
-	Id:      100,
-	Keyword: "marvel-cinematic-universe",
-}, KeywordItem{
-	Id:      200,
-	Keyword: "other",
-}}
+var keyword []KeywordItem
 
 type Movie_keywordItem struct {
 	Movie_id   int `json:"movie_id"`
 	Keyword_id int `json:"keyword_id"`
 }
 
-var movie_keyword []Movie_keywordItem = []Movie_keywordItem{Movie_keywordItem{
-	Movie_id:   1,
-	Keyword_id: 100,
-}, Movie_keywordItem{
-	Movie_id:   2,
-	Keyword_id: 200,
-}}
+var movie_keyword []Movie_keywordItem
 
 type NameItem struct {
 	Id   int    `json:"id"`
 	Name string `json:"name"`
 }
 
-var name []NameItem = []NameItem{NameItem{
-	Id:   101,
-	Name: "Downey Robert Jr.",
-}, NameItem{
-	Id:   102,
-	Name: "Chris Evans",
-}}
+var name []NameItem
 
 type TitleItem struct {
 	Id              int    `json:"id"`
@@ -105,53 +81,83 @@ type TitleItem struct {
 	Production_year int    `json:"production_year"`
 }
 
-var title []TitleItem = []TitleItem{TitleItem{
-	Id:              1,
-	Title:           "Iron Man 3",
-	Production_year: 2013,
-}, TitleItem{
-	Id:              2,
-	Title:           "Old Movie",
-	Production_year: 2000,
-}}
-var result []map[string]string = func() []map[string]string {
-	_res := []map[string]string{}
-	for _, ci := range cast_info {
-		for _, mk := range movie_keyword {
-			if !(ci.Movie_id == mk.Movie_id) {
-				continue
-			}
-			for _, k := range keyword {
-				if !(mk.Keyword_id == k.Id) {
+var title []TitleItem
+var result []map[string]string
+
+func main() {
+	failures := 0
+	cast_info = _cast[[]Cast_infoItem]([]Cast_infoItem{Cast_infoItem{
+		Movie_id:  1,
+		Person_id: 101,
+	}, Cast_infoItem{
+		Movie_id:  2,
+		Person_id: 102,
+	}})
+	keyword = _cast[[]KeywordItem]([]KeywordItem{KeywordItem{
+		Id:      100,
+		Keyword: "marvel-cinematic-universe",
+	}, KeywordItem{
+		Id:      200,
+		Keyword: "other",
+	}})
+	movie_keyword = _cast[[]Movie_keywordItem]([]Movie_keywordItem{Movie_keywordItem{
+		Movie_id:   1,
+		Keyword_id: 100,
+	}, Movie_keywordItem{
+		Movie_id:   2,
+		Keyword_id: 200,
+	}})
+	name = _cast[[]NameItem]([]NameItem{NameItem{
+		Id:   101,
+		Name: "Downey Robert Jr.",
+	}, NameItem{
+		Id:   102,
+		Name: "Chris Evans",
+	}})
+	title = _cast[[]TitleItem]([]TitleItem{TitleItem{
+		Id:              1,
+		Title:           "Iron Man 3",
+		Production_year: 2013,
+	}, TitleItem{
+		Id:              2,
+		Title:           "Old Movie",
+		Production_year: 2000,
+	}})
+	result = func() []map[string]string {
+		_res := []map[string]string{}
+		for _, ci := range cast_info {
+			for _, mk := range movie_keyword {
+				if !(ci.Movie_id == mk.Movie_id) {
 					continue
 				}
-				for _, n := range name {
-					if !(ci.Person_id == n.Id) {
+				for _, k := range keyword {
+					if !(mk.Keyword_id == k.Id) {
 						continue
 					}
-					for _, t := range title {
-						if !(ci.Movie_id == t.Id) {
+					for _, n := range name {
+						if !(ci.Person_id == n.Id) {
 							continue
 						}
-						if (((k.Keyword == "marvel-cinematic-universe") && strings.Contains(n.Name, "Downey")) && strings.Contains(n.Name, "Robert")) && (t.Production_year > 2010) {
+						for _, t := range title {
+							if !(ci.Movie_id == t.Id) {
+								continue
+							}
 							if (((k.Keyword == "marvel-cinematic-universe") && strings.Contains(n.Name, "Downey")) && strings.Contains(n.Name, "Robert")) && (t.Production_year > 2010) {
-								_res = append(_res, map[string]string{
-									"movie_keyword": k.Keyword,
-									"actor_name":    n.Name,
-									"marvel_movie":  t.Title,
-								})
+								if (((k.Keyword == "marvel-cinematic-universe") && strings.Contains(n.Name, "Downey")) && strings.Contains(n.Name, "Robert")) && (t.Production_year > 2010) {
+									_res = append(_res, map[string]string{
+										"movie_keyword": k.Keyword,
+										"actor_name":    n.Name,
+										"marvel_movie":  t.Title,
+									})
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-	}
-	return _res
-}()
-
-func main() {
-	failures := 0
+		return _res
+	}()
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
 		printTestStart("Q6 finds marvel movie with Robert Downey")
@@ -175,6 +181,66 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
 }
 
 func _equal(a, b any) bool {

--- a/tests/dataset/job/compiler/go/q6.out
+++ b/tests/dataset/job/compiler/go/q6.out
@@ -1,2 +1,2 @@
 [{"actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3","movie_keyword":"marvel-cinematic-universe"}]
-   test Q6 finds marvel movie with Robert Downey ... ok (8.0µs)
+   test Q6 finds marvel movie with Robert Downey ... ok (66.0µs)

--- a/tests/dataset/job/compiler/go/q8.go.out
+++ b/tests/dataset/job/compiler/go/q8.go.out
@@ -49,10 +49,7 @@ type Aka_nameItem struct {
 	Name      string `json:"name"`
 }
 
-var aka_name []Aka_nameItem = []Aka_nameItem{Aka_nameItem{
-	Person_id: 1,
-	Name:      "Y. S.",
-}}
+var aka_name []Aka_nameItem
 
 type Cast_infoItem struct {
 	Person_id int    `json:"person_id"`
@@ -61,22 +58,14 @@ type Cast_infoItem struct {
 	Role_id   int    `json:"role_id"`
 }
 
-var cast_info []Cast_infoItem = []Cast_infoItem{Cast_infoItem{
-	Person_id: 1,
-	Movie_id:  10,
-	Note:      "(voice: English version)",
-	Role_id:   1000,
-}}
+var cast_info []Cast_infoItem
 
 type Company_nameItem struct {
 	Id           int    `json:"id"`
 	Country_code string `json:"country_code"`
 }
 
-var company_name []Company_nameItem = []Company_nameItem{Company_nameItem{
-	Id:           50,
-	Country_code: "[jp]",
-}}
+var company_name []Company_nameItem
 
 type Movie_companiesItem struct {
 	Movie_id   int    `json:"movie_id"`
@@ -84,74 +73,104 @@ type Movie_companiesItem struct {
 	Note       string `json:"note"`
 }
 
-var movie_companies []Movie_companiesItem = []Movie_companiesItem{Movie_companiesItem{
-	Movie_id:   10,
-	Company_id: 50,
-	Note:       "Studio (Japan)",
-}}
+var movie_companies []Movie_companiesItem
 
 type NameItem struct {
 	Id   int    `json:"id"`
 	Name string `json:"name"`
 }
 
-var name []NameItem = []NameItem{NameItem{
-	Id:   1,
-	Name: "Yoko Ono",
-}, NameItem{
-	Id:   2,
-	Name: "Yuichi",
-}}
+var name []NameItem
 
 type Role_typeItem struct {
 	Id   int    `json:"id"`
 	Role string `json:"role"`
 }
 
-var role_type []Role_typeItem = []Role_typeItem{Role_typeItem{
-	Id:   1000,
-	Role: "actress",
-}}
+var role_type []Role_typeItem
 
 type TitleItem struct {
 	Id    int    `json:"id"`
 	Title string `json:"title"`
 }
 
-var title []TitleItem = []TitleItem{TitleItem{
-	Id:    10,
-	Title: "Dubbed Film",
-}}
-var eligible []map[string]string = func() []map[string]string {
-	_res := []map[string]string{}
-	for _, an1 := range aka_name {
-		for _, n1 := range name {
-			if !(n1.Id == an1.Person_id) {
-				continue
-			}
-			for _, ci := range cast_info {
-				if !(ci.Person_id == an1.Person_id) {
+var title []TitleItem
+var eligible []map[string]string
+
+type ResultItem struct {
+	Actress_pseudonym     any `json:"actress_pseudonym"`
+	Japanese_movie_dubbed any `json:"japanese_movie_dubbed"`
+}
+
+var result []ResultItem
+
+func main() {
+	failures := 0
+	aka_name = _cast[[]Aka_nameItem]([]Aka_nameItem{Aka_nameItem{
+		Person_id: 1,
+		Name:      "Y. S.",
+	}})
+	cast_info = _cast[[]Cast_infoItem]([]Cast_infoItem{Cast_infoItem{
+		Person_id: 1,
+		Movie_id:  10,
+		Note:      "(voice: English version)",
+		Role_id:   1000,
+	}})
+	company_name = _cast[[]Company_nameItem]([]Company_nameItem{Company_nameItem{
+		Id:           50,
+		Country_code: "[jp]",
+	}})
+	movie_companies = _cast[[]Movie_companiesItem]([]Movie_companiesItem{Movie_companiesItem{
+		Movie_id:   10,
+		Company_id: 50,
+		Note:       "Studio (Japan)",
+	}})
+	name = _cast[[]NameItem]([]NameItem{NameItem{
+		Id:   1,
+		Name: "Yoko Ono",
+	}, NameItem{
+		Id:   2,
+		Name: "Yuichi",
+	}})
+	role_type = _cast[[]Role_typeItem]([]Role_typeItem{Role_typeItem{
+		Id:   1000,
+		Role: "actress",
+	}})
+	title = _cast[[]TitleItem]([]TitleItem{TitleItem{
+		Id:    10,
+		Title: "Dubbed Film",
+	}})
+	eligible = func() []map[string]string {
+		_res := []map[string]string{}
+		for _, an1 := range aka_name {
+			for _, n1 := range name {
+				if !(n1.Id == an1.Person_id) {
 					continue
 				}
-				for _, t := range title {
-					if !(t.Id == ci.Movie_id) {
+				for _, ci := range cast_info {
+					if !(ci.Person_id == an1.Person_id) {
 						continue
 					}
-					for _, mc := range movie_companies {
-						if !(mc.Movie_id == ci.Movie_id) {
+					for _, t := range title {
+						if !(t.Id == ci.Movie_id) {
 							continue
 						}
-						for _, cn := range company_name {
-							if !(cn.Id == mc.Company_id) {
+						for _, mc := range movie_companies {
+							if !(mc.Movie_id == ci.Movie_id) {
 								continue
 							}
-							for _, rt := range role_type {
-								if !(rt.Id == ci.Role_id) {
+							for _, cn := range company_name {
+								if !(cn.Id == mc.Company_id) {
 									continue
 								}
-								if ((((((ci.Note == "(voice: English version)") && (cn.Country_code == "[jp]")) && strings.Contains(mc.Note, "(Japan)")) && (!strings.Contains(mc.Note, "(USA)"))) && strings.Contains(n1.Name, "Yo")) && (!strings.Contains(n1.Name, "Yu"))) && (rt.Role == "actress") {
+								for _, rt := range role_type {
+									if !(rt.Id == ci.Role_id) {
+										continue
+									}
 									if ((((((ci.Note == "(voice: English version)") && (cn.Country_code == "[jp]")) && strings.Contains(mc.Note, "(Japan)")) && (!strings.Contains(mc.Note, "(USA)"))) && strings.Contains(n1.Name, "Yo")) && (!strings.Contains(n1.Name, "Yu"))) && (rt.Role == "actress") {
-										_res = append(_res, map[string]string{"pseudonym": an1.Name, "movie_title": t.Title})
+										if ((((((ci.Note == "(voice: English version)") && (cn.Country_code == "[jp]")) && strings.Contains(mc.Note, "(Japan)")) && (!strings.Contains(mc.Note, "(USA)"))) && strings.Contains(n1.Name, "Yo")) && (!strings.Contains(n1.Name, "Yu"))) && (rt.Role == "actress") {
+											_res = append(_res, map[string]string{"pseudonym": an1.Name, "movie_title": t.Title})
+										}
 									}
 								}
 							}
@@ -160,34 +179,24 @@ var eligible []map[string]string = func() []map[string]string {
 				}
 			}
 		}
-	}
-	return _res
-}()
-
-type ResultItem struct {
-	Actress_pseudonym     any `json:"actress_pseudonym"`
-	Japanese_movie_dubbed any `json:"japanese_movie_dubbed"`
-}
-
-var result []ResultItem = []ResultItem{ResultItem{
-	Actress_pseudonym: _min(func() []string {
-		_res := []string{}
-		for _, x := range eligible {
-			_res = append(_res, x["pseudonym"])
-		}
 		return _res
-	}()),
-	Japanese_movie_dubbed: _min(func() []string {
-		_res := []string{}
-		for _, x := range eligible {
-			_res = append(_res, x["movie_title"])
-		}
-		return _res
-	}()),
-}}
-
-func main() {
-	failures := 0
+	}()
+	result = _cast[[]ResultItem]([]ResultItem{ResultItem{
+		Actress_pseudonym: _min(func() []string {
+			_res := []string{}
+			for _, x := range eligible {
+				_res = append(_res, x["pseudonym"])
+			}
+			return _res
+		}()),
+		Japanese_movie_dubbed: _min(func() []string {
+			_res := []string{}
+			for _, x := range eligible {
+				_res = append(_res, x["movie_title"])
+			}
+			return _res
+		}()),
+	}})
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
 		printTestStart("Q8 returns the pseudonym and movie title for Japanese dubbing")
@@ -211,6 +220,66 @@ func main() {
 	if failures > 0 {
 		fmt.Printf("\n[FAIL] %d test(s) failed.\n", failures)
 	}
+}
+
+func _cast[T any](v any) T {
+	if tv, ok := v.(T); ok {
+		return tv
+	}
+	var out T
+	switch any(out).(type) {
+	case int:
+		switch vv := v.(type) {
+		case int:
+			return any(vv).(T)
+		case float64:
+			return any(int(vv)).(T)
+		case float32:
+			return any(int(vv)).(T)
+		}
+	case float64:
+		switch vv := v.(type) {
+		case int:
+			return any(float64(vv)).(T)
+		case float64:
+			return any(vv).(T)
+		case float32:
+			return any(float64(vv)).(T)
+		}
+	case float32:
+		switch vv := v.(type) {
+		case int:
+			return any(float32(vv)).(T)
+		case float64:
+			return any(float32(vv)).(T)
+		case float32:
+			return any(vv).(T)
+		}
+	}
+	if m, ok := v.(map[any]any); ok {
+		v = _convertMapAny(m)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func _convertMapAny(m map[any]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		key := fmt.Sprint(k)
+		if sub, ok := v.(map[any]any); ok {
+			out[key] = _convertMapAny(sub)
+		} else {
+			out[key] = v
+		}
+	}
+	return out
 }
 
 func _equal(a, b any) bool {

--- a/tests/dataset/job/compiler/go/q8.out
+++ b/tests/dataset/job/compiler/go/q8.out
@@ -1,4 +1,4 @@
 [{"actress_pseudonym":"Y. S.","japanese_movie_dubbed":"Dubbed Film"}]
-   test Q8 returns the pseudonym and movie title for Japanese dubbing ... fail expect failed (3.0µs)
+   test Q8 returns the pseudonym and movie title for Japanese dubbing ... fail expect failed (4.0µs)
 
 [FAIL] 1 test(s) failed.

--- a/tests/dataset/job/compiler/go/q9.go.out
+++ b/tests/dataset/job/compiler/go/q9.go.out
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mochi/runtime/data"
 	"reflect"
+	"strings"
 	"time"
 )
 
@@ -39,9 +40,37 @@ func printTestFail(err error, d time.Duration) {
 	fmt.Printf(" fail %v (%s)\n", err, formatDuration(d))
 }
 
-func test_Q2_finds_earliest_title_for_German_companies_with_character_keyword() {
-	expect(_equal(result, "Der Film"))
+func test_Q9_selects_minimal_alternative_name__character_and_movie() {
+	expect(_equal(result, []map[string]string{map[string]string{
+		"alternative_name": "A. N. G.",
+		"character_name":   "Angel",
+		"movie":            "Famous Film",
+	}}))
 }
+
+type Aka_nameItem struct {
+	Person_id int    `json:"person_id"`
+	Name      string `json:"name"`
+}
+
+var aka_name []Aka_nameItem
+
+type Char_nameItem struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+var char_name []Char_nameItem
+
+type Cast_infoItem struct {
+	Person_id      int    `json:"person_id"`
+	Person_role_id int    `json:"person_role_id"`
+	Movie_id       int    `json:"movie_id"`
+	Role_id        int    `json:"role_id"`
+	Note           string `json:"note"`
+}
+
+var cast_info []Cast_infoItem
 
 type Company_nameItem struct {
 	Id           int    `json:"id"`
@@ -50,95 +79,167 @@ type Company_nameItem struct {
 
 var company_name []Company_nameItem
 
-type KeywordItem struct {
-	Id      int    `json:"id"`
-	Keyword string `json:"keyword"`
-}
-
-var keyword []KeywordItem
-
 type Movie_companiesItem struct {
-	Movie_id   int `json:"movie_id"`
-	Company_id int `json:"company_id"`
+	Movie_id   int    `json:"movie_id"`
+	Company_id int    `json:"company_id"`
+	Note       string `json:"note"`
 }
 
 var movie_companies []Movie_companiesItem
 
-type Movie_keywordItem struct {
-	Movie_id   int `json:"movie_id"`
-	Keyword_id int `json:"keyword_id"`
+type NameItem struct {
+	Id     int    `json:"id"`
+	Name   string `json:"name"`
+	Gender string `json:"gender"`
 }
 
-var movie_keyword []Movie_keywordItem
+var name []NameItem
+
+type Role_typeItem struct {
+	Id   int    `json:"id"`
+	Role string `json:"role"`
+}
+
+var role_type []Role_typeItem
 
 type TitleItem struct {
-	Id    int    `json:"id"`
-	Title string `json:"title"`
+	Id              int    `json:"id"`
+	Title           string `json:"title"`
+	Production_year int    `json:"production_year"`
 }
 
 var title []TitleItem
-var titles []string
-var result any
+var matches []map[string]string
+
+type ResultItem struct {
+	Alternative_name any `json:"alternative_name"`
+	Character_name   any `json:"character_name"`
+	Movie            any `json:"movie"`
+}
+
+var result []ResultItem
 
 func main() {
 	failures := 0
-	company_name = _cast[[]Company_nameItem]([]Company_nameItem{Company_nameItem{
-		Id:           1,
-		Country_code: "[de]",
-	}, Company_nameItem{
-		Id:           2,
-		Country_code: "[us]",
+	aka_name = _cast[[]Aka_nameItem]([]Aka_nameItem{Aka_nameItem{
+		Person_id: 1,
+		Name:      "A. N. G.",
+	}, Aka_nameItem{
+		Person_id: 2,
+		Name:      "J. D.",
 	}})
-	keyword = _cast[[]KeywordItem]([]KeywordItem{KeywordItem{
-		Id:      1,
-		Keyword: "character-name-in-title",
-	}, KeywordItem{
-		Id:      2,
-		Keyword: "other",
+	char_name = _cast[[]Char_nameItem]([]Char_nameItem{Char_nameItem{
+		Id:   10,
+		Name: "Angel",
+	}, Char_nameItem{
+		Id:   20,
+		Name: "Devil",
+	}})
+	cast_info = _cast[[]Cast_infoItem]([]Cast_infoItem{Cast_infoItem{
+		Person_id:      1,
+		Person_role_id: 10,
+		Movie_id:       100,
+		Role_id:        1000,
+		Note:           "(voice)",
+	}, Cast_infoItem{
+		Person_id:      2,
+		Person_role_id: 20,
+		Movie_id:       200,
+		Role_id:        1000,
+		Note:           "(voice)",
+	}})
+	company_name = _cast[[]Company_nameItem]([]Company_nameItem{Company_nameItem{
+		Id:           100,
+		Country_code: "[us]",
+	}, Company_nameItem{
+		Id:           200,
+		Country_code: "[gb]",
 	}})
 	movie_companies = _cast[[]Movie_companiesItem]([]Movie_companiesItem{Movie_companiesItem{
 		Movie_id:   100,
-		Company_id: 1,
+		Company_id: 100,
+		Note:       "ACME Studios (USA)",
 	}, Movie_companiesItem{
 		Movie_id:   200,
-		Company_id: 2,
+		Company_id: 200,
+		Note:       "Maple Films",
 	}})
-	movie_keyword = _cast[[]Movie_keywordItem]([]Movie_keywordItem{Movie_keywordItem{
-		Movie_id:   100,
-		Keyword_id: 1,
-	}, Movie_keywordItem{
-		Movie_id:   200,
-		Keyword_id: 2,
+	name = _cast[[]NameItem]([]NameItem{NameItem{
+		Id:     1,
+		Name:   "Angela Smith",
+		Gender: "f",
+	}, NameItem{
+		Id:     2,
+		Name:   "John Doe",
+		Gender: "m",
+	}})
+	role_type = _cast[[]Role_typeItem]([]Role_typeItem{Role_typeItem{
+		Id:   1000,
+		Role: "actress",
+	}, Role_typeItem{
+		Id:   2000,
+		Role: "actor",
 	}})
 	title = _cast[[]TitleItem]([]TitleItem{TitleItem{
-		Id:    100,
-		Title: "Der Film",
+		Id:              100,
+		Title:           "Famous Film",
+		Production_year: 2010,
 	}, TitleItem{
-		Id:    200,
-		Title: "Other Movie",
+		Id:              200,
+		Title:           "Old Movie",
+		Production_year: 1999,
 	}})
-	titles = func() []string {
-		_res := []string{}
-		for _, cn := range company_name {
-			for _, mc := range movie_companies {
-				if !(mc.Company_id == cn.Id) {
+	matches = func() []map[string]string {
+		_res := []map[string]string{}
+		for _, an := range aka_name {
+			for _, n := range name {
+				if !(an.Person_id == n.Id) {
 					continue
 				}
-				for _, t := range title {
-					if !(mc.Movie_id == t.Id) {
+				for _, ci := range cast_info {
+					if !(ci.Person_id == n.Id) {
 						continue
 					}
-					for _, mk := range movie_keyword {
-						if !(mk.Movie_id == t.Id) {
+					for _, chn := range char_name {
+						if !(chn.Id == ci.Person_role_id) {
 							continue
 						}
-						for _, k := range keyword {
-							if !(mk.Keyword_id == k.Id) {
+						for _, t := range title {
+							if !(t.Id == ci.Movie_id) {
 								continue
 							}
-							if ((cn.Country_code == "[de]") && (k.Keyword == "character-name-in-title")) && (mc.Movie_id == mk.Movie_id) {
-								if ((cn.Country_code == "[de]") && (k.Keyword == "character-name-in-title")) && (mc.Movie_id == mk.Movie_id) {
-									_res = append(_res, t.Title)
+							for _, mc := range movie_companies {
+								if !(mc.Movie_id == t.Id) {
+									continue
+								}
+								for _, cn := range company_name {
+									if !(cn.Id == mc.Company_id) {
+										continue
+									}
+									for _, rt := range role_type {
+										if !(rt.Id == ci.Role_id) {
+											continue
+										}
+										if (((((((_contains[string]([]string{
+											"(voice)",
+											"(voice: Japanese version)",
+											"(voice) (uncredited)",
+											"(voice: English version)",
+										}, ci.Note)) && (cn.Country_code == "[us]")) && (strings.Contains(mc.Note, "(USA)") || strings.Contains(mc.Note, "(worldwide)"))) && (n.Gender == "f")) && strings.Contains(n.Name, "Ang")) && (rt.Role == "actress")) && (t.Production_year >= 2005)) && (t.Production_year <= 2015) {
+											if (((((((_contains[string]([]string{
+												"(voice)",
+												"(voice: Japanese version)",
+												"(voice) (uncredited)",
+												"(voice: English version)",
+											}, ci.Note)) && (cn.Country_code == "[us]")) && (strings.Contains(mc.Note, "(USA)") || strings.Contains(mc.Note, "(worldwide)"))) && (n.Gender == "f")) && strings.Contains(n.Name, "Ang")) && (rt.Role == "actress")) && (t.Production_year >= 2005)) && (t.Production_year <= 2015) {
+												_res = append(_res, map[string]string{
+													"alt":       an.Name,
+													"character": chn.Name,
+													"movie":     t.Title,
+												})
+											}
+										}
+									}
 								}
 							}
 						}
@@ -148,10 +249,32 @@ func main() {
 		}
 		return _res
 	}()
-	result = _min(titles)
+	result = _cast[[]ResultItem]([]ResultItem{ResultItem{
+		Alternative_name: _min(func() []string {
+			_res := []string{}
+			for _, x := range matches {
+				_res = append(_res, x["alt"])
+			}
+			return _res
+		}()),
+		Character_name: _min(func() []string {
+			_res := []string{}
+			for _, x := range matches {
+				_res = append(_res, x["character"])
+			}
+			return _res
+		}()),
+		Movie: _min(func() []string {
+			_res := []string{}
+			for _, x := range matches {
+				_res = append(_res, x["movie"])
+			}
+			return _res
+		}()),
+	}})
 	func() { b, _ := json.Marshal(result); fmt.Println(string(b)) }()
 	{
-		printTestStart("Q2 finds earliest title for German companies with character keyword")
+		printTestStart("Q9 selects minimal alternative name, character and movie")
 		start := time.Now()
 		var failed error
 		func() {
@@ -160,7 +283,7 @@ func main() {
 					failed = fmt.Errorf("%v", r)
 				}
 			}()
-			test_Q2_finds_earliest_title_for_German_companies_with_character_keyword()
+			test_Q9_selects_minimal_alternative_name__character_and_movie()
 		}()
 		if failed != nil {
 			failures++
@@ -219,6 +342,15 @@ func _cast[T any](v any) T {
 		panic(err)
 	}
 	return out
+}
+
+func _contains[T comparable](s []T, v T) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func _convertMapAny(m map[any]any) map[string]any {

--- a/tests/dataset/job/compiler/go/q9.out
+++ b/tests/dataset/job/compiler/go/q9.out
@@ -1,0 +1,4 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]
+   test Q9 selects minimal alternative name, character and movie ... fail expect failed (4.0µs)
+
+[FAIL] 1 test(s) failed.


### PR DESCRIPTION
## Summary
- allow global statements with complex expressions by deferring init to main
- add `_contains` helper for list membership and use it for `in` expressions
- update JOB compiler golden files for Go backend
- document remaining failing JOB queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e8a2b3db48320a288d5dde49880ef