### PR TITLE
Add JOB compiler golden tests for Dart

### DIFF
--- a/compile/x/dart/TASKS.md
+++ b/compile/x/dart/TASKS.md
@@ -11,3 +11,11 @@ Completed tasks:
 - [x] Add `_Group.count`, `_Group.sum` and `_Group.avg` methods.
 - [x] Generate typed structs for dataset rows and register parsers.
 - [x] Add golden test `tpch_q1_test.go` and sample generated code.
+
+## Remaining work for JOB queries
+
+The JOB dataset queries up to `q10` compile but running the generated Dart code
+fails because dataset rows are translated to dynamic maps. The compiler needs to
+generate typed structs for the JOB schemas and adjust field access accordingly.
+Once struct generation works the tests in `job_test.go` should execute without
+skipping for `q1`–`q10`.

--- a/compile/x/dart/job_test.go
+++ b/compile/x/dart/job_test.go
@@ -19,7 +19,7 @@ func TestDartCompiler_JOB(t *testing.T) {
 		t.Skipf("dart not installed: %v", err)
 	}
 	root := findRoot(t)
-	for _, q := range []string{"q1", "q2"} {
+       for _, q := range []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10"} {
 		src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
 		prog, err := parser.Parse(src)
 		if err != nil {

--- a/tests/dataset/job/compiler/dart/q10.dart.out
+++ b/tests/dataset/job/compiler/dart/q10.dart.out
@@ -1,0 +1,129 @@
+import 'dart:io';
+import 'dart:convert';
+
+void test_Q10_finds_uncredited_voice_actor_in_Russian_movie() {
+  if (!(_equal(result, [{"uncredited_voiced_character": "Ivan", "russian_movie": "Vodka Dreams"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, dynamic>> char_name = [{"id": 1, "name": "Ivan"}, {"id": 2, "name": "Alex"}];
+  List<Map<String, dynamic>> cast_info = [{"movie_id": 10, "person_role_id": 1, "role_id": 1, "note": "Soldier (voice) (uncredited)"}, {"movie_id": 11, "person_role_id": 2, "role_id": 1, "note": "(voice)"}];
+  List<Map<String, dynamic>> company_name = [{"id": 1, "country_code": "[ru]"}, {"id": 2, "country_code": "[us]"}];
+  List<Map<String, int>> company_type = [{"id": 1}, {"id": 2}];
+  List<Map<String, int>> movie_companies = [{"movie_id": 10, "company_id": 1, "company_type_id": 1}, {"movie_id": 11, "company_id": 2, "company_type_id": 1}];
+  List<Map<String, dynamic>> role_type = [{"id": 1, "role": "actor"}, {"id": 2, "role": "director"}];
+  List<Map<String, dynamic>> title = [{"id": 10, "title": "Vodka Dreams", "production_year": 2006}, {"id": 11, "title": "Other Film", "production_year": 2004}];
+  List<Map<String, dynamic>> matches = (() {
+  var _res = [];
+  for (var chn in char_name) {
+    for (var ci in cast_info) {
+      if (!(_equal(chn.id, ci.person_role_id))) {
+        continue;
+      }
+      for (var rt in role_type) {
+        if (!(_equal(rt.id, ci.role_id))) {
+          continue;
+        }
+        for (var t in title) {
+          if (!(_equal(t.id, ci.movie_id))) {
+            continue;
+          }
+          for (var mc in movie_companies) {
+            if (!(_equal(mc.movie_id, t.id))) {
+              continue;
+            }
+            for (var cn in company_name) {
+              if (!(_equal(cn.id, mc.company_id))) {
+                continue;
+              }
+              for (var ct in company_type) {
+                if (!(_equal(ct.id, mc.company_type_id))) {
+                  continue;
+                }
+                if (!(((((ci.note.contains("(voice)") && ci.note.contains("(uncredited)")) && _equal(cn.country_code, "[ru]")) && _equal(rt.role, "actor")) && (t.production_year > 2005)))) {
+                  continue;
+                }
+                _res.add({"character": chn.name, "movie": t.title});
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  List<Map<String, dynamic>> result = [{"uncredited_voiced_character": _min((() {
+  var _res = [];
+  for (var x in matches) {
+    _res.add(x.character);
+  }
+  return _res;
+})()), "russian_movie": _min((() {
+  var _res = [];
+  for (var x in matches) {
+    _res.add(x.movie);
+  }
+  return _res;
+})())}];
+  _json(result);
+  if (!_runTest("Q10 finds uncredited voice actor in Russian movie", test_Q10_finds_uncredited_voice_actor_in_Russian_movie)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+dynamic _min(dynamic v) {
+    List<dynamic>? list;
+    if (v is List) list = v;
+    else if (v is Map && v['items'] is List) list = (v['items'] as List);
+    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);
+    else if (v is _Group) list = v.Items;
+    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }
+    if (list == null || list.isEmpty) return 0;
+    var m = list[0];
+    for (var n in list) { if ((n as Comparable).compareTo(m) < 0) m = n; }
+    return m;
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q10.out
+++ b/tests/dataset/job/compiler/dart/q10.out
@@ -1,0 +1,1 @@
+[{"russian_movie":"Vodka Dreams","uncredited_voiced_character":"Ivan"}]

--- a/tests/dataset/job/compiler/dart/q3.dart.out
+++ b/tests/dataset/job/compiler/dart/q3.dart.out
@@ -1,0 +1,100 @@
+import 'dart:io';
+import 'dart:convert';
+
+void test_Q3_returns_lexicographically_smallest_sequel_title() {
+  if (!(_equal(result, [{"movie_title": "Alpha"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, dynamic>> keyword = [{"id": 1, "keyword": "amazing sequel"}, {"id": 2, "keyword": "prequel"}];
+  List<Map<String, dynamic>> movie_info = [{"movie_id": 10, "info": "Germany"}, {"movie_id": 30, "info": "Sweden"}, {"movie_id": 20, "info": "France"}];
+  List<Map<String, int>> movie_keyword = [{"movie_id": 10, "keyword_id": 1}, {"movie_id": 30, "keyword_id": 1}, {"movie_id": 20, "keyword_id": 1}, {"movie_id": 10, "keyword_id": 2}];
+  List<Map<String, dynamic>> title = [{"id": 10, "title": "Alpha", "production_year": 2006}, {"id": 30, "title": "Beta", "production_year": 2008}, {"id": 20, "title": "Gamma", "production_year": 2009}];
+  List<String> allowed_infos = ["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"];
+  List candidate_titles = (() {
+  var _res = [];
+  for (var k in keyword) {
+    for (var mk in movie_keyword) {
+      if (!(_equal(mk.keyword_id, k.id))) {
+        continue;
+      }
+      for (var mi in movie_info) {
+        if (!(_equal(mi.movie_id, mk.movie_id))) {
+          continue;
+        }
+        for (var t in title) {
+          if (!(_equal(t.id, mi.movie_id))) {
+            continue;
+          }
+          if (!((((k.keyword.contains("sequel") && (allowed_infos.contains(mi.info))) && (t.production_year > 2005)) && _equal(mk.movie_id, mi.movie_id)))) {
+            continue;
+          }
+          _res.add(t.title);
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  List<Map<String, dynamic>> result = [{"movie_title": _min(candidate_titles)}];
+  _json(result);
+  if (!_runTest("Q3 returns lexicographically smallest sequel title", test_Q3_returns_lexicographically_smallest_sequel_title)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+dynamic _min(dynamic v) {
+    List<dynamic>? list;
+    if (v is List) list = v;
+    else if (v is Map && v['items'] is List) list = (v['items'] as List);
+    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);
+    else if (v is _Group) list = v.Items;
+    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }
+    if (list == null || list.isEmpty) return 0;
+    var m = list[0];
+    for (var n in list) { if ((n as Comparable).compareTo(m) < 0) m = n; }
+    return m;
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q3.out
+++ b/tests/dataset/job/compiler/dart/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/compiler/dart/q4.dart.out
+++ b/tests/dataset/job/compiler/dart/q4.dart.out
@@ -1,0 +1,117 @@
+import 'dart:io';
+import 'dart:convert';
+
+void test_Q4_returns_minimum_rating_and_title_for_sequels() {
+  if (!(_equal(result, [{"rating": "6.2", "movie_title": "Alpha Movie"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, dynamic>> info_type = [{"id": 1, "info": "rating"}, {"id": 2, "info": "other"}];
+  List<Map<String, dynamic>> keyword = [{"id": 1, "keyword": "great sequel"}, {"id": 2, "keyword": "prequel"}];
+  List<Map<String, dynamic>> title = [{"id": 10, "title": "Alpha Movie", "production_year": 2006}, {"id": 20, "title": "Beta Film", "production_year": 2007}, {"id": 30, "title": "Old Film", "production_year": 2004}];
+  List<Map<String, int>> movie_keyword = [{"movie_id": 10, "keyword_id": 1}, {"movie_id": 20, "keyword_id": 1}, {"movie_id": 30, "keyword_id": 1}];
+  List<Map<String, dynamic>> movie_info_idx = [{"movie_id": 10, "info_type_id": 1, "info": "6.2"}, {"movie_id": 20, "info_type_id": 1, "info": "7.8"}, {"movie_id": 30, "info_type_id": 1, "info": "4.5"}];
+  List<Map<String, dynamic>> rows = (() {
+  var _res = [];
+  for (var it in info_type) {
+    for (var mi in movie_info_idx) {
+      if (!(_equal(it.id, mi.info_type_id))) {
+        continue;
+      }
+      for (var t in title) {
+        if (!(_equal(t.id, mi.movie_id))) {
+          continue;
+        }
+        for (var mk in movie_keyword) {
+          if (!(_equal(mk.movie_id, t.id))) {
+            continue;
+          }
+          for (var k in keyword) {
+            if (!(_equal(k.id, mk.keyword_id))) {
+              continue;
+            }
+            if (!(((((_equal(it.info, "rating") && k.keyword.contains("sequel")) && (mi.info.compareTo("5.0") > 0)) && (t.production_year > 2005)) && _equal(mk.movie_id, mi.movie_id)))) {
+              continue;
+            }
+            _res.add({"rating": mi.info, "title": t.title});
+          }
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  List<Map<String, dynamic>> result = [{"rating": _min((() {
+  var _res = [];
+  for (var r in rows) {
+    _res.add(r.rating);
+  }
+  return _res;
+})()), "movie_title": _min((() {
+  var _res = [];
+  for (var r in rows) {
+    _res.add(r.title);
+  }
+  return _res;
+})())}];
+  _json(result);
+  if (!_runTest("Q4 returns minimum rating and title for sequels", test_Q4_returns_minimum_rating_and_title_for_sequels)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+dynamic _min(dynamic v) {
+    List<dynamic>? list;
+    if (v is List) list = v;
+    else if (v is Map && v['items'] is List) list = (v['items'] as List);
+    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);
+    else if (v is _Group) list = v.Items;
+    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }
+    if (list == null || list.isEmpty) return 0;
+    var m = list[0];
+    for (var n in list) { if ((n as Comparable).compareTo(m) < 0) m = n; }
+    return m;
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q4.out
+++ b/tests/dataset/job/compiler/dart/q4.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha Movie","rating":"6.2"}]

--- a/tests/dataset/job/compiler/dart/q5.dart.out
+++ b/tests/dataset/job/compiler/dart/q5.dart.out
@@ -1,0 +1,105 @@
+import 'dart:io';
+import 'dart:convert';
+
+void test_Q5_finds_the_lexicographically_first_qualifying_title() {
+  if (!(_equal(result, [{"typical_european_movie": "A Film"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, dynamic>> company_type = [{"ct_id": 1, "kind": "production companies"}, {"ct_id": 2, "kind": "other"}];
+  List<Map<String, dynamic>> info_type = [{"it_id": 10, "info": "languages"}];
+  List<Map<String, dynamic>> title = [{"t_id": 100, "title": "B Movie", "production_year": 2010}, {"t_id": 200, "title": "A Film", "production_year": 2012}, {"t_id": 300, "title": "Old Movie", "production_year": 2000}];
+  List<Map<String, dynamic>> movie_companies = [{"movie_id": 100, "company_type_id": 1, "note": "ACME (France) (theatrical)"}, {"movie_id": 200, "company_type_id": 1, "note": "ACME (France) (theatrical)"}, {"movie_id": 300, "company_type_id": 1, "note": "ACME (France) (theatrical)"}];
+  List<Map<String, dynamic>> movie_info = [{"movie_id": 100, "info": "German", "info_type_id": 10}, {"movie_id": 200, "info": "Swedish", "info_type_id": 10}, {"movie_id": 300, "info": "German", "info_type_id": 10}];
+  List candidate_titles = (() {
+  var _res = [];
+  for (var ct in company_type) {
+    for (var mc in movie_companies) {
+      if (!(_equal(mc.company_type_id, ct.ct_id))) {
+        continue;
+      }
+      for (var mi in movie_info) {
+        if (!(_equal(mi.movie_id, mc.movie_id))) {
+          continue;
+        }
+        for (var it in info_type) {
+          if (!(_equal(it.it_id, mi.info_type_id))) {
+            continue;
+          }
+          for (var t in title) {
+            if (!(_equal(t.t_id, mc.movie_id))) {
+              continue;
+            }
+            if (!(((((_equal(ct.kind, "production companies") && (mc.note.contains("(theatrical)"))) && (mc.note.contains("(France)"))) && (t.production_year > 2005)) && ((["Sweden", "Norway", "Germany", "Denmark", "Swedish", "Denish", "Norwegian", "German"].contains(mi.info)))))) {
+              continue;
+            }
+            _res.add(t.title);
+          }
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  List<Map<String, dynamic>> result = [{"typical_european_movie": _min(candidate_titles)}];
+  _json(result);
+  if (!_runTest("Q5 finds the lexicographically first qualifying title", test_Q5_finds_the_lexicographically_first_qualifying_title)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+dynamic _min(dynamic v) {
+    List<dynamic>? list;
+    if (v is List) list = v;
+    else if (v is Map && v['items'] is List) list = (v['items'] as List);
+    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);
+    else if (v is _Group) list = v.Items;
+    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }
+    if (list == null || list.isEmpty) return 0;
+    var m = list[0];
+    for (var n in list) { if ((n as Comparable).compareTo(m) < 0) m = n; }
+    return m;
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q5.out
+++ b/tests/dataset/job/compiler/dart/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/compiler/dart/q6.dart.out
+++ b/tests/dataset/job/compiler/dart/q6.dart.out
@@ -1,0 +1,91 @@
+import 'dart:io';
+import 'dart:convert';
+
+void test_Q6_finds_marvel_movie_with_Robert_Downey() {
+  if (!(_equal(result, [{"movie_keyword": "marvel-cinematic-universe", "actor_name": "Downey Robert Jr.", "marvel_movie": "Iron Man 3"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, int>> cast_info = [{"movie_id": 1, "person_id": 101}, {"movie_id": 2, "person_id": 102}];
+  List<Map<String, dynamic>> keyword = [{"id": 100, "keyword": "marvel-cinematic-universe"}, {"id": 200, "keyword": "other"}];
+  List<Map<String, int>> movie_keyword = [{"movie_id": 1, "keyword_id": 100}, {"movie_id": 2, "keyword_id": 200}];
+  List<Map<String, dynamic>> name = [{"id": 101, "name": "Downey Robert Jr."}, {"id": 102, "name": "Chris Evans"}];
+  List<Map<String, dynamic>> title = [{"id": 1, "title": "Iron Man 3", "production_year": 2013}, {"id": 2, "title": "Old Movie", "production_year": 2000}];
+  List<Map<String, dynamic>> result = (() {
+  var _res = [];
+  for (var ci in cast_info) {
+    for (var mk in movie_keyword) {
+      if (!(_equal(ci.movie_id, mk.movie_id))) {
+        continue;
+      }
+      for (var k in keyword) {
+        if (!(_equal(mk.keyword_id, k.id))) {
+          continue;
+        }
+        for (var n in name) {
+          if (!(_equal(ci.person_id, n.id))) {
+            continue;
+          }
+          for (var t in title) {
+            if (!(_equal(ci.movie_id, t.id))) {
+              continue;
+            }
+            if (!((((_equal(k.keyword, "marvel-cinematic-universe") && n.name.contains("Downey")) && n.name.contains("Robert")) && (t.production_year > 2010)))) {
+              continue;
+            }
+            _res.add({"movie_keyword": k.keyword, "actor_name": n.name, "marvel_movie": t.title});
+          }
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  _json(result);
+  if (!_runTest("Q6 finds marvel movie with Robert Downey", test_Q6_finds_marvel_movie_with_Robert_Downey)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q6.out
+++ b/tests/dataset/job/compiler/dart/q6.out
@@ -1,0 +1,1 @@
+[{"actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3","movie_keyword":"marvel-cinematic-universe"}]

--- a/tests/dataset/job/compiler/dart/q7.dart.out
+++ b/tests/dataset/job/compiler/dart/q7.dart.out
@@ -1,0 +1,135 @@
+import 'dart:io';
+import 'dart:convert';
+
+void test_Q7_finds_movie_features_biography_for_person() {
+  if (!(_equal(result, [{"of_person": "Alan Brown", "biography_movie": "Feature Film"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, dynamic>> aka_name = [{"person_id": 1, "name": "Anna Mae"}, {"person_id": 2, "name": "Chris"}];
+  List<Map<String, int>> cast_info = [{"person_id": 1, "movie_id": 10}, {"person_id": 2, "movie_id": 20}];
+  List<Map<String, dynamic>> info_type = [{"id": 1, "info": "mini biography"}, {"id": 2, "info": "trivia"}];
+  List<Map<String, dynamic>> link_type = [{"id": 1, "link": "features"}, {"id": 2, "link": "references"}];
+  List<Map<String, int>> movie_link = [{"linked_movie_id": 10, "link_type_id": 1}, {"linked_movie_id": 20, "link_type_id": 2}];
+  List<Map<String, dynamic>> name = [{"id": 1, "name": "Alan Brown", "name_pcode_cf": "B", "gender": "m"}, {"id": 2, "name": "Zoe", "name_pcode_cf": "Z", "gender": "f"}];
+  List<Map<String, dynamic>> person_info = [{"person_id": 1, "info_type_id": 1, "note": "Volker Boehm"}, {"person_id": 2, "info_type_id": 1, "note": "Other"}];
+  List<Map<String, dynamic>> title = [{"id": 10, "title": "Feature Film", "production_year": 1990}, {"id": 20, "title": "Late Film", "production_year": 2000}];
+  List<Map<String, dynamic>> rows = (() {
+  var _res = [];
+  for (var an in aka_name) {
+    for (var n in name) {
+      if (!(_equal(n.id, an.person_id))) {
+        continue;
+      }
+      for (var pi in person_info) {
+        if (!(_equal(pi.person_id, an.person_id))) {
+          continue;
+        }
+        for (var it in info_type) {
+          if (!(_equal(it.id, pi.info_type_id))) {
+            continue;
+          }
+          for (var ci in cast_info) {
+            if (!(_equal(ci.person_id, n.id))) {
+              continue;
+            }
+            for (var t in title) {
+              if (!(_equal(t.id, ci.movie_id))) {
+                continue;
+              }
+              for (var ml in movie_link) {
+                if (!(_equal(ml.linked_movie_id, t.id))) {
+                  continue;
+                }
+                for (var lt in link_type) {
+                  if (!(_equal(lt.id, ml.link_type_id))) {
+                    continue;
+                  }
+                  if (!((((((((((((((an.name.contains("a") && _equal(it.info, "mini biography")) && _equal(lt.link, "features")) && (n.name_pcode_cf.compareTo("A") >= 0)) && (n.name_pcode_cf.compareTo("F") <= 0)) && ((_equal(n.gender, "m") || ((_equal(n.gender, "f") && n.name.starts_with("B")))))) && _equal(pi.note, "Volker Boehm")) && (t.production_year >= 1980)) && (t.production_year <= 1995)) && _equal(pi.person_id, an.person_id)) && _equal(pi.person_id, ci.person_id)) && _equal(an.person_id, ci.person_id)) && _equal(ci.movie_id, ml.linked_movie_id))))) {
+                    continue;
+                  }
+                  _res.add({"person_name": n.name, "movie_title": t.title});
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  List<Map<String, dynamic>> result = [{"of_person": _min((() {
+  var _res = [];
+  for (var r in rows) {
+    _res.add(r.person_name);
+  }
+  return _res;
+})()), "biography_movie": _min((() {
+  var _res = [];
+  for (var r in rows) {
+    _res.add(r.movie_title);
+  }
+  return _res;
+})())}];
+  _json(result);
+  if (!_runTest("Q7 finds movie features biography for person", test_Q7_finds_movie_features_biography_for_person)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+dynamic _min(dynamic v) {
+    List<dynamic>? list;
+    if (v is List) list = v;
+    else if (v is Map && v['items'] is List) list = (v['items'] as List);
+    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);
+    else if (v is _Group) list = v.Items;
+    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }
+    if (list == null || list.isEmpty) return 0;
+    var m = list[0];
+    for (var n in list) { if ((n as Comparable).compareTo(m) < 0) m = n; }
+    return m;
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q7.out
+++ b/tests/dataset/job/compiler/dart/q7.out
@@ -1,0 +1,1 @@
+[{"biography_movie":"Feature Film","of_person":"Alan Brown"}]

--- a/tests/dataset/job/compiler/dart/q8.dart.out
+++ b/tests/dataset/job/compiler/dart/q8.dart.out
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'dart:io';
+
+void test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() {
+  if (!(_equal(result, [{"actress_pseudonym": "Y. S.", "japanese_movie_dubbed": "Dubbed Film"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, dynamic>> aka_name = [{"person_id": 1, "name": "Y. S."}];
+  List<Map<String, dynamic>> cast_info = [{"person_id": 1, "movie_id": 10, "note": "(voice: English version)", "role_id": 1000}];
+  List<Map<String, dynamic>> company_name = [{"id": 50, "country_code": "[jp]"}];
+  List<Map<String, dynamic>> movie_companies = [{"movie_id": 10, "company_id": 50, "note": "Studio (Japan)"}];
+  List<Map<String, dynamic>> name = [{"id": 1, "name": "Yoko Ono"}, {"id": 2, "name": "Yuichi"}];
+  List<Map<String, dynamic>> role_type = [{"id": 1000, "role": "actress"}];
+  List<Map<String, dynamic>> title = [{"id": 10, "title": "Dubbed Film"}];
+  List<Map<String, dynamic>> eligible = (() {
+  var _res = [];
+  for (var an1 in aka_name) {
+    for (var n1 in name) {
+      if (!(_equal(n1.id, an1.person_id))) {
+        continue;
+      }
+      for (var ci in cast_info) {
+        if (!(_equal(ci.person_id, an1.person_id))) {
+          continue;
+        }
+        for (var t in title) {
+          if (!(_equal(t.id, ci.movie_id))) {
+            continue;
+          }
+          for (var mc in movie_companies) {
+            if (!(_equal(mc.movie_id, ci.movie_id))) {
+              continue;
+            }
+            for (var cn in company_name) {
+              if (!(_equal(cn.id, mc.company_id))) {
+                continue;
+              }
+              for (var rt in role_type) {
+                if (!(_equal(rt.id, ci.role_id))) {
+                  continue;
+                }
+                if (!(((((((_equal(ci.note, "(voice: English version)") && _equal(cn.country_code, "[jp]")) && mc.note.contains("(Japan)")) && (!mc.note.contains("(USA)"))) && n1.name.contains("Yo")) && (!n1.name.contains("Yu"))) && _equal(rt.role, "actress")))) {
+                  continue;
+                }
+                _res.add({"pseudonym": an1.name, "movie_title": t.title});
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  List<Map<String, dynamic>> result = [{"actress_pseudonym": _min((() {
+  var _res = [];
+  for (var x in eligible) {
+    _res.add(x.pseudonym);
+  }
+  return _res;
+})()), "japanese_movie_dubbed": _min((() {
+  var _res = [];
+  for (var x in eligible) {
+    _res.add(x.movie_title);
+  }
+  return _res;
+})())}];
+  _json(result);
+  if (!_runTest("Q8 returns the pseudonym and movie title for Japanese dubbing", test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+dynamic _min(dynamic v) {
+    List<dynamic>? list;
+    if (v is List) list = v;
+    else if (v is Map && v['items'] is List) list = (v['items'] as List);
+    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);
+    else if (v is _Group) list = v.Items;
+    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }
+    if (list == null || list.isEmpty) return 0;
+    var m = list[0];
+    for (var n in list) { if ((n as Comparable).compareTo(m) < 0) m = n; }
+    return m;
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q8.out
+++ b/tests/dataset/job/compiler/dart/q8.out
@@ -1,0 +1,1 @@
+[{"actress_pseudonym":"Y. S.","japanese_movie_dubbed":"Dubbed Film"}]

--- a/tests/dataset/job/compiler/dart/q9.dart.out
+++ b/tests/dataset/job/compiler/dart/q9.dart.out
@@ -1,0 +1,141 @@
+import 'dart:io';
+import 'dart:convert';
+
+void test_Q9_selects_minimal_alternative_name__character_and_movie() {
+  if (!(_equal(result, [{"alternative_name": "A. N. G.", "character_name": "Angel", "movie": "Famous Film"}]))) { throw Exception('expect failed'); }
+}
+
+void main() {
+  int failures = 0;
+  List<Map<String, dynamic>> aka_name = [{"person_id": 1, "name": "A. N. G."}, {"person_id": 2, "name": "J. D."}];
+  List<Map<String, dynamic>> char_name = [{"id": 10, "name": "Angel"}, {"id": 20, "name": "Devil"}];
+  List<Map<String, dynamic>> cast_info = [{"person_id": 1, "person_role_id": 10, "movie_id": 100, "role_id": 1000, "note": "(voice)"}, {"person_id": 2, "person_role_id": 20, "movie_id": 200, "role_id": 1000, "note": "(voice)"}];
+  List<Map<String, dynamic>> company_name = [{"id": 100, "country_code": "[us]"}, {"id": 200, "country_code": "[gb]"}];
+  List<Map<String, dynamic>> movie_companies = [{"movie_id": 100, "company_id": 100, "note": "ACME Studios (USA)"}, {"movie_id": 200, "company_id": 200, "note": "Maple Films"}];
+  List<Map<String, dynamic>> name = [{"id": 1, "name": "Angela Smith", "gender": "f"}, {"id": 2, "name": "John Doe", "gender": "m"}];
+  List<Map<String, dynamic>> role_type = [{"id": 1000, "role": "actress"}, {"id": 2000, "role": "actor"}];
+  List<Map<String, dynamic>> title = [{"id": 100, "title": "Famous Film", "production_year": 2010}, {"id": 200, "title": "Old Movie", "production_year": 1999}];
+  List<Map<String, dynamic>> matches = (() {
+  var _res = [];
+  for (var an in aka_name) {
+    for (var n in name) {
+      if (!(_equal(an.person_id, n.id))) {
+        continue;
+      }
+      for (var ci in cast_info) {
+        if (!(_equal(ci.person_id, n.id))) {
+          continue;
+        }
+        for (var chn in char_name) {
+          if (!(_equal(chn.id, ci.person_role_id))) {
+            continue;
+          }
+          for (var t in title) {
+            if (!(_equal(t.id, ci.movie_id))) {
+              continue;
+            }
+            for (var mc in movie_companies) {
+              if (!(_equal(mc.movie_id, t.id))) {
+                continue;
+              }
+              for (var cn in company_name) {
+                if (!(_equal(cn.id, mc.company_id))) {
+                  continue;
+                }
+                for (var rt in role_type) {
+                  if (!(_equal(rt.id, ci.role_id))) {
+                    continue;
+                  }
+                  if (!((((((((((["(voice)", "(voice: Japanese version)", "(voice) (uncredited)", "(voice: English version)"].contains(ci.note))) && _equal(cn.country_code, "[us]")) && ((mc.note.contains("(USA)") || mc.note.contains("(worldwide)")))) && _equal(n.gender, "f")) && n.name.contains("Ang")) && _equal(rt.role, "actress")) && (t.production_year >= 2005)) && (t.production_year <= 2015)))) {
+                    continue;
+                  }
+                  _res.add({"alt": an.name, "character": chn.name, "movie": t.title});
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return _res;
+})();
+  List<Map<String, dynamic>> result = [{"alternative_name": _min((() {
+  var _res = [];
+  for (var x in matches) {
+    _res.add(x.alt);
+  }
+  return _res;
+})()), "character_name": _min((() {
+  var _res = [];
+  for (var x in matches) {
+    _res.add(x.character);
+  }
+  return _res;
+})()), "movie": _min((() {
+  var _res = [];
+  for (var x in matches) {
+    _res.add(x.movie);
+  }
+  return _res;
+})())}];
+  _json(result);
+  if (!_runTest("Q9 selects minimal alternative name, character and movie", test_Q9_selects_minimal_alternative_name__character_and_movie)) failures++;
+  if (failures > 0) {
+    print("\n[FAIL] $failures test(s) failed.");
+  }
+}
+
+bool _equal(dynamic a, dynamic b) {
+    if (a is List && b is List) {
+        if (a.length != b.length) return false;
+        for (var i = 0; i < a.length; i++) { if (!_equal(a[i], b[i])) return false; }
+        return true;
+    }
+    if (a is Map && b is Map) {
+        if (a.length != b.length) return false;
+        for (var k in a.keys) { if (!b.containsKey(k) || !_equal(a[k], b[k])) return false; }
+        return true;
+    }
+    return a == b;
+}
+
+String _formatDuration(Duration d) {
+    if (d.inMicroseconds < 1000) return '${d.inMicroseconds}µs';
+    if (d.inMilliseconds < 1000) return '${d.inMilliseconds}ms';
+    return '${(d.inMilliseconds/1000).toStringAsFixed(2)}s';
+}
+
+void _json(dynamic v) {
+    print(jsonEncode(v));
+}
+
+dynamic _min(dynamic v) {
+    List<dynamic>? list;
+    if (v is List) list = v;
+    else if (v is Map && v['items'] is List) list = (v['items'] as List);
+    else if (v is Map && v['Items'] is List) list = (v['Items'] as List);
+    else if (v is _Group) list = v.Items;
+    else { try { var it = (v as dynamic).items; if (it is List) list = it; } catch (_) {} }
+    if (list == null || list.isEmpty) return 0;
+    var m = list[0];
+    for (var n in list) { if ((n as Comparable).compareTo(m) < 0) m = n; }
+    return m;
+}
+
+bool _runTest(String name, void Function() f) {
+    stdout.write('   test $name ...');
+    var start = DateTime.now();
+    try {
+        f();
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' ok (${_formatDuration(d)})');
+        return true;
+    } catch (e) {
+        var d = DateTime.now().difference(start);
+        stdout.writeln(' fail $e (${_formatDuration(d)})');
+        return false;
+    }
+}
+
+

--- a/tests/dataset/job/compiler/dart/q9.out
+++ b/tests/dataset/job/compiler/dart/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]


### PR DESCRIPTION
## Summary
- extend dart JOB compiler tests to cover q1–q10
- add missing golden outputs for JOB q3–q10
- document remaining work for JOB support in TASKS

## Testing
- `go test -tags slow ./compile/x/dart -run TestDartCompiler_JOB -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e8abe67008320b8c8a88a9978cdca