### PR TITLE
Update Rust compiler job tests

### DIFF
--- a/compile/x/rust/job_golden_test.go
+++ b/compile/x/rust/job_golden_test.go
@@ -19,7 +19,7 @@ func TestRustCompiler_JOB(t *testing.T) {
 		t.Skipf("rust not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	for _, q := range []string{"q1", "q2"} {
+	for _, q := range []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10"} {
 		src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
 		prog, err := parser.Parse(src)
 		if err != nil {

--- a/tests/dataset/job/compiler/rust/q10.out
+++ b/tests/dataset/job/compiler/rust/q10.out
@@ -1,0 +1,1 @@
+[{"russian_movie":"Vodka Dreams","uncredited_voiced_character":"Ivan"}]

--- a/tests/dataset/job/compiler/rust/q10.rs.out
+++ b/tests/dataset/job/compiler/rust/q10.rs.out
@@ -1,0 +1,62 @@
+fn test_Q10_finds_uncredited_voice_actor_in_Russian_movie() {
+    expect(result == vec![std::collections::HashMap::from([("uncredited_voiced_character".to_string(), "Ivan"), ("russian_movie".to_string(), "Vodka Dreams")])]);
+}
+
+fn main() {
+    let mut char_name = vec![std::collections::HashMap::from([("id".to_string(), 1), ("name".to_string(), "Ivan")]), std::collections::HashMap::from([("id".to_string(), 2), ("name".to_string(), "Alex")])];
+    let mut cast_info = vec![std::collections::HashMap::from([("movie_id".to_string(), 10), ("person_role_id".to_string(), 1), ("role_id".to_string(), 1), ("note".to_string(), "Soldier (voice) (uncredited)")]), std::collections::HashMap::from([("movie_id".to_string(), 11), ("person_role_id".to_string(), 2), ("role_id".to_string(), 1), ("note".to_string(), "(voice)")])];
+    let mut company_name = vec![std::collections::HashMap::from([("id".to_string(), 1), ("country_code".to_string(), "[ru]")]), std::collections::HashMap::from([("id".to_string(), 2), ("country_code".to_string(), "[us]")])];
+    let mut company_type = vec![std::collections::HashMap::from([("id".to_string(), 1)]), std::collections::HashMap::from([("id".to_string(), 2)])];
+    let mut movie_companies = vec![std::collections::HashMap::from([("movie_id".to_string(), 10), ("company_id".to_string(), 1), ("company_type_id".to_string(), 1)]), std::collections::HashMap::from([("movie_id".to_string(), 11), ("company_id".to_string(), 2), ("company_type_id".to_string(), 1)])];
+    let mut role_type = vec![std::collections::HashMap::from([("id".to_string(), 1), ("role".to_string(), "actor")]), std::collections::HashMap::from([("id".to_string(), 2), ("role".to_string(), "director")])];
+    let mut title = vec![std::collections::HashMap::from([("id".to_string(), 10), ("title".to_string(), "Vodka Dreams"), ("production_year".to_string(), 2006)]), std::collections::HashMap::from([("id".to_string(), 11), ("title".to_string(), "Other Film"), ("production_year".to_string(), 2004)])];
+    let mut matches = {
+    let mut _res = Vec::new();
+    for chn in char_name.clone() {
+        for ci in cast_info.clone() {
+            if !(_map_get(&chn, &"id".to_string()) == _map_get(&ci, &"person_role_id".to_string())) { continue; }
+            for rt in role_type.clone() {
+                if !(_map_get(&rt, &"id".to_string()) == _map_get(&ci, &"role_id".to_string())) { continue; }
+                for t in title.clone() {
+                    if !(_map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string())) { continue; }
+                    for mc in movie_companies.clone() {
+                        if !(_map_get(&mc, &"movie_id".to_string()) == _map_get(&t, &"id".to_string())) { continue; }
+                        for cn in company_name.clone() {
+                            if !(_map_get(&cn, &"id".to_string()) == _map_get(&mc, &"company_id".to_string())) { continue; }
+                            for ct in company_type.clone() {
+                                if !(_map_get(&ct, &"id".to_string()) == _map_get(&mc, &"company_type_id".to_string())) { continue; }
+                                if _map_get(&chn, &"id".to_string()) == _map_get(&ci, &"person_role_id".to_string()) && _map_get(&rt, &"id".to_string()) == _map_get(&ci, &"role_id".to_string()) && _map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string()) && _map_get(&mc, &"movie_id".to_string()) == _map_get(&t, &"id".to_string()) && _map_get(&cn, &"id".to_string()) == _map_get(&mc, &"company_id".to_string()) && _map_get(&ct, &"id".to_string()) == _map_get(&mc, &"company_type_id".to_string()) && _map_get(&_map_get(&ci, &"note".to_string()), &"contains".to_string())("(voice)") && _map_get(&_map_get(&ci, &"note".to_string()), &"contains".to_string())("(uncredited)") && _map_get(&cn, &"country_code".to_string()) == "[ru]" && _map_get(&rt, &"role".to_string()) == "actor" && _map_get(&t, &"production_year".to_string()) > 2005 {
+                                    _res.push(std::collections::HashMap::from([("character".to_string(), _map_get(&chn, &"name".to_string())), ("movie".to_string(), _map_get(&t, &"title".to_string()))]));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    let mut result = vec![std::collections::HashMap::from([("uncredited_voiced_character".to_string(), min({
+    let mut _res = Vec::new();
+    for x in matches {
+        _res.push(_map_get(&x, &"character".to_string()));
+    }
+    _res
+})), ("russian_movie".to_string(), min({
+    let mut _res = Vec::new();
+    for x in matches {
+        _res.push(_map_get(&x, &"movie".to_string()));
+    }
+    _res
+}))])];
+    json(result);
+    test_Q10_finds_uncredited_voice_actor_in_Russian_movie();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}

--- a/tests/dataset/job/compiler/rust/q3.out
+++ b/tests/dataset/job/compiler/rust/q3.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha"}]

--- a/tests/dataset/job/compiler/rust/q3.rs.out
+++ b/tests/dataset/job/compiler/rust/q3.rs.out
@@ -1,0 +1,39 @@
+fn test_Q3_returns_lexicographically_smallest_sequel_title() {
+    expect(result == vec![std::collections::HashMap::from([("movie_title".to_string(), "Alpha")])]);
+}
+
+fn main() {
+    let mut keyword = vec![std::collections::HashMap::from([("id".to_string(), 1), ("keyword".to_string(), "amazing sequel")]), std::collections::HashMap::from([("id".to_string(), 2), ("keyword".to_string(), "prequel")])];
+    let mut movie_info = vec![std::collections::HashMap::from([("movie_id".to_string(), 10), ("info".to_string(), "Germany")]), std::collections::HashMap::from([("movie_id".to_string(), 30), ("info".to_string(), "Sweden")]), std::collections::HashMap::from([("movie_id".to_string(), 20), ("info".to_string(), "France")])];
+    let mut movie_keyword = vec![std::collections::HashMap::from([("movie_id".to_string(), 10), ("keyword_id".to_string(), 1)]), std::collections::HashMap::from([("movie_id".to_string(), 30), ("keyword_id".to_string(), 1)]), std::collections::HashMap::from([("movie_id".to_string(), 20), ("keyword_id".to_string(), 1)]), std::collections::HashMap::from([("movie_id".to_string(), 10), ("keyword_id".to_string(), 2)])];
+    let mut title = vec![std::collections::HashMap::from([("id".to_string(), 10), ("title".to_string(), "Alpha"), ("production_year".to_string(), 2006)]), std::collections::HashMap::from([("id".to_string(), 30), ("title".to_string(), "Beta"), ("production_year".to_string(), 2008)]), std::collections::HashMap::from([("id".to_string(), 20), ("title".to_string(), "Gamma"), ("production_year".to_string(), 2009)])];
+    let mut allowed_infos = vec!["Sweden".to_string(), "Norway".to_string(), "Germany".to_string(), "Denmark".to_string(), "Swedish".to_string(), "Denish".to_string(), "Norwegian".to_string(), "German".to_string()];
+    let mut candidate_titles = {
+    let mut _res = Vec::new();
+    for k in keyword.clone() {
+        for mk in movie_keyword.clone() {
+            if !(_map_get(&mk, &"keyword_id".to_string()) == _map_get(&k, &"id".to_string())) { continue; }
+            for mi in movie_info.clone() {
+                if !(_map_get(&mi, &"movie_id".to_string()) == _map_get(&mk, &"movie_id".to_string())) { continue; }
+                for t in title.clone() {
+                    if !(_map_get(&t, &"id".to_string()) == _map_get(&mi, &"movie_id".to_string())) { continue; }
+                    if _map_get(&mk, &"keyword_id".to_string()) == _map_get(&k, &"id".to_string()) && _map_get(&mi, &"movie_id".to_string()) == _map_get(&mk, &"movie_id".to_string()) && _map_get(&t, &"id".to_string()) == _map_get(&mi, &"movie_id".to_string()) && allowed_infos.contains(&_map_get(&_map_get(&k, &"keyword".to_string()), &"contains".to_string())("sequel") && _map_get(&mi, &"info".to_string())) && _map_get(&t, &"production_year".to_string()) > 2005 && _map_get(&mk, &"movie_id".to_string()) == _map_get(&mi, &"movie_id".to_string()) {
+                        _res.push(_map_get(&t, &"title".to_string()));
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    let mut result = vec![std::collections::HashMap::from([("movie_title".to_string(), min(candidate_titles))])];
+    json(result);
+    test_Q3_returns_lexicographically_smallest_sequel_title();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}

--- a/tests/dataset/job/compiler/rust/q4.out
+++ b/tests/dataset/job/compiler/rust/q4.out
@@ -1,0 +1,1 @@
+[{"movie_title":"Alpha Movie","rating":"6.2"}]

--- a/tests/dataset/job/compiler/rust/q4.rs.out
+++ b/tests/dataset/job/compiler/rust/q4.rs.out
@@ -1,0 +1,54 @@
+fn test_Q4_returns_minimum_rating_and_title_for_sequels() {
+    expect(result == vec![std::collections::HashMap::from([("rating".to_string(), "6.2"), ("movie_title".to_string(), "Alpha Movie")])]);
+}
+
+fn main() {
+    let mut info_type = vec![std::collections::HashMap::from([("id".to_string(), 1), ("info".to_string(), "rating")]), std::collections::HashMap::from([("id".to_string(), 2), ("info".to_string(), "other")])];
+    let mut keyword = vec![std::collections::HashMap::from([("id".to_string(), 1), ("keyword".to_string(), "great sequel")]), std::collections::HashMap::from([("id".to_string(), 2), ("keyword".to_string(), "prequel")])];
+    let mut title = vec![std::collections::HashMap::from([("id".to_string(), 10), ("title".to_string(), "Alpha Movie"), ("production_year".to_string(), 2006)]), std::collections::HashMap::from([("id".to_string(), 20), ("title".to_string(), "Beta Film"), ("production_year".to_string(), 2007)]), std::collections::HashMap::from([("id".to_string(), 30), ("title".to_string(), "Old Film"), ("production_year".to_string(), 2004)])];
+    let mut movie_keyword = vec![std::collections::HashMap::from([("movie_id".to_string(), 10), ("keyword_id".to_string(), 1)]), std::collections::HashMap::from([("movie_id".to_string(), 20), ("keyword_id".to_string(), 1)]), std::collections::HashMap::from([("movie_id".to_string(), 30), ("keyword_id".to_string(), 1)])];
+    let mut movie_info_idx = vec![std::collections::HashMap::from([("movie_id".to_string(), 10), ("info_type_id".to_string(), 1), ("info".to_string(), "6.2")]), std::collections::HashMap::from([("movie_id".to_string(), 20), ("info_type_id".to_string(), 1), ("info".to_string(), "7.8")]), std::collections::HashMap::from([("movie_id".to_string(), 30), ("info_type_id".to_string(), 1), ("info".to_string(), "4.5")])];
+    let mut rows = {
+    let mut _res = Vec::new();
+    for it in info_type.clone() {
+        for mi in movie_info_idx.clone() {
+            if !(_map_get(&it, &"id".to_string()) == _map_get(&mi, &"info_type_id".to_string())) { continue; }
+            for t in title.clone() {
+                if !(_map_get(&t, &"id".to_string()) == _map_get(&mi, &"movie_id".to_string())) { continue; }
+                for mk in movie_keyword.clone() {
+                    if !(_map_get(&mk, &"movie_id".to_string()) == _map_get(&t, &"id".to_string())) { continue; }
+                    for k in keyword.clone() {
+                        if !(_map_get(&k, &"id".to_string()) == _map_get(&mk, &"keyword_id".to_string())) { continue; }
+                        if _map_get(&it, &"id".to_string()) == _map_get(&mi, &"info_type_id".to_string()) && _map_get(&t, &"id".to_string()) == _map_get(&mi, &"movie_id".to_string()) && _map_get(&mk, &"movie_id".to_string()) == _map_get(&t, &"id".to_string()) && _map_get(&k, &"id".to_string()) == _map_get(&mk, &"keyword_id".to_string()) && _map_get(&it, &"info".to_string()) == "rating" && _map_get(&_map_get(&k, &"keyword".to_string()), &"contains".to_string())("sequel") && _map_get(&mi, &"info".to_string()) > "5.0" && _map_get(&t, &"production_year".to_string()) > 2005 && _map_get(&mk, &"movie_id".to_string()) == _map_get(&mi, &"movie_id".to_string()) {
+                            _res.push(std::collections::HashMap::from([("rating".to_string(), _map_get(&mi, &"info".to_string())), ("title".to_string(), _map_get(&t, &"title".to_string()))]));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    let mut result = vec![std::collections::HashMap::from([("rating".to_string(), min({
+    let mut _res = Vec::new();
+    for r in rows {
+        _res.push(_map_get(&r, &"rating".to_string()));
+    }
+    _res
+})), ("movie_title".to_string(), min({
+    let mut _res = Vec::new();
+    for r in rows {
+        _res.push(_map_get(&r, &"title".to_string()));
+    }
+    _res
+}))])];
+    json(result);
+    test_Q4_returns_minimum_rating_and_title_for_sequels();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}

--- a/tests/dataset/job/compiler/rust/q5.out
+++ b/tests/dataset/job/compiler/rust/q5.out
@@ -1,0 +1,1 @@
+[{"typical_european_movie":"A Film"}]

--- a/tests/dataset/job/compiler/rust/q5.rs.out
+++ b/tests/dataset/job/compiler/rust/q5.rs.out
@@ -1,0 +1,42 @@
+fn test_Q5_finds_the_lexicographically_first_qualifying_title() {
+    expect(result == vec![std::collections::HashMap::from([("typical_european_movie".to_string(), "A Film")])]);
+}
+
+fn main() {
+    let mut company_type = vec![std::collections::HashMap::from([("ct_id".to_string(), 1), ("kind".to_string(), "production companies")]), std::collections::HashMap::from([("ct_id".to_string(), 2), ("kind".to_string(), "other")])];
+    let mut info_type = vec![std::collections::HashMap::from([("it_id".to_string(), 10), ("info".to_string(), "languages")])];
+    let mut title = vec![std::collections::HashMap::from([("t_id".to_string(), 100), ("title".to_string(), "B Movie"), ("production_year".to_string(), 2010)]), std::collections::HashMap::from([("t_id".to_string(), 200), ("title".to_string(), "A Film"), ("production_year".to_string(), 2012)]), std::collections::HashMap::from([("t_id".to_string(), 300), ("title".to_string(), "Old Movie"), ("production_year".to_string(), 2000)])];
+    let mut movie_companies = vec![std::collections::HashMap::from([("movie_id".to_string(), 100), ("company_type_id".to_string(), 1), ("note".to_string(), "ACME (France) (theatrical)")]), std::collections::HashMap::from([("movie_id".to_string(), 200), ("company_type_id".to_string(), 1), ("note".to_string(), "ACME (France) (theatrical)")]), std::collections::HashMap::from([("movie_id".to_string(), 300), ("company_type_id".to_string(), 1), ("note".to_string(), "ACME (France) (theatrical)")])];
+    let mut movie_info = vec![std::collections::HashMap::from([("movie_id".to_string(), 100), ("info".to_string(), "German"), ("info_type_id".to_string(), 10)]), std::collections::HashMap::from([("movie_id".to_string(), 200), ("info".to_string(), "Swedish"), ("info_type_id".to_string(), 10)]), std::collections::HashMap::from([("movie_id".to_string(), 300), ("info".to_string(), "German"), ("info_type_id".to_string(), 10)])];
+    let mut candidate_titles = {
+    let mut _res = Vec::new();
+    for ct in company_type.clone() {
+        for mc in movie_companies.clone() {
+            if !(_map_get(&mc, &"company_type_id".to_string()) == _map_get(&ct, &"ct_id".to_string())) { continue; }
+            for mi in movie_info.clone() {
+                if !(_map_get(&mi, &"movie_id".to_string()) == _map_get(&mc, &"movie_id".to_string())) { continue; }
+                for it in info_type.clone() {
+                    if !(_map_get(&it, &"it_id".to_string()) == _map_get(&mi, &"info_type_id".to_string())) { continue; }
+                    for t in title.clone() {
+                        if !(_map_get(&t, &"t_id".to_string()) == _map_get(&mc, &"movie_id".to_string())) { continue; }
+                        if _map_get(&mc, &"company_type_id".to_string()) == _map_get(&ct, &"ct_id".to_string()) && _map_get(&mi, &"movie_id".to_string()) == _map_get(&mc, &"movie_id".to_string()) && _map_get(&it, &"it_id".to_string()) == _map_get(&mi, &"info_type_id".to_string()) && _map_get(&t, &"t_id".to_string()) == _map_get(&mc, &"movie_id".to_string()) && _map_get(&mc, &"note".to_string()).contains(&_map_get(&mc, &"note".to_string()).contains(&_map_get(&ct, &"kind".to_string()) == "production companies" && "(theatrical)") && "(France)") && _map_get(&t, &"production_year".to_string()) > 2005 && (vec!["Sweden".to_string(), "Norway".to_string(), "Germany".to_string(), "Denmark".to_string(), "Swedish".to_string(), "Denish".to_string(), "Norwegian".to_string(), "German".to_string()].contains(&_map_get(&mi, &"info".to_string()))) {
+                            _res.push(_map_get(&t, &"title".to_string()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    let mut result = vec![std::collections::HashMap::from([("typical_european_movie".to_string(), min(candidate_titles))])];
+    json(result);
+    test_Q5_finds_the_lexicographically_first_qualifying_title();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}

--- a/tests/dataset/job/compiler/rust/q6.out
+++ b/tests/dataset/job/compiler/rust/q6.out
@@ -1,0 +1,1 @@
+[{"actor_name":"Downey Robert Jr.","marvel_movie":"Iron Man 3","movie_keyword":"marvel-cinematic-universe"}]

--- a/tests/dataset/job/compiler/rust/q6.rs.out
+++ b/tests/dataset/job/compiler/rust/q6.rs.out
@@ -1,0 +1,41 @@
+fn test_Q6_finds_marvel_movie_with_Robert_Downey() {
+    expect(result == vec![std::collections::HashMap::from([("movie_keyword".to_string(), "marvel-cinematic-universe"), ("actor_name".to_string(), "Downey Robert Jr."), ("marvel_movie".to_string(), "Iron Man 3")])]);
+}
+
+fn main() {
+    let mut cast_info = vec![std::collections::HashMap::from([("movie_id".to_string(), 1), ("person_id".to_string(), 101)]), std::collections::HashMap::from([("movie_id".to_string(), 2), ("person_id".to_string(), 102)])];
+    let mut keyword = vec![std::collections::HashMap::from([("id".to_string(), 100), ("keyword".to_string(), "marvel-cinematic-universe")]), std::collections::HashMap::from([("id".to_string(), 200), ("keyword".to_string(), "other")])];
+    let mut movie_keyword = vec![std::collections::HashMap::from([("movie_id".to_string(), 1), ("keyword_id".to_string(), 100)]), std::collections::HashMap::from([("movie_id".to_string(), 2), ("keyword_id".to_string(), 200)])];
+    let mut name = vec![std::collections::HashMap::from([("id".to_string(), 101), ("name".to_string(), "Downey Robert Jr.")]), std::collections::HashMap::from([("id".to_string(), 102), ("name".to_string(), "Chris Evans")])];
+    let mut title = vec![std::collections::HashMap::from([("id".to_string(), 1), ("title".to_string(), "Iron Man 3"), ("production_year".to_string(), 2013)]), std::collections::HashMap::from([("id".to_string(), 2), ("title".to_string(), "Old Movie"), ("production_year".to_string(), 2000)])];
+    let mut result = {
+    let mut _res = Vec::new();
+    for ci in cast_info.clone() {
+        for mk in movie_keyword.clone() {
+            if !(_map_get(&ci, &"movie_id".to_string()) == _map_get(&mk, &"movie_id".to_string())) { continue; }
+            for k in keyword.clone() {
+                if !(_map_get(&mk, &"keyword_id".to_string()) == _map_get(&k, &"id".to_string())) { continue; }
+                for n in name.clone() {
+                    if !(_map_get(&ci, &"person_id".to_string()) == _map_get(&n, &"id".to_string())) { continue; }
+                    for t in title.clone() {
+                        if !(_map_get(&ci, &"movie_id".to_string()) == _map_get(&t, &"id".to_string())) { continue; }
+                        if _map_get(&ci, &"movie_id".to_string()) == _map_get(&mk, &"movie_id".to_string()) && _map_get(&mk, &"keyword_id".to_string()) == _map_get(&k, &"id".to_string()) && _map_get(&ci, &"person_id".to_string()) == _map_get(&n, &"id".to_string()) && _map_get(&ci, &"movie_id".to_string()) == _map_get(&t, &"id".to_string()) && _map_get(&k, &"keyword".to_string()) == "marvel-cinematic-universe" && _map_get(&_map_get(&n, &"name".to_string()), &"contains".to_string())("Downey") && _map_get(&_map_get(&n, &"name".to_string()), &"contains".to_string())("Robert") && _map_get(&t, &"production_year".to_string()) > 2010 {
+                            _res.push(std::collections::HashMap::from([("movie_keyword".to_string(), _map_get(&k, &"keyword".to_string())), ("actor_name".to_string(), _map_get(&n, &"name".to_string())), ("marvel_movie".to_string(), _map_get(&t, &"title".to_string()))]));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    json(result);
+    test_Q6_finds_marvel_movie_with_Robert_Downey();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}

--- a/tests/dataset/job/compiler/rust/q7.out
+++ b/tests/dataset/job/compiler/rust/q7.out
@@ -1,0 +1,1 @@
+[{"biography_movie":"Feature Film","of_person":"Alan Brown"}]

--- a/tests/dataset/job/compiler/rust/q7.rs.out
+++ b/tests/dataset/job/compiler/rust/q7.rs.out
@@ -1,0 +1,66 @@
+fn test_Q7_finds_movie_features_biography_for_person() {
+    expect(result == vec![std::collections::HashMap::from([("of_person".to_string(), "Alan Brown"), ("biography_movie".to_string(), "Feature Film")])]);
+}
+
+fn main() {
+    let mut aka_name = vec![std::collections::HashMap::from([("person_id".to_string(), 1), ("name".to_string(), "Anna Mae")]), std::collections::HashMap::from([("person_id".to_string(), 2), ("name".to_string(), "Chris")])];
+    let mut cast_info = vec![std::collections::HashMap::from([("person_id".to_string(), 1), ("movie_id".to_string(), 10)]), std::collections::HashMap::from([("person_id".to_string(), 2), ("movie_id".to_string(), 20)])];
+    let mut info_type = vec![std::collections::HashMap::from([("id".to_string(), 1), ("info".to_string(), "mini biography")]), std::collections::HashMap::from([("id".to_string(), 2), ("info".to_string(), "trivia")])];
+    let mut link_type = vec![std::collections::HashMap::from([("id".to_string(), 1), ("link".to_string(), "features")]), std::collections::HashMap::from([("id".to_string(), 2), ("link".to_string(), "references")])];
+    let mut movie_link = vec![std::collections::HashMap::from([("linked_movie_id".to_string(), 10), ("link_type_id".to_string(), 1)]), std::collections::HashMap::from([("linked_movie_id".to_string(), 20), ("link_type_id".to_string(), 2)])];
+    let mut name = vec![std::collections::HashMap::from([("id".to_string(), 1), ("name".to_string(), "Alan Brown"), ("name_pcode_cf".to_string(), "B"), ("gender".to_string(), "m")]), std::collections::HashMap::from([("id".to_string(), 2), ("name".to_string(), "Zoe"), ("name_pcode_cf".to_string(), "Z"), ("gender".to_string(), "f")])];
+    let mut person_info = vec![std::collections::HashMap::from([("person_id".to_string(), 1), ("info_type_id".to_string(), 1), ("note".to_string(), "Volker Boehm")]), std::collections::HashMap::from([("person_id".to_string(), 2), ("info_type_id".to_string(), 1), ("note".to_string(), "Other")])];
+    let mut title = vec![std::collections::HashMap::from([("id".to_string(), 10), ("title".to_string(), "Feature Film"), ("production_year".to_string(), 1990)]), std::collections::HashMap::from([("id".to_string(), 20), ("title".to_string(), "Late Film"), ("production_year".to_string(), 2000)])];
+    let mut rows = {
+    let mut _res = Vec::new();
+    for an in aka_name.clone() {
+        for n in name.clone() {
+            if !(_map_get(&n, &"id".to_string()) == _map_get(&an, &"person_id".to_string())) { continue; }
+            for pi in person_info.clone() {
+                if !(_map_get(&pi, &"person_id".to_string()) == _map_get(&an, &"person_id".to_string())) { continue; }
+                for it in info_type.clone() {
+                    if !(_map_get(&it, &"id".to_string()) == _map_get(&pi, &"info_type_id".to_string())) { continue; }
+                    for ci in cast_info.clone() {
+                        if !(_map_get(&ci, &"person_id".to_string()) == _map_get(&n, &"id".to_string())) { continue; }
+                        for t in title.clone() {
+                            if !(_map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string())) { continue; }
+                            for ml in movie_link.clone() {
+                                if !(_map_get(&ml, &"linked_movie_id".to_string()) == _map_get(&t, &"id".to_string())) { continue; }
+                                for lt in link_type.clone() {
+                                    if !(_map_get(&lt, &"id".to_string()) == _map_get(&ml, &"link_type_id".to_string())) { continue; }
+                                    if _map_get(&n, &"id".to_string()) == _map_get(&an, &"person_id".to_string()) && _map_get(&pi, &"person_id".to_string()) == _map_get(&an, &"person_id".to_string()) && _map_get(&it, &"id".to_string()) == _map_get(&pi, &"info_type_id".to_string()) && _map_get(&ci, &"person_id".to_string()) == _map_get(&n, &"id".to_string()) && _map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string()) && _map_get(&ml, &"linked_movie_id".to_string()) == _map_get(&t, &"id".to_string()) && _map_get(&lt, &"id".to_string()) == _map_get(&ml, &"link_type_id".to_string()) && (_map_get(&_map_get(&an, &"name".to_string()), &"contains".to_string())("a") && _map_get(&it, &"info".to_string()) == "mini biography" && _map_get(&lt, &"link".to_string()) == "features" && _map_get(&n, &"name_pcode_cf".to_string()) >= "A" && _map_get(&n, &"name_pcode_cf".to_string()) <= "F" && (_map_get(&n, &"gender".to_string()) == "m" || (_map_get(&n, &"gender".to_string()) == "f" && _map_get(&_map_get(&n, &"name".to_string()), &"starts_with".to_string())("B"))) && _map_get(&pi, &"note".to_string()) == "Volker Boehm" && _map_get(&t, &"production_year".to_string()) >= 1980 && _map_get(&t, &"production_year".to_string()) <= 1995 && _map_get(&pi, &"person_id".to_string()) == _map_get(&an, &"person_id".to_string()) && _map_get(&pi, &"person_id".to_string()) == _map_get(&ci, &"person_id".to_string()) && _map_get(&an, &"person_id".to_string()) == _map_get(&ci, &"person_id".to_string()) && _map_get(&ci, &"movie_id".to_string()) == _map_get(&ml, &"linked_movie_id".to_string())) {
+                                        _res.push(std::collections::HashMap::from([("person_name".to_string(), _map_get(&n, &"name".to_string())), ("movie_title".to_string(), _map_get(&t, &"title".to_string()))]));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    let mut result = vec![std::collections::HashMap::from([("of_person".to_string(), min({
+    let mut _res = Vec::new();
+    for r in rows {
+        _res.push(_map_get(&r, &"person_name".to_string()));
+    }
+    _res
+})), ("biography_movie".to_string(), min({
+    let mut _res = Vec::new();
+    for r in rows {
+        _res.push(_map_get(&r, &"movie_title".to_string()));
+    }
+    _res
+}))])];
+    json(result);
+    test_Q7_finds_movie_features_biography_for_person();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}

--- a/tests/dataset/job/compiler/rust/q8.out
+++ b/tests/dataset/job/compiler/rust/q8.out
@@ -1,0 +1,1 @@
+[{"actress_pseudonym":"Y. S.","japanese_movie_dubbed":"Dubbed Film"}]

--- a/tests/dataset/job/compiler/rust/q8.rs.out
+++ b/tests/dataset/job/compiler/rust/q8.rs.out
@@ -1,0 +1,62 @@
+fn test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing() {
+    expect(result == vec![std::collections::HashMap::from([("actress_pseudonym".to_string(), "Y. S."), ("japanese_movie_dubbed".to_string(), "Dubbed Film")])]);
+}
+
+fn main() {
+    let mut aka_name = vec![std::collections::HashMap::from([("person_id".to_string(), 1), ("name".to_string(), "Y. S.")])];
+    let mut cast_info = vec![std::collections::HashMap::from([("person_id".to_string(), 1), ("movie_id".to_string(), 10), ("note".to_string(), "(voice: English version)"), ("role_id".to_string(), 1000)])];
+    let mut company_name = vec![std::collections::HashMap::from([("id".to_string(), 50), ("country_code".to_string(), "[jp]")])];
+    let mut movie_companies = vec![std::collections::HashMap::from([("movie_id".to_string(), 10), ("company_id".to_string(), 50), ("note".to_string(), "Studio (Japan)")])];
+    let mut name = vec![std::collections::HashMap::from([("id".to_string(), 1), ("name".to_string(), "Yoko Ono")]), std::collections::HashMap::from([("id".to_string(), 2), ("name".to_string(), "Yuichi")])];
+    let mut role_type = vec![std::collections::HashMap::from([("id".to_string(), 1000), ("role".to_string(), "actress")])];
+    let mut title = vec![std::collections::HashMap::from([("id".to_string(), 10), ("title".to_string(), "Dubbed Film")])];
+    let mut eligible = {
+    let mut _res = Vec::new();
+    for an1 in aka_name.clone() {
+        for n1 in name.clone() {
+            if !(_map_get(&n1, &"id".to_string()) == _map_get(&an1, &"person_id".to_string())) { continue; }
+            for ci in cast_info.clone() {
+                if !(_map_get(&ci, &"person_id".to_string()) == _map_get(&an1, &"person_id".to_string())) { continue; }
+                for t in title.clone() {
+                    if !(_map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string())) { continue; }
+                    for mc in movie_companies.clone() {
+                        if !(_map_get(&mc, &"movie_id".to_string()) == _map_get(&ci, &"movie_id".to_string())) { continue; }
+                        for cn in company_name.clone() {
+                            if !(_map_get(&cn, &"id".to_string()) == _map_get(&mc, &"company_id".to_string())) { continue; }
+                            for rt in role_type.clone() {
+                                if !(_map_get(&rt, &"id".to_string()) == _map_get(&ci, &"role_id".to_string())) { continue; }
+                                if _map_get(&n1, &"id".to_string()) == _map_get(&an1, &"person_id".to_string()) && _map_get(&ci, &"person_id".to_string()) == _map_get(&an1, &"person_id".to_string()) && _map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string()) && _map_get(&mc, &"movie_id".to_string()) == _map_get(&ci, &"movie_id".to_string()) && _map_get(&cn, &"id".to_string()) == _map_get(&mc, &"company_id".to_string()) && _map_get(&rt, &"id".to_string()) == _map_get(&ci, &"role_id".to_string()) && _map_get(&ci, &"note".to_string()) == "(voice: English version)" && _map_get(&cn, &"country_code".to_string()) == "[jp]" && _map_get(&_map_get(&mc, &"note".to_string()), &"contains".to_string())("(Japan)") && (!_map_get(&_map_get(&mc, &"note".to_string()), &"contains".to_string())("(USA)")) && _map_get(&_map_get(&n1, &"name".to_string()), &"contains".to_string())("Yo") && (!_map_get(&_map_get(&n1, &"name".to_string()), &"contains".to_string())("Yu")) && _map_get(&rt, &"role".to_string()) == "actress" {
+                                    _res.push(std::collections::HashMap::from([("pseudonym".to_string(), _map_get(&an1, &"name".to_string())), ("movie_title".to_string(), _map_get(&t, &"title".to_string()))]));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    let mut result = vec![std::collections::HashMap::from([("actress_pseudonym".to_string(), min({
+    let mut _res = Vec::new();
+    for x in eligible {
+        _res.push(_map_get(&x, &"pseudonym".to_string()));
+    }
+    _res
+})), ("japanese_movie_dubbed".to_string(), min({
+    let mut _res = Vec::new();
+    for x in eligible {
+        _res.push(_map_get(&x, &"movie_title".to_string()));
+    }
+    _res
+}))])];
+    json(result);
+    test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}

--- a/tests/dataset/job/compiler/rust/q9.out
+++ b/tests/dataset/job/compiler/rust/q9.out
@@ -1,0 +1,1 @@
+[{"alternative_name":"A. N. G.","character_name":"Angel","movie":"Famous Film"}]

--- a/tests/dataset/job/compiler/rust/q9.rs.out
+++ b/tests/dataset/job/compiler/rust/q9.rs.out
@@ -1,0 +1,72 @@
+fn test_Q9_selects_minimal_alternative_name__character_and_movie() {
+    expect(result == vec![std::collections::HashMap::from([("alternative_name".to_string(), "A. N. G."), ("character_name".to_string(), "Angel"), ("movie".to_string(), "Famous Film")])]);
+}
+
+fn main() {
+    let mut aka_name = vec![std::collections::HashMap::from([("person_id".to_string(), 1), ("name".to_string(), "A. N. G.")]), std::collections::HashMap::from([("person_id".to_string(), 2), ("name".to_string(), "J. D.")])];
+    let mut char_name = vec![std::collections::HashMap::from([("id".to_string(), 10), ("name".to_string(), "Angel")]), std::collections::HashMap::from([("id".to_string(), 20), ("name".to_string(), "Devil")])];
+    let mut cast_info = vec![std::collections::HashMap::from([("person_id".to_string(), 1), ("person_role_id".to_string(), 10), ("movie_id".to_string(), 100), ("role_id".to_string(), 1000), ("note".to_string(), "(voice)")]), std::collections::HashMap::from([("person_id".to_string(), 2), ("person_role_id".to_string(), 20), ("movie_id".to_string(), 200), ("role_id".to_string(), 1000), ("note".to_string(), "(voice)")])];
+    let mut company_name = vec![std::collections::HashMap::from([("id".to_string(), 100), ("country_code".to_string(), "[us]")]), std::collections::HashMap::from([("id".to_string(), 200), ("country_code".to_string(), "[gb]")])];
+    let mut movie_companies = vec![std::collections::HashMap::from([("movie_id".to_string(), 100), ("company_id".to_string(), 100), ("note".to_string(), "ACME Studios (USA)")]), std::collections::HashMap::from([("movie_id".to_string(), 200), ("company_id".to_string(), 200), ("note".to_string(), "Maple Films")])];
+    let mut name = vec![std::collections::HashMap::from([("id".to_string(), 1), ("name".to_string(), "Angela Smith"), ("gender".to_string(), "f")]), std::collections::HashMap::from([("id".to_string(), 2), ("name".to_string(), "John Doe"), ("gender".to_string(), "m")])];
+    let mut role_type = vec![std::collections::HashMap::from([("id".to_string(), 1000), ("role".to_string(), "actress")]), std::collections::HashMap::from([("id".to_string(), 2000), ("role".to_string(), "actor")])];
+    let mut title = vec![std::collections::HashMap::from([("id".to_string(), 100), ("title".to_string(), "Famous Film"), ("production_year".to_string(), 2010)]), std::collections::HashMap::from([("id".to_string(), 200), ("title".to_string(), "Old Movie"), ("production_year".to_string(), 1999)])];
+    let mut matches = {
+    let mut _res = Vec::new();
+    for an in aka_name.clone() {
+        for n in name.clone() {
+            if !(_map_get(&an, &"person_id".to_string()) == _map_get(&n, &"id".to_string())) { continue; }
+            for ci in cast_info.clone() {
+                if !(_map_get(&ci, &"person_id".to_string()) == _map_get(&n, &"id".to_string())) { continue; }
+                for chn in char_name.clone() {
+                    if !(_map_get(&chn, &"id".to_string()) == _map_get(&ci, &"person_role_id".to_string())) { continue; }
+                    for t in title.clone() {
+                        if !(_map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string())) { continue; }
+                        for mc in movie_companies.clone() {
+                            if !(_map_get(&mc, &"movie_id".to_string()) == _map_get(&t, &"id".to_string())) { continue; }
+                            for cn in company_name.clone() {
+                                if !(_map_get(&cn, &"id".to_string()) == _map_get(&mc, &"company_id".to_string())) { continue; }
+                                for rt in role_type.clone() {
+                                    if !(_map_get(&rt, &"id".to_string()) == _map_get(&ci, &"role_id".to_string())) { continue; }
+                                    if _map_get(&an, &"person_id".to_string()) == _map_get(&n, &"id".to_string()) && _map_get(&ci, &"person_id".to_string()) == _map_get(&n, &"id".to_string()) && _map_get(&chn, &"id".to_string()) == _map_get(&ci, &"person_role_id".to_string()) && _map_get(&t, &"id".to_string()) == _map_get(&ci, &"movie_id".to_string()) && _map_get(&mc, &"movie_id".to_string()) == _map_get(&t, &"id".to_string()) && _map_get(&cn, &"id".to_string()) == _map_get(&mc, &"company_id".to_string()) && _map_get(&rt, &"id".to_string()) == _map_get(&ci, &"role_id".to_string()) && (vec!["(voice)".to_string(), "(voice: Japanese version)".to_string(), "(voice) (uncredited)".to_string(), "(voice: English version)".to_string()].contains(&_map_get(&ci, &"note".to_string()))) && _map_get(&cn, &"country_code".to_string()) == "[us]" && (_map_get(&_map_get(&mc, &"note".to_string()), &"contains".to_string())("(USA)") || _map_get(&_map_get(&mc, &"note".to_string()), &"contains".to_string())("(worldwide)")) && _map_get(&n, &"gender".to_string()) == "f" && _map_get(&_map_get(&n, &"name".to_string()), &"contains".to_string())("Ang") && _map_get(&rt, &"role".to_string()) == "actress" && _map_get(&t, &"production_year".to_string()) >= 2005 && _map_get(&t, &"production_year".to_string()) <= 2015 {
+                                        _res.push(std::collections::HashMap::from([("alt".to_string(), _map_get(&an, &"name".to_string())), ("character".to_string(), _map_get(&chn, &"name".to_string())), ("movie".to_string(), _map_get(&t, &"title".to_string()))]));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    _res
+};
+    let mut result = vec![std::collections::HashMap::from([("alternative_name".to_string(), min({
+    let mut _res = Vec::new();
+    for x in matches {
+        _res.push(_map_get(&x, &"alt".to_string()));
+    }
+    _res
+})), ("character_name".to_string(), min({
+    let mut _res = Vec::new();
+    for x in matches {
+        _res.push(_map_get(&x, &"character".to_string()));
+    }
+    _res
+})), ("movie".to_string(), min({
+    let mut _res = Vec::new();
+    for x in matches {
+        _res.push(_map_get(&x, &"movie".to_string()));
+    }
+    _res
+}))])];
+    json(result);
+    test_Q9_selects_minimal_alternative_name__character_and_movie();
+}
+
+fn _map_get<K: std::cmp::Eq + std::hash::Hash, V: Clone>(m: &std::collections::HashMap<K, V>, k: &K) -> V {
+    m.get(k).unwrap().clone()
+}
+fn expect(cond: bool) {
+    if !cond { panic!("expect failed"); }
+}


### PR DESCRIPTION
## Summary
- extend Rust compiler job tests to cover queries q1 through q10
- add generated Rust code for job dataset queries q3–q10
- store expected output for Rust-compiled job queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e8b997fc08320ac39c7598aa4082f