### PR TITLE
Add JOB golden test for Smalltalk backend

### DIFF
--- a/compile/x/st/TASKS.md
+++ b/compile/x/st/TASKS.md
@@ -8,9 +8,9 @@ golden tests cover `tpch_q1` and simple `group_by` queries.
 
 ## Pending JOB Queries
 
-The compiler still fails to execute JOB queries q1-q10 under GNU Smalltalk.
-Generated code raises "undefined variable" errors when run with `gst`.
-Future work should fix code generation for global result values and
-verify runtime output matches the VM implementation. Golden files for
-q1-q10 have been generated but tests remain skipped until execution
-succeeds.
+Initial work towards running the JOB dataset defined global variables
+before class creation and quoted map keys. The programs now compile,
+but `gst` still reports parse errors around query expressions. Further
+debugging of the generated Smalltalk syntax is required before the
+queries execute successfully. Golden files for `q1`–`q10` exist and a
+new `JOB_Golden` test validates the emitted code.

--- a/compile/x/st/job_golden_test.go
+++ b/compile/x/st/job_golden_test.go
@@ -1,0 +1,46 @@
+//go:build slow
+
+package stcode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	stcode "mochi/compile/x/st"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestSTCompiler_JOB_Golden(t *testing.T) {
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 10; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "job", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := stcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantPath := filepath.Join(root, "tests", "dataset", "job", "compiler", "st", q+".st.out")
+			want, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".st.out", got, bytes.TrimSpace(want))
+			}
+		})
+	}
+}

--- a/tests/dataset/job/compiler/st/q1.st.out
+++ b/tests/dataset/job/compiler/st/q1.st.out
@@ -1,8 +1,16 @@
+Smalltalk at: #company_type put: nil.
+Smalltalk at: #filtered put: nil.
+Smalltalk at: #info_type put: nil.
+Smalltalk at: #movie_companies put: nil.
+Smalltalk at: #movie_info_idx put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q1_returns_min_note__title_and_year_for_top_ranked_co_production
-    ((result = Dictionary from: {production_note -> 'ACME (co-production)'. movie_title -> 'Good Movie'. movie_year -> 1995})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Dictionary from: {'production_note' -> 'ACME (co-production)'. 'movie_title' -> 'Good Movie'. 'movie_year' -> 1995})) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,11 +22,11 @@ __min: v
     ^ m
 !
 !!
-company_type := Array with: Dictionary from: {id -> 1. kind -> 'production companies'} with: Dictionary from: {id -> 2. kind -> 'distributors'}.
-info_type := Array with: Dictionary from: {id -> 10. info -> 'top 250 rank'} with: Dictionary from: {id -> 20. info -> 'bottom 10 rank'}.
-title := Array with: Dictionary from: {id -> 100. title -> 'Good Movie'. production_year -> 1995} with: Dictionary from: {id -> 200. title -> 'Bad Movie'. production_year -> 2000}.
-movie_companies := Array with: Dictionary from: {movie_id -> 100. company_type_id -> 1. note -> 'ACME (co-production)'} with: Dictionary from: {movie_id -> 200. company_type_id -> 1. note -> 'MGM (as Metro-Goldwyn-Mayer Pictures)'}.
-movie_info_idx := Array with: Dictionary from: {movie_id -> 100. info_type_id -> 10} with: Dictionary from: {movie_id -> 200. info_type_id -> 20}.
+company_type := Array with: (Dictionary from: {'id' -> 1. 'kind' -> 'production companies'}) with: (Dictionary from: {'id' -> 2. 'kind' -> 'distributors'}).
+info_type := Array with: (Dictionary from: {'id' -> 10. 'info' -> 'top 250 rank'}) with: (Dictionary from: {'id' -> 20. 'info' -> 'bottom 10 rank'}).
+title := Array with: (Dictionary from: {'id' -> 100. 'title' -> 'Good Movie'. 'production_year' -> 1995}) with: (Dictionary from: {'id' -> 200. 'title' -> 'Bad Movie'. 'production_year' -> 2000}).
+movie_companies := Array with: (Dictionary from: {'movie_id' -> 100. 'company_type_id' -> 1. 'note' -> 'ACME (co-production)'}) with: (Dictionary from: {'movie_id' -> 200. 'company_type_id' -> 1. 'note' -> 'MGM (as Metro-Goldwyn-Mayer Pictures)'}).
+movie_info_idx := Array with: (Dictionary from: {'movie_id' -> 100. 'info_type_id' -> 10}) with: (Dictionary from: {'movie_id' -> 200. 'info_type_id' -> 20}).
 filtered := ((| res |
 res := OrderedCollection new.
 ((company_type) select: [:ct | (((((((((ct at: 'kind' = 'production companies') and: [it at: 'info']) = 'top 250 rank') and: [(((mc at: 'note' at: 'contains' value: '(as Metro-Goldwyn-Mayer Pictures)')) not)]) and: [(((mc at: 'note' at: 'contains' value: '(co-production)') or: [(mc at: 'note' at: 'contains' value: '(presents)')]))]) and: [(ct at: 'id' = mc at: 'company_type_id')]) and: [(t at: 'id' = mc at: 'movie_id')]) and: [(mi at: 'movie_id' = t at: 'id')]) and: [(it at: 'id' = mi at: 'info_type_id')])]) do: [:ct |
@@ -26,7 +34,7 @@ res := OrderedCollection new.
         (title) do: [:t |
             (movie_info_idx) do: [:mi |
                 (info_type) do: [:it |
-                    res add: Dictionary from: {note -> mc at: 'note'. title -> t at: 'title'. year -> t at: 'production_year'}.
+                    res add: Dictionary from: {'note' -> mc at: 'note'. 'title' -> t at: 'title'. 'year' -> t at: 'production_year'}.
                 ]
             ]
         ]
@@ -34,19 +42,19 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Dictionary from: {production_note -> (Main __min: ((| res |
+result := Dictionary from: {'production_note' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (filtered) do: [:r |
     res add: r at: 'note'.
 ]
 res := res asArray.
-res))). movie_title -> (Main __min: ((| res |
+res))). 'movie_title' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (filtered) do: [:r |
     res add: r at: 'title'.
 ]
 res := res asArray.
-res))). movie_year -> (Main __min: ((| res |
+res))). 'movie_year' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (filtered) do: [:r |
     res add: r at: 'year'.

--- a/tests/dataset/job/compiler/st/q10.st.out
+++ b/tests/dataset/job/compiler/st/q10.st.out
@@ -1,8 +1,18 @@
+Smalltalk at: #cast_info put: nil.
+Smalltalk at: #char_name put: nil.
+Smalltalk at: #company_name put: nil.
+Smalltalk at: #company_type put: nil.
+Smalltalk at: #matches put: nil.
+Smalltalk at: #movie_companies put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #role_type put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q10_finds_uncredited_voice_actor_in_Russian_movie
-    ((result = Array with: Dictionary from: {uncredited_voiced_character -> 'Ivan'. russian_movie -> 'Vodka Dreams'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'uncredited_voiced_character' -> 'Ivan'. 'russian_movie' -> 'Vodka Dreams'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,13 +24,13 @@ __min: v
     ^ m
 !
 !!
-char_name := Array with: Dictionary from: {id -> 1. name -> 'Ivan'} with: Dictionary from: {id -> 2. name -> 'Alex'}.
-cast_info := Array with: Dictionary from: {movie_id -> 10. person_role_id -> 1. role_id -> 1. note -> 'Soldier (voice) (uncredited)'} with: Dictionary from: {movie_id -> 11. person_role_id -> 2. role_id -> 1. note -> '(voice)'}.
-company_name := Array with: Dictionary from: {id -> 1. country_code -> '[ru]'} with: Dictionary from: {id -> 2. country_code -> '[us]'}.
-company_type := Array with: Dictionary from: {id -> 1} with: Dictionary from: {id -> 2}.
-movie_companies := Array with: Dictionary from: {movie_id -> 10. company_id -> 1. company_type_id -> 1} with: Dictionary from: {movie_id -> 11. company_id -> 2. company_type_id -> 1}.
-role_type := Array with: Dictionary from: {id -> 1. role -> 'actor'} with: Dictionary from: {id -> 2. role -> 'director'}.
-title := Array with: Dictionary from: {id -> 10. title -> 'Vodka Dreams'. production_year -> 2006} with: Dictionary from: {id -> 11. title -> 'Other Film'. production_year -> 2004}.
+char_name := Array with: (Dictionary from: {'id' -> 1. 'name' -> 'Ivan'}) with: (Dictionary from: {'id' -> 2. 'name' -> 'Alex'}).
+cast_info := Array with: (Dictionary from: {'movie_id' -> 10. 'person_role_id' -> 1. 'role_id' -> 1. 'note' -> 'Soldier (voice) (uncredited)'}) with: (Dictionary from: {'movie_id' -> 11. 'person_role_id' -> 2. 'role_id' -> 1. 'note' -> '(voice)'}).
+company_name := Array with: (Dictionary from: {'id' -> 1. 'country_code' -> '[ru]'}) with: (Dictionary from: {'id' -> 2. 'country_code' -> '[us]'}).
+company_type := Array with: (Dictionary from: {'id' -> 1}) with: (Dictionary from: {'id' -> 2}).
+movie_companies := Array with: (Dictionary from: {'movie_id' -> 10. 'company_id' -> 1. 'company_type_id' -> 1}) with: (Dictionary from: {'movie_id' -> 11. 'company_id' -> 2. 'company_type_id' -> 1}).
+role_type := Array with: (Dictionary from: {'id' -> 1. 'role' -> 'actor'}) with: (Dictionary from: {'id' -> 2. 'role' -> 'director'}).
+title := Array with: (Dictionary from: {'id' -> 10. 'title' -> 'Vodka Dreams'. 'production_year' -> 2006}) with: (Dictionary from: {'id' -> 11. 'title' -> 'Other Film'. 'production_year' -> 2004}).
 matches := ((| res |
 res := OrderedCollection new.
 ((char_name) select: [:chn | ((((((((((((((ci at: 'note' at: 'contains' value: '(voice)') and: [(ci at: 'note' at: 'contains' value: '(uncredited)')]) and: [cn at: 'country_code']) = '[ru]') and: [rt at: 'role']) = 'actor') and: [t at: 'production_year']) > 2005) and: [(chn at: 'id' = ci at: 'person_role_id')]) and: [(rt at: 'id' = ci at: 'role_id')]) and: [(t at: 'id' = ci at: 'movie_id')]) and: [(mc at: 'movie_id' = t at: 'id')]) and: [(cn at: 'id' = mc at: 'company_id')]) and: [(ct at: 'id' = mc at: 'company_type_id')])]) do: [:chn |
@@ -30,7 +40,7 @@ res := OrderedCollection new.
                 (movie_companies) do: [:mc |
                     (company_name) do: [:cn |
                         (company_type) do: [:ct |
-                            res add: Dictionary from: {character -> chn at: 'name'. movie -> t at: 'title'}.
+                            res add: Dictionary from: {'character' -> chn at: 'name'. 'movie' -> t at: 'title'}.
                         ]
                     ]
                 ]
@@ -40,18 +50,18 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Array with: Dictionary from: {uncredited_voiced_character -> (Main __min: ((| res |
+result := Array with: (Dictionary from: {'uncredited_voiced_character' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (matches) do: [:x |
     res add: x at: 'character'.
 ]
 res := res asArray.
-res))). russian_movie -> (Main __min: ((| res |
+res))). 'russian_movie' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (matches) do: [:x |
     res add: x at: 'movie'.
 ]
 res := res asArray.
-res)))}.
+res)))}).
 (result toJSON) displayOn: Transcript. Transcript cr.
 Main test_Q10_finds_uncredited_voice_actor_in_Russian_movie.

--- a/tests/dataset/job/compiler/st/q2.st.out
+++ b/tests/dataset/job/compiler/st/q2.st.out
@@ -1,3 +1,11 @@
+Smalltalk at: #company_name put: nil.
+Smalltalk at: #keyword put: nil.
+Smalltalk at: #movie_companies put: nil.
+Smalltalk at: #movie_keyword put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #title put: nil.
+Smalltalk at: #titles put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
@@ -14,11 +22,11 @@ __min: v
     ^ m
 !
 !!
-company_name := Array with: Dictionary from: {id -> 1. country_code -> '[de]'} with: Dictionary from: {id -> 2. country_code -> '[us]'}.
-keyword := Array with: Dictionary from: {id -> 1. keyword -> 'character-name-in-title'} with: Dictionary from: {id -> 2. keyword -> 'other'}.
-movie_companies := Array with: Dictionary from: {movie_id -> 100. company_id -> 1} with: Dictionary from: {movie_id -> 200. company_id -> 2}.
-movie_keyword := Array with: Dictionary from: {movie_id -> 100. keyword_id -> 1} with: Dictionary from: {movie_id -> 200. keyword_id -> 2}.
-title := Array with: Dictionary from: {id -> 100. title -> 'Der Film'} with: Dictionary from: {id -> 200. title -> 'Other Movie'}.
+company_name := Array with: (Dictionary from: {'id' -> 1. 'country_code' -> '[de]'}) with: (Dictionary from: {'id' -> 2. 'country_code' -> '[us]'}).
+keyword := Array with: (Dictionary from: {'id' -> 1. 'keyword' -> 'character-name-in-title'}) with: (Dictionary from: {'id' -> 2. 'keyword' -> 'other'}).
+movie_companies := Array with: (Dictionary from: {'movie_id' -> 100. 'company_id' -> 1}) with: (Dictionary from: {'movie_id' -> 200. 'company_id' -> 2}).
+movie_keyword := Array with: (Dictionary from: {'movie_id' -> 100. 'keyword_id' -> 1}) with: (Dictionary from: {'movie_id' -> 200. 'keyword_id' -> 2}).
+title := Array with: (Dictionary from: {'id' -> 100. 'title' -> 'Der Film'}) with: (Dictionary from: {'id' -> 200. 'title' -> 'Other Movie'}).
 titles := ((| res |
 res := OrderedCollection new.
 ((company_name) select: [:cn | (((((((((cn at: 'country_code' = '[de]') and: [k at: 'keyword']) = 'character-name-in-title') and: [mc at: 'movie_id']) = mk at: 'movie_id') and: [(mc at: 'company_id' = cn at: 'id')]) and: [(mc at: 'movie_id' = t at: 'id')]) and: [(mk at: 'movie_id' = t at: 'id')]) and: [(mk at: 'keyword_id' = k at: 'id')])]) do: [:cn |

--- a/tests/dataset/job/compiler/st/q3.st.out
+++ b/tests/dataset/job/compiler/st/q3.st.out
@@ -1,8 +1,16 @@
+Smalltalk at: #allowed_infos put: nil.
+Smalltalk at: #candidate_titles put: nil.
+Smalltalk at: #keyword put: nil.
+Smalltalk at: #movie_info put: nil.
+Smalltalk at: #movie_keyword put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q3_returns_lexicographically_smallest_sequel_title
-    ((result = Array with: Dictionary from: {movie_title -> 'Alpha'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'movie_title' -> 'Alpha'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,10 +22,10 @@ __min: v
     ^ m
 !
 !!
-keyword := Array with: Dictionary from: {id -> 1. keyword -> 'amazing sequel'} with: Dictionary from: {id -> 2. keyword -> 'prequel'}.
-movie_info := Array with: Dictionary from: {movie_id -> 10. info -> 'Germany'} with: Dictionary from: {movie_id -> 30. info -> 'Sweden'} with: Dictionary from: {movie_id -> 20. info -> 'France'}.
-movie_keyword := Array with: Dictionary from: {movie_id -> 10. keyword_id -> 1} with: Dictionary from: {movie_id -> 30. keyword_id -> 1} with: Dictionary from: {movie_id -> 20. keyword_id -> 1} with: Dictionary from: {movie_id -> 10. keyword_id -> 2}.
-title := Array with: Dictionary from: {id -> 10. title -> 'Alpha'. production_year -> 2006} with: Dictionary from: {id -> 30. title -> 'Beta'. production_year -> 2008} with: Dictionary from: {id -> 20. title -> 'Gamma'. production_year -> 2009}.
+keyword := Array with: (Dictionary from: {'id' -> 1. 'keyword' -> 'amazing sequel'}) with: (Dictionary from: {'id' -> 2. 'keyword' -> 'prequel'}).
+movie_info := Array with: (Dictionary from: {'movie_id' -> 10. 'info' -> 'Germany'}) with: (Dictionary from: {'movie_id' -> 30. 'info' -> 'Sweden'}) with: (Dictionary from: {'movie_id' -> 20. 'info' -> 'France'}).
+movie_keyword := Array with: (Dictionary from: {'movie_id' -> 10. 'keyword_id' -> 1}) with: (Dictionary from: {'movie_id' -> 30. 'keyword_id' -> 1}) with: (Dictionary from: {'movie_id' -> 20. 'keyword_id' -> 1}) with: (Dictionary from: {'movie_id' -> 10. 'keyword_id' -> 2}).
+title := Array with: (Dictionary from: {'id' -> 10. 'title' -> 'Alpha'. 'production_year' -> 2006}) with: (Dictionary from: {'id' -> 30. 'title' -> 'Beta'. 'production_year' -> 2008}) with: (Dictionary from: {'id' -> 20. 'title' -> 'Gamma'. 'production_year' -> 2009}).
 allowed_infos := Array with: 'Sweden' with: 'Norway' with: 'Germany' with: 'Denmark' with: 'Swedish' with: 'Denish' with: 'Norwegian' with: 'German'.
 candidate_titles := ((| res |
 res := OrderedCollection new.
@@ -32,6 +40,6 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Array with: Dictionary from: {movie_title -> (Main __min: candidate_titles)}.
+result := Array with: (Dictionary from: {'movie_title' -> (Main __min: candidate_titles)}).
 (result toJSON) displayOn: Transcript. Transcript cr.
 Main test_Q3_returns_lexicographically_smallest_sequel_title.

--- a/tests/dataset/job/compiler/st/q4.st.out
+++ b/tests/dataset/job/compiler/st/q4.st.out
@@ -1,8 +1,16 @@
+Smalltalk at: #info_type put: nil.
+Smalltalk at: #keyword put: nil.
+Smalltalk at: #movie_info_idx put: nil.
+Smalltalk at: #movie_keyword put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #rows put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q4_returns_minimum_rating_and_title_for_sequels
-    ((result = Array with: Dictionary from: {rating -> '6.2'. movie_title -> 'Alpha Movie'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'rating' -> '6.2'. 'movie_title' -> 'Alpha Movie'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,11 +22,11 @@ __min: v
     ^ m
 !
 !!
-info_type := Array with: Dictionary from: {id -> 1. info -> 'rating'} with: Dictionary from: {id -> 2. info -> 'other'}.
-keyword := Array with: Dictionary from: {id -> 1. keyword -> 'great sequel'} with: Dictionary from: {id -> 2. keyword -> 'prequel'}.
-title := Array with: Dictionary from: {id -> 10. title -> 'Alpha Movie'. production_year -> 2006} with: Dictionary from: {id -> 20. title -> 'Beta Film'. production_year -> 2007} with: Dictionary from: {id -> 30. title -> 'Old Film'. production_year -> 2004}.
-movie_keyword := Array with: Dictionary from: {movie_id -> 10. keyword_id -> 1} with: Dictionary from: {movie_id -> 20. keyword_id -> 1} with: Dictionary from: {movie_id -> 30. keyword_id -> 1}.
-movie_info_idx := Array with: Dictionary from: {movie_id -> 10. info_type_id -> 1. info -> '6.2'} with: Dictionary from: {movie_id -> 20. info_type_id -> 1. info -> '7.8'} with: Dictionary from: {movie_id -> 30. info_type_id -> 1. info -> '4.5'}.
+info_type := Array with: (Dictionary from: {'id' -> 1. 'info' -> 'rating'}) with: (Dictionary from: {'id' -> 2. 'info' -> 'other'}).
+keyword := Array with: (Dictionary from: {'id' -> 1. 'keyword' -> 'great sequel'}) with: (Dictionary from: {'id' -> 2. 'keyword' -> 'prequel'}).
+title := Array with: (Dictionary from: {'id' -> 10. 'title' -> 'Alpha Movie'. 'production_year' -> 2006}) with: (Dictionary from: {'id' -> 20. 'title' -> 'Beta Film'. 'production_year' -> 2007}) with: (Dictionary from: {'id' -> 30. 'title' -> 'Old Film'. 'production_year' -> 2004}).
+movie_keyword := Array with: (Dictionary from: {'movie_id' -> 10. 'keyword_id' -> 1}) with: (Dictionary from: {'movie_id' -> 20. 'keyword_id' -> 1}) with: (Dictionary from: {'movie_id' -> 30. 'keyword_id' -> 1}).
+movie_info_idx := Array with: (Dictionary from: {'movie_id' -> 10. 'info_type_id' -> 1. 'info' -> '6.2'}) with: (Dictionary from: {'movie_id' -> 20. 'info_type_id' -> 1. 'info' -> '7.8'}) with: (Dictionary from: {'movie_id' -> 30. 'info_type_id' -> 1. 'info' -> '4.5'}).
 rows := ((| res |
 res := OrderedCollection new.
 ((info_type) select: [:it | ((((((((((((it at: 'info' = 'rating') and: [(k at: 'keyword' at: 'contains' value: 'sequel')]) and: [mi at: 'info']) > '5.0') and: [t at: 'production_year']) > 2005) and: [mk at: 'movie_id']) = mi at: 'movie_id') and: [(it at: 'id' = mi at: 'info_type_id')]) and: [(t at: 'id' = mi at: 'movie_id')]) and: [(mk at: 'movie_id' = t at: 'id')]) and: [(k at: 'id' = mk at: 'keyword_id')])]) do: [:it |
@@ -26,7 +34,7 @@ res := OrderedCollection new.
         (title) do: [:t |
             (movie_keyword) do: [:mk |
                 (keyword) do: [:k |
-                    res add: Dictionary from: {rating -> mi at: 'info'. title -> t at: 'title'}.
+                    res add: Dictionary from: {'rating' -> mi at: 'info'. 'title' -> t at: 'title'}.
                 ]
             ]
         ]
@@ -34,18 +42,18 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Array with: Dictionary from: {rating -> (Main __min: ((| res |
+result := Array with: (Dictionary from: {'rating' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (rows) do: [:r |
     res add: r at: 'rating'.
 ]
 res := res asArray.
-res))). movie_title -> (Main __min: ((| res |
+res))). 'movie_title' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (rows) do: [:r |
     res add: r at: 'title'.
 ]
 res := res asArray.
-res)))}.
+res)))}).
 (result toJSON) displayOn: Transcript. Transcript cr.
 Main test_Q4_returns_minimum_rating_and_title_for_sequels.

--- a/tests/dataset/job/compiler/st/q5.st.out
+++ b/tests/dataset/job/compiler/st/q5.st.out
@@ -1,8 +1,16 @@
+Smalltalk at: #candidate_titles put: nil.
+Smalltalk at: #company_type put: nil.
+Smalltalk at: #info_type put: nil.
+Smalltalk at: #movie_companies put: nil.
+Smalltalk at: #movie_info put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q5_finds_the_lexicographically_first_qualifying_title
-    ((result = Array with: Dictionary from: {typical_european_movie -> 'A Film'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'typical_european_movie' -> 'A Film'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,11 +22,11 @@ __min: v
     ^ m
 !
 !!
-company_type := Array with: Dictionary from: {ct_id -> 1. kind -> 'production companies'} with: Dictionary from: {ct_id -> 2. kind -> 'other'}.
-info_type := Array with: Dictionary from: {it_id -> 10. info -> 'languages'}.
-title := Array with: Dictionary from: {t_id -> 100. title -> 'B Movie'. production_year -> 2010} with: Dictionary from: {t_id -> 200. title -> 'A Film'. production_year -> 2012} with: Dictionary from: {t_id -> 300. title -> 'Old Movie'. production_year -> 2000}.
-movie_companies := Array with: Dictionary from: {movie_id -> 100. company_type_id -> 1. note -> 'ACME (France) (theatrical)'} with: Dictionary from: {movie_id -> 200. company_type_id -> 1. note -> 'ACME (France) (theatrical)'} with: Dictionary from: {movie_id -> 300. company_type_id -> 1. note -> 'ACME (France) (theatrical)'}.
-movie_info := Array with: Dictionary from: {movie_id -> 100. info -> 'German'. info_type_id -> 10} with: Dictionary from: {movie_id -> 200. info -> 'Swedish'. info_type_id -> 10} with: Dictionary from: {movie_id -> 300. info -> 'German'. info_type_id -> 10}.
+company_type := Array with: (Dictionary from: {'ct_id' -> 1. 'kind' -> 'production companies'}) with: (Dictionary from: {'ct_id' -> 2. 'kind' -> 'other'}).
+info_type := Array with: (Dictionary from: {'it_id' -> 10. 'info' -> 'languages'}).
+title := Array with: (Dictionary from: {'t_id' -> 100. 'title' -> 'B Movie'. 'production_year' -> 2010}) with: (Dictionary from: {'t_id' -> 200. 'title' -> 'A Film'. 'production_year' -> 2012}) with: (Dictionary from: {'t_id' -> 300. 'title' -> 'Old Movie'. 'production_year' -> 2000}).
+movie_companies := Array with: (Dictionary from: {'movie_id' -> 100. 'company_type_id' -> 1. 'note' -> 'ACME (France) (theatrical)'}) with: (Dictionary from: {'movie_id' -> 200. 'company_type_id' -> 1. 'note' -> 'ACME (France) (theatrical)'}) with: (Dictionary from: {'movie_id' -> 300. 'company_type_id' -> 1. 'note' -> 'ACME (France) (theatrical)'}).
+movie_info := Array with: (Dictionary from: {'movie_id' -> 100. 'info' -> 'German'. 'info_type_id' -> 10}) with: (Dictionary from: {'movie_id' -> 200. 'info' -> 'Swedish'. 'info_type_id' -> 10}) with: (Dictionary from: {'movie_id' -> 300. 'info' -> 'German'. 'info_type_id' -> 10}).
 candidate_titles := ((| res |
 res := OrderedCollection new.
 ((company_type) select: [:ct | ((((((((mc at: 'note' includes: ct at: 'kind') and: [t at: 'production_year']) > 2005) and: [((Array with: 'Sweden' with: 'Norway' with: 'Germany' with: 'Denmark' with: 'Swedish' with: 'Denish' with: 'Norwegian' with: 'German' includes: mi at: 'info'))]) and: [(mc at: 'company_type_id' = ct at: 'ct_id')]) and: [(mi at: 'movie_id' = mc at: 'movie_id')]) and: [(it at: 'it_id' = mi at: 'info_type_id')]) and: [(t at: 't_id' = mc at: 'movie_id')])]) do: [:ct |
@@ -34,6 +42,6 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Array with: Dictionary from: {typical_european_movie -> (Main __min: candidate_titles)}.
+result := Array with: (Dictionary from: {'typical_european_movie' -> (Main __min: candidate_titles)}).
 (result toJSON) displayOn: Transcript. Transcript cr.
 Main test_Q5_finds_the_lexicographically_first_qualifying_title.

--- a/tests/dataset/job/compiler/st/q6.st.out
+++ b/tests/dataset/job/compiler/st/q6.st.out
@@ -1,16 +1,23 @@
+Smalltalk at: #cast_info put: nil.
+Smalltalk at: #keyword put: nil.
+Smalltalk at: #movie_keyword put: nil.
+Smalltalk at: #name put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q6_finds_marvel_movie_with_Robert_Downey
-    ((result = Array with: Dictionary from: {movie_keyword -> 'marvel-cinematic-universe'. actor_name -> 'Downey Robert Jr.'. marvel_movie -> 'Iron Man 3'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'movie_keyword' -> 'marvel-cinematic-universe'. 'actor_name' -> 'Downey Robert Jr.'. 'marvel_movie' -> 'Iron Man 3'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !!
-cast_info := Array with: Dictionary from: {movie_id -> 1. person_id -> 101} with: Dictionary from: {movie_id -> 2. person_id -> 102}.
-keyword := Array with: Dictionary from: {id -> 100. keyword -> 'marvel-cinematic-universe'} with: Dictionary from: {id -> 200. keyword -> 'other'}.
-movie_keyword := Array with: Dictionary from: {movie_id -> 1. keyword_id -> 100} with: Dictionary from: {movie_id -> 2. keyword_id -> 200}.
-name := Array with: Dictionary from: {id -> 101. name -> 'Downey Robert Jr.'} with: Dictionary from: {id -> 102. name -> 'Chris Evans'}.
-title := Array with: Dictionary from: {id -> 1. title -> 'Iron Man 3'. production_year -> 2013} with: Dictionary from: {id -> 2. title -> 'Old Movie'. production_year -> 2000}.
+cast_info := Array with: (Dictionary from: {'movie_id' -> 1. 'person_id' -> 101}) with: (Dictionary from: {'movie_id' -> 2. 'person_id' -> 102}).
+keyword := Array with: (Dictionary from: {'id' -> 100. 'keyword' -> 'marvel-cinematic-universe'}) with: (Dictionary from: {'id' -> 200. 'keyword' -> 'other'}).
+movie_keyword := Array with: (Dictionary from: {'movie_id' -> 1. 'keyword_id' -> 100}) with: (Dictionary from: {'movie_id' -> 2. 'keyword_id' -> 200}).
+name := Array with: (Dictionary from: {'id' -> 101. 'name' -> 'Downey Robert Jr.'}) with: (Dictionary from: {'id' -> 102. 'name' -> 'Chris Evans'}).
+title := Array with: (Dictionary from: {'id' -> 1. 'title' -> 'Iron Man 3'. 'production_year' -> 2013}) with: (Dictionary from: {'id' -> 2. 'title' -> 'Old Movie'. 'production_year' -> 2000}).
 result := ((| res |
 res := OrderedCollection new.
 ((cast_info) select: [:ci | (((((((((k at: 'keyword' = 'marvel-cinematic-universe') and: [(n at: 'name' at: 'contains' value: 'Downey')]) and: [(n at: 'name' at: 'contains' value: 'Robert')]) and: [t at: 'production_year']) > 2010) and: [(ci at: 'movie_id' = mk at: 'movie_id')]) and: [(mk at: 'keyword_id' = k at: 'id')]) and: [(ci at: 'person_id' = n at: 'id')]) and: [(ci at: 'movie_id' = t at: 'id')])]) do: [:ci |
@@ -18,7 +25,7 @@ res := OrderedCollection new.
         (keyword) do: [:k |
             (name) do: [:n |
                 (title) do: [:t |
-                    res add: Dictionary from: {movie_keyword -> k at: 'keyword'. actor_name -> n at: 'name'. marvel_movie -> t at: 'title'}.
+                    res add: Dictionary from: {'movie_keyword' -> k at: 'keyword'. 'actor_name' -> n at: 'name'. 'marvel_movie' -> t at: 'title'}.
                 ]
             ]
         ]

--- a/tests/dataset/job/compiler/st/q7.st.out
+++ b/tests/dataset/job/compiler/st/q7.st.out
@@ -1,8 +1,19 @@
+Smalltalk at: #aka_name put: nil.
+Smalltalk at: #cast_info put: nil.
+Smalltalk at: #info_type put: nil.
+Smalltalk at: #link_type put: nil.
+Smalltalk at: #movie_link put: nil.
+Smalltalk at: #name put: nil.
+Smalltalk at: #person_info put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #rows put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q7_finds_movie_features_biography_for_person
-    ((result = Array with: Dictionary from: {of_person -> 'Alan Brown'. biography_movie -> 'Feature Film'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'of_person' -> 'Alan Brown'. 'biography_movie' -> 'Feature Film'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,14 +25,14 @@ __min: v
     ^ m
 !
 !!
-aka_name := Array with: Dictionary from: {person_id -> 1. name -> 'Anna Mae'} with: Dictionary from: {person_id -> 2. name -> 'Chris'}.
-cast_info := Array with: Dictionary from: {person_id -> 1. movie_id -> 10} with: Dictionary from: {person_id -> 2. movie_id -> 20}.
-info_type := Array with: Dictionary from: {id -> 1. info -> 'mini biography'} with: Dictionary from: {id -> 2. info -> 'trivia'}.
-link_type := Array with: Dictionary from: {id -> 1. link -> 'features'} with: Dictionary from: {id -> 2. link -> 'references'}.
-movie_link := Array with: Dictionary from: {linked_movie_id -> 10. link_type_id -> 1} with: Dictionary from: {linked_movie_id -> 20. link_type_id -> 2}.
-name := Array with: Dictionary from: {id -> 1. name -> 'Alan Brown'. name_pcode_cf -> 'B'. gender -> 'm'} with: Dictionary from: {id -> 2. name -> 'Zoe'. name_pcode_cf -> 'Z'. gender -> 'f'}.
-person_info := Array with: Dictionary from: {person_id -> 1. info_type_id -> 1. note -> 'Volker Boehm'} with: Dictionary from: {person_id -> 2. info_type_id -> 1. note -> 'Other'}.
-title := Array with: Dictionary from: {id -> 10. title -> 'Feature Film'. production_year -> 1990} with: Dictionary from: {id -> 20. title -> 'Late Film'. production_year -> 2000}.
+aka_name := Array with: (Dictionary from: {'person_id' -> 1. 'name' -> 'Anna Mae'}) with: (Dictionary from: {'person_id' -> 2. 'name' -> 'Chris'}).
+cast_info := Array with: (Dictionary from: {'person_id' -> 1. 'movie_id' -> 10}) with: (Dictionary from: {'person_id' -> 2. 'movie_id' -> 20}).
+info_type := Array with: (Dictionary from: {'id' -> 1. 'info' -> 'mini biography'}) with: (Dictionary from: {'id' -> 2. 'info' -> 'trivia'}).
+link_type := Array with: (Dictionary from: {'id' -> 1. 'link' -> 'features'}) with: (Dictionary from: {'id' -> 2. 'link' -> 'references'}).
+movie_link := Array with: (Dictionary from: {'linked_movie_id' -> 10. 'link_type_id' -> 1}) with: (Dictionary from: {'linked_movie_id' -> 20. 'link_type_id' -> 2}).
+name := Array with: (Dictionary from: {'id' -> 1. 'name' -> 'Alan Brown'. 'name_pcode_cf' -> 'B'. 'gender' -> 'm'}) with: (Dictionary from: {'id' -> 2. 'name' -> 'Zoe'. 'name_pcode_cf' -> 'Z'. 'gender' -> 'f'}).
+person_info := Array with: (Dictionary from: {'person_id' -> 1. 'info_type_id' -> 1. 'note' -> 'Volker Boehm'}) with: (Dictionary from: {'person_id' -> 2. 'info_type_id' -> 1. 'note' -> 'Other'}).
+title := Array with: (Dictionary from: {'id' -> 10. 'title' -> 'Feature Film'. 'production_year' -> 1990}) with: (Dictionary from: {'id' -> 20. 'title' -> 'Late Film'. 'production_year' -> 2000}).
 rows := ((| res |
 res := OrderedCollection new.
 ((aka_name) select: [:an | ((((((((((((((((((((((((((((((((an at: 'name' at: 'contains' value: 'a') and: [it at: 'info']) = 'mini biography') and: [lt at: 'link']) = 'features') and: [n at: 'name_pcode_cf']) >= 'A') and: [n at: 'name_pcode_cf']) <= 'F') and: [(((n at: 'gender' = 'm') or: [(((n at: 'gender' = 'f') and: [(n at: 'name' at: 'starts_with' value: 'B')]))]))]) and: [pi at: 'note']) = 'Volker Boehm') and: [t at: 'production_year']) >= 1980) and: [t at: 'production_year']) <= 1995) and: [pi at: 'person_id']) = an at: 'person_id') and: [pi at: 'person_id']) = ci at: 'person_id') and: [an at: 'person_id']) = ci at: 'person_id') and: [ci at: 'movie_id']) = ml at: 'linked_movie_id')) and: [(n at: 'id' = an at: 'person_id')]) and: [(pi at: 'person_id' = an at: 'person_id')]) and: [(it at: 'id' = pi at: 'info_type_id')]) and: [(ci at: 'person_id' = n at: 'id')]) and: [(t at: 'id' = ci at: 'movie_id')]) and: [(ml at: 'linked_movie_id' = t at: 'id')]) and: [(lt at: 'id' = ml at: 'link_type_id')])]) do: [:an |
@@ -32,7 +43,7 @@ res := OrderedCollection new.
                     (title) do: [:t |
                         (movie_link) do: [:ml |
                             (link_type) do: [:lt |
-                                res add: Dictionary from: {person_name -> n at: 'name'. movie_title -> t at: 'title'}.
+                                res add: Dictionary from: {'person_name' -> n at: 'name'. 'movie_title' -> t at: 'title'}.
                             ]
                         ]
                     ]
@@ -43,18 +54,18 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Array with: Dictionary from: {of_person -> (Main __min: ((| res |
+result := Array with: (Dictionary from: {'of_person' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (rows) do: [:r |
     res add: r at: 'person_name'.
 ]
 res := res asArray.
-res))). biography_movie -> (Main __min: ((| res |
+res))). 'biography_movie' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (rows) do: [:r |
     res add: r at: 'movie_title'.
 ]
 res := res asArray.
-res)))}.
+res)))}).
 (result toJSON) displayOn: Transcript. Transcript cr.
 Main test_Q7_finds_movie_features_biography_for_person.

--- a/tests/dataset/job/compiler/st/q8.st.out
+++ b/tests/dataset/job/compiler/st/q8.st.out
@@ -1,8 +1,18 @@
+Smalltalk at: #aka_name put: nil.
+Smalltalk at: #cast_info put: nil.
+Smalltalk at: #company_name put: nil.
+Smalltalk at: #eligible put: nil.
+Smalltalk at: #movie_companies put: nil.
+Smalltalk at: #name put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #role_type put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing
-    ((result = Array with: Dictionary from: {actress_pseudonym -> 'Y. S.'. japanese_movie_dubbed -> 'Dubbed Film'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'actress_pseudonym' -> 'Y. S.'. 'japanese_movie_dubbed' -> 'Dubbed Film'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,13 +24,13 @@ __min: v
     ^ m
 !
 !!
-aka_name := Array with: Dictionary from: {person_id -> 1. name -> 'Y. S.'}.
-cast_info := Array with: Dictionary from: {person_id -> 1. movie_id -> 10. note -> '(voice: English version)'. role_id -> 1000}.
-company_name := Array with: Dictionary from: {id -> 50. country_code -> '[jp]'}.
-movie_companies := Array with: Dictionary from: {movie_id -> 10. company_id -> 50. note -> 'Studio (Japan)'}.
-name := Array with: Dictionary from: {id -> 1. name -> 'Yoko Ono'} with: Dictionary from: {id -> 2. name -> 'Yuichi'}.
-role_type := Array with: Dictionary from: {id -> 1000. role -> 'actress'}.
-title := Array with: Dictionary from: {id -> 10. title -> 'Dubbed Film'}.
+aka_name := Array with: (Dictionary from: {'person_id' -> 1. 'name' -> 'Y. S.'}).
+cast_info := Array with: (Dictionary from: {'person_id' -> 1. 'movie_id' -> 10. 'note' -> '(voice: English version)'. 'role_id' -> 1000}).
+company_name := Array with: (Dictionary from: {'id' -> 50. 'country_code' -> '[jp]'}).
+movie_companies := Array with: (Dictionary from: {'movie_id' -> 10. 'company_id' -> 50. 'note' -> 'Studio (Japan)'}).
+name := Array with: (Dictionary from: {'id' -> 1. 'name' -> 'Yoko Ono'}) with: (Dictionary from: {'id' -> 2. 'name' -> 'Yuichi'}).
+role_type := Array with: (Dictionary from: {'id' -> 1000. 'role' -> 'actress'}).
+title := Array with: (Dictionary from: {'id' -> 10. 'title' -> 'Dubbed Film'}).
 eligible := ((| res |
 res := OrderedCollection new.
 ((aka_name) select: [:an1 | (((((((((((((((ci at: 'note' = '(voice: English version)') and: [cn at: 'country_code']) = '[jp]') and: [(mc at: 'note' at: 'contains' value: '(Japan)')]) and: [(((mc at: 'note' at: 'contains' value: '(USA)')) not)]) and: [(n1 at: 'name' at: 'contains' value: 'Yo')]) and: [(((n1 at: 'name' at: 'contains' value: 'Yu')) not)]) and: [rt at: 'role']) = 'actress') and: [(n1 at: 'id' = an1 at: 'person_id')]) and: [(ci at: 'person_id' = an1 at: 'person_id')]) and: [(t at: 'id' = ci at: 'movie_id')]) and: [(mc at: 'movie_id' = ci at: 'movie_id')]) and: [(cn at: 'id' = mc at: 'company_id')]) and: [(rt at: 'id' = ci at: 'role_id')])]) do: [:an1 |
@@ -30,7 +40,7 @@ res := OrderedCollection new.
                 (movie_companies) do: [:mc |
                     (company_name) do: [:cn |
                         (role_type) do: [:rt |
-                            res add: Dictionary from: {pseudonym -> an1 at: 'name'. movie_title -> t at: 'title'}.
+                            res add: Dictionary from: {'pseudonym' -> an1 at: 'name'. 'movie_title' -> t at: 'title'}.
                         ]
                     ]
                 ]
@@ -40,18 +50,18 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Array with: Dictionary from: {actress_pseudonym -> (Main __min: ((| res |
+result := Array with: (Dictionary from: {'actress_pseudonym' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (eligible) do: [:x |
     res add: x at: 'pseudonym'.
 ]
 res := res asArray.
-res))). japanese_movie_dubbed -> (Main __min: ((| res |
+res))). 'japanese_movie_dubbed' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (eligible) do: [:x |
     res add: x at: 'movie_title'.
 ]
 res := res asArray.
-res)))}.
-(result) displayOn: Transcript. Transcript cr.
+res)))}).
+(result toJSON) displayOn: Transcript. Transcript cr.
 Main test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing.

--- a/tests/dataset/job/compiler/st/q9.st.out
+++ b/tests/dataset/job/compiler/st/q9.st.out
@@ -1,8 +1,19 @@
+Smalltalk at: #aka_name put: nil.
+Smalltalk at: #cast_info put: nil.
+Smalltalk at: #char_name put: nil.
+Smalltalk at: #company_name put: nil.
+Smalltalk at: #matches put: nil.
+Smalltalk at: #movie_companies put: nil.
+Smalltalk at: #name put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #role_type put: nil.
+Smalltalk at: #title put: nil.
+
 Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
 
 !Main class methodsFor: 'tests'!
 test_Q9_selects_minimal_alternative_name__character_and_movie
-    ((result = Array with: Dictionary from: {alternative_name -> 'A. N. G.'. character_name -> 'Angel'. movie -> 'Famous Film'})) ifFalse: [ self error: 'expect failed' ]
+    ((result = Array with: (Dictionary from: {'alternative_name' -> 'A. N. G.'. 'character_name' -> 'Angel'. 'movie' -> 'Famous Film'}))) ifFalse: [ self error: 'expect failed' ]
 !
 
 !Main class methodsFor: 'runtime'!
@@ -14,17 +25,17 @@ __min: v
     ^ m
 !
 !!
-aka_name := Array with: Dictionary from: {person_id -> 1. name -> 'A. N. G.'} with: Dictionary from: {person_id -> 2. name -> 'J. D.'}.
-char_name := Array with: Dictionary from: {id -> 10. name -> 'Angel'} with: Dictionary from: {id -> 20. name -> 'Devil'}.
-cast_info := Array with: Dictionary from: {person_id -> 1. person_role_id -> 10. movie_id -> 100. role_id -> 1000. note -> '(voice)'} with: Dictionary from: {person_id -> 2. person_role_id -> 20. movie_id -> 200. role_id -> 1000. note -> '(voice)'}.
-company_name := Array with: Dictionary from: {id -> 100. country_code -> '[us]'} with: Dictionary from: {id -> 200. country_code -> '[gb]'}.
-movie_companies := Array with: Dictionary from: {movie_id -> 100. company_id -> 100. note -> 'ACME Studios (USA)'} with: Dictionary from: {movie_id -> 200. company_id -> 200. note -> 'Maple Films'}.
-name := Array with: Dictionary from: {id -> 1. name -> 'Angela Smith'. gender -> 'f'} with: Dictionary from: {id -> 2. name -> 'John Doe'. gender -> 'm'}.
-role_type := Array with: Dictionary from: {id -> 1000. role -> 'actress'} with: Dictionary from: {id -> 2000. role -> 'actor'}.
-title := Array with: Dictionary from: {id -> 100. title -> 'Famous Film'. production_year -> 2010} with: Dictionary from: {id -> 200. title -> 'Old Movie'. production_year -> 1999}.
+aka_name := Array with: (Dictionary from: {'person_id' -> 1. 'name' -> 'A. N. G.'}) with: (Dictionary from: {'person_id' -> 2. 'name' -> 'J. D.'}).
+char_name := Array with: (Dictionary from: {'id' -> 10. 'name' -> 'Angel'}) with: (Dictionary from: {'id' -> 20. 'name' -> 'Devil'}).
+cast_info := Array with: (Dictionary from: {'person_id' -> 1. 'person_role_id' -> 10. 'movie_id' -> 100. 'role_id' -> 1000. 'note' -> '(voice)'}) with: (Dictionary from: {'person_id' -> 2. 'person_role_id' -> 20. 'movie_id' -> 200. 'role_id' -> 1000. 'note' -> '(voice)'}).
+company_name := Array with: (Dictionary from: {'id' -> 100. 'country_code' -> '[us]'}) with: (Dictionary from: {'id' -> 200. 'country_code' -> '[gb]'}).
+movie_companies := Array with: (Dictionary from: {'movie_id' -> 100. 'company_id' -> 100. 'note' -> 'ACME Studios (USA)'}) with: (Dictionary from: {'movie_id' -> 200. 'company_id' -> 200. 'note' -> 'Maple Films'}).
+name := Array with: (Dictionary from: {'id' -> 1. 'name' -> 'Angela Smith'. 'gender' -> 'f'}) with: (Dictionary from: {'id' -> 2. 'name' -> 'John Doe'. 'gender' -> 'm'}).
+role_type := Array with: (Dictionary from: {'id' -> 1000. 'role' -> 'actress'}) with: (Dictionary from: {'id' -> 2000. 'role' -> 'actor'}).
+title := Array with: (Dictionary from: {'id' -> 100. 'title' -> 'Famous Film'. 'production_year' -> 2010}) with: (Dictionary from: {'id' -> 200. 'title' -> 'Old Movie'. 'production_year' -> 1999}).
 matches := ((| res |
 res := OrderedCollection new.
-((aka_name) select: [:an | (((((((((((((((((((((Array with: '(voice)' with: '(voice: Japanese version)' with: '(voice) (uncredited)' with: '(voice: English version)' includes: ci at: 'note')) and: [cn at: 'country_code']) = '[us]') and: [(((mc at: 'note' at: 'contains' value: '(USA)') or: [(mc at: 'note' at: 'contains' value: '(worldwide)')]))]) and: [n at: 'gender']) = 'f') and: [(n at: 'name' at: 'contains' value: 'Ang')]) and: [rt at: 'role']) = 'actress') and: [t at: 'production_year']) >= 2005) and: [t at: 'production_year']) <= 2015) and: [(an at: 'person_id' = n at: 'id')]) and: [(ci at: 'person_id' = n at: 'id')]) and: [(chn at: 'id' = ci at: 'person_role_id')]) and: [(t at: 'id' = ci at: 'movie_id')]) and: [(mc at: 'movie_id' = t at: 'id')]) and: [(cn at: 'id' = mc at: 'company_id')]) and: [(rt at: 'id' = ci at: 'role_id')])]) do: [:an |
+((aka_name) select: [:an | (((((((((((((((((((((Array with: '(voice)' with: ('(voice: Japanese version)') with: ('(voice) (uncredited)') with: ('(voice: English version)') includes: ci at: 'note')) and: [cn at: 'country_code']) = '[us]') and: [(((mc at: 'note' at: 'contains' value: '(USA)') or: [(mc at: 'note' at: 'contains' value: '(worldwide)')]))]) and: [n at: 'gender']) = 'f') and: [(n at: 'name' at: 'contains' value: 'Ang')]) and: [rt at: 'role']) = 'actress') and: [t at: 'production_year']) >= 2005) and: [t at: 'production_year']) <= 2015) and: [(an at: 'person_id' = n at: 'id')]) and: [(ci at: 'person_id' = n at: 'id')]) and: [(chn at: 'id' = ci at: 'person_role_id')]) and: [(t at: 'id' = ci at: 'movie_id')]) and: [(mc at: 'movie_id' = t at: 'id')]) and: [(cn at: 'id' = mc at: 'company_id')]) and: [(rt at: 'id' = ci at: 'role_id')])]) do: [:an |
     (name) do: [:n |
         (cast_info) do: [:ci |
             (char_name) do: [:chn |
@@ -32,7 +43,7 @@ res := OrderedCollection new.
                     (movie_companies) do: [:mc |
                         (company_name) do: [:cn |
                             (role_type) do: [:rt |
-                                res add: Dictionary from: {alt -> an at: 'name'. character -> chn at: 'name'. movie -> t at: 'title'}.
+                                res add: Dictionary from: {'alt' -> an at: 'name'. 'character' -> chn at: 'name'. 'movie' -> t at: 'title'}.
                             ]
                         ]
                     ]
@@ -43,24 +54,24 @@ res := OrderedCollection new.
 ]
 res := res asArray.
 res)).
-result := Array with: Dictionary from: {alternative_name -> (Main __min: ((| res |
+result := Array with: (Dictionary from: {'alternative_name' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (matches) do: [:x |
     res add: x at: 'alt'.
 ]
 res := res asArray.
-res))). character_name -> (Main __min: ((| res |
+res))). 'character_name' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (matches) do: [:x |
     res add: x at: 'character'.
 ]
 res := res asArray.
-res))). movie -> (Main __min: ((| res |
+res))). 'movie' -> (Main __min: ((| res |
 res := OrderedCollection new.
 (matches) do: [:x |
     res add: x at: 'movie'.
 ]
 res := res asArray.
-res)))}.
+res)))}).
 (result toJSON) displayOn: Transcript. Transcript cr.
 Main test_Q9_selects_minimal_alternative_name__character_and_movie.


### PR DESCRIPTION
## Summary
- expand the Smalltalk compiler to declare globals and quote map keys
- regenerate `q1`–`q10` Smalltalk outputs for the JOB dataset
- add a new `JOB_Golden` test for the Smalltalk backend
- document remaining parse issues in `TASKS.md`

## Testing
- `go test ./compile/x/st -run JOB_Golden -tags slow -count=1`
- `go test ./... -tags slow -run TestSTCompiler_JOB_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685e8be764108320b1d31e8a332d5c8b