### PR TITLE
Document JOB Erlang issues and refactor tests

### DIFF
--- a/compile/x/erlang/TASKS.md
+++ b/compile/x/erlang/TASKS.md
@@ -11,3 +11,20 @@ boolean values to JSON.
   generation and execution of `tests/dataset/tpc-h/q1.mochi`.  Additional
   golden files in `tests/compiler/erl_simple` cover JSON output with
   booleans.
+
+## JOB Dataset Status
+
+Initial work attempted to compile JOB queries but the generated
+Erlang code fails to run. `escript` reports a syntax error around the
+`mochi_to_json(true)` helper when compiling `q1.mochi`. Queries
+`q1` through `q10` therefore remain unsupported and golden tests have
+not been generated yet.
+
+### TODO
+
+- Fix code generation of test blocks so anonymous functions compile
+  correctly and captured variables are valid.
+- Ensure `mochi_to_json/1` and other runtime helpers emit valid Erlang
+  syntax.
+- Once the programs execute, add golden tests for `tests/dataset/job`
+  covering `q1.mochi` to `q10.mochi` under `compile/x/erlang`.


### PR DESCRIPTION
## Summary
- adjust Erlang backend test handling to use closures instead of exported functions
- update TASKS for Erlang backend with JOB status and todo items

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e91da96a483208553f9ddec2a40b8