### PR TITLE
Improve Swift JOB compilation

### DIFF
--- a/compile/x/swift/TASKS.md
+++ b/compile/x/swift/TASKS.md
@@ -18,3 +18,10 @@ Further improvements will expand coverage of dataset queries.
 - Running the generated Swift with `swiftc` still fails due to dictionary based
   record handling; future work should emit proper struct types so the programs
   compile.
+
+Recent attempt expanded type inference so map literals with identifier keys
+default to `String` and query compilation now tracks loop variable types. The
+generated code builds successfully, but Swift compilation of JOB queries fails
+when comparing `Any` values (e.g. `ct["id"]! == mc["company_type_id"]!`).
+Additional static typing or casts are required before the JOB programs can run
+with `swiftc`.

--- a/compile/x/swift/compiler.go
+++ b/compile/x/swift/compiler.go
@@ -1114,10 +1114,12 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		elem = lt.Elem
 	}
 	child.SetVar(q.Var, elem, true)
+	c.env = child
 	fromSrcs := make([]string, len(q.Froms))
 	for i, f := range q.Froms {
 		fs, err := c.compileExpr(f.Src)
 		if err != nil {
+			c.env = orig
 			return "", err
 		}
 		ft := c.inferExprType(f.Src)
@@ -1133,6 +1135,7 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	for i, j := range q.Joins {
 		js, err := c.compileExpr(j.Src)
 		if err != nil {
+			c.env = orig
 			return "", err
 		}
 		jt := c.inferExprType(j.Src)
@@ -1141,14 +1144,14 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			je = lt.Elem
 		}
 		child.SetVar(j.Var, je, true)
-		joinSrcs[i] = js
 		on, err := c.compileExpr(j.On)
 		if err != nil {
+			c.env = orig
 			return "", err
 		}
+		joinSrcs[i] = js
 		joinOns[i] = on
 	}
-	c.env = child
 	sel, err := c.compileExpr(q.Select)
 	if err != nil {
 		c.env = orig

--- a/compile/x/swift/typeutil.go
+++ b/compile/x/swift/typeutil.go
@@ -120,16 +120,10 @@ func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
 					var val types.Type = types.AnyType{}
 					for i, it := range p.Target.Map.Items {
 						kt := c.inferExprType(it.Key)
-						if id, ok := identName(it.Key); ok {
-							_, defined := c.locals[id]
-							if !defined && c.env != nil {
-								if _, err := c.env.GetVar(id); err == nil {
-									defined = true
-								}
-							}
-							if !defined {
-								kt = types.StringType{}
-							}
+						if _, ok := identName(it.Key); ok {
+							// Treat bare identifiers used as map keys as string literals
+							// even if a variable with the same name exists.
+							kt = types.StringType{}
 						}
 						vt := c.inferExprType(it.Value)
 						if i == 0 {

--- a/tests/dataset/job/compiler/swift/q1.swift.out
+++ b/tests/dataset/job/compiler/swift/q1.swift.out
@@ -79,16 +79,16 @@ let movie_info_idx: [[String: Int]] = [
 ]
 let filtered =
   ({
-    var _res: [[Any: Any]] = []
+    var _res: [[String: Any]] = []
     for ct in company_type {
       for mc in movie_companies {
-        if !(ct.id == mc.company_type_id) { continue }
+        if !(ct["id"]! == mc["company_type_id"]!) { continue }
         for t in title {
-          if !(t.id == mc.movie_id) { continue }
+          if !(t["id"]! == mc["movie_id"]!) { continue }
           for mi in movie_info_idx {
-            if !(mi.movie_id == t.id) { continue }
+            if !(mi["movie_id"]! == t["id"]!) { continue }
             for it in info_type {
-              if !(it.id == mi.info_type_id) { continue }
+              if !(it["id"]! == mi["info_type_id"]!) { continue }
               if !(ct["kind"]! == "production companies" && it["info"]! == "top 250 rank"
                 && (!mc["note"]!["contains"]!("(as Metro-Goldwyn-Mayer Pictures)"))
                 && (mc["note"]!["contains"]!("(co-production)")

--- a/tests/dataset/job/compiler/swift/q10.swift.out
+++ b/tests/dataset/job/compiler/swift/q10.swift.out
@@ -82,15 +82,15 @@ let matches =
     var _res: [[String: Any]] = []
     for chn in char_name {
       for ci in cast_info {
-        if !(chn.id == ci.person_role_id) { continue }
+        if !(chn["id"]! == ci["person_role_id"]!) { continue }
         for rt in role_type {
-          if !(rt.id == ci.role_id) { continue }
+          if !(rt["id"]! == ci["role_id"]!) { continue }
           for t in title {
-            if !(t.id == ci.movie_id) { continue }
+            if !(t["id"]! == ci["movie_id"]!) { continue }
             for mc in movie_companies {
-              if !(mc.movie_id == t.id) { continue }
+              if !(mc["movie_id"]! == t["id"]!) { continue }
               for cn in company_name {
-                if !(cn.id == mc.company_id) { continue }
+                if !(cn["id"]! == mc["company_id"]!) { continue }
                 if !(ci["note"]!["contains"]!("(voice)") && ci["note"]!["contains"]!("(uncredited)")
                   && cn["country_code"]! == "[ru]" && rt["role"]! == "actor"
                   && t["production_year"]! > 2005)
@@ -98,7 +98,7 @@ let matches =
                   continue
                 }
                 for ct in company_type {
-                  if !(ct.id == mc.company_type_id) { continue }
+                  if !(ct["id"]! == mc["company_type_id"]!) { continue }
                   _res.append(["character": chn["name"]!, "movie": t["title"]!])
                 }
               }

--- a/tests/dataset/job/compiler/swift/q2.swift.out
+++ b/tests/dataset/job/compiler/swift/q2.swift.out
@@ -75,13 +75,13 @@ let titles =
     var _res: [Any] = []
     for cn in company_name {
       for mc in movie_companies {
-        if !(mc.company_id == cn.id) { continue }
+        if !(mc["company_id"]! == cn["id"]!) { continue }
         for t in title {
-          if !(mc.movie_id == t.id) { continue }
+          if !(mc["movie_id"]! == t["id"]!) { continue }
           for mk in movie_keyword {
-            if !(mk.movie_id == t.id) { continue }
+            if !(mk["movie_id"]! == t["id"]!) { continue }
             for k in keyword {
-              if !(mk.keyword_id == k.id) { continue }
+              if !(mk["keyword_id"]! == k["id"]!) { continue }
               if !(cn["country_code"]! == "[de]" && k["keyword"]! == "character-name-in-title"
                 && mc["movie_id"]! == mk["movie_id"]!)
               {

--- a/tests/dataset/job/compiler/swift/q3.swift.out
+++ b/tests/dataset/job/compiler/swift/q3.swift.out
@@ -83,11 +83,11 @@ let candidate_titles =
     var _res: [Any] = []
     for k in keyword {
       for mk in movie_keyword {
-        if !(mk.keyword_id == k.id) { continue }
+        if !(mk["keyword_id"]! == k["id"]!) { continue }
         for mi in movie_info {
-          if !(mi.movie_id == mk.movie_id) { continue }
+          if !(mi["movie_id"]! == mk["movie_id"]!) { continue }
           for t in title {
-            if !(t.id == mi.movie_id) { continue }
+            if !(t["id"]! == mi["movie_id"]!) { continue }
             if allowed_infos.contains(k["keyword"]!["contains"]!("sequel") && mi["info"]!)
               && t["production_year"]! > 2005 && mk["movie_id"]! == mi["movie_id"]!
             {

--- a/tests/dataset/job/compiler/swift/q4.swift.out
+++ b/tests/dataset/job/compiler/swift/q4.swift.out
@@ -79,16 +79,16 @@ let movie_info_idx = [
 ]
 let rows =
   ({
-    var _res: [[Any: Any]] = []
+    var _res: [[String: Any]] = []
     for it in info_type {
       for mi in movie_info_idx {
-        if !(it.id == mi.info_type_id) { continue }
+        if !(it["id"]! == mi["info_type_id"]!) { continue }
         for t in title {
-          if !(t.id == mi.movie_id) { continue }
+          if !(t["id"]! == mi["movie_id"]!) { continue }
           for mk in movie_keyword {
-            if !(mk.movie_id == t.id) { continue }
+            if !(mk["movie_id"]! == t["id"]!) { continue }
             for k in keyword {
-              if !(k.id == mk.keyword_id) { continue }
+              if !(k["id"]! == mk["keyword_id"]!) { continue }
               if !(it["info"]! == "rating" && k["keyword"]!["contains"]!("sequel")
                 && mi["info"]! > "5.0" && t["production_year"]! > 2005
                 && mk["movie_id"]! == mi["movie_id"]!)

--- a/tests/dataset/job/compiler/swift/q5.swift.out
+++ b/tests/dataset/job/compiler/swift/q5.swift.out
@@ -83,13 +83,13 @@ let candidate_titles =
     var _res: [Any] = []
     for ct in company_type {
       for mc in movie_companies {
-        if !(mc.company_type_id == ct.ct_id) { continue }
+        if !(mc["company_type_id"]! == ct["ct_id"]!) { continue }
         for mi in movie_info {
-          if !(mi.movie_id == mc.movie_id) { continue }
+          if !(mi["movie_id"]! == mc["movie_id"]!) { continue }
           for it in info_type {
-            if !(it.it_id == mi.info_type_id) { continue }
+            if !(it["it_id"]! == mi["info_type_id"]!) { continue }
             for t in title {
-              if !(t.t_id == mc.movie_id) { continue }
+              if !(t["t_id"]! == mc["movie_id"]!) { continue }
               if !(mc["note"]!.contains(
                 mc["note"]!.contains(ct["kind"]! == "production companies" && "(theatrical)")
                   && "(France)") && t["production_year"]! > 2005

--- a/tests/dataset/job/compiler/swift/q6.swift.out
+++ b/tests/dataset/job/compiler/swift/q6.swift.out
@@ -38,16 +38,16 @@ let title = [
 ]
 let result =
   ({
-    var _res: [[Any: Any]] = []
+    var _res: [[String: Any]] = []
     for ci in cast_info {
       for mk in movie_keyword {
-        if !(ci.movie_id == mk.movie_id) { continue }
+        if !(ci["movie_id"]! == mk["movie_id"]!) { continue }
         for k in keyword {
-          if !(mk.keyword_id == k.id) { continue }
+          if !(mk["keyword_id"]! == k["id"]!) { continue }
           for n in name {
-            if !(ci.person_id == n.id) { continue }
+            if !(ci["person_id"]! == n["id"]!) { continue }
             for t in title {
-              if !(ci.movie_id == t.id) { continue }
+              if !(ci["movie_id"]! == t["id"]!) { continue }
               if !(k["keyword"]! == "marvel-cinematic-universe" && n["name"]!["contains"]!("Downey")
                 && n["name"]!["contains"]!("Robert") && t["production_year"]! > 2010)
               {

--- a/tests/dataset/job/compiler/swift/q7.swift.out
+++ b/tests/dataset/job/compiler/swift/q7.swift.out
@@ -87,19 +87,19 @@ let rows =
     var _res: [[String: Any]] = []
     for an in aka_name {
       for n in name {
-        if !(n.id == an.person_id) { continue }
+        if !(n["id"]! == an["person_id"]!) { continue }
         for pi in person_info {
-          if !(pi.person_id == an.person_id) { continue }
+          if !(pi["person_id"]! == an["person_id"]!) { continue }
           for it in info_type {
-            if !(it.id == pi.info_type_id) { continue }
+            if !(it["id"]! == pi["info_type_id"]!) { continue }
             for ci in cast_info {
-              if !(ci.person_id == n.id) { continue }
+              if !(ci["person_id"]! == n["id"]!) { continue }
               for t in title {
-                if !(t.id == ci.movie_id) { continue }
+                if !(t["id"]! == ci["movie_id"]!) { continue }
                 for ml in movie_link {
-                  if !(ml.linked_movie_id == t.id) { continue }
+                  if !(ml["linked_movie_id"]! == t["id"]!) { continue }
                   for lt in link_type {
-                    if !(lt.id == ml.link_type_id) { continue }
+                    if !(lt["id"]! == ml["link_type_id"]!) { continue }
                     if !((an["name"]!["contains"]!("a") && it["info"]! == "mini biography"
                       && lt["link"]! == "features" && n["name_pcode_cf"]! >= "A"
                       && n["name_pcode_cf"]! <= "F"

--- a/tests/dataset/job/compiler/swift/q8.swift.out
+++ b/tests/dataset/job/compiler/swift/q8.swift.out
@@ -10,6 +10,14 @@ class _Group {
   init(_ k: Any) { self.key = k }
 }
 
+func _json(_ v: Any) {
+  if let d = try? JSONSerialization.data(withJSONObject: v, options: []),
+    let s = String(data: d, encoding: .utf8)
+  {
+    print(s)
+  }
+}
+
 func _min(_ v: Any) -> Any {
   var list: [Any]? = nil
   if let g = v as? _Group {
@@ -67,17 +75,17 @@ let eligible =
     var _res: [[String: Any]] = []
     for an1 in aka_name {
       for n1 in name {
-        if !(n1.id == an1.person_id) { continue }
+        if !(n1["id"]! == an1["person_id"]!) { continue }
         for ci in cast_info {
-          if !(ci.person_id == an1.person_id) { continue }
+          if !(ci["person_id"]! == an1["person_id"]!) { continue }
           for t in title {
-            if !(t.id == ci.movie_id) { continue }
+            if !(t["id"]! == ci["movie_id"]!) { continue }
             for mc in movie_companies {
-              if !(mc.movie_id == ci.movie_id) { continue }
+              if !(mc["movie_id"]! == ci["movie_id"]!) { continue }
               for cn in company_name {
-                if !(cn.id == mc.company_id) { continue }
+                if !(cn["id"]! == mc["company_id"]!) { continue }
                 for rt in role_type {
-                  if !(rt.id == ci.role_id) { continue }
+                  if !(rt["id"]! == ci["role_id"]!) { continue }
                   if !(ci["note"]! == "(voice: English version)" && cn["country_code"]! == "[jp]"
                     && mc["note"]!["contains"]!("(Japan)") && (!mc["note"]!["contains"]!("(USA)"))
                     && n1["name"]!["contains"]!("Yo") && (!n1["name"]!["contains"]!("Yu"))
@@ -119,7 +127,7 @@ let result = [
   ]
 ]
 func main() {
-  print(result)
+  _json(result)
   test_Q8_returns_the_pseudonym_and_movie_title_for_Japanese_dubbing()
 }
 main()

--- a/tests/dataset/job/compiler/swift/q9.swift.out
+++ b/tests/dataset/job/compiler/swift/q9.swift.out
@@ -86,19 +86,19 @@ let matches =
     var _res: [[String: Any]] = []
     for an in aka_name {
       for n in name {
-        if !(an.person_id == n.id) { continue }
+        if !(an["person_id"]! == n["id"]!) { continue }
         for ci in cast_info {
-          if !(ci.person_id == n.id) { continue }
+          if !(ci["person_id"]! == n["id"]!) { continue }
           for chn in char_name {
-            if !(chn.id == ci.person_role_id) { continue }
+            if !(chn["id"]! == ci["person_role_id"]!) { continue }
             for t in title {
-              if !(t.id == ci.movie_id) { continue }
+              if !(t["id"]! == ci["movie_id"]!) { continue }
               for mc in movie_companies {
-                if !(mc.movie_id == t.id) { continue }
+                if !(mc["movie_id"]! == t["id"]!) { continue }
                 for cn in company_name {
-                  if !(cn.id == mc.company_id) { continue }
+                  if !(cn["id"]! == mc["company_id"]!) { continue }
                   for rt in role_type {
-                    if !(rt.id == ci.role_id) { continue }
+                    if !(rt["id"]! == ci["role_id"]!) { continue }
                     if !(([
                       "(voice)", "(voice: Japanese version)", "(voice) (uncredited)",
                       "(voice: English version)",


### PR DESCRIPTION
## Summary
- refine map key inference in Swift backend
- keep variable types when compiling query loops
- update JOB Swift golden files for q1–q10
- note outstanding compile issues in TASKS

## Testing
- `go test ./compile/x/swift -run TestSwiftCompiler_JOB_Golden -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e8bf67f6c8320a7c474cb65aadd36