### PR TITLE
Add release notes for v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # 📦 CHANGELOG.md
+## [0.10.5] – 2025-06-27T20:39:39+07:00
+
+### Added
+
+* Join Order Benchmark dataset queries and golden tests across languages
+* `starts_with`, `like`, `min` and `max` builtins in the VM
+* JOB query examples 16–33
+* Map key inference and contains improvements
+
+### Changed
+
+* VM constant folding re-enabled with interpreter removed
+* Null ordering handled during comparisons
+
+### Fixed
+
+* C++ map literal inference
+* Zig operator precedence
+* `starts_with` edge cases
+* JOB C++ compilation issues
+
+
 ## [0.10.4] – 2025-06-27T14:33:48+07:00
 
 ### Added

--- a/releases/v0.10.5.md
+++ b/releases/v0.10.5.md
@@ -1,0 +1,27 @@
+# Jun 2025 (v0.10.5)
+
+Released on Fri Jun 27 20:39:39 2025 +0700.
+
+Mochi v0.10.5 expands the Join Order Benchmark dataset and strengthens string
+operations across the toolchain. The VM now supports additional helpers while
+compilers and examples cover the full JOB query suite.
+
+## Runtime
+
+- `starts_with`, `like` and string `min`/`max` builtins
+- Constant folding re-enabled with interpreter removed
+- Null ordering fixes in comparisons
+- JOB dataset query support with golden tests
+
+## Compilers
+
+- Map key inference improvements and contains handling
+- JOB dataset golden tests across all languages
+- Query examples added for JOB Q16–Q33
+
+## Fixes
+
+- C++ map literal type inference
+- Zig precedence handling
+- `starts_with` edge cases
+- JOB C++ compilation issues


### PR DESCRIPTION
## Summary
- document v0.10.5 changes in CHANGELOG
- add release notes for v0.10.5

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685e9f7a27ec8320a47d652b37219329