### PR TITLE
Add Fortran tpch tests

### DIFF
--- a/compile/x/fortran/TASKS.md
+++ b/compile/x/fortran/TASKS.md
@@ -1,10 +1,11 @@
-# Fortran Backend Tasks for TPCH Q1
+# Fortran Backend Tasks for TPCH Q1-Q2
 
-The Fortran backend only handles simple array loops. Grouping and dynamic lists are missing.
+The Fortran backend only handles simple array loops. Grouping, joins and dynamic lists are missing.
 
 - Define derived types for TPCH rows and query results.
 - Use `ALLOCATE` arrays and `stdlib` hash maps to build groups by key.
 - Provide `sum`, `avg` and `count` helpers written in Fortran.
 - Create a routine that prints JSON-like output for the test harness.
-- Add `q1.mochi` to `tests/compiler/fortran` once implemented.
+- Add `q1.mochi` and `q2.mochi` to `tests/compiler/fortran` once implemented.
 - Implement join clauses for JOB queries and additional string helpers.
+- Implement joins and grouping so that `q1.mochi` and `q2.mochi` compile successfully.

--- a/compile/x/fortran/tpch_test.go
+++ b/compile/x/fortran/tpch_test.go
@@ -15,7 +15,12 @@ func TestFortranCompiler_TPCH(t *testing.T) {
 	if _, err := ftncode.EnsureFortran(); err != nil {
 		t.Skipf("fortran not installed: %v", err)
 	}
-	testutil.CompileTPCH(t, "q1", func(env *types.Env, prog *parser.Program) ([]byte, error) {
-		return ftncode.New().Compile(prog)
-	})
+	for _, q := range []string{"q1", "q2"} {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			testutil.CompileTPCH(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+				return ftncode.New().Compile(prog)
+			})
+		})
+	}
 }

--- a/tests/dataset/tpc-h/compiler/fortran/README.md
+++ b/tests/dataset/tpc-h/compiler/fortran/README.md
@@ -1,0 +1,1 @@
+Fortran compiler outputs will be added once implemented.


### PR DESCRIPTION
## Summary
- add a README stub for future Fortran TPCH outputs
- expand Fortran tpch test to attempt q1 and q2
- update Fortran TASKS list with q2 tasks

## Testing
- `go test ./compile/x/fortran -run TestFortranCompiler_TPCH -tags slow -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685eaf1b8d88832082d32baabbf7843a