### PR TITLE
Update TPCH tasks for clj compiler

### DIFF
--- a/compile/x/clj/TASKS.md
+++ b/compile/x/clj/TASKS.md
@@ -8,5 +8,13 @@ Remaining work:
 
 - Ensure all generated sources pass `cljfmt` without warnings.
 
+## TPCH Queries
+
+The TPCH suite is not yet supported. Compiling `q1.mochi` produces
+unformatted code with unmatched parentheses and the generated program
+fails to run. Once the compiler can emit valid code, add golden tests
+and expected output for `q1.mochi` and `q2.mochi` under
+`tests/dataset/tpc-h/compiler/clj`.
+
 With formatting improvements the Clojure backend can now execute the initial JOB
 queries without errors.


### PR DESCRIPTION
## Summary
- update Clojure compiler TASKS.md noting TPCH Q1 and Q2 support is missing

## Testing
- `go test ./... | head`

------
https://chatgpt.com/codex/tasks/task_e_685eaf1273dc8320ab3d3dcf3a426f96