### PR TITLE
Add TPCH q1-q2 Haskell golden tests

### DIFF
--- a/compile/x/hs/TASKS.md
+++ b/compile/x/hs/TASKS.md
@@ -11,3 +11,6 @@ query suites.
 - Extend the runtime with heterogeneous map helpers so JOB queries `q2`–`q10`
   compile and run. Currently the generated code fails to type check because
   `VInt`/`VString` constructors are missing.
+- TPCH queries `q1` and `q2` compile but the generated Haskell does not type
+  check. `_writeOutput` and JSON helpers need to be incorporated into the
+  runtime so these programs execute correctly.

--- a/compile/x/hs/compiler.go
+++ b/compile/x/hs/compiler.go
@@ -182,10 +182,9 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	}
 	header.WriteString("import qualified Data.ByteString.Lazy.Char8 as BSL\n")
 	header.WriteString("\n")
+	header.WriteString(runtime)
 	if c.usesLoad || c.usesSave || c.usesFetch || c.usesMap {
 		header.WriteString(loadRuntime)
-	} else {
-		header.WriteString(runtime)
 	}
 	if c.usesExpect {
 		header.WriteString(expectHelper)

--- a/compile/x/hs/runtime.go
+++ b/compile/x/hs/runtime.go
@@ -86,17 +86,6 @@ _parseCSV text header delim =
                              | j <- [0 .. length heads - 1] ]
        in map row (drop start ls)
 
-_load :: Maybe String -> Maybe (Map.Map String String) -> IO [Map.Map String String]
-_load path _ = do
-  txt <- _readInput path
-  pure (_parseCSV txt True ',')
-
-_save :: [Map.Map String String] -> Maybe String -> Maybe (Map.Map String String) -> IO ()
-_save rows path _ =
-  let headers = if null rows then [] else Map.keys (head rows)
-      toLine m = intercalate "," [Map.findWithDefault "" h m | h <- headers]
-      text = unlines (if null headers then [] else intercalate "," headers : map toLine rows)
-  in _writeOutput path text
 `
 
 const expectHelper = `

--- a/compile/x/hs/tpch_golden_test.go
+++ b/compile/x/hs/tpch_golden_test.go
@@ -14,36 +14,40 @@ import (
 	"mochi/types"
 )
 
-func TestHSCompiler_TPCHQ1(t *testing.T) {
+func TestHSCompiler_TPCHQueries(t *testing.T) {
 	if err := hscode.EnsureHaskell(); err != nil {
 		t.Skipf("haskell not installed: %v", err)
 	}
 	root := testutil.FindRepoRoot(t)
-	src := filepath.Join(root, "tests", "dataset", "tpc-h", "q1.mochi")
-	prog, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
+	for _, name := range []string{"q1", "q2"} {
+		t.Run(name, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-h", name+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := hscode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			codeWantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "hs", name+".hs.out")
+			wantCode, err := os.ReadFile(codeWantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s.hs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", name, got, bytes.TrimSpace(wantCode))
+			}
+			dir := t.TempDir()
+			file := filepath.Join(dir, "main.hs")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
+		})
 	}
-	env := types.NewEnv(nil)
-	if errs := types.Check(prog, env); len(errs) > 0 {
-		t.Fatalf("type error: %v", errs[0])
-	}
-	code, err := hscode.New(env).Compile(prog)
-	if err != nil {
-		t.Fatalf("compile error: %v", err)
-	}
-	codeWantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "hs", "q1.hs.out")
-	wantCode, err := os.ReadFile(codeWantPath)
-	if err != nil {
-		t.Fatalf("read golden: %v", err)
-	}
-	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
-		t.Errorf("generated code mismatch for q1.hs.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", got, bytes.TrimSpace(wantCode))
-	}
-	dir := t.TempDir()
-	file := filepath.Join(dir, "main.hs")
-	if err := os.WriteFile(file, code, 0644); err != nil {
-		t.Fatalf("write error: %v", err)
-	}
-	t.Skip("Haskell runtime check disabled until heterogeneous maps are supported")
 }

--- a/tests/dataset/tpc-h/compiler/hs/q2.hs.out
+++ b/tests/dataset/tpc-h/compiler/hs/q2.hs.out
@@ -180,15 +180,35 @@ expect :: Bool -> IO ()
 expect True = pure ()
 expect False = error "expect failed"
 
-lineitem = [Map.fromList [("l_quantity", VInt (17)), ("l_extendedprice", VDouble (1000.0)), ("l_discount", VDouble (0.05)), ("l_tax", VDouble (0.07)), ("l_returnflag", VString ("N")), ("l_linestatus", VString ("O")), ("l_shipdate", VString ("1998-08-01"))], Map.fromList [("l_quantity", VInt (36)), ("l_extendedprice", VDouble (2000.0)), ("l_discount", VDouble (0.1)), ("l_tax", VDouble (0.05)), ("l_returnflag", VString ("N")), ("l_linestatus", VString ("O")), ("l_shipdate", VString ("1998-09-01"))], Map.fromList [("l_quantity", VInt (25)), ("l_extendedprice", VDouble (1500.0)), ("l_discount", VDouble (0.0)), ("l_tax", VDouble (0.08)), ("l_returnflag", VString ("R")), ("l_linestatus", VString ("F")), ("l_shipdate", VString ("1998-09-03"))]]
+region = [Map.fromList [("r_regionkey", VInt (1)), ("r_name", VString ("EUROPE"))], Map.fromList [("r_regionkey", VInt (2)), ("r_name", VString ("ASIA"))]]
 
-result = [Map.fromList [("returnflag", VString (fromMaybe (error "missing") (Map.lookup "returnflag" (key (g))))), ("linestatus", VString (fromMaybe (error "missing") (Map.lookup "linestatus" (key (g))))), ("sum_qty", VDouble (sum [fromMaybe (error "missing") (Map.lookup "l_quantity" (x)) | x <- g])), ("sum_base_price", VDouble (sum [fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) | x <- g])), ("sum_disc_price", VDouble (sum [(fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (x))))) | x <- g])), ("sum_charge", VDouble (sum [((fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) * ((1 - fromMaybe (error "missing") (Map.lookup "l_discount" (x))))) * ((1 + fromMaybe (error "missing") (Map.lookup "l_tax" (x))))) | x <- g])), ("avg_qty", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_quantity" (x)) | x <- g])), ("avg_price", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_extendedprice" (x)) | x <- g])), ("avg_disc", VDouble (avg [fromMaybe (error "missing") (Map.lookup "l_discount" (x)) | x <- g])), ("count_order", VInt (length (items g)))] | g <- _group_by [(row) | row <- lineitem, (fromMaybe (error "missing") (Map.lookup "l_shipdate" row) <= "1998-09-02")] (\(row) -> Map.fromList [("returnflag", VString (fromMaybe (error "missing") (Map.lookup "l_returnflag" row))), ("linestatus", VString (fromMaybe (error "missing") (Map.lookup "l_linestatus" row)))]), let g = g]
+nation = [Map.fromList [("n_nationkey", VInt (10)), ("n_regionkey", VInt (1)), ("n_name", VString ("FRANCE"))], Map.fromList [("n_nationkey", VInt (20)), ("n_regionkey", VInt (2)), ("n_name", VString ("CHINA"))]]
 
-test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus :: IO ()
-test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus = do
-  expect ((result == [Map.fromList [("returnflag", VString ("N")), ("linestatus", VString ("O")), ("sum_qty", VInt (53)), ("sum_base_price", VInt (3000)), ("sum_disc_price", VDouble ((950.0 + 1800.0))), ("sum_charge", VDouble ((((950.0 * 1.07)) + ((1800.0 * 1.05))))), ("avg_qty", VDouble (26.5)), ("avg_price", VInt (1500)), ("avg_disc", VDouble (0.07500000000000001)), ("count_order", VInt (2))]]))
+supplier = [Map.fromList [("s_suppkey", VInt (100)), ("s_name", VString ("BestSupplier")), ("s_address", VString ("123 Rue")), ("s_nationkey", VInt (10)), ("s_phone", VString ("123")), ("s_acctbal", VDouble (1000.0)), ("s_comment", VString ("Fast and reliable"))], Map.fromList [("s_suppkey", VInt (200)), ("s_name", VString ("AltSupplier")), ("s_address", VString ("456 Way")), ("s_nationkey", VInt (20)), ("s_phone", VString ("456")), ("s_acctbal", VDouble (500.0)), ("s_comment", VString ("Slow"))]]
+
+part = [Map.fromList [("p_partkey", VInt (1000)), ("p_type", VString ("LARGE BRASS")), ("p_size", VInt (15)), ("p_mfgr", VString ("M1"))], Map.fromList [("p_partkey", VInt (2000)), ("p_type", VString ("SMALL COPPER")), ("p_size", VInt (15)), ("p_mfgr", VString ("M2"))]]
+
+partsupp = [Map.fromList [("ps_partkey", VInt (1000)), ("ps_suppkey", VInt (100)), ("ps_supplycost", VDouble (10.0))], Map.fromList [("ps_partkey", VInt (1000)), ("ps_suppkey", VInt (200)), ("ps_supplycost", VDouble (15.0))]]
+
+europe_nations = [n | r <- region, n <- nation, (fromMaybe (error "missing") (Map.lookup "n_regionkey" (n)) == fromMaybe (error "missing") (Map.lookup "r_regionkey" (r))), (fromMaybe (error "missing") (Map.lookup "r_name" r) == "EUROPE")]
+
+europe_suppliers = [Map.fromList [("s", s), ("n", n)] | s <- supplier, n <- europe_nations, (fromMaybe (error "missing") (Map.lookup "s_nationkey" (s)) == fromMaybe (error "missing") (Map.lookup "n_nationkey" (n)))]
+
+target_parts = [p | p <- filter (\p -> (((fromMaybe (error "missing") (Map.lookup "p_size" p) == 15) && fromMaybe (error "missing") (Map.lookup "p_type" p)) == "LARGE BRASS")) part]
+
+target_partsupp = [Map.fromList [("s_acctbal", VString (fromMaybe (error "missing") (Map.lookup "s_acctbal" fromMaybe (error "missing") (Map.lookup "s" s)))), ("s_name", VString (fromMaybe (error "missing") (Map.lookup "s_name" fromMaybe (error "missing") (Map.lookup "s" s)))), ("n_name", VString (fromMaybe (error "missing") (Map.lookup "n_name" fromMaybe (error "missing") (Map.lookup "n" s)))), ("p_partkey", VString (fromMaybe (error "missing") (Map.lookup "p_partkey" p))), ("p_mfgr", VString (fromMaybe (error "missing") (Map.lookup "p_mfgr" p))), ("s_address", VString (fromMaybe (error "missing") (Map.lookup "s_address" fromMaybe (error "missing") (Map.lookup "s" s)))), ("s_phone", VString (fromMaybe (error "missing") (Map.lookup "s_phone" fromMaybe (error "missing") (Map.lookup "s" s)))), ("s_comment", VString (fromMaybe (error "missing") (Map.lookup "s_comment" fromMaybe (error "missing") (Map.lookup "s" s)))), ("ps_supplycost", VString (fromMaybe (error "missing") (Map.lookup "ps_supplycost" ps)))] | ps <- partsupp, p <- target_parts, s <- europe_suppliers, (fromMaybe (error "missing") (Map.lookup "ps_partkey" (ps)) == fromMaybe (error "missing") (Map.lookup "p_partkey" (p))), (fromMaybe (error "missing") (Map.lookup "ps_suppkey" (ps)) == fromMaybe (error "missing") (Map.lookup "s_suppkey" (fromMaybe (error "missing") (Map.lookup "s" (s)))))]
+
+costs = [fromMaybe (error "missing") (Map.lookup "ps_supplycost" x) | x <- target_partsupp]
+
+min_cost = min costs
+
+result = map snd (List.sortOn fst [((-fromMaybe (error "missing") (Map.lookup "s_acctbal" (x))), x) | x <- target_partsupp, (fromMaybe (error "missing") (Map.lookup "ps_supplycost" x) == min_cost)])
+
+test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part :: IO ()
+test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part = do
+  expect ((result == [Map.fromList [("s_acctbal", VDouble (1000.0)), ("s_name", VString ("BestSupplier")), ("n_name", VString ("FRANCE")), ("p_partkey", VInt (1000)), ("p_mfgr", VString ("M1")), ("s_address", VString ("123 Rue")), ("s_phone", VString ("123")), ("s_comment", VString ("Fast and reliable")), ("ps_supplycost", VDouble (10.0))]]))
 
 main :: IO ()
 main = do
   _json result
-  test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus
+  test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part


### PR DESCRIPTION
## Summary
- update Haskell runtime & compiler to always embed base runtime
- update tasks with note about failing TPCH queries
- add new golden output for TPCH q1 and q2
- extend TPCH golden test to compile q1 and q2

## Testing
- `go test ./compile/x/hs -run TPCHQueries -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685eaf2046cc83209904655b90ca9f25