### PR TITLE
Add Ruby TPCH q2 golden tests

### DIFF
--- a/compile/x/rb/TASKS.md
+++ b/compile/x/rb/TASKS.md
@@ -1,6 +1,6 @@
 # Ruby Backend Tasks
 
-The Ruby backend now supports running the TPCH `q1` example and the first ten JOB queries. Generated code and runtime output for JOB `q1` through `q10` are checked in under `tests/dataset/job/compiler/rb`.
+The Ruby backend now supports running the TPCH `q1` and `q2` examples and the first ten JOB queries. Generated code and runtime output for JOB `q1` through `q10` are checked in under `tests/dataset/job/compiler/rb` and TPCH output for `q1` and `q2` under `tests/dataset/tpc-h/compiler/rb`.
 
 Implemented features:
 - Grouping and query helpers via `_group_by` and `_query`.
@@ -8,4 +8,4 @@ Implemented features:
 - Helper methods `sum`, `avg`, `count` and `json` for datasets.
 
 Remaining work:
-- Compile and verify the rest of the JOB and TPCH queries.
+- Compile and verify the remaining JOB queries and TPCH queries beyond `q2`.

--- a/compile/x/rb/compiler_test.go
+++ b/compile/x/rb/compiler_test.go
@@ -254,6 +254,55 @@ func TestRBCompiler_TPCHQ1(t *testing.T) {
 	}
 }
 
+func TestRBCompiler_TPCHQ2(t *testing.T) {
+	if err := rbcode.EnsureRuby(); err != nil {
+		t.Skipf("ruby not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	src := filepath.Join(root, "tests", "dataset", "tpc-h", "q2.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	code, err := rbcode.New(env).Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	codeWantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "rb", "q2.rb.out")
+	wantCode, err := os.ReadFile(codeWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(wantCode)) {
+		t.Errorf("generated code mismatch for q2.rb.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", got, bytes.TrimSpace(wantCode))
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.rb")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("ruby", file)
+	cmd.Dir = findRepoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ruby run error: %v\n%s", err, out)
+	}
+	gotOut := bytes.TrimSpace(out)
+	outWantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "rb", "q2.out")
+	wantOut, err := os.ReadFile(outWantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+		t.Errorf("output mismatch for q2.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", gotOut, bytes.TrimSpace(wantOut))
+	}
+}
+
 func TestRBCompiler_JOBQ1(t *testing.T) {
 	if err := rbcode.EnsureRuby(); err != nil {
 		t.Skipf("ruby not installed: %v", err)

--- a/compile/x/rb/tpch_test.go
+++ b/compile/x/rb/tpch_test.go
@@ -15,7 +15,12 @@ func TestRBCompiler_TPCH(t *testing.T) {
 	if err := rbcode.EnsureRuby(); err != nil {
 		t.Skipf("ruby not installed: %v", err)
 	}
-	testutil.CompileTPCH(t, "q1", func(env *types.Env, prog *parser.Program) ([]byte, error) {
-		return rbcode.New(env).Compile(prog)
-	})
+	for _, q := range []string{"q1", "q2"} {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			testutil.CompileTPCH(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+				return rbcode.New(env).Compile(prog)
+			})
+		})
+	}
 }

--- a/tests/dataset/tpc-h/compiler/rb/q1.rb.out
+++ b/tests/dataset/tpc-h/compiler/rb/q1.rb.out
@@ -1,4 +1,4 @@
-require 'ostruct'
+require "ostruct"
 
 class MGroup
   include Enumerable
@@ -7,35 +7,39 @@ class MGroup
     @key = k
     @Items = []
   end
+
   def length
     @Items.length
   end
+
   def each(&block)
     @Items.each(&block)
   end
 end
+
 def _group_by(src, keyfn)
-grouped = src.group_by do |it|
-  if it.is_a?(Array)
-    keyfn.call(*it)
-  else
-    keyfn.call(it)
+  grouped = src.group_by do |it|
+    if it.is_a?(Array)
+      keyfn.call(*it)
+    else
+      keyfn.call(it)
+    end
+  end
+  grouped.map do |k, items|
+    g = MGroup.new(k)
+    items.each do |it|
+      g.Items << if it.is_a?(Array) && it.length == 1
+        it[0]
+      else
+        it
+      end
+    end
+    g
   end
 end
-grouped.map do |k, items|
-g = MGroup.new(k)
-items.each do |it|
-  if it.is_a?(Array) && it.length == 1
-    g.Items << it[0]
-  else
-    g.Items << it
-  end
-end
-g
-end
-end
+
 def _json(v)
-  require 'json'
+  require "json"
   obj = v
   if v.is_a?(Array)
     obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
@@ -44,8 +48,9 @@ def _json(v)
   end
   puts(JSON.generate(obj))
 end
+
 def _query(src, joins, opts)
-  where_fn = opts['where']
+  where_fn = opts["where"]
   items = []
   if joins.empty?
     src.each do |v|
@@ -57,10 +62,10 @@ def _query(src, joins, opts)
     items = src.map { |v| [v] }
     joins.each_with_index do |j, idx|
       joined = []
-      jitems = j['items']
-      on = j['on']
-      left = j['left']
-      right = j['right']
+      jitems = j["items"]
+      on = j["on"]
+      left = j["left"]
+      right = j["right"]
       last = idx == joins.length - 1
       if right && left
         matched = Array.new(jitems.length, false)
@@ -145,23 +150,24 @@ def _query(src, joins, opts)
       items = joined
     end
   end
-  if opts['sortKey']
-    items = items.map { |it| [it, opts['sortKey'].call(*it)] }
+  if opts["sortKey"]
+    items = items.map { |it| [it, opts["sortKey"].call(*it)] }
     items.sort_by! { |p| p[1] }
     items.map!(&:first)
   end
-  if opts.key?('skip')
-    n = opts['skip']
-    items = n < items.length ? items[n..-1] : []
+  if opts.key?("skip")
+    n = opts["skip"]
+    items = (n < items.length) ? items[n..-1] : []
   end
-  if opts.key?('take')
-    n = opts['take']
-    items = n < items.length ? items[0...n] : items
+  if opts.key?("take")
+    n = opts["take"]
+    items = (n < items.length) ? items[0...n] : items
   end
   res = []
-  items.each { |r| res << opts['select'].call(*r) }
+  items.each { |r| res << opts["select"].call(*r) }
   res
 end
+
 def _sum(v)
   list = nil
   if v.is_a?(MGroup)
@@ -179,15 +185,14 @@ end
 
 lineitem = [OpenStruct.new(l_quantity: 17, l_extendedprice: 1000.0, l_discount: 0.05, l_tax: 0.07, l_returnflag: "N", l_linestatus: "O", l_shipdate: "1998-08-01"), OpenStruct.new(l_quantity: 36, l_extendedprice: 2000.0, l_discount: 0.1, l_tax: 0.05, l_returnflag: "N", l_linestatus: "O", l_shipdate: "1998-09-01"), OpenStruct.new(l_quantity: 25, l_extendedprice: 1500.0, l_discount: 0.0, l_tax: 0.08, l_returnflag: "R", l_linestatus: "F", l_shipdate: "1998-09-03")]
 result = (begin
-	src = lineitem
-	_rows = _query(src, [
-	], { 'select' => ->(row){ [row] }, 'where' => ->(row){ (row.l_shipdate <= "1998-09-02") } })
-	_groups = _group_by(_rows, ->(row){ OpenStruct.new(returnflag: row.l_returnflag, linestatus: row.l_linestatus) })
-	_res = []
-	for g in _groups
-		_res << OpenStruct.new(returnflag: g.key.returnflag, linestatus: g.key.linestatus, sum_qty: _sum(((g)).map { |x| x.l_quantity }), sum_base_price: _sum(((g)).map { |x| x.l_extendedprice }), sum_disc_price: _sum(((g)).map { |x| (x.l_extendedprice * ((1 - x.l_discount))) }), sum_charge: _sum(((g)).map { |x| ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))) }), avg_qty: ((((g)).map { |x| x.l_quantity }).length > 0 ? (((g)).map { |x| x.l_quantity }).sum(0.0) / (((g)).map { |x| x.l_quantity }).length : 0), avg_price: ((((g)).map { |x| x.l_extendedprice }).length > 0 ? (((g)).map { |x| x.l_extendedprice }).sum(0.0) / (((g)).map { |x| x.l_extendedprice }).length : 0), avg_disc: ((((g)).map { |x| x.l_discount }).length > 0 ? (((g)).map { |x| x.l_discount }).sum(0.0) / (((g)).map { |x| x.l_discount }).length : 0), count_order: (g).length)
-	end
-	_res
+  src = lineitem
+  _rows = _query(src, [], {"select" => ->(row) { [row] }, "where" => ->(row) { (row.l_shipdate <= "1998-09-02") }})
+  _groups = _group_by(_rows, ->(row) { OpenStruct.new(returnflag: row.l_returnflag, linestatus: row.l_linestatus) })
+  _res = []
+  for g in _groups
+    _res << OpenStruct.new(returnflag: g.key.returnflag, linestatus: g.key.linestatus, sum_qty: _sum(g.map { |x| x.l_quantity }), sum_base_price: _sum(g.map { |x| x.l_extendedprice }), sum_disc_price: _sum(g.map { |x| (x.l_extendedprice * ((1 - x.l_discount))) }), sum_charge: _sum(g.map { |x| ((x.l_extendedprice * ((1 - x.l_discount))) * ((1 + x.l_tax))) }), avg_qty: (((g.map { |x| x.l_quantity }).length > 0) ? (g.map { |x| x.l_quantity }).sum(0.0) / (g.map { |x| x.l_quantity }).length : 0), avg_price: (((g.map { |x| x.l_extendedprice }).length > 0) ? (g.map { |x| x.l_extendedprice }).sum(0.0) / (g.map { |x| x.l_extendedprice }).length : 0), avg_disc: (((g.map { |x| x.l_discount }).length > 0) ? (g.map { |x| x.l_discount }).sum(0.0) / (g.map { |x| x.l_discount }).length : 0), count_order: g.length)
+  end
+  _res
 end)
 _json(result)
-raise "expect failed" unless (result == [OpenStruct.new(returnflag: "N", linestatus: "O", sum_qty: 53, sum_base_price: 3000, sum_disc_price: (950.0 + 1800.0), sum_charge: (((950.0 * 1.07)) + ((1800.0 * 1.05))), avg_qty: 26.5, avg_price: 1500, avg_disc: 0.07500000000000001, count_order: 2)])
+raise "expect failed" unless result == [OpenStruct.new(returnflag: "N", linestatus: "O", sum_qty: 53, sum_base_price: 3000, sum_disc_price: (950.0 + 1800.0), sum_charge: (((950.0 * 1.07)) + ((1800.0 * 1.05))), avg_qty: 26.5, avg_price: 1500, avg_disc: 0.07500000000000001, count_order: 2)]

--- a/tests/dataset/tpc-h/compiler/rb/q2.out
+++ b/tests/dataset/tpc-h/compiler/rb/q2.out
@@ -1,0 +1,1 @@
+[{"s_acctbal":1000.0,"s_name":"BestSupplier","n_name":"FRANCE","p_partkey":1000,"p_mfgr":"M1","s_address":"123 Rue","s_phone":"123","s_comment":"Fast and reliable","ps_supplycost":10.0}]

--- a/tests/dataset/tpc-h/compiler/rb/q2.rb.out
+++ b/tests/dataset/tpc-h/compiler/rb/q2.rb.out
@@ -1,0 +1,76 @@
+require "ostruct"
+
+def _json(v)
+  require "json"
+  obj = v
+  if v.is_a?(Array)
+    obj = v.map { |it| it.respond_to?(:to_h) ? it.to_h : it }
+  elsif v.respond_to?(:to_h)
+    obj = v.to_h
+  end
+  puts(JSON.generate(obj))
+end
+
+def _min(v)
+  list = nil
+  if v.respond_to?(:Items)
+    list = v.Items
+  elsif v.is_a?(Array)
+    list = v
+  elsif v.respond_to?(:to_a)
+    list = v.to_a
+  end
+  return 0 if !list || list.empty?
+  list.min
+end
+
+region = [OpenStruct.new(r_regionkey: 1, r_name: "EUROPE"), OpenStruct.new(r_regionkey: 2, r_name: "ASIA")]
+nation = [OpenStruct.new(n_nationkey: 10, n_regionkey: 1, n_name: "FRANCE"), OpenStruct.new(n_nationkey: 20, n_regionkey: 2, n_name: "CHINA")]
+supplier = [OpenStruct.new(s_suppkey: 100, s_name: "BestSupplier", s_address: "123 Rue", s_nationkey: 10, s_phone: "123", s_acctbal: 1000.0, s_comment: "Fast and reliable"), OpenStruct.new(s_suppkey: 200, s_name: "AltSupplier", s_address: "456 Way", s_nationkey: 20, s_phone: "456", s_acctbal: 500.0, s_comment: "Slow")]
+part = [OpenStruct.new(p_partkey: 1000, p_type: "LARGE BRASS", p_size: 15, p_mfgr: "M1"), OpenStruct.new(p_partkey: 2000, p_type: "SMALL COPPER", p_size: 15, p_mfgr: "M2")]
+partsupp = [OpenStruct.new(ps_partkey: 1000, ps_suppkey: 100, ps_supplycost: 10.0), OpenStruct.new(ps_partkey: 1000, ps_suppkey: 200, ps_supplycost: 15.0)]
+europe_nations = (begin
+  _res = []
+  for r in region
+    for n in nation
+      if n.n_regionkey == r.r_regionkey
+        if r.r_name == "EUROPE"
+          _res << n
+        end
+      end
+    end
+  end
+  _res
+end)
+europe_suppliers = (begin
+  _res = []
+  for s in supplier
+    for n in europe_nations
+      if s.s_nationkey == n.n_nationkey
+        _res << OpenStruct.new(s: s, n: n)
+      end
+    end
+  end
+  _res
+end)
+target_parts = (part.select { |p| (p.p_size == 15) && (p.p_type == "LARGE BRASS") }).map { |p| p }
+target_partsupp = (begin
+  _res = []
+  for ps in partsupp
+    for p in target_parts
+      if ps.ps_partkey == p.p_partkey
+        for s in europe_suppliers
+          if ps.ps_suppkey == s.s.s_suppkey
+            _res << OpenStruct.new(s_acctbal: s.s.s_acctbal, s_name: s.s.s_name, n_name: s.n.n_name, p_partkey: p.p_partkey, p_mfgr: p.p_mfgr, s_address: s.s.s_address, s_phone: s.s.s_phone, s_comment: s.s.s_comment, ps_supplycost: ps.ps_supplycost)
+          end
+        end
+      end
+    end
+  end
+  _res
+end)
+costs = target_partsupp.map { |x| x.ps_supplycost }
+min_cost = _min(costs)
+result = ((target_partsupp.select { |x| (x.ps_supplycost == min_cost) }).sort_by { |x| -x.s_acctbal }).map { |x| x }
+_json(result)
+raise "expect failed" unless result == [OpenStruct.new(s_acctbal: 1000.0, s_name: "BestSupplier", n_name: "FRANCE", p_partkey: 1000, p_mfgr: "M1", s_address: "123 Rue", s_phone: "123", s_comment: "Fast and reliable", ps_supplycost: 10.0)]


### PR DESCRIPTION
## Summary
- update Ruby backend TASKS
- support compiling TPCH q1 and q2 in rb tests
- add golden runtime and code for TPCH q2
- regenerate q1 Ruby output with current formatter

## Testing
- `go test ./compile/x/rb -run TPCH -tags slow -count=1`
- `go test ./... -tags slow -run TestRBCompiler_TPCHQ2 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_685eaf2f2d308320bb46f83cc82824e5