### PR TITLE
Add Smalltalk TPCH golden tests

### DIFF
--- a/compile/x/st/TASKS.md
+++ b/compile/x/st/TASKS.md
@@ -1,10 +1,12 @@
-# Smalltalk Backend Tasks for TPCH Q1
+# Smalltalk Backend Tasks for TPCH Q1-2
 
 The Smalltalk backend now supports dataset grouping used by TPCH Q1.
 Groups are accumulated via a `_Group` class backed by `Dictionary`
 objects and runtime helpers provide `sum`, `avg` and `count`.
 Query results can be printed as JSON via the `json` built-in and
-golden tests cover `tpch_q1` and simple `group_by` queries.
+golden tests cover `tpch_q1` and `tpch_q2` as well as simple `group_by` queries.
+Running the TPCH programs under `gst` still reports parse errors,
+so executing the compiled Smalltalk code remains TODO.
 
 ## Pending JOB Queries
 

--- a/compile/x/st/tpch_golden_test.go
+++ b/compile/x/st/tpch_golden_test.go
@@ -1,0 +1,46 @@
+//go:build slow
+
+package stcode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	stcode "mochi/compile/x/st"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestSTCompiler_TPCH_Golden(t *testing.T) {
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 2; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			src := filepath.Join(root, "tests", "dataset", "tpc-h", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := stcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "st", q+".st.out")
+			want, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if got := bytes.TrimSpace(code); !bytes.Equal(got, bytes.TrimSpace(want)) {
+				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".st.out", got, bytes.TrimSpace(want))
+			}
+		})
+	}
+}

--- a/compile/x/st/tpch_test.go
+++ b/compile/x/st/tpch_test.go
@@ -3,6 +3,7 @@
 package stcode_test
 
 import (
+	"fmt"
 	"testing"
 
 	stcode "mochi/compile/x/st"
@@ -15,7 +16,10 @@ func TestSTCompiler_TPCH(t *testing.T) {
 	if err := stcode.EnsureSmalltalk(); err != nil {
 		t.Skipf("smalltalk not installed: %v", err)
 	}
-	testutil.CompileTPCH(t, "q1", func(env *types.Env, prog *parser.Program) ([]byte, error) {
-		return stcode.New(env).Compile(prog)
-	})
+	for i := 1; i <= 2; i++ {
+		q := fmt.Sprintf("q%d", i)
+		testutil.CompileTPCH(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+			return stcode.New(env).Compile(prog)
+		})
+	}
 }

--- a/tests/dataset/tpc-h/compiler/st/q1.out
+++ b/tests/dataset/tpc-h/compiler/st/q1.out
@@ -1,0 +1,1 @@
+[{"avg_disc":0.07500000000000001,"avg_price":1500,"avg_qty":26.5,"count_order":2,"linestatus":"O","returnflag":"N","sum_base_price":3000,"sum_charge":2906.5,"sum_disc_price":2750,"sum_qty":53}]

--- a/tests/dataset/tpc-h/compiler/st/q1.st.out
+++ b/tests/dataset/tpc-h/compiler/st/q1.st.out
@@ -1,0 +1,131 @@
+Smalltalk at: #lineitem put: nil.
+Smalltalk at: #result put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus
+    ((result = Array with: (Dictionary from: {'returnflag' -> 'N'. 'linestatus' -> 'O'. 'sum_qty' -> 53. 'sum_base_price' -> 3000. 'sum_disc_price' -> (950.000000 + 1800.000000). 'sum_charge' -> (((950.000000 * 1.070000)) + ((1800.000000 * 1.050000))). 'avg_qty' -> 26.500000. 'avg_price' -> 1500. 'avg_disc' -> 0.075000. 'count_order' -> 2}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+Object subclass: #_Group instanceVariableNames: 'key items' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!_Group class methodsFor: 'instance creation'!
+key: k | g |
+    g := self new.
+    g key: k.
+    g initialize.
+    ^ g
+!
+!_Group methodsFor: 'initialization'!
+initialize
+    items := OrderedCollection new.
+    ^ self
+!
+!_Group methodsFor: 'accessing'!
+key
+    ^ key
+!
+key: k
+    key := k
+!
+add: it
+    items add: it
+!
+do: blk
+    items do: blk
+!
+size
+    ^ items size
+!
+!Main class methodsFor: 'runtime'!
+__count: v
+    (v respondsTo: #size) ifTrue: [ ^ v size ]
+    ^ self error: 'count() expects collection'
+!
+__avg: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'avg() expects collection' ]
+    v size = 0 ifTrue: [ ^ 0 ]
+    | sum |
+    sum := 0.
+    v do: [:it | sum := sum + it].
+    ^ sum / v size
+!
+__sum: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'sum() expects collection' ]
+    | s |
+    s := 0.
+    v do: [:it | s := s + it].
+    ^ s
+!
+_group_by: src keyFn: blk
+    | groups order |
+    groups := Dictionary new.
+    order := OrderedCollection new.
+    src do: [:it |
+        | key ks g |
+        key := blk value: it.
+        ks := key printString.
+        g := groups at: ks ifAbsentPut: [ |_g | _g := _Group key: key. order add: ks. groups at: ks put: _g. _g ].
+        g add: it.
+    ]
+    ^ order collect: [:k | groups at: k ]
+!
+!!
+lineitem := Array with: (Dictionary from: {'l_quantity' -> 17. 'l_extendedprice' -> 1000.000000. 'l_discount' -> 0.050000. 'l_tax' -> 0.070000. 'l_returnflag' -> 'N'. 'l_linestatus' -> 'O'. 'l_shipdate' -> '1998-08-01'}) with: (Dictionary from: {'l_quantity' -> 36. 'l_extendedprice' -> 2000.000000. 'l_discount' -> 0.100000. 'l_tax' -> 0.050000. 'l_returnflag' -> 'N'. 'l_linestatus' -> 'O'. 'l_shipdate' -> '1998-09-01'}) with: (Dictionary from: {'l_quantity' -> 25. 'l_extendedprice' -> 1500.000000. 'l_discount' -> 0.000000. 'l_tax' -> 0.080000. 'l_returnflag' -> 'R'. 'l_linestatus' -> 'F'. 'l_shipdate' -> '1998-09-03'}).
+result := ((| rows groups |
+rows := OrderedCollection new.
+(lineitem) do: [:row |
+    ((row at: 'l_shipdate' <= '1998-09-02')) ifTrue: [ rows add: row ].
+]
+groups := (Main _group_by: rows keyFn: [:row | Dictionary from: {'returnflag' -> row at: 'l_returnflag'. 'linestatus' -> row at: 'l_linestatus'}]).
+rows := OrderedCollection new.
+(groups) do: [:g |
+    rows add: Dictionary from: {'returnflag' -> g at: 'key' at: 'returnflag'. 'linestatus' -> g at: 'key' at: 'linestatus'. 'sum_qty' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'l_quantity'.
+]
+res := res asArray.
+res))). 'sum_base_price' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'l_extendedprice'.
+]
+res := res asArray.
+res))). 'sum_disc_price' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: (x at: 'l_extendedprice' * ((1 - x at: 'l_discount'))).
+]
+res := res asArray.
+res))). 'sum_charge' -> (Main __sum: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: ((x at: 'l_extendedprice' * ((1 - x at: 'l_discount'))) * ((1 + x at: 'l_tax'))).
+]
+res := res asArray.
+res))). 'avg_qty' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'l_quantity'.
+]
+res := res asArray.
+res))). 'avg_price' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'l_extendedprice'.
+]
+res := res asArray.
+res))). 'avg_disc' -> (Main __avg: ((| res |
+res := OrderedCollection new.
+(g) do: [:x |
+    res add: x at: 'l_discount'.
+]
+res := res asArray.
+res))). 'count_order' -> (Main __count: g)}.
+]
+rows := rows asArray.
+rows)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_Q1_aggregates_revenue_and_quantity_by_returnflag___linestatus.

--- a/tests/dataset/tpc-h/compiler/st/q2.out
+++ b/tests/dataset/tpc-h/compiler/st/q2.out
@@ -1,0 +1,1 @@
+[{"n_name":"FRANCE","p_mfgr":"M1","p_partkey":1000,"ps_supplycost":10,"s_acctbal":1000,"s_address":"123 Rue","s_comment":"Fast and reliable","s_name":"BestSupplier","s_phone":"123"}]

--- a/tests/dataset/tpc-h/compiler/st/q2.st.out
+++ b/tests/dataset/tpc-h/compiler/st/q2.st.out
@@ -1,0 +1,89 @@
+Smalltalk at: #costs put: nil.
+Smalltalk at: #europe_nations put: nil.
+Smalltalk at: #europe_suppliers put: nil.
+Smalltalk at: #min_cost put: nil.
+Smalltalk at: #nation put: nil.
+Smalltalk at: #part put: nil.
+Smalltalk at: #partsupp put: nil.
+Smalltalk at: #region put: nil.
+Smalltalk at: #result put: nil.
+Smalltalk at: #supplier put: nil.
+Smalltalk at: #target_parts put: nil.
+Smalltalk at: #target_partsupp put: nil.
+
+Object subclass: #Main instanceVariableNames: '' classVariableNames: '' poolDictionaries: '' category: nil!
+
+!Main class methodsFor: 'tests'!
+test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part
+    ((result = Array with: (Dictionary from: {'s_acctbal' -> 1000.000000. 's_name' -> 'BestSupplier'. 'n_name' -> 'FRANCE'. 'p_partkey' -> 1000. 'p_mfgr' -> 'M1'. 's_address' -> '123 Rue'. 's_phone' -> '123'. 's_comment' -> 'Fast and reliable'. 'ps_supplycost' -> 10.000000}))) ifFalse: [ self error: 'expect failed' ]
+!
+
+!Main class methodsFor: 'runtime'!
+__min: v
+    (v respondsTo: #do:) ifFalse: [ ^ self error: 'min() expects collection' ]
+    | m |
+    m := nil.
+    v do: [:it | m isNil ifTrue: [ m := it ] ifFalse: [ (it < m) ifTrue: [ m := it ] ] ].
+    ^ m
+!
+!!
+region := Array with: (Dictionary from: {'r_regionkey' -> 1. 'r_name' -> 'EUROPE'}) with: (Dictionary from: {'r_regionkey' -> 2. 'r_name' -> 'ASIA'}).
+nation := Array with: (Dictionary from: {'n_nationkey' -> 10. 'n_regionkey' -> 1. 'n_name' -> 'FRANCE'}) with: (Dictionary from: {'n_nationkey' -> 20. 'n_regionkey' -> 2. 'n_name' -> 'CHINA'}).
+supplier := Array with: (Dictionary from: {'s_suppkey' -> 100. 's_name' -> 'BestSupplier'. 's_address' -> '123 Rue'. 's_nationkey' -> 10. 's_phone' -> '123'. 's_acctbal' -> 1000.000000. 's_comment' -> 'Fast and reliable'}) with: (Dictionary from: {'s_suppkey' -> 200. 's_name' -> 'AltSupplier'. 's_address' -> '456 Way'. 's_nationkey' -> 20. 's_phone' -> '456'. 's_acctbal' -> 500.000000. 's_comment' -> 'Slow'}).
+part := Array with: (Dictionary from: {'p_partkey' -> 1000. 'p_type' -> 'LARGE BRASS'. 'p_size' -> 15. 'p_mfgr' -> 'M1'}) with: (Dictionary from: {'p_partkey' -> 2000. 'p_type' -> 'SMALL COPPER'. 'p_size' -> 15. 'p_mfgr' -> 'M2'}).
+partsupp := Array with: (Dictionary from: {'ps_partkey' -> 1000. 'ps_suppkey' -> 100. 'ps_supplycost' -> 10.000000}) with: (Dictionary from: {'ps_partkey' -> 1000. 'ps_suppkey' -> 200. 'ps_supplycost' -> 15.000000}).
+europe_nations := ((| res |
+res := OrderedCollection new.
+((region) select: [:r | ((r at: 'r_name' = 'EUROPE') and: [(n at: 'n_regionkey' = r at: 'r_regionkey')])]) do: [:r |
+    (nation) do: [:n |
+        res add: n.
+    ]
+]
+res := res asArray.
+res)).
+europe_suppliers := ((| res |
+res := OrderedCollection new.
+((supplier) select: [:s | (s at: 's_nationkey' = n at: 'n_nationkey')]) do: [:s |
+    (europe_nations) do: [:n |
+        res add: Dictionary from: {'s' -> s. 'n' -> n}.
+    ]
+]
+res := res asArray.
+res)).
+target_parts := ((| res |
+res := OrderedCollection new.
+((part) select: [:p | (((p at: 'p_size' = 15) and: [p at: 'p_type']) = 'LARGE BRASS')]) do: [:p |
+    res add: p.
+]
+res := res asArray.
+res)).
+target_partsupp := ((| res |
+res := OrderedCollection new.
+((partsupp) select: [:ps | ((ps at: 'ps_partkey' = p at: 'p_partkey') and: [(ps at: 'ps_suppkey' = s at: 's' at: 's_suppkey')])]) do: [:ps |
+    (target_parts) do: [:p |
+        (europe_suppliers) do: [:s |
+            res add: Dictionary from: {'s_acctbal' -> s at: 's' at: 's_acctbal'. 's_name' -> s at: 's' at: 's_name'. 'n_name' -> s at: 'n' at: 'n_name'. 'p_partkey' -> p at: 'p_partkey'. 'p_mfgr' -> p at: 'p_mfgr'. 's_address' -> s at: 's' at: 's_address'. 's_phone' -> s at: 's' at: 's_phone'. 's_comment' -> s at: 's' at: 's_comment'. 'ps_supplycost' -> ps at: 'ps_supplycost'}.
+        ]
+    ]
+]
+res := res asArray.
+res)).
+costs := ((| res |
+res := OrderedCollection new.
+(target_partsupp) do: [:x |
+    res add: x at: 'ps_supplycost'.
+]
+res := res asArray.
+res)).
+min_cost := (Main __min: costs).
+result := ((| res |
+res := OrderedCollection new.
+((target_partsupp) select: [:x | (x at: 'ps_supplycost' = min_cost)]) do: [:x |
+    res add: { (x at: 's_acctbal' negated) . x }.
+]
+res := res asArray.
+res := (SortedCollection sortBlock: [:a :b | a first <= b first ]) withAll: res; asArray.
+res := res collect: [:p | p second].
+res)).
+(result toJSON) displayOn: Transcript. Transcript cr.
+Main test_Q2_returns_only_supplier_with_min_cost_in_Europe_for_brass_part.


### PR DESCRIPTION
## Summary
- expand Smalltalk TPCH test to compile queries q1 and q2
- check generated Smalltalk code against golden files
- store compiled q1 and q2 examples and expected output
- update TPCH tasks to mention q2 and note gst parse errors

## Testing
- `go test ./compile/x/st -tags slow -run TPCH -count=1 -v`
- `go test ./... -count=1 -run ^$`

------
https://chatgpt.com/codex/tasks/task_e_685eaf377c1483208185c3ec96a6f78e