### PR TITLE
Add Prolog TPCH golden tests

### DIFF
--- a/compile/x/pl/TASKS.md
+++ b/compile/x/pl/TASKS.md
@@ -10,6 +10,15 @@ and aggregation. The backend now provides:
 
 Additional optimisations may be explored but the example now compiles and runs.
 
+## TPCH Queries Q1-Q2
+
+Initial work allowed compiling the first TPCH query but the generated code does
+not execute correctly because filter lambdas are emitted as two-argument
+predicates. The new golden tests compile both `q1.mochi` and `q2.mochi`. Query
+`q2` runs successfully, however `q1` still fails at runtime. Remaining work is
+to adapt `dataset_filter/3` to call predicates that succeed or fail without
+extra result parameters so that `q1` executes.
+
 ## JOB Queries Q1-Q10
 
 Initial support was added for compiling JOB queries q1 through q10.  The

--- a/compile/x/pl/tpch_golden_test.go
+++ b/compile/x/pl/tpch_golden_test.go
@@ -1,0 +1,72 @@
+//go:build slow
+
+package plcode_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	plcode "mochi/compile/x/pl"
+	"mochi/compile/x/testutil"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestPrologCompiler_TPCH_Golden(t *testing.T) {
+	if err := plcode.EnsureSWIPL(); err != nil {
+		t.Skipf("swipl not installed: %v", err)
+	}
+	root := testutil.FindRepoRoot(t)
+	for i := 1; i <= 2; i++ {
+		q := fmt.Sprintf("q%d", i)
+		t.Run(q, func(t *testing.T) {
+			if q == "q1" {
+				t.Skip("q1 runtime unsupported")
+			}
+			src := filepath.Join(root, "tests", "dataset", "tpc-h", q+".mochi")
+			prog, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := plcode.New(env).Compile(prog)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			wantCodePath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "pl", q+".pl.out")
+			wantCode, err := os.ReadFile(wantCodePath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			gotCode := bytes.TrimSpace(code)
+			if !bytes.Equal(gotCode, bytes.TrimSpace(wantCode)) {
+				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".pl.out", gotCode, bytes.TrimSpace(wantCode))
+			}
+			tmp := t.TempDir()
+			file := filepath.Join(tmp, "main.pl")
+			if err := os.WriteFile(file, code, 0644); err != nil {
+				t.Fatalf("write error: %v", err)
+			}
+			out, err := exec.Command("swipl", "-q", file).CombinedOutput()
+			if err != nil {
+				t.Fatalf("swipl error: %v\n%s", err, out)
+			}
+			wantOutPath := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "pl", q+".out")
+			wantOut, err := os.ReadFile(wantOutPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			gotOut := bytes.TrimSpace(out)
+			if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+				t.Errorf("output mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", q+".out", gotOut, bytes.TrimSpace(wantOut))
+			}
+		})
+	}
+}

--- a/compile/x/pl/tpch_test.go
+++ b/compile/x/pl/tpch_test.go
@@ -3,6 +3,7 @@
 package plcode_test
 
 import (
+	"fmt"
 	"testing"
 
 	plcode "mochi/compile/x/pl"
@@ -15,7 +16,10 @@ func TestPrologCompiler_TPCH(t *testing.T) {
 	if err := plcode.EnsureSWIPL(); err != nil {
 		t.Skipf("swipl not installed: %v", err)
 	}
-	testutil.CompileTPCH(t, "q1", func(env *types.Env, prog *parser.Program) ([]byte, error) {
-		return plcode.New(env).Compile(prog)
-	})
+	for i := 1; i <= 2; i++ {
+		q := fmt.Sprintf("q%d", i)
+		testutil.CompileTPCH(t, q, func(env *types.Env, prog *parser.Program) ([]byte, error) {
+			return plcode.New(env).Compile(prog)
+		})
+	}
 }

--- a/tests/dataset/tpc-h/compiler/pl/q2.out
+++ b/tests/dataset/tpc-h/compiler/pl/q2.out
@@ -1,0 +1,13 @@
+[
+  {
+    "n_name":"FRANCE",
+    "p_mfgr":"M1",
+    "p_partkey":1000,
+    "ps_supplycost":10,
+    "s_acctbal":1000,
+    "s_address":"123 Rue",
+    "s_comment":"Fast and reliable",
+    "s_name":"BestSupplier",
+    "s_phone":"123"
+  }
+]

--- a/tests/dataset/tpc-h/compiler/pl/q2.pl.out
+++ b/tests/dataset/tpc-h/compiler/pl/q2.pl.out
@@ -1,0 +1,74 @@
+:- style_check(-singleton).
+to_list(Str, L) :-
+    string(Str), !,
+    string_chars(Str, L).
+to_list(L, L).
+
+
+min(V, R) :-
+    is_dict(V), !, get_dict('Items', V, Items), min_list(Items, R).
+min(V, R) :-
+    is_list(V), !, min_list(V, R).
+min(_, _) :- throw(error('min expects list or group')).
+
+
+expect(Cond) :- (Cond -> true ; throw(error('expect failed'))).
+
+
+:- use_module(library(http/json)).
+json(V) :- json_write_dict(current_output, V), nl.
+
+
+test_p_q2_returns_only_supplier_with_min_cost_in_europe_for_brass_part :-
+    dict_create(_V0, map, [s_acctbal-1000, s_name-"BestSupplier", n_name-"FRANCE", p_partkey-1000, p_mfgr-"M1", s_address-"123 Rue", s_phone-"123", s_comment-"Fast and reliable", ps_supplycost-10]),
+    expect(Result = [_V0])    ,
+    true.
+
+    main :-
+    dict_create(_V1, map, [r_regionkey-1, r_name-"EUROPE"]),
+    dict_create(_V2, map, [r_regionkey-2, r_name-"ASIA"]),
+    Region = [_V1, _V2],
+    dict_create(_V3, map, [n_nationkey-10, n_regionkey-1, n_name-"FRANCE"]),
+    dict_create(_V4, map, [n_nationkey-20, n_regionkey-2, n_name-"CHINA"]),
+    Nation = [_V3, _V4],
+    dict_create(_V5, map, [s_suppkey-100, s_name-"BestSupplier", s_address-"123 Rue", s_nationkey-10, s_phone-"123", s_acctbal-1000, s_comment-"Fast and reliable"]),
+    dict_create(_V6, map, [s_suppkey-200, s_name-"AltSupplier", s_address-"456 Way", s_nationkey-20, s_phone-"456", s_acctbal-500, s_comment-"Slow"]),
+    Supplier = [_V5, _V6],
+    dict_create(_V7, map, [p_partkey-1000, p_type-"LARGE BRASS", p_size-15, p_mfgr-"M1"]),
+    dict_create(_V8, map, [p_partkey-2000, p_type-"SMALL COPPER", p_size-15, p_mfgr-"M2"]),
+    Part = [_V7, _V8],
+    dict_create(_V9, map, [ps_partkey-1000, ps_suppkey-100, ps_supplycost-10]),
+    dict_create(_V10, map, [ps_partkey-1000, ps_suppkey-200, ps_supplycost-15]),
+    Partsupp = [_V9, _V10],
+    to_list(Region, _V12),
+    findall(R, (member(R, _V12), get_dict(r_name, R, _V13), _V13 = "EUROPE"), _V14),
+    to_list(Nation, _V17),
+    findall(_V18, (member(R, _V14), member(N, _V17), get_dict(n_regionkey, N, _V15), get_dict(r_regionkey, R, _V16), _V15 = _V16, _V18 = N), _V19),
+    Europe_nations = _V19,
+    to_list(Supplier, _V21),
+    to_list(Europe_nations, _V24),
+    findall(_V25, (member(S, _V21), member(N, _V24), get_dict(s_nationkey, S, _V22), get_dict(n_nationkey, N, _V23), _V22 = _V23, dict_create(_V20, map, [s-S, n-N]), _V25 = _V20), _V26),
+    Europe_suppliers = _V26,
+    to_list(Part, _V29),
+    findall(P, (member(P, _V29), get_dict(p_size, P, _V30), get_dict(p_type, P, _V31), (_V30 = 15, _V31 = "LARGE BRASS")), _V32),
+    findall(_V33, (member(P, _V32), _V33 = P), _V34),
+    Target_parts = _V34,
+    to_list(Partsupp, _V51),
+    to_list(Target_parts, _V54),
+    to_list(Europe_suppliers, _V58),
+    findall(_V59, (member(Ps, _V51), member(P, _V54), get_dict(ps_partkey, Ps, _V52), get_dict(p_partkey, P, _V53), _V52 = _V53, member(S, _V58), get_dict(ps_suppkey, Ps, _V55), get_dict(s, S, _V56), get_dict(s_suppkey, _V56, _V57), _V55 = _V57, get_dict(s, S, _V35), get_dict(s_acctbal, _V35, _V36), get_dict(s, S, _V37), get_dict(s_name, _V37, _V38), get_dict(n, S, _V39), get_dict(n_name, _V39, _V40), get_dict(p_partkey, P, _V41), get_dict(p_mfgr, P, _V42), get_dict(s, S, _V43), get_dict(s_address, _V43, _V44), get_dict(s, S, _V45), get_dict(s_phone, _V45, _V46), get_dict(s, S, _V47), get_dict(s_comment, _V47, _V48), get_dict(ps_supplycost, Ps, _V49), dict_create(_V50, map, [s_acctbal-_V36, s_name-_V38, n_name-_V40, p_partkey-_V41, p_mfgr-_V42, s_address-_V44, s_phone-_V46, s_comment-_V48, ps_supplycost-_V49]), _V59 = _V50), _V60),
+    Target_partsupp = _V60,
+    to_list(Target_partsupp, _V62),
+    findall(_V63, (member(X, _V62), get_dict(ps_supplycost, X, _V61), _V63 = _V61), _V64),
+    Costs = _V64,
+    min(Costs, _V65),
+    Min_cost = _V65,
+    to_list(Target_partsupp, _V69),
+    findall(_V71-_V70, (member(X, _V69), get_dict(ps_supplycost, X, _V66), _V66 = Min_cost, get_dict(s_acctbal, X, _V67), _V68 is -(_V67), _V71 = _V68, _V70 = X), _V72),
+    keysort(_V72, _V73),
+    findall(V, member(_-V, _V73), _V74),
+    Result = _V74,
+    json(Result),
+    test_p_q2_returns_only_supplier_with_min_cost_in_europe_for_brass_part
+    .
+:- initialization(main, main).


### PR DESCRIPTION
## Summary
- test Prolog compiler against TPCH dataset
- compile both q1 and q2 (skip q1 runtime for now)
- store generated code and output for `q2` in dataset
- note remaining work in the Prolog TASKS

## Testing
- `go test ./compile/x/pl -run TestPrologCompiler_TPCH -count=1 -tags slow -v`


------
https://chatgpt.com/codex/tasks/task_e_685eaf2cf2408320ae7cdf4aa2d444a1