### PR TITLE
Add register coalescing

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -229,6 +229,7 @@ func Optimize(fn *Function) {
 			break
 		}
 	}
+	coalesceRegisters(fn)
 }
 
 // removeDead eliminates instructions that only define dead registers.

--- a/runtime/vm/regopt.go
+++ b/runtime/vm/regopt.go
@@ -119,3 +119,228 @@ func VisualizeUsage(fn *Function) string {
 	}
 	return b.String()
 }
+
+// replaceRegUse substitutes register references to "old" with "new" in ins.
+// It returns false if the register appears in a variable-width operand that
+// cannot be updated individually (eg. OpMakeList).
+func replaceRegUse(ins *Instr, old, new int) bool {
+	switch ins.Op {
+	case OpMove:
+		if ins.B == old {
+			ins.B = new
+		}
+	case OpAdd, OpSub, OpMul, OpDiv, OpMod,
+		OpAddInt, OpAddFloat, OpSubInt, OpSubFloat,
+		OpMulInt, OpMulFloat, OpDivInt, OpDivFloat,
+		OpModInt, OpModFloat,
+		OpEqual, OpNotEqual, OpEqualInt, OpEqualFloat,
+		OpLess, OpLessEq, OpLessInt, OpLessFloat,
+		OpLessEqInt, OpLessEqFloat, OpIn,
+		OpAppend, OpUnionAll, OpUnion, OpExcept, OpIntersect:
+		if ins.B == old {
+			ins.B = new
+		}
+		if ins.C == old {
+			ins.C = new
+		}
+	case OpNeg, OpNegInt, OpNegFloat, OpNot, OpStr, OpExists,
+		OpCount, OpAvg, OpSum, OpMin, OpMax, OpValues,
+		OpCast, OpIterPrep, OpNow, OpSort:
+		if ins.B == old {
+			ins.B = new
+		}
+	case OpIndex:
+		if ins.B == old {
+			ins.B = new
+		}
+		if ins.C == old {
+			ins.C = new
+		}
+	case OpSlice:
+		if ins.B == old {
+			ins.B = new
+		}
+		if ins.C == old {
+			ins.C = new
+		}
+		if ins.D == old {
+			ins.D = new
+		}
+	case OpSetIndex:
+		if ins.A == old {
+			ins.A = new
+		}
+		if ins.B == old {
+			ins.B = new
+		}
+		if ins.C == old {
+			ins.C = new
+		}
+	case OpMakeList:
+		if old >= ins.C && old < ins.C+ins.B {
+			return false
+		}
+	case OpMakeMap:
+		if old >= ins.C && old < ins.C+ins.B*2 {
+			return false
+		}
+	case OpPrint2:
+		if ins.A == old {
+			ins.A = new
+		}
+		if ins.B == old {
+			ins.B = new
+		}
+	case OpPrint:
+		if ins.A == old {
+			ins.A = new
+		}
+	case OpPrintN:
+		if old >= ins.C && old < ins.C+ins.B {
+			return false
+		}
+	case OpJumpIfFalse, OpJumpIfTrue, OpExpect:
+		if ins.A == old {
+			ins.A = new
+		}
+	case OpLen:
+		if ins.A == old {
+			ins.A = new
+		}
+		if ins.B == old {
+			ins.B = new
+		}
+	case OpCall2:
+		if ins.C == old {
+			ins.C = new
+		}
+		if ins.D == old {
+			ins.D = new
+		}
+	case OpCall:
+		if old >= ins.D && old < ins.D+ins.C {
+			return false
+		}
+	case OpCallV:
+		if ins.B == old {
+			ins.B = new
+		}
+		if old >= ins.D && old < ins.D+ins.C {
+			return false
+		}
+	case OpMakeClosure:
+		if old >= ins.D && old < ins.D+ins.C {
+			return false
+		}
+	case OpLoad:
+		if ins.B == old {
+			ins.B = new
+		}
+		if ins.C == old {
+			ins.C = new
+		}
+	case OpSave:
+		if ins.B == old {
+			ins.B = new
+		}
+		if ins.C == old {
+			ins.C = new
+		}
+		if ins.D == old {
+			ins.D = new
+		}
+	case OpEval:
+		if ins.B == old {
+			ins.B = new
+		}
+	case OpFetch:
+		if ins.B == old {
+			ins.B = new
+		}
+		if ins.C == old {
+			ins.C = new
+		}
+	case OpReturn:
+		if ins.A == old {
+			ins.A = new
+		}
+	}
+	return true
+}
+
+// coalesceRegisters merges virtual registers whose lifetimes do not overlap.
+// It primarily removes redundant Move instructions.
+func coalesceRegisters(fn *Function) bool {
+	changed := false
+	for {
+		analysis := Liveness(fn)
+		madeChange := false
+		for pc := 0; pc < len(fn.Code); pc++ {
+			ins := fn.Code[pc]
+			if ins.Op != OpMove {
+				continue
+			}
+			src := ins.B
+			dst := ins.A
+			if analysis.Out[pc][src] || analysis.In[pc][dst] {
+				continue
+			}
+			ok := true
+			for i := pc + 1; i < len(fn.Code); i++ {
+				use, def := useDef(fn.Code[i], fn.NumRegs)
+				if use[dst] {
+					if !replaceRegUse(&fn.Code[i], dst, src) {
+						ok = false
+						break
+					}
+				}
+				if def[dst] {
+					break
+				}
+			}
+			if ok {
+				fn.Code = append(fn.Code[:pc], fn.Code[pc+1:]...)
+				madeChange = true
+				changed = true
+				break
+			}
+		}
+		if !madeChange {
+			break
+		}
+	}
+
+	maxReg := 0
+	for _, ins := range fn.Code {
+		regs := []int{ins.A, ins.B, ins.C, ins.D}
+		for _, r := range regs {
+			if r > maxReg {
+				maxReg = r
+			}
+		}
+		switch ins.Op {
+		case OpMakeList:
+			if v := ins.C + ins.B - 1; v > maxReg {
+				maxReg = v
+			}
+		case OpMakeMap:
+			if v := ins.C + ins.B*2 - 1; v > maxReg {
+				maxReg = v
+			}
+		case OpPrintN:
+			if v := ins.C + ins.B - 1; v > maxReg {
+				maxReg = v
+			}
+		case OpCall, OpMakeClosure:
+			if v := ins.D + ins.C - 1; v > maxReg {
+				maxReg = v
+			}
+		case OpCallV:
+			if v := ins.D + ins.C - 1; v > maxReg {
+				maxReg = v
+			}
+		}
+	}
+	fn.NumRegs = maxReg + 1
+	return changed
+}

--- a/runtime/vm/regopt_test.go
+++ b/runtime/vm/regopt_test.go
@@ -1,0 +1,34 @@
+package vm
+
+import (
+	"mochi/parser"
+	"mochi/types"
+	"testing"
+)
+
+func TestRegisterCoalescing(t *testing.T) {
+	src := `var a = 1
+var b = a
+print(b)`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	p, err := Compile(prog, env)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	fn := p.Funcs[0]
+	for _, ins := range fn.Code {
+		if ins.Op == OpMove && ins.A == 2 && ins.B == 1 {
+			t.Fatalf("redundant move not eliminated")
+		}
+	}
+	if fn.NumRegs != 2 {
+		t.Fatalf("expected 2 regs, got %d", fn.NumRegs)
+	}
+}


### PR DESCRIPTION
## Summary
- implement register coalescing pass
- integrate it in Optimize
- test register coalescing
- rename pass to `coalesceRegisters`

## Testing
- `go vet ./...`
- `go test ./...`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685ebb524f7c83208f136ac3fa2cce32