### PR TITLE
Add stack VM golden tests

### DIFF
--- a/runtime/stackvm/benchmark_test.go
+++ b/runtime/stackvm/benchmark_test.go
@@ -1,0 +1,60 @@
+package stackvm
+
+import (
+	"bytes"
+	"testing"
+
+	"mochi/parser"
+	vm "mochi/runtime/vm"
+	"mochi/types"
+)
+
+const fibRecSource = `fun fib(n: int): int {
+  if n <= 1 { return n }
+  return fib(n - 1) + fib(n - 2)
+}
+
+print(fib(20))
+`
+
+func BenchmarkFibRecStackVM(b *testing.B) {
+	prog, err := parser.ParseString(fibRecSource)
+	if err != nil {
+		b.Fatal(err)
+	}
+	p, err := Compile(prog)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out bytes.Buffer
+		v := New(p, &out)
+		if err := v.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFibRecVM(b *testing.B) {
+	prog, err := parser.ParseString(fibRecSource)
+	if err != nil {
+		b.Fatal(err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		b.Fatalf("type error: %v", errs[0])
+	}
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out bytes.Buffer
+		m := vm.New(p, &out)
+		if err := m.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/runtime/stackvm/compile.go
+++ b/runtime/stackvm/compile.go
@@ -1,0 +1,228 @@
+package stackvm
+
+import (
+	"mochi/parser"
+)
+
+type compiler struct {
+	prog  *parser.Program
+	funcs []Function
+	fnIdx map[string]int
+}
+
+func Compile(p *parser.Program) (*Program, error) {
+	c := &compiler{prog: p, fnIdx: map[string]int{}}
+	// Pre-assign function indices
+	c.funcs = append(c.funcs, Function{Name: "main"})
+	for _, st := range p.Statements {
+		if st.Fun != nil {
+			idx := len(c.funcs)
+			c.fnIdx[st.Fun.Name] = idx
+			c.funcs = append(c.funcs, Function{Name: st.Fun.Name})
+		}
+	}
+	// Compile functions
+	for _, st := range p.Statements {
+		if st.Fun != nil {
+			idx := c.fnIdx[st.Fun.Name]
+			fn := c.compileFun(st.Fun)
+			c.funcs[idx] = fn
+		}
+	}
+	main := c.compileMain(p)
+	c.funcs[0] = main
+	return &Program{Funcs: c.funcs}, nil
+}
+
+type funcCompiler struct {
+	c    *compiler
+	fn   Function
+	vars map[string]int
+}
+
+func (c *compiler) compileMain(p *parser.Program) Function {
+	fc := &funcCompiler{c: c, vars: map[string]int{}}
+	for _, st := range p.Statements {
+		if st.Fun == nil {
+			fc.compileStmt(st)
+		}
+	}
+	fc.emit(OpReturn, 0, 0, Value{})
+	return fc.fn
+}
+
+func (c *compiler) compileFun(fn *parser.FunStmt) Function {
+	fc := &funcCompiler{c: c, vars: map[string]int{}}
+	// params
+	for i, p := range fn.Params {
+		fc.vars[p.Name] = i
+	}
+	fc.fn.NumVars = len(fn.Params)
+	for _, st := range fn.Body {
+		fc.compileStmt(st)
+	}
+	fc.emit(OpReturn, 0, 0, Value{})
+	fc.fn.Name = fn.Name
+	return fc.fn
+}
+
+func (fc *funcCompiler) emit(op Op, a, b int, val Value) {
+	fc.fn.Code = append(fc.fn.Code, Instr{Op: op, A: a, B: b, Val: val})
+}
+func (fc *funcCompiler) varIndex(name string) int {
+	idx, ok := fc.vars[name]
+	if !ok {
+		idx = fc.fn.NumVars
+		fc.fn.NumVars++
+		fc.vars[name] = idx
+	}
+	return idx
+}
+
+func (fc *funcCompiler) compileStmt(s *parser.Statement) {
+	switch {
+	case s.Let != nil:
+		idx := fc.varIndex(s.Let.Name)
+		if s.Let.Value != nil {
+			fc.compileExpr(s.Let.Value)
+			fc.emit(OpStore, idx, 0, Value{})
+		}
+	case s.Return != nil:
+		fc.compileExpr(s.Return.Value)
+		fc.emit(OpReturn, 1, 0, Value{})
+	case s.For != nil:
+		fc.compileFor(s.For)
+	case s.If != nil:
+		fc.compileIf(s.If)
+	case s.Expr != nil:
+		fc.compileExpr(s.Expr.Expr)
+		fc.emit(OpPop, 0, 0, Value{})
+	}
+}
+
+func (fc *funcCompiler) compileIf(s *parser.IfStmt) {
+	fc.compileExpr(s.Cond)
+	jmpFalseIdx := len(fc.fn.Code)
+	fc.emit(OpJumpIfFalse, 0, 0, Value{})
+	for _, st := range s.Then {
+		fc.compileStmt(st)
+	}
+	jmpEndIdx := len(fc.fn.Code)
+	fc.emit(OpJump, 0, 0, Value{})
+	fc.fn.Code[jmpFalseIdx].A = len(fc.fn.Code)
+	for _, st := range s.Else {
+		fc.compileStmt(st)
+	}
+	fc.fn.Code[jmpEndIdx].A = len(fc.fn.Code)
+}
+
+func (fc *funcCompiler) compileFor(f *parser.ForStmt) {
+	idx := fc.varIndex(f.Name)
+	// start
+	if f.Source != nil {
+		fc.compileExpr(f.Source)
+	} else {
+		fc.emit(OpPushConst, 0, 0, Value{Tag: ValueInt, Int: 0})
+	}
+	fc.emit(OpStore, idx, 0, Value{})
+	loopStart := len(fc.fn.Code)
+	// condition
+	fc.emit(OpLoad, idx, 0, Value{})
+	fc.compileExpr(f.RangeEnd)
+	fc.emit(OpLess, 0, 0, Value{})
+	jmpIdx := len(fc.fn.Code)
+	fc.emit(OpJumpIfFalse, 0, 0, Value{}) // placeholder
+	for _, st := range f.Body {
+		fc.compileStmt(st)
+	}
+	// i = i + 1
+	fc.emit(OpLoad, idx, 0, Value{})
+	fc.emit(OpPushConst, 0, 0, Value{Tag: ValueInt, Int: 1})
+	fc.emit(OpAdd, 0, 0, Value{})
+	fc.emit(OpStore, idx, 0, Value{})
+	fc.emit(OpJump, loopStart, 0, Value{})
+	fc.fn.Code[jmpIdx].A = len(fc.fn.Code)
+}
+
+func (fc *funcCompiler) compileExpr(e *parser.Expr) {
+	fc.compileBinary(e.Binary)
+}
+
+func (fc *funcCompiler) compileBinary(b *parser.BinaryExpr) {
+	fc.compileUnary(b.Left)
+	for _, op := range b.Right {
+		fc.compileUnary(&parser.Unary{Value: op.Right})
+		switch op.Op {
+		case "+":
+			fc.emit(OpAdd, 0, 0, Value{})
+		case "-":
+			fc.emit(OpSub, 0, 0, Value{})
+		case "==":
+			fc.emit(OpEqual, 0, 0, Value{})
+		case "<":
+			fc.emit(OpLess, 0, 0, Value{})
+		case "<=":
+			fc.emit(OpLessEq, 0, 0, Value{})
+		}
+	}
+}
+
+func (fc *funcCompiler) compileUnary(u *parser.Unary) {
+	fc.compilePostfix(u.Value)
+	for _, op := range u.Ops {
+		switch op {
+		case "-":
+			fc.emit(OpNeg, 0, 0, Value{})
+		case "!":
+			// not implemented
+		}
+	}
+}
+func (fc *funcCompiler) compilePostfix(p *parser.PostfixExpr) {
+	fc.compilePrimary(p.Target)
+	for _, op := range p.Ops {
+		if op.Index != nil {
+			if op.Index.Start != nil {
+				fc.compileExpr(op.Index.Start)
+			} else {
+				fc.emit(OpPushConst, 0, 0, Value{Tag: ValueInt, Int: 0})
+			}
+			fc.emit(OpIndex, 0, 0, Value{})
+		}
+	}
+}
+
+func (fc *funcCompiler) compilePrimary(p *parser.Primary) {
+	if p.Call != nil {
+		for _, arg := range p.Call.Args {
+			fc.compileExpr(arg)
+		}
+		name := p.Call.Func
+		if idx, ok := fc.c.fnIdx[name]; ok {
+			fc.emit(OpCall, idx, len(p.Call.Args), Value{})
+		} else if name == "print" {
+			fc.emit(OpCall, -1, len(p.Call.Args), Value{})
+		} else if name == "len" {
+			fc.emit(OpCall, -2, len(p.Call.Args), Value{})
+		}
+	} else if p.Lit != nil {
+		switch {
+		case p.Lit.Int != nil:
+			fc.emit(OpPushConst, 0, 0, Value{Tag: ValueInt, Int: *p.Lit.Int})
+		case p.Lit.Str != nil:
+			fc.emit(OpPushConst, 0, 0, Value{Tag: ValueStr, Str: *p.Lit.Str})
+		case p.Lit.Bool != nil:
+			fc.emit(OpPushConst, 0, 0, Value{Tag: ValueBool, Bool: bool(*p.Lit.Bool)})
+		case p.Lit.Null:
+			fc.emit(OpPushConst, 0, 0, Value{Tag: ValueNull})
+		}
+	} else if p.List != nil {
+		for _, e := range p.List.Elems {
+			fc.compileExpr(e)
+		}
+		fc.emit(OpMakeList, len(p.List.Elems), 0, Value{})
+	} else if p.Selector != nil && len(p.Selector.Tail) == 0 {
+		idx := fc.varIndex(p.Selector.Root)
+		fc.emit(OpLoad, idx, 0, Value{})
+	}
+}

--- a/runtime/stackvm/disasm.go
+++ b/runtime/stackvm/disasm.go
@@ -1,0 +1,96 @@
+package stackvm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Disassemble returns a human readable listing of the program instructions.
+// It is modeled after runtime/vm.Program.Disassemble but supports the
+// simplified stack based instruction set used by this VM.
+func (p *Program) Disassemble(src string) string {
+	var b strings.Builder
+	for idx, fn := range p.Funcs {
+		name := fn.Name
+		if name == "" {
+			if idx == 0 {
+				name = "main"
+			} else {
+				name = fmt.Sprintf("fn%d", idx)
+			}
+		}
+		fmt.Fprintf(&b, "func %s (vars=%d)\n", name, fn.NumVars)
+
+		labels := map[int]string{}
+		next := 0
+		for pc, ins := range fn.Code {
+			switch ins.Op {
+			case OpJump, OpJumpIfFalse:
+				if _, ok := labels[ins.A]; !ok {
+					labels[ins.A] = fmt.Sprintf("L%d", next)
+					next++
+				}
+			}
+			_ = pc
+		}
+
+		for pc, ins := range fn.Code {
+			if lbl, ok := labels[pc]; ok {
+				fmt.Fprintf(&b, "%s:\n", lbl)
+			}
+			fmt.Fprintf(&b, "  %-12s ", ins.Op)
+			switch ins.Op {
+			case OpPushConst:
+				fmt.Fprintf(&b, "%s", formatValue(ins.Val))
+			case OpLoad, OpStore, OpJump, OpReturn:
+				fmt.Fprintf(&b, "%d", ins.A)
+			case OpJumpIfFalse:
+				if lbl, ok := labels[ins.A]; ok {
+					fmt.Fprintf(&b, "%s", lbl)
+				} else {
+					fmt.Fprintf(&b, "%d", ins.A)
+				}
+			case OpCall:
+				if ins.A < 0 {
+					builtin := ""
+					switch -ins.A {
+					case 1:
+						builtin = "print"
+					case 2:
+						builtin = "len"
+					}
+					if builtin != "" {
+						fmt.Fprintf(&b, "%s %d", builtin, ins.B)
+					} else {
+						fmt.Fprintf(&b, "%d %d", ins.A, ins.B)
+					}
+				} else {
+					callee := p.Funcs[ins.A].Name
+					if callee == "" {
+						if ins.A == 0 {
+							callee = "main"
+						} else {
+							callee = fmt.Sprintf("fn%d", ins.A)
+						}
+					}
+					fmt.Fprintf(&b, "%s %d", callee, ins.B)
+				}
+			case OpMakeList:
+				fmt.Fprintf(&b, "%d", ins.A)
+			case OpPop:
+				// no args
+			case OpPrint:
+				// no args
+			default:
+				// ops like Add/Sub/etc have no operands
+			}
+			b.WriteByte('\n')
+			_ = pc
+		}
+		b.WriteByte('\n')
+	}
+	out := b.String()
+	out = strings.TrimRight(out, "\n")
+	out += "\n"
+	return out
+}

--- a/runtime/stackvm/disasm_test.go
+++ b/runtime/stackvm/disasm_test.go
@@ -1,0 +1,28 @@
+package stackvm
+
+import (
+	"strings"
+	"testing"
+
+	"mochi/parser"
+)
+
+func TestDisassemble(t *testing.T) {
+	src := `fun add(a:int,b:int): int { return a + b }
+print(add(1,2))`
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	p, err := Compile(prog)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	out := p.Disassemble(src)
+	if !strings.Contains(out, "func main") || !strings.Contains(out, "func add") {
+		t.Fatalf("missing function names in disassembly:\n%s", out)
+	}
+	if !strings.Contains(out, "Add") {
+		t.Fatalf("expected Add opcode in disassembly:\n%s", out)
+	}
+}

--- a/runtime/stackvm/golden_test.go
+++ b/runtime/stackvm/golden_test.go
@@ -1,0 +1,49 @@
+package stackvm
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"mochi/golden"
+	"mochi/parser"
+)
+
+func TestStackVM_ValidPrograms(t *testing.T) {
+	golden.Run(t, "tests/stackvm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		p, err := Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("compile error: %w", err)
+		}
+		var out bytes.Buffer
+		v := New(p, &out)
+		if err := v.Run(); err != nil {
+			return nil, fmt.Errorf("run error: %w", err)
+		}
+		return bytes.TrimSpace(out.Bytes()), nil
+	})
+}
+
+func TestStackVM_IR(t *testing.T) {
+	golden.Run(t, "tests/stackvm/valid", ".mochi", ".stack.ir.out", func(src string) ([]byte, error) {
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return nil, err
+		}
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		p, err := Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("compile error: %w", err)
+		}
+		ir := p.Disassemble(string(data))
+		return []byte(ir), nil
+	})
+}

--- a/runtime/stackvm/stackvm_test.go
+++ b/runtime/stackvm/stackvm_test.go
@@ -1,0 +1,31 @@
+package stackvm
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/parser"
+)
+
+func TestStackVM_TwoSum(t *testing.T) {
+	src := filepath.Join("..", "..", "examples", "leetcode", "1", "two-sum.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	p, err := Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	var out bytes.Buffer
+	vm := New(p, &out)
+	if err := vm.Run(); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != "0\n1" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}

--- a/runtime/stackvm/value.go
+++ b/runtime/stackvm/value.go
@@ -1,0 +1,47 @@
+package stackvm
+
+// ValueTag represents the type of a runtime value.
+type ValueTag uint8
+
+const (
+	ValueNull ValueTag = iota
+	ValueInt
+	ValueFloat
+	ValueStr
+	ValueBool
+	ValueList
+	ValueMap
+	ValueFunc
+)
+
+// Value is a tagged union used at runtime to avoid reflection.
+type Value struct {
+	Tag   ValueTag
+	Int   int
+	Float float64
+	Str   string
+	Bool  bool
+	List  []Value
+	Map   map[string]Value
+	Func  any
+}
+
+// Truthy returns the boolean interpretation of v.
+func (v Value) Truthy() bool {
+	switch v.Tag {
+	case ValueBool:
+		return v.Bool
+	case ValueInt:
+		return v.Int != 0
+	case ValueFloat:
+		return v.Float != 0
+	case ValueStr:
+		return v.Str != ""
+	case ValueList:
+		return len(v.List) > 0
+	case ValueMap:
+		return len(v.Map) > 0
+	default:
+		return false
+	}
+}

--- a/runtime/stackvm/vm.go
+++ b/runtime/stackvm/vm.go
@@ -1,0 +1,321 @@
+package stackvm
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Op defines an opcode for the stack VM.
+type Op uint8
+
+const (
+	OpPushConst Op = iota
+	OpLoad
+	OpStore
+	OpAdd
+	OpSub
+	OpNeg
+	OpEqual
+	OpLess
+	OpLessEq
+	OpLen
+	OpIndex
+	OpMakeList
+	OpJump
+	OpJumpIfFalse
+	OpCall
+	OpReturn
+	OpPop
+	OpPrint
+)
+
+// Instr represents a single VM instruction.
+type Instr struct {
+	Op  Op
+	A   int   // generic int argument (var index, jump target, function index)
+	B   int   // secondary argument (e.g. number of args)
+	Val Value // constant value for OpPushConst
+}
+
+type Function struct {
+	Code    []Instr
+	NumVars int
+	Name    string
+}
+
+type Program struct {
+	Funcs []Function
+}
+
+type frame struct {
+	fn     *Function
+	locals []Value
+	ip     int
+}
+
+type VM struct {
+	prog   *Program
+	writer io.Writer
+	reader *bufio.Reader
+}
+
+func New(p *Program, w io.Writer) *VM {
+	return &VM{prog: p, writer: w, reader: bufio.NewReader(os.Stdin)}
+}
+
+// Run executes the program starting at function 0 (main).
+func (v *VM) Run() error {
+	_, err := v.call(0, nil)
+	return err
+}
+
+func (v *VM) call(fnIndex int, args []Value) (Value, error) {
+	fn := &v.prog.Funcs[fnIndex]
+	fr := &frame{fn: fn, locals: make([]Value, fn.NumVars)}
+	for i := 0; i < len(args) && i < fn.NumVars; i++ {
+		fr.locals[i] = args[i]
+	}
+	stack := []Value{}
+	frames := []*frame{fr}
+	for len(frames) > 0 {
+		fr = frames[len(frames)-1]
+		if fr.ip >= len(fr.fn.Code) {
+			frames = frames[:len(frames)-1]
+			if len(frames) == 0 {
+				return Value{}, nil
+			}
+			continue
+		}
+		ins := fr.fn.Code[fr.ip]
+		fr.ip++
+		switch ins.Op {
+		case OpPushConst:
+			stack = append(stack, ins.Val)
+		case OpLoad:
+			stack = append(stack, fr.locals[ins.A])
+		case OpStore:
+			if len(stack) == 0 {
+				return Value{}, fmt.Errorf("stack underflow")
+			}
+			val := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			fr.locals[ins.A] = val
+		case OpAdd:
+			b := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			a := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			switch {
+			case a.Tag == ValueInt && b.Tag == ValueInt:
+				stack = append(stack, Value{Tag: ValueInt, Int: a.Int + b.Int})
+			case a.Tag == ValueStr && b.Tag == ValueStr:
+				stack = append(stack, Value{Tag: ValueStr, Str: a.Str + b.Str})
+			default:
+				return Value{}, fmt.Errorf("invalid add")
+			}
+		case OpSub:
+			b := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			a := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			stack = append(stack, Value{Tag: ValueInt, Int: a.Int - b.Int})
+		case OpNeg:
+			a := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			stack = append(stack, Value{Tag: ValueInt, Int: -a.Int})
+		case OpEqual:
+			b := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			a := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			var eq bool
+			if a.Tag == ValueInt && b.Tag == ValueInt {
+				eq = a.Int == b.Int
+			} else {
+				eq = false
+			}
+			stack = append(stack, Value{Tag: ValueBool, Bool: eq})
+		case OpLess:
+			b := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			a := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			stack = append(stack, Value{Tag: ValueBool, Bool: a.Int < b.Int})
+		case OpLessEq:
+			b := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			a := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			stack = append(stack, Value{Tag: ValueBool, Bool: a.Int <= b.Int})
+		case OpLen:
+			a := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			stack = append(stack, Value{Tag: ValueInt, Int: len(a.List)})
+		case OpIndex:
+			idxVal := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			list := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			idx := idxVal.Int
+			if idx < 0 {
+				idx += len(list.List)
+			}
+			if idx < 0 || idx >= len(list.List) {
+				return Value{}, fmt.Errorf("index out of range")
+			}
+			stack = append(stack, list.List[idx])
+		case OpMakeList:
+			n := ins.A
+			if len(stack) < n {
+				return Value{}, fmt.Errorf("stack underflow")
+			}
+			list := make([]Value, n)
+			for i := n - 1; i >= 0; i-- {
+				list[i] = stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+			}
+			stack = append(stack, Value{Tag: ValueList, List: list})
+		case OpJump:
+			fr.ip = ins.A
+		case OpJumpIfFalse:
+			if len(stack) == 0 {
+				return Value{}, fmt.Errorf("stack underflow")
+			}
+			cond := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if !cond.Truthy() {
+				fr.ip = ins.A
+			}
+		case OpCall:
+			if len(stack) < ins.B {
+				return Value{}, fmt.Errorf("stack underflow")
+			}
+			callArgs := make([]Value, ins.B)
+			for i := ins.B - 1; i >= 0; i-- {
+				callArgs[i] = stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+			}
+			// builtins
+			if ins.A < 0 {
+				switch -ins.A {
+				case 1: // print
+					for i := range callArgs {
+						fmt.Fprintln(v.writer, formatValue(callArgs[i]))
+					}
+					stack = append(stack, Value{Tag: ValueNull})
+				case 2: // len
+					if len(callArgs) != 1 {
+						return Value{}, fmt.Errorf("len expects 1 arg")
+					}
+					stack = append(stack, Value{Tag: ValueInt, Int: len(callArgs[0].List)})
+				default:
+					return Value{}, fmt.Errorf("unknown builtin")
+				}
+			} else {
+				ret, err := v.call(ins.A, callArgs)
+				if err != nil {
+					return Value{}, err
+				}
+				stack = append(stack, ret)
+			}
+		case OpReturn:
+			var ret Value
+			if ins.A == 1 {
+				if len(stack) == 0 {
+					return Value{}, fmt.Errorf("stack underflow")
+				}
+				ret = stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+			}
+			return ret, nil
+		case OpPop:
+			if len(stack) == 0 {
+				return Value{}, fmt.Errorf("stack underflow")
+			}
+			stack = stack[:len(stack)-1]
+		case OpPrint:
+			if len(stack) == 0 {
+				return Value{}, fmt.Errorf("stack underflow")
+			}
+			val := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			fmt.Fprintln(v.writer, formatValue(val))
+		default:
+			return Value{}, fmt.Errorf("unknown op")
+		}
+	}
+	return Value{}, nil
+}
+
+func formatValue(v Value) string {
+	switch v.Tag {
+	case ValueInt:
+		return fmt.Sprintf("%d", v.Int)
+	case ValueStr:
+		return v.Str
+	case ValueBool:
+		if v.Bool {
+			return "true"
+		}
+		return "false"
+	case ValueList:
+		s := "["
+		for i, vv := range v.List {
+			if i > 0 {
+				s += ","
+			}
+			s += formatValue(vv)
+		}
+		s += "]"
+		return s
+	case ValueNull:
+		return "null"
+	default:
+		return "?"
+	}
+}
+
+func (op Op) String() string {
+	switch op {
+	case OpPushConst:
+		return "PushConst"
+	case OpLoad:
+		return "Load"
+	case OpStore:
+		return "Store"
+	case OpAdd:
+		return "Add"
+	case OpSub:
+		return "Sub"
+	case OpNeg:
+		return "Neg"
+	case OpEqual:
+		return "Equal"
+	case OpLess:
+		return "Less"
+	case OpLessEq:
+		return "LessEq"
+	case OpLen:
+		return "Len"
+	case OpIndex:
+		return "Index"
+	case OpMakeList:
+		return "MakeList"
+	case OpJump:
+		return "Jump"
+	case OpJumpIfFalse:
+		return "JumpIfFalse"
+	case OpCall:
+		return "Call"
+	case OpReturn:
+		return "Return"
+	case OpPop:
+		return "Pop"
+	case OpPrint:
+		return "Print"
+	default:
+		return "?"
+	}
+}

--- a/tests/stackvm/valid/for_loop.mochi
+++ b/tests/stackvm/valid/for_loop.mochi
@@ -1,0 +1,1 @@
+../../vm/valid/for_loop.mochi

--- a/tests/stackvm/valid/for_loop.out
+++ b/tests/stackvm/valid/for_loop.out
@@ -1,0 +1,1 @@
+../../vm/valid/for_loop.out

--- a/tests/stackvm/valid/for_loop.stack.ir.out
+++ b/tests/stackvm/valid/for_loop.stack.ir.out
@@ -1,0 +1,18 @@
+func main (vars=1)
+  PushConst    1
+  Store        0
+L1:
+  Load         0
+  PushConst    4
+  Less         
+  JumpIfFalse  L0
+  Load         0
+  Call         print 1
+  Pop          
+  Load         0
+  PushConst    1
+  Add          
+  Store        0
+  Jump         2
+L0:
+  Return       0

--- a/tests/stackvm/valid/fun_call.mochi
+++ b/tests/stackvm/valid/fun_call.mochi
@@ -1,0 +1,1 @@
+../../vm/valid/fun_call.mochi

--- a/tests/stackvm/valid/fun_call.out
+++ b/tests/stackvm/valid/fun_call.out
@@ -1,0 +1,1 @@
+../../vm/valid/fun_call.out

--- a/tests/stackvm/valid/fun_call.stack.ir.out
+++ b/tests/stackvm/valid/fun_call.stack.ir.out
@@ -1,0 +1,14 @@
+func main (vars=0)
+  PushConst    2
+  PushConst    3
+  Call         add 2
+  Call         print 1
+  Pop          
+  Return       0
+
+func add (vars=2)
+  Load         0
+  Load         1
+  Add          
+  Return       1
+  Return       0

--- a/tests/stackvm/valid/list_index.mochi
+++ b/tests/stackvm/valid/list_index.mochi
@@ -1,0 +1,1 @@
+../../vm/valid/list_index.mochi

--- a/tests/stackvm/valid/list_index.out
+++ b/tests/stackvm/valid/list_index.out
@@ -1,0 +1,1 @@
+../../vm/valid/list_index.out

--- a/tests/stackvm/valid/list_index.stack.ir.out
+++ b/tests/stackvm/valid/list_index.stack.ir.out
@@ -1,0 +1,12 @@
+func main (vars=1)
+  PushConst    10
+  PushConst    20
+  PushConst    30
+  MakeList     3
+  Store        0
+  Load         0
+  PushConst    1
+  Index        
+  Call         print 1
+  Pop          
+  Return       0

--- a/tests/stackvm/valid/print_hello.mochi
+++ b/tests/stackvm/valid/print_hello.mochi
@@ -1,0 +1,1 @@
+../../vm/valid/print_hello.mochi

--- a/tests/stackvm/valid/print_hello.out
+++ b/tests/stackvm/valid/print_hello.out
@@ -1,0 +1,1 @@
+../../vm/valid/print_hello.out

--- a/tests/stackvm/valid/print_hello.stack.ir.out
+++ b/tests/stackvm/valid/print_hello.stack.ir.out
@@ -1,0 +1,5 @@
+func main (vars=0)
+  PushConst    hello
+  Call         print 1
+  Pop          
+  Return       0

--- a/tests/stackvm/valid/two-sum.mochi
+++ b/tests/stackvm/valid/two-sum.mochi
@@ -1,0 +1,1 @@
+../../vm/valid/two-sum.mochi

--- a/tests/stackvm/valid/two-sum.out
+++ b/tests/stackvm/valid/two-sum.out
@@ -1,0 +1,1 @@
+../../vm/valid/two-sum.out

--- a/tests/stackvm/valid/two-sum.stack.ir.out
+++ b/tests/stackvm/valid/two-sum.stack.ir.out
@@ -1,0 +1,76 @@
+func main (vars=1)
+  PushConst    2
+  PushConst    7
+  PushConst    11
+  PushConst    15
+  MakeList     4
+  PushConst    9
+  Call         twoSum 2
+  Store        0
+  Load         0
+  PushConst    0
+  Index        
+  Call         print 1
+  Pop          
+  Load         0
+  PushConst    1
+  Index        
+  Call         print 1
+  Pop          
+  Return       0
+
+func twoSum (vars=5)
+  Load         0
+  Call         len 1
+  Store        2
+  PushConst    0
+  Store        3
+L4:
+  Load         3
+  Load         2
+  Less         
+  JumpIfFalse  L0
+  Load         3
+  PushConst    1
+  Add          
+  Store        4
+L3:
+  Load         4
+  Load         2
+  Less         
+  JumpIfFalse  L1
+  Load         0
+  Load         3
+  Index        
+  Load         0
+  Load         4
+  Index        
+  Add          
+  Load         1
+  Equal        
+  JumpIfFalse  L2
+  Load         3
+  Load         4
+  MakeList     2
+  Return       1
+  Jump         32
+L2:
+  Load         4
+  PushConst    1
+  Add          
+  Store        4
+  Jump         13
+L1:
+  Load         3
+  PushConst    1
+  Add          
+  Store        3
+  Jump         5
+L0:
+  PushConst    1
+  Neg          
+  PushConst    1
+  Neg          
+  MakeList     2
+  Return       1
+  Return       0


### PR DESCRIPTION
## Summary
- add stack VM golden tests using subset of VM test programs
- support string and boolean literals in stack VM compiler
- support string addition and printing in stack VM runtime
- implement IR golden output via Disassemble
- reuse VM test sources via symlinks

## Testing
- `go test ./runtime/stackvm -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685f423364cc8320a93b2455abee0ffc