### PR TITLE
Avoid duplicating constants during peephole

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -156,3 +156,13 @@ from the disassembler:
 | `Intersect` | Intersection of lists B and C | `Intersect r0, r1, r2` |
 | `Sort` | Sort pairs in list B by first element | `Sort r0, r1` |
 
+## Instruction-Level Optimizations
+
+Compiled functions are optimized using a small set of peephole rules. These
+rules simplify operations like adding zero, multiplying by one and removing
+redundant moves. Constant values are tracked across instructions so later
+operations see literal values even when they are moved between registers. Pure
+function calls with literal arguments are folded to constants when possible.
+The optimizer runs after code generation and before execution to trim
+unnecessary instructions.
+

--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -222,6 +222,7 @@ func defRegs(ins Instr) []int {
 func Optimize(fn *Function) {
 	for {
 		changed := constFold(fn)
+		changed = peephole(fn) || changed
 		pruneRedundantJumps(fn)
 		analysis := Liveness(fn)
 		removed := removeDead(fn, analysis)
@@ -437,6 +438,150 @@ func pruneRedundantJumps(fn *Function) bool {
 	}
 	fn.Code = newCode
 	return true
+}
+
+// peephole applies small instruction-level optimizations.
+// It returns true if any instruction was replaced or removed.
+func peephole(fn *Function) bool {
+	changed := false
+	newCode := make([]Instr, 0, len(fn.Code))
+	consts := map[int]Value{}
+
+	applyDefs := func(ins Instr) {
+		switch ins.Op {
+		case OpConst:
+			consts[ins.A] = ins.Val
+		case OpMove:
+			if v, ok := consts[ins.B]; ok {
+				consts[ins.A] = v
+			} else {
+				delete(consts, ins.A)
+			}
+		default:
+			for _, r := range defRegs(ins) {
+				delete(consts, r)
+			}
+		}
+	}
+
+	for _, ins := range fn.Code {
+		switch ins.Op {
+		case OpMove:
+			if ins.A == ins.B {
+				changed = true
+				continue
+			}
+		case OpAddInt, OpAddFloat, OpAdd:
+			if v, ok := consts[ins.B]; ok && isZero(v) {
+				ins.Op = OpMove
+				ins.B = ins.C
+				changed = true
+			} else if v, ok := consts[ins.C]; ok && isZero(v) {
+				ins.Op = OpMove
+				changed = true
+			}
+		case OpSubInt, OpSubFloat, OpSub:
+			if v, ok := consts[ins.C]; ok && isZero(v) {
+				ins.Op = OpMove
+				changed = true
+			} else if v, ok := consts[ins.B]; ok && isZero(v) {
+				if ins.Op == OpSubInt {
+					ins.Op = OpNegInt
+				} else if ins.Op == OpSubFloat {
+					ins.Op = OpNegFloat
+				} else {
+					ins.Op = OpNeg
+				}
+				ins.B = ins.C
+				changed = true
+			}
+		case OpMulInt, OpMulFloat, OpMul:
+			if v, ok := consts[ins.B]; ok && isOne(v) {
+				ins.Op = OpMove
+				ins.B = ins.C
+				changed = true
+			} else if v, ok := consts[ins.C]; ok && isOne(v) {
+				ins.Op = OpMove
+				changed = true
+			} else if v, ok := consts[ins.B]; ok && isZero(v) {
+				ins.Op = OpConst
+				ins.Val = zeroValue(v)
+				changed = true
+			} else if v, ok := consts[ins.C]; ok && isZero(v) {
+				ins.Op = OpConst
+				ins.Val = zeroValue(v)
+				changed = true
+			}
+		case OpDivInt, OpDivFloat, OpDiv:
+			if v, ok := consts[ins.C]; ok && isOne(v) {
+				ins.Op = OpMove
+				changed = true
+			} else if v, ok := consts[ins.B]; ok && isZero(v) {
+				ins.Op = OpConst
+				ins.Val = zeroValue(v)
+				changed = true
+			}
+		case OpModInt:
+			if v, ok := consts[ins.B]; ok && isZero(v) {
+				ins.Op = OpConst
+				ins.Val = Value{Tag: ValueInt, Int: 0}
+				changed = true
+			} else if v, ok := consts[ins.C]; ok && isOne(v) {
+				ins.Op = OpConst
+				ins.Val = Value{Tag: ValueInt, Int: 0}
+				changed = true
+			}
+		case OpModFloat:
+			if v, ok := consts[ins.B]; ok && isZero(v) {
+				ins.Op = OpConst
+				ins.Val = Value{Tag: ValueFloat, Float: 0}
+				changed = true
+			} else if v, ok := consts[ins.C]; ok && isOne(v) {
+				ins.Op = OpConst
+				ins.Val = Value{Tag: ValueFloat, Float: 0}
+				changed = true
+			}
+		}
+
+		newCode = append(newCode, ins)
+		applyDefs(ins)
+	}
+
+	if changed {
+		fn.Code = newCode
+	}
+	return changed
+}
+
+func isZero(v Value) bool {
+	switch v.Tag {
+	case ValueInt:
+		return v.Int == 0
+	case ValueFloat:
+		return v.Float == 0
+	default:
+		return false
+	}
+}
+
+func isOne(v Value) bool {
+	switch v.Tag {
+	case ValueInt:
+		return v.Int == 1
+	case ValueFloat:
+		return v.Float == 1
+	default:
+		return false
+	}
+}
+
+func zeroValue(v Value) Value {
+	switch v.Tag {
+	case ValueFloat:
+		return Value{Tag: ValueFloat, Float: 0}
+	default:
+		return Value{Tag: ValueInt, Int: 0}
+	}
 }
 
 func evalUnaryConst(op Op, v Value) (Value, bool) {

--- a/tests/vm/valid/append_builtin.ir.out
+++ b/tests/vm/valid/append_builtin.ir.out
@@ -3,6 +3,7 @@ func main (regs=4)
   Const        r0, [1, 2]
   Move         r1, r0
   // print(append(a, 3))
+  Const        r2, 3
   Append       r3, r1, r2
   Print        r3
   Return       r0

--- a/tests/vm/valid/avg_builtin.ir.out
+++ b/tests/vm/valid/avg_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(avg([1,2,3]))
   Const        r0, [1, 2, 3]
-  Avg          r1, r0
+  Const        r1, 2
   Print        r1
   Return       r0

--- a/tests/vm/valid/bool_chain.ir.out
+++ b/tests/vm/valid/bool_chain.ir.out
@@ -1,26 +1,48 @@
 func main (regs=33)
   // print((1 < 2) && (2 < 3) && (3 < 4))
   Const        r0, 1
+  Const        r2, true
+  Move         r3, r2
+  JumpIfFalse  r3, L0
+  Const        r6, true
+  Move         r3, r6
+L0:
+  Move         r7, r3
+  JumpIfFalse  r7, L1
   Const        r10, true
   Move         r7, r10
+L1:
   Print        r7
   // print((1 < 2) && (2 > 3) && boom())
+  Const        r13, true
+  Move         r14, r13
+  JumpIfFalse  r14, L2
   Const        r17, false
   Move         r14, r17
+L2:
   Move         r18, r14
-  Jump         L0
+  JumpIfFalse  r18, L3
   Call         r19, boom, 
   Move         r18, r19
-L0:
+L3:
   Print        r18
   // print((1 < 2) && (2 < 3) && (3 > 4) && boom())
+  Const        r22, true
+  Move         r23, r22
+  JumpIfFalse  r23, L4
+  Const        r26, true
+  Move         r23, r26
+L4:
+  Move         r27, r23
+  JumpIfFalse  r27, L5
   Const        r30, false
   Move         r27, r30
+L5:
   Move         r31, r27
-  Jump         L1
+  JumpIfFalse  r31, L6
   Call         r32, boom, 
   Move         r31, r32
-L1:
+L6:
   Print        r31
   Return       r0
 

--- a/tests/vm/valid/break_continue.ir.out
+++ b/tests/vm/valid/break_continue.ir.out
@@ -32,7 +32,8 @@ L3:
   Print2       r14, r7
 L2:
   // for n in numbers {
-  Const        r16, 1
+  Const        r15, 1
+  Move         r16, r15
   Move         r4, r16
   Jump         L4
 L0:

--- a/tests/vm/valid/cast_string_to_int.ir.out
+++ b/tests/vm/valid/cast_string_to_int.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print("1995" as int)
   Const        r0, "1995"
-  Cast         1,0,0,0
+  Cast         r1, r0, int
   Print        r1
   Return       r0

--- a/tests/vm/valid/cast_struct.ir.out
+++ b/tests/vm/valid/cast_struct.ir.out
@@ -1,7 +1,7 @@
 func main (regs=5)
   // let todo = {"title": "hi"} as Todo
   Const        r0, {"title": "hi"}
-  Cast         1,0,0,0
+  Cast         r1, r0, Todo
   Move         r2, r1
   // print(todo.title)
   Const        r3, "title"

--- a/tests/vm/valid/count_builtin.ir.out
+++ b/tests/vm/valid/count_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(count([1,2,3]))
   Const        r0, [1, 2, 3]
-  Count        r1, r0
+  Const        r1, 3
   Print        r1
   Return       r0

--- a/tests/vm/valid/cross_join.ir.out
+++ b/tests/vm/valid/cross_join.ir.out
@@ -13,6 +13,8 @@ func main (regs=73)
 L3:
   Less         r8, r7, r6
   JumpIfFalse  r8, L0
+  Index        r9, r5, r7
+  Move         r10, r9
   // from c in customers
   IterPrep     r11, r1
   Len          r12, r11
@@ -20,13 +22,50 @@ L3:
 L2:
   Less         r14, r13, r12
   JumpIfFalse  r14, L1
+  Index        r15, r11, r13
+  Move         r16, r15
+  // orderId: o.id,
+  Const        r17, "orderId"
+  Const        r18, "id"
+  Index        r19, r10, r18
+  // orderCustomerId: o.customerId,
+  Const        r20, "orderCustomerId"
+  Const        r21, "customerId"
+  Index        r22, r10, r21
+  // pairedCustomerName: c.name,
+  Const        r23, "pairedCustomerName"
+  Const        r24, "name"
+  Index        r25, r16, r24
+  // orderTotal: o.total
+  Const        r26, "orderTotal"
+  Const        r27, "total"
+  Index        r28, r10, r27
+  // orderId: o.id,
+  Move         r29, r17
+  Move         r30, r19
+  // orderCustomerId: o.customerId,
+  Move         r31, r20
+  Move         r32, r22
+  // pairedCustomerName: c.name,
+  Move         r33, r23
+  Move         r34, r25
+  // orderTotal: o.total
+  Move         r35, r26
+  Move         r36, r28
+  // select {
+  MakeMap      r37, 4, r29
   // let result = from o in orders
   Append       r38, r4, r37
   Move         r4, r38
   // from c in customers
+  Const        r39, 1
+  Move         r40, r39
+  Move         r13, r40
   Jump         L2
+L1:
   // let result = from o in orders
-  Const        r42, 1
+  Const        r41, 1
+  Move         r42, r41
   Move         r7, r42
   Jump         L3
 L0:
@@ -70,7 +109,8 @@ L5:
   // print("Order", entry.orderId,
   PrintN       r51, 8, r51
   // for entry in result {
-  Const        r72, 1
+  Const        r71, 1
+  Move         r72, r71
   Move         r47, r72
   Jump         L5
 L4:

--- a/tests/vm/valid/cross_join_filter.ir.out
+++ b/tests/vm/valid/cross_join_filter.ir.out
@@ -28,15 +28,28 @@ L3:
 L2:
   Less         r18, r17, r16
   JumpIfFalse  r18, L1
+  Index        r19, r15, r17
+  Move         r20, r19
+  // select { n: n, l: l }
+  Const        r21, "n"
+  Const        r22, "l"
+  Move         r23, r21
+  Move         r24, r10
+  Move         r25, r22
+  Move         r26, r20
+  MakeMap      r27, 2, r23
   // let pairs = from n in nums
   Append       r28, r4, r27
   Move         r4, r28
   // from l in letters
-  Const        r30, 1
+  Const        r29, 1
+  Move         r30, r29
   Move         r17, r30
   Jump         L2
+L1:
   // let pairs = from n in nums
-  Const        r32, 1
+  Const        r31, 1
+  Move         r32, r31
   Move         r7, r32
   Jump         L3
 L0:
@@ -60,6 +73,9 @@ L5:
   Index        r44, r40, r43
   Print2       r42, r44
   // for p in pairs {
+  Const        r45, 1
+  Move         r46, r45
+  Move         r37, r46
   Jump         L5
 L4:
   Return       r0

--- a/tests/vm/valid/cross_join_triple.ir.out
+++ b/tests/vm/valid/cross_join_triple.ir.out
@@ -13,36 +13,60 @@ func main (regs=61)
   IterPrep     r7, r1
   Len          r8, r7
   Const        r9, 0
-L4:
+L5:
   Less         r10, r9, r8
   JumpIfFalse  r10, L0
+  Index        r11, r7, r9
+  Move         r12, r11
   // from l in letters
   IterPrep     r13, r3
   Len          r14, r13
   Const        r15, 0
-L3:
+L4:
   Less         r16, r15, r14
   JumpIfFalse  r16, L1
+  Index        r17, r13, r15
+  Move         r18, r17
   // from b in bools
   IterPrep     r19, r5
   Len          r20, r19
   Const        r21, 0
-L2:
+L3:
   Less         r22, r21, r20
-  JumpIfFalse  r22, L1
+  JumpIfFalse  r22, L2
+  Index        r23, r19, r21
+  Move         r24, r23
+  // select {n: n, l: l, b: b}
+  Const        r25, "n"
+  Const        r26, "l"
+  Const        r27, "b"
+  Move         r28, r25
+  Move         r29, r12
+  Move         r30, r26
+  Move         r31, r18
+  Move         r32, r27
+  Move         r33, r24
+  MakeMap      r34, 3, r28
   // let combos = from n in nums
   Append       r35, r6, r34
   Move         r6, r35
   // from b in bools
-  Const        r37, 1
+  Const        r36, 1
+  Move         r37, r36
   Move         r21, r37
-  Jump         L2
-  // from l in letters
   Jump         L3
-  // let combos = from n in nums
-  Const        r41, 1
-  Move         r9, r41
+L2:
+  // from l in letters
+  Const        r38, 1
+  Move         r39, r38
+  Move         r15, r39
   Jump         L4
+L1:
+  // let combos = from n in nums
+  Const        r40, 1
+  Move         r41, r40
+  Move         r9, r41
+  Jump         L5
 L0:
   Move         r42, r6
   // print("--- Cross Join of three lists ---")
@@ -52,9 +76,9 @@ L0:
   IterPrep     r44, r42
   Len          r45, r44
   Const        r46, 0
-L6:
+L7:
   Less         r47, r46, r45
-  JumpIfFalse  r47, L5
+  JumpIfFalse  r47, L6
   Index        r48, r44, r46
   Move         r49, r48
   // print(c.n, c.l, c.b)
@@ -69,8 +93,9 @@ L6:
   Move         r52, r58
   PrintN       r50, 3, r50
   // for c in combos {
-  Const        r60, 1
+  Const        r59, 1
+  Move         r60, r59
   Move         r46, r60
-  Jump         L6
-L5:
+  Jump         L7
+L6:
   Return       r0

--- a/tests/vm/valid/dataset_sort_take_limit.ir.out
+++ b/tests/vm/valid/dataset_sort_take_limit.ir.out
@@ -10,14 +10,25 @@ func main (regs=43)
 L1:
   Less         r6, r5, r4
   JumpIfFalse  r6, L0
+  Index        r7, r3, r5
+  Move         r8, r7
+  // sort by -p.price
+  Const        r9, "price"
+  Index        r10, r8, r9
+  Neg          r11, r10
+  Move         r12, r11
+  // let expensive = from p in products
+  Move         r13, r8
+  MakeList     r14, 2, r12
   Append       r15, r2, r14
   Move         r2, r15
-  Const        r17, 1
+  Const        r16, 1
+  Move         r17, r16
   Move         r5, r17
   Jump         L1
 L0:
   // sort by -p.price
-  Sort         18,2,0,0
+  Sort         r18, r2
   // let expensive = from p in products
   Move         r2, r18
   // skip 1
@@ -56,6 +67,9 @@ L3:
   Move         r35, r40
   PrintN       r33, 3, r33
   // for item in expensive {
+  Const        r41, 1
+  Move         r42, r41
+  Move         r29, r42
   Jump         L3
 L2:
   Return       r0

--- a/tests/vm/valid/dataset_where_filter.ir.out
+++ b/tests/vm/valid/dataset_where_filter.ir.out
@@ -18,10 +18,37 @@ L2:
   Const        r11, 18
   LessEq       r12, r11, r10
   JumpIfFalse  r12, L1
+  // name: person.name,
+  Const        r13, "name"
+  Const        r14, "name"
+  Index        r15, r8, r14
+  // age: person.age,
+  Const        r16, "age"
+  Const        r17, "age"
+  Index        r18, r8, r17
+  // is_senior: person.age >= 60
+  Const        r19, "is_senior"
+  Const        r20, "age"
+  Index        r21, r8, r20
+  Const        r22, 60
+  LessEq       r23, r22, r21
+  // name: person.name,
+  Move         r24, r13
+  Move         r25, r15
+  // age: person.age,
+  Move         r26, r16
+  Move         r27, r18
+  // is_senior: person.age >= 60
+  Move         r28, r19
+  Move         r29, r23
+  // select {
+  MakeMap      r30, 3, r24
   // let adults = from person in people
   Append       r31, r2, r30
   Move         r2, r31
-  Const        r33, 1
+L1:
+  Const        r32, 1
+  Move         r33, r32
   Move         r5, r33
   Jump         L2
 L0:
@@ -62,7 +89,8 @@ L5:
   // print(person.name, "is", person.age,
   PrintN       r41, 4, r41
   // for person in adults {
-  Const        r56, 1
+  Const        r55, 1
+  Move         r56, r55
   Move         r38, r56
   Jump         L6
 L3:

--- a/tests/vm/valid/exists_builtin.ir.out
+++ b/tests/vm/valid/exists_builtin.ir.out
@@ -19,12 +19,14 @@ L2:
   // from x in data
   Append       r11, r2, r8
   Move         r2, r11
-  Const        r13, 1
+L1:
+  Const        r12, 1
+  Move         r13, r12
   Move         r5, r13
   Jump         L2
 L0:
   // let flag = exists(
-  Exists       14,2,0,0
+  Exists       r14, r2
   Move         r15, r14
   // print(flag)
   Print        r15

--- a/tests/vm/valid/for_list_collection.ir.out
+++ b/tests/vm/valid/for_list_collection.ir.out
@@ -12,7 +12,8 @@ L1:
   // print(n)
   Print        r6
   // for n in [1,2,3] {
-  Const        r8, 1
+  Const        r7, 1
+  Move         r8, r7
   Move         r3, r8
   Jump         L1
 L0:

--- a/tests/vm/valid/for_loop.ir.out
+++ b/tests/vm/valid/for_loop.ir.out
@@ -1,9 +1,17 @@
 func main (regs=6)
   // for i in 1..4 {
   Const        r0, 1
+  Const        r1, 4
   Move         r2, r0
+L1:
+  Less         r3, r2, r1
+  JumpIfFalse  r3, L0
   // print(i)
   Print        r2
   // for i in 1..4 {
-  Jump         L0
+  Const        r4, 1
+  Add          r5, r2, r4
+  Move         r2, r5
+  Jump         L1
+L0:
   Return       r0

--- a/tests/vm/valid/for_map_collection.ir.out
+++ b/tests/vm/valid/for_map_collection.ir.out
@@ -14,7 +14,8 @@ L1:
   // print(k)
   Print        r7
   // for k in m {
-  Const        r9, 1
+  Const        r8, 1
+  Move         r9, r8
   Move         r4, r9
   Jump         L1
 L0:

--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -40,7 +40,8 @@ L1:
   Index        r26, r25, r24
   Append       r27, r26, r9
   SetIndex     r25, r24, r27
-  Const        r29, 1
+  Const        r28, 1
+  Move         r29, r28
   Move         r5, r29
   Jump         L2
 L0:
@@ -51,7 +52,15 @@ L6:
   JumpIfFalse  r32, L3
   Index        r33, r7, r30
   Move         r34, r33
+  // city: g.key,
+  Const        r35, "city"
+  Const        r36, "key"
+  Index        r37, r34, r36
+  // count: count(g),
+  Const        r38, "count"
+  Count        r39, r34
   // avg_age: avg(from p in g select p.age)
+  Const        r40, "avg_age"
   Const        r41, []
   IterPrep     r42, r34
   Len          r43, r42
@@ -59,15 +68,34 @@ L6:
 L5:
   Less         r45, r44, r43
   JumpIfFalse  r45, L4
+  Index        r46, r42, r44
+  Move         r47, r46
+  Const        r48, "age"
+  Index        r49, r47, r48
   Append       r50, r41, r49
   Move         r41, r50
-  Const        r52, 1
+  Const        r51, 1
+  Move         r52, r51
   Move         r44, r52
   Jump         L5
+L4:
+  Avg          r53, r41
+  // city: g.key,
+  Move         r54, r35
+  Move         r55, r37
+  // count: count(g),
+  Move         r56, r38
+  Move         r57, r39
+  // avg_age: avg(from p in g select p.age)
+  Move         r58, r40
+  Move         r59, r53
+  // select {
+  MakeMap      r60, 3, r54
   // let stats = from person in people
   Append       r61, r2, r60
   Move         r2, r61
-  Const        r63, 1
+  Const        r62, 1
+  Move         r63, r62
   Move         r30, r63
   Jump         L6
 L3:
@@ -100,7 +128,8 @@ L8:
   Move         r76, r84
   PrintN       r72, 5, r72
   // for s in stats {
-  Const        r86, 1
+  Const        r85, 1
+  Move         r86, r85
   Move         r68, r86
   Jump         L8
 L7:

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -40,57 +40,99 @@ L1:
   Index        r26, r25, r24
   Append       r27, r26, r9
   SetIndex     r25, r24, r27
-  Const        r29, 1
+  Const        r28, 1
+  Move         r29, r28
   Move         r5, r29
   Jump         L2
 L0:
   Const        r30, 0
   Len          r31, r7
-L7:
+L10:
   Less         r32, r30, r31
   JumpIfFalse  r32, L3
   Index        r33, r7, r30
   Move         r34, r33
+  // cat: g.key,
+  Const        r35, "cat"
+  Const        r36, "key"
+  Index        r37, r34, r36
+  // share:
+  Const        r38, "share"
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
   Const        r39, []
   IterPrep     r40, r34
   Len          r41, r40
   Const        r42, 0
-L5:
+L7:
   Less         r43, r42, r41
   JumpIfFalse  r43, L4
   Index        r44, r40, r42
   Move         r45, r44
   Const        r46, "flag"
   Index        r47, r45, r46
-  JumpIfFalse  r47, L4
+  JumpIfFalse  r47, L5
+  Const        r48, "val"
+  Index        r49, r45, r48
+  Move         r50, r49
+  Jump         L6
+L5:
+  Const        r51, 0
+  Move         r50, r51
+L6:
   Append       r52, r39, r50
   Move         r39, r52
-  Const        r54, 1
+  Const        r53, 1
+  Move         r54, r53
   Move         r42, r54
-  Jump         L5
+  Jump         L7
+L4:
+  Sum          r55, r39
   // sum(from x in g select x.val)
   Const        r56, []
   IterPrep     r57, r34
   Len          r58, r57
   Const        r59, 0
-L6:
+L9:
   Less         r60, r59, r58
-  JumpIfFalse  r60, L4
+  JumpIfFalse  r60, L8
+  Index        r61, r57, r59
+  Move         r45, r61
+  Const        r62, "val"
+  Index        r63, r45, r62
   Append       r64, r56, r63
   Move         r56, r64
-  Const        r66, 1
+  Const        r65, 1
+  Move         r66, r65
   Move         r59, r66
-  Jump         L6
+  Jump         L9
+L8:
+  Sum          r67, r56
+  // sum(from x in g select if x.flag { x.val } else { 0 }) /
+  Div          r68, r55, r67
+  // cat: g.key,
+  Move         r69, r35
+  Move         r70, r37
+  // share:
+  Move         r71, r38
+  Move         r72, r68
+  // select {
+  MakeMap      r73, 2, r69
+  // sort by g.key
+  Const        r74, "key"
+  Index        r75, r34, r74
+  Move         r76, r75
   // from i in items
+  Move         r77, r73
+  MakeList     r78, 2, r76
   Append       r79, r2, r78
   Move         r2, r79
-  Const        r81, 1
+  Const        r80, 1
+  Move         r81, r80
   Move         r30, r81
-  Jump         L7
+  Jump         L10
 L3:
   // sort by g.key
-  Sort         82,2,0,0
+  Sort         r82, r2
   // from i in items
   Move         r2, r82
   // let result =

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -40,7 +40,8 @@ L1:
   Index        r26, r25, r24
   Append       r27, r26, r9
   SetIndex     r25, r24, r27
-  Const        r29, 1
+  Const        r28, 1
+  Move         r29, r28
   Move         r5, r29
   Jump         L2
 L0:
@@ -56,10 +57,22 @@ L4:
   Const        r36, 4
   LessEqInt    r37, r36, r35
   JumpIfFalse  r37, L3
+  // select { city: g.key, num: count(g) }
+  Const        r38, "city"
+  Const        r39, "key"
+  Index        r40, r34, r39
+  Const        r41, "num"
+  Count        r42, r34
+  Move         r43, r38
+  Move         r44, r40
+  Move         r45, r41
+  Move         r46, r42
+  MakeMap      r47, 2, r43
   // from p in people
   Append       r48, r2, r47
   Move         r2, r48
-  Const        r50, 1
+  Const        r49, 1
+  Move         r50, r49
   Move         r30, r50
   Jump         L4
 L3:

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -12,7 +12,7 @@ func main (regs=86)
   IterPrep     r7, r3
   Len          r8, r7
   Const        r9, 0
-L4:
+L5:
   Less         r10, r9, r8
   JumpIfFalse  r10, L0
   Index        r11, r7, r9
@@ -21,7 +21,7 @@ L4:
   IterPrep     r13, r1
   Len          r14, r13
   Const        r15, 0
-L3:
+L4:
   Less         r16, r15, r14
   JumpIfFalse  r16, L1
   Index        r17, r13, r15
@@ -31,13 +31,19 @@ L3:
   Const        r21, "id"
   Index        r22, r18, r21
   Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
+  JumpIfFalse  r23, L2
+  // let stats = from o in orders
+  Const        r24, "o"
+  Move         r25, r12
+  Const        r26, "c"
+  Move         r27, r18
+  MakeMap      r28, 2, r24
   // group by c.name into g
   Const        r29, "name"
   Index        r30, r18, r29
   Str          r31, r30
   In           r32, r31, r5
-  JumpIfTrue   r32, L2
+  JumpIfTrue   r32, L3
   // let stats = from o in orders
   Const        r33, []
   Const        r34, "__group__"
@@ -52,32 +58,55 @@ L3:
   SetIndex     r5, r31, r40
   Append       r41, r6, r40
   Move         r6, r41
-L2:
+L3:
   Const        r42, "items"
   Index        r43, r5, r31
   Index        r44, r43, r42
   Append       r45, r44, r28
   SetIndex     r43, r42, r45
+L2:
   // join from c in customers on o.customerId == c.id
-  Const        r47, 1
+  Const        r46, 1
+  Move         r47, r46
   Move         r15, r47
-  Jump         L3
-  // let stats = from o in orders
-  Const        r49, 1
-  Move         r9, r49
   Jump         L4
+L1:
+  // let stats = from o in orders
+  Const        r48, 1
+  Move         r49, r48
+  Move         r9, r49
+  Jump         L5
 L0:
   Const        r50, 0
   Len          r51, r6
-L6:
+L7:
   Less         r52, r50, r51
-  JumpIfFalse  r52, L5
+  JumpIfFalse  r52, L6
+  Index        r53, r6, r50
+  Move         r54, r53
+  // name: g.key,
+  Const        r55, "name"
+  Const        r56, "key"
+  Index        r57, r54, r56
+  // count: count(g)
+  Const        r58, "count"
+  Count        r59, r54
+  // name: g.key,
+  Move         r60, r55
+  Move         r61, r57
+  // count: count(g)
+  Move         r62, r58
+  Move         r63, r59
+  // select {
+  MakeMap      r64, 2, r60
+  // let stats = from o in orders
   Append       r65, r4, r64
   Move         r4, r65
-  Const        r67, 1
+  Const        r66, 1
+  Move         r67, r66
   Move         r50, r67
-  Jump         L6
-L5:
+  Jump         L7
+L6:
   Move         r68, r4
   // print("--- Orders per customer ---")
   Const        r69, "--- Orders per customer ---"
@@ -86,9 +115,9 @@ L5:
   IterPrep     r70, r68
   Len          r71, r70
   Const        r72, 0
-L8:
+L9:
   Less         r73, r72, r71
-  JumpIfFalse  r73, L7
+  JumpIfFalse  r73, L8
   Index        r74, r70, r72
   Move         r75, r74
   // print(s.name, "orders:", s.count)
@@ -102,6 +131,9 @@ L8:
   Move         r78, r83
   PrintN       r76, 3, r76
   // for s in stats {
-  Jump         L8
-L7:
+  Const        r84, 1
+  Move         r85, r84
+  Move         r72, r85
+  Jump         L9
+L8:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -12,7 +12,7 @@ func main (regs=123)
   IterPrep     r7, r1
   Len          r8, r7
   Const        r9, 0
-L5:
+L7:
   Less         r10, r9, r8
   JumpIfFalse  r10, L0
   Index        r11, r7, r9
@@ -21,23 +21,31 @@ L5:
   IterPrep     r13, r3
   Len          r14, r13
   Const        r15, 0
-L3:
+L4:
   Less         r16, r15, r14
   JumpIfFalse  r16, L1
   Index        r17, r13, r15
   Move         r18, r17
+  Const        r19, false
   Const        r20, "customerId"
   Index        r21, r18, r20
   Const        r22, "id"
   Index        r23, r12, r22
   Equal        r24, r21, r23
-  JumpIfFalse  r24, L1
+  JumpIfFalse  r24, L2
+  Const        r19, true
+  // let stats = from c in customers
+  Const        r25, "c"
+  Move         r26, r12
+  Const        r27, "o"
+  Move         r28, r18
+  MakeMap      r29, 2, r25
   // group by c.name into g
   Const        r30, "name"
   Index        r31, r12, r30
   Str          r32, r31
   In           r33, r32, r5
-  JumpIfTrue   r33, L2
+  JumpIfTrue   r33, L3
   // let stats = from c in customers
   Const        r34, []
   Const        r35, "__group__"
@@ -52,23 +60,35 @@ L3:
   SetIndex     r5, r32, r41
   Append       r42, r6, r41
   Move         r6, r42
-L2:
+L3:
   Const        r43, "items"
   Index        r44, r5, r32
   Index        r45, r44, r43
   Append       r46, r45, r29
   SetIndex     r44, r43, r46
+L2:
   // left join o in orders on o.customerId == c.id
-  Const        r48, 1
+  Const        r47, 1
+  Move         r48, r47
   Move         r15, r48
-  Jump         L3
-  Jump         L1
+  Jump         L4
+L1:
+  Move         r49, r19
+  JumpIfTrue   r49, L5
+  Const        r50, nil
+  Move         r18, r50
+  // let stats = from c in customers
+  Const        r51, "c"
+  Move         r52, r12
+  Const        r53, "o"
+  Move         r54, r18
+  MakeMap      r55, 2, r51
   // group by c.name into g
   Const        r56, "name"
   Index        r57, r12, r56
   Str          r58, r57
   In           r59, r58, r5
-  JumpIfTrue   r59, L4
+  JumpIfTrue   r59, L6
   // let stats = from c in customers
   Const        r60, []
   Const        r61, "__group__"
@@ -83,48 +103,68 @@ L2:
   SetIndex     r5, r58, r67
   Append       r68, r6, r67
   Move         r6, r68
-L4:
+L6:
   Const        r69, "items"
   Index        r70, r5, r58
   Index        r71, r70, r69
   Append       r72, r71, r55
   SetIndex     r70, r69, r72
-  Const        r74, 1
+L5:
+  Const        r73, 1
+  Move         r74, r73
   Move         r9, r74
-  Jump         L5
+  Jump         L7
 L0:
   Const        r75, 0
   Len          r76, r6
-L8:
+L12:
   Less         r77, r75, r76
-  JumpIfFalse  r77, L6
+  JumpIfFalse  r77, L8
   Index        r78, r6, r75
   Move         r79, r78
+  // name: g.key,
+  Const        r80, "name"
+  Const        r81, "key"
+  Index        r82, r79, r81
   // count: count(from r in g where r.o select r)
+  Const        r83, "count"
   Const        r84, []
   IterPrep     r85, r79
   Len          r86, r85
   Const        r87, 0
-L7:
+L11:
   Less         r88, r87, r86
-  JumpIfFalse  r88, L1
+  JumpIfFalse  r88, L9
   Index        r89, r85, r87
   Move         r90, r89
   Const        r91, "o"
   Index        r92, r90, r91
-  JumpIfFalse  r92, L1
+  JumpIfFalse  r92, L10
   Append       r93, r84, r90
   Move         r84, r93
-  Const        r95, 1
+L10:
+  Const        r94, 1
+  Move         r95, r94
   Move         r87, r95
-  Jump         L7
+  Jump         L11
+L9:
+  Count        r96, r84
+  // name: g.key,
+  Move         r97, r80
+  Move         r98, r82
+  // count: count(from r in g where r.o select r)
+  Move         r99, r83
+  Move         r100, r96
+  // select {
+  MakeMap      r101, 2, r97
   // let stats = from c in customers
   Append       r102, r4, r101
   Move         r4, r102
-  Const        r104, 1
+  Const        r103, 1
+  Move         r104, r103
   Move         r75, r104
-  Jump         L8
-L6:
+  Jump         L12
+L8:
   Move         r105, r4
   // print("--- Group Left Join ---")
   Const        r106, "--- Group Left Join ---"
@@ -133,9 +173,9 @@ L6:
   IterPrep     r107, r105
   Len          r108, r107
   Const        r109, 0
-L10:
+L14:
   Less         r110, r109, r108
-  JumpIfFalse  r110, L9
+  JumpIfFalse  r110, L13
   Index        r111, r107, r109
   Move         r112, r111
   // print(s.name, "orders:", s.count)
@@ -149,6 +189,9 @@ L10:
   Move         r115, r120
   PrintN       r113, 3, r113
   // for s in stats {
-  Jump         L10
-L9:
+  Const        r121, 1
+  Move         r122, r121
+  Move         r109, r122
+  Jump         L14
+L13:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -13,7 +13,7 @@ func main (regs=120)
   IterPrep     r7, r5
   Len          r8, r7
   Const        r9, 0
-L4:
+L6:
   Less         r10, r9, r8
   JumpIfFalse  r10, L0
   Index        r11, r7, r9
@@ -22,7 +22,7 @@ L4:
   IterPrep     r13, r3
   Len          r14, r13
   Const        r15, 0
-L3:
+L5:
   Less         r16, r15, r14
   JumpIfFalse  r16, L1
   Index        r17, r13, r15
@@ -32,14 +32,14 @@ L3:
   Const        r21, "supplier"
   Index        r22, r12, r21
   Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
+  JumpIfFalse  r23, L2
   // join n in nations on n.id == s.nation
   IterPrep     r24, r1
   Len          r25, r24
   Const        r26, 0
-L2:
+L4:
   Less         r27, r26, r25
-  JumpIfFalse  r27, L1
+  JumpIfFalse  r27, L2
   Index        r28, r24, r26
   Move         r29, r28
   Const        r30, "id"
@@ -47,28 +47,53 @@ L2:
   Const        r32, "nation"
   Index        r33, r18, r32
   Equal        r34, r31, r33
-  JumpIfFalse  r34, L1
+  JumpIfFalse  r34, L3
   // where n.name == "A"
   Const        r35, "name"
   Index        r36, r29, r35
   Const        r37, "A"
   Equal        r38, r36, r37
-  JumpIfFalse  r38, L1
+  JumpIfFalse  r38, L3
+  // part: ps.part,
+  Const        r39, "part"
+  Const        r40, "part"
+  Index        r41, r12, r40
+  // value: ps.cost * ps.qty
+  Const        r42, "value"
+  Const        r43, "cost"
+  Index        r44, r12, r43
+  Const        r45, "qty"
+  Index        r46, r12, r45
+  Mul          r47, r44, r46
+  // part: ps.part,
+  Move         r48, r39
+  Move         r49, r41
+  // value: ps.cost * ps.qty
+  Move         r50, r42
+  Move         r51, r47
+  // select {
+  MakeMap      r52, 2, r48
   // from ps in partsupp
   Append       r53, r6, r52
   Move         r6, r53
+L3:
   // join n in nations on n.id == s.nation
-  Const        r55, 1
+  Const        r54, 1
+  Move         r55, r54
   Move         r26, r55
-  Jump         L2
-  // join s in suppliers on s.id == ps.supplier
-  Const        r57, 1
-  Move         r15, r57
-  Jump         L3
-  // from ps in partsupp
-  Const        r59, 1
-  Move         r9, r59
   Jump         L4
+L2:
+  // join s in suppliers on s.id == ps.supplier
+  Const        r56, 1
+  Move         r57, r56
+  Move         r15, r57
+  Jump         L5
+L1:
+  // from ps in partsupp
+  Const        r58, 1
+  Move         r59, r58
+  Move         r9, r59
+  Jump         L6
 L0:
   // let filtered =
   Move         r60, r6
@@ -79,9 +104,9 @@ L0:
   Const        r64, 0
   MakeMap      r65, 0, r0
   Const        r66, []
-L7:
+L9:
   Less         r67, r64, r63
-  JumpIfFalse  r67, L5
+  JumpIfFalse  r67, L7
   Index        r68, r62, r64
   Move         r69, r68
   // group by x.part into g
@@ -89,7 +114,7 @@ L7:
   Index        r71, r69, r70
   Str          r72, r71
   In           r73, r72, r65
-  JumpIfTrue   r73, L6
+  JumpIfTrue   r73, L8
   // from x in filtered
   Const        r74, []
   Const        r75, "__group__"
@@ -104,41 +129,65 @@ L7:
   SetIndex     r65, r72, r81
   Append       r82, r66, r81
   Move         r66, r82
-L6:
+L8:
   Const        r83, "items"
   Index        r84, r65, r72
   Index        r85, r84, r83
   Append       r86, r85, r68
   SetIndex     r84, r83, r86
-  Const        r88, 1
+  Const        r87, 1
+  Move         r88, r87
   Move         r64, r88
-  Jump         L7
-L5:
+  Jump         L9
+L7:
   Const        r89, 0
   Len          r90, r66
-L10:
+L13:
   Less         r91, r89, r90
-  JumpIfFalse  r91, L8
+  JumpIfFalse  r91, L10
   Index        r92, r66, r89
   Move         r93, r92
+  // part: g.key,
+  Const        r94, "part"
+  Const        r95, "key"
+  Index        r96, r93, r95
   // total: sum(from r in g select r.value)
+  Const        r97, "total"
   Const        r98, []
   IterPrep     r99, r93
   Len          r100, r99
   Const        r101, 0
-L9:
+L12:
   Less         r102, r101, r100
-  JumpIfFalse  r102, L1
+  JumpIfFalse  r102, L11
+  Index        r103, r99, r101
+  Move         r104, r103
+  Const        r105, "value"
+  Index        r106, r104, r105
   Append       r107, r98, r106
   Move         r98, r107
-  Jump         L9
+  Const        r108, 1
+  Move         r109, r108
+  Move         r101, r109
+  Jump         L12
+L11:
+  Sum          r110, r98
+  // part: g.key,
+  Move         r111, r94
+  Move         r112, r96
+  // total: sum(from r in g select r.value)
+  Move         r113, r97
+  Move         r114, r110
+  // select {
+  MakeMap      r115, 2, r111
   // from x in filtered
   Append       r116, r61, r115
   Move         r61, r116
-  Const        r118, 1
+  Const        r117, 1
+  Move         r118, r117
   Move         r89, r118
-  Jump         L10
-L8:
+  Jump         L13
+L10:
   // let grouped =
   Move         r119, r61
   // print(grouped)

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -24,7 +24,7 @@ func main (regs=244)
   IterPrep     r15, r3
   Len          r16, r15
   Const        r17, 0
-L8:
+L11:
   Less         r18, r17, r16
   JumpIfFalse  r18, L0
   Index        r19, r15, r17
@@ -33,7 +33,7 @@ L8:
   IterPrep     r21, r5
   Len          r22, r21
   Const        r23, 0
-L7:
+L10:
   Less         r24, r23, r22
   JumpIfFalse  r24, L1
   Index        r25, r21, r23
@@ -43,14 +43,14 @@ L7:
   Const        r29, "c_custkey"
   Index        r30, r20, r29
   Equal        r31, r28, r30
-  JumpIfFalse  r31, L1
+  JumpIfFalse  r31, L2
   // join l in lineitem on l.l_orderkey == o.o_orderkey
   IterPrep     r32, r7
   Len          r33, r32
   Const        r34, 0
-L6:
+L9:
   Less         r35, r34, r33
-  JumpIfFalse  r35, L1
+  JumpIfFalse  r35, L2
   Index        r36, r32, r34
   Move         r37, r36
   Const        r38, "l_orderkey"
@@ -58,14 +58,14 @@ L6:
   Const        r40, "o_orderkey"
   Index        r41, r26, r40
   Equal        r42, r39, r41
-  JumpIfFalse  r42, L1
+  JumpIfFalse  r42, L3
   // join n in nation on n.n_nationkey == c.c_nationkey
   IterPrep     r43, r1
   Len          r44, r43
   Const        r45, 0
-L5:
+L8:
   Less         r46, r45, r44
-  JumpIfFalse  r46, L1
+  JumpIfFalse  r46, L3
   Index        r47, r43, r45
   Move         r48, r47
   Const        r49, "n_nationkey"
@@ -73,7 +73,7 @@ L5:
   Const        r51, "c_nationkey"
   Index        r52, r20, r51
   Equal        r53, r50, r52
-  JumpIfFalse  r53, L1
+  JumpIfFalse  r53, L4
   // where o.o_orderdate >= start_date &&
   Const        r54, "o_orderdate"
   Index        r55, r26, r54
@@ -89,16 +89,26 @@ L5:
   Equal        r63, r61, r62
   // where o.o_orderdate >= start_date &&
   Move         r64, r56
-  JumpIfFalse  r64, L2
+  JumpIfFalse  r64, L5
   Move         r64, r59
-L2:
+L5:
   // o.o_orderdate < end_date &&
   Move         r65, r64
-  JumpIfFalse  r65, L3
+  JumpIfFalse  r65, L6
   Move         r65, r63
-L3:
+L6:
   // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r65, L1
+  JumpIfFalse  r65, L4
+  // from c in customer
+  Const        r66, "c"
+  Move         r67, r20
+  Const        r68, "o"
+  Move         r69, r26
+  Const        r70, "l"
+  Move         r71, r37
+  Const        r72, "n"
+  Move         r73, r48
+  MakeMap      r74, 4, r66
   // c_custkey: c.c_custkey,
   Const        r75, "c_custkey"
   Const        r76, "c_custkey"
@@ -152,7 +162,7 @@ L3:
   MakeMap      r110, 7, r96
   Str          r111, r110
   In           r112, r111, r13
-  JumpIfTrue   r112, L4
+  JumpIfTrue   r112, L7
   // from c in customer
   Const        r113, []
   Const        r114, "__group__"
@@ -167,71 +177,185 @@ L3:
   SetIndex     r13, r111, r120
   Append       r121, r14, r120
   Move         r14, r121
-L4:
+L7:
   Const        r122, "items"
   Index        r123, r13, r111
   Index        r124, r123, r122
   Append       r125, r124, r74
   SetIndex     r123, r122, r125
+L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  Const        r127, 1
+  Const        r126, 1
+  Move         r127, r126
   Move         r45, r127
-  Jump         L5
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  Const        r129, 1
-  Move         r34, r129
-  Jump         L6
-  // join o in orders on o.o_custkey == c.c_custkey
-  Const        r131, 1
-  Move         r23, r131
-  Jump         L7
-  // from c in customer
-  Const        r133, 1
-  Move         r17, r133
   Jump         L8
+L3:
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  Const        r128, 1
+  Move         r129, r128
+  Move         r34, r129
+  Jump         L9
+L2:
+  // join o in orders on o.o_custkey == c.c_custkey
+  Const        r130, 1
+  Move         r131, r130
+  Move         r23, r131
+  Jump         L10
+L1:
+  // from c in customer
+  Const        r132, 1
+  Move         r133, r132
+  Move         r17, r133
+  Jump         L11
 L0:
   Const        r134, 0
   Len          r135, r14
-L12:
+L17:
   Less         r136, r134, r135
-  JumpIfFalse  r136, L9
+  JumpIfFalse  r136, L12
   Index        r137, r14, r134
   Move         r138, r137
+  // c_custkey: g.key.c_custkey,
+  Const        r139, "c_custkey"
+  Const        r140, "key"
+  Index        r141, r138, r140
+  Const        r142, "c_custkey"
+  Index        r143, r141, r142
+  // c_name: g.key.c_name,
+  Const        r144, "c_name"
+  Const        r145, "key"
+  Index        r146, r138, r145
+  Const        r147, "c_name"
+  Index        r148, r146, r147
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Const        r149, "revenue"
   Const        r150, []
   IterPrep     r151, r138
   Len          r152, r151
   Const        r153, 0
-L10:
+L14:
   Less         r154, r153, r152
-  JumpIfFalse  r154, L1
+  JumpIfFalse  r154, L13
+  Index        r155, r151, r153
+  Move         r156, r155
+  Const        r157, "l"
+  Index        r158, r156, r157
+  Const        r159, "l_extendedprice"
+  Index        r160, r158, r159
+  Const        r161, 1
+  Const        r162, "l"
+  Index        r163, r156, r162
+  Const        r164, "l_discount"
+  Index        r165, r163, r164
+  Sub          r166, r161, r165
+  Mul          r167, r160, r166
   Append       r168, r150, r167
   Move         r150, r168
-  Const        r170, 1
+  Const        r169, 1
+  Move         r170, r169
   Move         r153, r170
-  Jump         L10
+  Jump         L14
+L13:
+  Sum          r171, r150
+  // c_acctbal: g.key.c_acctbal,
+  Const        r172, "c_acctbal"
+  Const        r173, "key"
+  Index        r174, r138, r173
+  Const        r175, "c_acctbal"
+  Index        r176, r174, r175
+  // n_name: g.key.n_name,
+  Const        r177, "n_name"
+  Const        r178, "key"
+  Index        r179, r138, r178
+  Const        r180, "n_name"
+  Index        r181, r179, r180
+  // c_address: g.key.c_address,
+  Const        r182, "c_address"
+  Const        r183, "key"
+  Index        r184, r138, r183
+  Const        r185, "c_address"
+  Index        r186, r184, r185
+  // c_phone: g.key.c_phone,
+  Const        r187, "c_phone"
+  Const        r188, "key"
+  Index        r189, r138, r188
+  Const        r190, "c_phone"
+  Index        r191, r189, r190
+  // c_comment: g.key.c_comment
+  Const        r192, "c_comment"
+  Const        r193, "key"
+  Index        r194, r138, r193
+  Const        r195, "c_comment"
+  Index        r196, r194, r195
+  // c_custkey: g.key.c_custkey,
+  Move         r197, r139
+  Move         r198, r143
+  // c_name: g.key.c_name,
+  Move         r199, r144
+  Move         r200, r148
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r201, r149
+  Move         r202, r171
+  // c_acctbal: g.key.c_acctbal,
+  Move         r203, r172
+  Move         r204, r176
+  // n_name: g.key.n_name,
+  Move         r205, r177
+  Move         r206, r181
+  // c_address: g.key.c_address,
+  Move         r207, r182
+  Move         r208, r186
+  // c_phone: g.key.c_phone,
+  Move         r209, r187
+  Move         r210, r191
+  // c_comment: g.key.c_comment
+  Move         r211, r192
+  Move         r212, r196
+  // select {
+  MakeMap      r213, 8, r197
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Const        r214, []
   IterPrep     r215, r138
   Len          r216, r215
   Const        r217, 0
-L11:
+L16:
   Less         r218, r217, r216
-  JumpIfFalse  r218, L1
+  JumpIfFalse  r218, L15
+  Index        r219, r215, r217
+  Move         r156, r219
+  Const        r220, "l"
+  Index        r221, r156, r220
+  Const        r222, "l_extendedprice"
+  Index        r223, r221, r222
+  Const        r224, 1
+  Const        r225, "l"
+  Index        r226, r156, r225
+  Const        r227, "l_discount"
+  Index        r228, r226, r227
+  Sub          r229, r224, r228
+  Mul          r230, r223, r229
   Append       r231, r214, r230
   Move         r214, r231
-  Const        r233, 1
+  Const        r232, 1
+  Move         r233, r232
   Move         r217, r233
-  Jump         L11
+  Jump         L16
+L15:
+  Sum          r234, r214
+  Neg          r235, r234
+  Move         r236, r235
   // from c in customer
+  Move         r237, r213
+  MakeList     r238, 2, r236
   Append       r239, r12, r238
   Move         r12, r239
-  Const        r241, 1
+  Const        r240, 1
+  Move         r241, r240
   Move         r134, r241
-  Jump         L12
-L9:
+  Jump         L17
+L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Sort         242,12,0,0
+  Sort         r242, r12
   // from c in customer
   Move         r12, r242
   // let result =

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -40,18 +40,24 @@ L1:
   Index        r26, r25, r24
   Append       r27, r26, r9
   SetIndex     r25, r24, r27
-  Const        r29, 1
+  Const        r28, 1
+  Move         r29, r28
   Move         r5, r29
   Jump         L2
 L0:
   Const        r30, 0
   Len          r31, r7
-L7:
+L8:
   Less         r32, r30, r31
   JumpIfFalse  r32, L3
   Index        r33, r7, r30
   Move         r34, r33
+  // cat: g.key,
+  Const        r35, "cat"
+  Const        r36, "key"
+  Index        r37, r34, r36
   // total: sum(from x in g select x.val)
+  Const        r38, "total"
   Const        r39, []
   IterPrep     r40, r34
   Len          r41, r40
@@ -59,30 +65,60 @@ L7:
 L5:
   Less         r43, r42, r41
   JumpIfFalse  r43, L4
+  Index        r44, r40, r42
+  Move         r45, r44
+  Const        r46, "val"
+  Index        r47, r45, r46
   Append       r48, r39, r47
   Move         r39, r48
-  Const        r50, 1
+  Const        r49, 1
+  Move         r50, r49
   Move         r42, r50
   Jump         L5
+L4:
+  Sum          r51, r39
+  // cat: g.key,
+  Move         r52, r35
+  Move         r53, r37
+  // total: sum(from x in g select x.val)
+  Move         r54, r38
+  Move         r55, r51
+  // select {
+  MakeMap      r56, 2, r52
   // sort by -sum(from x in g select x.val)
+  Const        r57, []
   IterPrep     r58, r34
   Len          r59, r58
   Const        r60, 0
-L6:
+L7:
   Less         r61, r60, r59
-  JumpIfFalse  r61, L4
-  Const        r67, 1
+  JumpIfFalse  r61, L6
+  Index        r62, r58, r60
+  Move         r45, r62
+  Const        r63, "val"
+  Index        r64, r45, r63
+  Append       r65, r57, r64
+  Move         r57, r65
+  Const        r66, 1
+  Move         r67, r66
   Move         r60, r67
-  Jump         L6
+  Jump         L7
+L6:
+  Sum          r68, r57
+  Neg          r69, r68
+  Move         r70, r69
   // from i in items
+  Move         r71, r56
+  MakeList     r72, 2, r70
   Append       r73, r2, r72
   Move         r2, r73
-  Const        r75, 1
+  Const        r74, 1
+  Move         r75, r74
   Move         r30, r75
-  Jump         L7
+  Jump         L8
 L3:
   // sort by -sum(from x in g select x.val)
-  Sort         76,2,0,0
+  Sort         r76, r2
   // from i in items
   Move         r2, r76
   // let grouped =

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -36,7 +36,8 @@ L1:
   Index        r26, r25, r24
   Append       r27, r26, r9
   SetIndex     r25, r24, r27
-  Const        r29, 1
+  Const        r28, 1
+  Move         r29, r28
   Move         r5, r29
   Jump         L2
 L0:
@@ -45,9 +46,12 @@ L0:
 L4:
   Less         r32, r30, r31
   JumpIfFalse  r32, L3
+  Index        r33, r7, r30
+  Move         r34, r33
   Append       r35, r2, r34
   Move         r2, r35
-  Const        r37, 1
+  Const        r36, 1
+  Move         r37, r36
   Move         r30, r37
   Jump         L4
 L3:
@@ -81,17 +85,29 @@ L7:
   // total = total + x.val
   Const        r56, "val"
   Index        r57, r55, r56
-  Add          r58, r47, r57
+  Move         r58, r57
   Move         r47, r58
   // for x in g.items {
-  Const        r60, 1
+  Const        r59, 1
+  Move         r60, r59
   Move         r52, r60
   Jump         L7
+L6:
   // tmp = append(tmp, {tag: g.key, total: total})
+  Const        r61, "tag"
+  Const        r62, "key"
+  Index        r63, r34, r62
+  Const        r64, "total"
+  Move         r65, r61
+  Move         r66, r63
+  Move         r67, r64
+  Move         r68, r47
+  MakeMap      r69, 2, r65
   Append       r70, r40, r69
   Move         r40, r70
   // for g in groups {
-  Const        r72, 1
+  Const        r71, 1
+  Move         r72, r71
   Move         r43, r72
   Jump         L8
 L5:
@@ -103,13 +119,21 @@ L5:
 L10:
   Less         r77, r76, r75
   JumpIfFalse  r77, L9
+  Index        r78, r74, r76
+  Move         r79, r78
+  Const        r80, "tag"
+  Index        r81, r79, r80
+  Move         r82, r81
+  Move         r83, r79
+  MakeList     r84, 2, r82
   Append       r85, r73, r84
   Move         r73, r85
-  Const        r87, 1
+  Const        r86, 1
+  Move         r87, r86
   Move         r76, r87
   Jump         L10
 L9:
-  Sort         88,73,0,0
+  Sort         r88, r73
   Move         r73, r88
   Move         r89, r73
   // print(result)

--- a/tests/vm/valid/in_operator_extended.ir.out
+++ b/tests/vm/valid/in_operator_extended.ir.out
@@ -19,7 +19,9 @@ L2:
   JumpIfFalse  r12, L1
   Append       r13, r2, r8
   Move         r2, r13
-  Const        r15, 1
+L1:
+  Const        r14, 1
+  Move         r15, r14
   Move         r5, r15
   Jump         L2
 L0:

--- a/tests/vm/valid/inner_join.ir.out
+++ b/tests/vm/valid/inner_join.ir.out
@@ -14,14 +14,14 @@ func main (regs=68)
   Len          r8, r7
   // let result = from o in orders
   Const        r9, 0
-L3:
+L4:
   Less         r10, r9, r6
   JumpIfFalse  r10, L0
   Index        r11, r5, r9
   Move         r12, r11
   // join from c in customers on o.customerId == c.id
   Const        r13, 0
-L2:
+L3:
   Less         r14, r13, r8
   JumpIfFalse  r14, L1
   Index        r15, r7, r13
@@ -31,18 +31,39 @@ L2:
   Const        r19, "id"
   Index        r20, r16, r19
   Equal        r21, r18, r20
-  JumpIfFalse  r21, L1
+  JumpIfFalse  r21, L2
+  // select { orderId: o.id, customerName: c.name, total: o.total }
+  Const        r22, "orderId"
+  Const        r23, "id"
+  Index        r24, r12, r23
+  Const        r25, "customerName"
+  Const        r26, "name"
+  Index        r27, r16, r26
+  Const        r28, "total"
+  Const        r29, "total"
+  Index        r30, r12, r29
+  Move         r31, r22
+  Move         r32, r24
+  Move         r33, r25
+  Move         r34, r27
+  Move         r35, r28
+  Move         r36, r30
+  MakeMap      r37, 3, r31
   // let result = from o in orders
   Append       r38, r4, r37
   Move         r4, r38
+L2:
   // join from c in customers on o.customerId == c.id
-  Const        r40, 1
+  Const        r39, 1
+  Move         r40, r39
   Move         r13, r40
-  Jump         L2
-  // let result = from o in orders
-  Const        r42, 1
-  Move         r9, r42
   Jump         L3
+L1:
+  // let result = from o in orders
+  Const        r41, 1
+  Move         r42, r41
+  Move         r9, r42
+  Jump         L4
 L0:
   Move         r43, r4
   // print("--- Orders with customer info ---")
@@ -52,9 +73,9 @@ L0:
   IterPrep     r45, r43
   Len          r46, r45
   Const        r47, 0
-L5:
+L6:
   Less         r48, r47, r46
-  JumpIfFalse  r48, L4
+  JumpIfFalse  r48, L5
   Index        r49, r45, r47
   Move         r50, r49
   // print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
@@ -75,8 +96,9 @@ L5:
   Move         r56, r65
   PrintN       r51, 6, r51
   // for entry in result {
-  Const        r67, 1
+  Const        r66, 1
+  Move         r67, r66
   Move         r47, r67
-  Jump         L5
-L4:
+  Jump         L6
+L5:
   Return       r0

--- a/tests/vm/valid/join_multi.ir.out
+++ b/tests/vm/valid/join_multi.ir.out
@@ -13,7 +13,7 @@ func main (regs=71)
   IterPrep     r7, r3
   Len          r8, r7
   Const        r9, 0
-L4:
+L6:
   Less         r10, r9, r8
   JumpIfFalse  r10, L0
   Index        r11, r7, r9
@@ -22,7 +22,7 @@ L4:
   IterPrep     r13, r1
   Len          r14, r13
   Const        r15, 0
-L3:
+L5:
   Less         r16, r15, r14
   JumpIfFalse  r16, L1
   Index        r17, r13, r15
@@ -32,14 +32,14 @@ L3:
   Const        r21, "id"
   Index        r22, r18, r21
   Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
+  JumpIfFalse  r23, L2
   // join from i in items on o.id == i.orderId
   IterPrep     r24, r5
   Len          r25, r24
   Const        r26, 0
-L2:
+L4:
   Less         r27, r26, r25
-  JumpIfFalse  r27, L1
+  JumpIfFalse  r27, L2
   Index        r28, r24, r26
   Move         r29, r28
   Const        r30, "id"
@@ -47,22 +47,40 @@ L2:
   Const        r32, "orderId"
   Index        r33, r29, r32
   Equal        r34, r31, r33
-  JumpIfFalse  r34, L1
+  JumpIfFalse  r34, L3
+  // select { name: c.name, sku: i.sku }
+  Const        r35, "name"
+  Const        r36, "name"
+  Index        r37, r18, r36
+  Const        r38, "sku"
+  Const        r39, "sku"
+  Index        r40, r29, r39
+  Move         r41, r35
+  Move         r42, r37
+  Move         r43, r38
+  Move         r44, r40
+  MakeMap      r45, 2, r41
   // let result = from o in orders
   Append       r46, r6, r45
   Move         r6, r46
+L3:
   // join from i in items on o.id == i.orderId
-  Const        r48, 1
+  Const        r47, 1
+  Move         r48, r47
   Move         r26, r48
-  Jump         L2
-  // join from c in customers on o.customerId == c.id
-  Const        r50, 1
-  Move         r15, r50
-  Jump         L3
-  // let result = from o in orders
-  Const        r52, 1
-  Move         r9, r52
   Jump         L4
+L2:
+  // join from c in customers on o.customerId == c.id
+  Const        r49, 1
+  Move         r50, r49
+  Move         r15, r50
+  Jump         L5
+L1:
+  // let result = from o in orders
+  Const        r51, 1
+  Move         r52, r51
+  Move         r9, r52
+  Jump         L6
 L0:
   Move         r53, r6
   // print("--- Multi Join ---")
@@ -72,9 +90,9 @@ L0:
   IterPrep     r55, r53
   Len          r56, r55
   Const        r57, 0
-L6:
+L8:
   Less         r58, r57, r56
-  JumpIfFalse  r58, L5
+  JumpIfFalse  r58, L7
   Index        r59, r55, r57
   Move         r60, r59
   // print(r.name, "bought item", r.sku)
@@ -88,6 +106,9 @@ L6:
   Move         r63, r68
   PrintN       r61, 3, r61
   // for r in result {
-  Jump         L6
-L5:
+  Const        r69, 1
+  Move         r70, r69
+  Move         r57, r70
+  Jump         L8
+L7:
   Return       r0

--- a/tests/vm/valid/left_join.ir.out
+++ b/tests/vm/valid/left_join.ir.out
@@ -14,14 +14,14 @@ func main (regs=99)
   Len          r8, r7
   // let result = from o in orders
   Const        r9, 0
-L3:
+L4:
   Less         r10, r9, r6
   JumpIfFalse  r10, L0
   Index        r11, r5, r9
   Move         r12, r11
   // left join c in customers on o.customerId == c.id
   Const        r13, 0
-L2:
+L3:
   Less         r14, r13, r8
   JumpIfFalse  r14, L1
   Index        r15, r7, r13
@@ -31,30 +31,56 @@ L2:
   Const        r19, "id"
   Index        r20, r16, r19
   Equal        r21, r18, r20
-  JumpIfFalse  r21, L1
+  JumpIfFalse  r21, L2
+  // orderId: o.id,
+  Const        r22, "orderId"
+  Const        r23, "id"
+  Index        r24, r12, r23
+  // customer: c,
+  Const        r25, "customer"
+  // total: o.total
+  Const        r26, "total"
+  Const        r27, "total"
+  Index        r28, r12, r27
+  // orderId: o.id,
+  Move         r29, r22
+  Move         r30, r24
+  // customer: c,
+  Move         r31, r25
+  Move         r32, r16
+  // total: o.total
+  Move         r33, r26
+  Move         r34, r28
+  // select {
+  MakeMap      r35, 3, r29
   // let result = from o in orders
   Append       r36, r4, r35
   Move         r4, r36
+L2:
   // left join c in customers on o.customerId == c.id
-  Const        r38, 1
+  Const        r37, 1
+  Move         r38, r37
   Move         r13, r38
-  Jump         L2
-  // let result = from o in orders
-  Const        r40, 1
-  Move         r9, r40
   Jump         L3
+L1:
+  // let result = from o in orders
+  Const        r39, 1
+  Move         r40, r39
+  Move         r9, r40
+  Jump         L4
 L0:
   Const        r41, 0
-L6:
+L10:
   Less         r42, r41, r6
-  JumpIfFalse  r42, L4
+  JumpIfFalse  r42, L5
   Index        r43, r5, r41
   Move         r12, r43
+  Const        r44, false
   // left join c in customers on o.customerId == c.id
   Const        r45, 0
-L5:
+L8:
   Less         r46, r45, r8
-  JumpIfFalse  r46, L1
+  JumpIfFalse  r46, L6
   Index        r47, r7, r45
   Move         r16, r47
   Const        r48, "customerId"
@@ -62,16 +88,49 @@ L5:
   Const        r50, "id"
   Index        r51, r16, r50
   Equal        r52, r49, r51
-  JumpIfFalse  r52, L1
-  Const        r54, 1
+  JumpIfFalse  r52, L7
+  Const        r44, true
+L7:
+  Const        r53, 1
+  Move         r54, r53
   Move         r45, r54
-  Jump         L5
+  Jump         L8
+L6:
   // let result = from o in orders
-  Jump         L1
+  Move         r55, r44
+  JumpIfTrue   r55, L9
+  Const        r56, nil
+  Move         r16, r56
+  // orderId: o.id,
+  Const        r57, "orderId"
+  Const        r58, "id"
+  Index        r59, r12, r58
+  // customer: c,
+  Const        r60, "customer"
+  // total: o.total
+  Const        r61, "total"
+  Const        r62, "total"
+  Index        r63, r12, r62
+  // orderId: o.id,
+  Move         r64, r57
+  Move         r65, r59
+  // customer: c,
+  Move         r66, r60
+  Move         r67, r16
+  // total: o.total
+  Move         r68, r61
+  Move         r69, r63
+  // select {
+  MakeMap      r70, 3, r64
+  // let result = from o in orders
   Append       r71, r4, r70
   Move         r4, r71
-  Jump         L6
-L4:
+L9:
+  Const        r72, 1
+  Move         r73, r72
+  Move         r41, r73
+  Jump         L10
+L5:
   Move         r74, r4
   // print("--- Left Join ---")
   Const        r75, "--- Left Join ---"
@@ -80,9 +139,9 @@ L4:
   IterPrep     r76, r74
   Len          r77, r76
   Const        r78, 0
-L8:
+L12:
   Less         r79, r78, r77
-  JumpIfFalse  r79, L7
+  JumpIfFalse  r79, L11
   Index        r80, r76, r78
   Move         r81, r80
   // print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
@@ -103,8 +162,9 @@ L8:
   Move         r87, r96
   PrintN       r82, 6, r82
   // for entry in result {
-  Const        r98, 1
+  Const        r97, 1
+  Move         r98, r97
   Move         r78, r98
-  Jump         L8
-L7:
+  Jump         L12
+L11:
   Return       r0

--- a/tests/vm/valid/left_join_multi.ir.out
+++ b/tests/vm/valid/left_join_multi.ir.out
@@ -13,7 +13,7 @@ func main (regs=93)
   IterPrep     r7, r3
   Len          r8, r7
   Const        r9, 0
-L4:
+L7:
   Less         r10, r9, r8
   JumpIfFalse  r10, L0
   Index        r11, r7, r9
@@ -22,7 +22,7 @@ L4:
   IterPrep     r13, r1
   Len          r14, r13
   Const        r15, 0
-L3:
+L6:
   Less         r16, r15, r14
   JumpIfFalse  r16, L1
   Index        r17, r13, r15
@@ -32,14 +32,14 @@ L3:
   Const        r21, "id"
   Index        r22, r18, r21
   Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
+  JumpIfFalse  r23, L2
   // left join i in items on o.id == i.orderId
   IterPrep     r24, r5
   Len          r25, r24
   Const        r26, 0
-L2:
+L5:
   Less         r27, r26, r25
-  JumpIfFalse  r27, L1
+  JumpIfFalse  r27, L3
   Index        r28, r24, r26
   Move         r29, r28
   Const        r31, "id"
@@ -47,26 +47,66 @@ L2:
   Const        r33, "orderId"
   Index        r34, r29, r33
   Equal        r35, r32, r34
-  JumpIfFalse  r35, L1
+  JumpIfFalse  r35, L4
+  // select { orderId: o.id, name: c.name, item: i }
+  Const        r36, "orderId"
+  Const        r37, "id"
+  Index        r38, r12, r37
+  Const        r39, "name"
+  Const        r40, "name"
+  Index        r41, r18, r40
+  Const        r42, "item"
+  Move         r43, r36
+  Move         r44, r38
+  Move         r45, r39
+  Move         r46, r41
+  Move         r47, r42
+  Move         r48, r29
+  MakeMap      r49, 3, r43
   // let result = from o in orders
   Append       r50, r6, r49
   Move         r6, r50
+L4:
   // left join i in items on o.id == i.orderId
-  Const        r52, 1
+  Const        r51, 1
+  Move         r52, r51
   Move         r26, r52
-  Jump         L2
-  Jump         L1
+  Jump         L5
+L3:
+  Move         r53, r30
+  JumpIfTrue   r53, L2
+  Const        r54, nil
+  Move         r29, r54
+  // select { orderId: o.id, name: c.name, item: i }
+  Const        r55, "orderId"
+  Const        r56, "id"
+  Index        r57, r12, r56
+  Const        r58, "name"
+  Const        r59, "name"
+  Index        r60, r18, r59
+  Const        r61, "item"
+  Move         r62, r55
+  Move         r63, r57
+  Move         r64, r58
+  Move         r65, r60
+  Move         r66, r61
+  Move         r67, r29
+  MakeMap      r68, 3, r62
   // let result = from o in orders
   Append       r69, r6, r68
   Move         r6, r69
+L2:
   // join from c in customers on o.customerId == c.id
-  Const        r71, 1
+  Const        r70, 1
+  Move         r71, r70
   Move         r15, r71
-  Jump         L3
+  Jump         L6
+L1:
   // let result = from o in orders
-  Const        r73, 1
+  Const        r72, 1
+  Move         r73, r72
   Move         r9, r73
-  Jump         L4
+  Jump         L7
 L0:
   Move         r74, r6
   // print("--- Left Join Multi ---")
@@ -76,9 +116,9 @@ L0:
   IterPrep     r76, r74
   Len          r77, r76
   Const        r78, 0
-L6:
+L9:
   Less         r79, r78, r77
-  JumpIfFalse  r79, L5
+  JumpIfFalse  r79, L8
   Index        r80, r76, r78
   Move         r81, r80
   // print(r.orderId, r.name, r.item)
@@ -93,8 +133,9 @@ L6:
   Move         r84, r90
   PrintN       r82, 3, r82
   // for r in result {
-  Const        r92, 1
+  Const        r91, 1
+  Move         r92, r91
   Move         r78, r92
-  Jump         L6
-L5:
+  Jump         L9
+L8:
   Return       r0

--- a/tests/vm/valid/len_builtin.ir.out
+++ b/tests/vm/valid/len_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(len([1,2,3]))
   Const        r0, [1, 2, 3]
-  Len          r1, r0
+  Const        r1, 3
   Print        r1
   Return       r0

--- a/tests/vm/valid/len_map.ir.out
+++ b/tests/vm/valid/len_map.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(len({"a":1, "b":2}))
   Const        r0, {"a": 1, "b": 2}
-  Len          r1, r0
+  Const        r1, 2
   Print        r1
   Return       r0

--- a/tests/vm/valid/list_assign.ir.out
+++ b/tests/vm/valid/list_assign.ir.out
@@ -7,7 +7,6 @@ func main (regs=6)
   Const        r3, 3
   SetIndex     r1, r2, r3
   // print(nums[1])
-  Const        r4, 1
-  Index        r5, r1, r4
+  Const        r5, 2
   Print        r5
   Return       r0

--- a/tests/vm/valid/list_index.ir.out
+++ b/tests/vm/valid/list_index.ir.out
@@ -1,9 +1,7 @@
 func main (regs=4)
   // let xs = [10, 20, 30]
   Const        r0, [10, 20, 30]
-  Move         r1, r0
   // print(xs[1])
-  Const        r2, 1
-  Index        r3, r1, r2
+  Const        r3, 20
   Print        r3
   Return       r0

--- a/tests/vm/valid/list_nested_assign.ir.out
+++ b/tests/vm/valid/list_nested_assign.ir.out
@@ -1,17 +1,12 @@
 func main (regs=10)
   // var matrix = [[1,2],[3,4]]
   Const        r0, [[1, 2], [3, 4]]
-  Move         r1, r0
   // matrix[1][0] = 5
-  Const        r2, 1
-  Index        r3, r1, r2
+  Const        r3, [3, 4]
   Const        r4, 0
   Const        r5, 5
   SetIndex     r3, r4, r5
   // print(matrix[1][0])
-  Const        r6, 1
-  Index        r7, r1, r6
-  Const        r8, 0
-  Index        r9, r7, r8
+  Const        r9, 3
   Print        r9
   Return       r0

--- a/tests/vm/valid/list_set_ops.ir.out
+++ b/tests/vm/valid/list_set_ops.ir.out
@@ -17,7 +17,7 @@ func main (regs=13)
   // print(len([1,2] union all [2,3]))
   Const        r9, [1, 2]
   Const        r10, [2, 3]
-  Union        r11, r9, r10
+  UnionAll     r11, r9, r10
   Len          r12, r11
   Print        r12
   Return       r0

--- a/tests/vm/valid/load_yaml.ir.out
+++ b/tests/vm/valid/load_yaml.ir.out
@@ -21,10 +21,24 @@ L2:
   Const        r14, 18
   LessEq       r15, r14, r13
   JumpIfFalse  r15, L1
+  // select { name: p.name, email: p.email }
+  Const        r16, "name"
+  Const        r17, "name"
+  Index        r18, r11, r17
+  Const        r19, "email"
+  Const        r20, "email"
+  Index        r21, r11, r20
+  Move         r22, r16
+  Move         r23, r18
+  Move         r24, r19
+  Move         r25, r21
+  MakeMap      r26, 2, r22
   // let adults = from p in people
   Append       r27, r5, r26
   Move         r5, r27
-  Const        r29, 1
+L1:
+  Const        r28, 1
+  Move         r29, r28
   Move         r8, r29
   Jump         L2
 L0:
@@ -45,6 +59,9 @@ L4:
   Index        r40, r36, r39
   Print2       r38, r40
   // for a in adults {
+  Const        r41, 1
+  Move         r42, r41
+  Move         r33, r42
   Jump         L4
 L3:
   Return       r0

--- a/tests/vm/valid/map_assign.ir.out
+++ b/tests/vm/valid/map_assign.ir.out
@@ -7,7 +7,6 @@ func main (regs=6)
   Const        r3, 2
   SetIndex     r1, r2, r3
   // print(scores["bob"])
-  Const        r4, "bob"
-  Index        r5, r1, r4
+  Const        r5, nil
   Print        r5
   Return       r0

--- a/tests/vm/valid/map_index.ir.out
+++ b/tests/vm/valid/map_index.ir.out
@@ -1,9 +1,7 @@
 func main (regs=4)
   // let m = {"a": 1, "b": 2}
   Const        r0, {"a": 1, "b": 2}
-  Move         r1, r0
   // print(m["b"])
-  Const        r2, "b"
-  Index        r3, r1, r2
+  Const        r3, 2
   Print        r3
   Return       r0

--- a/tests/vm/valid/map_int_key.ir.out
+++ b/tests/vm/valid/map_int_key.ir.out
@@ -1,9 +1,7 @@
 func main (regs=4)
   // let m = {1: "a", 2: "b"}
   Const        r0, {"1": "a", "2": "b"}
-  Move         r1, r0
   // print(m[1])
-  Const        r2, 1
-  Index        r3, r1, r2
+  Const        r3, "a"
   Print        r3
   Return       r0

--- a/tests/vm/valid/map_nested_assign.ir.out
+++ b/tests/vm/valid/map_nested_assign.ir.out
@@ -1,17 +1,12 @@
 func main (regs=10)
   // var data = {"outer": {"inner": 1}}
   Const        r0, {"outer": {"inner": 1}}
-  Move         r1, r0
   // data["outer"]["inner"] = 2
-  Const        r2, "outer"
-  Index        r3, r1, r2
+  Const        r3, {"inner": 1}
   Const        r4, "inner"
   Const        r5, 2
   SetIndex     r3, r4, r5
   // print(data["outer"]["inner"])
-  Const        r6, "outer"
-  Index        r7, r1, r6
-  Const        r8, "inner"
-  Index        r9, r7, r8
+  Const        r9, 1
   Print        r9
   Return       r0

--- a/tests/vm/valid/match_expr.ir.out
+++ b/tests/vm/valid/match_expr.ir.out
@@ -6,6 +6,7 @@ func main (regs=14)
   Const        r5, "one"
   Move         r2, r5
   Jump         L1
+L0:
   // 2 => "two"
   Const        r8, "two"
   Move         r2, r8

--- a/tests/vm/valid/match_full.ir.out
+++ b/tests/vm/valid/match_full.ir.out
@@ -6,6 +6,7 @@ func main (regs=44)
   Const        r5, "one"
   Move         r2, r5
   Jump         L1
+L0:
   // 2 => "two"
   Const        r8, "two"
   Move         r2, r8
@@ -27,25 +28,27 @@ L1:
   // print(label)
   Print        r13
   // "mon" => "tired"
-  Jump         L0
+  Jump         L3
   Const        r19, "tired"
   Move         r16, r19
-  Jump         L3
+  Jump         L4
+L3:
   // "fri" => "excited"
-  Jump         L0
+  Jump         L5
   Const        r22, "excited"
   Move         r16, r22
-  Jump         L3
+  Jump         L4
+L5:
   // "sun" => "relaxed"
   Const        r25, "relaxed"
   Move         r16, r25
-  Jump         L3
+  Jump         L4
   // _     => "normal"
   Const        r26, "normal"
   Move         r16, r26
-  Jump         L3
+  Jump         L4
   Const        r16, nil
-L3:
+L4:
   // let mood = match day {
   Move         r27, r16
   // print(mood)
@@ -53,15 +56,15 @@ L3:
   // true => "confirmed"
   Const        r33, "confirmed"
   Move         r30, r33
-  Jump         L4
+  Jump         L6
   // false => "denied"
-  Jump         L5
+  Jump         L7
   Const        r36, "denied"
   Move         r30, r36
-  Jump         L4
-L5:
+  Jump         L6
+L7:
   Const        r30, nil
-L4:
+L6:
   // let status = match ok {
   Move         r37, r30
   // print(status)

--- a/tests/vm/valid/min_max_builtin.ir.out
+++ b/tests/vm/valid/min_max_builtin.ir.out
@@ -1,11 +1,10 @@
 func main (regs=4)
   // let nums = [3,1,4]
   Const        r0, [3, 1, 4]
-  Move         r1, r0
   // print(min(nums))
-  Min          r2, r1
+  Const        r2, 1
   Print        r2
   // print(max(nums))
-  Max          r3, r1
+  Const        r3, 4
   Print        r3
   Return       r0

--- a/tests/vm/valid/order_by_map.ir.out
+++ b/tests/vm/valid/order_by_map.ir.out
@@ -10,14 +10,33 @@ func main (regs=28)
 L1:
   Less         r6, r5, r4
   JumpIfFalse  r6, L0
+  Index        r7, r3, r5
+  Move         r8, r7
+  // sort by { a: x.a, b: x.b }
+  Const        r9, "a"
+  Const        r10, "a"
+  Index        r11, r8, r10
+  Const        r12, "b"
+  Const        r13, "b"
+  Index        r14, r8, r13
+  Move         r15, r9
+  Move         r16, r11
+  Move         r17, r12
+  Move         r18, r14
+  MakeMap      r19, 2, r15
+  Move         r20, r19
+  // from x in data
+  Move         r21, r8
+  MakeList     r22, 2, r20
   Append       r23, r2, r22
   Move         r2, r23
-  Const        r25, 1
+  Const        r24, 1
+  Move         r25, r24
   Move         r5, r25
   Jump         L1
 L0:
   // sort by { a: x.a, b: x.b }
-  Sort         26,2,0,0
+  Sort         r26, r2
   // from x in data
   Move         r2, r26
   // let sorted =

--- a/tests/vm/valid/outer_join.ir.out
+++ b/tests/vm/valid/outer_join.ir.out
@@ -14,14 +14,14 @@ func main (regs=148)
   Len          r8, r7
   // let result = from o in orders
   Const        r9, 0
-L3:
+L4:
   Less         r10, r9, r6
   JumpIfFalse  r10, L0
   Index        r11, r5, r9
   Move         r12, r11
   // outer join c in customers on o.customerId == c.id
   Const        r13, 0
-L2:
+L3:
   Less         r14, r13, r8
   JumpIfFalse  r14, L1
   Index        r15, r7, r13
@@ -31,30 +31,47 @@ L2:
   Const        r19, "id"
   Index        r20, r16, r19
   Equal        r21, r18, r20
-  JumpIfFalse  r21, L1
+  JumpIfFalse  r21, L2
+  // order: o,
+  Const        r22, "order"
+  // customer: c
+  Const        r23, "customer"
+  // order: o,
+  Move         r24, r22
+  Move         r25, r12
+  // customer: c
+  Move         r26, r23
+  Move         r27, r16
+  // select {
+  MakeMap      r28, 2, r24
   // let result = from o in orders
   Append       r29, r4, r28
   Move         r4, r29
+L2:
   // outer join c in customers on o.customerId == c.id
-  Const        r31, 1
+  Const        r30, 1
+  Move         r31, r30
   Move         r13, r31
-  Jump         L2
-  // let result = from o in orders
-  Const        r33, 1
-  Move         r9, r33
   Jump         L3
+L1:
+  // let result = from o in orders
+  Const        r32, 1
+  Move         r33, r32
+  Move         r9, r33
+  Jump         L4
 L0:
   Const        r34, 0
-L6:
+L10:
   Less         r35, r34, r6
-  JumpIfFalse  r35, L4
+  JumpIfFalse  r35, L5
   Index        r36, r5, r34
   Move         r12, r36
+  Const        r37, false
   // outer join c in customers on o.customerId == c.id
   Const        r38, 0
-L5:
+L8:
   Less         r39, r38, r8
-  JumpIfFalse  r39, L1
+  JumpIfFalse  r39, L6
   Index        r40, r7, r38
   Move         r16, r40
   Const        r41, "customerId"
@@ -62,28 +79,53 @@ L5:
   Const        r43, "id"
   Index        r44, r16, r43
   Equal        r45, r42, r44
-  JumpIfFalse  r45, L1
-  Const        r47, 1
+  JumpIfFalse  r45, L7
+  Const        r37, true
+L7:
+  Const        r46, 1
+  Move         r47, r46
   Move         r38, r47
-  Jump         L5
+  Jump         L8
+L6:
   // let result = from o in orders
-  Jump         L1
+  Move         r48, r37
+  JumpIfTrue   r48, L9
+  Const        r49, nil
+  Move         r16, r49
+  // order: o,
+  Const        r50, "order"
+  // customer: c
+  Const        r51, "customer"
+  // order: o,
+  Move         r52, r50
+  Move         r53, r12
+  // customer: c
+  Move         r54, r51
+  Move         r55, r16
+  // select {
+  MakeMap      r56, 2, r52
+  // let result = from o in orders
   Append       r57, r4, r56
   Move         r4, r57
-  Jump         L6
-L4:
+L9:
+  Const        r58, 1
+  Move         r59, r58
+  Move         r34, r59
+  Jump         L10
+L5:
   // outer join c in customers on o.customerId == c.id
   Const        r60, 0
-L9:
+L16:
   Less         r61, r60, r8
-  JumpIfFalse  r61, L7
+  JumpIfFalse  r61, L11
   Index        r62, r7, r60
   Move         r16, r62
+  Const        r63, false
   // let result = from o in orders
   Const        r64, 0
-L8:
+L14:
   Less         r65, r64, r6
-  JumpIfFalse  r65, L1
+  JumpIfFalse  r65, L12
   Index        r66, r5, r64
   Move         r12, r66
   // outer join c in customers on o.customerId == c.id
@@ -92,19 +134,42 @@ L8:
   Const        r69, "id"
   Index        r70, r16, r69
   Equal        r71, r68, r70
-  JumpIfFalse  r71, L1
+  JumpIfFalse  r71, L13
+  Const        r63, true
+L13:
   // let result = from o in orders
-  Const        r73, 1
+  Const        r72, 1
+  Move         r73, r72
   Move         r64, r73
-  Jump         L8
+  Jump         L14
+L12:
   // outer join c in customers on o.customerId == c.id
-  Jump         L1
+  Move         r74, r63
+  JumpIfTrue   r74, L15
+  Const        r75, nil
+  Move         r12, r75
+  // order: o,
+  Const        r76, "order"
+  // customer: c
+  Const        r77, "customer"
+  // order: o,
+  Move         r78, r76
+  Move         r79, r12
+  // customer: c
+  Move         r80, r77
+  Move         r81, r16
+  // select {
+  MakeMap      r82, 2, r78
   // let result = from o in orders
   Append       r83, r4, r82
   Move         r4, r83
+L15:
   // outer join c in customers on o.customerId == c.id
-  Jump         L9
-L7:
+  Const        r84, 1
+  Move         r85, r84
+  Move         r60, r85
+  Jump         L16
+L11:
   // let result = from o in orders
   Move         r86, r4
   // print("--- Outer Join using syntax ---")
@@ -114,19 +179,19 @@ L7:
   IterPrep     r88, r86
   Len          r89, r88
   Const        r90, 0
-L14:
+L22:
   Less         r91, r90, r89
-  JumpIfFalse  r91, L10
+  JumpIfFalse  r91, L17
   Index        r92, r88, r90
   Move         r93, r92
   // if row.order {
   Const        r94, "order"
   Index        r95, r93, r94
-  JumpIfFalse  r95, L11
+  JumpIfFalse  r95, L18
   // if row.customer {
   Const        r96, "customer"
   Index        r97, r93, r96
-  JumpIfFalse  r97, L12
+  JumpIfFalse  r97, L19
   // print("Order", row.order.id, "by", row.customer.name, "- $", row.order.total)
   Const        r104, "Order"
   Move         r98, r104
@@ -151,8 +216,8 @@ L14:
   Move         r103, r118
   PrintN       r98, 6, r98
   // if row.customer {
-  Jump         L13
-L12:
+  Jump         L20
+L19:
   // print("Order", row.order.id, "by", "Unknown", "- $", row.order.total)
   Const        r125, "Order"
   Move         r119, r125
@@ -173,10 +238,10 @@ L12:
   Index        r136, r134, r135
   Move         r124, r136
   PrintN       r119, 6, r119
-L13:
+L20:
   // if row.order {
-  Jump         L1
-L11:
+  Jump         L21
+L18:
   // print("Customer", row.customer.name, "has no orders")
   Const        r140, "Customer"
   Move         r137, r140
@@ -188,9 +253,11 @@ L11:
   Const        r145, "has no orders"
   Move         r139, r145
   PrintN       r137, 3, r137
+L21:
   // for row in result {
-  Const        r147, 1
+  Const        r146, 1
+  Move         r147, r146
   Move         r90, r147
-  Jump         L14
-L10:
+  Jump         L22
+L17:
   Return       r0

--- a/tests/vm/valid/query_sum_select.ir.out
+++ b/tests/vm/valid/query_sum_select.ir.out
@@ -17,7 +17,9 @@ L2:
   JumpIfFalse  r10, L1
   Append       r11, r2, r8
   Move         r2, r11
-  Const        r13, 1
+L1:
+  Const        r12, 1
+  Move         r13, r12
   Move         r5, r13
   Jump         L2
 L0:

--- a/tests/vm/valid/right_join.ir.out
+++ b/tests/vm/valid/right_join.ir.out
@@ -13,14 +13,15 @@ func main (regs=87)
   IterPrep     r7, r3
   Len          r8, r7
   Const        r11, 0
-L3:
+L5:
   Less         r12, r11, r8
   JumpIfFalse  r12, L0
   Index        r13, r7, r11
   Move         r9, r13
+  Const        r14, false
   // let result = from c in customers
   Const        r15, 0
-L2:
+L3:
   Less         r16, r15, r6
   JumpIfFalse  r16, L1
   Index        r17, r5, r15
@@ -31,20 +32,59 @@ L2:
   Const        r20, "id"
   Index        r21, r10, r20
   Equal        r22, r19, r21
-  JumpIfFalse  r22, L1
+  JumpIfFalse  r22, L2
+  Const        r14, true
+  // customerName: c.name,
+  Const        r23, "customerName"
+  Const        r24, "name"
+  Index        r25, r10, r24
+  // order: o
+  Const        r26, "order"
+  // customerName: c.name,
+  Move         r27, r23
+  Move         r28, r25
+  // order: o
+  Move         r29, r26
+  Move         r30, r9
+  // select {
+  MakeMap      r31, 2, r27
   // let result = from c in customers
   Append       r32, r4, r31
   Move         r4, r32
-  Jump         L2
+L2:
+  Const        r33, 1
+  Move         r34, r33
+  Move         r15, r34
+  Jump         L3
+L1:
   // right join o in orders on o.customerId == c.id
-  Jump         L1
+  Move         r35, r14
+  JumpIfTrue   r35, L4
+  Const        r36, nil
+  Move         r10, r36
+  // customerName: c.name,
+  Const        r37, "customerName"
+  Const        r38, "name"
+  Index        r39, r10, r38
+  // order: o
+  Const        r40, "order"
+  // customerName: c.name,
+  Move         r41, r37
+  Move         r42, r39
+  // order: o
+  Move         r43, r40
+  Move         r44, r9
+  // select {
+  MakeMap      r45, 2, r41
   // let result = from c in customers
   Append       r46, r4, r45
   Move         r4, r46
+L4:
   // right join o in orders on o.customerId == c.id
-  Const        r48, 1
+  Const        r47, 1
+  Move         r48, r47
   Move         r11, r48
-  Jump         L3
+  Jump         L5
 L0:
   // let result = from c in customers
   Move         r49, r4
@@ -55,15 +95,15 @@ L0:
   IterPrep     r51, r49
   Len          r52, r51
   Const        r53, 0
-L6:
+L9:
   Less         r54, r53, r52
-  JumpIfFalse  r54, L4
+  JumpIfFalse  r54, L6
   Index        r55, r51, r53
   Move         r56, r55
   // if entry.order {
   Const        r57, "order"
   Index        r58, r56, r57
-  JumpIfFalse  r58, L5
+  JumpIfFalse  r58, L7
   // print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
   Const        r65, "Customer"
   Move         r59, r65
@@ -86,8 +126,8 @@ L6:
   Move         r64, r77
   PrintN       r59, 6, r59
   // if entry.order {
-  Jump         L1
-L5:
+  Jump         L8
+L7:
   // print("Customer", entry.customerName, "has no orders")
   Const        r81, "Customer"
   Move         r78, r81
@@ -97,9 +137,11 @@ L5:
   Const        r84, "has no orders"
   Move         r80, r84
   PrintN       r78, 3, r78
+L8:
   // for entry in result {
-  Const        r86, 1
+  Const        r85, 1
+  Move         r86, r85
   Move         r53, r86
-  Jump         L6
-L4:
+  Jump         L9
+L6:
   Return       r0

--- a/tests/vm/valid/short_circuit.ir.out
+++ b/tests/vm/valid/short_circuit.ir.out
@@ -2,7 +2,7 @@ func main (regs=14)
   // print(false && boom(1, 2))
   Const        r0, false
   Move         r1, r0
-  Jump         L0
+  JumpIfFalse  r1, L0
   Const        r4, 1
   Move         r2, r4
   Const        r5, 2
@@ -14,7 +14,7 @@ L0:
   // print(true || boom(1, 2))
   Const        r7, true
   Move         r8, r7
-  Jump         L1
+  JumpIfTrue   r8, L1
   Const        r11, 1
   Move         r9, r11
   Const        r12, 2

--- a/tests/vm/valid/slice.ir.out
+++ b/tests/vm/valid/slice.ir.out
@@ -1,26 +1,12 @@
 func main (regs=18)
   // print([1,2,3][1:3])
   Const        r0, [1, 2, 3]
-  Const        r2, 1
-  Move         r1, r2
-  Const        r4, 3
-  Move         r3, r4
-  Slice        r5, r0, r1, r3
+  Const        r5, [2, 3]
   Print        r5
   // print([1,2,3][0:2])
-  Const        r6, [1, 2, 3]
-  Const        r8, 0
-  Move         r7, r8
-  Const        r10, 2
-  Move         r9, r10
-  Slice        r11, r6, r7, r9
+  Const        r11, [1, 2]
   Print        r11
   // print("hello"[1:4])
-  Const        r12, "hello"
-  Const        r14, 1
-  Move         r13, r14
-  Const        r16, 4
-  Move         r15, r16
-  Slice        r17, r12, r13, r15
+  Const        r17, "ell"
   Print        r17
   Return       r0

--- a/tests/vm/valid/sort_stable.ir.out
+++ b/tests/vm/valid/sort_stable.ir.out
@@ -10,13 +10,23 @@ func main (regs=21)
 L1:
   Less         r6, r5, r4
   JumpIfFalse  r6, L0
+  Index        r7, r3, r5
+  Move         r8, r7
+  Const        r9, "v"
+  Index        r10, r8, r9
+  Const        r11, "n"
+  Index        r12, r8, r11
+  Move         r13, r12
+  Move         r14, r10
+  MakeList     r15, 2, r13
   Append       r16, r2, r15
   Move         r2, r16
-  Const        r18, 1
+  Const        r17, 1
+  Move         r18, r17
   Move         r5, r18
   Jump         L1
 L0:
-  Sort         19,2,0,0
+  Sort         r19, r2
   Move         r2, r19
   Move         r20, r2
   // print(result)

--- a/tests/vm/valid/string_index.ir.out
+++ b/tests/vm/valid/string_index.ir.out
@@ -1,9 +1,7 @@
 func main (regs=4)
   // let s = "mochi"
   Const        r0, "mochi"
-  Move         r1, r0
   // print(s[1])
-  Const        r2, 1
-  Index        r3, r1, r2
+  Const        r3, "o"
   Print        r3
   Return       r0

--- a/tests/vm/valid/string_prefix_slice.ir.out
+++ b/tests/vm/valid/string_prefix_slice.ir.out
@@ -1,27 +1,10 @@
 func main (regs=18)
   // let prefix = "fore"
   Const        r0, "fore"
-  Move         r1, r0
-  // let s1 = "forest"
-  Const        r2, "forest"
-  Move         r3, r2
   // print(s1[0:len(prefix)] == prefix)
-  Const        r5, 0
-  Move         r4, r5
-  Const        r7, 4
-  Move         r6, r7
-  Slice        r8, r3, r4, r6
-  Equal        r9, r8, r1
+  Const        r9, true
   Print        r9
-  // let s2 = "desert"
-  Const        r10, "desert"
-  Move         r11, r10
   // print(s2[0:len(prefix)] == prefix)
-  Const        r13, 0
-  Move         r12, r13
-  Const        r15, 4
-  Move         r14, r15
-  Slice        r16, r11, r12, r14
-  Equal        r17, r16, r1
+  Const        r17, false
   Print        r17
   Return       r0

--- a/tests/vm/valid/sum_builtin.ir.out
+++ b/tests/vm/valid/sum_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(sum([1,2,3]))
   Const        r0, [1, 2, 3]
-  Sum          r1, r0
+  Const        r1, 6
   Print        r1
   Return       r0

--- a/tests/vm/valid/two-sum.ir.out
+++ b/tests/vm/valid/two-sum.ir.out
@@ -24,13 +24,14 @@ func twoSum (regs=23)
   // for i in 0..n {
   Const        r4, 0
   Move         r5, r4
-L3:
+L4:
   Less         r6, r5, r3
   JumpIfFalse  r6, L0
   // for j in i+1..n {
-  Const        r8, 1
+  Const        r7, 1
+  Move         r8, r7
   Move         r9, r8
-L2:
+L3:
   Less         r10, r9, r3
   JumpIfFalse  r10, L1
   // if nums[i] + nums[j] == target {
@@ -38,18 +39,21 @@ L2:
   Index        r12, r0, r9
   Add          r13, r11, r12
   Equal        r14, r13, r1
-  JumpIfFalse  r14, L1
+  JumpIfFalse  r14, L2
   // return [i, j]
   Move         r15, r5
   Move         r16, r9
   MakeList     r17, 2, r15
   Return       r17
+L2:
   // for j in i+1..n {
-  Jump         L2
-  // for i in 0..n {
-  Const        r21, 1
-  Move         r5, r21
   Jump         L3
+L1:
+  // for i in 0..n {
+  Const        r20, 1
+  Move         r21, r20
+  Move         r5, r21
+  Jump         L4
 L0:
   // return [-1, -1]
   Const        r22, [-1, -1]

--- a/tests/vm/valid/values_builtin.ir.out
+++ b/tests/vm/valid/values_builtin.ir.out
@@ -1,8 +1,7 @@
 func main (regs=3)
   // let m = {"a":1, "b":2, "c":3}
   Const        r0, {"a": 1, "b": 2, "c": 3}
-  Move         r1, r0
   // print(values(m))
-  Values       2,1,0,0
+  Const        r2, [1, 2, 3]
   Print        r2
   Return       r0

--- a/tests/vm/valid/while_loop.ir.out
+++ b/tests/vm/valid/while_loop.ir.out
@@ -2,8 +2,18 @@ func main (regs=6)
   // var i = 0
   Const        r0, 0
   Move         r1, r0
+L1:
+  // while i < 3 {
+  Const        r2, 3
+  LessInt      r3, r1, r2
+  JumpIfFalse  r3, L0
   // print(i)
   Print        r1
+  // i = i + 1
+  Const        r4, 1
+  Move         r5, r4
+  Move         r1, r5
   // while i < 3 {
-  Jump         L0
+  Jump         L1
+L0:
   Return       r0


### PR DESCRIPTION
## Summary
- track constants across moves without rewriting moves to const
- clarify optimizer description in VM README
- regenerate VM IR test files after optimization tweaks

## Testing
- `go vet ./...`
- `go test ./...`
- `go test ./tests/vm -tags slow -run TestVM_IR -update`

------
https://chatgpt.com/codex/tasks/task_e_685f5b33ff8483209f5c4718156d409f