### PR TITLE
Add pure Mochi queue

### DIFF
--- a/core/mochi/container/queue/queue.mochi
+++ b/core/mochi/container/queue/queue.mochi
@@ -1,0 +1,42 @@
+package queue
+
+// Queue is a simple FIFO queue implemented in pure Mochi.
+type Queue {
+  items: list<any>
+}
+
+// new returns an empty Queue.
+export fun new(): Queue {
+  return Queue{ items: [] }
+}
+
+// enqueue adds a value to the end of the queue.
+export fun Queue.enqueue(q: Queue, v: any) {
+  q.items = q.items + [v]
+}
+
+// dequeue removes and returns the value at the front of the queue.
+// It returns (null, false) if the queue is empty.
+export fun Queue.dequeue(q: Queue): (any, bool) {
+  if count(q.items) == 0 { return (null, false) }
+  let v = q.items[0]
+  q.items = q.items[1:]
+  return (v, true)
+}
+
+// front returns the value at the front of the queue without removing it.
+// It returns (null, false) if the queue is empty.
+export fun Queue.front(q: Queue): (any, bool) {
+  if count(q.items) == 0 { return (null, false) }
+  return (q.items[0], true)
+}
+
+// len returns the number of items in the queue.
+export fun Queue.len(q: Queue): int {
+  return count(q.items)
+}
+
+// isEmpty reports whether the queue has no items.
+export fun Queue.isEmpty(q: Queue): bool {
+  return count(q.items) == 0
+}


### PR DESCRIPTION
## Summary
- implement `core/mochi/container/queue` package

## Testing
- `make fmt`
- `make test STAGE=types`


------
https://chatgpt.com/codex/tasks/task_e_685f6d1cbb54832096da4e964342581c