### PR TITLE
Implement stack container in pure Mochi

### DIFF
--- a/core/mochi/container/stack/stack.mochi
+++ b/core/mochi/container/stack/stack.mochi
@@ -1,0 +1,63 @@
+package stack
+
+type Stack {
+  items: list<any>
+}
+
+export fun new(): Stack {
+  return Stack{ items: [] }
+}
+
+export fun len(s: Stack): int { return count(s.items) }
+
+export fun empty(s: Stack): bool { return count(s.items) == 0 }
+
+export fun push(s: Stack, v: any): Stack {
+  return Stack{ items: s.items + [v] }
+}
+
+fun _removeLast(xs: list<any>): list<any> {
+  var out: list<any> = []
+  var i = 0
+  while i < count(xs) - 1 {
+    out = out + [xs[i]]
+    i = i + 1
+  }
+  return out
+}
+
+export fun pop(s: Stack): (Stack, any, bool) {
+  if count(s.items) == 0 { return (s, null, false) }
+  let idx = count(s.items) - 1
+  let val = s.items[idx]
+  let rest = _removeLast(s.items)
+  return (Stack{ items: rest }, val, true)
+}
+
+export fun peek(s: Stack): (any, bool) {
+  if count(s.items) == 0 { return (null, false) }
+  let idx = count(s.items) - 1
+  return (s.items[idx], true)
+}
+
+// simple tests
+
+test "stack push/pop" {
+  var s = new()
+  expect len(s) == 0
+  s = push(s, 1)
+  s = push(s, 2)
+  expect len(s) == 2
+  let (v, ok) = peek(s)
+  expect ok && v == 2
+  let tmp: Stack
+  let val: any
+  let ok2: bool
+  (tmp, val, ok2) = pop(s)
+  s = tmp
+  expect ok2 && val == 2 && len(s) == 1
+  (s, val, ok2) = pop(s)
+  expect ok2 && val == 1 && len(s) == 0
+  (s, val, ok2) = pop(s)
+  expect !ok2 && val == null && len(s) == 0
+}


### PR DESCRIPTION
## Summary
- add a new `core/mochi/container/stack` package
- implement a simple immutable stack with push/pop/peek helpers
- include basic tests inside the Mochi source

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685f6d11555c8320993ac9ee7112cffd