### PR TITLE
Optimize left join bytecode

### DIFF
--- a/tests/vm/valid/append_builtin.ir.out
+++ b/tests/vm/valid/append_builtin.ir.out
@@ -1,8 +1,8 @@
-func main (regs=4)
+func main (regs=3)
   // let a = [1,2]
   Const        r0, [1, 2]
-  Move         r1, r0
   // print(append(a, 3))
-  Append       r3, r1, r2
-  Print        r3
+  Const        r1, 3
+  Append       r2, r0, r1
+  Print        r2
   Return       r0

--- a/tests/vm/valid/avg_builtin.ir.out
+++ b/tests/vm/valid/avg_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(avg([1,2,3]))
   Const        r0, [1, 2, 3]
-  Avg          r1, r0
+  Const        r1, 2
   Print        r1
   Return       r0

--- a/tests/vm/valid/basic_compare.ir.out
+++ b/tests/vm/valid/basic_compare.ir.out
@@ -1,14 +1,13 @@
-func main (regs=12)
+func main (regs=9)
   // let a = 10 - 3
   Const        r0, 10
   Const        r2, 7
-  Move         r3, r2
   // print(a)
-  Print        r3
+  Print        r2
   // print(a == 7)
-  Const        r9, true
-  Print        r9
+  Const        r6, true
+  Print        r6
   // print(b < 5)
-  Const        r11, true
-  Print        r11
+  Const        r8, true
+  Print        r8
   Return       r0

--- a/tests/vm/valid/binary_precedence.ir.out
+++ b/tests/vm/valid/binary_precedence.ir.out
@@ -1,15 +1,15 @@
-func main (regs=20)
+func main (regs=11)
   // print(1 + 2 * 3)
   Const        r0, 1
   Const        r4, 7
   Print        r4
   // print((1 + 2) * 3)
-  Const        r9, 9
-  Print        r9
+  Const        r6, 9
+  Print        r6
   // print(2 * 3 + 1)
-  Const        r14, 7
-  Print        r14
+  Const        r8, 7
+  Print        r8
   // print(2 * (3 + 1))
-  Const        r19, 8
-  Print        r19
+  Const        r10, 8
+  Print        r10
   Return       r0

--- a/tests/vm/valid/bool_chain.ir.out
+++ b/tests/vm/valid/bool_chain.ir.out
@@ -1,27 +1,23 @@
-func main (regs=33)
+func main (regs=21)
   // print((1 < 2) && (2 < 3) && (3 < 4))
   Const        r0, 1
-  Const        r10, true
-  Move         r7, r10
-  Print        r7
-  // print((1 < 2) && (2 > 3) && boom())
-  Const        r17, false
-  Move         r14, r17
-  Move         r18, r14
-  Jump         L0
-  Call         r19, boom, 
-  Move         r18, r19
+  Const        r6, true
+  JumpIfFalse  r6, L0
+  Const        r6, true
 L0:
-  Print        r18
-  // print((1 < 2) && (2 < 3) && (3 > 4) && boom())
-  Const        r30, false
-  Move         r27, r30
-  Move         r31, r27
-  Jump         L1
-  Call         r32, boom, 
-  Move         r31, r32
+  Print        r6
+  // print((1 < 2) && (2 > 3) && boom())
+  Const        r12, false
+  JumpIfFalse  r12, L1
+  Call         r12, boom, 
 L1:
-  Print        r31
+  Print        r12
+  // print((1 < 2) && (2 < 3) && (3 > 4) && boom())
+  Const        r19, false
+  JumpIfFalse  r19, L2
+  Call         r19, boom, 
+L2:
+  Print        r19
   Return       r0
 
   // fun boom(): bool {

--- a/tests/vm/valid/break_continue.ir.out
+++ b/tests/vm/valid/break_continue.ir.out
@@ -1,39 +1,37 @@
-func main (regs=17)
+func main (regs=16)
   // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
   Const        r0, [1, 2, 3, 4, 5, 6, 7, 8, 9]
-  Move         r1, r0
   // for n in numbers {
-  IterPrep     r2, r1
-  Len          r3, r2
-  Const        r4, 0
+  IterPrep     r1, r0
+  Len          r2, r1
+  Const        r3, 0
 L4:
-  Less         r5, r4, r3
-  JumpIfFalse  r5, L0
-  Index        r6, r2, r4
-  Move         r7, r6
+  Less         r4, r3, r2
+  JumpIfFalse  r4, L0
+  Index        r6, r1, r3
   // if n % 2 == 0 {
-  Const        r8, 2
-  Mod          r9, r7, r8
-  Const        r10, 0
-  Equal        r11, r9, r10
-  JumpIfFalse  r11, L1
+  Const        r7, 2
+  Mod          r8, r6, r7
+  Const        r9, 0
+  Equal        r10, r8, r9
+  JumpIfFalse  r10, L1
   // continue
   Jump         L2
 L1:
   // if n > 7 {
-  Const        r12, 7
-  Less         r13, r12, r7
-  JumpIfFalse  r13, L3
+  Const        r11, 7
+  Less         r12, r11, r6
+  JumpIfFalse  r12, L3
   // break
   Jump         L0
 L3:
   // print("odd number:", n)
-  Const        r14, "odd number:"
-  Print2       r14, r7
+  Const        r13, "odd number:"
+  Print2       r13, r6
 L2:
   // for n in numbers {
-  Const        r16, 1
-  Move         r4, r16
+  Const        r14, 1
+  Add          r3, r3, r14
   Jump         L4
 L0:
   Return       r0

--- a/tests/vm/valid/cast_string_to_int.ir.out
+++ b/tests/vm/valid/cast_string_to_int.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print("1995" as int)
   Const        r0, "1995"
-  Cast         1,0,0,0
+  Cast         r1, r0, int
   Print        r1
   Return       r0

--- a/tests/vm/valid/cast_struct.ir.out
+++ b/tests/vm/valid/cast_struct.ir.out
@@ -1,10 +1,9 @@
-func main (regs=5)
+func main (regs=4)
   // let todo = {"title": "hi"} as Todo
   Const        r0, {"title": "hi"}
-  Cast         1,0,0,0
-  Move         r2, r1
+  Cast         r1, r0, Todo
   // print(todo.title)
-  Const        r3, "title"
-  Index        r4, r2, r3
-  Print        r4
+  Const        r2, "title"
+  Index        r3, r1, r2
+  Print        r3
   Return       r0

--- a/tests/vm/valid/closure.ir.out
+++ b/tests/vm/valid/closure.ir.out
@@ -1,21 +1,17 @@
-func main (regs=7)
+func main (regs=6)
   // let add10 = makeAdder(10)
-  Const        r1, 10
-  Move         r0, r1
+  Const        r0, 10
   Call         r2, makeAdder, r0
-  Move         r3, r2
   // print(add10(7))  // 17
-  Const        r5, 7
-  Move         r4, r5
-  CallV        r6, r3, 1, r4
-  Print        r6
+  Const        r3, 7
+  CallV        r5, r2, 1, r3
+  Print        r5
   Return       r0
 
   // fun makeAdder(n: int): fun(int): int {
 func makeAdder (regs=3)
   // return fun(x: int): int => x + n
-  Move         r1, r0
-  MakeClosure  r2, fn2, 1, r1
+  MakeClosure  r2, fn2, 0, r0
   Return       r2
   Return       r0
 

--- a/tests/vm/valid/count_builtin.ir.out
+++ b/tests/vm/valid/count_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(count([1,2,3]))
   Const        r0, [1, 2, 3]
-  Count        r1, r0
+  Const        r1, 3
   Print        r1
   Return       r0

--- a/tests/vm/valid/cross_join.ir.out
+++ b/tests/vm/valid/cross_join.ir.out
@@ -1,77 +1,77 @@
-func main (regs=73)
+func main (regs=62)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}]
   // let result = from o in orders
-  Const        r4, []
-  IterPrep     r5, r3
-  Len          r6, r5
-  Const        r7, 0
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  Const        r5, 0
 L3:
-  Less         r8, r7, r6
-  JumpIfFalse  r8, L0
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r8, r3, r5
   // from c in customers
-  IterPrep     r11, r1
-  Len          r12, r11
-  Const        r13, 0
+  IterPrep     r9, r0
+  Len          r10, r9
+  Const        r11, 0
 L2:
-  Less         r14, r13, r12
-  JumpIfFalse  r14, L1
+  Less         r12, r11, r10
+  JumpIfFalse  r12, L1
+  // orderId: o.id,
+  Const        r15, "orderId"
+  Const        r16, "id"
+  Index        r17, r8, r16
+  // orderCustomerId: o.customerId,
+  Const        r18, "orderCustomerId"
+  Const        r19, "customerId"
+  Index        r20, r8, r19
+  // pairedCustomerName: c.name,
+  Const        r21, "pairedCustomerName"
+  Const        r22, "name"
+  // orderTotal: o.total
+  Const        r24, "orderTotal"
+  // select {
+  MakeMap      r31, 4, r15
   // let result = from o in orders
-  Append       r38, r4, r37
-  Move         r4, r38
+  Append       r2, r2, r31
   // from c in customers
+  Const        r33, 1
+  Add          r11, r11, r33
   Jump         L2
+L1:
   // let result = from o in orders
-  Const        r42, 1
-  Move         r7, r42
+  Const        r35, 1
+  Add          r5, r5, r35
   Jump         L3
 L0:
-  Move         r43, r4
   // print("--- Cross Join: All order-customer pairs ---")
-  Const        r44, "--- Cross Join: All order-customer pairs ---"
-  Print        r44
+  Const        r37, "--- Cross Join: All order-customer pairs ---"
+  Print        r37
   // for entry in result {
-  IterPrep     r45, r43
-  Len          r46, r45
-  Const        r47, 0
+  IterPrep     r38, r2
+  Len          r39, r38
+  Const        r40, 0
 L5:
-  Less         r48, r47, r46
-  JumpIfFalse  r48, L4
-  Index        r49, r45, r47
-  Move         r50, r49
+  Less         r41, r40, r39
+  JumpIfFalse  r41, L4
+  Index        r43, r38, r40
   // print("Order", entry.orderId,
-  Const        r59, "Order"
-  Move         r51, r59
-  Const        r60, "orderId"
-  Index        r61, r50, r60
-  Move         r52, r61
+  Const        r44, "Order"
+  Index        r45, r43, r15
   // "(customerId:", entry.orderCustomerId,
-  Const        r62, "(customerId:"
-  Move         r53, r62
-  Const        r63, "orderCustomerId"
-  Index        r64, r50, r63
-  Move         r54, r64
+  Const        r46, "(customerId:"
+  Index        r47, r43, r18
   // ", total: $", entry.orderTotal,
-  Const        r65, ", total: $"
-  Move         r55, r65
-  Const        r66, "orderTotal"
-  Index        r67, r50, r66
-  Move         r56, r67
+  Const        r48, ", total: $"
+  Index        r49, r43, r24
   // ") paired with", entry.pairedCustomerName)
-  Const        r68, ") paired with"
-  Move         r57, r68
-  Const        r69, "pairedCustomerName"
-  Index        r70, r50, r69
-  Move         r58, r70
+  Const        r50, ") paired with"
+  Index        r51, r43, r21
   // print("Order", entry.orderId,
-  PrintN       r51, 8, r51
+  PrintN       r44, 8, r44
   // for entry in result {
-  Const        r72, 1
-  Move         r47, r72
   Jump         L5
 L4:
   Return       r0

--- a/tests/vm/valid/cross_join_filter.ir.out
+++ b/tests/vm/valid/cross_join_filter.ir.out
@@ -1,65 +1,67 @@
-func main (regs=47)
+func main (regs=40)
   // let nums = [1, 2, 3]
   Const        r0, [1, 2, 3]
-  Move         r1, r0
   // let letters = ["A", "B"]
-  Const        r2, ["A", "B"]
-  Move         r3, r2
+  Const        r1, ["A", "B"]
   // let pairs = from n in nums
-  Const        r4, []
-  IterPrep     r5, r1
-  Len          r6, r5
-  Const        r7, 0
+  Const        r2, []
+  IterPrep     r3, r0
+  Len          r4, r3
+  Const        r5, 0
 L3:
-  Less         r8, r7, r6
-  JumpIfFalse  r8, L0
-  Index        r9, r5, r7
-  Move         r10, r9
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r8, r3, r5
   // where n % 2 == 0
-  Const        r11, 2
-  Mod          r12, r10, r11
-  Const        r13, 0
-  Equal        r14, r12, r13
-  JumpIfFalse  r14, L1
+  Const        r9, 2
+  Mod          r10, r8, r9
+  Const        r11, 0
+  Equal        r12, r10, r11
+  JumpIfFalse  r12, L1
   // from l in letters
-  IterPrep     r15, r3
-  Len          r16, r15
-  Const        r17, 0
+  IterPrep     r13, r1
+  Len          r14, r13
+  Const        r15, 0
 L2:
-  Less         r18, r17, r16
-  JumpIfFalse  r18, L1
+  Less         r16, r15, r14
+  JumpIfFalse  r16, L1
+  Index        r18, r13, r15
+  // select { n: n, l: l }
+  Const        r19, "n"
+  Const        r20, "l"
+  Move         r21, r8
+  Move         r22, r18
+  MakeMap      r23, 2, r19
   // let pairs = from n in nums
-  Append       r28, r4, r27
-  Move         r4, r28
+  Append       r2, r2, r23
   // from l in letters
-  Const        r30, 1
-  Move         r17, r30
+  Const        r25, 1
+  Add          r15, r15, r25
   Jump         L2
+L1:
   // let pairs = from n in nums
-  Const        r32, 1
-  Move         r7, r32
+  Const        r27, 1
+  Add          r5, r5, r27
   Jump         L3
 L0:
-  Move         r33, r4
   // print("--- Even pairs ---")
-  Const        r34, "--- Even pairs ---"
-  Print        r34
+  Const        r29, "--- Even pairs ---"
+  Print        r29
   // for p in pairs {
-  IterPrep     r35, r33
-  Len          r36, r35
-  Const        r37, 0
+  IterPrep     r30, r2
+  Len          r31, r30
+  Const        r32, 0
 L5:
-  Less         r38, r37, r36
-  JumpIfFalse  r38, L4
-  Index        r39, r35, r37
-  Move         r40, r39
+  Less         r33, r32, r31
+  JumpIfFalse  r33, L4
+  Index        r35, r30, r32
   // print(p.n, p.l)
-  Const        r41, "n"
-  Index        r42, r40, r41
-  Const        r43, "l"
-  Index        r44, r40, r43
-  Print2       r42, r44
+  Index        r36, r35, r19
+  Index        r37, r35, r20
+  Print2       r36, r37
   // for p in pairs {
+  Const        r38, 1
+  Add          r32, r32, r38
   Jump         L5
 L4:
   Return       r0

--- a/tests/vm/valid/cross_join_triple.ir.out
+++ b/tests/vm/valid/cross_join_triple.ir.out
@@ -1,76 +1,79 @@
-func main (regs=61)
+func main (regs=51)
   // let nums = [1, 2]
   Const        r0, [1, 2]
-  Move         r1, r0
   // let letters = ["A", "B"]
-  Const        r2, ["A", "B"]
-  Move         r3, r2
+  Const        r1, ["A", "B"]
   // let bools = [true, false]
-  Const        r4, [true, false]
-  Move         r5, r4
+  Const        r2, [true, false]
   // let combos = from n in nums
-  Const        r6, []
-  IterPrep     r7, r1
-  Len          r8, r7
-  Const        r9, 0
-L4:
-  Less         r10, r9, r8
-  JumpIfFalse  r10, L0
-  // from l in letters
-  IterPrep     r13, r3
-  Len          r14, r13
-  Const        r15, 0
-L3:
-  Less         r16, r15, r14
-  JumpIfFalse  r16, L1
-  // from b in bools
-  IterPrep     r19, r5
-  Len          r20, r19
-  Const        r21, 0
-L2:
-  Less         r22, r21, r20
-  JumpIfFalse  r22, L1
-  // let combos = from n in nums
-  Append       r35, r6, r34
-  Move         r6, r35
-  // from b in bools
-  Const        r37, 1
-  Move         r21, r37
-  Jump         L2
-  // from l in letters
-  Jump         L3
-  // let combos = from n in nums
-  Const        r41, 1
-  Move         r9, r41
-  Jump         L4
-L0:
-  Move         r42, r6
-  // print("--- Cross Join of three lists ---")
-  Const        r43, "--- Cross Join of three lists ---"
-  Print        r43
-  // for c in combos {
-  IterPrep     r44, r42
-  Len          r45, r44
-  Const        r46, 0
-L6:
-  Less         r47, r46, r45
-  JumpIfFalse  r47, L5
-  Index        r48, r44, r46
-  Move         r49, r48
-  // print(c.n, c.l, c.b)
-  Const        r53, "n"
-  Index        r54, r49, r53
-  Move         r50, r54
-  Const        r55, "l"
-  Index        r56, r49, r55
-  Move         r51, r56
-  Const        r57, "b"
-  Index        r58, r49, r57
-  Move         r52, r58
-  PrintN       r50, 3, r50
-  // for c in combos {
-  Const        r60, 1
-  Move         r46, r60
-  Jump         L6
+  Const        r3, []
+  IterPrep     r4, r0
+  Len          r5, r4
+  Const        r6, 0
 L5:
+  Less         r7, r6, r5
+  JumpIfFalse  r7, L0
+  Index        r9, r4, r6
+  // from l in letters
+  IterPrep     r10, r1
+  Len          r11, r10
+  Const        r12, 0
+L4:
+  Less         r13, r12, r11
+  JumpIfFalse  r13, L1
+  Index        r15, r10, r12
+  // from b in bools
+  IterPrep     r16, r2
+  Len          r17, r16
+  Const        r18, 0
+L3:
+  Less         r19, r18, r17
+  JumpIfFalse  r19, L2
+  Index        r21, r16, r18
+  // select {n: n, l: l, b: b}
+  Const        r22, "n"
+  Const        r23, "l"
+  Const        r24, "b"
+  Move         r25, r9
+  Move         r26, r15
+  Move         r27, r21
+  MakeMap      r28, 3, r22
+  // let combos = from n in nums
+  Append       r3, r3, r28
+  // from b in bools
+  Const        r30, 1
+  Add          r18, r18, r30
+  Jump         L3
+L2:
+  // from l in letters
+  Const        r32, 1
+  Add          r12, r12, r32
+  Jump         L4
+L1:
+  // let combos = from n in nums
+  Const        r34, 1
+  Add          r6, r6, r34
+  Jump         L5
+L0:
+  // print("--- Cross Join of three lists ---")
+  Const        r36, "--- Cross Join of three lists ---"
+  Print        r36
+  // for c in combos {
+  IterPrep     r37, r3
+  Len          r38, r37
+  Const        r39, 0
+L7:
+  Less         r40, r39, r38
+  JumpIfFalse  r40, L6
+  Index        r42, r37, r39
+  // print(c.n, c.l, c.b)
+  Index        r43, r42, r22
+  Index        r44, r42, r23
+  Index        r45, r42, r24
+  PrintN       r43, 3, r43
+  // for c in combos {
+  Const        r49, 1
+  Add          r39, r39, r49
+  Jump         L7
+L6:
   Return       r0

--- a/tests/vm/valid/dataset_sort_take_limit.ir.out
+++ b/tests/vm/valid/dataset_sort_take_limit.ir.out
@@ -1,61 +1,59 @@
-func main (regs=43)
+func main (regs=40)
   // let products = [
   Const        r0, [{"name": "Laptop", "price": 1500}, {"name": "Smartphone", "price": 900}, {"name": "Tablet", "price": 600}, {"name": "Monitor", "price": 300}, {"name": "Keyboard", "price": 100}, {"name": "Mouse", "price": 50}, {"name": "Headphones", "price": 200}]
-  Move         r1, r0
   // let expensive = from p in products
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L1:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Append       r15, r2, r14
-  Move         r2, r15
-  Const        r17, 1
-  Move         r5, r17
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
+  // sort by -p.price
+  Const        r8, "price"
+  Index        r9, r7, r8
+  Neg          r11, r9
+  // let expensive = from p in products
+  Move         r12, r7
+  MakeList     r13, 2, r11
+  Append       r1, r1, r13
+  Const        r15, 1
+  Add          r4, r4, r15
   Jump         L1
 L0:
   // sort by -p.price
-  Sort         18,2,0,0
-  // let expensive = from p in products
-  Move         r2, r18
+  Sort         r1, r1
   // skip 1
-  Const        r19, 1
+  Const        r18, 1
   // let expensive = from p in products
-  Const        r20, nil
-  Slice        r21, r2, r19, r20
-  Move         r2, r21
-  Const        r22, 0
+  Const        r19, nil
+  Slice        r1, r1, r18, r19
+  Const        r21, 0
   // take 3
-  Const        r23, 3
+  Const        r22, 3
   // let expensive = from p in products
-  Slice        r24, r2, r22, r23
-  Move         r2, r24
-  Move         r25, r2
+  Slice        r1, r1, r21, r22
   // print("--- Top products (excluding most expensive) ---")
-  Const        r26, "--- Top products (excluding most expensive) ---"
-  Print        r26
+  Const        r24, "--- Top products (excluding most expensive) ---"
+  Print        r24
   // for item in expensive {
-  IterPrep     r27, r25
-  Len          r28, r27
-  Const        r29, 0
+  IterPrep     r25, r1
+  Len          r26, r25
+  Const        r27, 0
 L3:
-  Less         r30, r29, r28
-  JumpIfFalse  r30, L2
-  Index        r31, r27, r29
-  Move         r32, r31
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L2
+  Index        r30, r25, r27
   // print(item.name, "costs $", item.price)
-  Const        r36, "name"
-  Index        r37, r32, r36
-  Move         r33, r37
-  Const        r38, "costs $"
-  Move         r34, r38
-  Const        r39, "price"
-  Index        r40, r32, r39
-  Move         r35, r40
-  PrintN       r33, 3, r33
+  Const        r34, "name"
+  Index        r31, r30, r34
+  Const        r32, "costs $"
+  Index        r33, r30, r8
+  PrintN       r31, 3, r31
   // for item in expensive {
+  Const        r38, 1
+  Add          r27, r27, r38
   Jump         L3
 L2:
   Return       r0

--- a/tests/vm/valid/dataset_where_filter.ir.out
+++ b/tests/vm/valid/dataset_where_filter.ir.out
@@ -1,69 +1,64 @@
-func main (regs=57)
+func main (regs=45)
   // let people = [
   Const        r0, [{"age": 30, "name": "Alice"}, {"age": 15, "name": "Bob"}, {"age": 65, "name": "Charlie"}, {"age": 45, "name": "Diana"}]
-  Move         r1, r0
   // let adults = from person in people
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L2:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Index        r7, r3, r5
-  Move         r8, r7
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
   // where person.age >= 18
-  Const        r9, "age"
-  Index        r10, r8, r9
-  Const        r11, 18
-  LessEq       r12, r11, r10
-  JumpIfFalse  r12, L1
+  Const        r8, "age"
+  Index        r9, r7, r8
+  Const        r10, 18
+  LessEq       r11, r10, r9
+  JumpIfFalse  r11, L1
+  // name: person.name,
+  Const        r12, "name"
+  Index        r13, r7, r12
+  // age: person.age,
+  Index        r14, r7, r8
+  // is_senior: person.age >= 60
+  Const        r15, "is_senior"
+  Index        r16, r7, r8
+  Const        r17, 60
+  // select {
+  MakeMap      r22, 3, r12
   // let adults = from person in people
-  Append       r31, r2, r30
-  Move         r2, r31
-  Const        r33, 1
-  Move         r5, r33
+  Append       r1, r1, r22
+L1:
+  Const        r24, 1
+  Add          r4, r4, r24
   Jump         L2
 L0:
-  Move         r34, r2
   // print("--- Adults ---")
-  Const        r35, "--- Adults ---"
-  Print        r35
+  Const        r26, "--- Adults ---"
+  Print        r26
   // for person in adults {
-  IterPrep     r36, r34
-  Len          r37, r36
-  Const        r38, 0
+  IterPrep     r27, r1
+  Len          r28, r27
+  Const        r29, 0
 L6:
-  Less         r39, r38, r37
-  JumpIfFalse  r39, L3
-  Index        r40, r36, r38
-  Move         r8, r40
+  Less         r30, r29, r28
+  JumpIfFalse  r30, L3
+  Index        r7, r27, r29
   // print(person.name, "is", person.age,
-  Const        r45, "name"
-  Index        r46, r8, r45
-  Move         r41, r46
-  Const        r47, "is"
-  Move         r42, r47
-  Const        r48, "age"
-  Index        r49, r8, r48
-  Move         r43, r49
+  Index        r32, r7, r12
+  Const        r33, "is"
+  Index        r34, r7, r8
   // if person.is_senior { " (senior)" } else { "" })
-  Const        r50, "is_senior"
-  Index        r51, r8, r50
-  JumpIfFalse  r51, L4
-  Const        r52, " (senior)"
-  Move         r53, r52
+  Index        r39, r7, r15
+  JumpIfFalse  r39, L4
   Jump         L5
 L4:
-  Const        r54, ""
-  Move         r53, r54
+  Const        r35, ""
 L5:
-  Move         r44, r53
   // print(person.name, "is", person.age,
-  PrintN       r41, 4, r41
+  PrintN       r32, 4, r32
   // for person in adults {
-  Const        r56, 1
-  Move         r38, r56
   Jump         L6
 L3:
   Return       r0

--- a/tests/vm/valid/exists_builtin.ir.out
+++ b/tests/vm/valid/exists_builtin.ir.out
@@ -1,31 +1,28 @@
-func main (regs=16)
+func main (regs=14)
   // let data = [1,2]
   Const        r0, [1, 2]
-  Move         r1, r0
   // from x in data
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L2:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Index        r7, r3, r5
-  Move         r8, r7
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
   // where x == 1
-  Const        r9, 1
-  Equal        r10, r8, r9
-  JumpIfFalse  r10, L1
+  Const        r8, 1
+  Equal        r9, r7, r8
+  JumpIfFalse  r9, L1
   // from x in data
-  Append       r11, r2, r8
-  Move         r2, r11
-  Const        r13, 1
-  Move         r5, r13
+  Append       r1, r1, r7
+L1:
+  Const        r11, 1
+  Add          r4, r4, r11
   Jump         L2
 L0:
   // let flag = exists(
-  Exists       14,2,0,0
-  Move         r15, r14
+  Exists       r13, r1
   // print(flag)
-  Print        r15
+  Print        r13
   Return       r0

--- a/tests/vm/valid/for_list_collection.ir.out
+++ b/tests/vm/valid/for_list_collection.ir.out
@@ -7,13 +7,12 @@ func main (regs=9)
 L1:
   Less         r4, r3, r2
   JumpIfFalse  r4, L0
-  Index        r5, r1, r3
-  Move         r6, r5
+  Index        r6, r1, r3
   // print(n)
   Print        r6
   // for n in [1,2,3] {
-  Const        r8, 1
-  Move         r3, r8
+  Const        r7, 1
+  Add          r3, r3, r7
   Jump         L1
 L0:
   Return       r0

--- a/tests/vm/valid/for_loop.ir.out
+++ b/tests/vm/valid/for_loop.ir.out
@@ -1,9 +1,16 @@
 func main (regs=6)
   // for i in 1..4 {
   Const        r0, 1
+  Const        r1, 4
   Move         r2, r0
+L1:
+  Less         r3, r2, r1
+  JumpIfFalse  r3, L0
   // print(i)
   Print        r2
   // for i in 1..4 {
-  Jump         L0
+  Const        r4, 1
+  Add          r2, r2, r4
+  Jump         L1
+L0:
   Return       r0

--- a/tests/vm/valid/for_map_collection.ir.out
+++ b/tests/vm/valid/for_map_collection.ir.out
@@ -1,21 +1,17 @@
 func main (regs=10)
   // var m = {"a": 1, "b": 2}
   Const        r0, {"a": 1, "b": 2}
-  Move         r1, r0
   // for k in m {
-  IterPrep     r2, r1
+  IterPrep     r2, r0
   Len          r3, r2
   Const        r4, 0
 L1:
   Less         r5, r4, r3
   JumpIfFalse  r5, L0
-  Index        r6, r2, r4
-  Move         r7, r6
+  Index        r7, r2, r4
   // print(k)
   Print        r7
   // for k in m {
-  Const        r9, 1
-  Move         r4, r9
   Jump         L1
 L0:
   Return       r0

--- a/tests/vm/valid/fun_expr_in_let.ir.out
+++ b/tests/vm/valid/fun_expr_in_let.ir.out
@@ -1,12 +1,10 @@
-func main (regs=5)
+func main (regs=4)
   // let square = fun(x: int): int => x * x
   MakeClosure  r0, fn1, 0, r0
-  Move         r1, r0
   // print(square(6))  // 36
-  Const        r3, 6
-  Move         r2, r3
-  CallV        r4, r1, 1, r2
-  Print        r4
+  Const        r1, 6
+  CallV        r3, r0, 1, r1
+  Print        r3
   Return       r0
 
   // let square = fun(x: int): int => x * x

--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -1,107 +1,97 @@
-func main (regs=87)
+func main (regs=76)
   // let people = [
   Const        r0, [{"age": 30, "city": "Paris", "name": "Alice"}, {"age": 15, "city": "Hanoi", "name": "Bob"}, {"age": 65, "city": "Paris", "name": "Charlie"}, {"age": 45, "city": "Hanoi", "name": "Diana"}, {"age": 70, "city": "Paris", "name": "Eve"}, {"age": 22, "city": "Hanoi", "name": "Frank"}]
-  Move         r1, r0
   // let stats = from person in people
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
-  MakeMap      r6, 0, r0
-  Const        r7, []
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
+  MakeMap      r5, 0, r0
+  Const        r6, []
 L2:
-  Less         r8, r5, r4
-  JumpIfFalse  r8, L0
-  Index        r9, r3, r5
-  Move         r10, r9
+  Less         r7, r4, r3
+  JumpIfFalse  r7, L0
+  Index        r8, r2, r4
+  Move         r9, r8
   // group by person.city into g
-  Const        r11, "city"
-  Index        r12, r10, r11
-  Str          r13, r12
-  In           r14, r13, r6
-  JumpIfTrue   r14, L1
+  Const        r10, "city"
+  Index        r11, r9, r10
+  Str          r12, r11
+  In           r13, r12, r5
+  JumpIfTrue   r13, L1
   // let stats = from person in people
-  Const        r15, []
-  Const        r16, "__group__"
-  Const        r17, true
-  Const        r18, "key"
+  Const        r14, []
+  Const        r15, "__group__"
+  Const        r16, true
+  Const        r17, "key"
   // group by person.city into g
-  Move         r19, r12
+  Move         r18, r11
   // let stats = from person in people
-  Const        r20, "items"
-  Move         r21, r15
-  MakeMap      r22, 3, r16
-  SetIndex     r6, r13, r22
-  Append       r23, r7, r22
-  Move         r7, r23
+  Const        r19, "items"
+  Move         r20, r14
+  MakeMap      r21, 3, r15
+  SetIndex     r5, r12, r21
+  Append       r6, r6, r21
 L1:
-  Const        r24, "items"
-  Index        r25, r6, r13
-  Index        r26, r25, r24
-  Append       r27, r26, r9
-  SetIndex     r25, r24, r27
-  Const        r29, 1
-  Move         r5, r29
+  Index        r23, r5, r12
+  Index        r24, r23, r19
+  Append       r25, r24, r8
+  SetIndex     r23, r19, r25
+  Const        r26, 1
+  Add          r4, r4, r26
   Jump         L2
 L0:
-  Const        r30, 0
-  Len          r31, r7
+  Const        r28, 0
+  Len          r30, r6
 L6:
-  Less         r32, r30, r31
-  JumpIfFalse  r32, L3
-  Index        r33, r7, r30
-  Move         r34, r33
+  Less         r31, r28, r30
+  JumpIfFalse  r31, L3
+  Index        r33, r6, r28
   // avg_age: avg(from p in g select p.age)
-  Const        r41, []
-  IterPrep     r42, r34
-  Len          r43, r42
-  Const        r44, 0
+  Const        r37, "avg_age"
+  Const        r38, []
+  IterPrep     r39, r33
+  Len          r40, r39
+  Const        r41, 0
 L5:
-  Less         r45, r44, r43
-  JumpIfFalse  r45, L4
-  Append       r50, r41, r49
-  Move         r41, r50
-  Const        r52, 1
-  Move         r44, r52
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L4
+  Index        r44, r39, r41
+  Const        r45, "age"
+  Index        r46, r44, r45
+  Append       r38, r38, r46
+  Const        r48, 1
+  Add          r41, r41, r48
   Jump         L5
+L4:
+  // select {
+  MakeMap      r54, 3, r10
   // let stats = from person in people
-  Append       r61, r2, r60
-  Move         r2, r61
-  Const        r63, 1
-  Move         r30, r63
+  Append       r1, r1, r54
+  Add          r28, r28, r26
   Jump         L6
 L3:
-  Move         r64, r2
   // print("--- People grouped by city ---")
-  Const        r65, "--- People grouped by city ---"
-  Print        r65
+  Const        r57, "--- People grouped by city ---"
+  Print        r57
   // for s in stats {
-  IterPrep     r66, r64
-  Len          r67, r66
-  Const        r68, 0
+  IterPrep     r58, r1
+  Len          r59, r58
+  Const        r60, 0
 L8:
-  Less         r69, r68, r67
-  JumpIfFalse  r69, L7
-  Index        r70, r66, r68
-  Move         r71, r70
+  Less         r61, r60, r59
+  JumpIfFalse  r61, L7
+  Index        r63, r58, r60
   // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
-  Const        r77, "city"
-  Index        r78, r71, r77
-  Move         r72, r78
-  Const        r79, ": count ="
-  Move         r73, r79
-  Const        r80, "count"
-  Index        r81, r71, r80
-  Move         r74, r81
-  Const        r82, ", avg_age ="
-  Move         r75, r82
-  Const        r83, "avg_age"
-  Index        r84, r71, r83
-  Move         r76, r84
-  PrintN       r72, 5, r72
+  Index        r64, r63, r10
+  Const        r65, ": count ="
+  Index        r66, r63, r35
+  Const        r67, ", avg_age ="
+  Index        r68, r63, r37
+  PrintN       r64, 5, r64
   // for s in stats {
-  Const        r86, 1
-  Move         r68, r86
+  Const        r74, 1
+  Add          r60, r60, r74
   Jump         L8
 L7:
   Return       r0

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -1,100 +1,100 @@
-func main (regs=84)
+func main (regs=74)
   // let items = [
   Const        r0, [{"cat": "a", "flag": true, "val": 10}, {"cat": "a", "flag": false, "val": 5}, {"cat": "b", "flag": true, "val": 20}]
-  Move         r1, r0
   // from i in items
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
-  MakeMap      r6, 0, r0
-  Const        r7, []
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
+  MakeMap      r5, 0, r0
+  Const        r6, []
 L2:
-  Less         r8, r5, r4
-  JumpIfFalse  r8, L0
-  Index        r9, r3, r5
-  Move         r10, r9
+  Less         r7, r4, r3
+  JumpIfFalse  r7, L0
+  Index        r8, r2, r4
+  Move         r9, r8
   // group by i.cat into g
-  Const        r11, "cat"
-  Index        r12, r10, r11
-  Str          r13, r12
-  In           r14, r13, r6
-  JumpIfTrue   r14, L1
+  Const        r10, "cat"
+  Index        r11, r9, r10
+  Str          r12, r11
+  In           r13, r12, r5
+  JumpIfTrue   r13, L1
   // from i in items
-  Const        r15, []
-  Const        r16, "__group__"
-  Const        r17, true
-  Const        r18, "key"
+  Const        r14, []
+  Const        r15, "__group__"
+  Const        r16, true
+  Const        r17, "key"
   // group by i.cat into g
-  Move         r19, r12
+  Move         r18, r11
   // from i in items
-  Const        r20, "items"
-  Move         r21, r15
-  MakeMap      r22, 3, r16
-  SetIndex     r6, r13, r22
-  Append       r23, r7, r22
-  Move         r7, r23
+  Const        r19, "items"
+  Move         r20, r14
+  MakeMap      r21, 3, r15
+  SetIndex     r5, r12, r21
+  Append       r6, r6, r21
 L1:
-  Const        r24, "items"
-  Index        r25, r6, r13
-  Index        r26, r25, r24
-  Append       r27, r26, r9
-  SetIndex     r25, r24, r27
-  Const        r29, 1
-  Move         r5, r29
+  Index        r23, r5, r12
+  Index        r24, r23, r19
+  Append       r25, r24, r8
+  SetIndex     r23, r19, r25
+  Const        r26, 1
+  Add          r4, r4, r26
   Jump         L2
 L0:
-  Const        r30, 0
-  Len          r31, r7
-L7:
-  Less         r32, r30, r31
-  JumpIfFalse  r32, L3
-  Index        r33, r7, r30
-  Move         r34, r33
+  Const        r29, 0
+  Move         r28, r29
+  Len          r30, r6
+L9:
+  Less         r31, r28, r30
+  JumpIfFalse  r31, L3
+  Index        r33, r6, r28
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r39, []
-  IterPrep     r40, r34
-  Len          r41, r40
-  Const        r42, 0
-L5:
-  Less         r43, r42, r41
-  JumpIfFalse  r43, L4
-  Index        r44, r40, r42
-  Move         r45, r44
-  Const        r46, "flag"
-  Index        r47, r45, r46
-  JumpIfFalse  r47, L4
-  Append       r52, r39, r50
-  Move         r39, r52
-  Const        r54, 1
-  Move         r42, r54
-  Jump         L5
-  // sum(from x in g select x.val)
-  Const        r56, []
-  IterPrep     r57, r34
-  Len          r58, r57
-  Const        r59, 0
+  Const        r36, []
+  IterPrep     r37, r33
+  Len          r38, r37
+  Const        r39, 0
 L6:
-  Less         r60, r59, r58
-  JumpIfFalse  r60, L4
-  Append       r64, r56, r63
-  Move         r56, r64
-  Const        r66, 1
-  Move         r59, r66
+  Less         r40, r39, r38
+  JumpIfFalse  r40, L4
+  Index        r42, r37, r39
+  Const        r43, "flag"
+  Index        r44, r42, r43
+  JumpIfFalse  r44, L5
+  Const        r45, "val"
+L5:
+  Append       r36, r36, r29
+  Const        r49, 1
+  Add          r39, r39, r49
   Jump         L6
+L4:
+  // sum(from x in g select x.val)
+  Const        r52, []
+  IterPrep     r53, r33
+  Len          r54, r53
+  Const        r55, 0
+L8:
+  Less         r56, r55, r54
+  JumpIfFalse  r56, L7
+  Index        r42, r53, r55
+  Index        r58, r42, r45
+  Append       r52, r52, r58
+  Const        r60, 1
+  Add          r55, r55, r60
+  Jump         L8
+L7:
+  // select {
+  MakeMap      r66, 2, r10
+  // sort by g.key
+  Index        r68, r33, r17
   // from i in items
-  Append       r79, r2, r78
-  Move         r2, r79
-  Const        r81, 1
-  Move         r30, r81
-  Jump         L7
+  Move         r69, r66
+  MakeList     r70, 2, r68
+  Append       r1, r1, r70
+  Add          r28, r28, r26
+  Jump         L9
 L3:
   // sort by g.key
-  Sort         82,2,0,0
-  // from i in items
-  Move         r2, r82
-  // let result =
-  Move         r83, r2
+  Sort         r1, r1
   // print(result)
-  Print        r83
+  Print        r1
   Return       r0

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -1,70 +1,64 @@
-func main (regs=52)
+func main (regs=45)
   // let people = [
   Const        r0, [{"city": "Paris", "name": "Alice"}, {"city": "Hanoi", "name": "Bob"}, {"city": "Paris", "name": "Charlie"}, {"city": "Hanoi", "name": "Diana"}, {"city": "Paris", "name": "Eve"}, {"city": "Hanoi", "name": "Frank"}, {"city": "Paris", "name": "George"}]
-  Move         r1, r0
   // from p in people
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
-  MakeMap      r6, 0, r0
-  Const        r7, []
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
+  MakeMap      r5, 0, r0
+  Const        r6, []
 L2:
-  Less         r8, r5, r4
-  JumpIfFalse  r8, L0
-  Index        r9, r3, r5
-  Move         r10, r9
+  Less         r7, r4, r3
+  JumpIfFalse  r7, L0
+  Index        r8, r2, r4
+  Move         r9, r8
   // group by p.city into g
-  Const        r11, "city"
-  Index        r12, r10, r11
-  Str          r13, r12
-  In           r14, r13, r6
-  JumpIfTrue   r14, L1
+  Const        r10, "city"
+  Index        r11, r9, r10
+  Str          r12, r11
+  In           r13, r12, r5
+  JumpIfTrue   r13, L1
   // from p in people
-  Const        r15, []
-  Const        r16, "__group__"
-  Const        r17, true
-  Const        r18, "key"
+  Const        r14, []
+  Const        r15, "__group__"
+  Const        r16, true
+  Const        r17, "key"
   // group by p.city into g
-  Move         r19, r12
+  Move         r18, r11
   // from p in people
-  Const        r20, "items"
-  Move         r21, r15
-  MakeMap      r22, 3, r16
-  SetIndex     r6, r13, r22
-  Append       r23, r7, r22
-  Move         r7, r23
+  Const        r19, "items"
+  Move         r20, r14
+  MakeMap      r21, 3, r15
+  SetIndex     r5, r12, r21
+  Append       r6, r6, r21
 L1:
-  Const        r24, "items"
-  Index        r25, r6, r13
-  Index        r26, r25, r24
-  Append       r27, r26, r9
-  SetIndex     r25, r24, r27
-  Const        r29, 1
-  Move         r5, r29
+  Index        r23, r5, r12
+  Index        r24, r23, r19
+  Append       r25, r24, r8
+  SetIndex     r23, r19, r25
+  Const        r26, 1
+  Add          r4, r4, r26
   Jump         L2
 L0:
-  Const        r30, 0
-  Len          r31, r7
+  Const        r28, 0
+  Len          r30, r6
 L4:
-  Less         r32, r30, r31
-  JumpIfFalse  r32, L3
-  Index        r33, r7, r30
-  Move         r34, r33
+  Less         r31, r28, r30
+  JumpIfFalse  r31, L3
+  Index        r33, r6, r28
   // having count(g) >= 4
-  Count        r35, r34
-  Const        r36, 4
-  LessEqInt    r37, r36, r35
-  JumpIfFalse  r37, L3
+  Count        r34, r33
+  Const        r35, 4
+  LessEqInt    r36, r35, r34
+  JumpIfFalse  r36, L3
+  // select { city: g.key, num: count(g) }
+  MakeMap      r42, 2, r10
   // from p in people
-  Append       r48, r2, r47
-  Move         r2, r48
-  Const        r50, 1
-  Move         r30, r50
+  Append       r1, r1, r42
+  Add          r28, r28, r26
   Jump         L4
 L3:
-  // let big =
-  Move         r51, r2
   // json(big)
-  JSON         r51
+  JSON         r1
   Return       r0

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -1,107 +1,108 @@
-func main (regs=86)
+func main (regs=77)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from o in orders
+  Const        r2, []
+  MakeMap      r3, 0, r0
   Const        r4, []
-  MakeMap      r5, 0, r0
-  Const        r6, []
-  IterPrep     r7, r3
-  Len          r8, r7
-  Const        r9, 0
-L4:
-  Less         r10, r9, r8
-  JumpIfFalse  r10, L0
-  Index        r11, r7, r9
-  Move         r12, r11
-  // join from c in customers on o.customerId == c.id
-  IterPrep     r13, r1
-  Len          r14, r13
-  Const        r15, 0
-L3:
-  Less         r16, r15, r14
-  JumpIfFalse  r16, L1
-  Index        r17, r13, r15
-  Move         r18, r17
-  Const        r19, "customerId"
-  Index        r20, r12, r19
-  Const        r21, "id"
-  Index        r22, r18, r21
-  Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
-  // group by c.name into g
-  Const        r29, "name"
-  Index        r30, r18, r29
-  Str          r31, r30
-  In           r32, r31, r5
-  JumpIfTrue   r32, L2
-  // let stats = from o in orders
-  Const        r33, []
-  Const        r34, "__group__"
-  Const        r35, true
-  Const        r36, "key"
-  // group by c.name into g
-  Move         r37, r30
-  // let stats = from o in orders
-  Const        r38, "items"
-  Move         r39, r33
-  MakeMap      r40, 3, r34
-  SetIndex     r5, r31, r40
-  Append       r41, r6, r40
-  Move         r6, r41
-L2:
-  Const        r42, "items"
-  Index        r43, r5, r31
-  Index        r44, r43, r42
-  Append       r45, r44, r28
-  SetIndex     r43, r42, r45
-  // join from c in customers on o.customerId == c.id
-  Const        r47, 1
-  Move         r15, r47
-  Jump         L3
-  // let stats = from o in orders
-  Const        r49, 1
-  Move         r9, r49
-  Jump         L4
-L0:
-  Const        r50, 0
-  Len          r51, r6
-L6:
-  Less         r52, r50, r51
-  JumpIfFalse  r52, L5
-  Append       r65, r4, r64
-  Move         r4, r65
-  Const        r67, 1
-  Move         r50, r67
-  Jump         L6
+  IterPrep     r5, r1
+  Len          r6, r5
+  Const        r7, 0
 L5:
-  Move         r68, r4
-  // print("--- Orders per customer ---")
-  Const        r69, "--- Orders per customer ---"
-  Print        r69
-  // for s in stats {
-  IterPrep     r70, r68
-  Len          r71, r70
-  Const        r72, 0
-L8:
-  Less         r73, r72, r71
-  JumpIfFalse  r73, L7
-  Index        r74, r70, r72
-  Move         r75, r74
-  // print(s.name, "orders:", s.count)
-  Const        r79, "name"
-  Index        r80, r75, r79
-  Move         r76, r80
-  Const        r81, "orders:"
-  Move         r77, r81
-  Const        r82, "count"
-  Index        r83, r75, r82
-  Move         r78, r83
-  PrintN       r76, 3, r76
-  // for s in stats {
-  Jump         L8
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r10, r5, r7
+  // join from c in customers on o.customerId == c.id
+  IterPrep     r11, r0
+  Len          r12, r11
+  Const        r13, 0
+L4:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r16, r11, r13
+  Const        r17, "customerId"
+  Index        r18, r10, r17
+  Const        r19, "id"
+  Index        r20, r16, r19
+  Equal        r21, r18, r20
+  JumpIfFalse  r21, L2
+  // let stats = from o in orders
+  Const        r22, "o"
+  Move         r23, r10
+  Const        r24, "c"
+  Move         r25, r16
+  MakeMap      r26, 2, r22
+  // group by c.name into g
+  Const        r27, "name"
+  Index        r28, r16, r27
+  Str          r29, r28
+  In           r30, r29, r3
+  JumpIfTrue   r30, L3
+  // let stats = from o in orders
+  Const        r31, []
+  Const        r32, "__group__"
+  Const        r33, true
+  Const        r34, "key"
+  // group by c.name into g
+  Move         r35, r28
+  // let stats = from o in orders
+  Const        r36, "items"
+  Move         r37, r31
+  MakeMap      r38, 3, r32
+  SetIndex     r3, r29, r38
+  Append       r4, r4, r38
+L3:
+  Index        r40, r3, r29
+  Index        r41, r40, r36
+  Append       r42, r41, r26
+  SetIndex     r40, r36, r42
+L2:
+  // join from c in customers on o.customerId == c.id
+  Const        r43, 1
+  Add          r13, r13, r43
+  Jump         L4
+L1:
+  // let stats = from o in orders
+  Const        r45, 1
+  Add          r7, r7, r45
+  Jump         L5
+L0:
+  Const        r47, 0
+  Len          r49, r4
 L7:
+  Less         r50, r47, r49
+  JumpIfFalse  r50, L6
+  // count: count(g)
+  Const        r54, "count"
+  // select {
+  MakeMap      r58, 2, r27
+  // let stats = from o in orders
+  Append       r2, r2, r58
+  Const        r60, 1
+  Add          r47, r47, r60
+  Jump         L7
+L6:
+  // print("--- Orders per customer ---")
+  Const        r62, "--- Orders per customer ---"
+  Print        r62
+  // for s in stats {
+  IterPrep     r63, r2
+  Len          r64, r63
+  Const        r65, 0
+L9:
+  Less         r66, r65, r64
+  JumpIfFalse  r66, L8
+  Index        r68, r63, r65
+  // print(s.name, "orders:", s.count)
+  Index        r69, r68, r27
+  Const        r70, "orders:"
+  Index        r71, r68, r54
+  PrintN       r69, 3, r69
+  // for s in stats {
+  Const        r75, 1
+  Add          r65, r65, r75
+  Jump         L9
+L8:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -1,154 +1,144 @@
-func main (regs=123)
+func main (regs=105)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from c in customers
+  Const        r2, []
+  MakeMap      r3, 0, r0
   Const        r4, []
-  MakeMap      r5, 0, r0
-  Const        r6, []
-  IterPrep     r7, r1
-  Len          r8, r7
-  Const        r9, 0
-L5:
-  Less         r10, r9, r8
-  JumpIfFalse  r10, L0
-  Index        r11, r7, r9
-  Move         r12, r11
-  // left join o in orders on o.customerId == c.id
-  IterPrep     r13, r3
-  Len          r14, r13
-  Const        r15, 0
-L3:
-  Less         r16, r15, r14
-  JumpIfFalse  r16, L1
-  Index        r17, r13, r15
-  Move         r18, r17
-  Const        r20, "customerId"
-  Index        r21, r18, r20
-  Const        r22, "id"
-  Index        r23, r12, r22
-  Equal        r24, r21, r23
-  JumpIfFalse  r24, L1
-  // group by c.name into g
-  Const        r30, "name"
-  Index        r31, r12, r30
-  Str          r32, r31
-  In           r33, r32, r5
-  JumpIfTrue   r33, L2
-  // let stats = from c in customers
-  Const        r34, []
-  Const        r35, "__group__"
-  Const        r36, true
-  Const        r37, "key"
-  // group by c.name into g
-  Move         r38, r31
-  // let stats = from c in customers
-  Const        r39, "items"
-  Move         r40, r34
-  MakeMap      r41, 3, r35
-  SetIndex     r5, r32, r41
-  Append       r42, r6, r41
-  Move         r6, r42
-L2:
-  Const        r43, "items"
-  Index        r44, r5, r32
-  Index        r45, r44, r43
-  Append       r46, r45, r29
-  SetIndex     r44, r43, r46
-  // left join o in orders on o.customerId == c.id
-  Const        r48, 1
-  Move         r15, r48
-  Jump         L3
-  Jump         L1
-  // group by c.name into g
-  Const        r56, "name"
-  Index        r57, r12, r56
-  Str          r58, r57
-  In           r59, r58, r5
-  JumpIfTrue   r59, L4
-  // let stats = from c in customers
-  Const        r60, []
-  Const        r61, "__group__"
-  Const        r62, true
-  Const        r63, "key"
-  // group by c.name into g
-  Move         r64, r57
-  // let stats = from c in customers
-  Const        r65, "items"
-  Move         r66, r60
-  MakeMap      r67, 3, r61
-  SetIndex     r5, r58, r67
-  Append       r68, r6, r67
-  Move         r6, r68
-L4:
-  Const        r69, "items"
-  Index        r70, r5, r58
-  Index        r71, r70, r69
-  Append       r72, r71, r55
-  SetIndex     r70, r69, r72
-  Const        r74, 1
-  Move         r9, r74
-  Jump         L5
-L0:
-  Const        r75, 0
-  Len          r76, r6
-L8:
-  Less         r77, r75, r76
-  JumpIfFalse  r77, L6
-  Index        r78, r6, r75
-  Move         r79, r78
-  // count: count(from r in g where r.o select r)
-  Const        r84, []
-  IterPrep     r85, r79
-  Len          r86, r85
-  Const        r87, 0
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L7:
-  Less         r88, r87, r86
-  JumpIfFalse  r88, L1
-  Index        r89, r85, r87
-  Move         r90, r89
-  Const        r91, "o"
-  Index        r92, r90, r91
-  JumpIfFalse  r92, L1
-  Append       r93, r84, r90
-  Move         r84, r93
-  Const        r95, 1
-  Move         r87, r95
-  Jump         L7
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r10, r5, r7
+  // left join o in orders on o.customerId == c.id
+  IterPrep     r11, r1
+  Len          r12, r11
+  Const        r13, 0
+L4:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r16, r11, r13
+  Const        r17, false
+  Const        r18, "customerId"
+  Index        r19, r16, r18
+  Const        r20, "id"
+  Index        r21, r10, r20
+  Equal        r22, r19, r21
+  JumpIfFalse  r22, L2
+  Const        r17, true
   // let stats = from c in customers
-  Append       r102, r4, r101
-  Move         r4, r102
-  Const        r104, 1
-  Move         r75, r104
-  Jump         L8
+  Const        r23, "c"
+  Move         r24, r10
+  Const        r25, "o"
+  Move         r26, r16
+  MakeMap      r27, 2, r23
+  // group by c.name into g
+  Const        r28, "name"
+  Index        r29, r10, r28
+  Str          r30, r29
+  In           r31, r30, r3
+  JumpIfTrue   r31, L3
+  // let stats = from c in customers
+  Const        r32, []
+  Const        r33, "__group__"
+  Const        r34, true
+  Const        r35, "key"
+  // group by c.name into g
+  Move         r36, r29
+  // let stats = from c in customers
+  Const        r37, "items"
+  Move         r38, r32
+  MakeMap      r39, 3, r33
+  SetIndex     r3, r30, r39
+  Append       r4, r4, r39
+L3:
+  Index        r41, r3, r30
+  Index        r42, r41, r37
+  Append       r43, r42, r27
+  SetIndex     r41, r37, r43
+L2:
+  // left join o in orders on o.customerId == c.id
+  Const        r44, 1
+  Add          r13, r13, r44
+  Jump         L4
+L1:
+  Move         r46, r17
+  JumpIfTrue   r46, L5
+  // let stats = from c in customers
+  MakeMap      r50, 2, r23
+  // group by c.name into g
+  Index        r51, r10, r28
+  Str          r52, r51
+  In           r53, r52, r3
+  JumpIfTrue   r53, L6
+  // let stats = from c in customers
+  MakeMap      r57, 3, r33
+  SetIndex     r3, r52, r57
+  Append       r4, r4, r57
 L6:
-  Move         r105, r4
-  // print("--- Group Left Join ---")
-  Const        r106, "--- Group Left Join ---"
-  Print        r106
-  // for s in stats {
-  IterPrep     r107, r105
-  Len          r108, r107
-  Const        r109, 0
+  Index        r59, r3, r52
+  Index        r60, r59, r37
+  Append       r61, r60, r50
+  SetIndex     r59, r37, r61
+L5:
+  Const        r62, 1
+  Add          r7, r7, r62
+  Jump         L7
+L0:
+  Const        r64, 0
+  Len          r66, r4
+L12:
+  Less         r67, r64, r66
+  JumpIfFalse  r67, L8
+  Index        r69, r4, r64
+  // count: count(from r in g where r.o select r)
+  Const        r72, []
+  IterPrep     r73, r69
+  Len          r74, r73
+  Const        r75, 0
+L11:
+  Less         r76, r75, r74
+  JumpIfFalse  r76, L9
+  Index        r78, r73, r75
+  Index        r79, r78, r25
+  JumpIfFalse  r79, L10
+  Append       r72, r72, r78
 L10:
-  Less         r110, r109, r108
-  JumpIfFalse  r110, L9
-  Index        r111, r107, r109
-  Move         r112, r111
-  // print(s.name, "orders:", s.count)
-  Const        r116, "name"
-  Index        r117, r112, r116
-  Move         r113, r117
-  Const        r118, "orders:"
-  Move         r114, r118
-  Const        r119, "count"
-  Index        r120, r112, r119
-  Move         r115, r120
-  PrintN       r113, 3, r113
-  // for s in stats {
-  Jump         L10
+  Const        r81, 1
+  Add          r75, r75, r81
+  Jump         L11
 L9:
+  // select {
+  MakeMap      r86, 2, r28
+  // let stats = from c in customers
+  Append       r2, r2, r86
+  Const        r88, 1
+  Add          r64, r64, r88
+  Jump         L12
+L8:
+  // print("--- Group Left Join ---")
+  Const        r90, "--- Group Left Join ---"
+  Print        r90
+  // for s in stats {
+  IterPrep     r91, r2
+  Len          r92, r91
+  Const        r93, 0
+L14:
+  Less         r94, r93, r92
+  JumpIfFalse  r94, L13
+  Index        r96, r91, r93
+  // print(s.name, "orders:", s.count)
+  Index        r97, r96, r28
+  Const        r98, "orders:"
+  Index        r99, r96, r71
+  PrintN       r97, 3, r97
+  // for s in stats {
+  Const        r103, 1
+  Add          r93, r93, r103
+  Jump         L14
+L13:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -1,146 +1,142 @@
-func main (regs=120)
+func main (regs=99)
   // let nations = [
   Const        r0, [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
-  Move         r1, r0
   // let suppliers = [
-  Const        r2, [{"id": 1, "nation": 1}, {"id": 2, "nation": 2}]
-  Move         r3, r2
+  Const        r1, [{"id": 1, "nation": 1}, {"id": 2, "nation": 2}]
   // let partsupp = [
-  Const        r4, [{"cost": 10, "part": 100, "qty": 2, "supplier": 1}, {"cost": 20, "part": 100, "qty": 1, "supplier": 2}, {"cost": 5, "part": 200, "qty": 3, "supplier": 1}]
-  Move         r5, r4
+  Const        r2, [{"cost": 10, "part": 100, "qty": 2, "supplier": 1}, {"cost": 20, "part": 100, "qty": 1, "supplier": 2}, {"cost": 5, "part": 200, "qty": 3, "supplier": 1}]
   // from ps in partsupp
-  Const        r6, []
-  IterPrep     r7, r5
-  Len          r8, r7
-  Const        r9, 0
-L4:
-  Less         r10, r9, r8
-  JumpIfFalse  r10, L0
-  Index        r11, r7, r9
-  Move         r12, r11
-  // join s in suppliers on s.id == ps.supplier
-  IterPrep     r13, r3
-  Len          r14, r13
-  Const        r15, 0
-L3:
-  Less         r16, r15, r14
-  JumpIfFalse  r16, L1
-  Index        r17, r13, r15
-  Move         r18, r17
-  Const        r19, "id"
-  Index        r20, r18, r19
-  Const        r21, "supplier"
-  Index        r22, r12, r21
-  Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
-  // join n in nations on n.id == s.nation
-  IterPrep     r24, r1
-  Len          r25, r24
-  Const        r26, 0
-L2:
-  Less         r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r28, r24, r26
-  Move         r29, r28
-  Const        r30, "id"
-  Index        r31, r29, r30
-  Const        r32, "nation"
-  Index        r33, r18, r32
-  Equal        r34, r31, r33
-  JumpIfFalse  r34, L1
-  // where n.name == "A"
-  Const        r35, "name"
-  Index        r36, r29, r35
-  Const        r37, "A"
-  Equal        r38, r36, r37
-  JumpIfFalse  r38, L1
-  // from ps in partsupp
-  Append       r53, r6, r52
-  Move         r6, r53
-  // join n in nations on n.id == s.nation
-  Const        r55, 1
-  Move         r26, r55
-  Jump         L2
-  // join s in suppliers on s.id == ps.supplier
-  Const        r57, 1
-  Move         r15, r57
-  Jump         L3
-  // from ps in partsupp
-  Const        r59, 1
-  Move         r9, r59
-  Jump         L4
-L0:
-  // let filtered =
-  Move         r60, r6
-  // from x in filtered
-  Const        r61, []
-  IterPrep     r62, r60
-  Len          r63, r62
-  Const        r64, 0
-  MakeMap      r65, 0, r0
-  Const        r66, []
-L7:
-  Less         r67, r64, r63
-  JumpIfFalse  r67, L5
-  Index        r68, r62, r64
-  Move         r69, r68
-  // group by x.part into g
-  Const        r70, "part"
-  Index        r71, r69, r70
-  Str          r72, r71
-  In           r73, r72, r65
-  JumpIfTrue   r73, L6
-  // from x in filtered
-  Const        r74, []
-  Const        r75, "__group__"
-  Const        r76, true
-  Const        r77, "key"
-  // group by x.part into g
-  Move         r78, r71
-  // from x in filtered
-  Const        r79, "items"
-  Move         r80, r74
-  MakeMap      r81, 3, r75
-  SetIndex     r65, r72, r81
-  Append       r82, r66, r81
-  Move         r66, r82
+  Const        r3, []
+  IterPrep     r4, r2
+  Len          r5, r4
+  Const        r7, 0
+  Move         r6, r7
 L6:
-  Const        r83, "items"
-  Index        r84, r65, r72
-  Index        r85, r84, r83
-  Append       r86, r85, r68
-  SetIndex     r84, r83, r86
-  Const        r88, 1
-  Move         r64, r88
-  Jump         L7
+  Less         r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r10, r4, r6
+  // join s in suppliers on s.id == ps.supplier
+  IterPrep     r11, r1
+  Len          r12, r11
+  Move         r13, r7
 L5:
-  Const        r89, 0
-  Len          r90, r66
-L10:
-  Less         r91, r89, r90
-  JumpIfFalse  r91, L8
-  Index        r92, r66, r89
-  Move         r93, r92
-  // total: sum(from r in g select r.value)
-  Const        r98, []
-  IterPrep     r99, r93
-  Len          r100, r99
-  Const        r101, 0
-L9:
-  Less         r102, r101, r100
-  JumpIfFalse  r102, L1
-  Append       r107, r98, r106
-  Move         r98, r107
-  Jump         L9
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r16, r11, r13
+  Const        r17, "id"
+  Index        r18, r16, r17
+  Const        r19, "supplier"
+  Index        r20, r10, r19
+  Equal        r21, r18, r20
+  JumpIfFalse  r21, L2
+  // join n in nations on n.id == s.nation
+  IterPrep     r22, r0
+  Len          r23, r22
+  Move         r24, r7
+L4:
+  Less         r25, r24, r23
+  JumpIfFalse  r25, L2
+  Index        r27, r22, r24
+  Index        r28, r27, r17
+  Const        r29, "nation"
+  Index        r30, r16, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L3
+  // where n.name == "A"
+  Const        r32, "name"
+  Index        r33, r27, r32
+  Const        r34, "A"
+  Equal        r35, r33, r34
+  JumpIfFalse  r35, L3
+  // part: ps.part,
+  Const        r36, "part"
+  Index        r37, r10, r36
+  // value: ps.cost * ps.qty
+  Const        r38, "value"
+  Const        r39, "cost"
+  // select {
+  MakeMap      r46, 2, r36
+  // from ps in partsupp
+  Append       r3, r3, r46
+L3:
+  // join n in nations on n.id == s.nation
+  Const        r48, 1
+  Add          r24, r24, r48
+  Jump         L4
+L2:
+  // join s in suppliers on s.id == ps.supplier
+  Add          r13, r13, r48
+  Jump         L5
+L1:
+  // from ps in partsupp
+  Add          r6, r6, r48
+  Jump         L6
+L0:
   // from x in filtered
-  Append       r116, r61, r115
-  Move         r61, r116
-  Const        r118, 1
-  Move         r89, r118
-  Jump         L10
+  Const        r50, []
+  IterPrep     r51, r3
+  Len          r52, r51
+  Const        r53, 0
+  MakeMap      r54, 0, r0
+  Const        r55, []
+L9:
+  Less         r56, r53, r52
+  JumpIfFalse  r56, L7
+  Index        r57, r51, r53
+  // group by x.part into g
+  Index        r59, r57, r36
+  Str          r60, r59
+  In           r61, r60, r54
+  JumpIfTrue   r61, L8
+  // from x in filtered
+  Const        r62, []
+  Const        r63, "__group__"
+  Const        r64, true
+  Const        r65, "key"
+  // group by x.part into g
+  Move         r66, r59
+  // from x in filtered
+  Const        r67, "items"
+  Move         r68, r62
+  MakeMap      r69, 3, r63
+  SetIndex     r54, r60, r69
+  Append       r55, r55, r69
 L8:
-  // let grouped =
-  Move         r119, r61
+  Index        r71, r54, r60
+  Index        r72, r71, r67
+  Append       r73, r72, r57
+  SetIndex     r71, r67, r73
+  Add          r53, r53, r48
+  Jump         L9
+L7:
+  Move         r75, r7
+  Len          r76, r55
+L13:
+  Less         r77, r75, r76
+  JumpIfFalse  r77, L10
+  Index        r79, r55, r75
+  // total: sum(from r in g select r.value)
+  Const        r82, []
+  IterPrep     r83, r79
+  Len          r84, r83
+  Const        r85, 0
+L12:
+  Less         r86, r85, r84
+  JumpIfFalse  r86, L11
+  Index        r88, r83, r85
+  Index        r89, r88, r38
+  Append       r82, r82, r89
+  Const        r91, 1
+  Add          r85, r85, r91
+  Jump         L12
+L11:
+  // select {
+  MakeMap      r96, 2, r36
+  // from x in filtered
+  Append       r50, r50, r96
+  Add          r75, r75, r48
+  Jump         L13
+L10:
   // print(grouped)
-  Print        r119
+  Print        r50
   Return       r0

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -1,241 +1,207 @@
-func main (regs=244)
+func main (regs=184)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
-  Move         r1, r0
   // let customer = [
-  Const        r2, [{"c_acctbal": 100, "c_address": "123 St", "c_comment": "Loyal", "c_custkey": 1, "c_name": "Alice", "c_nationkey": 1, "c_phone": "123-456"}]
-  Move         r3, r2
+  Const        r1, [{"c_acctbal": 100, "c_address": "123 St", "c_comment": "Loyal", "c_custkey": 1, "c_name": "Alice", "c_nationkey": 1, "c_phone": "123-456"}]
   // let orders = [
-  Const        r4, [{"o_custkey": 1, "o_orderdate": "1993-10-15", "o_orderkey": 1000}, {"o_custkey": 1, "o_orderdate": "1994-01-02", "o_orderkey": 2000}]
-  Move         r5, r4
+  Const        r2, [{"o_custkey": 1, "o_orderdate": "1993-10-15", "o_orderkey": 1000}, {"o_custkey": 1, "o_orderdate": "1994-01-02", "o_orderkey": 2000}]
   // let lineitem = [
-  Const        r6, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 1000, "l_returnflag": "R"}, {"l_discount": 0, "l_extendedprice": 500, "l_orderkey": 2000, "l_returnflag": "N"}]
-  Move         r7, r6
+  Const        r3, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 1000, "l_returnflag": "R"}, {"l_discount": 0, "l_extendedprice": 500, "l_orderkey": 2000, "l_returnflag": "N"}]
   // let start_date = "1993-10-01"
-  Const        r8, "1993-10-01"
-  Move         r9, r8
+  Const        r4, "1993-10-01"
   // let end_date = "1994-01-01"
-  Const        r10, "1994-01-01"
-  Move         r11, r10
+  Const        r5, "1994-01-01"
   // from c in customer
-  Const        r12, []
-  MakeMap      r13, 0, r0
-  Const        r14, []
-  IterPrep     r15, r3
+  Const        r6, []
+  MakeMap      r7, 0, r0
+  Const        r8, []
+  IterPrep     r9, r1
+  Len          r10, r9
+  Const        r11, 0
+L11:
+  Less         r12, r11, r10
+  JumpIfFalse  r12, L0
+  Index        r14, r9, r11
+  // join o in orders on o.o_custkey == c.c_custkey
+  IterPrep     r15, r2
   Len          r16, r15
   Const        r17, 0
-L8:
-  Less         r18, r17, r16
-  JumpIfFalse  r18, L0
-  Index        r19, r15, r17
-  Move         r20, r19
-  // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r21, r5
-  Len          r22, r21
-  Const        r23, 0
-L7:
-  Less         r24, r23, r22
-  JumpIfFalse  r24, L1
-  Index        r25, r21, r23
-  Move         r26, r25
-  Const        r27, "o_custkey"
-  Index        r28, r26, r27
-  Const        r29, "c_custkey"
-  Index        r30, r20, r29
-  Equal        r31, r28, r30
-  JumpIfFalse  r31, L1
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r32, r7
-  Len          r33, r32
-  Const        r34, 0
-L6:
-  Less         r35, r34, r33
-  JumpIfFalse  r35, L1
-  Index        r36, r32, r34
-  Move         r37, r36
-  Const        r38, "l_orderkey"
-  Index        r39, r37, r38
-  Const        r40, "o_orderkey"
-  Index        r41, r26, r40
-  Equal        r42, r39, r41
-  JumpIfFalse  r42, L1
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r43, r1
-  Len          r44, r43
-  Const        r45, 0
-L5:
-  Less         r46, r45, r44
-  JumpIfFalse  r46, L1
-  Index        r47, r43, r45
-  Move         r48, r47
-  Const        r49, "n_nationkey"
-  Index        r50, r48, r49
-  Const        r51, "c_nationkey"
-  Index        r52, r20, r51
-  Equal        r53, r50, r52
-  JumpIfFalse  r53, L1
-  // where o.o_orderdate >= start_date &&
-  Const        r54, "o_orderdate"
-  Index        r55, r26, r54
-  LessEq       r56, r9, r55
-  // o.o_orderdate < end_date &&
-  Const        r57, "o_orderdate"
-  Index        r58, r26, r57
-  Less         r59, r58, r11
-  // l.l_returnflag == "R"
-  Const        r60, "l_returnflag"
-  Index        r61, r37, r60
-  Const        r62, "R"
-  Equal        r63, r61, r62
-  // where o.o_orderdate >= start_date &&
-  Move         r64, r56
-  JumpIfFalse  r64, L2
-  Move         r64, r59
-L2:
-  // o.o_orderdate < end_date &&
-  Move         r65, r64
-  JumpIfFalse  r65, L3
-  Move         r65, r63
-L3:
-  // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r65, L1
-  // c_custkey: c.c_custkey,
-  Const        r75, "c_custkey"
-  Const        r76, "c_custkey"
-  Index        r77, r20, r76
-  // c_name: c.c_name,
-  Const        r78, "c_name"
-  Const        r79, "c_name"
-  Index        r80, r20, r79
-  // c_acctbal: c.c_acctbal,
-  Const        r81, "c_acctbal"
-  Const        r82, "c_acctbal"
-  Index        r83, r20, r82
-  // c_address: c.c_address,
-  Const        r84, "c_address"
-  Const        r85, "c_address"
-  Index        r86, r20, r85
-  // c_phone: c.c_phone,
-  Const        r87, "c_phone"
-  Const        r88, "c_phone"
-  Index        r89, r20, r88
-  // c_comment: c.c_comment,
-  Const        r90, "c_comment"
-  Const        r91, "c_comment"
-  Index        r92, r20, r91
-  // n_name: n.n_name
-  Const        r93, "n_name"
-  Const        r94, "n_name"
-  Index        r95, r48, r94
-  // c_custkey: c.c_custkey,
-  Move         r96, r75
-  Move         r97, r77
-  // c_name: c.c_name,
-  Move         r98, r78
-  Move         r99, r80
-  // c_acctbal: c.c_acctbal,
-  Move         r100, r81
-  Move         r101, r83
-  // c_address: c.c_address,
-  Move         r102, r84
-  Move         r103, r86
-  // c_phone: c.c_phone,
-  Move         r104, r87
-  Move         r105, r89
-  // c_comment: c.c_comment,
-  Move         r106, r90
-  Move         r107, r92
-  // n_name: n.n_name
-  Move         r108, r93
-  Move         r109, r95
-  // group by {
-  MakeMap      r110, 7, r96
-  Str          r111, r110
-  In           r112, r111, r13
-  JumpIfTrue   r112, L4
-  // from c in customer
-  Const        r113, []
-  Const        r114, "__group__"
-  Const        r115, true
-  Const        r116, "key"
-  // group by {
-  Move         r117, r110
-  // from c in customer
-  Const        r118, "items"
-  Move         r119, r113
-  MakeMap      r120, 3, r114
-  SetIndex     r13, r111, r120
-  Append       r121, r14, r120
-  Move         r14, r121
-L4:
-  Const        r122, "items"
-  Index        r123, r13, r111
-  Index        r124, r123, r122
-  Append       r125, r124, r74
-  SetIndex     r123, r122, r125
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  Const        r127, 1
-  Move         r45, r127
-  Jump         L5
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  Const        r129, 1
-  Move         r34, r129
-  Jump         L6
-  // join o in orders on o.o_custkey == c.c_custkey
-  Const        r131, 1
-  Move         r23, r131
-  Jump         L7
-  // from c in customer
-  Const        r133, 1
-  Move         r17, r133
-  Jump         L8
-L0:
-  Const        r134, 0
-  Len          r135, r14
-L12:
-  Less         r136, r134, r135
-  JumpIfFalse  r136, L9
-  Index        r137, r14, r134
-  Move         r138, r137
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r150, []
-  IterPrep     r151, r138
-  Len          r152, r151
-  Const        r153, 0
 L10:
-  Less         r154, r153, r152
-  JumpIfFalse  r154, L1
-  Append       r168, r150, r167
-  Move         r150, r168
-  Const        r170, 1
-  Move         r153, r170
-  Jump         L10
-  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r214, []
-  IterPrep     r215, r138
-  Len          r216, r215
-  Const        r217, 0
-L11:
-  Less         r218, r217, r216
-  JumpIfFalse  r218, L1
-  Append       r231, r214, r230
-  Move         r214, r231
-  Const        r233, 1
-  Move         r217, r233
-  Jump         L11
-  // from c in customer
-  Append       r239, r12, r238
-  Move         r12, r239
-  Const        r241, 1
-  Move         r134, r241
-  Jump         L12
+  Less         r18, r17, r16
+  JumpIfFalse  r18, L1
+  Index        r20, r15, r17
+  Const        r21, "o_custkey"
+  Index        r22, r20, r21
+  Const        r23, "c_custkey"
+  Index        r24, r14, r23
+  Equal        r25, r22, r24
+  JumpIfFalse  r25, L2
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  IterPrep     r26, r3
+  Len          r27, r26
+  Const        r28, 0
 L9:
-  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Sort         242,12,0,0
+  Less         r29, r28, r27
+  JumpIfFalse  r29, L2
+  Index        r30, r26, r28
+  Move         r31, r30
+  Const        r32, "l_orderkey"
+  Index        r33, r31, r32
+  Const        r34, "o_orderkey"
+  Index        r35, r20, r34
+  Equal        r36, r33, r35
+  JumpIfFalse  r36, L3
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  IterPrep     r37, r0
+  Len          r38, r37
+  Const        r39, 0
+L8:
+  Less         r40, r39, r38
+  JumpIfFalse  r40, L3
+  Index        r42, r37, r39
+  Const        r43, "n_nationkey"
+  Index        r44, r42, r43
+  Const        r45, "c_nationkey"
+  Index        r46, r14, r45
+  Equal        r47, r44, r46
+  JumpIfFalse  r47, L4
+  // where o.o_orderdate >= start_date &&
+  Const        r48, "o_orderdate"
+  Index        r49, r20, r48
+  LessEq       r50, r4, r49
+  // o.o_orderdate < end_date &&
+  Index        r51, r20, r48
+  Less         r52, r51, r5
+  // l.l_returnflag == "R"
+  Const        r53, "l_returnflag"
+  Index        r54, r31, r53
+  Const        r55, "R"
+  Equal        r56, r54, r55
+  // where o.o_orderdate >= start_date &&
+  Move         r57, r50
+  JumpIfFalse  r57, L5
+L5:
+  // o.o_orderdate < end_date &&
+  Move         r58, r52
+  JumpIfFalse  r58, L6
+  Move         r58, r56
+L6:
+  // where o.o_orderdate >= start_date &&
+  JumpIfFalse  r58, L4
   // from c in customer
-  Move         r12, r242
-  // let result =
-  Move         r243, r12
+  Const        r59, "c"
+  Move         r60, r14
+  Const        r61, "o"
+  Move         r62, r20
+  Const        r63, "l"
+  Move         r64, r31
+  Const        r65, "n"
+  Move         r66, r42
+  MakeMap      r67, 4, r59
+  // group by {
+  MakeMap      r88, 7, r23
+  Str          r89, r88
+  In           r90, r89, r7
+  JumpIfTrue   r90, L7
+  // from c in customer
+  Const        r91, []
+  Const        r92, "__group__"
+  Const        r93, true
+  Const        r94, "key"
+  // group by {
+  Move         r95, r88
+  // from c in customer
+  Const        r96, "items"
+  Move         r97, r91
+  MakeMap      r98, 3, r92
+  SetIndex     r7, r89, r98
+  Append       r8, r8, r98
+L7:
+  Index        r100, r7, r89
+  Index        r101, r100, r96
+  Append       r102, r101, r67
+  SetIndex     r100, r96, r102
+L4:
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  Const        r103, 1
+  Add          r39, r39, r103
+  Jump         L8
+L3:
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  Const        r105, 1
+  Add          r28, r28, r105
+  Jump         L9
+L2:
+  // join o in orders on o.o_custkey == c.c_custkey
+  Const        r107, 1
+  Add          r17, r17, r107
+  Jump         L10
+L1:
+  // from c in customer
+  Const        r109, 1
+  Add          r11, r11, r109
+  Jump         L11
+L0:
+  Const        r111, 0
+  Len          r113, r8
+L17:
+  Less         r114, r111, r113
+  JumpIfFalse  r114, L12
+  Index        r116, r8, r111
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Const        r122, []
+  IterPrep     r123, r116
+  Len          r124, r123
+  Const        r125, 0
+L14:
+  Less         r126, r125, r124
+  JumpIfFalse  r126, L13
+  Index        r128, r123, r125
+  Index        r129, r128, r63
+  Const        r130, "l_extendedprice"
+  Index        r131, r129, r130
+  Const        r132, 1
+  Index        r133, r128, r63
+  Const        r134, "l_discount"
+  Index        r135, r133, r134
+  Sub          r136, r132, r135
+  Mul          r137, r131, r136
+  Append       r122, r122, r137
+  Const        r139, 1
+  Add          r125, r125, r139
+  Jump         L14
+L13:
+  // select {
+  MakeMap      r160, 8, r23
+  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Const        r161, []
+  IterPrep     r162, r116
+  Len          r163, r162
+  Const        r164, 0
+L16:
+  Less         r165, r164, r163
+  JumpIfFalse  r165, L15
+  Index        r128, r162, r164
+  Index        r167, r128, r63
+  Index        r168, r167, r130
+  Index        r169, r128, r63
+  Index        r170, r169, r134
+  Sub          r171, r132, r170
+  Mul          r172, r168, r171
+  Append       r161, r161, r172
+  Jump         L16
+L15:
+  Sum          r176, r161
+  Neg          r178, r176
+  // from c in customer
+  Move         r179, r160
+  MakeList     r180, 2, r178
+  Append       r6, r6, r180
+  Add          r111, r111, r132
+  Jump         L17
+L12:
+  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Sort         r6, r6
   // print(result)
-  Print        r243
+  Print        r6
   Return       r0

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,92 +1,96 @@
-func main (regs=78)
+func main (regs=70)
   // let items = [
   Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
-  Move         r1, r0
   // from i in items
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
-  MakeMap      r6, 0, r0
-  Const        r7, []
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
+  MakeMap      r5, 0, r0
+  Const        r6, []
 L2:
-  Less         r8, r5, r4
-  JumpIfFalse  r8, L0
-  Index        r9, r3, r5
-  Move         r10, r9
+  Less         r7, r4, r3
+  JumpIfFalse  r7, L0
+  Index        r8, r2, r4
+  Move         r9, r8
   // group by i.cat into g
-  Const        r11, "cat"
-  Index        r12, r10, r11
-  Str          r13, r12
-  In           r14, r13, r6
-  JumpIfTrue   r14, L1
+  Const        r10, "cat"
+  Index        r11, r9, r10
+  Str          r12, r11
+  In           r13, r12, r5
+  JumpIfTrue   r13, L1
   // from i in items
-  Const        r15, []
-  Const        r16, "__group__"
-  Const        r17, true
-  Const        r18, "key"
+  Const        r14, []
+  Const        r15, "__group__"
+  Const        r16, true
+  Const        r17, "key"
   // group by i.cat into g
-  Move         r19, r12
+  Move         r18, r11
   // from i in items
-  Const        r20, "items"
-  Move         r21, r15
-  MakeMap      r22, 3, r16
-  SetIndex     r6, r13, r22
-  Append       r23, r7, r22
-  Move         r7, r23
+  Const        r19, "items"
+  Move         r20, r14
+  MakeMap      r21, 3, r15
+  SetIndex     r5, r12, r21
+  Append       r6, r6, r21
 L1:
-  Const        r24, "items"
-  Index        r25, r6, r13
-  Index        r26, r25, r24
-  Append       r27, r26, r9
-  SetIndex     r25, r24, r27
-  Const        r29, 1
-  Move         r5, r29
+  Index        r23, r5, r12
+  Index        r24, r23, r19
+  Append       r25, r24, r8
+  SetIndex     r23, r19, r25
+  Const        r26, 1
+  Add          r4, r4, r26
   Jump         L2
 L0:
-  Const        r30, 0
-  Len          r31, r7
-L7:
-  Less         r32, r30, r31
-  JumpIfFalse  r32, L3
-  Index        r33, r7, r30
-  Move         r34, r33
+  Const        r28, 0
+  Len          r30, r6
+L8:
+  Less         r31, r28, r30
+  JumpIfFalse  r31, L3
+  Index        r33, r6, r28
   // total: sum(from x in g select x.val)
-  Const        r39, []
-  IterPrep     r40, r34
-  Len          r41, r40
-  Const        r42, 0
+  Const        r36, []
+  IterPrep     r37, r33
+  Len          r38, r37
+  Const        r39, 0
 L5:
-  Less         r43, r42, r41
-  JumpIfFalse  r43, L4
-  Append       r48, r39, r47
-  Move         r39, r48
-  Const        r50, 1
-  Move         r42, r50
+  Less         r40, r39, r38
+  JumpIfFalse  r40, L4
+  Index        r42, r37, r39
+  Const        r43, "val"
+  Index        r44, r42, r43
+  Append       r36, r36, r44
+  Const        r46, 1
+  Add          r39, r39, r46
   Jump         L5
+L4:
+  // select {
+  MakeMap      r51, 2, r10
   // sort by -sum(from x in g select x.val)
-  IterPrep     r58, r34
-  Len          r59, r58
-  Const        r60, 0
-L6:
-  Less         r61, r60, r59
-  JumpIfFalse  r61, L4
-  Const        r67, 1
-  Move         r60, r67
-  Jump         L6
-  // from i in items
-  Append       r73, r2, r72
-  Move         r2, r73
-  Const        r75, 1
-  Move         r30, r75
+  Const        r52, []
+  IterPrep     r53, r33
+  Len          r54, r53
+  Const        r55, 0
+L7:
+  Less         r56, r55, r54
+  JumpIfFalse  r56, L6
+  Index        r42, r53, r55
+  Index        r58, r42, r43
+  Append       r52, r52, r58
+  Const        r60, 1
+  Add          r55, r55, r60
   Jump         L7
+L6:
+  Sum          r62, r52
+  Neg          r64, r62
+  // from i in items
+  Move         r65, r51
+  MakeList     r66, 2, r64
+  Append       r1, r1, r66
+  Add          r28, r28, r26
+  Jump         L8
 L3:
   // sort by -sum(from x in g select x.val)
-  Sort         76,2,0,0
-  // from i in items
-  Move         r2, r76
-  // let grouped =
-  Move         r77, r2
+  Sort         r1, r1
   // print(grouped)
-  Print        r77
+  Print        r1
   Return       r0

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -1,117 +1,109 @@
-func main (regs=90)
+func main (regs=79)
   // let data = [
   Const        r0, [{"tag": "a", "val": 1}, {"tag": "a", "val": 2}, {"tag": "b", "val": 3}]
-  Move         r1, r0
   // let groups = from d in data group by d.tag into g select g
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
-  MakeMap      r6, 0, r0
-  Const        r7, []
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
+  MakeMap      r5, 0, r0
+  Const        r6, []
 L2:
-  Less         r8, r5, r4
-  JumpIfFalse  r8, L0
-  Index        r9, r3, r5
-  Move         r10, r9
-  Const        r11, "tag"
-  Index        r12, r10, r11
-  Str          r13, r12
-  In           r14, r13, r6
-  JumpIfTrue   r14, L1
-  Const        r15, []
-  Const        r16, "__group__"
-  Const        r17, true
-  Const        r18, "key"
-  Move         r19, r12
-  Const        r20, "items"
-  Move         r21, r15
-  MakeMap      r22, 3, r16
-  SetIndex     r6, r13, r22
-  Append       r23, r7, r22
-  Move         r7, r23
+  Less         r7, r4, r3
+  JumpIfFalse  r7, L0
+  Index        r8, r2, r4
+  Move         r9, r8
+  Const        r10, "tag"
+  Index        r11, r9, r10
+  Str          r12, r11
+  In           r13, r12, r5
+  JumpIfTrue   r13, L1
+  Const        r14, []
+  Const        r15, "__group__"
+  Const        r16, true
+  Const        r17, "key"
+  Move         r18, r11
+  Const        r19, "items"
+  Move         r20, r14
+  MakeMap      r21, 3, r15
+  SetIndex     r5, r12, r21
+  Append       r6, r6, r21
 L1:
-  Const        r24, "items"
-  Index        r25, r6, r13
-  Index        r26, r25, r24
-  Append       r27, r26, r9
-  SetIndex     r25, r24, r27
-  Const        r29, 1
-  Move         r5, r29
+  Index        r23, r5, r12
+  Index        r24, r23, r19
+  Append       r25, r24, r8
+  SetIndex     r23, r19, r25
+  Const        r26, 1
+  Add          r4, r4, r26
   Jump         L2
 L0:
-  Const        r30, 0
-  Len          r31, r7
+  Const        r29, 0
+  Move         r28, r29
+  Len          r30, r6
 L4:
-  Less         r32, r30, r31
-  JumpIfFalse  r32, L3
-  Append       r35, r2, r34
-  Move         r2, r35
-  Const        r37, 1
-  Move         r30, r37
+  Less         r31, r28, r30
+  JumpIfFalse  r31, L3
+  Index        r33, r6, r28
+  Append       r1, r1, r33
+  Add          r28, r28, r26
   Jump         L4
 L3:
-  Move         r38, r2
   // var tmp = []
-  Const        r39, []
-  Move         r40, r39
+  Const        r37, []
   // for g in groups {
-  IterPrep     r41, r38
-  Len          r42, r41
-  Const        r43, 0
+  IterPrep     r38, r1
+  Len          r39, r38
+  Const        r40, 0
 L8:
-  Less         r44, r43, r42
-  JumpIfFalse  r44, L5
-  Index        r45, r41, r43
-  Move         r34, r45
+  Less         r41, r40, r39
+  JumpIfFalse  r41, L5
+  Index        r33, r38, r40
   // var total = 0
-  Const        r46, 0
-  Move         r47, r46
+  Move         r43, r29
   // for x in g.items {
-  Const        r48, "items"
-  Index        r49, r34, r48
-  IterPrep     r50, r49
-  Len          r51, r50
-  Const        r52, 0
+  Index        r44, r33, r19
+  IterPrep     r45, r44
+  Len          r46, r45
+  Const        r47, 0
 L7:
-  Less         r53, r52, r51
-  JumpIfFalse  r53, L6
-  Index        r54, r50, r52
-  Move         r55, r54
+  Less         r48, r47, r46
+  JumpIfFalse  r48, L6
+  Index        r50, r45, r47
   // total = total + x.val
-  Const        r56, "val"
-  Index        r57, r55, r56
-  Add          r58, r47, r57
-  Move         r47, r58
+  Const        r51, "val"
+  Index        r52, r50, r51
+  Add          r43, r43, r52
   // for x in g.items {
-  Const        r60, 1
-  Move         r52, r60
+  Const        r54, 1
+  Add          r47, r47, r54
   Jump         L7
+L6:
   // tmp = append(tmp, {tag: g.key, total: total})
-  Append       r70, r40, r69
-  Move         r40, r70
+  MakeMap      r60, 2, r10
+  Append       r37, r37, r60
   // for g in groups {
-  Const        r72, 1
-  Move         r43, r72
+  Const        r62, 1
+  Add          r40, r40, r62
   Jump         L8
 L5:
   // let result = from r in tmp sort by r.tag select r
-  Const        r73, []
-  IterPrep     r74, r40
-  Len          r75, r74
-  Const        r76, 0
+  Const        r64, []
+  IterPrep     r65, r37
+  Len          r66, r65
+  Const        r67, 0
 L10:
-  Less         r77, r76, r75
-  JumpIfFalse  r77, L9
-  Append       r85, r73, r84
-  Move         r73, r85
-  Const        r87, 1
-  Move         r76, r87
+  Less         r68, r67, r66
+  JumpIfFalse  r68, L9
+  Index        r70, r65, r67
+  Index        r72, r70, r10
+  Move         r73, r70
+  MakeList     r74, 2, r72
+  Append       r64, r64, r74
+  Const        r76, 1
+  Add          r67, r67, r76
   Jump         L10
 L9:
-  Sort         88,73,0,0
-  Move         r73, r88
-  Move         r89, r73
+  Sort         r64, r64
   // print(result)
-  Print        r89
+  Print        r64
   Return       r0

--- a/tests/vm/valid/if_else.ir.out
+++ b/tests/vm/valid/if_else.ir.out
@@ -1,13 +1,13 @@
-func main (regs=6)
+func main (regs=5)
   // let x = 5
   Const        r0, 5
   // print("big")
-  Const        r4, "big"
-  Print        r4
+  Const        r3, "big"
+  Print        r3
   // if x > 3 {
   Jump         L0
   // print("small")
-  Const        r5, "small"
-  Print        r5
+  Const        r4, "small"
+  Print        r4
 L0:
   Return       r0

--- a/tests/vm/valid/in_operator.ir.out
+++ b/tests/vm/valid/in_operator.ir.out
@@ -1,14 +1,13 @@
-func main (regs=7)
+func main (regs=6)
   // let xs = [1, 2, 3]
   Const        r0, [1, 2, 3]
-  Move         r1, r0
   // print(2 in xs)
-  Const        r2, 2
-  In           r3, r2, r1
-  Print        r3
+  Const        r1, 2
+  In           r2, r1, r0
+  Print        r2
   // print(!(5 in xs))
-  Const        r4, 5
-  In           r5, r4, r1
-  Not          r6, r5
-  Print        r6
+  Const        r3, 5
+  In           r4, r3, r0
+  Not          r5, r4
+  Print        r5
   Return       r0

--- a/tests/vm/valid/in_operator_extended.ir.out
+++ b/tests/vm/valid/in_operator_extended.ir.out
@@ -1,57 +1,50 @@
-func main (regs=33)
+func main (regs=27)
   // let xs = [1, 2, 3]
   Const        r0, [1, 2, 3]
-  Move         r1, r0
   // let ys = from x in xs where x % 2 == 1 select x
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L2:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Index        r7, r3, r5
-  Move         r8, r7
-  Const        r9, 2
-  Mod          r10, r8, r9
-  Const        r11, 1
-  Equal        r12, r10, r11
-  JumpIfFalse  r12, L1
-  Append       r13, r2, r8
-  Move         r2, r13
-  Const        r15, 1
-  Move         r5, r15
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
+  Const        r8, 2
+  Mod          r9, r7, r8
+  Const        r10, 1
+  Equal        r11, r9, r10
+  JumpIfFalse  r11, L1
+  Append       r1, r1, r7
+L1:
+  Const        r13, 1
+  Add          r4, r4, r13
   Jump         L2
 L0:
-  Move         r16, r2
   // print(1 in ys)
-  Const        r17, 1
-  In           r18, r17, r16
-  Print        r18
+  In           r15, r10, r1
+  Print        r15
   // print(2 in ys)
-  Const        r19, 2
-  In           r20, r19, r16
-  Print        r20
+  In           r16, r8, r1
+  Print        r16
   // let m = {a: 1}
-  Const        r21, {"a": 1}
-  Move         r22, r21
+  Const        r17, {"a": 1}
   // print("a" in m)
-  Const        r23, "a"
+  Const        r18, "a"
+  In           r19, r18, r17
+  Print        r19
+  // print("b" in m)
+  Const        r20, "b"
+  In           r21, r20, r17
+  Print        r21
+  // let s = "hello"
+  Const        r22, "hello"
+  // print("ell" in s)
+  Const        r23, "ell"
   In           r24, r23, r22
   Print        r24
-  // print("b" in m)
-  Const        r25, "b"
+  // print("foo" in s)
+  Const        r25, "foo"
   In           r26, r25, r22
   Print        r26
-  // let s = "hello"
-  Const        r27, "hello"
-  Move         r28, r27
-  // print("ell" in s)
-  Const        r29, "ell"
-  In           r30, r29, r28
-  Print        r30
-  // print("foo" in s)
-  Const        r31, "foo"
-  In           r32, r31, r28
-  Print        r32
   Return       r0

--- a/tests/vm/valid/inner_join.ir.out
+++ b/tests/vm/valid/inner_join.ir.out
@@ -1,82 +1,75 @@
-func main (regs=68)
+func main (regs=54)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}, {"customerId": 4, "id": 103, "total": 80}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}, {"customerId": 4, "id": 103, "total": 80}]
   // let result = from o in orders
-  Const        r4, []
-  IterPrep     r5, r3
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  // join from c in customers on o.customerId == c.id
+  IterPrep     r5, r0
   Len          r6, r5
-  // join from c in customers on o.customerId == c.id
-  IterPrep     r7, r1
-  Len          r8, r7
   // let result = from o in orders
-  Const        r9, 0
-L3:
-  Less         r10, r9, r6
-  JumpIfFalse  r10, L0
-  Index        r11, r5, r9
-  Move         r12, r11
-  // join from c in customers on o.customerId == c.id
-  Const        r13, 0
-L2:
-  Less         r14, r13, r8
-  JumpIfFalse  r14, L1
-  Index        r15, r7, r13
-  Move         r16, r15
-  Const        r17, "customerId"
-  Index        r18, r12, r17
-  Const        r19, "id"
-  Index        r20, r16, r19
-  Equal        r21, r18, r20
-  JumpIfFalse  r21, L1
-  // let result = from o in orders
-  Append       r38, r4, r37
-  Move         r4, r38
-  // join from c in customers on o.customerId == c.id
-  Const        r40, 1
-  Move         r13, r40
-  Jump         L2
-  // let result = from o in orders
-  Const        r42, 1
-  Move         r9, r42
-  Jump         L3
-L0:
-  Move         r43, r4
-  // print("--- Orders with customer info ---")
-  Const        r44, "--- Orders with customer info ---"
-  Print        r44
-  // for entry in result {
-  IterPrep     r45, r43
-  Len          r46, r45
-  Const        r47, 0
-L5:
-  Less         r48, r47, r46
-  JumpIfFalse  r48, L4
-  Index        r49, r45, r47
-  Move         r50, r49
-  // print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
-  Const        r57, "Order"
-  Move         r51, r57
-  Const        r58, "orderId"
-  Index        r59, r50, r58
-  Move         r52, r59
-  Const        r60, "by"
-  Move         r53, r60
-  Const        r61, "customerName"
-  Index        r62, r50, r61
-  Move         r54, r62
-  Const        r63, "- $"
-  Move         r55, r63
-  Const        r64, "total"
-  Index        r65, r50, r64
-  Move         r56, r65
-  PrintN       r51, 6, r51
-  // for entry in result {
-  Const        r67, 1
-  Move         r47, r67
-  Jump         L5
+  Const        r7, 0
 L4:
+  Less         r8, r7, r4
+  JumpIfFalse  r8, L0
+  Index        r10, r3, r7
+  // join from c in customers on o.customerId == c.id
+  Const        r11, 0
+L3:
+  Less         r12, r11, r6
+  JumpIfFalse  r12, L1
+  Index        r14, r5, r11
+  Const        r15, "customerId"
+  Index        r16, r10, r15
+  Const        r17, "id"
+  Index        r18, r14, r17
+  Equal        r19, r16, r18
+  JumpIfFalse  r19, L2
+  // select { orderId: o.id, customerName: c.name, total: o.total }
+  Const        r20, "orderId"
+  Index        r21, r10, r17
+  Const        r22, "customerName"
+  Const        r23, "name"
+  Index        r24, r14, r23
+  Const        r25, "total"
+  MakeMap      r30, 3, r20
+  // let result = from o in orders
+  Append       r2, r2, r30
+L2:
+  // join from c in customers on o.customerId == c.id
+  Const        r32, 1
+  Add          r11, r11, r32
+  Jump         L3
+L1:
+  // let result = from o in orders
+  Add          r7, r7, r32
+  Jump         L4
+L0:
+  // print("--- Orders with customer info ---")
+  Const        r33, "--- Orders with customer info ---"
+  Print        r33
+  // for entry in result {
+  IterPrep     r34, r2
+  Len          r35, r34
+  Const        r36, 0
+L6:
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L5
+  Index        r39, r34, r36
+  // print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
+  Const        r40, "Order"
+  Index        r41, r39, r20
+  Const        r42, "by"
+  Index        r43, r39, r22
+  Const        r44, "- $"
+  Index        r45, r39, r25
+  PrintN       r40, 6, r40
+  // for entry in result {
+  Const        r52, 1
+  Add          r36, r36, r52
+  Jump         L6
+L5:
   Return       r0

--- a/tests/vm/valid/join_multi.ir.out
+++ b/tests/vm/valid/join_multi.ir.out
@@ -1,93 +1,88 @@
-func main (regs=71)
+func main (regs=57)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100}, {"customerId": 2, "id": 101}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 2, "id": 101}]
   // let items = [
-  Const        r4, [{"orderId": 100, "sku": "a"}, {"orderId": 101, "sku": "b"}]
-  Move         r5, r4
+  Const        r2, [{"orderId": 100, "sku": "a"}, {"orderId": 101, "sku": "b"}]
   // let result = from o in orders
-  Const        r6, []
-  IterPrep     r7, r3
-  Len          r8, r7
-  Const        r9, 0
-L4:
-  Less         r10, r9, r8
-  JumpIfFalse  r10, L0
-  Index        r11, r7, r9
-  Move         r12, r11
-  // join from c in customers on o.customerId == c.id
-  IterPrep     r13, r1
-  Len          r14, r13
-  Const        r15, 0
-L3:
-  Less         r16, r15, r14
-  JumpIfFalse  r16, L1
-  Index        r17, r13, r15
-  Move         r18, r17
-  Const        r19, "customerId"
-  Index        r20, r12, r19
-  Const        r21, "id"
-  Index        r22, r18, r21
-  Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
-  // join from i in items on o.id == i.orderId
-  IterPrep     r24, r5
-  Len          r25, r24
-  Const        r26, 0
-L2:
-  Less         r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r28, r24, r26
-  Move         r29, r28
-  Const        r30, "id"
-  Index        r31, r12, r30
-  Const        r32, "orderId"
-  Index        r33, r29, r32
-  Equal        r34, r31, r33
-  JumpIfFalse  r34, L1
-  // let result = from o in orders
-  Append       r46, r6, r45
-  Move         r6, r46
-  // join from i in items on o.id == i.orderId
-  Const        r48, 1
-  Move         r26, r48
-  Jump         L2
-  // join from c in customers on o.customerId == c.id
-  Const        r50, 1
-  Move         r15, r50
-  Jump         L3
-  // let result = from o in orders
-  Const        r52, 1
-  Move         r9, r52
-  Jump         L4
-L0:
-  Move         r53, r6
-  // print("--- Multi Join ---")
-  Const        r54, "--- Multi Join ---"
-  Print        r54
-  // for r in result {
-  IterPrep     r55, r53
-  Len          r56, r55
-  Const        r57, 0
+  Const        r3, []
+  IterPrep     r4, r1
+  Len          r5, r4
+  Const        r7, 0
+  Move         r6, r7
 L6:
-  Less         r58, r57, r56
-  JumpIfFalse  r58, L5
-  Index        r59, r55, r57
-  Move         r60, r59
-  // print(r.name, "bought item", r.sku)
-  Const        r64, "name"
-  Index        r65, r60, r64
-  Move         r61, r65
-  Const        r66, "bought item"
-  Move         r62, r66
-  Const        r67, "sku"
-  Index        r68, r60, r67
-  Move         r63, r68
-  PrintN       r61, 3, r61
-  // for r in result {
-  Jump         L6
+  Less         r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r10, r4, r6
+  // join from c in customers on o.customerId == c.id
+  IterPrep     r11, r0
+  Len          r12, r11
+  Move         r13, r7
 L5:
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r16, r11, r13
+  Const        r17, "customerId"
+  Index        r18, r10, r17
+  Const        r19, "id"
+  Index        r20, r16, r19
+  Equal        r21, r18, r20
+  JumpIfFalse  r21, L2
+  // join from i in items on o.id == i.orderId
+  IterPrep     r22, r2
+  Len          r23, r22
+  Move         r24, r7
+L4:
+  Less         r25, r24, r23
+  JumpIfFalse  r25, L2
+  Index        r27, r22, r24
+  Index        r28, r10, r19
+  Const        r29, "orderId"
+  Index        r30, r27, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L3
+  // select { name: c.name, sku: i.sku }
+  Const        r32, "name"
+  Index        r33, r16, r32
+  Const        r34, "sku"
+  Index        r35, r27, r34
+  MakeMap      r38, 2, r32
+  // let result = from o in orders
+  Append       r3, r3, r38
+L3:
+  // join from i in items on o.id == i.orderId
+  Const        r40, 1
+  Add          r24, r24, r40
+  Jump         L4
+L2:
+  // join from c in customers on o.customerId == c.id
+  Add          r13, r13, r40
+  Jump         L5
+L1:
+  // let result = from o in orders
+  Add          r6, r6, r40
+  Jump         L6
+L0:
+  // print("--- Multi Join ---")
+  Const        r42, "--- Multi Join ---"
+  Print        r42
+  // for r in result {
+  IterPrep     r43, r3
+  Len          r44, r43
+  Const        r45, 0
+L8:
+  Less         r46, r45, r44
+  JumpIfFalse  r46, L7
+  Index        r48, r43, r45
+  // print(r.name, "bought item", r.sku)
+  Index        r49, r48, r32
+  Const        r50, "bought item"
+  Index        r51, r48, r34
+  PrintN       r49, 3, r49
+  // for r in result {
+  Const        r55, 1
+  Add          r45, r45, r55
+  Jump         L8
+L7:
   Return       r0

--- a/tests/vm/valid/json_builtin.ir.out
+++ b/tests/vm/valid/json_builtin.ir.out
@@ -1,7 +1,6 @@
-func main (regs=2)
+func main (regs=1)
   // let m = {a: 1, b: 2}
   Const        r0, {"a": 1, "b": 2}
-  Move         r1, r0
   // json(m)
-  JSON         r1
+  JSON         r0
   Return       r0

--- a/tests/vm/valid/left_join.ir.out
+++ b/tests/vm/valid/left_join.ir.out
@@ -1,110 +1,111 @@
-func main (regs=99)
+func main (regs=69)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 3, "id": 101, "total": 80}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 3, "id": 101, "total": 80}]
   // let result = from o in orders
-  Const        r4, []
-  IterPrep     r5, r3
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  // left join c in customers on o.customerId == c.id
+  IterPrep     r5, r0
   Len          r6, r5
-  // left join c in customers on o.customerId == c.id
-  IterPrep     r7, r1
-  Len          r8, r7
   // let result = from o in orders
-  Const        r9, 0
-L3:
-  Less         r10, r9, r6
-  JumpIfFalse  r10, L0
-  Index        r11, r5, r9
-  Move         r12, r11
-  // left join c in customers on o.customerId == c.id
-  Const        r13, 0
-L2:
-  Less         r14, r13, r8
-  JumpIfFalse  r14, L1
-  Index        r15, r7, r13
-  Move         r16, r15
-  Const        r17, "customerId"
-  Index        r18, r12, r17
-  Const        r19, "id"
-  Index        r20, r16, r19
-  Equal        r21, r18, r20
-  JumpIfFalse  r21, L1
-  // let result = from o in orders
-  Append       r36, r4, r35
-  Move         r4, r36
-  // left join c in customers on o.customerId == c.id
-  Const        r38, 1
-  Move         r13, r38
-  Jump         L2
-  // let result = from o in orders
-  Const        r40, 1
-  Move         r9, r40
-  Jump         L3
-L0:
-  Const        r41, 0
-L6:
-  Less         r42, r41, r6
-  JumpIfFalse  r42, L4
-  Index        r43, r5, r41
-  Move         r12, r43
-  // left join c in customers on o.customerId == c.id
-  Const        r45, 0
-L5:
-  Less         r46, r45, r8
-  JumpIfFalse  r46, L1
-  Index        r47, r7, r45
-  Move         r16, r47
-  Const        r48, "customerId"
-  Index        r49, r12, r48
-  Const        r50, "id"
-  Index        r51, r16, r50
-  Equal        r52, r49, r51
-  JumpIfFalse  r52, L1
-  Const        r54, 1
-  Move         r45, r54
-  Jump         L5
-  // let result = from o in orders
-  Jump         L1
-  Append       r71, r4, r70
-  Move         r4, r71
-  Jump         L6
+  Const        r7, 0
 L4:
-  Move         r74, r4
-  // print("--- Left Join ---")
-  Const        r75, "--- Left Join ---"
-  Print        r75
-  // for entry in result {
-  IterPrep     r76, r74
-  Len          r77, r76
-  Const        r78, 0
+  Less         r8, r7, r4
+  JumpIfFalse  r8, L0
+  Index        r10, r3, r7
+  // left join c in customers on o.customerId == c.id
+  Const        r11, 0
+L3:
+  Less         r12, r11, r6
+  JumpIfFalse  r12, L1
+  Index        r14, r5, r11
+  Const        r15, "customerId"
+  Index        r16, r10, r15
+  Const        r17, "id"
+  Index        r18, r14, r17
+  Equal        r19, r16, r18
+  JumpIfFalse  r19, L2
+  // orderId: o.id,
+  Const        r20, "orderId"
+  Index        r21, r10, r17
+  // customer: c,
+  Const        r22, "customer"
+  // total: o.total
+  Const        r23, "total"
+  Index        r24, r10, r23
+  // orderId: o.id,
+  Move         r25, r21
+  // select {
+  MakeMap      r28, 3, r20
+  // let result = from o in orders
+  Append       r2, r2, r28
+L2:
+  // left join c in customers on o.customerId == c.id
+  Const        r30, 1
+  Add          r11, r11, r30
+  Jump         L3
+L1:
+  // let result = from o in orders
+  Add          r7, r7, r30
+  Jump         L4
+L0:
+  Const        r31, 0
+L10:
+  Less         r32, r31, r4
+  JumpIfFalse  r32, L5
+  Index        r10, r3, r31
+  Const        r34, false
+  // left join c in customers on o.customerId == c.id
+  Const        r35, 0
 L8:
-  Less         r79, r78, r77
-  JumpIfFalse  r79, L7
-  Index        r80, r76, r78
-  Move         r81, r80
-  // print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
-  Const        r88, "Order"
-  Move         r82, r88
-  Const        r89, "orderId"
-  Index        r90, r81, r89
-  Move         r83, r90
-  Const        r91, "customer"
-  Move         r84, r91
-  Const        r92, "customer"
-  Index        r93, r81, r92
-  Move         r85, r93
-  Const        r94, "total"
-  Move         r86, r94
-  Const        r95, "total"
-  Index        r96, r81, r95
-  Move         r87, r96
-  PrintN       r82, 6, r82
-  // for entry in result {
-  Const        r98, 1
-  Move         r78, r98
-  Jump         L8
+  Less         r36, r35, r6
+  JumpIfFalse  r36, L6
+  Index        r14, r5, r35
+  Index        r38, r10, r15
+  Index        r39, r14, r17
+  Equal        r40, r38, r39
+  JumpIfFalse  r40, L7
+  Const        r34, true
 L7:
+  Add          r35, r35, r30
+  Jump         L8
+L6:
+  // let result = from o in orders
+  Move         r41, r34
+  JumpIfTrue   r41, L9
+  // select {
+  MakeMap      r48, 3, r20
+  // let result = from o in orders
+  Append       r2, r2, r48
+L9:
+  Add          r31, r31, r30
+  Jump         L10
+L5:
+  // print("--- Left Join ---")
+  Const        r50, "--- Left Join ---"
+  Print        r50
+  // for entry in result {
+  IterPrep     r51, r2
+  Len          r52, r51
+  Const        r53, 0
+L12:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L11
+  Index        r56, r51, r53
+  // print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+  Const        r57, "Order"
+  Index        r58, r56, r20
+  Move         r59, r22
+  Index        r60, r56, r22
+  Move         r61, r23
+  Index        r62, r56, r23
+  PrintN       r57, 6, r57
+  // for entry in result {
+  Const        r67, 1
+  Add          r53, r53, r67
+  Jump         L12
+L11:
   Return       r0

--- a/tests/vm/valid/left_join_multi.ir.out
+++ b/tests/vm/valid/left_join_multi.ir.out
@@ -1,100 +1,97 @@
-func main (regs=93)
+func main (regs=68)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100}, {"customerId": 2, "id": 101}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 2, "id": 101}]
   // let items = [
-  Const        r4, [{"orderId": 100, "sku": "a"}]
-  Move         r5, r4
+  Const        r2, [{"orderId": 100, "sku": "a"}]
   // let result = from o in orders
-  Const        r6, []
-  IterPrep     r7, r3
-  Len          r8, r7
-  Const        r9, 0
-L4:
-  Less         r10, r9, r8
-  JumpIfFalse  r10, L0
-  Index        r11, r7, r9
-  Move         r12, r11
+  Const        r3, []
+  IterPrep     r4, r1
+  Len          r5, r4
+  Const        r7, 0
+  Move         r6, r7
+L7:
+  Less         r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r10, r4, r6
   // join from c in customers on o.customerId == c.id
-  IterPrep     r13, r1
-  Len          r14, r13
-  Const        r15, 0
-L3:
-  Less         r16, r15, r14
-  JumpIfFalse  r16, L1
-  Index        r17, r13, r15
-  Move         r18, r17
-  Const        r19, "customerId"
-  Index        r20, r12, r19
-  Const        r21, "id"
-  Index        r22, r18, r21
-  Equal        r23, r20, r22
-  JumpIfFalse  r23, L1
-  // left join i in items on o.id == i.orderId
-  IterPrep     r24, r5
-  Len          r25, r24
-  Const        r26, 0
-L2:
-  Less         r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r28, r24, r26
-  Move         r29, r28
-  Const        r31, "id"
-  Index        r32, r12, r31
-  Const        r33, "orderId"
-  Index        r34, r29, r33
-  Equal        r35, r32, r34
-  JumpIfFalse  r35, L1
-  // let result = from o in orders
-  Append       r50, r6, r49
-  Move         r6, r50
-  // left join i in items on o.id == i.orderId
-  Const        r52, 1
-  Move         r26, r52
-  Jump         L2
-  Jump         L1
-  // let result = from o in orders
-  Append       r69, r6, r68
-  Move         r6, r69
-  // join from c in customers on o.customerId == c.id
-  Const        r71, 1
-  Move         r15, r71
-  Jump         L3
-  // let result = from o in orders
-  Const        r73, 1
-  Move         r9, r73
-  Jump         L4
-L0:
-  Move         r74, r6
-  // print("--- Left Join Multi ---")
-  Const        r75, "--- Left Join Multi ---"
-  Print        r75
-  // for r in result {
-  IterPrep     r76, r74
-  Len          r77, r76
-  Const        r78, 0
+  IterPrep     r11, r0
+  Len          r12, r11
+  Move         r13, r7
 L6:
-  Less         r79, r78, r77
-  JumpIfFalse  r79, L5
-  Index        r80, r76, r78
-  Move         r81, r80
-  // print(r.orderId, r.name, r.item)
-  Const        r85, "orderId"
-  Index        r86, r81, r85
-  Move         r82, r86
-  Const        r87, "name"
-  Index        r88, r81, r87
-  Move         r83, r88
-  Const        r89, "item"
-  Index        r90, r81, r89
-  Move         r84, r90
-  PrintN       r82, 3, r82
-  // for r in result {
-  Const        r92, 1
-  Move         r78, r92
-  Jump         L6
+  Less         r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r16, r11, r13
+  Const        r17, "customerId"
+  Index        r18, r10, r17
+  Const        r19, "id"
+  Index        r20, r16, r19
+  Equal        r21, r18, r20
+  JumpIfFalse  r21, L2
+  // left join i in items on o.id == i.orderId
+  IterPrep     r22, r2
+  Len          r23, r22
+  Move         r24, r7
 L5:
+  Less         r25, r24, r23
+  JumpIfFalse  r25, L3
+  Index        r27, r22, r24
+  Const        r28, false
+  Index        r29, r10, r19
+  Const        r30, "orderId"
+  Index        r31, r27, r30
+  Equal        r32, r29, r31
+  JumpIfFalse  r32, L4
+  Const        r28, true
+  // select { orderId: o.id, name: c.name, item: i }
+  Index        r33, r10, r19
+  Const        r34, "name"
+  Index        r35, r16, r34
+  Const        r36, "item"
+  MakeMap      r40, 3, r30
+  // let result = from o in orders
+  Append       r3, r3, r40
+L4:
+  // left join i in items on o.id == i.orderId
+  Const        r42, 1
+  Add          r24, r24, r42
+  Jump         L5
+L3:
+  Move         r43, r28
+  JumpIfTrue   r43, L2
+  // select { orderId: o.id, name: c.name, item: i }
+  MakeMap      r50, 3, r30
+  // let result = from o in orders
+  Append       r3, r3, r50
+L2:
+  // join from c in customers on o.customerId == c.id
+  Add          r13, r13, r42
+  Jump         L6
+L1:
+  // let result = from o in orders
+  Add          r6, r6, r42
+  Jump         L7
+L0:
+  // print("--- Left Join Multi ---")
+  Const        r53, "--- Left Join Multi ---"
+  Print        r53
+  // for r in result {
+  IterPrep     r54, r3
+  Len          r55, r54
+  Const        r56, 0
+L9:
+  Less         r57, r56, r55
+  JumpIfFalse  r57, L8
+  Index        r59, r54, r56
+  // print(r.orderId, r.name, r.item)
+  Index        r60, r59, r30
+  Index        r61, r59, r34
+  Index        r62, r59, r36
+  PrintN       r60, 3, r60
+  // for r in result {
+  Const        r66, 1
+  Add          r56, r56, r66
+  Jump         L9
+L8:
   Return       r0

--- a/tests/vm/valid/len_builtin.ir.out
+++ b/tests/vm/valid/len_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(len([1,2,3]))
   Const        r0, [1, 2, 3]
-  Len          r1, r0
+  Const        r1, 3
   Print        r1
   Return       r0

--- a/tests/vm/valid/len_map.ir.out
+++ b/tests/vm/valid/len_map.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(len({"a":1, "b":2}))
   Const        r0, {"a": 1, "b": 2}
-  Len          r1, r0
+  Const        r1, 2
   Print        r1
   Return       r0

--- a/tests/vm/valid/let_and_print.ir.out
+++ b/tests/vm/valid/let_and_print.ir.out
@@ -1,7 +1,7 @@
-func main (regs=5)
+func main (regs=3)
   // let a = 10
   Const        r0, 10
   // print(a + b)
-  Const        r4, 30
-  Print        r4
+  Const        r2, 30
+  Print        r2
   Return       r0

--- a/tests/vm/valid/list_assign.ir.out
+++ b/tests/vm/valid/list_assign.ir.out
@@ -1,4 +1,4 @@
-func main (regs=6)
+func main (regs=5)
   // var nums = [1, 2]
   Const        r0, [1, 2]
   Move         r1, r0
@@ -7,7 +7,6 @@ func main (regs=6)
   Const        r3, 3
   SetIndex     r1, r2, r3
   // print(nums[1])
-  Const        r4, 1
-  Index        r5, r1, r4
-  Print        r5
+  Const        r4, 2
+  Print        r4
   Return       r0

--- a/tests/vm/valid/list_index.ir.out
+++ b/tests/vm/valid/list_index.ir.out
@@ -1,9 +1,7 @@
-func main (regs=4)
+func main (regs=3)
   // let xs = [10, 20, 30]
   Const        r0, [10, 20, 30]
-  Move         r1, r0
   // print(xs[1])
-  Const        r2, 1
-  Index        r3, r1, r2
-  Print        r3
+  Const        r2, 20
+  Print        r2
   Return       r0

--- a/tests/vm/valid/list_nested_assign.ir.out
+++ b/tests/vm/valid/list_nested_assign.ir.out
@@ -1,17 +1,12 @@
-func main (regs=10)
+func main (regs=8)
   // var matrix = [[1,2],[3,4]]
   Const        r0, [[1, 2], [3, 4]]
-  Move         r1, r0
   // matrix[1][0] = 5
-  Const        r2, 1
-  Index        r3, r1, r2
+  Const        r3, [3, 4]
   Const        r4, 0
   Const        r5, 5
   SetIndex     r3, r4, r5
   // print(matrix[1][0])
-  Const        r6, 1
-  Index        r7, r1, r6
-  Const        r8, 0
-  Index        r9, r7, r8
-  Print        r9
+  Const        r7, 3
+  Print        r7
   Return       r0

--- a/tests/vm/valid/list_set_ops.ir.out
+++ b/tests/vm/valid/list_set_ops.ir.out
@@ -17,7 +17,7 @@ func main (regs=13)
   // print(len([1,2] union all [2,3]))
   Const        r9, [1, 2]
   Const        r10, [2, 3]
-  Union        r11, r9, r10
+  UnionAll     r11, r9, r10
   Len          r12, r11
   Print        r12
   Return       r0

--- a/tests/vm/valid/load_yaml.ir.out
+++ b/tests/vm/valid/load_yaml.ir.out
@@ -1,50 +1,49 @@
-func main (regs=43)
+func main (regs=35)
   // let people = load "../interpreter/valid/people.yaml" as Person with { format: "yaml" }
   Const        r0, "../interpreter/valid/people.yaml"
-  Const        r2, {"format": "yaml"}
-  Move         r1, r2
+  Const        r1, {"format": "yaml"}
   Load         3,0,1,0
-  Move         r4, r3
   // let adults = from p in people
-  Const        r5, []
-  IterPrep     r6, r4
-  Len          r7, r6
-  Const        r8, 0
+  Const        r4, []
+  IterPrep     r5, r3
+  Len          r6, r5
+  Const        r7, 0
 L2:
-  Less         r9, r8, r7
-  JumpIfFalse  r9, L0
-  Index        r10, r6, r8
-  Move         r11, r10
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r10, r5, r7
   // where p.age >= 18
-  Const        r12, "age"
-  Index        r13, r11, r12
-  Const        r14, 18
-  LessEq       r15, r14, r13
-  JumpIfFalse  r15, L1
+  Const        r11, "age"
+  Index        r12, r10, r11
+  Const        r13, 18
+  LessEq       r14, r13, r12
+  JumpIfFalse  r14, L1
+  // select { name: p.name, email: p.email }
+  Const        r15, "name"
+  Index        r16, r10, r15
+  Const        r17, "email"
+  Index        r18, r10, r17
+  MakeMap      r21, 2, r15
   // let adults = from p in people
-  Append       r27, r5, r26
-  Move         r5, r27
-  Const        r29, 1
-  Move         r8, r29
+  Append       r4, r4, r21
+L1:
   Jump         L2
 L0:
-  Move         r30, r5
   // for a in adults {
-  IterPrep     r31, r30
-  Len          r32, r31
-  Const        r33, 0
+  IterPrep     r25, r4
+  Len          r26, r25
+  Const        r27, 0
 L4:
-  Less         r34, r33, r32
-  JumpIfFalse  r34, L3
-  Index        r35, r31, r33
-  Move         r36, r35
+  Less         r28, r27, r26
+  JumpIfFalse  r28, L3
+  Index        r30, r25, r27
   // print(a.name, a.email)
-  Const        r37, "name"
-  Index        r38, r36, r37
-  Const        r39, "email"
-  Index        r40, r36, r39
-  Print2       r38, r40
+  Index        r31, r30, r15
+  Index        r32, r30, r17
+  Print2       r31, r32
   // for a in adults {
+  Const        r33, 1
+  Add          r27, r27, r33
   Jump         L4
 L3:
   Return       r0

--- a/tests/vm/valid/map_assign.ir.out
+++ b/tests/vm/valid/map_assign.ir.out
@@ -1,4 +1,4 @@
-func main (regs=6)
+func main (regs=5)
   // var scores = {"alice": 1}
   Const        r0, {"alice": 1}
   Move         r1, r0
@@ -7,7 +7,6 @@ func main (regs=6)
   Const        r3, 2
   SetIndex     r1, r2, r3
   // print(scores["bob"])
-  Const        r4, "bob"
-  Index        r5, r1, r4
-  Print        r5
+  Const        r4, nil
+  Print        r4
   Return       r0

--- a/tests/vm/valid/map_in_operator.ir.out
+++ b/tests/vm/valid/map_in_operator.ir.out
@@ -1,13 +1,12 @@
-func main (regs=6)
+func main (regs=5)
   // let m = {1: "a", 2: "b"}
   Const        r0, {"1": "a", "2": "b"}
-  Move         r1, r0
   // print(1 in m)
-  Const        r2, 1
-  In           r3, r2, r1
-  Print        r3
+  Const        r1, 1
+  In           r2, r1, r0
+  Print        r2
   // print(3 in m)
-  Const        r4, 3
-  In           r5, r4, r1
-  Print        r5
+  Const        r3, 3
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/map_index.ir.out
+++ b/tests/vm/valid/map_index.ir.out
@@ -1,9 +1,7 @@
-func main (regs=4)
+func main (regs=3)
   // let m = {"a": 1, "b": 2}
   Const        r0, {"a": 1, "b": 2}
-  Move         r1, r0
   // print(m["b"])
-  Const        r2, "b"
-  Index        r3, r1, r2
-  Print        r3
+  Const        r2, 2
+  Print        r2
   Return       r0

--- a/tests/vm/valid/map_int_key.ir.out
+++ b/tests/vm/valid/map_int_key.ir.out
@@ -1,9 +1,7 @@
-func main (regs=4)
+func main (regs=3)
   // let m = {1: "a", 2: "b"}
   Const        r0, {"1": "a", "2": "b"}
-  Move         r1, r0
   // print(m[1])
-  Const        r2, 1
-  Index        r3, r1, r2
-  Print        r3
+  Const        r2, "a"
+  Print        r2
   Return       r0

--- a/tests/vm/valid/map_literal_dynamic.ir.out
+++ b/tests/vm/valid/map_literal_dynamic.ir.out
@@ -1,23 +1,17 @@
-func main (regs=16)
+func main (regs=12)
   // var x = 3
   Const        r0, 3
   Move         r1, r0
   // var y = 4
-  Const        r2, 4
-  Move         r3, r2
+  Const        r3, 4
   // var m = {"a": x, "b": y}
   Const        r4, "a"
   Const        r5, "b"
-  Move         r6, r4
-  Move         r7, r1
-  Move         r8, r5
-  Move         r9, r3
-  MakeMap      r10, 2, r6
-  Move         r11, r10
+  Move         r6, r1
+  Move         r7, r3
+  MakeMap      r9, 2, r4
   // print(m["a"], m["b"])
-  Const        r12, "a"
-  Index        r13, r11, r12
-  Const        r14, "b"
-  Index        r15, r11, r14
-  Print2       r13, r15
+  Index        r10, r9, r4
+  Index        r11, r9, r5
+  Print2       r10, r11
   Return       r0

--- a/tests/vm/valid/map_membership.ir.out
+++ b/tests/vm/valid/map_membership.ir.out
@@ -1,13 +1,12 @@
-func main (regs=6)
+func main (regs=5)
   // let m = {"a": 1, "b": 2}
   Const        r0, {"a": 1, "b": 2}
-  Move         r1, r0
   // print("a" in m)
-  Const        r2, "a"
-  In           r3, r2, r1
-  Print        r3
+  Const        r1, "a"
+  In           r2, r1, r0
+  Print        r2
   // print("c" in m)
-  Const        r4, "c"
-  In           r5, r4, r1
-  Print        r5
+  Const        r3, "c"
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/map_nested_assign.ir.out
+++ b/tests/vm/valid/map_nested_assign.ir.out
@@ -1,17 +1,12 @@
-func main (regs=10)
+func main (regs=8)
   // var data = {"outer": {"inner": 1}}
   Const        r0, {"outer": {"inner": 1}}
-  Move         r1, r0
   // data["outer"]["inner"] = 2
-  Const        r2, "outer"
-  Index        r3, r1, r2
+  Const        r3, {"inner": 1}
   Const        r4, "inner"
   Const        r5, 2
   SetIndex     r3, r4, r5
   // print(data["outer"]["inner"])
-  Const        r6, "outer"
-  Index        r7, r1, r6
-  Const        r8, "inner"
-  Index        r9, r7, r8
-  Print        r9
+  Const        r7, 1
+  Print        r7
   Return       r0

--- a/tests/vm/valid/match_expr.ir.out
+++ b/tests/vm/valid/match_expr.ir.out
@@ -1,29 +1,24 @@
-func main (regs=14)
+func main (regs=11)
   // let x = 2
   Const        r0, 2
   // 1 => "one"
   Jump         L0
-  Const        r5, "one"
-  Move         r2, r5
+  Const        r1, "one"
   Jump         L1
+L0:
   // 2 => "two"
-  Const        r8, "two"
-  Move         r2, r8
+  Const        r1, "two"
   Jump         L1
   // 3 => "three"
   Jump         L2
-  Const        r11, "three"
-  Move         r2, r11
+  Const        r1, "three"
   Jump         L1
 L2:
   // _ => "unknown"
-  Const        r12, "unknown"
-  Move         r2, r12
+  Const        r1, "unknown"
   Jump         L1
-  Const        r2, nil
+  Const        r1, nil
 L1:
-  // let label = match x {
-  Move         r13, r2
   // print(label)
-  Print        r13
+  Print        r1
   Return       r0

--- a/tests/vm/valid/match_full.ir.out
+++ b/tests/vm/valid/match_full.ir.out
@@ -1,81 +1,66 @@
-func main (regs=44)
+func main (regs=35)
   // let x = 2
   Const        r0, 2
   // 1 => "one"
   Jump         L0
-  Const        r5, "one"
-  Move         r2, r5
+  Const        r1, "one"
   Jump         L1
+L0:
   // 2 => "two"
-  Const        r8, "two"
-  Move         r2, r8
+  Const        r1, "two"
   Jump         L1
   // 3 => "three"
   Jump         L2
-  Const        r11, "three"
-  Move         r2, r11
+  Const        r1, "three"
   Jump         L1
 L2:
   // _ => "unknown"
-  Const        r12, "unknown"
-  Move         r2, r12
+  Const        r1, "unknown"
   Jump         L1
-  Const        r2, nil
+  Const        r1, nil
 L1:
-  // let label = match x {
-  Move         r13, r2
   // print(label)
-  Print        r13
+  Print        r1
   // "mon" => "tired"
-  Jump         L0
-  Const        r19, "tired"
-  Move         r16, r19
   Jump         L3
-  // "fri" => "excited"
-  Jump         L0
-  Const        r22, "excited"
-  Move         r16, r22
-  Jump         L3
-  // "sun" => "relaxed"
-  Const        r25, "relaxed"
-  Move         r16, r25
-  Jump         L3
-  // _     => "normal"
-  Const        r26, "normal"
-  Move         r16, r26
-  Jump         L3
-  Const        r16, nil
-L3:
-  // let mood = match day {
-  Move         r27, r16
-  // print(mood)
-  Print        r27
-  // true => "confirmed"
-  Const        r33, "confirmed"
-  Move         r30, r33
+  Const        r12, "tired"
   Jump         L4
-  // false => "denied"
+L3:
+  // "fri" => "excited"
   Jump         L5
-  Const        r36, "denied"
-  Move         r30, r36
+  Const        r12, "excited"
   Jump         L4
 L5:
-  Const        r30, nil
+  // "sun" => "relaxed"
+  Const        r12, "relaxed"
+  Jump         L4
+  // _     => "normal"
+  Const        r12, "normal"
+  Jump         L4
+  Const        r12, nil
 L4:
-  // let status = match ok {
-  Move         r37, r30
+  // print(mood)
+  Print        r12
+  // true => "confirmed"
+  Const        r23, "confirmed"
+  Jump         L6
+  // false => "denied"
+  Jump         L7
+  Const        r23, "denied"
+  Jump         L6
+L7:
+  Const        r23, nil
+L6:
   // print(status)
-  Print        r37
+  Print        r23
   // print(classify(0))
-  Const        r39, 0
-  Move         r38, r39
-  Call         r40, classify, r38
-  Print        r40
+  Const        r29, 0
+  Call         r31, classify, r29
+  Print        r31
   // print(classify(5))
-  Const        r42, 5
-  Move         r41, r42
-  Call         r43, classify, r41
-  Print        r43
+  Const        r32, 5
+  Call         r34, classify, r32
+  Print        r34
   Return       r0
 
   // fun classify(n: int): string {
@@ -84,21 +69,18 @@ func classify (regs=9)
   Const        r3, 0
   Equal        r2, r0, r3
   JumpIfFalse  r2, L0
-  Const        r4, "zero"
-  Move         r1, r4
+  Const        r1, "zero"
   Jump         L1
 L0:
   // 1 => "one"
   Const        r6, 1
   Equal        r5, r0, r6
   JumpIfFalse  r5, L2
-  Const        r7, "one"
-  Move         r1, r7
+  Const        r1, "one"
   Jump         L1
 L2:
   // _ => "many"
-  Const        r8, "many"
-  Move         r1, r8
+  Const        r1, "many"
   Jump         L1
   Const        r1, nil
 L1:

--- a/tests/vm/valid/math_ops.ir.out
+++ b/tests/vm/valid/math_ops.ir.out
@@ -1,12 +1,12 @@
-func main (regs=9)
+func main (regs=6)
   // print(6 * 7)
   Const        r0, 6
   Const        r2, 42
   Print        r2
   // print(7 / 2)
-  Const        r5, 3
-  Print        r5
+  Const        r4, 3
+  Print        r4
   // print(7 % 2)
-  Const        r8, 1
-  Print        r8
+  Const        r5, 1
+  Print        r5
   Return       r0

--- a/tests/vm/valid/membership.ir.out
+++ b/tests/vm/valid/membership.ir.out
@@ -1,13 +1,12 @@
-func main (regs=6)
+func main (regs=5)
   // let nums = [1, 2, 3]
   Const        r0, [1, 2, 3]
-  Move         r1, r0
   // print(2 in nums)
-  Const        r2, 2
-  In           r3, r2, r1
-  Print        r3
+  Const        r1, 2
+  In           r2, r1, r0
+  Print        r2
   // print(4 in nums)
-  Const        r4, 4
-  In           r5, r4, r1
-  Print        r5
+  Const        r3, 4
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/min_max_builtin.ir.out
+++ b/tests/vm/valid/min_max_builtin.ir.out
@@ -1,11 +1,10 @@
-func main (regs=4)
+func main (regs=3)
   // let nums = [3,1,4]
   Const        r0, [3, 1, 4]
-  Move         r1, r0
   // print(min(nums))
-  Min          r2, r1
-  Print        r2
+  Const        r1, 1
+  Print        r1
   // print(max(nums))
-  Max          r3, r1
-  Print        r3
+  Const        r2, 4
+  Print        r2
   Return       r0

--- a/tests/vm/valid/nested_function.ir.out
+++ b/tests/vm/valid/nested_function.ir.out
@@ -1,7 +1,6 @@
 func main (regs=3)
   // print(outer(3))  // 8
-  Const        r1, 3
-  Move         r0, r1
+  Const        r0, 3
   Call         r2, outer, r0
   Print        r2
   Return       r0
@@ -9,11 +8,9 @@ func main (regs=3)
   // fun outer(x: int): int {
 func outer (regs=6)
   // fun inner(y: int): int {
-  Move         r1, r0
-  MakeClosure  r2, inner, 1, r1
+  MakeClosure  r2, inner, 0, r0
   // return inner(5)
-  Const        r4, 5
-  Move         r3, r4
+  Const        r3, 5
   CallV        r5, r2, 1, r3
   Return       r5
   Return       r0

--- a/tests/vm/valid/order_by_map.ir.out
+++ b/tests/vm/valid/order_by_map.ir.out
@@ -1,27 +1,31 @@
-func main (regs=28)
+func main (regs=22)
   // let data = [
   Const        r0, [{"a": 1, "b": 2}, {"a": 1, "b": 1}, {"a": 0, "b": 5}]
-  Move         r1, r0
   // from x in data
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L1:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Append       r23, r2, r22
-  Move         r2, r23
-  Const        r25, 1
-  Move         r5, r25
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
+  // sort by { a: x.a, b: x.b }
+  Const        r8, "a"
+  Index        r9, r7, r8
+  Const        r10, "b"
+  Index        r11, r7, r10
+  MakeMap      r15, 2, r8
+  // from x in data
+  Move         r16, r7
+  MakeList     r17, 2, r15
+  Append       r1, r1, r17
+  Const        r19, 1
+  Add          r4, r4, r19
   Jump         L1
 L0:
   // sort by { a: x.a, b: x.b }
-  Sort         26,2,0,0
-  // from x in data
-  Move         r2, r26
-  // let sorted =
-  Move         r27, r2
+  Sort         r1, r1
   // print(sorted)
-  Print        r27
+  Print        r1
   Return       r0

--- a/tests/vm/valid/outer_join.ir.out
+++ b/tests/vm/valid/outer_join.ir.out
@@ -1,196 +1,182 @@
-func main (regs=148)
+func main (regs=105)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}, {"id": 4, "name": "Diana"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}, {"customerId": 5, "id": 103, "total": 80}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}, {"customerId": 5, "id": 103, "total": 80}]
   // let result = from o in orders
-  Const        r4, []
-  IterPrep     r5, r3
+  Const        r2, []
+  IterPrep     r3, r1
+  Len          r4, r3
+  // outer join c in customers on o.customerId == c.id
+  IterPrep     r5, r0
   Len          r6, r5
-  // outer join c in customers on o.customerId == c.id
-  IterPrep     r7, r1
-  Len          r8, r7
   // let result = from o in orders
-  Const        r9, 0
-L3:
-  Less         r10, r9, r6
-  JumpIfFalse  r10, L0
-  Index        r11, r5, r9
-  Move         r12, r11
-  // outer join c in customers on o.customerId == c.id
-  Const        r13, 0
-L2:
-  Less         r14, r13, r8
-  JumpIfFalse  r14, L1
-  Index        r15, r7, r13
-  Move         r16, r15
-  Const        r17, "customerId"
-  Index        r18, r12, r17
-  Const        r19, "id"
-  Index        r20, r16, r19
-  Equal        r21, r18, r20
-  JumpIfFalse  r21, L1
-  // let result = from o in orders
-  Append       r29, r4, r28
-  Move         r4, r29
-  // outer join c in customers on o.customerId == c.id
-  Const        r31, 1
-  Move         r13, r31
-  Jump         L2
-  // let result = from o in orders
-  Const        r33, 1
-  Move         r9, r33
-  Jump         L3
-L0:
-  Const        r34, 0
-L6:
-  Less         r35, r34, r6
-  JumpIfFalse  r35, L4
-  Index        r36, r5, r34
-  Move         r12, r36
-  // outer join c in customers on o.customerId == c.id
-  Const        r38, 0
-L5:
-  Less         r39, r38, r8
-  JumpIfFalse  r39, L1
-  Index        r40, r7, r38
-  Move         r16, r40
-  Const        r41, "customerId"
-  Index        r42, r12, r41
-  Const        r43, "id"
-  Index        r44, r16, r43
-  Equal        r45, r42, r44
-  JumpIfFalse  r45, L1
-  Const        r47, 1
-  Move         r38, r47
-  Jump         L5
-  // let result = from o in orders
-  Jump         L1
-  Append       r57, r4, r56
-  Move         r4, r57
-  Jump         L6
+  Const        r7, 0
 L4:
+  Less         r8, r7, r4
+  JumpIfFalse  r8, L0
+  Index        r10, r3, r7
   // outer join c in customers on o.customerId == c.id
-  Const        r60, 0
-L9:
-  Less         r61, r60, r8
-  JumpIfFalse  r61, L7
-  Index        r62, r7, r60
-  Move         r16, r62
+  Const        r11, 0
+L3:
+  Less         r12, r11, r6
+  JumpIfFalse  r12, L1
+  Index        r14, r5, r11
+  Const        r15, "customerId"
+  Index        r16, r10, r15
+  Const        r17, "id"
+  Index        r18, r14, r17
+  Equal        r19, r16, r18
+  JumpIfFalse  r19, L2
+  // order: o,
+  Const        r20, "order"
+  // customer: c
+  Const        r21, "customer"
+  // order: o,
+  Move         r22, r10
+  // customer: c
+  Move         r23, r14
+  // select {
+  MakeMap      r24, 2, r20
   // let result = from o in orders
-  Const        r64, 0
-L8:
-  Less         r65, r64, r6
-  JumpIfFalse  r65, L1
-  Index        r66, r5, r64
-  Move         r12, r66
+  Append       r2, r2, r24
+L2:
   // outer join c in customers on o.customerId == c.id
-  Const        r67, "customerId"
-  Index        r68, r12, r67
-  Const        r69, "id"
-  Index        r70, r16, r69
-  Equal        r71, r68, r70
-  JumpIfFalse  r71, L1
+  Const        r26, 1
+  Add          r11, r11, r26
+  Jump         L3
+L1:
   // let result = from o in orders
-  Const        r73, 1
-  Move         r64, r73
-  Jump         L8
-  // outer join c in customers on o.customerId == c.id
-  Jump         L1
-  // let result = from o in orders
-  Append       r83, r4, r82
-  Move         r4, r83
-  // outer join c in customers on o.customerId == c.id
-  Jump         L9
-L7:
-  // let result = from o in orders
-  Move         r86, r4
-  // print("--- Outer Join using syntax ---")
-  Const        r87, "--- Outer Join using syntax ---"
-  Print        r87
-  // for row in result {
-  IterPrep     r88, r86
-  Len          r89, r88
-  Const        r90, 0
-L14:
-  Less         r91, r90, r89
-  JumpIfFalse  r91, L10
-  Index        r92, r88, r90
-  Move         r93, r92
-  // if row.order {
-  Const        r94, "order"
-  Index        r95, r93, r94
-  JumpIfFalse  r95, L11
-  // if row.customer {
-  Const        r96, "customer"
-  Index        r97, r93, r96
-  JumpIfFalse  r97, L12
-  // print("Order", row.order.id, "by", row.customer.name, "- $", row.order.total)
-  Const        r104, "Order"
-  Move         r98, r104
-  Const        r105, "order"
-  Index        r106, r93, r105
-  Const        r107, "id"
-  Index        r108, r106, r107
-  Move         r99, r108
-  Const        r109, "by"
-  Move         r100, r109
-  Const        r110, "customer"
-  Index        r111, r93, r110
-  Const        r112, "name"
-  Index        r113, r111, r112
-  Move         r101, r113
-  Const        r114, "- $"
-  Move         r102, r114
-  Const        r115, "order"
-  Index        r116, r93, r115
-  Const        r117, "total"
-  Index        r118, r116, r117
-  Move         r103, r118
-  PrintN       r98, 6, r98
-  // if row.customer {
-  Jump         L13
-L12:
-  // print("Order", row.order.id, "by", "Unknown", "- $", row.order.total)
-  Const        r125, "Order"
-  Move         r119, r125
-  Const        r126, "order"
-  Index        r127, r93, r126
-  Const        r128, "id"
-  Index        r129, r127, r128
-  Move         r120, r129
-  Const        r130, "by"
-  Move         r121, r130
-  Const        r131, "Unknown"
-  Move         r122, r131
-  Const        r132, "- $"
-  Move         r123, r132
-  Const        r133, "order"
-  Index        r134, r93, r133
-  Const        r135, "total"
-  Index        r136, r134, r135
-  Move         r124, r136
-  PrintN       r119, 6, r119
-L13:
-  // if row.order {
-  Jump         L1
-L11:
-  // print("Customer", row.customer.name, "has no orders")
-  Const        r140, "Customer"
-  Move         r137, r140
-  Const        r141, "customer"
-  Index        r142, r93, r141
-  Const        r143, "name"
-  Index        r144, r142, r143
-  Move         r138, r144
-  Const        r145, "has no orders"
-  Move         r139, r145
-  PrintN       r137, 3, r137
-  // for row in result {
-  Const        r147, 1
-  Move         r90, r147
-  Jump         L14
+  Add          r7, r7, r26
+  Jump         L4
+L0:
+  Const        r27, 0
 L10:
+  Less         r28, r27, r4
+  JumpIfFalse  r28, L5
+  Index        r10, r3, r27
+  Const        r30, false
+  // outer join c in customers on o.customerId == c.id
+  Const        r31, 0
+L8:
+  Less         r32, r31, r6
+  JumpIfFalse  r32, L6
+  Index        r14, r5, r31
+  Index        r34, r10, r15
+  Index        r35, r14, r17
+  Equal        r36, r34, r35
+  JumpIfFalse  r36, L7
+  Const        r30, true
+L7:
+  Add          r31, r31, r26
+  Jump         L8
+L6:
+  // let result = from o in orders
+  Move         r37, r30
+  JumpIfTrue   r37, L9
+  // select {
+  MakeMap      r41, 2, r20
+  // let result = from o in orders
+  Append       r2, r2, r41
+L9:
+  Add          r27, r27, r26
+  Jump         L10
+L5:
+  // outer join c in customers on o.customerId == c.id
+  Const        r43, 0
+L16:
+  Less         r44, r43, r6
+  JumpIfFalse  r44, L11
+  Index        r14, r5, r43
+  Const        r46, false
+  // let result = from o in orders
+  Const        r47, 0
+L14:
+  Less         r48, r47, r4
+  JumpIfFalse  r48, L12
+  Index        r10, r3, r47
+  // outer join c in customers on o.customerId == c.id
+  Index        r50, r10, r15
+  Index        r51, r14, r17
+  Equal        r52, r50, r51
+  JumpIfFalse  r52, L13
+  Const        r46, true
+L13:
+  // let result = from o in orders
+  Add          r47, r47, r26
+  Jump         L14
+L12:
+  // outer join c in customers on o.customerId == c.id
+  Move         r53, r46
+  JumpIfTrue   r53, L15
+  // select {
+  MakeMap      r57, 2, r20
+  // let result = from o in orders
+  Append       r2, r2, r57
+L15:
+  // outer join c in customers on o.customerId == c.id
+  Add          r43, r43, r26
+  Jump         L16
+L11:
+  // print("--- Outer Join using syntax ---")
+  Const        r59, "--- Outer Join using syntax ---"
+  Print        r59
+  // for row in result {
+  IterPrep     r60, r2
+  Len          r61, r60
+  Const        r62, 0
+L22:
+  Less         r63, r62, r61
+  JumpIfFalse  r63, L17
+  Index        r65, r60, r62
+  // if row.order {
+  Index        r66, r65, r20
+  JumpIfFalse  r66, L18
+  // if row.customer {
+  Index        r67, r65, r21
+  JumpIfFalse  r67, L19
+  // print("Order", row.order.id, "by", row.customer.name, "- $", row.order.total)
+  Const        r74, "Order"
+  Move         r68, r74
+  Index        r75, r65, r20
+  Index        r69, r75, r17
+  Const        r77, "by"
+  Move         r70, r77
+  Index        r78, r65, r21
+  Const        r79, "name"
+  Index        r71, r78, r79
+  Const        r72, "- $"
+  Index        r82, r65, r20
+  Const        r83, "total"
+  Index        r73, r82, r83
+  PrintN       r68, 6, r68
+  // if row.customer {
+  Jump         L20
+L19:
+  // print("Order", row.order.id, "by", "Unknown", "- $", row.order.total)
+  Move         r85, r74
+  Index        r91, r65, r20
+  Index        r86, r91, r17
+  Move         r87, r77
+  Const        r88, "Unknown"
+  Move         r89, r81
+  Index        r94, r65, r20
+  Index        r90, r94, r83
+  PrintN       r85, 6, r85
+L20:
+  // if row.order {
+  Jump         L21
+L18:
+  // print("Customer", row.customer.name, "has no orders")
+  Const        r96, "Customer"
+  Index        r100, r65, r21
+  Index        r97, r100, r79
+  Const        r98, "has no orders"
+  PrintN       r96, 3, r96
+L21:
+  // for row in result {
+  Const        r103, 1
+  Add          r62, r62, r103
+  Jump         L22
+L17:
   Return       r0

--- a/tests/vm/valid/partial_application.ir.out
+++ b/tests/vm/valid/partial_application.ir.out
@@ -1,14 +1,11 @@
-func main (regs=7)
+func main (regs=6)
   // let add5 = add(5)
-  Const        r1, 5
-  Move         r0, r1
+  Const        r0, 5
   Call         r2, add, r0
-  Move         r3, r2
   // print(add5(3))
-  Const        r5, 3
-  Move         r4, r5
-  CallV        r6, r3, 1, r4
-  Print        r6
+  Const        r3, 3
+  CallV        r5, r2, 1, r3
+  Print        r5
   Return       r0
 
   // fun add(a: int, b: int): int {

--- a/tests/vm/valid/query_sum_select.ir.out
+++ b/tests/vm/valid/query_sum_select.ir.out
@@ -1,28 +1,25 @@
-func main (regs=16)
+func main (regs=14)
   // let nums = [1,2,3]
   Const        r0, [1, 2, 3]
-  Move         r1, r0
   // let result = from n in nums where n > 1 select sum(n)
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L2:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Index        r7, r3, r5
-  Move         r8, r7
-  Const        r9, 1
-  Less         r10, r9, r8
-  JumpIfFalse  r10, L1
-  Append       r11, r2, r8
-  Move         r2, r11
-  Const        r13, 1
-  Move         r5, r13
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
+  Const        r8, 1
+  Less         r9, r8, r7
+  JumpIfFalse  r9, L1
+  Append       r1, r1, r7
+L1:
+  Const        r11, 1
+  Add          r4, r4, r11
   Jump         L2
 L0:
-  Sum          r14, r2
-  Move         r15, r14
+  Sum          r13, r1
   // print(result)
-  Print        r15
+  Print        r13
   Return       r0

--- a/tests/vm/valid/right_join.ir.out
+++ b/tests/vm/valid/right_join.ir.out
@@ -1,105 +1,99 @@
-func main (regs=87)
+func main (regs=67)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}, {"id": 4, "name": "Diana"}]
-  Move         r1, r0
   // let orders = [
-  Const        r2, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}]
-  Move         r3, r2
+  Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}]
   // let result = from c in customers
-  Const        r4, []
+  Const        r2, []
+  IterPrep     r3, r0
+  Len          r4, r3
+  // right join o in orders on o.customerId == c.id
   IterPrep     r5, r1
   Len          r6, r5
-  // right join o in orders on o.customerId == c.id
-  IterPrep     r7, r3
-  Len          r8, r7
-  Const        r11, 0
-L3:
-  Less         r12, r11, r8
-  JumpIfFalse  r12, L0
-  Index        r13, r7, r11
-  Move         r9, r13
-  // let result = from c in customers
-  Const        r15, 0
-L2:
-  Less         r16, r15, r6
-  JumpIfFalse  r16, L1
-  Index        r17, r5, r15
-  Move         r10, r17
-  // right join o in orders on o.customerId == c.id
-  Const        r18, "customerId"
-  Index        r19, r9, r18
-  Const        r20, "id"
-  Index        r21, r10, r20
-  Equal        r22, r19, r21
-  JumpIfFalse  r22, L1
-  // let result = from c in customers
-  Append       r32, r4, r31
-  Move         r4, r32
-  Jump         L2
-  // right join o in orders on o.customerId == c.id
-  Jump         L1
-  // let result = from c in customers
-  Append       r46, r4, r45
-  Move         r4, r46
-  // right join o in orders on o.customerId == c.id
-  Const        r48, 1
-  Move         r11, r48
-  Jump         L3
-L0:
-  // let result = from c in customers
-  Move         r49, r4
-  // print("--- Right Join using syntax ---")
-  Const        r50, "--- Right Join using syntax ---"
-  Print        r50
-  // for entry in result {
-  IterPrep     r51, r49
-  Len          r52, r51
-  Const        r53, 0
-L6:
-  Less         r54, r53, r52
-  JumpIfFalse  r54, L4
-  Index        r55, r51, r53
-  Move         r56, r55
-  // if entry.order {
-  Const        r57, "order"
-  Index        r58, r56, r57
-  JumpIfFalse  r58, L5
-  // print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
-  Const        r65, "Customer"
-  Move         r59, r65
-  Const        r66, "customerName"
-  Index        r67, r56, r66
-  Move         r60, r67
-  Const        r68, "has order"
-  Move         r61, r68
-  Const        r69, "order"
-  Index        r70, r56, r69
-  Const        r71, "id"
-  Index        r72, r70, r71
-  Move         r62, r72
-  Const        r73, "- $"
-  Move         r63, r73
-  Const        r74, "order"
-  Index        r75, r56, r74
-  Const        r76, "total"
-  Index        r77, r75, r76
-  Move         r64, r77
-  PrintN       r59, 6, r59
-  // if entry.order {
-  Jump         L1
+  Const        r9, 0
 L5:
-  // print("Customer", entry.customerName, "has no orders")
-  Const        r81, "Customer"
-  Move         r78, r81
-  Const        r82, "customerName"
-  Index        r83, r56, r82
-  Move         r79, r83
-  Const        r84, "has no orders"
-  Move         r80, r84
-  PrintN       r78, 3, r78
-  // for entry in result {
-  Const        r86, 1
-  Move         r53, r86
-  Jump         L6
+  Less         r10, r9, r6
+  JumpIfFalse  r10, L0
+  Index        r7, r5, r9
+  Const        r12, false
+  // let result = from c in customers
+  Const        r13, 0
+L3:
+  Less         r14, r13, r4
+  JumpIfFalse  r14, L1
+  Index        r8, r3, r13
+  // right join o in orders on o.customerId == c.id
+  Const        r16, "customerId"
+  Index        r17, r7, r16
+  Const        r18, "id"
+  Index        r19, r8, r18
+  Equal        r20, r17, r19
+  JumpIfFalse  r20, L2
+  Const        r12, true
+  // customerName: c.name,
+  Const        r21, "customerName"
+  Const        r22, "name"
+  Index        r23, r8, r22
+  // order: o
+  Const        r24, "order"
+  // select {
+  MakeMap      r27, 2, r21
+  // let result = from c in customers
+  Append       r2, r2, r27
+L2:
+  Const        r29, 1
+  Jump         L3
+L1:
+  // right join o in orders on o.customerId == c.id
+  Move         r30, r12
+  JumpIfTrue   r30, L4
+  // select {
+  MakeMap      r35, 2, r21
+  // let result = from c in customers
+  Append       r2, r2, r35
 L4:
+  // right join o in orders on o.customerId == c.id
+  Add          r9, r9, r29
+  Jump         L5
+L0:
+  // print("--- Right Join using syntax ---")
+  Const        r37, "--- Right Join using syntax ---"
+  Print        r37
+  // for entry in result {
+  IterPrep     r38, r2
+  Len          r39, r38
+  Const        r40, 0
+L9:
+  Less         r41, r40, r39
+  JumpIfFalse  r41, L6
+  Index        r43, r38, r40
+  // if entry.order {
+  Index        r44, r43, r24
+  JumpIfFalse  r44, L7
+  // print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
+  Const        r51, "Customer"
+  Move         r45, r51
+  Index        r46, r43, r21
+  Const        r47, "has order"
+  Index        r54, r43, r24
+  Index        r48, r54, r18
+  Const        r49, "- $"
+  Index        r57, r43, r24
+  Const        r58, "total"
+  Index        r50, r57, r58
+  PrintN       r45, 6, r45
+  // if entry.order {
+  Jump         L8
+L7:
+  // print("Customer", entry.customerName, "has no orders")
+  Move         r60, r51
+  Index        r61, r43, r21
+  Const        r62, "has no orders"
+  PrintN       r60, 3, r60
+L8:
+  // for entry in result {
+  Const        r65, 1
+  Add          r40, r40, r65
+  Jump         L9
+L6:
   Return       r0

--- a/tests/vm/valid/save_jsonl_stdout.ir.out
+++ b/tests/vm/valid/save_jsonl_stdout.ir.out
@@ -1,10 +1,8 @@
-func main (regs=6)
+func main (regs=5)
   // let people = [
   Const        r0, [{"age": 30, "name": "Alice"}, {"age": 25, "name": "Bob"}]
-  Move         r1, r0
   // save people to "-" with { format: "jsonl" }
-  Const        r2, "-"
-  Const        r4, {"format": "jsonl"}
-  Move         r3, r4
-  Save         5,1,2,3
+  Const        r1, "-"
+  Const        r2, {"format": "jsonl"}
+  Save         4,0,1,2
   Return       r0

--- a/tests/vm/valid/short_circuit.ir.out
+++ b/tests/vm/valid/short_circuit.ir.out
@@ -1,26 +1,18 @@
-func main (regs=14)
+func main (regs=12)
   // print(false && boom(1, 2))
   Const        r0, false
   Move         r1, r0
-  Jump         L0
+  JumpIfFalse  r1, L0
   Const        r4, 1
   Move         r2, r4
   Const        r5, 2
-  Move         r3, r5
-  Call2        r6, boom, r2, r3
-  Move         r1, r6
+  Call2        r1, boom, r2, r5
 L0:
   Print        r1
   // print(true || boom(1, 2))
-  Const        r7, true
-  Move         r8, r7
-  Jump         L1
-  Const        r11, 1
-  Move         r9, r11
-  Const        r12, 2
-  Move         r10, r12
-  Call2        r13, boom, r9, r10
-  Move         r8, r13
+  Const        r8, true
+  JumpIfTrue   r8, L1
+  Call2        r8, boom, r4, r5
 L1:
   Print        r8
   Return       r0

--- a/tests/vm/valid/slice.ir.out
+++ b/tests/vm/valid/slice.ir.out
@@ -1,26 +1,12 @@
-func main (regs=18)
+func main (regs=17)
   // print([1,2,3][1:3])
   Const        r0, [1, 2, 3]
-  Const        r2, 1
-  Move         r1, r2
-  Const        r4, 3
-  Move         r3, r4
-  Slice        r5, r0, r1, r3
+  Const        r5, [2, 3]
   Print        r5
   // print([1,2,3][0:2])
-  Const        r6, [1, 2, 3]
-  Const        r8, 0
-  Move         r7, r8
-  Const        r10, 2
-  Move         r9, r10
-  Slice        r11, r6, r7, r9
+  Const        r11, [1, 2]
   Print        r11
   // print("hello"[1:4])
-  Const        r12, "hello"
-  Const        r14, 1
-  Move         r13, r14
-  Const        r16, 4
-  Move         r15, r16
-  Slice        r17, r12, r13, r15
-  Print        r17
+  Const        r16, "ell"
+  Print        r16
   Return       r0

--- a/tests/vm/valid/sort_stable.ir.out
+++ b/tests/vm/valid/sort_stable.ir.out
@@ -1,24 +1,27 @@
-func main (regs=21)
+func main (regs=19)
   // let items = [
   Const        r0, [{"n": 1, "v": "a"}, {"n": 1, "v": "b"}, {"n": 2, "v": "c"}]
-  Move         r1, r0
   // let result = from i in items sort by i.n select i.v
-  Const        r2, []
-  IterPrep     r3, r1
-  Len          r4, r3
-  Const        r5, 0
+  Const        r1, []
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L1:
-  Less         r6, r5, r4
-  JumpIfFalse  r6, L0
-  Append       r16, r2, r15
-  Move         r2, r16
-  Const        r18, 1
-  Move         r5, r18
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
+  Const        r8, "v"
+  Index        r9, r7, r8
+  Const        r10, "n"
+  Index        r12, r7, r10
+  Move         r13, r9
+  MakeList     r14, 2, r12
+  Append       r1, r1, r14
+  Const        r16, 1
+  Add          r4, r4, r16
   Jump         L1
 L0:
-  Sort         19,2,0,0
-  Move         r2, r19
-  Move         r20, r2
+  Sort         r1, r1
   // print(result)
-  Print        r20
+  Print        r1
   Return       r0

--- a/tests/vm/valid/string_compare.ir.out
+++ b/tests/vm/valid/string_compare.ir.out
@@ -1,15 +1,15 @@
-func main (regs=12)
+func main (regs=6)
   // print("a" < "b")
   Const        r0, "a"
   Const        r2, true
   Print        r2
   // print("a" <= "a")
+  Const        r3, true
+  Print        r3
+  // print("b" > "a")
+  Const        r4, true
+  Print        r4
+  // print("b" >= "b")
   Const        r5, true
   Print        r5
-  // print("b" > "a")
-  Const        r8, true
-  Print        r8
-  // print("b" >= "b")
-  Const        r11, true
-  Print        r11
   Return       r0

--- a/tests/vm/valid/string_contains.ir.out
+++ b/tests/vm/valid/string_contains.ir.out
@@ -1,13 +1,12 @@
-func main (regs=6)
+func main (regs=5)
   // let s = "catch"
   Const        r0, "catch"
-  Move         r1, r0
   // print(s.contains("cat"))
-  Const        r2, "cat"
-  In           r3, r2, r1
-  Print        r3
+  Const        r1, "cat"
+  In           r2, r1, r0
+  Print        r2
   // print(s.contains("dog"))
-  Const        r4, "dog"
-  In           r5, r4, r1
-  Print        r5
+  Const        r3, "dog"
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/string_in_operator.ir.out
+++ b/tests/vm/valid/string_in_operator.ir.out
@@ -1,13 +1,12 @@
-func main (regs=6)
+func main (regs=5)
   // let s = "catch"
   Const        r0, "catch"
-  Move         r1, r0
   // print("cat" in s)
-  Const        r2, "cat"
-  In           r3, r2, r1
-  Print        r3
+  Const        r1, "cat"
+  In           r2, r1, r0
+  Print        r2
   // print("dog" in s)
-  Const        r4, "dog"
-  In           r5, r4, r1
-  Print        r5
+  Const        r3, "dog"
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/string_index.ir.out
+++ b/tests/vm/valid/string_index.ir.out
@@ -1,9 +1,7 @@
-func main (regs=4)
+func main (regs=3)
   // let s = "mochi"
   Const        r0, "mochi"
-  Move         r1, r0
   // print(s[1])
-  Const        r2, 1
-  Index        r3, r1, r2
-  Print        r3
+  Const        r2, "o"
+  Print        r2
   Return       r0

--- a/tests/vm/valid/string_prefix_slice.ir.out
+++ b/tests/vm/valid/string_prefix_slice.ir.out
@@ -1,27 +1,10 @@
-func main (regs=18)
+func main (regs=14)
   // let prefix = "fore"
   Const        r0, "fore"
-  Move         r1, r0
-  // let s1 = "forest"
-  Const        r2, "forest"
-  Move         r3, r2
   // print(s1[0:len(prefix)] == prefix)
-  Const        r5, 0
-  Move         r4, r5
-  Const        r7, 4
-  Move         r6, r7
-  Slice        r8, r3, r4, r6
-  Equal        r9, r8, r1
-  Print        r9
-  // let s2 = "desert"
-  Const        r10, "desert"
-  Move         r11, r10
+  Const        r7, true
+  Print        r7
   // print(s2[0:len(prefix)] == prefix)
-  Const        r13, 0
-  Move         r12, r13
-  Const        r15, 4
-  Move         r14, r15
-  Slice        r16, r11, r12, r14
-  Equal        r17, r16, r1
-  Print        r17
+  Const        r13, false
+  Print        r13
   Return       r0

--- a/tests/vm/valid/sum_builtin.ir.out
+++ b/tests/vm/valid/sum_builtin.ir.out
@@ -1,6 +1,6 @@
 func main (regs=2)
   // print(sum([1,2,3]))
   Const        r0, [1, 2, 3]
-  Sum          r1, r0
+  Const        r1, 6
   Print        r1
   Return       r0

--- a/tests/vm/valid/tail_recursion.ir.out
+++ b/tests/vm/valid/tail_recursion.ir.out
@@ -1,9 +1,7 @@
 func main (regs=5)
   // print(sum_rec(10, 0))
-  Const        r2, 10
-  Move         r0, r2
-  Const        r3, 0
-  Move         r1, r3
+  Const        r0, 10
+  Const        r1, 0
   Call2        r4, sum_rec, r0, r1
   Print        r4
   Return       r0
@@ -19,10 +17,8 @@ func sum_rec (regs=10)
 L0:
   // return sum_rec(n - 1, acc + n)
   Const        r6, 1
-  Sub          r7, r0, r6
-  Move         r4, r7
-  Add          r8, r1, r0
-  Move         r5, r8
+  Sub          r4, r0, r6
+  Add          r5, r1, r0
   Call2        r9, sum_rec, r4, r5
   Return       r9
   Return       r0

--- a/tests/vm/valid/test_block.ir.out
+++ b/tests/vm/valid/test_block.ir.out
@@ -1,10 +1,10 @@
-func main (regs=7)
+func main (regs=6)
   // let x = 1 + 2
   Const        r0, 1
   // expect x == 3
-  Const        r5, true
-  Expect       r5
+  Const        r4, true
+  Expect       r4
   // print("ok")
-  Const        r6, "ok"
-  Print        r6
+  Const        r5, "ok"
+  Print        r5
   Return       r0

--- a/tests/vm/valid/tree_sum.ir.out
+++ b/tests/vm/valid/tree_sum.ir.out
@@ -1,4 +1,4 @@
-func main (regs=32)
+func main (regs=21)
   // left: Leaf,
   Const        r0, "__name"
   Const        r1, "Leaf"
@@ -6,48 +6,18 @@ func main (regs=32)
   // value: 1,
   Const        r3, 1
   // left: Leaf,
-  Const        r4, "__name"
-  Const        r5, "Leaf"
-  MakeMap      r6, 1, r4
+  MakeMap      r4, 1, r0
   // value: 2,
-  Const        r7, 2
+  Const        r5, 2
   // right: Leaf
-  Const        r8, "__name"
-  Const        r9, "Leaf"
-  MakeMap      r10, 1, r8
+  MakeMap      r6, 1, r0
   // right: Node {
-  Const        r11, "__name"
-  Const        r12, "Node"
-  // left: Leaf,
-  Const        r13, "left"
-  Move         r14, r6
-  // value: 2,
-  Const        r15, "value"
-  Move         r16, r7
-  // right: Leaf
-  Const        r17, "right"
-  Move         r18, r10
-  // right: Node {
-  MakeMap      r19, 4, r11
+  Const        r7, "Node"
   // let t = Node {
-  Const        r20, "__name"
-  Const        r21, "Node"
-  // left: Leaf,
-  Const        r22, "left"
-  Move         r23, r2
-  // value: 1,
-  Const        r24, "value"
-  Move         r25, r3
-  // right: Node {
-  Const        r26, "right"
-  Move         r27, r19
-  // let t = Node {
-  MakeMap      r28, 4, r20
-  Move         r29, r28
+  MakeMap      r19, 4, r0
   // print(sum_tree(t))
-  Move         r30, r29
-  Call         r31, sum_tree, r30
-  Print        r31
+  Call         r20, sum_tree, r19
+  Print        r20
   Return       r0
 
   // fun sum_tree(t: Tree): int {
@@ -58,8 +28,7 @@ func sum_tree (regs=23)
   Const        r5, "Leaf"
   Equal        r2, r4, r5
   JumpIfFalse  r2, L0
-  Const        r6, 0
-  Move         r1, r6
+  Const        r1, 0
   Jump         L1
 L0:
   // Node(left, value, right) => sum_tree(left) + value + sum_tree(right)
@@ -74,13 +43,10 @@ L0:
   Index        r14, r0, r13
   Const        r15, "right"
   Index        r16, r0, r15
-  Move         r17, r12
-  Call         r18, sum_tree, r17
+  Call         r18, sum_tree, r12
   Add          r19, r18, r14
-  Move         r20, r16
-  Call         r21, sum_tree, r20
-  Add          r22, r19, r21
-  Move         r1, r22
+  Call         r21, sum_tree, r16
+  Add          r1, r19, r21
   Jump         L1
 L2:
   Const        r1, nil

--- a/tests/vm/valid/two-sum.ir.out
+++ b/tests/vm/valid/two-sum.ir.out
@@ -1,57 +1,56 @@
-func main (regs=10)
+func main (regs=9)
   // let result = twoSum([2,7,11,15], 9)
-  Const        r2, [2, 7, 11, 15]
-  Move         r0, r2
-  Const        r3, 9
-  Move         r1, r3
+  Const        r0, [2, 7, 11, 15]
+  Const        r1, 9
   Call2        r4, twoSum, r0, r1
-  Move         r5, r4
   // print(result[0])
-  Const        r6, 0
-  Index        r7, r5, r6
-  Print        r7
+  Const        r5, 0
+  Index        r6, r4, r5
+  Print        r6
   // print(result[1])
-  Const        r8, 1
-  Index        r9, r5, r8
-  Print        r9
+  Const        r7, 1
+  Index        r8, r4, r7
+  Print        r8
   Return       r0
 
   // fun twoSum(nums: list<int>, target: int): list<int> {
-func twoSum (regs=23)
+func twoSum (regs=22)
   // let n = len(nums)
   Len          r2, r0
-  Move         r3, r2
   // for i in 0..n {
   Const        r4, 0
-  Move         r5, r4
+L4:
+  Less         r5, r4, r2
+  JumpIfFalse  r5, L0
+  // for j in i+1..n {
+  Const        r6, 1
+  AddInt       r8, r4, r6
 L3:
-  Less         r6, r5, r3
-  JumpIfFalse  r6, L0
-  // for j in i+1..n {
-  Const        r8, 1
-  Move         r9, r8
-L2:
-  Less         r10, r9, r3
-  JumpIfFalse  r10, L1
+  Less         r9, r8, r2
+  JumpIfFalse  r9, L1
   // if nums[i] + nums[j] == target {
-  Index        r11, r0, r5
-  Index        r12, r0, r9
-  Add          r13, r11, r12
-  Equal        r14, r13, r1
-  JumpIfFalse  r14, L1
+  Index        r10, r0, r4
+  Index        r11, r0, r8
+  Add          r12, r10, r11
+  Equal        r13, r12, r1
+  JumpIfFalse  r13, L2
   // return [i, j]
-  Move         r15, r5
-  Move         r16, r9
-  MakeList     r17, 2, r15
-  Return       r17
+  Move         r14, r4
+  Move         r15, r8
+  MakeList     r16, 2, r14
+  Return       r16
+L2:
   // for j in i+1..n {
-  Jump         L2
-  // for i in 0..n {
-  Const        r21, 1
-  Move         r5, r21
+  Const        r17, 1
+  Add          r8, r8, r17
   Jump         L3
+L1:
+  // for i in 0..n {
+  Const        r19, 1
+  Add          r4, r4, r19
+  Jump         L4
 L0:
   // return [-1, -1]
-  Const        r22, [-1, -1]
-  Return       r22
+  Const        r21, [-1, -1]
+  Return       r21
   Return       r0

--- a/tests/vm/valid/typed_let.ir.out
+++ b/tests/vm/valid/typed_let.ir.out
@@ -1,6 +1,4 @@
-func main (regs=2)
-  // let y: int
-  Move         r1, r0
+func main (regs=1)
   // print(y)
-  Print        r1
+  Print        r0
   Return       r0

--- a/tests/vm/valid/user_type_literal.ir.out
+++ b/tests/vm/valid/user_type_literal.ir.out
@@ -1,4 +1,4 @@
-func main (regs=22)
+func main (regs=18)
   // title: "Go",
   Const        r0, "Go"
   // author: Person { name: "Bob", age: 42 },
@@ -10,23 +10,11 @@ func main (regs=22)
   Move         r6, r1
   Const        r7, "age"
   Move         r8, r2
-  MakeMap      r9, 3, r3
+  Const        r13, "author"
   // let book = Book {
-  Const        r10, "__name"
-  Const        r11, "Book"
-  // title: "Go",
-  Const        r12, "title"
-  Move         r13, r0
-  // author: Person { name: "Bob", age: 42 },
-  Const        r14, "author"
-  Move         r15, r9
-  // let book = Book {
-  MakeMap      r16, 3, r10
-  Move         r17, r16
+  MakeMap      r15, 3, r3
   // print(book.author.name)
-  Const        r18, "author"
-  Index        r19, r17, r18
-  Const        r20, "name"
-  Index        r21, r19, r20
-  Print        r21
+  Index        r16, r15, r13
+  Index        r17, r16, r5
+  Print        r17
   Return       r0

--- a/tests/vm/valid/values_builtin.ir.out
+++ b/tests/vm/valid/values_builtin.ir.out
@@ -1,8 +1,7 @@
-func main (regs=3)
+func main (regs=2)
   // let m = {"a":1, "b":2, "c":3}
   Const        r0, {"a": 1, "b": 2, "c": 3}
-  Move         r1, r0
   // print(values(m))
-  Values       2,1,0,0
-  Print        r2
+  Const        r1, [1, 2, 3]
+  Print        r1
   Return       r0

--- a/tests/vm/valid/var_assignment.ir.out
+++ b/tests/vm/valid/var_assignment.ir.out
@@ -2,8 +2,7 @@ func main (regs=3)
   // var x = 1
   Const        r0, 1
   // x = 2
-  Const        r2, 2
-  Move         r1, r2
+  Const        r1, 2
   // print(x)
   Print        r1
   Return       r0

--- a/tests/vm/valid/while_loop.ir.out
+++ b/tests/vm/valid/while_loop.ir.out
@@ -2,8 +2,17 @@ func main (regs=6)
   // var i = 0
   Const        r0, 0
   Move         r1, r0
+L1:
+  // while i < 3 {
+  Const        r2, 3
+  LessInt      r3, r1, r2
+  JumpIfFalse  r3, L0
   // print(i)
   Print        r1
+  // i = i + 1
+  Const        r4, 1
+  AddInt       r1, r1, r4
   // while i < 3 {
-  Jump         L0
+  Jump         L1
+L0:
   Return       r0


### PR DESCRIPTION
## Summary
- reuse const registers for selector field names and struct metadata
- increment join loop counters in-place without temporaries
- regenerate VM IR output files

## Testing
- `go test ./runtime/...`
- `go test -tags slow ./tests/vm -run TestVM_IR -update`


------
https://chatgpt.com/codex/tasks/task_e_685f5a555bfc8320890ad01a923103dc