### PR TITLE
Add Mochi language server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,8 +48,10 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sourcegraph/jsonrpc2 v0.2.0 // indirect
 	github.com/spf13/cast v1.9.2 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/tliron/glsp v0.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -109,6 +110,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sourcegraph/jsonrpc2 v0.2.0 h1:KjN/dC4fP6aN9030MZCJs9WQbTOjWHhrtKVpzzSrr/U=
+github.com/sourcegraph/jsonrpc2 v0.2.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/cast v1.9.2 h1:SsGfm7M8QOFtEzumm7UZrZdLLquNdzFYfIbEXntcFbE=
 github.com/spf13/cast v1.9.2/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
@@ -118,6 +121,8 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tliron/glsp v0.2.2 h1:IKPfwpE8Lu8yB6Dayta+IyRMAbTVunudeauEgjXBt+c=
+github.com/tliron/glsp v0.2.2/go.mod h1:GMVWDNeODxHzmDPvYbYTCs7yHVaEATfYtXiYJ9w1nBg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/tools/lsp/cmd/mochi-lsp/main.go
+++ b/tools/lsp/cmd/mochi-lsp/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "mochi/tools/lsp"
+
+func main() {
+	s := lsp.New()
+	_ = s.RunStdio()
+}

--- a/tools/lsp/server.go
+++ b/tools/lsp/server.go
@@ -1,0 +1,201 @@
+package lsp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/alecthomas/participle/v2/lexer"
+
+	"github.com/sourcegraph/jsonrpc2"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+
+	"mochi/parser"
+)
+
+// Server implements a minimal Language Server Protocol server for Mochi.
+type Server struct {
+	handler protocol.Handler
+	docs    map[protocol.DocumentUri]string
+}
+
+// New returns a new Server instance with handlers registered.
+func New() *Server {
+	s := &Server{docs: make(map[protocol.DocumentUri]string)}
+	s.handler = protocol.Handler{
+		Initialize:            s.initialize,
+		Initialized:           s.initialized,
+		Shutdown:              s.shutdown,
+		SetTrace:              s.setTrace,
+		TextDocumentDidOpen:   s.didOpen,
+		TextDocumentDidChange: s.didChange,
+		TextDocumentDidSave:   s.didSave,
+		TextDocumentHover:     s.hover,
+	}
+	return s
+}
+
+// Serve runs the server on the given connection.
+func (s *Server) Serve(ctx context.Context, rwc io.ReadWriteCloser) error {
+	conn := newConn(ctx, rwc, s.handler)
+	<-conn.DisconnectNotify()
+	return nil
+}
+
+// RunStdio runs the server using stdin/stdout streams.
+func (s *Server) RunStdio() error {
+	return s.Serve(context.Background(), stdrwc{})
+}
+
+func (s *Server) initialize(ctx *glsp.Context, params *protocol.InitializeParams) (any, error) {
+	caps := s.handler.CreateServerCapabilities()
+	kind := protocol.TextDocumentSyncKindIncremental
+	caps.TextDocumentSync = &protocol.TextDocumentSyncOptions{Change: &kind}
+	hoverProvider := true
+	caps.HoverProvider = &hoverProvider
+	version := "0.1"
+	return protocol.InitializeResult{
+		Capabilities: caps,
+		ServerInfo: &protocol.InitializeResultServerInfo{
+			Name:    "mochi-lsp",
+			Version: &version,
+		},
+	}, nil
+}
+
+func (s *Server) initialized(ctx *glsp.Context, params *protocol.InitializedParams) error {
+	return nil
+}
+
+func (s *Server) shutdown(ctx *glsp.Context) error { return nil }
+func (s *Server) setTrace(ctx *glsp.Context, params *protocol.SetTraceParams) error {
+	protocol.SetTraceValue(params.Value)
+	return nil
+}
+
+func (s *Server) didOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocumentParams) error {
+	uri := params.TextDocument.URI
+	s.docs[uri] = params.TextDocument.Text
+	s.publishDiagnostics(ctx, uri, params.TextDocument.Text)
+	return nil
+}
+
+func (s *Server) didChange(ctx *glsp.Context, params *protocol.DidChangeTextDocumentParams) error {
+	uri := params.TextDocument.URI
+	text := s.docs[uri]
+	for _, ch := range params.ContentChanges {
+		switch c := ch.(type) {
+		case protocol.TextDocumentContentChangeEvent:
+			if c.Text != "" {
+				text = c.Text
+			}
+		case protocol.TextDocumentContentChangeEventWhole:
+			if c.Text != "" {
+				text = c.Text
+			}
+		}
+	}
+	s.docs[uri] = text
+	s.publishDiagnostics(ctx, uri, text)
+	return nil
+}
+
+func (s *Server) didSave(ctx *glsp.Context, params *protocol.DidSaveTextDocumentParams) error {
+	uri := params.TextDocument.URI
+	text := s.docs[uri]
+	if params.Text != nil {
+		text = *params.Text
+	}
+	s.publishDiagnostics(ctx, uri, text)
+	return nil
+}
+
+func (s *Server) hover(ctx *glsp.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
+	// Very basic hover: return file URI and position
+	msg := fmt.Sprintf("%s:%d:%d", params.TextDocument.URI, params.Position.Line+1, params.Position.Character+1)
+	markup := protocol.MarkupContent{Kind: protocol.MarkupKindPlainText, Value: msg}
+	return &protocol.Hover{Contents: markup}, nil
+}
+
+func (s *Server) publishDiagnostics(ctx *glsp.Context, uri protocol.DocumentUri, text string) {
+	var diags []protocol.Diagnostic
+	if _, err := parser.ParseString(text); err != nil {
+		var posErr interface{ Position() lexer.Position }
+		if errors.As(err, &posErr) {
+			pos := posErr.Position()
+			sev := protocol.DiagnosticSeverityError
+			src := "parser"
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: uint32(pos.Line - 1), Character: uint32(pos.Column - 1)},
+					End:   protocol.Position{Line: uint32(pos.Line - 1), Character: uint32(pos.Column)},
+				},
+				Severity: &sev,
+				Source:   &src,
+				Message:  err.Error(),
+			})
+		} else {
+			sev := protocol.DiagnosticSeverityError
+			src := "parser"
+			diags = append(diags, protocol.Diagnostic{
+				Severity: &sev,
+				Source:   &src,
+				Message:  err.Error(),
+			})
+		}
+	}
+	ctx.Notify(string(protocol.ServerTextDocumentPublishDiagnostics), protocol.PublishDiagnosticsParams{URI: uri, Diagnostics: diags})
+}
+
+type pipe struct {
+	r io.ReadCloser
+	w io.WriteCloser
+}
+
+func (p *pipe) Read(b []byte) (int, error)  { return p.r.Read(b) }
+func (p *pipe) Write(b []byte) (int, error) { return p.w.Write(b) }
+func (p *pipe) Close() error                { p.r.Close(); return p.w.Close() }
+
+type stdrwc struct{}
+
+func (stdrwc) Read(p []byte) (int, error)  { return io.ReadFull(os.Stdin, p) }
+func (stdrwc) Write(p []byte) (int, error) { return os.Stdout.Write(p) }
+func (stdrwc) Close() error                { return nil }
+
+// newConn creates a JSON-RPC2 connection for the handler.
+func newConn(ctx context.Context, rwc io.ReadWriteCloser, handler protocol.Handler) *jsonrpc2.Conn {
+	h := jsonrpc2.HandlerWithError(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+		glspCtx := glsp.Context{
+			Method: req.Method,
+			Notify: func(method string, params any) { _ = conn.Notify(ctx, method, params) },
+			Call:   func(method string, params, result any) { _ = conn.Call(ctx, method, params, result) },
+		}
+		if req.Params != nil {
+			glspCtx.Params = *req.Params
+		}
+		switch req.Method {
+		case "exit":
+			handler.Handle(&glspCtx)
+			return nil, conn.Close()
+		default:
+			r, validMethod, validParams, err := handler.Handle(&glspCtx)
+			if !validMethod {
+				return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: fmt.Sprintf("method not supported: %s", req.Method)}
+			}
+			if !validParams {
+				if err != nil {
+					return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams, Message: err.Error()}
+				}
+				return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+			}
+			if err != nil {
+				return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidRequest, Message: err.Error()}
+			}
+			return r, nil
+		}
+	})
+	return jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(rwc, jsonrpc2.VSCodeObjectCodec{}), h)
+}

--- a/tools/lsp/server_test.go
+++ b/tools/lsp/server_test.go
@@ -1,0 +1,102 @@
+package lsp_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"mochi/tools/lsp"
+
+	"github.com/sourcegraph/jsonrpc2"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// pipe implements io.ReadWriteCloser using two pipe ends.
+type pipe struct {
+	r io.ReadCloser
+	w io.WriteCloser
+}
+
+func (p *pipe) Read(b []byte) (int, error)  { return p.r.Read(b) }
+func (p *pipe) Write(b []byte) (int, error) { return p.w.Write(b) }
+func (p *pipe) Close() error                { p.r.Close(); return p.w.Close() }
+
+func startServer(t *testing.T) (*jsonrpc2.Conn, *[]protocol.PublishDiagnosticsParams) {
+	t.Helper()
+	sr, cw := io.Pipe() // server reads from sr, client writes to cw
+	cr, sw := io.Pipe() // client reads from cr, server writes to sw
+	serverPipe := &pipe{r: sr, w: sw}
+	clientPipe := &pipe{r: cr, w: cw}
+
+	ls := lsp.New()
+	go ls.Serve(context.Background(), serverPipe)
+
+	var mu sync.Mutex
+	var diags []protocol.PublishDiagnosticsParams
+	conn := jsonrpc2.NewConn(context.Background(), jsonrpc2.NewBufferedStream(clientPipe, jsonrpc2.VSCodeObjectCodec{}),
+		jsonrpc2.HandlerWithError(func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) { return nil, nil }),
+		jsonrpc2.OnRecv(func(req *jsonrpc2.Request, resp *jsonrpc2.Response) {
+			if req != nil && req.Method == string(protocol.ServerTextDocumentPublishDiagnostics) {
+				var p protocol.PublishDiagnosticsParams
+				_ = json.Unmarshal(*req.Params, &p)
+				mu.Lock()
+				diags = append(diags, p)
+				mu.Unlock()
+			}
+		}))
+	return conn, &diags
+}
+
+func TestLSPInitialize(t *testing.T) {
+	conn, _ := startServer(t)
+	var result protocol.InitializeResult
+	if err := conn.Call(context.Background(), "initialize", &protocol.InitializeParams{}, &result); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if result.ServerInfo == nil || result.ServerInfo.Name != "mochi-lsp" {
+		t.Fatalf("unexpected server info: %#v", result.ServerInfo)
+	}
+}
+
+func TestLSPDiagnostics(t *testing.T) {
+	conn, diags := startServer(t)
+	ctx := context.Background()
+	var initRes protocol.InitializeResult
+	if err := conn.Call(ctx, "initialize", &protocol.InitializeParams{}, &initRes); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	_ = conn.Notify(ctx, "initialized", &protocol.InitializedParams{})
+
+	uri := protocol.DocumentUri("file:///test.mochi")
+	open := protocol.DidOpenTextDocumentParams{TextDocument: protocol.TextDocumentItem{URI: uri, LanguageID: "mochi", Version: 1, Text: "print(\"hi\")"}}
+	_ = conn.Notify(ctx, "textDocument/didOpen", open)
+
+	bad := "fun {"
+	invalid := protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: uri},
+			Version:                2,
+		},
+		ContentChanges: []any{protocol.TextDocumentContentChangeEvent{Text: bad}},
+	}
+	_ = conn.Notify(ctx, "textDocument/didChange", invalid)
+
+	// Allow diagnostics to be processed
+	// Wait for at most short time
+	for i := 0; i < 100; i++ {
+		if len(*diags) >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Logf("diags: %+v", *diags)
+	if len(*diags) < 2 {
+		t.Fatal("no diagnostics published")
+	}
+	if last := (*diags)[len(*diags)-1]; len(last.Diagnostics) == 0 {
+		t.Fatalf("expected error diagnostics")
+	}
+}


### PR DESCRIPTION
## Summary
- add new `tools/lsp` package implementing a minimal Language Server Protocol server
- support initialization, text document sync, diagnostics and hover
- expose binary under `tools/lsp/cmd/mochi-lsp`
- include tests exercising initialization and diagnostics
- update dependencies

## Testing
- `go test ./tools/lsp -run TestLSP`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860a79a11708320b90aec5d67d9b517