### PR TITLE
Extend LSP with docs and parse doc comments

### DIFF
--- a/examples/v0.7/docs.mochi
+++ b/examples/v0.7/docs.mochi
@@ -1,21 +1,21 @@
-// Package mathutil provides helper functions for math operations.
-// This package includes functions like square, clamp, and average.
+/// Package mathutil provides helper functions for math operations.
+/// This package includes functions like square, clamp, and average.
 package mathutil
 
-// PI is the mathematical constant \u03c0 (approx. 3.14159).
+/// PI is the mathematical constant \u03c0 (approx. 3.14159).
 let PI = 3.14159
 
-// square returns the square of a number.
-// Example:
-//   square(3) => 9
+/// square returns the square of a number.
+/// Example:
+///   square(3) => 9
 fun square(x: float): float {
   return x * x
 }
 
-// clamp restricts a value to a given min and max range.
-// Example:
-//   clamp(5, 0, 10) => 5
-//   clamp(15, 0, 10) => 10
+/// clamp restricts a value to a given min and max range.
+/// Example:
+///   clamp(5, 0, 10) => 5
+///   clamp(15, 0, 10) => 10
 fun clamp(value: float, min: float, max: float): float {
   if value < min {
     return min
@@ -25,8 +25,8 @@ fun clamp(value: float, min: float, max: float): float {
   return value
 }
 
-// average computes the mean of a list of floats.
-// If the list is empty, returns 0.
+/// average computes the mean of a list of floats.
+/// If the list is empty, returns 0.
   fun average(nums: list<float>): float {
     if len(nums) == 0 {
       return 0.0
@@ -38,14 +38,14 @@ fun clamp(value: float, min: float, max: float): float {
     return sum / (len(nums) as float)
   }
 
-// Person represents a simple record with a name and age.
+/// Person represents a simple record with a name and age.
 type Person {
-  // The person's name.
+  /// The person's name.
   name: string
 
-  // The person's age in years.
+  /// The person's age in years.
   age: int
 }
 
-// Status represents a state a task can be in.
+/// Status represents a state a task can be in.
 type Status = Pending | Done | Failed

--- a/parser/docs.go
+++ b/parser/docs.go
@@ -22,13 +22,13 @@ func extractLineDocs(src string) map[int]string {
 	i := 0
 	for i < len(lines) {
 		line := strings.TrimSpace(lines[i])
-		if strings.HasPrefix(line, "//") {
-			block := []string{strings.TrimSpace(strings.TrimPrefix(line, "//"))}
+		if strings.HasPrefix(line, "///") {
+			block := []string{strings.TrimSpace(strings.TrimPrefix(line, "///"))}
 			j := i + 1
 			for j < len(lines) {
 				t := strings.TrimSpace(lines[j])
-				if strings.HasPrefix(t, "//") {
-					block = append(block, strings.TrimSpace(strings.TrimPrefix(t, "//")))
+				if strings.HasPrefix(t, "///") {
+					block = append(block, strings.TrimSpace(strings.TrimPrefix(t, "///")))
 					j++
 				} else {
 					break
@@ -51,17 +51,42 @@ func attachStmtDocs(s *Statement, docs map[int]string) {
 		if doc, ok := docs[s.Fun.Pos.Line]; ok {
 			s.Fun.Doc = doc
 		}
-	case s.Agent != nil:
-		if doc, ok := docs[s.Agent.Pos.Line]; ok {
-			s.Agent.Doc = doc
+	case s.Let != nil:
+		if doc, ok := docs[s.Let.Pos.Line]; ok {
+			s.Let.Doc = doc
+		}
+	case s.Var != nil:
+		if doc, ok := docs[s.Var.Pos.Line]; ok {
+			s.Var.Doc = doc
 		}
 	case s.Type != nil:
 		if doc, ok := docs[s.Type.Pos.Line]; ok {
 			s.Type.Doc = doc
 		}
+		for _, m := range s.Type.Members {
+			if m.Field != nil {
+				if doc, ok := docs[m.Field.Pos.Line]; ok {
+					m.Field.Doc = doc
+				}
+			}
+			if m.Method != nil {
+				if doc, ok := docs[m.Method.Pos.Line]; ok {
+					m.Method.Doc = doc
+				}
+			}
+		}
+	case s.Agent != nil:
+		if doc, ok := docs[s.Agent.Pos.Line]; ok {
+			s.Agent.Doc = doc
+		}
 	case s.Stream != nil:
 		if doc, ok := docs[s.Stream.Pos.Line]; ok {
 			s.Stream.Doc = doc
+		}
+		for _, f := range s.Stream.Fields {
+			if doc, ok := docs[f.Pos.Line]; ok {
+				f.Doc = doc
+			}
 		}
 	}
 }

--- a/parser/docs_test.go
+++ b/parser/docs_test.go
@@ -27,6 +27,16 @@ func TestParser_DocComments(t *testing.T) {
 			}
 			found = true
 		}
+		if stmt.Let != nil && stmt.Let.Name == "PI" && stmt.Let.Doc == "" {
+			t.Errorf("missing doc for PI")
+		}
+		if stmt.Type != nil && stmt.Type.Name == "Person" {
+			for _, m := range stmt.Type.Members {
+				if m.Field != nil && m.Field.Name == "name" && m.Field.Doc == "" {
+					t.Errorf("missing doc for field name")
+				}
+			}
+		}
 	}
 	if !found {
 		t.Fatalf("square function not found")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -138,7 +138,8 @@ type TypeVariant struct {
 
 type TypeField struct {
 	Pos  lexer.Position
-	Name string   `parser:"@Ident ':'"`
+	Name string `parser:"@Ident ':'"`
+	Doc  string
 	Type *TypeRef `parser:"@@"`
 }
 
@@ -169,14 +170,16 @@ type FunType struct {
 
 type LetStmt struct {
 	Pos   lexer.Position
-	Name  string   `parser:"'let' @Ident"`
+	Name  string `parser:"'let' @Ident"`
+	Doc   string
 	Type  *TypeRef `parser:"[ ':' @@ ]"`
 	Value *Expr    `parser:"[ '=' @@ ]"`
 }
 
 type VarStmt struct {
 	Pos   lexer.Position
-	Name  string   `parser:"'var' @Ident"`
+	Name  string `parser:"'var' @Ident"`
+	Doc   string
 	Type  *TypeRef `parser:"[ ':' @@ ]"`
 	Value *Expr    `parser:"[ '=' @@ ]"`
 }
@@ -561,7 +564,8 @@ type ImportStmt struct {
 
 type StreamField struct {
 	Pos  lexer.Position
-	Name string   `parser:"@Ident ':'"`
+	Name string `parser:"@Ident ':'"`
+	Doc  string
 	Type *TypeRef `parser:"@@"`
 }
 

--- a/tools/lsp/README.md
+++ b/tools/lsp/README.md
@@ -11,5 +11,7 @@ The command line entry point is `cmd/mochi-lsp`.  The binary communicates over s
 - Return hover text for identifiers
 - Offer keyword completion items
 - Jump to symbol definitions
+- Search symbols across open files via `workspaceSymbol`
+- Find references to a symbol via `references`
 
 Unit tests under this directory verify the analyser and server behaviour.

--- a/tools/lsp/references_test.go
+++ b/tools/lsp/references_test.go
@@ -1,0 +1,12 @@
+package lsp
+
+import "testing"
+
+func TestReferences(t *testing.T) {
+	uri := "file:///test.mochi"
+	src := "fun add(x:int,y:int):int{ return x+y } let z = add(1,2)"
+	locs, _ := References(uri, src, 0, 1)
+	if len(locs) < 2 {
+		t.Fatalf("expected multiple references, got %v", locs)
+	}
+}

--- a/tools/lsp/server_test.go
+++ b/tools/lsp/server_test.go
@@ -49,4 +49,25 @@ func TestServerHandlers(t *testing.T) {
 	if loc.URI != uri {
 		t.Fatalf("unexpected definition location %v", loc)
 	}
+
+	syms2, err := srv.workspaceSymbol(ctx, &protocol.WorkspaceSymbolParams{Query: "add"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(syms2) != 1 || syms2[0].Name != "add" {
+		t.Fatalf("unexpected workspace symbols: %v", syms2)
+	}
+
+	refs, err := srv.references(ctx, &protocol.ReferenceParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     protocol.Position{Line: 0, Character: 1},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) == 0 {
+		t.Fatalf("expected references")
+	}
 }

--- a/tools/lsp/workspace_symbol_test.go
+++ b/tools/lsp/workspace_symbol_test.go
@@ -1,0 +1,11 @@
+package lsp
+
+import "testing"
+
+func TestWorkspaceSymbols(t *testing.T) {
+	docs := map[string]string{"file:///test.mochi": "fun add(x:int,y:int):int{ return x+y }"}
+	syms := WorkspaceSymbols(docs, "add")
+	if len(syms) != 1 || syms[0].Name != "add" {
+		t.Fatalf("unexpected symbols: %v", syms)
+	}
+}


### PR DESCRIPTION
## Summary
- capture documentation comments using `///` and attach them to structs, stream fields and functions
- expose docs to LSP features and improve hover text
- parse docs when generating workspace or document symbols
- adjust documentation example and tests
- added doc support for let/var and implement LSP references feature

## Testing
- `go test ./... -run .`


------
https://chatgpt.com/codex/tasks/task_e_6860b2c097bc83209362f44d7bb49dcc