### PR TITLE
Enhance LSP hover and symbol details

### DIFF
--- a/tools/lsp/README.md
+++ b/tools/lsp/README.md
@@ -6,12 +6,33 @@ The command line entry point is `cmd/mochi-lsp`.  The binary communicates over s
 
 ## Features
 
-- Parse and type check files to surface diagnostics
-- Provide document outline information via `documentSymbol`
-- Return hover text for identifiers
-- Offer keyword completion items
+- Parse source files and run the static type checker to surface diagnostics with helpful error codes
+- Provide document outline information via `documentSymbol` including the inferred type of each declaration
+- Return hover text that shows the symbol's type and any preceding documentation comment
+- Offer basic keyword completion items
 - Jump to symbol definitions
 - Search symbols across open files via `workspaceSymbol`
 - Find references to a symbol via `references`
+- Highlight all usages of a symbol in the current file via `documentHighlight`
+- Rename a symbol across the workspace via `rename`
+
+Much of this information comes from the `types` checker and built‑ins defined in `runtime/vm`.
 
 Unit tests under this directory verify the analyser and server behaviour.
+
+## Feature Checklist
+
+Inspired by popular language servers such as [gopls](https://pkg.go.dev/golang.org/x/tools/gopls) and [rust-analyzer](https://rust-analyzer.github.io/), we track feature parity using the following checklist:
+
+- [x] Diagnostics
+- [x] Document symbols
+- [x] Hover information
+- [x] Keyword completions
+- [x] Go to definition
+- [x] Workspace symbol search
+- [x] References
+- [x] Document highlights
+- [x] Rename
+- [ ] Signature help
+- [ ] Formatting support
+- [ ] Semantic tokens

--- a/tools/lsp/document_highlight_test.go
+++ b/tools/lsp/document_highlight_test.go
@@ -1,0 +1,12 @@
+package lsp
+
+import "testing"
+
+func TestDocumentHighlight(t *testing.T) {
+	uri := "file:///test.mochi"
+	src := "fun add(x:int,y:int):int{ return x+y } let z = add(1,2)"
+	highlights, _ := DocumentHighlight(uri, src, 0, 1)
+	if len(highlights) < 2 {
+		t.Fatalf("expected multiple highlights, got %v", highlights)
+	}
+}

--- a/tools/lsp/document_symbols_test.go
+++ b/tools/lsp/document_symbols_test.go
@@ -14,4 +14,10 @@ func TestDocumentSymbols(t *testing.T) {
 	if syms[0].Name != "add" || syms[1].Name != "v" {
 		t.Fatalf("unexpected symbols: %v", syms)
 	}
+	if syms[0].Detail == nil || *syms[0].Detail != "fun(int, int): int [pure]" {
+		t.Fatalf("unexpected detail for add: %v", syms[0].Detail)
+	}
+	if syms[1].Detail == nil || *syms[1].Detail != "int" {
+		t.Fatalf("unexpected detail for v: %v", syms[1].Detail)
+	}
 }

--- a/tools/lsp/hover_test.go
+++ b/tools/lsp/hover_test.go
@@ -1,6 +1,11 @@
 package lsp
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
 
 func TestHover(t *testing.T) {
 	src := "fun add(x:int,y:int):int{ return x+y }"
@@ -8,7 +13,8 @@ func TestHover(t *testing.T) {
 	if len(diags) != 0 {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
-	if hover.Contents == nil {
-		t.Fatalf("expected hover text")
+	mc, ok := hover.Contents.(protocol.MarkupContent)
+	if !ok || !strings.Contains(mc.Value, "fun(int, int): int") {
+		t.Fatalf("unexpected hover: %#v", hover)
 	}
 }

--- a/tools/lsp/rename_test.go
+++ b/tools/lsp/rename_test.go
@@ -1,0 +1,14 @@
+package lsp
+
+import "testing"
+
+func TestRename(t *testing.T) {
+	docs := map[string]string{"file:///test.mochi": "fun add(x:int,y:int):int{ return x+y } let z = add(1,2)"}
+	edit, _ := Rename(docs, "file:///test.mochi", 0, 1, "sum")
+	if len(edit.Changes) == 0 {
+		t.Fatalf("expected edits, got %v", edit)
+	}
+	if len(edit.Changes["file:///test.mochi"]) < 2 {
+		t.Fatalf("expected multiple edits, got %v", edit.Changes["file:///test.mochi"])
+	}
+}


### PR DESCRIPTION
## Summary
- update README with more detailed feature list
- factor out parseAndCheck helper for parsing and type checking
- include type and doc info in DocumentSymbols and Hover
- expand unit tests for DocumentSymbols and Hover

## Testing
- `go test ./tools/lsp -run Test`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860b914a30483209b49855ff1312ba9