### PR TITLE
Update join benchmarks docs

### DIFF
--- a/runtime/vm/JOINS_BENCHMARKS.md
+++ b/runtime/vm/JOINS_BENCHMARKS.md
@@ -1,12 +1,10 @@
 # Join Benchmarks
 
-The table below compares naive nested-loop joins against the optimized hash join implementation. Each benchmark executes a simple join 100 times with 100 rows on each side.
+Benchmarks are implemented in [join_bench_test.go](./join_bench_test.go). Each test constructs two lists of 100 rows with an integer `id` field and executes the join algorithm.
 
-| Benchmark | Nested Join (µs) | Hash Join (µs) |
-|-----------|-----------------:|---------------:|
-| plain join | 900 | 200 |
-| left filter | 850 | 180 |
-| right filter | 840 | 170 |
-| empty right | 50 | 5 |
+| Benchmark    | Nested Join (µs) | Hash Join (µs) | Hash+Prealloc (µs) | Merge Join (µs) |
+|--------------|-----------------:|---------------:|-------------------:|---------------:|
+| plain join   | 193              | 50             | 33                 | 36             |
 
-The optimized hash join yields a ~4-5x speedup over the unoptimized nested-loop approach.
+The preallocated hash join reduces allocations compared to the basic hash join.
+Merge join further optimizes joins when both inputs are pre-sorted by the join key.

--- a/runtime/vm/join_algos.go
+++ b/runtime/vm/join_algos.go
@@ -1,0 +1,75 @@
+package vm
+
+// Simple join algorithms used for benchmarking.
+
+// NestedLoopJoin performs a basic nested loop join on the "id" field.
+func NestedLoopJoin(left, right []Value) []Value {
+	out := make([]Value, 0)
+	for _, l := range left {
+		lid := l.Map["id"].Int
+		for _, r := range right {
+			if lid == r.Map["id"].Int {
+				out = append(out, Value{Tag: ValueList, List: []Value{l, r}})
+			}
+		}
+	}
+	return out
+}
+
+// HashJoin performs an inner hash join on the "id" field.
+func HashJoin(left, right []Value) []Value {
+	buckets := make(map[int][]Value)
+	for _, r := range right {
+		id := r.Map["id"].Int
+		buckets[id] = append(buckets[id], r)
+	}
+	out := make([]Value, 0)
+	for _, l := range left {
+		id := l.Map["id"].Int
+		if matches, ok := buckets[id]; ok {
+			for _, r := range matches {
+				out = append(out, Value{Tag: ValueList, List: []Value{l, r}})
+			}
+		}
+	}
+	return out
+}
+
+// HashJoinPrealloc is like HashJoin but preallocates buckets and the result slice.
+func HashJoinPrealloc(left, right []Value) []Value {
+	buckets := make(map[int][]Value, len(right))
+	for _, r := range right {
+		id := r.Map["id"].Int
+		buckets[id] = append(buckets[id], r)
+	}
+	out := make([]Value, 0, len(left))
+	for _, l := range left {
+		id := l.Map["id"].Int
+		if matches, ok := buckets[id]; ok {
+			for _, r := range matches {
+				out = append(out, Value{Tag: ValueList, List: []Value{l, r}})
+			}
+		}
+	}
+	return out
+}
+
+// MergeJoin performs an inner merge join on sorted inputs.
+func MergeJoin(left, right []Value) []Value {
+	out := make([]Value, 0)
+	i, j := 0, 0
+	for i < len(left) && j < len(right) {
+		lid := left[i].Map["id"].Int
+		rid := right[j].Map["id"].Int
+		if lid == rid {
+			out = append(out, Value{Tag: ValueList, List: []Value{left[i], right[j]}})
+			i++
+			j++
+		} else if lid < rid {
+			i++
+		} else {
+			j++
+		}
+	}
+	return out
+}

--- a/runtime/vm/join_bench_test.go
+++ b/runtime/vm/join_bench_test.go
@@ -1,0 +1,47 @@
+package vm
+
+import "testing"
+
+func makeRows(n int) []Value {
+	rows := make([]Value, n)
+	for i := 0; i < n; i++ {
+		rows[i] = Value{Tag: ValueMap, Map: map[string]Value{"id": {Tag: ValueInt, Int: i}}}
+	}
+	return rows
+}
+
+func BenchmarkNestedLoopJoin(b *testing.B) {
+	left := makeRows(100)
+	right := makeRows(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NestedLoopJoin(left, right)
+	}
+}
+
+func BenchmarkHashJoin(b *testing.B) {
+	left := makeRows(100)
+	right := makeRows(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = HashJoin(left, right)
+	}
+}
+
+func BenchmarkHashJoinPrealloc(b *testing.B) {
+	left := makeRows(100)
+	right := makeRows(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = HashJoinPrealloc(left, right)
+	}
+}
+
+func BenchmarkMergeJoin(b *testing.B) {
+	left := makeRows(100)
+	right := makeRows(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MergeJoin(left, right)
+	}
+}


### PR DESCRIPTION
## Summary
- add benchmarked join algorithms in Go tests
- document merge join optimization

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`
- `go test ./runtime/vm -bench Join -benchmem`

------
https://chatgpt.com/codex/tasks/task_e_6860ba8d8100832092eb99e835475b2b