### PR TITLE
Optimize vm grouping

### DIFF
--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -1,4 +1,4 @@
-func main (regs=75)
+func main (regs=77)
   // let people = [
   Const        r0, [{"age": 30, "city": "Paris", "name": "Alice"}, {"age": 15, "city": "Hanoi", "name": "Bob"}, {"age": 65, "city": "Paris", "name": "Charlie"}, {"age": 45, "city": "Hanoi", "name": "Diana"}, {"age": 70, "city": "Paris", "name": "Eve"}, {"age": 22, "city": "Hanoi", "name": "Frank"}]
   // let stats = from person in people
@@ -36,74 +36,78 @@ L2:
   // let stats = from person in people
   Const        r22, "items"
   Move         r23, r18
-  MakeMap      r24, 3, r19
-  SetIndex     r10, r16, r24
-  Append       r11, r11, r24
+  Const        r24, 0
+  MakeMap      r25, 4, r19
+  SetIndex     r10, r16, r25
+  Append       r26, r11, r25
+  Move         r11, r26
 L1:
-  Index        r26, r10, r16
-  Index        r27, r26, r22
-  Append       r28, r27, r13
-  SetIndex     r26, r22, r28
-  Const        r29, 1
-  AddInt       r9, r9, r29
+  Index        r27, r10, r16
+  Index        r28, r27, r22
+  Append       r29, r28, r13
+  SetIndex     r27, r22, r29
+  Index        r30, r27, r4
+  Const        r31, 1
+  AddInt       r32, r30, r31
+  SetIndex     r27, r4, r32
+  AddInt       r9, r9, r31
   Jump         L2
 L0:
-  Const        r31, 0
-  Move         r30, r31
-  Len          r32, r11
+  Move         r33, r24
+  Len          r34, r11
 L6:
-  LessInt      r33, r30, r32
-  JumpIfFalse  r33, L3
-  Index        r35, r11, r30
+  LessInt      r35, r33, r34
+  JumpIfFalse  r35, L3
+  Index        r37, r11, r33
   // city: g.key,
-  Const        r36, "city"
-  Index        r37, r35, r3
+  Const        r38, "city"
+  Index        r39, r37, r3
   // count: count(g),
-  Const        r38, "count"
-  Count        r39, r35
+  Const        r40, "count"
+  Index        r41, r37, r4
   // avg_age: avg(from p in g select p.age)
-  Const        r40, "avg_age"
-  Const        r41, []
-  IterPrep     r42, r35
-  Len          r43, r42
-  Move         r44, r31
+  Const        r42, "avg_age"
+  Const        r43, []
+  IterPrep     r44, r37
+  Len          r45, r44
+  Move         r46, r24
 L5:
-  LessInt      r45, r44, r43
-  JumpIfFalse  r45, L4
-  Index        r47, r42, r44
-  Index        r48, r47, r6
-  Append       r41, r41, r48
-  AddInt       r44, r44, r29
+  LessInt      r47, r46, r45
+  JumpIfFalse  r47, L4
+  Index        r49, r44, r46
+  Index        r50, r49, r6
+  Append       r43, r43, r50
+  AddInt       r46, r46, r31
   Jump         L5
 L4:
   // select {
-  MakeMap      r54, 3, r36
+  MakeMap      r56, 3, r38
   // let stats = from person in people
-  Append       r1, r1, r54
-  AddInt       r30, r30, r29
+  Append       r1, r1, r56
+  AddInt       r33, r33, r31
   Jump         L6
 L3:
   // print("--- People grouped by city ---")
-  Const        r56, "--- People grouped by city ---"
-  Print        r56
+  Const        r58, "--- People grouped by city ---"
+  Print        r58
   // for s in stats {
-  IterPrep     r57, r1
-  Len          r58, r57
-  Const        r59, 0
+  IterPrep     r59, r1
+  Len          r60, r59
+  Const        r61, 0
 L8:
-  Less         r60, r59, r58
-  JumpIfFalse  r60, L7
-  Index        r62, r57, r59
+  Less         r62, r61, r60
+  JumpIfFalse  r62, L7
+  Index        r64, r59, r61
   // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
-  Index        r63, r62, r2
-  Const        r64, ": count ="
-  Index        r65, r62, r4
-  Const        r66, ", avg_age ="
-  Index        r67, r62, r5
-  PrintN       r63, 5, r63
+  Index        r65, r64, r2
+  Const        r66, ": count ="
+  Index        r67, r64, r4
+  Const        r68, ", avg_age ="
+  Index        r69, r64, r5
+  PrintN       r65, 5, r65
   // for s in stats {
-  Const        r73, 1
-  Add          r59, r59, r73
+  Const        r75, 1
+  Add          r61, r61, r75
   Jump         L8
 L7:
   Return       r0

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -1,4 +1,4 @@
-func main (regs=70)
+func main (regs=73)
   // let items = [
   Const        r0, [{"cat": "a", "flag": true, "val": 10}, {"cat": "a", "flag": false, "val": 5}, {"cat": "b", "flag": true, "val": 20}]
   // from i in items
@@ -34,68 +34,72 @@ L2:
   // from i in items
   Const        r22, "items"
   Move         r23, r18
-  MakeMap      r24, 3, r19
-  SetIndex     r10, r16, r24
+  Const        r24, "count"
+  Const        r25, 0
+  MakeMap      r26, 4, r19
+  SetIndex     r10, r16, r26
 L1:
-  Index        r26, r10, r16
-  Index        r27, r26, r22
-  Append       r28, r27, r13
-  SetIndex     r26, r22, r28
-  Const        r29, 1
-  AddInt       r9, r9, r29
+  Index        r28, r10, r16
+  Index        r29, r28, r22
+  Append       r30, r29, r13
+  SetIndex     r28, r22, r30
+  Index        r31, r28, r24
+  Const        r32, 1
+  AddInt       r33, r31, r32
+  SetIndex     r28, r24, r33
+  AddInt       r9, r9, r32
   Jump         L2
 L0:
-  Const        r31, 0
-  Move         r30, r31
-  Const        r32, 0
+  Move         r34, r25
+  Const        r35, 0
 L9:
-  LessInt      r33, r30, r32
-  JumpIfFalse  r33, L3
-  Index        r35, r11, r30
+  LessInt      r36, r34, r35
+  JumpIfFalse  r36, L3
+  Index        r38, r11, r34
   // cat: g.key,
-  Const        r36, "cat"
-  Index        r37, r35, r3
+  Const        r39, "cat"
+  Index        r40, r38, r3
   // share:
-  Const        r38, "share"
+  Const        r41, "share"
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r39, []
-  IterPrep     r40, r35
-  Len          r41, r40
-  Move         r42, r31
+  Const        r42, []
+  IterPrep     r43, r38
+  Len          r44, r43
+  Move         r45, r25
 L6:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L4
-  Index        r45, r40, r42
-  Index        r46, r45, r5
-  JumpIfFalse  r46, L5
+  LessInt      r46, r45, r44
+  JumpIfFalse  r46, L4
+  Index        r48, r43, r45
+  Index        r49, r48, r5
+  JumpIfFalse  r49, L5
 L5:
-  Append       r39, r39, r31
-  AddInt       r42, r42, r29
+  Append       r42, r42, r25
+  AddInt       r45, r45, r32
   Jump         L6
 L4:
   // sum(from x in g select x.val)
-  Const        r51, []
-  IterPrep     r52, r35
-  Len          r53, r52
-  Move         r54, r31
+  Const        r54, []
+  IterPrep     r55, r38
+  Len          r56, r55
+  Move         r57, r25
 L8:
-  LessInt      r55, r54, r53
-  JumpIfFalse  r55, L7
-  Index        r45, r52, r54
-  Index        r57, r45, r6
-  Append       r51, r51, r57
-  AddInt       r54, r54, r29
+  LessInt      r58, r57, r56
+  JumpIfFalse  r58, L7
+  Index        r48, r55, r57
+  Index        r60, r48, r6
+  Append       r54, r54, r60
+  AddInt       r57, r57, r32
   Jump         L8
 L7:
   // select {
-  MakeMap      r63, 2, r36
+  MakeMap      r66, 2, r39
   // sort by g.key
-  Index        r65, r35, r3
+  Index        r68, r38, r3
   // from i in items
-  Move         r66, r63
-  MakeList     r67, 2, r65
-  Append       r1, r1, r67
-  AddInt       r30, r30, r29
+  Move         r69, r66
+  MakeList     r70, 2, r68
+  Append       r1, r1, r70
+  AddInt       r34, r34, r32
   Jump         L9
 L3:
   // sort by g.key

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -1,4 +1,4 @@
-func main (regs=45)
+func main (regs=48)
   // let people = [
   Const        r0, [{"city": "Paris", "name": "Alice"}, {"city": "Hanoi", "name": "Bob"}, {"city": "Paris", "name": "Charlie"}, {"city": "Hanoi", "name": "Diana"}, {"city": "Paris", "name": "Eve"}, {"city": "Hanoi", "name": "Frank"}, {"city": "Paris", "name": "George"}]
   // from p in people
@@ -31,37 +31,42 @@ L2:
   // from p in people
   Const        r20, "items"
   Move         r21, r16
-  MakeMap      r22, 3, r17
-  SetIndex     r8, r14, r22
+  Const        r22, "count"
+  Const        r23, 0
+  MakeMap      r24, 4, r17
+  SetIndex     r8, r14, r24
 L1:
-  Index        r24, r8, r14
-  Index        r25, r24, r20
-  Append       r26, r25, r11
-  SetIndex     r24, r20, r26
-  Const        r27, 1
-  AddInt       r7, r7, r27
+  Index        r26, r8, r14
+  Index        r27, r26, r20
+  Append       r28, r27, r11
+  SetIndex     r26, r20, r28
+  Index        r29, r26, r22
+  Const        r30, 1
+  AddInt       r31, r29, r30
+  SetIndex     r26, r22, r31
+  AddInt       r7, r7, r30
   Jump         L2
 L0:
-  Const        r28, 0
-  Const        r30, 0
+  Move         r32, r23
+  Const        r33, 0
 L4:
-  LessInt      r31, r28, r30
-  JumpIfFalse  r31, L3
-  Index        r33, r9, r28
+  LessInt      r34, r32, r33
+  JumpIfFalse  r34, L3
+  Index        r36, r9, r32
   // having count(g) >= 4
-  Count        r34, r33
-  Const        r35, 4
-  LessEqInt    r36, r35, r34
-  JumpIfFalse  r36, L3
+  Index        r37, r36, r22
+  Const        r38, 4
+  LessEq       r39, r38, r37
+  JumpIfFalse  r39, L3
   // select { city: g.key, num: count(g) }
-  Const        r37, "city"
-  Index        r38, r33, r3
-  Const        r39, "num"
-  Count        r40, r33
-  MakeMap      r43, 2, r37
+  Const        r40, "city"
+  Index        r41, r36, r3
+  Const        r42, "num"
+  Index        r43, r36, r22
+  MakeMap      r46, 2, r40
   // from p in people
-  Append       r1, r1, r43
-  AddInt       r28, r28, r27
+  Append       r1, r1, r46
+  AddInt       r32, r32, r30
   Jump         L4
 L3:
   // json(big)

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=74)
+func main (regs=76)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
   // let orders = [
@@ -55,62 +55,67 @@ L4:
   // let stats = from o in orders
   Const        r37, "items"
   Move         r38, r33
-  MakeMap      r39, 3, r34
-  SetIndex     r6, r31, r39
-  Append       r7, r7, r39
+  Const        r39, 0
+  MakeMap      r40, 4, r34
+  SetIndex     r6, r31, r40
+  Append       r41, r7, r40
+  Move         r7, r41
 L3:
-  Index        r41, r6, r31
-  Index        r42, r41, r37
-  Append       r43, r42, r29
-  SetIndex     r41, r37, r43
+  Index        r42, r6, r31
+  Index        r43, r42, r37
+  Append       r44, r43, r29
+  SetIndex     r42, r37, r44
+  Index        r45, r42, r5
+  Const        r46, 1
+  AddInt       r47, r45, r46
+  SetIndex     r42, r5, r47
 L2:
   // join from c in customers on o.customerId == c.id
-  Const        r44, 1
-  AddInt       r16, r16, r44
+  AddInt       r16, r16, r46
   Jump         L4
 L1:
   // let stats = from o in orders
-  AddInt       r10, r10, r44
+  AddInt       r10, r10, r46
   Jump         L5
 L0:
-  Const        r45, 0
-  Len          r47, r7
+  Move         r48, r39
+  Len          r49, r7
 L7:
-  LessInt      r48, r45, r47
-  JumpIfFalse  r48, L6
-  Index        r50, r7, r45
+  LessInt      r50, r48, r49
+  JumpIfFalse  r50, L6
+  Index        r52, r7, r48
   // name: g.key,
-  Const        r51, "name"
-  Index        r52, r50, r4
+  Const        r53, "name"
+  Index        r54, r52, r4
   // count: count(g)
-  Const        r53, "count"
-  Count        r54, r50
+  Const        r55, "count"
+  Index        r56, r52, r5
   // select {
-  MakeMap      r57, 2, r51
+  MakeMap      r59, 2, r53
   // let stats = from o in orders
-  Append       r2, r2, r57
-  AddInt       r45, r45, r44
+  Append       r2, r2, r59
+  AddInt       r48, r48, r46
   Jump         L7
 L6:
   // print("--- Orders per customer ---")
-  Const        r59, "--- Orders per customer ---"
-  Print        r59
+  Const        r61, "--- Orders per customer ---"
+  Print        r61
   // for s in stats {
-  IterPrep     r60, r2
-  Len          r61, r60
-  Const        r62, 0
+  IterPrep     r62, r2
+  Len          r63, r62
+  Const        r64, 0
 L9:
-  Less         r63, r62, r61
-  JumpIfFalse  r63, L8
-  Index        r65, r60, r62
+  Less         r65, r64, r63
+  JumpIfFalse  r65, L8
+  Index        r67, r62, r64
   // print(s.name, "orders:", s.count)
-  Index        r66, r65, r3
-  Const        r67, "orders:"
-  Index        r68, r65, r5
-  PrintN       r66, 3, r66
+  Index        r68, r67, r3
+  Const        r69, "orders:"
+  Index        r70, r67, r5
+  PrintN       r68, 3, r68
   // for s in stats {
-  Const        r72, 1
-  Add          r62, r62, r72
+  Const        r74, 1
+  Add          r64, r64, r74
   Jump         L9
 L8:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=100)
+func main (regs=104)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
   // let orders = [
@@ -57,95 +57,102 @@ L4:
   // let stats = from c in customers
   Const        r38, "items"
   Move         r39, r34
-  MakeMap      r40, 3, r35
-  SetIndex     r7, r32, r40
-  Append       r8, r8, r40
+  Const        r40, 0
+  MakeMap      r41, 4, r35
+  SetIndex     r7, r32, r41
+  Append       r42, r8, r41
+  Move         r8, r42
 L3:
-  Index        r42, r7, r32
-  Index        r43, r42, r38
-  Append       r44, r43, r30
-  SetIndex     r42, r38, r44
+  Index        r43, r7, r32
+  Index        r44, r43, r38
+  Append       r45, r44, r30
+  SetIndex     r43, r38, r45
+  Index        r46, r43, r5
+  Const        r47, 1
+  AddInt       r48, r46, r47
+  SetIndex     r43, r5, r48
 L2:
   // left join o in orders on o.customerId == c.id
-  Const        r45, 1
-  AddInt       r17, r17, r45
+  AddInt       r17, r17, r47
   Jump         L4
 L1:
-  Move         r46, r21
-  JumpIfTrue   r46, L5
+  Move         r49, r21
+  JumpIfTrue   r49, L5
   // let stats = from c in customers
-  MakeMap      r50, 2, r27
+  MakeMap      r53, 2, r27
   // group by c.name into g
-  Index        r51, r14, r3
-  Str          r52, r51
-  In           r53, r52, r7
-  JumpIfTrue   r53, L6
+  Index        r54, r14, r3
+  Str          r55, r54
+  In           r56, r55, r7
+  JumpIfTrue   r56, L6
   // let stats = from c in customers
-  MakeMap      r57, 3, r35
-  SetIndex     r7, r52, r57
-  Append       r8, r8, r57
+  MakeMap      r60, 4, r35
+  SetIndex     r7, r55, r60
+  Append       r8, r8, r60
 L6:
-  Index        r59, r7, r52
-  Index        r60, r59, r38
-  Append       r61, r60, r50
-  SetIndex     r59, r38, r61
+  Index        r62, r7, r55
+  Index        r63, r62, r38
+  Append       r64, r63, r53
+  SetIndex     r62, r38, r64
+  Index        r65, r62, r5
+  AddInt       r66, r65, r47
+  SetIndex     r62, r5, r66
 L5:
-  AddInt       r11, r11, r45
+  AddInt       r11, r11, r47
   Jump         L7
 L0:
-  Const        r63, 0
-  Move         r62, r63
-  Len          r64, r8
+  Move         r67, r40
+  Len          r68, r8
 L12:
-  LessInt      r65, r62, r64
-  JumpIfFalse  r65, L8
-  Index        r67, r8, r62
+  LessInt      r69, r67, r68
+  JumpIfFalse  r69, L8
+  Index        r71, r8, r67
   // name: g.key,
-  Const        r68, "name"
-  Index        r69, r67, r4
+  Const        r72, "name"
+  Index        r73, r71, r4
   // count: count(from r in g where r.o select r)
-  Const        r70, "count"
-  Const        r71, []
-  IterPrep     r72, r67
-  Len          r73, r72
-  Move         r74, r63
+  Const        r74, "count"
+  Const        r75, []
+  IterPrep     r76, r71
+  Len          r77, r76
+  Move         r78, r40
 L11:
-  LessInt      r75, r74, r73
-  JumpIfFalse  r75, L9
-  Index        r77, r72, r74
-  Index        r78, r77, r6
-  JumpIfFalse  r78, L10
-  Append       r71, r71, r77
+  LessInt      r79, r78, r77
+  JumpIfFalse  r79, L9
+  Index        r81, r76, r78
+  Index        r82, r81, r6
+  JumpIfFalse  r82, L10
+  Append       r75, r75, r81
 L10:
-  AddInt       r74, r74, r45
+  AddInt       r78, r78, r47
   Jump         L11
 L9:
   // select {
-  MakeMap      r83, 2, r68
+  MakeMap      r87, 2, r72
   // let stats = from c in customers
-  Append       r2, r2, r83
-  AddInt       r62, r62, r45
+  Append       r2, r2, r87
+  AddInt       r67, r67, r47
   Jump         L12
 L8:
   // print("--- Group Left Join ---")
-  Const        r85, "--- Group Left Join ---"
-  Print        r85
+  Const        r89, "--- Group Left Join ---"
+  Print        r89
   // for s in stats {
-  IterPrep     r86, r2
-  Len          r87, r86
-  Const        r88, 0
+  IterPrep     r90, r2
+  Len          r91, r90
+  Const        r92, 0
 L14:
-  Less         r89, r88, r87
-  JumpIfFalse  r89, L13
-  Index        r91, r86, r88
+  Less         r93, r92, r91
+  JumpIfFalse  r93, L13
+  Index        r95, r90, r92
   // print(s.name, "orders:", s.count)
-  Index        r92, r91, r3
-  Const        r93, "orders:"
-  Index        r94, r91, r5
-  PrintN       r92, 3, r92
+  Index        r96, r95, r3
+  Const        r97, "orders:"
+  Index        r98, r95, r5
+  PrintN       r96, 3, r96
   // for s in stats {
-  Const        r98, 1
-  Add          r88, r88, r98
+  Const        r102, 1
+  Add          r92, r92, r102
   Jump         L14
 L13:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=98)
+func main (regs=101)
   // let nations = [
   Const        r0, [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
   // let suppliers = [
@@ -106,46 +106,51 @@ L9:
   // from x in filtered
   Const        r69, "items"
   Move         r70, r65
-  MakeMap      r71, 3, r66
-  SetIndex     r57, r63, r71
-  Append       r58, r58, r71
+  Const        r71, "count"
+  MakeMap      r72, 4, r66
+  SetIndex     r57, r63, r72
+  Append       r73, r58, r72
+  Move         r58, r73
 L8:
-  Index        r73, r57, r63
-  Index        r74, r73, r69
-  Append       r75, r74, r60
-  SetIndex     r73, r69, r75
+  Index        r74, r57, r63
+  Index        r75, r74, r69
+  Append       r76, r75, r60
+  SetIndex     r74, r69, r76
+  Index        r77, r74, r71
+  AddInt       r78, r77, r50
+  SetIndex     r74, r71, r78
   AddInt       r56, r56, r50
   Jump         L9
 L7:
-  Move         r76, r12
-  Len          r77, r58
+  Move         r79, r12
+  Len          r80, r58
 L13:
-  LessInt      r78, r76, r77
-  JumpIfFalse  r78, L10
-  Index        r80, r58, r76
+  LessInt      r81, r79, r80
+  JumpIfFalse  r81, L10
+  Index        r83, r58, r79
   // part: g.key,
-  Const        r81, "part"
-  Index        r82, r80, r52
+  Const        r84, "part"
+  Index        r85, r83, r52
   // total: sum(from r in g select r.value)
-  Const        r83, "total"
-  Const        r84, []
-  IterPrep     r85, r80
-  Len          r86, r85
-  Move         r87, r12
+  Const        r86, "total"
+  Const        r87, []
+  IterPrep     r88, r83
+  Len          r89, r88
+  Move         r90, r12
 L12:
-  LessInt      r88, r87, r86
-  JumpIfFalse  r88, L11
-  Index        r90, r85, r87
-  Index        r91, r90, r6
-  Append       r84, r84, r91
-  AddInt       r87, r87, r50
+  LessInt      r91, r90, r89
+  JumpIfFalse  r91, L11
+  Index        r93, r88, r90
+  Index        r94, r93, r6
+  Append       r87, r87, r94
+  AddInt       r90, r90, r50
   Jump         L12
 L11:
   // select {
-  MakeMap      r96, 2, r81
+  MakeMap      r99, 2, r84
   // from x in filtered
-  Append       r51, r51, r96
-  AddInt       r76, r76, r50
+  Append       r51, r51, r99
+  AddInt       r79, r79, r50
   Jump         L13
 L10:
   // print(grouped)

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -1,4 +1,4 @@
-func main (regs=186)
+func main (regs=189)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
@@ -153,22 +153,27 @@ L6:
   // from c in customer
   Const        r106, "items"
   Move         r107, r102
-  MakeMap      r108, 3, r103
-  SetIndex     r21, r100, r108
-  Append       r22, r22, r108
+  Const        r108, "count"
+  Const        r109, 0
+  MakeMap      r110, 4, r103
+  SetIndex     r21, r100, r110
+  Append       r22, r22, r110
 L7:
-  Index        r110, r21, r100
-  Index        r111, r110, r106
-  Append       r112, r111, r77
-  SetIndex     r110, r106, r112
+  Index        r112, r21, r100
+  Index        r113, r112, r106
+  Append       r114, r113, r77
+  SetIndex     r112, r106, r114
+  Index        r115, r112, r108
+  Const        r116, 1
+  AddInt       r117, r115, r116
+  SetIndex     r112, r108, r117
 L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  Const        r113, 1
-  AddInt       r52, r52, r113
+  AddInt       r52, r52, r116
   Jump         L8
 L3:
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r41, r41, r113
+  AddInt       r41, r41, r116
   Jump         L9
 L2:
   // join o in orders on o.o_custkey == c.c_custkey
@@ -177,70 +182,69 @@ L1:
   // from c in customer
   Jump         L11
 L0:
-  Const        r115, 0
-  Move         r114, r115
-  Len          r116, r22
+  Move         r118, r109
+  Len          r119, r22
 L17:
-  LessInt      r117, r114, r116
-  JumpIfFalse  r117, L12
-  Index        r119, r22, r114
+  LessInt      r120, r118, r119
+  JumpIfFalse  r120, L12
+  Index        r122, r22, r118
   // c_custkey: g.key.c_custkey,
-  Const        r120, "c_custkey"
-  Index        r121, r119, r16
-  Index        r122, r121, r7
+  Const        r123, "c_custkey"
+  Index        r124, r122, r16
+  Index        r125, r124, r7
   // c_name: g.key.c_name,
-  Const        r123, "c_name"
-  Index        r124, r119, r16
-  Index        r125, r124, r8
+  Const        r126, "c_name"
+  Index        r127, r122, r16
+  Index        r128, r127, r8
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r126, "revenue"
-  Const        r127, []
-  IterPrep     r128, r119
-  Len          r129, r128
-  Move         r130, r115
+  Const        r129, "revenue"
+  Const        r130, []
+  IterPrep     r131, r122
+  Len          r132, r131
+  Move         r133, r109
 L14:
-  LessInt      r131, r130, r129
-  JumpIfFalse  r131, L13
-  Index        r132, r128, r130
-  Move         r133, r132
-  Index        r134, r133, r18
-  Index        r135, r134, r19
-  Index        r136, r133, r18
-  Index        r137, r136, r20
-  Sub          r138, r113, r137
-  Mul          r139, r135, r138
-  Append       r127, r127, r139
-  AddInt       r130, r130, r113
+  LessInt      r134, r133, r132
+  JumpIfFalse  r134, L13
+  Index        r135, r131, r133
+  Move         r136, r135
+  Index        r137, r136, r18
+  Index        r138, r137, r19
+  Index        r139, r136, r18
+  Index        r140, r139, r20
+  Sub          r141, r116, r140
+  Mul          r142, r138, r141
+  Append       r130, r130, r142
+  AddInt       r133, r133, r116
   Jump         L14
 L13:
   // select {
-  MakeMap      r165, 8, r120
+  MakeMap      r168, 8, r123
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r166, []
-  IterPrep     r167, r119
-  Len          r168, r167
-  Move         r169, r115
+  Const        r169, []
+  IterPrep     r170, r122
+  Len          r171, r170
+  Move         r172, r109
 L16:
-  LessInt      r170, r169, r168
-  JumpIfFalse  r170, L15
-  Index        r133, r167, r169
-  Index        r172, r133, r18
-  Index        r173, r172, r19
-  Index        r174, r133, r18
-  Index        r175, r174, r20
-  Sub          r176, r113, r175
-  Mul          r177, r173, r176
-  Append       r166, r166, r177
-  AddInt       r169, r169, r113
+  LessInt      r173, r172, r171
+  JumpIfFalse  r173, L15
+  Index        r136, r170, r172
+  Index        r175, r136, r18
+  Index        r176, r175, r19
+  Index        r177, r136, r18
+  Index        r178, r177, r20
+  Sub          r179, r116, r178
+  Mul          r180, r176, r179
+  Append       r169, r169, r180
+  AddInt       r172, r172, r116
   Jump         L16
 L15:
-  Sum          r179, r166
-  Neg          r181, r179
+  Sum          r182, r169
+  Neg          r184, r182
   // from c in customer
-  Move         r182, r165
-  MakeList     r183, 2, r181
-  Append       r6, r6, r183
-  AddInt       r114, r114, r113
+  Move         r185, r168
+  MakeList     r186, 2, r184
+  Append       r6, r6, r186
+  AddInt       r118, r118, r116
   Jump         L17
 L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,4 +1,4 @@
-func main (regs=66)
+func main (regs=69)
   // let items = [
   Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
   // from i in items
@@ -33,65 +33,69 @@ L2:
   // from i in items
   Const        r21, "items"
   Move         r22, r17
-  MakeMap      r23, 3, r18
-  SetIndex     r9, r15, r23
+  Const        r23, "count"
+  Const        r24, 0
+  MakeMap      r25, 4, r18
+  SetIndex     r9, r15, r25
 L1:
-  Index        r25, r9, r15
-  Index        r26, r25, r21
-  Append       r27, r26, r12
-  SetIndex     r25, r21, r27
-  Const        r28, 1
-  AddInt       r8, r8, r28
+  Index        r27, r9, r15
+  Index        r28, r27, r21
+  Append       r29, r28, r12
+  SetIndex     r27, r21, r29
+  Index        r30, r27, r23
+  Const        r31, 1
+  AddInt       r32, r30, r31
+  SetIndex     r27, r23, r32
+  AddInt       r8, r8, r31
   Jump         L2
 L0:
-  Const        r30, 0
-  Move         r29, r30
-  Const        r31, 0
+  Move         r33, r24
+  Const        r34, 0
 L8:
-  LessInt      r32, r29, r31
-  JumpIfFalse  r32, L3
-  Index        r34, r10, r29
+  LessInt      r35, r33, r34
+  JumpIfFalse  r35, L3
+  Index        r37, r10, r33
   // cat: g.key,
-  Const        r35, "cat"
-  Index        r36, r34, r3
+  Const        r38, "cat"
+  Index        r39, r37, r3
   // total: sum(from x in g select x.val)
-  Const        r37, "total"
-  Const        r38, []
-  IterPrep     r39, r34
-  Len          r40, r39
-  Move         r41, r30
+  Const        r40, "total"
+  Const        r41, []
+  IterPrep     r42, r37
+  Len          r43, r42
+  Move         r44, r24
 L5:
-  LessInt      r42, r41, r40
-  JumpIfFalse  r42, L4
-  Index        r44, r39, r41
-  Index        r45, r44, r5
-  Append       r38, r38, r45
-  AddInt       r41, r41, r28
+  LessInt      r45, r44, r43
+  JumpIfFalse  r45, L4
+  Index        r47, r42, r44
+  Index        r48, r47, r5
+  Append       r41, r41, r48
+  AddInt       r44, r44, r31
   Jump         L5
 L4:
   // select {
-  MakeMap      r50, 2, r35
+  MakeMap      r53, 2, r38
   // sort by -sum(from x in g select x.val)
-  Const        r51, []
-  IterPrep     r52, r34
-  Len          r53, r52
-  Move         r54, r30
+  Const        r54, []
+  IterPrep     r55, r37
+  Len          r56, r55
+  Move         r57, r24
 L7:
-  LessInt      r55, r54, r53
-  JumpIfFalse  r55, L6
-  Index        r44, r52, r54
-  Index        r57, r44, r5
-  Append       r51, r51, r57
-  AddInt       r54, r54, r28
+  LessInt      r58, r57, r56
+  JumpIfFalse  r58, L6
+  Index        r47, r55, r57
+  Index        r60, r47, r5
+  Append       r54, r54, r60
+  AddInt       r57, r57, r31
   Jump         L7
 L6:
-  Sum          r59, r51
-  Neg          r61, r59
+  Sum          r62, r54
+  Neg          r64, r62
   // from i in items
-  Move         r62, r50
-  MakeList     r63, 2, r61
-  Append       r1, r1, r63
-  AddInt       r29, r29, r28
+  Move         r65, r53
+  MakeList     r66, 2, r64
+  Append       r1, r1, r66
+  AddInt       r33, r33, r31
   Jump         L8
 L3:
   // sort by -sum(from x in g select x.val)

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -1,4 +1,4 @@
-func main (regs=76)
+func main (regs=79)
   // let data = [
   Const        r0, [{"tag": "a", "val": 1}, {"tag": "a", "val": 2}, {"tag": "b", "val": 3}]
   // let groups = from d in data group by d.tag into g select g
@@ -24,88 +24,92 @@ L2:
   Move         r18, r11
   Const        r19, "items"
   Move         r20, r14
-  MakeMap      r21, 3, r15
-  SetIndex     r6, r12, r21
-  Append       r7, r7, r21
+  Const        r21, "count"
+  Const        r22, 0
+  MakeMap      r23, 4, r15
+  SetIndex     r6, r12, r23
+  Append       r7, r7, r23
 L1:
-  Index        r23, r6, r12
-  Index        r24, r23, r19
-  Append       r25, r24, r9
-  SetIndex     r23, r19, r25
-  Const        r26, 1
-  AddInt       r5, r5, r26
+  Index        r25, r6, r12
+  Index        r26, r25, r19
+  Append       r27, r26, r9
+  SetIndex     r25, r19, r27
+  Index        r28, r25, r21
+  Const        r29, 1
+  AddInt       r30, r28, r29
+  SetIndex     r25, r21, r30
+  AddInt       r5, r5, r29
   Jump         L2
 L0:
-  Const        r28, 0
-  Move         r27, r28
-  Len          r29, r7
+  Move         r31, r22
+  Len          r32, r7
 L4:
-  LessInt      r30, r27, r29
-  JumpIfFalse  r30, L3
-  Index        r32, r7, r27
-  Append       r1, r1, r32
-  AddInt       r27, r27, r26
+  LessInt      r33, r31, r32
+  JumpIfFalse  r33, L3
+  Index        r35, r7, r31
+  Append       r1, r1, r35
+  AddInt       r31, r31, r29
   Jump         L4
 L3:
   // var tmp = []
-  Const        r35, []
+  Const        r38, []
   // for g in groups {
-  IterPrep     r36, r1
-  Len          r37, r36
-  Const        r38, 0
+  IterPrep     r39, r1
+  Len          r40, r39
+  Const        r41, 0
 L8:
-  Less         r39, r38, r37
-  JumpIfFalse  r39, L5
-  Index        r32, r36, r38
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L5
+  Index        r35, r39, r41
   // var total = 0
-  Move         r41, r28
+  Move         r44, r22
   // for x in g.items {
-  Index        r42, r32, r19
-  IterPrep     r43, r42
-  Len          r44, r43
-  Const        r45, 0
+  Index        r45, r35, r19
+  IterPrep     r46, r45
+  Len          r47, r46
+  Const        r48, 0
 L7:
-  Less         r46, r45, r44
-  JumpIfFalse  r46, L6
-  Index        r48, r43, r45
+  Less         r49, r48, r47
+  JumpIfFalse  r49, L6
+  Index        r51, r46, r48
   // total = total + x.val
-  Const        r49, "val"
-  Index        r50, r48, r49
-  Add          r41, r41, r50
+  Const        r52, "val"
+  Index        r53, r51, r52
+  Add          r44, r44, r53
   // for x in g.items {
-  Const        r52, 1
-  Add          r45, r45, r52
+  Const        r55, 1
+  Add          r48, r48, r55
   Jump         L7
 L6:
   // tmp = append(tmp, {tag: g.key, total: total})
-  Const        r54, "tag"
-  Index        r55, r32, r17
-  Const        r56, "total"
-  Move         r57, r55
-  MakeMap      r59, 2, r54
-  Append       r35, r35, r59
+  Const        r57, "tag"
+  Index        r58, r35, r17
+  Const        r59, "total"
+  Move         r60, r58
+  MakeMap      r62, 2, r57
+  Append       r38, r38, r62
   // for g in groups {
-  Const        r61, 1
-  Add          r38, r38, r61
+  Const        r64, 1
+  Add          r41, r41, r64
   Jump         L8
 L5:
   // let result = from r in tmp sort by r.tag select r
-  Const        r63, []
-  IterPrep     r64, r35
-  Len          r65, r64
-  Move         r66, r28
+  Const        r66, []
+  IterPrep     r67, r38
+  Len          r68, r67
+  Move         r69, r22
 L10:
-  LessInt      r67, r66, r65
-  JumpIfFalse  r67, L9
-  Index        r69, r64, r66
-  Index        r71, r69, r2
-  Move         r72, r69
-  MakeList     r73, 2, r71
-  Append       r63, r63, r73
-  AddInt       r66, r66, r26
+  LessInt      r70, r69, r68
+  JumpIfFalse  r70, L9
+  Index        r72, r67, r69
+  Index        r74, r72, r2
+  Move         r75, r72
+  MakeList     r76, 2, r74
+  Append       r66, r66, r76
+  AddInt       r69, r69, r29
   Jump         L10
 L9:
-  Sort         r63, r63
+  Sort         r66, r66
   // print(result)
-  Print        r63
+  Print        r66
   Return       r0


### PR DESCRIPTION
## Summary
- optimize group by by precalculating count
- regenerate IR golden files

## Testing
- `go test ./...`
- `go test -tags slow ./tests/vm -run TestVM_IR -update`

------
https://chatgpt.com/codex/tasks/task_e_6861129b9b388320b583fadf63b24343