### PR TITLE
Optimize group by to avoid storing items

### DIFF
--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -28,24 +28,23 @@ L2:
   In           r17, r16, r10
   JumpIfTrue   r17, L1
   // let stats = from person in people
-  Const        r18, []
-  Const        r19, "__group__"
-  Const        r20, true
+  Const        r18, "__group__"
+  Const        r19, true
   // group by person.city into g
-  Move         r21, r15
+  Move         r20, r15
   // let stats = from person in people
-  Const        r22, "items"
-  Move         r23, r18
-  Const        r24, 0
-  MakeMap      r25, 4, r19
+  Const        r21, 0
+  Const        r22, []
+  Const        r23, "items"
+  Move         r24, r22
+  MakeMap      r25, 4, r18
   SetIndex     r10, r16, r25
-  Append       r26, r11, r25
-  Move         r11, r26
+  Append       r11, r11, r25
 L1:
   Index        r27, r10, r16
-  Index        r28, r27, r22
+  Index        r28, r27, r23
   Append       r29, r28, r13
-  SetIndex     r27, r22, r29
+  SetIndex     r27, r23, r29
   Index        r30, r27, r4
   Const        r31, 1
   AddInt       r32, r30, r31
@@ -53,7 +52,7 @@ L1:
   AddInt       r9, r9, r31
   Jump         L2
 L0:
-  Move         r33, r24
+  Move         r33, r21
   Len          r34, r11
 L6:
   LessInt      r35, r33, r34
@@ -70,7 +69,7 @@ L6:
   Const        r43, []
   IterPrep     r44, r37
   Len          r45, r44
-  Move         r46, r24
+  Move         r46, r21
 L5:
   LessInt      r47, r46, r45
   JumpIfFalse  r47, L4

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -1,4 +1,4 @@
-func main (regs=73)
+func main (regs=70)
   // let items = [
   Const        r0, [{"cat": "a", "flag": true, "val": 10}, {"cat": "a", "flag": false, "val": 5}, {"cat": "b", "flag": true, "val": 20}]
   // from i in items
@@ -26,80 +26,76 @@ L2:
   In           r17, r16, r10
   JumpIfTrue   r17, L1
   // from i in items
-  Const        r18, []
-  Const        r19, "__group__"
-  Const        r20, true
+  Const        r18, "__group__"
+  Const        r19, true
   // group by i.cat into g
-  Move         r21, r15
+  Move         r20, r15
   // from i in items
+  Const        r21, []
   Const        r22, "items"
-  Move         r23, r18
-  Const        r24, "count"
-  Const        r25, 0
-  MakeMap      r26, 4, r19
-  SetIndex     r10, r16, r26
+  Move         r23, r21
+  MakeMap      r24, 3, r18
+  SetIndex     r10, r16, r24
 L1:
-  Index        r28, r10, r16
-  Index        r29, r28, r22
-  Append       r30, r29, r13
-  SetIndex     r28, r22, r30
-  Index        r31, r28, r24
-  Const        r32, 1
-  AddInt       r33, r31, r32
-  SetIndex     r28, r24, r33
-  AddInt       r9, r9, r32
+  Index        r26, r10, r16
+  Index        r27, r26, r22
+  Append       r28, r27, r13
+  SetIndex     r26, r22, r28
+  Const        r29, 1
+  AddInt       r9, r9, r29
   Jump         L2
 L0:
-  Move         r34, r25
-  Const        r35, 0
+  Const        r31, 0
+  Move         r30, r31
+  Const        r32, 0
 L9:
-  LessInt      r36, r34, r35
-  JumpIfFalse  r36, L3
-  Index        r38, r11, r34
+  LessInt      r33, r30, r32
+  JumpIfFalse  r33, L3
+  Index        r35, r11, r30
   // cat: g.key,
-  Const        r39, "cat"
-  Index        r40, r38, r3
+  Const        r36, "cat"
+  Index        r37, r35, r3
   // share:
-  Const        r41, "share"
+  Const        r38, "share"
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r42, []
-  IterPrep     r43, r38
-  Len          r44, r43
-  Move         r45, r25
+  Const        r39, []
+  IterPrep     r40, r35
+  Len          r41, r40
+  Move         r42, r31
 L6:
-  LessInt      r46, r45, r44
-  JumpIfFalse  r46, L4
-  Index        r48, r43, r45
-  Index        r49, r48, r5
-  JumpIfFalse  r49, L5
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L4
+  Index        r45, r40, r42
+  Index        r46, r45, r5
+  JumpIfFalse  r46, L5
 L5:
-  Append       r42, r42, r25
-  AddInt       r45, r45, r32
+  Append       r39, r39, r31
+  AddInt       r42, r42, r29
   Jump         L6
 L4:
   // sum(from x in g select x.val)
-  Const        r54, []
-  IterPrep     r55, r38
-  Len          r56, r55
-  Move         r57, r25
+  Const        r51, []
+  IterPrep     r52, r35
+  Len          r53, r52
+  Move         r54, r31
 L8:
-  LessInt      r58, r57, r56
-  JumpIfFalse  r58, L7
-  Index        r48, r55, r57
-  Index        r60, r48, r6
-  Append       r54, r54, r60
-  AddInt       r57, r57, r32
+  LessInt      r55, r54, r53
+  JumpIfFalse  r55, L7
+  Index        r45, r52, r54
+  Index        r57, r45, r6
+  Append       r51, r51, r57
+  AddInt       r54, r54, r29
   Jump         L8
 L7:
   // select {
-  MakeMap      r66, 2, r39
+  MakeMap      r63, 2, r36
   // sort by g.key
-  Index        r68, r38, r3
+  Index        r65, r35, r3
   // from i in items
-  Move         r69, r66
-  MakeList     r70, 2, r68
-  Append       r1, r1, r70
-  AddInt       r34, r34, r32
+  Move         r66, r63
+  MakeList     r67, 2, r65
+  Append       r1, r1, r67
+  AddInt       r30, r30, r29
   Jump         L9
 L3:
   // sort by g.key

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -1,4 +1,4 @@
-func main (regs=48)
+func main (regs=43)
   // let people = [
   Const        r0, [{"city": "Paris", "name": "Alice"}, {"city": "Hanoi", "name": "Bob"}, {"city": "Paris", "name": "Charlie"}, {"city": "Hanoi", "name": "Diana"}, {"city": "Paris", "name": "Eve"}, {"city": "Hanoi", "name": "Frank"}, {"city": "Paris", "name": "George"}]
   // from p in people
@@ -16,57 +16,51 @@ func main (regs=48)
 L2:
   LessInt      r10, r7, r6
   JumpIfFalse  r10, L0
-  Index        r11, r5, r7
+  Index        r12, r5, r7
   // group by p.city into g
-  Index        r13, r11, r2
+  Index        r13, r12, r2
   Str          r14, r13
   In           r15, r14, r8
   JumpIfTrue   r15, L1
   // from p in people
-  Const        r16, []
-  Const        r17, "__group__"
-  Const        r18, true
+  Const        r16, "__group__"
+  Const        r17, true
   // group by p.city into g
-  Move         r19, r13
+  Move         r18, r13
   // from p in people
-  Const        r20, "items"
-  Move         r21, r16
-  Const        r22, "count"
-  Const        r23, 0
-  MakeMap      r24, 4, r17
-  SetIndex     r8, r14, r24
+  Const        r19, "count"
+  Const        r20, 0
+  MakeMap      r21, 3, r16
+  SetIndex     r8, r14, r21
 L1:
-  Index        r26, r8, r14
-  Index        r27, r26, r20
-  Append       r28, r27, r11
-  SetIndex     r26, r20, r28
-  Index        r29, r26, r22
-  Const        r30, 1
-  AddInt       r31, r29, r30
-  SetIndex     r26, r22, r31
-  AddInt       r7, r7, r30
+  Index        r23, r8, r14
+  Index        r24, r23, r19
+  Const        r25, 1
+  AddInt       r26, r24, r25
+  SetIndex     r23, r19, r26
+  AddInt       r7, r7, r25
   Jump         L2
 L0:
-  Move         r32, r23
-  Const        r33, 0
+  Move         r27, r20
+  Const        r28, 0
 L4:
-  LessInt      r34, r32, r33
-  JumpIfFalse  r34, L3
-  Index        r36, r9, r32
+  LessInt      r29, r27, r28
+  JumpIfFalse  r29, L3
+  Index        r31, r9, r27
   // having count(g) >= 4
-  Index        r37, r36, r22
-  Const        r38, 4
-  LessEq       r39, r38, r37
-  JumpIfFalse  r39, L3
+  Index        r32, r31, r19
+  Const        r33, 4
+  LessEq       r34, r33, r32
+  JumpIfFalse  r34, L3
   // select { city: g.key, num: count(g) }
-  Const        r40, "city"
-  Index        r41, r36, r3
-  Const        r42, "num"
-  Index        r43, r36, r22
-  MakeMap      r46, 2, r40
+  Const        r35, "city"
+  Index        r36, r31, r3
+  Const        r37, "num"
+  Index        r38, r31, r19
+  MakeMap      r41, 2, r35
   // from p in people
-  Append       r1, r1, r46
-  AddInt       r32, r32, r30
+  Append       r1, r1, r41
+  AddInt       r27, r27, r25
   Jump         L4
 L3:
   // json(big)

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=76)
+func main (regs=71)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
   // let orders = [
@@ -35,87 +35,75 @@ L4:
   Index        r23, r19, r22
   Equal        r24, r21, r23
   JumpIfFalse  r24, L2
-  // let stats = from o in orders
-  Const        r25, "o"
-  Move         r26, r13
-  Const        r27, "c"
-  Move         r28, r19
-  MakeMap      r29, 2, r25
   // group by c.name into g
   Index        r30, r19, r3
   Str          r31, r30
   In           r32, r31, r6
   JumpIfTrue   r32, L3
   // let stats = from o in orders
-  Const        r33, []
-  Const        r34, "__group__"
-  Const        r35, true
+  Const        r33, "__group__"
+  Const        r34, true
   // group by c.name into g
-  Move         r36, r30
+  Move         r35, r30
   // let stats = from o in orders
-  Const        r37, "items"
-  Move         r38, r33
-  Const        r39, 0
-  MakeMap      r40, 4, r34
-  SetIndex     r6, r31, r40
-  Append       r41, r7, r40
-  Move         r7, r41
+  Const        r36, 0
+  MakeMap      r37, 3, r33
+  SetIndex     r6, r31, r37
+  Append       r38, r7, r37
+  Move         r7, r38
 L3:
-  Index        r42, r6, r31
-  Index        r43, r42, r37
-  Append       r44, r43, r29
-  SetIndex     r42, r37, r44
-  Index        r45, r42, r5
-  Const        r46, 1
-  AddInt       r47, r45, r46
-  SetIndex     r42, r5, r47
+  Index        r39, r6, r31
+  Index        r40, r39, r5
+  Const        r41, 1
+  AddInt       r42, r40, r41
+  SetIndex     r39, r5, r42
 L2:
   // join from c in customers on o.customerId == c.id
-  AddInt       r16, r16, r46
+  AddInt       r16, r16, r41
   Jump         L4
 L1:
   // let stats = from o in orders
-  AddInt       r10, r10, r46
+  AddInt       r10, r10, r41
   Jump         L5
 L0:
-  Move         r48, r39
-  Len          r49, r7
+  Move         r43, r36
+  Len          r44, r7
 L7:
-  LessInt      r50, r48, r49
-  JumpIfFalse  r50, L6
-  Index        r52, r7, r48
+  LessInt      r45, r43, r44
+  JumpIfFalse  r45, L6
+  Index        r47, r7, r43
   // name: g.key,
-  Const        r53, "name"
-  Index        r54, r52, r4
+  Const        r48, "name"
+  Index        r49, r47, r4
   // count: count(g)
-  Const        r55, "count"
-  Index        r56, r52, r5
+  Const        r50, "count"
+  Index        r51, r47, r5
   // select {
-  MakeMap      r59, 2, r53
+  MakeMap      r54, 2, r48
   // let stats = from o in orders
-  Append       r2, r2, r59
-  AddInt       r48, r48, r46
+  Append       r2, r2, r54
+  AddInt       r43, r43, r41
   Jump         L7
 L6:
   // print("--- Orders per customer ---")
-  Const        r61, "--- Orders per customer ---"
-  Print        r61
+  Const        r56, "--- Orders per customer ---"
+  Print        r56
   // for s in stats {
-  IterPrep     r62, r2
-  Len          r63, r62
-  Const        r64, 0
+  IterPrep     r57, r2
+  Len          r58, r57
+  Const        r59, 0
 L9:
-  Less         r65, r64, r63
-  JumpIfFalse  r65, L8
-  Index        r67, r62, r64
+  Less         r60, r59, r58
+  JumpIfFalse  r60, L8
+  Index        r62, r57, r59
   // print(s.name, "orders:", s.count)
-  Index        r68, r67, r3
-  Const        r69, "orders:"
-  Index        r70, r67, r5
-  PrintN       r68, 3, r68
+  Index        r63, r62, r3
+  Const        r64, "orders:"
+  Index        r65, r62, r5
+  PrintN       r63, 3, r63
   // for s in stats {
-  Const        r74, 1
-  Add          r64, r64, r74
+  Const        r69, 1
+  Add          r59, r59, r69
   Jump         L9
 L8:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=104)
+func main (regs=100)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
   // let orders = [
@@ -49,110 +49,103 @@ L4:
   In           r33, r32, r7
   JumpIfTrue   r33, L3
   // let stats = from c in customers
-  Const        r34, []
-  Const        r35, "__group__"
-  Const        r36, true
+  Const        r34, "__group__"
+  Const        r35, true
   // group by c.name into g
-  Move         r37, r31
+  Move         r36, r31
   // let stats = from c in customers
+  Const        r37, []
   Const        r38, "items"
-  Move         r39, r34
-  Const        r40, 0
-  MakeMap      r41, 4, r35
-  SetIndex     r7, r32, r41
-  Append       r42, r8, r41
-  Move         r8, r42
+  Move         r39, r37
+  MakeMap      r40, 3, r34
+  SetIndex     r7, r32, r40
+  Append       r8, r8, r40
 L3:
-  Index        r43, r7, r32
-  Index        r44, r43, r38
-  Append       r45, r44, r30
-  SetIndex     r43, r38, r45
-  Index        r46, r43, r5
-  Const        r47, 1
-  AddInt       r48, r46, r47
-  SetIndex     r43, r5, r48
+  Index        r42, r7, r32
+  Index        r43, r42, r38
+  Append       r44, r43, r30
+  SetIndex     r42, r38, r44
 L2:
   // left join o in orders on o.customerId == c.id
-  AddInt       r17, r17, r47
+  Const        r45, 1
+  AddInt       r17, r17, r45
   Jump         L4
 L1:
-  Move         r49, r21
-  JumpIfTrue   r49, L5
+  Move         r46, r21
+  JumpIfTrue   r46, L5
   // let stats = from c in customers
-  MakeMap      r53, 2, r27
+  MakeMap      r50, 2, r27
   // group by c.name into g
-  Index        r54, r14, r3
-  Str          r55, r54
-  In           r56, r55, r7
-  JumpIfTrue   r56, L6
+  Index        r51, r14, r3
+  Str          r52, r51
+  In           r53, r52, r7
+  JumpIfTrue   r53, L6
   // let stats = from c in customers
-  MakeMap      r60, 4, r35
-  SetIndex     r7, r55, r60
-  Append       r8, r8, r60
+  MakeMap      r57, 3, r34
+  SetIndex     r7, r52, r57
+  Append       r8, r8, r57
 L6:
-  Index        r62, r7, r55
-  Index        r63, r62, r38
-  Append       r64, r63, r53
-  SetIndex     r62, r38, r64
-  Index        r65, r62, r5
-  AddInt       r66, r65, r47
-  SetIndex     r62, r5, r66
+  Index        r59, r7, r52
+  Index        r60, r59, r38
+  Append       r61, r60, r50
+  SetIndex     r59, r38, r61
 L5:
-  AddInt       r11, r11, r47
+  AddInt       r11, r11, r45
   Jump         L7
 L0:
-  Move         r67, r40
-  Len          r68, r8
+  Const        r63, 0
+  Move         r62, r63
+  Len          r64, r8
 L12:
-  LessInt      r69, r67, r68
-  JumpIfFalse  r69, L8
-  Index        r71, r8, r67
+  LessInt      r65, r62, r64
+  JumpIfFalse  r65, L8
+  Index        r67, r8, r62
   // name: g.key,
-  Const        r72, "name"
-  Index        r73, r71, r4
+  Const        r68, "name"
+  Index        r69, r67, r4
   // count: count(from r in g where r.o select r)
-  Const        r74, "count"
-  Const        r75, []
-  IterPrep     r76, r71
-  Len          r77, r76
-  Move         r78, r40
+  Const        r70, "count"
+  Const        r71, []
+  IterPrep     r72, r67
+  Len          r73, r72
+  Move         r74, r63
 L11:
-  LessInt      r79, r78, r77
-  JumpIfFalse  r79, L9
-  Index        r81, r76, r78
-  Index        r82, r81, r6
-  JumpIfFalse  r82, L10
-  Append       r75, r75, r81
+  LessInt      r75, r74, r73
+  JumpIfFalse  r75, L9
+  Index        r77, r72, r74
+  Index        r78, r77, r6
+  JumpIfFalse  r78, L10
+  Append       r71, r71, r77
 L10:
-  AddInt       r78, r78, r47
+  AddInt       r74, r74, r45
   Jump         L11
 L9:
   // select {
-  MakeMap      r87, 2, r72
+  MakeMap      r83, 2, r68
   // let stats = from c in customers
-  Append       r2, r2, r87
-  AddInt       r67, r67, r47
+  Append       r2, r2, r83
+  AddInt       r62, r62, r45
   Jump         L12
 L8:
   // print("--- Group Left Join ---")
-  Const        r89, "--- Group Left Join ---"
-  Print        r89
+  Const        r85, "--- Group Left Join ---"
+  Print        r85
   // for s in stats {
-  IterPrep     r90, r2
-  Len          r91, r90
-  Const        r92, 0
+  IterPrep     r86, r2
+  Len          r87, r86
+  Const        r88, 0
 L14:
-  Less         r93, r92, r91
-  JumpIfFalse  r93, L13
-  Index        r95, r90, r92
+  Less         r89, r88, r87
+  JumpIfFalse  r89, L13
+  Index        r91, r86, r88
   // print(s.name, "orders:", s.count)
-  Index        r96, r95, r3
-  Const        r97, "orders:"
-  Index        r98, r95, r5
-  PrintN       r96, 3, r96
+  Index        r92, r91, r3
+  Const        r93, "orders:"
+  Index        r94, r91, r5
+  PrintN       r92, 3, r92
   // for s in stats {
-  Const        r102, 1
-  Add          r92, r92, r102
+  Const        r98, 1
+  Add          r88, r88, r98
   Jump         L14
 L13:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=101)
+func main (regs=98)
   // let nations = [
   Const        r0, [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
   // let suppliers = [
@@ -98,59 +98,54 @@ L9:
   In           r64, r63, r57
   JumpIfTrue   r64, L8
   // from x in filtered
-  Const        r65, []
-  Const        r66, "__group__"
-  Const        r67, true
+  Const        r65, "__group__"
+  Const        r66, true
   // group by x.part into g
-  Move         r68, r62
+  Move         r67, r62
   // from x in filtered
+  Const        r68, []
   Const        r69, "items"
-  Move         r70, r65
-  Const        r71, "count"
-  MakeMap      r72, 4, r66
-  SetIndex     r57, r63, r72
-  Append       r73, r58, r72
-  Move         r58, r73
+  Move         r70, r68
+  MakeMap      r71, 3, r65
+  SetIndex     r57, r63, r71
+  Append       r58, r58, r71
 L8:
-  Index        r74, r57, r63
-  Index        r75, r74, r69
-  Append       r76, r75, r60
-  SetIndex     r74, r69, r76
-  Index        r77, r74, r71
-  AddInt       r78, r77, r50
-  SetIndex     r74, r71, r78
+  Index        r73, r57, r63
+  Index        r74, r73, r69
+  Append       r75, r74, r60
+  SetIndex     r73, r69, r75
   AddInt       r56, r56, r50
   Jump         L9
 L7:
-  Move         r79, r12
-  Len          r80, r58
+  Move         r76, r12
+  Len          r77, r58
 L13:
-  LessInt      r81, r79, r80
-  JumpIfFalse  r81, L10
-  Index        r83, r58, r79
+  LessInt      r78, r76, r77
+  JumpIfFalse  r78, L10
+  Index        r80, r58, r76
   // part: g.key,
-  Const        r84, "part"
-  Index        r85, r83, r52
+  Const        r81, "part"
+  Index        r82, r80, r52
   // total: sum(from r in g select r.value)
-  Const        r86, "total"
-  Const        r87, []
-  IterPrep     r88, r83
-  Len          r89, r88
-  Move         r90, r12
+  Const        r83, "total"
+  Const        r84, []
+  IterPrep     r85, r80
+  Len          r86, r85
+  Move         r87, r12
 L12:
-  LessInt      r91, r90, r89
-  JumpIfFalse  r91, L11
-  Index        r93, r88, r90
-  Index        r94, r93, r6
-  Append       r87, r87, r94
-  AddInt       r90, r90, r50
+  LessInt      r88, r87, r86
+  JumpIfFalse  r88, L11
+  Index        r90, r85, r87
+  Index        r91, r90, r6
+  Append       r84, r84, r91
+  AddInt       r87, r87, r50
   Jump         L12
 L11:
   // select {
-  MakeMap      r99, 2, r84
+  MakeMap      r96, 2, r81
   // from x in filtered
-  Append       r51, r51, r99
-  AddInt       r79, r79, r50
+  Append       r51, r51, r96
+  AddInt       r76, r76, r50
   Jump         L13
 L10:
   // print(grouped)

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -1,4 +1,4 @@
-func main (regs=189)
+func main (regs=186)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
@@ -145,35 +145,30 @@ L6:
   In           r101, r100, r21
   JumpIfTrue   r101, L7
   // from c in customer
-  Const        r102, []
-  Const        r103, "__group__"
-  Const        r104, true
+  Const        r102, "__group__"
+  Const        r103, true
   // group by {
-  Move         r105, r99
+  Move         r104, r99
   // from c in customer
+  Const        r105, []
   Const        r106, "items"
-  Move         r107, r102
-  Const        r108, "count"
-  Const        r109, 0
-  MakeMap      r110, 4, r103
-  SetIndex     r21, r100, r110
-  Append       r22, r22, r110
+  Move         r107, r105
+  MakeMap      r108, 3, r102
+  SetIndex     r21, r100, r108
+  Append       r22, r22, r108
 L7:
-  Index        r112, r21, r100
-  Index        r113, r112, r106
-  Append       r114, r113, r77
-  SetIndex     r112, r106, r114
-  Index        r115, r112, r108
-  Const        r116, 1
-  AddInt       r117, r115, r116
-  SetIndex     r112, r108, r117
+  Index        r110, r21, r100
+  Index        r111, r110, r106
+  Append       r112, r111, r77
+  SetIndex     r110, r106, r112
 L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r52, r52, r116
+  Const        r113, 1
+  AddInt       r52, r52, r113
   Jump         L8
 L3:
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r41, r41, r116
+  AddInt       r41, r41, r113
   Jump         L9
 L2:
   // join o in orders on o.o_custkey == c.c_custkey
@@ -182,69 +177,70 @@ L1:
   // from c in customer
   Jump         L11
 L0:
-  Move         r118, r109
-  Len          r119, r22
+  Const        r115, 0
+  Move         r114, r115
+  Len          r116, r22
 L17:
-  LessInt      r120, r118, r119
-  JumpIfFalse  r120, L12
-  Index        r122, r22, r118
+  LessInt      r117, r114, r116
+  JumpIfFalse  r117, L12
+  Index        r119, r22, r114
   // c_custkey: g.key.c_custkey,
-  Const        r123, "c_custkey"
-  Index        r124, r122, r16
-  Index        r125, r124, r7
+  Const        r120, "c_custkey"
+  Index        r121, r119, r16
+  Index        r122, r121, r7
   // c_name: g.key.c_name,
-  Const        r126, "c_name"
-  Index        r127, r122, r16
-  Index        r128, r127, r8
+  Const        r123, "c_name"
+  Index        r124, r119, r16
+  Index        r125, r124, r8
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r129, "revenue"
-  Const        r130, []
-  IterPrep     r131, r122
-  Len          r132, r131
-  Move         r133, r109
+  Const        r126, "revenue"
+  Const        r127, []
+  IterPrep     r128, r119
+  Len          r129, r128
+  Move         r130, r115
 L14:
-  LessInt      r134, r133, r132
-  JumpIfFalse  r134, L13
-  Index        r135, r131, r133
-  Move         r136, r135
-  Index        r137, r136, r18
-  Index        r138, r137, r19
-  Index        r139, r136, r18
-  Index        r140, r139, r20
-  Sub          r141, r116, r140
-  Mul          r142, r138, r141
-  Append       r130, r130, r142
-  AddInt       r133, r133, r116
+  LessInt      r131, r130, r129
+  JumpIfFalse  r131, L13
+  Index        r132, r128, r130
+  Move         r133, r132
+  Index        r134, r133, r18
+  Index        r135, r134, r19
+  Index        r136, r133, r18
+  Index        r137, r136, r20
+  Sub          r138, r113, r137
+  Mul          r139, r135, r138
+  Append       r127, r127, r139
+  AddInt       r130, r130, r113
   Jump         L14
 L13:
   // select {
-  MakeMap      r168, 8, r123
+  MakeMap      r165, 8, r120
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r169, []
-  IterPrep     r170, r122
-  Len          r171, r170
-  Move         r172, r109
+  Const        r166, []
+  IterPrep     r167, r119
+  Len          r168, r167
+  Move         r169, r115
 L16:
-  LessInt      r173, r172, r171
-  JumpIfFalse  r173, L15
-  Index        r136, r170, r172
-  Index        r175, r136, r18
-  Index        r176, r175, r19
-  Index        r177, r136, r18
-  Index        r178, r177, r20
-  Sub          r179, r116, r178
-  Mul          r180, r176, r179
-  Append       r169, r169, r180
-  AddInt       r172, r172, r116
+  LessInt      r170, r169, r168
+  JumpIfFalse  r170, L15
+  Index        r133, r167, r169
+  Index        r172, r133, r18
+  Index        r173, r172, r19
+  Index        r174, r133, r18
+  Index        r175, r174, r20
+  Sub          r176, r113, r175
+  Mul          r177, r173, r176
+  Append       r166, r166, r177
+  AddInt       r169, r169, r113
   Jump         L16
 L15:
-  Sum          r182, r169
-  Neg          r184, r182
+  Sum          r179, r166
+  Neg          r181, r179
   // from c in customer
-  Move         r185, r168
-  MakeList     r186, 2, r184
-  Append       r6, r6, r186
-  AddInt       r118, r118, r116
+  Move         r182, r165
+  MakeList     r183, 2, r181
+  Append       r6, r6, r183
+  AddInt       r114, r114, r113
   Jump         L17
 L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,4 +1,4 @@
-func main (regs=69)
+func main (regs=66)
   // let items = [
   Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
   // from i in items
@@ -25,77 +25,73 @@ L2:
   In           r16, r15, r9
   JumpIfTrue   r16, L1
   // from i in items
-  Const        r17, []
-  Const        r18, "__group__"
-  Const        r19, true
+  Const        r17, "__group__"
+  Const        r18, true
   // group by i.cat into g
-  Move         r20, r14
+  Move         r19, r14
   // from i in items
+  Const        r20, []
   Const        r21, "items"
-  Move         r22, r17
-  Const        r23, "count"
-  Const        r24, 0
-  MakeMap      r25, 4, r18
-  SetIndex     r9, r15, r25
+  Move         r22, r20
+  MakeMap      r23, 3, r17
+  SetIndex     r9, r15, r23
 L1:
-  Index        r27, r9, r15
-  Index        r28, r27, r21
-  Append       r29, r28, r12
-  SetIndex     r27, r21, r29
-  Index        r30, r27, r23
-  Const        r31, 1
-  AddInt       r32, r30, r31
-  SetIndex     r27, r23, r32
-  AddInt       r8, r8, r31
+  Index        r25, r9, r15
+  Index        r26, r25, r21
+  Append       r27, r26, r12
+  SetIndex     r25, r21, r27
+  Const        r28, 1
+  AddInt       r8, r8, r28
   Jump         L2
 L0:
-  Move         r33, r24
-  Const        r34, 0
+  Const        r30, 0
+  Move         r29, r30
+  Const        r31, 0
 L8:
-  LessInt      r35, r33, r34
-  JumpIfFalse  r35, L3
-  Index        r37, r10, r33
+  LessInt      r32, r29, r31
+  JumpIfFalse  r32, L3
+  Index        r34, r10, r29
   // cat: g.key,
-  Const        r38, "cat"
-  Index        r39, r37, r3
+  Const        r35, "cat"
+  Index        r36, r34, r3
   // total: sum(from x in g select x.val)
-  Const        r40, "total"
-  Const        r41, []
-  IterPrep     r42, r37
-  Len          r43, r42
-  Move         r44, r24
+  Const        r37, "total"
+  Const        r38, []
+  IterPrep     r39, r34
+  Len          r40, r39
+  Move         r41, r30
 L5:
-  LessInt      r45, r44, r43
-  JumpIfFalse  r45, L4
-  Index        r47, r42, r44
-  Index        r48, r47, r5
-  Append       r41, r41, r48
-  AddInt       r44, r44, r31
+  LessInt      r42, r41, r40
+  JumpIfFalse  r42, L4
+  Index        r44, r39, r41
+  Index        r45, r44, r5
+  Append       r38, r38, r45
+  AddInt       r41, r41, r28
   Jump         L5
 L4:
   // select {
-  MakeMap      r53, 2, r38
+  MakeMap      r50, 2, r35
   // sort by -sum(from x in g select x.val)
-  Const        r54, []
-  IterPrep     r55, r37
-  Len          r56, r55
-  Move         r57, r24
+  Const        r51, []
+  IterPrep     r52, r34
+  Len          r53, r52
+  Move         r54, r30
 L7:
-  LessInt      r58, r57, r56
-  JumpIfFalse  r58, L6
-  Index        r47, r55, r57
-  Index        r60, r47, r5
-  Append       r54, r54, r60
-  AddInt       r57, r57, r31
+  LessInt      r55, r54, r53
+  JumpIfFalse  r55, L6
+  Index        r44, r52, r54
+  Index        r57, r44, r5
+  Append       r51, r51, r57
+  AddInt       r54, r54, r28
   Jump         L7
 L6:
-  Sum          r62, r54
-  Neg          r64, r62
+  Sum          r59, r51
+  Neg          r61, r59
   // from i in items
-  Move         r65, r53
-  MakeList     r66, 2, r64
-  Append       r1, r1, r66
-  AddInt       r33, r33, r31
+  Move         r62, r50
+  MakeList     r63, 2, r61
+  Append       r1, r1, r63
+  AddInt       r29, r29, r28
   Jump         L8
 L3:
   // sort by -sum(from x in g select x.val)

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -1,4 +1,4 @@
-func main (regs=79)
+func main (regs=75)
   // let data = [
   Const        r0, [{"tag": "a", "val": 1}, {"tag": "a", "val": 2}, {"tag": "b", "val": 3}]
   // let groups = from d in data group by d.tag into g select g
@@ -17,99 +17,92 @@ L2:
   Str          r12, r11
   In           r13, r12, r6
   JumpIfTrue   r13, L1
-  Const        r14, []
-  Const        r15, "__group__"
-  Const        r16, true
-  Const        r17, "key"
-  Move         r18, r11
-  Const        r19, "items"
-  Move         r20, r14
-  Const        r21, "count"
-  Const        r22, 0
-  MakeMap      r23, 4, r15
-  SetIndex     r6, r12, r23
-  Append       r7, r7, r23
+  Const        r14, "__group__"
+  Const        r15, true
+  Const        r16, []
+  Const        r17, "items"
+  MakeMap      r19, 2, r14
+  SetIndex     r6, r12, r19
+  Append       r7, r7, r19
 L1:
-  Index        r25, r6, r12
-  Index        r26, r25, r19
-  Append       r27, r26, r9
-  SetIndex     r25, r19, r27
-  Index        r28, r25, r21
-  Const        r29, 1
-  AddInt       r30, r28, r29
-  SetIndex     r25, r21, r30
-  AddInt       r5, r5, r29
+  Index        r21, r6, r12
+  Index        r22, r21, r17
+  Append       r23, r22, r9
+  SetIndex     r21, r17, r23
+  Const        r24, 1
+  AddInt       r5, r5, r24
   Jump         L2
 L0:
-  Move         r31, r22
-  Len          r32, r7
+  Const        r26, 0
+  Move         r25, r26
+  Len          r27, r7
 L4:
-  LessInt      r33, r31, r32
-  JumpIfFalse  r33, L3
-  Index        r35, r7, r31
-  Append       r1, r1, r35
-  AddInt       r31, r31, r29
+  LessInt      r28, r25, r27
+  JumpIfFalse  r28, L3
+  Index        r30, r7, r25
+  Append       r1, r1, r30
+  AddInt       r25, r25, r24
   Jump         L4
 L3:
   // var tmp = []
-  Const        r38, []
+  Const        r33, []
   // for g in groups {
-  IterPrep     r39, r1
-  Len          r40, r39
-  Const        r41, 0
+  IterPrep     r34, r1
+  Len          r35, r34
+  Const        r36, 0
 L8:
-  Less         r42, r41, r40
-  JumpIfFalse  r42, L5
-  Index        r35, r39, r41
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L5
+  Index        r30, r34, r36
   // var total = 0
-  Move         r44, r22
+  Move         r39, r26
   // for x in g.items {
-  Index        r45, r35, r19
-  IterPrep     r46, r45
-  Len          r47, r46
-  Const        r48, 0
+  Index        r40, r30, r17
+  IterPrep     r41, r40
+  Len          r42, r41
+  Const        r43, 0
 L7:
-  Less         r49, r48, r47
-  JumpIfFalse  r49, L6
-  Index        r51, r46, r48
+  Less         r44, r43, r42
+  JumpIfFalse  r44, L6
+  Index        r46, r41, r43
   // total = total + x.val
-  Const        r52, "val"
-  Index        r53, r51, r52
-  Add          r44, r44, r53
+  Const        r47, "val"
+  Index        r48, r46, r47
+  Add          r39, r39, r48
   // for x in g.items {
-  Const        r55, 1
-  Add          r48, r48, r55
+  Const        r50, 1
+  Add          r43, r43, r50
   Jump         L7
 L6:
   // tmp = append(tmp, {tag: g.key, total: total})
-  Const        r57, "tag"
-  Index        r58, r35, r17
-  Const        r59, "total"
-  Move         r60, r58
-  MakeMap      r62, 2, r57
-  Append       r38, r38, r62
+  Const        r52, "tag"
+  Const        r53, "key"
+  Index        r54, r30, r53
+  Const        r55, "total"
+  MakeMap      r58, 2, r52
+  Append       r33, r33, r58
   // for g in groups {
-  Const        r64, 1
-  Add          r41, r41, r64
+  Const        r60, 1
+  Add          r36, r36, r60
   Jump         L8
 L5:
   // let result = from r in tmp sort by r.tag select r
-  Const        r66, []
-  IterPrep     r67, r38
-  Len          r68, r67
-  Move         r69, r22
+  Const        r62, []
+  IterPrep     r63, r33
+  Len          r64, r63
+  Move         r65, r26
 L10:
-  LessInt      r70, r69, r68
-  JumpIfFalse  r70, L9
-  Index        r72, r67, r69
-  Index        r74, r72, r2
-  Move         r75, r72
-  MakeList     r76, 2, r74
-  Append       r66, r66, r76
-  AddInt       r69, r69, r29
+  LessInt      r66, r65, r64
+  JumpIfFalse  r66, L9
+  Index        r68, r63, r65
+  Index        r70, r68, r2
+  Move         r71, r68
+  MakeList     r72, 2, r70
+  Append       r62, r62, r72
+  AddInt       r65, r65, r24
   Jump         L10
 L9:
-  Sort         r66, r66
+  Sort         r62, r62
   // print(result)
-  Print        r66
+  Print        r62
   Return       r0


### PR DESCRIPTION
## Summary
- avoid building group `items` list when not needed
- regenerate VM IR for group queries

## Testing
- `go test ./...`
- `go test -tags slow ./tests/vm -run TestVM_IR -update`

------
https://chatgpt.com/codex/tasks/task_e_68611d8233488320bcc0ebb3c9a1044f