### PR TITLE
Disable vm optimizations

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -20,6 +20,10 @@ import (
 	"mochi/types"
 )
 
+// EnableOptimizations toggles bytecode optimization passes when compiling.
+// It defaults to false so tests can exercise unoptimized code.
+var EnableOptimizations = false
+
 // Value represents a runtime value handled by the VM.
 // The definition lives in value.go and mirrors the interpreter's Value without
 // requiring that package.
@@ -1676,9 +1680,11 @@ func compileProgram(p *parser.Program, env *types.Env) (*Program, error) {
 		return nil, err
 	}
 	c.funcs[0] = main
-	// Run liveness-based optimization on all functions
-	for i := range c.funcs {
-		Optimize(&c.funcs[i])
+	// Optionally optimize bytecode across all functions
+	if EnableOptimizations {
+		for i := range c.funcs {
+			Optimize(&c.funcs[i])
+		}
 	}
 	return &Program{Funcs: c.funcs, Types: c.types}, nil
 }

--- a/tests/dataset/tpc-h/out/q1.ir.out
+++ b/tests/dataset/tpc-h/out/q1.ir.out
@@ -1,4 +1,4 @@
-func main (regs=198)
+func main (regs=201)
   // let lineitem = [
   Const        r0, [{"l_discount": 0.05, "l_extendedprice": 1000, "l_linestatus": "O", "l_quantity": 17, "l_returnflag": "N", "l_shipdate": "1998-08-01", "l_tax": 0.07}, {"l_discount": 0.1, "l_extendedprice": 2000, "l_linestatus": "O", "l_quantity": 36, "l_returnflag": "N", "l_shipdate": "1998-09-01", "l_tax": 0.05}, {"l_discount": 0, "l_extendedprice": 1500, "l_linestatus": "F", "l_quantity": 25, "l_returnflag": "R", "l_shipdate": "1998-09-03", "l_tax": 0.08}]
   // from row in lineitem
@@ -14,13 +14,25 @@ func main (regs=198)
   // returnflag: g.key.returnflag,
   Const        r7, "key"
   // sum_qty: sum(from x in g select x.l_quantity),
+  Const        r8, "sum_qty"
   Const        r9, "l_quantity"
   // sum_base_price: sum(from x in g select x.l_extendedprice),
+  Const        r10, "sum_base_price"
   Const        r11, "l_extendedprice"
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+  Const        r12, "sum_disc_price"
   Const        r13, "l_discount"
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+  Const        r14, "sum_charge"
   Const        r15, "l_tax"
+  // avg_qty: avg(from x in g select x.l_quantity),
+  Const        r16, "avg_qty"
+  // avg_price: avg(from x in g select x.l_extendedprice),
+  Const        r17, "avg_price"
+  // avg_disc: avg(from x in g select x.l_discount),
+  Const        r18, "avg_disc"
+  // count_order: count(g)
+  Const        r19, "count_order"
   // from row in lineitem
   IterPrep     r20, r0
   Len          r21, r20
@@ -43,6 +55,10 @@ L3:
   // linestatus: row.l_linestatus
   Const        r33, "linestatus"
   Index        r34, r27, r5
+  // returnflag: row.l_returnflag,
+  Move         r35, r32
+  // linestatus: row.l_linestatus
+  Move         r36, r34
   // group by {
   MakeMap      r37, 2, r31
   Str          r38, r37
@@ -57,185 +73,269 @@ L3:
   // from row in lineitem
   Const        r44, "items"
   Move         r45, r40
-  MakeMap      r46, 3, r41
-  SetIndex     r23, r38, r46
-  Append       r24, r24, r46
+  Const        r46, "count"
+  Const        r47, 0
+  MakeMap      r48, 4, r41
+  SetIndex     r23, r38, r48
+  Append       r49, r24, r48
+  Move         r24, r49
 L2:
-  Index        r48, r23, r38
-  Index        r49, r48, r44
-  Append       r50, r49, r26
-  SetIndex     r48, r44, r50
+  Index        r50, r23, r38
+  Index        r51, r50, r44
+  Append       r52, r51, r26
+  SetIndex     r50, r44, r52
+  Index        r53, r50, r46
+  Const        r54, 1
+  AddInt       r55, r53, r54
+  SetIndex     r50, r46, r55
 L1:
-  Const        r51, 1
-  AddInt       r22, r22, r51
+  AddInt       r22, r22, r54
   Jump         L3
 L0:
-  Const        r53, 0
-  Move         r52, r53
-  Len          r54, r24
+  Move         r56, r47
+  Len          r57, r24
 L19:
-  LessInt      r55, r52, r54
-  JumpIfFalse  r55, L4
-  Index        r57, r24, r52
+  LessInt      r58, r56, r57
+  JumpIfFalse  r58, L4
+  Index        r59, r24, r56
+  Move         r60, r59
   // returnflag: g.key.returnflag,
-  Const        r58, "returnflag"
-  Index        r59, r57, r7
-  Index        r60, r59, r2
+  Const        r61, "returnflag"
+  Index        r62, r60, r7
+  Index        r63, r62, r2
   // linestatus: g.key.linestatus,
-  Const        r61, "linestatus"
-  Index        r62, r57, r7
-  Index        r63, r62, r4
+  Const        r64, "linestatus"
+  Index        r65, r60, r7
+  Index        r66, r65, r4
   // sum_qty: sum(from x in g select x.l_quantity),
-  Const        r64, "sum_qty"
-  Const        r65, []
-  IterPrep     r66, r57
-  Len          r67, r66
-  Move         r68, r53
+  Const        r67, "sum_qty"
+  Const        r68, []
+  IterPrep     r69, r60
+  Len          r70, r69
+  Move         r71, r47
 L6:
-  LessInt      r69, r68, r67
-  JumpIfFalse  r69, L5
-  Index        r70, r66, r68
-  Move         r71, r70
-  Index        r72, r71, r9
-  Append       r73, r65, r72
-  Move         r65, r73
-  AddInt       r68, r68, r51
+  LessInt      r72, r71, r70
+  JumpIfFalse  r72, L5
+  Index        r73, r69, r71
+  Move         r74, r73
+  Index        r75, r74, r9
+  Append       r76, r68, r75
+  Move         r68, r76
+  AddInt       r71, r71, r54
   Jump         L6
 L5:
-  Sum          r74, r65
+  Sum          r77, r68
   // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Const        r75, "sum_base_price"
-  Const        r76, []
-  IterPrep     r77, r57
-  Len          r78, r77
-  Move         r79, r53
+  Const        r78, "sum_base_price"
+  Const        r79, []
+  IterPrep     r80, r60
+  Len          r81, r80
+  Move         r82, r47
 L8:
-  LessInt      r80, r79, r78
-  JumpIfFalse  r80, L7
-  Index        r71, r77, r79
-  Index        r82, r71, r11
-  Append       r76, r76, r82
-  AddInt       r79, r79, r51
+  LessInt      r83, r82, r81
+  JumpIfFalse  r83, L7
+  Index        r84, r80, r82
+  Move         r74, r84
+  Index        r85, r74, r11
+  Append       r86, r79, r85
+  Move         r79, r86
+  AddInt       r82, r82, r54
   Jump         L8
 L7:
+  Sum          r87, r79
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Const        r86, []
-  IterPrep     r87, r57
-  Len          r88, r87
-  Move         r89, r53
+  Const        r88, "sum_disc_price"
+  Const        r89, []
+  IterPrep     r90, r60
+  Len          r91, r90
+  Move         r92, r47
 L10:
-  LessInt      r90, r89, r88
-  JumpIfFalse  r90, L9
-  Index        r71, r87, r89
-  Index        r92, r71, r11
-  Index        r93, r71, r13
-  Sub          r94, r51, r93
-  Mul          r95, r92, r94
-  Append       r86, r86, r95
-  AddInt       r89, r89, r51
+  LessInt      r93, r92, r91
+  JumpIfFalse  r93, L9
+  Index        r94, r90, r92
+  Move         r74, r94
+  Index        r95, r74, r11
+  Index        r96, r74, r13
+  Sub          r97, r54, r96
+  Mul          r98, r95, r97
+  Append       r99, r89, r98
+  Move         r89, r99
+  AddInt       r92, r92, r54
   Jump         L10
 L9:
+  Sum          r100, r89
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Const        r99, []
-  IterPrep     r100, r57
-  Len          r101, r100
-  Move         r102, r53
+  Const        r101, "sum_charge"
+  Const        r102, []
+  IterPrep     r103, r60
+  Len          r104, r103
+  Move         r105, r47
 L12:
-  LessInt      r103, r102, r101
-  JumpIfFalse  r103, L11
-  Index        r71, r100, r102
-  Index        r105, r71, r11
-  Index        r106, r71, r13
-  Sub          r107, r51, r106
-  Mul          r108, r105, r107
-  Index        r109, r71, r15
-  Add          r110, r51, r109
+  LessInt      r106, r105, r104
+  JumpIfFalse  r106, L11
+  Index        r107, r103, r105
+  Move         r74, r107
+  Index        r108, r74, r11
+  Index        r109, r74, r13
+  Sub          r110, r54, r109
   Mul          r111, r108, r110
-  Append       r99, r99, r111
-  AddInt       r102, r102, r51
+  Index        r112, r74, r15
+  Add          r113, r54, r112
+  Mul          r114, r111, r113
+  Append       r115, r102, r114
+  Move         r102, r115
+  AddInt       r105, r105, r54
   Jump         L12
 L11:
+  Sum          r116, r102
   // avg_qty: avg(from x in g select x.l_quantity),
-  Const        r115, []
-  IterPrep     r116, r57
-  Len          r117, r116
-  Move         r118, r53
+  Const        r117, "avg_qty"
+  Const        r118, []
+  IterPrep     r119, r60
+  Len          r120, r119
+  Move         r121, r47
 L14:
-  LessInt      r119, r118, r117
-  JumpIfFalse  r119, L13
-  Index        r71, r116, r118
-  Index        r121, r71, r9
-  Append       r115, r115, r121
-  AddInt       r118, r118, r51
+  LessInt      r122, r121, r120
+  JumpIfFalse  r122, L13
+  Index        r123, r119, r121
+  Move         r74, r123
+  Index        r124, r74, r9
+  Append       r125, r118, r124
+  Move         r118, r125
+  AddInt       r121, r121, r54
   Jump         L14
 L13:
+  Avg          r126, r118
   // avg_price: avg(from x in g select x.l_extendedprice),
-  Const        r125, []
-  IterPrep     r126, r57
-  Len          r127, r126
-  Move         r128, r53
+  Const        r127, "avg_price"
+  Const        r128, []
+  IterPrep     r129, r60
+  Len          r130, r129
+  Move         r131, r47
 L16:
-  LessInt      r129, r128, r127
-  JumpIfFalse  r129, L15
-  Index        r71, r126, r128
-  Index        r131, r71, r11
-  Append       r125, r125, r131
-  AddInt       r128, r128, r51
+  LessInt      r132, r131, r130
+  JumpIfFalse  r132, L15
+  Index        r133, r129, r131
+  Move         r74, r133
+  Index        r134, r74, r11
+  Append       r135, r128, r134
+  Move         r128, r135
+  AddInt       r131, r131, r54
   Jump         L16
 L15:
+  Avg          r136, r128
   // avg_disc: avg(from x in g select x.l_discount),
-  Const        r135, []
-  IterPrep     r136, r57
-  Len          r137, r136
-  Move         r138, r53
+  Const        r137, "avg_disc"
+  Const        r138, []
+  IterPrep     r139, r60
+  Len          r140, r139
+  Move         r141, r47
 L18:
-  LessInt      r139, r138, r137
-  JumpIfFalse  r139, L17
-  Index        r71, r136, r138
-  Index        r141, r71, r13
-  Append       r135, r135, r141
-  AddInt       r138, r138, r51
+  LessInt      r142, r141, r140
+  JumpIfFalse  r142, L17
+  Index        r143, r139, r141
+  Move         r74, r143
+  Index        r144, r74, r13
+  Append       r145, r138, r144
+  Move         r138, r145
+  AddInt       r141, r141, r54
   Jump         L18
 L17:
+  Avg          r146, r138
+  // count_order: count(g)
+  Const        r147, "count_order"
+  Index        r148, r60, r46
+  // returnflag: g.key.returnflag,
+  Move         r149, r63
+  // linestatus: g.key.linestatus,
+  Move         r150, r66
+  // sum_qty: sum(from x in g select x.l_quantity),
+  Move         r151, r77
+  // sum_base_price: sum(from x in g select x.l_extendedprice),
+  Move         r152, r87
+  // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+  Move         r153, r100
+  // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+  Move         r154, r116
+  // avg_qty: avg(from x in g select x.l_quantity),
+  Move         r155, r126
+  // avg_price: avg(from x in g select x.l_extendedprice),
+  Move         r156, r136
+  // avg_disc: avg(from x in g select x.l_discount),
+  Move         r157, r146
+  // count_order: count(g)
+  Move         r158, r148
   // select {
-  MakeMap      r156, 10, r58
+  MakeMap      r159, 10, r61
   // from row in lineitem
-  Append       r1, r1, r156
+  Append       r160, r1, r159
+  Move         r1, r160
+  AddInt       r56, r56, r54
   Jump         L19
 L4:
   // json(result)
   JSON         r1
   // returnflag: "N",
-  Const        r158, "returnflag"
-  Const        r159, "N"
+  Const        r161, "returnflag"
+  Const        r162, "N"
   // linestatus: "O",
-  Const        r160, "linestatus"
-  Const        r161, "O"
+  Const        r163, "linestatus"
+  Const        r164, "O"
   // sum_qty: 53,
-  Const        r162, "sum_qty"
-  Const        r163, 53
+  Const        r165, "sum_qty"
+  Const        r166, 53
   // sum_base_price: 3000,
-  Const        r164, "sum_base_price"
-  Const        r165, 3000
+  Const        r167, "sum_base_price"
+  Const        r168, 3000
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
-  Const        r166, "sum_disc_price"
-  Const        r167, 950
-  Const        r168, 1800
-  Const        r169, 2750
+  Const        r169, "sum_disc_price"
+  Const        r170, 950
+  Const        r171, 1800
+  AddFloat     r172, r170, r171
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
-  Const        r170, "sum_charge"
-  Const        r171, 1.07
-  Const        r172, 1016.5000000000001
-  Const        r173, 1.05
-  Const        r174, 1890
-  Const        r175, 2906.5
+  Const        r173, "sum_charge"
+  Const        r174, 1.07
+  MulFloat     r175, r170, r174
+  Const        r176, 1.05
+  MulFloat     r177, r171, r176
+  AddFloat     r178, r175, r177
   // avg_qty: 26.5,
-  Const        r176, "avg_qty"
-  Const        r177, 26.5
+  Const        r179, "avg_qty"
+  Const        r180, 26.5
+  // avg_price: 1500,
+  Const        r181, "avg_price"
+  Const        r182, 1500
+  // avg_disc: 0.07500000000000001,
+  Const        r183, "avg_disc"
+  Const        r184, 0.07500000000000001
+  // count_order: 2
+  Const        r185, "count_order"
+  Const        r186, 2
+  // returnflag: "N",
+  Move         r187, r162
+  // linestatus: "O",
+  Move         r188, r164
+  // sum_qty: 53,
+  Move         r189, r166
+  // sum_base_price: 3000,
+  Move         r190, r168
+  // sum_disc_price: 950.0 + 1800.0,               // 2750.0
+  Move         r191, r172
+  // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
+  Move         r192, r178
+  // avg_qty: 26.5,
+  Move         r193, r180
+  // avg_price: 1500,
+  Move         r194, r182
+  // avg_disc: 0.07500000000000001,
+  Move         r195, r184
+  // count_order: 2
+  Move         r196, r186
   // {
-  MakeMap      r195, 10, r158
+  MakeMap      r197, 10, r161
+  Move         r198, r197
   // expect result == [
-  MakeList     r196, 1, r195
-  Equal        r197, r1, r196
-  Expect       r197
+  MakeList     r199, 1, r198
+  Equal        r200, r1, r199
+  Expect       r200
   Return       r0

--- a/tests/dataset/tpc-h/out/q10.ir.out
+++ b/tests/dataset/tpc-h/out/q10.ir.out
@@ -1,4 +1,4 @@
-func main (regs=216)
+func main (regs=219)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
@@ -34,6 +34,7 @@ func main (regs=216)
   // c_custkey: g.key.c_custkey,
   Const        r16, "key"
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Const        r17, "revenue"
   Const        r18, "l"
   Const        r19, "l_extendedprice"
   Const        r20, "l_discount"
@@ -46,15 +47,17 @@ func main (regs=216)
 L11:
   LessInt      r26, r25, r24
   JumpIfFalse  r26, L0
-  Index        r28, r23, r25
+  Index        r27, r23, r25
+  Move         r28, r27
   // join o in orders on o.o_custkey == c.c_custkey
   IterPrep     r29, r2
   Len          r30, r29
   Const        r31, 0
 L10:
-  Less         r32, r31, r30
+  LessInt      r32, r31, r30
   JumpIfFalse  r32, L1
-  Index        r34, r29, r31
+  Index        r33, r29, r31
+  Move         r34, r33
   Const        r35, "o_custkey"
   Index        r36, r34, r35
   Index        r37, r28, r7
@@ -65,9 +68,10 @@ L10:
   Len          r40, r39
   Const        r41, 0
 L9:
-  Less         r42, r41, r40
+  LessInt      r42, r41, r40
   JumpIfFalse  r42, L2
-  Index        r44, r39, r41
+  Index        r43, r39, r41
+  Move         r44, r43
   Const        r45, "l_orderkey"
   Index        r46, r44, r45
   Const        r47, "o_orderkey"
@@ -79,9 +83,10 @@ L9:
   Len          r51, r50
   Const        r52, 0
 L8:
-  Less         r53, r52, r51
+  LessInt      r53, r52, r51
   JumpIfFalse  r53, L3
-  Index        r55, r50, r52
+  Index        r54, r50, r52
+  Move         r55, r54
   Const        r56, "n_nationkey"
   Index        r57, r55, r56
   Const        r58, "c_nationkey"
@@ -101,9 +106,10 @@ L8:
   // where o.o_orderdate >= start_date &&
   Move         r68, r62
   JumpIfFalse  r68, L5
+  Move         r68, r64
 L5:
   // o.o_orderdate < end_date &&
-  Move         r69, r64
+  Move         r69, r68
   JumpIfFalse  r69, L6
   Move         r69, r67
 L6:
@@ -139,6 +145,20 @@ L6:
   // n_name: n.n_name
   Const        r90, "n_name"
   Index        r91, r55, r13
+  // c_custkey: c.c_custkey,
+  Move         r92, r79
+  // c_name: c.c_name,
+  Move         r93, r81
+  // c_acctbal: c.c_acctbal,
+  Move         r94, r83
+  // c_address: c.c_address,
+  Move         r95, r85
+  // c_phone: c.c_phone,
+  Move         r96, r87
+  // c_comment: c.c_comment,
+  Move         r97, r89
+  // n_name: n.n_name
+  Move         r98, r91
   // group by {
   MakeMap      r99, 7, r78
   Str          r100, r99
@@ -153,126 +173,196 @@ L6:
   // from c in customer
   Const        r106, "items"
   Move         r107, r102
-  MakeMap      r108, 3, r103
-  SetIndex     r21, r100, r108
-  Append       r22, r22, r108
+  Const        r108, "count"
+  Const        r109, 0
+  MakeMap      r110, 4, r103
+  SetIndex     r21, r100, r110
+  Append       r111, r22, r110
+  Move         r22, r111
 L7:
-  Index        r110, r21, r100
-  Index        r111, r110, r106
-  Append       r112, r111, r77
-  SetIndex     r110, r106, r112
+  Index        r112, r21, r100
+  Index        r113, r112, r106
+  Append       r114, r113, r77
+  SetIndex     r112, r106, r114
+  Index        r115, r112, r108
+  Const        r116, 1
+  AddInt       r117, r115, r116
+  SetIndex     r112, r108, r117
 L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  Const        r113, 1
-  AddInt       r52, r52, r113
+  AddInt       r52, r52, r116
   Jump         L8
 L3:
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r41, r41, r113
+  AddInt       r41, r41, r116
   Jump         L9
 L2:
   // join o in orders on o.o_custkey == c.c_custkey
+  AddInt       r31, r31, r116
   Jump         L10
 L1:
   // from c in customer
+  AddInt       r25, r25, r116
   Jump         L11
 L0:
-  Const        r115, 0
-  Move         r114, r115
-  Len          r116, r22
+  Move         r118, r109
+  Len          r119, r22
 L17:
-  LessInt      r117, r114, r116
-  JumpIfFalse  r117, L12
-  Index        r119, r22, r114
+  LessInt      r120, r118, r119
+  JumpIfFalse  r120, L12
+  Index        r121, r22, r118
+  Move         r122, r121
   // c_custkey: g.key.c_custkey,
-  Const        r120, "c_custkey"
-  Index        r121, r119, r16
-  Index        r122, r121, r7
+  Const        r123, "c_custkey"
+  Index        r124, r122, r16
+  Index        r125, r124, r7
   // c_name: g.key.c_name,
-  Const        r123, "c_name"
-  Index        r124, r119, r16
-  Index        r125, r124, r8
+  Const        r126, "c_name"
+  Index        r127, r122, r16
+  Index        r128, r127, r8
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r126, "revenue"
-  Const        r127, []
-  IterPrep     r128, r119
-  Len          r129, r128
-  Move         r130, r115
+  Const        r129, "revenue"
+  Const        r130, []
+  IterPrep     r131, r122
+  Len          r132, r131
+  Move         r133, r109
 L14:
-  LessInt      r131, r130, r129
-  JumpIfFalse  r131, L13
-  Index        r132, r128, r130
-  Move         r133, r132
-  Index        r134, r133, r18
-  Index        r135, r134, r19
-  Index        r136, r133, r18
-  Index        r137, r136, r20
-  Sub          r138, r113, r137
-  Mul          r139, r135, r138
-  Append       r127, r127, r139
-  AddInt       r130, r130, r113
+  LessInt      r134, r133, r132
+  JumpIfFalse  r134, L13
+  Index        r135, r131, r133
+  Move         r136, r135
+  Index        r137, r136, r18
+  Index        r138, r137, r19
+  Index        r139, r136, r18
+  Index        r140, r139, r20
+  Sub          r141, r116, r140
+  Mul          r142, r138, r141
+  Append       r143, r130, r142
+  Move         r130, r143
+  AddInt       r133, r133, r116
   Jump         L14
 L13:
+  Sum          r144, r130
+  // c_acctbal: g.key.c_acctbal,
+  Const        r145, "c_acctbal"
+  Index        r146, r122, r16
+  Index        r147, r146, r9
+  // n_name: g.key.n_name,
+  Const        r148, "n_name"
+  Index        r149, r122, r16
+  Index        r150, r149, r13
+  // c_address: g.key.c_address,
+  Const        r151, "c_address"
+  Index        r152, r122, r16
+  Index        r153, r152, r10
+  // c_phone: g.key.c_phone,
+  Const        r154, "c_phone"
+  Index        r155, r122, r16
+  Index        r156, r155, r11
+  // c_comment: g.key.c_comment
+  Const        r157, "c_comment"
+  Index        r158, r122, r16
+  Index        r159, r158, r12
+  // c_custkey: g.key.c_custkey,
+  Move         r160, r125
+  // c_name: g.key.c_name,
+  Move         r161, r128
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r162, r144
+  // c_acctbal: g.key.c_acctbal,
+  Move         r163, r147
+  // n_name: g.key.n_name,
+  Move         r164, r150
+  // c_address: g.key.c_address,
+  Move         r165, r153
+  // c_phone: g.key.c_phone,
+  Move         r166, r156
+  // c_comment: g.key.c_comment
+  Move         r167, r159
   // select {
-  MakeMap      r165, 8, r120
+  MakeMap      r168, 8, r123
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r166, []
-  IterPrep     r167, r119
-  Len          r168, r167
-  Move         r169, r115
+  Const        r169, []
+  IterPrep     r170, r122
+  Len          r171, r170
+  Move         r172, r109
 L16:
-  LessInt      r170, r169, r168
-  JumpIfFalse  r170, L15
-  Index        r133, r167, r169
-  Index        r172, r133, r18
-  Index        r173, r172, r19
-  Index        r174, r133, r18
-  Index        r175, r174, r20
-  Sub          r176, r113, r175
-  Mul          r177, r173, r176
-  Append       r166, r166, r177
-  AddInt       r169, r169, r113
+  LessInt      r173, r172, r171
+  JumpIfFalse  r173, L15
+  Index        r174, r170, r172
+  Move         r136, r174
+  Index        r175, r136, r18
+  Index        r176, r175, r19
+  Index        r177, r136, r18
+  Index        r178, r177, r20
+  Sub          r179, r116, r178
+  Mul          r180, r176, r179
+  Append       r181, r169, r180
+  Move         r169, r181
+  AddInt       r172, r172, r116
   Jump         L16
 L15:
-  Sum          r179, r166
-  Neg          r181, r179
+  Sum          r182, r169
+  Neg          r183, r182
+  Move         r184, r183
   // from c in customer
-  Move         r182, r165
-  MakeList     r183, 2, r181
-  Append       r6, r6, r183
-  AddInt       r114, r114, r113
+  Move         r185, r168
+  MakeList     r186, 2, r184
+  Append       r187, r6, r186
+  Move         r6, r187
+  AddInt       r118, r118, r116
   Jump         L17
 L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Sort         r6, r6
+  Sort         r188, r6
+  // from c in customer
+  Move         r6, r188
   // c_custkey: 1,
-  Const        r187, "c_custkey"
+  Const        r190, "c_custkey"
   // c_name: "Alice",
-  Const        r188, "c_name"
-  Const        r189, "Alice"
+  Const        r191, "c_name"
+  Const        r192, "Alice"
   // revenue: 1000.0 * 0.9, // 900.0
-  Const        r190, "revenue"
-  Const        r191, 1000
-  Const        r192, 0.9
-  Const        r193, 900
+  Const        r193, "revenue"
+  Const        r194, 1000
+  Const        r195, 0.9
+  MulFloat     r196, r194, r195
   // c_acctbal: 100.0,
-  Const        r194, "c_acctbal"
-  Const        r195, 100
+  Const        r197, "c_acctbal"
+  Const        r198, 100
   // n_name: "BRAZIL",
-  Const        r196, "n_name"
-  Const        r197, "BRAZIL"
+  Const        r199, "n_name"
+  Const        r200, "BRAZIL"
   // c_address: "123 St",
-  Const        r198, "c_address"
-  Const        r199, "123 St"
+  Const        r201, "c_address"
+  Const        r202, "123 St"
   // c_phone: "123-456",
-  Const        r200, "c_phone"
-  Const        r201, "123-456"
+  Const        r203, "c_phone"
+  Const        r204, "123-456"
   // c_comment: "Loyal"
-  Const        r202, "c_comment"
+  Const        r205, "c_comment"
+  Const        r206, "Loyal"
+  // c_custkey: 1,
+  Move         r207, r116
+  // c_name: "Alice",
+  Move         r208, r192
+  // revenue: 1000.0 * 0.9, // 900.0
+  Move         r209, r196
+  // c_acctbal: 100.0,
+  Move         r210, r198
+  // n_name: "BRAZIL",
+  Move         r211, r200
+  // c_address: "123 St",
+  Move         r212, r202
+  // c_phone: "123-456",
+  Move         r213, r204
+  // c_comment: "Loyal"
+  Move         r214, r206
   // {
-  MakeMap      r213, 8, r187
+  MakeMap      r215, 8, r190
+  Move         r216, r215
   // expect result == [
-  MakeList     r214, 1, r213
-  Equal        r215, r6, r214
-  Expect       r215
+  MakeList     r217, 1, r216
+  Equal        r218, r6, r217
+  Expect       r218
   Return       r0

--- a/tests/dataset/tpc-h/out/q11.ir.out
+++ b/tests/dataset/tpc-h/out/q11.ir.out
@@ -1,4 +1,4 @@
-func main (regs=126)
+func main (regs=129)
   // let nation = [
   Const        r0, [{"n_name": "GERMANY", "n_nationkey": 1}, {"n_name": "FRANCE", "n_nationkey": 2}]
   // let supplier = [
@@ -16,6 +16,7 @@ func main (regs=126)
   // value: ps.ps_supplycost * ps.ps_availqty
   Const        r7, "value"
   Const        r8, "ps_supplycost"
+  Const        r9, "ps_availqty"
   // from ps in partsupp
   IterPrep     r10, r2
   Len          r11, r10
@@ -24,7 +25,8 @@ func main (regs=126)
 L6:
   LessInt      r14, r12, r11
   JumpIfFalse  r14, L0
-  Index        r16, r10, r12
+  Index        r15, r10, r12
+  Move         r16, r15
   // join s in supplier on s.s_suppkey == ps.ps_suppkey
   IterPrep     r17, r1
   Len          r18, r17
@@ -34,7 +36,8 @@ L6:
 L5:
   LessInt      r22, r21, r18
   JumpIfFalse  r22, L1
-  Index        r24, r17, r21
+  Index        r23, r17, r21
+  Move         r24, r23
   Index        r25, r24, r19
   Index        r26, r16, r20
   Equal        r27, r25, r26
@@ -48,7 +51,8 @@ L5:
 L4:
   LessInt      r33, r32, r29
   JumpIfFalse  r33, L2
-  Index        r35, r28, r32
+  Index        r34, r28, r32
+  Move         r35, r34
   Index        r36, r35, r30
   Index        r37, r24, r31
   Equal        r38, r36, r37
@@ -63,10 +67,17 @@ L4:
   // value: ps.ps_supplycost * ps.ps_availqty
   Const        r43, "value"
   Index        r44, r16, r8
+  Index        r45, r16, r9
+  Mul          r46, r44, r45
+  // ps_partkey: ps.ps_partkey,
+  Move         r47, r42
+  // value: ps.ps_supplycost * ps.ps_availqty
+  Move         r48, r46
   // select {
   MakeMap      r49, 2, r41
   // from ps in partsupp
-  Append       r4, r4, r49
+  Append       r50, r4, r49
+  Move         r4, r50
 L3:
   // join n in nation on n.n_nationkey == s.s_nationkey
   Const        r51, 1
@@ -74,6 +85,7 @@ L3:
   Jump         L4
 L2:
   // join s in supplier on s.s_suppkey == ps.ps_suppkey
+  Add          r21, r21, r51
   Jump         L5
 L1:
   // from ps in partsupp
@@ -94,8 +106,9 @@ L9:
   LessInt      r59, r56, r55
   JumpIfFalse  r59, L7
   Index        r60, r54, r56
+  Move         r61, r60
   // group by x.ps_partkey into g
-  Index        r62, r60, r6
+  Index        r62, r61, r6
   Str          r63, r62
   In           r64, r63, r57
   JumpIfTrue   r64, L8
@@ -108,96 +121,117 @@ L9:
   // from x in filtered
   Const        r69, "items"
   Move         r70, r65
-  MakeMap      r71, 3, r66
-  SetIndex     r57, r63, r71
-  Append       r58, r58, r71
+  Const        r71, "count"
+  MakeMap      r72, 4, r66
+  SetIndex     r57, r63, r72
+  Append       r73, r58, r72
+  Move         r58, r73
 L8:
-  Index        r73, r57, r63
-  Index        r74, r73, r69
-  Append       r75, r74, r60
-  SetIndex     r73, r69, r75
+  Index        r74, r57, r63
+  Index        r75, r74, r69
+  Append       r76, r75, r60
+  SetIndex     r74, r69, r76
+  Index        r77, r74, r71
+  AddInt       r78, r77, r51
+  SetIndex     r74, r71, r78
   AddInt       r56, r56, r51
   Jump         L9
 L7:
-  Move         r76, r13
-  Len          r77, r58
+  Move         r79, r13
+  Len          r80, r58
 L13:
-  LessInt      r78, r76, r77
-  JumpIfFalse  r78, L10
-  Index        r80, r58, r76
+  LessInt      r81, r79, r80
+  JumpIfFalse  r81, L10
+  Index        r82, r58, r79
+  Move         r83, r82
   // ps_partkey: g.key,
-  Const        r81, "ps_partkey"
-  Index        r82, r80, r53
+  Const        r84, "ps_partkey"
+  Index        r85, r83, r53
   // value: sum(from r in g select r.value)
-  Const        r83, "value"
-  Const        r84, []
-  IterPrep     r85, r80
-  Len          r86, r85
-  Move         r87, r13
+  Const        r86, "value"
+  Const        r87, []
+  IterPrep     r88, r83
+  Len          r89, r88
+  Move         r90, r13
 L12:
-  LessInt      r88, r87, r86
-  JumpIfFalse  r88, L11
-  Index        r90, r85, r87
-  Index        r91, r90, r7
-  Append       r84, r84, r91
-  AddInt       r87, r87, r51
+  LessInt      r91, r90, r89
+  JumpIfFalse  r91, L11
+  Index        r92, r88, r90
+  Move         r93, r92
+  Index        r94, r93, r7
+  Append       r95, r87, r94
+  Move         r87, r95
+  AddInt       r90, r90, r51
   Jump         L12
 L11:
+  Sum          r96, r87
+  // ps_partkey: g.key,
+  Move         r97, r85
+  // value: sum(from r in g select r.value)
+  Move         r98, r96
   // select {
-  MakeMap      r96, 2, r81
+  MakeMap      r99, 2, r84
   // from x in filtered
-  Append       r52, r52, r96
-  AddInt       r76, r76, r51
+  Append       r100, r52, r99
+  Move         r52, r100
+  AddInt       r79, r79, r51
   Jump         L13
 L10:
   // sum(from x in filtered select x.value)
-  Const        r98, []
-  IterPrep     r99, r4
-  Len          r100, r99
-  Move         r101, r13
+  Const        r101, []
+  IterPrep     r102, r4
+  Len          r103, r102
+  Move         r104, r13
 L15:
-  LessInt      r102, r101, r100
-  JumpIfFalse  r102, L14
-  Index        r61, r99, r101
-  Index        r104, r61, r7
-  Append       r98, r98, r104
-  AddInt       r101, r101, r51
+  LessInt      r105, r104, r103
+  JumpIfFalse  r105, L14
+  Index        r106, r102, r104
+  Move         r61, r106
+  Index        r107, r61, r7
+  Append       r108, r101, r107
+  Move         r101, r108
+  AddInt       r104, r104, r51
   Jump         L15
 L14:
-  Sum          r106, r98
+  Sum          r109, r101
   // let threshold = total * 0.0001
-  Const        r107, 0.0001
-  MulFloat     r108, r106, r107
+  Const        r110, 0.0001
+  MulFloat     r111, r109, r110
   // from x in grouped
-  Const        r109, []
-  IterPrep     r110, r52
-  Len          r111, r110
-  Move         r112, r13
+  Const        r112, []
+  IterPrep     r113, r52
+  Len          r114, r113
+  Move         r115, r13
 L18:
-  LessInt      r113, r112, r111
-  JumpIfFalse  r113, L16
-  Index        r61, r110, r112
+  LessInt      r116, r115, r114
+  JumpIfFalse  r116, L16
+  Index        r117, r113, r115
+  Move         r61, r117
   // where x.value > threshold
-  Index        r115, r61, r7
-  LessFloat    r116, r108, r115
-  JumpIfFalse  r116, L17
+  Index        r118, r61, r7
+  LessFloat    r119, r111, r118
+  JumpIfFalse  r119, L17
   // sort by -x.value
-  Index        r117, r61, r7
-  Neg          r119, r117
+  Index        r120, r61, r7
+  Neg          r121, r120
+  Move         r122, r121
   // from x in grouped
-  Move         r120, r61
-  MakeList     r121, 2, r119
-  Append       r109, r109, r121
+  Move         r123, r61
+  MakeList     r124, 2, r122
+  Append       r125, r112, r124
+  Move         r112, r125
 L17:
-  AddInt       r112, r112, r51
+  AddInt       r115, r115, r51
   Jump         L18
 L16:
   // sort by -x.value
-  Sort         r109, r109
+  Sort         r126, r112
+  // from x in grouped
+  Move         r112, r126
   // json(result)
-  JSON         r109
+  JSON         r112
   // expect result == [
-  Const        r124, [{"ps_partkey": 1000, "value": 2000}, {"ps_partkey": 2000, "value": 50}]
-  Equal        r125, r109, r124
-  Expect       r125
+  Const        r127, [{"ps_partkey": 1000, "value": 2000}, {"ps_partkey": 2000, "value": 50}]
+  Equal        r128, r112, r127
+  Expect       r128
   Return       r0

--- a/tests/dataset/tpc-h/out/q12.ir.out
+++ b/tests/dataset/tpc-h/out/q12.ir.out
@@ -1,4 +1,4 @@
-func main (regs=119)
+func main (regs=122)
   // let orders = [
   Const        r0, [{"o_orderkey": 1, "o_orderpriority": "1-URGENT"}, {"o_orderkey": 2, "o_orderpriority": "3-MEDIUM"}]
   // let lineitem = [
@@ -15,8 +15,11 @@ func main (regs=119)
   // l_shipmode: g.key,
   Const        r7, "key"
   // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
+  Const        r8, "high_line_count"
   Const        r9, "o"
   Const        r10, "o_orderpriority"
+  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
+  Const        r11, "low_line_count"
   // from l in lineitem
   MakeMap      r12, 0, r0
   Const        r13, []
@@ -26,15 +29,17 @@ func main (regs=119)
 L9:
   LessInt      r17, r16, r15
   JumpIfFalse  r17, L0
-  Index        r19, r14, r16
+  Index        r18, r14, r16
+  Move         r19, r18
   // join o in orders on o.o_orderkey == l.l_orderkey
   IterPrep     r20, r0
   Len          r21, r20
   Const        r22, 0
 L8:
-  Less         r23, r22, r21
+  LessInt      r23, r22, r21
   JumpIfFalse  r23, L1
-  Index        r25, r20, r22
+  Index        r24, r20, r22
+  Move         r25, r24
   Const        r26, "o_orderkey"
   Index        r27, r25, r26
   Const        r28, "l_orderkey"
@@ -44,30 +49,45 @@ L8:
   // (l.l_shipmode in ["MAIL", "SHIP"]) &&
   Index        r31, r19, r3
   Const        r32, ["MAIL", "SHIP"]
-  In           r34, r31, r32
+  In           r33, r31, r32
+  Move         r34, r33
   JumpIfFalse  r34, L3
   // (l.l_commitdate < l.l_receiptdate) &&
   Index        r35, r19, r4
   Index        r36, r19, r5
-  Less         r38, r35, r36
+  Less         r37, r35, r36
+  // (l.l_shipmode in ["MAIL", "SHIP"]) &&
+  Move         r34, r37
 L3:
+  // (l.l_commitdate < l.l_receiptdate) &&
+  Move         r38, r34
   JumpIfFalse  r38, L4
   // (l.l_shipdate < l.l_commitdate) &&
   Index        r39, r19, r6
   Index        r40, r19, r4
-  Less         r42, r39, r40
+  Less         r41, r39, r40
+  // (l.l_commitdate < l.l_receiptdate) &&
+  Move         r38, r41
 L4:
+  // (l.l_shipdate < l.l_commitdate) &&
+  Move         r42, r38
   JumpIfFalse  r42, L5
   // (l.l_receiptdate >= "1994-01-01") &&
   Index        r43, r19, r5
   Const        r44, "1994-01-01"
-  LessEq       r46, r44, r43
+  LessEq       r45, r44, r43
+  // (l.l_shipdate < l.l_commitdate) &&
+  Move         r42, r45
 L5:
+  // (l.l_receiptdate >= "1994-01-01") &&
+  Move         r46, r42
   JumpIfFalse  r46, L6
   // (l.l_receiptdate < "1995-01-01")
   Index        r47, r19, r5
   Const        r48, "1995-01-01"
-  Less         r46, r47, r48
+  Less         r49, r47, r48
+  // (l.l_receiptdate >= "1994-01-01") &&
+  Move         r46, r49
 L6:
   // (l.l_shipmode in ["MAIL", "SHIP"]) &&
   JumpIfFalse  r46, L2
@@ -90,91 +110,122 @@ L6:
   // from l in lineitem
   Const        r61, "items"
   Move         r62, r57
-  MakeMap      r63, 3, r58
-  SetIndex     r12, r55, r63
-  Append       r13, r13, r63
+  Const        r63, "count"
+  Const        r64, 0
+  MakeMap      r65, 4, r58
+  SetIndex     r12, r55, r65
+  Append       r66, r13, r65
+  Move         r13, r66
 L7:
-  Index        r65, r12, r55
-  Index        r66, r65, r61
-  Append       r67, r66, r53
-  SetIndex     r65, r61, r67
+  Index        r67, r12, r55
+  Index        r68, r67, r61
+  Append       r69, r68, r53
+  SetIndex     r67, r61, r69
+  Index        r70, r67, r63
+  Const        r71, 1
+  AddInt       r72, r70, r71
+  SetIndex     r67, r63, r72
 L2:
   // join o in orders on o.o_orderkey == l.l_orderkey
-  Const        r68, 1
-  AddInt       r22, r22, r68
+  AddInt       r22, r22, r71
   Jump         L8
 L1:
   // from l in lineitem
-  AddInt       r16, r16, r68
+  AddInt       r16, r16, r71
   Jump         L9
 L0:
-  Const        r70, 0
-  Move         r69, r70
-  Len          r71, r13
-L17:
-  LessInt      r72, r69, r71
-  JumpIfFalse  r72, L10
-  Index        r74, r13, r69
+  Move         r73, r64
+  Len          r74, r13
+L19:
+  LessInt      r75, r73, r74
+  JumpIfFalse  r75, L10
+  Index        r76, r13, r73
+  Move         r77, r76
   // l_shipmode: g.key,
-  Const        r75, "l_shipmode"
-  Index        r76, r74, r7
+  Const        r78, "l_shipmode"
+  Index        r79, r77, r7
   // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
-  Const        r77, "high_line_count"
-  Const        r78, []
-  IterPrep     r79, r74
-  Len          r80, r79
-  Move         r81, r70
-L13:
-  LessInt      r82, r81, r80
-  JumpIfFalse  r82, L11
-  Index        r84, r79, r81
-  Index        r85, r84, r9
-  Index        r86, r85, r10
-  Const        r87, ["1-URGENT", "2-HIGH"]
-  In           r88, r86, r87
-  JumpIfFalse  r88, L12
-L12:
-  Append       r78, r78, r70
-  AddInt       r81, r81, r68
-  Jump         L13
-L11:
-  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
-  Const        r93, []
-  IterPrep     r94, r74
-  Len          r95, r94
-  Move         r96, r70
-L16:
-  LessInt      r97, r96, r95
-  JumpIfFalse  r97, L14
-  Index        r84, r94, r96
-  Index        r99, r84, r9
-  Index        r100, r99, r10
-  Const        r101, ["1-URGENT", "2-HIGH"]
-  In           r102, r100, r101
-  Not          r103, r102
-  JumpIfFalse  r103, L15
-L15:
-  Append       r93, r93, r70
-  AddInt       r96, r96, r68
-  Jump         L16
+  Const        r80, "high_line_count"
+  Const        r81, []
+  IterPrep     r82, r77
+  Len          r83, r82
+  Move         r84, r64
 L14:
-  // select {
-  MakeMap      r110, 3, r75
-  // sort by g.key
-  Index        r112, r74, r7
-  // from l in lineitem
-  Move         r113, r110
-  MakeList     r114, 2, r112
-  Append       r2, r2, r114
-  AddInt       r69, r69, r68
+  LessInt      r85, r84, r83
+  JumpIfFalse  r85, L11
+  Index        r86, r82, r84
+  Move         r87, r86
+  Index        r88, r87, r9
+  Index        r89, r88, r10
+  Const        r90, ["1-URGENT", "2-HIGH"]
+  In           r91, r89, r90
+  JumpIfFalse  r91, L12
+  Move         r92, r71
+  Jump         L13
+L12:
+  Move         r92, r64
+L13:
+  Append       r93, r81, r92
+  Move         r81, r93
+  AddInt       r84, r84, r71
+  Jump         L14
+L11:
+  Sum          r94, r81
+  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
+  Const        r95, "low_line_count"
+  Const        r96, []
+  IterPrep     r97, r77
+  Len          r98, r97
+  Move         r99, r64
+L18:
+  LessInt      r100, r99, r98
+  JumpIfFalse  r100, L15
+  Index        r101, r97, r99
+  Move         r87, r101
+  Index        r102, r87, r9
+  Index        r103, r102, r10
+  Const        r104, ["1-URGENT", "2-HIGH"]
+  In           r105, r103, r104
+  Not          r106, r105
+  JumpIfFalse  r106, L16
+  Move         r107, r71
   Jump         L17
+L16:
+  Move         r107, r64
+L17:
+  Append       r108, r96, r107
+  Move         r96, r108
+  AddInt       r99, r99, r71
+  Jump         L18
+L15:
+  Sum          r109, r96
+  // l_shipmode: g.key,
+  Move         r110, r79
+  // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
+  Move         r111, r94
+  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
+  Move         r112, r109
+  // select {
+  MakeMap      r113, 3, r78
+  // sort by g.key
+  Index        r114, r77, r7
+  Move         r115, r114
+  // from l in lineitem
+  Move         r116, r113
+  MakeList     r117, 2, r115
+  Append       r118, r2, r117
+  Move         r2, r118
+  AddInt       r73, r73, r71
+  Jump         L19
 L10:
   // sort by g.key
-  Sort         r2, r2
+  Sort         r119, r2
+  // from l in lineitem
+  Move         r2, r119
   // json(result)
   JSON         r2
   // expect result == [
-  Const        r117, [{"high_line_count": 1, "l_shipmode": "MAIL", "low_line_count": 0}]
-  Equal        r118, r2, r117
-  Expect       r118
+  Const        r120, [{"high_line_count": 1, "l_shipmode": "MAIL", "low_line_count": 0}]
+  Equal        r121, r2, r120
+  Expect       r121
   Return       r0

--- a/tests/dataset/tpc-h/out/q13.ir.out
+++ b/tests/dataset/tpc-h/out/q13.ir.out
@@ -1,4 +1,4 @@
-func main (regs=87)
+func main (regs=90)
   // let customer = [
   Const        r0, [{"c_custkey": 1}, {"c_custkey": 2}, {"c_custkey": 3}]
   // let orders = [
@@ -20,7 +20,8 @@ func main (regs=87)
 L6:
   LessInt      r11, r9, r8
   JumpIfFalse  r11, L0
-  Index        r13, r7, r9
+  Index        r12, r7, r9
+  Move         r13, r12
   // c_count: count(
   Const        r14, "c_count"
   // from o in orders
@@ -31,38 +32,51 @@ L6:
 L5:
   LessInt      r19, r18, r17
   JumpIfFalse  r19, L1
-  Index        r21, r16, r18
+  Index        r20, r16, r18
+  Move         r21, r20
   // o.o_custkey == c.c_custkey &&
   Index        r22, r21, r4
   Index        r23, r13, r5
-  Equal        r25, r22, r23
+  Equal        r24, r22, r23
+  Move         r25, r24
   JumpIfFalse  r25, L2
   // (!("special" in o.o_comment)) &&
   Const        r26, "special"
   Index        r27, r21, r6
   In           r28, r26, r27
-  Not          r30, r28
+  Not          r29, r28
+  // o.o_custkey == c.c_custkey &&
+  Move         r25, r29
 L2:
+  // (!("special" in o.o_comment)) &&
+  Move         r30, r25
   JumpIfFalse  r30, L3
   // (!("requests" in o.o_comment))
   Const        r31, "requests"
   Index        r32, r21, r6
   In           r33, r31, r32
-  Not          r30, r33
+  Not          r34, r33
+  // (!("special" in o.o_comment)) &&
+  Move         r30, r34
 L3:
   // where (
   JumpIfFalse  r30, L4
   // from o in orders
-  Append       r15, r15, r21
+  Append       r35, r15, r21
+  Move         r15, r35
 L4:
   Const        r36, 1
   AddInt       r18, r18, r36
   Jump         L5
 L1:
+  // c_count: count(
+  Count        r37, r15
+  Move         r38, r37
   // select {
   MakeMap      r39, 1, r14
   // from c in customer
-  Append       r2, r2, r39
+  Append       r40, r2, r39
+  Move         r2, r40
   AddInt       r9, r9, r36
   Jump         L6
 L0:
@@ -70,6 +84,7 @@ L0:
   Const        r41, []
   // select { c_count: g.key, custdist: count(g) }
   Const        r42, "key"
+  Const        r43, "custdist"
   // from x in per_customer
   IterPrep     r44, r2
   Len          r45, r44
@@ -80,8 +95,9 @@ L9:
   LessInt      r49, r46, r45
   JumpIfFalse  r49, L7
   Index        r50, r44, r46
+  Move         r51, r50
   // group by x.c_count into g
-  Index        r52, r50, r3
+  Index        r52, r51, r3
   Str          r53, r52
   In           r54, r53, r47
   JumpIfTrue   r54, L8
@@ -94,45 +110,57 @@ L9:
   // from x in per_customer
   Const        r59, "items"
   Move         r60, r55
-  MakeMap      r61, 3, r56
-  SetIndex     r47, r53, r61
-  Append       r48, r48, r61
+  Const        r61, "count"
+  MakeMap      r62, 4, r56
+  SetIndex     r47, r53, r62
+  Append       r63, r48, r62
+  Move         r48, r63
 L8:
-  Index        r63, r47, r53
-  Index        r64, r63, r59
-  Append       r65, r64, r50
-  SetIndex     r63, r59, r65
+  Index        r64, r47, r53
+  Index        r65, r64, r59
+  Append       r66, r65, r50
+  SetIndex     r64, r59, r66
+  Index        r67, r64, r61
+  AddInt       r68, r67, r36
+  SetIndex     r64, r61, r68
   AddInt       r46, r46, r36
   Jump         L9
 L7:
-  Move         r66, r10
-  Len          r67, r48
+  Move         r69, r10
+  Len          r70, r48
 L11:
-  LessInt      r68, r66, r67
-  JumpIfFalse  r68, L10
-  Index        r70, r48, r66
+  LessInt      r71, r69, r70
+  JumpIfFalse  r71, L10
+  Index        r72, r48, r69
+  Move         r73, r72
   // select { c_count: g.key, custdist: count(g) }
-  Const        r71, "c_count"
-  Index        r72, r70, r42
-  Const        r73, "custdist"
-  Count        r74, r70
-  MakeMap      r77, 2, r71
+  Const        r74, "c_count"
+  Index        r75, r73, r42
+  Const        r76, "custdist"
+  Index        r77, r73, r61
+  Move         r78, r75
+  Move         r79, r77
+  MakeMap      r80, 2, r74
   // sort by -g.key
-  Index        r78, r70, r42
-  Neg          r80, r78
+  Index        r81, r73, r42
+  Neg          r82, r81
+  Move         r83, r82
   // from x in per_customer
-  Move         r81, r77
-  MakeList     r82, 2, r80
-  Append       r41, r41, r82
-  AddInt       r66, r66, r36
+  Move         r84, r80
+  MakeList     r85, 2, r83
+  Append       r86, r41, r85
+  Move         r41, r86
+  AddInt       r69, r69, r36
   Jump         L11
 L10:
   // sort by -g.key
-  Sort         r41, r41
+  Sort         r87, r41
+  // from x in per_customer
+  Move         r41, r87
   // json(grouped)
   JSON         r41
   // expect grouped == [
-  Const        r85, [{"c_count": 2, "custdist": 1}, {"c_count": 0, "custdist": 2}]
-  Equal        r86, r41, r85
-  Expect       r86
+  Const        r88, [{"c_count": 2, "custdist": 1}, {"c_count": 0, "custdist": 2}]
+  Equal        r89, r41, r88
+  Expect       r89
   Return       r0


### PR DESCRIPTION
## Summary
- add EnableOptimizations flag to runtime/vm
- avoid running Optimize unless flag enabled
- regenerate IR for a subset of TPC-H queries with optimizations off

## Testing
- `go run ./tools/update_tpch >/tmp/update.log`

------
https://chatgpt.com/codex/tasks/task_e_6861205dbb388320a3014c08596ea849