### PR TITLE
Optimize group by to avoid storing items

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1590,6 +1590,7 @@ type funcCompiler struct {
 	tags       map[int]regTag
 	constCache map[string]int
 	groupVar   string
+	groupAggs  map[*parser.CallExpr]*groupAggInfo
 }
 
 func (fc *funcCompiler) freshConst(pos lexer.Position, v Value) int {
@@ -1684,7 +1685,7 @@ func compileProgram(p *parser.Program, env *types.Env) (*Program, error) {
 }
 
 func (c *compiler) compileFun(fn *parser.FunStmt) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: "", groupAggs: nil}
 	fc.fn.Name = fn.Name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(fn.Params)
@@ -1708,7 +1709,7 @@ func (c *compiler) compileFun(fn *parser.FunStmt) (Function, error) {
 }
 
 func (c *compiler) compileMethod(st types.StructType, fn *parser.FunStmt) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: "", groupAggs: nil}
 	fc.fn.Name = st.Name + "." + fn.Name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(st.Order) + len(fn.Params)
@@ -1762,7 +1763,7 @@ func (c *compiler) compileTypeMethods(td *parser.TypeDecl) error {
 }
 
 func (c *compiler) compileFunExpr(fn *parser.FunExpr, captures []string) int {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: "", groupAggs: nil}
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(captures) + len(fn.Params)
 	for i, name := range captures {
@@ -1804,7 +1805,7 @@ func (c *compiler) compileNamedFunExpr(name string, fn *parser.FunExpr, captures
 	prev, exists := c.fnIndex[name]
 	c.fnIndex[name] = idx
 
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: "", groupAggs: nil}
 	fc.fn.Name = name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(captures) + len(fn.Params)
@@ -1846,7 +1847,7 @@ func (c *compiler) compileNamedFunExpr(name string, fn *parser.FunExpr, captures
 }
 
 func (c *compiler) compileMain(p *parser.Program) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: "", groupAggs: nil}
 	fc.fn.Name = "main"
 	fc.fn.Line = 0
 	fc.fn.NumParams = 0
@@ -2737,21 +2738,70 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 			fc.emit(p.Pos, Instr{Op: OpExists, A: dst, B: arg})
 			return dst
 		case "avg":
+			if info, ok := fc.groupAggs[p.Call]; ok {
+				greg, ok := fc.vars[fc.groupVar]
+				if !ok {
+					greg = fc.newReg()
+					fc.vars[fc.groupVar] = greg
+				}
+				sumKey := fc.constReg(p.Pos, Value{Tag: ValueStr, Str: info.Field})
+				sumReg := fc.newReg()
+				fc.emit(p.Pos, Instr{Op: OpIndex, A: sumReg, B: greg, C: sumKey})
+				cntKey := fc.constReg(p.Pos, Value{Tag: ValueStr, Str: "count"})
+				cntReg := fc.newReg()
+				fc.emit(p.Pos, Instr{Op: OpIndex, A: cntReg, B: greg, C: cntKey})
+				dst := fc.newReg()
+				fc.emit(p.Pos, Instr{Op: OpDivFloat, A: dst, B: sumReg, C: cntReg})
+				return dst
+			}
 			arg := fc.compileExpr(p.Call.Args[0])
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpAvg, A: dst, B: arg})
 			return dst
 		case "sum":
+			if info, ok := fc.groupAggs[p.Call]; ok {
+				greg, ok := fc.vars[fc.groupVar]
+				if !ok {
+					greg = fc.newReg()
+					fc.vars[fc.groupVar] = greg
+				}
+				key := fc.constReg(p.Pos, Value{Tag: ValueStr, Str: info.Field})
+				dst := fc.newReg()
+				fc.emit(p.Pos, Instr{Op: OpIndex, A: dst, B: greg, C: key})
+				return dst
+			}
 			arg := fc.compileExpr(p.Call.Args[0])
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpSum, A: dst, B: arg})
 			return dst
 		case "min":
+			if info, ok := fc.groupAggs[p.Call]; ok {
+				greg, ok := fc.vars[fc.groupVar]
+				if !ok {
+					greg = fc.newReg()
+					fc.vars[fc.groupVar] = greg
+				}
+				key := fc.constReg(p.Pos, Value{Tag: ValueStr, Str: info.Field})
+				dst := fc.newReg()
+				fc.emit(p.Pos, Instr{Op: OpIndex, A: dst, B: greg, C: key})
+				return dst
+			}
 			arg := fc.compileExpr(p.Call.Args[0])
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpMin, A: dst, B: arg})
 			return dst
 		case "max":
+			if info, ok := fc.groupAggs[p.Call]; ok {
+				greg, ok := fc.vars[fc.groupVar]
+				if !ok {
+					greg = fc.newReg()
+					fc.vars[fc.groupVar] = greg
+				}
+				key := fc.constReg(p.Pos, Value{Tag: ValueStr, Str: info.Field})
+				dst := fc.newReg()
+				fc.emit(p.Pos, Instr{Op: OpIndex, A: dst, B: greg, C: key})
+				return dst
+			}
 			arg := fc.compileExpr(p.Call.Args[0])
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpMax, A: dst, B: arg})
@@ -4044,6 +4094,24 @@ func (fc *funcCompiler) compileJoinQueryRight(q *parser.QueryExpr, dst int) {
 
 // compileGroupQuery handles simple queries with a single FROM clause and GROUP BY.
 func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
+	aggs := map[*parser.CallExpr]*groupAggInfo{}
+	collectGroupAggs(q.Select, q.Group.Name, aggs)
+	collectGroupAggs(q.Group.Having, q.Group.Name, aggs)
+	collectGroupAggs(q.Sort, q.Group.Name, aggs)
+	idxAgg := 0
+	for _, a := range aggs {
+		a.Field = fmt.Sprintf("__agg%d", idxAgg)
+		idxAgg++
+		fc.preloadFieldConsts(a.Expr)
+	}
+	keepItems := groupNeedsItems(q)
+	keepCount := groupNeedsCount(q)
+	for _, a := range aggs {
+		if a.FuncName == "avg" {
+			keepCount = true
+		}
+	}
+	keepKey := groupNeedsKey(q)
 	for _, g := range q.Group.Exprs {
 		fc.preloadFieldConsts(g)
 	}
@@ -4052,8 +4120,10 @@ func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
 	fc.preloadFieldConsts(q.Select)
 	fc.preloadFieldConsts(q.Sort)
 	prevGroup := fc.groupVar
+	prevAggs := fc.groupAggs
 	fc.groupVar = q.Group.Name
-	defer func() { fc.groupVar = prevGroup }()
+	fc.groupAggs = aggs
+	defer func() { fc.groupVar = prevGroup; fc.groupAggs = prevAggs }()
 	srcReg := fc.compileExpr(q.Source)
 	listReg := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpIterPrep, A: listReg, B: srcReg})
@@ -4086,10 +4156,10 @@ func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
 		cond := fc.compileExpr(q.Where)
 		skip := len(fc.fn.Code)
 		fc.emit(q.Where.Pos, Instr{Op: OpJumpIfFalse, A: cond})
-		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList)
+		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList, keepItems, keepCount, keepKey, aggs)
 		fc.fn.Code[skip].B = len(fc.fn.Code)
 	} else {
-		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList)
+		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList, keepItems, keepCount, keepKey, aggs)
 	}
 
 	one := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 1})
@@ -4154,7 +4224,7 @@ func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
 	}
 }
 
-func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, gmap, glist int) {
+func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, gmap, glist int, keepItems, keepCount, keepKey bool, aggs map[*parser.CallExpr]*groupAggInfo) {
 	exprs := q.Group.Exprs
 	regs := make([]int, len(exprs))
 	for i, e := range exprs {
@@ -4181,6 +4251,16 @@ func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, 
 		start := pairs[0]
 		fc.emit(q.Pos, Instr{Op: OpMakeMap, A: key, B: len(exprs), C: start})
 	}
+	// precompute aggregate values for this element
+	valRegs := map[*groupAggInfo]int{}
+	for _, ag := range aggs {
+		fc.pushScope()
+		fc.vars[ag.VarName] = elemReg
+		v := fc.compileExpr(ag.Expr)
+		fc.popScope()
+		valRegs[ag] = v
+	}
+
 	keyStr := fc.newReg()
 	fc.emit(q.Group.Pos, Instr{Op: OpStr, A: keyStr, B: key})
 	exists := fc.newReg()
@@ -4188,23 +4268,36 @@ func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, 
 	jump := len(fc.fn.Code)
 	fc.emit(q.Group.Pos, Instr{Op: OpJumpIfTrue, A: exists})
 
-	items := fc.constReg(q.Pos, Value{Tag: ValueList, List: []Value{}})
 	k1 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "__group__"})
 	v1 := fc.constReg(q.Pos, Value{Tag: ValueBool, Bool: true})
-	k2 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "key"})
-	v2 := fc.newReg()
-	fc.emit(q.Group.Pos, Instr{Op: OpMove, A: v2, B: key})
-	k3 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "items"})
-	v3 := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpMove, A: v3, B: items})
-	kcnt := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "count"})
-	vcnt := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 0})
-	pairsGrp := []int{k1, v1, k2, v2, k3, v3, kcnt, vcnt}
+	pairsGrp := []int{k1, v1}
+	if keepKey {
+		k2 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "key"})
+		v2 := fc.newReg()
+		fc.emit(q.Group.Pos, Instr{Op: OpMove, A: v2, B: key})
+		pairsGrp = append(pairsGrp, k2, v2)
+	}
+	if keepCount {
+		kcnt := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "count"})
+		vcnt := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 0})
+		pairsGrp = append(pairsGrp, kcnt, vcnt)
+	}
+	if keepItems {
+		items := fc.constReg(q.Pos, Value{Tag: ValueList, List: []Value{}})
+		k3 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "items"})
+		v3 := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpMove, A: v3, B: items})
+		pairsGrp = append(pairsGrp, k3, v3)
+	}
 	if len(fieldNames) > 0 {
 		for i, name := range fieldNames {
 			k := fc.constReg(exprs[i].Pos, Value{Tag: ValueStr, Str: name})
 			pairsGrp = append(pairsGrp, k, regs[i])
 		}
+	}
+	for _, ag := range aggs {
+		k := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: ag.Field})
+		pairsGrp = append(pairsGrp, k, valRegs[ag])
 	}
 	grp := fc.newReg()
 	startGrp := pairsGrp[0]
@@ -4217,27 +4310,69 @@ func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, 
 	end := len(fc.fn.Code)
 	fc.fn.Code[jump].B = end
 
-	itemsKey := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "items"})
 	grp2 := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpIndex, A: grp2, B: gmap, C: keyStr})
-	cur := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpIndex, A: cur, B: grp2, C: itemsKey})
-	newList := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpAppend, A: newList, B: cur, C: elemReg})
-	fc.emit(q.Pos, Instr{Op: OpSetIndex, A: grp2, B: itemsKey, C: newList})
-	countKey := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "count"})
-	curCnt := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpIndex, A: curCnt, B: grp2, C: countKey})
-	one := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 1})
-	newCnt := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpAddInt, A: newCnt, B: curCnt, C: one})
-	fc.emit(q.Pos, Instr{Op: OpSetIndex, A: grp2, B: countKey, C: newCnt})
+	if keepItems {
+		itemsKey := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "items"})
+		cur := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpIndex, A: cur, B: grp2, C: itemsKey})
+		newList := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpAppend, A: newList, B: cur, C: elemReg})
+		fc.emit(q.Pos, Instr{Op: OpSetIndex, A: grp2, B: itemsKey, C: newList})
+	}
+	if keepCount {
+		countKey := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "count"})
+		curCnt := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpIndex, A: curCnt, B: grp2, C: countKey})
+		one := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 1})
+		newCnt := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpAddInt, A: newCnt, B: curCnt, C: one})
+		fc.emit(q.Pos, Instr{Op: OpSetIndex, A: grp2, B: countKey, C: newCnt})
+	}
+	skipAgg := len(fc.fn.Code)
+	fc.emit(q.Pos, Instr{Op: OpJumpIfFalse, A: exists})
+	for _, ag := range aggs {
+		k := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: ag.Field})
+		cur := fc.newReg()
+		fc.emit(q.Pos, Instr{Op: OpIndex, A: cur, B: grp2, C: k})
+		val := valRegs[ag]
+		out := fc.newReg()
+		switch ag.FuncName {
+		case "sum", "avg":
+			fc.emit(q.Pos, Instr{Op: OpAdd, A: out, B: cur, C: val})
+		case "min":
+			fc.emit(q.Pos, Instr{Op: OpMin, A: out, B: cur, C: val})
+		case "max":
+			fc.emit(q.Pos, Instr{Op: OpMax, A: out, B: cur, C: val})
+		}
+		fc.emit(q.Pos, Instr{Op: OpSetIndex, A: grp2, B: k, C: out})
+	}
+	endAgg := len(fc.fn.Code)
+	fc.fn.Code[skipAgg].B = endAgg
 }
 
 // compileGroupQueryAny handles GROUP BY queries that may include additional FROM
 // clauses or JOINs. It builds row objects containing all bound variables which
 // are accumulated into groups.
 func (fc *funcCompiler) compileGroupQueryAny(q *parser.QueryExpr, dst int) {
+	aggs := map[*parser.CallExpr]*groupAggInfo{}
+	collectGroupAggs(q.Select, q.Group.Name, aggs)
+	collectGroupAggs(q.Group.Having, q.Group.Name, aggs)
+	collectGroupAggs(q.Sort, q.Group.Name, aggs)
+	idxAgg := 0
+	for _, a := range aggs {
+		a.Field = fmt.Sprintf("__agg%d", idxAgg)
+		idxAgg++
+		fc.preloadFieldConsts(a.Expr)
+	}
+	keepItems := groupNeedsItems(q)
+	keepCount := groupNeedsCount(q)
+	for _, a := range aggs {
+		if a.FuncName == "avg" {
+			keepCount = true
+		}
+	}
+	keepKey := groupNeedsKey(q)
 	for _, g := range q.Group.Exprs {
 		fc.preloadFieldConsts(g)
 	}
@@ -4246,14 +4381,16 @@ func (fc *funcCompiler) compileGroupQueryAny(q *parser.QueryExpr, dst int) {
 	fc.preloadFieldConsts(q.Select)
 	fc.preloadFieldConsts(q.Sort)
 	prevGroup := fc.groupVar
+	prevAggs := fc.groupAggs
 	fc.groupVar = q.Group.Name
-	defer func() { fc.groupVar = prevGroup }()
+	fc.groupAggs = aggs
+	defer func() { fc.groupVar = prevGroup; fc.groupAggs = prevAggs }()
 	groupsMap := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpMakeMap, A: groupsMap, B: 0})
 	groupsList := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpConst, A: groupsList, Val: Value{Tag: ValueList, List: []Value{}}})
 
-	fc.compileGroupFromAny(q, groupsMap, groupsList, 0)
+	fc.compileGroupFromAny(q, groupsMap, groupsList, 0, keepItems, keepCount, keepKey)
 
 	// iterate groups and produce final results
 	gi := fc.newReg()
@@ -4311,7 +4448,7 @@ func (fc *funcCompiler) compileGroupQueryAny(q *parser.QueryExpr, dst int) {
 	}
 }
 
-func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist int, level int) {
+func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist int, level int, keepItems, keepCount, keepKey bool) {
 	var name string
 	var src *parser.Expr
 	if level == 0 {
@@ -4347,11 +4484,11 @@ func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist int
 
 	if level < len(q.Froms) {
 		fc.pushScope()
-		fc.compileGroupFromAny(q, gmap, glist, level+1)
+		fc.compileGroupFromAny(q, gmap, glist, level+1, keepItems, keepCount, keepKey)
 		fc.popScope()
 	} else {
 		fc.pushScope()
-		fc.compileGroupJoinAny(q, gmap, glist, 0)
+		fc.compileGroupJoinAny(q, gmap, glist, 0, keepItems, keepCount, keepKey)
 		fc.popScope()
 	}
 
@@ -4362,7 +4499,7 @@ func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist int
 	fc.fn.Code[jmp].B = end
 }
 
-func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int, idx int) {
+func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int, idx int, keepItems, keepCount, keepKey bool) {
 	if idx >= len(q.Joins) {
 		doAccum := func() {
 			row := fc.buildRowMap(q)
@@ -4371,7 +4508,7 @@ func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int
 				vreg = fc.newReg()
 				fc.vars[q.Var] = vreg
 			}
-			fc.compileGroupAccum(q, row, vreg, gmap, glist)
+			fc.compileGroupAccum(q, row, vreg, gmap, glist, keepItems, keepCount, keepKey, fc.groupAggs)
 		}
 		if q.Where != nil {
 			cond := fc.compileExpr(q.Where)
@@ -4420,11 +4557,11 @@ func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int
 			skip := len(fc.fn.Code)
 			fc.emit(join.On.Pos, Instr{Op: OpJumpIfFalse, A: cond})
 			fc.emit(join.Pos, Instr{Op: OpConst, A: matched, Val: Value{Tag: ValueBool, Bool: true}})
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, idx+1, keepItems, keepCount, keepKey)
 			fc.fn.Code[skip].B = len(fc.fn.Code)
 		} else {
 			fc.emit(join.Pos, Instr{Op: OpConst, A: matched, Val: Value{Tag: ValueBool, Bool: true}})
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, idx+1, keepItems, keepCount, keepKey)
 		}
 
 		one := fc.constReg(join.Pos, Value{Tag: ValueInt, Int: 1})
@@ -4439,17 +4576,17 @@ func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int
 		fc.emit(join.Pos, Instr{Op: OpJumpIfTrue, A: check})
 		nilreg := fc.constReg(join.Pos, Value{Tag: ValueNull})
 		fc.emit(join.Pos, Instr{Op: OpMove, A: rvar, B: nilreg})
-		fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+		fc.compileGroupJoinAny(q, gmap, glist, idx+1, keepItems, keepCount, keepKey)
 		fc.fn.Code[skipAdd].B = len(fc.fn.Code)
 	} else {
 		if join.On != nil {
 			cond := fc.compileExpr(join.On)
 			skip := len(fc.fn.Code)
 			fc.emit(join.On.Pos, Instr{Op: OpJumpIfFalse, A: cond})
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, idx+1, keepItems, keepCount, keepKey)
 			fc.fn.Code[skip].B = len(fc.fn.Code)
 		} else {
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, idx+1, keepItems, keepCount, keepKey)
 		}
 
 		one := fc.constReg(join.Pos, Value{Tag: ValueInt, Int: 1})
@@ -4952,6 +5089,391 @@ func extractFieldName(e *parser.Expr) string {
 		return sel.Tail[len(sel.Tail)-1]
 	}
 	return sel.Root
+}
+
+func exprUsesGroupItems(e *parser.Expr, g string) bool {
+	var found bool
+	var walkExpr func(*parser.Expr)
+	var walkUnary func(*parser.Unary)
+	var walkPostfix func(*parser.PostfixExpr)
+	var walkPrimary func(*parser.Primary)
+
+	walkExpr = func(e *parser.Expr) {
+		if e == nil || found {
+			return
+		}
+		walkUnary(e.Binary.Left)
+		for _, op := range e.Binary.Right {
+			walkPostfix(op.Right)
+		}
+	}
+
+	walkUnary = func(u *parser.Unary) {
+		if u == nil || found {
+			return
+		}
+		walkPostfix(u.Value)
+	}
+
+	walkPostfix = func(pf *parser.PostfixExpr) {
+		if pf == nil || found {
+			return
+		}
+		walkPrimary(pf.Target)
+		for _, op := range pf.Ops {
+			if op.Call != nil {
+				for _, a := range op.Call.Args {
+					walkExpr(a)
+				}
+			}
+			if op.Index != nil {
+				walkExpr(op.Index.Start)
+				walkExpr(op.Index.End)
+				walkExpr(op.Index.Step)
+			}
+			if op.Field != nil {
+				// no-op
+			}
+		}
+	}
+
+	walkPrimary = func(p *parser.Primary) {
+		if p == nil || found {
+			return
+		}
+		switch {
+		case p.Selector != nil:
+			if p.Selector.Root == g {
+				if len(p.Selector.Tail) == 0 {
+					found = true
+					return
+				}
+				if p.Selector.Tail[0] == "items" {
+					found = true
+					return
+				}
+				if p.Selector.Tail[0] == "key" && len(p.Selector.Tail) == 1 {
+					return
+				}
+				if p.Selector.Tail[0] == "count" && len(p.Selector.Tail) == 1 {
+					return
+				}
+				if len(p.Selector.Tail) > 1 {
+					found = true
+					return
+				}
+				// access to stored group field is fine
+				return
+			}
+		case p.Call != nil:
+			if p.Call.Func == "count" && len(p.Call.Args) == 1 {
+				if name, ok := identName(p.Call.Args[0]); ok && name == g {
+					return
+				}
+			}
+			if (p.Call.Func == "sum" || p.Call.Func == "avg" || p.Call.Func == "min" || p.Call.Func == "max") && len(p.Call.Args) == 1 {
+				if _, _, ok := matchGroupAgg(p.Call, g); ok {
+					return
+				}
+			}
+			for _, a := range p.Call.Args {
+				walkExpr(a)
+			}
+		case p.Query != nil:
+			if name, ok := identName(p.Query.Source); ok && name == g {
+				found = true
+				return
+			}
+			walkExpr(p.Query.Source)
+			for _, f := range p.Query.Froms {
+				walkExpr(f.Src)
+			}
+			for _, j := range p.Query.Joins {
+				walkExpr(j.Src)
+				walkExpr(j.On)
+			}
+			walkExpr(p.Query.Where)
+			if p.Query.Group != nil {
+				for _, g := range p.Query.Group.Exprs {
+					walkExpr(g)
+				}
+			}
+			walkExpr(p.Query.Sort)
+			walkExpr(p.Query.Skip)
+			walkExpr(p.Query.Take)
+			walkExpr(p.Query.Select)
+		case p.List != nil:
+			for _, el := range p.List.Elems {
+				walkExpr(el)
+			}
+		case p.Map != nil:
+			for _, it := range p.Map.Items {
+				walkExpr(it.Key)
+				walkExpr(it.Value)
+			}
+		case p.FunExpr != nil:
+			walkExpr(p.FunExpr.ExprBody)
+			if len(p.FunExpr.BlockBody) > 0 {
+				// statements may reference the group variable
+				found = true
+				return
+			}
+		}
+		if p.Group != nil {
+			walkExpr(p.Group)
+		}
+	}
+
+	walkExpr(e)
+	return found
+}
+
+func groupNeedsItems(q *parser.QueryExpr) bool {
+	if exprUsesGroupItems(q.Select, q.Group.Name) {
+		return true
+	}
+	if exprUsesGroupItems(q.Group.Having, q.Group.Name) {
+		return true
+	}
+	if exprUsesGroupItems(q.Sort, q.Group.Name) {
+		return true
+	}
+	return false
+}
+
+func exprUsesGroupCount(e *parser.Expr, g string) bool {
+	var found bool
+	var walkExpr func(*parser.Expr)
+	var walkUnary func(*parser.Unary)
+	var walkPostfix func(*parser.PostfixExpr)
+	var walkPrimary func(*parser.Primary)
+
+	walkExpr = func(e *parser.Expr) {
+		if e == nil || found {
+			return
+		}
+		walkUnary(e.Binary.Left)
+		for _, op := range e.Binary.Right {
+			walkPostfix(op.Right)
+		}
+	}
+
+	walkUnary = func(u *parser.Unary) {
+		if u == nil || found {
+			return
+		}
+		walkPostfix(u.Value)
+	}
+
+	walkPostfix = func(pf *parser.PostfixExpr) {
+		if pf == nil || found {
+			return
+		}
+		walkPrimary(pf.Target)
+		for _, op := range pf.Ops {
+			if op.Call != nil {
+				for _, a := range op.Call.Args {
+					walkExpr(a)
+				}
+			}
+			if op.Index != nil {
+				walkExpr(op.Index.Start)
+				walkExpr(op.Index.End)
+				walkExpr(op.Index.Step)
+			}
+		}
+	}
+
+	walkPrimary = func(p *parser.Primary) {
+		if p == nil || found {
+			return
+		}
+		switch {
+		case p.Selector != nil:
+			if p.Selector.Root == g && len(p.Selector.Tail) == 1 && p.Selector.Tail[0] == "count" {
+				found = true
+				return
+			}
+		case p.Call != nil:
+			if p.Call.Func == "count" && len(p.Call.Args) == 1 {
+				if name, ok := identName(p.Call.Args[0]); ok && name == g {
+					found = true
+					return
+				}
+			}
+			for _, a := range p.Call.Args {
+				walkExpr(a)
+			}
+		case p.Query != nil:
+			walkExpr(p.Query.Source)
+			for _, f := range p.Query.Froms {
+				walkExpr(f.Src)
+			}
+			for _, j := range p.Query.Joins {
+				walkExpr(j.Src)
+				walkExpr(j.On)
+			}
+			walkExpr(p.Query.Where)
+			if p.Query.Group != nil {
+				for _, g := range p.Query.Group.Exprs {
+					walkExpr(g)
+				}
+			}
+			walkExpr(p.Query.Sort)
+			walkExpr(p.Query.Skip)
+			walkExpr(p.Query.Take)
+			walkExpr(p.Query.Select)
+		case p.List != nil:
+			for _, el := range p.List.Elems {
+				walkExpr(el)
+			}
+		case p.Map != nil:
+			for _, it := range p.Map.Items {
+				walkExpr(it.Key)
+				walkExpr(it.Value)
+			}
+		case p.FunExpr != nil:
+			walkExpr(p.FunExpr.ExprBody)
+		}
+		if p.Group != nil {
+			walkExpr(p.Group)
+		}
+	}
+
+	walkExpr(e)
+	return found
+}
+
+func exprUsesGroupKey(e *parser.Expr, g string) bool {
+	var found bool
+	var walkExpr func(*parser.Expr)
+	var walkUnary func(*parser.Unary)
+	var walkPostfix func(*parser.PostfixExpr)
+	var walkPrimary func(*parser.Primary)
+
+	walkExpr = func(e *parser.Expr) {
+		if e == nil || found {
+			return
+		}
+		walkUnary(e.Binary.Left)
+		for _, op := range e.Binary.Right {
+			walkPostfix(op.Right)
+		}
+	}
+
+	walkUnary = func(u *parser.Unary) {
+		if u == nil || found {
+			return
+		}
+		walkPostfix(u.Value)
+	}
+
+	walkPostfix = func(pf *parser.PostfixExpr) {
+		if pf == nil || found {
+			return
+		}
+		walkPrimary(pf.Target)
+		for _, op := range pf.Ops {
+			if op.Call != nil {
+				for _, a := range op.Call.Args {
+					walkExpr(a)
+				}
+			}
+			if op.Index != nil {
+				walkExpr(op.Index.Start)
+				walkExpr(op.Index.End)
+				walkExpr(op.Index.Step)
+			}
+		}
+	}
+
+	walkPrimary = func(p *parser.Primary) {
+		if p == nil || found {
+			return
+		}
+		switch {
+		case p.Selector != nil:
+			if p.Selector.Root == g && len(p.Selector.Tail) > 0 && p.Selector.Tail[0] == "key" {
+				found = true
+				return
+			}
+		case p.Call != nil:
+			for _, a := range p.Call.Args {
+				walkExpr(a)
+			}
+		case p.Query != nil:
+			walkExpr(p.Query.Source)
+			for _, f := range p.Query.Froms {
+				walkExpr(f.Src)
+			}
+			for _, j := range p.Query.Joins {
+				walkExpr(j.Src)
+				walkExpr(j.On)
+			}
+			walkExpr(p.Query.Where)
+			if p.Query.Group != nil {
+				for _, g := range p.Query.Group.Exprs {
+					walkExpr(g)
+				}
+			}
+			walkExpr(p.Query.Sort)
+			walkExpr(p.Query.Skip)
+			walkExpr(p.Query.Take)
+			walkExpr(p.Query.Select)
+		case p.List != nil:
+			for _, el := range p.List.Elems {
+				walkExpr(el)
+			}
+		case p.Map != nil:
+			for _, it := range p.Map.Items {
+				walkExpr(it.Key)
+				walkExpr(it.Value)
+			}
+		case p.FunExpr != nil:
+			walkExpr(p.FunExpr.ExprBody)
+		}
+		if p.Group != nil {
+			walkExpr(p.Group)
+		}
+	}
+
+	walkExpr(e)
+	return found
+}
+
+func groupNeedsCount(q *parser.QueryExpr) bool {
+	if exprUsesGroupCount(q.Select, q.Group.Name) {
+		return true
+	}
+	if exprUsesGroupCount(q.Group.Having, q.Group.Name) {
+		return true
+	}
+	if exprUsesGroupCount(q.Sort, q.Group.Name) {
+		return true
+	}
+	aggs := map[*parser.CallExpr]*groupAggInfo{}
+	collectGroupAggs(q.Select, q.Group.Name, aggs)
+	collectGroupAggs(q.Group.Having, q.Group.Name, aggs)
+	collectGroupAggs(q.Sort, q.Group.Name, aggs)
+	for _, a := range aggs {
+		if a.FuncName == "avg" {
+			return true
+		}
+	}
+	return false
+}
+
+func groupNeedsKey(q *parser.QueryExpr) bool {
+	if exprUsesGroupKey(q.Select, q.Group.Name) {
+		return true
+	}
+	if exprUsesGroupKey(q.Group.Having, q.Group.Name) {
+		return true
+	}
+	if exprUsesGroupKey(q.Sort, q.Group.Name) {
+		return true
+	}
+	return false
 }
 
 // preloadFieldConsts emits Const instructions for all selector field names

--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -1,113 +1,105 @@
-func main (regs=77)
+func main (regs=69)
   // let people = [
   Const        r0, [{"age": 30, "city": "Paris", "name": "Alice"}, {"age": 15, "city": "Hanoi", "name": "Bob"}, {"age": 65, "city": "Paris", "name": "Charlie"}, {"age": 45, "city": "Hanoi", "name": "Diana"}, {"age": 70, "city": "Paris", "name": "Eve"}, {"age": 22, "city": "Hanoi", "name": "Frank"}]
   // let stats = from person in people
   Const        r1, []
-  // group by person.city into g
-  Const        r2, "city"
-  // city: g.key,
-  Const        r3, "key"
-  // count: count(g),
-  Const        r4, "count"
   // avg_age: avg(from p in g select p.age)
-  Const        r5, "avg_age"
-  Const        r6, "age"
+  Const        r2, "age"
+  // group by person.city into g
+  Const        r3, "city"
+  // city: g.key,
+  Const        r4, "key"
+  // count: count(g),
+  Const        r5, "count"
+  // avg_age: avg(from p in g select p.age)
+  Const        r6, "avg_age"
   // let stats = from person in people
   IterPrep     r7, r0
   Len          r8, r7
   Const        r9, 0
   MakeMap      r10, 0, r0
   Const        r11, []
-L2:
+L3:
   LessInt      r12, r9, r8
   JumpIfFalse  r12, L0
   Index        r13, r7, r9
   // group by person.city into g
-  Index        r15, r13, r2
-  Str          r16, r15
-  In           r17, r16, r10
-  JumpIfTrue   r17, L1
+  Index        r15, r13, r3
+  // avg_age: avg(from p in g select p.age)
+  Index        r16, r13, r2
+  // group by person.city into g
+  Str          r17, r15
+  In           r18, r17, r10
+  JumpIfTrue   r18, L1
   // let stats = from person in people
-  Const        r18, []
   Const        r19, "__group__"
   Const        r20, true
   // group by person.city into g
   Move         r21, r15
   // let stats = from person in people
-  Const        r22, "items"
-  Move         r23, r18
-  Const        r24, 0
-  MakeMap      r25, 4, r19
-  SetIndex     r10, r16, r25
-  Append       r26, r11, r25
-  Move         r11, r26
+  Const        r22, 0
+  Const        r23, "__agg0"
+  MakeMap      r24, 4, r19
+  SetIndex     r10, r17, r24
+  Append       r25, r11, r24
+  Move         r11, r25
 L1:
-  Index        r27, r10, r16
-  Index        r28, r27, r22
-  Append       r29, r28, r13
-  SetIndex     r27, r22, r29
-  Index        r30, r27, r4
-  Const        r31, 1
-  AddInt       r32, r30, r31
-  SetIndex     r27, r4, r32
-  AddInt       r9, r9, r31
-  Jump         L2
+  Index        r26, r10, r17
+  Index        r27, r26, r5
+  Const        r28, 1
+  AddInt       r29, r27, r28
+  SetIndex     r26, r5, r29
+  JumpIfFalse  r18, L2
+  Index        r30, r26, r23
+  Add          r31, r30, r16
+  SetIndex     r26, r23, r31
+L2:
+  AddInt       r9, r9, r28
+  Jump         L3
 L0:
-  Move         r33, r24
-  Len          r34, r11
-L6:
-  LessInt      r35, r33, r34
-  JumpIfFalse  r35, L3
-  Index        r37, r11, r33
-  // city: g.key,
-  Const        r38, "city"
-  Index        r39, r37, r3
-  // count: count(g),
-  Const        r40, "count"
-  Index        r41, r37, r4
-  // avg_age: avg(from p in g select p.age)
-  Const        r42, "avg_age"
-  Const        r43, []
-  IterPrep     r44, r37
-  Len          r45, r44
-  Move         r46, r24
+  Move         r32, r22
+  Len          r33, r11
 L5:
-  LessInt      r47, r46, r45
-  JumpIfFalse  r47, L4
-  Index        r49, r44, r46
-  Index        r50, r49, r6
-  Append       r43, r43, r50
-  AddInt       r46, r46, r31
+  LessInt      r34, r32, r33
+  JumpIfFalse  r34, L4
+  Index        r36, r11, r32
+  // city: g.key,
+  Const        r37, "city"
+  Index        r38, r36, r4
+  // count: count(g),
+  Const        r39, "count"
+  Index        r40, r36, r5
+  // avg_age: avg(from p in g select p.age)
+  Const        r41, "avg_age"
+  Index        r42, r36, r23
+  // select {
+  MakeMap      r48, 3, r37
+  // let stats = from person in people
+  Append       r1, r1, r48
+  AddInt       r32, r32, r28
   Jump         L5
 L4:
-  // select {
-  MakeMap      r56, 3, r38
-  // let stats = from person in people
-  Append       r1, r1, r56
-  AddInt       r33, r33, r31
-  Jump         L6
-L3:
   // print("--- People grouped by city ---")
-  Const        r58, "--- People grouped by city ---"
-  Print        r58
+  Const        r50, "--- People grouped by city ---"
+  Print        r50
   // for s in stats {
-  IterPrep     r59, r1
-  Len          r60, r59
-  Const        r61, 0
-L8:
-  Less         r62, r61, r60
-  JumpIfFalse  r62, L7
-  Index        r64, r59, r61
-  // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
-  Index        r65, r64, r2
-  Const        r66, ": count ="
-  Index        r67, r64, r4
-  Const        r68, ", avg_age ="
-  Index        r69, r64, r5
-  PrintN       r65, 5, r65
-  // for s in stats {
-  Const        r75, 1
-  Add          r61, r61, r75
-  Jump         L8
+  IterPrep     r51, r1
+  Len          r52, r51
+  Const        r53, 0
 L7:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L6
+  Index        r56, r51, r53
+  // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+  Index        r57, r56, r3
+  Const        r58, ": count ="
+  Index        r59, r56, r5
+  Const        r60, ", avg_age ="
+  Index        r61, r56, r6
+  PrintN       r57, 5, r57
+  // for s in stats {
+  Const        r67, 1
+  Add          r53, r53, r67
+  Jump         L7
+L6:
   Return       r0

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -1,107 +1,91 @@
-func main (regs=73)
+func main (regs=56)
   // let items = [
   Const        r0, [{"cat": "a", "flag": true, "val": 10}, {"cat": "a", "flag": false, "val": 5}, {"cat": "b", "flag": true, "val": 20}]
   // from i in items
   Const        r1, []
-  // group by i.cat into g
-  Const        r2, "cat"
-  // cat: g.key,
-  Const        r3, "key"
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r5, "flag"
-  Const        r6, "val"
+  Const        r2, "flag"
+  Const        r3, "val"
+  // group by i.cat into g
+  Const        r4, "cat"
+  // cat: g.key,
+  Const        r5, "key"
   // from i in items
   IterPrep     r7, r0
   Len          r8, r7
   Const        r9, 0
   MakeMap      r10, 0, r0
   Const        r11, []
-L2:
+L5:
   LessInt      r12, r9, r8
   JumpIfFalse  r12, L0
   Index        r13, r7, r9
   // group by i.cat into g
-  Index        r15, r13, r2
-  Str          r16, r15
-  In           r17, r16, r10
-  JumpIfTrue   r17, L1
-  // from i in items
-  Const        r18, []
-  Const        r19, "__group__"
-  Const        r20, true
-  // group by i.cat into g
-  Move         r21, r15
-  // from i in items
-  Const        r22, "items"
-  Move         r23, r18
-  Const        r24, "count"
-  Const        r25, 0
-  MakeMap      r26, 4, r19
-  SetIndex     r10, r16, r26
-L1:
-  Index        r28, r10, r16
-  Index        r29, r28, r22
-  Append       r30, r29, r13
-  SetIndex     r28, r22, r30
-  Index        r31, r28, r24
-  Const        r32, 1
-  AddInt       r33, r31, r32
-  SetIndex     r28, r24, r33
-  AddInt       r9, r9, r32
-  Jump         L2
-L0:
-  Move         r34, r25
-  Const        r35, 0
-L9:
-  LessInt      r36, r34, r35
-  JumpIfFalse  r36, L3
-  Index        r38, r11, r34
-  // cat: g.key,
-  Const        r39, "cat"
-  Index        r40, r38, r3
-  // share:
-  Const        r41, "share"
+  Index        r15, r13, r4
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r42, []
-  IterPrep     r43, r38
-  Len          r44, r43
-  Move         r45, r25
-L6:
-  LessInt      r46, r45, r44
-  JumpIfFalse  r46, L4
-  Index        r48, r43, r45
-  Index        r49, r48, r5
-  JumpIfFalse  r49, L5
-L5:
-  Append       r42, r42, r25
-  AddInt       r45, r45, r32
-  Jump         L6
-L4:
+  Index        r16, r13, r2
+  JumpIfFalse  r16, L1
+  Index        r18, r13, r3
+  Jump         L2
+L1:
+  Const        r19, 0
+  Move         r18, r19
+L2:
   // sum(from x in g select x.val)
-  Const        r54, []
-  IterPrep     r55, r38
-  Len          r56, r55
-  Move         r57, r25
-L8:
-  LessInt      r58, r57, r56
-  JumpIfFalse  r58, L7
-  Index        r48, r55, r57
-  Index        r60, r48, r6
-  Append       r54, r54, r60
-  AddInt       r57, r57, r32
-  Jump         L8
-L7:
-  // select {
-  MakeMap      r66, 2, r39
-  // sort by g.key
-  Index        r68, r38, r3
+  Index        r20, r13, r3
+  // group by i.cat into g
+  Str          r21, r15
+  In           r22, r21, r10
+  JumpIfTrue   r22, L3
   // from i in items
-  Move         r69, r66
-  MakeList     r70, 2, r68
-  Append       r1, r1, r70
-  AddInt       r34, r34, r32
-  Jump         L9
+  Const        r23, "__group__"
+  Const        r24, true
+  // group by i.cat into g
+  Move         r25, r15
+  // from i in items
+  Const        r26, "__agg0"
+  Const        r27, "__agg1"
+  MakeMap      r28, 4, r23
+  SetIndex     r10, r21, r28
+  Append       r29, r11, r28
 L3:
+  Index        r30, r10, r21
+  JumpIfFalse  r22, L4
+  Index        r31, r30, r26
+  Add          r32, r31, r18
+  SetIndex     r30, r26, r32
+  Index        r33, r30, r27
+  Add          r34, r33, r20
+  SetIndex     r30, r27, r34
+L4:
+  Const        r35, 1
+  AddInt       r9, r9, r35
+  Jump         L5
+L0:
+  Move         r36, r19
+  Const        r37, 0
+L7:
+  LessInt      r38, r36, r37
+  JumpIfFalse  r38, L6
+  Index        r40, r11, r36
+  // cat: g.key,
+  Const        r41, "cat"
+  Index        r42, r40, r5
+  // share:
+  Const        r43, "share"
+  // sum(from x in g select if x.flag { x.val } else { 0 }) /
+  Index        r44, r40, r26
+  // select {
+  MakeMap      r49, 2, r41
+  // sort by g.key
+  Index        r51, r40, r5
+  // from i in items
+  Move         r52, r49
+  MakeList     r53, 2, r51
+  Append       r1, r1, r53
+  AddInt       r36, r36, r35
+  Jump         L7
+L6:
   // sort by g.key
   Sort         r1, r1
   // print(result)

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -1,4 +1,4 @@
-func main (regs=48)
+func main (regs=43)
   // let people = [
   Const        r0, [{"city": "Paris", "name": "Alice"}, {"city": "Hanoi", "name": "Bob"}, {"city": "Paris", "name": "Charlie"}, {"city": "Hanoi", "name": "Diana"}, {"city": "Paris", "name": "Eve"}, {"city": "Hanoi", "name": "Frank"}, {"city": "Paris", "name": "George"}]
   // from p in people
@@ -13,62 +13,58 @@ func main (regs=48)
   Const        r7, 0
   MakeMap      r8, 0, r0
   Const        r9, []
-L2:
+L3:
   LessInt      r10, r7, r6
   JumpIfFalse  r10, L0
-  Index        r11, r5, r7
+  Index        r12, r5, r7
   // group by p.city into g
-  Index        r13, r11, r2
+  Index        r13, r12, r2
   Str          r14, r13
   In           r15, r14, r8
   JumpIfTrue   r15, L1
   // from p in people
-  Const        r16, []
-  Const        r17, "__group__"
-  Const        r18, true
+  Const        r16, "__group__"
+  Const        r17, true
   // group by p.city into g
-  Move         r19, r13
+  Move         r18, r13
   // from p in people
-  Const        r20, "items"
-  Move         r21, r16
-  Const        r22, "count"
-  Const        r23, 0
-  MakeMap      r24, 4, r17
-  SetIndex     r8, r14, r24
+  Const        r19, "count"
+  Const        r20, 0
+  MakeMap      r21, 3, r16
+  SetIndex     r8, r14, r21
 L1:
-  Index        r26, r8, r14
-  Index        r27, r26, r20
-  Append       r28, r27, r11
-  SetIndex     r26, r20, r28
-  Index        r29, r26, r22
-  Const        r30, 1
-  AddInt       r31, r29, r30
-  SetIndex     r26, r22, r31
-  AddInt       r7, r7, r30
-  Jump         L2
+  Index        r23, r8, r14
+  Index        r24, r23, r19
+  Const        r25, 1
+  AddInt       r26, r24, r25
+  SetIndex     r23, r19, r26
+  JumpIfFalse  r15, L2
+L2:
+  AddInt       r7, r7, r25
+  Jump         L3
 L0:
-  Move         r32, r23
-  Const        r33, 0
-L4:
-  LessInt      r34, r32, r33
-  JumpIfFalse  r34, L3
-  Index        r36, r9, r32
+  Move         r27, r20
+  Const        r28, 0
+L5:
+  LessInt      r29, r27, r28
+  JumpIfFalse  r29, L4
+  Index        r31, r9, r27
   // having count(g) >= 4
-  Index        r37, r36, r22
-  Const        r38, 4
-  LessEq       r39, r38, r37
-  JumpIfFalse  r39, L3
+  Index        r32, r31, r19
+  Const        r33, 4
+  LessEq       r34, r33, r32
+  JumpIfFalse  r34, L4
   // select { city: g.key, num: count(g) }
-  Const        r40, "city"
-  Index        r41, r36, r3
-  Const        r42, "num"
-  Index        r43, r36, r22
-  MakeMap      r46, 2, r40
+  Const        r35, "city"
+  Index        r36, r31, r3
+  Const        r37, "num"
+  Index        r38, r31, r19
+  MakeMap      r41, 2, r35
   // from p in people
-  Append       r1, r1, r46
-  AddInt       r32, r32, r30
-  Jump         L4
-L3:
+  Append       r1, r1, r41
+  AddInt       r27, r27, r25
+  Jump         L5
+L4:
   // json(big)
   JSON         r1
   Return       r0

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=76)
+func main (regs=71)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
   // let orders = [
@@ -35,87 +35,76 @@ L4:
   Index        r23, r19, r22
   Equal        r24, r21, r23
   JumpIfFalse  r24, L2
-  // let stats = from o in orders
-  Const        r25, "o"
-  Move         r26, r13
-  Const        r27, "c"
-  Move         r28, r19
-  MakeMap      r29, 2, r25
   // group by c.name into g
   Index        r30, r19, r3
   Str          r31, r30
   In           r32, r31, r6
   JumpIfTrue   r32, L3
   // let stats = from o in orders
-  Const        r33, []
-  Const        r34, "__group__"
-  Const        r35, true
+  Const        r33, "__group__"
+  Const        r34, true
   // group by c.name into g
-  Move         r36, r30
+  Move         r35, r30
   // let stats = from o in orders
-  Const        r37, "items"
-  Move         r38, r33
-  Const        r39, 0
-  MakeMap      r40, 4, r34
-  SetIndex     r6, r31, r40
-  Append       r41, r7, r40
-  Move         r7, r41
+  Const        r36, 0
+  MakeMap      r37, 3, r33
+  SetIndex     r6, r31, r37
+  Append       r38, r7, r37
+  Move         r7, r38
 L3:
-  Index        r42, r6, r31
-  Index        r43, r42, r37
-  Append       r44, r43, r29
-  SetIndex     r42, r37, r44
-  Index        r45, r42, r5
-  Const        r46, 1
-  AddInt       r47, r45, r46
-  SetIndex     r42, r5, r47
+  Index        r39, r6, r31
+  Index        r40, r39, r5
+  Const        r41, 1
+  AddInt       r42, r40, r41
+  SetIndex     r39, r5, r42
+  JumpIfFalse  r32, L2
 L2:
   // join from c in customers on o.customerId == c.id
-  AddInt       r16, r16, r46
+  AddInt       r16, r16, r41
   Jump         L4
 L1:
   // let stats = from o in orders
-  AddInt       r10, r10, r46
+  AddInt       r10, r10, r41
   Jump         L5
 L0:
-  Move         r48, r39
-  Len          r49, r7
+  Move         r43, r36
+  Len          r44, r7
 L7:
-  LessInt      r50, r48, r49
-  JumpIfFalse  r50, L6
-  Index        r52, r7, r48
+  LessInt      r45, r43, r44
+  JumpIfFalse  r45, L6
+  Index        r47, r7, r43
   // name: g.key,
-  Const        r53, "name"
-  Index        r54, r52, r4
+  Const        r48, "name"
+  Index        r49, r47, r4
   // count: count(g)
-  Const        r55, "count"
-  Index        r56, r52, r5
+  Const        r50, "count"
+  Index        r51, r47, r5
   // select {
-  MakeMap      r59, 2, r53
+  MakeMap      r54, 2, r48
   // let stats = from o in orders
-  Append       r2, r2, r59
-  AddInt       r48, r48, r46
+  Append       r2, r2, r54
+  AddInt       r43, r43, r41
   Jump         L7
 L6:
   // print("--- Orders per customer ---")
-  Const        r61, "--- Orders per customer ---"
-  Print        r61
+  Const        r56, "--- Orders per customer ---"
+  Print        r56
   // for s in stats {
-  IterPrep     r62, r2
-  Len          r63, r62
-  Const        r64, 0
+  IterPrep     r57, r2
+  Len          r58, r57
+  Const        r59, 0
 L9:
-  Less         r65, r64, r63
-  JumpIfFalse  r65, L8
-  Index        r67, r62, r64
+  Less         r60, r59, r58
+  JumpIfFalse  r60, L8
+  Index        r62, r57, r59
   // print(s.name, "orders:", s.count)
-  Index        r68, r67, r3
-  Const        r69, "orders:"
-  Index        r70, r67, r5
-  PrintN       r68, 3, r68
+  Index        r63, r62, r3
+  Const        r64, "orders:"
+  Index        r65, r62, r5
+  PrintN       r63, 3, r63
   // for s in stats {
-  Const        r74, 1
-  Add          r64, r64, r74
+  Const        r69, 1
+  Add          r59, r59, r69
   Jump         L9
 L8:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=104)
+func main (regs=100)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
   // let orders = [
@@ -49,110 +49,105 @@ L4:
   In           r33, r32, r7
   JumpIfTrue   r33, L3
   // let stats = from c in customers
-  Const        r34, []
-  Const        r35, "__group__"
-  Const        r36, true
+  Const        r34, "__group__"
+  Const        r35, true
   // group by c.name into g
-  Move         r37, r31
+  Move         r36, r31
   // let stats = from c in customers
+  Const        r37, []
   Const        r38, "items"
-  Move         r39, r34
-  Const        r40, 0
-  MakeMap      r41, 4, r35
-  SetIndex     r7, r32, r41
-  Append       r42, r8, r41
-  Move         r8, r42
+  Move         r39, r37
+  MakeMap      r40, 3, r34
+  SetIndex     r7, r32, r40
+  Append       r8, r8, r40
 L3:
-  Index        r43, r7, r32
-  Index        r44, r43, r38
-  Append       r45, r44, r30
-  SetIndex     r43, r38, r45
-  Index        r46, r43, r5
-  Const        r47, 1
-  AddInt       r48, r46, r47
-  SetIndex     r43, r5, r48
+  Index        r42, r7, r32
+  Index        r43, r42, r38
+  Append       r44, r43, r30
+  SetIndex     r42, r38, r44
+  JumpIfFalse  r33, L2
 L2:
   // left join o in orders on o.customerId == c.id
-  AddInt       r17, r17, r47
+  Const        r45, 1
+  AddInt       r17, r17, r45
   Jump         L4
 L1:
-  Move         r49, r21
-  JumpIfTrue   r49, L5
+  Move         r46, r21
+  JumpIfTrue   r46, L5
   // let stats = from c in customers
-  MakeMap      r53, 2, r27
+  MakeMap      r50, 2, r27
   // group by c.name into g
-  Index        r54, r14, r3
-  Str          r55, r54
-  In           r56, r55, r7
-  JumpIfTrue   r56, L6
+  Index        r51, r14, r3
+  Str          r52, r51
+  In           r53, r52, r7
+  JumpIfTrue   r53, L6
   // let stats = from c in customers
-  MakeMap      r60, 4, r35
-  SetIndex     r7, r55, r60
-  Append       r8, r8, r60
+  MakeMap      r57, 3, r34
+  SetIndex     r7, r52, r57
+  Append       r8, r8, r57
 L6:
-  Index        r62, r7, r55
-  Index        r63, r62, r38
-  Append       r64, r63, r53
-  SetIndex     r62, r38, r64
-  Index        r65, r62, r5
-  AddInt       r66, r65, r47
-  SetIndex     r62, r5, r66
+  Index        r59, r7, r52
+  Index        r60, r59, r38
+  Append       r61, r60, r50
+  SetIndex     r59, r38, r61
+  JumpIfFalse  r53, L5
 L5:
-  AddInt       r11, r11, r47
+  AddInt       r11, r11, r45
   Jump         L7
 L0:
-  Move         r67, r40
-  Len          r68, r8
+  Const        r63, 0
+  Move         r62, r63
+  Len          r64, r8
 L12:
-  LessInt      r69, r67, r68
-  JumpIfFalse  r69, L8
-  Index        r71, r8, r67
+  LessInt      r65, r62, r64
+  JumpIfFalse  r65, L8
+  Index        r67, r8, r62
   // name: g.key,
-  Const        r72, "name"
-  Index        r73, r71, r4
+  Const        r68, "name"
+  Index        r69, r67, r4
   // count: count(from r in g where r.o select r)
-  Const        r74, "count"
-  Const        r75, []
-  IterPrep     r76, r71
-  Len          r77, r76
-  Move         r78, r40
+  Const        r70, "count"
+  Const        r71, []
+  IterPrep     r72, r67
+  Len          r73, r72
+  Move         r74, r63
 L11:
-  LessInt      r79, r78, r77
-  JumpIfFalse  r79, L9
-  Index        r81, r76, r78
-  Index        r82, r81, r6
-  JumpIfFalse  r82, L10
-  Append       r75, r75, r81
+  LessInt      r75, r74, r73
+  JumpIfFalse  r75, L9
+  Index        r77, r72, r74
+  Index        r78, r77, r6
+  JumpIfFalse  r78, L10
+  Append       r71, r71, r77
 L10:
-  AddInt       r78, r78, r47
+  AddInt       r74, r74, r45
   Jump         L11
 L9:
   // select {
-  MakeMap      r87, 2, r72
+  MakeMap      r83, 2, r68
   // let stats = from c in customers
-  Append       r2, r2, r87
-  AddInt       r67, r67, r47
+  Append       r2, r2, r83
+  AddInt       r62, r62, r45
   Jump         L12
 L8:
   // print("--- Group Left Join ---")
-  Const        r89, "--- Group Left Join ---"
-  Print        r89
+  Const        r85, "--- Group Left Join ---"
+  Print        r85
   // for s in stats {
-  IterPrep     r90, r2
-  Len          r91, r90
-  Const        r92, 0
+  IterPrep     r86, r2
+  Len          r87, r86
+  Const        r88, 0
 L14:
-  Less         r93, r92, r91
-  JumpIfFalse  r93, L13
-  Index        r95, r90, r92
+  Less         r89, r88, r87
+  JumpIfFalse  r89, L13
+  Index        r91, r86, r88
   // print(s.name, "orders:", s.count)
-  Index        r96, r95, r3
-  Const        r97, "orders:"
-  Index        r98, r95, r5
-  PrintN       r96, 3, r96
+  Index        r92, r91, r3
+  Const        r93, "orders:"
+  Index        r94, r91, r5
+  PrintN       r92, 3, r92
   // for s in stats {
-  Const        r102, 1
-  Add          r92, r92, r102
+  Const        r98, 1
+  Add          r88, r88, r98
   Jump         L14
 L13:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=101)
+func main (regs=88)
   // let nations = [
   Const        r0, [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
   // let suppliers = [
@@ -88,71 +88,58 @@ L0:
   Const        r56, 0
   MakeMap      r57, 0, r0
   Const        r58, []
-L9:
+L10:
   LessInt      r59, r56, r55
   JumpIfFalse  r59, L7
   Index        r60, r54, r56
   // group by x.part into g
   Index        r62, r60, r5
-  Str          r63, r62
-  In           r64, r63, r57
-  JumpIfTrue   r64, L8
+  // total: sum(from r in g select r.value)
+  Index        r63, r60, r6
+  // group by x.part into g
+  Str          r64, r62
+  In           r65, r64, r57
+  JumpIfTrue   r65, L8
   // from x in filtered
-  Const        r65, []
   Const        r66, "__group__"
   Const        r67, true
   // group by x.part into g
   Move         r68, r62
   // from x in filtered
-  Const        r69, "items"
-  Move         r70, r65
-  Const        r71, "count"
-  MakeMap      r72, 4, r66
-  SetIndex     r57, r63, r72
-  Append       r73, r58, r72
-  Move         r58, r73
+  Const        r69, "__agg0"
+  MakeMap      r70, 3, r66
+  SetIndex     r57, r64, r70
+  Append       r71, r58, r70
+  Move         r58, r71
 L8:
-  Index        r74, r57, r63
-  Index        r75, r74, r69
-  Append       r76, r75, r60
-  SetIndex     r74, r69, r76
-  Index        r77, r74, r71
-  AddInt       r78, r77, r50
-  SetIndex     r74, r71, r78
+  Index        r72, r57, r64
+  JumpIfFalse  r65, L9
+  Index        r73, r72, r69
+  Add          r74, r73, r63
+  SetIndex     r72, r69, r74
+L9:
   AddInt       r56, r56, r50
-  Jump         L9
+  Jump         L10
 L7:
-  Move         r79, r12
-  Len          r80, r58
-L13:
-  LessInt      r81, r79, r80
-  JumpIfFalse  r81, L10
-  Index        r83, r58, r79
-  // part: g.key,
-  Const        r84, "part"
-  Index        r85, r83, r52
-  // total: sum(from r in g select r.value)
-  Const        r86, "total"
-  Const        r87, []
-  IterPrep     r88, r83
-  Len          r89, r88
-  Move         r90, r12
+  Move         r75, r12
+  Len          r76, r58
 L12:
-  LessInt      r91, r90, r89
-  JumpIfFalse  r91, L11
-  Index        r93, r88, r90
-  Index        r94, r93, r6
-  Append       r87, r87, r94
-  AddInt       r90, r90, r50
+  LessInt      r77, r75, r76
+  JumpIfFalse  r77, L11
+  Index        r79, r58, r75
+  // part: g.key,
+  Const        r80, "part"
+  Index        r81, r79, r52
+  // total: sum(from r in g select r.value)
+  Const        r82, "total"
+  Index        r83, r79, r69
+  // select {
+  MakeMap      r86, 2, r80
+  // from x in filtered
+  Append       r51, r51, r86
+  AddInt       r75, r75, r50
   Jump         L12
 L11:
-  // select {
-  MakeMap      r99, 2, r84
-  // from x in filtered
-  Append       r51, r51, r99
-  AddInt       r79, r79, r50
-  Jump         L13
-L10:
   // print(grouped)
   Print        r51
   Return       r0

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -1,4 +1,4 @@
-func main (regs=189)
+func main (regs=177)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
@@ -13,30 +13,30 @@ func main (regs=189)
   Const        r5, "1994-01-01"
   // from c in customer
   Const        r6, []
-  // c_custkey: c.c_custkey,
-  Const        r7, "c_custkey"
-  // c_name: c.c_name,
-  Const        r8, "c_name"
-  // c_acctbal: c.c_acctbal,
-  Const        r9, "c_acctbal"
-  // c_address: c.c_address,
-  Const        r10, "c_address"
-  // c_phone: c.c_phone,
-  Const        r11, "c_phone"
-  // c_comment: c.c_comment,
-  Const        r12, "c_comment"
-  // n_name: n.n_name
-  Const        r13, "n_name"
-  // where o.o_orderdate >= start_date &&
-  Const        r14, "o_orderdate"
-  // l.l_returnflag == "R"
-  Const        r15, "l_returnflag"
-  // c_custkey: g.key.c_custkey,
-  Const        r16, "key"
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r18, "l"
-  Const        r19, "l_extendedprice"
-  Const        r20, "l_discount"
+  Const        r7, "l"
+  Const        r8, "l_extendedprice"
+  Const        r9, "l_discount"
+  // c_custkey: c.c_custkey,
+  Const        r10, "c_custkey"
+  // c_name: c.c_name,
+  Const        r11, "c_name"
+  // c_acctbal: c.c_acctbal,
+  Const        r12, "c_acctbal"
+  // c_address: c.c_address,
+  Const        r13, "c_address"
+  // c_phone: c.c_phone,
+  Const        r14, "c_phone"
+  // c_comment: c.c_comment,
+  Const        r15, "c_comment"
+  // n_name: n.n_name
+  Const        r16, "n_name"
+  // where o.o_orderdate >= start_date &&
+  Const        r17, "o_orderdate"
+  // l.l_returnflag == "R"
+  Const        r18, "l_returnflag"
+  // c_custkey: g.key.c_custkey,
+  Const        r19, "key"
   // from c in customer
   MakeMap      r21, 0, r0
   Const        r22, []
@@ -57,7 +57,7 @@ L10:
   Index        r34, r29, r31
   Const        r35, "o_custkey"
   Index        r36, r34, r35
-  Index        r37, r28, r7
+  Index        r37, r28, r10
   Equal        r38, r36, r37
   JumpIfFalse  r38, L2
   // join l in lineitem on l.l_orderkey == o.o_orderkey
@@ -89,13 +89,13 @@ L8:
   Equal        r60, r57, r59
   JumpIfFalse  r60, L4
   // where o.o_orderdate >= start_date &&
-  Index        r61, r34, r14
+  Index        r61, r34, r17
   LessEq       r62, r4, r61
   // o.o_orderdate < end_date &&
-  Index        r63, r34, r14
+  Index        r63, r34, r17
   Less         r64, r63, r5
   // l.l_returnflag == "R"
-  Index        r65, r44, r15
+  Index        r65, r44, r18
   Const        r66, "R"
   Equal        r67, r65, r66
   // where o.o_orderdate >= start_date &&
@@ -120,60 +120,80 @@ L6:
   MakeMap      r77, 4, r70
   // c_custkey: c.c_custkey,
   Const        r78, "c_custkey"
-  Index        r79, r28, r7
+  Index        r79, r28, r10
   // c_name: c.c_name,
   Const        r80, "c_name"
-  Index        r81, r28, r8
+  Index        r81, r28, r11
   // c_acctbal: c.c_acctbal,
   Const        r82, "c_acctbal"
-  Index        r83, r28, r9
+  Index        r83, r28, r12
   // c_address: c.c_address,
   Const        r84, "c_address"
-  Index        r85, r28, r10
+  Index        r85, r28, r13
   // c_phone: c.c_phone,
   Const        r86, "c_phone"
-  Index        r87, r28, r11
+  Index        r87, r28, r14
   // c_comment: c.c_comment,
   Const        r88, "c_comment"
-  Index        r89, r28, r12
+  Index        r89, r28, r15
   // n_name: n.n_name
   Const        r90, "n_name"
-  Index        r91, r55, r13
+  Index        r91, r55, r16
   // group by {
   MakeMap      r99, 7, r78
-  Str          r100, r99
-  In           r101, r100, r21
-  JumpIfTrue   r101, L7
-  // from c in customer
-  Const        r102, []
-  Const        r103, "__group__"
-  Const        r104, true
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Index        r100, r77, r7
+  Index        r101, r100, r8
+  Const        r102, 1
+  Index        r103, r77, r7
+  Index        r104, r103, r9
+  Sub          r105, r102, r104
+  Mul          r106, r101, r105
+  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Index        r107, r77, r7
+  Index        r108, r107, r8
+  Index        r109, r77, r7
+  Index        r110, r109, r9
+  Sub          r111, r102, r110
+  Mul          r112, r108, r111
   // group by {
-  Move         r105, r99
+  Str          r113, r99
+  In           r114, r113, r21
+  JumpIfTrue   r114, L7
   // from c in customer
-  Const        r106, "items"
-  Move         r107, r102
-  Const        r108, "count"
-  Const        r109, 0
-  MakeMap      r110, 4, r103
-  SetIndex     r21, r100, r110
-  Append       r22, r22, r110
+  Const        r115, "__group__"
+  Const        r116, true
+  // group by {
+  Move         r117, r99
+  // from c in customer
+  Const        r118, []
+  Const        r119, "items"
+  Move         r120, r118
+  Const        r121, "__agg1"
+  Const        r122, "__agg0"
+  MakeMap      r123, 5, r115
+  SetIndex     r21, r113, r123
+  Append       r124, r22, r123
+  Move         r22, r124
 L7:
-  Index        r112, r21, r100
-  Index        r113, r112, r106
-  Append       r114, r113, r77
-  SetIndex     r112, r106, r114
-  Index        r115, r112, r108
-  Const        r116, 1
-  AddInt       r117, r115, r116
-  SetIndex     r112, r108, r117
+  Index        r125, r21, r113
+  Index        r126, r125, r119
+  Append       r127, r126, r77
+  SetIndex     r125, r119, r127
+  JumpIfFalse  r114, L4
+  Index        r128, r125, r122
+  Add          r129, r128, r106
+  SetIndex     r125, r122, r129
+  Index        r130, r125, r121
+  Add          r131, r130, r112
+  SetIndex     r125, r121, r131
 L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r52, r52, r116
+  AddInt       r52, r52, r102
   Jump         L8
 L3:
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r41, r41, r116
+  AddInt       r41, r41, r102
   Jump         L9
 L2:
   // join o in orders on o.o_custkey == c.c_custkey
@@ -182,70 +202,45 @@ L1:
   // from c in customer
   Jump         L11
 L0:
-  Move         r118, r109
-  Len          r119, r22
-L17:
-  LessInt      r120, r118, r119
-  JumpIfFalse  r120, L12
-  Index        r122, r22, r118
-  // c_custkey: g.key.c_custkey,
-  Const        r123, "c_custkey"
-  Index        r124, r122, r16
-  Index        r125, r124, r7
-  // c_name: g.key.c_name,
-  Const        r126, "c_name"
-  Index        r127, r122, r16
-  Index        r128, r127, r8
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r129, "revenue"
-  Const        r130, []
-  IterPrep     r131, r122
-  Len          r132, r131
-  Move         r133, r109
-L14:
-  LessInt      r134, r133, r132
-  JumpIfFalse  r134, L13
-  Index        r135, r131, r133
-  Move         r136, r135
-  Index        r137, r136, r18
-  Index        r138, r137, r19
-  Index        r139, r136, r18
-  Index        r140, r139, r20
-  Sub          r141, r116, r140
-  Mul          r142, r138, r141
-  Append       r130, r130, r142
-  AddInt       r133, r133, r116
-  Jump         L14
+  Const        r132, 0
+  Len          r134, r22
 L13:
+  LessInt      r135, r132, r134
+  JumpIfFalse  r135, L12
+  Index        r137, r22, r132
+  // c_custkey: g.key.c_custkey,
+  Const        r138, "c_custkey"
+  Index        r139, r137, r19
+  Index        r140, r139, r10
+  // c_name: g.key.c_name,
+  Const        r141, "c_name"
+  Index        r142, r137, r19
+  Index        r143, r142, r11
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Const        r144, "revenue"
+  Index        r145, r137, r122
+  // c_acctbal: g.key.c_acctbal,
+  Const        r146, "c_acctbal"
+  Index        r147, r137, r19
+  Index        r148, r147, r12
+  // n_name: g.key.n_name,
+  Const        r149, "n_name"
+  Index        r150, r137, r19
+  Index        r151, r150, r16
+  // c_address: g.key.c_address,
+  Const        r152, "c_address"
+  Index        r153, r137, r19
   // select {
-  MakeMap      r168, 8, r123
+  MakeMap      r169, 8, r138
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r169, []
-  IterPrep     r170, r122
-  Len          r171, r170
-  Move         r172, r109
-L16:
-  LessInt      r173, r172, r171
-  JumpIfFalse  r173, L15
-  Index        r136, r170, r172
-  Index        r175, r136, r18
-  Index        r176, r175, r19
-  Index        r177, r136, r18
-  Index        r178, r177, r20
-  Sub          r179, r116, r178
-  Mul          r180, r176, r179
-  Append       r169, r169, r180
-  AddInt       r172, r172, r116
-  Jump         L16
-L15:
-  Sum          r182, r169
-  Neg          r184, r182
+  Index        r170, r137, r121
+  Neg          r172, r170
   // from c in customer
-  Move         r185, r168
-  MakeList     r186, 2, r184
-  Append       r6, r6, r186
-  AddInt       r118, r118, r116
-  Jump         L17
+  Move         r173, r169
+  MakeList     r174, 2, r172
+  Append       r6, r6, r174
+  AddInt       r132, r132, r102
+  Jump         L13
 L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r6, r6

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,103 +1,83 @@
-func main (regs=69)
+func main (regs=52)
   // let items = [
   Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
   // from i in items
   Const        r1, []
-  // group by i.cat into g
-  Const        r2, "cat"
-  // cat: g.key,
-  Const        r3, "key"
   // total: sum(from x in g select x.val)
-  Const        r5, "val"
+  Const        r2, "val"
+  // group by i.cat into g
+  Const        r3, "cat"
+  // cat: g.key,
+  Const        r4, "key"
   // from i in items
   IterPrep     r6, r0
   Len          r7, r6
   Const        r8, 0
   MakeMap      r9, 0, r0
   Const        r10, []
-L2:
+L3:
   LessInt      r11, r8, r7
   JumpIfFalse  r11, L0
   Index        r12, r6, r8
   // group by i.cat into g
-  Index        r14, r12, r2
-  Str          r15, r14
-  In           r16, r15, r9
-  JumpIfTrue   r16, L1
-  // from i in items
-  Const        r17, []
-  Const        r18, "__group__"
-  Const        r19, true
+  Index        r14, r12, r3
+  // total: sum(from x in g select x.val)
+  Index        r15, r12, r2
+  // sort by -sum(from x in g select x.val)
+  Index        r16, r12, r2
   // group by i.cat into g
-  Move         r20, r14
+  Str          r17, r14
+  In           r18, r17, r9
+  JumpIfTrue   r18, L1
   // from i in items
-  Const        r21, "items"
-  Move         r22, r17
-  Const        r23, "count"
-  Const        r24, 0
-  MakeMap      r25, 4, r18
-  SetIndex     r9, r15, r25
+  Const        r19, "__group__"
+  Const        r20, true
+  // group by i.cat into g
+  Move         r21, r14
+  // from i in items
+  Const        r22, "__agg0"
+  Const        r23, "__agg1"
+  MakeMap      r24, 4, r19
+  SetIndex     r9, r17, r24
+  Append       r25, r10, r24
 L1:
-  Index        r27, r9, r15
-  Index        r28, r27, r21
-  Append       r29, r28, r12
-  SetIndex     r27, r21, r29
-  Index        r30, r27, r23
+  Index        r26, r9, r17
+  JumpIfFalse  r18, L2
+  Index        r27, r26, r22
+  Add          r28, r27, r15
+  SetIndex     r26, r22, r28
+  Index        r29, r26, r23
+  Add          r30, r29, r16
+  SetIndex     r26, r23, r30
+L2:
   Const        r31, 1
-  AddInt       r32, r30, r31
-  SetIndex     r27, r23, r32
   AddInt       r8, r8, r31
-  Jump         L2
+  Jump         L3
 L0:
-  Move         r33, r24
+  Const        r32, 0
   Const        r34, 0
-L8:
-  LessInt      r35, r33, r34
-  JumpIfFalse  r35, L3
-  Index        r37, r10, r33
+L5:
+  LessInt      r35, r32, r34
+  JumpIfFalse  r35, L4
+  Index        r37, r10, r32
   // cat: g.key,
   Const        r38, "cat"
-  Index        r39, r37, r3
+  Index        r39, r37, r4
   // total: sum(from x in g select x.val)
   Const        r40, "total"
-  Const        r41, []
-  IterPrep     r42, r37
-  Len          r43, r42
-  Move         r44, r24
-L5:
-  LessInt      r45, r44, r43
-  JumpIfFalse  r45, L4
-  Index        r47, r42, r44
-  Index        r48, r47, r5
-  Append       r41, r41, r48
-  AddInt       r44, r44, r31
+  Index        r41, r37, r22
+  // select {
+  MakeMap      r44, 2, r38
+  // sort by -sum(from x in g select x.val)
+  Index        r45, r37, r23
+  Neg          r47, r45
+  // from i in items
+  Move         r48, r44
+  MakeList     r49, 2, r47
+  Append       r1, r1, r49
+  AddInt       r32, r32, r31
   Jump         L5
 L4:
-  // select {
-  MakeMap      r53, 2, r38
-  // sort by -sum(from x in g select x.val)
-  Const        r54, []
-  IterPrep     r55, r37
-  Len          r56, r55
-  Move         r57, r24
-L7:
-  LessInt      r58, r57, r56
-  JumpIfFalse  r58, L6
-  Index        r47, r55, r57
-  Index        r60, r47, r5
-  Append       r54, r54, r60
-  AddInt       r57, r57, r31
-  Jump         L7
-L6:
-  Sum          r62, r54
-  Neg          r64, r62
-  // from i in items
-  Move         r65, r53
-  MakeList     r66, 2, r64
-  Append       r1, r1, r66
-  AddInt       r33, r33, r31
-  Jump         L8
-L3:
   // sort by -sum(from x in g select x.val)
   Sort         r1, r1
   // print(grouped)

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -1,4 +1,4 @@
-func main (regs=79)
+func main (regs=75)
   // let data = [
   Const        r0, [{"tag": "a", "val": 1}, {"tag": "a", "val": 2}, {"tag": "b", "val": 3}]
   // let groups = from d in data group by d.tag into g select g
@@ -9,7 +9,7 @@ func main (regs=79)
   Const        r5, 0
   MakeMap      r6, 0, r0
   Const        r7, []
-L2:
+L3:
   LessInt      r8, r5, r4
   JumpIfFalse  r8, L0
   Index        r9, r3, r5
@@ -17,99 +17,94 @@ L2:
   Str          r12, r11
   In           r13, r12, r6
   JumpIfTrue   r13, L1
-  Const        r14, []
-  Const        r15, "__group__"
-  Const        r16, true
-  Const        r17, "key"
-  Move         r18, r11
-  Const        r19, "items"
-  Move         r20, r14
-  Const        r21, "count"
-  Const        r22, 0
-  MakeMap      r23, 4, r15
-  SetIndex     r6, r12, r23
-  Append       r7, r7, r23
+  Const        r14, "__group__"
+  Const        r15, true
+  Const        r16, []
+  Const        r17, "items"
+  MakeMap      r19, 2, r14
+  SetIndex     r6, r12, r19
+  Append       r7, r7, r19
 L1:
-  Index        r25, r6, r12
-  Index        r26, r25, r19
-  Append       r27, r26, r9
-  SetIndex     r25, r19, r27
-  Index        r28, r25, r21
-  Const        r29, 1
-  AddInt       r30, r28, r29
-  SetIndex     r25, r21, r30
-  AddInt       r5, r5, r29
-  Jump         L2
+  Index        r21, r6, r12
+  Index        r22, r21, r17
+  Append       r23, r22, r9
+  SetIndex     r21, r17, r23
+  JumpIfFalse  r13, L2
+L2:
+  Const        r24, 1
+  AddInt       r5, r5, r24
+  Jump         L3
 L0:
-  Move         r31, r22
-  Len          r32, r7
-L4:
-  LessInt      r33, r31, r32
-  JumpIfFalse  r33, L3
-  Index        r35, r7, r31
-  Append       r1, r1, r35
-  AddInt       r31, r31, r29
-  Jump         L4
-L3:
-  // var tmp = []
-  Const        r38, []
-  // for g in groups {
-  IterPrep     r39, r1
-  Len          r40, r39
-  Const        r41, 0
-L8:
-  Less         r42, r41, r40
-  JumpIfFalse  r42, L5
-  Index        r35, r39, r41
-  // var total = 0
-  Move         r44, r22
-  // for x in g.items {
-  Index        r45, r35, r19
-  IterPrep     r46, r45
-  Len          r47, r46
-  Const        r48, 0
-L7:
-  Less         r49, r48, r47
-  JumpIfFalse  r49, L6
-  Index        r51, r46, r48
-  // total = total + x.val
-  Const        r52, "val"
-  Index        r53, r51, r52
-  Add          r44, r44, r53
-  // for x in g.items {
-  Const        r55, 1
-  Add          r48, r48, r55
-  Jump         L7
-L6:
-  // tmp = append(tmp, {tag: g.key, total: total})
-  Const        r57, "tag"
-  Index        r58, r35, r17
-  Const        r59, "total"
-  Move         r60, r58
-  MakeMap      r62, 2, r57
-  Append       r38, r38, r62
-  // for g in groups {
-  Const        r64, 1
-  Add          r41, r41, r64
-  Jump         L8
+  Const        r26, 0
+  Move         r25, r26
+  Len          r27, r7
 L5:
-  // let result = from r in tmp sort by r.tag select r
-  Const        r66, []
-  IterPrep     r67, r38
-  Len          r68, r67
-  Move         r69, r22
-L10:
-  LessInt      r70, r69, r68
-  JumpIfFalse  r70, L9
-  Index        r72, r67, r69
-  Index        r74, r72, r2
-  Move         r75, r72
-  MakeList     r76, 2, r74
-  Append       r66, r66, r76
-  AddInt       r69, r69, r29
-  Jump         L10
+  LessInt      r28, r25, r27
+  JumpIfFalse  r28, L4
+  Index        r30, r7, r25
+  Append       r1, r1, r30
+  AddInt       r25, r25, r24
+  Jump         L5
+L4:
+  // var tmp = []
+  Const        r33, []
+  // for g in groups {
+  IterPrep     r34, r1
+  Len          r35, r34
+  Const        r36, 0
 L9:
-  Sort         r66, r66
+  Less         r37, r36, r35
+  JumpIfFalse  r37, L6
+  Index        r30, r34, r36
+  // var total = 0
+  Move         r39, r26
+  // for x in g.items {
+  Index        r40, r30, r17
+  IterPrep     r41, r40
+  Len          r42, r41
+  Const        r43, 0
+L8:
+  Less         r44, r43, r42
+  JumpIfFalse  r44, L7
+  Index        r46, r41, r43
+  // total = total + x.val
+  Const        r47, "val"
+  Index        r48, r46, r47
+  Add          r39, r39, r48
+  // for x in g.items {
+  Const        r50, 1
+  Add          r43, r43, r50
+  Jump         L8
+L7:
+  // tmp = append(tmp, {tag: g.key, total: total})
+  Const        r52, "tag"
+  Const        r53, "key"
+  Index        r54, r30, r53
+  Const        r55, "total"
+  MakeMap      r58, 2, r52
+  Append       r33, r33, r58
+  // for g in groups {
+  Const        r60, 1
+  Add          r36, r36, r60
+  Jump         L9
+L6:
+  // let result = from r in tmp sort by r.tag select r
+  Const        r62, []
+  IterPrep     r63, r33
+  Len          r64, r63
+  Move         r65, r26
+L11:
+  LessInt      r66, r65, r64
+  JumpIfFalse  r66, L10
+  Index        r68, r63, r65
+  Index        r70, r68, r2
+  Move         r71, r68
+  MakeList     r72, 2, r70
+  Append       r62, r62, r72
+  AddInt       r65, r65, r24
+  Jump         L11
+L10:
+  Sort         r62, r62
   // print(result)
-  Print        r66
+  Print        r62
   Return       r0


### PR DESCRIPTION
## Summary
- avoid building group `items` list when not needed
- regenerate VM IR for group queries
- compute `sum` and `avg` aggregates during grouping
- compute `min` and `max` aggregates during grouping

## Testing
- `go test ./...`
- `go test -tags slow ./tests/vm -run TestVM_IR -update`


------
https://chatgpt.com/codex/tasks/task_e_68611d8233488320bcc0ebb3c9a1044f