### PR TITLE
Fix VM map key handling

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -815,8 +815,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				case ValueInt:
 					key = fmt.Sprintf("%d", idxVal.Int)
 				default:
-					fr.regs[ins.A] = Value{Tag: ValueNull}
-					break
+					key = valueToString(idxVal)
 				}
 				fr.regs[ins.A] = src.Map[key]
 			case ValueStr:
@@ -922,7 +921,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				case ValueInt:
 					key = fmt.Sprintf("%d", idxVal.Int)
 				default:
-					return Value{}, m.newError(fmt.Errorf("invalid map key"), trace, ins.Line)
+					key = valueToString(idxVal)
 				}
 				if dst.Map == nil {
 					dst.Map = map[string]Value{}
@@ -951,7 +950,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				case ValueInt:
 					k = fmt.Sprintf("%d", key.Int)
 				default:
-					return Value{}, m.newError(fmt.Errorf("invalid map key"), trace, ins.Line)
+					k = valueToString(key)
 				}
 				mp[k] = val
 			}


### PR DESCRIPTION
## Summary
- allow arbitrary map keys in OpSetIndex and OpMakeMap

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68613a883fd883209c742b9fd0f38790