### PR TITLE
Improve vm numeric conversions

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -5633,8 +5633,26 @@ func anyToValue(v any) Value {
 		return Value{Tag: ValueInt, Int: val}
 	case int64:
 		return Value{Tag: ValueInt, Int: int(val)}
+	case int32:
+		return Value{Tag: ValueInt, Int: int(val)}
+	case int16:
+		return Value{Tag: ValueInt, Int: int(val)}
+	case int8:
+		return Value{Tag: ValueInt, Int: int(val)}
+	case uint:
+		return Value{Tag: ValueInt, Int: int(val)}
+	case uint64:
+		return Value{Tag: ValueInt, Int: int(val)}
+	case uint32:
+		return Value{Tag: ValueInt, Int: int(val)}
+	case uint16:
+		return Value{Tag: ValueInt, Int: int(val)}
+	case uint8:
+		return Value{Tag: ValueInt, Int: int(val)}
 	case float64:
 		return Value{Tag: ValueFloat, Float: val}
+	case float32:
+		return Value{Tag: ValueFloat, Float: float64(val)}
 	case string:
 		return Value{Tag: ValueStr, Str: val}
 	case bool:


### PR DESCRIPTION
## Summary
- handle more numeric types in `anyToValue`

## Testing
- `go test -tags slow ./runtime/vm -run TestInfer_TagPropagation -v`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68615ea034c88320b87495ba9291f385