### PR TITLE
Optimize group by compilation

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -4060,6 +4060,8 @@ func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
 	fc.emit(q.Pos, Instr{Op: OpMakeMap, A: groupsMap, B: 0})
 	groupsList := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpConst, A: groupsList, Val: Value{Tag: ValueList, List: []Value{}}})
+	gidx := fc.newReg()
+	fc.emit(q.Pos, Instr{Op: OpConst, A: gidx, Val: Value{Tag: ValueInt, Int: 0}})
 
 	loopStart := len(fc.fn.Code)
 	condReg := fc.newReg()
@@ -4080,10 +4082,10 @@ func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
 		cond := fc.compileExpr(q.Where)
 		skip := len(fc.fn.Code)
 		fc.emit(q.Where.Pos, Instr{Op: OpJumpIfFalse, A: cond})
-		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList)
+		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList, gidx)
 		fc.fn.Code[skip].B = len(fc.fn.Code)
 	} else {
-		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList)
+		fc.compileGroupAccum(q, elemReg, varReg, groupsMap, groupsList, gidx)
 	}
 
 	one := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 1})
@@ -4148,7 +4150,7 @@ func (fc *funcCompiler) compileGroupQuery(q *parser.QueryExpr, dst int) {
 	}
 }
 
-func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, gmap, glist int) {
+func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, gmap, glist, gidx int) {
 	exprs := q.Group.Exprs
 	regs := make([]int, len(exprs))
 	for i, e := range exprs {
@@ -4215,17 +4217,21 @@ func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, 
 	grp := fc.newReg()
 	startGrp := contig[0]
 	fc.emit(q.Pos, Instr{Op: OpMakeMap, A: grp, B: len(contig) / 2, C: startGrp})
-	fc.emit(q.Pos, Instr{Op: OpSetIndex, A: gmap, B: keyStr, C: grp})
+	fc.emit(q.Pos, Instr{Op: OpSetIndex, A: gmap, B: keyStr, C: gidx})
 	tmp := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpAppend, A: tmp, B: glist, C: grp})
 	fc.emit(q.Pos, Instr{Op: OpMove, A: glist, B: tmp})
+	inc := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 1})
+	fc.emit(q.Pos, Instr{Op: OpAddInt, A: gidx, B: gidx, C: inc})
 
 	end := len(fc.fn.Code)
 	fc.fn.Code[jump].B = end
 
 	itemsKey := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "items"})
+	idxReg := fc.newReg()
+	fc.emit(q.Pos, Instr{Op: OpIndex, A: idxReg, B: gmap, C: keyStr})
 	grp2 := fc.newReg()
-	fc.emit(q.Pos, Instr{Op: OpIndex, A: grp2, B: gmap, C: keyStr})
+	fc.emit(q.Pos, Instr{Op: OpIndex, A: grp2, B: glist, C: idxReg})
 	cur := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpIndex, A: cur, B: grp2, C: itemsKey})
 	newList := fc.newReg()
@@ -4258,8 +4264,10 @@ func (fc *funcCompiler) compileGroupQueryAny(q *parser.QueryExpr, dst int) {
 	fc.emit(q.Pos, Instr{Op: OpMakeMap, A: groupsMap, B: 0})
 	groupsList := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpConst, A: groupsList, Val: Value{Tag: ValueList, List: []Value{}}})
+	gidx := fc.newReg()
+	fc.emit(q.Pos, Instr{Op: OpConst, A: gidx, Val: Value{Tag: ValueInt, Int: 0}})
 
-	fc.compileGroupFromAny(q, groupsMap, groupsList, 0)
+	fc.compileGroupFromAny(q, groupsMap, groupsList, gidx, 0)
 
 	// iterate groups and produce final results
 	gi := fc.newReg()
@@ -4317,7 +4325,7 @@ func (fc *funcCompiler) compileGroupQueryAny(q *parser.QueryExpr, dst int) {
 	}
 }
 
-func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist int, level int) {
+func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist, gidx int, level int) {
 	var name string
 	var src *parser.Expr
 	if level == 0 {
@@ -4353,11 +4361,11 @@ func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist int
 
 	if level < len(q.Froms) {
 		fc.pushScope()
-		fc.compileGroupFromAny(q, gmap, glist, level+1)
+		fc.compileGroupFromAny(q, gmap, glist, gidx, level+1)
 		fc.popScope()
 	} else {
 		fc.pushScope()
-		fc.compileGroupJoinAny(q, gmap, glist, 0)
+		fc.compileGroupJoinAny(q, gmap, glist, gidx, 0)
 		fc.popScope()
 	}
 
@@ -4368,7 +4376,7 @@ func (fc *funcCompiler) compileGroupFromAny(q *parser.QueryExpr, gmap, glist int
 	fc.fn.Code[jmp].B = end
 }
 
-func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int, idx int) {
+func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist, gidx int, idx int) {
 	if idx >= len(q.Joins) {
 		doAccum := func() {
 			row := fc.buildRowMap(q)
@@ -4377,7 +4385,7 @@ func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int
 				vreg = fc.newReg()
 				fc.vars[q.Var] = vreg
 			}
-			fc.compileGroupAccum(q, row, vreg, gmap, glist)
+			fc.compileGroupAccum(q, row, vreg, gmap, glist, gidx)
 		}
 		if q.Where != nil {
 			cond := fc.compileExpr(q.Where)
@@ -4426,11 +4434,11 @@ func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int
 			skip := len(fc.fn.Code)
 			fc.emit(join.On.Pos, Instr{Op: OpJumpIfFalse, A: cond})
 			fc.emit(join.Pos, Instr{Op: OpConst, A: matched, Val: Value{Tag: ValueBool, Bool: true}})
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, gidx, idx+1)
 			fc.fn.Code[skip].B = len(fc.fn.Code)
 		} else {
 			fc.emit(join.Pos, Instr{Op: OpConst, A: matched, Val: Value{Tag: ValueBool, Bool: true}})
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, gidx, idx+1)
 		}
 
 		one := fc.constReg(join.Pos, Value{Tag: ValueInt, Int: 1})
@@ -4445,17 +4453,17 @@ func (fc *funcCompiler) compileGroupJoinAny(q *parser.QueryExpr, gmap, glist int
 		fc.emit(join.Pos, Instr{Op: OpJumpIfTrue, A: check})
 		nilreg := fc.constReg(join.Pos, Value{Tag: ValueNull})
 		fc.emit(join.Pos, Instr{Op: OpMove, A: rvar, B: nilreg})
-		fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+		fc.compileGroupJoinAny(q, gmap, glist, gidx, idx+1)
 		fc.fn.Code[skipAdd].B = len(fc.fn.Code)
 	} else {
 		if join.On != nil {
 			cond := fc.compileExpr(join.On)
 			skip := len(fc.fn.Code)
 			fc.emit(join.On.Pos, Instr{Op: OpJumpIfFalse, A: cond})
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, gidx, idx+1)
 			fc.fn.Code[skip].B = len(fc.fn.Code)
 		} else {
-			fc.compileGroupJoinAny(q, gmap, glist, idx+1)
+			fc.compileGroupJoinAny(q, gmap, glist, gidx, idx+1)
 		}
 
 		one := fc.constReg(join.Pos, Value{Tag: ValueInt, Int: 1})

--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -1,134 +1,135 @@
-func main (regs=22)
+func main (regs=23)
   // let people = [
   Const        r0, [{"age": 30, "city": "Paris", "name": "Alice"}, {"age": 15, "city": "Hanoi", "name": "Bob"}, {"age": 65, "city": "Paris", "name": "Charlie"}, {"age": 45, "city": "Hanoi", "name": "Diana"}, {"age": 70, "city": "Paris", "name": "Eve"}, {"age": 22, "city": "Hanoi", "name": "Frank"}]
   // let stats = from person in people
   Const        r1, []
   // group by person.city into g
   Const        r2, "city"
-L8:
+L3:
   // city: g.key,
   Const        r3, "key"
-L3:
   // count: count(g),
   Const        r4, "count"
   // avg_age: avg(from p in g select p.age)
   Const        r5, "avg_age"
   Const        r6, "age"
-L5:
   // let stats = from person in people
   IterPrep     r7, r0
   Len          r8, r7
-L6:
   Const        r9, 0
   MakeMap      r10, 0, r0
-L0:
   Const        r11, []
+L5:
+  Const        r12, 0
 L2:
-  LessInt      r12, r9, r8
+  LessInt      r13, r9, r8
+L0:
+  JumpIfFalse  r13, L0
 L1:
-  JumpIfFalse  r12, L0
   Index        r8, r7, r9
   // group by person.city into g
   Index        r7, r8, r2
-  Str          r13, r7
-  In           r14, r13, r10
-  JumpIfTrue   r14, L1
+  Str          r14, r7
+  In           r15, r14, r10
+  JumpIfTrue   r15, L1
+L4:
   // let stats = from person in people
-  Const        r14, []
-  Const        r15, "__group__"
-  Const        r16, true
-  Const        r17, "key"
+  Const        r15, []
+  Const        r16, "__group__"
+  Const        r17, true
+  Const        r18, "key"
   // group by person.city into g
-  Move         r18, r7
+  Move         r19, r7
   // let stats = from person in people
   Const        r7, "items"
-  Move         r19, r14
-  Const        r14, "count"
-  Const        r20, 0
-  Move         r21, r15
-  Move         r15, r16
+  Move         r20, r15
+  Const        r15, "count"
+  Const        r21, 0
+  Move         r22, r16
   Move         r16, r17
   Move         r17, r18
-  Move         r18, r7
-  Move         r7, r19
-  Move         r19, r14
-  Move         r14, r20
-  MakeMap      r20, 4, r21
-  SetIndex     r10, r13, r20
-  Append       r11, r11, r20
-  Const        r20, "items"
-  Index        r14, r10, r13
-  Index        r13, r14, r20
-  Append       r10, r13, r8
-  SetIndex     r14, r20, r10
+  Move         r18, r19
+  Move         r19, r7
+  Move         r7, r20
+  Move         r20, r15
+  Move         r15, r21
+  MakeMap      r21, 4, r22
+  SetIndex     r10, r14, r12
+  Append       r11, r11, r21
+  Const        r21, 1
+  AddInt       r12, r12, r21
+  Const        r12, "items"
+  Index        r15, r10, r14
+  Index        r14, r11, r15
+  Index        r15, r14, r12
+  Append       r10, r15, r8
+  SetIndex     r14, r12, r10
   Index        r10, r14, r4
-  Const        r13, 1
-  AddInt       r20, r10, r13
-  SetIndex     r14, r4, r20
-  AddInt       r9, r9, r13
+  AddInt       r15, r10, r21
+  SetIndex     r14, r4, r15
+  AddInt       r9, r9, r21
   Jump         L2
-  Const        r20, 0
-  Move         r10, r20
+  Const        r15, 0
+  Move         r10, r15
   Len          r14, r11
-  LessInt      r12, r10, r14
-  JumpIfFalse  r12, L3
-  Index        r12, r11, r10
+  LessInt      r13, r10, r14
+  JumpIfFalse  r13, L3
+  Index        r13, r11, r10
   // city: g.key,
   Const        r11, "city"
-  Index        r14, r12, r3
+  Index        r14, r13, r3
   // count: count(g),
   Const        r3, "count"
-  Index        r9, r12, r4
+  Index        r9, r13, r4
   // avg_age: avg(from p in g select p.age)
-  Const        r8, "avg_age"
-  Const        r19, []
-  IterPrep     r7, r12
-  Len          r12, r7
-  Move         r18, r20
-  LessInt      r20, r18, r12
-  JumpIfFalse  r20, L4
-  Index        r20, r7, r18
-  Index        r7, r20, r6
-  Append       r19, r19, r7
-  AddInt       r18, r18, r13
-  Jump         L5
-L4:
-  Avg          r20, r19
+  Const        r12, "avg_age"
+  Const        r8, []
+  IterPrep     r20, r13
+  Len          r13, r20
+  Move         r7, r15
+  LessInt      r15, r7, r13
+  JumpIfFalse  r15, L1
+  Index        r15, r20, r7
+  Index        r20, r15, r6
+  Append       r8, r8, r20
+  AddInt       r7, r7, r21
+  Jump         L4
+  Avg          r15, r8
   // city: g.key,
-  Move         r7, r11
-  Move         r19, r14
+  Move         r8, r11
+  Move         r20, r14
   // count: count(g),
   Move         r14, r3
   Move         r3, r9
   // avg_age: avg(from p in g select p.age)
-  Move         r11, r8
-  Move         r8, r20
+  Move         r9, r12
+  Move         r11, r15
   // select {
-  MakeMap      r20, 3, r7
+  MakeMap      r15, 3, r8
   // let stats = from person in people
-  Append       r1, r1, r20
-  AddInt       r10, r10, r13
-  Jump         L6
+  Append       r1, r1, r15
+  AddInt       r10, r10, r21
+  Jump         L5
   // print("--- People grouped by city ---")
-  Const        r20, "--- People grouped by city ---"
-  Print        r20
+  Const        r15, "--- People grouped by city ---"
+  Print        r15
   // for s in stats {
-  IterPrep     r20, r1
-  Len          r1, r20
-  Const        r8, 0
-  Less         r11, r8, r1
-  JumpIfFalse  r11, L7
-  Index        r11, r20, r8
+  IterPrep     r15, r1
+  Len          r1, r15
+  Const        r11, 0
+  Less         r9, r11, r1
+  JumpIfFalse  r9, L6
+  Index        r9, r15, r11
   // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
-  Index        r20, r11, r2
+  Index        r15, r9, r2
   Const        r2, ": count ="
-  Index        r1, r11, r4
+  Index        r1, r9, r4
   Const        r4, ", avg_age ="
-  Index        r3, r11, r5
-  PrintN       r20, 5, r20
+  Index        r3, r9, r5
+  PrintN       r15, 5, r15
   // for s in stats {
   Const        r3, 1
-  Add          r8, r8, r3
-  Jump         L8
-L7:
+  Add          r11, r11, r3
+  Jump         L3
+L6:
   Return       r0

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -1,127 +1,129 @@
-func main (regs=19)
+func main (regs=20)
   // let items = [
   Const        r0, [{"cat": "a", "flag": true, "val": 10}, {"cat": "a", "flag": false, "val": 5}, {"cat": "b", "flag": true, "val": 20}]
   // from i in items
   Const        r1, []
+L0:
   // group by i.cat into g
   Const        r2, "cat"
   // cat: g.key,
   Const        r3, "key"
+L5:
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
   Const        r4, "flag"
   Const        r5, "val"
-L6:
   // from i in items
   IterPrep     r6, r0
-  Len          r7, r6
 L7:
+  Len          r7, r6
   Const        r8, 0
-L8:
   MakeMap      r9, 0, r0
-L2:
   Const        r10, []
-L4:
-  LessInt      r11, r8, r7
-  JumpIfFalse  r11, L0
-  Index        r11, r6, r8
-L5:
+L2:
+  Const        r11, 0
+L6:
+  LessInt      r12, r8, r7
+  JumpIfFalse  r12, L0
+  Index        r12, r6, r8
   // group by i.cat into g
-  Index        r6, r11, r2
+  Index        r6, r12, r2
   Str          r2, r6
-  In           r7, r2, r9
 L1:
+  In           r7, r2, r9
   JumpIfTrue   r7, L1
   // from i in items
   Const        r7, []
-  Const        r12, "__group__"
-  Const        r13, true
-  Const        r14, "key"
+  Const        r13, "__group__"
+  Const        r14, true
+  Const        r15, "key"
   // group by i.cat into g
-  Move         r15, r6
+  Move         r16, r6
   // from i in items
   Const        r6, "items"
-  Move         r16, r7
+  Move         r17, r7
   Const        r7, "count"
-  Const        r17, 0
-  Move         r18, r12
-  Move         r12, r13
+  Const        r18, 0
+  Move         r19, r13
   Move         r13, r14
   Move         r14, r15
-  Move         r15, r6
-  Move         r6, r16
-  Move         r16, r7
-  Move         r7, r17
-  MakeMap      r17, 4, r18
-  SetIndex     r9, r2, r17
-  Const        r17, "items"
-  Index        r7, r9, r2
-  Index        r2, r7, r17
-  Append       r9, r2, r11
-  SetIndex     r7, r17, r9
+  Move         r15, r16
+  Move         r16, r6
+  Move         r6, r17
+  Move         r17, r7
+  Move         r7, r18
+  MakeMap      r18, 4, r19
+  SetIndex     r9, r2, r11
+  Append       r10, r10, r18
+  Const        r18, 1
+  Const        r7, "items"
+  Index        r17, r9, r2
+  Index        r2, r10, r17
+  Index        r17, r2, r7
+  Append       r9, r17, r12
+  SetIndex     r2, r7, r9
   Const        r9, "count"
-  Index        r2, r7, r9
-  Const        r17, 1
-  AddInt       r11, r2, r17
-  SetIndex     r7, r9, r11
-  AddInt       r8, r8, r17
+  Index        r17, r2, r9
+  AddInt       r7, r17, r18
+  SetIndex     r2, r9, r7
+  AddInt       r8, r8, r18
   Jump         L2
-L0:
-  Const        r11, 0
-  Move         r2, r11
-  Const        r9, 0
-  LessInt      r7, r2, r9
-  JumpIfFalse  r7, L3
-  Index        r7, r10, r2
+  Const        r7, 0
+  Move         r17, r7
+  Len          r9, r10
+  LessInt      r2, r17, r9
+  JumpIfFalse  r2, L3
+  Index        r2, r10, r17
   // cat: g.key,
   Const        r10, "cat"
-  Index        r9, r7, r3
+  Index        r9, r2, r3
   // share:
-  Const        r8, "share"
+  Const        r11, "share"
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r16, []
-  IterPrep     r6, r7
-  Len          r15, r6
-  Move         r14, r11
-  LessInt      r13, r14, r15
-  JumpIfFalse  r13, L4
-  Index        r13, r6, r14
-  Index        r6, r13, r4
-  JumpIfFalse  r6, L5
-  Append       r16, r16, r11
-  AddInt       r14, r14, r17
+  Const        r8, []
+  IterPrep     r12, r2
+  Len          r6, r12
+  Move         r16, r7
+  LessInt      r15, r16, r6
+  JumpIfFalse  r15, L4
+  Index        r15, r12, r16
+  Index        r12, r15, r4
+  JumpIfFalse  r12, L5
+  Append       r8, r8, r7
+  AddInt       r16, r16, r18
   Jump         L6
-  Sum          r6, r16
+L4:
+  Sum          r12, r8
   // sum(from x in g select x.val)
-  Const        r16, []
-  IterPrep     r14, r7
-  Len          r4, r14
-  Move         r15, r11
-  LessInt      r11, r15, r4
-  JumpIfFalse  r11, L7
-  Index        r13, r14, r15
-  Index        r11, r13, r5
-  Append       r16, r16, r11
-  AddInt       r15, r15, r17
-  Jump         L4
-  Sum          r15, r16
+  Const        r8, []
+  IterPrep     r16, r2
+  Len          r4, r16
+  Move         r6, r7
+  LessInt      r7, r6, r4
+  JumpIfFalse  r7, L0
+  Index        r15, r16, r6
+  Index        r7, r15, r5
+  Append       r8, r8, r7
+  AddInt       r6, r6, r18
+  Jump         L7
+  Sum          r6, r8
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Div          r11, r6, r15
+  Div          r8, r12, r6
   // cat: g.key,
-  Move         r15, r10
-  Move         r10, r9
+  Move         r7, r10
+  Move         r6, r9
   // share:
-  Move         r16, r8
-  Move         r8, r11
+  Move         r9, r11
+  Move         r12, r8
   // select {
-  MakeMap      r11, 2, r15
+  MakeMap      r8, 2, r7
   // sort by g.key
-  Index        r8, r7, r3
+  Index        r12, r2, r3
   // from i in items
-  Move         r7, r11
-  MakeList     r11, 2, r8
-  Append       r1, r1, r11
-  AddInt       r2, r2, r17
-  Jump         L8
+  Move         r2, r8
+  MakeList     r8, 2, r12
+  Append       r1, r1, r8
+  AddInt       r17, r17, r18
+  Jump         L2
 L3:
   // sort by g.key
   Sort         r1, r1

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -1,8 +1,9 @@
-func main (regs=17)
+func main (regs=18)
   // let people = [
   Const        r0, [{"city": "Paris", "name": "Alice"}, {"city": "Hanoi", "name": "Bob"}, {"city": "Paris", "name": "Charlie"}, {"city": "Hanoi", "name": "Diana"}, {"city": "Paris", "name": "Eve"}, {"city": "Hanoi", "name": "Frank"}, {"city": "Paris", "name": "George"}]
   // from p in people
   Const        r1, []
+L0:
   // group by p.city into g
   Const        r2, "city"
   // select { city: g.key, num: count(g) }
@@ -12,76 +13,78 @@ func main (regs=17)
   Len          r5, r4
   Const        r6, 0
   MakeMap      r7, 0, r0
-L2:
   Const        r8, []
-  LessInt      r9, r6, r5
-  JumpIfFalse  r9, L0
-  Index        r9, r4, r6
+L2:
+  Const        r9, 0
+  LessInt      r10, r6, r5
+  JumpIfFalse  r10, L0
+  Index        r10, r4, r6
   // group by p.city into g
-  Index        r4, r9, r2
+  Index        r4, r10, r2
   Str          r2, r4
-  In           r5, r2, r7
 L1:
+  In           r5, r2, r7
   JumpIfTrue   r5, L1
   // from p in people
   Const        r5, []
-  Const        r10, "__group__"
-  Const        r11, true
-  Const        r12, "key"
+  Const        r11, "__group__"
+  Const        r12, true
+  Const        r13, "key"
   // group by p.city into g
-  Move         r13, r4
+  Move         r14, r4
   // from p in people
   Const        r4, "items"
-  Move         r14, r5
+  Move         r15, r5
   Const        r5, "count"
-  Const        r15, 0
-  Move         r16, r10
-  Move         r10, r11
+  Const        r16, 0
+  Move         r17, r11
   Move         r11, r12
   Move         r12, r13
-  Move         r13, r4
-  Move         r4, r14
-  Move         r14, r5
-  Move         r5, r15
-  MakeMap      r15, 4, r16
-  SetIndex     r7, r2, r15
-  Const        r15, "items"
-  Index        r5, r7, r2
-  Index        r2, r5, r15
-  Append       r7, r2, r9
-  SetIndex     r5, r15, r7
+  Move         r13, r14
+  Move         r14, r4
+  Move         r4, r15
+  Move         r15, r5
+  Move         r5, r16
+  MakeMap      r16, 4, r17
+  SetIndex     r7, r2, r9
+  Append       r8, r8, r16
+  Const        r16, 1
+  Const        r5, "items"
+  Index        r15, r7, r2
+  Index        r2, r8, r15
+  Index        r15, r2, r5
+  Append       r7, r15, r10
+  SetIndex     r2, r5, r7
   Const        r7, "count"
-  Index        r2, r5, r7
-  Const        r15, 1
-  AddInt       r9, r2, r15
-  SetIndex     r5, r7, r9
-  AddInt       r6, r6, r15
+  Index        r15, r2, r7
+  AddInt       r5, r15, r16
+  SetIndex     r2, r7, r5
+  AddInt       r6, r6, r16
   Jump         L2
-L0:
-  Const        r9, 0
-  Const        r2, 0
-  LessInt      r5, r9, r2
-  JumpIfFalse  r5, L3
-  Index        r5, r8, r9
+  Const        r5, 0
+  Len          r15, r8
+  LessInt      r2, r5, r15
+  JumpIfFalse  r2, L3
+  Index        r2, r8, r5
   // having count(g) >= 4
-  Index        r8, r5, r7
-  Const        r2, 4
-  LessEq       r6, r2, r8
-  JumpIfFalse  r6, L3
+  Index        r8, r2, r7
+  Const        r15, 4
+  LessEq       r9, r15, r8
+  JumpIfFalse  r9, L3
   // select { city: g.key, num: count(g) }
-  Const        r6, "city"
-  Index        r2, r5, r3
+  Const        r9, "city"
+  Index        r8, r2, r3
   Const        r3, "num"
-  Index        r14, r5, r7
-  Move         r5, r6
-  Move         r6, r2
-  Move         r2, r3
-  Move         r3, r14
-  MakeMap      r14, 2, r5
+  Index        r6, r2, r7
+  Move         r2, r9
+  Move         r9, r8
+  Move         r8, r3
+  Move         r3, r6
+  MakeMap      r6, 2, r2
   // from p in people
-  Append       r1, r1, r14
-  AddInt       r9, r9, r15
-  Jump         L2
+  Append       r1, r1, r6
+  AddInt       r5, r5, r16
+  Jump         L1
 L3:
   // json(big)
   JSON         r1

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -1,135 +1,139 @@
-func main (regs=22)
+func main (regs=23)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-L2:
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from o in orders
   Const        r2, []
   // group by c.name into g
   Const        r3, "name"
+L1:
   // name: g.key,
   Const        r4, "key"
   // count: count(g)
   Const        r5, "count"
-L1:
+L3:
   // let stats = from o in orders
   MakeMap      r6, 0, r0
-L5:
+L2:
   Const        r7, []
-  IterPrep     r8, r1
-  Len          r1, r8
-L3:
-  Const        r9, 0
-  LessInt      r10, r9, r1
-  JumpIfFalse  r10, L0
+  Const        r8, 0
+  IterPrep     r9, r1
+  Len          r1, r9
+L5:
+  Const        r10, 0
 L0:
-  Index        r1, r8, r9
+  LessInt      r11, r10, r1
+  JumpIfFalse  r11, L0
+L4:
+  Index        r1, r9, r10
   // join from c in customers on o.customerId == c.id
-  IterPrep     r8, r0
-  Len          r11, r8
-  Const        r12, 0
-  LessInt      r13, r12, r11
-  JumpIfFalse  r13, L1
-  Index        r11, r8, r12
-  Const        r8, "customerId"
-  Index        r14, r1, r8
-  Const        r8, "id"
-  Index        r15, r11, r8
-  Equal        r8, r14, r15
-  JumpIfFalse  r8, L2
+  IterPrep     r9, r0
+  Len          r12, r9
+  Const        r13, 0
+  LessInt      r14, r13, r12
+  JumpIfFalse  r14, L1
+  Index        r12, r9, r13
+  Const        r9, "customerId"
+  Index        r15, r1, r9
+  Const        r9, "id"
+  Index        r16, r12, r9
+  Equal        r9, r15, r16
+  JumpIfFalse  r9, L2
   // let stats = from o in orders
-  Const        r8, "o"
-  Move         r15, r1
+  Const        r9, "o"
+  Move         r16, r1
   Const        r1, "c"
-  Move         r14, r11
-  MakeMap      r16, 2, r8
+  Move         r15, r12
+  MakeMap      r17, 2, r9
   // group by c.name into g
-  Index        r14, r11, r3
-  Str          r11, r14
-  In           r1, r11, r6
-  JumpIfTrue   r1, L1
+  Index        r15, r12, r3
+  Str          r12, r15
+  In           r1, r12, r6
+  JumpIfTrue   r1, L3
   // let stats = from o in orders
   Const        r1, []
-  Const        r15, "__group__"
-  Const        r8, true
-  Const        r17, "key"
+  Const        r16, "__group__"
+  Const        r9, true
+  Const        r18, "key"
   // group by c.name into g
-  Move         r18, r14
+  Move         r19, r15
   // let stats = from o in orders
-  Const        r14, "items"
-  Move         r19, r1
+  Const        r15, "items"
+  Move         r20, r1
   Const        r1, "count"
-  Const        r20, 0
-  Move         r21, r15
-  Move         r15, r8
-  Move         r8, r17
-  Move         r17, r18
-  Move         r18, r14
-  Move         r14, r19
-  Move         r19, r1
-  Move         r1, r20
-  MakeMap      r20, 4, r21
-  SetIndex     r6, r11, r20
-  Append       r7, r7, r20
-  Const        r20, "items"
-  Index        r1, r6, r11
-  Index        r11, r1, r20
-  Append       r6, r11, r16
-  SetIndex     r1, r20, r6
-  Index        r6, r1, r5
-  Const        r11, 1
-  AddInt       r20, r6, r11
-  SetIndex     r1, r5, r20
+  Const        r21, 0
+  Move         r22, r16
+  Move         r16, r9
+  Move         r9, r18
+  Move         r18, r19
+  Move         r19, r15
+  Move         r15, r20
+  Move         r20, r1
+  Move         r1, r21
+  MakeMap      r21, 4, r22
+  SetIndex     r6, r12, r8
+  Append       r7, r7, r21
+  Const        r21, 1
+  AddInt       r8, r8, r21
+  Const        r8, "items"
+  Index        r1, r6, r12
+  Index        r12, r7, r1
+  Index        r1, r12, r8
+  Append       r6, r1, r17
+  SetIndex     r12, r8, r6
+  Index        r6, r12, r5
+  AddInt       r1, r6, r21
+  SetIndex     r12, r5, r1
   // join from c in customers on o.customerId == c.id
-  AddInt       r12, r12, r11
-  Jump         L0
+  AddInt       r13, r13, r21
+  Jump         L4
   // let stats = from o in orders
-  AddInt       r9, r9, r11
-  Jump         L3
-  Const        r20, 0
+  AddInt       r10, r10, r21
+  Jump         L5
+  Const        r1, 0
   Len          r6, r7
-  LessInt      r1, r20, r6
-  JumpIfFalse  r1, L4
-  Index        r1, r7, r20
+  LessInt      r12, r1, r6
+  JumpIfFalse  r12, L6
+  Index        r12, r7, r1
   // name: g.key,
   Const        r7, "name"
-  Index        r6, r1, r4
+  Index        r6, r12, r4
   // count: count(g)
   Const        r4, "count"
-  Index        r13, r1, r5
+  Index        r14, r12, r5
   // name: g.key,
-  Move         r1, r7
+  Move         r12, r7
   Move         r7, r6
   // count: count(g)
   Move         r6, r4
-  Move         r4, r13
+  Move         r4, r14
   // select {
-  MakeMap      r13, 2, r1
+  MakeMap      r14, 2, r12
   // let stats = from o in orders
-  Append       r2, r2, r13
-  AddInt       r20, r20, r11
-  Jump         L5
-L4:
+  Append       r2, r2, r14
+  AddInt       r1, r1, r21
+  Jump         L3
+L6:
   // print("--- Orders per customer ---")
-  Const        r13, "--- Orders per customer ---"
-  Print        r13
+  Const        r14, "--- Orders per customer ---"
+  Print        r14
   // for s in stats {
-  IterPrep     r13, r2
-  Len          r2, r13
+  IterPrep     r14, r2
+  Len          r2, r14
   Const        r4, 0
-L7:
+L8:
   Less         r6, r4, r2
-  JumpIfFalse  r6, L6
-  Index        r6, r13, r4
+  JumpIfFalse  r6, L7
+  Index        r6, r14, r4
   // print(s.name, "orders:", s.count)
-  Index        r13, r6, r3
+  Index        r14, r6, r3
   Const        r3, "orders:"
   Index        r2, r6, r5
-  PrintN       r13, 3, r13
+  PrintN       r14, 3, r14
   // for s in stats {
   Const        r2, 1
   Add          r4, r4, r2
-  Jump         L7
-L6:
+  Jump         L8
+L7:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -1,11 +1,11 @@
-func main (regs=28)
+func main (regs=29)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from c in customers
   Const        r2, []
-L8:
+L10:
   // group by c.name into g
   Const        r3, "name"
   // name: g.key,
@@ -16,176 +16,184 @@ L8:
   // let stats = from c in customers
   MakeMap      r7, 0, r0
   Const        r8, []
-  IterPrep     r9, r0
-L2:
-  Len          r10, r9
-  Const        r11, 0
-L6:
-  LessInt      r12, r11, r10
-  JumpIfFalse  r12, L0
+  Const        r9, 0
+  IterPrep     r10, r0
+  Len          r11, r10
+  Const        r12, 0
+L7:
+  LessInt      r13, r12, r11
+  JumpIfFalse  r13, L0
 L4:
-  Index        r10, r9, r11
+  Index        r11, r10, r12
   // left join o in orders on o.customerId == c.id
-  IterPrep     r9, r1
+  IterPrep     r10, r1
+L2:
+  Len          r1, r10
 L1:
-  Len          r1, r9
-  Const        r13, 0
-L5:
-  LessInt      r14, r13, r1
-  JumpIfFalse  r14, L1
-  Index        r1, r9, r13
-  Const        r9, false
-  Const        r15, "customerId"
-  Index        r16, r1, r15
-  Const        r15, "id"
+  Const        r14, 0
 L3:
-  Index        r17, r10, r15
-L0:
-  Equal        r15, r16, r17
-  JumpIfFalse  r15, L2
-  Const        r9, true
+  LessInt      r15, r14, r1
+  JumpIfFalse  r15, L1
+L5:
+  Index        r1, r10, r14
+  Const        r10, false
+  Const        r16, "customerId"
+  Index        r17, r1, r16
+  Const        r16, "id"
+L11:
+  Index        r18, r11, r16
+  Equal        r16, r17, r18
+  JumpIfFalse  r16, L2
+  Const        r10, true
   // let stats = from c in customers
-  Const        r15, "c"
-  Move         r17, r10
-  Move         r16, r1
-  MakeMap      r1, 2, r15
+  Const        r16, "c"
+  Move         r18, r11
+  Move         r17, r1
+  MakeMap      r1, 2, r16
   // group by c.name into g
-  Index        r18, r10, r3
-  Str          r19, r18
-  In           r20, r19, r7
-  JumpIfTrue   r20, L3
+  Index        r19, r11, r3
+  Str          r20, r19
+  In           r21, r20, r7
+  JumpIfTrue   r21, L3
   // let stats = from c in customers
-  Const        r20, []
-  Const        r21, "__group__"
-  Const        r22, true
-  Const        r23, "key"
+  Const        r21, []
+  Const        r22, "__group__"
+  Const        r23, true
+  Const        r24, "key"
   // group by c.name into g
-  Move         r24, r18
+  Move         r25, r19
   // let stats = from c in customers
-  Const        r18, "items"
-  Move         r25, r20
-  Const        r20, "count"
-  Const        r26, 0
-  Move         r27, r21
-  Move         r21, r22
+  Const        r19, "items"
+  Move         r26, r21
+  Const        r21, "count"
+  Const        r27, 0
+  Move         r28, r22
   Move         r22, r23
   Move         r23, r24
-  Move         r24, r18
-  Move         r18, r25
-  Move         r25, r20
-  Move         r20, r26
-  MakeMap      r26, 4, r27
-  SetIndex     r7, r19, r26
-  Append       r8, r8, r26
-  Const        r26, "items"
-  Index        r20, r7, r19
-  Index        r19, r20, r26
-  Append       r25, r19, r1
-  SetIndex     r20, r26, r25
-  Index        r25, r20, r5
-  Const        r19, 1
-  AddInt       r18, r25, r19
-  SetIndex     r20, r5, r18
+  Move         r24, r25
+  Move         r25, r19
+  Move         r19, r26
+  Move         r26, r21
+  Move         r21, r27
+  MakeMap      r27, 4, r28
+  SetIndex     r7, r20, r9
+  Append       r8, r8, r27
+  Const        r27, 1
+  AddInt       r9, r9, r27
+  Const        r21, "items"
+  Index        r26, r7, r20
+  Index        r20, r8, r26
+  Index        r26, r20, r21
+  Append       r19, r26, r1
+  SetIndex     r20, r21, r19
+  Index        r19, r20, r5
+  AddInt       r26, r19, r27
+  SetIndex     r20, r5, r26
   // left join o in orders on o.customerId == c.id
-  AddInt       r13, r13, r19
+  AddInt       r14, r14, r27
   Jump         L4
-  Move         r18, r9
-  JumpIfTrue   r18, L5
+  Move         r26, r10
+  JumpIfTrue   r26, L5
   // let stats = from c in customers
-  MakeMap      r18, 2, r15
+  MakeMap      r26, 2, r16
   // group by c.name into g
-  Index        r1, r10, r3
-  Str          r10, r1
-  In           r16, r10, r7
-  JumpIfTrue   r16, L6
+  Index        r1, r11, r3
+  Str          r11, r1
+  In           r17, r11, r7
+  JumpIfTrue   r17, L6
   // let stats = from c in customers
-  Const        r16, []
-  Const        r17, "__group__"
-  Const        r15, true
-  Const        r9, "key"
+  Const        r17, []
+  Const        r18, "__group__"
+  Const        r16, true
+  Const        r10, "key"
   // group by c.name into g
-  Move         r25, r1
+  Move         r19, r1
   // let stats = from c in customers
   Const        r1, "items"
-  Move         r20, r16
-  Const        r16, "count"
-  Const        r14, 0
-  Move         r13, r17
-  Move         r17, r15
-  Move         r15, r9
-  Move         r9, r25
-  Move         r25, r1
+  Move         r20, r17
+  Const        r17, "count"
+  Const        r15, 0
+  Move         r14, r18
+  Move         r18, r16
+  Move         r16, r10
+  Move         r10, r19
+  Move         r19, r1
   Move         r1, r20
-  Move         r20, r16
-  Move         r16, r14
-  MakeMap      r14, 4, r13
-  SetIndex     r7, r10, r14
-  Append       r8, r8, r14
-  Index        r14, r7, r10
-  Index        r10, r14, r26
-  Append       r7, r10, r18
-  SetIndex     r14, r26, r7
-  Index        r7, r14, r5
-  AddInt       r10, r7, r19
-  SetIndex     r14, r5, r10
-  AddInt       r11, r11, r19
-  Jump         L6
-  Const        r10, 0
-  Move         r7, r10
-  Len          r14, r8
-  LessInt      r12, r7, r14
-  JumpIfFalse  r12, L7
-  Index        r12, r8, r7
+  Move         r20, r17
+  Move         r17, r15
+  MakeMap      r15, 4, r14
+  SetIndex     r7, r11, r9
+  Append       r8, r8, r15
+  AddInt       r9, r9, r27
+L6:
+  Index        r15, r7, r11
+  Index        r11, r8, r15
+  Index        r15, r11, r21
+  Append       r7, r15, r26
+  SetIndex     r11, r21, r7
+  Index        r7, r11, r5
+  AddInt       r15, r7, r27
+  SetIndex     r11, r5, r15
+  AddInt       r12, r12, r27
+  Jump         L7
+L0:
+  Const        r15, 0
+  Move         r7, r15
+  Len          r11, r8
+  LessInt      r13, r7, r11
+  JumpIfFalse  r13, L8
+  Index        r13, r8, r7
   // name: g.key,
   Const        r8, "name"
-  Index        r14, r12, r4
+  Index        r11, r13, r4
   // count: count(from r in g where r.o select r)
   Const        r4, "count"
-  Const        r11, []
-  IterPrep     r18, r12
-  Len          r12, r18
-  Move         r26, r10
-  LessInt      r10, r26, r12
-  JumpIfFalse  r10, L8
-  Index        r10, r18, r26
-  Index        r18, r10, r6
-  JumpIfFalse  r18, L4
-  Append       r11, r11, r10
-  AddInt       r26, r26, r19
-  Jump         L5
-  Count        r26, r11
-  // name: g.key,
-  Move         r11, r8
-  Move         r8, r14
-  // count: count(from r in g where r.o select r)
-  Move         r14, r4
-  Move         r4, r26
-  // select {
-  MakeMap      r26, 2, r11
-  // let stats = from c in customers
-  Append       r2, r2, r26
-  AddInt       r7, r7, r19
-  Jump         L2
-L7:
-  // print("--- Group Left Join ---")
-  Const        r18, "--- Group Left Join ---"
-  Print        r18
-  // for s in stats {
-  IterPrep     r26, r2
-  Len          r2, r26
-  Const        r4, 0
-L10:
-  Less         r14, r4, r2
-  JumpIfFalse  r14, L9
-  Index        r14, r26, r4
-  // print(s.name, "orders:", s.count)
-  Index        r26, r14, r3
-  Const        r3, "orders:"
-  Index        r2, r14, r5
-  PrintN       r26, 3, r26
-  // for s in stats {
-  Const        r2, 1
-  Add          r4, r4, r2
-  Jump         L10
+  Const        r12, []
+  IterPrep     r26, r13
+  Len          r13, r26
+  Move         r21, r15
+  LessInt      r15, r21, r13
+  JumpIfFalse  r15, L9
+  Index        r15, r26, r21
+  Index        r26, r15, r6
+  JumpIfFalse  r26, L10
+  Append       r12, r12, r15
+  AddInt       r21, r21, r27
+  Jump         L11
 L9:
+  Count        r15, r12
+  // name: g.key,
+  Move         r12, r8
+  Move         r8, r11
+  // count: count(from r in g where r.o select r)
+  Move         r11, r4
+  Move         r4, r15
+  // select {
+  MakeMap      r15, 2, r12
+  // let stats = from c in customers
+  Append       r2, r2, r15
+  AddInt       r7, r7, r27
+  Jump         L4
+L8:
+  // print("--- Group Left Join ---")
+  Const        r15, "--- Group Left Join ---"
+  Print        r15
+  // for s in stats {
+  IterPrep     r15, r2
+  Len          r26, r15
+  Const        r2, 0
+L13:
+  Less         r4, r2, r26
+  JumpIfFalse  r4, L12
+  Index        r4, r15, r2
+  // print(s.name, "orders:", s.count)
+  Index        r15, r4, r3
+  Const        r3, "orders:"
+  Index        r26, r4, r5
+  PrintN       r15, 3, r15
+  // for s in stats {
+  Const        r26, 1
+  Add          r2, r2, r26
+  Jump         L13
+L12:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=21)
+func main (regs=22)
   // let nations = [
   Const        r0, [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
   // let suppliers = [
@@ -7,23 +7,23 @@ func main (regs=21)
   Const        r2, [{"cost": 10, "part": 100, "qty": 2, "supplier": 1}, {"cost": 20, "part": 100, "qty": 1, "supplier": 2}, {"cost": 5, "part": 200, "qty": 3, "supplier": 1}]
   // from ps in partsupp
   Const        r3, []
+L0:
   // where n.name == "A"
   Const        r4, "name"
   // part: ps.part,
   Const        r5, "part"
   // value: ps.cost * ps.qty
   Const        r6, "value"
-L8:
   Const        r7, "cost"
   Const        r8, "qty"
 L1:
   // from ps in partsupp
   IterPrep     r9, r2
-L6:
   Len          r2, r9
   Const        r10, 0
 L2:
   Move         r11, r10
+L6:
   LessInt      r12, r11, r2
   JumpIfFalse  r12, L0
   Index        r2, r9, r11
@@ -33,7 +33,6 @@ L5:
   Len          r1, r9
 L4:
   Const        r13, "id"
-L0:
   Const        r14, "supplier"
   Move         r15, r10
   LessInt      r16, r15, r1
@@ -99,86 +98,89 @@ L3:
   Const        r12, 0
   MakeMap      r11, 0, r0
   Const        r9, []
-  LessInt      r19, r12, r3
-  JumpIfFalse  r19, L6
-  Index        r19, r15, r12
+  Const        r19, 0
+  LessInt      r4, r12, r3
+  JumpIfFalse  r4, L6
+  Index        r4, r15, r12
   // group by x.part into g
-  Index        r15, r19, r5
+  Index        r15, r4, r5
   Str          r5, r15
   In           r3, r5, r11
   JumpIfTrue   r3, L7
   // from x in filtered
   Const        r3, []
-  Const        r4, "__group__"
-  Const        r7, true
-  Const        r13, "key"
+  Const        r7, "__group__"
+  Const        r13, true
+  Const        r8, "key"
   // group by x.part into g
-  Move         r8, r15
+  Move         r14, r15
   // from x in filtered
   Const        r15, "items"
-  Move         r14, r3
+  Move         r1, r3
   Const        r3, "count"
-  Const        r1, 0
-  Move         r17, r4
-  Move         r4, r7
-  Move         r20, r13
-  Move         r13, r8
-  Move         r8, r15
-  Move         r15, r14
-  Move         r14, r3
-  Move         r3, r1
-  MakeMap      r1, 4, r17
-  SetIndex     r11, r5, r1
-  Append       r9, r9, r1
+  Const        r17, 0
+  Move         r20, r7
+  Move         r7, r13
+  Move         r21, r8
+  Move         r8, r14
+  Move         r14, r15
+  Move         r15, r1
+  Move         r1, r3
+  Move         r3, r17
+  MakeMap      r17, 4, r20
+  SetIndex     r11, r5, r19
+  Append       r9, r9, r17
+  AddInt       r19, r19, r2
 L7:
-  Const        r1, "items"
+  Const        r17, "items"
   Index        r3, r11, r5
-  Index        r5, r3, r1
-  Append       r11, r5, r19
-  SetIndex     r3, r1, r11
+  Index        r5, r9, r3
+  Index        r3, r5, r17
+  Append       r11, r3, r4
+  SetIndex     r5, r17, r11
   Const        r11, "count"
-  Index        r5, r3, r11
-  AddInt       r1, r5, r2
-  SetIndex     r3, r11, r1
+  Index        r3, r5, r11
+  AddInt       r17, r3, r2
+  SetIndex     r5, r11, r17
   AddInt       r12, r12, r2
-  Jump         L8
-  Move         r1, r10
-  Len          r5, r9
-  LessInt      r11, r1, r5
-  JumpIfFalse  r11, L9
-  Index        r11, r9, r1
+  Jump         L6
+  Move         r17, r10
+  Len          r3, r9
+  LessInt      r11, r17, r3
+  JumpIfFalse  r11, L8
+  Index        r11, r9, r17
   // part: g.key,
   Const        r9, "part"
-  Index        r5, r11, r16
+  Index        r3, r11, r16
   // total: sum(from r in g select r.value)
   Const        r16, "total"
-  Const        r3, []
-  IterPrep     r7, r11
-  Len          r11, r7
+  Const        r5, []
+  IterPrep     r13, r11
+  Len          r11, r13
   Move         r12, r10
-L11:
-  LessInt      r10, r12, r11
-  JumpIfFalse  r10, L10
-  Index        r10, r7, r12
-  Index        r7, r10, r6
-  Append       r3, r3, r7
-  AddInt       r12, r12, r2
-  Jump         L11
 L10:
-  Sum          r7, r3
-  // part: g.key,
-  Move         r3, r9
-  Move         r9, r5
-  // total: sum(from r in g select r.value)
-  Move         r5, r16
-  Move         r16, r7
-  // select {
-  MakeMap      r7, 2, r3
-  // from x in filtered
-  Append       r18, r18, r7
-  AddInt       r1, r1, r2
-  Jump         L8
+  LessInt      r10, r12, r11
+  JumpIfFalse  r10, L9
+  Index        r10, r13, r12
+  Index        r13, r10, r6
+  Append       r5, r5, r13
+  AddInt       r12, r12, r2
+  Jump         L10
 L9:
+  Sum          r13, r5
+  // part: g.key,
+  Move         r5, r9
+  Move         r9, r3
+  // total: sum(from r in g select r.value)
+  Move         r3, r16
+  Move         r16, r13
+  // select {
+  MakeMap      r10, 2, r5
+  // from x in filtered
+  Append       r18, r18, r10
+  AddInt       r17, r17, r2
+  Jump         L6
+L8:
   // print(grouped)
   Print        r18
   Return       r0

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -1,41 +1,41 @@
-func main (regs=34)
+func main (regs=35)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
   Const        r1, [{"c_acctbal": 100, "c_address": "123 St", "c_comment": "Loyal", "c_custkey": 1, "c_name": "Alice", "c_nationkey": 1, "c_phone": "123-456"}]
   // let orders = [
   Const        r2, [{"o_custkey": 1, "o_orderdate": "1993-10-15", "o_orderkey": 1000}, {"o_custkey": 1, "o_orderdate": "1994-01-02", "o_orderkey": 2000}]
-L5:
+L6:
   // let lineitem = [
   Const        r3, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 1000, "l_returnflag": "R"}, {"l_discount": 0, "l_extendedprice": 500, "l_orderkey": 2000, "l_returnflag": "N"}]
-L6:
+L0:
   // let start_date = "1993-10-01"
   Const        r4, "1993-10-01"
   // let end_date = "1994-01-01"
   Const        r5, "1994-01-01"
   // from c in customer
   Const        r6, []
-L3:
   // c_custkey: c.c_custkey,
   Const        r7, "c_custkey"
+L3:
   // c_name: c.c_name,
   Const        r8, "c_name"
   // c_acctbal: c.c_acctbal,
   Const        r9, "c_acctbal"
   // c_address: c.c_address,
   Const        r10, "c_address"
-L8:
   // c_phone: c.c_phone,
   Const        r11, "c_phone"
   // c_comment: c.c_comment,
   Const        r12, "c_comment"
   // n_name: n.n_name
   Const        r13, "n_name"
-L4:
+L5:
   // where o.o_orderdate >= start_date &&
   Const        r14, "o_orderdate"
   // l.l_returnflag == "R"
   Const        r15, "l_returnflag"
+L13:
   // c_custkey: g.key.c_custkey,
   Const        r16, "key"
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
@@ -44,59 +44,61 @@ L4:
   Const        r19, "l_discount"
   // from c in customer
   MakeMap      r20, 0, r0
-  Const        r21, []
-L2:
-  IterPrep     r22, r1
-L1:
-  Len          r1, r22
-  Const        r23, 0
-L0:
-  LessInt      r24, r23, r1
-L12:
-  JumpIfFalse  r24, L0
-  Index        r24, r22, r23
-  // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r23, r2
-  Len          r2, r23
 L9:
+  Const        r21, []
+L7:
   Const        r22, 0
-  LessInt      r1, r22, r2
+L2:
+  IterPrep     r23, r1
+L1:
+  Len          r1, r23
+L4:
+  Const        r24, 0
+  LessInt      r25, r24, r1
+L10:
+  JumpIfFalse  r25, L0
+  Index        r25, r23, r24
+  // join o in orders on o.o_custkey == c.c_custkey
+  IterPrep     r24, r2
+  Len          r2, r24
+  Const        r23, 0
+  LessInt      r1, r23, r2
   JumpIfFalse  r1, L1
-  Index        r1, r23, r22
-  Const        r22, "o_custkey"
-  Index        r23, r1, r22
-  Index        r22, r24, r7
-  Equal        r2, r23, r22
+  Index        r1, r24, r23
+  Const        r23, "o_custkey"
+  Index        r24, r1, r23
+  Index        r23, r25, r7
+  Equal        r2, r24, r23
   JumpIfFalse  r2, L2
   // join l in lineitem on l.l_orderkey == o.o_orderkey
   IterPrep     r2, r3
   Len          r3, r2
-  Const        r22, 0
-  LessInt      r23, r22, r3
-  JumpIfFalse  r23, L2
-  Index        r3, r2, r22
+  Const        r23, 0
+  LessInt      r24, r23, r3
+  JumpIfFalse  r24, L2
+  Index        r3, r2, r23
   Const        r2, "l_orderkey"
-  Index        r25, r3, r2
+  Index        r26, r3, r2
   Const        r2, "o_orderkey"
-  Index        r26, r1, r2
-  Equal        r2, r25, r26
+  Index        r27, r1, r2
+  Equal        r2, r26, r27
   JumpIfFalse  r2, L3
   // join n in nation on n.n_nationkey == c.c_nationkey
   IterPrep     r2, r0
-  Len          r26, r2
-  Const        r25, 0
-  LessInt      r27, r25, r26
-  JumpIfFalse  r27, L3
-  Index        r27, r2, r25
+  Len          r27, r2
+  Const        r26, 0
+  LessInt      r28, r26, r27
+  JumpIfFalse  r28, L3
+  Index        r28, r2, r26
   Const        r2, "n_nationkey"
-  Index        r26, r27, r2
+  Index        r27, r28, r2
   Const        r2, "c_nationkey"
-  Index        r28, r24, r2
-  Equal        r2, r26, r28
-  JumpIfFalse  r2, L3
+  Index        r29, r25, r2
+  Equal        r2, r27, r29
+  JumpIfFalse  r2, L4
   // where o.o_orderdate >= start_date &&
   Index        r2, r1, r14
-  LessEq       r28, r4, r2
+  LessEq       r29, r4, r2
   // o.o_orderdate < end_date &&
   Index        r2, r1, r14
   Less         r14, r2, r5
@@ -105,217 +107,219 @@ L9:
   Const        r15, "R"
   Equal        r5, r2, r15
   // where o.o_orderdate >= start_date &&
-  Move         r15, r28
-  JumpIfFalse  r15, L4
+  Move         r15, r29
+  JumpIfFalse  r15, L5
   // o.o_orderdate < end_date &&
   Move         r15, r14
-  JumpIfFalse  r15, L5
+  JumpIfFalse  r15, L6
   Move         r15, r5
   // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r15, L3
+  JumpIfFalse  r15, L4
   // from c in customer
   Const        r15, "c"
-  Move         r5, r24
+  Move         r5, r25
   Const        r14, "o"
-  Move         r28, r1
+  Move         r29, r1
   Move         r1, r3
   Const        r3, "n"
-  Move         r2, r27
+  Move         r2, r28
   MakeMap      r4, 4, r15
   // c_custkey: c.c_custkey,
   Const        r2, "c_custkey"
-  Index        r3, r24, r7
+  Index        r3, r25, r7
   // c_name: c.c_name,
   Const        r1, "c_name"
-  Index        r28, r24, r8
+  Index        r29, r25, r8
   // c_acctbal: c.c_acctbal,
   Const        r14, "c_acctbal"
-  Index        r5, r24, r9
+  Index        r5, r25, r9
   // c_address: c.c_address,
   Const        r15, "c_address"
-  Index        r26, r24, r10
+  Index        r27, r25, r10
   // c_phone: c.c_phone,
-  Const        r29, "c_phone"
-  Index        r30, r24, r11
+  Const        r30, "c_phone"
+  Index        r31, r25, r11
   // c_comment: c.c_comment,
-  Const        r31, "c_comment"
-  Index        r32, r24, r12
+  Const        r32, "c_comment"
+  Index        r33, r25, r12
   // n_name: n.n_name
-  Const        r24, "n_name"
-  Index        r33, r27, r13
+  Const        r25, "n_name"
+  Index        r34, r28, r13
   // c_custkey: c.c_custkey,
-  Move         r27, r2
+  Move         r28, r2
   Move         r2, r3
   // c_name: c.c_name,
   Move         r3, r1
-  Move         r1, r28
+  Move         r1, r29
   // c_acctbal: c.c_acctbal,
-  Move         r28, r14
+  Move         r29, r14
   Move         r14, r5
   // c_address: c.c_address,
   Move         r5, r15
-  Move         r15, r26
+  Move         r15, r27
   // c_phone: c.c_phone,
-  Move         r26, r29
-  Move         r29, r30
-  // c_comment: c.c_comment,
+  Move         r27, r30
   Move         r30, r31
+  // c_comment: c.c_comment,
   Move         r31, r32
+  Move         r32, r33
   // n_name: n.n_name
-  Move         r32, r24
-  Move         r24, r33
+  Move         r33, r25
+  Move         r25, r34
   // group by {
-  MakeMap      r33, 7, r27
-  Str          r24, r33
-  In           r32, r24, r20
-  JumpIfTrue   r32, L1
+  MakeMap      r34, 7, r28
+  Str          r25, r34
+  In           r33, r25, r20
+  JumpIfTrue   r33, L7
   // from c in customer
-  Const        r32, []
-  Const        r31, "__group__"
-  Const        r30, true
-  Const        r29, "key"
+  Const        r33, []
+  Const        r32, "__group__"
+  Const        r31, true
+  Const        r30, "key"
   // group by {
-  Move         r26, r33
+  Move         r27, r34
   // from c in customer
-  Const        r33, "items"
-  Move         r15, r32
-  Const        r32, "count"
+  Const        r34, "items"
+  Move         r15, r33
+  Const        r33, "count"
   Const        r5, 0
-  Move         r14, r31
+  Move         r14, r32
+  Move         r32, r31
   Move         r31, r30
-  Move         r30, r29
-  Move         r29, r26
-  Move         r26, r33
-  Move         r33, r15
-  Move         r15, r32
-  Move         r32, r5
+  Move         r30, r27
+  Move         r27, r34
+  Move         r34, r15
+  Move         r15, r33
+  Move         r33, r5
   MakeMap      r5, 4, r14
-  SetIndex     r20, r24, r5
+  SetIndex     r20, r25, r22
   Append       r21, r21, r5
-  Const        r5, "items"
-  Index        r32, r20, r24
-  Index        r24, r32, r5
-  Append       r20, r24, r4
-  SetIndex     r32, r5, r20
-  Const        r20, "count"
-  Index        r24, r32, r20
   Const        r5, 1
-  AddInt       r4, r24, r5
-  SetIndex     r32, r20, r4
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r25, r25, r5
-  Jump         L6
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
   AddInt       r22, r22, r5
+  Const        r22, "items"
+  Index        r33, r20, r25
+  Index        r25, r21, r33
+  Index        r33, r25, r22
+  Append       r20, r33, r4
+  SetIndex     r25, r22, r20
+  Const        r20, "count"
+  Index        r33, r25, r20
+  AddInt       r22, r33, r5
+  SetIndex     r25, r20, r22
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  AddInt       r26, r26, r5
+  Jump         L7
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  AddInt       r23, r23, r5
   Jump         L1
   // from c in customer
-  Const        r4, 0
-  Move         r23, r4
-  Len          r22, r21
-  LessInt      r24, r23, r22
-  JumpIfFalse  r24, L7
-  Index        r24, r21, r23
+  Const        r22, 0
+  Move         r24, r22
+  Len          r23, r21
+  LessInt      r33, r24, r23
+  JumpIfFalse  r33, L8
+  Index        r33, r21, r24
   // c_custkey: g.key.c_custkey,
   Const        r21, "c_custkey"
-  Index        r22, r24, r16
-  Index        r20, r22, r7
+  Index        r23, r33, r16
+  Index        r20, r23, r7
   // c_name: g.key.c_name,
-  Const        r22, "c_name"
-  Index        r7, r24, r16
-  Index        r32, r7, r8
+  Const        r23, "c_name"
+  Index        r7, r33, r16
+  Index        r25, r7, r8
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
   Const        r7, "revenue"
   Const        r8, []
-  IterPrep     r25, r24
-  Len          r15, r25
-  Move         r33, r4
-  LessInt      r26, r33, r15
-  JumpIfFalse  r26, L8
-  Index        r15, r25, r33
-  Index        r25, r15, r17
-  Index        r29, r25, r18
-  Index        r25, r15, r17
-  Index        r30, r25, r19
-  Sub          r25, r5, r30
-  Mul          r30, r29, r25
-  Append       r8, r8, r30
-  AddInt       r33, r33, r5
-  Jump         L9
-  Sum          r25, r8
+  IterPrep     r26, r33
+  Len          r4, r26
+  Move         r15, r22
+  LessInt      r34, r15, r4
+  JumpIfFalse  r34, L9
+  Index        r34, r26, r15
+  Index        r26, r34, r17
+  Index        r4, r26, r18
+  Index        r26, r34, r17
+  Index        r27, r26, r19
+  Sub          r26, r5, r27
+  Mul          r27, r4, r26
+  Append       r8, r8, r27
+  AddInt       r15, r15, r5
+  Jump         L10
+  Sum          r26, r8
   // c_acctbal: g.key.c_acctbal,
   Const        r8, "c_acctbal"
-  Index        r29, r24, r16
-  Index        r33, r29, r9
+  Index        r4, r33, r16
+  Index        r15, r4, r9
   // n_name: g.key.n_name,
-  Const        r30, "n_name"
-  Index        r29, r24, r16
-  Index        r9, r29, r13
+  Const        r4, "n_name"
+  Index        r27, r33, r16
+  Index        r9, r27, r13
   // c_address: g.key.c_address,
-  Const        r29, "c_address"
-  Index        r13, r24, r16
-  Index        r31, r13, r10
+  Const        r27, "c_address"
+  Index        r13, r33, r16
+  Index        r30, r13, r10
   // c_phone: g.key.c_phone,
   Const        r13, "c_phone"
-  Index        r10, r24, r16
-  Index        r14, r10, r11
+  Index        r10, r33, r16
+  Index        r31, r10, r11
   // c_comment: g.key.c_comment
   Const        r10, "c_comment"
-  Index        r11, r24, r16
+  Index        r11, r33, r16
   Index        r16, r11, r12
   // c_custkey: g.key.c_custkey,
   Move         r11, r21
   Move         r21, r20
   // c_name: g.key.c_name,
-  Move         r20, r22
-  Move         r22, r32
+  Move         r20, r23
+  Move         r23, r25
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r32, r7
-  Move         r7, r25
+  Move         r25, r7
+  Move         r7, r26
   // c_acctbal: g.key.c_acctbal,
-  Move         r25, r8
-  Move         r8, r33
+  Move         r26, r8
+  Move         r8, r15
   // n_name: g.key.n_name,
-  Move         r33, r30
-  Move         r30, r9
+  Move         r15, r4
+  Move         r4, r9
   // c_address: g.key.c_address,
-  Move         r9, r29
-  Move         r29, r31
+  Move         r9, r27
+  Move         r27, r30
   // c_phone: g.key.c_phone,
-  Move         r31, r13
-  Move         r13, r14
+  Move         r30, r13
+  Move         r13, r31
   // c_comment: g.key.c_comment
-  Move         r14, r10
+  Move         r31, r10
   Move         r10, r16
   // select {
   MakeMap      r16, 8, r11
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Const        r10, []
-  IterPrep     r14, r24
-  Len          r24, r14
-  Move         r13, r4
-L11:
-  LessInt      r4, r13, r24
-  JumpIfFalse  r4, L10
-  Index        r15, r14, r13
-  Index        r4, r15, r17
-  Index        r24, r4, r18
-  Index        r4, r15, r17
-  Index        r15, r4, r19
-  Sub          r4, r5, r15
-  Mul          r15, r24, r4
-  Append       r10, r10, r15
+  IterPrep     r31, r33
+  Len          r33, r31
+  Move         r13, r22
+L12:
+  LessInt      r22, r13, r33
+  JumpIfFalse  r22, L11
+  Index        r34, r31, r13
+  Index        r22, r34, r17
+  Index        r33, r22, r18
+  Index        r22, r34, r17
+  Index        r34, r22, r19
+  Sub          r22, r5, r34
+  Mul          r34, r33, r22
+  Append       r10, r10, r34
   AddInt       r13, r13, r5
-  Jump         L11
-L10:
-  Sum          r15, r10
-  Neg          r10, r15
+  Jump         L12
+L11:
+  Sum          r34, r10
+  Neg          r10, r34
   // from c in customer
-  Move         r15, r16
+  Move         r34, r16
   MakeList     r16, 2, r10
   Append       r6, r6, r16
-  AddInt       r23, r23, r5
-  Jump         L12
-L7:
+  AddInt       r24, r24, r5
+  Jump         L13
+L8:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r6, r6
   // print(result)

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,120 +1,123 @@
-func main (regs=18)
+func main (regs=19)
   // let items = [
   Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
   // from i in items
   Const        r1, []
+L0:
   // group by i.cat into g
   Const        r2, "cat"
-L4:
+L8:
   // cat: g.key,
   Const        r3, "key"
   // total: sum(from x in g select x.val)
   Const        r4, "val"
   // from i in items
   IterPrep     r5, r0
-  Len          r6, r5
-  Const        r7, 0
-L8:
-  MakeMap      r8, 0, r0
-L2:
-  Const        r9, []
 L7:
-  LessInt      r10, r7, r6
-  JumpIfFalse  r10, L0
-  Index        r10, r5, r7
-  // group by i.cat into g
-  Index        r5, r10, r2
-  Str          r2, r5
+  Len          r6, r5
 L5:
-  In           r6, r2, r8
+  Const        r7, 0
+L4:
+  MakeMap      r8, 0, r0
+  Const        r9, []
+L2:
+  Const        r10, 0
+  LessInt      r11, r7, r6
+  JumpIfFalse  r11, L0
+  Index        r11, r5, r7
+  // group by i.cat into g
+  Index        r5, r11, r2
+  Str          r2, r5
 L1:
+  In           r6, r2, r8
   JumpIfTrue   r6, L1
   // from i in items
   Const        r6, []
-  Const        r11, "__group__"
-  Const        r12, true
-  Const        r13, "key"
+  Const        r12, "__group__"
+  Const        r13, true
+  Const        r14, "key"
   // group by i.cat into g
-  Move         r14, r5
+  Move         r15, r5
   // from i in items
   Const        r5, "items"
-  Move         r15, r6
+  Move         r16, r6
   Const        r6, "count"
-  Const        r16, 0
-  Move         r17, r11
-  Move         r11, r12
+  Const        r17, 0
+  Move         r18, r12
   Move         r12, r13
   Move         r13, r14
-  Move         r14, r5
-  Move         r5, r15
-  Move         r15, r6
-  Move         r6, r16
-  MakeMap      r16, 4, r17
-  SetIndex     r8, r2, r16
-  Const        r16, "items"
-  Index        r6, r8, r2
-  Index        r2, r6, r16
-  Append       r8, r2, r10
-  SetIndex     r6, r16, r8
+  Move         r14, r15
+  Move         r15, r5
+  Move         r5, r16
+  Move         r16, r6
+  Move         r6, r17
+  MakeMap      r17, 4, r18
+  SetIndex     r8, r2, r10
+  Append       r9, r9, r17
+  Const        r17, 1
+  Const        r6, "items"
+  Index        r16, r8, r2
+  Index        r2, r9, r16
+  Index        r16, r2, r6
+  Append       r8, r16, r11
+  SetIndex     r2, r6, r8
   Const        r8, "count"
-  Index        r2, r6, r8
-  Const        r16, 1
-  AddInt       r10, r2, r16
-  SetIndex     r6, r8, r10
-  AddInt       r7, r7, r16
+  Index        r16, r2, r8
+  AddInt       r6, r16, r17
+  SetIndex     r2, r8, r6
+  AddInt       r7, r7, r17
   Jump         L2
-L0:
-  Const        r10, 0
-  Move         r2, r10
-  Const        r8, 0
-  LessInt      r6, r2, r8
-  JumpIfFalse  r6, L3
-  Index        r6, r9, r2
+  Const        r6, 0
+  Move         r16, r6
+  Len          r8, r9
+  LessInt      r2, r16, r8
+  JumpIfFalse  r2, L3
+  Index        r2, r9, r16
   // cat: g.key,
   Const        r9, "cat"
-  Index        r8, r6, r3
+  Index        r8, r2, r3
   // total: sum(from x in g select x.val)
   Const        r3, "total"
-  Const        r7, []
-  IterPrep     r15, r6
-  Len          r5, r15
-  Move         r14, r10
-  LessInt      r13, r14, r5
-  JumpIfFalse  r13, L4
-  Index        r13, r15, r14
-  Index        r15, r13, r4
-  Append       r7, r7, r15
-  AddInt       r14, r14, r16
+  Const        r10, []
+  IterPrep     r7, r2
+  Len          r11, r7
+  Move         r5, r6
+  LessInt      r15, r5, r11
+  JumpIfFalse  r15, L4
+  Index        r15, r7, r5
+  Index        r7, r15, r4
+  Append       r10, r10, r7
+  AddInt       r5, r5, r17
   Jump         L5
-  Sum          r15, r7
+  Sum          r7, r10
   // cat: g.key,
-  Move         r7, r9
+  Move         r10, r9
   Move         r9, r8
   // total: sum(from x in g select x.val)
-  Move         r14, r3
-  Move         r3, r15
+  Move         r8, r3
+  Move         r5, r7
   // select {
-  MakeMap      r15, 2, r7
+  MakeMap      r7, 2, r10
   // sort by -sum(from x in g select x.val)
-  Const        r3, []
-  IterPrep     r14, r6
-  Len          r6, r14
-  Move         r9, r10
-  LessInt      r10, r9, r6
-  JumpIfFalse  r10, L6
-  Index        r13, r14, r9
-  Index        r10, r13, r4
-  Append       r3, r3, r10
-  AddInt       r9, r9, r16
+  Const        r5, []
+  IterPrep     r8, r2
+  Len          r2, r8
+  Move         r9, r6
+  LessInt      r6, r9, r2
+  JumpIfFalse  r6, L6
+  Index        r15, r8, r9
+  Index        r6, r15, r4
+  Append       r5, r5, r6
+  AddInt       r9, r9, r17
   Jump         L7
 L6:
-  Sum          r9, r3
-  Neg          r10, r9
+  Sum          r9, r5
+  Neg          r5, r9
   // from i in items
-  Move         r9, r15
-  MakeList     r15, 2, r10
-  Append       r1, r1, r15
-  AddInt       r2, r2, r16
+  Move         r6, r7
+  MakeList     r9, 2, r5
+  Append       r1, r1, r9
+  AddInt       r16, r16, r17
   Jump         L8
 L3:
   // sort by -sum(from x in g select x.val)

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -1,129 +1,130 @@
-func main (regs=18)
+func main (regs=19)
   // let data = [
   Const        r0, [{"tag": "a", "val": 1}, {"tag": "a", "val": 2}, {"tag": "b", "val": 3}]
-L3:
   // let groups = from d in data group by d.tag into g select g
   Const        r1, []
   Const        r2, "tag"
-L6:
   IterPrep     r3, r0
   Len          r4, r3
-L7:
   Const        r5, 0
+L5:
   MakeMap      r6, 0, r0
   Const        r7, []
+L3:
+  Const        r8, 0
 L2:
-  LessInt      r8, r5, r4
+  LessInt      r9, r5, r4
+  JumpIfFalse  r9, L0
 L1:
-  JumpIfFalse  r8, L0
   Index        r4, r3, r5
   Index        r3, r4, r2
-  Str          r9, r3
-  In           r10, r9, r6
-  JumpIfTrue   r10, L1
-L4:
-  Const        r10, []
-  Const        r11, "__group__"
-  Const        r12, true
-  Const        r13, "key"
-  Move         r14, r3
+  Str          r10, r3
+  In           r11, r10, r6
+  JumpIfTrue   r11, L1
+  Const        r11, []
+  Const        r12, "__group__"
+  Const        r13, true
+  Const        r14, "key"
+  Move         r15, r3
   Const        r3, "items"
-  Move         r15, r10
-  Const        r10, "count"
-  Const        r16, 0
-  Move         r17, r11
-  Move         r11, r12
+  Move         r16, r11
+  Const        r11, "count"
+  Const        r17, 0
+  Move         r18, r12
   Move         r12, r13
   Move         r13, r14
-  Move         r14, r3
-  Move         r3, r15
-  Move         r15, r10
-  Move         r10, r16
-  MakeMap      r16, 4, r17
-  SetIndex     r6, r9, r16
-  Append       r7, r7, r16
-  Const        r16, "items"
-  Index        r10, r6, r9
-  Index        r9, r10, r16
-  Append       r6, r9, r4
-  SetIndex     r10, r16, r6
+  Move         r14, r15
+  Move         r15, r3
+  Move         r3, r16
+  Move         r16, r11
+  Move         r11, r17
+  MakeMap      r17, 4, r18
+  SetIndex     r6, r10, r8
+  Append       r7, r7, r17
+  Const        r17, 1
+  AddInt       r8, r8, r17
+  Const        r8, "items"
+  Index        r11, r6, r10
+  Index        r10, r7, r11
+  Index        r11, r10, r8
+  Append       r6, r11, r4
+  SetIndex     r10, r8, r6
   Const        r6, "count"
-  Index        r9, r10, r6
-  Const        r4, 1
-  AddInt       r15, r9, r4
-  SetIndex     r10, r6, r15
-  AddInt       r5, r5, r4
+  Index        r11, r10, r6
+  AddInt       r4, r11, r17
+  SetIndex     r10, r6, r4
+  AddInt       r5, r5, r17
   Jump         L2
 L0:
-  Const        r15, 0
-  Move         r9, r15
+  Const        r4, 0
+  Move         r11, r4
   Len          r6, r7
-  LessInt      r10, r9, r6
+  LessInt      r10, r11, r6
   JumpIfFalse  r10, L3
-  Index        r10, r7, r9
+  Index        r10, r7, r11
   Append       r1, r1, r10
-  AddInt       r9, r9, r4
+  AddInt       r11, r11, r17
   Jump         L1
   // var tmp = []
   Const        r7, []
   // for g in groups {
-  IterPrep     r9, r1
-  Len          r1, r9
-  Const        r6, 0
-  Less         r8, r6, r1
-  JumpIfFalse  r8, L4
-  Index        r10, r9, r6
+  IterPrep     r6, r1
+  Len          r11, r6
+  Const        r1, 0
+  Less         r9, r1, r11
+  JumpIfFalse  r9, L4
+  Index        r10, r6, r1
   // var total = 0
-  Move         r8, r15
+  Move         r9, r4
   // for x in g.items {
-  Index        r1, r10, r16
-  IterPrep     r16, r1
-  Len          r1, r16
-  Const        r9, 0
-  Less         r5, r9, r1
-  JumpIfFalse  r5, L5
-  Index        r1, r16, r9
+  Index        r6, r10, r8
+  IterPrep     r8, r6
+  Len          r6, r8
+  Const        r11, 0
+  Less         r5, r11, r6
+  JumpIfFalse  r5, L2
+  Index        r5, r8, r11
   // total = total + x.val
-  Const        r16, "val"
-  Index        r3, r1, r16
-  Add          r8, r8, r3
+  Const        r8, "val"
+  Index        r6, r5, r8
+  Add          r9, r9, r6
   // for x in g.items {
-  Const        r3, 1
-  Add          r9, r9, r3
-  Jump         L6
-L5:
+  Const        r6, 1
+  Add          r11, r11, r6
+  Jump         L5
   // tmp = append(tmp, {tag: g.key, total: total})
-  Const        r3, "tag"
-  Const        r9, "key"
-  Index        r16, r10, r9
-  Const        r9, "total"
-  Move         r10, r3
-  Move         r3, r16
-  Move         r16, r9
-  Move         r9, r8
-  MakeMap      r8, 2, r10
-  Append       r7, r7, r8
+  Const        r11, "tag"
+  Const        r6, "key"
+  Index        r8, r10, r6
+  Const        r6, "total"
+  Move         r10, r11
+  Move         r11, r8
+  Move         r8, r6
+  Move         r6, r9
+  MakeMap      r9, 2, r10
+  Append       r7, r7, r9
   // for g in groups {
-  Const        r8, 1
-  Add          r6, r6, r8
-  Jump         L7
+  Const        r9, 1
+  Add          r1, r1, r9
+  Jump         L2
+L4:
   // let result = from r in tmp sort by r.tag select r
-  Const        r8, []
-  IterPrep     r5, r7
-  Len          r7, r5
-  Move         r6, r15
-L9:
-  LessInt      r15, r6, r7
-  JumpIfFalse  r15, L8
-  Index        r15, r5, r6
-  Index        r5, r15, r2
-  Move         r2, r15
-  MakeList     r15, 2, r5
-  Append       r8, r8, r15
-  AddInt       r6, r6, r4
-  Jump         L9
-L8:
-  Sort         r8, r8
+  Const        r9, []
+  IterPrep     r1, r7
+  Len          r7, r1
+  Move         r6, r4
+L7:
+  LessInt      r4, r6, r7
+  JumpIfFalse  r4, L6
+  Index        r4, r1, r6
+  Index        r1, r4, r2
+  Move         r2, r4
+  MakeList     r4, 2, r1
+  Append       r9, r9, r4
+  AddInt       r6, r6, r17
+  Jump         L7
+L6:
+  Sort         r9, r9
   // print(result)
-  Print        r8
+  Print        r9
   Return       r0


### PR DESCRIPTION
## Summary
- optimize VM compiler for group queries by storing group index separately
- regenerate IR golden files

## Testing
- `go test -tags slow ./tests/vm -run TestVM_IR -update`


------
https://chatgpt.com/codex/tasks/task_e_68616031fb8083209432cdba77413783