### PR TITLE
Improve group by compilation

### DIFF
--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -1,13 +1,13 @@
-func main (regs=23)
+func main (regs=22)
   // let people = [
   Const        r0, [{"age": 30, "city": "Paris", "name": "Alice"}, {"age": 15, "city": "Hanoi", "name": "Bob"}, {"age": 65, "city": "Paris", "name": "Charlie"}, {"age": 45, "city": "Hanoi", "name": "Diana"}, {"age": 70, "city": "Paris", "name": "Eve"}, {"age": 22, "city": "Hanoi", "name": "Frank"}]
   // let stats = from person in people
   Const        r1, []
   // group by person.city into g
   Const        r2, "city"
-L3:
   // city: g.key,
   Const        r3, "key"
+L2:
   // count: count(g),
   Const        r4, "count"
   // avg_age: avg(from p in g select p.age)
@@ -16,120 +16,116 @@ L3:
   // let stats = from person in people
   IterPrep     r7, r0
   Len          r8, r7
+L5:
   Const        r9, 0
   MakeMap      r10, 0, r0
-  Const        r11, []
-L5:
-  Const        r12, 0
-L2:
-  LessInt      r13, r9, r8
 L0:
-  JumpIfFalse  r13, L0
+  LessInt      r11, r9, r8
 L1:
+  JumpIfFalse  r11, L0
   Index        r8, r7, r9
   // group by person.city into g
   Index        r7, r8, r2
-  Str          r14, r7
-  In           r15, r14, r10
-  JumpIfTrue   r15, L1
-L4:
+  Str          r12, r7
+  In           r13, r12, r10
+  JumpIfTrue   r13, L1
   // let stats = from person in people
-  Const        r15, []
-  Const        r16, "__group__"
-  Const        r17, true
-  Const        r18, "key"
+  Move         r13, r1
+L7:
+  Const        r14, "__group__"
+  Const        r15, true
+L4:
+  Move         r16, r3
   // group by person.city into g
-  Move         r19, r7
+  Move         r17, r7
   // let stats = from person in people
   Const        r7, "items"
-  Move         r20, r15
-  Const        r15, "count"
-  Const        r21, 0
-  Move         r22, r16
-  Move         r16, r17
-  Move         r17, r18
-  Move         r18, r19
-  Move         r19, r7
-  Move         r7, r20
-  Move         r20, r15
-  Move         r15, r21
-  MakeMap      r21, 4, r22
-  SetIndex     r10, r14, r12
-  Append       r11, r11, r21
-  Const        r21, 1
-  AddInt       r12, r12, r21
-  Const        r12, "items"
-  Index        r15, r10, r14
-  Index        r14, r11, r15
-  Index        r15, r14, r12
-  Append       r10, r15, r8
-  SetIndex     r14, r12, r10
-  Index        r10, r14, r4
-  AddInt       r15, r10, r21
-  SetIndex     r14, r4, r15
-  AddInt       r9, r9, r21
-  Jump         L2
-  Const        r15, 0
-  Move         r10, r15
-  Len          r14, r11
-  LessInt      r13, r10, r14
-  JumpIfFalse  r13, L3
-  Index        r13, r11, r10
-  // city: g.key,
-  Const        r11, "city"
-  Index        r14, r13, r3
-  // count: count(g),
-  Const        r3, "count"
-  Index        r9, r13, r4
-  // avg_age: avg(from p in g select p.age)
-  Const        r12, "avg_age"
-  Const        r8, []
-  IterPrep     r20, r13
-  Len          r13, r20
-  Move         r7, r15
-  LessInt      r15, r7, r13
-  JumpIfFalse  r15, L1
-  Index        r15, r20, r7
-  Index        r20, r15, r6
-  Append       r8, r8, r20
-  AddInt       r7, r7, r21
-  Jump         L4
-  Avg          r15, r8
-  // city: g.key,
-  Move         r8, r11
+  Move         r18, r13
+  Move         r13, r4
+  Move         r19, r9
   Move         r20, r14
+  Move         r14, r15
+  Move         r15, r16
+  Move         r16, r17
+  Move         r17, r7
+  Move         r21, r18
+  Move         r18, r13
+  Move         r13, r19
+  MakeMap      r19, 4, r20
+  SetIndex     r10, r12, r19
+  Move         r19, r7
+  Index        r7, r10, r12
+  Index        r12, r7, r19
+  Append       r13, r12, r8
+  SetIndex     r7, r19, r13
+  Index        r13, r7, r4
+  Const        r12, 1
+  AddInt       r19, r13, r12
+  SetIndex     r7, r4, r19
+  AddInt       r9, r9, r12
+  Jump         L0
+  Values       19,10,0,0
+  Const        r10, 0
+  Move         r13, r10
+  Len          r7, r19
+  LessInt      r11, r13, r7
+  JumpIfFalse  r11, L2
+  Index        r11, r19, r13
+  // city: g.key,
+  Move         r19, r2
+  Index        r7, r11, r3
   // count: count(g),
-  Move         r14, r3
+  Move         r3, r4
+  Index        r9, r11, r4
+  // avg_age: avg(from p in g select p.age)
+  Move         r8, r5
+  Move         r18, r1
+  IterPrep     r21, r11
+  Len          r11, r21
+  Move         r17, r10
+  LessInt      r16, r17, r11
+  JumpIfFalse  r16, L3
+  Index        r16, r21, r17
+  Index        r21, r16, r6
+  Append       r18, r18, r21
+  AddInt       r17, r17, r12
+  Jump         L4
+L3:
+  Avg          r16, r18
+  // city: g.key,
+  Move         r21, r19
+  Move         r18, r7
+  // count: count(g),
+  Move         r7, r3
   Move         r3, r9
   // avg_age: avg(from p in g select p.age)
-  Move         r9, r12
-  Move         r11, r15
+  Move         r19, r8
+  Move         r8, r16
   // select {
-  MakeMap      r15, 3, r8
+  MakeMap      r16, 3, r21
   // let stats = from person in people
-  Append       r1, r1, r15
-  AddInt       r10, r10, r21
+  Append       r1, r1, r16
+  AddInt       r13, r13, r12
   Jump         L5
   // print("--- People grouped by city ---")
-  Const        r15, "--- People grouped by city ---"
-  Print        r15
+  Const        r16, "--- People grouped by city ---"
+  Print        r16
   // for s in stats {
-  IterPrep     r15, r1
-  Len          r1, r15
-  Const        r11, 0
-  Less         r9, r11, r1
-  JumpIfFalse  r9, L6
-  Index        r9, r15, r11
+  IterPrep     r16, r1
+  Len          r1, r16
+  Move         r8, r10
+  Less         r10, r8, r1
+  JumpIfFalse  r10, L6
+  Index        r10, r16, r8
   // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
-  Index        r15, r9, r2
+  Index        r16, r10, r2
   Const        r2, ": count ="
-  Index        r1, r9, r4
+  Index        r1, r10, r4
   Const        r4, ", avg_age ="
-  Index        r3, r9, r5
-  PrintN       r15, 5, r15
+  Index        r19, r10, r5
+  PrintN       r16, 5, r16
   // for s in stats {
-  Const        r3, 1
-  Add          r11, r11, r3
-  Jump         L3
+  Add          r8, r8, r12
+  Jump         L7
 L6:
   Return       r0

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -1,129 +1,128 @@
-func main (regs=20)
+func main (regs=23)
   // let items = [
   Const        r0, [{"cat": "a", "flag": true, "val": 10}, {"cat": "a", "flag": false, "val": 5}, {"cat": "b", "flag": true, "val": 20}]
   // from i in items
   Const        r1, []
-L0:
   // group by i.cat into g
   Const        r2, "cat"
   // cat: g.key,
   Const        r3, "key"
-L5:
-  // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r4, "flag"
-  Const        r5, "val"
-  // from i in items
-  IterPrep     r6, r0
 L7:
-  Len          r7, r6
-  Const        r8, 0
-  MakeMap      r9, 0, r0
-  Const        r10, []
-L2:
-  Const        r11, 0
+  // share:
+  Const        r4, "share"
+  // sum(from x in g select if x.flag { x.val } else { 0 }) /
+  Const        r5, "flag"
+  Const        r6, "val"
+L0:
+  // from i in items
+  IterPrep     r7, r0
 L6:
-  LessInt      r12, r8, r7
-  JumpIfFalse  r12, L0
-  Index        r12, r6, r8
-  // group by i.cat into g
-  Index        r6, r12, r2
-  Str          r2, r6
+  Len          r8, r7
+  Const        r9, 0
+L4:
+  MakeMap      r10, 0, r0
+L2:
+  LessInt      r11, r9, r8
 L1:
-  In           r7, r2, r9
-  JumpIfTrue   r7, L1
-  // from i in items
-  Const        r7, []
-  Const        r13, "__group__"
-  Const        r14, true
-  Const        r15, "key"
+  JumpIfFalse  r11, L0
+  Index        r8, r7, r9
   // group by i.cat into g
-  Move         r16, r6
+  Index        r7, r8, r2
+  Str          r12, r7
+  In           r13, r12, r10
+  JumpIfTrue   r13, L1
   // from i in items
-  Const        r6, "items"
+  Move         r13, r1
+  Const        r14, "__group__"
+  Const        r15, true
+L5:
+  Move         r16, r3
+  // group by i.cat into g
   Move         r17, r7
-  Const        r7, "count"
-  Const        r18, 0
-  Move         r19, r13
-  Move         r13, r14
+  // from i in items
+  Const        r7, "items"
+  Move         r18, r13
+  Const        r13, "count"
+  Move         r19, r9
+  Move         r20, r14
   Move         r14, r15
   Move         r15, r16
-  Move         r16, r6
-  Move         r6, r17
+  Move         r16, r17
   Move         r17, r7
-  Move         r7, r18
-  MakeMap      r18, 4, r19
-  SetIndex     r9, r2, r11
-  Append       r10, r10, r18
-  Const        r18, 1
-  Const        r7, "items"
-  Index        r17, r9, r2
-  Index        r2, r10, r17
-  Index        r17, r2, r7
-  Append       r9, r17, r12
-  SetIndex     r2, r7, r9
-  Const        r9, "count"
-  Index        r17, r2, r9
-  AddInt       r7, r17, r18
-  SetIndex     r2, r9, r7
-  AddInt       r8, r8, r18
+  Move         r21, r18
+  Move         r18, r13
+  Move         r22, r19
+  MakeMap      r19, 4, r20
+  SetIndex     r10, r12, r19
+  Move         r19, r7
+  Index        r7, r10, r12
+  Index        r12, r7, r19
+  Append       r22, r12, r8
+  SetIndex     r7, r19, r22
+  Move         r22, r13
+  Index        r13, r7, r22
+  Const        r12, 1
+  AddInt       r19, r13, r12
+  SetIndex     r7, r22, r19
+  AddInt       r9, r9, r12
   Jump         L2
-  Const        r7, 0
-  Move         r17, r7
-  Len          r9, r10
-  LessInt      r2, r17, r9
-  JumpIfFalse  r2, L3
-  Index        r2, r10, r17
+  Values       19,10,0,0
+  Const        r10, 0
+  Move         r13, r10
+  Len          r22, r19
+  LessInt      r7, r13, r22
+  JumpIfFalse  r7, L3
+  Index        r7, r19, r13
   // cat: g.key,
-  Const        r10, "cat"
-  Index        r9, r2, r3
+  Move         r19, r2
+  Index        r2, r7, r3
   // share:
-  Const        r11, "share"
+  Move         r22, r4
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Const        r8, []
-  IterPrep     r12, r2
-  Len          r6, r12
-  Move         r16, r7
-  LessInt      r15, r16, r6
-  JumpIfFalse  r15, L4
-  Index        r15, r12, r16
-  Index        r12, r15, r4
-  JumpIfFalse  r12, L5
-  Append       r8, r8, r7
-  AddInt       r16, r16, r18
-  Jump         L6
-L4:
-  Sum          r12, r8
+  Move         r4, r1
+  IterPrep     r11, r7
+  Len          r9, r11
+  Move         r8, r10
+  LessInt      r18, r8, r9
+  JumpIfFalse  r18, L4
+  Index        r18, r11, r8
+  Index        r11, r18, r5
+  JumpIfFalse  r11, L5
+  Append       r4, r4, r10
+  AddInt       r8, r8, r12
+  Jump         L2
+  Sum          r11, r4
   // sum(from x in g select x.val)
-  Const        r8, []
-  IterPrep     r16, r2
-  Len          r4, r16
-  Move         r6, r7
-  LessInt      r7, r6, r4
-  JumpIfFalse  r7, L0
-  Index        r15, r16, r6
-  Index        r7, r15, r5
-  Append       r8, r8, r7
-  AddInt       r6, r6, r18
-  Jump         L7
-  Sum          r6, r8
+  Move         r8, r1
+  IterPrep     r5, r7
+  Len          r9, r5
+  Move         r21, r10
+  LessInt      r10, r21, r9
+  JumpIfFalse  r10, L6
+  Index        r18, r5, r21
+  Index        r10, r18, r6
+  Append       r8, r8, r10
+  AddInt       r21, r21, r12
+  Jump         L4
+  Sum          r21, r8
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Div          r8, r12, r6
+  Div          r8, r11, r21
   // cat: g.key,
-  Move         r7, r10
-  Move         r6, r9
+  Move         r21, r19
+  Move         r10, r2
   // share:
-  Move         r9, r11
-  Move         r12, r8
+  Move         r2, r22
+  Move         r22, r8
   // select {
-  MakeMap      r8, 2, r7
+  MakeMap      r8, 2, r21
   // sort by g.key
-  Index        r12, r2, r3
+  Index        r22, r7, r3
   // from i in items
-  Move         r2, r8
-  MakeList     r8, 2, r12
+  Move         r7, r8
+  MakeList     r8, 2, r22
   Append       r1, r1, r8
-  AddInt       r17, r17, r18
-  Jump         L2
+  AddInt       r13, r13, r12
+  Jump         L7
 L3:
   // sort by g.key
   Sort         r1, r1

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -1,90 +1,88 @@
-func main (regs=18)
+func main (regs=21)
   // let people = [
   Const        r0, [{"city": "Paris", "name": "Alice"}, {"city": "Hanoi", "name": "Bob"}, {"city": "Paris", "name": "Charlie"}, {"city": "Hanoi", "name": "Diana"}, {"city": "Paris", "name": "Eve"}, {"city": "Hanoi", "name": "Frank"}, {"city": "Paris", "name": "George"}]
   // from p in people
   Const        r1, []
-L0:
   // group by p.city into g
   Const        r2, "city"
   // select { city: g.key, num: count(g) }
   Const        r3, "key"
+  Const        r4, "num"
+L0:
   // from p in people
-  IterPrep     r4, r0
-  Len          r5, r4
-  Const        r6, 0
-  MakeMap      r7, 0, r0
-  Const        r8, []
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
+  MakeMap      r8, 0, r0
 L2:
-  Const        r9, 0
-  LessInt      r10, r6, r5
-  JumpIfFalse  r10, L0
-  Index        r10, r4, r6
-  // group by p.city into g
-  Index        r4, r10, r2
-  Str          r2, r4
+  LessInt      r9, r7, r6
 L1:
-  In           r5, r2, r7
-  JumpIfTrue   r5, L1
-  // from p in people
-  Const        r5, []
-  Const        r11, "__group__"
-  Const        r12, true
-  Const        r13, "key"
+  JumpIfFalse  r9, L0
+  Index        r6, r5, r7
   // group by p.city into g
-  Move         r14, r4
+  Index        r5, r6, r2
+  Str          r10, r5
+  In           r11, r10, r8
+  JumpIfTrue   r11, L1
   // from p in people
-  Const        r4, "items"
+  Move         r11, r1
+  Const        r12, "__group__"
+  Const        r13, true
+  Move         r14, r3
+  // group by p.city into g
   Move         r15, r5
-  Const        r5, "count"
-  Const        r16, 0
-  Move         r17, r11
-  Move         r11, r12
+  // from p in people
+  Const        r5, "items"
+  Move         r16, r11
+  Const        r11, "count"
+  Move         r17, r7
+  Move         r18, r12
   Move         r12, r13
   Move         r13, r14
-  Move         r14, r4
-  Move         r4, r15
+  Move         r14, r15
   Move         r15, r5
-  Move         r5, r16
-  MakeMap      r16, 4, r17
-  SetIndex     r7, r2, r9
-  Append       r8, r8, r16
-  Const        r16, 1
-  Const        r5, "items"
-  Index        r15, r7, r2
-  Index        r2, r8, r15
-  Index        r15, r2, r5
-  Append       r7, r15, r10
-  SetIndex     r2, r5, r7
-  Const        r7, "count"
-  Index        r15, r2, r7
-  AddInt       r5, r15, r16
-  SetIndex     r2, r7, r5
-  AddInt       r6, r6, r16
+  Move         r19, r16
+  Move         r16, r11
+  Move         r20, r17
+  MakeMap      r17, 4, r18
+  SetIndex     r8, r10, r17
+  Move         r17, r5
+  Index        r5, r8, r10
+  Index        r10, r5, r17
+  Append       r20, r10, r6
+  SetIndex     r5, r17, r20
+  Move         r20, r11
+  Index        r11, r5, r20
+  Const        r10, 1
+  AddInt       r17, r11, r10
+  SetIndex     r5, r20, r17
+  AddInt       r7, r7, r10
   Jump         L2
-  Const        r5, 0
-  Len          r15, r8
-  LessInt      r2, r5, r15
-  JumpIfFalse  r2, L3
-  Index        r2, r8, r5
+  Values       17,8,0,0
+  Const        r8, 0
+  Len          r11, r17
+  LessInt      r5, r8, r11
+  JumpIfFalse  r5, L3
+  Index        r5, r17, r8
   // having count(g) >= 4
-  Index        r8, r2, r7
-  Const        r15, 4
-  LessEq       r9, r15, r8
+  Index        r17, r5, r20
+  Const        r11, 4
+  LessEq       r9, r11, r17
   JumpIfFalse  r9, L3
   // select { city: g.key, num: count(g) }
-  Const        r9, "city"
-  Index        r8, r2, r3
-  Const        r3, "num"
-  Index        r6, r2, r7
-  Move         r2, r9
-  Move         r9, r8
-  Move         r8, r3
-  Move         r3, r6
-  MakeMap      r6, 2, r2
+  Move         r11, r2
+  Index        r2, r5, r3
+  Move         r3, r4
+  Index        r4, r5, r20
+  Move         r5, r11
+  Move         r11, r2
+  Move         r2, r3
+  Move         r3, r4
+  MakeMap      r4, 2, r5
   // from p in people
-  Append       r1, r1, r6
-  AddInt       r5, r5, r16
-  Jump         L1
+  Append       r1, r1, r4
+  AddInt       r8, r8, r10
+  Jump         L2
 L3:
   // json(big)
   JSON         r1

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -1,139 +1,134 @@
 func main (regs=23)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+L3:
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from o in orders
   Const        r2, []
   // group by c.name into g
   Const        r3, "name"
-L1:
+L0:
   // name: g.key,
   Const        r4, "key"
   // count: count(g)
   Const        r5, "count"
-L3:
   // let stats = from o in orders
   MakeMap      r6, 0, r0
-L2:
-  Const        r7, []
-  Const        r8, 0
-  IterPrep     r9, r1
-  Len          r1, r9
+  IterPrep     r7, r1
+  Len          r1, r7
 L5:
-  Const        r10, 0
-L0:
-  LessInt      r11, r10, r1
-  JumpIfFalse  r11, L0
+  Const        r8, 0
+  LessInt      r9, r8, r1
+  JumpIfFalse  r9, L0
 L4:
-  Index        r1, r9, r10
+  Index        r1, r7, r8
   // join from c in customers on o.customerId == c.id
-  IterPrep     r9, r0
-  Len          r12, r9
-  Const        r13, 0
-  LessInt      r14, r13, r12
-  JumpIfFalse  r14, L1
-  Index        r12, r9, r13
-  Const        r9, "customerId"
-  Index        r15, r1, r9
-  Const        r9, "id"
-  Index        r16, r12, r9
-  Equal        r9, r15, r16
-  JumpIfFalse  r9, L2
+  IterPrep     r7, r0
+  Len          r10, r7
+  Move         r11, r8
+  LessInt      r12, r11, r10
+  JumpIfFalse  r12, L1
+  Index        r10, r7, r11
+  Const        r7, "customerId"
+  Index        r13, r1, r7
+  Const        r7, "id"
+L1:
+  Index        r14, r10, r7
+  Equal        r7, r13, r14
+  JumpIfFalse  r7, L2
   // let stats = from o in orders
-  Const        r9, "o"
-  Move         r16, r1
+  Const        r7, "o"
+  Move         r14, r1
   Const        r1, "c"
-  Move         r15, r12
-  MakeMap      r17, 2, r9
+  Move         r13, r10
+  MakeMap      r15, 2, r7
   // group by c.name into g
-  Index        r15, r12, r3
-  Str          r12, r15
-  In           r1, r12, r6
+  Index        r13, r10, r3
+  Str          r10, r13
+  In           r1, r10, r6
   JumpIfTrue   r1, L3
   // let stats = from o in orders
-  Const        r1, []
-  Const        r16, "__group__"
-  Const        r9, true
-  Const        r18, "key"
+  Move         r1, r2
+  Const        r14, "__group__"
+  Const        r7, true
+  Move         r16, r4
   // group by c.name into g
-  Move         r19, r15
+  Move         r17, r13
   // let stats = from o in orders
-  Const        r15, "items"
-  Move         r20, r1
-  Const        r1, "count"
-  Const        r21, 0
-  Move         r22, r16
-  Move         r16, r9
-  Move         r9, r18
-  Move         r18, r19
-  Move         r19, r15
-  Move         r15, r20
-  Move         r20, r1
-  Move         r1, r21
-  MakeMap      r21, 4, r22
-  SetIndex     r6, r12, r8
-  Append       r7, r7, r21
-  Const        r21, 1
-  AddInt       r8, r8, r21
-  Const        r8, "items"
-  Index        r1, r6, r12
-  Index        r12, r7, r1
-  Index        r1, r12, r8
-  Append       r6, r1, r17
-  SetIndex     r12, r8, r6
-  Index        r6, r12, r5
-  AddInt       r1, r6, r21
-  SetIndex     r12, r5, r1
+  Const        r13, "items"
+  Move         r18, r1
+  Move         r1, r5
+  Move         r19, r8
+  Move         r20, r14
+  Move         r14, r7
+  Move         r7, r16
+  Move         r16, r17
+  Move         r17, r13
+  Move         r21, r18
+  Move         r18, r1
+  Move         r1, r19
+  MakeMap      r22, 4, r20
+  SetIndex     r6, r10, r22
+  Move         r22, r13
+  Index        r13, r6, r10
+  Index        r10, r13, r22
+  Append       r1, r10, r15
+  SetIndex     r13, r22, r1
+  Index        r1, r13, r5
+  Const        r10, 1
+  AddInt       r22, r1, r10
+  SetIndex     r13, r5, r22
+L2:
   // join from c in customers on o.customerId == c.id
-  AddInt       r13, r13, r21
+  AddInt       r11, r11, r10
   Jump         L4
   // let stats = from o in orders
-  AddInt       r10, r10, r21
+  AddInt       r8, r8, r10
   Jump         L5
-  Const        r1, 0
-  Len          r6, r7
-  LessInt      r12, r1, r6
-  JumpIfFalse  r12, L6
-  Index        r12, r7, r1
+  Values       22,6,0,0
+  Move         r6, r19
+  Len          r19, r22
+  LessInt      r1, r6, r19
+  JumpIfFalse  r1, L6
+  Index        r1, r22, r6
   // name: g.key,
-  Const        r7, "name"
-  Index        r6, r12, r4
+  Move         r22, r3
+  Index        r19, r1, r4
   // count: count(g)
-  Const        r4, "count"
-  Index        r14, r12, r5
+  Move         r4, r5
+  Index        r13, r1, r5
   // name: g.key,
-  Move         r12, r7
-  Move         r7, r6
+  Move         r1, r22
+  Move         r22, r19
   // count: count(g)
-  Move         r6, r4
-  Move         r4, r14
+  Move         r19, r4
+  Move         r4, r13
   // select {
-  MakeMap      r14, 2, r12
+  MakeMap      r13, 2, r1
   // let stats = from o in orders
-  Append       r2, r2, r14
-  AddInt       r1, r1, r21
-  Jump         L3
+  Append       r2, r2, r13
+  AddInt       r6, r6, r10
+  Jump         L1
 L6:
   // print("--- Orders per customer ---")
-  Const        r14, "--- Orders per customer ---"
-  Print        r14
+  Const        r13, "--- Orders per customer ---"
+  Print        r13
   // for s in stats {
-  IterPrep     r14, r2
-  Len          r2, r14
+  IterPrep     r13, r2
+  Len          r2, r13
   Const        r4, 0
 L8:
-  Less         r6, r4, r2
-  JumpIfFalse  r6, L7
-  Index        r6, r14, r4
+  Less         r19, r4, r2
+  JumpIfFalse  r19, L7
+  Index        r19, r13, r4
   // print(s.name, "orders:", s.count)
-  Index        r14, r6, r3
+  Index        r13, r19, r3
   Const        r3, "orders:"
-  Index        r2, r6, r5
-  PrintN       r14, 3, r14
+  Index        r2, r19, r5
+  PrintN       r13, 3, r13
   // for s in stats {
-  Const        r2, 1
-  Add          r4, r4, r2
+  Add          r4, r4, r10
   Jump         L8
 L7:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -1,11 +1,11 @@
-func main (regs=29)
+func main (regs=30)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from c in customers
   Const        r2, []
-L10:
+L7:
   // group by c.name into g
   Const        r3, "name"
   // name: g.key,
@@ -13,187 +13,177 @@ L10:
   // count: count(from r in g where r.o select r)
   Const        r5, "count"
   Const        r6, "o"
+L8:
   // let stats = from c in customers
   MakeMap      r7, 0, r0
-  Const        r8, []
-  Const        r9, 0
-  IterPrep     r10, r0
-  Len          r11, r10
-  Const        r12, 0
-L7:
-  LessInt      r13, r12, r11
-  JumpIfFalse  r13, L0
-L4:
-  Index        r11, r10, r12
-  // left join o in orders on o.customerId == c.id
-  IterPrep     r10, r1
+  IterPrep     r8, r0
 L2:
-  Len          r1, r10
-L1:
-  Const        r14, 0
-L3:
-  LessInt      r15, r14, r1
-  JumpIfFalse  r15, L1
-L5:
-  Index        r1, r10, r14
-  Const        r10, false
-  Const        r16, "customerId"
-  Index        r17, r1, r16
-  Const        r16, "id"
-L11:
-  Index        r18, r11, r16
-  Equal        r16, r17, r18
-  JumpIfFalse  r16, L2
-  Const        r10, true
-  // let stats = from c in customers
-  Const        r16, "c"
-  Move         r18, r11
-  Move         r17, r1
-  MakeMap      r1, 2, r16
-  // group by c.name into g
-  Index        r19, r11, r3
-  Str          r20, r19
-  In           r21, r20, r7
-  JumpIfTrue   r21, L3
-  // let stats = from c in customers
-  Const        r21, []
-  Const        r22, "__group__"
-  Const        r23, true
-  Const        r24, "key"
-  // group by c.name into g
-  Move         r25, r19
-  // let stats = from c in customers
-  Const        r19, "items"
-  Move         r26, r21
-  Const        r21, "count"
-  Const        r27, 0
-  Move         r28, r22
-  Move         r22, r23
-  Move         r23, r24
-  Move         r24, r25
-  Move         r25, r19
-  Move         r19, r26
-  Move         r26, r21
-  Move         r21, r27
-  MakeMap      r27, 4, r28
-  SetIndex     r7, r20, r9
-  Append       r8, r8, r27
-  Const        r27, 1
-  AddInt       r9, r9, r27
-  Const        r21, "items"
-  Index        r26, r7, r20
-  Index        r20, r8, r26
-  Index        r26, r20, r21
-  Append       r19, r26, r1
-  SetIndex     r20, r21, r19
-  Index        r19, r20, r5
-  AddInt       r26, r19, r27
-  SetIndex     r20, r5, r26
-  // left join o in orders on o.customerId == c.id
-  AddInt       r14, r14, r27
-  Jump         L4
-  Move         r26, r10
-  JumpIfTrue   r26, L5
-  // let stats = from c in customers
-  MakeMap      r26, 2, r16
-  // group by c.name into g
-  Index        r1, r11, r3
-  Str          r11, r1
-  In           r17, r11, r7
-  JumpIfTrue   r17, L6
-  // let stats = from c in customers
-  Const        r17, []
-  Const        r18, "__group__"
-  Const        r16, true
-  Const        r10, "key"
-  // group by c.name into g
-  Move         r19, r1
-  // let stats = from c in customers
-  Const        r1, "items"
-  Move         r20, r17
-  Const        r17, "count"
-  Const        r15, 0
-  Move         r14, r18
-  Move         r18, r16
-  Move         r16, r10
-  Move         r10, r19
-  Move         r19, r1
-  Move         r1, r20
-  Move         r20, r17
-  Move         r17, r15
-  MakeMap      r15, 4, r14
-  SetIndex     r7, r11, r9
-  Append       r8, r8, r15
-  AddInt       r9, r9, r27
-L6:
-  Index        r15, r7, r11
-  Index        r11, r8, r15
-  Index        r15, r11, r21
-  Append       r7, r15, r26
-  SetIndex     r11, r21, r7
-  Index        r7, r11, r5
-  AddInt       r15, r7, r27
-  SetIndex     r11, r5, r15
-  AddInt       r12, r12, r27
-  Jump         L7
+  Len          r9, r8
+  Const        r10, 0
 L0:
-  Const        r15, 0
-  Move         r7, r15
-  Len          r11, r8
-  LessInt      r13, r7, r11
-  JumpIfFalse  r13, L8
-  Index        r13, r8, r7
-  // name: g.key,
-  Const        r8, "name"
-  Index        r11, r13, r4
-  // count: count(from r in g where r.o select r)
-  Const        r4, "count"
-  Const        r12, []
-  IterPrep     r26, r13
-  Len          r13, r26
-  Move         r21, r15
-  LessInt      r15, r21, r13
-  JumpIfFalse  r15, L9
-  Index        r15, r26, r21
-  Index        r26, r15, r6
-  JumpIfFalse  r26, L10
-  Append       r12, r12, r15
-  AddInt       r21, r21, r27
-  Jump         L11
+  LessInt      r11, r10, r9
+  JumpIfFalse  r11, L0
+L4:
+  Index        r9, r8, r10
+  // left join o in orders on o.customerId == c.id
+  IterPrep     r8, r1
+L1:
+  Len          r1, r8
+  Move         r12, r10
+  LessInt      r13, r12, r1
+  JumpIfFalse  r13, L1
+L5:
+  Index        r1, r8, r12
+  Const        r8, false
+  Const        r14, "customerId"
+  Index        r15, r1, r14
+  Const        r14, "id"
+L3:
+  Index        r16, r9, r14
+  Equal        r14, r15, r16
+  JumpIfFalse  r14, L2
+  Const        r8, true
 L9:
-  Count        r15, r12
-  // name: g.key,
-  Move         r12, r8
-  Move         r8, r11
-  // count: count(from r in g where r.o select r)
-  Move         r11, r4
-  Move         r4, r15
-  // select {
-  MakeMap      r15, 2, r12
   // let stats = from c in customers
-  Append       r2, r2, r15
-  AddInt       r7, r7, r27
+  Const        r14, "c"
+  Move         r16, r9
+  Move         r15, r1
+  MakeMap      r1, 2, r14
+  // group by c.name into g
+  Index        r17, r9, r3
+  Str          r18, r17
+  In           r19, r18, r7
+  JumpIfTrue   r19, L3
+  // let stats = from c in customers
+  Move         r19, r2
+  Const        r20, "__group__"
+  Move         r21, r8
+  Move         r22, r4
+  // group by c.name into g
+  Move         r23, r17
+  // let stats = from c in customers
+  Const        r17, "items"
+  Move         r24, r19
+  Move         r19, r5
+  Move         r25, r10
+  Move         r26, r20
+  Move         r27, r21
+  Move         r21, r22
+  Move         r22, r23
+  Move         r23, r17
+  Move         r28, r24
+  Move         r24, r19
+  Move         r19, r25
+  MakeMap      r29, 4, r26
+  SetIndex     r7, r18, r29
+  Move         r29, r17
+  Index        r19, r7, r18
+  Index        r18, r19, r29
+  Append       r24, r18, r1
+  SetIndex     r19, r29, r24
+  Index        r24, r19, r5
+  Const        r18, 1
+  AddInt       r28, r24, r18
+  SetIndex     r19, r5, r28
+  // left join o in orders on o.customerId == c.id
+  AddInt       r12, r12, r18
   Jump         L4
-L8:
+  Move         r28, r8
+  JumpIfTrue   r28, L3
+  // let stats = from c in customers
+  MakeMap      r28, 2, r14
+  // group by c.name into g
+  Index        r1, r9, r3
+  Str          r9, r1
+  In           r15, r9, r7
+  JumpIfTrue   r15, L5
+  // let stats = from c in customers
+  Move         r15, r2
+  Move         r16, r20
+  Move         r20, r8
+  Move         r8, r4
+  // group by c.name into g
+  Move         r14, r1
+  // let stats = from c in customers
+  Move         r1, r17
+  Move         r17, r15
+  Move         r24, r5
+  Move         r19, r25
+  Move         r25, r16
+  Move         r16, r20
+  Move         r20, r8
+  Move         r8, r14
+  Move         r14, r1
+  Move         r1, r17
+  Move         r17, r24
+  Move         r13, r19
+  MakeMap      r19, 4, r25
+  SetIndex     r7, r9, r19
+  Index        r19, r7, r9
+  Index        r9, r19, r29
+  Append       r13, r9, r28
+  SetIndex     r19, r29, r13
+  Index        r13, r19, r5
+  AddInt       r9, r13, r18
+  SetIndex     r19, r5, r9
+  AddInt       r10, r10, r18
+  Jump         L0
+  Values       9,7,0,0
+  Const        r7, 0
+  Move         r13, r7
+  Len          r19, r9
+  LessInt      r11, r13, r19
+  JumpIfFalse  r11, L6
+  Index        r11, r9, r13
+  // name: g.key,
+  Move         r9, r3
+  Index        r19, r11, r4
+  // count: count(from r in g where r.o select r)
+  Move         r4, r24
+  Move         r24, r15
+  IterPrep     r15, r11
+  Len          r11, r15
+  Move         r10, r7
+  LessInt      r28, r10, r11
+  JumpIfFalse  r28, L7
+  Index        r28, r15, r10
+  Index        r15, r28, r6
+  JumpIfFalse  r15, L8
+  Append       r24, r24, r28
+  AddInt       r10, r10, r18
+  Jump         L1
+  Count        r10, r24
+  // name: g.key,
+  Move         r24, r9
+  Move         r9, r19
+  // count: count(from r in g where r.o select r)
+  Move         r19, r4
+  Move         r4, r10
+  // select {
+  MakeMap      r10, 2, r24
+  // let stats = from c in customers
+  Append       r2, r2, r10
+  AddInt       r13, r13, r18
+  Jump         L9
+L6:
   // print("--- Group Left Join ---")
   Const        r15, "--- Group Left Join ---"
   Print        r15
   // for s in stats {
-  IterPrep     r15, r2
-  Len          r26, r15
-  Const        r2, 0
-L13:
-  Less         r4, r2, r26
-  JumpIfFalse  r4, L12
-  Index        r4, r15, r2
+  IterPrep     r10, r2
+  Len          r2, r10
+  Move         r4, r7
+L11:
+  Less         r7, r4, r2
+  JumpIfFalse  r7, L10
+  Index        r7, r10, r4
   // print(s.name, "orders:", s.count)
-  Index        r15, r4, r3
+  Index        r10, r7, r3
   Const        r3, "orders:"
-  Index        r26, r4, r5
-  PrintN       r15, 3, r15
+  Index        r2, r7, r5
+  PrintN       r10, 3, r10
   // for s in stats {
-  Const        r26, 1
-  Add          r2, r2, r26
-  Jump         L13
-L12:
+  Add          r4, r4, r18
+  Jump         L11
+L10:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=22)
+func main (regs=24)
   // let nations = [
   Const        r0, [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
   // let suppliers = [
@@ -7,7 +7,7 @@ func main (regs=22)
   Const        r2, [{"cost": 10, "part": 100, "qty": 2, "supplier": 1}, {"cost": 20, "part": 100, "qty": 1, "supplier": 2}, {"cost": 5, "part": 200, "qty": 3, "supplier": 1}]
   // from ps in partsupp
   Const        r3, []
-L0:
+L13:
   // where n.name == "A"
   Const        r4, "name"
   // part: ps.part,
@@ -15,17 +15,19 @@ L0:
   // value: ps.cost * ps.qty
   Const        r6, "value"
   Const        r7, "cost"
+L9:
   Const        r8, "qty"
-L1:
   // from ps in partsupp
   IterPrep     r9, r2
+L7:
   Len          r2, r9
-  Const        r10, 0
 L2:
-  Move         r11, r10
+  Const        r10, 0
 L6:
+  Move         r11, r10
   LessInt      r12, r11, r2
   JumpIfFalse  r12, L0
+L3:
   Index        r2, r9, r11
 L5:
   // join s in suppliers on s.id == ps.supplier
@@ -33,6 +35,7 @@ L5:
   Len          r1, r9
 L4:
   Const        r13, "id"
+L1:
   Const        r14, "supplier"
   Move         r15, r10
   LessInt      r16, r15, r1
@@ -60,10 +63,10 @@ L4:
   Equal        r4, r9, r19
   JumpIfFalse  r4, L3
   // part: ps.part,
-  Const        r4, "part"
+  Move         r4, r5
   Index        r19, r2, r5
   // value: ps.cost * ps.qty
-  Const        r9, "value"
+  Move         r9, r6
   Index        r13, r2, r7
   Index        r7, r2, r8
   Mul          r2, r13, r7
@@ -77,7 +80,6 @@ L4:
   MakeMap      r2, 2, r7
   // from ps in partsupp
   Append       r3, r3, r2
-L3:
   // join n in nations on n.id == s.nation
   Const        r2, 1
   Add          r18, r18, r2
@@ -87,100 +89,99 @@ L3:
   Jump         L5
   // from ps in partsupp
   AddInt       r11, r11, r2
-  Jump         L2
+  Jump         L6
+L0:
   // from x in filtered
   Const        r18, []
   // part: g.key,
   Const        r16, "key"
+  // total: sum(from r in g select r.value)
+  Const        r15, "total"
   // from x in filtered
-  IterPrep     r15, r3
-  Len          r3, r15
-  Const        r12, 0
-  MakeMap      r11, 0, r0
-  Const        r9, []
-  Const        r19, 0
-  LessInt      r4, r12, r3
-  JumpIfFalse  r4, L6
-  Index        r4, r15, r12
+  IterPrep     r12, r3
+  Len          r3, r12
+  Move         r11, r10
+  MakeMap      r9, 0, r0
+  LessInt      r19, r11, r3
+  JumpIfFalse  r19, L7
+  Index        r19, r12, r11
   // group by x.part into g
-  Index        r15, r4, r5
-  Str          r5, r15
-  In           r3, r5, r11
-  JumpIfTrue   r3, L7
+  Index        r12, r19, r5
+  Str          r3, r12
+  In           r4, r3, r9
+  JumpIfTrue   r4, L8
   // from x in filtered
-  Const        r3, []
+  Move         r4, r18
   Const        r7, "__group__"
   Const        r13, true
-  Const        r8, "key"
+  Move         r8, r16
   // group by x.part into g
-  Move         r14, r15
+  Move         r14, r12
   // from x in filtered
-  Const        r15, "items"
-  Move         r1, r3
-  Const        r3, "count"
-  Const        r17, 0
+  Const        r12, "items"
+  Move         r1, r4
+  Const        r4, "count"
+  Move         r17, r10
   Move         r20, r7
   Move         r7, r13
-  Move         r21, r8
-  Move         r8, r14
-  Move         r14, r15
-  Move         r15, r1
-  Move         r1, r3
-  Move         r3, r17
+  Move         r13, r8
+  Move         r21, r14
+  Move         r14, r12
+  Move         r22, r1
+  Move         r1, r4
+  Move         r23, r17
   MakeMap      r17, 4, r20
-  SetIndex     r11, r5, r19
-  Append       r9, r9, r17
-  AddInt       r19, r19, r2
-L7:
-  Const        r17, "items"
-  Index        r3, r11, r5
-  Index        r5, r9, r3
-  Index        r3, r5, r17
-  Append       r11, r3, r4
-  SetIndex     r5, r17, r11
-  Const        r11, "count"
-  Index        r3, r5, r11
-  AddInt       r17, r3, r2
-  SetIndex     r5, r11, r17
-  AddInt       r12, r12, r2
-  Jump         L6
-  Move         r17, r10
-  Len          r3, r9
-  LessInt      r11, r17, r3
-  JumpIfFalse  r11, L8
-  Index        r11, r9, r17
+  SetIndex     r9, r3, r17
+L8:
+  Move         r17, r12
+  Index        r12, r9, r3
+  Index        r3, r12, r17
+  Append       r23, r3, r19
+  SetIndex     r12, r17, r23
+  Move         r23, r4
+  Index        r4, r12, r23
+  AddInt       r3, r4, r2
+  SetIndex     r12, r23, r3
+  AddInt       r11, r11, r2
+  Jump         L9
+  Values       3,9,0,0
+  Move         r9, r10
+  Len          r4, r3
+  LessInt      r23, r9, r4
+  JumpIfFalse  r23, L10
+  Index        r23, r3, r9
   // part: g.key,
-  Const        r9, "part"
-  Index        r3, r11, r16
+  Move         r3, r5
+  Index        r5, r23, r16
   // total: sum(from r in g select r.value)
-  Const        r16, "total"
-  Const        r5, []
-  IterPrep     r13, r11
-  Len          r11, r13
+  Move         r16, r15
+  Move         r15, r18
+  IterPrep     r4, r23
+  Len          r23, r4
   Move         r12, r10
-L10:
-  LessInt      r10, r12, r11
-  JumpIfFalse  r10, L9
-  Index        r10, r13, r12
-  Index        r13, r10, r6
-  Append       r5, r5, r13
+L12:
+  LessInt      r10, r12, r23
+  JumpIfFalse  r10, L11
+  Index        r10, r4, r12
+  Index        r4, r10, r6
+  Append       r15, r15, r4
   AddInt       r12, r12, r2
-  Jump         L10
-L9:
-  Sum          r13, r5
+  Jump         L12
+L11:
+  Sum          r4, r15
   // part: g.key,
-  Move         r5, r9
-  Move         r9, r3
+  Move         r15, r3
+  Move         r3, r5
   // total: sum(from r in g select r.value)
-  Move         r3, r16
-  Move         r16, r13
+  Move         r5, r16
+  Move         r16, r4
   // select {
-  MakeMap      r10, 2, r5
+  MakeMap      r10, 2, r15
   // from x in filtered
   Append       r18, r18, r10
-  AddInt       r17, r17, r2
-  Jump         L6
-L8:
+  AddInt       r9, r9, r2
+  Jump         L13
+L10:
   // print(grouped)
   Print        r18
   Return       r0

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -1,23 +1,24 @@
-func main (regs=35)
+func main (regs=38)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
   Const        r1, [{"c_acctbal": 100, "c_address": "123 St", "c_comment": "Loyal", "c_custkey": 1, "c_name": "Alice", "c_nationkey": 1, "c_phone": "123-456"}]
+L1:
   // let orders = [
   Const        r2, [{"o_custkey": 1, "o_orderdate": "1993-10-15", "o_orderkey": 1000}, {"o_custkey": 1, "o_orderdate": "1994-01-02", "o_orderkey": 2000}]
-L6:
   // let lineitem = [
   Const        r3, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 1000, "l_returnflag": "R"}, {"l_discount": 0, "l_extendedprice": 500, "l_orderkey": 2000, "l_returnflag": "N"}]
-L0:
   // let start_date = "1993-10-01"
   Const        r4, "1993-10-01"
+L6:
   // let end_date = "1994-01-01"
   Const        r5, "1994-01-01"
   // from c in customer
   Const        r6, []
+L3:
   // c_custkey: c.c_custkey,
   Const        r7, "c_custkey"
-L3:
+L2:
   // c_name: c.c_name,
   Const        r8, "c_name"
   // c_acctbal: c.c_acctbal,
@@ -30,296 +31,297 @@ L3:
   Const        r12, "c_comment"
   // n_name: n.n_name
   Const        r13, "n_name"
-L5:
   // where o.o_orderdate >= start_date &&
   Const        r14, "o_orderdate"
   // l.l_returnflag == "R"
   Const        r15, "l_returnflag"
-L13:
   // c_custkey: g.key.c_custkey,
   Const        r16, "key"
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r17, "l"
-  Const        r18, "l_extendedprice"
-  Const        r19, "l_discount"
+  Const        r17, "revenue"
+  Const        r18, "l"
+  Const        r19, "l_extendedprice"
+  Const        r20, "l_discount"
   // from c in customer
-  MakeMap      r20, 0, r0
-L9:
-  Const        r21, []
-L7:
-  Const        r22, 0
-L2:
-  IterPrep     r23, r1
-L1:
-  Len          r1, r23
-L4:
-  Const        r24, 0
-  LessInt      r25, r24, r1
+  MakeMap      r21, 0, r0
+  IterPrep     r22, r1
+  Len          r1, r22
 L10:
-  JumpIfFalse  r25, L0
-  Index        r25, r23, r24
+  Const        r23, 0
+  LessInt      r24, r23, r1
+L9:
+  JumpIfFalse  r24, L0
+L8:
+  Index        r1, r22, r23
+L5:
   // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r24, r2
-  Len          r2, r24
-  Const        r23, 0
-  LessInt      r1, r23, r2
-  JumpIfFalse  r1, L1
-  Index        r1, r24, r23
-  Const        r23, "o_custkey"
-  Index        r24, r1, r23
-  Index        r23, r25, r7
-  Equal        r2, r24, r23
-  JumpIfFalse  r2, L2
+  IterPrep     r22, r2
+  Len          r2, r22
+L7:
+  Move         r25, r23
+L4:
+  LessInt      r26, r25, r2
+  JumpIfFalse  r26, L1
+  Index        r2, r22, r25
+  Const        r22, "o_custkey"
+  Index        r27, r2, r22
+  Index        r22, r1, r7
+  Equal        r28, r27, r22
+  JumpIfFalse  r28, L2
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r2, r3
-  Len          r3, r2
-  Const        r23, 0
-  LessInt      r24, r23, r3
-  JumpIfFalse  r24, L2
-  Index        r3, r2, r23
-  Const        r2, "l_orderkey"
-  Index        r26, r3, r2
-  Const        r2, "o_orderkey"
-  Index        r27, r1, r2
-  Equal        r2, r26, r27
-  JumpIfFalse  r2, L3
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r2, r0
-  Len          r27, r2
-  Const        r26, 0
-  LessInt      r28, r26, r27
+  IterPrep     r28, r3
+  Len          r3, r28
+  Move         r22, r23
+  LessInt      r27, r22, r3
+  JumpIfFalse  r27, L2
+  Index        r27, r28, r22
+  Const        r28, "l_orderkey"
+  Index        r3, r27, r28
+  Const        r28, "o_orderkey"
+  Index        r29, r2, r28
+  Equal        r28, r3, r29
   JumpIfFalse  r28, L3
-  Index        r28, r2, r26
-  Const        r2, "n_nationkey"
-  Index        r27, r28, r2
-  Const        r2, "c_nationkey"
-  Index        r29, r25, r2
-  Equal        r2, r27, r29
-  JumpIfFalse  r2, L4
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  IterPrep     r28, r0
+  Len          r29, r28
+  Move         r3, r22
+  LessInt      r30, r3, r29
+  JumpIfFalse  r30, L3
+  Index        r30, r28, r3
+  Const        r28, "n_nationkey"
+  Index        r29, r30, r28
+  Const        r28, "c_nationkey"
+  Index        r31, r1, r28
+  Equal        r28, r29, r31
+  JumpIfFalse  r28, L3
   // where o.o_orderdate >= start_date &&
-  Index        r2, r1, r14
-  LessEq       r29, r4, r2
+  Index        r28, r2, r14
+  LessEq       r31, r4, r28
   // o.o_orderdate < end_date &&
-  Index        r2, r1, r14
-  Less         r14, r2, r5
+  Index        r28, r2, r14
+  Less         r14, r28, r5
   // l.l_returnflag == "R"
-  Index        r2, r3, r15
+  Index        r28, r27, r15
   Const        r15, "R"
-  Equal        r5, r2, r15
+  Equal        r5, r28, r15
   // where o.o_orderdate >= start_date &&
-  Move         r15, r29
-  JumpIfFalse  r15, L5
+  Move         r15, r31
+  JumpIfFalse  r15, L4
   // o.o_orderdate < end_date &&
   Move         r15, r14
-  JumpIfFalse  r15, L6
+  JumpIfFalse  r15, L5
   Move         r15, r5
   // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r15, L4
+  JumpIfFalse  r15, L3
   // from c in customer
   Const        r15, "c"
-  Move         r5, r25
+  Move         r5, r1
   Const        r14, "o"
-  Move         r29, r1
-  Move         r1, r3
-  Const        r3, "n"
-  Move         r2, r28
+  Move         r31, r2
+  Move         r2, r27
+  Const        r27, "n"
+  Move         r28, r30
   MakeMap      r4, 4, r15
   // c_custkey: c.c_custkey,
-  Const        r2, "c_custkey"
-  Index        r3, r25, r7
+  Move         r28, r7
+  Index        r27, r1, r7
   // c_name: c.c_name,
-  Const        r1, "c_name"
-  Index        r29, r25, r8
+  Move         r2, r8
+  Index        r31, r1, r8
   // c_acctbal: c.c_acctbal,
-  Const        r14, "c_acctbal"
-  Index        r5, r25, r9
+  Move         r14, r9
+  Index        r5, r1, r9
   // c_address: c.c_address,
-  Const        r15, "c_address"
-  Index        r27, r25, r10
+  Move         r15, r10
+  Index        r29, r1, r10
   // c_phone: c.c_phone,
-  Const        r30, "c_phone"
-  Index        r31, r25, r11
+  Move         r32, r11
+  Index        r33, r1, r11
   // c_comment: c.c_comment,
-  Const        r32, "c_comment"
-  Index        r33, r25, r12
+  Move         r34, r12
+  Index        r35, r1, r12
   // n_name: n.n_name
-  Const        r25, "n_name"
-  Index        r34, r28, r13
+  Move         r1, r13
+  Index        r36, r30, r13
   // c_custkey: c.c_custkey,
-  Move         r28, r2
-  Move         r2, r3
+  Move         r37, r28
+  Move         r28, r27
   // c_name: c.c_name,
-  Move         r3, r1
-  Move         r1, r29
+  Move         r27, r2
+  Move         r2, r31
   // c_acctbal: c.c_acctbal,
-  Move         r29, r14
+  Move         r31, r14
   Move         r14, r5
   // c_address: c.c_address,
   Move         r5, r15
-  Move         r15, r27
+  Move         r15, r29
   // c_phone: c.c_phone,
-  Move         r27, r30
-  Move         r30, r31
-  // c_comment: c.c_comment,
-  Move         r31, r32
+  Move         r29, r32
   Move         r32, r33
+  // c_comment: c.c_comment,
+  Move         r33, r34
+  Move         r34, r35
   // n_name: n.n_name
-  Move         r33, r25
-  Move         r25, r34
+  Move         r35, r1
+  Move         r1, r36
   // group by {
-  MakeMap      r34, 7, r28
-  Str          r25, r34
-  In           r33, r25, r20
-  JumpIfTrue   r33, L7
+  MakeMap      r36, 7, r37
+  Str          r1, r36
+  In           r35, r1, r21
+  JumpIfTrue   r35, L6
   // from c in customer
-  Const        r33, []
-  Const        r32, "__group__"
-  Const        r31, true
-  Const        r30, "key"
+  Move         r35, r6
+  Const        r34, "__group__"
+  Const        r33, true
+  Move         r32, r16
   // group by {
-  Move         r27, r34
+  Move         r29, r36
   // from c in customer
-  Const        r34, "items"
-  Move         r15, r33
-  Const        r33, "count"
-  Const        r5, 0
-  Move         r14, r32
-  Move         r32, r31
-  Move         r31, r30
-  Move         r30, r27
-  Move         r27, r34
-  Move         r34, r15
-  Move         r15, r33
-  Move         r33, r5
-  MakeMap      r5, 4, r14
-  SetIndex     r20, r25, r22
-  Append       r21, r21, r5
-  Const        r5, 1
-  AddInt       r22, r22, r5
-  Const        r22, "items"
-  Index        r33, r20, r25
-  Index        r25, r21, r33
-  Index        r33, r25, r22
-  Append       r20, r33, r4
-  SetIndex     r25, r22, r20
-  Const        r20, "count"
-  Index        r33, r25, r20
-  AddInt       r22, r33, r5
-  SetIndex     r25, r20, r22
+  Const        r36, "items"
+  Move         r15, r35
+  Const        r35, "count"
+  Move         r5, r23
+  Move         r14, r34
+  Move         r34, r33
+  Move         r33, r32
+  Move         r32, r29
+  Move         r29, r36
+  Move         r31, r15
+  Move         r15, r35
+  Move         r2, r5
+  MakeMap      r27, 4, r14
+  SetIndex     r21, r1, r27
+  Move         r27, r36
+  Index        r36, r21, r1
+  Index        r1, r36, r27
+  Append       r2, r1, r4
+  SetIndex     r36, r27, r2
+  Move         r2, r35
+  Index        r35, r36, r2
+  Const        r1, 1
+  AddInt       r27, r35, r1
+  SetIndex     r36, r2, r27
   // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r26, r26, r5
+  AddInt       r3, r3, r1
   Jump         L7
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r23, r23, r5
-  Jump         L1
+  AddInt       r22, r22, r1
+  Jump         L8
+  // join o in orders on o.o_custkey == c.c_custkey
+  AddInt       r25, r25, r1
+  Jump         L9
   // from c in customer
-  Const        r22, 0
-  Move         r24, r22
-  Len          r23, r21
-  LessInt      r33, r24, r23
-  JumpIfFalse  r33, L8
-  Index        r33, r21, r24
-  // c_custkey: g.key.c_custkey,
-  Const        r21, "c_custkey"
-  Index        r23, r33, r16
-  Index        r20, r23, r7
-  // c_name: g.key.c_name,
-  Const        r23, "c_name"
-  Index        r7, r33, r16
-  Index        r25, r7, r8
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r7, "revenue"
-  Const        r8, []
-  IterPrep     r26, r33
-  Len          r4, r26
-  Move         r15, r22
-  LessInt      r34, r15, r4
-  JumpIfFalse  r34, L9
-  Index        r34, r26, r15
-  Index        r26, r34, r17
-  Index        r4, r26, r18
-  Index        r26, r34, r17
-  Index        r27, r26, r19
-  Sub          r26, r5, r27
-  Mul          r27, r4, r26
-  Append       r8, r8, r27
-  AddInt       r15, r15, r5
+  AddInt       r23, r23, r1
   Jump         L10
-  Sum          r26, r8
+L0:
+  Values       27,21,0,0
+  Move         r21, r5
+  Move         r5, r21
+  Len          r26, r27
+  LessInt      r25, r5, r26
+  JumpIfFalse  r25, L11
+  Index        r25, r27, r5
+  // c_custkey: g.key.c_custkey,
+  Move         r27, r7
+  Index        r26, r25, r16
+  Index        r24, r26, r7
+  // c_name: g.key.c_name,
+  Move         r26, r8
+  Index        r7, r25, r16
+  Index        r23, r7, r8
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r7, r17
+  Move         r17, r6
+  IterPrep     r8, r25
+  Len          r35, r8
+  Move         r2, r21
+  LessInt      r36, r2, r35
+  JumpIfFalse  r36, L3
+  Index        r36, r8, r2
+  Index        r8, r36, r18
+  Index        r35, r8, r19
+  Index        r8, r36, r18
+  Index        r30, r8, r20
+  Sub          r3, r1, r30
+  Mul          r30, r35, r3
+  Append       r17, r17, r30
+  AddInt       r2, r2, r1
+  Jump         L7
+  Sum          r3, r17
   // c_acctbal: g.key.c_acctbal,
-  Const        r8, "c_acctbal"
-  Index        r4, r33, r16
-  Index        r15, r4, r9
+  Move         r17, r9
+  Index        r35, r25, r16
+  Index        r2, r35, r9
   // n_name: g.key.n_name,
-  Const        r4, "n_name"
-  Index        r27, r33, r16
-  Index        r9, r27, r13
+  Move         r35, r13
+  Index        r9, r25, r16
+  Index        r22, r9, r13
   // c_address: g.key.c_address,
-  Const        r27, "c_address"
-  Index        r13, r33, r16
+  Move         r9, r10
+  Index        r13, r25, r16
   Index        r30, r13, r10
   // c_phone: g.key.c_phone,
-  Const        r13, "c_phone"
-  Index        r10, r33, r16
-  Index        r31, r10, r11
+  Move         r13, r11
+  Index        r10, r25, r16
+  Index        r4, r10, r11
   // c_comment: g.key.c_comment
-  Const        r10, "c_comment"
-  Index        r11, r33, r16
+  Move         r10, r12
+  Index        r11, r25, r16
   Index        r16, r11, r12
   // c_custkey: g.key.c_custkey,
-  Move         r11, r21
-  Move         r21, r20
+  Move         r11, r27
+  Move         r27, r24
   // c_name: g.key.c_name,
-  Move         r20, r23
-  Move         r23, r25
+  Move         r24, r26
+  Move         r26, r23
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r25, r7
-  Move         r7, r26
+  Move         r23, r7
+  Move         r7, r3
   // c_acctbal: g.key.c_acctbal,
-  Move         r26, r8
-  Move         r8, r15
+  Move         r3, r17
+  Move         r17, r2
   // n_name: g.key.n_name,
-  Move         r15, r4
-  Move         r4, r9
+  Move         r2, r35
+  Move         r35, r22
   // c_address: g.key.c_address,
-  Move         r9, r27
-  Move         r27, r30
+  Move         r22, r9
+  Move         r9, r30
   // c_phone: g.key.c_phone,
   Move         r30, r13
-  Move         r13, r31
+  Move         r13, r4
   // c_comment: g.key.c_comment
-  Move         r31, r10
+  Move         r4, r10
   Move         r10, r16
   // select {
   MakeMap      r16, 8, r11
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r10, []
-  IterPrep     r31, r33
-  Len          r33, r31
-  Move         r13, r22
+  Move         r10, r6
+  IterPrep     r4, r25
+  Len          r25, r4
+  Move         r13, r21
+L13:
+  LessInt      r21, r13, r25
+  JumpIfFalse  r21, L12
+  Index        r36, r4, r13
+  Index        r21, r36, r18
+  Index        r25, r21, r19
+  Index        r21, r36, r18
+  Index        r36, r21, r20
+  Sub          r21, r1, r36
+  Mul          r36, r25, r21
+  Append       r10, r10, r36
+  AddInt       r13, r13, r1
+  Jump         L13
 L12:
-  LessInt      r22, r13, r33
-  JumpIfFalse  r22, L11
-  Index        r34, r31, r13
-  Index        r22, r34, r17
-  Index        r33, r22, r18
-  Index        r22, r34, r17
-  Index        r34, r22, r19
-  Sub          r22, r5, r34
-  Mul          r34, r33, r22
-  Append       r10, r10, r34
-  AddInt       r13, r13, r5
-  Jump         L12
-L11:
-  Sum          r34, r10
-  Neg          r10, r34
+  Sum          r36, r10
+  Neg          r10, r36
   // from c in customer
-  Move         r34, r16
+  Move         r36, r16
   MakeList     r16, 2, r10
   Append       r6, r6, r16
-  AddInt       r24, r24, r5
-  Jump         L13
-L8:
+  AddInt       r5, r5, r1
+  Jump         L2
+L11:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r6, r6
   // print(result)

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,124 +1,121 @@
-func main (regs=19)
+func main (regs=22)
   // let items = [
   Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
   // from i in items
   Const        r1, []
-L0:
   // group by i.cat into g
   Const        r2, "cat"
-L8:
   // cat: g.key,
   Const        r3, "key"
-  // total: sum(from x in g select x.val)
-  Const        r4, "val"
-  // from i in items
-  IterPrep     r5, r0
 L7:
-  Len          r6, r5
-L5:
-  Const        r7, 0
-L4:
-  MakeMap      r8, 0, r0
-  Const        r9, []
+  // total: sum(from x in g select x.val)
+  Const        r4, "total"
+  Const        r5, "val"
+L0:
+  // from i in items
+  IterPrep     r6, r0
+  Len          r7, r6
+  Const        r8, 0
+L6:
+  MakeMap      r9, 0, r0
 L2:
-  Const        r10, 0
-  LessInt      r11, r7, r6
-  JumpIfFalse  r11, L0
-  Index        r11, r5, r7
-  // group by i.cat into g
-  Index        r5, r11, r2
-  Str          r2, r5
+  LessInt      r10, r8, r7
 L1:
-  In           r6, r2, r8
-  JumpIfTrue   r6, L1
-  // from i in items
-  Const        r6, []
-  Const        r12, "__group__"
-  Const        r13, true
-  Const        r14, "key"
+  JumpIfFalse  r10, L0
+  Index        r7, r6, r8
   // group by i.cat into g
-  Move         r15, r5
+  Index        r6, r7, r2
+  Str          r11, r6
+  In           r12, r11, r9
+  JumpIfTrue   r12, L1
   // from i in items
-  Const        r5, "items"
+  Move         r12, r1
+  Const        r13, "__group__"
+  Const        r14, true
+  Move         r15, r3
+L4:
+  // group by i.cat into g
   Move         r16, r6
-  Const        r6, "count"
-  Const        r17, 0
-  Move         r18, r12
-  Move         r12, r13
+  // from i in items
+  Const        r6, "items"
+  Move         r17, r12
+  Const        r12, "count"
+  Move         r18, r8
+  Move         r19, r13
   Move         r13, r14
   Move         r14, r15
-  Move         r15, r5
-  Move         r5, r16
+  Move         r15, r16
   Move         r16, r6
-  Move         r6, r17
-  MakeMap      r17, 4, r18
-  SetIndex     r8, r2, r10
-  Append       r9, r9, r17
-  Const        r17, 1
-  Const        r6, "items"
-  Index        r16, r8, r2
-  Index        r2, r9, r16
-  Index        r16, r2, r6
-  Append       r8, r16, r11
-  SetIndex     r2, r6, r8
-  Const        r8, "count"
-  Index        r16, r2, r8
-  AddInt       r6, r16, r17
-  SetIndex     r2, r8, r6
-  AddInt       r7, r7, r17
+  Move         r20, r17
+  Move         r17, r12
+  Move         r21, r18
+  MakeMap      r18, 4, r19
+  SetIndex     r9, r11, r18
+  Move         r18, r6
+  Index        r6, r9, r11
+  Index        r11, r6, r18
+  Append       r21, r11, r7
+  SetIndex     r6, r18, r21
+  Move         r21, r12
+  Index        r12, r6, r21
+  Const        r11, 1
+  AddInt       r18, r12, r11
+  SetIndex     r6, r21, r18
+  AddInt       r8, r8, r11
   Jump         L2
-  Const        r6, 0
-  Move         r16, r6
-  Len          r8, r9
-  LessInt      r2, r16, r8
-  JumpIfFalse  r2, L3
-  Index        r2, r9, r16
+  Values       18,9,0,0
+  Const        r9, 0
+  Move         r12, r9
+  Len          r21, r18
+  LessInt      r6, r12, r21
+  JumpIfFalse  r6, L3
+  Index        r6, r18, r12
   // cat: g.key,
-  Const        r9, "cat"
-  Index        r8, r2, r3
+  Move         r18, r2
+  Index        r2, r6, r3
   // total: sum(from x in g select x.val)
-  Const        r3, "total"
-  Const        r10, []
-  IterPrep     r7, r2
-  Len          r11, r7
-  Move         r5, r6
-  LessInt      r15, r5, r11
-  JumpIfFalse  r15, L4
-  Index        r15, r7, r5
-  Index        r7, r15, r4
-  Append       r10, r10, r7
-  AddInt       r5, r5, r17
-  Jump         L5
-  Sum          r7, r10
+  Move         r3, r4
+  Move         r4, r1
+  IterPrep     r21, r6
+  Len          r10, r21
+  Move         r8, r9
+  LessInt      r7, r8, r10
+  JumpIfFalse  r7, L0
+  Index        r7, r21, r8
+  Index        r21, r7, r5
+  Append       r4, r4, r21
+  AddInt       r8, r8, r11
+  Jump         L4
+  Sum          r8, r4
   // cat: g.key,
-  Move         r10, r9
-  Move         r9, r8
+  Move         r21, r18
+  Move         r18, r2
   // total: sum(from x in g select x.val)
-  Move         r8, r3
-  Move         r5, r7
+  Move         r2, r3
+  Move         r3, r8
   // select {
-  MakeMap      r7, 2, r10
+  MakeMap      r8, 2, r21
   // sort by -sum(from x in g select x.val)
-  Const        r5, []
-  IterPrep     r8, r2
-  Len          r2, r8
-  Move         r9, r6
-  LessInt      r6, r9, r2
-  JumpIfFalse  r6, L6
-  Index        r15, r8, r9
-  Index        r6, r15, r4
-  Append       r5, r5, r6
-  AddInt       r9, r9, r17
-  Jump         L7
-L6:
-  Sum          r9, r5
-  Neg          r5, r9
+  Move         r3, r1
+  IterPrep     r2, r6
+  Len          r6, r2
+  Move         r18, r9
+  LessInt      r9, r18, r6
+  JumpIfFalse  r9, L5
+  Index        r7, r2, r18
+  Index        r9, r7, r5
+  Append       r3, r3, r9
+  AddInt       r18, r18, r11
+  Jump         L6
+L5:
+  Sum          r18, r3
+  Neg          r3, r18
   // from i in items
-  Move         r6, r7
-  MakeList     r9, 2, r5
+  Move         r18, r8
+  MakeList     r9, 2, r3
   Append       r1, r1, r9
-  AddInt       r16, r16, r17
-  Jump         L8
+  AddInt       r12, r12, r11
+  Jump         L7
 L3:
   // sort by -sum(from x in g select x.val)
   Sort         r1, r1


### PR DESCRIPTION
## Summary
- optimize VM group by compile logic to avoid extra index lookups
- update IR golden files for group by tests

## Testing
- `make fmt`
- `make test` *(fails: cc error: returnflag undeclared)*
- `go test -tags=slow ./tests/vm -run TestVM_IR -update`


------
https://chatgpt.com/codex/tasks/task_e_686163d459a8832091f5698d8a0d1d64