### PR TITLE
Optimize group by algorithm

### DIFF
--- a/runtime/vm/queryutil.go
+++ b/runtime/vm/queryutil.go
@@ -5,6 +5,14 @@ import (
 	"mochi/parser"
 )
 
+var aggNeedsItems = map[string]struct{}{
+	"sum":    {},
+	"avg":    {},
+	"min":    {},
+	"max":    {},
+	"values": {},
+}
+
 // aggregateCall returns the aggregate opcode and argument if e is a simple
 // aggregate function call like `sum(x)`.
 func aggregateCall(e *parser.Expr) (Op, *parser.Expr, lexer.Position, bool) {
@@ -241,4 +249,248 @@ func whereAlias(where *parser.Expr) (string, bool) {
 		return v, true
 	}
 	return "", false
+}
+
+// exprHasAggCall reports whether expression e contains a function call that
+// requires group items such as sum(), avg(), min(), max() or values().
+func exprHasAggCall(e *parser.Expr) bool {
+	found := false
+	var scanExpr func(*parser.Expr)
+	var scanUnary func(*parser.Unary)
+	var scanPostfix func(*parser.PostfixExpr)
+	var scanPrimary func(*parser.Primary)
+
+	scanExpr = func(e *parser.Expr) {
+		if found || e == nil || e.Binary == nil {
+			return
+		}
+		scanUnary(e.Binary.Left)
+		for _, op := range e.Binary.Right {
+			scanPostfix(op.Right)
+		}
+	}
+	scanUnary = func(u *parser.Unary) {
+		if found || u == nil {
+			return
+		}
+		scanPostfix(u.Value)
+	}
+	scanPostfix = func(p *parser.PostfixExpr) {
+		if found || p == nil {
+			return
+		}
+		scanPrimary(p.Target)
+		for _, op := range p.Ops {
+			if op.Call != nil {
+				for _, a := range op.Call.Args {
+					scanExpr(a)
+				}
+			}
+			if op.Index != nil {
+				scanExpr(op.Index.Start)
+				scanExpr(op.Index.End)
+				scanExpr(op.Index.Step)
+			}
+			if op.Field != nil {
+				// no-op
+			}
+		}
+	}
+	scanPrimary = func(p *parser.Primary) {
+		if found || p == nil {
+			return
+		}
+		if p.Call != nil {
+			if _, ok := aggNeedsItems[p.Call.Func]; ok {
+				found = true
+				return
+			}
+			for _, a := range p.Call.Args {
+				scanExpr(a)
+			}
+		}
+		if p.Struct != nil {
+			for _, f := range p.Struct.Fields {
+				scanExpr(f.Value)
+			}
+		}
+		if p.List != nil {
+			for _, el := range p.List.Elems {
+				scanExpr(el)
+			}
+		}
+		if p.Map != nil {
+			for _, it := range p.Map.Items {
+				scanExpr(it.Key)
+				scanExpr(it.Value)
+			}
+		}
+		if p.Group != nil {
+			scanExpr(p.Group)
+		}
+		if p.If != nil {
+			scanExpr(p.If.Cond)
+			scanExpr(p.If.Then)
+			scanExpr(p.If.Else)
+			if p.If.ElseIf != nil {
+				scanExpr(p.If.ElseIf.Cond)
+				scanExpr(p.If.ElseIf.Then)
+				scanExpr(p.If.ElseIf.Else)
+			}
+		}
+		if p.Query != nil {
+			// ignore nested query expressions
+		}
+		if p.FunExpr != nil {
+			scanExpr(p.FunExpr.ExprBody)
+			for _, st := range p.FunExpr.BlockBody {
+				// Only expressions from statements are scanned
+				if st.Return != nil {
+					scanExpr(st.Return.Value)
+				}
+				if st.Expr != nil {
+					scanExpr(st.Expr.Expr)
+				}
+			}
+		}
+		if p.Match != nil {
+			scanExpr(p.Match.Target)
+			for _, c := range p.Match.Cases {
+				scanExpr(c.Pattern)
+				scanExpr(c.Result)
+			}
+		}
+		if p.Generate != nil {
+			for _, f := range p.Generate.Fields {
+				scanExpr(f.Value)
+			}
+		}
+		if p.Fetch != nil {
+			scanExpr(p.Fetch.URL)
+			scanExpr(p.Fetch.With)
+		}
+		if p.Load != nil {
+			scanExpr(p.Load.With)
+		}
+		if p.Save != nil {
+			scanExpr(p.Save.Src)
+			scanExpr(p.Save.With)
+		}
+	}
+
+	scanExpr(e)
+	return found
+}
+
+// exprUsesField reports whether expression e references alias.field.
+func exprUsesField(e *parser.Expr, alias, field string) bool {
+	found := false
+	var scanExpr func(*parser.Expr)
+	var scanUnary func(*parser.Unary)
+	var scanPostfix func(*parser.PostfixExpr)
+	var scanPrimary func(*parser.Primary)
+
+	scanExpr = func(e *parser.Expr) {
+		if found || e == nil || e.Binary == nil {
+			return
+		}
+		scanUnary(e.Binary.Left)
+		for _, op := range e.Binary.Right {
+			scanPostfix(op.Right)
+		}
+	}
+	scanUnary = func(u *parser.Unary) {
+		if found || u == nil {
+			return
+		}
+		scanPostfix(u.Value)
+	}
+	scanPostfix = func(p *parser.PostfixExpr) {
+		if found || p == nil {
+			return
+		}
+		scanPrimary(p.Target)
+		for _, op := range p.Ops {
+			if op.Field != nil {
+				if p.Target != nil && p.Target.Selector != nil {
+					if p.Target.Selector.Root == alias {
+						for _, t := range append([]string{op.Field.Name}, op.Field.Name) {
+							if t == field {
+								found = true
+								return
+							}
+						}
+					}
+				}
+			}
+			if op.Call != nil {
+				for _, a := range op.Call.Args {
+					scanExpr(a)
+				}
+			}
+			if op.Index != nil {
+				scanExpr(op.Index.Start)
+				scanExpr(op.Index.End)
+				scanExpr(op.Index.Step)
+			}
+		}
+	}
+	scanPrimary = func(p *parser.Primary) {
+		if found || p == nil {
+			return
+		}
+		if p.Selector != nil {
+			if p.Selector.Root == alias {
+				for _, n := range p.Selector.Tail {
+					if n == field {
+						found = true
+						return
+					}
+				}
+			}
+		}
+		if p.Call != nil {
+			for _, a := range p.Call.Args {
+				scanExpr(a)
+			}
+		}
+		if p.Struct != nil {
+			for _, f := range p.Struct.Fields {
+				scanExpr(f.Value)
+			}
+		}
+		if p.List != nil {
+			for _, el := range p.List.Elems {
+				scanExpr(el)
+			}
+		}
+		if p.Map != nil {
+			for _, it := range p.Map.Items {
+				scanExpr(it.Key)
+				scanExpr(it.Value)
+			}
+		}
+		if p.Group != nil {
+			scanExpr(p.Group)
+		}
+	}
+
+	scanExpr(e)
+	return found
+}
+
+// groupNeedsItems determines whether GROUP BY query q requires storing
+// group items based on its SELECT, HAVING or SORT expressions.
+func groupNeedsItems(q *parser.QueryExpr) bool {
+	if q == nil || q.Group == nil {
+		return false
+	}
+	if exprHasAggCall(q.Select) || exprHasAggCall(q.Group.Having) || exprHasAggCall(q.Sort) {
+		return true
+	}
+	name := q.Group.Name
+	if exprUsesField(q.Select, name, "items") || exprUsesField(q.Group.Having, name, "items") || exprUsesField(q.Sort, name, "items") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- add `needItems` tracking to VM compiler to omit storing group items when unused
- detect aggregate usage via new helpers in `queryutil.go`
- conditionally accumulate group items only when required

## Testing
- `go test ./...`
- `go test -tags slow ./tests/vm -update` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6861673a3c788320a30d44672464ff34