### PR TITLE
Improve VM len op

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -786,6 +786,8 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				fr.regs[ins.A] = Value{Tag: ValueInt, Int: len([]rune(v.Str))}
 			case ValueMap:
 				fr.regs[ins.A] = Value{Tag: ValueInt, Int: len(v.Map)}
+			case ValueNull:
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
 			default:
 				return Value{}, m.newError(fmt.Errorf("invalid len operand"), trace, ins.Line)
 			}


### PR DESCRIPTION
## Summary
- handle `len` for `null` values in the VM

## Testing
- `go test ./runtime/vm -tags slow -run TestInfer_TagPropagation -count=1`
- `go test ./... -run TestInfer_TagPropagation -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686169e11b748320924afda2549879cd