### PR TITLE
Handle nil lists in VM append

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -972,6 +972,9 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fmt.Fprintln(m.writer, string(b))
 		case OpAppend:
 			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				lst = Value{Tag: ValueList, List: []Value{}}
+			}
 			if lst.Tag != ValueList {
 				return Value{}, m.newError(fmt.Errorf("append expects list"), trace, ins.Line)
 			}


### PR DESCRIPTION
## Summary
- improve VM append instruction by treating `null` as empty list

## Testing
- `go test ./tests/vm -tags slow -run TestVM_TPCH/q1.mochi -count=1` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6861676efbb883209d75d03e8b3387cb