### PR TITLE
Fix VM dataset tests

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -295,7 +295,9 @@ func Optimize(fn *Function) {
 			break
 		}
 	}
-	CompactRegisters(fn)
+	// Compacting registers can break instructions like OpMakeMap which
+	// rely on contiguous register ranges. Skip this step for now.
+	// CompactRegisters(fn)
 }
 
 // removeDead eliminates instructions that only define dead registers.

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -4645,7 +4645,9 @@ func (fc *funcCompiler) buildRowMap(q *parser.QueryExpr) int {
 
 	pairs := make([]int, len(names)*2)
 	for i, n := range names {
-		k := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: n})
+		// Use fresh constants to ensure contiguous registers when
+		// building the key/value pairs for the row object.
+		k := fc.freshConst(q.Pos, Value{Tag: ValueStr, Str: n})
 		v := fc.newReg()
 		fc.emit(q.Pos, Instr{Op: OpMove, A: v, B: regs[i]})
 		pairs[i*2] = k

--- a/tests/dataset/tpc-h/out/q1.ir.out
+++ b/tests/dataset/tpc-h/out/q1.ir.out
@@ -1,4 +1,4 @@
-func main (regs=235)
+func main (regs=234)
   // let lineitem = [
   Const        r0, [{"l_discount": 0.05, "l_extendedprice": 1000, "l_linestatus": "O", "l_quantity": 17, "l_returnflag": "N", "l_shipdate": "1998-08-01", "l_tax": 0.07}, {"l_discount": 0.1, "l_extendedprice": 2000, "l_linestatus": "O", "l_quantity": 36, "l_returnflag": "N", "l_shipdate": "1998-09-01", "l_tax": 0.05}, {"l_discount": 0, "l_extendedprice": 1500, "l_linestatus": "F", "l_quantity": 25, "l_returnflag": "R", "l_shipdate": "1998-09-03", "l_tax": 0.08}]
   // from row in lineitem
@@ -14,58 +14,70 @@ func main (regs=235)
   // returnflag: g.key.returnflag,
   Const        r7, "key"
   // sum_qty: sum(from x in g select x.l_quantity),
+  Const        r8, "sum_qty"
   Const        r9, "l_quantity"
   // sum_base_price: sum(from x in g select x.l_extendedprice),
+  Const        r10, "sum_base_price"
   Const        r11, "l_extendedprice"
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+  Const        r12, "sum_disc_price"
   Const        r13, "l_discount"
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+  Const        r14, "sum_charge"
   Const        r15, "l_tax"
+  // avg_qty: avg(from x in g select x.l_quantity),
+  Const        r16, "avg_qty"
+  // avg_price: avg(from x in g select x.l_extendedprice),
+  Const        r17, "avg_price"
+  // avg_disc: avg(from x in g select x.l_discount),
+  Const        r18, "avg_disc"
+  // count_order: count(g)
+  Const        r19, "count_order"
   // from row in lineitem
   IterPrep     r20, r0
   Len          r21, r20
   Const        r22, 0
   MakeMap      r23, 0, r0
-  Const        r24, []
 L3:
-  LessInt      r25, r22, r21
-  JumpIfFalse  r25, L0
-  Index        r26, r20, r22
-  Move         r27, r26
+  LessInt      r24, r22, r21
+  JumpIfFalse  r24, L0
+  Index        r25, r20, r22
+  Move         r26, r25
   // where row.l_shipdate <= "1998-09-02"
-  Index        r28, r27, r6
-  Const        r29, "1998-09-02"
-  LessEq       r30, r28, r29
-  JumpIfFalse  r30, L1
+  Index        r27, r26, r6
+  Const        r28, "1998-09-02"
+  LessEq       r29, r27, r28
+  JumpIfFalse  r29, L1
   // returnflag: row.l_returnflag,
-  Const        r31, "returnflag"
-  Index        r32, r27, r3
+  Move         r30, r2
+  Index        r31, r26, r3
   // linestatus: row.l_linestatus
-  Const        r33, "linestatus"
-  Index        r34, r27, r5
+  Move         r32, r4
+  Index        r33, r26, r5
   // returnflag: row.l_returnflag,
+  Move         r34, r30
   Move         r35, r31
-  Move         r36, r32
   // linestatus: row.l_linestatus
+  Move         r36, r32
   Move         r37, r33
-  Move         r38, r34
   // group by {
-  MakeMap      r39, 2, r35
-  Str          r40, r39
-  In           r41, r40, r23
-  JumpIfTrue   r41, L2
+  MakeMap      r38, 2, r34
+  Str          r39, r38
+  In           r40, r39, r23
+  JumpIfTrue   r40, L2
   // from row in lineitem
-  Const        r42, []
-  Const        r43, "__group__"
-  Const        r44, true
-  Const        r45, "key"
+  Move         r41, r1
+  Const        r42, "__group__"
+  Const        r43, true
+  Move         r44, r7
   // group by {
-  Move         r46, r39
+  Move         r45, r38
   // from row in lineitem
-  Const        r47, "items"
-  Move         r48, r42
-  Const        r49, "count"
-  Const        r50, 0
+  Const        r46, "items"
+  Move         r47, r41
+  Const        r48, "count"
+  Move         r49, r22
+  Move         r50, r42
   Move         r51, r43
   Move         r52, r44
   Move         r53, r45
@@ -73,267 +85,266 @@ L3:
   Move         r55, r47
   Move         r56, r48
   Move         r57, r49
-  Move         r58, r50
-  MakeMap      r59, 4, r51
-  SetIndex     r23, r40, r59
-  Append       r24, r24, r59
+  MakeMap      r58, 4, r50
+  SetIndex     r23, r39, r58
 L2:
-  Const        r61, "items"
-  Index        r62, r23, r40
-  Index        r63, r62, r61
-  Append       r64, r63, r26
-  SetIndex     r62, r61, r64
-  Const        r65, "count"
-  Index        r66, r62, r65
-  Const        r67, 1
-  AddInt       r68, r66, r67
-  SetIndex     r62, r65, r68
+  Move         r59, r46
+  Index        r60, r23, r39
+  Index        r61, r60, r59
+  Append       r62, r61, r25
+  SetIndex     r60, r59, r62
+  Move         r63, r48
+  Index        r64, r60, r63
+  Const        r65, 1
+  AddInt       r66, r64, r65
+  SetIndex     r60, r63, r66
 L1:
-  AddInt       r22, r22, r67
+  AddInt       r22, r22, r65
   Jump         L3
 L0:
-  Const        r70, 0
-  Move         r69, r70
-  Len          r71, r24
+  Values       67,23,0,0
+  Const        r69, 0
+  Move         r68, r69
+  Len          r70, r67
 L19:
-  LessInt      r72, r69, r71
-  JumpIfFalse  r72, L4
-  Index        r74, r24, r69
+  LessInt      r71, r68, r70
+  JumpIfFalse  r71, L4
+  Index        r73, r67, r68
   // returnflag: g.key.returnflag,
-  Const        r75, "returnflag"
-  Index        r76, r74, r7
-  Index        r77, r76, r2
+  Move         r74, r2
+  Index        r75, r73, r7
+  Index        r76, r75, r2
   // linestatus: g.key.linestatus,
-  Const        r78, "linestatus"
-  Index        r79, r74, r7
-  Index        r80, r79, r4
+  Move         r77, r4
+  Index        r78, r73, r7
+  Index        r79, r78, r4
   // sum_qty: sum(from x in g select x.l_quantity),
-  Const        r81, "sum_qty"
-  Const        r82, []
-  IterPrep     r83, r74
-  Len          r84, r83
-  Move         r85, r70
+  Move         r80, r8
+  Move         r81, r1
+  IterPrep     r82, r73
+  Len          r83, r82
+  Move         r84, r69
 L6:
-  LessInt      r86, r85, r84
-  JumpIfFalse  r86, L5
-  Index        r88, r83, r85
-  Index        r89, r88, r9
-  Append       r82, r82, r89
-  AddInt       r85, r85, r67
+  LessInt      r85, r84, r83
+  JumpIfFalse  r85, L5
+  Index        r87, r82, r84
+  Index        r88, r87, r9
+  Append       r81, r81, r88
+  AddInt       r84, r84, r65
   Jump         L6
 L5:
-  Sum          r91, r82
+  Sum          r90, r81
   // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Const        r92, "sum_base_price"
-  Const        r93, []
-  IterPrep     r94, r74
-  Len          r95, r94
-  Move         r96, r70
+  Move         r91, r10
+  Move         r92, r1
+  IterPrep     r93, r73
+  Len          r94, r93
+  Move         r95, r69
 L8:
-  LessInt      r97, r96, r95
-  JumpIfFalse  r97, L7
-  Index        r88, r94, r96
-  Index        r99, r88, r11
-  Append       r93, r93, r99
-  AddInt       r96, r96, r67
+  LessInt      r96, r95, r94
+  JumpIfFalse  r96, L7
+  Index        r87, r93, r95
+  Index        r98, r87, r11
+  Append       r92, r92, r98
+  AddInt       r95, r95, r65
   Jump         L8
 L7:
-  Sum          r101, r93
+  Sum          r100, r92
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Const        r102, "sum_disc_price"
-  Const        r103, []
-  IterPrep     r104, r74
-  Len          r105, r104
-  Move         r106, r70
+  Move         r101, r12
+  Move         r102, r1
+  IterPrep     r103, r73
+  Len          r104, r103
+  Move         r105, r69
 L10:
-  LessInt      r107, r106, r105
-  JumpIfFalse  r107, L9
-  Index        r88, r104, r106
-  Index        r109, r88, r11
-  Index        r110, r88, r13
-  Sub          r111, r67, r110
-  Mul          r112, r109, r111
-  Append       r103, r103, r112
-  AddInt       r106, r106, r67
+  LessInt      r106, r105, r104
+  JumpIfFalse  r106, L9
+  Index        r87, r103, r105
+  Index        r108, r87, r11
+  Index        r109, r87, r13
+  Sub          r110, r65, r109
+  Mul          r111, r108, r110
+  Append       r102, r102, r111
+  AddInt       r105, r105, r65
   Jump         L10
 L9:
-  Sum          r114, r103
+  Sum          r113, r102
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Const        r115, "sum_charge"
-  Const        r116, []
-  IterPrep     r117, r74
-  Len          r118, r117
-  Move         r119, r70
+  Move         r114, r14
+  Move         r115, r1
+  IterPrep     r116, r73
+  Len          r117, r116
+  Move         r118, r69
 L12:
-  LessInt      r120, r119, r118
-  JumpIfFalse  r120, L11
-  Index        r88, r117, r119
-  Index        r122, r88, r11
-  Index        r123, r88, r13
-  Sub          r124, r67, r123
-  Mul          r125, r122, r124
-  Index        r126, r88, r15
-  Add          r127, r67, r126
-  Mul          r128, r125, r127
-  Append       r116, r116, r128
-  AddInt       r119, r119, r67
+  LessInt      r119, r118, r117
+  JumpIfFalse  r119, L11
+  Index        r87, r116, r118
+  Index        r121, r87, r11
+  Index        r122, r87, r13
+  Sub          r123, r65, r122
+  Mul          r124, r121, r123
+  Index        r125, r87, r15
+  Add          r126, r65, r125
+  Mul          r127, r124, r126
+  Append       r115, r115, r127
+  AddInt       r118, r118, r65
   Jump         L12
 L11:
-  Sum          r130, r116
+  Sum          r129, r115
   // avg_qty: avg(from x in g select x.l_quantity),
-  Const        r131, "avg_qty"
-  Const        r132, []
-  IterPrep     r133, r74
-  Len          r134, r133
-  Move         r135, r70
+  Move         r130, r16
+  Move         r131, r1
+  IterPrep     r132, r73
+  Len          r133, r132
+  Move         r134, r69
 L14:
-  LessInt      r136, r135, r134
-  JumpIfFalse  r136, L13
-  Index        r88, r133, r135
-  Index        r138, r88, r9
-  Append       r132, r132, r138
-  AddInt       r135, r135, r67
+  LessInt      r135, r134, r133
+  JumpIfFalse  r135, L13
+  Index        r87, r132, r134
+  Index        r137, r87, r9
+  Append       r131, r131, r137
+  AddInt       r134, r134, r65
   Jump         L14
 L13:
-  Avg          r140, r132
+  Avg          r139, r131
   // avg_price: avg(from x in g select x.l_extendedprice),
-  Const        r141, "avg_price"
-  Const        r142, []
-  IterPrep     r143, r74
-  Len          r144, r143
-  Move         r145, r70
+  Move         r140, r17
+  Move         r141, r1
+  IterPrep     r142, r73
+  Len          r143, r142
+  Move         r144, r69
 L16:
-  LessInt      r146, r145, r144
-  JumpIfFalse  r146, L15
-  Index        r88, r143, r145
-  Index        r148, r88, r11
-  Append       r142, r142, r148
-  AddInt       r145, r145, r67
+  LessInt      r145, r144, r143
+  JumpIfFalse  r145, L15
+  Index        r87, r142, r144
+  Index        r147, r87, r11
+  Append       r141, r141, r147
+  AddInt       r144, r144, r65
   Jump         L16
 L15:
-  Avg          r150, r142
+  Avg          r149, r141
   // avg_disc: avg(from x in g select x.l_discount),
-  Const        r151, "avg_disc"
-  Const        r152, []
-  IterPrep     r153, r74
-  Len          r154, r153
-  Move         r155, r70
+  Move         r150, r18
+  Move         r151, r1
+  IterPrep     r152, r73
+  Len          r153, r152
+  Move         r154, r69
 L18:
-  LessInt      r156, r155, r154
-  JumpIfFalse  r156, L17
-  Index        r88, r153, r155
-  Index        r158, r88, r13
-  Append       r152, r152, r158
-  AddInt       r155, r155, r67
+  LessInt      r155, r154, r153
+  JumpIfFalse  r155, L17
+  Index        r87, r152, r154
+  Index        r157, r87, r13
+  Append       r151, r151, r157
+  AddInt       r154, r154, r65
   Jump         L18
 L17:
-  Avg          r160, r152
+  Avg          r159, r151
   // count_order: count(g)
-  Const        r161, "count_order"
-  Index        r162, r74, r65
+  Move         r160, r19
+  Index        r161, r73, r63
   // returnflag: g.key.returnflag,
-  Move         r163, r75
-  Move         r164, r77
+  Move         r162, r74
+  Move         r163, r76
   // linestatus: g.key.linestatus,
-  Move         r165, r78
-  Move         r166, r80
+  Move         r164, r77
+  Move         r165, r79
   // sum_qty: sum(from x in g select x.l_quantity),
-  Move         r167, r81
-  Move         r168, r91
+  Move         r166, r80
+  Move         r167, r90
   // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Move         r169, r92
-  Move         r170, r101
+  Move         r168, r91
+  Move         r169, r100
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Move         r171, r102
-  Move         r172, r114
+  Move         r170, r101
+  Move         r171, r113
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Move         r173, r115
-  Move         r174, r130
+  Move         r172, r114
+  Move         r173, r129
   // avg_qty: avg(from x in g select x.l_quantity),
-  Move         r175, r131
-  Move         r176, r140
+  Move         r174, r130
+  Move         r175, r139
   // avg_price: avg(from x in g select x.l_extendedprice),
-  Move         r177, r141
-  Move         r178, r150
+  Move         r176, r140
+  Move         r177, r149
   // avg_disc: avg(from x in g select x.l_discount),
-  Move         r179, r151
-  Move         r180, r160
+  Move         r178, r150
+  Move         r179, r159
   // count_order: count(g)
+  Move         r180, r160
   Move         r181, r161
-  Move         r182, r162
   // select {
-  MakeMap      r183, 10, r163
+  MakeMap      r182, 10, r162
   // from row in lineitem
-  Append       r1, r1, r183
-  AddInt       r69, r69, r67
+  Append       r1, r1, r182
+  AddInt       r68, r68, r65
   Jump         L19
 L4:
   // json(result)
   JSON         r1
   // returnflag: "N",
-  Const        r185, "returnflag"
-  Const        r186, "N"
+  Move         r184, r74
+  Const        r185, "N"
   // linestatus: "O",
-  Const        r187, "linestatus"
-  Const        r188, "O"
+  Move         r186, r77
+  Const        r187, "O"
   // sum_qty: 53,
-  Const        r189, "sum_qty"
-  Const        r190, 53
+  Move         r188, r8
+  Const        r189, 53
   // sum_base_price: 3000,
-  Const        r191, "sum_base_price"
-  Const        r192, 3000
+  Move         r190, r10
+  Const        r191, 3000
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
-  Const        r193, "sum_disc_price"
-  Const        r196, 2750
+  Move         r192, r12
+  Const        r195, 2750
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
-  Const        r197, "sum_charge"
-  Const        r202, 2906.5
+  Move         r196, r14
+  Const        r201, 2906.5
   // avg_qty: 26.5,
-  Const        r203, "avg_qty"
-  Const        r204, 26.5
+  Move         r202, r16
+  Const        r203, 26.5
   // avg_price: 1500,
-  Const        r205, "avg_price"
-  Const        r206, 1500
+  Move         r204, r17
+  Const        r205, 1500
   // avg_disc: 0.07500000000000001,
-  Const        r207, "avg_disc"
-  Const        r208, 0.07500000000000001
+  Move         r206, r18
+  Const        r207, 0.07500000000000001
   // count_order: 2
-  Const        r209, "count_order"
-  Const        r210, 2
+  Move         r208, r19
+  Const        r209, 2
   // returnflag: "N",
+  Move         r210, r184
   Move         r211, r185
-  Move         r212, r186
   // linestatus: "O",
+  Move         r212, r186
   Move         r213, r187
-  Move         r214, r188
   // sum_qty: 53,
+  Move         r214, r188
   Move         r215, r189
-  Move         r216, r190
   // sum_base_price: 3000,
+  Move         r216, r190
   Move         r217, r191
-  Move         r218, r192
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
-  Move         r219, r193
-  Move         r220, r196
+  Move         r218, r192
+  Move         r219, r195
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
-  Move         r221, r197
-  Move         r222, r202
+  Move         r220, r196
+  Move         r221, r201
   // avg_qty: 26.5,
+  Move         r222, r202
   Move         r223, r203
-  Move         r224, r204
   // avg_price: 1500,
+  Move         r224, r204
   Move         r225, r205
-  Move         r226, r206
   // avg_disc: 0.07500000000000001,
+  Move         r226, r206
   Move         r227, r207
-  Move         r228, r208
   // count_order: 2
+  Move         r228, r208
   Move         r229, r209
-  Move         r230, r210
   // {
-  MakeMap      r232, 10, r211
+  MakeMap      r231, 10, r210
   // expect result == [
-  MakeList     r233, 1, r232
-  Equal        r234, r1, r233
-  Expect       r234
+  MakeList     r232, 1, r231
+  Equal        r233, r1, r232
+  Expect       r233
   Return       r0

--- a/tests/dataset/tpc-h/out/q10.ir.out
+++ b/tests/dataset/tpc-h/out/q10.ir.out
@@ -1,4 +1,4 @@
-func main (regs=216)
+func main (regs=254)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
@@ -34,245 +34,352 @@ func main (regs=216)
   // c_custkey: g.key.c_custkey,
   Const        r16, "key"
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Const        r17, "revenue"
   Const        r18, "l"
   Const        r19, "l_extendedprice"
   Const        r20, "l_discount"
   // from c in customer
   MakeMap      r21, 0, r0
-  Const        r22, []
-  IterPrep     r23, r1
-  Len          r24, r23
-  Const        r25, 0
+  IterPrep     r22, r1
+  Len          r23, r22
+  Const        r24, 0
 L11:
-  LessInt      r26, r25, r24
-  JumpIfFalse  r26, L0
-  Index        r28, r23, r25
+  LessInt      r25, r24, r23
+  JumpIfFalse  r25, L0
+  Index        r27, r22, r24
   // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r29, r2
-  Len          r30, r29
-  Const        r31, 0
+  IterPrep     r28, r2
+  Len          r29, r28
+  Move         r30, r24
 L10:
-  Less         r32, r31, r30
-  JumpIfFalse  r32, L1
-  Index        r34, r29, r31
-  Const        r35, "o_custkey"
-  Index        r36, r34, r35
-  Index        r37, r28, r7
-  Equal        r38, r36, r37
-  JumpIfFalse  r38, L2
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L1
+  Index        r33, r28, r30
+  Const        r34, "o_custkey"
+  Index        r35, r33, r34
+  Index        r36, r27, r7
+  Equal        r37, r35, r36
+  JumpIfFalse  r37, L2
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r39, r3
-  Len          r40, r39
-  Const        r41, 0
+  IterPrep     r38, r3
+  Len          r39, r38
+  Move         r40, r24
 L9:
-  Less         r42, r41, r40
-  JumpIfFalse  r42, L2
-  Index        r44, r39, r41
-  Const        r45, "l_orderkey"
-  Index        r46, r44, r45
-  Const        r47, "o_orderkey"
-  Index        r48, r34, r47
-  Equal        r49, r46, r48
-  JumpIfFalse  r49, L3
+  LessInt      r41, r40, r39
+  JumpIfFalse  r41, L2
+  Index        r43, r38, r40
+  Const        r44, "l_orderkey"
+  Index        r45, r43, r44
+  Const        r46, "o_orderkey"
+  Index        r47, r33, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L3
   // join n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r50, r0
-  Len          r51, r50
-  Const        r52, 0
+  IterPrep     r49, r0
+  Len          r50, r49
+  Move         r51, r40
 L8:
-  Less         r53, r52, r51
-  JumpIfFalse  r53, L3
-  Index        r55, r50, r52
-  Const        r56, "n_nationkey"
-  Index        r57, r55, r56
-  Const        r58, "c_nationkey"
-  Index        r59, r28, r58
-  Equal        r60, r57, r59
-  JumpIfFalse  r60, L4
+  LessInt      r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r54, r49, r51
+  Const        r55, "n_nationkey"
+  Index        r56, r54, r55
+  Const        r57, "c_nationkey"
+  Index        r58, r27, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
   // where o.o_orderdate >= start_date &&
-  Index        r61, r34, r14
-  LessEq       r62, r4, r61
+  Index        r60, r33, r14
+  LessEq       r61, r4, r60
   // o.o_orderdate < end_date &&
-  Index        r63, r34, r14
-  Less         r64, r63, r5
+  Index        r62, r33, r14
+  Less         r63, r62, r5
   // l.l_returnflag == "R"
-  Index        r65, r44, r15
-  Const        r66, "R"
-  Equal        r67, r65, r66
+  Index        r64, r43, r15
+  Const        r65, "R"
+  Equal        r66, r64, r65
   // where o.o_orderdate >= start_date &&
-  Move         r68, r62
-  JumpIfFalse  r68, L5
+  Move         r67, r61
+  JumpIfFalse  r67, L5
 L5:
   // o.o_orderdate < end_date &&
-  Move         r69, r64
-  JumpIfFalse  r69, L6
-  Move         r69, r67
+  Move         r68, r63
+  JumpIfFalse  r68, L6
+  Move         r68, r66
 L6:
   // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r69, L4
+  JumpIfFalse  r68, L4
   // from c in customer
-  Const        r70, "c"
-  Move         r71, r28
-  Const        r72, "o"
-  Move         r73, r34
-  Move         r74, r44
+  Const        r69, "c"
+  Move         r70, r27
+  Const        r71, "o"
+  Move         r72, r33
+  Move         r73, r18
+  Move         r74, r43
   Const        r75, "n"
-  Move         r76, r55
-  MakeMap      r77, 4, r70
+  Move         r76, r54
+  MakeMap      r77, 4, r69
   // c_custkey: c.c_custkey,
-  Const        r78, "c_custkey"
-  Index        r79, r28, r7
+  Move         r78, r7
+  Index        r79, r27, r7
   // c_name: c.c_name,
-  Const        r80, "c_name"
-  Index        r81, r28, r8
+  Move         r80, r8
+  Index        r81, r27, r8
   // c_acctbal: c.c_acctbal,
-  Const        r82, "c_acctbal"
-  Index        r83, r28, r9
+  Move         r82, r9
+  Index        r83, r27, r9
   // c_address: c.c_address,
-  Const        r84, "c_address"
-  Index        r85, r28, r10
+  Move         r84, r10
+  Index        r85, r27, r10
   // c_phone: c.c_phone,
-  Const        r86, "c_phone"
-  Index        r87, r28, r11
+  Move         r86, r11
+  Index        r87, r27, r11
   // c_comment: c.c_comment,
-  Const        r88, "c_comment"
-  Index        r89, r28, r12
+  Move         r88, r12
+  Index        r89, r27, r12
   // n_name: n.n_name
-  Const        r90, "n_name"
-  Index        r91, r55, r13
+  Move         r90, r13
+  Index        r91, r54, r13
+  // c_custkey: c.c_custkey,
+  Move         r92, r78
+  Move         r93, r79
+  // c_name: c.c_name,
+  Move         r94, r80
+  Move         r95, r81
+  // c_acctbal: c.c_acctbal,
+  Move         r96, r82
+  Move         r97, r83
+  // c_address: c.c_address,
+  Move         r98, r84
+  Move         r99, r85
+  // c_phone: c.c_phone,
+  Move         r100, r86
+  Move         r101, r87
+  // c_comment: c.c_comment,
+  Move         r102, r88
+  Move         r103, r89
+  // n_name: n.n_name
+  Move         r104, r90
+  Move         r105, r91
   // group by {
-  MakeMap      r99, 7, r78
-  Str          r100, r99
-  In           r101, r100, r21
-  JumpIfTrue   r101, L7
+  MakeMap      r106, 7, r92
+  Str          r107, r106
+  In           r108, r107, r21
+  JumpIfTrue   r108, L7
   // from c in customer
-  Const        r102, []
-  Const        r103, "__group__"
-  Const        r104, true
+  Move         r109, r6
+  Const        r110, "__group__"
+  Const        r111, true
+  Move         r112, r16
   // group by {
-  Move         r105, r99
+  Move         r113, r106
   // from c in customer
-  Const        r106, "items"
-  Move         r107, r102
-  MakeMap      r108, 3, r103
-  SetIndex     r21, r100, r108
-  Append       r22, r22, r108
+  Const        r114, "items"
+  Move         r115, r109
+  Const        r116, "count"
+  Move         r117, r24
+  Move         r118, r110
+  Move         r119, r111
+  Move         r120, r112
+  Move         r121, r113
+  Move         r122, r114
+  Move         r123, r115
+  Move         r124, r116
+  Move         r125, r117
+  MakeMap      r126, 4, r118
+  SetIndex     r21, r107, r126
 L7:
-  Index        r110, r21, r100
-  Index        r111, r110, r106
-  Append       r112, r111, r77
-  SetIndex     r110, r106, r112
+  Move         r127, r114
+  Index        r128, r21, r107
+  Index        r129, r128, r127
+  Append       r130, r129, r77
+  SetIndex     r128, r127, r130
+  Move         r131, r116
+  Index        r132, r128, r131
+  Const        r133, 1
+  AddInt       r134, r132, r133
+  SetIndex     r128, r131, r134
 L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  Const        r113, 1
-  AddInt       r52, r52, r113
+  AddInt       r51, r51, r133
   Jump         L8
 L3:
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r41, r41, r113
+  AddInt       r40, r40, r133
   Jump         L9
 L2:
   // join o in orders on o.o_custkey == c.c_custkey
+  AddInt       r30, r30, r133
   Jump         L10
 L1:
   // from c in customer
+  AddInt       r24, r24, r133
   Jump         L11
 L0:
-  Const        r115, 0
-  Move         r114, r115
-  Len          r116, r22
+  Values       135,21,0,0
+  Move         r137, r117
+  Move         r136, r137
+  Len          r138, r135
 L17:
-  LessInt      r117, r114, r116
-  JumpIfFalse  r117, L12
-  Index        r119, r22, r114
+  LessInt      r139, r136, r138
+  JumpIfFalse  r139, L12
+  Index        r141, r135, r136
   // c_custkey: g.key.c_custkey,
-  Const        r120, "c_custkey"
-  Index        r121, r119, r16
-  Index        r122, r121, r7
+  Move         r142, r7
+  Index        r143, r141, r16
+  Index        r144, r143, r7
   // c_name: g.key.c_name,
-  Const        r123, "c_name"
-  Index        r124, r119, r16
-  Index        r125, r124, r8
+  Move         r145, r8
+  Index        r146, r141, r16
+  Index        r147, r146, r8
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r126, "revenue"
-  Const        r127, []
-  IterPrep     r128, r119
-  Len          r129, r128
-  Move         r130, r115
+  Move         r148, r17
+  Move         r149, r6
+  IterPrep     r150, r141
+  Len          r151, r150
+  Move         r152, r137
 L14:
-  LessInt      r131, r130, r129
-  JumpIfFalse  r131, L13
-  Index        r132, r128, r130
-  Move         r133, r132
-  Index        r134, r133, r18
-  Index        r135, r134, r19
-  Index        r136, r133, r18
-  Index        r137, r136, r20
-  Sub          r138, r113, r137
-  Mul          r139, r135, r138
-  Append       r127, r127, r139
-  AddInt       r130, r130, r113
+  LessInt      r153, r152, r151
+  JumpIfFalse  r153, L13
+  Index        r155, r150, r152
+  Index        r156, r155, r18
+  Index        r157, r156, r19
+  Index        r158, r155, r18
+  Index        r159, r158, r20
+  Sub          r160, r133, r159
+  Mul          r161, r157, r160
+  Append       r149, r149, r161
+  AddInt       r152, r152, r133
   Jump         L14
 L13:
+  Sum          r163, r149
+  // c_acctbal: g.key.c_acctbal,
+  Move         r164, r9
+  Index        r165, r141, r16
+  Index        r166, r165, r9
+  // n_name: g.key.n_name,
+  Move         r167, r13
+  Index        r168, r141, r16
+  Index        r169, r168, r13
+  // c_address: g.key.c_address,
+  Move         r170, r10
+  Index        r171, r141, r16
+  Index        r172, r171, r10
+  // c_phone: g.key.c_phone,
+  Move         r173, r11
+  Index        r174, r141, r16
+  Index        r175, r174, r11
+  // c_comment: g.key.c_comment
+  Move         r176, r12
+  Index        r177, r141, r16
+  Index        r178, r177, r12
+  // c_custkey: g.key.c_custkey,
+  Move         r179, r142
+  Move         r180, r144
+  // c_name: g.key.c_name,
+  Move         r181, r145
+  Move         r182, r147
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r183, r148
+  Move         r184, r163
+  // c_acctbal: g.key.c_acctbal,
+  Move         r185, r164
+  Move         r186, r166
+  // n_name: g.key.n_name,
+  Move         r187, r167
+  Move         r188, r169
+  // c_address: g.key.c_address,
+  Move         r189, r170
+  Move         r190, r172
+  // c_phone: g.key.c_phone,
+  Move         r191, r173
+  Move         r192, r175
+  // c_comment: g.key.c_comment
+  Move         r193, r176
+  Move         r194, r178
   // select {
-  MakeMap      r165, 8, r120
+  MakeMap      r195, 8, r179
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r166, []
-  IterPrep     r167, r119
-  Len          r168, r167
-  Move         r169, r115
+  Move         r196, r6
+  IterPrep     r197, r141
+  Len          r198, r197
+  Move         r199, r137
 L16:
-  LessInt      r170, r169, r168
-  JumpIfFalse  r170, L15
-  Index        r133, r167, r169
-  Index        r172, r133, r18
-  Index        r173, r172, r19
-  Index        r174, r133, r18
-  Index        r175, r174, r20
-  Sub          r176, r113, r175
-  Mul          r177, r173, r176
-  Append       r166, r166, r177
-  AddInt       r169, r169, r113
+  LessInt      r200, r199, r198
+  JumpIfFalse  r200, L15
+  Index        r155, r197, r199
+  Index        r202, r155, r18
+  Index        r203, r202, r19
+  Index        r204, r155, r18
+  Index        r205, r204, r20
+  Sub          r206, r133, r205
+  Mul          r207, r203, r206
+  Append       r196, r196, r207
+  AddInt       r199, r199, r133
   Jump         L16
 L15:
-  Sum          r179, r166
-  Neg          r181, r179
+  Sum          r209, r196
+  Neg          r211, r209
   // from c in customer
-  Move         r182, r165
-  MakeList     r183, 2, r181
-  Append       r6, r6, r183
-  AddInt       r114, r114, r113
+  Move         r212, r195
+  MakeList     r213, 2, r211
+  Append       r6, r6, r213
+  AddInt       r136, r136, r133
   Jump         L17
 L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r6, r6
   // c_custkey: 1,
-  Const        r187, "c_custkey"
+  Move         r217, r142
   // c_name: "Alice",
-  Const        r188, "c_name"
-  Const        r189, "Alice"
+  Move         r218, r145
+  Const        r219, "Alice"
   // revenue: 1000.0 * 0.9, // 900.0
-  Const        r190, "revenue"
-  Const        r191, 1000
-  Const        r192, 0.9
-  Const        r193, 900
+  Move         r220, r17
+  Const        r223, 900
   // c_acctbal: 100.0,
-  Const        r194, "c_acctbal"
-  Const        r195, 100
+  Move         r224, r164
+  Const        r225, 100
   // n_name: "BRAZIL",
-  Const        r196, "n_name"
-  Const        r197, "BRAZIL"
+  Move         r226, r167
+  Const        r227, "BRAZIL"
   // c_address: "123 St",
-  Const        r198, "c_address"
-  Const        r199, "123 St"
+  Move         r228, r170
+  Const        r229, "123 St"
   // c_phone: "123-456",
-  Const        r200, "c_phone"
-  Const        r201, "123-456"
+  Move         r230, r173
+  Const        r231, "123-456"
   // c_comment: "Loyal"
-  Const        r202, "c_comment"
+  Move         r232, r176
+  Const        r233, "Loyal"
+  // c_custkey: 1,
+  Move         r234, r217
+  Move         r235, r133
+  // c_name: "Alice",
+  Move         r236, r218
+  Move         r237, r219
+  // revenue: 1000.0 * 0.9, // 900.0
+  Move         r238, r220
+  Move         r239, r223
+  // c_acctbal: 100.0,
+  Move         r240, r224
+  Move         r241, r225
+  // n_name: "BRAZIL",
+  Move         r242, r226
+  Move         r243, r227
+  // c_address: "123 St",
+  Move         r244, r228
+  Move         r245, r229
+  // c_phone: "123-456",
+  Move         r246, r230
+  Move         r247, r231
+  // c_comment: "Loyal"
+  Move         r248, r232
+  Move         r249, r233
   // {
-  MakeMap      r213, 8, r187
+  MakeMap      r251, 8, r234
   // expect result == [
-  MakeList     r214, 1, r213
-  Equal        r215, r6, r214
-  Expect       r215
+  MakeList     r252, 1, r251
+  Equal        r253, r6, r252
+  Expect       r253
   Return       r0


### PR DESCRIPTION
## Summary
- ensure row map building uses fresh constants for contiguous registers
- skip register compaction to avoid corrupting MakeMap sequences
- update tpch dataset IR for q1 and q10

## Testing
- `go test ./tests/vm -run "TestVM_TPCH/q1\.mochi$" -tags slow -count=1`
- `go test ./tests/vm -run "TestVM_TPCH/q10\.mochi$" -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686167dd612c83208e7b2d9fb9869543