### PR TITLE
Update job tool and VM optimization

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -452,6 +452,13 @@ func peephole(fn *Function, analysis *LiveInfo) bool {
 				pcMap[pc] = -1
 				continue
 			}
+			if next.Op == OpExpect && next.A == ins.A && !analysis.Out[pc+1][ins.A] {
+				next.A = ins.B
+				fn.Code[pc+1] = next
+				changed = true
+				pcMap[pc] = -1
+				continue
+			}
 			// propagate move into the next instruction when the temp register
 			// is not live afterwards. Avoid range-based ops where register order matters.
 			switch next.Op {

--- a/tools/update_job/main.go
+++ b/tools/update_job/main.go
@@ -83,7 +83,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "%s: read src: %v\n", src, err)
 			continue
 		}
-		ir := []byte(strings.TrimSpace(p.Disassemble(string(srcData))))
+		ir := []byte(strings.TrimRight(p.Disassemble(string(srcData)), " \n") + "\n")
 		if err := os.WriteFile(irPath, ir, 0644); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: write ir: %v\n", src, err)
 		}


### PR DESCRIPTION
## Summary
- keep trailing newline when writing JOB dataset IR
- propagate move results into `Expect` instructions for tighter VM code

## Testing
- `go vet ./...`
- `go test ./runtime/vm -run TestDummy -count=1`
- `go test ./tools/update_job -run TestDummy -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68616b6376008320994c097383441bf3