### PR TITLE
Fix TPC-H row map generation in VM

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -295,7 +295,9 @@ func Optimize(fn *Function) {
 			break
 		}
 	}
-	CompactRegisters(fn)
+	// Register compaction can disturb MakeMap sequences that rely on
+	// contiguous key/value registers, so skip this step.
+	// CompactRegisters(fn)
 }
 
 // removeDead eliminates instructions that only define dead registers.

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -4647,7 +4647,7 @@ func (fc *funcCompiler) buildRowMap(q *parser.QueryExpr) int {
 
 	pairs := make([]int, len(names)*2)
 	for i, n := range names {
-		k := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: n})
+		k := fc.freshConst(q.Pos, Value{Tag: ValueStr, Str: n})
 		v := fc.newReg()
 		fc.emit(q.Pos, Instr{Op: OpMove, A: v, B: regs[i]})
 		pairs[i*2] = k

--- a/tests/dataset/tpc-h/out/q1.ir.out
+++ b/tests/dataset/tpc-h/out/q1.ir.out
@@ -1,4 +1,4 @@
-func main (regs=39)
+func main (regs=234)
   // let lineitem = [
   Const        r0, [{"l_discount": 0.05, "l_extendedprice": 1000, "l_linestatus": "O", "l_quantity": 17, "l_returnflag": "N", "l_shipdate": "1998-08-01", "l_tax": 0.07}, {"l_discount": 0.1, "l_extendedprice": 2000, "l_linestatus": "O", "l_quantity": 36, "l_returnflag": "N", "l_shipdate": "1998-09-01", "l_tax": 0.05}, {"l_discount": 0, "l_extendedprice": 1500, "l_linestatus": "F", "l_quantity": 25, "l_returnflag": "R", "l_shipdate": "1998-09-03", "l_tax": 0.08}]
   // from row in lineitem
@@ -11,7 +11,6 @@ func main (regs=39)
   Const        r5, "l_linestatus"
   // where row.l_shipdate <= "1998-09-02"
   Const        r6, "l_shipdate"
-L12:
   // returnflag: g.key.returnflag,
   Const        r7, "key"
   // sum_qty: sum(from x in g select x.l_quantity),
@@ -25,7 +24,6 @@ L12:
   Const        r13, "l_discount"
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
   Const        r14, "sum_charge"
-L6:
   Const        r15, "l_tax"
   // avg_qty: avg(from x in g select x.l_quantity),
   Const        r16, "avg_qty"
@@ -35,309 +33,318 @@ L6:
   Const        r18, "avg_disc"
   // count_order: count(g)
   Const        r19, "count_order"
-L3:
   // from row in lineitem
   IterPrep     r20, r0
-L4:
   Len          r21, r20
   Const        r22, 0
-L11:
   MakeMap      r23, 0, r0
-L1:
+L3:
   LessInt      r24, r22, r21
-L0:
   JumpIfFalse  r24, L0
-L5:
-  Index        r21, r20, r22
-L8:
-  Move         r20, r21
+  Index        r25, r20, r22
+  Move         r26, r25
   // where row.l_shipdate <= "1998-09-02"
-  Index        r25, r20, r6
-  Const        r6, "1998-09-02"
-  LessEq       r26, r25, r6
-  JumpIfFalse  r26, L1
+  Index        r27, r26, r6
+  Const        r28, "1998-09-02"
+  LessEq       r29, r27, r28
+  JumpIfFalse  r29, L1
+  // returnflag: row.l_returnflag,
+  Move         r30, r2
+  Index        r31, r26, r3
+  // linestatus: row.l_linestatus
+  Move         r32, r4
+  Index        r33, r26, r5
+  // returnflag: row.l_returnflag,
+  Move         r34, r30
+  Move         r35, r31
+  // linestatus: row.l_linestatus
+  Move         r36, r32
+  Move         r37, r33
+  // group by {
+  MakeMap      r38, 2, r34
+  Str          r39, r38
+  In           r40, r39, r23
+  JumpIfTrue   r40, L2
+  // from row in lineitem
+  Move         r41, r1
+  Const        r42, "__group__"
+  Const        r43, true
+  Move         r44, r7
+  // group by {
+  Move         r45, r38
+  // from row in lineitem
+  Const        r46, "items"
+  Move         r47, r41
+  Const        r48, "count"
+  Move         r49, r22
+  Move         r50, r42
+  Move         r51, r43
+  Move         r52, r44
+  Move         r53, r45
+  Move         r54, r46
+  Move         r55, r47
+  Move         r56, r48
+  Move         r57, r49
+  MakeMap      r58, 4, r50
+  SetIndex     r23, r39, r58
 L2:
-  // returnflag: row.l_returnflag,
-  Move         r26, r2
-  Index        r6, r20, r3
-L9:
-  // linestatus: row.l_linestatus
-  Move         r3, r4
-  Index        r25, r20, r5
-  // returnflag: row.l_returnflag,
-  Move         r20, r26
-  Move         r26, r6
-L10:
-  // linestatus: row.l_linestatus
-  Move         r6, r3
-  Move         r3, r25
-  // group by {
-  MakeMap      r25, 2, r20
-  Str          r3, r25
-  In           r6, r3, r23
-  JumpIfTrue   r6, L2
-  // from row in lineitem
-  Move         r6, r1
-  Const        r26, "__group__"
-  Const        r20, true
-  Move         r5, r7
-  // group by {
-  Move         r27, r25
-  // from row in lineitem
-  Const        r25, "items"
-  Move         r28, r6
-  Const        r6, "count"
-  Move         r29, r22
-  Move         r30, r26
-  Move         r26, r20
-  Move         r20, r5
-  Move         r5, r27
-  Move         r27, r25
-  Move         r31, r28
-  Move         r28, r6
-  Move         r32, r29
-  MakeMap      r29, 4, r30
-  SetIndex     r23, r3, r29
-  Move         r29, r25
-  Index        r25, r23, r3
-  Index        r3, r25, r29
-  Append       r32, r3, r21
-  SetIndex     r25, r29, r32
-  Move         r32, r6
-  Index        r6, r25, r32
-  Const        r3, 1
-  AddInt       r29, r6, r3
-  SetIndex     r25, r32, r29
-  AddInt       r22, r22, r3
-  Jump         L1
-  Values       29,23,0,0
-  Const        r23, 0
-  Move         r6, r23
-  Len          r25, r29
-  LessInt      r24, r6, r25
-  JumpIfFalse  r24, L0
-  Index        r24, r29, r6
+  Move         r59, r46
+  Index        r60, r23, r39
+  Index        r61, r60, r59
+  Append       r62, r61, r25
+  SetIndex     r60, r59, r62
+  Move         r63, r48
+  Index        r64, r60, r63
+  Const        r65, 1
+  AddInt       r66, r64, r65
+  SetIndex     r60, r63, r66
+L1:
+  AddInt       r22, r22, r65
+  Jump         L3
+L0:
+  Values       67,23,0,0
+  Const        r69, 0
+  Move         r68, r69
+  Len          r70, r67
+L19:
+  LessInt      r71, r68, r70
+  JumpIfFalse  r71, L4
+  Index        r73, r67, r68
   // returnflag: g.key.returnflag,
-  Move         r29, r2
-  Index        r25, r24, r7
-  Index        r22, r25, r2
+  Move         r74, r2
+  Index        r75, r73, r7
+  Index        r76, r75, r2
   // linestatus: g.key.linestatus,
-  Move         r25, r4
-  Index        r2, r24, r7
-  Index        r7, r2, r4
+  Move         r77, r4
+  Index        r78, r73, r7
+  Index        r79, r78, r4
   // sum_qty: sum(from x in g select x.l_quantity),
-  Move         r2, r8
-  Move         r4, r1
-  IterPrep     r21, r24
-  Len          r28, r21
-  Move         r31, r23
-  LessInt      r27, r31, r28
-  JumpIfFalse  r27, L3
-  Index        r27, r21, r31
-  Index        r21, r27, r9
-  Append       r4, r4, r21
-  AddInt       r31, r31, r3
-  Jump         L4
-  Sum          r31, r4
+  Move         r80, r8
+  Move         r81, r1
+  IterPrep     r82, r73
+  Len          r83, r82
+  Move         r84, r69
+L6:
+  LessInt      r85, r84, r83
+  JumpIfFalse  r85, L5
+  Index        r87, r82, r84
+  Index        r88, r87, r9
+  Append       r81, r81, r88
+  AddInt       r84, r84, r65
+  Jump         L6
+L5:
+  Sum          r90, r81
   // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Move         r4, r10
-  Move         r28, r1
-  IterPrep     r21, r24
-  Len          r5, r21
-  Move         r20, r23
-  LessInt      r26, r20, r5
-  JumpIfFalse  r26, L5
-  Index        r27, r21, r20
-  Index        r26, r27, r11
-  Append       r28, r28, r26
-  AddInt       r20, r20, r3
-  Jump         L5
-  Sum          r20, r28
-  // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Move         r28, r12
-  Move         r5, r1
-  IterPrep     r21, r24
-  Len          r30, r21
-  Move         r33, r23
-  LessInt      r26, r33, r30
-  JumpIfFalse  r26, L6
-  Index        r27, r21, r33
-  Index        r30, r27, r11
-  Index        r21, r27, r13
-  Sub          r26, r3, r21
-  Mul          r21, r30, r26
-  Append       r5, r5, r21
-  AddInt       r33, r33, r3
-  Jump         L4
-  Sum          r26, r5
-  // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Move         r5, r14
-  Move         r30, r1
-  IterPrep     r33, r24
-  Len          r34, r33
-  Move         r35, r23
-  LessInt      r21, r35, r34
-  JumpIfFalse  r21, L7
-  Index        r27, r33, r35
-  Index        r34, r27, r11
-  Index        r33, r27, r13
-  Sub          r21, r3, r33
-  Mul          r33, r34, r21
-  Index        r21, r27, r15
-  Add          r15, r3, r21
-  Mul          r21, r33, r15
-  Append       r30, r30, r21
-  AddInt       r35, r35, r3
-  Jump         L4
+  Move         r91, r10
+  Move         r92, r1
+  IterPrep     r93, r73
+  Len          r94, r93
+  Move         r95, r69
+L8:
+  LessInt      r96, r95, r94
+  JumpIfFalse  r96, L7
+  Index        r87, r93, r95
+  Index        r98, r87, r11
+  Append       r92, r92, r98
+  AddInt       r95, r95, r65
+  Jump         L8
 L7:
-  Sum          r15, r30
-  // avg_qty: avg(from x in g select x.l_quantity),
-  Move         r30, r16
-  Move         r33, r1
-  IterPrep     r35, r24
-  Len          r34, r35
-  Move         r36, r23
-  LessInt      r21, r36, r34
-  JumpIfFalse  r21, L8
-  Index        r27, r35, r36
-  Index        r34, r27, r9
-  Append       r33, r33, r34
-  AddInt       r36, r36, r3
-  Jump         L9
-  Avg          r36, r33
-  // avg_price: avg(from x in g select x.l_extendedprice),
-  Move         r33, r17
-  Move         r9, r1
-  IterPrep     r35, r24
-  Len          r21, r35
-  Move         r37, r23
-  LessInt      r38, r37, r21
-  JumpIfFalse  r38, L6
-  Index        r27, r35, r37
-  Index        r38, r27, r11
-  Append       r9, r9, r38
-  AddInt       r37, r37, r3
-  Jump         L10
-  Avg          r37, r9
-  // avg_disc: avg(from x in g select x.l_discount),
-  Move         r9, r18
-  Move         r11, r1
-  IterPrep     r21, r24
-  Len          r35, r21
-  Move         r34, r23
-  LessInt      r23, r34, r35
-  JumpIfFalse  r23, L0
-  Index        r27, r21, r34
-  Index        r23, r27, r13
-  Append       r11, r11, r23
-  AddInt       r34, r34, r3
-  Jump         L11
-  Avg          r34, r11
-  // count_order: count(g)
-  Move         r11, r19
-  Index        r27, r24, r32
-  // returnflag: g.key.returnflag,
-  Move         r24, r29
-  Move         r32, r22
-  // linestatus: g.key.linestatus,
-  Move         r22, r25
-  Move         r13, r7
-  // sum_qty: sum(from x in g select x.l_quantity),
-  Move         r35, r2
-  Move         r38, r31
-  // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Move         r31, r4
-  Move         r4, r20
+  Sum          r100, r92
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Move         r20, r28
-  Move         r28, r26
+  Move         r101, r12
+  Move         r102, r1
+  IterPrep     r103, r73
+  Len          r104, r103
+  Move         r105, r69
+L10:
+  LessInt      r106, r105, r104
+  JumpIfFalse  r106, L9
+  Index        r87, r103, r105
+  Index        r108, r87, r11
+  Index        r109, r87, r13
+  Sub          r110, r65, r109
+  Mul          r111, r108, r110
+  Append       r102, r102, r111
+  AddInt       r105, r105, r65
+  Jump         L10
+L9:
+  Sum          r113, r102
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Move         r26, r5
-  Move         r5, r15
-  // avg_qty: avg(from x in g select x.l_quantity),
-  Move         r15, r30
-  Move         r30, r36
-  // avg_price: avg(from x in g select x.l_extendedprice),
-  Move         r36, r33
-  Move         r33, r37
-  // avg_disc: avg(from x in g select x.l_discount),
-  Move         r37, r9
-  Move         r9, r34
-  // count_order: count(g)
-  Move         r23, r11
-  Move         r11, r27
-  // select {
-  MakeMap      r27, 10, r24
-  // from row in lineitem
-  Append       r1, r1, r27
-  AddInt       r6, r6, r3
+  Move         r114, r14
+  Move         r115, r1
+  IterPrep     r116, r73
+  Len          r117, r116
+  Move         r118, r69
+L12:
+  LessInt      r119, r118, r117
+  JumpIfFalse  r119, L11
+  Index        r87, r116, r118
+  Index        r121, r87, r11
+  Index        r122, r87, r13
+  Sub          r123, r65, r122
+  Mul          r124, r121, r123
+  Index        r125, r87, r15
+  Add          r126, r65, r125
+  Mul          r127, r124, r126
+  Append       r115, r115, r127
+  AddInt       r118, r118, r65
   Jump         L12
+L11:
+  Sum          r129, r115
+  // avg_qty: avg(from x in g select x.l_quantity),
+  Move         r130, r16
+  Move         r131, r1
+  IterPrep     r132, r73
+  Len          r133, r132
+  Move         r134, r69
+L14:
+  LessInt      r135, r134, r133
+  JumpIfFalse  r135, L13
+  Index        r87, r132, r134
+  Index        r137, r87, r9
+  Append       r131, r131, r137
+  AddInt       r134, r134, r65
+  Jump         L14
+L13:
+  Avg          r139, r131
+  // avg_price: avg(from x in g select x.l_extendedprice),
+  Move         r140, r17
+  Move         r141, r1
+  IterPrep     r142, r73
+  Len          r143, r142
+  Move         r144, r69
+L16:
+  LessInt      r145, r144, r143
+  JumpIfFalse  r145, L15
+  Index        r87, r142, r144
+  Index        r147, r87, r11
+  Append       r141, r141, r147
+  AddInt       r144, r144, r65
+  Jump         L16
+L15:
+  Avg          r149, r141
+  // avg_disc: avg(from x in g select x.l_discount),
+  Move         r150, r18
+  Move         r151, r1
+  IterPrep     r152, r73
+  Len          r153, r152
+  Move         r154, r69
+L18:
+  LessInt      r155, r154, r153
+  JumpIfFalse  r155, L17
+  Index        r87, r152, r154
+  Index        r157, r87, r13
+  Append       r151, r151, r157
+  AddInt       r154, r154, r65
+  Jump         L18
+L17:
+  Avg          r159, r151
+  // count_order: count(g)
+  Move         r160, r19
+  Index        r161, r73, r63
+  // returnflag: g.key.returnflag,
+  Move         r162, r74
+  Move         r163, r76
+  // linestatus: g.key.linestatus,
+  Move         r164, r77
+  Move         r165, r79
+  // sum_qty: sum(from x in g select x.l_quantity),
+  Move         r166, r80
+  Move         r167, r90
+  // sum_base_price: sum(from x in g select x.l_extendedprice),
+  Move         r168, r91
+  Move         r169, r100
+  // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
+  Move         r170, r101
+  Move         r171, r113
+  // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
+  Move         r172, r114
+  Move         r173, r129
+  // avg_qty: avg(from x in g select x.l_quantity),
+  Move         r174, r130
+  Move         r175, r139
+  // avg_price: avg(from x in g select x.l_extendedprice),
+  Move         r176, r140
+  Move         r177, r149
+  // avg_disc: avg(from x in g select x.l_discount),
+  Move         r178, r150
+  Move         r179, r159
+  // count_order: count(g)
+  Move         r180, r160
+  Move         r181, r161
+  // select {
+  MakeMap      r182, 10, r162
+  // from row in lineitem
+  Append       r1, r1, r182
+  AddInt       r68, r68, r65
+  Jump         L19
+L4:
   // json(result)
   JSON         r1
   // returnflag: "N",
-  Move         r27, r29
-  Const        r29, "N"
+  Move         r184, r74
+  Const        r185, "N"
   // linestatus: "O",
-  Move         r11, r25
-  Const        r25, "O"
+  Move         r186, r77
+  Const        r187, "O"
   // sum_qty: 53,
-  Move         r9, r8
-  Const        r8, 53
+  Move         r188, r8
+  Const        r189, 53
   // sum_base_price: 3000,
-  Move         r37, r10
-  Const        r10, 3000
+  Move         r190, r10
+  Const        r191, 3000
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
-  Move         r33, r12
-  Const        r12, 2750
+  Move         r192, r12
+  Const        r195, 2750
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
-  Move         r36, r14
-  Const        r14, 2906.5
+  Move         r196, r14
+  Const        r201, 2906.5
   // avg_qty: 26.5,
-  Move         r30, r16
-  Const        r16, 26.5
+  Move         r202, r16
+  Const        r203, 26.5
   // avg_price: 1500,
-  Move         r15, r17
-  Const        r17, 1500
+  Move         r204, r17
+  Const        r205, 1500
   // avg_disc: 0.07500000000000001,
-  Move         r5, r18
-  Const        r18, 0.07500000000000001
+  Move         r206, r18
+  Const        r207, 0.07500000000000001
   // count_order: 2
-  Move         r26, r19
-  Const        r19, 2
+  Move         r208, r19
+  Const        r209, 2
   // returnflag: "N",
-  Move         r28, r27
-  Move         r27, r29
+  Move         r210, r184
+  Move         r211, r185
   // linestatus: "O",
-  Move         r29, r11
-  Move         r11, r25
+  Move         r212, r186
+  Move         r213, r187
   // sum_qty: 53,
-  Move         r25, r9
-  Move         r9, r8
+  Move         r214, r188
+  Move         r215, r189
   // sum_base_price: 3000,
-  Move         r8, r37
-  Move         r37, r10
+  Move         r216, r190
+  Move         r217, r191
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
-  Move         r10, r33
-  Move         r33, r12
+  Move         r218, r192
+  Move         r219, r195
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
-  Move         r12, r36
-  Move         r36, r14
+  Move         r220, r196
+  Move         r221, r201
   // avg_qty: 26.5,
-  Move         r14, r30
-  Move         r30, r16
+  Move         r222, r202
+  Move         r223, r203
   // avg_price: 1500,
-  Move         r16, r15
-  Move         r15, r17
+  Move         r224, r204
+  Move         r225, r205
   // avg_disc: 0.07500000000000001,
-  Move         r17, r5
-  Move         r5, r18
+  Move         r226, r206
+  Move         r227, r207
   // count_order: 2
-  Move         r18, r26
-  Move         r26, r19
+  Move         r228, r208
+  Move         r229, r209
   // {
-  MakeMap      r19, 10, r28
+  MakeMap      r231, 10, r210
   // expect result == [
-  MakeList     r26, 1, r19
-  Equal        r19, r1, r26
-  Expect       r19
+  MakeList     r232, 1, r231
+  Equal        r233, r1, r232
+  Expect       r233
   Return       r0

--- a/tests/dataset/tpc-h/out/q10.ir.out
+++ b/tests/dataset/tpc-h/out/q10.ir.out
@@ -1,28 +1,24 @@
-func main (regs=38)
+func main (regs=254)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
   Const        r1, [{"c_acctbal": 100, "c_address": "123 St", "c_comment": "Loyal", "c_custkey": 1, "c_name": "Alice", "c_nationkey": 1, "c_phone": "123-456"}]
   // let orders = [
   Const        r2, [{"o_custkey": 1, "o_orderdate": "1993-10-15", "o_orderkey": 1000}, {"o_custkey": 1, "o_orderdate": "1994-01-02", "o_orderkey": 2000}]
-L12:
   // let lineitem = [
   Const        r3, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 1000, "l_returnflag": "R"}, {"l_discount": 0, "l_extendedprice": 500, "l_orderkey": 2000, "l_returnflag": "N"}]
   // let start_date = "1993-10-01"
   Const        r4, "1993-10-01"
-L6:
   // let end_date = "1994-01-01"
   Const        r5, "1994-01-01"
   // from c in customer
   Const        r6, []
-L3:
   // c_custkey: c.c_custkey,
   Const        r7, "c_custkey"
   // c_name: c.c_name,
   Const        r8, "c_name"
   // c_acctbal: c.c_acctbal,
   Const        r9, "c_acctbal"
-L13:
   // c_address: c.c_address,
   Const        r10, "c_address"
   // c_phone: c.c_phone,
@@ -37,7 +33,6 @@ L13:
   Const        r15, "l_returnflag"
   // c_custkey: g.key.c_custkey,
   Const        r16, "key"
-L11:
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
   Const        r17, "revenue"
   Const        r18, "l"
@@ -46,335 +41,345 @@ L11:
   // from c in customer
   MakeMap      r21, 0, r0
   IterPrep     r22, r1
-  Len          r1, r22
-L10:
-  Const        r23, 0
-  LessInt      r24, r23, r1
-L9:
-  JumpIfFalse  r24, L0
-L8:
-  Index        r1, r22, r23
-L5:
+  Len          r23, r22
+  Const        r24, 0
+L11:
+  LessInt      r25, r24, r23
+  JumpIfFalse  r25, L0
+  Index        r27, r22, r24
   // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r22, r2
-  Len          r2, r22
-L7:
-  Move         r25, r23
-L4:
-  LessInt      r26, r25, r2
-  JumpIfFalse  r26, L1
-  Index        r2, r22, r25
-  Const        r22, "o_custkey"
-L2:
-  Index        r27, r2, r22
-L1:
-  Index        r22, r1, r7
-  Equal        r28, r27, r22
-  JumpIfFalse  r28, L2
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r28, r3
-  Len          r3, r28
-  Move         r22, r23
-  LessInt      r27, r22, r3
-  JumpIfFalse  r27, L2
-  Index        r27, r28, r22
-  Const        r28, "l_orderkey"
-  Index        r3, r27, r28
-  Const        r28, "o_orderkey"
-  Index        r29, r2, r28
-  Equal        r28, r3, r29
-  JumpIfFalse  r28, L3
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r28, r0
+  IterPrep     r28, r2
   Len          r29, r28
-  Move         r3, r22
-  LessInt      r30, r3, r29
-  JumpIfFalse  r30, L3
-  Index        r30, r28, r3
-  Const        r28, "n_nationkey"
-  Index        r29, r30, r28
-  Const        r28, "c_nationkey"
-  Index        r31, r1, r28
-  Equal        r28, r29, r31
-  JumpIfFalse  r28, L3
-  // where o.o_orderdate >= start_date &&
-  Index        r28, r2, r14
-  LessEq       r31, r4, r28
-  // o.o_orderdate < end_date &&
-  Index        r28, r2, r14
-  Less         r14, r28, r5
-  // l.l_returnflag == "R"
-  Index        r28, r27, r15
-  Const        r15, "R"
-  Equal        r5, r28, r15
-  // where o.o_orderdate >= start_date &&
-  Move         r15, r31
-  JumpIfFalse  r15, L4
-  // o.o_orderdate < end_date &&
-  Move         r15, r14
-  JumpIfFalse  r15, L5
-  Move         r15, r5
-  // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r15, L3
-  // from c in customer
-  Const        r15, "c"
-  Move         r5, r1
-  Const        r14, "o"
-  Move         r31, r2
-  Move         r2, r27
-  Const        r27, "n"
-  Move         r28, r30
-  MakeMap      r4, 4, r15
-  // c_custkey: c.c_custkey,
-  Move         r28, r7
-  Index        r27, r1, r7
-  // c_name: c.c_name,
-  Move         r2, r8
-  Index        r31, r1, r8
-  // c_acctbal: c.c_acctbal,
-  Move         r14, r9
-  Index        r5, r1, r9
-  // c_address: c.c_address,
-  Move         r15, r10
-  Index        r29, r1, r10
-  // c_phone: c.c_phone,
-  Move         r32, r11
-  Index        r33, r1, r11
-  // c_comment: c.c_comment,
-  Move         r34, r12
-  Index        r35, r1, r12
-  // n_name: n.n_name
-  Move         r1, r13
-  Index        r36, r30, r13
-  // c_custkey: c.c_custkey,
-  Move         r37, r28
-  Move         r28, r27
-  // c_name: c.c_name,
-  Move         r27, r2
-  Move         r2, r31
-  // c_acctbal: c.c_acctbal,
-  Move         r31, r14
-  Move         r14, r5
-  // c_address: c.c_address,
-  Move         r5, r15
-  Move         r15, r29
-  // c_phone: c.c_phone,
-  Move         r29, r32
-  Move         r32, r33
-  // c_comment: c.c_comment,
-  Move         r33, r34
-  Move         r34, r35
-  // n_name: n.n_name
-  Move         r35, r1
-  Move         r1, r36
-  // group by {
-  MakeMap      r36, 7, r37
-  Str          r1, r36
-  In           r35, r1, r21
-  JumpIfTrue   r35, L6
-  // from c in customer
-  Move         r35, r6
-  Const        r34, "__group__"
-  Const        r33, true
-  Move         r32, r16
-  // group by {
-  Move         r29, r36
-  // from c in customer
-  Const        r36, "items"
-  Move         r15, r35
-  Const        r35, "count"
-  Move         r5, r23
-  Move         r14, r34
-  Move         r34, r33
-  Move         r33, r32
-  Move         r32, r29
-  Move         r29, r36
-  Move         r31, r15
-  Move         r15, r35
-  Move         r2, r5
-  MakeMap      r27, 4, r14
-  SetIndex     r21, r1, r27
-  Move         r27, r36
-  Index        r36, r21, r1
-  Index        r1, r36, r27
-  Append       r2, r1, r4
-  SetIndex     r36, r27, r2
-  Move         r2, r35
-  Index        r35, r36, r2
-  Const        r1, 1
-  AddInt       r27, r35, r1
-  SetIndex     r36, r2, r27
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r3, r3, r1
-  Jump         L7
+  Move         r30, r24
+L10:
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L1
+  Index        r33, r28, r30
+  Const        r34, "o_custkey"
+  Index        r35, r33, r34
+  Index        r36, r27, r7
+  Equal        r37, r35, r36
+  JumpIfFalse  r37, L2
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r22, r22, r1
+  IterPrep     r38, r3
+  Len          r39, r38
+  Move         r40, r24
+L9:
+  LessInt      r41, r40, r39
+  JumpIfFalse  r41, L2
+  Index        r43, r38, r40
+  Const        r44, "l_orderkey"
+  Index        r45, r43, r44
+  Const        r46, "o_orderkey"
+  Index        r47, r33, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L3
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  IterPrep     r49, r0
+  Len          r50, r49
+  Move         r51, r40
+L8:
+  LessInt      r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r54, r49, r51
+  Const        r55, "n_nationkey"
+  Index        r56, r54, r55
+  Const        r57, "c_nationkey"
+  Index        r58, r27, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
+  // where o.o_orderdate >= start_date &&
+  Index        r60, r33, r14
+  LessEq       r61, r4, r60
+  // o.o_orderdate < end_date &&
+  Index        r62, r33, r14
+  Less         r63, r62, r5
+  // l.l_returnflag == "R"
+  Index        r64, r43, r15
+  Const        r65, "R"
+  Equal        r66, r64, r65
+  // where o.o_orderdate >= start_date &&
+  Move         r67, r61
+  JumpIfFalse  r67, L5
+L5:
+  // o.o_orderdate < end_date &&
+  Move         r68, r63
+  JumpIfFalse  r68, L6
+  Move         r68, r66
+L6:
+  // where o.o_orderdate >= start_date &&
+  JumpIfFalse  r68, L4
+  // from c in customer
+  Const        r69, "c"
+  Move         r70, r27
+  Const        r71, "o"
+  Move         r72, r33
+  Move         r73, r18
+  Move         r74, r43
+  Const        r75, "n"
+  Move         r76, r54
+  MakeMap      r77, 4, r69
+  // c_custkey: c.c_custkey,
+  Move         r78, r7
+  Index        r79, r27, r7
+  // c_name: c.c_name,
+  Move         r80, r8
+  Index        r81, r27, r8
+  // c_acctbal: c.c_acctbal,
+  Move         r82, r9
+  Index        r83, r27, r9
+  // c_address: c.c_address,
+  Move         r84, r10
+  Index        r85, r27, r10
+  // c_phone: c.c_phone,
+  Move         r86, r11
+  Index        r87, r27, r11
+  // c_comment: c.c_comment,
+  Move         r88, r12
+  Index        r89, r27, r12
+  // n_name: n.n_name
+  Move         r90, r13
+  Index        r91, r54, r13
+  // c_custkey: c.c_custkey,
+  Move         r92, r78
+  Move         r93, r79
+  // c_name: c.c_name,
+  Move         r94, r80
+  Move         r95, r81
+  // c_acctbal: c.c_acctbal,
+  Move         r96, r82
+  Move         r97, r83
+  // c_address: c.c_address,
+  Move         r98, r84
+  Move         r99, r85
+  // c_phone: c.c_phone,
+  Move         r100, r86
+  Move         r101, r87
+  // c_comment: c.c_comment,
+  Move         r102, r88
+  Move         r103, r89
+  // n_name: n.n_name
+  Move         r104, r90
+  Move         r105, r91
+  // group by {
+  MakeMap      r106, 7, r92
+  Str          r107, r106
+  In           r108, r107, r21
+  JumpIfTrue   r108, L7
+  // from c in customer
+  Move         r109, r6
+  Const        r110, "__group__"
+  Const        r111, true
+  Move         r112, r16
+  // group by {
+  Move         r113, r106
+  // from c in customer
+  Const        r114, "items"
+  Move         r115, r109
+  Const        r116, "count"
+  Move         r117, r24
+  Move         r118, r110
+  Move         r119, r111
+  Move         r120, r112
+  Move         r121, r113
+  Move         r122, r114
+  Move         r123, r115
+  Move         r124, r116
+  Move         r125, r117
+  MakeMap      r126, 4, r118
+  SetIndex     r21, r107, r126
+L7:
+  Move         r127, r114
+  Index        r128, r21, r107
+  Index        r129, r128, r127
+  Append       r130, r129, r77
+  SetIndex     r128, r127, r130
+  Move         r131, r116
+  Index        r132, r128, r131
+  Const        r133, 1
+  AddInt       r134, r132, r133
+  SetIndex     r128, r131, r134
+L4:
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  AddInt       r51, r51, r133
   Jump         L8
-  // join o in orders on o.o_custkey == c.c_custkey
-  AddInt       r25, r25, r1
+L3:
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  AddInt       r40, r40, r133
   Jump         L9
-  // from c in customer
-  AddInt       r23, r23, r1
+L2:
+  // join o in orders on o.o_custkey == c.c_custkey
+  AddInt       r30, r30, r133
   Jump         L10
-L0:
-  Values       27,21,0,0
-  Move         r21, r5
-  Move         r5, r21
-  Len          r26, r27
-  LessInt      r25, r5, r26
-  JumpIfFalse  r25, L11
-  Index        r25, r27, r5
-  // c_custkey: g.key.c_custkey,
-  Move         r27, r7
-  Index        r26, r25, r16
-  Index        r24, r26, r7
-  // c_name: g.key.c_name,
-  Move         r26, r8
-  Index        r7, r25, r16
-  Index        r23, r7, r8
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r7, r17
-  Move         r8, r6
-  IterPrep     r35, r25
-  Len          r2, r35
-  Move         r36, r21
-  LessInt      r30, r36, r2
-  JumpIfFalse  r30, L3
-  Index        r30, r35, r36
-  Index        r35, r30, r18
-  Index        r2, r35, r19
-  Index        r35, r30, r18
-  Index        r3, r35, r20
-  Sub          r22, r1, r3
-  Mul          r3, r2, r22
-  Append       r8, r8, r3
-  AddInt       r36, r36, r1
-  Jump         L12
-  Sum          r22, r8
-  // c_acctbal: g.key.c_acctbal,
-  Move         r8, r9
-  Index        r2, r25, r16
-  Index        r36, r2, r9
-  // n_name: g.key.n_name,
-  Move         r2, r13
-  Index        r9, r25, r16
-  Index        r4, r9, r13
-  // c_address: g.key.c_address,
-  Move         r9, r10
-  Index        r13, r25, r16
-  Index        r3, r13, r10
-  // c_phone: g.key.c_phone,
-  Move         r13, r11
-  Index        r10, r25, r16
-  Index        r15, r10, r11
-  // c_comment: g.key.c_comment
-  Move         r10, r12
-  Index        r11, r25, r16
-  Index        r16, r11, r12
-  // c_custkey: g.key.c_custkey,
-  Move         r11, r27
-  Move         r12, r24
-  // c_name: g.key.c_name,
-  Move         r24, r26
-  Move         r31, r23
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r23, r7
-  Move         r7, r22
-  // c_acctbal: g.key.c_acctbal,
-  Move         r22, r8
-  Move         r29, r36
-  // n_name: g.key.n_name,
-  Move         r36, r2
-  Move         r32, r4
-  // c_address: g.key.c_address,
-  Move         r4, r9
-  Move         r33, r3
-  // c_phone: g.key.c_phone,
-  Move         r3, r13
-  Move         r34, r15
-  // c_comment: g.key.c_comment
-  Move         r15, r10
-  Move         r14, r16
-  // select {
-  MakeMap      r16, 8, r11
-  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Move         r14, r6
-  IterPrep     r15, r25
-  Len          r25, r15
-  Move         r34, r21
-  LessInt      r21, r34, r25
-  JumpIfFalse  r21, L13
-  Index        r30, r15, r34
-  Index        r21, r30, r18
-  Index        r25, r21, r19
-  Index        r21, r30, r18
-  Index        r30, r21, r20
-  Sub          r21, r1, r30
-  Mul          r30, r25, r21
-  Append       r14, r14, r30
-  AddInt       r34, r34, r1
-  Jump         L7
-  Sum          r30, r14
-  Neg          r14, r30
+L1:
   // from c in customer
-  Move         r30, r16
-  MakeList     r16, 2, r14
-  Append       r6, r6, r16
-  AddInt       r5, r5, r1
-  Jump         L2
+  AddInt       r24, r24, r133
+  Jump         L11
+L0:
+  Values       135,21,0,0
+  Move         r137, r117
+  Move         r136, r137
+  Len          r138, r135
+L17:
+  LessInt      r139, r136, r138
+  JumpIfFalse  r139, L12
+  Index        r141, r135, r136
+  // c_custkey: g.key.c_custkey,
+  Move         r142, r7
+  Index        r143, r141, r16
+  Index        r144, r143, r7
+  // c_name: g.key.c_name,
+  Move         r145, r8
+  Index        r146, r141, r16
+  Index        r147, r146, r8
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r148, r17
+  Move         r149, r6
+  IterPrep     r150, r141
+  Len          r151, r150
+  Move         r152, r137
+L14:
+  LessInt      r153, r152, r151
+  JumpIfFalse  r153, L13
+  Index        r155, r150, r152
+  Index        r156, r155, r18
+  Index        r157, r156, r19
+  Index        r158, r155, r18
+  Index        r159, r158, r20
+  Sub          r160, r133, r159
+  Mul          r161, r157, r160
+  Append       r149, r149, r161
+  AddInt       r152, r152, r133
+  Jump         L14
+L13:
+  Sum          r163, r149
+  // c_acctbal: g.key.c_acctbal,
+  Move         r164, r9
+  Index        r165, r141, r16
+  Index        r166, r165, r9
+  // n_name: g.key.n_name,
+  Move         r167, r13
+  Index        r168, r141, r16
+  Index        r169, r168, r13
+  // c_address: g.key.c_address,
+  Move         r170, r10
+  Index        r171, r141, r16
+  Index        r172, r171, r10
+  // c_phone: g.key.c_phone,
+  Move         r173, r11
+  Index        r174, r141, r16
+  Index        r175, r174, r11
+  // c_comment: g.key.c_comment
+  Move         r176, r12
+  Index        r177, r141, r16
+  Index        r178, r177, r12
+  // c_custkey: g.key.c_custkey,
+  Move         r179, r142
+  Move         r180, r144
+  // c_name: g.key.c_name,
+  Move         r181, r145
+  Move         r182, r147
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r183, r148
+  Move         r184, r163
+  // c_acctbal: g.key.c_acctbal,
+  Move         r185, r164
+  Move         r186, r166
+  // n_name: g.key.n_name,
+  Move         r187, r167
+  Move         r188, r169
+  // c_address: g.key.c_address,
+  Move         r189, r170
+  Move         r190, r172
+  // c_phone: g.key.c_phone,
+  Move         r191, r173
+  Move         r192, r175
+  // c_comment: g.key.c_comment
+  Move         r193, r176
+  Move         r194, r178
+  // select {
+  MakeMap      r195, 8, r179
+  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Move         r196, r6
+  IterPrep     r197, r141
+  Len          r198, r197
+  Move         r199, r137
+L16:
+  LessInt      r200, r199, r198
+  JumpIfFalse  r200, L15
+  Index        r155, r197, r199
+  Index        r202, r155, r18
+  Index        r203, r202, r19
+  Index        r204, r155, r18
+  Index        r205, r204, r20
+  Sub          r206, r133, r205
+  Mul          r207, r203, r206
+  Append       r196, r196, r207
+  AddInt       r199, r199, r133
+  Jump         L16
+L15:
+  Sum          r209, r196
+  Neg          r211, r209
+  // from c in customer
+  Move         r212, r195
+  MakeList     r213, 2, r211
+  Append       r6, r6, r213
+  AddInt       r136, r136, r133
+  Jump         L17
+L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r6, r6
   // c_custkey: 1,
-  Move         r16, r27
+  Move         r217, r142
   // c_name: "Alice",
-  Move         r27, r26
-  Const        r26, "Alice"
+  Move         r218, r145
+  Const        r219, "Alice"
   // revenue: 1000.0 * 0.9, // 900.0
-  Move         r30, r17
-  Const        r17, 900
+  Move         r220, r17
+  Const        r223, 900
   // c_acctbal: 100.0,
-  Move         r14, r8
-  Const        r8, 100
+  Move         r224, r164
+  Const        r225, 100
   // n_name: "BRAZIL",
-  Move         r35, r2
-  Const        r2, "BRAZIL"
+  Move         r226, r167
+  Const        r227, "BRAZIL"
   // c_address: "123 St",
-  Move         r5, r9
-  Const        r9, "123 St"
+  Move         r228, r170
+  Const        r229, "123 St"
   // c_phone: "123-456",
-  Move         r21, r13
-  Const        r13, "123-456"
+  Move         r230, r173
+  Const        r231, "123-456"
   // c_comment: "Loyal"
-  Move         r25, r10
-  Const        r10, "Loyal"
+  Move         r232, r176
+  Const        r233, "Loyal"
   // c_custkey: 1,
-  Move         r34, r16
-  Move         r16, r1
+  Move         r234, r217
+  Move         r235, r133
   // c_name: "Alice",
-  Move         r1, r27
-  Move         r27, r26
+  Move         r236, r218
+  Move         r237, r219
   // revenue: 1000.0 * 0.9, // 900.0
-  Move         r26, r30
-  Move         r30, r17
+  Move         r238, r220
+  Move         r239, r223
   // c_acctbal: 100.0,
-  Move         r17, r14
-  Move         r14, r8
+  Move         r240, r224
+  Move         r241, r225
   // n_name: "BRAZIL",
-  Move         r8, r35
-  Move         r35, r2
+  Move         r242, r226
+  Move         r243, r227
   // c_address: "123 St",
-  Move         r2, r5
-  Move         r5, r9
+  Move         r244, r228
+  Move         r245, r229
   // c_phone: "123-456",
-  Move         r9, r21
-  Move         r21, r13
+  Move         r246, r230
+  Move         r247, r231
   // c_comment: "Loyal"
-  Move         r13, r25
-  Move         r25, r10
+  Move         r248, r232
+  Move         r249, r233
   // {
-  MakeMap      r10, 8, r34
+  MakeMap      r251, 8, r234
   // expect result == [
-  MakeList     r25, 1, r10
-  Equal        r10, r6, r25
-  Expect       r10
+  MakeList     r252, 1, r251
+  Equal        r253, r6, r252
+  Expect       r253
   Return       r0


### PR DESCRIPTION
## Summary
- keep MakeMap register sequences intact by skipping register compaction
- allocate fresh constants when building row maps
- regenerate q1 and q10 IR after VM changes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68616e1c05648320bb79434172916146