### PR TITLE
Improve group by compile-time performance

### DIFF
--- a/tests/vm/valid/group_by.ir.out
+++ b/tests/vm/valid/group_by.ir.out
@@ -1,4 +1,4 @@
-func main (regs=22)
+func main (regs=93)
   // let people = [
   Const        r0, [{"age": 30, "city": "Paris", "name": "Alice"}, {"age": 15, "city": "Hanoi", "name": "Bob"}, {"age": 65, "city": "Paris", "name": "Charlie"}, {"age": 45, "city": "Hanoi", "name": "Diana"}, {"age": 70, "city": "Paris", "name": "Eve"}, {"age": 22, "city": "Hanoi", "name": "Frank"}]
   // let stats = from person in people
@@ -7,7 +7,6 @@ func main (regs=22)
   Const        r2, "city"
   // city: g.key,
   Const        r3, "key"
-L2:
   // count: count(g),
   Const        r4, "count"
   // avg_age: avg(from p in g select p.age)
@@ -16,116 +15,119 @@ L2:
   // let stats = from person in people
   IterPrep     r7, r0
   Len          r8, r7
-L5:
   Const        r9, 0
   MakeMap      r10, 0, r0
-L0:
-  LessInt      r11, r9, r8
+  Move         r11, r1
+L2:
+  LessInt      r13, r9, r8
+  JumpIfFalse  r13, L0
+  Index        r14, r7, r9
+  // group by person.city into g
+  Index        r16, r14, r2
+  Str          r17, r16
+  In           r18, r17, r10
+  JumpIfTrue   r18, L1
+  // let stats = from person in people
+  Move         r19, r1
+  Const        r20, "__group__"
+  Const        r21, true
+  Move         r22, r3
+  // group by person.city into g
+  Move         r23, r16
+  // let stats = from person in people
+  Const        r24, "items"
+  Move         r25, r19
+  Move         r26, r4
+  Move         r27, r9
+  Move         r28, r20
+  Move         r29, r21
+  Move         r30, r22
+  Move         r31, r23
+  Move         r32, r24
+  Move         r33, r25
+  Move         r34, r26
+  Move         r35, r27
+  MakeMap      r36, 4, r28
+  SetIndex     r10, r17, r36
+  Append       r11, r11, r36
 L1:
-  JumpIfFalse  r11, L0
-  Index        r8, r7, r9
-  // group by person.city into g
-  Index        r7, r8, r2
-  Str          r12, r7
-  In           r13, r12, r10
-  JumpIfTrue   r13, L1
-  // let stats = from person in people
-  Move         r13, r1
-L7:
-  Const        r14, "__group__"
-  Const        r15, true
-L4:
-  Move         r16, r3
-  // group by person.city into g
-  Move         r17, r7
-  // let stats = from person in people
-  Const        r7, "items"
-  Move         r18, r13
-  Move         r13, r4
-  Move         r19, r9
-  Move         r20, r14
-  Move         r14, r15
-  Move         r15, r16
-  Move         r16, r17
-  Move         r17, r7
-  Move         r21, r18
-  Move         r18, r13
-  Move         r13, r19
-  MakeMap      r19, 4, r20
-  SetIndex     r10, r12, r19
-  Move         r19, r7
-  Index        r7, r10, r12
-  Index        r12, r7, r19
-  Append       r13, r12, r8
-  SetIndex     r7, r19, r13
-  Index        r13, r7, r4
-  Const        r12, 1
-  AddInt       r19, r13, r12
-  SetIndex     r7, r4, r19
-  AddInt       r9, r9, r12
-  Jump         L0
-  Values       19,10,0,0
-  Const        r10, 0
-  Move         r13, r10
-  Len          r7, r19
-  LessInt      r11, r13, r7
-  JumpIfFalse  r11, L2
-  Index        r11, r19, r13
-  // city: g.key,
-  Move         r19, r2
-  Index        r7, r11, r3
-  // count: count(g),
-  Move         r3, r4
-  Index        r9, r11, r4
-  // avg_age: avg(from p in g select p.age)
-  Move         r8, r5
-  Move         r18, r1
-  IterPrep     r21, r11
-  Len          r11, r21
-  Move         r17, r10
-  LessInt      r16, r17, r11
-  JumpIfFalse  r16, L3
-  Index        r16, r21, r17
-  Index        r21, r16, r6
-  Append       r18, r18, r21
-  AddInt       r17, r17, r12
-  Jump         L4
-L3:
-  Avg          r16, r18
-  // city: g.key,
-  Move         r21, r19
-  Move         r18, r7
-  // count: count(g),
-  Move         r7, r3
-  Move         r3, r9
-  // avg_age: avg(from p in g select p.age)
-  Move         r19, r8
-  Move         r8, r16
-  // select {
-  MakeMap      r16, 3, r21
-  // let stats = from person in people
-  Append       r1, r1, r16
-  AddInt       r13, r13, r12
-  Jump         L5
-  // print("--- People grouped by city ---")
-  Const        r16, "--- People grouped by city ---"
-  Print        r16
-  // for s in stats {
-  IterPrep     r16, r1
-  Len          r1, r16
-  Move         r8, r10
-  Less         r10, r8, r1
-  JumpIfFalse  r10, L6
-  Index        r10, r16, r8
-  // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
-  Index        r16, r10, r2
-  Const        r2, ": count ="
-  Index        r1, r10, r4
-  Const        r4, ", avg_age ="
-  Index        r19, r10, r5
-  PrintN       r16, 5, r16
-  // for s in stats {
-  Add          r8, r8, r12
-  Jump         L7
+  Move         r38, r24
+  Index        r39, r10, r17
+  Index        r40, r39, r38
+  Append       r41, r40, r14
+  SetIndex     r39, r38, r41
+  Index        r42, r39, r4
+  Const        r43, 1
+  AddInt       r44, r42, r43
+  SetIndex     r39, r4, r44
+  AddInt       r9, r9, r43
+  Jump         L2
+L0:
+  Const        r46, 0
+  Move         r45, r46
+  Len          r47, r11
 L6:
+  LessInt      r48, r45, r47
+  JumpIfFalse  r48, L3
+  Index        r50, r11, r45
+  // city: g.key,
+  Move         r51, r2
+  Index        r52, r50, r3
+  // count: count(g),
+  Move         r53, r4
+  Index        r54, r50, r4
+  // avg_age: avg(from p in g select p.age)
+  Move         r55, r5
+  Move         r56, r19
+  IterPrep     r57, r50
+  Len          r58, r57
+  Move         r59, r46
+L5:
+  LessInt      r60, r59, r58
+  JumpIfFalse  r60, L4
+  Index        r62, r57, r59
+  Index        r63, r62, r6
+  Append       r56, r56, r63
+  AddInt       r59, r59, r43
+  Jump         L5
+L4:
+  Avg          r65, r56
+  // city: g.key,
+  Move         r66, r51
+  Move         r67, r52
+  // count: count(g),
+  Move         r68, r53
+  Move         r69, r54
+  // avg_age: avg(from p in g select p.age)
+  Move         r70, r55
+  Move         r71, r65
+  // select {
+  MakeMap      r72, 3, r66
+  // let stats = from person in people
+  Append       r1, r1, r72
+  AddInt       r45, r45, r43
+  Jump         L6
+L3:
+  // print("--- People grouped by city ---")
+  Const        r74, "--- People grouped by city ---"
+  Print        r74
+  // for s in stats {
+  IterPrep     r75, r1
+  Len          r76, r75
+  Move         r77, r46
+L8:
+  Less         r78, r77, r76
+  JumpIfFalse  r78, L7
+  Index        r80, r75, r77
+  // print(s.city, ": count =", s.count, ", avg_age =", s.avg_age)
+  Index        r81, r80, r2
+  Const        r82, ": count ="
+  Index        r83, r80, r4
+  Const        r84, ", avg_age ="
+  Index        r85, r80, r5
+  PrintN       r81, 5, r81
+  // for s in stats {
+  Add          r77, r77, r43
+  Jump         L8
+L7:
   Return       r0

--- a/tests/vm/valid/group_by_conditional_sum.ir.out
+++ b/tests/vm/valid/group_by_conditional_sum.ir.out
@@ -1,4 +1,4 @@
-func main (regs=23)
+func main (regs=88)
   // let items = [
   Const        r0, [{"cat": "a", "flag": true, "val": 10}, {"cat": "a", "flag": false, "val": 5}, {"cat": "b", "flag": true, "val": 20}]
   // from i in items
@@ -7,122 +7,125 @@ func main (regs=23)
   Const        r2, "cat"
   // cat: g.key,
   Const        r3, "key"
-L7:
   // share:
   Const        r4, "share"
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
   Const        r5, "flag"
   Const        r6, "val"
-L0:
   // from i in items
   IterPrep     r7, r0
-L6:
   Len          r8, r7
   Const        r9, 0
-L4:
   MakeMap      r10, 0, r0
+  Move         r11, r1
 L2:
-  LessInt      r11, r9, r8
+  LessInt      r13, r9, r8
+  JumpIfFalse  r13, L0
+  Index        r14, r7, r9
+  // group by i.cat into g
+  Index        r16, r14, r2
+  Str          r17, r16
+  In           r18, r17, r10
+  JumpIfTrue   r18, L1
+  // from i in items
+  Move         r19, r1
+  Const        r20, "__group__"
+  Const        r21, true
+  Move         r22, r3
+  // group by i.cat into g
+  Move         r23, r16
+  // from i in items
+  Const        r24, "items"
+  Move         r25, r19
+  Const        r26, "count"
+  Move         r27, r9
+  Move         r28, r20
+  Move         r29, r21
+  Move         r30, r22
+  Move         r31, r23
+  Move         r32, r24
+  Move         r33, r25
+  Move         r34, r26
+  Move         r35, r27
+  MakeMap      r36, 4, r28
+  SetIndex     r10, r17, r36
+  Append       r11, r11, r36
 L1:
-  JumpIfFalse  r11, L0
-  Index        r8, r7, r9
-  // group by i.cat into g
-  Index        r7, r8, r2
-  Str          r12, r7
-  In           r13, r12, r10
-  JumpIfTrue   r13, L1
-  // from i in items
-  Move         r13, r1
-  Const        r14, "__group__"
-  Const        r15, true
+  Move         r38, r24
+  Index        r39, r10, r17
+  Index        r40, r39, r38
+  Append       r41, r40, r14
+  SetIndex     r39, r38, r41
+  Move         r42, r26
+  Index        r43, r39, r42
+  Const        r44, 1
+  AddInt       r45, r43, r44
+  SetIndex     r39, r42, r45
+  AddInt       r9, r9, r44
+  Jump         L2
+L0:
+  Const        r47, 0
+  Move         r46, r47
+  Len          r48, r11
+L9:
+  LessInt      r49, r46, r48
+  JumpIfFalse  r49, L3
+  Index        r51, r11, r46
+  // cat: g.key,
+  Move         r52, r2
+  Index        r53, r51, r3
+  // share:
+  Move         r54, r4
+  // sum(from x in g select if x.flag { x.val } else { 0 }) /
+  Move         r55, r19
+  IterPrep     r56, r51
+  Len          r57, r56
+  Move         r58, r47
+L6:
+  LessInt      r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r61, r56, r58
+  Index        r62, r61, r5
+  JumpIfFalse  r62, L5
 L5:
-  Move         r16, r3
-  // group by i.cat into g
-  Move         r17, r7
-  // from i in items
-  Const        r7, "items"
-  Move         r18, r13
-  Const        r13, "count"
-  Move         r19, r9
-  Move         r20, r14
-  Move         r14, r15
-  Move         r15, r16
-  Move         r16, r17
-  Move         r17, r7
-  Move         r21, r18
-  Move         r18, r13
-  Move         r22, r19
-  MakeMap      r19, 4, r20
-  SetIndex     r10, r12, r19
-  Move         r19, r7
-  Index        r7, r10, r12
-  Index        r12, r7, r19
-  Append       r22, r12, r8
-  SetIndex     r7, r19, r22
-  Move         r22, r13
-  Index        r13, r7, r22
-  Const        r12, 1
-  AddInt       r19, r13, r12
-  SetIndex     r7, r22, r19
-  AddInt       r9, r9, r12
-  Jump         L2
-  Values       19,10,0,0
-  Const        r10, 0
-  Move         r13, r10
-  Len          r22, r19
-  LessInt      r7, r13, r22
-  JumpIfFalse  r7, L3
-  Index        r7, r19, r13
-  // cat: g.key,
-  Move         r19, r2
-  Index        r2, r7, r3
-  // share:
-  Move         r22, r4
-  // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Move         r4, r1
-  IterPrep     r11, r7
-  Len          r9, r11
-  Move         r8, r10
-  LessInt      r18, r8, r9
-  JumpIfFalse  r18, L4
-  Index        r18, r11, r8
-  Index        r11, r18, r5
-  JumpIfFalse  r11, L5
-  Append       r4, r4, r10
-  AddInt       r8, r8, r12
-  Jump         L2
-  Sum          r11, r4
+  Append       r55, r55, r47
+  AddInt       r58, r58, r44
+  Jump         L6
+L4:
+  Sum          r66, r55
   // sum(from x in g select x.val)
-  Move         r8, r1
-  IterPrep     r5, r7
-  Len          r9, r5
-  Move         r21, r10
-  LessInt      r10, r21, r9
-  JumpIfFalse  r10, L6
-  Index        r18, r5, r21
-  Index        r10, r18, r6
-  Append       r8, r8, r10
-  AddInt       r21, r21, r12
-  Jump         L4
-  Sum          r21, r8
+  Move         r67, r1
+  IterPrep     r68, r51
+  Len          r69, r68
+  Move         r70, r47
+L8:
+  LessInt      r71, r70, r69
+  JumpIfFalse  r71, L7
+  Index        r61, r68, r70
+  Index        r73, r61, r6
+  Append       r67, r67, r73
+  AddInt       r70, r70, r44
+  Jump         L8
+L7:
+  Sum          r75, r67
   // sum(from x in g select if x.flag { x.val } else { 0 }) /
-  Div          r8, r11, r21
+  Div          r76, r66, r75
   // cat: g.key,
-  Move         r21, r19
-  Move         r10, r2
+  Move         r77, r52
+  Move         r78, r53
   // share:
-  Move         r2, r22
-  Move         r22, r8
+  Move         r79, r54
+  Move         r80, r76
   // select {
-  MakeMap      r8, 2, r21
+  MakeMap      r81, 2, r77
   // sort by g.key
-  Index        r22, r7, r3
+  Index        r83, r51, r3
   // from i in items
-  Move         r7, r8
-  MakeList     r8, 2, r22
-  Append       r1, r1, r8
-  AddInt       r13, r13, r12
-  Jump         L7
+  Move         r84, r81
+  MakeList     r85, 2, r83
+  Append       r1, r1, r85
+  AddInt       r46, r46, r44
+  Jump         L9
 L3:
   // sort by g.key
   Sort         r1, r1

--- a/tests/vm/valid/group_by_having.ir.out
+++ b/tests/vm/valid/group_by_having.ir.out
@@ -1,4 +1,4 @@
-func main (regs=21)
+func main (regs=63)
   // let people = [
   Const        r0, [{"city": "Paris", "name": "Alice"}, {"city": "Hanoi", "name": "Bob"}, {"city": "Paris", "name": "Charlie"}, {"city": "Hanoi", "name": "Diana"}, {"city": "Paris", "name": "Eve"}, {"city": "Hanoi", "name": "Frank"}, {"city": "Paris", "name": "George"}]
   // from p in people
@@ -8,81 +8,83 @@ func main (regs=21)
   // select { city: g.key, num: count(g) }
   Const        r3, "key"
   Const        r4, "num"
-L0:
   // from p in people
   IterPrep     r5, r0
   Len          r6, r5
   Const        r7, 0
   MakeMap      r8, 0, r0
+  Move         r9, r1
 L2:
-  LessInt      r9, r7, r6
+  LessInt      r11, r7, r6
+  JumpIfFalse  r11, L0
+  Index        r12, r5, r7
+  // group by p.city into g
+  Index        r14, r12, r2
+  Str          r15, r14
+  In           r16, r15, r8
+  JumpIfTrue   r16, L1
+  // from p in people
+  Move         r17, r1
+  Const        r18, "__group__"
+  Const        r19, true
+  Move         r20, r3
+  // group by p.city into g
+  Move         r21, r14
+  // from p in people
+  Const        r22, "items"
+  Move         r23, r17
+  Const        r24, "count"
+  Move         r25, r7
+  Move         r26, r18
+  Move         r27, r19
+  Move         r28, r20
+  Move         r29, r21
+  Move         r30, r22
+  Move         r31, r23
+  Move         r32, r24
+  Move         r33, r25
+  MakeMap      r34, 4, r26
+  SetIndex     r8, r15, r34
+  Append       r9, r9, r34
 L1:
-  JumpIfFalse  r9, L0
-  Index        r6, r5, r7
-  // group by p.city into g
-  Index        r5, r6, r2
-  Str          r10, r5
-  In           r11, r10, r8
-  JumpIfTrue   r11, L1
-  // from p in people
-  Move         r11, r1
-  Const        r12, "__group__"
-  Const        r13, true
-  Move         r14, r3
-  // group by p.city into g
-  Move         r15, r5
-  // from p in people
-  Const        r5, "items"
-  Move         r16, r11
-  Const        r11, "count"
-  Move         r17, r7
-  Move         r18, r12
-  Move         r12, r13
-  Move         r13, r14
-  Move         r14, r15
-  Move         r15, r5
-  Move         r19, r16
-  Move         r16, r11
-  Move         r20, r17
-  MakeMap      r17, 4, r18
-  SetIndex     r8, r10, r17
-  Move         r17, r5
-  Index        r5, r8, r10
-  Index        r10, r5, r17
-  Append       r20, r10, r6
-  SetIndex     r5, r17, r20
-  Move         r20, r11
-  Index        r11, r5, r20
-  Const        r10, 1
-  AddInt       r17, r11, r10
-  SetIndex     r5, r20, r17
-  AddInt       r7, r7, r10
+  Move         r36, r22
+  Index        r37, r8, r15
+  Index        r38, r37, r36
+  Append       r39, r38, r12
+  SetIndex     r37, r36, r39
+  Move         r40, r24
+  Index        r41, r37, r40
+  Const        r42, 1
+  AddInt       r43, r41, r42
+  SetIndex     r37, r40, r43
+  AddInt       r7, r7, r42
   Jump         L2
-  Values       17,8,0,0
-  Const        r8, 0
-  Len          r11, r17
-  LessInt      r5, r8, r11
-  JumpIfFalse  r5, L3
-  Index        r5, r17, r8
+L0:
+  Const        r44, 0
+  Len          r46, r9
+L4:
+  LessInt      r47, r44, r46
+  JumpIfFalse  r47, L3
+  Index        r49, r9, r44
   // having count(g) >= 4
-  Index        r17, r5, r20
-  Const        r11, 4
-  LessEq       r9, r11, r17
-  JumpIfFalse  r9, L3
+  Index        r50, r49, r40
+  Const        r51, 4
+  LessEq       r52, r51, r50
+  JumpIfFalse  r52, L3
   // select { city: g.key, num: count(g) }
-  Move         r11, r2
-  Index        r2, r5, r3
-  Move         r3, r4
-  Index        r4, r5, r20
-  Move         r5, r11
-  Move         r11, r2
-  Move         r2, r3
-  Move         r3, r4
-  MakeMap      r4, 2, r5
+  Move         r53, r2
+  Index        r54, r49, r3
+  Move         r55, r4
+  Index        r56, r49, r40
+  Move         r57, r53
+  Move         r58, r54
+  Move         r59, r55
+  Move         r60, r56
+  MakeMap      r61, 2, r57
   // from p in people
-  Append       r1, r1, r4
-  AddInt       r8, r8, r10
-  Jump         L2
+  Append       r1, r1, r61
+  AddInt       r44, r44, r42
+  Jump         L4
 L3:
   // json(big)
   JSON         r1

--- a/tests/vm/valid/group_by_join.ir.out
+++ b/tests/vm/valid/group_by_join.ir.out
@@ -1,134 +1,131 @@
-func main (regs=23)
+func main (regs=91)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-L3:
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from o in orders
   Const        r2, []
   // group by c.name into g
   Const        r3, "name"
-L0:
   // name: g.key,
   Const        r4, "key"
   // count: count(g)
   Const        r5, "count"
   // let stats = from o in orders
   MakeMap      r6, 0, r0
-  IterPrep     r7, r1
-  Len          r1, r7
-L5:
-  Const        r8, 0
-  LessInt      r9, r8, r1
-  JumpIfFalse  r9, L0
-L4:
-  Index        r1, r7, r8
-  // join from c in customers on o.customerId == c.id
-  IterPrep     r7, r0
-  Len          r10, r7
-  Move         r11, r8
-  LessInt      r12, r11, r10
-  JumpIfFalse  r12, L1
-  Index        r10, r7, r11
-  Const        r7, "customerId"
-  Index        r13, r1, r7
-  Const        r7, "id"
+  Move         r7, r2
+  IterPrep     r9, r1
+  Len          r10, r9
+  Const        r11, 0
 L1:
-  Index        r14, r10, r7
-  Equal        r7, r13, r14
-  JumpIfFalse  r7, L2
-  // let stats = from o in orders
-  Const        r7, "o"
-  Move         r14, r1
-  Const        r1, "c"
-  Move         r13, r10
-  MakeMap      r15, 2, r7
-  // group by c.name into g
-  Index        r13, r10, r3
-  Str          r10, r13
-  In           r1, r10, r6
-  JumpIfTrue   r1, L3
-  // let stats = from o in orders
-  Move         r1, r2
-  Const        r14, "__group__"
-  Const        r7, true
-  Move         r16, r4
-  // group by c.name into g
-  Move         r17, r13
-  // let stats = from o in orders
-  Const        r13, "items"
-  Move         r18, r1
-  Move         r1, r5
-  Move         r19, r8
-  Move         r20, r14
-  Move         r14, r7
-  Move         r7, r16
-  Move         r16, r17
-  Move         r17, r13
-  Move         r21, r18
-  Move         r18, r1
-  Move         r1, r19
-  MakeMap      r22, 4, r20
-  SetIndex     r6, r10, r22
-  Move         r22, r13
-  Index        r13, r6, r10
-  Index        r10, r13, r22
-  Append       r1, r10, r15
-  SetIndex     r13, r22, r1
-  Index        r1, r13, r5
-  Const        r10, 1
-  AddInt       r22, r1, r10
-  SetIndex     r13, r5, r22
-L2:
+  LessInt      r12, r11, r10
+  JumpIfFalse  r12, L0
+  Index        r14, r9, r11
   // join from c in customers on o.customerId == c.id
-  AddInt       r11, r11, r10
-  Jump         L4
+  IterPrep     r15, r0
+  Len          r16, r15
+  Move         r17, r11
+L2:
+  LessInt      r18, r17, r16
+  JumpIfFalse  r18, L1
+  Index        r20, r15, r17
+  Const        r21, "customerId"
+  Index        r22, r14, r21
+  Const        r23, "id"
+  Index        r24, r20, r23
+  Equal        r25, r22, r24
+  JumpIfFalse  r25, L2
   // let stats = from o in orders
-  AddInt       r8, r8, r10
-  Jump         L5
-  Values       22,6,0,0
-  Move         r6, r19
-  Len          r19, r22
-  LessInt      r1, r6, r19
-  JumpIfFalse  r1, L6
-  Index        r1, r22, r6
+  Const        r26, "o"
+  Move         r27, r14
+  Const        r28, "c"
+  Move         r29, r20
+  MakeMap      r30, 2, r26
+  // group by c.name into g
+  Index        r31, r20, r3
+  Str          r32, r31
+  In           r33, r32, r6
+  JumpIfTrue   r33, L3
+  // let stats = from o in orders
+  Move         r34, r2
+  Const        r35, "__group__"
+  Const        r36, true
+  Move         r37, r4
+  // group by c.name into g
+  Move         r38, r31
+  // let stats = from o in orders
+  Const        r39, "items"
+  Move         r40, r34
+  Move         r41, r5
+  Move         r42, r11
+  Move         r43, r35
+  Move         r44, r36
+  Move         r45, r37
+  Move         r46, r38
+  Move         r47, r39
+  Move         r48, r40
+  Move         r49, r41
+  Move         r50, r42
+  MakeMap      r51, 4, r43
+  SetIndex     r6, r32, r51
+  Append       r7, r7, r51
+L3:
+  Move         r53, r39
+  Index        r54, r6, r32
+  Index        r55, r54, r53
+  Append       r56, r55, r30
+  SetIndex     r54, r53, r56
+  Index        r57, r54, r5
+  Const        r58, 1
+  AddInt       r59, r57, r58
+  SetIndex     r54, r5, r59
+  // join from c in customers on o.customerId == c.id
+  Jump         L2
+L0:
+  // let stats = from o in orders
+  Move         r60, r42
+  Len          r62, r7
+L5:
+  LessInt      r63, r60, r62
+  JumpIfFalse  r63, L4
+  Index        r65, r7, r60
   // name: g.key,
-  Move         r22, r3
-  Index        r19, r1, r4
+  Move         r66, r3
+  Index        r67, r65, r4
   // count: count(g)
-  Move         r4, r5
-  Index        r13, r1, r5
+  Move         r68, r5
+  Index        r69, r65, r5
   // name: g.key,
-  Move         r1, r22
-  Move         r22, r19
+  Move         r70, r66
+  Move         r71, r67
   // count: count(g)
-  Move         r19, r4
-  Move         r4, r13
+  Move         r72, r68
+  Move         r73, r69
   // select {
-  MakeMap      r13, 2, r1
+  MakeMap      r74, 2, r70
   // let stats = from o in orders
-  Append       r2, r2, r13
-  AddInt       r6, r6, r10
-  Jump         L1
-L6:
+  Append       r2, r2, r74
+  AddInt       r60, r60, r58
+  Jump         L5
+L4:
   // print("--- Orders per customer ---")
-  Const        r13, "--- Orders per customer ---"
-  Print        r13
+  Const        r76, "--- Orders per customer ---"
+  Print        r76
   // for s in stats {
-  IterPrep     r13, r2
-  Len          r2, r13
-  Const        r4, 0
-L8:
-  Less         r19, r4, r2
-  JumpIfFalse  r19, L7
-  Index        r19, r13, r4
-  // print(s.name, "orders:", s.count)
-  Index        r13, r19, r3
-  Const        r3, "orders:"
-  Index        r2, r19, r5
-  PrintN       r13, 3, r13
-  // for s in stats {
-  Add          r4, r4, r10
-  Jump         L8
+  IterPrep     r77, r2
+  Len          r78, r77
+  Move         r79, r11
 L7:
+  Less         r80, r79, r78
+  JumpIfFalse  r80, L6
+  Index        r82, r77, r79
+  // print(s.name, "orders:", s.count)
+  Index        r83, r82, r3
+  Const        r84, "orders:"
+  Index        r85, r82, r5
+  PrintN       r83, 3, r83
+  // for s in stats {
+  Add          r79, r79, r58
+  Jump         L7
+L6:
   Return       r0

--- a/tests/vm/valid/group_by_left_join.ir.out
+++ b/tests/vm/valid/group_by_left_join.ir.out
@@ -1,11 +1,10 @@
-func main (regs=30)
+func main (regs=136)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 1, "id": 101}, {"customerId": 2, "id": 102}]
   // let stats = from c in customers
   Const        r2, []
-L7:
   // group by c.name into g
   Const        r3, "name"
   // name: g.key,
@@ -13,177 +12,185 @@ L7:
   // count: count(from r in g where r.o select r)
   Const        r5, "count"
   Const        r6, "o"
-L8:
   // let stats = from c in customers
   MakeMap      r7, 0, r0
-  IterPrep     r8, r0
-L2:
-  Len          r9, r8
-  Const        r10, 0
-L0:
-  LessInt      r11, r10, r9
-  JumpIfFalse  r11, L0
+  Move         r8, r2
+  IterPrep     r10, r0
+  Len          r11, r10
+  Const        r12, 0
 L4:
-  Index        r9, r8, r10
+  LessInt      r13, r12, r11
+  JumpIfFalse  r13, L0
+  Index        r15, r10, r12
   // left join o in orders on o.customerId == c.id
-  IterPrep     r8, r1
-L1:
-  Len          r1, r8
-  Move         r12, r10
-  LessInt      r13, r12, r1
-  JumpIfFalse  r13, L1
-L5:
-  Index        r1, r8, r12
-  Const        r8, false
-  Const        r14, "customerId"
-  Index        r15, r1, r14
-  Const        r14, "id"
+  IterPrep     r16, r1
+  Len          r17, r16
+  Move         r18, r12
+L2:
+  LessInt      r19, r18, r17
+  JumpIfFalse  r19, L1
+  Index        r21, r16, r18
+  Const        r22, false
+  Const        r23, "customerId"
+  Index        r24, r21, r23
+  Const        r25, "id"
+  Index        r26, r15, r25
+  Equal        r27, r24, r26
+  JumpIfFalse  r27, L2
+  Const        r22, true
+  // let stats = from c in customers
+  Const        r28, "c"
+  Move         r29, r15
+  Move         r30, r6
+  Move         r31, r21
+  MakeMap      r32, 2, r28
+  // group by c.name into g
+  Index        r33, r15, r3
+  Str          r34, r33
+  In           r35, r34, r7
+  JumpIfTrue   r35, L3
+  // let stats = from c in customers
+  Move         r36, r2
+  Const        r37, "__group__"
+  Move         r38, r22
+  Move         r39, r4
+  // group by c.name into g
+  Move         r40, r33
+  // let stats = from c in customers
+  Const        r41, "items"
+  Move         r42, r36
+  Move         r43, r5
+  Move         r44, r12
+  Move         r45, r37
+  Move         r46, r38
+  Move         r47, r39
+  Move         r48, r40
+  Move         r49, r41
+  Move         r50, r42
+  Move         r51, r43
+  Move         r52, r44
+  MakeMap      r53, 4, r45
+  SetIndex     r7, r34, r53
+  Append       r8, r8, r53
 L3:
-  Index        r16, r9, r14
-  Equal        r14, r15, r16
-  JumpIfFalse  r14, L2
-  Const        r8, true
-L9:
-  // let stats = from c in customers
-  Const        r14, "c"
-  Move         r16, r9
-  Move         r15, r1
-  MakeMap      r1, 2, r14
-  // group by c.name into g
-  Index        r17, r9, r3
-  Str          r18, r17
-  In           r19, r18, r7
-  JumpIfTrue   r19, L3
-  // let stats = from c in customers
-  Move         r19, r2
-  Const        r20, "__group__"
-  Move         r21, r8
-  Move         r22, r4
-  // group by c.name into g
-  Move         r23, r17
-  // let stats = from c in customers
-  Const        r17, "items"
-  Move         r24, r19
-  Move         r19, r5
-  Move         r25, r10
-  Move         r26, r20
-  Move         r27, r21
-  Move         r21, r22
-  Move         r22, r23
-  Move         r23, r17
-  Move         r28, r24
-  Move         r24, r19
-  Move         r19, r25
-  MakeMap      r29, 4, r26
-  SetIndex     r7, r18, r29
-  Move         r29, r17
-  Index        r19, r7, r18
-  Index        r18, r19, r29
-  Append       r24, r18, r1
-  SetIndex     r19, r29, r24
-  Index        r24, r19, r5
-  Const        r18, 1
-  AddInt       r28, r24, r18
-  SetIndex     r19, r5, r28
+  Move         r55, r41
+  Index        r56, r7, r34
+  Index        r57, r56, r55
+  Append       r58, r57, r32
+  SetIndex     r56, r55, r58
+  Index        r59, r56, r5
+  Const        r60, 1
+  AddInt       r61, r59, r60
+  SetIndex     r56, r5, r61
   // left join o in orders on o.customerId == c.id
-  AddInt       r12, r12, r18
-  Jump         L4
-  Move         r28, r8
-  JumpIfTrue   r28, L3
+  Jump         L2
+L1:
+  Move         r62, r22
+  JumpIfTrue   r62, L4
+  Const        r21, nil
   // let stats = from c in customers
-  MakeMap      r28, 2, r14
+  Move         r64, r28
+  Move         r65, r15
+  Move         r66, r6
+  Move         r67, r21
+  MakeMap      r68, 2, r64
   // group by c.name into g
-  Index        r1, r9, r3
-  Str          r9, r1
-  In           r15, r9, r7
-  JumpIfTrue   r15, L5
+  Index        r69, r15, r3
+  Str          r70, r69
+  In           r71, r70, r7
+  JumpIfTrue   r71, L5
   // let stats = from c in customers
-  Move         r15, r2
-  Move         r16, r20
-  Move         r20, r8
-  Move         r8, r4
+  Move         r72, r36
+  Move         r73, r37
+  Move         r74, r22
+  Move         r75, r4
   // group by c.name into g
-  Move         r14, r1
+  Move         r76, r69
   // let stats = from c in customers
-  Move         r1, r17
-  Move         r17, r15
-  Move         r24, r5
-  Move         r19, r25
-  Move         r25, r16
-  Move         r16, r20
-  Move         r20, r8
-  Move         r8, r14
-  Move         r14, r1
-  Move         r1, r17
-  Move         r17, r24
-  Move         r13, r19
-  MakeMap      r19, 4, r25
-  SetIndex     r7, r9, r19
-  Index        r19, r7, r9
-  Index        r9, r19, r29
-  Append       r13, r9, r28
-  SetIndex     r19, r29, r13
-  Index        r13, r19, r5
-  AddInt       r9, r13, r18
-  SetIndex     r19, r5, r9
-  AddInt       r10, r10, r18
-  Jump         L0
-  Values       9,7,0,0
-  Const        r7, 0
-  Move         r13, r7
-  Len          r19, r9
-  LessInt      r11, r13, r19
-  JumpIfFalse  r11, L6
-  Index        r11, r9, r13
-  // name: g.key,
-  Move         r9, r3
-  Index        r19, r11, r4
-  // count: count(from r in g where r.o select r)
-  Move         r4, r24
-  Move         r24, r15
-  IterPrep     r15, r11
-  Len          r11, r15
-  Move         r10, r7
-  LessInt      r28, r10, r11
-  JumpIfFalse  r28, L7
-  Index        r28, r15, r10
-  Index        r15, r28, r6
-  JumpIfFalse  r15, L8
-  Append       r24, r24, r28
-  AddInt       r10, r10, r18
-  Jump         L1
-  Count        r10, r24
-  // name: g.key,
-  Move         r24, r9
-  Move         r9, r19
-  // count: count(from r in g where r.o select r)
-  Move         r19, r4
-  Move         r4, r10
-  // select {
-  MakeMap      r10, 2, r24
-  // let stats = from c in customers
-  Append       r2, r2, r10
-  AddInt       r13, r13, r18
-  Jump         L9
+  Move         r77, r41
+  Move         r78, r72
+  Move         r79, r5
+  Move         r80, r44
+  Move         r81, r73
+  Move         r82, r74
+  Move         r83, r75
+  Move         r84, r76
+  Move         r85, r77
+  Move         r86, r78
+  Move         r87, r79
+  Move         r88, r80
 L6:
-  // print("--- Group Left Join ---")
-  Const        r15, "--- Group Left Join ---"
-  Print        r15
-  // for s in stats {
-  IterPrep     r10, r2
-  Len          r2, r10
-  Move         r4, r7
+  MakeMap      r89, 4, r81
+  SetIndex     r7, r70, r89
+  Append       r8, r8, r89
+L5:
+  Index        r91, r7, r70
+  Index        r92, r91, r55
+  Append       r93, r92, r68
+  SetIndex     r91, r55, r93
+  Index        r94, r91, r5
+  AddInt       r95, r94, r60
+  SetIndex     r91, r5, r95
+  Jump         L6
+L0:
+  Move         r96, r97
+  Len          r98, r8
 L11:
-  Less         r7, r4, r2
-  JumpIfFalse  r7, L10
-  Index        r7, r10, r4
-  // print(s.name, "orders:", s.count)
-  Index        r10, r7, r3
-  Const        r3, "orders:"
-  Index        r2, r7, r5
-  PrintN       r10, 3, r10
-  // for s in stats {
-  Add          r4, r4, r18
-  Jump         L11
+  LessInt      r99, r96, r98
+  JumpIfFalse  r99, L7
+  Index        r101, r8, r96
+  // name: g.key,
+  Move         r102, r3
+  Index        r103, r101, r4
+  // count: count(from r in g where r.o select r)
+  Move         r104, r79
+  Move         r105, r2
+  IterPrep     r106, r101
+  Len          r107, r106
+  Move         r108, r97
 L10:
+  LessInt      r109, r108, r107
+  JumpIfFalse  r109, L8
+  Index        r111, r106, r108
+  Index        r112, r111, r6
+  JumpIfFalse  r112, L9
+  Append       r105, r105, r111
+L9:
+  AddInt       r108, r108, r60
+  Jump         L10
+L8:
+  Count        r114, r105
+  // name: g.key,
+  Move         r115, r102
+  Move         r116, r103
+  // count: count(from r in g where r.o select r)
+  Move         r117, r104
+  Move         r118, r114
+  // select {
+  MakeMap      r119, 2, r115
+  // let stats = from c in customers
+  Append       r2, r2, r119
+  AddInt       r96, r96, r60
+  Jump         L11
+L7:
+  // print("--- Group Left Join ---")
+  Const        r121, "--- Group Left Join ---"
+  Print        r121
+  // for s in stats {
+  IterPrep     r122, r2
+  Len          r123, r122
+  Move         r124, r97
+L13:
+  Less         r125, r124, r123
+  JumpIfFalse  r125, L12
+  Index        r127, r122, r124
+  // print(s.name, "orders:", s.count)
+  Index        r128, r127, r3
+  Const        r129, "orders:"
+  Index        r130, r127, r5
+  PrintN       r128, 3, r128
+  // for s in stats {
+  Add          r124, r124, r60
+  Jump         L13
+L12:
   Return       r0

--- a/tests/vm/valid/group_by_multi_join.ir.out
+++ b/tests/vm/valid/group_by_multi_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=24)
+func main (regs=118)
   // let nations = [
   Const        r0, [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
   // let suppliers = [
@@ -7,7 +7,6 @@ func main (regs=24)
   Const        r2, [{"cost": 10, "part": 100, "qty": 2, "supplier": 1}, {"cost": 20, "part": 100, "qty": 1, "supplier": 2}, {"cost": 5, "part": 200, "qty": 3, "supplier": 1}]
   // from ps in partsupp
   Const        r3, []
-L13:
   // where n.name == "A"
   Const        r4, "name"
   // part: ps.part,
@@ -15,173 +14,175 @@ L13:
   // value: ps.cost * ps.qty
   Const        r6, "value"
   Const        r7, "cost"
-L9:
   Const        r8, "qty"
   // from ps in partsupp
   IterPrep     r9, r2
-L7:
-  Len          r2, r9
-L2:
-  Const        r10, 0
+  Len          r10, r9
+  Const        r12, 0
+  Move         r11, r12
 L6:
-  Move         r11, r10
-  LessInt      r12, r11, r2
-  JumpIfFalse  r12, L0
-L3:
-  Index        r2, r9, r11
+  LessInt      r13, r11, r10
+  JumpIfFalse  r13, L0
+  Index        r15, r9, r11
+  // join s in suppliers on s.id == ps.supplier
+  IterPrep     r16, r1
+  Len          r17, r16
+  Const        r18, "id"
+  Const        r19, "supplier"
+  Move         r20, r12
 L5:
-  // join s in suppliers on s.id == ps.supplier
-  IterPrep     r9, r1
-  Len          r1, r9
+  LessInt      r21, r20, r17
+  JumpIfFalse  r21, L1
+  Index        r23, r16, r20
+  Index        r24, r23, r18
+  Index        r25, r15, r19
+  Equal        r26, r24, r25
+  JumpIfFalse  r26, L2
+  // join n in nations on n.id == s.nation
+  IterPrep     r27, r0
+  Len          r28, r27
+  Const        r29, "nation"
+  Move         r30, r12
 L4:
-  Const        r13, "id"
-L1:
-  Const        r14, "supplier"
-  Move         r15, r10
-  LessInt      r16, r15, r1
-  JumpIfFalse  r16, L1
-  Index        r1, r9, r15
-  Index        r9, r1, r13
-  Index        r17, r2, r14
-  Equal        r14, r9, r17
-  JumpIfFalse  r14, L2
-  // join n in nations on n.id == s.nation
-  IterPrep     r14, r0
-  Len          r17, r14
-  Const        r9, "nation"
-  Move         r18, r10
-  LessInt      r19, r18, r17
-  JumpIfFalse  r19, L2
-  Index        r19, r14, r18
-  Index        r14, r19, r13
-  Index        r13, r1, r9
-  Equal        r9, r14, r13
-  JumpIfFalse  r9, L3
+  LessInt      r31, r30, r28
+  JumpIfFalse  r31, L2
+  Index        r33, r27, r30
+  Index        r34, r33, r18
+  Index        r35, r23, r29
+  Equal        r36, r34, r35
+  JumpIfFalse  r36, L3
   // where n.name == "A"
-  Index        r9, r19, r4
-  Const        r19, "A"
-  Equal        r4, r9, r19
-  JumpIfFalse  r4, L3
+  Index        r37, r33, r4
+  Const        r38, "A"
+  Equal        r39, r37, r38
+  JumpIfFalse  r39, L3
   // part: ps.part,
-  Move         r4, r5
-  Index        r19, r2, r5
+  Move         r40, r5
+  Index        r41, r15, r5
   // value: ps.cost * ps.qty
-  Move         r9, r6
-  Index        r13, r2, r7
-  Index        r7, r2, r8
-  Mul          r2, r13, r7
+  Move         r42, r6
+  Index        r43, r15, r7
+  Index        r44, r15, r8
+  Mul          r45, r43, r44
   // part: ps.part,
-  Move         r7, r4
-  Move         r4, r19
+  Move         r46, r40
+  Move         r47, r41
   // value: ps.cost * ps.qty
-  Move         r19, r9
-  Move         r9, r2
+  Move         r48, r42
+  Move         r49, r45
   // select {
-  MakeMap      r2, 2, r7
+  MakeMap      r50, 2, r46
   // from ps in partsupp
-  Append       r3, r3, r2
+  Append       r3, r3, r50
+L3:
   // join n in nations on n.id == s.nation
-  Const        r2, 1
-  Add          r18, r18, r2
+  Const        r52, 1
+  Add          r30, r30, r52
   Jump         L4
+L2:
   // join s in suppliers on s.id == ps.supplier
-  Add          r15, r15, r2
+  Add          r20, r20, r52
   Jump         L5
+L1:
   // from ps in partsupp
-  AddInt       r11, r11, r2
+  AddInt       r11, r11, r52
   Jump         L6
 L0:
   // from x in filtered
-  Const        r18, []
+  Const        r53, []
   // part: g.key,
-  Const        r16, "key"
+  Const        r54, "key"
   // total: sum(from r in g select r.value)
-  Const        r15, "total"
+  Const        r55, "total"
   // from x in filtered
-  IterPrep     r12, r3
-  Len          r3, r12
-  Move         r11, r10
-  MakeMap      r9, 0, r0
-  LessInt      r19, r11, r3
-  JumpIfFalse  r19, L7
-  Index        r19, r12, r11
+  IterPrep     r56, r3
+  Len          r57, r56
+  Move         r58, r12
+  MakeMap      r59, 0, r0
+  Move         r60, r53
+L9:
+  LessInt      r62, r58, r57
+  JumpIfFalse  r62, L7
+  Index        r63, r56, r58
   // group by x.part into g
-  Index        r12, r19, r5
-  Str          r3, r12
-  In           r4, r3, r9
-  JumpIfTrue   r4, L8
+  Index        r65, r63, r5
+  Str          r66, r65
+  In           r67, r66, r59
+  JumpIfTrue   r67, L8
   // from x in filtered
-  Move         r4, r18
-  Const        r7, "__group__"
-  Const        r13, true
-  Move         r8, r16
+  Move         r68, r53
+  Const        r69, "__group__"
+  Const        r70, true
+  Move         r71, r54
   // group by x.part into g
-  Move         r14, r12
+  Move         r72, r65
   // from x in filtered
-  Const        r12, "items"
-  Move         r1, r4
-  Const        r4, "count"
-  Move         r17, r10
-  Move         r20, r7
-  Move         r7, r13
-  Move         r13, r8
-  Move         r21, r14
-  Move         r14, r12
-  Move         r22, r1
-  Move         r1, r4
-  Move         r23, r17
-  MakeMap      r17, 4, r20
-  SetIndex     r9, r3, r17
+  Const        r73, "items"
+  Move         r74, r68
+  Const        r75, "count"
+  Move         r76, r12
+  Move         r77, r69
+  Move         r78, r70
+  Move         r79, r71
+  Move         r80, r72
+  Move         r81, r73
+  Move         r82, r74
+  Move         r83, r75
+  Move         r84, r76
+  MakeMap      r85, 4, r77
+  SetIndex     r59, r66, r85
+  Append       r60, r60, r85
 L8:
-  Move         r17, r12
-  Index        r12, r9, r3
-  Index        r3, r12, r17
-  Append       r23, r3, r19
-  SetIndex     r12, r17, r23
-  Move         r23, r4
-  Index        r4, r12, r23
-  AddInt       r3, r4, r2
-  SetIndex     r12, r23, r3
-  AddInt       r11, r11, r2
+  Move         r87, r73
+  Index        r88, r59, r66
+  Index        r89, r88, r87
+  Append       r90, r89, r63
+  SetIndex     r88, r87, r90
+  Move         r91, r75
+  Index        r92, r88, r91
+  AddInt       r93, r92, r52
+  SetIndex     r88, r91, r93
+  AddInt       r58, r58, r52
   Jump         L9
-  Values       3,9,0,0
-  Move         r9, r10
-  Len          r4, r3
-  LessInt      r23, r9, r4
-  JumpIfFalse  r23, L10
-  Index        r23, r3, r9
+L7:
+  Move         r94, r12
+  Len          r95, r60
+L13:
+  LessInt      r96, r94, r95
+  JumpIfFalse  r96, L10
+  Index        r98, r60, r94
   // part: g.key,
-  Move         r3, r5
-  Index        r5, r23, r16
+  Move         r99, r5
+  Index        r100, r98, r54
   // total: sum(from r in g select r.value)
-  Move         r16, r15
-  Move         r15, r18
-  IterPrep     r4, r23
-  Len          r23, r4
-  Move         r12, r10
+  Move         r101, r55
+  Move         r102, r68
+  IterPrep     r103, r98
+  Len          r104, r103
+  Move         r105, r12
 L12:
-  LessInt      r10, r12, r23
-  JumpIfFalse  r10, L11
-  Index        r10, r4, r12
-  Index        r4, r10, r6
-  Append       r15, r15, r4
-  AddInt       r12, r12, r2
+  LessInt      r106, r105, r104
+  JumpIfFalse  r106, L11
+  Index        r108, r103, r105
+  Index        r109, r108, r6
+  Append       r102, r102, r109
+  AddInt       r105, r105, r52
   Jump         L12
 L11:
-  Sum          r4, r15
+  Sum          r111, r102
   // part: g.key,
-  Move         r15, r3
-  Move         r3, r5
+  Move         r112, r99
+  Move         r113, r100
   // total: sum(from r in g select r.value)
-  Move         r5, r16
-  Move         r16, r4
+  Move         r114, r101
+  Move         r115, r111
   // select {
-  MakeMap      r10, 2, r15
+  MakeMap      r116, 2, r112
   // from x in filtered
-  Append       r18, r18, r10
-  AddInt       r9, r9, r2
+  Append       r53, r53, r116
+  AddInt       r94, r94, r52
   Jump         L13
 L10:
   // print(grouped)
-  Print        r18
+  Print        r53
   Return       r0

--- a/tests/vm/valid/group_by_multi_join_sort.ir.out
+++ b/tests/vm/valid/group_by_multi_join_sort.ir.out
@@ -1,24 +1,20 @@
-func main (regs=38)
+func main (regs=218)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
   Const        r1, [{"c_acctbal": 100, "c_address": "123 St", "c_comment": "Loyal", "c_custkey": 1, "c_name": "Alice", "c_nationkey": 1, "c_phone": "123-456"}]
-L1:
   // let orders = [
   Const        r2, [{"o_custkey": 1, "o_orderdate": "1993-10-15", "o_orderkey": 1000}, {"o_custkey": 1, "o_orderdate": "1994-01-02", "o_orderkey": 2000}]
   // let lineitem = [
   Const        r3, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 1000, "l_returnflag": "R"}, {"l_discount": 0, "l_extendedprice": 500, "l_orderkey": 2000, "l_returnflag": "N"}]
   // let start_date = "1993-10-01"
   Const        r4, "1993-10-01"
-L6:
   // let end_date = "1994-01-01"
   Const        r5, "1994-01-01"
   // from c in customer
   Const        r6, []
-L3:
   // c_custkey: c.c_custkey,
   Const        r7, "c_custkey"
-L2:
   // c_name: c.c_name,
   Const        r8, "c_name"
   // c_acctbal: c.c_acctbal,
@@ -44,284 +40,287 @@ L2:
   Const        r20, "l_discount"
   // from c in customer
   MakeMap      r21, 0, r0
-  IterPrep     r22, r1
-  Len          r1, r22
-L10:
-  Const        r23, 0
-  LessInt      r24, r23, r1
+  Move         r22, r6
+  IterPrep     r24, r1
+  Len          r25, r24
+  Const        r26, 0
+L1:
+  LessInt      r27, r26, r25
+  JumpIfFalse  r27, L0
+  Index        r29, r24, r26
+  // join o in orders on o.o_custkey == c.c_custkey
+  IterPrep     r30, r2
+  Len          r31, r30
+  Move         r32, r26
+L2:
+  LessInt      r33, r32, r31
+  JumpIfFalse  r33, L1
+  Index        r35, r30, r32
+  Const        r36, "o_custkey"
+  Index        r37, r35, r36
+  Index        r38, r29, r7
+  Equal        r39, r37, r38
+  JumpIfFalse  r39, L2
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  IterPrep     r40, r3
+  Len          r41, r40
+  Move         r42, r26
 L9:
-  JumpIfFalse  r24, L0
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L2
+  Index        r45, r40, r42
+  Const        r46, "l_orderkey"
+  Index        r47, r45, r46
+  Const        r48, "o_orderkey"
+  Index        r49, r35, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L3
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  IterPrep     r51, r0
+  Len          r52, r51
+  Move         r53, r42
 L8:
-  Index        r1, r22, r23
-L5:
-  // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r22, r2
-  Len          r2, r22
-L7:
-  Move         r25, r23
-L4:
-  LessInt      r26, r25, r2
-  JumpIfFalse  r26, L1
-  Index        r2, r22, r25
-  Const        r22, "o_custkey"
-  Index        r27, r2, r22
-  Index        r22, r1, r7
-  Equal        r28, r27, r22
-  JumpIfFalse  r28, L2
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r28, r3
-  Len          r3, r28
-  Move         r22, r23
-  LessInt      r27, r22, r3
-  JumpIfFalse  r27, L2
-  Index        r27, r28, r22
-  Const        r28, "l_orderkey"
-  Index        r3, r27, r28
-  Const        r28, "o_orderkey"
-  Index        r29, r2, r28
-  Equal        r28, r3, r29
-  JumpIfFalse  r28, L3
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r28, r0
-  Len          r29, r28
-  Move         r3, r22
-  LessInt      r30, r3, r29
-  JumpIfFalse  r30, L3
-  Index        r30, r28, r3
-  Const        r28, "n_nationkey"
-  Index        r29, r30, r28
-  Const        r28, "c_nationkey"
-  Index        r31, r1, r28
-  Equal        r28, r29, r31
-  JumpIfFalse  r28, L3
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L3
+  Index        r56, r51, r53
+  Const        r57, "n_nationkey"
+  Index        r58, r56, r57
+  Const        r59, "c_nationkey"
+  Index        r60, r29, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L4
   // where o.o_orderdate >= start_date &&
-  Index        r28, r2, r14
-  LessEq       r31, r4, r28
+  Index        r62, r35, r14
+  LessEq       r63, r4, r62
   // o.o_orderdate < end_date &&
-  Index        r28, r2, r14
-  Less         r14, r28, r5
+  Index        r64, r35, r14
+  Less         r65, r64, r5
   // l.l_returnflag == "R"
-  Index        r28, r27, r15
-  Const        r15, "R"
-  Equal        r5, r28, r15
+  Index        r66, r45, r15
+  Const        r67, "R"
+  Equal        r68, r66, r67
   // where o.o_orderdate >= start_date &&
-  Move         r15, r31
-  JumpIfFalse  r15, L4
+  Move         r69, r63
+  JumpIfFalse  r69, L5
+L5:
   // o.o_orderdate < end_date &&
-  Move         r15, r14
-  JumpIfFalse  r15, L5
-  Move         r15, r5
+  Move         r70, r65
+  JumpIfFalse  r70, L6
+  Move         r70, r68
+L6:
   // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r15, L3
+  JumpIfFalse  r70, L4
   // from c in customer
-  Const        r15, "c"
-  Move         r5, r1
-  Const        r14, "o"
-  Move         r31, r2
-  Move         r2, r27
-  Const        r27, "n"
-  Move         r28, r30
-  MakeMap      r4, 4, r15
+  Const        r71, "c"
+  Move         r72, r29
+  Const        r73, "o"
+  Move         r74, r35
+  Move         r75, r18
+  Move         r76, r45
+  Const        r77, "n"
+  Move         r78, r56
+  MakeMap      r79, 4, r71
   // c_custkey: c.c_custkey,
-  Move         r28, r7
-  Index        r27, r1, r7
+  Move         r80, r7
+  Index        r81, r29, r7
   // c_name: c.c_name,
-  Move         r2, r8
-  Index        r31, r1, r8
+  Move         r82, r8
+  Index        r83, r29, r8
   // c_acctbal: c.c_acctbal,
-  Move         r14, r9
-  Index        r5, r1, r9
+  Move         r84, r9
+  Index        r85, r29, r9
   // c_address: c.c_address,
-  Move         r15, r10
-  Index        r29, r1, r10
+  Move         r86, r10
+  Index        r87, r29, r10
   // c_phone: c.c_phone,
-  Move         r32, r11
-  Index        r33, r1, r11
+  Move         r88, r11
+  Index        r89, r29, r11
   // c_comment: c.c_comment,
-  Move         r34, r12
-  Index        r35, r1, r12
+  Move         r90, r12
+  Index        r91, r29, r12
   // n_name: n.n_name
-  Move         r1, r13
-  Index        r36, r30, r13
+  Move         r92, r13
+  Index        r93, r56, r13
   // c_custkey: c.c_custkey,
-  Move         r37, r28
-  Move         r28, r27
+  Move         r94, r80
+  Move         r95, r81
   // c_name: c.c_name,
-  Move         r27, r2
-  Move         r2, r31
+  Move         r96, r82
+  Move         r97, r83
   // c_acctbal: c.c_acctbal,
-  Move         r31, r14
-  Move         r14, r5
+  Move         r98, r84
+  Move         r99, r85
   // c_address: c.c_address,
-  Move         r5, r15
-  Move         r15, r29
+  Move         r100, r86
+  Move         r101, r87
   // c_phone: c.c_phone,
-  Move         r29, r32
-  Move         r32, r33
+  Move         r102, r88
+  Move         r103, r89
   // c_comment: c.c_comment,
-  Move         r33, r34
-  Move         r34, r35
+  Move         r104, r90
+  Move         r105, r91
   // n_name: n.n_name
-  Move         r35, r1
-  Move         r1, r36
+  Move         r106, r92
+  Move         r107, r93
   // group by {
-  MakeMap      r36, 7, r37
-  Str          r1, r36
-  In           r35, r1, r21
-  JumpIfTrue   r35, L6
+  MakeMap      r108, 7, r94
+  Str          r109, r108
+  In           r110, r109, r21
+  JumpIfTrue   r110, L7
   // from c in customer
-  Move         r35, r6
-  Const        r34, "__group__"
-  Const        r33, true
-  Move         r32, r16
+  Move         r111, r6
+  Const        r112, "__group__"
+  Const        r113, true
+  Move         r114, r16
   // group by {
-  Move         r29, r36
+  Move         r115, r108
   // from c in customer
-  Const        r36, "items"
-  Move         r15, r35
-  Const        r35, "count"
-  Move         r5, r23
-  Move         r14, r34
-  Move         r34, r33
-  Move         r33, r32
-  Move         r32, r29
-  Move         r29, r36
-  Move         r31, r15
-  Move         r15, r35
-  Move         r2, r5
-  MakeMap      r27, 4, r14
-  SetIndex     r21, r1, r27
-  Move         r27, r36
-  Index        r36, r21, r1
-  Index        r1, r36, r27
-  Append       r2, r1, r4
-  SetIndex     r36, r27, r2
-  Move         r2, r35
-  Index        r35, r36, r2
-  Const        r1, 1
-  AddInt       r27, r35, r1
-  SetIndex     r36, r2, r27
+  Const        r116, "items"
+  Move         r117, r111
+  Const        r118, "count"
+  Move         r119, r26
+  Move         r120, r112
+  Move         r121, r113
+  Move         r122, r114
+  Move         r123, r115
+  Move         r124, r116
+  Move         r125, r117
+  Move         r126, r118
+  Move         r127, r119
+  MakeMap      r128, 4, r120
+  SetIndex     r21, r109, r128
+  Append       r22, r22, r128
+L7:
+  Move         r130, r116
+  Index        r131, r21, r109
+  Index        r132, r131, r130
+  Append       r133, r132, r79
+  SetIndex     r131, r130, r133
+  Move         r134, r118
+  Index        r135, r131, r134
+  Const        r136, 1
+  AddInt       r137, r135, r136
+  SetIndex     r131, r134, r137
+L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r3, r3, r1
-  Jump         L7
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r22, r22, r1
+  AddInt       r53, r53, r136
   Jump         L8
-  // join o in orders on o.o_custkey == c.c_custkey
-  AddInt       r25, r25, r1
+L3:
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  AddInt       r42, r42, r136
   Jump         L9
-  // from c in customer
-  AddInt       r23, r23, r1
-  Jump         L10
 L0:
-  Values       27,21,0,0
-  Move         r21, r5
-  Move         r5, r21
-  Len          r26, r27
-  LessInt      r25, r5, r26
-  JumpIfFalse  r25, L11
-  Index        r25, r27, r5
-  // c_custkey: g.key.c_custkey,
-  Move         r27, r7
-  Index        r26, r25, r16
-  Index        r24, r26, r7
-  // c_name: g.key.c_name,
-  Move         r26, r8
-  Index        r7, r25, r16
-  Index        r23, r7, r8
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r7, r17
-  Move         r17, r6
-  IterPrep     r8, r25
-  Len          r35, r8
-  Move         r2, r21
-  LessInt      r36, r2, r35
-  JumpIfFalse  r36, L3
-  Index        r36, r8, r2
-  Index        r8, r36, r18
-  Index        r35, r8, r19
-  Index        r8, r36, r18
-  Index        r30, r8, r20
-  Sub          r3, r1, r30
-  Mul          r30, r35, r3
-  Append       r17, r17, r30
-  AddInt       r2, r2, r1
-  Jump         L7
-  Sum          r3, r17
-  // c_acctbal: g.key.c_acctbal,
-  Move         r17, r9
-  Index        r35, r25, r16
-  Index        r2, r35, r9
-  // n_name: g.key.n_name,
-  Move         r35, r13
-  Index        r9, r25, r16
-  Index        r22, r9, r13
-  // c_address: g.key.c_address,
-  Move         r9, r10
-  Index        r13, r25, r16
-  Index        r30, r13, r10
-  // c_phone: g.key.c_phone,
-  Move         r13, r11
-  Index        r10, r25, r16
-  Index        r4, r10, r11
-  // c_comment: g.key.c_comment
-  Move         r10, r12
-  Index        r11, r25, r16
-  Index        r16, r11, r12
-  // c_custkey: g.key.c_custkey,
-  Move         r11, r27
-  Move         r27, r24
-  // c_name: g.key.c_name,
-  Move         r24, r26
-  Move         r26, r23
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r23, r7
-  Move         r7, r3
-  // c_acctbal: g.key.c_acctbal,
-  Move         r3, r17
-  Move         r17, r2
-  // n_name: g.key.n_name,
-  Move         r2, r35
-  Move         r35, r22
-  // c_address: g.key.c_address,
-  Move         r22, r9
-  Move         r9, r30
-  // c_phone: g.key.c_phone,
-  Move         r30, r13
-  Move         r13, r4
-  // c_comment: g.key.c_comment
-  Move         r4, r10
-  Move         r10, r16
-  // select {
-  MakeMap      r16, 8, r11
-  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Move         r10, r6
-  IterPrep     r4, r25
-  Len          r25, r4
-  Move         r13, r21
-L13:
-  LessInt      r21, r13, r25
-  JumpIfFalse  r21, L12
-  Index        r36, r4, r13
-  Index        r21, r36, r18
-  Index        r25, r21, r19
-  Index        r21, r36, r18
-  Index        r36, r21, r20
-  Sub          r21, r1, r36
-  Mul          r36, r25, r21
-  Append       r10, r10, r36
-  AddInt       r13, r13, r1
-  Jump         L13
-L12:
-  Sum          r36, r10
-  Neg          r10, r36
   // from c in customer
-  Move         r36, r16
-  MakeList     r16, 2, r10
-  Append       r6, r6, r16
-  AddInt       r5, r5, r1
-  Jump         L2
+  Move         r139, r119
+  Move         r138, r139
+  Len          r140, r22
+L15:
+  LessInt      r141, r138, r140
+  JumpIfFalse  r141, L10
+  Index        r143, r22, r138
+  // c_custkey: g.key.c_custkey,
+  Move         r144, r7
+  Index        r145, r143, r16
+  Index        r146, r145, r7
+  // c_name: g.key.c_name,
+  Move         r147, r8
+  Index        r148, r143, r16
+  Index        r149, r148, r8
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r150, r17
+  Move         r151, r111
+  IterPrep     r152, r143
+  Len          r153, r152
+  Move         r154, r139
+L12:
+  LessInt      r155, r154, r153
+  JumpIfFalse  r155, L11
+  Index        r157, r152, r154
+  Index        r158, r157, r18
+  Index        r159, r158, r19
+  Index        r160, r157, r18
+  Index        r161, r160, r20
+  Sub          r162, r136, r161
+  Mul          r163, r159, r162
+  Append       r151, r151, r163
+  AddInt       r154, r154, r136
+  Jump         L12
 L11:
+  Sum          r165, r151
+  // c_acctbal: g.key.c_acctbal,
+  Move         r166, r9
+  Index        r167, r143, r16
+  Index        r168, r167, r9
+  // n_name: g.key.n_name,
+  Move         r169, r13
+  Index        r170, r143, r16
+  Index        r171, r170, r13
+  // c_address: g.key.c_address,
+  Move         r172, r10
+  Index        r173, r143, r16
+  Index        r174, r173, r10
+  // c_phone: g.key.c_phone,
+  Move         r175, r11
+  Index        r176, r143, r16
+  Index        r177, r176, r11
+  // c_comment: g.key.c_comment
+  Move         r178, r12
+  Index        r179, r143, r16
+  Index        r180, r179, r12
+  // c_custkey: g.key.c_custkey,
+  Move         r181, r144
+  Move         r182, r146
+  // c_name: g.key.c_name,
+  Move         r183, r147
+  Move         r184, r149
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r185, r150
+  Move         r186, r165
+  // c_acctbal: g.key.c_acctbal,
+  Move         r187, r166
+  Move         r188, r168
+  // n_name: g.key.n_name,
+  Move         r189, r169
+  Move         r190, r171
+  // c_address: g.key.c_address,
+  Move         r191, r172
+  Move         r192, r174
+  // c_phone: g.key.c_phone,
+  Move         r193, r175
+  Move         r194, r177
+  // c_comment: g.key.c_comment
+  Move         r195, r178
+  Move         r196, r180
+  // select {
+  MakeMap      r197, 8, r181
+  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Move         r198, r6
+  IterPrep     r199, r143
+  Len          r200, r199
+  Move         r201, r139
+L14:
+  LessInt      r202, r201, r200
+  JumpIfFalse  r202, L13
+  Index        r157, r199, r201
+  Index        r204, r157, r18
+  Index        r205, r204, r19
+  Index        r206, r157, r18
+  Index        r207, r206, r20
+  Sub          r208, r136, r207
+  Mul          r209, r205, r208
+  Append       r198, r198, r209
+  AddInt       r201, r201, r136
+  Jump         L14
+L13:
+  Sum          r211, r198
+  Neg          r213, r211
+  // from c in customer
+  Move         r214, r197
+  MakeList     r215, 2, r213
+  Append       r6, r6, r215
+  AddInt       r138, r138, r136
+  Jump         L15
+L10:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r6, r6
   // print(result)

--- a/tests/vm/valid/group_by_sort.ir.out
+++ b/tests/vm/valid/group_by_sort.ir.out
@@ -1,4 +1,4 @@
-func main (regs=22)
+func main (regs=84)
   // let items = [
   Const        r0, [{"cat": "a", "val": 3}, {"cat": "a", "val": 1}, {"cat": "b", "val": 5}, {"cat": "b", "val": 2}]
   // from i in items
@@ -7,115 +7,117 @@ func main (regs=22)
   Const        r2, "cat"
   // cat: g.key,
   Const        r3, "key"
-L7:
   // total: sum(from x in g select x.val)
   Const        r4, "total"
   Const        r5, "val"
-L0:
   // from i in items
   IterPrep     r6, r0
   Len          r7, r6
   Const        r8, 0
-L6:
   MakeMap      r9, 0, r0
+  Move         r10, r1
 L2:
-  LessInt      r10, r8, r7
+  LessInt      r12, r8, r7
+  JumpIfFalse  r12, L0
+  Index        r13, r6, r8
+  // group by i.cat into g
+  Index        r15, r13, r2
+  Str          r16, r15
+  In           r17, r16, r9
+  JumpIfTrue   r17, L1
+  // from i in items
+  Move         r18, r1
+  Const        r19, "__group__"
+  Const        r20, true
+  Move         r21, r3
+  // group by i.cat into g
+  Move         r22, r15
+  // from i in items
+  Const        r23, "items"
+  Move         r24, r18
+  Const        r25, "count"
+  Move         r26, r8
+  Move         r27, r19
+  Move         r28, r20
+  Move         r29, r21
+  Move         r30, r22
+  Move         r31, r23
+  Move         r32, r24
+  Move         r33, r25
+  Move         r34, r26
+  MakeMap      r35, 4, r27
+  SetIndex     r9, r16, r35
+  Append       r10, r10, r35
 L1:
-  JumpIfFalse  r10, L0
-  Index        r7, r6, r8
-  // group by i.cat into g
-  Index        r6, r7, r2
-  Str          r11, r6
-  In           r12, r11, r9
-  JumpIfTrue   r12, L1
-  // from i in items
-  Move         r12, r1
-  Const        r13, "__group__"
-  Const        r14, true
-  Move         r15, r3
-L4:
-  // group by i.cat into g
-  Move         r16, r6
-  // from i in items
-  Const        r6, "items"
-  Move         r17, r12
-  Const        r12, "count"
-  Move         r18, r8
-  Move         r19, r13
-  Move         r13, r14
-  Move         r14, r15
-  Move         r15, r16
-  Move         r16, r6
-  Move         r20, r17
-  Move         r17, r12
-  Move         r21, r18
-  MakeMap      r18, 4, r19
-  SetIndex     r9, r11, r18
-  Move         r18, r6
-  Index        r6, r9, r11
-  Index        r11, r6, r18
-  Append       r21, r11, r7
-  SetIndex     r6, r18, r21
-  Move         r21, r12
-  Index        r12, r6, r21
-  Const        r11, 1
-  AddInt       r18, r12, r11
-  SetIndex     r6, r21, r18
-  AddInt       r8, r8, r11
+  Move         r37, r23
+  Index        r38, r9, r16
+  Index        r39, r38, r37
+  Append       r40, r39, r13
+  SetIndex     r38, r37, r40
+  Move         r41, r25
+  Index        r42, r38, r41
+  Const        r43, 1
+  AddInt       r44, r42, r43
+  SetIndex     r38, r41, r44
+  AddInt       r8, r8, r43
   Jump         L2
-  Values       18,9,0,0
-  Const        r9, 0
-  Move         r12, r9
-  Len          r21, r18
-  LessInt      r6, r12, r21
-  JumpIfFalse  r6, L3
-  Index        r6, r18, r12
+L0:
+  Const        r46, 0
+  Move         r45, r46
+  Len          r47, r10
+L8:
+  LessInt      r48, r45, r47
+  JumpIfFalse  r48, L3
+  Index        r50, r10, r45
   // cat: g.key,
-  Move         r18, r2
-  Index        r2, r6, r3
+  Move         r51, r2
+  Index        r52, r50, r3
   // total: sum(from x in g select x.val)
-  Move         r3, r4
-  Move         r4, r1
-  IterPrep     r21, r6
-  Len          r10, r21
-  Move         r8, r9
-  LessInt      r7, r8, r10
-  JumpIfFalse  r7, L0
-  Index        r7, r21, r8
-  Index        r21, r7, r5
-  Append       r4, r4, r21
-  AddInt       r8, r8, r11
-  Jump         L4
-  Sum          r8, r4
-  // cat: g.key,
-  Move         r21, r18
-  Move         r18, r2
-  // total: sum(from x in g select x.val)
-  Move         r2, r3
-  Move         r3, r8
-  // select {
-  MakeMap      r8, 2, r21
-  // sort by -sum(from x in g select x.val)
-  Move         r3, r1
-  IterPrep     r2, r6
-  Len          r6, r2
-  Move         r18, r9
-  LessInt      r9, r18, r6
-  JumpIfFalse  r9, L5
-  Index        r7, r2, r18
-  Index        r9, r7, r5
-  Append       r3, r3, r9
-  AddInt       r18, r18, r11
-  Jump         L6
+  Move         r53, r4
+  Move         r54, r18
+  IterPrep     r55, r50
+  Len          r56, r55
+  Move         r57, r46
 L5:
-  Sum          r18, r3
-  Neg          r3, r18
-  // from i in items
-  Move         r18, r8
-  MakeList     r9, 2, r3
-  Append       r1, r1, r9
-  AddInt       r12, r12, r11
+  LessInt      r58, r57, r56
+  JumpIfFalse  r58, L4
+  Index        r60, r55, r57
+  Index        r61, r60, r5
+  Append       r54, r54, r61
+  AddInt       r57, r57, r43
+  Jump         L5
+L4:
+  Sum          r63, r54
+  // cat: g.key,
+  Move         r64, r51
+  Move         r65, r52
+  // total: sum(from x in g select x.val)
+  Move         r66, r53
+  Move         r67, r63
+  // select {
+  MakeMap      r68, 2, r64
+  // sort by -sum(from x in g select x.val)
+  Move         r69, r1
+  IterPrep     r70, r50
+  Len          r71, r70
+  Move         r72, r46
+L7:
+  LessInt      r73, r72, r71
+  JumpIfFalse  r73, L6
+  Index        r60, r70, r72
+  Index        r75, r60, r5
+  Append       r69, r69, r75
+  AddInt       r72, r72, r43
   Jump         L7
+L6:
+  Sum          r77, r69
+  Neg          r79, r77
+  // from i in items
+  Move         r80, r68
+  MakeList     r81, 2, r79
+  Append       r1, r1, r81
+  AddInt       r45, r45, r43
+  Jump         L8
 L3:
   // sort by -sum(from x in g select x.val)
   Sort         r1, r1

--- a/tests/vm/valid/group_items_iteration.ir.out
+++ b/tests/vm/valid/group_items_iteration.ir.out
@@ -1,4 +1,4 @@
-func main (regs=19)
+func main (regs=94)
   // let data = [
   Const        r0, [{"tag": "a", "val": 1}, {"tag": "a", "val": 2}, {"tag": "b", "val": 3}]
   // let groups = from d in data group by d.tag into g select g
@@ -7,124 +7,121 @@ func main (regs=19)
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
-L5:
   MakeMap      r6, 0, r0
-  Const        r7, []
-L3:
-  Const        r8, 0
+  Move         r7, r1
 L2:
   LessInt      r9, r5, r4
   JumpIfFalse  r9, L0
+  Index        r10, r3, r5
+  Index        r12, r10, r2
+  Str          r13, r12
+  In           r14, r13, r6
+  JumpIfTrue   r14, L1
+  Move         r15, r1
+  Const        r16, "__group__"
+  Const        r17, true
+  Const        r18, "key"
+  Move         r19, r12
+  Const        r20, "items"
+  Move         r21, r15
+  Const        r22, "count"
+  Move         r23, r5
+  Move         r24, r16
+  Move         r25, r17
+  Move         r26, r18
+  Move         r27, r19
+  Move         r28, r20
+  Move         r29, r21
+  Move         r30, r22
+  Move         r31, r23
+  MakeMap      r32, 4, r24
+  SetIndex     r6, r13, r32
+  Append       r7, r7, r32
 L1:
-  Index        r4, r3, r5
-  Index        r3, r4, r2
-  Str          r10, r3
-  In           r11, r10, r6
-  JumpIfTrue   r11, L1
-  Const        r11, []
-  Const        r12, "__group__"
-  Const        r13, true
-  Const        r14, "key"
-  Move         r15, r3
-  Const        r3, "items"
-  Move         r16, r11
-  Const        r11, "count"
-  Const        r17, 0
-  Move         r18, r12
-  Move         r12, r13
-  Move         r13, r14
-  Move         r14, r15
-  Move         r15, r3
-  Move         r3, r16
-  Move         r16, r11
-  Move         r11, r17
-  MakeMap      r17, 4, r18
-  SetIndex     r6, r10, r8
-  Append       r7, r7, r17
-  Const        r17, 1
-  AddInt       r8, r8, r17
-  Const        r8, "items"
-  Index        r11, r6, r10
-  Index        r10, r7, r11
-  Index        r11, r10, r8
-  Append       r6, r11, r4
-  SetIndex     r10, r8, r6
-  Const        r6, "count"
-  Index        r11, r10, r6
-  AddInt       r4, r11, r17
-  SetIndex     r10, r6, r4
-  AddInt       r5, r5, r17
+  Move         r34, r20
+  Index        r35, r6, r13
+  Index        r36, r35, r34
+  Append       r37, r36, r10
+  SetIndex     r35, r34, r37
+  Move         r38, r22
+  Index        r39, r35, r38
+  Const        r40, 1
+  AddInt       r41, r39, r40
+  SetIndex     r35, r38, r41
+  AddInt       r5, r5, r40
   Jump         L2
 L0:
-  Const        r4, 0
-  Move         r11, r4
-  Len          r6, r7
-  LessInt      r10, r11, r6
-  JumpIfFalse  r10, L3
-  Index        r10, r7, r11
-  Append       r1, r1, r10
-  AddInt       r11, r11, r17
-  Jump         L1
-  // var tmp = []
-  Const        r7, []
-  // for g in groups {
-  IterPrep     r6, r1
-  Len          r11, r6
-  Const        r1, 0
-  Less         r9, r1, r11
-  JumpIfFalse  r9, L4
-  Index        r10, r6, r1
-  // var total = 0
-  Move         r9, r4
-  // for x in g.items {
-  Index        r6, r10, r8
-  IterPrep     r8, r6
-  Len          r6, r8
-  Const        r11, 0
-  Less         r5, r11, r6
-  JumpIfFalse  r5, L2
-  Index        r5, r8, r11
-  // total = total + x.val
-  Const        r8, "val"
-  Index        r6, r5, r8
-  Add          r9, r9, r6
-  // for x in g.items {
-  Const        r6, 1
-  Add          r11, r11, r6
-  Jump         L5
-  // tmp = append(tmp, {tag: g.key, total: total})
-  Const        r11, "tag"
-  Const        r6, "key"
-  Index        r8, r10, r6
-  Const        r6, "total"
-  Move         r10, r11
-  Move         r11, r8
-  Move         r8, r6
-  Move         r6, r9
-  MakeMap      r9, 2, r10
-  Append       r7, r7, r9
-  // for g in groups {
-  Const        r9, 1
-  Add          r1, r1, r9
-  Jump         L2
+  Const        r43, 0
+  Move         r42, r43
+  Len          r44, r7
 L4:
-  // let result = from r in tmp sort by r.tag select r
-  Const        r9, []
-  IterPrep     r1, r7
-  Len          r7, r1
-  Move         r6, r4
+  LessInt      r45, r42, r44
+  JumpIfFalse  r45, L3
+  Index        r47, r7, r42
+  Append       r1, r1, r47
+  AddInt       r42, r42, r40
+  Jump         L4
+L3:
+  // var tmp = []
+  Move         r50, r15
+  // for g in groups {
+  IterPrep     r51, r1
+  Len          r52, r51
+  Move         r53, r43
+L8:
+  Less         r54, r53, r52
+  JumpIfFalse  r54, L5
+  Index        r47, r51, r53
+  // var total = 0
+  Move         r56, r43
+  // for x in g.items {
+  Index        r57, r47, r34
+  IterPrep     r58, r57
+  Len          r59, r58
+  Move         r60, r43
 L7:
-  LessInt      r4, r6, r7
-  JumpIfFalse  r4, L6
-  Index        r4, r1, r6
-  Index        r1, r4, r2
-  Move         r2, r4
-  MakeList     r4, 2, r1
-  Append       r9, r9, r4
-  AddInt       r6, r6, r17
+  Less         r61, r60, r59
+  JumpIfFalse  r61, L6
+  Index        r63, r58, r60
+  // total = total + x.val
+  Const        r64, "val"
+  Index        r65, r63, r64
+  Add          r56, r56, r65
+  // for x in g.items {
+  Add          r60, r60, r40
   Jump         L7
 L6:
-  Sort         r9, r9
+  // tmp = append(tmp, {tag: g.key, total: total})
+  Move         r69, r2
+  Index        r71, r47, r18
+  Const        r72, "total"
+  Move         r73, r69
+  Move         r74, r71
+  Move         r75, r72
+  Move         r76, r56
+  MakeMap      r77, 2, r73
+  Append       r50, r50, r77
+  // for g in groups {
+  Add          r53, r53, r40
+  Jump         L8
+L5:
+  // let result = from r in tmp sort by r.tag select r
+  Const        r81, []
+  IterPrep     r82, r50
+  Len          r83, r82
+  Move         r84, r43
+L10:
+  LessInt      r85, r84, r83
+  JumpIfFalse  r85, L9
+  Index        r87, r82, r84
+  Index        r89, r87, r2
+  Move         r90, r87
+  MakeList     r91, 2, r89
+  Append       r81, r81, r91
+  AddInt       r84, r84, r40
+  Jump         L10
+L9:
+  Sort         r81, r81
   // print(result)
-  Print        r9
+  Print        r81
   Return       r0


### PR DESCRIPTION
## Summary
- optimize group-by query compilation by maintaining a list of groups during accumulation
- regenerate IR outputs for group-by query tests

## Testing
- `go test -tags=slow ./tests/vm -run TestVM_IR -update` *(fails: no tests to run)*
- `go test -tags=slow ./tests/vm -run group_by -update` *(fails: no tests to run)*
- `go run ./cmd/mochi run --ir tests/vm/valid/group_by.mochi`


------
https://chatgpt.com/codex/tasks/task_e_6861717baa848320bd588c48309ebb1e