### PR TITLE
Optimize inner joins

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -3175,6 +3175,12 @@ func (fc *funcCompiler) compileJoinQuery(q *parser.QueryExpr, dst int) {
 			fc.compileHashJoin(q, dst, lk, rk)
 			return
 		}
+		if ll, ok1 := fc.constListLen(q.Source); ok1 {
+			if rl, ok2 := fc.constListLen(join.Src); ok2 && rl < ll {
+				fc.compileJoinQueryRight(q, dst)
+				return
+			}
+		}
 	}
 
 	if joinType == "left" {


### PR DESCRIPTION
## Summary
- improve `compileJoinQuery` to pick smaller side for non-equality inner joins

## Testing
- `go test -tags slow ./... -update` *(fails: go run error: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_686177eacff08320b33533ff0f3ed0c7