### PR TITLE
Improve VM join performance

### DIFF
--- a/tests/vm/valid/append_builtin.ir.out
+++ b/tests/vm/valid/append_builtin.ir.out
@@ -2,7 +2,6 @@ func main (regs=3)
   // let a = [1,2]
   Const        r0, [1, 2]
   // print(append(a, 3))
-  Const        r1, 3
-  Append       r2, r0, r1
+  Const        r2, [1, 2, 3]
   Print        r2
   Return       r0

--- a/tests/vm/valid/basic_compare.ir.out
+++ b/tests/vm/valid/basic_compare.ir.out
@@ -1,13 +1,13 @@
-func main (regs=2)
+func main (regs=9)
   // let a = 10 - 3
   Const        r0, 10
-  Const        r1, 7
+  Const        r2, 7
   // print(a)
-  Print        r1
+  Print        r2
   // print(a == 7)
-  Const        r1, true
-  Print        r1
+  Const        r6, true
+  Print        r6
   // print(b < 5)
-  Const        r1, true
-  Print        r1
+  Move         r8, r6
+  Print        r8
   Return       r0

--- a/tests/vm/valid/binary_precedence.ir.out
+++ b/tests/vm/valid/binary_precedence.ir.out
@@ -1,15 +1,15 @@
-func main (regs=2)
+func main (regs=11)
   // print(1 + 2 * 3)
   Const        r0, 1
-  Const        r1, 7
-  Print        r1
+  Const        r4, 7
+  Print        r4
   // print((1 + 2) * 3)
-  Const        r1, 9
-  Print        r1
+  Const        r6, 9
+  Print        r6
   // print(2 * 3 + 1)
-  Const        r1, 7
-  Print        r1
+  Move         r8, r4
+  Print        r8
   // print(2 * (3 + 1))
-  Const        r1, 8
-  Print        r1
+  Const        r10, 8
+  Print        r10
   Return       r0

--- a/tests/vm/valid/bool_chain.ir.out
+++ b/tests/vm/valid/bool_chain.ir.out
@@ -1,30 +1,32 @@
-func main (regs=2)
+func main (regs=21)
   // print((1 < 2) && (2 < 3) && (3 < 4))
   Const        r0, 1
-L2:
-  Const        r1, true
-  JumpIfFalse  r1, L0
-  Const        r1, true
+  Const        r2, true
+  Move         r6, r2
+  JumpIfFalse  r6, L0
+  Move         r6, r2
 L0:
-  Print        r1
+  Print        r6
   // print((1 < 2) && (2 > 3) && boom())
-  Const        r1, false
-  JumpIfFalse  r1, L1
-  Call         r1, boom, 
+  Const        r11, false
+  Move         r12, r11
+  JumpIfFalse  r12, L1
+  Call         r12, boom, 
 L1:
-  Print        r1
+  Print        r12
   // print((1 < 2) && (2 < 3) && (3 > 4) && boom())
-  Const        r1, false
-  JumpIfFalse  r1, L2
-  Call         r1, boom, 
-  Print        r1
+  Move         r19, r11
+  JumpIfFalse  r19, L2
+  Call         r19, boom, 
+L2:
+  Print        r19
   Return       r0
 
   // fun boom(): bool {
-func boom (regs=1)
+func boom (regs=2)
   // print("boom")
   Const        r0, "boom"
   Print        r0
   // return true
-  Const        r0, true
-  Return       r0
+  Const        r1, true
+  Return       r1

--- a/tests/vm/valid/break_continue.ir.out
+++ b/tests/vm/valid/break_continue.ir.out
@@ -1,7 +1,6 @@
-func main (regs=7)
+func main (regs=16)
   // let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
   Const        r0, [1, 2, 3, 4, 5, 6, 7, 8, 9]
-L1:
   // for n in numbers {
   IterPrep     r1, r0
   Len          r2, r1
@@ -9,29 +8,29 @@ L1:
 L4:
   Less         r4, r3, r2
   JumpIfFalse  r4, L0
-  Index        r2, r1, r3
+  Index        r6, r1, r3
   // if n % 2 == 0 {
-  Const        r1, 2
-  Mod          r5, r2, r1
-  Const        r1, 0
-  Equal        r6, r5, r1
-  JumpIfFalse  r6, L1
+  Const        r7, 2
+  Mod          r8, r6, r7
+  Equal        r10, r8, r3
+  JumpIfFalse  r10, L1
   // continue
   Jump         L2
+L1:
   // if n > 7 {
-  Const        r6, 7
-  Less         r1, r6, r2
-  JumpIfFalse  r1, L3
+  Const        r11, 7
+  Less         r12, r11, r6
+  JumpIfFalse  r12, L3
   // break
   Jump         L0
 L3:
   // print("odd number:", n)
-  Const        r1, "odd number:"
-  Print2       r1, r2
+  Const        r13, "odd number:"
+  Print2       r13, r6
 L2:
   // for n in numbers {
-  Const        r1, 1
-  Add          r3, r3, r1
+  Const        r14, 1
+  Add          r3, r3, r14
   Jump         L4
 L0:
   Return       r0

--- a/tests/vm/valid/closure.ir.out
+++ b/tests/vm/valid/closure.ir.out
@@ -1,19 +1,19 @@
-func main (regs=4)
+func main (regs=6)
   // let add10 = makeAdder(10)
   Const        r0, 10
-  Call         r1, makeAdder, r0
+  Call         r2, makeAdder, r0
   // print(add10(7))  // 17
-  Const        r2, 7
-  CallV        r3, r1, 1, r2
-  Print        r3
+  Const        r3, 7
+  CallV        r5, r2, 1, r3
+  Print        r5
   Return       r0
 
   // fun makeAdder(n: int): fun(int): int {
-func makeAdder (regs=2)
+func makeAdder (regs=3)
   // return fun(x: int): int => x + n
   Move         r1, r0
-  MakeClosure  r0, main, 1, r1
-  Return       r0
+  MakeClosure  r2, fn2, 1, r1
+  Return       r2
 
   // return fun(x: int): int => x + n
 func fn2 (regs=3)

--- a/tests/vm/valid/cross_join.ir.out
+++ b/tests/vm/valid/cross_join.ir.out
@@ -1,12 +1,10 @@
-func main (regs=20)
+func main (regs=68)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}]
-L1:
   // let result = from o in orders
   Const        r2, []
-L5:
   // orderId: o.id,
   Const        r3, "orderId"
   Const        r4, "id"
@@ -21,84 +19,85 @@ L5:
   Const        r10, "total"
   // let result = from o in orders
   IterPrep     r11, r1
-L2:
-  Len          r1, r11
-  Const        r12, 0
+  Len          r12, r11
+  Const        r14, 0
+  Move         r13, r14
 L3:
-  Move         r13, r12
-  LessInt      r14, r13, r1
-L0:
-  JumpIfFalse  r14, L0
-  Index        r1, r11, r13
+  LessInt      r15, r13, r12
+  JumpIfFalse  r15, L0
+  Index        r17, r11, r13
   // from c in customers
-  IterPrep     r11, r0
-  Len          r15, r11
-  Move         r16, r12
-  LessInt      r12, r16, r15
-  JumpIfFalse  r12, L1
-  Index        r15, r11, r16
+  IterPrep     r18, r0
+  Len          r19, r18
+  Move         r20, r14
+L2:
+  LessInt      r21, r20, r19
+  JumpIfFalse  r21, L1
+  Index        r23, r18, r20
   // orderId: o.id,
-  Const        r11, "orderId"
-  Index        r17, r1, r4
+  Move         r24, r3
+  Index        r25, r17, r4
   // orderCustomerId: o.customerId,
-  Const        r4, "orderCustomerId"
-  Index        r18, r1, r6
+  Move         r26, r5
+  Index        r27, r17, r6
   // pairedCustomerName: c.name,
-  Const        r6, "pairedCustomerName"
-  Index        r19, r15, r8
+  Move         r28, r7
+  Index        r29, r23, r8
   // orderTotal: o.total
-  Const        r15, "orderTotal"
-  Index        r8, r1, r10
+  Move         r30, r9
+  Index        r31, r17, r10
   // orderId: o.id,
-  Move         r1, r11
-  Move         r11, r17
+  Move         r32, r24
+  Move         r33, r25
   // orderCustomerId: o.customerId,
-  Move         r17, r4
-  Move         r4, r18
+  Move         r34, r26
+  Move         r35, r27
   // pairedCustomerName: c.name,
-  Move         r18, r6
-  Move         r6, r19
+  Move         r36, r28
+  Move         r37, r29
   // orderTotal: o.total
-  Move         r19, r15
-  Move         r15, r8
+  Move         r38, r30
+  Move         r39, r31
   // select {
-  MakeMap      r8, 4, r1
+  MakeMap      r40, 4, r32
   // let result = from o in orders
-  Append       r2, r2, r8
+  Append       r2, r2, r40
   // from c in customers
-  Const        r8, 1
-  AddInt       r16, r16, r8
+  Const        r42, 1
+  AddInt       r20, r20, r42
   Jump         L2
+L1:
   // let result = from o in orders
-  AddInt       r13, r13, r8
+  AddInt       r13, r13, r42
   Jump         L3
+L0:
   // print("--- Cross Join: All order-customer pairs ---")
-  Const        r8, "--- Cross Join: All order-customer pairs ---"
-  Print        r8
+  Const        r43, "--- Cross Join: All order-customer pairs ---"
+  Print        r43
   // for entry in result {
-  IterPrep     r8, r2
-  Len          r2, r8
-  Const        r12, 0
-  Less         r16, r12, r2
-  JumpIfFalse  r16, L4
-  Index        r16, r8, r12
+  IterPrep     r44, r2
+  Len          r45, r44
+  Move         r46, r14
+L5:
+  Less         r47, r46, r45
+  JumpIfFalse  r47, L4
+  Index        r49, r44, r46
   // print("Order", entry.orderId,
-  Const        r8, "Order"
-  Index        r2, r16, r3
+  Const        r50, "Order"
+  Index        r51, r49, r3
   // "(customerId:", entry.orderCustomerId,
-  Const        r3, "(customerId:"
-  Index        r14, r16, r5
+  Const        r52, "(customerId:"
+  Index        r53, r49, r5
   // ", total: $", entry.orderTotal,
-  Const        r5, ", total: $"
-  Index        r13, r16, r9
+  Const        r54, ", total: $"
+  Index        r55, r49, r9
   // ") paired with", entry.pairedCustomerName)
-  Const        r9, ") paired with"
-  Index        r15, r16, r7
+  Const        r56, ") paired with"
+  Index        r57, r49, r7
   // print("Order", entry.orderId,
-  PrintN       r8, 8, r8
+  PrintN       r50, 8, r50
   // for entry in result {
-  Const        r15, 1
-  Add          r12, r12, r15
+  Add          r46, r46, r42
   Jump         L5
 L4:
   Return       r0

--- a/tests/vm/valid/cross_join_filter.ir.out
+++ b/tests/vm/valid/cross_join_filter.ir.out
@@ -1,72 +1,71 @@
-func main (regs=12)
+func main (regs=41)
   // let nums = [1, 2, 3]
   Const        r0, [1, 2, 3]
   // let letters = ["A", "B"]
   Const        r1, ["A", "B"]
   // let pairs = from n in nums
   Const        r2, []
-L5:
   // select { n: n, l: l }
   Const        r3, "n"
   Const        r4, "l"
   // let pairs = from n in nums
   IterPrep     r5, r0
   Len          r6, r5
-L1:
-  Const        r7, 0
-  Move         r8, r7
+  Const        r8, 0
+  Move         r7, r8
 L3:
-  LessInt      r9, r8, r6
-L2:
+  LessInt      r9, r7, r6
   JumpIfFalse  r9, L0
-  Index        r6, r5, r8
+  Index        r11, r5, r7
   // where n % 2 == 0
-  Const        r5, 2
-  Mod          r10, r6, r5
-  Equal        r5, r10, r7
-  JumpIfFalse  r5, L1
+  Const        r12, 2
+  Mod          r13, r11, r12
+  Equal        r14, r13, r8
+  JumpIfFalse  r14, L1
   // from l in letters
-  IterPrep     r5, r1
-  Len          r1, r5
-  Move         r10, r7
-  LessInt      r7, r10, r1
-  JumpIfFalse  r7, L1
-  Index        r7, r5, r10
+  IterPrep     r15, r1
+  Len          r16, r15
+  Move         r17, r8
+L2:
+  LessInt      r18, r17, r16
+  JumpIfFalse  r18, L1
+  Index        r20, r15, r17
   // select { n: n, l: l }
-  Const        r5, "n"
-  Const        r1, "l"
-  Move         r11, r5
-  Move         r5, r6
-  Move         r6, r1
-  Move         r1, r7
-  MakeMap      r7, 2, r11
+  Move         r21, r3
+  Move         r22, r4
+  Move         r23, r21
+  Move         r24, r11
+  Move         r25, r22
+  Move         r26, r20
+  MakeMap      r27, 2, r23
   // let pairs = from n in nums
-  Append       r2, r2, r7
+  Append       r2, r2, r27
   // from l in letters
-  Const        r7, 1
-  AddInt       r10, r10, r7
+  Const        r29, 1
+  AddInt       r17, r17, r29
   Jump         L2
+L1:
   // let pairs = from n in nums
-  AddInt       r8, r8, r7
+  AddInt       r7, r7, r29
   Jump         L3
 L0:
   // print("--- Even pairs ---")
-  Const        r10, "--- Even pairs ---"
-  Print        r10
+  Const        r30, "--- Even pairs ---"
+  Print        r30
   // for p in pairs {
-  IterPrep     r10, r2
-  Len          r2, r10
-  Const        r7, 0
-  Less         r9, r7, r2
-  JumpIfFalse  r9, L4
-  Index        r9, r10, r7
+  IterPrep     r31, r2
+  Len          r32, r31
+  Move         r33, r8
+L5:
+  Less         r34, r33, r32
+  JumpIfFalse  r34, L4
+  Index        r36, r31, r33
   // print(p.n, p.l)
-  Index        r10, r9, r3
-  Index        r3, r9, r4
-  Print2       r10, r3
+  Index        r37, r36, r3
+  Index        r38, r36, r4
+  Print2       r37, r38
   // for p in pairs {
-  Const        r3, 1
-  Add          r7, r7, r3
+  Add          r33, r33, r29
   Jump         L5
 L4:
   Return       r0

--- a/tests/vm/valid/cross_join_triple.ir.out
+++ b/tests/vm/valid/cross_join_triple.ir.out
@@ -1,85 +1,85 @@
-func main (regs=18)
+func main (regs=53)
   // let nums = [1, 2]
   Const        r0, [1, 2]
   // let letters = ["A", "B"]
   Const        r1, ["A", "B"]
   // let bools = [true, false]
   Const        r2, [true, false]
-L1:
   // let combos = from n in nums
   Const        r3, []
   // select {n: n, l: l, b: b}
   Const        r4, "n"
-L6:
   Const        r5, "l"
   Const        r6, "b"
   // let combos = from n in nums
   IterPrep     r7, r0
   Len          r8, r7
-L2:
-  Const        r9, 0
-  Move         r10, r9
-L4:
-  LessInt      r11, r10, r8
-  JumpIfFalse  r11, L0
-L3:
-  Index        r8, r7, r10
-L0:
-  // from l in letters
-  IterPrep     r7, r1
-  Len          r1, r7
-  Move         r12, r9
-  LessInt      r13, r12, r1
-  JumpIfFalse  r13, L0
-  Index        r1, r7, r12
-  // from b in bools
-  IterPrep     r7, r2
-  Len          r2, r7
-  Move         r14, r9
-  LessInt      r9, r14, r2
-  JumpIfFalse  r9, L1
-  Index        r2, r7, r14
-  // select {n: n, l: l, b: b}
-  Const        r7, "n"
-  Const        r15, "l"
-  Const        r16, "b"
-  Move         r17, r7
-  Move         r7, r8
-  Move         r8, r15
-  Move         r15, r1
-  Move         r1, r16
-  Move         r16, r2
-  MakeMap      r2, 3, r17
-  // let combos = from n in nums
-  Append       r3, r3, r2
-  // from b in bools
-  Const        r2, 1
-  AddInt       r14, r14, r2
-  Jump         L2
-  // from l in letters
-  AddInt       r12, r12, r2
-  Jump         L3
-  // let combos = from n in nums
-  AddInt       r10, r10, r2
-  Jump         L4
-  // print("--- Cross Join of three lists ---")
-  Const        r2, "--- Cross Join of three lists ---"
-  Print        r2
-  // for c in combos {
-  IterPrep     r2, r3
-  Len          r3, r2
-  Const        r9, 0
-  Less         r14, r9, r3
-  JumpIfFalse  r14, L5
-  Index        r14, r2, r9
-  // print(c.n, c.l, c.b)
-  Index        r2, r14, r4
-  Index        r4, r14, r5
-  Index        r5, r14, r6
-  PrintN       r2, 3, r2
-  // for c in combos {
-  Const        r5, 1
-  Add          r9, r9, r5
-  Jump         L6
+  Const        r10, 0
+  Move         r9, r10
 L5:
+  LessInt      r11, r9, r8
+  JumpIfFalse  r11, L0
+  Index        r13, r7, r9
+  // from l in letters
+  IterPrep     r14, r1
+  Len          r15, r14
+  Move         r16, r10
+L4:
+  LessInt      r17, r16, r15
+  JumpIfFalse  r17, L1
+  Index        r19, r14, r16
+  // from b in bools
+  IterPrep     r20, r2
+  Len          r21, r20
+  Move         r22, r10
+L3:
+  LessInt      r23, r22, r21
+  JumpIfFalse  r23, L2
+  Index        r25, r20, r22
+  // select {n: n, l: l, b: b}
+  Move         r26, r4
+  Move         r27, r5
+  Move         r28, r6
+  Move         r29, r26
+  Move         r30, r13
+  Move         r31, r27
+  Move         r32, r19
+  Move         r33, r28
+  Move         r34, r25
+  MakeMap      r35, 3, r29
+  // let combos = from n in nums
+  Append       r3, r3, r35
+  // from b in bools
+  Const        r37, 1
+  AddInt       r22, r22, r37
+  Jump         L3
+L2:
+  // from l in letters
+  AddInt       r16, r16, r37
+  Jump         L4
+L1:
+  // let combos = from n in nums
+  AddInt       r9, r9, r37
+  Jump         L5
+L0:
+  // print("--- Cross Join of three lists ---")
+  Const        r38, "--- Cross Join of three lists ---"
+  Print        r38
+  // for c in combos {
+  IterPrep     r39, r3
+  Len          r40, r39
+  Move         r41, r10
+L7:
+  Less         r42, r41, r40
+  JumpIfFalse  r42, L6
+  Index        r44, r39, r41
+  // print(c.n, c.l, c.b)
+  Index        r45, r44, r4
+  Index        r46, r44, r5
+  Index        r47, r44, r6
+  PrintN       r45, 3, r45
+  // for c in combos {
+  Add          r41, r41, r37
+  Jump         L7
+L6:
   Return       r0

--- a/tests/vm/valid/dataset_sort_take_limit.ir.out
+++ b/tests/vm/valid/dataset_sort_take_limit.ir.out
@@ -1,4 +1,4 @@
-func main (regs=7)
+func main (regs=39)
   // let products = [
   Const        r0, [{"name": "Laptop", "price": 1500}, {"name": "Smartphone", "price": 900}, {"name": "Tablet", "price": 600}, {"name": "Monitor", "price": 300}, {"name": "Keyboard", "price": 100}, {"name": "Mouse", "price": 50}, {"name": "Headphones", "price": 200}]
   // let expensive = from p in products
@@ -7,53 +7,53 @@ func main (regs=7)
   Const        r2, "price"
   // let expensive = from p in products
   IterPrep     r3, r0
-L3:
   Len          r4, r3
+  Const        r6, 0
+  Move         r5, r6
 L1:
-  Const        r5, 0
-  LessInt      r6, r5, r4
-  JumpIfFalse  r6, L0
-  Index        r6, r3, r5
+  LessInt      r7, r5, r4
+  JumpIfFalse  r7, L0
+  Index        r9, r3, r5
   // sort by -p.price
-  Index        r3, r6, r2
-  Neg          r4, r3
+  Index        r10, r9, r2
+  Neg          r12, r10
   // let expensive = from p in products
-  Move         r3, r6
-  MakeList     r6, 2, r4
-  Append       r1, r1, r6
-  Const        r6, 1
-  AddInt       r5, r5, r6
+  Move         r13, r9
+  MakeList     r14, 2, r12
+  Append       r1, r1, r14
+  Const        r16, 1
+  AddInt       r5, r5, r16
   Jump         L1
 L0:
   // sort by -p.price
   Sort         r1, r1
   // let expensive = from p in products
-  Const        r5, nil
-  Slice        r1, r1, r6, r5
-  Const        r5, 0
+  Const        r18, nil
+  Slice        r1, r1, r16, r18
+  Move         r20, r6
   // take 3
-  Const        r6, 3
+  Const        r21, 3
   // let expensive = from p in products
-  Slice        r1, r1, r5, r6
+  Slice        r1, r1, r20, r21
   // print("--- Top products (excluding most expensive) ---")
-  Const        r6, "--- Top products (excluding most expensive) ---"
-  Print        r6
+  Const        r23, "--- Top products (excluding most expensive) ---"
+  Print        r23
   // for item in expensive {
-  IterPrep     r6, r1
-  Len          r1, r6
-  Const        r5, 0
-  Less         r3, r5, r1
-  JumpIfFalse  r3, L2
-  Index        r3, r6, r5
+  IterPrep     r24, r1
+  Len          r25, r24
+  Move         r26, r6
+L3:
+  Less         r27, r26, r25
+  JumpIfFalse  r27, L2
+  Index        r29, r24, r26
   // print(item.name, "costs $", item.price)
-  Const        r6, "name"
-  Index        r1, r3, r6
-  Const        r6, "costs $"
-  Index        r4, r3, r2
-  PrintN       r1, 3, r1
+  Const        r33, "name"
+  Index        r30, r29, r33
+  Const        r31, "costs $"
+  Index        r32, r29, r2
+  PrintN       r30, 3, r30
   // for item in expensive {
-  Const        r4, 1
-  Add          r5, r5, r4
+  Add          r26, r26, r16
   Jump         L3
 L2:
   Return       r0

--- a/tests/vm/valid/dataset_where_filter.ir.out
+++ b/tests/vm/valid/dataset_where_filter.ir.out
@@ -1,13 +1,10 @@
-func main (regs=15)
+func main (regs=51)
   // let people = [
   Const        r0, [{"age": 30, "name": "Alice"}, {"age": 15, "name": "Bob"}, {"age": 65, "name": "Charlie"}, {"age": 45, "name": "Diana"}]
-L0:
   // let adults = from person in people
   Const        r1, []
-L4:
   // where person.age >= 18
   Const        r2, "age"
-L5:
   // name: person.name,
   Const        r3, "name"
   // is_senior: person.age >= 60
@@ -15,68 +12,72 @@ L5:
   // let adults = from person in people
   IterPrep     r5, r0
   Len          r6, r5
-  Const        r7, 0
-  LessInt      r8, r7, r6
-  JumpIfFalse  r8, L0
-  Index        r8, r5, r7
-  // where person.age >= 18
-  Index        r5, r8, r2
-  Const        r6, 18
-  LessEq       r9, r6, r5
-L1:
-  JumpIfFalse  r9, L1
-  // name: person.name,
-  Const        r9, "name"
-  Index        r6, r8, r3
-  // age: person.age,
-  Const        r5, "age"
-  Index        r10, r8, r2
-  // is_senior: person.age >= 60
-  Const        r11, "is_senior"
-  Index        r12, r8, r2
-  Const        r13, 60
-  LessEq       r14, r13, r12
-  // name: person.name,
-  Move         r13, r9
-  Move         r9, r6
-  // age: person.age,
-  Move         r6, r5
-  Move         r5, r10
-  // is_senior: person.age >= 60
-  Move         r10, r11
-  Move         r11, r14
-  // select {
-  MakeMap      r14, 3, r13
-  // let adults = from person in people
-  Append       r1, r1, r14
-  Const        r14, 1
-  AddInt       r7, r7, r14
-  Jump         L1
-  // print("--- Adults ---")
-  Const        r14, "--- Adults ---"
-  Print        r14
-  // for person in adults {
-  IterPrep     r14, r1
-  Len          r1, r14
-  Const        r7, 0
-  Less         r11, r7, r1
-  JumpIfFalse  r11, L2
-  Index        r8, r14, r7
-  // print(person.name, "is", person.age,
-  Index        r11, r8, r3
-  Const        r3, "is"
-  Index        r1, r8, r2
-  // if person.is_senior { " (senior)" } else { "" })
-  Index        r2, r8, r4
-  JumpIfFalse  r2, L3
-  Jump         L4
-L3:
-  Const        r8, ""
-  // print(person.name, "is", person.age,
-  PrintN       r11, 4, r11
-  // for person in adults {
-  Const        r2, 1
-  Add          r7, r7, r2
-  Jump         L5
+  Const        r8, 0
+  Move         r7, r8
 L2:
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  // where person.age >= 18
+  Index        r12, r11, r2
+  Const        r13, 18
+  LessEq       r14, r13, r12
+  JumpIfFalse  r14, L1
+  // name: person.name,
+  Move         r15, r3
+  Index        r16, r11, r3
+  // age: person.age,
+  Move         r17, r2
+  Index        r18, r11, r2
+  // is_senior: person.age >= 60
+  Move         r19, r4
+  Index        r20, r11, r2
+  Const        r21, 60
+  LessEq       r22, r21, r20
+  // name: person.name,
+  Move         r23, r15
+  Move         r24, r16
+  // age: person.age,
+  Move         r25, r17
+  Move         r26, r18
+  // is_senior: person.age >= 60
+  Move         r27, r19
+  Move         r28, r22
+  // select {
+  MakeMap      r29, 3, r23
+  // let adults = from person in people
+  Append       r1, r1, r29
+L1:
+  Const        r31, 1
+  AddInt       r7, r7, r31
+  Jump         L2
+L0:
+  // print("--- Adults ---")
+  Const        r32, "--- Adults ---"
+  Print        r32
+  // for person in adults {
+  IterPrep     r33, r1
+  Len          r34, r33
+  Move         r35, r8
+L6:
+  Less         r36, r35, r34
+  JumpIfFalse  r36, L3
+  Index        r11, r33, r35
+  // print(person.name, "is", person.age,
+  Index        r38, r11, r3
+  Const        r39, "is"
+  Index        r40, r11, r2
+  // if person.is_senior { " (senior)" } else { "" })
+  Index        r45, r11, r4
+  JumpIfFalse  r45, L4
+  Jump         L5
+L4:
+  Const        r41, ""
+L5:
+  // print(person.name, "is", person.age,
+  PrintN       r38, 4, r38
+  // for person in adults {
+  Add          r35, r35, r31
+  Jump         L6
+L3:
   Return       r0

--- a/tests/vm/valid/exists_builtin.ir.out
+++ b/tests/vm/valid/exists_builtin.ir.out
@@ -1,26 +1,27 @@
-func main (regs=6)
+func main (regs=13)
   // let data = [1,2]
   Const        r0, [1, 2]
   // from x in data
   Const        r1, []
   IterPrep     r2, r0
-L1:
   Len          r3, r2
   Const        r4, 0
-  LessInt      r5, r4, r3
-  JumpIfFalse  r5, L0
-  Index        r5, r2, r4
+L2:
+  LessInt      r6, r4, r3
+  JumpIfFalse  r6, L0
+  Index        r8, r2, r4
   // where x == 1
-  Const        r2, 1
-  Equal        r3, r5, r2
-  JumpIfFalse  r3, L1
+  Const        r9, 1
+  Equal        r10, r8, r9
+  JumpIfFalse  r10, L1
   // from x in data
-  Append       r1, r1, r5
-  AddInt       r4, r4, r2
-  Jump         L1
+  Append       r1, r1, r8
+L1:
+  AddInt       r4, r4, r9
+  Jump         L2
 L0:
   // let flag = exists(
-  Exists       r3, r1
+  Exists       r12, r1
   // print(flag)
-  Print        r3
+  Print        r12
   Return       r0

--- a/tests/vm/valid/for_list_collection.ir.out
+++ b/tests/vm/valid/for_list_collection.ir.out
@@ -1,4 +1,4 @@
-func main (regs=5)
+func main (regs=9)
   // for n in [1,2,3] {
   Const        r0, [1, 2, 3]
   IterPrep     r1, r0
@@ -7,12 +7,12 @@ func main (regs=5)
 L1:
   Less         r4, r3, r2
   JumpIfFalse  r4, L0
-  Index        r2, r1, r3
+  Index        r6, r1, r3
   // print(n)
-  Print        r2
+  Print        r6
   // for n in [1,2,3] {
-  Const        r2, 1
-  Add          r3, r3, r2
+  Const        r7, 1
+  Add          r3, r3, r7
   Jump         L1
 L0:
   Return       r0

--- a/tests/vm/valid/for_loop.ir.out
+++ b/tests/vm/valid/for_loop.ir.out
@@ -1,4 +1,4 @@
-func main (regs=4)
+func main (regs=6)
   // for i in 1..4 {
   Const        r0, 1
   Const        r1, 4
@@ -9,8 +9,7 @@ L1:
   // print(i)
   Print        r2
   // for i in 1..4 {
-  Const        r1, 1
-  Add          r2, r2, r1
+  Add          r2, r2, r0
   Jump         L1
 L0:
   Return       r0

--- a/tests/vm/valid/for_map_collection.ir.out
+++ b/tests/vm/valid/for_map_collection.ir.out
@@ -1,16 +1,16 @@
-func main (regs=5)
+func main (regs=10)
   // var m = {"a": 1, "b": 2}
   Const        r0, {"a": 1, "b": 2}
   // for k in m {
-  IterPrep     r1, r0
-  Len          r2, r1
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L1:
-  Const        r3, 0
-  Less         r4, r3, r2
-  JumpIfFalse  r4, L0
-  Index        r4, r1, r3
+  Less         r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r7, r2, r4
   // print(k)
-  Print        r4
+  Print        r7
   // for k in m {
   Jump         L1
 L0:

--- a/tests/vm/valid/fun_call.ir.out
+++ b/tests/vm/valid/fun_call.ir.out
@@ -1,9 +1,9 @@
-func main (regs=3)
+func main (regs=5)
   // print(add(2, 3))  // 5
   Const        r0, 2
   Const        r1, 3
-  Call2        r2, add, r0, r1
-  Print        r2
+  Call2        r4, add, r0, r1
+  Print        r4
   Return       r0
 
   // fun add(a: int, b: int): int {

--- a/tests/vm/valid/fun_expr_in_let.ir.out
+++ b/tests/vm/valid/fun_expr_in_let.ir.out
@@ -1,10 +1,10 @@
-func main (regs=3)
+func main (regs=4)
   // let square = fun(x: int): int => x * x
   MakeClosure  r0, fn1, 0, r0
   // print(square(6))  // 36
   Const        r1, 6
-  CallV        r2, r0, 1, r1
-  Print        r2
+  CallV        r3, r0, 1, r1
+  Print        r3
   Return       r0
 
   // let square = fun(x: int): int => x * x

--- a/tests/vm/valid/fun_three_args.ir.out
+++ b/tests/vm/valid/fun_three_args.ir.out
@@ -1,15 +1,15 @@
-func main (regs=4)
+func main (regs=7)
   // print(sum3(1, 2, 3))  // 6
   Const        r0, 1
   Const        r1, 2
   Const        r2, 3
-  Call         r3, sum3, r0, r1, r2
-  Print        r3
+  Call         r6, sum3, r0, r1, r2
+  Print        r6
   Return       r0
 
   // fun sum3(a: int, b: int, c: int): int {
-func sum3 (regs=4)
+func sum3 (regs=5)
   // return a + b + c
   Add          r3, r0, r1
-  Add          r1, r3, r2
-  Return       r1
+  Add          r4, r3, r2
+  Return       r4

--- a/tests/vm/valid/if_else.ir.out
+++ b/tests/vm/valid/if_else.ir.out
@@ -1,7 +1,7 @@
-func main (regs=2)
+func main (regs=5)
   // let x = 5
   Const        r0, 5
   // print("big")
-  Const        r1, "big"
-  Print        r1
+  Const        r3, "big"
+  Print        r3
   Return       r0

--- a/tests/vm/valid/in_operator.ir.out
+++ b/tests/vm/valid/in_operator.ir.out
@@ -1,4 +1,4 @@
-func main (regs=3)
+func main (regs=6)
   // let xs = [1, 2, 3]
   Const        r0, [1, 2, 3]
   // print(2 in xs)
@@ -6,8 +6,8 @@ func main (regs=3)
   In           r2, r1, r0
   Print        r2
   // print(!(5 in xs))
-  Const        r2, 5
-  In           r1, r2, r0
-  Not          r2, r1
-  Print        r2
+  Const        r3, 5
+  In           r4, r3, r0
+  Not          r5, r4
+  Print        r5
   Return       r0

--- a/tests/vm/valid/in_operator_extended.ir.out
+++ b/tests/vm/valid/in_operator_extended.ir.out
@@ -1,4 +1,4 @@
-func main (regs=8)
+func main (regs=26)
   // let xs = [1, 2, 3]
   Const        r0, [1, 2, 3]
   // let ys = from x in xs where x % 2 == 1 select x
@@ -6,42 +6,44 @@ func main (regs=8)
   IterPrep     r2, r0
   Len          r3, r2
   Const        r4, 0
-  LessInt      r5, r4, r3
-  JumpIfFalse  r5, L0
+L2:
+  LessInt      r6, r4, r3
+  JumpIfFalse  r6, L0
+  Index        r8, r2, r4
+  Const        r9, 2
+  Mod          r10, r8, r9
+  Const        r11, 1
+  Equal        r12, r10, r11
+  JumpIfFalse  r12, L1
+  Append       r1, r1, r8
+L1:
+  AddInt       r4, r4, r11
+  Jump         L2
 L0:
-  Index        r5, r2, r4
-  Const        r2, 2
-  Mod          r3, r5, r2
-  Const        r6, 1
-  Equal        r7, r3, r6
-  JumpIfFalse  r7, L0
-  Append       r1, r1, r5
-  AddInt       r4, r4, r6
-  Jump         L0
   // print(1 in ys)
-  In           r7, r6, r1
-  Print        r7
+  In           r14, r11, r1
+  Print        r14
   // print(2 in ys)
-  In           r7, r2, r1
-  Print        r7
+  In           r15, r9, r1
+  Print        r15
   // let m = {a: 1}
-  Const        r7, {"a": 1}
+  Const        r16, {"a": 1}
   // print("a" in m)
-  Const        r2, "a"
-  In           r1, r2, r7
-  Print        r1
+  Const        r17, "a"
+  In           r18, r17, r16
+  Print        r18
   // print("b" in m)
-  Const        r1, "b"
-  In           r2, r1, r7
-  Print        r2
+  Const        r19, "b"
+  In           r20, r19, r16
+  Print        r20
   // let s = "hello"
-  Const        r2, "hello"
+  Const        r21, "hello"
   // print("ell" in s)
-  Const        r1, "ell"
-  In           r7, r1, r2
-  Print        r7
+  Const        r22, "ell"
+  In           r23, r22, r21
+  Print        r23
   // print("foo" in s)
-  Const        r7, "foo"
-  In           r1, r7, r2
-  Print        r1
+  Const        r24, "foo"
+  In           r25, r24, r21
+  Print        r25
   Return       r0

--- a/tests/vm/valid/inner_join.ir.out
+++ b/tests/vm/valid/inner_join.ir.out
@@ -1,4 +1,4 @@
-func main (regs=23)
+func main (regs=111)
 L0:
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}]
@@ -6,171 +6,168 @@ L0:
   Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}, {"customerId": 4, "id": 103, "total": 80}]
   // let result = from o in orders
   Const        r2, []
-L9:
   IterPrep     r3, r1
-  Len          r1, r3
-L5:
+  Len          r4, r3
   // join from c in customers on o.customerId == c.id
-  IterPrep     r4, r0
-  Len          r5, r4
-L6:
+  IterPrep     r5, r0
+  Len          r6, r5
   // let result = from o in orders
-  Const        r6, 0
-L2:
-  EqualInt     r7, r1, r6
-L8:
-  JumpIfTrue   r7, L0
+  Const        r7, 0
+  EqualInt     r8, r4, r7
+  JumpIfTrue   r8, L0
+  EqualInt     r9, r6, r7
+  JumpIfTrue   r9, L0
+  LessEq       r10, r6, r4
+  JumpIfFalse  r10, L1
+  // join from c in customers on o.customerId == c.id
+  MakeMap      r11, 0, r0
+  Move         r12, r7
 L4:
-  EqualInt     r7, r5, r6
+  LessInt      r13, r12, r6
+  JumpIfFalse  r13, L2
+  Index        r14, r5, r12
+  Move         r15, r14
+  Const        r16, "id"
+  Index        r17, r15, r16
+  Index        r18, r11, r17
+  Const        r19, nil
+  NotEqual     r20, r18, r19
+  JumpIfTrue   r20, L3
+  MakeList     r21, 0, r0
+  SetIndex     r11, r17, r21
 L3:
-  JumpIfTrue   r7, L0
-  LessEq       r7, r5, r1
-  JumpIfFalse  r7, L1
-  // join from c in customers on o.customerId == c.id
-  MakeMap      r7, 0, r0
-L7:
-  Const        r6, 0
-L10:
-  LessInt      r8, r6, r5
-  JumpIfFalse  r8, L2
-  Index        r8, r4, r6
-  Move         r9, r8
-  Const        r10, "id"
-L1:
-  Index        r11, r9, r10
-  Index        r12, r7, r11
-  Const        r13, nil
-  NotEqual     r14, r12, r13
-  JumpIfTrue   r14, L3
-  MakeList     r14, 0, r0
-  SetIndex     r7, r11, r14
-  Index        r12, r7, r11
-  Append       r14, r12, r8
-  SetIndex     r7, r11, r14
-  Const        r14, 1
-  AddInt       r6, r6, r14
+  Index        r18, r11, r17
+  Append       r22, r18, r14
+  SetIndex     r11, r17, r22
+  Const        r23, 1
+  AddInt       r12, r12, r23
   Jump         L4
+L2:
   // let result = from o in orders
-  Const        r6, 0
-  LessInt      r12, r6, r1
-  JumpIfFalse  r12, L0
-  Index        r12, r3, r6
+  Move         r24, r7
+L7:
+  LessInt      r25, r24, r4
+  JumpIfFalse  r25, L0
+  Index        r27, r3, r24
   // join from c in customers on o.customerId == c.id
-  Const        r11, "customerId"
-  Index        r8, r12, r11
+  Const        r28, "customerId"
+  Index        r29, r27, r28
   // let result = from o in orders
-  Index        r13, r7, r8
-  Const        r8, nil
-  NotEqual     r7, r13, r8
-  JumpIfFalse  r7, L5
-  Len          r7, r13
-  Const        r8, 0
-  LessInt      r15, r8, r7
-  JumpIfFalse  r15, L5
-  Index        r9, r13, r8
+  Index        r30, r11, r29
+  NotEqual     r32, r30, r19
+  JumpIfFalse  r32, L5
+  Len          r33, r30
+  Move         r34, r24
+L6:
+  LessInt      r35, r34, r33
+  JumpIfFalse  r35, L5
+  Index        r15, r30, r34
   // select { orderId: o.id, customerName: c.name, total: o.total }
-  Const        r7, "orderId"
-  Index        r13, r12, r10
-  Const        r16, "customerName"
-  Const        r17, "name"
-  Index        r18, r9, r17
-  Const        r19, "total"
-  Const        r20, "total"
-  Index        r21, r12, r20
-  Move         r22, r7
-  Move         r7, r13
-  Move         r13, r16
-  Move         r16, r18
-  Move         r18, r19
-  Move         r19, r21
-  MakeMap      r21, 3, r22
+  Const        r37, "orderId"
+  Index        r38, r27, r16
+  Const        r39, "customerName"
+  Const        r40, "name"
+  Index        r41, r15, r40
+  Const        r42, "total"
+  Move         r43, r42
+  Index        r44, r27, r43
+  Move         r45, r37
+  Move         r46, r38
+  Move         r47, r39
+  Move         r48, r41
+  Move         r49, r42
+  Move         r50, r44
+  MakeMap      r51, 3, r45
   // let result = from o in orders
-  Append       r2, r2, r21
-  AddInt       r8, r8, r14
+  Append       r2, r2, r51
+  AddInt       r34, r34, r23
   Jump         L6
-  AddInt       r6, r6, r14
+L5:
+  AddInt       r24, r24, r23
   Jump         L7
-  MakeMap      r21, 0, r0
-  Const        r19, 0
-  LessInt      r18, r19, r1
-  JumpIfFalse  r18, L8
-  Index        r18, r3, r19
+L1:
+  MakeMap      r53, 0, r0
+  Move         r54, r7
+L10:
+  LessInt      r55, r54, r4
+  JumpIfFalse  r55, L8
+  Index        r56, r3, r54
   // join from c in customers on o.customerId == c.id
-  Index        r3, r18, r11
+  Index        r57, r56, r28
   // let result = from o in orders
-  Index        r11, r21, r3
-  Const        r1, nil
-  NotEqual     r16, r11, r1
-  JumpIfTrue   r16, L9
-  MakeList     r16, 0, r0
-  SetIndex     r21, r3, r16
-  Index        r11, r21, r3
-  Append       r16, r11, r18
-  SetIndex     r21, r3, r16
-  AddInt       r19, r19, r14
+  Index        r58, r53, r57
+  Move         r59, r19
+  NotEqual     r60, r58, r59
+  JumpIfTrue   r60, L9
+  MakeList     r61, 0, r0
+  SetIndex     r53, r57, r61
+L9:
+  Index        r58, r53, r57
+  Append       r62, r58, r56
+  SetIndex     r53, r57, r62
+  AddInt       r54, r54, r23
   Jump         L10
+L8:
   // join from c in customers on o.customerId == c.id
-  Const        r11, 0
-  LessInt      r3, r11, r5
-  JumpIfFalse  r3, L11
-  Index        r9, r4, r11
-  Index        r3, r9, r10
-  Index        r5, r21, r3
-  Const        r3, nil
-  NotEqual     r21, r5, r3
-  JumpIfFalse  r21, L12
-  Len          r21, r5
-  Const        r16, 0
-  LessInt      r3, r16, r21
-  JumpIfFalse  r3, L12
-  Index        r12, r5, r16
+  Move         r63, r7
+L14:
+  LessInt      r64, r63, r6
+  JumpIfFalse  r64, L11
+  Index        r15, r5, r63
+  Index        r66, r15, r16
+  Index        r67, r53, r66
+  NotEqual     r69, r67, r59
+  JumpIfFalse  r69, L12
+  Len          r70, r67
+  Move         r71, r63
+L13:
+  LessInt      r72, r71, r70
+  JumpIfFalse  r72, L12
+  Index        r27, r67, r71
   // select { orderId: o.id, customerName: c.name, total: o.total }
-  Const        r3, "orderId"
-  Index        r21, r12, r10
-  Const        r10, "customerName"
-  Index        r5, r9, r17
-  Const        r17, "total"
-  Index        r9, r12, r20
-  Move         r12, r3
-  Move         r3, r21
-  Move         r21, r10
-  Move         r10, r5
-  Move         r5, r17
-  Move         r17, r9
-  MakeMap      r9, 3, r12
+  Move         r74, r37
+  Index        r75, r27, r16
+  Move         r76, r39
+  Index        r77, r15, r40
+  Move         r78, r42
+  Index        r79, r27, r43
+  Move         r80, r74
+  Move         r81, r75
+  Move         r82, r76
+  Move         r83, r77
+  Move         r84, r78
+  Move         r85, r79
+  MakeMap      r86, 3, r80
   // let result = from o in orders
-  Append       r2, r2, r9
+  Append       r2, r2, r86
   // join from c in customers on o.customerId == c.id
-  AddInt       r16, r16, r14
-  Jump         L8
+  AddInt       r71, r71, r23
+  Jump         L13
 L12:
-  AddInt       r11, r11, r14
-  Jump         L3
+  AddInt       r63, r63, r23
+  Jump         L14
 L11:
   // print("--- Orders with customer info ---")
-  Const        r11, "--- Orders with customer info ---"
-  Print        r11
+  Const        r88, "--- Orders with customer info ---"
+  Print        r88
   // for entry in result {
-  IterPrep     r11, r2
-  Len          r2, r11
-  Const        r14, 0
-L14:
-  Less         r17, r14, r2
-  JumpIfFalse  r17, L13
-  Index        r17, r11, r14
+  IterPrep     r89, r2
+  Len          r90, r89
+  Move         r91, r7
+L16:
+  Less         r92, r91, r90
+  JumpIfFalse  r92, L15
+  Index        r94, r89, r91
   // print("Order", entry.orderId, "by", entry.customerName, "- $", entry.total)
-  Const        r11, "Order"
-  Const        r2, "orderId"
-  Index        r5, r17, r2
-  Const        r9, "by"
-  Const        r2, "customerName"
-  Index        r10, r17, r2
-  Const        r2, "- $"
-  Index        r21, r17, r20
-  PrintN       r11, 5, r11
+  Const        r95, "Order"
+  Index        r96, r94, r37
+  Const        r97, "by"
+  Index        r98, r94, r39
+  Const        r99, "- $"
+  Index        r100, r94, r43
+  PrintN       r95, 6, r95
   // for entry in result {
-  Const        r21, 1
-  Add          r14, r14, r21
-  Jump         L14
-L13:
+  Add          r91, r91, r23
+  Jump         L16
+L15:
   Return       r0

--- a/tests/vm/valid/join_multi.ir.out
+++ b/tests/vm/valid/join_multi.ir.out
@@ -1,93 +1,95 @@
-func main (regs=16)
+func main (regs=60)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100}, {"customerId": 2, "id": 101}]
   // let items = [
   Const        r2, [{"orderId": 100, "sku": "a"}, {"orderId": 101, "sku": "b"}]
-L5:
   // let result = from o in orders
   Const        r3, []
-L0:
   // select { name: c.name, sku: i.sku }
   Const        r4, "name"
   Const        r5, "sku"
-L2:
   // let result = from o in orders
   IterPrep     r6, r1
-  Len          r1, r6
-  Const        r7, 0
-L3:
-  Move         r8, r7
-  LessInt      r9, r8, r1
-  JumpIfFalse  r9, L0
-  Index        r1, r6, r8
+  Len          r7, r6
+  Const        r9, 0
+  Move         r8, r9
+L6:
+  LessInt      r10, r8, r7
+  JumpIfFalse  r10, L0
+  Index        r12, r6, r8
   // join from c in customers on o.customerId == c.id
-  IterPrep     r6, r0
-L1:
-  Len          r10, r6
-  Const        r11, "customerId"
-  Const        r12, "id"
-  Move         r13, r7
-  LessInt      r14, r13, r10
-  JumpIfFalse  r14, L1
-  Index        r10, r6, r13
-  Index        r6, r1, r11
-  Index        r11, r10, r12
-  Equal        r15, r6, r11
-  JumpIfFalse  r15, L1
+  IterPrep     r13, r0
+  Len          r14, r13
+  Const        r15, "customerId"
+  Const        r16, "id"
+  Move         r17, r9
+L5:
+  LessInt      r18, r17, r14
+  JumpIfFalse  r18, L1
+  Index        r20, r13, r17
+  Index        r21, r12, r15
+  Index        r22, r20, r16
+  Equal        r23, r21, r22
+  JumpIfFalse  r23, L2
   // join from i in items on o.id == i.orderId
-  IterPrep     r15, r2
-  Len          r2, r15
-  Const        r11, "orderId"
-  Move         r6, r7
-  LessInt      r7, r6, r2
-  JumpIfFalse  r7, L1
-  Index        r7, r15, r6
-  Index        r15, r1, r12
-  Index        r12, r7, r11
-  Equal        r11, r15, r12
-  JumpIfFalse  r11, L2
-  // select { name: c.name, sku: i.sku }
-  Const        r11, "name"
-  Index        r12, r10, r4
-  Const        r10, "sku"
-  Index        r15, r7, r5
-  Move         r7, r11
-  Move         r11, r12
-  Move         r12, r10
-  Move         r10, r15
-  MakeMap      r15, 2, r7
-  // let result = from o in orders
-  Append       r3, r3, r15
-  // join from i in items on o.id == i.orderId
-  Const        r15, 1
-  Add          r6, r6, r15
-  Jump         L2
-  // join from c in customers on o.customerId == c.id
-  Add          r13, r13, r15
-  Jump         L1
-  // let result = from o in orders
-  AddInt       r8, r8, r15
-  Jump         L3
-  // print("--- Multi Join ---")
-  Const        r6, "--- Multi Join ---"
-  Print        r6
-  // for r in result {
-  IterPrep     r6, r3
-  Len          r3, r6
-  Const        r15, 0
-  Less         r14, r15, r3
-  JumpIfFalse  r14, L4
-  Index        r14, r6, r15
-  // print(r.name, "bought item", r.sku)
-  Index        r6, r14, r4
-  Const        r4, "bought item"
-  Index        r3, r14, r5
-  PrintN       r6, 3, r6
-  // for r in result {
-  Const        r3, 1
-  Add          r15, r15, r3
-  Jump         L5
+  IterPrep     r24, r2
+  Len          r25, r24
+  Const        r26, "orderId"
+  Move         r27, r9
 L4:
+  LessInt      r28, r27, r25
+  JumpIfFalse  r28, L2
+  Index        r30, r24, r27
+  Index        r31, r12, r16
+  Index        r32, r30, r26
+  Equal        r33, r31, r32
+  JumpIfFalse  r33, L3
+  // select { name: c.name, sku: i.sku }
+  Move         r34, r4
+  Index        r35, r20, r4
+  Move         r36, r5
+  Index        r37, r30, r5
+  Move         r38, r34
+  Move         r39, r35
+  Move         r40, r36
+  Move         r41, r37
+  MakeMap      r42, 2, r38
+  // let result = from o in orders
+  Append       r3, r3, r42
+L3:
+  // join from i in items on o.id == i.orderId
+  Const        r44, 1
+  Add          r27, r27, r44
+  Jump         L4
+L2:
+  // join from c in customers on o.customerId == c.id
+  Add          r17, r17, r44
+  Jump         L5
+L1:
+  // let result = from o in orders
+  AddInt       r8, r8, r44
+  Jump         L6
+L0:
+  // print("--- Multi Join ---")
+  Const        r45, "--- Multi Join ---"
+  Print        r45
+  // for r in result {
+  IterPrep     r46, r3
+  Len          r47, r46
+  Move         r48, r9
+L8:
+  Less         r49, r48, r47
+  JumpIfFalse  r49, L7
+  Index        r51, r46, r48
+  // print(r.name, "bought item", r.sku)
+  Index        r52, r51, r4
+  Const        r53, "bought item"
+  Index        r54, r51, r5
+  PrintN       r52, 3, r52
+  // for r in result {
+  Add          r48, r48, r44
+  Jump         L8
+L7:
   Return       r0

--- a/tests/vm/valid/left_join.ir.out
+++ b/tests/vm/valid/left_join.ir.out
@@ -1,132 +1,131 @@
-func main (regs=17)
+func main (regs=82)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-L0:
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 3, "id": 101, "total": 80}]
-L3:
   // let result = from o in orders
   Const        r2, []
   IterPrep     r3, r1
-  Len          r1, r3
+  Len          r4, r3
   // left join c in customers on o.customerId == c.id
-  IterPrep     r4, r0
-L6:
-  Len          r5, r4
-L1:
-  MakeMap      r6, 0, r0
-L2:
-  Const        r7, 0
-  LessInt      r8, r7, r5
-  JumpIfFalse  r8, L0
-  Index        r5, r4, r7
-  Move         r4, r5
-  Const        r9, "id"
-  Index        r10, r4, r9
-L5:
-  Index        r11, r6, r10
-L4:
-  Const        r12, nil
-  NotEqual     r13, r11, r12
-  JumpIfTrue   r13, L1
-  MakeList     r13, 0, r0
-  SetIndex     r6, r10, r13
-  Index        r11, r6, r10
-  Append       r13, r11, r5
-  SetIndex     r6, r10, r13
-  Const        r13, 1
-  AddInt       r7, r7, r13
-  Jump         L2
-  // let result = from o in orders
+  IterPrep     r5, r0
+  Len          r6, r5
+  MakeMap      r7, 0, r0
   Const        r8, 0
-  LessInt      r7, r8, r1
-  JumpIfFalse  r7, L3
-  Index        r7, r3, r8
-  // left join c in customers on o.customerId == c.id
-  Const        r3, "customerId"
-  Index        r1, r7, r3
+L2:
+  LessInt      r9, r8, r6
+  JumpIfFalse  r9, L0
+  Index        r10, r5, r8
+  Move         r11, r10
+  Const        r12, "id"
+  Index        r13, r11, r12
+  Index        r14, r7, r13
+  Const        r15, nil
+  NotEqual     r16, r14, r15
+  JumpIfTrue   r16, L1
+  MakeList     r17, 0, r0
+  SetIndex     r7, r13, r17
+L1:
+  Index        r14, r7, r13
+  Append       r18, r14, r10
+  SetIndex     r7, r13, r18
+  Const        r19, 1
+  AddInt       r8, r8, r19
+  Jump         L2
+L0:
   // let result = from o in orders
-  Index        r3, r6, r1
-  Const        r1, nil
-  NotEqual     r6, r3, r1
-  JumpIfFalse  r6, L4
-  Len          r1, r3
-  Const        r11, 0
-  LessInt      r10, r11, r1
-  JumpIfFalse  r10, L4
-  Index        r4, r3, r11
-  // orderId: o.id,
-  Const        r10, "orderId"
-  Index        r1, r7, r9
-  // customer: c,
-  Const        r3, "customer"
-  // total: o.total
-  Const        r5, "total"
-  Const        r12, "total"
-  Index        r14, r7, r12
-  // orderId: o.id,
-  Move         r15, r10
-  Move         r10, r1
-  // customer: c,
-  Move         r1, r3
-  Move         r3, r4
-  // total: o.total
-  Move         r16, r5
-  Move         r5, r14
-  // select {
-  MakeMap      r14, 3, r15
-  // let result = from o in orders
-  Append       r2, r2, r14
-  AddInt       r11, r11, r13
-  Jump         L5
-  JumpIfTrue   r6, L1
-  Const        r4, nil
-  // orderId: o.id,
-  Const        r14, "orderId"
-  Index        r5, r7, r9
-  // customer: c,
-  Const        r9, "customer"
-  // total: o.total
-  Const        r16, "total"
-  Index        r3, r7, r12
-  // orderId: o.id,
-  Move         r7, r14
-  Move         r14, r5
-  // customer: c,
-  Move         r5, r9
-  Move         r9, r4
-  // total: o.total
-  Move         r4, r16
-  Move         r16, r3
-  // select {
-  MakeMap      r3, 3, r7
-  // let result = from o in orders
-  Append       r2, r2, r3
-  AddInt       r8, r8, r13
-  Jump         L6
-  // print("--- Left Join ---")
-  Const        r3, "--- Left Join ---"
-  Print        r3
-  // for entry in result {
-  IterPrep     r3, r2
-  Len          r2, r3
-  Const        r16, 0
-  Less         r4, r16, r2
-  JumpIfFalse  r4, L7
-  Index        r4, r3, r16
-  // print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
-  Const        r3, "Order"
-  Const        r2, "orderId"
-  Index        r9, r4, r2
-  Const        r2, "customer"
-  Move         r5, r2
-  Index        r14, r4, r2
-  Move         r2, r12
-  Index        r7, r4, r12
-  PrintN       r3, 5, r3
-  // for entry in result {
-  Const        r7, 1
-  Add          r16, r16, r7
-  Jump         L1
+  Const        r20, 0
 L7:
+  LessInt      r21, r20, r4
+  JumpIfFalse  r21, L3
+  Index        r23, r3, r20
+  // left join c in customers on o.customerId == c.id
+  Const        r24, "customerId"
+  Index        r25, r23, r24
+  // let result = from o in orders
+  Index        r26, r7, r25
+  NotEqual     r28, r26, r15
+  JumpIfFalse  r28, L4
+  Len          r29, r26
+  Move         r30, r20
+L5:
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L4
+  Index        r11, r26, r30
+  // orderId: o.id,
+  Const        r33, "orderId"
+  Index        r34, r23, r12
+  // customer: c,
+  Const        r35, "customer"
+  // total: o.total
+  Const        r36, "total"
+  Move         r37, r36
+  Index        r38, r23, r37
+  // orderId: o.id,
+  Move         r39, r33
+  Move         r40, r34
+  // customer: c,
+  Move         r41, r35
+  Move         r42, r11
+  // total: o.total
+  Move         r43, r36
+  Move         r44, r38
+  // select {
+  MakeMap      r45, 3, r39
+  // let result = from o in orders
+  Append       r2, r2, r45
+  AddInt       r30, r30, r19
+  Jump         L5
+L4:
+  JumpIfTrue   r28, L6
+  Move         r11, r15
+  // orderId: o.id,
+  Move         r48, r33
+  Index        r49, r23, r12
+  // customer: c,
+  Move         r50, r35
+  // total: o.total
+  Move         r51, r36
+  Index        r52, r23, r37
+  // orderId: o.id,
+  Move         r53, r48
+  Move         r54, r49
+  // customer: c,
+  Move         r55, r50
+  Move         r56, r11
+  // total: o.total
+  Move         r57, r51
+  Move         r58, r52
+  // select {
+  MakeMap      r59, 3, r53
+  // let result = from o in orders
+  Append       r2, r2, r59
+L6:
+  AddInt       r20, r20, r19
+  Jump         L7
+L3:
+  // print("--- Left Join ---")
+  Const        r61, "--- Left Join ---"
+  Print        r61
+  // for entry in result {
+  IterPrep     r62, r2
+  Len          r63, r62
+  Const        r64, 0
+L9:
+  Less         r65, r64, r63
+  JumpIfFalse  r65, L8
+  Index        r67, r62, r64
+  // print("Order", entry.orderId, "customer", entry.customer, "total", entry.total)
+  Const        r68, "Order"
+  Index        r69, r67, r33
+  Move         r77, r35
+  Move         r70, r77
+  Index        r71, r67, r77
+  Move         r72, r37
+  Index        r73, r67, r37
+  PrintN       r68, 6, r68
+  // for entry in result {
+  Add          r64, r64, r19
+  Jump         L9
+L8:
   Return       r0

--- a/tests/vm/valid/left_join_multi.ir.out
+++ b/tests/vm/valid/left_join_multi.ir.out
@@ -1,4 +1,4 @@
-func main (regs=22)
+func main (regs=79)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
   // let orders = [
@@ -7,112 +7,113 @@ func main (regs=22)
   Const        r2, [{"orderId": 100, "sku": "a"}]
   // let result = from o in orders
   Const        r3, []
-L1:
   // select { orderId: o.id, name: c.name, item: i }
   Const        r4, "orderId"
-L2:
   Const        r5, "id"
   Const        r6, "name"
   Const        r7, "item"
   // let result = from o in orders
   IterPrep     r8, r1
-  Len          r1, r8
-  Const        r9, 0
+  Len          r9, r8
+  Const        r11, 0
+  Move         r10, r11
+L7:
+  LessInt      r12, r10, r9
+  JumpIfFalse  r12, L0
+  Index        r14, r8, r10
+  // join from c in customers on o.customerId == c.id
+  IterPrep     r15, r0
+  Len          r16, r15
+  Const        r17, "customerId"
+  Move         r18, r11
+L6:
+  LessInt      r19, r18, r16
+  JumpIfFalse  r19, L1
+  Index        r21, r15, r18
+  Index        r22, r14, r17
+  Index        r23, r21, r5
+  Equal        r24, r22, r23
+  JumpIfFalse  r24, L2
+  // left join i in items on o.id == i.orderId
+  IterPrep     r25, r2
+  Len          r26, r25
+  Move         r27, r11
 L5:
-  Move         r10, r9
-  LessInt      r11, r10, r1
-L3:
-  JumpIfFalse  r11, L0
-  Index        r1, r8, r10
+  LessInt      r28, r27, r26
+  JumpIfFalse  r28, L3
+  Index        r30, r25, r27
+  Const        r31, false
+  Index        r32, r14, r5
+  Index        r33, r30, r4
+  Equal        r34, r32, r33
+  JumpIfFalse  r34, L4
+  Const        r31, true
+  // select { orderId: o.id, name: c.name, item: i }
+  Move         r35, r4
+  Index        r36, r14, r5
+  Move         r37, r6
+  Index        r38, r21, r6
+  Move         r39, r7
+  Move         r40, r35
+  Move         r41, r36
+  Move         r42, r37
+  Move         r43, r38
+  Move         r44, r39
+  Move         r45, r30
+  MakeMap      r46, 3, r40
+  // let result = from o in orders
+  Append       r3, r3, r46
 L4:
-  // join from c in customers on o.customerId == c.id
-  IterPrep     r8, r0
-  Len          r12, r8
-  Const        r13, "customerId"
-  Move         r14, r9
-  LessInt      r15, r14, r12
-  JumpIfFalse  r15, L1
-  Index        r12, r8, r14
-  Index        r8, r1, r13
-  Index        r13, r12, r5
-  Equal        r16, r8, r13
-  JumpIfFalse  r16, L2
   // left join i in items on o.id == i.orderId
-  IterPrep     r16, r2
-  Len          r2, r16
-  Move         r13, r9
-  LessInt      r9, r13, r2
-  JumpIfFalse  r9, L2
-  Index        r9, r16, r13
-  Const        r16, false
-  Index        r2, r1, r5
-  Index        r8, r9, r4
-  Equal        r17, r2, r8
-  JumpIfFalse  r17, L3
-  Const        r16, true
-  // select { orderId: o.id, name: c.name, item: i }
-  Const        r17, "orderId"
-  Index        r8, r1, r5
-  Const        r2, "name"
-  Index        r18, r12, r6
-  Const        r19, "item"
-  Move         r20, r17
-  Move         r17, r8
-  Move         r8, r2
-  Move         r2, r18
-  Move         r18, r19
-  Move         r19, r9
-  MakeMap      r21, 3, r20
-  // let result = from o in orders
-  Append       r3, r3, r21
-  // left join i in items on o.id == i.orderId
-  Const        r21, 1
-  Add          r13, r13, r21
-  Jump         L3
-  Move         r13, r16
-  JumpIfTrue   r13, L2
-  Const        r9, nil
-  // select { orderId: o.id, name: c.name, item: i }
-  Const        r13, "orderId"
-  Index        r16, r1, r5
-  Const        r1, "name"
-  Index        r5, r12, r6
-  Const        r12, "item"
-  Move         r19, r13
-  Move         r13, r16
-  Move         r16, r1
-  Move         r1, r5
-  Move         r5, r12
-  Move         r12, r9
-  MakeMap      r9, 3, r19
-  // let result = from o in orders
-  Append       r3, r3, r9
-  // join from c in customers on o.customerId == c.id
-  Add          r14, r14, r21
-  Jump         L4
-  // let result = from o in orders
-  AddInt       r10, r10, r21
+  Const        r48, 1
+  Add          r27, r27, r48
   Jump         L5
+L3:
+  Move         r49, r31
+  JumpIfTrue   r49, L2
+  Const        r30, nil
+  // select { orderId: o.id, name: c.name, item: i }
+  Move         r51, r4
+  Index        r52, r14, r5
+  Move         r53, r6
+  Index        r54, r21, r6
+  Move         r55, r7
+  Move         r56, r51
+  Move         r57, r52
+  Move         r58, r53
+  Move         r59, r54
+  Move         r60, r55
+  Move         r61, r30
+  MakeMap      r62, 3, r56
+  // let result = from o in orders
+  Append       r3, r3, r62
+L2:
+  // join from c in customers on o.customerId == c.id
+  Add          r18, r18, r48
+  Jump         L6
+L1:
+  // let result = from o in orders
+  AddInt       r10, r10, r48
+  Jump         L7
 L0:
   // print("--- Left Join Multi ---")
-  Const        r9, "--- Left Join Multi ---"
-  Print        r9
+  Const        r64, "--- Left Join Multi ---"
+  Print        r64
   // for r in result {
-  IterPrep     r9, r3
-  Len          r3, r9
-  Const        r12, 0
-L7:
-  Less         r5, r12, r3
-  JumpIfFalse  r5, L6
-  Index        r5, r9, r12
+  IterPrep     r65, r3
+  Len          r66, r65
+  Move         r67, r11
+L9:
+  Less         r68, r67, r66
+  JumpIfFalse  r68, L8
+  Index        r70, r65, r67
   // print(r.orderId, r.name, r.item)
-  Index        r9, r5, r4
-  Index        r4, r5, r6
-  Index        r6, r5, r7
-  PrintN       r9, 3, r9
+  Index        r71, r70, r4
+  Index        r72, r70, r6
+  Index        r73, r70, r7
+  PrintN       r71, 3, r71
   // for r in result {
-  Const        r6, 1
-  Add          r12, r12, r6
-  Jump         L7
-L6:
+  Add          r67, r67, r48
+  Jump         L9
+L8:
   Return       r0

--- a/tests/vm/valid/let_and_print.ir.out
+++ b/tests/vm/valid/let_and_print.ir.out
@@ -1,7 +1,7 @@
-func main (regs=2)
+func main (regs=3)
   // let a = 10
   Const        r0, 10
   // print(a + b)
-  Const        r1, 30
-  Print        r1
+  Const        r2, 30
+  Print        r2
   Return       r0

--- a/tests/vm/valid/list_assign.ir.out
+++ b/tests/vm/valid/list_assign.ir.out
@@ -1,4 +1,4 @@
-func main (regs=4)
+func main (regs=5)
   // var nums = [1, 2]
   Const        r0, [1, 2]
   Move         r1, r0
@@ -7,6 +7,6 @@ func main (regs=4)
   Const        r3, 3
   SetIndex     r1, r2, r3
   // print(nums[1])
-  Const        r3, 2
-  Print        r3
+  Const        r4, 2
+  Print        r4
   Return       r0

--- a/tests/vm/valid/list_index.ir.out
+++ b/tests/vm/valid/list_index.ir.out
@@ -1,7 +1,7 @@
-func main (regs=2)
+func main (regs=3)
   // let xs = [10, 20, 30]
   Const        r0, [10, 20, 30]
   // print(xs[1])
-  Const        r1, 20
-  Print        r1
+  Const        r2, 20
+  Print        r2
   Return       r0

--- a/tests/vm/valid/list_nested_assign.ir.out
+++ b/tests/vm/valid/list_nested_assign.ir.out
@@ -1,12 +1,12 @@
-func main (regs=4)
+func main (regs=8)
   // var matrix = [[1,2],[3,4]]
   Const        r0, [[1, 2], [3, 4]]
   // matrix[1][0] = 5
-  Const        r1, [3, 4]
-  Const        r2, 0
-  Const        r3, 5
-  SetIndex     r1, r2, r3
+  Const        r3, [3, 4]
+  Const        r4, 0
+  Const        r5, 5
+  SetIndex     r3, r4, r5
   // print(matrix[1][0])
-  Const        r3, 3
-  Print        r3
+  Const        r7, 3
+  Print        r7
   Return       r0

--- a/tests/vm/valid/list_set_ops.ir.out
+++ b/tests/vm/valid/list_set_ops.ir.out
@@ -1,20 +1,16 @@
-func main (regs=4)
+func main (regs=10)
   // print([1,2] union [2,3])
   Const        r0, [1, 2]
-  Const        r1, [2, 3]
-  Union        r2, r0, r1
+  Const        r2, [1, 2, 3]
   Print        r2
   // print([1,2,3] except [2])
-  Const        r2, [1, 2, 3]
-  Const        r1, [2]
-  Except       r3, r2, r1
-  Print        r3
+  Const        r4, [2]
+  Const        r5, [1, 3]
+  Print        r5
   // print([1,2,3] intersect [2,4])
-  Const        r3, [1, 2, 3]
-  Const        r1, [2, 4]
-  Intersect    r2, r3, r1
-  Print        r2
+  Move         r8, r4
+  Print        r8
   // print(len([1,2] union all [2,3]))
-  Const        r2, 3
-  Print        r2
+  Const        r9, 3
+  Print        r9
   Return       r0

--- a/tests/vm/valid/load_yaml.ir.out
+++ b/tests/vm/valid/load_yaml.ir.out
@@ -1,55 +1,60 @@
-func main (regs=10)
+func main (regs=39)
   // let people = load "../interpreter/valid/people.yaml" as Person with { format: "yaml" }
   Const        r0, "../interpreter/valid/people.yaml"
-  Const        r1, {"format": "yaml"}
-  Load         2,0,1,0
+  Const        r2, {"format": "yaml"}
+  Load         3,0,2,0
   // let adults = from p in people
-  Const        r1, []
+  Const        r4, []
   // where p.age >= 18
-  Const        r3, "age"
+  Const        r5, "age"
   // select { name: p.name, email: p.email }
-  Const        r4, "name"
-L3:
-  Const        r5, "email"
+  Const        r6, "name"
+  Const        r7, "email"
+  // let adults = from p in people
+  IterPrep     r8, r3
+  Len          r9, r8
+  Const        r11, 0
+  Move         r10, r11
+L2:
+  LessInt      r12, r10, r9
+  JumpIfFalse  r12, L0
+  Index        r14, r8, r10
+  // where p.age >= 18
+  Index        r15, r14, r5
+  Const        r16, 18
+  LessEq       r17, r16, r15
+  JumpIfFalse  r17, L1
+  // select { name: p.name, email: p.email }
+  Move         r18, r6
+  Index        r19, r14, r6
+  Move         r20, r7
+  Index        r21, r14, r7
+  Move         r22, r18
+  Move         r23, r19
+  Move         r24, r20
+  Move         r25, r21
+  MakeMap      r26, 2, r22
+  // let adults = from p in people
+  Append       r4, r4, r26
 L1:
-  // let adults = from p in people
-  IterPrep     r6, r2
-  Len          r2, r6
-  Const        r7, 0
-  LessInt      r8, r7, r2
-  JumpIfFalse  r8, L0
-  Index        r8, r6, r7
-  // where p.age >= 18
-  Index        r6, r8, r3
-  Const        r3, 18
-  LessEq       r2, r3, r6
-  JumpIfFalse  r2, L1
-  // select { name: p.name, email: p.email }
-  Const        r2, "name"
-  Index        r3, r8, r4
-  Const        r6, "email"
-  Index        r9, r8, r5
-  Move         r8, r2
-  Move         r2, r3
-  Move         r3, r6
-  Move         r6, r9
-  MakeMap      r9, 1, r8
-  // let adults = from p in people
-  Append       r1, r1, r9
-  Jump         L1
+  Const        r28, 1
+  AddInt       r10, r10, r28
+  Jump         L2
 L0:
   // for a in adults {
-  IterPrep     r9, r1
-  Len          r1, r9
-  Const        r6, 0
-  Less         r3, r6, r1
-  JumpIfFalse  r3, L2
-  Index        r3, r9, r6
+  IterPrep     r29, r4
+  Len          r30, r29
+  Move         r31, r11
+L4:
+  Less         r32, r31, r30
+  JumpIfFalse  r32, L3
+  Index        r34, r29, r31
   // print(a.name, a.email)
-  Index        r9, r3, r4
-  Index        r4, r3, r5
-  Print2       r9, r4
+  Index        r35, r34, r6
+  Index        r36, r34, r7
+  Print2       r35, r36
   // for a in adults {
-  Jump         L3
-L2:
+  Add          r31, r31, r28
+  Jump         L4
+L3:
   Return       r0

--- a/tests/vm/valid/map_assign.ir.out
+++ b/tests/vm/valid/map_assign.ir.out
@@ -1,4 +1,4 @@
-func main (regs=4)
+func main (regs=5)
   // var scores = {"alice": 1}
   Const        r0, {"alice": 1}
   Move         r1, r0
@@ -7,6 +7,6 @@ func main (regs=4)
   Const        r3, 2
   SetIndex     r1, r2, r3
   // print(scores["bob"])
-  Const        r3, nil
-  Print        r3
+  Const        r4, nil
+  Print        r4
   Return       r0

--- a/tests/vm/valid/map_in_operator.ir.out
+++ b/tests/vm/valid/map_in_operator.ir.out
@@ -1,4 +1,4 @@
-func main (regs=3)
+func main (regs=5)
   // let m = {1: "a", 2: "b"}
   Const        r0, {"1": "a", "2": "b"}
   // print(1 in m)
@@ -6,7 +6,7 @@ func main (regs=3)
   In           r2, r1, r0
   Print        r2
   // print(3 in m)
-  Const        r2, 3
-  In           r1, r2, r0
-  Print        r1
+  Const        r3, 3
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/map_index.ir.out
+++ b/tests/vm/valid/map_index.ir.out
@@ -1,7 +1,7 @@
-func main (regs=2)
+func main (regs=3)
   // let m = {"a": 1, "b": 2}
   Const        r0, {"a": 1, "b": 2}
   // print(m["b"])
-  Const        r1, 2
-  Print        r1
+  Const        r2, 2
+  Print        r2
   Return       r0

--- a/tests/vm/valid/map_int_key.ir.out
+++ b/tests/vm/valid/map_int_key.ir.out
@@ -1,7 +1,7 @@
-func main (regs=2)
+func main (regs=3)
   // let m = {1: "a", 2: "b"}
   Const        r0, {"1": "a", "2": "b"}
   // print(m[1])
-  Const        r1, "a"
-  Print        r1
+  Const        r2, "a"
+  Print        r2
   Return       r0

--- a/tests/vm/valid/map_literal_dynamic.ir.out
+++ b/tests/vm/valid/map_literal_dynamic.ir.out
@@ -1,19 +1,19 @@
-func main (regs=8)
+func main (regs=14)
   // var x = 3
   Const        r0, 3
   Move         r1, r0
   // var y = 4
-  Const        r2, 4
+  Const        r3, 4
   // var m = {"a": x, "b": y}
-  Const        r3, "a"
-  Const        r4, "b"
-  Move         r5, r3
-  Move         r6, r1
-  Move         r1, r4
-  Move         r7, r2
-  MakeMap      r2, 2, r5
+  Const        r4, "a"
+  Const        r5, "b"
+  Move         r6, r4
+  Move         r7, r1
+  Move         r8, r5
+  Move         r9, r3
+  MakeMap      r11, 2, r6
   // print(m["a"], m["b"])
-  Index        r7, r2, r3
-  Index        r3, r2, r4
-  Print2       r7, r3
+  Index        r12, r11, r4
+  Index        r13, r11, r5
+  Print2       r12, r13
   Return       r0

--- a/tests/vm/valid/map_membership.ir.out
+++ b/tests/vm/valid/map_membership.ir.out
@@ -1,4 +1,4 @@
-func main (regs=3)
+func main (regs=5)
   // let m = {"a": 1, "b": 2}
   Const        r0, {"a": 1, "b": 2}
   // print("a" in m)
@@ -6,7 +6,7 @@ func main (regs=3)
   In           r2, r1, r0
   Print        r2
   // print("c" in m)
-  Const        r2, "c"
-  In           r1, r2, r0
-  Print        r1
+  Const        r3, "c"
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/map_nested_assign.ir.out
+++ b/tests/vm/valid/map_nested_assign.ir.out
@@ -1,12 +1,12 @@
-func main (regs=4)
+func main (regs=8)
   // var data = {"outer": {"inner": 1}}
   Const        r0, {"outer": {"inner": 1}}
   // data["outer"]["inner"] = 2
-  Const        r1, {"inner": 1}
-  Const        r2, "inner"
-  Const        r3, 2
-  SetIndex     r1, r2, r3
+  Const        r3, {"inner": 1}
+  Const        r4, "inner"
+  Const        r5, 2
+  SetIndex     r3, r4, r5
   // print(data["outer"]["inner"])
-  Const        r3, 1
-  Print        r3
+  Const        r7, 1
+  Print        r7
   Return       r0

--- a/tests/vm/valid/match_expr.ir.out
+++ b/tests/vm/valid/match_expr.ir.out
@@ -1,4 +1,4 @@
-func main (regs=2)
+func main (regs=11)
   // let x = 2
   Const        r0, 2
   // 2 => "two"

--- a/tests/vm/valid/match_full.ir.out
+++ b/tests/vm/valid/match_full.ir.out
@@ -1,4 +1,4 @@
-func main (regs=3)
+func main (regs=35)
   // let x = 2
   Const        r0, 2
   // 2 => "two"
@@ -6,41 +6,41 @@ func main (regs=3)
   // print(label)
   Print        r1
   // "sun" => "relaxed"
-  Const        r1, "relaxed"
+  Const        r12, "relaxed"
   // print(mood)
-  Print        r1
+  Print        r12
   // true => "confirmed"
-  Const        r1, "confirmed"
+  Const        r23, "confirmed"
   // print(status)
-  Print        r1
+  Print        r23
   // print(classify(0))
-  Const        r1, 0
-  Call         r2, classify, r1
-  Print        r2
+  Const        r29, 0
+  Call         r31, classify, r29
+  Print        r31
   // print(classify(5))
-  Const        r2, 5
-  Call         r1, classify, r2
-  Print        r1
+  Const        r32, 5
+  Call         r34, classify, r32
+  Print        r34
   Return       r0
 
   // fun classify(n: int): string {
-func classify (regs=4)
+func classify (regs=9)
   // 0 => "zero"
-  Const        r1, 0
-  Equal        r2, r0, r1
+  Const        r3, 0
+  Equal        r2, r0, r3
   JumpIfFalse  r2, L0
-L0:
-  Const        r2, "zero"
+  Const        r1, "zero"
   Jump         L1
+L0:
   // 1 => "one"
-  Const        r1, 1
-  Equal        r3, r0, r1
-  JumpIfFalse  r3, L2
-  Const        r2, "one"
+  Const        r6, 1
+  Equal        r5, r0, r6
+  JumpIfFalse  r5, L2
+  Const        r1, "one"
   Jump         L1
 L2:
   // _ => "many"
-  Const        r2, "many"
+  Const        r1, "many"
 L1:
   // return match n {
-  Return       r2
+  Return       r1

--- a/tests/vm/valid/math_ops.ir.out
+++ b/tests/vm/valid/math_ops.ir.out
@@ -1,12 +1,12 @@
-func main (regs=2)
+func main (regs=6)
   // print(6 * 7)
   Const        r0, 6
-  Const        r1, 42
-  Print        r1
+  Const        r2, 42
+  Print        r2
   // print(7 / 2)
-  Const        r1, 3
-  Print        r1
+  Const        r4, 3
+  Print        r4
   // print(7 % 2)
-  Const        r1, 1
-  Print        r1
+  Const        r5, 1
+  Print        r5
   Return       r0

--- a/tests/vm/valid/membership.ir.out
+++ b/tests/vm/valid/membership.ir.out
@@ -1,4 +1,4 @@
-func main (regs=3)
+func main (regs=5)
   // let nums = [1, 2, 3]
   Const        r0, [1, 2, 3]
   // print(2 in nums)
@@ -6,7 +6,7 @@ func main (regs=3)
   In           r2, r1, r0
   Print        r2
   // print(4 in nums)
-  Const        r2, 4
-  In           r1, r2, r0
-  Print        r1
+  Const        r3, 4
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/min_max_builtin.ir.out
+++ b/tests/vm/valid/min_max_builtin.ir.out
@@ -1,10 +1,10 @@
-func main (regs=2)
+func main (regs=3)
   // let nums = [3,1,4]
   Const        r0, [3, 1, 4]
   // print(min(nums))
   Const        r1, 1
   Print        r1
   // print(max(nums))
-  Const        r1, 4
-  Print        r1
+  Const        r2, 4
+  Print        r2
   Return       r0

--- a/tests/vm/valid/nested_function.ir.out
+++ b/tests/vm/valid/nested_function.ir.out
@@ -1,19 +1,19 @@
-func main (regs=2)
+func main (regs=3)
   // print(outer(3))  // 8
   Const        r0, 3
-  Call         r1, outer, r0
-  Print        r1
+  Call         r2, outer, r0
+  Print        r2
   Return       r0
 
   // fun outer(x: int): int {
-func outer (regs=3)
+func outer (regs=6)
   // fun inner(y: int): int {
   Move         r1, r0
-  MakeClosure  r0, main, 1, r1
+  MakeClosure  r2, inner, 1, r1
   // return inner(5)
-  Const        r1, 5
-  CallV        r2, r0, 1, r1
-  Return       r2
+  Const        r3, 5
+  CallV        r5, r2, 1, r3
+  Return       r5
 
   // fun inner(y: int): int {
 func inner (regs=3)

--- a/tests/vm/valid/order_by_map.ir.out
+++ b/tests/vm/valid/order_by_map.ir.out
@@ -1,4 +1,4 @@
-func main (regs=9)
+func main (regs=26)
   // let data = [
   Const        r0, [{"a": 1, "b": 2}, {"a": 1, "b": 1}, {"a": 0, "b": 5}]
   // from x in data
@@ -11,25 +11,25 @@ func main (regs=9)
   Len          r5, r4
   Const        r6, 0
 L1:
-  LessInt      r7, r6, r5
-  JumpIfFalse  r7, L0
-  Index        r7, r4, r6
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r10, r4, r6
   // sort by { a: x.a, b: x.b }
-  Const        r4, "a"
-  Index        r5, r7, r2
-  Const        r2, "b"
-  Index        r8, r7, r3
-  Move         r3, r4
-  Move         r4, r5
-  Move         r5, r2
-  Move         r2, r8
-  MakeMap      r8, 2, r3
+  Move         r11, r2
+  Index        r12, r10, r2
+  Move         r13, r3
+  Index        r14, r10, r3
+  Move         r15, r11
+  Move         r16, r12
+  Move         r17, r13
+  Move         r18, r14
+  MakeMap      r20, 2, r15
   // from x in data
-  Move         r2, r7
-  MakeList     r7, 2, r8
-  Append       r1, r1, r7
-  Const        r7, 1
-  AddInt       r6, r6, r7
+  Move         r21, r10
+  MakeList     r22, 2, r20
+  Append       r1, r1, r22
+  Const        r24, 1
+  AddInt       r6, r6, r24
   Jump         L1
 L0:
   // sort by { a: x.a, b: x.b }

--- a/tests/vm/valid/partial_application.ir.out
+++ b/tests/vm/valid/partial_application.ir.out
@@ -1,11 +1,11 @@
-func main (regs=4)
+func main (regs=6)
   // let add5 = add(5)
   Const        r0, 5
-  Call         r1, add, r0
+  Call         r2, add, r0
   // print(add5(3))
-  Const        r2, 3
-  CallV        r3, r1, 1, r2
-  Print        r3
+  Const        r3, 3
+  CallV        r5, r2, 1, r3
+  Print        r5
   Return       r0
 
   // fun add(a: int, b: int): int {

--- a/tests/vm/valid/query_sum_select.ir.out
+++ b/tests/vm/valid/query_sum_select.ir.out
@@ -1,23 +1,24 @@
-func main (regs=6)
+func main (regs=13)
   // let nums = [1,2,3]
   Const        r0, [1, 2, 3]
   // let result = from n in nums where n > 1 select sum(n)
   Const        r1, []
   IterPrep     r2, r0
-L1:
   Len          r3, r2
   Const        r4, 0
-  LessInt      r5, r4, r3
-  JumpIfFalse  r5, L0
-  Index        r5, r2, r4
-  Const        r2, 1
-  Less         r3, r2, r5
-  JumpIfFalse  r3, L1
-  Append       r1, r1, r5
-  AddInt       r4, r4, r2
-  Jump         L1
+L2:
+  LessInt      r6, r4, r3
+  JumpIfFalse  r6, L0
+  Index        r8, r2, r4
+  Const        r9, 1
+  Less         r10, r9, r8
+  JumpIfFalse  r10, L1
+  Append       r1, r1, r8
+L1:
+  AddInt       r4, r4, r9
+  Jump         L2
 L0:
-  Sum          r3, r1
+  Sum          r12, r1
   // print(result)
-  Print        r3
+  Print        r12
   Return       r0

--- a/tests/vm/valid/right_join.ir.out
+++ b/tests/vm/valid/right_join.ir.out
@@ -1,139 +1,139 @@
-func main (regs=15)
+func main (regs=85)
   // let customers = [
   Const        r0, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}, {"id": 3, "name": "Charlie"}, {"id": 4, "name": "Diana"}]
-L0:
   // let orders = [
   Const        r1, [{"customerId": 1, "id": 100, "total": 250}, {"customerId": 2, "id": 101, "total": 125}, {"customerId": 1, "id": 102, "total": 300}]
   // let result = from c in customers
   Const        r2, []
   IterPrep     r3, r0
   Len          r4, r3
-L4:
   // right join o in orders on o.customerId == c.id
   IterPrep     r5, r1
-L5:
-  Len          r1, r5
-L1:
+  Len          r6, r5
   // let result = from c in customers
-  MakeMap      r6, 0, r0
-L2:
-  Const        r7, 0
-  LessInt      r8, r7, r4
-  JumpIfFalse  r8, L0
-  Index        r4, r3, r7
-L3:
-  Move         r3, r4
-L9:
-  // right join o in orders on o.customerId == c.id
-  Const        r9, "id"
-  Index        r10, r3, r9
-  // let result = from c in customers
-  Index        r11, r6, r10
-  Const        r12, nil
-  NotEqual     r13, r11, r12
-  JumpIfTrue   r13, L1
-  MakeList     r13, 0, r0
-  SetIndex     r6, r10, r13
-  Index        r11, r6, r10
-  Append       r13, r11, r4
-  SetIndex     r6, r10, r13
-  Const        r13, 1
-  AddInt       r7, r7, r13
-  Jump         L2
-  // right join o in orders on o.customerId == c.id
+  MakeMap      r7, 0, r0
   Const        r8, 0
-  LessInt      r7, r8, r1
-  JumpIfFalse  r7, L3
-  Index        r7, r5, r8
-  Const        r5, "customerId"
-  Index        r1, r7, r5
-  Index        r5, r6, r1
-  Const        r1, nil
-  NotEqual     r6, r5, r1
-  JumpIfFalse  r6, L1
-  Len          r1, r5
-  Const        r11, 0
-  LessInt      r10, r11, r1
-  JumpIfFalse  r10, L1
-  Index        r3, r5, r11
-  // customerName: c.name,
-  Const        r10, "customerName"
-  Const        r1, "name"
-  Index        r5, r3, r1
-  // order: o
-  Const        r4, "order"
-  // customerName: c.name,
-  Move         r12, r10
-  Move         r10, r5
-  // order: o
-  Move         r5, r4
-  Move         r4, r7
-  // select {
-  MakeMap      r14, 2, r12
-  // let result = from c in customers
-  Append       r2, r2, r14
+L2:
+  LessInt      r9, r8, r4
+  JumpIfFalse  r9, L0
+  Index        r10, r3, r8
+  Move         r11, r10
   // right join o in orders on o.customerId == c.id
-  AddInt       r11, r11, r13
-  Jump         L4
-  JumpIfTrue   r6, L4
-  Const        r3, nil
-  // customerName: c.name,
-  Const        r14, "customerName"
-  Index        r4, r3, r1
-  // order: o
-  Const        r1, "order"
-  // customerName: c.name,
-  Move         r3, r14
-  Move         r14, r4
-  // order: o
-  Move         r4, r1
-  Move         r1, r7
-  // select {
-  MakeMap      r7, 2, r3
+  Const        r12, "id"
+  Index        r13, r11, r12
   // let result = from c in customers
-  Append       r2, r2, r7
+  Index        r14, r7, r13
+  Const        r15, nil
+  NotEqual     r16, r14, r15
+  JumpIfTrue   r16, L1
+  MakeList     r17, 0, r0
+  SetIndex     r7, r13, r17
+L1:
+  Index        r14, r7, r13
+  Append       r18, r14, r10
+  SetIndex     r7, r13, r18
+  Const        r19, 1
+  AddInt       r8, r8, r19
+  Jump         L2
+L0:
   // right join o in orders on o.customerId == c.id
-  AddInt       r8, r8, r13
-  Jump         L5
-  // print("--- Right Join using syntax ---")
-  Const        r7, "--- Right Join using syntax ---"
-  Print        r7
-  // for entry in result {
-  IterPrep     r7, r2
-  Len          r2, r7
-  Const        r1, 0
-  Less         r4, r1, r2
-  JumpIfFalse  r4, L6
-  Index        r4, r7, r1
-  // if entry.order {
-  Const        r7, "order"
-  Index        r2, r4, r7
-  JumpIfFalse  r2, L7
-  // print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
-  Const        r2, "Customer"
-  Move         r14, r2
-  Const        r3, "customerName"
-  Index        r6, r4, r3
-  Const        r8, "has order"
-  Index        r13, r4, r7
-  Index        r5, r13, r9
-  Const        r9, "- $"
-  Index        r10, r4, r7
-  Const        r7, "total"
-  Index        r12, r10, r7
-  PrintN       r14, 1, r14
-  // if entry.order {
-  Jump         L8
+  Const        r20, 0
 L7:
-  // print("Customer", entry.customerName, "has no orders")
-  Move         r12, r2
-  Index        r2, r4, r3
-  Const        r3, "has no orders"
-  PrintN       r12, 3, r12
-L8:
-  // for entry in result {
-  Const        r3, 1
-  Add          r1, r1, r3
-  Jump         L9
+  LessInt      r21, r20, r6
+  JumpIfFalse  r21, L3
+  Index        r23, r5, r20
+  Const        r24, "customerId"
+  Index        r25, r23, r24
+  Index        r26, r7, r25
+  NotEqual     r28, r26, r15
+  JumpIfFalse  r28, L4
+  Len          r29, r26
+  Move         r30, r20
+L5:
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L4
+  Index        r11, r26, r30
+  // customerName: c.name,
+  Const        r33, "customerName"
+  Const        r34, "name"
+  Index        r35, r11, r34
+  // order: o
+  Const        r36, "order"
+  // customerName: c.name,
+  Move         r37, r33
+  Move         r38, r35
+  // order: o
+  Move         r39, r36
+  Move         r40, r23
+  // select {
+  MakeMap      r41, 2, r37
+  // let result = from c in customers
+  Append       r2, r2, r41
+  // right join o in orders on o.customerId == c.id
+  AddInt       r30, r30, r19
+  Jump         L5
+L4:
+  JumpIfTrue   r28, L6
+  Move         r11, r15
+  // customerName: c.name,
+  Move         r44, r33
+  Index        r45, r11, r34
+  // order: o
+  Move         r46, r36
+  // customerName: c.name,
+  Move         r47, r44
+  Move         r48, r45
+  // order: o
+  Move         r49, r46
+  Move         r50, r23
+  // select {
+  MakeMap      r51, 2, r47
+  // let result = from c in customers
+  Append       r2, r2, r51
 L6:
+  // right join o in orders on o.customerId == c.id
+  AddInt       r20, r20, r19
+  Jump         L7
+L3:
+  // print("--- Right Join using syntax ---")
+  Const        r53, "--- Right Join using syntax ---"
+  Print        r53
+  // for entry in result {
+  IterPrep     r54, r2
+  Len          r55, r54
+  Const        r56, 0
+L11:
+  Less         r57, r56, r55
+  JumpIfFalse  r57, L8
+  Index        r59, r54, r56
+  // if entry.order {
+  Move         r60, r36
+  Index        r61, r59, r60
+  JumpIfFalse  r61, L9
+  // print("Customer", entry.customerName, "has order", entry.order.id, "- $", entry.order.total)
+  Const        r68, "Customer"
+  Move         r62, r68
+  Move         r69, r33
+  Index        r63, r59, r69
+  Const        r64, "has order"
+  Index        r72, r59, r60
+  Index        r65, r72, r12
+  Const        r66, "- $"
+  Index        r75, r59, r60
+  Const        r76, "total"
+  Index        r67, r75, r76
+  PrintN       r62, 6, r62
+  // if entry.order {
+  Jump         L10
+L9:
+  // print("Customer", entry.customerName, "has no orders")
+  Move         r78, r68
+  Index        r79, r59, r69
+  Const        r80, "has no orders"
+  PrintN       r78, 3, r78
+L10:
+  // for entry in result {
+  Add          r56, r56, r19
+  Jump         L11
+L8:
   Return       r0

--- a/tests/vm/valid/save_jsonl_stdout.ir.out
+++ b/tests/vm/valid/save_jsonl_stdout.ir.out
@@ -1,8 +1,8 @@
-func main (regs=4)
+func main (regs=5)
   // let people = [
   Const        r0, [{"age": 30, "name": "Alice"}, {"age": 25, "name": "Bob"}]
   // save people to "-" with { format: "jsonl" }
   Const        r1, "-"
-  Const        r2, {"format": "jsonl"}
-  Save         3,0,1,2
+  Const        r3, {"format": "jsonl"}
+  Save         4,0,1,3
   Return       r0

--- a/tests/vm/valid/short_circuit.ir.out
+++ b/tests/vm/valid/short_circuit.ir.out
@@ -1,27 +1,27 @@
-func main (regs=5)
+func main (regs=12)
   // print(false && boom(1, 2))
   Const        r0, false
   Move         r1, r0
   JumpIfFalse  r1, L0
-  Const        r2, 1
-  Move         r3, r2
-  Const        r4, 2
-  Call2        r1, boom, r3, r4
+  Const        r4, 1
+  Move         r2, r4
+  Const        r5, 2
+  Call2        r1, boom, r2, r5
 L0:
   Print        r1
   // print(true || boom(1, 2))
-  Const        r3, true
-  JumpIfTrue   r3, L1
-  Call2        r3, boom, r2, r4
+  Const        r8, true
+  JumpIfTrue   r8, L1
+  Call2        r8, boom, r4, r5
 L1:
-  Print        r3
+  Print        r8
   Return       r0
 
   // fun boom(a: int, b: int): bool {
-func boom (regs=2)
+func boom (regs=4)
   // print("boom")
-  Const        r1, "boom"
-  Print        r1
+  Const        r2, "boom"
+  Print        r2
   // return true
-  Const        r1, true
-  Return       r1
+  Const        r3, true
+  Return       r3

--- a/tests/vm/valid/slice.ir.out
+++ b/tests/vm/valid/slice.ir.out
@@ -1,12 +1,12 @@
-func main (regs=2)
+func main (regs=17)
   // print([1,2,3][1:3])
   Const        r0, [1, 2, 3]
-  Const        r1, [2, 3]
-  Print        r1
+  Const        r5, [2, 3]
+  Print        r5
   // print([1,2,3][0:2])
-  Const        r1, [1, 2]
-  Print        r1
+  Const        r11, [1, 2]
+  Print        r11
   // print("hello"[1:4])
-  Const        r1, "ell"
-  Print        r1
+  Const        r16, "ell"
+  Print        r16
   Return       r0

--- a/tests/vm/valid/sort_stable.ir.out
+++ b/tests/vm/valid/sort_stable.ir.out
@@ -1,24 +1,24 @@
-func main (regs=8)
+func main (regs=19)
   // let items = [
   Const        r0, [{"n": 1, "v": "a"}, {"n": 1, "v": "b"}, {"n": 2, "v": "c"}]
   // let result = from i in items sort by i.n select i.v
   Const        r1, []
   Const        r2, "v"
   Const        r3, "n"
-L1:
   IterPrep     r4, r0
   Len          r5, r4
   Const        r6, 0
-  LessInt      r7, r6, r5
-  JumpIfFalse  r7, L0
-  Index        r7, r4, r6
-  Index        r4, r7, r2
-  Index        r2, r7, r3
-  Move         r7, r4
-  MakeList     r4, 2, r2
-  Append       r1, r1, r4
-  Const        r4, 1
-  AddInt       r6, r6, r4
+L1:
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r10, r4, r6
+  Index        r11, r10, r2
+  Index        r13, r10, r3
+  Move         r14, r11
+  MakeList     r15, 2, r13
+  Append       r1, r1, r15
+  Const        r17, 1
+  AddInt       r6, r6, r17
   Jump         L1
 L0:
   Sort         r1, r1

--- a/tests/vm/valid/string_compare.ir.out
+++ b/tests/vm/valid/string_compare.ir.out
@@ -1,15 +1,15 @@
-func main (regs=2)
+func main (regs=6)
   // print("a" < "b")
   Const        r0, "a"
-  Const        r1, true
-  Print        r1
+  Const        r2, true
+  Print        r2
   // print("a" <= "a")
-  Const        r1, true
-  Print        r1
+  Move         r3, r2
+  Print        r3
   // print("b" > "a")
-  Const        r1, true
-  Print        r1
+  Move         r4, r2
+  Print        r4
   // print("b" >= "b")
-  Const        r1, true
-  Print        r1
+  Move         r5, r4
+  Print        r5
   Return       r0

--- a/tests/vm/valid/string_concat.ir.out
+++ b/tests/vm/valid/string_concat.ir.out
@@ -1,6 +1,6 @@
-func main (regs=2)
+func main (regs=3)
   // print("hello " + "world")
   Const        r0, "hello "
-  Const        r1, "hello world"
-  Print        r1
+  Const        r2, "hello world"
+  Print        r2
   Return       r0

--- a/tests/vm/valid/string_contains.ir.out
+++ b/tests/vm/valid/string_contains.ir.out
@@ -1,4 +1,4 @@
-func main (regs=3)
+func main (regs=5)
   // let s = "catch"
   Const        r0, "catch"
   // print(s.contains("cat"))
@@ -6,7 +6,7 @@ func main (regs=3)
   In           r2, r1, r0
   Print        r2
   // print(s.contains("dog"))
-  Const        r2, "dog"
-  In           r1, r2, r0
-  Print        r1
+  Const        r3, "dog"
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/string_in_operator.ir.out
+++ b/tests/vm/valid/string_in_operator.ir.out
@@ -1,4 +1,4 @@
-func main (regs=3)
+func main (regs=5)
   // let s = "catch"
   Const        r0, "catch"
   // print("cat" in s)
@@ -6,7 +6,7 @@ func main (regs=3)
   In           r2, r1, r0
   Print        r2
   // print("dog" in s)
-  Const        r2, "dog"
-  In           r1, r2, r0
-  Print        r1
+  Const        r3, "dog"
+  In           r4, r3, r0
+  Print        r4
   Return       r0

--- a/tests/vm/valid/string_index.ir.out
+++ b/tests/vm/valid/string_index.ir.out
@@ -1,7 +1,7 @@
-func main (regs=2)
+func main (regs=3)
   // let s = "mochi"
   Const        r0, "mochi"
   // print(s[1])
-  Const        r1, "o"
-  Print        r1
+  Const        r2, "o"
+  Print        r2
   Return       r0

--- a/tests/vm/valid/string_prefix_slice.ir.out
+++ b/tests/vm/valid/string_prefix_slice.ir.out
@@ -1,10 +1,10 @@
-func main (regs=2)
+func main (regs=14)
   // let prefix = "fore"
   Const        r0, "fore"
   // print(s1[0:len(prefix)] == prefix)
-  Const        r1, true
-  Print        r1
+  Const        r7, true
+  Print        r7
   // print(s2[0:len(prefix)] == prefix)
-  Const        r1, false
-  Print        r1
+  Const        r13, false
+  Print        r13
   Return       r0

--- a/tests/vm/valid/tail_recursion.ir.out
+++ b/tests/vm/valid/tail_recursion.ir.out
@@ -1,23 +1,23 @@
-func main (regs=3)
+func main (regs=5)
   // print(sum_rec(10, 0))
   Const        r0, 10
   Const        r1, 0
-  Call2        r2, sum_rec, r0, r1
-  Print        r2
+  Call2        r4, sum_rec, r0, r1
+  Print        r4
   Return       r0
 
   // fun sum_rec(n: int, acc: int): int {
-func sum_rec (regs=4)
+func sum_rec (regs=10)
   // if n == 0 {
   Const        r2, 0
   Equal        r3, r0, r2
-L0:
   JumpIfFalse  r3, L0
   // return acc
   Return       r1
+L0:
   // return sum_rec(n - 1, acc + n)
-  Const        r3, 1
-  Sub          r2, r0, r3
-  Add          r3, r1, r0
-  Call2        r1, sum_rec, r2, r3
-  Return       r1
+  Const        r6, 1
+  Sub          r4, r0, r6
+  Add          r5, r1, r0
+  Call2        r9, sum_rec, r4, r5
+  Return       r9

--- a/tests/vm/valid/test_block.ir.out
+++ b/tests/vm/valid/test_block.ir.out
@@ -1,10 +1,10 @@
-func main (regs=2)
+func main (regs=6)
   // let x = 1 + 2
   Const        r0, 1
   // expect x == 3
-  Const        r1, true
-  Expect       r1
+  Const        r4, true
+  Expect       r4
   // print("ok")
-  Const        r1, "ok"
-  Print        r1
+  Const        r5, "ok"
+  Print        r5
   Return       r0

--- a/tests/vm/valid/tree_sum.ir.out
+++ b/tests/vm/valid/tree_sum.ir.out
@@ -1,4 +1,4 @@
-func main (regs=12)
+func main (regs=27)
   // left: Leaf,
   Const        r0, "__name"
   Const        r1, "Leaf"
@@ -12,70 +12,69 @@ func main (regs=12)
   // right: Leaf
   MakeMap      r6, 1, r0
   // right: Node {
-  Const        r1, "__name"
-  Const        r7, "Node"
+  Move         r7, r0
+  Const        r8, "Node"
   // left: Leaf,
-  Const        r8, "left"
-  Move         r9, r4
+  Const        r9, "left"
+  Move         r10, r4
   // value: 2,
-  Const        r4, "value"
-  Move         r10, r5
+  Const        r11, "value"
+  Move         r12, r5
   // right: Leaf
-  Const        r5, "right"
-  Move         r11, r6
+  Const        r13, "right"
+  Move         r14, r6
   // right: Node {
-  MakeMap      r6, 4, r1
+  MakeMap      r15, 4, r7
   // let t = Node {
-  Const        r11, "__name"
-  Const        r5, "Node"
+  Move         r16, r0
+  Move         r17, r8
   // left: Leaf,
-  Const        r10, "left"
-  Move         r4, r2
+  Move         r18, r9
+  Move         r19, r2
   // value: 1,
-  Const        r2, "value"
-  Move         r9, r3
+  Move         r20, r11
+  Move         r21, r3
   // right: Node {
-  Const        r3, "right"
-  Move         r8, r6
+  Move         r22, r13
+  Move         r23, r15
   // let t = Node {
-  MakeMap      r6, 4, r11
+  MakeMap      r25, 4, r16
   // print(sum_tree(t))
-  Call         r8, sum_tree, r6
-  Print        r8
+  Call         r26, sum_tree, r25
+  Print        r26
   Return       r0
 
   // fun sum_tree(t: Tree): int {
-func sum_tree (regs=6)
+func sum_tree (regs=23)
   // Leaf => 0
-  Const        r1, "__name"
-  Index        r2, r0, r1
-  Const        r1, "Leaf"
-  Equal        r3, r2, r1
-L0:
-  JumpIfFalse  r3, L0
-  Const        r3, 0
+  Const        r3, "__name"
+  Index        r4, r0, r3
+  Const        r5, "Leaf"
+  Equal        r2, r4, r5
+  JumpIfFalse  r2, L0
+  Const        r1, 0
   Jump         L1
+L0:
   // Node(left, value, right) => sum_tree(left) + value + sum_tree(right)
-  Const        r1, "__name"
-  Index        r2, r0, r1
-  Const        r1, "Node"
-  Equal        r4, r2, r1
-  JumpIfFalse  r4, L2
-  Const        r4, "left"
-  Index        r1, r0, r4
-  Const        r4, "value"
-  Index        r2, r0, r4
-  Const        r4, "right"
-  Index        r5, r0, r4
-  Move         r4, r1
-  Call         r1, 3, r4, r5, r6
-  Add          r4, r1, r2
-  Move         r1, r5
-  Call         r5, 3, r1, r2, r3
-  Add          r3, r4, r5
+  Index        r9, r0, r3
+  Const        r10, "Node"
+  Equal        r7, r9, r10
+  JumpIfFalse  r7, L2
+  Const        r11, "left"
+  Index        r12, r0, r11
+  Const        r13, "value"
+  Index        r14, r0, r13
+  Const        r15, "right"
+  Index        r16, r0, r15
+  Move         r17, r12
+  Call         r18, sum_tree, r17
+  Add          r19, r18, r14
+  Move         r20, r16
+  Call         r21, sum_tree, r20
+  Add          r1, r19, r21
   Jump         L1
 L2:
-  Const        r3, nil
+  Const        r1, nil
 L1:
   // return match t {
-  Return       r3
+  Return       r1

--- a/tests/vm/valid/two-sum.ir.out
+++ b/tests/vm/valid/two-sum.ir.out
@@ -1,55 +1,48 @@
-func main (regs=4)
+func main (regs=9)
   // let result = twoSum([2,7,11,15], 9)
   Const        r0, [2, 7, 11, 15]
   Const        r1, 9
-  Call2        r2, twoSum, r0, r1
+  Call2        r4, twoSum, r0, r1
   // print(result[0])
-  Const        r1, 0
-  Index        r3, r2, r1
-  Print        r3
+  Const        r5, 0
+  Index        r6, r4, r5
+  Print        r6
   // print(result[1])
-  Const        r3, 1
-  Index        r1, r2, r3
-  Print        r1
+  Const        r7, 1
+  Index        r8, r4, r7
+  Print        r8
   Return       r0
 
   // fun twoSum(nums: list<int>, target: int): list<int> {
-func twoSum (regs=9)
+func twoSum (regs=22)
   // let n = len(nums)
   Len          r2, r0
-L2:
   // for i in 0..n {
-  Const        r3, 0
-L4:
-  Less         r4, r3, r2
-  JumpIfFalse  r4, L0
-L3:
+  Const        r4, 0
+L2:
+  Less         r5, r4, r2
+  JumpIfFalse  r5, L0
   // for j in i+1..n {
-  Const        r4, 1
-  AddInt       r5, r3, r4
-  Less         r6, r5, r2
-  JumpIfFalse  r6, L1
+  Const        r6, 1
+  AddInt       r8, r4, r6
+  Less         r9, r8, r2
+  JumpIfFalse  r9, L1
   // if nums[i] + nums[j] == target {
-  Index        r6, r0, r3
-  Index        r7, r0, r5
-  Add          r8, r6, r7
-  Equal        r7, r8, r1
-  JumpIfFalse  r7, L2
+  Index        r10, r0, r4
+  Index        r11, r0, r8
+  Add          r12, r10, r11
+  Equal        r13, r12, r1
+  JumpIfFalse  r13, L1
   // return [i, j]
-  Move         r7, r3
-  Move         r8, r5
-  MakeList     r1, 2, r7
-  Return       r1
-  // for j in i+1..n {
-  Const        r1, 1
-  Add          r5, r5, r1
-  Jump         L3
+  Move         r14, r4
+  Move         r15, r8
+  MakeList     r16, 2, r14
+  Return       r16
 L1:
   // for i in 0..n {
-  Const        r1, 1
-  Add          r3, r3, r1
-  Jump         L4
+  Add          r4, r4, r19
+  Jump         L2
 L0:
   // return [-1, -1]
-  Const        r1, [-1, -1]
-  Return       r1
+  Const        r21, [-1, -1]
+  Return       r21

--- a/tests/vm/valid/unary_neg.ir.out
+++ b/tests/vm/valid/unary_neg.ir.out
@@ -1,9 +1,9 @@
-func main (regs=2)
+func main (regs=6)
   // print(-3)
   Const        r0, 3
   Const        r1, -3
   Print        r1
   // print(5 + (-2))
-  Const        r1, 3
-  Print        r1
+  Move         r5, r0
+  Print        r5
   Return       r0

--- a/tests/vm/valid/user_type_literal.ir.out
+++ b/tests/vm/valid/user_type_literal.ir.out
@@ -1,4 +1,4 @@
-func main (regs=8)
+func main (regs=21)
   // title: "Go",
   Const        r0, "Go"
   // author: Person { name: "Bob", age: 42 },
@@ -8,24 +8,22 @@ func main (regs=8)
   Const        r4, "Person"
   Const        r5, "name"
   Move         r6, r1
-  Const        r1, "age"
-  Move         r7, r2
-  MakeMap      r2, 3, r3
+  Const        r7, "age"
+  Move         r8, r2
+  MakeMap      r9, 3, r3
   // let book = Book {
-  Const        r7, "__name"
-  Const        r1, "Book"
+  Move         r10, r3
+  Const        r11, "Book"
   // title: "Go",
-  Const        r6, "title"
-  Move         r5, r0
+  Const        r12, "title"
+  Move         r13, r0
   // author: Person { name: "Bob", age: 42 },
-  Const        r4, "author"
-  Move         r3, r2
+  Const        r14, "author"
+  Move         r15, r9
   // let book = Book {
-  MakeMap      r2, 3, r7
+  MakeMap      r16, 3, r10
   // print(book.author.name)
-  Const        r3, "author"
-  Index        r4, r2, r3
-  Const        r3, "name"
-  Index        r2, r4, r3
-  Print        r2
+  Index        r18, r16, r14
+  Index        r20, r18, r5
+  Print        r20
   Return       r0

--- a/tests/vm/valid/var_assignment.ir.out
+++ b/tests/vm/valid/var_assignment.ir.out
@@ -1,4 +1,4 @@
-func main (regs=2)
+func main (regs=3)
   // var x = 1
   Const        r0, 1
   // x = 2

--- a/tests/vm/valid/while_loop.ir.out
+++ b/tests/vm/valid/while_loop.ir.out
@@ -1,4 +1,4 @@
-func main (regs=4)
+func main (regs=6)
   // var i = 0
   Const        r0, 0
   Move         r1, r0
@@ -10,8 +10,8 @@ L1:
   // print(i)
   Print        r1
   // i = i + 1
-  Const        r3, 1
-  AddInt       r1, r1, r3
+  Const        r4, 1
+  AddInt       r1, r1, r4
   // while i < 3 {
   Jump         L1
 L0:


### PR DESCRIPTION
## Summary
- optimize join query compilation by avoiding hash joins for small constant sources
- regenerate IR output for VM tests

## Testing
- `go test ./tests/vm -tags slow -update` *(fails: go test couldn't complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68617e636d0c8320ac1841aa1b23e65d