### PR TITLE
Improve VM peephole

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -529,6 +529,12 @@ func peephole(fn *Function, analysis *LiveInfo) bool {
 					changed = true
 					pcMap[pc-1] = -1
 				}
+			case OpNot:
+				if prev.Op == OpNot && prev.A == ins.B && !analysis.Out[pc][prev.A] {
+					ins = Instr{Op: OpMove, A: ins.A, B: prev.B, Line: ins.Line}
+					changed = true
+					pcMap[pc-1] = -1
+				}
 			case OpSubInt, OpSubFloat, OpSub:
 				if isConst(ins.C, (Value{Tag: ValueInt, Int: 0})) {
 					ins = Instr{Op: OpMove, A: ins.A, B: ins.B, Line: ins.Line}


### PR DESCRIPTION
## Summary
- optimize peephole pass by removing double negation patterns

## Testing
- `go test ./...`
- `go test ./tests/vm -tags slow -run TestVM_IR -update`


------
https://chatgpt.com/codex/tasks/task_e_6861832cf3d083208564fa6bd3c6a927