### PR TITLE
Enable VM register compaction when MakeMap absent

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -296,8 +296,11 @@ func Optimize(fn *Function) {
 		}
 	}
 	// Register compaction can disturb MakeMap sequences that rely on
-	// contiguous key/value registers, so skip this step.
-	// CompactRegisters(fn)
+	// contiguous key/value registers, so only perform this step for
+	// functions that do not use MakeMap.
+	if !hasMakeMap(fn) {
+		CompactRegisters(fn)
+	}
 }
 
 // removeDead eliminates instructions that only define dead registers.

--- a/runtime/vm/regopt.go
+++ b/runtime/vm/regopt.go
@@ -121,6 +121,18 @@ func VisualizeUsage(fn *Function) string {
 	return b.String()
 }
 
+// hasMakeMap reports whether fn contains any MakeMap instructions. Register
+// compaction needs to know this to avoid remapping the contiguous key/value
+// register ranges used by MakeMap.
+func hasMakeMap(fn *Function) bool {
+	for _, ins := range fn.Code {
+		if ins.Op == OpMakeMap {
+			return true
+		}
+	}
+	return false
+}
+
 // CompactRegisters remaps registers to reduce the overall count by reusing
 // registers whose lifetimes do not overlap. Parameters keep their original
 // numbers to avoid changing the calling convention.


### PR DESCRIPTION
## Summary
- add helper to detect MakeMap usage
- enable CompactRegisters optimisation when safe

## Testing
- `go build ./runtime/vm/...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6861747e93448320b472f1b0f1f77eff