### PR TITLE
Improve constant folding in VM compiler

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -662,6 +662,106 @@ func constFold(fn *Function) bool {
 					changed = true
 					continue
 				}
+			} else {
+				switch ins.Op {
+				case OpAddInt, OpAddFloat, OpAdd:
+					if b.known && isZeroValue(b.val) {
+						fn.Code[pc] = Instr{Op: OpMove, A: ins.A, B: ins.C, Line: ins.Line}
+						if defCount[ins.A] == 1 {
+							consts[ins.A] = consts[ins.C]
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+					if c.known && isZeroValue(c.val) {
+						fn.Code[pc] = Instr{Op: OpMove, A: ins.A, B: ins.B, Line: ins.Line}
+						if defCount[ins.A] == 1 {
+							consts[ins.A] = consts[ins.B]
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+				case OpSubInt, OpSubFloat, OpSub:
+					if c.known && isZeroValue(c.val) {
+						fn.Code[pc] = Instr{Op: OpMove, A: ins.A, B: ins.B, Line: ins.Line}
+						if defCount[ins.A] == 1 {
+							consts[ins.A] = consts[ins.B]
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+					if b.known && isZeroValue(b.val) {
+						var nop Op
+						switch ins.Op {
+						case OpSubInt:
+							nop = OpNegInt
+						case OpSubFloat:
+							nop = OpNegFloat
+						default:
+							nop = OpNeg
+						}
+						fn.Code[pc] = Instr{Op: nop, A: ins.A, B: ins.C, Line: ins.Line}
+						if val, ok := evalUnaryConst(nop, consts[ins.C].val); ok && defCount[ins.A] == 1 {
+							consts[ins.A] = cinfo{true, val}
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+				case OpMulInt, OpMulFloat, OpMul:
+					if b.known && isOneValue(b.val) {
+						fn.Code[pc] = Instr{Op: OpMove, A: ins.A, B: ins.C, Line: ins.Line}
+						if defCount[ins.A] == 1 {
+							consts[ins.A] = consts[ins.C]
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+					if c.known && isOneValue(c.val) {
+						fn.Code[pc] = Instr{Op: OpMove, A: ins.A, B: ins.B, Line: ins.Line}
+						if defCount[ins.A] == 1 {
+							consts[ins.A] = consts[ins.B]
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+					if (b.known && isZeroValue(b.val)) || (c.known && isZeroValue(c.val)) {
+						zero := b.val
+						if !isZeroValue(zero) {
+							zero = c.val
+						}
+						fn.Code[pc] = Instr{Op: OpConst, A: ins.A, Val: zero, Line: ins.Line}
+						if defCount[ins.A] == 1 {
+							consts[ins.A] = cinfo{true, zero}
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+				case OpDivInt, OpDivFloat, OpDiv:
+					if c.known && isOneValue(c.val) {
+						fn.Code[pc] = Instr{Op: OpMove, A: ins.A, B: ins.B, Line: ins.Line}
+						if defCount[ins.A] == 1 {
+							consts[ins.A] = consts[ins.B]
+						} else {
+							consts[ins.A] = cinfo{}
+						}
+						changed = true
+						continue
+					}
+				}
 			}
 			consts[ins.A] = cinfo{}
 		case OpSlice:
@@ -1281,4 +1381,26 @@ func evalSliceConst(src, startVal, endVal Value) (Value, bool) {
 		return Value{Tag: ValueStr, Str: string(runes[start:end])}, true
 	}
 	return Value{}, false
+}
+
+func isZeroValue(v Value) bool {
+	switch v.Tag {
+	case ValueInt:
+		return v.Int == 0
+	case ValueFloat:
+		return v.Float == 0
+	default:
+		return false
+	}
+}
+
+func isOneValue(v Value) bool {
+	switch v.Tag {
+	case ValueInt:
+		return v.Int == 1
+	case ValueFloat:
+		return v.Float == 1
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Summary
- enhance constant folding in `runtime/vm` to handle identity cases
- add helper functions to recognize zero and one numeric values
- regenerate IR snapshots via `go test -tags=slow ./tests/vm -run TestVM_IR -update`

## Testing
- `go vet ./...`
- `go test -tags=slow ./tests/vm -run TestVM_IR -update --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_686183f9c4e08320809ddcda2753fce7