### PR TITLE
Optimize VM join compilation

### DIFF
--- a/runtime/vm/queryutil.go
+++ b/runtime/vm/queryutil.go
@@ -337,3 +337,25 @@ func whereAlias(where *parser.Expr) (string, bool) {
 	}
 	return "", false
 }
+
+// aliasFieldPath extracts the field path from an expression of the form
+// `alias.foo.bar`. It returns the list of field names or false when the
+// expression is not a simple selector chain on the alias.
+func aliasFieldPath(e *parser.Expr, alias string) ([]string, bool) {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return nil, false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 || u.Value == nil {
+		return nil, false
+	}
+	p := u.Value
+	if len(p.Ops) != 0 || p.Target == nil || p.Target.Selector == nil {
+		return nil, false
+	}
+	sel := p.Target.Selector
+	if sel.Root != alias {
+		return nil, false
+	}
+	return sel.Tail, true
+}

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -4549,19 +4549,15 @@ func (fc *funcCompiler) compileJoinQuery(q *parser.QueryExpr, dst int) {
 
 	if joinType == "left" {
 		if lk, rk, ok := eqJoinKeys(join.On, q.Var, join.Var); ok {
-			if !fc.smallConstJoin(q.Source, join.Src) {
-				fc.compileHashLeftJoin(q, dst, lk, rk)
-				return
-			}
+			fc.compileHashLeftJoin(q, dst, lk, rk)
+			return
 		}
 	}
 
 	if joinType == "right" {
 		if lk, rk, ok := eqJoinKeys(join.On, q.Var, join.Var); ok {
-			if !fc.smallConstJoin(q.Source, join.Src) {
-				fc.compileHashRightJoin(q, dst, lk, rk)
-				return
-			}
+			fc.compileHashRightJoin(q, dst, lk, rk)
+			return
 		} else {
 			fc.compileJoinQueryRight(q, dst)
 			return
@@ -4570,10 +4566,8 @@ func (fc *funcCompiler) compileJoinQuery(q *parser.QueryExpr, dst int) {
 
 	if joinType == "outer" {
 		if lk, rk, ok := eqJoinKeys(join.On, q.Var, join.Var); ok {
-			if !fc.smallConstJoin(q.Source, join.Src) {
-				fc.compileHashOuterJoin(q, dst, lk, rk)
-				return
-			}
+			fc.compileHashOuterJoin(q, dst, lk, rk)
+			return
 		} else {
 			fc.compileJoinQueryRight(q, dst)
 			return


### PR DESCRIPTION
## Summary
- add helper to extract alias field paths in queries
- always prefer hash join when join keys match

## Testing
- `go test ./tests/vm -run TestVM_IR -tags slow -update -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6861850f787c832090437450dfaac684