### PR TITLE
Add TPC‑DS queries 80–89

### DIFF
--- a/tests/dataset/tpc-ds/q80.md
+++ b/tests/dataset/tpc-ds/q80.md
@@ -1,10 +1,106 @@
 # TPC-DS Query 80
 
-This is a placeholder implementation for TPC-DS query 80.
+This query is reproduced from the official TPC-DS specification. The companion [q80.mochi](./q80.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 80;
+ define YEAR = random(1998, 2002, uniform);
+ define SALES_DATE=date([YEAR]+"-08-01",[YEAR]+"-08-30",sales);
+ define _LIMIT=100; 
+ 
+ with ssr as
+ (select  s_store_id as store_id,
+          sum(ss_ext_sales_price) as sales,
+          sum(coalesce(sr_return_amt, 0)) as returns,
+          sum(ss_net_profit - coalesce(sr_net_loss, 0)) as profit
+  from store_sales left outer join store_returns on
+         (ss_item_sk = sr_item_sk and ss_ticket_number = sr_ticket_number),
+     date_dim,
+     store,
+     item,
+     promotion
+ where ss_sold_date_sk = d_date_sk
+       and d_date between cast('[SALES_DATE]' as date) 
+                  and (cast('[SALES_DATE]' as date) +  30 days)
+       and ss_store_sk = s_store_sk
+       and ss_item_sk = i_item_sk
+       and i_current_price > 50
+       and ss_promo_sk = p_promo_sk
+       and p_channel_tv = 'N'
+ group by s_store_id)
+ ,
+ csr as
+ (select  cp_catalog_page_id as catalog_page_id,
+          sum(cs_ext_sales_price) as sales,
+          sum(coalesce(cr_return_amount, 0)) as returns,
+          sum(cs_net_profit - coalesce(cr_net_loss, 0)) as profit
+  from catalog_sales left outer join catalog_returns on
+         (cs_item_sk = cr_item_sk and cs_order_number = cr_order_number),
+     date_dim,
+     catalog_page,
+     item,
+     promotion
+ where cs_sold_date_sk = d_date_sk
+       and d_date between cast('[SALES_DATE]' as date)
+                  and (cast('[SALES_DATE]' as date) +  30 days)
+        and cs_catalog_page_sk = cp_catalog_page_sk
+       and cs_item_sk = i_item_sk
+       and i_current_price > 50
+       and cs_promo_sk = p_promo_sk
+       and p_channel_tv = 'N'
+group by cp_catalog_page_id)
+ ,
+ wsr as
+ (select  web_site_id,
+          sum(ws_ext_sales_price) as sales,
+          sum(coalesce(wr_return_amt, 0)) as returns,
+          sum(ws_net_profit - coalesce(wr_net_loss, 0)) as profit
+  from web_sales left outer join web_returns on
+         (ws_item_sk = wr_item_sk and ws_order_number = wr_order_number),
+     date_dim,
+     web_site,
+     item,
+     promotion
+ where ws_sold_date_sk = d_date_sk
+       and d_date between cast('[SALES_DATE]' as date)
+                  and (cast('[SALES_DATE]' as date) +  30 days)
+        and ws_web_site_sk = web_site_sk
+       and ws_item_sk = i_item_sk
+       and i_current_price > 50
+       and ws_promo_sk = p_promo_sk
+       and p_channel_tv = 'N'
+group by web_site_id)
+ [_LIMITA] select [_LIMITB] channel
+        , id
+        , sum(sales) as sales
+        , sum(returns) as returns
+        , sum(profit) as profit
+ from 
+ (select 'store channel' as channel
+        , 'store' || store_id as id
+        , sales
+        , returns
+        , profit
+ from   ssr
+ union all
+ select 'catalog channel' as channel
+        , 'catalog_page' || catalog_page_id as id
+        , sales
+        , returns
+        , profit
+ from  csr
+ union all
+ select 'web channel' as channel
+        , 'web_site' || web_site_id as id
+        , sales
+        , returns
+        , profit
+ from   wsr
+ ) x
+ group by rollup (channel, id)
+ order by channel
+         ,id
+ [_LIMITC];
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q80.mochi
+++ b/tests/dataset/tpc-ds/q80.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 80
 let t = [{id: 1, val: 80}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q81.md
+++ b/tests/dataset/tpc-ds/q81.md
@@ -1,10 +1,43 @@
 # TPC-DS Query 81
 
-This is a placeholder implementation for TPC-DS query 81.
+This query is reproduced from the official TPC-DS specification. The companion [q81.mochi](./q81.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 81;
+ define STATE= dist(fips_county, 3, 1);
+ define YEAR= random(1998, 2002, uniform);
+ define _LIMIT=100; 
+ 
+ with customer_total_return as
+ (select cr_returning_customer_sk as ctr_customer_sk
+        ,ca_state as ctr_state, 
+ 	sum(cr_return_amt_inc_tax) as ctr_total_return
+ from catalog_returns
+     ,date_dim
+     ,customer_address
+ where cr_returned_date_sk = d_date_sk 
+   and d_year =[YEAR]
+   and cr_returning_addr_sk = ca_address_sk 
+ group by cr_returning_customer_sk
+         ,ca_state )
+ [_LIMITA] select [_LIMITB] c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name
+                   ,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset
+                  ,ca_location_type,ctr_total_return
+ from customer_total_return ctr1
+     ,customer_address
+     ,customer
+ where ctr1.ctr_total_return > (select avg(ctr_total_return)*1.2
+ 			  from customer_total_return ctr2 
+                  	  where ctr1.ctr_state = ctr2.ctr_state)
+       and ca_address_sk = c_current_addr_sk
+       and ca_state = '[STATE]'
+       and ctr1.ctr_customer_sk = c_customer_sk
+ order by c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name
+                   ,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset
+                  ,ca_location_type,ctr_total_return
+ [_LIMITC];
+ 
+
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q81.mochi
+++ b/tests/dataset/tpc-ds/q81.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 81
 let t = [{id: 1, val: 81}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q82.md
+++ b/tests/dataset/tpc-ds/q82.md
@@ -1,10 +1,31 @@
 # TPC-DS Query 82
 
-This is a placeholder implementation for TPC-DS query 82.
+This query is reproduced from the official TPC-DS specification. The companion [q82.mochi](./q82.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 82;
+ define YEAR=random(1998,2002,uniform);
+ define PRICE=random(0,90,uniform);
+ define INVDATE=date([YEAR]+"-01-01",[YEAR]+"-07-24",sales);
+ define MANUFACT_ID=ulist(random(1,1000,uniform),4);
+ define _LIMIT=100;
+ 
+ [_LIMITA] select [_LIMITB] i_item_id
+       ,i_item_desc
+       ,i_current_price
+ from item, inventory, date_dim, store_sales
+ where i_current_price between [PRICE] and [PRICE]+30
+ and inv_item_sk = i_item_sk
+ and d_date_sk=inv_date_sk
+ and d_date between cast('[INVDATE]' as date) and (cast('[INVDATE]' as date) +  60 days)
+ and i_manufact_id in ([MANUFACT_ID.1],[MANUFACT_ID.2],[MANUFACT_ID.3],[MANUFACT_ID.4])
+ and inv_quantity_on_hand between 100 and 500
+ and ss_item_sk = i_item_sk
+ group by i_item_id,i_item_desc,i_current_price
+ order by i_item_id
+ [_LIMITC];
+ 
+
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q82.mochi
+++ b/tests/dataset/tpc-ds/q82.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 82
 let t = [{id: 1, val: 82}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q83.md
+++ b/tests/dataset/tpc-ds/q83.md
@@ -1,10 +1,79 @@
 # TPC-DS Query 83
 
-This is a placeholder implementation for TPC-DS query 83.
+This query is reproduced from the official TPC-DS specification. The companion [q83.mochi](./q83.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 83;
+ define YEAR = random(1998, 2002, uniform);
+ define RETURNED_DATE_ONE=date([YEAR]+"-01-01",[YEAR]+"-07-24",sales);
+ define RETURNED_DATE_TWO=date([YEAR]+"-08-01",[YEAR]+"-10-24",sales);
+ define RETURNED_DATE_THREE=date([YEAR]+"-11-01",[YEAR]+"-11-24",sales);
+ define _LIMIT=100;
+ 
+ with sr_items as
+ (select i_item_id item_id,
+        sum(sr_return_quantity) sr_item_qty
+ from store_returns,
+      item,
+      date_dim
+ where sr_item_sk = i_item_sk
+ and   d_date    in 
+	(select d_date
+	from date_dim
+	where d_week_seq in 
+		(select d_week_seq
+		from date_dim
+	  where d_date in ('[RETURNED_DATE_ONE]','[RETURNED_DATE_TWO]','[RETURNED_DATE_THREE]')))
+ and   sr_returned_date_sk   = d_date_sk
+ group by i_item_id),
+ cr_items as
+ (select i_item_id item_id,
+        sum(cr_return_quantity) cr_item_qty
+ from catalog_returns,
+      item,
+      date_dim
+ where cr_item_sk = i_item_sk
+ and   d_date    in 
+	(select d_date
+	from date_dim
+	where d_week_seq in 
+		(select d_week_seq
+		from date_dim
+	  where d_date in ('[RETURNED_DATE_ONE]','[RETURNED_DATE_TWO]','[RETURNED_DATE_THREE]')))
+ and   cr_returned_date_sk   = d_date_sk
+ group by i_item_id),
+ wr_items as
+ (select i_item_id item_id,
+        sum(wr_return_quantity) wr_item_qty
+ from web_returns,
+      item,
+      date_dim
+ where wr_item_sk = i_item_sk
+ and   d_date    in 
+	(select d_date
+	from date_dim
+	where d_week_seq in 
+		(select d_week_seq
+		from date_dim
+		where d_date in ('[RETURNED_DATE_ONE]','[RETURNED_DATE_TWO]','[RETURNED_DATE_THREE]')))
+ and   wr_returned_date_sk   = d_date_sk
+ group by i_item_id)
+ [_LIMITA] select [_LIMITB] sr_items.item_id
+       ,sr_item_qty
+       ,sr_item_qty/(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 * 100 sr_dev
+       ,cr_item_qty
+       ,cr_item_qty/(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 * 100 cr_dev
+       ,wr_item_qty
+       ,wr_item_qty/(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 * 100 wr_dev
+       ,(sr_item_qty+cr_item_qty+wr_item_qty)/3.0 average
+ from sr_items
+     ,cr_items
+     ,wr_items
+ where sr_items.item_id=cr_items.item_id
+   and sr_items.item_id=wr_items.item_id 
+ order by sr_items.item_id
+         ,sr_item_qty
+ [_LIMITC];
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q83.mochi
+++ b/tests/dataset/tpc-ds/q83.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 83
 let t = [{id: 1, val: 83}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q84.md
+++ b/tests/dataset/tpc-ds/q84.md
@@ -1,10 +1,33 @@
 # TPC-DS Query 84
 
-This is a placeholder implementation for TPC-DS query 84.
+This query is reproduced from the official TPC-DS specification. The companion [q84.mochi](./q84.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 84;
+ define CITY = dist(cities, 1, large);
+ define INCOME = random(0, 70000, uniform);
+ define _LIMIT=100;
+ 
+ [_LIMITA] select [_LIMITB] c_customer_id as customer_id
+       , coalesce(c_last_name,'') || ', ' || coalesce(c_first_name,'') as customername
+ from customer
+     ,customer_address
+     ,customer_demographics
+     ,household_demographics
+     ,income_band
+     ,store_returns
+ where ca_city	        =  '[CITY]'
+   and c_current_addr_sk = ca_address_sk
+   and ib_lower_bound   >=  [INCOME]
+   and ib_upper_bound   <=  [INCOME] + 50000
+   and ib_income_band_sk = hd_income_band_sk
+   and cd_demo_sk = c_current_cdemo_sk
+   and hd_demo_sk = c_current_hdemo_sk
+   and sr_cdemo_sk = cd_demo_sk
+ order by c_customer_id
+ [_LIMITC];
+ 
+
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q84.mochi
+++ b/tests/dataset/tpc-ds/q84.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 84
 let t = [{id: 1, val: 84}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q85.md
+++ b/tests/dataset/tpc-ds/q85.md
@@ -1,10 +1,96 @@
 # TPC-DS Query 85
 
-This is a placeholder implementation for TPC-DS query 85.
+This query is reproduced from the official TPC-DS specification. The companion [q85.mochi](./q85.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 85;
+ define MS= ulist(dist(marital_status, 1, 1), 3);
+ define ES= ulist(dist(education, 1, 1), 3);
+ define STATE= ulist(dist(fips_county, 3, 1), 9);
+ define YEAR= random(1998,2002, uniform);
+ define _LIMIT=100;
+
+ [_LIMITA] select [_LIMITB] substr(r_reason_desc,1,20)
+       ,avg(ws_quantity)
+       ,avg(wr_refunded_cash)
+       ,avg(wr_fee)
+ from web_sales, web_returns, web_page, customer_demographics cd1,
+      customer_demographics cd2, customer_address, date_dim, reason 
+ where ws_web_page_sk = wp_web_page_sk
+   and ws_item_sk = wr_item_sk
+   and ws_order_number = wr_order_number
+   and ws_sold_date_sk = d_date_sk and d_year = [YEAR]
+   and cd1.cd_demo_sk = wr_refunded_cdemo_sk 
+   and cd2.cd_demo_sk = wr_returning_cdemo_sk
+   and ca_address_sk = wr_refunded_addr_sk
+   and r_reason_sk = wr_reason_sk
+   and
+   (
+    (
+     cd1.cd_marital_status = '[MS.1]'
+     and
+     cd1.cd_marital_status = cd2.cd_marital_status
+     and
+     cd1.cd_education_status = '[ES.1]'
+     and 
+     cd1.cd_education_status = cd2.cd_education_status
+     and
+     ws_sales_price between 100.00 and 150.00
+    )
+   or
+    (
+     cd1.cd_marital_status = '[MS.2]'
+     and
+     cd1.cd_marital_status = cd2.cd_marital_status
+     and
+     cd1.cd_education_status = '[ES.2]' 
+     and
+     cd1.cd_education_status = cd2.cd_education_status
+     and
+     ws_sales_price between 50.00 and 100.00
+    )
+   or
+    (
+     cd1.cd_marital_status = '[MS.3]'
+     and
+     cd1.cd_marital_status = cd2.cd_marital_status
+     and
+     cd1.cd_education_status = '[ES.3]'
+     and
+     cd1.cd_education_status = cd2.cd_education_status
+     and
+     ws_sales_price between 150.00 and 200.00
+    )
+   )
+   and
+   (
+    (
+     ca_country = 'United States'
+     and
+     ca_state in ('[STATE.1]', '[STATE.2]', '[STATE.3]')
+     and ws_net_profit between 100 and 200  
+    )
+    or
+    (
+     ca_country = 'United States'
+     and
+     ca_state in ('[STATE.4]', '[STATE.5]', '[STATE.6]')
+     and ws_net_profit between 150 and 300  
+    )
+    or
+    (
+     ca_country = 'United States'
+     and
+     ca_state in ('[STATE.7]', '[STATE.8]', '[STATE.9]')
+     and ws_net_profit between 50 and 250  
+    )
+   )
+group by r_reason_desc
+order by substr(r_reason_desc,1,20)
+        ,avg(ws_quantity)
+        ,avg(wr_refunded_cash)
+        ,avg(wr_fee)
+[_LIMITC]; 
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q85.mochi
+++ b/tests/dataset/tpc-ds/q85.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 85
 let t = [{id: 1, val: 85}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q86.md
+++ b/tests/dataset/tpc-ds/q86.md
@@ -1,10 +1,35 @@
 # TPC-DS Query 86
 
-This is a placeholder implementation for TPC-DS query 86.
+This query is reproduced from the official TPC-DS specification. The companion [q86.mochi](./q86.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 86;
+ define DMS = random(1176,1224,uniform);
+ define _LIMIT=100; 
+ [_LIMITA] select [_LIMITB]  
+    sum(ws_net_paid) as total_sum
+   ,i_category
+   ,i_class
+   ,grouping(i_category)+grouping(i_class) as lochierarchy
+   ,rank() over (
+ 	partition by grouping(i_category)+grouping(i_class),
+ 	case when grouping(i_class) = 0 then i_category end 
+ 	order by sum(ws_net_paid) desc) as rank_within_parent
+ from
+    web_sales
+   ,date_dim       d1
+   ,item
+ where
+    d1.d_month_seq between [DMS] and [DMS]+11
+ and d1.d_date_sk = ws_sold_date_sk
+ and i_item_sk  = ws_item_sk
+ group by rollup(i_category,i_class)
+ order by
+   lochierarchy desc,
+   case when lochierarchy = 0 then i_category end,
+   rank_within_parent
+ [_LIMITC];
+
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q86.mochi
+++ b/tests/dataset/tpc-ds/q86.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 86
 let t = [{id: 1, val: 86}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q87.md
+++ b/tests/dataset/tpc-ds/q87.md
@@ -1,10 +1,31 @@
 # TPC-DS Query 87
 
-This is a placeholder implementation for TPC-DS query 87.
+This query is reproduced from the official TPC-DS specification. The companion [q87.mochi](./q87.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 87;
+define DMS = random(1176,1224, uniform); 
+
+select count(*) 
+from ((select distinct c_last_name, c_first_name, d_date
+       from store_sales, date_dim, customer
+       where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+         and store_sales.ss_customer_sk = customer.c_customer_sk
+         and d_month_seq between [DMS] and [DMS]+11)
+       except
+      (select distinct c_last_name, c_first_name, d_date
+       from catalog_sales, date_dim, customer
+       where catalog_sales.cs_sold_date_sk = date_dim.d_date_sk
+         and catalog_sales.cs_bill_customer_sk = customer.c_customer_sk
+         and d_month_seq between [DMS] and [DMS]+11)
+       except
+      (select distinct c_last_name, c_first_name, d_date
+       from web_sales, date_dim, customer
+       where web_sales.ws_sold_date_sk = date_dim.d_date_sk
+         and web_sales.ws_bill_customer_sk = customer.c_customer_sk
+         and d_month_seq between [DMS] and [DMS]+11)
+) cool_cust
+;
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q87.mochi
+++ b/tests/dataset/tpc-ds/q87.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 87
 let t = [{id: 1, val: 87}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q88.md
+++ b/tests/dataset/tpc-ds/q88.md
@@ -1,10 +1,103 @@
 # TPC-DS Query 88
 
-This is a placeholder implementation for TPC-DS query 88.
+This query is reproduced from the official TPC-DS specification. The companion [q88.mochi](./q88.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 88;
+ define HOUR = ulist(random(-1,4,uniform),3);
+ define STORE = dist(stores,1,1);
+
+select  *
+from
+ (select count(*) h8_30_to_9
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk   
+     and ss_hdemo_sk = household_demographics.hd_demo_sk 
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 8
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2)) 
+     and store.s_store_name = 'ese') s1,
+ (select count(*) h9_to_9_30 
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk 
+     and time_dim.t_hour = 9 
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2))
+     and store.s_store_name = 'ese') s2,
+ (select count(*) h9_30_to_10 
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 9
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2))
+     and store.s_store_name = 'ese') s3,
+ (select count(*) h10_to_10_30
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 10 
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2))
+     and store.s_store_name = 'ese') s4,
+ (select count(*) h10_30_to_11
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 10 
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2))
+     and store.s_store_name = 'ese') s5,
+ (select count(*) h11_to_11_30
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk 
+     and time_dim.t_hour = 11
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2))
+     and store.s_store_name = 'ese') s6,
+ (select count(*) h11_30_to_12
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 11
+     and time_dim.t_minute >= 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2))
+     and store.s_store_name = 'ese') s7,
+ (select count(*) h12_to_12_30
+ from store_sales, household_demographics , time_dim, store
+ where ss_sold_time_sk = time_dim.t_time_sk
+     and ss_hdemo_sk = household_demographics.hd_demo_sk
+     and ss_store_sk = s_store_sk
+     and time_dim.t_hour = 12
+     and time_dim.t_minute < 30
+     and ((household_demographics.hd_dep_count = [HOUR.1] and household_demographics.hd_vehicle_count<=[HOUR.1]+2) or
+          (household_demographics.hd_dep_count = [HOUR.2] and household_demographics.hd_vehicle_count<=[HOUR.2]+2) or
+          (household_demographics.hd_dep_count = [HOUR.3] and household_demographics.hd_vehicle_count<=[HOUR.3]+2))
+     and store.s_store_name = 'ese') s8
+;
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q88.mochi
+++ b/tests/dataset/tpc-ds/q88.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 88
 let t = [{id: 1, val: 88}]
 let result = from r in t select r.val |> first
 json(result)

--- a/tests/dataset/tpc-ds/q89.md
+++ b/tests/dataset/tpc-ds/q89.md
@@ -1,10 +1,50 @@
 # TPC-DS Query 89
 
-This is a placeholder implementation for TPC-DS query 89.
+This query is reproduced from the official TPC-DS specification. The companion [q89.mochi](./q89.mochi) program only verifies that the environment runs and returns the query id.
 
 ## SQL
 ```sql
-SELECT 89;
+define YEAR = random(1998, 2002, uniform);
+define IDX = ulist(random(1, rowcount("categories"), uniform), 6);
+define CAT_A = distmember(categories, [IDX.1], 1);
+define CLASS_A = DIST(distmember(categories, [IDX.1], 2), 1, 1);
+define CAT_B = distmember(categories, [IDX.2], 1);
+define CLASS_B = DIST(distmember(categories, [IDX.2], 2), 1, 1);
+define CAT_C = distmember(categories, [IDX.3], 1);
+define CLASS_C = DIST(distmember(categories, [IDX.3], 2), 1, 1);
+define CAT_D = distmember(categories, [IDX.4], 1);
+define CLASS_D = DIST(distmember(categories, [IDX.4], 2), 1, 1);
+define CAT_E = distmember(categories, [IDX.5], 1);
+define CLASS_E = DIST(distmember(categories, [IDX.5], 2), 1, 1);
+define CAT_F = distmember(categories, [IDX.6], 1);
+define CLASS_F = DIST(distmember(categories, [IDX.6], 2), 1, 1);
+define _LIMIT=100;
+
+[_LIMITA] select [_LIMITB] *
+from(
+select i_category, i_class, i_brand,
+       s_store_name, s_company_name,
+       d_moy,
+       sum(ss_sales_price) sum_sales,
+       avg(sum(ss_sales_price)) over
+         (partition by i_category, i_brand, s_store_name, s_company_name)
+         avg_monthly_sales
+from item, store_sales, date_dim, store
+where ss_item_sk = i_item_sk and
+      ss_sold_date_sk = d_date_sk and
+      ss_store_sk = s_store_sk and
+      d_year in ([YEAR]) and
+        ((i_category in ('[CAT_A]','[CAT_B]','[CAT_C]') and
+          i_class in ('[CLASS_A]','[CLASS_B]','[CLASS_C]')
+         )
+      or (i_category in ('[CAT_D]','[CAT_E]','[CAT_F]') and
+          i_class in ('[CLASS_D]','[CLASS_E]','[CLASS_F]') 
+        ))
+group by i_category, i_class, i_brand,
+         s_store_name, s_company_name, d_moy) tmp1
+where case when (avg_monthly_sales <> 0) then (abs(sum_sales - avg_monthly_sales) / avg_monthly_sales) else null end > 0.1
+order by sum_sales - avg_monthly_sales, s_store_name
+[_LIMITC];
 ```
 
 ## Expected Output

--- a/tests/dataset/tpc-ds/q89.mochi
+++ b/tests/dataset/tpc-ds/q89.mochi
@@ -1,3 +1,4 @@
+// Placeholder evaluation for real TPC-DS query 89
 let t = [{id: 1, val: 89}]
 let result = from r in t select r.val |> first
 json(result)


### PR DESCRIPTION
## Summary
- pull official TPC‑DS SQL templates for queries 80–89
- document these SQL statements in the dataset
- keep placeholder Mochi programs with a note that they map to real queries

## Testing
- `make test STAGE=parser`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861eaa633b4832086f60475962dad4f