### PR TITLE
Implement TPC‑DS queries 20‑29

### DIFF
--- a/tests/dataset/tpc-ds/q20.md
+++ b/tests/dataset/tpc-ds/q20.md
@@ -1,13 +1,34 @@
 # TPC-DS Query 20
 
-This is a placeholder implementation for TPC-DS query 20.
+This query examines catalog sales for three item categories over a one month
+period. Revenue is aggregated by item and compared to the total for its class to
+produce a percentage.
 
 ## SQL
 ```sql
-SELECT 20;
+SELECT i_item_id,
+       i_item_desc,
+       i_category,
+       i_class,
+       i_current_price,
+       SUM(cs_ext_sales_price) AS itemrevenue,
+       SUM(cs_ext_sales_price)*100/SUM(SUM(cs_ext_sales_price))
+         OVER(PARTITION BY i_class) AS revenueratio
+FROM catalog_sales, item, date_dim
+WHERE cs_item_sk = i_item_sk
+  AND i_category IN ('A','B','C')
+  AND cs_sold_date_sk = d_date_sk
+  AND d_date BETWEEN DATE '2000-02-01' AND DATE '2000-03-02'
+GROUP BY i_item_id,i_item_desc,i_category,i_class,i_current_price
+ORDER BY i_category,i_class,i_item_id,i_item_desc,revenueratio;
 ```
 
 ## Expected Output
+The first item accounts for two thirds of class revenue while the second makes
+up the remaining third.
 ```json
-20
+[
+  { "i_item_id": "ITEM1", "revenueratio": 66.66666666666666 },
+  { "i_item_id": "ITEM2", "revenueratio": 33.33333333333333 }
+]
 ```

--- a/tests/dataset/tpc-ds/q20.mochi
+++ b/tests/dataset/tpc-ds/q20.mochi
@@ -1,7 +1,111 @@
-let t = [{id: 1, val: 20}]
-let result = from r in t select r.val |> first
+// Catalog sales by item category with revenue ratio per class
+
+type CatalogSale {
+  cs_item_sk: int
+  cs_sold_date_sk: int
+  cs_ext_sales_price: float
+}
+
+type Item {
+  i_item_sk: int
+  i_item_id: string
+  i_item_desc: string
+  i_category: string
+  i_class: string
+  i_current_price: float
+}
+
+type DateDim { d_date_sk: int, d_date: string }
+
+let catalog_sales = [
+  { cs_item_sk: 1, cs_sold_date_sk: 1, cs_ext_sales_price: 100.0 },
+  { cs_item_sk: 1, cs_sold_date_sk: 1, cs_ext_sales_price: 200.0 },
+  { cs_item_sk: 2, cs_sold_date_sk: 1, cs_ext_sales_price: 150.0 }
+]
+
+let item = [
+  {
+    i_item_sk: 1,
+    i_item_id: "ITEM1",
+    i_item_desc: "Item One",
+    i_category: "A",
+    i_class: "X",
+    i_current_price: 10.0
+  },
+  {
+    i_item_sk: 2,
+    i_item_id: "ITEM2",
+    i_item_desc: "Item Two",
+    i_category: "A",
+    i_class: "X",
+    i_current_price: 20.0
+  }
+]
+
+let date_dim = [ { d_date_sk: 1, d_date: "2000-02-10" } ]
+
+let filtered =
+  from cs in catalog_sales
+  join i in item on cs.cs_item_sk == i.i_item_sk
+  join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  where i.i_category in ["A", "B", "C"] &&
+        d.d_date >= "2000-02-01" && d.d_date <= "2000-03-02"
+  group by {
+    id: i.i_item_id,
+    desc: i.i_item_desc,
+    cat: i.i_category,
+    class: i.i_class,
+    price: i.i_current_price
+  } into g
+  select {
+    i_item_id: g.key.id,
+    i_item_desc: g.key.desc,
+    i_category: g.key.cat,
+    i_class: g.key.class,
+    i_current_price: g.key.price,
+    itemrevenue: sum(from x in g select x.cs_ext_sales_price)
+  }
+
+let class_totals =
+  from f in filtered
+  group by f.i_class into g
+  select { class: g.key, total: sum(from x in g select x.itemrevenue) }
+
+let result =
+  from f in filtered
+  join t in class_totals on f.i_class == t.class
+  sort by [f.i_category, f.i_class, f.i_item_id, f.i_item_desc]
+  select {
+    i_item_id: f.i_item_id,
+    i_item_desc: f.i_item_desc,
+    i_category: f.i_category,
+    i_class: f.i_class,
+    i_current_price: f.i_current_price,
+    itemrevenue: f.itemrevenue,
+    revenueratio: (f.itemrevenue * 100.0) / t.total
+  }
+
 json(result)
 
-test "TPCDS Q20 placeholder" {
-  expect result == 20
+test "TPCDS Q20 revenue ratio" {
+  expect result == [
+    {
+      i_item_id: "ITEM1",
+      i_item_desc: "Item One",
+      i_category: "A",
+      i_class: "X",
+      i_current_price: 10.0,
+      itemrevenue: 300.0,
+      revenueratio: 66.66666666666666
+    },
+    {
+      i_item_id: "ITEM2",
+      i_item_desc: "Item Two",
+      i_category: "A",
+      i_class: "X",
+      i_current_price: 20.0,
+      itemrevenue: 150.0,
+      revenueratio: 33.33333333333333
+    }
+  ]
 }

--- a/tests/dataset/tpc-ds/q21.md
+++ b/tests/dataset/tpc-ds/q21.md
@@ -1,13 +1,33 @@
 # TPC-DS Query 21
 
-This is a placeholder implementation for TPC-DS query 21.
+This query checks how inventory levels change around a particular sales date.
+It calculates the quantity on hand for each warehouse and item before and after
+the date and filters rows where the ratio stays within reasonable bounds.
 
 ## SQL
 ```sql
-SELECT 21;
+SELECT *
+FROM (
+  SELECT w_warehouse_name,
+         i_item_id,
+         SUM(CASE WHEN d_date < DATE '2000-03-15' THEN inv_quantity_on_hand ELSE 0 END) AS inv_before,
+         SUM(CASE WHEN d_date >= DATE '2000-03-15' THEN inv_quantity_on_hand ELSE 0 END) AS inv_after
+  FROM inventory, warehouse, item, date_dim
+  WHERE inv_item_sk = i_item_sk
+    AND inv_warehouse_sk = w_warehouse_sk
+    AND inv_date_sk = d_date_sk
+    AND i_current_price BETWEEN 0.99 AND 1.49
+    AND d_date BETWEEN DATE '2000-02-15' AND DATE '2000-03-20'
+  GROUP BY w_warehouse_name, i_item_id
+) x
+WHERE CASE WHEN inv_before > 0 THEN inv_after / inv_before ELSE NULL END BETWEEN 2.0/3.0 AND 3.0/2.0
+ORDER BY w_warehouse_name, i_item_id;
 ```
 
 ## Expected Output
+Only the Main warehouse item satisfies the ratio condition.
 ```json
-21
+[
+  { "w_warehouse_name": "Main", "i_item_id": "ITEM1", "inv_before": 30, "inv_after": 40 }
+]
 ```

--- a/tests/dataset/tpc-ds/q21.mochi
+++ b/tests/dataset/tpc-ds/q21.mochi
@@ -1,7 +1,47 @@
-let t = [{id: 1, val: 21}]
-let result = from r in t select r.val |> first
+// Inventory ratio before and after a target date
+
+type Inventory { inv_item_sk: int, inv_warehouse_sk: int, inv_date_sk: int, inv_quantity_on_hand: int }
+type Warehouse { w_warehouse_sk: int, w_warehouse_name: string }
+type Item { i_item_sk: int, i_item_id: string }
+type DateDim { d_date_sk: int, d_date: string }
+
+let inventory = [
+  { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 30 },
+  { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 40 }
+]
+
+let warehouse = [ { w_warehouse_sk: 1, w_warehouse_name: "Main" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
+let date_dim = [ { d_date_sk: 1, d_date: "2000-03-01" }, { d_date_sk: 2, d_date: "2000-03-20" } ]
+
+let before =
+  from inv in inventory
+  join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  where d.d_date < "2000-03-15"
+  group by { w: inv.inv_warehouse_sk, i: inv.inv_item_sk } into g
+  select { w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand) }
+
+let after =
+  from inv in inventory
+  join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  where d.d_date >= "2000-03-15"
+  group by { w: inv.inv_warehouse_sk, i: inv.inv_item_sk } into g
+  select { w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand) }
+
+let result =
+  from b in before
+  join a in after on b.w == a.w && b.i == a.i
+  join w in warehouse on w.w_warehouse_sk == b.w
+  join it in item on it.i_item_sk == b.i
+  let ratio = a.qty / b.qty
+  where ratio >= (2.0 / 3.0) && ratio <= (3.0 / 2.0)
+  sort by [w.w_warehouse_name, it.i_item_id]
+  select { w_warehouse_name: w.w_warehouse_name, i_item_id: it.i_item_id, inv_before: b.qty, inv_after: a.qty }
+
 json(result)
 
-test "TPCDS Q21 placeholder" {
-  expect result == 21
+test "TPCDS Q21 inventory ratio" {
+  expect result == [
+    { w_warehouse_name: "Main", i_item_id: "ITEM1", inv_before: 30, inv_after: 40 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q22.md
+++ b/tests/dataset/tpc-ds/q22.md
@@ -1,13 +1,29 @@
 # TPC-DS Query 22
 
-This is a placeholder implementation for TPC-DS query 22.
+Query 22 averages inventory levels for each product and brand over a twelve
+month span. The rollup clause in the original query also produces subtotals at
+various levels of the product hierarchy.
 
 ## SQL
 ```sql
-SELECT 22;
+SELECT i_product_name,
+       i_brand,
+       i_class,
+       i_category,
+       AVG(inv_quantity_on_hand) AS qoh
+FROM inventory, date_dim, item
+WHERE inv_date_sk = d_date_sk
+  AND inv_item_sk = i_item_sk
+  AND d_month_seq BETWEEN 0 AND 11
+GROUP BY ROLLUP(i_product_name, i_brand, i_class, i_category)
+ORDER BY qoh, i_product_name, i_brand, i_class, i_category;
 ```
 
 ## Expected Output
+In the simplified dataset every month has either 10 or 20 units on hand, so the
+average is 15.
 ```json
-22
+[
+  { "i_product_name": "Prod1", "qoh": 15.0 }
+]
 ```

--- a/tests/dataset/tpc-ds/q22.mochi
+++ b/tests/dataset/tpc-ds/q22.mochi
@@ -1,7 +1,61 @@
-let t = [{id: 1, val: 22}]
-let result = from r in t select r.val |> first
-json(result)
+// Average quantity on hand by product hierarchy
 
-test "TPCDS Q22 placeholder" {
-  expect result == 22
+type Inventory { inv_item_sk: int, inv_date_sk: int, inv_quantity_on_hand: int }
+type DateDim { d_date_sk: int, d_month_seq: int }
+type Item {
+  i_item_sk: int
+  i_product_name: string
+  i_brand: string
+  i_class: string
+  i_category: string
+}
+
+let inventory = [
+  { inv_item_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 10 },
+  { inv_item_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 20 }
+]
+
+let date_dim = [ { d_date_sk: 1, d_month_seq: 0 }, { d_date_sk: 2, d_month_seq: 1 } ]
+
+let item = [
+  {
+    i_item_sk: 1,
+    i_product_name: "Prod1",
+    i_brand: "Brand1",
+    i_class: "Class1",
+    i_category: "Cat1"
+  }
+]
+
+let qoh =
+  from inv in inventory
+  join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  join i in item on inv.inv_item_sk == i.i_item_sk
+  where d.d_month_seq >= 0 && d.d_month_seq <= 11
+  group by {
+    product_name: i.i_product_name,
+    brand: i.i_brand,
+    class: i.i_class,
+    category: i.i_category
+  } into g
+  select {
+    i_product_name: g.key.product_name,
+    i_brand: g.key.brand,
+    i_class: g.key.class,
+    i_category: g.key.category,
+    qoh: avg(from x in g select x.inv_quantity_on_hand)
+  }
+
+json(qoh)
+
+test "TPCDS Q22 average inventory" {
+  expect qoh == [
+    {
+      i_product_name: "Prod1",
+      i_brand: "Brand1",
+      i_class: "Class1",
+      i_category: "Cat1",
+      qoh: 15.0
+    }
+  ]
 }

--- a/tests/dataset/tpc-ds/q23.md
+++ b/tests/dataset/tpc-ds/q23.md
@@ -1,13 +1,50 @@
 # TPC-DS Query 23
 
-This is a placeholder implementation for TPC-DS query 23.
+Query 23 identifies items that sell frequently in stores and then finds the most
+profitable customers for those products. It sums sales from both catalog and web
+channels for a single month.
 
 ## SQL
 ```sql
-SELECT 23;
+WITH frequent_ss_items AS (
+  SELECT i_item_sk
+  FROM store_sales, date_dim, item
+  WHERE ss_sold_date_sk = d_date_sk
+    AND ss_item_sk = i_item_sk
+    AND d_year = 2000
+  GROUP BY i_item_sk, d_date
+  HAVING COUNT(*) > 4
+), best_ss_customer AS (
+  SELECT ss_customer_sk
+  FROM store_sales
+  GROUP BY ss_customer_sk
+  HAVING SUM(ss_quantity * ss_sales_price) > 0.95 * (
+    SELECT MAX(csales) FROM (
+      SELECT ss_customer_sk, SUM(ss_quantity * ss_sales_price) csales
+      FROM store_sales GROUP BY ss_customer_sk
+    ) m
+  )
+)
+SELECT SUM(sales) AS sales
+FROM (
+  SELECT cs_quantity * cs_list_price AS sales
+  FROM catalog_sales, date_dim
+  WHERE cs_sold_date_sk = d_date_sk
+    AND d_year = 2000 AND d_moy = 1
+    AND cs_bill_customer_sk IN (SELECT ss_customer_sk FROM best_ss_customer)
+    AND cs_item_sk IN (SELECT i_item_sk FROM frequent_ss_items)
+  UNION ALL
+  SELECT ws_quantity * ws_list_price
+  FROM web_sales, date_dim
+  WHERE ws_sold_date_sk = d_date_sk
+    AND d_year = 2000 AND d_moy = 1
+    AND ws_bill_customer_sk IN (SELECT ss_customer_sk FROM best_ss_customer)
+    AND ws_item_sk IN (SELECT i_item_sk FROM frequent_ss_items)
+) x;
 ```
 
 ## Expected Output
+Both catalog and web sales contribute to a total of 50 in the example dataset.
 ```json
-23
+50.0
 ```

--- a/tests/dataset/tpc-ds/q23.mochi
+++ b/tests/dataset/tpc-ds/q23.mochi
@@ -1,7 +1,63 @@
-let t = [{id: 1, val: 23}]
-let result = from r in t select r.val |> first
+// Sales for frequent items purchased by top customers
+
+type StoreSale { ss_customer_sk: int, ss_item_sk: int, ss_sold_date_sk: int, ss_quantity: int, ss_sales_price: float }
+type Customer { c_customer_sk: int, c_last_name: string, c_first_name: string }
+type Item { i_item_sk: int, i_item_desc: string }
+type DateDim { d_date_sk: int, d_year: int, d_moy: int }
+type CatalogSale { cs_bill_customer_sk: int, cs_item_sk: int, cs_sold_date_sk: int, cs_quantity: int, cs_list_price: float }
+type WebSale { ws_bill_customer_sk: int, ws_item_sk: int, ws_sold_date_sk: int, ws_quantity: int, ws_list_price: float }
+
+let store_sales = [
+  { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
+  { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
+  { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
+  { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
+  { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 }
+]
+
+let catalog_sales = [
+  { cs_bill_customer_sk: 1, cs_item_sk: 1, cs_sold_date_sk: 1, cs_quantity: 1, cs_list_price: 20.0 }
+]
+
+let web_sales = [
+  { ws_bill_customer_sk: 1, ws_item_sk: 1, ws_sold_date_sk: 1, ws_quantity: 1, ws_list_price: 30.0 }
+]
+
+let customer = [ { c_customer_sk: 1, c_last_name: "Smith", c_first_name: "Ann" } ]
+let item = [ { i_item_sk: 1, i_item_desc: "Item1" } ]
+let date_dim = [ { d_date_sk: 1, d_year: 2000, d_moy: 1 } ]
+
+let frequent_items =
+  from ss in store_sales
+  group by { item: ss.ss_item_sk, date: ss.ss_sold_date_sk } into g
+  where count(g) > 4
+  select g.key.item
+
+let sales_by_customer =
+  from ss in store_sales
+  group by ss.ss_customer_sk into g
+  select { cust: g.key, total: sum(from x in g select x.ss_quantity * x.ss_sales_price) }
+
+let max_sales = max(from s in sales_by_customer select s.total)
+let best_customers = from s in sales_by_customer where s.total > 0.95 * max_sales select s.cust
+
+let catalog_and_web =
+  from cs in catalog_sales
+  join d in date_dim on d.d_date_sk == cs.cs_sold_date_sk
+  join i in item on i.i_item_sk == cs.cs_item_sk
+  where d.d_year == 2000 && d.d_moy == 1 && cs.cs_item_sk in frequent_items && cs.cs_bill_customer_sk in best_customers
+  select cs.cs_quantity * cs.cs_list_price
+  union all
+  from ws in web_sales
+  join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
+  join i in item on i.i_item_sk == ws.ws_item_sk
+  where d.d_year == 2000 && d.d_moy == 1 && ws.ws_item_sk in frequent_items && ws.ws_bill_customer_sk in best_customers
+  select ws.ws_quantity * ws.ws_list_price
+
+let result = sum(catalog_and_web)
+
 json(result)
 
-test "TPCDS Q23 placeholder" {
-  expect result == 23
+test "TPCDS Q23 frequent item sales" {
+  expect result == 50.0
 }

--- a/tests/dataset/tpc-ds/q24.md
+++ b/tests/dataset/tpc-ds/q24.md
@@ -1,13 +1,41 @@
 # TPC-DS Query 24
 
-This is a placeholder implementation for TPC-DS query 24.
+Query 24 totals the amount paid by customers after matching store sales with
+their corresponding returns. It filters on item color and market before
+comparing each customer's payment against the overall average.
 
 ## SQL
 ```sql
-SELECT 24;
+WITH ssales AS (
+  SELECT c_last_name,
+         c_first_name,
+         s_store_name,
+         i_color,
+         SUM(ss_net_paid) AS netpaid
+  FROM store_sales, store_returns, store, item, customer, customer_address
+  WHERE ss_ticket_number = sr_ticket_number
+    AND ss_item_sk = sr_item_sk
+    AND ss_customer_sk = c_customer_sk
+    AND ss_item_sk = i_item_sk
+    AND ss_store_sk = s_store_sk
+    AND c_current_addr_sk = ca_address_sk
+    AND c_birth_country <> UPPER(ca_country)
+    AND s_zip = ca_zip
+    AND s_market_id = 5
+  GROUP BY c_last_name,c_first_name,s_store_name,i_color
+)
+SELECT c_last_name,c_first_name,s_store_name,SUM(netpaid) paid
+FROM ssales
+WHERE i_color = 'RED'
+GROUP BY c_last_name,c_first_name,s_store_name
+HAVING SUM(netpaid) > (SELECT 0.05 * AVG(netpaid) FROM ssales)
+ORDER BY c_last_name,c_first_name,s_store_name;
 ```
 
 ## Expected Output
+Only one customer in the example meets the threshold.
 ```json
-24
+[
+  { "c_last_name": "Smith", "c_first_name": "Ann", "s_store_name": "Store1", "paid": 100.0 }
+]
 ```

--- a/tests/dataset/tpc-ds/q24.mochi
+++ b/tests/dataset/tpc-ds/q24.mochi
@@ -1,7 +1,58 @@
-let t = [{id: 1, val: 24}]
-let result = from r in t select r.val |> first
+// Net paid totals for customers by color and market
+
+type StoreSale { ss_ticket_number: int, ss_item_sk: int, ss_customer_sk: int, ss_store_sk: int, ss_net_paid: float }
+type StoreReturn { sr_ticket_number: int, sr_item_sk: int }
+type Store { s_store_sk: int, s_store_name: string, s_market_id: int, s_state: string, s_zip: string }
+type Item { i_item_sk: int, i_color: string, i_current_price: float, i_manager_id: int, i_units: string, i_size: string }
+type Customer { c_customer_sk: int, c_first_name: string, c_last_name: string, c_current_addr_sk: int, c_birth_country: string }
+type CustomerAddress { ca_address_sk: int, ca_state: string, ca_country: string, ca_zip: string }
+
+let store_sales = [
+  { ss_ticket_number: 1, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_net_paid: 100.0 }
+]
+
+let store_returns = [ { sr_ticket_number: 1, sr_item_sk: 1 } ]
+
+let store = [ { s_store_sk: 1, s_store_name: "Store1", s_market_id: 5, s_state: "CA", s_zip: "12345" } ]
+
+let item = [ { i_item_sk: 1, i_color: "RED", i_current_price: 10.0, i_manager_id: 1, i_units: "EA", i_size: "M" } ]
+
+let customer = [ { c_customer_sk: 1, c_first_name: "Ann", c_last_name: "Smith", c_current_addr_sk: 1, c_birth_country: "Canada" } ]
+
+let customer_address = [ { ca_address_sk: 1, ca_state: "CA", ca_country: "USA", ca_zip: "12345" } ]
+
+let ssales =
+  from ss in store_sales
+  join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  join i in item on ss.ss_item_sk == i.i_item_sk
+  join c in customer on ss.ss_customer_sk == c.c_customer_sk
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  where c.c_birth_country != upper(ca.ca_country) && s.s_zip == ca.ca_zip && s.s_market_id == 5
+  group by {
+    last: c.c_last_name,
+    first: c.c_first_name,
+    store_name: s.s_store_name,
+    color: i.i_color
+  } into g
+  select {
+    c_last_name: g.key.last,
+    c_first_name: g.key.first,
+    s_store_name: g.key.store_name,
+    color: g.key.color,
+    netpaid: sum(from x in g select x.ss_net_paid)
+  }
+
+let avg_paid = avg(from x in ssales select x.netpaid)
+
+let result =
+  from x in ssales
+  where x.color == "RED" && x.netpaid > 0.05 * avg_paid
+  sort by [x.c_last_name, x.c_first_name, x.s_store_name]
+  select { c_last_name: x.c_last_name, c_first_name: x.c_first_name, s_store_name: x.s_store_name, paid: x.netpaid }
+
 json(result)
 
-test "TPCDS Q24 placeholder" {
-  expect result == 24
+test "TPCDS Q24 customer net paid" {
+  expect result == [ { c_last_name: "Smith", c_first_name: "Ann", s_store_name: "Store1", paid: 100.0 } ]
 }

--- a/tests/dataset/tpc-ds/q25.md
+++ b/tests/dataset/tpc-ds/q25.md
@@ -1,13 +1,44 @@
 # TPC-DS Query 25
 
-This is a placeholder implementation for TPC-DS query 25.
+Query 25 aggregates profits and losses from store, returns and catalog channels
+for a given month. The TPC-DS specification allows different aggregate
+functions; this example uses `SUM`.
 
 ## SQL
 ```sql
-SELECT 25;
+SELECT i_item_id,
+       i_item_desc,
+       s_store_id,
+       s_store_name,
+       SUM(ss_net_profit) AS store_sales_profit,
+       SUM(sr_net_loss)   AS store_returns_loss,
+       SUM(cs_net_profit) AS catalog_sales_profit
+FROM store_sales, store_returns, catalog_sales,
+     date_dim d1, date_dim d2, date_dim d3,
+     store, item
+WHERE d1.d_moy = 4 AND d1.d_year = 2000 AND d1.d_date_sk = ss_sold_date_sk
+  AND i_item_sk = ss_item_sk AND s_store_sk = ss_store_sk
+  AND ss_customer_sk = sr_customer_sk
+  AND ss_item_sk = sr_item_sk
+  AND ss_ticket_number = sr_ticket_number
+  AND sr_returned_date_sk = d2.d_date_sk
+  AND d2.d_moy BETWEEN 4 AND 10 AND d2.d_year = 2000
+  AND sr_customer_sk = cs_bill_customer_sk
+  AND sr_item_sk = cs_item_sk
+  AND cs_sold_date_sk = d3.d_date_sk
+  AND d3.d_moy BETWEEN 4 AND 10 AND d3.d_year = 2000
+GROUP BY i_item_id,i_item_desc,s_store_id,s_store_name;
 ```
 
 ## Expected Output
+The simplified dataset yields the following totals.
 ```json
-25
+[
+  {
+    "i_item_id": "ITEM1",
+    "store_sales_profit": 50.0,
+    "store_returns_loss": 10.0,
+    "catalog_sales_profit": 30.0
+  }
+]
 ```

--- a/tests/dataset/tpc-ds/q25.mochi
+++ b/tests/dataset/tpc-ds/q25.mochi
@@ -1,7 +1,66 @@
-let t = [{id: 1, val: 25}]
-let result = from r in t select r.val |> first
+// Aggregate profits across store, returns and catalog channels
+
+type StoreSale { ss_sold_date_sk: int, ss_item_sk: int, ss_store_sk: int, ss_customer_sk: int, ss_net_profit: float, ss_ticket_number: int }
+type StoreReturn { sr_returned_date_sk: int, sr_item_sk: int, sr_customer_sk: int, sr_ticket_number: int, sr_net_loss: float }
+type CatalogSale { cs_sold_date_sk: int, cs_item_sk: int, cs_bill_customer_sk: int, cs_net_profit: float }
+type DateDim { d_date_sk: int, d_moy: int, d_year: int }
+type Store { s_store_sk: int, s_store_id: string, s_store_name: string }
+type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
+
+let store_sales = [
+  { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_net_profit: 50.0, ss_ticket_number: 1 }
+]
+
+let store_returns = [
+  { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_net_loss: 10.0 }
+]
+
+let catalog_sales = [
+  { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_net_profit: 30.0 }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_moy: 4, d_year: 2000 },
+  { d_date_sk: 2, d_moy: 5, d_year: 2000 },
+  { d_date_sk: 3, d_moy: 6, d_year: 2000 }
+]
+
+let store = [ { s_store_sk: 1, s_store_id: "S1", s_store_name: "Store1" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" } ]
+
+let result =
+  from ss in store_sales
+  join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
+  join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
+  join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
+  join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
+  join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
+  join s in store on s.s_store_sk == ss.ss_store_sk
+  join i in item on i.i_item_sk == ss.ss_item_sk
+  where d1.d_moy == 4 && d1.d_year == 2000 && d2.d_moy >= 4 && d2.d_moy <= 10 && d3.d_moy >= 4 && d3.d_moy <= 10
+  group by { item_id: i.i_item_id, item_desc: i.i_item_desc, s_store_id: s.s_store_id, s_store_name: s.s_store_name } into g
+  select {
+    i_item_id: g.key.item_id,
+    i_item_desc: g.key.item_desc,
+    s_store_id: g.key.s_store_id,
+    s_store_name: g.key.s_store_name,
+    store_sales_profit: sum(from x in g select x.ss_net_profit),
+    store_returns_loss: sum(from x in g select x.sr_net_loss),
+    catalog_sales_profit: sum(from x in g select x.cs_net_profit)
+  }
+
 json(result)
 
-test "TPCDS Q25 placeholder" {
-  expect result == 25
+test "TPCDS Q25 aggregated profit" {
+  expect result == [
+    {
+      i_item_id: "ITEM1",
+      i_item_desc: "Desc1",
+      s_store_id: "S1",
+      s_store_name: "Store1",
+      store_sales_profit: 50.0,
+      store_returns_loss: 10.0,
+      catalog_sales_profit: 30.0
+    }
+  ]
 }

--- a/tests/dataset/tpc-ds/q26.md
+++ b/tests/dataset/tpc-ds/q26.md
@@ -1,13 +1,32 @@
 # TPC-DS Query 26
 
-This is a placeholder implementation for TPC-DS query 26.
+Query 26 calculates averages of quantity, list price, coupon amount and sales
+price for catalog sales targeting a specific demographic segment.
 
 ## SQL
 ```sql
-SELECT 26;
+SELECT i_item_id,
+       AVG(cs_quantity)     AS agg1,
+       AVG(cs_list_price)   AS agg2,
+       AVG(cs_coupon_amt)   AS agg3,
+       AVG(cs_sales_price)  AS agg4
+FROM catalog_sales, customer_demographics, date_dim, item, promotion
+WHERE cs_sold_date_sk = d_date_sk
+  AND cs_item_sk = i_item_sk
+  AND cs_bill_cdemo_sk = cd_demo_sk
+  AND cs_promo_sk = p_promo_sk
+  AND cd_gender = 'M'
+  AND cd_marital_status = 'S'
+  AND cd_education_status = 'College'
+  AND (p_channel_email = 'N' OR p_channel_event = 'N')
+  AND d_year = 2000
+GROUP BY i_item_id;
 ```
 
 ## Expected Output
+Our sample data returns one row with averages equal to the raw values.
 ```json
-26
+[
+  { "i_item_id": "ITEM1", "agg1": 10.0, "agg2": 100.0, "agg3": 5.0, "agg4": 95.0 }
+]
 ```

--- a/tests/dataset/tpc-ds/q26.mochi
+++ b/tests/dataset/tpc-ds/q26.mochi
@@ -1,7 +1,53 @@
-let t = [{id: 1, val: 26}]
-let result = from r in t select r.val |> first
+// Average catalog sales metrics for specific customer demographics
+
+type CatalogSale {
+  cs_sold_date_sk: int
+  cs_item_sk: int
+  cs_bill_cdemo_sk: int
+  cs_promo_sk: int
+  cs_quantity: int
+  cs_list_price: float
+  cs_coupon_amt: float
+  cs_sales_price: float
+}
+
+type CustomerDemo { cd_demo_sk: int, cd_gender: string, cd_marital_status: string, cd_education_status: string }
+type DateDim { d_date_sk: int, d_year: int }
+type Item { i_item_sk: int, i_item_id: string }
+type Promotion { p_promo_sk: int, p_channel_email: string, p_channel_event: string }
+
+let catalog_sales = [
+  { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_promo_sk: 1, cs_quantity: 10, cs_list_price: 100.0, cs_coupon_amt: 5.0, cs_sales_price: 95.0 }
+]
+
+let customer_demographics = [
+  { cd_demo_sk: 1, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College" }
+]
+
+let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
+let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" } ]
+
+let result =
+  from cs in catalog_sales
+  join cd in customer_demographics on cs.cs_bill_cdemo_sk == cd.cd_demo_sk
+  join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  join i in item on cs.cs_item_sk == i.i_item_sk
+  join p in promotion on cs.cs_promo_sk == p.p_promo_sk
+  where cd.cd_gender == "M" && cd.cd_marital_status == "S" && cd.cd_education_status == "College" && (p.p_channel_email == "N" || p.p_channel_event == "N") && d.d_year == 2000
+  group by i.i_item_id into g
+  select {
+    i_item_id: g.key,
+    agg1: avg(from x in g select x.cs_quantity),
+    agg2: avg(from x in g select x.cs_list_price),
+    agg3: avg(from x in g select x.cs_coupon_amt),
+    agg4: avg(from x in g select x.cs_sales_price)
+  }
+
 json(result)
 
-test "TPCDS Q26 placeholder" {
-  expect result == 26
+test "TPCDS Q26 demographic averages" {
+  expect result == [
+    { i_item_id: "ITEM1", agg1: 10.0, agg2: 100.0, agg3: 5.0, agg4: 95.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q27.md
+++ b/tests/dataset/tpc-ds/q27.md
@@ -1,13 +1,34 @@
 # TPC-DS Query 27
 
-This is a placeholder implementation for TPC-DS query 27.
+Query 27 reports average store sales statistics for selected customer
+demographics across several U.S. states.
 
 ## SQL
 ```sql
-SELECT 27;
+SELECT i_item_id,
+       s_state,
+       AVG(ss_quantity)    AS agg1,
+       AVG(ss_list_price)  AS agg2,
+       AVG(ss_coupon_amt)  AS agg3,
+       AVG(ss_sales_price) AS agg4
+FROM store_sales, customer_demographics, date_dim, store, item
+WHERE ss_sold_date_sk = d_date_sk
+  AND ss_item_sk = i_item_sk
+  AND ss_store_sk = s_store_sk
+  AND ss_cdemo_sk = cd_demo_sk
+  AND cd_gender = 'F'
+  AND cd_marital_status = 'M'
+  AND cd_education_status = 'College'
+  AND d_year = 2000
+  AND s_state IN ('CA')
+GROUP BY ROLLUP(i_item_id, s_state)
+ORDER BY i_item_id, s_state;
 ```
 
 ## Expected Output
+The sample contains one item sold in California.
 ```json
-27
+[
+  { "i_item_id": "ITEM1", "s_state": "CA", "agg1": 5.0, "agg2": 100.0, "agg3": 10.0, "agg4": 90.0 }
+]
 ```

--- a/tests/dataset/tpc-ds/q27.mochi
+++ b/tests/dataset/tpc-ds/q27.mochi
@@ -1,7 +1,42 @@
-let t = [{id: 1, val: 27}]
-let result = from r in t select r.val |> first
+// Average store sales metrics by item and state
+
+type StoreSale { ss_item_sk: int, ss_store_sk: int, ss_cdemo_sk: int, ss_sold_date_sk: int, ss_quantity: int, ss_list_price: float, ss_coupon_amt: float, ss_sales_price: float }
+type CustomerDemo { cd_demo_sk: int, cd_gender: string, cd_marital_status: string, cd_education_status: string }
+type DateDim { d_date_sk: int, d_year: int }
+type Store { s_store_sk: int, s_state: string }
+type Item { i_item_sk: int, i_item_id: string }
+
+let store_sales = [
+  { ss_item_sk: 1, ss_store_sk: 1, ss_cdemo_sk: 1, ss_sold_date_sk: 1, ss_quantity: 5, ss_list_price: 100.0, ss_coupon_amt: 10.0, ss_sales_price: 90.0 }
+]
+
+let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" } ]
+let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
+let store = [ { s_store_sk: 1, s_state: "CA" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
+
+let result =
+  from ss in store_sales
+  join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  join i in item on ss.ss_item_sk == i.i_item_sk
+  where cd.cd_gender == "F" && cd.cd_marital_status == "M" && cd.cd_education_status == "College" && d.d_year == 2000 && s.s_state in ["CA"]
+  group by { item_id: i.i_item_id, state: s.s_state } into g
+  sort by [g.key.item_id, g.key.state]
+  select {
+    i_item_id: g.key.item_id,
+    s_state: g.key.state,
+    agg1: avg(from x in g select x.ss_quantity),
+    agg2: avg(from x in g select x.ss_list_price),
+    agg3: avg(from x in g select x.ss_coupon_amt),
+    agg4: avg(from x in g select x.ss_sales_price)
+  }
+
 json(result)
 
-test "TPCDS Q27 placeholder" {
-  expect result == 27
+test "TPCDS Q27 averages by state" {
+  expect result == [
+    { i_item_id: "ITEM1", s_state: "CA", agg1: 5.0, agg2: 100.0, agg3: 10.0, agg4: 90.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q28.md
+++ b/tests/dataset/tpc-ds/q28.md
@@ -1,13 +1,42 @@
 # TPC-DS Query 28
 
-This is a placeholder implementation for TPC-DS query 28.
+Query 28 analyzes store sales by splitting rows into quantity ranges and
+reporting statistics for each bucket.
 
 ## SQL
 ```sql
-SELECT 28;
+SELECT *
+FROM (
+  SELECT AVG(ss_list_price) AS B1_LP,
+         COUNT(ss_list_price) AS B1_CNT,
+         COUNT(DISTINCT ss_list_price) AS B1_CNTD
+  FROM store_sales
+  WHERE ss_quantity BETWEEN 0 AND 5
+    AND (ss_list_price BETWEEN 0 AND 10
+         OR ss_coupon_amt BETWEEN 0 AND 1000
+         OR ss_wholesale_cost BETWEEN 0 AND 20)
+) B1,
+(
+  SELECT AVG(ss_list_price) AS B2_LP,
+         COUNT(ss_list_price) AS B2_CNT,
+         COUNT(DISTINCT ss_list_price) AS B2_CNTD
+  FROM store_sales
+  WHERE ss_quantity BETWEEN 6 AND 10
+    AND (ss_list_price BETWEEN 0 AND 10
+         OR ss_coupon_amt BETWEEN 0 AND 1000
+         OR ss_wholesale_cost BETWEEN 0 AND 20)
+) B2;
 ```
 
 ## Expected Output
+Only two buckets are populated in the sample data.
 ```json
-28
+{
+  "B1_LP": 100.0,
+  "B1_CNT": 1,
+  "B1_CNTD": 1,
+  "B2_LP": 80.0,
+  "B2_CNT": 1,
+  "B2_CNTD": 1
+}
 ```

--- a/tests/dataset/tpc-ds/q28.mochi
+++ b/tests/dataset/tpc-ds/q28.mochi
@@ -1,7 +1,42 @@
-let t = [{id: 1, val: 28}]
-let result = from r in t select r.val |> first
+// Bucket statistics for store sales quantities
+
+type StoreSale { ss_quantity: int, ss_list_price: float, ss_coupon_amt: float, ss_wholesale_cost: float }
+
+let store_sales = [
+  { ss_quantity: 3, ss_list_price: 100.0, ss_coupon_amt: 50.0, ss_wholesale_cost: 30.0 },
+  { ss_quantity: 8, ss_list_price: 80.0, ss_coupon_amt: 10.0, ss_wholesale_cost: 20.0 }
+]
+
+let bucket1 =
+  from ss in store_sales
+  where ss.ss_quantity >= 0 && ss.ss_quantity <= 5
+    && (ss.ss_list_price between 0 && 110 || ss.ss_coupon_amt between 0 && 1000 || ss.ss_wholesale_cost between 0 && 50)
+  select ss
+
+let bucket2 =
+  from ss in store_sales
+  where ss.ss_quantity >= 6 && ss.ss_quantity <= 10
+    && (ss.ss_list_price between 0 && 110 || ss.ss_coupon_amt between 0 && 1000 || ss.ss_wholesale_cost between 0 && 50)
+  select ss
+
+let result = {
+  B1_LP: avg(from x in bucket1 select x.ss_list_price),
+  B1_CNT: count(bucket1),
+  B1_CNTD: count(distinct from x in bucket1 select x.ss_list_price),
+  B2_LP: avg(from x in bucket2 select x.ss_list_price),
+  B2_CNT: count(bucket2),
+  B2_CNTD: count(distinct from x in bucket2 select x.ss_list_price)
+}
+
 json(result)
 
-test "TPCDS Q28 placeholder" {
-  expect result == 28
+test "TPCDS Q28 buckets" {
+  expect result == {
+    B1_LP: 100.0,
+    B1_CNT: 1,
+    B1_CNTD: 1,
+    B2_LP: 80.0,
+    B2_CNT: 1,
+    B2_CNTD: 1
+  }
 }

--- a/tests/dataset/tpc-ds/q29.md
+++ b/tests/dataset/tpc-ds/q29.md
@@ -1,13 +1,45 @@
 # TPC-DS Query 29
 
-This is a placeholder implementation for TPC-DS query 29.
+Query 29 summarizes sales and returns quantities for each item and store over a
+specified time window.
 
 ## SQL
 ```sql
-SELECT 29;
+SELECT i_item_id,
+       i_item_desc,
+       s_store_id,
+       s_store_name,
+       SUM(ss_quantity)        AS store_sales_quantity,
+       SUM(sr_return_quantity) AS store_returns_quantity,
+       SUM(cs_quantity)        AS catalog_sales_quantity
+FROM store_sales, store_returns, catalog_sales,
+     date_dim d1, date_dim d2, date_dim d3,
+     store, item
+WHERE d1.d_moy = 4 AND d1.d_year = 1999 AND d1.d_date_sk = ss_sold_date_sk
+  AND i_item_sk = ss_item_sk
+  AND s_store_sk = ss_store_sk
+  AND ss_customer_sk = sr_customer_sk
+  AND ss_item_sk = sr_item_sk
+  AND ss_ticket_number = sr_ticket_number
+  AND sr_returned_date_sk = d2.d_date_sk
+  AND d2.d_moy BETWEEN 4 AND 7 AND d2.d_year = 1999
+  AND sr_customer_sk = cs_bill_customer_sk
+  AND sr_item_sk = cs_item_sk
+  AND cs_sold_date_sk = d3.d_date_sk
+  AND d3.d_year IN (1999,2000,2001)
+GROUP BY i_item_id,i_item_desc,s_store_id,s_store_name
+ORDER BY i_item_id,i_item_desc,s_store_id,s_store_name;
 ```
 
 ## Expected Output
+The single row of sample data results in the following totals.
 ```json
-29
+[
+  {
+    "i_item_id": "ITEM1",
+    "store_sales_quantity": 10,
+    "store_returns_quantity": 2,
+    "catalog_sales_quantity": 5
+  }
+]
 ```

--- a/tests/dataset/tpc-ds/q29.mochi
+++ b/tests/dataset/tpc-ds/q29.mochi
@@ -1,7 +1,58 @@
-let t = [{id: 1, val: 29}]
-let result = from r in t select r.val |> first
+// Aggregated quantity across store, returns and catalog sales
+
+type StoreSale { ss_sold_date_sk: int, ss_item_sk: int, ss_store_sk: int, ss_customer_sk: int, ss_quantity: int, ss_ticket_number: int }
+type StoreReturn { sr_returned_date_sk: int, sr_item_sk: int, sr_customer_sk: int, sr_ticket_number: int, sr_return_quantity: int }
+type CatalogSale { cs_sold_date_sk: int, cs_item_sk: int, cs_bill_customer_sk: int, cs_quantity: int }
+type DateDim { d_date_sk: int, d_moy: int, d_year: int }
+type Store { s_store_sk: int, s_store_id: string, s_store_name: string }
+type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
+
+let store_sales = [ { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 10, ss_ticket_number: 1 } ]
+let store_returns = [ { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_return_quantity: 2 } ]
+let catalog_sales = [ { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 5 } ]
+
+let date_dim = [
+  { d_date_sk: 1, d_moy: 4, d_year: 1999 },
+  { d_date_sk: 2, d_moy: 5, d_year: 1999 },
+  { d_date_sk: 3, d_moy: 5, d_year: 2000 }
+]
+
+let store = [ { s_store_sk: 1, s_store_id: "S1", s_store_name: "Store1" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" } ]
+
+let result =
+  from ss in store_sales
+  join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
+  join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
+  join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
+  join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
+  join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
+  join s in store on s.s_store_sk == ss.ss_store_sk
+  join i in item on i.i_item_sk == ss.ss_item_sk
+  where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
+  group by { item_id: i.i_item_id, item_desc: i.i_item_desc, s_store_id: s.s_store_id, s_store_name: s.s_store_name } into g
+  select {
+    i_item_id: g.key.item_id,
+    i_item_desc: g.key.item_desc,
+    s_store_id: g.key.s_store_id,
+    s_store_name: g.key.s_store_name,
+    store_sales_quantity: sum(from x in g select x.ss_quantity),
+    store_returns_quantity: sum(from x in g select x.sr_return_quantity),
+    catalog_sales_quantity: sum(from x in g select x.cs_quantity)
+  }
+
 json(result)
 
-test "TPCDS Q29 placeholder" {
-  expect result == 29
+test "TPCDS Q29 quantity summary" {
+  expect result == [
+    {
+      i_item_id: "ITEM1",
+      i_item_desc: "Desc1",
+      s_store_id: "S1",
+      s_store_name: "Store1",
+      store_sales_quantity: 10,
+      store_returns_quantity: 2,
+      catalog_sales_quantity: 5
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add real implementations for TPC-DS queries 20-29
- include simplified SQL in docs with expected outputs
- add small datasets for each query and runnable tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861f7c9f1b48320a3c84c7dc01e91d1