### PR TITLE
Implement real TPC‑DS q40–q49 samples

### DIFF
--- a/tests/dataset/tpc-ds/q40.md
+++ b/tests/dataset/tpc-ds/q40.md
@@ -33,5 +33,12 @@ select
 
 ## Expected Output
 ```json
-40
+[
+  {
+    "w_state": "CA",
+    "i_item_id": "I1",
+    "sales_before": 100.0,
+    "sales_after": 0.0
+  }
+]
 ```

--- a/tests/dataset/tpc-ds/q40.mochi
+++ b/tests/dataset/tpc-ds/q40.mochi
@@ -1,7 +1,55 @@
-let t = [{id: 1, val: 40}]
-let result = from r in t select r.val |> first
+let catalog_sales = [
+  { order: 1, item_sk: 1, warehouse_sk: 1, date_sk: 1, price: 100.0 },
+  { order: 2, item_sk: 1, warehouse_sk: 1, date_sk: 2, price: 150.0 }
+]
+
+let catalog_returns = [
+  { order: 2, item_sk: 1, refunded: 150.0 }
+]
+
+let item = [
+  { item_sk: 1, item_id: "I1", current_price: 1.2 }
+]
+
+let warehouse = [
+  { warehouse_sk: 1, state: "CA" }
+]
+
+let date_dim = [
+  { date_sk: 1, date: "2020-01-10" },
+  { date_sk: 2, date: "2020-01-20" }
+]
+
+let sales_date = "2020-01-15"
+
+let records =
+  from cs in catalog_sales
+  left join cr in catalog_returns on cs.order == cr.order && cs.item_sk == cr.item_sk
+  join w in warehouse on cs.warehouse_sk == w.warehouse_sk
+  join i in item on cs.item_sk == i.item_sk
+  join d in date_dim on cs.date_sk == d.date_sk
+  where i.current_price >= 0.99 && i.current_price <= 1.49
+  select {
+    w_state: w.state,
+    i_item_id: i.item_id,
+    sold_date: d.date,
+    net: cs.price - (cr?refunded ?? 0.0)
+  }
+
+let result =
+  from r in records
+  group by { w_state: r.w_state, i_item_id: r.i_item_id } into g
+  select {
+    w_state: g.key.w_state,
+    i_item_id: g.key.i_item_id,
+    sales_before: sum(from x in g select x.sold_date < sales_date ? x.net : 0.0),
+    sales_after: sum(from x in g select x.sold_date >= sales_date ? x.net : 0.0)
+  }
+
 json(result)
 
-test "TPCDS Q40 placeholder" {
-  expect result == 40
+test "TPCDS Q40 simplified" {
+  expect result == [
+    { w_state: "CA", i_item_id: "I1", sales_before: 100.0, sales_after: 0.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q41.md
+++ b/tests/dataset/tpc-ds/q41.md
@@ -58,5 +58,8 @@ select distinct(i_product_name)
 
 ## Expected Output
 ```json
-41
+[
+  "Blue Shirt",
+  "Red Dress"
+]
 ```

--- a/tests/dataset/tpc-ds/q41.mochi
+++ b/tests/dataset/tpc-ds/q41.mochi
@@ -1,7 +1,20 @@
-let t = [{id: 1, val: 41}]
-let result = from r in t select r.val |> first
+let item = [
+  { product_name: "Blue Shirt", manufact_id: 100, manufact: 1, category: "Women", color: "blue", units: "pack", size: "M" },
+  { product_name: "Red Dress", manufact_id: 120, manufact: 1, category: "Women", color: "red", units: "pack", size: "M" },
+  { product_name: "Pants", manufact_id: 200, manufact: 2, category: "Men", color: "black", units: "pair", size: "L" }
+]
+
+let lower = 100
+
+let result =
+  from i1 in item
+  where i1.manufact_id >= lower && i1.manufact_id <= lower + 40 &&
+        count(from i2 in item where i2.manufact == i1.manufact && i2.category == i1.category) > 1
+  order by i1.product_name
+  select i1.product_name
+
 json(result)
 
-test "TPCDS Q41 placeholder" {
-  expect result == 41
+test "TPCDS Q41 simplified" {
+  expect result == ["Blue Shirt", "Red Dress"]
 }

--- a/tests/dataset/tpc-ds/q42.md
+++ b/tests/dataset/tpc-ds/q42.md
@@ -34,5 +34,12 @@ select dt.d_year
 
 ## Expected Output
 ```json
-42
+[
+  {
+    "d_year": 2020,
+    "i_category_id": 100,
+    "i_category": "CatA",
+    "sum_ss_ext_sales_price": 10.0
+  }
+]
 ```

--- a/tests/dataset/tpc-ds/q42.mochi
+++ b/tests/dataset/tpc-ds/q42.mochi
@@ -1,7 +1,40 @@
-let t = [{id: 1, val: 42}]
-let result = from r in t select r.val |> first
+let store_sales = [
+  { sold_date_sk: 1, item_sk: 1, ext_sales_price: 10.0 },
+  { sold_date_sk: 1, item_sk: 2, ext_sales_price: 20.0 },
+  { sold_date_sk: 2, item_sk: 1, ext_sales_price: 15.0 }
+]
+
+let item = [
+  { i_item_sk: 1, i_manager_id: 1, i_category_id: 100, i_category: "CatA" },
+  { i_item_sk: 2, i_manager_id: 2, i_category_id: 200, i_category: "CatB" }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_year: 2020, d_moy: 5 },
+  { d_date_sk: 2, d_year: 2021, d_moy: 5 }
+]
+
+let month = 5
+let year = 2020
+
+let result =
+  from dt in date_dim
+  join ss in store_sales on ss.sold_date_sk == dt.d_date_sk
+  join it in item on ss.item_sk == it.i_item_sk
+  where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
+  group by { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category } into g
+  order by -sum(from x in g select x.ss.ext_sales_price), g.key.d_year, g.key.i_category_id, g.key.i_category
+  select {
+    d_year: g.key.d_year,
+    i_category_id: g.key.i_category_id,
+    i_category: g.key.i_category,
+    sum_ss_ext_sales_price: sum(from x in g select x.ss.ext_sales_price)
+  }
+
 json(result)
 
-test "TPCDS Q42 placeholder" {
-  expect result == 42
+test "TPCDS Q42 simplified" {
+  expect result == [
+    { d_year: 2020, i_category_id: 100, i_category: "CatA", sum_ss_ext_sales_price: 10.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q43.md
+++ b/tests/dataset/tpc-ds/q43.md
@@ -24,5 +24,17 @@ select s_store_name, s_store_id,
 
 ## Expected Output
 ```json
-43
+[
+  {
+    "s_store_name": "Main",
+    "s_store_id": "S1",
+    "sun_sales": 10.0,
+    "mon_sales": 20.0,
+    "tue_sales": 30.0,
+    "wed_sales": 40.0,
+    "thu_sales": 50.0,
+    "fri_sales": 60.0,
+    "sat_sales": 70.0
+  }
+]
 ```

--- a/tests/dataset/tpc-ds/q43.mochi
+++ b/tests/dataset/tpc-ds/q43.mochi
@@ -1,7 +1,64 @@
-let t = [{id: 1, val: 43}]
-let result = from r in t select r.val |> first
+let date_dim = [
+  { date_sk: 1, d_day_name: "Sunday", d_year: 2020 },
+  { date_sk: 2, d_day_name: "Monday", d_year: 2020 },
+  { date_sk: 3, d_day_name: "Tuesday", d_year: 2020 },
+  { date_sk: 4, d_day_name: "Wednesday", d_year: 2020 },
+  { date_sk: 5, d_day_name: "Thursday", d_year: 2020 },
+  { date_sk: 6, d_day_name: "Friday", d_year: 2020 },
+  { date_sk: 7, d_day_name: "Saturday", d_year: 2020 }
+]
+
+let store = [ { store_sk: 1, store_id: "S1", store_name: "Main", gmt_offset: 0 } ]
+
+let store_sales = [
+  { sold_date_sk: 1, store_sk: 1, sales_price: 10.0 },
+  { sold_date_sk: 2, store_sk: 1, sales_price: 20.0 },
+  { sold_date_sk: 3, store_sk: 1, sales_price: 30.0 },
+  { sold_date_sk: 4, store_sk: 1, sales_price: 40.0 },
+  { sold_date_sk: 5, store_sk: 1, sales_price: 50.0 },
+  { sold_date_sk: 6, store_sk: 1, sales_price: 60.0 },
+  { sold_date_sk: 7, store_sk: 1, sales_price: 70.0 }
+]
+
+let year = 2020
+let gmt = 0
+
+let records =
+  from d in date_dim
+  join ss in store_sales on ss.sold_date_sk == d.date_sk
+  join s in store on ss.store_sk == s.store_sk
+  where s.gmt_offset == gmt && d.d_year == year
+  select { d_day_name: d.d_day_name, s_store_name: s.store_name, s_store_id: s.store_id, price: ss.sales_price }
+
+let result =
+  from r in records
+  group by { name: r.s_store_name, id: r.s_store_id } into g
+  select {
+    s_store_name: g.key.name,
+    s_store_id: g.key.id,
+    sun_sales: sum(from x in g select x.d_day_name == "Sunday" ? x.price : 0.0),
+    mon_sales: sum(from x in g select x.d_day_name == "Monday" ? x.price : 0.0),
+    tue_sales: sum(from x in g select x.d_day_name == "Tuesday" ? x.price : 0.0),
+    wed_sales: sum(from x in g select x.d_day_name == "Wednesday" ? x.price : 0.0),
+    thu_sales: sum(from x in g select x.d_day_name == "Thursday" ? x.price : 0.0),
+    fri_sales: sum(from x in g select x.d_day_name == "Friday" ? x.price : 0.0),
+    sat_sales: sum(from x in g select x.d_day_name == "Saturday" ? x.price : 0.0)
+  }
+
 json(result)
 
-test "TPCDS Q43 placeholder" {
-  expect result == 43
+test "TPCDS Q43 simplified" {
+  expect result == [
+    {
+      s_store_name: "Main",
+      s_store_id: "S1",
+      sun_sales: 10.0,
+      mon_sales: 20.0,
+      tue_sales: 30.0,
+      wed_sales: 40.0,
+      thu_sales: 50.0,
+      fri_sales: 60.0,
+      sat_sales: 70.0
+    }
+  ]
 }

--- a/tests/dataset/tpc-ds/q44.md
+++ b/tests/dataset/tpc-ds/q44.md
@@ -41,5 +41,8 @@ order by asceding.rnk
 
 ## Expected Output
 ```json
-44
+{
+  "best_performing": "ItemA",
+  "worst_performing": "ItemB"
+}
 ```

--- a/tests/dataset/tpc-ds/q44.mochi
+++ b/tests/dataset/tpc-ds/q44.mochi
@@ -1,7 +1,30 @@
-let t = [{id: 1, val: 44}]
-let result = from r in t select r.val |> first
+let store_sales = [
+  { ss_item_sk: 1, ss_store_sk: 1, ss_net_profit: 5.0 },
+  { ss_item_sk: 1, ss_store_sk: 1, ss_net_profit: 5.0 },
+  { ss_item_sk: 2, ss_store_sk: 1, ss_net_profit: -1.0 }
+]
+
+let item = [
+  { i_item_sk: 1, i_product_name: "ItemA" },
+  { i_item_sk: 2, i_product_name: "ItemB" }
+]
+
+let grouped =
+  from ss in store_sales
+  group by ss.ss_item_sk into g
+  let avg_profit = avg(from x in g select x.ss_net_profit)
+  select { item_sk: g.key, avg_profit: avg_profit }
+
+let best = first(from x in grouped sort by -x.avg_profit select x)
+let worst = first(from x in grouped sort by x.avg_profit select x)
+
+let best_name = from i in item where i.i_item_sk == best.item_sk select i.i_product_name |> first
+let worst_name = from i in item where i.i_item_sk == worst.item_sk select i.i_product_name |> first
+
+let result = { best_performing: best_name, worst_performing: worst_name }
+
 json(result)
 
-test "TPCDS Q44 placeholder" {
-  expect result == 44
+test "TPCDS Q44 simplified" {
+  expect result == { best_performing: "ItemA", worst_performing: "ItemB" }
 }

--- a/tests/dataset/tpc-ds/q45.md
+++ b/tests/dataset/tpc-ds/q45.md
@@ -25,5 +25,8 @@ select ca_zip, [GBOBC], sum(ws_sales_price)
 
 ## Expected Output
 ```json
-45
+[
+  { "ca_zip": "85669", "sum_ws_sales_price": 50.0 },
+  { "ca_zip": "99999", "sum_ws_sales_price": 30.0 }
+]
 ```

--- a/tests/dataset/tpc-ds/q45.mochi
+++ b/tests/dataset/tpc-ds/q45.mochi
@@ -1,7 +1,43 @@
-let t = [{id: 1, val: 45}]
-let result = from r in t select r.val |> first
-json(result)
+let web_sales = [
+  { bill_customer_sk: 1, item_sk: 1, sold_date_sk: 1, sales_price: 50.0 },
+  { bill_customer_sk: 2, item_sk: 2, sold_date_sk: 1, sales_price: 30.0 }
+]
 
-test "TPCDS Q45 placeholder" {
-  expect result == 45
+let customer = [
+  { c_customer_sk: 1, c_current_addr_sk: 1 },
+  { c_customer_sk: 2, c_current_addr_sk: 2 }
+]
+
+let customer_address = [
+  { ca_address_sk: 1, ca_zip: "85669" },
+  { ca_address_sk: 2, ca_zip: "99999" }
+]
+
+let item = [
+  { i_item_sk: 1, i_item_id: "I1" },
+  { i_item_sk: 2, i_item_id: "I2" }
+]
+
+let date_dim = [ { d_date_sk: 1, d_qoy: 1, d_year: 2020 } ]
+
+let zip_list = ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"]
+let item_ids = ["I2"]
+let qoy = 1
+let year = 2020
+
+let records =
+  from ws in web_sales
+  join c in customer on ws.bill_customer_sk == c.c_customer_sk
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  join i in item on ws.item_sk == i.i_item_sk
+  join d in date_dim on ws.sold_date_sk == d.d_date_sk
+  where (zip_list.contains(substr(ca.ca_zip, 0, 5)) || item_ids.contains(i.i_item_id)) &&
+        d.d_qoy == qoy && d.d_year == year
+  group by ca.ca_zip into g
+  select { ca_zip: g.key, sum_ws_sales_price: sum(from x in g select x.ws.sales_price) }
+
+json(records)
+
+test "TPCDS Q45 simplified" {
+  expect records == [ { ca_zip: "85669", sum_ws_sales_price: 50.0 }, { ca_zip: "99999", sum_ws_sales_price: 30.0 } ]
 }

--- a/tests/dataset/tpc-ds/q46.md
+++ b/tests/dataset/tpc-ds/q46.md
@@ -41,5 +41,15 @@ select c_last_name
 
 ## Expected Output
 ```json
-46
+[
+  {
+    "c_last_name": "Doe",
+    "c_first_name": "John",
+    "ca_city": "Seattle",
+    "bought_city": "Portland",
+    "ss_ticket_number": 1,
+    "amt": 5.0,
+    "profit": 20.0
+  }
+]
 ```

--- a/tests/dataset/tpc-ds/q46.mochi
+++ b/tests/dataset/tpc-ds/q46.mochi
@@ -1,7 +1,41 @@
-let t = [{id: 1, val: 46}]
-let result = from r in t select r.val |> first
+let store_sales = [
+  { ss_ticket_number: 1, ss_customer_sk: 1, ss_addr_sk: 1, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_coupon_amt: 5.0, ss_net_profit: 20.0 }
+]
+
+let date_dim = [ { d_date_sk: 1, d_dow: 6, d_year: 2020 } ]
+let store = [ { s_store_sk: 1, s_city: "CityA" } ]
+let household_demographics = [ { hd_demo_sk: 1, hd_dep_count: 2, hd_vehicle_count: 0 } ]
+let customer_address = [ { ca_address_sk: 1, ca_city: "Portland" }, { ca_address_sk: 2, ca_city: "Seattle" } ]
+let customer = [ { c_customer_sk: 1, c_last_name: "Doe", c_first_name: "John", c_current_addr_sk: 2 } ]
+
+let depcnt = 2
+let vehcnt = 0
+let year = 2020
+let cities = ["CityA"]
+
+let dn =
+  from ss in store_sales
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
+  where (hd.hd_dep_count == depcnt || hd.hd_vehicle_count == vehcnt) &&
+        d.d_dow in [6,0] && d.d_year == year && cities.contains(s.s_city)
+  group by { ss_ticket_number: ss.ss_ticket_number, ss_customer_sk: ss.ss_customer_sk, ca_city: ca.ca_city } into g
+  select { ss_ticket_number: g.key.ss_ticket_number, ss_customer_sk: g.key.ss_customer_sk, bought_city: g.key.ca_city, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
+
+let result =
+  from dnrec in dn
+  join c in customer on dnrec.ss_customer_sk == c.c_customer_sk
+  join current_addr in customer_address on c.c_current_addr_sk == current_addr.ca_address_sk
+  where current_addr.ca_city != dnrec.bought_city
+  order by c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number
+  select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, ca_city: current_addr.ca_city, bought_city: dnrec.bought_city, ss_ticket_number: dnrec.ss_ticket_number, amt: dnrec.amt, profit: dnrec.profit }
+
 json(result)
 
-test "TPCDS Q46 placeholder" {
-  expect result == 46
+test "TPCDS Q46 simplified" {
+  expect result == [
+    { c_last_name: "Doe", c_first_name: "John", ca_city: "Seattle", bought_city: "Portland", ss_ticket_number: 1, amt: 5.0, profit: 20.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q47.md
+++ b/tests/dataset/tpc-ds/q47.md
@@ -16,5 +16,8 @@ select *
 
 ## Expected Output
 ```json
-47
+[
+  { "d_year": 2020, "item": "B", "avg_monthly_sales": 80.0, "sum_sales": 70.0 },
+  { "d_year": 2020, "item": "A", "avg_monthly_sales": 100.0, "sum_sales": 120.0 }
+]
 ```

--- a/tests/dataset/tpc-ds/q47.mochi
+++ b/tests/dataset/tpc-ds/q47.mochi
@@ -1,7 +1,23 @@
-let t = [{id: 1, val: 47}]
-let result = from r in t select r.val |> first
+let v2 = [
+  { d_year: 2020, item: "A", avg_monthly_sales: 100.0, sum_sales: 120.0 },
+  { d_year: 2020, item: "B", avg_monthly_sales: 80.0, sum_sales: 70.0 },
+  { d_year: 2019, item: "C", avg_monthly_sales: 50.0, sum_sales: 60.0 }
+]
+
+let year = 2020
+let orderby = "item"
+
+let result =
+  from v in v2
+  where v.d_year == year && v.avg_monthly_sales > 0 && abs(v.sum_sales - v.avg_monthly_sales) / v.avg_monthly_sales > 0.1
+  order by v.sum_sales - v.avg_monthly_sales, v.item
+  select v
+
 json(result)
 
-test "TPCDS Q47 placeholder" {
-  expect result == 47
+test "TPCDS Q47 simplified" {
+  expect result == [
+    { d_year: 2020, item: "B", avg_monthly_sales: 80.0, sum_sales: 70.0 },
+    { d_year: 2020, item: "A", avg_monthly_sales: 100.0, sum_sales: 120.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q48.md
+++ b/tests/dataset/tpc-ds/q48.md
@@ -4,9 +4,42 @@ This query comes from the TPC-DS specification.
 
 ## SQL
 ```sql
+select sum (ss_quantity)
+from store_sales, store, customer_demographics, customer_address, date_dim
+where s_store_sk = ss_store_sk
+  and ss_sold_date_sk = d_date_sk and d_year = [YEAR]
+  and (
+        (cd_demo_sk = ss_cdemo_sk
+         and cd_marital_status = '[MS.1]'
+         and cd_education_status = '[ES.1]'
+         and ss_sales_price between 100.00 and 150.00)
+     or (cd_demo_sk = ss_cdemo_sk
+         and cd_marital_status = '[MS.2]'
+         and cd_education_status = '[ES.2]'
+         and ss_sales_price between 50.00 and 100.00)
+     or (cd_demo_sk = ss_cdemo_sk
+         and cd_marital_status = '[MS.3]'
+         and cd_education_status = '[ES.3]'
+         and ss_sales_price between 150.00 and 200.00)
+      )
+  and (
+        (ss_addr_sk = ca_address_sk
+         and ca_country = 'United States'
+         and ca_state in ('[STATE.1]', '[STATE.2]', '[STATE.3]')
+         and ss_net_profit between 0 and 2000)
+      or (ss_addr_sk = ca_address_sk
+         and ca_country = 'United States'
+         and ca_state in ('[STATE.4]', '[STATE.5]', '[STATE.6]')
+         and ss_net_profit between 150 and 3000)
+      or (ss_addr_sk = ca_address_sk
+         and ca_country = 'United States'
+         and ca_state in ('[STATE.7]', '[STATE.8]', '[STATE.9]')
+         and ss_net_profit between 50 and 25000)
+      )
+;
 ```
 
 ## Expected Output
 ```json
-48
+35
 ```

--- a/tests/dataset/tpc-ds/q48.mochi
+++ b/tests/dataset/tpc-ds/q48.mochi
@@ -1,7 +1,50 @@
-let t = [{id: 1, val: 48}]
-let result = from r in t select r.val |> first
+let store_sales = [
+  { cdemo_sk: 1, addr_sk: 1, sold_date_sk: 1, sales_price: 120.0, net_profit: 1000.0, quantity: 5 },
+  { cdemo_sk: 2, addr_sk: 2, sold_date_sk: 1, sales_price: 60.0, net_profit: 2000.0, quantity: 10 },
+  { cdemo_sk: 3, addr_sk: 3, sold_date_sk: 1, sales_price: 170.0, net_profit: 10000.0, quantity: 20 }
+]
+
+let store = [ { s_store_sk: 1 } ]
+let customer_demographics = [
+  { cd_demo_sk: 1, cd_marital_status: "S", cd_education_status: "E1" },
+  { cd_demo_sk: 2, cd_marital_status: "M", cd_education_status: "E2" },
+  { cd_demo_sk: 3, cd_marital_status: "W", cd_education_status: "E3" }
+]
+let customer_address = [
+  { ca_address_sk: 1, ca_country: "United States", ca_state: "TX" },
+  { ca_address_sk: 2, ca_country: "United States", ca_state: "CA" },
+  { ca_address_sk: 3, ca_country: "United States", ca_state: "NY" }
+]
+let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
+
+let year = 2000
+
+let states1 = ["TX"]
+let states2 = ["CA"]
+let states3 = ["NY"]
+
+let qty =
+  from ss in store_sales
+  join cd in customer_demographics on ss.cdemo_sk == cd.cd_demo_sk
+  join ca in customer_address on ss.addr_sk == ca.ca_address_sk
+  join d in date_dim on ss.sold_date_sk == d.d_date_sk
+  where d.d_year == year &&
+    (
+      (cd.cd_marital_status == "S" && cd.cd_education_status == "E1" && ss.sales_price >= 100.0 && ss.sales_price <= 150.0) ||
+      (cd.cd_marital_status == "M" && cd.cd_education_status == "E2" && ss.sales_price >= 50.0 && ss.sales_price <= 100.0) ||
+      (cd.cd_marital_status == "W" && cd.cd_education_status == "E3" && ss.sales_price >= 150.0 && ss.sales_price <= 200.0)
+    ) &&
+    (
+      (states1.contains(ca.ca_state) && ss.net_profit >= 0 && ss.net_profit <= 2000) ||
+      (states2.contains(ca.ca_state) && ss.net_profit >= 150 && ss.net_profit <= 3000) ||
+      (states3.contains(ca.ca_state) && ss.net_profit >= 50 && ss.net_profit <= 25000)
+    )
+  select ss.quantity
+
+let result = sum(qty)
+
 json(result)
 
-test "TPCDS Q48 placeholder" {
-  expect result == 48
+test "TPCDS Q48 simplified" {
+  expect result == 35
 }

--- a/tests/dataset/tpc-ds/q49.md
+++ b/tests/dataset/tpc-ds/q49.md
@@ -134,5 +134,10 @@ select channel, item, return_ratio, return_rank, currency_rank from
 
 ## Expected Output
 ```json
-49
+[
+  {"channel": "catalog", "item": "A", "return_ratio": 0.3, "return_rank": 1, "currency_rank": 1},
+  {"channel": "store", "item": "A", "return_ratio": 0.25, "return_rank": 1, "currency_rank": 1},
+  {"channel": "web", "item": "A", "return_ratio": 0.2, "return_rank": 1, "currency_rank": 1},
+  {"channel": "web", "item": "B", "return_ratio": 0.5, "return_rank": 2, "currency_rank": 2}
+]
 ```

--- a/tests/dataset/tpc-ds/q49.mochi
+++ b/tests/dataset/tpc-ds/q49.mochi
@@ -1,7 +1,41 @@
-let t = [{id: 1, val: 49}]
-let result = from r in t select r.val |> first
+let web = [
+  { item: "A", return_ratio: 0.2, currency_ratio: 0.3, return_rank: 1, currency_rank: 1 },
+  { item: "B", return_ratio: 0.5, currency_ratio: 0.6, return_rank: 2, currency_rank: 2 }
+]
+
+let catalog = [
+  { item: "A", return_ratio: 0.3, currency_ratio: 0.4, return_rank: 1, currency_rank: 1 }
+]
+
+let store = [
+  { item: "A", return_ratio: 0.25, currency_ratio: 0.35, return_rank: 1, currency_rank: 1 }
+]
+
+let result =
+  (
+    from w in web
+    where w.return_rank <= 10 || w.currency_rank <= 10
+    select { channel: "web", item: w.item, return_ratio: w.return_ratio, return_rank: w.return_rank, currency_rank: w.currency_rank }
+  ) ++
+  (
+    from c in catalog
+    where c.return_rank <= 10 || c.currency_rank <= 10
+    select { channel: "catalog", item: c.item, return_ratio: c.return_ratio, return_rank: c.return_rank, currency_rank: c.currency_rank }
+  ) ++
+  (
+    from s in store
+    where s.return_rank <= 10 || s.currency_rank <= 10
+    select { channel: "store", item: s.item, return_ratio: s.return_ratio, return_rank: s.return_rank, currency_rank: s.currency_rank }
+  )
+  sort by [channel, return_rank, currency_rank, item]
+
 json(result)
 
-test "TPCDS Q49 placeholder" {
-  expect result == 49
+test "TPCDS Q49 simplified" {
+  expect result == [
+    { channel: "catalog", item: "A", return_ratio: 0.3, return_rank: 1, currency_rank: 1 },
+    { channel: "store", item: "A", return_ratio: 0.25, return_rank: 1, currency_rank: 1 },
+    { channel: "web", item: "A", return_ratio: 0.2, return_rank: 1, currency_rank: 1 },
+    { channel: "web", item: "B", return_ratio: 0.5, return_rank: 2, currency_rank: 2 }
+  ]
 }


### PR DESCRIPTION
## Summary
- replace placeholder programs for q40–q49 with simplified data sets
- include full SQL text and expected JSON output
- add small datasets demonstrating joins, grouping and ranking

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6861f8313778832098f272834e371dc7