### PR TITLE
Implement TPC‑DS queries 72‑79

### DIFF
--- a/tests/dataset/tpc-ds/q72.md
+++ b/tests/dataset/tpc-ds/q72.md
@@ -1,8 +1,6 @@
 # TPC-DS Query 72 (Excerpt)
 
-The official specification counts how many catalog orders were shipped more than
-five days after the sale when inventory was low. It groups the results by item
-and warehouse.
+The official specification counts how many catalog orders were shipped more than five days after the sale when inventory was low. It groups the results by item and warehouse.
 
 ## SQL
 ```sql
@@ -36,3 +34,10 @@ LIMIT 100;
 ```
 
 The Mochi implementation uses a much smaller data set and returns one row.
+
+## Expected Output
+```json
+[
+  { "i_item_desc": "ItemA", "w_warehouse_name": "Main", "d_week_seq": 10, "no_promo": 1, "promo": 0, "total_cnt": 1 }
+]
+```

--- a/tests/dataset/tpc-ds/q72.mochi
+++ b/tests/dataset/tpc-ds/q72.mochi
@@ -1,7 +1,72 @@
-let t = [{id: 1, val: 72}]
-let result = from r in t select r.val |> first
+let catalog_sales = [
+  {
+    cs_item_sk: 1,
+    cs_order_number: 1,
+    cs_quantity: 1,
+    cs_sold_date_sk: 1,
+    cs_ship_date_sk: 3,
+    cs_bill_cdemo_sk: 1,
+    cs_bill_hdemo_sk: 1,
+    cs_promo_sk: null
+  }
+]
+
+let inventory = [
+  { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 0 }
+]
+
+let warehouse = [
+  { w_warehouse_sk: 1, w_warehouse_name: "Main" }
+]
+
+let item = [
+  { i_item_sk: 1, i_item_desc: "ItemA" }
+]
+
+let customer_demographics = [
+  { cd_demo_sk: 1, cd_marital_status: "M" }
+]
+
+let household_demographics = [
+  { hd_demo_sk: 1, hd_buy_potential: "5001-10000" }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_week_seq: 10, d_date: 1, d_year: 2000 },
+  { d_date_sk: 2, d_week_seq: 10, d_date: 1, d_year: 2000 },
+  { d_date_sk: 3, d_week_seq: 10, d_date: 7, d_year: 2000 }
+]
+
+let result =
+  from cs in catalog_sales
+  join inv in inventory on inv.inv_item_sk == cs.cs_item_sk
+  join w in warehouse on w.w_warehouse_sk == inv.inv_warehouse_sk
+  join i in item on i.i_item_sk == cs.cs_item_sk
+  join cd in customer_demographics on cd.cd_demo_sk == cs.cs_bill_cdemo_sk
+  join hd in household_demographics on hd.hd_demo_sk == cs.cs_bill_hdemo_sk
+  join d1 in date_dim on d1.d_date_sk == cs.cs_sold_date_sk
+  join d2 in date_dim on d2.d_date_sk == inv.inv_date_sk
+  join d3 in date_dim on d3.d_date_sk == cs.cs_ship_date_sk
+  where d1.d_week_seq == d2.d_week_seq &&
+        inv.inv_quantity_on_hand < cs.cs_quantity &&
+        d3.d_date > d1.d_date + 5 &&
+        hd.hd_buy_potential == "5001-10000" &&
+        d1.d_year == 2000 &&
+        cd.cd_marital_status == "M"
+  group by { item_desc: i.i_item_desc, warehouse: w.w_warehouse_name, week_seq: d1.d_week_seq } into g
+  select {
+    i_item_desc: g.key.item_desc,
+    w_warehouse_name: g.key.warehouse,
+    d_week_seq: g.key.week_seq,
+    no_promo: count(from x in g where x.cs.cs_promo_sk == null select x),
+    promo: count(from x in g where x.cs.cs_promo_sk != null select x),
+    total_cnt: count(g)
+  }
+
 json(result)
 
-test "TPCDS Q72 placeholder" {
-  expect result == 72
+test "TPCDS Q72 simplified" {
+  expect result == [
+    { i_item_desc: "ItemA", w_warehouse_name: "Main", d_week_seq: 10, no_promo: 1, promo: 0, total_cnt: 1 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q73.md
+++ b/tests/dataset/tpc-ds/q73.md
@@ -1,8 +1,6 @@
 # TPC-DS Query 73 (Excerpt)
 
-This query identifies customers from selected counties who made one to five
-purchases during the first two days of the month. Only households with buying
-potential in specific ranges are considered.
+This query identifies customers from selected counties who made one to five purchases during the first two days of the month. Only households with buying potential in specific ranges are considered.
 
 ## SQL
 ```sql
@@ -28,3 +26,10 @@ ORDER BY cnt DESC, c_last_name ASC;
 ```
 
 The simplified test data returns a single matching customer.
+
+## Expected Output
+```json
+[
+  { "c_last_name": "Smith", "c_first_name": "Alice", "c_salutation": "Ms.", "c_preferred_cust_flag": "Y", "ss_ticket_number": 1, "cnt": 1 }
+]
+```

--- a/tests/dataset/tpc-ds/q73.mochi
+++ b/tests/dataset/tpc-ds/q73.mochi
@@ -1,7 +1,55 @@
-let t = [{id: 1, val: 73}]
-let result = from r in t select r.val |> first
+let store_sales = [
+  { ss_ticket_number: 1, ss_customer_sk: 1, ss_sold_date_sk: 1, ss_store_sk: 1, ss_hdemo_sk: 1 }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_dom: 1, d_year: 1998 }
+]
+
+let store = [
+  { s_store_sk: 1, s_county: "A" }
+]
+
+let household_demographics = [
+  { hd_demo_sk: 1, hd_buy_potential: "1001-5000", hd_vehicle_count: 2, hd_dep_count: 3 }
+]
+
+let customer = [
+  { c_customer_sk: 1, c_last_name: "Smith", c_first_name: "Alice", c_salutation: "Ms.", c_preferred_cust_flag: "Y" }
+]
+
+let groups =
+  from ss in store_sales
+  join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  join s in store on s.s_store_sk == ss.ss_store_sk
+  join hd in household_demographics on hd.hd_demo_sk == ss.ss_hdemo_sk
+  where d.d_dom >= 1 && d.d_dom <= 2 &&
+        (hd.hd_buy_potential == "1001-5000" || hd.hd_buy_potential == "0-500") &&
+        hd.hd_vehicle_count > 0 &&
+        hd.hd_dep_count / hd.hd_vehicle_count > 1 &&
+        (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
+        s.s_county == "A"
+  group by { ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk } into g
+  select { key: g.key, cnt: count(g) }
+
+let result =
+  from g in groups
+  join c in customer on c.c_customer_sk == g.key.cust
+  where g.cnt >= 1 && g.cnt <= 5
+  sort by -g.cnt, c.c_last_name
+  select {
+    c_last_name: c.c_last_name,
+    c_first_name: c.c_first_name,
+    c_salutation: c.c_salutation,
+    c_preferred_cust_flag: c.c_preferred_cust_flag,
+    ss_ticket_number: g.key.ticket,
+    cnt: g.cnt
+  }
+
 json(result)
 
-test "TPCDS Q73 placeholder" {
-  expect result == 73
+test "TPCDS Q73 simplified" {
+  expect result == [
+    { c_last_name: "Smith", c_first_name: "Alice", c_salutation: "Ms.", c_preferred_cust_flag: "Y", ss_ticket_number: 1, cnt: 1 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q74.md
+++ b/tests/dataset/tpc-ds/q74.md
@@ -1,7 +1,6 @@
 # TPC-DS Query 74 (Excerpt)
 
-Query 74 compares year over year spending for customers across store and web
-channels. Customers whose web growth outpaces store growth are returned.
+Query 74 compares year over year spending for customers across store and web channels. Customers whose web growth outpaces store growth are returned.
 
 ## SQL
 ```sql
@@ -54,3 +53,10 @@ LIMIT 100;
 ```
 
 The simplified data set yields one customer meeting the criteria.
+
+## Expected Output
+```json
+[
+  { "customer_id": 1, "customer_first_name": "Alice", "customer_last_name": "Smith" }
+]
+```

--- a/tests/dataset/tpc-ds/q74.mochi
+++ b/tests/dataset/tpc-ds/q74.mochi
@@ -1,7 +1,55 @@
-let t = [{id: 1, val: 74}]
-let result = from r in t select r.val |> first
+let customer = [
+  { c_customer_sk: 1, c_customer_id: 1, c_first_name: "Alice", c_last_name: "Smith" }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_year: 1998 },
+  { d_date_sk: 2, d_year: 1999 }
+]
+
+let store_sales = [
+  { ss_customer_sk: 1, ss_sold_date_sk: 1, ss_net_paid: 100.0 },
+  { ss_customer_sk: 1, ss_sold_date_sk: 2, ss_net_paid: 110.0 }
+]
+
+let web_sales = [
+  { ws_bill_customer_sk: 1, ws_sold_date_sk: 1, ws_net_paid: 40.0 },
+  { ws_bill_customer_sk: 1, ws_sold_date_sk: 2, ws_net_paid: 80.0 }
+]
+
+let year_total =
+  concat(
+    from c in customer
+    join ss in store_sales on c.c_customer_sk == ss.ss_customer_sk
+    join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+    where d.d_year == 1998 || d.d_year == 1999
+    group by { id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, year: d.d_year } into g
+    select { customer_id: g.key.id, customer_first_name: g.key.first, customer_last_name: g.key.last, year: g.key.year, year_total: sum(from x in g select x.ss.ss_net_paid), sale_type: "s" },
+    from c in customer
+    join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
+    join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
+    where d.d_year == 1998 || d.d_year == 1999
+    group by { id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, year: d.d_year } into g
+    select { customer_id: g.key.id, customer_first_name: g.key.first, customer_last_name: g.key.last, year: g.key.year, year_total: sum(from x in g select x.ws.ws_net_paid), sale_type: "w" }
+  )
+
+let s_firstyear = from y in year_total where y.sale_type == "s" && y.year == 1998 select y |> first
+let s_secyear = from y in year_total where y.sale_type == "s" && y.year == 1999 select y |> first
+let w_firstyear = from y in year_total where y.sale_type == "w" && y.year == 1998 select y |> first
+let w_secyear = from y in year_total where y.sale_type == "w" && y.year == 1999 select y |> first
+
+let result =
+  if s_firstyear.year_total > 0 && w_firstyear.year_total > 0 &&
+     (w_secyear.year_total / w_firstyear.year_total) > (s_secyear.year_total / s_firstyear.year_total) {
+    [{ customer_id: s_secyear.customer_id, customer_first_name: s_secyear.customer_first_name, customer_last_name: s_secyear.customer_last_name }]
+  } else {
+    []
+  }
+
 json(result)
 
-test "TPCDS Q74 placeholder" {
-  expect result == 74
+test "TPCDS Q74 simplified" {
+  expect result == [
+    { customer_id: 1, customer_first_name: "Alice", customer_last_name: "Smith" }
+  ]
 }

--- a/tests/dataset/tpc-ds/q75.md
+++ b/tests/dataset/tpc-ds/q75.md
@@ -1,7 +1,6 @@
 # TPC-DS Query 75 (Excerpt)
 
-Query 75 compares yearly sales for a particular item category across all three
-sales channels. Items whose sales drop by more than ten percent are returned.
+Query 75 compares yearly sales for a particular item category across all three sales channels. Items whose sales drop by more than ten percent are returned.
 
 ## SQL
 ```sql
@@ -18,25 +17,25 @@ WITH all_sales AS (
       LEFT JOIN catalog_returns ON cs_order_number = cr_order_number
                                AND cs_item_sk = cr_item_sk
       WHERE i_category = 'Electronics'
-    UNION
+    UNION ALL
     SELECT d_year, i_brand_id, i_class_id, i_category_id, i_manufact_id,
-           ss_quantity - COALESCE(sr_return_quantity,0) AS sales_cnt,
-           ss_ext_sales_price - COALESCE(sr_return_amt,0.0) AS sales_amt
+           ss_quantity - COALESCE(sr_return_quantity,0),
+           ss_ext_sales_price - COALESCE(sr_return_amt,0.0)
       FROM store_sales
       JOIN item ON i_item_sk = ss_item_sk
       JOIN date_dim ON d_date_sk = ss_sold_date_sk
-      LEFT JOIN store_returns ON ss_ticket_number = sr_ticket_number
-                             AND ss_item_sk = sr_item_sk
+      LEFT JOIN store_returns ON sr_ticket_number = ss_ticket_number
+                              AND sr_item_sk = ss_item_sk
       WHERE i_category = 'Electronics'
-    UNION
+    UNION ALL
     SELECT d_year, i_brand_id, i_class_id, i_category_id, i_manufact_id,
-           ws_quantity - COALESCE(wr_return_quantity,0) AS sales_cnt,
-           ws_ext_sales_price - COALESCE(wr_return_amt,0.0) AS sales_amt
+           ws_quantity - COALESCE(wr_return_quantity,0),
+           ws_ext_sales_price - COALESCE(wr_return_amt,0.0)
       FROM web_sales
       JOIN item ON i_item_sk = ws_item_sk
       JOIN date_dim ON d_date_sk = ws_sold_date_sk
-      LEFT JOIN web_returns ON ws_order_number = wr_order_number
-                           AND ws_item_sk = wr_item_sk
+      LEFT JOIN web_returns ON wr_order_number = ws_order_number
+                            AND wr_item_sk = ws_item_sk
       WHERE i_category = 'Electronics'
   ) sales_detail
   GROUP BY d_year, i_brand_id, i_class_id, i_category_id, i_manufact_id
@@ -65,3 +64,10 @@ LIMIT 100;
 ```
 
 Our tiny data set reports a single item with reduced sales.
+
+## Expected Output
+```json
+[
+  { "prev_year": 2000, "year": 2001, "i_brand_id": 1, "i_class_id": 2, "i_category_id": 3, "i_manufact_id": 4, "prev_yr_cnt": 100, "curr_yr_cnt": 80, "sales_cnt_diff": -20, "sales_amt_diff": -200.0 }
+]
+```

--- a/tests/dataset/tpc-ds/q75.mochi
+++ b/tests/dataset/tpc-ds/q75.mochi
@@ -1,7 +1,74 @@
-let t = [{id: 1, val: 75}]
-let result = from r in t select r.val |> first
+let date_dim = [
+  { d_date_sk: 1, d_year: 2000 },
+  { d_date_sk: 2, d_year: 2001 }
+]
+
+let store_sales = [
+  { ss_item_sk: 1, ss_quantity: 50, ss_sales_price: 500.0, ss_sold_date_sk: 1 },
+  { ss_item_sk: 1, ss_quantity: 40, ss_sales_price: 400.0, ss_sold_date_sk: 2 }
+]
+
+let web_sales = [
+  { ws_item_sk: 1, ws_quantity: 30, ws_sales_price: 300.0, ws_sold_date_sk: 1 },
+  { ws_item_sk: 1, ws_quantity: 25, ws_sales_price: 250.0, ws_sold_date_sk: 2 }
+]
+
+let catalog_sales = [
+  { cs_item_sk: 1, cs_quantity: 20, cs_sales_price: 200.0, cs_sold_date_sk: 1 },
+  { cs_item_sk: 1, cs_quantity: 15, cs_sales_price: 150.0, cs_sold_date_sk: 2 }
+]
+
+let item = [
+  { i_item_sk: 1, i_brand_id: 1, i_class_id: 2, i_category_id: 3, i_manufact_id: 4, i_category: "Electronics" }
+]
+
+let sales_detail =
+  concat(
+    from ss in store_sales join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk select { d_year: d.d_year, i_item_sk: ss.ss_item_sk, quantity: ss.ss_quantity, amount: ss.ss_sales_price },
+    from ws in web_sales join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk select { d_year: d.d_year, i_item_sk: ws.ws_item_sk, quantity: ws.ws_quantity, amount: ws.ws_sales_price },
+    from cs in catalog_sales join d in date_dim on d.d_date_sk == cs.cs_sold_date_sk select { d_year: d.d_year, i_item_sk: cs.cs_item_sk, quantity: cs.cs_quantity, amount: cs.cs_sales_price }
+  )
+
+let all_sales =
+  from sd in sales_detail
+  join i in item on i.i_item_sk == sd.i_item_sk
+  where i.i_category == "Electronics"
+  group by { year: sd.d_year, brand_id: i.i_brand_id, class_id: i.i_class_id, category_id: i.i_category_id, manuf_id: i.i_manufact_id } into g
+  select {
+    d_year: g.key.year,
+    i_brand_id: g.key.brand_id,
+    i_class_id: g.key.class_id,
+    i_category_id: g.key.category_id,
+    i_manufact_id: g.key.manuf_id,
+    sales_cnt: sum(from x in g select x.sd.quantity),
+    sales_amt: sum(from x in g select x.sd.amount)
+  }
+
+let prev_yr = from a in all_sales where a.d_year == 2000 |> first
+let curr_yr = from a in all_sales where a.d_year == 2001 |> first
+
+let result =
+  if (curr_yr.sales_cnt / prev_yr.sales_cnt) < 0.9 {
+    [{
+      prev_year: prev_yr.d_year,
+      year: curr_yr.d_year,
+      i_brand_id: curr_yr.i_brand_id,
+      i_class_id: curr_yr.i_class_id,
+      i_category_id: curr_yr.i_category_id,
+      i_manufact_id: curr_yr.i_manufact_id,
+      prev_yr_cnt: prev_yr.sales_cnt,
+      curr_yr_cnt: curr_yr.sales_cnt,
+      sales_cnt_diff: curr_yr.sales_cnt - prev_yr.sales_cnt,
+      sales_amt_diff: curr_yr.sales_amt - prev_yr.sales_amt
+    }]
+  } else {
+    []
+  }
+
 json(result)
 
-test "TPCDS Q75 placeholder" {
-  expect result == 75
+test "TPCDS Q75 simplified" {
+  expect result == [
+    { prev_year: 2000, year: 2001, i_brand_id: 1, i_class_id: 2, i_category_id: 3, i_manufact_id: 4, prev_yr_cnt: 100, curr_yr_cnt: 80, sales_cnt_diff: -20, sales_amt_diff: -200.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q76.md
+++ b/tests/dataset/tpc-ds/q76.md
@@ -1,7 +1,6 @@
 # TPC-DS Query 76 (Excerpt)
 
-This query counts sales rows where certain foreign keys are `NULL` across all
-three sales tables and reports the totals by quarter and item category.
+This query counts sales rows where certain foreign keys are `NULL` across all three sales tables and reports the totals by quarter and item category.
 
 ## SQL
 ```sql
@@ -33,3 +32,12 @@ LIMIT 100;
 ```
 
 The small example only demonstrates the query structure.
+
+## Expected Output
+```json
+[
+  { "channel": "store", "col_name": null, "d_year": 1998, "d_qoy": 1, "i_category": "CatA", "sales_cnt": 1, "sales_amt": 10.0 },
+  { "channel": "web", "col_name": null, "d_year": 1998, "d_qoy": 1, "i_category": "CatB", "sales_cnt": 1, "sales_amt": 15.0 },
+  { "channel": "catalog", "col_name": null, "d_year": 1998, "d_qoy": 1, "i_category": "CatC", "sales_cnt": 1, "sales_amt": 20.0 }
+]
+```

--- a/tests/dataset/tpc-ds/q76.mochi
+++ b/tests/dataset/tpc-ds/q76.mochi
@@ -1,7 +1,68 @@
-let t = [{id: 1, val: 76}]
-let result = from r in t select r.val |> first
+let date_dim = [
+  { d_date_sk: 1, d_year: 1998, d_qoy: 1 }
+]
+
+let item = [
+  { i_item_sk: 1, i_category: "CatA" },
+  { i_item_sk: 2, i_category: "CatB" },
+  { i_item_sk: 3, i_category: "CatC" }
+]
+
+let store_sales = [
+  { ss_customer_sk: null, ss_item_sk: 1, ss_ext_sales_price: 10.0, ss_sold_date_sk: 1 }
+]
+
+let web_sales = [
+  { ws_bill_customer_sk: null, ws_item_sk: 2, ws_ext_sales_price: 15.0, ws_sold_date_sk: 1 }
+]
+
+let catalog_sales = [
+  { cs_bill_customer_sk: null, cs_item_sk: 3, cs_ext_sales_price: 20.0, cs_sold_date_sk: 1 }
+]
+
+let store_part =
+  from ss in store_sales
+  join i in item on i.i_item_sk == ss.ss_item_sk
+  join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  where ss.ss_customer_sk == null
+  select { channel: "store", col_name: ss.ss_customer_sk, d_year: d.d_year, d_qoy: d.d_qoy, i_category: i.i_category, ext_sales_price: ss.ss_ext_sales_price }
+
+let web_part =
+  from ws in web_sales
+  join i in item on i.i_item_sk == ws.ws_item_sk
+  join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
+  where ws.ws_bill_customer_sk == null
+  select { channel: "web", col_name: ws.ws_bill_customer_sk, d_year: d.d_year, d_qoy: d.d_qoy, i_category: i.i_category, ext_sales_price: ws.ws_ext_sales_price }
+
+let catalog_part =
+  from cs in catalog_sales
+  join i in item on i.i_item_sk == cs.cs_item_sk
+  join d in date_dim on d.d_date_sk == cs.cs_sold_date_sk
+  where cs.cs_bill_customer_sk == null
+  select { channel: "catalog", col_name: cs.cs_bill_customer_sk, d_year: d.d_year, d_qoy: d.d_qoy, i_category: i.i_category, ext_sales_price: cs.cs_ext_sales_price }
+
+let all_rows = concat(store_part, web_part, catalog_part)
+
+let result =
+  from r in all_rows
+  group by { channel: r.channel, col_name: r.col_name, d_year: r.d_year, d_qoy: r.d_qoy, i_category: r.i_category } into g
+  sort by g.key.channel
+  select {
+    channel: g.key.channel,
+    col_name: g.key.col_name,
+    d_year: g.key.d_year,
+    d_qoy: g.key.d_qoy,
+    i_category: g.key.i_category,
+    sales_cnt: count(g),
+    sales_amt: sum(from x in g select x.r.ext_sales_price)
+  }
+
 json(result)
 
-test "TPCDS Q76 placeholder" {
-  expect result == 76
+test "TPCDS Q76 simplified" {
+  expect result == [
+    { channel: "store", col_name: null, d_year: 1998, d_qoy: 1, i_category: "CatA", sales_cnt: 1, sales_amt: 10.0 },
+    { channel: "web", col_name: null, d_year: 1998, d_qoy: 1, i_category: "CatB", sales_cnt: 1, sales_amt: 15.0 },
+    { channel: "catalog", col_name: null, d_year: 1998, d_qoy: 1, i_category: "CatC", sales_cnt: 1, sales_amt: 20.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q77.md
+++ b/tests/dataset/tpc-ds/q77.md
@@ -1,7 +1,6 @@
 # TPC-DS Query 77 (Excerpt)
 
-This query reports thirty day sales, returns and profit across store, catalog and
-web channels using a `ROLLUP` to produce both per-channel and overall totals.
+This query reports thirty day sales, returns and profit across store, catalog and web channels using a `ROLLUP` to produce both per-channel and overall totals.
 
 ## SQL
 ```sql
@@ -86,3 +85,12 @@ LIMIT 100;
 ```
 
 Only a few rows are produced in the simplified test.
+
+## Expected Output
+```json
+[
+  { "channel": "catalog channel", "id": 1, "sales": 150.0, "returns": 7.0, "profit": 12.0 },
+  { "channel": "store channel", "id": 1, "sales": 100.0, "returns": 5.0, "profit": 9.0 },
+  { "channel": "web channel", "id": 1, "sales": 200.0, "returns": 10.0, "profit": 18.0 }
+]
+```

--- a/tests/dataset/tpc-ds/q77.mochi
+++ b/tests/dataset/tpc-ds/q77.mochi
@@ -1,7 +1,86 @@
-let t = [{id: 1, val: 77}]
-let result = from r in t select r.val |> first
+let date_dim = [
+  { d_date_sk: 1, d_date: 1 }
+]
+
+let store_sales = [
+  { ss_sold_date_sk: 1, s_store_sk: 1, ss_ext_sales_price: 100.0, ss_net_profit: 10.0 }
+]
+
+let store_returns = [
+  { sr_returned_date_sk: 1, s_store_sk: 1, sr_return_amt: 5.0, sr_net_loss: 1.0 }
+]
+
+let catalog_sales = [
+  { cs_sold_date_sk: 1, cs_call_center_sk: 1, cs_ext_sales_price: 150.0, cs_net_profit: 15.0 }
+]
+
+let catalog_returns = [
+  { cr_returned_date_sk: 1, cr_call_center_sk: 1, cr_return_amount: 7.0, cr_net_loss: 3.0 }
+]
+
+let web_sales = [
+  { ws_sold_date_sk: 1, ws_web_page_sk: 1, ws_ext_sales_price: 200.0, ws_net_profit: 20.0 }
+]
+
+let web_returns = [
+  { wr_returned_date_sk: 1, wr_web_page_sk: 1, wr_return_amt: 10.0, wr_net_loss: 2.0 }
+]
+
+let ss =
+  from ss in store_sales
+  join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  group by ss.s_store_sk into g
+  select { s_store_sk: g.key, sales: sum(from x in g select x.ss.ss_ext_sales_price), profit: sum(from x in g select x.ss.ss_net_profit) }
+
+let sr =
+  from sr in store_returns
+  join d in date_dim on d.d_date_sk == sr.sr_returned_date_sk
+  group by sr.s_store_sk into g
+  select { s_store_sk: g.key, returns: sum(from x in g select x.sr.sr_return_amt), profit_loss: sum(from x in g select x.sr.sr_net_loss) }
+
+let cs =
+  from cs in catalog_sales
+  join d in date_dim on d.d_date_sk == cs.cs_sold_date_sk
+  group by cs.cs_call_center_sk into g
+  select { cs_call_center_sk: g.key, sales: sum(from x in g select x.cs.cs_ext_sales_price), profit: sum(from x in g select x.cs.cs_net_profit) }
+
+let cr =
+  from cr in catalog_returns
+  join d in date_dim on d.d_date_sk == cr.cr_returned_date_sk
+  group by cr.cr_call_center_sk into g
+  select { cr_call_center_sk: g.key, returns: sum(from x in g select x.cr.cr_return_amount), profit_loss: sum(from x in g select x.cr.cr_net_loss) }
+
+let ws =
+  from ws in web_sales
+  join d in date_dim on d.d_date_sk == ws.ws_sold_date_sk
+  group by ws.ws_web_page_sk into g
+  select { wp_web_page_sk: g.key, sales: sum(from x in g select x.ws.ws_ext_sales_price), profit: sum(from x in g select x.ws.ws_net_profit) }
+
+let wr =
+  from wr in web_returns
+  join d in date_dim on d.d_date_sk == wr.wr_returned_date_sk
+  group by wr.wr_web_page_sk into g
+  select { wp_web_page_sk: g.key, returns: sum(from x in g select x.wr.wr_return_amt), profit_loss: sum(from x in g select x.wr.wr_net_loss) }
+
+let per_channel =
+  concat(
+    from s in ss left join r in sr on s.s_store_sk == r.s_store_sk select { channel: "store channel", id: s.s_store_sk, sales: s.sales, returns: r?.returns ?? 0.0, profit: s.profit - (r?.profit_loss ?? 0.0) },
+    from c in cs join r in cr on c.cs_call_center_sk == r.cr_call_center_sk select { channel: "catalog channel", id: c.cs_call_center_sk, sales: c.sales, returns: r.returns, profit: c.profit - r.profit_loss },
+    from w in ws left join r in wr on w.wp_web_page_sk == r.wp_web_page_sk select { channel: "web channel", id: w.wp_web_page_sk, sales: w.sales, returns: r?.returns ?? 0.0, profit: w.profit - (r?.profit_loss ?? 0.0) }
+  )
+
+let result =
+  from p in per_channel
+  group by { channel: p.channel, id: p.id } into g
+  sort by g.key.channel
+  select { channel: g.key.channel, id: g.key.id, sales: sum(from x in g select x.p.sales), returns: sum(from x in g select x.p.returns), profit: sum(from x in g select x.p.profit) }
+
 json(result)
 
-test "TPCDS Q77 placeholder" {
-  expect result == 77
+test "TPCDS Q77 simplified" {
+  expect result == [
+    { channel: "catalog channel", id: 1, sales: 150.0, returns: 7.0, profit: 12.0 },
+    { channel: "store channel", id: 1, sales: 100.0, returns: 5.0, profit: 9.0 },
+    { channel: "web channel", id: 1, sales: 200.0, returns: 10.0, profit: 18.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q78.md
+++ b/tests/dataset/tpc-ds/q78.md
@@ -1,7 +1,6 @@
 # TPC-DS Query 78 (Excerpt)
 
-Query 78 compares store sales for a given year to sales of the same items in
-other channels. Only items also sold on the web or catalog are included.
+Query 78 compares store sales for a given year to sales of the same items in other channels. Only items also sold on the web or catalog are included.
 
 ## SQL
 ```sql
@@ -61,3 +60,10 @@ LIMIT 100;
 ```
 
 A minimal data set is used for demonstration.
+
+## Expected Output
+```json
+[
+  { "ss_sold_year": 1998, "ss_item_sk": 1, "ss_customer_sk": 1, "ratio": 1.25, "store_qty": 10, "store_wholesale_cost": 50.0, "store_sales_price": 100.0, "other_chan_qty": 8, "other_chan_wholesale_cost": 40.0, "other_chan_sales_price": 80.0 }
+]
+```

--- a/tests/dataset/tpc-ds/q78.mochi
+++ b/tests/dataset/tpc-ds/q78.mochi
@@ -1,7 +1,37 @@
-let t = [{id: 1, val: 78}]
-let result = from r in t select r.val |> first
+let ss = [
+  { ss_sold_year: 1998, ss_item_sk: 1, ss_customer_sk: 1, ss_qty: 10, ss_wc: 50.0, ss_sp: 100.0 }
+]
+
+let ws = [
+  { ws_sold_year: 1998, ws_item_sk: 1, ws_customer_sk: 1, ws_qty: 5, ws_wc: 25.0, ws_sp: 50.0 }
+]
+
+let cs = [
+  { cs_sold_year: 1998, cs_item_sk: 1, cs_customer_sk: 1, cs_qty: 3, cs_wc: 15.0, cs_sp: 30.0 }
+]
+
+let result =
+  from s in ss
+  left join w in ws on w.ws_sold_year == s.ss_sold_year && w.ws_item_sk == s.ss_item_sk && w.ws_customer_sk == s.ss_customer_sk
+  left join c in cs on c.cs_sold_year == s.ss_sold_year && c.cs_item_sk == s.ss_item_sk && c.cs_customer_sk == s.ss_customer_sk
+  where (coalesce(w.ws_qty,0) > 0 || coalesce(c.cs_qty,0) > 0) && s.ss_sold_year == 1998
+  select {
+    ss_sold_year: s.ss_sold_year,
+    ss_item_sk: s.ss_item_sk,
+    ss_customer_sk: s.ss_customer_sk,
+    ratio: s.ss_qty / (coalesce(w.ws_qty,0) + coalesce(c.cs_qty,0)),
+    store_qty: s.ss_qty,
+    store_wholesale_cost: s.ss_wc,
+    store_sales_price: s.ss_sp,
+    other_chan_qty: coalesce(w.ws_qty,0) + coalesce(c.cs_qty,0),
+    other_chan_wholesale_cost: coalesce(w.ws_wc,0) + coalesce(c.cs_wc,0),
+    other_chan_sales_price: coalesce(w.ws_sp,0) + coalesce(c.cs_sp,0)
+  }
+
 json(result)
 
-test "TPCDS Q78 placeholder" {
-  expect result == 78
+test "TPCDS Q78 simplified" {
+  expect result == [
+    { ss_sold_year: 1998, ss_item_sk: 1, ss_customer_sk: 1, ratio: 1.25, store_qty: 10, store_wholesale_cost: 50.0, store_sales_price: 100.0, other_chan_qty: 8, other_chan_wholesale_cost: 40.0, other_chan_sales_price: 80.0 }
+  ]
 }

--- a/tests/dataset/tpc-ds/q79.md
+++ b/tests/dataset/tpc-ds/q79.md
@@ -1,8 +1,6 @@
 # TPC-DS Query 79 (Excerpt)
 
-This query lists customers with store purchases made on Mondays where coupon
-amounts contributed to profit. The filter considers household demographics such
-as dependent and vehicle counts.
+This query lists customers with store purchases made on Mondays where coupon amounts contributed to profit. The filter considers household demographics such as dependent and vehicle counts.
 
 ## SQL
 ```sql
@@ -28,3 +26,10 @@ LIMIT 100;
 ```
 
 Only a single customer appears in this reduced example.
+
+## Expected Output
+```json
+[
+  { "c_last_name": "Smith", "c_first_name": "Alice", "s_city": "CityA", "ss_ticket_number": 1, "amt": 5.0, "profit": 10.0 }
+]
+```

--- a/tests/dataset/tpc-ds/q79.mochi
+++ b/tests/dataset/tpc-ds/q79.mochi
@@ -1,7 +1,45 @@
-let t = [{id: 1, val: 79}]
-let result = from r in t select r.val |> first
+let date_dim = [
+  { d_date_sk: 1, d_dow: 1, d_year: 1999 }
+]
+
+let store = [
+  { s_store_sk: 1, s_city: "CityA", s_number_employees: 250 }
+]
+
+let household_demographics = [
+  { hd_demo_sk: 1, hd_dep_count: 2, hd_vehicle_count: 1 }
+]
+
+let store_sales = [
+  { ss_sold_date_sk: 1, ss_store_sk: 1, ss_ticket_number: 1, ss_customer_sk: 1, ss_hdemo_sk: 1, ss_coupon_amt: 5.0, ss_net_profit: 10.0 }
+]
+
+let customer = [
+  { c_customer_sk: 1, c_last_name: "Smith", c_first_name: "Alice" }
+]
+
+let agg =
+  from ss in store_sales
+  join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  join s in store on s.s_store_sk == ss.ss_store_sk
+  join hd in household_demographics on hd.hd_demo_sk == ss.ss_hdemo_sk
+  where (hd.hd_dep_count == 2 || hd.hd_vehicle_count > 1) &&
+        d.d_dow == 1 &&
+        (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
+        s.s_number_employees >= 200 && s.s_number_employees <= 295
+  group by { ticket: ss.ss_ticket_number, customer_sk: ss.ss_customer_sk, city: s.s_city } into g
+  select { key: g.key, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
+
+let result =
+  from a in agg
+  join c in customer on c.c_customer_sk == a.key.customer_sk
+  sort by c.c_last_name, c.c_first_name, a.key.city, a.profit
+  select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
+
 json(result)
 
-test "TPCDS Q79 placeholder" {
-  expect result == 79
+test "TPCDS Q79 simplified" {
+  expect result == [
+    { c_last_name: "Smith", c_first_name: "Alice", s_city: "CityA", ss_ticket_number: 1, amt: 5.0, profit: 10.0 }
+  ]
 }


### PR DESCRIPTION
## Summary
- add simplified implementations for TPC‑DS queries 72–79
- document SQL and expected output for queries 72–79

## Testing
- `go test ./...` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6861f876d5dc832087bdfcc2caf691c9