### PR TITLE
Add realistic TPC‑DC examples q40‑49

### DIFF
--- a/tests/dataset/tpc-dc/q40.md
+++ b/tests/dataset/tpc-dc/q40.md
@@ -1,0 +1,56 @@
+# TPC-DC Query 40
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select 
+   w_state
+  ,i_item_id
+  ,sum(case when (cast(d_date as date) < cast ('[SALES_DATE]' as date)) 
+ 		then cs_sales_price - coalesce(cr_refunded_cash,0) else 0 end) as sales_before
+  ,sum(case when (cast(d_date as date) >= cast ('[SALES_DATE]' as date)) 
+ 		then cs_sales_price - coalesce(cr_refunded_cash,0) else 0 end) as sales_after
+ from
+   catalog_sales left outer join catalog_returns on
+       (cs_order_number = cr_order_number 
+        and cs_item_sk = cr_item_sk)
+  ,warehouse 
+  ,item
+  ,date_dim
+ where
+     i_current_price between 0.99 and 1.49
+ and i_item_sk          = cs_item_sk
+ and cs_warehouse_sk    = w_warehouse_sk 
+ and cs_sold_date_sk    = d_date_sk
+ and d_date between (cast ('[SALES_DATE]' as date) - 30 days)
+                and (cast ('[SALES_DATE]' as date) + 30 days) 
+ group by
+    w_state,i_item_id
+ order by w_state,i_item_id
+;
+```
+
+## Expected Output
+```json
+[
+  {
+    "w_state": "CA",
+    "i_item_id": "I1",
+    "sales_before": 100.0,
+    "sales_after": 0.0
+  },
+  {
+    "w_state": "CA",
+    "i_item_id": "I2",
+    "sales_before": 0.0,
+    "sales_after": 50.0
+  },
+  {
+    "w_state": "NY",
+    "i_item_id": "I2",
+    "sales_before": 0.0,
+    "sales_after": 150.0
+  }
+]
+```

--- a/tests/dataset/tpc-dc/q40.mochi
+++ b/tests/dataset/tpc-dc/q40.mochi
@@ -1,0 +1,64 @@
+let catalog_sales = [
+  { order: 1, item_sk: 1, warehouse_sk: 1, date_sk: 1, price: 100.0 },
+  { order: 2, item_sk: 1, warehouse_sk: 1, date_sk: 2, price: 150.0 },
+  { order: 3, item_sk: 2, warehouse_sk: 2, date_sk: 3, price: 200.0 },
+  { order: 4, item_sk: 2, warehouse_sk: 1, date_sk: 4, price: 50.0 }
+]
+
+let catalog_returns = [
+  { order: 2, item_sk: 1, refunded: 150.0 },
+  { order: 3, item_sk: 2, refunded: 50.0 }
+]
+
+let item = [
+  { item_sk: 1, item_id: "I1", current_price: 1.2 },
+  { item_sk: 2, item_id: "I2", current_price: 1.1 }
+]
+
+let warehouse = [
+  { warehouse_sk: 1, state: "CA" },
+  { warehouse_sk: 2, state: "NY" }
+]
+
+let date_dim = [
+  { date_sk: 1, date: "2020-01-10" },
+  { date_sk: 2, date: "2020-01-20" },
+  { date_sk: 3, date: "2020-01-25" },
+  { date_sk: 4, date: "2020-02-05" }
+]
+
+let sales_date = "2020-01-15"
+
+let records =
+  from cs in catalog_sales
+  left join cr in catalog_returns on cs.order == cr.order && cs.item_sk == cr.item_sk
+  join w in warehouse on cs.warehouse_sk == w.warehouse_sk
+  join i in item on cs.item_sk == i.item_sk
+  join d in date_dim on cs.date_sk == d.date_sk
+  where i.current_price >= 0.99 && i.current_price <= 1.49
+  select {
+    w_state: w.state,
+    i_item_id: i.item_id,
+    sold_date: d.date,
+    net: cs.price - (cr?refunded ?? 0.0)
+  }
+
+let result =
+  from r in records
+  group by { w_state: r.w_state, i_item_id: r.i_item_id } into g
+  select {
+    w_state: g.key.w_state,
+    i_item_id: g.key.i_item_id,
+    sales_before: sum(from x in g select x.sold_date < sales_date ? x.net : 0.0),
+    sales_after: sum(from x in g select x.sold_date >= sales_date ? x.net : 0.0)
+  }
+
+json(result)
+
+test "TPCDS Q40 simplified" {
+  expect result == [
+    { w_state: "CA", i_item_id: "I1", sales_before: 100.0, sales_after: 0.0 },
+    { w_state: "CA", i_item_id: "I2", sales_before: 0.0, sales_after: 50.0 },
+    { w_state: "NY", i_item_id: "I2", sales_before: 0.0, sales_after: 150.0 }
+  ]
+}

--- a/tests/dataset/tpc-dc/q41.md
+++ b/tests/dataset/tpc-dc/q41.md
@@ -1,0 +1,68 @@
+# TPC-DC Query 41
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select distinct(i_product_name)
+ from item i1
+ where i_manufact_id between [MANUFACT] and [MANUFACT]+40 
+   and (select count(*) as item_cnt
+        from item
+        where (i_manufact = i1.i_manufact and
+        ((i_category = 'Women' and 
+        (i_color = '[COLOR.1]' or i_color = '[COLOR.2]') and 
+        (i_units = '[UNIT.1]' or i_units = '[UNIT.2]') and
+        (i_size = '[SIZE.1]' or i_size = '[SIZE.2]')
+        ) or
+        (i_category = 'Women' and
+        (i_color = '[COLOR.3]' or i_color = '[COLOR.4]') and
+        (i_units = '[UNIT.3]' or i_units = '[UNIT.4]') and
+        (i_size = '[SIZE.3]' or i_size = '[SIZE.4]')
+        ) or
+        (i_category = 'Men' and
+        (i_color = '[COLOR.5]' or i_color = '[COLOR.6]') and
+        (i_units = '[UNIT.5]' or i_units = '[UNIT.6]') and
+        (i_size = '[SIZE.5]' or i_size = '[SIZE.6]')
+        ) or
+        (i_category = 'Men' and
+        (i_color = '[COLOR.7]' or i_color = '[COLOR.8]') and
+        (i_units = '[UNIT.7]' or i_units = '[UNIT.8]') and
+        (i_size = '[SIZE.1]' or i_size = '[SIZE.2]')
+        ))) or
+       (i_manufact = i1.i_manufact and
+        ((i_category = 'Women' and 
+        (i_color = '[COLOR.9]' or i_color = '[COLOR.10]') and 
+        (i_units = '[UNIT.9]' or i_units = '[UNIT.10]') and
+        (i_size = '[SIZE.1]' or i_size = '[SIZE.2]')
+        ) or
+        (i_category = 'Women' and
+        (i_color = '[COLOR.11]' or i_color = '[COLOR.12]') and
+        (i_units = '[UNIT.11]' or i_units = '[UNIT.12]') and
+        (i_size = '[SIZE.3]' or i_size = '[SIZE.4]')
+        ) or
+        (i_category = 'Men' and
+        (i_color = '[COLOR.13]' or i_color = '[COLOR.14]') and
+        (i_units = '[UNIT.13]' or i_units = '[UNIT.14]') and
+        (i_size = '[SIZE.5]' or i_size = '[SIZE.6]')
+        ) or
+        (i_category = 'Men' and
+        (i_color = '[COLOR.15]' or i_color = '[COLOR.16]') and
+        (i_units = '[UNIT.15]' or i_units = '[UNIT.16]') and
+        (i_size = '[SIZE.1]' or i_size = '[SIZE.2]')
+        )))) > 0
+ order by i_product_name
+ ;
+
+```
+
+## Expected Output
+```json
+[
+  "Black Shorts",
+  "Blue Shirt",
+  "Green Shirt",
+  "Grey Pants",
+  "Red Dress"
+]
+```

--- a/tests/dataset/tpc-dc/q41.mochi
+++ b/tests/dataset/tpc-dc/q41.mochi
@@ -1,0 +1,23 @@
+let item = [
+  { product_name: "Blue Shirt", manufact_id: 100, manufact: 1, category: "Women", color: "blue", units: "pack", size: "M" },
+  { product_name: "Red Dress", manufact_id: 120, manufact: 1, category: "Women", color: "red", units: "pack", size: "M" },
+  { product_name: "Pants", manufact_id: 200, manufact: 2, category: "Men", color: "black", units: "pair", size: "L" },
+  { product_name: "Green Shirt", manufact_id: 110, manufact: 1, category: "Women", color: "green", units: "pack", size: "L" },
+  { product_name: "Grey Pants", manufact_id: 115, manufact: 1, category: "Men", color: "grey", units: "pair", size: "L" },
+  { product_name: "Black Shorts", manufact_id: 125, manufact: 1, category: "Men", color: "black", units: "pair", size: "M" }
+]
+
+let lower = 100
+
+let result =
+  from i1 in item
+  where i1.manufact_id >= lower && i1.manufact_id <= lower + 40 &&
+        count(from i2 in item where i2.manufact == i1.manufact && i2.category == i1.category) > 1
+  order by i1.product_name
+  select i1.product_name
+
+json(result)
+
+test "TPCDS Q41 simplified" {
+  expect result == ["Black Shorts", "Blue Shirt", "Green Shirt", "Grey Pants", "Red Dress"]
+}

--- a/tests/dataset/tpc-dc/q42.md
+++ b/tests/dataset/tpc-dc/q42.md
@@ -1,0 +1,45 @@
+# TPC-DC Query 42
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select dt.d_year
+ 	,item.i_category_id
+ 	,item.i_category
+ 	,sum(ss_ext_sales_price)
+ from 	date_dim dt
+ 	,store_sales
+ 	,item
+ where dt.d_date_sk = store_sales.ss_sold_date_sk
+ 	and store_sales.ss_item_sk = item.i_item_sk
+ 	and item.i_manager_id = 1  	
+ 	and dt.d_moy=[MONTH]
+ 	and dt.d_year=[YEAR]
+ group by 	dt.d_year
+ 		,item.i_category_id
+ 		,item.i_category
+ order by       sum(ss_ext_sales_price) desc,dt.d_year
+ 		,item.i_category_id
+ 		,item.i_category
+ ;
+
+
+ 
+ 
+ 
+ 
+
+```
+
+## Expected Output
+```json
+[
+  {
+    "d_year": 2020,
+    "i_category_id": 100,
+    "i_category": "CatA",
+    "sum_ss_ext_sales_price": 65.0
+  }
+]
+```

--- a/tests/dataset/tpc-dc/q42.mochi
+++ b/tests/dataset/tpc-dc/q42.mochi
@@ -1,0 +1,43 @@
+let store_sales = [
+  { sold_date_sk: 1, item_sk: 1, ext_sales_price: 10.0 },
+  { sold_date_sk: 1, item_sk: 2, ext_sales_price: 20.0 },
+  { sold_date_sk: 2, item_sk: 1, ext_sales_price: 15.0 },
+  { sold_date_sk: 1, item_sk: 1, ext_sales_price: 5.0 },
+  { sold_date_sk: 1, item_sk: 2, ext_sales_price: 30.0 }
+]
+
+let item = [
+  { i_item_sk: 1, i_manager_id: 1, i_category_id: 100, i_category: "CatA" },
+  { i_item_sk: 2, i_manager_id: 1, i_category_id: 100, i_category: "CatA" },
+  { i_item_sk: 3, i_manager_id: 2, i_category_id: 200, i_category: "CatB" }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_year: 2020, d_moy: 5 },
+  { d_date_sk: 2, d_year: 2021, d_moy: 5 }
+]
+
+let month = 5
+let year = 2020
+
+let result =
+  from dt in date_dim
+  join ss in store_sales on ss.sold_date_sk == dt.d_date_sk
+  join it in item on ss.item_sk == it.i_item_sk
+  where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
+  group by { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category } into g
+  order by -sum(from x in g select x.ss.ext_sales_price), g.key.d_year, g.key.i_category_id, g.key.i_category
+  select {
+    d_year: g.key.d_year,
+    i_category_id: g.key.i_category_id,
+    i_category: g.key.i_category,
+    sum_ss_ext_sales_price: sum(from x in g select x.ss.ext_sales_price)
+  }
+
+json(result)
+
+test "TPCDS Q42 simplified" {
+  expect result == [
+    { d_year: 2020, i_category_id: 100, i_category: "CatA", sum_ss_ext_sales_price: 65.0 }
+  ]
+}

--- a/tests/dataset/tpc-dc/q43.md
+++ b/tests/dataset/tpc-dc/q43.md
@@ -1,0 +1,51 @@
+# TPC-DC Query 43
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select s_store_name, s_store_id,
+        sum(case when (d_day_name='Sunday') then ss_sales_price else null end) sun_sales,
+        sum(case when (d_day_name='Monday') then ss_sales_price else null end) mon_sales,
+        sum(case when (d_day_name='Tuesday') then ss_sales_price else  null end) tue_sales,
+        sum(case when (d_day_name='Wednesday') then ss_sales_price else null end) wed_sales,
+        sum(case when (d_day_name='Thursday') then ss_sales_price else null end) thu_sales,
+        sum(case when (d_day_name='Friday') then ss_sales_price else null end) fri_sales,
+        sum(case when (d_day_name='Saturday') then ss_sales_price else null end) sat_sales
+ from date_dim, store_sales, store
+ where d_date_sk = ss_sold_date_sk and
+       s_store_sk = ss_store_sk and
+       s_gmt_offset = [GMT] and
+       d_year = [YEAR] 
+ group by s_store_name, s_store_id
+ order by s_store_name, s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales
+ ; 
+```
+
+## Expected Output
+```json
+[
+  {
+    "s_store_name": "Branch",
+    "s_store_id": "S2",
+    "sun_sales": 15.0,
+    "mon_sales": 25.0,
+    "tue_sales": 35.0,
+    "wed_sales": 0.0,
+    "thu_sales": 0.0,
+    "fri_sales": 0.0,
+    "sat_sales": 0.0
+  },
+  {
+    "s_store_name": "Main",
+    "s_store_id": "S1",
+    "sun_sales": 10.0,
+    "mon_sales": 20.0,
+    "tue_sales": 30.0,
+    "wed_sales": 40.0,
+    "thu_sales": 50.0,
+    "fri_sales": 60.0,
+    "sat_sales": 70.0
+  }
+]
+```

--- a/tests/dataset/tpc-dc/q43.mochi
+++ b/tests/dataset/tpc-dc/q43.mochi
@@ -1,0 +1,81 @@
+let date_dim = [
+  { date_sk: 1, d_day_name: "Sunday", d_year: 2020 },
+  { date_sk: 2, d_day_name: "Monday", d_year: 2020 },
+  { date_sk: 3, d_day_name: "Tuesday", d_year: 2020 },
+  { date_sk: 4, d_day_name: "Wednesday", d_year: 2020 },
+  { date_sk: 5, d_day_name: "Thursday", d_year: 2020 },
+  { date_sk: 6, d_day_name: "Friday", d_year: 2020 },
+  { date_sk: 7, d_day_name: "Saturday", d_year: 2020 }
+]
+
+let store = [
+  { store_sk: 1, store_id: "S1", store_name: "Main", gmt_offset: 0 },
+  { store_sk: 2, store_id: "S2", store_name: "Branch", gmt_offset: 0 }
+]
+
+let store_sales = [
+  { sold_date_sk: 1, store_sk: 1, sales_price: 10.0 },
+  { sold_date_sk: 2, store_sk: 1, sales_price: 20.0 },
+  { sold_date_sk: 3, store_sk: 1, sales_price: 30.0 },
+  { sold_date_sk: 4, store_sk: 1, sales_price: 40.0 },
+  { sold_date_sk: 5, store_sk: 1, sales_price: 50.0 },
+  { sold_date_sk: 6, store_sk: 1, sales_price: 60.0 },
+  { sold_date_sk: 7, store_sk: 1, sales_price: 70.0 },
+  { sold_date_sk: 1, store_sk: 2, sales_price: 15.0 },
+  { sold_date_sk: 2, store_sk: 2, sales_price: 25.0 },
+  { sold_date_sk: 3, store_sk: 2, sales_price: 35.0 }
+]
+
+let year = 2020
+let gmt = 0
+
+let records =
+  from d in date_dim
+  join ss in store_sales on ss.sold_date_sk == d.date_sk
+  join s in store on ss.store_sk == s.store_sk
+  where s.gmt_offset == gmt && d.d_year == year
+  select { d_day_name: d.d_day_name, s_store_name: s.store_name, s_store_id: s.store_id, price: ss.sales_price }
+
+let result =
+  from r in records
+  group by { name: r.s_store_name, id: r.s_store_id } into g
+  select {
+    s_store_name: g.key.name,
+    s_store_id: g.key.id,
+    sun_sales: sum(from x in g select x.d_day_name == "Sunday" ? x.price : 0.0),
+    mon_sales: sum(from x in g select x.d_day_name == "Monday" ? x.price : 0.0),
+    tue_sales: sum(from x in g select x.d_day_name == "Tuesday" ? x.price : 0.0),
+    wed_sales: sum(from x in g select x.d_day_name == "Wednesday" ? x.price : 0.0),
+    thu_sales: sum(from x in g select x.d_day_name == "Thursday" ? x.price : 0.0),
+    fri_sales: sum(from x in g select x.d_day_name == "Friday" ? x.price : 0.0),
+    sat_sales: sum(from x in g select x.d_day_name == "Saturday" ? x.price : 0.0)
+  }
+
+json(result)
+
+test "TPCDS Q43 simplified" {
+  expect result == [
+    {
+      s_store_name: "Branch",
+      s_store_id: "S2",
+      sun_sales: 15.0,
+      mon_sales: 25.0,
+      tue_sales: 35.0,
+      wed_sales: 0.0,
+      thu_sales: 0.0,
+      fri_sales: 0.0,
+      sat_sales: 0.0
+    },
+    {
+      s_store_name: "Main",
+      s_store_id: "S1",
+      sun_sales: 10.0,
+      mon_sales: 20.0,
+      tue_sales: 30.0,
+      wed_sales: 40.0,
+      thu_sales: 50.0,
+      fri_sales: 60.0,
+      sat_sales: 70.0
+    }
+  ]
+}

--- a/tests/dataset/tpc-dc/q44.md
+++ b/tests/dataset/tpc-dc/q44.md
@@ -1,0 +1,48 @@
+# TPC-DC Query 44
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select asceding.rnk, i1.i_product_name best_performing, i2.i_product_name worst_performing
+from(select *
+     from (select item_sk,rank() over (order by rank_col asc) rnk
+           from (select ss_item_sk item_sk,avg(ss_net_profit) rank_col 
+                 from store_sales ss1
+                 where ss_store_sk = [STORE]
+                 group by ss_item_sk
+                 having avg(ss_net_profit) > 0.9*(select avg(ss_net_profit) rank_col
+                                                  from store_sales
+                                                  where ss_store_sk = [STORE]
+                                                    and [NULLCOLSS] is null
+                                                  group by ss_store_sk))V1)V11
+     where rnk  < 11) asceding,
+    (select *
+     from (select item_sk,rank() over (order by rank_col desc) rnk
+           from (select ss_item_sk item_sk,avg(ss_net_profit) rank_col
+                 from store_sales ss1
+                 where ss_store_sk = [STORE]
+                 group by ss_item_sk
+                 having avg(ss_net_profit) > 0.9*(select avg(ss_net_profit) rank_col
+                                                  from store_sales
+                                                  where ss_store_sk = [STORE]
+                                                    and [NULLCOLSS] is null
+                                                  group by ss_store_sk))V2)V21
+     where rnk  < 11) descending,
+item i1,
+item i2
+where asceding.rnk = descending.rnk 
+  and i1.i_item_sk=asceding.item_sk
+  and i2.i_item_sk=descending.item_sk
+order by asceding.rnk
+;
+
+```
+
+## Expected Output
+```json
+{
+  "best_performing": "ItemC",
+  "worst_performing": "ItemB"
+}
+```

--- a/tests/dataset/tpc-dc/q44.mochi
+++ b/tests/dataset/tpc-dc/q44.mochi
@@ -1,0 +1,33 @@
+let store_sales = [
+  { ss_item_sk: 1, ss_store_sk: 1, ss_net_profit: 5.0 },
+  { ss_item_sk: 1, ss_store_sk: 1, ss_net_profit: 5.0 },
+  { ss_item_sk: 2, ss_store_sk: 1, ss_net_profit: -1.0 },
+  { ss_item_sk: 3, ss_store_sk: 1, ss_net_profit: 8.0 },
+  { ss_item_sk: 3, ss_store_sk: 1, ss_net_profit: 7.0 }
+]
+
+let item = [
+  { i_item_sk: 1, i_product_name: "ItemA" },
+  { i_item_sk: 2, i_product_name: "ItemB" },
+  { i_item_sk: 3, i_product_name: "ItemC" }
+]
+
+let grouped =
+  from ss in store_sales
+  group by ss.ss_item_sk into g
+  let avg_profit = avg(from x in g select x.ss_net_profit)
+  select { item_sk: g.key, avg_profit: avg_profit }
+
+let best = first(from x in grouped sort by -x.avg_profit select x)
+let worst = first(from x in grouped sort by x.avg_profit select x)
+
+let best_name = from i in item where i.i_item_sk == best.item_sk select i.i_product_name |> first
+let worst_name = from i in item where i.i_item_sk == worst.item_sk select i.i_product_name |> first
+
+let result = { best_performing: best_name, worst_performing: worst_name }
+
+json(result)
+
+test "TPCDS Q44 simplified" {
+  expect result == { best_performing: "ItemC", worst_performing: "ItemB" }
+}

--- a/tests/dataset/tpc-dc/q45.md
+++ b/tests/dataset/tpc-dc/q45.md
@@ -1,0 +1,33 @@
+# TPC-DC Query 45
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select ca_zip, [GBOBC], sum(ws_sales_price)
+ from web_sales, customer, customer_address, date_dim, item
+ where ws_bill_customer_sk = c_customer_sk
+ 	and c_current_addr_sk = ca_address_sk 
+ 	and ws_item_sk = i_item_sk 
+ 	and ( substr(ca_zip,1,5) in ('85669', '86197','88274','83405','86475', '85392', '85460', '80348', '81792')
+ 	      or 
+ 	      i_item_id in (select i_item_id
+                             from item
+                             where i_item_sk in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29)
+                             )
+ 	    )
+ 	and ws_sold_date_sk = d_date_sk
+ 	and d_qoy = [QOY] and d_year = [YEAR]
+ group by ca_zip, [GBOBC]
+ order by ca_zip, [GBOBC]
+ ;
+```
+
+## Expected Output
+```json
+[
+  { "ca_zip": "80348", "sum_ws_sales_price": 20.0 },
+  { "ca_zip": "85669", "sum_ws_sales_price": 100.0 },
+  { "ca_zip": "99999", "sum_ws_sales_price": 30.0 }
+]
+```

--- a/tests/dataset/tpc-dc/q45.mochi
+++ b/tests/dataset/tpc-dc/q45.mochi
@@ -1,0 +1,52 @@
+let web_sales = [
+  { bill_customer_sk: 1, item_sk: 1, sold_date_sk: 1, sales_price: 50.0 },
+  { bill_customer_sk: 2, item_sk: 2, sold_date_sk: 1, sales_price: 30.0 },
+  { bill_customer_sk: 1, item_sk: 2, sold_date_sk: 1, sales_price: 40.0 },
+  { bill_customer_sk: 1, item_sk: 1, sold_date_sk: 1, sales_price: 10.0 },
+  { bill_customer_sk: 3, item_sk: 1, sold_date_sk: 1, sales_price: 20.0 }
+]
+
+let customer = [
+  { c_customer_sk: 1, c_current_addr_sk: 1 },
+  { c_customer_sk: 2, c_current_addr_sk: 2 },
+  { c_customer_sk: 3, c_current_addr_sk: 3 }
+]
+
+let customer_address = [
+  { ca_address_sk: 1, ca_zip: "85669" },
+  { ca_address_sk: 2, ca_zip: "99999" },
+  { ca_address_sk: 3, ca_zip: "80348" }
+]
+
+let item = [
+  { i_item_sk: 1, i_item_id: "I1" },
+  { i_item_sk: 2, i_item_id: "I2" }
+]
+
+let date_dim = [ { d_date_sk: 1, d_qoy: 1, d_year: 2020 } ]
+
+let zip_list = ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"]
+let item_ids = ["I2"]
+let qoy = 1
+let year = 2020
+
+let records =
+  from ws in web_sales
+  join c in customer on ws.bill_customer_sk == c.c_customer_sk
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  join i in item on ws.item_sk == i.i_item_sk
+  join d in date_dim on ws.sold_date_sk == d.d_date_sk
+  where (zip_list.contains(substr(ca.ca_zip, 0, 5)) || item_ids.contains(i.i_item_id)) &&
+        d.d_qoy == qoy && d.d_year == year
+  group by ca.ca_zip into g
+  select { ca_zip: g.key, sum_ws_sales_price: sum(from x in g select x.ws.sales_price) }
+
+json(records)
+
+test "TPCDS Q45 simplified" {
+  expect records == [
+    { ca_zip: "80348", sum_ws_sales_price: 20.0 },
+    { ca_zip: "85669", sum_ws_sales_price: 100.0 },
+    { ca_zip: "99999", sum_ws_sales_price: 30.0 }
+  ]
+}

--- a/tests/dataset/tpc-dc/q46.md
+++ b/tests/dataset/tpc-dc/q46.md
@@ -1,0 +1,55 @@
+# TPC-DC Query 46
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select c_last_name
+       ,c_first_name
+       ,ca_city
+       ,bought_city
+       ,ss_ticket_number
+       ,amt,profit 
+ from
+   (select ss_ticket_number
+          ,ss_customer_sk
+          ,ca_city bought_city
+          ,sum(ss_coupon_amt) amt
+          ,sum(ss_net_profit) profit
+    from store_sales,date_dim,store,household_demographics,customer_address 
+    where store_sales.ss_sold_date_sk = date_dim.d_date_sk
+    and store_sales.ss_store_sk = store.s_store_sk  
+    and store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk
+    and store_sales.ss_addr_sk = customer_address.ca_address_sk
+    and (household_demographics.hd_dep_count = [DEPCNT] or
+         household_demographics.hd_vehicle_count= [VEHCNT])
+    and date_dim.d_dow in (6,0)
+    and date_dim.d_year in ([YEAR],[YEAR]+1,[YEAR]+2) 
+    and store.s_city in ('[CITY_A]','[CITY_B]','[CITY_C]','[CITY_D]','[CITY_E]') 
+    group by ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city) dn,customer,customer_address current_addr
+    where ss_customer_sk = c_customer_sk
+      and customer.c_current_addr_sk = current_addr.ca_address_sk
+      and current_addr.ca_city <> bought_city
+  order by c_last_name
+          ,c_first_name
+          ,ca_city
+          ,bought_city
+          ,ss_ticket_number
+  ;
+
+```
+
+## Expected Output
+```json
+[
+  {
+    "c_last_name": "Doe",
+    "c_first_name": "John",
+    "ca_city": "Seattle",
+    "bought_city": "Portland",
+    "ss_ticket_number": 1,
+    "amt": 5.0,
+    "profit": 20.0
+  }
+]
+```

--- a/tests/dataset/tpc-dc/q46.mochi
+++ b/tests/dataset/tpc-dc/q46.mochi
@@ -1,0 +1,42 @@
+let store_sales = [
+  { ss_ticket_number: 1, ss_customer_sk: 1, ss_addr_sk: 1, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_coupon_amt: 5.0, ss_net_profit: 20.0 },
+  { ss_ticket_number: 2, ss_customer_sk: 1, ss_addr_sk: 2, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_coupon_amt: 2.0, ss_net_profit: 10.0 }
+]
+
+let date_dim = [ { d_date_sk: 1, d_dow: 6, d_year: 2020 } ]
+let store = [ { s_store_sk: 1, s_city: "CityA" } ]
+let household_demographics = [ { hd_demo_sk: 1, hd_dep_count: 2, hd_vehicle_count: 0 } ]
+let customer_address = [ { ca_address_sk: 1, ca_city: "Portland" }, { ca_address_sk: 2, ca_city: "Seattle" } ]
+let customer = [ { c_customer_sk: 1, c_last_name: "Doe", c_first_name: "John", c_current_addr_sk: 2 } ]
+
+let depcnt = 2
+let vehcnt = 0
+let year = 2020
+let cities = ["CityA"]
+
+let dn =
+  from ss in store_sales
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
+  where (hd.hd_dep_count == depcnt || hd.hd_vehicle_count == vehcnt) &&
+        d.d_dow in [6,0] && d.d_year == year && cities.contains(s.s_city)
+  group by { ss_ticket_number: ss.ss_ticket_number, ss_customer_sk: ss.ss_customer_sk, ca_city: ca.ca_city } into g
+  select { ss_ticket_number: g.key.ss_ticket_number, ss_customer_sk: g.key.ss_customer_sk, bought_city: g.key.ca_city, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
+
+let result =
+  from dnrec in dn
+  join c in customer on dnrec.ss_customer_sk == c.c_customer_sk
+  join current_addr in customer_address on c.c_current_addr_sk == current_addr.ca_address_sk
+  where current_addr.ca_city != dnrec.bought_city
+  order by c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number
+  select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, ca_city: current_addr.ca_city, bought_city: dnrec.bought_city, ss_ticket_number: dnrec.ss_ticket_number, amt: dnrec.amt, profit: dnrec.profit }
+
+json(result)
+
+test "TPCDS Q46 simplified" {
+  expect result == [
+    { c_last_name: "Doe", c_first_name: "John", ca_city: "Seattle", bought_city: "Portland", ss_ticket_number: 1, amt: 5.0, profit: 20.0 }
+  ]
+}

--- a/tests/dataset/tpc-dc/q47.md
+++ b/tests/dataset/tpc-dc/q47.md
@@ -1,0 +1,23 @@
+# TPC-DC Query 47
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select *
+ from v2
+ where  d_year = [YEAR] and    
+        avg_monthly_sales > 0 and
+        case when avg_monthly_sales > 0 then abs(sum_sales - avg_monthly_sales) / avg_monthly_sales else null end > 0.1
+ order by sum_sales - avg_monthly_sales, [ORDERBY]
+ ;
+
+```
+
+## Expected Output
+```json
+[
+  { "d_year": 2020, "item": "B", "avg_monthly_sales": 80.0, "sum_sales": 70.0 },
+  { "d_year": 2020, "item": "A", "avg_monthly_sales": 100.0, "sum_sales": 120.0 }
+]
+```

--- a/tests/dataset/tpc-dc/q47.mochi
+++ b/tests/dataset/tpc-dc/q47.mochi
@@ -1,0 +1,25 @@
+let v2 = [
+  { d_year: 2020, item: "A", avg_monthly_sales: 100.0, sum_sales: 120.0 },
+  { d_year: 2020, item: "B", avg_monthly_sales: 80.0, sum_sales: 70.0 },
+  { d_year: 2019, item: "C", avg_monthly_sales: 50.0, sum_sales: 60.0 },
+  { d_year: 2020, item: "D", avg_monthly_sales: 50.0, sum_sales: 45.0 },
+  { d_year: 2020, item: "E", avg_monthly_sales: 75.0, sum_sales: 70.0 }
+]
+
+let year = 2020
+let orderby = "item"
+
+let result =
+  from v in v2
+  where v.d_year == year && v.avg_monthly_sales > 0 && abs(v.sum_sales - v.avg_monthly_sales) / v.avg_monthly_sales > 0.1
+  order by v.sum_sales - v.avg_monthly_sales, v.item
+  select v
+
+json(result)
+
+test "TPCDS Q47 simplified" {
+  expect result == [
+    { d_year: 2020, item: "B", avg_monthly_sales: 80.0, sum_sales: 70.0 },
+    { d_year: 2020, item: "A", avg_monthly_sales: 100.0, sum_sales: 120.0 }
+  ]
+}

--- a/tests/dataset/tpc-dc/q48.md
+++ b/tests/dataset/tpc-dc/q48.md
@@ -1,0 +1,45 @@
+# TPC-DC Query 48
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select sum (ss_quantity)
+from store_sales, store, customer_demographics, customer_address, date_dim
+where s_store_sk = ss_store_sk
+  and ss_sold_date_sk = d_date_sk and d_year = [YEAR]
+  and (
+        (cd_demo_sk = ss_cdemo_sk
+         and cd_marital_status = '[MS.1]'
+         and cd_education_status = '[ES.1]'
+         and ss_sales_price between 100.00 and 150.00)
+     or (cd_demo_sk = ss_cdemo_sk
+         and cd_marital_status = '[MS.2]'
+         and cd_education_status = '[ES.2]'
+         and ss_sales_price between 50.00 and 100.00)
+     or (cd_demo_sk = ss_cdemo_sk
+         and cd_marital_status = '[MS.3]'
+         and cd_education_status = '[ES.3]'
+         and ss_sales_price between 150.00 and 200.00)
+      )
+  and (
+        (ss_addr_sk = ca_address_sk
+         and ca_country = 'United States'
+         and ca_state in ('[STATE.1]', '[STATE.2]', '[STATE.3]')
+         and ss_net_profit between 0 and 2000)
+      or (ss_addr_sk = ca_address_sk
+         and ca_country = 'United States'
+         and ca_state in ('[STATE.4]', '[STATE.5]', '[STATE.6]')
+         and ss_net_profit between 150 and 3000)
+      or (ss_addr_sk = ca_address_sk
+         and ca_country = 'United States'
+         and ca_state in ('[STATE.7]', '[STATE.8]', '[STATE.9]')
+         and ss_net_profit between 50 and 25000)
+      )
+;
+```
+
+## Expected Output
+```json
+52
+```

--- a/tests/dataset/tpc-dc/q48.mochi
+++ b/tests/dataset/tpc-dc/q48.mochi
@@ -1,0 +1,52 @@
+let store_sales = [
+  { cdemo_sk: 1, addr_sk: 1, sold_date_sk: 1, sales_price: 120.0, net_profit: 1000.0, quantity: 5 },
+  { cdemo_sk: 2, addr_sk: 2, sold_date_sk: 1, sales_price: 60.0, net_profit: 2000.0, quantity: 10 },
+  { cdemo_sk: 3, addr_sk: 3, sold_date_sk: 1, sales_price: 170.0, net_profit: 10000.0, quantity: 20 },
+  { cdemo_sk: 1, addr_sk: 2, sold_date_sk: 1, sales_price: 110.0, net_profit: 160.0, quantity: 7 },
+  { cdemo_sk: 3, addr_sk: 3, sold_date_sk: 1, sales_price: 180.0, net_profit: 20000.0, quantity: 10 }
+]
+
+let store = [ { s_store_sk: 1 } ]
+let customer_demographics = [
+  { cd_demo_sk: 1, cd_marital_status: "S", cd_education_status: "E1" },
+  { cd_demo_sk: 2, cd_marital_status: "M", cd_education_status: "E2" },
+  { cd_demo_sk: 3, cd_marital_status: "W", cd_education_status: "E3" }
+]
+let customer_address = [
+  { ca_address_sk: 1, ca_country: "United States", ca_state: "TX" },
+  { ca_address_sk: 2, ca_country: "United States", ca_state: "CA" },
+  { ca_address_sk: 3, ca_country: "United States", ca_state: "NY" }
+]
+let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
+
+let year = 2000
+
+let states1 = ["TX"]
+let states2 = ["CA"]
+let states3 = ["NY"]
+
+let qty =
+  from ss in store_sales
+  join cd in customer_demographics on ss.cdemo_sk == cd.cd_demo_sk
+  join ca in customer_address on ss.addr_sk == ca.ca_address_sk
+  join d in date_dim on ss.sold_date_sk == d.d_date_sk
+  where d.d_year == year &&
+    (
+      (cd.cd_marital_status == "S" && cd.cd_education_status == "E1" && ss.sales_price >= 100.0 && ss.sales_price <= 150.0) ||
+      (cd.cd_marital_status == "M" && cd.cd_education_status == "E2" && ss.sales_price >= 50.0 && ss.sales_price <= 100.0) ||
+      (cd.cd_marital_status == "W" && cd.cd_education_status == "E3" && ss.sales_price >= 150.0 && ss.sales_price <= 200.0)
+    ) &&
+    (
+      (states1.contains(ca.ca_state) && ss.net_profit >= 0 && ss.net_profit <= 2000) ||
+      (states2.contains(ca.ca_state) && ss.net_profit >= 150 && ss.net_profit <= 3000) ||
+      (states3.contains(ca.ca_state) && ss.net_profit >= 50 && ss.net_profit <= 25000)
+    )
+  select ss.quantity
+
+let result = sum(qty)
+
+json(result)
+
+test "TPCDS Q48 simplified" {
+  expect result == 52
+}

--- a/tests/dataset/tpc-dc/q49.md
+++ b/tests/dataset/tpc-dc/q49.md
@@ -1,0 +1,146 @@
+# TPC-DC Query 49
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+select channel, item, return_ratio, return_rank, currency_rank from
+ (select
+ 'web' as channel
+ ,web.item
+ ,web.return_ratio
+ ,web.return_rank
+ ,web.currency_rank
+ from (
+ 	select 
+ 	 item
+ 	,return_ratio
+ 	,currency_ratio
+ 	,rank() over (order by return_ratio) as return_rank
+ 	,rank() over (order by currency_ratio) as currency_rank
+ 	from
+ 	(	select ws.ws_item_sk as item
+ 		,(cast(sum(coalesce(wr.wr_return_quantity,0)) as decimal(15,4))/
+ 		cast(sum(coalesce(ws.ws_quantity,0)) as decimal(15,4) )) as return_ratio
+ 		,(cast(sum(coalesce(wr.wr_return_amt,0)) as decimal(15,4))/
+ 		cast(sum(coalesce(ws.ws_net_paid,0)) as decimal(15,4) )) as currency_ratio
+ 		from 
+ 		 web_sales ws left outer join web_returns wr 
+ 			on (ws.ws_order_number = wr.wr_order_number and 
+ 			ws.ws_item_sk = wr.wr_item_sk)
+                 ,date_dim
+ 		where 
+ 			wr.wr_return_amt > 10000 
+ 			and ws.ws_net_profit > 1
+                         and ws.ws_net_paid > 0
+                         and ws.ws_quantity > 0
+                         and ws_sold_date_sk = d_date_sk
+                         and d_year = [YEAR]
+                         and d_moy = [MONTH]
+ 		group by ws.ws_item_sk
+ 	) in_web
+ ) web
+ where 
+ (
+ web.return_rank <= 10
+ or
+ web.currency_rank <= 10
+ )
+ union
+ select 
+ 'catalog' as channel
+ ,catalog.item
+ ,catalog.return_ratio
+ ,catalog.return_rank
+ ,catalog.currency_rank
+ from (
+ 	select 
+ 	 item
+ 	,return_ratio
+ 	,currency_ratio
+ 	,rank() over (order by return_ratio) as return_rank
+ 	,rank() over (order by currency_ratio) as currency_rank
+ 	from
+ 	(	select 
+ 		cs.cs_item_sk as item
+ 		,(cast(sum(coalesce(cr.cr_return_quantity,0)) as decimal(15,4))/
+ 		cast(sum(coalesce(cs.cs_quantity,0)) as decimal(15,4) )) as return_ratio
+ 		,(cast(sum(coalesce(cr.cr_return_amount,0)) as decimal(15,4))/
+ 		cast(sum(coalesce(cs.cs_net_paid,0)) as decimal(15,4) )) as currency_ratio
+ 		from 
+ 		catalog_sales cs left outer join catalog_returns cr
+ 			on (cs.cs_order_number = cr.cr_order_number and 
+ 			cs.cs_item_sk = cr.cr_item_sk)
+                ,date_dim
+ 		where 
+ 			cr.cr_return_amount > 10000 
+ 			and cs.cs_net_profit > 1
+                         and cs.cs_net_paid > 0
+                         and cs.cs_quantity > 0
+                         and cs_sold_date_sk = d_date_sk
+                         and d_year = [YEAR]
+                         and d_moy = [MONTH]
+                 group by cs.cs_item_sk
+ 	) in_cat
+ ) catalog
+ where 
+ (
+ catalog.return_rank <= 10
+ or
+ catalog.currency_rank <=10
+ )
+ union
+ select 
+ 'store' as channel
+ ,store.item
+ ,store.return_ratio
+ ,store.return_rank
+ ,store.currency_rank
+ from (
+ 	select 
+ 	 item
+ 	,return_ratio
+ 	,currency_ratio
+ 	,rank() over (order by return_ratio) as return_rank
+ 	,rank() over (order by currency_ratio) as currency_rank
+ 	from
+ 	(	select sts.ss_item_sk as item
+ 		,(cast(sum(coalesce(sr.sr_return_quantity,0)) as decimal(15,4))/cast(sum(coalesce(sts.ss_quantity,0)) as decimal(15,4) )) as return_ratio
+ 		,(cast(sum(coalesce(sr.sr_return_amt,0)) as decimal(15,4))/cast(sum(coalesce(sts.ss_net_paid,0)) as decimal(15,4) )) as currency_ratio
+ 		from 
+ 		store_sales sts left outer join store_returns sr
+ 			on (sts.ss_ticket_number = sr.sr_ticket_number and sts.ss_item_sk = sr.sr_item_sk)
+                ,date_dim
+ 		where 
+ 			sr.sr_return_amt > 10000 
+ 			and sts.ss_net_profit > 1
+                         and sts.ss_net_paid > 0 
+                         and sts.ss_quantity > 0
+                         and ss_sold_date_sk = d_date_sk
+                         and d_year = [YEAR]
+                         and d_moy = [MONTH]
+ 		group by sts.ss_item_sk
+ 	) in_store
+ ) store
+ where  (
+ store.return_rank <= 10
+ or 
+ store.currency_rank <= 10
+ )
+ )
+ order by 1,4,5,2
+ ;
+```
+
+## Expected Output
+```json
+[
+  {"channel": "catalog", "item": "A", "return_ratio": 0.3, "return_rank": 1, "currency_rank": 1},
+  {"channel": "catalog", "item": "C", "return_ratio": 0.15, "return_rank": 2, "currency_rank": 2},
+  {"channel": "store", "item": "A", "return_ratio": 0.25, "return_rank": 1, "currency_rank": 1},
+  {"channel": "store", "item": "E", "return_ratio": 0.4, "return_rank": 3, "currency_rank": 2},
+  {"channel": "web", "item": "A", "return_ratio": 0.2, "return_rank": 1, "currency_rank": 1},
+  {"channel": "web", "item": "B", "return_ratio": 0.5, "return_rank": 2, "currency_rank": 2},
+  {"channel": "web", "item": "C", "return_ratio": 0.1, "return_rank": 5, "currency_rank": 3}
+]
+```

--- a/tests/dataset/tpc-dc/q49.mochi
+++ b/tests/dataset/tpc-dc/q49.mochi
@@ -1,0 +1,48 @@
+let web = [
+  { item: "A", return_ratio: 0.2, currency_ratio: 0.3, return_rank: 1, currency_rank: 1 },
+  { item: "B", return_ratio: 0.5, currency_ratio: 0.6, return_rank: 2, currency_rank: 2 },
+  { item: "C", return_ratio: 0.1, currency_ratio: 0.2, return_rank: 5, currency_rank: 3 },
+  { item: "D", return_ratio: 0.9, currency_ratio: 0.7, return_rank: 12, currency_rank: 12 }
+]
+
+let catalog = [
+  { item: "A", return_ratio: 0.3, currency_ratio: 0.4, return_rank: 1, currency_rank: 1 },
+  { item: "C", return_ratio: 0.15, currency_ratio: 0.25, return_rank: 2, currency_rank: 2 }
+]
+
+let store = [
+  { item: "A", return_ratio: 0.25, currency_ratio: 0.35, return_rank: 1, currency_rank: 1 },
+  { item: "E", return_ratio: 0.4, currency_ratio: 0.5, return_rank: 3, currency_rank: 2 }
+]
+
+let result =
+  (
+    from w in web
+    where w.return_rank <= 10 || w.currency_rank <= 10
+    select { channel: "web", item: w.item, return_ratio: w.return_ratio, return_rank: w.return_rank, currency_rank: w.currency_rank }
+  ) ++
+  (
+    from c in catalog
+    where c.return_rank <= 10 || c.currency_rank <= 10
+    select { channel: "catalog", item: c.item, return_ratio: c.return_ratio, return_rank: c.return_rank, currency_rank: c.currency_rank }
+  ) ++
+  (
+    from s in store
+    where s.return_rank <= 10 || s.currency_rank <= 10
+    select { channel: "store", item: s.item, return_ratio: s.return_ratio, return_rank: s.return_rank, currency_rank: s.currency_rank }
+  )
+  sort by [channel, return_rank, currency_rank, item]
+
+json(result)
+
+test "TPCDS Q49 simplified" {
+  expect result == [
+    { channel: "catalog", item: "A", return_ratio: 0.3, return_rank: 1, currency_rank: 1 },
+    { channel: "catalog", item: "C", return_ratio: 0.15, return_rank: 2, currency_rank: 2 },
+    { channel: "store", item: "A", return_ratio: 0.25, return_rank: 1, currency_rank: 1 },
+    { channel: "store", item: "E", return_ratio: 0.4, return_rank: 3, currency_rank: 2 },
+    { channel: "web", item: "A", return_ratio: 0.2, return_rank: 1, currency_rank: 1 },
+    { channel: "web", item: "B", return_ratio: 0.5, return_rank: 2, currency_rank: 2 },
+    { channel: "web", item: "C", return_ratio: 0.1, return_rank: 5, currency_rank: 3 }
+  ]
+}


### PR DESCRIPTION
## Summary
- add markdown and mochi examples for TPC-DC queries 40-49
- provide realistic sample data and expected outputs for each query

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6861fe455dec83209ccfd13ab65555c5