### PR TITLE
Expand TPC-DC test data

### DIFF
--- a/tests/dataset/tpc-dc/q1.mochi
+++ b/tests/dataset/tpc-dc/q1.mochi
@@ -1,12 +1,19 @@
 let store_returns = [
   {sr_customer_sk: 1, sr_store_sk: 1, sr_return_amt: 20.0, sr_returned_date_sk: 1},
-  {sr_customer_sk: 2, sr_store_sk: 1, sr_return_amt: 5.0, sr_returned_date_sk: 1}
+  {sr_customer_sk: 2, sr_store_sk: 1, sr_return_amt: 5.0, sr_returned_date_sk: 1},
+  {sr_customer_sk: 3, sr_store_sk: 1, sr_return_amt: 18.0, sr_returned_date_sk: 1},
+  {sr_customer_sk: 4, sr_store_sk: 2, sr_return_amt: 10.0, sr_returned_date_sk: 1}
 ]
 let date_dim = [{d_date_sk: 1, d_year: 2000}]
-let store = [{s_store_sk: 1, s_state: "TN"}]
+let store = [
+  {s_store_sk: 1, s_state: "TN"},
+  {s_store_sk: 2, s_state: "TN"}
+]
 let customer = [
   {c_customer_sk: 1, c_customer_id: "C1"},
-  {c_customer_sk: 2, c_customer_id: "C2"}
+  {c_customer_sk: 2, c_customer_id: "C2"},
+  {c_customer_sk: 3, c_customer_id: "C3"},
+  {c_customer_sk: 4, c_customer_id: "C4"}
 ]
 
 let customer_total_return =
@@ -32,5 +39,8 @@ let result =
 json(result)
 
 test "TPCDC Q1 sample" {
-  expect result == [{c_customer_id: "C1"}]
+  expect result == [
+    {c_customer_id: "C1"},
+    {c_customer_id: "C3"}
+  ]
 }

--- a/tests/dataset/tpc-dc/q2.mochi
+++ b/tests/dataset/tpc-dc/q2.mochi
@@ -1,13 +1,26 @@
 let web_sales = [
   {ws_sold_date_sk: 1, ws_ext_sales_price: 100.0},
-  {ws_sold_date_sk: 8, ws_ext_sales_price: 200.0}
+  {ws_sold_date_sk: 2, ws_ext_sales_price: 50.0},
+  {ws_sold_date_sk: 8, ws_ext_sales_price: 200.0},
+  {ws_sold_date_sk: 9, ws_ext_sales_price: 150.0},
+  {ws_sold_date_sk: 15, ws_ext_sales_price: 120.0},
+  {ws_sold_date_sk: 22, ws_ext_sales_price: 220.0}
 ]
 let catalog_sales = [
-  {cs_sold_date_sk: 1, cs_ext_sales_price: 50.0}
+  {cs_sold_date_sk: 1, cs_ext_sales_price: 50.0},
+  {cs_sold_date_sk: 2, cs_ext_sales_price: 60.0},
+  {cs_sold_date_sk: 8, cs_ext_sales_price: 80.0},
+  {cs_sold_date_sk: 9, cs_ext_sales_price: 40.0},
+  {cs_sold_date_sk: 15, cs_ext_sales_price: 80.0},
+  {cs_sold_date_sk: 22, cs_ext_sales_price: 100.0}
 ]
 let date_dim = [
   {d_date_sk: 1, d_day_name: "Sunday", d_week_seq: 1, d_year: 2001},
-  {d_date_sk: 8, d_day_name: "Sunday", d_week_seq: 1, d_year: 2002}
+  {d_date_sk: 2, d_day_name: "Monday", d_week_seq: 1, d_year: 2001},
+  {d_date_sk: 8, d_day_name: "Sunday", d_week_seq: 1, d_year: 2002},
+  {d_date_sk: 9, d_day_name: "Monday", d_week_seq: 1, d_year: 2002},
+  {d_date_sk: 15, d_day_name: "Sunday", d_week_seq: 2, d_year: 2001},
+  {d_date_sk: 22, d_day_name: "Sunday", d_week_seq: 2, d_year: 2002}
 ]
 
 let wscs =
@@ -38,5 +51,8 @@ let result =
 json(result)
 
 test "TPCDC Q2 weekly ratio" {
-  expect result == [{d_week_seq: 1, sun_ratio: round(150.0 / 200.0, 2)}]
+  expect result == [
+    {d_week_seq: 1, sun_ratio: round(260.0 / 470.0, 2)},
+    {d_week_seq: 2, sun_ratio: round(200.0 / 320.0, 2)}
+  ]
 }

--- a/tests/dataset/tpc-dc/q3.mochi
+++ b/tests/dataset/tpc-dc/q3.mochi
@@ -1,11 +1,19 @@
-let date_dim = [{d_date_sk: 1, d_year: 2000, d_moy: 11}]
+let date_dim = [
+  {d_date_sk: 1, d_year: 2000, d_moy: 11},
+  {d_date_sk: 2, d_year: 2000, d_moy: 11},
+  {d_date_sk: 3, d_year: 2000, d_moy: 12},
+  {d_date_sk: 4, d_year: 2001, d_moy: 11}
+]
 let store_sales = [
   {ss_sold_date_sk: 1, ss_item_sk: 1, ss_ext_sales_price: 100.0},
-  {ss_sold_date_sk: 1, ss_item_sk: 2, ss_ext_sales_price: 80.0}
+  {ss_sold_date_sk: 2, ss_item_sk: 2, ss_ext_sales_price: 50.0},
+  {ss_sold_date_sk: 3, ss_item_sk: 1, ss_ext_sales_price: 70.0},
+  {ss_sold_date_sk: 4, ss_item_sk: 1, ss_ext_sales_price: 80.0}
 ]
 let item = [
   {i_item_sk: 1, i_brand_id: 10, i_brand: "B1", i_manufact_id: 128},
-  {i_item_sk: 2, i_brand_id: 20, i_brand: "B2", i_manufact_id: 129}
+  {i_item_sk: 2, i_brand_id: 10, i_brand: "B1", i_manufact_id: 128},
+  {i_item_sk: 3, i_brand_id: 20, i_brand: "B2", i_manufact_id: 129}
 ]
 
 let result =
@@ -20,5 +28,8 @@ let result =
 json(result)
 
 test "TPCDC Q3 brand sales" {
-  expect result == [{d_year: 2000, brand_id: 10, brand: "B1", sum_agg: 100.0}]
+  expect result == [
+    {d_year: 2000, brand_id: 10, brand: "B1", sum_agg: 150.0},
+    {d_year: 2001, brand_id: 10, brand: "B1", sum_agg: 80.0}
+  ]
 }

--- a/tests/dataset/tpc-dc/q4.mochi
+++ b/tests/dataset/tpc-dc/q4.mochi
@@ -1,14 +1,20 @@
 let store_totals = [
   {customer_id: "C1", year: 2001, total: 100.0},
-  {customer_id: "C1", year: 2002, total: 40.0}
+  {customer_id: "C1", year: 2002, total: 40.0},
+  {customer_id: "C2", year: 2001, total: 80.0},
+  {customer_id: "C2", year: 2002, total: 90.0}
 ]
 let catalog_totals = [
   {customer_id: "C1", year: 2001, total: 80.0},
-  {customer_id: "C1", year: 2002, total: 60.0}
+  {customer_id: "C1", year: 2002, total: 60.0},
+  {customer_id: "C2", year: 2001, total: 50.0},
+  {customer_id: "C2", year: 2002, total: 80.0}
 ]
 let web_totals = [
   {customer_id: "C1", year: 2001, total: 60.0},
-  {customer_id: "C1", year: 2002, total: 20.0}
+  {customer_id: "C1", year: 2002, total: 20.0},
+  {customer_id: "C2", year: 2001, total: 40.0},
+  {customer_id: "C2", year: 2002, total: 30.0}
 ]
 
 let result =
@@ -25,5 +31,8 @@ let result =
 json(result)
 
 test "TPCDC Q4 simplified" {
-  expect result == [{customer_id: "C1"}]
+  expect result == [
+    {customer_id: "C1"},
+    {customer_id: "C2"}
+  ]
 }

--- a/tests/dataset/tpc-dc/q5.mochi
+++ b/tests/dataset/tpc-dc/q5.mochi
@@ -1,15 +1,19 @@
 let store_sales = [
   {store_sk: 1, sales_price: 100.0, profit: 10.0},
-  {store_sk: 1, sales_price: 50.0, profit: 5.0}
+  {store_sk: 1, sales_price: 50.0, profit: 5.0},
+  {store_sk: 2, sales_price: 70.0, profit: 8.0}
 ]
 let store_returns = [
-  {store_sk: 1, return_amt: 10.0, net_loss: 1.0}
+  {store_sk: 1, return_amt: 10.0, net_loss: 1.0},
+  {store_sk: 2, return_amt: 5.0, net_loss: 0.5}
 ]
 let catalog_sales = [
-  {call_center_sk: 1, sales_price: 80.0, profit: 8.0}
+  {call_center_sk: 1, sales_price: 80.0, profit: 8.0},
+  {call_center_sk: 2, sales_price: 40.0, profit: 4.0}
 ]
 let catalog_returns = [
-  {call_center_sk: 1, return_amt: 5.0, net_loss: 0.5}
+  {call_center_sk: 1, return_amt: 5.0, net_loss: 0.5},
+  {call_center_sk: 2, return_amt: 2.0, net_loss: 0.2}
 ]
 
 let ss_sales = sum(from s in store_sales select s.sales_price)
@@ -20,5 +24,5 @@ let result = [{store_sales: ss_sales, catalog_sales: cs_sales}]
 json(result)
 
 test "TPCDC Q5 simplified" {
-  expect result == [{store_sales: 150.0, catalog_sales: 80.0}]
+  expect result == [{store_sales: 220.0, catalog_sales: 120.0}]
 }

--- a/tests/dataset/tpc-dc/q6.mochi
+++ b/tests/dataset/tpc-dc/q6.mochi
@@ -1,8 +1,20 @@
-let customer_address = [{ca_state: "TX", ca_address_sk: 1}]
-let customer = [{c_customer_sk: 1, c_current_addr_sk: 1}]
+let customer_address = [
+  {ca_state: "TX", ca_address_sk: 1},
+  {ca_state: "NY", ca_address_sk: 2}
+]
+let customer = [
+  {c_customer_sk: 1, c_current_addr_sk: 1},
+  {c_customer_sk: 2, c_current_addr_sk: 2}
+]
 let date_dim = [{d_date_sk: 1, d_month_seq: 1}]
-let item = [{i_item_sk: 1, i_current_price: 10.0, i_category: "A"}]
-let store_sales = [{ss_customer_sk: 1, ss_sold_date_sk: 1, ss_item_sk: 1}]
+let item = [
+  {i_item_sk: 1, i_current_price: 13.0, i_category: "A"},
+  {i_item_sk: 2, i_current_price: 8.0, i_category: "A"}
+]
+let store_sales = [
+  {ss_customer_sk: 1, ss_sold_date_sk: 1, ss_item_sk: 1},
+  {ss_customer_sk: 2, ss_sold_date_sk: 1, ss_item_sk: 2}
+]
 
 let month_seq = 1
 let avg_price = avg(from j in item where j.i_category == "A" select j.i_current_price)

--- a/tests/dataset/tpc-dc/q7.mochi
+++ b/tests/dataset/tpc-dc/q7.mochi
@@ -1,7 +1,13 @@
-let store_sales = [{ss_item_sk: 1, ss_quantity: 10, ss_list_price: 20.0, ss_coupon_amt: 1.0, ss_sales_price: 18.0, ss_sold_date_sk: 1, ss_cdemo_sk: 1, ss_promo_sk: 1}]
+let store_sales = [
+  {ss_item_sk: 1, ss_quantity: 10, ss_list_price: 20.0, ss_coupon_amt: 1.0, ss_sales_price: 18.0, ss_sold_date_sk: 1, ss_cdemo_sk: 1, ss_promo_sk: 1},
+  {ss_item_sk: 2, ss_quantity: 20, ss_list_price: 40.0, ss_coupon_amt: 2.0, ss_sales_price: 38.0, ss_sold_date_sk: 1, ss_cdemo_sk: 1, ss_promo_sk: 1}
+]
 let customer_demographics = [{cd_demo_sk: 1, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College"}]
 let date_dim = [{d_date_sk: 1, d_year: 2000}]
-let item = [{i_item_sk: 1, i_item_id: "I1"}]
+let item = [
+  {i_item_sk: 1, i_item_id: "I1"},
+  {i_item_sk: 2, i_item_id: "I2"}
+]
 let promotion = [{p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y"}]
 
 let result =
@@ -17,9 +23,13 @@ let result =
           agg2: avg(from x in g select x.ss_list_price),
           agg3: avg(from x in g select x.ss_coupon_amt),
           agg4: avg(from x in g select x.ss_sales_price)}
+  sort by i_item_id
 
 json(result)
 
 test "TPCDC Q7 simplified" {
-  expect result == [{i_item_id: "I1", agg1: 10.0, agg2: 20.0, agg3: 1.0, agg4: 18.0}]
+  expect result == [
+    {i_item_id: "I1", agg1: 10.0, agg2: 20.0, agg3: 1.0, agg4: 18.0},
+    {i_item_id: "I2", agg1: 20.0, agg2: 40.0, agg3: 2.0, agg4: 38.0}
+  ]
 }

--- a/tests/dataset/tpc-dc/q8.mochi
+++ b/tests/dataset/tpc-dc/q8.mochi
@@ -1,5 +1,11 @@
-let store_sales = [{ss_store_sk: 1, ss_sold_date_sk: 1, ss_net_profit: 10.0}]
-let store = [{s_store_sk: 1, s_store_name: "Store1", s_zip: "12345"}]
+let store_sales = [
+  {ss_store_sk: 1, ss_sold_date_sk: 1, ss_net_profit: 10.0},
+  {ss_store_sk: 2, ss_sold_date_sk: 1, ss_net_profit: 15.0}
+]
+let store = [
+  {s_store_sk: 1, s_store_name: "Store1", s_zip: "12345"},
+  {s_store_sk: 2, s_store_name: "Store2", s_zip: "12350"}
+]
 let date_dim = [{d_date_sk: 1, d_qoy: 2, d_year: 1998}]
 let customer_address = [{ca_zip: "12345"}]
 let customer = [{c_current_addr_sk: 1}]
@@ -14,9 +20,13 @@ let result =
   where d.d_qoy == 2 && d.d_year == 1998 && substr(s.s_zip,0,2) == substr(first(valid_zips),0,2)
   group by {s_store_name: s.s_store_name} into g
   select {s_store_name: g.key.s_store_name, net: sum(from x in g select x.ss_net_profit)}
+  sort by s_store_name
 
 json(result)
 
 test "TPCDC Q8 simplified" {
-  expect result == [{s_store_name: "Store1", net: 10.0}]
+  expect result == [
+    {s_store_name: "Store1", net: 10.0},
+    {s_store_name: "Store2", net: 15.0}
+  ]
 }

--- a/tests/dataset/tpc-dc/q9.mochi
+++ b/tests/dataset/tpc-dc/q9.mochi
@@ -1,6 +1,10 @@
 let store_sales = [
   {ss_quantity: 10, ss_ext_discount_amt: 1.0, ss_net_paid: 9.0},
-  {ss_quantity: 30, ss_ext_discount_amt: 2.0, ss_net_paid: 28.0}
+  {ss_quantity: 15, ss_ext_discount_amt: 3.0, ss_net_paid: 12.0},
+  {ss_quantity: 30, ss_ext_discount_amt: 2.0, ss_net_paid: 28.0},
+  {ss_quantity: 35, ss_ext_discount_amt: 4.0, ss_net_paid: 33.0},
+  {ss_quantity: 50, ss_ext_discount_amt: 5.0, ss_net_paid: 45.0},
+  {ss_quantity: 70, ss_ext_discount_amt: 7.0, ss_net_paid: 63.0}
 ]
 let reason = [{r_reason_sk: 1}]
 
@@ -15,11 +19,13 @@ let bucket = fn(min, max) {
 
 let result = [
   bucket(1,20),
-  bucket(21,40)
+  bucket(21,40),
+  bucket(41,60),
+  bucket(61,80)
 ]
 
 json(result)
 
 test "TPCDC Q9 simplified" {
-  expect result == [1.0, 15.0]
+  expect result == [2.0, 3.0, 45.0, 63.0]
 }


### PR DESCRIPTION
## Summary
- enrich TPC-DC q1–q9 sample datasets
- update expected results for the new data

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68620665a0fc8320b52b5e51028a9a3a