### PR TITLE
Expand sample data for TPC‑DC q40‑49

### DIFF
--- a/tests/dataset/tpc-dc/q40.md
+++ b/tests/dataset/tpc-dc/q40.md
@@ -37,20 +37,26 @@ select
   {
     "w_state": "CA",
     "i_item_id": "I1",
-    "sales_before": 100.0,
+    "sales_before": 220.0,
     "sales_after": 0.0
   },
   {
     "w_state": "CA",
     "i_item_id": "I2",
     "sales_before": 0.0,
-    "sales_after": 50.0
+    "sales_after": 130.0
   },
   {
     "w_state": "NY",
     "i_item_id": "I2",
     "sales_before": 0.0,
-    "sales_after": 150.0
+    "sales_after": 250.0
+  },
+  {
+    "w_state": "TX",
+    "i_item_id": "I1",
+    "sales_before": 0.0,
+    "sales_after": 110.0
   }
 ]
 ```

--- a/tests/dataset/tpc-dc/q40.mochi
+++ b/tests/dataset/tpc-dc/q40.mochi
@@ -2,29 +2,39 @@ let catalog_sales = [
   { order: 1, item_sk: 1, warehouse_sk: 1, date_sk: 1, price: 100.0 },
   { order: 2, item_sk: 1, warehouse_sk: 1, date_sk: 2, price: 150.0 },
   { order: 3, item_sk: 2, warehouse_sk: 2, date_sk: 3, price: 200.0 },
-  { order: 4, item_sk: 2, warehouse_sk: 1, date_sk: 4, price: 50.0 }
+  { order: 4, item_sk: 2, warehouse_sk: 1, date_sk: 4, price: 50.0 },
+  { order: 5, item_sk: 1, warehouse_sk: 1, date_sk: 1, price: 120.0 },
+  { order: 6, item_sk: 2, warehouse_sk: 1, date_sk: 3, price: 80.0 },
+  { order: 7, item_sk: 3, warehouse_sk: 1, date_sk: 2, price: 100.0 },
+  { order: 8, item_sk: 2, warehouse_sk: 2, date_sk: 2, price: 130.0 },
+  { order: 9, item_sk: 1, warehouse_sk: 3, date_sk: 5, price: 110.0 }
 ]
 
 let catalog_returns = [
   { order: 2, item_sk: 1, refunded: 150.0 },
-  { order: 3, item_sk: 2, refunded: 50.0 }
+  { order: 3, item_sk: 2, refunded: 50.0 },
+  { order: 8, item_sk: 2, refunded: 30.0 },
+  { order: 9, item_sk: 1, refunded: 0.0 }
 ]
 
 let item = [
   { item_sk: 1, item_id: "I1", current_price: 1.2 },
-  { item_sk: 2, item_id: "I2", current_price: 1.1 }
+  { item_sk: 2, item_id: "I2", current_price: 1.1 },
+  { item_sk: 3, item_id: "I3", current_price: 2.2 }
 ]
 
 let warehouse = [
   { warehouse_sk: 1, state: "CA" },
-  { warehouse_sk: 2, state: "NY" }
+  { warehouse_sk: 2, state: "NY" },
+  { warehouse_sk: 3, state: "TX" }
 ]
 
 let date_dim = [
   { date_sk: 1, date: "2020-01-10" },
   { date_sk: 2, date: "2020-01-20" },
   { date_sk: 3, date: "2020-01-25" },
-  { date_sk: 4, date: "2020-02-05" }
+  { date_sk: 4, date: "2020-02-05" },
+  { date_sk: 5, date: "2020-02-15" }
 ]
 
 let sales_date = "2020-01-15"
@@ -57,8 +67,9 @@ json(result)
 
 test "TPCDS Q40 simplified" {
   expect result == [
-    { w_state: "CA", i_item_id: "I1", sales_before: 100.0, sales_after: 0.0 },
-    { w_state: "CA", i_item_id: "I2", sales_before: 0.0, sales_after: 50.0 },
-    { w_state: "NY", i_item_id: "I2", sales_before: 0.0, sales_after: 150.0 }
+    { w_state: "CA", i_item_id: "I1", sales_before: 220.0, sales_after: 0.0 },
+    { w_state: "CA", i_item_id: "I2", sales_before: 0.0, sales_after: 130.0 },
+    { w_state: "NY", i_item_id: "I2", sales_before: 0.0, sales_after: 250.0 },
+    { w_state: "TX", i_item_id: "I1", sales_before: 0.0, sales_after: 110.0 }
   ]
 }

--- a/tests/dataset/tpc-dc/q41.mochi
+++ b/tests/dataset/tpc-dc/q41.mochi
@@ -5,6 +5,8 @@ let item = [
   { product_name: "Green Shirt", manufact_id: 110, manufact: 1, category: "Women", color: "green", units: "pack", size: "L" },
   { product_name: "Grey Pants", manufact_id: 115, manufact: 1, category: "Men", color: "grey", units: "pair", size: "L" },
   { product_name: "Black Shorts", manufact_id: 125, manufact: 1, category: "Men", color: "black", units: "pair", size: "M" }
+  ,{ product_name: "Purple Scarf", manufact_id: 150, manufact: 1, category: "Women", color: "purple", units: "pack", size: "S" }
+  ,{ product_name: "White Hat", manufact_id: 130, manufact: 3, category: "Kids", color: "white", units: "each", size: "S" }
 ]
 
 let lower = 100

--- a/tests/dataset/tpc-dc/q42.mochi
+++ b/tests/dataset/tpc-dc/q42.mochi
@@ -4,12 +4,15 @@ let store_sales = [
   { sold_date_sk: 2, item_sk: 1, ext_sales_price: 15.0 },
   { sold_date_sk: 1, item_sk: 1, ext_sales_price: 5.0 },
   { sold_date_sk: 1, item_sk: 2, ext_sales_price: 30.0 }
+  ,{ sold_date_sk: 2, item_sk: 3, ext_sales_price: 5.0 }
+  ,{ sold_date_sk: 2, item_sk: 1, ext_sales_price: 5.0 }
 ]
 
 let item = [
   { i_item_sk: 1, i_manager_id: 1, i_category_id: 100, i_category: "CatA" },
   { i_item_sk: 2, i_manager_id: 1, i_category_id: 100, i_category: "CatA" },
   { i_item_sk: 3, i_manager_id: 2, i_category_id: 200, i_category: "CatB" }
+  ,{ i_item_sk: 4, i_manager_id: 2, i_category_id: 300, i_category: "CatC" }
 ]
 
 let date_dim = [

--- a/tests/dataset/tpc-dc/q43.mochi
+++ b/tests/dataset/tpc-dc/q43.mochi
@@ -10,7 +10,8 @@ let date_dim = [
 
 let store = [
   { store_sk: 1, store_id: "S1", store_name: "Main", gmt_offset: 0 },
-  { store_sk: 2, store_id: "S2", store_name: "Branch", gmt_offset: 0 }
+  { store_sk: 2, store_id: "S2", store_name: "Branch", gmt_offset: 0 },
+  { store_sk: 3, store_id: "S3", store_name: "Remote", gmt_offset: 5 }
 ]
 
 let store_sales = [
@@ -23,7 +24,8 @@ let store_sales = [
   { sold_date_sk: 7, store_sk: 1, sales_price: 70.0 },
   { sold_date_sk: 1, store_sk: 2, sales_price: 15.0 },
   { sold_date_sk: 2, store_sk: 2, sales_price: 25.0 },
-  { sold_date_sk: 3, store_sk: 2, sales_price: 35.0 }
+  { sold_date_sk: 3, store_sk: 2, sales_price: 35.0 },
+  { sold_date_sk: 1, store_sk: 3, sales_price: 5.0 }
 ]
 
 let year = 2020

--- a/tests/dataset/tpc-dc/q44.mochi
+++ b/tests/dataset/tpc-dc/q44.mochi
@@ -4,12 +4,17 @@ let store_sales = [
   { ss_item_sk: 2, ss_store_sk: 1, ss_net_profit: -1.0 },
   { ss_item_sk: 3, ss_store_sk: 1, ss_net_profit: 8.0 },
   { ss_item_sk: 3, ss_store_sk: 1, ss_net_profit: 7.0 }
+  ,{ ss_item_sk: 4, ss_store_sk: 1, ss_net_profit: 6.0 }
+  ,{ ss_item_sk: 4, ss_store_sk: 1, ss_net_profit: 4.0 }
+  ,{ ss_item_sk: 5, ss_store_sk: 1, ss_net_profit: 2.0 }
 ]
 
 let item = [
   { i_item_sk: 1, i_product_name: "ItemA" },
   { i_item_sk: 2, i_product_name: "ItemB" },
   { i_item_sk: 3, i_product_name: "ItemC" }
+  ,{ i_item_sk: 4, i_product_name: "ItemD" }
+  ,{ i_item_sk: 5, i_product_name: "ItemE" }
 ]
 
 let grouped =

--- a/tests/dataset/tpc-dc/q45.mochi
+++ b/tests/dataset/tpc-dc/q45.mochi
@@ -4,18 +4,22 @@ let web_sales = [
   { bill_customer_sk: 1, item_sk: 2, sold_date_sk: 1, sales_price: 40.0 },
   { bill_customer_sk: 1, item_sk: 1, sold_date_sk: 1, sales_price: 10.0 },
   { bill_customer_sk: 3, item_sk: 1, sold_date_sk: 1, sales_price: 20.0 }
+  ,{ bill_customer_sk: 4, item_sk: 1, sold_date_sk: 1, sales_price: 40.0 }
+  ,{ bill_customer_sk: 2, item_sk: 1, sold_date_sk: 2, sales_price: 60.0 }
 ]
 
 let customer = [
   { c_customer_sk: 1, c_current_addr_sk: 1 },
   { c_customer_sk: 2, c_current_addr_sk: 2 },
   { c_customer_sk: 3, c_current_addr_sk: 3 }
+  ,{ c_customer_sk: 4, c_current_addr_sk: 4 }
 ]
 
 let customer_address = [
   { ca_address_sk: 1, ca_zip: "85669" },
   { ca_address_sk: 2, ca_zip: "99999" },
-  { ca_address_sk: 3, ca_zip: "80348" }
+  { ca_address_sk: 3, ca_zip: "80348" },
+  { ca_address_sk: 4, ca_zip: "70000" }
 ]
 
 let item = [

--- a/tests/dataset/tpc-dc/q46.mochi
+++ b/tests/dataset/tpc-dc/q46.mochi
@@ -1,13 +1,14 @@
 let store_sales = [
   { ss_ticket_number: 1, ss_customer_sk: 1, ss_addr_sk: 1, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_coupon_amt: 5.0, ss_net_profit: 20.0 },
-  { ss_ticket_number: 2, ss_customer_sk: 1, ss_addr_sk: 2, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_coupon_amt: 2.0, ss_net_profit: 10.0 }
+  { ss_ticket_number: 2, ss_customer_sk: 1, ss_addr_sk: 2, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_coupon_amt: 2.0, ss_net_profit: 10.0 },
+  { ss_ticket_number: 3, ss_customer_sk: 2, ss_addr_sk: 1, ss_hdemo_sk: 2, ss_store_sk: 2, ss_sold_date_sk: 1, ss_coupon_amt: 1.0, ss_net_profit: 5.0 }
 ]
 
-let date_dim = [ { d_date_sk: 1, d_dow: 6, d_year: 2020 } ]
-let store = [ { s_store_sk: 1, s_city: "CityA" } ]
-let household_demographics = [ { hd_demo_sk: 1, hd_dep_count: 2, hd_vehicle_count: 0 } ]
+let date_dim = [ { d_date_sk: 1, d_dow: 6, d_year: 2020 }, { d_date_sk: 2, d_dow: 1, d_year: 2021 } ]
+let store = [ { s_store_sk: 1, s_city: "CityA" }, { s_store_sk: 2, s_city: "CityB" } ]
+let household_demographics = [ { hd_demo_sk: 1, hd_dep_count: 2, hd_vehicle_count: 0 }, { hd_demo_sk: 2, hd_dep_count: 1, hd_vehicle_count: 2 } ]
 let customer_address = [ { ca_address_sk: 1, ca_city: "Portland" }, { ca_address_sk: 2, ca_city: "Seattle" } ]
-let customer = [ { c_customer_sk: 1, c_last_name: "Doe", c_first_name: "John", c_current_addr_sk: 2 } ]
+let customer = [ { c_customer_sk: 1, c_last_name: "Doe", c_first_name: "John", c_current_addr_sk: 2 }, { c_customer_sk: 2, c_last_name: "Smith", c_first_name: "Jane", c_current_addr_sk: 1 } ]
 
 let depcnt = 2
 let vehcnt = 0

--- a/tests/dataset/tpc-dc/q47.mochi
+++ b/tests/dataset/tpc-dc/q47.mochi
@@ -3,7 +3,10 @@ let v2 = [
   { d_year: 2020, item: "B", avg_monthly_sales: 80.0, sum_sales: 70.0 },
   { d_year: 2019, item: "C", avg_monthly_sales: 50.0, sum_sales: 60.0 },
   { d_year: 2020, item: "D", avg_monthly_sales: 50.0, sum_sales: 45.0 },
-  { d_year: 2020, item: "E", avg_monthly_sales: 75.0, sum_sales: 70.0 }
+  { d_year: 2020, item: "E", avg_monthly_sales: 75.0, sum_sales: 70.0 },
+  { d_year: 2020, item: "F", avg_monthly_sales: 0.0, sum_sales: 0.0 },
+  { d_year: 2020, item: "G", avg_monthly_sales: 100.0, sum_sales: 105.0 },
+  { d_year: 2018, item: "H", avg_monthly_sales: 90.0, sum_sales: 110.0 }
 ]
 
 let year = 2020

--- a/tests/dataset/tpc-dc/q48.mochi
+++ b/tests/dataset/tpc-dc/q48.mochi
@@ -4,6 +4,8 @@ let store_sales = [
   { cdemo_sk: 3, addr_sk: 3, sold_date_sk: 1, sales_price: 170.0, net_profit: 10000.0, quantity: 20 },
   { cdemo_sk: 1, addr_sk: 2, sold_date_sk: 1, sales_price: 110.0, net_profit: 160.0, quantity: 7 },
   { cdemo_sk: 3, addr_sk: 3, sold_date_sk: 1, sales_price: 180.0, net_profit: 20000.0, quantity: 10 }
+  ,{ cdemo_sk: 2, addr_sk: 2, sold_date_sk: 2, sales_price: 80.0, net_profit: 1000.0, quantity: 3 }
+  ,{ cdemo_sk: 3, addr_sk: 3, sold_date_sk: 1, sales_price: 220.0, net_profit: 300.0, quantity: 5 }
 ]
 
 let store = [ { s_store_sk: 1 } ]

--- a/tests/dataset/tpc-dc/q49.mochi
+++ b/tests/dataset/tpc-dc/q49.mochi
@@ -3,16 +3,19 @@ let web = [
   { item: "B", return_ratio: 0.5, currency_ratio: 0.6, return_rank: 2, currency_rank: 2 },
   { item: "C", return_ratio: 0.1, currency_ratio: 0.2, return_rank: 5, currency_rank: 3 },
   { item: "D", return_ratio: 0.9, currency_ratio: 0.7, return_rank: 12, currency_rank: 12 }
+  ,{ item: "F", return_ratio: 0.05, currency_ratio: 0.1, return_rank: 20, currency_rank: 20 }
 ]
 
 let catalog = [
   { item: "A", return_ratio: 0.3, currency_ratio: 0.4, return_rank: 1, currency_rank: 1 },
   { item: "C", return_ratio: 0.15, currency_ratio: 0.25, return_rank: 2, currency_rank: 2 }
+  ,{ item: "G", return_ratio: 0.05, currency_ratio: 0.05, return_rank: 11, currency_rank: 11 }
 ]
 
 let store = [
   { item: "A", return_ratio: 0.25, currency_ratio: 0.35, return_rank: 1, currency_rank: 1 },
   { item: "E", return_ratio: 0.4, currency_ratio: 0.5, return_rank: 3, currency_rank: 2 }
+  ,{ item: "H", return_ratio: 0.2, currency_ratio: 0.9, return_rank: 15, currency_rank: 15 }
 ]
 
 let result =


### PR DESCRIPTION
## Summary
- add more catalog sales data and expected output for `q40`
- enrich `q41`‑`q49` datasets with extra rows

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686206726e5083208df8df2e36f393b9