### PR TITLE
Enhance TPC‑DC sample data q60‑q69

### DIFF
--- a/tests/dataset/tpc-dc/q60.mochi
+++ b/tests/dataset/tpc-dc/q60.mochi
@@ -1,27 +1,40 @@
-// Minimal dataset for TPC-DC Q60
+// Expanded dataset for TPC-DC Q60
 let item = [
   { i_item_sk: 1, i_item_id: "I1", i_category: "Music" },
-  { i_item_sk: 2, i_item_id: "I2", i_category: "Electronics" }
+  { i_item_sk: 2, i_item_id: "I2", i_category: "Electronics" },
+  { i_item_sk: 3, i_item_id: "I3", i_category: "Music" }
 ]
 
 let date_dim = [
-  { d_date_sk: 1, d_year: 1998, d_moy: 9 }
+  { d_date_sk: 1, d_year: 1998, d_moy: 9 },
+  { d_date_sk: 2, d_year: 1998, d_moy: 10 }
 ]
 
 let customer_address = [
-  { ca_address_sk: 10, ca_gmt_offset: -5 }
+  { ca_address_sk: 10, ca_gmt_offset: -5 },
+  { ca_address_sk: 11, ca_gmt_offset: -4 }
 ]
 
 let store_sales = [
-  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_addr_sk: 10, ss_ext_sales_price: 100 }
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_addr_sk: 10, ss_ext_sales_price: 100 },
+  { ss_item_sk: 1, ss_sold_date_sk: 2, ss_addr_sk: 10, ss_ext_sales_price: 100 },
+  { ss_item_sk: 3, ss_sold_date_sk: 1, ss_addr_sk: 10, ss_ext_sales_price: 50 },
+  { ss_item_sk: 2, ss_sold_date_sk: 1, ss_addr_sk: 10, ss_ext_sales_price: 80 },
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_addr_sk: 11, ss_ext_sales_price: 30 }
 ]
 
 let catalog_sales = [
-  { cs_item_sk: 1, cs_sold_date_sk: 1, cs_bill_addr_sk: 10, cs_ext_sales_price: 50 }
+  { cs_item_sk: 1, cs_sold_date_sk: 1, cs_bill_addr_sk: 10, cs_ext_sales_price: 50 },
+  { cs_item_sk: 3, cs_sold_date_sk: 1, cs_bill_addr_sk: 10, cs_ext_sales_price: 20 },
+  { cs_item_sk: 1, cs_sold_date_sk: 2, cs_bill_addr_sk: 10, cs_ext_sales_price: 20 },
+  { cs_item_sk: 1, cs_sold_date_sk: 1, cs_bill_addr_sk: 11, cs_ext_sales_price: 10 }
 ]
 
 let web_sales = [
-  { ws_item_sk: 1, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 30 }
+  { ws_item_sk: 1, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 30 },
+  { ws_item_sk: 3, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 40 },
+  { ws_item_sk: 1, ws_sold_date_sk: 2, ws_bill_addr_sk: 10, ws_ext_sales_price: 15 },
+  { ws_item_sk: 2, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 15 }
 ]
 
 let ss =
@@ -60,5 +73,8 @@ let result =
 json(result)
 
 test "TPCDC Q60 aggregates sales across channels" {
-  expect result == [{i_item_id: "I1", total_sales: 180}]
+  expect result == [
+    {i_item_id: "I1", total_sales: 180},
+    {i_item_id: "I3", total_sales: 110}
+  ]
 }

--- a/tests/dataset/tpc-dc/q61.mochi
+++ b/tests/dataset/tpc-dc/q61.mochi
@@ -9,7 +9,8 @@ let store = [
 ]
 
 let date_dim = [
-  { d_date_sk: 1, d_year: 1998, d_moy: 11 }
+  { d_date_sk: 1, d_year: 1998, d_moy: 11 },
+  { d_date_sk: 2, d_year: 1998, d_moy: 12 }
 ]
 
 let customer = [
@@ -26,7 +27,9 @@ let item = [
 
 let store_sales = [
   { ss_ext_sales_price: 100.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 1, ss_customer_sk: 1, ss_item_sk: 1 },
-  { ss_ext_sales_price: 200.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 2, ss_customer_sk: 1, ss_item_sk: 1 }
+  { ss_ext_sales_price: 200.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 2, ss_customer_sk: 1, ss_item_sk: 1 },
+  { ss_ext_sales_price: 150.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 1, ss_customer_sk: 1, ss_item_sk: 1 },
+  { ss_ext_sales_price: 80.0, ss_sold_date_sk: 2, ss_store_sk: 1, ss_promo_sk: 1, ss_customer_sk: 1, ss_item_sk: 1 }
 ]
 
 let promotional_sales =
@@ -67,5 +70,5 @@ let result = [{ promotions: promotions, total: total, pct: promotions * 100 / to
 json(result)
 
 test "TPCDC Q61 ratio of promotional to total sales" {
-  expect result == [{promotions: 100.0, total: 300.0, pct: 33.333333333333336}]
+  expect result == [{promotions: 250.0, total: 450.0, pct: 55.55555555555556}]
 }

--- a/tests/dataset/tpc-dc/q62.mochi
+++ b/tests/dataset/tpc-dc/q62.mochi
@@ -17,7 +17,9 @@ let date_dim = [
   { d_date_sk: 80, d_month_seq: 1200 },
   { d_date_sk: 120, d_month_seq: 1200 },
   { d_date_sk: 150, d_month_seq: 1200 },
-  { d_date_sk: 200, d_month_seq: 1200 }
+  { d_date_sk: 200, d_month_seq: 1200 },
+  { d_date_sk: 25, d_month_seq: 1200 },
+  { d_date_sk: 115, d_month_seq: 1200 }
 ]
 
 let web_sales = [
@@ -25,7 +27,9 @@ let web_sales = [
   { ws_ship_date_sk: 80, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 },   // 40 days
   { ws_ship_date_sk: 120, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 },  // 80 days
   { ws_ship_date_sk: 150, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 },  // 110 days
-  { ws_ship_date_sk: 200, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 }   // 160 days
+  { ws_ship_date_sk: 200, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 },   // 160 days
+  { ws_ship_date_sk: 25, ws_sold_date_sk: 5, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 },     // 20 days
+  { ws_ship_date_sk: 115, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 }    // 75 days
 ]
 
 let result =
@@ -50,5 +54,5 @@ let result =
 json(result)
 
 test "TPCDC Q62 shipping days buckets" {
-  expect result == [{warehouse: "MainWarehouse", sm_type: "AIR", web_name: "WebStore", d30: 1, d31_60: 1, d61_90: 1, d91_120: 1, d120_plus: 1}]
+  expect result == [{warehouse: "MainWarehouse", sm_type: "AIR", web_name: "WebStore", d30: 2, d31_60: 1, d61_90: 2, d91_120: 1, d120_plus: 1}]
 }

--- a/tests/dataset/tpc-dc/q63.mochi
+++ b/tests/dataset/tpc-dc/q63.mochi
@@ -5,12 +5,16 @@ let item = [
 
 let store_sales = [
   { ss_item_sk: 1, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 10.0 },
-  { ss_item_sk: 1, ss_sold_date_sk: 2, ss_store_sk: 1, ss_sales_price: 20.0 }
+  { ss_item_sk: 1, ss_sold_date_sk: 2, ss_store_sk: 1, ss_sales_price: 20.0 },
+  { ss_item_sk: 1, ss_sold_date_sk: 3, ss_store_sk: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 1, ss_sold_date_sk: 4, ss_store_sk: 1, ss_sales_price: 20.0 }
 ]
 
 let date_dim = [
   { d_date_sk: 1, d_month_seq: 1200, d_moy: 1 },
-  { d_date_sk: 2, d_month_seq: 1201, d_moy: 2 }
+  { d_date_sk: 2, d_month_seq: 1201, d_moy: 2 },
+  { d_date_sk: 3, d_month_seq: 1202, d_moy: 3 },
+  { d_date_sk: 4, d_month_seq: 1203, d_moy: 4 }
 ]
 
 let store = [
@@ -40,6 +44,8 @@ json(result)
 
 test "TPCDC Q63 monthly sales deviation" {
   expect result == [
+    { i_manager_id: 101, sum_sales: 10.0, avg_monthly_sales: 15.0 },
+    { i_manager_id: 101, sum_sales: 20.0, avg_monthly_sales: 15.0 },
     { i_manager_id: 101, sum_sales: 10.0, avg_monthly_sales: 15.0 },
     { i_manager_id: 101, sum_sales: 20.0, avg_monthly_sales: 15.0 }
   ]

--- a/tests/dataset/tpc-dc/q64.mochi
+++ b/tests/dataset/tpc-dc/q64.mochi
@@ -7,7 +7,15 @@ let cross_sales = [
   { product_name: "P1", item_sk: 1, store_name: "Store1", store_zip: "10001",
     b_street_number: "10", b_streen_name: "Main", b_city: "CityA", b_zip: "Z1",
     c_street_number: "20", c_street_name: "Second", c_city: "CityB", c_zip: "Z2",
-    syear: 2000, cnt: 4, s1: 8, s2: 18, s3: 4 }
+    syear: 2000, cnt: 4, s1: 8, s2: 18, s3: 4 },
+  { product_name: "P2", item_sk: 2, store_name: "Store1", store_zip: "10001",
+    b_street_number: "10", b_streen_name: "Main", b_city: "CityA", b_zip: "Z1",
+    c_street_number: "20", c_street_name: "Second", c_city: "CityB", c_zip: "Z2",
+    syear: 1999, cnt: 6, s1: 12, s2: 24, s3: 6 },
+  { product_name: "P2", item_sk: 2, store_name: "Store1", store_zip: "10001",
+    b_street_number: "10", b_streen_name: "Main", b_city: "CityA", b_zip: "Z1",
+    c_street_number: "20", c_street_name: "Second", c_city: "CityB", c_zip: "Z2",
+    syear: 2000, cnt: 5, s1: 10, s2: 22, s3: 5 }
 ]
 
 let result =
@@ -45,11 +53,20 @@ let result =
 json(result)
 
 test "TPCDC Q64 compare cross year sales" {
-  expect result == [{
-    product_name: "P1", store_name: "Store1", store_zip: "10001",
-    b_street_number: "10", b_streen_name: "Main", b_city: "CityA", b_zip: "Z1",
-    c_street_number: "20", c_street_name: "Second", c_city: "CityB", c_zip: "Z2",
-    syear: 1999, cnt: 5, s1: 10, s2: 20, s3: 5,
-    s1_2: 8, s2_2: 18, s3_2: 4, syear_2: 2000, cnt_2: 4
-  }]
+  expect result == [
+    {
+      product_name: "P1", store_name: "Store1", store_zip: "10001",
+      b_street_number: "10", b_streen_name: "Main", b_city: "CityA", b_zip: "Z1",
+      c_street_number: "20", c_street_name: "Second", c_city: "CityB", c_zip: "Z2",
+      syear: 1999, cnt: 5, s1: 10, s2: 20, s3: 5,
+      s1_2: 8, s2_2: 18, s3_2: 4, syear_2: 2000, cnt_2: 4
+    },
+    {
+      product_name: "P2", store_name: "Store1", store_zip: "10001",
+      b_street_number: "10", b_streen_name: "Main", b_city: "CityA", b_zip: "Z1",
+      c_street_number: "20", c_street_name: "Second", c_city: "CityB", c_zip: "Z2",
+      syear: 1999, cnt: 6, s1: 12, s2: 24, s3: 6,
+      s1_2: 10, s2_2: 22, s3_2: 5, syear_2: 2000, cnt_2: 5
+    }
+  ]
 }

--- a/tests/dataset/tpc-dc/q65.mochi
+++ b/tests/dataset/tpc-dc/q65.mochi
@@ -5,7 +5,8 @@ let store = [
 
 let item = [
   { i_item_sk: 1, i_item_desc: "Item1", i_current_price: 12.0, i_wholesale_cost: 8.0, i_brand: "Brand1" },
-  { i_item_sk: 2, i_item_desc: "Item2", i_current_price: 10.0, i_wholesale_cost: 7.0, i_brand: "Brand2" }
+  { i_item_sk: 2, i_item_desc: "Item2", i_current_price: 10.0, i_wholesale_cost: 7.0, i_brand: "Brand2" },
+  { i_item_sk: 3, i_item_desc: "Item3", i_current_price: 9.0, i_wholesale_cost: 6.0, i_brand: "Brand3" }
 ]
 
 let date_dim = [
@@ -16,7 +17,9 @@ let date_dim = [
 let store_sales = [
   { ss_store_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_sales_price: 100.0 },
   { ss_store_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 2, ss_sales_price: 50.0 },
-  { ss_store_sk: 1, ss_item_sk: 2, ss_sold_date_sk: 1, ss_sales_price: 5.0 }
+  { ss_store_sk: 1, ss_item_sk: 2, ss_sold_date_sk: 1, ss_sales_price: 5.0 },
+  { ss_store_sk: 1, ss_item_sk: 3, ss_sold_date_sk: 1, ss_sales_price: 2.0 },
+  { ss_store_sk: 1, ss_item_sk: 3, ss_sold_date_sk: 2, ss_sales_price: 3.0 }
 ]
 
 let sales =
@@ -43,5 +46,8 @@ let result =
 json(result)
 
 test "TPCDC Q65 low selling items" {
-  expect result == [{ s_store_name: "Store1", i_item_desc: "Item2", revenue: 5.0, i_current_price: 10.0, i_wholesale_cost: 7.0, i_brand: "Brand2" }]
+  expect result == [
+    { s_store_name: "Store1", i_item_desc: "Item2", revenue: 5.0, i_current_price: 10.0, i_wholesale_cost: 7.0, i_brand: "Brand2" },
+    { s_store_name: "Store1", i_item_desc: "Item3", revenue: 5.0, i_current_price: 9.0, i_wholesale_cost: 6.0, i_brand: "Brand3" }
+  ]
 }

--- a/tests/dataset/tpc-dc/q66.mochi
+++ b/tests/dataset/tpc-dc/q66.mochi
@@ -2,7 +2,10 @@
 let x = [
   { w_warehouse_name: "Wh1", w_warehouse_sq_ft: 1000.0, w_city: "City1", w_county: "County1", w_state: "ST", w_country: "USA", ship_carriers: "DHL,BARIAN", year: 2001,
     jan_sales: 10.0, feb_sales: 20.0, mar_sales: 0.0, apr_sales: 0.0, may_sales: 0.0, jun_sales: 0.0, jul_sales: 0.0, aug_sales: 0.0, sep_sales: 0.0, oct_sales: 0.0, nov_sales: 0.0, dec_sales: 0.0,
-    jan_net: 9.0, feb_net: 18.0, mar_net: 0.0, apr_net: 0.0, may_net: 0.0, jun_net: 0.0, jul_net: 0.0, aug_net: 0.0, sep_net: 0.0, oct_net: 0.0, nov_net: 0.0, dec_net: 0.0 }
+    jan_net: 9.0, feb_net: 18.0, mar_net: 0.0, apr_net: 0.0, may_net: 0.0, jun_net: 0.0, jul_net: 0.0, aug_net: 0.0, sep_net: 0.0, oct_net: 0.0, nov_net: 0.0, dec_net: 0.0 },
+  { w_warehouse_name: "Wh1", w_warehouse_sq_ft: 1000.0, w_city: "City1", w_county: "County1", w_state: "ST", w_country: "USA", ship_carriers: "DHL,BARIAN", year: 2002,
+    jan_sales: 5.0, feb_sales: 15.0, mar_sales: 0.0, apr_sales: 0.0, may_sales: 0.0, jun_sales: 0.0, jul_sales: 0.0, aug_sales: 0.0, sep_sales: 0.0, oct_sales: 0.0, nov_sales: 0.0, dec_sales: 0.0,
+    jan_net: 4.0, feb_net: 12.0, mar_net: 0.0, apr_net: 0.0, may_net: 0.0, jun_net: 0.0, jul_net: 0.0, aug_net: 0.0, sep_net: 0.0, oct_net: 0.0, nov_net: 0.0, dec_net: 0.0 }
 ]
 
 let result =
@@ -63,5 +66,10 @@ test "TPCDC Q66 yearly warehouse totals" {
     jan_sales: 10.0, feb_sales: 20.0, mar_sales: 0.0, apr_sales: 0.0, may_sales: 0.0, jun_sales: 0.0, jul_sales: 0.0, aug_sales: 0.0, sep_sales: 0.0, oct_sales: 0.0, nov_sales: 0.0, dec_sales: 0.0,
     jan_sales_per_sq_foot: 0.01, feb_sales_per_sq_foot: 0.02, mar_sales_per_sq_foot: 0.0, apr_sales_per_sq_foot: 0.0, may_sales_per_sq_foot: 0.0, jun_sales_per_sq_foot: 0.0, jul_sales_per_sq_foot: 0.0, aug_sales_per_sq_foot: 0.0, sep_sales_per_sq_foot: 0.0, oct_sales_per_sq_foot: 0.0, nov_sales_per_sq_foot: 0.0, dec_sales_per_sq_foot: 0.0,
     jan_net: 9.0, feb_net: 18.0, mar_net: 0.0, apr_net: 0.0, may_net: 0.0, jun_net: 0.0, jul_net: 0.0, aug_net: 0.0, sep_net: 0.0, oct_net: 0.0, nov_net: 0.0, dec_net: 0.0
+  },{
+    w_warehouse_name: "Wh1", w_warehouse_sq_ft: 1000.0, w_city: "City1", w_county: "County1", w_state: "ST", w_country: "USA", ship_carriers: "DHL,BARIAN", year: 2002,
+    jan_sales: 5.0, feb_sales: 15.0, mar_sales: 0.0, apr_sales: 0.0, may_sales: 0.0, jun_sales: 0.0, jul_sales: 0.0, aug_sales: 0.0, sep_sales: 0.0, oct_sales: 0.0, nov_sales: 0.0, dec_sales: 0.0,
+    jan_sales_per_sq_foot: 0.005, feb_sales_per_sq_foot: 0.015, mar_sales_per_sq_foot: 0.0, apr_sales_per_sq_foot: 0.0, may_sales_per_sq_foot: 0.0, jun_sales_per_sq_foot: 0.0, jul_sales_per_sq_foot: 0.0, aug_sales_per_sq_foot: 0.0, sep_sales_per_sq_foot: 0.0, oct_sales_per_sq_foot: 0.0, nov_sales_per_sq_foot: 0.0, dec_sales_per_sq_foot: 0.0,
+    jan_net: 4.0, feb_net: 12.0, mar_net: 0.0, apr_net: 0.0, may_net: 0.0, jun_net: 0.0, jul_net: 0.0, aug_net: 0.0, sep_net: 0.0, oct_net: 0.0, nov_net: 0.0, dec_net: 0.0
   }]
 }

--- a/tests/dataset/tpc-dc/q67.mochi
+++ b/tests/dataset/tpc-dc/q67.mochi
@@ -1,6 +1,7 @@
 // Minimal dataset for TPC-DC Q67
 let item = [
-  { i_item_sk: 1, i_category: "Cat1", i_class: "Class1", i_brand: "Brand1", i_product_name: "Prod1" }
+  { i_item_sk: 1, i_category: "Cat1", i_class: "Class1", i_brand: "Brand1", i_product_name: "Prod1" },
+  { i_item_sk: 2, i_category: "Cat1", i_class: "Class2", i_brand: "Brand2", i_product_name: "Prod2" }
 ]
 
 let store = [
@@ -12,7 +13,8 @@ let date_dim = [
 ]
 
 let store_sales = [
-  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 10.0, ss_quantity: 1 }
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 10.0, ss_quantity: 1 },
+  { ss_item_sk: 2, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 5.0, ss_quantity: 3 }
 ]
 
 let dw1 =

--- a/tests/dataset/tpc-dc/q68.mochi
+++ b/tests/dataset/tpc-dc/q68.mochi
@@ -1,6 +1,8 @@
 // Minimal dataset for TPC-DC Q68
 let store_sales = [
-  { ss_ticket_number: 1, ss_customer_sk: 1, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 100.0, ss_ext_list_price: 120.0, ss_ext_tax: 5.0 }
+  { ss_ticket_number: 1, ss_customer_sk: 1, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 100.0, ss_ext_list_price: 120.0, ss_ext_tax: 5.0 },
+  { ss_ticket_number: 2, ss_customer_sk: 2, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 200.0, ss_ext_list_price: 250.0, ss_ext_tax: 10.0 },
+  { ss_ticket_number: 3, ss_customer_sk: 3, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 50.0, ss_ext_list_price: 70.0, ss_ext_tax: 2.0 }
 ]
 
 let date_dim = [
@@ -21,7 +23,9 @@ let customer_address = [
 ]
 
 let customer = [
-  { c_customer_sk: 1, c_current_addr_sk: 20, c_last_name: "Doe", c_first_name: "John" }
+  { c_customer_sk: 1, c_current_addr_sk: 20, c_last_name: "Doe", c_first_name: "John" },
+  { c_customer_sk: 2, c_current_addr_sk: 20, c_last_name: "Smith", c_first_name: "Jane" },
+  { c_customer_sk: 3, c_current_addr_sk: 10, c_last_name: "Brown", c_first_name: "Bob" }
 ]
 
 let current_addr = customer_address
@@ -66,5 +70,8 @@ let result =
 json(result)
 
 test "TPCDC Q68 sales by customer city" {
-  expect result == [{ c_last_name: "Doe", c_first_name: "John", ca_city: "City2", bought_city: "City1", ss_ticket_number: 1, extended_price: 100.0, extended_tax: 5.0, list_price: 120.0 }]
+  expect result == [
+    { c_last_name: "Doe", c_first_name: "John", ca_city: "City2", bought_city: "City1", ss_ticket_number: 1, extended_price: 100.0, extended_tax: 5.0, list_price: 120.0 },
+    { c_last_name: "Smith", c_first_name: "Jane", ca_city: "City2", bought_city: "City1", ss_ticket_number: 2, extended_price: 200.0, extended_tax: 10.0, list_price: 250.0 }
+  ]
 }

--- a/tests/dataset/tpc-dc/q69.mochi
+++ b/tests/dataset/tpc-dc/q69.mochi
@@ -1,18 +1,24 @@
 // Minimal dataset for TPC-DC Q69
 let customer = [
-  { c_customer_sk: 1, c_current_addr_sk: 10, c_current_cdemo_sk: 100 }
+  { c_customer_sk: 1, c_current_addr_sk: 10, c_current_cdemo_sk: 100 },
+  { c_customer_sk: 2, c_current_addr_sk: 11, c_current_cdemo_sk: 100 },
+  { c_customer_sk: 3, c_current_addr_sk: 11, c_current_cdemo_sk: 101 }
 ]
 
 let customer_address = [
-  { ca_address_sk: 10, ca_state: "KY" }
+  { ca_address_sk: 10, ca_state: "KY" },
+  { ca_address_sk: 11, ca_state: "GA" }
 ]
 
 let customer_demographics = [
-  { cd_demo_sk: 100, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College", cd_purchase_estimate: 1000, cd_credit_rating: "Good" }
+  { cd_demo_sk: 100, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College", cd_purchase_estimate: 1000, cd_credit_rating: "Good" },
+  { cd_demo_sk: 101, cd_gender: "F", cd_marital_status: "S", cd_education_status: "College", cd_purchase_estimate: 500, cd_credit_rating: "Excellent" }
 ]
 
 let store_sales = [
-  { ss_customer_sk: 1, ss_sold_date_sk: 1 }
+  { ss_customer_sk: 1, ss_sold_date_sk: 1 },
+  { ss_customer_sk: 2, ss_sold_date_sk: 1 },
+  { ss_customer_sk: 3, ss_sold_date_sk: 1 }
 ]
 
 let web_sales = []
@@ -45,5 +51,8 @@ let result =
 json(result)
 
 test "TPCDC Q69 customer demographics" {
-  expect result == [{ cd_gender: "M", cd_marital_status: "S", cd_education_status: "College", cnt1: 1, cd_purchase_estimate: 1000, cnt2: 1, cd_credit_rating: "Good", cnt3: 1 }]
+  expect result == [
+    { cd_gender: "F", cd_marital_status: "S", cd_education_status: "College", cnt1: 1, cd_purchase_estimate: 500, cnt2: 1, cd_credit_rating: "Excellent", cnt3: 1 },
+    { cd_gender: "M", cd_marital_status: "S", cd_education_status: "College", cnt1: 2, cd_purchase_estimate: 1000, cnt2: 2, cd_credit_rating: "Good", cnt3: 2 }
+  ]
 }


### PR DESCRIPTION
## Summary
- expand datasets for TPC-DC q60 through q69
- adjust expected results to match richer data

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68620679a0588320bd94d1a401a3f972