### PR TITLE
Expand TPC‑DC examples q20–q29

### DIFF
--- a/tests/dataset/tpc-dc/q20.mochi
+++ b/tests/dataset/tpc-dc/q20.mochi
@@ -18,9 +18,15 @@ type Item {
 type DateDim { d_date_sk: int, d_date: string }
 
 let catalog_sales = [
+  // two qualifying rows for ITEM1
   { cs_item_sk: 1, cs_sold_date_sk: 1, cs_ext_sales_price: 100.0 },
   { cs_item_sk: 1, cs_sold_date_sk: 1, cs_ext_sales_price: 200.0 },
-  { cs_item_sk: 2, cs_sold_date_sk: 1, cs_ext_sales_price: 150.0 }
+  // one qualifying row for ITEM2
+  { cs_item_sk: 2, cs_sold_date_sk: 1, cs_ext_sales_price: 150.0 },
+  // ITEM3 falls outside the category filter
+  { cs_item_sk: 3, cs_sold_date_sk: 1, cs_ext_sales_price: 50.0 },
+  // ITEM4 uses a date outside the range filter
+  { cs_item_sk: 4, cs_sold_date_sk: 2, cs_ext_sales_price: 120.0 }
 ]
 
 let item = [
@@ -39,10 +45,29 @@ let item = [
     i_category: "A",
     i_class: "X",
     i_current_price: 20.0
+  },
+  {
+    i_item_sk: 3,
+    i_item_id: "ITEM3",
+    i_item_desc: "Item Three",
+    i_category: "D",
+    i_class: "X",
+    i_current_price: 15.0
+  },
+  {
+    i_item_sk: 4,
+    i_item_id: "ITEM4",
+    i_item_desc: "Item Four",
+    i_category: "B",
+    i_class: "Y",
+    i_current_price: 25.0
   }
 ]
 
-let date_dim = [ { d_date_sk: 1, d_date: "2000-02-10" } ]
+let date_dim = [
+  { d_date_sk: 1, d_date: "2000-02-10" },
+  { d_date_sk: 2, d_date: "2000-04-05" }
+]
 
 let filtered =
   from cs in catalog_sales

--- a/tests/dataset/tpc-dc/q21.mochi
+++ b/tests/dataset/tpc-dc/q21.mochi
@@ -6,13 +6,30 @@ type Item { i_item_sk: int, i_item_id: string }
 type DateDim { d_date_sk: int, d_date: string }
 
 let inventory = [
+  // ITEM1 in Main warehouse (qualifies)
   { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 30 },
-  { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 40 }
+  { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 40 },
+  // ITEM1 in Secondary warehouse - ratio too high
+  { inv_item_sk: 1, inv_warehouse_sk: 2, inv_date_sk: 1, inv_quantity_on_hand: 100 },
+  { inv_item_sk: 1, inv_warehouse_sk: 2, inv_date_sk: 2, inv_quantity_on_hand: 200 },
+  // ITEM2 in Main warehouse - ratio too high
+  { inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 10 },
+  { inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 40 }
 ]
 
-let warehouse = [ { w_warehouse_sk: 1, w_warehouse_name: "Main" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
-let date_dim = [ { d_date_sk: 1, d_date: "2000-03-01" }, { d_date_sk: 2, d_date: "2000-03-20" } ]
+let warehouse = [
+  { w_warehouse_sk: 1, w_warehouse_name: "Main" },
+  { w_warehouse_sk: 2, w_warehouse_name: "Secondary" }
+]
+let item = [
+  { i_item_sk: 1, i_item_id: "ITEM1" },
+  { i_item_sk: 2, i_item_id: "ITEM2" }
+]
+let date_dim = [
+  { d_date_sk: 1, d_date: "2000-03-01" },
+  { d_date_sk: 2, d_date: "2000-03-20" },
+  { d_date_sk: 3, d_date: "2000-04-10" }
+]
 
 let before =
   from inv in inventory

--- a/tests/dataset/tpc-dc/q22.mochi
+++ b/tests/dataset/tpc-dc/q22.mochi
@@ -12,10 +12,16 @@ type Item {
 
 let inventory = [
   { inv_item_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 10 },
-  { inv_item_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 20 }
+  { inv_item_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 20 },
+  // ITEM2 inventory outside month range
+  { inv_item_sk: 2, inv_date_sk: 3, inv_quantity_on_hand: 5 }
 ]
 
-let date_dim = [ { d_date_sk: 1, d_month_seq: 0 }, { d_date_sk: 2, d_month_seq: 1 } ]
+let date_dim = [
+  { d_date_sk: 1, d_month_seq: 0 },
+  { d_date_sk: 2, d_month_seq: 1 },
+  { d_date_sk: 3, d_month_seq: 12 }
+]
 
 let item = [
   {
@@ -24,6 +30,13 @@ let item = [
     i_brand: "Brand1",
     i_class: "Class1",
     i_category: "Cat1"
+  },
+  {
+    i_item_sk: 2,
+    i_product_name: "Prod2",
+    i_brand: "Brand2",
+    i_class: "Class2",
+    i_category: "Cat2"
   }
 ]
 

--- a/tests/dataset/tpc-dc/q23.mochi
+++ b/tests/dataset/tpc-dc/q23.mochi
@@ -12,20 +12,34 @@ let store_sales = [
   { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
   { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
   { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
-  { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 }
+  { ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 1, ss_quantity: 2, ss_sales_price: 10.0 },
+  // extra sales for a different customer/item that do not qualify
+  { ss_customer_sk: 2, ss_item_sk: 2, ss_sold_date_sk: 1, ss_quantity: 1, ss_sales_price: 5.0 },
+  { ss_customer_sk: 2, ss_item_sk: 2, ss_sold_date_sk: 2, ss_quantity: 1, ss_sales_price: 5.0 }
 ]
 
 let catalog_sales = [
-  { cs_bill_customer_sk: 1, cs_item_sk: 1, cs_sold_date_sk: 1, cs_quantity: 1, cs_list_price: 20.0 }
+  { cs_bill_customer_sk: 1, cs_item_sk: 1, cs_sold_date_sk: 1, cs_quantity: 1, cs_list_price: 20.0 },
+  { cs_bill_customer_sk: 2, cs_item_sk: 2, cs_sold_date_sk: 2, cs_quantity: 2, cs_list_price: 15.0 }
 ]
 
 let web_sales = [
-  { ws_bill_customer_sk: 1, ws_item_sk: 1, ws_sold_date_sk: 1, ws_quantity: 1, ws_list_price: 30.0 }
+  { ws_bill_customer_sk: 1, ws_item_sk: 1, ws_sold_date_sk: 1, ws_quantity: 1, ws_list_price: 30.0 },
+  { ws_bill_customer_sk: 2, ws_item_sk: 2, ws_sold_date_sk: 2, ws_quantity: 1, ws_list_price: 8.0 }
 ]
 
-let customer = [ { c_customer_sk: 1, c_last_name: "Smith", c_first_name: "Ann" } ]
-let item = [ { i_item_sk: 1, i_item_desc: "Item1" } ]
-let date_dim = [ { d_date_sk: 1, d_year: 2000, d_moy: 1 } ]
+let customer = [
+  { c_customer_sk: 1, c_last_name: "Smith", c_first_name: "Ann" },
+  { c_customer_sk: 2, c_last_name: "Doe", c_first_name: "Bob" }
+]
+let item = [
+  { i_item_sk: 1, i_item_desc: "Item1" },
+  { i_item_sk: 2, i_item_desc: "Item2" }
+]
+let date_dim = [
+  { d_date_sk: 1, d_year: 2000, d_moy: 1 },
+  { d_date_sk: 2, d_year: 2000, d_moy: 2 }
+]
 
 let frequent_items =
   from ss in store_sales

--- a/tests/dataset/tpc-dc/q24.mochi
+++ b/tests/dataset/tpc-dc/q24.mochi
@@ -8,18 +8,31 @@ type Customer { c_customer_sk: int, c_first_name: string, c_last_name: string, c
 type CustomerAddress { ca_address_sk: int, ca_state: string, ca_country: string, ca_zip: string }
 
 let store_sales = [
-  { ss_ticket_number: 1, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_net_paid: 100.0 }
+  { ss_ticket_number: 1, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_net_paid: 100.0 },
+  { ss_ticket_number: 2, ss_item_sk: 2, ss_customer_sk: 2, ss_store_sk: 1, ss_net_paid: 50.0 }
 ]
 
-let store_returns = [ { sr_ticket_number: 1, sr_item_sk: 1 } ]
+let store_returns = [
+  { sr_ticket_number: 1, sr_item_sk: 1 },
+  { sr_ticket_number: 2, sr_item_sk: 2 }
+]
 
 let store = [ { s_store_sk: 1, s_store_name: "Store1", s_market_id: 5, s_state: "CA", s_zip: "12345" } ]
 
-let item = [ { i_item_sk: 1, i_color: "RED", i_current_price: 10.0, i_manager_id: 1, i_units: "EA", i_size: "M" } ]
+let item = [
+  { i_item_sk: 1, i_color: "RED", i_current_price: 10.0, i_manager_id: 1, i_units: "EA", i_size: "M" },
+  { i_item_sk: 2, i_color: "BLUE", i_current_price: 12.0, i_manager_id: 2, i_units: "EA", i_size: "L" }
+]
 
-let customer = [ { c_customer_sk: 1, c_first_name: "Ann", c_last_name: "Smith", c_current_addr_sk: 1, c_birth_country: "Canada" } ]
+let customer = [
+  { c_customer_sk: 1, c_first_name: "Ann", c_last_name: "Smith", c_current_addr_sk: 1, c_birth_country: "Canada" },
+  { c_customer_sk: 2, c_first_name: "Jane", c_last_name: "Doe", c_current_addr_sk: 2, c_birth_country: "USA" }
+]
 
-let customer_address = [ { ca_address_sk: 1, ca_state: "CA", ca_country: "USA", ca_zip: "12345" } ]
+let customer_address = [
+  { ca_address_sk: 1, ca_state: "CA", ca_country: "USA", ca_zip: "12345" },
+  { ca_address_sk: 2, ca_state: "NV", ca_country: "USA", ca_zip: "54321" }
+]
 
 let ssales =
   from ss in store_sales

--- a/tests/dataset/tpc-dc/q25.mochi
+++ b/tests/dataset/tpc-dc/q25.mochi
@@ -8,25 +8,32 @@ type Store { s_store_sk: int, s_store_id: string, s_store_name: string }
 type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
 
 let store_sales = [
-  { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_net_profit: 50.0, ss_ticket_number: 1 }
+  { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_net_profit: 50.0, ss_ticket_number: 1 },
+  { ss_sold_date_sk: 2, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_net_profit: 5.0, ss_ticket_number: 2 }
 ]
 
 let store_returns = [
-  { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_net_loss: 10.0 }
+  { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_net_loss: 10.0 },
+  { sr_returned_date_sk: 3, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_net_loss: 1.0 }
 ]
 
 let catalog_sales = [
-  { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_net_profit: 30.0 }
+  { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_net_profit: 30.0 },
+  { cs_sold_date_sk: 4, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_net_profit: 2.0 }
 ]
 
 let date_dim = [
   { d_date_sk: 1, d_moy: 4, d_year: 2000 },
   { d_date_sk: 2, d_moy: 5, d_year: 2000 },
-  { d_date_sk: 3, d_moy: 6, d_year: 2000 }
+  { d_date_sk: 3, d_moy: 6, d_year: 2000 },
+  { d_date_sk: 4, d_moy: 11, d_year: 2000 }
 ]
 
 let store = [ { s_store_sk: 1, s_store_id: "S1", s_store_name: "Store1" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" } ]
+let item = [
+  { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" },
+  { i_item_sk: 2, i_item_id: "ITEM2", i_item_desc: "Desc2" }
+]
 
 let result =
   from ss in store_sales

--- a/tests/dataset/tpc-dc/q26.mochi
+++ b/tests/dataset/tpc-dc/q26.mochi
@@ -17,16 +17,18 @@ type Item { i_item_sk: int, i_item_id: string }
 type Promotion { p_promo_sk: int, p_channel_email: string, p_channel_event: string }
 
 let catalog_sales = [
-  { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_promo_sk: 1, cs_quantity: 10, cs_list_price: 100.0, cs_coupon_amt: 5.0, cs_sales_price: 95.0 }
+  { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_promo_sk: 1, cs_quantity: 10, cs_list_price: 100.0, cs_coupon_amt: 5.0, cs_sales_price: 95.0 },
+  { cs_sold_date_sk: 2, cs_item_sk: 2, cs_bill_cdemo_sk: 2, cs_promo_sk: 2, cs_quantity: 5, cs_list_price: 50.0, cs_coupon_amt: 0.0, cs_sales_price: 50.0 }
 ]
 
 let customer_demographics = [
-  { cd_demo_sk: 1, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College" }
+  { cd_demo_sk: 1, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College" },
+  { cd_demo_sk: 2, cd_gender: "F", cd_marital_status: "M", cd_education_status: "High School" }
 ]
 
-let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
-let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" } ]
+let date_dim = [ { d_date_sk: 1, d_year: 2000 }, { d_date_sk: 2, d_year: 1999 } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" } ]
+let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" }, { p_promo_sk: 2, p_channel_email: "Y", p_channel_event: "Y" } ]
 
 let result =
   from cs in catalog_sales

--- a/tests/dataset/tpc-dc/q27.mochi
+++ b/tests/dataset/tpc-dc/q27.mochi
@@ -7,13 +7,14 @@ type Store { s_store_sk: int, s_state: string }
 type Item { i_item_sk: int, i_item_id: string }
 
 let store_sales = [
-  { ss_item_sk: 1, ss_store_sk: 1, ss_cdemo_sk: 1, ss_sold_date_sk: 1, ss_quantity: 5, ss_list_price: 100.0, ss_coupon_amt: 10.0, ss_sales_price: 90.0 }
+  { ss_item_sk: 1, ss_store_sk: 1, ss_cdemo_sk: 1, ss_sold_date_sk: 1, ss_quantity: 5, ss_list_price: 100.0, ss_coupon_amt: 10.0, ss_sales_price: 90.0 },
+  { ss_item_sk: 2, ss_store_sk: 2, ss_cdemo_sk: 2, ss_sold_date_sk: 1, ss_quantity: 3, ss_list_price: 50.0, ss_coupon_amt: 5.0, ss_sales_price: 45.0 }
 ]
 
-let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" } ]
+let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" }, { cd_demo_sk: 2, cd_gender: "M", cd_marital_status: "S", cd_education_status: "High" } ]
 let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
-let store = [ { s_store_sk: 1, s_state: "CA" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
+let store = [ { s_store_sk: 1, s_state: "CA" }, { s_store_sk: 2, s_state: "NY" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" } ]
 
 let result =
   from ss in store_sales

--- a/tests/dataset/tpc-dc/q28.mochi
+++ b/tests/dataset/tpc-dc/q28.mochi
@@ -4,7 +4,8 @@ type StoreSale { ss_quantity: int, ss_list_price: float, ss_coupon_amt: float, s
 
 let store_sales = [
   { ss_quantity: 3, ss_list_price: 100.0, ss_coupon_amt: 50.0, ss_wholesale_cost: 30.0 },
-  { ss_quantity: 8, ss_list_price: 80.0, ss_coupon_amt: 10.0, ss_wholesale_cost: 20.0 }
+  { ss_quantity: 8, ss_list_price: 80.0, ss_coupon_amt: 10.0, ss_wholesale_cost: 20.0 },
+  { ss_quantity: 15, ss_list_price: 70.0, ss_coupon_amt: 5.0, ss_wholesale_cost: 25.0 }
 ]
 
 let bucket1 =

--- a/tests/dataset/tpc-dc/q29.mochi
+++ b/tests/dataset/tpc-dc/q29.mochi
@@ -7,18 +7,19 @@ type DateDim { d_date_sk: int, d_moy: int, d_year: int }
 type Store { s_store_sk: int, s_store_id: string, s_store_name: string }
 type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
 
-let store_sales = [ { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 10, ss_ticket_number: 1 } ]
-let store_returns = [ { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_return_quantity: 2 } ]
-let catalog_sales = [ { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 5 } ]
+let store_sales = [ { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 10, ss_ticket_number: 1 }, { ss_sold_date_sk: 2, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_quantity: 4, ss_ticket_number: 2 } ]
+let store_returns = [ { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_return_quantity: 2 }, { sr_returned_date_sk: 3, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_return_quantity: 1 } ]
+let catalog_sales = [ { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 5 }, { cs_sold_date_sk: 4, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_quantity: 1 } ]
 
 let date_dim = [
   { d_date_sk: 1, d_moy: 4, d_year: 1999 },
   { d_date_sk: 2, d_moy: 5, d_year: 1999 },
-  { d_date_sk: 3, d_moy: 5, d_year: 2000 }
+  { d_date_sk: 3, d_moy: 5, d_year: 2000 },
+  { d_date_sk: 4, d_moy: 8, d_year: 2001 }
 ]
 
 let store = [ { s_store_sk: 1, s_store_id: "S1", s_store_name: "Store1" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" }, { i_item_sk: 2, i_item_id: "ITEM2", i_item_desc: "Desc2" } ]
 
 let result =
   from ss in store_sales


### PR DESCRIPTION
## Summary
- enrich TPC‑DC sample data for q20–q29
- keep expected query results the same

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862066bbea88320ae56c8da8dc41220