### PR TITLE
Improve TPC-DC q50–59 examples

### DIFF
--- a/tests/dataset/tpc-dc/q50.md
+++ b/tests/dataset/tpc-dc/q50.md
@@ -78,10 +78,10 @@ Sample output for the small dataset defined in `q50.mochi`:
     "s_state": "CA",
     "s_zip": "12345",
     "30 days": 1,
-    "31-60 days": 0,
+    "31-60 days": 1,
     "61-90 days": 1,
-    "91-120 days": 0,
-    ">120 days": 0
+    "91-120 days": 1,
+    ">120 days": 1
   }
 ]
 ```

--- a/tests/dataset/tpc-dc/q50.mochi
+++ b/tests/dataset/tpc-dc/q50.mochi
@@ -1,11 +1,18 @@
+// Expanded dataset with one sale/return for each return bucket
 let store_sales = [
-  {ticket: 1, item: 100, sold_date: 1, customer: 1, store: 1},
-  {ticket: 2, item: 101, sold_date: 10, customer: 2, store: 1}
+  {ticket: 1, item: 100, sold_date: 1,  customer: 1, store: 1},  // <30 days
+  {ticket: 2, item: 101, sold_date: 10, customer: 2, store: 1}, // 31-60 days
+  {ticket: 3, item: 102, sold_date: 30, customer: 1, store: 1}, // 61-90 days
+  {ticket: 4, item: 103, sold_date: 40, customer: 2, store: 1}, // 91-120 days
+  {ticket: 5, item: 104, sold_date: 50, customer: 1, store: 1}  // >120 days
 ]
 
 let store_returns = [
-  {ticket: 1, item: 100, returned_date: 21, customer: 1},
-  {ticket: 2, item: 101, returned_date: 70, customer: 2}
+  {ticket: 1, item: 100, returned_date: 21,  customer: 1},  // diff 20
+  {ticket: 2, item: 101, returned_date: 50,  customer: 2},  // diff 40
+  {ticket: 3, item: 102, returned_date: 100, customer: 1},  // diff 70
+  {ticket: 4, item: 103, returned_date: 140, customer: 2},  // diff 100
+  {ticket: 5, item: 104, returned_date: 180, customer: 1}   // diff 130
 ]
 
 let store = [
@@ -25,10 +32,16 @@ let store = [
 ]
 
 let date_dim = [
-  {date_sk: 1, year: 2000, month: 1},
-  {date_sk: 10, year: 2000, month: 1},
-  {date_sk: 21, year: 2000, month: 1},
-  {date_sk: 70, year: 2000, month: 2}
+  {date_sk: 1,   year: 2000, month: 1},
+  {date_sk: 10,  year: 2000, month: 1},
+  {date_sk: 21,  year: 2000, month: 1},
+  {date_sk: 30,  year: 2000, month: 1},
+  {date_sk: 40,  year: 2000, month: 1},
+  {date_sk: 50,  year: 2000, month: 1},
+  {date_sk: 100, year: 2000, month: 1},
+  {date_sk: 130, year: 2000, month: 1},
+  {date_sk: 140, year: 2000, month: 1},
+  {date_sk: 180, year: 2000, month: 1}
 ]
 
 let result =
@@ -83,9 +96,9 @@ test "TPCDC Q50 return days by store" {
     s_state: "CA",
     s_zip: "12345",
     "30 days": 1,
-    "31-60 days": 0,
+    "31-60 days": 1,
     "61-90 days": 1,
-    "91-120 days": 0,
-    ">120 days": 0
+    "91-120 days": 1,
+    ">120 days": 1
   }]
 }

--- a/tests/dataset/tpc-dc/q51.md
+++ b/tests/dataset/tpc-dc/q51.md
@@ -46,11 +46,13 @@ order by item_sk
 ```
 
 ## Expected Output
-For our small sample data the cumulative web sales exceed store sales in each month:
+For the expanded sample data the cumulative web sales exceed store sales in each month:
 ```json
 [
-  {"item_sk":1, "d_date":1, "web_sales":20, "store_sales":10},
-  {"item_sk":1, "d_date":2, "web_sales":25, "store_sales":20},
-  {"item_sk":1, "d_date":3, "web_sales":35, "store_sales":30}
+  {"item_sk":1, "d_date":1, "web_sales":10, "store_sales":5},
+  {"item_sk":1, "d_date":2, "web_sales":25, "store_sales":10},
+  {"item_sk":1, "d_date":3, "web_sales":35, "store_sales":20},
+  {"item_sk":1, "d_date":4, "web_sales":40, "store_sales":30},
+  {"item_sk":1, "d_date":5, "web_sales":60, "store_sales":45}
 ]
 ```

--- a/tests/dataset/tpc-dc/q51.mochi
+++ b/tests/dataset/tpc-dc/q51.mochi
@@ -1,45 +1,72 @@
 let date_dim = [
   {date_sk: 1, month_seq: 1},
   {date_sk: 2, month_seq: 2},
-  {date_sk: 3, month_seq: 3}
+  {date_sk: 3, month_seq: 3},
+  {date_sk: 4, month_seq: 4},
+  {date_sk: 5, month_seq: 5}
 ]
 
 let web_sales = [
-  {item_sk: 1, sold_date: 1, price: 20},
-  {item_sk: 1, sold_date: 2, price: 5},
-  {item_sk: 1, sold_date: 3, price: 10}
+  {item_sk: 1, sold_date: 1, price: 10},
+  {item_sk: 1, sold_date: 2, price: 15},
+  {item_sk: 1, sold_date: 3, price: 10},
+  {item_sk: 1, sold_date: 4, price: 5},
+  {item_sk: 1, sold_date: 5, price: 20}
 ]
 
 let store_sales = [
-  {item_sk: 1, sold_date: 1, price: 10},
-  {item_sk: 1, sold_date: 2, price: 10},
-  {item_sk: 1, sold_date: 3, price: 10}
+  {item_sk: 1, sold_date: 1, price: 5},
+  {item_sk: 1, sold_date: 2, price: 5},
+  {item_sk: 1, sold_date: 3, price: 10},
+  {item_sk: 1, sold_date: 4, price: 10},
+  {item_sk: 1, sold_date: 5, price: 15}
 ]
 
-let ws_totals =
+// Aggregate sales by date
+let ws_daily =
   from ws in web_sales
   join d in date_dim on ws.sold_date == d.date_sk
-  group by {item: ws.item_sk, date: d.date_sk} into g
-  select {item: g.key.item, date: g.key.date, sales: sum(from x in g select x.ws.price)}
+  group by {date: d.date_sk} into g
+  sort by g.key.date
+  select {date: g.key.date, sales: sum(from x in g select x.ws.price)}
 
-let ss_totals =
+let ss_daily =
   from ss in store_sales
   join d in date_dim on ss.sold_date == d.date_sk
-  group by {item: ss.item_sk, date: d.date_sk} into g
-  select {item: g.key.item, date: g.key.date, sales: sum(from x in g select x.ss.price)}
+  group by {date: d.date_sk} into g
+  sort by g.key.date
+  select {date: g.key.date, sales: sum(from x in g select x.ss.price)}
 
-let result = [
-  {item_sk:1, d_date:1, web_sales:20, store_sales:10},
-  {item_sk:1, d_date:2, web_sales:25, store_sales:20},
-  {item_sk:1, d_date:3, web_sales:35, store_sales:30}
-]
+// Compute cumulative sums
+var ws_running = []
+var ws_total = 0
+for r in ws_daily {
+  ws_total = ws_total + r.sales
+  ws_running = ws_running + [{date:r.date, total:ws_total}]
+}
+
+var ss_running = []
+var ss_total = 0
+for r in ss_daily {
+  ss_total = ss_total + r.sales
+  ss_running = ss_running + [{date:r.date, total:ss_total}]
+}
+
+var result = []
+for w in ws_running {
+  var s_total = 0
+  for s in ss_running { if s.date == w.date { s_total = s.total } }
+  result = result + [{item_sk:1, d_date:w.date, web_sales:w.total, store_sales:s_total}]
+}
 
 json(result)
 
 test "TPCDC Q51 cumulative" {
   expect result == [
-    {item_sk:1, d_date:1, web_sales:20, store_sales:10},
-    {item_sk:1, d_date:2, web_sales:25, store_sales:20},
-    {item_sk:1, d_date:3, web_sales:35, store_sales:30}
+    {item_sk:1, d_date:1, web_sales:10, store_sales:5},
+    {item_sk:1, d_date:2, web_sales:25, store_sales:10},
+    {item_sk:1, d_date:3, web_sales:35, store_sales:20},
+    {item_sk:1, d_date:4, web_sales:40, store_sales:30},
+    {item_sk:1, d_date:5, web_sales:60, store_sales:45}
   ]
 }

--- a/tests/dataset/tpc-dc/q52.md
+++ b/tests/dataset/tpc-dc/q52.md
@@ -28,6 +28,7 @@ Example result using the small dataset from `q52.mochi`:
 ```json
 [
   {"d_year":2000, "brand_id":1, "brand":"BrandA", "ext_price":150},
-  {"d_year":2000, "brand_id":2, "brand":"BrandB", "ext_price":50}
+  {"d_year":2000, "brand_id":2, "brand":"BrandB", "ext_price":75},
+  {"d_year":2000, "brand_id":3, "brand":"BrandC", "ext_price":75}
 ]
 ```

--- a/tests/dataset/tpc-dc/q52.mochi
+++ b/tests/dataset/tpc-dc/q52.mochi
@@ -1,17 +1,21 @@
 let date_dim = [
   {date_sk: 1, year: 2000, month: 1},
-  {date_sk: 2, year: 2000, month: 1}
+  {date_sk: 2, year: 2000, month: 1},
+  {date_sk: 3, year: 2000, month: 1}
 ]
 
 let item = [
   {i_item_sk: 100, i_brand_id: 1, i_brand: "BrandA", i_manager_id: 1},
-  {i_item_sk: 101, i_brand_id: 2, i_brand: "BrandB", i_manager_id: 1}
+  {i_item_sk: 101, i_brand_id: 2, i_brand: "BrandB", i_manager_id: 1},
+  {i_item_sk: 102, i_brand_id: 3, i_brand: "BrandC", i_manager_id: 1}
 ]
 
 let store_sales = [
   {ss_item_sk: 100, ss_sold_date_sk: 1, ss_ext_sales_price: 100},
   {ss_item_sk: 100, ss_sold_date_sk: 2, ss_ext_sales_price: 50},
-  {ss_item_sk: 101, ss_sold_date_sk: 1, ss_ext_sales_price: 50}
+  {ss_item_sk: 101, ss_sold_date_sk: 1, ss_ext_sales_price: 50},
+  {ss_item_sk: 101, ss_sold_date_sk: 2, ss_ext_sales_price: 25},
+  {ss_item_sk: 102, ss_sold_date_sk: 3, ss_ext_sales_price: 75}
 ]
 
 let result =
@@ -28,6 +32,7 @@ json(result)
 test "TPCDC Q52 brand totals" {
   expect result == [
     {d_year:2000, brand_id:1, brand:"BrandA", ext_price:150},
-    {d_year:2000, brand_id:2, brand:"BrandB", ext_price:50}
+    {d_year:2000, brand_id:2, brand:"BrandB", ext_price:75},
+    {d_year:2000, brand_id:3, brand:"BrandC", ext_price:75}
   ]
 }

--- a/tests/dataset/tpc-dc/q53.md
+++ b/tests/dataset/tpc-dc/q53.md
@@ -31,9 +31,10 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Sample output from `q53.mochi` using a very small dataset:
+Sample output from `q53.mochi` with two quarters of sales:
 ```json
 [
-  {"i_manufact_id":1, "sum_sales":300, "avg_quarterly_sales":150}
+  {"i_manufact_id":1, "sum_sales":300, "avg_quarterly_sales":225},
+  {"i_manufact_id":1, "sum_sales":150, "avg_quarterly_sales":225}
 ]
 ```

--- a/tests/dataset/tpc-dc/q53.mochi
+++ b/tests/dataset/tpc-dc/q53.mochi
@@ -4,14 +4,16 @@ let item = [
 
 let date_dim = [
   {d_date_sk: 1, d_qoy: 1, d_month_seq: 1},
-  {d_date_sk: 2, d_qoy: 1, d_month_seq: 2}
+  {d_date_sk: 2, d_qoy: 1, d_month_seq: 2},
+  {d_date_sk: 3, d_qoy: 2, d_month_seq: 4}
 ]
 
 let store = [ {s_store_sk: 1} ]
 
 let store_sales = [
   {ss_item_sk: 1, ss_sold_date_sk: 1, ss_store_sk:1, ss_sales_price: 100},
-  {ss_item_sk: 1, ss_sold_date_sk: 2, ss_store_sk:1, ss_sales_price: 200}
+  {ss_item_sk: 1, ss_sold_date_sk: 2, ss_store_sk:1, ss_sales_price: 200},
+  {ss_item_sk: 1, ss_sold_date_sk: 3, ss_store_sk:1, ss_sales_price: 150}
 ]
 
 let tmp =
@@ -30,5 +32,8 @@ let result =
 json(result)
 
 test "TPCDC Q53 quarterly" {
-  expect result == [{i_manufact_id:1, sum_sales:300, avg_quarterly_sales:150}]
+  expect result == [
+    {i_manufact_id:1, sum_sales:300, avg_quarterly_sales:225},
+    {i_manufact_id:1, sum_sales:150, avg_quarterly_sales:225}
+  ]
 }

--- a/tests/dataset/tpc-dc/q54.md
+++ b/tests/dataset/tpc-dc/q54.md
@@ -63,6 +63,7 @@ order by segment, num_customers
 Based on the toy data in `q54.mochi` the customers fall into revenue segments:
 ```json
 [
+  {"segment":1, "num_customers":1, "segment_base":50},
   {"segment":2, "num_customers":1, "segment_base":100},
   {"segment":3, "num_customers":1, "segment_base":150}
 ]

--- a/tests/dataset/tpc-dc/q54.mochi
+++ b/tests/dataset/tpc-dc/q54.mochi
@@ -1,13 +1,25 @@
-let catalog_sales = [{cs_bill_customer_sk:1, cs_sold_date_sk:1, cs_item_sk:1}]
+let catalog_sales = [
+  {cs_bill_customer_sk:1, cs_sold_date_sk:1, cs_item_sk:1},
+  {cs_bill_customer_sk:3, cs_sold_date_sk:1, cs_item_sk:1}
+]
 let web_sales = [{ws_bill_customer_sk:2, ws_sold_date_sk:1, ws_item_sk:1}]
 let item = [{i_item_sk:1, i_category:"Cat", i_class:"Class"}]
 let date_dim = [{d_date_sk:1, d_moy:1, d_year:2000, d_month_seq:1}]
-let customer = [{c_customer_sk:1, c_current_addr_sk:1}, {c_customer_sk:2, c_current_addr_sk:2}]
+let customer = [
+  {c_customer_sk:1, c_current_addr_sk:1},
+  {c_customer_sk:2, c_current_addr_sk:2},
+  {c_customer_sk:3, c_current_addr_sk:3}
+]
 let store_sales = [
   {ss_customer_sk:1, ss_sold_date_sk:2, ss_ext_sales_price:120},
-  {ss_customer_sk:2, ss_sold_date_sk:2, ss_ext_sales_price:160}
+  {ss_customer_sk:2, ss_sold_date_sk:2, ss_ext_sales_price:160},
+  {ss_customer_sk:3, ss_sold_date_sk:2, ss_ext_sales_price:60}
 ]
-let customer_address=[{ca_address_sk:1, ca_county:"C", ca_state:"S"},{ca_address_sk:2, ca_county:"C", ca_state:"S"}]
+let customer_address=[
+  {ca_address_sk:1, ca_county:"C", ca_state:"S"},
+  {ca_address_sk:2, ca_county:"C", ca_state:"S"},
+  {ca_address_sk:3, ca_county:"C", ca_state:"S"}
+]
 let store=[{s_store_sk:1, s_county:"C", s_state:"S"}]
 
 let my_customers =
@@ -39,6 +51,7 @@ json(result)
 
 test "TPCDC Q54 segments" {
   expect result == [
+    {segment:1, num_customers:1, segment_base:50},
     {segment:2, num_customers:1, segment_base:100},
     {segment:3, num_customers:1, segment_base:150}
   ]

--- a/tests/dataset/tpc-dc/q55.md
+++ b/tests/dataset/tpc-dc/q55.md
@@ -21,6 +21,7 @@ Query extracted from the official TPC-DS specification.
 Using the simplified dataset in `q55.mochi`:
 ```json
 [
-  {"brand_id":1, "brand":"BrandA", "ext_price":100}
+  {"brand_id":1, "brand":"BrandA", "ext_price":100},
+  {"brand_id":2, "brand":"BrandB", "ext_price":50}
 ]
 ```

--- a/tests/dataset/tpc-dc/q55.mochi
+++ b/tests/dataset/tpc-dc/q55.mochi
@@ -1,6 +1,12 @@
 let date_dim = [{d_date_sk:1, d_year:2000, d_moy:1}]
-let item = [{i_item_sk:1, i_brand_id:1, i_brand:"BrandA", i_manager_id:1}]
-let store_sales = [{ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:100}]
+let item = [
+  {i_item_sk:1, i_brand_id:1, i_brand:"BrandA", i_manager_id:1},
+  {i_item_sk:2, i_brand_id:2, i_brand:"BrandB", i_manager_id:1}
+]
+let store_sales = [
+  {ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:100},
+  {ss_item_sk:2, ss_sold_date_sk:1, ss_ext_sales_price:50}
+]
 
 let result =
   from ss in store_sales
@@ -13,5 +19,8 @@ let result =
 json(result)
 
 test "TPCDC Q55 brand manager" {
-  expect result == [{brand_id:1, brand:"BrandA", ext_price:100}]
+  expect result == [
+    {brand_id:1, brand:"BrandA", ext_price:100},
+    {brand_id:2, brand:"BrandB", ext_price:50}
+  ]
 }

--- a/tests/dataset/tpc-dc/q56.md
+++ b/tests/dataset/tpc-dc/q56.md
@@ -76,6 +76,7 @@ order by total_sales,
 The combined sales from all channels:
 ```json
 [
-  {"i_item_id":1, "total_sales":60}
+  {"i_item_id":1, "total_sales":60},
+  {"i_item_id":2, "total_sales":100}
 ]
 ```

--- a/tests/dataset/tpc-dc/q56.mochi
+++ b/tests/dataset/tpc-dc/q56.mochi
@@ -1,9 +1,21 @@
-let item = [{i_item_id:1, i_color:"Red"}]
+let item = [
+  {i_item_id:1, i_color:"Red"},
+  {i_item_id:2, i_color:"Blue"}
+]
 let date_dim = [{d_date_sk:1, d_year:2000, d_moy:1}]
 let customer_address=[{ca_address_sk:1, ca_gmt_offset:0}]
-let store_sales=[{ss_item_sk:1, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:20}]
-let catalog_sales=[{cs_item_sk:1, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:20}]
-let web_sales=[{ws_item_sk:1, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:20}]
+let store_sales=[
+  {ss_item_sk:1, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:20},
+  {ss_item_sk:2, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:30}
+]
+let catalog_sales=[
+  {cs_item_sk:1, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:20},
+  {cs_item_sk:2, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:40}
+]
+let web_sales=[
+  {ws_item_sk:1, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:20},
+  {ws_item_sk:2, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:30}
+]
 
 let ss=
   from ss in store_sales
@@ -37,5 +49,8 @@ let result=
 json(result)
 
 test "TPCDC Q56 union sales" {
-  expect result == [{i_item_id:1, total_sales:60}]
+  expect result == [
+    {i_item_id:1, total_sales:60},
+    {i_item_id:2, total_sales:100}
+  ]
 }

--- a/tests/dataset/tpc-dc/q57.md
+++ b/tests/dataset/tpc-dc/q57.md
@@ -55,6 +55,7 @@ order by sum_sales - avg_monthly_sales, [ORDERBY]
 With the dummy data the single call center shows one row:
 ```json
 [
-  {"cc_name":"CC", "sum_sales":100, "avg_monthly_sales":50}
+  {"cc_name":"CC", "sum_sales":100, "avg_monthly_sales":150},
+  {"cc_name":"CC", "sum_sales":200, "avg_monthly_sales":150}
 ]
 ```

--- a/tests/dataset/tpc-dc/q57.mochi
+++ b/tests/dataset/tpc-dc/q57.mochi
@@ -1,7 +1,13 @@
 let item=[{i_item_sk:1, i_category:"Cat", i_brand:"Brand"}]
 let call_center=[{cc_call_center_sk:1, cc_name:"CC"}]
-let date_dim=[{d_date_sk:1, d_year:2000, d_moy:1}]
-let catalog_sales=[{cs_item_sk:1, cs_sold_date_sk:1, cs_call_center_sk:1, cs_sales_price:100}]
+let date_dim=[
+  {d_date_sk:1, d_year:2000, d_moy:1},
+  {d_date_sk:2, d_year:2000, d_moy:2}
+]
+let catalog_sales=[
+  {cs_item_sk:1, cs_sold_date_sk:1, cs_call_center_sk:1, cs_sales_price:100},
+  {cs_item_sk:1, cs_sold_date_sk:2, cs_call_center_sk:1, cs_sales_price:200}
+]
 
 let v1=
   from cs in catalog_sales
@@ -27,5 +33,8 @@ let result =
 json(result)
 
 test "TPCDC Q57 call center" {
-  expect result == [{cc_name:"CC", sum_sales:100, avg_monthly_sales:50}]
+  expect result == [
+    {cc_name:"CC", sum_sales:100, avg_monthly_sales:150},
+    {cc_name:"CC", sum_sales:200, avg_monthly_sales:150}
+  ]
 }

--- a/tests/dataset/tpc-dc/q58.md
+++ b/tests/dataset/tpc-dc/q58.md
@@ -69,9 +69,10 @@ order by item_id
 ```
 
 ## Expected Output
-For our toy dataset the revenues are equal so deviations are 100%:
+For the expanded dataset two items meet the deviation criteria:
 ```json
 [
-  {"item_id":1, "average":20}
+  {"item_id":1, "average":20},
+  {"item_id":2, "average":30.666666666666668}
 ]
 ```

--- a/tests/dataset/tpc-dc/q58.mochi
+++ b/tests/dataset/tpc-dc/q58.mochi
@@ -1,8 +1,20 @@
-let item=[{i_item_id:1}]
-let date_dim=[{d_date_sk:1, d_week_seq:1, d_date:"2023-01-01"}]
-let store_sales=[{ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:20}]
-let catalog_sales=[{cs_item_sk:1, cs_sold_date_sk:1, cs_ext_sales_price:20}]
-let web_sales=[{ws_item_sk:1, ws_sold_date_sk:1, ws_ext_sales_price:20}]
+let item=[{i_item_id:1}, {i_item_id:2}]
+let date_dim=[
+  {d_date_sk:1, d_week_seq:1, d_date:"2023-01-01"},
+  {d_date_sk:2, d_week_seq:1, d_date:"2023-01-02"}
+]
+let store_sales=[
+  {ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:20},
+  {ss_item_sk:2, ss_sold_date_sk:2, ss_ext_sales_price:30}
+]
+let catalog_sales=[
+  {cs_item_sk:1, cs_sold_date_sk:1, cs_ext_sales_price:20},
+  {cs_item_sk:2, cs_sold_date_sk:2, cs_ext_sales_price:30}
+]
+let web_sales=[
+  {ws_item_sk:1, ws_sold_date_sk:1, ws_ext_sales_price:20},
+  {ws_item_sk:2, ws_sold_date_sk:2, ws_ext_sales_price:32}
+]
 
 let ss_items=
   from ss in store_sales
@@ -32,5 +44,8 @@ let combined=
 json(combined)
 
 test "TPCDC Q58 revenue parity" {
-  expect combined == [{item_id:1, average:20}]
+  expect combined == [
+    {item_id:1, average:20},
+    {item_id:2, average:30.666666666666668}
+  ]
 }

--- a/tests/dataset/tpc-dc/q59.md
+++ b/tests/dataset/tpc-dc/q59.md
@@ -34,9 +34,16 @@ order by s_store_name1,s_store_id1,d_week_seq1
 ```
 
 ## Expected Output
-The ratio between the two weeks is 1 for all days in our small dataset:
+Example ratios comparing matching weeks:
 ```json
 [
-  {"s_store_name1":"Store", "d_week_seq1":1}
+  {"s_store_name1":"Store", "d_week_seq1":1,
+   "sun_ratio":2, "mon_ratio":2, "tue_ratio":2, "wed_ratio":2,
+   "thu_ratio":2, "fri_ratio":2, "sat_ratio":2},
+  {"s_store_name1":"Store", "d_week_seq1":2,
+   "sun_ratio":0.6666666666666666, "mon_ratio":0.6666666666666666,
+   "tue_ratio":0.6666666666666666, "wed_ratio":0.6666666666666666,
+   "thu_ratio":0.6666666666666666, "fri_ratio":0.6666666666666666,
+   "sat_ratio":0.6666666666666666}
 ]
 ```

--- a/tests/dataset/tpc-dc/q59.mochi
+++ b/tests/dataset/tpc-dc/q59.mochi
@@ -1,7 +1,20 @@
-let wss=[{d_week_seq:1, ss_store_sk:1,
-  sun_sales:10, mon_sales:10, tue_sales:10, wed_sales:10, thu_sales:10, fri_sales:10, sat_sales:10}]
+let wss=[
+  {d_week_seq:1, ss_store_sk:1,
+    sun_sales:10, mon_sales:10, tue_sales:10, wed_sales:10, thu_sales:10, fri_sales:10, sat_sales:10},
+  {d_week_seq:2, ss_store_sk:1,
+    sun_sales:8, mon_sales:8, tue_sales:8, wed_sales:8, thu_sales:8, fri_sales:8, sat_sales:8},
+  {d_week_seq:53, ss_store_sk:1,
+    sun_sales:5, mon_sales:5, tue_sales:5, wed_sales:5, thu_sales:5, fri_sales:5, sat_sales:5},
+  {d_week_seq:54, ss_store_sk:1,
+    sun_sales:12, mon_sales:12, tue_sales:12, wed_sales:12, thu_sales:12, fri_sales:12, sat_sales:12}
+]
 let store=[{s_store_sk:1, s_store_name:"Store", s_store_id:1}]
-let date_dim=[{d_week_seq:1, d_month_seq:1},{d_week_seq:53, d_month_seq:13}]
+let date_dim=[
+  {d_week_seq:1, d_month_seq:1},
+  {d_week_seq:2, d_month_seq:2},
+  {d_week_seq:53, d_month_seq:13},
+  {d_week_seq:54, d_month_seq:14}
+]
 
 let y=
   from w in wss
@@ -24,10 +37,29 @@ let x=
 let result=
   from a in y
   join b in x on a.s_store_id1==b.s_store_id2 && a.d_week_seq1==b.d_week_seq2-52
-  select {s_store_name1:a.s_store_name1, d_week_seq1:a.d_week_seq1}
+  select {
+    s_store_name1:a.s_store_name1,
+    d_week_seq1:a.d_week_seq1,
+    sun_ratio:a.sun_sales1 / b.sun_sales2,
+    mon_ratio:a.mon_sales1 / b.mon_sales2,
+    tue_ratio:a.tue_sales1 / b.tue_sales2,
+    wed_ratio:a.wed_sales1 / b.wed_sales2,
+    thu_ratio:a.thu_sales1 / b.thu_sales2,
+    fri_ratio:a.fri_sales1 / b.fri_sales2,
+    sat_ratio:a.sat_sales1 / b.sat_sales2
+  }
 
 json(result)
 
 test "TPCDC Q59 ratios" {
-  expect result == [{s_store_name1:"Store", d_week_seq1:1}]
+  expect result == [
+    {s_store_name1:"Store", d_week_seq1:1,
+     sun_ratio:2, mon_ratio:2, tue_ratio:2, wed_ratio:2,
+     thu_ratio:2, fri_ratio:2, sat_ratio:2},
+    {s_store_name1:"Store", d_week_seq1:2,
+     sun_ratio:0.6666666666666666, mon_ratio:0.6666666666666666,
+     tue_ratio:0.6666666666666666, wed_ratio:0.6666666666666666,
+     thu_ratio:0.6666666666666666, fri_ratio:0.6666666666666666,
+     sat_ratio:0.6666666666666666}
+  ]
 }


### PR DESCRIPTION
## Summary
- expand datasets for queries q50–q59 with additional rows
- update query documentation with realistic sample outputs
- adjust tests to match the new sample data

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862067624a88320aed11c108cceb5cf