### PR TITLE
Add TPC-DC q11 and q12 sample datasets

### DIFF
--- a/tests/dataset/tpc-dc/q11.md
+++ b/tests/dataset/tpc-dc/q11.md
@@ -1,0 +1,90 @@
+# TPC-DC Query 11
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q11.sql--
+
+with year_total as (
+  select c_customer_id customer_id,
+         c_first_name customer_first_name,
+         c_last_name customer_last_name,
+         c_preferred_cust_flag customer_preferred_cust_flag,
+         c_birth_country customer_birth_country,
+         c_login customer_login,
+         c_email_address customer_email_address,
+         d_year dyear,
+         sum(ss_ext_list_price-ss_ext_discount_amt) year_total,
+         's' sale_type
+  from customer,
+       store_sales,
+       date_dim
+  where c_customer_sk = ss_customer_sk
+    and ss_sold_date_sk = d_date_sk
+  group by c_customer_id,
+           c_first_name,
+           c_last_name,
+           c_preferred_cust_flag,
+           c_birth_country,
+           c_login,
+           c_email_address,
+           d_year
+  union all
+  select c_customer_id customer_id,
+         c_first_name customer_first_name,
+         c_last_name customer_last_name,
+         c_preferred_cust_flag customer_preferred_cust_flag,
+         c_birth_country customer_birth_country,
+         c_login customer_login,
+         c_email_address customer_email_address,
+         d_year dyear,
+         sum(ws_ext_list_price-ws_ext_discount_amt) year_total,
+         'w' sale_type
+  from customer,
+       web_sales,
+       date_dim
+  where c_customer_sk = ws_bill_customer_sk
+    and ws_sold_date_sk = d_date_sk
+  group by c_customer_id,
+           c_first_name,
+           c_last_name,
+           c_preferred_cust_flag,
+           c_birth_country,
+           c_login,
+           c_email_address,
+           d_year
+)
+select
+       t_s_secyear.customer_id,
+       t_s_secyear.customer_first_name,
+       t_s_secyear.customer_last_name,
+       t_s_secyear.customer_preferred_cust_flag
+from year_total t_s_firstyear,
+     year_total t_s_secyear,
+     year_total t_w_firstyear,
+     year_total t_w_secyear
+where t_s_secyear.customer_id = t_s_firstyear.customer_id
+  and t_s_firstyear.customer_id = t_w_secyear.customer_id
+  and t_s_firstyear.customer_id = t_w_firstyear.customer_id
+  and t_s_firstyear.sale_type = 's'
+  and t_w_firstyear.sale_type = 'w'
+  and t_s_secyear.sale_type = 's'
+  and t_w_secyear.sale_type = 'w'
+  and t_s_firstyear.dyear = 1998
+  and t_s_secyear.dyear = 1999
+  and t_w_firstyear.dyear = 1998
+  and t_w_secyear.dyear = 1999
+  and t_s_firstyear.year_total > 0
+  and t_w_firstyear.year_total > 0
+  and case when t_w_firstyear.year_total > 0 then t_w_secyear.year_total / t_w_firstyear.year_total else 0.0 end >
+      case when t_s_firstyear.year_total > 0 then t_s_secyear.year_total / t_s_firstyear.year_total else 0.0 end
+order by t_s_secyear.customer_id,
+         t_s_secyear.customer_first_name,
+         t_s_secyear.customer_last_name,
+         t_s_secyear.customer_preferred_cust_flag
+LIMIT 100
+```
+
+## Expected Output
+Results depend on dataset scale.

--- a/tests/dataset/tpc-dc/q11.mochi
+++ b/tests/dataset/tpc-dc/q11.mochi
@@ -1,0 +1,75 @@
+let customer = [
+  {c_customer_sk: 1, c_customer_id: "C1", c_first_name: "Alice", c_last_name: "Smith", c_preferred_cust_flag: "Y", c_birth_country: "US", c_login: "alice", c_email_address: "alice@example.com"},
+  {c_customer_sk: 2, c_customer_id: "C2", c_first_name: "Bob", c_last_name: "Jones", c_preferred_cust_flag: "N", c_birth_country: "US", c_login: "bob", c_email_address: "bob@example.com"}
+]
+
+let store_sales = [
+  {ss_customer_sk: 1, ss_sold_date_sk: 1, ss_ext_list_price: 100.0, ss_ext_discount_amt: 0.0},
+  {ss_customer_sk: 1, ss_sold_date_sk: 2, ss_ext_list_price: 120.0, ss_ext_discount_amt: 0.0},
+  {ss_customer_sk: 2, ss_sold_date_sk: 1, ss_ext_list_price: 100.0, ss_ext_discount_amt: 0.0},
+  {ss_customer_sk: 2, ss_sold_date_sk: 2, ss_ext_list_price: 150.0, ss_ext_discount_amt: 0.0}
+]
+
+let web_sales = [
+  {ws_bill_customer_sk: 1, ws_sold_date_sk: 1, ws_ext_list_price: 100.0, ws_ext_discount_amt: 0.0},
+  {ws_bill_customer_sk: 1, ws_sold_date_sk: 2, ws_ext_list_price: 150.0, ws_ext_discount_amt: 0.0},
+  {ws_bill_customer_sk: 2, ws_sold_date_sk: 1, ws_ext_list_price: 100.0, ws_ext_discount_amt: 0.0},
+  {ws_bill_customer_sk: 2, ws_sold_date_sk: 2, ws_ext_list_price: 100.0, ws_ext_discount_amt: 0.0}
+]
+
+let date_dim = [
+  {d_date_sk: 1, d_year: 1998},
+  {d_date_sk: 2, d_year: 1999}
+]
+
+let store_totals =
+  from c in customer
+  join ss in store_sales on c.c_customer_sk == ss.ss_customer_sk
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, flag: c.c_preferred_cust_flag, year: d.d_year} into g
+  select {
+    customer_id: g.key.id,
+    customer_first_name: g.key.first,
+    customer_last_name: g.key.last,
+    customer_preferred_cust_flag: g.key.flag,
+    dyear: g.key.year,
+    year_total: sum(from x in g select x.ss_ext_list_price - x.ss_ext_discount_amt)
+  }
+
+let web_totals =
+  from c in customer
+  join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
+  join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, flag: c.c_preferred_cust_flag, year: d.d_year} into g
+  select {
+    customer_id: g.key.id,
+    customer_first_name: g.key.first,
+    customer_last_name: g.key.last,
+    customer_preferred_cust_flag: g.key.flag,
+    dyear: g.key.year,
+    year_total: sum(from x in g select x.ws_ext_list_price - x.ws_ext_discount_amt)
+  }
+
+let result =
+  from s1 in store_totals
+  join s2 in store_totals on s1.customer_id == s2.customer_id && s2.dyear == 1999
+  join w1 in web_totals on s1.customer_id == w1.customer_id && w1.dyear == 1998
+  join w2 in web_totals on s1.customer_id == w2.customer_id && w2.dyear == 1999
+  where s1.dyear == 1998 &&
+        s1.year_total > 0 && w1.year_total > 0 &&
+        (w2.year_total / w1.year_total) > (s2.year_total / s1.year_total)
+  sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_preferred_cust_flag]
+  select {
+    customer_id: s2.customer_id,
+    customer_first_name: s2.customer_first_name,
+    customer_last_name: s2.customer_last_name,
+    customer_preferred_cust_flag: s2.customer_preferred_cust_flag
+  }
+
+json(result)
+
+test "TPCDC Q11 ratio" {
+  expect result == [
+    {customer_id: "C1", customer_first_name: "Alice", customer_last_name: "Smith", customer_preferred_cust_flag: "Y"}
+  ]
+}

--- a/tests/dataset/tpc-dc/q12.md
+++ b/tests/dataset/tpc-dc/q12.md
@@ -1,0 +1,37 @@
+# TPC-DC Query 12
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q12.sql--
+
+select i_item_id,
+       i_item_desc,
+       i_category,
+       i_class,
+       i_current_price,
+       sum(ws_ext_sales_price) as itemrevenue,
+       sum(ws_ext_sales_price)*100/sum(sum(ws_ext_sales_price)) over (partition by i_class) as revenueratio
+from web_sales,
+     item,
+     date_dim
+where ws_item_sk = i_item_sk
+  and i_category in ('A','B','C')
+  and ws_sold_date_sk = d_date_sk
+  and d_date between cast('2000-06-01' as date) and (cast('2000-06-01' as date) + 30 days)
+group by i_item_id,
+         i_item_desc,
+         i_category,
+         i_class,
+         i_current_price
+order by i_category,
+         i_class,
+         i_item_id,
+         i_item_desc,
+         revenueratio
+LIMIT 100
+```
+
+## Expected Output
+Results depend on dataset scale.

--- a/tests/dataset/tpc-dc/q12.mochi
+++ b/tests/dataset/tpc-dc/q12.mochi
@@ -1,0 +1,95 @@
+// Web sales revenue ratio by class for select categories
+
+type WebSale { ws_item_sk: int, ws_sold_date_sk: int, ws_ext_sales_price: float }
+type Item { i_item_sk: int, i_item_id: string, i_item_desc: string, i_category: string, i_class: string, i_current_price: float }
+type DateDim { d_date_sk: int, d_date: string }
+
+let web_sales = [
+  // two qualifying rows for ITEM1
+  { ws_item_sk: 1, ws_sold_date_sk: 1, ws_ext_sales_price: 100.0 },
+  { ws_item_sk: 1, ws_sold_date_sk: 1, ws_ext_sales_price: 200.0 },
+  // one qualifying row for ITEM2
+  { ws_item_sk: 2, ws_sold_date_sk: 1, ws_ext_sales_price: 150.0 },
+  // ITEM3 falls outside the category filter
+  { ws_item_sk: 3, ws_sold_date_sk: 1, ws_ext_sales_price: 50.0 },
+  // ITEM4 uses a date outside the range
+  { ws_item_sk: 4, ws_sold_date_sk: 2, ws_ext_sales_price: 120.0 }
+]
+
+let item = [
+  { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Item One", i_category: "A", i_class: "X", i_current_price: 10.0 },
+  { i_item_sk: 2, i_item_id: "ITEM2", i_item_desc: "Item Two", i_category: "A", i_class: "X", i_current_price: 20.0 },
+  { i_item_sk: 3, i_item_id: "ITEM3", i_item_desc: "Item Three", i_category: "D", i_class: "X", i_current_price: 15.0 },
+  { i_item_sk: 4, i_item_id: "ITEM4", i_item_desc: "Item Four", i_category: "B", i_class: "Y", i_current_price: 25.0 }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_date: "2000-06-10" },
+  { d_date_sk: 2, d_date: "2000-08-05" }
+]
+
+let filtered =
+  from ws in web_sales
+  join i in item on ws.ws_item_sk == i.i_item_sk
+  join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  where i.i_category in ["A", "B", "C"] &&
+        d.d_date >= "2000-06-01" && d.d_date <= "2000-07-01"
+  group by {
+    id: i.i_item_id,
+    desc: i.i_item_desc,
+    cat: i.i_category,
+    class: i.i_class,
+    price: i.i_current_price
+  } into g
+  select {
+    i_item_id: g.key.id,
+    i_item_desc: g.key.desc,
+    i_category: g.key.cat,
+    i_class: g.key.class,
+    i_current_price: g.key.price,
+    itemrevenue: sum(from x in g select x.ws_ext_sales_price)
+  }
+
+let class_totals =
+  from f in filtered
+  group by f.i_class into g
+  select { class: g.key, total: sum(from x in g select x.itemrevenue) }
+
+let result =
+  from f in filtered
+  join t in class_totals on f.i_class == t.class
+  sort by [f.i_category, f.i_class, f.i_item_id, f.i_item_desc, (f.itemrevenue * 100.0) / t.total]
+  select {
+    i_item_id: f.i_item_id,
+    i_item_desc: f.i_item_desc,
+    i_category: f.i_category,
+    i_class: f.i_class,
+    i_current_price: f.i_current_price,
+    itemrevenue: f.itemrevenue,
+    revenueratio: (f.itemrevenue * 100.0) / t.total
+  }
+
+json(result)
+
+test "TPCDC Q12 revenue ratio" {
+  expect result == [
+    {
+      i_item_id: "ITEM1",
+      i_item_desc: "Item One",
+      i_category: "A",
+      i_class: "X",
+      i_current_price: 10.0,
+      itemrevenue: 300.0,
+      revenueratio: 66.66666666666666
+    },
+    {
+      i_item_id: "ITEM2",
+      i_item_desc: "Item Two",
+      i_category: "A",
+      i_class: "X",
+      i_current_price: 20.0,
+      itemrevenue: 150.0,
+      revenueratio: 33.33333333333333
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add SQL spec and Mochi implementations for TPC‑DC queries 11 and 12
- include realistic sample data and regression tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68620ffc944c8320af0fdb53ea871905