### PR TITLE
Expand TPC‑DC sample queries

### DIFF
--- a/tests/dataset/tpc-dc/q60.mochi
+++ b/tests/dataset/tpc-dc/q60.mochi
@@ -2,12 +2,16 @@
 let item = [
   { i_item_sk: 1, i_item_id: "I1", i_category: "Music" },
   { i_item_sk: 2, i_item_id: "I2", i_category: "Electronics" },
-  { i_item_sk: 3, i_item_id: "I3", i_category: "Music" }
+  { i_item_sk: 3, i_item_id: "I3", i_category: "Music" },
+  // item not in selected category
+  { i_item_sk: 4, i_item_id: "I4", i_category: "Shoes" }
 ]
 
 let date_dim = [
   { d_date_sk: 1, d_year: 1998, d_moy: 9 },
-  { d_date_sk: 2, d_year: 1998, d_moy: 10 }
+  { d_date_sk: 2, d_year: 1998, d_moy: 10 },
+  // date outside selected month
+  { d_date_sk: 3, d_year: 1999, d_moy: 9 }
 ]
 
 let customer_address = [
@@ -20,21 +24,26 @@ let store_sales = [
   { ss_item_sk: 1, ss_sold_date_sk: 2, ss_addr_sk: 10, ss_ext_sales_price: 100 },
   { ss_item_sk: 3, ss_sold_date_sk: 1, ss_addr_sk: 10, ss_ext_sales_price: 50 },
   { ss_item_sk: 2, ss_sold_date_sk: 1, ss_addr_sk: 10, ss_ext_sales_price: 80 },
-  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_addr_sk: 11, ss_ext_sales_price: 30 }
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_addr_sk: 11, ss_ext_sales_price: 30 },
+  // sold from address with different offset
+  { ss_item_sk: 4, ss_sold_date_sk: 1, ss_addr_sk: 11, ss_ext_sales_price: 60 }
 ]
 
 let catalog_sales = [
   { cs_item_sk: 1, cs_sold_date_sk: 1, cs_bill_addr_sk: 10, cs_ext_sales_price: 50 },
   { cs_item_sk: 3, cs_sold_date_sk: 1, cs_bill_addr_sk: 10, cs_ext_sales_price: 20 },
   { cs_item_sk: 1, cs_sold_date_sk: 2, cs_bill_addr_sk: 10, cs_ext_sales_price: 20 },
-  { cs_item_sk: 1, cs_sold_date_sk: 1, cs_bill_addr_sk: 11, cs_ext_sales_price: 10 }
+  { cs_item_sk: 1, cs_sold_date_sk: 1, cs_bill_addr_sk: 11, cs_ext_sales_price: 10 },
+  // catalog sale for non-matching year
+  { cs_item_sk: 4, cs_sold_date_sk: 3, cs_bill_addr_sk: 11, cs_ext_sales_price: 25 }
 ]
 
 let web_sales = [
   { ws_item_sk: 1, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 30 },
   { ws_item_sk: 3, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 40 },
   { ws_item_sk: 1, ws_sold_date_sk: 2, ws_bill_addr_sk: 10, ws_ext_sales_price: 15 },
-  { ws_item_sk: 2, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 15 }
+  { ws_item_sk: 2, ws_sold_date_sk: 1, ws_bill_addr_sk: 10, ws_ext_sales_price: 15 },
+  { ws_item_sk: 4, ws_sold_date_sk: 3, ws_bill_addr_sk: 11, ws_ext_sales_price: 20 }
 ]
 
 let ss =

--- a/tests/dataset/tpc-dc/q61.mochi
+++ b/tests/dataset/tpc-dc/q61.mochi
@@ -1,7 +1,8 @@
 // Minimal dataset for TPC-DC Q61
 let promotion = [
   { p_promo_sk: 1, p_channel_dmail: "Y", p_channel_email: "N", p_channel_tv: "N" },
-  { p_promo_sk: 2, p_channel_dmail: "N", p_channel_email: "N", p_channel_tv: "N" }
+  { p_promo_sk: 2, p_channel_dmail: "N", p_channel_email: "N", p_channel_tv: "N" },
+  { p_promo_sk: 3, p_channel_dmail: "N", p_channel_email: "Y", p_channel_tv: "N" }
 ]
 
 let store = [
@@ -22,14 +23,16 @@ let customer_address = [
 ]
 
 let item = [
-  { i_item_sk: 1, i_category: "Jewelry" }
+  { i_item_sk: 1, i_category: "Jewelry" },
+  { i_item_sk: 2, i_category: "Electronics" }
 ]
 
 let store_sales = [
   { ss_ext_sales_price: 100.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 1, ss_customer_sk: 1, ss_item_sk: 1 },
   { ss_ext_sales_price: 200.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 2, ss_customer_sk: 1, ss_item_sk: 1 },
   { ss_ext_sales_price: 150.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 1, ss_customer_sk: 1, ss_item_sk: 1 },
-  { ss_ext_sales_price: 80.0, ss_sold_date_sk: 2, ss_store_sk: 1, ss_promo_sk: 1, ss_customer_sk: 1, ss_item_sk: 1 }
+  { ss_ext_sales_price: 80.0, ss_sold_date_sk: 2, ss_store_sk: 1, ss_promo_sk: 1, ss_customer_sk: 1, ss_item_sk: 1 },
+  { ss_ext_sales_price: 60.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 3, ss_customer_sk: 1, ss_item_sk: 2 }
 ]
 
 let promotional_sales =

--- a/tests/dataset/tpc-dc/q62.mochi
+++ b/tests/dataset/tpc-dc/q62.mochi
@@ -20,6 +20,7 @@ let date_dim = [
   { d_date_sk: 200, d_month_seq: 1200 },
   { d_date_sk: 25, d_month_seq: 1200 },
   { d_date_sk: 115, d_month_seq: 1200 }
+  ,{ d_date_sk: 300, d_month_seq: 1300 }
 ]
 
 let web_sales = [
@@ -30,6 +31,7 @@ let web_sales = [
   { ws_ship_date_sk: 200, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 },   // 160 days
   { ws_ship_date_sk: 25, ws_sold_date_sk: 5, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 },     // 20 days
   { ws_ship_date_sk: 115, ws_sold_date_sk: 40, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 }    // 75 days
+  ,{ ws_ship_date_sk: 300, ws_sold_date_sk: 25, ws_warehouse_sk: 1, ws_ship_mode_sk: 1, ws_web_site_sk: 1 }
 ]
 
 let result =

--- a/tests/dataset/tpc-dc/q63.mochi
+++ b/tests/dataset/tpc-dc/q63.mochi
@@ -7,21 +7,26 @@ let store_sales = [
   { ss_item_sk: 1, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 10.0 },
   { ss_item_sk: 1, ss_sold_date_sk: 2, ss_store_sk: 1, ss_sales_price: 20.0 },
   { ss_item_sk: 1, ss_sold_date_sk: 3, ss_store_sk: 1, ss_sales_price: 10.0 },
-  { ss_item_sk: 1, ss_sold_date_sk: 4, ss_store_sk: 1, ss_sales_price: 20.0 }
+  { ss_item_sk: 1, ss_sold_date_sk: 4, ss_store_sk: 1, ss_sales_price: 20.0 },
+  // outside the reporting period
+  { ss_item_sk: 1, ss_sold_date_sk: 5, ss_store_sk: 1, ss_sales_price: 30.0 }
 ]
 
 let date_dim = [
   { d_date_sk: 1, d_month_seq: 1200, d_moy: 1 },
   { d_date_sk: 2, d_month_seq: 1201, d_moy: 2 },
   { d_date_sk: 3, d_month_seq: 1202, d_moy: 3 },
-  { d_date_sk: 4, d_month_seq: 1203, d_moy: 4 }
+  { d_date_sk: 4, d_month_seq: 1203, d_moy: 4 },
+  // month before reporting period
+  { d_date_sk: 5, d_month_seq: 1199, d_moy: 12 }
 ]
 
 let store = [
   { s_store_sk: 1 }
 ]
 
-let tmp1 =
+// Calculate monthly sales per manager
+let monthly =
   from ss in store_sales
   join i in item on ss.ss_item_sk == i.i_item_sk
   join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
@@ -30,15 +35,27 @@ let tmp1 =
   group by {i_manager_id: i.i_manager_id, d_moy: d.d_moy} into g
   select {
     i_manager_id: g.key.i_manager_id,
-    sum_sales: sum(from x in g select x.ss_sales_price),
-    avg_monthly_sales: avg(from x in g select x.ss_sales_price)
+    d_moy: g.key.d_moy,
+    sum_sales: sum(from x in g select x.ss_sales_price)
+  }
+
+// Compute average monthly sales per manager
+let monthly_with_avg =
+  from m in monthly
+  group by {i_manager_id: m.i_manager_id} into g
+  from m in g
+  select {
+    i_manager_id: m.i_manager_id,
+    sum_sales: m.sum_sales,
+    avg_monthly_sales: avg(from x in g select x.sum_sales)
   }
 
 let result =
-  from r in tmp1
-  where abs(r.sum_sales - r.avg_monthly_sales) / r.avg_monthly_sales > 0.1
+  from r in monthly_with_avg
+  where r.avg_monthly_sales > 0 &&
+        abs(r.sum_sales - r.avg_monthly_sales) / r.avg_monthly_sales > 0.1
   sort by r.i_manager_id, r.avg_monthly_sales, r.sum_sales
-  select r
+  select { i_manager_id: r.i_manager_id, sum_sales: r.sum_sales, avg_monthly_sales: r.avg_monthly_sales }
 
 json(result)
 

--- a/tests/dataset/tpc-dc/q64.mochi
+++ b/tests/dataset/tpc-dc/q64.mochi
@@ -15,8 +15,13 @@ let cross_sales = [
   { product_name: "P2", item_sk: 2, store_name: "Store1", store_zip: "10001",
     b_street_number: "10", b_streen_name: "Main", b_city: "CityA", b_zip: "Z1",
     c_street_number: "20", c_street_name: "Second", c_city: "CityB", c_zip: "Z2",
-    syear: 2000, cnt: 5, s1: 10, s2: 22, s3: 5 }
+    syear: 2000, cnt: 5, s1: 10, s2: 22, s3: 5 },
+  { product_name: "P3", item_sk: 3, store_name: "Store2", store_zip: "10002",
+    b_street_number: "30", b_streen_name: "Third", b_city: "CityC", b_zip: "Z3",
+    c_street_number: "40", c_street_name: "Fourth", c_city: "CityD", c_zip: "Z4",
+    syear: 2001, cnt: 7, s1: 14, s2: 28, s3: 7 }
 ]
+
 
 let result =
   from cs1 in cross_sales

--- a/tests/dataset/tpc-dc/q65.mochi
+++ b/tests/dataset/tpc-dc/q65.mochi
@@ -11,7 +11,8 @@ let item = [
 
 let date_dim = [
   { d_date_sk: 1, d_month_seq: 1176 },
-  { d_date_sk: 2, d_month_seq: 1176 }
+  { d_date_sk: 2, d_month_seq: 1176 },
+  { d_date_sk: 3, d_month_seq: 1175 }
 ]
 
 let store_sales = [
@@ -19,7 +20,8 @@ let store_sales = [
   { ss_store_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 2, ss_sales_price: 50.0 },
   { ss_store_sk: 1, ss_item_sk: 2, ss_sold_date_sk: 1, ss_sales_price: 5.0 },
   { ss_store_sk: 1, ss_item_sk: 3, ss_sold_date_sk: 1, ss_sales_price: 2.0 },
-  { ss_store_sk: 1, ss_item_sk: 3, ss_sold_date_sk: 2, ss_sales_price: 3.0 }
+  { ss_store_sk: 1, ss_item_sk: 3, ss_sold_date_sk: 2, ss_sales_price: 3.0 },
+  { ss_store_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 3, ss_sales_price: 20.0 }
 ]
 
 let sales =

--- a/tests/dataset/tpc-dc/q66.mochi
+++ b/tests/dataset/tpc-dc/q66.mochi
@@ -6,6 +6,7 @@ let x = [
   { w_warehouse_name: "Wh1", w_warehouse_sq_ft: 1000.0, w_city: "City1", w_county: "County1", w_state: "ST", w_country: "USA", ship_carriers: "DHL,BARIAN", year: 2002,
     jan_sales: 5.0, feb_sales: 15.0, mar_sales: 0.0, apr_sales: 0.0, may_sales: 0.0, jun_sales: 0.0, jul_sales: 0.0, aug_sales: 0.0, sep_sales: 0.0, oct_sales: 0.0, nov_sales: 0.0, dec_sales: 0.0,
     jan_net: 4.0, feb_net: 12.0, mar_net: 0.0, apr_net: 0.0, may_net: 0.0, jun_net: 0.0, jul_net: 0.0, aug_net: 0.0, sep_net: 0.0, oct_net: 0.0, nov_net: 0.0, dec_net: 0.0 }
+  { w_warehouse_name: "Wh2", w_warehouse_sq_ft: 800.0, w_city: "City2", w_county: "County2", w_state: "ST", w_country: "USA", ship_carriers: "DHL", year: 2003, jan_sales: 0.0, feb_sales: 0.0, mar_sales: 0.0, apr_sales: 0.0, may_sales: 0.0, jun_sales: 0.0, jul_sales: 0.0, aug_sales: 0.0, sep_sales: 0.0, oct_sales: 0.0, nov_sales: 0.0, dec_sales: 0.0, jan_net: 0.0, feb_net: 0.0, mar_net: 0.0, apr_net: 0.0, may_net: 0.0, jun_net: 0.0, jul_net: 0.0, aug_net: 0.0, sep_net: 0.0, oct_net: 0.0, nov_net: 0.0, dec_net: 0.0 }
 ]
 
 let result =

--- a/tests/dataset/tpc-dc/q67.mochi
+++ b/tests/dataset/tpc-dc/q67.mochi
@@ -9,12 +9,14 @@ let store = [
 ]
 
 let date_dim = [
-  { d_date_sk: 1, d_year: 2001, d_qoy: 1, d_moy: 1, d_month_seq: 1200 }
+  { d_date_sk: 1, d_year: 2001, d_qoy: 1, d_moy: 1, d_month_seq: 1200 },
+  { d_date_sk: 2, d_year: 2000, d_qoy: 4, d_moy: 12, d_month_seq: 1190 }
 ]
 
 let store_sales = [
   { ss_item_sk: 1, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 10.0, ss_quantity: 1 },
-  { ss_item_sk: 2, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 5.0, ss_quantity: 3 }
+  { ss_item_sk: 2, ss_sold_date_sk: 1, ss_store_sk: 1, ss_sales_price: 5.0, ss_quantity: 3 },
+  { ss_item_sk: 2, ss_sold_date_sk: 2, ss_store_sk: 1, ss_sales_price: 8.0, ss_quantity: 2 }
 ]
 
 let dw1 =

--- a/tests/dataset/tpc-dc/q68.mochi
+++ b/tests/dataset/tpc-dc/q68.mochi
@@ -2,11 +2,13 @@
 let store_sales = [
   { ss_ticket_number: 1, ss_customer_sk: 1, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 100.0, ss_ext_list_price: 120.0, ss_ext_tax: 5.0 },
   { ss_ticket_number: 2, ss_customer_sk: 2, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 200.0, ss_ext_list_price: 250.0, ss_ext_tax: 10.0 },
-  { ss_ticket_number: 3, ss_customer_sk: 3, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 50.0, ss_ext_list_price: 70.0, ss_ext_tax: 2.0 }
+  { ss_ticket_number: 3, ss_customer_sk: 3, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 50.0, ss_ext_list_price: 70.0, ss_ext_tax: 2.0 },
+  { ss_ticket_number: 4, ss_customer_sk: 4, ss_addr_sk: 10, ss_hdemo_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 2, ss_ext_sales_price: 60.0, ss_ext_list_price: 80.0, ss_ext_tax: 3.0 }
 ]
 
 let date_dim = [
-  { d_date_sk: 1, d_dom: 1, d_year: 1999 }
+  { d_date_sk: 1, d_dom: 1, d_year: 1999 },
+  { d_date_sk: 2, d_dom: 3, d_year: 1999 }
 ]
 
 let store = [
@@ -25,7 +27,8 @@ let customer_address = [
 let customer = [
   { c_customer_sk: 1, c_current_addr_sk: 20, c_last_name: "Doe", c_first_name: "John" },
   { c_customer_sk: 2, c_current_addr_sk: 20, c_last_name: "Smith", c_first_name: "Jane" },
-  { c_customer_sk: 3, c_current_addr_sk: 10, c_last_name: "Brown", c_first_name: "Bob" }
+  { c_customer_sk: 3, c_current_addr_sk: 10, c_last_name: "Brown", c_first_name: "Bob" },
+  { c_customer_sk: 4, c_current_addr_sk: 20, c_last_name: "Green", c_first_name: "Alice" }
 ]
 
 let current_addr = customer_address

--- a/tests/dataset/tpc-dc/q69.mochi
+++ b/tests/dataset/tpc-dc/q69.mochi
@@ -2,17 +2,20 @@
 let customer = [
   { c_customer_sk: 1, c_current_addr_sk: 10, c_current_cdemo_sk: 100 },
   { c_customer_sk: 2, c_current_addr_sk: 11, c_current_cdemo_sk: 100 },
-  { c_customer_sk: 3, c_current_addr_sk: 11, c_current_cdemo_sk: 101 }
+  { c_customer_sk: 3, c_current_addr_sk: 11, c_current_cdemo_sk: 101 },
+  { c_customer_sk: 4, c_current_addr_sk: 12, c_current_cdemo_sk: 102 }
 ]
 
 let customer_address = [
   { ca_address_sk: 10, ca_state: "KY" },
-  { ca_address_sk: 11, ca_state: "GA" }
+  { ca_address_sk: 11, ca_state: "GA" },
+  { ca_address_sk: 12, ca_state: "TX" }
 ]
 
 let customer_demographics = [
   { cd_demo_sk: 100, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College", cd_purchase_estimate: 1000, cd_credit_rating: "Good" },
-  { cd_demo_sk: 101, cd_gender: "F", cd_marital_status: "S", cd_education_status: "College", cd_purchase_estimate: 500, cd_credit_rating: "Excellent" }
+  { cd_demo_sk: 101, cd_gender: "F", cd_marital_status: "S", cd_education_status: "College", cd_purchase_estimate: 500, cd_credit_rating: "Excellent" },
+  { cd_demo_sk: 102, cd_gender: "M", cd_marital_status: "M", cd_education_status: "College", cd_purchase_estimate: 700, cd_credit_rating: "Fair" }
 ]
 
 let store_sales = [


### PR DESCRIPTION
## Summary
- add extra rows to TPC-DC query data sets to make them more realistic
- adjust Q63 implementation to better mirror the SQL spec

## Testing
- `make test STAGE=parser`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6862100fce648320a91337ef68cbacc6