### PR TITLE
Add richer TPC‑DC samples for q20‑q29

### DIFF
--- a/tests/dataset/tpc-dc/q20.md
+++ b/tests/dataset/tpc-dc/q20.md
@@ -24,11 +24,12 @@ ORDER BY i_category,i_class,i_item_id,i_item_desc,revenueratio;
 ```
 
 ## Expected Output
-The first item accounts for two thirds of class revenue while the second makes
-up the remaining third.
+The first two items belong to the same class and split its revenue while the
+fourth item is the only entry in its class.
 ```json
 [
   { "i_item_id": "ITEM1", "revenueratio": 66.66666666666666 },
-  { "i_item_id": "ITEM2", "revenueratio": 33.33333333333333 }
+  { "i_item_id": "ITEM2", "revenueratio": 33.33333333333333 },
+  { "i_item_id": "ITEM4", "revenueratio": 100.0 }
 ]
 ```

--- a/tests/dataset/tpc-dc/q20.mochi
+++ b/tests/dataset/tpc-dc/q20.mochi
@@ -27,6 +27,8 @@ let catalog_sales = [
   { cs_item_sk: 3, cs_sold_date_sk: 1, cs_ext_sales_price: 50.0 },
   // ITEM4 uses a date outside the range filter
   { cs_item_sk: 4, cs_sold_date_sk: 2, cs_ext_sales_price: 120.0 }
+  // ITEM4 sale within the range so class Y has data
+  ,{ cs_item_sk: 4, cs_sold_date_sk: 1, cs_ext_sales_price: 80.0 }
 ]
 
 let item = [
@@ -131,6 +133,15 @@ test "TPCDC Q20 revenue ratio" {
       i_current_price: 20.0,
       itemrevenue: 150.0,
       revenueratio: 33.33333333333333
+    },
+    {
+      i_item_id: "ITEM4",
+      i_item_desc: "Item Four",
+      i_category: "B",
+      i_class: "Y",
+      i_current_price: 25.0,
+      itemrevenue: 80.0,
+      revenueratio: 100.0
     }
   ]
 }

--- a/tests/dataset/tpc-dc/q21.md
+++ b/tests/dataset/tpc-dc/q21.md
@@ -25,9 +25,10 @@ ORDER BY w_warehouse_name, i_item_id;
 ```
 
 ## Expected Output
-Only the Main warehouse item satisfies the ratio condition.
+Two items in the Main warehouse satisfy the ratio condition.
 ```json
 [
-  { "w_warehouse_name": "Main", "i_item_id": "ITEM1", "inv_before": 30, "inv_after": 40 }
+  { "w_warehouse_name": "Main", "i_item_id": "ITEM1", "inv_before": 30, "inv_after": 40 },
+  { "w_warehouse_name": "Main", "i_item_id": "ITEM3", "inv_before": 60, "inv_after": 90 }
 ]
 ```

--- a/tests/dataset/tpc-dc/q21.mochi
+++ b/tests/dataset/tpc-dc/q21.mochi
@@ -15,6 +15,9 @@ let inventory = [
   // ITEM2 in Main warehouse - ratio too high
   { inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 10 },
   { inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 40 }
+  // ITEM3 in Main warehouse qualifies with ratio 1.5
+  ,{ inv_item_sk: 3, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 60 }
+  ,{ inv_item_sk: 3, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 90 }
 ]
 
 let warehouse = [
@@ -23,7 +26,8 @@ let warehouse = [
 ]
 let item = [
   { i_item_sk: 1, i_item_id: "ITEM1" },
-  { i_item_sk: 2, i_item_id: "ITEM2" }
+  { i_item_sk: 2, i_item_id: "ITEM2" },
+  { i_item_sk: 3, i_item_id: "ITEM3" }
 ]
 let date_dim = [
   { d_date_sk: 1, d_date: "2000-03-01" },
@@ -59,6 +63,7 @@ json(result)
 
 test "TPCDC Q21 inventory ratio" {
   expect result == [
-    { w_warehouse_name: "Main", i_item_id: "ITEM1", inv_before: 30, inv_after: 40 }
+    { w_warehouse_name: "Main", i_item_id: "ITEM1", inv_before: 30, inv_after: 40 },
+    { w_warehouse_name: "Main", i_item_id: "ITEM3", inv_before: 60, inv_after: 90 }
   ]
 }

--- a/tests/dataset/tpc-dc/q22.md
+++ b/tests/dataset/tpc-dc/q22.md
@@ -20,10 +20,11 @@ ORDER BY qoh, i_product_name, i_brand, i_class, i_category;
 ```
 
 ## Expected Output
-In the simplified dataset every month has either 10 or 20 units on hand, so the
-average is 15.
+With additional months of data the average quantity on hand for Prod1 is
+18.33 while Prod2 averages 5 units.
 ```json
 [
-  { "i_product_name": "Prod1", "qoh": 15.0 }
+  { "i_product_name": "Prod1", "qoh": 18.333333333333332 },
+  { "i_product_name": "Prod2", "qoh": 5.0 }
 ]
 ```

--- a/tests/dataset/tpc-dc/q22.mochi
+++ b/tests/dataset/tpc-dc/q22.mochi
@@ -13,13 +13,16 @@ type Item {
 let inventory = [
   { inv_item_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 10 },
   { inv_item_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 20 },
+  { inv_item_sk: 1, inv_date_sk: 4, inv_quantity_on_hand: 25 },
   // ITEM2 inventory outside month range
-  { inv_item_sk: 2, inv_date_sk: 3, inv_quantity_on_hand: 5 }
+  { inv_item_sk: 2, inv_date_sk: 3, inv_quantity_on_hand: 5 },
+  { inv_item_sk: 2, inv_date_sk: 1, inv_quantity_on_hand: 5 }
 ]
 
 let date_dim = [
   { d_date_sk: 1, d_month_seq: 0 },
   { d_date_sk: 2, d_month_seq: 1 },
+  { d_date_sk: 4, d_month_seq: 2 },
   { d_date_sk: 3, d_month_seq: 12 }
 ]
 
@@ -68,7 +71,14 @@ test "TPCDC Q22 average inventory" {
       i_brand: "Brand1",
       i_class: "Class1",
       i_category: "Cat1",
-      qoh: 15.0
+      qoh: 18.333333333333332
+    },
+    {
+      i_product_name: "Prod2",
+      i_brand: "Brand2",
+      i_class: "Class2",
+      i_category: "Cat2",
+      qoh: 5.0
     }
   ]
 }

--- a/tests/dataset/tpc-dc/q23.md
+++ b/tests/dataset/tpc-dc/q23.md
@@ -44,7 +44,7 @@ FROM (
 ```
 
 ## Expected Output
-Both catalog and web sales contribute to a total of 50 in the example dataset.
+Additional rows increase the total sales to 130 in the example dataset.
 ```json
-50.0
+130.0
 ```

--- a/tests/dataset/tpc-dc/q23.mochi
+++ b/tests/dataset/tpc-dc/q23.mochi
@@ -16,16 +16,20 @@ let store_sales = [
   // extra sales for a different customer/item that do not qualify
   { ss_customer_sk: 2, ss_item_sk: 2, ss_sold_date_sk: 1, ss_quantity: 1, ss_sales_price: 5.0 },
   { ss_customer_sk: 2, ss_item_sk: 2, ss_sold_date_sk: 2, ss_quantity: 1, ss_sales_price: 5.0 }
+  // extra qualifying sale different date
+  ,{ ss_customer_sk: 1, ss_item_sk: 1, ss_sold_date_sk: 2, ss_quantity: 1, ss_sales_price: 9.0 }
 ]
 
 let catalog_sales = [
   { cs_bill_customer_sk: 1, cs_item_sk: 1, cs_sold_date_sk: 1, cs_quantity: 1, cs_list_price: 20.0 },
   { cs_bill_customer_sk: 2, cs_item_sk: 2, cs_sold_date_sk: 2, cs_quantity: 2, cs_list_price: 15.0 }
+  ,{ cs_bill_customer_sk: 1, cs_item_sk: 1, cs_sold_date_sk: 1, cs_quantity: 2, cs_list_price: 15.0 }
 ]
 
 let web_sales = [
   { ws_bill_customer_sk: 1, ws_item_sk: 1, ws_sold_date_sk: 1, ws_quantity: 1, ws_list_price: 30.0 },
   { ws_bill_customer_sk: 2, ws_item_sk: 2, ws_sold_date_sk: 2, ws_quantity: 1, ws_list_price: 8.0 }
+  ,{ ws_bill_customer_sk: 1, ws_item_sk: 1, ws_sold_date_sk: 1, ws_quantity: 2, ws_list_price: 25.0 }
 ]
 
 let customer = [
@@ -73,5 +77,5 @@ let result = sum(catalog_and_web)
 json(result)
 
 test "TPCDC Q23 frequent item sales" {
-  expect result == 50.0
+  expect result == 130.0
 }

--- a/tests/dataset/tpc-dc/q24.md
+++ b/tests/dataset/tpc-dc/q24.md
@@ -36,6 +36,6 @@ ORDER BY c_last_name,c_first_name,s_store_name;
 Only one customer in the example meets the threshold.
 ```json
 [
-  { "c_last_name": "Smith", "c_first_name": "Ann", "s_store_name": "Store1", "paid": 100.0 }
+  { "c_last_name": "Smith", "c_first_name": "Ann", "s_store_name": "Store1", "paid": 180.0 }
 ]
 ```

--- a/tests/dataset/tpc-dc/q24.mochi
+++ b/tests/dataset/tpc-dc/q24.mochi
@@ -9,12 +9,14 @@ type CustomerAddress { ca_address_sk: int, ca_state: string, ca_country: string,
 
 let store_sales = [
   { ss_ticket_number: 1, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_net_paid: 100.0 },
-  { ss_ticket_number: 2, ss_item_sk: 2, ss_customer_sk: 2, ss_store_sk: 1, ss_net_paid: 50.0 }
+  { ss_ticket_number: 2, ss_item_sk: 2, ss_customer_sk: 2, ss_store_sk: 1, ss_net_paid: 50.0 },
+  { ss_ticket_number: 3, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_net_paid: 80.0 }
 ]
 
 let store_returns = [
   { sr_ticket_number: 1, sr_item_sk: 1 },
-  { sr_ticket_number: 2, sr_item_sk: 2 }
+  { sr_ticket_number: 2, sr_item_sk: 2 },
+  { sr_ticket_number: 3, sr_item_sk: 1 }
 ]
 
 let store = [ { s_store_sk: 1, s_store_name: "Store1", s_market_id: 5, s_state: "CA", s_zip: "12345" } ]
@@ -67,5 +69,5 @@ let result =
 json(result)
 
 test "TPCDC Q24 customer net paid" {
-  expect result == [ { c_last_name: "Smith", c_first_name: "Ann", s_store_name: "Store1", paid: 100.0 } ]
+  expect result == [ { c_last_name: "Smith", c_first_name: "Ann", s_store_name: "Store1", paid: 180.0 } ]
 }

--- a/tests/dataset/tpc-dc/q25.md
+++ b/tests/dataset/tpc-dc/q25.md
@@ -36,9 +36,9 @@ The simplified dataset yields the following totals.
 [
   {
     "i_item_id": "ITEM1",
-    "store_sales_profit": 50.0,
-    "store_returns_loss": 10.0,
-    "catalog_sales_profit": 30.0
+    "store_sales_profit": 110.0,
+    "store_returns_loss": 15.0,
+    "catalog_sales_profit": 65.0
   }
 ]
 ```

--- a/tests/dataset/tpc-dc/q25.mochi
+++ b/tests/dataset/tpc-dc/q25.mochi
@@ -9,17 +9,20 @@ type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
 
 let store_sales = [
   { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_net_profit: 50.0, ss_ticket_number: 1 },
-  { ss_sold_date_sk: 2, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_net_profit: 5.0, ss_ticket_number: 2 }
+  { ss_sold_date_sk: 2, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_net_profit: 5.0, ss_ticket_number: 2 },
+  { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_net_profit: 60.0, ss_ticket_number: 3 }
 ]
 
 let store_returns = [
   { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_net_loss: 10.0 },
-  { sr_returned_date_sk: 3, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_net_loss: 1.0 }
+  { sr_returned_date_sk: 3, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_net_loss: 1.0 },
+  { sr_returned_date_sk: 3, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 3, sr_net_loss: 5.0 }
 ]
 
 let catalog_sales = [
   { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_net_profit: 30.0 },
-  { cs_sold_date_sk: 4, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_net_profit: 2.0 }
+  { cs_sold_date_sk: 4, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_net_profit: 2.0 },
+  { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_net_profit: 35.0 }
 ]
 
 let date_dim = [
@@ -65,9 +68,9 @@ test "TPCDC Q25 aggregated profit" {
       i_item_desc: "Desc1",
       s_store_id: "S1",
       s_store_name: "Store1",
-      store_sales_profit: 50.0,
-      store_returns_loss: 10.0,
-      catalog_sales_profit: 30.0
+      store_sales_profit: 110.0,
+      store_returns_loss: 15.0,
+      catalog_sales_profit: 65.0
     }
   ]
 }

--- a/tests/dataset/tpc-dc/q26.md
+++ b/tests/dataset/tpc-dc/q26.md
@@ -24,9 +24,9 @@ GROUP BY i_item_id;
 ```
 
 ## Expected Output
-Our sample data returns one row with averages equal to the raw values.
+With two qualifying rows the averages reflect their mean values.
 ```json
 [
-  { "i_item_id": "ITEM1", "agg1": 10.0, "agg2": 100.0, "agg3": 5.0, "agg4": 95.0 }
+  { "i_item_id": "ITEM1", "agg1": 15.0, "agg2": 110.0, "agg3": 7.5, "agg4": 102.5 }
 ]
 ```

--- a/tests/dataset/tpc-dc/q26.mochi
+++ b/tests/dataset/tpc-dc/q26.mochi
@@ -18,7 +18,8 @@ type Promotion { p_promo_sk: int, p_channel_email: string, p_channel_event: stri
 
 let catalog_sales = [
   { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_promo_sk: 1, cs_quantity: 10, cs_list_price: 100.0, cs_coupon_amt: 5.0, cs_sales_price: 95.0 },
-  { cs_sold_date_sk: 2, cs_item_sk: 2, cs_bill_cdemo_sk: 2, cs_promo_sk: 2, cs_quantity: 5, cs_list_price: 50.0, cs_coupon_amt: 0.0, cs_sales_price: 50.0 }
+  { cs_sold_date_sk: 2, cs_item_sk: 2, cs_bill_cdemo_sk: 2, cs_promo_sk: 2, cs_quantity: 5, cs_list_price: 50.0, cs_coupon_amt: 0.0, cs_sales_price: 50.0 },
+  { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_promo_sk: 1, cs_quantity: 20, cs_list_price: 120.0, cs_coupon_amt: 10.0, cs_sales_price: 110.0 }
 ]
 
 let customer_demographics = [
@@ -27,7 +28,7 @@ let customer_demographics = [
 ]
 
 let date_dim = [ { d_date_sk: 1, d_year: 2000 }, { d_date_sk: 2, d_year: 1999 } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" }, { i_item_sk: 3, i_item_id: "ITEM3" } ]
 let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" }, { p_promo_sk: 2, p_channel_email: "Y", p_channel_event: "Y" } ]
 
 let result =
@@ -50,6 +51,6 @@ json(result)
 
 test "TPCDC Q26 demographic averages" {
   expect result == [
-    { i_item_id: "ITEM1", agg1: 10.0, agg2: 100.0, agg3: 5.0, agg4: 95.0 }
+    { i_item_id: "ITEM1", agg1: 15.0, agg2: 110.0, agg3: 7.5, agg4: 102.5 }
   ]
 }

--- a/tests/dataset/tpc-dc/q27.md
+++ b/tests/dataset/tpc-dc/q27.md
@@ -26,9 +26,9 @@ ORDER BY i_item_id, s_state;
 ```
 
 ## Expected Output
-The sample contains one item sold in California.
+The averages now reflect two sales of the same item in California.
 ```json
 [
-  { "i_item_id": "ITEM1", "s_state": "CA", "agg1": 5.0, "agg2": 100.0, "agg3": 10.0, "agg4": 90.0 }
+  { "i_item_id": "ITEM1", "s_state": "CA", "agg1": 6.0, "agg2": 105.0, "agg3": 9.0, "agg4": 95.0 }
 ]
 ```

--- a/tests/dataset/tpc-dc/q27.mochi
+++ b/tests/dataset/tpc-dc/q27.mochi
@@ -8,7 +8,8 @@ type Item { i_item_sk: int, i_item_id: string }
 
 let store_sales = [
   { ss_item_sk: 1, ss_store_sk: 1, ss_cdemo_sk: 1, ss_sold_date_sk: 1, ss_quantity: 5, ss_list_price: 100.0, ss_coupon_amt: 10.0, ss_sales_price: 90.0 },
-  { ss_item_sk: 2, ss_store_sk: 2, ss_cdemo_sk: 2, ss_sold_date_sk: 1, ss_quantity: 3, ss_list_price: 50.0, ss_coupon_amt: 5.0, ss_sales_price: 45.0 }
+  { ss_item_sk: 2, ss_store_sk: 2, ss_cdemo_sk: 2, ss_sold_date_sk: 1, ss_quantity: 3, ss_list_price: 50.0, ss_coupon_amt: 5.0, ss_sales_price: 45.0 },
+  { ss_item_sk: 1, ss_store_sk: 1, ss_cdemo_sk: 1, ss_sold_date_sk: 1, ss_quantity: 7, ss_list_price: 110.0, ss_coupon_amt: 8.0, ss_sales_price: 100.0 }
 ]
 
 let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" }, { cd_demo_sk: 2, cd_gender: "M", cd_marital_status: "S", cd_education_status: "High" } ]
@@ -38,6 +39,6 @@ json(result)
 
 test "TPCDC Q27 averages by state" {
   expect result == [
-    { i_item_id: "ITEM1", s_state: "CA", agg1: 5.0, agg2: 100.0, agg3: 10.0, agg4: 90.0 }
+    { i_item_id: "ITEM1", s_state: "CA", agg1: 6.0, agg2: 105.0, agg3: 9.0, agg4: 95.0 }
   ]
 }

--- a/tests/dataset/tpc-dc/q28.md
+++ b/tests/dataset/tpc-dc/q28.md
@@ -32,11 +32,11 @@ FROM (
 Only two buckets are populated in the sample data.
 ```json
 {
-  "B1_LP": 100.0,
-  "B1_CNT": 1,
-  "B1_CNTD": 1,
-  "B2_LP": 80.0,
-  "B2_CNT": 1,
-  "B2_CNTD": 1
+  "B1_LP": 95.0,
+  "B1_CNT": 2,
+  "B1_CNTD": 2,
+  "B2_LP": 82.5,
+  "B2_CNT": 2,
+  "B2_CNTD": 2
 }
 ```

--- a/tests/dataset/tpc-dc/q28.mochi
+++ b/tests/dataset/tpc-dc/q28.mochi
@@ -5,7 +5,9 @@ type StoreSale { ss_quantity: int, ss_list_price: float, ss_coupon_amt: float, s
 let store_sales = [
   { ss_quantity: 3, ss_list_price: 100.0, ss_coupon_amt: 50.0, ss_wholesale_cost: 30.0 },
   { ss_quantity: 8, ss_list_price: 80.0, ss_coupon_amt: 10.0, ss_wholesale_cost: 20.0 },
-  { ss_quantity: 15, ss_list_price: 70.0, ss_coupon_amt: 5.0, ss_wholesale_cost: 25.0 }
+  { ss_quantity: 15, ss_list_price: 70.0, ss_coupon_amt: 5.0, ss_wholesale_cost: 25.0 },
+  { ss_quantity: 4, ss_list_price: 90.0, ss_coupon_amt: 20.0, ss_wholesale_cost: 15.0 },
+  { ss_quantity: 9, ss_list_price: 85.0, ss_coupon_amt: 0.0, ss_wholesale_cost: 10.0 }
 ]
 
 let bucket1 =
@@ -33,11 +35,11 @@ json(result)
 
 test "TPCDC Q28 buckets" {
   expect result == {
-    B1_LP: 100.0,
-    B1_CNT: 1,
-    B1_CNTD: 1,
-    B2_LP: 80.0,
-    B2_CNT: 1,
-    B2_CNTD: 1
+    B1_LP: 95.0,
+    B1_CNT: 2,
+    B1_CNTD: 2,
+    B2_LP: 82.5,
+    B2_CNT: 2,
+    B2_CNTD: 2
   }
 }

--- a/tests/dataset/tpc-dc/q29.md
+++ b/tests/dataset/tpc-dc/q29.md
@@ -37,9 +37,9 @@ The single row of sample data results in the following totals.
 [
   {
     "i_item_id": "ITEM1",
-    "store_sales_quantity": 10,
-    "store_returns_quantity": 2,
-    "catalog_sales_quantity": 5
+    "store_sales_quantity": 16,
+    "store_returns_quantity": 3,
+    "catalog_sales_quantity": 8
   }
 ]
 ```

--- a/tests/dataset/tpc-dc/q29.mochi
+++ b/tests/dataset/tpc-dc/q29.mochi
@@ -7,9 +7,9 @@ type DateDim { d_date_sk: int, d_moy: int, d_year: int }
 type Store { s_store_sk: int, s_store_id: string, s_store_name: string }
 type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
 
-let store_sales = [ { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 10, ss_ticket_number: 1 }, { ss_sold_date_sk: 2, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_quantity: 4, ss_ticket_number: 2 } ]
-let store_returns = [ { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_return_quantity: 2 }, { sr_returned_date_sk: 3, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_return_quantity: 1 } ]
-let catalog_sales = [ { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 5 }, { cs_sold_date_sk: 4, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_quantity: 1 } ]
+let store_sales = [ { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 10, ss_ticket_number: 1 }, { ss_sold_date_sk: 2, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_quantity: 4, ss_ticket_number: 2 }, { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 6, ss_ticket_number: 3 } ]
+let store_returns = [ { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_return_quantity: 2 }, { sr_returned_date_sk: 3, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_return_quantity: 1 }, { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 3, sr_return_quantity: 1 } ]
+let catalog_sales = [ { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 5 }, { cs_sold_date_sk: 4, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_quantity: 1 }, { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 3 } ]
 
 let date_dim = [
   { d_date_sk: 1, d_moy: 4, d_year: 1999 },
@@ -51,9 +51,9 @@ test "TPCDC Q29 quantity summary" {
       i_item_desc: "Desc1",
       s_store_id: "S1",
       s_store_name: "Store1",
-      store_sales_quantity: 10,
-      store_returns_quantity: 2,
-      catalog_sales_quantity: 5
+      store_sales_quantity: 16,
+      store_returns_quantity: 3,
+      catalog_sales_quantity: 8
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand sample datasets for TPC‑DC queries q20 through q29
- update expected outputs accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862100217ec8320b84fb07ed47b0f75