### PR TITLE
Fix tpc-ds vm outputs

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -465,9 +465,7 @@ func (p *Program) Disassemble(src string) string {
 		b.WriteByte('\n')
 	}
 	out := b.String()
-	out = strings.TrimRight(out, "\n")
-	out += "\n"
-	return out
+	return strings.TrimRight(out, "\n")
 }
 
 type VM struct {


### PR DESCRIPTION
## Summary
- strip trailing newline in `Program.Disassemble`
- refresh IR golden files for TPC‑DS queries q1–q9

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686211583be483209bd567f7a65e12a7