### PR TITLE
Add detailed TPC‑DC q80–q89 samples

### DIFF
--- a/tests/dataset/tpc-dc/q80.md
+++ b/tests/dataset/tpc-dc/q80.md
@@ -104,4 +104,14 @@ group by web_site_id)
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  { "channel": "catalog channel", "id": "catalog_page1", "sales": 120.0, "returns": 14.0, "profit": 21.0 },
+  { "channel": "catalog channel", "id": "catalog_page2", "sales": 20.0, "returns": 0.0, "profit": 4.0 },
+  { "channel": "store channel", "id": "store1", "sales": 150.0, "returns": 15.0, "profit": 27.0 },
+  { "channel": "store channel", "id": "store2", "sales": 60.0, "returns": 5.0, "profit": 11.0 },
+  { "channel": "web channel", "id": "web_site1", "sales": 100.0, "returns": 7.0, "profit": 19.0 },
+  { "channel": "web channel", "id": "web_site2", "sales": 20.0, "returns": 3.0, "profit": 4.5 }
+]
+```

--- a/tests/dataset/tpc-dc/q80.mochi
+++ b/tests/dataset/tpc-dc/q80.mochi
@@ -1,24 +1,128 @@
+let date_dim = [
+  { d_date_sk: 1, d_date: "2000-08-15" }
+]
+
+let store = [
+  { s_store_sk: 1, s_store_id: 1 },
+  { s_store_sk: 2, s_store_id: 2 }
+]
+
+let catalog_page = [
+  { cp_catalog_page_sk: 1, cp_catalog_page_id: 1 },
+  { cp_catalog_page_sk: 2, cp_catalog_page_id: 2 }
+]
+
+let web_site = [
+  { web_site_sk: 1, web_site_id: 1 },
+  { web_site_sk: 2, web_site_id: 2 }
+]
+
+let item = [
+  { i_item_sk: 1, i_current_price: 60 },
+  { i_item_sk: 2, i_current_price: 70 }
+]
+
+let promotion = [
+  { p_promo_sk: 1, p_channel_tv: "N" }
+]
+
 let store_sales = [
-  {price: 20.0, ret: 5.0},
-  {price: 10.0, ret: 0.0},
-  {price: 5.0, ret: 0.0}
+  { ss_item_sk: 1, ss_ticket_number: 100, ss_ext_sales_price: 100.0, ss_net_profit: 20.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 1 },
+  { ss_item_sk: 2, ss_ticket_number: 101, ss_ext_sales_price: 50.0, ss_net_profit: 10.0, ss_sold_date_sk: 1, ss_store_sk: 1, ss_promo_sk: 1 },
+  { ss_item_sk: 1, ss_ticket_number: 102, ss_ext_sales_price: 60.0, ss_net_profit: 12.0, ss_sold_date_sk: 1, ss_store_sk: 2, ss_promo_sk: 1 }
 ]
+
+let store_returns = [
+  { sr_item_sk: 1, sr_ticket_number: 100, sr_return_amt: 15.0, sr_net_loss: 3.0 },
+  { sr_item_sk: 1, sr_ticket_number: 102, sr_return_amt: 5.0, sr_net_loss: 1.0 }
+]
+
 let catalog_sales = [
-  {price: 15.0, ret: 3.0},
-  {price: 8.0, ret: 0.0}
+  { cs_item_sk: 1, cs_order_number: 200, cs_ext_sales_price: 40.0, cs_net_profit: 8.0, cs_sold_date_sk: 1, cs_catalog_page_sk: 1, cs_promo_sk: 1 },
+  { cs_item_sk: 2, cs_order_number: 201, cs_ext_sales_price: 80.0, cs_net_profit: 16.0, cs_sold_date_sk: 1, cs_catalog_page_sk: 1, cs_promo_sk: 1 },
+  { cs_item_sk: 2, cs_order_number: 202, cs_ext_sales_price: 20.0, cs_net_profit: 4.0, cs_sold_date_sk: 1, cs_catalog_page_sk: 2, cs_promo_sk: 1 }
 ]
+
+let catalog_returns = [
+  { cr_item_sk: 1, cr_order_number: 200, cr_return_amount: 4.0, cr_net_loss: 1.0 },
+  { cr_item_sk: 2, cr_order_number: 201, cr_return_amount: 10.0, cr_net_loss: 2.0 }
+]
+
 let web_sales = [
-  {price: 25.0, ret: 5.0},
-  {price: 15.0, ret: 5.0}
+  { ws_item_sk: 1, ws_order_number: 300, ws_ext_sales_price: 70.0, ws_net_profit: 14.0, ws_sold_date_sk: 1, ws_web_site_sk: 1, ws_promo_sk: 1 },
+  { ws_item_sk: 2, ws_order_number: 301, ws_ext_sales_price: 30.0, ws_net_profit: 6.0, ws_sold_date_sk: 1, ws_web_site_sk: 1, ws_promo_sk: 1 },
+  { ws_item_sk: 1, ws_order_number: 302, ws_ext_sales_price: 20.0, ws_net_profit: 5.0, ws_sold_date_sk: 1, ws_web_site_sk: 2, ws_promo_sk: 1 }
 ]
 
-let total_profit =
-  sum(from s in store_sales select s.price - s.ret) +
-  sum(from c in catalog_sales select c.price - c.ret) +
-  sum(from w in web_sales select w.price - w.ret)
+let web_returns = [
+  { wr_item_sk: 1, wr_order_number: 300, wr_return_amt: 7.0, wr_net_loss: 1.0 },
+  { wr_item_sk: 1, wr_order_number: 302, wr_return_amt: 3.0, wr_net_loss: 0.5 }
+]
 
-json(total_profit)
+let ssr =
+  from ss in store_sales
+  left join sr in store_returns on ss.ss_item_sk == sr.sr_item_sk && ss.ss_ticket_number == sr.sr_ticket_number
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  join i in item on ss.ss_item_sk == i.i_item_sk
+  join p in promotion on ss.ss_promo_sk == p.p_promo_sk
+  where i.i_current_price > 50 && p.p_channel_tv == "N"
+  group by s.s_store_id into g
+  select {
+    channel: "store channel",
+    id: "store" + g.key,
+    sales: sum(from x in g select x.ss.ss_ext_sales_price),
+    returns: sum(from x in g select coalesce(x.sr?.sr_return_amt, 0.0)),
+    profit: sum(from x in g select x.ss.ss_net_profit - coalesce(x.sr?.sr_net_loss, 0.0))
+  }
 
-test "TPCDC Q80 sample" {
-  expect total_profit == 80.0
+let csr =
+  from cs in catalog_sales
+  left join cr in catalog_returns on cs.cs_item_sk == cr.cr_item_sk && cs.cs_order_number == cr.cr_order_number
+  join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
+  join i in item on cs.cs_item_sk == i.i_item_sk
+  join p in promotion on cs.cs_promo_sk == p.p_promo_sk
+  where i.i_current_price > 50 && p.p_channel_tv == "N"
+  group by cp.cp_catalog_page_id into g
+  select {
+    channel: "catalog channel",
+    id: "catalog_page" + g.key,
+    sales: sum(from x in g select x.cs.cs_ext_sales_price),
+    returns: sum(from x in g select coalesce(x.cr?.cr_return_amount, 0.0)),
+    profit: sum(from x in g select x.cs.cs_net_profit - coalesce(x.cr?.cr_net_loss, 0.0))
+  }
+
+let wsr =
+  from ws in web_sales
+  left join wr in web_returns on ws.ws_item_sk == wr.wr_item_sk && ws.ws_order_number == wr.wr_order_number
+  join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  join i in item on ws.ws_item_sk == i.i_item_sk
+  join p in promotion on ws.ws_promo_sk == p.p_promo_sk
+  where i.i_current_price > 50 && p.p_channel_tv == "N"
+  group by w.web_site_id into g
+  select {
+    channel: "web channel",
+    id: "web_site" + g.key,
+    sales: sum(from x in g select x.ws.ws_ext_sales_price),
+    returns: sum(from x in g select coalesce(x.wr?.wr_return_amt, 0.0)),
+    profit: sum(from x in g select x.ws.ws_net_profit - coalesce(x.wr?.wr_net_loss, 0.0))
+  }
+
+let result =
+  concat(ssr, csr, wsr)
+  |> sort_by(fn(a,b) a.channel < b.channel || (a.channel == b.channel && a.id < b.id))
+
+json(result)
+
+test "TPCDC Q80 totals" {
+  expect result == [
+    { channel: "catalog channel", id: "catalog_page1", sales: 120.0, returns: 14.0, profit: 21.0 },
+    { channel: "catalog channel", id: "catalog_page2", sales: 20.0, returns: 0.0, profit: 4.0 },
+    { channel: "store channel", id: "store1", sales: 150.0, returns: 15.0, profit: 27.0 },
+    { channel: "store channel", id: "store2", sales: 60.0, returns: 5.0, profit: 11.0 },
+    { channel: "web channel", id: "web_site1", sales: 100.0, returns: 7.0, profit: 19.0 },
+    { channel: "web channel", id: "web_site2", sales: 20.0, returns: 3.0, profit: 4.5 }
+  ]
 }

--- a/tests/dataset/tpc-dc/q81.md
+++ b/tests/dataset/tpc-dc/q81.md
@@ -41,4 +41,9 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  { "c_customer_id": "C1", "ctr_total_return": 180.0 }
+]
+```

--- a/tests/dataset/tpc-dc/q81.mochi
+++ b/tests/dataset/tpc-dc/q81.mochi
@@ -1,19 +1,55 @@
 let catalog_returns = [
-  {cust: 1, state: "CA", amt: 40.0},
-  {cust: 2, state: "CA", amt: 50.0},
-  {cust: 3, state: "CA", amt: 81.0},
-  {cust: 4, state: "TX", amt: 30.0},
-  {cust: 5, state: "TX", amt: 20.0}
+  { cr_returning_customer_sk: 1, cr_returned_date_sk: 1, cr_return_amt_inc_tax: 100.0, cr_returning_addr_sk: 1 },
+  { cr_returning_customer_sk: 1, cr_returned_date_sk: 1, cr_return_amt_inc_tax: 80.0, cr_returning_addr_sk: 1 },
+  { cr_returning_customer_sk: 2, cr_returned_date_sk: 1, cr_return_amt_inc_tax: 50.0, cr_returning_addr_sk: 2 },
+  { cr_returning_customer_sk: 3, cr_returned_date_sk: 1, cr_return_amt_inc_tax: 40.0, cr_returning_addr_sk: 3 }
 ]
 
-let avg_amt = avg(from r in catalog_returns where r.state == "CA" select r.amt)
-let result_list = to_list(from r in catalog_returns
-  where r.state == "CA" && r.amt > avg_amt * 1.2
-  select r.amt)
-let result = result_list[0]
+let date_dim = [
+  { d_date_sk: 1, d_year: 2000 }
+]
+
+let customer_address = [
+  { ca_address_sk: 1, ca_state: "CA" },
+  { ca_address_sk: 2, ca_state: "CA" },
+  { ca_address_sk: 3, ca_state: "TX" }
+]
+
+let customer = [
+  { c_customer_sk: 1, c_customer_id: "C1", c_salutation: "Mr.", c_first_name: "John", c_last_name: "Doe", c_current_addr_sk: 1 },
+  { c_customer_sk: 2, c_customer_id: "C2", c_salutation: "Ms.", c_first_name: "Jane", c_last_name: "Smith", c_current_addr_sk: 2 },
+  { c_customer_sk: 3, c_customer_id: "C3", c_salutation: "Mr.", c_first_name: "Bob", c_last_name: "Brown", c_current_addr_sk: 3 }
+]
+
+let customer_total_return =
+  from cr in catalog_returns
+  join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
+  join ca in customer_address on cr.cr_returning_addr_sk == ca.ca_address_sk
+  where d.d_year == 2000
+  group by {cust: cr.cr_returning_customer_sk, state: ca.ca_state} into g
+  select {
+    ctr_customer_sk: g.key.cust,
+    ctr_state: g.key.state,
+    ctr_total_return: sum(from x in g select x.cr.cr_return_amt_inc_tax)
+  }
+
+let avg_by_state =
+  from ctr in customer_total_return
+  group by ctr.ctr_state into g
+  select { state: g.key, avg_return: avg(from x in g select x.ctr_total_return) }
+
+let result =
+  from ctr in customer_total_return
+  join avg in avg_by_state on ctr.ctr_state == avg.state
+  join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  where ca.ca_state == "CA" && ctr.ctr_total_return > avg.avg_return * 1.2
+  sort by c.c_customer_id
+  select { c_customer_id: c.c_customer_id, ctr_total_return: ctr.ctr_total_return }
+  |> to_list
 
 json(result)
 
-test "TPCDC Q81 sample" {
-  expect result == 81.0
+test "TPCDC Q81 high returns" {
+  expect result == [{ c_customer_id: "C1", ctr_total_return: 180.0 }]
 }

--- a/tests/dataset/tpc-dc/q82.md
+++ b/tests/dataset/tpc-dc/q82.md
@@ -29,4 +29,11 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  { "i_item_id": "I2", "i_item_desc": "Item2", "i_current_price": 55 },
+  { "i_item_id": "I3", "i_item_desc": "Item3", "i_current_price": 65 },
+  { "i_item_id": "I4", "i_item_desc": "Item4", "i_current_price": 70 }
+]
+```

--- a/tests/dataset/tpc-dc/q82.mochi
+++ b/tests/dataset/tpc-dc/q82.mochi
@@ -1,27 +1,44 @@
 let item = [
-  {id: 1},
-  {id: 2},
-  {id: 3}
+  { i_item_sk: 2, i_item_id: "I2", i_item_desc: "Item2", i_current_price: 55, i_manufact_id: 11 },
+  { i_item_sk: 3, i_item_id: "I3", i_item_desc: "Item3", i_current_price: 65, i_manufact_id: 22 },
+  { i_item_sk: 4, i_item_id: "I4", i_item_desc: "Item4", i_current_price: 70, i_manufact_id: 33 }
 ]
+
 let inventory = [
-  {item: 1, qty: 40},
-  {item: 1, qty: 30},
-  {item: 2, qty: 10},
-  {item: 2, qty: 2},
-  {item: 3, qty: 5}
+  { inv_item_sk: 2, inv_date_sk: 1, inv_quantity_on_hand: 200 },
+  { inv_item_sk: 3, inv_date_sk: 1, inv_quantity_on_hand: 150 },
+  { inv_item_sk: 4, inv_date_sk: 1, inv_quantity_on_hand: 120 }
 ]
+
+let date_dim = [
+  { d_date_sk: 1, d_date: "2000-05-01" }
+]
+
 let store_sales = [
-  {item: 1},
-  {item: 2}
+  { ss_item_sk: 2 },
+  { ss_item_sk: 3 },
+  { ss_item_sk: 3 },
+  { ss_item_sk: 4 }
 ]
 
 let result =
-  sum(from inv in inventory
-      join s in store_sales on inv.item == s.item
-      select inv.qty)
+  from i in item
+  join inv in inventory on inv.inv_item_sk == i.i_item_sk
+  join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  join ss in store_sales on ss.ss_item_sk == i.i_item_sk
+  where i.i_current_price >= 50 && i.i_current_price <= 80 &&
+        inv.inv_quantity_on_hand >= 100 && inv.inv_quantity_on_hand <= 500
+  group by { id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price } into g
+  sort by g.key.id
+  select { i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price }
+  |> to_list
 
 json(result)
 
-test "TPCDC Q82 sample" {
-  expect result == 82
+test "TPCDC Q82 items" {
+  expect result == [
+    { i_item_id: "I2", i_item_desc: "Item2", i_current_price: 55 },
+    { i_item_id: "I3", i_item_desc: "Item3", i_current_price: 65 },
+    { i_item_id: "I4", i_item_desc: "Item4", i_current_price: 70 }
+  ]
 }

--- a/tests/dataset/tpc-dc/q83.md
+++ b/tests/dataset/tpc-dc/q83.md
@@ -77,4 +77,28 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  {
+    "item_id": 1,
+    "sr_item_qty": 30,
+    "sr_dev": 16.666666666666664,
+    "cr_item_qty": 20,
+    "cr_dev": 11.11111111111111,
+    "wr_item_qty": 10,
+    "wr_dev": 5.555555555555555,
+    "average": 20.0
+  },
+  {
+    "item_id": 2,
+    "sr_item_qty": 15,
+    "sr_dev": 16.666666666666664,
+    "cr_item_qty": 10,
+    "cr_dev": 11.11111111111111,
+    "wr_item_qty": 5,
+    "wr_dev": 5.555555555555555,
+    "average": 10.0
+  }
+]
+```

--- a/tests/dataset/tpc-dc/q83.mochi
+++ b/tests/dataset/tpc-dc/q83.mochi
@@ -1,22 +1,41 @@
 let sr_items = [
-  {qty: 10},
-  {qty: 15}
-]
-let cr_items = [
-  {qty: 18},
-  {qty: 20}
-]
-let wr_items = [
-  {qty: 10},
-  {qty: 10}
+  { item_id: 1, sr_return_quantity: 30 },
+  { item_id: 2, sr_return_quantity: 15 }
 ]
 
-let result = sum(from x in sr_items select x.qty) +
-             sum(from x in cr_items select x.qty) +
-             sum(from x in wr_items select x.qty)
+let cr_items = [
+  { item_id: 1, cr_return_quantity: 20 },
+  { item_id: 2, cr_return_quantity: 10 }
+]
+
+let wr_items = [
+  { item_id: 1, wr_return_quantity: 10 },
+  { item_id: 2, wr_return_quantity: 5 }
+]
+
+let result =
+  from sr in sr_items
+  join cr in cr_items on sr.item_id == cr.item_id
+  join wr in wr_items on sr.item_id == wr.item_id
+  let total = sr.sr_return_quantity + cr.cr_return_quantity + wr.wr_return_quantity
+  sort by sr.item_id
+  select {
+    item_id: sr.item_id,
+    sr_item_qty: sr.sr_return_quantity,
+    sr_dev: sr.sr_return_quantity / total / 3.0 * 100,
+    cr_item_qty: cr.cr_return_quantity,
+    cr_dev: cr.cr_return_quantity / total / 3.0 * 100,
+    wr_item_qty: wr.wr_return_quantity,
+    wr_dev: wr.wr_return_quantity / total / 3.0 * 100,
+    average: total / 3.0
+  }
+  |> to_list
 
 json(result)
 
-test "TPCDC Q83 sample" {
-  expect result == 83
+test "TPCDC Q83 returns" {
+  expect result == [
+    { item_id: 1, sr_item_qty: 30, sr_dev: 16.666666666666664, cr_item_qty: 20, cr_dev: 11.11111111111111, wr_item_qty: 10, wr_dev: 5.555555555555555, average: 20.0 },
+    { item_id: 2, sr_item_qty: 15, sr_dev: 16.666666666666664, cr_item_qty: 10, cr_dev: 11.11111111111111, wr_item_qty: 5, wr_dev: 5.555555555555555, average: 10.0 }
+  ]
 }

--- a/tests/dataset/tpc-dc/q84.md
+++ b/tests/dataset/tpc-dc/q84.md
@@ -31,4 +31,9 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  { "customer_id": "C1", "customername": "Doe, John" }
+]
+```

--- a/tests/dataset/tpc-dc/q84.mochi
+++ b/tests/dataset/tpc-dc/q84.mochi
@@ -1,35 +1,48 @@
-let customers = [
-  {id: 1, city: "A", cdemo: 1},
-  {id: 2, city: "A", cdemo: 2},
-  {id: 3, city: "B", cdemo: 1}
-]
-let customer_demographics = [
-  {cd_demo_sk: 1},
-  {cd_demo_sk: 2}
-]
-let household_demographics = [
-  {hd_demo_sk: 1, income_band_sk: 1},
-  {hd_demo_sk: 2, income_band_sk: 2}
-]
-let income_band = [
-  {ib_income_band_sk: 1, ib_lower_bound: 0, ib_upper_bound: 50000},
-  {ib_income_band_sk: 2, ib_lower_bound: 50001, ib_upper_bound: 100000}
-]
-let customer_address = [
-  {ca_address_sk: 1, ca_city: "A"},
-  {ca_address_sk: 2, ca_city: "B"}
-]
-let store_returns = [
-  {sr_cdemo_sk: 1},
-  {sr_cdemo_sk: 1},
-  {sr_cdemo_sk: 2},
-  {sr_cdemo_sk: 1}
+let customer = [
+  { c_customer_id: "C1", c_current_addr_sk: 1, c_current_cdemo_sk: 1, c_current_hdemo_sk: 1, c_first_name: "John", c_last_name: "Doe" },
+  { c_customer_id: "C2", c_current_addr_sk: 1, c_current_cdemo_sk: 2, c_current_hdemo_sk: 2, c_first_name: "Jane", c_last_name: "Smith" }
 ]
 
-let result = 80 + len(store_returns)
+let customer_address = [
+  { ca_address_sk: 1, ca_city: "Spring" }
+]
+
+let customer_demographics = [
+  { cd_demo_sk: 1 },
+  { cd_demo_sk: 2 }
+]
+
+let household_demographics = [
+  { hd_demo_sk: 1, hd_income_band_sk: 1 },
+  { hd_demo_sk: 2, hd_income_band_sk: 2 }
+]
+
+let income_band = [
+  { ib_income_band_sk: 1, ib_lower_bound: 0, ib_upper_bound: 50000 },
+  { ib_income_band_sk: 2, ib_lower_bound: 60000, ib_upper_bound: 100000 }
+]
+
+let store_returns = [
+  { sr_cdemo_sk: 1 },
+  { sr_cdemo_sk: 1 },
+  { sr_cdemo_sk: 2 }
+]
+
+let result =
+  from c in customer
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
+  join hd in household_demographics on c.c_current_hdemo_sk == hd.hd_demo_sk
+  join ib in income_band on hd.hd_income_band_sk == ib.ib_income_band_sk
+  join sr in store_returns on sr.sr_cdemo_sk == cd.cd_demo_sk
+  where ca.ca_city == "Spring" && ib.ib_lower_bound >= 0 && ib.ib_upper_bound <= 50000
+  sort by c.c_customer_id
+  select { customer_id: c.c_customer_id, customername: c.c_last_name + ", " + c.c_first_name }
+  |> distinct
+  |> to_list
 
 json(result)
 
-test "TPCDC Q84 sample" {
-  expect result == 84
+test "TPCDC Q84 customers" {
+  expect result == [{ customer_id: "C1", customername: "Doe, John" }]
 }

--- a/tests/dataset/tpc-dc/q85.md
+++ b/tests/dataset/tpc-dc/q85.md
@@ -94,4 +94,9 @@ order by substr(r_reason_desc,1,20)
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  { "reason": "ReasonA", "avg_ws_quantity": 2.0, "avg_wr_refunded_cash": 50.0, "avg_wr_fee": 2.0 }
+]
+```

--- a/tests/dataset/tpc-dc/q85.mochi
+++ b/tests/dataset/tpc-dc/q85.mochi
@@ -1,13 +1,58 @@
-let web_returns = [
-  {qty: 60, cash: 20.0, fee: 1.0},
-  {qty: 100, cash: 30.0, fee: 2.0},
-  {qty: 95, cash: 25.0, fee: 3.0}
+let web_sales = [
+  { ws_item_sk: 1, ws_order_number: 100, ws_quantity: 2, ws_sales_price: 120.0, ws_net_profit: 180.0, ws_web_page_sk: 1, ws_sold_date_sk: 1 }
 ]
 
-let result = avg(from r in web_returns select r.qty)
+let web_returns = [
+  { wr_item_sk: 1, wr_order_number: 100, wr_refunded_cash: 50.0, wr_fee: 2.0, wr_refunded_cdemo_sk: 1, wr_returning_cdemo_sk: 1, wr_refunded_addr_sk: 1, wr_reason_sk: 1 }
+]
+
+let web_page = [
+  { wp_web_page_sk: 1 }
+]
+
+let customer_demographics = [
+  { cd_demo_sk: 1, cd_marital_status: "M", cd_education_status: "E1" }
+]
+
+let customer_address = [
+  { ca_address_sk: 1, ca_country: "United States", ca_state: "CA" }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_year: 2000 }
+]
+
+let reason = [
+  { r_reason_sk: 1, r_reason_desc: "ReasonA" }
+]
+
+let result =
+  from ws in web_sales
+  join wr in web_returns on ws.ws_item_sk == wr.wr_item_sk && ws.ws_order_number == wr.wr_order_number
+  join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
+  join cd1 in customer_demographics on wr.wr_refunded_cdemo_sk == cd1.cd_demo_sk
+  join cd2 in customer_demographics on wr.wr_returning_cdemo_sk == cd2.cd_demo_sk
+  join ca in customer_address on wr.wr_refunded_addr_sk == ca.ca_address_sk
+  join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  join r in reason on wr.wr_reason_sk == r.r_reason_sk
+  where d.d_year == 2000 && cd1.cd_marital_status == "M" && cd2.cd_marital_status == "M" &&
+        cd1.cd_education_status == "E1" && cd2.cd_education_status == "E1" &&
+        ws.ws_sales_price >= 100.0 && ws.ws_sales_price <= 150.0 &&
+        ca.ca_country == "United States" && ca.ca_state == "CA" &&
+        ws.ws_net_profit >= 100 && ws.ws_net_profit <= 200
+  group by substr(r.r_reason_desc,0,20) into g
+  select {
+    reason: g.key,
+    avg_ws_quantity: avg(from x in g select x.ws.ws_quantity),
+    avg_wr_refunded_cash: avg(from x in g select x.wr.wr_refunded_cash),
+    avg_wr_fee: avg(from x in g select x.wr.wr_fee)
+  }
+  |> to_list
 
 json(result)
 
-test "TPCDC Q85 sample" {
-  expect result == 85.0
+test "TPCDC Q85 averages" {
+  expect result == [
+    { reason: "ReasonA", avg_ws_quantity: 2.0, avg_wr_refunded_cash: 50.0, avg_wr_fee: 2.0 }
+  ]
 }

--- a/tests/dataset/tpc-dc/q86.md
+++ b/tests/dataset/tpc-dc/q86.md
@@ -33,4 +33,10 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  { "i_category": "CatA", "i_class": "ClassA", "total_sum": 70.0 },
+  { "i_category": "CatA", "i_class": "ClassB", "total_sum": 60.0 }
+]
+```

--- a/tests/dataset/tpc-dc/q86.mochi
+++ b/tests/dataset/tpc-dc/q86.mochi
@@ -1,18 +1,36 @@
 let web_sales = [
-  {cat: "A", class: "B", net: 40.0},
-  {cat: "A", class: "B", net: 46.0},
-  {cat: "A", class: "C", net: 10.0},
-  {cat: "B", class: "B", net: 20.0}
+  { ws_sold_date_sk: 1, ws_item_sk: 1, ws_net_paid: 40.0 },
+  { ws_sold_date_sk: 1, ws_item_sk: 2, ws_net_paid: 60.0 },
+  { ws_sold_date_sk: 2, ws_item_sk: 1, ws_net_paid: 30.0 }
 ]
+
+let date_dim = [
+  { d_date_sk: 1, d_month_seq: 1200 },
+  { d_date_sk: 2, d_month_seq: 1201 }
+]
+
+let item = [
+  { i_item_sk: 1, i_category: "CatA", i_class: "ClassA" },
+  { i_item_sk: 2, i_category: "CatA", i_class: "ClassB" }
+]
+
+let dms = 1200
 
 let result =
   from ws in web_sales
-  group by {c: ws.cat, cls: ws.class} into g
-  select sum(from x in g select x.net)
-  |> first
+  join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  join i in item on ws.ws_item_sk == i.i_item_sk
+  where d.d_month_seq >= dms && d.d_month_seq <= dms + 11
+  group by { category: i.i_category, class: i.i_class } into g
+  sort by g.key.category, g.key.class
+  select { i_category: g.key.category, i_class: g.key.class, total_sum: sum(from x in g select x.ws.ws_net_paid) }
+  |> to_list
 
 json(result)
 
-test "TPCDC Q86 sample" {
-  expect result == 86.0
+test "TPCDC Q86 totals" {
+  expect result == [
+    { i_category: "CatA", i_class: "ClassA", total_sum: 70.0 },
+    { i_category: "CatA", i_class: "ClassB", total_sum: 60.0 }
+  ]
 }

--- a/tests/dataset/tpc-dc/q87.md
+++ b/tests/dataset/tpc-dc/q87.md
@@ -29,4 +29,7 @@ from ((select distinct c_last_name, c_first_name, d_date
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+1
+```

--- a/tests/dataset/tpc-dc/q87.mochi
+++ b/tests/dataset/tpc-dc/q87.mochi
@@ -1,28 +1,46 @@
 let store_sales = [
-  {cust: "A"},
-  {cust: "B"},
-  {cust: "B"},
-  {cust: "C"}
+  { ss_sold_date_sk: 1, ss_customer_sk: 1 },
+  { ss_sold_date_sk: 1, ss_customer_sk: 2 }
 ]
+
 let catalog_sales = [
-  {cust: "A"},
-  {cust: "C"},
-  {cust: "D"}
+  { cs_sold_date_sk: 1, cs_bill_customer_sk: 2 }
 ]
+
 let web_sales = [
-  {cust: "A"},
-  {cust: "D"}
+  { ws_sold_date_sk: 1, ws_bill_customer_sk: 3 }
 ]
 
-let store_customers = distinct(from s in store_sales select s.cust)
-let other_customers = distinct(concat(from c in catalog_sales select c.cust,
-                                      from w in web_sales select w.cust))
-let diff = from c in store_customers where !contains(other_customers, c) select c |> to_list
+let date_dim = [
+  { d_date_sk: 1, d_month_seq: 1200 }
+]
 
-let result = len(diff) * 87
+let dms = 1200
+
+let store_customers =
+  from ss in store_sales
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  where d.d_month_seq >= dms && d.d_month_seq <= dms + 11
+  select ss.ss_customer_sk
+  |> distinct
+
+let other_customers =
+  concat(
+    from cs in catalog_sales join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk where d.d_month_seq >= dms && d.d_month_seq <= dms + 11 select cs.cs_bill_customer_sk,
+    from ws in web_sales join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk where d.d_month_seq >= dms && d.d_month_seq <= dms + 11 select ws.ws_bill_customer_sk
+  )
+  |> distinct
+
+let diff =
+  from c in store_customers
+  where !contains(other_customers, c)
+  select c
+  |> to_list
+
+let result = len(diff)
 
 json(result)
 
-test "TPCDC Q87 sample" {
-  expect result == 87
+test "TPCDC Q87 diff" {
+  expect result == 1
 }

--- a/tests/dataset/tpc-dc/q88.md
+++ b/tests/dataset/tpc-dc/q88.md
@@ -101,4 +101,16 @@ from
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+{
+  "h8_30_to_9": 1,
+  "h9_to_9_30": 1,
+  "h9_30_to_10": 0,
+  "h10_to_10_30": 1,
+  "h10_30_to_11": 0,
+  "h11_to_11_30": 0,
+  "h11_30_to_12": 1,
+  "h12_to_12_30": 0
+}
+```

--- a/tests/dataset/tpc-dc/q88.mochi
+++ b/tests/dataset/tpc-dc/q88.mochi
@@ -1,25 +1,52 @@
 let time_dim = [
-  {time_sk: 1, hour: 8, minute: 30},
-  {time_sk: 2, hour: 9, minute: 0},
-  {time_sk: 3, hour: 11, minute: 15}
+  { t_time_sk: 1, t_hour: 8, t_minute: 45 },
+  { t_time_sk: 2, t_hour: 9, t_minute: 15 },
+  { t_time_sk: 3, t_hour: 10, t_minute: 5 },
+  { t_time_sk: 4, t_hour: 11, t_minute: 45 }
 ]
+
+let household_demographics = [
+  { hd_demo_sk: 1, hd_dep_count: 1, hd_vehicle_count: 1 }
+]
+
+let store = [
+  { s_store_sk: 1, s_store_name: "ese" }
+]
+
 let store_sales = [
-  {sold_time_sk: 1},
-  {sold_time_sk: 2},
-  {sold_time_sk: 3}
+  { ss_sold_time_sk: 1, ss_hdemo_sk: 1, ss_store_sk: 1 },
+  { ss_sold_time_sk: 2, ss_hdemo_sk: 1, ss_store_sk: 1 },
+  { ss_sold_time_sk: 3, ss_hdemo_sk: 1, ss_store_sk: 1 },
+  { ss_sold_time_sk: 4, ss_hdemo_sk: 1, ss_store_sk: 1 }
 ]
 
-let morning_sales =
-  from s in store_sales
-  join t in time_dim on t.time_sk == s.sold_time_sk
-  where t.hour <= 9
-  select s
-  |> count
+let count_interval = fn(start_hour, start_min, end_hour, end_min) {
+  from ss in store_sales
+  join t in time_dim on ss.ss_sold_time_sk == t.t_time_sk
+  join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  where s.s_store_name == "ese" &&
+        (t.t_hour > start_hour || (t.t_hour == start_hour && t.t_minute >= start_min)) &&
+        (t.t_hour < end_hour || (t.t_hour == end_hour && t.t_minute < end_min))
+  count
+}
 
-let result = morning_sales * 44
+let result = {
+  h8_30_to_9: count_interval(8,30,9,0),
+  h9_to_9_30: count_interval(9,0,9,30),
+  h9_30_to_10: count_interval(9,30,10,0),
+  h10_to_10_30: count_interval(10,0,10,30),
+  h10_30_to_11: count_interval(10,30,11,0),
+  h11_to_11_30: count_interval(11,0,11,30),
+  h11_30_to_12: count_interval(11,30,12,0),
+  h12_to_12_30: count_interval(12,0,12,30)
+}
 
 json(result)
 
-test "TPCDC Q88 sample" {
-  expect result == 88
+test "TPCDC Q88 counts" {
+  expect result == {
+    h8_30_to_9: 1, h9_to_9_30: 1, h9_30_to_10: 0, h10_to_10_30: 1,
+    h10_30_to_11: 0, h11_to_11_30: 0, h11_30_to_12: 1, h12_to_12_30: 0
+  }
 }

--- a/tests/dataset/tpc-dc/q89.md
+++ b/tests/dataset/tpc-dc/q89.md
@@ -48,4 +48,10 @@ order by sum_sales - avg_monthly_sales, s_store_name
 ```
 
 ## Expected Output
-Results depend on dataset scale.
+Example using the small test dataset:
+```json
+[
+  { "i_category": "CatA", "i_class": "Class1", "i_brand": "Brand1", "s_store_name": "Store1", "s_company_name": "CompanyA", "d_moy": 1, "sum_sales": 10.0, "avg_monthly_sales": 15.0 },
+  { "i_category": "CatA", "i_class": "Class1", "i_brand": "Brand1", "s_store_name": "Store1", "s_company_name": "CompanyA", "d_moy": 2, "sum_sales": 20.0, "avg_monthly_sales": 15.0 }
+]
+```

--- a/tests/dataset/tpc-dc/q89.mochi
+++ b/tests/dataset/tpc-dc/q89.mochi
@@ -1,13 +1,61 @@
-let store_sales = [
-  {price: 40.0},
-  {price: 30.0},
-  {price: 19.0}
+let item = [
+  { i_item_sk: 1, i_category: "CatA", i_class: "Class1", i_brand: "Brand1" },
+  { i_item_sk: 2, i_category: "CatA", i_class: "Class2", i_brand: "Brand1" },
+  { i_item_sk: 3, i_category: "CatB", i_class: "Class3", i_brand: "Brand2" }
 ]
 
-let result = sum(from s in store_sales select s.price)
+let store = [
+  { s_store_sk: 1, s_store_name: "Store1", s_company_name: "CompanyA" }
+]
+
+let date_dim = [
+  { d_date_sk: 1, d_moy: 1, d_year: 1999 },
+  { d_date_sk: 2, d_moy: 2, d_year: 1999 }
+]
+
+let store_sales = [
+  { ss_item_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 2, ss_sales_price: 20.0 },
+  { ss_item_sk: 2, ss_store_sk: 1, ss_sold_date_sk: 1, ss_sales_price: 15.0 },
+  { ss_item_sk: 3, ss_store_sk: 1, ss_sold_date_sk: 1, ss_sales_price: 30.0 }
+]
+
+let yearly =
+  from ss in store_sales
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  join i in item on ss.ss_item_sk == i.i_item_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  where d.d_year == 1999
+  group by { cat: i.i_category, class: i.i_class, brand: i.i_brand, store: s.s_store_name, company: s.s_company_name, moy: d.d_moy } into g
+  select { key: g.key, sum_sales: sum(from x in g select x.ss.ss_sales_price) }
+
+let avg_map =
+  from y in yearly
+  group by { cat: y.key.cat, brand: y.key.brand, store: y.key.store, company: y.key.company } into g
+  select { key: g.key, avg_sales: avg(from x in g select x.sum_sales) }
+
+let result =
+  from y in yearly
+  join a in avg_map on y.key.cat == a.key.cat && y.key.brand == a.key.brand && y.key.store == a.key.store && y.key.company == a.key.company
+  where abs(y.sum_sales - a.avg_sales) / a.avg_sales > 0.1
+  sort by y.key.cat, y.key.class, y.key.moy
+  select {
+    i_category: y.key.cat,
+    i_class: y.key.class,
+    i_brand: y.key.brand,
+    s_store_name: y.key.store,
+    s_company_name: y.key.company,
+    d_moy: y.key.moy,
+    sum_sales: y.sum_sales,
+    avg_monthly_sales: a.avg_sales
+  }
+  |> to_list
 
 json(result)
 
-test "TPCDC Q89 sample" {
-  expect result == 89.0
+test "TPCDC Q89 variance" {
+  expect result == [
+    { i_category: "CatA", i_class: "Class1", i_brand: "Brand1", s_store_name: "Store1", s_company_name: "CompanyA", d_moy: 1, sum_sales: 10.0, avg_monthly_sales: 15.0 },
+    { i_category: "CatA", i_class: "Class1", i_brand: "Brand1", s_store_name: "Store1", s_company_name: "CompanyA", d_moy: 2, sum_sales: 20.0, avg_monthly_sales: 15.0 }
+  ]
 }


### PR DESCRIPTION
## Summary
- implement realistic sample datasets for TPC‑DC queries 80‑89
- update associated docs with example outputs
- add tests matching the SQL semantics

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862101b893483209fbccbd5bc3f7979