### PR TITLE
Update TPC‑DS Q1 IR and improve VM sum

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -144,7 +144,7 @@ func applyTags(tags []RegTag, ins Instr) {
 	case OpAvg:
 		tags[ins.A] = TagFloat
 	case OpSum:
-		tags[ins.A] = TagFloat
+		tags[ins.A] = TagUnknown
 	case OpMin, OpMax:
 		tags[ins.A] = TagUnknown
 	case OpValues:

--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -842,11 +842,22 @@ func evalUnaryConst(op Op, v Value) (Value, bool) {
 		}
 	case OpSum:
 		if lst, ok := toList(v); ok {
-			var sum float64
+			allInt := true
+			var sumF float64
+			var sumI int
 			for _, it := range lst {
-				sum += toFloat(it)
+				if it.Tag == ValueInt {
+					sumI += it.Int
+				} else {
+					allInt = false
+					sumF += toFloat(it)
+				}
 			}
-			return Value{Tag: ValueFloat, Float: sum}, true
+			if allInt {
+				return Value{Tag: ValueInt, Int: sumI}, true
+			}
+			sumF += float64(sumI)
+			return Value{Tag: ValueFloat, Float: sumF}, true
 		}
 	case OpMin:
 		if lst, ok := toList(v); ok {

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1334,11 +1334,23 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("sum expects list")
 			}
-			var sum float64
+			var sumF float64
+			var sumI int
+			allInt := true
 			for _, v := range lst.List {
-				sum += toFloat(v)
+				if v.Tag == ValueInt {
+					sumI += v.Int
+				} else {
+					allInt = false
+					sumF += toFloat(v)
+				}
 			}
-			fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sum}
+			if allInt {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: sumI}
+			} else {
+				sumF += float64(sumI)
+				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sumF}
+			}
 		case OpMin:
 			lst := fr.regs[ins.B]
 			if lst.Tag == ValueMap {

--- a/tests/dataset/tpc-ds/q1.mochi
+++ b/tests/dataset/tpc-ds/q1.mochi
@@ -4,6 +4,8 @@ let date_dim = []
 let store = []
 let customer = []
 
+// Tables are intentionally empty so the query executes without loading data
+
 // Query executes over the empty tables and therefore
 // produces an empty result set.
 let customer_total_return =


### PR DESCRIPTION
## Summary
- refine `OpSum` so sums of integers return an integer
- propagate this in liveness and inference passes
- clarify that TPC‑DS tables are empty
- regenerate `q1.ir.out` with no trailing newline

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862140ab0d0832080e5360f5a70d7a8