### PR TITLE
Add TPC-DC queries 13-19

### DIFF
--- a/tests/dataset/tpc-dc/q13.md
+++ b/tests/dataset/tpc-dc/q13.md
@@ -1,0 +1,61 @@
+# TPC-DC Query 13
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q13.sql--
+
+SELECT
+  avg(ss_quantity),
+  avg(ss_ext_sales_price),
+  avg(ss_ext_wholesale_cost),
+  sum(ss_ext_wholesale_cost)
+FROM store_sales
+  , store
+  , customer_demographics
+  , household_demographics
+  , customer_address
+  , date_dim
+WHERE s_store_sk = ss_store_sk
+  AND ss_sold_date_sk = d_date_sk AND d_year = 2001
+  AND ((ss_hdemo_sk = hd_demo_sk
+  AND cd_demo_sk = ss_cdemo_sk
+  AND cd_marital_status = 'M'
+  AND cd_education_status = 'Advanced Degree'
+  AND ss_sales_price BETWEEN 100.00 AND 150.00
+  AND hd_dep_count = 3
+) OR
+  (ss_hdemo_sk = hd_demo_sk
+    AND cd_demo_sk = ss_cdemo_sk
+    AND cd_marital_status = 'S'
+    AND cd_education_status = 'College'
+    AND ss_sales_price BETWEEN 50.00 AND 100.00
+    AND hd_dep_count = 1
+  ) OR
+  (ss_hdemo_sk = hd_demo_sk
+    AND cd_demo_sk = ss_cdemo_sk
+    AND cd_marital_status = 'W'
+    AND cd_education_status = '2 yr Degree'
+    AND ss_sales_price BETWEEN 150.00 AND 200.00
+    AND hd_dep_count = 1
+  ))
+  AND ((ss_addr_sk = ca_address_sk
+  AND ca_country = 'United States'
+  AND ca_state IN ('TX', 'OH', 'TX')
+  AND ss_net_profit BETWEEN 100 AND 200
+) OR
+  (ss_addr_sk = ca_address_sk
+    AND ca_country = 'United States'
+    AND ca_state IN ('OR', 'NM', 'KY')
+    AND ss_net_profit BETWEEN 150 AND 300
+  ) OR
+  (ss_addr_sk = ca_address_sk
+    AND ca_country = 'United States'
+    AND ca_state IN ('VA', 'TX', 'MS')
+    AND ss_net_profit BETWEEN 50 AND 250
+  ))
+```
+
+## Expected Output
+Aggregates of sales quantities and prices that match the filter conditions.

--- a/tests/dataset/tpc-dc/q13.mochi
+++ b/tests/dataset/tpc-dc/q13.mochi
@@ -1,0 +1,73 @@
+let store_sales = [
+  {ss_quantity: 2, ss_ext_sales_price: 200.0, ss_ext_wholesale_cost: 150.0,
+   ss_sales_price: 120.0, ss_net_profit: 150, ss_hdemo_sk: 1, ss_cdemo_sk: 1,
+   ss_addr_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1},
+  {ss_quantity: 3, ss_ext_sales_price: 90.0, ss_ext_wholesale_cost: 70.0,
+   ss_sales_price: 75.0, ss_net_profit: 160, ss_hdemo_sk: 2, ss_cdemo_sk: 2,
+   ss_addr_sk: 2, ss_store_sk: 1, ss_sold_date_sk: 1},
+  {ss_quantity: 4, ss_ext_sales_price: 180.0, ss_ext_wholesale_cost: 100.0,
+   ss_sales_price: 170.0, ss_net_profit: 60, ss_hdemo_sk: 3, ss_cdemo_sk: 3,
+   ss_addr_sk: 3, ss_store_sk: 1, ss_sold_date_sk: 1},
+]
+
+let store = [{s_store_sk: 1}]
+
+let customer_demographics = [
+  {cd_demo_sk: 1, cd_marital_status: "M", cd_education_status: "Advanced Degree"},
+  {cd_demo_sk: 2, cd_marital_status: "S", cd_education_status: "College"},
+  {cd_demo_sk: 3, cd_marital_status: "W", cd_education_status: "2 yr Degree"},
+]
+
+let household_demographics = [
+  {hd_demo_sk: 1, hd_dep_count: 3},
+  {hd_demo_sk: 2, hd_dep_count: 1},
+  {hd_demo_sk: 3, hd_dep_count: 1},
+]
+
+let customer_address = [
+  {ca_address_sk: 1, ca_country: "United States", ca_state: "TX"},
+  {ca_address_sk: 2, ca_country: "United States", ca_state: "OR"},
+  {ca_address_sk: 3, ca_country: "United States", ca_state: "VA"},
+]
+
+let date_dim = [{d_date_sk: 1, d_year: 2001}]
+
+let filtered =
+  from ss in store_sales
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
+  join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  where d.d_year == 2001 &&
+        (
+          (cd.cd_marital_status == "M" && cd.cd_education_status == "Advanced Degree" &&
+           ss.ss_sales_price >= 100.0 && ss.ss_sales_price <= 150.0 && hd.hd_dep_count == 3) ||
+          (cd.cd_marital_status == "S" && cd.cd_education_status == "College" &&
+           ss.ss_sales_price >= 50.0 && ss.ss_sales_price <= 100.0 && hd.hd_dep_count == 1) ||
+          (cd.cd_marital_status == "W" && cd.cd_education_status == "2 yr Degree" &&
+           ss.ss_sales_price >= 150.0 && ss.ss_sales_price <= 200.0 && hd.hd_dep_count == 1)
+        ) &&
+        (
+          (ca.ca_country == "United States" && ca.ca_state in ["TX","OH","TX"] && ss.ss_net_profit >= 100 && ss.ss_net_profit <= 200) ||
+          (ca.ca_country == "United States" && ca.ca_state in ["OR","NM","KY"] && ss.ss_net_profit >= 150 && ss.ss_net_profit <= 300) ||
+          (ca.ca_country == "United States" && ca.ca_state in ["VA","TX","MS"] && ss.ss_net_profit >= 50 && ss.ss_net_profit <= 250)
+        )
+  select ss
+  |> to_list
+
+let result = {
+  avg_ss_quantity: avg(from x in filtered select x.ss_quantity),
+  avg_ss_ext_sales_price: avg(from x in filtered select x.ss_ext_sales_price),
+  avg_ss_ext_wholesale_cost: avg(from x in filtered select x.ss_ext_wholesale_cost),
+  sum_ss_ext_wholesale_cost: sum(from x in filtered select x.ss_ext_wholesale_cost)
+}
+
+json(result)
+
+test "TPCDC Q13 aggregates" {
+  expect result.avg_ss_quantity == 3.0
+  expect result.avg_ss_ext_sales_price == 156.66666666666666
+  expect result.avg_ss_ext_wholesale_cost == 106.66666666666667
+  expect result.sum_ss_ext_wholesale_cost == 320.0
+}

--- a/tests/dataset/tpc-dc/q14.md
+++ b/tests/dataset/tpc-dc/q14.md
@@ -1,0 +1,131 @@
+# TPC-DC Query 14
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q14.sql--
+WITH cross_items AS
+(SELECT i_item_sk ss_item_sk
+  FROM item,
+    (SELECT
+      iss.i_brand_id brand_id,
+      iss.i_class_id class_id,
+      iss.i_category_id category_id
+    FROM store_sales, item iss, date_dim d1
+    WHERE ss_item_sk = iss.i_item_sk
+      AND ss_sold_date_sk = d1.d_date_sk
+      AND d1.d_year BETWEEN 1999 AND 1999 + 2
+    INTERSECT
+    SELECT
+      ics.i_brand_id,
+      ics.i_class_id,
+      ics.i_category_id
+    FROM catalog_sales, item ics, date_dim d2
+    WHERE cs_item_sk = ics.i_item_sk
+      AND cs_sold_date_sk = d2.d_date_sk
+      AND d2.d_year BETWEEN 1999 AND 1999 + 2
+    INTERSECT
+    SELECT
+      iws.i_brand_id,
+      iws.i_class_id,
+      iws.i_category_id
+    FROM web_sales, item iws, date_dim d3
+    WHERE ws_item_sk = iws.i_item_sk
+      AND ws_sold_date_sk = d3.d_date_sk
+      AND d3.d_year BETWEEN 1999 AND 1999 + 2) x
+  WHERE i_brand_id = brand_id
+    AND i_class_id = class_id
+    AND i_category_id = category_id
+),
+    avg_sales AS
+  (SELECT avg(quantity * list_price) average_sales
+  FROM (
+         SELECT
+           ss_quantity quantity,
+           ss_list_price list_price
+         FROM store_sales, date_dim
+         WHERE ss_sold_date_sk = d_date_sk
+           AND d_year BETWEEN 1999 AND 2001
+         UNION ALL
+         SELECT
+           cs_quantity quantity,
+           cs_list_price list_price
+         FROM catalog_sales, date_dim
+         WHERE cs_sold_date_sk = d_date_sk
+           AND d_year BETWEEN 1999 AND 1999 + 2
+         UNION ALL
+         SELECT
+           ws_quantity quantity,
+           ws_list_price list_price
+         FROM web_sales, date_dim
+         WHERE ws_sold_date_sk = d_date_sk
+           AND d_year BETWEEN 1999 AND 1999 + 2) x)
+SELECT
+  channel,
+  i_brand_id,
+  i_class_id,
+  i_category_id,
+  sum(sales),
+  sum(number_sales)
+FROM (
+       SELECT
+         'store' channel,
+         i_brand_id,
+         i_class_id,
+         i_category_id,
+         sum(ss_quantity * ss_list_price) sales,
+         count(*) number_sales
+       FROM store_sales, item, date_dim
+       WHERE ss_item_sk IN (SELECT ss_item_sk
+       FROM cross_items)
+         AND ss_item_sk = i_item_sk
+         AND ss_sold_date_sk = d_date_sk
+         AND d_year = 1999 + 2
+         AND d_moy = 11
+       GROUP BY i_brand_id, i_class_id, i_category_id
+       HAVING sum(ss_quantity * ss_list_price) > (SELECT average_sales
+       FROM avg_sales)
+       UNION ALL
+       SELECT
+         'catalog' channel,
+         i_brand_id,
+         i_class_id,
+         i_category_id,
+         sum(cs_quantity * cs_list_price) sales,
+         count(*) number_sales
+       FROM catalog_sales, item, date_dim
+       WHERE cs_item_sk IN (SELECT ss_item_sk
+       FROM cross_items)
+         AND cs_item_sk = i_item_sk
+         AND cs_sold_date_sk = d_date_sk
+         AND d_year = 1999 + 2
+         AND d_moy = 11
+       GROUP BY i_brand_id, i_class_id, i_category_id
+       HAVING sum(cs_quantity * cs_list_price) > (SELECT average_sales FROM avg_sales)
+       UNION ALL
+       SELECT
+         'web' channel,
+         i_brand_id,
+         i_class_id,
+         i_category_id,
+         sum(ws_quantity * ws_list_price) sales,
+         count(*) number_sales
+       FROM web_sales, item, date_dim
+       WHERE ws_item_sk IN (SELECT ss_item_sk
+       FROM cross_items)
+         AND ws_item_sk = i_item_sk
+         AND ws_sold_date_sk = d_date_sk
+         AND d_year = 1999 + 2
+         AND d_moy = 11
+       GROUP BY i_brand_id, i_class_id, i_category_id
+       HAVING sum(ws_quantity * ws_list_price) > (SELECT average_sales
+       FROM avg_sales)
+     ) y
+GROUP BY ROLLUP (channel, i_brand_id, i_class_id, i_category_id)
+ORDER BY channel, i_brand_id, i_class_id, i_category_id
+LIMIT 100
+```
+
+## Expected Output
+Sales totals by channel for items appearing in all channels over the analysis period.

--- a/tests/dataset/tpc-dc/q14.mochi
+++ b/tests/dataset/tpc-dc/q14.mochi
@@ -1,0 +1,78 @@
+let item = [
+  {i_item_sk: 1, i_brand_id: 1, i_class_id: 1, i_category_id: 1}
+]
+
+let store_sales = [
+  {i_item_sk: 1, ss_quantity: 3, ss_list_price: 10.0, d_year: 1999},
+  {i_item_sk: 1, ss_quantity: 7, ss_list_price: 10.0, d_year: 2001, d_moy: 11}
+]
+
+let catalog_sales = [
+  {i_item_sk: 1, cs_quantity: 4, cs_list_price: 10.0, d_year: 1999},
+  {i_item_sk: 1, cs_quantity: 8, cs_list_price: 10.0, d_year: 2001, d_moy: 11}
+]
+
+let web_sales = [
+  {i_item_sk: 1, ws_quantity: 5, ws_list_price: 10.0, d_year: 1999},
+  {i_item_sk: 1, ws_quantity: 9, ws_list_price: 10.0, d_year: 2001, d_moy: 11}
+]
+
+// items appearing in all channels between 1999 and 2001
+let cross_items =
+  let store_items = distinct(from s in store_sales select s.i_item_sk)
+  let catalog_items = distinct(from c in catalog_sales select c.i_item_sk)
+  let web_items = distinct(from w in web_sales select w.i_item_sk)
+  from i in store_items where contains(catalog_items, i) && contains(web_items, i) select i |> to_list
+
+// average sales across all channels in that period
+let all_sales =
+  concat(
+    from s in store_sales select s.ss_quantity * s.ss_list_price,
+    from c in catalog_sales select c.cs_quantity * c.cs_list_price,
+    from w in web_sales select w.ws_quantity * w.ws_list_price
+  )
+let avg_sales = avg(all_sales)
+
+// totals for November of 2001
+let result =
+  from channel in ["store", "catalog", "web"]
+  let rows =
+    if channel == "store" {
+      from s in store_sales where s.d_year == 2001 && s.d_moy == 11 && contains(cross_items, s.i_item_sk) select {
+        qty_price: s.ss_quantity * s.ss_list_price,
+        item_sk: s.i_item_sk
+      }
+    } else if channel == "catalog" {
+      from c in catalog_sales where c.d_year == 2001 && c.d_moy == 11 && contains(cross_items, c.i_item_sk) select {
+        qty_price: c.cs_quantity * c.cs_list_price,
+        item_sk: c.i_item_sk
+      }
+    } else {
+      from w in web_sales where w.d_year == 2001 && w.d_moy == 11 && contains(cross_items, w.i_item_sk) select {
+        qty_price: w.ws_quantity * w.ws_list_price,
+        item_sk: w.i_item_sk
+      }
+    }
+  let total = sum(from r in rows select r.qty_price)
+  let count_rows = len(rows)
+  where total > avg_sales
+  join it in item on first(from r in rows select r.item_sk) == it.i_item_sk
+  select {
+    channel: channel,
+    i_brand_id: it.i_brand_id,
+    i_class_id: it.i_class_id,
+    i_category_id: it.i_category_id,
+    sales: total,
+    number_sales: count_rows
+  }
+  |> to_list
+
+json(result)
+
+test "TPCDC Q14 channel sales" {
+  expect result == [
+    {channel: "store", i_brand_id: 1, i_class_id: 1, i_category_id: 1, sales: 70.0, number_sales: 1},
+    {channel: "catalog", i_brand_id: 1, i_class_id: 1, i_category_id: 1, sales: 80.0, number_sales: 1},
+    {channel: "web", i_brand_id: 1, i_class_id: 1, i_category_id: 1, sales: 90.0, number_sales: 1}
+  ]
+}

--- a/tests/dataset/tpc-dc/q15.md
+++ b/tests/dataset/tpc-dc/q15.md
@@ -1,0 +1,26 @@
+# TPC-DC Query 15
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q15.sql--
+SELECT
+  ca_zip,
+  sum(cs_sales_price)
+FROM catalog_sales, customer, customer_address, date_dim
+WHERE cs_bill_customer_sk = c_customer_sk
+  AND c_current_addr_sk = ca_address_sk
+  AND (substr(ca_zip, 1, 5) IN ('85669', '86197', '88274', '83405', '86475',
+                                '85392', '85460', '80348', '81792')
+  OR ca_state IN ('CA', 'WA', 'GA')
+  OR cs_sales_price > 500)
+  AND cs_sold_date_sk = d_date_sk
+  AND d_qoy = 2 AND d_year = 2001
+GROUP BY ca_zip
+ORDER BY ca_zip
+LIMIT 100
+```
+
+## Expected Output
+Catalog sales by zip code for the filtered addresses.

--- a/tests/dataset/tpc-dc/q15.mochi
+++ b/tests/dataset/tpc-dc/q15.mochi
@@ -1,0 +1,45 @@
+let customer = [
+  {c_customer_sk: 1, c_current_addr_sk: 1},
+  {c_customer_sk: 2, c_current_addr_sk: 2},
+  {c_customer_sk: 3, c_current_addr_sk: 3}
+]
+
+let customer_address = [
+  {ca_address_sk: 1, ca_zip: "85669", ca_state: "TX"},
+  {ca_address_sk: 2, ca_zip: "00000", ca_state: "CA"},
+  {ca_address_sk: 3, ca_zip: "99999", ca_state: "FL"}
+]
+
+let catalog_sales = [
+  {cs_bill_customer_sk: 1, cs_sold_date_sk: 1, cs_sales_price: 100.0},
+  {cs_bill_customer_sk: 2, cs_sold_date_sk: 1, cs_sales_price: 50.0},
+  {cs_bill_customer_sk: 3, cs_sold_date_sk: 1, cs_sales_price: 600.0}
+]
+
+let date_dim = [{d_date_sk: 1, d_qoy: 2, d_year: 2001}]
+
+let result =
+  from cs in catalog_sales
+  join c in customer on cs.cs_bill_customer_sk == c.c_customer_sk
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  where (
+    substr(ca.ca_zip, 0, 5) in ["85669","86197","88274","83405","86475","85392","85460","80348","81792"] ||
+    ca.ca_state in ["CA","WA","GA"] ||
+    cs.cs_sales_price > 500.0
+  ) &&
+        d.d_qoy == 2 && d.d_year == 2001
+  group by {zip: ca.ca_zip} into g
+  sort by g.key.zip
+  select {ca_zip: g.key.zip, total: sum(from x in g select x.cs_sales_price)}
+  |> to_list
+
+json(result)
+
+test "TPCDC Q15 catalog sales" {
+  expect result == [
+    {ca_zip: "00000", total: 50.0},
+    {ca_zip: "85669", total: 100.0},
+    {ca_zip: "99999", total: 600.0}
+  ]
+}

--- a/tests/dataset/tpc-dc/q16.md
+++ b/tests/dataset/tpc-dc/q16.md
@@ -1,0 +1,34 @@
+# TPC-DC Query 16
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q16.sql--
+SELECT
+  count(DISTINCT cs_order_number) AS `order count `,
+  sum(cs_ext_ship_cost) AS `total shipping cost `,
+  sum(cs_net_profit) AS `total net profit `
+FROM
+  catalog_sales cs1, date_dim, customer_address, call_center
+WHERE
+  d_date BETWEEN '2002-02-01' AND (CAST('2002-02-01' AS DATE) + INTERVAL 60 days)
+    AND cs1.cs_ship_date_sk = d_date_sk
+    AND cs1.cs_ship_addr_sk = ca_address_sk
+    AND ca_state = 'GA'
+    AND cs1.cs_call_center_sk = cc_call_center_sk
+    AND cc_county IN
+    ('Williamson County', 'Williamson County', 'Williamson County', 'Williamson County', 'Williamson County')
+    AND EXISTS(SELECT *
+               FROM catalog_sales cs2
+               WHERE cs1.cs_order_number = cs2.cs_order_number
+                 AND cs1.cs_warehouse_sk <> cs2.cs_warehouse_sk)
+    AND NOT EXISTS(SELECT *
+                   FROM catalog_returns cr1
+                   WHERE cs1.cs_order_number = cr1.cr_order_number)
+ORDER BY count(DISTINCT cs_order_number)
+LIMIT 100
+```
+
+## Expected Output
+Counts and sums for qualifying catalog orders.

--- a/tests/dataset/tpc-dc/q16.mochi
+++ b/tests/dataset/tpc-dc/q16.mochi
@@ -1,0 +1,46 @@
+let catalog_sales = [
+  {cs_order_number: 1, cs_warehouse_sk: 1, cs_ship_date_sk: 1, cs_ship_addr_sk: 1,
+   cs_call_center_sk: 1, cs_ext_ship_cost: 10.0, cs_net_profit: 20.0},
+  {cs_order_number: 1, cs_warehouse_sk: 2, cs_ship_date_sk: 1, cs_ship_addr_sk: 1,
+   cs_call_center_sk: 1, cs_ext_ship_cost: 15.0, cs_net_profit: 25.0},
+  {cs_order_number: 2, cs_warehouse_sk: 1, cs_ship_date_sk: 1, cs_ship_addr_sk: 1,
+   cs_call_center_sk: 1, cs_ext_ship_cost: 5.0, cs_net_profit: 10.0}
+]
+
+let catalog_returns = [
+  {cr_order_number: 2}
+]
+
+let date_dim = [{d_date_sk: 1, d_date: "2002-02-10"}]
+let customer_address = [{ca_address_sk: 1, ca_state: "GA"}]
+let call_center = [{cc_call_center_sk: 1, cc_county: "Williamson County"}]
+
+// filter catalog sales with the complex conditions
+let filtered =
+  from cs1 in catalog_sales
+  join d in date_dim on cs1.cs_ship_date_sk == d.d_date_sk
+  join ca in customer_address on cs1.cs_ship_addr_sk == ca.ca_address_sk
+  join cc in call_center on cs1.cs_call_center_sk == cc.cc_call_center_sk
+  where d.d_date >= "2002-02-01" && d.d_date <= "2002-04-02" &&
+        ca.ca_state == "GA" &&
+        cc.cc_county == "Williamson County" &&
+        exists(from cs2 in catalog_sales
+               where cs1.cs_order_number == cs2.cs_order_number && cs1.cs_warehouse_sk != cs2.cs_warehouse_sk
+               select cs2) &&
+        !exists(from cr in catalog_returns where cs1.cs_order_number == cr.cr_order_number select cr)
+  select cs1
+  |> to_list
+
+let result = {
+  order_count: len(distinct(from x in filtered select x.cs_order_number)),
+  total_shipping_cost: sum(from x in filtered select x.cs_ext_ship_cost),
+  total_net_profit: sum(from x in filtered select x.cs_net_profit)
+}
+
+json(result)
+
+test "TPCDC Q16 order summary" {
+  expect result.order_count == 1
+  expect result.total_shipping_cost == 25.0
+  expect result.total_net_profit == 45.0
+}

--- a/tests/dataset/tpc-dc/q17.md
+++ b/tests/dataset/tpc-dc/q17.md
@@ -1,0 +1,44 @@
+# TPC-DC Query 17
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q17.sql--
+SELECT
+  i_item_id,
+  i_item_desc,
+  s_state,
+  count(ss_quantity) AS store_sales_quantitycount,
+  avg(ss_quantity) AS store_sales_quantityave,
+  stddev_samp(ss_quantity) AS store_sales_quantitystdev,
+  stddev_samp(ss_quantity) / avg(ss_quantity) AS store_sales_quantitycov,
+  count(sr_return_quantity) as_store_returns_quantitycount,
+  avg(sr_return_quantity) as_store_returns_quantityave,
+  stddev_samp(sr_return_quantity) as_store_returns_quantitystdev,
+  stddev_samp(sr_return_quantity) / avg(sr_return_quantity) AS store_returns_quantitycov,
+  count(cs_quantity) AS catalog_sales_quantitycount,
+  avg(cs_quantity) AS catalog_sales_quantityave,
+  stddev_samp(cs_quantity) / avg(cs_quantity) AS catalog_sales_quantitystdev,
+  stddev_samp(cs_quantity) / avg(cs_quantity) AS catalog_sales_quantitycov
+FROM store_sales, store_returns, catalog_sales, date_dim d1, date_dim d2, date_dim d3, store, item
+WHERE d1.d_quarter_name = '2001Q1'
+  AND d1.d_date_sk = ss_sold_date_sk
+  AND i_item_sk = ss_item_sk
+  AND s_store_sk = ss_store_sk
+  AND ss_customer_sk = sr_customer_sk
+  AND ss_item_sk = sr_item_sk
+  AND ss_ticket_number = sr_ticket_number
+  AND sr_returned_date_sk = d2.d_date_sk
+  AND d2.d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3')
+  AND sr_customer_sk = cs_bill_customer_sk
+  AND sr_item_sk = cs_item_sk
+  AND cs_sold_date_sk = d3.d_date_sk
+  AND d3.d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3')
+GROUP BY i_item_id, i_item_desc, s_state
+ORDER BY i_item_id, i_item_desc, s_state
+LIMIT 100
+```
+
+## Expected Output
+Item sales and return statistics across channels.

--- a/tests/dataset/tpc-dc/q17.mochi
+++ b/tests/dataset/tpc-dc/q17.mochi
@@ -1,0 +1,90 @@
+import math
+
+let store_sales = [
+  {ss_quantity: 10, ss_sold_date_sk: 1, ss_customer_sk: 1, ss_item_sk: 1, ss_ticket_number: 1, ss_store_sk: 1}
+]
+
+let store_returns = [
+  {sr_return_quantity: 2, sr_customer_sk: 1, sr_item_sk: 1, sr_ticket_number: 1, sr_returned_date_sk: 2}
+]
+
+let catalog_sales = [
+  {cs_quantity: 3, cs_bill_customer_sk: 1, cs_item_sk: 1, cs_sold_date_sk: 3}
+]
+
+let date_dim = [
+  {d_date_sk: 1, d_quarter_name: "2001Q1"},
+  {d_date_sk: 2, d_quarter_name: "2001Q2"},
+  {d_date_sk: 3, d_quarter_name: "2001Q3"}
+]
+
+let store = [{s_store_sk: 1, s_state: "TX"}]
+let item = [{i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Item 1"}]
+
+fn stddev_samp(xs: list<float>) {
+  let m = avg(xs)
+  let v = sum(from x in xs select (x - m) * (x - m)) / (len(xs) - 1)
+  math.sqrt(v)
+}
+
+let joined =
+  from ss in store_sales
+  join sr in store_returns on ss.ss_customer_sk == sr.sr_customer_sk && ss.ss_item_sk == sr.sr_item_sk && ss.ss_ticket_number == sr.sr_ticket_number
+  join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
+  join d1 in date_dim on ss.ss_sold_date_sk == d1.d_date_sk
+  join d2 in date_dim on sr.sr_returned_date_sk == d2.d_date_sk
+  join d3 in date_dim on cs.cs_sold_date_sk == d3.d_date_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  join i in item on ss.ss_item_sk == i.i_item_sk
+  where d1.d_quarter_name == "2001Q1" && d2.d_quarter_name in ["2001Q1","2001Q2","2001Q3"] && d3.d_quarter_name in ["2001Q1","2001Q2","2001Q3"]
+  select {i_item_id: i.i_item_id, i_item_desc: i.i_item_desc, s_state: s.s_state, ss_quantity: ss.ss_quantity, sr_qty: sr.sr_return_quantity, cs_qty: cs.cs_quantity}
+  |> to_list
+
+let result =
+  from j in joined
+  group by {id: j.i_item_id, desc: j.i_item_desc, state: j.s_state} into g
+  let ssq = from x in g select float(x.ss_quantity)
+  let srq = from x in g select float(x.sr_qty)
+  let csq = from x in g select float(x.cs_qty)
+  select {
+    i_item_id: g.key.id,
+    i_item_desc: g.key.desc,
+    s_state: g.key.state,
+    store_sales_quantitycount: len(ssq),
+    store_sales_quantityave: avg(ssq),
+    store_sales_quantitystdev: if len(ssq) > 1 { stddev_samp(ssq) } else { 0.0 },
+    store_sales_quantitycov: if avg(ssq) != 0 { (if len(ssq) > 1 { stddev_samp(ssq) } else { 0.0 }) / avg(ssq) } else { 0.0 },
+    store_returns_quantitycount: len(srq),
+    store_returns_quantityave: avg(srq),
+    store_returns_quantitystdev: if len(srq) > 1 { stddev_samp(srq) } else { 0.0 },
+    store_returns_quantitycov: if avg(srq) != 0 { (if len(srq) > 1 { stddev_samp(srq) } else { 0.0 }) / avg(srq) } else { 0.0 },
+    catalog_sales_quantitycount: len(csq),
+    catalog_sales_quantityave: avg(csq),
+    catalog_sales_quantitystdev: if len(csq) > 1 { stddev_samp(csq) } else { 0.0 },
+    catalog_sales_quantitycov: if avg(csq) != 0 { (if len(csq) > 1 { stddev_samp(csq) } else { 0.0 }) / avg(csq) } else { 0.0 }
+  }
+  |> to_list
+
+json(result)
+
+test "TPCDC Q17 statistics" {
+  expect result == [
+    {
+      i_item_id: "ITEM1",
+      i_item_desc: "Item 1",
+      s_state: "TX",
+      store_sales_quantitycount: 1,
+      store_sales_quantityave: 10.0,
+      store_sales_quantitystdev: 0.0,
+      store_sales_quantitycov: 0.0,
+      store_returns_quantitycount: 1,
+      store_returns_quantityave: 2.0,
+      store_returns_quantitystdev: 0.0,
+      store_returns_quantitycov: 0.0,
+      catalog_sales_quantitycount: 1,
+      catalog_sales_quantityave: 3.0,
+      catalog_sales_quantitystdev: 0.0,
+      catalog_sales_quantitycov: 0.0
+    }
+  ]
+}

--- a/tests/dataset/tpc-dc/q18.md
+++ b/tests/dataset/tpc-dc/q18.md
@@ -1,0 +1,39 @@
+# TPC-DC Query 18
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q18.sql--
+SELECT
+  i_item_id,
+  ca_country,
+  ca_state,
+  ca_county,
+  avg(cast(cs_quantity AS DECIMAL(12, 2))) agg1,
+  avg(cast(cs_list_price AS DECIMAL(12, 2))) agg2,
+  avg(cast(cs_coupon_amt AS DECIMAL(12, 2))) agg3,
+  avg(cast(cs_sales_price AS DECIMAL(12, 2))) agg4,
+  avg(cast(cs_net_profit AS DECIMAL(12, 2))) agg5,
+  avg(cast(c_birth_year AS DECIMAL(12, 2))) agg6,
+  avg(cast(cd1.cd_dep_count AS DECIMAL(12, 2))) agg7
+FROM catalog_sales, customer_demographics cd1,
+  customer_demographics cd2, customer, customer_address, date_dim, item
+WHERE cs_sold_date_sk = d_date_sk AND
+  cs_item_sk = i_item_sk AND
+  cs_bill_cdemo_sk = cd1.cd_demo_sk AND
+  cs_bill_customer_sk = c_customer_sk AND
+  cd1.cd_gender = 'F' AND
+  cd1.cd_education_status = 'Unknown' AND
+  c_current_cdemo_sk = cd2.cd_demo_sk AND
+  c_current_addr_sk = ca_address_sk AND
+  c_birth_month IN (1, 6, 8, 9, 12, 2) AND
+  d_year = 1998 AND
+  ca_state IN ('MS', 'IN', 'ND', 'OK', 'NM', 'VA', 'MS')
+GROUP BY ROLLUP (i_item_id, ca_country, ca_state, ca_county)
+ORDER BY ca_country, ca_state, ca_county, i_item_id
+LIMIT 100
+```
+
+## Expected Output
+Average metrics for catalog sales grouped by location and item.

--- a/tests/dataset/tpc-dc/q18.mochi
+++ b/tests/dataset/tpc-dc/q18.mochi
@@ -1,0 +1,68 @@
+let catalog_sales = [
+  {cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_bill_customer_sk: 1,
+   cs_quantity: 10.0, cs_list_price: 20.0, cs_coupon_amt: 2.0, cs_sales_price: 18.0, cs_net_profit: 5.0}
+]
+
+let customer_demographics = [
+  {cd_demo_sk: 1, cd_gender: "F", cd_education_status: "Unknown"},
+  {cd_demo_sk: 2}
+]
+
+let customer = [
+  {c_customer_sk: 1, c_current_cdemo_sk: 2, c_current_addr_sk: 1, c_birth_year: 1990, c_birth_month: 1}
+]
+
+let customer_address = [
+  {ca_address_sk: 1, ca_country: "US", ca_state: "MS", ca_county: "C1"}
+]
+
+let date_dim = [{d_date_sk: 1, d_year: 1998}]
+let item = [{i_item_sk: 1, i_item_id: "ITEM1"}]
+
+let rows =
+  from cs in catalog_sales
+  join cd1 in customer_demographics on cs.cs_bill_cdemo_sk == cd1.cd_demo_sk
+  join c in customer on cs.cs_bill_customer_sk == c.c_customer_sk
+  join cd2 in customer_demographics on c.c_current_cdemo_sk == cd2.cd_demo_sk
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  join i in item on cs.cs_item_sk == i.i_item_sk
+  where cd1.cd_gender == "F" && cd1.cd_education_status == "Unknown" &&
+        c.c_birth_month in [1,6,8,9,12,2] &&
+        d.d_year == 1998 &&
+        ca.ca_state in ["MS","IN","ND","OK","NM","VA","MS"]
+  group by {item: i.i_item_id, country: ca.ca_country, state: ca.ca_state, county: ca.ca_county} into g
+  select {
+    i_item_id: g.key.item,
+    ca_country: g.key.country,
+    ca_state: g.key.state,
+    ca_county: g.key.county,
+    agg1: avg(from x in g select x.cs_quantity),
+    agg2: avg(from x in g select x.cs_list_price),
+    agg3: avg(from x in g select x.cs_coupon_amt),
+    agg4: avg(from x in g select x.cs_sales_price),
+    agg5: avg(from x in g select x.cs_net_profit),
+    agg6: avg(from x in g select float(c.c_birth_year)),
+    agg7: avg(from x in g select float(cd1.cd_dep_count ?? 0))
+  }
+  |> to_list
+
+json(rows)
+
+test "TPCDC Q18 averages" {
+  expect rows == [
+    {
+      i_item_id: "ITEM1",
+      ca_country: "US",
+      ca_state: "MS",
+      ca_county: "C1",
+      agg1: 10.0,
+      agg2: 20.0,
+      agg3: 2.0,
+      agg4: 18.0,
+      agg5: 5.0,
+      agg6: 1990.0,
+      agg7: 0.0
+    }
+  ]
+}

--- a/tests/dataset/tpc-dc/q19.md
+++ b/tests/dataset/tpc-dc/q19.md
@@ -1,0 +1,30 @@
+# TPC-DC Query 19
+
+Query extracted from the official TPC-DS specification.
+
+## SQL
+```sql
+--q19.sql--
+SELECT
+  i_brand_id brand_id,
+  i_brand brand,
+  i_manufact_id,
+  i_manufact,
+  sum(ss_ext_sales_price) ext_price
+FROM date_dim, store_sales, item, customer, customer_address, store
+WHERE d_date_sk = ss_sold_date_sk
+  AND ss_item_sk = i_item_sk
+  AND i_manager_id = 8
+  AND d_moy = 11
+  AND d_year = 1998
+  AND ss_customer_sk = c_customer_sk
+  AND c_current_addr_sk = ca_address_sk
+  AND substr(ca_zip, 1, 5) <> substr(s_zip, 1, 5)
+  AND ss_store_sk = s_store_sk
+GROUP BY i_brand, i_brand_id, i_manufact_id, i_manufact
+ORDER BY ext_price DESC, brand, brand_id, i_manufact_id, i_manufact
+LIMIT 100
+```
+
+## Expected Output
+Brand and manufacturer revenue for cross-zip sales.

--- a/tests/dataset/tpc-dc/q19.mochi
+++ b/tests/dataset/tpc-dc/q19.mochi
@@ -1,0 +1,33 @@
+let date_dim = [{d_date_sk: 1, d_moy: 11, d_year: 1998}]
+let item = [{i_item_sk: 1, i_brand_id: 1, i_brand: "B1", i_manufact_id: 1, i_manufact: "M1", i_manager_id: 8}]
+let customer = [{c_customer_sk: 1, c_current_addr_sk: 1}]
+let customer_address = [{ca_address_sk: 1, ca_zip: "12345"}]
+let store = [{s_store_sk: 1, s_zip: "99999"}]
+let store_sales = [{ss_sold_date_sk: 1, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_ext_sales_price: 100.0}]
+
+let result =
+  from d in date_dim
+  join ss in store_sales on d.d_date_sk == ss.ss_sold_date_sk
+  join i in item on ss.ss_item_sk == i.i_item_sk
+  join c in customer on ss.ss_customer_sk == c.c_customer_sk
+  join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  join s in store on ss.ss_store_sk == s.s_store_sk
+  where i.i_manager_id == 8 && d.d_moy == 11 && d.d_year == 1998 && substr(ca.ca_zip,0,5) != substr(s.s_zip,0,5)
+  group by {brand:i.i_brand, brand_id:i.i_brand_id, man_id:i.i_manufact_id, man:i.i_manufact} into g
+  sort by [sum(from x in g select x.ss_ext_sales_price) desc, g.key.brand, g.key.brand_id, g.key.man_id, g.key.man]
+  select {
+    brand: g.key.brand,
+    brand_id: g.key.brand_id,
+    i_manufact_id: g.key.man_id,
+    i_manufact: g.key.man,
+    ext_price: sum(from x in g select x.ss_ext_sales_price)
+  }
+  |> to_list
+
+json(result)
+
+test "TPCDC Q19 brand revenue" {
+  expect result == [
+    {brand: "B1", brand_id: 1, i_manufact_id: 1, i_manufact: "M1", ext_price: 100.0}
+  ]
+}


### PR DESCRIPTION
## Summary
- implement queries 13-19 from the TPC‑DS specification for the TPC‑DC dataset
- provide simplified Mochi implementations with sample data and tests

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_686211b535ec83209df0e21f34994b59