### PR TITLE
Add substr builtin and update q8 dataset

### DIFF
--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -285,6 +285,7 @@ func (i *Interpreter) builtinFuncs() map[string]func(*Interpreter, *parser.CallE
 		"input":     builtinInput,
 		"count":     builtinCount,
 		"avg":       builtinAvg,
+		"substr":    builtinSubstring,
 		"substring": builtinSubstring,
 		"eval":      builtinEval,
 	}

--- a/tests/dataset/tpc-ds/out/q8.ir.out
+++ b/tests/dataset/tpc-ds/out/q8.ir.out
@@ -1,11 +1,11 @@
-func main (regs=8)
+func main (regs=9)
   // let store_sales = []
   Const        r0, []
   // let result = []
-  Move         r5, r0
+  Move         r6, r0
   // json(result)
-  JSON         r5
+  JSON         r6
   // expect result == []
-  Equal        r7, r5, r0
-  Expect       r7
+  Equal        r8, r6, r0
+  Expect       r8
   Return       r0

--- a/tests/dataset/tpc-ds/q8.mochi
+++ b/tests/dataset/tpc-ds/q8.mochi
@@ -4,6 +4,9 @@ let store = []
 let customer_address = []
 let customer = []
 
+// exercise substr builtin
+substr("zip", 0, 2)
+
 let result = []
 json(result)
 

--- a/types/check.go
+++ b/types/check.go
@@ -428,6 +428,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: StringType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("substr", FuncType{
+		Params: []Type{StringType{}, IntType{}, IntType{}},
+		Return: StringType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("input", FuncType{
 		Params: []Type{},
 		Return: StringType{},


### PR DESCRIPTION
## Summary
- allow `substr` as an alias for `substring`
- call new builtin in the TPC-DS q8 sample
- regenerate `q8.ir.out`

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q8.mochi -update`

------
https://chatgpt.com/codex/tasks/task_e_6862141a45d8832082e6e2e695461e7b