### PR TITLE
Improve VM sum handling

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -842,6 +842,9 @@ func evalUnaryConst(op Op, v Value) (Value, bool) {
 		}
 	case OpSum:
 		if lst, ok := toList(v); ok {
+			if len(lst) == 0 {
+				return Value{Tag: ValueInt, Int: 0}, true
+			}
 			allInt := true
 			var sumF float64
 			var sumI int

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1340,11 +1340,20 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			lst := fr.regs[ins.B]
 			if lst.Tag == ValueMap {
 				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					// fast path: check group count before iterating
+					if cnt, ok := lst.Map["count"]; ok && cnt.Tag == ValueInt && cnt.Int == 0 {
+						fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+						break
+					}
 					lst = lst.Map["items"]
 				}
 			}
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("sum expects list")
+			}
+			if len(lst.List) == 0 {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
 			}
 			var sumF float64
 			var sumI int

--- a/tests/dataset/tpc-ds/q1.mochi
+++ b/tests/dataset/tpc-ds/q1.mochi
@@ -4,7 +4,8 @@ let date_dim = []
 let store = []
 let customer = []
 
-// Tables are intentionally empty so the query executes without loading data
+// Tables are intentionally empty so the query executes without loading data.
+// This sample exercises the VM's improved `sum` handling for integer groups.
 
 // Query executes over the empty tables and therefore
 // produces an empty result set.


### PR DESCRIPTION
## Summary
- speed up `sum` on groups by checking the stored count
- regenerate TPC-DS q1 IR
- clarify q1 dataset comments

## Testing
- `go test ./tests/vm -tags slow -run TestVM_TPCDS/q1.mochi -v`

------
https://chatgpt.com/codex/tasks/task_e_68621ea9039483208f671c2955bca4c8