### PR TITLE
Add first builtin and update TPC-DS query examples

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -24,7 +24,7 @@ The VM supports a small but useful subset of Mochi:
 * Function definitions
 * Function calls with any number of arguments
 * Anonymous function expressions
-* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min` and `max`
+* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `first`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min` and `max`
 * Dataset loading with `load` (optionally casting rows to a type) and saving with `save`
 * HTTP requests using the `fetch` expression
 * List, map and struct construction

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2830,6 +2830,13 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 				dst = tmp
 			}
 			return dst
+		case "first":
+			arg := fc.compileExpr(p.Call.Args[0])
+			zero := fc.newReg()
+			fc.emit(p.Pos, Instr{Op: OpConst, A: zero, Val: Value{Tag: ValueInt, Int: 0}})
+			dst := fc.newReg()
+			fc.emit(p.Pos, Instr{Op: OpIndex, A: dst, B: arg, C: zero})
+			return dst
 		case "substring":
 			str := fc.compileExpr(p.Call.Args[0])
 			start := fc.compileExpr(p.Call.Args[1])

--- a/tests/dataset/tpc-ds/out/q10.ir.out
+++ b/tests/dataset/tpc-ds/out/q10.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 10}]
   Const        r0, [{"id": 1, "val": 10}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 10
-  Const        r14, 10
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 10
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q11.ir.out
+++ b/tests/dataset/tpc-ds/out/q11.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 11}]
   Const        r0, [{"id": 1, "val": 11}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 11
-  Const        r14, 11
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 11
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q12.ir.out
+++ b/tests/dataset/tpc-ds/out/q12.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 12}]
   Const        r0, [{"id": 1, "val": 12}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 12
-  Const        r14, 12
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 12
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q13.ir.out
+++ b/tests/dataset/tpc-ds/out/q13.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 13}]
   Const        r0, [{"id": 1, "val": 13}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 13
-  Const        r14, 13
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 13
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q14.ir.out
+++ b/tests/dataset/tpc-ds/out/q14.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 14}]
   Const        r0, [{"id": 1, "val": 14}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 14
-  Const        r14, 14
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 14
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q15.ir.out
+++ b/tests/dataset/tpc-ds/out/q15.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 15}]
   Const        r0, [{"id": 1, "val": 15}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 15
-  Const        r14, 15
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 15
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q16.ir.out
+++ b/tests/dataset/tpc-ds/out/q16.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 16}]
   Const        r0, [{"id": 1, "val": 16}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 16
-  Const        r14, 16
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 16
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q17.ir.out
+++ b/tests/dataset/tpc-ds/out/q17.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 17}]
   Const        r0, [{"id": 1, "val": 17}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 17
-  Const        r14, 17
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 17
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q18.ir.out
+++ b/tests/dataset/tpc-ds/out/q18.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 18}]
   Const        r0, [{"id": 1, "val": 18}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 18
-  Const        r14, 18
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 18
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q19.ir.out
+++ b/tests/dataset/tpc-ds/out/q19.ir.out
@@ -1,4 +1,4 @@
-func main (regs=16)
+func main (regs=17)
   // let t = [{id: 1, val: 19}]
   Const        r0, [{"id": 1, "val": 19}]
   // let vals = from r in t select r.val
@@ -18,12 +18,12 @@ L1:
   AddInt       r5, r5, r12
   Jump         L1
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  // let result = first(vals)
+  Index        r14, r1, r6
   // json(result)
-  JSON         r13
+  JSON         r14
   // expect result == 19
-  Const        r14, 19
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r15, 19
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/q10.mochi
+++ b/tests/dataset/tpc-ds/q10.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 10}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q10 placeholder" {
+test "TPCDS Q10 first" {
   expect result == 10
 }

--- a/tests/dataset/tpc-ds/q11.mochi
+++ b/tests/dataset/tpc-ds/q11.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 11}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q11 placeholder" {
+test "TPCDS Q11 first" {
   expect result == 11
 }

--- a/tests/dataset/tpc-ds/q12.mochi
+++ b/tests/dataset/tpc-ds/q12.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 12}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q12 placeholder" {
+test "TPCDS Q12 first" {
   expect result == 12
 }

--- a/tests/dataset/tpc-ds/q13.mochi
+++ b/tests/dataset/tpc-ds/q13.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 13}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q13 placeholder" {
+test "TPCDS Q13 first" {
   expect result == 13
 }

--- a/tests/dataset/tpc-ds/q14.mochi
+++ b/tests/dataset/tpc-ds/q14.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 14}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q14 placeholder" {
+test "TPCDS Q14 first" {
   expect result == 14
 }

--- a/tests/dataset/tpc-ds/q15.mochi
+++ b/tests/dataset/tpc-ds/q15.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 15}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q15 placeholder" {
+test "TPCDS Q15 first" {
   expect result == 15
 }

--- a/tests/dataset/tpc-ds/q16.mochi
+++ b/tests/dataset/tpc-ds/q16.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 16}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q16 placeholder" {
+test "TPCDS Q16 first" {
   expect result == 16
 }

--- a/tests/dataset/tpc-ds/q17.mochi
+++ b/tests/dataset/tpc-ds/q17.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 17}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q17 placeholder" {
+test "TPCDS Q17 first" {
   expect result == 17
 }

--- a/tests/dataset/tpc-ds/q18.mochi
+++ b/tests/dataset/tpc-ds/q18.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 18}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q18 placeholder" {
+test "TPCDS Q18 first" {
   expect result == 18
 }

--- a/tests/dataset/tpc-ds/q19.mochi
+++ b/tests/dataset/tpc-ds/q19.mochi
@@ -1,8 +1,8 @@
 let t = [{id: 1, val: 19}]
 let vals = from r in t select r.val
-let result = vals[0]
+let result = first(vals)
 json(result)
 
-test "TPCDS Q19 placeholder" {
+test "TPCDS Q19 first" {
   expect result == 19
 }

--- a/types/check.go
+++ b/types/check.go
@@ -360,6 +360,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Pure:     true,
 		Variadic: true,
 	}, false)
+	env.SetVar("first", FuncType{
+		Params: []Type{ListType{Elem: AnyType{}}},
+		Return: AnyType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("push", FuncType{
 		Params: []Type{ListType{Elem: AnyType{}}, AnyType{}},
 		Return: ListType{Elem: AnyType{}},
@@ -2169,6 +2174,7 @@ var builtinArity = map[string]int{
 	"reduce":    3,
 	"append":    2,
 	"push":      2,
+	"first":     1,
 	"substring": 3,
 }
 
@@ -2328,6 +2334,16 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 				if _, ok := a.(AnyType); !ok {
 					return errArgTypeMismatch(pos, i, IntType{}, a)
 				}
+			}
+		}
+		return nil
+	case "first":
+		if len(args) != 1 {
+			return errArgCount(pos, name, 1, len(args))
+		}
+		if _, ok := args[0].(ListType); !ok {
+			if _, ok := args[0].(AnyType); !ok {
+				return fmt.Errorf("first() expects list, got %v", args[0])
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary
- implement `first` builtin in the VM compiler
- expose `first` builtin via type checker and README
- simplify TPC-DS queries q10–q19 to exercise `first`
- regenerate IR output for q10–q19

## Testing
- `go run ./tools/update_tpcds q10 q11 q12 q13 q14 q15 q16 q17 q18 q19`

------
https://chatgpt.com/codex/tasks/task_e_68621ef38b388320aa4c9ba5c43f4c3d