### PR TITLE
Fix VM constant handling and update TPC-DS tests

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -240,33 +240,9 @@ func replaceReg(ins *Instr, old, new int) {
 // dedupConst replaces repeated Const instructions with moves from the first
 // register holding the constant value.
 func dedupConst(fn *Function) bool {
-	changed := false
-	constReg := map[string]int{}
-	key := func(v Value) string {
-		return valueToString(v)
-	}
-	for i := 0; i < len(fn.Code); i++ {
-		ins := &fn.Code[i]
-		defs := defRegs(*ins)
-		if ins.Op == OpConst {
-			k := key(ins.Val)
-			if r, ok := constReg[k]; ok {
-				*ins = Instr{Op: OpMove, A: ins.A, B: r, Line: ins.Line}
-				changed = true
-				constReg[k] = ins.A
-			} else {
-				constReg[k] = ins.A
-			}
-		}
-		for _, r := range defs {
-			for k, reg := range constReg {
-				if reg == r && !(ins.Op == OpConst && r == ins.A && k == key(ins.Val)) {
-					delete(constReg, k)
-				}
-			}
-		}
-	}
-	return changed
+	// Disabled to avoid replacing constants defined inside conditional blocks
+	// which may lead to uninitialized register values.
+	return false
 }
 
 // Optimize removes dead instructions with no side effects.

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1603,15 +1603,14 @@ type compiler struct {
 }
 
 type funcCompiler struct {
-	fn         Function
-	idx        int
-	comp       *compiler
-	vars       map[string]int
-	scopes     []map[string]int
-	loops      []*loopContext
-	tags       map[int]regTag
-	constCache map[string]int
-	groupVar   string
+	fn       Function
+	idx      int
+	comp     *compiler
+	vars     map[string]int
+	scopes   []map[string]int
+	loops    []*loopContext
+	tags     map[int]regTag
+	groupVar string
 }
 
 func (fc *funcCompiler) freshConst(pos lexer.Position, v Value) int {
@@ -1706,7 +1705,7 @@ func compileProgram(p *parser.Program, env *types.Env) (*Program, error) {
 }
 
 func (c *compiler) compileFun(fn *parser.FunStmt) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
 	fc.fn.Name = fn.Name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(fn.Params)
@@ -1730,7 +1729,7 @@ func (c *compiler) compileFun(fn *parser.FunStmt) (Function, error) {
 }
 
 func (c *compiler) compileMethod(st types.StructType, fn *parser.FunStmt) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
 	fc.fn.Name = st.Name + "." + fn.Name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(st.Order) + len(fn.Params)
@@ -1784,7 +1783,7 @@ func (c *compiler) compileTypeMethods(td *parser.TypeDecl) error {
 }
 
 func (c *compiler) compileFunExpr(fn *parser.FunExpr, captures []string) int {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(captures) + len(fn.Params)
 	for i, name := range captures {
@@ -1826,7 +1825,7 @@ func (c *compiler) compileNamedFunExpr(name string, fn *parser.FunExpr, captures
 	prev, exists := c.fnIndex[name]
 	c.fnIndex[name] = idx
 
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
 	fc.fn.Name = name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(captures) + len(fn.Params)
@@ -1868,7 +1867,7 @@ func (c *compiler) compileNamedFunExpr(name string, fn *parser.FunExpr, captures
 }
 
 func (c *compiler) compileMain(p *parser.Program) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, constCache: map[string]int{}, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
 	fc.fn.Name = "main"
 	fc.fn.Line = 0
 	fc.fn.NumParams = 0
@@ -1960,13 +1959,9 @@ func constKey(v Value) (string, bool) {
 }
 
 func (fc *funcCompiler) constReg(pos lexer.Position, v Value) int {
-	if k, ok := constKey(v); ok {
-		if r, ok2 := fc.constCache[k]; ok2 {
-			return r
-		}
+	if _, ok := constKey(v); ok {
 		r := fc.newReg()
 		fc.emit(pos, Instr{Op: OpConst, A: r, Val: v})
-		fc.constCache[k] = r
 		return r
 	}
 	r := fc.newReg()

--- a/tests/dataset/tpc-ds/out/q1.ir.out
+++ b/tests/dataset/tpc-ds/out/q1.ir.out
@@ -1,274 +1,277 @@
-func main (regs=175)
+func main (regs=239)
   // let store_returns = []
   Const        r0, []
   // let date_dim = []
-  Move         r1, r0
+  Const        r1, []
   // let store = []
-  Move         r2, r0
+  Const        r2, []
   // let customer = []
-  Move         r3, r2
+  Const        r3, []
   // from sr in store_returns
-  Move         r4, r0
-  // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Const        r5, "customer_sk"
-  Const        r6, "sr_customer_sk"
-  Const        r7, "store_sk"
-  Const        r8, "sr_store_sk"
-  // where d.d_year == 1998
-  Const        r9, "d_year"
-  // ctr_customer_sk: g.key.customer_sk,
-  Const        r10, "ctr_customer_sk"
-  Const        r11, "key"
-  // ctr_store_sk: g.key.store_sk,
-  Const        r12, "ctr_store_sk"
-  // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Const        r13, "ctr_total_return"
-  Const        r14, "sr_return_amt"
-  // from sr in store_returns
-  MakeMap      r15, 0, r0
-  Move         r16, r4
-  IterPrep     r18, r0
-  Len          r19, r18
-  Const        r20, 0
+  Const        r4, []
+  MakeMap      r18, 0, r0
+  Const        r19, []
+  IterPrep     r21, r0
+  Len          r22, r21
+  Const        r23, 0
 L1:
-  LessInt      r21, r20, r19
-  JumpIfFalse  r21, L0
-  Index        r23, r18, r20
+  LessInt      r24, r23, r22
+  JumpIfFalse  r24, L0
+  Index        r26, r21, r23
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  IterPrep     r24, r1
-  Len          r25, r24
-  Move         r26, r20
+  IterPrep     r27, r1
+  Len          r28, r27
+  Const        r29, 0
 L2:
-  LessInt      r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r29, r24, r26
-  Const        r30, "sr_returned_date_sk"
-  Index        r31, r23, r30
-  Const        r32, "d_date_sk"
-  Index        r33, r29, r32
-  Equal        r34, r31, r33
-  JumpIfFalse  r34, L2
-  // where d.d_year == 1998
-  Index        r35, r29, r9
-  Const        r36, 1998
-  Equal        r37, r35, r36
+  LessInt      r30, r29, r28
+  JumpIfFalse  r30, L1
+  Index        r32, r27, r29
+  Const        r33, "sr_returned_date_sk"
+  Index        r34, r26, r33
+  Const        r35, "d_date_sk"
+  Index        r36, r32, r35
+  Equal        r37, r34, r36
   JumpIfFalse  r37, L2
+  // where d.d_year == 1998
+  Const        r38, "d_year"
+  Index        r39, r32, r38
+  Const        r40, 1998
+  Equal        r41, r39, r40
+  JumpIfFalse  r41, L2
   // from sr in store_returns
-  Const        r38, "sr"
-  Move         r39, r23
-  Const        r40, "d"
-  Move         r41, r29
-  MakeMap      r42, 2, r38
+  Const        r42, "sr"
+  Move         r43, r26
+  Const        r44, "d"
+  Move         r45, r32
+  MakeMap      r46, 2, r42
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Move         r43, r5
-  Index        r44, r23, r6
-  Move         r45, r7
-  Index        r46, r23, r8
-  Move         r47, r43
-  Move         r48, r44
-  Move         r49, r45
-  Move         r50, r46
-  MakeMap      r51, 2, r47
-  Str          r52, r51
-  In           r53, r52, r15
-  JumpIfTrue   r53, L3
+  Const        r47, "customer_sk"
+  Const        r48, "sr_customer_sk"
+  Index        r49, r26, r48
+  Const        r50, "store_sk"
+  Const        r51, "sr_store_sk"
+  Index        r52, r26, r51
+  Move         r53, r47
+  Move         r54, r49
+  Move         r55, r50
+  Move         r56, r52
+  MakeMap      r57, 2, r53
+  Str          r58, r57
+  In           r59, r58, r18
+  JumpIfTrue   r59, L3
   // from sr in store_returns
-  Move         r54, r4
-  Const        r55, "__group__"
-  Const        r56, true
-  Move         r57, r11
+  Const        r60, []
+  Const        r61, "__group__"
+  Const        r62, true
+  Const        r63, "key"
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Move         r58, r51
+  Move         r64, r57
   // from sr in store_returns
-  Const        r59, "items"
-  Move         r60, r54
-  Const        r61, "count"
-  Move         r62, r20
-  Move         r63, r55
-  Move         r64, r56
-  Move         r65, r57
-  Move         r66, r58
-  Move         r67, r59
-  Move         r68, r60
+  Const        r65, "items"
+  Move         r66, r60
+  Const        r67, "count"
+  Const        r68, 0
   Move         r69, r61
   Move         r70, r62
-  MakeMap      r71, 4, r63
-  SetIndex     r15, r52, r71
-  Append       r16, r16, r71
+  Move         r71, r63
+  Move         r72, r64
+  Move         r73, r65
+  Move         r74, r66
+  Move         r75, r67
+  Move         r76, r68
+  MakeMap      r77, 4, r69
+  SetIndex     r18, r58, r77
+  Append       r19, r19, r77
 L3:
-  Move         r73, r59
-  Index        r74, r15, r52
-  Index        r75, r74, r73
-  Append       r76, r75, r42
-  SetIndex     r74, r73, r76
-  Move         r77, r61
-  Index        r78, r74, r77
-  Const        r79, 1
-  AddInt       r80, r78, r79
-  SetIndex     r74, r77, r80
+  Const        r79, "items"
+  Index        r80, r18, r58
+  Index        r81, r80, r79
+  Append       r82, r81, r46
+  SetIndex     r80, r79, r82
+  Const        r83, "count"
+  Index        r84, r80, r83
+  Const        r85, 1
+  AddInt       r86, r84, r85
+  SetIndex     r80, r83, r86
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
   Jump         L2
 L0:
   // from sr in store_returns
-  Move         r82, r62
-  Move         r81, r82
-  Len          r83, r16
+  Const        r89, 0
+  Len          r91, r19
 L7:
-  LessInt      r84, r81, r83
-  JumpIfFalse  r84, L4
-  Index        r86, r16, r81
+  LessInt      r92, r89, r91
+  JumpIfFalse  r92, L4
+  Index        r94, r19, r89
   // ctr_customer_sk: g.key.customer_sk,
-  Move         r87, r10
-  Index        r88, r86, r11
-  Index        r89, r88, r5
+  Const        r95, "ctr_customer_sk"
+  Const        r96, "key"
+  Index        r97, r94, r96
+  Const        r98, "customer_sk"
+  Index        r99, r97, r98
   // ctr_store_sk: g.key.store_sk,
-  Move         r90, r12
-  Index        r91, r86, r11
-  Index        r92, r91, r7
+  Const        r100, "ctr_store_sk"
+  Const        r101, "key"
+  Index        r102, r94, r101
+  Const        r103, "store_sk"
+  Index        r104, r102, r103
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Move         r93, r13
-  Move         r94, r54
-  IterPrep     r95, r86
-  Len          r96, r95
-  Move         r97, r82
+  Const        r105, "ctr_total_return"
+  Const        r106, []
+  IterPrep     r108, r94
+  Len          r109, r108
+  Const        r110, 0
 L6:
-  LessInt      r98, r97, r96
-  JumpIfFalse  r98, L5
-  Index        r100, r95, r97
-  Index        r101, r100, r14
-  Append       r94, r94, r101
-  AddInt       r97, r97, r79
+  LessInt      r112, r110, r109
+  JumpIfFalse  r112, L5
+  Index        r114, r108, r110
+  Const        r115, "sr_return_amt"
+  Index        r116, r114, r115
+  Append       r106, r106, r116
+  Const        r118, 1
+  AddInt       r110, r110, r118
   Jump         L6
 L5:
-  Sum          r103, r94
+  Sum          r119, r106
   // ctr_customer_sk: g.key.customer_sk,
-  Move         r104, r87
-  Move         r105, r89
+  Move         r120, r95
+  Move         r121, r99
   // ctr_store_sk: g.key.store_sk,
-  Move         r106, r90
-  Move         r107, r92
+  Move         r122, r100
+  Move         r123, r104
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Move         r108, r93
-  Move         r109, r103
+  Move         r124, r105
+  Move         r125, r119
   // select {
-  MakeMap      r110, 3, r104
+  MakeMap      r126, 3, r120
   // from sr in store_returns
-  Append       r4, r4, r110
-  AddInt       r81, r81, r79
+  Append       r4, r4, r126
+  Const        r128, 1
+  AddInt       r89, r89, r128
   Jump         L7
 L4:
   // from ctr1 in customer_total_return
-  Move         r112, r0
-  // s.s_state == "TN"
-  Const        r113, "s_state"
-  // select {c_customer_id: c.c_customer_id}
-  Const        r114, "c_customer_id"
-  // from ctr1 in customer_total_return
-  IterPrep     r115, r4
-  Len          r116, r115
-  Move         r117, r82
+  Const        r129, []
+  IterPrep     r138, r4
+  Len          r139, r138
+  Const        r140, 0
 L18:
-  LessInt      r118, r117, r116
-  JumpIfFalse  r118, L8
-  Index        r120, r115, r117
+  LessInt      r142, r140, r139
+  JumpIfFalse  r142, L8
+  Index        r144, r138, r140
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  IterPrep     r121, r2
-  Len          r122, r121
-  Const        r123, "s_store_sk"
-  Move         r124, r82
+  IterPrep     r145, r2
+  Len          r146, r145
+  Const        r157, 0
 L17:
-  LessInt      r125, r124, r122
-  JumpIfFalse  r125, L9
-  Index        r127, r121, r124
-  Index        r128, r120, r12
-  Index        r129, r127, r123
-  Equal        r130, r128, r129
-  JumpIfFalse  r130, L10
+  LessInt      r159, r157, r146
+  JumpIfFalse  r159, L9
+  Index        r161, r145, r157
+  Const        r162, "ctr_store_sk"
+  Index        r163, r144, r162
+  Const        r164, "s_store_sk"
+  Index        r165, r161, r164
+  Equal        r166, r163, r165
+  JumpIfFalse  r166, L10
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  IterPrep     r131, r3
-  Len          r132, r131
-  Const        r133, "c_customer_sk"
-  Move         r134, r82
+  IterPrep     r167, r3
+  Len          r168, r167
+  Const        r179, 0
 L16:
-  LessInt      r135, r134, r132
-  JumpIfFalse  r135, L10
-  Index        r137, r131, r134
-  Index        r138, r120, r10
-  Index        r139, r137, r133
-  Equal        r140, r138, r139
-  JumpIfFalse  r140, L11
+  LessInt      r181, r179, r168
+  JumpIfFalse  r181, L10
+  Index        r183, r167, r179
+  Const        r184, "ctr_customer_sk"
+  Index        r185, r144, r184
+  Const        r186, "c_customer_sk"
+  Index        r187, r183, r186
+  Equal        r188, r185, r187
+  JumpIfFalse  r188, L11
   // where ctr1.ctr_total_return > avg(
-  Index        r141, r120, r13
+  Const        r189, "ctr_total_return"
+  Index        r190, r144, r189
   // from ctr2 in customer_total_return
-  Move         r142, r112
-  IterPrep     r143, r4
-  Len          r144, r143
-  Move         r145, r82
+  Const        r191, []
+  IterPrep     r195, r4
+  Len          r196, r195
+  Const        r197, 0
 L14:
-  LessInt      r146, r145, r144
-  JumpIfFalse  r146, L12
-  Index        r148, r143, r145
+  LessInt      r199, r197, r196
+  JumpIfFalse  r199, L12
+  Index        r201, r195, r197
   // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Index        r149, r120, r12
-  Index        r150, r148, r12
-  Equal        r151, r149, r150
-  JumpIfFalse  r151, L13
+  Const        r202, "ctr_store_sk"
+  Index        r203, r144, r202
+  Const        r204, "ctr_store_sk"
+  Index        r205, r201, r204
+  Equal        r206, r203, r205
+  JumpIfFalse  r206, L13
   // select ctr2.ctr_total_return
-  Index        r152, r148, r13
+  Const        r207, "ctr_total_return"
+  Index        r208, r201, r207
   // from ctr2 in customer_total_return
-  Append       r142, r142, r152
+  Append       r191, r191, r208
 L13:
-  AddInt       r145, r145, r79
+  Const        r210, 1
+  AddInt       r197, r197, r210
   Jump         L14
 L12:
   // where ctr1.ctr_total_return > avg(
-  Avg          r154, r142
+  Avg          r211, r191
   // ) * 1.2 &&
-  Const        r155, 1.2
-  MulFloat     r156, r154, r155
+  Const        r212, 1.2
+  MulFloat     r213, r211, r212
   // where ctr1.ctr_total_return > avg(
-  LessFloat    r157, r156, r141
+  LessFloat    r214, r213, r190
   // s.s_state == "TN"
-  Index        r158, r127, r113
-  Const        r159, "TN"
-  Equal        r160, r158, r159
+  Const        r215, "s_state"
+  Index        r216, r161, r215
+  Const        r217, "TN"
+  Equal        r218, r216, r217
   // ) * 1.2 &&
-  Move         r161, r157
-  JumpIfFalse  r161, L15
-  Move         r161, r160
+  Move         r219, r214
+  JumpIfFalse  r219, L15
+  Move         r219, r218
 L15:
   // where ctr1.ctr_total_return > avg(
-  JumpIfFalse  r161, L11
+  JumpIfFalse  r219, L11
   // select {c_customer_id: c.c_customer_id}
-  Move         r162, r114
-  Index        r163, r137, r114
-  Move         r164, r162
-  Move         r165, r163
-  MakeMap      r166, 1, r164
+  Const        r220, "c_customer_id"
+  Const        r221, "c_customer_id"
+  Index        r222, r183, r221
+  Move         r223, r220
+  Move         r224, r222
+  MakeMap      r225, 1, r223
   // sort by c.c_customer_id
-  Index        r168, r137, r114
+  Const        r226, "c_customer_id"
+  Index        r228, r183, r226
   // from ctr1 in customer_total_return
-  Move         r169, r166
-  MakeList     r170, 2, r168
-  Append       r112, r112, r170
+  Move         r229, r225
+  MakeList     r230, 2, r228
+  Append       r129, r129, r230
 L11:
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  Add          r134, r134, r79
+  Const        r232, 1
+  Add          r179, r179, r232
   Jump         L16
 L10:
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  Add          r124, r124, r79
+  Const        r233, 1
+  Add          r157, r157, r233
   Jump         L17
 L9:
   // from ctr1 in customer_total_return
-  AddInt       r117, r117, r79
+  Const        r234, 1
+  AddInt       r140, r140, r234
   Jump         L18
 L8:
   // sort by c.c_customer_id
-  Sort         r112, r112
+  Sort         r129, r129
   // json(result)
-  JSON         r112
-  // expect result == []
-  Equal        r174, r112, r0
-  Expect       r174
+  JSON         r129
+  // expect len(result) == 0
+  Len          r236, r129
+  Const        r237, 0
+  EqualInt     r238, r236, r237
+  Expect       r238
   Return       r0

--- a/tests/dataset/tpc-ds/out/q2.ir.out
+++ b/tests/dataset/tpc-ds/out/q2.ir.out
@@ -1,304 +1,306 @@
-func main (regs=198)
+func main (regs=261)
   // let web_sales = []
   Const        r0, []
   // let date_dim = []
-  Move         r2, r0
+  Const        r2, []
   // let wscs = []
-  Move         r3, r2
+  Const        r3, []
   // from w in wscs
-  Move         r4, r0
-  // group by {week_seq: d.d_week_seq} into g
-  Const        r5, "week_seq"
-  Const        r6, "d_week_seq"
-  // d_week_seq: g.key.week_seq,
-  Const        r7, "key"
-  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Const        r8, "sun_sales"
-  Const        r9, "day"
-  Const        r10, "sales_price"
-  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Const        r11, "mon_sales"
-  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Const        r12, "tue_sales"
-  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Const        r13, "wed_sales"
-  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Const        r14, "thu_sales"
-  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Const        r15, "fri_sales"
-  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Const        r16, "sat_sales"
-  // from w in wscs
-  MakeMap      r17, 0, r0
-  Move         r18, r4
-  IterPrep     r20, r3
-  Len          r21, r20
-  Const        r22, 0
+  Const        r4, []
+  MakeMap      r31, 0, r0
+  Const        r32, []
+  IterPrep     r34, r3
+  Len          r35, r34
+  Const        r36, 0
 L1:
-  LessInt      r23, r22, r21
-  JumpIfFalse  r23, L0
-  Index        r25, r20, r22
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L0
+  Index        r39, r34, r36
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  IterPrep     r26, r2
-  Len          r27, r26
-  Move         r28, r22
+  IterPrep     r40, r2
+  Len          r41, r40
+  Const        r42, 0
 L2:
-  LessInt      r29, r28, r27
-  JumpIfFalse  r29, L1
-  Index        r31, r26, r28
-  Const        r32, "sold_date_sk"
-  Index        r33, r25, r32
-  Const        r34, "d_date_sk"
-  Index        r35, r31, r34
-  Equal        r36, r33, r35
-  JumpIfFalse  r36, L2
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L1
+  Index        r45, r40, r42
+  Const        r46, "sold_date_sk"
+  Index        r47, r39, r46
+  Const        r48, "d_date_sk"
+  Index        r49, r45, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L2
   // from w in wscs
-  Const        r37, "w"
-  Move         r38, r25
-  Const        r39, "d"
-  Move         r40, r31
-  MakeMap      r41, 2, r37
+  Const        r51, "w"
+  Move         r52, r39
+  Const        r53, "d"
+  Move         r54, r45
+  MakeMap      r55, 2, r51
   // group by {week_seq: d.d_week_seq} into g
-  Move         r42, r5
-  Index        r43, r31, r6
-  Move         r44, r42
-  Move         r45, r43
-  MakeMap      r46, 1, r44
-  Str          r47, r46
-  In           r48, r47, r17
-  JumpIfTrue   r48, L3
+  Const        r56, "week_seq"
+  Const        r57, "d_week_seq"
+  Index        r58, r45, r57
+  Move         r59, r56
+  Move         r60, r58
+  MakeMap      r61, 1, r59
+  Str          r62, r61
+  In           r63, r62, r31
+  JumpIfTrue   r63, L3
   // from w in wscs
-  Move         r49, r4
-  Const        r50, "__group__"
-  Const        r51, true
-  Move         r52, r7
+  Const        r64, []
+  Const        r65, "__group__"
+  Const        r66, true
+  Const        r67, "key"
   // group by {week_seq: d.d_week_seq} into g
-  Move         r53, r46
+  Move         r68, r61
   // from w in wscs
-  Const        r54, "items"
-  Move         r55, r49
-  Const        r56, "count"
-  Move         r57, r22
-  Move         r58, r50
-  Move         r59, r51
-  Move         r60, r52
-  Move         r61, r53
-  Move         r62, r54
-  Move         r63, r55
-  Move         r64, r56
-  Move         r65, r57
-  MakeMap      r66, 4, r58
-  SetIndex     r17, r47, r66
-  Append       r18, r18, r66
+  Const        r69, "items"
+  Move         r70, r64
+  Const        r71, "count"
+  Const        r72, 0
+  Move         r73, r65
+  Move         r74, r66
+  Move         r75, r67
+  Move         r76, r68
+  Move         r77, r69
+  Move         r78, r70
+  Move         r79, r71
+  Move         r80, r72
+  MakeMap      r81, 4, r73
+  SetIndex     r31, r62, r81
+  Append       r32, r32, r81
 L3:
-  Move         r68, r54
-  Index        r69, r17, r47
-  Index        r70, r69, r68
-  Append       r71, r70, r41
-  SetIndex     r69, r68, r71
-  Move         r72, r56
-  Index        r73, r69, r72
-  Const        r74, 1
-  AddInt       r75, r73, r74
-  SetIndex     r69, r72, r75
+  Const        r83, "items"
+  Index        r84, r31, r62
+  Index        r85, r84, r83
+  Append       r86, r85, r55
+  SetIndex     r84, r83, r86
+  Const        r87, "count"
+  Index        r88, r84, r87
+  Const        r89, 1
+  AddInt       r90, r88, r89
+  SetIndex     r84, r87, r90
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
   Jump         L2
 L0:
   // from w in wscs
-  Move         r77, r57
-  Move         r76, r77
-  Len          r78, r18
+  Const        r93, 0
+  Len          r95, r32
 L26:
-  LessInt      r79, r76, r78
-  JumpIfFalse  r79, L4
-  Index        r81, r18, r76
+  LessInt      r96, r93, r95
+  JumpIfFalse  r96, L4
+  Index        r98, r32, r93
   // d_week_seq: g.key.week_seq,
-  Move         r82, r6
-  Index        r83, r81, r7
-  Index        r84, r83, r5
+  Const        r99, "d_week_seq"
+  Const        r100, "key"
+  Index        r101, r98, r100
+  Const        r102, "week_seq"
+  Index        r103, r101, r102
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Move         r85, r8
-  Move         r86, r49
-  IterPrep     r87, r81
-  Len          r88, r87
-  Move         r89, r77
+  Const        r104, "sun_sales"
+  Const        r105, []
+  IterPrep     r108, r98
+  Len          r109, r108
+  Const        r110, 0
 L7:
-  LessInt      r90, r89, r88
-  JumpIfFalse  r90, L5
-  Index        r92, r87, r89
-  Index        r93, r92, r9
-  Const        r94, "Sunday"
-  Equal        r95, r93, r94
-  JumpIfFalse  r95, L6
-  Index        r96, r92, r10
-  Append       r86, r86, r96
+  LessInt      r112, r110, r109
+  JumpIfFalse  r112, L5
+  Index        r114, r108, r110
+  Const        r115, "day"
+  Index        r116, r114, r115
+  Const        r117, "Sunday"
+  Equal        r118, r116, r117
+  JumpIfFalse  r118, L6
+  Const        r119, "sales_price"
+  Index        r120, r114, r119
+  Append       r105, r105, r120
 L6:
-  AddInt       r89, r89, r74
+  Const        r122, 1
+  AddInt       r110, r110, r122
   Jump         L7
 L5:
-  Sum          r98, r86
+  Sum          r123, r105
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Move         r99, r11
-  Move         r100, r0
-  IterPrep     r101, r81
-  Len          r102, r101
-  Move         r103, r77
+  Const        r124, "mon_sales"
+  Const        r125, []
+  IterPrep     r128, r98
+  Len          r129, r128
+  Const        r130, 0
 L10:
-  LessInt      r104, r103, r102
-  JumpIfFalse  r104, L8
-  Index        r92, r101, r103
-  Index        r106, r92, r9
-  Const        r107, "Monday"
-  Equal        r108, r106, r107
-  JumpIfFalse  r108, L9
-  Index        r109, r92, r10
-  Append       r100, r100, r109
+  LessInt      r132, r130, r129
+  JumpIfFalse  r132, L8
+  Index        r114, r128, r130
+  Const        r134, "day"
+  Index        r135, r114, r134
+  Const        r136, "Monday"
+  Equal        r137, r135, r136
+  JumpIfFalse  r137, L9
+  Const        r138, "sales_price"
+  Index        r139, r114, r138
+  Append       r125, r125, r139
 L9:
-  AddInt       r103, r103, r74
+  Const        r141, 1
+  AddInt       r130, r130, r141
   Jump         L10
 L8:
-  Sum          r111, r100
+  Sum          r142, r125
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Move         r112, r12
-  Move         r113, r0
-  IterPrep     r114, r81
-  Len          r115, r114
-  Move         r116, r77
+  Const        r143, "tue_sales"
+  Const        r144, []
+  IterPrep     r147, r98
+  Len          r148, r147
+  Const        r149, 0
 L13:
-  LessInt      r117, r116, r115
-  JumpIfFalse  r117, L11
-  Index        r92, r114, r116
-  Index        r119, r92, r9
-  Const        r120, "Tuesday"
-  Equal        r121, r119, r120
-  JumpIfFalse  r121, L12
-  Index        r122, r92, r10
-  Append       r113, r113, r122
+  LessInt      r151, r149, r148
+  JumpIfFalse  r151, L11
+  Index        r114, r147, r149
+  Const        r153, "day"
+  Index        r154, r114, r153
+  Const        r155, "Tuesday"
+  Equal        r156, r154, r155
+  JumpIfFalse  r156, L12
+  Const        r157, "sales_price"
+  Index        r158, r114, r157
+  Append       r144, r144, r158
 L12:
-  AddInt       r116, r116, r74
+  Const        r160, 1
+  AddInt       r149, r149, r160
   Jump         L13
 L11:
-  Sum          r124, r113
+  Sum          r161, r144
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Move         r125, r13
-  Move         r126, r0
-  IterPrep     r127, r81
-  Len          r128, r127
-  Move         r129, r77
+  Const        r162, "wed_sales"
+  Const        r163, []
+  IterPrep     r166, r98
+  Len          r167, r166
+  Const        r168, 0
 L16:
-  LessInt      r130, r129, r128
-  JumpIfFalse  r130, L14
-  Index        r92, r127, r129
-  Index        r132, r92, r9
-  Const        r133, "Wednesday"
-  Equal        r134, r132, r133
-  JumpIfFalse  r134, L15
-  Index        r135, r92, r10
-  Append       r126, r126, r135
+  LessInt      r170, r168, r167
+  JumpIfFalse  r170, L14
+  Index        r114, r166, r168
+  Const        r172, "day"
+  Index        r173, r114, r172
+  Const        r174, "Wednesday"
+  Equal        r175, r173, r174
+  JumpIfFalse  r175, L15
+  Const        r176, "sales_price"
+  Index        r177, r114, r176
+  Append       r163, r163, r177
 L15:
-  AddInt       r129, r129, r74
+  Const        r179, 1
+  AddInt       r168, r168, r179
   Jump         L16
 L14:
-  Sum          r137, r126
+  Sum          r180, r163
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Move         r138, r14
-  Move         r139, r0
-  IterPrep     r140, r81
-  Len          r141, r140
-  Move         r142, r77
+  Const        r181, "thu_sales"
+  Const        r182, []
+  IterPrep     r185, r98
+  Len          r186, r185
+  Const        r187, 0
 L19:
-  LessInt      r143, r142, r141
-  JumpIfFalse  r143, L17
-  Index        r92, r140, r142
-  Index        r145, r92, r9
-  Const        r146, "Thursday"
-  Equal        r147, r145, r146
-  JumpIfFalse  r147, L18
-  Index        r148, r92, r10
-  Append       r139, r139, r148
+  LessInt      r189, r187, r186
+  JumpIfFalse  r189, L17
+  Index        r114, r185, r187
+  Const        r191, "day"
+  Index        r192, r114, r191
+  Const        r193, "Thursday"
+  Equal        r194, r192, r193
+  JumpIfFalse  r194, L18
+  Const        r195, "sales_price"
+  Index        r196, r114, r195
+  Append       r182, r182, r196
 L18:
-  AddInt       r142, r142, r74
+  Const        r198, 1
+  AddInt       r187, r187, r198
   Jump         L19
 L17:
-  Sum          r150, r139
+  Sum          r199, r182
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Move         r151, r15
-  Move         r152, r0
-  IterPrep     r153, r81
-  Len          r154, r153
-  Move         r155, r77
+  Const        r200, "fri_sales"
+  Const        r201, []
+  IterPrep     r204, r98
+  Len          r205, r204
+  Const        r206, 0
 L22:
-  LessInt      r156, r155, r154
-  JumpIfFalse  r156, L20
-  Index        r92, r153, r155
-  Index        r158, r92, r9
-  Const        r159, "Friday"
-  Equal        r160, r158, r159
-  JumpIfFalse  r160, L21
-  Index        r161, r92, r10
-  Append       r152, r152, r161
+  LessInt      r208, r206, r205
+  JumpIfFalse  r208, L20
+  Index        r114, r204, r206
+  Const        r210, "day"
+  Index        r211, r114, r210
+  Const        r212, "Friday"
+  Equal        r213, r211, r212
+  JumpIfFalse  r213, L21
+  Const        r214, "sales_price"
+  Index        r215, r114, r214
+  Append       r201, r201, r215
 L21:
-  AddInt       r155, r155, r74
+  Const        r217, 1
+  AddInt       r206, r206, r217
   Jump         L22
 L20:
-  Sum          r163, r152
+  Sum          r218, r201
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Move         r164, r16
-  Move         r165, r0
-  IterPrep     r166, r81
-  Len          r167, r166
-  Move         r168, r77
+  Const        r219, "sat_sales"
+  Const        r220, []
+  IterPrep     r223, r98
+  Len          r224, r223
+  Const        r225, 0
 L25:
-  LessInt      r169, r168, r167
-  JumpIfFalse  r169, L23
-  Index        r92, r166, r168
-  Index        r171, r92, r9
-  Const        r172, "Saturday"
-  Equal        r173, r171, r172
-  JumpIfFalse  r173, L24
-  Index        r174, r92, r10
-  Append       r165, r165, r174
+  LessInt      r227, r225, r224
+  JumpIfFalse  r227, L23
+  Index        r114, r223, r225
+  Const        r229, "day"
+  Index        r230, r114, r229
+  Const        r231, "Saturday"
+  Equal        r232, r230, r231
+  JumpIfFalse  r232, L24
+  Const        r233, "sales_price"
+  Index        r234, r114, r233
+  Append       r220, r220, r234
 L24:
-  AddInt       r168, r168, r74
+  Const        r236, 1
+  AddInt       r225, r225, r236
   Jump         L25
 L23:
-  Sum          r176, r165
+  Sum          r237, r220
   // d_week_seq: g.key.week_seq,
-  Move         r177, r82
-  Move         r178, r84
+  Move         r238, r99
+  Move         r239, r103
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Move         r179, r85
-  Move         r180, r98
+  Move         r240, r104
+  Move         r241, r123
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Move         r181, r99
-  Move         r182, r111
+  Move         r242, r124
+  Move         r243, r142
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Move         r183, r112
-  Move         r184, r124
+  Move         r244, r143
+  Move         r245, r161
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Move         r185, r125
-  Move         r186, r137
+  Move         r246, r162
+  Move         r247, r180
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Move         r187, r138
-  Move         r188, r150
+  Move         r248, r181
+  Move         r249, r199
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Move         r189, r151
-  Move         r190, r163
+  Move         r250, r200
+  Move         r251, r218
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Move         r191, r164
-  Move         r192, r176
+  Move         r252, r219
+  Move         r253, r237
   // select {
-  MakeMap      r193, 8, r177
+  MakeMap      r254, 8, r238
   // from w in wscs
-  Append       r4, r4, r193
-  AddInt       r76, r76, r74
+  Append       r4, r4, r254
+  Const        r256, 1
+  AddInt       r93, r93, r256
   Jump         L26
 L4:
   // let result = []
-  Move         r195, r0
+  Const        r257, []
   // json(result)
-  JSON         r195
-  // expect result == []
-  Equal        r197, r195, r195
-  Expect       r197
+  JSON         r257
+  // expect len(result) == 0
+  Const        r260, true
+  Expect       r260
   Return       r0

--- a/tests/dataset/tpc-ds/out/q3.ir.out
+++ b/tests/dataset/tpc-ds/out/q3.ir.out
@@ -1,232 +1,231 @@
-func main (regs=164)
+func main (regs=211)
   // let date_dim = []
   Const        r0, []
   // let store_sales = []
-  Move         r1, r0
+  Const        r1, []
   // let item = []
-  Move         r2, r0
+  Const        r2, []
   // from dt in date_dim
-  Move         r3, r2
-  // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Const        r4, "d_year"
-  Const        r5, "brand_id"
-  Const        r6, "i_brand_id"
-  Const        r7, "brand"
-  Const        r8, "i_brand"
-  // where i.i_manufact_id == 100 && dt.d_moy == 12
-  Const        r9, "i_manufact_id"
-  Const        r10, "d_moy"
-  // d_year: g.key.d_year,
-  Const        r11, "key"
-  // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Const        r12, "sum_agg"
-  Const        r13, "ss"
-  Const        r14, "ss_ext_sales_price"
-  // from dt in date_dim
-  MakeMap      r15, 0, r0
-  Move         r17, r0
-  Move         r16, r17
-  IterPrep     r18, r0
-  Len          r19, r18
-  Const        r20, 0
-L8:
-  LessInt      r21, r20, r19
-  JumpIfFalse  r21, L0
-  Index        r23, r18, r20
+  Const        r3, []
+  MakeMap      r30, 0, r0
+  Const        r31, []
+  IterPrep     r33, r0
+  Len          r34, r33
+  Const        r35, 0
+L1:
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L0
+  Index        r38, r33, r35
   // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
-  IterPrep     r24, r1
-  Len          r25, r24
-  Move         r26, r20
-L7:
-  LessInt      r27, r26, r25
-  JumpIfFalse  r27, L1
-  Index        r29, r24, r26
-  Const        r30, "d_date_sk"
-  Index        r31, r23, r30
-  Const        r32, "ss_sold_date_sk"
-  Index        r33, r29, r32
-  Equal        r34, r31, r33
-  JumpIfFalse  r34, L2
+  IterPrep     r39, r1
+  Len          r40, r39
+  Const        r41, 0
+L2:
+  LessInt      r42, r41, r40
+  JumpIfFalse  r42, L1
+  Index        r44, r39, r41
+  Const        r45, "d_date_sk"
+  Index        r46, r38, r45
+  Const        r47, "ss_sold_date_sk"
+  Index        r48, r44, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L2
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r35, r2
-  Len          r36, r35
-  Move         r37, r20
+  IterPrep     r50, r2
+  Len          r51, r50
+  Const        r52, 0
 L6:
-  LessInt      r38, r37, r36
-  JumpIfFalse  r38, L2
-  Index        r40, r35, r37
-  Const        r41, "ss_item_sk"
-  Index        r42, r29, r41
-  Const        r43, "i_item_sk"
-  Index        r44, r40, r43
-  Equal        r45, r42, r44
-  JumpIfFalse  r45, L3
+  LessInt      r53, r52, r51
+  JumpIfFalse  r53, L2
+  Index        r55, r50, r52
+  Const        r56, "ss_item_sk"
+  Index        r57, r44, r56
+  Const        r58, "i_item_sk"
+  Index        r59, r55, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L3
   // where i.i_manufact_id == 100 && dt.d_moy == 12
-  Index        r46, r40, r9
-  Const        r47, 100
-  Equal        r48, r46, r47
-  Index        r49, r23, r10
-  Const        r50, 12
-  Equal        r51, r49, r50
-  Move         r52, r48
-  JumpIfFalse  r52, L4
-  Move         r52, r51
+  Const        r61, "i_manufact_id"
+  Index        r62, r55, r61
+  Const        r63, 100
+  Equal        r64, r62, r63
+  Const        r65, "d_moy"
+  Index        r66, r38, r65
+  Const        r67, 12
+  Equal        r68, r66, r67
+  Move         r69, r64
+  JumpIfFalse  r69, L4
+  Move         r69, r68
 L4:
-  JumpIfFalse  r52, L3
+  JumpIfFalse  r69, L3
   // from dt in date_dim
-  Const        r53, "dt"
-  Move         r54, r23
-  Move         r55, r13
-  Move         r56, r29
-  Const        r57, "i"
-  Move         r58, r40
-  MakeMap      r59, 3, r53
+  Const        r70, "dt"
+  Move         r71, r38
+  Const        r72, "ss"
+  Move         r73, r44
+  Const        r74, "i"
+  Move         r75, r55
+  MakeMap      r76, 3, r70
   // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Move         r60, r4
-  Index        r61, r23, r4
-  Move         r62, r5
-  Index        r63, r40, r6
-  Move         r64, r7
-  Index        r65, r40, r8
-  Move         r66, r60
-  Move         r67, r61
-  Move         r68, r62
-  Move         r69, r63
-  Move         r70, r64
-  Move         r71, r65
-  MakeMap      r72, 3, r66
-  Str          r73, r72
-  In           r74, r73, r15
-  JumpIfTrue   r74, L5
-  // from dt in date_dim
-  Move         r75, r17
-  Const        r76, "__group__"
-  Const        r77, true
-  Move         r78, r11
-  // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Move         r79, r72
-  // from dt in date_dim
-  Const        r80, "items"
-  Move         r81, r75
-  Const        r82, "count"
-  Move         r83, r37
-  Move         r84, r76
-  Move         r85, r77
-  Move         r86, r78
+  Const        r77, "d_year"
+  Const        r78, "d_year"
+  Index        r79, r38, r78
+  Const        r80, "brand_id"
+  Const        r81, "i_brand_id"
+  Index        r82, r55, r81
+  Const        r83, "brand"
+  Const        r84, "i_brand"
+  Index        r85, r55, r84
+  Move         r86, r77
   Move         r87, r79
   Move         r88, r80
-  Move         r89, r81
-  Move         r90, r82
-  Move         r91, r83
-  MakeMap      r92, 4, r84
-  SetIndex     r15, r73, r92
-  Append       r16, r16, r92
+  Move         r89, r82
+  Move         r90, r83
+  Move         r91, r85
+  MakeMap      r92, 3, r86
+  Str          r93, r92
+  In           r94, r93, r30
+  JumpIfTrue   r94, L5
+  // from dt in date_dim
+  Const        r95, []
+  Const        r96, "__group__"
+  Const        r97, true
+  Const        r98, "key"
+  // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
+  Move         r99, r92
+  // from dt in date_dim
+  Const        r100, "items"
+  Move         r101, r95
+  Const        r102, "count"
+  Const        r103, 0
+  Move         r104, r96
+  Move         r105, r97
+  Move         r106, r98
+  Move         r107, r99
+  Move         r108, r100
+  Move         r109, r101
+  Move         r110, r102
+  Move         r111, r103
+  MakeMap      r112, 4, r104
+  SetIndex     r30, r93, r112
+  Append       r31, r31, r112
 L5:
-  Move         r94, r80
-  Index        r95, r15, r73
-  Index        r96, r95, r94
-  Append       r97, r96, r59
-  SetIndex     r95, r94, r97
-  Move         r98, r82
-  Index        r99, r95, r98
-  Const        r100, 1
-  AddInt       r101, r99, r100
-  SetIndex     r95, r98, r101
+  Const        r114, "items"
+  Index        r115, r30, r93
+  Index        r116, r115, r114
+  Append       r117, r116, r76
+  SetIndex     r115, r114, r117
+  Const        r118, "count"
+  Index        r119, r115, r118
+  Const        r120, 1
+  AddInt       r121, r119, r120
+  SetIndex     r115, r118, r121
 L3:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r37, r37, r100
+  Const        r122, 1
+  AddInt       r52, r52, r122
   Jump         L6
-L2:
-  // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
-  AddInt       r26, r26, r100
-  Jump         L7
-L1:
-  // from dt in date_dim
-  AddInt       r20, r20, r100
-  Jump         L8
 L0:
-  Const        r103, 0
-  Move         r102, r103
-  Len          r104, r16
-L14:
-  LessInt      r105, r102, r104
-  JumpIfFalse  r105, L9
-  Index        r107, r16, r102
+  // from dt in date_dim
+  Const        r125, 0
+  Len          r127, r31
+L12:
+  LessInt      r128, r125, r127
+  JumpIfFalse  r128, L7
+  Index        r130, r31, r125
   // d_year: g.key.d_year,
-  Move         r108, r4
-  Index        r109, r107, r11
-  Index        r110, r109, r4
+  Const        r131, "d_year"
+  Const        r132, "key"
+  Index        r133, r130, r132
+  Const        r134, "d_year"
+  Index        r135, r133, r134
   // brand_id: g.key.brand_id,
-  Move         r111, r5
-  Index        r112, r107, r11
-  Index        r113, r112, r5
+  Const        r136, "brand_id"
+  Const        r137, "key"
+  Index        r138, r130, r137
+  Const        r139, "brand_id"
+  Index        r140, r138, r139
   // brand: g.key.brand,
-  Move         r114, r7
-  Index        r115, r107, r11
-  Index        r116, r115, r7
+  Const        r141, "brand"
+  Const        r142, "key"
+  Index        r143, r130, r142
+  Const        r144, "brand"
+  Index        r145, r143, r144
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Move         r117, r12
-  Move         r118, r17
-  IterPrep     r119, r107
-  Len          r120, r119
-  Move         r121, r103
+  Const        r146, "sum_agg"
+  Const        r147, []
+  IterPrep     r150, r130
+  Len          r151, r150
+  Const        r152, 0
+L9:
+  LessInt      r154, r152, r151
+  JumpIfFalse  r154, L8
+  Index        r156, r150, r152
+  Const        r157, "ss"
+  Index        r158, r156, r157
+  Const        r159, "ss_ext_sales_price"
+  Index        r160, r158, r159
+  Append       r147, r147, r160
+  Const        r162, 1
+  AddInt       r152, r152, r162
+  Jump         L9
+L8:
+  Sum          r163, r147
+  // d_year: g.key.d_year,
+  Move         r164, r131
+  Move         r165, r135
+  // brand_id: g.key.brand_id,
+  Move         r166, r136
+  Move         r167, r140
+  // brand: g.key.brand,
+  Move         r168, r141
+  Move         r169, r145
+  // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
+  Move         r170, r146
+  Move         r171, r163
+  // select {
+  MakeMap      r172, 4, r164
+  // sort by [g.key.d_year,
+  Const        r173, "key"
+  Index        r174, r130, r173
+  Const        r175, "d_year"
+  Index        r177, r174, r175
+  // -sum(from x in g select x.ss.ss_ext_sales_price),
+  Const        r178, []
+  Const        r179, "ss"
+  IterPrep     r181, r130
+  Len          r182, r181
+  Const        r183, 0
 L11:
-  LessInt      r122, r121, r120
-  JumpIfFalse  r122, L10
-  Index        r124, r119, r121
-  Index        r125, r124, r13
-  Index        r126, r125, r14
-  Append       r118, r118, r126
-  AddInt       r121, r121, r100
+  LessInt      r185, r183, r182
+  JumpIfFalse  r185, L10
+  Index        r156, r181, r183
+  Const        r187, "ss"
+  Index        r188, r156, r187
+  Const        r189, "ss_ext_sales_price"
+  Index        r190, r188, r189
+  Append       r178, r178, r190
+  Const        r192, 1
+  AddInt       r183, r183, r192
   Jump         L11
 L10:
-  Sum          r128, r118
-  // d_year: g.key.d_year,
-  Move         r129, r108
-  Move         r130, r110
-  // brand_id: g.key.brand_id,
-  Move         r131, r111
-  Move         r132, r113
-  // brand: g.key.brand,
-  Move         r133, r114
-  Move         r134, r116
-  // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Move         r135, r117
-  Move         r136, r128
-  // select {
-  MakeMap      r137, 4, r129
   // sort by [g.key.d_year,
-  Index        r138, r107, r11
-  Index        r140, r138, r4
-  // -sum(from x in g select x.ss.ss_ext_sales_price),
-  Move         r141, r0
-  IterPrep     r142, r107
-  Len          r143, r142
-  Move         r144, r103
-L13:
-  LessInt      r145, r144, r143
-  JumpIfFalse  r145, L12
-  Index        r124, r142, r144
-  Index        r147, r124, r13
-  Index        r148, r147, r14
-  Append       r141, r141, r148
-  AddInt       r144, r144, r100
-  Jump         L13
-L12:
-  // sort by [g.key.d_year,
-  MakeList     r157, 3, r140
+  MakeList     r202, 3, r177
   // from dt in date_dim
-  Move         r158, r137
-  MakeList     r159, 2, r157
-  Append       r3, r3, r159
-  AddInt       r102, r102, r100
-  Jump         L14
-L9:
+  Move         r203, r172
+  MakeList     r204, 2, r202
+  Append       r3, r3, r204
+  Const        r206, 1
+  AddInt       r125, r125, r206
+  Jump         L12
+L7:
   // sort by [g.key.d_year,
   Sort         r3, r3
   // json(result)
   JSON         r3
-  // expect result == []
-  Equal        r163, r3, r0
-  Expect       r163
+  // expect len(result) == 0
+  Len          r208, r3
+  Const        r209, 0
+  EqualInt     r210, r208, r209
+  Expect       r210
   Return       r0

--- a/tests/dataset/tpc-ds/out/q4.ir.out
+++ b/tests/dataset/tpc-ds/out/q4.ir.out
@@ -1,921 +1,1028 @@
-func main (regs=621)
+func main (regs=1104)
   // let customer = []
   Const        r0, []
   // let store_sales = []
-  Move         r1, r0
+  Const        r1, []
   // let catalog_sales = []
-  Move         r2, r0
+  Const        r2, []
   // let web_sales = []
-  Move         r3, r2
+  Const        r3, []
   // let date_dim = []
-  Move         r4, r0
+  Const        r4, []
   // from c in customer
-  Move         r5, r4
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r6, "id"
-  Const        r7, "c_customer_id"
-  Const        r8, "first"
-  Const        r9, "c_first_name"
-  Const        r10, "last"
-  Const        r11, "c_last_name"
-  Const        r12, "login"
-  Const        r13, "c_login"
-  Const        r14, "year"
-  Const        r15, "d_year"
-  // customer_id: g.key.id,
-  Const        r16, "customer_id"
-  Const        r17, "key"
-  // customer_first_name: g.key.first,
-  Const        r18, "customer_first_name"
-  // customer_last_name: g.key.last,
-  Const        r19, "customer_last_name"
-  // customer_login: g.key.login,
-  Const        r20, "customer_login"
-  // dyear: g.key.year,
-  Const        r21, "dyear"
-  // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Const        r22, "year_total"
-  Const        r23, "ss_ext_list_price"
-  Const        r24, "ss_ext_wholesale_cost"
-  Const        r25, "ss_ext_discount_amt"
-  Const        r26, "ss_ext_sales_price"
-  // sale_type: "s",
-  Const        r27, "sale_type"
-  // from c in customer
-  MakeMap      r28, 0, r0
-  Move         r30, r4
-  Move         r29, r30
-  IterPrep     r31, r0
-  Len          r32, r31
-  Const        r33, 0
-L7:
-  LessInt      r34, r33, r32
-  JumpIfFalse  r34, L0
-  Index        r36, r31, r33
+  Const        r5, []
+  MakeMap      r37, 0, r0
+  Const        r38, []
+  IterPrep     r40, r0
+  Len          r41, r40
+  Const        r42, 0
+L1:
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L0
+  Index        r45, r40, r42
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  IterPrep     r37, r1
-  Len          r38, r37
-  Move         r39, r33
-L6:
-  LessInt      r40, r39, r38
-  JumpIfFalse  r40, L1
-  Index        r42, r37, r39
-  Const        r43, "c_customer_sk"
-  Index        r44, r36, r43
-  Const        r45, "ss_customer_sk"
-  Index        r46, r42, r45
-  Equal        r47, r44, r46
-  JumpIfFalse  r47, L2
+  IterPrep     r46, r1
+  Len          r47, r46
+  Const        r48, 0
+L2:
+  LessInt      r49, r48, r47
+  JumpIfFalse  r49, L1
+  Index        r51, r46, r48
+  Const        r52, "c_customer_sk"
+  Index        r53, r45, r52
+  Const        r54, "ss_customer_sk"
+  Index        r55, r51, r54
+  Equal        r56, r53, r55
+  JumpIfFalse  r56, L2
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r48, r4
-  Len          r49, r48
-  Move         r50, r33
+  IterPrep     r57, r4
+  Len          r58, r57
+  Const        r59, 0
 L5:
-  LessInt      r51, r50, r49
-  JumpIfFalse  r51, L2
-  Index        r53, r48, r50
-  Const        r54, "ss_sold_date_sk"
-  Index        r55, r42, r54
-  Const        r56, "d_date_sk"
-  Index        r57, r53, r56
-  Equal        r58, r55, r57
-  JumpIfFalse  r58, L3
+  LessInt      r60, r59, r58
+  JumpIfFalse  r60, L2
+  Index        r62, r57, r59
+  Const        r63, "ss_sold_date_sk"
+  Index        r64, r51, r63
+  Const        r65, "d_date_sk"
+  Index        r66, r62, r65
+  Equal        r67, r64, r66
+  JumpIfFalse  r67, L3
   // from c in customer
-  Const        r59, "c"
-  Move         r60, r36
-  Const        r61, "s"
-  Move         r62, r42
-  Const        r63, "d"
-  Move         r64, r53
-  MakeMap      r65, 3, r59
+  Const        r68, "c"
+  Move         r69, r45
+  Const        r70, "s"
+  Move         r71, r51
+  Const        r72, "d"
+  Move         r73, r62
+  MakeMap      r74, 3, r68
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r66, r6
-  Index        r67, r36, r7
-  Move         r68, r8
-  Index        r69, r36, r9
-  Move         r70, r10
-  Index        r71, r36, r11
-  Move         r72, r12
-  Index        r73, r36, r13
-  Move         r74, r14
-  Index        r75, r53, r15
-  Move         r76, r66
-  Move         r77, r67
-  Move         r78, r68
-  Move         r79, r69
-  Move         r80, r70
-  Move         r81, r71
-  Move         r82, r72
-  Move         r83, r73
-  Move         r84, r74
-  Move         r85, r75
-  MakeMap      r86, 5, r76
-  Str          r87, r86
-  In           r88, r87, r28
-  JumpIfTrue   r88, L4
+  Const        r75, "id"
+  Const        r76, "c_customer_id"
+  Index        r77, r45, r76
+  Const        r78, "first"
+  Const        r79, "c_first_name"
+  Index        r80, r45, r79
+  Const        r81, "last"
+  Const        r82, "c_last_name"
+  Index        r83, r45, r82
+  Const        r84, "login"
+  Const        r85, "c_login"
+  Index        r86, r45, r85
+  Const        r87, "year"
+  Const        r88, "d_year"
+  Index        r89, r62, r88
+  Move         r90, r75
+  Move         r91, r77
+  Move         r92, r78
+  Move         r93, r80
+  Move         r94, r81
+  Move         r95, r83
+  Move         r96, r84
+  Move         r97, r86
+  Move         r98, r87
+  Move         r99, r89
+  MakeMap      r100, 5, r90
+  Str          r101, r100
+  In           r102, r101, r37
+  JumpIfTrue   r102, L4
   // from c in customer
-  Move         r89, r30
-  Const        r90, "__group__"
-  Const        r91, true
-  Move         r92, r17
+  Const        r103, []
+  Const        r104, "__group__"
+  Const        r105, true
+  Const        r106, "key"
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r93, r86
+  Move         r107, r100
   // from c in customer
-  Const        r94, "items"
-  Move         r95, r89
-  Const        r96, "count"
-  Move         r97, r50
-  Move         r98, r90
-  Move         r99, r91
-  Move         r100, r92
-  Move         r101, r93
-  Move         r102, r94
-  Move         r103, r95
-  Move         r104, r96
-  Move         r105, r97
-  MakeMap      r106, 4, r98
-  SetIndex     r28, r87, r106
-  Append       r29, r29, r106
+  Const        r108, "items"
+  Move         r109, r103
+  Const        r110, "count"
+  Const        r111, 0
+  Move         r112, r104
+  Move         r113, r105
+  Move         r114, r106
+  Move         r115, r107
+  Move         r116, r108
+  Move         r117, r109
+  Move         r118, r110
+  Move         r119, r111
+  MakeMap      r120, 4, r112
+  SetIndex     r37, r101, r120
+  Append       r38, r38, r120
 L4:
-  Move         r108, r94
-  Index        r109, r28, r87
-  Index        r110, r109, r108
-  Append       r111, r110, r65
-  SetIndex     r109, r108, r111
-  Move         r112, r96
-  Index        r113, r109, r112
-  Const        r114, 1
-  AddInt       r115, r113, r114
-  SetIndex     r109, r112, r115
+  Const        r122, "items"
+  Index        r123, r37, r101
+  Index        r124, r123, r122
+  Append       r125, r124, r74
+  SetIndex     r123, r122, r125
+  Const        r126, "count"
+  Index        r127, r123, r126
+  Const        r128, 1
+  AddInt       r129, r127, r128
+  SetIndex     r123, r126, r129
 L3:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  AddInt       r50, r50, r114
+  Const        r130, 1
+  AddInt       r59, r59, r130
   Jump         L5
-L2:
-  // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  AddInt       r39, r39, r114
-  Jump         L6
-L1:
-  // from c in customer
-  AddInt       r33, r33, r114
-  Jump         L7
 L0:
-  Const        r117, 0
-  Move         r116, r117
-  Len          r118, r29
-L11:
-  LessInt      r119, r116, r118
-  JumpIfFalse  r119, L8
-  Index        r121, r29, r116
-  // customer_id: g.key.id,
-  Move         r122, r16
-  Index        r123, r121, r17
-  Index        r124, r123, r6
-  // customer_first_name: g.key.first,
-  Move         r125, r18
-  Index        r126, r121, r17
-  Index        r127, r126, r8
-  // customer_last_name: g.key.last,
-  Move         r128, r19
-  Index        r129, r121, r17
-  Index        r130, r129, r10
-  // customer_login: g.key.login,
-  Move         r131, r20
-  Index        r132, r121, r17
-  Index        r133, r132, r12
-  // dyear: g.key.year,
-  Move         r134, r21
-  Index        r135, r121, r17
-  Index        r136, r135, r14
-  // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Move         r137, r22
-  Move         r138, r0
-  IterPrep     r139, r121
-  Len          r140, r139
-  Move         r141, r117
-L10:
-  LessInt      r142, r141, r140
-  JumpIfFalse  r142, L9
-  Index        r144, r139, r141
-  Index        r145, r144, r23
-  Index        r146, r144, r24
-  Sub          r147, r145, r146
-  Index        r148, r144, r25
-  Sub          r149, r147, r148
-  Index        r150, r144, r26
-  Add          r151, r149, r150
-  Const        r152, 2
-  Div          r153, r151, r152
-  Append       r138, r138, r153
-  AddInt       r141, r141, r114
-  Jump         L10
+  // from c in customer
+  Const        r133, 0
+  Len          r135, r38
 L9:
-  Sum          r155, r138
-  // sale_type: "s",
-  Move         r156, r27
-  Move         r157, r61
+  LessInt      r136, r133, r135
+  JumpIfFalse  r136, L6
+  Index        r138, r38, r133
   // customer_id: g.key.id,
-  Move         r158, r122
-  Move         r159, r124
+  Const        r139, "customer_id"
+  Const        r140, "key"
+  Index        r141, r138, r140
+  Const        r142, "id"
+  Index        r143, r141, r142
   // customer_first_name: g.key.first,
-  Move         r160, r125
-  Move         r161, r127
+  Const        r144, "customer_first_name"
+  Const        r145, "key"
+  Index        r146, r138, r145
+  Const        r147, "first"
+  Index        r148, r146, r147
   // customer_last_name: g.key.last,
-  Move         r162, r128
-  Move         r163, r130
+  Const        r149, "customer_last_name"
+  Const        r150, "key"
+  Index        r151, r138, r150
+  Const        r152, "last"
+  Index        r153, r151, r152
   // customer_login: g.key.login,
-  Move         r164, r131
-  Move         r165, r133
+  Const        r154, "customer_login"
+  Const        r155, "key"
+  Index        r156, r138, r155
+  Const        r157, "login"
+  Index        r158, r156, r157
   // dyear: g.key.year,
-  Move         r166, r134
-  Move         r167, r136
+  Const        r159, "dyear"
+  Const        r160, "key"
+  Index        r161, r138, r160
+  Const        r162, "year"
+  Index        r163, r161, r162
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Move         r168, r137
-  Move         r169, r155
-  // sale_type: "s",
-  Move         r170, r156
-  Move         r171, r157
-  // select {
-  MakeMap      r172, 7, r158
-  // from c in customer
-  Append       r5, r5, r172
-  AddInt       r116, r116, r114
-  Jump         L11
+  Const        r164, "year_total"
+  Const        r165, []
+  IterPrep     r170, r138
+  Len          r171, r170
+  Const        r172, 0
 L8:
+  LessInt      r174, r172, r171
+  JumpIfFalse  r174, L7
+  Index        r176, r170, r172
+  Const        r177, "ss_ext_list_price"
+  Index        r178, r176, r177
+  Const        r179, "ss_ext_wholesale_cost"
+  Index        r180, r176, r179
+  Sub          r181, r178, r180
+  Const        r182, "ss_ext_discount_amt"
+  Index        r183, r176, r182
+  Sub          r184, r181, r183
+  Const        r185, "ss_ext_sales_price"
+  Index        r186, r176, r185
+  Add          r187, r184, r186
+  Const        r188, 2
+  Div          r189, r187, r188
+  Append       r165, r165, r189
+  Const        r191, 1
+  AddInt       r172, r172, r191
+  Jump         L8
+L7:
+  Sum          r192, r165
+  // sale_type: "s",
+  Const        r193, "sale_type"
+  Const        r194, "s"
+  // customer_id: g.key.id,
+  Move         r195, r139
+  Move         r196, r143
+  // customer_first_name: g.key.first,
+  Move         r197, r144
+  Move         r198, r148
+  // customer_last_name: g.key.last,
+  Move         r199, r149
+  Move         r200, r153
+  // customer_login: g.key.login,
+  Move         r201, r154
+  Move         r202, r158
+  // dyear: g.key.year,
+  Move         r203, r159
+  Move         r204, r163
+  // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
+  Move         r205, r164
+  Move         r206, r192
+  // sale_type: "s",
+  Move         r207, r193
+  Move         r208, r194
+  // select {
+  MakeMap      r209, 7, r195
   // from c in customer
-  Move         r174, r0
-  // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Const        r175, "cs_ext_list_price"
-  Const        r176, "cs_ext_wholesale_cost"
-  Const        r177, "cs_ext_discount_amt"
-  Const        r178, "cs_ext_sales_price"
+  Append       r5, r5, r209
+  Const        r211, 1
+  AddInt       r133, r133, r211
+  Jump         L9
+L6:
   // from c in customer
-  MakeMap      r179, 0, r0
-  Move         r180, r174
-  IterPrep     r182, r0
-  Len          r183, r182
-  Move         r184, r117
-L19:
-  LessInt      r185, r184, r183
-  JumpIfFalse  r185, L12
-  Index        r36, r182, r184
-  // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  IterPrep     r187, r2
-  Len          r188, r187
-  Move         r189, r117
-L18:
-  LessInt      r190, r189, r188
-  JumpIfFalse  r190, L13
-  Index        r192, r187, r189
-  Index        r193, r36, r43
-  Const        r194, "cs_bill_customer_sk"
-  Index        r195, r192, r194
-  Equal        r196, r193, r195
-  JumpIfFalse  r196, L14
-  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r197, r4
-  Len          r198, r197
-  Move         r199, r189
+  Const        r212, []
+  MakeMap      r244, 0, r0
+  Const        r245, []
+  IterPrep     r247, r0
+  Len          r248, r247
+  Const        r249, 0
 L17:
-  LessInt      r200, r199, r198
-  JumpIfFalse  r200, L14
-  Index        r202, r197, r199
-  Const        r203, "cs_sold_date_sk"
-  Index        r204, r192, r203
-  Index        r205, r202, r56
-  Equal        r206, r204, r205
-  JumpIfFalse  r206, L15
-  // from c in customer
-  Move         r207, r59
-  Move         r208, r36
-  Const        r209, "cs"
-  Move         r210, r192
-  Move         r211, r63
-  Move         r212, r202
-  MakeMap      r213, 3, r207
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r214, r6
-  Index        r215, r36, r7
-  Move         r216, r8
-  Index        r217, r36, r9
-  Move         r218, r10
-  Index        r219, r36, r11
-  Move         r220, r12
-  Index        r221, r36, r13
-  Move         r222, r14
-  Index        r223, r202, r15
-  Move         r224, r214
-  Move         r225, r215
-  Move         r226, r216
-  Move         r227, r217
-  Move         r228, r218
-  Move         r229, r219
-  Move         r230, r220
-  Move         r231, r221
-  Move         r232, r222
-  Move         r233, r223
-  MakeMap      r234, 5, r224
-  Str          r235, r234
-  In           r236, r235, r179
-  JumpIfTrue   r236, L16
-  // from c in customer
-  Move         r237, r174
-  Move         r238, r90
-  Move         r239, r91
-  Move         r240, r17
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r241, r234
-  // from c in customer
-  Move         r242, r94
-  Move         r243, r237
-  Move         r244, r96
-  Move         r245, r117
-  Move         r246, r238
-  Move         r247, r239
-  Move         r248, r240
-  Move         r249, r241
-  Move         r250, r242
-  Move         r251, r243
-  Move         r252, r244
-  Move         r253, r245
-  MakeMap      r254, 4, r246
-  SetIndex     r179, r235, r254
-  Append       r180, r180, r254
-L16:
-  Index        r256, r179, r235
-  Index        r257, r256, r108
-  Append       r258, r257, r213
-  SetIndex     r256, r108, r258
-  Index        r259, r256, r112
-  AddInt       r260, r259, r114
-  SetIndex     r256, r112, r260
-L15:
-  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r199, r199, r114
-  Jump         L17
-L14:
+  LessInt      r250, r249, r248
+  JumpIfFalse  r250, L10
+  Index        r45, r247, r249
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  AddInt       r189, r189, r114
-  Jump         L18
+  IterPrep     r252, r2
+  Len          r253, r252
+  Const        r254, 0
+L16:
+  LessInt      r255, r254, r253
+  JumpIfFalse  r255, L11
+  Index        r257, r252, r254
+  Const        r258, "c_customer_sk"
+  Index        r259, r45, r258
+  Const        r260, "cs_bill_customer_sk"
+  Index        r261, r257, r260
+  Equal        r262, r259, r261
+  JumpIfFalse  r262, L12
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  IterPrep     r263, r4
+  Len          r264, r263
+  Const        r265, 0
+L15:
+  LessInt      r266, r265, r264
+  JumpIfFalse  r266, L12
+  Index        r268, r263, r265
+  Const        r269, "cs_sold_date_sk"
+  Index        r270, r257, r269
+  Const        r271, "d_date_sk"
+  Index        r272, r268, r271
+  Equal        r273, r270, r272
+  JumpIfFalse  r273, L13
+  // from c in customer
+  Const        r274, "c"
+  Move         r275, r45
+  Const        r276, "cs"
+  Move         r277, r257
+  Const        r278, "d"
+  Move         r279, r268
+  MakeMap      r280, 3, r274
+  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
+  Const        r281, "id"
+  Const        r282, "c_customer_id"
+  Index        r283, r45, r282
+  Const        r284, "first"
+  Const        r285, "c_first_name"
+  Index        r286, r45, r285
+  Const        r287, "last"
+  Const        r288, "c_last_name"
+  Index        r289, r45, r288
+  Const        r290, "login"
+  Const        r291, "c_login"
+  Index        r292, r45, r291
+  Const        r293, "year"
+  Const        r294, "d_year"
+  Index        r295, r268, r294
+  Move         r296, r281
+  Move         r297, r283
+  Move         r298, r284
+  Move         r299, r286
+  Move         r300, r287
+  Move         r301, r289
+  Move         r302, r290
+  Move         r303, r292
+  Move         r304, r293
+  Move         r305, r295
+  MakeMap      r306, 5, r296
+  Str          r307, r306
+  In           r308, r307, r244
+  JumpIfTrue   r308, L14
+  // from c in customer
+  Const        r309, []
+  Const        r310, "__group__"
+  Const        r311, true
+  Const        r312, "key"
+  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
+  Move         r313, r306
+  // from c in customer
+  Const        r314, "items"
+  Move         r315, r309
+  Const        r316, "count"
+  Const        r317, 0
+  Move         r318, r310
+  Move         r319, r311
+  Move         r320, r312
+  Move         r321, r313
+  Move         r322, r314
+  Move         r323, r315
+  Move         r324, r316
+  Move         r325, r317
+  MakeMap      r326, 4, r318
+  SetIndex     r244, r307, r326
+  Append       r245, r245, r326
+L14:
+  Const        r328, "items"
+  Index        r329, r244, r307
+  Index        r330, r329, r328
+  Append       r331, r330, r280
+  SetIndex     r329, r328, r331
+  Const        r332, "count"
+  Index        r333, r329, r332
+  Const        r334, 1
+  AddInt       r335, r333, r334
+  SetIndex     r329, r332, r335
 L13:
-  // from c in customer
-  AddInt       r184, r184, r114
-  Jump         L19
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  Const        r336, 1
+  AddInt       r265, r265, r336
+  Jump         L15
 L12:
-  Move         r261, r117
-  Len          r262, r180
-L23:
-  LessInt      r263, r261, r262
-  JumpIfFalse  r263, L20
-  Index        r121, r180, r261
-  // customer_id: g.key.id,
-  Move         r265, r16
-  Index        r266, r121, r17
-  Index        r267, r266, r6
-  // customer_first_name: g.key.first,
-  Move         r268, r18
-  Index        r269, r121, r17
-  Index        r270, r269, r8
-  // customer_last_name: g.key.last,
-  Move         r271, r19
-  Index        r272, r121, r17
-  Index        r273, r272, r10
-  // customer_login: g.key.login,
-  Move         r274, r20
-  Index        r275, r121, r17
-  Index        r276, r275, r12
-  // dyear: g.key.year,
-  Move         r277, r21
-  Index        r278, r121, r17
-  Index        r279, r278, r14
-  // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Move         r280, r22
-  Move         r281, r237
-  IterPrep     r282, r121
-  Len          r283, r282
-  Move         r284, r117
-L22:
-  LessInt      r285, r284, r283
-  JumpIfFalse  r285, L21
-  Index        r144, r282, r284
-  Index        r287, r144, r175
-  Index        r288, r144, r176
-  Sub          r289, r287, r288
-  Index        r290, r144, r177
-  Sub          r291, r289, r290
-  Index        r292, r144, r178
-  Add          r293, r291, r292
-  Div          r294, r293, r152
-  Append       r281, r281, r294
-  AddInt       r284, r284, r114
-  Jump         L22
+  // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
+  Const        r337, 1
+  AddInt       r254, r254, r337
+  Jump         L16
+L11:
+  // from c in customer
+  Const        r338, 1
+  AddInt       r249, r249, r338
+  Jump         L17
+L10:
+  Const        r339, 0
+  Len          r341, r245
 L21:
-  Sum          r296, r281
-  // sale_type: "c",
-  Move         r297, r27
-  Move         r298, r59
+  LessInt      r342, r339, r341
+  JumpIfFalse  r342, L18
+  Index        r138, r245, r339
   // customer_id: g.key.id,
-  Move         r299, r265
-  Move         r300, r267
+  Const        r344, "customer_id"
+  Const        r345, "key"
+  Index        r346, r138, r345
+  Const        r347, "id"
+  Index        r348, r346, r347
   // customer_first_name: g.key.first,
-  Move         r301, r268
-  Move         r302, r270
+  Const        r349, "customer_first_name"
+  Const        r350, "key"
+  Index        r351, r138, r350
+  Const        r352, "first"
+  Index        r353, r351, r352
   // customer_last_name: g.key.last,
-  Move         r303, r271
-  Move         r304, r273
+  Const        r354, "customer_last_name"
+  Const        r355, "key"
+  Index        r356, r138, r355
+  Const        r357, "last"
+  Index        r358, r356, r357
   // customer_login: g.key.login,
-  Move         r305, r274
-  Move         r306, r276
+  Const        r359, "customer_login"
+  Const        r360, "key"
+  Index        r361, r138, r360
+  Const        r362, "login"
+  Index        r363, r361, r362
   // dyear: g.key.year,
-  Move         r307, r277
-  Move         r308, r279
+  Const        r364, "dyear"
+  Const        r365, "key"
+  Index        r366, r138, r365
+  Const        r367, "year"
+  Index        r368, r366, r367
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Move         r309, r280
-  Move         r310, r296
-  // sale_type: "c",
-  Move         r311, r297
-  Move         r312, r298
-  // select {
-  MakeMap      r313, 7, r299
-  // from c in customer
-  Append       r174, r174, r313
-  AddInt       r261, r261, r114
-  Jump         L23
+  Const        r369, "year_total"
+  Const        r370, []
+  IterPrep     r375, r138
+  Len          r376, r375
+  Const        r377, 0
 L20:
-  // ) union all (
-  UnionAll     r315, r5, r174
-  // from c in customer
-  Move         r316, r0
-  // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Const        r317, "ws_ext_list_price"
-  Const        r318, "ws_ext_wholesale_cost"
-  Const        r319, "ws_ext_discount_amt"
-  Const        r320, "ws_ext_sales_price"
-  // from c in customer
-  MakeMap      r321, 0, r0
-  Move         r322, r316
-  IterPrep     r324, r0
-  Len          r325, r324
-  Move         r326, r245
-L31:
-  LessInt      r327, r326, r325
-  JumpIfFalse  r327, L24
-  Index        r36, r324, r326
-  // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  IterPrep     r329, r3
-  Len          r330, r329
-  Move         r331, r245
-L30:
-  LessInt      r332, r331, r330
-  JumpIfFalse  r332, L25
-  Index        r334, r329, r331
-  Index        r335, r36, r43
-  Const        r336, "ws_bill_customer_sk"
-  Index        r337, r334, r336
-  Equal        r338, r335, r337
-  JumpIfFalse  r338, L26
-  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r339, r4
-  Len          r340, r339
-  Move         r341, r331
-L29:
-  LessInt      r342, r341, r340
-  JumpIfFalse  r342, L26
-  Index        r344, r339, r341
-  Const        r345, "ws_sold_date_sk"
-  Index        r346, r334, r345
-  Index        r347, r344, r56
-  Equal        r348, r346, r347
-  JumpIfFalse  r348, L27
-  // from c in customer
-  Move         r349, r298
-  Move         r350, r36
-  Const        r351, "ws"
-  Move         r352, r334
-  Move         r353, r63
-  Move         r354, r344
-  MakeMap      r355, 3, r349
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r356, r214
-  Index        r357, r36, r7
-  Move         r358, r216
-  Index        r359, r36, r9
-  Move         r360, r218
-  Index        r361, r36, r11
-  Move         r362, r220
-  Index        r363, r36, r13
-  Move         r364, r222
-  Index        r365, r344, r15
-  Move         r366, r356
-  Move         r367, r357
-  Move         r368, r358
-  Move         r369, r359
-  Move         r370, r360
-  Move         r371, r361
-  Move         r372, r362
-  Move         r373, r363
-  Move         r374, r364
-  Move         r375, r365
-  MakeMap      r376, 5, r366
-  Str          r377, r376
-  In           r378, r377, r321
-  JumpIfTrue   r378, L28
-  // from c in customer
-  Move         r379, r316
-  Move         r380, r90
-  Move         r381, r91
-  Move         r382, r240
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r383, r376
-  // from c in customer
-  Move         r384, r242
-  Move         r385, r379
-  Move         r386, r244
-  Move         r387, r117
-  Move         r388, r380
-  Move         r389, r381
-  Move         r390, r382
-  Move         r391, r383
-  Move         r392, r384
-  Move         r393, r385
-  Move         r394, r386
-  Move         r395, r387
-  MakeMap      r396, 4, r388
-  SetIndex     r321, r377, r396
-  Append       r322, r322, r396
-L28:
-  Index        r398, r321, r377
-  Index        r399, r398, r108
-  Append       r400, r399, r355
-  SetIndex     r398, r108, r400
-  Index        r401, r398, r112
-  AddInt       r402, r401, r114
-  SetIndex     r398, r112, r402
-L27:
-  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  AddInt       r341, r341, r114
-  Jump         L29
-L26:
-  // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  AddInt       r331, r331, r114
-  Jump         L30
-L25:
-  // from c in customer
-  AddInt       r326, r326, r114
-  Jump         L31
-L24:
-  Move         r403, r117
-  Len          r404, r322
-L35:
-  LessInt      r405, r403, r404
-  JumpIfFalse  r405, L32
-  Index        r121, r322, r403
+  LessInt      r379, r377, r376
+  JumpIfFalse  r379, L19
+  Index        r176, r375, r377
+  Const        r381, "cs_ext_list_price"
+  Index        r382, r176, r381
+  Const        r383, "cs_ext_wholesale_cost"
+  Index        r384, r176, r383
+  Sub          r385, r382, r384
+  Const        r386, "cs_ext_discount_amt"
+  Index        r387, r176, r386
+  Sub          r388, r385, r387
+  Const        r389, "cs_ext_sales_price"
+  Index        r390, r176, r389
+  Add          r391, r388, r390
+  Const        r392, 2
+  Div          r393, r391, r392
+  Append       r370, r370, r393
+  Const        r395, 1
+  AddInt       r377, r377, r395
+  Jump         L20
+L19:
+  Sum          r396, r370
+  // sale_type: "c",
+  Const        r397, "sale_type"
+  Const        r398, "c"
   // customer_id: g.key.id,
-  Move         r407, r265
-  Index        r408, r121, r17
-  Index        r409, r408, r6
+  Move         r399, r344
+  Move         r400, r348
   // customer_first_name: g.key.first,
-  Move         r410, r268
-  Index        r411, r121, r17
-  Index        r412, r411, r8
+  Move         r401, r349
+  Move         r402, r353
   // customer_last_name: g.key.last,
-  Move         r413, r271
-  Index        r414, r121, r17
-  Index        r415, r414, r10
+  Move         r403, r354
+  Move         r404, r358
   // customer_login: g.key.login,
-  Move         r416, r274
-  Index        r417, r121, r17
-  Index        r418, r417, r12
+  Move         r405, r359
+  Move         r406, r363
   // dyear: g.key.year,
-  Move         r419, r277
-  Index        r420, r121, r17
-  Index        r421, r420, r14
-  // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Move         r422, r280
-  Move         r423, r379
-  IterPrep     r424, r121
-  Len          r425, r424
-  Move         r426, r117
-L34:
-  LessInt      r427, r426, r425
-  JumpIfFalse  r427, L33
-  Index        r144, r424, r426
-  Index        r429, r144, r317
-  Index        r430, r144, r318
-  Sub          r431, r429, r430
-  Index        r432, r144, r319
-  Sub          r433, r431, r432
-  Index        r434, r144, r320
-  Add          r435, r433, r434
-  Div          r436, r435, r152
-  Append       r423, r423, r436
-  AddInt       r426, r426, r114
-  Jump         L34
-L33:
-  Sum          r438, r423
-  // sale_type: "w",
-  Move         r439, r297
-  Const        r440, "w"
-  // customer_id: g.key.id,
-  Move         r441, r407
-  Move         r442, r409
-  // customer_first_name: g.key.first,
-  Move         r443, r410
-  Move         r444, r412
-  // customer_last_name: g.key.last,
-  Move         r445, r413
-  Move         r446, r415
-  // customer_login: g.key.login,
-  Move         r447, r416
-  Move         r448, r418
-  // dyear: g.key.year,
-  Move         r449, r419
-  Move         r450, r421
-  // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Move         r451, r422
-  Move         r452, r438
-  // sale_type: "w",
-  Move         r453, r439
-  Move         r454, r440
+  Move         r407, r364
+  Move         r408, r368
+  // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
+  Move         r409, r369
+  Move         r410, r396
+  // sale_type: "c",
+  Move         r411, r397
+  Move         r412, r398
   // select {
-  MakeMap      r455, 7, r441
+  MakeMap      r413, 7, r399
   // from c in customer
-  Append       r316, r316, r455
-  AddInt       r403, r403, r114
-  Jump         L35
-L32:
+  Append       r212, r212, r413
+  Const        r415, 1
+  AddInt       r339, r339, r415
+  Jump         L21
+L18:
   // ) union all (
-  UnionAll     r457, r315, r316
+  UnionAll     r416, r5, r212
+  // from c in customer
+  Const        r417, []
+  MakeMap      r449, 0, r0
+  Const        r450, []
+  IterPrep     r452, r0
+  Len          r453, r452
+  Const        r454, 0
+L29:
+  LessInt      r455, r454, r453
+  JumpIfFalse  r455, L22
+  Index        r45, r452, r454
+  // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
+  IterPrep     r457, r3
+  Len          r458, r457
+  Const        r459, 0
+L28:
+  LessInt      r460, r459, r458
+  JumpIfFalse  r460, L23
+  Index        r462, r457, r459
+  Const        r463, "c_customer_sk"
+  Index        r464, r45, r463
+  Const        r465, "ws_bill_customer_sk"
+  Index        r466, r462, r465
+  Equal        r467, r464, r466
+  JumpIfFalse  r467, L24
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  IterPrep     r468, r4
+  Len          r469, r468
+  Const        r470, 0
+L27:
+  LessInt      r471, r470, r469
+  JumpIfFalse  r471, L24
+  Index        r473, r468, r470
+  Const        r474, "ws_sold_date_sk"
+  Index        r475, r462, r474
+  Const        r476, "d_date_sk"
+  Index        r477, r473, r476
+  Equal        r478, r475, r477
+  JumpIfFalse  r478, L25
+  // from c in customer
+  Const        r479, "c"
+  Move         r480, r45
+  Const        r481, "ws"
+  Move         r482, r462
+  Const        r483, "d"
+  Move         r484, r473
+  MakeMap      r485, 3, r479
+  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
+  Const        r486, "id"
+  Const        r487, "c_customer_id"
+  Index        r488, r45, r487
+  Const        r489, "first"
+  Const        r490, "c_first_name"
+  Index        r491, r45, r490
+  Const        r492, "last"
+  Const        r493, "c_last_name"
+  Index        r494, r45, r493
+  Const        r495, "login"
+  Const        r496, "c_login"
+  Index        r497, r45, r496
+  Const        r498, "year"
+  Const        r499, "d_year"
+  Index        r500, r473, r499
+  Move         r501, r486
+  Move         r502, r488
+  Move         r503, r489
+  Move         r504, r491
+  Move         r505, r492
+  Move         r506, r494
+  Move         r507, r495
+  Move         r508, r497
+  Move         r509, r498
+  Move         r510, r500
+  MakeMap      r511, 5, r501
+  Str          r512, r511
+  In           r513, r512, r449
+  JumpIfTrue   r513, L26
+  // from c in customer
+  Const        r514, []
+  Const        r515, "__group__"
+  Const        r516, true
+  Const        r517, "key"
+  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
+  Move         r518, r511
+  // from c in customer
+  Const        r519, "items"
+  Move         r520, r514
+  Const        r521, "count"
+  Const        r522, 0
+  Move         r523, r515
+  Move         r524, r516
+  Move         r525, r517
+  Move         r526, r518
+  Move         r527, r519
+  Move         r528, r520
+  Move         r529, r521
+  Move         r530, r522
+  MakeMap      r531, 4, r523
+  SetIndex     r449, r512, r531
+  Append       r450, r450, r531
+L26:
+  Const        r533, "items"
+  Index        r534, r449, r512
+  Index        r535, r534, r533
+  Append       r536, r535, r485
+  SetIndex     r534, r533, r536
+  Const        r537, "count"
+  Index        r538, r534, r537
+  Const        r539, 1
+  AddInt       r540, r538, r539
+  SetIndex     r534, r537, r540
+L25:
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  Const        r541, 1
+  AddInt       r470, r470, r541
+  Jump         L27
+L24:
+  // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
+  Const        r542, 1
+  AddInt       r459, r459, r542
+  Jump         L28
+L23:
+  // from c in customer
+  Const        r543, 1
+  AddInt       r454, r454, r543
+  Jump         L29
+L22:
+  Const        r544, 0
+  Len          r546, r450
+L33:
+  LessInt      r547, r544, r546
+  JumpIfFalse  r547, L30
+  Index        r138, r450, r544
+  // customer_id: g.key.id,
+  Const        r549, "customer_id"
+  Const        r550, "key"
+  Index        r551, r138, r550
+  Const        r552, "id"
+  Index        r553, r551, r552
+  // customer_first_name: g.key.first,
+  Const        r554, "customer_first_name"
+  Const        r555, "key"
+  Index        r556, r138, r555
+  Const        r557, "first"
+  Index        r558, r556, r557
+  // customer_last_name: g.key.last,
+  Const        r559, "customer_last_name"
+  Const        r560, "key"
+  Index        r561, r138, r560
+  Const        r562, "last"
+  Index        r563, r561, r562
+  // customer_login: g.key.login,
+  Const        r564, "customer_login"
+  Const        r565, "key"
+  Index        r566, r138, r565
+  Const        r567, "login"
+  Index        r568, r566, r567
+  // dyear: g.key.year,
+  Const        r569, "dyear"
+  Const        r570, "key"
+  Index        r571, r138, r570
+  Const        r572, "year"
+  Index        r573, r571, r572
+  // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
+  Const        r574, "year_total"
+  Const        r575, []
+  IterPrep     r580, r138
+  Len          r581, r580
+  Const        r582, 0
+L32:
+  LessInt      r584, r582, r581
+  JumpIfFalse  r584, L31
+  Index        r176, r580, r582
+  Const        r586, "ws_ext_list_price"
+  Index        r587, r176, r586
+  Const        r588, "ws_ext_wholesale_cost"
+  Index        r589, r176, r588
+  Sub          r590, r587, r589
+  Const        r591, "ws_ext_discount_amt"
+  Index        r592, r176, r591
+  Sub          r593, r590, r592
+  Const        r594, "ws_ext_sales_price"
+  Index        r595, r176, r594
+  Add          r596, r593, r595
+  Const        r597, 2
+  Div          r598, r596, r597
+  Append       r575, r575, r598
+  Const        r600, 1
+  AddInt       r582, r582, r600
+  Jump         L32
+L31:
+  Sum          r601, r575
+  // sale_type: "w",
+  Const        r602, "sale_type"
+  Const        r603, "w"
+  // customer_id: g.key.id,
+  Move         r604, r549
+  Move         r605, r553
+  // customer_first_name: g.key.first,
+  Move         r606, r554
+  Move         r607, r558
+  // customer_last_name: g.key.last,
+  Move         r608, r559
+  Move         r609, r563
+  // customer_login: g.key.login,
+  Move         r610, r564
+  Move         r611, r568
+  // dyear: g.key.year,
+  Move         r612, r569
+  Move         r613, r573
+  // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
+  Move         r614, r574
+  Move         r615, r601
+  // sale_type: "w",
+  Move         r616, r602
+  Move         r617, r603
+  // select {
+  MakeMap      r618, 7, r604
+  // from c in customer
+  Append       r417, r417, r618
+  Const        r620, 1
+  AddInt       r544, r544, r620
+  Jump         L33
+L30:
+  // ) union all (
+  UnionAll     r621, r416, r417
   // from s1 in year_total
-  Move         r458, r0
-  IterPrep     r459, r457
-  Len          r460, r459
-  Move         r461, r117
+  Const        r622, []
+  IterPrep     r662, r621
+  Len          r663, r662
+  Const        r664, 0
 L70:
-  LessInt      r462, r461, r460
-  JumpIfFalse  r462, L36
-  Index        r464, r459, r461
+  LessInt      r666, r664, r663
+  JumpIfFalse  r666, L34
+  Index        r668, r662, r664
   // join s2 in year_total on s2.customer_id == s1.customer_id
-  IterPrep     r465, r457
-  Len          r466, r465
-  Move         r467, r117
+  IterPrep     r669, r621
+  Len          r670, r669
+  Const        r712, 0
 L69:
-  LessInt      r468, r467, r466
-  JumpIfFalse  r468, L37
-  Index        r470, r465, r467
-  Index        r471, r470, r16
-  Index        r472, r464, r16
-  Equal        r473, r471, r472
-  JumpIfFalse  r473, L38
+  LessInt      r714, r712, r670
+  JumpIfFalse  r714, L35
+  Index        r716, r669, r712
+  Const        r717, "customer_id"
+  Index        r718, r716, r717
+  Const        r719, "customer_id"
+  Index        r720, r668, r719
+  Equal        r721, r718, r720
+  JumpIfFalse  r721, L36
   // join c1 in year_total on c1.customer_id == s1.customer_id
-  IterPrep     r474, r457
-  Len          r475, r474
-  Move         r476, r117
+  IterPrep     r722, r621
+  Len          r723, r722
+  Const        r765, 0
 L68:
-  LessInt      r477, r476, r475
-  JumpIfFalse  r477, L38
-  Index        r479, r474, r476
-  Index        r480, r479, r16
-  Index        r481, r464, r16
-  Equal        r482, r480, r481
-  JumpIfFalse  r482, L39
+  LessInt      r767, r765, r723
+  JumpIfFalse  r767, L36
+  Index        r769, r722, r765
+  Const        r770, "customer_id"
+  Index        r771, r769, r770
+  Const        r772, "customer_id"
+  Index        r773, r668, r772
+  Equal        r774, r771, r773
+  JumpIfFalse  r774, L37
   // join c2 in year_total on c2.customer_id == s1.customer_id
-  IterPrep     r483, r457
-  Len          r484, r483
-  Move         r485, r117
+  IterPrep     r775, r621
+  Len          r776, r775
+  Const        r818, 0
 L67:
-  LessInt      r486, r485, r484
-  JumpIfFalse  r486, L39
-  Index        r488, r483, r485
-  Index        r489, r488, r16
-  Index        r490, r464, r16
-  Equal        r491, r489, r490
-  JumpIfFalse  r491, L40
+  LessInt      r820, r818, r776
+  JumpIfFalse  r820, L37
+  Index        r822, r775, r818
+  Const        r823, "customer_id"
+  Index        r824, r822, r823
+  Const        r825, "customer_id"
+  Index        r826, r668, r825
+  Equal        r827, r824, r826
+  JumpIfFalse  r827, L38
   // join w1 in year_total on w1.customer_id == s1.customer_id
-  IterPrep     r492, r457
-  Len          r493, r492
-  Move         r494, r117
+  IterPrep     r828, r621
+  Len          r829, r828
+  Const        r871, 0
 L66:
-  LessInt      r495, r494, r493
-  JumpIfFalse  r495, L40
-  Index        r497, r492, r494
-  Index        r498, r497, r16
-  Index        r499, r464, r16
-  Equal        r500, r498, r499
-  JumpIfFalse  r500, L41
+  LessInt      r873, r871, r829
+  JumpIfFalse  r873, L38
+  Index        r875, r828, r871
+  Const        r876, "customer_id"
+  Index        r877, r875, r876
+  Const        r878, "customer_id"
+  Index        r879, r668, r878
+  Equal        r880, r877, r879
+  JumpIfFalse  r880, L39
   // join w2 in year_total on w2.customer_id == s1.customer_id
-  IterPrep     r501, r457
-  Len          r502, r501
-  Move         r503, r117
+  IterPrep     r881, r621
+  Len          r882, r881
+  Const        r924, 0
 L65:
-  LessInt      r504, r503, r502
-  JumpIfFalse  r504, L41
-  Index        r506, r501, r503
-  Index        r507, r506, r16
-  Index        r508, r464, r16
-  Equal        r509, r507, r508
-  JumpIfFalse  r509, L42
+  LessInt      r926, r924, r882
+  JumpIfFalse  r926, L39
+  Index        r928, r881, r924
+  Const        r929, "customer_id"
+  Index        r930, r928, r929
+  Const        r931, "customer_id"
+  Index        r932, r668, r931
+  Equal        r933, r930, r932
+  JumpIfFalse  r933, L40
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Index        r510, r464, r27
+  Const        r934, "sale_type"
+  Index        r935, r668, r934
   // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Index        r511, r464, r22
-  Less         r512, r117, r511
-  Index        r513, r479, r22
-  Less         r514, r117, r513
-  Index        r515, r497, r22
-  Less         r516, r117, r515
+  Const        r936, "year_total"
+  Index        r937, r668, r936
+  Const        r938, 0
+  Less         r939, r938, r937
+  Const        r940, "year_total"
+  Index        r941, r769, r940
+  Const        r942, 0
+  Less         r943, r942, r941
+  Const        r944, "year_total"
+  Index        r945, r875, r944
+  Const        r946, 0
+  Less         r947, r946, r945
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Index        r517, r479, r22
-  Less         r518, r117, r517
-  JumpIfFalse  r518, L43
-  Index        r519, r488, r22
-  Index        r520, r479, r22
-  Div          r522, r519, r520
+  Const        r948, "year_total"
+  Index        r949, r769, r948
+  Const        r950, 0
+  Less         r951, r950, r949
+  JumpIfFalse  r951, L41
+  Const        r952, "year_total"
+  Index        r953, r822, r952
+  Const        r954, "year_total"
+  Index        r955, r769, r954
+  Div          r957, r953, r955
+  Jump         L42
+L41:
+  Const        r957, nil
+L42:
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Const        r959, "year_total"
+  Index        r960, r668, r959
+  Const        r961, 0
+  Less         r962, r961, r960
+  JumpIfFalse  r962, L43
+  Const        r963, "year_total"
+  Index        r964, r716, r963
+  Const        r965, "year_total"
+  Index        r966, r668, r965
+  Div          r968, r964, r966
   Jump         L44
 L43:
-  Const        r523, nil
-  Move         r522, r523
+  Const        r968, nil
 L44:
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Index        r524, r464, r22
-  Less         r525, r117, r524
-  JumpIfFalse  r525, L45
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Less         r970, r968, r957
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r971, "year_total"
+  Index        r972, r769, r971
+  Const        r973, 0
+  Less         r974, r973, r972
+  JumpIfFalse  r974, L45
+  Const        r975, "year_total"
+  Index        r976, r822, r975
+  Const        r977, "year_total"
+  Index        r978, r769, r977
+  Div          r980, r976, r978
+  Jump         L46
 L45:
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r531, r523, r522
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Index        r532, r479, r22
-  Less         r533, r117, r532
-  JumpIfFalse  r533, L46
-  Index        r534, r488, r22
-  Index        r535, r479, r22
-  Div          r537, r534, r535
-  Jump         L47
+  Const        r980, nil
 L46:
-  Move         r538, r523
-  Move         r537, r538
-L47:
   // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Index        r539, r497, r22
-  Less         r540, r117, r539
-  JumpIfFalse  r540, L48
+  Const        r982, "year_total"
+  Index        r983, r875, r982
+  Const        r984, 0
+  Less         r985, r984, r983
+  JumpIfFalse  r985, L47
+  Const        r986, "year_total"
+  Index        r987, r928, r986
+  Const        r988, "year_total"
+  Index        r989, r875, r988
+  Div          r991, r987, r989
+  Jump         L48
+L47:
+  Const        r991, nil
 L48:
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r546, r538, r537
+  Less         r993, r991, r980
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Equal        r547, r510, r157
-  Index        r548, r479, r27
-  Equal        r549, r548, r298
-  Index        r550, r497, r27
-  Equal        r551, r550, r440
+  Const        r994, "s"
+  Equal        r995, r935, r994
+  Const        r996, "sale_type"
+  Index        r997, r769, r996
+  Const        r998, "c"
+  Equal        r999, r997, r998
+  Const        r1000, "sale_type"
+  Index        r1001, r875, r1000
+  Const        r1002, "w"
+  Equal        r1003, r1001, r1002
   // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Index        r552, r470, r27
-  Equal        r553, r552, r157
-  Index        r554, r488, r27
-  Equal        r555, r554, r298
-  Index        r556, r506, r27
-  Equal        r557, r556, r440
+  Const        r1004, "sale_type"
+  Index        r1005, r716, r1004
+  Const        r1006, "s"
+  Equal        r1007, r1005, r1006
+  Const        r1008, "sale_type"
+  Index        r1009, r822, r1008
+  Const        r1010, "c"
+  Equal        r1011, r1009, r1010
+  Const        r1012, "sale_type"
+  Index        r1013, r928, r1012
+  Const        r1014, "w"
+  Equal        r1015, r1013, r1014
   // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Index        r558, r464, r21
-  Const        r559, 2001
-  Equal        r560, r558, r559
-  Index        r561, r470, r21
-  Const        r562, 2002
-  Equal        r563, r561, r562
+  Const        r1016, "dyear"
+  Index        r1017, r668, r1016
+  Const        r1018, 2001
+  Equal        r1019, r1017, r1018
+  Const        r1020, "dyear"
+  Index        r1021, r716, r1020
+  Const        r1022, 2002
+  Equal        r1023, r1021, r1022
   // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Index        r564, r479, r21
-  Equal        r565, r564, r559
-  Index        r566, r488, r21
-  Equal        r567, r566, r562
+  Const        r1024, "dyear"
+  Index        r1025, r769, r1024
+  Const        r1026, 2001
+  Equal        r1027, r1025, r1026
+  Const        r1028, "dyear"
+  Index        r1029, r822, r1028
+  Const        r1030, 2002
+  Equal        r1031, r1029, r1030
   // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Index        r568, r497, r21
-  Equal        r569, r568, r559
-  Index        r570, r506, r21
-  Equal        r571, r570, r562
+  Const        r1032, "dyear"
+  Index        r1033, r875, r1032
+  Const        r1034, 2001
+  Equal        r1035, r1033, r1034
+  Const        r1036, "dyear"
+  Index        r1037, r928, r1036
+  Const        r1038, 2002
+  Equal        r1039, r1037, r1038
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Move         r572, r547
-  JumpIfFalse  r572, L49
+  Move         r1040, r995
+  JumpIfFalse  r1040, L49
 L49:
-  Move         r573, r549
-  JumpIfFalse  r573, L50
+  Move         r1041, r999
+  JumpIfFalse  r1041, L50
 L50:
-  Move         r574, r551
-  JumpIfFalse  r574, L51
+  Move         r1042, r1003
+  JumpIfFalse  r1042, L51
 L51:
   // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Move         r575, r553
-  JumpIfFalse  r575, L52
+  Move         r1043, r1007
+  JumpIfFalse  r1043, L52
 L52:
-  Move         r576, r555
-  JumpIfFalse  r576, L53
+  Move         r1044, r1011
+  JumpIfFalse  r1044, L53
 L53:
-  Move         r577, r557
-  JumpIfFalse  r577, L54
+  Move         r1045, r1015
+  JumpIfFalse  r1045, L54
 L54:
   // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Move         r578, r560
-  JumpIfFalse  r578, L55
+  Move         r1046, r1019
+  JumpIfFalse  r1046, L55
 L55:
-  Move         r579, r563
-  JumpIfFalse  r579, L56
+  Move         r1047, r1023
+  JumpIfFalse  r1047, L56
 L56:
   // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Move         r580, r565
-  JumpIfFalse  r580, L57
+  Move         r1048, r1027
+  JumpIfFalse  r1048, L57
 L57:
-  Move         r581, r567
-  JumpIfFalse  r581, L58
+  Move         r1049, r1031
+  JumpIfFalse  r1049, L58
 L58:
   // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Move         r582, r569
-  JumpIfFalse  r582, L59
+  Move         r1050, r1035
+  JumpIfFalse  r1050, L59
 L59:
-  Move         r583, r571
-  JumpIfFalse  r583, L60
+  Move         r1051, r1039
+  JumpIfFalse  r1051, L60
 L60:
   // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Move         r584, r512
-  JumpIfFalse  r584, L61
+  Move         r1052, r939
+  JumpIfFalse  r1052, L61
 L61:
-  Move         r585, r514
-  JumpIfFalse  r585, L62
+  Move         r1053, r943
+  JumpIfFalse  r1053, L62
 L62:
-  Move         r586, r516
-  JumpIfFalse  r586, L63
+  Move         r1054, r947
+  JumpIfFalse  r1054, L63
 L63:
   // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Move         r587, r531
-  JumpIfFalse  r587, L64
-  Move         r587, r546
+  Move         r1055, r970
+  JumpIfFalse  r1055, L64
+  Move         r1055, r993
 L64:
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  JumpIfFalse  r587, L42
+  JumpIfFalse  r1055, L40
   // customer_id: s2.customer_id,
-  Move         r588, r16
-  Index        r589, r470, r16
+  Const        r1056, "customer_id"
+  Const        r1057, "customer_id"
+  Index        r1058, r716, r1057
   // customer_first_name: s2.customer_first_name,
-  Move         r590, r18
-  Index        r591, r470, r18
+  Const        r1059, "customer_first_name"
+  Const        r1060, "customer_first_name"
+  Index        r1061, r716, r1060
   // customer_last_name: s2.customer_last_name,
-  Move         r592, r19
-  Index        r593, r470, r19
+  Const        r1062, "customer_last_name"
+  Const        r1063, "customer_last_name"
+  Index        r1064, r716, r1063
   // customer_login: s2.customer_login,
-  Move         r594, r20
-  Index        r595, r470, r20
+  Const        r1065, "customer_login"
+  Const        r1066, "customer_login"
+  Index        r1067, r716, r1066
   // customer_id: s2.customer_id,
-  Move         r596, r588
-  Move         r597, r589
+  Move         r1068, r1056
+  Move         r1069, r1058
   // customer_first_name: s2.customer_first_name,
-  Move         r598, r590
-  Move         r599, r591
+  Move         r1070, r1059
+  Move         r1071, r1061
   // customer_last_name: s2.customer_last_name,
-  Move         r600, r592
-  Move         r601, r593
+  Move         r1072, r1062
+  Move         r1073, r1064
   // customer_login: s2.customer_login,
-  Move         r602, r594
-  Move         r603, r595
+  Move         r1074, r1065
+  Move         r1075, r1067
   // select {
-  MakeMap      r604, 4, r596
+  MakeMap      r1076, 4, r1068
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Index        r606, r470, r16
-  Index        r607, r470, r18
-  Move         r608, r607
-  Index        r609, r470, r19
-  MakeList     r614, 4, r606
+  Const        r1077, "customer_id"
+  Index        r1079, r716, r1077
+  Const        r1080, "customer_first_name"
+  Index        r1081, r716, r1080
+  Move         r1082, r1081
+  MakeList     r1090, 4, r1079
   // from s1 in year_total
-  Move         r615, r604
-  MakeList     r616, 2, r614
-  Append       r458, r458, r616
-L42:
-  // join w2 in year_total on w2.customer_id == s1.customer_id
-  Add          r503, r503, r114
-  Jump         L65
-L41:
-  // join w1 in year_total on w1.customer_id == s1.customer_id
-  Add          r494, r494, r114
-  Jump         L66
+  Move         r1091, r1076
+  MakeList     r1092, 2, r1090
+  Append       r622, r622, r1092
 L40:
-  // join c2 in year_total on c2.customer_id == s1.customer_id
-  Add          r485, r485, r114
-  Jump         L67
+  // join w2 in year_total on w2.customer_id == s1.customer_id
+  Const        r1094, 1
+  Add          r924, r924, r1094
+  Jump         L65
 L39:
-  // join c1 in year_total on c1.customer_id == s1.customer_id
-  Add          r476, r476, r114
-  Jump         L68
+  // join w1 in year_total on w1.customer_id == s1.customer_id
+  Const        r1095, 1
+  Add          r871, r871, r1095
+  Jump         L66
 L38:
-  // join s2 in year_total on s2.customer_id == s1.customer_id
-  Add          r467, r467, r114
-  Jump         L69
+  // join c2 in year_total on c2.customer_id == s1.customer_id
+  Const        r1096, 1
+  Add          r818, r818, r1096
+  Jump         L67
 L37:
-  // from s1 in year_total
-  AddInt       r461, r461, r114
-  Jump         L70
+  // join c1 in year_total on c1.customer_id == s1.customer_id
+  Const        r1097, 1
+  Add          r765, r765, r1097
+  Jump         L68
 L36:
+  // join s2 in year_total on s2.customer_id == s1.customer_id
+  Const        r1098, 1
+  Add          r712, r712, r1098
+  Jump         L69
+L35:
+  // from s1 in year_total
+  Const        r1099, 1
+  AddInt       r664, r664, r1099
+  Jump         L70
+L34:
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Sort         r458, r458
+  Sort         r622, r622
   // json(result)
-  JSON         r458
-  // expect result == []
-  Equal        r620, r458, r0
-  Expect       r620
+  JSON         r622
+  // expect len(result) == 0
+  Len          r1101, r622
+  Const        r1102, 0
+  EqualInt     r1103, r1101, r1102
+  Expect       r1103
   Return       r0

--- a/tests/dataset/tpc-ds/out/q5.ir.out
+++ b/tests/dataset/tpc-ds/out/q5.ir.out
@@ -1,1378 +1,1465 @@
-func main (regs=896)
+func main (regs=1189)
   // let store_sales = []
   Const        r0, []
   // let store_returns = []
-  Move         r1, r0
+  Const        r1, []
   // let store = []
-  Move         r2, r0
+  Const        r2, []
   // let catalog_sales = []
-  Move         r3, r2
+  Const        r3, []
   // let catalog_returns = []
-  Move         r4, r0
+  Const        r4, []
   // let catalog_page = []
-  Move         r5, r4
+  Const        r5, []
   // let web_sales = []
-  Move         r6, r4
+  Const        r6, []
   // let web_returns = []
-  Move         r7, r6
+  Const        r7, []
   // let web_site = []
-  Move         r8, r0
+  Const        r8, []
   // let date_dim = []
-  Move         r9, r8
+  Const        r9, []
   // from ss in store_sales
-  Move         r10, r8
-  // group by s.s_store_id into g
-  Const        r11, "s_store_id"
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r12, "d_date"
-  // channel: "store channel",
-  Const        r13, "channel"
-  // id: "store" + str(g.key),
-  Const        r14, "id"
-  Const        r15, "key"
-  // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r16, "sales"
-  Const        r17, "ss"
-  Const        r18, "ss_ext_sales_price"
-  // returns: 0.0,
-  Const        r19, "returns"
-  // profit: sum(from x in g select x.ss.ss_net_profit),
-  Const        r20, "profit"
-  Const        r21, "ss_net_profit"
-  // profit_loss: 0.0
-  Const        r22, "profit_loss"
-  // from ss in store_sales
-  MakeMap      r23, 0, r0
-  Move         r24, r10
-  IterPrep     r26, r0
-  Len          r27, r26
-  Const        r28, 0
+  Const        r10, []
+  MakeMap      r25, 0, r0
+  Const        r26, []
+  IterPrep     r28, r0
+  Len          r29, r28
+  Const        r30, 0
 L1:
-  LessInt      r29, r28, r27
-  JumpIfFalse  r29, L0
-  Index        r31, r26, r28
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L0
+  Index        r33, r28, r30
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r32, r9
-  Len          r33, r32
-  Move         r34, r28
+  IterPrep     r34, r9
+  Len          r35, r34
+  Const        r36, 0
 L2:
-  LessInt      r35, r34, r33
-  JumpIfFalse  r35, L1
-  Index        r37, r32, r34
-  Const        r38, "ss_sold_date_sk"
-  Index        r39, r31, r38
-  Const        r40, "d_date_sk"
-  Index        r41, r37, r40
-  Equal        r42, r39, r41
-  JumpIfFalse  r42, L2
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L1
+  Index        r39, r34, r36
+  Const        r40, "ss_sold_date_sk"
+  Index        r41, r33, r40
+  Const        r42, "d_date_sk"
+  Index        r43, r39, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L2
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  IterPrep     r43, r2
-  Len          r44, r43
-  Move         r45, r28
+  IterPrep     r45, r2
+  Len          r46, r45
+  Const        r47, 0
 L6:
-  LessInt      r46, r45, r44
-  JumpIfFalse  r46, L2
-  Index        r48, r43, r45
-  Const        r49, "ss_store_sk"
-  Index        r50, r31, r49
-  Const        r51, "s_store_sk"
-  Index        r52, r48, r51
-  Equal        r53, r50, r52
-  JumpIfFalse  r53, L3
+  LessInt      r48, r47, r46
+  JumpIfFalse  r48, L2
+  Index        r50, r45, r47
+  Const        r51, "ss_store_sk"
+  Index        r52, r33, r51
+  Const        r53, "s_store_sk"
+  Index        r54, r50, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L3
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r54, r37, r12
-  Const        r55, "1998-12-01"
-  LessEq       r56, r55, r54
-  Index        r57, r37, r12
-  Const        r58, "1998-12-15"
-  LessEq       r59, r57, r58
-  Move         r60, r56
-  JumpIfFalse  r60, L4
-  Move         r60, r59
+  Const        r56, "d_date"
+  Index        r57, r39, r56
+  Const        r58, "1998-12-01"
+  LessEq       r59, r58, r57
+  Const        r60, "d_date"
+  Index        r61, r39, r60
+  Const        r62, "1998-12-15"
+  LessEq       r63, r61, r62
+  Move         r64, r59
+  JumpIfFalse  r64, L4
+  Move         r64, r63
 L4:
-  JumpIfFalse  r60, L3
+  JumpIfFalse  r64, L3
   // from ss in store_sales
-  Move         r61, r17
-  Move         r62, r31
-  Const        r63, "d"
-  Move         r64, r37
-  Const        r65, "s"
-  Move         r66, r48
-  MakeMap      r67, 3, r61
+  Const        r65, "ss"
+  Move         r66, r33
+  Const        r67, "d"
+  Move         r68, r39
+  Const        r69, "s"
+  Move         r70, r50
+  MakeMap      r71, 3, r65
   // group by s.s_store_id into g
-  Index        r68, r48, r11
-  Str          r69, r68
-  In           r70, r69, r23
-  JumpIfTrue   r70, L5
+  Const        r72, "s_store_id"
+  Index        r73, r50, r72
+  Str          r74, r73
+  In           r75, r74, r25
+  JumpIfTrue   r75, L5
   // from ss in store_sales
-  Move         r71, r8
-  Const        r72, "__group__"
-  Const        r73, true
-  Move         r74, r15
+  Const        r76, []
+  Const        r77, "__group__"
+  Const        r78, true
+  Const        r79, "key"
   // group by s.s_store_id into g
-  Move         r75, r68
+  Move         r80, r73
   // from ss in store_sales
-  Const        r76, "items"
-  Move         r77, r71
-  Const        r78, "count"
-  Move         r79, r45
-  Move         r80, r72
-  Move         r81, r73
-  Move         r82, r74
-  Move         r83, r75
-  Move         r84, r76
+  Const        r81, "items"
+  Move         r82, r76
+  Const        r83, "count"
+  Const        r84, 0
   Move         r85, r77
   Move         r86, r78
   Move         r87, r79
-  MakeMap      r88, 4, r80
-  SetIndex     r23, r69, r88
-  Append       r24, r24, r88
+  Move         r88, r80
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  Move         r92, r84
+  MakeMap      r93, 4, r85
+  SetIndex     r25, r74, r93
+  Append       r26, r26, r93
 L5:
-  Move         r90, r76
-  Index        r91, r23, r69
-  Index        r92, r91, r90
-  Append       r93, r92, r67
-  SetIndex     r91, r90, r93
-  Move         r94, r78
-  Index        r95, r91, r94
-  Const        r96, 1
-  AddInt       r97, r95, r96
-  SetIndex     r91, r94, r97
+  Const        r95, "items"
+  Index        r96, r25, r74
+  Index        r97, r96, r95
+  Append       r98, r97, r71
+  SetIndex     r96, r95, r98
+  Const        r99, "count"
+  Index        r100, r96, r99
+  Const        r101, 1
+  AddInt       r102, r100, r101
+  SetIndex     r96, r99, r102
 L3:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r45, r45, r96
+  Const        r103, 1
+  AddInt       r47, r47, r103
   Jump         L6
 L0:
   // from ss in store_sales
-  Move         r99, r28
-  Move         r98, r99
-  Len          r100, r24
+  Const        r106, 0
+  Len          r108, r26
 L12:
-  LessInt      r101, r98, r100
-  JumpIfFalse  r101, L7
-  Index        r103, r24, r98
+  LessInt      r109, r106, r108
+  JumpIfFalse  r109, L7
+  Index        r111, r26, r106
   // channel: "store channel",
-  Move         r104, r13
-  Const        r105, "store channel"
+  Const        r112, "channel"
+  Const        r113, "store channel"
   // id: "store" + str(g.key),
-  Move         r106, r14
-  Const        r107, "store"
-  Index        r108, r103, r15
-  Str          r109, r108
-  Add          r110, r107, r109
+  Const        r114, "id"
+  Const        r115, "store"
+  Const        r116, "key"
+  Index        r117, r111, r116
+  Str          r118, r117
+  Add          r119, r115, r118
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Move         r111, r16
-  Move         r112, r71
-  IterPrep     r113, r103
-  Len          r114, r113
-  Move         r115, r99
+  Const        r120, "sales"
+  Const        r121, []
+  IterPrep     r124, r111
+  Len          r125, r124
+  Const        r126, 0
 L9:
-  LessInt      r116, r115, r114
-  JumpIfFalse  r116, L8
-  Index        r118, r113, r115
-  Index        r119, r118, r17
-  Index        r120, r119, r18
-  Append       r112, r112, r120
-  AddInt       r115, r115, r96
+  LessInt      r128, r126, r125
+  JumpIfFalse  r128, L8
+  Index        r130, r124, r126
+  Const        r131, "ss"
+  Index        r132, r130, r131
+  Const        r133, "ss_ext_sales_price"
+  Index        r134, r132, r133
+  Append       r121, r121, r134
+  Const        r136, 1
+  AddInt       r126, r126, r136
   Jump         L9
 L8:
-  Sum          r122, r112
+  Sum          r137, r121
   // returns: 0.0,
-  Move         r123, r19
-  Move         r124, r99
+  Const        r138, "returns"
+  Const        r139, 0
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Move         r125, r20
-  Move         r126, r71
-  IterPrep     r127, r103
-  Len          r128, r127
-  Move         r129, r99
+  Const        r140, "profit"
+  IterPrep     r144, r111
+  Len          r145, r144
+  Const        r146, 0
 L11:
-  LessInt      r130, r129, r128
-  JumpIfFalse  r130, L10
-  Index        r118, r127, r129
-  Index        r132, r118, r17
-  Index        r133, r132, r21
-  Append       r126, r126, r133
-  AddInt       r129, r129, r96
+  LessInt      r148, r146, r145
+  JumpIfFalse  r148, L10
+  Const        r155, 1
+  AddInt       r146, r146, r155
   Jump         L11
 L10:
-  Sum          r135, r126
+  Const        r156, 0
   // profit_loss: 0.0
-  Move         r136, r22
+  Const        r157, "profit_loss"
+  Const        r158, 0
   // channel: "store channel",
-  Move         r137, r104
-  Move         r138, r105
+  Move         r159, r112
+  Move         r160, r113
   // id: "store" + str(g.key),
-  Move         r139, r106
-  Move         r140, r110
+  Move         r161, r114
+  Move         r162, r119
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Move         r141, r111
-  Move         r142, r122
+  Move         r163, r120
+  Move         r164, r137
   // returns: 0.0,
-  Move         r143, r123
-  Move         r144, r124
+  Move         r165, r138
+  Move         r166, r139
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Move         r145, r125
-  Move         r146, r135
+  Move         r167, r140
+  Move         r168, r156
   // profit_loss: 0.0
-  Move         r147, r136
-  Move         r148, r124
+  Move         r169, r157
+  Move         r170, r158
   // select {
-  MakeMap      r149, 6, r137
+  MakeMap      r171, 6, r159
   // from ss in store_sales
-  Append       r10, r10, r149
-  AddInt       r98, r98, r96
+  Append       r10, r10, r171
   Jump         L12
 L7:
   // from sr in store_returns
-  Move         r151, r0
-  // returns: sum(from x in g select x.sr.sr_return_amt),
-  Const        r152, "sr"
-  Const        r153, "sr_return_amt"
-  // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Const        r154, "sr_net_loss"
-  // from sr in store_returns
-  MakeMap      r155, 0, r0
-  Move         r156, r151
-  IterPrep     r158, r1
-  Len          r159, r158
-  Move         r160, r99
+  Const        r174, []
+  MakeMap      r189, 0, r0
+  Const        r190, []
+  IterPrep     r192, r1
+  Len          r193, r192
+  Const        r194, 0
 L21:
-  LessInt      r161, r160, r159
-  JumpIfFalse  r161, L13
-  Index        r163, r158, r160
+  LessInt      r195, r194, r193
+  JumpIfFalse  r195, L13
+  Index        r197, r192, r194
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  IterPrep     r164, r9
-  Len          r165, r164
-  Move         r166, r160
+  IterPrep     r198, r9
+  Len          r199, r198
+  Const        r200, 0
 L20:
-  LessInt      r167, r166, r165
-  JumpIfFalse  r167, L14
-  Index        r169, r164, r166
-  Const        r170, "sr_returned_date_sk"
-  Index        r171, r163, r170
-  Index        r172, r169, r40
-  Equal        r173, r171, r172
-  JumpIfFalse  r173, L15
+  LessInt      r201, r200, r199
+  JumpIfFalse  r201, L14
+  Index        r203, r198, r200
+  Const        r204, "sr_returned_date_sk"
+  Index        r205, r197, r204
+  Const        r206, "d_date_sk"
+  Index        r207, r203, r206
+  Equal        r208, r205, r207
+  JumpIfFalse  r208, L15
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  IterPrep     r174, r2
-  Len          r175, r174
-  Move         r176, r28
+  IterPrep     r209, r2
+  Len          r210, r209
+  Const        r211, 0
 L19:
-  LessInt      r177, r176, r175
-  JumpIfFalse  r177, L15
-  Index        r179, r174, r176
-  Const        r180, "sr_store_sk"
-  Index        r181, r163, r180
-  Index        r182, r179, r51
-  Equal        r183, r181, r182
-  JumpIfFalse  r183, L16
+  LessInt      r212, r211, r210
+  JumpIfFalse  r212, L15
+  Index        r214, r209, r211
+  Const        r215, "sr_store_sk"
+  Index        r216, r197, r215
+  Const        r217, "s_store_sk"
+  Index        r218, r214, r217
+  Equal        r219, r216, r218
+  JumpIfFalse  r219, L16
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r184, r169, r12
-  LessEq       r185, r55, r184
-  Index        r186, r169, r12
-  LessEq       r187, r186, r58
-  Move         r188, r185
-  JumpIfFalse  r188, L17
-  Move         r188, r187
+  Const        r220, "d_date"
+  Index        r221, r203, r220
+  Const        r222, "1998-12-01"
+  LessEq       r223, r222, r221
+  Const        r224, "d_date"
+  Index        r225, r203, r224
+  Const        r226, "1998-12-15"
+  LessEq       r227, r225, r226
+  Move         r228, r223
+  JumpIfFalse  r228, L17
+  Move         r228, r227
 L17:
-  JumpIfFalse  r188, L16
+  JumpIfFalse  r228, L16
   // from sr in store_returns
-  Move         r189, r152
-  Move         r190, r163
-  Move         r191, r63
-  Move         r192, r169
-  Move         r193, r65
-  Move         r194, r179
-  MakeMap      r195, 3, r189
+  Const        r229, "sr"
+  Move         r230, r197
+  Const        r231, "d"
+  Move         r232, r203
+  Const        r233, "s"
+  Move         r234, r214
+  MakeMap      r235, 3, r229
   // group by s.s_store_id into g
-  Index        r196, r179, r11
-  Str          r197, r196
-  In           r198, r197, r155
-  JumpIfTrue   r198, L18
+  Const        r236, "s_store_id"
+  Index        r237, r214, r236
+  Str          r238, r237
+  In           r239, r238, r189
+  JumpIfTrue   r239, L18
   // from sr in store_returns
-  Move         r199, r151
-  Move         r200, r72
-  Move         r201, r73
-  Move         r202, r15
+  Const        r240, []
+  Const        r241, "__group__"
+  Const        r242, true
+  Const        r243, "key"
   // group by s.s_store_id into g
-  Move         r203, r196
+  Move         r244, r237
   // from sr in store_returns
-  Move         r204, r76
-  Move         r205, r199
-  Move         r206, r78
-  Move         r207, r176
-  Move         r208, r200
-  Move         r209, r201
-  Move         r210, r202
-  Move         r211, r203
-  Move         r212, r204
-  Move         r213, r205
-  Move         r214, r206
-  Move         r215, r207
-  MakeMap      r216, 4, r208
-  SetIndex     r155, r197, r216
-  Append       r156, r156, r216
+  Const        r245, "items"
+  Move         r246, r240
+  Const        r247, "count"
+  Const        r248, 0
+  Move         r249, r241
+  Move         r250, r242
+  Move         r251, r243
+  Move         r252, r244
+  Move         r253, r245
+  Move         r254, r246
+  Move         r255, r247
+  Move         r256, r248
+  MakeMap      r257, 4, r249
+  SetIndex     r189, r238, r257
+  Append       r190, r190, r257
 L18:
-  Index        r218, r155, r197
-  Index        r219, r218, r90
-  Append       r220, r219, r195
-  SetIndex     r218, r90, r220
-  Index        r221, r218, r94
-  AddInt       r222, r221, r96
-  SetIndex     r218, r94, r222
+  Const        r259, "items"
+  Index        r260, r189, r238
+  Index        r261, r260, r259
+  Append       r262, r261, r235
+  SetIndex     r260, r259, r262
+  Const        r263, "count"
+  Index        r264, r260, r263
+  Const        r265, 1
+  AddInt       r266, r264, r265
+  SetIndex     r260, r263, r266
 L16:
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  AddInt       r176, r176, r96
+  Const        r267, 1
+  AddInt       r211, r211, r267
   Jump         L19
 L15:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  AddInt       r166, r166, r96
+  Const        r268, 1
+  AddInt       r200, r200, r268
   Jump         L20
 L14:
   // from sr in store_returns
-  AddInt       r160, r160, r96
+  Const        r269, 1
+  AddInt       r194, r194, r269
   Jump         L21
 L13:
-  Move         r223, r99
-  Len          r224, r156
+  Const        r270, 0
+  Len          r272, r190
 L27:
-  LessInt      r225, r223, r224
-  JumpIfFalse  r225, L22
-  Index        r103, r156, r223
+  LessInt      r273, r270, r272
+  JumpIfFalse  r273, L22
+  Index        r111, r190, r270
   // channel: "store channel",
-  Move         r227, r13
+  Const        r275, "channel"
+  Const        r276, "store channel"
   // id: "store" + str(g.key),
-  Move         r228, r14
-  Index        r229, r103, r15
-  Str          r230, r229
-  Add          r231, r107, r230
+  Const        r277, "id"
+  Const        r278, "store"
+  Const        r279, "key"
+  Index        r280, r111, r279
+  Str          r281, r280
+  Add          r282, r278, r281
   // sales: 0.0,
-  Move         r232, r16
+  Const        r283, "sales"
+  Const        r284, 0
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Move         r233, r19
-  Move         r234, r199
-  IterPrep     r235, r103
-  Len          r236, r235
-  Move         r237, r99
+  Const        r285, "returns"
+  Const        r286, []
+  IterPrep     r289, r111
+  Len          r290, r289
+  Const        r291, 0
 L24:
-  LessInt      r238, r237, r236
-  JumpIfFalse  r238, L23
-  Index        r118, r235, r237
-  Index        r240, r118, r152
-  Index        r241, r240, r153
-  Append       r234, r234, r241
-  AddInt       r237, r237, r96
+  LessInt      r293, r291, r290
+  JumpIfFalse  r293, L23
+  Index        r130, r289, r291
+  Const        r295, "sr"
+  Index        r296, r130, r295
+  Const        r297, "sr_return_amt"
+  Index        r298, r296, r297
+  Append       r286, r286, r298
+  Const        r300, 1
+  AddInt       r291, r291, r300
   Jump         L24
 L23:
-  Sum          r243, r234
+  Sum          r301, r286
   // profit: 0.0,
-  Move         r244, r20
+  Const        r302, "profit"
+  Const        r303, 0
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Move         r245, r22
-  Move         r246, r151
-  IterPrep     r247, r103
-  Len          r248, r247
-  Move         r249, r99
+  Const        r304, "profit_loss"
+  Const        r305, []
+  IterPrep     r308, r111
+  Len          r309, r308
+  Const        r310, 0
 L26:
-  LessInt      r250, r249, r248
-  JumpIfFalse  r250, L25
-  Index        r118, r247, r249
-  Index        r252, r118, r152
-  Index        r253, r252, r154
-  Append       r246, r246, r253
-  AddInt       r249, r249, r96
+  LessInt      r312, r310, r309
+  JumpIfFalse  r312, L25
+  Index        r130, r308, r310
+  Const        r314, "sr"
+  Index        r315, r130, r314
+  Const        r316, "sr_net_loss"
+  Index        r317, r315, r316
+  Append       r305, r305, r317
+  Const        r319, 1
+  AddInt       r310, r310, r319
   Jump         L26
 L25:
-  Sum          r255, r246
+  Sum          r320, r305
   // channel: "store channel",
-  Move         r256, r227
-  Move         r257, r105
+  Move         r321, r275
+  Move         r322, r276
   // id: "store" + str(g.key),
-  Move         r258, r228
-  Move         r259, r231
+  Move         r323, r277
+  Move         r324, r282
   // sales: 0.0,
-  Move         r260, r232
-  Move         r261, r124
+  Move         r325, r283
+  Move         r326, r284
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Move         r262, r233
-  Move         r263, r243
+  Move         r327, r285
+  Move         r328, r301
   // profit: 0.0,
-  Move         r264, r244
-  Move         r265, r124
+  Move         r329, r302
+  Move         r330, r303
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Move         r266, r245
-  Move         r267, r255
+  Move         r331, r304
+  Move         r332, r320
   // select {
-  MakeMap      r268, 6, r256
+  MakeMap      r333, 6, r321
   // from sr in store_returns
-  Append       r151, r151, r268
-  AddInt       r223, r223, r96
+  Append       r174, r174, r333
   Jump         L27
 L22:
   // from cs in catalog_sales
-  Move         r270, r0
-  // group by cp.cp_catalog_page_id into g
-  Const        r271, "cp_catalog_page_id"
-  // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Const        r272, "cs"
-  Const        r273, "cs_ext_sales_price"
-  // profit: sum(from x in g select x.cs.cs_net_profit),
-  Const        r274, "cs_net_profit"
-  // from cs in catalog_sales
-  MakeMap      r275, 0, r0
-  Move         r276, r270
-  IterPrep     r278, r3
-  Len          r279, r278
-  Move         r280, r28
+  Const        r336, []
+  MakeMap      r351, 0, r0
+  Const        r352, []
+  IterPrep     r354, r3
+  Len          r355, r354
+  Const        r356, 0
 L36:
-  LessInt      r281, r280, r279
-  JumpIfFalse  r281, L28
-  Index        r283, r278, r280
+  LessInt      r357, r356, r355
+  JumpIfFalse  r357, L28
+  Index        r359, r354, r356
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r284, r9
-  Len          r285, r284
-  Move         r286, r280
+  IterPrep     r360, r9
+  Len          r361, r360
+  Const        r362, 0
 L35:
-  LessInt      r287, r286, r285
-  JumpIfFalse  r287, L29
-  Index        r289, r284, r286
-  Const        r290, "cs_sold_date_sk"
-  Index        r291, r283, r290
-  Index        r292, r289, r40
-  Equal        r293, r291, r292
-  JumpIfFalse  r293, L30
+  LessInt      r363, r362, r361
+  JumpIfFalse  r363, L29
+  Index        r365, r360, r362
+  Const        r366, "cs_sold_date_sk"
+  Index        r367, r359, r366
+  Const        r368, "d_date_sk"
+  Index        r369, r365, r368
+  Equal        r370, r367, r369
+  JumpIfFalse  r370, L30
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r294, r5
-  Len          r295, r294
-  Move         r296, r280
+  IterPrep     r371, r5
+  Len          r372, r371
+  Const        r373, 0
 L34:
-  LessInt      r297, r296, r295
-  JumpIfFalse  r297, L30
-  Index        r299, r294, r296
-  Const        r300, "cs_catalog_page_sk"
-  Index        r301, r283, r300
-  Const        r302, "cp_catalog_page_sk"
-  Index        r303, r299, r302
-  Equal        r304, r301, r303
-  JumpIfFalse  r304, L31
+  LessInt      r374, r373, r372
+  JumpIfFalse  r374, L30
+  Index        r376, r371, r373
+  Const        r377, "cs_catalog_page_sk"
+  Index        r378, r359, r377
+  Const        r379, "cp_catalog_page_sk"
+  Index        r380, r376, r379
+  Equal        r381, r378, r380
+  JumpIfFalse  r381, L31
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r305, r289, r12
-  LessEq       r306, r55, r305
-  Index        r307, r289, r12
-  LessEq       r308, r307, r58
-  Move         r309, r306
-  JumpIfFalse  r309, L32
-  Move         r309, r308
+  Const        r382, "d_date"
+  Index        r383, r365, r382
+  Const        r384, "1998-12-01"
+  LessEq       r385, r384, r383
+  Const        r386, "d_date"
+  Index        r387, r365, r386
+  Const        r388, "1998-12-15"
+  LessEq       r389, r387, r388
+  Move         r390, r385
+  JumpIfFalse  r390, L32
+  Move         r390, r389
 L32:
-  JumpIfFalse  r309, L31
+  JumpIfFalse  r390, L31
   // from cs in catalog_sales
-  Move         r310, r272
-  Move         r311, r283
-  Move         r312, r63
-  Move         r313, r289
-  Const        r314, "cp"
-  Move         r315, r299
-  MakeMap      r316, 3, r310
+  Const        r391, "cs"
+  Move         r392, r359
+  Const        r393, "d"
+  Move         r394, r365
+  Const        r395, "cp"
+  Move         r396, r376
+  MakeMap      r397, 3, r391
   // group by cp.cp_catalog_page_id into g
-  Index        r317, r299, r271
-  Str          r318, r317
-  In           r319, r318, r275
-  JumpIfTrue   r319, L33
+  Const        r398, "cp_catalog_page_id"
+  Index        r399, r376, r398
+  Str          r400, r399
+  In           r401, r400, r351
+  JumpIfTrue   r401, L33
   // from cs in catalog_sales
-  Move         r320, r270
-  Move         r321, r72
-  Move         r322, r73
-  Move         r323, r202
+  Const        r402, []
+  Const        r403, "__group__"
+  Const        r404, true
+  Const        r405, "key"
   // group by cp.cp_catalog_page_id into g
-  Move         r324, r317
+  Move         r406, r399
   // from cs in catalog_sales
-  Move         r325, r204
-  Move         r326, r320
-  Move         r327, r206
-  Move         r328, r296
-  Move         r329, r321
-  Move         r330, r322
-  Move         r331, r323
-  Move         r332, r324
-  Move         r333, r325
-  Move         r334, r326
-  Move         r335, r327
-  Move         r336, r328
-  MakeMap      r337, 4, r329
-  SetIndex     r275, r318, r337
-  Append       r276, r276, r337
+  Const        r407, "items"
+  Move         r408, r402
+  Const        r409, "count"
+  Const        r410, 0
+  Move         r411, r403
+  Move         r412, r404
+  Move         r413, r405
+  Move         r414, r406
+  Move         r415, r407
+  Move         r416, r408
+  Move         r417, r409
+  Move         r418, r410
+  MakeMap      r419, 4, r411
+  SetIndex     r351, r400, r419
+  Append       r352, r352, r419
 L33:
-  Index        r339, r275, r318
-  Index        r340, r339, r90
-  Append       r341, r340, r316
-  SetIndex     r339, r90, r341
-  Index        r342, r339, r94
-  AddInt       r343, r342, r96
-  SetIndex     r339, r94, r343
+  Const        r421, "items"
+  Index        r422, r351, r400
+  Index        r423, r422, r421
+  Append       r424, r423, r397
+  SetIndex     r422, r421, r424
+  Const        r425, "count"
+  Index        r426, r422, r425
+  Const        r427, 1
+  AddInt       r428, r426, r427
+  SetIndex     r422, r425, r428
 L31:
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  AddInt       r296, r296, r96
+  Const        r429, 1
+  AddInt       r373, r373, r429
   Jump         L34
 L30:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r286, r286, r96
+  Const        r430, 1
+  AddInt       r362, r362, r430
   Jump         L35
 L29:
   // from cs in catalog_sales
-  AddInt       r280, r280, r96
+  Const        r431, 1
+  AddInt       r356, r356, r431
   Jump         L36
 L28:
-  Move         r344, r99
-  Len          r345, r276
+  Const        r432, 0
+  Len          r434, r352
 L42:
-  LessInt      r346, r344, r345
-  JumpIfFalse  r346, L37
-  Index        r103, r276, r344
+  LessInt      r435, r432, r434
+  JumpIfFalse  r435, L37
+  Index        r111, r352, r432
   // channel: "catalog channel",
-  Move         r348, r227
-  Const        r349, "catalog channel"
+  Const        r437, "channel"
+  Const        r438, "catalog channel"
   // id: "catalog_page" + str(g.key),
-  Move         r350, r228
-  Const        r351, "catalog_page"
-  Index        r352, r103, r15
-  Str          r353, r352
-  Add          r354, r351, r353
+  Const        r439, "id"
+  Const        r440, "catalog_page"
+  Const        r441, "key"
+  Index        r442, r111, r441
+  Str          r443, r442
+  Add          r444, r440, r443
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Move         r355, r232
-  Move         r356, r320
-  IterPrep     r357, r103
-  Len          r358, r357
-  Move         r359, r99
+  Const        r445, "sales"
+  Const        r446, []
+  IterPrep     r449, r111
+  Len          r450, r449
+  Const        r451, 0
 L39:
-  LessInt      r360, r359, r358
-  JumpIfFalse  r360, L38
-  Index        r118, r357, r359
-  Index        r362, r118, r272
-  Index        r363, r362, r273
-  Append       r356, r356, r363
-  AddInt       r359, r359, r96
+  LessInt      r453, r451, r450
+  JumpIfFalse  r453, L38
+  Index        r130, r449, r451
+  Const        r455, "cs"
+  Index        r456, r130, r455
+  Const        r457, "cs_ext_sales_price"
+  Index        r458, r456, r457
+  Append       r446, r446, r458
+  Const        r460, 1
+  AddInt       r451, r451, r460
   Jump         L39
 L38:
-  Sum          r365, r356
+  Sum          r461, r446
   // returns: 0.0,
-  Move         r366, r233
+  Const        r462, "returns"
+  Const        r463, 0
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Move         r367, r244
-  Move         r368, r270
-  IterPrep     r369, r103
-  Len          r370, r369
-  Move         r371, r99
+  Const        r464, "profit"
+  Const        r465, []
+  IterPrep     r468, r111
+  Len          r469, r468
+  Const        r470, 0
 L41:
-  LessInt      r372, r371, r370
-  JumpIfFalse  r372, L40
-  Index        r118, r369, r371
-  Index        r374, r118, r272
-  Index        r375, r374, r274
-  Append       r368, r368, r375
-  AddInt       r371, r371, r96
+  LessInt      r472, r470, r469
+  JumpIfFalse  r472, L40
+  Index        r130, r468, r470
+  Const        r474, "cs"
+  Index        r475, r130, r474
+  Const        r476, "cs_net_profit"
+  Index        r477, r475, r476
+  Append       r465, r465, r477
+  Const        r479, 1
+  AddInt       r470, r470, r479
   Jump         L41
 L40:
-  Sum          r377, r368
+  Sum          r480, r465
   // profit_loss: 0.0
-  Move         r378, r245
+  Const        r481, "profit_loss"
+  Const        r482, 0
   // channel: "catalog channel",
-  Move         r379, r348
-  Move         r380, r349
+  Move         r483, r437
+  Move         r484, r438
   // id: "catalog_page" + str(g.key),
-  Move         r381, r350
-  Move         r382, r354
+  Move         r485, r439
+  Move         r486, r444
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Move         r383, r355
-  Move         r384, r365
+  Move         r487, r445
+  Move         r488, r461
   // returns: 0.0,
-  Move         r385, r366
-  Move         r386, r124
+  Move         r489, r462
+  Move         r490, r463
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Move         r387, r367
-  Move         r388, r377
+  Move         r491, r464
+  Move         r492, r480
   // profit_loss: 0.0
-  Move         r389, r378
-  Move         r390, r124
+  Move         r493, r481
+  Move         r494, r482
   // select {
-  MakeMap      r391, 6, r379
+  MakeMap      r495, 6, r483
   // from cs in catalog_sales
-  Append       r270, r270, r391
-  AddInt       r344, r344, r96
+  Append       r336, r336, r495
+  Const        r497, 1
+  AddInt       r432, r432, r497
   Jump         L42
 L37:
   // from cr in catalog_returns
-  Move         r393, r0
-  // returns: sum(from x in g select x.cr.cr_return_amount),
-  Const        r394, "cr"
-  Const        r395, "cr_return_amount"
-  // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Const        r396, "cr_net_loss"
-  // from cr in catalog_returns
-  MakeMap      r397, 0, r0
-  Move         r398, r393
-  IterPrep     r400, r4
-  Len          r401, r400
-  Move         r402, r28
+  Const        r498, []
+  MakeMap      r513, 0, r0
+  Const        r514, []
+  IterPrep     r516, r4
+  Len          r517, r516
+  Const        r518, 0
 L51:
-  LessInt      r403, r402, r401
-  JumpIfFalse  r403, L43
-  Index        r405, r400, r402
+  LessInt      r519, r518, r517
+  JumpIfFalse  r519, L43
+  Index        r521, r516, r518
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  IterPrep     r406, r9
-  Len          r407, r406
-  Move         r408, r402
+  IterPrep     r522, r9
+  Len          r523, r522
+  Const        r524, 0
 L50:
-  LessInt      r409, r408, r407
-  JumpIfFalse  r409, L44
-  Index        r411, r406, r408
-  Const        r412, "cr_returned_date_sk"
-  Index        r413, r405, r412
-  Index        r414, r411, r40
-  Equal        r415, r413, r414
-  JumpIfFalse  r415, L45
+  LessInt      r525, r524, r523
+  JumpIfFalse  r525, L44
+  Index        r527, r522, r524
+  Const        r528, "cr_returned_date_sk"
+  Index        r529, r521, r528
+  Const        r530, "d_date_sk"
+  Index        r531, r527, r530
+  Equal        r532, r529, r531
+  JumpIfFalse  r532, L45
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r416, r5
-  Len          r417, r416
-  Move         r418, r402
+  IterPrep     r533, r5
+  Len          r534, r533
+  Const        r535, 0
 L49:
-  LessInt      r419, r418, r417
-  JumpIfFalse  r419, L45
-  Index        r421, r416, r418
-  Const        r422, "cr_catalog_page_sk"
-  Index        r423, r405, r422
-  Index        r424, r421, r302
-  Equal        r425, r423, r424
-  JumpIfFalse  r425, L46
+  LessInt      r536, r535, r534
+  JumpIfFalse  r536, L45
+  Index        r538, r533, r535
+  Const        r539, "cr_catalog_page_sk"
+  Index        r540, r521, r539
+  Const        r541, "cp_catalog_page_sk"
+  Index        r542, r538, r541
+  Equal        r543, r540, r542
+  JumpIfFalse  r543, L46
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r426, r411, r12
-  LessEq       r427, r55, r426
-  Index        r428, r411, r12
-  LessEq       r429, r428, r58
-  Move         r430, r427
-  JumpIfFalse  r430, L47
-  Move         r430, r429
+  Const        r544, "d_date"
+  Index        r545, r527, r544
+  Const        r546, "1998-12-01"
+  LessEq       r547, r546, r545
+  Const        r548, "d_date"
+  Index        r549, r527, r548
+  Const        r550, "1998-12-15"
+  LessEq       r551, r549, r550
+  Move         r552, r547
+  JumpIfFalse  r552, L47
+  Move         r552, r551
 L47:
-  JumpIfFalse  r430, L46
+  JumpIfFalse  r552, L46
   // from cr in catalog_returns
-  Move         r431, r394
-  Move         r432, r405
-  Move         r433, r312
-  Move         r434, r411
-  Move         r435, r314
-  Move         r436, r421
-  MakeMap      r437, 3, r431
+  Const        r553, "cr"
+  Move         r554, r521
+  Const        r555, "d"
+  Move         r556, r527
+  Const        r557, "cp"
+  Move         r558, r538
+  MakeMap      r559, 3, r553
   // group by cp.cp_catalog_page_id into g
-  Index        r438, r421, r271
-  Str          r439, r438
-  In           r440, r439, r397
-  JumpIfTrue   r440, L48
+  Const        r560, "cp_catalog_page_id"
+  Index        r561, r538, r560
+  Str          r562, r561
+  In           r563, r562, r513
+  JumpIfTrue   r563, L48
   // from cr in catalog_returns
-  Move         r441, r393
-  Move         r442, r321
-  Move         r443, r322
-  Move         r444, r15
+  Const        r564, []
+  Const        r565, "__group__"
+  Const        r566, true
+  Const        r567, "key"
   // group by cp.cp_catalog_page_id into g
-  Move         r445, r438
+  Move         r568, r561
   // from cr in catalog_returns
-  Move         r446, r76
-  Move         r447, r441
-  Move         r448, r78
-  Move         r449, r418
-  Move         r450, r442
-  Move         r451, r443
-  Move         r452, r444
-  Move         r453, r445
-  Move         r454, r446
-  Move         r455, r447
-  Move         r456, r448
-  Move         r457, r449
-  MakeMap      r458, 4, r450
-  SetIndex     r397, r439, r458
-  Append       r398, r398, r458
-L48:
-  Index        r460, r397, r439
-  Index        r461, r460, r90
-  Append       r462, r461, r437
-  SetIndex     r460, r90, r462
-  Index        r463, r460, r94
-  AddInt       r464, r463, r96
-  SetIndex     r460, r94, r464
-L46:
-  // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  AddInt       r418, r418, r96
-  Jump         L49
-L45:
-  // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  AddInt       r408, r408, r96
-  Jump         L50
-L44:
-  // from cr in catalog_returns
-  AddInt       r402, r402, r96
-  Jump         L51
-L43:
-  Move         r465, r99
-  Len          r466, r398
-L57:
-  LessInt      r467, r465, r466
-  JumpIfFalse  r467, L52
-  Index        r103, r398, r465
-  // channel: "catalog channel",
-  Move         r469, r13
-  // id: "catalog_page" + str(g.key),
-  Move         r470, r14
-  Index        r471, r103, r15
-  Str          r472, r471
-  Add          r473, r351, r472
-  // sales: 0.0,
-  Move         r474, r16
-  // returns: sum(from x in g select x.cr.cr_return_amount),
-  Move         r475, r19
-  Move         r476, r441
-  IterPrep     r477, r103
-  Len          r478, r477
-  Move         r479, r99
-L54:
-  LessInt      r480, r479, r478
-  JumpIfFalse  r480, L53
-  Index        r118, r477, r479
-  Index        r482, r118, r394
-  Index        r483, r482, r395
-  Append       r476, r476, r483
-  AddInt       r479, r479, r96
-  Jump         L54
-L53:
-  Sum          r485, r476
-  // profit: 0.0,
-  Move         r486, r20
-  // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Move         r487, r22
-  Move         r488, r393
-  IterPrep     r489, r103
-  Len          r490, r489
-  Move         r491, r99
-L56:
-  LessInt      r492, r491, r490
-  JumpIfFalse  r492, L55
-  Index        r118, r489, r491
-  Index        r494, r118, r394
-  Index        r495, r494, r396
-  Append       r488, r488, r495
-  AddInt       r491, r491, r96
-  Jump         L56
-L55:
-  Sum          r497, r488
-  // channel: "catalog channel",
-  Move         r498, r469
-  Move         r499, r349
-  // id: "catalog_page" + str(g.key),
-  Move         r500, r470
-  Move         r501, r473
-  // sales: 0.0,
-  Move         r502, r474
-  Move         r503, r124
-  // returns: sum(from x in g select x.cr.cr_return_amount),
-  Move         r504, r475
-  Move         r505, r485
-  // profit: 0.0,
-  Move         r506, r486
-  Move         r507, r124
-  // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Move         r508, r487
-  Move         r509, r497
-  // select {
-  MakeMap      r510, 6, r498
-  // from cr in catalog_returns
-  Append       r393, r393, r510
-  AddInt       r465, r465, r96
-  Jump         L57
-L52:
-  // from ws in web_sales
-  Move         r512, r0
-  // group by w.web_site_id into g
-  Const        r513, "web_site_id"
-  // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Const        r514, "ws"
-  Const        r515, "ws_ext_sales_price"
-  // profit: sum(from x in g select x.ws.ws_net_profit),
-  Const        r516, "ws_net_profit"
-  // from ws in web_sales
-  MakeMap      r517, 0, r0
-  Move         r518, r512
-  IterPrep     r520, r6
-  Len          r521, r520
-  Move         r522, r28
-L66:
-  LessInt      r523, r522, r521
-  JumpIfFalse  r523, L58
-  Index        r525, r520, r522
-  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r526, r9
-  Len          r527, r526
-  Move         r528, r522
-L65:
-  LessInt      r529, r528, r527
-  JumpIfFalse  r529, L59
-  Index        r531, r526, r528
-  Const        r532, "ws_sold_date_sk"
-  Index        r533, r525, r532
-  Index        r534, r531, r40
-  Equal        r535, r533, r534
-  JumpIfFalse  r535, L60
-  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r536, r8
-  Len          r537, r536
-  Move         r538, r522
-L64:
-  LessInt      r539, r538, r537
-  JumpIfFalse  r539, L60
-  Index        r541, r536, r538
-  Const        r542, "ws_web_site_sk"
-  Index        r543, r525, r542
-  Const        r544, "web_site_sk"
-  Index        r545, r541, r544
-  Equal        r546, r543, r545
-  JumpIfFalse  r546, L61
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r547, r531, r12
-  LessEq       r548, r55, r547
-  Index        r549, r531, r12
-  LessEq       r550, r549, r58
-  Move         r551, r548
-  JumpIfFalse  r551, L62
-  Move         r551, r550
-L62:
-  JumpIfFalse  r551, L61
-  // from ws in web_sales
-  Move         r552, r514
-  Move         r553, r525
-  Move         r554, r63
-  Move         r555, r531
-  Const        r556, "w"
-  Move         r557, r541
-  MakeMap      r558, 3, r552
-  // group by w.web_site_id into g
-  Index        r559, r541, r513
-  Str          r560, r559
-  In           r561, r560, r517
-  JumpIfTrue   r561, L63
-  // from ws in web_sales
-  Move         r562, r512
-  Move         r563, r72
-  Move         r564, r73
-  Move         r565, r444
-  // group by w.web_site_id into g
-  Move         r566, r559
-  // from ws in web_sales
-  Move         r567, r446
-  Move         r568, r562
-  Move         r569, r448
-  Move         r570, r538
-  Move         r571, r563
-  Move         r572, r564
+  Const        r569, "items"
+  Move         r570, r564
+  Const        r571, "count"
+  Const        r572, 0
   Move         r573, r565
   Move         r574, r566
   Move         r575, r567
   Move         r576, r568
   Move         r577, r569
   Move         r578, r570
-  MakeMap      r579, 4, r571
-  SetIndex     r517, r560, r579
-  Append       r518, r518, r579
+  Move         r579, r571
+  Move         r580, r572
+  MakeMap      r581, 4, r573
+  SetIndex     r513, r562, r581
+  Append       r514, r514, r581
+L48:
+  Const        r583, "items"
+  Index        r584, r513, r562
+  Index        r585, r584, r583
+  Append       r586, r585, r559
+  SetIndex     r584, r583, r586
+  Const        r587, "count"
+  Index        r588, r584, r587
+  Const        r589, 1
+  AddInt       r590, r588, r589
+  SetIndex     r584, r587, r590
+L46:
+  // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
+  Const        r591, 1
+  AddInt       r535, r535, r591
+  Jump         L49
+L45:
+  // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
+  Const        r592, 1
+  AddInt       r524, r524, r592
+  Jump         L50
+L44:
+  // from cr in catalog_returns
+  Const        r593, 1
+  AddInt       r518, r518, r593
+  Jump         L51
+L43:
+  Const        r594, 0
+  Len          r596, r514
+L57:
+  LessInt      r597, r594, r596
+  JumpIfFalse  r597, L52
+  Index        r111, r514, r594
+  // channel: "catalog channel",
+  Const        r599, "channel"
+  Const        r600, "catalog channel"
+  // id: "catalog_page" + str(g.key),
+  Const        r601, "id"
+  Const        r602, "catalog_page"
+  Const        r603, "key"
+  Index        r604, r111, r603
+  Str          r605, r604
+  Add          r606, r602, r605
+  // sales: 0.0,
+  Const        r607, "sales"
+  Const        r608, 0
+  // returns: sum(from x in g select x.cr.cr_return_amount),
+  Const        r609, "returns"
+  Const        r610, []
+  IterPrep     r613, r111
+  Len          r614, r613
+  Const        r615, 0
+L54:
+  LessInt      r617, r615, r614
+  JumpIfFalse  r617, L53
+  Index        r130, r613, r615
+  Const        r619, "cr"
+  Index        r620, r130, r619
+  Const        r621, "cr_return_amount"
+  Index        r622, r620, r621
+  Append       r610, r610, r622
+  Const        r624, 1
+  AddInt       r615, r615, r624
+  Jump         L54
+L53:
+  Sum          r625, r610
+  // profit: 0.0,
+  Const        r626, "profit"
+  Const        r627, 0
+  // profit_loss: sum(from x in g select x.cr.cr_net_loss)
+  Const        r628, "profit_loss"
+  Const        r629, []
+  IterPrep     r632, r111
+  Len          r633, r632
+  Const        r634, 0
+L56:
+  LessInt      r636, r634, r633
+  JumpIfFalse  r636, L55
+  Index        r130, r632, r634
+  Const        r638, "cr"
+  Index        r639, r130, r638
+  Const        r640, "cr_net_loss"
+  Index        r641, r639, r640
+  Append       r629, r629, r641
+  Const        r643, 1
+  AddInt       r634, r634, r643
+  Jump         L56
+L55:
+  Sum          r644, r629
+  // channel: "catalog channel",
+  Move         r645, r599
+  Move         r646, r600
+  // id: "catalog_page" + str(g.key),
+  Move         r647, r601
+  Move         r648, r606
+  // sales: 0.0,
+  Move         r649, r607
+  Move         r650, r608
+  // returns: sum(from x in g select x.cr.cr_return_amount),
+  Move         r651, r609
+  Move         r652, r625
+  // profit: 0.0,
+  Move         r653, r626
+  Move         r654, r627
+  // profit_loss: sum(from x in g select x.cr.cr_net_loss)
+  Move         r655, r628
+  Move         r656, r644
+  // select {
+  MakeMap      r657, 6, r645
+  // from cr in catalog_returns
+  Append       r498, r498, r657
+  Const        r659, 1
+  AddInt       r594, r594, r659
+  Jump         L57
+L52:
+  // from ws in web_sales
+  Const        r660, []
+  MakeMap      r675, 0, r0
+  Const        r676, []
+  IterPrep     r678, r6
+  Len          r679, r678
+  Const        r680, 0
+L66:
+  LessInt      r681, r680, r679
+  JumpIfFalse  r681, L58
+  Index        r683, r678, r680
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  IterPrep     r684, r9
+  Len          r685, r684
+  Const        r686, 0
+L65:
+  LessInt      r687, r686, r685
+  JumpIfFalse  r687, L59
+  Index        r689, r684, r686
+  Const        r690, "ws_sold_date_sk"
+  Index        r691, r683, r690
+  Const        r692, "d_date_sk"
+  Index        r693, r689, r692
+  Equal        r694, r691, r693
+  JumpIfFalse  r694, L60
+  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  IterPrep     r695, r8
+  Len          r696, r695
+  Const        r697, 0
+L64:
+  LessInt      r698, r697, r696
+  JumpIfFalse  r698, L60
+  Index        r700, r695, r697
+  Const        r701, "ws_web_site_sk"
+  Index        r702, r683, r701
+  Const        r703, "web_site_sk"
+  Index        r704, r700, r703
+  Equal        r705, r702, r704
+  JumpIfFalse  r705, L61
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Const        r706, "d_date"
+  Index        r707, r689, r706
+  Const        r708, "1998-12-01"
+  LessEq       r709, r708, r707
+  Const        r710, "d_date"
+  Index        r711, r689, r710
+  Const        r712, "1998-12-15"
+  LessEq       r713, r711, r712
+  Move         r714, r709
+  JumpIfFalse  r714, L62
+  Move         r714, r713
+L62:
+  JumpIfFalse  r714, L61
+  // from ws in web_sales
+  Const        r715, "ws"
+  Move         r716, r683
+  Const        r717, "d"
+  Move         r718, r689
+  Const        r719, "w"
+  Move         r720, r700
+  MakeMap      r721, 3, r715
+  // group by w.web_site_id into g
+  Const        r722, "web_site_id"
+  Index        r723, r700, r722
+  Str          r724, r723
+  In           r725, r724, r675
+  JumpIfTrue   r725, L63
+  // from ws in web_sales
+  Const        r726, []
+  Const        r727, "__group__"
+  Const        r728, true
+  Const        r729, "key"
+  // group by w.web_site_id into g
+  Move         r730, r723
+  // from ws in web_sales
+  Const        r731, "items"
+  Move         r732, r726
+  Const        r733, "count"
+  Const        r734, 0
+  Move         r735, r727
+  Move         r736, r728
+  Move         r737, r729
+  Move         r738, r730
+  Move         r739, r731
+  Move         r740, r732
+  Move         r741, r733
+  Move         r742, r734
+  MakeMap      r743, 4, r735
+  SetIndex     r675, r724, r743
+  Append       r676, r676, r743
 L63:
-  Index        r581, r517, r560
-  Index        r582, r581, r90
-  Append       r583, r582, r558
-  SetIndex     r581, r90, r583
-  Index        r584, r581, r94
-  AddInt       r585, r584, r96
-  SetIndex     r581, r94, r585
+  Const        r745, "items"
+  Index        r746, r675, r724
+  Index        r747, r746, r745
+  Append       r748, r747, r721
+  SetIndex     r746, r745, r748
+  Const        r749, "count"
+  Index        r750, r746, r749
+  Const        r751, 1
+  AddInt       r752, r750, r751
+  SetIndex     r746, r749, r752
 L61:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  AddInt       r538, r538, r96
+  Const        r753, 1
+  AddInt       r697, r697, r753
   Jump         L64
 L60:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  AddInt       r528, r528, r96
+  Const        r754, 1
+  AddInt       r686, r686, r754
   Jump         L65
 L59:
   // from ws in web_sales
-  AddInt       r522, r522, r96
+  Const        r755, 1
+  AddInt       r680, r680, r755
   Jump         L66
 L58:
-  Move         r586, r99
-  Len          r587, r518
+  Const        r756, 0
+  Len          r758, r676
 L72:
-  LessInt      r588, r586, r587
-  JumpIfFalse  r588, L67
-  Index        r103, r518, r586
+  LessInt      r759, r756, r758
+  JumpIfFalse  r759, L67
+  Index        r111, r676, r756
   // channel: "web channel",
-  Move         r590, r469
-  Const        r591, "web channel"
+  Const        r761, "channel"
+  Const        r762, "web channel"
   // id: "web_site" + str(g.key),
-  Move         r592, r470
-  Const        r593, "web_site"
-  Index        r594, r103, r15
-  Str          r595, r594
-  Add          r596, r593, r595
+  Const        r763, "id"
+  Const        r764, "web_site"
+  Const        r765, "key"
+  Index        r766, r111, r765
+  Str          r767, r766
+  Add          r768, r764, r767
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Move         r597, r474
-  Move         r598, r562
-  IterPrep     r599, r103
-  Len          r600, r599
-  Move         r601, r99
+  Const        r769, "sales"
+  Const        r770, []
+  IterPrep     r773, r111
+  Len          r774, r773
+  Const        r775, 0
 L69:
-  LessInt      r602, r601, r600
-  JumpIfFalse  r602, L68
-  Index        r118, r599, r601
-  Index        r604, r118, r514
-  Index        r605, r604, r515
-  Append       r598, r598, r605
-  AddInt       r601, r601, r96
+  LessInt      r777, r775, r774
+  JumpIfFalse  r777, L68
+  Index        r130, r773, r775
+  Const        r779, "ws"
+  Index        r780, r130, r779
+  Const        r781, "ws_ext_sales_price"
+  Index        r782, r780, r781
+  Append       r770, r770, r782
+  Const        r784, 1
+  AddInt       r775, r775, r784
   Jump         L69
 L68:
-  Sum          r607, r598
+  Sum          r785, r770
   // returns: 0.0,
-  Move         r608, r475
+  Const        r786, "returns"
+  Const        r787, 0
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Move         r609, r486
-  Move         r610, r512
-  IterPrep     r611, r103
-  Len          r612, r611
-  Move         r613, r99
+  Const        r788, "profit"
+  Const        r789, []
+  IterPrep     r792, r111
+  Len          r793, r792
+  Const        r794, 0
 L71:
-  LessInt      r614, r613, r612
-  JumpIfFalse  r614, L70
-  Index        r118, r611, r613
-  Index        r616, r118, r514
-  Index        r617, r616, r516
-  Append       r610, r610, r617
-  AddInt       r613, r613, r96
+  LessInt      r796, r794, r793
+  JumpIfFalse  r796, L70
+  Index        r130, r792, r794
+  Const        r798, "ws"
+  Index        r799, r130, r798
+  Const        r800, "ws_net_profit"
+  Index        r801, r799, r800
+  Append       r789, r789, r801
+  Const        r803, 1
+  AddInt       r794, r794, r803
   Jump         L71
 L70:
-  Sum          r619, r610
+  Sum          r804, r789
   // profit_loss: 0.0
-  Move         r620, r487
+  Const        r805, "profit_loss"
+  Const        r806, 0
   // channel: "web channel",
-  Move         r621, r590
-  Move         r622, r591
+  Move         r807, r761
+  Move         r808, r762
   // id: "web_site" + str(g.key),
-  Move         r623, r592
-  Move         r624, r596
+  Move         r809, r763
+  Move         r810, r768
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Move         r625, r597
-  Move         r626, r607
+  Move         r811, r769
+  Move         r812, r785
   // returns: 0.0,
-  Move         r627, r608
-  Move         r628, r124
+  Move         r813, r786
+  Move         r814, r787
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Move         r629, r609
-  Move         r630, r619
+  Move         r815, r788
+  Move         r816, r804
   // profit_loss: 0.0
-  Move         r631, r620
-  Move         r632, r124
+  Move         r817, r805
+  Move         r818, r806
   // select {
-  MakeMap      r633, 6, r621
+  MakeMap      r819, 6, r807
   // from ws in web_sales
-  Append       r512, r512, r633
-  AddInt       r586, r586, r96
+  Append       r660, r660, r819
+  Const        r821, 1
+  AddInt       r756, r756, r821
   Jump         L72
 L67:
   // from wr in web_returns
-  Move         r635, r0
-  // returns: sum(from x in g select x.wr.wr_return_amt),
-  Const        r636, "wr"
-  Const        r637, "wr_return_amt"
-  // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Const        r638, "wr_net_loss"
-  // from wr in web_returns
-  MakeMap      r639, 0, r0
-  Move         r640, r635
-  IterPrep     r642, r7
-  Len          r643, r642
-  Move         r644, r28
+  Const        r822, []
+  MakeMap      r837, 0, r0
+  Const        r838, []
+  IterPrep     r840, r7
+  Len          r841, r840
+  Const        r842, 0
 L84:
-  LessInt      r645, r644, r643
-  JumpIfFalse  r645, L73
-  Index        r647, r642, r644
+  LessInt      r843, r842, r841
+  JumpIfFalse  r843, L73
+  Index        r845, r840, r842
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  IterPrep     r648, r6
-  Len          r649, r648
-  Move         r650, r644
+  IterPrep     r846, r6
+  Len          r847, r846
+  Const        r848, 0
 L83:
-  LessInt      r651, r650, r649
-  JumpIfFalse  r651, L74
-  Index        r512, r648, r650
-  Const        r653, "wr_item_sk"
-  Index        r654, r647, r653
-  Const        r655, "ws_item_sk"
-  Index        r656, r512, r655
-  Equal        r657, r654, r656
-  Const        r658, "wr_order_number"
-  Index        r659, r647, r658
-  Const        r660, "ws_order_number"
-  Index        r661, r512, r660
-  Equal        r662, r659, r661
-  Move         r663, r657
-  JumpIfFalse  r663, L75
-  Move         r663, r662
+  LessInt      r849, r848, r847
+  JumpIfFalse  r849, L74
+  Index        r660, r846, r848
+  Const        r851, "wr_item_sk"
+  Index        r852, r845, r851
+  Const        r853, "ws_item_sk"
+  Index        r854, r660, r853
+  Equal        r855, r852, r854
+  Const        r856, "wr_order_number"
+  Index        r857, r845, r856
+  Const        r858, "ws_order_number"
+  Index        r859, r660, r858
+  Equal        r860, r857, r859
+  Move         r861, r855
+  JumpIfFalse  r861, L75
+  Move         r861, r860
 L75:
-  JumpIfFalse  r663, L76
+  JumpIfFalse  r861, L76
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  IterPrep     r664, r9
-  Len          r665, r664
-  Move         r666, r644
+  IterPrep     r862, r9
+  Len          r863, r862
+  Const        r864, 0
 L82:
-  LessInt      r667, r666, r665
-  JumpIfFalse  r667, L76
-  Index        r669, r664, r666
-  Const        r670, "wr_returned_date_sk"
-  Index        r671, r647, r670
-  Index        r672, r669, r40
-  Equal        r673, r671, r672
-  JumpIfFalse  r673, L77
+  LessInt      r865, r864, r863
+  JumpIfFalse  r865, L76
+  Index        r867, r862, r864
+  Const        r868, "wr_returned_date_sk"
+  Index        r869, r845, r868
+  Const        r870, "d_date_sk"
+  Index        r871, r867, r870
+  Equal        r872, r869, r871
+  JumpIfFalse  r872, L77
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r674, r8
-  Len          r675, r674
-  Move         r676, r666
+  IterPrep     r873, r8
+  Len          r874, r873
+  Const        r875, 0
 L81:
-  LessInt      r677, r676, r675
-  JumpIfFalse  r677, L77
-  Index        r679, r674, r676
-  Index        r680, r512, r542
-  Index        r681, r679, r544
-  Equal        r682, r680, r681
-  JumpIfFalse  r682, L78
+  LessInt      r876, r875, r874
+  JumpIfFalse  r876, L77
+  Index        r878, r873, r875
+  Const        r879, "ws_web_site_sk"
+  Index        r880, r660, r879
+  Const        r881, "web_site_sk"
+  Index        r882, r878, r881
+  Equal        r883, r880, r882
+  JumpIfFalse  r883, L78
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r683, r669, r12
-  LessEq       r684, r55, r683
-  Index        r685, r669, r12
-  LessEq       r686, r685, r58
-  Move         r687, r684
-  JumpIfFalse  r687, L79
-  Move         r687, r686
+  Const        r884, "d_date"
+  Index        r885, r867, r884
+  Const        r886, "1998-12-01"
+  LessEq       r887, r886, r885
+  Const        r888, "d_date"
+  Index        r889, r867, r888
+  Const        r890, "1998-12-15"
+  LessEq       r891, r889, r890
+  Move         r892, r887
+  JumpIfFalse  r892, L79
+  Move         r892, r891
 L79:
-  JumpIfFalse  r687, L78
+  JumpIfFalse  r892, L78
   // from wr in web_returns
-  Move         r688, r636
-  Move         r689, r647
-  Move         r690, r514
-  Move         r691, r512
-  Move         r692, r554
-  Move         r693, r669
-  Move         r694, r556
-  Move         r695, r679
-  MakeMap      r696, 4, r688
+  Const        r893, "wr"
+  Move         r894, r845
+  Const        r895, "ws"
+  Move         r896, r660
+  Const        r897, "d"
+  Move         r898, r867
+  Const        r899, "w"
+  Move         r900, r878
+  MakeMap      r901, 4, r893
   // group by w.web_site_id into g
-  Index        r697, r679, r513
-  Str          r698, r697
-  In           r699, r698, r639
-  JumpIfTrue   r699, L80
+  Const        r902, "web_site_id"
+  Index        r903, r878, r902
+  Str          r904, r903
+  In           r905, r904, r837
+  JumpIfTrue   r905, L80
   // from wr in web_returns
-  Move         r700, r635
-  Move         r701, r563
-  Move         r702, r564
-  Move         r703, r444
+  Const        r906, []
+  Const        r907, "__group__"
+  Const        r908, true
+  Const        r909, "key"
   // group by w.web_site_id into g
-  Move         r704, r697
+  Move         r910, r903
   // from wr in web_returns
-  Move         r705, r446
-  Move         r706, r700
-  Move         r707, r448
-  Move         r708, r644
-  Move         r709, r701
-  Move         r710, r702
-  Move         r711, r703
-  Move         r712, r704
-  Move         r713, r705
-  Move         r714, r706
-  Move         r715, r707
-  Move         r716, r708
-  MakeMap      r717, 4, r709
-  SetIndex     r639, r698, r717
-  Append       r640, r640, r717
+  Const        r911, "items"
+  Move         r912, r906
+  Const        r913, "count"
+  Const        r914, 0
+  Move         r915, r907
+  Move         r916, r908
+  Move         r917, r909
+  Move         r918, r910
+  Move         r919, r911
+  Move         r920, r912
+  Move         r921, r913
+  Move         r922, r914
+  MakeMap      r923, 4, r915
+  SetIndex     r837, r904, r923
+  Append       r838, r838, r923
 L80:
-  Index        r719, r639, r698
-  Index        r720, r719, r90
-  Append       r721, r720, r696
-  SetIndex     r719, r90, r721
-  Index        r722, r719, r94
-  AddInt       r723, r722, r96
-  SetIndex     r719, r94, r723
+  Const        r925, "items"
+  Index        r926, r837, r904
+  Index        r927, r926, r925
+  Append       r928, r927, r901
+  SetIndex     r926, r925, r928
+  Const        r929, "count"
+  Index        r930, r926, r929
+  Const        r931, 1
+  AddInt       r932, r930, r931
+  SetIndex     r926, r929, r932
 L78:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  AddInt       r676, r676, r96
+  Const        r933, 1
+  AddInt       r875, r875, r933
   Jump         L81
 L77:
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  AddInt       r666, r666, r96
+  Const        r934, 1
+  AddInt       r864, r864, r934
   Jump         L82
 L76:
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  AddInt       r650, r650, r96
+  Const        r935, 1
+  AddInt       r848, r848, r935
   Jump         L83
 L74:
   // from wr in web_returns
-  AddInt       r644, r644, r96
+  Const        r936, 1
+  AddInt       r842, r842, r936
   Jump         L84
 L73:
-  Move         r724, r99
-  Len          r725, r640
+  Const        r937, 0
+  Len          r939, r838
 L90:
-  LessInt      r726, r724, r725
-  JumpIfFalse  r726, L85
-  Index        r103, r640, r724
+  LessInt      r940, r937, r939
+  JumpIfFalse  r940, L85
+  Index        r111, r838, r937
   // channel: "web channel",
-  Move         r728, r469
+  Const        r942, "channel"
+  Const        r943, "web channel"
   // id: "web_site" + str(g.key),
-  Move         r729, r470
-  Index        r730, r103, r15
-  Str          r731, r730
-  Add          r732, r593, r731
+  Const        r944, "id"
+  Const        r945, "web_site"
+  Const        r946, "key"
+  Index        r947, r111, r946
+  Str          r948, r947
+  Add          r949, r945, r948
   // sales: 0.0,
-  Move         r733, r474
+  Const        r950, "sales"
+  Const        r951, 0
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Move         r734, r475
-  Move         r735, r700
-  IterPrep     r736, r103
-  Len          r737, r736
-  Move         r738, r99
+  Const        r952, "returns"
+  Const        r953, []
+  IterPrep     r956, r111
+  Len          r957, r956
+  Const        r958, 0
 L87:
-  LessInt      r739, r738, r737
-  JumpIfFalse  r739, L86
-  Index        r118, r736, r738
-  Index        r741, r118, r636
-  Index        r742, r741, r637
-  Append       r735, r735, r742
-  AddInt       r738, r738, r96
+  LessInt      r960, r958, r957
+  JumpIfFalse  r960, L86
+  Index        r130, r956, r958
+  Const        r962, "wr"
+  Index        r963, r130, r962
+  Const        r964, "wr_return_amt"
+  Index        r965, r963, r964
+  Append       r953, r953, r965
   Jump         L87
 L86:
-  Sum          r744, r735
+  Sum          r968, r953
   // profit: 0.0,
-  Move         r745, r486
+  Const        r969, "profit"
+  Const        r970, 0
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Move         r746, r487
-  Move         r747, r635
-  IterPrep     r748, r103
-  Len          r749, r748
-  Move         r750, r99
+  Const        r971, "profit_loss"
+  Const        r972, []
+  IterPrep     r975, r111
+  Len          r976, r975
+  Const        r977, 0
 L89:
-  LessInt      r751, r750, r749
-  JumpIfFalse  r751, L88
-  Index        r118, r748, r750
-  Index        r753, r118, r636
-  Index        r754, r753, r638
-  Append       r747, r747, r754
-  AddInt       r750, r750, r96
+  LessInt      r979, r977, r976
+  JumpIfFalse  r979, L88
+  Index        r130, r975, r977
+  Const        r981, "wr"
+  Index        r982, r130, r981
+  Const        r983, "wr_net_loss"
+  Index        r984, r982, r983
+  Append       r972, r972, r984
   Jump         L89
 L88:
-  Sum          r756, r747
+  Sum          r987, r972
   // channel: "web channel",
-  Move         r757, r728
-  Move         r758, r591
+  Move         r988, r942
+  Move         r989, r943
   // id: "web_site" + str(g.key),
-  Move         r759, r729
-  Move         r760, r732
+  Move         r990, r944
+  Move         r991, r949
   // sales: 0.0,
-  Move         r761, r733
-  Move         r762, r124
+  Move         r992, r950
+  Move         r993, r951
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Move         r763, r734
-  Move         r764, r744
+  Move         r994, r952
+  Move         r995, r968
   // profit: 0.0,
-  Move         r765, r745
-  Move         r766, r124
+  Move         r996, r969
+  Move         r997, r970
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Move         r767, r746
-  Move         r768, r756
+  Move         r998, r971
+  Move         r999, r987
   // select {
-  MakeMap      r769, 6, r757
+  MakeMap      r1000, 6, r988
   // from wr in web_returns
-  Append       r635, r635, r769
-  AddInt       r724, r724, r96
+  Append       r822, r822, r1000
+  Const        r1002, 1
+  AddInt       r937, r937, r1002
   Jump         L90
 L85:
   // let per_channel = concat(ss union all sr, cs union all cr, ws union all wr)
-  UnionAll     r771, r10, r151
-  UnionAll     r772, r270, r393
-  UnionAll     r773, r771, r772
-  UnionAll     r774, r512, r635
-  UnionAll     r775, r773, r774
+  UnionAll     r1003, r10, r174
+  UnionAll     r1004, r336, r498
+  UnionAll     r1005, r1003, r1004
+  UnionAll     r1006, r660, r822
+  UnionAll     r1007, r1005, r1006
   // from p in per_channel
-  Move         r776, r0
-  // sales: sum(from x in g select x.p.sales),
-  Const        r777, "p"
-  // from p in per_channel
-  IterPrep     r778, r775
-  Len          r779, r778
-  Move         r780, r708
-  MakeMap      r781, 0, r0
-  Move         r782, r776
+  Const        r1008, []
+  IterPrep     r1032, r1007
+  Len          r1033, r1032
+  Const        r1034, 0
+  MakeMap      r1035, 0, r0
+  Const        r1036, []
 L93:
-  LessInt      r784, r780, r779
-  JumpIfFalse  r784, L91
-  Index        r785, r778, r780
-  Move         r786, r785
+  LessInt      r1038, r1034, r1033
+  JumpIfFalse  r1038, L91
+  Index        r1039, r1032, r1034
+  Move         r1040, r1039
   // group by { channel: p.channel, id: p.id } into g
-  Move         r787, r728
-  Index        r788, r786, r13
-  Move         r789, r729
-  Index        r790, r786, r14
-  Move         r791, r787
-  Move         r792, r788
-  Move         r793, r789
-  Move         r794, r790
-  MakeMap      r795, 2, r791
-  Str          r796, r795
-  In           r797, r796, r781
-  JumpIfTrue   r797, L92
+  Const        r1041, "channel"
+  Const        r1042, "channel"
+  Index        r1043, r1040, r1042
+  Const        r1044, "id"
+  Const        r1045, "id"
+  Index        r1046, r1040, r1045
+  Move         r1047, r1041
+  Move         r1048, r1043
+  Move         r1049, r1044
+  Move         r1050, r1046
+  MakeMap      r1051, 2, r1047
+  Str          r1052, r1051
+  In           r1053, r1052, r1035
+  JumpIfTrue   r1053, L92
   // from p in per_channel
-  Move         r798, r776
-  Move         r799, r563
-  Move         r800, r564
-  Move         r801, r703
+  Const        r1054, []
+  Const        r1055, "__group__"
+  Const        r1056, true
+  Const        r1057, "key"
   // group by { channel: p.channel, id: p.id } into g
-  Move         r802, r795
+  Move         r1058, r1051
   // from p in per_channel
-  Move         r803, r705
-  Move         r804, r798
-  Move         r805, r707
-  Move         r806, r708
-  Move         r807, r799
-  Move         r808, r800
-  Move         r809, r801
-  Move         r810, r802
-  Move         r811, r803
-  Move         r812, r804
-  Move         r813, r805
-  Move         r814, r806
-  MakeMap      r815, 4, r807
-  SetIndex     r781, r796, r815
-  Append       r782, r782, r815
+  Const        r1059, "items"
+  Move         r1060, r1054
+  Const        r1061, "count"
+  Const        r1062, 0
+  Move         r1063, r1055
+  Move         r1064, r1056
+  Move         r1065, r1057
+  Move         r1066, r1058
+  Move         r1067, r1059
+  Move         r1068, r1060
+  Move         r1069, r1061
+  Move         r1070, r1062
+  MakeMap      r1071, 4, r1063
+  SetIndex     r1035, r1052, r1071
+  Append       r1036, r1036, r1071
 L92:
-  Index        r817, r781, r796
-  Index        r818, r817, r90
-  Append       r819, r818, r785
-  SetIndex     r817, r90, r819
-  Index        r820, r817, r94
-  AddInt       r821, r820, r96
-  SetIndex     r817, r94, r821
-  AddInt       r780, r780, r96
+  Const        r1073, "items"
+  Index        r1074, r1035, r1052
+  Index        r1075, r1074, r1073
+  Append       r1076, r1075, r1039
+  SetIndex     r1074, r1073, r1076
+  Const        r1077, "count"
+  Index        r1078, r1074, r1077
+  Const        r1079, 1
+  AddInt       r1080, r1078, r1079
+  SetIndex     r1074, r1077, r1080
+  Const        r1081, 1
+  AddInt       r1034, r1034, r1081
   Jump         L93
 L91:
-  Move         r822, r99
-  Len          r823, r782
+  Const        r1082, 0
+  Len          r1084, r1036
 L103:
-  LessInt      r824, r822, r823
-  JumpIfFalse  r824, L94
-  Index        r103, r782, r822
+  LessInt      r1085, r1082, r1084
+  JumpIfFalse  r1085, L94
+  Index        r111, r1036, r1082
   // channel: g.key.channel,
-  Move         r826, r13
-  Index        r827, r103, r15
-  Index        r828, r827, r13
+  Const        r1087, "channel"
+  Const        r1088, "key"
+  Index        r1089, r111, r1088
+  Const        r1090, "channel"
+  Index        r1091, r1089, r1090
   // id: g.key.id,
-  Move         r829, r14
-  Index        r830, r103, r15
-  Index        r831, r830, r14
+  Const        r1092, "id"
+  Const        r1093, "key"
+  Index        r1094, r111, r1093
+  Const        r1095, "id"
+  Index        r1096, r1094, r1095
   // sales: sum(from x in g select x.p.sales),
-  Move         r832, r733
-  Move         r833, r798
-  IterPrep     r834, r103
-  Len          r835, r834
-  Move         r836, r99
+  Const        r1097, "sales"
+  Const        r1098, []
+  IterPrep     r1101, r111
+  Len          r1102, r1101
+  Const        r1103, 0
 L96:
-  LessInt      r837, r836, r835
-  JumpIfFalse  r837, L95
-  Index        r118, r834, r836
-  Index        r839, r118, r777
-  Index        r840, r839, r16
-  Append       r833, r833, r840
-  AddInt       r836, r836, r96
+  LessInt      r1105, r1103, r1102
+  JumpIfFalse  r1105, L95
+  Index        r130, r1101, r1103
+  Const        r1107, "p"
+  Index        r1108, r130, r1107
+  Const        r1109, "sales"
+  Index        r1110, r1108, r1109
+  Append       r1098, r1098, r1110
+  Const        r1112, 1
+  AddInt       r1103, r1103, r1112
   Jump         L96
 L95:
-  Sum          r842, r833
+  Sum          r1113, r1098
   // returns: sum(from x in g select x.p.returns),
-  Move         r843, r734
-  Move         r844, r776
-  IterPrep     r845, r103
-  Len          r846, r845
-  Move         r847, r99
+  Const        r1114, "returns"
+  Const        r1115, []
+  IterPrep     r1118, r111
+  Len          r1119, r1118
+  Const        r1120, 0
 L98:
-  LessInt      r848, r847, r846
-  JumpIfFalse  r848, L97
-  Index        r118, r845, r847
-  Index        r850, r118, r777
-  Index        r851, r850, r19
-  Append       r844, r844, r851
-  AddInt       r847, r847, r96
+  LessInt      r1122, r1120, r1119
+  JumpIfFalse  r1122, L97
+  Index        r130, r1118, r1120
+  Const        r1124, "p"
+  Index        r1125, r130, r1124
+  Const        r1126, "returns"
+  Index        r1127, r1125, r1126
+  Append       r1115, r1115, r1127
+  Const        r1129, 1
+  AddInt       r1120, r1120, r1129
   Jump         L98
 L97:
-  Sum          r853, r844
+  Sum          r1130, r1115
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Move         r854, r745
-  Move         r855, r776
-  IterPrep     r856, r103
-  Len          r857, r856
-  Move         r858, r99
+  Const        r1131, "profit"
+  Const        r1132, []
+  IterPrep     r1135, r111
+  Len          r1136, r1135
+  Const        r1137, 0
 L100:
-  LessInt      r859, r858, r857
-  JumpIfFalse  r859, L99
-  Index        r118, r856, r858
-  Index        r861, r118, r777
-  Index        r862, r861, r20
-  Append       r855, r855, r862
-  AddInt       r858, r858, r96
+  LessInt      r1139, r1137, r1136
+  JumpIfFalse  r1139, L99
+  Index        r130, r1135, r1137
+  Const        r1141, "p"
+  Index        r1142, r130, r1141
+  Const        r1143, "profit"
+  Index        r1144, r1142, r1143
+  Append       r1132, r1132, r1144
+  Const        r1146, 1
+  AddInt       r1137, r1137, r1146
   Jump         L100
 L99:
-  Sum          r864, r855
-  Move         r865, r776
-  IterPrep     r866, r103
-  Len          r867, r866
-  Move         r868, r99
+  Sum          r1147, r1132
+  Const        r1148, []
+  IterPrep     r1151, r111
+  Len          r1152, r1151
+  Const        r1153, 0
 L102:
-  LessInt      r869, r868, r867
-  JumpIfFalse  r869, L101
-  Index        r118, r866, r868
-  Index        r871, r118, r777
-  Index        r872, r871, r22
-  Append       r865, r865, r872
-  AddInt       r868, r868, r96
+  LessInt      r1155, r1153, r1152
+  JumpIfFalse  r1155, L101
+  Index        r130, r1151, r1153
+  Const        r1157, "p"
+  Index        r1158, r130, r1157
+  Const        r1159, "profit_loss"
+  Index        r1160, r1158, r1159
+  Append       r1148, r1148, r1160
+  Const        r1162, 1
+  AddInt       r1153, r1153, r1162
   Jump         L102
 L101:
-  Sum          r874, r865
-  Sub          r875, r864, r874
+  Sum          r1163, r1148
+  Sub          r1164, r1147, r1163
   // channel: g.key.channel,
-  Move         r876, r826
-  Move         r877, r828
+  Move         r1165, r1087
+  Move         r1166, r1091
   // id: g.key.id,
-  Move         r878, r829
-  Move         r879, r831
+  Move         r1167, r1092
+  Move         r1168, r1096
   // sales: sum(from x in g select x.p.sales),
-  Move         r880, r832
-  Move         r881, r842
+  Move         r1169, r1097
+  Move         r1170, r1113
   // returns: sum(from x in g select x.p.returns),
-  Move         r882, r843
-  Move         r883, r853
+  Move         r1171, r1114
+  Move         r1172, r1130
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Move         r884, r854
-  Move         r885, r875
+  Move         r1173, r1131
+  Move         r1174, r1164
   // select {
-  MakeMap      r886, 5, r876
+  MakeMap      r1175, 5, r1165
   // sort by g.key.channel
-  Index        r887, r103, r15
-  Index        r889, r887, r13
+  Const        r1176, "key"
+  Index        r1177, r111, r1176
+  Const        r1178, "channel"
+  Index        r1180, r1177, r1178
   // from p in per_channel
-  Move         r890, r886
-  MakeList     r891, 2, r889
-  Append       r776, r776, r891
-  AddInt       r822, r822, r96
+  Move         r1181, r1175
+  MakeList     r1182, 2, r1180
+  Append       r1008, r1008, r1182
+  Const        r1184, 1
+  AddInt       r1082, r1082, r1184
   Jump         L103
 L94:
   // sort by g.key.channel
-  Sort         r776, r776
+  Sort         r1008, r1008
   // json(result)
-  JSON         r776
-  // expect result == []
-  Equal        r895, r776, r0
-  Expect       r895
+  JSON         r1008
+  // expect len(result) == 0
+  Len          r1186, r1008
+  Const        r1187, 0
+  EqualInt     r1188, r1186, r1187
+  Expect       r1188
   Return       r0

--- a/tests/dataset/tpc-ds/out/q6.ir.out
+++ b/tests/dataset/tpc-ds/out/q6.ir.out
@@ -1,282 +1,287 @@
-func main (regs=178)
+func main (regs=210)
   // let customer_address = []
   Const        r0, []
   // let customer = []
-  Move         r1, r0
+  Const        r1, []
   // let store_sales = []
-  Move         r2, r0
+  Const        r2, []
   // let date_dim = []
-  Move         r3, r2
+  Const        r3, []
   // let item = []
-  Move         r4, r0
+  Const        r4, []
   // from d in date_dim
-  Move         r5, r4
-  // where d.d_year == 1999 && d.d_moy == 5
-  Const        r6, "d_year"
-  Const        r7, "d_moy"
-  // select d.d_month_seq
-  Const        r8, "d_month_seq"
-  // from d in date_dim
+  Const        r5, []
   IterPrep     r9, r3
   Len          r10, r9
-  Const        r12, 0
-  Move         r11, r12
+  Const        r11, 0
 L3:
   LessInt      r13, r11, r10
   JumpIfFalse  r13, L0
   Index        r15, r9, r11
   // where d.d_year == 1999 && d.d_moy == 5
-  Index        r16, r15, r6
-  Const        r17, 1999
-  Equal        r18, r16, r17
-  Index        r19, r15, r7
-  Const        r20, 5
-  Equal        r21, r19, r20
-  Move         r22, r18
-  JumpIfFalse  r22, L1
-  Move         r22, r21
+  Const        r16, "d_year"
+  Index        r17, r15, r16
+  Const        r18, 1999
+  Equal        r19, r17, r18
+  Const        r20, "d_moy"
+  Index        r21, r15, r20
+  Const        r22, 5
+  Equal        r23, r21, r22
+  Move         r24, r19
+  JumpIfFalse  r24, L1
+  Move         r24, r23
 L1:
-  JumpIfFalse  r22, L2
+  JumpIfFalse  r24, L2
   // select d.d_month_seq
-  Index        r23, r15, r8
+  Const        r25, "d_month_seq"
+  Index        r26, r15, r25
   // from d in date_dim
-  Append       r5, r5, r23
+  Append       r5, r5, r26
 L2:
-  Const        r25, 1
-  AddInt       r11, r11, r25
+  Const        r28, 1
+  AddInt       r11, r11, r28
   Jump         L3
 L0:
   // let target_month_seq = max(
-  Max          r26, r5
+  Max          r29, r5
   // from a in customer_address
-  Move         r27, r4
-  // group by a.ca_state into g
-  Const        r28, "ca_state"
-  // i.i_current_price > 1.2 * avg(
-  Const        r29, "i_current_price"
-  // where j.i_category == i.i_category
-  Const        r30, "i_category"
-  // select { state: g.key, cnt: count(g) }
-  Const        r31, "state"
-  Const        r32, "key"
-  Const        r33, "cnt"
-  // from a in customer_address
-  MakeMap      r34, 0, r0
-  Move         r35, r27
-  IterPrep     r37, r0
-  Len          r38, r37
-  Move         r39, r12
+  Const        r30, []
+  MakeMap      r41, 0, r0
+  Const        r42, []
+  IterPrep     r44, r0
+  Len          r45, r44
+  Const        r46, 0
 L19:
-  LessInt      r40, r39, r38
-  JumpIfFalse  r40, L4
-  Index        r42, r37, r39
+  LessInt      r47, r46, r45
+  JumpIfFalse  r47, L4
+  Index        r49, r44, r46
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  IterPrep     r43, r1
-  Len          r44, r43
-  Move         r45, r12
+  IterPrep     r50, r1
+  Len          r51, r50
+  Const        r52, 0
 L18:
-  LessInt      r46, r45, r44
-  JumpIfFalse  r46, L5
-  Index        r48, r43, r45
-  Const        r49, "ca_address_sk"
-  Index        r50, r42, r49
-  Const        r51, "c_current_addr_sk"
-  Index        r52, r48, r51
-  Equal        r53, r50, r52
-  JumpIfFalse  r53, L6
+  LessInt      r53, r52, r51
+  JumpIfFalse  r53, L5
+  Index        r55, r50, r52
+  Const        r56, "ca_address_sk"
+  Index        r57, r49, r56
+  Const        r58, "c_current_addr_sk"
+  Index        r59, r55, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L6
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  IterPrep     r54, r2
-  Len          r55, r54
-  Move         r56, r45
+  IterPrep     r61, r2
+  Len          r62, r61
+  Const        r63, 0
 L17:
-  LessInt      r57, r56, r55
-  JumpIfFalse  r57, L6
-  Index        r59, r54, r56
-  Const        r60, "c_customer_sk"
-  Index        r61, r48, r60
-  Const        r62, "ss_customer_sk"
-  Index        r63, r59, r62
-  Equal        r64, r61, r63
-  JumpIfFalse  r64, L7
+  LessInt      r64, r63, r62
+  JumpIfFalse  r64, L6
+  Index        r66, r61, r63
+  Const        r67, "c_customer_sk"
+  Index        r68, r55, r67
+  Const        r69, "ss_customer_sk"
+  Index        r70, r66, r69
+  Equal        r71, r68, r70
+  JumpIfFalse  r71, L7
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r65, r3
-  Len          r66, r65
-  Move         r67, r12
+  IterPrep     r72, r3
+  Len          r73, r72
+  Const        r74, 0
 L16:
-  LessInt      r68, r67, r66
-  JumpIfFalse  r68, L7
-  Index        r15, r65, r67
-  Const        r70, "ss_sold_date_sk"
-  Index        r71, r59, r70
-  Const        r72, "d_date_sk"
-  Index        r73, r15, r72
-  Equal        r74, r71, r73
-  JumpIfFalse  r74, L8
+  LessInt      r75, r74, r73
+  JumpIfFalse  r75, L7
+  Index        r15, r72, r74
+  Const        r77, "ss_sold_date_sk"
+  Index        r78, r66, r77
+  Const        r79, "d_date_sk"
+  Index        r80, r15, r79
+  Equal        r81, r78, r80
+  JumpIfFalse  r81, L8
   // join i in item on s.ss_item_sk == i.i_item_sk
-  IterPrep     r75, r4
-  Len          r76, r75
-  Move         r77, r67
+  IterPrep     r82, r4
+  Len          r83, r82
+  Const        r84, 0
 L15:
-  LessInt      r78, r77, r76
-  JumpIfFalse  r78, L8
-  Index        r80, r75, r77
-  Const        r81, "ss_item_sk"
-  Index        r82, r59, r81
-  Const        r83, "i_item_sk"
-  Index        r84, r80, r83
-  Equal        r85, r82, r84
-  JumpIfFalse  r85, L9
+  LessInt      r85, r84, r83
+  JumpIfFalse  r85, L8
+  Index        r87, r82, r84
+  Const        r88, "ss_item_sk"
+  Index        r89, r66, r88
+  Const        r90, "i_item_sk"
+  Index        r91, r87, r90
+  Equal        r92, r89, r91
+  JumpIfFalse  r92, L9
   // where d.d_month_seq == target_month_seq &&
-  Index        r86, r15, r8
+  Const        r93, "d_month_seq"
+  Index        r94, r15, r93
   // i.i_current_price > 1.2 * avg(
-  Const        r87, 1.2
+  Const        r95, 1.2
   // from j in item
-  Move         r88, r0
-  IterPrep     r89, r4
-  Len          r90, r89
-  Move         r91, r12
+  Const        r96, []
+  IterPrep     r100, r4
+  Len          r101, r100
+  Const        r102, 0
 L12:
-  LessInt      r92, r91, r90
-  JumpIfFalse  r92, L10
-  Index        r94, r89, r91
+  LessInt      r104, r102, r101
+  JumpIfFalse  r104, L10
+  Index        r106, r100, r102
   // where j.i_category == i.i_category
-  Index        r95, r94, r30
-  Index        r96, r80, r30
-  Equal        r97, r95, r96
-  JumpIfFalse  r97, L11
+  Const        r107, "i_category"
+  Index        r108, r106, r107
+  Const        r109, "i_category"
+  Index        r110, r87, r109
+  Equal        r111, r108, r110
+  JumpIfFalse  r111, L11
   // select j.i_current_price
-  Index        r98, r94, r29
+  Const        r112, "i_current_price"
+  Index        r113, r106, r112
   // from j in item
-  Append       r88, r88, r98
+  Append       r96, r96, r113
 L11:
-  AddInt       r91, r91, r25
+  Const        r115, 1
+  AddInt       r102, r102, r115
   Jump         L12
 L10:
   // i.i_current_price > 1.2 * avg(
-  Avg          r100, r88
-  MulFloat     r101, r87, r100
-  Index        r102, r80, r29
-  LessFloat    r103, r101, r102
+  Avg          r116, r96
+  MulFloat     r117, r95, r116
+  Const        r118, "i_current_price"
+  Index        r119, r87, r118
+  LessFloat    r120, r117, r119
   // where d.d_month_seq == target_month_seq &&
-  Equal        r105, r86, r26
-  JumpIfFalse  r105, L13
-  Move         r105, r103
+  Equal        r122, r94, r29
+  JumpIfFalse  r122, L13
+  Move         r122, r120
 L13:
-  JumpIfFalse  r105, L9
+  JumpIfFalse  r122, L9
   // from a in customer_address
-  Const        r106, "a"
-  Move         r107, r42
-  Const        r108, "c"
-  Move         r109, r48
-  Const        r110, "s"
-  Move         r111, r59
-  Const        r112, "d"
-  Move         r113, r15
-  Const        r114, "i"
-  Move         r115, r80
-  MakeMap      r116, 5, r106
+  Const        r123, "a"
+  Move         r124, r49
+  Const        r125, "c"
+  Move         r126, r55
+  Const        r127, "s"
+  Move         r128, r66
+  Const        r129, "d"
+  Move         r130, r15
+  Const        r131, "i"
+  Move         r132, r87
+  MakeMap      r133, 5, r123
   // group by a.ca_state into g
-  Index        r117, r42, r28
-  Str          r118, r117
-  In           r119, r118, r34
-  JumpIfTrue   r119, L14
+  Const        r134, "ca_state"
+  Index        r135, r49, r134
+  Str          r136, r135
+  In           r137, r136, r41
+  JumpIfTrue   r137, L14
   // from a in customer_address
-  Move         r120, r0
-  Const        r121, "__group__"
-  Const        r122, true
-  Move         r123, r32
+  Const        r138, []
+  Const        r139, "__group__"
+  Const        r140, true
+  Const        r141, "key"
   // group by a.ca_state into g
-  Move         r124, r117
+  Move         r142, r135
   // from a in customer_address
-  Const        r125, "items"
-  Move         r126, r120
-  Const        r127, "count"
-  Move         r128, r67
-  Move         r129, r121
-  Move         r130, r122
-  Move         r131, r123
-  Move         r132, r124
-  Move         r133, r125
-  Move         r134, r126
-  Move         r135, r127
-  Move         r136, r128
-  MakeMap      r137, 4, r129
-  SetIndex     r34, r118, r137
-  Append       r35, r35, r137
+  Const        r143, "items"
+  Move         r144, r138
+  Const        r145, "count"
+  Const        r146, 0
+  Move         r147, r139
+  Move         r148, r140
+  Move         r149, r141
+  Move         r150, r142
+  Move         r151, r143
+  Move         r152, r144
+  Move         r153, r145
+  Move         r154, r146
+  MakeMap      r155, 4, r147
+  SetIndex     r41, r136, r155
+  Append       r42, r42, r155
 L14:
-  Move         r139, r125
-  Index        r140, r34, r118
-  Index        r141, r140, r139
-  Append       r142, r141, r116
-  SetIndex     r140, r139, r142
-  Move         r143, r127
-  Index        r144, r140, r143
-  AddInt       r145, r144, r25
-  SetIndex     r140, r143, r145
+  Const        r157, "items"
+  Index        r158, r41, r136
+  Index        r159, r158, r157
+  Append       r160, r159, r133
+  SetIndex     r158, r157, r160
+  Const        r161, "count"
+  Index        r162, r158, r161
+  Const        r163, 1
+  AddInt       r164, r162, r163
+  SetIndex     r158, r161, r164
 L9:
   // join i in item on s.ss_item_sk == i.i_item_sk
-  AddInt       r77, r77, r25
+  Const        r165, 1
+  AddInt       r84, r84, r165
   Jump         L15
 L8:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  AddInt       r67, r67, r25
+  Const        r166, 1
+  AddInt       r74, r74, r166
   Jump         L16
 L7:
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  AddInt       r56, r56, r25
+  Const        r167, 1
+  AddInt       r63, r63, r167
   Jump         L17
 L6:
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  AddInt       r45, r45, r25
+  Const        r168, 1
+  AddInt       r52, r52, r168
   Jump         L18
 L5:
   // from a in customer_address
-  AddInt       r39, r39, r25
+  Const        r169, 1
+  AddInt       r46, r46, r169
   Jump         L19
 L4:
-  Move         r146, r12
-  Len          r147, r35
+  Const        r170, 0
+  Len          r172, r42
 L21:
-  LessInt      r148, r146, r147
-  JumpIfFalse  r148, L20
-  Index        r150, r35, r146
+  LessInt      r173, r170, r172
+  JumpIfFalse  r173, L20
+  Index        r175, r42, r170
   // having count(g) >= 10
-  Index        r151, r150, r143
-  Const        r152, 10
-  LessEq       r153, r152, r151
-  JumpIfFalse  r153, L20
+  Const        r176, "count"
+  Index        r177, r175, r176
+  Const        r178, 10
+  LessEq       r179, r178, r177
+  JumpIfFalse  r179, L20
   // select { state: g.key, cnt: count(g) }
-  Move         r154, r31
-  Index        r155, r150, r32
-  Move         r156, r33
-  Index        r157, r150, r143
-  Move         r158, r154
-  Move         r159, r155
-  Move         r160, r156
-  Move         r161, r157
-  MakeMap      r162, 2, r158
+  Const        r180, "state"
+  Const        r181, "key"
+  Index        r182, r175, r181
+  Const        r183, "cnt"
+  Const        r184, "count"
+  Index        r185, r175, r184
+  Move         r186, r180
+  Move         r187, r182
+  Move         r188, r183
+  Move         r189, r185
+  MakeMap      r190, 2, r186
   // sort by [count(g), g.key]
-  Index        r164, r150, r143
-  Index        r165, r150, r32
-  MakeList     r168, 2, r164
+  Const        r191, "count"
+  Index        r193, r175, r191
+  Const        r194, "key"
+  MakeList     r198, 2, r193
   // from a in customer_address
-  Move         r169, r162
-  MakeList     r170, 2, r168
-  Append       r27, r27, r170
-  AddInt       r146, r146, r25
+  Move         r199, r190
+  MakeList     r200, 2, r198
+  Append       r30, r30, r200
+  Const        r202, 1
+  AddInt       r170, r170, r202
   Jump         L21
 L20:
   // sort by [count(g), g.key]
-  Sort         r27, r27
+  Sort         r30, r30
   // from a in customer_address
-  Move         r173, r128
+  Const        r204, 0
   // take 100
-  Const        r174, 100
+  Const        r205, 100
   // from a in customer_address
-  Slice        r27, r27, r173, r174
+  Slice        r30, r30, r204, r205
   // json(result)
-  JSON         r27
-  // expect result == []
-  Equal        r177, r27, r120
-  Expect       r177
+  JSON         r30
+  // expect len(result) == 0
+  Len          r207, r30
+  Const        r208, 0
+  EqualInt     r209, r207, r208
+  Expect       r209
   Return       r0

--- a/tests/dataset/tpc-ds/out/q7.ir.out
+++ b/tests/dataset/tpc-ds/out/q7.ir.out
@@ -1,340 +1,325 @@
-func main (regs=217)
+func main (regs=268)
   // let store_sales = []
   Const        r0, []
   // let customer_demographics = []
-  Move         r1, r0
+  Const        r1, []
   // let date_dim = []
-  Move         r2, r0
+  Const        r2, []
   // let item = []
-  Move         r3, r2
+  Const        r3, []
   // let promotion = []
-  Move         r4, r0
+  Const        r4, []
   // from ss in store_sales
-  Move         r5, r4
-  // group by { i_item_id: i.i_item_id } into g
-  Const        r6, "i_item_id"
-  // where cd.cd_gender == "M" &&
-  Const        r7, "cd_gender"
-  // cd.cd_marital_status == "S" &&
-  Const        r8, "cd_marital_status"
-  // cd.cd_education_status == "College" &&
-  Const        r9, "cd_education_status"
-  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  Const        r10, "p_channel_email"
-  Const        r11, "p_channel_event"
-  // d.d_year == 1998
-  Const        r12, "d_year"
-  // i_item_id: g.key.i_item_id,
-  Const        r13, "key"
-  // agg1: avg(from x in g select x.ss.ss_quantity),
-  Const        r14, "agg1"
-  Const        r15, "ss"
-  Const        r16, "ss_quantity"
-  // agg2: avg(from x in g select x.ss.ss_list_price),
-  Const        r17, "agg2"
-  Const        r18, "ss_list_price"
-  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Const        r19, "agg3"
-  Const        r20, "ss_coupon_amt"
-  // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Const        r21, "agg4"
-  Const        r22, "ss_sales_price"
-  // from ss in store_sales
-  MakeMap      r23, 0, r0
-  Move         r25, r4
-  Move         r24, r25
-  IterPrep     r26, r0
-  Len          r27, r26
-  Const        r28, 0
-L15:
-  LessInt      r29, r28, r27
-  JumpIfFalse  r29, L0
-  Index        r31, r26, r28
+  Const        r5, []
+  MakeMap      r31, 0, r0
+  Const        r32, []
+  IterPrep     r34, r0
+  Len          r35, r34
+  Const        r36, 0
+L1:
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L0
+  Index        r39, r34, r36
   // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
-  IterPrep     r32, r1
-  Len          r33, r32
-  Move         r34, r28
-L14:
-  LessInt      r35, r34, r33
-  JumpIfFalse  r35, L1
-  Index        r37, r32, r34
-  Const        r38, "ss_cdemo_sk"
-  Index        r39, r31, r38
-  Const        r40, "cd_demo_sk"
-  Index        r41, r37, r40
-  Equal        r42, r39, r41
-  JumpIfFalse  r42, L2
+  IterPrep     r40, r1
+  Len          r41, r40
+  Const        r42, 0
+L2:
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L1
+  Index        r45, r40, r42
+  Const        r46, "ss_cdemo_sk"
+  Index        r47, r39, r46
+  Const        r48, "cd_demo_sk"
+  Index        r49, r45, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L2
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r43, r2
-  Len          r44, r43
-  Move         r45, r28
+  IterPrep     r51, r2
+  Len          r52, r51
+  Const        r53, 0
 L13:
-  LessInt      r46, r45, r44
-  JumpIfFalse  r46, L2
-  Index        r48, r43, r45
-  Const        r49, "ss_sold_date_sk"
-  Index        r50, r31, r49
-  Const        r51, "d_date_sk"
-  Index        r52, r48, r51
-  Equal        r53, r50, r52
-  JumpIfFalse  r53, L3
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L2
+  Index        r56, r51, r53
+  Const        r57, "ss_sold_date_sk"
+  Index        r58, r39, r57
+  Const        r59, "d_date_sk"
+  Index        r60, r56, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L3
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r54, r3
-  Len          r55, r54
-  Move         r56, r45
+  IterPrep     r62, r3
+  Len          r63, r62
+  Const        r64, 0
 L12:
-  LessInt      r57, r56, r55
-  JumpIfFalse  r57, L3
-  Index        r59, r54, r56
-  Const        r60, "ss_item_sk"
-  Index        r61, r31, r60
-  Const        r62, "i_item_sk"
-  Index        r63, r59, r62
-  Equal        r64, r61, r63
-  JumpIfFalse  r64, L4
+  LessInt      r65, r64, r63
+  JumpIfFalse  r65, L3
+  Index        r67, r62, r64
+  Const        r68, "ss_item_sk"
+  Index        r69, r39, r68
+  Const        r70, "i_item_sk"
+  Index        r71, r67, r70
+  Equal        r72, r69, r71
+  JumpIfFalse  r72, L4
   // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
-  IterPrep     r65, r4
-  Len          r66, r65
-  Move         r67, r28
+  IterPrep     r73, r4
+  Len          r74, r73
+  Const        r75, 0
 L11:
-  LessInt      r68, r67, r66
-  JumpIfFalse  r68, L4
-  Index        r70, r65, r67
-  Const        r71, "ss_promo_sk"
-  Index        r72, r31, r71
-  Const        r73, "p_promo_sk"
-  Index        r74, r70, r73
-  Equal        r75, r72, r74
-  JumpIfFalse  r75, L5
+  LessInt      r76, r75, r74
+  JumpIfFalse  r76, L4
+  Index        r78, r73, r75
+  Const        r79, "ss_promo_sk"
+  Index        r80, r39, r79
+  Const        r81, "p_promo_sk"
+  Index        r82, r78, r81
+  Equal        r83, r80, r82
+  JumpIfFalse  r83, L5
   // where cd.cd_gender == "M" &&
-  Index        r76, r37, r7
-  Const        r77, "M"
-  Equal        r78, r76, r77
-  // cd.cd_marital_status == "S" &&
-  Index        r79, r37, r8
-  Const        r80, "S"
-  Equal        r81, r79, r80
-  // cd.cd_education_status == "College" &&
-  Index        r82, r37, r9
-  Const        r83, "College"
-  Equal        r84, r82, r83
-  // d.d_year == 1998
-  Index        r85, r48, r12
-  Const        r86, 1998
+  Const        r84, "cd_gender"
+  Index        r85, r45, r84
+  Const        r86, "M"
   Equal        r87, r85, r86
+  // cd.cd_marital_status == "S" &&
+  Const        r88, "cd_marital_status"
+  Index        r89, r45, r88
+  Const        r90, "S"
+  Equal        r91, r89, r90
+  // cd.cd_education_status == "College" &&
+  Const        r92, "cd_education_status"
+  Index        r93, r45, r92
+  Const        r94, "College"
+  Equal        r95, r93, r94
+  // d.d_year == 1998
+  Const        r96, "d_year"
+  Index        r97, r56, r96
+  Const        r98, 1998
+  Equal        r99, r97, r98
   // where cd.cd_gender == "M" &&
-  Move         r88, r78
-  JumpIfFalse  r88, L6
+  Move         r100, r87
+  JumpIfFalse  r100, L6
 L6:
   // cd.cd_marital_status == "S" &&
-  Move         r89, r81
-  JumpIfFalse  r89, L7
+  Move         r101, r91
+  JumpIfFalse  r101, L7
 L7:
   // cd.cd_education_status == "College" &&
-  Move         r90, r84
-  JumpIfFalse  r90, L8
+  Move         r102, r95
+  JumpIfFalse  r102, L8
   // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  Index        r91, r70, r10
-  Const        r92, "N"
-  Equal        r93, r91, r92
-  Index        r94, r70, r11
-  Equal        r95, r94, r92
-  Move         r96, r93
-  JumpIfTrue   r96, L8
+  Const        r103, "p_channel_email"
+  Index        r104, r78, r103
+  Const        r105, "N"
+  Equal        r106, r104, r105
+  Const        r107, "p_channel_event"
+  Index        r108, r78, r107
+  Const        r109, "N"
+  Equal        r110, r108, r109
+  Move         r111, r106
+  JumpIfTrue   r111, L8
 L8:
-  Move         r97, r95
-  JumpIfFalse  r97, L9
-  Move         r97, r87
+  Move         r112, r110
+  JumpIfFalse  r112, L9
+  Move         r112, r99
 L9:
   // where cd.cd_gender == "M" &&
-  JumpIfFalse  r97, L5
+  JumpIfFalse  r112, L5
   // from ss in store_sales
-  Move         r98, r15
-  Move         r99, r31
-  Const        r100, "cd"
-  Move         r101, r37
-  Const        r102, "d"
-  Move         r103, r48
-  Const        r104, "i"
-  Move         r105, r59
-  Const        r106, "p"
-  Move         r107, r70
-  MakeMap      r108, 5, r98
+  Const        r113, "ss"
+  Move         r114, r39
+  Const        r115, "cd"
+  Move         r116, r45
+  Const        r117, "d"
+  Move         r118, r56
+  Const        r119, "i"
+  Move         r120, r67
+  Const        r121, "p"
+  Move         r122, r78
+  MakeMap      r123, 5, r113
   // group by { i_item_id: i.i_item_id } into g
-  Move         r109, r6
-  Index        r110, r59, r6
-  Move         r111, r109
-  Move         r112, r110
-  MakeMap      r113, 1, r111
-  Str          r114, r113
-  In           r115, r114, r23
-  JumpIfTrue   r115, L10
+  Const        r124, "i_item_id"
+  Const        r125, "i_item_id"
+  Index        r126, r67, r125
+  Move         r127, r124
+  Move         r128, r126
+  MakeMap      r129, 1, r127
+  Str          r130, r129
+  In           r131, r130, r31
+  JumpIfTrue   r131, L10
   // from ss in store_sales
-  Move         r116, r25
-  Const        r117, "__group__"
-  Const        r118, true
-  Move         r119, r13
+  Const        r132, []
+  Const        r133, "__group__"
+  Const        r134, true
+  Const        r135, "key"
   // group by { i_item_id: i.i_item_id } into g
-  Move         r120, r113
+  Move         r136, r129
   // from ss in store_sales
-  Const        r121, "items"
-  Move         r122, r116
-  Const        r123, "count"
-  Move         r124, r67
-  Move         r125, r117
-  Move         r126, r118
-  Move         r127, r119
-  Move         r128, r120
-  Move         r129, r121
-  Move         r130, r122
-  Move         r131, r123
-  Move         r132, r124
-  MakeMap      r133, 4, r125
-  SetIndex     r23, r114, r133
-  Append       r24, r24, r133
+  Const        r137, "items"
+  Move         r138, r132
+  Const        r139, "count"
+  Const        r140, 0
+  Move         r141, r133
+  Move         r142, r134
+  Move         r143, r135
+  Move         r144, r136
+  Move         r145, r137
+  Move         r146, r138
+  Move         r147, r139
+  Move         r148, r140
+  MakeMap      r149, 4, r141
+  SetIndex     r31, r130, r149
+  Append       r32, r32, r149
 L10:
-  Move         r135, r121
-  Index        r136, r23, r114
-  Index        r137, r136, r135
-  Append       r138, r137, r108
-  SetIndex     r136, r135, r138
-  Move         r139, r123
-  Index        r140, r136, r139
-  Const        r141, 1
-  AddInt       r142, r140, r141
-  SetIndex     r136, r139, r142
+  Const        r151, "items"
+  Index        r152, r31, r130
+  Index        r153, r152, r151
+  Append       r154, r153, r123
+  SetIndex     r152, r151, r154
+  Const        r155, "count"
+  Index        r156, r152, r155
+  Const        r157, 1
+  AddInt       r158, r156, r157
+  SetIndex     r152, r155, r158
 L5:
   // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
-  AddInt       r67, r67, r141
+  Const        r159, 1
+  AddInt       r75, r75, r159
   Jump         L11
 L4:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r56, r56, r141
+  Const        r160, 1
+  AddInt       r64, r64, r160
   Jump         L12
 L3:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r45, r45, r141
+  Const        r161, 1
+  AddInt       r53, r53, r161
   Jump         L13
-L2:
-  // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
-  AddInt       r34, r34, r141
-  Jump         L14
-L1:
-  // from ss in store_sales
-  AddInt       r28, r28, r141
-  Jump         L15
 L0:
-  Const        r144, 0
-  Move         r143, r144
-  Len          r145, r24
-L25:
-  LessInt      r146, r143, r145
-  JumpIfFalse  r146, L16
-  Index        r148, r24, r143
+  // from ss in store_sales
+  Const        r164, 0
+  Len          r166, r32
+L23:
+  LessInt      r167, r164, r166
+  JumpIfFalse  r167, L14
+  Index        r169, r32, r164
   // i_item_id: g.key.i_item_id,
-  Move         r149, r6
-  Index        r150, r148, r13
-  Index        r151, r150, r6
+  Const        r170, "i_item_id"
+  Const        r171, "key"
+  Index        r172, r169, r171
+  Const        r173, "i_item_id"
+  Index        r174, r172, r173
   // agg1: avg(from x in g select x.ss.ss_quantity),
-  Move         r152, r14
-  Move         r153, r0
-  IterPrep     r154, r148
-  Len          r155, r154
-  Move         r156, r144
+  Const        r175, "agg1"
+  IterPrep     r179, r169
+  Len          r180, r179
+  Const        r181, 0
+L16:
+  LessInt      r183, r181, r180
+  JumpIfFalse  r183, L15
+  Const        r191, 1
+  AddInt       r181, r181, r191
+  Jump         L16
+L15:
+  Const        r192, 0
+  // agg2: avg(from x in g select x.ss.ss_list_price),
+  Const        r193, "agg2"
+  Const        r194, []
+  IterPrep     r197, r169
+  Len          r198, r197
+  Const        r199, 0
 L18:
-  LessInt      r157, r156, r155
-  JumpIfFalse  r157, L17
-  Index        r159, r154, r156
-  Index        r160, r159, r15
-  Index        r161, r160, r16
-  Append       r153, r153, r161
-  AddInt       r156, r156, r141
+  LessInt      r201, r199, r198
+  JumpIfFalse  r201, L17
+  Index        r185, r197, r199
+  Const        r203, "ss"
+  Index        r204, r185, r203
+  Const        r205, "ss_list_price"
+  Index        r206, r204, r205
+  Append       r194, r194, r206
+  Const        r208, 1
+  AddInt       r199, r199, r208
   Jump         L18
 L17:
-  Avg          r163, r153
-  // agg2: avg(from x in g select x.ss.ss_list_price),
-  Move         r164, r17
-  Move         r165, r0
-  IterPrep     r166, r148
-  Len          r167, r166
-  Move         r168, r144
+  Avg          r209, r194
+  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
+  Const        r210, "agg3"
+  Const        r211, []
+  IterPrep     r214, r169
+  Len          r215, r214
+  Const        r216, 0
 L20:
-  LessInt      r169, r168, r167
-  JumpIfFalse  r169, L19
-  Index        r159, r166, r168
-  Index        r171, r159, r15
-  Index        r172, r171, r18
-  Append       r165, r165, r172
-  AddInt       r168, r168, r141
+  LessInt      r218, r216, r215
+  JumpIfFalse  r218, L19
+  Index        r185, r214, r216
+  Const        r220, "ss"
+  Index        r221, r185, r220
+  Const        r222, "ss_coupon_amt"
+  Index        r223, r221, r222
+  Append       r211, r211, r223
+  Const        r225, 1
+  AddInt       r216, r216, r225
   Jump         L20
 L19:
-  Avg          r174, r165
-  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Move         r175, r19
-  Move         r176, r0
-  IterPrep     r177, r148
-  Len          r178, r177
-  Move         r179, r144
+  Avg          r226, r211
+  // agg4: avg(from x in g select x.ss.ss_sales_price)
+  Const        r227, "agg4"
+  Const        r228, []
+  IterPrep     r231, r169
+  Len          r232, r231
+  Const        r233, 0
 L22:
-  LessInt      r180, r179, r178
-  JumpIfFalse  r180, L21
-  Index        r159, r177, r179
-  Index        r182, r159, r15
-  Index        r183, r182, r20
-  Append       r176, r176, r183
-  AddInt       r179, r179, r141
+  LessInt      r235, r233, r232
+  JumpIfFalse  r235, L21
+  Index        r185, r231, r233
+  Const        r237, "ss"
+  Index        r238, r185, r237
+  Const        r239, "ss_sales_price"
+  Index        r240, r238, r239
+  Append       r228, r228, r240
+  Const        r242, 1
+  AddInt       r233, r233, r242
   Jump         L22
 L21:
-  Avg          r185, r176
-  // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Move         r186, r21
-  Move         r187, r0
-  IterPrep     r188, r148
-  Len          r189, r188
-  Move         r190, r144
-L24:
-  LessInt      r191, r190, r189
-  JumpIfFalse  r191, L23
-  Index        r159, r188, r190
-  Index        r193, r159, r15
-  Index        r194, r193, r22
-  Append       r187, r187, r194
-  AddInt       r190, r190, r141
-  Jump         L24
-L23:
-  Avg          r196, r187
+  Avg          r243, r228
   // i_item_id: g.key.i_item_id,
-  Move         r197, r149
-  Move         r198, r151
+  Move         r244, r170
+  Move         r245, r174
   // agg1: avg(from x in g select x.ss.ss_quantity),
-  Move         r199, r152
-  Move         r200, r163
+  Move         r246, r175
+  Move         r247, r192
   // agg2: avg(from x in g select x.ss.ss_list_price),
-  Move         r201, r164
-  Move         r202, r174
+  Move         r248, r193
+  Move         r249, r209
   // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Move         r203, r175
-  Move         r204, r185
+  Move         r250, r210
+  Move         r251, r226
   // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Move         r205, r186
-  Move         r206, r196
+  Move         r252, r227
+  Move         r253, r243
   // select {
-  MakeMap      r207, 5, r197
+  MakeMap      r254, 5, r244
   // sort by g.key.i_item_id
-  Index        r208, r148, r13
-  Index        r210, r208, r6
+  Const        r255, "key"
+  Index        r256, r169, r255
+  Const        r257, "i_item_id"
+  Index        r259, r256, r257
   // from ss in store_sales
-  Move         r211, r207
-  MakeList     r212, 2, r210
-  Append       r5, r5, r212
-  AddInt       r143, r143, r141
-  Jump         L25
-L16:
+  Move         r260, r254
+  MakeList     r261, 2, r259
+  Append       r5, r5, r261
+  Const        r263, 1
+  AddInt       r164, r164, r263
+  Jump         L23
+L14:
   // sort by g.key.i_item_id
   Sort         r5, r5
   // json(result)
   JSON         r5
-  // expect result == []
-  Equal        r216, r5, r0
-  Expect       r216
+  // expect len(result) == 0
+  Len          r265, r5
+  Const        r266, 0
+  EqualInt     r267, r265, r266
+  Expect       r267
   Return       r0

--- a/tests/dataset/tpc-ds/out/q8.ir.out
+++ b/tests/dataset/tpc-ds/out/q8.ir.out
@@ -1,11 +1,11 @@
-func main (regs=9)
+func main (regs=10)
   // let store_sales = []
   Const        r0, []
   // let result = []
-  Move         r6, r0
+  Const        r6, []
   // json(result)
   JSON         r6
-  // expect result == []
-  Equal        r8, r6, r0
-  Expect       r8
+  // expect len(result) == 0
+  Const        r9, true
+  Expect       r9
   Return       r0

--- a/tests/dataset/tpc-ds/out/q9.ir.out
+++ b/tests/dataset/tpc-ds/out/q9.ir.out
@@ -1,543 +1,602 @@
-func main (regs=269)
+func main (regs=402)
   // let store_sales = []
   Const        r0, []
   // let reason = []
-  Move         r1, r0
+  Const        r1, []
   // if count(from s in store_sales
-  Move         r2, r0
-  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Const        r3, "ss_quantity"
-  // if count(from s in store_sales
-  IterPrep     r4, r0
-  Len          r5, r4
+  Const        r2, []
+  IterPrep     r5, r0
+  Len          r6, r5
   Const        r7, 0
-  Move         r6, r7
 L3:
-  LessInt      r8, r6, r5
-  JumpIfFalse  r8, L0
-  Index        r10, r4, r6
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Index        r11, r10, r3
-  Const        r12, 1
-  LessEq       r13, r12, r11
-  Index        r14, r10, r3
-  Const        r15, 20
-  LessEq       r16, r14, r15
-  Move         r17, r13
-  JumpIfFalse  r17, L1
-  Move         r17, r16
+  Const        r12, "ss_quantity"
+  Index        r13, r11, r12
+  Const        r14, 1
+  LessEq       r15, r14, r13
+  Const        r16, "ss_quantity"
+  Index        r17, r11, r16
+  Const        r18, 20
+  LessEq       r19, r17, r18
+  Move         r20, r15
+  JumpIfFalse  r20, L1
+  Move         r20, r19
 L1:
-  JumpIfFalse  r17, L2
+  JumpIfFalse  r20, L2
   // if count(from s in store_sales
-  Append       r2, r2, r10
+  Append       r2, r2, r11
 L2:
-  AddInt       r6, r6, r12
+  Const        r22, 1
+  AddInt       r7, r7, r22
   Jump         L3
 L0:
-  Count        r19, r2
+  Count        r23, r2
   // select s) > 10 {
-  Const        r20, 10
-  LessInt      r21, r20, r19
+  Const        r24, 10
+  LessInt      r25, r24, r23
   // if count(from s in store_sales
-  JumpIfFalse  r21, L4
+  JumpIfFalse  r25, L4
   // avg(from s in store_sales
-  Move         r22, r0
-  // select s.ss_ext_discount_amt)
-  Const        r23, "ss_ext_discount_amt"
-  // avg(from s in store_sales
-  IterPrep     r24, r0
-  Len          r25, r24
-  Move         r26, r7
+  Const        r26, []
+  IterPrep     r30, r0
+  Len          r31, r30
+  Const        r32, 0
 L8:
-  LessInt      r27, r26, r25
-  JumpIfFalse  r27, L5
-  Index        r10, r24, r26
+  LessInt      r34, r32, r31
+  JumpIfFalse  r34, L5
+  Index        r11, r30, r32
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Index        r29, r10, r3
-  LessEq       r30, r12, r29
-  Index        r31, r10, r3
-  LessEq       r32, r31, r15
-  Move         r33, r30
-  JumpIfFalse  r33, L6
-  Move         r33, r32
+  Const        r36, "ss_quantity"
+  Index        r37, r11, r36
+  Const        r38, 1
+  LessEq       r39, r38, r37
+  Const        r40, "ss_quantity"
+  Index        r41, r11, r40
+  Const        r42, 20
+  LessEq       r43, r41, r42
+  Move         r44, r39
+  JumpIfFalse  r44, L6
+  Move         r44, r43
 L6:
-  JumpIfFalse  r33, L7
+  JumpIfFalse  r44, L7
   // select s.ss_ext_discount_amt)
-  Index        r34, r10, r23
+  Const        r45, "ss_ext_discount_amt"
+  Index        r46, r11, r45
   // avg(from s in store_sales
-  Append       r22, r22, r34
+  Append       r26, r26, r46
 L7:
-  AddInt       r26, r26, r12
+  Const        r48, 1
+  AddInt       r32, r32, r48
   Jump         L8
 L5:
-  Avg          r37, r22
+  Avg          r50, r26
   // if count(from s in store_sales
   Jump         L9
 L4:
   // avg(from s in store_sales
-  Move         r38, r0
-  // select s.ss_net_paid)
-  Const        r39, "ss_net_paid"
-  // avg(from s in store_sales
-  IterPrep     r40, r0
-  Len          r41, r40
-  Move         r42, r7
+  Const        r51, []
+  IterPrep     r55, r0
+  Len          r56, r55
+  Const        r57, 0
 L13:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L10
-  Index        r10, r40, r42
+  LessInt      r59, r57, r56
+  JumpIfFalse  r59, L10
+  Index        r11, r55, r57
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Index        r45, r10, r3
-  LessEq       r46, r12, r45
-  Index        r47, r10, r3
-  LessEq       r48, r47, r15
-  Move         r49, r46
-  JumpIfFalse  r49, L11
-  Move         r49, r48
+  Const        r61, "ss_quantity"
+  Index        r62, r11, r61
+  Const        r63, 1
+  LessEq       r64, r63, r62
+  Const        r65, "ss_quantity"
+  Index        r66, r11, r65
+  Const        r67, 20
+  LessEq       r68, r66, r67
+  Move         r69, r64
+  JumpIfFalse  r69, L11
+  Move         r69, r68
 L11:
-  JumpIfFalse  r49, L12
+  JumpIfFalse  r69, L12
   // select s.ss_net_paid)
-  Index        r50, r10, r39
+  Const        r70, "ss_net_paid"
+  Index        r71, r11, r70
   // avg(from s in store_sales
-  Append       r38, r38, r50
+  Append       r51, r51, r71
 L12:
-  AddInt       r42, r42, r12
+  Const        r73, 1
+  AddInt       r57, r57, r73
   Jump         L13
 L10:
-  Avg          r37, r38
+  Avg          r50, r51
 L9:
   // if count(from s in store_sales
-  Move         r53, r0
-  IterPrep     r54, r0
-  Len          r55, r54
-  Move         r56, r7
+  Const        r75, []
+  IterPrep     r78, r0
+  Len          r79, r78
+  Const        r80, 0
 L17:
-  LessInt      r57, r56, r55
-  JumpIfFalse  r57, L14
-  Index        r10, r54, r56
+  LessInt      r82, r80, r79
+  JumpIfFalse  r82, L14
+  Index        r11, r78, r80
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Index        r59, r10, r3
-  Const        r60, 21
-  LessEq       r61, r60, r59
-  Index        r62, r10, r3
-  Const        r63, 40
-  LessEq       r64, r62, r63
-  Move         r65, r61
-  JumpIfFalse  r65, L15
-  Move         r65, r64
+  Const        r84, "ss_quantity"
+  Index        r85, r11, r84
+  Const        r86, 21
+  LessEq       r87, r86, r85
+  Const        r88, "ss_quantity"
+  Index        r89, r11, r88
+  Const        r90, 40
+  LessEq       r91, r89, r90
+  Move         r92, r87
+  JumpIfFalse  r92, L15
+  Move         r92, r91
 L15:
-  JumpIfFalse  r65, L16
+  JumpIfFalse  r92, L16
   // if count(from s in store_sales
-  Append       r53, r53, r10
+  Append       r75, r75, r11
 L16:
-  AddInt       r56, r56, r12
+  Const        r94, 1
+  AddInt       r80, r80, r94
   Jump         L17
 L14:
-  Count        r67, r53
+  Count        r95, r75
   // select s) > 20 {
-  LessInt      r68, r15, r67
+  Const        r96, 20
+  LessInt      r97, r96, r95
   // if count(from s in store_sales
-  JumpIfFalse  r68, L18
+  JumpIfFalse  r97, L18
   // avg(from s in store_sales
-  Move         r69, r0
-  IterPrep     r70, r0
-  Len          r71, r70
-  Move         r72, r7
+  Const        r98, []
+  IterPrep     r102, r0
+  Len          r103, r102
+  Const        r104, 0
 L22:
-  LessInt      r73, r72, r71
-  JumpIfFalse  r73, L19
-  Index        r10, r70, r72
+  LessInt      r106, r104, r103
+  JumpIfFalse  r106, L19
+  Index        r11, r102, r104
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Index        r75, r10, r3
-  LessEq       r76, r60, r75
-  Index        r77, r10, r3
-  LessEq       r78, r77, r63
-  Move         r79, r76
-  JumpIfFalse  r79, L20
-  Move         r79, r78
+  Const        r108, "ss_quantity"
+  Index        r109, r11, r108
+  Const        r110, 21
+  LessEq       r111, r110, r109
+  Const        r112, "ss_quantity"
+  Index        r113, r11, r112
+  Const        r114, 40
+  LessEq       r115, r113, r114
+  Move         r116, r111
+  JumpIfFalse  r116, L20
+  Move         r116, r115
 L20:
-  JumpIfFalse  r79, L21
+  JumpIfFalse  r116, L21
   // select s.ss_ext_discount_amt)
-  Index        r80, r10, r23
+  Const        r117, "ss_ext_discount_amt"
+  Index        r118, r11, r117
   // avg(from s in store_sales
-  Append       r69, r69, r80
+  Append       r98, r98, r118
 L21:
-  AddInt       r72, r72, r12
+  Const        r120, 1
+  AddInt       r104, r104, r120
   Jump         L22
 L19:
-  Avg          r83, r69
+  Avg          r122, r98
   // if count(from s in store_sales
   Jump         L23
 L18:
   // avg(from s in store_sales
-  Move         r84, r0
-  IterPrep     r85, r0
-  Len          r86, r85
-  Move         r87, r7
+  Const        r123, []
+  IterPrep     r127, r0
+  Len          r128, r127
+  Const        r129, 0
 L27:
-  LessInt      r88, r87, r86
-  JumpIfFalse  r88, L24
-  Index        r10, r85, r87
+  LessInt      r131, r129, r128
+  JumpIfFalse  r131, L24
+  Index        r11, r127, r129
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Index        r90, r10, r3
-  LessEq       r91, r60, r90
-  Index        r92, r10, r3
-  LessEq       r93, r92, r63
-  Move         r94, r91
-  JumpIfFalse  r94, L25
-  Move         r94, r93
+  Const        r133, "ss_quantity"
+  Index        r134, r11, r133
+  Const        r135, 21
+  LessEq       r136, r135, r134
+  Const        r137, "ss_quantity"
+  Index        r138, r11, r137
+  Const        r139, 40
+  LessEq       r140, r138, r139
+  Move         r141, r136
+  JumpIfFalse  r141, L25
+  Move         r141, r140
 L25:
-  JumpIfFalse  r94, L26
+  JumpIfFalse  r141, L26
   // select s.ss_net_paid)
-  Index        r95, r10, r39
+  Const        r142, "ss_net_paid"
+  Index        r143, r11, r142
   // avg(from s in store_sales
-  Append       r84, r84, r95
+  Append       r123, r123, r143
 L26:
-  AddInt       r87, r87, r12
+  Const        r145, 1
+  AddInt       r129, r129, r145
   Jump         L27
 L24:
-  Avg          r83, r84
+  Avg          r122, r123
 L23:
   // if count(from s in store_sales
-  Move         r98, r0
-  IterPrep     r99, r0
-  Len          r100, r99
-  Move         r101, r7
+  Const        r147, []
+  IterPrep     r150, r0
+  Len          r151, r150
+  Const        r152, 0
 L31:
-  LessInt      r102, r101, r100
-  JumpIfFalse  r102, L28
-  Index        r10, r99, r101
+  LessInt      r154, r152, r151
+  JumpIfFalse  r154, L28
+  Index        r11, r150, r152
   // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Index        r104, r10, r3
-  Const        r105, 41
-  LessEq       r106, r105, r104
-  Index        r107, r10, r3
-  Const        r108, 60
-  LessEq       r109, r107, r108
-  Move         r110, r106
-  JumpIfFalse  r110, L29
-  Move         r110, r109
+  Const        r156, "ss_quantity"
+  Index        r157, r11, r156
+  Const        r158, 41
+  LessEq       r159, r158, r157
+  Const        r160, "ss_quantity"
+  Index        r161, r11, r160
+  Const        r162, 60
+  LessEq       r163, r161, r162
+  Move         r164, r159
+  JumpIfFalse  r164, L29
+  Move         r164, r163
 L29:
-  JumpIfFalse  r110, L30
+  JumpIfFalse  r164, L30
   // if count(from s in store_sales
-  Append       r98, r98, r10
+  Append       r147, r147, r11
 L30:
-  AddInt       r101, r101, r12
+  Const        r166, 1
+  AddInt       r152, r152, r166
   Jump         L31
 L28:
-  Count        r112, r98
+  Count        r167, r147
   // select s) > 30 {
-  Const        r113, 30
-  LessInt      r114, r113, r112
+  Const        r168, 30
+  LessInt      r169, r168, r167
   // if count(from s in store_sales
-  JumpIfFalse  r114, L32
+  JumpIfFalse  r169, L32
   // avg(from s in store_sales
-  Move         r115, r0
-  IterPrep     r116, r0
-  Len          r117, r116
-  Move         r118, r7
+  Const        r170, []
+  IterPrep     r174, r0
+  Len          r175, r174
+  Const        r176, 0
 L36:
-  LessInt      r119, r118, r117
-  JumpIfFalse  r119, L33
-  Index        r10, r116, r118
+  LessInt      r178, r176, r175
+  JumpIfFalse  r178, L33
+  Index        r11, r174, r176
   // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Index        r121, r10, r3
-  LessEq       r122, r105, r121
-  Index        r123, r10, r3
-  LessEq       r124, r123, r108
-  Move         r125, r122
-  JumpIfFalse  r125, L34
-  Move         r125, r124
+  Const        r180, "ss_quantity"
+  Index        r181, r11, r180
+  Const        r182, 41
+  LessEq       r183, r182, r181
+  Const        r184, "ss_quantity"
+  Index        r185, r11, r184
+  Const        r186, 60
+  LessEq       r187, r185, r186
+  Move         r188, r183
+  JumpIfFalse  r188, L34
+  Move         r188, r187
 L34:
-  JumpIfFalse  r125, L35
+  JumpIfFalse  r188, L35
   // select s.ss_ext_discount_amt)
-  Index        r126, r10, r23
+  Const        r189, "ss_ext_discount_amt"
+  Index        r190, r11, r189
   // avg(from s in store_sales
-  Append       r115, r115, r126
+  Append       r170, r170, r190
 L35:
-  AddInt       r118, r118, r12
+  Const        r192, 1
+  AddInt       r176, r176, r192
   Jump         L36
 L33:
-  Avg          r129, r115
+  Avg          r194, r170
   // if count(from s in store_sales
   Jump         L37
 L32:
   // avg(from s in store_sales
-  Move         r130, r0
-  IterPrep     r131, r0
-  Len          r132, r131
-  Move         r133, r7
+  Const        r195, []
+  IterPrep     r199, r0
+  Len          r200, r199
+  Const        r201, 0
 L41:
-  LessInt      r134, r133, r132
-  JumpIfFalse  r134, L38
-  Index        r10, r131, r133
+  LessInt      r203, r201, r200
+  JumpIfFalse  r203, L38
+  Index        r11, r199, r201
   // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Index        r136, r10, r3
-  LessEq       r137, r105, r136
-  Index        r138, r10, r3
-  LessEq       r139, r138, r108
-  Move         r140, r137
-  JumpIfFalse  r140, L39
-  Move         r140, r139
+  Const        r205, "ss_quantity"
+  Index        r206, r11, r205
+  Const        r207, 41
+  LessEq       r208, r207, r206
+  Const        r209, "ss_quantity"
+  Index        r210, r11, r209
+  Const        r211, 60
+  LessEq       r212, r210, r211
+  Move         r213, r208
+  JumpIfFalse  r213, L39
+  Move         r213, r212
 L39:
-  JumpIfFalse  r140, L40
+  JumpIfFalse  r213, L40
   // select s.ss_net_paid)
-  Index        r141, r10, r39
+  Const        r214, "ss_net_paid"
+  Index        r215, r11, r214
   // avg(from s in store_sales
-  Append       r130, r130, r141
+  Append       r195, r195, r215
 L40:
-  AddInt       r133, r133, r12
+  Const        r217, 1
+  AddInt       r201, r201, r217
   Jump         L41
 L38:
-  Avg          r129, r130
+  Avg          r194, r195
 L37:
   // if count(from s in store_sales
-  Move         r144, r0
-  IterPrep     r145, r0
-  Len          r146, r145
-  Move         r147, r7
+  Const        r219, []
+  IterPrep     r222, r0
+  Len          r223, r222
+  Const        r224, 0
 L45:
-  LessInt      r148, r147, r146
-  JumpIfFalse  r148, L42
-  Index        r10, r145, r147
+  LessInt      r226, r224, r223
+  JumpIfFalse  r226, L42
+  Index        r11, r222, r224
   // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Index        r150, r10, r3
-  Const        r151, 61
-  LessEq       r152, r151, r150
-  Index        r153, r10, r3
-  Const        r154, 80
-  LessEq       r155, r153, r154
-  Move         r156, r152
-  JumpIfFalse  r156, L43
-  Move         r156, r155
+  Const        r228, "ss_quantity"
+  Index        r229, r11, r228
+  Const        r230, 61
+  LessEq       r231, r230, r229
+  Const        r232, "ss_quantity"
+  Index        r233, r11, r232
+  Const        r234, 80
+  LessEq       r235, r233, r234
+  Move         r236, r231
+  JumpIfFalse  r236, L43
+  Move         r236, r235
 L43:
-  JumpIfFalse  r156, L44
+  JumpIfFalse  r236, L44
   // if count(from s in store_sales
-  Append       r144, r144, r10
+  Append       r219, r219, r11
 L44:
-  AddInt       r147, r147, r12
+  Const        r238, 1
+  AddInt       r224, r224, r238
   Jump         L45
 L42:
-  Count        r158, r144
+  Count        r239, r219
   // select s) > 40 {
-  LessInt      r159, r63, r158
+  Const        r240, 40
+  LessInt      r241, r240, r239
   // if count(from s in store_sales
-  JumpIfFalse  r159, L46
+  JumpIfFalse  r241, L46
   // avg(from s in store_sales
-  Move         r160, r0
-  IterPrep     r161, r0
-  Len          r162, r161
-  Move         r163, r7
+  Const        r242, []
+  IterPrep     r246, r0
+  Len          r247, r246
+  Const        r248, 0
 L50:
-  LessInt      r164, r163, r162
-  JumpIfFalse  r164, L47
-  Index        r10, r161, r163
+  LessInt      r250, r248, r247
+  JumpIfFalse  r250, L47
+  Index        r11, r246, r248
   // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Index        r166, r10, r3
-  LessEq       r167, r151, r166
-  Index        r168, r10, r3
-  LessEq       r169, r168, r154
-  Move         r170, r167
-  JumpIfFalse  r170, L48
-  Move         r170, r169
+  Const        r252, "ss_quantity"
+  Index        r253, r11, r252
+  Const        r254, 61
+  LessEq       r255, r254, r253
+  Const        r256, "ss_quantity"
+  Index        r257, r11, r256
+  Const        r258, 80
+  LessEq       r259, r257, r258
+  Move         r260, r255
+  JumpIfFalse  r260, L48
+  Move         r260, r259
 L48:
-  JumpIfFalse  r170, L49
+  JumpIfFalse  r260, L49
   // select s.ss_ext_discount_amt)
-  Index        r171, r10, r23
+  Const        r261, "ss_ext_discount_amt"
+  Index        r262, r11, r261
   // avg(from s in store_sales
-  Append       r160, r160, r171
+  Append       r242, r242, r262
 L49:
-  AddInt       r163, r163, r12
+  Const        r264, 1
+  AddInt       r248, r248, r264
   Jump         L50
 L47:
-  Avg          r174, r160
+  Avg          r266, r242
   // if count(from s in store_sales
   Jump         L51
 L46:
   // avg(from s in store_sales
-  Move         r175, r0
-  IterPrep     r176, r0
-  Len          r177, r176
-  Move         r178, r7
+  Const        r267, []
+  IterPrep     r271, r0
+  Len          r272, r271
+  Const        r273, 0
 L55:
-  LessInt      r179, r178, r177
-  JumpIfFalse  r179, L52
-  Index        r10, r176, r178
+  LessInt      r275, r273, r272
+  JumpIfFalse  r275, L52
+  Index        r11, r271, r273
   // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Index        r181, r10, r3
-  LessEq       r182, r151, r181
-  Index        r183, r10, r3
-  LessEq       r184, r183, r154
-  Move         r185, r182
-  JumpIfFalse  r185, L53
-  Move         r185, r184
+  Const        r277, "ss_quantity"
+  Index        r278, r11, r277
+  Const        r279, 61
+  LessEq       r280, r279, r278
+  Const        r281, "ss_quantity"
+  Index        r282, r11, r281
+  Const        r283, 80
+  LessEq       r284, r282, r283
+  Move         r285, r280
+  JumpIfFalse  r285, L53
+  Move         r285, r284
 L53:
-  JumpIfFalse  r185, L54
+  JumpIfFalse  r285, L54
   // select s.ss_net_paid)
-  Index        r186, r10, r39
+  Const        r286, "ss_net_paid"
+  Index        r287, r11, r286
   // avg(from s in store_sales
-  Append       r175, r175, r186
+  Append       r267, r267, r287
 L54:
-  AddInt       r178, r178, r12
+  Const        r289, 1
+  AddInt       r273, r273, r289
   Jump         L55
 L52:
-  Avg          r174, r175
+  Avg          r266, r267
 L51:
   // if count(from s in store_sales
-  Move         r189, r0
-  IterPrep     r190, r0
-  Len          r191, r190
-  Move         r192, r7
+  Const        r291, []
+  IterPrep     r294, r0
+  Len          r295, r294
+  Const        r296, 0
 L59:
-  LessInt      r193, r192, r191
-  JumpIfFalse  r193, L56
-  Index        r10, r190, r192
+  LessInt      r298, r296, r295
+  JumpIfFalse  r298, L56
+  Index        r11, r294, r296
   // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Index        r195, r10, r3
-  Const        r196, 81
-  LessEq       r197, r196, r195
-  Index        r198, r10, r3
-  Const        r199, 100
-  LessEq       r200, r198, r199
-  Move         r201, r197
-  JumpIfFalse  r201, L57
-  Move         r201, r200
+  Const        r300, "ss_quantity"
+  Index        r301, r11, r300
+  Const        r302, 81
+  LessEq       r303, r302, r301
+  Const        r304, "ss_quantity"
+  Index        r305, r11, r304
+  Const        r306, 100
+  LessEq       r307, r305, r306
+  Move         r308, r303
+  JumpIfFalse  r308, L57
+  Move         r308, r307
 L57:
-  JumpIfFalse  r201, L58
+  JumpIfFalse  r308, L58
   // if count(from s in store_sales
-  Append       r189, r189, r10
+  Append       r291, r291, r11
 L58:
-  AddInt       r192, r192, r12
+  Const        r310, 1
+  AddInt       r296, r296, r310
   Jump         L59
 L56:
-  Count        r203, r189
+  Count        r311, r291
   // select s) > 50 {
-  Const        r204, 50
-  LessInt      r205, r204, r203
+  Const        r312, 50
+  LessInt      r313, r312, r311
   // if count(from s in store_sales
-  JumpIfFalse  r205, L60
+  JumpIfFalse  r313, L60
   // avg(from s in store_sales
-  Move         r206, r0
-  IterPrep     r207, r0
-  Len          r208, r207
-  Move         r209, r7
+  Const        r314, []
+  IterPrep     r318, r0
+  Len          r319, r318
+  Const        r320, 0
 L64:
-  LessInt      r210, r209, r208
-  JumpIfFalse  r210, L61
-  Index        r10, r207, r209
+  LessInt      r322, r320, r319
+  JumpIfFalse  r322, L61
+  Index        r11, r318, r320
   // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Index        r212, r10, r3
-  LessEq       r213, r196, r212
-  Index        r214, r10, r3
-  LessEq       r215, r214, r199
-  Move         r216, r213
-  JumpIfFalse  r216, L62
-  Move         r216, r215
+  Const        r324, "ss_quantity"
+  Index        r325, r11, r324
+  Const        r326, 81
+  LessEq       r327, r326, r325
+  Const        r328, "ss_quantity"
+  Index        r329, r11, r328
+  Const        r330, 100
+  LessEq       r331, r329, r330
+  Move         r332, r327
+  JumpIfFalse  r332, L62
+  Move         r332, r331
 L62:
-  JumpIfFalse  r216, L63
+  JumpIfFalse  r332, L63
   // select s.ss_ext_discount_amt)
-  Index        r217, r10, r23
+  Const        r333, "ss_ext_discount_amt"
+  Index        r334, r11, r333
   // avg(from s in store_sales
-  Append       r206, r206, r217
+  Append       r314, r314, r334
 L63:
-  AddInt       r209, r209, r12
+  Const        r336, 1
+  AddInt       r320, r320, r336
   Jump         L64
 L61:
-  Avg          r220, r206
+  Avg          r338, r314
   // if count(from s in store_sales
   Jump         L65
 L60:
   // avg(from s in store_sales
-  Move         r221, r0
-  IterPrep     r222, r0
-  Len          r223, r222
-  Move         r224, r7
+  Const        r339, []
+  IterPrep     r343, r0
+  Len          r344, r343
+  Const        r345, 0
 L69:
-  LessInt      r225, r224, r223
-  JumpIfFalse  r225, L66
-  Index        r10, r222, r224
+  LessInt      r347, r345, r344
+  JumpIfFalse  r347, L66
+  Index        r11, r343, r345
   // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Index        r227, r10, r3
-  LessEq       r228, r196, r227
-  Index        r229, r10, r3
-  LessEq       r230, r229, r199
-  Move         r231, r228
-  JumpIfFalse  r231, L67
-  Move         r231, r230
+  Const        r349, "ss_quantity"
+  Index        r350, r11, r349
+  Const        r351, 81
+  LessEq       r352, r351, r350
+  Const        r353, "ss_quantity"
+  Index        r354, r11, r353
+  Const        r355, 100
+  LessEq       r356, r354, r355
+  Move         r357, r352
+  JumpIfFalse  r357, L67
+  Move         r357, r356
 L67:
-  JumpIfFalse  r231, L68
+  JumpIfFalse  r357, L68
   // select s.ss_net_paid)
-  Index        r232, r10, r39
+  Const        r358, "ss_net_paid"
+  Index        r359, r11, r358
   // avg(from s in store_sales
-  Append       r221, r221, r232
+  Append       r339, r339, r359
 L68:
-  AddInt       r224, r224, r12
+  Const        r361, 1
+  AddInt       r345, r345, r361
   Jump         L69
 L66:
-  Avg          r220, r221
+  Avg          r338, r339
 L65:
   // from r in reason
-  Move         r235, r0
-  // where r.r_reason_sk == 1
-  Const        r236, "r_reason_sk"
-  // bucket1: bucket1,
-  Const        r237, "bucket1"
-  // bucket2: bucket2,
-  Const        r238, "bucket2"
-  // bucket3: bucket3,
-  Const        r239, "bucket3"
-  // bucket4: bucket4,
-  Const        r240, "bucket4"
-  // bucket5: bucket5
-  Const        r241, "bucket5"
-  // from r in reason
-  IterPrep     r242, r1
-  Len          r243, r242
-  Move         r244, r7
+  Const        r363, []
+  IterPrep     r370, r1
+  Len          r371, r370
+  Const        r372, 0
 L72:
-  LessInt      r245, r244, r243
-  JumpIfFalse  r245, L70
-  Index        r247, r242, r244
+  LessInt      r374, r372, r371
+  JumpIfFalse  r374, L70
+  Index        r376, r370, r372
   // where r.r_reason_sk == 1
-  Index        r248, r247, r236
-  Equal        r249, r248, r12
-  JumpIfFalse  r249, L71
+  Const        r377, "r_reason_sk"
+  Index        r378, r376, r377
+  Const        r379, 1
+  Equal        r380, r378, r379
+  JumpIfFalse  r380, L71
   // bucket1: bucket1,
-  Move         r250, r237
+  Const        r381, "bucket1"
   // bucket2: bucket2,
-  Move         r251, r238
+  Const        r382, "bucket2"
   // bucket3: bucket3,
-  Move         r252, r239
+  Const        r383, "bucket3"
   // bucket4: bucket4,
-  Move         r253, r240
+  Const        r384, "bucket4"
   // bucket5: bucket5
-  Move         r254, r241
+  Const        r385, "bucket5"
   // bucket1: bucket1,
-  Move         r255, r250
-  Move         r256, r37
+  Move         r386, r381
+  Move         r387, r50
   // bucket2: bucket2,
-  Move         r257, r251
-  Move         r258, r83
+  Move         r388, r382
+  Move         r389, r122
   // bucket3: bucket3,
-  Move         r259, r252
-  Move         r260, r129
+  Move         r390, r383
+  Move         r391, r194
   // bucket4: bucket4,
-  Move         r261, r253
-  Move         r262, r174
+  Move         r392, r384
+  Move         r393, r266
   // bucket5: bucket5
-  Move         r263, r254
-  Move         r264, r220
+  Move         r394, r385
+  Move         r395, r338
   // select {
-  MakeMap      r265, 5, r255
+  MakeMap      r396, 5, r386
   // from r in reason
-  Append       r235, r235, r265
+  Append       r363, r363, r396
 L71:
-  AddInt       r244, r244, r12
+  Const        r398, 1
+  AddInt       r372, r372, r398
   Jump         L72
 L70:
   // json(result)
-  JSON         r235
-  // expect result == []
-  Equal        r268, r235, r0
-  Expect       r268
+  JSON         r363
+  // expect len(result) == 0
+  Len          r399, r363
+  Const        r400, 0
+  EqualInt     r401, r399, r400
+  Expect       r401
   Return       r0

--- a/tests/dataset/tpc-ds/q1.mochi
+++ b/tests/dataset/tpc-ds/q1.mochi
@@ -35,5 +35,5 @@ let result =
 json(result)
 
 test "TPCDS Q1 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q2.mochi
+++ b/tests/dataset/tpc-ds/q2.mochi
@@ -24,5 +24,5 @@ let result = []
 json(result)
 
 test "TPCDS Q2 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q3.mochi
+++ b/tests/dataset/tpc-ds/q3.mochi
@@ -21,5 +21,5 @@ let result =
 json(result)
 
 test "TPCDS Q3 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q4.mochi
+++ b/tests/dataset/tpc-ds/q4.mochi
@@ -78,5 +78,5 @@ let result =
 json(result)
 
 test "TPCDS Q4 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q5.mochi
+++ b/tests/dataset/tpc-ds/q5.mochi
@@ -117,5 +117,5 @@ let result =
 json(result)
 
 test "TPCDS Q5 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q6.mochi
+++ b/tests/dataset/tpc-ds/q6.mochi
@@ -34,5 +34,5 @@ let result =
 json(result)
 
 test "TPCDS Q6 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q7.mochi
+++ b/tests/dataset/tpc-ds/q7.mochi
@@ -27,5 +27,5 @@ let result =
 json(result)
 
 test "TPCDS Q7 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q8.mochi
+++ b/tests/dataset/tpc-ds/q8.mochi
@@ -11,5 +11,5 @@ let result = []
 json(result)
 
 test "TPCDS Q8 empty" {
-  expect result == []
+  expect len(result) == 0
 }

--- a/tests/dataset/tpc-ds/q9.mochi
+++ b/tests/dataset/tpc-ds/q9.mochi
@@ -81,5 +81,5 @@ let result =
 json(result)
 
 test "TPCDS Q9 empty" {
-  expect result == []
+  expect len(result) == 0
 }


### PR DESCRIPTION
## Summary
- disable constant deduplication in VM optimizer
- ensure constant registers are always emitted
- adjust TPC-DS queries 1-9 tests to check `len(result)`
- update IR output for TPC-DS queries

## Testing
- `go test ./...`
- `go run ./cmd/mochi test tests/dataset/tpc-ds/q6.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68621edfc3ec832084938156a838c2ff