### PR TITLE
Add First op to VM

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -117,6 +117,7 @@ from the disassembler:
 | `Append` | Append C to list B | `Append r0, r1, r2` |
 | `Str` | Convert value B to string | `Str r0, r1` |
 | `Input` | Read line from input | `Input r0` |
+| `First` | First element of list B | `First r0, r1` |
 | `Count` | Count elements in list/map B | `Count r0, r1` |
 | `Exists` | True if list/map/string B is non-empty | `Exists r0, r1` |
 | `Avg` | Average of numeric list B | `Avg r0, r1` |

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -79,6 +79,7 @@ const (
 	OpStr
 	OpUpper
 	OpInput
+	OpFirst
 	OpCount
 	OpExists
 	OpAvg
@@ -200,6 +201,8 @@ func (op Op) String() string {
 		return "Upper"
 	case OpInput:
 		return "Input"
+	case OpFirst:
+		return "First"
 	case OpCount:
 		return "Count"
 	case OpExists:
@@ -435,6 +438,8 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpInput:
 				fmt.Fprintf(&b, "%s", formatReg(ins.A))
+			case OpFirst:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpIterPrep:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpCount:
@@ -1106,6 +1111,13 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			line = strings.TrimRight(line, "\r\n")
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: line}
+		case OpFirst:
+			lst := fr.regs[ins.B]
+			if lst.Tag != ValueList || len(lst.List) == 0 {
+				fr.regs[ins.A] = Value{Tag: ValueNull}
+			} else {
+				fr.regs[ins.A] = lst.List[0]
+			}
 		case OpIterPrep:
 			src := fr.regs[ins.B]
 			switch src.Tag {
@@ -1922,7 +1934,7 @@ func (fc *funcCompiler) emit(pos lexer.Position, i Instr) {
 		fc.tags[i.A] = tagInt
 	case OpJSON, OpPrint, OpPrint2, OpPrintN:
 		// no result
-	case OpAppend, OpStr, OpUpper, OpInput:
+	case OpAppend, OpStr, OpUpper, OpInput, OpFirst:
 		fc.tags[i.A] = tagUnknown
 	case OpLoad:
 		fc.tags[i.A] = tagUnknown
@@ -2836,10 +2848,8 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 			return dst
 		case "first":
 			arg := fc.compileExpr(p.Call.Args[0])
-			zero := fc.newReg()
-			fc.emit(p.Pos, Instr{Op: OpConst, A: zero, Val: Value{Tag: ValueInt, Int: 0}})
 			dst := fc.newReg()
-			fc.emit(p.Pos, Instr{Op: OpIndex, A: dst, B: arg, C: zero})
+			fc.emit(p.Pos, Instr{Op: OpFirst, A: dst, B: arg})
 			return dst
 		case "substring":
 			str := fc.compileExpr(p.Call.Args[0])

--- a/tests/dataset/tpc-ds/out/q10.ir.out
+++ b/tests/dataset/tpc-ds/out/q10.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 10}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 10

--- a/tests/dataset/tpc-ds/out/q11.ir.out
+++ b/tests/dataset/tpc-ds/out/q11.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 11}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 11

--- a/tests/dataset/tpc-ds/out/q12.ir.out
+++ b/tests/dataset/tpc-ds/out/q12.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 12}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 12

--- a/tests/dataset/tpc-ds/out/q13.ir.out
+++ b/tests/dataset/tpc-ds/out/q13.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 13}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 13

--- a/tests/dataset/tpc-ds/out/q14.ir.out
+++ b/tests/dataset/tpc-ds/out/q14.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 14}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 14

--- a/tests/dataset/tpc-ds/out/q15.ir.out
+++ b/tests/dataset/tpc-ds/out/q15.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 15}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 15

--- a/tests/dataset/tpc-ds/out/q16.ir.out
+++ b/tests/dataset/tpc-ds/out/q16.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 16}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 16

--- a/tests/dataset/tpc-ds/out/q17.ir.out
+++ b/tests/dataset/tpc-ds/out/q17.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 17}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 17

--- a/tests/dataset/tpc-ds/out/q18.ir.out
+++ b/tests/dataset/tpc-ds/out/q18.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 18}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 18

--- a/tests/dataset/tpc-ds/out/q19.ir.out
+++ b/tests/dataset/tpc-ds/out/q19.ir.out
@@ -3,23 +3,20 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 19}]
   // let vals = from r in t select r.val
   Const        r1, []
-  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+  Const        r5, 0
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  Const        r10, "val"
+  Index        r11, r9, r10
+  Append       r1, r1, r11
   Jump         L1
 L0:
   // let result = first(vals)
-  Index        r14, r1, r6
+  First        r14, r1
   // json(result)
   JSON         r14
   // expect result == 19


### PR DESCRIPTION
## Summary
- enhance VM with new `First` instruction
- compile built-in `first` to `OpFirst`
- document opcode in README
- regenerate tpc-ds IR output for q10-q19

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68622ac2637483208eb0db139d8f82a5