### PR TITLE
Fix TPC‑DS sort syntax and add bool comparison

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6645,6 +6645,10 @@ func valueLess(a, b Value) bool {
 		if b.Tag == ValueStr {
 			return a.Str < b.Str
 		}
+	case ValueBool:
+		if b.Tag == ValueBool {
+			return !a.Bool && b.Bool
+		}
 	case ValueList:
 		if b.Tag == ValueList {
 			n := len(a.List)

--- a/tests/dataset/tpc-ds/out/q70.ir.out
+++ b/tests/dataset/tpc-ds/out/q70.ir.out
@@ -1,0 +1,198 @@
+func main (regs=174)
+  // let store = [
+  Const        r0, [{"s_county": "Orange", "s_state": "CA", "s_store_sk": 1}, {"s_county": "Orange", "s_state": "CA", "s_store_sk": 2}, {"s_county": "Travis", "s_state": "TX", "s_store_sk": 3}]
+  // let date_dim = [
+  Const        r1, [{"d_date_sk": 1, "d_month_seq": 1200}, {"d_date_sk": 2, "d_month_seq": 1201}]
+  // let store_sales = [
+  Const        r2, [{"ss_net_profit": 10, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_net_profit": 5, "ss_sold_date_sk": 1, "ss_store_sk": 2}, {"ss_net_profit": 20, "ss_sold_date_sk": 2, "ss_store_sk": 3}]
+  // let dms = 1200
+  Const        r3, 1200
+  // from ss in store_sales
+  Const        r4, []
+  MakeMap      r24, 0, r0
+  Const        r25, []
+  IterPrep     r27, r2
+  Len          r28, r27
+  Const        r29, 0
+L1:
+  LessInt      r30, r29, r28
+  JumpIfFalse  r30, L0
+  Index        r32, r27, r29
+  // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  IterPrep     r33, r1
+  Len          r34, r33
+  Const        r35, 0
+L2:
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L1
+  Index        r38, r33, r35
+  Const        r39, "d_date_sk"
+  Index        r40, r38, r39
+  Const        r41, "ss_sold_date_sk"
+  Index        r42, r32, r41
+  Equal        r43, r40, r42
+  JumpIfFalse  r43, L2
+  // join s in store on s.s_store_sk == ss.ss_store_sk
+  IterPrep     r44, r0
+  Len          r45, r44
+  Const        r46, 0
+L6:
+  LessInt      r47, r46, r45
+  JumpIfFalse  r47, L2
+  Index        r49, r44, r46
+  Const        r50, "s_store_sk"
+  Index        r51, r49, r50
+  Const        r52, "ss_store_sk"
+  Index        r53, r32, r52
+  Equal        r54, r51, r53
+  JumpIfFalse  r54, L3
+  // where d.d_month_seq >= dms && d.d_month_seq <= dms + 11
+  Const        r55, "d_month_seq"
+  Index        r56, r38, r55
+  Const        r58, 1211
+  LessEq       r59, r3, r56
+  Const        r60, "d_month_seq"
+  Index        r61, r38, r60
+  LessEq       r62, r61, r58
+  Move         r63, r59
+  JumpIfFalse  r63, L4
+  Move         r63, r62
+L4:
+  JumpIfFalse  r63, L3
+  // from ss in store_sales
+  Const        r64, "ss"
+  Move         r65, r32
+  Const        r66, "d"
+  Move         r67, r38
+  Const        r68, "s"
+  Move         r69, r49
+  MakeMap      r70, 3, r64
+  // group by { state: s.s_state, county: s.s_county } into g
+  Const        r71, "state"
+  Const        r72, "s_state"
+  Index        r73, r49, r72
+  Const        r74, "county"
+  Const        r75, "s_county"
+  Index        r76, r49, r75
+  Move         r77, r71
+  Move         r78, r73
+  Move         r79, r74
+  Move         r80, r76
+  MakeMap      r81, 2, r77
+  Str          r82, r81
+  In           r83, r82, r24
+  JumpIfTrue   r83, L5
+  // from ss in store_sales
+  Const        r84, []
+  Const        r85, "__group__"
+  Const        r86, true
+  Const        r87, "key"
+  // group by { state: s.s_state, county: s.s_county } into g
+  Move         r88, r81
+  // from ss in store_sales
+  Const        r89, "items"
+  Move         r90, r84
+  Const        r91, "count"
+  Const        r92, 0
+  Move         r93, r85
+  Move         r94, r86
+  Move         r95, r87
+  Move         r96, r88
+  Move         r97, r89
+  Move         r98, r90
+  Move         r99, r91
+  Move         r100, r92
+  MakeMap      r101, 4, r93
+  SetIndex     r24, r82, r101
+  Append       r25, r25, r101
+L5:
+  Const        r103, "items"
+  Index        r104, r24, r82
+  Index        r105, r104, r103
+  Append       r106, r105, r70
+  SetIndex     r104, r103, r106
+  Const        r107, "count"
+  Index        r108, r104, r107
+  Const        r109, 1
+  AddInt       r110, r108, r109
+  SetIndex     r104, r107, r110
+L3:
+  // join s in store on s.s_store_sk == ss.ss_store_sk
+  Const        r111, 1
+  AddInt       r46, r46, r111
+  Jump         L6
+L0:
+  // from ss in store_sales
+  Const        r114, 0
+  Len          r116, r25
+L10:
+  LessInt      r117, r114, r116
+  JumpIfFalse  r117, L7
+  Index        r119, r25, r114
+  // s_state: g.key.state,
+  Const        r120, "s_state"
+  Const        r121, "key"
+  Index        r122, r119, r121
+  Const        r123, "state"
+  Index        r124, r122, r123
+  // s_county: g.key.county,
+  Const        r125, "s_county"
+  Const        r126, "key"
+  Index        r127, r119, r126
+  Const        r128, "county"
+  Index        r129, r127, r128
+  // total_sum: sum(from x in g select x.ss.ss_net_profit)
+  Const        r130, "total_sum"
+  Const        r131, []
+  IterPrep     r134, r119
+  Len          r135, r134
+  Const        r136, 0
+L9:
+  LessInt      r138, r136, r135
+  JumpIfFalse  r138, L8
+  Index        r140, r134, r136
+  Const        r141, "ss"
+  Index        r142, r140, r141
+  Const        r143, "ss_net_profit"
+  Index        r144, r142, r143
+  Append       r131, r131, r144
+  Const        r146, 1
+  AddInt       r136, r136, r146
+  Jump         L9
+L8:
+  Sum          r147, r131
+  // s_state: g.key.state,
+  Move         r148, r120
+  Move         r149, r124
+  // s_county: g.key.county,
+  Move         r150, r125
+  Move         r151, r129
+  // total_sum: sum(from x in g select x.ss.ss_net_profit)
+  Move         r152, r130
+  Move         r153, r147
+  // select {
+  MakeMap      r154, 3, r148
+  // sort by [g.key.state, g.key.county]
+  Const        r155, "key"
+  Index        r156, r119, r155
+  Const        r157, "state"
+  Index        r159, r156, r157
+  Const        r160, "key"
+  MakeList     r166, 2, r159
+  // from ss in store_sales
+  Move         r167, r154
+  MakeList     r168, 2, r166
+  Append       r4, r4, r168
+  Const        r170, 1
+  AddInt       r114, r114, r170
+  Jump         L10
+L7:
+  // sort by [g.key.state, g.key.county]
+  Sort         r4, r4
+  // json(result)
+  JSON         r4
+  // expect result == [
+  Const        r172, [{"s_county": "Orange", "s_state": "CA", "total_sum": 15}, {"s_county": "Travis", "s_state": "TX", "total_sum": 20}]
+  Equal        r173, r4, r172
+  Expect       r173
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q79.ir.out
+++ b/tests/dataset/tpc-ds/out/q79.ir.out
@@ -1,0 +1,481 @@
+func main (regs=398)
+L20:
+  // let date_dim = [
+  Const        r0, [{"d_date_sk": 1, "d_dow": 1, "d_year": 1999}]
+  // let store = [
+  Const        r1, [{"s_city": "CityA", "s_number_employees": 250, "s_store_sk": 1}]
+  // let household_demographics = [
+  Const        r2, [{"hd_demo_sk": 1, "hd_dep_count": 2, "hd_vehicle_count": 1}]
+  // let store_sales = [
+  Const        r3, [{"ss_coupon_amt": 5, "ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_net_profit": 10, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}]
+  // let customer = [
+  Const        r4, [{"c_customer_sk": 1, "c_first_name": "Alice", "c_last_name": "Smith"}]
+  // from ss in store_sales
+  Const        r5, []
+  MakeMap      r28, 0, r0
+  Const        r29, []
+  IterPrep     r31, r3
+  Len          r32, r31
+  Const        r33, 0
+L1:
+  LessInt      r34, r33, r32
+  JumpIfFalse  r34, L0
+  Index        r36, r31, r33
+  // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  IterPrep     r37, r0
+  Len          r38, r37
+  Const        r39, 0
+L2:
+  LessInt      r40, r39, r38
+  JumpIfFalse  r40, L1
+  Index        r42, r37, r39
+  Const        r43, "d_date_sk"
+  Index        r44, r42, r43
+  Const        r45, "ss_sold_date_sk"
+  Index        r46, r36, r45
+  Equal        r47, r44, r46
+  JumpIfFalse  r47, L2
+  // join s in store on s.s_store_sk == ss.ss_store_sk
+  IterPrep     r48, r1
+  Len          r49, r48
+  Const        r50, 0
+L13:
+  LessInt      r51, r50, r49
+  JumpIfFalse  r51, L2
+  Index        r53, r48, r50
+  Const        r54, "s_store_sk"
+  Index        r55, r53, r54
+  Const        r56, "ss_store_sk"
+  Index        r57, r36, r56
+  Equal        r58, r55, r57
+  JumpIfFalse  r58, L3
+  // join hd in household_demographics on hd.hd_demo_sk == ss.ss_hdemo_sk
+  IterPrep     r59, r2
+  Len          r60, r59
+  Const        r61, 0
+L12:
+  LessInt      r62, r61, r60
+  JumpIfFalse  r62, L3
+  Index        r64, r59, r61
+  Const        r65, "hd_demo_sk"
+  Index        r66, r64, r65
+  Const        r67, "ss_hdemo_sk"
+  Index        r68, r36, r67
+  Equal        r69, r66, r68
+  JumpIfFalse  r69, L4
+  // where (hd.hd_dep_count == 2 || hd.hd_vehicle_count > 1) &&
+  Const        r70, "hd_dep_count"
+  Index        r71, r64, r70
+  Const        r72, "hd_vehicle_count"
+  Index        r73, r64, r72
+  Const        r74, 1
+  Less         r75, r74, r73
+  Const        r76, 2
+  Equal        r78, r71, r76
+  JumpIfTrue   r78, L5
+  Move         r78, r75
+L5:
+  // s.s_number_employees >= 200 && s.s_number_employees <= 295
+  Const        r79, "s_number_employees"
+  Index        r80, r53, r79
+  Const        r81, 200
+  LessEq       r82, r81, r80
+  Const        r83, "s_number_employees"
+  Index        r84, r53, r83
+  Const        r85, 295
+  LessEq       r86, r84, r85
+  // d.d_dow == 1 &&
+  Const        r87, "d_dow"
+  Index        r88, r42, r87
+  Const        r89, 1
+  Equal        r90, r88, r89
+  // where (hd.hd_dep_count == 2 || hd.hd_vehicle_count > 1) &&
+  Move         r91, r78
+  JumpIfFalse  r91, L6
+L6:
+  // d.d_dow == 1 &&
+  Move         r92, r90
+  JumpIfFalse  r92, L7
+  // (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
+  Const        r93, "d_year"
+  Index        r94, r42, r93
+  Const        r95, 1998
+  Equal        r96, r94, r95
+  Const        r97, "d_year"
+  Index        r98, r42, r97
+  Const        r99, 1999
+  Equal        r100, r98, r99
+  Const        r101, "d_year"
+  Index        r102, r42, r101
+  Const        r103, 2000
+  Equal        r104, r102, r103
+  Move         r105, r96
+  JumpIfTrue   r105, L8
+L8:
+  Move         r106, r100
+  JumpIfTrue   r106, L7
+L7:
+  Move         r107, r104
+  JumpIfFalse  r107, L9
+L9:
+  // s.s_number_employees >= 200 && s.s_number_employees <= 295
+  Move         r108, r82
+  JumpIfFalse  r108, L10
+  Move         r108, r86
+L10:
+  // where (hd.hd_dep_count == 2 || hd.hd_vehicle_count > 1) &&
+  JumpIfFalse  r108, L4
+  // from ss in store_sales
+  Const        r109, "ss"
+  Move         r110, r36
+  Const        r111, "d"
+  Move         r112, r42
+  Const        r113, "s"
+  Move         r114, r53
+  Const        r115, "hd"
+  Move         r116, r64
+  MakeMap      r117, 4, r109
+  // group by { ticket: ss.ss_ticket_number, customer_sk: ss.ss_customer_sk, city: s.s_city } into g
+  Const        r118, "ticket"
+  Const        r119, "ss_ticket_number"
+  Index        r120, r36, r119
+  Const        r121, "customer_sk"
+  Const        r122, "ss_customer_sk"
+  Index        r123, r36, r122
+  Const        r124, "city"
+  Const        r125, "s_city"
+  Index        r126, r53, r125
+  Move         r127, r118
+  Move         r128, r120
+  Move         r129, r121
+  Move         r130, r123
+  Move         r131, r124
+  Move         r132, r126
+  MakeMap      r133, 3, r127
+  Str          r134, r133
+  In           r135, r134, r28
+  JumpIfTrue   r135, L11
+  // from ss in store_sales
+  Const        r136, []
+  Const        r137, "__group__"
+  Const        r138, true
+  Const        r139, "key"
+  // group by { ticket: ss.ss_ticket_number, customer_sk: ss.ss_customer_sk, city: s.s_city } into g
+  Move         r140, r133
+  // from ss in store_sales
+  Const        r141, "items"
+  Move         r142, r136
+  Const        r143, "count"
+  Const        r144, 0
+  Move         r145, r137
+  Move         r146, r138
+  Move         r147, r139
+  Move         r148, r140
+  Move         r149, r141
+  Move         r150, r142
+  Move         r151, r143
+  Move         r152, r144
+  MakeMap      r153, 4, r145
+  SetIndex     r28, r134, r153
+  Append       r29, r29, r153
+L11:
+  Const        r155, "items"
+  Index        r156, r28, r134
+  Index        r157, r156, r155
+  Append       r158, r157, r117
+  SetIndex     r156, r155, r158
+  Const        r159, "count"
+  Index        r160, r156, r159
+  Const        r161, 1
+  AddInt       r162, r160, r161
+  SetIndex     r156, r159, r162
+L4:
+  // join hd in household_demographics on hd.hd_demo_sk == ss.ss_hdemo_sk
+  Const        r163, 1
+  AddInt       r61, r61, r163
+  Jump         L12
+L3:
+  // join s in store on s.s_store_sk == ss.ss_store_sk
+  Const        r164, 1
+  AddInt       r50, r50, r164
+  Jump         L13
+L0:
+  // from ss in store_sales
+  Const        r167, 0
+  Len          r169, r29
+L19:
+  LessInt      r170, r167, r169
+  JumpIfFalse  r170, L14
+  Index        r172, r29, r167
+  // select { key: g.key, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
+  Const        r173, "key"
+  Const        r174, "key"
+  Index        r175, r172, r174
+  Const        r176, "amt"
+  IterPrep     r180, r172
+  Len          r181, r180
+  Const        r182, 0
+L16:
+  LessInt      r184, r182, r181
+  JumpIfFalse  r184, L15
+  Const        r192, 1
+  AddInt       r182, r182, r192
+  Jump         L16
+L15:
+  Const        r193, 0
+  Const        r194, "profit"
+  Const        r195, []
+  IterPrep     r198, r172
+  Len          r199, r198
+  Const        r200, 0
+L18:
+  LessInt      r202, r200, r199
+  JumpIfFalse  r202, L17
+  Index        r186, r198, r200
+  Const        r204, "ss"
+  Index        r205, r186, r204
+  Const        r206, "ss_net_profit"
+  Index        r207, r205, r206
+  Append       r195, r195, r207
+  Const        r209, 1
+  AddInt       r200, r200, r209
+  Jump         L18
+L17:
+  Sum          r210, r195
+  Move         r211, r173
+  Move         r212, r175
+  Move         r213, r176
+  Move         r214, r193
+  Move         r215, r194
+  Move         r216, r210
+  MakeMap      r217, 3, r211
+  // from ss in store_sales
+  Append       r5, r5, r217
+  Const        r219, 1
+  AddInt       r167, r167, r219
+  Jump         L19
+L14:
+  // from a in agg
+  Const        r220, []
+  IterPrep     r221, r5
+  Len          r222, r221
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  IterPrep     r223, r4
+  Len          r224, r223
+  // from a in agg
+  Const        r225, 0
+  EqualInt     r226, r222, r225
+  JumpIfTrue   r226, L20
+  EqualInt     r227, r224, r225
+  JumpIfTrue   r227, L20
+  LessEq       r228, r224, r222
+  JumpIfFalse  r228, L21
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  MakeMap      r229, 0, r0
+  Const        r230, 0
+L24:
+  LessInt      r231, r230, r224
+  JumpIfFalse  r231, L22
+  Index        r232, r223, r230
+  Move         r233, r232
+  Const        r234, "c_customer_sk"
+  Index        r235, r233, r234
+  Index        r236, r229, r235
+  Const        r237, nil
+  NotEqual     r238, r236, r237
+  JumpIfTrue   r238, L23
+  MakeList     r239, 0, r0
+  SetIndex     r229, r235, r239
+L23:
+  Index        r236, r229, r235
+  Append       r240, r236, r232
+  SetIndex     r229, r235, r240
+  Const        r241, 1
+  AddInt       r230, r230, r241
+  Jump         L24
+L22:
+  // from a in agg
+  Const        r242, 0
+L27:
+  LessInt      r243, r242, r222
+  JumpIfFalse  r243, L20
+  Index        r245, r221, r242
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  Const        r246, "key"
+  Index        r247, r245, r246
+  Const        r248, "customer_sk"
+  Index        r249, r247, r248
+  // from a in agg
+  Index        r250, r229, r249
+  Const        r251, nil
+  NotEqual     r252, r250, r251
+  JumpIfFalse  r252, L25
+  Len          r253, r250
+  Const        r254, 0
+L26:
+  LessInt      r255, r254, r253
+  JumpIfFalse  r255, L25
+  Index        r233, r250, r254
+  // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
+  Const        r257, "c_last_name"
+  Const        r258, "c_last_name"
+  Index        r259, r233, r258
+  Const        r260, "c_first_name"
+  Const        r261, "c_first_name"
+  Index        r262, r233, r261
+  Const        r263, "s_city"
+  Const        r264, "key"
+  Index        r265, r245, r264
+  Const        r266, "city"
+  Index        r267, r265, r266
+  Const        r268, "ss_ticket_number"
+  Const        r269, "key"
+  Index        r270, r245, r269
+  Const        r271, "ticket"
+  Index        r272, r270, r271
+  Const        r273, "amt"
+  Const        r274, "amt"
+  Index        r275, r245, r274
+  Const        r276, "profit"
+  Const        r277, "profit"
+  Index        r278, r245, r277
+  Move         r279, r257
+  Move         r280, r259
+  Move         r281, r260
+  Move         r282, r262
+  Move         r283, r263
+  Move         r284, r267
+  Move         r285, r268
+  Move         r286, r272
+  Move         r287, r273
+  Move         r288, r275
+  Move         r289, r276
+  Move         r290, r278
+  MakeMap      r291, 6, r279
+  // sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
+  Const        r292, "c_last_name"
+  Index        r294, r233, r292
+  Const        r295, "c_first_name"
+  Index        r296, r233, r295
+  Move         r297, r296
+  MakeList     r307, 4, r294
+  // from a in agg
+  Move         r308, r291
+  MakeList     r309, 2, r307
+  Append       r220, r220, r309
+  Jump         L26
+L25:
+  Const        r312, 1
+  AddInt       r242, r242, r312
+  Jump         L27
+L21:
+  MakeMap      r313, 0, r0
+  Const        r314, 0
+L30:
+  LessInt      r315, r314, r222
+  JumpIfFalse  r315, L28
+  Index        r316, r221, r314
+  Move         r245, r316
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  Const        r317, "key"
+  Index        r318, r245, r317
+  Const        r319, "customer_sk"
+  Index        r320, r318, r319
+  // from a in agg
+  Index        r321, r313, r320
+  Const        r322, nil
+  NotEqual     r323, r321, r322
+  JumpIfTrue   r323, L29
+  MakeList     r324, 0, r0
+  SetIndex     r313, r320, r324
+L29:
+  Index        r321, r313, r320
+  Append       r325, r321, r316
+  SetIndex     r313, r320, r325
+  Const        r326, 1
+  AddInt       r314, r314, r326
+  Jump         L30
+L28:
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  Const        r327, 0
+L34:
+  LessInt      r328, r327, r224
+  JumpIfFalse  r328, L31
+  Index        r233, r223, r327
+  Const        r330, "c_customer_sk"
+  Index        r331, r233, r330
+  Index        r332, r313, r331
+  Const        r333, nil
+  NotEqual     r334, r332, r333
+  JumpIfFalse  r334, L32
+  Len          r335, r332
+  Const        r336, 0
+L33:
+  LessInt      r337, r336, r335
+  JumpIfFalse  r337, L32
+  Index        r245, r332, r336
+  // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
+  Const        r339, "c_last_name"
+  Const        r340, "c_last_name"
+  Index        r341, r233, r340
+  Const        r342, "c_first_name"
+  Const        r343, "c_first_name"
+  Index        r344, r233, r343
+  Const        r345, "s_city"
+  Const        r346, "key"
+  Index        r347, r245, r346
+  Const        r348, "city"
+  Index        r349, r347, r348
+  Const        r350, "ss_ticket_number"
+  Const        r351, "key"
+  Index        r352, r245, r351
+  Const        r353, "ticket"
+  Index        r354, r352, r353
+  Const        r355, "amt"
+  Const        r356, "amt"
+  Index        r357, r245, r356
+  Const        r358, "profit"
+  Const        r359, "profit"
+  Index        r360, r245, r359
+  Move         r361, r339
+  Move         r362, r341
+  Move         r363, r342
+  Move         r364, r344
+  Move         r365, r345
+  Move         r366, r349
+  Move         r367, r350
+  Move         r368, r354
+  Move         r369, r355
+  Move         r370, r357
+  Move         r371, r358
+  Move         r372, r360
+  MakeMap      r373, 6, r361
+  // sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
+  Const        r374, "c_last_name"
+  Index        r376, r233, r374
+  Const        r377, "c_first_name"
+  Index        r378, r233, r377
+  Move         r379, r378
+  MakeList     r389, 4, r376
+  // from a in agg
+  Move         r390, r373
+  MakeList     r391, 2, r389
+  Append       r220, r220, r391
+  // join c in customer on c.c_customer_sk == a.key.customer_sk
+  Const        r393, 1
+  AddInt       r336, r336, r393
+  Jump         L33
+L32:
+  Const        r394, 1
+  AddInt       r327, r327, r394
+  Jump         L34
+L31:
+  // sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
+  Sort         r220, r220
+  // json(result)
+  JSON         r220
+  // expect result == [
+  Const        r396, [{"amt": 5, "c_first_name": "Alice", "c_last_name": "Smith", "profit": 10, "s_city": "CityA", "ss_ticket_number": 1}]
+  Equal        r397, r220, r396
+  Expect       r397
+  Return       r0

--- a/tests/dataset/tpc-ds/q70.mochi
+++ b/tests/dataset/tpc-ds/q70.mochi
@@ -23,7 +23,7 @@ let result =
   join s in store on s.s_store_sk == ss.ss_store_sk
   where d.d_month_seq >= dms && d.d_month_seq <= dms + 11
   group by { state: s.s_state, county: s.s_county } into g
-  sort by g.key.state, g.key.county
+  sort by [g.key.state, g.key.county]
   select {
     s_state: g.key.state,
     s_county: g.key.county,

--- a/tests/dataset/tpc-ds/q79.mochi
+++ b/tests/dataset/tpc-ds/q79.mochi
@@ -33,7 +33,7 @@ let agg =
 let result =
   from a in agg
   join c in customer on c.c_customer_sk == a.key.customer_sk
-  sort by c.c_last_name, c.c_first_name, a.key.city, a.profit
+  sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
   select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
 
 json(result)


### PR DESCRIPTION
## Summary
- allow VM sorting of boolean values
- fix `sort by` syntax in q70 and q79
- add IR output for q70 and q79

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68622b873c848320a2fc07eaf657b1f4