### PR TITLE
Add runnable TPC-DS queries q30–q39

### DIFF
--- a/tests/dataset/tpc-ds/out/q30.ir.out
+++ b/tests/dataset/tpc-ds/out/q30.ir.out
@@ -1,0 +1,370 @@
+func main (regs=324)
+  // let web_returns = [
+  Const        r0, [{"wr_return_amt": 100, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}, {"wr_return_amt": 30, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 2, "wr_returning_customer_sk": 2}, {"wr_return_amt": 50, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}]
+  // let date_dim = [
+  Const        r1, [{"d_date_sk": 1, "d_year": 2000}]
+  // let customer_address = [
+  Const        r2, [{"ca_address_sk": 1, "ca_state": "CA"}, {"ca_address_sk": 2, "ca_state": "CA"}]
+  // let customer = [
+  Const        r3, [{"c_current_addr_sk": 1, "c_customer_id": "C1", "c_customer_sk": 1, "c_first_name": "John", "c_last_name": "Doe"}, {"c_current_addr_sk": 2, "c_customer_id": "C2", "c_customer_sk": 2, "c_first_name": "Jane", "c_last_name": "Smith"}]
+  // from wr in web_returns
+  Const        r4, []
+  MakeMap      r19, 0, r0
+  Const        r20, []
+  IterPrep     r22, r0
+  Len          r23, r22
+  Const        r24, 0
+L1:
+  LessInt      r25, r24, r23
+  JumpIfFalse  r25, L0
+  Index        r27, r22, r24
+  // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
+  IterPrep     r28, r1
+  Len          r29, r28
+  Const        r30, 0
+L2:
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L1
+  Index        r33, r28, r30
+  Const        r34, "wr_returned_date_sk"
+  Index        r35, r27, r34
+  Const        r36, "d_date_sk"
+  Index        r37, r33, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L2
+  // join ca in customer_address on wr.wr_returning_addr_sk == ca.ca_address_sk
+  IterPrep     r39, r2
+  Len          r40, r39
+  Const        r41, 0
+L6:
+  LessInt      r42, r41, r40
+  JumpIfFalse  r42, L2
+  Index        r44, r39, r41
+  Const        r45, "wr_returning_addr_sk"
+  Index        r46, r27, r45
+  Const        r47, "ca_address_sk"
+  Index        r48, r44, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L3
+  // where d.d_year == 2000 && ca.ca_state == "CA"
+  Const        r50, "d_year"
+  Index        r51, r33, r50
+  Const        r52, 2000
+  Equal        r53, r51, r52
+  Const        r54, "ca_state"
+  Index        r55, r44, r54
+  Const        r56, "CA"
+  Equal        r57, r55, r56
+  Move         r58, r53
+  JumpIfFalse  r58, L4
+  Move         r58, r57
+L4:
+  JumpIfFalse  r58, L3
+  // from wr in web_returns
+  Const        r59, "wr"
+  Move         r60, r27
+  Const        r61, "d"
+  Move         r62, r33
+  Const        r63, "ca"
+  Move         r64, r44
+  MakeMap      r65, 3, r59
+  // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
+  Const        r66, "cust"
+  Const        r67, "wr_returning_customer_sk"
+  Index        r68, r27, r67
+  Const        r69, "state"
+  Const        r70, "ca_state"
+  Index        r71, r44, r70
+  Move         r72, r66
+  Move         r73, r68
+  Move         r74, r69
+  Move         r75, r71
+  MakeMap      r76, 2, r72
+  Str          r77, r76
+  In           r78, r77, r19
+  JumpIfTrue   r78, L5
+  // from wr in web_returns
+  Const        r79, []
+  Const        r80, "__group__"
+  Const        r81, true
+  Const        r82, "key"
+  // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
+  Move         r83, r76
+  // from wr in web_returns
+  Const        r84, "items"
+  Move         r85, r79
+  Const        r86, "count"
+  Const        r87, 0
+  Move         r88, r80
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  Move         r92, r84
+  Move         r93, r85
+  Move         r94, r86
+  Move         r95, r87
+  MakeMap      r96, 4, r88
+  SetIndex     r19, r77, r96
+  Append       r20, r20, r96
+L5:
+  Const        r98, "items"
+  Index        r99, r19, r77
+  Index        r100, r99, r98
+  Append       r101, r100, r65
+  SetIndex     r99, r98, r101
+  Const        r102, "count"
+  Index        r103, r99, r102
+  Const        r104, 1
+  AddInt       r105, r103, r104
+  SetIndex     r99, r102, r105
+L3:
+  // join ca in customer_address on wr.wr_returning_addr_sk == ca.ca_address_sk
+  Const        r106, 1
+  AddInt       r41, r41, r106
+  Jump         L6
+L0:
+  // from wr in web_returns
+  Const        r109, 0
+  Len          r111, r20
+L10:
+  LessInt      r112, r109, r111
+  JumpIfFalse  r112, L7
+  Index        r114, r20, r109
+  // ctr_customer_sk: g.key.cust,
+  Const        r115, "ctr_customer_sk"
+  Const        r116, "key"
+  Index        r117, r114, r116
+  Const        r118, "cust"
+  Index        r119, r117, r118
+  // ctr_state: g.key.state,
+  Const        r120, "ctr_state"
+  Const        r121, "key"
+  Index        r122, r114, r121
+  Const        r123, "state"
+  Index        r124, r122, r123
+  // ctr_total_return: sum(from x in g select x.wr_return_amt)
+  Const        r125, "ctr_total_return"
+  Const        r126, []
+  IterPrep     r128, r114
+  Len          r129, r128
+  Const        r130, 0
+L9:
+  LessInt      r132, r130, r129
+  JumpIfFalse  r132, L8
+  Index        r134, r128, r130
+  Const        r135, "wr_return_amt"
+  Index        r136, r134, r135
+  Append       r126, r126, r136
+  Const        r138, 1
+  AddInt       r130, r130, r138
+  Jump         L9
+L8:
+  Sum          r139, r126
+  // ctr_customer_sk: g.key.cust,
+  Move         r140, r115
+  Move         r141, r119
+  // ctr_state: g.key.state,
+  Move         r142, r120
+  Move         r143, r124
+  // ctr_total_return: sum(from x in g select x.wr_return_amt)
+  Move         r144, r125
+  Move         r145, r139
+  // select {
+  MakeMap      r146, 3, r140
+  // from wr in web_returns
+  Append       r4, r4, r146
+  Jump         L10
+L7:
+  // from ctr in customer_total_return
+  Const        r149, []
+  IterPrep     r155, r4
+  Len          r156, r155
+  Const        r157, 0
+  MakeMap      r158, 0, r0
+  Const        r159, []
+L13:
+  LessInt      r161, r157, r156
+  JumpIfFalse  r161, L11
+  Index        r162, r155, r157
+  Move         r163, r162
+  // group by ctr.ctr_state into g
+  Const        r164, "ctr_state"
+  Index        r165, r163, r164
+  Str          r166, r165
+  In           r167, r166, r158
+  JumpIfTrue   r167, L12
+  // from ctr in customer_total_return
+  Const        r168, []
+  Const        r169, "__group__"
+  Const        r170, true
+  Const        r171, "key"
+  // group by ctr.ctr_state into g
+  Move         r172, r165
+  // from ctr in customer_total_return
+  Const        r173, "items"
+  Move         r174, r168
+  Const        r175, "count"
+  Const        r176, 0
+  Move         r177, r169
+  Move         r178, r170
+  Move         r179, r171
+  Move         r180, r172
+  Move         r181, r173
+  Move         r182, r174
+  Move         r183, r175
+  Move         r184, r176
+  MakeMap      r185, 4, r177
+  SetIndex     r158, r166, r185
+  Append       r159, r159, r185
+L12:
+  Const        r187, "items"
+  Index        r188, r158, r166
+  Index        r189, r188, r187
+  Append       r190, r189, r162
+  SetIndex     r188, r187, r190
+  Const        r191, "count"
+  Index        r192, r188, r191
+  Const        r193, 1
+  AddInt       r194, r192, r193
+  SetIndex     r188, r191, r194
+  Const        r195, 1
+  AddInt       r157, r157, r195
+  Jump         L13
+L11:
+  Const        r196, 0
+  Len          r198, r159
+L17:
+  LessInt      r199, r196, r198
+  JumpIfFalse  r199, L14
+  Index        r114, r159, r196
+  // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
+  Const        r201, "state"
+  Const        r202, "key"
+  Index        r203, r114, r202
+  Const        r204, "avg_return"
+  Const        r205, []
+  IterPrep     r207, r114
+  Len          r208, r207
+  Const        r209, 0
+L16:
+  LessInt      r211, r209, r208
+  JumpIfFalse  r211, L15
+  Index        r134, r207, r209
+  Const        r213, "ctr_total_return"
+  Index        r214, r134, r213
+  Append       r205, r205, r214
+  Jump         L16
+L15:
+  Avg          r217, r205
+  Move         r218, r201
+  Move         r219, r203
+  Move         r220, r204
+  Move         r221, r217
+  MakeMap      r222, 2, r218
+  // from ctr in customer_total_return
+  Append       r149, r149, r222
+  Const        r224, 1
+  AddInt       r196, r196, r224
+  Jump         L17
+L14:
+  // from ctr in customer_total_return
+  Const        r225, []
+  IterPrep     r236, r4
+  Len          r237, r236
+  Const        r238, 0
+L24:
+  LessInt      r240, r238, r237
+  JumpIfFalse  r240, L18
+  Index        r163, r236, r238
+  // join avg in avg_by_state on ctr.ctr_state == avg.state
+  IterPrep     r242, r149
+  Len          r243, r242
+  Const        r256, 0
+L23:
+  LessInt      r258, r256, r243
+  JumpIfFalse  r258, L19
+  Index        r260, r242, r256
+  Const        r261, "ctr_state"
+  Index        r262, r163, r261
+  Const        r263, "state"
+  Index        r264, r260, r263
+  Equal        r265, r262, r264
+  JumpIfFalse  r265, L20
+  // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
+  IterPrep     r266, r3
+  Len          r267, r266
+  Const        r280, 0
+L22:
+  LessInt      r282, r280, r267
+  JumpIfFalse  r282, L20
+  Index        r284, r266, r280
+  Const        r285, "ctr_customer_sk"
+  Index        r286, r163, r285
+  Const        r287, "c_customer_sk"
+  Index        r288, r284, r287
+  Equal        r289, r286, r288
+  JumpIfFalse  r289, L21
+  // where ctr.ctr_total_return > avg.avg_return * 1.2
+  Const        r290, "ctr_total_return"
+  Index        r291, r163, r290
+  Const        r292, "avg_return"
+  Index        r293, r260, r292
+  Const        r294, 1.2
+  MulFloat     r295, r293, r294
+  LessFloat    r296, r295, r291
+  JumpIfFalse  r296, L21
+  // c_customer_id: c.c_customer_id,
+  Const        r297, "c_customer_id"
+  Const        r298, "c_customer_id"
+  Index        r299, r284, r298
+  // c_first_name: c.c_first_name,
+  Const        r300, "c_first_name"
+  Const        r301, "c_first_name"
+  Index        r302, r284, r301
+  // c_last_name: c.c_last_name,
+  Const        r303, "c_last_name"
+  Const        r304, "c_last_name"
+  Index        r305, r284, r304
+  // ctr_total_return: ctr.ctr_total_return
+  Const        r306, "ctr_total_return"
+  Const        r307, "ctr_total_return"
+  Index        r308, r163, r307
+  // c_customer_id: c.c_customer_id,
+  Move         r309, r297
+  Move         r310, r299
+  // c_first_name: c.c_first_name,
+  Move         r311, r300
+  Move         r312, r302
+  // c_last_name: c.c_last_name,
+  Move         r313, r303
+  Move         r314, r305
+  // ctr_total_return: ctr.ctr_total_return
+  Move         r315, r306
+  Move         r316, r308
+  // select {
+  MakeMap      r317, 4, r309
+  // from ctr in customer_total_return
+  Append       r225, r225, r317
+L21:
+  // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
+  Const        r319, 1
+  Add          r280, r280, r319
+  Jump         L22
+L20:
+  // join avg in avg_by_state on ctr.ctr_state == avg.state
+  Const        r320, 1
+  Add          r256, r256, r320
+  Jump         L23
+L19:
+  // from ctr in customer_total_return
+  Const        r321, 1
+  AddInt       r238, r238, r321
+  Jump         L24
+L18:
+  // json(result)
+  JSON         r225
+  // expect result == [{c_customer_id: "C1", c_first_name: "John", c_last_name: "Doe", ctr_total_return: 150.0}]
+  Const        r322, [{"c_customer_id": "C1", "c_first_name": "John", "c_last_name": "Doe", "ctr_total_return": 150}]
+  Equal        r323, r225, r322
+  Expect       r323
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q31.ir.out
+++ b/tests/dataset/tpc-ds/out/q31.ir.out
@@ -1,0 +1,245 @@
+func main (regs=183)
+  // let store_sales = [
+  Const        r0, [{"ca_county": "A", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 100}, {"ca_county": "A", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 120}, {"ca_county": "A", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 160}, {"ca_county": "B", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 80}, {"ca_county": "B", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 90}, {"ca_county": "B", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 100}]
+  // let web_sales = [
+  Const        r1, [{"ca_county": "A", "d_qoy": 1, "d_year": 2000, "ws_ext_sales_price": 100}, {"ca_county": "A", "d_qoy": 2, "d_year": 2000, "ws_ext_sales_price": 150}, {"ca_county": "A", "d_qoy": 3, "d_year": 2000, "ws_ext_sales_price": 250}, {"ca_county": "B", "d_qoy": 1, "d_year": 2000, "ws_ext_sales_price": 80}, {"ca_county": "B", "d_qoy": 2, "d_year": 2000, "ws_ext_sales_price": 90}, {"ca_county": "B", "d_qoy": 3, "d_year": 2000, "ws_ext_sales_price": 95}]
+  // let counties = ["A", "B"]
+  Const        r2, ["A", "B"]
+  // var result = []
+  Const        r4, []
+  // for county in counties {
+  IterPrep     r5, r2
+  Len          r6, r5
+  Const        r7, 0
+L22:
+  Less         r8, r7, r6
+  JumpIfFalse  r8, L0
+  Index        r10, r5, r7
+  // let ss1 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 1 select s.ss_ext_sales_price)
+  Const        r11, []
+  IterPrep     r15, r0
+  Len          r16, r15
+  Const        r17, 0
+L3:
+  LessInt      r19, r17, r16
+  JumpIfFalse  r19, L1
+  Index        r21, r15, r17
+  Const        r22, "ca_county"
+  Index        r23, r21, r22
+  Equal        r24, r23, r10
+  Const        r25, "d_qoy"
+  Index        r26, r21, r25
+  Const        r27, 1
+  Equal        r28, r26, r27
+  Move         r29, r24
+  JumpIfFalse  r29, L2
+  Move         r29, r28
+L2:
+  JumpIfFalse  r29, L3
+  Const        r30, "ss_ext_sales_price"
+  Index        r31, r21, r30
+  Append       r11, r11, r31
+  Jump         L3
+L1:
+  Sum          r34, r11
+  // let ss2 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 2 select s.ss_ext_sales_price)
+  Const        r35, []
+  IterPrep     r39, r0
+  Len          r40, r39
+  Const        r41, 0
+L7:
+  LessInt      r43, r41, r40
+  JumpIfFalse  r43, L4
+  Index        r21, r39, r41
+  Const        r45, "ca_county"
+  Index        r46, r21, r45
+  Equal        r47, r46, r10
+  Const        r48, "d_qoy"
+  Index        r49, r21, r48
+  Const        r50, 2
+  Equal        r51, r49, r50
+  Move         r52, r47
+  JumpIfFalse  r52, L5
+  Move         r52, r51
+L5:
+  JumpIfFalse  r52, L6
+  Const        r53, "ss_ext_sales_price"
+  Index        r54, r21, r53
+  Append       r35, r35, r54
+L6:
+  Const        r56, 1
+  AddInt       r41, r41, r56
+  Jump         L7
+L4:
+  Sum          r57, r35
+  // let ss3 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 3 select s.ss_ext_sales_price)
+  Const        r58, []
+  IterPrep     r62, r0
+  Len          r63, r62
+  Const        r64, 0
+L11:
+  LessInt      r66, r64, r63
+  JumpIfFalse  r66, L8
+  Index        r21, r62, r64
+  Const        r68, "ca_county"
+  Index        r69, r21, r68
+  Equal        r70, r69, r10
+  Const        r71, "d_qoy"
+  Index        r72, r21, r71
+  Const        r73, 3
+  Equal        r74, r72, r73
+  Move         r75, r70
+  JumpIfFalse  r75, L9
+  Move         r75, r74
+L9:
+  JumpIfFalse  r75, L10
+  Const        r76, "ss_ext_sales_price"
+  Index        r77, r21, r76
+  Append       r58, r58, r77
+L10:
+  Const        r79, 1
+  AddInt       r64, r64, r79
+  Jump         L11
+L8:
+  Sum          r80, r58
+  // let ws1 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 1 select w.ws_ext_sales_price)
+  Const        r81, []
+  IterPrep     r85, r1
+  Len          r86, r85
+  Const        r87, 0
+L14:
+  LessInt      r89, r87, r86
+  JumpIfFalse  r89, L12
+  Index        r91, r85, r87
+  Const        r92, "ca_county"
+  Index        r93, r91, r92
+  Equal        r94, r93, r10
+  Const        r95, "d_qoy"
+  Index        r96, r91, r95
+  Const        r97, 1
+  Equal        r98, r96, r97
+  Move         r99, r94
+  JumpIfFalse  r99, L13
+  Move         r99, r98
+L13:
+  JumpIfFalse  r99, L14
+  Const        r100, "ws_ext_sales_price"
+  Index        r101, r91, r100
+  Append       r81, r81, r101
+  Jump         L14
+L12:
+  Sum          r104, r81
+  // let ws2 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 2 select w.ws_ext_sales_price)
+  Const        r105, []
+  IterPrep     r109, r1
+  Len          r110, r109
+  Const        r111, 0
+L17:
+  LessInt      r113, r111, r110
+  JumpIfFalse  r113, L15
+  Index        r91, r109, r111
+  Const        r115, "ca_county"
+  Index        r116, r91, r115
+  Equal        r117, r116, r10
+  Const        r118, "d_qoy"
+  Index        r119, r91, r118
+  Const        r120, 2
+  Equal        r121, r119, r120
+  Move         r122, r117
+  JumpIfFalse  r122, L16
+  Move         r122, r121
+L16:
+  JumpIfFalse  r122, L17
+  Const        r123, "ws_ext_sales_price"
+  Index        r124, r91, r123
+  Append       r105, r105, r124
+  Jump         L17
+L15:
+  Sum          r127, r105
+  // let ws3 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 3 select w.ws_ext_sales_price)
+  Const        r128, []
+  IterPrep     r132, r1
+  Len          r133, r132
+  Const        r134, 0
+L20:
+  LessInt      r136, r134, r133
+  JumpIfFalse  r136, L18
+  Index        r91, r132, r134
+  Const        r138, "ca_county"
+  Index        r139, r91, r138
+  Equal        r140, r139, r10
+  Const        r141, "d_qoy"
+  Index        r142, r91, r141
+  Const        r143, 3
+  Equal        r144, r142, r143
+  Move         r145, r140
+  JumpIfFalse  r145, L19
+  Move         r145, r144
+L19:
+  JumpIfFalse  r145, L20
+  Const        r146, "ws_ext_sales_price"
+  Index        r147, r91, r146
+  Append       r128, r128, r147
+  Jump         L20
+L18:
+  Sum          r150, r128
+  // let web_g1 = ws2 / ws1
+  Div          r151, r127, r104
+  // let store_g1 = ss2 / ss1
+  Div          r152, r57, r34
+  // let web_g2 = ws3 / ws2
+  Div          r153, r150, r127
+  // let store_g2 = ss3 / ss2
+  Div          r154, r80, r57
+  // if web_g1 > store_g1 && web_g2 > store_g2 {
+  Less         r155, r152, r151
+  Less         r156, r154, r153
+  Move         r157, r155
+  JumpIfFalse  r157, L21
+  Move         r157, r156
+L21:
+  JumpIfFalse  r157, L22
+  // ca_county: county,
+  Const        r158, "ca_county"
+  // d_year: 2000,
+  Const        r159, "d_year"
+  Const        r160, 2000
+  // web_q1_q2_increase: web_g1,
+  Const        r161, "web_q1_q2_increase"
+  // store_q1_q2_increase: store_g1,
+  Const        r162, "store_q1_q2_increase"
+  // web_q2_q3_increase: web_g2,
+  Const        r163, "web_q2_q3_increase"
+  // store_q2_q3_increase: store_g2
+  Const        r164, "store_q2_q3_increase"
+  // ca_county: county,
+  Move         r165, r158
+  Move         r166, r10
+  // d_year: 2000,
+  Move         r167, r159
+  Move         r168, r160
+  // web_q1_q2_increase: web_g1,
+  Move         r169, r161
+  Move         r170, r151
+  // store_q1_q2_increase: store_g1,
+  Move         r171, r162
+  Move         r172, r152
+  // web_q2_q3_increase: web_g2,
+  Move         r173, r163
+  Move         r174, r153
+  // store_q2_q3_increase: store_g2
+  Move         r175, r164
+  Move         r176, r154
+  // result = append(result, {
+  MakeMap      r177, 6, r165
+  Append       r4, r4, r177
+  // for county in counties {
+  Jump         L22
+L0:
+  // json(result)
+  JSON         r4
+  // expect result == [
+  Const        r181, [{"ca_county": "A", "d_year": 2000, "store_q1_q2_increase": 1.2, "store_q2_q3_increase": 1.3333333333333333, "web_q1_q2_increase": 1.5, "web_q2_q3_increase": 1.6666666666666667}]
+  Equal        r182, r4, r181
+  Expect       r182
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q32.ir.out
+++ b/tests/dataset/tpc-ds/out/q32.ir.out
@@ -1,0 +1,100 @@
+func main (regs=80)
+  // let catalog_sales = [
+  Const        r0, [{"cs_ext_discount_amt": 5, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_discount_amt": 10, "cs_item_sk": 1, "cs_sold_date_sk": 2}, {"cs_ext_discount_amt": 20, "cs_item_sk": 1, "cs_sold_date_sk": 3}]
+  // let item = [
+  Const        r1, [{"i_item_sk": 1, "i_manufact_id": 1}]
+  // let date_dim = [
+  Const        r2, [{"d_date_sk": 1, "d_year": 2000}, {"d_date_sk": 2, "d_year": 2000}, {"d_date_sk": 3, "d_year": 2000}]
+  // from cs in catalog_sales
+  Const        r3, []
+  IterPrep     r7, r0
+  Len          r8, r7
+  Const        r9, 0
+L5:
+  LessInt      r11, r9, r8
+  JumpIfFalse  r11, L0
+  Index        r13, r7, r9
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  IterPrep     r14, r1
+  Len          r15, r14
+  Const        r21, 0
+L2:
+  LessInt      r23, r21, r15
+  JumpIfFalse  r23, L1
+  Index        r25, r14, r21
+  Const        r26, "cs_item_sk"
+  Index        r27, r13, r26
+  Const        r28, "i_item_sk"
+  Index        r29, r25, r28
+  Equal        r30, r27, r29
+  JumpIfFalse  r30, L2
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  IterPrep     r31, r2
+  Len          r32, r31
+  Const        r38, 0
+L3:
+  LessInt      r40, r38, r32
+  JumpIfFalse  r40, L2
+  Index        r42, r31, r38
+  Const        r43, "cs_sold_date_sk"
+  Index        r44, r13, r43
+  Const        r45, "d_date_sk"
+  Index        r46, r42, r45
+  Equal        r47, r44, r46
+  JumpIfFalse  r47, L3
+  // where i.i_manufact_id == 1 && d.d_year == 2000
+  Const        r48, "i_manufact_id"
+  Index        r49, r25, r48
+  Const        r50, 1
+  Equal        r51, r49, r50
+  Const        r52, "d_year"
+  Index        r53, r42, r52
+  Const        r54, 2000
+  Equal        r55, r53, r54
+  Move         r56, r51
+  JumpIfFalse  r56, L4
+  Move         r56, r55
+L4:
+  JumpIfFalse  r56, L3
+  // select cs.cs_ext_discount_amt
+  Const        r57, "cs_ext_discount_amt"
+  Index        r58, r13, r57
+  // from cs in catalog_sales
+  Append       r3, r3, r58
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  Jump         L3
+L1:
+  // from cs in catalog_sales
+  Const        r62, 1
+  AddInt       r9, r9, r62
+  Jump         L5
+L0:
+  // let avg_discount = avg(filtered)
+  Avg          r63, r3
+  // let result = sum(from x in filtered where x > avg_discount * 1.3 select x)
+  Const        r64, []
+  IterPrep     r65, r3
+  Len          r66, r65
+  Const        r67, 0
+L8:
+  LessInt      r69, r67, r66
+  JumpIfFalse  r69, L6
+  Index        r71, r65, r67
+  Const        r72, 1.3
+  MulFloat     r73, r63, r72
+  LessFloat    r74, r73, r71
+  JumpIfFalse  r74, L7
+  Append       r64, r64, r71
+L7:
+  Const        r76, 1
+  AddInt       r67, r67, r76
+  Jump         L8
+L6:
+  Sum          r77, r64
+  // json(result)
+  JSON         r77
+  // expect result == 20.0
+  Const        r78, 20
+  EqualFloat   r79, r77, r78
+  Expect       r79
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q33.ir.out
+++ b/tests/dataset/tpc-ds/out/q33.ir.out
@@ -1,0 +1,467 @@
+func main (regs=451)
+  // let item = [
+  Const        r0, [{"i_category": "Books", "i_item_sk": 1, "i_manufact_id": 1}, {"i_category": "Books", "i_item_sk": 2, "i_manufact_id": 2}]
+  // let date_dim = [
+  Const        r1, [{"d_date_sk": 1, "d_moy": 1, "d_year": 2000}]
+  // let customer_address = [
+  Const        r2, [{"ca_address_sk": 1, "ca_gmt_offset": -5}, {"ca_address_sk": 2, "ca_gmt_offset": -5}]
+  // let store_sales = [
+  Const        r3, [{"ss_addr_sk": 1, "ss_ext_sales_price": 100, "ss_item_sk": 1, "ss_sold_date_sk": 1}, {"ss_addr_sk": 2, "ss_ext_sales_price": 50, "ss_item_sk": 2, "ss_sold_date_sk": 1}]
+  // let catalog_sales = [
+  Const        r4, [{"cs_bill_addr_sk": 1, "cs_ext_sales_price": 20, "cs_item_sk": 1, "cs_sold_date_sk": 1}]
+  // let web_sales = [
+  Const        r5, [{"ws_bill_addr_sk": 1, "ws_ext_sales_price": 30, "ws_item_sk": 1, "ws_sold_date_sk": 1}]
+  // let month = 1
+  Const        r6, 1
+  // let year = 2000
+  Const        r7, 2000
+  // from ss in store_sales
+  Const        r8, []
+  IterPrep     r17, r3
+  Len          r18, r17
+  Const        r19, 0
+L8:
+  LessInt      r21, r19, r18
+  JumpIfFalse  r21, L0
+  Index        r23, r17, r19
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r24, r1
+  Len          r25, r24
+  Const        r36, 0
+L2:
+  LessInt      r38, r36, r25
+  JumpIfFalse  r38, L1
+  Index        r40, r24, r36
+  Const        r41, "ss_sold_date_sk"
+  Index        r42, r23, r41
+  Const        r43, "d_date_sk"
+  Index        r44, r40, r43
+  Equal        r45, r42, r44
+  JumpIfFalse  r45, L2
+  // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
+  IterPrep     r46, r2
+  Len          r47, r46
+  Const        r58, 0
+L3:
+  LessInt      r60, r58, r47
+  JumpIfFalse  r60, L2
+  Index        r62, r46, r58
+  Const        r63, "ss_addr_sk"
+  Index        r64, r23, r63
+  Const        r65, "ca_address_sk"
+  Index        r66, r62, r65
+  Equal        r67, r64, r66
+  JumpIfFalse  r67, L3
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r68, r0
+  Len          r69, r68
+  Const        r80, 0
+L4:
+  LessInt      r82, r80, r69
+  JumpIfFalse  r82, L3
+  Index        r84, r68, r80
+  Const        r85, "ss_item_sk"
+  Index        r86, r23, r85
+  Const        r87, "i_item_sk"
+  Index        r88, r84, r87
+  Equal        r89, r86, r88
+  JumpIfFalse  r89, L4
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r90, "i_category"
+  Index        r91, r84, r90
+  Const        r92, "Books"
+  Equal        r93, r91, r92
+  Const        r94, "d_year"
+  Index        r95, r40, r94
+  Equal        r96, r95, r7
+  Const        r97, "d_moy"
+  Index        r98, r40, r97
+  Equal        r99, r98, r6
+  Const        r100, "ca_gmt_offset"
+  Index        r101, r62, r100
+  Const        r103, -5
+  Equal        r104, r101, r103
+  Move         r105, r93
+  JumpIfFalse  r105, L5
+L5:
+  Move         r106, r96
+  JumpIfFalse  r106, L6
+L6:
+  Move         r107, r99
+  JumpIfFalse  r107, L7
+  Move         r107, r104
+L7:
+  JumpIfFalse  r107, L4
+  // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
+  Const        r108, "manu"
+  Const        r109, "i_manufact_id"
+  Index        r110, r84, r109
+  Const        r111, "price"
+  Const        r112, "ss_ext_sales_price"
+  Index        r113, r23, r112
+  Move         r114, r108
+  Move         r115, r110
+  Move         r116, r111
+  Move         r117, r113
+  MakeMap      r118, 2, r114
+  // from ss in store_sales
+  Append       r8, r8, r118
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  Jump         L4
+L1:
+  // from ss in store_sales
+  Const        r123, 1
+  AddInt       r19, r19, r123
+  Jump         L8
+L0:
+  // from cs in catalog_sales
+  Const        r124, []
+  IterPrep     r133, r4
+  Len          r134, r133
+  Const        r135, 0
+L20:
+  LessInt      r137, r135, r134
+  JumpIfFalse  r137, L9
+  Index        r139, r133, r135
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  IterPrep     r140, r1
+  Len          r141, r140
+  Const        r152, 0
+L19:
+  LessInt      r154, r152, r141
+  JumpIfFalse  r154, L10
+  Index        r40, r140, r152
+  Const        r156, "cs_sold_date_sk"
+  Index        r157, r139, r156
+  Const        r158, "d_date_sk"
+  Index        r159, r40, r158
+  Equal        r160, r157, r159
+  JumpIfFalse  r160, L11
+  // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
+  IterPrep     r161, r2
+  Len          r162, r161
+  Const        r173, 0
+L18:
+  LessInt      r175, r173, r162
+  JumpIfFalse  r175, L11
+  Index        r62, r161, r173
+  Const        r177, "cs_bill_addr_sk"
+  Index        r178, r139, r177
+  Const        r179, "ca_address_sk"
+  Index        r180, r62, r179
+  Equal        r181, r178, r180
+  JumpIfFalse  r181, L12
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  IterPrep     r182, r0
+  Len          r183, r182
+  Const        r194, 0
+L17:
+  LessInt      r196, r194, r183
+  JumpIfFalse  r196, L12
+  Index        r84, r182, r194
+  Const        r198, "cs_item_sk"
+  Index        r199, r139, r198
+  Const        r200, "i_item_sk"
+  Index        r201, r84, r200
+  Equal        r202, r199, r201
+  JumpIfFalse  r202, L13
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r203, "i_category"
+  Index        r204, r84, r203
+  Const        r205, "Books"
+  Equal        r206, r204, r205
+  Const        r207, "d_year"
+  Index        r208, r40, r207
+  Equal        r209, r208, r7
+  Const        r210, "d_moy"
+  Index        r211, r40, r210
+  Equal        r212, r211, r6
+  Const        r213, "ca_gmt_offset"
+  Index        r214, r62, r213
+  Const        r216, -5
+  Equal        r217, r214, r216
+  Move         r218, r206
+  JumpIfFalse  r218, L14
+L14:
+  Move         r219, r209
+  JumpIfFalse  r219, L15
+L15:
+  Move         r220, r212
+  JumpIfFalse  r220, L16
+  Move         r220, r217
+L16:
+  JumpIfFalse  r220, L13
+  // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
+  Const        r221, "manu"
+  Const        r222, "i_manufact_id"
+  Index        r223, r84, r222
+  Const        r224, "price"
+  Const        r225, "cs_ext_sales_price"
+  Index        r226, r139, r225
+  Move         r227, r221
+  Move         r228, r223
+  Move         r229, r224
+  Move         r230, r226
+  MakeMap      r231, 2, r227
+  // from cs in catalog_sales
+  Append       r124, r124, r231
+L13:
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  Const        r233, 1
+  Add          r194, r194, r233
+  Jump         L17
+L12:
+  // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
+  Const        r234, 1
+  Add          r173, r173, r234
+  Jump         L18
+L11:
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  Const        r235, 1
+  Add          r152, r152, r235
+  Jump         L19
+L10:
+  // from cs in catalog_sales
+  Const        r236, 1
+  AddInt       r135, r135, r236
+  Jump         L20
+L9:
+  // let union_sales = concat(
+  UnionAll     r237, r8, r124
+  // from ws in web_sales
+  Const        r238, []
+  IterPrep     r247, r5
+  Len          r248, r247
+  Const        r249, 0
+L32:
+  LessInt      r251, r249, r248
+  JumpIfFalse  r251, L21
+  Index        r253, r247, r249
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  IterPrep     r254, r1
+  Len          r255, r254
+  Const        r266, 0
+L31:
+  LessInt      r268, r266, r255
+  JumpIfFalse  r268, L22
+  Index        r40, r254, r266
+  Const        r270, "ws_sold_date_sk"
+  Index        r271, r253, r270
+  Const        r272, "d_date_sk"
+  Index        r273, r40, r272
+  Equal        r274, r271, r273
+  JumpIfFalse  r274, L23
+  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
+  IterPrep     r275, r2
+  Len          r276, r275
+  Const        r287, 0
+L30:
+  LessInt      r289, r287, r276
+  JumpIfFalse  r289, L23
+  Index        r62, r275, r287
+  Const        r291, "ws_bill_addr_sk"
+  Index        r292, r253, r291
+  Const        r293, "ca_address_sk"
+  Index        r294, r62, r293
+  Equal        r295, r292, r294
+  JumpIfFalse  r295, L24
+  // join i in item on ws.ws_item_sk == i.i_item_sk
+  IterPrep     r296, r0
+  Len          r297, r296
+  Const        r308, 0
+L29:
+  LessInt      r310, r308, r297
+  JumpIfFalse  r310, L24
+  Index        r84, r296, r308
+  Const        r312, "ws_item_sk"
+  Index        r313, r253, r312
+  Const        r314, "i_item_sk"
+  Index        r315, r84, r314
+  Equal        r316, r313, r315
+  JumpIfFalse  r316, L25
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r317, "i_category"
+  Index        r318, r84, r317
+  Const        r319, "Books"
+  Equal        r320, r318, r319
+  Const        r321, "d_year"
+  Index        r322, r40, r321
+  Equal        r323, r322, r7
+  Const        r324, "d_moy"
+  Index        r325, r40, r324
+  Equal        r326, r325, r6
+  Const        r327, "ca_gmt_offset"
+  Index        r328, r62, r327
+  Const        r330, -5
+  Equal        r331, r328, r330
+  Move         r332, r320
+  JumpIfFalse  r332, L26
+L26:
+  Move         r333, r323
+  JumpIfFalse  r333, L27
+L27:
+  Move         r334, r326
+  JumpIfFalse  r334, L28
+  Move         r334, r331
+L28:
+  JumpIfFalse  r334, L25
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r335, "manu"
+  Const        r336, "i_manufact_id"
+  Index        r337, r84, r336
+  Const        r338, "price"
+  Const        r339, "ws_ext_sales_price"
+  Index        r340, r253, r339
+  Move         r341, r335
+  Move         r342, r337
+  Move         r343, r338
+  Move         r344, r340
+  MakeMap      r345, 2, r341
+  // from ws in web_sales
+  Append       r238, r238, r345
+L25:
+  // join i in item on ws.ws_item_sk == i.i_item_sk
+  Const        r347, 1
+  Add          r308, r308, r347
+  Jump         L29
+L24:
+  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
+  Const        r348, 1
+  Add          r287, r287, r348
+  Jump         L30
+L23:
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  Const        r349, 1
+  Add          r266, r266, r349
+  Jump         L31
+L22:
+  // from ws in web_sales
+  Const        r350, 1
+  AddInt       r249, r249, r350
+  Jump         L32
+L21:
+  // let union_sales = concat(
+  UnionAll     r351, r237, r238
+  // from s in union_sales
+  Const        r352, []
+  IterPrep     r359, r351
+  Len          r360, r359
+  Const        r361, 0
+  MakeMap      r362, 0, r0
+  Const        r363, []
+L35:
+  LessInt      r365, r361, r360
+  JumpIfFalse  r365, L33
+  Index        r366, r359, r361
+  Move         r367, r366
+  // group by s.manu into g
+  Const        r368, "manu"
+  Index        r369, r367, r368
+  Str          r370, r369
+  In           r371, r370, r362
+  JumpIfTrue   r371, L34
+  // from s in union_sales
+  Const        r372, []
+  Const        r373, "__group__"
+  Const        r374, true
+  Const        r375, "key"
+  // group by s.manu into g
+  Move         r376, r369
+  // from s in union_sales
+  Const        r377, "items"
+  Move         r378, r372
+  Const        r379, "count"
+  Const        r380, 0
+  Move         r381, r373
+  Move         r382, r374
+  Move         r383, r375
+  Move         r384, r376
+  Move         r385, r377
+  Move         r386, r378
+  Move         r387, r379
+  Move         r388, r380
+  MakeMap      r389, 4, r381
+  SetIndex     r362, r370, r389
+  Append       r363, r363, r389
+L34:
+  Const        r391, "items"
+  Index        r392, r362, r370
+  Index        r393, r392, r391
+  Append       r394, r393, r366
+  SetIndex     r392, r391, r394
+  Const        r395, "count"
+  Index        r396, r392, r395
+  Const        r397, 1
+  AddInt       r398, r396, r397
+  SetIndex     r392, r395, r398
+  Const        r399, 1
+  AddInt       r361, r361, r399
+  Jump         L35
+L33:
+  Const        r400, 0
+  Len          r402, r363
+L41:
+  LessInt      r403, r400, r402
+  JumpIfFalse  r403, L36
+  Index        r405, r363, r400
+  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
+  Const        r406, "i_manufact_id"
+  Const        r407, "key"
+  Index        r408, r405, r407
+  Const        r409, "total_sales"
+  Const        r410, []
+  IterPrep     r412, r405
+  Len          r413, r412
+  Const        r414, 0
+L38:
+  LessInt      r416, r414, r413
+  JumpIfFalse  r416, L37
+  Index        r418, r412, r414
+  Const        r419, "price"
+  Index        r420, r418, r419
+  Append       r410, r410, r420
+  Const        r422, 1
+  AddInt       r414, r414, r422
+  Jump         L38
+L37:
+  Sum          r423, r410
+  Move         r424, r406
+  Move         r425, r408
+  Move         r426, r409
+  Move         r427, r423
+  MakeMap      r428, 2, r424
+  // sort by -sum(from x in g select x.price)
+  Const        r429, []
+  IterPrep     r431, r405
+  Len          r432, r431
+  Const        r433, 0
+L40:
+  LessInt      r435, r433, r432
+  JumpIfFalse  r435, L39
+  Index        r418, r431, r433
+  Const        r437, "price"
+  Index        r438, r418, r437
+  Append       r429, r429, r438
+  Const        r440, 1
+  AddInt       r433, r433, r440
+  Jump         L40
+L39:
+  Sum          r441, r429
+  Neg          r443, r441
+  // from s in union_sales
+  Move         r444, r428
+  MakeList     r445, 2, r443
+  Append       r352, r352, r445
+  Const        r447, 1
+  AddInt       r400, r400, r447
+  Jump         L41
+L36:
+  // sort by -sum(from x in g select x.price)
+  Sort         r352, r352
+  // json(result)
+  JSON         r352
+  // expect result == [
+  Const        r449, [{"i_manufact_id": 1, "total_sales": 150}, {"i_manufact_id": 2, "total_sales": 50}]
+  Equal        r450, r352, r449
+  Expect       r450
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q34.ir.out
+++ b/tests/dataset/tpc-ds/out/q34.ir.out
@@ -1,0 +1,471 @@
+func main (regs=352)
+L16:
+  // let store_sales = [
+  Const        r0, [{"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}]
+  // let date_dim = [
+  Const        r1, [{"d_date_sk": 1, "d_dom": 2, "d_year": 2000}]
+  // let store = [
+  Const        r2, [{"s_county": "A", "s_store_sk": 1}]
+  // let household_demographics = [
+  Const        r3, [{"hd_buy_potential": ">10000", "hd_demo_sk": 1, "hd_dep_count": 3, "hd_vehicle_count": 2}, {"hd_buy_potential": ">10000", "hd_demo_sk": 2, "hd_dep_count": 1, "hd_vehicle_count": 2}]
+  // let customer = [
+  Const        r4, [{"c_customer_sk": 1, "c_first_name": "John", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Mr."}, {"c_customer_sk": 2, "c_first_name": "Alice", "c_last_name": "Jones", "c_preferred_cust_flag": "N", "c_salutation": "Ms."}]
+  // from ss in store_sales
+  Const        r5, []
+  MakeMap      r25, 0, r0
+  Const        r26, []
+  IterPrep     r28, r0
+  Len          r29, r28
+  Const        r30, 0
+L1:
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L0
+  Index        r33, r28, r30
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r34, r1
+  Len          r35, r34
+  Const        r36, 0
+L2:
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L1
+  Index        r39, r34, r36
+  Const        r40, "ss_sold_date_sk"
+  Index        r41, r33, r40
+  Const        r42, "d_date_sk"
+  Index        r43, r39, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L2
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  IterPrep     r45, r2
+  Len          r46, r45
+  Const        r47, 0
+L13:
+  LessInt      r48, r47, r46
+  JumpIfFalse  r48, L2
+  Index        r50, r45, r47
+  Const        r51, "ss_store_sk"
+  Index        r52, r33, r51
+  Const        r53, "s_store_sk"
+  Index        r54, r50, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L3
+  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  IterPrep     r56, r3
+  Len          r57, r56
+  Const        r58, 0
+L12:
+  LessInt      r59, r58, r57
+  JumpIfFalse  r59, L3
+  Index        r61, r56, r58
+  Const        r62, "ss_hdemo_sk"
+  Index        r63, r33, r62
+  Const        r64, "hd_demo_sk"
+  Index        r65, r61, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L4
+  // where (d.d_dom >= 1 && d.d_dom <= 3) && hd.hd_buy_potential == ">10000" && hd.hd_vehicle_count > 0 && (hd.hd_dep_count / hd.hd_vehicle_count) > 1.2 && d.d_year == 2000 && s.s_county == "A"
+  Const        r67, "d_dom"
+  Index        r68, r39, r67
+  Const        r69, 1
+  LessEq       r70, r69, r68
+  Const        r71, "d_dom"
+  Index        r72, r39, r71
+  Const        r73, 3
+  LessEq       r74, r72, r73
+  Move         r75, r70
+  JumpIfFalse  r75, L5
+  Move         r75, r74
+L5:
+  Const        r76, "hd_vehicle_count"
+  Index        r77, r61, r76
+  Const        r78, 0
+  Less         r79, r78, r77
+  Const        r80, "hd_dep_count"
+  Index        r81, r61, r80
+  Const        r82, "hd_vehicle_count"
+  Index        r83, r61, r82
+  Div          r84, r81, r83
+  Const        r85, 1.2
+  LessFloat    r86, r85, r84
+  Const        r87, "hd_buy_potential"
+  Index        r88, r61, r87
+  Const        r89, ">10000"
+  Equal        r90, r88, r89
+  Const        r91, "d_year"
+  Index        r92, r39, r91
+  Const        r93, 2000
+  Equal        r94, r92, r93
+  Const        r95, "s_county"
+  Index        r96, r50, r95
+  Const        r97, "A"
+  Equal        r98, r96, r97
+  Move         r99, r75
+  JumpIfFalse  r99, L6
+L6:
+  Move         r100, r90
+  JumpIfFalse  r100, L7
+L7:
+  Move         r101, r79
+  JumpIfFalse  r101, L8
+L8:
+  Move         r102, r86
+  JumpIfFalse  r102, L9
+L9:
+  Move         r103, r94
+  JumpIfFalse  r103, L10
+  Move         r103, r98
+L10:
+  JumpIfFalse  r103, L4
+  // from ss in store_sales
+  Const        r104, "ss"
+  Move         r105, r33
+  Const        r106, "d"
+  Move         r107, r39
+  Const        r108, "s"
+  Move         r109, r50
+  Const        r110, "hd"
+  Move         r111, r61
+  MakeMap      r112, 4, r104
+  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
+  Const        r113, "ticket"
+  Const        r114, "ss_ticket_number"
+  Index        r115, r33, r114
+  Const        r116, "cust"
+  Const        r117, "ss_customer_sk"
+  Index        r118, r33, r117
+  Move         r119, r113
+  Move         r120, r115
+  Move         r121, r116
+  Move         r122, r118
+  MakeMap      r123, 2, r119
+  Str          r124, r123
+  In           r125, r124, r25
+  JumpIfTrue   r125, L11
+  // from ss in store_sales
+  Const        r126, []
+  Const        r127, "__group__"
+  Const        r128, true
+  Const        r129, "key"
+  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
+  Move         r130, r123
+  // from ss in store_sales
+  Const        r131, "items"
+  Move         r132, r126
+  Const        r133, "count"
+  Const        r134, 0
+  Move         r135, r127
+  Move         r136, r128
+  Move         r137, r129
+  Move         r138, r130
+  Move         r139, r131
+  Move         r140, r132
+  Move         r141, r133
+  Move         r142, r134
+  MakeMap      r143, 4, r135
+  SetIndex     r25, r124, r143
+  Append       r26, r26, r143
+L11:
+  Const        r145, "items"
+  Index        r146, r25, r124
+  Index        r147, r146, r145
+  Append       r148, r147, r112
+  SetIndex     r146, r145, r148
+  Const        r149, "count"
+  Index        r150, r146, r149
+  Const        r151, 1
+  AddInt       r152, r150, r151
+  SetIndex     r146, r149, r152
+L4:
+  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  Const        r153, 1
+  AddInt       r58, r58, r153
+  Jump         L12
+L3:
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  Const        r154, 1
+  AddInt       r47, r47, r154
+  Jump         L13
+L0:
+  // from ss in store_sales
+  Const        r157, 0
+  Len          r159, r26
+L15:
+  LessInt      r160, r157, r159
+  JumpIfFalse  r160, L14
+  Index        r162, r26, r157
+  // select {ss_ticket_number: g.key.ticket, ss_customer_sk: g.key.cust, cnt: count(g)}
+  Const        r163, "ss_ticket_number"
+  Const        r164, "key"
+  Index        r165, r162, r164
+  Const        r166, "ticket"
+  Index        r167, r165, r166
+  Const        r168, "ss_customer_sk"
+  Const        r169, "key"
+  Index        r170, r162, r169
+  Const        r171, "cust"
+  Index        r172, r170, r171
+  Const        r173, "cnt"
+  Const        r174, "count"
+  Index        r175, r162, r174
+  Move         r176, r163
+  Move         r177, r167
+  Move         r178, r168
+  Move         r179, r172
+  Move         r180, r173
+  Move         r181, r175
+  MakeMap      r182, 3, r176
+  // from ss in store_sales
+  Append       r5, r5, r182
+  Jump         L15
+L14:
+  // from dn1 in dn
+  Const        r185, []
+  IterPrep     r186, r5
+  Len          r187, r186
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  IterPrep     r188, r4
+  Len          r189, r188
+  // from dn1 in dn
+  Const        r190, 0
+  EqualInt     r191, r187, r190
+  JumpIfTrue   r191, L16
+  EqualInt     r192, r189, r190
+  JumpIfTrue   r192, L16
+  LessEq       r193, r189, r187
+  JumpIfFalse  r193, L17
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  MakeMap      r194, 0, r0
+  Const        r195, 0
+L20:
+  LessInt      r196, r195, r189
+  JumpIfFalse  r196, L18
+  Index        r197, r188, r195
+  Move         r198, r197
+  Const        r199, "c_customer_sk"
+  Index        r200, r198, r199
+  Index        r201, r194, r200
+  Const        r202, nil
+  NotEqual     r203, r201, r202
+  JumpIfTrue   r203, L19
+  MakeList     r204, 0, r0
+  SetIndex     r194, r200, r204
+L19:
+  Index        r201, r194, r200
+  Append       r205, r201, r197
+  SetIndex     r194, r200, r205
+  Const        r206, 1
+  AddInt       r195, r195, r206
+  Jump         L20
+L18:
+  // from dn1 in dn
+  Const        r207, 0
+L25:
+  LessInt      r208, r207, r187
+  JumpIfFalse  r208, L16
+  Index        r210, r186, r207
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  Const        r211, "ss_customer_sk"
+  Index        r212, r210, r211
+  // from dn1 in dn
+  Index        r213, r194, r212
+  Const        r214, nil
+  NotEqual     r215, r213, r214
+  JumpIfFalse  r215, L21
+  Len          r216, r213
+  Const        r217, 0
+L24:
+  LessInt      r218, r217, r216
+  JumpIfFalse  r218, L21
+  Index        r198, r213, r217
+  // where dn1.cnt >= 15 && dn1.cnt <= 20
+  Const        r220, "cnt"
+  Index        r221, r210, r220
+  Const        r222, 15
+  LessEq       r223, r222, r221
+  Const        r224, "cnt"
+  Index        r225, r210, r224
+  Const        r226, 20
+  LessEq       r227, r225, r226
+  Move         r228, r223
+  JumpIfFalse  r228, L22
+  Move         r228, r227
+L22:
+  JumpIfFalse  r228, L23
+  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
+  Const        r229, "c_last_name"
+  Const        r230, "c_last_name"
+  Index        r231, r198, r230
+  Const        r232, "c_first_name"
+  Const        r233, "c_first_name"
+  Index        r234, r198, r233
+  Const        r235, "c_salutation"
+  Const        r236, "c_salutation"
+  Index        r237, r198, r236
+  Const        r238, "c_preferred_cust_flag"
+  Const        r239, "c_preferred_cust_flag"
+  Index        r240, r198, r239
+  Const        r241, "ss_ticket_number"
+  Const        r242, "ss_ticket_number"
+  Index        r243, r210, r242
+  Const        r244, "cnt"
+  Const        r245, "cnt"
+  Index        r246, r210, r245
+  Move         r247, r229
+  Move         r248, r231
+  Move         r249, r232
+  Move         r250, r234
+  Move         r251, r235
+  Move         r252, r237
+  Move         r253, r238
+  Move         r254, r240
+  Move         r255, r241
+  Move         r256, r243
+  Move         r257, r244
+  Move         r258, r246
+  MakeMap      r259, 6, r247
+  // sort by c.c_last_name
+  Const        r260, "c_last_name"
+  Index        r262, r198, r260
+  // from dn1 in dn
+  Move         r263, r259
+  MakeList     r264, 2, r262
+  Append       r185, r185, r264
+L23:
+  Const        r266, 1
+  AddInt       r217, r217, r266
+  Jump         L24
+L21:
+  Const        r267, 1
+  AddInt       r207, r207, r267
+  Jump         L25
+L17:
+  MakeMap      r268, 0, r0
+  Const        r269, 0
+L30:
+  LessInt      r270, r269, r187
+  JumpIfFalse  r270, L26
+  Index        r271, r186, r269
+  Move         r210, r271
+  // where dn1.cnt >= 15 && dn1.cnt <= 20
+  Const        r272, "cnt"
+  Index        r273, r210, r272
+  Const        r274, 15
+  LessEq       r275, r274, r273
+  Const        r276, "cnt"
+  Index        r277, r210, r276
+  Const        r278, 20
+  LessEq       r279, r277, r278
+  Move         r280, r275
+  JumpIfFalse  r280, L27
+  Move         r280, r279
+L27:
+  JumpIfFalse  r280, L28
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  Const        r281, "ss_customer_sk"
+  Index        r282, r210, r281
+  // from dn1 in dn
+  Index        r283, r268, r282
+  Const        r284, nil
+  NotEqual     r285, r283, r284
+  JumpIfTrue   r285, L29
+  MakeList     r286, 0, r0
+  SetIndex     r268, r282, r286
+L29:
+  Index        r283, r268, r282
+  Append       r287, r283, r271
+  SetIndex     r268, r282, r287
+L28:
+  Const        r288, 1
+  AddInt       r269, r269, r288
+  Jump         L30
+L26:
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  Const        r289, 0
+L36:
+  LessInt      r290, r289, r189
+  JumpIfFalse  r290, L31
+  Index        r198, r188, r289
+  Const        r292, "c_customer_sk"
+  Index        r293, r198, r292
+  Index        r294, r268, r293
+  Const        r295, nil
+  NotEqual     r296, r294, r295
+  JumpIfFalse  r296, L32
+  Len          r297, r294
+  Const        r298, 0
+L35:
+  LessInt      r299, r298, r297
+  JumpIfFalse  r299, L32
+  Index        r210, r294, r298
+  // where dn1.cnt >= 15 && dn1.cnt <= 20
+  Const        r301, "cnt"
+  Index        r302, r210, r301
+  Const        r303, 15
+  LessEq       r304, r303, r302
+  Const        r305, "cnt"
+  Index        r306, r210, r305
+  Const        r307, 20
+  LessEq       r308, r306, r307
+  Move         r309, r304
+  JumpIfFalse  r309, L33
+  Move         r309, r308
+L33:
+  JumpIfFalse  r309, L34
+  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
+  Const        r310, "c_last_name"
+  Const        r311, "c_last_name"
+  Index        r312, r198, r311
+  Const        r313, "c_first_name"
+  Const        r314, "c_first_name"
+  Index        r315, r198, r314
+  Const        r316, "c_salutation"
+  Const        r317, "c_salutation"
+  Index        r318, r198, r317
+  Const        r319, "c_preferred_cust_flag"
+  Const        r320, "c_preferred_cust_flag"
+  Index        r321, r198, r320
+  Const        r322, "ss_ticket_number"
+  Const        r323, "ss_ticket_number"
+  Index        r324, r210, r323
+  Const        r325, "cnt"
+  Const        r326, "cnt"
+  Index        r327, r210, r326
+  Move         r328, r310
+  Move         r329, r312
+  Move         r330, r313
+  Move         r331, r315
+  Move         r332, r316
+  Move         r333, r318
+  Move         r334, r319
+  Move         r335, r321
+  Move         r336, r322
+  Move         r337, r324
+  Move         r338, r325
+  Move         r339, r327
+  MakeMap      r340, 6, r328
+  // sort by c.c_last_name
+  Const        r341, "c_last_name"
+  Index        r343, r198, r341
+  // from dn1 in dn
+  Move         r344, r340
+  MakeList     r345, 2, r343
+  Append       r185, r185, r345
+L34:
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  Const        r347, 1
+  AddInt       r298, r298, r347
+  Jump         L35
+L32:
+  Const        r348, 1
+  AddInt       r289, r289, r348
+  Jump         L36
+L31:
+  // sort by c.c_last_name
+  Sort         r185, r185
+  // json(result)
+  JSON         r185
+  // expect result == [{c_last_name: "Smith", c_first_name: "John", c_salutation: "Mr.", c_preferred_cust_flag: "Y", ss_ticket_number: 1, cnt: 16}]
+  Const        r350, [{"c_first_name": "John", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Mr.", "cnt": 16, "ss_ticket_number": 1}]
+  Equal        r351, r185, r350
+  Expect       r351
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q35.ir.out
+++ b/tests/dataset/tpc-ds/out/q35.ir.out
@@ -1,0 +1,403 @@
+func main (regs=296)
+L0:
+  // let customer = [
+  Const        r0, [{"c_current_addr_sk": 1, "c_current_cdemo_sk": 1, "c_customer_sk": 1}, {"c_current_addr_sk": 2, "c_current_cdemo_sk": 2, "c_customer_sk": 2}]
+  // let customer_address = [
+  Const        r1, [{"ca_address_sk": 1, "ca_state": "CA"}, {"ca_address_sk": 2, "ca_state": "NY"}]
+  // let customer_demographics = [
+  Const        r2, [{"cd_demo_sk": 1, "cd_dep_college_count": 0, "cd_dep_count": 1, "cd_dep_employed_count": 1, "cd_gender": "M", "cd_marital_status": "S"}, {"cd_demo_sk": 2, "cd_dep_college_count": 1, "cd_dep_count": 2, "cd_dep_employed_count": 1, "cd_gender": "F", "cd_marital_status": "M"}]
+  // let store_sales = [
+  Const        r3, [{"ss_customer_sk": 1, "ss_sold_date_sk": 1}]
+  // let date_dim = [
+  Const        r4, [{"d_date_sk": 1, "d_qoy": 1, "d_year": 2000}]
+  // from ss in store_sales
+  Const        r5, []
+  IterPrep     r6, r3
+  Len          r7, r6
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r8, r4
+  Len          r9, r8
+  // from ss in store_sales
+  Const        r10, 0
+  EqualInt     r11, r7, r10
+  JumpIfTrue   r11, L0
+  EqualInt     r12, r9, r10
+  JumpIfTrue   r12, L0
+  LessEq       r13, r9, r7
+  JumpIfFalse  r13, L1
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  MakeMap      r14, 0, r0
+  Const        r15, 0
+L6:
+  LessInt      r16, r15, r9
+  JumpIfFalse  r16, L2
+  Index        r17, r8, r15
+  Move         r18, r17
+  // where d.d_year == 2000 && d.d_qoy < 4
+  Const        r19, "d_year"
+  Index        r20, r18, r19
+  Const        r21, "d_qoy"
+  Index        r22, r18, r21
+  Const        r23, 4
+  Less         r24, r22, r23
+  Const        r25, 2000
+  Equal        r27, r20, r25
+  JumpIfFalse  r27, L3
+  Move         r27, r24
+L3:
+  JumpIfFalse  r27, L4
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r28, "d_date_sk"
+  Index        r29, r18, r28
+  Index        r30, r14, r29
+  Const        r31, nil
+  NotEqual     r32, r30, r31
+  JumpIfTrue   r32, L5
+  MakeList     r33, 0, r0
+  SetIndex     r14, r29, r33
+L5:
+  Index        r30, r14, r29
+  Append       r34, r30, r17
+  SetIndex     r14, r29, r34
+L4:
+  Const        r35, 1
+  AddInt       r15, r15, r35
+  Jump         L6
+L2:
+  // from ss in store_sales
+  Const        r36, 0
+L11:
+  LessInt      r37, r36, r7
+  JumpIfFalse  r37, L0
+  Index        r39, r6, r36
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r40, "ss_sold_date_sk"
+  Index        r41, r39, r40
+  // from ss in store_sales
+  Index        r42, r14, r41
+  Const        r43, nil
+  NotEqual     r44, r42, r43
+  JumpIfFalse  r44, L7
+  Len          r45, r42
+  Const        r46, 0
+L10:
+  LessInt      r47, r46, r45
+  JumpIfFalse  r47, L7
+  Index        r18, r42, r46
+  // where d.d_year == 2000 && d.d_qoy < 4
+  Const        r49, "d_year"
+  Index        r50, r18, r49
+  Const        r51, "d_qoy"
+  Index        r52, r18, r51
+  Const        r53, 4
+  Less         r54, r52, r53
+  Const        r55, 2000
+  Equal        r57, r50, r55
+  JumpIfFalse  r57, L8
+  Move         r57, r54
+L8:
+  JumpIfFalse  r57, L9
+  // select ss.ss_customer_sk
+  Const        r58, "ss_customer_sk"
+  Index        r59, r39, r58
+  // from ss in store_sales
+  Append       r5, r5, r59
+L9:
+  Const        r61, 1
+  AddInt       r46, r46, r61
+  Jump         L10
+L7:
+  Const        r62, 1
+  AddInt       r36, r36, r62
+  Jump         L11
+L1:
+  MakeMap      r63, 0, r0
+  Const        r64, 0
+L14:
+  LessInt      r65, r64, r7
+  JumpIfFalse  r65, L12
+  Index        r66, r6, r64
+  Move         r39, r66
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r67, "ss_sold_date_sk"
+  Index        r68, r39, r67
+  // from ss in store_sales
+  Index        r69, r63, r68
+  Const        r70, nil
+  NotEqual     r71, r69, r70
+  JumpIfTrue   r71, L13
+  MakeList     r72, 0, r0
+  SetIndex     r63, r68, r72
+L13:
+  Index        r69, r63, r68
+  Append       r73, r69, r66
+  SetIndex     r63, r68, r73
+  Const        r74, 1
+  AddInt       r64, r64, r74
+  Jump         L14
+L12:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r75, 0
+L20:
+  LessInt      r76, r75, r9
+  JumpIfFalse  r76, L15
+  Index        r18, r8, r75
+  Const        r78, "d_date_sk"
+  Index        r79, r18, r78
+  Index        r80, r63, r79
+  Const        r81, nil
+  NotEqual     r82, r80, r81
+  JumpIfFalse  r82, L16
+  Len          r83, r80
+  Const        r84, 0
+L19:
+  LessInt      r85, r84, r83
+  JumpIfFalse  r85, L16
+  Index        r39, r80, r84
+  // where d.d_year == 2000 && d.d_qoy < 4
+  Const        r87, "d_year"
+  Index        r88, r18, r87
+  Const        r89, "d_qoy"
+  Index        r90, r18, r89
+  Const        r91, 4
+  Less         r92, r90, r91
+  Const        r93, 2000
+  Equal        r95, r88, r93
+  JumpIfFalse  r95, L17
+  Move         r95, r92
+L17:
+  JumpIfFalse  r95, L18
+  // select ss.ss_customer_sk
+  Const        r96, "ss_customer_sk"
+  Index        r97, r39, r96
+  // from ss in store_sales
+  Append       r5, r5, r97
+L18:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r99, 1
+  AddInt       r84, r84, r99
+  Jump         L19
+L16:
+  Const        r100, 1
+  AddInt       r75, r75, r100
+  Jump         L20
+L15:
+  // from c in customer
+  Const        r101, []
+  MakeMap      r134, 0, r0
+  Const        r135, []
+  IterPrep     r137, r0
+  Len          r138, r137
+  Const        r139, 0
+L28:
+  LessInt      r140, r139, r138
+  JumpIfFalse  r140, L21
+  Index        r142, r137, r139
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  IterPrep     r143, r1
+  Len          r144, r143
+  Const        r145, 0
+L27:
+  LessInt      r146, r145, r144
+  JumpIfFalse  r146, L22
+  Index        r148, r143, r145
+  Const        r149, "c_current_addr_sk"
+  Index        r150, r142, r149
+  Const        r151, "ca_address_sk"
+  Index        r152, r148, r151
+  Equal        r153, r150, r152
+  JumpIfFalse  r153, L23
+  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
+  IterPrep     r154, r2
+  Len          r155, r154
+  Const        r156, 0
+L26:
+  LessInt      r157, r156, r155
+  JumpIfFalse  r157, L23
+  Index        r159, r154, r156
+  Const        r160, "c_current_cdemo_sk"
+  Index        r161, r142, r160
+  Const        r162, "cd_demo_sk"
+  Index        r163, r159, r162
+  Equal        r164, r161, r163
+  JumpIfFalse  r164, L24
+  // where c.c_customer_sk in purchased
+  Const        r165, "c_customer_sk"
+  Index        r166, r142, r165
+  In           r167, r166, r5
+  JumpIfFalse  r167, L24
+  // from c in customer
+  Const        r168, "c"
+  Move         r169, r142
+  Const        r170, "ca"
+  Move         r171, r148
+  Const        r172, "cd"
+  Move         r173, r159
+  MakeMap      r174, 3, r168
+  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
+  Const        r175, "state"
+  Const        r176, "ca_state"
+  Index        r177, r148, r176
+  Const        r178, "gender"
+  Const        r179, "cd_gender"
+  Index        r180, r159, r179
+  Const        r181, "marital"
+  Const        r182, "cd_marital_status"
+  Index        r183, r159, r182
+  Const        r184, "dep"
+  Const        r185, "cd_dep_count"
+  Index        r186, r159, r185
+  Const        r187, "emp"
+  Const        r188, "cd_dep_employed_count"
+  Index        r189, r159, r188
+  Const        r190, "col"
+  Const        r191, "cd_dep_college_count"
+  Index        r192, r159, r191
+  Move         r193, r175
+  Move         r194, r177
+  Move         r195, r178
+  Move         r196, r180
+  Move         r197, r181
+  Move         r198, r183
+  Move         r199, r184
+  Move         r200, r186
+  Move         r201, r187
+  Move         r202, r189
+  Move         r203, r190
+  Move         r204, r192
+  MakeMap      r205, 6, r193
+  Str          r206, r205
+  In           r207, r206, r134
+  JumpIfTrue   r207, L25
+  // from c in customer
+  Const        r208, []
+  Const        r209, "__group__"
+  Const        r210, true
+  Const        r211, "key"
+  // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
+  Move         r212, r205
+  // from c in customer
+  Const        r213, "items"
+  Move         r214, r208
+  Const        r215, "count"
+  Const        r216, 0
+  Move         r217, r209
+  Move         r218, r210
+  Move         r219, r211
+  Move         r220, r212
+  Move         r221, r213
+  Move         r222, r214
+  Move         r223, r215
+  Move         r224, r216
+  MakeMap      r225, 4, r217
+  SetIndex     r134, r206, r225
+  Append       r135, r135, r225
+L25:
+  Const        r227, "items"
+  Index        r228, r134, r206
+  Index        r229, r228, r227
+  Append       r230, r229, r174
+  SetIndex     r228, r227, r230
+  Const        r231, "count"
+  Index        r232, r228, r231
+  Const        r233, 1
+  AddInt       r234, r232, r233
+  SetIndex     r228, r231, r234
+L24:
+  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
+  Const        r235, 1
+  AddInt       r156, r156, r235
+  Jump         L26
+L23:
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  Const        r236, 1
+  AddInt       r145, r145, r236
+  Jump         L27
+L22:
+  // from c in customer
+  Const        r237, 1
+  AddInt       r139, r139, r237
+  Jump         L28
+L21:
+  Const        r238, 0
+  Len          r240, r135
+L30:
+  LessInt      r241, r238, r240
+  JumpIfFalse  r241, L29
+  Index        r243, r135, r238
+  // ca_state: g.key.state,
+  Const        r244, "ca_state"
+  Const        r245, "key"
+  Index        r246, r243, r245
+  Const        r247, "state"
+  Index        r248, r246, r247
+  // cd_gender: g.key.gender,
+  Const        r249, "cd_gender"
+  Const        r250, "key"
+  Index        r251, r243, r250
+  Const        r252, "gender"
+  Index        r253, r251, r252
+  // cd_marital_status: g.key.marital,
+  Const        r254, "cd_marital_status"
+  Const        r255, "key"
+  Index        r256, r243, r255
+  Const        r257, "marital"
+  Index        r258, r256, r257
+  // cd_dep_count: g.key.dep,
+  Const        r259, "cd_dep_count"
+  Const        r260, "key"
+  Index        r261, r243, r260
+  Const        r262, "dep"
+  Index        r263, r261, r262
+  // cd_dep_employed_count: g.key.emp,
+  Const        r264, "cd_dep_employed_count"
+  Const        r265, "key"
+  Index        r266, r243, r265
+  Const        r267, "emp"
+  Index        r268, r266, r267
+  // cd_dep_college_count: g.key.col,
+  Const        r269, "cd_dep_college_count"
+  Const        r270, "key"
+  Index        r271, r243, r270
+  Const        r272, "col"
+  Index        r273, r271, r272
+  // cnt: count(g)
+  Const        r274, "cnt"
+  Const        r275, "count"
+  Index        r276, r243, r275
+  // ca_state: g.key.state,
+  Move         r277, r244
+  Move         r278, r248
+  // cd_gender: g.key.gender,
+  Move         r279, r249
+  Move         r280, r253
+  // cd_marital_status: g.key.marital,
+  Move         r281, r254
+  Move         r282, r258
+  // cd_dep_count: g.key.dep,
+  Move         r283, r259
+  Move         r284, r263
+  // cd_dep_employed_count: g.key.emp,
+  Move         r285, r264
+  Move         r286, r268
+  // cd_dep_college_count: g.key.col,
+  Move         r287, r269
+  Move         r288, r273
+  // cnt: count(g)
+  Move         r289, r274
+  Move         r290, r276
+  // select {
+  MakeMap      r291, 7, r277
+  // from c in customer
+  Append       r101, r101, r291
+  Const        r293, 1
+  AddInt       r238, r238, r293
+  Jump         L30
+L29:
+  // json(groups)
+  JSON         r101
+  // expect groups == [{ca_state: "CA", cd_gender: "M", cd_marital_status: "S", cd_dep_count: 1, cd_dep_employed_count: 1, cd_dep_college_count: 0, cnt: 1}]
+  Const        r294, [{"ca_state": "CA", "cd_dep_college_count": 0, "cd_dep_count": 1, "cd_dep_employed_count": 1, "cd_gender": "M", "cd_marital_status": "S", "cnt": 1}]
+  Equal        r295, r101, r294
+  Expect       r295
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q36.ir.out
+++ b/tests/dataset/tpc-ds/out/q36.ir.out
@@ -1,0 +1,241 @@
+func main (regs=205)
+  // let store_sales = [
+  Const        r0, [{"ss_ext_sales_price": 100, "ss_item_sk": 1, "ss_net_profit": 20, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 200, "ss_item_sk": 2, "ss_net_profit": 50, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 150, "ss_item_sk": 3, "ss_net_profit": 30, "ss_sold_date_sk": 1, "ss_store_sk": 2}]
+  // let item = [
+  Const        r1, [{"i_category": "Books", "i_class": "C1", "i_item_sk": 1}, {"i_category": "Books", "i_class": "C2", "i_item_sk": 2}, {"i_category": "Electronics", "i_class": "C3", "i_item_sk": 3}]
+  // let store = [
+  Const        r2, [{"s_state": "A", "s_store_sk": 1}, {"s_state": "B", "s_store_sk": 2}]
+  // let date_dim = [
+  Const        r3, [{"d_date_sk": 1, "d_year": 2000}]
+  // from ss in store_sales
+  Const        r4, []
+  MakeMap      r25, 0, r0
+  Const        r26, []
+  IterPrep     r28, r0
+  Len          r29, r28
+  Const        r30, 0
+L1:
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L0
+  Index        r33, r28, r30
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r34, r3
+  Len          r35, r34
+  Const        r36, 0
+L2:
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L1
+  Index        r39, r34, r36
+  Const        r40, "ss_sold_date_sk"
+  Index        r41, r33, r40
+  Const        r42, "d_date_sk"
+  Index        r43, r39, r42
+  Equal        r44, r41, r43
+  JumpIfFalse  r44, L2
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r45, r1
+  Len          r46, r45
+  Const        r47, 0
+L9:
+  LessInt      r48, r47, r46
+  JumpIfFalse  r48, L2
+  Index        r50, r45, r47
+  Const        r51, "ss_item_sk"
+  Index        r52, r33, r51
+  Const        r53, "i_item_sk"
+  Index        r54, r50, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L3
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  IterPrep     r56, r2
+  Len          r57, r56
+  Const        r58, 0
+L8:
+  LessInt      r59, r58, r57
+  JumpIfFalse  r59, L3
+  Index        r61, r56, r58
+  Const        r62, "ss_store_sk"
+  Index        r63, r33, r62
+  Const        r64, "s_store_sk"
+  Index        r65, r61, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L4
+  // where d.d_year == 2000 && (s.s_state == "A" || s.s_state == "B")
+  Const        r67, "d_year"
+  Index        r68, r39, r67
+  Const        r69, 2000
+  Equal        r71, r68, r69
+  JumpIfFalse  r71, L5
+  Const        r72, "s_state"
+  Index        r73, r61, r72
+  Const        r74, "A"
+  Equal        r75, r73, r74
+  Const        r76, "s_state"
+  Index        r77, r61, r76
+  Const        r78, "B"
+  Equal        r79, r77, r78
+  Move         r80, r75
+  JumpIfTrue   r80, L6
+L6:
+  Move         r71, r79
+L5:
+  JumpIfFalse  r71, L4
+  // from ss in store_sales
+  Const        r81, "ss"
+  Move         r82, r33
+  Const        r83, "d"
+  Move         r84, r39
+  Const        r85, "i"
+  Move         r86, r50
+  Const        r87, "s"
+  Move         r88, r61
+  MakeMap      r89, 4, r81
+  // group by {category: i.i_category, class: i.i_class} into g
+  Const        r90, "category"
+  Const        r91, "i_category"
+  Index        r92, r50, r91
+  Const        r93, "class"
+  Const        r94, "i_class"
+  Index        r95, r50, r94
+  Move         r96, r90
+  Move         r97, r92
+  Move         r98, r93
+  Move         r99, r95
+  MakeMap      r100, 2, r96
+  Str          r101, r100
+  In           r102, r101, r25
+  JumpIfTrue   r102, L7
+  // from ss in store_sales
+  Const        r103, []
+  Const        r104, "__group__"
+  Const        r105, true
+  Const        r106, "key"
+  // group by {category: i.i_category, class: i.i_class} into g
+  Move         r107, r100
+  // from ss in store_sales
+  Const        r108, "items"
+  Move         r109, r103
+  Const        r110, "count"
+  Const        r111, 0
+  Move         r112, r104
+  Move         r113, r105
+  Move         r114, r106
+  Move         r115, r107
+  Move         r116, r108
+  Move         r117, r109
+  Move         r118, r110
+  Move         r119, r111
+  MakeMap      r120, 4, r112
+  SetIndex     r25, r101, r120
+  Append       r26, r26, r120
+L7:
+  Const        r122, "items"
+  Index        r123, r25, r101
+  Index        r124, r123, r122
+  Append       r125, r124, r89
+  SetIndex     r123, r122, r125
+  Const        r126, "count"
+  Index        r127, r123, r126
+  Const        r128, 1
+  AddInt       r129, r127, r128
+  SetIndex     r123, r126, r129
+L4:
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  Const        r130, 1
+  AddInt       r58, r58, r130
+  Jump         L8
+L3:
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  Const        r131, 1
+  AddInt       r47, r47, r131
+  Jump         L9
+L0:
+  // from ss in store_sales
+  Const        r134, 0
+  Len          r136, r26
+L15:
+  LessInt      r137, r134, r136
+  JumpIfFalse  r137, L10
+  Index        r139, r26, r134
+  // i_category: g.key.category,
+  Const        r140, "i_category"
+  Const        r141, "key"
+  Index        r142, r139, r141
+  Const        r143, "category"
+  Index        r144, r142, r143
+  // i_class: g.key.class,
+  Const        r145, "i_class"
+  Const        r146, "key"
+  Index        r147, r139, r146
+  Const        r148, "class"
+  Index        r149, r147, r148
+  // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
+  Const        r150, "gross_margin"
+  Const        r151, []
+  IterPrep     r153, r139
+  Len          r154, r153
+  Const        r155, 0
+L12:
+  LessInt      r157, r155, r154
+  JumpIfFalse  r157, L11
+  Index        r159, r153, r155
+  Const        r160, "ss_net_profit"
+  Index        r161, r159, r160
+  Append       r151, r151, r161
+  Const        r163, 1
+  AddInt       r155, r155, r163
+  Jump         L12
+L11:
+  Sum          r164, r151
+  Const        r165, []
+  IterPrep     r167, r139
+  Len          r168, r167
+  Const        r169, 0
+L14:
+  LessInt      r171, r169, r168
+  JumpIfFalse  r171, L13
+  Index        r159, r167, r169
+  Const        r173, "ss_ext_sales_price"
+  Index        r174, r159, r173
+  Append       r165, r165, r174
+  Const        r176, 1
+  AddInt       r169, r169, r176
+  Jump         L14
+L13:
+  Sum          r177, r165
+  Div          r178, r164, r177
+  // i_category: g.key.category,
+  Move         r179, r140
+  Move         r180, r144
+  // i_class: g.key.class,
+  Move         r181, r145
+  Move         r182, r149
+  // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
+  Move         r183, r150
+  Move         r184, r178
+  // select {
+  MakeMap      r185, 3, r179
+  // sort by [g.key.category, g.key.class]
+  Const        r186, "key"
+  Index        r187, r139, r186
+  Const        r188, "category"
+  Index        r190, r187, r188
+  Const        r191, "key"
+  MakeList     r197, 2, r190
+  // from ss in store_sales
+  Move         r198, r185
+  MakeList     r199, 2, r197
+  Append       r4, r4, r199
+  Const        r201, 1
+  AddInt       r134, r134, r201
+  Jump         L15
+L10:
+  // sort by [g.key.category, g.key.class]
+  Sort         r4, r4
+  // json(result)
+  JSON         r4
+  // expect result == [
+  Const        r203, [{"gross_margin": 0.2, "i_category": "Books", "i_class": "C1"}, {"gross_margin": 0.25, "i_category": "Books", "i_class": "C2"}, {"gross_margin": 0.2, "i_category": "Electronics", "i_class": "C3"}]
+  Equal        r204, r4, r203
+  Expect       r204
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q37.ir.out
+++ b/tests/dataset/tpc-ds/out/q37.ir.out
@@ -1,0 +1,231 @@
+func main (regs=197)
+  // let item = [
+  Const        r0, [{"i_current_price": 30, "i_item_desc": "Item1", "i_item_id": "I1", "i_item_sk": 1, "i_manufact_id": 800}, {"i_current_price": 60, "i_item_desc": "Item2", "i_item_id": "I2", "i_item_sk": 2, "i_manufact_id": 801}]
+  // let inventory = [
+  Const        r1, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 200, "inv_warehouse_sk": 1}, {"inv_date_sk": 1, "inv_item_sk": 2, "inv_quantity_on_hand": 300, "inv_warehouse_sk": 1}]
+  // let date_dim = [
+  Const        r2, [{"d_date": "2000-01-15", "d_date_sk": 1}]
+  // let catalog_sales = [
+  Const        r3, [{"cs_item_sk": 1, "cs_sold_date_sk": 1}]
+  // from i in item
+  Const        r4, []
+  MakeMap      r28, 0, r0
+  Const        r29, []
+  IterPrep     r31, r0
+  Len          r32, r31
+  Const        r33, 0
+L1:
+  LessInt      r34, r33, r32
+  JumpIfFalse  r34, L0
+  Index        r36, r31, r33
+  // join inv in inventory on i.i_item_sk == inv.inv_item_sk
+  IterPrep     r37, r1
+  Len          r38, r37
+  Const        r39, 0
+L2:
+  LessInt      r40, r39, r38
+  JumpIfFalse  r40, L1
+  Index        r42, r37, r39
+  Const        r43, "i_item_sk"
+  Index        r44, r36, r43
+  Const        r45, "inv_item_sk"
+  Index        r46, r42, r45
+  Equal        r47, r44, r46
+  JumpIfFalse  r47, L2
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  IterPrep     r48, r2
+  Len          r49, r48
+  Const        r50, 0
+L12:
+  LessInt      r51, r50, r49
+  JumpIfFalse  r51, L2
+  Index        r53, r48, r50
+  Const        r54, "inv_date_sk"
+  Index        r55, r42, r54
+  Const        r56, "d_date_sk"
+  Index        r57, r53, r56
+  Equal        r58, r55, r57
+  JumpIfFalse  r58, L3
+  // join cs in catalog_sales on cs.cs_item_sk == i.i_item_sk
+  IterPrep     r59, r3
+  Len          r60, r59
+  Const        r61, 0
+L11:
+  LessInt      r62, r61, r60
+  JumpIfFalse  r62, L3
+  Index        r64, r59, r61
+  Const        r65, "cs_item_sk"
+  Index        r66, r64, r65
+  Const        r67, "i_item_sk"
+  Index        r68, r36, r67
+  Equal        r69, r66, r68
+  JumpIfFalse  r69, L4
+  // where i.i_current_price >= 20 && i.i_current_price <= 50 && i.i_manufact_id >= 800 && i.i_manufact_id <= 803 && inv.inv_quantity_on_hand >= 100 && inv.inv_quantity_on_hand <= 500
+  Const        r70, "i_current_price"
+  Index        r71, r36, r70
+  Const        r72, 20
+  LessEq       r73, r72, r71
+  Const        r74, "i_current_price"
+  Index        r75, r36, r74
+  Const        r76, 50
+  LessEq       r77, r75, r76
+  Const        r78, "i_manufact_id"
+  Index        r79, r36, r78
+  Const        r80, 800
+  LessEq       r81, r80, r79
+  Const        r82, "i_manufact_id"
+  Index        r83, r36, r82
+  Const        r84, 803
+  LessEq       r85, r83, r84
+  Const        r86, "inv_quantity_on_hand"
+  Index        r87, r42, r86
+  Const        r88, 100
+  LessEq       r89, r88, r87
+  Const        r90, "inv_quantity_on_hand"
+  Index        r91, r42, r90
+  Const        r92, 500
+  LessEq       r93, r91, r92
+  Move         r94, r73
+  JumpIfFalse  r94, L5
+L5:
+  Move         r95, r77
+  JumpIfFalse  r95, L6
+L6:
+  Move         r96, r81
+  JumpIfFalse  r96, L7
+L7:
+  Move         r97, r85
+  JumpIfFalse  r97, L8
+L8:
+  Move         r98, r89
+  JumpIfFalse  r98, L9
+  Move         r98, r93
+L9:
+  JumpIfFalse  r98, L4
+  // from i in item
+  Const        r99, "i"
+  Move         r100, r36
+  Const        r101, "inv"
+  Move         r102, r42
+  Const        r103, "d"
+  Move         r104, r53
+  Const        r105, "cs"
+  Move         r106, r64
+  MakeMap      r107, 4, r99
+  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
+  Const        r108, "id"
+  Const        r109, "i_item_id"
+  Index        r110, r36, r109
+  Const        r111, "desc"
+  Const        r112, "i_item_desc"
+  Index        r113, r36, r112
+  Const        r114, "price"
+  Const        r115, "i_current_price"
+  Index        r116, r36, r115
+  Move         r117, r108
+  Move         r118, r110
+  Move         r119, r111
+  Move         r120, r113
+  Move         r121, r114
+  Move         r122, r116
+  MakeMap      r123, 3, r117
+  Str          r124, r123
+  In           r125, r124, r28
+  JumpIfTrue   r125, L10
+  // from i in item
+  Const        r126, []
+  Const        r127, "__group__"
+  Const        r128, true
+  Const        r129, "key"
+  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
+  Move         r130, r123
+  // from i in item
+  Const        r131, "items"
+  Move         r132, r126
+  Const        r133, "count"
+  Const        r134, 0
+  Move         r135, r127
+  Move         r136, r128
+  Move         r137, r129
+  Move         r138, r130
+  Move         r139, r131
+  Move         r140, r132
+  Move         r141, r133
+  Move         r142, r134
+  MakeMap      r143, 4, r135
+  SetIndex     r28, r124, r143
+  Append       r29, r29, r143
+L10:
+  Const        r145, "items"
+  Index        r146, r28, r124
+  Index        r147, r146, r145
+  Append       r148, r147, r107
+  SetIndex     r146, r145, r148
+  Const        r149, "count"
+  Index        r150, r146, r149
+  Const        r151, 1
+  AddInt       r152, r150, r151
+  SetIndex     r146, r149, r152
+L4:
+  // join cs in catalog_sales on cs.cs_item_sk == i.i_item_sk
+  Const        r153, 1
+  AddInt       r61, r61, r153
+  Jump         L11
+L3:
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  Const        r154, 1
+  AddInt       r50, r50, r154
+  Jump         L12
+L0:
+  // from i in item
+  Const        r157, 0
+  Len          r159, r29
+L14:
+  LessInt      r160, r157, r159
+  JumpIfFalse  r160, L13
+  Index        r162, r29, r157
+  // select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
+  Const        r163, "i_item_id"
+  Const        r164, "key"
+  Index        r165, r162, r164
+  Const        r166, "id"
+  Index        r167, r165, r166
+  Const        r168, "i_item_desc"
+  Const        r169, "key"
+  Index        r170, r162, r169
+  Const        r171, "desc"
+  Index        r172, r170, r171
+  Const        r173, "i_current_price"
+  Const        r174, "key"
+  Index        r175, r162, r174
+  Const        r176, "price"
+  Index        r177, r175, r176
+  Move         r178, r163
+  Move         r179, r167
+  Move         r180, r168
+  Move         r181, r172
+  Move         r182, r173
+  Move         r183, r177
+  MakeMap      r184, 3, r178
+  // sort by g.key.id
+  Const        r185, "key"
+  Index        r186, r162, r185
+  Const        r187, "id"
+  Index        r189, r186, r187
+  // from i in item
+  Move         r190, r184
+  MakeList     r191, 2, r189
+  Append       r4, r4, r191
+  Const        r193, 1
+  AddInt       r157, r157, r193
+  Jump         L14
+L13:
+  // sort by g.key.id
+  Sort         r4, r4
+  // json(result)
+  JSON         r4
+  // expect result == [{i_item_id: "I1", i_item_desc: "Item1", i_current_price: 30.0}]
+  Const        r195, [{"i_current_price": 30, "i_item_desc": "Item1", "i_item_id": "I1"}]
+  Equal        r196, r4, r195
+  Expect       r196
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q38.ir.out
+++ b/tests/dataset/tpc-ds/out/q38.ir.out
@@ -1,0 +1,140 @@
+func main (regs=87)
+  // let customer = [
+  Const        r0, [{"c_customer_sk": 1, "c_first_name": "John", "c_last_name": "Smith"}, {"c_customer_sk": 2, "c_first_name": "Alice", "c_last_name": "Jones"}]
+  // let store_sales = [
+  Const        r1, [{"d_month_seq": 1200, "ss_customer_sk": 1}, {"d_month_seq": 1205, "ss_customer_sk": 2}]
+  // let catalog_sales = [
+  Const        r2, [{"cs_bill_customer_sk": 1, "d_month_seq": 1203}]
+  // let web_sales = [
+  Const        r3, [{"d_month_seq": 1206, "ws_bill_customer_sk": 1}]
+  // let store_ids = distinct(from s in store_sales where s.d_month_seq >= 1200 && s.d_month_seq <= 1211 select s.ss_customer_sk)
+  Const        r5, []
+  IterPrep     r9, r1
+  Len          r10, r9
+  Const        r11, 0
+L2:
+  LessInt      r13, r11, r10
+  JumpIfFalse  r13, L0
+  Index        r15, r9, r11
+  Const        r16, "d_month_seq"
+  Index        r17, r15, r16
+  Const        r18, 1200
+  LessEq       r19, r18, r17
+  Const        r20, "d_month_seq"
+  Index        r21, r15, r20
+  Const        r22, 1211
+  LessEq       r23, r21, r22
+  Move         r24, r19
+  JumpIfFalse  r24, L1
+  Move         r24, r23
+L1:
+  JumpIfFalse  r24, L2
+  Const        r25, "ss_customer_sk"
+  Index        r26, r15, r25
+  Append       r5, r5, r26
+  Jump         L2
+L0:
+  Move         r4, r5
+  Call         r29, distinct, r4
+  // let catalog_ids = distinct(from c in catalog_sales where c.d_month_seq >= 1200 && c.d_month_seq <= 1211 select c.cs_bill_customer_sk)
+  Const        r31, []
+  IterPrep     r35, r2
+  Len          r36, r35
+  Const        r37, 0
+L6:
+  LessInt      r39, r37, r36
+  JumpIfFalse  r39, L3
+  Index        r41, r35, r37
+  Const        r42, "d_month_seq"
+  Index        r43, r41, r42
+  Const        r44, 1200
+  LessEq       r45, r44, r43
+  Const        r46, "d_month_seq"
+  Index        r47, r41, r46
+  Const        r48, 1211
+  LessEq       r49, r47, r48
+  Move         r50, r45
+  JumpIfFalse  r50, L4
+  Move         r50, r49
+L4:
+  JumpIfFalse  r50, L5
+  Const        r51, "cs_bill_customer_sk"
+  Index        r52, r41, r51
+  Append       r31, r31, r52
+L5:
+  Const        r54, 1
+  AddInt       r37, r37, r54
+  Jump         L6
+L3:
+  Move         r30, r31
+  Call         r55, distinct, r30
+  // let web_ids = distinct(from w in web_sales where w.d_month_seq >= 1200 && w.d_month_seq <= 1211 select w.ws_bill_customer_sk)
+  Const        r57, []
+  IterPrep     r61, r3
+  Len          r62, r61
+  Const        r63, 0
+L10:
+  LessInt      r65, r63, r62
+  JumpIfFalse  r65, L7
+  Index        r67, r61, r63
+  Const        r68, "d_month_seq"
+  Index        r69, r67, r68
+  Const        r70, 1200
+  LessEq       r71, r70, r69
+  Const        r72, "d_month_seq"
+  Index        r73, r67, r72
+  Const        r74, 1211
+  LessEq       r75, r73, r74
+  Move         r76, r71
+  JumpIfFalse  r76, L8
+  Move         r76, r75
+L8:
+  JumpIfFalse  r76, L9
+  Const        r77, "ws_bill_customer_sk"
+  Index        r78, r67, r77
+  Append       r57, r57, r78
+L9:
+  Const        r80, 1
+  AddInt       r63, r63, r80
+  Jump         L10
+L7:
+  Move         r56, r57
+  Call         r81, distinct, r56
+  // let hot = store_ids intersect catalog_ids intersect web_ids
+  Intersect    r82, r29, r55
+  Intersect    r83, r82, r81
+  // let result = len(hot)
+  Len          r84, r83
+  // json(result)
+  JSON         r84
+  // expect result == 1
+  Const        r85, 1
+  EqualInt     r86, r84, r85
+  Expect       r86
+  Return       r0
+
+  // fun distinct(xs: list<any>): list<any> {
+func distinct (regs=14)
+  // var out = []
+  Const        r2, []
+  // for x in xs {
+  IterPrep     r3, r0
+  Len          r4, r3
+  Const        r5, 0
+L2:
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r8, r3, r5
+  // if !contains(out, x) {
+  Not          r10, r9
+  JumpIfFalse  r10, L1
+  // out = append(out, x)
+  Append       r2, r2, r8
+L1:
+  // for x in xs {
+  Const        r12, 1
+  Add          r5, r5, r12
+  Jump         L2
+L0:
+  // return out
+  Return       r2

--- a/tests/dataset/tpc-ds/out/q39.ir.out
+++ b/tests/dataset/tpc-ds/out/q39.ir.out
@@ -1,0 +1,353 @@
+func main (regs=280)
+  // let inventory = [
+  Const        r0, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 10, "inv_warehouse_sk": 1}, {"inv_date_sk": 2, "inv_item_sk": 1, "inv_quantity_on_hand": 10, "inv_warehouse_sk": 1}, {"inv_date_sk": 3, "inv_item_sk": 1, "inv_quantity_on_hand": 250, "inv_warehouse_sk": 1}]
+  // let item = [
+  Const        r1, [{"i_item_sk": 1}]
+  // let warehouse = [
+  Const        r2, [{"w_warehouse_name": "W1", "w_warehouse_sk": 1}]
+  // let date_dim = [
+  Const        r3, [{"d_date_sk": 1, "d_moy": 1, "d_year": 2000}, {"d_date_sk": 2, "d_moy": 2, "d_year": 2000}, {"d_date_sk": 3, "d_moy": 3, "d_year": 2000}]
+  // from inv in inventory
+  Const        r4, []
+  MakeMap      r20, 0, r0
+  Const        r21, []
+  IterPrep     r23, r0
+  Len          r24, r23
+  Const        r25, 0
+L1:
+  LessInt      r26, r25, r24
+  JumpIfFalse  r26, L0
+  Index        r28, r23, r25
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  IterPrep     r29, r3
+  Len          r30, r29
+  Const        r31, 0
+L2:
+  LessInt      r32, r31, r30
+  JumpIfFalse  r32, L1
+  Index        r34, r29, r31
+  Const        r35, "inv_date_sk"
+  Index        r36, r28, r35
+  Const        r37, "d_date_sk"
+  Index        r38, r34, r37
+  Equal        r39, r36, r38
+  JumpIfFalse  r39, L2
+  // join i in item on inv.inv_item_sk == i.i_item_sk
+  IterPrep     r40, r1
+  Len          r41, r40
+  Const        r42, 0
+L7:
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L2
+  Index        r45, r40, r42
+  Const        r46, "inv_item_sk"
+  Index        r47, r28, r46
+  Const        r48, "i_item_sk"
+  Index        r49, r45, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L3
+  // join w in warehouse on inv.inv_warehouse_sk == w.w_warehouse_sk
+  IterPrep     r51, r2
+  Len          r52, r51
+  Const        r53, 0
+L6:
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L3
+  Index        r56, r51, r53
+  Const        r57, "inv_warehouse_sk"
+  Index        r58, r28, r57
+  Const        r59, "w_warehouse_sk"
+  Index        r60, r56, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L4
+  // where d.d_year == 2000
+  Const        r62, "d_year"
+  Index        r63, r34, r62
+  Const        r64, 2000
+  Equal        r65, r63, r64
+  JumpIfFalse  r65, L4
+  // from inv in inventory
+  Const        r66, "inv"
+  Move         r67, r28
+  Const        r68, "d"
+  Move         r69, r34
+  Const        r70, "i"
+  Move         r71, r45
+  Const        r72, "w"
+  Move         r73, r56
+  MakeMap      r74, 4, r66
+  // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
+  Const        r75, "w"
+  Const        r76, "w_warehouse_sk"
+  Index        r77, r56, r76
+  Const        r78, "i"
+  Const        r79, "i_item_sk"
+  Index        r80, r45, r79
+  Const        r81, "month"
+  Const        r82, "d_moy"
+  Index        r83, r34, r82
+  Move         r84, r75
+  Move         r85, r77
+  Move         r86, r78
+  Move         r87, r80
+  Move         r88, r81
+  Move         r89, r83
+  MakeMap      r90, 3, r84
+  Str          r91, r90
+  In           r92, r91, r20
+  JumpIfTrue   r92, L5
+  // from inv in inventory
+  Const        r93, []
+  Const        r94, "__group__"
+  Const        r95, true
+  Const        r96, "key"
+  // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
+  Move         r97, r90
+  // from inv in inventory
+  Const        r98, "items"
+  Move         r99, r93
+  Const        r100, "count"
+  Const        r101, 0
+  Move         r102, r94
+  Move         r103, r95
+  Move         r104, r96
+  Move         r105, r97
+  Move         r106, r98
+  Move         r107, r99
+  Move         r108, r100
+  Move         r109, r101
+  MakeMap      r110, 4, r102
+  SetIndex     r20, r91, r110
+  Append       r21, r21, r110
+L5:
+  Const        r112, "items"
+  Index        r113, r20, r91
+  Index        r114, r113, r112
+  Append       r115, r114, r74
+  SetIndex     r113, r112, r115
+  Const        r116, "count"
+  Index        r117, r113, r116
+  Const        r118, 1
+  AddInt       r119, r117, r118
+  SetIndex     r113, r116, r119
+L4:
+  // join w in warehouse on inv.inv_warehouse_sk == w.w_warehouse_sk
+  Const        r120, 1
+  AddInt       r53, r53, r120
+  Jump         L6
+L3:
+  // join i in item on inv.inv_item_sk == i.i_item_sk
+  Const        r121, 1
+  AddInt       r42, r42, r121
+  Jump         L7
+L0:
+  // from inv in inventory
+  Const        r124, 0
+  Len          r126, r21
+L11:
+  LessInt      r127, r124, r126
+  JumpIfFalse  r127, L8
+  Index        r129, r21, r124
+  // select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
+  Const        r130, "w"
+  Const        r131, "key"
+  Index        r132, r129, r131
+  Const        r133, "w"
+  Index        r134, r132, r133
+  Const        r135, "i"
+  Const        r136, "key"
+  Index        r137, r129, r136
+  Const        r138, "i"
+  Index        r139, r137, r138
+  Const        r140, "qty"
+  Const        r141, []
+  IterPrep     r143, r129
+  Len          r144, r143
+  Const        r145, 0
+L10:
+  LessInt      r147, r145, r144
+  JumpIfFalse  r147, L9
+  Index        r149, r143, r145
+  Const        r150, "inv_quantity_on_hand"
+  Index        r151, r149, r150
+  Append       r141, r141, r151
+  Const        r153, 1
+  AddInt       r145, r145, r153
+  Jump         L10
+L9:
+  Sum          r154, r141
+  Move         r155, r130
+  Move         r156, r134
+  Move         r157, r135
+  Move         r158, r139
+  Move         r159, r140
+  Move         r160, r154
+  MakeMap      r161, 3, r155
+  // from inv in inventory
+  Append       r4, r4, r161
+  Jump         L11
+L8:
+  // var grouped: map<string, map<string, any>> = {}
+  Const        r165, {}
+  // for m in monthly {
+  IterPrep     r166, r4
+  Len          r167, r166
+  Const        r168, 0
+L15:
+  Less         r169, r168, r167
+  JumpIfFalse  r169, L12
+  Index        r171, r166, r168
+  // let key = str({w: m.w, i: m.i})
+  Const        r172, "w"
+  Const        r173, "w"
+  Index        r174, r171, r173
+  Const        r175, "i"
+  Const        r176, "i"
+  Index        r177, r171, r176
+  Move         r178, r172
+  Move         r179, r174
+  Move         r180, r175
+  Move         r181, r177
+  MakeMap      r182, 2, r178
+  Str          r183, r182
+  // if key in grouped {
+  In           r184, r183, r165
+  JumpIfFalse  r184, L13
+  // let g = grouped[key]
+  Index        r185, r165, r183
+  // grouped[key] = {w: g.w, i: g.i, qtys: append(g.qtys, m.qty)}
+  Const        r186, "w"
+  Const        r187, "w"
+  Index        r188, r185, r187
+  Const        r189, "i"
+  Const        r190, "i"
+  Index        r191, r185, r190
+  Const        r192, "qtys"
+  Const        r193, "qtys"
+  Index        r194, r185, r193
+  Const        r195, "qty"
+  Index        r196, r171, r195
+  Append       r197, r194, r196
+  Move         r198, r186
+  Move         r199, r188
+  Move         r200, r189
+  Move         r201, r191
+  Move         r202, r192
+  Move         r203, r197
+  MakeMap      r204, 3, r198
+  SetIndex     r165, r183, r204
+  // if key in grouped {
+  Jump         L14
+L13:
+  // grouped[key] = {w: m.w, i: m.i, qtys: [m.qty]}
+  Const        r205, "w"
+  Const        r206, "w"
+  Index        r207, r171, r206
+  Const        r208, "i"
+  Const        r209, "i"
+  Index        r210, r171, r209
+  Const        r211, "qtys"
+  Const        r212, "qty"
+  Index        r214, r171, r212
+  MakeList     r215, 1, r214
+  Move         r216, r205
+  Move         r217, r207
+  Move         r218, r208
+  Move         r219, r210
+  Move         r220, r211
+  Move         r221, r215
+  MakeMap      r222, 3, r216
+  SetIndex     r165, r183, r222
+L14:
+  // for m in monthly {
+  Const        r223, 1
+  Add          r168, r168, r223
+  Jump         L15
+L12:
+  // var summary = []
+  Const        r226, []
+  // for g in values(grouped) {
+  Const        r227, []
+  IterPrep     r228, r227
+  Len          r229, r228
+  Const        r230, 0
+L20:
+  Less         r231, r230, r229
+  JumpIfFalse  r231, L16
+  Index        r129, r228, r230
+  // let mean = avg(g.qtys)
+  Const        r233, "qtys"
+  Index        r234, r129, r233
+  Avg          r235, r234
+  // var sumsq = 0.0
+  Const        r237, 0
+  // for q in g.qtys {
+  Const        r238, "qtys"
+  Index        r239, r129, r238
+  IterPrep     r240, r239
+  Len          r241, r240
+  Const        r242, 0
+L18:
+  Less         r243, r242, r241
+  JumpIfFalse  r243, L17
+  Index        r245, r240, r242
+  // sumsq = sumsq + (q - mean) * (q - mean)
+  SubFloat     r246, r245, r235
+  SubFloat     r247, r245, r235
+  MulFloat     r248, r246, r247
+  AddFloat     r237, r237, r248
+  // for q in g.qtys {
+  Const        r250, 1
+  Add          r242, r242, r250
+  Jump         L18
+L17:
+  // let variance = sumsq / len(g.qtys)
+  Const        r252, "qtys"
+  Index        r253, r129, r252
+  Len          r254, r253
+  DivFloat     r256, r237, r254
+  // let cov = sqrt(variance) / mean
+  Call         r257, sqrt, r256
+  DivFloat     r258, r257, r235
+  // if cov > 1.5 {
+  Const        r259, 1.5
+  LessFloat    r260, r259, r258
+  JumpIfFalse  r260, L19
+L19:
+  // for g in values(grouped) {
+  Const        r276, 1
+  Add          r230, r230, r276
+  Jump         L20
+L16:
+  // json(summary)
+  JSON         r226
+  // expect summary == [{w_warehouse_sk: 1, i_item_sk: 1, cov: 1.5396007178390022}]
+  Const        r278, [{"cov": 1.539600717839002, "i_item_sk": 1, "w_warehouse_sk": 1}]
+  Equal        r279, r226, r278
+  Expect       r279
+  Return       r0
+
+  // fun sqrt(x: float): float {
+func sqrt (regs=14)
+  // let guess = x / 2.0
+  Const        r1, 2
+  DivFloat     r3, r0, r1
+  // for i in 0..5 {
+  Const        r4, 0
+  Const        r5, 5
+  Move         r6, r4
+L1:
+  Less         r7, r6, r5
+  JumpIfFalse  r7, L0
+  // result = (result + x / result) / 2.0
+  DivFloat     r8, r0, r3
+  AddFloat     r9, r3, r8
+  Const        r10, 2
+  DivFloat     r3, r9, r10
+  // for i in 0..5 {
+  Const        r12, 1
+  Add          r6, r6, r12
+  Jump         L1
+L0:
+  // return result
+  Return       r3

--- a/tests/dataset/tpc-ds/q30.mochi
+++ b/tests/dataset/tpc-ds/q30.mochi
@@ -46,7 +46,6 @@ let result =
     c_last_name: c.c_last_name,
     ctr_total_return: ctr.ctr_total_return
   }
-  |> to_list
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q31.mochi
+++ b/tests/dataset/tpc-ds/q31.mochi
@@ -18,8 +18,8 @@ let web_sales = [
 
 let counties = ["A", "B"]
 
-let result =
-  from county in counties
+var result = []
+for county in counties {
   let ss1 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 1 select s.ss_ext_sales_price)
   let ss2 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 2 select s.ss_ext_sales_price)
   let ss3 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 3 select s.ss_ext_sales_price)
@@ -30,16 +30,17 @@ let result =
   let store_g1 = ss2 / ss1
   let web_g2 = ws3 / ws2
   let store_g2 = ss3 / ss2
-  where web_g1 > store_g1 && web_g2 > store_g2
-  select {
-    ca_county: county,
-    d_year: 2000,
-    web_q1_q2_increase: web_g1,
-    store_q1_q2_increase: store_g1,
-    web_q2_q3_increase: web_g2,
-    store_q2_q3_increase: store_g2
+  if web_g1 > store_g1 && web_g2 > store_g2 {
+    result = append(result, {
+      ca_county: county,
+      d_year: 2000,
+      web_q1_q2_increase: web_g1,
+      store_q1_q2_increase: store_g1,
+      web_q2_q3_increase: web_g2,
+      store_q2_q3_increase: store_g2
+    })
   }
-  |> to_list
+}
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q32.mochi
+++ b/tests/dataset/tpc-ds/q32.mochi
@@ -20,7 +20,7 @@ let filtered =
   join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   where i.i_manufact_id == 1 && d.d_year == 2000
   select cs.cs_ext_discount_amt
-  |> to_list
+  
 
 let avg_discount = avg(filtered)
 let result = sum(from x in filtered where x > avg_discount * 1.3 select x)

--- a/tests/dataset/tpc-ds/q33.mochi
+++ b/tests/dataset/tpc-ds/q33.mochi
@@ -33,19 +33,19 @@ let union_sales = concat(
     join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
     join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
     join i in item on ss.ss_item_sk == i.i_item_sk
-    where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == -5
+    where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
     select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
-  from cs in catalog_sales
-    join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-    join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
-    join i in item on cs.cs_item_sk == i.i_item_sk
-    where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == -5
+    from cs in catalog_sales
+      join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+      join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
+      join i in item on cs.cs_item_sk == i.i_item_sk
+      where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
     select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
-  from ws in web_sales
-    join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-    join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
-    join i in item on ws.ws_item_sk == i.i_item_sk
-    where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == -5
+    from ws in web_sales
+      join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+      join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
+      join i in item on ws.ws_item_sk == i.i_item_sk
+      where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
     select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
 )
 
@@ -54,7 +54,7 @@ let result =
   group by s.manu into g
   sort by -sum(from x in g select x.price)
   select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
-  |> to_list
+  
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q34.mochi
+++ b/tests/dataset/tpc-ds/q34.mochi
@@ -60,7 +60,7 @@ let result =
   where dn1.cnt >= 15 && dn1.cnt <= 20
   sort by c.c_last_name
   select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
-  |> to_list
+  
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q35.mochi
+++ b/tests/dataset/tpc-ds/q35.mochi
@@ -26,13 +26,13 @@ let purchased =
   join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   where d.d_year == 2000 && d.d_qoy < 4
   select ss.ss_customer_sk
-  |> to_list
+  
 
 let groups =
   from c in customer
   join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
   join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
-  where contains(purchased, c.c_customer_sk)
+  where c.c_customer_sk in purchased
   group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
   select {
     ca_state: g.key.state,
@@ -43,7 +43,7 @@ let groups =
     cd_dep_college_count: g.key.col,
     cnt: count(g)
   }
-  |> to_list
+  
 
 json(groups)
 

--- a/tests/dataset/tpc-ds/q36.mochi
+++ b/tests/dataset/tpc-ds/q36.mochi
@@ -26,13 +26,13 @@ let result =
   join s in store on ss.ss_store_sk == s.s_store_sk
   where d.d_year == 2000 && (s.s_state == "A" || s.s_state == "B")
   group by {category: i.i_category, class: i.i_class} into g
-  sort by g.key.category, g.key.class
+  sort by [g.key.category, g.key.class]
   select {
     i_category: g.key.category,
     i_class: g.key.class,
     gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
   }
-  |> to_list
+  
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q37.mochi
+++ b/tests/dataset/tpc-ds/q37.mochi
@@ -25,7 +25,7 @@ let result =
   group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
   sort by g.key.id
   select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
-  |> to_list
+  
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q38.mochi
+++ b/tests/dataset/tpc-ds/q38.mochi
@@ -16,9 +16,19 @@ let web_sales = [
   {ws_bill_customer_sk: 1, d_month_seq: 1206}
 ]
 
-let store_ids = from s in store_sales where s.d_month_seq >= 1200 && s.d_month_seq <= 1211 select s.ss_customer_sk |> to_list |> distinct
-let catalog_ids = from c in catalog_sales where c.d_month_seq >= 1200 && c.d_month_seq <= 1211 select c.cs_bill_customer_sk |> to_list |> distinct
-let web_ids = from w in web_sales where w.d_month_seq >= 1200 && w.d_month_seq <= 1211 select w.ws_bill_customer_sk |> to_list |> distinct
+fun distinct(xs: list<any>): list<any> {
+  var out = []
+  for x in xs {
+    if !contains(out, x) {
+      out = append(out, x)
+    }
+  }
+  return out
+}
+
+let store_ids = distinct(from s in store_sales where s.d_month_seq >= 1200 && s.d_month_seq <= 1211 select s.ss_customer_sk)
+let catalog_ids = distinct(from c in catalog_sales where c.d_month_seq >= 1200 && c.d_month_seq <= 1211 select c.cs_bill_customer_sk)
+let web_ids = distinct(from w in web_sales where w.d_month_seq >= 1200 && w.d_month_seq <= 1211 select w.ws_bill_customer_sk)
 
 let hot = store_ids intersect catalog_ids intersect web_ids
 let result = len(hot)

--- a/tests/dataset/tpc-ds/q39.mochi
+++ b/tests/dataset/tpc-ds/q39.mochi
@@ -1,6 +1,12 @@
-import python "math" as math
-extern fun math.pow(x: float, y: float): float
-extern fun math.sqrt(x: float): float
+
+fun sqrt(x: float): float {
+  let guess = x / 2.0
+  var result = guess
+  for i in 0..5 {
+    result = (result + x / result) / 2.0
+  }
+  return result
+}
 
 let inventory = [
   {inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 10},
@@ -31,17 +37,31 @@ let monthly =
   group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
   select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
 
-let summary =
-  from m in monthly
-  group by {w: m.w, i: m.i} into g
-  let qtys = to_list(from x in g select x.qty)
-  let mean = avg(qtys)
-  let variance = avg(from q in qtys select math.pow(q - mean, 2.0))
-  let stdev = math.sqrt(variance)
-  let cov = stdev / mean
-  where cov > 1.5
-  select {w_warehouse_sk: g.key.w, i_item_sk: g.key.i, cov: cov}
-  |> to_list
+var grouped: map<string, map<string, any>> = {}
+for m in monthly {
+  let key = str({w: m.w, i: m.i})
+  if key in grouped {
+    let g = grouped[key]
+    grouped[key] = {w: g.w, i: g.i, qtys: append(g.qtys, m.qty)}
+  } else {
+    grouped[key] = {w: m.w, i: m.i, qtys: [m.qty]}
+  }
+}
+
+var summary = []
+for g in values(grouped) {
+  let mean = avg(g.qtys)
+  var sumsq = 0.0
+  for q in g.qtys {
+    sumsq = sumsq + (q - mean) * (q - mean)
+  }
+  let variance = sumsq / len(g.qtys)
+  let cov = sqrt(variance) / mean
+  if cov > 1.5 {
+    summary = append(summary, {w_warehouse_sk: g.w, i_item_sk: g.i, cov: cov})
+  }
+}
+  
 
 json(summary)
 


### PR DESCRIPTION
## Summary
- update TPC‑DS queries q30‒q39 to avoid unsupported syntax
- add simple `distinct` helper for q38
- reimplement q31 and q39 logic without query `let` clauses
- generate IR outputs for the new queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68622b4a83988320bc5dabb9994c2d3d