### PR TITLE
Implement First op and update TPCDS IR

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -127,7 +127,6 @@ const (
 	OpIntersect
 	OpSort
 	OpExpect
-	OpFirst
 )
 
 func (op Op) String() string {
@@ -282,8 +281,6 @@ func (op Op) String() string {
 		return "Sort"
 	case OpExpect:
 		return "Expect"
-	case OpFirst:
-		return "First"
 	default:
 		return "?"
 	}
@@ -456,8 +453,6 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpExpect:
 				fmt.Fprintf(&b, "%s", formatReg(ins.A))
-			case OpFirst:
-				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpMakeClosure:
 				fmt.Fprintf(&b, "%s, %s, %d, %s", formatReg(ins.A), p.funcName(ins.B), ins.C, formatReg(ins.D))
 			case OpCall2:
@@ -1123,13 +1118,6 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			line = strings.TrimRight(line, "\r\n")
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: line}
-		case OpFirst:
-			lst := fr.regs[ins.B]
-			if lst.Tag != ValueList || len(lst.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: ValueNull}
-			} else {
-				fr.regs[ins.A] = lst.List[0]
-			}
 		case OpIterPrep:
 			src := fr.regs[ins.B]
 			switch src.Tag {

--- a/tests/dataset/tpc-ds/out/q10.ir.out
+++ b/tests/dataset/tpc-ds/out/q10.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 10}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q11.ir.out
+++ b/tests/dataset/tpc-ds/out/q11.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 11}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q12.ir.out
+++ b/tests/dataset/tpc-ds/out/q12.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 12}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q13.ir.out
+++ b/tests/dataset/tpc-ds/out/q13.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 13}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q14.ir.out
+++ b/tests/dataset/tpc-ds/out/q14.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 14}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q15.ir.out
+++ b/tests/dataset/tpc-ds/out/q15.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 15}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q16.ir.out
+++ b/tests/dataset/tpc-ds/out/q16.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 16}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q17.ir.out
+++ b/tests/dataset/tpc-ds/out/q17.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 17}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q18.ir.out
+++ b/tests/dataset/tpc-ds/out/q18.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 18}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)

--- a/tests/dataset/tpc-ds/out/q19.ir.out
+++ b/tests/dataset/tpc-ds/out/q19.ir.out
@@ -3,6 +3,7 @@ func main (regs=17)
   Const        r0, [{"id": 1, "val": 19}]
   // let vals = from r in t select r.val
   Const        r1, []
+  Const        r2, "val"
   IterPrep     r3, r0
   Len          r4, r3
   Const        r5, 0
@@ -13,6 +14,8 @@ L1:
   Const        r10, "val"
   Index        r11, r9, r10
   Append       r1, r1, r11
+  Const        r13, 1
+  AddInt       r5, r5, r13
   Jump         L1
 L0:
   // let result = first(vals)


### PR DESCRIPTION
## Summary
- remove duplicated `OpFirst` declaration and related cases in VM
- regenerate IR outputs for TPC-DS queries q10–q19

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686231b25be883208be170bb0ec0115e