### PR TITLE
Improve TPC-DS examples q20–q29

### DIFF
--- a/tests/dataset/tpc-ds/q20.mochi
+++ b/tests/dataset/tpc-ds/q20.mochi
@@ -20,7 +20,10 @@ type DateDim { d_date_sk: int, d_date: string }
 let catalog_sales = [
   { cs_item_sk: 1, cs_sold_date_sk: 1, cs_ext_sales_price: 100.0 },
   { cs_item_sk: 1, cs_sold_date_sk: 1, cs_ext_sales_price: 200.0 },
-  { cs_item_sk: 2, cs_sold_date_sk: 1, cs_ext_sales_price: 150.0 }
+  { cs_item_sk: 2, cs_sold_date_sk: 1, cs_ext_sales_price: 150.0 },
+  { cs_item_sk: 1, cs_sold_date_sk: 2, cs_ext_sales_price: 300.0 },
+  { cs_item_sk: 2, cs_sold_date_sk: 2, cs_ext_sales_price: 150.0 },
+  { cs_item_sk: 3, cs_sold_date_sk: 1, cs_ext_sales_price: 50.0 }
 ]
 
 let item = [
@@ -39,10 +42,21 @@ let item = [
     i_category: "A",
     i_class: "X",
     i_current_price: 20.0
+  },
+  {
+    i_item_sk: 3,
+    i_item_id: "ITEM3",
+    i_item_desc: "Item Three",
+    i_category: "D",
+    i_class: "Y",
+    i_current_price: 15.0
   }
 ]
 
-let date_dim = [ { d_date_sk: 1, d_date: "2000-02-10" } ]
+let date_dim = [
+  { d_date_sk: 1, d_date: "2000-02-10" },
+  { d_date_sk: 2, d_date: "2000-02-20" }
+]
 
 let filtered =
   from cs in catalog_sales

--- a/tests/dataset/tpc-ds/q21.mochi
+++ b/tests/dataset/tpc-ds/q21.mochi
@@ -7,12 +7,23 @@ type DateDim { d_date_sk: int, d_date: string }
 
 let inventory = [
   { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 30 },
-  { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 40 }
+  { inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 40 },
+  { inv_item_sk: 2, inv_warehouse_sk: 2, inv_date_sk: 1, inv_quantity_on_hand: 20 },
+  { inv_item_sk: 2, inv_warehouse_sk: 2, inv_date_sk: 2, inv_quantity_on_hand: 20 }
 ]
 
-let warehouse = [ { w_warehouse_sk: 1, w_warehouse_name: "Main" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
-let date_dim = [ { d_date_sk: 1, d_date: "2000-03-01" }, { d_date_sk: 2, d_date: "2000-03-20" } ]
+let warehouse = [
+  { w_warehouse_sk: 1, w_warehouse_name: "Main" },
+  { w_warehouse_sk: 2, w_warehouse_name: "Backup" }
+]
+let item = [
+  { i_item_sk: 1, i_item_id: "ITEM1" },
+  { i_item_sk: 2, i_item_id: "ITEM2" }
+]
+let date_dim = [
+  { d_date_sk: 1, d_date: "2000-03-01" },
+  { d_date_sk: 2, d_date: "2000-03-20" }
+]
 
 let before =
   from inv in inventory

--- a/tests/dataset/tpc-ds/q22.mochi
+++ b/tests/dataset/tpc-ds/q22.mochi
@@ -12,10 +12,18 @@ type Item {
 
 let inventory = [
   { inv_item_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 10 },
-  { inv_item_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 20 }
+  { inv_item_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 20 },
+  { inv_item_sk: 1, inv_date_sk: 3, inv_quantity_on_hand: 10 },
+  { inv_item_sk: 1, inv_date_sk: 4, inv_quantity_on_hand: 20 },
+  { inv_item_sk: 2, inv_date_sk: 1, inv_quantity_on_hand: 50 }
 ]
 
-let date_dim = [ { d_date_sk: 1, d_month_seq: 0 }, { d_date_sk: 2, d_month_seq: 1 } ]
+let date_dim = [
+  { d_date_sk: 1, d_month_seq: 0 },
+  { d_date_sk: 2, d_month_seq: 1 },
+  { d_date_sk: 3, d_month_seq: 2 },
+  { d_date_sk: 4, d_month_seq: 3 }
+]
 
 let item = [
   {
@@ -24,7 +32,8 @@ let item = [
     i_brand: "Brand1",
     i_class: "Class1",
     i_category: "Cat1"
-  }
+  },
+  { i_item_sk: 2, i_product_name: "Prod2", i_brand: "Brand2", i_class: "Class2", i_category: "Cat2" }
 ]
 
 let qoh =

--- a/tests/dataset/tpc-ds/q23.mochi
+++ b/tests/dataset/tpc-ds/q23.mochi
@@ -1,8 +1,86 @@
-let t = [{id: 1, val: 23}]
-let vals = from r in t select r.val
-let result = vals[0]
+// Sales from best customers on frequently sold items
+
+// Schema definitions
+
+type StoreSale {
+  ss_item_sk: int
+  ss_sold_date_sk: int
+  ss_customer_sk: int
+  ss_quantity: int
+  ss_sales_price: float
+}
+
+type DateDim { d_date_sk: int, d_year: int, d_moy: int }
+
+type Item { i_item_sk: int }
+
+type CatalogSale { cs_sold_date_sk: int, cs_item_sk: int, cs_bill_customer_sk: int, cs_quantity: int, cs_list_price: float }
+
+type WebSale { ws_sold_date_sk: int, ws_item_sk: int, ws_bill_customer_sk: int, ws_quantity: int, ws_list_price: float }
+
+// Sample data
+let store_sales = [
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_customer_sk: 1, ss_quantity: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_customer_sk: 1, ss_quantity: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_customer_sk: 1, ss_quantity: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_customer_sk: 1, ss_quantity: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 1, ss_sold_date_sk: 1, ss_customer_sk: 1, ss_quantity: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 2, ss_sold_date_sk: 1, ss_customer_sk: 2, ss_quantity: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 2, ss_sold_date_sk: 1, ss_customer_sk: 2, ss_quantity: 1, ss_sales_price: 10.0 },
+  { ss_item_sk: 2, ss_sold_date_sk: 1, ss_customer_sk: 2, ss_quantity: 1, ss_sales_price: 10.0 }
+]
+
+let date_dim = [ { d_date_sk: 1, d_year: 2000, d_moy: 1 } ]
+let item = [ { i_item_sk: 1 }, { i_item_sk: 2 } ]
+let catalog_sales = [
+  { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 2, cs_list_price: 10.0 },
+  { cs_sold_date_sk: 1, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_quantity: 2, cs_list_price: 10.0 }
+]
+let web_sales = [
+  { ws_sold_date_sk: 1, ws_item_sk: 1, ws_bill_customer_sk: 1, ws_quantity: 3, ws_list_price: 10.0 },
+  { ws_sold_date_sk: 1, ws_item_sk: 2, ws_bill_customer_sk: 2, ws_quantity: 1, ws_list_price: 10.0 }
+]
+
+// Frequent store items
+let frequent_ss_items =
+  from ss in store_sales
+  join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  join i in item on ss.ss_item_sk == i.i_item_sk
+  where d.d_year == 2000
+  group by { item_sk: i.i_item_sk, date_sk: d.d_date_sk } into g
+  having count(g) > 4
+  select g.key.item_sk
+
+// Best store customers
+let customer_totals =
+  from ss in store_sales
+  group by ss.ss_customer_sk into g
+  select { cust: g.key, sales: sum(from x in g select x.ss_quantity * x.ss_sales_price) }
+
+let max_sales = max(from c in customer_totals select c.sales)
+
+let best_ss_customer =
+  from c in customer_totals
+  where c.sales > 0.95 * max_sales
+  select c.cust
+
+// Sales from catalog and web for those customers and items in Jan 2000
+let catalog =
+  from cs in catalog_sales
+  join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  where d.d_year == 2000 && d.d_moy == 1 && cs.cs_bill_customer_sk in best_ss_customer && cs.cs_item_sk in frequent_ss_items
+  select cs.cs_quantity * cs.cs_list_price
+
+let web =
+  from ws in web_sales
+  join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  where d.d_year == 2000 && d.d_moy == 1 && ws.ws_bill_customer_sk in best_ss_customer && ws.ws_item_sk in frequent_ss_items
+  select ws.ws_quantity * ws.ws_list_price
+
+let result = sum(catalog) + sum(web)
+
 json(result)
 
-test "TPCDS Q23 placeholder" {
-  expect result == 23
+test "TPCDS Q23 cross-channel sales" {
+  expect result == 50.0
 }

--- a/tests/dataset/tpc-ds/q24.mochi
+++ b/tests/dataset/tpc-ds/q24.mochi
@@ -9,18 +9,31 @@ type Customer { c_customer_sk: int, c_first_name: string, c_last_name: string, c
 type CustomerAddress { ca_address_sk: int, ca_state: string, ca_country: string, ca_zip: string }
 
 let store_sales = [
-  { ss_ticket_number: 1, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_net_paid: 100.0 }
+  { ss_ticket_number: 1, ss_item_sk: 1, ss_customer_sk: 1, ss_store_sk: 1, ss_net_paid: 100.0 },
+  { ss_ticket_number: 2, ss_item_sk: 2, ss_customer_sk: 2, ss_store_sk: 1, ss_net_paid: 50.0 }
 ]
 
-let store_returns = [ { sr_ticket_number: 1, sr_item_sk: 1 } ]
+let store_returns = [
+  { sr_ticket_number: 1, sr_item_sk: 1 },
+  { sr_ticket_number: 2, sr_item_sk: 2 }
+]
 
 let store = [ { s_store_sk: 1, s_store_name: "Store1", s_market_id: 5, s_state: "CA", s_zip: "12345" } ]
 
-let item = [ { i_item_sk: 1, i_color: "RED", i_current_price: 10.0, i_manager_id: 1, i_units: "EA", i_size: "M" } ]
+let item = [
+  { i_item_sk: 1, i_color: "RED", i_current_price: 10.0, i_manager_id: 1, i_units: "EA", i_size: "M" },
+  { i_item_sk: 2, i_color: "BLUE", i_current_price: 20.0, i_manager_id: 2, i_units: "EA", i_size: "L" }
+]
 
-let customer = [ { c_customer_sk: 1, c_first_name: "Ann", c_last_name: "Smith", c_current_addr_sk: 1, c_birth_country: "Canada" } ]
+let customer = [
+  { c_customer_sk: 1, c_first_name: "Ann", c_last_name: "Smith", c_current_addr_sk: 1, c_birth_country: "Canada" },
+  { c_customer_sk: 2, c_first_name: "Bob", c_last_name: "Jones", c_current_addr_sk: 2, c_birth_country: "USA" }
+]
 
-let customer_address = [ { ca_address_sk: 1, ca_state: "CA", ca_country: "USA", ca_zip: "12345" } ]
+let customer_address = [
+  { ca_address_sk: 1, ca_state: "CA", ca_country: "USA", ca_zip: "12345" },
+  { ca_address_sk: 2, ca_state: "CA", ca_country: "USA", ca_zip: "54321" }
+]
 
 let ssales =
   from ss in store_sales

--- a/tests/dataset/tpc-ds/q25.mochi
+++ b/tests/dataset/tpc-ds/q25.mochi
@@ -8,15 +8,18 @@ type Store { s_store_sk: int, s_store_id: string, s_store_name: string }
 type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
 
 let store_sales = [
-  { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_net_profit: 50.0, ss_ticket_number: 1 }
+  { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_net_profit: 50.0, ss_ticket_number: 1 },
+  { ss_sold_date_sk: 1, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_net_profit: 20.0, ss_ticket_number: 2 }
 ]
 
 let store_returns = [
-  { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_net_loss: 10.0 }
+  { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_net_loss: 10.0 },
+  { sr_returned_date_sk: 2, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_net_loss: 5.0 }
 ]
 
 let catalog_sales = [
-  { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_net_profit: 30.0 }
+  { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_net_profit: 30.0 },
+  { cs_sold_date_sk: 3, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_net_profit: 15.0 }
 ]
 
 let date_dim = [
@@ -26,7 +29,10 @@ let date_dim = [
 ]
 
 let store = [ { s_store_sk: 1, s_store_id: "S1", s_store_name: "Store1" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" } ]
+let item = [
+  { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" },
+  { i_item_sk: 2, i_item_id: "ITEM2", i_item_desc: "Desc2" }
+]
 
 let result =
   from ss in store_sales

--- a/tests/dataset/tpc-ds/q26.mochi
+++ b/tests/dataset/tpc-ds/q26.mochi
@@ -17,16 +17,18 @@ type Item { i_item_sk: int, i_item_id: string }
 type Promotion { p_promo_sk: int, p_channel_email: string, p_channel_event: string }
 
 let catalog_sales = [
-  { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_promo_sk: 1, cs_quantity: 10, cs_list_price: 100.0, cs_coupon_amt: 5.0, cs_sales_price: 95.0 }
+  { cs_sold_date_sk: 1, cs_item_sk: 1, cs_bill_cdemo_sk: 1, cs_promo_sk: 1, cs_quantity: 10, cs_list_price: 100.0, cs_coupon_amt: 5.0, cs_sales_price: 95.0 },
+  { cs_sold_date_sk: 1, cs_item_sk: 2, cs_bill_cdemo_sk: 2, cs_promo_sk: 2, cs_quantity: 5, cs_list_price: 50.0, cs_coupon_amt: 2.0, cs_sales_price: 48.0 }
 ]
 
 let customer_demographics = [
-  { cd_demo_sk: 1, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College" }
+  { cd_demo_sk: 1, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College" },
+  { cd_demo_sk: 2, cd_gender: "F", cd_marital_status: "M", cd_education_status: "High School" }
 ]
 
 let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
-let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" } ]
+let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" }, { p_promo_sk: 2, p_channel_email: "Y", p_channel_event: "N" } ]
 
 let result =
   from cs in catalog_sales

--- a/tests/dataset/tpc-ds/q27.mochi
+++ b/tests/dataset/tpc-ds/q27.mochi
@@ -7,13 +7,14 @@ type Store { s_store_sk: int, s_state: string }
 type Item { i_item_sk: int, i_item_id: string }
 
 let store_sales = [
-  { ss_item_sk: 1, ss_store_sk: 1, ss_cdemo_sk: 1, ss_sold_date_sk: 1, ss_quantity: 5, ss_list_price: 100.0, ss_coupon_amt: 10.0, ss_sales_price: 90.0 }
+  { ss_item_sk: 1, ss_store_sk: 1, ss_cdemo_sk: 1, ss_sold_date_sk: 1, ss_quantity: 5, ss_list_price: 100.0, ss_coupon_amt: 10.0, ss_sales_price: 90.0 },
+  { ss_item_sk: 2, ss_store_sk: 2, ss_cdemo_sk: 2, ss_sold_date_sk: 1, ss_quantity: 2, ss_list_price: 50.0, ss_coupon_amt: 5.0, ss_sales_price: 45.0 }
 ]
 
-let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" } ]
+let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" }, { cd_demo_sk: 2, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College" } ]
 let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
-let store = [ { s_store_sk: 1, s_state: "CA" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
+let store = [ { s_store_sk: 1, s_state: "CA" }, { s_store_sk: 2, s_state: "TX" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" } ]
 
 let result =
   from ss in store_sales

--- a/tests/dataset/tpc-ds/q28.mochi
+++ b/tests/dataset/tpc-ds/q28.mochi
@@ -4,7 +4,8 @@ type StoreSale { ss_quantity: int, ss_list_price: float, ss_coupon_amt: float, s
 
 let store_sales = [
   { ss_quantity: 3, ss_list_price: 100.0, ss_coupon_amt: 50.0, ss_wholesale_cost: 30.0 },
-  { ss_quantity: 8, ss_list_price: 80.0, ss_coupon_amt: 10.0, ss_wholesale_cost: 20.0 }
+  { ss_quantity: 8, ss_list_price: 80.0, ss_coupon_amt: 10.0, ss_wholesale_cost: 20.0 },
+  { ss_quantity: 12, ss_list_price: 60.0, ss_coupon_amt: 5.0, ss_wholesale_cost: 15.0 }
 ]
 
 let bucket1 =

--- a/tests/dataset/tpc-ds/q29.mochi
+++ b/tests/dataset/tpc-ds/q29.mochi
@@ -7,9 +7,18 @@ type DateDim { d_date_sk: int, d_moy: int, d_year: int }
 type Store { s_store_sk: int, s_store_id: string, s_store_name: string }
 type Item { i_item_sk: int, i_item_id: string, i_item_desc: string }
 
-let store_sales = [ { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 10, ss_ticket_number: 1 } ]
-let store_returns = [ { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_return_quantity: 2 } ]
-let catalog_sales = [ { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 5 } ]
+let store_sales = [
+  { ss_sold_date_sk: 1, ss_item_sk: 1, ss_store_sk: 1, ss_customer_sk: 1, ss_quantity: 10, ss_ticket_number: 1 },
+  { ss_sold_date_sk: 1, ss_item_sk: 2, ss_store_sk: 1, ss_customer_sk: 2, ss_quantity: 4, ss_ticket_number: 2 }
+]
+let store_returns = [
+  { sr_returned_date_sk: 2, sr_item_sk: 1, sr_customer_sk: 1, sr_ticket_number: 1, sr_return_quantity: 2 },
+  { sr_returned_date_sk: 2, sr_item_sk: 2, sr_customer_sk: 2, sr_ticket_number: 2, sr_return_quantity: 1 }
+]
+let catalog_sales = [
+  { cs_sold_date_sk: 3, cs_item_sk: 1, cs_bill_customer_sk: 1, cs_quantity: 5 },
+  { cs_sold_date_sk: 3, cs_item_sk: 2, cs_bill_customer_sk: 2, cs_quantity: 3 }
+]
 
 let date_dim = [
   { d_date_sk: 1, d_moy: 4, d_year: 1999 },
@@ -18,7 +27,7 @@ let date_dim = [
 ]
 
 let store = [ { s_store_sk: 1, s_store_id: "S1", s_store_name: "Store1" } ]
-let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" } ]
+let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" }, { i_item_sk: 2, i_item_id: "ITEM2", i_item_desc: "Desc2" } ]
 
 let result =
   from ss in store_sales

--- a/tests/vm/vm_test.go
+++ b/tests/vm/vm_test.go
@@ -204,7 +204,7 @@ func TestVM_TPCH(t *testing.T) {
 
 func TestVM_TPCDS(t *testing.T) {
 	root := findRepoRoot(t)
-	queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19"}
+	queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19", "q20", "q21", "q22", "q23", "q24", "q25", "q26", "q27", "q28", "q29"}
 	found := false
 	for _, q := range queries {
 		src := filepath.Join(root, "tests/dataset/tpc-ds", q+".mochi")


### PR DESCRIPTION
## Summary
- flesh out query 20–29 examples with larger sample datasets
- add a real implementation for `q23.mochi`
- run the later TPC‑DS examples during testing

## Testing
- `go run ./tools/update_tpcds q20 q21 q22 q23 q24 q25 q26 q27 q28 q29` *(fails: OpFirst redeclared)*
- `go test ./...` *(fails: OpFirst redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_6862332a4ef8832083d7db01bb24c9a3