### PR TITLE
Expand TPC-DC sample queries q50–q58

### DIFF
--- a/tests/dataset/tpc-dc/q50.md
+++ b/tests/dataset/tpc-dc/q50.md
@@ -63,7 +63,7 @@ order by s_store_name
 ```
 
 ## Expected Output
-Sample output for the small dataset defined in `q50.mochi`:
+Sample output for the expanded dataset defined in `q50.mochi`:
 ```json
 [
   {
@@ -77,6 +77,23 @@ Sample output for the small dataset defined in `q50.mochi`:
     "s_county": "County",
     "s_state": "CA",
     "s_zip": "12345",
+    "30 days": 1,
+    "31-60 days": 1,
+    "61-90 days": 1,
+    "91-120 days": 1,
+    ">120 days": 1
+  },
+  {
+    "s_store_name": "Store B",
+    "s_company_id": 2,
+    "s_street_number": "2",
+    "s_street_name": "Second",
+    "s_street_type": "Rd",
+    "s_suite_number": "B",
+    "s_city": "Villagetown",
+    "s_county": "County",
+    "s_state": "CA",
+    "s_zip": "54321",
     "30 days": 1,
     "31-60 days": 1,
     "61-90 days": 1,

--- a/tests/dataset/tpc-dc/q50.mochi
+++ b/tests/dataset/tpc-dc/q50.mochi
@@ -1,18 +1,32 @@
 // Expanded dataset with one sale/return for each return bucket
 let store_sales = [
+  // Store A sales/returns
   {ticket: 1, item: 100, sold_date: 1,  customer: 1, store: 1},  // <30 days
   {ticket: 2, item: 101, sold_date: 10, customer: 2, store: 1}, // 31-60 days
   {ticket: 3, item: 102, sold_date: 30, customer: 1, store: 1}, // 61-90 days
   {ticket: 4, item: 103, sold_date: 40, customer: 2, store: 1}, // 91-120 days
-  {ticket: 5, item: 104, sold_date: 50, customer: 1, store: 1}  // >120 days
+  {ticket: 5, item: 104, sold_date: 50, customer: 1, store: 1}, // >120 days
+  // Store B additional sales
+  {ticket: 6, item: 105, sold_date: 5,  customer: 3, store: 2},  // <30 days
+  {ticket: 7, item: 106, sold_date: 10, customer: 4, store: 2}, // 31-60 days
+  {ticket: 8, item: 107, sold_date: 20, customer: 3, store: 2}, // 61-90 days
+  {ticket: 9, item: 108, sold_date: 30, customer: 4, store: 2}, // 91-120 days
+  {ticket: 10, item: 109, sold_date: 35, customer: 3, store: 2}  // >120 days
 ]
 
 let store_returns = [
+  // Returns for Store A
   {ticket: 1, item: 100, returned_date: 21,  customer: 1},  // diff 20
   {ticket: 2, item: 101, returned_date: 50,  customer: 2},  // diff 40
   {ticket: 3, item: 102, returned_date: 100, customer: 1},  // diff 70
   {ticket: 4, item: 103, returned_date: 140, customer: 2},  // diff 100
-  {ticket: 5, item: 104, returned_date: 180, customer: 1}   // diff 130
+  {ticket: 5, item: 104, returned_date: 180, customer: 1},  // diff 130
+  // Returns for Store B
+  {ticket: 6, item: 105, returned_date: 15,  customer: 3},  // diff 10
+  {ticket: 7, item: 106, returned_date: 50,  customer: 4},  // diff 40
+  {ticket: 8, item: 107, returned_date: 95,  customer: 3},  // diff 75
+  {ticket: 9, item: 108, returned_date: 130, customer: 4},  // diff 100
+  {ticket: 10, item: 109, returned_date: 200, customer: 3}   // diff 165
 ]
 
 let store = [
@@ -28,20 +42,37 @@ let store = [
     s_county: "County",
     s_state: "CA",
     s_zip: "12345"
+  },
+  {
+    store_sk: 2,
+    s_store_name: "Store B",
+    s_company_id: 2,
+    s_street_number: "2",
+    s_street_name: "Second",
+    s_street_type: "Rd",
+    s_suite_number: "B",
+    s_city: "Villagetown",
+    s_county: "County",
+    s_state: "CA",
+    s_zip: "54321"
   }
 ]
 
 let date_dim = [
   {date_sk: 1,   year: 2000, month: 1},
   {date_sk: 10,  year: 2000, month: 1},
+  {date_sk: 15,  year: 2000, month: 1},
   {date_sk: 21,  year: 2000, month: 1},
   {date_sk: 30,  year: 2000, month: 1},
+  {date_sk: 35,  year: 2000, month: 1},
   {date_sk: 40,  year: 2000, month: 1},
   {date_sk: 50,  year: 2000, month: 1},
   {date_sk: 100, year: 2000, month: 1},
+  {date_sk: 95,  year: 2000, month: 1},
   {date_sk: 130, year: 2000, month: 1},
   {date_sk: 140, year: 2000, month: 1},
-  {date_sk: 180, year: 2000, month: 1}
+  {date_sk: 180, year: 2000, month: 1},
+  {date_sk: 200, year: 2000, month: 1}
 ]
 
 let result =
@@ -84,21 +115,40 @@ let result =
 json(result)
 
 test "TPCDC Q50 return days by store" {
-  expect result == [{
-    s_store_name: "Store A",
-    s_company_id: 1,
-    s_street_number: "1",
-    s_street_name: "Main",
-    s_street_type: "St",
-    s_suite_number: "A",
-    s_city: "Townsville",
-    s_county: "County",
-    s_state: "CA",
-    s_zip: "12345",
-    "30 days": 1,
-    "31-60 days": 1,
-    "61-90 days": 1,
-    "91-120 days": 1,
-    ">120 days": 1
-  }]
+  expect result == [
+    {
+      s_store_name: "Store A",
+      s_company_id: 1,
+      s_street_number: "1",
+      s_street_name: "Main",
+      s_street_type: "St",
+      s_suite_number: "A",
+      s_city: "Townsville",
+      s_county: "County",
+      s_state: "CA",
+      s_zip: "12345",
+      "30 days": 1,
+      "31-60 days": 1,
+      "61-90 days": 1,
+      "91-120 days": 1,
+      ">120 days": 1
+    },
+    {
+      s_store_name: "Store B",
+      s_company_id: 2,
+      s_street_number: "2",
+      s_street_name: "Second",
+      s_street_type: "Rd",
+      s_suite_number: "B",
+      s_city: "Villagetown",
+      s_county: "County",
+      s_state: "CA",
+      s_zip: "54321",
+      "30 days": 1,
+      "31-60 days": 1,
+      "61-90 days": 1,
+      "91-120 days": 1,
+      ">120 days": 1
+    }
+  ]
 }

--- a/tests/dataset/tpc-dc/q51.md
+++ b/tests/dataset/tpc-dc/q51.md
@@ -46,13 +46,18 @@ order by item_sk
 ```
 
 ## Expected Output
-For the expanded sample data the cumulative web sales exceed store sales in each month:
+For the expanded sample data the cumulative web sales exceed store sales for two items:
 ```json
 [
   {"item_sk":1, "d_date":1, "web_sales":10, "store_sales":5},
   {"item_sk":1, "d_date":2, "web_sales":25, "store_sales":10},
   {"item_sk":1, "d_date":3, "web_sales":35, "store_sales":20},
   {"item_sk":1, "d_date":4, "web_sales":40, "store_sales":30},
-  {"item_sk":1, "d_date":5, "web_sales":60, "store_sales":45}
+  {"item_sk":1, "d_date":5, "web_sales":60, "store_sales":45},
+  {"item_sk":2, "d_date":1, "web_sales":5,  "store_sales":2},
+  {"item_sk":2, "d_date":2, "web_sales":10, "store_sales":4},
+  {"item_sk":2, "d_date":3, "web_sales":15, "store_sales":5},
+  {"item_sk":2, "d_date":4, "web_sales":20, "store_sales":7},
+  {"item_sk":2, "d_date":5, "web_sales":25, "store_sales":10}
 ]
 ```

--- a/tests/dataset/tpc-dc/q51.mochi
+++ b/tests/dataset/tpc-dc/q51.mochi
@@ -11,7 +11,12 @@ let web_sales = [
   {item_sk: 1, sold_date: 2, price: 15},
   {item_sk: 1, sold_date: 3, price: 10},
   {item_sk: 1, sold_date: 4, price: 5},
-  {item_sk: 1, sold_date: 5, price: 20}
+  {item_sk: 1, sold_date: 5, price: 20},
+  {item_sk: 2, sold_date: 1, price: 5},
+  {item_sk: 2, sold_date: 2, price: 5},
+  {item_sk: 2, sold_date: 3, price: 5},
+  {item_sk: 2, sold_date: 4, price: 5},
+  {item_sk: 2, sold_date: 5, price: 5}
 ]
 
 let store_sales = [
@@ -19,44 +24,53 @@ let store_sales = [
   {item_sk: 1, sold_date: 2, price: 5},
   {item_sk: 1, sold_date: 3, price: 10},
   {item_sk: 1, sold_date: 4, price: 10},
-  {item_sk: 1, sold_date: 5, price: 15}
+  {item_sk: 1, sold_date: 5, price: 15},
+  {item_sk: 2, sold_date: 1, price: 2},
+  {item_sk: 2, sold_date: 2, price: 2},
+  {item_sk: 2, sold_date: 3, price: 1},
+  {item_sk: 2, sold_date: 4, price: 2},
+  {item_sk: 2, sold_date: 5, price: 3}
 ]
 
-// Aggregate sales by date
+// Aggregate sales by item and date
 let ws_daily =
   from ws in web_sales
   join d in date_dim on ws.sold_date == d.date_sk
-  group by {date: d.date_sk} into g
-  sort by g.key.date
-  select {date: g.key.date, sales: sum(from x in g select x.ws.price)}
+  group by {item: ws.item_sk, date: d.date_sk} into g
+  sort by {item: g.key.item, date: g.key.date}
+  select {item: g.key.item, date: g.key.date, sales: sum(from x in g select x.ws.price)}
 
 let ss_daily =
   from ss in store_sales
   join d in date_dim on ss.sold_date == d.date_sk
-  group by {date: d.date_sk} into g
-  sort by g.key.date
-  select {date: g.key.date, sales: sum(from x in g select x.ss.price)}
+  group by {item: ss.item_sk, date: d.date_sk} into g
+  sort by {item: g.key.item, date: g.key.date}
+  select {item: g.key.item, date: g.key.date, sales: sum(from x in g select x.ss.price)}
 
 // Compute cumulative sums
 var ws_running = []
-var ws_total = 0
+var current_item = nil
+var total = 0
 for r in ws_daily {
-  ws_total = ws_total + r.sales
-  ws_running = ws_running + [{date:r.date, total:ws_total}]
+  if current_item != r.item { current_item = r.item; total = 0 }
+  total = total + r.sales
+  ws_running = ws_running + [{item_sk:r.item, date:r.date, total:total}]
 }
 
 var ss_running = []
-var ss_total = 0
+var ss_cur = nil
+var ss_tot = 0
 for r in ss_daily {
-  ss_total = ss_total + r.sales
-  ss_running = ss_running + [{date:r.date, total:ss_total}]
+  if ss_cur != r.item { ss_cur = r.item; ss_tot = 0 }
+  ss_tot = ss_tot + r.sales
+  ss_running = ss_running + [{item_sk:r.item, date:r.date, total:ss_tot}]
 }
 
 var result = []
 for w in ws_running {
   var s_total = 0
-  for s in ss_running { if s.date == w.date { s_total = s.total } }
-  result = result + [{item_sk:1, d_date:w.date, web_sales:w.total, store_sales:s_total}]
+  for s in ss_running { if s.item_sk == w.item_sk && s.date == w.date { s_total = s.total } }
+  result = result + [{item_sk:w.item_sk, d_date:w.date, web_sales:w.total, store_sales:s_total}]
 }
 
 json(result)
@@ -67,6 +81,11 @@ test "TPCDC Q51 cumulative" {
     {item_sk:1, d_date:2, web_sales:25, store_sales:10},
     {item_sk:1, d_date:3, web_sales:35, store_sales:20},
     {item_sk:1, d_date:4, web_sales:40, store_sales:30},
-    {item_sk:1, d_date:5, web_sales:60, store_sales:45}
+    {item_sk:1, d_date:5, web_sales:60, store_sales:45},
+    {item_sk:2, d_date:1, web_sales:5, store_sales:2},
+    {item_sk:2, d_date:2, web_sales:10, store_sales:4},
+    {item_sk:2, d_date:3, web_sales:15, store_sales:5},
+    {item_sk:2, d_date:4, web_sales:20, store_sales:7},
+    {item_sk:2, d_date:5, web_sales:25, store_sales:10}
   ]
 }

--- a/tests/dataset/tpc-dc/q52.md
+++ b/tests/dataset/tpc-dc/q52.md
@@ -24,10 +24,10 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Example result using the small dataset from `q52.mochi`:
+Example result using the expanded dataset from `q52.mochi`:
 ```json
 [
-  {"d_year":2000, "brand_id":1, "brand":"BrandA", "ext_price":150},
+  {"d_year":2000, "brand_id":1, "brand":"BrandA", "ext_price":250},
   {"d_year":2000, "brand_id":2, "brand":"BrandB", "ext_price":75},
   {"d_year":2000, "brand_id":3, "brand":"BrandC", "ext_price":75}
 ]

--- a/tests/dataset/tpc-dc/q52.mochi
+++ b/tests/dataset/tpc-dc/q52.mochi
@@ -1,13 +1,15 @@
 let date_dim = [
   {date_sk: 1, year: 2000, month: 1},
   {date_sk: 2, year: 2000, month: 1},
-  {date_sk: 3, year: 2000, month: 1}
+  {date_sk: 3, year: 2000, month: 1},
+  {date_sk: 4, year: 2001, month: 1}
 ]
 
 let item = [
   {i_item_sk: 100, i_brand_id: 1, i_brand: "BrandA", i_manager_id: 1},
   {i_item_sk: 101, i_brand_id: 2, i_brand: "BrandB", i_manager_id: 1},
-  {i_item_sk: 102, i_brand_id: 3, i_brand: "BrandC", i_manager_id: 1}
+  {i_item_sk: 102, i_brand_id: 3, i_brand: "BrandC", i_manager_id: 1},
+  {i_item_sk: 103, i_brand_id: 1, i_brand: "BrandA", i_manager_id: 1}
 ]
 
 let store_sales = [
@@ -15,7 +17,9 @@ let store_sales = [
   {ss_item_sk: 100, ss_sold_date_sk: 2, ss_ext_sales_price: 50},
   {ss_item_sk: 101, ss_sold_date_sk: 1, ss_ext_sales_price: 50},
   {ss_item_sk: 101, ss_sold_date_sk: 2, ss_ext_sales_price: 25},
-  {ss_item_sk: 102, ss_sold_date_sk: 3, ss_ext_sales_price: 75}
+  {ss_item_sk: 102, ss_sold_date_sk: 3, ss_ext_sales_price: 75},
+  {ss_item_sk: 103, ss_sold_date_sk: 2, ss_ext_sales_price: 100},
+  {ss_item_sk: 101, ss_sold_date_sk: 4, ss_ext_sales_price: 60}
 ]
 
 let result =
@@ -31,7 +35,7 @@ json(result)
 
 test "TPCDC Q52 brand totals" {
   expect result == [
-    {d_year:2000, brand_id:1, brand:"BrandA", ext_price:150},
+    {d_year:2000, brand_id:1, brand:"BrandA", ext_price:250},
     {d_year:2000, brand_id:2, brand:"BrandB", ext_price:75},
     {d_year:2000, brand_id:3, brand:"BrandC", ext_price:75}
   ]

--- a/tests/dataset/tpc-dc/q53.md
+++ b/tests/dataset/tpc-dc/q53.md
@@ -34,7 +34,9 @@ Query extracted from the official TPC-DS specification.
 Sample output from `q53.mochi` with two quarters of sales:
 ```json
 [
-  {"i_manufact_id":1, "sum_sales":300, "avg_quarterly_sales":225},
-  {"i_manufact_id":1, "sum_sales":150, "avg_quarterly_sales":225}
+  {"i_manufact_id":2, "sum_sales":80, "avg_quarterly_sales":120},
+  {"i_manufact_id":2, "sum_sales":160, "avg_quarterly_sales":120},
+  {"i_manufact_id":1, "sum_sales":150, "avg_quarterly_sales":225},
+  {"i_manufact_id":1, "sum_sales":300, "avg_quarterly_sales":225}
 ]
 ```

--- a/tests/dataset/tpc-dc/q53.mochi
+++ b/tests/dataset/tpc-dc/q53.mochi
@@ -1,5 +1,6 @@
 let item = [
-  {i_item_sk: 1, i_manufact_id: 1, i_category: "Books", i_class: "personal", i_brand: "scholaramalgamalg #14"}
+  {i_item_sk: 1, i_manufact_id: 1, i_category: "Books", i_class: "personal", i_brand: "scholaramalgamalg #14"},
+  {i_item_sk: 2, i_manufact_id: 2, i_category: "Books", i_class: "personal", i_brand: "scholaramalgamalg #14"}
 ]
 
 let date_dim = [
@@ -13,7 +14,10 @@ let store = [ {s_store_sk: 1} ]
 let store_sales = [
   {ss_item_sk: 1, ss_sold_date_sk: 1, ss_store_sk:1, ss_sales_price: 100},
   {ss_item_sk: 1, ss_sold_date_sk: 2, ss_store_sk:1, ss_sales_price: 200},
-  {ss_item_sk: 1, ss_sold_date_sk: 3, ss_store_sk:1, ss_sales_price: 150}
+  {ss_item_sk: 1, ss_sold_date_sk: 3, ss_store_sk:1, ss_sales_price: 150},
+  {ss_item_sk: 2, ss_sold_date_sk: 1, ss_store_sk:1, ss_sales_price: 80},
+  {ss_item_sk: 2, ss_sold_date_sk: 2, ss_store_sk:1, ss_sales_price: 80},
+  {ss_item_sk: 2, ss_sold_date_sk: 3, ss_store_sk:1, ss_sales_price: 80}
 ]
 
 let tmp =
@@ -33,7 +37,9 @@ json(result)
 
 test "TPCDC Q53 quarterly" {
   expect result == [
-    {i_manufact_id:1, sum_sales:300, avg_quarterly_sales:225},
-    {i_manufact_id:1, sum_sales:150, avg_quarterly_sales:225}
+    {i_manufact_id:2, sum_sales:80, avg_quarterly_sales:120},
+    {i_manufact_id:2, sum_sales:160, avg_quarterly_sales:120},
+    {i_manufact_id:1, sum_sales:150, avg_quarterly_sales:225},
+    {i_manufact_id:1, sum_sales:300, avg_quarterly_sales:225}
   ]
 }

--- a/tests/dataset/tpc-dc/q54.md
+++ b/tests/dataset/tpc-dc/q54.md
@@ -60,11 +60,11 @@ order by segment, num_customers
 ```
 
 ## Expected Output
-Based on the toy data in `q54.mochi` the customers fall into revenue segments:
+Based on the expanded data in `q54.mochi` the customers fall into revenue segments:
 ```json
 [
-  {"segment":1, "num_customers":1, "segment_base":50},
+  {"segment":0, "num_customers":1, "segment_base":0},
   {"segment":2, "num_customers":1, "segment_base":100},
-  {"segment":3, "num_customers":1, "segment_base":150}
+  {"segment":3, "num_customers":2, "segment_base":150}
 ]
 ```

--- a/tests/dataset/tpc-dc/q54.mochi
+++ b/tests/dataset/tpc-dc/q54.mochi
@@ -1,24 +1,32 @@
 let catalog_sales = [
   {cs_bill_customer_sk:1, cs_sold_date_sk:1, cs_item_sk:1},
-  {cs_bill_customer_sk:3, cs_sold_date_sk:1, cs_item_sk:1}
+  {cs_bill_customer_sk:3, cs_sold_date_sk:1, cs_item_sk:1},
+  {cs_bill_customer_sk:4, cs_sold_date_sk:1, cs_item_sk:1}
 ]
-let web_sales = [{ws_bill_customer_sk:2, ws_sold_date_sk:1, ws_item_sk:1}]
+let web_sales = [
+  {ws_bill_customer_sk:2, ws_sold_date_sk:1, ws_item_sk:1}
+]
 let item = [{i_item_sk:1, i_category:"Cat", i_class:"Class"}]
 let date_dim = [{d_date_sk:1, d_moy:1, d_year:2000, d_month_seq:1}]
 let customer = [
   {c_customer_sk:1, c_current_addr_sk:1},
   {c_customer_sk:2, c_current_addr_sk:2},
-  {c_customer_sk:3, c_current_addr_sk:3}
+  {c_customer_sk:3, c_current_addr_sk:3},
+  {c_customer_sk:4, c_current_addr_sk:4}
 ]
 let store_sales = [
   {ss_customer_sk:1, ss_sold_date_sk:2, ss_ext_sales_price:120},
   {ss_customer_sk:2, ss_sold_date_sk:2, ss_ext_sales_price:160},
-  {ss_customer_sk:3, ss_sold_date_sk:2, ss_ext_sales_price:60}
+  {ss_customer_sk:3, ss_sold_date_sk:2, ss_ext_sales_price:60},
+  {ss_customer_sk:1, ss_sold_date_sk:2, ss_ext_sales_price:30},
+  {ss_customer_sk:3, ss_sold_date_sk:2, ss_ext_sales_price:40},
+  {ss_customer_sk:4, ss_sold_date_sk:2, ss_ext_sales_price:40}
 ]
 let customer_address=[
   {ca_address_sk:1, ca_county:"C", ca_state:"S"},
   {ca_address_sk:2, ca_county:"C", ca_state:"S"},
-  {ca_address_sk:3, ca_county:"C", ca_state:"S"}
+  {ca_address_sk:3, ca_county:"C", ca_state:"S"},
+  {ca_address_sk:4, ca_county:"C", ca_state:"S"}
 ]
 let store=[{s_store_sk:1, s_county:"C", s_state:"S"}]
 
@@ -51,8 +59,8 @@ json(result)
 
 test "TPCDC Q54 segments" {
   expect result == [
-    {segment:1, num_customers:1, segment_base:50},
+    {segment:0, num_customers:1, segment_base:0},
     {segment:2, num_customers:1, segment_base:100},
-    {segment:3, num_customers:1, segment_base:150}
+    {segment:3, num_customers:2, segment_base:150}
   ]
 }

--- a/tests/dataset/tpc-dc/q55.md
+++ b/tests/dataset/tpc-dc/q55.md
@@ -18,10 +18,10 @@ Query extracted from the official TPC-DS specification.
 ```
 
 ## Expected Output
-Using the simplified dataset in `q55.mochi`:
+Using the expanded dataset in `q55.mochi`:
 ```json
 [
-  {"brand_id":1, "brand":"BrandA", "ext_price":100},
+  {"brand_id":1, "brand":"BrandA", "ext_price":250},
   {"brand_id":2, "brand":"BrandB", "ext_price":50}
 ]
 ```

--- a/tests/dataset/tpc-dc/q55.mochi
+++ b/tests/dataset/tpc-dc/q55.mochi
@@ -1,11 +1,13 @@
 let date_dim = [{d_date_sk:1, d_year:2000, d_moy:1}]
 let item = [
   {i_item_sk:1, i_brand_id:1, i_brand:"BrandA", i_manager_id:1},
-  {i_item_sk:2, i_brand_id:2, i_brand:"BrandB", i_manager_id:1}
+  {i_item_sk:2, i_brand_id:2, i_brand:"BrandB", i_manager_id:1},
+  {i_item_sk:3, i_brand_id:1, i_brand:"BrandA", i_manager_id:1}
 ]
 let store_sales = [
   {ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:100},
-  {ss_item_sk:2, ss_sold_date_sk:1, ss_ext_sales_price:50}
+  {ss_item_sk:2, ss_sold_date_sk:1, ss_ext_sales_price:50},
+  {ss_item_sk:3, ss_sold_date_sk:1, ss_ext_sales_price:150}
 ]
 
 let result =
@@ -20,7 +22,7 @@ json(result)
 
 test "TPCDC Q55 brand manager" {
   expect result == [
-    {brand_id:1, brand:"BrandA", ext_price:100},
+    {brand_id:1, brand:"BrandA", ext_price:250},
     {brand_id:2, brand:"BrandB", ext_price:50}
   ]
 }

--- a/tests/dataset/tpc-dc/q56.md
+++ b/tests/dataset/tpc-dc/q56.md
@@ -76,6 +76,7 @@ order by total_sales,
 The combined sales from all channels:
 ```json
 [
+  {"i_item_id":3, "total_sales":30},
   {"i_item_id":1, "total_sales":60},
   {"i_item_id":2, "total_sales":100}
 ]

--- a/tests/dataset/tpc-dc/q56.mochi
+++ b/tests/dataset/tpc-dc/q56.mochi
@@ -1,20 +1,24 @@
 let item = [
   {i_item_id:1, i_color:"Red"},
-  {i_item_id:2, i_color:"Blue"}
+  {i_item_id:2, i_color:"Blue"},
+  {i_item_id:3, i_color:"Green"}
 ]
 let date_dim = [{d_date_sk:1, d_year:2000, d_moy:1}]
 let customer_address=[{ca_address_sk:1, ca_gmt_offset:0}]
 let store_sales=[
   {ss_item_sk:1, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:20},
-  {ss_item_sk:2, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:30}
+  {ss_item_sk:2, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:30},
+  {ss_item_sk:3, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:10}
 ]
 let catalog_sales=[
   {cs_item_sk:1, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:20},
-  {cs_item_sk:2, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:40}
+  {cs_item_sk:2, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:40},
+  {cs_item_sk:3, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:10}
 ]
 let web_sales=[
   {ws_item_sk:1, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:20},
-  {ws_item_sk:2, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:30}
+  {ws_item_sk:2, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:30},
+  {ws_item_sk:3, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:10}
 ]
 
 let ss=
@@ -22,6 +26,7 @@ let ss=
   join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
   join i in item on ss.ss_item_sk == i.i_item_id
+  where (i.i_color == "Red" || i.i_color == "Blue" || i.i_color == "Green") && d.d_year == 2000 && d.d_moy == 1 && ca.ca_gmt_offset == 0
   group by {id:i.i_item_id} into g
   select {i_item_id:g.key.id, total_sales:sum(from x in g select x.ss.ss_ext_sales_price)}
 
@@ -30,6 +35,7 @@ let cs=
   join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
   join i in item on cs.cs_item_sk == i.i_item_id
+  where (i.i_color == "Red" || i.i_color == "Blue" || i.i_color == "Green") && d.d_year == 2000 && d.d_moy == 1 && ca.ca_gmt_offset == 0
   group by {id:i.i_item_id} into g
   select {i_item_id:g.key.id, total_sales:sum(from x in g select x.cs.cs_ext_sales_price)}
 
@@ -38,6 +44,7 @@ let ws=
   join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
   join i in item on ws.ws_item_sk == i.i_item_id
+  where (i.i_color == "Red" || i.i_color == "Blue" || i.i_color == "Green") && d.d_year == 2000 && d.d_moy == 1 && ca.ca_gmt_offset == 0
   group by {id:i.i_item_id} into g
   select {i_item_id:g.key.id, total_sales:sum(from x in g select x.ws.ws_ext_sales_price)}
 
@@ -50,6 +57,7 @@ json(result)
 
 test "TPCDC Q56 union sales" {
   expect result == [
+    {i_item_id:3, total_sales:30},
     {i_item_id:1, total_sales:60},
     {i_item_id:2, total_sales:100}
   ]

--- a/tests/dataset/tpc-dc/q57.md
+++ b/tests/dataset/tpc-dc/q57.md
@@ -52,10 +52,10 @@ order by sum_sales - avg_monthly_sales, [ORDERBY]
 ```
 
 ## Expected Output
-With the dummy data the single call center shows one row:
+With the updated sample data the single call center shows two months:
 ```json
 [
-  {"cc_name":"CC", "sum_sales":100, "avg_monthly_sales":150},
-  {"cc_name":"CC", "sum_sales":200, "avg_monthly_sales":150}
+  {"cc_name":"CC", "sum_sales":150, "avg_monthly_sales":175},
+  {"cc_name":"CC", "sum_sales":200, "avg_monthly_sales":175}
 ]
 ```

--- a/tests/dataset/tpc-dc/q57.mochi
+++ b/tests/dataset/tpc-dc/q57.mochi
@@ -6,24 +6,41 @@ let date_dim=[
 ]
 let catalog_sales=[
   {cs_item_sk:1, cs_sold_date_sk:1, cs_call_center_sk:1, cs_sales_price:100},
+  {cs_item_sk:1, cs_sold_date_sk:1, cs_call_center_sk:1, cs_sales_price:50},
   {cs_item_sk:1, cs_sold_date_sk:2, cs_call_center_sk:1, cs_sales_price:200}
 ]
 
-let v1=
+let monthly=
   from cs in catalog_sales
   join i in item on cs.cs_item_sk == i.i_item_sk
   join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   join cc in call_center on cs.cs_call_center_sk == cc.cc_call_center_sk
   group by {cat:i.i_category, brand:i.i_brand, cc:cc.cc_name, year:d.d_year, moy:d.d_moy} into g
-  select {
-    i_category:g.key.cat,
-    i_brand:g.key.brand,
-    cc_name:g.key.cc,
-    d_year:g.key.year,
-    d_moy:g.key.moy,
-    sum_sales: sum(from x in g select x.cs.cs_sales_price),
-    avg_monthly_sales: avg(from x in g select x.cs.cs_sales_price)
+  select {i_category:g.key.cat, i_brand:g.key.brand, cc_name:g.key.cc, d_year:g.key.year, d_moy:g.key.moy, sum_sales: sum(from x in g select x.cs.cs_sales_price)}
+
+let yearly=
+  from m in monthly
+  group by {cat:m.i_category, brand:m.i_brand, cc:m.cc_name, year:m.d_year} into g
+  select {cat:g.key.cat, brand:g.key.brand, cc:g.key.cc, year:g.key.year, avg_sales: avg(from x in g select x.sum_sales), months: from x in g select {moy:x.d_moy, sum_sales:x.sum_sales}}
+
+var v1 = []
+for y in yearly {
+  var sorted = sort(y.months, fn a,b -> a.moy < b.moy end)
+  var rn = 1
+  for m in sorted {
+    v1 = v1 + [{
+      i_category:y.cat,
+      i_brand:y.brand,
+      cc_name:y.cc,
+      d_year:y.year,
+      d_moy:m.moy,
+      sum_sales:m.sum_sales,
+      avg_monthly_sales:y.avg_sales,
+      rn:rn
+    }]
+    rn = rn + 1
   }
+}
 
 let result =
   from r in v1
@@ -34,7 +51,7 @@ json(result)
 
 test "TPCDC Q57 call center" {
   expect result == [
-    {cc_name:"CC", sum_sales:100, avg_monthly_sales:150},
-    {cc_name:"CC", sum_sales:200, avg_monthly_sales:150}
+    {cc_name:"CC", sum_sales:150, avg_monthly_sales:175},
+    {cc_name:"CC", sum_sales:200, avg_monthly_sales:175}
   ]
 }

--- a/tests/dataset/tpc-dc/q58.mochi
+++ b/tests/dataset/tpc-dc/q58.mochi
@@ -1,19 +1,22 @@
-let item=[{i_item_id:1}, {i_item_id:2}]
+let item=[{i_item_id:1}, {i_item_id:2}, {i_item_id:3}]
 let date_dim=[
   {d_date_sk:1, d_week_seq:1, d_date:"2023-01-01"},
   {d_date_sk:2, d_week_seq:1, d_date:"2023-01-02"}
 ]
 let store_sales=[
   {ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:20},
-  {ss_item_sk:2, ss_sold_date_sk:2, ss_ext_sales_price:30}
+  {ss_item_sk:2, ss_sold_date_sk:2, ss_ext_sales_price:30},
+  {ss_item_sk:3, ss_sold_date_sk:1, ss_ext_sales_price:40}
 ]
 let catalog_sales=[
   {cs_item_sk:1, cs_sold_date_sk:1, cs_ext_sales_price:20},
-  {cs_item_sk:2, cs_sold_date_sk:2, cs_ext_sales_price:30}
+  {cs_item_sk:2, cs_sold_date_sk:2, cs_ext_sales_price:30},
+  {cs_item_sk:3, cs_sold_date_sk:1, cs_ext_sales_price:70}
 ]
 let web_sales=[
   {ws_item_sk:1, ws_sold_date_sk:1, ws_ext_sales_price:20},
-  {ws_item_sk:2, ws_sold_date_sk:2, ws_ext_sales_price:32}
+  {ws_item_sk:2, ws_sold_date_sk:2, ws_ext_sales_price:32},
+  {ws_item_sk:3, ws_sold_date_sk:1, ws_ext_sales_price:20}
 ]
 
 let ss_items=
@@ -39,7 +42,11 @@ let combined=
   from s in ss_items
   join c in cs_items on s.item_id==c.item_id
   join w in ws_items on s.item_id==w.item_id
-  select {item_id:s.item_id, average:(s.ss_item_rev+c.cs_item_rev+w.ws_item_rev)/3}
+  let avg=(s.ss_item_rev+c.cs_item_rev+w.ws_item_rev)/3
+  where abs(s.ss_item_rev-c.cs_item_rev) <= 0.1*avg &&
+        abs(s.ss_item_rev-w.ws_item_rev) <= 0.1*avg &&
+        abs(c.cs_item_rev-w.ws_item_rev) <= 0.1*avg
+  select {item_id:s.item_id, average:avg}
 
 json(combined)
 


### PR DESCRIPTION
## Summary
- enrich sample data for TPC-DC q50–q58
- update query docs with new expected results
- keep Mochi code aligned with SQL templates

## Testing
- `make test` *(fails: duplicate symbol errors)*

------
https://chatgpt.com/codex/tasks/task_e_68623318398c8320b75228313054ae7f