### PR TITLE
Update VM opcodes and regenerate tpc‑ds IR

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -121,13 +121,12 @@ const (
 	OpNegFloat
 
 	// List operations
-	OpUnionAll
-	OpUnion
-	OpExcept
-	OpIntersect
-	OpSort
-	OpExpect
-	OpFirst
+        OpUnionAll
+        OpUnion
+        OpExcept
+        OpIntersect
+        OpSort
+        OpExpect
 )
 
 func (op Op) String() string {
@@ -280,10 +279,8 @@ func (op Op) String() string {
 		return "Intersect"
 	case OpSort:
 		return "Sort"
-	case OpExpect:
-		return "Expect"
-	case OpFirst:
-		return "First"
+        case OpExpect:
+                return "Expect"
 	default:
 		return "?"
 	}
@@ -454,10 +451,8 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s, %s", formatReg(ins.A), formatReg(ins.B), typ)
 			case OpAvg, OpSum, OpMin, OpMax:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
-			case OpExpect:
-				fmt.Fprintf(&b, "%s", formatReg(ins.A))
-			case OpFirst:
-				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
+                        case OpExpect:
+                                fmt.Fprintf(&b, "%s", formatReg(ins.A))
 			case OpMakeClosure:
 				fmt.Fprintf(&b, "%s, %s, %d, %s", formatReg(ins.A), p.funcName(ins.B), ins.C, formatReg(ins.D))
 			case OpCall2:
@@ -1109,27 +1104,20 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				return Value{}, m.newError(fmt.Errorf("upper expects string"), trace, ins.Line)
 			}
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToUpper(b.Str)}
-		case OpFirst:
-			list := fr.regs[ins.B]
-			if list.Tag != ValueList || len(list.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: ValueNull}
-			} else {
-				fr.regs[ins.A] = list.List[0]
-			}
-		case OpInput:
-			line, err := m.reader.ReadString('\n')
-			if err != nil && err != io.EOF {
-				return Value{}, err
-			}
-			line = strings.TrimRight(line, "\r\n")
-			fr.regs[ins.A] = Value{Tag: ValueStr, Str: line}
-		case OpFirst:
-			lst := fr.regs[ins.B]
-			if lst.Tag != ValueList || len(lst.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: ValueNull}
-			} else {
-				fr.regs[ins.A] = lst.List[0]
-			}
+               case OpInput:
+                       line, err := m.reader.ReadString('\n')
+                       if err != nil && err != io.EOF {
+                               return Value{}, err
+                       }
+                       line = strings.TrimRight(line, "\r\n")
+                       fr.regs[ins.A] = Value{Tag: ValueStr, Str: line}
+               case OpFirst:
+                       lst := fr.regs[ins.B]
+                       if lst.Tag != ValueList || len(lst.List) == 0 {
+                               fr.regs[ins.A] = Value{Tag: ValueNull}
+                       } else {
+                               fr.regs[ins.A] = lst.List[0]
+                       }
 		case OpIterPrep:
 			src := fr.regs[ins.B]
 			switch src.Tag {

--- a/tests/dataset/tpc-ds/out/q70.ir.out
+++ b/tests/dataset/tpc-ds/out/q70.ir.out
@@ -9,12 +9,38 @@ func main (regs=174)
   Const        r3, 1200
   // from ss in store_sales
   Const        r4, []
+  // group by { state: s.s_state, county: s.s_county } into g
+  Const        r5, "state"
+  Const        r6, "s_state"
+  Const        r7, "county"
+  Const        r8, "s_county"
+  // where d.d_month_seq >= dms && d.d_month_seq <= dms + 11
+  Const        r9, "d_month_seq"
+  Const        r10, "d_month_seq"
+  // s_state: g.key.state,
+  Const        r11, "s_state"
+  Const        r12, "key"
+  Const        r13, "state"
+  // s_county: g.key.county,
+  Const        r14, "s_county"
+  Const        r15, "key"
+  Const        r16, "county"
+  // total_sum: sum(from x in g select x.ss.ss_net_profit)
+  Const        r17, "total_sum"
+  Const        r18, "ss"
+  Const        r19, "ss_net_profit"
+  // sort by [g.key.state, g.key.county]
+  Const        r20, "key"
+  Const        r21, "state"
+  Const        r22, "key"
+  Const        r23, "county"
+  // from ss in store_sales
   MakeMap      r24, 0, r0
   Const        r25, []
   IterPrep     r27, r2
   Len          r28, r27
   Const        r29, 0
-L1:
+L8:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L0
   Index        r32, r27, r29
@@ -22,7 +48,7 @@ L1:
   IterPrep     r33, r1
   Len          r34, r33
   Const        r35, 0
-L2:
+L7:
   LessInt      r36, r35, r34
   JumpIfFalse  r36, L1
   Index        r38, r33, r35
@@ -49,6 +75,7 @@ L6:
   // where d.d_month_seq >= dms && d.d_month_seq <= dms + 11
   Const        r55, "d_month_seq"
   Index        r56, r38, r55
+  Const        r57, 11
   Const        r58, 1211
   LessEq       r59, r3, r56
   Const        r60, "d_month_seq"
@@ -121,13 +148,22 @@ L3:
   Const        r111, 1
   AddInt       r46, r46, r111
   Jump         L6
-L0:
+L2:
+  // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  Const        r112, 1
+  AddInt       r35, r35, r112
+  Jump         L7
+L1:
   // from ss in store_sales
+  Const        r113, 1
+  AddInt       r29, r29, r113
+  Jump         L8
+L0:
   Const        r114, 0
   Len          r116, r25
-L10:
+L12:
   LessInt      r117, r114, r116
-  JumpIfFalse  r117, L7
+  JumpIfFalse  r117, L9
   Index        r119, r25, r114
   // s_state: g.key.state,
   Const        r120, "s_state"
@@ -144,12 +180,14 @@ L10:
   // total_sum: sum(from x in g select x.ss.ss_net_profit)
   Const        r130, "total_sum"
   Const        r131, []
+  Const        r132, "ss"
+  Const        r133, "ss_net_profit"
   IterPrep     r134, r119
   Len          r135, r134
   Const        r136, 0
-L9:
+L11:
   LessInt      r138, r136, r135
-  JumpIfFalse  r138, L8
+  JumpIfFalse  r138, L10
   Index        r140, r134, r136
   Const        r141, "ss"
   Index        r142, r140, r141
@@ -158,8 +196,8 @@ L9:
   Append       r131, r131, r144
   Const        r146, 1
   AddInt       r136, r136, r146
-  Jump         L9
-L8:
+  Jump         L11
+L10:
   Sum          r147, r131
   // s_state: g.key.state,
   Move         r148, r120
@@ -178,6 +216,9 @@ L8:
   Const        r157, "state"
   Index        r159, r156, r157
   Const        r160, "key"
+  Index        r161, r119, r160
+  Const        r162, "county"
+  Index        r164, r161, r162
   MakeList     r166, 2, r159
   // from ss in store_sales
   Move         r167, r154
@@ -185,8 +226,8 @@ L8:
   Append       r4, r4, r168
   Const        r170, 1
   AddInt       r114, r114, r170
-  Jump         L10
-L7:
+  Jump         L12
+L9:
   // sort by [g.key.state, g.key.county]
   Sort         r4, r4
   // json(result)

--- a/tests/dataset/tpc-ds/out/q79.ir.out
+++ b/tests/dataset/tpc-ds/out/q79.ir.out
@@ -1,5 +1,5 @@
 func main (regs=398)
-L20:
+L22:
   // let date_dim = [
   Const        r0, [{"d_date_sk": 1, "d_dow": 1, "d_year": 1999}]
   // let store = [
@@ -12,12 +12,41 @@ L20:
   Const        r4, [{"c_customer_sk": 1, "c_first_name": "Alice", "c_last_name": "Smith"}]
   // from ss in store_sales
   Const        r5, []
+  // group by { ticket: ss.ss_ticket_number, customer_sk: ss.ss_customer_sk, city: s.s_city } into g
+  Const        r6, "ticket"
+  Const        r7, "ss_ticket_number"
+  Const        r8, "customer_sk"
+  Const        r9, "ss_customer_sk"
+  Const        r10, "city"
+  Const        r11, "s_city"
+  // where (hd.hd_dep_count == 2 || hd.hd_vehicle_count > 1) &&
+  Const        r12, "hd_dep_count"
+  Const        r13, "hd_vehicle_count"
+  // d.d_dow == 1 &&
+  Const        r14, "d_dow"
+  // (d.d_year == 1998 || d.d_year == 1999 || d.d_year == 2000) &&
+  Const        r15, "d_year"
+  Const        r16, "d_year"
+  Const        r17, "d_year"
+  // s.s_number_employees >= 200 && s.s_number_employees <= 295
+  Const        r18, "s_number_employees"
+  Const        r19, "s_number_employees"
+  // select { key: g.key, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
+  Const        r20, "key"
+  Const        r21, "key"
+  Const        r22, "amt"
+  Const        r23, "ss"
+  Const        r24, "ss_coupon_amt"
+  Const        r25, "profit"
+  Const        r26, "ss"
+  Const        r27, "ss_net_profit"
+  // from ss in store_sales
   MakeMap      r28, 0, r0
   Const        r29, []
   IterPrep     r31, r3
   Len          r32, r31
   Const        r33, 0
-L1:
+L15:
   LessInt      r34, r33, r32
   JumpIfFalse  r34, L0
   Index        r36, r31, r33
@@ -25,7 +54,7 @@ L1:
   IterPrep     r37, r0
   Len          r38, r37
   Const        r39, 0
-L2:
+L14:
   LessInt      r40, r39, r38
   JumpIfFalse  r40, L1
   Index        r42, r37, r39
@@ -199,38 +228,58 @@ L3:
   Const        r164, 1
   AddInt       r50, r50, r164
   Jump         L13
-L0:
+L2:
+  // join d in date_dim on d.d_date_sk == ss.ss_sold_date_sk
+  Const        r165, 1
+  AddInt       r39, r39, r165
+  Jump         L14
+L1:
   // from ss in store_sales
+  Const        r166, 1
+  AddInt       r33, r33, r166
+  Jump         L15
+L0:
   Const        r167, 0
   Len          r169, r29
-L19:
+L21:
   LessInt      r170, r167, r169
-  JumpIfFalse  r170, L14
+  JumpIfFalse  r170, L16
   Index        r172, r29, r167
   // select { key: g.key, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
   Const        r173, "key"
   Const        r174, "key"
   Index        r175, r172, r174
   Const        r176, "amt"
+  Const        r177, []
+  Const        r178, "ss"
+  Const        r179, "ss_coupon_amt"
   IterPrep     r180, r172
   Len          r181, r180
   Const        r182, 0
-L16:
+L18:
   LessInt      r184, r182, r181
-  JumpIfFalse  r184, L15
+  JumpIfFalse  r184, L17
+  Index        r186, r180, r182
+  Const        r187, "ss"
+  Index        r188, r186, r187
+  Const        r189, "ss_coupon_amt"
+  Index        r190, r188, r189
+  Append       r177, r177, r190
   Const        r192, 1
   AddInt       r182, r182, r192
-  Jump         L16
-L15:
-  Const        r193, 0
+  Jump         L18
+L17:
+  Sum          r193, r177
   Const        r194, "profit"
   Const        r195, []
+  Const        r196, "ss"
+  Const        r197, "ss_net_profit"
   IterPrep     r198, r172
   Len          r199, r198
   Const        r200, 0
-L18:
+L20:
   LessInt      r202, r200, r199
-  JumpIfFalse  r202, L17
+  JumpIfFalse  r202, L19
   Index        r186, r198, r200
   Const        r204, "ss"
   Index        r205, r186, r204
@@ -239,8 +288,8 @@ L18:
   Append       r195, r195, r207
   Const        r209, 1
   AddInt       r200, r200, r209
-  Jump         L18
-L17:
+  Jump         L20
+L19:
   Sum          r210, r195
   Move         r211, r173
   Move         r212, r175
@@ -253,8 +302,8 @@ L17:
   Append       r5, r5, r217
   Const        r219, 1
   AddInt       r167, r167, r219
-  Jump         L19
-L14:
+  Jump         L21
+L16:
   // from a in agg
   Const        r220, []
   IterPrep     r221, r5
@@ -265,17 +314,17 @@ L14:
   // from a in agg
   Const        r225, 0
   EqualInt     r226, r222, r225
-  JumpIfTrue   r226, L20
+  JumpIfTrue   r226, L22
   EqualInt     r227, r224, r225
-  JumpIfTrue   r227, L20
+  JumpIfTrue   r227, L22
   LessEq       r228, r224, r222
-  JumpIfFalse  r228, L21
+  JumpIfFalse  r228, L23
   // join c in customer on c.c_customer_sk == a.key.customer_sk
   MakeMap      r229, 0, r0
   Const        r230, 0
-L24:
+L26:
   LessInt      r231, r230, r224
-  JumpIfFalse  r231, L22
+  JumpIfFalse  r231, L24
   Index        r232, r223, r230
   Move         r233, r232
   Const        r234, "c_customer_sk"
@@ -283,22 +332,22 @@ L24:
   Index        r236, r229, r235
   Const        r237, nil
   NotEqual     r238, r236, r237
-  JumpIfTrue   r238, L23
+  JumpIfTrue   r238, L25
   MakeList     r239, 0, r0
   SetIndex     r229, r235, r239
-L23:
+L25:
   Index        r236, r229, r235
   Append       r240, r236, r232
   SetIndex     r229, r235, r240
   Const        r241, 1
   AddInt       r230, r230, r241
-  Jump         L24
-L22:
+  Jump         L26
+L24:
   // from a in agg
   Const        r242, 0
-L27:
+L29:
   LessInt      r243, r242, r222
-  JumpIfFalse  r243, L20
+  JumpIfFalse  r243, L22
   Index        r245, r221, r242
   // join c in customer on c.c_customer_sk == a.key.customer_sk
   Const        r246, "key"
@@ -309,12 +358,12 @@ L27:
   Index        r250, r229, r249
   Const        r251, nil
   NotEqual     r252, r250, r251
-  JumpIfFalse  r252, L25
+  JumpIfFalse  r252, L27
   Len          r253, r250
   Const        r254, 0
-L26:
+L28:
   LessInt      r255, r254, r253
-  JumpIfFalse  r255, L25
+  JumpIfFalse  r255, L27
   Index        r233, r250, r254
   // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
   Const        r257, "c_last_name"
@@ -358,22 +407,30 @@ L26:
   Const        r295, "c_first_name"
   Index        r296, r233, r295
   Move         r297, r296
+  Const        r298, "key"
+  Index        r299, r245, r298
+  Const        r300, "city"
+  Index        r302, r299, r300
+  Const        r303, "profit"
+  Index        r305, r245, r303
   MakeList     r307, 4, r294
   // from a in agg
   Move         r308, r291
   MakeList     r309, 2, r307
   Append       r220, r220, r309
-  Jump         L26
-L25:
+  Const        r311, 1
+  AddInt       r254, r254, r311
+  Jump         L28
+L27:
   Const        r312, 1
   AddInt       r242, r242, r312
-  Jump         L27
-L21:
+  Jump         L29
+L23:
   MakeMap      r313, 0, r0
   Const        r314, 0
-L30:
+L32:
   LessInt      r315, r314, r222
-  JumpIfFalse  r315, L28
+  JumpIfFalse  r315, L30
   Index        r316, r221, r314
   Move         r245, r316
   // join c in customer on c.c_customer_sk == a.key.customer_sk
@@ -385,34 +442,34 @@ L30:
   Index        r321, r313, r320
   Const        r322, nil
   NotEqual     r323, r321, r322
-  JumpIfTrue   r323, L29
+  JumpIfTrue   r323, L31
   MakeList     r324, 0, r0
   SetIndex     r313, r320, r324
-L29:
+L31:
   Index        r321, r313, r320
   Append       r325, r321, r316
   SetIndex     r313, r320, r325
   Const        r326, 1
   AddInt       r314, r314, r326
-  Jump         L30
-L28:
+  Jump         L32
+L30:
   // join c in customer on c.c_customer_sk == a.key.customer_sk
   Const        r327, 0
-L34:
+L36:
   LessInt      r328, r327, r224
-  JumpIfFalse  r328, L31
+  JumpIfFalse  r328, L33
   Index        r233, r223, r327
   Const        r330, "c_customer_sk"
   Index        r331, r233, r330
   Index        r332, r313, r331
   Const        r333, nil
   NotEqual     r334, r332, r333
-  JumpIfFalse  r334, L32
+  JumpIfFalse  r334, L34
   Len          r335, r332
   Const        r336, 0
-L33:
+L35:
   LessInt      r337, r336, r335
-  JumpIfFalse  r337, L32
+  JumpIfFalse  r337, L34
   Index        r245, r332, r336
   // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, s_city: a.key.city, ss_ticket_number: a.key.ticket, amt: a.amt, profit: a.profit }
   Const        r339, "c_last_name"
@@ -456,6 +513,12 @@ L33:
   Const        r377, "c_first_name"
   Index        r378, r233, r377
   Move         r379, r378
+  Const        r380, "key"
+  Index        r381, r245, r380
+  Const        r382, "city"
+  Index        r384, r381, r382
+  Const        r385, "profit"
+  Index        r387, r245, r385
   MakeList     r389, 4, r376
   // from a in agg
   Move         r390, r373
@@ -464,12 +527,12 @@ L33:
   // join c in customer on c.c_customer_sk == a.key.customer_sk
   Const        r393, 1
   AddInt       r336, r336, r393
-  Jump         L33
-L32:
+  Jump         L35
+L34:
   Const        r394, 1
   AddInt       r327, r327, r394
-  Jump         L34
-L31:
+  Jump         L36
+L33:
   // sort by [c.c_last_name, c.c_first_name, a.key.city, a.profit]
   Sort         r220, r220
   // json(result)


### PR DESCRIPTION
## Summary
- remove duplicate OpFirst opcode and handlers in the VM
- regenerate IR for TPC‑DS queries q70 and q79

## Testing
- `go run /tmp/gen_ir.go`
- `go run /tmp/gen_ir70.go`


------
https://chatgpt.com/codex/tasks/task_e_6862320f3ecc8320a6cc7d8512dfdb78