### PR TITLE
Enable VM compilation past q30 and refresh IR outputs

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -127,7 +127,6 @@ const (
 	OpIntersect
 	OpSort
 	OpExpect
-	OpFirst
 )
 
 func (op Op) String() string {
@@ -282,8 +281,6 @@ func (op Op) String() string {
 		return "Sort"
 	case OpExpect:
 		return "Expect"
-	case OpFirst:
-		return "First"
 	default:
 		return "?"
 	}
@@ -456,8 +453,6 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpExpect:
 				fmt.Fprintf(&b, "%s", formatReg(ins.A))
-			case OpFirst:
-				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpMakeClosure:
 				fmt.Fprintf(&b, "%s, %s, %d, %s", formatReg(ins.A), p.funcName(ins.B), ins.C, formatReg(ins.D))
 			case OpCall2:
@@ -1123,13 +1118,6 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			line = strings.TrimRight(line, "\r\n")
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: line}
-		case OpFirst:
-			lst := fr.regs[ins.B]
-			if lst.Tag != ValueList || len(lst.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: ValueNull}
-			} else {
-				fr.regs[ins.A] = lst.List[0]
-			}
 		case OpIterPrep:
 			src := fr.regs[ins.B]
 			switch src.Tag {

--- a/tests/dataset/tpc-ds/out/q30.ir.out
+++ b/tests/dataset/tpc-ds/out/q30.ir.out
@@ -9,12 +9,32 @@ func main (regs=324)
   Const        r3, [{"c_current_addr_sk": 1, "c_customer_id": "C1", "c_customer_sk": 1, "c_first_name": "John", "c_last_name": "Doe"}, {"c_current_addr_sk": 2, "c_customer_id": "C2", "c_customer_sk": 2, "c_first_name": "Jane", "c_last_name": "Smith"}]
   // from wr in web_returns
   Const        r4, []
+  // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
+  Const        r5, "cust"
+  Const        r6, "wr_returning_customer_sk"
+  Const        r7, "state"
+  Const        r8, "ca_state"
+  // where d.d_year == 2000 && ca.ca_state == "CA"
+  Const        r9, "d_year"
+  Const        r10, "ca_state"
+  // ctr_customer_sk: g.key.cust,
+  Const        r11, "ctr_customer_sk"
+  Const        r12, "key"
+  Const        r13, "cust"
+  // ctr_state: g.key.state,
+  Const        r14, "ctr_state"
+  Const        r15, "key"
+  Const        r16, "state"
+  // ctr_total_return: sum(from x in g select x.wr_return_amt)
+  Const        r17, "ctr_total_return"
+  Const        r18, "wr_return_amt"
+  // from wr in web_returns
   MakeMap      r19, 0, r0
   Const        r20, []
   IterPrep     r22, r0
   Len          r23, r22
   Const        r24, 0
-L1:
+L8:
   LessInt      r25, r24, r23
   JumpIfFalse  r25, L0
   Index        r27, r22, r24
@@ -22,7 +42,7 @@ L1:
   IterPrep     r28, r1
   Len          r29, r28
   Const        r30, 0
-L2:
+L7:
   LessInt      r31, r30, r29
   JumpIfFalse  r31, L1
   Index        r33, r28, r30
@@ -122,13 +142,22 @@ L3:
   Const        r106, 1
   AddInt       r41, r41, r106
   Jump         L6
-L0:
+L2:
+  // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
+  Const        r107, 1
+  AddInt       r30, r30, r107
+  Jump         L7
+L1:
   // from wr in web_returns
+  Const        r108, 1
+  AddInt       r24, r24, r108
+  Jump         L8
+L0:
   Const        r109, 0
   Len          r111, r20
-L10:
+L12:
   LessInt      r112, r109, r111
-  JumpIfFalse  r112, L7
+  JumpIfFalse  r112, L9
   Index        r114, r20, r109
   // ctr_customer_sk: g.key.cust,
   Const        r115, "ctr_customer_sk"
@@ -145,20 +174,21 @@ L10:
   // ctr_total_return: sum(from x in g select x.wr_return_amt)
   Const        r125, "ctr_total_return"
   Const        r126, []
+  Const        r127, "wr_return_amt"
   IterPrep     r128, r114
   Len          r129, r128
   Const        r130, 0
-L9:
+L11:
   LessInt      r132, r130, r129
-  JumpIfFalse  r132, L8
+  JumpIfFalse  r132, L10
   Index        r134, r128, r130
   Const        r135, "wr_return_amt"
   Index        r136, r134, r135
   Append       r126, r126, r136
   Const        r138, 1
   AddInt       r130, r130, r138
-  Jump         L9
-L8:
+  Jump         L11
+L10:
   Sum          r139, r126
   // ctr_customer_sk: g.key.cust,
   Move         r140, r115
@@ -173,18 +203,28 @@ L8:
   MakeMap      r146, 3, r140
   // from wr in web_returns
   Append       r4, r4, r146
-  Jump         L10
-L7:
+  Const        r148, 1
+  AddInt       r109, r109, r148
+  Jump         L12
+L9:
   // from ctr in customer_total_return
   Const        r149, []
+  // group by ctr.ctr_state into g
+  Const        r150, "ctr_state"
+  // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
+  Const        r151, "state"
+  Const        r152, "key"
+  Const        r153, "avg_return"
+  Const        r154, "ctr_total_return"
+  // from ctr in customer_total_return
   IterPrep     r155, r4
   Len          r156, r155
   Const        r157, 0
   MakeMap      r158, 0, r0
   Const        r159, []
-L13:
+L15:
   LessInt      r161, r157, r156
-  JumpIfFalse  r161, L11
+  JumpIfFalse  r161, L13
   Index        r162, r155, r157
   Move         r163, r162
   // group by ctr.ctr_state into g
@@ -192,7 +232,7 @@ L13:
   Index        r165, r163, r164
   Str          r166, r165
   In           r167, r166, r158
-  JumpIfTrue   r167, L12
+  JumpIfTrue   r167, L14
   // from ctr in customer_total_return
   Const        r168, []
   Const        r169, "__group__"
@@ -216,7 +256,7 @@ L13:
   MakeMap      r185, 4, r177
   SetIndex     r158, r166, r185
   Append       r159, r159, r185
-L12:
+L14:
   Const        r187, "items"
   Index        r188, r158, r166
   Index        r189, r188, r187
@@ -229,13 +269,13 @@ L12:
   SetIndex     r188, r191, r194
   Const        r195, 1
   AddInt       r157, r157, r195
-  Jump         L13
-L11:
+  Jump         L15
+L13:
   Const        r196, 0
   Len          r198, r159
-L17:
+L19:
   LessInt      r199, r196, r198
-  JumpIfFalse  r199, L14
+  JumpIfFalse  r199, L16
   Index        r114, r159, r196
   // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
   Const        r201, "state"
@@ -243,18 +283,21 @@ L17:
   Index        r203, r114, r202
   Const        r204, "avg_return"
   Const        r205, []
+  Const        r206, "ctr_total_return"
   IterPrep     r207, r114
   Len          r208, r207
   Const        r209, 0
-L16:
+L18:
   LessInt      r211, r209, r208
-  JumpIfFalse  r211, L15
+  JumpIfFalse  r211, L17
   Index        r134, r207, r209
   Const        r213, "ctr_total_return"
   Index        r214, r134, r213
   Append       r205, r205, r214
-  Jump         L16
-L15:
+  Const        r216, 1
+  AddInt       r209, r209, r216
+  Jump         L18
+L17:
   Avg          r217, r205
   Move         r218, r201
   Move         r219, r203
@@ -265,45 +308,97 @@ L15:
   Append       r149, r149, r222
   Const        r224, 1
   AddInt       r196, r196, r224
-  Jump         L17
-L14:
+  Jump         L19
+L16:
   // from ctr in customer_total_return
   Const        r225, []
+  // where ctr.ctr_total_return > avg.avg_return * 1.2
+  Const        r226, "ctr_total_return"
+  Const        r227, "avg_return"
+  // c_customer_id: c.c_customer_id,
+  Const        r228, "c_customer_id"
+  Const        r229, "c_customer_id"
+  // c_first_name: c.c_first_name,
+  Const        r230, "c_first_name"
+  Const        r231, "c_first_name"
+  // c_last_name: c.c_last_name,
+  Const        r232, "c_last_name"
+  Const        r233, "c_last_name"
+  // ctr_total_return: ctr.ctr_total_return
+  Const        r234, "ctr_total_return"
+  Const        r235, "ctr_total_return"
+  // from ctr in customer_total_return
   IterPrep     r236, r4
   Len          r237, r236
   Const        r238, 0
-L24:
+L26:
   LessInt      r240, r238, r237
-  JumpIfFalse  r240, L18
+  JumpIfFalse  r240, L20
   Index        r163, r236, r238
   // join avg in avg_by_state on ctr.ctr_state == avg.state
   IterPrep     r242, r149
   Len          r243, r242
+  Const        r244, "ctr_state"
+  Const        r245, "state"
+  // where ctr.ctr_total_return > avg.avg_return * 1.2
+  Const        r246, "ctr_total_return"
+  Const        r247, "avg_return"
+  // c_customer_id: c.c_customer_id,
+  Const        r248, "c_customer_id"
+  Const        r249, "c_customer_id"
+  // c_first_name: c.c_first_name,
+  Const        r250, "c_first_name"
+  Const        r251, "c_first_name"
+  // c_last_name: c.c_last_name,
+  Const        r252, "c_last_name"
+  Const        r253, "c_last_name"
+  // ctr_total_return: ctr.ctr_total_return
+  Const        r254, "ctr_total_return"
+  Const        r255, "ctr_total_return"
+  // join avg in avg_by_state on ctr.ctr_state == avg.state
   Const        r256, 0
-L23:
+L25:
   LessInt      r258, r256, r243
-  JumpIfFalse  r258, L19
+  JumpIfFalse  r258, L21
   Index        r260, r242, r256
   Const        r261, "ctr_state"
   Index        r262, r163, r261
   Const        r263, "state"
   Index        r264, r260, r263
   Equal        r265, r262, r264
-  JumpIfFalse  r265, L20
+  JumpIfFalse  r265, L22
   // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
   IterPrep     r266, r3
   Len          r267, r266
+  Const        r268, "ctr_customer_sk"
+  Const        r269, "c_customer_sk"
+  // where ctr.ctr_total_return > avg.avg_return * 1.2
+  Const        r270, "ctr_total_return"
+  Const        r271, "avg_return"
+  // c_customer_id: c.c_customer_id,
+  Const        r272, "c_customer_id"
+  Const        r273, "c_customer_id"
+  // c_first_name: c.c_first_name,
+  Const        r274, "c_first_name"
+  Const        r275, "c_first_name"
+  // c_last_name: c.c_last_name,
+  Const        r276, "c_last_name"
+  Const        r277, "c_last_name"
+  // ctr_total_return: ctr.ctr_total_return
+  Const        r278, "ctr_total_return"
+  Const        r279, "ctr_total_return"
+  // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
   Const        r280, 0
-L22:
+L24:
   LessInt      r282, r280, r267
-  JumpIfFalse  r282, L20
+  JumpIfFalse  r282, L22
   Index        r284, r266, r280
   Const        r285, "ctr_customer_sk"
   Index        r286, r163, r285
   Const        r287, "c_customer_sk"
   Index        r288, r284, r287
   Equal        r289, r286, r288
-  JumpIfFalse  r289, L21
+  JumpIfFalse  r289, L23
   // where ctr.ctr_total_return > avg.avg_return * 1.2
   Const        r290, "ctr_total_return"
   Index        r291, r163, r290
@@ -312,7 +407,7 @@ L22:
   Const        r294, 1.2
   MulFloat     r295, r293, r294
   LessFloat    r296, r295, r291
-  JumpIfFalse  r296, L21
+  JumpIfFalse  r296, L23
   // c_customer_id: c.c_customer_id,
   Const        r297, "c_customer_id"
   Const        r298, "c_customer_id"
@@ -345,22 +440,22 @@ L22:
   MakeMap      r317, 4, r309
   // from ctr in customer_total_return
   Append       r225, r225, r317
-L21:
+L23:
   // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
   Const        r319, 1
   Add          r280, r280, r319
-  Jump         L22
-L20:
+  Jump         L24
+L22:
   // join avg in avg_by_state on ctr.ctr_state == avg.state
   Const        r320, 1
   Add          r256, r256, r320
-  Jump         L23
-L19:
+  Jump         L25
+L21:
   // from ctr in customer_total_return
   Const        r321, 1
   AddInt       r238, r238, r321
-  Jump         L24
-L18:
+  Jump         L26
+L20:
   // json(result)
   JSON         r225
   // expect result == [{c_customer_id: "C1", c_first_name: "John", c_last_name: "Doe", ctr_total_return: 150.0}]

--- a/tests/dataset/tpc-ds/out/q31.ir.out
+++ b/tests/dataset/tpc-ds/out/q31.ir.out
@@ -11,16 +11,19 @@ func main (regs=183)
   IterPrep     r5, r2
   Len          r6, r5
   Const        r7, 0
-L22:
+L27:
   Less         r8, r7, r6
   JumpIfFalse  r8, L0
   Index        r10, r5, r7
   // let ss1 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 1 select s.ss_ext_sales_price)
   Const        r11, []
+  Const        r12, "ca_county"
+  Const        r13, "d_qoy"
+  Const        r14, "ss_ext_sales_price"
   IterPrep     r15, r0
   Len          r16, r15
   Const        r17, 0
-L3:
+L4:
   LessInt      r19, r17, r16
   JumpIfFalse  r19, L1
   Index        r21, r15, r17
@@ -39,17 +42,23 @@ L2:
   Const        r30, "ss_ext_sales_price"
   Index        r31, r21, r30
   Append       r11, r11, r31
-  Jump         L3
+L3:
+  Const        r33, 1
+  AddInt       r17, r17, r33
+  Jump         L4
 L1:
   Sum          r34, r11
   // let ss2 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 2 select s.ss_ext_sales_price)
   Const        r35, []
+  Const        r36, "ca_county"
+  Const        r37, "d_qoy"
+  Const        r38, "ss_ext_sales_price"
   IterPrep     r39, r0
   Len          r40, r39
   Const        r41, 0
-L7:
+L8:
   LessInt      r43, r41, r40
-  JumpIfFalse  r43, L4
+  JumpIfFalse  r43, L5
   Index        r21, r39, r41
   Const        r45, "ca_county"
   Index        r46, r21, r45
@@ -59,27 +68,30 @@ L7:
   Const        r50, 2
   Equal        r51, r49, r50
   Move         r52, r47
-  JumpIfFalse  r52, L5
-  Move         r52, r51
-L5:
   JumpIfFalse  r52, L6
+  Move         r52, r51
+L6:
+  JumpIfFalse  r52, L7
   Const        r53, "ss_ext_sales_price"
   Index        r54, r21, r53
   Append       r35, r35, r54
-L6:
+L7:
   Const        r56, 1
   AddInt       r41, r41, r56
-  Jump         L7
-L4:
+  Jump         L8
+L5:
   Sum          r57, r35
   // let ss3 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 3 select s.ss_ext_sales_price)
   Const        r58, []
+  Const        r59, "ca_county"
+  Const        r60, "d_qoy"
+  Const        r61, "ss_ext_sales_price"
   IterPrep     r62, r0
   Len          r63, r62
   Const        r64, 0
-L11:
+L12:
   LessInt      r66, r64, r63
-  JumpIfFalse  r66, L8
+  JumpIfFalse  r66, L9
   Index        r21, r62, r64
   Const        r68, "ca_county"
   Index        r69, r21, r68
@@ -89,27 +101,30 @@ L11:
   Const        r73, 3
   Equal        r74, r72, r73
   Move         r75, r70
-  JumpIfFalse  r75, L9
-  Move         r75, r74
-L9:
   JumpIfFalse  r75, L10
+  Move         r75, r74
+L10:
+  JumpIfFalse  r75, L11
   Const        r76, "ss_ext_sales_price"
   Index        r77, r21, r76
   Append       r58, r58, r77
-L10:
+L11:
   Const        r79, 1
   AddInt       r64, r64, r79
-  Jump         L11
-L8:
+  Jump         L12
+L9:
   Sum          r80, r58
   // let ws1 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 1 select w.ws_ext_sales_price)
   Const        r81, []
+  Const        r82, "ca_county"
+  Const        r83, "d_qoy"
+  Const        r84, "ws_ext_sales_price"
   IterPrep     r85, r1
   Len          r86, r85
   Const        r87, 0
-L14:
+L16:
   LessInt      r89, r87, r86
-  JumpIfFalse  r89, L12
+  JumpIfFalse  r89, L13
   Index        r91, r85, r87
   Const        r92, "ca_county"
   Index        r93, r91, r92
@@ -119,24 +134,30 @@ L14:
   Const        r97, 1
   Equal        r98, r96, r97
   Move         r99, r94
-  JumpIfFalse  r99, L13
-  Move         r99, r98
-L13:
   JumpIfFalse  r99, L14
+  Move         r99, r98
+L14:
+  JumpIfFalse  r99, L15
   Const        r100, "ws_ext_sales_price"
   Index        r101, r91, r100
   Append       r81, r81, r101
-  Jump         L14
-L12:
+L15:
+  Const        r103, 1
+  AddInt       r87, r87, r103
+  Jump         L16
+L13:
   Sum          r104, r81
   // let ws2 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 2 select w.ws_ext_sales_price)
   Const        r105, []
+  Const        r106, "ca_county"
+  Const        r107, "d_qoy"
+  Const        r108, "ws_ext_sales_price"
   IterPrep     r109, r1
   Len          r110, r109
   Const        r111, 0
-L17:
+L20:
   LessInt      r113, r111, r110
-  JumpIfFalse  r113, L15
+  JumpIfFalse  r113, L17
   Index        r91, r109, r111
   Const        r115, "ca_county"
   Index        r116, r91, r115
@@ -146,24 +167,30 @@ L17:
   Const        r120, 2
   Equal        r121, r119, r120
   Move         r122, r117
-  JumpIfFalse  r122, L16
+  JumpIfFalse  r122, L18
   Move         r122, r121
-L16:
-  JumpIfFalse  r122, L17
+L18:
+  JumpIfFalse  r122, L19
   Const        r123, "ws_ext_sales_price"
   Index        r124, r91, r123
   Append       r105, r105, r124
-  Jump         L17
-L15:
+L19:
+  Const        r126, 1
+  AddInt       r111, r111, r126
+  Jump         L20
+L17:
   Sum          r127, r105
   // let ws3 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 3 select w.ws_ext_sales_price)
   Const        r128, []
+  Const        r129, "ca_county"
+  Const        r130, "d_qoy"
+  Const        r131, "ws_ext_sales_price"
   IterPrep     r132, r1
   Len          r133, r132
   Const        r134, 0
-L20:
+L24:
   LessInt      r136, r134, r133
-  JumpIfFalse  r136, L18
+  JumpIfFalse  r136, L21
   Index        r91, r132, r134
   Const        r138, "ca_county"
   Index        r139, r91, r138
@@ -173,15 +200,18 @@ L20:
   Const        r143, 3
   Equal        r144, r142, r143
   Move         r145, r140
-  JumpIfFalse  r145, L19
+  JumpIfFalse  r145, L22
   Move         r145, r144
-L19:
-  JumpIfFalse  r145, L20
+L22:
+  JumpIfFalse  r145, L23
   Const        r146, "ws_ext_sales_price"
   Index        r147, r91, r146
   Append       r128, r128, r147
-  Jump         L20
-L18:
+L23:
+  Const        r149, 1
+  AddInt       r134, r134, r149
+  Jump         L24
+L21:
   Sum          r150, r128
   // let web_g1 = ws2 / ws1
   Div          r151, r127, r104
@@ -195,10 +225,10 @@ L18:
   Less         r155, r152, r151
   Less         r156, r154, r153
   Move         r157, r155
-  JumpIfFalse  r157, L21
+  JumpIfFalse  r157, L25
   Move         r157, r156
-L21:
-  JumpIfFalse  r157, L22
+L25:
+  JumpIfFalse  r157, L26
   // ca_county: county,
   Const        r158, "ca_county"
   // d_year: 2000,
@@ -233,8 +263,11 @@ L21:
   // result = append(result, {
   MakeMap      r177, 6, r165
   Append       r4, r4, r177
+L26:
   // for county in counties {
-  Jump         L22
+  Const        r179, 1
+  Add          r7, r7, r179
+  Jump         L27
 L0:
   // json(result)
   JSON         r4

--- a/tests/dataset/tpc-ds/out/q32.ir.out
+++ b/tests/dataset/tpc-ds/out/q32.ir.out
@@ -7,18 +7,32 @@ func main (regs=80)
   Const        r2, [{"d_date_sk": 1, "d_year": 2000}, {"d_date_sk": 2, "d_year": 2000}, {"d_date_sk": 3, "d_year": 2000}]
   // from cs in catalog_sales
   Const        r3, []
+  // where i.i_manufact_id == 1 && d.d_year == 2000
+  Const        r4, "i_manufact_id"
+  Const        r5, "d_year"
+  // select cs.cs_ext_discount_amt
+  Const        r6, "cs_ext_discount_amt"
+  // from cs in catalog_sales
   IterPrep     r7, r0
   Len          r8, r7
   Const        r9, 0
-L5:
+L7:
   LessInt      r11, r9, r8
   JumpIfFalse  r11, L0
   Index        r13, r7, r9
   // join i in item on cs.cs_item_sk == i.i_item_sk
   IterPrep     r14, r1
   Len          r15, r14
+  Const        r16, "cs_item_sk"
+  Const        r17, "i_item_sk"
+  // where i.i_manufact_id == 1 && d.d_year == 2000
+  Const        r18, "i_manufact_id"
+  Const        r19, "d_year"
+  // select cs.cs_ext_discount_amt
+  Const        r20, "cs_ext_discount_amt"
+  // join i in item on cs.cs_item_sk == i.i_item_sk
   Const        r21, 0
-L2:
+L6:
   LessInt      r23, r21, r15
   JumpIfFalse  r23, L1
   Index        r25, r14, r21
@@ -31,8 +45,16 @@ L2:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   IterPrep     r31, r2
   Len          r32, r31
+  Const        r33, "cs_sold_date_sk"
+  Const        r34, "d_date_sk"
+  // where i.i_manufact_id == 1 && d.d_year == 2000
+  Const        r35, "i_manufact_id"
+  Const        r36, "d_year"
+  // select cs.cs_ext_discount_amt
+  Const        r37, "cs_ext_discount_amt"
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   Const        r38, 0
-L3:
+L5:
   LessInt      r40, r38, r32
   JumpIfFalse  r40, L2
   Index        r42, r31, r38
@@ -61,13 +83,21 @@ L4:
   Index        r58, r13, r57
   // from cs in catalog_sales
   Append       r3, r3, r58
+L3:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  Jump         L3
+  Const        r60, 1
+  Add          r38, r38, r60
+  Jump         L5
+L2:
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  Const        r61, 1
+  Add          r21, r21, r61
+  Jump         L6
 L1:
   // from cs in catalog_sales
   Const        r62, 1
   AddInt       r9, r9, r62
-  Jump         L5
+  Jump         L7
 L0:
   // let avg_discount = avg(filtered)
   Avg          r63, r3
@@ -76,20 +106,20 @@ L0:
   IterPrep     r65, r3
   Len          r66, r65
   Const        r67, 0
-L8:
+L10:
   LessInt      r69, r67, r66
-  JumpIfFalse  r69, L6
+  JumpIfFalse  r69, L8
   Index        r71, r65, r67
   Const        r72, 1.3
   MulFloat     r73, r63, r72
   LessFloat    r74, r73, r71
-  JumpIfFalse  r74, L7
+  JumpIfFalse  r74, L9
   Append       r64, r64, r71
-L7:
+L9:
   Const        r76, 1
   AddInt       r67, r67, r76
-  Jump         L8
-L6:
+  Jump         L10
+L8:
   Sum          r77, r64
   // json(result)
   JSON         r77

--- a/tests/dataset/tpc-ds/out/q33.ir.out
+++ b/tests/dataset/tpc-ds/out/q33.ir.out
@@ -17,18 +17,42 @@ func main (regs=451)
   Const        r7, 2000
   // from ss in store_sales
   Const        r8, []
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r9, "i_category"
+  Const        r10, "d_year"
+  Const        r11, "d_moy"
+  Const        r12, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
+  Const        r13, "manu"
+  Const        r14, "i_manufact_id"
+  Const        r15, "price"
+  Const        r16, "ss_ext_sales_price"
+  // from ss in store_sales
   IterPrep     r17, r3
   Len          r18, r17
   Const        r19, 0
-L8:
+L11:
   LessInt      r21, r19, r18
   JumpIfFalse  r21, L0
   Index        r23, r17, r19
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   IterPrep     r24, r1
   Len          r25, r24
+  Const        r26, "ss_sold_date_sk"
+  Const        r27, "d_date_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r28, "i_category"
+  Const        r29, "d_year"
+  Const        r30, "d_moy"
+  Const        r31, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
+  Const        r32, "manu"
+  Const        r33, "i_manufact_id"
+  Const        r34, "price"
+  Const        r35, "ss_ext_sales_price"
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   Const        r36, 0
-L2:
+L10:
   LessInt      r38, r36, r25
   JumpIfFalse  r38, L1
   Index        r40, r24, r36
@@ -41,8 +65,21 @@ L2:
   // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
   IterPrep     r46, r2
   Len          r47, r46
+  Const        r48, "ss_addr_sk"
+  Const        r49, "ca_address_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r50, "i_category"
+  Const        r51, "d_year"
+  Const        r52, "d_moy"
+  Const        r53, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
+  Const        r54, "manu"
+  Const        r55, "i_manufact_id"
+  Const        r56, "price"
+  Const        r57, "ss_ext_sales_price"
+  // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
   Const        r58, 0
-L3:
+L9:
   LessInt      r60, r58, r47
   JumpIfFalse  r60, L2
   Index        r62, r46, r58
@@ -55,8 +92,21 @@ L3:
   // join i in item on ss.ss_item_sk == i.i_item_sk
   IterPrep     r68, r0
   Len          r69, r68
+  Const        r70, "ss_item_sk"
+  Const        r71, "i_item_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r72, "i_category"
+  Const        r73, "d_year"
+  Const        r74, "d_moy"
+  Const        r75, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
+  Const        r76, "manu"
+  Const        r77, "i_manufact_id"
+  Const        r78, "price"
+  Const        r79, "ss_ext_sales_price"
+  // join i in item on ss.ss_item_sk == i.i_item_sk
   Const        r80, 0
-L4:
+L8:
   LessInt      r82, r80, r69
   JumpIfFalse  r82, L3
   Index        r84, r68, r80
@@ -79,6 +129,7 @@ L4:
   Equal        r99, r98, r6
   Const        r100, "ca_gmt_offset"
   Index        r101, r62, r100
+  Const        r102, 5
   Const        r103, -5
   Equal        r104, r101, r103
   Move         r105, r93
@@ -106,65 +157,128 @@ L7:
   MakeMap      r118, 2, r114
   // from ss in store_sales
   Append       r8, r8, r118
+L4:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  Jump         L4
+  Const        r120, 1
+  Add          r80, r80, r120
+  Jump         L8
+L3:
+  // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
+  Const        r121, 1
+  Add          r58, r58, r121
+  Jump         L9
+L2:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r122, 1
+  Add          r36, r36, r122
+  Jump         L10
 L1:
   // from ss in store_sales
   Const        r123, 1
   AddInt       r19, r19, r123
-  Jump         L8
+  Jump         L11
 L0:
   // from cs in catalog_sales
   Const        r124, []
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r125, "i_category"
+  Const        r126, "d_year"
+  Const        r127, "d_moy"
+  Const        r128, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
+  Const        r129, "manu"
+  Const        r130, "i_manufact_id"
+  Const        r131, "price"
+  Const        r132, "cs_ext_sales_price"
+  // from cs in catalog_sales
   IterPrep     r133, r4
   Len          r134, r133
   Const        r135, 0
-L20:
+L23:
   LessInt      r137, r135, r134
-  JumpIfFalse  r137, L9
+  JumpIfFalse  r137, L12
   Index        r139, r133, r135
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   IterPrep     r140, r1
   Len          r141, r140
+  Const        r142, "cs_sold_date_sk"
+  Const        r143, "d_date_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r144, "i_category"
+  Const        r145, "d_year"
+  Const        r146, "d_moy"
+  Const        r147, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
+  Const        r148, "manu"
+  Const        r149, "i_manufact_id"
+  Const        r150, "price"
+  Const        r151, "cs_ext_sales_price"
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   Const        r152, 0
-L19:
+L22:
   LessInt      r154, r152, r141
-  JumpIfFalse  r154, L10
+  JumpIfFalse  r154, L13
   Index        r40, r140, r152
   Const        r156, "cs_sold_date_sk"
   Index        r157, r139, r156
   Const        r158, "d_date_sk"
   Index        r159, r40, r158
   Equal        r160, r157, r159
-  JumpIfFalse  r160, L11
+  JumpIfFalse  r160, L14
   // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
   IterPrep     r161, r2
   Len          r162, r161
+  Const        r163, "cs_bill_addr_sk"
+  Const        r164, "ca_address_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r165, "i_category"
+  Const        r166, "d_year"
+  Const        r167, "d_moy"
+  Const        r168, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
+  Const        r169, "manu"
+  Const        r170, "i_manufact_id"
+  Const        r171, "price"
+  Const        r172, "cs_ext_sales_price"
+  // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
   Const        r173, 0
-L18:
+L21:
   LessInt      r175, r173, r162
-  JumpIfFalse  r175, L11
+  JumpIfFalse  r175, L14
   Index        r62, r161, r173
   Const        r177, "cs_bill_addr_sk"
   Index        r178, r139, r177
   Const        r179, "ca_address_sk"
   Index        r180, r62, r179
   Equal        r181, r178, r180
-  JumpIfFalse  r181, L12
+  JumpIfFalse  r181, L15
   // join i in item on cs.cs_item_sk == i.i_item_sk
   IterPrep     r182, r0
   Len          r183, r182
+  Const        r184, "cs_item_sk"
+  Const        r185, "i_item_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r186, "i_category"
+  Const        r187, "d_year"
+  Const        r188, "d_moy"
+  Const        r189, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
+  Const        r190, "manu"
+  Const        r191, "i_manufact_id"
+  Const        r192, "price"
+  Const        r193, "cs_ext_sales_price"
+  // join i in item on cs.cs_item_sk == i.i_item_sk
   Const        r194, 0
-L17:
+L20:
   LessInt      r196, r194, r183
-  JumpIfFalse  r196, L12
+  JumpIfFalse  r196, L15
   Index        r84, r182, r194
   Const        r198, "cs_item_sk"
   Index        r199, r139, r198
   Const        r200, "i_item_sk"
   Index        r201, r84, r200
   Equal        r202, r199, r201
-  JumpIfFalse  r202, L13
+  JumpIfFalse  r202, L16
   // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
   Const        r203, "i_category"
   Index        r204, r84, r203
@@ -178,19 +292,20 @@ L17:
   Equal        r212, r211, r6
   Const        r213, "ca_gmt_offset"
   Index        r214, r62, r213
+  Const        r215, 5
   Const        r216, -5
   Equal        r217, r214, r216
   Move         r218, r206
-  JumpIfFalse  r218, L14
-L14:
+  JumpIfFalse  r218, L17
+L17:
   Move         r219, r209
-  JumpIfFalse  r219, L15
-L15:
+  JumpIfFalse  r219, L18
+L18:
   Move         r220, r212
-  JumpIfFalse  r220, L16
+  JumpIfFalse  r220, L19
   Move         r220, r217
-L16:
-  JumpIfFalse  r220, L13
+L19:
+  JumpIfFalse  r220, L16
   // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
   Const        r221, "manu"
   Const        r222, "i_manufact_id"
@@ -205,80 +320,130 @@ L16:
   MakeMap      r231, 2, r227
   // from cs in catalog_sales
   Append       r124, r124, r231
-L13:
+L16:
   // join i in item on cs.cs_item_sk == i.i_item_sk
   Const        r233, 1
   Add          r194, r194, r233
-  Jump         L17
-L12:
+  Jump         L20
+L15:
   // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
   Const        r234, 1
   Add          r173, r173, r234
-  Jump         L18
-L11:
+  Jump         L21
+L14:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   Const        r235, 1
   Add          r152, r152, r235
-  Jump         L19
-L10:
+  Jump         L22
+L13:
   // from cs in catalog_sales
   Const        r236, 1
   AddInt       r135, r135, r236
-  Jump         L20
-L9:
+  Jump         L23
+L12:
   // let union_sales = concat(
   UnionAll     r237, r8, r124
   // from ws in web_sales
   Const        r238, []
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r239, "i_category"
+  Const        r240, "d_year"
+  Const        r241, "d_moy"
+  Const        r242, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r243, "manu"
+  Const        r244, "i_manufact_id"
+  Const        r245, "price"
+  Const        r246, "ws_ext_sales_price"
+  // from ws in web_sales
   IterPrep     r247, r5
   Len          r248, r247
   Const        r249, 0
-L32:
+L35:
   LessInt      r251, r249, r248
-  JumpIfFalse  r251, L21
+  JumpIfFalse  r251, L24
   Index        r253, r247, r249
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   IterPrep     r254, r1
   Len          r255, r254
+  Const        r256, "ws_sold_date_sk"
+  Const        r257, "d_date_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r258, "i_category"
+  Const        r259, "d_year"
+  Const        r260, "d_moy"
+  Const        r261, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r262, "manu"
+  Const        r263, "i_manufact_id"
+  Const        r264, "price"
+  Const        r265, "ws_ext_sales_price"
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   Const        r266, 0
-L31:
+L34:
   LessInt      r268, r266, r255
-  JumpIfFalse  r268, L22
+  JumpIfFalse  r268, L25
   Index        r40, r254, r266
   Const        r270, "ws_sold_date_sk"
   Index        r271, r253, r270
   Const        r272, "d_date_sk"
   Index        r273, r40, r272
   Equal        r274, r271, r273
-  JumpIfFalse  r274, L23
+  JumpIfFalse  r274, L26
   // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
   IterPrep     r275, r2
   Len          r276, r275
+  Const        r277, "ws_bill_addr_sk"
+  Const        r278, "ca_address_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r279, "i_category"
+  Const        r280, "d_year"
+  Const        r281, "d_moy"
+  Const        r282, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r283, "manu"
+  Const        r284, "i_manufact_id"
+  Const        r285, "price"
+  Const        r286, "ws_ext_sales_price"
+  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
   Const        r287, 0
-L30:
+L33:
   LessInt      r289, r287, r276
-  JumpIfFalse  r289, L23
+  JumpIfFalse  r289, L26
   Index        r62, r275, r287
   Const        r291, "ws_bill_addr_sk"
   Index        r292, r253, r291
   Const        r293, "ca_address_sk"
   Index        r294, r62, r293
   Equal        r295, r292, r294
-  JumpIfFalse  r295, L24
+  JumpIfFalse  r295, L27
   // join i in item on ws.ws_item_sk == i.i_item_sk
   IterPrep     r296, r0
   Len          r297, r296
+  Const        r298, "ws_item_sk"
+  Const        r299, "i_item_sk"
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Const        r300, "i_category"
+  Const        r301, "d_year"
+  Const        r302, "d_moy"
+  Const        r303, "ca_gmt_offset"
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r304, "manu"
+  Const        r305, "i_manufact_id"
+  Const        r306, "price"
+  Const        r307, "ws_ext_sales_price"
+  // join i in item on ws.ws_item_sk == i.i_item_sk
   Const        r308, 0
-L29:
+L32:
   LessInt      r310, r308, r297
-  JumpIfFalse  r310, L24
+  JumpIfFalse  r310, L27
   Index        r84, r296, r308
   Const        r312, "ws_item_sk"
   Index        r313, r253, r312
   Const        r314, "i_item_sk"
   Index        r315, r84, r314
   Equal        r316, r313, r315
-  JumpIfFalse  r316, L25
+  JumpIfFalse  r316, L28
   // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
   Const        r317, "i_category"
   Index        r318, r84, r317
@@ -292,19 +457,20 @@ L29:
   Equal        r326, r325, r6
   Const        r327, "ca_gmt_offset"
   Index        r328, r62, r327
+  Const        r329, 5
   Const        r330, -5
   Equal        r331, r328, r330
   Move         r332, r320
-  JumpIfFalse  r332, L26
-L26:
+  JumpIfFalse  r332, L29
+L29:
   Move         r333, r323
-  JumpIfFalse  r333, L27
-L27:
+  JumpIfFalse  r333, L30
+L30:
   Move         r334, r326
-  JumpIfFalse  r334, L28
+  JumpIfFalse  r334, L31
   Move         r334, r331
-L28:
-  JumpIfFalse  r334, L25
+L31:
+  JumpIfFalse  r334, L28
   // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
   Const        r335, "manu"
   Const        r336, "i_manufact_id"
@@ -319,39 +485,49 @@ L28:
   MakeMap      r345, 2, r341
   // from ws in web_sales
   Append       r238, r238, r345
-L25:
+L28:
   // join i in item on ws.ws_item_sk == i.i_item_sk
   Const        r347, 1
   Add          r308, r308, r347
-  Jump         L29
-L24:
+  Jump         L32
+L27:
   // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
   Const        r348, 1
   Add          r287, r287, r348
-  Jump         L30
-L23:
+  Jump         L33
+L26:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   Const        r349, 1
   Add          r266, r266, r349
-  Jump         L31
-L22:
+  Jump         L34
+L25:
   // from ws in web_sales
   Const        r350, 1
   AddInt       r249, r249, r350
-  Jump         L32
-L21:
+  Jump         L35
+L24:
   // let union_sales = concat(
   UnionAll     r351, r237, r238
   // from s in union_sales
   Const        r352, []
+  // group by s.manu into g
+  Const        r353, "manu"
+  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
+  Const        r354, "i_manufact_id"
+  Const        r355, "key"
+  Const        r356, "total_sales"
+  Const        r357, "price"
+  // sort by -sum(from x in g select x.price)
+  Const        r358, "price"
+  // from s in union_sales
   IterPrep     r359, r351
   Len          r360, r359
   Const        r361, 0
   MakeMap      r362, 0, r0
   Const        r363, []
-L35:
+L38:
   LessInt      r365, r361, r360
-  JumpIfFalse  r365, L33
+  JumpIfFalse  r365, L36
   Index        r366, r359, r361
   Move         r367, r366
   // group by s.manu into g
@@ -359,7 +535,7 @@ L35:
   Index        r369, r367, r368
   Str          r370, r369
   In           r371, r370, r362
-  JumpIfTrue   r371, L34
+  JumpIfTrue   r371, L37
   // from s in union_sales
   Const        r372, []
   Const        r373, "__group__"
@@ -383,7 +559,7 @@ L35:
   MakeMap      r389, 4, r381
   SetIndex     r362, r370, r389
   Append       r363, r363, r389
-L34:
+L37:
   Const        r391, "items"
   Index        r392, r362, r370
   Index        r393, r392, r391
@@ -396,13 +572,13 @@ L34:
   SetIndex     r392, r395, r398
   Const        r399, 1
   AddInt       r361, r361, r399
-  Jump         L35
-L33:
+  Jump         L38
+L36:
   Const        r400, 0
   Len          r402, r363
-L41:
+L44:
   LessInt      r403, r400, r402
-  JumpIfFalse  r403, L36
+  JumpIfFalse  r403, L39
   Index        r405, r363, r400
   // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
   Const        r406, "i_manufact_id"
@@ -410,20 +586,21 @@ L41:
   Index        r408, r405, r407
   Const        r409, "total_sales"
   Const        r410, []
+  Const        r411, "price"
   IterPrep     r412, r405
   Len          r413, r412
   Const        r414, 0
-L38:
+L41:
   LessInt      r416, r414, r413
-  JumpIfFalse  r416, L37
+  JumpIfFalse  r416, L40
   Index        r418, r412, r414
   Const        r419, "price"
   Index        r420, r418, r419
   Append       r410, r410, r420
   Const        r422, 1
   AddInt       r414, r414, r422
-  Jump         L38
-L37:
+  Jump         L41
+L40:
   Sum          r423, r410
   Move         r424, r406
   Move         r425, r408
@@ -432,20 +609,21 @@ L37:
   MakeMap      r428, 2, r424
   // sort by -sum(from x in g select x.price)
   Const        r429, []
+  Const        r430, "price"
   IterPrep     r431, r405
   Len          r432, r431
   Const        r433, 0
-L40:
+L43:
   LessInt      r435, r433, r432
-  JumpIfFalse  r435, L39
+  JumpIfFalse  r435, L42
   Index        r418, r431, r433
   Const        r437, "price"
   Index        r438, r418, r437
   Append       r429, r429, r438
   Const        r440, 1
   AddInt       r433, r433, r440
-  Jump         L40
-L39:
+  Jump         L43
+L42:
   Sum          r441, r429
   Neg          r443, r441
   // from s in union_sales
@@ -454,8 +632,8 @@ L39:
   Append       r352, r352, r445
   Const        r447, 1
   AddInt       r400, r400, r447
-  Jump         L41
-L36:
+  Jump         L44
+L39:
   // sort by -sum(from x in g select x.price)
   Sort         r352, r352
   // json(result)

--- a/tests/dataset/tpc-ds/out/q36.ir.out
+++ b/tests/dataset/tpc-ds/out/q36.ir.out
@@ -9,12 +9,39 @@ func main (regs=205)
   Const        r3, [{"d_date_sk": 1, "d_year": 2000}]
   // from ss in store_sales
   Const        r4, []
+  // group by {category: i.i_category, class: i.i_class} into g
+  Const        r5, "category"
+  Const        r6, "i_category"
+  Const        r7, "class"
+  Const        r8, "i_class"
+  // where d.d_year == 2000 && (s.s_state == "A" || s.s_state == "B")
+  Const        r9, "d_year"
+  Const        r10, "s_state"
+  Const        r11, "s_state"
+  // i_category: g.key.category,
+  Const        r12, "i_category"
+  Const        r13, "key"
+  Const        r14, "category"
+  // i_class: g.key.class,
+  Const        r15, "i_class"
+  Const        r16, "key"
+  Const        r17, "class"
+  // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
+  Const        r18, "gross_margin"
+  Const        r19, "ss_net_profit"
+  Const        r20, "ss_ext_sales_price"
+  // sort by [g.key.category, g.key.class]
+  Const        r21, "key"
+  Const        r22, "category"
+  Const        r23, "key"
+  Const        r24, "class"
+  // from ss in store_sales
   MakeMap      r25, 0, r0
   Const        r26, []
   IterPrep     r28, r0
   Len          r29, r28
   Const        r30, 0
-L1:
+L11:
   LessInt      r31, r30, r29
   JumpIfFalse  r31, L0
   Index        r33, r28, r30
@@ -22,7 +49,7 @@ L1:
   IterPrep     r34, r3
   Len          r35, r34
   Const        r36, 0
-L2:
+L10:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L1
   Index        r39, r34, r36
@@ -149,13 +176,22 @@ L3:
   Const        r131, 1
   AddInt       r47, r47, r131
   Jump         L9
-L0:
+L2:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r132, 1
+  AddInt       r36, r36, r132
+  Jump         L10
+L1:
   // from ss in store_sales
+  Const        r133, 1
+  AddInt       r30, r30, r133
+  Jump         L11
+L0:
   Const        r134, 0
   Len          r136, r26
-L15:
+L17:
   LessInt      r137, r134, r136
-  JumpIfFalse  r137, L10
+  JumpIfFalse  r137, L12
   Index        r139, r26, r134
   // i_category: g.key.category,
   Const        r140, "i_category"
@@ -172,36 +208,38 @@ L15:
   // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
   Const        r150, "gross_margin"
   Const        r151, []
+  Const        r152, "ss_net_profit"
   IterPrep     r153, r139
   Len          r154, r153
   Const        r155, 0
-L12:
+L14:
   LessInt      r157, r155, r154
-  JumpIfFalse  r157, L11
+  JumpIfFalse  r157, L13
   Index        r159, r153, r155
   Const        r160, "ss_net_profit"
   Index        r161, r159, r160
   Append       r151, r151, r161
   Const        r163, 1
   AddInt       r155, r155, r163
-  Jump         L12
-L11:
+  Jump         L14
+L13:
   Sum          r164, r151
   Const        r165, []
+  Const        r166, "ss_ext_sales_price"
   IterPrep     r167, r139
   Len          r168, r167
   Const        r169, 0
-L14:
+L16:
   LessInt      r171, r169, r168
-  JumpIfFalse  r171, L13
+  JumpIfFalse  r171, L15
   Index        r159, r167, r169
   Const        r173, "ss_ext_sales_price"
   Index        r174, r159, r173
   Append       r165, r165, r174
   Const        r176, 1
   AddInt       r169, r169, r176
-  Jump         L14
-L13:
+  Jump         L16
+L15:
   Sum          r177, r165
   Div          r178, r164, r177
   // i_category: g.key.category,
@@ -221,6 +259,9 @@ L13:
   Const        r188, "category"
   Index        r190, r187, r188
   Const        r191, "key"
+  Index        r192, r139, r191
+  Const        r193, "class"
+  Index        r195, r192, r193
   MakeList     r197, 2, r190
   // from ss in store_sales
   Move         r198, r185
@@ -228,8 +269,8 @@ L13:
   Append       r4, r4, r199
   Const        r201, 1
   AddInt       r134, r134, r201
-  Jump         L15
-L10:
+  Jump         L17
+L12:
   // sort by [g.key.category, g.key.class]
   Sort         r4, r4
   // json(result)

--- a/tests/dataset/tpc-ds/out/q37.ir.out
+++ b/tests/dataset/tpc-ds/out/q37.ir.out
@@ -9,12 +9,40 @@ func main (regs=197)
   Const        r3, [{"cs_item_sk": 1, "cs_sold_date_sk": 1}]
   // from i in item
   Const        r4, []
+  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
+  Const        r5, "id"
+  Const        r6, "i_item_id"
+  Const        r7, "desc"
+  Const        r8, "i_item_desc"
+  Const        r9, "price"
+  Const        r10, "i_current_price"
+  // where i.i_current_price >= 20 && i.i_current_price <= 50 && i.i_manufact_id >= 800 && i.i_manufact_id <= 803 && inv.inv_quantity_on_hand >= 100 && inv.inv_quantity_on_hand <= 500
+  Const        r11, "i_current_price"
+  Const        r12, "i_current_price"
+  Const        r13, "i_manufact_id"
+  Const        r14, "i_manufact_id"
+  Const        r15, "inv_quantity_on_hand"
+  Const        r16, "inv_quantity_on_hand"
+  // select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
+  Const        r17, "i_item_id"
+  Const        r18, "key"
+  Const        r19, "id"
+  Const        r20, "i_item_desc"
+  Const        r21, "key"
+  Const        r22, "desc"
+  Const        r23, "i_current_price"
+  Const        r24, "key"
+  Const        r25, "price"
+  // sort by g.key.id
+  Const        r26, "key"
+  Const        r27, "id"
+  // from i in item
   MakeMap      r28, 0, r0
   Const        r29, []
   IterPrep     r31, r0
   Len          r32, r31
   Const        r33, 0
-L1:
+L14:
   LessInt      r34, r33, r32
   JumpIfFalse  r34, L0
   Index        r36, r31, r33
@@ -22,7 +50,7 @@ L1:
   IterPrep     r37, r1
   Len          r38, r37
   Const        r39, 0
-L2:
+L13:
   LessInt      r40, r39, r38
   JumpIfFalse  r40, L1
   Index        r42, r37, r39
@@ -176,13 +204,22 @@ L3:
   Const        r154, 1
   AddInt       r50, r50, r154
   Jump         L12
-L0:
+L2:
+  // join inv in inventory on i.i_item_sk == inv.inv_item_sk
+  Const        r155, 1
+  AddInt       r39, r39, r155
+  Jump         L13
+L1:
   // from i in item
+  Const        r156, 1
+  AddInt       r33, r33, r156
+  Jump         L14
+L0:
   Const        r157, 0
   Len          r159, r29
-L14:
+L16:
   LessInt      r160, r157, r159
-  JumpIfFalse  r160, L13
+  JumpIfFalse  r160, L15
   Index        r162, r29, r157
   // select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
   Const        r163, "i_item_id"
@@ -218,8 +255,8 @@ L14:
   Append       r4, r4, r191
   Const        r193, 1
   AddInt       r157, r157, r193
-  Jump         L14
-L13:
+  Jump         L16
+L15:
   // sort by g.key.id
   Sort         r4, r4
   // json(result)

--- a/tests/dataset/tpc-ds/out/q38.ir.out
+++ b/tests/dataset/tpc-ds/out/q38.ir.out
@@ -9,10 +9,13 @@ func main (regs=87)
   Const        r3, [{"d_month_seq": 1206, "ws_bill_customer_sk": 1}]
   // let store_ids = distinct(from s in store_sales where s.d_month_seq >= 1200 && s.d_month_seq <= 1211 select s.ss_customer_sk)
   Const        r5, []
+  Const        r6, "d_month_seq"
+  Const        r7, "d_month_seq"
+  Const        r8, "ss_customer_sk"
   IterPrep     r9, r1
   Len          r10, r9
   Const        r11, 0
-L2:
+L3:
   LessInt      r13, r11, r10
   JumpIfFalse  r13, L0
   Index        r15, r9, r11
@@ -32,18 +35,24 @@ L1:
   Const        r25, "ss_customer_sk"
   Index        r26, r15, r25
   Append       r5, r5, r26
-  Jump         L2
+L2:
+  Const        r28, 1
+  AddInt       r11, r11, r28
+  Jump         L3
 L0:
   Move         r4, r5
   Call         r29, distinct, r4
   // let catalog_ids = distinct(from c in catalog_sales where c.d_month_seq >= 1200 && c.d_month_seq <= 1211 select c.cs_bill_customer_sk)
   Const        r31, []
+  Const        r32, "d_month_seq"
+  Const        r33, "d_month_seq"
+  Const        r34, "cs_bill_customer_sk"
   IterPrep     r35, r2
   Len          r36, r35
   Const        r37, 0
-L6:
+L7:
   LessInt      r39, r37, r36
-  JumpIfFalse  r39, L3
+  JumpIfFalse  r39, L4
   Index        r41, r35, r37
   Const        r42, "d_month_seq"
   Index        r43, r41, r42
@@ -54,28 +63,31 @@ L6:
   Const        r48, 1211
   LessEq       r49, r47, r48
   Move         r50, r45
-  JumpIfFalse  r50, L4
-  Move         r50, r49
-L4:
   JumpIfFalse  r50, L5
+  Move         r50, r49
+L5:
+  JumpIfFalse  r50, L6
   Const        r51, "cs_bill_customer_sk"
   Index        r52, r41, r51
   Append       r31, r31, r52
-L5:
+L6:
   Const        r54, 1
   AddInt       r37, r37, r54
-  Jump         L6
-L3:
+  Jump         L7
+L4:
   Move         r30, r31
   Call         r55, distinct, r30
   // let web_ids = distinct(from w in web_sales where w.d_month_seq >= 1200 && w.d_month_seq <= 1211 select w.ws_bill_customer_sk)
   Const        r57, []
+  Const        r58, "d_month_seq"
+  Const        r59, "d_month_seq"
+  Const        r60, "ws_bill_customer_sk"
   IterPrep     r61, r3
   Len          r62, r61
   Const        r63, 0
-L10:
+L11:
   LessInt      r65, r63, r62
-  JumpIfFalse  r65, L7
+  JumpIfFalse  r65, L8
   Index        r67, r61, r63
   Const        r68, "d_month_seq"
   Index        r69, r67, r68
@@ -86,18 +98,18 @@ L10:
   Const        r74, 1211
   LessEq       r75, r73, r74
   Move         r76, r71
-  JumpIfFalse  r76, L8
-  Move         r76, r75
-L8:
   JumpIfFalse  r76, L9
+  Move         r76, r75
+L9:
+  JumpIfFalse  r76, L10
   Const        r77, "ws_bill_customer_sk"
   Index        r78, r67, r77
   Append       r57, r57, r78
-L9:
+L10:
   Const        r80, 1
   AddInt       r63, r63, r80
-  Jump         L10
-L7:
+  Jump         L11
+L8:
   Move         r56, r57
   Call         r81, distinct, r56
   // let hot = store_ids intersect catalog_ids intersect web_ids

--- a/tests/dataset/tpc-ds/out/q39.ir.out
+++ b/tests/dataset/tpc-ds/out/q39.ir.out
@@ -9,12 +9,31 @@ func main (regs=280)
   Const        r3, [{"d_date_sk": 1, "d_moy": 1, "d_year": 2000}, {"d_date_sk": 2, "d_moy": 2, "d_year": 2000}, {"d_date_sk": 3, "d_moy": 3, "d_year": 2000}]
   // from inv in inventory
   Const        r4, []
+  // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
+  Const        r5, "w"
+  Const        r6, "w_warehouse_sk"
+  Const        r7, "i"
+  Const        r8, "i_item_sk"
+  Const        r9, "month"
+  Const        r10, "d_moy"
+  // where d.d_year == 2000
+  Const        r11, "d_year"
+  // select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
+  Const        r12, "w"
+  Const        r13, "key"
+  Const        r14, "w"
+  Const        r15, "i"
+  Const        r16, "key"
+  Const        r17, "i"
+  Const        r18, "qty"
+  Const        r19, "inv_quantity_on_hand"
+  // from inv in inventory
   MakeMap      r20, 0, r0
   Const        r21, []
   IterPrep     r23, r0
   Len          r24, r23
   Const        r25, 0
-L1:
+L9:
   LessInt      r26, r25, r24
   JumpIfFalse  r26, L0
   Index        r28, r23, r25
@@ -22,7 +41,7 @@ L1:
   IterPrep     r29, r3
   Len          r30, r29
   Const        r31, 0
-L2:
+L8:
   LessInt      r32, r31, r30
   JumpIfFalse  r32, L1
   Index        r34, r29, r31
@@ -140,13 +159,22 @@ L3:
   Const        r121, 1
   AddInt       r42, r42, r121
   Jump         L7
-L0:
+L2:
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  Const        r122, 1
+  AddInt       r31, r31, r122
+  Jump         L8
+L1:
   // from inv in inventory
+  Const        r123, 1
+  AddInt       r25, r25, r123
+  Jump         L9
+L0:
   Const        r124, 0
   Len          r126, r21
-L11:
+L13:
   LessInt      r127, r124, r126
-  JumpIfFalse  r127, L8
+  JumpIfFalse  r127, L10
   Index        r129, r21, r124
   // select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
   Const        r130, "w"
@@ -161,20 +189,21 @@ L11:
   Index        r139, r137, r138
   Const        r140, "qty"
   Const        r141, []
+  Const        r142, "inv_quantity_on_hand"
   IterPrep     r143, r129
   Len          r144, r143
   Const        r145, 0
-L10:
+L12:
   LessInt      r147, r145, r144
-  JumpIfFalse  r147, L9
+  JumpIfFalse  r147, L11
   Index        r149, r143, r145
   Const        r150, "inv_quantity_on_hand"
   Index        r151, r149, r150
   Append       r141, r141, r151
   Const        r153, 1
   AddInt       r145, r145, r153
-  Jump         L10
-L9:
+  Jump         L12
+L11:
   Sum          r154, r141
   Move         r155, r130
   Move         r156, r134
@@ -185,17 +214,19 @@ L9:
   MakeMap      r161, 3, r155
   // from inv in inventory
   Append       r4, r4, r161
-  Jump         L11
-L8:
+  Const        r163, 1
+  AddInt       r124, r124, r163
+  Jump         L13
+L10:
   // var grouped: map<string, map<string, any>> = {}
-  Const        r165, {}
+  Const        r165, {"map[i:1 w:1]": {"i": 1, "qtys": [0, 0, 0], "w": 1}}
   // for m in monthly {
   IterPrep     r166, r4
   Len          r167, r166
   Const        r168, 0
-L15:
+L17:
   Less         r169, r168, r167
-  JumpIfFalse  r169, L12
+  JumpIfFalse  r169, L14
   Index        r171, r166, r168
   // let key = str({w: m.w, i: m.i})
   Const        r172, "w"
@@ -212,7 +243,7 @@ L15:
   Str          r183, r182
   // if key in grouped {
   In           r184, r183, r165
-  JumpIfFalse  r184, L13
+  JumpIfFalse  r184, L15
   // let g = grouped[key]
   Index        r185, r165, r183
   // grouped[key] = {w: g.w, i: g.i, qtys: append(g.qtys, m.qty)}
@@ -237,8 +268,8 @@ L15:
   MakeMap      r204, 3, r198
   SetIndex     r165, r183, r204
   // if key in grouped {
-  Jump         L14
-L13:
+  Jump         L16
+L15:
   // grouped[key] = {w: m.w, i: m.i, qtys: [m.qty]}
   Const        r205, "w"
   Const        r206, "w"
@@ -258,12 +289,12 @@ L13:
   Move         r221, r215
   MakeMap      r222, 3, r216
   SetIndex     r165, r183, r222
-L14:
+L16:
   // for m in monthly {
   Const        r223, 1
   Add          r168, r168, r223
-  Jump         L15
-L12:
+  Jump         L17
+L14:
   // var summary = []
   Const        r226, []
   // for g in values(grouped) {
@@ -271,9 +302,9 @@ L12:
   IterPrep     r228, r227
   Len          r229, r228
   Const        r230, 0
-L20:
+L22:
   Less         r231, r230, r229
-  JumpIfFalse  r231, L16
+  JumpIfFalse  r231, L18
   Index        r129, r228, r230
   // let mean = avg(g.qtys)
   Const        r233, "qtys"
@@ -287,9 +318,9 @@ L20:
   IterPrep     r240, r239
   Len          r241, r240
   Const        r242, 0
-L18:
+L20:
   Less         r243, r242, r241
-  JumpIfFalse  r243, L17
+  JumpIfFalse  r243, L19
   Index        r245, r240, r242
   // sumsq = sumsq + (q - mean) * (q - mean)
   SubFloat     r246, r245, r235
@@ -299,8 +330,8 @@ L18:
   // for q in g.qtys {
   Const        r250, 1
   Add          r242, r242, r250
-  Jump         L18
-L17:
+  Jump         L20
+L19:
   // let variance = sumsq / len(g.qtys)
   Const        r252, "qtys"
   Index        r253, r129, r252
@@ -312,13 +343,29 @@ L17:
   // if cov > 1.5 {
   Const        r259, 1.5
   LessFloat    r260, r259, r258
-  JumpIfFalse  r260, L19
-L19:
+  JumpIfFalse  r260, L21
+  // summary = append(summary, {w_warehouse_sk: g.w, i_item_sk: g.i, cov: cov})
+  Const        r261, "w_warehouse_sk"
+  Const        r262, "w"
+  Index        r263, r129, r262
+  Const        r264, "i_item_sk"
+  Const        r265, "i"
+  Index        r266, r129, r265
+  Const        r267, "cov"
+  Move         r268, r261
+  Move         r269, r263
+  Move         r270, r264
+  Move         r271, r266
+  Move         r272, r267
+  Move         r273, r258
+  MakeMap      r274, 3, r268
+  Append       r226, r226, r274
+L21:
   // for g in values(grouped) {
   Const        r276, 1
   Add          r230, r230, r276
-  Jump         L20
-L16:
+  Jump         L22
+L18:
   // json(summary)
   JSON         r226
   // expect summary == [{w_warehouse_sk: 1, i_item_sk: 1, cov: 1.5396007178390022}]


### PR DESCRIPTION
## Summary
- remove duplicate `OpFirst` handling to fix vm build
- refresh IR outputs for tpc-ds queries q30–q39

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862313766cc832086f596c6dd9da3b3