### PR TITLE
Enhance TPC‑DC samples q30‑q39

### DIFF
--- a/tests/dataset/tpc-dc/q30.md
+++ b/tests/dataset/tpc-dc/q30.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 30 – High-Return Customers
 
-This query identifies customers from a given state whose total web returns in a particular year exceed 120% of the average return amount for that state. The example below fixes the year to 2000 and the state to `CA`.
+This query identifies customers from a given state whose total web returns in a particular year exceed 120% of the average return amount for that state. The example below fixes the year to 2000 and the state to `CA`. The accompanying dataset includes a few additional rows from other years and states to better emulate realistic data volumes.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q30.mochi
+++ b/tests/dataset/tpc-dc/q30.mochi
@@ -8,25 +8,31 @@ let web_returns = [
   {wr_returning_customer_sk: 4, wr_returned_date_sk: 1, wr_return_amt: 30.0,  wr_returning_addr_sk: 4},
   {wr_returning_customer_sk: 1, wr_returned_date_sk: 1, wr_return_amt: 20.0,  wr_returning_addr_sk: 1},
   {wr_returning_customer_sk: 2, wr_returned_date_sk: 1, wr_return_amt: 40.0,  wr_returning_addr_sk: 2},
-  {wr_returning_customer_sk: 4, wr_returned_date_sk: 1, wr_return_amt: 10.0,  wr_returning_addr_sk: 4}
+  {wr_returning_customer_sk: 4, wr_returned_date_sk: 1, wr_return_amt: 10.0,  wr_returning_addr_sk: 4},
+  # additional rows outside filtered state/year
+  {wr_returning_customer_sk: 5, wr_returned_date_sk: 2, wr_return_amt: 70.0,  wr_returning_addr_sk: 5},
+  {wr_returning_customer_sk: 3, wr_returned_date_sk: 2, wr_return_amt: 25.0,  wr_returning_addr_sk: 3}
 ]
 
 let date_dim = [
-  {d_date_sk: 1, d_year: 2000}
+  {d_date_sk: 1, d_year: 2000},
+  {d_date_sk: 2, d_year: 2001}
 ]
 
 let customer_address = [
   {ca_address_sk: 1, ca_state: "CA"},
   {ca_address_sk: 2, ca_state: "CA"},
   {ca_address_sk: 3, ca_state: "NY"},
-  {ca_address_sk: 4, ca_state: "CA"}
+  {ca_address_sk: 4, ca_state: "CA"},
+  {ca_address_sk: 5, ca_state: "TX"}
 ]
 
 let customer = [
   {c_customer_sk: 1, c_customer_id: "C1", c_first_name: "John",  c_last_name: "Doe",   c_current_addr_sk: 1},
   {c_customer_sk: 2, c_customer_id: "C2", c_first_name: "Jane",  c_last_name: "Smith", c_current_addr_sk: 2},
   {c_customer_sk: 3, c_customer_id: "C3", c_first_name: "Bob",   c_last_name: "Brown", c_current_addr_sk: 3},
-  {c_customer_sk: 4, c_customer_id: "C4", c_first_name: "Mary",  c_last_name: "Jones", c_current_addr_sk: 4}
+  {c_customer_sk: 4, c_customer_id: "C4", c_first_name: "Mary",  c_last_name: "Jones", c_current_addr_sk: 4},
+  {c_customer_sk: 5, c_customer_id: "C5", c_first_name: "Mike",  c_last_name: "Stone", c_current_addr_sk: 5}
 ]
 
 let customer_total_return =

--- a/tests/dataset/tpc-dc/q31.md
+++ b/tests/dataset/tpc-dc/q31.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 31 – Channel Growth Comparison
 
-This query compares quarter-over-quarter sales growth between the store and web channels for each county in a given year. The parameters here fix the year to 2000.
+This query compares quarter-over-quarter sales growth between the store and web channels for each county in a given year. The parameters here fix the year to 2000. Additional rows for an unused county are present in the dataset to keep the example realistic while not affecting the result set.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q31.mochi
+++ b/tests/dataset/tpc-dc/q31.mochi
@@ -10,7 +10,11 @@ let store_sales = [
   {ca_county: "C", d_qoy: 3, d_year: 2000, ss_ext_sales_price: 60.0},
   {ca_county: "D", d_qoy: 1, d_year: 2000, ss_ext_sales_price: 90.0},
   {ca_county: "D", d_qoy: 2, d_year: 2000, ss_ext_sales_price: 80.0},
-  {ca_county: "D", d_qoy: 3, d_year: 2000, ss_ext_sales_price: 100.0}
+  {ca_county: "D", d_qoy: 3, d_year: 2000, ss_ext_sales_price: 100.0},
+  # additional data not part of counties list
+  {ca_county: "E", d_qoy: 1, d_year: 2000, ss_ext_sales_price: 70.0},
+  {ca_county: "E", d_qoy: 2, d_year: 2000, ss_ext_sales_price: 75.0},
+  {ca_county: "E", d_qoy: 3, d_year: 2000, ss_ext_sales_price: 80.0}
 ]
 
 let web_sales = [
@@ -25,7 +29,11 @@ let web_sales = [
   {ca_county: "C", d_qoy: 3, d_year: 2000, ws_ext_sales_price: 65.0},
   {ca_county: "D", d_qoy: 1, d_year: 2000, ws_ext_sales_price: 85.0},
   {ca_county: "D", d_qoy: 2, d_year: 2000, ws_ext_sales_price: 90.0},
-  {ca_county: "D", d_qoy: 3, d_year: 2000, ws_ext_sales_price: 92.0}
+  {ca_county: "D", d_qoy: 3, d_year: 2000, ws_ext_sales_price: 92.0},
+  # extra web sales for county outside list
+  {ca_county: "E", d_qoy: 1, d_year: 2000, ws_ext_sales_price: 60.0},
+  {ca_county: "E", d_qoy: 2, d_year: 2000, ws_ext_sales_price: 62.0},
+  {ca_county: "E", d_qoy: 3, d_year: 2000, ws_ext_sales_price: 64.0}
 ]
 
 let counties = ["A", "B", "C", "D"]

--- a/tests/dataset/tpc-dc/q32.md
+++ b/tests/dataset/tpc-dc/q32.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 32 – Excess Catalog Discounts
 
-This query calculates the total discount for catalog sales of a specific manufacturer that exceeds 130% of the average discount over a 90‑day window. The sample query fixes the manufacturer ID to 1 and the date window to the first quarter of 2000.
+This query calculates the total discount for catalog sales of a specific manufacturer that exceeds 130% of the average discount over a 90‑day window. The sample query fixes the manufacturer ID to 1 and the date window to the first quarter of 2000. Some extra rows from other manufacturers and years are included to mimic a larger sales table.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q32.mochi
+++ b/tests/dataset/tpc-dc/q32.mochi
@@ -5,11 +5,14 @@ let catalog_sales = [
   {cs_item_sk: 1, cs_sold_date_sk: 4, cs_ext_discount_amt: 8.0},
   {cs_item_sk: 2, cs_sold_date_sk: 1, cs_ext_discount_amt: 15.0},
   {cs_item_sk: 1, cs_sold_date_sk: 5, cs_ext_discount_amt: 18.0}
+  ,{cs_item_sk: 2, cs_sold_date_sk: 6, cs_ext_discount_amt: 12.0}
+  ,{cs_item_sk: 1, cs_sold_date_sk: 7, cs_ext_discount_amt: 7.0}
 ]
 
 let item = [
   {i_item_sk: 1, i_manufact_id: 1},
-  {i_item_sk: 2, i_manufact_id: 2}
+  {i_item_sk: 2, i_manufact_id: 2},
+  {i_item_sk: 3, i_manufact_id: 3}
 ]
 
 let date_dim = [
@@ -17,7 +20,9 @@ let date_dim = [
   {d_date_sk: 2, d_year: 2000, d_date: 30},
   {d_date_sk: 3, d_year: 2000, d_date: 60},
   {d_date_sk: 4, d_year: 2001, d_date: 1},
-  {d_date_sk: 5, d_year: 2000, d_date: 120}
+  {d_date_sk: 5, d_year: 2000, d_date: 120},
+  {d_date_sk: 6, d_year: 2001, d_date: 200},
+  {d_date_sk: 7, d_year: 1999, d_date: 300}
 ]
 
 let filtered =

--- a/tests/dataset/tpc-dc/q33.md
+++ b/tests/dataset/tpc-dc/q33.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 33 – Sales by Manufacturer
 
-This query sums sales across store, catalog and web channels for items in a given category, month and year at a specific time zone offset. Manufacturers are ranked by total sales.
+This query sums sales across store, catalog and web channels for items in a given category, month and year at a specific time zone offset. Manufacturers are ranked by total sales. The dataset also contains a few extra sales from another month that are ignored by the filter.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q33.mochi
+++ b/tests/dataset/tpc-dc/q33.mochi
@@ -19,17 +19,20 @@ let store_sales = [
   {ss_item_sk: 2, ss_ext_sales_price: 50.0, ss_sold_date_sk: 1, ss_addr_sk: 2},
   {ss_item_sk: 3, ss_ext_sales_price: 60.0, ss_sold_date_sk: 1, ss_addr_sk: 1},
   {ss_item_sk: 4, ss_ext_sales_price: 50.0, ss_sold_date_sk: 1, ss_addr_sk: 1}
+  ,{ss_item_sk: 2, ss_ext_sales_price: 80.0, ss_sold_date_sk: 2, ss_addr_sk: 2}
 ]
 
 let catalog_sales = [
   {cs_item_sk: 1, cs_ext_sales_price: 20.0, cs_sold_date_sk: 1, cs_bill_addr_sk: 1},
   {cs_item_sk: 4, cs_ext_sales_price: 20.0, cs_sold_date_sk: 1, cs_bill_addr_sk: 1}
+  ,{cs_item_sk: 3, cs_ext_sales_price: 15.0, cs_sold_date_sk: 2, cs_bill_addr_sk: 2}
 ]
 
 let web_sales = [
   {ws_item_sk: 1, ws_ext_sales_price: 30.0, ws_sold_date_sk: 1, ws_bill_addr_sk: 1},
   {ws_item_sk: 3, ws_ext_sales_price: 15.0, ws_sold_date_sk: 1, ws_bill_addr_sk: 1},
-  {ws_item_sk: 4, ws_ext_sales_price: 5.0, ws_sold_date_sk: 1, ws_bill_addr_sk: 1}
+  {ws_item_sk: 4, ws_ext_sales_price: 5.0, ws_sold_date_sk: 1, ws_bill_addr_sk: 1},
+  {ws_item_sk: 2, ws_ext_sales_price: 25.0, ws_sold_date_sk: 2, ws_bill_addr_sk: 2}
 ]
 
 let month = 1

--- a/tests/dataset/tpc-dc/q34.md
+++ b/tests/dataset/tpc-dc/q34.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 34 – Frequent Buyer Listing
 
-This query finds customers who repeatedly shop at stores within a set of counties and whose household demographics meet certain criteria. It targets tickets with between 15 and 20 items.
+This query finds customers who repeatedly shop at stores within a set of counties and whose household demographics meet certain criteria. It targets tickets with between 15 and 20 items. The example dataset contains a handful of extra purchases that fall outside the time window used in the filter.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q34.mochi
+++ b/tests/dataset/tpc-dc/q34.mochi
@@ -30,11 +30,14 @@ let store_sales = [
   {ss_ticket_number: 4, ss_customer_sk: 2, ss_sold_date_sk: 1, ss_store_sk: 1, ss_hdemo_sk: 2},
   {ss_ticket_number: 4, ss_customer_sk: 2, ss_sold_date_sk: 1, ss_store_sk: 1, ss_hdemo_sk: 2},
   {ss_ticket_number: 4, ss_customer_sk: 2, ss_sold_date_sk: 1, ss_store_sk: 1, ss_hdemo_sk: 2}
+  ,{ss_ticket_number: 5, ss_customer_sk: 3, ss_sold_date_sk: 2, ss_store_sk: 2, ss_hdemo_sk: 3}
+  ,{ss_ticket_number: 6, ss_customer_sk: 2, ss_sold_date_sk: 3, ss_store_sk: 1, ss_hdemo_sk: 2}
 ]
 
 let date_dim = [
   {d_date_sk: 1, d_dom: 2, d_year: 2000},
-  {d_date_sk: 2, d_dom: 5, d_year: 2000}
+  {d_date_sk: 2, d_dom: 5, d_year: 2000},
+  {d_date_sk: 3, d_dom: 10, d_year: 2001}
 ]
 
 let store = [

--- a/tests/dataset/tpc-dc/q35.md
+++ b/tests/dataset/tpc-dc/q35.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 35 – Demographics Rollup Statistics
 
-This query computes aggregate statistics about dependents per household for customers that made purchases in the first three quarters of a year. Results are grouped by state and demographic attributes.
+This query computes aggregate statistics about dependents per household for customers that made purchases in the first three quarters of a year. Results are grouped by state and demographic attributes. Extra demographic and address rows are present in the data but filtered out by the query conditions.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q35.mochi
+++ b/tests/dataset/tpc-dc/q35.mochi
@@ -3,28 +3,33 @@ let customer = [
   {c_customer_sk: 2, c_current_addr_sk: 2, c_current_cdemo_sk: 2},
   {c_customer_sk: 3, c_current_addr_sk: 3, c_current_cdemo_sk: 1},
   {c_customer_sk: 4, c_current_addr_sk: 1, c_current_cdemo_sk: 1}
+  ,{c_customer_sk: 5, c_current_addr_sk: 4, c_current_cdemo_sk: 3}
 ]
 
 let customer_address = [
   {ca_address_sk: 1, ca_state: "CA"},
   {ca_address_sk: 2, ca_state: "NY"},
-  {ca_address_sk: 3, ca_state: "TX"}
+  {ca_address_sk: 3, ca_state: "TX"},
+  {ca_address_sk: 4, ca_state: "FL"}
 ]
 
 let customer_demographics = [
   {cd_demo_sk: 1, cd_gender: "M", cd_marital_status: "S", cd_dep_count: 1, cd_dep_employed_count: 1, cd_dep_college_count: 0},
   {cd_demo_sk: 2, cd_gender: "F", cd_marital_status: "M", cd_dep_count: 2, cd_dep_employed_count: 1, cd_dep_college_count: 1}
+  ,{cd_demo_sk: 3, cd_gender: "F", cd_marital_status: "S", cd_dep_count: 0, cd_dep_employed_count: 0, cd_dep_college_count: 0}
 ]
 
 let store_sales = [
   {ss_customer_sk: 1, ss_sold_date_sk: 1},
   {ss_customer_sk: 2, ss_sold_date_sk: 2},
   {ss_customer_sk: 4, ss_sold_date_sk: 1}
+  ,{ss_customer_sk: 5, ss_sold_date_sk: 3}
 ]
 
 let date_dim = [
   {d_date_sk: 1, d_year: 2000, d_qoy: 1},
-  {d_date_sk: 2, d_year: 2000, d_qoy: 4}
+  {d_date_sk: 2, d_year: 2000, d_qoy: 4},
+  {d_date_sk: 3, d_year: 2001, d_qoy: 1}
 ]
 
 let purchased =

--- a/tests/dataset/tpc-dc/q36.md
+++ b/tests/dataset/tpc-dc/q36.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 36 – Gross Margin Hierarchy
 
-Query 36 ranks item categories and classes by gross margin across several states for a chosen year.
+Query 36 ranks item categories and classes by gross margin across several states for a chosen year. The test data includes an extra store and date from a different year so the filter excludes them.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q36.mochi
+++ b/tests/dataset/tpc-dc/q36.mochi
@@ -3,7 +3,8 @@ let store_sales = [
   {ss_item_sk: 2, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 200.0, ss_net_profit: 50.0},
   {ss_item_sk: 3, ss_store_sk: 2, ss_sold_date_sk: 1, ss_ext_sales_price: 150.0, ss_net_profit: 30.0},
   {ss_item_sk: 1, ss_store_sk: 1, ss_sold_date_sk: 1, ss_ext_sales_price: 50.0, ss_net_profit: 10.0},
-  {ss_item_sk: 4, ss_store_sk: 2, ss_sold_date_sk: 1, ss_ext_sales_price: 100.0, ss_net_profit: 25.0}
+  {ss_item_sk: 4, ss_store_sk: 2, ss_sold_date_sk: 1, ss_ext_sales_price: 100.0, ss_net_profit: 25.0},
+  {ss_item_sk: 2, ss_store_sk: 3, ss_sold_date_sk: 2, ss_ext_sales_price: 80.0, ss_net_profit: 20.0}
 ]
 
 let item = [
@@ -20,7 +21,8 @@ let store = [
 ]
 
 let date_dim = [
-  {d_date_sk: 1, d_year: 2000}
+  {d_date_sk: 1, d_year: 2000},
+  {d_date_sk: 2, d_year: 2001}
 ]
 
 let result =

--- a/tests/dataset/tpc-dc/q37.md
+++ b/tests/dataset/tpc-dc/q37.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 37 – Inventory for Promotional Items
 
-This query lists items from specified manufacturers that have inventory on hand within a price range and were sold through the catalog within a 60‑day interval.
+This query lists items from specified manufacturers that have inventory on hand within a price range and were sold through the catalog within a 60‑day interval. A few additional items and dates outside the range are included in the dataset for realism.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q37.mochi
+++ b/tests/dataset/tpc-dc/q37.mochi
@@ -2,6 +2,7 @@ let item = [
   {i_item_sk: 1, i_item_id: "I1", i_item_desc: "Item1", i_current_price: 30.0, i_manufact_id: 800},
   {i_item_sk: 2, i_item_id: "I2", i_item_desc: "Item2", i_current_price: 60.0, i_manufact_id: 801},
   {i_item_sk: 3, i_item_id: "I3", i_item_desc: "Item3", i_current_price: 45.0, i_manufact_id: 802}
+  ,{i_item_sk: 4, i_item_id: "I4", i_item_desc: "Item4", i_current_price: 55.0, i_manufact_id: 804}
 ]
 
 let inventory = [
@@ -9,16 +10,19 @@ let inventory = [
   {inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 300},
   {inv_item_sk: 3, inv_warehouse_sk: 1, inv_date_sk: 1, inv_quantity_on_hand: 150},
   {inv_item_sk: 1, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 250}
+  ,{inv_item_sk: 4, inv_warehouse_sk: 2, inv_date_sk: 1, inv_quantity_on_hand: 100}
 ]
 
 let date_dim = [
   {d_date_sk: 1, d_date: "2000-01-15"},
   {d_date_sk: 2, d_date: "2000-02-15"}
+  ,{d_date_sk: 3, d_date: "1999-12-15"}
 ]
 
 let catalog_sales = [
   {cs_item_sk: 1, cs_sold_date_sk: 1},
   {cs_item_sk: 2, cs_sold_date_sk: 1}
+  ,{cs_item_sk: 4, cs_sold_date_sk: 3}
 ]
 
 let result =

--- a/tests/dataset/tpc-dc/q38.md
+++ b/tests/dataset/tpc-dc/q38.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 38 – Cross-Channel Best Customers
 
-Query 38 counts customers who made purchases in the store, catalog, and web channels within the same twelve‑month period.
+Query 38 counts customers who made purchases in the store, catalog, and web channels within the same twelve‑month period. A few extra transactions falling outside the reporting window are present but ignored.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q38.mochi
+++ b/tests/dataset/tpc-dc/q38.mochi
@@ -9,16 +9,19 @@ let store_sales = [
   {ss_customer_sk: 2, d_month_seq: 1205},
   {ss_customer_sk: 3, d_month_seq: 1190},
   {ss_customer_sk: 2, d_month_seq: 1201}
+  ,{ss_customer_sk: 4, d_month_seq: 1180}
 ]
 
 let catalog_sales = [
   {cs_bill_customer_sk: 1, d_month_seq: 1203}
   ,{cs_bill_customer_sk: 2, d_month_seq: 1202}
+  ,{cs_bill_customer_sk: 3, d_month_seq: 1220}
 ]
 
 let web_sales = [
   {ws_bill_customer_sk: 1, d_month_seq: 1206}
   ,{ws_bill_customer_sk: 2, d_month_seq: 1215}
+  ,{ws_bill_customer_sk: 3, d_month_seq: 1195}
 ]
 
 let store_ids = from s in store_sales where s.d_month_seq >= 1200 && s.d_month_seq <= 1211 select s.ss_customer_sk |> to_list |> distinct

--- a/tests/dataset/tpc-dc/q39.md
+++ b/tests/dataset/tpc-dc/q39.md
@@ -1,6 +1,6 @@
 # TPC-DC Query 39 – Inventory Variation
 
-Query 39 finds items with large month‑to‑month variation in inventory by computing the coefficient of variation for each warehouse.
+Query 39 finds items with large month‑to‑month variation in inventory by computing the coefficient of variation for each warehouse. The sample data includes a second warehouse and an extra year to demonstrate the filtering logic.
 
 ## SQL
 ```sql

--- a/tests/dataset/tpc-dc/q39.mochi
+++ b/tests/dataset/tpc-dc/q39.mochi
@@ -11,15 +11,18 @@ let inventory = [
   {inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 2, inv_quantity_on_hand: 60},
   {inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 3, inv_quantity_on_hand: 55},
   {inv_item_sk: 2, inv_warehouse_sk: 1, inv_date_sk: 4, inv_quantity_on_hand: 70}
+  ,{inv_item_sk: 3, inv_warehouse_sk: 2, inv_date_sk: 1, inv_quantity_on_hand: 40}
 ]
 
 let item = [
   {i_item_sk: 1},
-  {i_item_sk: 2}
+  {i_item_sk: 2},
+  {i_item_sk: 3}
 ]
 
 let warehouse = [
   {w_warehouse_sk: 1, w_warehouse_name: "W1"}
+  ,{w_warehouse_sk: 2, w_warehouse_name: "W2"}
 ]
 
 let date_dim = [
@@ -27,6 +30,7 @@ let date_dim = [
   {d_date_sk: 2, d_year: 2000, d_moy: 2},
   {d_date_sk: 3, d_year: 2000, d_moy: 3},
   {d_date_sk: 4, d_year: 2000, d_moy: 4}
+  ,{d_date_sk: 5, d_year: 2001, d_moy: 1}
 ]
 
 let monthly =


### PR DESCRIPTION
## Summary
- expand sample datasets for TPC-DC queries 30–39
- clarify docs with notes on additional data

## Testing
- `go test ./...` *(fails: undefined `OpFirst`)*

------
https://chatgpt.com/codex/tasks/task_e_6862389cef34832081156fe03ea1a228