### PR TITLE
Fix VM op handling and update TPC-DS queries

### DIFF
--- a/tests/dataset/tpc-ds/q63.mochi
+++ b/tests/dataset/tpc-ds/q63.mochi
@@ -1,6 +1,6 @@
 let sales = [
-  {mgr: 1, amount: 30},
-  {mgr: 2, amount: 33}
+  {mgr: 1, amount: 15.75},
+  {mgr: 2, amount: 47.25}
 ]
 
 
@@ -16,3 +16,4 @@ json(result)
 test "TPCDS Q63 simplified" {
   expect result == 63
 }
+


### PR DESCRIPTION
## Summary
- remove duplicate `OpFirst` definitions in the VM
- adjust VM switch statements
- update simplified TPC‑DS queries q60–q67 for current syntax
- regenerate IR outputs for queries q60–q63

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68623172ffcc8320969fb1578edc8689