### PR TITLE
Add First builtin to VM and update TPC-DS query

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -132,7 +132,7 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagInt
 	case OpJSON, OpPrint, OpPrint2, OpPrintN:
 		// no result
-	case OpInput, OpMakeList, OpIndex, OpSlice, OpSetIndex, OpCall, OpCall2, OpCallV,
+	case OpInput, OpFirst, OpMakeList, OpIndex, OpSlice, OpSetIndex, OpCall, OpCall2, OpCallV,
 		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpSort, OpMakeClosure, OpExpect:
 		tags[ins.A] = TagUnknown
 	case OpIterPrep:

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -542,6 +542,8 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s, %s, %s", formatReg(ins.A), formatReg(ins.B), formatReg(ins.C), formatReg(ins.D))
 			case OpInput:
 				fmt.Fprintf(&b, "%s", formatReg(ins.A))
+			case OpFirst:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpIterPrep:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpCount:


### PR DESCRIPTION
## Summary
- add `OpFirst` instruction in VM
- implement runtime semantics for `first`
- integrate `OpFirst` into type inference
- regenerate IR for tpc-ds q59

## Testing
- `go test ./...`
- `go run ./cmd/mochi run tests/dataset/tpc-ds/q50.mochi`

------
https://chatgpt.com/codex/tasks/task_e_686237f6ada48320abb1d820948ea7cf