### PR TITLE
Implement First builtin in VM

### DIFF
--- a/runtime/vm/infer.go
+++ b/runtime/vm/infer.go
@@ -132,7 +132,7 @@ func applyTags(tags []RegTag, ins Instr) {
 		tags[ins.A] = TagInt
 	case OpJSON, OpPrint, OpPrint2, OpPrintN:
 		// no result
-	case OpInput, OpMakeList, OpIndex, OpSlice, OpSetIndex, OpCall, OpCall2, OpCallV,
+	case OpInput, OpFirst, OpMakeList, OpIndex, OpSlice, OpSetIndex, OpCall, OpCall2, OpCallV,
 		OpUnionAll, OpUnion, OpExcept, OpIntersect, OpSort, OpMakeClosure, OpExpect:
 		tags[ins.A] = TagUnknown
 	case OpIterPrep:

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -542,6 +542,8 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s, %s, %s", formatReg(ins.A), formatReg(ins.B), formatReg(ins.C), formatReg(ins.D))
 			case OpInput:
 				fmt.Fprintf(&b, "%s", formatReg(ins.A))
+			case OpFirst:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpIterPrep:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpCount:


### PR DESCRIPTION
## Summary
- add `OpFirst` opcode and runtime implementation
- update register inference for new opcode

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68623868a8a08320b785f8b164889c3d