### PR TITLE
Add TPC-DS q40-q49 tests and outputs

### DIFF
--- a/tests/dataset/tpc-ds/out/q44.ir.out
+++ b/tests/dataset/tpc-ds/out/q44.ir.out
@@ -1,0 +1,225 @@
+func main (regs=165)
+  // let store_sales = [
+  Const        r0, [{"ss_item_sk": 1, "ss_net_profit": 5, "ss_store_sk": 1}, {"ss_item_sk": 1, "ss_net_profit": 5, "ss_store_sk": 1}, {"ss_item_sk": 2, "ss_net_profit": -1, "ss_store_sk": 1}]
+  // let item = [
+  Const        r1, [{"i_item_sk": 1, "i_product_name": "ItemA"}, {"i_item_sk": 2, "i_product_name": "ItemB"}]
+  // from ss in store_sales
+  Const        r2, []
+  // group by ss.ss_item_sk into g
+  Const        r3, "ss_item_sk"
+  // select { item_sk: g.key,
+  Const        r4, "item_sk"
+  Const        r5, "key"
+  // avg_profit: avg(from x in g select x.ss_net_profit) }
+  Const        r6, "avg_profit"
+  Const        r7, "ss_net_profit"
+  // from ss in store_sales
+  IterPrep     r8, r0
+  Len          r9, r8
+  Const        r10, 0
+  MakeMap      r11, 0, r0
+  Const        r12, []
+L2:
+  LessInt      r14, r10, r9
+  JumpIfFalse  r14, L0
+  Index        r15, r8, r10
+  Move         r16, r15
+  // group by ss.ss_item_sk into g
+  Const        r17, "ss_item_sk"
+  Index        r18, r16, r17
+  Str          r19, r18
+  In           r20, r19, r11
+  JumpIfTrue   r20, L1
+  // from ss in store_sales
+  Const        r21, []
+  Const        r22, "__group__"
+  Const        r23, true
+  Const        r24, "key"
+  // group by ss.ss_item_sk into g
+  Move         r25, r18
+  // from ss in store_sales
+  Const        r26, "items"
+  Move         r27, r21
+  Const        r28, "count"
+  Const        r29, 0
+  Move         r30, r22
+  Move         r31, r23
+  Move         r32, r24
+  Move         r33, r25
+  Move         r34, r26
+  Move         r35, r27
+  Move         r36, r28
+  Move         r37, r29
+  MakeMap      r38, 4, r30
+  SetIndex     r11, r19, r38
+  Append       r12, r12, r38
+L1:
+  Const        r40, "items"
+  Index        r41, r11, r19
+  Index        r42, r41, r40
+  Append       r43, r42, r15
+  SetIndex     r41, r40, r43
+  Const        r44, "count"
+  Index        r45, r41, r44
+  Const        r46, 1
+  AddInt       r47, r45, r46
+  SetIndex     r41, r44, r47
+  Const        r48, 1
+  AddInt       r10, r10, r48
+  Jump         L2
+L0:
+  Const        r49, 0
+  Len          r51, r12
+L6:
+  LessInt      r52, r49, r51
+  JumpIfFalse  r52, L3
+  Index        r54, r12, r49
+  // select { item_sk: g.key,
+  Const        r55, "item_sk"
+  Const        r56, "key"
+  Index        r57, r54, r56
+  // avg_profit: avg(from x in g select x.ss_net_profit) }
+  Const        r58, "avg_profit"
+  Const        r59, []
+  Const        r60, "ss_net_profit"
+  IterPrep     r61, r54
+  Len          r62, r61
+  Const        r63, 0
+L5:
+  LessInt      r65, r63, r62
+  JumpIfFalse  r65, L4
+  Index        r67, r61, r63
+  Const        r68, "ss_net_profit"
+  Index        r69, r67, r68
+  Append       r59, r59, r69
+  Const        r71, 1
+  AddInt       r63, r63, r71
+  Jump         L5
+L4:
+  Avg          r72, r59
+  // select { item_sk: g.key,
+  Move         r73, r55
+  Move         r74, r57
+  // avg_profit: avg(from x in g select x.ss_net_profit) }
+  Move         r75, r58
+  Move         r76, r72
+  // select { item_sk: g.key,
+  MakeMap      r77, 2, r73
+  // from ss in store_sales
+  Append       r2, r2, r77
+  Const        r79, 1
+  AddInt       r49, r49, r79
+  Jump         L6
+L3:
+  // let best = first(from x in grouped sort by -x.avg_profit select x)
+  Const        r80, []
+  Const        r81, "avg_profit"
+  IterPrep     r82, r2
+  Len          r83, r82
+  Const        r84, 0
+L8:
+  LessInt      r86, r84, r83
+  JumpIfFalse  r86, L7
+  Index        r67, r82, r84
+  Const        r88, "avg_profit"
+  Index        r89, r67, r88
+  Neg          r91, r89
+  Move         r92, r67
+  MakeList     r93, 2, r91
+  Append       r80, r80, r93
+  Const        r95, 1
+  AddInt       r84, r84, r95
+  Jump         L8
+L7:
+  Sort         r80, r80
+  First        97,80,0,0
+  // let worst = first(from x in grouped sort by x.avg_profit select x)
+  Const        r98, []
+  Const        r99, "avg_profit"
+  IterPrep     r100, r2
+  Len          r101, r100
+  Const        r102, 0
+L10:
+  LessInt      r104, r102, r101
+  JumpIfFalse  r104, L9
+  Index        r67, r100, r102
+  Const        r106, "avg_profit"
+  Index        r108, r67, r106
+  Move         r109, r67
+  MakeList     r110, 2, r108
+  Append       r98, r98, r110
+  Const        r112, 1
+  AddInt       r102, r102, r112
+  Jump         L10
+L9:
+  Sort         r98, r98
+  First        114,98,0,0
+  // let best_name = first(from i in item where i.i_item_sk == best.item_sk select i.i_product_name)
+  Const        r115, []
+  Const        r116, "i_item_sk"
+  Const        r117, "item_sk"
+  Const        r118, "i_product_name"
+  IterPrep     r119, r1
+  Len          r120, r119
+  Const        r121, 0
+L13:
+  LessInt      r123, r121, r120
+  JumpIfFalse  r123, L11
+  Index        r125, r119, r121
+  Const        r126, "i_item_sk"
+  Index        r127, r125, r126
+  Const        r128, "item_sk"
+  Index        r129, r97, r128
+  Equal        r130, r127, r129
+  JumpIfFalse  r130, L12
+  Const        r131, "i_product_name"
+  Index        r132, r125, r131
+  Append       r115, r115, r132
+L12:
+  Const        r134, 1
+  AddInt       r121, r121, r134
+  Jump         L13
+L11:
+  First        135,115,0,0
+  // let worst_name = first(from i in item where i.i_item_sk == worst.item_sk select i.i_product_name)
+  Const        r136, []
+  Const        r137, "i_item_sk"
+  Const        r138, "item_sk"
+  Const        r139, "i_product_name"
+  IterPrep     r140, r1
+  Len          r141, r140
+  Const        r142, 0
+L16:
+  LessInt      r144, r142, r141
+  JumpIfFalse  r144, L14
+  Index        r125, r140, r142
+  Const        r146, "i_item_sk"
+  Index        r147, r125, r146
+  Const        r148, "item_sk"
+  Index        r149, r114, r148
+  Equal        r150, r147, r149
+  JumpIfFalse  r150, L15
+  Const        r151, "i_product_name"
+  Index        r152, r125, r151
+  Append       r136, r136, r152
+L15:
+  Const        r154, 1
+  AddInt       r142, r142, r154
+  Jump         L16
+L14:
+  First        155,136,0,0
+  // let result = { best_performing: best_name, worst_performing: worst_name }
+  Const        r156, "best_performing"
+  Const        r157, "worst_performing"
+  Move         r158, r156
+  Move         r159, r135
+  Move         r160, r157
+  Move         r161, r155
+  MakeMap      r162, 2, r158
+  // json(result)
+  JSON         r162
+  // expect result == { best_performing: "ItemA", worst_performing: "ItemB" }
+  Const        r163, {"best_performing": "ItemA", "worst_performing": "ItemB"}
+  Equal        r164, r162, r163
+  Expect       r164
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q44.out
+++ b/tests/dataset/tpc-ds/out/q44.out
@@ -1,0 +1,1 @@
+{"best_performing":"ItemA","worst_performing":"ItemB"}

--- a/tests/dataset/tpc-ds/q44.mochi
+++ b/tests/dataset/tpc-ds/q44.mochi
@@ -12,8 +12,8 @@ let item = [
 let grouped = (
   from ss in store_sales
   group by ss.ss_item_sk into g
-  let avg_profit = avg(from x in g select x.ss_net_profit)
-  select { item_sk: g.key, avg_profit: avg_profit }
+  select { item_sk: g.key,
+           avg_profit: avg(from x in g select x.ss_net_profit) }
 )
 
 let best = first(from x in grouped sort by -x.avg_profit select x)

--- a/tests/vm/vm_test.go
+++ b/tests/vm/vm_test.go
@@ -204,7 +204,7 @@ func TestVM_TPCH(t *testing.T) {
 
 func TestVM_TPCDS(t *testing.T) {
 	root := findRepoRoot(t)
-	queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19", "q20", "q21", "q22", "q23", "q24", "q25", "q26", "q27", "q28", "q29"}
+	queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19", "q20", "q21", "q22", "q23", "q24", "q25", "q26", "q27", "q28", "q29", "q40", "q41", "q42", "q43", "q44", "q45", "q46", "q47", "q48", "q49"}
 	found := false
 	for _, q := range queries {
 		src := filepath.Join(root, "tests/dataset/tpc-ds", q+".mochi")


### PR DESCRIPTION
## Summary
- add missing TPC-DS query 40-49 tests to the VM suite
- fix q44 to avoid unsupported inline `let`
- refresh IR goldens for queries q40–q49

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q44 -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q45 -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q49 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68623a1252ac8320b32afdf4735cbd4a