### PR TITLE
Add lower builtin and update TPC-DS placeholders

### DIFF
--- a/tests/dataset/tpc-ds/out/q50.ir.out
+++ b/tests/dataset/tpc-ds/out/q50.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 50}]
   Const        r0, [{"id": 1, "val": 50}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 50
-  Const        r15, 50
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 50
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q51.ir.out
+++ b/tests/dataset/tpc-ds/out/q51.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 51}]
   Const        r0, [{"id": 1, "val": 51}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 51
-  Const        r15, 51
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 51
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q52.ir.out
+++ b/tests/dataset/tpc-ds/out/q52.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 52}]
   Const        r0, [{"id": 1, "val": 52}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 52
-  Const        r15, 52
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 52
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q53.ir.out
+++ b/tests/dataset/tpc-ds/out/q53.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 53}]
   Const        r0, [{"id": 1, "val": 53}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 53
-  Const        r15, 53
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 53
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q54.ir.out
+++ b/tests/dataset/tpc-ds/out/q54.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 54}]
   Const        r0, [{"id": 1, "val": 54}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 54
-  Const        r15, 54
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 54
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q55.ir.out
+++ b/tests/dataset/tpc-ds/out/q55.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 55}]
   Const        r0, [{"id": 1, "val": 55}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 55
-  Const        r15, 55
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 55
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q56.ir.out
+++ b/tests/dataset/tpc-ds/out/q56.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 56}]
   Const        r0, [{"id": 1, "val": 56}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 56
-  Const        r15, 56
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 56
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q57.ir.out
+++ b/tests/dataset/tpc-ds/out/q57.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 57}]
   Const        r0, [{"id": 1, "val": 57}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 57
-  Const        r15, 57
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 57
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q58.ir.out
+++ b/tests/dataset/tpc-ds/out/q58.ir.out
@@ -1,29 +1,32 @@
-func main (regs=17)
+func main (regs=19)
   // let t = [{id: 1, val: 58}]
   Const        r0, [{"id": 1, "val": 58}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Const        r10, "val"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r14, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r14
+  JSON         r16
   // expect result == 58
-  Const        r15, 58
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r17, 58
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/out/q59.ir.out
+++ b/tests/dataset/tpc-ds/out/q59.ir.out
@@ -1,28 +1,32 @@
-func main (regs=16)
+func main (regs=19)
   // let t = [{id: 1, val: 59}]
   Const        r0, [{"id": 1, "val": 59}]
+  // let tmp = lower("ignore")
+  Const        r1, "ignore"
+  Lower        2,1,0,0
   // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r5, 0
+  Const        r3, []
+  Const        r4, "val"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "val"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r13, r1
+  First        16,3,0,0
   // json(result)
-  JSON         r13
+  JSON         r16
   // expect result == 59
-  Const        r14, 59
-  Equal        r15, r13, r14
-  Expect       r15
+  Const        r17, 59
+  Equal        r18, r16, r17
+  Expect       r18
   Return       r0

--- a/tests/dataset/tpc-ds/q50.mochi
+++ b/tests/dataset/tpc-ds/q50.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 50}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q51.mochi
+++ b/tests/dataset/tpc-ds/q51.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 51}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q52.mochi
+++ b/tests/dataset/tpc-ds/q52.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 52}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q53.mochi
+++ b/tests/dataset/tpc-ds/q53.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 53}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q54.mochi
+++ b/tests/dataset/tpc-ds/q54.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 54}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q55.mochi
+++ b/tests/dataset/tpc-ds/q55.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 55}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q56.mochi
+++ b/tests/dataset/tpc-ds/q56.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 56}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q57.mochi
+++ b/tests/dataset/tpc-ds/q57.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 57}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q58.mochi
+++ b/tests/dataset/tpc-ds/q58.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 58}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/dataset/tpc-ds/q59.mochi
+++ b/tests/dataset/tpc-ds/q59.mochi
@@ -1,4 +1,5 @@
 let t = [{id: 1, val: 59}]
+let tmp = lower("ignore")
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)


### PR DESCRIPTION
## Summary
- add `OpLower` instruction to VM
- handle lowering of strings in VM execution and compiler
- emit `lower()` built-in in compiler
- use the new builtin in tpc-ds q50–q59
- refresh golden IR output for the updated queries

## Testing
- `go test ./...`
- `go run tools/update_tpcds/main.go q50 q51 q52 q53 q54 q55 q56 q57 q58 q59`

------
https://chatgpt.com/codex/tasks/task_e_68623a7d32bc83209b478d91b299e002