### PR TITLE
Fix disassembly for First op

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -442,6 +442,8 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpCount:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
+			case OpFirst:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpExists:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpCast:

--- a/tests/dataset/tpc-ds/out/q1.ir.out
+++ b/tests/dataset/tpc-ds/out/q1.ir.out
@@ -9,12 +9,31 @@ func main (regs=239)
   Const        r3, []
   // from sr in store_returns
   Const        r4, []
+  // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
+  Const        r5, "customer_sk"
+  Const        r6, "sr_customer_sk"
+  Const        r7, "store_sk"
+  Const        r8, "sr_store_sk"
+  // where d.d_year == 1998
+  Const        r9, "d_year"
+  // ctr_customer_sk: g.key.customer_sk,
+  Const        r10, "ctr_customer_sk"
+  Const        r11, "key"
+  Const        r12, "customer_sk"
+  // ctr_store_sk: g.key.store_sk,
+  Const        r13, "ctr_store_sk"
+  Const        r14, "key"
+  Const        r15, "store_sk"
+  // ctr_total_return: sum(from x in g select x.sr_return_amt)
+  Const        r16, "ctr_total_return"
+  Const        r17, "sr_return_amt"
+  // from sr in store_returns
   MakeMap      r18, 0, r0
   Const        r19, []
   IterPrep     r21, r0
   Len          r22, r21
   Const        r23, 0
-L1:
+L5:
   LessInt      r24, r23, r22
   JumpIfFalse  r24, L0
   Index        r26, r21, r23
@@ -22,7 +41,7 @@ L1:
   IterPrep     r27, r1
   Len          r28, r27
   Const        r29, 0
-L2:
+L4:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L1
   Index        r32, r27, r29
@@ -93,15 +112,22 @@ L3:
   Const        r85, 1
   AddInt       r86, r84, r85
   SetIndex     r80, r83, r86
+L2:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  Jump         L2
-L0:
+  Const        r87, 1
+  AddInt       r29, r29, r87
+  Jump         L4
+L1:
   // from sr in store_returns
+  Const        r88, 1
+  AddInt       r23, r23, r88
+  Jump         L5
+L0:
   Const        r89, 0
   Len          r91, r19
-L7:
+L9:
   LessInt      r92, r89, r91
-  JumpIfFalse  r92, L4
+  JumpIfFalse  r92, L6
   Index        r94, r19, r89
   // ctr_customer_sk: g.key.customer_sk,
   Const        r95, "ctr_customer_sk"
@@ -118,20 +144,21 @@ L7:
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
   Const        r105, "ctr_total_return"
   Const        r106, []
+  Const        r107, "sr_return_amt"
   IterPrep     r108, r94
   Len          r109, r108
   Const        r110, 0
-L6:
+L8:
   LessInt      r112, r110, r109
-  JumpIfFalse  r112, L5
+  JumpIfFalse  r112, L7
   Index        r114, r108, r110
   Const        r115, "sr_return_amt"
   Index        r116, r114, r115
   Append       r106, r106, r116
   Const        r118, 1
   AddInt       r110, r110, r118
-  Jump         L6
-L5:
+  Jump         L8
+L7:
   Sum          r119, r106
   // ctr_customer_sk: g.key.customer_sk,
   Move         r120, r95
@@ -148,56 +175,111 @@ L5:
   Append       r4, r4, r126
   Const        r128, 1
   AddInt       r89, r89, r128
-  Jump         L7
-L4:
+  Jump         L9
+L6:
   // from ctr1 in customer_total_return
   Const        r129, []
+  // where ctr1.ctr_total_return > avg(
+  Const        r130, "ctr_total_return"
+  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
+  Const        r131, "ctr_store_sk"
+  Const        r132, "ctr_store_sk"
+  // select ctr2.ctr_total_return
+  Const        r133, "ctr_total_return"
+  // s.s_state == "TN"
+  Const        r134, "s_state"
+  // select {c_customer_id: c.c_customer_id}
+  Const        r135, "c_customer_id"
+  Const        r136, "c_customer_id"
+  // sort by c.c_customer_id
+  Const        r137, "c_customer_id"
+  // from ctr1 in customer_total_return
   IterPrep     r138, r4
   Len          r139, r138
   Const        r140, 0
-L18:
+L20:
   LessInt      r142, r140, r139
-  JumpIfFalse  r142, L8
+  JumpIfFalse  r142, L10
   Index        r144, r138, r140
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
   IterPrep     r145, r2
   Len          r146, r145
+  Const        r147, "ctr_store_sk"
+  Const        r148, "s_store_sk"
+  // where ctr1.ctr_total_return > avg(
+  Const        r149, "ctr_total_return"
+  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
+  Const        r150, "ctr_store_sk"
+  Const        r151, "ctr_store_sk"
+  // select ctr2.ctr_total_return
+  Const        r152, "ctr_total_return"
+  // s.s_state == "TN"
+  Const        r153, "s_state"
+  // select {c_customer_id: c.c_customer_id}
+  Const        r154, "c_customer_id"
+  Const        r155, "c_customer_id"
+  // sort by c.c_customer_id
+  Const        r156, "c_customer_id"
+  // join s in store on ctr1.ctr_store_sk == s.s_store_sk
   Const        r157, 0
-L17:
+L19:
   LessInt      r159, r157, r146
-  JumpIfFalse  r159, L9
+  JumpIfFalse  r159, L11
   Index        r161, r145, r157
   Const        r162, "ctr_store_sk"
   Index        r163, r144, r162
   Const        r164, "s_store_sk"
   Index        r165, r161, r164
   Equal        r166, r163, r165
-  JumpIfFalse  r166, L10
+  JumpIfFalse  r166, L12
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
   IterPrep     r167, r3
   Len          r168, r167
+  Const        r169, "ctr_customer_sk"
+  Const        r170, "c_customer_sk"
+  // where ctr1.ctr_total_return > avg(
+  Const        r171, "ctr_total_return"
+  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
+  Const        r172, "ctr_store_sk"
+  Const        r173, "ctr_store_sk"
+  // select ctr2.ctr_total_return
+  Const        r174, "ctr_total_return"
+  // s.s_state == "TN"
+  Const        r175, "s_state"
+  // select {c_customer_id: c.c_customer_id}
+  Const        r176, "c_customer_id"
+  Const        r177, "c_customer_id"
+  // sort by c.c_customer_id
+  Const        r178, "c_customer_id"
+  // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
   Const        r179, 0
-L16:
+L18:
   LessInt      r181, r179, r168
-  JumpIfFalse  r181, L10
+  JumpIfFalse  r181, L12
   Index        r183, r167, r179
   Const        r184, "ctr_customer_sk"
   Index        r185, r144, r184
   Const        r186, "c_customer_sk"
   Index        r187, r183, r186
   Equal        r188, r185, r187
-  JumpIfFalse  r188, L11
+  JumpIfFalse  r188, L13
   // where ctr1.ctr_total_return > avg(
   Const        r189, "ctr_total_return"
   Index        r190, r144, r189
   // from ctr2 in customer_total_return
   Const        r191, []
+  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
+  Const        r192, "ctr_store_sk"
+  Const        r193, "ctr_store_sk"
+  // select ctr2.ctr_total_return
+  Const        r194, "ctr_total_return"
+  // from ctr2 in customer_total_return
   IterPrep     r195, r4
   Len          r196, r195
   Const        r197, 0
-L14:
+L16:
   LessInt      r199, r197, r196
-  JumpIfFalse  r199, L12
+  JumpIfFalse  r199, L14
   Index        r201, r195, r197
   // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
   Const        r202, "ctr_store_sk"
@@ -205,17 +287,17 @@ L14:
   Const        r204, "ctr_store_sk"
   Index        r205, r201, r204
   Equal        r206, r203, r205
-  JumpIfFalse  r206, L13
+  JumpIfFalse  r206, L15
   // select ctr2.ctr_total_return
   Const        r207, "ctr_total_return"
   Index        r208, r201, r207
   // from ctr2 in customer_total_return
   Append       r191, r191, r208
-L13:
+L15:
   Const        r210, 1
   AddInt       r197, r197, r210
-  Jump         L14
-L12:
+  Jump         L16
+L14:
   // where ctr1.ctr_total_return > avg(
   Avg          r211, r191
   // ) * 1.2 &&
@@ -230,11 +312,11 @@ L12:
   Equal        r218, r216, r217
   // ) * 1.2 &&
   Move         r219, r214
-  JumpIfFalse  r219, L15
+  JumpIfFalse  r219, L17
   Move         r219, r218
-L15:
+L17:
   // where ctr1.ctr_total_return > avg(
-  JumpIfFalse  r219, L11
+  JumpIfFalse  r219, L13
   // select {c_customer_id: c.c_customer_id}
   Const        r220, "c_customer_id"
   Const        r221, "c_customer_id"
@@ -249,22 +331,22 @@ L15:
   Move         r229, r225
   MakeList     r230, 2, r228
   Append       r129, r129, r230
-L11:
+L13:
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
   Const        r232, 1
   Add          r179, r179, r232
-  Jump         L16
-L10:
+  Jump         L18
+L12:
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
   Const        r233, 1
   Add          r157, r157, r233
-  Jump         L17
-L9:
+  Jump         L19
+L11:
   // from ctr1 in customer_total_return
   Const        r234, 1
   AddInt       r140, r140, r234
-  Jump         L18
-L8:
+  Jump         L20
+L10:
   // sort by c.c_customer_id
   Sort         r129, r129
   // json(result)

--- a/tests/dataset/tpc-ds/out/q2.ir.out
+++ b/tests/dataset/tpc-ds/out/q2.ir.out
@@ -1,18 +1,56 @@
 func main (regs=261)
   // let web_sales = []
   Const        r0, []
+  // let catalog_sales = []
+  Const        r1, []
   // let date_dim = []
   Const        r2, []
   // let wscs = []
   Const        r3, []
   // from w in wscs
   Const        r4, []
+  // group by {week_seq: d.d_week_seq} into g
+  Const        r5, "week_seq"
+  Const        r6, "d_week_seq"
+  // d_week_seq: g.key.week_seq,
+  Const        r7, "d_week_seq"
+  Const        r8, "key"
+  Const        r9, "week_seq"
+  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
+  Const        r10, "sun_sales"
+  Const        r11, "day"
+  Const        r12, "sales_price"
+  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
+  Const        r13, "mon_sales"
+  Const        r14, "day"
+  Const        r15, "sales_price"
+  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
+  Const        r16, "tue_sales"
+  Const        r17, "day"
+  Const        r18, "sales_price"
+  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
+  Const        r19, "wed_sales"
+  Const        r20, "day"
+  Const        r21, "sales_price"
+  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
+  Const        r22, "thu_sales"
+  Const        r23, "day"
+  Const        r24, "sales_price"
+  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
+  Const        r25, "fri_sales"
+  Const        r26, "day"
+  Const        r27, "sales_price"
+  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
+  Const        r28, "sat_sales"
+  Const        r29, "day"
+  Const        r30, "sales_price"
+  // from w in wscs
   MakeMap      r31, 0, r0
   Const        r32, []
   IterPrep     r34, r3
   Len          r35, r34
   Const        r36, 0
-L1:
+L5:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L0
   Index        r39, r34, r36
@@ -20,7 +58,7 @@ L1:
   IterPrep     r40, r2
   Len          r41, r40
   Const        r42, 0
-L2:
+L4:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L1
   Index        r45, r40, r42
@@ -80,15 +118,22 @@ L3:
   Const        r89, 1
   AddInt       r90, r88, r89
   SetIndex     r84, r87, r90
+L2:
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  Jump         L2
-L0:
+  Const        r91, 1
+  AddInt       r42, r42, r91
+  Jump         L4
+L1:
   // from w in wscs
+  Const        r92, 1
+  AddInt       r36, r36, r92
+  Jump         L5
+L0:
   Const        r93, 0
   Len          r95, r32
-L26:
+L28:
   LessInt      r96, r93, r95
-  JumpIfFalse  r96, L4
+  JumpIfFalse  r96, L6
   Index        r98, r32, r93
   // d_week_seq: g.key.week_seq,
   Const        r99, "d_week_seq"
@@ -99,170 +144,184 @@ L26:
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
   Const        r104, "sun_sales"
   Const        r105, []
+  Const        r106, "day"
+  Const        r107, "sales_price"
   IterPrep     r108, r98
   Len          r109, r108
   Const        r110, 0
-L7:
+L9:
   LessInt      r112, r110, r109
-  JumpIfFalse  r112, L5
+  JumpIfFalse  r112, L7
   Index        r114, r108, r110
   Const        r115, "day"
   Index        r116, r114, r115
   Const        r117, "Sunday"
   Equal        r118, r116, r117
-  JumpIfFalse  r118, L6
+  JumpIfFalse  r118, L8
   Const        r119, "sales_price"
   Index        r120, r114, r119
   Append       r105, r105, r120
-L6:
+L8:
   Const        r122, 1
   AddInt       r110, r110, r122
-  Jump         L7
-L5:
+  Jump         L9
+L7:
   Sum          r123, r105
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
   Const        r124, "mon_sales"
   Const        r125, []
+  Const        r126, "day"
+  Const        r127, "sales_price"
   IterPrep     r128, r98
   Len          r129, r128
   Const        r130, 0
-L10:
+L12:
   LessInt      r132, r130, r129
-  JumpIfFalse  r132, L8
+  JumpIfFalse  r132, L10
   Index        r114, r128, r130
   Const        r134, "day"
   Index        r135, r114, r134
   Const        r136, "Monday"
   Equal        r137, r135, r136
-  JumpIfFalse  r137, L9
+  JumpIfFalse  r137, L11
   Const        r138, "sales_price"
   Index        r139, r114, r138
   Append       r125, r125, r139
-L9:
+L11:
   Const        r141, 1
   AddInt       r130, r130, r141
-  Jump         L10
-L8:
+  Jump         L12
+L10:
   Sum          r142, r125
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
   Const        r143, "tue_sales"
   Const        r144, []
+  Const        r145, "day"
+  Const        r146, "sales_price"
   IterPrep     r147, r98
   Len          r148, r147
   Const        r149, 0
-L13:
+L15:
   LessInt      r151, r149, r148
-  JumpIfFalse  r151, L11
+  JumpIfFalse  r151, L13
   Index        r114, r147, r149
   Const        r153, "day"
   Index        r154, r114, r153
   Const        r155, "Tuesday"
   Equal        r156, r154, r155
-  JumpIfFalse  r156, L12
+  JumpIfFalse  r156, L14
   Const        r157, "sales_price"
   Index        r158, r114, r157
   Append       r144, r144, r158
-L12:
+L14:
   Const        r160, 1
   AddInt       r149, r149, r160
-  Jump         L13
-L11:
+  Jump         L15
+L13:
   Sum          r161, r144
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
   Const        r162, "wed_sales"
   Const        r163, []
+  Const        r164, "day"
+  Const        r165, "sales_price"
   IterPrep     r166, r98
   Len          r167, r166
   Const        r168, 0
-L16:
+L18:
   LessInt      r170, r168, r167
-  JumpIfFalse  r170, L14
+  JumpIfFalse  r170, L16
   Index        r114, r166, r168
   Const        r172, "day"
   Index        r173, r114, r172
   Const        r174, "Wednesday"
   Equal        r175, r173, r174
-  JumpIfFalse  r175, L15
+  JumpIfFalse  r175, L17
   Const        r176, "sales_price"
   Index        r177, r114, r176
   Append       r163, r163, r177
-L15:
+L17:
   Const        r179, 1
   AddInt       r168, r168, r179
-  Jump         L16
-L14:
+  Jump         L18
+L16:
   Sum          r180, r163
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
   Const        r181, "thu_sales"
   Const        r182, []
+  Const        r183, "day"
+  Const        r184, "sales_price"
   IterPrep     r185, r98
   Len          r186, r185
   Const        r187, 0
-L19:
+L21:
   LessInt      r189, r187, r186
-  JumpIfFalse  r189, L17
+  JumpIfFalse  r189, L19
   Index        r114, r185, r187
   Const        r191, "day"
   Index        r192, r114, r191
   Const        r193, "Thursday"
   Equal        r194, r192, r193
-  JumpIfFalse  r194, L18
+  JumpIfFalse  r194, L20
   Const        r195, "sales_price"
   Index        r196, r114, r195
   Append       r182, r182, r196
-L18:
+L20:
   Const        r198, 1
   AddInt       r187, r187, r198
-  Jump         L19
-L17:
+  Jump         L21
+L19:
   Sum          r199, r182
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
   Const        r200, "fri_sales"
   Const        r201, []
+  Const        r202, "day"
+  Const        r203, "sales_price"
   IterPrep     r204, r98
   Len          r205, r204
   Const        r206, 0
-L22:
+L24:
   LessInt      r208, r206, r205
-  JumpIfFalse  r208, L20
+  JumpIfFalse  r208, L22
   Index        r114, r204, r206
   Const        r210, "day"
   Index        r211, r114, r210
   Const        r212, "Friday"
   Equal        r213, r211, r212
-  JumpIfFalse  r213, L21
+  JumpIfFalse  r213, L23
   Const        r214, "sales_price"
   Index        r215, r114, r214
   Append       r201, r201, r215
-L21:
+L23:
   Const        r217, 1
   AddInt       r206, r206, r217
-  Jump         L22
-L20:
+  Jump         L24
+L22:
   Sum          r218, r201
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
   Const        r219, "sat_sales"
   Const        r220, []
+  Const        r221, "day"
+  Const        r222, "sales_price"
   IterPrep     r223, r98
   Len          r224, r223
   Const        r225, 0
-L25:
+L27:
   LessInt      r227, r225, r224
-  JumpIfFalse  r227, L23
+  JumpIfFalse  r227, L25
   Index        r114, r223, r225
   Const        r229, "day"
   Index        r230, r114, r229
   Const        r231, "Saturday"
   Equal        r232, r230, r231
-  JumpIfFalse  r232, L24
+  JumpIfFalse  r232, L26
   Const        r233, "sales_price"
   Index        r234, r114, r233
   Append       r220, r220, r234
-L24:
+L26:
   Const        r236, 1
   AddInt       r225, r225, r236
-  Jump         L25
-L23:
+  Jump         L27
+L25:
   Sum          r237, r220
   // d_week_seq: g.key.week_seq,
   Move         r238, r99
@@ -294,13 +353,15 @@ L23:
   Append       r4, r4, r254
   Const        r256, 1
   AddInt       r93, r93, r256
-  Jump         L26
-L4:
+  Jump         L28
+L6:
   // let result = []
   Const        r257, []
   // json(result)
   JSON         r257
   // expect len(result) == 0
+  Const        r258, 0
+  Const        r259, 0
   Const        r260, true
   Expect       r260
   Return       r0

--- a/tests/dataset/tpc-ds/out/q3.ir.out
+++ b/tests/dataset/tpc-ds/out/q3.ir.out
@@ -7,12 +7,48 @@ func main (regs=211)
   Const        r2, []
   // from dt in date_dim
   Const        r3, []
+  // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
+  Const        r4, "d_year"
+  Const        r5, "d_year"
+  Const        r6, "brand_id"
+  Const        r7, "i_brand_id"
+  Const        r8, "brand"
+  Const        r9, "i_brand"
+  // where i.i_manufact_id == 100 && dt.d_moy == 12
+  Const        r10, "i_manufact_id"
+  Const        r11, "d_moy"
+  // d_year: g.key.d_year,
+  Const        r12, "d_year"
+  Const        r13, "key"
+  Const        r14, "d_year"
+  // brand_id: g.key.brand_id,
+  Const        r15, "brand_id"
+  Const        r16, "key"
+  Const        r17, "brand_id"
+  // brand: g.key.brand,
+  Const        r18, "brand"
+  Const        r19, "key"
+  Const        r20, "brand"
+  // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
+  Const        r21, "sum_agg"
+  Const        r22, "ss"
+  Const        r23, "ss_ext_sales_price"
+  // sort by [g.key.d_year,
+  Const        r24, "key"
+  Const        r25, "d_year"
+  // -sum(from x in g select x.ss.ss_ext_sales_price),
+  Const        r26, "ss"
+  Const        r27, "ss_ext_sales_price"
+  // g.key.brand_id]
+  Const        r28, "key"
+  Const        r29, "brand_id"
+  // from dt in date_dim
   MakeMap      r30, 0, r0
   Const        r31, []
   IterPrep     r33, r0
   Len          r34, r33
   Const        r35, 0
-L1:
+L8:
   LessInt      r36, r35, r34
   JumpIfFalse  r36, L0
   Index        r38, r33, r35
@@ -20,7 +56,7 @@ L1:
   IterPrep     r39, r1
   Len          r40, r39
   Const        r41, 0
-L2:
+L7:
   LessInt      r42, r41, r40
   JumpIfFalse  r42, L1
   Index        r44, r39, r41
@@ -125,13 +161,22 @@ L3:
   Const        r122, 1
   AddInt       r52, r52, r122
   Jump         L6
-L0:
+L2:
+  // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
+  Const        r123, 1
+  AddInt       r41, r41, r123
+  Jump         L7
+L1:
   // from dt in date_dim
+  Const        r124, 1
+  AddInt       r35, r35, r124
+  Jump         L8
+L0:
   Const        r125, 0
   Len          r127, r31
-L12:
+L14:
   LessInt      r128, r125, r127
-  JumpIfFalse  r128, L7
+  JumpIfFalse  r128, L9
   Index        r130, r31, r125
   // d_year: g.key.d_year,
   Const        r131, "d_year"
@@ -154,12 +199,14 @@ L12:
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
   Const        r146, "sum_agg"
   Const        r147, []
+  Const        r148, "ss"
+  Const        r149, "ss_ext_sales_price"
   IterPrep     r150, r130
   Len          r151, r150
   Const        r152, 0
-L9:
+L11:
   LessInt      r154, r152, r151
-  JumpIfFalse  r154, L8
+  JumpIfFalse  r154, L10
   Index        r156, r150, r152
   Const        r157, "ss"
   Index        r158, r156, r157
@@ -168,8 +215,8 @@ L9:
   Append       r147, r147, r160
   Const        r162, 1
   AddInt       r152, r152, r162
-  Jump         L9
-L8:
+  Jump         L11
+L10:
   Sum          r163, r147
   // d_year: g.key.d_year,
   Move         r164, r131
@@ -193,12 +240,13 @@ L8:
   // -sum(from x in g select x.ss.ss_ext_sales_price),
   Const        r178, []
   Const        r179, "ss"
+  Const        r180, "ss_ext_sales_price"
   IterPrep     r181, r130
   Len          r182, r181
   Const        r183, 0
-L11:
+L13:
   LessInt      r185, r183, r182
-  JumpIfFalse  r185, L10
+  JumpIfFalse  r185, L12
   Index        r156, r181, r183
   Const        r187, "ss"
   Index        r188, r156, r187
@@ -207,8 +255,15 @@ L11:
   Append       r178, r178, r190
   Const        r192, 1
   AddInt       r183, r183, r192
-  Jump         L11
-L10:
+  Jump         L13
+L12:
+  Sum          r193, r178
+  Neg          r195, r193
+  // g.key.brand_id]
+  Const        r196, "key"
+  Index        r197, r130, r196
+  Const        r198, "brand_id"
+  Index        r200, r197, r198
   // sort by [g.key.d_year,
   MakeList     r202, 3, r177
   // from dt in date_dim
@@ -217,8 +272,8 @@ L10:
   Append       r3, r3, r204
   Const        r206, 1
   AddInt       r125, r125, r206
-  Jump         L12
-L7:
+  Jump         L14
+L9:
   // sort by [g.key.d_year,
   Sort         r3, r3
   // json(result)

--- a/tests/dataset/tpc-ds/out/q4.ir.out
+++ b/tests/dataset/tpc-ds/out/q4.ir.out
@@ -11,12 +11,52 @@ func main (regs=1104)
   Const        r4, []
   // from c in customer
   Const        r5, []
+  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
+  Const        r6, "id"
+  Const        r7, "c_customer_id"
+  Const        r8, "first"
+  Const        r9, "c_first_name"
+  Const        r10, "last"
+  Const        r11, "c_last_name"
+  Const        r12, "login"
+  Const        r13, "c_login"
+  Const        r14, "year"
+  Const        r15, "d_year"
+  // customer_id: g.key.id,
+  Const        r16, "customer_id"
+  Const        r17, "key"
+  Const        r18, "id"
+  // customer_first_name: g.key.first,
+  Const        r19, "customer_first_name"
+  Const        r20, "key"
+  Const        r21, "first"
+  // customer_last_name: g.key.last,
+  Const        r22, "customer_last_name"
+  Const        r23, "key"
+  Const        r24, "last"
+  // customer_login: g.key.login,
+  Const        r25, "customer_login"
+  Const        r26, "key"
+  Const        r27, "login"
+  // dyear: g.key.year,
+  Const        r28, "dyear"
+  Const        r29, "key"
+  Const        r30, "year"
+  // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
+  Const        r31, "year_total"
+  Const        r32, "ss_ext_list_price"
+  Const        r33, "ss_ext_wholesale_cost"
+  Const        r34, "ss_ext_discount_amt"
+  Const        r35, "ss_ext_sales_price"
+  // sale_type: "s",
+  Const        r36, "sale_type"
+  // from c in customer
   MakeMap      r37, 0, r0
   Const        r38, []
   IterPrep     r40, r0
   Len          r41, r40
   Const        r42, 0
-L1:
+L7:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L0
   Index        r45, r40, r42
@@ -24,7 +64,7 @@ L1:
   IterPrep     r46, r1
   Len          r47, r46
   Const        r48, 0
-L2:
+L6:
   LessInt      r49, r48, r47
   JumpIfFalse  r49, L1
   Index        r51, r46, r48
@@ -125,13 +165,22 @@ L3:
   Const        r130, 1
   AddInt       r59, r59, r130
   Jump         L5
-L0:
+L2:
+  // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
+  Const        r131, 1
+  AddInt       r48, r48, r131
+  Jump         L6
+L1:
   // from c in customer
+  Const        r132, 1
+  AddInt       r42, r42, r132
+  Jump         L7
+L0:
   Const        r133, 0
   Len          r135, r38
-L9:
+L11:
   LessInt      r136, r133, r135
-  JumpIfFalse  r136, L6
+  JumpIfFalse  r136, L8
   Index        r138, r38, r133
   // customer_id: g.key.id,
   Const        r139, "customer_id"
@@ -166,12 +215,16 @@ L9:
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
   Const        r164, "year_total"
   Const        r165, []
+  Const        r166, "ss_ext_list_price"
+  Const        r167, "ss_ext_wholesale_cost"
+  Const        r168, "ss_ext_discount_amt"
+  Const        r169, "ss_ext_sales_price"
   IterPrep     r170, r138
   Len          r171, r170
   Const        r172, 0
-L8:
+L10:
   LessInt      r174, r172, r171
-  JumpIfFalse  r174, L7
+  JumpIfFalse  r174, L9
   Index        r176, r170, r172
   Const        r177, "ss_ext_list_price"
   Index        r178, r176, r177
@@ -189,8 +242,8 @@ L8:
   Append       r165, r165, r189
   Const        r191, 1
   AddInt       r172, r172, r191
-  Jump         L8
-L7:
+  Jump         L10
+L9:
   Sum          r192, r165
   // sale_type: "s",
   Const        r193, "sale_type"
@@ -222,47 +275,87 @@ L7:
   Append       r5, r5, r209
   Const        r211, 1
   AddInt       r133, r133, r211
-  Jump         L9
-L6:
+  Jump         L11
+L8:
   // from c in customer
   Const        r212, []
+  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
+  Const        r213, "id"
+  Const        r214, "c_customer_id"
+  Const        r215, "first"
+  Const        r216, "c_first_name"
+  Const        r217, "last"
+  Const        r218, "c_last_name"
+  Const        r219, "login"
+  Const        r220, "c_login"
+  Const        r221, "year"
+  Const        r222, "d_year"
+  // customer_id: g.key.id,
+  Const        r223, "customer_id"
+  Const        r224, "key"
+  Const        r225, "id"
+  // customer_first_name: g.key.first,
+  Const        r226, "customer_first_name"
+  Const        r227, "key"
+  Const        r228, "first"
+  // customer_last_name: g.key.last,
+  Const        r229, "customer_last_name"
+  Const        r230, "key"
+  Const        r231, "last"
+  // customer_login: g.key.login,
+  Const        r232, "customer_login"
+  Const        r233, "key"
+  Const        r234, "login"
+  // dyear: g.key.year,
+  Const        r235, "dyear"
+  Const        r236, "key"
+  Const        r237, "year"
+  // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
+  Const        r238, "year_total"
+  Const        r239, "cs_ext_list_price"
+  Const        r240, "cs_ext_wholesale_cost"
+  Const        r241, "cs_ext_discount_amt"
+  Const        r242, "cs_ext_sales_price"
+  // sale_type: "c",
+  Const        r243, "sale_type"
+  // from c in customer
   MakeMap      r244, 0, r0
   Const        r245, []
   IterPrep     r247, r0
   Len          r248, r247
   Const        r249, 0
-L17:
+L19:
   LessInt      r250, r249, r248
-  JumpIfFalse  r250, L10
+  JumpIfFalse  r250, L12
   Index        r45, r247, r249
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
   IterPrep     r252, r2
   Len          r253, r252
   Const        r254, 0
-L16:
+L18:
   LessInt      r255, r254, r253
-  JumpIfFalse  r255, L11
+  JumpIfFalse  r255, L13
   Index        r257, r252, r254
   Const        r258, "c_customer_sk"
   Index        r259, r45, r258
   Const        r260, "cs_bill_customer_sk"
   Index        r261, r257, r260
   Equal        r262, r259, r261
-  JumpIfFalse  r262, L12
+  JumpIfFalse  r262, L14
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   IterPrep     r263, r4
   Len          r264, r263
   Const        r265, 0
-L15:
+L17:
   LessInt      r266, r265, r264
-  JumpIfFalse  r266, L12
+  JumpIfFalse  r266, L14
   Index        r268, r263, r265
   Const        r269, "cs_sold_date_sk"
   Index        r270, r257, r269
   Const        r271, "d_date_sk"
   Index        r272, r268, r271
   Equal        r273, r270, r272
-  JumpIfFalse  r273, L13
+  JumpIfFalse  r273, L15
   // from c in customer
   Const        r274, "c"
   Move         r275, r45
@@ -300,7 +393,7 @@ L15:
   MakeMap      r306, 5, r296
   Str          r307, r306
   In           r308, r307, r244
-  JumpIfTrue   r308, L14
+  JumpIfTrue   r308, L16
   // from c in customer
   Const        r309, []
   Const        r310, "__group__"
@@ -324,7 +417,7 @@ L15:
   MakeMap      r326, 4, r318
   SetIndex     r244, r307, r326
   Append       r245, r245, r326
-L14:
+L16:
   Const        r328, "items"
   Index        r329, r244, r307
   Index        r330, r329, r328
@@ -335,27 +428,27 @@ L14:
   Const        r334, 1
   AddInt       r335, r333, r334
   SetIndex     r329, r332, r335
-L13:
+L15:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   Const        r336, 1
   AddInt       r265, r265, r336
-  Jump         L15
-L12:
+  Jump         L17
+L14:
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
   Const        r337, 1
   AddInt       r254, r254, r337
-  Jump         L16
-L11:
+  Jump         L18
+L13:
   // from c in customer
   Const        r338, 1
   AddInt       r249, r249, r338
-  Jump         L17
-L10:
+  Jump         L19
+L12:
   Const        r339, 0
   Len          r341, r245
-L21:
+L23:
   LessInt      r342, r339, r341
-  JumpIfFalse  r342, L18
+  JumpIfFalse  r342, L20
   Index        r138, r245, r339
   // customer_id: g.key.id,
   Const        r344, "customer_id"
@@ -390,12 +483,16 @@ L21:
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
   Const        r369, "year_total"
   Const        r370, []
+  Const        r371, "cs_ext_list_price"
+  Const        r372, "cs_ext_wholesale_cost"
+  Const        r373, "cs_ext_discount_amt"
+  Const        r374, "cs_ext_sales_price"
   IterPrep     r375, r138
   Len          r376, r375
   Const        r377, 0
-L20:
+L22:
   LessInt      r379, r377, r376
-  JumpIfFalse  r379, L19
+  JumpIfFalse  r379, L21
   Index        r176, r375, r377
   Const        r381, "cs_ext_list_price"
   Index        r382, r176, r381
@@ -413,8 +510,8 @@ L20:
   Append       r370, r370, r393
   Const        r395, 1
   AddInt       r377, r377, r395
-  Jump         L20
-L19:
+  Jump         L22
+L21:
   Sum          r396, r370
   // sale_type: "c",
   Const        r397, "sale_type"
@@ -446,49 +543,89 @@ L19:
   Append       r212, r212, r413
   Const        r415, 1
   AddInt       r339, r339, r415
-  Jump         L21
-L18:
+  Jump         L23
+L20:
   // ) union all (
   UnionAll     r416, r5, r212
   // from c in customer
   Const        r417, []
+  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
+  Const        r418, "id"
+  Const        r419, "c_customer_id"
+  Const        r420, "first"
+  Const        r421, "c_first_name"
+  Const        r422, "last"
+  Const        r423, "c_last_name"
+  Const        r424, "login"
+  Const        r425, "c_login"
+  Const        r426, "year"
+  Const        r427, "d_year"
+  // customer_id: g.key.id,
+  Const        r428, "customer_id"
+  Const        r429, "key"
+  Const        r430, "id"
+  // customer_first_name: g.key.first,
+  Const        r431, "customer_first_name"
+  Const        r432, "key"
+  Const        r433, "first"
+  // customer_last_name: g.key.last,
+  Const        r434, "customer_last_name"
+  Const        r435, "key"
+  Const        r436, "last"
+  // customer_login: g.key.login,
+  Const        r437, "customer_login"
+  Const        r438, "key"
+  Const        r439, "login"
+  // dyear: g.key.year,
+  Const        r440, "dyear"
+  Const        r441, "key"
+  Const        r442, "year"
+  // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
+  Const        r443, "year_total"
+  Const        r444, "ws_ext_list_price"
+  Const        r445, "ws_ext_wholesale_cost"
+  Const        r446, "ws_ext_discount_amt"
+  Const        r447, "ws_ext_sales_price"
+  // sale_type: "w",
+  Const        r448, "sale_type"
+  // from c in customer
   MakeMap      r449, 0, r0
   Const        r450, []
   IterPrep     r452, r0
   Len          r453, r452
   Const        r454, 0
-L29:
+L31:
   LessInt      r455, r454, r453
-  JumpIfFalse  r455, L22
+  JumpIfFalse  r455, L24
   Index        r45, r452, r454
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
   IterPrep     r457, r3
   Len          r458, r457
   Const        r459, 0
-L28:
+L30:
   LessInt      r460, r459, r458
-  JumpIfFalse  r460, L23
+  JumpIfFalse  r460, L25
   Index        r462, r457, r459
   Const        r463, "c_customer_sk"
   Index        r464, r45, r463
   Const        r465, "ws_bill_customer_sk"
   Index        r466, r462, r465
   Equal        r467, r464, r466
-  JumpIfFalse  r467, L24
+  JumpIfFalse  r467, L26
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   IterPrep     r468, r4
   Len          r469, r468
   Const        r470, 0
-L27:
+L29:
   LessInt      r471, r470, r469
-  JumpIfFalse  r471, L24
+  JumpIfFalse  r471, L26
   Index        r473, r468, r470
   Const        r474, "ws_sold_date_sk"
   Index        r475, r462, r474
   Const        r476, "d_date_sk"
   Index        r477, r473, r476
   Equal        r478, r475, r477
-  JumpIfFalse  r478, L25
+  JumpIfFalse  r478, L27
   // from c in customer
   Const        r479, "c"
   Move         r480, r45
@@ -526,7 +663,7 @@ L27:
   MakeMap      r511, 5, r501
   Str          r512, r511
   In           r513, r512, r449
-  JumpIfTrue   r513, L26
+  JumpIfTrue   r513, L28
   // from c in customer
   Const        r514, []
   Const        r515, "__group__"
@@ -550,7 +687,7 @@ L27:
   MakeMap      r531, 4, r523
   SetIndex     r449, r512, r531
   Append       r450, r450, r531
-L26:
+L28:
   Const        r533, "items"
   Index        r534, r449, r512
   Index        r535, r534, r533
@@ -561,27 +698,27 @@ L26:
   Const        r539, 1
   AddInt       r540, r538, r539
   SetIndex     r534, r537, r540
-L25:
+L27:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   Const        r541, 1
   AddInt       r470, r470, r541
-  Jump         L27
-L24:
+  Jump         L29
+L26:
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
   Const        r542, 1
   AddInt       r459, r459, r542
-  Jump         L28
-L23:
+  Jump         L30
+L25:
   // from c in customer
   Const        r543, 1
   AddInt       r454, r454, r543
-  Jump         L29
-L22:
+  Jump         L31
+L24:
   Const        r544, 0
   Len          r546, r450
-L33:
+L35:
   LessInt      r547, r544, r546
-  JumpIfFalse  r547, L30
+  JumpIfFalse  r547, L32
   Index        r138, r450, r544
   // customer_id: g.key.id,
   Const        r549, "customer_id"
@@ -616,12 +753,16 @@ L33:
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
   Const        r574, "year_total"
   Const        r575, []
+  Const        r576, "ws_ext_list_price"
+  Const        r577, "ws_ext_wholesale_cost"
+  Const        r578, "ws_ext_discount_amt"
+  Const        r579, "ws_ext_sales_price"
   IterPrep     r580, r138
   Len          r581, r580
   Const        r582, 0
-L32:
+L34:
   LessInt      r584, r582, r581
-  JumpIfFalse  r584, L31
+  JumpIfFalse  r584, L33
   Index        r176, r580, r582
   Const        r586, "ws_ext_list_price"
   Index        r587, r176, r586
@@ -639,8 +780,8 @@ L32:
   Append       r575, r575, r598
   Const        r600, 1
   AddInt       r582, r582, r600
-  Jump         L32
-L31:
+  Jump         L34
+L33:
   Sum          r601, r575
   // sale_type: "w",
   Const        r602, "sale_type"
@@ -672,89 +813,429 @@ L31:
   Append       r417, r417, r618
   Const        r620, 1
   AddInt       r544, r544, r620
-  Jump         L33
-L30:
+  Jump         L35
+L32:
   // ) union all (
   UnionAll     r621, r416, r417
   // from s1 in year_total
   Const        r622, []
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Const        r623, "sale_type"
+  Const        r624, "sale_type"
+  Const        r625, "sale_type"
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Const        r626, "sale_type"
+  Const        r627, "sale_type"
+  Const        r628, "sale_type"
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Const        r629, "dyear"
+  Const        r630, "dyear"
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Const        r631, "dyear"
+  Const        r632, "dyear"
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Const        r633, "dyear"
+  Const        r634, "dyear"
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Const        r635, "year_total"
+  Const        r636, "year_total"
+  Const        r637, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r638, "year_total"
+  Const        r639, "year_total"
+  Const        r640, "year_total"
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Const        r641, "year_total"
+  Const        r642, "year_total"
+  Const        r643, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r644, "year_total"
+  Const        r645, "year_total"
+  Const        r646, "year_total"
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Const        r647, "year_total"
+  Const        r648, "year_total"
+  Const        r649, "year_total"
+  // customer_id: s2.customer_id,
+  Const        r650, "customer_id"
+  Const        r651, "customer_id"
+  // customer_first_name: s2.customer_first_name,
+  Const        r652, "customer_first_name"
+  Const        r653, "customer_first_name"
+  // customer_last_name: s2.customer_last_name,
+  Const        r654, "customer_last_name"
+  Const        r655, "customer_last_name"
+  // customer_login: s2.customer_login,
+  Const        r656, "customer_login"
+  Const        r657, "customer_login"
+  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
+  Const        r658, "customer_id"
+  Const        r659, "customer_first_name"
+  Const        r660, "customer_last_name"
+  Const        r661, "customer_login"
+  // from s1 in year_total
   IterPrep     r662, r621
   Len          r663, r662
   Const        r664, 0
-L70:
+L72:
   LessInt      r666, r664, r663
-  JumpIfFalse  r666, L34
+  JumpIfFalse  r666, L36
   Index        r668, r662, r664
   // join s2 in year_total on s2.customer_id == s1.customer_id
   IterPrep     r669, r621
   Len          r670, r669
+  Const        r671, "customer_id"
+  Const        r672, "customer_id"
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Const        r673, "sale_type"
+  Const        r674, "sale_type"
+  Const        r675, "sale_type"
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Const        r676, "sale_type"
+  Const        r677, "sale_type"
+  Const        r678, "sale_type"
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Const        r679, "dyear"
+  Const        r680, "dyear"
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Const        r681, "dyear"
+  Const        r682, "dyear"
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Const        r683, "dyear"
+  Const        r684, "dyear"
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Const        r685, "year_total"
+  Const        r686, "year_total"
+  Const        r687, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r688, "year_total"
+  Const        r689, "year_total"
+  Const        r690, "year_total"
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Const        r691, "year_total"
+  Const        r692, "year_total"
+  Const        r693, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r694, "year_total"
+  Const        r695, "year_total"
+  Const        r696, "year_total"
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Const        r697, "year_total"
+  Const        r698, "year_total"
+  Const        r699, "year_total"
+  // customer_id: s2.customer_id,
+  Const        r700, "customer_id"
+  Const        r701, "customer_id"
+  // customer_first_name: s2.customer_first_name,
+  Const        r702, "customer_first_name"
+  Const        r703, "customer_first_name"
+  // customer_last_name: s2.customer_last_name,
+  Const        r704, "customer_last_name"
+  Const        r705, "customer_last_name"
+  // customer_login: s2.customer_login,
+  Const        r706, "customer_login"
+  Const        r707, "customer_login"
+  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
+  Const        r708, "customer_id"
+  Const        r709, "customer_first_name"
+  Const        r710, "customer_last_name"
+  Const        r711, "customer_login"
+  // join s2 in year_total on s2.customer_id == s1.customer_id
   Const        r712, 0
-L69:
+L71:
   LessInt      r714, r712, r670
-  JumpIfFalse  r714, L35
+  JumpIfFalse  r714, L37
   Index        r716, r669, r712
   Const        r717, "customer_id"
   Index        r718, r716, r717
   Const        r719, "customer_id"
   Index        r720, r668, r719
   Equal        r721, r718, r720
-  JumpIfFalse  r721, L36
+  JumpIfFalse  r721, L38
   // join c1 in year_total on c1.customer_id == s1.customer_id
   IterPrep     r722, r621
   Len          r723, r722
+  Const        r724, "customer_id"
+  Const        r725, "customer_id"
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Const        r726, "sale_type"
+  Const        r727, "sale_type"
+  Const        r728, "sale_type"
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Const        r729, "sale_type"
+  Const        r730, "sale_type"
+  Const        r731, "sale_type"
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Const        r732, "dyear"
+  Const        r733, "dyear"
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Const        r734, "dyear"
+  Const        r735, "dyear"
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Const        r736, "dyear"
+  Const        r737, "dyear"
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Const        r738, "year_total"
+  Const        r739, "year_total"
+  Const        r740, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r741, "year_total"
+  Const        r742, "year_total"
+  Const        r743, "year_total"
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Const        r744, "year_total"
+  Const        r745, "year_total"
+  Const        r746, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r747, "year_total"
+  Const        r748, "year_total"
+  Const        r749, "year_total"
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Const        r750, "year_total"
+  Const        r751, "year_total"
+  Const        r752, "year_total"
+  // customer_id: s2.customer_id,
+  Const        r753, "customer_id"
+  Const        r754, "customer_id"
+  // customer_first_name: s2.customer_first_name,
+  Const        r755, "customer_first_name"
+  Const        r756, "customer_first_name"
+  // customer_last_name: s2.customer_last_name,
+  Const        r757, "customer_last_name"
+  Const        r758, "customer_last_name"
+  // customer_login: s2.customer_login,
+  Const        r759, "customer_login"
+  Const        r760, "customer_login"
+  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
+  Const        r761, "customer_id"
+  Const        r762, "customer_first_name"
+  Const        r763, "customer_last_name"
+  Const        r764, "customer_login"
+  // join c1 in year_total on c1.customer_id == s1.customer_id
   Const        r765, 0
-L68:
+L70:
   LessInt      r767, r765, r723
-  JumpIfFalse  r767, L36
+  JumpIfFalse  r767, L38
   Index        r769, r722, r765
   Const        r770, "customer_id"
   Index        r771, r769, r770
   Const        r772, "customer_id"
   Index        r773, r668, r772
   Equal        r774, r771, r773
-  JumpIfFalse  r774, L37
+  JumpIfFalse  r774, L39
   // join c2 in year_total on c2.customer_id == s1.customer_id
   IterPrep     r775, r621
   Len          r776, r775
+  Const        r777, "customer_id"
+  Const        r778, "customer_id"
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Const        r779, "sale_type"
+  Const        r780, "sale_type"
+  Const        r781, "sale_type"
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Const        r782, "sale_type"
+  Const        r783, "sale_type"
+  Const        r784, "sale_type"
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Const        r785, "dyear"
+  Const        r786, "dyear"
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Const        r787, "dyear"
+  Const        r788, "dyear"
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Const        r789, "dyear"
+  Const        r790, "dyear"
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Const        r791, "year_total"
+  Const        r792, "year_total"
+  Const        r793, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r794, "year_total"
+  Const        r795, "year_total"
+  Const        r796, "year_total"
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Const        r797, "year_total"
+  Const        r798, "year_total"
+  Const        r799, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r800, "year_total"
+  Const        r801, "year_total"
+  Const        r802, "year_total"
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Const        r803, "year_total"
+  Const        r804, "year_total"
+  Const        r805, "year_total"
+  // customer_id: s2.customer_id,
+  Const        r806, "customer_id"
+  Const        r807, "customer_id"
+  // customer_first_name: s2.customer_first_name,
+  Const        r808, "customer_first_name"
+  Const        r809, "customer_first_name"
+  // customer_last_name: s2.customer_last_name,
+  Const        r810, "customer_last_name"
+  Const        r811, "customer_last_name"
+  // customer_login: s2.customer_login,
+  Const        r812, "customer_login"
+  Const        r813, "customer_login"
+  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
+  Const        r814, "customer_id"
+  Const        r815, "customer_first_name"
+  Const        r816, "customer_last_name"
+  Const        r817, "customer_login"
+  // join c2 in year_total on c2.customer_id == s1.customer_id
   Const        r818, 0
-L67:
+L69:
   LessInt      r820, r818, r776
-  JumpIfFalse  r820, L37
+  JumpIfFalse  r820, L39
   Index        r822, r775, r818
   Const        r823, "customer_id"
   Index        r824, r822, r823
   Const        r825, "customer_id"
   Index        r826, r668, r825
   Equal        r827, r824, r826
-  JumpIfFalse  r827, L38
+  JumpIfFalse  r827, L40
   // join w1 in year_total on w1.customer_id == s1.customer_id
   IterPrep     r828, r621
   Len          r829, r828
+  Const        r830, "customer_id"
+  Const        r831, "customer_id"
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Const        r832, "sale_type"
+  Const        r833, "sale_type"
+  Const        r834, "sale_type"
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Const        r835, "sale_type"
+  Const        r836, "sale_type"
+  Const        r837, "sale_type"
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Const        r838, "dyear"
+  Const        r839, "dyear"
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Const        r840, "dyear"
+  Const        r841, "dyear"
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Const        r842, "dyear"
+  Const        r843, "dyear"
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Const        r844, "year_total"
+  Const        r845, "year_total"
+  Const        r846, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r847, "year_total"
+  Const        r848, "year_total"
+  Const        r849, "year_total"
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Const        r850, "year_total"
+  Const        r851, "year_total"
+  Const        r852, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r853, "year_total"
+  Const        r854, "year_total"
+  Const        r855, "year_total"
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Const        r856, "year_total"
+  Const        r857, "year_total"
+  Const        r858, "year_total"
+  // customer_id: s2.customer_id,
+  Const        r859, "customer_id"
+  Const        r860, "customer_id"
+  // customer_first_name: s2.customer_first_name,
+  Const        r861, "customer_first_name"
+  Const        r862, "customer_first_name"
+  // customer_last_name: s2.customer_last_name,
+  Const        r863, "customer_last_name"
+  Const        r864, "customer_last_name"
+  // customer_login: s2.customer_login,
+  Const        r865, "customer_login"
+  Const        r866, "customer_login"
+  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
+  Const        r867, "customer_id"
+  Const        r868, "customer_first_name"
+  Const        r869, "customer_last_name"
+  Const        r870, "customer_login"
+  // join w1 in year_total on w1.customer_id == s1.customer_id
   Const        r871, 0
-L66:
+L68:
   LessInt      r873, r871, r829
-  JumpIfFalse  r873, L38
+  JumpIfFalse  r873, L40
   Index        r875, r828, r871
   Const        r876, "customer_id"
   Index        r877, r875, r876
   Const        r878, "customer_id"
   Index        r879, r668, r878
   Equal        r880, r877, r879
-  JumpIfFalse  r880, L39
+  JumpIfFalse  r880, L41
   // join w2 in year_total on w2.customer_id == s1.customer_id
   IterPrep     r881, r621
   Len          r882, r881
+  Const        r883, "customer_id"
+  Const        r884, "customer_id"
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Const        r885, "sale_type"
+  Const        r886, "sale_type"
+  Const        r887, "sale_type"
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Const        r888, "sale_type"
+  Const        r889, "sale_type"
+  Const        r890, "sale_type"
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Const        r891, "dyear"
+  Const        r892, "dyear"
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Const        r893, "dyear"
+  Const        r894, "dyear"
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Const        r895, "dyear"
+  Const        r896, "dyear"
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Const        r897, "year_total"
+  Const        r898, "year_total"
+  Const        r899, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r900, "year_total"
+  Const        r901, "year_total"
+  Const        r902, "year_total"
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Const        r903, "year_total"
+  Const        r904, "year_total"
+  Const        r905, "year_total"
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Const        r906, "year_total"
+  Const        r907, "year_total"
+  Const        r908, "year_total"
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Const        r909, "year_total"
+  Const        r910, "year_total"
+  Const        r911, "year_total"
+  // customer_id: s2.customer_id,
+  Const        r912, "customer_id"
+  Const        r913, "customer_id"
+  // customer_first_name: s2.customer_first_name,
+  Const        r914, "customer_first_name"
+  Const        r915, "customer_first_name"
+  // customer_last_name: s2.customer_last_name,
+  Const        r916, "customer_last_name"
+  Const        r917, "customer_last_name"
+  // customer_login: s2.customer_login,
+  Const        r918, "customer_login"
+  Const        r919, "customer_login"
+  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
+  Const        r920, "customer_id"
+  Const        r921, "customer_first_name"
+  Const        r922, "customer_last_name"
+  Const        r923, "customer_login"
+  // join w2 in year_total on w2.customer_id == s1.customer_id
   Const        r924, 0
-L65:
+L67:
   LessInt      r926, r924, r882
-  JumpIfFalse  r926, L39
+  JumpIfFalse  r926, L41
   Index        r928, r881, r924
   Const        r929, "customer_id"
   Index        r930, r928, r929
   Const        r931, "customer_id"
   Index        r932, r668, r931
   Equal        r933, r930, r932
-  JumpIfFalse  r933, L40
+  JumpIfFalse  r933, L42
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
   Const        r934, "sale_type"
   Index        r935, r668, r934
@@ -776,31 +1257,31 @@ L65:
   Index        r949, r769, r948
   Const        r950, 0
   Less         r951, r950, r949
-  JumpIfFalse  r951, L41
+  JumpIfFalse  r951, L43
   Const        r952, "year_total"
   Index        r953, r822, r952
   Const        r954, "year_total"
   Index        r955, r769, r954
   Div          r957, r953, r955
-  Jump         L42
-L41:
+  Jump         L44
+L43:
   Const        r957, nil
-L42:
+L44:
   // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
   Const        r959, "year_total"
   Index        r960, r668, r959
   Const        r961, 0
   Less         r962, r961, r960
-  JumpIfFalse  r962, L43
+  JumpIfFalse  r962, L45
   Const        r963, "year_total"
   Index        r964, r716, r963
   Const        r965, "year_total"
   Index        r966, r668, r965
   Div          r968, r964, r966
-  Jump         L44
-L43:
+  Jump         L46
+L45:
   Const        r968, nil
-L44:
+L46:
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
   Less         r970, r968, r957
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
@@ -808,31 +1289,31 @@ L44:
   Index        r972, r769, r971
   Const        r973, 0
   Less         r974, r973, r972
-  JumpIfFalse  r974, L45
+  JumpIfFalse  r974, L47
   Const        r975, "year_total"
   Index        r976, r822, r975
   Const        r977, "year_total"
   Index        r978, r769, r977
   Div          r980, r976, r978
-  Jump         L46
-L45:
+  Jump         L48
+L47:
   Const        r980, nil
-L46:
+L48:
   // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
   Const        r982, "year_total"
   Index        r983, r875, r982
   Const        r984, 0
   Less         r985, r984, r983
-  JumpIfFalse  r985, L47
+  JumpIfFalse  r985, L49
   Const        r986, "year_total"
   Index        r987, r928, r986
   Const        r988, "year_total"
   Index        r989, r875, r988
   Div          r991, r987, r989
-  Jump         L48
-L47:
+  Jump         L50
+L49:
   Const        r991, nil
-L48:
+L50:
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
   Less         r993, r991, r980
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
@@ -888,62 +1369,62 @@ L48:
   Equal        r1039, r1037, r1038
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
   Move         r1040, r995
-  JumpIfFalse  r1040, L49
-L49:
-  Move         r1041, r999
-  JumpIfFalse  r1041, L50
-L50:
-  Move         r1042, r1003
-  JumpIfFalse  r1042, L51
+  JumpIfFalse  r1040, L51
 L51:
+  Move         r1041, r999
+  JumpIfFalse  r1041, L52
+L52:
+  Move         r1042, r1003
+  JumpIfFalse  r1042, L53
+L53:
   // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
   Move         r1043, r1007
-  JumpIfFalse  r1043, L52
-L52:
-  Move         r1044, r1011
-  JumpIfFalse  r1044, L53
-L53:
-  Move         r1045, r1015
-  JumpIfFalse  r1045, L54
+  JumpIfFalse  r1043, L54
 L54:
+  Move         r1044, r1011
+  JumpIfFalse  r1044, L55
+L55:
+  Move         r1045, r1015
+  JumpIfFalse  r1045, L56
+L56:
   // s1.dyear == 2001 && s2.dyear == 2002 &&
   Move         r1046, r1019
-  JumpIfFalse  r1046, L55
-L55:
+  JumpIfFalse  r1046, L57
+L57:
   Move         r1047, r1023
-  JumpIfFalse  r1047, L56
-L56:
+  JumpIfFalse  r1047, L58
+L58:
   // c1.dyear == 2001 && c2.dyear == 2002 &&
   Move         r1048, r1027
-  JumpIfFalse  r1048, L57
-L57:
+  JumpIfFalse  r1048, L59
+L59:
   Move         r1049, r1031
-  JumpIfFalse  r1049, L58
-L58:
+  JumpIfFalse  r1049, L60
+L60:
   // w1.dyear == 2001 && w2.dyear == 2002 &&
   Move         r1050, r1035
-  JumpIfFalse  r1050, L59
-L59:
+  JumpIfFalse  r1050, L61
+L61:
   Move         r1051, r1039
-  JumpIfFalse  r1051, L60
-L60:
+  JumpIfFalse  r1051, L62
+L62:
   // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
   Move         r1052, r939
-  JumpIfFalse  r1052, L61
-L61:
-  Move         r1053, r943
-  JumpIfFalse  r1053, L62
-L62:
-  Move         r1054, r947
-  JumpIfFalse  r1054, L63
+  JumpIfFalse  r1052, L63
 L63:
+  Move         r1053, r943
+  JumpIfFalse  r1053, L64
+L64:
+  Move         r1054, r947
+  JumpIfFalse  r1054, L65
+L65:
   // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
   Move         r1055, r970
-  JumpIfFalse  r1055, L64
+  JumpIfFalse  r1055, L66
   Move         r1055, r993
-L64:
+L66:
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  JumpIfFalse  r1055, L40
+  JumpIfFalse  r1055, L42
   // customer_id: s2.customer_id,
   Const        r1056, "customer_id"
   Const        r1057, "customer_id"
@@ -980,42 +1461,46 @@ L64:
   Const        r1080, "customer_first_name"
   Index        r1081, r716, r1080
   Move         r1082, r1081
+  Const        r1083, "customer_last_name"
+  Index        r1085, r716, r1083
+  Const        r1086, "customer_login"
+  Index        r1088, r716, r1086
   MakeList     r1090, 4, r1079
   // from s1 in year_total
   Move         r1091, r1076
   MakeList     r1092, 2, r1090
   Append       r622, r622, r1092
-L40:
+L42:
   // join w2 in year_total on w2.customer_id == s1.customer_id
   Const        r1094, 1
   Add          r924, r924, r1094
-  Jump         L65
-L39:
+  Jump         L67
+L41:
   // join w1 in year_total on w1.customer_id == s1.customer_id
   Const        r1095, 1
   Add          r871, r871, r1095
-  Jump         L66
-L38:
+  Jump         L68
+L40:
   // join c2 in year_total on c2.customer_id == s1.customer_id
   Const        r1096, 1
   Add          r818, r818, r1096
-  Jump         L67
-L37:
+  Jump         L69
+L39:
   // join c1 in year_total on c1.customer_id == s1.customer_id
   Const        r1097, 1
   Add          r765, r765, r1097
-  Jump         L68
-L36:
+  Jump         L70
+L38:
   // join s2 in year_total on s2.customer_id == s1.customer_id
   Const        r1098, 1
   Add          r712, r712, r1098
-  Jump         L69
-L35:
+  Jump         L71
+L37:
   // from s1 in year_total
   Const        r1099, 1
   AddInt       r664, r664, r1099
-  Jump         L70
-L34:
+  Jump         L72
+L36:
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
   Sort         r622, r622
   // json(result)

--- a/tests/dataset/tpc-ds/out/q5.ir.out
+++ b/tests/dataset/tpc-ds/out/q5.ir.out
@@ -21,12 +21,35 @@ func main (regs=1189)
   Const        r9, []
   // from ss in store_sales
   Const        r10, []
+  // group by s.s_store_id into g
+  Const        r11, "s_store_id"
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Const        r12, "d_date"
+  Const        r13, "d_date"
+  // channel: "store channel",
+  Const        r14, "channel"
+  // id: "store" + str(g.key),
+  Const        r15, "id"
+  Const        r16, "key"
+  // sales: sum(from x in g select x.ss.ss_ext_sales_price),
+  Const        r17, "sales"
+  Const        r18, "ss"
+  Const        r19, "ss_ext_sales_price"
+  // returns: 0.0,
+  Const        r20, "returns"
+  // profit: sum(from x in g select x.ss.ss_net_profit),
+  Const        r21, "profit"
+  Const        r22, "ss"
+  Const        r23, "ss_net_profit"
+  // profit_loss: 0.0
+  Const        r24, "profit_loss"
+  // from ss in store_sales
   MakeMap      r25, 0, r0
   Const        r26, []
   IterPrep     r28, r0
   Len          r29, r28
   Const        r30, 0
-L1:
+L8:
   LessInt      r31, r30, r29
   JumpIfFalse  r31, L0
   Index        r33, r28, r30
@@ -34,7 +57,7 @@ L1:
   IterPrep     r34, r9
   Len          r35, r34
   Const        r36, 0
-L2:
+L7:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L1
   Index        r39, r34, r36
@@ -125,13 +148,22 @@ L3:
   Const        r103, 1
   AddInt       r47, r47, r103
   Jump         L6
-L0:
+L2:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r104, 1
+  AddInt       r36, r36, r104
+  Jump         L7
+L1:
   // from ss in store_sales
+  Const        r105, 1
+  AddInt       r30, r30, r105
+  Jump         L8
+L0:
   Const        r106, 0
   Len          r108, r26
-L12:
+L14:
   LessInt      r109, r106, r108
-  JumpIfFalse  r109, L7
+  JumpIfFalse  r109, L9
   Index        r111, r26, r106
   // channel: "store channel",
   Const        r112, "channel"
@@ -146,12 +178,14 @@ L12:
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
   Const        r120, "sales"
   Const        r121, []
+  Const        r122, "ss"
+  Const        r123, "ss_ext_sales_price"
   IterPrep     r124, r111
   Len          r125, r124
   Const        r126, 0
-L9:
+L11:
   LessInt      r128, r126, r125
-  JumpIfFalse  r128, L8
+  JumpIfFalse  r128, L10
   Index        r130, r124, r126
   Const        r131, "ss"
   Index        r132, r130, r131
@@ -160,25 +194,34 @@ L9:
   Append       r121, r121, r134
   Const        r136, 1
   AddInt       r126, r126, r136
-  Jump         L9
-L8:
+  Jump         L11
+L10:
   Sum          r137, r121
   // returns: 0.0,
   Const        r138, "returns"
   Const        r139, 0
   // profit: sum(from x in g select x.ss.ss_net_profit),
   Const        r140, "profit"
+  Const        r141, []
+  Const        r142, "ss"
+  Const        r143, "ss_net_profit"
   IterPrep     r144, r111
   Len          r145, r144
   Const        r146, 0
-L11:
+L13:
   LessInt      r148, r146, r145
-  JumpIfFalse  r148, L10
+  JumpIfFalse  r148, L12
+  Index        r130, r144, r146
+  Const        r150, "ss"
+  Index        r151, r130, r150
+  Const        r152, "ss_net_profit"
+  Index        r153, r151, r152
+  Append       r141, r141, r153
   Const        r155, 1
   AddInt       r146, r146, r155
-  Jump         L11
-L10:
-  Const        r156, 0
+  Jump         L13
+L12:
+  Sum          r156, r141
   // profit_loss: 0.0
   Const        r157, "profit_loss"
   Const        r158, 0
@@ -204,47 +247,72 @@ L10:
   MakeMap      r171, 6, r159
   // from ss in store_sales
   Append       r10, r10, r171
-  Jump         L12
-L7:
+  Const        r173, 1
+  AddInt       r106, r106, r173
+  Jump         L14
+L9:
   // from sr in store_returns
   Const        r174, []
+  // group by s.s_store_id into g
+  Const        r175, "s_store_id"
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Const        r176, "d_date"
+  Const        r177, "d_date"
+  // channel: "store channel",
+  Const        r178, "channel"
+  // id: "store" + str(g.key),
+  Const        r179, "id"
+  Const        r180, "key"
+  // sales: 0.0,
+  Const        r181, "sales"
+  // returns: sum(from x in g select x.sr.sr_return_amt),
+  Const        r182, "returns"
+  Const        r183, "sr"
+  Const        r184, "sr_return_amt"
+  // profit: 0.0,
+  Const        r185, "profit"
+  // profit_loss: sum(from x in g select x.sr.sr_net_loss)
+  Const        r186, "profit_loss"
+  Const        r187, "sr"
+  Const        r188, "sr_net_loss"
+  // from sr in store_returns
   MakeMap      r189, 0, r0
   Const        r190, []
   IterPrep     r192, r1
   Len          r193, r192
   Const        r194, 0
-L21:
+L23:
   LessInt      r195, r194, r193
-  JumpIfFalse  r195, L13
+  JumpIfFalse  r195, L15
   Index        r197, r192, r194
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
   IterPrep     r198, r9
   Len          r199, r198
   Const        r200, 0
-L20:
+L22:
   LessInt      r201, r200, r199
-  JumpIfFalse  r201, L14
+  JumpIfFalse  r201, L16
   Index        r203, r198, r200
   Const        r204, "sr_returned_date_sk"
   Index        r205, r197, r204
   Const        r206, "d_date_sk"
   Index        r207, r203, r206
   Equal        r208, r205, r207
-  JumpIfFalse  r208, L15
+  JumpIfFalse  r208, L17
   // join s in store on sr.sr_store_sk == s.s_store_sk
   IterPrep     r209, r2
   Len          r210, r209
   Const        r211, 0
-L19:
+L21:
   LessInt      r212, r211, r210
-  JumpIfFalse  r212, L15
+  JumpIfFalse  r212, L17
   Index        r214, r209, r211
   Const        r215, "sr_store_sk"
   Index        r216, r197, r215
   Const        r217, "s_store_sk"
   Index        r218, r214, r217
   Equal        r219, r216, r218
-  JumpIfFalse  r219, L16
+  JumpIfFalse  r219, L18
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
   Const        r220, "d_date"
   Index        r221, r203, r220
@@ -255,10 +323,10 @@ L19:
   Const        r226, "1998-12-15"
   LessEq       r227, r225, r226
   Move         r228, r223
-  JumpIfFalse  r228, L17
+  JumpIfFalse  r228, L19
   Move         r228, r227
-L17:
-  JumpIfFalse  r228, L16
+L19:
+  JumpIfFalse  r228, L18
   // from sr in store_returns
   Const        r229, "sr"
   Move         r230, r197
@@ -272,7 +340,7 @@ L17:
   Index        r237, r214, r236
   Str          r238, r237
   In           r239, r238, r189
-  JumpIfTrue   r239, L18
+  JumpIfTrue   r239, L20
   // from sr in store_returns
   Const        r240, []
   Const        r241, "__group__"
@@ -296,7 +364,7 @@ L17:
   MakeMap      r257, 4, r249
   SetIndex     r189, r238, r257
   Append       r190, r190, r257
-L18:
+L20:
   Const        r259, "items"
   Index        r260, r189, r238
   Index        r261, r260, r259
@@ -307,27 +375,27 @@ L18:
   Const        r265, 1
   AddInt       r266, r264, r265
   SetIndex     r260, r263, r266
-L16:
+L18:
   // join s in store on sr.sr_store_sk == s.s_store_sk
   Const        r267, 1
   AddInt       r211, r211, r267
-  Jump         L19
-L15:
+  Jump         L21
+L17:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
   Const        r268, 1
   AddInt       r200, r200, r268
-  Jump         L20
-L14:
+  Jump         L22
+L16:
   // from sr in store_returns
   Const        r269, 1
   AddInt       r194, r194, r269
-  Jump         L21
-L13:
+  Jump         L23
+L15:
   Const        r270, 0
   Len          r272, r190
-L27:
+L29:
   LessInt      r273, r270, r272
-  JumpIfFalse  r273, L22
+  JumpIfFalse  r273, L24
   Index        r111, r190, r270
   // channel: "store channel",
   Const        r275, "channel"
@@ -345,12 +413,14 @@ L27:
   // returns: sum(from x in g select x.sr.sr_return_amt),
   Const        r285, "returns"
   Const        r286, []
+  Const        r287, "sr"
+  Const        r288, "sr_return_amt"
   IterPrep     r289, r111
   Len          r290, r289
   Const        r291, 0
-L24:
+L26:
   LessInt      r293, r291, r290
-  JumpIfFalse  r293, L23
+  JumpIfFalse  r293, L25
   Index        r130, r289, r291
   Const        r295, "sr"
   Index        r296, r130, r295
@@ -359,8 +429,8 @@ L24:
   Append       r286, r286, r298
   Const        r300, 1
   AddInt       r291, r291, r300
-  Jump         L24
-L23:
+  Jump         L26
+L25:
   Sum          r301, r286
   // profit: 0.0,
   Const        r302, "profit"
@@ -368,12 +438,14 @@ L23:
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
   Const        r304, "profit_loss"
   Const        r305, []
+  Const        r306, "sr"
+  Const        r307, "sr_net_loss"
   IterPrep     r308, r111
   Len          r309, r308
   Const        r310, 0
-L26:
+L28:
   LessInt      r312, r310, r309
-  JumpIfFalse  r312, L25
+  JumpIfFalse  r312, L27
   Index        r130, r308, r310
   Const        r314, "sr"
   Index        r315, r130, r314
@@ -382,8 +454,8 @@ L26:
   Append       r305, r305, r317
   Const        r319, 1
   AddInt       r310, r310, r319
-  Jump         L26
-L25:
+  Jump         L28
+L27:
   Sum          r320, r305
   // channel: "store channel",
   Move         r321, r275
@@ -407,47 +479,72 @@ L25:
   MakeMap      r333, 6, r321
   // from sr in store_returns
   Append       r174, r174, r333
-  Jump         L27
-L22:
+  Const        r335, 1
+  AddInt       r270, r270, r335
+  Jump         L29
+L24:
   // from cs in catalog_sales
   Const        r336, []
+  // group by cp.cp_catalog_page_id into g
+  Const        r337, "cp_catalog_page_id"
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Const        r338, "d_date"
+  Const        r339, "d_date"
+  // channel: "catalog channel",
+  Const        r340, "channel"
+  // id: "catalog_page" + str(g.key),
+  Const        r341, "id"
+  Const        r342, "key"
+  // sales: sum(from x in g select x.cs.cs_ext_sales_price),
+  Const        r343, "sales"
+  Const        r344, "cs"
+  Const        r345, "cs_ext_sales_price"
+  // returns: 0.0,
+  Const        r346, "returns"
+  // profit: sum(from x in g select x.cs.cs_net_profit),
+  Const        r347, "profit"
+  Const        r348, "cs"
+  Const        r349, "cs_net_profit"
+  // profit_loss: 0.0
+  Const        r350, "profit_loss"
+  // from cs in catalog_sales
   MakeMap      r351, 0, r0
   Const        r352, []
   IterPrep     r354, r3
   Len          r355, r354
   Const        r356, 0
-L36:
+L38:
   LessInt      r357, r356, r355
-  JumpIfFalse  r357, L28
+  JumpIfFalse  r357, L30
   Index        r359, r354, r356
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   IterPrep     r360, r9
   Len          r361, r360
   Const        r362, 0
-L35:
+L37:
   LessInt      r363, r362, r361
-  JumpIfFalse  r363, L29
+  JumpIfFalse  r363, L31
   Index        r365, r360, r362
   Const        r366, "cs_sold_date_sk"
   Index        r367, r359, r366
   Const        r368, "d_date_sk"
   Index        r369, r365, r368
   Equal        r370, r367, r369
-  JumpIfFalse  r370, L30
+  JumpIfFalse  r370, L32
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
   IterPrep     r371, r5
   Len          r372, r371
   Const        r373, 0
-L34:
+L36:
   LessInt      r374, r373, r372
-  JumpIfFalse  r374, L30
+  JumpIfFalse  r374, L32
   Index        r376, r371, r373
   Const        r377, "cs_catalog_page_sk"
   Index        r378, r359, r377
   Const        r379, "cp_catalog_page_sk"
   Index        r380, r376, r379
   Equal        r381, r378, r380
-  JumpIfFalse  r381, L31
+  JumpIfFalse  r381, L33
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
   Const        r382, "d_date"
   Index        r383, r365, r382
@@ -458,10 +555,10 @@ L34:
   Const        r388, "1998-12-15"
   LessEq       r389, r387, r388
   Move         r390, r385
-  JumpIfFalse  r390, L32
+  JumpIfFalse  r390, L34
   Move         r390, r389
-L32:
-  JumpIfFalse  r390, L31
+L34:
+  JumpIfFalse  r390, L33
   // from cs in catalog_sales
   Const        r391, "cs"
   Move         r392, r359
@@ -475,7 +572,7 @@ L32:
   Index        r399, r376, r398
   Str          r400, r399
   In           r401, r400, r351
-  JumpIfTrue   r401, L33
+  JumpIfTrue   r401, L35
   // from cs in catalog_sales
   Const        r402, []
   Const        r403, "__group__"
@@ -499,7 +596,7 @@ L32:
   MakeMap      r419, 4, r411
   SetIndex     r351, r400, r419
   Append       r352, r352, r419
-L33:
+L35:
   Const        r421, "items"
   Index        r422, r351, r400
   Index        r423, r422, r421
@@ -510,27 +607,27 @@ L33:
   Const        r427, 1
   AddInt       r428, r426, r427
   SetIndex     r422, r425, r428
-L31:
+L33:
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
   Const        r429, 1
   AddInt       r373, r373, r429
-  Jump         L34
-L30:
+  Jump         L36
+L32:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   Const        r430, 1
   AddInt       r362, r362, r430
-  Jump         L35
-L29:
+  Jump         L37
+L31:
   // from cs in catalog_sales
   Const        r431, 1
   AddInt       r356, r356, r431
-  Jump         L36
-L28:
+  Jump         L38
+L30:
   Const        r432, 0
   Len          r434, r352
-L42:
+L44:
   LessInt      r435, r432, r434
-  JumpIfFalse  r435, L37
+  JumpIfFalse  r435, L39
   Index        r111, r352, r432
   // channel: "catalog channel",
   Const        r437, "channel"
@@ -545,12 +642,14 @@ L42:
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
   Const        r445, "sales"
   Const        r446, []
+  Const        r447, "cs"
+  Const        r448, "cs_ext_sales_price"
   IterPrep     r449, r111
   Len          r450, r449
   Const        r451, 0
-L39:
+L41:
   LessInt      r453, r451, r450
-  JumpIfFalse  r453, L38
+  JumpIfFalse  r453, L40
   Index        r130, r449, r451
   Const        r455, "cs"
   Index        r456, r130, r455
@@ -559,8 +658,8 @@ L39:
   Append       r446, r446, r458
   Const        r460, 1
   AddInt       r451, r451, r460
-  Jump         L39
-L38:
+  Jump         L41
+L40:
   Sum          r461, r446
   // returns: 0.0,
   Const        r462, "returns"
@@ -568,12 +667,14 @@ L38:
   // profit: sum(from x in g select x.cs.cs_net_profit),
   Const        r464, "profit"
   Const        r465, []
+  Const        r466, "cs"
+  Const        r467, "cs_net_profit"
   IterPrep     r468, r111
   Len          r469, r468
   Const        r470, 0
-L41:
+L43:
   LessInt      r472, r470, r469
-  JumpIfFalse  r472, L40
+  JumpIfFalse  r472, L42
   Index        r130, r468, r470
   Const        r474, "cs"
   Index        r475, r130, r474
@@ -582,8 +683,8 @@ L41:
   Append       r465, r465, r477
   Const        r479, 1
   AddInt       r470, r470, r479
-  Jump         L41
-L40:
+  Jump         L43
+L42:
   Sum          r480, r465
   // profit_loss: 0.0
   Const        r481, "profit_loss"
@@ -612,47 +713,70 @@ L40:
   Append       r336, r336, r495
   Const        r497, 1
   AddInt       r432, r432, r497
-  Jump         L42
-L37:
+  Jump         L44
+L39:
   // from cr in catalog_returns
   Const        r498, []
+  // group by cp.cp_catalog_page_id into g
+  Const        r499, "cp_catalog_page_id"
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Const        r500, "d_date"
+  Const        r501, "d_date"
+  // channel: "catalog channel",
+  Const        r502, "channel"
+  // id: "catalog_page" + str(g.key),
+  Const        r503, "id"
+  Const        r504, "key"
+  // sales: 0.0,
+  Const        r505, "sales"
+  // returns: sum(from x in g select x.cr.cr_return_amount),
+  Const        r506, "returns"
+  Const        r507, "cr"
+  Const        r508, "cr_return_amount"
+  // profit: 0.0,
+  Const        r509, "profit"
+  // profit_loss: sum(from x in g select x.cr.cr_net_loss)
+  Const        r510, "profit_loss"
+  Const        r511, "cr"
+  Const        r512, "cr_net_loss"
+  // from cr in catalog_returns
   MakeMap      r513, 0, r0
   Const        r514, []
   IterPrep     r516, r4
   Len          r517, r516
   Const        r518, 0
-L51:
+L53:
   LessInt      r519, r518, r517
-  JumpIfFalse  r519, L43
+  JumpIfFalse  r519, L45
   Index        r521, r516, r518
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
   IterPrep     r522, r9
   Len          r523, r522
   Const        r524, 0
-L50:
+L52:
   LessInt      r525, r524, r523
-  JumpIfFalse  r525, L44
+  JumpIfFalse  r525, L46
   Index        r527, r522, r524
   Const        r528, "cr_returned_date_sk"
   Index        r529, r521, r528
   Const        r530, "d_date_sk"
   Index        r531, r527, r530
   Equal        r532, r529, r531
-  JumpIfFalse  r532, L45
+  JumpIfFalse  r532, L47
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
   IterPrep     r533, r5
   Len          r534, r533
   Const        r535, 0
-L49:
+L51:
   LessInt      r536, r535, r534
-  JumpIfFalse  r536, L45
+  JumpIfFalse  r536, L47
   Index        r538, r533, r535
   Const        r539, "cr_catalog_page_sk"
   Index        r540, r521, r539
   Const        r541, "cp_catalog_page_sk"
   Index        r542, r538, r541
   Equal        r543, r540, r542
-  JumpIfFalse  r543, L46
+  JumpIfFalse  r543, L48
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
   Const        r544, "d_date"
   Index        r545, r527, r544
@@ -663,10 +787,10 @@ L49:
   Const        r550, "1998-12-15"
   LessEq       r551, r549, r550
   Move         r552, r547
-  JumpIfFalse  r552, L47
+  JumpIfFalse  r552, L49
   Move         r552, r551
-L47:
-  JumpIfFalse  r552, L46
+L49:
+  JumpIfFalse  r552, L48
   // from cr in catalog_returns
   Const        r553, "cr"
   Move         r554, r521
@@ -680,7 +804,7 @@ L47:
   Index        r561, r538, r560
   Str          r562, r561
   In           r563, r562, r513
-  JumpIfTrue   r563, L48
+  JumpIfTrue   r563, L50
   // from cr in catalog_returns
   Const        r564, []
   Const        r565, "__group__"
@@ -704,7 +828,7 @@ L47:
   MakeMap      r581, 4, r573
   SetIndex     r513, r562, r581
   Append       r514, r514, r581
-L48:
+L50:
   Const        r583, "items"
   Index        r584, r513, r562
   Index        r585, r584, r583
@@ -715,27 +839,27 @@ L48:
   Const        r589, 1
   AddInt       r590, r588, r589
   SetIndex     r584, r587, r590
-L46:
+L48:
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
   Const        r591, 1
   AddInt       r535, r535, r591
-  Jump         L49
-L45:
+  Jump         L51
+L47:
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
   Const        r592, 1
   AddInt       r524, r524, r592
-  Jump         L50
-L44:
+  Jump         L52
+L46:
   // from cr in catalog_returns
   Const        r593, 1
   AddInt       r518, r518, r593
-  Jump         L51
-L43:
+  Jump         L53
+L45:
   Const        r594, 0
   Len          r596, r514
-L57:
+L59:
   LessInt      r597, r594, r596
-  JumpIfFalse  r597, L52
+  JumpIfFalse  r597, L54
   Index        r111, r514, r594
   // channel: "catalog channel",
   Const        r599, "channel"
@@ -753,12 +877,14 @@ L57:
   // returns: sum(from x in g select x.cr.cr_return_amount),
   Const        r609, "returns"
   Const        r610, []
+  Const        r611, "cr"
+  Const        r612, "cr_return_amount"
   IterPrep     r613, r111
   Len          r614, r613
   Const        r615, 0
-L54:
+L56:
   LessInt      r617, r615, r614
-  JumpIfFalse  r617, L53
+  JumpIfFalse  r617, L55
   Index        r130, r613, r615
   Const        r619, "cr"
   Index        r620, r130, r619
@@ -767,8 +893,8 @@ L54:
   Append       r610, r610, r622
   Const        r624, 1
   AddInt       r615, r615, r624
-  Jump         L54
-L53:
+  Jump         L56
+L55:
   Sum          r625, r610
   // profit: 0.0,
   Const        r626, "profit"
@@ -776,12 +902,14 @@ L53:
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
   Const        r628, "profit_loss"
   Const        r629, []
+  Const        r630, "cr"
+  Const        r631, "cr_net_loss"
   IterPrep     r632, r111
   Len          r633, r632
   Const        r634, 0
-L56:
+L58:
   LessInt      r636, r634, r633
-  JumpIfFalse  r636, L55
+  JumpIfFalse  r636, L57
   Index        r130, r632, r634
   Const        r638, "cr"
   Index        r639, r130, r638
@@ -790,8 +918,8 @@ L56:
   Append       r629, r629, r641
   Const        r643, 1
   AddInt       r634, r634, r643
-  Jump         L56
-L55:
+  Jump         L58
+L57:
   Sum          r644, r629
   // channel: "catalog channel",
   Move         r645, r599
@@ -817,47 +945,70 @@ L55:
   Append       r498, r498, r657
   Const        r659, 1
   AddInt       r594, r594, r659
-  Jump         L57
-L52:
+  Jump         L59
+L54:
   // from ws in web_sales
   Const        r660, []
+  // group by w.web_site_id into g
+  Const        r661, "web_site_id"
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Const        r662, "d_date"
+  Const        r663, "d_date"
+  // channel: "web channel",
+  Const        r664, "channel"
+  // id: "web_site" + str(g.key),
+  Const        r665, "id"
+  Const        r666, "key"
+  // sales: sum(from x in g select x.ws.ws_ext_sales_price),
+  Const        r667, "sales"
+  Const        r668, "ws"
+  Const        r669, "ws_ext_sales_price"
+  // returns: 0.0,
+  Const        r670, "returns"
+  // profit: sum(from x in g select x.ws.ws_net_profit),
+  Const        r671, "profit"
+  Const        r672, "ws"
+  Const        r673, "ws_net_profit"
+  // profit_loss: 0.0
+  Const        r674, "profit_loss"
+  // from ws in web_sales
   MakeMap      r675, 0, r0
   Const        r676, []
   IterPrep     r678, r6
   Len          r679, r678
   Const        r680, 0
-L66:
+L68:
   LessInt      r681, r680, r679
-  JumpIfFalse  r681, L58
+  JumpIfFalse  r681, L60
   Index        r683, r678, r680
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   IterPrep     r684, r9
   Len          r685, r684
   Const        r686, 0
-L65:
+L67:
   LessInt      r687, r686, r685
-  JumpIfFalse  r687, L59
+  JumpIfFalse  r687, L61
   Index        r689, r684, r686
   Const        r690, "ws_sold_date_sk"
   Index        r691, r683, r690
   Const        r692, "d_date_sk"
   Index        r693, r689, r692
   Equal        r694, r691, r693
-  JumpIfFalse  r694, L60
+  JumpIfFalse  r694, L62
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
   IterPrep     r695, r8
   Len          r696, r695
   Const        r697, 0
-L64:
+L66:
   LessInt      r698, r697, r696
-  JumpIfFalse  r698, L60
+  JumpIfFalse  r698, L62
   Index        r700, r695, r697
   Const        r701, "ws_web_site_sk"
   Index        r702, r683, r701
   Const        r703, "web_site_sk"
   Index        r704, r700, r703
   Equal        r705, r702, r704
-  JumpIfFalse  r705, L61
+  JumpIfFalse  r705, L63
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
   Const        r706, "d_date"
   Index        r707, r689, r706
@@ -868,10 +1019,10 @@ L64:
   Const        r712, "1998-12-15"
   LessEq       r713, r711, r712
   Move         r714, r709
-  JumpIfFalse  r714, L62
+  JumpIfFalse  r714, L64
   Move         r714, r713
-L62:
-  JumpIfFalse  r714, L61
+L64:
+  JumpIfFalse  r714, L63
   // from ws in web_sales
   Const        r715, "ws"
   Move         r716, r683
@@ -885,7 +1036,7 @@ L62:
   Index        r723, r700, r722
   Str          r724, r723
   In           r725, r724, r675
-  JumpIfTrue   r725, L63
+  JumpIfTrue   r725, L65
   // from ws in web_sales
   Const        r726, []
   Const        r727, "__group__"
@@ -909,7 +1060,7 @@ L62:
   MakeMap      r743, 4, r735
   SetIndex     r675, r724, r743
   Append       r676, r676, r743
-L63:
+L65:
   Const        r745, "items"
   Index        r746, r675, r724
   Index        r747, r746, r745
@@ -920,27 +1071,27 @@ L63:
   Const        r751, 1
   AddInt       r752, r750, r751
   SetIndex     r746, r749, r752
-L61:
+L63:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
   Const        r753, 1
   AddInt       r697, r697, r753
-  Jump         L64
-L60:
+  Jump         L66
+L62:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
   Const        r754, 1
   AddInt       r686, r686, r754
-  Jump         L65
-L59:
+  Jump         L67
+L61:
   // from ws in web_sales
   Const        r755, 1
   AddInt       r680, r680, r755
-  Jump         L66
-L58:
+  Jump         L68
+L60:
   Const        r756, 0
   Len          r758, r676
-L72:
+L74:
   LessInt      r759, r756, r758
-  JumpIfFalse  r759, L67
+  JumpIfFalse  r759, L69
   Index        r111, r676, r756
   // channel: "web channel",
   Const        r761, "channel"
@@ -955,12 +1106,14 @@ L72:
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
   Const        r769, "sales"
   Const        r770, []
+  Const        r771, "ws"
+  Const        r772, "ws_ext_sales_price"
   IterPrep     r773, r111
   Len          r774, r773
   Const        r775, 0
-L69:
+L71:
   LessInt      r777, r775, r774
-  JumpIfFalse  r777, L68
+  JumpIfFalse  r777, L70
   Index        r130, r773, r775
   Const        r779, "ws"
   Index        r780, r130, r779
@@ -969,8 +1122,8 @@ L69:
   Append       r770, r770, r782
   Const        r784, 1
   AddInt       r775, r775, r784
-  Jump         L69
-L68:
+  Jump         L71
+L70:
   Sum          r785, r770
   // returns: 0.0,
   Const        r786, "returns"
@@ -978,12 +1131,14 @@ L68:
   // profit: sum(from x in g select x.ws.ws_net_profit),
   Const        r788, "profit"
   Const        r789, []
+  Const        r790, "ws"
+  Const        r791, "ws_net_profit"
   IterPrep     r792, r111
   Len          r793, r792
   Const        r794, 0
-L71:
+L73:
   LessInt      r796, r794, r793
-  JumpIfFalse  r796, L70
+  JumpIfFalse  r796, L72
   Index        r130, r792, r794
   Const        r798, "ws"
   Index        r799, r130, r798
@@ -992,8 +1147,8 @@ L71:
   Append       r789, r789, r801
   Const        r803, 1
   AddInt       r794, r794, r803
-  Jump         L71
-L70:
+  Jump         L73
+L72:
   Sum          r804, r789
   // profit_loss: 0.0
   Const        r805, "profit_loss"
@@ -1022,26 +1177,49 @@ L70:
   Append       r660, r660, r819
   Const        r821, 1
   AddInt       r756, r756, r821
-  Jump         L72
-L67:
+  Jump         L74
+L69:
   // from wr in web_returns
   Const        r822, []
+  // group by w.web_site_id into g
+  Const        r823, "web_site_id"
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Const        r824, "d_date"
+  Const        r825, "d_date"
+  // channel: "web channel",
+  Const        r826, "channel"
+  // id: "web_site" + str(g.key),
+  Const        r827, "id"
+  Const        r828, "key"
+  // sales: 0.0,
+  Const        r829, "sales"
+  // returns: sum(from x in g select x.wr.wr_return_amt),
+  Const        r830, "returns"
+  Const        r831, "wr"
+  Const        r832, "wr_return_amt"
+  // profit: 0.0,
+  Const        r833, "profit"
+  // profit_loss: sum(from x in g select x.wr.wr_net_loss)
+  Const        r834, "profit_loss"
+  Const        r835, "wr"
+  Const        r836, "wr_net_loss"
+  // from wr in web_returns
   MakeMap      r837, 0, r0
   Const        r838, []
   IterPrep     r840, r7
   Len          r841, r840
   Const        r842, 0
-L84:
+L86:
   LessInt      r843, r842, r841
-  JumpIfFalse  r843, L73
+  JumpIfFalse  r843, L75
   Index        r845, r840, r842
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
   IterPrep     r846, r6
   Len          r847, r846
   Const        r848, 0
-L83:
+L85:
   LessInt      r849, r848, r847
-  JumpIfFalse  r849, L74
+  JumpIfFalse  r849, L76
   Index        r660, r846, r848
   Const        r851, "wr_item_sk"
   Index        r852, r845, r851
@@ -1054,38 +1232,38 @@ L83:
   Index        r859, r660, r858
   Equal        r860, r857, r859
   Move         r861, r855
-  JumpIfFalse  r861, L75
+  JumpIfFalse  r861, L77
   Move         r861, r860
-L75:
-  JumpIfFalse  r861, L76
+L77:
+  JumpIfFalse  r861, L78
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
   IterPrep     r862, r9
   Len          r863, r862
   Const        r864, 0
-L82:
+L84:
   LessInt      r865, r864, r863
-  JumpIfFalse  r865, L76
+  JumpIfFalse  r865, L78
   Index        r867, r862, r864
   Const        r868, "wr_returned_date_sk"
   Index        r869, r845, r868
   Const        r870, "d_date_sk"
   Index        r871, r867, r870
   Equal        r872, r869, r871
-  JumpIfFalse  r872, L77
+  JumpIfFalse  r872, L79
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
   IterPrep     r873, r8
   Len          r874, r873
   Const        r875, 0
-L81:
+L83:
   LessInt      r876, r875, r874
-  JumpIfFalse  r876, L77
+  JumpIfFalse  r876, L79
   Index        r878, r873, r875
   Const        r879, "ws_web_site_sk"
   Index        r880, r660, r879
   Const        r881, "web_site_sk"
   Index        r882, r878, r881
   Equal        r883, r880, r882
-  JumpIfFalse  r883, L78
+  JumpIfFalse  r883, L80
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
   Const        r884, "d_date"
   Index        r885, r867, r884
@@ -1096,10 +1274,10 @@ L81:
   Const        r890, "1998-12-15"
   LessEq       r891, r889, r890
   Move         r892, r887
-  JumpIfFalse  r892, L79
+  JumpIfFalse  r892, L81
   Move         r892, r891
-L79:
-  JumpIfFalse  r892, L78
+L81:
+  JumpIfFalse  r892, L80
   // from wr in web_returns
   Const        r893, "wr"
   Move         r894, r845
@@ -1115,7 +1293,7 @@ L79:
   Index        r903, r878, r902
   Str          r904, r903
   In           r905, r904, r837
-  JumpIfTrue   r905, L80
+  JumpIfTrue   r905, L82
   // from wr in web_returns
   Const        r906, []
   Const        r907, "__group__"
@@ -1139,7 +1317,7 @@ L79:
   MakeMap      r923, 4, r915
   SetIndex     r837, r904, r923
   Append       r838, r838, r923
-L80:
+L82:
   Const        r925, "items"
   Index        r926, r837, r904
   Index        r927, r926, r925
@@ -1150,32 +1328,32 @@ L80:
   Const        r931, 1
   AddInt       r932, r930, r931
   SetIndex     r926, r929, r932
-L78:
+L80:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
   Const        r933, 1
   AddInt       r875, r875, r933
-  Jump         L81
-L77:
+  Jump         L83
+L79:
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
   Const        r934, 1
   AddInt       r864, r864, r934
-  Jump         L82
-L76:
+  Jump         L84
+L78:
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
   Const        r935, 1
   AddInt       r848, r848, r935
-  Jump         L83
-L74:
+  Jump         L85
+L76:
   // from wr in web_returns
   Const        r936, 1
   AddInt       r842, r842, r936
-  Jump         L84
-L73:
+  Jump         L86
+L75:
   Const        r937, 0
   Len          r939, r838
-L90:
+L92:
   LessInt      r940, r937, r939
-  JumpIfFalse  r940, L85
+  JumpIfFalse  r940, L87
   Index        r111, r838, r937
   // channel: "web channel",
   Const        r942, "channel"
@@ -1193,20 +1371,24 @@ L90:
   // returns: sum(from x in g select x.wr.wr_return_amt),
   Const        r952, "returns"
   Const        r953, []
+  Const        r954, "wr"
+  Const        r955, "wr_return_amt"
   IterPrep     r956, r111
   Len          r957, r956
   Const        r958, 0
-L87:
+L89:
   LessInt      r960, r958, r957
-  JumpIfFalse  r960, L86
+  JumpIfFalse  r960, L88
   Index        r130, r956, r958
   Const        r962, "wr"
   Index        r963, r130, r962
   Const        r964, "wr_return_amt"
   Index        r965, r963, r964
   Append       r953, r953, r965
-  Jump         L87
-L86:
+  Const        r967, 1
+  AddInt       r958, r958, r967
+  Jump         L89
+L88:
   Sum          r968, r953
   // profit: 0.0,
   Const        r969, "profit"
@@ -1214,20 +1396,24 @@ L86:
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
   Const        r971, "profit_loss"
   Const        r972, []
+  Const        r973, "wr"
+  Const        r974, "wr_net_loss"
   IterPrep     r975, r111
   Len          r976, r975
   Const        r977, 0
-L89:
+L91:
   LessInt      r979, r977, r976
-  JumpIfFalse  r979, L88
+  JumpIfFalse  r979, L90
   Index        r130, r975, r977
   Const        r981, "wr"
   Index        r982, r130, r981
   Const        r983, "wr_net_loss"
   Index        r984, r982, r983
   Append       r972, r972, r984
-  Jump         L89
-L88:
+  Const        r986, 1
+  AddInt       r977, r977, r986
+  Jump         L91
+L90:
   Sum          r987, r972
   // channel: "web channel",
   Move         r988, r942
@@ -1253,8 +1439,8 @@ L88:
   Append       r822, r822, r1000
   Const        r1002, 1
   AddInt       r937, r937, r1002
-  Jump         L90
-L85:
+  Jump         L92
+L87:
   // let per_channel = concat(ss union all sr, cs union all cr, ws union all wr)
   UnionAll     r1003, r10, r174
   UnionAll     r1004, r336, r498
@@ -1263,14 +1449,45 @@ L85:
   UnionAll     r1007, r1005, r1006
   // from p in per_channel
   Const        r1008, []
+  // group by { channel: p.channel, id: p.id } into g
+  Const        r1009, "channel"
+  Const        r1010, "channel"
+  Const        r1011, "id"
+  Const        r1012, "id"
+  // channel: g.key.channel,
+  Const        r1013, "channel"
+  Const        r1014, "key"
+  Const        r1015, "channel"
+  // id: g.key.id,
+  Const        r1016, "id"
+  Const        r1017, "key"
+  Const        r1018, "id"
+  // sales: sum(from x in g select x.p.sales),
+  Const        r1019, "sales"
+  Const        r1020, "p"
+  Const        r1021, "sales"
+  // returns: sum(from x in g select x.p.returns),
+  Const        r1022, "returns"
+  Const        r1023, "p"
+  Const        r1024, "returns"
+  // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
+  Const        r1025, "profit"
+  Const        r1026, "p"
+  Const        r1027, "profit"
+  Const        r1028, "p"
+  Const        r1029, "profit_loss"
+  // sort by g.key.channel
+  Const        r1030, "key"
+  Const        r1031, "channel"
+  // from p in per_channel
   IterPrep     r1032, r1007
   Len          r1033, r1032
   Const        r1034, 0
   MakeMap      r1035, 0, r0
   Const        r1036, []
-L93:
+L95:
   LessInt      r1038, r1034, r1033
-  JumpIfFalse  r1038, L91
+  JumpIfFalse  r1038, L93
   Index        r1039, r1032, r1034
   Move         r1040, r1039
   // group by { channel: p.channel, id: p.id } into g
@@ -1287,7 +1504,7 @@ L93:
   MakeMap      r1051, 2, r1047
   Str          r1052, r1051
   In           r1053, r1052, r1035
-  JumpIfTrue   r1053, L92
+  JumpIfTrue   r1053, L94
   // from p in per_channel
   Const        r1054, []
   Const        r1055, "__group__"
@@ -1311,7 +1528,7 @@ L93:
   MakeMap      r1071, 4, r1063
   SetIndex     r1035, r1052, r1071
   Append       r1036, r1036, r1071
-L92:
+L94:
   Const        r1073, "items"
   Index        r1074, r1035, r1052
   Index        r1075, r1074, r1073
@@ -1324,13 +1541,13 @@ L92:
   SetIndex     r1074, r1077, r1080
   Const        r1081, 1
   AddInt       r1034, r1034, r1081
-  Jump         L93
-L91:
+  Jump         L95
+L93:
   Const        r1082, 0
   Len          r1084, r1036
-L103:
+L105:
   LessInt      r1085, r1082, r1084
-  JumpIfFalse  r1085, L94
+  JumpIfFalse  r1085, L96
   Index        r111, r1036, r1082
   // channel: g.key.channel,
   Const        r1087, "channel"
@@ -1347,12 +1564,14 @@ L103:
   // sales: sum(from x in g select x.p.sales),
   Const        r1097, "sales"
   Const        r1098, []
+  Const        r1099, "p"
+  Const        r1100, "sales"
   IterPrep     r1101, r111
   Len          r1102, r1101
   Const        r1103, 0
-L96:
+L98:
   LessInt      r1105, r1103, r1102
-  JumpIfFalse  r1105, L95
+  JumpIfFalse  r1105, L97
   Index        r130, r1101, r1103
   Const        r1107, "p"
   Index        r1108, r130, r1107
@@ -1361,18 +1580,20 @@ L96:
   Append       r1098, r1098, r1110
   Const        r1112, 1
   AddInt       r1103, r1103, r1112
-  Jump         L96
-L95:
+  Jump         L98
+L97:
   Sum          r1113, r1098
   // returns: sum(from x in g select x.p.returns),
   Const        r1114, "returns"
   Const        r1115, []
+  Const        r1116, "p"
+  Const        r1117, "returns"
   IterPrep     r1118, r111
   Len          r1119, r1118
   Const        r1120, 0
-L98:
+L100:
   LessInt      r1122, r1120, r1119
-  JumpIfFalse  r1122, L97
+  JumpIfFalse  r1122, L99
   Index        r130, r1118, r1120
   Const        r1124, "p"
   Index        r1125, r130, r1124
@@ -1381,18 +1602,20 @@ L98:
   Append       r1115, r1115, r1127
   Const        r1129, 1
   AddInt       r1120, r1120, r1129
-  Jump         L98
-L97:
+  Jump         L100
+L99:
   Sum          r1130, r1115
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
   Const        r1131, "profit"
   Const        r1132, []
+  Const        r1133, "p"
+  Const        r1134, "profit"
   IterPrep     r1135, r111
   Len          r1136, r1135
   Const        r1137, 0
-L100:
+L102:
   LessInt      r1139, r1137, r1136
-  JumpIfFalse  r1139, L99
+  JumpIfFalse  r1139, L101
   Index        r130, r1135, r1137
   Const        r1141, "p"
   Index        r1142, r130, r1141
@@ -1401,16 +1624,18 @@ L100:
   Append       r1132, r1132, r1144
   Const        r1146, 1
   AddInt       r1137, r1137, r1146
-  Jump         L100
-L99:
+  Jump         L102
+L101:
   Sum          r1147, r1132
   Const        r1148, []
+  Const        r1149, "p"
+  Const        r1150, "profit_loss"
   IterPrep     r1151, r111
   Len          r1152, r1151
   Const        r1153, 0
-L102:
+L104:
   LessInt      r1155, r1153, r1152
-  JumpIfFalse  r1155, L101
+  JumpIfFalse  r1155, L103
   Index        r130, r1151, r1153
   Const        r1157, "p"
   Index        r1158, r130, r1157
@@ -1419,8 +1644,8 @@ L102:
   Append       r1148, r1148, r1160
   Const        r1162, 1
   AddInt       r1153, r1153, r1162
-  Jump         L102
-L101:
+  Jump         L104
+L103:
   Sum          r1163, r1148
   Sub          r1164, r1147, r1163
   // channel: g.key.channel,
@@ -1451,8 +1676,8 @@ L101:
   Append       r1008, r1008, r1182
   Const        r1184, 1
   AddInt       r1082, r1082, r1184
-  Jump         L103
-L94:
+  Jump         L105
+L96:
   // sort by g.key.channel
   Sort         r1008, r1008
   // json(result)

--- a/tests/dataset/tpc-ds/out/q6.ir.out
+++ b/tests/dataset/tpc-ds/out/q6.ir.out
@@ -11,6 +11,12 @@ func main (regs=210)
   Const        r4, []
   // from d in date_dim
   Const        r5, []
+  // where d.d_year == 1999 && d.d_moy == 5
+  Const        r6, "d_year"
+  Const        r7, "d_moy"
+  // select d.d_month_seq
+  Const        r8, "d_month_seq"
+  // from d in date_dim
   IterPrep     r9, r3
   Len          r10, r9
   Const        r11, 0
@@ -46,6 +52,24 @@ L0:
   Max          r29, r5
   // from a in customer_address
   Const        r30, []
+  // group by a.ca_state into g
+  Const        r31, "ca_state"
+  // where d.d_month_seq == target_month_seq &&
+  Const        r32, "d_month_seq"
+  // i.i_current_price > 1.2 * avg(
+  Const        r33, "i_current_price"
+  // where j.i_category == i.i_category
+  Const        r34, "i_category"
+  Const        r35, "i_category"
+  // select j.i_current_price
+  Const        r36, "i_current_price"
+  // select { state: g.key, cnt: count(g) }
+  Const        r37, "state"
+  Const        r38, "key"
+  Const        r39, "cnt"
+  // sort by [count(g), g.key]
+  Const        r40, "key"
+  // from a in customer_address
   MakeMap      r41, 0, r0
   Const        r42, []
   IterPrep     r44, r0
@@ -118,6 +142,12 @@ L15:
   Const        r95, 1.2
   // from j in item
   Const        r96, []
+  // where j.i_category == i.i_category
+  Const        r97, "i_category"
+  Const        r98, "i_category"
+  // select j.i_current_price
+  Const        r99, "i_current_price"
+  // from j in item
   IterPrep     r100, r4
   Len          r101, r100
   Const        r102, 0
@@ -260,6 +290,7 @@ L21:
   Const        r191, "count"
   Index        r193, r175, r191
   Const        r194, "key"
+  Index        r196, r175, r194
   MakeList     r198, 2, r193
   // from a in customer_address
   Move         r199, r190

--- a/tests/dataset/tpc-ds/out/q7.ir.out
+++ b/tests/dataset/tpc-ds/out/q7.ir.out
@@ -11,12 +11,50 @@ func main (regs=268)
   Const        r4, []
   // from ss in store_sales
   Const        r5, []
+  // group by { i_item_id: i.i_item_id } into g
+  Const        r6, "i_item_id"
+  Const        r7, "i_item_id"
+  // where cd.cd_gender == "M" &&
+  Const        r8, "cd_gender"
+  // cd.cd_marital_status == "S" &&
+  Const        r9, "cd_marital_status"
+  // cd.cd_education_status == "College" &&
+  Const        r10, "cd_education_status"
+  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
+  Const        r11, "p_channel_email"
+  Const        r12, "p_channel_event"
+  // d.d_year == 1998
+  Const        r13, "d_year"
+  // i_item_id: g.key.i_item_id,
+  Const        r14, "i_item_id"
+  Const        r15, "key"
+  Const        r16, "i_item_id"
+  // agg1: avg(from x in g select x.ss.ss_quantity),
+  Const        r17, "agg1"
+  Const        r18, "ss"
+  Const        r19, "ss_quantity"
+  // agg2: avg(from x in g select x.ss.ss_list_price),
+  Const        r20, "agg2"
+  Const        r21, "ss"
+  Const        r22, "ss_list_price"
+  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
+  Const        r23, "agg3"
+  Const        r24, "ss"
+  Const        r25, "ss_coupon_amt"
+  // agg4: avg(from x in g select x.ss.ss_sales_price)
+  Const        r26, "agg4"
+  Const        r27, "ss"
+  Const        r28, "ss_sales_price"
+  // sort by g.key.i_item_id
+  Const        r29, "key"
+  Const        r30, "i_item_id"
+  // from ss in store_sales
   MakeMap      r31, 0, r0
   Const        r32, []
   IterPrep     r34, r0
   Len          r35, r34
   Const        r36, 0
-L1:
+L15:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L0
   Index        r39, r34, r36
@@ -24,7 +62,7 @@ L1:
   IterPrep     r40, r1
   Len          r41, r40
   Const        r42, 0
-L2:
+L14:
   LessInt      r43, r42, r41
   JumpIfFalse  r43, L1
   Index        r45, r40, r42
@@ -196,13 +234,22 @@ L3:
   Const        r161, 1
   AddInt       r53, r53, r161
   Jump         L13
-L0:
+L2:
+  // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
+  Const        r162, 1
+  AddInt       r42, r42, r162
+  Jump         L14
+L1:
   // from ss in store_sales
+  Const        r163, 1
+  AddInt       r36, r36, r163
+  Jump         L15
+L0:
   Const        r164, 0
   Len          r166, r32
-L23:
+L25:
   LessInt      r167, r164, r166
-  JumpIfFalse  r167, L14
+  JumpIfFalse  r167, L16
   Index        r169, r32, r164
   // i_item_id: g.key.i_item_id,
   Const        r170, "i_item_id"
@@ -212,26 +259,37 @@ L23:
   Index        r174, r172, r173
   // agg1: avg(from x in g select x.ss.ss_quantity),
   Const        r175, "agg1"
+  Const        r176, []
+  Const        r177, "ss"
+  Const        r178, "ss_quantity"
   IterPrep     r179, r169
   Len          r180, r179
   Const        r181, 0
-L16:
+L18:
   LessInt      r183, r181, r180
-  JumpIfFalse  r183, L15
+  JumpIfFalse  r183, L17
+  Index        r185, r179, r181
+  Const        r186, "ss"
+  Index        r187, r185, r186
+  Const        r188, "ss_quantity"
+  Index        r189, r187, r188
+  Append       r176, r176, r189
   Const        r191, 1
   AddInt       r181, r181, r191
-  Jump         L16
-L15:
-  Const        r192, 0
+  Jump         L18
+L17:
+  Avg          r192, r176
   // agg2: avg(from x in g select x.ss.ss_list_price),
   Const        r193, "agg2"
   Const        r194, []
+  Const        r195, "ss"
+  Const        r196, "ss_list_price"
   IterPrep     r197, r169
   Len          r198, r197
   Const        r199, 0
-L18:
+L20:
   LessInt      r201, r199, r198
-  JumpIfFalse  r201, L17
+  JumpIfFalse  r201, L19
   Index        r185, r197, r199
   Const        r203, "ss"
   Index        r204, r185, r203
@@ -240,18 +298,20 @@ L18:
   Append       r194, r194, r206
   Const        r208, 1
   AddInt       r199, r199, r208
-  Jump         L18
-L17:
+  Jump         L20
+L19:
   Avg          r209, r194
   // agg3: avg(from x in g select x.ss.ss_coupon_amt),
   Const        r210, "agg3"
   Const        r211, []
+  Const        r212, "ss"
+  Const        r213, "ss_coupon_amt"
   IterPrep     r214, r169
   Len          r215, r214
   Const        r216, 0
-L20:
+L22:
   LessInt      r218, r216, r215
-  JumpIfFalse  r218, L19
+  JumpIfFalse  r218, L21
   Index        r185, r214, r216
   Const        r220, "ss"
   Index        r221, r185, r220
@@ -260,18 +320,20 @@ L20:
   Append       r211, r211, r223
   Const        r225, 1
   AddInt       r216, r216, r225
-  Jump         L20
-L19:
+  Jump         L22
+L21:
   Avg          r226, r211
   // agg4: avg(from x in g select x.ss.ss_sales_price)
   Const        r227, "agg4"
   Const        r228, []
+  Const        r229, "ss"
+  Const        r230, "ss_sales_price"
   IterPrep     r231, r169
   Len          r232, r231
   Const        r233, 0
-L22:
+L24:
   LessInt      r235, r233, r232
-  JumpIfFalse  r235, L21
+  JumpIfFalse  r235, L23
   Index        r185, r231, r233
   Const        r237, "ss"
   Index        r238, r185, r237
@@ -280,8 +342,8 @@ L22:
   Append       r228, r228, r240
   Const        r242, 1
   AddInt       r233, r233, r242
-  Jump         L22
-L21:
+  Jump         L24
+L23:
   Avg          r243, r228
   // i_item_id: g.key.i_item_id,
   Move         r244, r170
@@ -311,8 +373,8 @@ L21:
   Append       r5, r5, r261
   Const        r263, 1
   AddInt       r164, r164, r263
-  Jump         L23
-L14:
+  Jump         L25
+L16:
   // sort by g.key.i_item_id
   Sort         r5, r5
   // json(result)

--- a/tests/dataset/tpc-ds/out/q8.ir.out
+++ b/tests/dataset/tpc-ds/out/q8.ir.out
@@ -1,11 +1,23 @@
 func main (regs=10)
   // let store_sales = []
   Const        r0, []
+  // let date_dim = []
+  Const        r1, []
+  // let store = []
+  Const        r2, []
+  // let customer_address = []
+  Const        r3, []
+  // let customer = []
+  Const        r4, []
+  // substr("zip", 0, 2)
+  Const        r5, "zi"
   // let result = []
   Const        r6, []
   // json(result)
   JSON         r6
   // expect len(result) == 0
+  Const        r7, 0
+  Const        r8, 0
   Const        r9, true
   Expect       r9
   Return       r0

--- a/tests/dataset/tpc-ds/out/q9.ir.out
+++ b/tests/dataset/tpc-ds/out/q9.ir.out
@@ -5,6 +5,10 @@ func main (regs=402)
   Const        r1, []
   // if count(from s in store_sales
   Const        r2, []
+  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
+  Const        r3, "ss_quantity"
+  Const        r4, "ss_quantity"
+  // if count(from s in store_sales
   IterPrep     r5, r0
   Len          r6, r5
   Const        r7, 0
@@ -41,6 +45,12 @@ L0:
   JumpIfFalse  r25, L4
   // avg(from s in store_sales
   Const        r26, []
+  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
+  Const        r27, "ss_quantity"
+  Const        r28, "ss_quantity"
+  // select s.ss_ext_discount_amt)
+  Const        r29, "ss_ext_discount_amt"
+  // avg(from s in store_sales
   IterPrep     r30, r0
   Len          r31, r30
   Const        r32, 0
@@ -78,6 +88,12 @@ L5:
 L4:
   // avg(from s in store_sales
   Const        r51, []
+  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
+  Const        r52, "ss_quantity"
+  Const        r53, "ss_quantity"
+  // select s.ss_net_paid)
+  Const        r54, "ss_net_paid"
+  // avg(from s in store_sales
   IterPrep     r55, r0
   Len          r56, r55
   Const        r57, 0
@@ -113,6 +129,10 @@ L10:
 L9:
   // if count(from s in store_sales
   Const        r75, []
+  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
+  Const        r76, "ss_quantity"
+  Const        r77, "ss_quantity"
+  // if count(from s in store_sales
   IterPrep     r78, r0
   Len          r79, r78
   Const        r80, 0
@@ -149,6 +169,12 @@ L14:
   JumpIfFalse  r97, L18
   // avg(from s in store_sales
   Const        r98, []
+  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
+  Const        r99, "ss_quantity"
+  Const        r100, "ss_quantity"
+  // select s.ss_ext_discount_amt)
+  Const        r101, "ss_ext_discount_amt"
+  // avg(from s in store_sales
   IterPrep     r102, r0
   Len          r103, r102
   Const        r104, 0
@@ -186,6 +212,12 @@ L19:
 L18:
   // avg(from s in store_sales
   Const        r123, []
+  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
+  Const        r124, "ss_quantity"
+  Const        r125, "ss_quantity"
+  // select s.ss_net_paid)
+  Const        r126, "ss_net_paid"
+  // avg(from s in store_sales
   IterPrep     r127, r0
   Len          r128, r127
   Const        r129, 0
@@ -221,6 +253,10 @@ L24:
 L23:
   // if count(from s in store_sales
   Const        r147, []
+  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
+  Const        r148, "ss_quantity"
+  Const        r149, "ss_quantity"
+  // if count(from s in store_sales
   IterPrep     r150, r0
   Len          r151, r150
   Const        r152, 0
@@ -257,6 +293,12 @@ L28:
   JumpIfFalse  r169, L32
   // avg(from s in store_sales
   Const        r170, []
+  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
+  Const        r171, "ss_quantity"
+  Const        r172, "ss_quantity"
+  // select s.ss_ext_discount_amt)
+  Const        r173, "ss_ext_discount_amt"
+  // avg(from s in store_sales
   IterPrep     r174, r0
   Len          r175, r174
   Const        r176, 0
@@ -294,6 +336,12 @@ L33:
 L32:
   // avg(from s in store_sales
   Const        r195, []
+  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
+  Const        r196, "ss_quantity"
+  Const        r197, "ss_quantity"
+  // select s.ss_net_paid)
+  Const        r198, "ss_net_paid"
+  // avg(from s in store_sales
   IterPrep     r199, r0
   Len          r200, r199
   Const        r201, 0
@@ -329,6 +377,10 @@ L38:
 L37:
   // if count(from s in store_sales
   Const        r219, []
+  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
+  Const        r220, "ss_quantity"
+  Const        r221, "ss_quantity"
+  // if count(from s in store_sales
   IterPrep     r222, r0
   Len          r223, r222
   Const        r224, 0
@@ -365,6 +417,12 @@ L42:
   JumpIfFalse  r241, L46
   // avg(from s in store_sales
   Const        r242, []
+  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
+  Const        r243, "ss_quantity"
+  Const        r244, "ss_quantity"
+  // select s.ss_ext_discount_amt)
+  Const        r245, "ss_ext_discount_amt"
+  // avg(from s in store_sales
   IterPrep     r246, r0
   Len          r247, r246
   Const        r248, 0
@@ -402,6 +460,12 @@ L47:
 L46:
   // avg(from s in store_sales
   Const        r267, []
+  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
+  Const        r268, "ss_quantity"
+  Const        r269, "ss_quantity"
+  // select s.ss_net_paid)
+  Const        r270, "ss_net_paid"
+  // avg(from s in store_sales
   IterPrep     r271, r0
   Len          r272, r271
   Const        r273, 0
@@ -437,6 +501,10 @@ L52:
 L51:
   // if count(from s in store_sales
   Const        r291, []
+  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
+  Const        r292, "ss_quantity"
+  Const        r293, "ss_quantity"
+  // if count(from s in store_sales
   IterPrep     r294, r0
   Len          r295, r294
   Const        r296, 0
@@ -473,6 +541,12 @@ L56:
   JumpIfFalse  r313, L60
   // avg(from s in store_sales
   Const        r314, []
+  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
+  Const        r315, "ss_quantity"
+  Const        r316, "ss_quantity"
+  // select s.ss_ext_discount_amt)
+  Const        r317, "ss_ext_discount_amt"
+  // avg(from s in store_sales
   IterPrep     r318, r0
   Len          r319, r318
   Const        r320, 0
@@ -510,6 +584,12 @@ L61:
 L60:
   // avg(from s in store_sales
   Const        r339, []
+  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
+  Const        r340, "ss_quantity"
+  Const        r341, "ss_quantity"
+  // select s.ss_net_paid)
+  Const        r342, "ss_net_paid"
+  // avg(from s in store_sales
   IterPrep     r343, r0
   Len          r344, r343
   Const        r345, 0
@@ -545,6 +625,19 @@ L66:
 L65:
   // from r in reason
   Const        r363, []
+  // where r.r_reason_sk == 1
+  Const        r364, "r_reason_sk"
+  // bucket1: bucket1,
+  Const        r365, "bucket1"
+  // bucket2: bucket2,
+  Const        r366, "bucket2"
+  // bucket3: bucket3,
+  Const        r367, "bucket3"
+  // bucket4: bucket4,
+  Const        r368, "bucket4"
+  // bucket5: bucket5
+  Const        r369, "bucket5"
+  // from r in reason
   IterPrep     r370, r1
   Len          r371, r370
   Const        r372, 0


### PR DESCRIPTION
## Summary
- add missing OpFirst case in disassembler
- regenerate IR golden outputs for TPC‑DS q1–q9

## Testing
- `go test ./...`
- `go test -tags=slow ./tests/vm -run TestVM_TPCDS/q1\.mochi -count=1 -update`
- `for i in {2..9}; do go test -tags=slow ./tests/vm -run TestVM_TPCDS/q${i}\.mochi -count=1 -update; done`

------
https://chatgpt.com/codex/tasks/task_e_68623c96ceac8320b073e316baeebb0a