### PR TITLE
Optimize VM concat and refresh TPC‑DS IR

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -7990,12 +7990,19 @@ func (fc *funcCompiler) foldCallValue(call *parser.CallExpr) (Value, bool) {
 			return Value{Tag: ValueInt, Int: int(maxVal)}, true
 		}
 	case "concat":
-		out := []Value{}
-		for _, v := range args {
+		// Preallocate the result list to avoid repeated allocations
+		lists := make([][]Value, len(args))
+		total := 0
+		for i, v := range args {
 			lst, ok := toList(v)
 			if !ok {
 				return Value{}, false
 			}
+			lists[i] = lst
+			total += len(lst)
+		}
+		out := make([]Value, 0, total)
+		for _, lst := range lists {
 			out = append(out, lst...)
 		}
 		return Value{Tag: ValueList, List: out}, true


### PR DESCRIPTION
## Summary
- optimize `concat` builtin in the VM to preallocate the result
- regenerate TPC‑DS IR output for queries q40–q49 with the updated runtime

## Testing
- `go test ./...`
- `go run tools/update_tpcds/main.go q40 q41 q42 q43 q44 q45 q46 q47 q48 q49`


------
https://chatgpt.com/codex/tasks/task_e_68623df878d083208a0a4c56ca992910