### PR TITLE
Update TPC‑DS q1‑q9 IR; minor VM builtin tweak

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1491,14 +1491,18 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			if m.Tag != ValueMap {
 				return Value{}, fmt.Errorf("values expects map")
 			}
+			if len(m.Map) == 0 {
+				fr.regs[ins.A] = Value{Tag: ValueList, List: []Value{}}
+				break
+			}
 			keys := make([]string, 0, len(m.Map))
 			for k := range m.Map {
 				keys = append(keys, k)
 			}
 			sort.Strings(keys)
-			vals := make([]Value, len(keys))
-			for i, k := range keys {
-				vals[i] = m.Map[k]
+			vals := make([]Value, 0, len(keys))
+			for _, k := range keys {
+				vals = append(vals, m.Map[k])
 			}
 			fr.regs[ins.A] = Value{Tag: ValueList, List: vals}
 		case OpCast:

--- a/tests/dataset/tpc-ds/out/q2.ir.out
+++ b/tests/dataset/tpc-ds/out/q2.ir.out
@@ -1,367 +1,463 @@
-func main (regs=261)
+func main (regs=325)
   // let web_sales = []
   Const        r0, []
   // let catalog_sales = []
   Const        r1, []
   // let date_dim = []
   Const        r2, []
-  // let wscs = []
+  // (from ws in web_sales
   Const        r3, []
-  // from w in wscs
-  Const        r4, []
-  // group by {week_seq: d.d_week_seq} into g
-  Const        r5, "week_seq"
-  Const        r6, "d_week_seq"
-  // d_week_seq: g.key.week_seq,
-  Const        r7, "d_week_seq"
-  Const        r8, "key"
-  Const        r9, "week_seq"
-  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Const        r10, "sun_sales"
-  Const        r11, "day"
-  Const        r12, "sales_price"
-  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Const        r13, "mon_sales"
-  Const        r14, "day"
-  Const        r15, "sales_price"
-  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Const        r16, "tue_sales"
-  Const        r17, "day"
-  Const        r18, "sales_price"
-  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Const        r19, "wed_sales"
-  Const        r20, "day"
-  Const        r21, "sales_price"
-  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Const        r22, "thu_sales"
-  Const        r23, "day"
-  Const        r24, "sales_price"
-  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Const        r25, "fri_sales"
-  Const        r26, "day"
-  Const        r27, "sales_price"
-  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Const        r28, "sat_sales"
-  Const        r29, "day"
-  Const        r30, "sales_price"
-  // from w in wscs
-  MakeMap      r31, 0, r0
-  Const        r32, []
-  IterPrep     r34, r3
-  Len          r35, r34
-  Const        r36, 0
-L5:
-  LessInt      r37, r36, r35
-  JumpIfFalse  r37, L0
-  Index        r39, r34, r36
-  // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  IterPrep     r40, r2
-  Len          r41, r40
-  Const        r42, 0
-L4:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L1
-  Index        r45, r40, r42
-  Const        r46, "sold_date_sk"
-  Index        r47, r39, r46
-  Const        r48, "d_date_sk"
-  Index        r49, r45, r48
-  Equal        r50, r47, r49
-  JumpIfFalse  r50, L2
-  // from w in wscs
-  Const        r51, "w"
-  Move         r52, r39
-  Const        r53, "d"
-  Move         r54, r45
-  MakeMap      r55, 2, r51
-  // group by {week_seq: d.d_week_seq} into g
-  Const        r56, "week_seq"
-  Const        r57, "d_week_seq"
-  Index        r58, r45, r57
-  Move         r59, r56
-  Move         r60, r58
-  MakeMap      r61, 1, r59
-  Str          r62, r61
-  In           r63, r62, r31
-  JumpIfTrue   r63, L3
-  // from w in wscs
-  Const        r64, []
-  Const        r65, "__group__"
-  Const        r66, true
-  Const        r67, "key"
-  // group by {week_seq: d.d_week_seq} into g
-  Move         r68, r61
-  // from w in wscs
-  Const        r69, "items"
-  Move         r70, r64
-  Const        r71, "count"
-  Const        r72, 0
-  Move         r73, r65
-  Move         r74, r66
-  Move         r75, r67
-  Move         r76, r68
-  Move         r77, r69
-  Move         r78, r70
-  Move         r79, r71
-  Move         r80, r72
-  MakeMap      r81, 4, r73
-  SetIndex     r31, r62, r81
-  Append       r32, r32, r81
-L3:
-  Const        r83, "items"
-  Index        r84, r31, r62
-  Index        r85, r84, r83
-  Append       r86, r85, r55
-  SetIndex     r84, r83, r86
-  Const        r87, "count"
-  Index        r88, r84, r87
-  Const        r89, 1
-  AddInt       r90, r88, r89
-  SetIndex     r84, r87, r90
-L2:
-  // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  Const        r91, 1
-  AddInt       r42, r42, r91
-  Jump         L4
+  // sold_date_sk: ws.ws_sold_date_sk,
+  Const        r4, "sold_date_sk"
+  Const        r5, "ws_sold_date_sk"
+  // sales_price: ws.ws_ext_sales_price,
+  Const        r6, "sales_price"
+  Const        r7, "ws_ext_sales_price"
+  // day: ws.ws_sold_date_name
+  Const        r8, "day"
+  Const        r9, "ws_sold_date_name"
+  // (from ws in web_sales
+  IterPrep     r10, r0
+  Len          r11, r10
+  Const        r12, 0
 L1:
-  // from w in wscs
-  Const        r92, 1
-  AddInt       r36, r36, r92
-  Jump         L5
-L0:
-  Const        r93, 0
-  Len          r95, r32
-L28:
-  LessInt      r96, r93, r95
-  JumpIfFalse  r96, L6
-  Index        r98, r32, r93
-  // d_week_seq: g.key.week_seq,
-  Const        r99, "d_week_seq"
-  Const        r100, "key"
-  Index        r101, r98, r100
-  Const        r102, "week_seq"
-  Index        r103, r101, r102
-  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Const        r104, "sun_sales"
-  Const        r105, []
-  Const        r106, "day"
-  Const        r107, "sales_price"
-  IterPrep     r108, r98
-  Len          r109, r108
-  Const        r110, 0
-L9:
-  LessInt      r112, r110, r109
-  JumpIfFalse  r112, L7
-  Index        r114, r108, r110
-  Const        r115, "day"
-  Index        r116, r114, r115
-  Const        r117, "Sunday"
-  Equal        r118, r116, r117
-  JumpIfFalse  r118, L8
-  Const        r119, "sales_price"
-  Index        r120, r114, r119
-  Append       r105, r105, r120
-L8:
-  Const        r122, 1
-  AddInt       r110, r110, r122
-  Jump         L9
-L7:
-  Sum          r123, r105
-  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Const        r124, "mon_sales"
-  Const        r125, []
-  Const        r126, "day"
-  Const        r127, "sales_price"
-  IterPrep     r128, r98
-  Len          r129, r128
-  Const        r130, 0
-L12:
-  LessInt      r132, r130, r129
-  JumpIfFalse  r132, L10
-  Index        r114, r128, r130
-  Const        r134, "day"
-  Index        r135, r114, r134
-  Const        r136, "Monday"
-  Equal        r137, r135, r136
-  JumpIfFalse  r137, L11
-  Const        r138, "sales_price"
-  Index        r139, r114, r138
-  Append       r125, r125, r139
-L11:
-  Const        r141, 1
-  AddInt       r130, r130, r141
-  Jump         L12
-L10:
-  Sum          r142, r125
-  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Const        r143, "tue_sales"
-  Const        r144, []
-  Const        r145, "day"
-  Const        r146, "sales_price"
-  IterPrep     r147, r98
-  Len          r148, r147
-  Const        r149, 0
-L15:
-  LessInt      r151, r149, r148
-  JumpIfFalse  r151, L13
-  Index        r114, r147, r149
-  Const        r153, "day"
-  Index        r154, r114, r153
-  Const        r155, "Tuesday"
-  Equal        r156, r154, r155
-  JumpIfFalse  r156, L14
-  Const        r157, "sales_price"
-  Index        r158, r114, r157
-  Append       r144, r144, r158
-L14:
-  Const        r160, 1
-  AddInt       r149, r149, r160
-  Jump         L15
-L13:
-  Sum          r161, r144
-  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Const        r162, "wed_sales"
-  Const        r163, []
-  Const        r164, "day"
-  Const        r165, "sales_price"
-  IterPrep     r166, r98
-  Len          r167, r166
-  Const        r168, 0
-L18:
-  LessInt      r170, r168, r167
-  JumpIfFalse  r170, L16
-  Index        r114, r166, r168
-  Const        r172, "day"
-  Index        r173, r114, r172
-  Const        r174, "Wednesday"
-  Equal        r175, r173, r174
-  JumpIfFalse  r175, L17
-  Const        r176, "sales_price"
-  Index        r177, r114, r176
-  Append       r163, r163, r177
-L17:
-  Const        r179, 1
-  AddInt       r168, r168, r179
-  Jump         L18
-L16:
-  Sum          r180, r163
-  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Const        r181, "thu_sales"
-  Const        r182, []
-  Const        r183, "day"
-  Const        r184, "sales_price"
-  IterPrep     r185, r98
-  Len          r186, r185
-  Const        r187, 0
-L21:
-  LessInt      r189, r187, r186
-  JumpIfFalse  r189, L19
-  Index        r114, r185, r187
-  Const        r191, "day"
-  Index        r192, r114, r191
-  Const        r193, "Thursday"
-  Equal        r194, r192, r193
-  JumpIfFalse  r194, L20
-  Const        r195, "sales_price"
-  Index        r196, r114, r195
-  Append       r182, r182, r196
-L20:
-  Const        r198, 1
-  AddInt       r187, r187, r198
-  Jump         L21
-L19:
-  Sum          r199, r182
-  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Const        r200, "fri_sales"
-  Const        r201, []
-  Const        r202, "day"
-  Const        r203, "sales_price"
-  IterPrep     r204, r98
-  Len          r205, r204
-  Const        r206, 0
-L24:
-  LessInt      r208, r206, r205
-  JumpIfFalse  r208, L22
-  Index        r114, r204, r206
-  Const        r210, "day"
-  Index        r211, r114, r210
-  Const        r212, "Friday"
-  Equal        r213, r211, r212
-  JumpIfFalse  r213, L23
-  Const        r214, "sales_price"
-  Index        r215, r114, r214
-  Append       r201, r201, r215
-L23:
-  Const        r217, 1
-  AddInt       r206, r206, r217
-  Jump         L24
-L22:
-  Sum          r218, r201
-  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Const        r219, "sat_sales"
-  Const        r220, []
-  Const        r221, "day"
-  Const        r222, "sales_price"
-  IterPrep     r223, r98
-  Len          r224, r223
-  Const        r225, 0
-L27:
-  LessInt      r227, r225, r224
-  JumpIfFalse  r227, L25
-  Index        r114, r223, r225
-  Const        r229, "day"
-  Index        r230, r114, r229
-  Const        r231, "Saturday"
-  Equal        r232, r230, r231
-  JumpIfFalse  r232, L26
-  Const        r233, "sales_price"
-  Index        r234, r114, r233
-  Append       r220, r220, r234
-L26:
-  Const        r236, 1
-  AddInt       r225, r225, r236
-  Jump         L27
-L25:
-  Sum          r237, r220
-  // d_week_seq: g.key.week_seq,
-  Move         r238, r99
-  Move         r239, r103
-  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Move         r240, r104
-  Move         r241, r123
-  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Move         r242, r124
-  Move         r243, r142
-  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Move         r244, r143
-  Move         r245, r161
-  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Move         r246, r162
-  Move         r247, r180
-  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Move         r248, r181
-  Move         r249, r199
-  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Move         r250, r200
-  Move         r251, r218
-  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Move         r252, r219
-  Move         r253, r237
+  LessInt      r14, r12, r11
+  JumpIfFalse  r14, L0
+  Index        r16, r10, r12
+  // sold_date_sk: ws.ws_sold_date_sk,
+  Const        r17, "sold_date_sk"
+  Const        r18, "ws_sold_date_sk"
+  Index        r19, r16, r18
+  // sales_price: ws.ws_ext_sales_price,
+  Const        r20, "sales_price"
+  Const        r21, "ws_ext_sales_price"
+  Index        r22, r16, r21
+  // day: ws.ws_sold_date_name
+  Const        r23, "day"
+  Const        r24, "ws_sold_date_name"
+  Index        r25, r16, r24
+  // sold_date_sk: ws.ws_sold_date_sk,
+  Move         r26, r17
+  Move         r27, r19
+  // sales_price: ws.ws_ext_sales_price,
+  Move         r28, r20
+  Move         r29, r22
+  // day: ws.ws_sold_date_name
+  Move         r30, r23
+  Move         r31, r25
   // select {
-  MakeMap      r254, 8, r238
+  MakeMap      r32, 3, r26
+  // (from ws in web_sales
+  Append       r3, r3, r32
+  Const        r34, 1
+  AddInt       r12, r12, r34
+  Jump         L1
+L0:
+  // from cs in catalog_sales
+  Const        r35, []
+  // sold_date_sk: cs.cs_sold_date_sk,
+  Const        r36, "sold_date_sk"
+  Const        r37, "cs_sold_date_sk"
+  // sales_price: cs.cs_ext_sales_price,
+  Const        r38, "sales_price"
+  Const        r39, "cs_ext_sales_price"
+  // day: cs.cs_sold_date_name
+  Const        r40, "day"
+  Const        r41, "cs_sold_date_name"
+  // from cs in catalog_sales
+  IterPrep     r42, r1
+  Len          r43, r42
+  Const        r44, 0
+L3:
+  LessInt      r46, r44, r43
+  JumpIfFalse  r46, L2
+  Index        r48, r42, r44
+  // sold_date_sk: cs.cs_sold_date_sk,
+  Const        r49, "sold_date_sk"
+  Const        r50, "cs_sold_date_sk"
+  Index        r51, r48, r50
+  // sales_price: cs.cs_ext_sales_price,
+  Const        r52, "sales_price"
+  Const        r53, "cs_ext_sales_price"
+  Index        r54, r48, r53
+  // day: cs.cs_sold_date_name
+  Const        r55, "day"
+  Const        r56, "cs_sold_date_name"
+  Index        r57, r48, r56
+  // sold_date_sk: cs.cs_sold_date_sk,
+  Move         r58, r49
+  Move         r59, r51
+  // sales_price: cs.cs_ext_sales_price,
+  Move         r60, r52
+  Move         r61, r54
+  // day: cs.cs_sold_date_name
+  Move         r62, r55
+  Move         r63, r57
+  // select {
+  MakeMap      r64, 3, r58
+  // from cs in catalog_sales
+  Append       r35, r35, r64
+  Const        r66, 1
+  AddInt       r44, r44, r66
+  Jump         L3
+L2:
+  // }) union all (
+  UnionAll     r67, r3, r35
   // from w in wscs
-  Append       r4, r4, r254
-  Const        r256, 1
-  AddInt       r93, r93, r256
-  Jump         L28
+  Const        r68, []
+  // group by {week_seq: d.d_week_seq} into g
+  Const        r69, "week_seq"
+  Const        r70, "d_week_seq"
+  // d_week_seq: g.key.week_seq,
+  Const        r71, "d_week_seq"
+  Const        r72, "key"
+  Const        r73, "week_seq"
+  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
+  Const        r74, "sun_sales"
+  Const        r75, "day"
+  Const        r76, "sales_price"
+  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
+  Const        r77, "mon_sales"
+  Const        r78, "day"
+  Const        r79, "sales_price"
+  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
+  Const        r80, "tue_sales"
+  Const        r81, "day"
+  Const        r82, "sales_price"
+  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
+  Const        r83, "wed_sales"
+  Const        r84, "day"
+  Const        r85, "sales_price"
+  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
+  Const        r86, "thu_sales"
+  Const        r87, "day"
+  Const        r88, "sales_price"
+  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
+  Const        r89, "fri_sales"
+  Const        r90, "day"
+  Const        r91, "sales_price"
+  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
+  Const        r92, "sat_sales"
+  Const        r93, "day"
+  Const        r94, "sales_price"
+  // from w in wscs
+  MakeMap      r95, 0, r0
+  Const        r96, []
+  IterPrep     r98, r67
+  Len          r99, r98
+  Const        r100, 0
+L9:
+  LessInt      r101, r100, r99
+  JumpIfFalse  r101, L4
+  Index        r103, r98, r100
+  // join d in date_dim on w.sold_date_sk == d.d_date_sk
+  IterPrep     r104, r2
+  Len          r105, r104
+  Const        r106, 0
+L8:
+  LessInt      r107, r106, r105
+  JumpIfFalse  r107, L5
+  Index        r109, r104, r106
+  Const        r110, "sold_date_sk"
+  Index        r111, r103, r110
+  Const        r112, "d_date_sk"
+  Index        r113, r109, r112
+  Equal        r114, r111, r113
+  JumpIfFalse  r114, L6
+  // from w in wscs
+  Const        r115, "w"
+  Move         r116, r103
+  Const        r117, "d"
+  Move         r118, r109
+  MakeMap      r119, 2, r115
+  // group by {week_seq: d.d_week_seq} into g
+  Const        r120, "week_seq"
+  Const        r121, "d_week_seq"
+  Index        r122, r109, r121
+  Move         r123, r120
+  Move         r124, r122
+  MakeMap      r125, 1, r123
+  Str          r126, r125
+  In           r127, r126, r95
+  JumpIfTrue   r127, L7
+  // from w in wscs
+  Const        r128, []
+  Const        r129, "__group__"
+  Const        r130, true
+  Const        r131, "key"
+  // group by {week_seq: d.d_week_seq} into g
+  Move         r132, r125
+  // from w in wscs
+  Const        r133, "items"
+  Move         r134, r128
+  Const        r135, "count"
+  Const        r136, 0
+  Move         r137, r129
+  Move         r138, r130
+  Move         r139, r131
+  Move         r140, r132
+  Move         r141, r133
+  Move         r142, r134
+  Move         r143, r135
+  Move         r144, r136
+  MakeMap      r145, 4, r137
+  SetIndex     r95, r126, r145
+  Append       r96, r96, r145
+L7:
+  Const        r147, "items"
+  Index        r148, r95, r126
+  Index        r149, r148, r147
+  Append       r150, r149, r119
+  SetIndex     r148, r147, r150
+  Const        r151, "count"
+  Index        r152, r148, r151
+  Const        r153, 1
+  AddInt       r154, r152, r153
+  SetIndex     r148, r151, r154
 L6:
+  // join d in date_dim on w.sold_date_sk == d.d_date_sk
+  Const        r155, 1
+  AddInt       r106, r106, r155
+  Jump         L8
+L5:
+  // from w in wscs
+  Const        r156, 1
+  AddInt       r100, r100, r156
+  Jump         L9
+L4:
+  Const        r157, 0
+  Len          r159, r96
+L32:
+  LessInt      r160, r157, r159
+  JumpIfFalse  r160, L10
+  Index        r162, r96, r157
+  // d_week_seq: g.key.week_seq,
+  Const        r163, "d_week_seq"
+  Const        r164, "key"
+  Index        r165, r162, r164
+  Const        r166, "week_seq"
+  Index        r167, r165, r166
+  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
+  Const        r168, "sun_sales"
+  Const        r169, []
+  Const        r170, "day"
+  Const        r171, "sales_price"
+  IterPrep     r172, r162
+  Len          r173, r172
+  Const        r174, 0
+L13:
+  LessInt      r176, r174, r173
+  JumpIfFalse  r176, L11
+  Index        r178, r172, r174
+  Const        r179, "day"
+  Index        r180, r178, r179
+  Const        r181, "Sunday"
+  Equal        r182, r180, r181
+  JumpIfFalse  r182, L12
+  Const        r183, "sales_price"
+  Index        r184, r178, r183
+  Append       r169, r169, r184
+L12:
+  Const        r186, 1
+  AddInt       r174, r174, r186
+  Jump         L13
+L11:
+  Sum          r187, r169
+  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
+  Const        r188, "mon_sales"
+  Const        r189, []
+  Const        r190, "day"
+  Const        r191, "sales_price"
+  IterPrep     r192, r162
+  Len          r193, r192
+  Const        r194, 0
+L16:
+  LessInt      r196, r194, r193
+  JumpIfFalse  r196, L14
+  Index        r178, r192, r194
+  Const        r198, "day"
+  Index        r199, r178, r198
+  Const        r200, "Monday"
+  Equal        r201, r199, r200
+  JumpIfFalse  r201, L15
+  Const        r202, "sales_price"
+  Index        r203, r178, r202
+  Append       r189, r189, r203
+L15:
+  Const        r205, 1
+  AddInt       r194, r194, r205
+  Jump         L16
+L14:
+  Sum          r206, r189
+  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
+  Const        r207, "tue_sales"
+  Const        r208, []
+  Const        r209, "day"
+  Const        r210, "sales_price"
+  IterPrep     r211, r162
+  Len          r212, r211
+  Const        r213, 0
+L19:
+  LessInt      r215, r213, r212
+  JumpIfFalse  r215, L17
+  Index        r178, r211, r213
+  Const        r217, "day"
+  Index        r218, r178, r217
+  Const        r219, "Tuesday"
+  Equal        r220, r218, r219
+  JumpIfFalse  r220, L18
+  Const        r221, "sales_price"
+  Index        r222, r178, r221
+  Append       r208, r208, r222
+L18:
+  Const        r224, 1
+  AddInt       r213, r213, r224
+  Jump         L19
+L17:
+  Sum          r225, r208
+  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
+  Const        r226, "wed_sales"
+  Const        r227, []
+  Const        r228, "day"
+  Const        r229, "sales_price"
+  IterPrep     r230, r162
+  Len          r231, r230
+  Const        r232, 0
+L22:
+  LessInt      r234, r232, r231
+  JumpIfFalse  r234, L20
+  Index        r178, r230, r232
+  Const        r236, "day"
+  Index        r237, r178, r236
+  Const        r238, "Wednesday"
+  Equal        r239, r237, r238
+  JumpIfFalse  r239, L21
+  Const        r240, "sales_price"
+  Index        r241, r178, r240
+  Append       r227, r227, r241
+L21:
+  Const        r243, 1
+  AddInt       r232, r232, r243
+  Jump         L22
+L20:
+  Sum          r244, r227
+  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
+  Const        r245, "thu_sales"
+  Const        r246, []
+  Const        r247, "day"
+  Const        r248, "sales_price"
+  IterPrep     r249, r162
+  Len          r250, r249
+  Const        r251, 0
+L25:
+  LessInt      r253, r251, r250
+  JumpIfFalse  r253, L23
+  Index        r178, r249, r251
+  Const        r255, "day"
+  Index        r256, r178, r255
+  Const        r257, "Thursday"
+  Equal        r258, r256, r257
+  JumpIfFalse  r258, L24
+  Const        r259, "sales_price"
+  Index        r260, r178, r259
+  Append       r246, r246, r260
+L24:
+  Const        r262, 1
+  AddInt       r251, r251, r262
+  Jump         L25
+L23:
+  Sum          r263, r246
+  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
+  Const        r264, "fri_sales"
+  Const        r265, []
+  Const        r266, "day"
+  Const        r267, "sales_price"
+  IterPrep     r268, r162
+  Len          r269, r268
+  Const        r270, 0
+L28:
+  LessInt      r272, r270, r269
+  JumpIfFalse  r272, L26
+  Index        r178, r268, r270
+  Const        r274, "day"
+  Index        r275, r178, r274
+  Const        r276, "Friday"
+  Equal        r277, r275, r276
+  JumpIfFalse  r277, L27
+  Const        r278, "sales_price"
+  Index        r279, r178, r278
+  Append       r265, r265, r279
+L27:
+  Const        r281, 1
+  AddInt       r270, r270, r281
+  Jump         L28
+L26:
+  Sum          r282, r265
+  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
+  Const        r283, "sat_sales"
+  Const        r284, []
+  Const        r285, "day"
+  Const        r286, "sales_price"
+  IterPrep     r287, r162
+  Len          r288, r287
+  Const        r289, 0
+L31:
+  LessInt      r291, r289, r288
+  JumpIfFalse  r291, L29
+  Index        r178, r287, r289
+  Const        r293, "day"
+  Index        r294, r178, r293
+  Const        r295, "Saturday"
+  Equal        r296, r294, r295
+  JumpIfFalse  r296, L30
+  Const        r297, "sales_price"
+  Index        r298, r178, r297
+  Append       r284, r284, r298
+L30:
+  Const        r300, 1
+  AddInt       r289, r289, r300
+  Jump         L31
+L29:
+  Sum          r301, r284
+  // d_week_seq: g.key.week_seq,
+  Move         r302, r163
+  Move         r303, r167
+  // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
+  Move         r304, r168
+  Move         r305, r187
+  // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
+  Move         r306, r188
+  Move         r307, r206
+  // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
+  Move         r308, r207
+  Move         r309, r225
+  // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
+  Move         r310, r226
+  Move         r311, r244
+  // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
+  Move         r312, r245
+  Move         r313, r263
+  // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
+  Move         r314, r264
+  Move         r315, r282
+  // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
+  Move         r316, r283
+  Move         r317, r301
+  // select {
+  MakeMap      r318, 8, r302
+  // from w in wscs
+  Append       r68, r68, r318
+  Const        r320, 1
+  AddInt       r157, r157, r320
+  Jump         L32
+L10:
   // let result = []
-  Const        r257, []
+  Const        r321, []
   // json(result)
-  JSON         r257
+  JSON         r321
   // expect len(result) == 0
-  Const        r258, 0
-  Const        r259, 0
-  Const        r260, true
-  Expect       r260
+  Const        r322, 0
+  Const        r323, 0
+  Const        r324, true
+  Expect       r324
   Return       r0

--- a/tests/dataset/tpc-ds/q2.mochi
+++ b/tests/dataset/tpc-ds/q2.mochi
@@ -3,7 +3,19 @@ let web_sales = []
 let catalog_sales = []
 let date_dim = []
 
-let wscs = []
+let wscs =
+  (from ws in web_sales
+   select {
+     sold_date_sk: ws.ws_sold_date_sk,
+     sales_price: ws.ws_ext_sales_price,
+     day: ws.ws_sold_date_name
+   }) union all (
+  from cs in catalog_sales
+   select {
+     sold_date_sk: cs.cs_sold_date_sk,
+     sales_price: cs.cs_ext_sales_price,
+     day: cs.cs_sold_date_name
+   })
 
 let wswscs =
   from w in wscs


### PR DESCRIPTION
## Summary
- tweak `OpValues` builtin to return an empty list quickly and simplify allocation
- expand `tpc-ds/q2.mochi` to actually build the `wscs` union
- refresh IR golden files for TPC‑DS queries q1–q9

## Testing
- `go test ./...`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q[1-9].mochi -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68623fa039f08320b6bc857410fd9ad1