### PR TITLE
Enable float division for ints and add TPC-DS Q59

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -920,7 +920,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			if toFloat(c) == 0 {
 				return Value{}, m.newError(fmt.Errorf("division by zero"), trace, ins.Line)
 			}
-			if b.Tag == ValueFloat || c.Tag == ValueFloat {
+			if b.Tag == ValueFloat || c.Tag == ValueFloat || (b.Tag == ValueInt && c.Tag == ValueInt) {
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: toFloat(b) / toFloat(c)}
 			} else if b.Tag == ValueBigRat || c.Tag == ValueBigRat {
 				br := new(big.Rat).Quo(toRat(b), toRat(c))
@@ -3220,7 +3220,8 @@ func (fc *funcCompiler) emitBinaryOp(pos lexer.Position, op string, all bool, le
 			// SQL division with floats yields a float result.
 			fc.emit(pos, Instr{Op: OpDivFloat, A: dst, B: left, C: right})
 		} else if fc.tags[left] == tagInt && fc.tags[right] == tagInt {
-			fc.emit(pos, Instr{Op: OpDivInt, A: dst, B: left, C: right})
+			// Perform floating-point division for two integer operands
+			fc.emit(pos, Instr{Op: OpDivFloat, A: dst, B: left, C: right})
 		} else {
 			fc.emit(pos, Instr{Op: OpDiv, A: dst, B: left, C: right})
 		}


### PR DESCRIPTION
## Summary
- allow integer division to yield floats in the VM
- update codegen to emit OpDivFloat for int operands
- add real query for TPC‑DS Q59 and update golden outputs

## Testing
- `go test ./...`
- `go run ./tools/update_tpcds q59`

------
https://chatgpt.com/codex/tasks/task_e_68624032f7f48320be0a3d6b65125c44