### PR TITLE
Enable null list union

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -1174,6 +1174,8 @@ func toList(v Value) ([]Value, bool) {
 				return items.List, true
 			}
 		}
+	case ValueNull:
+		return []Value{}, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
## Summary
- treat `null` as an empty list during constant evaluation
- regenerate IR for tpc-ds queries q40-q49

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCDS -count=1`

------
https://chatgpt.com/codex/tasks/task_e_686242018d4c8320bea6eb6b6a31cf0f