### PR TITLE
Support len(null) and refresh IR files

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -24,7 +24,7 @@ The VM supports a small but useful subset of Mochi:
 * Function definitions
 * Function calls with any number of arguments
 * Anonymous function expressions
-* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `first`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min` and `max`
+* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `first`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min`, `max`, `substring`, `substr`, `upper` and `lower`
 * Dataset loading with `load` (optionally casting rows to a type) and saving with `save`
 * HTTP requests using the `fetch` expression
 * List, map and struct construction
@@ -116,6 +116,8 @@ from the disassembler:
 | `JSON` | Print value A as JSON | `JSON r0` |
 | `Append` | Append C to list B | `Append r0, r1, r2` |
 | `Str` | Convert value B to string | `Str r0, r1` |
+| `Upper` | Uppercase string B | `Upper r0, r1` |
+| `Lower` | Lowercase string B | `Lower r0, r1` |
 | `Input` | Read line from input | `Input r0` |
 | `First` | First element of list B | `First r0, r1` |
 | `Count` | Count elements in list/map B | `Count r0, r1` |

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1364,18 +1364,18 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			default:
 				fr.regs[ins.A] = Value{Tag: ValueBool, Bool: false}
 			}
-               case OpAvg:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
-                       if lst.Tag != ValueList {
+		case OpAvg:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
+			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("avg expects list")
 			}
 			if len(lst.List) == 0 {
@@ -1387,19 +1387,19 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				}
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sum / float64(len(lst.List))}
 			}
-               case OpSum:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
-                       if lst.Tag != ValueList {
-                               return Value{}, fmt.Errorf("sum expects list")
+		case OpSum:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
+			if lst.Tag != ValueList {
+				return Value{}, fmt.Errorf("sum expects list")
 			}
 			var sumF float64
 			var sumI int
@@ -1418,17 +1418,17 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				sumF += float64(sumI)
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sumF}
 			}
-               case OpMin:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
+		case OpMin:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("min expects list")
 			}
@@ -1460,17 +1460,17 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 					fr.regs[ins.A] = Value{Tag: ValueInt, Int: int(minVal)}
 				}
 			}
-               case OpMax:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
+		case OpMax:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("max expects list")
 			}
@@ -5935,6 +5935,8 @@ func (fc *funcCompiler) foldCallValue(call *parser.CallExpr) (Value, bool) {
 			return Value{Tag: ValueInt, Int: len([]rune(v.Str))}, true
 		case ValueMap:
 			return Value{Tag: ValueInt, Int: len(v.Map)}, true
+		case ValueNull:
+			return Value{Tag: ValueInt, Int: 0}, true
 		}
 	case "str":
 		if len(args) != 1 {


### PR DESCRIPTION
## Summary
- return zero for `len(null)` in VM constant folding
- document substring, upper, and lower builtins
- regenerate TPC-DS IR outputs for queries q1–q9

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862424a3efc8320aa8e51d7a0a4b8b7