### PR TITLE
Add to_list builtin and update TPC-DS queries

### DIFF
--- a/tests/dataset/tpc-ds/out/q10.ir.out
+++ b/tests/dataset/tpc-ds/out/q10.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 10}]
   Const        r0, [{"id": 1, "val": 10}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 10
-  Const        r15, 10
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 10
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q11.ir.out
+++ b/tests/dataset/tpc-ds/out/q11.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 11}]
   Const        r0, [{"id": 1, "val": 11}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 11
-  Const        r15, 11
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 11
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q12.ir.out
+++ b/tests/dataset/tpc-ds/out/q12.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 12}]
   Const        r0, [{"id": 1, "val": 12}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 12
-  Const        r15, 12
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 12
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q13.ir.out
+++ b/tests/dataset/tpc-ds/out/q13.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 13}]
   Const        r0, [{"id": 1, "val": 13}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 13
-  Const        r15, 13
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 13
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q14.ir.out
+++ b/tests/dataset/tpc-ds/out/q14.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 14}]
   Const        r0, [{"id": 1, "val": 14}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 14
-  Const        r15, 14
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 14
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q15.ir.out
+++ b/tests/dataset/tpc-ds/out/q15.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 15}]
   Const        r0, [{"id": 1, "val": 15}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 15
-  Const        r15, 15
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 15
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q16.ir.out
+++ b/tests/dataset/tpc-ds/out/q16.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 16}]
   Const        r0, [{"id": 1, "val": 16}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 16
-  Const        r15, 16
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 16
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q17.ir.out
+++ b/tests/dataset/tpc-ds/out/q17.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 17}]
   Const        r0, [{"id": 1, "val": 17}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 17
-  Const        r15, 17
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 17
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q18.ir.out
+++ b/tests/dataset/tpc-ds/out/q18.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 18}]
   Const        r0, [{"id": 1, "val": 18}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 18
-  Const        r15, 18
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 18
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q19.ir.out
+++ b/tests/dataset/tpc-ds/out/q19.ir.out
@@ -1,7 +1,7 @@
-func main (regs=17)
+func main (regs=18)
   // let t = [{id: 1, val: 19}]
   Const        r0, [{"id": 1, "val": 19}]
-  // let vals = from r in t select r.val
+  // let vals = to_list(from r in t select r.val)
   Const        r1, []
   Const        r2, "val"
   IterPrep     r3, r0
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
+  ToList       r14, r1
   // let result = first(vals)
-  First        r14, r1
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 19
-  Const        r15, 19
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 19
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/q10.mochi
+++ b/tests/dataset/tpc-ds/q10.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 10}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q11.mochi
+++ b/tests/dataset/tpc-ds/q11.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 11}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q12.mochi
+++ b/tests/dataset/tpc-ds/q12.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 12}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q13.mochi
+++ b/tests/dataset/tpc-ds/q13.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 13}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q14.mochi
+++ b/tests/dataset/tpc-ds/q14.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 14}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q15.mochi
+++ b/tests/dataset/tpc-ds/q15.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 15}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q16.mochi
+++ b/tests/dataset/tpc-ds/q16.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 16}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q17.mochi
+++ b/tests/dataset/tpc-ds/q17.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 17}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q18.mochi
+++ b/tests/dataset/tpc-ds/q18.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 18}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/tests/dataset/tpc-ds/q19.mochi
+++ b/tests/dataset/tpc-ds/q19.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 19}]
-let vals = from r in t select r.val
+let vals = to_list(from r in t select r.val)
 let result = first(vals)
 json(result)
 

--- a/types/check.go
+++ b/types/check.go
@@ -380,6 +380,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: ListType{Elem: AnyType{}},
 		Pure:   true,
 	}, false)
+	env.SetVar("to_list", FuncType{
+		Params: []Type{AnyType{}},
+		Return: ListType{Elem: AnyType{}},
+		Pure:   true,
+	}, false)
 	env.SetVar("range", FuncType{
 		Params:   []Type{IntType{}},
 		Return:   ListType{Elem: IntType{}},
@@ -2171,6 +2176,7 @@ var builtinArity = map[string]int{
 	"max":       1,
 	"keys":      1,
 	"values":    1,
+	"to_list":   1,
 	"reduce":    3,
 	"append":    2,
 	"push":      2,
@@ -2295,6 +2301,11 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 		default:
 			return fmt.Errorf("%s() expects map", name)
 		}
+	case "to_list":
+		if len(args) != 1 {
+			return errArgCount(pos, name, 1, len(args))
+		}
+		return nil
 	case "reduce":
 		if len(args) != 3 {
 			return errArgCount(pos, name, 3, len(args))


### PR DESCRIPTION
## Summary
- add `OpToList` instruction to the VM
- support `to_list` builtin in type checker and VM
- use `to_list` in TPC-DS q10–q19 sample queries
- update IR golden files for q10–q19

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCDS -update -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68623f36ca348320b4276cf3405ed6f4