### PR TITLE
Add reverse builtin and update TPC-DS samples

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -79,6 +79,7 @@ const (
 	OpStr
 	OpUpper
 	OpLower
+	OpReverse
 	OpInput
 	OpFirst
 	OpCount
@@ -202,6 +203,8 @@ func (op Op) String() string {
 		return "Upper"
 	case OpLower:
 		return "Lower"
+	case OpReverse:
+		return "Reverse"
 	case OpInput:
 		return "Input"
 	case OpFirst:
@@ -1127,6 +1130,16 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				return Value{}, m.newError(fmt.Errorf("lower expects string"), trace, ins.Line)
 			}
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToLower(b.Str)}
+		case OpReverse:
+			lst := fr.regs[ins.B]
+			if lst.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("reverse expects list"), trace, ins.Line)
+			}
+			newList := append([]Value(nil), lst.List...)
+			for i, j := 0, len(newList)-1; i < j; i, j = i+1, j-1 {
+				newList[i], newList[j] = newList[j], newList[i]
+			}
+			fr.regs[ins.A] = Value{Tag: ValueList, List: newList}
 		case OpInput:
 			line, err := m.reader.ReadString('\n')
 			if err != nil && err != io.EOF {
@@ -1960,7 +1973,7 @@ func (fc *funcCompiler) emit(pos lexer.Position, i Instr) {
 		fc.tags[i.A] = tagInt
 	case OpJSON, OpPrint, OpPrint2, OpPrintN:
 		// no result
-	case OpAppend, OpStr, OpUpper, OpLower, OpInput, OpFirst:
+	case OpAppend, OpStr, OpUpper, OpLower, OpReverse, OpInput, OpFirst:
 		fc.tags[i.A] = tagUnknown
 	case OpLoad:
 		fc.tags[i.A] = tagUnknown
@@ -2905,6 +2918,11 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 			arg := fc.compileExpr(p.Call.Args[0])
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpLower, A: dst, B: arg})
+			return dst
+		case "reverse":
+			arg := fc.compileExpr(p.Call.Args[0])
+			dst := fc.newReg()
+			fc.emit(p.Pos, Instr{Op: OpReverse, A: dst, B: arg})
 			return dst
 		case "str":
 			arg := fc.compileExpr(p.Call.Args[0])

--- a/tests/dataset/tpc-ds/out/q11.ir.out
+++ b/tests/dataset/tpc-ds/out/q11.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 11}]
-  Const        r0, [{"id": 1, "val": 11}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 11}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 11}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 11
-  Const        r15, 11
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 11
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q12.ir.out
+++ b/tests/dataset/tpc-ds/out/q12.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 12}]
-  Const        r0, [{"id": 1, "val": 12}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 12}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 12}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 12
-  Const        r15, 12
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 12
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q13.ir.out
+++ b/tests/dataset/tpc-ds/out/q13.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 13}]
-  Const        r0, [{"id": 1, "val": 13}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 13}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 13}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 13
-  Const        r15, 13
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 13
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q14.ir.out
+++ b/tests/dataset/tpc-ds/out/q14.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 14}]
-  Const        r0, [{"id": 1, "val": 14}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 14}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 14}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 14
-  Const        r15, 14
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 14
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q15.ir.out
+++ b/tests/dataset/tpc-ds/out/q15.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 15}]
-  Const        r0, [{"id": 1, "val": 15}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 15}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 15}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 15
-  Const        r15, 15
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 15
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q16.ir.out
+++ b/tests/dataset/tpc-ds/out/q16.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 16}]
-  Const        r0, [{"id": 1, "val": 16}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 16}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 16}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 16
-  Const        r15, 16
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 16
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q17.ir.out
+++ b/tests/dataset/tpc-ds/out/q17.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 17}]
-  Const        r0, [{"id": 1, "val": 17}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 17}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 17}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 17
-  Const        r15, 17
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 17
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q18.ir.out
+++ b/tests/dataset/tpc-ds/out/q18.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 18}]
-  Const        r0, [{"id": 1, "val": 18}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 18}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 18}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 18
-  Const        r15, 18
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 18
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/out/q19.ir.out
+++ b/tests/dataset/tpc-ds/out/q19.ir.out
@@ -1,6 +1,6 @@
-func main (regs=17)
-  // let t = [{id: 1, val: 19}]
-  Const        r0, [{"id": 1, "val": 19}]
+func main (regs=18)
+  // let t = [{id: 0, val: 0}, {id: 1, val: 19}]
+  Const        r0, [{"id": 0, "val": 0}, {"id": 1, "val": 19}]
   // let vals = from r in t select r.val
   Const        r1, []
   Const        r2, "val"
@@ -18,12 +18,13 @@ L1:
   AddInt       r5, r5, r13
   Jump         L1
 L0:
-  // let result = first(vals)
-  First        r14, r1
+  // let result = first(reverse(vals))
+  Reverse      14,1,0,0
+  First        r15, r14
   // json(result)
-  JSON         r14
+  JSON         r15
   // expect result == 19
-  Const        r15, 19
-  Equal        r16, r14, r15
-  Expect       r16
+  Const        r16, 19
+  Equal        r17, r15, r16
+  Expect       r17
   Return       r0

--- a/tests/dataset/tpc-ds/q11.mochi
+++ b/tests/dataset/tpc-ds/q11.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 11}]
+let t = [{id: 0, val: 0}, {id: 1, val: 11}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q11 first" {

--- a/tests/dataset/tpc-ds/q12.mochi
+++ b/tests/dataset/tpc-ds/q12.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 12}]
+let t = [{id: 0, val: 0}, {id: 1, val: 12}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q12 first" {

--- a/tests/dataset/tpc-ds/q13.mochi
+++ b/tests/dataset/tpc-ds/q13.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 13}]
+let t = [{id: 0, val: 0}, {id: 1, val: 13}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q13 first" {

--- a/tests/dataset/tpc-ds/q14.mochi
+++ b/tests/dataset/tpc-ds/q14.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 14}]
+let t = [{id: 0, val: 0}, {id: 1, val: 14}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q14 first" {

--- a/tests/dataset/tpc-ds/q15.mochi
+++ b/tests/dataset/tpc-ds/q15.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 15}]
+let t = [{id: 0, val: 0}, {id: 1, val: 15}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q15 first" {

--- a/tests/dataset/tpc-ds/q16.mochi
+++ b/tests/dataset/tpc-ds/q16.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 16}]
+let t = [{id: 0, val: 0}, {id: 1, val: 16}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q16 first" {

--- a/tests/dataset/tpc-ds/q17.mochi
+++ b/tests/dataset/tpc-ds/q17.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 17}]
+let t = [{id: 0, val: 0}, {id: 1, val: 17}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q17 first" {

--- a/tests/dataset/tpc-ds/q18.mochi
+++ b/tests/dataset/tpc-ds/q18.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 18}]
+let t = [{id: 0, val: 0}, {id: 1, val: 18}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q18 first" {

--- a/tests/dataset/tpc-ds/q19.mochi
+++ b/tests/dataset/tpc-ds/q19.mochi
@@ -1,6 +1,6 @@
-let t = [{id: 1, val: 19}]
+let t = [{id: 0, val: 0}, {id: 1, val: 19}]
 let vals = from r in t select r.val
-let result = first(vals)
+let result = first(reverse(vals))
 json(result)
 
 test "TPCDS Q19 first" {

--- a/types/check.go
+++ b/types/check.go
@@ -365,6 +365,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: AnyType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("reverse", FuncType{
+		Params: []Type{ListType{Elem: AnyType{}}},
+		Return: ListType{Elem: AnyType{}},
+		Pure:   true,
+	}, false)
 	env.SetVar("push", FuncType{
 		Params: []Type{ListType{Elem: AnyType{}}, AnyType{}},
 		Return: ListType{Elem: AnyType{}},
@@ -2157,6 +2162,7 @@ var builtinArity = map[string]int{
 	"str":       1,
 	"upper":     1,
 	"lower":     1,
+	"reverse":   1,
 	"trim":      1,
 	"contains":  2,
 	"split":     2,
@@ -2344,6 +2350,16 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 		if _, ok := args[0].(ListType); !ok {
 			if _, ok := args[0].(AnyType); !ok {
 				return fmt.Errorf("first() expects list, got %v", args[0])
+			}
+		}
+		return nil
+	case "reverse":
+		if len(args) != 1 {
+			return errArgCount(pos, name, 1, len(args))
+		}
+		if _, ok := args[0].(ListType); !ok {
+			if _, ok := args[0].(AnyType); !ok {
+				return fmt.Errorf("reverse() expects list, got %v", args[0])
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary
- add `reverse` builtin to VM and type checker
- use `reverse` in TPC-DS q11–q19 examples
- update IR golden files for the modified queries

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68623fbcfc048320a8caac4db966b8b4