### PR TITLE
Add TPC-DS q79 output and improve VM sort

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1097,11 +1097,16 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			pairs := append([]Value(nil), src.List...)
 			sort.SliceStable(pairs, func(i, j int) bool {
-				return valueLess(pairs[i].List[0], pairs[j].List[0])
+				a := pairs[i]
+				b := pairs[j]
+				if a.Tag != ValueList || b.Tag != ValueList || len(a.List) == 0 || len(b.List) == 0 {
+					return false
+				}
+				return valueLess(a.List[0], b.List[0])
 			})
 			out := make([]Value, len(pairs))
 			for i, p := range pairs {
-				if len(p.List) > 1 {
+				if p.Tag == ValueList && len(p.List) > 1 {
 					out[i] = p.List[1]
 				} else {
 					out[i] = Value{Tag: ValueNull}
@@ -1364,18 +1369,18 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			default:
 				fr.regs[ins.A] = Value{Tag: ValueBool, Bool: false}
 			}
-               case OpAvg:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
-                       if lst.Tag != ValueList {
+		case OpAvg:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
+			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("avg expects list")
 			}
 			if len(lst.List) == 0 {
@@ -1387,19 +1392,19 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				}
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sum / float64(len(lst.List))}
 			}
-               case OpSum:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
-                       if lst.Tag != ValueList {
-                               return Value{}, fmt.Errorf("sum expects list")
+		case OpSum:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
+			if lst.Tag != ValueList {
+				return Value{}, fmt.Errorf("sum expects list")
 			}
 			var sumF float64
 			var sumI int
@@ -1418,17 +1423,17 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				sumF += float64(sumI)
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sumF}
 			}
-               case OpMin:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
+		case OpMin:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("min expects list")
 			}
@@ -1460,17 +1465,17 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 					fr.regs[ins.A] = Value{Tag: ValueInt, Int: int(minVal)}
 				}
 			}
-               case OpMax:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
+		case OpMax:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("max expects list")
 			}

--- a/tests/dataset/tpc-ds/out/q79.out
+++ b/tests/dataset/tpc-ds/out/q79.out
@@ -1,0 +1,1 @@
+[{"c_last_name":"Smith","c_first_name":"Alice","s_city":"CityA","ss_ticket_number":1,"amt":5.0,"profit":10.0}]


### PR DESCRIPTION
## Summary
- handle malformed pair data in VM Sort implementation
- include golden output for TPC-DS query q79

## Testing
- `gofmt -w runtime/vm/vm.go`


------
https://chatgpt.com/codex/tasks/task_e_6862430c3bd88320854682e5c4377d5d