### PR TITLE
Handle null in set ops

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1022,7 +1022,13 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fr.regs[ins.A] = Value{Tag: ValueList, List: newList}
 		case OpUnionAll:
 			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			}
 			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			}
 			if a.Tag != ValueList || b.Tag != ValueList {
 				return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
 			}
@@ -1030,7 +1036,13 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fr.regs[ins.A] = Value{Tag: ValueList, List: out}
 		case OpUnion:
 			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			}
 			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			}
 			if a.Tag != ValueList || b.Tag != ValueList {
 				return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
 			}
@@ -1053,7 +1065,13 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fr.regs[ins.A] = Value{Tag: ValueList, List: out}
 		case OpExcept:
 			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			}
 			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			}
 			if a.Tag != ValueList || b.Tag != ValueList {
 				return Value{}, m.newError(fmt.Errorf("except expects lists"), trace, ins.Line)
 			}
@@ -1070,7 +1088,13 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fr.regs[ins.A] = Value{Tag: ValueList, List: diff}
 		case OpIntersect:
 			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			}
 			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			}
 			if a.Tag != ValueList || b.Tag != ValueList {
 				return Value{}, m.newError(fmt.Errorf("intersect expects lists"), trace, ins.Line)
 			}
@@ -1364,18 +1388,18 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			default:
 				fr.regs[ins.A] = Value{Tag: ValueBool, Bool: false}
 			}
-               case OpAvg:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
-                       if lst.Tag != ValueList {
+		case OpAvg:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
+			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("avg expects list")
 			}
 			if len(lst.List) == 0 {
@@ -1387,19 +1411,19 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				}
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sum / float64(len(lst.List))}
 			}
-               case OpSum:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
-                       if lst.Tag != ValueList {
-                               return Value{}, fmt.Errorf("sum expects list")
+		case OpSum:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
+			if lst.Tag != ValueList {
+				return Value{}, fmt.Errorf("sum expects list")
 			}
 			var sumF float64
 			var sumI int
@@ -1418,17 +1442,17 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				sumF += float64(sumI)
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: sumF}
 			}
-               case OpMin:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
+		case OpMin:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("min expects list")
 			}
@@ -1460,17 +1484,17 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 					fr.regs[ins.A] = Value{Tag: ValueInt, Int: int(minVal)}
 				}
 			}
-               case OpMax:
-                       lst := fr.regs[ins.B]
-                       if lst.Tag == ValueNull {
-                               fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
-                               break
-                       }
-                       if lst.Tag == ValueMap {
-                               if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                       lst = lst.Map["items"]
-                               }
-                       }
+		case OpMax:
+			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				break
+			}
+			if lst.Tag == ValueMap {
+				if flag, ok := lst.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					lst = lst.Map["items"]
+				}
+			}
 			if lst.Tag != ValueList {
 				return Value{}, fmt.Errorf("max expects list")
 			}

--- a/tests/dataset/tpc-ds/out/q40.ir.out
+++ b/tests/dataset/tpc-ds/out/q40.ir.out
@@ -1,4 +1,4 @@
-func main (regs=429)
+func main (regs=431)
   // let catalog_sales = [
   Const        r0, [{"date_sk": 1, "item_sk": 1, "order": 1, "price": 100, "warehouse_sk": 1}, {"date_sk": 2, "item_sk": 1, "order": 2, "price": 150, "warehouse_sk": 1}]
   // let catalog_returns = [
@@ -11,495 +11,496 @@ func main (regs=429)
   Const        r4, [{"date": "2020-01-10", "date_sk": 1}, {"date": "2020-01-20", "date_sk": 2}]
   // let sales_date = "2020-01-15"
   Const        r5, "2020-01-15"
+  // let dummy = null
+  Const        r6, nil
   // from cs in catalog_sales
-  Const        r6, []
+  Const        r7, []
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r7, "current_price"
   Const        r8, "current_price"
+  Const        r9, "current_price"
   // w_state: w.state,
-  Const        r9, "w_state"
-  Const        r10, "state"
+  Const        r10, "w_state"
+  Const        r11, "state"
   // i_item_id: i.item_id,
-  Const        r11, "i_item_id"
-  Const        r12, "item_id"
+  Const        r12, "i_item_id"
+  Const        r13, "item_id"
   // sold_date: d.date,
-  Const        r13, "sold_date"
-  Const        r14, "date"
+  Const        r14, "sold_date"
+  Const        r15, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r15, "net"
-  Const        r16, "price"
-  Const        r17, "refunded"
+  Const        r16, "net"
+  Const        r17, "price"
+  Const        r18, "refunded"
   // from cs in catalog_sales
-  IterPrep     r18, r0
-  Len          r19, r18
-  Const        r20, 0
+  IterPrep     r19, r0
+  Len          r20, r19
+  Const        r21, 0
 L24:
-  LessInt      r22, r20, r19
-  JumpIfFalse  r22, L0
-  Index        r24, r18, r20
+  LessInt      r23, r21, r20
+  JumpIfFalse  r23, L0
+  Index        r25, r19, r21
   // left join cr in catalog_returns on cs.order == cr.order && cs.item_sk == cr.item_sk
-  IterPrep     r25, r1
-  Len          r26, r25
-  Const        r27, "order"
+  IterPrep     r26, r1
+  Len          r27, r26
   Const        r28, "order"
-  Const        r29, "item_sk"
+  Const        r29, "order"
   Const        r30, "item_sk"
+  Const        r31, "item_sk"
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r31, "current_price"
   Const        r32, "current_price"
+  Const        r33, "current_price"
   // w_state: w.state,
-  Const        r33, "w_state"
-  Const        r34, "state"
+  Const        r34, "w_state"
+  Const        r35, "state"
   // i_item_id: i.item_id,
-  Const        r35, "i_item_id"
-  Const        r36, "item_id"
+  Const        r36, "i_item_id"
+  Const        r37, "item_id"
   // sold_date: d.date,
-  Const        r37, "sold_date"
-  Const        r38, "date"
+  Const        r38, "sold_date"
+  Const        r39, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r39, "net"
-  Const        r40, "price"
-  Const        r41, "refunded"
+  Const        r40, "net"
+  Const        r41, "price"
+  Const        r42, "refunded"
   // left join cr in catalog_returns on cs.order == cr.order && cs.item_sk == cr.item_sk
-  Const        r42, 0
+  Const        r43, 0
 L13:
-  LessInt      r44, r42, r26
-  JumpIfFalse  r44, L1
-  Index        r46, r25, r42
-  Const        r47, false
-  Const        r48, "order"
-  Index        r49, r24, r48
-  Const        r50, "order"
-  Index        r51, r46, r50
-  Equal        r52, r49, r51
-  Const        r53, "item_sk"
-  Index        r54, r24, r53
-  Const        r55, "item_sk"
-  Index        r56, r46, r55
-  Equal        r57, r54, r56
-  Move         r58, r52
-  JumpIfFalse  r58, L2
-  Move         r58, r57
+  LessInt      r45, r43, r27
+  JumpIfFalse  r45, L1
+  Index        r47, r26, r43
+  Const        r48, false
+  Const        r49, "order"
+  Index        r50, r25, r49
+  Const        r51, "order"
+  Index        r52, r47, r51
+  Equal        r53, r50, r52
+  Const        r54, "item_sk"
+  Index        r55, r25, r54
+  Const        r56, "item_sk"
+  Index        r57, r47, r56
+  Equal        r58, r55, r57
+  Move         r59, r53
+  JumpIfFalse  r59, L2
+  Move         r59, r58
 L2:
-  JumpIfFalse  r58, L3
-  Const        r47, true
+  JumpIfFalse  r59, L3
+  Const        r48, true
   // join w in warehouse on cs.warehouse_sk == w.warehouse_sk
-  IterPrep     r59, r3
-  Len          r60, r59
-  Const        r61, "warehouse_sk"
+  IterPrep     r60, r3
+  Len          r61, r60
   Const        r62, "warehouse_sk"
+  Const        r63, "warehouse_sk"
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r63, "current_price"
   Const        r64, "current_price"
+  Const        r65, "current_price"
   // w_state: w.state,
-  Const        r65, "w_state"
-  Const        r66, "state"
+  Const        r66, "w_state"
+  Const        r67, "state"
   // i_item_id: i.item_id,
-  Const        r67, "i_item_id"
-  Const        r68, "item_id"
+  Const        r68, "i_item_id"
+  Const        r69, "item_id"
   // sold_date: d.date,
-  Const        r69, "sold_date"
-  Const        r70, "date"
+  Const        r70, "sold_date"
+  Const        r71, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r71, "net"
-  Const        r72, "price"
-  Const        r73, "refunded"
+  Const        r72, "net"
+  Const        r73, "price"
+  Const        r74, "refunded"
   // join w in warehouse on cs.warehouse_sk == w.warehouse_sk
-  Const        r74, 0
+  Const        r75, 0
 L12:
-  LessInt      r76, r74, r60
-  JumpIfFalse  r76, L3
-  Index        r78, r59, r74
-  Const        r79, "warehouse_sk"
-  Index        r80, r24, r79
-  Const        r81, "warehouse_sk"
-  Index        r82, r78, r81
-  Equal        r83, r80, r82
-  JumpIfFalse  r83, L4
+  LessInt      r77, r75, r61
+  JumpIfFalse  r77, L3
+  Index        r79, r60, r75
+  Const        r80, "warehouse_sk"
+  Index        r81, r25, r80
+  Const        r82, "warehouse_sk"
+  Index        r83, r79, r82
+  Equal        r84, r81, r83
+  JumpIfFalse  r84, L4
   // join i in item on cs.item_sk == i.item_sk
-  IterPrep     r84, r2
-  Len          r85, r84
-  Const        r86, "item_sk"
+  IterPrep     r85, r2
+  Len          r86, r85
   Const        r87, "item_sk"
+  Const        r88, "item_sk"
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r88, "current_price"
   Const        r89, "current_price"
+  Const        r90, "current_price"
   // w_state: w.state,
-  Const        r90, "w_state"
-  Const        r91, "state"
+  Const        r91, "w_state"
+  Const        r92, "state"
   // i_item_id: i.item_id,
-  Const        r92, "i_item_id"
-  Const        r93, "item_id"
+  Const        r93, "i_item_id"
+  Const        r94, "item_id"
   // sold_date: d.date,
-  Const        r94, "sold_date"
-  Const        r95, "date"
+  Const        r95, "sold_date"
+  Const        r96, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r96, "net"
-  Const        r97, "price"
-  Const        r98, "refunded"
+  Const        r97, "net"
+  Const        r98, "price"
+  Const        r99, "refunded"
   // join i in item on cs.item_sk == i.item_sk
-  Const        r99, 0
+  Const        r100, 0
 L11:
-  LessInt      r101, r99, r85
-  JumpIfFalse  r101, L4
-  Index        r103, r84, r99
-  Const        r104, "item_sk"
-  Index        r105, r24, r104
-  Const        r106, "item_sk"
-  Index        r107, r103, r106
-  Equal        r108, r105, r107
-  JumpIfFalse  r108, L5
+  LessInt      r102, r100, r86
+  JumpIfFalse  r102, L4
+  Index        r104, r85, r100
+  Const        r105, "item_sk"
+  Index        r106, r25, r105
+  Const        r107, "item_sk"
+  Index        r108, r104, r107
+  Equal        r109, r106, r108
+  JumpIfFalse  r109, L5
   // join d in date_dim on cs.date_sk == d.date_sk
-  IterPrep     r109, r4
-  Len          r110, r109
-  Const        r111, "date_sk"
+  IterPrep     r110, r4
+  Len          r111, r110
   Const        r112, "date_sk"
+  Const        r113, "date_sk"
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r113, "current_price"
   Const        r114, "current_price"
+  Const        r115, "current_price"
   // w_state: w.state,
-  Const        r115, "w_state"
-  Const        r116, "state"
+  Const        r116, "w_state"
+  Const        r117, "state"
   // i_item_id: i.item_id,
-  Const        r117, "i_item_id"
-  Const        r118, "item_id"
+  Const        r118, "i_item_id"
+  Const        r119, "item_id"
   // sold_date: d.date,
-  Const        r119, "sold_date"
-  Const        r120, "date"
+  Const        r120, "sold_date"
+  Const        r121, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r121, "net"
-  Const        r122, "price"
-  Const        r123, "refunded"
+  Const        r122, "net"
+  Const        r123, "price"
+  Const        r124, "refunded"
   // join d in date_dim on cs.date_sk == d.date_sk
-  Const        r124, 0
+  Const        r125, 0
 L10:
-  LessInt      r126, r124, r110
-  JumpIfFalse  r126, L5
-  Index        r128, r109, r124
-  Const        r129, "date_sk"
-  Index        r130, r24, r129
-  Const        r131, "date_sk"
-  Index        r132, r128, r131
-  Equal        r133, r130, r132
-  JumpIfFalse  r133, L6
+  LessInt      r127, r125, r111
+  JumpIfFalse  r127, L5
+  Index        r129, r110, r125
+  Const        r130, "date_sk"
+  Index        r131, r25, r130
+  Const        r132, "date_sk"
+  Index        r133, r129, r132
+  Equal        r134, r131, r133
+  JumpIfFalse  r134, L6
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r134, "current_price"
-  Index        r135, r103, r134
-  Const        r136, 0.99
-  LessEqFloat  r137, r136, r135
-  Const        r138, "current_price"
-  Index        r139, r103, r138
-  Const        r140, 1.49
-  LessEqFloat  r141, r139, r140
-  Move         r142, r137
-  JumpIfFalse  r142, L7
-  Move         r142, r141
+  Const        r135, "current_price"
+  Index        r136, r104, r135
+  Const        r137, 0.99
+  LessEqFloat  r138, r137, r136
+  Const        r139, "current_price"
+  Index        r140, r104, r139
+  Const        r141, 1.49
+  LessEqFloat  r142, r140, r141
+  Move         r143, r138
+  JumpIfFalse  r143, L7
+  Move         r143, r142
 L7:
-  JumpIfFalse  r142, L6
+  JumpIfFalse  r143, L6
   // w_state: w.state,
-  Const        r143, "w_state"
-  Const        r144, "state"
-  Index        r145, r78, r144
+  Const        r144, "w_state"
+  Const        r145, "state"
+  Index        r146, r79, r145
   // i_item_id: i.item_id,
-  Const        r146, "i_item_id"
-  Const        r147, "item_id"
-  Index        r148, r103, r147
+  Const        r147, "i_item_id"
+  Const        r148, "item_id"
+  Index        r149, r104, r148
   // sold_date: d.date,
-  Const        r149, "sold_date"
-  Const        r150, "date"
-  Index        r151, r128, r150
+  Const        r150, "sold_date"
+  Const        r151, "date"
+  Index        r152, r129, r151
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r152, "net"
-  Const        r153, "price"
-  Index        r154, r24, r153
-  Const        r155, nil
-  Equal        r156, r46, r155
-  JumpIfFalse  r156, L8
-  Const        r158, 0
+  Const        r153, "net"
+  Const        r154, "price"
+  Index        r155, r25, r154
+  Const        r156, nil
+  Equal        r157, r47, r156
+  JumpIfFalse  r157, L8
+  Const        r159, 0
   Jump         L9
 L8:
-  Const        r159, "refunded"
-  Index        r158, r46, r159
+  Const        r160, "refunded"
+  Index        r159, r47, r160
 L9:
-  Sub          r161, r154, r158
+  Sub          r162, r155, r159
   // w_state: w.state,
-  Move         r162, r143
-  Move         r163, r145
-  // i_item_id: i.item_id,
+  Move         r163, r144
   Move         r164, r146
-  Move         r165, r148
-  // sold_date: d.date,
+  // i_item_id: i.item_id,
+  Move         r165, r147
   Move         r166, r149
-  Move         r167, r151
-  // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
+  // sold_date: d.date,
+  Move         r167, r150
   Move         r168, r152
-  Move         r169, r161
+  // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
+  Move         r169, r153
+  Move         r170, r162
   // select {
-  MakeMap      r170, 4, r162
+  MakeMap      r171, 4, r163
   // from cs in catalog_sales
-  Append       r6, r6, r170
+  Append       r7, r7, r171
 L6:
   // join d in date_dim on cs.date_sk == d.date_sk
-  Const        r172, 1
-  Add          r124, r124, r172
+  Const        r173, 1
+  Add          r125, r125, r173
   Jump         L10
 L5:
   // join i in item on cs.item_sk == i.item_sk
-  Const        r173, 1
-  Add          r99, r99, r173
+  Const        r174, 1
+  Add          r100, r100, r174
   Jump         L11
 L4:
   // join w in warehouse on cs.warehouse_sk == w.warehouse_sk
-  Const        r174, 1
-  Add          r74, r74, r174
+  Const        r175, 1
+  Add          r75, r75, r175
   Jump         L12
 L3:
   // left join cr in catalog_returns on cs.order == cr.order && cs.item_sk == cr.item_sk
-  Const        r175, 1
-  Add          r42, r42, r175
+  Const        r176, 1
+  Add          r43, r43, r176
   Jump         L13
 L1:
-  Move         r176, r47
-  JumpIfTrue   r176, L14
-  Const        r46, nil
+  Move         r177, r48
+  JumpIfTrue   r177, L14
+  Const        r47, nil
   // join w in warehouse on cs.warehouse_sk == w.warehouse_sk
-  IterPrep     r178, r3
-  Len          r179, r178
-  Const        r180, "warehouse_sk"
+  IterPrep     r179, r3
+  Len          r180, r179
   Const        r181, "warehouse_sk"
+  Const        r182, "warehouse_sk"
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r182, "current_price"
   Const        r183, "current_price"
+  Const        r184, "current_price"
   // w_state: w.state,
-  Const        r184, "w_state"
-  Const        r185, "state"
+  Const        r185, "w_state"
+  Const        r186, "state"
   // i_item_id: i.item_id,
-  Const        r186, "i_item_id"
-  Const        r187, "item_id"
+  Const        r187, "i_item_id"
+  Const        r188, "item_id"
   // sold_date: d.date,
-  Const        r188, "sold_date"
-  Const        r189, "date"
+  Const        r189, "sold_date"
+  Const        r190, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r190, "net"
-  Const        r191, "price"
-  Const        r192, "refunded"
+  Const        r191, "net"
+  Const        r192, "price"
+  Const        r193, "refunded"
   // join w in warehouse on cs.warehouse_sk == w.warehouse_sk
-  Const        r193, 0
+  Const        r194, 0
 L23:
-  LessInt      r195, r193, r179
-  JumpIfFalse  r195, L14
-  Index        r78, r178, r193
-  Const        r197, "warehouse_sk"
-  Index        r198, r24, r197
-  Const        r199, "warehouse_sk"
-  Index        r200, r78, r199
-  Equal        r201, r198, r200
-  JumpIfFalse  r201, L15
+  LessInt      r196, r194, r180
+  JumpIfFalse  r196, L14
+  Index        r79, r179, r194
+  Const        r198, "warehouse_sk"
+  Index        r199, r25, r198
+  Const        r200, "warehouse_sk"
+  Index        r201, r79, r200
+  Equal        r202, r199, r201
+  JumpIfFalse  r202, L15
   // join i in item on cs.item_sk == i.item_sk
-  IterPrep     r202, r2
-  Len          r203, r202
-  Const        r204, "item_sk"
+  IterPrep     r203, r2
+  Len          r204, r203
   Const        r205, "item_sk"
+  Const        r206, "item_sk"
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r206, "current_price"
   Const        r207, "current_price"
+  Const        r208, "current_price"
   // w_state: w.state,
-  Const        r208, "w_state"
-  Const        r209, "state"
+  Const        r209, "w_state"
+  Const        r210, "state"
   // i_item_id: i.item_id,
-  Const        r210, "i_item_id"
-  Const        r211, "item_id"
+  Const        r211, "i_item_id"
+  Const        r212, "item_id"
   // sold_date: d.date,
-  Const        r212, "sold_date"
-  Const        r213, "date"
+  Const        r213, "sold_date"
+  Const        r214, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r214, "net"
-  Const        r215, "price"
-  Const        r216, "refunded"
+  Const        r215, "net"
+  Const        r216, "price"
+  Const        r217, "refunded"
   // join i in item on cs.item_sk == i.item_sk
-  Const        r217, 0
+  Const        r218, 0
 L22:
-  LessInt      r219, r217, r203
-  JumpIfFalse  r219, L15
-  Index        r103, r202, r217
-  Const        r221, "item_sk"
-  Index        r222, r24, r221
-  Const        r223, "item_sk"
-  Index        r224, r103, r223
-  Equal        r225, r222, r224
-  JumpIfFalse  r225, L16
+  LessInt      r220, r218, r204
+  JumpIfFalse  r220, L15
+  Index        r104, r203, r218
+  Const        r222, "item_sk"
+  Index        r223, r25, r222
+  Const        r224, "item_sk"
+  Index        r225, r104, r224
+  Equal        r226, r223, r225
+  JumpIfFalse  r226, L16
   // join d in date_dim on cs.date_sk == d.date_sk
-  IterPrep     r226, r4
-  Len          r227, r226
-  Const        r228, "date_sk"
+  IterPrep     r227, r4
+  Len          r228, r227
   Const        r229, "date_sk"
+  Const        r230, "date_sk"
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r230, "current_price"
   Const        r231, "current_price"
+  Const        r232, "current_price"
   // w_state: w.state,
-  Const        r232, "w_state"
-  Const        r233, "state"
+  Const        r233, "w_state"
+  Const        r234, "state"
   // i_item_id: i.item_id,
-  Const        r234, "i_item_id"
-  Const        r235, "item_id"
+  Const        r235, "i_item_id"
+  Const        r236, "item_id"
   // sold_date: d.date,
-  Const        r236, "sold_date"
-  Const        r237, "date"
+  Const        r237, "sold_date"
+  Const        r238, "date"
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r238, "net"
-  Const        r239, "price"
-  Const        r240, "refunded"
+  Const        r239, "net"
+  Const        r240, "price"
+  Const        r241, "refunded"
   // join d in date_dim on cs.date_sk == d.date_sk
-  Const        r241, 0
+  Const        r242, 0
 L21:
-  LessInt      r243, r241, r227
-  JumpIfFalse  r243, L16
-  Index        r128, r226, r241
-  Const        r245, "date_sk"
-  Index        r246, r24, r245
-  Const        r247, "date_sk"
-  Index        r248, r128, r247
-  Equal        r249, r246, r248
-  JumpIfFalse  r249, L17
+  LessInt      r244, r242, r228
+  JumpIfFalse  r244, L16
+  Index        r129, r227, r242
+  Const        r246, "date_sk"
+  Index        r247, r25, r246
+  Const        r248, "date_sk"
+  Index        r249, r129, r248
+  Equal        r250, r247, r249
+  JumpIfFalse  r250, L17
   // where i.current_price >= 0.99 && i.current_price <= 1.49
-  Const        r250, "current_price"
-  Index        r251, r103, r250
-  Const        r252, 0.99
-  LessEqFloat  r253, r252, r251
-  Const        r254, "current_price"
-  Index        r255, r103, r254
-  Const        r256, 1.49
-  LessEqFloat  r257, r255, r256
-  Move         r258, r253
-  JumpIfFalse  r258, L18
-  Move         r258, r257
+  Const        r251, "current_price"
+  Index        r252, r104, r251
+  Const        r253, 0.99
+  LessEqFloat  r254, r253, r252
+  Const        r255, "current_price"
+  Index        r256, r104, r255
+  Const        r257, 1.49
+  LessEqFloat  r258, r256, r257
+  Move         r259, r254
+  JumpIfFalse  r259, L18
+  Move         r259, r258
 L18:
-  JumpIfFalse  r258, L17
+  JumpIfFalse  r259, L17
   // w_state: w.state,
-  Const        r259, "w_state"
-  Const        r260, "state"
-  Index        r261, r78, r260
+  Const        r260, "w_state"
+  Const        r261, "state"
+  Index        r262, r79, r261
   // i_item_id: i.item_id,
-  Const        r262, "i_item_id"
-  Const        r263, "item_id"
-  Index        r264, r103, r263
+  Const        r263, "i_item_id"
+  Const        r264, "item_id"
+  Index        r265, r104, r264
   // sold_date: d.date,
-  Const        r265, "sold_date"
-  Const        r266, "date"
-  Index        r267, r128, r266
+  Const        r266, "sold_date"
+  Const        r267, "date"
+  Index        r268, r129, r267
   // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
-  Const        r268, "net"
-  Const        r269, "price"
-  Index        r270, r24, r269
-  Const        r271, nil
-  Equal        r272, r46, r271
-  JumpIfFalse  r272, L19
-  Const        r274, 0
+  Const        r269, "net"
+  Const        r270, "price"
+  Index        r271, r25, r270
+  Const        r272, nil
+  Equal        r273, r47, r272
+  JumpIfFalse  r273, L19
+  Const        r275, 0
   Jump         L20
 L19:
-  Const        r275, "refunded"
-  Index        r274, r46, r275
+  Const        r276, "refunded"
+  Index        r275, r47, r276
 L20:
-  Sub          r277, r270, r274
+  Sub          r278, r271, r275
   // w_state: w.state,
-  Move         r278, r259
-  Move         r279, r261
-  // i_item_id: i.item_id,
+  Move         r279, r260
   Move         r280, r262
-  Move         r281, r264
-  // sold_date: d.date,
+  // i_item_id: i.item_id,
+  Move         r281, r263
   Move         r282, r265
-  Move         r283, r267
-  // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
+  // sold_date: d.date,
+  Move         r283, r266
   Move         r284, r268
-  Move         r285, r277
+  // net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
+  Move         r285, r269
+  Move         r286, r278
   // select {
-  MakeMap      r286, 4, r278
+  MakeMap      r287, 4, r279
   // from cs in catalog_sales
-  Append       r6, r6, r286
+  Append       r7, r7, r287
 L17:
   // join d in date_dim on cs.date_sk == d.date_sk
-  Const        r288, 1
-  Add          r241, r241, r288
+  Const        r289, 1
+  Add          r242, r242, r289
   Jump         L21
 L16:
   // join i in item on cs.item_sk == i.item_sk
-  Const        r289, 1
-  Add          r217, r217, r289
+  Const        r290, 1
+  Add          r218, r218, r290
   Jump         L22
 L15:
   // join w in warehouse on cs.warehouse_sk == w.warehouse_sk
-  Const        r290, 1
-  Add          r193, r193, r290
+  Const        r291, 1
+  Add          r194, r194, r291
   Jump         L23
 L14:
   // from cs in catalog_sales
-  Const        r291, 1
-  AddInt       r20, r20, r291
+  Const        r292, 1
+  AddInt       r21, r21, r292
   Jump         L24
 L0:
   // from r in records
-  Const        r292, []
+  Const        r293, []
   // group by { w_state: r.w_state, i_item_id: r.i_item_id } into g
-  Const        r293, "w_state"
   Const        r294, "w_state"
-  Const        r295, "i_item_id"
+  Const        r295, "w_state"
   Const        r296, "i_item_id"
+  Const        r297, "i_item_id"
   // w_state: g.key.w_state,
-  Const        r297, "w_state"
-  Const        r298, "key"
-  Const        r299, "w_state"
+  Const        r298, "w_state"
+  Const        r299, "key"
+  Const        r300, "w_state"
   // i_item_id: g.key.i_item_id,
-  Const        r300, "i_item_id"
-  Const        r301, "key"
-  Const        r302, "i_item_id"
+  Const        r301, "i_item_id"
+  Const        r302, "key"
+  Const        r303, "i_item_id"
   // sales_before: sum(from x in g select if x.sold_date < sales_date { x.net } else { 0.0 }),
-  Const        r303, "sales_before"
-  Const        r304, "sold_date"
-  Const        r305, "net"
+  Const        r304, "sales_before"
+  Const        r305, "sold_date"
+  Const        r306, "net"
   // sales_after: sum(from x in g select if x.sold_date >= sales_date { x.net } else { 0.0 })
-  Const        r306, "sales_after"
-  Const        r307, "sold_date"
-  Const        r308, "net"
+  Const        r307, "sales_after"
+  Const        r308, "sold_date"
+  Const        r309, "net"
   // from r in records
-  IterPrep     r309, r6
-  Len          r310, r309
-  Const        r311, 0
-  MakeMap      r312, 0, r0
-  Const        r313, []
+  IterPrep     r310, r7
+  Len          r311, r310
+  Const        r312, 0
+  MakeMap      r313, 0, r0
+  Const        r314, []
 L27:
-  LessInt      r315, r311, r310
-  JumpIfFalse  r315, L25
-  Index        r316, r309, r311
-  Move         r317, r316
+  LessInt      r316, r312, r311
+  JumpIfFalse  r316, L25
+  Index        r317, r310, r312
+  Move         r318, r317
   // group by { w_state: r.w_state, i_item_id: r.i_item_id } into g
-  Const        r318, "w_state"
   Const        r319, "w_state"
-  Index        r320, r317, r319
-  Const        r321, "i_item_id"
+  Const        r320, "w_state"
+  Index        r321, r318, r320
   Const        r322, "i_item_id"
-  Index        r323, r317, r322
-  Move         r324, r318
-  Move         r325, r320
+  Const        r323, "i_item_id"
+  Index        r324, r318, r323
+  Move         r325, r319
   Move         r326, r321
-  Move         r327, r323
-  MakeMap      r328, 2, r324
-  Str          r329, r328
-  In           r330, r329, r312
-  JumpIfTrue   r330, L26
+  Move         r327, r322
+  Move         r328, r324
+  MakeMap      r329, 2, r325
+  Str          r330, r329
+  In           r331, r330, r313
+  JumpIfTrue   r331, L26
   // from r in records
-  Const        r331, []
-  Const        r332, "__group__"
-  Const        r333, true
-  Const        r334, "key"
+  Const        r332, []
+  Const        r333, "__group__"
+  Const        r334, true
+  Const        r335, "key"
   // group by { w_state: r.w_state, i_item_id: r.i_item_id } into g
-  Move         r335, r328
+  Move         r336, r329
   // from r in records
-  Const        r336, "items"
-  Move         r337, r331
-  Const        r338, "count"
-  Const        r339, 0
-  Move         r340, r332
+  Const        r337, "items"
+  Move         r338, r332
+  Const        r339, "count"
+  Const        r340, 0
   Move         r341, r333
   Move         r342, r334
   Move         r343, r335
@@ -507,122 +508,125 @@ L27:
   Move         r345, r337
   Move         r346, r338
   Move         r347, r339
-  MakeMap      r348, 4, r340
-  SetIndex     r312, r329, r348
-  Append       r313, r313, r348
+  Move         r348, r340
+  MakeMap      r349, 4, r341
+  SetIndex     r313, r330, r349
+  Append       r314, r314, r349
 L26:
-  Const        r350, "items"
-  Index        r351, r312, r329
-  Index        r352, r351, r350
-  Append       r353, r352, r316
-  SetIndex     r351, r350, r353
-  Const        r354, "count"
-  Index        r355, r351, r354
-  Const        r356, 1
-  AddInt       r357, r355, r356
-  SetIndex     r351, r354, r357
-  Const        r358, 1
-  AddInt       r311, r311, r358
+  Const        r351, "items"
+  Index        r352, r313, r330
+  Index        r353, r352, r351
+  Append       r354, r353, r317
+  SetIndex     r352, r351, r354
+  Const        r355, "count"
+  Index        r356, r352, r355
+  Const        r357, 1
+  AddInt       r358, r356, r357
+  SetIndex     r352, r355, r358
+  Const        r359, 1
+  AddInt       r312, r312, r359
   Jump         L27
 L25:
-  Const        r359, 0
-  Len          r361, r313
+  Const        r360, 0
+  Len          r362, r314
 L37:
-  LessInt      r362, r359, r361
-  JumpIfFalse  r362, L28
-  Index        r364, r313, r359
+  LessInt      r363, r360, r362
+  JumpIfFalse  r363, L28
+  Index        r365, r314, r360
   // w_state: g.key.w_state,
-  Const        r365, "w_state"
-  Const        r366, "key"
-  Index        r367, r364, r366
-  Const        r368, "w_state"
-  Index        r369, r367, r368
+  Const        r366, "w_state"
+  Const        r367, "key"
+  Index        r368, r365, r367
+  Const        r369, "w_state"
+  Index        r370, r368, r369
   // i_item_id: g.key.i_item_id,
-  Const        r370, "i_item_id"
-  Const        r371, "key"
-  Index        r372, r364, r371
-  Const        r373, "i_item_id"
-  Index        r374, r372, r373
+  Const        r371, "i_item_id"
+  Const        r372, "key"
+  Index        r373, r365, r372
+  Const        r374, "i_item_id"
+  Index        r375, r373, r374
   // sales_before: sum(from x in g select if x.sold_date < sales_date { x.net } else { 0.0 }),
-  Const        r375, "sales_before"
-  Const        r376, []
-  Const        r377, "sold_date"
-  Const        r378, "net"
-  IterPrep     r379, r364
-  Len          r380, r379
-  Const        r381, 0
+  Const        r376, "sales_before"
+  Const        r377, []
+  Const        r378, "sold_date"
+  Const        r379, "net"
+  IterPrep     r380, r365
+  Len          r381, r380
+  Const        r382, 0
 L32:
-  LessInt      r383, r381, r380
-  JumpIfFalse  r383, L29
-  Index        r385, r379, r381
-  Const        r386, "sold_date"
-  Index        r387, r385, r386
-  Less         r388, r387, r5
-  JumpIfFalse  r388, L30
-  Const        r389, "net"
-  Index        r391, r385, r389
+  LessInt      r384, r382, r381
+  JumpIfFalse  r384, L29
+  Index        r386, r380, r382
+  Const        r387, "sold_date"
+  Index        r388, r386, r387
+  Less         r389, r388, r5
+  JumpIfFalse  r389, L30
+  Const        r390, "net"
+  Index        r392, r386, r390
   Jump         L31
 L30:
-  Const        r391, 0
+  Const        r392, 0
 L31:
-  Append       r376, r376, r391
-  Const        r394, 1
-  AddInt       r381, r381, r394
+  Append       r377, r377, r392
+  Const        r395, 1
+  AddInt       r382, r382, r395
   Jump         L32
 L29:
-  Sum          r395, r376
+  Sum          r396, r377
   // sales_after: sum(from x in g select if x.sold_date >= sales_date { x.net } else { 0.0 })
-  Const        r396, "sales_after"
-  Const        r397, []
-  Const        r398, "sold_date"
-  Const        r399, "net"
-  IterPrep     r400, r364
-  Len          r401, r400
-  Const        r402, 0
+  Const        r397, "sales_after"
+  Const        r398, []
+  Const        r399, "sold_date"
+  Const        r400, "net"
+  IterPrep     r401, r365
+  Len          r402, r401
+  Const        r403, 0
 L36:
-  LessInt      r404, r402, r401
-  JumpIfFalse  r404, L33
-  Index        r385, r400, r402
-  Const        r406, "sold_date"
-  Index        r407, r385, r406
-  LessEq       r408, r5, r407
-  JumpIfFalse  r408, L34
-  Const        r409, "net"
-  Index        r411, r385, r409
+  LessInt      r405, r403, r402
+  JumpIfFalse  r405, L33
+  Index        r386, r401, r403
+  Const        r407, "sold_date"
+  Index        r408, r386, r407
+  LessEq       r409, r5, r408
+  JumpIfFalse  r409, L34
+  Const        r410, "net"
+  Index        r412, r386, r410
   Jump         L35
 L34:
-  Const        r411, 0
+  Const        r412, 0
 L35:
-  Append       r397, r397, r411
-  Const        r414, 1
-  AddInt       r402, r402, r414
+  Append       r398, r398, r412
+  Const        r415, 1
+  AddInt       r403, r403, r415
   Jump         L36
 L33:
-  Sum          r415, r397
+  Sum          r416, r398
   // w_state: g.key.w_state,
-  Move         r416, r365
-  Move         r417, r369
-  // i_item_id: g.key.i_item_id,
+  Move         r417, r366
   Move         r418, r370
-  Move         r419, r374
-  // sales_before: sum(from x in g select if x.sold_date < sales_date { x.net } else { 0.0 }),
+  // i_item_id: g.key.i_item_id,
+  Move         r419, r371
   Move         r420, r375
-  Move         r421, r395
-  // sales_after: sum(from x in g select if x.sold_date >= sales_date { x.net } else { 0.0 })
+  // sales_before: sum(from x in g select if x.sold_date < sales_date { x.net } else { 0.0 }),
+  Move         r421, r376
   Move         r422, r396
-  Move         r423, r415
+  // sales_after: sum(from x in g select if x.sold_date >= sales_date { x.net } else { 0.0 })
+  Move         r423, r397
+  Move         r424, r416
   // select {
-  MakeMap      r424, 4, r416
+  MakeMap      r425, 4, r417
   // from r in records
-  Append       r292, r292, r424
-  Const        r426, 1
-  AddInt       r359, r359, r426
+  Append       r293, r293, r425
+  Const        r427, 1
+  AddInt       r360, r360, r427
   Jump         L37
 L28:
+  // let result = concat(dummy, base)
+  UnionAll     r428, r6, r293
   // json(result)
-  JSON         r292
+  JSON         r428
   // expect result == [
-  Const        r427, [{"i_item_id": "I1", "sales_after": 0, "sales_before": 100, "w_state": "CA"}]
-  Equal        r428, r292, r427
-  Expect       r428
+  Const        r429, [{"i_item_id": "I1", "sales_after": 0, "sales_before": 100, "w_state": "CA"}]
+  Equal        r430, r428, r429
+  Expect       r430
   Return       r0

--- a/tests/dataset/tpc-ds/out/q41.ir.out
+++ b/tests/dataset/tpc-ds/out/q41.ir.out
@@ -1,106 +1,110 @@
-func main (regs=68)
+func main (regs=70)
   // let item = [
   Const        r0, [{"category": "Women", "color": "blue", "manufact": 1, "manufact_id": 100, "product_name": "Blue Shirt", "size": "M", "units": "pack"}, {"category": "Women", "color": "red", "manufact": 1, "manufact_id": 120, "product_name": "Red Dress", "size": "M", "units": "pack"}, {"category": "Men", "color": "black", "manufact": 2, "manufact_id": 200, "product_name": "Pants", "size": "L", "units": "pair"}]
   // let lower = 100
   Const        r1, 100
+  // let dummy = null
+  Const        r2, nil
   // from i1 in item
-  Const        r2, []
+  Const        r3, []
   // where i1.manufact_id >= lower && i1.manufact_id <= lower + 40 &&
-  Const        r3, "manufact_id"
   Const        r4, "manufact_id"
+  Const        r5, "manufact_id"
   // count(from i2 in item where i2.manufact == i1.manufact && i2.category == i1.category select i2) > 1
-  Const        r5, "manufact"
   Const        r6, "manufact"
-  Const        r7, "category"
+  Const        r7, "manufact"
   Const        r8, "category"
+  Const        r9, "category"
   // select i1.product_name
-  Const        r9, "product_name"
-  // order by i1.product_name
   Const        r10, "product_name"
+  // order by i1.product_name
+  Const        r11, "product_name"
   // from i1 in item
-  IterPrep     r11, r0
-  Len          r12, r11
-  Const        r13, 0
+  IterPrep     r12, r0
+  Len          r13, r12
+  Const        r14, 0
 L8:
-  LessInt      r15, r13, r12
-  JumpIfFalse  r15, L0
-  Index        r17, r11, r13
+  LessInt      r16, r14, r13
+  JumpIfFalse  r16, L0
+  Index        r18, r12, r14
   // where i1.manufact_id >= lower && i1.manufact_id <= lower + 40 &&
-  Const        r18, "manufact_id"
-  Index        r19, r17, r18
-  Const        r20, 40
-  Const        r21, 140
-  LessEq       r22, r1, r19
-  Const        r23, "manufact_id"
-  Index        r24, r17, r23
-  LessEq       r25, r24, r21
+  Const        r19, "manufact_id"
+  Index        r20, r18, r19
+  Const        r21, 40
+  Const        r22, 140
+  LessEq       r23, r1, r20
+  Const        r24, "manufact_id"
+  Index        r25, r18, r24
+  LessEq       r26, r25, r22
   // count(from i2 in item where i2.manufact == i1.manufact && i2.category == i1.category select i2) > 1
-  Const        r26, []
-  Const        r27, "manufact"
+  Const        r27, []
   Const        r28, "manufact"
-  Const        r29, "category"
+  Const        r29, "manufact"
   Const        r30, "category"
-  IterPrep     r31, r0
-  Len          r32, r31
-  Const        r33, 0
+  Const        r31, "category"
+  IterPrep     r32, r0
+  Len          r33, r32
+  Const        r34, 0
 L4:
-  LessInt      r35, r33, r32
-  JumpIfFalse  r35, L1
-  Index        r37, r31, r33
-  Const        r38, "manufact"
-  Index        r39, r37, r38
-  Const        r40, "manufact"
-  Index        r41, r17, r40
-  Equal        r42, r39, r41
-  Const        r43, "category"
-  Index        r44, r37, r43
-  Const        r45, "category"
-  Index        r46, r17, r45
-  Equal        r47, r44, r46
-  Move         r48, r42
-  JumpIfFalse  r48, L2
-  Move         r48, r47
+  LessInt      r36, r34, r33
+  JumpIfFalse  r36, L1
+  Index        r38, r32, r34
+  Const        r39, "manufact"
+  Index        r40, r38, r39
+  Const        r41, "manufact"
+  Index        r42, r18, r41
+  Equal        r43, r40, r42
+  Const        r44, "category"
+  Index        r45, r38, r44
+  Const        r46, "category"
+  Index        r47, r18, r46
+  Equal        r48, r45, r47
+  Move         r49, r43
+  JumpIfFalse  r49, L2
+  Move         r49, r48
 L2:
-  JumpIfFalse  r48, L3
-  Append       r26, r26, r37
+  JumpIfFalse  r49, L3
+  Append       r27, r27, r38
 L3:
-  Const        r50, 1
-  AddInt       r33, r33, r50
+  Const        r51, 1
+  AddInt       r34, r34, r51
   Jump         L4
 L1:
-  Count        r51, r26
-  Const        r52, 1
-  LessInt      r53, r52, r51
+  Count        r52, r27
+  Const        r53, 1
+  LessInt      r54, r53, r52
   // where i1.manufact_id >= lower && i1.manufact_id <= lower + 40 &&
-  Move         r54, r22
-  JumpIfFalse  r54, L5
+  Move         r55, r23
+  JumpIfFalse  r55, L5
 L5:
-  Move         r55, r25
-  JumpIfFalse  r55, L6
-  Move         r55, r53
+  Move         r56, r26
+  JumpIfFalse  r56, L6
+  Move         r56, r54
 L6:
-  JumpIfFalse  r55, L7
+  JumpIfFalse  r56, L7
   // select i1.product_name
-  Const        r56, "product_name"
-  Index        r57, r17, r56
+  Const        r57, "product_name"
+  Index        r58, r18, r57
   // order by i1.product_name
-  Const        r58, "product_name"
-  Index        r60, r17, r58
+  Const        r59, "product_name"
+  Index        r61, r18, r59
   // from i1 in item
-  Move         r61, r57
-  MakeList     r62, 2, r60
-  Append       r2, r2, r62
+  Move         r62, r58
+  MakeList     r63, 2, r61
+  Append       r3, r3, r63
 L7:
-  Const        r64, 1
-  AddInt       r13, r13, r64
+  Const        r65, 1
+  AddInt       r14, r14, r65
   Jump         L8
 L0:
   // order by i1.product_name
-  Sort         r2, r2
+  Sort         r3, r3
+  // let result = concat(dummy, base)
+  UnionAll     r67, r2, r3
   // json(result)
-  JSON         r2
+  JSON         r67
   // expect result == ["Blue Shirt", "Red Dress"]
-  Const        r66, ["Blue Shirt", "Red Dress"]
-  Equal        r67, r2, r66
-  Expect       r67
+  Const        r68, ["Blue Shirt", "Red Dress"]
+  Equal        r69, r67, r68
+  Expect       r69
   Return       r0

--- a/tests/dataset/tpc-ds/out/q42.ir.out
+++ b/tests/dataset/tpc-ds/out/q42.ir.out
@@ -1,4 +1,4 @@
-func main (regs=275)
+func main (regs=277)
   // let store_sales = [
   Const        r0, [{"ext_sales_price": 10, "item_sk": 1, "sold_date_sk": 1}, {"ext_sales_price": 20, "item_sk": 2, "sold_date_sk": 1}, {"ext_sales_price": 15, "item_sk": 1, "sold_date_sk": 2}]
   // let item = [
@@ -9,224 +9,225 @@ func main (regs=275)
   Const        r3, 5
   // let year = 2020
   Const        r4, 2020
+  // let dummy = null
+  Const        r5, nil
   // from dt in date_dim
-  Const        r5, []
+  Const        r6, []
   // where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
-  Const        r6, "i_manager_id"
-  Const        r7, "d_moy"
-  Const        r8, "d_year"
-  // select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
+  Const        r7, "i_manager_id"
+  Const        r8, "d_moy"
   Const        r9, "d_year"
+  // select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
   Const        r10, "d_year"
-  Const        r11, "i_category_id"
+  Const        r11, "d_year"
   Const        r12, "i_category_id"
-  Const        r13, "i_category"
+  Const        r13, "i_category_id"
   Const        r14, "i_category"
-  Const        r15, "price"
-  Const        r16, "ext_sales_price"
+  Const        r15, "i_category"
+  Const        r16, "price"
+  Const        r17, "ext_sales_price"
   // from dt in date_dim
-  IterPrep     r17, r2
-  Len          r18, r17
-  Const        r19, 0
+  IterPrep     r18, r2
+  Len          r19, r18
+  Const        r20, 0
 L8:
-  LessInt      r21, r19, r18
-  JumpIfFalse  r21, L0
-  Index        r23, r17, r19
+  LessInt      r22, r20, r19
+  JumpIfFalse  r22, L0
+  Index        r24, r18, r20
   // join ss in store_sales on ss.sold_date_sk == dt.d_date_sk
-  IterPrep     r24, r0
-  Len          r25, r24
-  Const        r26, "sold_date_sk"
-  Const        r27, "d_date_sk"
+  IterPrep     r25, r0
+  Len          r26, r25
+  Const        r27, "sold_date_sk"
+  Const        r28, "d_date_sk"
   // where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
-  Const        r28, "i_manager_id"
-  Const        r29, "d_moy"
-  Const        r30, "d_year"
-  // select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
+  Const        r29, "i_manager_id"
+  Const        r30, "d_moy"
   Const        r31, "d_year"
+  // select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
   Const        r32, "d_year"
-  Const        r33, "i_category_id"
+  Const        r33, "d_year"
   Const        r34, "i_category_id"
-  Const        r35, "i_category"
+  Const        r35, "i_category_id"
   Const        r36, "i_category"
-  Const        r37, "price"
-  Const        r38, "ext_sales_price"
+  Const        r37, "i_category"
+  Const        r38, "price"
+  Const        r39, "ext_sales_price"
   // join ss in store_sales on ss.sold_date_sk == dt.d_date_sk
-  Const        r39, 0
+  Const        r40, 0
 L7:
-  LessInt      r41, r39, r25
-  JumpIfFalse  r41, L1
-  Index        r43, r24, r39
-  Const        r44, "sold_date_sk"
-  Index        r45, r43, r44
-  Const        r46, "d_date_sk"
-  Index        r47, r23, r46
-  Equal        r48, r45, r47
-  JumpIfFalse  r48, L2
+  LessInt      r42, r40, r26
+  JumpIfFalse  r42, L1
+  Index        r44, r25, r40
+  Const        r45, "sold_date_sk"
+  Index        r46, r44, r45
+  Const        r47, "d_date_sk"
+  Index        r48, r24, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L2
   // join it in item on ss.item_sk == it.i_item_sk
-  IterPrep     r49, r1
-  Len          r50, r49
-  Const        r51, "item_sk"
-  Const        r52, "i_item_sk"
+  IterPrep     r50, r1
+  Len          r51, r50
+  Const        r52, "item_sk"
+  Const        r53, "i_item_sk"
   // where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
-  Const        r53, "i_manager_id"
-  Const        r54, "d_moy"
-  Const        r55, "d_year"
-  // select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
+  Const        r54, "i_manager_id"
+  Const        r55, "d_moy"
   Const        r56, "d_year"
-  Const        r57, "d_year"
-  Const        r58, "i_category_id"
-  Const        r59, "i_category_id"
-  Const        r60, "i_category"
-  Const        r61, "i_category"
-  Const        r62, "price"
-  Const        r63, "ext_sales_price"
-  // join it in item on ss.item_sk == it.i_item_sk
-  Const        r64, 0
-L6:
-  LessInt      r66, r64, r50
-  JumpIfFalse  r66, L2
-  Index        r68, r49, r64
-  Const        r69, "item_sk"
-  Index        r70, r43, r69
-  Const        r71, "i_item_sk"
-  Index        r72, r68, r71
-  Equal        r73, r70, r72
-  JumpIfFalse  r73, L3
-  // where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
-  Const        r74, "i_manager_id"
-  Index        r75, r68, r74
-  Const        r76, 1
-  Equal        r77, r75, r76
-  Const        r78, "d_moy"
-  Index        r79, r23, r78
-  Equal        r80, r79, r3
-  Const        r81, "d_year"
-  Index        r82, r23, r81
-  Equal        r83, r82, r4
-  Move         r84, r77
-  JumpIfFalse  r84, L4
-L4:
-  Move         r85, r80
-  JumpIfFalse  r85, L5
-  Move         r85, r83
-L5:
-  JumpIfFalse  r85, L3
   // select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
-  Const        r86, "d_year"
+  Const        r57, "d_year"
+  Const        r58, "d_year"
+  Const        r59, "i_category_id"
+  Const        r60, "i_category_id"
+  Const        r61, "i_category"
+  Const        r62, "i_category"
+  Const        r63, "price"
+  Const        r64, "ext_sales_price"
+  // join it in item on ss.item_sk == it.i_item_sk
+  Const        r65, 0
+L6:
+  LessInt      r67, r65, r51
+  JumpIfFalse  r67, L2
+  Index        r69, r50, r65
+  Const        r70, "item_sk"
+  Index        r71, r44, r70
+  Const        r72, "i_item_sk"
+  Index        r73, r69, r72
+  Equal        r74, r71, r73
+  JumpIfFalse  r74, L3
+  // where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
+  Const        r75, "i_manager_id"
+  Index        r76, r69, r75
+  Const        r77, 1
+  Equal        r78, r76, r77
+  Const        r79, "d_moy"
+  Index        r80, r24, r79
+  Equal        r81, r80, r3
+  Const        r82, "d_year"
+  Index        r83, r24, r82
+  Equal        r84, r83, r4
+  Move         r85, r78
+  JumpIfFalse  r85, L4
+L4:
+  Move         r86, r81
+  JumpIfFalse  r86, L5
+  Move         r86, r84
+L5:
+  JumpIfFalse  r86, L3
+  // select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
   Const        r87, "d_year"
-  Index        r88, r23, r87
-  Const        r89, "i_category_id"
+  Const        r88, "d_year"
+  Index        r89, r24, r88
   Const        r90, "i_category_id"
-  Index        r91, r68, r90
-  Const        r92, "i_category"
+  Const        r91, "i_category_id"
+  Index        r92, r69, r91
   Const        r93, "i_category"
-  Index        r94, r68, r93
-  Const        r95, "price"
-  Const        r96, "ext_sales_price"
-  Index        r97, r43, r96
-  Move         r98, r86
-  Move         r99, r88
+  Const        r94, "i_category"
+  Index        r95, r69, r94
+  Const        r96, "price"
+  Const        r97, "ext_sales_price"
+  Index        r98, r44, r97
+  Move         r99, r87
   Move         r100, r89
-  Move         r101, r91
+  Move         r101, r90
   Move         r102, r92
-  Move         r103, r94
+  Move         r103, r93
   Move         r104, r95
-  Move         r105, r97
-  MakeMap      r106, 4, r98
+  Move         r105, r96
+  Move         r106, r98
+  MakeMap      r107, 4, r99
   // from dt in date_dim
-  Append       r5, r5, r106
+  Append       r6, r6, r107
 L3:
   // join it in item on ss.item_sk == it.i_item_sk
-  Const        r108, 1
-  Add          r64, r64, r108
+  Const        r109, 1
+  Add          r65, r65, r109
   Jump         L6
 L2:
   // join ss in store_sales on ss.sold_date_sk == dt.d_date_sk
-  Const        r109, 1
-  Add          r39, r39, r109
+  Const        r110, 1
+  Add          r40, r40, r110
   Jump         L7
 L1:
   // from dt in date_dim
-  Const        r110, 1
-  AddInt       r19, r19, r110
+  Const        r111, 1
+  AddInt       r20, r20, r111
   Jump         L8
 L0:
   // from r in records
-  Const        r111, []
+  Const        r112, []
   // group by { d_year: r.d_year, i_category_id: r.i_category_id, i_category: r.i_category } into g
-  Const        r112, "d_year"
   Const        r113, "d_year"
-  Const        r114, "i_category_id"
+  Const        r114, "d_year"
   Const        r115, "i_category_id"
-  Const        r116, "i_category"
+  Const        r116, "i_category_id"
   Const        r117, "i_category"
+  Const        r118, "i_category"
   // d_year: g.key.d_year,
-  Const        r118, "d_year"
-  Const        r119, "key"
-  Const        r120, "d_year"
+  Const        r119, "d_year"
+  Const        r120, "key"
+  Const        r121, "d_year"
   // i_category_id: g.key.i_category_id,
-  Const        r121, "i_category_id"
-  Const        r122, "key"
-  Const        r123, "i_category_id"
+  Const        r122, "i_category_id"
+  Const        r123, "key"
+  Const        r124, "i_category_id"
   // i_category: g.key.i_category,
-  Const        r124, "i_category"
-  Const        r125, "key"
-  Const        r126, "i_category"
+  Const        r125, "i_category"
+  Const        r126, "key"
+  Const        r127, "i_category"
   // sum_ss_ext_sales_price: sum(from x in g select x.price)
-  Const        r127, "sum_ss_ext_sales_price"
-  Const        r128, "price"
-  // sort by [-sum(from x in g select x.price), g.key.d_year, g.key.i_category_id, g.key.i_category]
+  Const        r128, "sum_ss_ext_sales_price"
   Const        r129, "price"
-  Const        r130, "key"
-  Const        r131, "d_year"
-  Const        r132, "key"
-  Const        r133, "i_category_id"
-  Const        r134, "key"
-  Const        r135, "i_category"
+  // sort by [-sum(from x in g select x.price), g.key.d_year, g.key.i_category_id, g.key.i_category]
+  Const        r130, "price"
+  Const        r131, "key"
+  Const        r132, "d_year"
+  Const        r133, "key"
+  Const        r134, "i_category_id"
+  Const        r135, "key"
+  Const        r136, "i_category"
   // from r in records
-  IterPrep     r136, r5
-  Len          r137, r136
-  Const        r138, 0
-  MakeMap      r139, 0, r0
-  Const        r140, []
+  IterPrep     r137, r6
+  Len          r138, r137
+  Const        r139, 0
+  MakeMap      r140, 0, r0
+  Const        r141, []
 L11:
-  LessInt      r142, r138, r137
-  JumpIfFalse  r142, L9
-  Index        r143, r136, r138
-  Move         r144, r143
+  LessInt      r143, r139, r138
+  JumpIfFalse  r143, L9
+  Index        r144, r137, r139
+  Move         r145, r144
   // group by { d_year: r.d_year, i_category_id: r.i_category_id, i_category: r.i_category } into g
-  Const        r145, "d_year"
   Const        r146, "d_year"
-  Index        r147, r144, r146
-  Const        r148, "i_category_id"
+  Const        r147, "d_year"
+  Index        r148, r145, r147
   Const        r149, "i_category_id"
-  Index        r150, r144, r149
-  Const        r151, "i_category"
+  Const        r150, "i_category_id"
+  Index        r151, r145, r150
   Const        r152, "i_category"
-  Index        r153, r144, r152
-  Move         r154, r145
-  Move         r155, r147
+  Const        r153, "i_category"
+  Index        r154, r145, r153
+  Move         r155, r146
   Move         r156, r148
-  Move         r157, r150
+  Move         r157, r149
   Move         r158, r151
-  Move         r159, r153
-  MakeMap      r160, 3, r154
-  Str          r161, r160
-  In           r162, r161, r139
-  JumpIfTrue   r162, L10
+  Move         r159, r152
+  Move         r160, r154
+  MakeMap      r161, 3, r155
+  Str          r162, r161
+  In           r163, r162, r140
+  JumpIfTrue   r163, L10
   // from r in records
-  Const        r163, []
-  Const        r164, "__group__"
-  Const        r165, true
-  Const        r166, "key"
+  Const        r164, []
+  Const        r165, "__group__"
+  Const        r166, true
+  Const        r167, "key"
   // group by { d_year: r.d_year, i_category_id: r.i_category_id, i_category: r.i_category } into g
-  Move         r167, r160
+  Move         r168, r161
   // from r in records
-  Const        r168, "items"
-  Move         r169, r163
-  Const        r170, "count"
-  Const        r171, 0
-  Move         r172, r164
+  Const        r169, "items"
+  Move         r170, r164
+  Const        r171, "count"
+  Const        r172, 0
   Move         r173, r165
   Move         r174, r166
   Move         r175, r167
@@ -234,127 +235,130 @@ L11:
   Move         r177, r169
   Move         r178, r170
   Move         r179, r171
-  MakeMap      r180, 4, r172
-  SetIndex     r139, r161, r180
-  Append       r140, r140, r180
+  Move         r180, r172
+  MakeMap      r181, 4, r173
+  SetIndex     r140, r162, r181
+  Append       r141, r141, r181
 L10:
-  Const        r182, "items"
-  Index        r183, r139, r161
-  Index        r184, r183, r182
-  Append       r185, r184, r143
-  SetIndex     r183, r182, r185
-  Const        r186, "count"
-  Index        r187, r183, r186
-  Const        r188, 1
-  AddInt       r189, r187, r188
-  SetIndex     r183, r186, r189
-  Const        r190, 1
-  AddInt       r138, r138, r190
+  Const        r183, "items"
+  Index        r184, r140, r162
+  Index        r185, r184, r183
+  Append       r186, r185, r144
+  SetIndex     r184, r183, r186
+  Const        r187, "count"
+  Index        r188, r184, r187
+  Const        r189, 1
+  AddInt       r190, r188, r189
+  SetIndex     r184, r187, r190
+  Const        r191, 1
+  AddInt       r139, r139, r191
   Jump         L11
 L9:
-  Const        r191, 0
-  Len          r193, r140
+  Const        r192, 0
+  Len          r194, r141
 L17:
-  LessInt      r194, r191, r193
-  JumpIfFalse  r194, L12
-  Index        r196, r140, r191
+  LessInt      r195, r192, r194
+  JumpIfFalse  r195, L12
+  Index        r197, r141, r192
   // d_year: g.key.d_year,
-  Const        r197, "d_year"
-  Const        r198, "key"
-  Index        r199, r196, r198
-  Const        r200, "d_year"
-  Index        r201, r199, r200
+  Const        r198, "d_year"
+  Const        r199, "key"
+  Index        r200, r197, r199
+  Const        r201, "d_year"
+  Index        r202, r200, r201
   // i_category_id: g.key.i_category_id,
-  Const        r202, "i_category_id"
-  Const        r203, "key"
-  Index        r204, r196, r203
-  Const        r205, "i_category_id"
-  Index        r206, r204, r205
+  Const        r203, "i_category_id"
+  Const        r204, "key"
+  Index        r205, r197, r204
+  Const        r206, "i_category_id"
+  Index        r207, r205, r206
   // i_category: g.key.i_category,
-  Const        r207, "i_category"
-  Const        r208, "key"
-  Index        r209, r196, r208
-  Const        r210, "i_category"
-  Index        r211, r209, r210
+  Const        r208, "i_category"
+  Const        r209, "key"
+  Index        r210, r197, r209
+  Const        r211, "i_category"
+  Index        r212, r210, r211
   // sum_ss_ext_sales_price: sum(from x in g select x.price)
-  Const        r212, "sum_ss_ext_sales_price"
-  Const        r213, []
-  Const        r214, "price"
-  IterPrep     r215, r196
-  Len          r216, r215
-  Const        r217, 0
+  Const        r213, "sum_ss_ext_sales_price"
+  Const        r214, []
+  Const        r215, "price"
+  IterPrep     r216, r197
+  Len          r217, r216
+  Const        r218, 0
 L14:
-  LessInt      r219, r217, r216
-  JumpIfFalse  r219, L13
-  Index        r221, r215, r217
-  Const        r222, "price"
-  Index        r223, r221, r222
-  Append       r213, r213, r223
-  Const        r225, 1
-  AddInt       r217, r217, r225
+  LessInt      r220, r218, r217
+  JumpIfFalse  r220, L13
+  Index        r222, r216, r218
+  Const        r223, "price"
+  Index        r224, r222, r223
+  Append       r214, r214, r224
+  Const        r226, 1
+  AddInt       r218, r218, r226
   Jump         L14
 L13:
-  Sum          r226, r213
+  Sum          r227, r214
   // d_year: g.key.d_year,
-  Move         r227, r197
-  Move         r228, r201
-  // i_category_id: g.key.i_category_id,
+  Move         r228, r198
   Move         r229, r202
-  Move         r230, r206
-  // i_category: g.key.i_category,
+  // i_category_id: g.key.i_category_id,
+  Move         r230, r203
   Move         r231, r207
-  Move         r232, r211
-  // sum_ss_ext_sales_price: sum(from x in g select x.price)
+  // i_category: g.key.i_category,
+  Move         r232, r208
   Move         r233, r212
-  Move         r234, r226
+  // sum_ss_ext_sales_price: sum(from x in g select x.price)
+  Move         r234, r213
+  Move         r235, r227
   // select {
-  MakeMap      r235, 4, r227
+  MakeMap      r236, 4, r228
   // sort by [-sum(from x in g select x.price), g.key.d_year, g.key.i_category_id, g.key.i_category]
-  Const        r236, []
-  Const        r237, "price"
-  IterPrep     r238, r196
-  Len          r239, r238
-  Const        r240, 0
+  Const        r237, []
+  Const        r238, "price"
+  IterPrep     r239, r197
+  Len          r240, r239
+  Const        r241, 0
 L16:
-  LessInt      r242, r240, r239
-  JumpIfFalse  r242, L15
-  Index        r221, r238, r240
-  Const        r244, "price"
-  Index        r245, r221, r244
-  Append       r236, r236, r245
-  Const        r247, 1
-  AddInt       r240, r240, r247
+  LessInt      r243, r241, r240
+  JumpIfFalse  r243, L15
+  Index        r222, r239, r241
+  Const        r245, "price"
+  Index        r246, r222, r245
+  Append       r237, r237, r246
+  Const        r248, 1
+  AddInt       r241, r241, r248
   Jump         L16
 L15:
-  Sum          r248, r236
-  Neg          r250, r248
-  Const        r251, "key"
-  Index        r252, r196, r251
-  Const        r253, "d_year"
-  Index        r255, r252, r253
-  Const        r256, "key"
-  Index        r257, r196, r256
-  Const        r258, "i_category_id"
-  Index        r260, r257, r258
-  Const        r261, "key"
-  Index        r262, r196, r261
-  Const        r263, "i_category"
-  Index        r265, r262, r263
-  MakeList     r267, 4, r250
+  Sum          r249, r237
+  Neg          r251, r249
+  Const        r252, "key"
+  Index        r253, r197, r252
+  Const        r254, "d_year"
+  Index        r256, r253, r254
+  Const        r257, "key"
+  Index        r258, r197, r257
+  Const        r259, "i_category_id"
+  Index        r261, r258, r259
+  Const        r262, "key"
+  Index        r263, r197, r262
+  Const        r264, "i_category"
+  Index        r266, r263, r264
+  MakeList     r268, 4, r251
   // from r in records
-  Move         r268, r235
-  MakeList     r269, 2, r267
-  Append       r111, r111, r269
-  Const        r271, 1
-  AddInt       r191, r191, r271
+  Move         r269, r236
+  MakeList     r270, 2, r268
+  Append       r112, r112, r270
+  Const        r272, 1
+  AddInt       r192, r192, r272
   Jump         L17
 L12:
   // sort by [-sum(from x in g select x.price), g.key.d_year, g.key.i_category_id, g.key.i_category]
-  Sort         r111, r111
+  Sort         r112, r112
+  // let result = concat(dummy, base)
+  UnionAll     r274, r5, r112
   // json(result)
-  JSON         r111
+  JSON         r274
   // expect result == [
-  Const        r273, [{"d_year": 2020, "i_category": "CatB", "i_category_id": 200, "sum_ss_ext_sales_price": 20}, {"d_year": 2020, "i_category": "CatA", "i_category_id": 100, "sum_ss_ext_sales_price": 10}]
-  Equal        r274, r111, r273
-  Expect       r274
+  Const        r275, [{"d_year": 2020, "i_category": "CatB", "i_category_id": 200, "sum_ss_ext_sales_price": 20}, {"d_year": 2020, "i_category": "CatA", "i_category_id": 100, "sum_ss_ext_sales_price": 10}]
+  Equal        r276, r274, r275
+  Expect       r276
   Return       r0

--- a/tests/dataset/tpc-ds/out/q43.ir.out
+++ b/tests/dataset/tpc-ds/out/q43.ir.out
@@ -1,4 +1,4 @@
-func main (regs=372)
+func main (regs=374)
   // let date_dim = [
   Const        r0, [{"d_day_name": "Sunday", "d_year": 2020, "date_sk": 1}, {"d_day_name": "Monday", "d_year": 2020, "date_sk": 2}, {"d_day_name": "Tuesday", "d_year": 2020, "date_sk": 3}, {"d_day_name": "Wednesday", "d_year": 2020, "date_sk": 4}, {"d_day_name": "Thursday", "d_year": 2020, "date_sk": 5}, {"d_day_name": "Friday", "d_year": 2020, "date_sk": 6}, {"d_day_name": "Saturday", "d_year": 2020, "date_sk": 7}]
   // let store = [ { store_sk: 1, store_id: "S1", store_name: "Main", gmt_offset: 0 } ]
@@ -9,220 +9,221 @@ func main (regs=372)
   Const        r3, 2020
   // let gmt = 0
   Const        r4, 0
+  // let dummy = null
+  Const        r5, nil
   // from d in date_dim
-  Const        r5, []
+  Const        r6, []
   // where s.gmt_offset == gmt && d.d_year == year
-  Const        r6, "gmt_offset"
-  Const        r7, "d_year"
+  Const        r7, "gmt_offset"
+  Const        r8, "d_year"
   // select { d_day_name: d.d_day_name, s_store_name: s.store_name, s_store_id: s.store_id, price: ss.sales_price }
-  Const        r8, "d_day_name"
   Const        r9, "d_day_name"
-  Const        r10, "s_store_name"
-  Const        r11, "store_name"
-  Const        r12, "s_store_id"
-  Const        r13, "store_id"
-  Const        r14, "price"
-  Const        r15, "sales_price"
+  Const        r10, "d_day_name"
+  Const        r11, "s_store_name"
+  Const        r12, "store_name"
+  Const        r13, "s_store_id"
+  Const        r14, "store_id"
+  Const        r15, "price"
+  Const        r16, "sales_price"
   // from d in date_dim
-  IterPrep     r16, r0
-  Len          r17, r16
-  Const        r18, 0
+  IterPrep     r17, r0
+  Len          r18, r17
+  Const        r19, 0
 L7:
-  LessInt      r20, r18, r17
-  JumpIfFalse  r20, L0
-  Index        r22, r16, r18
+  LessInt      r21, r19, r18
+  JumpIfFalse  r21, L0
+  Index        r23, r17, r19
   // join ss in store_sales on ss.sold_date_sk == d.date_sk
-  IterPrep     r23, r2
-  Len          r24, r23
-  Const        r25, "sold_date_sk"
-  Const        r26, "date_sk"
+  IterPrep     r24, r2
+  Len          r25, r24
+  Const        r26, "sold_date_sk"
+  Const        r27, "date_sk"
   // where s.gmt_offset == gmt && d.d_year == year
-  Const        r27, "gmt_offset"
-  Const        r28, "d_year"
+  Const        r28, "gmt_offset"
+  Const        r29, "d_year"
   // select { d_day_name: d.d_day_name, s_store_name: s.store_name, s_store_id: s.store_id, price: ss.sales_price }
-  Const        r29, "d_day_name"
   Const        r30, "d_day_name"
-  Const        r31, "s_store_name"
-  Const        r32, "store_name"
-  Const        r33, "s_store_id"
-  Const        r34, "store_id"
-  Const        r35, "price"
-  Const        r36, "sales_price"
+  Const        r31, "d_day_name"
+  Const        r32, "s_store_name"
+  Const        r33, "store_name"
+  Const        r34, "s_store_id"
+  Const        r35, "store_id"
+  Const        r36, "price"
+  Const        r37, "sales_price"
   // join ss in store_sales on ss.sold_date_sk == d.date_sk
-  Const        r37, 0
+  Const        r38, 0
 L6:
-  LessInt      r39, r37, r24
-  JumpIfFalse  r39, L1
-  Index        r41, r23, r37
-  Const        r42, "sold_date_sk"
-  Index        r43, r41, r42
-  Const        r44, "date_sk"
-  Index        r45, r22, r44
-  Equal        r46, r43, r45
-  JumpIfFalse  r46, L2
+  LessInt      r40, r38, r25
+  JumpIfFalse  r40, L1
+  Index        r42, r24, r38
+  Const        r43, "sold_date_sk"
+  Index        r44, r42, r43
+  Const        r45, "date_sk"
+  Index        r46, r23, r45
+  Equal        r47, r44, r46
+  JumpIfFalse  r47, L2
   // join s in store on ss.store_sk == s.store_sk
-  IterPrep     r47, r1
-  Len          r48, r47
-  Const        r49, "store_sk"
+  IterPrep     r48, r1
+  Len          r49, r48
   Const        r50, "store_sk"
+  Const        r51, "store_sk"
   // where s.gmt_offset == gmt && d.d_year == year
-  Const        r51, "gmt_offset"
-  Const        r52, "d_year"
+  Const        r52, "gmt_offset"
+  Const        r53, "d_year"
   // select { d_day_name: d.d_day_name, s_store_name: s.store_name, s_store_id: s.store_id, price: ss.sales_price }
-  Const        r53, "d_day_name"
   Const        r54, "d_day_name"
-  Const        r55, "s_store_name"
-  Const        r56, "store_name"
-  Const        r57, "s_store_id"
-  Const        r58, "store_id"
-  Const        r59, "price"
-  Const        r60, "sales_price"
+  Const        r55, "d_day_name"
+  Const        r56, "s_store_name"
+  Const        r57, "store_name"
+  Const        r58, "s_store_id"
+  Const        r59, "store_id"
+  Const        r60, "price"
+  Const        r61, "sales_price"
   // join s in store on ss.store_sk == s.store_sk
-  Const        r61, 0
+  Const        r62, 0
 L5:
-  LessInt      r63, r61, r48
-  JumpIfFalse  r63, L2
-  Index        r65, r47, r61
-  Const        r66, "store_sk"
-  Index        r67, r41, r66
-  Const        r68, "store_sk"
-  Index        r69, r65, r68
-  Equal        r70, r67, r69
-  JumpIfFalse  r70, L3
+  LessInt      r64, r62, r49
+  JumpIfFalse  r64, L2
+  Index        r66, r48, r62
+  Const        r67, "store_sk"
+  Index        r68, r42, r67
+  Const        r69, "store_sk"
+  Index        r70, r66, r69
+  Equal        r71, r68, r70
+  JumpIfFalse  r71, L3
   // where s.gmt_offset == gmt && d.d_year == year
-  Const        r71, "gmt_offset"
-  Index        r72, r65, r71
-  Equal        r73, r72, r4
-  Const        r74, "d_year"
-  Index        r75, r22, r74
-  Equal        r76, r75, r3
-  Move         r77, r73
-  JumpIfFalse  r77, L4
-  Move         r77, r76
+  Const        r72, "gmt_offset"
+  Index        r73, r66, r72
+  Equal        r74, r73, r4
+  Const        r75, "d_year"
+  Index        r76, r23, r75
+  Equal        r77, r76, r3
+  Move         r78, r74
+  JumpIfFalse  r78, L4
+  Move         r78, r77
 L4:
-  JumpIfFalse  r77, L3
+  JumpIfFalse  r78, L3
   // select { d_day_name: d.d_day_name, s_store_name: s.store_name, s_store_id: s.store_id, price: ss.sales_price }
-  Const        r78, "d_day_name"
   Const        r79, "d_day_name"
-  Index        r80, r22, r79
-  Const        r81, "s_store_name"
-  Const        r82, "store_name"
-  Index        r83, r65, r82
-  Const        r84, "s_store_id"
-  Const        r85, "store_id"
-  Index        r86, r65, r85
-  Const        r87, "price"
-  Const        r88, "sales_price"
-  Index        r89, r41, r88
-  Move         r90, r78
-  Move         r91, r80
+  Const        r80, "d_day_name"
+  Index        r81, r23, r80
+  Const        r82, "s_store_name"
+  Const        r83, "store_name"
+  Index        r84, r66, r83
+  Const        r85, "s_store_id"
+  Const        r86, "store_id"
+  Index        r87, r66, r86
+  Const        r88, "price"
+  Const        r89, "sales_price"
+  Index        r90, r42, r89
+  Move         r91, r79
   Move         r92, r81
-  Move         r93, r83
+  Move         r93, r82
   Move         r94, r84
-  Move         r95, r86
+  Move         r95, r85
   Move         r96, r87
-  Move         r97, r89
-  MakeMap      r98, 4, r90
+  Move         r97, r88
+  Move         r98, r90
+  MakeMap      r99, 4, r91
   // from d in date_dim
-  Append       r5, r5, r98
+  Append       r6, r6, r99
 L3:
   // join s in store on ss.store_sk == s.store_sk
-  Const        r100, 1
-  Add          r61, r61, r100
+  Const        r101, 1
+  Add          r62, r62, r101
   Jump         L5
 L2:
   // join ss in store_sales on ss.sold_date_sk == d.date_sk
-  Const        r101, 1
-  Add          r37, r37, r101
+  Const        r102, 1
+  Add          r38, r38, r102
   Jump         L6
 L1:
   // from d in date_dim
-  Const        r102, 1
-  AddInt       r18, r18, r102
+  Const        r103, 1
+  AddInt       r19, r19, r103
   Jump         L7
 L0:
   // from r in records
-  Const        r103, []
+  Const        r104, []
   // group by { name: r.s_store_name, id: r.s_store_id } into g
-  Const        r104, "name"
-  Const        r105, "s_store_name"
-  Const        r106, "id"
-  Const        r107, "s_store_id"
+  Const        r105, "name"
+  Const        r106, "s_store_name"
+  Const        r107, "id"
+  Const        r108, "s_store_id"
   // s_store_name: g.key.name,
-  Const        r108, "s_store_name"
-  Const        r109, "key"
-  Const        r110, "name"
+  Const        r109, "s_store_name"
+  Const        r110, "key"
+  Const        r111, "name"
   // s_store_id: g.key.id,
-  Const        r111, "s_store_id"
-  Const        r112, "key"
-  Const        r113, "id"
+  Const        r112, "s_store_id"
+  Const        r113, "key"
+  Const        r114, "id"
   // sun_sales: sum(from x in g select if x.d_day_name == "Sunday" { x.price } else { 0.0 }),
-  Const        r114, "sun_sales"
-  Const        r115, "d_day_name"
-  Const        r116, "price"
+  Const        r115, "sun_sales"
+  Const        r116, "d_day_name"
+  Const        r117, "price"
   // mon_sales: sum(from x in g select if x.d_day_name == "Monday" { x.price } else { 0.0 }),
-  Const        r117, "mon_sales"
-  Const        r118, "d_day_name"
-  Const        r119, "price"
+  Const        r118, "mon_sales"
+  Const        r119, "d_day_name"
+  Const        r120, "price"
   // tue_sales: sum(from x in g select if x.d_day_name == "Tuesday" { x.price } else { 0.0 }),
-  Const        r120, "tue_sales"
-  Const        r121, "d_day_name"
-  Const        r122, "price"
+  Const        r121, "tue_sales"
+  Const        r122, "d_day_name"
+  Const        r123, "price"
   // wed_sales: sum(from x in g select if x.d_day_name == "Wednesday" { x.price } else { 0.0 }),
-  Const        r123, "wed_sales"
-  Const        r124, "d_day_name"
-  Const        r125, "price"
+  Const        r124, "wed_sales"
+  Const        r125, "d_day_name"
+  Const        r126, "price"
   // thu_sales: sum(from x in g select if x.d_day_name == "Thursday" { x.price } else { 0.0 }),
-  Const        r126, "thu_sales"
-  Const        r127, "d_day_name"
-  Const        r128, "price"
+  Const        r127, "thu_sales"
+  Const        r128, "d_day_name"
+  Const        r129, "price"
   // fri_sales: sum(from x in g select if x.d_day_name == "Friday" { x.price } else { 0.0 }),
-  Const        r129, "fri_sales"
-  Const        r130, "d_day_name"
-  Const        r131, "price"
+  Const        r130, "fri_sales"
+  Const        r131, "d_day_name"
+  Const        r132, "price"
   // sat_sales: sum(from x in g select if x.d_day_name == "Saturday" { x.price } else { 0.0 })
-  Const        r132, "sat_sales"
-  Const        r133, "d_day_name"
-  Const        r134, "price"
+  Const        r133, "sat_sales"
+  Const        r134, "d_day_name"
+  Const        r135, "price"
   // from r in records
-  IterPrep     r135, r5
-  Len          r136, r135
-  Const        r137, 0
-  MakeMap      r138, 0, r0
-  Const        r139, []
+  IterPrep     r136, r6
+  Len          r137, r136
+  Const        r138, 0
+  MakeMap      r139, 0, r0
+  Const        r140, []
 L10:
-  LessInt      r141, r137, r136
-  JumpIfFalse  r141, L8
-  Index        r142, r135, r137
-  Move         r143, r142
+  LessInt      r142, r138, r137
+  JumpIfFalse  r142, L8
+  Index        r143, r136, r138
+  Move         r144, r143
   // group by { name: r.s_store_name, id: r.s_store_id } into g
-  Const        r144, "name"
-  Const        r145, "s_store_name"
-  Index        r146, r143, r145
-  Const        r147, "id"
-  Const        r148, "s_store_id"
-  Index        r149, r143, r148
-  Move         r150, r144
-  Move         r151, r146
+  Const        r145, "name"
+  Const        r146, "s_store_name"
+  Index        r147, r144, r146
+  Const        r148, "id"
+  Const        r149, "s_store_id"
+  Index        r150, r144, r149
+  Move         r151, r145
   Move         r152, r147
-  Move         r153, r149
-  MakeMap      r154, 2, r150
-  Str          r155, r154
-  In           r156, r155, r138
-  JumpIfTrue   r156, L9
+  Move         r153, r148
+  Move         r154, r150
+  MakeMap      r155, 2, r151
+  Str          r156, r155
+  In           r157, r156, r139
+  JumpIfTrue   r157, L9
   // from r in records
-  Const        r157, []
-  Const        r158, "__group__"
-  Const        r159, true
-  Const        r160, "key"
+  Const        r158, []
+  Const        r159, "__group__"
+  Const        r160, true
+  Const        r161, "key"
   // group by { name: r.s_store_name, id: r.s_store_id } into g
-  Move         r161, r154
+  Move         r162, r155
   // from r in records
-  Const        r162, "items"
-  Move         r163, r157
-  Const        r164, "count"
-  Const        r165, 0
-  Move         r166, r158
+  Const        r163, "items"
+  Move         r164, r158
+  Const        r165, "count"
+  Const        r166, 0
   Move         r167, r159
   Move         r168, r160
   Move         r169, r161
@@ -230,284 +231,287 @@ L10:
   Move         r171, r163
   Move         r172, r164
   Move         r173, r165
-  MakeMap      r174, 4, r166
-  SetIndex     r138, r155, r174
-  Append       r139, r139, r174
+  Move         r174, r166
+  MakeMap      r175, 4, r167
+  SetIndex     r139, r156, r175
+  Append       r140, r140, r175
 L9:
-  Const        r176, "items"
-  Index        r177, r138, r155
-  Index        r178, r177, r176
-  Append       r179, r178, r142
-  SetIndex     r177, r176, r179
-  Const        r180, "count"
-  Index        r181, r177, r180
-  Const        r182, 1
-  AddInt       r183, r181, r182
-  SetIndex     r177, r180, r183
-  Const        r184, 1
-  AddInt       r137, r137, r184
+  Const        r177, "items"
+  Index        r178, r139, r156
+  Index        r179, r178, r177
+  Append       r180, r179, r143
+  SetIndex     r178, r177, r180
+  Const        r181, "count"
+  Index        r182, r178, r181
+  Const        r183, 1
+  AddInt       r184, r182, r183
+  SetIndex     r178, r181, r184
+  Const        r185, 1
+  AddInt       r138, r138, r185
   Jump         L10
 L8:
-  Const        r185, 0
-  Len          r187, r139
+  Const        r186, 0
+  Len          r188, r140
 L40:
-  LessInt      r188, r185, r187
-  JumpIfFalse  r188, L11
-  Index        r190, r139, r185
+  LessInt      r189, r186, r188
+  JumpIfFalse  r189, L11
+  Index        r191, r140, r186
   // s_store_name: g.key.name,
-  Const        r191, "s_store_name"
-  Const        r192, "key"
-  Index        r193, r190, r192
-  Const        r194, "name"
-  Index        r195, r193, r194
+  Const        r192, "s_store_name"
+  Const        r193, "key"
+  Index        r194, r191, r193
+  Const        r195, "name"
+  Index        r196, r194, r195
   // s_store_id: g.key.id,
-  Const        r196, "s_store_id"
-  Const        r197, "key"
-  Index        r198, r190, r197
-  Const        r199, "id"
-  Index        r200, r198, r199
+  Const        r197, "s_store_id"
+  Const        r198, "key"
+  Index        r199, r191, r198
+  Const        r200, "id"
+  Index        r201, r199, r200
   // sun_sales: sum(from x in g select if x.d_day_name == "Sunday" { x.price } else { 0.0 }),
-  Const        r201, "sun_sales"
-  Const        r202, []
-  Const        r203, "d_day_name"
-  Const        r204, "price"
-  IterPrep     r205, r190
-  Len          r206, r205
-  Const        r207, 0
+  Const        r202, "sun_sales"
+  Const        r203, []
+  Const        r204, "d_day_name"
+  Const        r205, "price"
+  IterPrep     r206, r191
+  Len          r207, r206
+  Const        r208, 0
 L15:
-  LessInt      r209, r207, r206
-  JumpIfFalse  r209, L12
-  Index        r211, r205, r207
-  Const        r212, "d_day_name"
-  Index        r213, r211, r212
-  Const        r214, "Sunday"
-  Equal        r215, r213, r214
-  JumpIfFalse  r215, L13
-  Const        r216, "price"
-  Index        r218, r211, r216
+  LessInt      r210, r208, r207
+  JumpIfFalse  r210, L12
+  Index        r212, r206, r208
+  Const        r213, "d_day_name"
+  Index        r214, r212, r213
+  Const        r215, "Sunday"
+  Equal        r216, r214, r215
+  JumpIfFalse  r216, L13
+  Const        r217, "price"
+  Index        r219, r212, r217
   Jump         L14
 L13:
-  Const        r218, 0
+  Const        r219, 0
 L14:
-  Append       r202, r202, r218
-  Const        r221, 1
-  AddInt       r207, r207, r221
+  Append       r203, r203, r219
+  Const        r222, 1
+  AddInt       r208, r208, r222
   Jump         L15
 L12:
-  Sum          r222, r202
+  Sum          r223, r203
   // mon_sales: sum(from x in g select if x.d_day_name == "Monday" { x.price } else { 0.0 }),
-  Const        r223, "mon_sales"
-  Const        r224, []
-  Const        r225, "d_day_name"
-  Const        r226, "price"
-  IterPrep     r227, r190
-  Len          r228, r227
-  Const        r229, 0
+  Const        r224, "mon_sales"
+  Const        r225, []
+  Const        r226, "d_day_name"
+  Const        r227, "price"
+  IterPrep     r228, r191
+  Len          r229, r228
+  Const        r230, 0
 L19:
-  LessInt      r231, r229, r228
-  JumpIfFalse  r231, L16
-  Index        r211, r227, r229
-  Const        r233, "d_day_name"
-  Index        r234, r211, r233
-  Const        r235, "Monday"
-  Equal        r236, r234, r235
-  JumpIfFalse  r236, L17
-  Const        r237, "price"
-  Index        r239, r211, r237
+  LessInt      r232, r230, r229
+  JumpIfFalse  r232, L16
+  Index        r212, r228, r230
+  Const        r234, "d_day_name"
+  Index        r235, r212, r234
+  Const        r236, "Monday"
+  Equal        r237, r235, r236
+  JumpIfFalse  r237, L17
+  Const        r238, "price"
+  Index        r240, r212, r238
   Jump         L18
 L17:
-  Const        r239, 0
+  Const        r240, 0
 L18:
-  Append       r224, r224, r239
-  Const        r242, 1
-  AddInt       r229, r229, r242
+  Append       r225, r225, r240
+  Const        r243, 1
+  AddInt       r230, r230, r243
   Jump         L19
 L16:
-  Sum          r243, r224
+  Sum          r244, r225
   // tue_sales: sum(from x in g select if x.d_day_name == "Tuesday" { x.price } else { 0.0 }),
-  Const        r244, "tue_sales"
-  Const        r245, []
-  Const        r246, "d_day_name"
-  Const        r247, "price"
-  IterPrep     r248, r190
-  Len          r249, r248
-  Const        r250, 0
+  Const        r245, "tue_sales"
+  Const        r246, []
+  Const        r247, "d_day_name"
+  Const        r248, "price"
+  IterPrep     r249, r191
+  Len          r250, r249
+  Const        r251, 0
 L23:
-  LessInt      r252, r250, r249
-  JumpIfFalse  r252, L20
-  Index        r211, r248, r250
-  Const        r254, "d_day_name"
-  Index        r255, r211, r254
-  Const        r256, "Tuesday"
-  Equal        r257, r255, r256
-  JumpIfFalse  r257, L21
-  Const        r258, "price"
-  Index        r260, r211, r258
+  LessInt      r253, r251, r250
+  JumpIfFalse  r253, L20
+  Index        r212, r249, r251
+  Const        r255, "d_day_name"
+  Index        r256, r212, r255
+  Const        r257, "Tuesday"
+  Equal        r258, r256, r257
+  JumpIfFalse  r258, L21
+  Const        r259, "price"
+  Index        r261, r212, r259
   Jump         L22
 L21:
-  Const        r260, 0
+  Const        r261, 0
 L22:
-  Append       r245, r245, r260
-  Const        r263, 1
-  AddInt       r250, r250, r263
+  Append       r246, r246, r261
+  Const        r264, 1
+  AddInt       r251, r251, r264
   Jump         L23
 L20:
-  Sum          r264, r245
+  Sum          r265, r246
   // wed_sales: sum(from x in g select if x.d_day_name == "Wednesday" { x.price } else { 0.0 }),
-  Const        r265, "wed_sales"
-  Const        r266, []
-  Const        r267, "d_day_name"
-  Const        r268, "price"
-  IterPrep     r269, r190
-  Len          r270, r269
-  Const        r271, 0
+  Const        r266, "wed_sales"
+  Const        r267, []
+  Const        r268, "d_day_name"
+  Const        r269, "price"
+  IterPrep     r270, r191
+  Len          r271, r270
+  Const        r272, 0
 L27:
-  LessInt      r273, r271, r270
-  JumpIfFalse  r273, L24
-  Index        r211, r269, r271
-  Const        r275, "d_day_name"
-  Index        r276, r211, r275
-  Const        r277, "Wednesday"
-  Equal        r278, r276, r277
-  JumpIfFalse  r278, L25
-  Const        r279, "price"
-  Index        r281, r211, r279
+  LessInt      r274, r272, r271
+  JumpIfFalse  r274, L24
+  Index        r212, r270, r272
+  Const        r276, "d_day_name"
+  Index        r277, r212, r276
+  Const        r278, "Wednesday"
+  Equal        r279, r277, r278
+  JumpIfFalse  r279, L25
+  Const        r280, "price"
+  Index        r282, r212, r280
   Jump         L26
 L25:
-  Const        r281, 0
+  Const        r282, 0
 L26:
-  Append       r266, r266, r281
-  Const        r284, 1
-  AddInt       r271, r271, r284
+  Append       r267, r267, r282
+  Const        r285, 1
+  AddInt       r272, r272, r285
   Jump         L27
 L24:
-  Sum          r285, r266
+  Sum          r286, r267
   // thu_sales: sum(from x in g select if x.d_day_name == "Thursday" { x.price } else { 0.0 }),
-  Const        r286, "thu_sales"
-  Const        r287, []
-  Const        r288, "d_day_name"
-  Const        r289, "price"
-  IterPrep     r290, r190
-  Len          r291, r290
-  Const        r292, 0
+  Const        r287, "thu_sales"
+  Const        r288, []
+  Const        r289, "d_day_name"
+  Const        r290, "price"
+  IterPrep     r291, r191
+  Len          r292, r291
+  Const        r293, 0
 L31:
-  LessInt      r294, r292, r291
-  JumpIfFalse  r294, L28
-  Index        r211, r290, r292
-  Const        r296, "d_day_name"
-  Index        r297, r211, r296
-  Const        r298, "Thursday"
-  Equal        r299, r297, r298
-  JumpIfFalse  r299, L29
-  Const        r300, "price"
-  Index        r302, r211, r300
+  LessInt      r295, r293, r292
+  JumpIfFalse  r295, L28
+  Index        r212, r291, r293
+  Const        r297, "d_day_name"
+  Index        r298, r212, r297
+  Const        r299, "Thursday"
+  Equal        r300, r298, r299
+  JumpIfFalse  r300, L29
+  Const        r301, "price"
+  Index        r303, r212, r301
   Jump         L30
 L29:
-  Const        r302, 0
+  Const        r303, 0
 L30:
-  Append       r287, r287, r302
-  Const        r305, 1
-  AddInt       r292, r292, r305
+  Append       r288, r288, r303
+  Const        r306, 1
+  AddInt       r293, r293, r306
   Jump         L31
 L28:
-  Sum          r306, r287
+  Sum          r307, r288
   // fri_sales: sum(from x in g select if x.d_day_name == "Friday" { x.price } else { 0.0 }),
-  Const        r307, "fri_sales"
-  Const        r308, []
-  Const        r309, "d_day_name"
-  Const        r310, "price"
-  IterPrep     r311, r190
-  Len          r312, r311
-  Const        r313, 0
+  Const        r308, "fri_sales"
+  Const        r309, []
+  Const        r310, "d_day_name"
+  Const        r311, "price"
+  IterPrep     r312, r191
+  Len          r313, r312
+  Const        r314, 0
 L35:
-  LessInt      r315, r313, r312
-  JumpIfFalse  r315, L32
-  Index        r211, r311, r313
-  Const        r317, "d_day_name"
-  Index        r318, r211, r317
-  Const        r319, "Friday"
-  Equal        r320, r318, r319
-  JumpIfFalse  r320, L33
-  Const        r321, "price"
-  Index        r323, r211, r321
+  LessInt      r316, r314, r313
+  JumpIfFalse  r316, L32
+  Index        r212, r312, r314
+  Const        r318, "d_day_name"
+  Index        r319, r212, r318
+  Const        r320, "Friday"
+  Equal        r321, r319, r320
+  JumpIfFalse  r321, L33
+  Const        r322, "price"
+  Index        r324, r212, r322
   Jump         L34
 L33:
-  Const        r323, 0
+  Const        r324, 0
 L34:
-  Append       r308, r308, r323
-  Const        r326, 1
-  AddInt       r313, r313, r326
+  Append       r309, r309, r324
+  Const        r327, 1
+  AddInt       r314, r314, r327
   Jump         L35
 L32:
-  Sum          r327, r308
+  Sum          r328, r309
   // sat_sales: sum(from x in g select if x.d_day_name == "Saturday" { x.price } else { 0.0 })
-  Const        r328, "sat_sales"
-  Const        r329, []
-  Const        r330, "d_day_name"
-  Const        r331, "price"
-  IterPrep     r332, r190
-  Len          r333, r332
-  Const        r334, 0
+  Const        r329, "sat_sales"
+  Const        r330, []
+  Const        r331, "d_day_name"
+  Const        r332, "price"
+  IterPrep     r333, r191
+  Len          r334, r333
+  Const        r335, 0
 L39:
-  LessInt      r336, r334, r333
-  JumpIfFalse  r336, L36
-  Index        r211, r332, r334
-  Const        r338, "d_day_name"
-  Index        r339, r211, r338
-  Const        r340, "Saturday"
-  Equal        r341, r339, r340
-  JumpIfFalse  r341, L37
-  Const        r342, "price"
-  Index        r344, r211, r342
+  LessInt      r337, r335, r334
+  JumpIfFalse  r337, L36
+  Index        r212, r333, r335
+  Const        r339, "d_day_name"
+  Index        r340, r212, r339
+  Const        r341, "Saturday"
+  Equal        r342, r340, r341
+  JumpIfFalse  r342, L37
+  Const        r343, "price"
+  Index        r345, r212, r343
   Jump         L38
 L37:
-  Const        r344, 0
+  Const        r345, 0
 L38:
-  Append       r329, r329, r344
-  Const        r347, 1
-  AddInt       r334, r334, r347
+  Append       r330, r330, r345
+  Const        r348, 1
+  AddInt       r335, r335, r348
   Jump         L39
 L36:
-  Sum          r348, r329
+  Sum          r349, r330
   // s_store_name: g.key.name,
-  Move         r349, r191
-  Move         r350, r195
-  // s_store_id: g.key.id,
+  Move         r350, r192
   Move         r351, r196
-  Move         r352, r200
-  // sun_sales: sum(from x in g select if x.d_day_name == "Sunday" { x.price } else { 0.0 }),
+  // s_store_id: g.key.id,
+  Move         r352, r197
   Move         r353, r201
-  Move         r354, r222
-  // mon_sales: sum(from x in g select if x.d_day_name == "Monday" { x.price } else { 0.0 }),
+  // sun_sales: sum(from x in g select if x.d_day_name == "Sunday" { x.price } else { 0.0 }),
+  Move         r354, r202
   Move         r355, r223
-  Move         r356, r243
-  // tue_sales: sum(from x in g select if x.d_day_name == "Tuesday" { x.price } else { 0.0 }),
+  // mon_sales: sum(from x in g select if x.d_day_name == "Monday" { x.price } else { 0.0 }),
+  Move         r356, r224
   Move         r357, r244
-  Move         r358, r264
-  // wed_sales: sum(from x in g select if x.d_day_name == "Wednesday" { x.price } else { 0.0 }),
+  // tue_sales: sum(from x in g select if x.d_day_name == "Tuesday" { x.price } else { 0.0 }),
+  Move         r358, r245
   Move         r359, r265
-  Move         r360, r285
-  // thu_sales: sum(from x in g select if x.d_day_name == "Thursday" { x.price } else { 0.0 }),
+  // wed_sales: sum(from x in g select if x.d_day_name == "Wednesday" { x.price } else { 0.0 }),
+  Move         r360, r266
   Move         r361, r286
-  Move         r362, r306
-  // fri_sales: sum(from x in g select if x.d_day_name == "Friday" { x.price } else { 0.0 }),
+  // thu_sales: sum(from x in g select if x.d_day_name == "Thursday" { x.price } else { 0.0 }),
+  Move         r362, r287
   Move         r363, r307
-  Move         r364, r327
-  // sat_sales: sum(from x in g select if x.d_day_name == "Saturday" { x.price } else { 0.0 })
+  // fri_sales: sum(from x in g select if x.d_day_name == "Friday" { x.price } else { 0.0 }),
+  Move         r364, r308
   Move         r365, r328
-  Move         r366, r348
+  // sat_sales: sum(from x in g select if x.d_day_name == "Saturday" { x.price } else { 0.0 })
+  Move         r366, r329
+  Move         r367, r349
   // select {
-  MakeMap      r367, 9, r349
+  MakeMap      r368, 9, r350
   // from r in records
-  Append       r103, r103, r367
-  Const        r369, 1
-  AddInt       r185, r185, r369
+  Append       r104, r104, r368
+  Const        r370, 1
+  AddInt       r186, r186, r370
   Jump         L40
 L11:
+  // let result = concat(dummy, base)
+  UnionAll     r371, r5, r104
   // json(result)
-  JSON         r103
+  JSON         r371
   // expect result == [
-  Const        r370, [{"fri_sales": 60, "mon_sales": 20, "s_store_id": "S1", "s_store_name": "Main", "sat_sales": 70, "sun_sales": 10, "thu_sales": 50, "tue_sales": 30, "wed_sales": 40}]
-  Equal        r371, r103, r370
-  Expect       r371
+  Const        r372, [{"fri_sales": 60, "mon_sales": 20, "s_store_id": "S1", "s_store_name": "Main", "sat_sales": 70, "sun_sales": 10, "thu_sales": 50, "tue_sales": 30, "wed_sales": 40}]
+  Equal        r373, r371, r372
+  Expect       r373
   Return       r0

--- a/tests/dataset/tpc-ds/out/q44.ir.out
+++ b/tests/dataset/tpc-ds/out/q44.ir.out
@@ -1,48 +1,49 @@
-func main (regs=165)
+func main (regs=167)
   // let store_sales = [
   Const        r0, [{"ss_item_sk": 1, "ss_net_profit": 5, "ss_store_sk": 1}, {"ss_item_sk": 1, "ss_net_profit": 5, "ss_store_sk": 1}, {"ss_item_sk": 2, "ss_net_profit": -1, "ss_store_sk": 1}]
   // let item = [
   Const        r1, [{"i_item_sk": 1, "i_product_name": "ItemA"}, {"i_item_sk": 2, "i_product_name": "ItemB"}]
+  // let dummy = null
+  Const        r2, nil
   // from ss in store_sales
-  Const        r2, []
+  Const        r3, []
   // group by ss.ss_item_sk into g
-  Const        r3, "ss_item_sk"
+  Const        r4, "ss_item_sk"
   // select { item_sk: g.key,
-  Const        r4, "item_sk"
-  Const        r5, "key"
+  Const        r5, "item_sk"
+  Const        r6, "key"
   // avg_profit: avg(from x in g select x.ss_net_profit) }
-  Const        r6, "avg_profit"
-  Const        r7, "ss_net_profit"
+  Const        r7, "avg_profit"
+  Const        r8, "ss_net_profit"
   // from ss in store_sales
-  IterPrep     r8, r0
-  Len          r9, r8
-  Const        r10, 0
-  MakeMap      r11, 0, r0
-  Const        r12, []
+  IterPrep     r9, r0
+  Len          r10, r9
+  Const        r11, 0
+  MakeMap      r12, 0, r0
+  Const        r13, []
 L2:
-  LessInt      r14, r10, r9
-  JumpIfFalse  r14, L0
-  Index        r15, r8, r10
-  Move         r16, r15
+  LessInt      r15, r11, r10
+  JumpIfFalse  r15, L0
+  Index        r16, r9, r11
+  Move         r17, r16
   // group by ss.ss_item_sk into g
-  Const        r17, "ss_item_sk"
-  Index        r18, r16, r17
-  Str          r19, r18
-  In           r20, r19, r11
-  JumpIfTrue   r20, L1
+  Const        r18, "ss_item_sk"
+  Index        r19, r17, r18
+  Str          r20, r19
+  In           r21, r20, r12
+  JumpIfTrue   r21, L1
   // from ss in store_sales
-  Const        r21, []
-  Const        r22, "__group__"
-  Const        r23, true
-  Const        r24, "key"
+  Const        r22, []
+  Const        r23, "__group__"
+  Const        r24, true
+  Const        r25, "key"
   // group by ss.ss_item_sk into g
-  Move         r25, r18
+  Move         r26, r19
   // from ss in store_sales
-  Const        r26, "items"
-  Move         r27, r21
-  Const        r28, "count"
-  Const        r29, 0
-  Move         r30, r22
+  Const        r27, "items"
+  Move         r28, r22
+  Const        r29, "count"
+  Const        r30, 0
   Move         r31, r23
   Move         r32, r24
   Move         r33, r25
@@ -50,176 +51,179 @@ L2:
   Move         r35, r27
   Move         r36, r28
   Move         r37, r29
-  MakeMap      r38, 4, r30
-  SetIndex     r11, r19, r38
-  Append       r12, r12, r38
+  Move         r38, r30
+  MakeMap      r39, 4, r31
+  SetIndex     r12, r20, r39
+  Append       r13, r13, r39
 L1:
-  Const        r40, "items"
-  Index        r41, r11, r19
-  Index        r42, r41, r40
-  Append       r43, r42, r15
-  SetIndex     r41, r40, r43
-  Const        r44, "count"
-  Index        r45, r41, r44
-  Const        r46, 1
-  AddInt       r47, r45, r46
-  SetIndex     r41, r44, r47
-  Const        r48, 1
-  AddInt       r10, r10, r48
+  Const        r41, "items"
+  Index        r42, r12, r20
+  Index        r43, r42, r41
+  Append       r44, r43, r16
+  SetIndex     r42, r41, r44
+  Const        r45, "count"
+  Index        r46, r42, r45
+  Const        r47, 1
+  AddInt       r48, r46, r47
+  SetIndex     r42, r45, r48
+  Const        r49, 1
+  AddInt       r11, r11, r49
   Jump         L2
 L0:
-  Const        r49, 0
-  Len          r51, r12
+  Const        r50, 0
+  Len          r52, r13
 L6:
-  LessInt      r52, r49, r51
-  JumpIfFalse  r52, L3
-  Index        r54, r12, r49
+  LessInt      r53, r50, r52
+  JumpIfFalse  r53, L3
+  Index        r55, r13, r50
   // select { item_sk: g.key,
-  Const        r55, "item_sk"
-  Const        r56, "key"
-  Index        r57, r54, r56
+  Const        r56, "item_sk"
+  Const        r57, "key"
+  Index        r58, r55, r57
   // avg_profit: avg(from x in g select x.ss_net_profit) }
-  Const        r58, "avg_profit"
-  Const        r59, []
-  Const        r60, "ss_net_profit"
-  IterPrep     r61, r54
-  Len          r62, r61
-  Const        r63, 0
+  Const        r59, "avg_profit"
+  Const        r60, []
+  Const        r61, "ss_net_profit"
+  IterPrep     r62, r55
+  Len          r63, r62
+  Const        r64, 0
 L5:
-  LessInt      r65, r63, r62
-  JumpIfFalse  r65, L4
-  Index        r67, r61, r63
-  Const        r68, "ss_net_profit"
-  Index        r69, r67, r68
-  Append       r59, r59, r69
-  Const        r71, 1
-  AddInt       r63, r63, r71
+  LessInt      r66, r64, r63
+  JumpIfFalse  r66, L4
+  Index        r68, r62, r64
+  Const        r69, "ss_net_profit"
+  Index        r70, r68, r69
+  Append       r60, r60, r70
+  Const        r72, 1
+  AddInt       r64, r64, r72
   Jump         L5
 L4:
-  Avg          r72, r59
+  Avg          r73, r60
   // select { item_sk: g.key,
-  Move         r73, r55
-  Move         r74, r57
-  // avg_profit: avg(from x in g select x.ss_net_profit) }
+  Move         r74, r56
   Move         r75, r58
-  Move         r76, r72
+  // avg_profit: avg(from x in g select x.ss_net_profit) }
+  Move         r76, r59
+  Move         r77, r73
   // select { item_sk: g.key,
-  MakeMap      r77, 2, r73
+  MakeMap      r78, 2, r74
   // from ss in store_sales
-  Append       r2, r2, r77
-  Const        r79, 1
-  AddInt       r49, r49, r79
+  Append       r3, r3, r78
+  Const        r80, 1
+  AddInt       r50, r50, r80
   Jump         L6
 L3:
+  // let grouped = concat(dummy, grouped_base)
+  UnionAll     r81, r2, r3
   // let best = first(from x in grouped sort by -x.avg_profit select x)
-  Const        r80, []
-  Const        r81, "avg_profit"
-  IterPrep     r82, r2
-  Len          r83, r82
-  Const        r84, 0
+  Const        r82, []
+  Const        r83, "avg_profit"
+  IterPrep     r84, r81
+  Len          r85, r84
+  Const        r86, 0
 L8:
-  LessInt      r86, r84, r83
-  JumpIfFalse  r86, L7
-  Index        r67, r82, r84
-  Const        r88, "avg_profit"
-  Index        r89, r67, r88
-  Neg          r91, r89
-  Move         r92, r67
-  MakeList     r93, 2, r91
-  Append       r80, r80, r93
-  Const        r95, 1
-  AddInt       r84, r84, r95
+  LessInt      r88, r86, r85
+  JumpIfFalse  r88, L7
+  Index        r68, r84, r86
+  Const        r90, "avg_profit"
+  Index        r91, r68, r90
+  Neg          r93, r91
+  Move         r94, r68
+  MakeList     r95, 2, r93
+  Append       r82, r82, r95
+  Const        r97, 1
+  AddInt       r86, r86, r97
   Jump         L8
 L7:
-  Sort         r80, r80
-  First        r97, r80
+  Sort         r82, r82
+  First        r99, r82
   // let worst = first(from x in grouped sort by x.avg_profit select x)
-  Const        r98, []
-  Const        r99, "avg_profit"
-  IterPrep     r100, r2
-  Len          r101, r100
-  Const        r102, 0
+  Const        r100, []
+  Const        r101, "avg_profit"
+  IterPrep     r102, r81
+  Len          r103, r102
+  Const        r104, 0
 L10:
-  LessInt      r104, r102, r101
-  JumpIfFalse  r104, L9
-  Index        r67, r100, r102
-  Const        r106, "avg_profit"
-  Index        r108, r67, r106
-  Move         r109, r67
-  MakeList     r110, 2, r108
-  Append       r98, r98, r110
-  Const        r112, 1
-  AddInt       r102, r102, r112
+  LessInt      r106, r104, r103
+  JumpIfFalse  r106, L9
+  Index        r68, r102, r104
+  Const        r108, "avg_profit"
+  Index        r110, r68, r108
+  Move         r111, r68
+  MakeList     r112, 2, r110
+  Append       r100, r100, r112
+  Const        r114, 1
+  AddInt       r104, r104, r114
   Jump         L10
 L9:
-  Sort         r98, r98
-  First        r114, r98
+  Sort         r100, r100
+  First        r116, r100
   // let best_name = first(from i in item where i.i_item_sk == best.item_sk select i.i_product_name)
-  Const        r115, []
-  Const        r116, "i_item_sk"
-  Const        r117, "item_sk"
-  Const        r118, "i_product_name"
-  IterPrep     r119, r1
-  Len          r120, r119
-  Const        r121, 0
+  Const        r117, []
+  Const        r118, "i_item_sk"
+  Const        r119, "item_sk"
+  Const        r120, "i_product_name"
+  IterPrep     r121, r1
+  Len          r122, r121
+  Const        r123, 0
 L13:
-  LessInt      r123, r121, r120
-  JumpIfFalse  r123, L11
-  Index        r125, r119, r121
-  Const        r126, "i_item_sk"
-  Index        r127, r125, r126
-  Const        r128, "item_sk"
-  Index        r129, r97, r128
-  Equal        r130, r127, r129
-  JumpIfFalse  r130, L12
-  Const        r131, "i_product_name"
-  Index        r132, r125, r131
-  Append       r115, r115, r132
+  LessInt      r125, r123, r122
+  JumpIfFalse  r125, L11
+  Index        r127, r121, r123
+  Const        r128, "i_item_sk"
+  Index        r129, r127, r128
+  Const        r130, "item_sk"
+  Index        r131, r99, r130
+  Equal        r132, r129, r131
+  JumpIfFalse  r132, L12
+  Const        r133, "i_product_name"
+  Index        r134, r127, r133
+  Append       r117, r117, r134
 L12:
-  Const        r134, 1
-  AddInt       r121, r121, r134
+  Const        r136, 1
+  AddInt       r123, r123, r136
   Jump         L13
 L11:
-  First        r135, r115
+  First        r137, r117
   // let worst_name = first(from i in item where i.i_item_sk == worst.item_sk select i.i_product_name)
-  Const        r136, []
-  Const        r137, "i_item_sk"
-  Const        r138, "item_sk"
-  Const        r139, "i_product_name"
-  IterPrep     r140, r1
-  Len          r141, r140
-  Const        r142, 0
+  Const        r138, []
+  Const        r139, "i_item_sk"
+  Const        r140, "item_sk"
+  Const        r141, "i_product_name"
+  IterPrep     r142, r1
+  Len          r143, r142
+  Const        r144, 0
 L16:
-  LessInt      r144, r142, r141
-  JumpIfFalse  r144, L14
-  Index        r125, r140, r142
-  Const        r146, "i_item_sk"
-  Index        r147, r125, r146
-  Const        r148, "item_sk"
-  Index        r149, r114, r148
-  Equal        r150, r147, r149
-  JumpIfFalse  r150, L15
-  Const        r151, "i_product_name"
-  Index        r152, r125, r151
-  Append       r136, r136, r152
+  LessInt      r146, r144, r143
+  JumpIfFalse  r146, L14
+  Index        r127, r142, r144
+  Const        r148, "i_item_sk"
+  Index        r149, r127, r148
+  Const        r150, "item_sk"
+  Index        r151, r116, r150
+  Equal        r152, r149, r151
+  JumpIfFalse  r152, L15
+  Const        r153, "i_product_name"
+  Index        r154, r127, r153
+  Append       r138, r138, r154
 L15:
-  Const        r154, 1
-  AddInt       r142, r142, r154
+  Const        r156, 1
+  AddInt       r144, r144, r156
   Jump         L16
 L14:
-  First        r155, r136
+  First        r157, r138
   // let result = { best_performing: best_name, worst_performing: worst_name }
-  Const        r156, "best_performing"
-  Const        r157, "worst_performing"
-  Move         r158, r156
-  Move         r159, r135
-  Move         r160, r157
-  Move         r161, r155
-  MakeMap      r162, 2, r158
+  Const        r158, "best_performing"
+  Const        r159, "worst_performing"
+  Move         r160, r158
+  Move         r161, r137
+  Move         r162, r159
+  Move         r163, r157
+  MakeMap      r164, 2, r160
   // json(result)
-  JSON         r162
+  JSON         r164
   // expect result == { best_performing: "ItemA", worst_performing: "ItemB" }
-  Const        r163, {"best_performing": "ItemA", "worst_performing": "ItemB"}
-  Equal        r164, r162, r163
-  Expect       r164
+  Const        r165, {"best_performing": "ItemA", "worst_performing": "ItemB"}
+  Equal        r166, r164, r165
+  Expect       r166
   Return       r0

--- a/tests/dataset/tpc-ds/out/q45.ir.out
+++ b/tests/dataset/tpc-ds/out/q45.ir.out
@@ -1,4 +1,4 @@
-func main (regs=174)
+func main (regs=176)
   // let web_sales = [
   Const        r0, [{"bill_customer_sk": 1, "item_sk": 1, "sales_price": 50, "sold_date_sk": 1}, {"bill_customer_sk": 2, "item_sk": 2, "sales_price": 30, "sold_date_sk": 1}]
   // let customer = [
@@ -9,159 +9,160 @@ func main (regs=174)
   Const        r3, [{"i_item_id": "I1", "i_item_sk": 1}, {"i_item_id": "I2", "i_item_sk": 2}]
   // let date_dim = [ { d_date_sk: 1, d_qoy: 1, d_year: 2020 } ]
   Const        r4, [{"d_date_sk": 1, "d_qoy": 1, "d_year": 2020}]
+  // let dummy = null
+  Const        r5, nil
   // let zip_list = ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"]
-  Const        r5, ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"]
+  Const        r6, ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"]
   // let item_ids = ["I2"]
-  Const        r6, ["I2"]
+  Const        r7, ["I2"]
   // let qoy = 1
-  Const        r7, 1
+  Const        r8, 1
   // let year = 2020
-  Const        r8, 2020
+  Const        r9, 2020
   // from ws in web_sales
-  Const        r9, []
+  Const        r10, []
   // group by ca.ca_zip into g
-  Const        r10, "ca_zip"
-  // where (substr(ca.ca_zip, 0, 5) in zip_list || i.i_item_id in item_ids) &&
   Const        r11, "ca_zip"
-  Const        r12, "i_item_id"
-  // d.d_qoy == qoy && d.d_year == year
-  Const        r13, "d_qoy"
-  Const        r14, "d_year"
-  // select { ca_zip: g.key, sum_ws_sales_price: sum(from x in g select x.ws.sales_price) }
-  Const        r15, "ca_zip"
-  Const        r16, "key"
-  Const        r17, "sum_ws_sales_price"
-  Const        r18, "ws"
-  Const        r19, "sales_price"
-  // from ws in web_sales
-  MakeMap      r20, 0, r0
-  Const        r21, []
-  IterPrep     r23, r0
-  Len          r24, r23
-  Const        r25, 0
-L14:
-  LessInt      r26, r25, r24
-  JumpIfFalse  r26, L0
-  Index        r28, r23, r25
-  // join c in customer on ws.bill_customer_sk == c.c_customer_sk
-  IterPrep     r29, r1
-  Len          r30, r29
-  Const        r31, 0
-L13:
-  LessInt      r32, r31, r30
-  JumpIfFalse  r32, L1
-  Index        r34, r29, r31
-  Const        r35, "bill_customer_sk"
-  Index        r36, r28, r35
-  Const        r37, "c_customer_sk"
-  Index        r38, r34, r37
-  Equal        r39, r36, r38
-  JumpIfFalse  r39, L2
-  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  IterPrep     r40, r2
-  Len          r41, r40
-  Const        r42, 0
-L12:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L2
-  Index        r45, r40, r42
-  Const        r46, "c_current_addr_sk"
-  Index        r47, r34, r46
-  Const        r48, "ca_address_sk"
-  Index        r49, r45, r48
-  Equal        r50, r47, r49
-  JumpIfFalse  r50, L3
-  // join i in item on ws.item_sk == i.i_item_sk
-  IterPrep     r51, r3
-  Len          r52, r51
-  Const        r53, 0
-L11:
-  LessInt      r54, r53, r52
-  JumpIfFalse  r54, L3
-  Index        r56, r51, r53
-  Const        r57, "item_sk"
-  Index        r58, r28, r57
-  Const        r59, "i_item_sk"
-  Index        r60, r56, r59
-  Equal        r61, r58, r60
-  JumpIfFalse  r61, L4
-  // join d in date_dim on ws.sold_date_sk == d.d_date_sk
-  IterPrep     r62, r4
-  Len          r63, r62
-  Const        r64, 0
-L10:
-  LessInt      r65, r64, r63
-  JumpIfFalse  r65, L4
-  Index        r67, r62, r64
-  Const        r68, "sold_date_sk"
-  Index        r69, r28, r68
-  Const        r70, "d_date_sk"
-  Index        r71, r67, r70
-  Equal        r72, r69, r71
-  JumpIfFalse  r72, L5
   // where (substr(ca.ca_zip, 0, 5) in zip_list || i.i_item_id in item_ids) &&
-  Const        r73, "ca_zip"
-  Index        r74, r45, r73
-  Const        r75, 0
-  Const        r76, 5
-  Slice        r77, r74, r75, r76
-  In           r78, r77, r5
-  Const        r79, "i_item_id"
-  Index        r80, r56, r79
-  In           r81, r80, r6
-  Move         r82, r78
-  JumpIfTrue   r82, L6
-  Move         r82, r81
+  Const        r12, "ca_zip"
+  Const        r13, "i_item_id"
+  // d.d_qoy == qoy && d.d_year == year
+  Const        r14, "d_qoy"
+  Const        r15, "d_year"
+  // select { ca_zip: g.key, sum_ws_sales_price: sum(from x in g select x.ws.sales_price) }
+  Const        r16, "ca_zip"
+  Const        r17, "key"
+  Const        r18, "sum_ws_sales_price"
+  Const        r19, "ws"
+  Const        r20, "sales_price"
+  // from ws in web_sales
+  MakeMap      r21, 0, r0
+  Const        r22, []
+  IterPrep     r24, r0
+  Len          r25, r24
+  Const        r26, 0
+L14:
+  LessInt      r27, r26, r25
+  JumpIfFalse  r27, L0
+  Index        r29, r24, r26
+  // join c in customer on ws.bill_customer_sk == c.c_customer_sk
+  IterPrep     r30, r1
+  Len          r31, r30
+  Const        r32, 0
+L13:
+  LessInt      r33, r32, r31
+  JumpIfFalse  r33, L1
+  Index        r35, r30, r32
+  Const        r36, "bill_customer_sk"
+  Index        r37, r29, r36
+  Const        r38, "c_customer_sk"
+  Index        r39, r35, r38
+  Equal        r40, r37, r39
+  JumpIfFalse  r40, L2
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  IterPrep     r41, r2
+  Len          r42, r41
+  Const        r43, 0
+L12:
+  LessInt      r44, r43, r42
+  JumpIfFalse  r44, L2
+  Index        r46, r41, r43
+  Const        r47, "c_current_addr_sk"
+  Index        r48, r35, r47
+  Const        r49, "ca_address_sk"
+  Index        r50, r46, r49
+  Equal        r51, r48, r50
+  JumpIfFalse  r51, L3
+  // join i in item on ws.item_sk == i.i_item_sk
+  IterPrep     r52, r3
+  Len          r53, r52
+  Const        r54, 0
+L11:
+  LessInt      r55, r54, r53
+  JumpIfFalse  r55, L3
+  Index        r57, r52, r54
+  Const        r58, "item_sk"
+  Index        r59, r29, r58
+  Const        r60, "i_item_sk"
+  Index        r61, r57, r60
+  Equal        r62, r59, r61
+  JumpIfFalse  r62, L4
+  // join d in date_dim on ws.sold_date_sk == d.d_date_sk
+  IterPrep     r63, r4
+  Len          r64, r63
+  Const        r65, 0
+L10:
+  LessInt      r66, r65, r64
+  JumpIfFalse  r66, L4
+  Index        r68, r63, r65
+  Const        r69, "sold_date_sk"
+  Index        r70, r29, r69
+  Const        r71, "d_date_sk"
+  Index        r72, r68, r71
+  Equal        r73, r70, r72
+  JumpIfFalse  r73, L5
+  // where (substr(ca.ca_zip, 0, 5) in zip_list || i.i_item_id in item_ids) &&
+  Const        r74, "ca_zip"
+  Index        r75, r46, r74
+  Const        r76, 0
+  Const        r77, 5
+  Slice        r78, r75, r76, r77
+  In           r79, r78, r6
+  Const        r80, "i_item_id"
+  Index        r81, r57, r80
+  In           r82, r81, r7
+  Move         r83, r79
+  JumpIfTrue   r83, L6
+  Move         r83, r82
 L6:
   // d.d_qoy == qoy && d.d_year == year
-  Const        r83, "d_qoy"
-  Index        r84, r67, r83
-  Equal        r85, r84, r7
-  Const        r86, "d_year"
-  Index        r87, r67, r86
-  Equal        r88, r87, r8
+  Const        r84, "d_qoy"
+  Index        r85, r68, r84
+  Equal        r86, r85, r8
+  Const        r87, "d_year"
+  Index        r88, r68, r87
+  Equal        r89, r88, r9
   // where (substr(ca.ca_zip, 0, 5) in zip_list || i.i_item_id in item_ids) &&
-  Move         r89, r82
-  JumpIfFalse  r89, L7
+  Move         r90, r83
+  JumpIfFalse  r90, L7
 L7:
   // d.d_qoy == qoy && d.d_year == year
-  Move         r90, r85
-  JumpIfFalse  r90, L8
-  Move         r90, r88
+  Move         r91, r86
+  JumpIfFalse  r91, L8
+  Move         r91, r89
 L8:
   // where (substr(ca.ca_zip, 0, 5) in zip_list || i.i_item_id in item_ids) &&
-  JumpIfFalse  r90, L5
+  JumpIfFalse  r91, L5
   // from ws in web_sales
-  Const        r91, "ws"
-  Move         r92, r28
-  Const        r93, "c"
-  Move         r94, r34
-  Const        r95, "ca"
-  Move         r96, r45
-  Const        r97, "i"
-  Move         r98, r56
-  Const        r99, "d"
-  Move         r100, r67
-  MakeMap      r101, 5, r91
+  Const        r92, "ws"
+  Move         r93, r29
+  Const        r94, "c"
+  Move         r95, r35
+  Const        r96, "ca"
+  Move         r97, r46
+  Const        r98, "i"
+  Move         r99, r57
+  Const        r100, "d"
+  Move         r101, r68
+  MakeMap      r102, 5, r92
   // group by ca.ca_zip into g
-  Const        r102, "ca_zip"
-  Index        r103, r45, r102
-  Str          r104, r103
-  In           r105, r104, r20
-  JumpIfTrue   r105, L9
+  Const        r103, "ca_zip"
+  Index        r104, r46, r103
+  Str          r105, r104
+  In           r106, r105, r21
+  JumpIfTrue   r106, L9
   // from ws in web_sales
-  Const        r106, []
-  Const        r107, "__group__"
-  Const        r108, true
-  Const        r109, "key"
+  Const        r107, []
+  Const        r108, "__group__"
+  Const        r109, true
+  Const        r110, "key"
   // group by ca.ca_zip into g
-  Move         r110, r103
+  Move         r111, r104
   // from ws in web_sales
-  Const        r111, "items"
-  Move         r112, r106
-  Const        r113, "count"
-  Const        r114, 0
-  Move         r115, r107
+  Const        r112, "items"
+  Move         r113, r107
+  Const        r114, "count"
+  Const        r115, 0
   Move         r116, r108
   Move         r117, r109
   Move         r118, r110
@@ -169,92 +170,95 @@ L8:
   Move         r120, r112
   Move         r121, r113
   Move         r122, r114
-  MakeMap      r123, 4, r115
-  SetIndex     r20, r104, r123
-  Append       r21, r21, r123
+  Move         r123, r115
+  MakeMap      r124, 4, r116
+  SetIndex     r21, r105, r124
+  Append       r22, r22, r124
 L9:
-  Const        r125, "items"
-  Index        r126, r20, r104
-  Index        r127, r126, r125
-  Append       r128, r127, r101
-  SetIndex     r126, r125, r128
-  Const        r129, "count"
-  Index        r130, r126, r129
-  Const        r131, 1
-  AddInt       r132, r130, r131
-  SetIndex     r126, r129, r132
+  Const        r126, "items"
+  Index        r127, r21, r105
+  Index        r128, r127, r126
+  Append       r129, r128, r102
+  SetIndex     r127, r126, r129
+  Const        r130, "count"
+  Index        r131, r127, r130
+  Const        r132, 1
+  AddInt       r133, r131, r132
+  SetIndex     r127, r130, r133
 L5:
   // join d in date_dim on ws.sold_date_sk == d.d_date_sk
-  Const        r133, 1
-  AddInt       r64, r64, r133
+  Const        r134, 1
+  AddInt       r65, r65, r134
   Jump         L10
 L4:
   // join i in item on ws.item_sk == i.i_item_sk
-  Const        r134, 1
-  AddInt       r53, r53, r134
+  Const        r135, 1
+  AddInt       r54, r54, r135
   Jump         L11
 L3:
   // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  Const        r135, 1
-  AddInt       r42, r42, r135
+  Const        r136, 1
+  AddInt       r43, r43, r136
   Jump         L12
 L2:
   // join c in customer on ws.bill_customer_sk == c.c_customer_sk
-  Const        r136, 1
-  AddInt       r31, r31, r136
+  Const        r137, 1
+  AddInt       r32, r32, r137
   Jump         L13
 L1:
   // from ws in web_sales
-  Const        r137, 1
-  AddInt       r25, r25, r137
+  Const        r138, 1
+  AddInt       r26, r26, r138
   Jump         L14
 L0:
-  Const        r138, 0
-  Len          r140, r21
+  Const        r139, 0
+  Len          r141, r22
 L18:
-  LessInt      r141, r138, r140
-  JumpIfFalse  r141, L15
-  Index        r143, r21, r138
+  LessInt      r142, r139, r141
+  JumpIfFalse  r142, L15
+  Index        r144, r22, r139
   // select { ca_zip: g.key, sum_ws_sales_price: sum(from x in g select x.ws.sales_price) }
-  Const        r144, "ca_zip"
-  Const        r145, "key"
-  Index        r146, r143, r145
-  Const        r147, "sum_ws_sales_price"
-  Const        r148, []
-  Const        r149, "ws"
-  Const        r150, "sales_price"
-  IterPrep     r151, r143
-  Len          r152, r151
-  Const        r153, 0
+  Const        r145, "ca_zip"
+  Const        r146, "key"
+  Index        r147, r144, r146
+  Const        r148, "sum_ws_sales_price"
+  Const        r149, []
+  Const        r150, "ws"
+  Const        r151, "sales_price"
+  IterPrep     r152, r144
+  Len          r153, r152
+  Const        r154, 0
 L17:
-  LessInt      r155, r153, r152
-  JumpIfFalse  r155, L16
-  Index        r157, r151, r153
-  Const        r158, "ws"
-  Index        r159, r157, r158
-  Const        r160, "sales_price"
-  Index        r161, r159, r160
-  Append       r148, r148, r161
-  Const        r163, 1
-  AddInt       r153, r153, r163
+  LessInt      r156, r154, r153
+  JumpIfFalse  r156, L16
+  Index        r158, r152, r154
+  Const        r159, "ws"
+  Index        r160, r158, r159
+  Const        r161, "sales_price"
+  Index        r162, r160, r161
+  Append       r149, r149, r162
+  Const        r164, 1
+  AddInt       r154, r154, r164
   Jump         L17
 L16:
-  Sum          r164, r148
-  Move         r165, r144
-  Move         r166, r146
+  Sum          r165, r149
+  Move         r166, r145
   Move         r167, r147
-  Move         r168, r164
-  MakeMap      r169, 2, r165
+  Move         r168, r148
+  Move         r169, r165
+  MakeMap      r170, 2, r166
   // from ws in web_sales
-  Append       r9, r9, r169
-  Const        r171, 1
-  AddInt       r138, r138, r171
+  Append       r10, r10, r170
+  Const        r172, 1
+  AddInt       r139, r139, r172
   Jump         L18
 L15:
+  // let records = concat(dummy, base)
+  UnionAll     r173, r5, r10
   // json(records)
-  JSON         r9
+  JSON         r173
   // expect records == [ { ca_zip: "85669", sum_ws_sales_price: 50.0 }, { ca_zip: "99999", sum_ws_sales_price: 30.0 } ]
-  Const        r172, [{"ca_zip": "85669", "sum_ws_sales_price": 50}, {"ca_zip": "99999", "sum_ws_sales_price": 30}]
-  Equal        r173, r9, r172
-  Expect       r173
+  Const        r174, [{"ca_zip": "85669", "sum_ws_sales_price": 50}, {"ca_zip": "99999", "sum_ws_sales_price": 30}]
+  Equal        r175, r173, r174
+  Expect       r175
   Return       r0

--- a/tests/dataset/tpc-ds/out/q46.ir.out
+++ b/tests/dataset/tpc-ds/out/q46.ir.out
@@ -1,4 +1,4 @@
-func main (regs=406)
+func main (regs=408)
   // let store_sales = [
   Const        r0, [{"ss_addr_sk": 1, "ss_coupon_amt": 5, "ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_net_profit": 20, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}]
   // let date_dim = [ { d_date_sk: 1, d_dow: 6, d_year: 2020 } ]
@@ -19,185 +19,186 @@ func main (regs=406)
   Const        r8, 2020
   // let cities = ["CityA"]
   Const        r9, ["CityA"]
+  // let dummy = null
+  Const        r10, nil
   // from ss in store_sales
-  Const        r10, []
+  Const        r11, []
   // group by { ss_ticket_number: ss.ss_ticket_number, ss_customer_sk: ss.ss_customer_sk, ca_city: ca.ca_city } into g
-  Const        r11, "ss_ticket_number"
   Const        r12, "ss_ticket_number"
-  Const        r13, "ss_customer_sk"
+  Const        r13, "ss_ticket_number"
   Const        r14, "ss_customer_sk"
-  Const        r15, "ca_city"
+  Const        r15, "ss_customer_sk"
   Const        r16, "ca_city"
+  Const        r17, "ca_city"
   // where (hd.hd_dep_count == depcnt || hd.hd_vehicle_count == vehcnt) &&
-  Const        r17, "hd_dep_count"
-  Const        r18, "hd_vehicle_count"
+  Const        r18, "hd_dep_count"
+  Const        r19, "hd_vehicle_count"
   // d.d_dow in [6,0] && d.d_year == year && s.s_city in cities
-  Const        r19, "d_dow"
-  Const        r20, "d_year"
-  Const        r21, "s_city"
+  Const        r20, "d_dow"
+  Const        r21, "d_year"
+  Const        r22, "s_city"
   // select { ss_ticket_number: g.key.ss_ticket_number, ss_customer_sk: g.key.ss_customer_sk, bought_city: g.key.ca_city, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
-  Const        r22, "ss_ticket_number"
-  Const        r23, "key"
-  Const        r24, "ss_ticket_number"
-  Const        r25, "ss_customer_sk"
-  Const        r26, "key"
-  Const        r27, "ss_customer_sk"
-  Const        r28, "bought_city"
-  Const        r29, "key"
-  Const        r30, "ca_city"
-  Const        r31, "amt"
-  Const        r32, "ss"
-  Const        r33, "ss_coupon_amt"
-  Const        r34, "profit"
-  Const        r35, "ss"
-  Const        r36, "ss_net_profit"
+  Const        r23, "ss_ticket_number"
+  Const        r24, "key"
+  Const        r25, "ss_ticket_number"
+  Const        r26, "ss_customer_sk"
+  Const        r27, "key"
+  Const        r28, "ss_customer_sk"
+  Const        r29, "bought_city"
+  Const        r30, "key"
+  Const        r31, "ca_city"
+  Const        r32, "amt"
+  Const        r33, "ss"
+  Const        r34, "ss_coupon_amt"
+  Const        r35, "profit"
+  Const        r36, "ss"
+  Const        r37, "ss_net_profit"
   // from ss in store_sales
-  MakeMap      r37, 0, r0
-  Const        r38, []
-  IterPrep     r40, r0
-  Len          r41, r40
-  Const        r42, 0
+  MakeMap      r38, 0, r0
+  Const        r39, []
+  IterPrep     r41, r0
+  Len          r42, r41
+  Const        r43, 0
 L15:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L0
-  Index        r45, r40, r42
+  LessInt      r44, r43, r42
+  JumpIfFalse  r44, L0
+  Index        r46, r41, r43
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r46, r1
-  Len          r47, r46
-  Const        r48, 0
+  IterPrep     r47, r1
+  Len          r48, r47
+  Const        r49, 0
 L14:
-  LessInt      r49, r48, r47
-  JumpIfFalse  r49, L1
-  Index        r51, r46, r48
-  Const        r52, "ss_sold_date_sk"
-  Index        r53, r45, r52
-  Const        r54, "d_date_sk"
-  Index        r55, r51, r54
-  Equal        r56, r53, r55
-  JumpIfFalse  r56, L2
+  LessInt      r50, r49, r48
+  JumpIfFalse  r50, L1
+  Index        r52, r47, r49
+  Const        r53, "ss_sold_date_sk"
+  Index        r54, r46, r53
+  Const        r55, "d_date_sk"
+  Index        r56, r52, r55
+  Equal        r57, r54, r56
+  JumpIfFalse  r57, L2
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  IterPrep     r57, r2
-  Len          r58, r57
-  Const        r59, 0
+  IterPrep     r58, r2
+  Len          r59, r58
+  Const        r60, 0
 L13:
-  LessInt      r60, r59, r58
-  JumpIfFalse  r60, L2
-  Index        r62, r57, r59
-  Const        r63, "ss_store_sk"
-  Index        r64, r45, r63
-  Const        r65, "s_store_sk"
-  Index        r66, r62, r65
-  Equal        r67, r64, r66
-  JumpIfFalse  r67, L3
+  LessInt      r61, r60, r59
+  JumpIfFalse  r61, L2
+  Index        r63, r58, r60
+  Const        r64, "ss_store_sk"
+  Index        r65, r46, r64
+  Const        r66, "s_store_sk"
+  Index        r67, r63, r66
+  Equal        r68, r65, r67
+  JumpIfFalse  r68, L3
   // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
-  IterPrep     r68, r3
-  Len          r69, r68
-  Const        r70, 0
+  IterPrep     r69, r3
+  Len          r70, r69
+  Const        r71, 0
 L12:
-  LessInt      r71, r70, r69
-  JumpIfFalse  r71, L3
-  Index        r73, r68, r70
-  Const        r74, "ss_hdemo_sk"
-  Index        r75, r45, r74
-  Const        r76, "hd_demo_sk"
-  Index        r77, r73, r76
-  Equal        r78, r75, r77
-  JumpIfFalse  r78, L4
+  LessInt      r72, r71, r70
+  JumpIfFalse  r72, L3
+  Index        r74, r69, r71
+  Const        r75, "ss_hdemo_sk"
+  Index        r76, r46, r75
+  Const        r77, "hd_demo_sk"
+  Index        r78, r74, r77
+  Equal        r79, r76, r78
+  JumpIfFalse  r79, L4
   // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
-  IterPrep     r79, r4
-  Len          r80, r79
-  Const        r81, 0
+  IterPrep     r80, r4
+  Len          r81, r80
+  Const        r82, 0
 L11:
-  LessInt      r82, r81, r80
-  JumpIfFalse  r82, L4
-  Index        r84, r79, r81
-  Const        r85, "ss_addr_sk"
-  Index        r86, r45, r85
-  Const        r87, "ca_address_sk"
-  Index        r88, r84, r87
-  Equal        r89, r86, r88
-  JumpIfFalse  r89, L5
+  LessInt      r83, r82, r81
+  JumpIfFalse  r83, L4
+  Index        r85, r80, r82
+  Const        r86, "ss_addr_sk"
+  Index        r87, r46, r86
+  Const        r88, "ca_address_sk"
+  Index        r89, r85, r88
+  Equal        r90, r87, r89
+  JumpIfFalse  r90, L5
   // where (hd.hd_dep_count == depcnt || hd.hd_vehicle_count == vehcnt) &&
-  Const        r90, "hd_dep_count"
-  Index        r91, r73, r90
-  Equal        r92, r91, r6
-  Const        r93, "hd_vehicle_count"
-  Index        r94, r73, r93
-  Equal        r95, r94, r7
-  Move         r96, r92
-  JumpIfTrue   r96, L6
-  Move         r96, r95
+  Const        r91, "hd_dep_count"
+  Index        r92, r74, r91
+  Equal        r93, r92, r6
+  Const        r94, "hd_vehicle_count"
+  Index        r95, r74, r94
+  Equal        r96, r95, r7
+  Move         r97, r93
+  JumpIfTrue   r97, L6
+  Move         r97, r96
 L6:
   // d.d_dow in [6,0] && d.d_year == year && s.s_city in cities
-  Const        r97, "d_dow"
-  Index        r98, r51, r97
-  Const        r99, [6, 0]
-  In           r100, r98, r99
-  Const        r101, "d_year"
-  Index        r102, r51, r101
-  Equal        r103, r102, r8
-  Const        r104, "s_city"
-  Index        r105, r62, r104
-  In           r106, r105, r9
+  Const        r98, "d_dow"
+  Index        r99, r52, r98
+  Const        r100, [6, 0]
+  In           r101, r99, r100
+  Const        r102, "d_year"
+  Index        r103, r52, r102
+  Equal        r104, r103, r8
+  Const        r105, "s_city"
+  Index        r106, r63, r105
+  In           r107, r106, r9
   // where (hd.hd_dep_count == depcnt || hd.hd_vehicle_count == vehcnt) &&
-  Move         r107, r96
-  JumpIfFalse  r107, L7
+  Move         r108, r97
+  JumpIfFalse  r108, L7
 L7:
   // d.d_dow in [6,0] && d.d_year == year && s.s_city in cities
-  Move         r108, r100
-  JumpIfFalse  r108, L8
+  Move         r109, r101
+  JumpIfFalse  r109, L8
 L8:
-  Move         r109, r103
-  JumpIfFalse  r109, L9
-  Move         r109, r106
+  Move         r110, r104
+  JumpIfFalse  r110, L9
+  Move         r110, r107
 L9:
   // where (hd.hd_dep_count == depcnt || hd.hd_vehicle_count == vehcnt) &&
-  JumpIfFalse  r109, L5
+  JumpIfFalse  r110, L5
   // from ss in store_sales
-  Const        r110, "ss"
-  Move         r111, r45
-  Const        r112, "d"
-  Move         r113, r51
-  Const        r114, "s"
-  Move         r115, r62
-  Const        r116, "hd"
-  Move         r117, r73
-  Const        r118, "ca"
-  Move         r119, r84
-  MakeMap      r120, 5, r110
+  Const        r111, "ss"
+  Move         r112, r46
+  Const        r113, "d"
+  Move         r114, r52
+  Const        r115, "s"
+  Move         r116, r63
+  Const        r117, "hd"
+  Move         r118, r74
+  Const        r119, "ca"
+  Move         r120, r85
+  MakeMap      r121, 5, r111
   // group by { ss_ticket_number: ss.ss_ticket_number, ss_customer_sk: ss.ss_customer_sk, ca_city: ca.ca_city } into g
-  Const        r121, "ss_ticket_number"
   Const        r122, "ss_ticket_number"
-  Index        r123, r45, r122
-  Const        r124, "ss_customer_sk"
+  Const        r123, "ss_ticket_number"
+  Index        r124, r46, r123
   Const        r125, "ss_customer_sk"
-  Index        r126, r45, r125
-  Const        r127, "ca_city"
+  Const        r126, "ss_customer_sk"
+  Index        r127, r46, r126
   Const        r128, "ca_city"
-  Index        r129, r84, r128
-  Move         r130, r121
-  Move         r131, r123
+  Const        r129, "ca_city"
+  Index        r130, r85, r129
+  Move         r131, r122
   Move         r132, r124
-  Move         r133, r126
+  Move         r133, r125
   Move         r134, r127
-  Move         r135, r129
-  MakeMap      r136, 3, r130
-  Str          r137, r136
-  In           r138, r137, r37
-  JumpIfTrue   r138, L10
+  Move         r135, r128
+  Move         r136, r130
+  MakeMap      r137, 3, r131
+  Str          r138, r137
+  In           r139, r138, r38
+  JumpIfTrue   r139, L10
   // from ss in store_sales
-  Const        r139, []
-  Const        r140, "__group__"
-  Const        r141, true
-  Const        r142, "key"
+  Const        r140, []
+  Const        r141, "__group__"
+  Const        r142, true
+  Const        r143, "key"
   // group by { ss_ticket_number: ss.ss_ticket_number, ss_customer_sk: ss.ss_customer_sk, ca_city: ca.ca_city } into g
-  Move         r143, r136
+  Move         r144, r137
   // from ss in store_sales
-  Const        r144, "items"
-  Move         r145, r139
-  Const        r146, "count"
-  Const        r147, 0
-  Move         r148, r140
+  Const        r145, "items"
+  Move         r146, r140
+  Const        r147, "count"
+  Const        r148, 0
   Move         r149, r141
   Move         r150, r142
   Move         r151, r143
@@ -205,326 +206,329 @@ L9:
   Move         r153, r145
   Move         r154, r146
   Move         r155, r147
-  MakeMap      r156, 4, r148
-  SetIndex     r37, r137, r156
-  Append       r38, r38, r156
+  Move         r156, r148
+  MakeMap      r157, 4, r149
+  SetIndex     r38, r138, r157
+  Append       r39, r39, r157
 L10:
-  Const        r158, "items"
-  Index        r159, r37, r137
-  Index        r160, r159, r158
-  Append       r161, r160, r120
-  SetIndex     r159, r158, r161
-  Const        r162, "count"
-  Index        r163, r159, r162
-  Const        r164, 1
-  AddInt       r165, r163, r164
-  SetIndex     r159, r162, r165
+  Const        r159, "items"
+  Index        r160, r38, r138
+  Index        r161, r160, r159
+  Append       r162, r161, r121
+  SetIndex     r160, r159, r162
+  Const        r163, "count"
+  Index        r164, r160, r163
+  Const        r165, 1
+  AddInt       r166, r164, r165
+  SetIndex     r160, r163, r166
 L5:
   // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
-  Const        r166, 1
-  AddInt       r81, r81, r166
+  Const        r167, 1
+  AddInt       r82, r82, r167
   Jump         L11
 L4:
   // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
-  Const        r167, 1
-  AddInt       r70, r70, r167
+  Const        r168, 1
+  AddInt       r71, r71, r168
   Jump         L12
 L3:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  Const        r168, 1
-  AddInt       r59, r59, r168
+  Const        r169, 1
+  AddInt       r60, r60, r169
   Jump         L13
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  Const        r169, 1
-  AddInt       r48, r48, r169
+  Const        r170, 1
+  AddInt       r49, r49, r170
   Jump         L14
 L1:
   // from ss in store_sales
-  Const        r170, 1
-  AddInt       r42, r42, r170
+  Const        r171, 1
+  AddInt       r43, r43, r171
   Jump         L15
 L0:
-  Const        r171, 0
-  Len          r173, r38
+  Const        r172, 0
+  Len          r174, r39
 L21:
-  LessInt      r174, r171, r173
-  JumpIfFalse  r174, L16
-  Index        r176, r38, r171
+  LessInt      r175, r172, r174
+  JumpIfFalse  r175, L16
+  Index        r177, r39, r172
   // select { ss_ticket_number: g.key.ss_ticket_number, ss_customer_sk: g.key.ss_customer_sk, bought_city: g.key.ca_city, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
-  Const        r177, "ss_ticket_number"
-  Const        r178, "key"
-  Index        r179, r176, r178
-  Const        r180, "ss_ticket_number"
-  Index        r181, r179, r180
-  Const        r182, "ss_customer_sk"
-  Const        r183, "key"
-  Index        r184, r176, r183
-  Const        r185, "ss_customer_sk"
-  Index        r186, r184, r185
-  Const        r187, "bought_city"
-  Const        r188, "key"
-  Index        r189, r176, r188
-  Const        r190, "ca_city"
-  Index        r191, r189, r190
-  Const        r192, "amt"
-  Const        r193, []
-  Const        r194, "ss"
-  Const        r195, "ss_coupon_amt"
-  IterPrep     r196, r176
-  Len          r197, r196
-  Const        r198, 0
+  Const        r178, "ss_ticket_number"
+  Const        r179, "key"
+  Index        r180, r177, r179
+  Const        r181, "ss_ticket_number"
+  Index        r182, r180, r181
+  Const        r183, "ss_customer_sk"
+  Const        r184, "key"
+  Index        r185, r177, r184
+  Const        r186, "ss_customer_sk"
+  Index        r187, r185, r186
+  Const        r188, "bought_city"
+  Const        r189, "key"
+  Index        r190, r177, r189
+  Const        r191, "ca_city"
+  Index        r192, r190, r191
+  Const        r193, "amt"
+  Const        r194, []
+  Const        r195, "ss"
+  Const        r196, "ss_coupon_amt"
+  IterPrep     r197, r177
+  Len          r198, r197
+  Const        r199, 0
 L18:
-  LessInt      r200, r198, r197
-  JumpIfFalse  r200, L17
-  Index        r202, r196, r198
-  Const        r203, "ss"
-  Index        r204, r202, r203
-  Const        r205, "ss_coupon_amt"
-  Index        r206, r204, r205
-  Append       r193, r193, r206
-  Const        r208, 1
-  AddInt       r198, r198, r208
+  LessInt      r201, r199, r198
+  JumpIfFalse  r201, L17
+  Index        r203, r197, r199
+  Const        r204, "ss"
+  Index        r205, r203, r204
+  Const        r206, "ss_coupon_amt"
+  Index        r207, r205, r206
+  Append       r194, r194, r207
+  Const        r209, 1
+  AddInt       r199, r199, r209
   Jump         L18
 L17:
-  Sum          r209, r193
-  Const        r210, "profit"
-  Const        r211, []
-  Const        r212, "ss"
-  Const        r213, "ss_net_profit"
-  IterPrep     r214, r176
-  Len          r215, r214
-  Const        r216, 0
+  Sum          r210, r194
+  Const        r211, "profit"
+  Const        r212, []
+  Const        r213, "ss"
+  Const        r214, "ss_net_profit"
+  IterPrep     r215, r177
+  Len          r216, r215
+  Const        r217, 0
 L20:
-  LessInt      r218, r216, r215
-  JumpIfFalse  r218, L19
-  Index        r202, r214, r216
-  Const        r220, "ss"
-  Index        r221, r202, r220
-  Const        r222, "ss_net_profit"
-  Index        r223, r221, r222
-  Append       r211, r211, r223
-  Const        r225, 1
-  AddInt       r216, r216, r225
+  LessInt      r219, r217, r216
+  JumpIfFalse  r219, L19
+  Index        r203, r215, r217
+  Const        r221, "ss"
+  Index        r222, r203, r221
+  Const        r223, "ss_net_profit"
+  Index        r224, r222, r223
+  Append       r212, r212, r224
+  Const        r226, 1
+  AddInt       r217, r217, r226
   Jump         L20
 L19:
-  Sum          r226, r211
-  Move         r227, r177
-  Move         r228, r181
+  Sum          r227, r212
+  Move         r228, r178
   Move         r229, r182
-  Move         r230, r186
+  Move         r230, r183
   Move         r231, r187
-  Move         r232, r191
+  Move         r232, r188
   Move         r233, r192
-  Move         r234, r209
+  Move         r234, r193
   Move         r235, r210
-  Move         r236, r226
-  MakeMap      r237, 5, r227
+  Move         r236, r211
+  Move         r237, r227
+  MakeMap      r238, 5, r228
   // from ss in store_sales
-  Append       r10, r10, r237
-  Const        r239, 1
-  AddInt       r171, r171, r239
+  Append       r11, r11, r238
+  Const        r240, 1
+  AddInt       r172, r172, r240
   Jump         L21
 L16:
   // from dnrec in dn
-  Const        r240, []
+  Const        r241, []
   // where current_addr.ca_city != dnrec.bought_city
-  Const        r241, "ca_city"
-  Const        r242, "bought_city"
+  Const        r242, "ca_city"
+  Const        r243, "bought_city"
   // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, ca_city: current_addr.ca_city, bought_city: dnrec.bought_city, ss_ticket_number: dnrec.ss_ticket_number, amt: dnrec.amt, profit: dnrec.profit }
-  Const        r243, "c_last_name"
   Const        r244, "c_last_name"
-  Const        r245, "c_first_name"
+  Const        r245, "c_last_name"
   Const        r246, "c_first_name"
-  Const        r247, "ca_city"
+  Const        r247, "c_first_name"
   Const        r248, "ca_city"
-  Const        r249, "bought_city"
+  Const        r249, "ca_city"
   Const        r250, "bought_city"
-  Const        r251, "ss_ticket_number"
+  Const        r251, "bought_city"
   Const        r252, "ss_ticket_number"
-  Const        r253, "amt"
+  Const        r253, "ss_ticket_number"
   Const        r254, "amt"
-  Const        r255, "profit"
+  Const        r255, "amt"
   Const        r256, "profit"
+  Const        r257, "profit"
   // sort by [c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number]
-  Const        r257, "c_last_name"
-  Const        r258, "c_first_name"
-  Const        r259, "ca_city"
-  Const        r260, "bought_city"
-  Const        r261, "ss_ticket_number"
+  Const        r258, "c_last_name"
+  Const        r259, "c_first_name"
+  Const        r260, "ca_city"
+  Const        r261, "bought_city"
+  Const        r262, "ss_ticket_number"
   // from dnrec in dn
-  IterPrep     r262, r10
-  Len          r263, r262
-  Const        r264, 0
+  IterPrep     r263, r11
+  Len          r264, r263
+  Const        r265, 0
 L28:
-  LessInt      r266, r264, r263
-  JumpIfFalse  r266, L22
-  Index        r268, r262, r264
+  LessInt      r267, r265, r264
+  JumpIfFalse  r267, L22
+  Index        r269, r263, r265
   // join c in customer on dnrec.ss_customer_sk == c.c_customer_sk
-  IterPrep     r269, r5
-  Len          r270, r269
-  Const        r271, "ss_customer_sk"
-  Const        r272, "c_customer_sk"
+  IterPrep     r270, r5
+  Len          r271, r270
+  Const        r272, "ss_customer_sk"
+  Const        r273, "c_customer_sk"
   // where current_addr.ca_city != dnrec.bought_city
-  Const        r273, "ca_city"
-  Const        r274, "bought_city"
+  Const        r274, "ca_city"
+  Const        r275, "bought_city"
   // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, ca_city: current_addr.ca_city, bought_city: dnrec.bought_city, ss_ticket_number: dnrec.ss_ticket_number, amt: dnrec.amt, profit: dnrec.profit }
-  Const        r275, "c_last_name"
   Const        r276, "c_last_name"
-  Const        r277, "c_first_name"
+  Const        r277, "c_last_name"
   Const        r278, "c_first_name"
-  Const        r279, "ca_city"
+  Const        r279, "c_first_name"
   Const        r280, "ca_city"
-  Const        r281, "bought_city"
+  Const        r281, "ca_city"
   Const        r282, "bought_city"
-  Const        r283, "ss_ticket_number"
+  Const        r283, "bought_city"
   Const        r284, "ss_ticket_number"
-  Const        r285, "amt"
+  Const        r285, "ss_ticket_number"
   Const        r286, "amt"
-  Const        r287, "profit"
+  Const        r287, "amt"
   Const        r288, "profit"
+  Const        r289, "profit"
   // sort by [c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number]
-  Const        r289, "c_last_name"
-  Const        r290, "c_first_name"
-  Const        r291, "ca_city"
-  Const        r292, "bought_city"
-  Const        r293, "ss_ticket_number"
+  Const        r290, "c_last_name"
+  Const        r291, "c_first_name"
+  Const        r292, "ca_city"
+  Const        r293, "bought_city"
+  Const        r294, "ss_ticket_number"
   // join c in customer on dnrec.ss_customer_sk == c.c_customer_sk
-  Const        r294, 0
+  Const        r295, 0
 L27:
-  LessInt      r296, r294, r270
-  JumpIfFalse  r296, L23
-  Index        r298, r269, r294
-  Const        r299, "ss_customer_sk"
-  Index        r300, r268, r299
-  Const        r301, "c_customer_sk"
-  Index        r302, r298, r301
-  Equal        r303, r300, r302
-  JumpIfFalse  r303, L24
+  LessInt      r297, r295, r271
+  JumpIfFalse  r297, L23
+  Index        r299, r270, r295
+  Const        r300, "ss_customer_sk"
+  Index        r301, r269, r300
+  Const        r302, "c_customer_sk"
+  Index        r303, r299, r302
+  Equal        r304, r301, r303
+  JumpIfFalse  r304, L24
   // join current_addr in customer_address on c.c_current_addr_sk == current_addr.ca_address_sk
-  IterPrep     r304, r4
-  Len          r305, r304
-  Const        r306, "c_current_addr_sk"
-  Const        r307, "ca_address_sk"
+  IterPrep     r305, r4
+  Len          r306, r305
+  Const        r307, "c_current_addr_sk"
+  Const        r308, "ca_address_sk"
   // where current_addr.ca_city != dnrec.bought_city
-  Const        r308, "ca_city"
-  Const        r309, "bought_city"
+  Const        r309, "ca_city"
+  Const        r310, "bought_city"
   // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, ca_city: current_addr.ca_city, bought_city: dnrec.bought_city, ss_ticket_number: dnrec.ss_ticket_number, amt: dnrec.amt, profit: dnrec.profit }
-  Const        r310, "c_last_name"
   Const        r311, "c_last_name"
-  Const        r312, "c_first_name"
+  Const        r312, "c_last_name"
   Const        r313, "c_first_name"
-  Const        r314, "ca_city"
+  Const        r314, "c_first_name"
   Const        r315, "ca_city"
-  Const        r316, "bought_city"
+  Const        r316, "ca_city"
   Const        r317, "bought_city"
-  Const        r318, "ss_ticket_number"
+  Const        r318, "bought_city"
   Const        r319, "ss_ticket_number"
-  Const        r320, "amt"
+  Const        r320, "ss_ticket_number"
   Const        r321, "amt"
-  Const        r322, "profit"
+  Const        r322, "amt"
   Const        r323, "profit"
+  Const        r324, "profit"
   // sort by [c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number]
-  Const        r324, "c_last_name"
-  Const        r325, "c_first_name"
-  Const        r326, "ca_city"
-  Const        r327, "bought_city"
-  Const        r328, "ss_ticket_number"
+  Const        r325, "c_last_name"
+  Const        r326, "c_first_name"
+  Const        r327, "ca_city"
+  Const        r328, "bought_city"
+  Const        r329, "ss_ticket_number"
   // join current_addr in customer_address on c.c_current_addr_sk == current_addr.ca_address_sk
-  Const        r329, 0
+  Const        r330, 0
 L26:
-  LessInt      r331, r329, r305
-  JumpIfFalse  r331, L24
-  Index        r333, r304, r329
-  Const        r334, "c_current_addr_sk"
-  Index        r335, r298, r334
-  Const        r336, "ca_address_sk"
-  Index        r337, r333, r336
-  Equal        r338, r335, r337
-  JumpIfFalse  r338, L25
+  LessInt      r332, r330, r306
+  JumpIfFalse  r332, L24
+  Index        r334, r305, r330
+  Const        r335, "c_current_addr_sk"
+  Index        r336, r299, r335
+  Const        r337, "ca_address_sk"
+  Index        r338, r334, r337
+  Equal        r339, r336, r338
+  JumpIfFalse  r339, L25
   // where current_addr.ca_city != dnrec.bought_city
-  Const        r339, "ca_city"
-  Index        r340, r333, r339
-  Const        r341, "bought_city"
-  Index        r342, r268, r341
-  NotEqual     r343, r340, r342
-  JumpIfFalse  r343, L25
+  Const        r340, "ca_city"
+  Index        r341, r334, r340
+  Const        r342, "bought_city"
+  Index        r343, r269, r342
+  NotEqual     r344, r341, r343
+  JumpIfFalse  r344, L25
   // select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, ca_city: current_addr.ca_city, bought_city: dnrec.bought_city, ss_ticket_number: dnrec.ss_ticket_number, amt: dnrec.amt, profit: dnrec.profit }
-  Const        r344, "c_last_name"
   Const        r345, "c_last_name"
-  Index        r346, r298, r345
-  Const        r347, "c_first_name"
+  Const        r346, "c_last_name"
+  Index        r347, r299, r346
   Const        r348, "c_first_name"
-  Index        r349, r298, r348
-  Const        r350, "ca_city"
+  Const        r349, "c_first_name"
+  Index        r350, r299, r349
   Const        r351, "ca_city"
-  Index        r352, r333, r351
-  Const        r353, "bought_city"
+  Const        r352, "ca_city"
+  Index        r353, r334, r352
   Const        r354, "bought_city"
-  Index        r355, r268, r354
-  Const        r356, "ss_ticket_number"
+  Const        r355, "bought_city"
+  Index        r356, r269, r355
   Const        r357, "ss_ticket_number"
-  Index        r358, r268, r357
-  Const        r359, "amt"
+  Const        r358, "ss_ticket_number"
+  Index        r359, r269, r358
   Const        r360, "amt"
-  Index        r361, r268, r360
-  Const        r362, "profit"
+  Const        r361, "amt"
+  Index        r362, r269, r361
   Const        r363, "profit"
-  Index        r364, r268, r363
-  Move         r365, r344
-  Move         r366, r346
+  Const        r364, "profit"
+  Index        r365, r269, r364
+  Move         r366, r345
   Move         r367, r347
-  Move         r368, r349
+  Move         r368, r348
   Move         r369, r350
-  Move         r370, r352
+  Move         r370, r351
   Move         r371, r353
-  Move         r372, r355
+  Move         r372, r354
   Move         r373, r356
-  Move         r374, r358
+  Move         r374, r357
   Move         r375, r359
-  Move         r376, r361
+  Move         r376, r360
   Move         r377, r362
-  Move         r378, r364
-  MakeMap      r379, 7, r365
+  Move         r378, r363
+  Move         r379, r365
+  MakeMap      r380, 7, r366
   // sort by [c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number]
-  Const        r380, "c_last_name"
-  Index        r382, r298, r380
-  Const        r383, "c_first_name"
-  Index        r384, r298, r383
-  Move         r385, r384
-  Const        r386, "ca_city"
-  Index        r388, r333, r386
-  Const        r389, "bought_city"
-  Index        r391, r268, r389
-  Const        r392, "ss_ticket_number"
-  Index        r394, r268, r392
-  MakeList     r396, 5, r382
+  Const        r381, "c_last_name"
+  Index        r383, r299, r381
+  Const        r384, "c_first_name"
+  Index        r385, r299, r384
+  Move         r386, r385
+  Const        r387, "ca_city"
+  Index        r389, r334, r387
+  Const        r390, "bought_city"
+  Index        r392, r269, r390
+  Const        r393, "ss_ticket_number"
+  Index        r395, r269, r393
+  MakeList     r397, 5, r383
   // from dnrec in dn
-  Move         r397, r379
-  MakeList     r398, 2, r396
-  Append       r240, r240, r398
+  Move         r398, r380
+  MakeList     r399, 2, r397
+  Append       r241, r241, r399
 L25:
   // join current_addr in customer_address on c.c_current_addr_sk == current_addr.ca_address_sk
-  Const        r400, 1
-  Add          r329, r329, r400
+  Const        r401, 1
+  Add          r330, r330, r401
   Jump         L26
 L24:
   // join c in customer on dnrec.ss_customer_sk == c.c_customer_sk
-  Const        r401, 1
-  Add          r294, r294, r401
+  Const        r402, 1
+  Add          r295, r295, r402
   Jump         L27
 L23:
   // from dnrec in dn
-  Const        r402, 1
-  AddInt       r264, r264, r402
+  Const        r403, 1
+  AddInt       r265, r265, r403
   Jump         L28
 L22:
   // sort by [c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number]
-  Sort         r240, r240
+  Sort         r241, r241
+  // let result = concat(dummy, base)
+  UnionAll     r405, r10, r241
   // json(result)
-  JSON         r240
+  JSON         r405
   // expect result == [
-  Const        r404, [{"amt": 5, "bought_city": "Portland", "c_first_name": "John", "c_last_name": "Doe", "ca_city": "Seattle", "profit": 20, "ss_ticket_number": 1}]
-  Equal        r405, r240, r404
-  Expect       r405
+  Const        r406, [{"amt": 5, "bought_city": "Portland", "c_first_name": "John", "c_last_name": "Doe", "ca_city": "Seattle", "profit": 20, "ss_ticket_number": 1}]
+  Equal        r407, r405, r406
+  Expect       r407
   Return       r0

--- a/tests/dataset/tpc-ds/out/q47.ir.out
+++ b/tests/dataset/tpc-ds/out/q47.ir.out
@@ -1,82 +1,86 @@
-func main (regs=58)
+func main (regs=60)
   // let v2 = [
   Const        r0, [{"avg_monthly_sales": 100, "d_year": 2020, "item": "A", "sum_sales": 120}, {"avg_monthly_sales": 80, "d_year": 2020, "item": "B", "sum_sales": 70}, {"avg_monthly_sales": 50, "d_year": 2019, "item": "C", "sum_sales": 60}]
   // let year = 2020
   Const        r1, 2020
   // let orderby = "item"
   Const        r2, "item"
+  // let dummy = null
+  Const        r3, nil
   // from v in v2
-  Const        r3, []
+  Const        r4, []
   // where v.d_year == year && v.avg_monthly_sales > 0 && abs(v.sum_sales - v.avg_monthly_sales) / v.avg_monthly_sales > 0.1
-  Const        r4, "d_year"
-  Const        r5, "avg_monthly_sales"
-  Const        r6, "sum_sales"
-  Const        r7, "avg_monthly_sales"
+  Const        r5, "d_year"
+  Const        r6, "avg_monthly_sales"
+  Const        r7, "sum_sales"
   Const        r8, "avg_monthly_sales"
+  Const        r9, "avg_monthly_sales"
   // sort by [v.sum_sales - v.avg_monthly_sales, v.item]
-  Const        r9, "sum_sales"
-  Const        r10, "avg_monthly_sales"
-  Const        r11, "item"
+  Const        r10, "sum_sales"
+  Const        r11, "avg_monthly_sales"
+  Const        r12, "item"
   // from v in v2
-  IterPrep     r12, r0
-  Len          r13, r12
-  Const        r14, 0
+  IterPrep     r13, r0
+  Len          r14, r13
+  Const        r15, 0
 L4:
-  LessInt      r16, r14, r13
-  JumpIfFalse  r16, L0
-  Index        r18, r12, r14
+  LessInt      r17, r15, r14
+  JumpIfFalse  r17, L0
+  Index        r19, r13, r15
   // where v.d_year == year && v.avg_monthly_sales > 0 && abs(v.sum_sales - v.avg_monthly_sales) / v.avg_monthly_sales > 0.1
-  Const        r19, "d_year"
-  Index        r20, r18, r19
-  Const        r22, "sum_sales"
-  Index        r23, r18, r22
-  Const        r24, "avg_monthly_sales"
-  Index        r25, r18, r24
-  Sub          r21, r23, r25
-  Call         r27, abs, r21
-  Const        r28, "avg_monthly_sales"
-  Index        r29, r18, r28
-  Div          r30, r27, r29
-  Const        r31, "avg_monthly_sales"
-  Index        r32, r18, r31
-  Const        r33, 0
-  Less         r34, r33, r32
-  Const        r35, 0.1
-  LessFloat    r36, r35, r30
-  Equal        r38, r20, r1
-  JumpIfFalse  r38, L1
+  Const        r20, "d_year"
+  Index        r21, r19, r20
+  Const        r23, "sum_sales"
+  Index        r24, r19, r23
+  Const        r25, "avg_monthly_sales"
+  Index        r26, r19, r25
+  Sub          r22, r24, r26
+  Call         r28, abs, r22
+  Const        r29, "avg_monthly_sales"
+  Index        r30, r19, r29
+  Div          r31, r28, r30
+  Const        r32, "avg_monthly_sales"
+  Index        r33, r19, r32
+  Const        r34, 0
+  Less         r35, r34, r33
+  Const        r36, 0.1
+  LessFloat    r37, r36, r31
+  Equal        r39, r21, r1
+  JumpIfFalse  r39, L1
 L1:
-  Move         r39, r34
-  JumpIfFalse  r39, L2
-  Move         r39, r36
+  Move         r40, r35
+  JumpIfFalse  r40, L2
+  Move         r40, r37
 L2:
-  JumpIfFalse  r39, L3
+  JumpIfFalse  r40, L3
   // sort by [v.sum_sales - v.avg_monthly_sales, v.item]
-  Const        r40, "sum_sales"
-  Index        r41, r18, r40
-  Const        r42, "avg_monthly_sales"
-  Index        r43, r18, r42
-  Sub          r45, r41, r43
-  Const        r46, "item"
-  Index        r48, r18, r46
-  MakeList     r50, 2, r45
+  Const        r41, "sum_sales"
+  Index        r42, r19, r41
+  Const        r43, "avg_monthly_sales"
+  Index        r44, r19, r43
+  Sub          r46, r42, r44
+  Const        r47, "item"
+  Index        r49, r19, r47
+  MakeList     r51, 2, r46
   // from v in v2
-  Move         r51, r18
-  MakeList     r52, 2, r50
-  Append       r3, r3, r52
+  Move         r52, r19
+  MakeList     r53, 2, r51
+  Append       r4, r4, r53
 L3:
-  Const        r54, 1
-  AddInt       r14, r14, r54
+  Const        r55, 1
+  AddInt       r15, r15, r55
   Jump         L4
 L0:
   // sort by [v.sum_sales - v.avg_monthly_sales, v.item]
-  Sort         r3, r3
+  Sort         r4, r4
+  // let result = concat(dummy, base)
+  UnionAll     r57, r3, r4
   // json(result)
-  JSON         r3
+  JSON         r57
   // expect result == [
-  Const        r56, [{"avg_monthly_sales": 50, "d_year": 2019, "item": "C", "sum_sales": 60}, {"avg_monthly_sales": 100, "d_year": 2020, "item": "A", "sum_sales": 120}]
-  Equal        r57, r3, r56
-  Expect       r57
+  Const        r58, [{"avg_monthly_sales": 50, "d_year": 2019, "item": "C", "sum_sales": 60}, {"avg_monthly_sales": 100, "d_year": 2020, "item": "A", "sum_sales": 120}]
+  Equal        r59, r57, r58
+  Expect       r59
   Return       r0
 
   // fun abs(x: float): float {

--- a/tests/dataset/tpc-ds/out/q48.ir.out
+++ b/tests/dataset/tpc-ds/out/q48.ir.out
@@ -1,4 +1,4 @@
-func main (regs=266)
+func main (regs=268)
   // let store_sales = [
   Const        r0, [{"addr_sk": 1, "cdemo_sk": 1, "net_profit": 1000, "quantity": 5, "sales_price": 120, "sold_date_sk": 1}, {"addr_sk": 2, "cdemo_sk": 2, "net_profit": 2000, "quantity": 10, "sales_price": 60, "sold_date_sk": 1}, {"addr_sk": 3, "cdemo_sk": 3, "net_profit": 10000, "quantity": 20, "sales_price": 170, "sold_date_sk": 1}]
   // let store = [ { s_store_sk: 1 } ]
@@ -9,381 +9,385 @@ func main (regs=266)
   Const        r3, [{"ca_address_sk": 1, "ca_country": "United States", "ca_state": "TX"}, {"ca_address_sk": 2, "ca_country": "United States", "ca_state": "CA"}, {"ca_address_sk": 3, "ca_country": "United States", "ca_state": "NY"}]
   // let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
   Const        r4, [{"d_date_sk": 1, "d_year": 2000}]
+  // let dummy = null
+  Const        r5, nil
   // let year = 2000
-  Const        r5, 2000
+  Const        r6, 2000
   // let states1 = ["TX"]
-  Const        r6, ["TX"]
+  Const        r7, ["TX"]
   // let states2 = ["CA"]
-  Const        r7, ["CA"]
+  Const        r8, ["CA"]
   // let states3 = ["NY"]
-  Const        r8, ["NY"]
+  Const        r9, ["NY"]
   // from ss in store_sales
-  Const        r9, []
+  Const        r10, []
   // where d.d_year == year &&
-  Const        r10, "d_year"
+  Const        r11, "d_year"
   // (cd.cd_marital_status == "S" && cd.cd_education_status == "E1" && ss.sales_price >= 100.0 && ss.sales_price <= 150.0) ||
-  Const        r11, "cd_marital_status"
-  Const        r12, "cd_education_status"
-  Const        r13, "sales_price"
+  Const        r12, "cd_marital_status"
+  Const        r13, "cd_education_status"
   Const        r14, "sales_price"
+  Const        r15, "sales_price"
   // (cd.cd_marital_status == "M" && cd.cd_education_status == "E2" && ss.sales_price >= 50.0 && ss.sales_price <= 100.0) ||
-  Const        r15, "cd_marital_status"
-  Const        r16, "cd_education_status"
-  Const        r17, "sales_price"
+  Const        r16, "cd_marital_status"
+  Const        r17, "cd_education_status"
   Const        r18, "sales_price"
+  Const        r19, "sales_price"
   // (cd.cd_marital_status == "W" && cd.cd_education_status == "E3" && ss.sales_price >= 150.0 && ss.sales_price <= 200.0)
-  Const        r19, "cd_marital_status"
-  Const        r20, "cd_education_status"
-  Const        r21, "sales_price"
+  Const        r20, "cd_marital_status"
+  Const        r21, "cd_education_status"
   Const        r22, "sales_price"
+  Const        r23, "sales_price"
   // (ca.ca_state in states1 && ss.net_profit >= 0 && ss.net_profit <= 2000) ||
-  Const        r23, "ca_state"
-  Const        r24, "net_profit"
+  Const        r24, "ca_state"
   Const        r25, "net_profit"
+  Const        r26, "net_profit"
   // (ca.ca_state in states2 && ss.net_profit >= 150 && ss.net_profit <= 3000) ||
-  Const        r26, "ca_state"
-  Const        r27, "net_profit"
+  Const        r27, "ca_state"
   Const        r28, "net_profit"
+  Const        r29, "net_profit"
   // (ca.ca_state in states3 && ss.net_profit >= 50 && ss.net_profit <= 25000)
-  Const        r29, "ca_state"
-  Const        r30, "net_profit"
+  Const        r30, "ca_state"
   Const        r31, "net_profit"
+  Const        r32, "net_profit"
   // select ss.quantity
-  Const        r32, "quantity"
+  Const        r33, "quantity"
   // from ss in store_sales
-  IterPrep     r33, r0
-  Len          r34, r33
-  Const        r35, 0
+  IterPrep     r34, r0
+  Len          r35, r34
+  Const        r36, 0
 L24:
-  LessInt      r37, r35, r34
-  JumpIfFalse  r37, L0
-  Index        r39, r33, r35
+  LessInt      r38, r36, r35
+  JumpIfFalse  r38, L0
+  Index        r40, r34, r36
   // join cd in customer_demographics on ss.cdemo_sk == cd.cd_demo_sk
-  IterPrep     r40, r2
-  Len          r41, r40
-  Const        r42, "cdemo_sk"
-  Const        r43, "cd_demo_sk"
+  IterPrep     r41, r2
+  Len          r42, r41
+  Const        r43, "cdemo_sk"
+  Const        r44, "cd_demo_sk"
   // where d.d_year == year &&
-  Const        r44, "d_year"
+  Const        r45, "d_year"
   // (cd.cd_marital_status == "S" && cd.cd_education_status == "E1" && ss.sales_price >= 100.0 && ss.sales_price <= 150.0) ||
-  Const        r45, "cd_marital_status"
-  Const        r46, "cd_education_status"
-  Const        r47, "sales_price"
+  Const        r46, "cd_marital_status"
+  Const        r47, "cd_education_status"
   Const        r48, "sales_price"
+  Const        r49, "sales_price"
   // (cd.cd_marital_status == "M" && cd.cd_education_status == "E2" && ss.sales_price >= 50.0 && ss.sales_price <= 100.0) ||
-  Const        r49, "cd_marital_status"
-  Const        r50, "cd_education_status"
-  Const        r51, "sales_price"
+  Const        r50, "cd_marital_status"
+  Const        r51, "cd_education_status"
   Const        r52, "sales_price"
+  Const        r53, "sales_price"
   // (cd.cd_marital_status == "W" && cd.cd_education_status == "E3" && ss.sales_price >= 150.0 && ss.sales_price <= 200.0)
-  Const        r53, "cd_marital_status"
-  Const        r54, "cd_education_status"
-  Const        r55, "sales_price"
+  Const        r54, "cd_marital_status"
+  Const        r55, "cd_education_status"
   Const        r56, "sales_price"
+  Const        r57, "sales_price"
   // (ca.ca_state in states1 && ss.net_profit >= 0 && ss.net_profit <= 2000) ||
-  Const        r57, "ca_state"
-  Const        r58, "net_profit"
+  Const        r58, "ca_state"
   Const        r59, "net_profit"
+  Const        r60, "net_profit"
   // (ca.ca_state in states2 && ss.net_profit >= 150 && ss.net_profit <= 3000) ||
-  Const        r60, "ca_state"
-  Const        r61, "net_profit"
+  Const        r61, "ca_state"
   Const        r62, "net_profit"
+  Const        r63, "net_profit"
   // (ca.ca_state in states3 && ss.net_profit >= 50 && ss.net_profit <= 25000)
-  Const        r63, "ca_state"
-  Const        r64, "net_profit"
+  Const        r64, "ca_state"
   Const        r65, "net_profit"
+  Const        r66, "net_profit"
   // select ss.quantity
-  Const        r66, "quantity"
+  Const        r67, "quantity"
   // join cd in customer_demographics on ss.cdemo_sk == cd.cd_demo_sk
-  Const        r67, 0
+  Const        r68, 0
 L23:
-  LessInt      r69, r67, r41
-  JumpIfFalse  r69, L1
-  Index        r71, r40, r67
-  Const        r72, "cdemo_sk"
-  Index        r73, r39, r72
-  Const        r74, "cd_demo_sk"
-  Index        r75, r71, r74
-  Equal        r76, r73, r75
-  JumpIfFalse  r76, L2
+  LessInt      r70, r68, r42
+  JumpIfFalse  r70, L1
+  Index        r72, r41, r68
+  Const        r73, "cdemo_sk"
+  Index        r74, r40, r73
+  Const        r75, "cd_demo_sk"
+  Index        r76, r72, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L2
   // join ca in customer_address on ss.addr_sk == ca.ca_address_sk
-  IterPrep     r77, r3
-  Len          r78, r77
-  Const        r79, "addr_sk"
-  Const        r80, "ca_address_sk"
+  IterPrep     r78, r3
+  Len          r79, r78
+  Const        r80, "addr_sk"
+  Const        r81, "ca_address_sk"
   // where d.d_year == year &&
-  Const        r81, "d_year"
+  Const        r82, "d_year"
   // (cd.cd_marital_status == "S" && cd.cd_education_status == "E1" && ss.sales_price >= 100.0 && ss.sales_price <= 150.0) ||
-  Const        r82, "cd_marital_status"
-  Const        r83, "cd_education_status"
-  Const        r84, "sales_price"
+  Const        r83, "cd_marital_status"
+  Const        r84, "cd_education_status"
   Const        r85, "sales_price"
+  Const        r86, "sales_price"
   // (cd.cd_marital_status == "M" && cd.cd_education_status == "E2" && ss.sales_price >= 50.0 && ss.sales_price <= 100.0) ||
-  Const        r86, "cd_marital_status"
-  Const        r87, "cd_education_status"
-  Const        r88, "sales_price"
+  Const        r87, "cd_marital_status"
+  Const        r88, "cd_education_status"
   Const        r89, "sales_price"
+  Const        r90, "sales_price"
   // (cd.cd_marital_status == "W" && cd.cd_education_status == "E3" && ss.sales_price >= 150.0 && ss.sales_price <= 200.0)
-  Const        r90, "cd_marital_status"
-  Const        r91, "cd_education_status"
-  Const        r92, "sales_price"
+  Const        r91, "cd_marital_status"
+  Const        r92, "cd_education_status"
   Const        r93, "sales_price"
+  Const        r94, "sales_price"
   // (ca.ca_state in states1 && ss.net_profit >= 0 && ss.net_profit <= 2000) ||
-  Const        r94, "ca_state"
-  Const        r95, "net_profit"
+  Const        r95, "ca_state"
   Const        r96, "net_profit"
+  Const        r97, "net_profit"
   // (ca.ca_state in states2 && ss.net_profit >= 150 && ss.net_profit <= 3000) ||
-  Const        r97, "ca_state"
-  Const        r98, "net_profit"
+  Const        r98, "ca_state"
   Const        r99, "net_profit"
+  Const        r100, "net_profit"
   // (ca.ca_state in states3 && ss.net_profit >= 50 && ss.net_profit <= 25000)
-  Const        r100, "ca_state"
-  Const        r101, "net_profit"
+  Const        r101, "ca_state"
   Const        r102, "net_profit"
+  Const        r103, "net_profit"
   // select ss.quantity
-  Const        r103, "quantity"
+  Const        r104, "quantity"
   // join ca in customer_address on ss.addr_sk == ca.ca_address_sk
-  Const        r104, 0
+  Const        r105, 0
 L22:
-  LessInt      r106, r104, r78
-  JumpIfFalse  r106, L2
-  Index        r108, r77, r104
-  Const        r109, "addr_sk"
-  Index        r110, r39, r109
-  Const        r111, "ca_address_sk"
-  Index        r112, r108, r111
-  Equal        r113, r110, r112
-  JumpIfFalse  r113, L3
+  LessInt      r107, r105, r79
+  JumpIfFalse  r107, L2
+  Index        r109, r78, r105
+  Const        r110, "addr_sk"
+  Index        r111, r40, r110
+  Const        r112, "ca_address_sk"
+  Index        r113, r109, r112
+  Equal        r114, r111, r113
+  JumpIfFalse  r114, L3
   // join d in date_dim on ss.sold_date_sk == d.d_date_sk
-  IterPrep     r114, r4
-  Len          r115, r114
-  Const        r116, "sold_date_sk"
-  Const        r117, "d_date_sk"
+  IterPrep     r115, r4
+  Len          r116, r115
+  Const        r117, "sold_date_sk"
+  Const        r118, "d_date_sk"
   // where d.d_year == year &&
-  Const        r118, "d_year"
+  Const        r119, "d_year"
   // (cd.cd_marital_status == "S" && cd.cd_education_status == "E1" && ss.sales_price >= 100.0 && ss.sales_price <= 150.0) ||
-  Const        r119, "cd_marital_status"
-  Const        r120, "cd_education_status"
-  Const        r121, "sales_price"
+  Const        r120, "cd_marital_status"
+  Const        r121, "cd_education_status"
   Const        r122, "sales_price"
+  Const        r123, "sales_price"
   // (cd.cd_marital_status == "M" && cd.cd_education_status == "E2" && ss.sales_price >= 50.0 && ss.sales_price <= 100.0) ||
-  Const        r123, "cd_marital_status"
-  Const        r124, "cd_education_status"
-  Const        r125, "sales_price"
+  Const        r124, "cd_marital_status"
+  Const        r125, "cd_education_status"
   Const        r126, "sales_price"
+  Const        r127, "sales_price"
   // (cd.cd_marital_status == "W" && cd.cd_education_status == "E3" && ss.sales_price >= 150.0 && ss.sales_price <= 200.0)
-  Const        r127, "cd_marital_status"
-  Const        r128, "cd_education_status"
-  Const        r129, "sales_price"
+  Const        r128, "cd_marital_status"
+  Const        r129, "cd_education_status"
   Const        r130, "sales_price"
+  Const        r131, "sales_price"
   // (ca.ca_state in states1 && ss.net_profit >= 0 && ss.net_profit <= 2000) ||
-  Const        r131, "ca_state"
-  Const        r132, "net_profit"
+  Const        r132, "ca_state"
   Const        r133, "net_profit"
+  Const        r134, "net_profit"
   // (ca.ca_state in states2 && ss.net_profit >= 150 && ss.net_profit <= 3000) ||
-  Const        r134, "ca_state"
-  Const        r135, "net_profit"
+  Const        r135, "ca_state"
   Const        r136, "net_profit"
+  Const        r137, "net_profit"
   // (ca.ca_state in states3 && ss.net_profit >= 50 && ss.net_profit <= 25000)
-  Const        r137, "ca_state"
-  Const        r138, "net_profit"
+  Const        r138, "ca_state"
   Const        r139, "net_profit"
+  Const        r140, "net_profit"
   // select ss.quantity
-  Const        r140, "quantity"
+  Const        r141, "quantity"
   // join d in date_dim on ss.sold_date_sk == d.d_date_sk
-  Const        r141, 0
+  Const        r142, 0
 L21:
-  LessInt      r143, r141, r115
-  JumpIfFalse  r143, L3
-  Index        r145, r114, r141
-  Const        r146, "sold_date_sk"
-  Index        r147, r39, r146
-  Const        r148, "d_date_sk"
-  Index        r149, r145, r148
-  Equal        r150, r147, r149
-  JumpIfFalse  r150, L4
+  LessInt      r144, r142, r116
+  JumpIfFalse  r144, L3
+  Index        r146, r115, r142
+  Const        r147, "sold_date_sk"
+  Index        r148, r40, r147
+  Const        r149, "d_date_sk"
+  Index        r150, r146, r149
+  Equal        r151, r148, r150
+  JumpIfFalse  r151, L4
   // where d.d_year == year &&
-  Const        r151, "d_year"
-  Index        r152, r145, r151
-  Equal        r154, r152, r5
-  JumpIfFalse  r154, L5
+  Const        r152, "d_year"
+  Index        r153, r146, r152
+  Equal        r155, r153, r6
+  JumpIfFalse  r155, L5
   // (cd.cd_marital_status == "S" && cd.cd_education_status == "E1" && ss.sales_price >= 100.0 && ss.sales_price <= 150.0) ||
-  Const        r155, "cd_marital_status"
-  Index        r156, r71, r155
-  Const        r157, "sales_price"
-  Index        r158, r39, r157
-  Const        r159, 100
-  LessEqFloat  r160, r159, r158
-  Const        r161, "sales_price"
-  Index        r162, r39, r161
-  Const        r163, 150
-  LessEqFloat  r164, r162, r163
-  Const        r165, "S"
-  Equal        r166, r156, r165
-  Const        r167, "cd_education_status"
-  Index        r168, r71, r167
-  Const        r169, "E1"
-  Equal        r170, r168, r169
-  Move         r171, r166
-  JumpIfFalse  r171, L6
+  Const        r156, "cd_marital_status"
+  Index        r157, r72, r156
+  Const        r158, "sales_price"
+  Index        r159, r40, r158
+  Const        r160, 100
+  LessEqFloat  r161, r160, r159
+  Const        r162, "sales_price"
+  Index        r163, r40, r162
+  Const        r164, 150
+  LessEqFloat  r165, r163, r164
+  Const        r166, "S"
+  Equal        r167, r157, r166
+  Const        r168, "cd_education_status"
+  Index        r169, r72, r168
+  Const        r170, "E1"
+  Equal        r171, r169, r170
+  Move         r172, r167
+  JumpIfFalse  r172, L6
 L6:
-  Move         r172, r170
-  JumpIfFalse  r172, L7
+  Move         r173, r171
+  JumpIfFalse  r173, L7
 L7:
-  Move         r173, r160
-  JumpIfFalse  r173, L8
+  Move         r174, r161
+  JumpIfFalse  r174, L8
 L8:
-  Move         r174, r164
-  JumpIfTrue   r174, L9
+  Move         r175, r165
+  JumpIfTrue   r175, L9
   // (cd.cd_marital_status == "M" && cd.cd_education_status == "E2" && ss.sales_price >= 50.0 && ss.sales_price <= 100.0) ||
-  Const        r175, "cd_marital_status"
-  Index        r176, r71, r175
-  Const        r177, "sales_price"
-  Index        r178, r39, r177
-  Const        r179, 50
-  LessEqFloat  r180, r179, r178
-  Const        r181, "sales_price"
-  Index        r182, r39, r181
-  Const        r183, 100
-  LessEqFloat  r184, r182, r183
-  Const        r185, "M"
-  Equal        r186, r176, r185
-  Const        r187, "cd_education_status"
-  Index        r188, r71, r187
-  Const        r189, "E2"
-  Equal        r190, r188, r189
-  Move         r191, r186
-  JumpIfFalse  r191, L10
+  Const        r176, "cd_marital_status"
+  Index        r177, r72, r176
+  Const        r178, "sales_price"
+  Index        r179, r40, r178
+  Const        r180, 50
+  LessEqFloat  r181, r180, r179
+  Const        r182, "sales_price"
+  Index        r183, r40, r182
+  Const        r184, 100
+  LessEqFloat  r185, r183, r184
+  Const        r186, "M"
+  Equal        r187, r177, r186
+  Const        r188, "cd_education_status"
+  Index        r189, r72, r188
+  Const        r190, "E2"
+  Equal        r191, r189, r190
+  Move         r192, r187
+  JumpIfFalse  r192, L10
 L10:
-  Move         r192, r190
-  JumpIfFalse  r192, L11
+  Move         r193, r191
+  JumpIfFalse  r193, L11
 L11:
-  Move         r193, r180
-  JumpIfFalse  r193, L9
+  Move         r194, r181
+  JumpIfFalse  r194, L9
 L9:
-  Move         r194, r184
-  JumpIfTrue   r194, L5
+  Move         r195, r185
+  JumpIfTrue   r195, L5
   // (cd.cd_marital_status == "W" && cd.cd_education_status == "E3" && ss.sales_price >= 150.0 && ss.sales_price <= 200.0)
-  Const        r195, "cd_marital_status"
-  Index        r196, r71, r195
-  Const        r197, "sales_price"
-  Index        r198, r39, r197
-  Const        r199, 150
-  LessEqFloat  r200, r199, r198
-  Const        r201, "sales_price"
-  Index        r202, r39, r201
-  Const        r203, 200
-  LessEqFloat  r204, r202, r203
-  Const        r205, "W"
-  Equal        r206, r196, r205
-  Const        r207, "cd_education_status"
-  Index        r208, r71, r207
-  Const        r209, "E3"
-  Equal        r210, r208, r209
-  Move         r211, r206
-  JumpIfFalse  r211, L12
+  Const        r196, "cd_marital_status"
+  Index        r197, r72, r196
+  Const        r198, "sales_price"
+  Index        r199, r40, r198
+  Const        r200, 150
+  LessEqFloat  r201, r200, r199
+  Const        r202, "sales_price"
+  Index        r203, r40, r202
+  Const        r204, 200
+  LessEqFloat  r205, r203, r204
+  Const        r206, "W"
+  Equal        r207, r197, r206
+  Const        r208, "cd_education_status"
+  Index        r209, r72, r208
+  Const        r210, "E3"
+  Equal        r211, r209, r210
+  Move         r212, r207
+  JumpIfFalse  r212, L12
 L12:
-  Move         r212, r210
-  JumpIfFalse  r212, L13
+  Move         r213, r211
+  JumpIfFalse  r213, L13
 L13:
-  Move         r213, r200
-  JumpIfFalse  r213, L5
+  Move         r214, r201
+  JumpIfFalse  r214, L5
 L5:
   // ) &&
-  Move         r214, r204
-  JumpIfFalse  r214, L14
+  Move         r215, r205
+  JumpIfFalse  r215, L14
   // (ca.ca_state in states1 && ss.net_profit >= 0 && ss.net_profit <= 2000) ||
-  Const        r215, "ca_state"
-  Index        r216, r108, r215
-  Const        r217, "net_profit"
-  Index        r218, r39, r217
-  Const        r219, 0
-  LessEq       r220, r219, r218
-  Const        r221, "net_profit"
-  Index        r222, r39, r221
-  Const        r223, 2000
-  LessEq       r224, r222, r223
-  In           r226, r216, r6
-  JumpIfFalse  r226, L15
+  Const        r216, "ca_state"
+  Index        r217, r109, r216
+  Const        r218, "net_profit"
+  Index        r219, r40, r218
+  Const        r220, 0
+  LessEq       r221, r220, r219
+  Const        r222, "net_profit"
+  Index        r223, r40, r222
+  Const        r224, 2000
+  LessEq       r225, r223, r224
+  In           r227, r217, r7
+  JumpIfFalse  r227, L15
 L15:
-  Move         r227, r220
-  JumpIfFalse  r227, L16
+  Move         r228, r221
+  JumpIfFalse  r228, L16
 L16:
-  Move         r228, r224
-  JumpIfTrue   r228, L17
+  Move         r229, r225
+  JumpIfTrue   r229, L17
   // (ca.ca_state in states2 && ss.net_profit >= 150 && ss.net_profit <= 3000) ||
-  Const        r229, "ca_state"
-  Index        r230, r108, r229
-  Const        r231, "net_profit"
-  Index        r232, r39, r231
-  Const        r233, 150
-  LessEq       r234, r233, r232
-  Const        r235, "net_profit"
-  Index        r236, r39, r235
-  Const        r237, 3000
-  LessEq       r238, r236, r237
-  In           r240, r230, r7
-  JumpIfFalse  r240, L18
+  Const        r230, "ca_state"
+  Index        r231, r109, r230
+  Const        r232, "net_profit"
+  Index        r233, r40, r232
+  Const        r234, 150
+  LessEq       r235, r234, r233
+  Const        r236, "net_profit"
+  Index        r237, r40, r236
+  Const        r238, 3000
+  LessEq       r239, r237, r238
+  In           r241, r231, r8
+  JumpIfFalse  r241, L18
 L18:
-  Move         r241, r234
-  JumpIfFalse  r241, L17
+  Move         r242, r235
+  JumpIfFalse  r242, L17
 L17:
-  Move         r242, r238
-  JumpIfTrue   r242, L19
+  Move         r243, r239
+  JumpIfTrue   r243, L19
   // (ca.ca_state in states3 && ss.net_profit >= 50 && ss.net_profit <= 25000)
-  Const        r243, "ca_state"
-  Index        r244, r108, r243
-  Const        r245, "net_profit"
-  Index        r246, r39, r245
-  Const        r247, 50
-  LessEq       r248, r247, r246
-  Const        r249, "net_profit"
-  Index        r250, r39, r249
-  Const        r251, 25000
-  LessEq       r252, r250, r251
-  In           r254, r244, r8
-  JumpIfFalse  r254, L20
+  Const        r244, "ca_state"
+  Index        r245, r109, r244
+  Const        r246, "net_profit"
+  Index        r247, r40, r246
+  Const        r248, 50
+  LessEq       r249, r248, r247
+  Const        r250, "net_profit"
+  Index        r251, r40, r250
+  Const        r252, 25000
+  LessEq       r253, r251, r252
+  In           r255, r245, r9
+  JumpIfFalse  r255, L20
 L20:
-  Move         r255, r248
-  JumpIfFalse  r255, L19
+  Move         r256, r249
+  JumpIfFalse  r256, L19
 L19:
   // ) &&
-  Move         r214, r252
+  Move         r215, r253
 L14:
   // where d.d_year == year &&
-  JumpIfFalse  r214, L4
+  JumpIfFalse  r215, L4
   // select ss.quantity
-  Const        r256, "quantity"
-  Index        r257, r39, r256
+  Const        r257, "quantity"
+  Index        r258, r40, r257
   // from ss in store_sales
-  Append       r9, r9, r257
+  Append       r10, r10, r258
 L4:
   // join d in date_dim on ss.sold_date_sk == d.d_date_sk
-  Const        r259, 1
-  Add          r141, r141, r259
+  Const        r260, 1
+  Add          r142, r142, r260
   Jump         L21
 L3:
   // join ca in customer_address on ss.addr_sk == ca.ca_address_sk
-  Const        r260, 1
-  Add          r104, r104, r260
+  Const        r261, 1
+  Add          r105, r105, r261
   Jump         L22
 L2:
   // join cd in customer_demographics on ss.cdemo_sk == cd.cd_demo_sk
-  Const        r261, 1
-  Add          r67, r67, r261
+  Const        r262, 1
+  Add          r68, r68, r262
   Jump         L23
 L1:
   // from ss in store_sales
-  Const        r262, 1
-  AddInt       r35, r35, r262
+  Const        r263, 1
+  AddInt       r36, r36, r263
   Jump         L24
 L0:
+  // let qty = concat(dummy, qty_base)
+  UnionAll     r264, r5, r10
   // let result = sum(qty)
-  Sum          r263, r9
+  Sum          r265, r264
   // json(result)
-  JSON         r263
+  JSON         r265
   // expect result == 35
-  Const        r264, 35
-  Equal        r265, r263, r264
-  Expect       r265
+  Const        r266, 35
+  Equal        r267, r265, r266
+  Expect       r267
   Return       r0

--- a/tests/dataset/tpc-ds/out/q49.ir.out
+++ b/tests/dataset/tpc-ds/out/q49.ir.out
@@ -1,264 +1,268 @@
-func main (regs=203)
+func main (regs=205)
   // let web = [
   Const        r0, [{"currency_rank": 1, "currency_ratio": 0.3, "item": "A", "return_rank": 1, "return_ratio": 0.2}, {"currency_rank": 2, "currency_ratio": 0.6, "item": "B", "return_rank": 2, "return_ratio": 0.5}]
   // let catalog = [
   Const        r1, [{"currency_rank": 1, "currency_ratio": 0.4, "item": "A", "return_rank": 1, "return_ratio": 0.3}]
   // let store = [
   Const        r2, [{"currency_rank": 1, "currency_ratio": 0.35, "item": "A", "return_rank": 1, "return_ratio": 0.25}]
+  // let dummy = null
+  Const        r3, nil
   // from w in web
-  Const        r3, []
+  Const        r4, []
   // where w.return_rank <= 10 || w.currency_rank <= 10
-  Const        r4, "return_rank"
-  Const        r5, "currency_rank"
+  Const        r5, "return_rank"
+  Const        r6, "currency_rank"
   // select { channel: "web", item: w.item, return_ratio: w.return_ratio, return_rank: w.return_rank, currency_rank: w.currency_rank },
-  Const        r6, "channel"
-  Const        r7, "item"
+  Const        r7, "channel"
   Const        r8, "item"
-  Const        r9, "return_ratio"
+  Const        r9, "item"
   Const        r10, "return_ratio"
-  Const        r11, "return_rank"
+  Const        r11, "return_ratio"
   Const        r12, "return_rank"
-  Const        r13, "currency_rank"
+  Const        r13, "return_rank"
   Const        r14, "currency_rank"
+  Const        r15, "currency_rank"
   // from w in web
-  IterPrep     r15, r0
-  Len          r16, r15
-  Const        r17, 0
+  IterPrep     r16, r0
+  Len          r17, r16
+  Const        r18, 0
 L3:
-  LessInt      r19, r17, r16
-  JumpIfFalse  r19, L0
-  Index        r21, r15, r17
+  LessInt      r20, r18, r17
+  JumpIfFalse  r20, L0
+  Index        r22, r16, r18
   // where w.return_rank <= 10 || w.currency_rank <= 10
-  Const        r22, "return_rank"
-  Index        r23, r21, r22
-  Const        r24, 10
-  LessEq       r25, r23, r24
-  Const        r26, "currency_rank"
-  Index        r27, r21, r26
-  Const        r28, 10
-  LessEq       r29, r27, r28
-  Move         r30, r25
-  JumpIfTrue   r30, L1
-  Move         r30, r29
+  Const        r23, "return_rank"
+  Index        r24, r22, r23
+  Const        r25, 10
+  LessEq       r26, r24, r25
+  Const        r27, "currency_rank"
+  Index        r28, r22, r27
+  Const        r29, 10
+  LessEq       r30, r28, r29
+  Move         r31, r26
+  JumpIfTrue   r31, L1
+  Move         r31, r30
 L1:
-  JumpIfFalse  r30, L2
+  JumpIfFalse  r31, L2
   // select { channel: "web", item: w.item, return_ratio: w.return_ratio, return_rank: w.return_rank, currency_rank: w.currency_rank },
-  Const        r31, "channel"
-  Const        r32, "web"
-  Const        r33, "item"
+  Const        r32, "channel"
+  Const        r33, "web"
   Const        r34, "item"
-  Index        r35, r21, r34
-  Const        r36, "return_ratio"
+  Const        r35, "item"
+  Index        r36, r22, r35
   Const        r37, "return_ratio"
-  Index        r38, r21, r37
-  Const        r39, "return_rank"
+  Const        r38, "return_ratio"
+  Index        r39, r22, r38
   Const        r40, "return_rank"
-  Index        r41, r21, r40
-  Const        r42, "currency_rank"
+  Const        r41, "return_rank"
+  Index        r42, r22, r41
   Const        r43, "currency_rank"
-  Index        r44, r21, r43
-  Move         r45, r31
+  Const        r44, "currency_rank"
+  Index        r45, r22, r44
   Move         r46, r32
   Move         r47, r33
-  Move         r48, r35
+  Move         r48, r34
   Move         r49, r36
-  Move         r50, r38
+  Move         r50, r37
   Move         r51, r39
-  Move         r52, r41
+  Move         r52, r40
   Move         r53, r42
-  Move         r54, r44
-  MakeMap      r55, 5, r45
+  Move         r54, r43
+  Move         r55, r45
+  MakeMap      r56, 5, r46
   // from w in web
-  Append       r3, r3, r55
+  Append       r4, r4, r56
 L2:
-  Const        r57, 1
-  AddInt       r17, r17, r57
+  Const        r58, 1
+  AddInt       r18, r18, r58
   Jump         L3
 L0:
   // from c in catalog
-  Const        r58, []
+  Const        r59, []
   // where c.return_rank <= 10 || c.currency_rank <= 10
-  Const        r59, "return_rank"
-  Const        r60, "currency_rank"
+  Const        r60, "return_rank"
+  Const        r61, "currency_rank"
   // select { channel: "catalog", item: c.item, return_ratio: c.return_ratio, return_rank: c.return_rank, currency_rank: c.currency_rank },
-  Const        r61, "channel"
-  Const        r62, "item"
+  Const        r62, "channel"
   Const        r63, "item"
-  Const        r64, "return_ratio"
+  Const        r64, "item"
   Const        r65, "return_ratio"
-  Const        r66, "return_rank"
+  Const        r66, "return_ratio"
   Const        r67, "return_rank"
-  Const        r68, "currency_rank"
+  Const        r68, "return_rank"
   Const        r69, "currency_rank"
+  Const        r70, "currency_rank"
   // from c in catalog
-  IterPrep     r70, r1
-  Len          r71, r70
-  Const        r72, 0
+  IterPrep     r71, r1
+  Len          r72, r71
+  Const        r73, 0
 L7:
-  LessInt      r74, r72, r71
-  JumpIfFalse  r74, L4
-  Index        r76, r70, r72
+  LessInt      r75, r73, r72
+  JumpIfFalse  r75, L4
+  Index        r77, r71, r73
   // where c.return_rank <= 10 || c.currency_rank <= 10
-  Const        r77, "return_rank"
-  Index        r78, r76, r77
-  Const        r79, 10
-  LessEq       r80, r78, r79
-  Const        r81, "currency_rank"
-  Index        r82, r76, r81
-  Const        r83, 10
-  LessEq       r84, r82, r83
-  Move         r85, r80
-  JumpIfTrue   r85, L5
-  Move         r85, r84
+  Const        r78, "return_rank"
+  Index        r79, r77, r78
+  Const        r80, 10
+  LessEq       r81, r79, r80
+  Const        r82, "currency_rank"
+  Index        r83, r77, r82
+  Const        r84, 10
+  LessEq       r85, r83, r84
+  Move         r86, r81
+  JumpIfTrue   r86, L5
+  Move         r86, r85
 L5:
-  JumpIfFalse  r85, L6
+  JumpIfFalse  r86, L6
   // select { channel: "catalog", item: c.item, return_ratio: c.return_ratio, return_rank: c.return_rank, currency_rank: c.currency_rank },
-  Const        r86, "channel"
-  Const        r87, "catalog"
-  Const        r88, "item"
+  Const        r87, "channel"
+  Const        r88, "catalog"
   Const        r89, "item"
-  Index        r90, r76, r89
-  Const        r91, "return_ratio"
+  Const        r90, "item"
+  Index        r91, r77, r90
   Const        r92, "return_ratio"
-  Index        r93, r76, r92
-  Const        r94, "return_rank"
+  Const        r93, "return_ratio"
+  Index        r94, r77, r93
   Const        r95, "return_rank"
-  Index        r96, r76, r95
-  Const        r97, "currency_rank"
+  Const        r96, "return_rank"
+  Index        r97, r77, r96
   Const        r98, "currency_rank"
-  Index        r99, r76, r98
-  Move         r100, r86
+  Const        r99, "currency_rank"
+  Index        r100, r77, r99
   Move         r101, r87
   Move         r102, r88
-  Move         r103, r90
+  Move         r103, r89
   Move         r104, r91
-  Move         r105, r93
+  Move         r105, r92
   Move         r106, r94
-  Move         r107, r96
+  Move         r107, r95
   Move         r108, r97
-  Move         r109, r99
-  MakeMap      r110, 5, r100
+  Move         r109, r98
+  Move         r110, r100
+  MakeMap      r111, 5, r101
   // from c in catalog
-  Append       r58, r58, r110
+  Append       r59, r59, r111
 L6:
-  Const        r112, 1
-  AddInt       r72, r72, r112
+  Const        r113, 1
+  AddInt       r73, r73, r113
   Jump         L7
 L4:
   // concat(
-  UnionAll     r113, r3, r58
+  UnionAll     r114, r4, r59
   // from s in store
-  Const        r114, []
+  Const        r115, []
   // where s.return_rank <= 10 || s.currency_rank <= 10
-  Const        r115, "return_rank"
-  Const        r116, "currency_rank"
+  Const        r116, "return_rank"
+  Const        r117, "currency_rank"
   // select { channel: "store", item: s.item, return_ratio: s.return_ratio, return_rank: s.return_rank, currency_rank: s.currency_rank }
-  Const        r117, "channel"
-  Const        r118, "item"
+  Const        r118, "channel"
   Const        r119, "item"
-  Const        r120, "return_ratio"
+  Const        r120, "item"
   Const        r121, "return_ratio"
-  Const        r122, "return_rank"
+  Const        r122, "return_ratio"
   Const        r123, "return_rank"
-  Const        r124, "currency_rank"
+  Const        r124, "return_rank"
   Const        r125, "currency_rank"
+  Const        r126, "currency_rank"
   // from s in store
-  IterPrep     r126, r2
-  Len          r127, r126
-  Const        r128, 0
+  IterPrep     r127, r2
+  Len          r128, r127
+  Const        r129, 0
 L11:
-  LessInt      r130, r128, r127
-  JumpIfFalse  r130, L8
-  Index        r132, r126, r128
+  LessInt      r131, r129, r128
+  JumpIfFalse  r131, L8
+  Index        r133, r127, r129
   // where s.return_rank <= 10 || s.currency_rank <= 10
-  Const        r133, "return_rank"
-  Index        r134, r132, r133
-  Const        r135, 10
-  LessEq       r136, r134, r135
-  Const        r137, "currency_rank"
-  Index        r138, r132, r137
-  Const        r139, 10
-  LessEq       r140, r138, r139
-  Move         r141, r136
-  JumpIfTrue   r141, L9
-  Move         r141, r140
+  Const        r134, "return_rank"
+  Index        r135, r133, r134
+  Const        r136, 10
+  LessEq       r137, r135, r136
+  Const        r138, "currency_rank"
+  Index        r139, r133, r138
+  Const        r140, 10
+  LessEq       r141, r139, r140
+  Move         r142, r137
+  JumpIfTrue   r142, L9
+  Move         r142, r141
 L9:
-  JumpIfFalse  r141, L10
+  JumpIfFalse  r142, L10
   // select { channel: "store", item: s.item, return_ratio: s.return_ratio, return_rank: s.return_rank, currency_rank: s.currency_rank }
-  Const        r142, "channel"
-  Const        r143, "store"
-  Const        r144, "item"
+  Const        r143, "channel"
+  Const        r144, "store"
   Const        r145, "item"
-  Index        r146, r132, r145
-  Const        r147, "return_ratio"
+  Const        r146, "item"
+  Index        r147, r133, r146
   Const        r148, "return_ratio"
-  Index        r149, r132, r148
-  Const        r150, "return_rank"
+  Const        r149, "return_ratio"
+  Index        r150, r133, r149
   Const        r151, "return_rank"
-  Index        r152, r132, r151
-  Const        r153, "currency_rank"
+  Const        r152, "return_rank"
+  Index        r153, r133, r152
   Const        r154, "currency_rank"
-  Index        r155, r132, r154
-  Move         r156, r142
+  Const        r155, "currency_rank"
+  Index        r156, r133, r155
   Move         r157, r143
   Move         r158, r144
-  Move         r159, r146
+  Move         r159, r145
   Move         r160, r147
-  Move         r161, r149
+  Move         r161, r148
   Move         r162, r150
-  Move         r163, r152
+  Move         r163, r151
   Move         r164, r153
-  Move         r165, r155
-  MakeMap      r166, 5, r156
+  Move         r165, r154
+  Move         r166, r156
+  MakeMap      r167, 5, r157
   // from s in store
-  Append       r114, r114, r166
+  Append       r115, r115, r167
 L10:
-  Const        r168, 1
-  AddInt       r128, r128, r168
+  Const        r169, 1
+  AddInt       r129, r129, r169
   Jump         L11
 L8:
   // concat(
-  UnionAll     r169, r113, r114
+  UnionAll     r170, r114, r115
   // from r in tmp
-  Const        r170, []
+  Const        r171, []
   // sort by [r.channel, r.return_rank, r.currency_rank, r.item]
-  Const        r171, "channel"
-  Const        r172, "return_rank"
-  Const        r173, "currency_rank"
-  Const        r174, "item"
+  Const        r172, "channel"
+  Const        r173, "return_rank"
+  Const        r174, "currency_rank"
+  Const        r175, "item"
   // from r in tmp
-  IterPrep     r175, r169
-  Len          r176, r175
-  Const        r177, 0
+  IterPrep     r176, r170
+  Len          r177, r176
+  Const        r178, 0
 L13:
-  LessInt      r179, r177, r176
-  JumpIfFalse  r179, L12
-  Index        r181, r175, r177
+  LessInt      r180, r178, r177
+  JumpIfFalse  r180, L12
+  Index        r182, r176, r178
   // sort by [r.channel, r.return_rank, r.currency_rank, r.item]
-  Const        r182, "channel"
-  Index        r184, r181, r182
-  Const        r185, "return_rank"
-  Index        r186, r181, r185
-  Move         r187, r186
-  Const        r188, "currency_rank"
-  Index        r190, r181, r188
-  Const        r191, "item"
-  Index        r193, r181, r191
-  MakeList     r195, 4, r184
+  Const        r183, "channel"
+  Index        r185, r182, r183
+  Const        r186, "return_rank"
+  Index        r187, r182, r186
+  Move         r188, r187
+  Const        r189, "currency_rank"
+  Index        r191, r182, r189
+  Const        r192, "item"
+  Index        r194, r182, r192
+  MakeList     r196, 4, r185
   // from r in tmp
-  Move         r196, r181
-  MakeList     r197, 2, r195
-  Append       r170, r170, r197
-  Const        r199, 1
-  AddInt       r177, r177, r199
+  Move         r197, r182
+  MakeList     r198, 2, r196
+  Append       r171, r171, r198
+  Const        r200, 1
+  AddInt       r178, r178, r200
   Jump         L13
 L12:
   // sort by [r.channel, r.return_rank, r.currency_rank, r.item]
-  Sort         r170, r170
+  Sort         r171, r171
+  // let result = concat(dummy, base)
+  UnionAll     r202, r3, r171
   // json(result)
-  JSON         r170
+  JSON         r202
   // expect result == [
-  Const        r201, [{"channel": "catalog", "currency_rank": 1, "item": "A", "return_rank": 1, "return_ratio": 0.3}, {"channel": "store", "currency_rank": 1, "item": "A", "return_rank": 1, "return_ratio": 0.25}, {"channel": "web", "currency_rank": 1, "item": "A", "return_rank": 1, "return_ratio": 0.2}, {"channel": "web", "currency_rank": 2, "item": "B", "return_rank": 2, "return_ratio": 0.5}]
-  Equal        r202, r170, r201
-  Expect       r202
+  Const        r203, [{"channel": "catalog", "currency_rank": 1, "item": "A", "return_rank": 1, "return_ratio": 0.3}, {"channel": "store", "currency_rank": 1, "item": "A", "return_rank": 1, "return_ratio": 0.25}, {"channel": "web", "currency_rank": 1, "item": "A", "return_rank": 1, "return_ratio": 0.2}, {"channel": "web", "currency_rank": 2, "item": "B", "return_rank": 2, "return_ratio": 0.5}]
+  Equal        r204, r202, r203
+  Expect       r204
   Return       r0

--- a/tests/dataset/tpc-ds/q40.mochi
+++ b/tests/dataset/tpc-ds/q40.mochi
@@ -22,6 +22,8 @@ let date_dim = [
 
 let sales_date = "2020-01-15"
 
+let dummy = null
+
 let records =
   from cs in catalog_sales
   left join cr in catalog_returns on cs.order == cr.order && cs.item_sk == cr.item_sk
@@ -36,7 +38,7 @@ let records =
     net: cs.price - (if cr == null { 0.0 } else { cr.refunded })
   }
 
-let result =
+let base =
   from r in records
   group by { w_state: r.w_state, i_item_id: r.i_item_id } into g
   select {
@@ -45,6 +47,8 @@ let result =
     sales_before: sum(from x in g select if x.sold_date < sales_date { x.net } else { 0.0 }),
     sales_after: sum(from x in g select if x.sold_date >= sales_date { x.net } else { 0.0 })
   }
+
+let result = concat(dummy, base)
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q41.mochi
+++ b/tests/dataset/tpc-ds/q41.mochi
@@ -6,12 +6,15 @@ let item = [
 
 let lower = 100
 
-let result =
+let dummy = null
+let base =
   from i1 in item
   where i1.manufact_id >= lower && i1.manufact_id <= lower + 40 &&
         count(from i2 in item where i2.manufact == i1.manufact && i2.category == i1.category select i2) > 1
   order by i1.product_name
   select i1.product_name
+
+let result = concat(dummy, base)
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q42.mochi
+++ b/tests/dataset/tpc-ds/q42.mochi
@@ -17,6 +17,8 @@ let date_dim = [
 let month = 5
 let year = 2020
 
+let dummy = null
+
 let records =
   from dt in date_dim
   join ss in store_sales on ss.sold_date_sk == dt.d_date_sk
@@ -24,7 +26,7 @@ let records =
   where it.i_manager_id == 1 && dt.d_moy == month && dt.d_year == year
   select { d_year: dt.d_year, i_category_id: it.i_category_id, i_category: it.i_category, price: ss.ext_sales_price }
 
-let result =
+let base =
   from r in records
   group by { d_year: r.d_year, i_category_id: r.i_category_id, i_category: r.i_category } into g
   sort by [-sum(from x in g select x.price), g.key.d_year, g.key.i_category_id, g.key.i_category]
@@ -34,6 +36,8 @@ let result =
     i_category: g.key.i_category,
     sum_ss_ext_sales_price: sum(from x in g select x.price)
   }
+
+let result = concat(dummy, base)
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q43.mochi
+++ b/tests/dataset/tpc-ds/q43.mochi
@@ -23,6 +23,8 @@ let store_sales = [
 let year = 2020
 let gmt = 0
 
+let dummy = null
+
 let records =
   from d in date_dim
   join ss in store_sales on ss.sold_date_sk == d.date_sk
@@ -30,7 +32,7 @@ let records =
   where s.gmt_offset == gmt && d.d_year == year
   select { d_day_name: d.d_day_name, s_store_name: s.store_name, s_store_id: s.store_id, price: ss.sales_price }
 
-let result =
+let base =
   from r in records
   group by { name: r.s_store_name, id: r.s_store_id } into g
   select {
@@ -44,6 +46,8 @@ let result =
     fri_sales: sum(from x in g select if x.d_day_name == "Friday" { x.price } else { 0.0 }),
     sat_sales: sum(from x in g select if x.d_day_name == "Saturday" { x.price } else { 0.0 })
   }
+
+let result = concat(dummy, base)
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q44.mochi
+++ b/tests/dataset/tpc-ds/q44.mochi
@@ -9,12 +9,15 @@ let item = [
   { i_item_sk: 2, i_product_name: "ItemB" }
 ]
 
-let grouped = (
+let dummy = null
+
+let grouped_base = (
   from ss in store_sales
   group by ss.ss_item_sk into g
   select { item_sk: g.key,
            avg_profit: avg(from x in g select x.ss_net_profit) }
 )
+let grouped = concat(dummy, grouped_base)
 
 let best = first(from x in grouped sort by -x.avg_profit select x)
 let worst = first(from x in grouped sort by x.avg_profit select x)

--- a/tests/dataset/tpc-ds/q45.mochi
+++ b/tests/dataset/tpc-ds/q45.mochi
@@ -20,12 +20,14 @@ let item = [
 
 let date_dim = [ { d_date_sk: 1, d_qoy: 1, d_year: 2020 } ]
 
+let dummy = null
+
 let zip_list = ["85669", "86197", "88274", "83405", "86475", "85392", "85460", "80348", "81792"]
 let item_ids = ["I2"]
 let qoy = 1
 let year = 2020
 
-let records =
+let base =
   from ws in web_sales
   join c in customer on ws.bill_customer_sk == c.c_customer_sk
   join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
@@ -35,6 +37,8 @@ let records =
         d.d_qoy == qoy && d.d_year == year
   group by ca.ca_zip into g
   select { ca_zip: g.key, sum_ws_sales_price: sum(from x in g select x.ws.sales_price) }
+
+let records = concat(dummy, base)
 
 json(records)
 

--- a/tests/dataset/tpc-ds/q46.mochi
+++ b/tests/dataset/tpc-ds/q46.mochi
@@ -13,6 +13,8 @@ let vehcnt = 0
 let year = 2020
 let cities = ["CityA"]
 
+let dummy = null
+
 let dn =
   from ss in store_sales
   join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
@@ -24,13 +26,15 @@ let dn =
   group by { ss_ticket_number: ss.ss_ticket_number, ss_customer_sk: ss.ss_customer_sk, ca_city: ca.ca_city } into g
   select { ss_ticket_number: g.key.ss_ticket_number, ss_customer_sk: g.key.ss_customer_sk, bought_city: g.key.ca_city, amt: sum(from x in g select x.ss.ss_coupon_amt), profit: sum(from x in g select x.ss.ss_net_profit) }
 
-let result =
+let base =
   from dnrec in dn
   join c in customer on dnrec.ss_customer_sk == c.c_customer_sk
   join current_addr in customer_address on c.c_current_addr_sk == current_addr.ca_address_sk
   where current_addr.ca_city != dnrec.bought_city
   sort by [c.c_last_name, c.c_first_name, current_addr.ca_city, dnrec.bought_city, dnrec.ss_ticket_number]
   select { c_last_name: c.c_last_name, c_first_name: c.c_first_name, ca_city: current_addr.ca_city, bought_city: dnrec.bought_city, ss_ticket_number: dnrec.ss_ticket_number, amt: dnrec.amt, profit: dnrec.profit }
+
+let result = concat(dummy, base)
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q47.mochi
+++ b/tests/dataset/tpc-ds/q47.mochi
@@ -7,15 +7,19 @@ let v2 = [
 let year = 2020
 let orderby = "item"
 
+let dummy = null
+
 fun abs(x: float): float {
   if x >= 0.0 { x } else { -x }
 }
 
-let result =
+let base =
   from v in v2
   where v.d_year == year && v.avg_monthly_sales > 0 && abs(v.sum_sales - v.avg_monthly_sales) / v.avg_monthly_sales > 0.1
   sort by [v.sum_sales - v.avg_monthly_sales, v.item]
   select v
+
+let result = concat(dummy, base)
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q48.mochi
+++ b/tests/dataset/tpc-ds/q48.mochi
@@ -17,13 +17,15 @@ let customer_address = [
 ]
 let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
 
+let dummy = null
+
 let year = 2000
 
 let states1 = ["TX"]
 let states2 = ["CA"]
 let states3 = ["NY"]
 
-let qty =
+let qty_base =
   from ss in store_sales
   join cd in customer_demographics on ss.cdemo_sk == cd.cd_demo_sk
   join ca in customer_address on ss.addr_sk == ca.ca_address_sk
@@ -40,6 +42,8 @@ let qty =
       (ca.ca_state in states3 && ss.net_profit >= 50 && ss.net_profit <= 25000)
     )
   select ss.quantity
+
+let qty = concat(dummy, qty_base)
 
 let result = sum(qty)
 

--- a/tests/dataset/tpc-ds/q49.mochi
+++ b/tests/dataset/tpc-ds/q49.mochi
@@ -11,6 +11,8 @@ let store = [
   { item: "A", return_ratio: 0.25, currency_ratio: 0.35, return_rank: 1, currency_rank: 1 }
 ]
 
+let dummy = null
+
 let tmp = (
   concat(
   from w in web
@@ -25,10 +27,12 @@ let tmp = (
   )
 )
 
-let result =
+let base =
   from r in tmp
   sort by [r.channel, r.return_rank, r.currency_rank, r.item]
   select r
+
+let result = concat(dummy, base)
 
 json(result)
 


### PR DESCRIPTION
## Summary
- enhance the VM to treat null as empty lists for union, except and intersect
- exercise new behaviour in TPC‑DS samples q40–q49
- regenerate IR for updated queries

## Testing
- `go test ./tests/vm -run TestVM_TPCDS -tags slow -update`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6862442372948320805cf3466a217adc