### PR TITLE
Add Distinct opcode and compile TPC-DS Q90-99

### DIFF
--- a/tests/dataset/tpc-ds/out/q90.ir.out
+++ b/tests/dataset/tpc-ds/out/q90.ir.out
@@ -1,0 +1,336 @@
+func main (regs=205)
+  // let web_sales = [
+  Const        r0, [{"ws_ship_hdemo_sk": 1, "ws_sold_time_sk": 1, "ws_web_page_sk": 10}, {"ws_ship_hdemo_sk": 1, "ws_sold_time_sk": 1, "ws_web_page_sk": 10}, {"ws_ship_hdemo_sk": 1, "ws_sold_time_sk": 2, "ws_web_page_sk": 10}]
+  // let household_demographics = [{hd_demo_sk: 1, hd_dep_count: 2}]
+  Const        r1, [{"hd_demo_sk": 1, "hd_dep_count": 2}]
+  // let time_dim = [
+  Const        r2, [{"t_hour": 7, "t_time_sk": 1}, {"t_hour": 14, "t_time_sk": 2}]
+  // let web_page = [{wp_web_page_sk: 10, wp_char_count: 5100}]
+  Const        r3, [{"wp_char_count": 5100, "wp_web_page_sk": 10}]
+  // count(from ws in web_sales
+  Const        r4, []
+  // where t.t_hour >= 7 && t.t_hour <= 8 &&
+  Const        r5, "t_hour"
+  Const        r6, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r7, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r8, "wp_char_count"
+  Const        r9, "wp_char_count"
+  // count(from ws in web_sales
+  IterPrep     r10, r0
+  Len          r11, r10
+  Const        r12, 0
+L12:
+  LessInt      r14, r12, r11
+  JumpIfFalse  r14, L0
+  Index        r16, r10, r12
+  // join hd in household_demographics on ws.ws_ship_hdemo_sk == hd.hd_demo_sk
+  IterPrep     r17, r1
+  Len          r18, r17
+  Const        r19, "ws_ship_hdemo_sk"
+  Const        r20, "hd_demo_sk"
+  // where t.t_hour >= 7 && t.t_hour <= 8 &&
+  Const        r21, "t_hour"
+  Const        r22, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r23, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r24, "wp_char_count"
+  Const        r25, "wp_char_count"
+  // join hd in household_demographics on ws.ws_ship_hdemo_sk == hd.hd_demo_sk
+  Const        r26, 0
+L11:
+  LessInt      r28, r26, r18
+  JumpIfFalse  r28, L1
+  Index        r30, r17, r26
+  Const        r31, "ws_ship_hdemo_sk"
+  Index        r32, r16, r31
+  Const        r33, "hd_demo_sk"
+  Index        r34, r30, r33
+  Equal        r35, r32, r34
+  JumpIfFalse  r35, L2
+  // join t in time_dim on ws.ws_sold_time_sk == t.t_time_sk
+  IterPrep     r36, r2
+  Len          r37, r36
+  Const        r38, "ws_sold_time_sk"
+  Const        r39, "t_time_sk"
+  // where t.t_hour >= 7 && t.t_hour <= 8 &&
+  Const        r40, "t_hour"
+  Const        r41, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r42, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r43, "wp_char_count"
+  Const        r44, "wp_char_count"
+  // join t in time_dim on ws.ws_sold_time_sk == t.t_time_sk
+  Const        r45, 0
+L10:
+  LessInt      r47, r45, r37
+  JumpIfFalse  r47, L2
+  Index        r49, r36, r45
+  Const        r50, "ws_sold_time_sk"
+  Index        r51, r16, r50
+  Const        r52, "t_time_sk"
+  Index        r53, r49, r52
+  Equal        r54, r51, r53
+  JumpIfFalse  r54, L3
+  // join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
+  IterPrep     r55, r3
+  Len          r56, r55
+  Const        r57, "ws_web_page_sk"
+  Const        r58, "wp_web_page_sk"
+  // where t.t_hour >= 7 && t.t_hour <= 8 &&
+  Const        r59, "t_hour"
+  Const        r60, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r61, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r62, "wp_char_count"
+  Const        r63, "wp_char_count"
+  // join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
+  Const        r64, 0
+L9:
+  LessInt      r66, r64, r56
+  JumpIfFalse  r66, L3
+  Index        r68, r55, r64
+  Const        r69, "ws_web_page_sk"
+  Index        r70, r16, r69
+  Const        r71, "wp_web_page_sk"
+  Index        r72, r68, r71
+  Equal        r73, r70, r72
+  JumpIfFalse  r73, L4
+  // where t.t_hour >= 7 && t.t_hour <= 8 &&
+  Const        r74, "t_hour"
+  Index        r75, r49, r74
+  Const        r76, 7
+  LessEq       r77, r76, r75
+  Const        r78, "t_hour"
+  Index        r79, r49, r78
+  Const        r80, 8
+  LessEq       r81, r79, r80
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r82, "wp_char_count"
+  Index        r83, r68, r82
+  Const        r84, 5000
+  LessEq       r85, r84, r83
+  Const        r86, "wp_char_count"
+  Index        r87, r68, r86
+  Const        r88, 5200
+  LessEq       r89, r87, r88
+  // hd.hd_dep_count == 2 &&
+  Const        r90, "hd_dep_count"
+  Index        r91, r30, r90
+  Const        r92, 2
+  Equal        r93, r91, r92
+  // where t.t_hour >= 7 && t.t_hour <= 8 &&
+  Move         r94, r77
+  JumpIfFalse  r94, L5
+L5:
+  Move         r95, r81
+  JumpIfFalse  r95, L6
+L6:
+  // hd.hd_dep_count == 2 &&
+  Move         r96, r93
+  JumpIfFalse  r96, L7
+L7:
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Move         r97, r85
+  JumpIfFalse  r97, L8
+  Move         r97, r89
+L8:
+  // where t.t_hour >= 7 && t.t_hour <= 8 &&
+  JumpIfFalse  r97, L4
+  // count(from ws in web_sales
+  Append       r4, r4, r16
+L4:
+  // join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
+  Const        r99, 1
+  Add          r64, r64, r99
+  Jump         L9
+L3:
+  // join t in time_dim on ws.ws_sold_time_sk == t.t_time_sk
+  Const        r100, 1
+  Add          r45, r45, r100
+  Jump         L10
+L2:
+  // join hd in household_demographics on ws.ws_ship_hdemo_sk == hd.hd_demo_sk
+  Const        r101, 1
+  Add          r26, r26, r101
+  Jump         L11
+L1:
+  // count(from ws in web_sales
+  Const        r102, 1
+  AddInt       r12, r12, r102
+  Jump         L12
+L0:
+  Count        r103, r4
+  // count(from ws in web_sales
+  Const        r104, []
+  // where t.t_hour >= 14 && t.t_hour <= 15 &&
+  Const        r105, "t_hour"
+  Const        r106, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r107, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r108, "wp_char_count"
+  Const        r109, "wp_char_count"
+  // count(from ws in web_sales
+  IterPrep     r110, r0
+  Len          r111, r110
+  Const        r112, 0
+L25:
+  LessInt      r114, r112, r111
+  JumpIfFalse  r114, L13
+  Index        r16, r110, r112
+  // join hd in household_demographics on ws.ws_ship_hdemo_sk == hd.hd_demo_sk
+  IterPrep     r116, r1
+  Len          r117, r116
+  Const        r118, "ws_ship_hdemo_sk"
+  Const        r119, "hd_demo_sk"
+  // where t.t_hour >= 14 && t.t_hour <= 15 &&
+  Const        r120, "t_hour"
+  Const        r121, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r122, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r123, "wp_char_count"
+  Const        r124, "wp_char_count"
+  // join hd in household_demographics on ws.ws_ship_hdemo_sk == hd.hd_demo_sk
+  Const        r125, 0
+L24:
+  LessInt      r127, r125, r117
+  JumpIfFalse  r127, L14
+  Index        r30, r116, r125
+  Const        r129, "ws_ship_hdemo_sk"
+  Index        r130, r16, r129
+  Const        r131, "hd_demo_sk"
+  Index        r132, r30, r131
+  Equal        r133, r130, r132
+  JumpIfFalse  r133, L15
+  // join t in time_dim on ws.ws_sold_time_sk == t.t_time_sk
+  IterPrep     r134, r2
+  Len          r135, r134
+  Const        r136, "ws_sold_time_sk"
+  Const        r137, "t_time_sk"
+  // where t.t_hour >= 14 && t.t_hour <= 15 &&
+  Const        r138, "t_hour"
+  Const        r139, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r140, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r141, "wp_char_count"
+  Const        r142, "wp_char_count"
+  // join t in time_dim on ws.ws_sold_time_sk == t.t_time_sk
+  Const        r143, 0
+L23:
+  LessInt      r145, r143, r135
+  JumpIfFalse  r145, L15
+  Index        r49, r134, r143
+  Const        r147, "ws_sold_time_sk"
+  Index        r148, r16, r147
+  Const        r149, "t_time_sk"
+  Index        r150, r49, r149
+  Equal        r151, r148, r150
+  JumpIfFalse  r151, L16
+  // join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
+  IterPrep     r152, r3
+  Len          r153, r152
+  Const        r154, "ws_web_page_sk"
+  Const        r155, "wp_web_page_sk"
+  // where t.t_hour >= 14 && t.t_hour <= 15 &&
+  Const        r156, "t_hour"
+  Const        r157, "t_hour"
+  // hd.hd_dep_count == 2 &&
+  Const        r158, "hd_dep_count"
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r159, "wp_char_count"
+  Const        r160, "wp_char_count"
+  // join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
+  Const        r161, 0
+L22:
+  LessInt      r163, r161, r153
+  JumpIfFalse  r163, L16
+  Index        r68, r152, r161
+  Const        r165, "ws_web_page_sk"
+  Index        r166, r16, r165
+  Const        r167, "wp_web_page_sk"
+  Index        r168, r68, r167
+  Equal        r169, r166, r168
+  JumpIfFalse  r169, L17
+  // where t.t_hour >= 14 && t.t_hour <= 15 &&
+  Const        r170, "t_hour"
+  Index        r171, r49, r170
+  Const        r172, 14
+  LessEq       r173, r172, r171
+  Const        r174, "t_hour"
+  Index        r175, r49, r174
+  Const        r176, 15
+  LessEq       r177, r175, r176
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Const        r178, "wp_char_count"
+  Index        r179, r68, r178
+  Const        r180, 5000
+  LessEq       r181, r180, r179
+  Const        r182, "wp_char_count"
+  Index        r183, r68, r182
+  Const        r184, 5200
+  LessEq       r185, r183, r184
+  // hd.hd_dep_count == 2 &&
+  Const        r186, "hd_dep_count"
+  Index        r187, r30, r186
+  Const        r188, 2
+  Equal        r189, r187, r188
+  // where t.t_hour >= 14 && t.t_hour <= 15 &&
+  Move         r190, r173
+  JumpIfFalse  r190, L18
+L18:
+  Move         r191, r177
+  JumpIfFalse  r191, L19
+L19:
+  // hd.hd_dep_count == 2 &&
+  Move         r192, r189
+  JumpIfFalse  r192, L20
+L20:
+  // wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
+  Move         r193, r181
+  JumpIfFalse  r193, L21
+  Move         r193, r185
+L21:
+  // where t.t_hour >= 14 && t.t_hour <= 15 &&
+  JumpIfFalse  r193, L17
+  // count(from ws in web_sales
+  Append       r104, r104, r16
+L17:
+  // join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
+  Const        r195, 1
+  Add          r161, r161, r195
+  Jump         L22
+L16:
+  // join t in time_dim on ws.ws_sold_time_sk == t.t_time_sk
+  Const        r196, 1
+  Add          r143, r143, r196
+  Jump         L23
+L15:
+  // join hd in household_demographics on ws.ws_ship_hdemo_sk == hd.hd_demo_sk
+  Const        r197, 1
+  Add          r125, r125, r197
+  Jump         L24
+L14:
+  // count(from ws in web_sales
+  Const        r198, 1
+  AddInt       r112, r112, r198
+  Jump         L25
+L13:
+  Count        r199, r104
+  // let result = (amc as float) / (pmc as float)
+  Cast         r200, r103, float
+  Cast         r201, r199, float
+  Div          r202, r200, r201
+  // json(result)
+  JSON         r202
+  // expect result == 2.0
+  Const        r203, 2
+  EqualFloat   r204, r202, r203
+  Expect       r204
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q91.ir.out
+++ b/tests/dataset/tpc-ds/out/q91.ir.out
@@ -1,0 +1,369 @@
+func main (regs=253)
+  // let call_center = [
+  Const        r0, [{"cc_call_center_id": "CC1", "cc_call_center_sk": 1, "cc_manager": "Alice", "cc_name": "Main"}]
+  // let catalog_returns = [
+  Const        r1, [{"cr_call_center_sk": 1, "cr_net_loss": 10, "cr_returned_date_sk": 1, "cr_returning_customer_sk": 1}]
+  // let date_dim = [{d_date_sk: 1, d_year: 2001, d_moy: 5}]
+  Const        r2, [{"d_date_sk": 1, "d_moy": 5, "d_year": 2001}]
+  // let customer = [
+  Const        r3, [{"c_current_addr_sk": 1, "c_current_cdemo_sk": 1, "c_current_hdemo_sk": 1, "c_customer_sk": 1}]
+  // let customer_demographics = [{cd_demo_sk: 1, cd_marital_status: "M", cd_education_status: "Unknown"}]
+  Const        r4, [{"cd_demo_sk": 1, "cd_education_status": "Unknown", "cd_marital_status": "M"}]
+  // let household_demographics = [{hd_demo_sk: 1, hd_buy_potential: "1001-5000"}]
+  Const        r5, [{"hd_buy_potential": "1001-5000", "hd_demo_sk": 1}]
+  // let customer_address = [{ca_address_sk: 1, ca_gmt_offset: -6}]
+  Const        r6, [{"ca_address_sk": 1, "ca_gmt_offset": -6}]
+  // from cc in call_center
+  Const        r7, []
+  // group by {id: cc.cc_call_center_id, name: cc.cc_name, mgr: cc.cc_manager} into g
+  Const        r8, "id"
+  Const        r9, "cc_call_center_id"
+  Const        r10, "name"
+  Const        r11, "cc_name"
+  Const        r12, "mgr"
+  Const        r13, "cc_manager"
+  // where d.d_year == 2001 && d.d_moy == 5 &&
+  Const        r14, "d_year"
+  Const        r15, "d_moy"
+  // cd.cd_marital_status == "M" && cd.cd_education_status == "Unknown" &&
+  Const        r16, "cd_marital_status"
+  Const        r17, "cd_education_status"
+  // hd.hd_buy_potential == "1001-5000" && ca.ca_gmt_offset == (-6)
+  Const        r18, "hd_buy_potential"
+  Const        r19, "ca_gmt_offset"
+  // Call_Center: g.key.id,
+  Const        r20, "Call_Center"
+  Const        r21, "key"
+  Const        r22, "id"
+  // Call_Center_Name: g.key.name,
+  Const        r23, "Call_Center_Name"
+  Const        r24, "key"
+  Const        r25, "name"
+  // Manager: g.key.mgr,
+  Const        r26, "Manager"
+  Const        r27, "key"
+  Const        r28, "mgr"
+  // Returns_Loss: sum(from x in g select x.cr_net_loss)
+  Const        r29, "Returns_Loss"
+  Const        r30, "cr_net_loss"
+  // from cc in call_center
+  MakeMap      r31, 0, r0
+  Const        r32, []
+  IterPrep     r34, r0
+  Len          r35, r34
+  Const        r36, 0
+L20:
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L0
+  Index        r39, r34, r36
+  // join cr in catalog_returns on cc.cc_call_center_sk == cr.cr_call_center_sk
+  IterPrep     r40, r1
+  Len          r41, r40
+  Const        r42, 0
+L19:
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L1
+  Index        r45, r40, r42
+  Const        r46, "cc_call_center_sk"
+  Index        r47, r39, r46
+  Const        r48, "cr_call_center_sk"
+  Index        r49, r45, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L2
+  // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
+  IterPrep     r51, r2
+  Len          r52, r51
+  Const        r53, 0
+L18:
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L2
+  Index        r56, r51, r53
+  Const        r57, "cr_returned_date_sk"
+  Index        r58, r45, r57
+  Const        r59, "d_date_sk"
+  Index        r60, r56, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L3
+  // join c in customer on cr.cr_returning_customer_sk == c.c_customer_sk
+  IterPrep     r62, r3
+  Len          r63, r62
+  Const        r64, 0
+L17:
+  LessInt      r65, r64, r63
+  JumpIfFalse  r65, L3
+  Index        r67, r62, r64
+  Const        r68, "cr_returning_customer_sk"
+  Index        r69, r45, r68
+  Const        r70, "c_customer_sk"
+  Index        r71, r67, r70
+  Equal        r72, r69, r71
+  JumpIfFalse  r72, L4
+  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
+  IterPrep     r73, r4
+  Len          r74, r73
+  Const        r75, 0
+L16:
+  LessInt      r76, r75, r74
+  JumpIfFalse  r76, L4
+  Index        r78, r73, r75
+  Const        r79, "c_current_cdemo_sk"
+  Index        r80, r67, r79
+  Const        r81, "cd_demo_sk"
+  Index        r82, r78, r81
+  Equal        r83, r80, r82
+  JumpIfFalse  r83, L5
+  // join hd in household_demographics on c.c_current_hdemo_sk == hd.hd_demo_sk
+  IterPrep     r84, r5
+  Len          r85, r84
+  Const        r86, 0
+L15:
+  LessInt      r87, r86, r85
+  JumpIfFalse  r87, L5
+  Index        r89, r84, r86
+  Const        r90, "c_current_hdemo_sk"
+  Index        r91, r67, r90
+  Const        r92, "hd_demo_sk"
+  Index        r93, r89, r92
+  Equal        r94, r91, r93
+  JumpIfFalse  r94, L6
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  IterPrep     r95, r6
+  Len          r96, r95
+  Const        r97, 0
+L14:
+  LessInt      r98, r97, r96
+  JumpIfFalse  r98, L6
+  Index        r100, r95, r97
+  Const        r101, "c_current_addr_sk"
+  Index        r102, r67, r101
+  Const        r103, "ca_address_sk"
+  Index        r104, r100, r103
+  Equal        r105, r102, r104
+  JumpIfFalse  r105, L7
+  // where d.d_year == 2001 && d.d_moy == 5 &&
+  Const        r106, "d_year"
+  Index        r107, r56, r106
+  Const        r108, 2001
+  Equal        r109, r107, r108
+  Const        r110, "d_moy"
+  Index        r111, r56, r110
+  Const        r112, 5
+  Equal        r113, r111, r112
+  // cd.cd_marital_status == "M" && cd.cd_education_status == "Unknown" &&
+  Const        r114, "cd_marital_status"
+  Index        r115, r78, r114
+  Const        r116, "M"
+  Equal        r117, r115, r116
+  Const        r118, "cd_education_status"
+  Index        r119, r78, r118
+  Const        r120, "Unknown"
+  Equal        r121, r119, r120
+  // hd.hd_buy_potential == "1001-5000" && ca.ca_gmt_offset == (-6)
+  Const        r122, "hd_buy_potential"
+  Index        r123, r89, r122
+  Const        r124, "1001-5000"
+  Equal        r125, r123, r124
+  Const        r126, "ca_gmt_offset"
+  Index        r127, r100, r126
+  Const        r128, 6
+  Const        r129, -6
+  Equal        r130, r127, r129
+  // where d.d_year == 2001 && d.d_moy == 5 &&
+  Move         r131, r109
+  JumpIfFalse  r131, L8
+L8:
+  Move         r132, r113
+  JumpIfFalse  r132, L9
+L9:
+  // cd.cd_marital_status == "M" && cd.cd_education_status == "Unknown" &&
+  Move         r133, r117
+  JumpIfFalse  r133, L10
+L10:
+  Move         r134, r121
+  JumpIfFalse  r134, L11
+L11:
+  // hd.hd_buy_potential == "1001-5000" && ca.ca_gmt_offset == (-6)
+  Move         r135, r125
+  JumpIfFalse  r135, L12
+  Move         r135, r130
+L12:
+  // where d.d_year == 2001 && d.d_moy == 5 &&
+  JumpIfFalse  r135, L7
+  // from cc in call_center
+  Const        r136, "cc"
+  Move         r137, r39
+  Const        r138, "cr"
+  Move         r139, r45
+  Const        r140, "d"
+  Move         r141, r56
+  Const        r142, "c"
+  Move         r143, r67
+  Const        r144, "cd"
+  Move         r145, r78
+  Const        r146, "hd"
+  Move         r147, r89
+  Const        r148, "ca"
+  Move         r149, r100
+  MakeMap      r150, 7, r136
+  // group by {id: cc.cc_call_center_id, name: cc.cc_name, mgr: cc.cc_manager} into g
+  Const        r151, "id"
+  Const        r152, "cc_call_center_id"
+  Index        r153, r39, r152
+  Const        r154, "name"
+  Const        r155, "cc_name"
+  Index        r156, r39, r155
+  Const        r157, "mgr"
+  Const        r158, "cc_manager"
+  Index        r159, r39, r158
+  Move         r160, r151
+  Move         r161, r153
+  Move         r162, r154
+  Move         r163, r156
+  Move         r164, r157
+  Move         r165, r159
+  MakeMap      r166, 3, r160
+  Str          r167, r166
+  In           r168, r167, r31
+  JumpIfTrue   r168, L13
+  // from cc in call_center
+  Const        r169, []
+  Const        r170, "__group__"
+  Const        r171, true
+  Const        r172, "key"
+  // group by {id: cc.cc_call_center_id, name: cc.cc_name, mgr: cc.cc_manager} into g
+  Move         r173, r166
+  // from cc in call_center
+  Const        r174, "items"
+  Move         r175, r169
+  Const        r176, "count"
+  Const        r177, 0
+  Move         r178, r170
+  Move         r179, r171
+  Move         r180, r172
+  Move         r181, r173
+  Move         r182, r174
+  Move         r183, r175
+  Move         r184, r176
+  Move         r185, r177
+  MakeMap      r186, 4, r178
+  SetIndex     r31, r167, r186
+  Append       r32, r32, r186
+L13:
+  Const        r188, "items"
+  Index        r189, r31, r167
+  Index        r190, r189, r188
+  Append       r191, r190, r150
+  SetIndex     r189, r188, r191
+  Const        r192, "count"
+  Index        r193, r189, r192
+  Const        r194, 1
+  AddInt       r195, r193, r194
+  SetIndex     r189, r192, r195
+L7:
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  Const        r196, 1
+  AddInt       r97, r97, r196
+  Jump         L14
+L6:
+  // join hd in household_demographics on c.c_current_hdemo_sk == hd.hd_demo_sk
+  Const        r197, 1
+  AddInt       r86, r86, r197
+  Jump         L15
+L5:
+  // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
+  Const        r198, 1
+  AddInt       r75, r75, r198
+  Jump         L16
+L4:
+  // join c in customer on cr.cr_returning_customer_sk == c.c_customer_sk
+  Const        r199, 1
+  AddInt       r64, r64, r199
+  Jump         L17
+L3:
+  // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
+  Const        r200, 1
+  AddInt       r53, r53, r200
+  Jump         L18
+L2:
+  // join cr in catalog_returns on cc.cc_call_center_sk == cr.cr_call_center_sk
+  Const        r201, 1
+  AddInt       r42, r42, r201
+  Jump         L19
+L1:
+  // from cc in call_center
+  Const        r202, 1
+  AddInt       r36, r36, r202
+  Jump         L20
+L0:
+  Const        r203, 0
+  Len          r205, r32
+L24:
+  LessInt      r206, r203, r205
+  JumpIfFalse  r206, L21
+  Index        r208, r32, r203
+  // Call_Center: g.key.id,
+  Const        r209, "Call_Center"
+  Const        r210, "key"
+  Index        r211, r208, r210
+  Const        r212, "id"
+  Index        r213, r211, r212
+  // Call_Center_Name: g.key.name,
+  Const        r214, "Call_Center_Name"
+  Const        r215, "key"
+  Index        r216, r208, r215
+  Const        r217, "name"
+  Index        r218, r216, r217
+  // Manager: g.key.mgr,
+  Const        r219, "Manager"
+  Const        r220, "key"
+  Index        r221, r208, r220
+  Const        r222, "mgr"
+  Index        r223, r221, r222
+  // Returns_Loss: sum(from x in g select x.cr_net_loss)
+  Const        r224, "Returns_Loss"
+  Const        r225, []
+  Const        r226, "cr_net_loss"
+  IterPrep     r227, r208
+  Len          r228, r227
+  Const        r229, 0
+L23:
+  LessInt      r231, r229, r228
+  JumpIfFalse  r231, L22
+  Index        r233, r227, r229
+  Const        r234, "cr_net_loss"
+  Index        r235, r233, r234
+  Append       r225, r225, r235
+  Const        r237, 1
+  AddInt       r229, r229, r237
+  Jump         L23
+L22:
+  Sum          r238, r225
+  // Call_Center: g.key.id,
+  Move         r239, r209
+  Move         r240, r213
+  // Call_Center_Name: g.key.name,
+  Move         r241, r214
+  Move         r242, r218
+  // Manager: g.key.mgr,
+  Move         r243, r219
+  Move         r244, r223
+  // Returns_Loss: sum(from x in g select x.cr_net_loss)
+  Move         r245, r224
+  Move         r246, r238
+  // select {
+  MakeMap      r247, 4, r239
+  // from cc in call_center
+  Append       r7, r7, r247
+  Const        r249, 1
+  AddInt       r203, r203, r249
+  Jump         L24
+L21:
+  // let result = first(
+  First        r250, r7
+  // json(result)
+  JSON         r250
+  // expect result == {
+  Const        r251, {"Call_Center": "CC1", "Call_Center_Name": "Main", "Manager": "Alice", "Returns_Loss": 10}
+  Equal        r252, r250, r251
+  Expect       r252
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q92.ir.out
+++ b/tests/dataset/tpc-ds/out/q92.ir.out
@@ -1,0 +1,60 @@
+func main (regs=37)
+  // let web_sales = [
+  Const        r0, [{"ws_ext_discount_amt": 1, "ws_item_sk": 1, "ws_sold_date_sk": 1}, {"ws_ext_discount_amt": 1, "ws_item_sk": 1, "ws_sold_date_sk": 1}, {"ws_ext_discount_amt": 2, "ws_item_sk": 1, "ws_sold_date_sk": 1}]
+  // let item = [{i_item_sk: 1, i_manufact_id: 1}]
+  Const        r1, [{"i_item_sk": 1, "i_manufact_id": 1}]
+  // let date_dim = [{d_date_sk: 1, d_date: "2000-01-02"}]
+  Const        r2, [{"d_date": "2000-01-02", "d_date_sk": 1}]
+  // let sum_amt = sum(from ws in web_sales select ws.ws_ext_discount_amt)
+  Const        r3, []
+  Const        r4, "ws_ext_discount_amt"
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r7, 0
+L1:
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
+  Const        r12, "ws_ext_discount_amt"
+  Index        r13, r11, r12
+  Append       r3, r3, r13
+  Const        r15, 1
+  AddInt       r7, r7, r15
+  Jump         L1
+L0:
+  Sum          r16, r3
+  // let avg_amt = avg(from ws in web_sales select ws.ws_ext_discount_amt)
+  Const        r17, []
+  Const        r18, "ws_ext_discount_amt"
+  IterPrep     r19, r0
+  Len          r20, r19
+  Const        r21, 0
+L3:
+  LessInt      r23, r21, r20
+  JumpIfFalse  r23, L2
+  Index        r11, r19, r21
+  Const        r25, "ws_ext_discount_amt"
+  Index        r26, r11, r25
+  Append       r17, r17, r26
+  Const        r28, 1
+  AddInt       r21, r21, r28
+  Jump         L3
+L2:
+  Avg          r29, r17
+  // let result = if sum_amt > avg_amt * 1.3 { sum_amt } else { 0.0 }
+  Const        r30, 1.3
+  MulFloat     r31, r29, r30
+  LessFloat    r32, r31, r16
+  JumpIfFalse  r32, L4
+  Move         r33, r16
+  Jump         L5
+L4:
+  Const        r33, 0
+L5:
+  // json(result)
+  JSON         r33
+  // expect result == 4.0
+  Const        r35, 4
+  EqualFloat   r36, r33, r35
+  Expect       r36
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q93.ir.out
+++ b/tests/dataset/tpc-ds/out/q93.ir.out
@@ -1,0 +1,346 @@
+func main (regs=243)
+  // let store_sales = [
+  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_quantity": 5, "ss_sales_price": 10, "ss_ticket_number": 1}, {"ss_customer_sk": 2, "ss_item_sk": 1, "ss_quantity": 3, "ss_sales_price": 20, "ss_ticket_number": 2}]
+  // let store_returns = [
+  Const        r1, [{"sr_item_sk": 1, "sr_reason_sk": 1, "sr_return_quantity": 1, "sr_ticket_number": 1}]
+  // let reason = [{r_reason_sk: 1, r_reason_desc: "ReasonA"}]
+  Const        r2, [{"r_reason_desc": "ReasonA", "r_reason_sk": 1}]
+  // from ss in store_sales
+  Const        r3, []
+  // where r.r_reason_desc == "ReasonA"
+  Const        r4, "r_reason_desc"
+  // ss_customer_sk: ss.ss_customer_sk,
+  Const        r5, "ss_customer_sk"
+  Const        r6, "ss_customer_sk"
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Const        r7, "act_sales"
+  Const        r8, "ss_quantity"
+  Const        r9, "sr_return_quantity"
+  Const        r10, "ss_sales_price"
+  Const        r11, "ss_quantity"
+  Const        r12, "ss_sales_price"
+  // from ss in store_sales
+  IterPrep     r13, r0
+  Len          r14, r13
+  Const        r15, 0
+L14:
+  LessInt      r17, r15, r14
+  JumpIfFalse  r17, L0
+  Index        r19, r13, r15
+  // left join sr in store_returns on ss.ss_item_sk == sr.sr_item_sk && ss.ss_ticket_number == sr.sr_ticket_number
+  IterPrep     r20, r1
+  Len          r21, r20
+  Const        r22, "ss_item_sk"
+  Const        r23, "sr_item_sk"
+  Const        r24, "ss_ticket_number"
+  Const        r25, "sr_ticket_number"
+  // where r.r_reason_desc == "ReasonA"
+  Const        r26, "r_reason_desc"
+  // ss_customer_sk: ss.ss_customer_sk,
+  Const        r27, "ss_customer_sk"
+  Const        r28, "ss_customer_sk"
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Const        r29, "act_sales"
+  Const        r30, "ss_quantity"
+  Const        r31, "sr_return_quantity"
+  Const        r32, "ss_sales_price"
+  Const        r33, "ss_quantity"
+  Const        r34, "ss_sales_price"
+  // left join sr in store_returns on ss.ss_item_sk == sr.sr_item_sk && ss.ss_ticket_number == sr.sr_ticket_number
+  Const        r35, 0
+L8:
+  LessInt      r37, r35, r21
+  JumpIfFalse  r37, L1
+  Index        r39, r20, r35
+  Const        r40, false
+  Const        r41, "ss_item_sk"
+  Index        r42, r19, r41
+  Const        r43, "sr_item_sk"
+  Index        r44, r39, r43
+  Equal        r45, r42, r44
+  Const        r46, "ss_ticket_number"
+  Index        r47, r19, r46
+  Const        r48, "sr_ticket_number"
+  Index        r49, r39, r48
+  Equal        r50, r47, r49
+  Move         r51, r45
+  JumpIfFalse  r51, L2
+  Move         r51, r50
+L2:
+  JumpIfFalse  r51, L3
+  Const        r40, true
+  // join r in reason on sr.sr_reason_sk == r.r_reason_sk
+  IterPrep     r52, r2
+  Len          r53, r52
+  Const        r54, "sr_reason_sk"
+  Const        r55, "r_reason_sk"
+  // where r.r_reason_desc == "ReasonA"
+  Const        r56, "r_reason_desc"
+  // ss_customer_sk: ss.ss_customer_sk,
+  Const        r57, "ss_customer_sk"
+  Const        r58, "ss_customer_sk"
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Const        r59, "act_sales"
+  Const        r60, "ss_quantity"
+  Const        r61, "sr_return_quantity"
+  Const        r62, "ss_sales_price"
+  Const        r63, "ss_quantity"
+  Const        r64, "ss_sales_price"
+  // join r in reason on sr.sr_reason_sk == r.r_reason_sk
+  Const        r65, 0
+L7:
+  LessInt      r67, r65, r53
+  JumpIfFalse  r67, L3
+  Index        r69, r52, r65
+  Const        r70, "sr_reason_sk"
+  Index        r71, r39, r70
+  Const        r72, "r_reason_sk"
+  Index        r73, r69, r72
+  Equal        r74, r71, r73
+  JumpIfFalse  r74, L4
+  // where r.r_reason_desc == "ReasonA"
+  Const        r75, "r_reason_desc"
+  Index        r76, r69, r75
+  Const        r77, "ReasonA"
+  Equal        r78, r76, r77
+  JumpIfFalse  r78, L4
+  // ss_customer_sk: ss.ss_customer_sk,
+  Const        r79, "ss_customer_sk"
+  Const        r80, "ss_customer_sk"
+  Index        r81, r19, r80
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Const        r82, "act_sales"
+  Const        r83, nil
+  NotEqual     r84, r39, r83
+  JumpIfFalse  r84, L5
+  Const        r85, "ss_quantity"
+  Index        r86, r19, r85
+  Const        r87, "sr_return_quantity"
+  Index        r88, r39, r87
+  Sub          r89, r86, r88
+  Const        r90, "ss_sales_price"
+  Index        r91, r19, r90
+  Mul          r93, r89, r91
+  Jump         L6
+L5:
+  Const        r94, "ss_quantity"
+  Index        r95, r19, r94
+  Const        r96, "ss_sales_price"
+  Index        r97, r19, r96
+  Mul          r93, r95, r97
+L6:
+  // ss_customer_sk: ss.ss_customer_sk,
+  Move         r99, r79
+  Move         r100, r81
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Move         r101, r82
+  Move         r102, r93
+  // select {
+  MakeMap      r103, 2, r99
+  // from ss in store_sales
+  Append       r3, r3, r103
+L4:
+  // join r in reason on sr.sr_reason_sk == r.r_reason_sk
+  Const        r105, 1
+  Add          r65, r65, r105
+  Jump         L7
+L3:
+  // left join sr in store_returns on ss.ss_item_sk == sr.sr_item_sk && ss.ss_ticket_number == sr.sr_ticket_number
+  Const        r106, 1
+  Add          r35, r35, r106
+  Jump         L8
+L1:
+  Move         r107, r40
+  JumpIfTrue   r107, L9
+  Const        r39, nil
+  // join r in reason on sr.sr_reason_sk == r.r_reason_sk
+  IterPrep     r109, r2
+  Len          r110, r109
+  Const        r111, "sr_reason_sk"
+  Const        r112, "r_reason_sk"
+  // where r.r_reason_desc == "ReasonA"
+  Const        r113, "r_reason_desc"
+  // ss_customer_sk: ss.ss_customer_sk,
+  Const        r114, "ss_customer_sk"
+  Const        r115, "ss_customer_sk"
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Const        r116, "act_sales"
+  Const        r117, "ss_quantity"
+  Const        r118, "sr_return_quantity"
+  Const        r119, "ss_sales_price"
+  Const        r120, "ss_quantity"
+  Const        r121, "ss_sales_price"
+  // join r in reason on sr.sr_reason_sk == r.r_reason_sk
+  Const        r122, 0
+L13:
+  LessInt      r124, r122, r110
+  JumpIfFalse  r124, L9
+  Index        r69, r109, r122
+  Const        r126, "sr_reason_sk"
+  Index        r127, r39, r126
+  Const        r128, "r_reason_sk"
+  Index        r129, r69, r128
+  Equal        r130, r127, r129
+  JumpIfFalse  r130, L10
+  // where r.r_reason_desc == "ReasonA"
+  Const        r131, "r_reason_desc"
+  Index        r132, r69, r131
+  Const        r133, "ReasonA"
+  Equal        r134, r132, r133
+  JumpIfFalse  r134, L10
+  // ss_customer_sk: ss.ss_customer_sk,
+  Const        r135, "ss_customer_sk"
+  Const        r136, "ss_customer_sk"
+  Index        r137, r19, r136
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Const        r138, "act_sales"
+  Const        r139, nil
+  NotEqual     r140, r39, r139
+  JumpIfFalse  r140, L11
+  Const        r141, "ss_quantity"
+  Index        r142, r19, r141
+  Const        r143, "sr_return_quantity"
+  Index        r144, r39, r143
+  Sub          r145, r142, r144
+  Const        r146, "ss_sales_price"
+  Index        r147, r19, r146
+  Mul          r149, r145, r147
+  Jump         L12
+L11:
+  Const        r150, "ss_quantity"
+  Index        r151, r19, r150
+  Const        r152, "ss_sales_price"
+  Index        r153, r19, r152
+  Mul          r149, r151, r153
+L12:
+  // ss_customer_sk: ss.ss_customer_sk,
+  Move         r155, r135
+  Move         r156, r137
+  // act_sales: if sr != null { (ss.ss_quantity - sr.sr_return_quantity) * ss.ss_sales_price } else { ss.ss_quantity * ss.ss_sales_price }
+  Move         r157, r138
+  Move         r158, r149
+  // select {
+  MakeMap      r159, 2, r155
+  // from ss in store_sales
+  Append       r3, r3, r159
+L10:
+  // join r in reason on sr.sr_reason_sk == r.r_reason_sk
+  Const        r161, 1
+  Add          r122, r122, r161
+  Jump         L13
+L9:
+  // from ss in store_sales
+  Const        r162, 1
+  AddInt       r15, r15, r162
+  Jump         L14
+L0:
+  // from x in t
+  Const        r163, []
+  // group by x.ss_customer_sk into g
+  Const        r164, "ss_customer_sk"
+  // select {ss_customer_sk: g.key, sumsales: sum(from y in g select y.act_sales)}
+  Const        r165, "ss_customer_sk"
+  Const        r166, "key"
+  Const        r167, "sumsales"
+  Const        r168, "act_sales"
+  // from x in t
+  IterPrep     r169, r3
+  Len          r170, r169
+  Const        r171, 0
+  MakeMap      r172, 0, r0
+  Const        r173, []
+L17:
+  LessInt      r175, r171, r170
+  JumpIfFalse  r175, L15
+  Index        r176, r169, r171
+  Move         r177, r176
+  // group by x.ss_customer_sk into g
+  Const        r178, "ss_customer_sk"
+  Index        r179, r177, r178
+  Str          r180, r179
+  In           r181, r180, r172
+  JumpIfTrue   r181, L16
+  // from x in t
+  Const        r182, []
+  Const        r183, "__group__"
+  Const        r184, true
+  Const        r185, "key"
+  // group by x.ss_customer_sk into g
+  Move         r186, r179
+  // from x in t
+  Const        r187, "items"
+  Move         r188, r182
+  Const        r189, "count"
+  Const        r190, 0
+  Move         r191, r183
+  Move         r192, r184
+  Move         r193, r185
+  Move         r194, r186
+  Move         r195, r187
+  Move         r196, r188
+  Move         r197, r189
+  Move         r198, r190
+  MakeMap      r199, 4, r191
+  SetIndex     r172, r180, r199
+  Append       r173, r173, r199
+L16:
+  Const        r201, "items"
+  Index        r202, r172, r180
+  Index        r203, r202, r201
+  Append       r204, r203, r176
+  SetIndex     r202, r201, r204
+  Const        r205, "count"
+  Index        r206, r202, r205
+  Const        r207, 1
+  AddInt       r208, r206, r207
+  SetIndex     r202, r205, r208
+  Const        r209, 1
+  AddInt       r171, r171, r209
+  Jump         L17
+L15:
+  Const        r210, 0
+  Len          r212, r173
+L21:
+  LessInt      r213, r210, r212
+  JumpIfFalse  r213, L18
+  Index        r215, r173, r210
+  // select {ss_customer_sk: g.key, sumsales: sum(from y in g select y.act_sales)}
+  Const        r216, "ss_customer_sk"
+  Const        r217, "key"
+  Index        r218, r215, r217
+  Const        r219, "sumsales"
+  Const        r220, []
+  Const        r221, "act_sales"
+  IterPrep     r222, r215
+  Len          r223, r222
+  Const        r224, 0
+L20:
+  LessInt      r226, r224, r223
+  JumpIfFalse  r226, L19
+  Index        r228, r222, r224
+  Const        r229, "act_sales"
+  Index        r230, r228, r229
+  Append       r220, r220, r230
+  Const        r232, 1
+  AddInt       r224, r224, r232
+  Jump         L20
+L19:
+  Sum          r233, r220
+  Move         r234, r216
+  Move         r235, r218
+  Move         r236, r219
+  Move         r237, r233
+  MakeMap      r238, 2, r234
+  // from x in t
+  Append       r163, r163, r238
+  Const        r240, 1
+  AddInt       r210, r210, r240
+  Jump         L21
+L18:
+  // json(result)
+  JSON         r163
+  // expect result == [
+  Const        r241, [{"ss_customer_sk": 1, "sumsales": 40}, {"ss_customer_sk": 2, "sumsales": 60}]
+  Equal        r242, r163, r241
+  Expect       r242
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q94.ir.out
+++ b/tests/dataset/tpc-ds/out/q94.ir.out
@@ -1,0 +1,265 @@
+func main (regs=159)
+  // let web_sales = [
+  Const        r0, [{"ws_ext_ship_cost": 2, "ws_net_profit": 5, "ws_order_number": 1, "ws_ship_addr_sk": 1, "ws_ship_date_sk": 1, "ws_warehouse_sk": 1, "ws_web_site_sk": 1}, {"ws_ext_ship_cost": 1, "ws_net_profit": 3, "ws_order_number": 2, "ws_ship_addr_sk": 1, "ws_ship_date_sk": 1, "ws_warehouse_sk": 2, "ws_web_site_sk": 1}]
+  // let web_returns = [{wr_order_number: 2}]
+  Const        r1, [{"wr_order_number": 2}]
+  // let date_dim = [{d_date_sk: 1, d_date: "2001-02-01"}]
+  Const        r2, [{"d_date": "2001-02-01", "d_date_sk": 1}]
+  // let customer_address = [{ca_address_sk: 1, ca_state: "CA"}]
+  Const        r3, [{"ca_address_sk": 1, "ca_state": "CA"}]
+  // let web_site = [{web_site_sk: 1, web_company_name: "pri"}]
+  Const        r4, [{"web_company_name": "pri", "web_site_sk": 1}]
+  // from ws in web_sales
+  Const        r5, []
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r6, "ca_state"
+  Const        r7, "web_company_name"
+  // exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr) == false
+  Const        r8, "wr_order_number"
+  Const        r9, "ws_order_number"
+  // from ws in web_sales
+  IterPrep     r10, r0
+  Len          r11, r10
+  Const        r12, 0
+L13:
+  LessInt      r14, r12, r11
+  JumpIfFalse  r14, L0
+  Index        r16, r10, r12
+  // join d in date_dim on ws.ws_ship_date_sk == d.d_date_sk
+  IterPrep     r17, r2
+  Len          r18, r17
+  Const        r19, "ws_ship_date_sk"
+  Const        r20, "d_date_sk"
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r21, "ca_state"
+  Const        r22, "web_company_name"
+  // exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr) == false
+  Const        r23, "wr_order_number"
+  Const        r24, "ws_order_number"
+  // join d in date_dim on ws.ws_ship_date_sk == d.d_date_sk
+  Const        r25, 0
+L12:
+  LessInt      r27, r25, r18
+  JumpIfFalse  r27, L1
+  Index        r29, r17, r25
+  Const        r30, "ws_ship_date_sk"
+  Index        r31, r16, r30
+  Const        r32, "d_date_sk"
+  Index        r33, r29, r32
+  Equal        r34, r31, r33
+  JumpIfFalse  r34, L2
+  // join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
+  IterPrep     r35, r3
+  Len          r36, r35
+  Const        r37, "ws_ship_addr_sk"
+  Const        r38, "ca_address_sk"
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r39, "ca_state"
+  Const        r40, "web_company_name"
+  // exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr) == false
+  Const        r41, "wr_order_number"
+  Const        r42, "ws_order_number"
+  // join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
+  Const        r43, 0
+L11:
+  LessInt      r45, r43, r36
+  JumpIfFalse  r45, L2
+  Index        r47, r35, r43
+  Const        r48, "ws_ship_addr_sk"
+  Index        r49, r16, r48
+  Const        r50, "ca_address_sk"
+  Index        r51, r47, r50
+  Equal        r52, r49, r51
+  JumpIfFalse  r52, L3
+  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  IterPrep     r53, r4
+  Len          r54, r53
+  Const        r55, "ws_web_site_sk"
+  Const        r56, "web_site_sk"
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r57, "ca_state"
+  Const        r58, "web_company_name"
+  // exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr) == false
+  Const        r59, "wr_order_number"
+  Const        r60, "ws_order_number"
+  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  Const        r61, 0
+L10:
+  LessInt      r63, r61, r54
+  JumpIfFalse  r63, L3
+  Index        r65, r53, r61
+  Const        r66, "ws_web_site_sk"
+  Index        r67, r16, r66
+  Const        r68, "web_site_sk"
+  Index        r69, r65, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L4
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r71, "ca_state"
+  Index        r72, r47, r71
+  Const        r73, "CA"
+  Equal        r74, r72, r73
+  Const        r75, "web_company_name"
+  Index        r76, r65, r75
+  Const        r77, "pri"
+  Equal        r78, r76, r77
+  // exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr) == false
+  Const        r79, []
+  Const        r80, "wr_order_number"
+  Const        r81, "ws_order_number"
+  IterPrep     r82, r1
+  Len          r83, r82
+  Const        r84, 0
+L7:
+  LessInt      r86, r84, r83
+  JumpIfFalse  r86, L5
+  Index        r88, r82, r84
+  Const        r89, "wr_order_number"
+  Index        r90, r88, r89
+  Const        r91, "ws_order_number"
+  Index        r92, r16, r91
+  Equal        r93, r90, r92
+  JumpIfFalse  r93, L6
+  Append       r79, r79, r88
+L6:
+  Const        r95, 1
+  AddInt       r84, r84, r95
+  Jump         L7
+L5:
+  Exists       r96, r79
+  Const        r97, false
+  Equal        r98, r96, r97
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Move         r99, r74
+  JumpIfFalse  r99, L8
+L8:
+  Move         r100, r78
+  JumpIfFalse  r100, L9
+  Move         r100, r98
+L9:
+  JumpIfFalse  r100, L4
+  // from ws in web_sales
+  Append       r5, r5, r16
+L4:
+  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  Const        r102, 1
+  Add          r61, r61, r102
+  Jump         L10
+L3:
+  // join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
+  Const        r103, 1
+  Add          r43, r43, r103
+  Jump         L11
+L2:
+  // join d in date_dim on ws.ws_ship_date_sk == d.d_date_sk
+  Const        r104, 1
+  Add          r25, r25, r104
+  Jump         L12
+L1:
+  // from ws in web_sales
+  Const        r105, 1
+  AddInt       r12, r12, r105
+  Jump         L13
+L0:
+  // order_count: len(distinct(from x in filtered select x.ws_order_number)),
+  Const        r106, "order_count"
+  Const        r107, []
+  Const        r108, "ws_order_number"
+  IterPrep     r109, r5
+  Len          r110, r109
+  Const        r111, 0
+L15:
+  LessInt      r113, r111, r110
+  JumpIfFalse  r113, L14
+  Index        r115, r109, r111
+  Const        r116, "ws_order_number"
+  Index        r117, r115, r116
+  Append       r107, r107, r117
+  Const        r119, 1
+  AddInt       r111, r111, r119
+  Jump         L15
+L14:
+  Distinct     120,107,0,0
+  Len          r121, r120
+  // total_shipping_cost: sum(from x in filtered select x.ws_ext_ship_cost),
+  Const        r122, "total_shipping_cost"
+  Const        r123, []
+  Const        r124, "ws_ext_ship_cost"
+  IterPrep     r125, r5
+  Len          r126, r125
+  Const        r127, 0
+L17:
+  LessInt      r129, r127, r126
+  JumpIfFalse  r129, L16
+  Index        r115, r125, r127
+  Const        r131, "ws_ext_ship_cost"
+  Index        r132, r115, r131
+  Append       r123, r123, r132
+  Const        r134, 1
+  AddInt       r127, r127, r134
+  Jump         L17
+L16:
+  Sum          r135, r123
+  // total_net_profit: sum(from x in filtered select x.ws_net_profit)
+  Const        r136, "total_net_profit"
+  Const        r137, []
+  Const        r138, "ws_net_profit"
+  IterPrep     r139, r5
+  Len          r140, r139
+  Const        r141, 0
+L19:
+  LessInt      r143, r141, r140
+  JumpIfFalse  r143, L18
+  Index        r115, r139, r141
+  Const        r145, "ws_net_profit"
+  Index        r146, r115, r145
+  Append       r137, r137, r146
+  Const        r148, 1
+  AddInt       r141, r141, r148
+  Jump         L19
+L18:
+  Sum          r149, r137
+  // order_count: len(distinct(from x in filtered select x.ws_order_number)),
+  Move         r150, r106
+  Move         r151, r121
+  // total_shipping_cost: sum(from x in filtered select x.ws_ext_ship_cost),
+  Move         r152, r122
+  Move         r153, r135
+  // total_net_profit: sum(from x in filtered select x.ws_net_profit)
+  Move         r154, r136
+  Move         r155, r149
+  // let result = {
+  MakeMap      r156, 3, r150
+  // json(result)
+  JSON         r156
+  // expect result == {order_count: 1, total_shipping_cost: 2.0, total_net_profit: 5.0}
+  Const        r157, {"order_count": 1, "total_net_profit": 5, "total_shipping_cost": 2}
+  Equal        r158, r156, r157
+  Expect       r158
+  Return       r0
+
+  // fun distinct(xs: list<any>): list<any> {
+func distinct (regs=14)
+  // var out = []
+  Const        r2, []
+  // for x in xs {
+  IterPrep     r3, r0
+  Len          r4, r3
+  Const        r5, 0
+L2:
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r8, r3, r5
+  // if !contains(out, x) {
+  Not          r10, r9
+  JumpIfFalse  r10, L1
+  // out = append(out, x)
+  Append       r2, r2, r8
+L1:
+  // for x in xs {
+  Const        r12, 1
+  Add          r5, r5, r12
+  Jump         L2
+L0:
+  // return out
+  Return       r2

--- a/tests/dataset/tpc-ds/out/q95.ir.out
+++ b/tests/dataset/tpc-ds/out/q95.ir.out
@@ -1,0 +1,358 @@
+func main (regs=220)
+  // let web_sales = [
+  Const        r0, [{"ws_ext_ship_cost": 2, "ws_net_profit": 5, "ws_order_number": 1, "ws_ship_addr_sk": 1, "ws_ship_date_sk": 1, "ws_warehouse_sk": 1, "ws_web_site_sk": 1}, {"ws_ext_ship_cost": 0, "ws_net_profit": 0, "ws_order_number": 1, "ws_ship_addr_sk": 1, "ws_ship_date_sk": 1, "ws_warehouse_sk": 2, "ws_web_site_sk": 1}]
+  // let web_returns = [{wr_order_number: 1}]
+  Const        r1, [{"wr_order_number": 1}]
+  // let date_dim = [{d_date_sk: 1, d_date: "2001-02-01"}]
+  Const        r2, [{"d_date": "2001-02-01", "d_date_sk": 1}]
+  // let customer_address = [{ca_address_sk: 1, ca_state: "CA"}]
+  Const        r3, [{"ca_address_sk": 1, "ca_state": "CA"}]
+  // let web_site = [{web_site_sk: 1, web_company_name: "pri"}]
+  Const        r4, [{"web_company_name": "pri", "web_site_sk": 1}]
+  // from ws1 in web_sales
+  Const        r5, []
+  // where ws1.ws_order_number == ws2.ws_order_number && ws1.ws_warehouse_sk != ws2.ws_warehouse_sk
+  Const        r6, "ws_order_number"
+  Const        r7, "ws_order_number"
+  Const        r8, "ws_warehouse_sk"
+  Const        r9, "ws_warehouse_sk"
+  // select {ws_order_number: ws1.ws_order_number}
+  Const        r10, "ws_order_number"
+  Const        r11, "ws_order_number"
+  // from ws1 in web_sales
+  IterPrep     r12, r0
+  Len          r13, r12
+  Const        r14, 0
+L5:
+  LessInt      r16, r14, r13
+  JumpIfFalse  r16, L0
+  Index        r18, r12, r14
+  // from ws2 in web_sales
+  IterPrep     r19, r0
+  Len          r20, r19
+  Const        r21, 0
+L4:
+  LessInt      r23, r21, r20
+  JumpIfFalse  r23, L1
+  Index        r25, r19, r21
+  // where ws1.ws_order_number == ws2.ws_order_number && ws1.ws_warehouse_sk != ws2.ws_warehouse_sk
+  Const        r26, "ws_order_number"
+  Index        r27, r18, r26
+  Const        r28, "ws_order_number"
+  Index        r29, r25, r28
+  Equal        r30, r27, r29
+  Const        r31, "ws_warehouse_sk"
+  Index        r32, r18, r31
+  Const        r33, "ws_warehouse_sk"
+  Index        r34, r25, r33
+  NotEqual     r35, r32, r34
+  Move         r36, r30
+  JumpIfFalse  r36, L2
+  Move         r36, r35
+L2:
+  JumpIfFalse  r36, L3
+  // select {ws_order_number: ws1.ws_order_number}
+  Const        r37, "ws_order_number"
+  Const        r38, "ws_order_number"
+  Index        r39, r18, r38
+  Move         r40, r37
+  Move         r41, r39
+  MakeMap      r42, 1, r40
+  // from ws1 in web_sales
+  Append       r5, r5, r42
+L3:
+  // from ws2 in web_sales
+  Const        r44, 1
+  AddInt       r21, r21, r44
+  Jump         L4
+L1:
+  // from ws1 in web_sales
+  Const        r45, 1
+  AddInt       r14, r14, r45
+  Jump         L5
+L0:
+  // from ws in web_sales
+  Const        r46, []
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r47, "ca_state"
+  Const        r48, "web_company_name"
+  // ws.ws_order_number in (from x in ws_wh select x.ws_order_number) &&
+  Const        r49, "ws_order_number"
+  Const        r50, "ws_order_number"
+  // ws.ws_order_number in (from wr in web_returns select wr.wr_order_number)
+  Const        r51, "ws_order_number"
+  Const        r52, "wr_order_number"
+  // from ws in web_sales
+  IterPrep     r53, r0
+  Len          r54, r53
+  Const        r55, 0
+L21:
+  LessInt      r57, r55, r54
+  JumpIfFalse  r57, L6
+  Index        r59, r53, r55
+  // join d in date_dim on ws.ws_ship_date_sk == d.d_date_sk
+  IterPrep     r60, r2
+  Len          r61, r60
+  Const        r62, "ws_ship_date_sk"
+  Const        r63, "d_date_sk"
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r64, "ca_state"
+  Const        r65, "web_company_name"
+  // ws.ws_order_number in (from x in ws_wh select x.ws_order_number) &&
+  Const        r66, "ws_order_number"
+  Const        r67, "ws_order_number"
+  // ws.ws_order_number in (from wr in web_returns select wr.wr_order_number)
+  Const        r68, "ws_order_number"
+  Const        r69, "wr_order_number"
+  // join d in date_dim on ws.ws_ship_date_sk == d.d_date_sk
+  Const        r70, 0
+L20:
+  LessInt      r72, r70, r61
+  JumpIfFalse  r72, L7
+  Index        r74, r60, r70
+  Const        r75, "ws_ship_date_sk"
+  Index        r76, r59, r75
+  Const        r77, "d_date_sk"
+  Index        r78, r74, r77
+  Equal        r79, r76, r78
+  JumpIfFalse  r79, L8
+  // join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
+  IterPrep     r80, r3
+  Len          r81, r80
+  Const        r82, "ws_ship_addr_sk"
+  Const        r83, "ca_address_sk"
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r84, "ca_state"
+  Const        r85, "web_company_name"
+  // ws.ws_order_number in (from x in ws_wh select x.ws_order_number) &&
+  Const        r86, "ws_order_number"
+  Const        r87, "ws_order_number"
+  // ws.ws_order_number in (from wr in web_returns select wr.wr_order_number)
+  Const        r88, "ws_order_number"
+  Const        r89, "wr_order_number"
+  // join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
+  Const        r90, 0
+L19:
+  LessInt      r92, r90, r81
+  JumpIfFalse  r92, L8
+  Index        r94, r80, r90
+  Const        r95, "ws_ship_addr_sk"
+  Index        r96, r59, r95
+  Const        r97, "ca_address_sk"
+  Index        r98, r94, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L9
+  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  IterPrep     r100, r4
+  Len          r101, r100
+  Const        r102, "ws_web_site_sk"
+  Const        r103, "web_site_sk"
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r104, "ca_state"
+  Const        r105, "web_company_name"
+  // ws.ws_order_number in (from x in ws_wh select x.ws_order_number) &&
+  Const        r106, "ws_order_number"
+  Const        r107, "ws_order_number"
+  // ws.ws_order_number in (from wr in web_returns select wr.wr_order_number)
+  Const        r108, "ws_order_number"
+  Const        r109, "wr_order_number"
+  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  Const        r110, 0
+L18:
+  LessInt      r112, r110, r101
+  JumpIfFalse  r112, L9
+  Index        r114, r100, r110
+  Const        r115, "ws_web_site_sk"
+  Index        r116, r59, r115
+  Const        r117, "web_site_sk"
+  Index        r118, r114, r117
+  Equal        r119, r116, r118
+  JumpIfFalse  r119, L10
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Const        r120, "ca_state"
+  Index        r121, r94, r120
+  Const        r122, "CA"
+  Equal        r123, r121, r122
+  Const        r124, "web_company_name"
+  Index        r125, r114, r124
+  Const        r126, "pri"
+  Equal        r127, r125, r126
+  // ws.ws_order_number in (from x in ws_wh select x.ws_order_number) &&
+  Const        r128, "ws_order_number"
+  Index        r129, r59, r128
+  Const        r130, []
+  Const        r131, "ws_order_number"
+  IterPrep     r132, r5
+  Len          r133, r132
+  Const        r134, 0
+L12:
+  LessInt      r136, r134, r133
+  JumpIfFalse  r136, L11
+  Index        r138, r132, r134
+  Const        r139, "ws_order_number"
+  Index        r140, r138, r139
+  Append       r130, r130, r140
+  Const        r142, 1
+  AddInt       r134, r134, r142
+  Jump         L12
+L11:
+  In           r143, r129, r130
+  // ws.ws_order_number in (from wr in web_returns select wr.wr_order_number)
+  Const        r144, "ws_order_number"
+  Index        r145, r59, r144
+  Const        r146, []
+  Const        r147, "wr_order_number"
+  IterPrep     r148, r1
+  Len          r149, r148
+  Const        r150, 0
+L14:
+  LessInt      r152, r150, r149
+  JumpIfFalse  r152, L13
+  Index        r154, r148, r150
+  Const        r155, "wr_order_number"
+  Index        r156, r154, r155
+  Append       r146, r146, r156
+  Const        r158, 1
+  AddInt       r150, r150, r158
+  Jump         L14
+L13:
+  In           r159, r145, r146
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  Move         r160, r123
+  JumpIfFalse  r160, L15
+L15:
+  Move         r161, r127
+  JumpIfFalse  r161, L16
+L16:
+  // ws.ws_order_number in (from x in ws_wh select x.ws_order_number) &&
+  Move         r162, r143
+  JumpIfFalse  r162, L17
+  Move         r162, r159
+L17:
+  // where ca.ca_state == "CA" && w.web_company_name == "pri" &&
+  JumpIfFalse  r162, L10
+  // from ws in web_sales
+  Append       r46, r46, r59
+L10:
+  // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
+  Const        r164, 1
+  Add          r110, r110, r164
+  Jump         L18
+L9:
+  // join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
+  Const        r165, 1
+  Add          r90, r90, r165
+  Jump         L19
+L8:
+  // join d in date_dim on ws.ws_ship_date_sk == d.d_date_sk
+  Const        r166, 1
+  Add          r70, r70, r166
+  Jump         L20
+L7:
+  // from ws in web_sales
+  Const        r167, 1
+  AddInt       r55, r55, r167
+  Jump         L21
+L6:
+  // order_count: len(distinct(from x in filtered select x.ws_order_number)),
+  Const        r168, "order_count"
+  Const        r169, []
+  Const        r170, "ws_order_number"
+  IterPrep     r171, r46
+  Len          r172, r171
+  Const        r173, 0
+L23:
+  LessInt      r175, r173, r172
+  JumpIfFalse  r175, L22
+  Index        r138, r171, r173
+  Const        r177, "ws_order_number"
+  Index        r178, r138, r177
+  Append       r169, r169, r178
+  Const        r180, 1
+  AddInt       r173, r173, r180
+  Jump         L23
+L22:
+  Distinct     181,169,0,0
+  Len          r182, r181
+  // total_shipping_cost: sum(from x in filtered select x.ws_ext_ship_cost),
+  Const        r183, "total_shipping_cost"
+  Const        r184, []
+  Const        r185, "ws_ext_ship_cost"
+  IterPrep     r186, r46
+  Len          r187, r186
+  Const        r188, 0
+L25:
+  LessInt      r190, r188, r187
+  JumpIfFalse  r190, L24
+  Index        r138, r186, r188
+  Const        r192, "ws_ext_ship_cost"
+  Index        r193, r138, r192
+  Append       r184, r184, r193
+  Const        r195, 1
+  AddInt       r188, r188, r195
+  Jump         L25
+L24:
+  Sum          r196, r184
+  // total_net_profit: sum(from x in filtered select x.ws_net_profit)
+  Const        r197, "total_net_profit"
+  Const        r198, []
+  Const        r199, "ws_net_profit"
+  IterPrep     r200, r46
+  Len          r201, r200
+  Const        r202, 0
+L27:
+  LessInt      r204, r202, r201
+  JumpIfFalse  r204, L26
+  Index        r138, r200, r202
+  Const        r206, "ws_net_profit"
+  Index        r207, r138, r206
+  Append       r198, r198, r207
+  Const        r209, 1
+  AddInt       r202, r202, r209
+  Jump         L27
+L26:
+  Sum          r210, r198
+  // order_count: len(distinct(from x in filtered select x.ws_order_number)),
+  Move         r211, r168
+  Move         r212, r182
+  // total_shipping_cost: sum(from x in filtered select x.ws_ext_ship_cost),
+  Move         r213, r183
+  Move         r214, r196
+  // total_net_profit: sum(from x in filtered select x.ws_net_profit)
+  Move         r215, r197
+  Move         r216, r210
+  // let result = {
+  MakeMap      r217, 3, r211
+  // json(result)
+  JSON         r217
+  // expect result == {order_count: 1, total_shipping_cost: 2.0, total_net_profit: 5.0}
+  Const        r218, {"order_count": 1, "total_net_profit": 5, "total_shipping_cost": 2}
+  Equal        r219, r217, r218
+  Expect       r219
+  Return       r0
+
+  // fun distinct(xs: list<any>): list<any> {
+func distinct (regs=14)
+  // var out = []
+  Const        r2, []
+  // for x in xs {
+  IterPrep     r3, r0
+  Len          r4, r3
+  Const        r5, 0
+L2:
+  Less         r6, r5, r4
+  JumpIfFalse  r6, L0
+  Index        r8, r3, r5
+  // if !contains(out, x) {
+  Not          r10, r9
+  JumpIfFalse  r10, L1
+  // out = append(out, x)
+  Append       r2, r2, r8
+L1:
+  // for x in xs {
+  Const        r12, 1
+  Add          r5, r5, r12
+  Jump         L2
+L0:
+  // return out
+  Return       r2

--- a/tests/dataset/tpc-ds/out/q96.ir.out
+++ b/tests/dataset/tpc-ds/out/q96.ir.out
@@ -1,0 +1,157 @@
+func main (regs=97)
+  // let store_sales = [
+  Const        r0, [{"ss_hdemo_sk": 1, "ss_sold_time_sk": 1, "ss_store_sk": 1}, {"ss_hdemo_sk": 1, "ss_sold_time_sk": 1, "ss_store_sk": 1}, {"ss_hdemo_sk": 1, "ss_sold_time_sk": 2, "ss_store_sk": 1}]
+  // let household_demographics = [{hd_demo_sk: 1, hd_dep_count: 3}]
+  Const        r1, [{"hd_demo_sk": 1, "hd_dep_count": 3}]
+  // let time_dim = [
+  Const        r2, [{"t_hour": 20, "t_minute": 35, "t_time_sk": 1}, {"t_hour": 20, "t_minute": 45, "t_time_sk": 2}]
+  // let store = [{s_store_sk: 1, s_store_name: "ese"}]
+  Const        r3, [{"s_store_name": "ese", "s_store_sk": 1}]
+  // count(from ss in store_sales
+  Const        r4, []
+  // where t.t_hour == 20 && t.t_minute >= 30 &&
+  Const        r5, "t_hour"
+  Const        r6, "t_minute"
+  // hd.hd_dep_count == 3 && s.s_store_name == "ese"
+  Const        r7, "hd_dep_count"
+  Const        r8, "s_store_name"
+  // count(from ss in store_sales
+  IterPrep     r9, r0
+  Len          r10, r9
+  Const        r11, 0
+L11:
+  LessInt      r13, r11, r10
+  JumpIfFalse  r13, L0
+  Index        r15, r9, r11
+  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  IterPrep     r16, r1
+  Len          r17, r16
+  Const        r18, "ss_hdemo_sk"
+  Const        r19, "hd_demo_sk"
+  // where t.t_hour == 20 && t.t_minute >= 30 &&
+  Const        r20, "t_hour"
+  Const        r21, "t_minute"
+  // hd.hd_dep_count == 3 && s.s_store_name == "ese"
+  Const        r22, "hd_dep_count"
+  Const        r23, "s_store_name"
+  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  Const        r24, 0
+L10:
+  LessInt      r26, r24, r17
+  JumpIfFalse  r26, L1
+  Index        r28, r16, r24
+  Const        r29, "ss_hdemo_sk"
+  Index        r30, r15, r29
+  Const        r31, "hd_demo_sk"
+  Index        r32, r28, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join t in time_dim on ss.ss_sold_time_sk == t.t_time_sk
+  IterPrep     r34, r2
+  Len          r35, r34
+  Const        r36, "ss_sold_time_sk"
+  Const        r37, "t_time_sk"
+  // where t.t_hour == 20 && t.t_minute >= 30 &&
+  Const        r38, "t_hour"
+  Const        r39, "t_minute"
+  // hd.hd_dep_count == 3 && s.s_store_name == "ese"
+  Const        r40, "hd_dep_count"
+  Const        r41, "s_store_name"
+  // join t in time_dim on ss.ss_sold_time_sk == t.t_time_sk
+  Const        r42, 0
+L9:
+  LessInt      r44, r42, r35
+  JumpIfFalse  r44, L2
+  Index        r46, r34, r42
+  Const        r47, "ss_sold_time_sk"
+  Index        r48, r15, r47
+  Const        r49, "t_time_sk"
+  Index        r50, r46, r49
+  Equal        r51, r48, r50
+  JumpIfFalse  r51, L3
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  IterPrep     r52, r3
+  Len          r53, r52
+  Const        r54, "ss_store_sk"
+  Const        r55, "s_store_sk"
+  // where t.t_hour == 20 && t.t_minute >= 30 &&
+  Const        r56, "t_hour"
+  Const        r57, "t_minute"
+  // hd.hd_dep_count == 3 && s.s_store_name == "ese"
+  Const        r58, "hd_dep_count"
+  Const        r59, "s_store_name"
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  Const        r60, 0
+L8:
+  LessInt      r62, r60, r53
+  JumpIfFalse  r62, L3
+  Index        r64, r52, r60
+  Const        r65, "ss_store_sk"
+  Index        r66, r15, r65
+  Const        r67, "s_store_sk"
+  Index        r68, r64, r67
+  Equal        r69, r66, r68
+  JumpIfFalse  r69, L4
+  // where t.t_hour == 20 && t.t_minute >= 30 &&
+  Const        r70, "t_hour"
+  Index        r71, r46, r70
+  Const        r72, "t_minute"
+  Index        r73, r46, r72
+  Const        r74, 30
+  LessEq       r75, r74, r73
+  Const        r76, 20
+  Equal        r77, r71, r76
+  // hd.hd_dep_count == 3 && s.s_store_name == "ese"
+  Const        r78, "hd_dep_count"
+  Index        r79, r28, r78
+  Const        r80, 3
+  Equal        r81, r79, r80
+  Const        r82, "s_store_name"
+  Index        r83, r64, r82
+  Const        r84, "ese"
+  Equal        r85, r83, r84
+  // where t.t_hour == 20 && t.t_minute >= 30 &&
+  Move         r86, r77
+  JumpIfFalse  r86, L5
+L5:
+  Move         r87, r75
+  JumpIfFalse  r87, L6
+L6:
+  // hd.hd_dep_count == 3 && s.s_store_name == "ese"
+  Move         r88, r81
+  JumpIfFalse  r88, L7
+  Move         r88, r85
+L7:
+  // where t.t_hour == 20 && t.t_minute >= 30 &&
+  JumpIfFalse  r88, L4
+  // count(from ss in store_sales
+  Append       r4, r4, r15
+L4:
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  Const        r90, 1
+  Add          r60, r60, r90
+  Jump         L8
+L3:
+  // join t in time_dim on ss.ss_sold_time_sk == t.t_time_sk
+  Const        r91, 1
+  Add          r42, r42, r91
+  Jump         L9
+L2:
+  // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
+  Const        r92, 1
+  Add          r24, r24, r92
+  Jump         L10
+L1:
+  // count(from ss in store_sales
+  Const        r93, 1
+  AddInt       r11, r11, r93
+  Jump         L11
+L0:
+  Count        r94, r4
+  // json(result)
+  JSON         r94
+  // expect result == 3
+  Const        r95, 3
+  EqualInt     r96, r94, r95
+  Expect       r96
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q97.ir.out
+++ b/tests/dataset/tpc-ds/out/q97.ir.out
@@ -1,0 +1,488 @@
+func main (regs=356)
+  // let store_sales = [
+  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1}, {"ss_customer_sk": 2, "ss_item_sk": 1}]
+  // let catalog_sales = [
+  Const        r1, [{"cs_bill_customer_sk": 1, "cs_item_sk": 1}, {"cs_bill_customer_sk": 3, "cs_item_sk": 2}]
+  // let ssci = from ss in store_sales group by {customer_sk: ss.ss_customer_sk, item_sk: ss.ss_item_sk} into g select {customer_sk: g.key.customer_sk, item_sk: g.key.item_sk}
+  Const        r2, []
+  Const        r3, "customer_sk"
+  Const        r4, "ss_customer_sk"
+  Const        r5, "item_sk"
+  Const        r6, "ss_item_sk"
+  Const        r7, "customer_sk"
+  Const        r8, "key"
+  Const        r9, "customer_sk"
+  Const        r10, "item_sk"
+  Const        r11, "key"
+  Const        r12, "item_sk"
+  IterPrep     r13, r0
+  Len          r14, r13
+  Const        r15, 0
+  MakeMap      r16, 0, r0
+  Const        r17, []
+L2:
+  LessInt      r19, r15, r14
+  JumpIfFalse  r19, L0
+  Index        r20, r13, r15
+  Move         r21, r20
+  Const        r22, "customer_sk"
+  Const        r23, "ss_customer_sk"
+  Index        r24, r21, r23
+  Const        r25, "item_sk"
+  Const        r26, "ss_item_sk"
+  Index        r27, r21, r26
+  Move         r28, r22
+  Move         r29, r24
+  Move         r30, r25
+  Move         r31, r27
+  MakeMap      r32, 2, r28
+  Str          r33, r32
+  In           r34, r33, r16
+  JumpIfTrue   r34, L1
+  Const        r35, []
+  Const        r36, "__group__"
+  Const        r37, true
+  Const        r38, "key"
+  Move         r39, r32
+  Const        r40, "items"
+  Move         r41, r35
+  Const        r42, "count"
+  Const        r43, 0
+  Move         r44, r36
+  Move         r45, r37
+  Move         r46, r38
+  Move         r47, r39
+  Move         r48, r40
+  Move         r49, r41
+  Move         r50, r42
+  Move         r51, r43
+  MakeMap      r52, 4, r44
+  SetIndex     r16, r33, r52
+  Append       r17, r17, r52
+L1:
+  Const        r54, "items"
+  Index        r55, r16, r33
+  Index        r56, r55, r54
+  Append       r57, r56, r20
+  SetIndex     r55, r54, r57
+  Const        r58, "count"
+  Index        r59, r55, r58
+  Const        r60, 1
+  AddInt       r61, r59, r60
+  SetIndex     r55, r58, r61
+  Const        r62, 1
+  AddInt       r15, r15, r62
+  Jump         L2
+L0:
+  Const        r63, 0
+  Len          r65, r17
+L4:
+  LessInt      r66, r63, r65
+  JumpIfFalse  r66, L3
+  Index        r68, r17, r63
+  Const        r69, "customer_sk"
+  Const        r70, "key"
+  Index        r71, r68, r70
+  Const        r72, "customer_sk"
+  Index        r73, r71, r72
+  Const        r74, "item_sk"
+  Const        r75, "key"
+  Index        r76, r68, r75
+  Const        r77, "item_sk"
+  Index        r78, r76, r77
+  Move         r79, r69
+  Move         r80, r73
+  Move         r81, r74
+  Move         r82, r78
+  MakeMap      r83, 2, r79
+  Append       r2, r2, r83
+  Const        r85, 1
+  AddInt       r63, r63, r85
+  Jump         L4
+L3:
+  // let csci = from cs in catalog_sales group by {customer_sk: cs.cs_bill_customer_sk, item_sk: cs.cs_item_sk} into g select {customer_sk: g.key.customer_sk, item_sk: g.key.item_sk}
+  Const        r86, []
+  Const        r87, "customer_sk"
+  Const        r88, "cs_bill_customer_sk"
+  Const        r89, "item_sk"
+  Const        r90, "cs_item_sk"
+  Const        r91, "customer_sk"
+  Const        r92, "key"
+  Const        r93, "customer_sk"
+  Const        r94, "item_sk"
+  Const        r95, "key"
+  Const        r96, "item_sk"
+  IterPrep     r97, r1
+  Len          r98, r97
+  Const        r99, 0
+  MakeMap      r100, 0, r0
+  Const        r101, []
+L7:
+  LessInt      r103, r99, r98
+  JumpIfFalse  r103, L5
+  Index        r104, r97, r99
+  Move         r105, r104
+  Const        r106, "customer_sk"
+  Const        r107, "cs_bill_customer_sk"
+  Index        r108, r105, r107
+  Const        r109, "item_sk"
+  Const        r110, "cs_item_sk"
+  Index        r111, r105, r110
+  Move         r112, r106
+  Move         r113, r108
+  Move         r114, r109
+  Move         r115, r111
+  MakeMap      r116, 2, r112
+  Str          r117, r116
+  In           r118, r117, r100
+  JumpIfTrue   r118, L6
+  Const        r119, []
+  Const        r120, "__group__"
+  Const        r121, true
+  Const        r122, "key"
+  Move         r123, r116
+  Const        r124, "items"
+  Move         r125, r119
+  Const        r126, "count"
+  Const        r127, 0
+  Move         r128, r120
+  Move         r129, r121
+  Move         r130, r122
+  Move         r131, r123
+  Move         r132, r124
+  Move         r133, r125
+  Move         r134, r126
+  Move         r135, r127
+  MakeMap      r136, 4, r128
+  SetIndex     r100, r117, r136
+  Append       r101, r101, r136
+L6:
+  Const        r138, "items"
+  Index        r139, r100, r117
+  Index        r140, r139, r138
+  Append       r141, r140, r104
+  SetIndex     r139, r138, r141
+  Const        r142, "count"
+  Index        r143, r139, r142
+  Const        r144, 1
+  AddInt       r145, r143, r144
+  SetIndex     r139, r142, r145
+  Const        r146, 1
+  AddInt       r99, r99, r146
+  Jump         L7
+L5:
+  Const        r147, 0
+  Len          r149, r101
+L9:
+  LessInt      r150, r147, r149
+  JumpIfFalse  r150, L8
+  Index        r68, r101, r147
+  Const        r152, "customer_sk"
+  Const        r153, "key"
+  Index        r154, r68, r153
+  Const        r155, "customer_sk"
+  Index        r156, r154, r155
+  Const        r157, "item_sk"
+  Const        r158, "key"
+  Index        r159, r68, r158
+  Const        r160, "item_sk"
+  Index        r161, r159, r160
+  Move         r162, r152
+  Move         r163, r156
+  Move         r164, r157
+  Move         r165, r161
+  MakeMap      r166, 2, r162
+  Append       r86, r86, r166
+  Const        r168, 1
+  AddInt       r147, r147, r168
+  Jump         L9
+L8:
+  // from s in ssci outer join c in csci on s.customer_sk == c.customer_sk && s.item_sk == c.item_sk
+  Const        r169, []
+  IterPrep     r170, r2
+  Len          r171, r170
+  IterPrep     r172, r86
+  Len          r173, r172
+  Const        r176, 0
+L34:
+  LessInt      r177, r176, r173
+  JumpIfFalse  r177, L10
+  Index        r174, r172, r176
+  Const        r179, false
+  Const        r180, 0
+L23:
+  LessInt      r181, r180, r171
+  JumpIfFalse  r181, L11
+  Index        r175, r170, r180
+  Const        r183, "customer_sk"
+  Index        r184, r175, r183
+  Const        r185, "customer_sk"
+  Index        r186, r174, r185
+  Equal        r187, r184, r186
+  Const        r188, "item_sk"
+  Index        r189, r175, r188
+  Const        r190, "item_sk"
+  Index        r191, r174, r190
+  Equal        r192, r189, r191
+  Move         r193, r187
+  JumpIfFalse  r193, L12
+  Move         r193, r192
+L12:
+  JumpIfFalse  r193, L13
+  Const        r179, true
+  // store_only: if s.customer_sk != null && c.customer_sk == null {1} else {0},
+  Const        r194, "store_only"
+  Const        r195, "customer_sk"
+  Index        r196, r175, r195
+  Const        r197, nil
+  NotEqual     r198, r196, r197
+  Const        r199, "customer_sk"
+  Index        r200, r174, r199
+  Const        r201, nil
+  Equal        r202, r200, r201
+  Move         r203, r198
+  JumpIfFalse  r203, L14
+  Move         r203, r202
+L14:
+  JumpIfFalse  r203, L15
+  Const        r205, 1
+  Jump         L16
+L15:
+  Const        r205, 0
+L16:
+  // catalog_only: if s.customer_sk == null && c.customer_sk != null {1} else {0},
+  Const        r207, "catalog_only"
+  Const        r208, "customer_sk"
+  Index        r209, r175, r208
+  Const        r210, nil
+  Equal        r211, r209, r210
+  Const        r212, "customer_sk"
+  Index        r213, r174, r212
+  Const        r214, nil
+  NotEqual     r215, r213, r214
+  Move         r216, r211
+  JumpIfFalse  r216, L17
+  Move         r216, r215
+L17:
+  JumpIfFalse  r216, L18
+  Const        r218, 1
+  Jump         L19
+L18:
+  Const        r218, 0
+L19:
+  // both: if s.customer_sk != null && c.customer_sk != null {1} else {0}
+  Const        r220, "both"
+  Const        r221, "customer_sk"
+  Index        r222, r175, r221
+  Const        r223, nil
+  NotEqual     r224, r222, r223
+  Const        r225, "customer_sk"
+  Index        r226, r174, r225
+  Const        r227, nil
+  NotEqual     r228, r226, r227
+  Move         r229, r224
+  JumpIfFalse  r229, L20
+  Move         r229, r228
+L20:
+  JumpIfFalse  r229, L21
+  Const        r231, 1
+  Jump         L22
+L21:
+  Const        r231, 0
+L22:
+  // store_only: if s.customer_sk != null && c.customer_sk == null {1} else {0},
+  Move         r233, r194
+  Move         r234, r205
+  // catalog_only: if s.customer_sk == null && c.customer_sk != null {1} else {0},
+  Move         r235, r207
+  Move         r236, r218
+  // both: if s.customer_sk != null && c.customer_sk != null {1} else {0}
+  Move         r237, r220
+  Move         r238, r231
+  // select {
+  MakeMap      r239, 3, r233
+  // from s in ssci outer join c in csci on s.customer_sk == c.customer_sk && s.item_sk == c.item_sk
+  Append       r169, r169, r239
+L13:
+  Const        r241, 1
+  AddInt       r180, r180, r241
+  Jump         L23
+L11:
+  Move         r242, r179
+  JumpIfTrue   r242, L24
+  Const        r175, nil
+  // store_only: if s.customer_sk != null && c.customer_sk == null {1} else {0},
+  Const        r244, "store_only"
+  Const        r245, "customer_sk"
+  Index        r246, r175, r245
+  Const        r247, nil
+  NotEqual     r248, r246, r247
+  Const        r249, "customer_sk"
+  Index        r250, r174, r249
+  Const        r251, nil
+  Equal        r252, r250, r251
+  Move         r253, r248
+  JumpIfFalse  r253, L25
+  Move         r253, r252
+L25:
+  JumpIfFalse  r253, L26
+  Const        r255, 1
+  Jump         L27
+L26:
+  Const        r255, 0
+L27:
+  // catalog_only: if s.customer_sk == null && c.customer_sk != null {1} else {0},
+  Const        r257, "catalog_only"
+  Const        r258, "customer_sk"
+  Index        r259, r175, r258
+  Const        r260, nil
+  Equal        r261, r259, r260
+  Const        r262, "customer_sk"
+  Index        r263, r174, r262
+  Const        r264, nil
+  NotEqual     r265, r263, r264
+  Move         r266, r261
+  JumpIfFalse  r266, L28
+  Move         r266, r265
+L28:
+  JumpIfFalse  r266, L29
+  Const        r268, 1
+  Jump         L30
+L29:
+  Const        r268, 0
+L30:
+  // both: if s.customer_sk != null && c.customer_sk != null {1} else {0}
+  Const        r270, "both"
+  Const        r271, "customer_sk"
+  Index        r272, r175, r271
+  Const        r273, nil
+  NotEqual     r274, r272, r273
+  Const        r275, "customer_sk"
+  Index        r276, r174, r275
+  Const        r277, nil
+  NotEqual     r278, r276, r277
+  Move         r279, r274
+  JumpIfFalse  r279, L31
+  Move         r279, r278
+L31:
+  JumpIfFalse  r279, L32
+  Const        r281, 1
+  Jump         L33
+L32:
+  Const        r281, 0
+L33:
+  // store_only: if s.customer_sk != null && c.customer_sk == null {1} else {0},
+  Move         r283, r244
+  Move         r284, r255
+  // catalog_only: if s.customer_sk == null && c.customer_sk != null {1} else {0},
+  Move         r285, r257
+  Move         r286, r268
+  // both: if s.customer_sk != null && c.customer_sk != null {1} else {0}
+  Move         r287, r270
+  Move         r288, r281
+  // select {
+  MakeMap      r289, 3, r283
+  // from s in ssci outer join c in csci on s.customer_sk == c.customer_sk && s.item_sk == c.item_sk
+  Append       r169, r169, r289
+L24:
+  Const        r291, 1
+  AddInt       r176, r176, r291
+  Jump         L34
+L10:
+  // store_only: sum(from x in joined select x.store_only),
+  Const        r292, "store_only"
+  Const        r293, []
+  Const        r294, "store_only"
+  IterPrep     r295, r169
+  Len          r296, r295
+  Const        r297, 0
+L36:
+  LessInt      r299, r297, r296
+  JumpIfFalse  r299, L35
+  Index        r301, r295, r297
+  Const        r302, "store_only"
+  Index        r303, r301, r302
+  Append       r293, r293, r303
+  Const        r305, 1
+  AddInt       r297, r297, r305
+  Jump         L36
+L35:
+  Sum          r306, r293
+  // catalog_only: sum(from x in joined select x.catalog_only),
+  Const        r307, "catalog_only"
+  Const        r308, []
+  Const        r309, "catalog_only"
+  IterPrep     r310, r169
+  Len          r311, r310
+  Const        r312, 0
+L38:
+  LessInt      r314, r312, r311
+  JumpIfFalse  r314, L37
+  Index        r301, r310, r312
+  Const        r316, "catalog_only"
+  Index        r317, r301, r316
+  Append       r308, r308, r317
+  Const        r319, 1
+  AddInt       r312, r312, r319
+  Jump         L38
+L37:
+  Sum          r320, r308
+  // store_and_catalog: sum(from x in joined select x.both)
+  Const        r321, "store_and_catalog"
+  Const        r322, []
+  Const        r323, "both"
+  IterPrep     r324, r169
+  Len          r325, r324
+  Const        r326, 0
+L40:
+  LessInt      r328, r326, r325
+  JumpIfFalse  r328, L39
+  Index        r301, r324, r326
+  Const        r330, "both"
+  Index        r331, r301, r330
+  Append       r322, r322, r331
+  Const        r333, 1
+  AddInt       r326, r326, r333
+  Jump         L40
+L39:
+  Sum          r334, r322
+  // store_only: sum(from x in joined select x.store_only),
+  Move         r335, r292
+  Move         r336, r306
+  // catalog_only: sum(from x in joined select x.catalog_only),
+  Move         r337, r307
+  Move         r338, r320
+  // store_and_catalog: sum(from x in joined select x.both)
+  Move         r339, r321
+  Move         r340, r334
+  // let result = {
+  MakeMap      r341, 3, r335
+  // json(result)
+  JSON         r341
+  // expect result.store_only == 1 &&
+  Const        r342, "store_only"
+  Index        r343, r341, r342
+  Const        r344, 1
+  Equal        r345, r343, r344
+  // result.catalog_only == 1 &&
+  Const        r346, "catalog_only"
+  Index        r347, r341, r346
+  Const        r348, 1
+  Equal        r349, r347, r348
+  // result.store_and_catalog == 1
+  Const        r350, "store_and_catalog"
+  Index        r351, r341, r350
+  Const        r352, 1
+  Equal        r353, r351, r352
+  // expect result.store_only == 1 &&
+  Move         r354, r345
+  JumpIfFalse  r354, L41
+L41:
+  // result.catalog_only == 1 &&
+  Move         r355, r349
+  JumpIfFalse  r355, L42
+  Move         r355, r353
+L42:
+  // expect result.store_only == 1 &&
+  Expect       r355
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q98.ir.out
+++ b/tests/dataset/tpc-ds/out/q98.ir.out
@@ -1,0 +1,596 @@
+func main (regs=412)
+L19:
+  // let store_sales = [
+  Const        r0, [{"ss_ext_sales_price": 50, "ss_item_sk": 1, "ss_sold_date_sk": 1}, {"ss_ext_sales_price": 100, "ss_item_sk": 2, "ss_sold_date_sk": 1}]
+  // let item = [
+  Const        r1, [{"i_category": "CatA", "i_class": "Class1", "i_current_price": 100, "i_item_desc": "desc1", "i_item_id": "I1", "i_item_sk": 1}, {"i_category": "CatB", "i_class": "Class1", "i_current_price": 200, "i_item_desc": "desc2", "i_item_id": "I2", "i_item_sk": 2}]
+  // let date_dim = [{d_date_sk: 1, d_date: "2000-02-01"}]
+  Const        r2, [{"d_date": "2000-02-01", "d_date_sk": 1}]
+  // from ss in store_sales
+  Const        r3, []
+  // group by {item_id: i.i_item_id, item_desc: i.i_item_desc, category: i.i_category, class: i.i_class, price: i.i_current_price} into g
+  Const        r4, "item_id"
+  Const        r5, "i_item_id"
+  Const        r6, "item_desc"
+  Const        r7, "i_item_desc"
+  Const        r8, "category"
+  Const        r9, "i_category"
+  Const        r10, "class"
+  Const        r11, "i_class"
+  Const        r12, "price"
+  Const        r13, "i_current_price"
+  // i_item_id: g.key.item_id,
+  Const        r14, "i_item_id"
+  Const        r15, "key"
+  Const        r16, "item_id"
+  // i_item_desc: g.key.item_desc,
+  Const        r17, "i_item_desc"
+  Const        r18, "key"
+  Const        r19, "item_desc"
+  // i_category: g.key.category,
+  Const        r20, "i_category"
+  Const        r21, "key"
+  Const        r22, "category"
+  // i_class: g.key.class,
+  Const        r23, "i_class"
+  Const        r24, "key"
+  Const        r25, "class"
+  // i_current_price: g.key.price,
+  Const        r26, "i_current_price"
+  Const        r27, "key"
+  Const        r28, "price"
+  // itemrevenue: sum(from x in g select x.ss_ext_sales_price)
+  Const        r29, "itemrevenue"
+  Const        r30, "ss_ext_sales_price"
+  // from ss in store_sales
+  MakeMap      r31, 0, r0
+  Const        r32, []
+  IterPrep     r34, r0
+  Len          r35, r34
+  Const        r36, 0
+L7:
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L0
+  Index        r39, r34, r36
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r40, r1
+  Len          r41, r40
+  Const        r42, 0
+L6:
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L1
+  Index        r45, r40, r42
+  Const        r46, "ss_item_sk"
+  Index        r47, r39, r46
+  Const        r48, "i_item_sk"
+  Index        r49, r45, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L2
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r51, r2
+  Len          r52, r51
+  Const        r53, 0
+L5:
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L2
+  Index        r56, r51, r53
+  Const        r57, "ss_sold_date_sk"
+  Index        r58, r39, r57
+  Const        r59, "d_date_sk"
+  Index        r60, r56, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L3
+  // from ss in store_sales
+  Const        r62, "ss"
+  Move         r63, r39
+  Const        r64, "i"
+  Move         r65, r45
+  Const        r66, "d"
+  Move         r67, r56
+  MakeMap      r68, 3, r62
+  // group by {item_id: i.i_item_id, item_desc: i.i_item_desc, category: i.i_category, class: i.i_class, price: i.i_current_price} into g
+  Const        r69, "item_id"
+  Const        r70, "i_item_id"
+  Index        r71, r45, r70
+  Const        r72, "item_desc"
+  Const        r73, "i_item_desc"
+  Index        r74, r45, r73
+  Const        r75, "category"
+  Const        r76, "i_category"
+  Index        r77, r45, r76
+  Const        r78, "class"
+  Const        r79, "i_class"
+  Index        r80, r45, r79
+  Const        r81, "price"
+  Const        r82, "i_current_price"
+  Index        r83, r45, r82
+  Move         r84, r69
+  Move         r85, r71
+  Move         r86, r72
+  Move         r87, r74
+  Move         r88, r75
+  Move         r89, r77
+  Move         r90, r78
+  Move         r91, r80
+  Move         r92, r81
+  Move         r93, r83
+  MakeMap      r94, 5, r84
+  Str          r95, r94
+  In           r96, r95, r31
+  JumpIfTrue   r96, L4
+  // from ss in store_sales
+  Const        r97, []
+  Const        r98, "__group__"
+  Const        r99, true
+  Const        r100, "key"
+  // group by {item_id: i.i_item_id, item_desc: i.i_item_desc, category: i.i_category, class: i.i_class, price: i.i_current_price} into g
+  Move         r101, r94
+  // from ss in store_sales
+  Const        r102, "items"
+  Move         r103, r97
+  Const        r104, "count"
+  Const        r105, 0
+  Move         r106, r98
+  Move         r107, r99
+  Move         r108, r100
+  Move         r109, r101
+  Move         r110, r102
+  Move         r111, r103
+  Move         r112, r104
+  Move         r113, r105
+  MakeMap      r114, 4, r106
+  SetIndex     r31, r95, r114
+  Append       r32, r32, r114
+L4:
+  Const        r116, "items"
+  Index        r117, r31, r95
+  Index        r118, r117, r116
+  Append       r119, r118, r68
+  SetIndex     r117, r116, r119
+  Const        r120, "count"
+  Index        r121, r117, r120
+  Const        r122, 1
+  AddInt       r123, r121, r122
+  SetIndex     r117, r120, r123
+L3:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  Const        r124, 1
+  AddInt       r53, r53, r124
+  Jump         L5
+L2:
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  Const        r125, 1
+  AddInt       r42, r42, r125
+  Jump         L6
+L1:
+  // from ss in store_sales
+  Const        r126, 1
+  AddInt       r36, r36, r126
+  Jump         L7
+L0:
+  Const        r127, 0
+  Len          r129, r32
+L11:
+  LessInt      r130, r127, r129
+  JumpIfFalse  r130, L8
+  Index        r132, r32, r127
+  // i_item_id: g.key.item_id,
+  Const        r133, "i_item_id"
+  Const        r134, "key"
+  Index        r135, r132, r134
+  Const        r136, "item_id"
+  Index        r137, r135, r136
+  // i_item_desc: g.key.item_desc,
+  Const        r138, "i_item_desc"
+  Const        r139, "key"
+  Index        r140, r132, r139
+  Const        r141, "item_desc"
+  Index        r142, r140, r141
+  // i_category: g.key.category,
+  Const        r143, "i_category"
+  Const        r144, "key"
+  Index        r145, r132, r144
+  Const        r146, "category"
+  Index        r147, r145, r146
+  // i_class: g.key.class,
+  Const        r148, "i_class"
+  Const        r149, "key"
+  Index        r150, r132, r149
+  Const        r151, "class"
+  Index        r152, r150, r151
+  // i_current_price: g.key.price,
+  Const        r153, "i_current_price"
+  Const        r154, "key"
+  Index        r155, r132, r154
+  Const        r156, "price"
+  Index        r157, r155, r156
+  // itemrevenue: sum(from x in g select x.ss_ext_sales_price)
+  Const        r158, "itemrevenue"
+  Const        r159, []
+  Const        r160, "ss_ext_sales_price"
+  IterPrep     r161, r132
+  Len          r162, r161
+  Const        r163, 0
+L10:
+  LessInt      r165, r163, r162
+  JumpIfFalse  r165, L9
+  Index        r167, r161, r163
+  Const        r168, "ss_ext_sales_price"
+  Index        r169, r167, r168
+  Append       r159, r159, r169
+  Const        r171, 1
+  AddInt       r163, r163, r171
+  Jump         L10
+L9:
+  Sum          r172, r159
+  // i_item_id: g.key.item_id,
+  Move         r173, r133
+  Move         r174, r137
+  // i_item_desc: g.key.item_desc,
+  Move         r175, r138
+  Move         r176, r142
+  // i_category: g.key.category,
+  Move         r177, r143
+  Move         r178, r147
+  // i_class: g.key.class,
+  Move         r179, r148
+  Move         r180, r152
+  // i_current_price: g.key.price,
+  Move         r181, r153
+  Move         r182, r157
+  // itemrevenue: sum(from x in g select x.ss_ext_sales_price)
+  Move         r183, r158
+  Move         r184, r172
+  // select {
+  MakeMap      r185, 6, r173
+  // from ss in store_sales
+  Append       r3, r3, r185
+  Const        r187, 1
+  AddInt       r127, r127, r187
+  Jump         L11
+L8:
+  // from g in grouped
+  Const        r188, []
+  // group by g.i_class into cg
+  Const        r189, "i_class"
+  // select {class: cg.key, total: sum(from x in cg select x.itemrevenue)}
+  Const        r190, "class"
+  Const        r191, "key"
+  Const        r192, "total"
+  Const        r193, "itemrevenue"
+  // from g in grouped
+  IterPrep     r194, r3
+  Len          r195, r194
+  Const        r196, 0
+  MakeMap      r197, 0, r0
+  Const        r198, []
+L14:
+  LessInt      r200, r196, r195
+  JumpIfFalse  r200, L12
+  Index        r201, r194, r196
+  Move         r132, r201
+  // group by g.i_class into cg
+  Const        r202, "i_class"
+  Index        r203, r132, r202
+  Str          r204, r203
+  In           r205, r204, r197
+  JumpIfTrue   r205, L13
+  // from g in grouped
+  Const        r206, []
+  Const        r207, "__group__"
+  Const        r208, true
+  Const        r209, "key"
+  // group by g.i_class into cg
+  Move         r210, r203
+  // from g in grouped
+  Const        r211, "items"
+  Move         r212, r206
+  Const        r213, "count"
+  Const        r214, 0
+  Move         r215, r207
+  Move         r216, r208
+  Move         r217, r209
+  Move         r218, r210
+  Move         r219, r211
+  Move         r220, r212
+  Move         r221, r213
+  Move         r222, r214
+  MakeMap      r223, 4, r215
+  SetIndex     r197, r204, r223
+  Append       r198, r198, r223
+L13:
+  Const        r225, "items"
+  Index        r226, r197, r204
+  Index        r227, r226, r225
+  Append       r228, r227, r201
+  SetIndex     r226, r225, r228
+  Const        r229, "count"
+  Index        r230, r226, r229
+  Const        r231, 1
+  AddInt       r232, r230, r231
+  SetIndex     r226, r229, r232
+  Const        r233, 1
+  AddInt       r196, r196, r233
+  Jump         L14
+L12:
+  Const        r234, 0
+  Len          r236, r198
+L18:
+  LessInt      r237, r234, r236
+  JumpIfFalse  r237, L15
+  Index        r239, r198, r234
+  // select {class: cg.key, total: sum(from x in cg select x.itemrevenue)}
+  Const        r240, "class"
+  Const        r241, "key"
+  Index        r242, r239, r241
+  Const        r243, "total"
+  Const        r244, []
+  Const        r245, "itemrevenue"
+  IterPrep     r246, r239
+  Len          r247, r246
+  Const        r248, 0
+L17:
+  LessInt      r250, r248, r247
+  JumpIfFalse  r250, L16
+  Index        r167, r246, r248
+  Const        r252, "itemrevenue"
+  Index        r253, r167, r252
+  Append       r244, r244, r253
+  Const        r255, 1
+  AddInt       r248, r248, r255
+  Jump         L17
+L16:
+  Sum          r256, r244
+  Move         r257, r240
+  Move         r258, r242
+  Move         r259, r243
+  Move         r260, r256
+  MakeMap      r261, 2, r257
+  // from g in grouped
+  Append       r188, r188, r261
+  Const        r263, 1
+  AddInt       r234, r234, r263
+  Jump         L18
+L15:
+  // from g in grouped
+  Const        r264, []
+  IterPrep     r265, r3
+  Len          r266, r265
+  // join t in totals on g.i_class == t.class
+  IterPrep     r267, r188
+  Len          r268, r267
+  // from g in grouped
+  Const        r269, 0
+  EqualInt     r270, r266, r269
+  JumpIfTrue   r270, L19
+  EqualInt     r271, r268, r269
+  JumpIfTrue   r271, L19
+  LessEq       r272, r268, r266
+  JumpIfFalse  r272, L20
+  // join t in totals on g.i_class == t.class
+  MakeMap      r273, 0, r0
+  Const        r274, 0
+L23:
+  LessInt      r275, r274, r268
+  JumpIfFalse  r275, L21
+  Index        r276, r267, r274
+  Move         r277, r276
+  Const        r278, "class"
+  Index        r279, r277, r278
+  Index        r280, r273, r279
+  Const        r281, nil
+  NotEqual     r282, r280, r281
+  JumpIfTrue   r282, L22
+  MakeList     r283, 0, r0
+  SetIndex     r273, r279, r283
+L22:
+  Index        r280, r273, r279
+  Append       r284, r280, r276
+  SetIndex     r273, r279, r284
+  Const        r285, 1
+  AddInt       r274, r274, r285
+  Jump         L23
+L21:
+  // from g in grouped
+  Const        r286, 0
+L26:
+  LessInt      r287, r286, r266
+  JumpIfFalse  r287, L19
+  Index        r132, r265, r286
+  // join t in totals on g.i_class == t.class
+  Const        r289, "i_class"
+  Index        r290, r132, r289
+  // from g in grouped
+  Index        r291, r273, r290
+  Const        r292, nil
+  NotEqual     r293, r291, r292
+  JumpIfFalse  r293, L24
+  Len          r294, r291
+  Const        r295, 0
+L25:
+  LessInt      r296, r295, r294
+  JumpIfFalse  r296, L24
+  Index        r277, r291, r295
+  // i_item_id: g.i_item_id,
+  Const        r298, "i_item_id"
+  Const        r299, "i_item_id"
+  Index        r300, r132, r299
+  // i_item_desc: g.i_item_desc,
+  Const        r301, "i_item_desc"
+  Const        r302, "i_item_desc"
+  Index        r303, r132, r302
+  // i_category: g.i_category,
+  Const        r304, "i_category"
+  Const        r305, "i_category"
+  Index        r306, r132, r305
+  // i_class: g.i_class,
+  Const        r307, "i_class"
+  Const        r308, "i_class"
+  Index        r309, r132, r308
+  // i_current_price: g.i_current_price,
+  Const        r310, "i_current_price"
+  Const        r311, "i_current_price"
+  Index        r312, r132, r311
+  // itemrevenue: g.itemrevenue,
+  Const        r313, "itemrevenue"
+  Const        r314, "itemrevenue"
+  Index        r315, r132, r314
+  // revenueratio: g.itemrevenue * 100 / t.total
+  Const        r316, "revenueratio"
+  Const        r317, "itemrevenue"
+  Index        r318, r132, r317
+  Const        r319, 100
+  Mul          r320, r318, r319
+  Const        r321, "total"
+  Index        r322, r277, r321
+  Div          r323, r320, r322
+  // i_item_id: g.i_item_id,
+  Move         r324, r298
+  Move         r325, r300
+  // i_item_desc: g.i_item_desc,
+  Move         r326, r301
+  Move         r327, r303
+  // i_category: g.i_category,
+  Move         r328, r304
+  Move         r329, r306
+  // i_class: g.i_class,
+  Move         r330, r307
+  Move         r331, r309
+  // i_current_price: g.i_current_price,
+  Move         r332, r310
+  Move         r333, r312
+  // itemrevenue: g.itemrevenue,
+  Move         r334, r313
+  Move         r335, r315
+  // revenueratio: g.itemrevenue * 100 / t.total
+  Move         r336, r316
+  Move         r337, r323
+  // select {
+  MakeMap      r338, 7, r324
+  // from g in grouped
+  Append       r264, r264, r338
+  Const        r340, 1
+  AddInt       r295, r295, r340
+  Jump         L25
+L24:
+  Const        r341, 1
+  AddInt       r286, r286, r341
+  Jump         L26
+L20:
+  MakeMap      r342, 0, r0
+  Const        r343, 0
+L29:
+  LessInt      r344, r343, r266
+  JumpIfFalse  r344, L27
+  Index        r345, r265, r343
+  Move         r132, r345
+  // join t in totals on g.i_class == t.class
+  Const        r346, "i_class"
+  Index        r347, r132, r346
+  // from g in grouped
+  Index        r348, r342, r347
+  Const        r349, nil
+  NotEqual     r350, r348, r349
+  JumpIfTrue   r350, L28
+  MakeList     r351, 0, r0
+  SetIndex     r342, r347, r351
+L28:
+  Index        r348, r342, r347
+  Append       r352, r348, r345
+  SetIndex     r342, r347, r352
+  Const        r353, 1
+  AddInt       r343, r343, r353
+  Jump         L29
+L27:
+  // join t in totals on g.i_class == t.class
+  Const        r354, 0
+L33:
+  LessInt      r355, r354, r268
+  JumpIfFalse  r355, L30
+  Index        r277, r267, r354
+  Const        r357, "class"
+  Index        r358, r277, r357
+  Index        r359, r342, r358
+  Const        r360, nil
+  NotEqual     r361, r359, r360
+  JumpIfFalse  r361, L31
+  Len          r362, r359
+  Const        r363, 0
+L32:
+  LessInt      r364, r363, r362
+  JumpIfFalse  r364, L31
+  Index        r132, r359, r363
+  // i_item_id: g.i_item_id,
+  Const        r366, "i_item_id"
+  Const        r367, "i_item_id"
+  Index        r368, r132, r367
+  // i_item_desc: g.i_item_desc,
+  Const        r369, "i_item_desc"
+  Const        r370, "i_item_desc"
+  Index        r371, r132, r370
+  // i_category: g.i_category,
+  Const        r372, "i_category"
+  Const        r373, "i_category"
+  Index        r374, r132, r373
+  // i_class: g.i_class,
+  Const        r375, "i_class"
+  Const        r376, "i_class"
+  Index        r377, r132, r376
+  // i_current_price: g.i_current_price,
+  Const        r378, "i_current_price"
+  Const        r379, "i_current_price"
+  Index        r380, r132, r379
+  // itemrevenue: g.itemrevenue,
+  Const        r381, "itemrevenue"
+  Const        r382, "itemrevenue"
+  Index        r383, r132, r382
+  // revenueratio: g.itemrevenue * 100 / t.total
+  Const        r384, "revenueratio"
+  Const        r385, "itemrevenue"
+  Index        r386, r132, r385
+  Const        r387, 100
+  Mul          r388, r386, r387
+  Const        r389, "total"
+  Index        r390, r277, r389
+  Div          r391, r388, r390
+  // i_item_id: g.i_item_id,
+  Move         r392, r366
+  Move         r393, r368
+  // i_item_desc: g.i_item_desc,
+  Move         r394, r369
+  Move         r395, r371
+  // i_category: g.i_category,
+  Move         r396, r372
+  Move         r397, r374
+  // i_class: g.i_class,
+  Move         r398, r375
+  Move         r399, r377
+  // i_current_price: g.i_current_price,
+  Move         r400, r378
+  Move         r401, r380
+  // itemrevenue: g.itemrevenue,
+  Move         r402, r381
+  Move         r403, r383
+  // revenueratio: g.itemrevenue * 100 / t.total
+  Move         r404, r384
+  Move         r405, r391
+  // select {
+  MakeMap      r406, 7, r392
+  // from g in grouped
+  Append       r264, r264, r406
+  // join t in totals on g.i_class == t.class
+  Const        r408, 1
+  AddInt       r363, r363, r408
+  Jump         L32
+L31:
+  Const        r409, 1
+  AddInt       r354, r354, r409
+  Jump         L33
+L30:
+  // json(result)
+  JSON         r264
+  // expect result == [
+  Const        r410, [{"i_category": "CatA", "i_class": "Class1", "i_current_price": 100, "i_item_desc": "desc1", "i_item_id": "I1", "itemrevenue": 50, "revenueratio": 33.333333333333336}, {"i_category": "CatB", "i_class": "Class1", "i_current_price": 200, "i_item_desc": "desc2", "i_item_id": "I2", "itemrevenue": 100, "revenueratio": 66.66666666666667}]
+  Equal        r411, r264, r410
+  Expect       r411
+  Return       r0

--- a/tests/dataset/tpc-ds/out/q99.ir.out
+++ b/tests/dataset/tpc-ds/out/q99.ir.out
@@ -1,0 +1,433 @@
+func main (regs=317)
+  // let catalog_sales = [
+  Const        r0, [{"cs_call_center_sk": 1, "cs_ship_date_sk": 31, "cs_ship_mode_sk": 1, "cs_sold_date_sk": 1, "cs_warehouse_sk": 1}, {"cs_call_center_sk": 1, "cs_ship_date_sk": 51, "cs_ship_mode_sk": 1, "cs_sold_date_sk": 1, "cs_warehouse_sk": 1}, {"cs_call_center_sk": 1, "cs_ship_date_sk": 71, "cs_ship_mode_sk": 1, "cs_sold_date_sk": 1, "cs_warehouse_sk": 1}, {"cs_call_center_sk": 1, "cs_ship_date_sk": 101, "cs_ship_mode_sk": 1, "cs_sold_date_sk": 1, "cs_warehouse_sk": 1}, {"cs_call_center_sk": 1, "cs_ship_date_sk": 131, "cs_ship_mode_sk": 1, "cs_sold_date_sk": 1, "cs_warehouse_sk": 1}]
+  // let warehouse = [{w_warehouse_sk: 1, w_warehouse_name: "Warehouse1"}]
+  Const        r1, [{"w_warehouse_name": "Warehouse1", "w_warehouse_sk": 1}]
+  // let ship_mode = [{sm_ship_mode_sk: 1, sm_type: "EXP"}]
+  Const        r2, [{"sm_ship_mode_sk": 1, "sm_type": "EXP"}]
+  // let call_center = [{cc_call_center_sk: 1, cc_name: "CC1"}]
+  Const        r3, [{"cc_call_center_sk": 1, "cc_name": "CC1"}]
+  // from cs in catalog_sales
+  Const        r4, []
+  // group by {warehouse: substr(w.w_warehouse_name,1,20), sm_type: sm.sm_type, cc_name: cc.cc_name} into g
+  Const        r5, "warehouse"
+  Const        r6, "w_warehouse_name"
+  Const        r7, "sm_type"
+  Const        r8, "sm_type"
+  Const        r9, "cc_name"
+  Const        r10, "cc_name"
+  // warehouse: g.key.warehouse,
+  Const        r11, "warehouse"
+  Const        r12, "key"
+  Const        r13, "warehouse"
+  // sm_type: g.key.sm_type,
+  Const        r14, "sm_type"
+  Const        r15, "key"
+  Const        r16, "sm_type"
+  // cc_name: g.key.cc_name,
+  Const        r17, "cc_name"
+  Const        r18, "key"
+  Const        r19, "cc_name"
+  // d30: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk <= 30 select x),
+  Const        r20, "d30"
+  Const        r21, "cs_ship_date_sk"
+  Const        r22, "cs_sold_date_sk"
+  // d60: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 30 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 60 select x),
+  Const        r23, "d60"
+  Const        r24, "cs_ship_date_sk"
+  Const        r25, "cs_sold_date_sk"
+  Const        r26, "cs_ship_date_sk"
+  Const        r27, "cs_sold_date_sk"
+  // d90: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 60 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 90 select x),
+  Const        r28, "d90"
+  Const        r29, "cs_ship_date_sk"
+  Const        r30, "cs_sold_date_sk"
+  Const        r31, "cs_ship_date_sk"
+  Const        r32, "cs_sold_date_sk"
+  // d120: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 90 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 120 select x),
+  Const        r33, "d120"
+  Const        r34, "cs_ship_date_sk"
+  Const        r35, "cs_sold_date_sk"
+  Const        r36, "cs_ship_date_sk"
+  Const        r37, "cs_sold_date_sk"
+  // dmore: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 120 select x)
+  Const        r38, "dmore"
+  Const        r39, "cs_ship_date_sk"
+  Const        r40, "cs_sold_date_sk"
+  // from cs in catalog_sales
+  MakeMap      r41, 0, r0
+  Const        r42, []
+  IterPrep     r44, r0
+  Len          r45, r44
+  Const        r46, 0
+L9:
+  LessInt      r47, r46, r45
+  JumpIfFalse  r47, L0
+  Index        r49, r44, r46
+  // join w in warehouse on cs.cs_warehouse_sk == w.w_warehouse_sk
+  IterPrep     r50, r1
+  Len          r51, r50
+  Const        r52, 0
+L8:
+  LessInt      r53, r52, r51
+  JumpIfFalse  r53, L1
+  Index        r55, r50, r52
+  Const        r56, "cs_warehouse_sk"
+  Index        r57, r49, r56
+  Const        r58, "w_warehouse_sk"
+  Index        r59, r55, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L2
+  // join sm in ship_mode on cs.cs_ship_mode_sk == sm.sm_ship_mode_sk
+  IterPrep     r61, r2
+  Len          r62, r61
+  Const        r63, 0
+L7:
+  LessInt      r64, r63, r62
+  JumpIfFalse  r64, L2
+  Index        r66, r61, r63
+  Const        r67, "cs_ship_mode_sk"
+  Index        r68, r49, r67
+  Const        r69, "sm_ship_mode_sk"
+  Index        r70, r66, r69
+  Equal        r71, r68, r70
+  JumpIfFalse  r71, L3
+  // join cc in call_center on cs.cs_call_center_sk == cc.cc_call_center_sk
+  IterPrep     r72, r3
+  Len          r73, r72
+  Const        r74, 0
+L6:
+  LessInt      r75, r74, r73
+  JumpIfFalse  r75, L3
+  Index        r77, r72, r74
+  Const        r78, "cs_call_center_sk"
+  Index        r79, r49, r78
+  Const        r80, "cc_call_center_sk"
+  Index        r81, r77, r80
+  Equal        r82, r79, r81
+  JumpIfFalse  r82, L4
+  // from cs in catalog_sales
+  Const        r83, "cs"
+  Move         r84, r49
+  Const        r85, "w"
+  Move         r86, r55
+  Const        r87, "sm"
+  Move         r88, r66
+  Const        r89, "cc"
+  Move         r90, r77
+  MakeMap      r91, 4, r83
+  // group by {warehouse: substr(w.w_warehouse_name,1,20), sm_type: sm.sm_type, cc_name: cc.cc_name} into g
+  Const        r92, "warehouse"
+  Const        r93, "w_warehouse_name"
+  Index        r94, r55, r93
+  Const        r95, 1
+  Const        r96, 20
+  Slice        r97, r94, r95, r96
+  Const        r98, "sm_type"
+  Const        r99, "sm_type"
+  Index        r100, r66, r99
+  Const        r101, "cc_name"
+  Const        r102, "cc_name"
+  Index        r103, r77, r102
+  Move         r104, r92
+  Move         r105, r97
+  Move         r106, r98
+  Move         r107, r100
+  Move         r108, r101
+  Move         r109, r103
+  MakeMap      r110, 3, r104
+  Str          r111, r110
+  In           r112, r111, r41
+  JumpIfTrue   r112, L5
+  // from cs in catalog_sales
+  Const        r113, []
+  Const        r114, "__group__"
+  Const        r115, true
+  Const        r116, "key"
+  // group by {warehouse: substr(w.w_warehouse_name,1,20), sm_type: sm.sm_type, cc_name: cc.cc_name} into g
+  Move         r117, r110
+  // from cs in catalog_sales
+  Const        r118, "items"
+  Move         r119, r113
+  Const        r120, "count"
+  Const        r121, 0
+  Move         r122, r114
+  Move         r123, r115
+  Move         r124, r116
+  Move         r125, r117
+  Move         r126, r118
+  Move         r127, r119
+  Move         r128, r120
+  Move         r129, r121
+  MakeMap      r130, 4, r122
+  SetIndex     r41, r111, r130
+  Append       r42, r42, r130
+L5:
+  Const        r132, "items"
+  Index        r133, r41, r111
+  Index        r134, r133, r132
+  Append       r135, r134, r91
+  SetIndex     r133, r132, r135
+  Const        r136, "count"
+  Index        r137, r133, r136
+  Const        r138, 1
+  AddInt       r139, r137, r138
+  SetIndex     r133, r136, r139
+L4:
+  // join cc in call_center on cs.cs_call_center_sk == cc.cc_call_center_sk
+  Const        r140, 1
+  AddInt       r74, r74, r140
+  Jump         L6
+L3:
+  // join sm in ship_mode on cs.cs_ship_mode_sk == sm.sm_ship_mode_sk
+  Const        r141, 1
+  AddInt       r63, r63, r141
+  Jump         L7
+L2:
+  // join w in warehouse on cs.cs_warehouse_sk == w.w_warehouse_sk
+  Const        r142, 1
+  AddInt       r52, r52, r142
+  Jump         L8
+L1:
+  // from cs in catalog_sales
+  Const        r143, 1
+  AddInt       r46, r46, r143
+  Jump         L9
+L0:
+  Const        r144, 0
+  Len          r146, r42
+L29:
+  LessInt      r147, r144, r146
+  JumpIfFalse  r147, L10
+  Index        r149, r42, r144
+  // warehouse: g.key.warehouse,
+  Const        r150, "warehouse"
+  Const        r151, "key"
+  Index        r152, r149, r151
+  Const        r153, "warehouse"
+  Index        r154, r152, r153
+  // sm_type: g.key.sm_type,
+  Const        r155, "sm_type"
+  Const        r156, "key"
+  Index        r157, r149, r156
+  Const        r158, "sm_type"
+  Index        r159, r157, r158
+  // cc_name: g.key.cc_name,
+  Const        r160, "cc_name"
+  Const        r161, "key"
+  Index        r162, r149, r161
+  Const        r163, "cc_name"
+  Index        r164, r162, r163
+  // d30: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk <= 30 select x),
+  Const        r165, "d30"
+  Const        r166, []
+  Const        r167, "cs_ship_date_sk"
+  Const        r168, "cs_sold_date_sk"
+  IterPrep     r169, r149
+  Len          r170, r169
+  Const        r171, 0
+L13:
+  LessInt      r173, r171, r170
+  JumpIfFalse  r173, L11
+  Index        r175, r169, r171
+  Const        r176, "cs_ship_date_sk"
+  Index        r177, r175, r176
+  Const        r178, "cs_sold_date_sk"
+  Index        r179, r175, r178
+  Sub          r180, r177, r179
+  Const        r181, 30
+  LessEq       r182, r180, r181
+  JumpIfFalse  r182, L12
+  Append       r166, r166, r175
+L12:
+  Const        r184, 1
+  AddInt       r171, r171, r184
+  Jump         L13
+L11:
+  Count        r185, r166
+  // d60: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 30 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 60 select x),
+  Const        r186, "d60"
+  Const        r187, []
+  Const        r188, "cs_ship_date_sk"
+  Const        r189, "cs_sold_date_sk"
+  Const        r190, "cs_ship_date_sk"
+  Const        r191, "cs_sold_date_sk"
+  IterPrep     r192, r149
+  Len          r193, r192
+  Const        r194, 0
+L17:
+  LessInt      r196, r194, r193
+  JumpIfFalse  r196, L14
+  Index        r175, r192, r194
+  Const        r198, "cs_ship_date_sk"
+  Index        r199, r175, r198
+  Const        r200, "cs_sold_date_sk"
+  Index        r201, r175, r200
+  Sub          r202, r199, r201
+  Const        r203, "cs_ship_date_sk"
+  Index        r204, r175, r203
+  Const        r205, "cs_sold_date_sk"
+  Index        r206, r175, r205
+  Sub          r207, r204, r206
+  Const        r208, 30
+  Less         r209, r208, r202
+  Const        r210, 60
+  LessEq       r211, r207, r210
+  Move         r212, r209
+  JumpIfFalse  r212, L15
+  Move         r212, r211
+L15:
+  JumpIfFalse  r212, L16
+  Append       r187, r187, r175
+L16:
+  Const        r214, 1
+  AddInt       r194, r194, r214
+  Jump         L17
+L14:
+  Count        r215, r187
+  // d90: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 60 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 90 select x),
+  Const        r216, "d90"
+  Const        r217, []
+  Const        r218, "cs_ship_date_sk"
+  Const        r219, "cs_sold_date_sk"
+  Const        r220, "cs_ship_date_sk"
+  Const        r221, "cs_sold_date_sk"
+  IterPrep     r222, r149
+  Len          r223, r222
+  Const        r224, 0
+L21:
+  LessInt      r226, r224, r223
+  JumpIfFalse  r226, L18
+  Index        r175, r222, r224
+  Const        r228, "cs_ship_date_sk"
+  Index        r229, r175, r228
+  Const        r230, "cs_sold_date_sk"
+  Index        r231, r175, r230
+  Sub          r232, r229, r231
+  Const        r233, "cs_ship_date_sk"
+  Index        r234, r175, r233
+  Const        r235, "cs_sold_date_sk"
+  Index        r236, r175, r235
+  Sub          r237, r234, r236
+  Const        r238, 60
+  Less         r239, r238, r232
+  Const        r240, 90
+  LessEq       r241, r237, r240
+  Move         r242, r239
+  JumpIfFalse  r242, L19
+  Move         r242, r241
+L19:
+  JumpIfFalse  r242, L20
+  Append       r217, r217, r175
+L20:
+  Const        r244, 1
+  AddInt       r224, r224, r244
+  Jump         L21
+L18:
+  Count        r245, r217
+  // d120: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 90 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 120 select x),
+  Const        r246, "d120"
+  Const        r247, []
+  Const        r248, "cs_ship_date_sk"
+  Const        r249, "cs_sold_date_sk"
+  Const        r250, "cs_ship_date_sk"
+  Const        r251, "cs_sold_date_sk"
+  IterPrep     r252, r149
+  Len          r253, r252
+  Const        r254, 0
+L25:
+  LessInt      r256, r254, r253
+  JumpIfFalse  r256, L22
+  Index        r175, r252, r254
+  Const        r258, "cs_ship_date_sk"
+  Index        r259, r175, r258
+  Const        r260, "cs_sold_date_sk"
+  Index        r261, r175, r260
+  Sub          r262, r259, r261
+  Const        r263, "cs_ship_date_sk"
+  Index        r264, r175, r263
+  Const        r265, "cs_sold_date_sk"
+  Index        r266, r175, r265
+  Sub          r267, r264, r266
+  Const        r268, 90
+  Less         r269, r268, r262
+  Const        r270, 120
+  LessEq       r271, r267, r270
+  Move         r272, r269
+  JumpIfFalse  r272, L23
+  Move         r272, r271
+L23:
+  JumpIfFalse  r272, L24
+  Append       r247, r247, r175
+L24:
+  Const        r274, 1
+  AddInt       r254, r254, r274
+  Jump         L25
+L22:
+  Count        r275, r247
+  // dmore: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 120 select x)
+  Const        r276, "dmore"
+  Const        r277, []
+  Const        r278, "cs_ship_date_sk"
+  Const        r279, "cs_sold_date_sk"
+  IterPrep     r280, r149
+  Len          r281, r280
+  Const        r282, 0
+L28:
+  LessInt      r284, r282, r281
+  JumpIfFalse  r284, L26
+  Index        r175, r280, r282
+  Const        r286, "cs_ship_date_sk"
+  Index        r287, r175, r286
+  Const        r288, "cs_sold_date_sk"
+  Index        r289, r175, r288
+  Sub          r290, r287, r289
+  Const        r291, 120
+  Less         r292, r291, r290
+  JumpIfFalse  r292, L27
+  Append       r277, r277, r175
+L27:
+  Const        r294, 1
+  AddInt       r282, r282, r294
+  Jump         L28
+L26:
+  Count        r295, r277
+  // warehouse: g.key.warehouse,
+  Move         r296, r150
+  Move         r297, r154
+  // sm_type: g.key.sm_type,
+  Move         r298, r155
+  Move         r299, r159
+  // cc_name: g.key.cc_name,
+  Move         r300, r160
+  Move         r301, r164
+  // d30: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk <= 30 select x),
+  Move         r302, r165
+  Move         r303, r185
+  // d60: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 30 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 60 select x),
+  Move         r304, r186
+  Move         r305, r215
+  // d90: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 60 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 90 select x),
+  Move         r306, r216
+  Move         r307, r245
+  // d120: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 90 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 120 select x),
+  Move         r308, r246
+  Move         r309, r275
+  // dmore: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 120 select x)
+  Move         r310, r276
+  Move         r311, r295
+  // select {
+  MakeMap      r312, 8, r296
+  // from cs in catalog_sales
+  Append       r4, r4, r312
+  Const        r314, 1
+  AddInt       r144, r144, r314
+  Jump         L29
+L10:
+  // json(grouped)
+  JSON         r4
+  // expect grouped == [{warehouse: "Warehouse1", sm_type: "EXP", cc_name: "CC1", d30: 1, d60: 1, d90: 1, d120: 1, dmore: 1}]
+  Const        r315, [{"cc_name": "CC1", "d120": 1, "d30": 1, "d60": 1, "d90": 1, "dmore": 1, "sm_type": "EXP", "warehouse": "Warehouse1"}]
+  Equal        r316, r4, r315
+  Expect       r316
+  Return       r0

--- a/tests/dataset/tpc-ds/q90.mochi
+++ b/tests/dataset/tpc-ds/q90.mochi
@@ -20,7 +20,7 @@ let amc =
         join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
         where t.t_hour >= 7 && t.t_hour <= 8 &&
               hd.hd_dep_count == 2 &&
-              wp.wp_char_count between 5000 && 5200
+              wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
         select ws)
 
 let pmc =
@@ -30,10 +30,10 @@ let pmc =
         join wp in web_page on ws.ws_web_page_sk == wp.wp_web_page_sk
         where t.t_hour >= 14 && t.t_hour <= 15 &&
               hd.hd_dep_count == 2 &&
-              wp.wp_char_count between 5000 && 5200
+              wp.wp_char_count >= 5000 && wp.wp_char_count <= 5200
         select ws)
 
-let result = float(amc) / float(pmc)
+let result = (amc as float) / (pmc as float)
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q91.mochi
+++ b/tests/dataset/tpc-ds/q91.mochi
@@ -25,7 +25,7 @@ let customer_demographics = [{cd_demo_sk: 1, cd_marital_status: "M", cd_educatio
 let household_demographics = [{hd_demo_sk: 1, hd_buy_potential: "1001-5000"}]
 let customer_address = [{ca_address_sk: 1, ca_gmt_offset: -6}]
 
-let result =
+let result = first(
   from cc in call_center
   join cr in catalog_returns on cc.cc_call_center_sk == cr.cr_call_center_sk
   join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
@@ -35,14 +35,14 @@ let result =
   join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
   where d.d_year == 2001 && d.d_moy == 5 &&
         cd.cd_marital_status == "M" && cd.cd_education_status == "Unknown" &&
-        hd.hd_buy_potential == "1001-5000" && ca.ca_gmt_offset == -6
+        hd.hd_buy_potential == "1001-5000" && ca.ca_gmt_offset == (-6)
   group by {id: cc.cc_call_center_id, name: cc.cc_name, mgr: cc.cc_manager} into g
   select {
     Call_Center: g.key.id,
     Call_Center_Name: g.key.name,
     Manager: g.key.mgr,
     Returns_Loss: sum(from x in g select x.cr_net_loss)
-  } |> first
+  })
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q93.mochi
+++ b/tests/dataset/tpc-ds/q93.mochi
@@ -27,7 +27,7 @@ let t =
 let result =
   from x in t
   group by x.ss_customer_sk into g
-  select {ss_customer_sk: g.key, sumsales: sum(from y in g select y.act_sales)} |> collect
+  select {ss_customer_sk: g.key, sumsales: sum(from y in g select y.act_sales)}
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q94.mochi
+++ b/tests/dataset/tpc-ds/q94.mochi
@@ -15,17 +15,27 @@ let date_dim = [{d_date_sk: 1, d_date: "2001-02-01"}]
 let customer_address = [{ca_address_sk: 1, ca_state: "CA"}]
 let web_site = [{web_site_sk: 1, web_company_name: "pri"}]
 
+fun distinct(xs: list<any>): list<any> {
+  var out = []
+  for x in xs {
+    if !contains(out, x) {
+      out = append(out, x)
+    }
+  }
+  return out
+}
+
 let filtered =
   from ws in web_sales
   join d in date_dim on ws.ws_ship_date_sk == d.d_date_sk
   join ca in customer_address on ws.ws_ship_addr_sk == ca.ca_address_sk
   join w in web_site on ws.ws_web_site_sk == w.web_site_sk
   where ca.ca_state == "CA" && w.web_company_name == "pri" &&
-        not exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr)
+        exists(from wr in web_returns where wr.wr_order_number == ws.ws_order_number select wr) == false
   select ws
 
 let result = {
-  order_count: count(distinct from x in filtered select x.ws_order_number),
+  order_count: len(distinct(from x in filtered select x.ws_order_number)),
   total_shipping_cost: sum(from x in filtered select x.ws_ext_ship_cost),
   total_net_profit: sum(from x in filtered select x.ws_net_profit)
 }

--- a/tests/dataset/tpc-ds/q95.mochi
+++ b/tests/dataset/tpc-ds/q95.mochi
@@ -5,6 +5,16 @@ type DateDim { d_date_sk: int, d_date: string }
 type CustomerAddress { ca_address_sk: int, ca_state: string }
 type WebSite { web_site_sk: int, web_company_name: string }
 
+fun distinct(xs: list<any>): list<any> {
+  var out = []
+  for x in xs {
+    if !contains(out, x) {
+      out = append(out, x)
+    }
+  }
+  return out
+}
+
 let web_sales = [
   {ws_order_number: 1, ws_warehouse_sk: 1, ws_ship_date_sk: 1, ws_ship_addr_sk: 1, ws_web_site_sk: 1, ws_ext_ship_cost: 2.0, ws_net_profit: 5.0},
   {ws_order_number: 1, ws_warehouse_sk: 2, ws_ship_date_sk: 1, ws_ship_addr_sk: 1, ws_web_site_sk: 1, ws_ext_ship_cost: 0.0, ws_net_profit: 0.0}
@@ -32,7 +42,7 @@ let filtered =
   select ws
 
 let result = {
-  order_count: count(distinct from x in filtered select x.ws_order_number),
+  order_count: len(distinct(from x in filtered select x.ws_order_number)),
   total_shipping_cost: sum(from x in filtered select x.ws_ext_ship_cost),
   total_net_profit: sum(from x in filtered select x.ws_net_profit)
 }

--- a/tests/dataset/tpc-ds/q97.mochi
+++ b/tests/dataset/tpc-ds/q97.mochi
@@ -16,7 +16,7 @@ let ssci = from ss in store_sales group by {customer_sk: ss.ss_customer_sk, item
 let csci = from cs in catalog_sales group by {customer_sk: cs.cs_bill_customer_sk, item_sk: cs.cs_item_sk} into g select {customer_sk: g.key.customer_sk, item_sk: g.key.item_sk}
 
 let joined =
-  from s in ssci full join c in csci on s.customer_sk == c.customer_sk && s.item_sk == c.item_sk
+  from s in ssci outer join c in csci on s.customer_sk == c.customer_sk && s.item_sk == c.item_sk
   select {
     store_only: if s.customer_sk != null && c.customer_sk == null {1} else {0},
     catalog_only: if s.customer_sk == null && c.customer_sk != null {1} else {0},
@@ -32,5 +32,7 @@ let result = {
 json(result)
 
 test "TPCDS Q97 overlap" {
-  expect result == {store_only: 1, catalog_only: 1, store_and_catalog: 1}
+  expect result.store_only == 1 &&
+         result.catalog_only == 1 &&
+         result.store_and_catalog == 1
 }

--- a/tests/dataset/tpc-ds/q98.mochi
+++ b/tests/dataset/tpc-ds/q98.mochi
@@ -32,12 +32,20 @@ let grouped =
 let totals =
   from g in grouped
   group by g.i_class into cg
-  select {class: cg.key, total: sum(from x in cg select x.itemrevenue)} |> collect
+  select {class: cg.key, total: sum(from x in cg select x.itemrevenue)}
 
 let result =
   from g in grouped
   join t in totals on g.i_class == t.class
-  select merge(g, {revenueratio: g.itemrevenue * 100 / t.total}) |> collect
+  select {
+    i_item_id: g.i_item_id,
+    i_item_desc: g.i_item_desc,
+    i_category: g.i_category,
+    i_class: g.i_class,
+    i_current_price: g.i_current_price,
+    itemrevenue: g.itemrevenue,
+    revenueratio: g.itemrevenue * 100 / t.total
+  }
 
 json(result)
 

--- a/tests/dataset/tpc-ds/q99.mochi
+++ b/tests/dataset/tpc-ds/q99.mochi
@@ -31,7 +31,7 @@ let grouped =
     d90: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 60 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 90 select x),
     d120: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 90 && x.cs_ship_date_sk - x.cs_sold_date_sk <= 120 select x),
     dmore: count(from x in g where x.cs_ship_date_sk - x.cs_sold_date_sk > 120 select x)
-  } |> collect
+  }
 
 json(grouped)
 


### PR DESCRIPTION
## Summary
- add new `OpDistinct` to runtime/vm
- support `distinct()` builtin in the VM
- tweak TPC‑DS queries Q90–Q99 for existing syntax
- regenerate IR outputs for Q90–Q99

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6862452e6db88320a5a0bad641c33fbf