### PR TITLE
Add lower(any) and expand tpc-ds tests

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -782,6 +782,7 @@ func evalUnaryConst(op Op, v Value) (Value, bool) {
 		if v.Tag == ValueStr {
 			return Value{Tag: ValueStr, Str: strings.ToLower(v.Str)}, true
 		}
+		return Value{Tag: ValueStr, Str: strings.ToLower(fmt.Sprint(valueToAny(v)))}, true
 	case OpFirst:
 		if lst, ok := toList(v); ok {
 			if len(lst) > 0 {

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1131,10 +1131,11 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToUpper(b.Str)}
 		case OpLower:
 			b := fr.regs[ins.B]
-			if b.Tag != ValueStr {
-				return Value{}, m.newError(fmt.Errorf("lower expects string"), trace, ins.Line)
+			if b.Tag == ValueStr {
+				fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToLower(b.Str)}
+			} else {
+				fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToLower(fmt.Sprint(valueToAny(b)))}
 			}
-			fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToLower(b.Str)}
 		case OpReverse:
 			lst := fr.regs[ins.B]
 			if lst.Tag != ValueList {

--- a/tests/dataset/tpc-ds/out/q50.ir.out
+++ b/tests/dataset/tpc-ds/out/q50.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 50}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 50

--- a/tests/dataset/tpc-ds/out/q51.ir.out
+++ b/tests/dataset/tpc-ds/out/q51.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 51}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 51

--- a/tests/dataset/tpc-ds/out/q52.ir.out
+++ b/tests/dataset/tpc-ds/out/q52.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 52}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 52

--- a/tests/dataset/tpc-ds/out/q53.ir.out
+++ b/tests/dataset/tpc-ds/out/q53.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 53}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 53

--- a/tests/dataset/tpc-ds/out/q54.ir.out
+++ b/tests/dataset/tpc-ds/out/q54.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 54}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 54

--- a/tests/dataset/tpc-ds/out/q55.ir.out
+++ b/tests/dataset/tpc-ds/out/q55.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 55}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 55

--- a/tests/dataset/tpc-ds/out/q56.ir.out
+++ b/tests/dataset/tpc-ds/out/q56.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 56}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 56

--- a/tests/dataset/tpc-ds/out/q57.ir.out
+++ b/tests/dataset/tpc-ds/out/q57.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 57}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 57

--- a/tests/dataset/tpc-ds/out/q58.ir.out
+++ b/tests/dataset/tpc-ds/out/q58.ir.out
@@ -3,7 +3,7 @@ func main (regs=19)
   Const        r0, [{"id": 1, "val": 58}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Lower        2,1,0,0
+  Const        r2, "ignore"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 58

--- a/tests/dataset/tpc-ds/out/q59.ir.out
+++ b/tests/dataset/tpc-ds/out/q59.ir.out
@@ -1,9 +1,9 @@
 func main (regs=19)
   // let t = [{id: 1, val: 59}]
   Const        r0, [{"id": 1, "val": 59}]
-  // let tmp = lower("ignore")
-  Const        r1, "ignore"
-  Lower        2,1,0,0
+  // let tmp = lower(59)
+  Const        r1, 59
+  Const        r2, "59"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"
@@ -22,7 +22,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(vals)
-  First        16,3,0,0
+  First        r16, r3
   // json(result)
   JSON         r16
   // expect result == 59

--- a/tests/dataset/tpc-ds/q59.mochi
+++ b/tests/dataset/tpc-ds/q59.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 59}]
-let tmp = lower("ignore")
+let tmp = lower(59)
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/tests/vm/vm_test.go
+++ b/tests/vm/vm_test.go
@@ -204,7 +204,7 @@ func TestVM_TPCH(t *testing.T) {
 
 func TestVM_TPCDS(t *testing.T) {
 	root := findRepoRoot(t)
-	queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19", "q20", "q21", "q22", "q23", "q24", "q25", "q26", "q27", "q28", "q29", "q40", "q41", "q42", "q43", "q44", "q45", "q46", "q47", "q48", "q49"}
+	queries := []string{"q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19", "q20", "q21", "q22", "q23", "q24", "q25", "q26", "q27", "q28", "q29", "q40", "q41", "q42", "q43", "q44", "q45", "q46", "q47", "q48", "q49", "q50", "q51", "q52", "q53", "q54", "q55", "q56", "q57", "q58", "q59"}
 	found := false
 	for _, q := range queries {
 		src := filepath.Join(root, "tests/dataset/tpc-ds", q+".mochi")

--- a/types/check.go
+++ b/types/check.go
@@ -415,7 +415,7 @@ func Check(prog *parser.Program, env *Env) []error {
 		Pure:   true,
 	}, false)
 	env.SetVar("lower", FuncType{
-		Params: []Type{StringType{}},
+		Params: []Type{AnyType{}},
 		Return: StringType{},
 		Pure:   true,
 	}, false)


### PR DESCRIPTION
## Summary
- relax builtin `lower` typing to accept any type and stringifies at runtime
- fold `lower` calls on constants during liveness
- update tpc-ds q59 example to use `lower` on an int
- run tpc-ds query 50-59 in the slow VM tests
- refresh IR output for tpc-ds queries

## Testing
- `go test ./tests/vm -tags slow -run TestVM_TPCDS -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686245fb6f28832087c1312e6ebb25db