### PR TITLE
Fix Reverse disassembly and update tpc-ds IR

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -442,6 +442,12 @@ func (p *Program) Disassemble(src string) string {
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpStr:
 				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
+			case OpUpper:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
+			case OpLower:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
+			case OpReverse:
+				fmt.Fprintf(&b, "%s, %s", formatReg(ins.A), formatReg(ins.B))
 			case OpInput:
 				fmt.Fprintf(&b, "%s", formatReg(ins.A))
 			case OpIterPrep:

--- a/tests/dataset/tpc-ds/out/q11.ir.out
+++ b/tests/dataset/tpc-ds/out/q11.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q12.ir.out
+++ b/tests/dataset/tpc-ds/out/q12.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q13.ir.out
+++ b/tests/dataset/tpc-ds/out/q13.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q14.ir.out
+++ b/tests/dataset/tpc-ds/out/q14.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q15.ir.out
+++ b/tests/dataset/tpc-ds/out/q15.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q16.ir.out
+++ b/tests/dataset/tpc-ds/out/q16.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q17.ir.out
+++ b/tests/dataset/tpc-ds/out/q17.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q18.ir.out
+++ b/tests/dataset/tpc-ds/out/q18.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15

--- a/tests/dataset/tpc-ds/out/q19.ir.out
+++ b/tests/dataset/tpc-ds/out/q19.ir.out
@@ -19,7 +19,7 @@ L1:
   Jump         L1
 L0:
   // let result = first(reverse(vals))
-  Reverse      14,1,0,0
+  Reverse      r14, r1
   First        r15, r14
   // json(result)
   JSON         r15


### PR DESCRIPTION
## Summary
- add `OpReverse` disassembly case in `runtime/vm`
- regenerate IR for TPC‑DS queries q11–q19 using updated VM

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862472acfa08320ae676625fa3c1574