### PR TITLE
Add string support for reverse builtin

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1037,48 +1037,48 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			newList := append(append([]Value(nil), lst.List...), fr.regs[ins.C])
 			fr.regs[ins.A] = Value{Tag: ValueList, List: newList}
-               case OpUnionAll:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
-                        }
-                        out := append(append([]Value(nil), a.List...), b.List...)
-                        fr.regs[ins.A] = Value{Tag: ValueList, List: out}
-               case OpUnion:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
-                        }
+		case OpUnionAll:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
+			}
+			out := append(append([]Value(nil), a.List...), b.List...)
+			fr.regs[ins.A] = Value{Tag: ValueList, List: out}
+		case OpUnion:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
+			}
 			seen := make(map[string]struct{}, len(a.List)+len(b.List))
 			out := make([]Value, 0, len(a.List)+len(b.List))
 			for _, v := range a.List {
@@ -1096,26 +1096,26 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				}
 			}
 			fr.regs[ins.A] = Value{Tag: ValueList, List: out}
-               case OpExcept:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("except expects lists"), trace, ins.Line)
-                        }
+		case OpExcept:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("except expects lists"), trace, ins.Line)
+			}
 			set := make(map[string]struct{}, len(b.List))
 			for _, v := range b.List {
 				set[valueToString(v)] = struct{}{}
@@ -1127,26 +1127,26 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				}
 			}
 			fr.regs[ins.A] = Value{Tag: ValueList, List: diff}
-               case OpIntersect:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("intersect expects lists"), trace, ins.Line)
-                        }
+		case OpIntersect:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("intersect expects lists"), trace, ins.Line)
+			}
 			setA := make(map[string]struct{}, len(a.List))
 			for _, v := range a.List {
 				setA[valueToString(v)] = struct{}{}
@@ -1222,15 +1222,23 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToLower(fmt.Sprint(valueToAny(b)))}
 			}
 		case OpReverse:
-			lst := fr.regs[ins.B]
-			if lst.Tag != ValueList {
-				return Value{}, m.newError(fmt.Errorf("reverse expects list"), trace, ins.Line)
+			val := fr.regs[ins.B]
+			switch val.Tag {
+			case ValueList:
+				newList := append([]Value(nil), val.List...)
+				for i, j := 0, len(newList)-1; i < j; i, j = i+1, j-1 {
+					newList[i], newList[j] = newList[j], newList[i]
+				}
+				fr.regs[ins.A] = Value{Tag: ValueList, List: newList}
+			case ValueStr:
+				r := []rune(val.Str)
+				for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+					r[i], r[j] = r[j], r[i]
+				}
+				fr.regs[ins.A] = Value{Tag: ValueStr, Str: string(r)}
+			default:
+				return Value{}, m.newError(fmt.Errorf("reverse expects list or string"), trace, ins.Line)
 			}
-			newList := append([]Value(nil), lst.List...)
-			for i, j := 0, len(newList)-1; i < j; i, j = i+1, j-1 {
-				newList[i], newList[j] = newList[j], newList[i]
-			}
-			fr.regs[ins.A] = Value{Tag: ValueList, List: newList}
 		case OpInput:
 			line, err := m.reader.ReadString('\n')
 			if err != nil && err != io.EOF {

--- a/tests/dataset/tpc-ds/out/q8.ir.out
+++ b/tests/dataset/tpc-ds/out/q8.ir.out
@@ -1,4 +1,4 @@
-func main (regs=10)
+func main (regs=11)
   // let store_sales = []
   Const        r0, []
   // let date_dim = []
@@ -9,15 +9,16 @@ func main (regs=10)
   Const        r3, []
   // let customer = []
   Const        r4, []
-  // substr("zip", 0, 2)
+  // reverse(substr("zip", 0, 2))
   Const        r5, "zi"
+  Reverse      r6, r5
   // let result = []
-  Const        r6, []
+  Const        r7, []
   // json(result)
-  JSON         r6
+  JSON         r7
   // expect len(result) == 0
-  Const        r7, 0
   Const        r8, 0
-  Const        r9, true
-  Expect       r9
+  Const        r9, 0
+  Const        r10, true
+  Expect       r10
   Return       r0

--- a/tests/dataset/tpc-ds/q8.mochi
+++ b/tests/dataset/tpc-ds/q8.mochi
@@ -4,8 +4,8 @@ let store = []
 let customer_address = []
 let customer = []
 
-// exercise substr builtin
-substr("zip", 0, 2)
+// exercise substr and reverse builtins
+reverse(substr("zip", 0, 2))
 
 let result = []
 json(result)

--- a/types/check.go
+++ b/types/check.go
@@ -366,8 +366,8 @@ func Check(prog *parser.Program, env *Env) []error {
 		Pure:   true,
 	}, false)
 	env.SetVar("reverse", FuncType{
-		Params: []Type{ListType{Elem: AnyType{}}},
-		Return: ListType{Elem: AnyType{}},
+		Params: []Type{AnyType{}},
+		Return: AnyType{},
 		Pure:   true,
 	}, false)
 	env.SetVar("push", FuncType{
@@ -2357,12 +2357,12 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 		if len(args) != 1 {
 			return errArgCount(pos, name, 1, len(args))
 		}
-		if _, ok := args[0].(ListType); !ok {
-			if _, ok := args[0].(AnyType); !ok {
-				return fmt.Errorf("reverse() expects list, got %v", args[0])
-			}
+		switch args[0].(type) {
+		case ListType, StringType, AnyType:
+			return nil
+		default:
+			return fmt.Errorf("reverse() expects list or string, got %v", args[0])
 		}
-		return nil
 	case "substring":
 		if len(args) != 3 {
 			return errArgCount(pos, name, 3, len(args))


### PR DESCRIPTION
## Summary
- support reversing strings in the VM
- loosen type checking to accept strings in `reverse`
- demo `reverse(substr(...))` in TPC‑DS q8
- update q8 IR output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68624d5d4c688320a0e465fa11d9c152