### PR TITLE
Add upper support for any type

### DIFF
--- a/runtime/vm/liveness.go
+++ b/runtime/vm/liveness.go
@@ -778,6 +778,7 @@ func evalUnaryConst(op Op, v Value) (Value, bool) {
 		if v.Tag == ValueStr {
 			return Value{Tag: ValueStr, Str: strings.ToUpper(v.Str)}, true
 		}
+		return Value{Tag: ValueStr, Str: strings.ToUpper(fmt.Sprint(valueToAny(v)))}, true
 	case OpLower:
 		if v.Tag == ValueStr {
 			return Value{Tag: ValueStr, Str: strings.ToLower(v.Str)}, true

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1037,48 +1037,48 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			}
 			newList := append(append([]Value(nil), lst.List...), fr.regs[ins.C])
 			fr.regs[ins.A] = Value{Tag: ValueList, List: newList}
-               case OpUnionAll:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
-                        }
-                        out := append(append([]Value(nil), a.List...), b.List...)
-                        fr.regs[ins.A] = Value{Tag: ValueList, List: out}
-               case OpUnion:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
-                        }
+		case OpUnionAll:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
+			}
+			out := append(append([]Value(nil), a.List...), b.List...)
+			fr.regs[ins.A] = Value{Tag: ValueList, List: out}
+		case OpUnion:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
+			}
 			seen := make(map[string]struct{}, len(a.List)+len(b.List))
 			out := make([]Value, 0, len(a.List)+len(b.List))
 			for _, v := range a.List {
@@ -1096,26 +1096,26 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				}
 			}
 			fr.regs[ins.A] = Value{Tag: ValueList, List: out}
-               case OpExcept:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("except expects lists"), trace, ins.Line)
-                        }
+		case OpExcept:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("except expects lists"), trace, ins.Line)
+			}
 			set := make(map[string]struct{}, len(b.List))
 			for _, v := range b.List {
 				set[valueToString(v)] = struct{}{}
@@ -1127,26 +1127,26 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				}
 			}
 			fr.regs[ins.A] = Value{Tag: ValueList, List: diff}
-               case OpIntersect:
-                        a := fr.regs[ins.B]
-                        if a.Tag == ValueNull {
-                                a = Value{Tag: ValueList}
-                        } else if a.Tag == ValueMap {
-                                if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        a = a.Map["items"]
-                                }
-                        }
-                        b := fr.regs[ins.C]
-                        if b.Tag == ValueNull {
-                                b = Value{Tag: ValueList}
-                        } else if b.Tag == ValueMap {
-                                if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
-                                        b = b.Map["items"]
-                                }
-                        }
-                        if a.Tag != ValueList || b.Tag != ValueList {
-                                return Value{}, m.newError(fmt.Errorf("intersect expects lists"), trace, ins.Line)
-                        }
+		case OpIntersect:
+			a := fr.regs[ins.B]
+			if a.Tag == ValueNull {
+				a = Value{Tag: ValueList}
+			} else if a.Tag == ValueMap {
+				if flag, ok := a.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					a = a.Map["items"]
+				}
+			}
+			b := fr.regs[ins.C]
+			if b.Tag == ValueNull {
+				b = Value{Tag: ValueList}
+			} else if b.Tag == ValueMap {
+				if flag, ok := b.Map["__group__"]; ok && flag.Tag == ValueBool && flag.Bool {
+					b = b.Map["items"]
+				}
+			}
+			if a.Tag != ValueList || b.Tag != ValueList {
+				return Value{}, m.newError(fmt.Errorf("intersect expects lists"), trace, ins.Line)
+			}
 			setA := make(map[string]struct{}, len(a.List))
 			for _, v := range a.List {
 				setA[valueToString(v)] = struct{}{}
@@ -1210,10 +1210,11 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: fmt.Sprint(valueToAny(fr.regs[ins.B]))}
 		case OpUpper:
 			b := fr.regs[ins.B]
-			if b.Tag != ValueStr {
-				return Value{}, m.newError(fmt.Errorf("upper expects string"), trace, ins.Line)
+			if b.Tag == ValueStr {
+				fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToUpper(b.Str)}
+			} else {
+				fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToUpper(fmt.Sprint(valueToAny(b)))}
 			}
-			fr.regs[ins.A] = Value{Tag: ValueStr, Str: strings.ToUpper(b.Str)}
 		case OpLower:
 			b := fr.regs[ins.B]
 			if b.Tag == ValueStr {

--- a/tests/dataset/tpc-ds/out/q50.ir.out
+++ b/tests/dataset/tpc-ds/out/q50.ir.out
@@ -1,9 +1,9 @@
 func main (regs=19)
   // let t = [{id: 1, val: 50}]
   Const        r0, [{"id": 1, "val": 50}]
-  // let tmp = lower("ignore")
-  Const        r1, "ignore"
-  Const        r2, "ignore"
+  // let tmp = upper(50)
+  Const        r1, 50
+  Const        r2, "50"
   // let vals = from r in t select r.val
   Const        r3, []
   Const        r4, "val"

--- a/tests/dataset/tpc-ds/q50.mochi
+++ b/tests/dataset/tpc-ds/q50.mochi
@@ -1,5 +1,5 @@
 let t = [{id: 1, val: 50}]
-let tmp = lower("ignore")
+let tmp = upper(50)
 let vals = from r in t select r.val
 let result = first(vals)
 json(result)

--- a/types/check.go
+++ b/types/check.go
@@ -410,7 +410,7 @@ func Check(prog *parser.Program, env *Env) []error {
 		Pure:   true,
 	}, false)
 	env.SetVar("upper", FuncType{
-		Params: []Type{StringType{}},
+		Params: []Type{AnyType{}},
 		Return: StringType{},
 		Pure:   true,
 	}, false)


### PR DESCRIPTION
## Summary
- allow `upper` to operate on non-string inputs similar to `lower`
- update type checker for `upper`
- test new behaviour using TPC-DS q50
- regenerate q50 IR output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68625059b370832083e6d706091736a5