### PR TITLE
Update tpch IR and skip move propagation into jumps

### DIFF
--- a/tests/dataset/tpc-h/out/q1.ir.out
+++ b/tests/dataset/tpc-h/out/q1.ir.out
@@ -1,4 +1,4 @@
-func main (regs=236)
+func main (regs=296)
   // let lineitem = [
   Const        r0, [{"l_discount": 0.05, "l_extendedprice": 1000, "l_linestatus": "O", "l_quantity": 17, "l_returnflag": "N", "l_shipdate": "1998-08-01", "l_tax": 0.07}, {"l_discount": 0.1, "l_extendedprice": 2000, "l_linestatus": "O", "l_quantity": 36, "l_returnflag": "N", "l_shipdate": "1998-09-01", "l_tax": 0.05}, {"l_discount": 0, "l_extendedprice": 1500, "l_linestatus": "F", "l_quantity": 25, "l_returnflag": "R", "l_shipdate": "1998-09-03", "l_tax": 0.08}]
   // from row in lineitem
@@ -12,340 +12,399 @@ func main (regs=236)
   // where row.l_shipdate <= "1998-09-02"
   Const        r6, "l_shipdate"
   // returnflag: g.key.returnflag,
-  Const        r7, "key"
+  Const        r7, "returnflag"
+  Const        r8, "key"
+  Const        r9, "returnflag"
+  // linestatus: g.key.linestatus,
+  Const        r10, "linestatus"
+  Const        r11, "key"
+  Const        r12, "linestatus"
   // sum_qty: sum(from x in g select x.l_quantity),
-  Const        r8, "sum_qty"
-  Const        r9, "l_quantity"
+  Const        r13, "sum_qty"
+  Const        r14, "l_quantity"
   // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Const        r10, "sum_base_price"
-  Const        r11, "l_extendedprice"
+  Const        r15, "sum_base_price"
+  Const        r16, "l_extendedprice"
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Const        r12, "sum_disc_price"
-  Const        r13, "l_discount"
+  Const        r17, "sum_disc_price"
+  Const        r18, "l_extendedprice"
+  Const        r19, "l_discount"
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Const        r14, "sum_charge"
-  Const        r15, "l_tax"
+  Const        r20, "sum_charge"
+  Const        r21, "l_extendedprice"
+  Const        r22, "l_discount"
+  Const        r23, "l_tax"
   // avg_qty: avg(from x in g select x.l_quantity),
-  Const        r16, "avg_qty"
+  Const        r24, "avg_qty"
+  Const        r25, "l_quantity"
   // avg_price: avg(from x in g select x.l_extendedprice),
-  Const        r17, "avg_price"
+  Const        r26, "avg_price"
+  Const        r27, "l_extendedprice"
   // avg_disc: avg(from x in g select x.l_discount),
-  Const        r18, "avg_disc"
+  Const        r28, "avg_disc"
+  Const        r29, "l_discount"
   // count_order: count(g)
-  Const        r19, "count_order"
+  Const        r30, "count_order"
   // from row in lineitem
-  IterPrep     r20, r0
-  Len          r21, r20
-  Const        r22, 0
-  MakeMap      r23, 0, r0
-  Move         r24, r1
+  IterPrep     r31, r0
+  Len          r32, r31
+  Const        r33, 0
+  MakeMap      r34, 0, r0
+  Const        r35, []
 L3:
-  LessInt      r26, r22, r21
-  JumpIfFalse  r26, L0
-  Index        r27, r20, r22
-  Move         r28, r27
+  LessInt      r37, r33, r32
+  JumpIfFalse  r37, L0
+  Index        r38, r31, r33
+  Move         r39, r38
   // where row.l_shipdate <= "1998-09-02"
-  Index        r29, r28, r6
-  Const        r30, "1998-09-02"
-  LessEq       r31, r29, r30
-  JumpIfFalse  r31, L1
+  Const        r40, "l_shipdate"
+  Index        r41, r39, r40
+  Const        r42, "1998-09-02"
+  LessEq       r43, r41, r42
+  JumpIfFalse  r43, L1
   // returnflag: row.l_returnflag,
-  Move         r32, r2
-  Index        r33, r28, r3
+  Const        r44, "returnflag"
+  Const        r45, "l_returnflag"
+  Index        r46, r39, r45
   // linestatus: row.l_linestatus
-  Move         r34, r4
-  Index        r35, r28, r5
+  Const        r47, "linestatus"
+  Const        r48, "l_linestatus"
+  Index        r49, r39, r48
   // returnflag: row.l_returnflag,
-  Move         r36, r32
-  Move         r37, r33
+  Move         r50, r44
+  Move         r51, r46
   // linestatus: row.l_linestatus
-  Move         r38, r34
-  Move         r39, r35
+  Move         r52, r47
+  Move         r53, r49
   // group by {
-  MakeMap      r40, 2, r36
-  Str          r41, r40
-  In           r42, r41, r23
-  JumpIfTrue   r42, L2
+  MakeMap      r54, 2, r50
+  Str          r55, r54
+  In           r56, r55, r34
+  JumpIfTrue   r56, L2
   // from row in lineitem
-  Move         r43, r1
-  Const        r44, "__group__"
-  Const        r45, true
-  Move         r46, r7
+  Const        r57, []
+  Const        r58, "__group__"
+  Const        r59, true
+  Const        r60, "key"
   // group by {
-  Move         r47, r40
+  Move         r61, r54
   // from row in lineitem
-  Const        r48, "items"
-  Move         r49, r43
-  Const        r50, "count"
-  Move         r51, r22
-  Move         r52, r44
-  Move         r53, r45
-  Move         r54, r46
-  Move         r55, r47
-  Move         r56, r48
-  Move         r57, r49
-  Move         r58, r50
-  Move         r59, r51
-  MakeMap      r60, 4, r52
-  SetIndex     r23, r41, r60
-  Append       r24, r24, r60
+  Const        r62, "items"
+  Move         r63, r57
+  Const        r64, "count"
+  Const        r65, 0
+  Move         r66, r58
+  Move         r67, r59
+  Move         r68, r60
+  Move         r69, r61
+  Move         r70, r62
+  Move         r71, r63
+  Move         r72, r64
+  Move         r73, r65
+  MakeMap      r74, 4, r66
+  SetIndex     r34, r55, r74
+  Append       r35, r35, r74
 L2:
-  Move         r62, r48
-  Index        r63, r23, r41
-  Index        r64, r63, r62
-  Append       r65, r64, r27
-  SetIndex     r63, r62, r65
-  Move         r66, r50
-  Index        r67, r63, r66
-  Const        r68, 1
-  AddInt       r69, r67, r68
-  SetIndex     r63, r66, r69
+  Const        r76, "items"
+  Index        r77, r34, r55
+  Index        r78, r77, r76
+  Append       r79, r78, r38
+  SetIndex     r77, r76, r79
+  Const        r80, "count"
+  Index        r81, r77, r80
+  Const        r82, 1
+  AddInt       r83, r81, r82
+  SetIndex     r77, r80, r83
 L1:
-  AddInt       r22, r22, r68
+  Const        r84, 1
+  AddInt       r33, r33, r84
   Jump         L3
 L0:
-  Const        r71, 0
-  Move         r70, r71
-  Len          r72, r24
+  Const        r85, 0
+  Len          r87, r35
 L19:
-  LessInt      r73, r70, r72
-  JumpIfFalse  r73, L4
-  Index        r75, r24, r70
+  LessInt      r88, r85, r87
+  JumpIfFalse  r88, L4
+  Index        r90, r35, r85
   // returnflag: g.key.returnflag,
-  Move         r76, r2
-  Index        r77, r75, r7
-  Index        r78, r77, r2
+  Const        r91, "returnflag"
+  Const        r92, "key"
+  Index        r93, r90, r92
+  Const        r94, "returnflag"
+  Index        r95, r93, r94
   // linestatus: g.key.linestatus,
-  Move         r79, r4
-  Index        r80, r75, r7
-  Index        r81, r80, r4
+  Const        r96, "linestatus"
+  Const        r97, "key"
+  Index        r98, r90, r97
+  Const        r99, "linestatus"
+  Index        r100, r98, r99
   // sum_qty: sum(from x in g select x.l_quantity),
-  Move         r82, r8
-  Move         r83, r43
-  IterPrep     r84, r75
-  Len          r85, r84
-  Move         r86, r71
+  Const        r101, "sum_qty"
+  Const        r102, []
+  Const        r103, "l_quantity"
+  IterPrep     r104, r90
+  Len          r105, r104
+  Const        r106, 0
 L6:
-  LessInt      r87, r86, r85
-  JumpIfFalse  r87, L5
-  Index        r89, r84, r86
-  Index        r90, r89, r9
-  Append       r83, r83, r90
-  AddInt       r86, r86, r68
+  LessInt      r108, r106, r105
+  JumpIfFalse  r108, L5
+  Index        r110, r104, r106
+  Const        r111, "l_quantity"
+  Index        r112, r110, r111
+  Append       r102, r102, r112
+  Const        r114, 1
+  AddInt       r106, r106, r114
   Jump         L6
 L5:
-  Sum          r92, r83
+  Sum          r115, r102
   // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Move         r93, r10
-  Move         r94, r1
-  IterPrep     r95, r75
-  Len          r96, r95
-  Move         r97, r71
+  Const        r116, "sum_base_price"
+  Const        r117, []
+  Const        r118, "l_extendedprice"
+  IterPrep     r119, r90
+  Len          r120, r119
+  Const        r121, 0
 L8:
-  LessInt      r98, r97, r96
-  JumpIfFalse  r98, L7
-  Index        r89, r95, r97
-  Index        r100, r89, r11
-  Append       r94, r94, r100
-  AddInt       r97, r97, r68
+  LessInt      r123, r121, r120
+  JumpIfFalse  r123, L7
+  Index        r110, r119, r121
+  Const        r125, "l_extendedprice"
+  Index        r126, r110, r125
+  Append       r117, r117, r126
+  Const        r128, 1
+  AddInt       r121, r121, r128
   Jump         L8
 L7:
-  Sum          r102, r94
+  Sum          r129, r117
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Move         r103, r12
-  Move         r104, r1
-  IterPrep     r105, r75
-  Len          r106, r105
-  Move         r107, r71
+  Const        r130, "sum_disc_price"
+  Const        r131, []
+  Const        r132, "l_extendedprice"
+  Const        r133, "l_discount"
+  IterPrep     r134, r90
+  Len          r135, r134
+  Const        r136, 0
 L10:
-  LessInt      r108, r107, r106
-  JumpIfFalse  r108, L9
-  Index        r89, r105, r107
-  Index        r110, r89, r11
-  Index        r111, r89, r13
-  Sub          r112, r68, r111
-  Mul          r113, r110, r112
-  Append       r104, r104, r113
-  AddInt       r107, r107, r68
+  LessInt      r138, r136, r135
+  JumpIfFalse  r138, L9
+  Index        r110, r134, r136
+  Const        r140, "l_extendedprice"
+  Index        r141, r110, r140
+  Const        r142, 1
+  Const        r143, "l_discount"
+  Index        r144, r110, r143
+  Sub          r145, r142, r144
+  Mul          r146, r141, r145
+  Append       r131, r131, r146
+  Const        r148, 1
+  AddInt       r136, r136, r148
   Jump         L10
 L9:
-  Sum          r115, r104
+  Sum          r149, r131
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Move         r116, r14
-  Move         r117, r1
-  IterPrep     r118, r75
-  Len          r119, r118
-  Move         r120, r71
+  Const        r150, "sum_charge"
+  Const        r151, []
+  Const        r152, "l_extendedprice"
+  Const        r153, "l_discount"
+  Const        r154, "l_tax"
+  IterPrep     r155, r90
+  Len          r156, r155
+  Const        r157, 0
 L12:
-  LessInt      r121, r120, r119
-  JumpIfFalse  r121, L11
-  Index        r89, r118, r120
-  Index        r123, r89, r11
-  Index        r124, r89, r13
-  Sub          r125, r68, r124
-  Mul          r126, r123, r125
-  Index        r127, r89, r15
-  Add          r128, r68, r127
-  Mul          r129, r126, r128
-  Append       r117, r117, r129
-  AddInt       r120, r120, r68
+  LessInt      r159, r157, r156
+  JumpIfFalse  r159, L11
+  Index        r110, r155, r157
+  Const        r161, "l_extendedprice"
+  Index        r162, r110, r161
+  Const        r163, 1
+  Const        r164, "l_discount"
+  Index        r165, r110, r164
+  Sub          r166, r163, r165
+  Mul          r167, r162, r166
+  Const        r168, 1
+  Const        r169, "l_tax"
+  Index        r170, r110, r169
+  Add          r171, r168, r170
+  Mul          r172, r167, r171
+  Append       r151, r151, r172
+  Const        r174, 1
+  AddInt       r157, r157, r174
   Jump         L12
 L11:
-  Sum          r131, r117
+  Sum          r175, r151
   // avg_qty: avg(from x in g select x.l_quantity),
-  Move         r132, r16
-  Move         r133, r1
-  IterPrep     r134, r75
-  Len          r135, r134
-  Move         r136, r71
+  Const        r176, "avg_qty"
+  Const        r177, []
+  Const        r178, "l_quantity"
+  IterPrep     r179, r90
+  Len          r180, r179
+  Const        r181, 0
 L14:
-  LessInt      r137, r136, r135
-  JumpIfFalse  r137, L13
-  Index        r89, r134, r136
-  Index        r139, r89, r9
-  Append       r133, r133, r139
-  AddInt       r136, r136, r68
+  LessInt      r183, r181, r180
+  JumpIfFalse  r183, L13
+  Index        r110, r179, r181
+  Const        r185, "l_quantity"
+  Index        r186, r110, r185
+  Append       r177, r177, r186
+  Const        r188, 1
+  AddInt       r181, r181, r188
   Jump         L14
 L13:
-  Avg          r141, r133
+  Avg          r189, r177
   // avg_price: avg(from x in g select x.l_extendedprice),
-  Move         r142, r17
-  Move         r143, r1
-  IterPrep     r144, r75
-  Len          r145, r144
-  Move         r146, r71
+  Const        r190, "avg_price"
+  Const        r191, []
+  Const        r192, "l_extendedprice"
+  IterPrep     r193, r90
+  Len          r194, r193
+  Const        r195, 0
 L16:
-  LessInt      r147, r146, r145
-  JumpIfFalse  r147, L15
-  Index        r89, r144, r146
-  Index        r149, r89, r11
-  Append       r143, r143, r149
-  AddInt       r146, r146, r68
+  LessInt      r197, r195, r194
+  JumpIfFalse  r197, L15
+  Index        r110, r193, r195
+  Const        r199, "l_extendedprice"
+  Index        r200, r110, r199
+  Append       r191, r191, r200
+  Const        r202, 1
+  AddInt       r195, r195, r202
   Jump         L16
 L15:
-  Avg          r151, r143
+  Avg          r203, r191
   // avg_disc: avg(from x in g select x.l_discount),
-  Move         r152, r18
-  Move         r153, r1
-  IterPrep     r154, r75
-  Len          r155, r154
-  Move         r156, r71
+  Const        r204, "avg_disc"
+  Const        r205, []
+  Const        r206, "l_discount"
+  IterPrep     r207, r90
+  Len          r208, r207
+  Const        r209, 0
 L18:
-  LessInt      r157, r156, r155
-  JumpIfFalse  r157, L17
-  Index        r89, r154, r156
-  Index        r159, r89, r13
-  Append       r153, r153, r159
-  AddInt       r156, r156, r68
+  LessInt      r211, r209, r208
+  JumpIfFalse  r211, L17
+  Index        r110, r207, r209
+  Const        r213, "l_discount"
+  Index        r214, r110, r213
+  Append       r205, r205, r214
+  Const        r216, 1
+  AddInt       r209, r209, r216
   Jump         L18
 L17:
-  Avg          r161, r153
+  Avg          r217, r205
   // count_order: count(g)
-  Move         r162, r19
-  Index        r163, r75, r66
+  Const        r218, "count_order"
+  Const        r219, "count"
+  Index        r220, r90, r219
   // returnflag: g.key.returnflag,
-  Move         r164, r76
-  Move         r165, r78
+  Move         r221, r91
+  Move         r222, r95
   // linestatus: g.key.linestatus,
-  Move         r166, r79
-  Move         r167, r81
+  Move         r223, r96
+  Move         r224, r100
   // sum_qty: sum(from x in g select x.l_quantity),
-  Move         r168, r82
-  Move         r169, r92
+  Move         r225, r101
+  Move         r226, r115
   // sum_base_price: sum(from x in g select x.l_extendedprice),
-  Move         r170, r93
-  Move         r171, r102
+  Move         r227, r116
+  Move         r228, r129
   // sum_disc_price: sum(from x in g select x.l_extendedprice * (1 - x.l_discount)),
-  Move         r172, r103
-  Move         r173, r115
+  Move         r229, r130
+  Move         r230, r149
   // sum_charge: sum(from x in g select x.l_extendedprice * (1 - x.l_discount) * (1 + x.l_tax)),
-  Move         r174, r116
-  Move         r175, r131
+  Move         r231, r150
+  Move         r232, r175
   // avg_qty: avg(from x in g select x.l_quantity),
-  Move         r176, r132
-  Move         r177, r141
+  Move         r233, r176
+  Move         r234, r189
   // avg_price: avg(from x in g select x.l_extendedprice),
-  Move         r178, r142
-  Move         r179, r151
+  Move         r235, r190
+  Move         r236, r203
   // avg_disc: avg(from x in g select x.l_discount),
-  Move         r180, r152
-  Move         r181, r161
+  Move         r237, r204
+  Move         r238, r217
   // count_order: count(g)
-  Move         r182, r162
-  Move         r183, r163
+  Move         r239, r218
+  Move         r240, r220
   // select {
-  MakeMap      r184, 10, r164
+  MakeMap      r241, 10, r221
   // from row in lineitem
-  Append       r1, r1, r184
-  AddInt       r70, r70, r68
+  Append       r1, r1, r241
+  Const        r243, 1
+  AddInt       r85, r85, r243
   Jump         L19
 L4:
   // json(result)
   JSON         r1
   // returnflag: "N",
-  Move         r186, r76
-  Const        r187, "N"
+  Const        r244, "returnflag"
+  Const        r245, "N"
   // linestatus: "O",
-  Move         r188, r79
-  Const        r189, "O"
+  Const        r246, "linestatus"
+  Const        r247, "O"
   // sum_qty: 53,
-  Move         r190, r8
-  Const        r191, 53
+  Const        r248, "sum_qty"
+  Const        r249, 53
   // sum_base_price: 3000,
-  Move         r192, r10
-  Const        r193, 3000
+  Const        r250, "sum_base_price"
+  Const        r251, 3000
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
-  Move         r194, r12
-  Const        r197, 2750
+  Const        r252, "sum_disc_price"
+  Const        r253, 950
+  Const        r254, 1800
+  Const        r255, 2750
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
-  Move         r198, r14
-  Const        r203, 2906.5
+  Const        r256, "sum_charge"
+  Const        r257, 950
+  Const        r258, 1.07
+  Const        r259, 1016.5000000000001
+  Const        r260, 1800
+  Const        r261, 1.05
+  Const        r262, 1890
+  Const        r263, 2906.5
   // avg_qty: 26.5,
-  Move         r204, r16
-  Const        r205, 26.5
+  Const        r264, "avg_qty"
+  Const        r265, 26.5
   // avg_price: 1500,
-  Move         r206, r17
-  Const        r207, 1500
+  Const        r266, "avg_price"
+  Const        r267, 1500
   // avg_disc: 0.07500000000000001,
-  Move         r208, r18
-  Const        r209, 0.07500000000000001
+  Const        r268, "avg_disc"
+  Const        r269, 0.07500000000000001
   // count_order: 2
-  Move         r210, r19
-  Const        r211, 2
+  Const        r270, "count_order"
+  Const        r271, 2
   // returnflag: "N",
-  Move         r212, r186
-  Move         r213, r187
+  Move         r272, r244
+  Move         r273, r245
   // linestatus: "O",
-  Move         r214, r188
-  Move         r215, r189
+  Move         r274, r246
+  Move         r275, r247
   // sum_qty: 53,
-  Move         r216, r190
-  Move         r217, r191
+  Move         r276, r248
+  Move         r277, r249
   // sum_base_price: 3000,
-  Move         r218, r192
-  Move         r219, r193
+  Move         r278, r250
+  Move         r279, r251
   // sum_disc_price: 950.0 + 1800.0,               // 2750.0
-  Move         r220, r194
-  Move         r221, r197
+  Move         r280, r252
+  Move         r281, r255
   // sum_charge: (950.0 * 1.07) + (1800.0 * 1.05), // 1016.5 + 1890 = 2906.5
-  Move         r222, r198
-  Move         r223, r203
+  Move         r282, r256
+  Move         r283, r263
   // avg_qty: 26.5,
-  Move         r224, r204
-  Move         r225, r205
+  Move         r284, r264
+  Move         r285, r265
   // avg_price: 1500,
-  Move         r226, r206
-  Move         r227, r207
+  Move         r286, r266
+  Move         r287, r267
   // avg_disc: 0.07500000000000001,
-  Move         r228, r208
-  Move         r229, r209
+  Move         r288, r268
+  Move         r289, r269
   // count_order: 2
-  Move         r230, r210
-  Move         r231, r211
+  Move         r290, r270
+  Move         r291, r271
   // {
-  MakeMap      r233, 10, r212
+  MakeMap      r293, 10, r272
   // expect result == [
-  MakeList     r234, 1, r233
-  Equal        r235, r1, r234
-  Expect       r235
+  MakeList     r294, 1, r293
+  Equal        r295, r1, r294
+  Expect       r295
   Return       r0

--- a/tests/dataset/tpc-h/out/q10.ir.out
+++ b/tests/dataset/tpc-h/out/q10.ir.out
@@ -1,4 +1,4 @@
-func main (regs=256)
+func main (regs=342)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}]
   // let customer = [
@@ -15,365 +15,465 @@ func main (regs=256)
   Const        r6, []
   // c_custkey: c.c_custkey,
   Const        r7, "c_custkey"
+  Const        r8, "c_custkey"
   // c_name: c.c_name,
-  Const        r8, "c_name"
+  Const        r9, "c_name"
+  Const        r10, "c_name"
   // c_acctbal: c.c_acctbal,
-  Const        r9, "c_acctbal"
+  Const        r11, "c_acctbal"
+  Const        r12, "c_acctbal"
   // c_address: c.c_address,
-  Const        r10, "c_address"
+  Const        r13, "c_address"
+  Const        r14, "c_address"
   // c_phone: c.c_phone,
-  Const        r11, "c_phone"
+  Const        r15, "c_phone"
+  Const        r16, "c_phone"
   // c_comment: c.c_comment,
-  Const        r12, "c_comment"
+  Const        r17, "c_comment"
+  Const        r18, "c_comment"
   // n_name: n.n_name
-  Const        r13, "n_name"
+  Const        r19, "n_name"
+  Const        r20, "n_name"
   // where o.o_orderdate >= start_date &&
-  Const        r14, "o_orderdate"
-  // l.l_returnflag == "R"
-  Const        r15, "l_returnflag"
-  // c_custkey: g.key.c_custkey,
-  Const        r16, "key"
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r17, "revenue"
-  Const        r18, "l"
-  Const        r19, "l_extendedprice"
-  Const        r20, "l_discount"
-  // from c in customer
-  MakeMap      r21, 0, r0
-  Move         r22, r6
-  IterPrep     r24, r1
-  Len          r25, r24
-  Const        r26, 0
-L1:
-  LessInt      r27, r26, r25
-  JumpIfFalse  r27, L0
-  Index        r29, r24, r26
-  // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r30, r2
-  Len          r31, r30
-  Move         r32, r26
-L2:
-  LessInt      r33, r32, r31
-  JumpIfFalse  r33, L1
-  Index        r35, r30, r32
-  Const        r36, "o_custkey"
-  Index        r37, r35, r36
-  Index        r38, r29, r7
-  Equal        r39, r37, r38
-  JumpIfFalse  r39, L2
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r40, r3
-  Len          r41, r40
-  Move         r42, r26
-L9:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L2
-  Index        r45, r40, r42
-  Const        r46, "l_orderkey"
-  Index        r47, r45, r46
-  Const        r48, "o_orderkey"
-  Index        r49, r35, r48
-  Equal        r50, r47, r49
-  JumpIfFalse  r50, L3
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r51, r0
-  Len          r52, r51
-  Move         r53, r42
-L8:
-  LessInt      r54, r53, r52
-  JumpIfFalse  r54, L3
-  Index        r56, r51, r53
-  Const        r57, "n_nationkey"
-  Index        r58, r56, r57
-  Const        r59, "c_nationkey"
-  Index        r60, r29, r59
-  Equal        r61, r58, r60
-  JumpIfFalse  r61, L4
-  // where o.o_orderdate >= start_date &&
-  Index        r62, r35, r14
-  LessEq       r63, r4, r62
+  Const        r21, "o_orderdate"
   // o.o_orderdate < end_date &&
-  Index        r64, r35, r14
-  Less         r65, r64, r5
+  Const        r22, "o_orderdate"
   // l.l_returnflag == "R"
-  Index        r66, r45, r15
-  Const        r67, "R"
-  Equal        r68, r66, r67
+  Const        r23, "l_returnflag"
+  // c_custkey: g.key.c_custkey,
+  Const        r24, "c_custkey"
+  Const        r25, "key"
+  Const        r26, "c_custkey"
+  // c_name: g.key.c_name,
+  Const        r27, "c_name"
+  Const        r28, "key"
+  Const        r29, "c_name"
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Const        r30, "revenue"
+  Const        r31, "l"
+  Const        r32, "l_extendedprice"
+  Const        r33, "l"
+  Const        r34, "l_discount"
+  // c_acctbal: g.key.c_acctbal,
+  Const        r35, "c_acctbal"
+  Const        r36, "key"
+  Const        r37, "c_acctbal"
+  // n_name: g.key.n_name,
+  Const        r38, "n_name"
+  Const        r39, "key"
+  Const        r40, "n_name"
+  // c_address: g.key.c_address,
+  Const        r41, "c_address"
+  Const        r42, "key"
+  Const        r43, "c_address"
+  // c_phone: g.key.c_phone,
+  Const        r44, "c_phone"
+  Const        r45, "key"
+  Const        r46, "c_phone"
+  // c_comment: g.key.c_comment
+  Const        r47, "c_comment"
+  Const        r48, "key"
+  Const        r49, "c_comment"
+  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Const        r50, "l"
+  Const        r51, "l_extendedprice"
+  Const        r52, "l"
+  Const        r53, "l_discount"
+  // from c in customer
+  MakeMap      r54, 0, r0
+  Const        r55, []
+  IterPrep     r57, r1
+  Len          r58, r57
+  Const        r59, 0
+L11:
+  LessInt      r60, r59, r58
+  JumpIfFalse  r60, L0
+  Index        r62, r57, r59
+  // join o in orders on o.o_custkey == c.c_custkey
+  IterPrep     r63, r2
+  Len          r64, r63
+  Const        r65, 0
+L10:
+  LessInt      r66, r65, r64
+  JumpIfFalse  r66, L1
+  Index        r68, r63, r65
+  Const        r69, "o_custkey"
+  Index        r70, r68, r69
+  Const        r71, "c_custkey"
+  Index        r72, r62, r71
+  Equal        r73, r70, r72
+  JumpIfFalse  r73, L2
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  IterPrep     r74, r3
+  Len          r75, r74
+  Const        r76, 0
+L9:
+  LessInt      r77, r76, r75
+  JumpIfFalse  r77, L2
+  Index        r79, r74, r76
+  Const        r80, "l_orderkey"
+  Index        r81, r79, r80
+  Const        r82, "o_orderkey"
+  Index        r83, r68, r82
+  Equal        r84, r81, r83
+  JumpIfFalse  r84, L3
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  IterPrep     r85, r0
+  Len          r86, r85
+  Const        r87, 0
+L8:
+  LessInt      r88, r87, r86
+  JumpIfFalse  r88, L3
+  Index        r90, r85, r87
+  Const        r91, "n_nationkey"
+  Index        r92, r90, r91
+  Const        r93, "c_nationkey"
+  Index        r94, r62, r93
+  Equal        r95, r92, r94
+  JumpIfFalse  r95, L4
   // where o.o_orderdate >= start_date &&
-  Move         r69, r63
-  JumpIfFalse  r69, L5
+  Const        r96, "o_orderdate"
+  Index        r97, r68, r96
+  LessEq       r98, r4, r97
+  // o.o_orderdate < end_date &&
+  Const        r99, "o_orderdate"
+  Index        r100, r68, r99
+  Less         r101, r100, r5
+  // l.l_returnflag == "R"
+  Const        r102, "l_returnflag"
+  Index        r103, r79, r102
+  Const        r104, "R"
+  Equal        r105, r103, r104
+  // where o.o_orderdate >= start_date &&
+  Move         r106, r98
+  JumpIfFalse  r106, L5
 L5:
   // o.o_orderdate < end_date &&
-  Move         r70, r65
-  JumpIfFalse  r70, L6
-  Move         r70, r68
+  Move         r107, r101
+  JumpIfFalse  r107, L6
+  Move         r107, r105
 L6:
   // where o.o_orderdate >= start_date &&
-  JumpIfFalse  r70, L4
+  JumpIfFalse  r107, L4
   // from c in customer
-  Const        r71, "c"
-  Move         r72, r29
-  Const        r73, "o"
-  Move         r74, r35
-  Move         r75, r18
-  Move         r76, r45
-  Const        r77, "n"
-  Move         r78, r56
-  MakeMap      r79, 4, r71
+  Const        r108, "c"
+  Move         r109, r62
+  Const        r110, "o"
+  Move         r111, r68
+  Const        r112, "l"
+  Move         r113, r79
+  Const        r114, "n"
+  Move         r115, r90
+  MakeMap      r116, 4, r108
   // c_custkey: c.c_custkey,
-  Move         r80, r7
-  Index        r81, r29, r7
+  Const        r117, "c_custkey"
+  Const        r118, "c_custkey"
+  Index        r119, r62, r118
   // c_name: c.c_name,
-  Move         r82, r8
-  Index        r83, r29, r8
+  Const        r120, "c_name"
+  Const        r121, "c_name"
+  Index        r122, r62, r121
   // c_acctbal: c.c_acctbal,
-  Move         r84, r9
-  Index        r85, r29, r9
+  Const        r123, "c_acctbal"
+  Const        r124, "c_acctbal"
+  Index        r125, r62, r124
   // c_address: c.c_address,
-  Move         r86, r10
-  Index        r87, r29, r10
+  Const        r126, "c_address"
+  Const        r127, "c_address"
+  Index        r128, r62, r127
   // c_phone: c.c_phone,
-  Move         r88, r11
-  Index        r89, r29, r11
+  Const        r129, "c_phone"
+  Const        r130, "c_phone"
+  Index        r131, r62, r130
   // c_comment: c.c_comment,
-  Move         r90, r12
-  Index        r91, r29, r12
+  Const        r132, "c_comment"
+  Const        r133, "c_comment"
+  Index        r134, r62, r133
   // n_name: n.n_name
-  Move         r92, r13
-  Index        r93, r56, r13
+  Const        r135, "n_name"
+  Const        r136, "n_name"
+  Index        r137, r90, r136
   // c_custkey: c.c_custkey,
-  Move         r94, r80
-  Move         r95, r81
+  Move         r138, r117
+  Move         r139, r119
   // c_name: c.c_name,
-  Move         r96, r82
-  Move         r97, r83
+  Move         r140, r120
+  Move         r141, r122
   // c_acctbal: c.c_acctbal,
-  Move         r98, r84
-  Move         r99, r85
+  Move         r142, r123
+  Move         r143, r125
   // c_address: c.c_address,
-  Move         r100, r86
-  Move         r101, r87
+  Move         r144, r126
+  Move         r145, r128
   // c_phone: c.c_phone,
-  Move         r102, r88
-  Move         r103, r89
+  Move         r146, r129
+  Move         r147, r131
   // c_comment: c.c_comment,
-  Move         r104, r90
-  Move         r105, r91
+  Move         r148, r132
+  Move         r149, r134
   // n_name: n.n_name
-  Move         r106, r92
-  Move         r107, r93
+  Move         r150, r135
+  Move         r151, r137
   // group by {
-  MakeMap      r108, 7, r94
-  Str          r109, r108
-  In           r110, r109, r21
-  JumpIfTrue   r110, L7
+  MakeMap      r152, 7, r138
+  Str          r153, r152
+  In           r154, r153, r54
+  JumpIfTrue   r154, L7
   // from c in customer
-  Move         r111, r6
-  Const        r112, "__group__"
-  Const        r113, true
-  Move         r114, r16
+  Const        r155, []
+  Const        r156, "__group__"
+  Const        r157, true
+  Const        r158, "key"
   // group by {
-  Move         r115, r108
+  Move         r159, r152
   // from c in customer
-  Const        r116, "items"
-  Move         r117, r111
-  Const        r118, "count"
-  Move         r119, r26
-  Move         r120, r112
-  Move         r121, r113
-  Move         r122, r114
-  Move         r123, r115
-  Move         r124, r116
-  Move         r125, r117
-  Move         r126, r118
-  Move         r127, r119
-  MakeMap      r128, 4, r120
-  SetIndex     r21, r109, r128
-  Append       r22, r22, r128
+  Const        r160, "items"
+  Move         r161, r155
+  Const        r162, "count"
+  Const        r163, 0
+  Move         r164, r156
+  Move         r165, r157
+  Move         r166, r158
+  Move         r167, r159
+  Move         r168, r160
+  Move         r169, r161
+  Move         r170, r162
+  Move         r171, r163
+  MakeMap      r172, 4, r164
+  SetIndex     r54, r153, r172
+  Append       r55, r55, r172
 L7:
-  Move         r130, r116
-  Index        r131, r21, r109
-  Index        r132, r131, r130
-  Append       r133, r132, r79
-  SetIndex     r131, r130, r133
-  Move         r134, r118
-  Index        r135, r131, r134
-  Const        r136, 1
-  AddInt       r137, r135, r136
-  SetIndex     r131, r134, r137
+  Const        r174, "items"
+  Index        r175, r54, r153
+  Index        r176, r175, r174
+  Append       r177, r176, r116
+  SetIndex     r175, r174, r177
+  Const        r178, "count"
+  Index        r179, r175, r178
+  Const        r180, 1
+  AddInt       r181, r179, r180
+  SetIndex     r175, r178, r181
 L4:
   // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r53, r53, r136
+  Const        r182, 1
+  AddInt       r87, r87, r182
   Jump         L8
 L3:
   // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r42, r42, r136
+  Const        r183, 1
+  AddInt       r76, r76, r183
   Jump         L9
-L0:
+L2:
+  // join o in orders on o.o_custkey == c.c_custkey
+  Const        r184, 1
+  AddInt       r65, r65, r184
+  Jump         L10
+L1:
   // from c in customer
-  Move         r139, r119
-  Move         r138, r139
-  Len          r140, r22
-L15:
-  LessInt      r141, r138, r140
-  JumpIfFalse  r141, L10
-  Index        r143, r22, r138
+  Const        r185, 1
+  AddInt       r59, r59, r185
+  Jump         L11
+L0:
+  Const        r186, 0
+  Len          r188, r55
+L17:
+  LessInt      r189, r186, r188
+  JumpIfFalse  r189, L12
+  Index        r191, r55, r186
   // c_custkey: g.key.c_custkey,
-  Move         r144, r7
-  Index        r145, r143, r16
-  Index        r146, r145, r7
+  Const        r192, "c_custkey"
+  Const        r193, "key"
+  Index        r194, r191, r193
+  Const        r195, "c_custkey"
+  Index        r196, r194, r195
   // c_name: g.key.c_name,
-  Move         r147, r8
-  Index        r148, r143, r16
-  Index        r149, r148, r8
+  Const        r197, "c_name"
+  Const        r198, "key"
+  Index        r199, r191, r198
+  Const        r200, "c_name"
+  Index        r201, r199, r200
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r150, r17
-  Move         r151, r111
-  IterPrep     r152, r143
-  Len          r153, r152
-  Move         r154, r139
-L12:
-  LessInt      r155, r154, r153
-  JumpIfFalse  r155, L11
-  Index        r157, r152, r154
-  Index        r158, r157, r18
-  Index        r159, r158, r19
-  Index        r160, r157, r18
-  Index        r161, r160, r20
-  Sub          r162, r136, r161
-  Mul          r163, r159, r162
-  Append       r151, r151, r163
-  AddInt       r154, r154, r136
-  Jump         L12
-L11:
-  Sum          r165, r151
-  // c_acctbal: g.key.c_acctbal,
-  Move         r166, r9
-  Index        r167, r143, r16
-  Index        r168, r167, r9
-  // n_name: g.key.n_name,
-  Move         r169, r13
-  Index        r170, r143, r16
-  Index        r171, r170, r13
-  // c_address: g.key.c_address,
-  Move         r172, r10
-  Index        r173, r143, r16
-  Index        r174, r173, r10
-  // c_phone: g.key.c_phone,
-  Move         r175, r11
-  Index        r176, r143, r16
-  Index        r177, r176, r11
-  // c_comment: g.key.c_comment
-  Move         r178, r12
-  Index        r179, r143, r16
-  Index        r180, r179, r12
-  // c_custkey: g.key.c_custkey,
-  Move         r181, r144
-  Move         r182, r146
-  // c_name: g.key.c_name,
-  Move         r183, r147
-  Move         r184, r149
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r185, r150
-  Move         r186, r165
-  // c_acctbal: g.key.c_acctbal,
-  Move         r187, r166
-  Move         r188, r168
-  // n_name: g.key.n_name,
-  Move         r189, r169
-  Move         r190, r171
-  // c_address: g.key.c_address,
-  Move         r191, r172
-  Move         r192, r174
-  // c_phone: g.key.c_phone,
-  Move         r193, r175
-  Move         r194, r177
-  // c_comment: g.key.c_comment
-  Move         r195, r178
-  Move         r196, r180
-  // select {
-  MakeMap      r197, 8, r181
-  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Move         r198, r6
-  IterPrep     r199, r143
-  Len          r200, r199
-  Move         r201, r139
+  Const        r202, "revenue"
+  Const        r203, []
+  Const        r204, "l"
+  Const        r205, "l_extendedprice"
+  Const        r206, "l"
+  Const        r207, "l_discount"
+  IterPrep     r208, r191
+  Len          r209, r208
+  Const        r210, 0
 L14:
-  LessInt      r202, r201, r200
-  JumpIfFalse  r202, L13
-  Index        r157, r199, r201
-  Index        r204, r157, r18
-  Index        r205, r204, r19
-  Index        r206, r157, r18
-  Index        r207, r206, r20
-  Sub          r208, r136, r207
-  Mul          r209, r205, r208
-  Append       r198, r198, r209
-  AddInt       r201, r201, r136
+  LessInt      r212, r210, r209
+  JumpIfFalse  r212, L13
+  Index        r214, r208, r210
+  Const        r215, "l"
+  Index        r216, r214, r215
+  Const        r217, "l_extendedprice"
+  Index        r218, r216, r217
+  Const        r219, 1
+  Const        r220, "l"
+  Index        r221, r214, r220
+  Const        r222, "l_discount"
+  Index        r223, r221, r222
+  Sub          r224, r219, r223
+  Mul          r225, r218, r224
+  Append       r203, r203, r225
+  Const        r227, 1
+  AddInt       r210, r210, r227
   Jump         L14
 L13:
-  Sum          r211, r198
-  Neg          r213, r211
+  Sum          r228, r203
+  // c_acctbal: g.key.c_acctbal,
+  Const        r229, "c_acctbal"
+  Const        r230, "key"
+  Index        r231, r191, r230
+  Const        r232, "c_acctbal"
+  Index        r233, r231, r232
+  // n_name: g.key.n_name,
+  Const        r234, "n_name"
+  Const        r235, "key"
+  Index        r236, r191, r235
+  Const        r237, "n_name"
+  Index        r238, r236, r237
+  // c_address: g.key.c_address,
+  Const        r239, "c_address"
+  Const        r240, "key"
+  Index        r241, r191, r240
+  Const        r242, "c_address"
+  Index        r243, r241, r242
+  // c_phone: g.key.c_phone,
+  Const        r244, "c_phone"
+  Const        r245, "key"
+  Index        r246, r191, r245
+  Const        r247, "c_phone"
+  Index        r248, r246, r247
+  // c_comment: g.key.c_comment
+  Const        r249, "c_comment"
+  Const        r250, "key"
+  Index        r251, r191, r250
+  Const        r252, "c_comment"
+  Index        r253, r251, r252
+  // c_custkey: g.key.c_custkey,
+  Move         r254, r192
+  Move         r255, r196
+  // c_name: g.key.c_name,
+  Move         r256, r197
+  Move         r257, r201
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r258, r202
+  Move         r259, r228
+  // c_acctbal: g.key.c_acctbal,
+  Move         r260, r229
+  Move         r261, r233
+  // n_name: g.key.n_name,
+  Move         r262, r234
+  Move         r263, r238
+  // c_address: g.key.c_address,
+  Move         r264, r239
+  Move         r265, r243
+  // c_phone: g.key.c_phone,
+  Move         r266, r244
+  Move         r267, r248
+  // c_comment: g.key.c_comment
+  Move         r268, r249
+  Move         r269, r253
+  // select {
+  MakeMap      r270, 8, r254
+  // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Const        r271, []
+  Const        r272, "l"
+  Const        r273, "l_extendedprice"
+  Const        r274, "l"
+  Const        r275, "l_discount"
+  IterPrep     r276, r191
+  Len          r277, r276
+  Const        r278, 0
+L16:
+  LessInt      r280, r278, r277
+  JumpIfFalse  r280, L15
+  Index        r214, r276, r278
+  Const        r282, "l"
+  Index        r283, r214, r282
+  Const        r284, "l_extendedprice"
+  Index        r285, r283, r284
+  Const        r286, 1
+  Const        r287, "l"
+  Index        r288, r214, r287
+  Const        r289, "l_discount"
+  Index        r290, r288, r289
+  Sub          r291, r286, r290
+  Mul          r292, r285, r291
+  Append       r271, r271, r292
+  Const        r294, 1
+  AddInt       r278, r278, r294
+  Jump         L16
+L15:
+  Sum          r295, r271
+  Neg          r297, r295
   // from c in customer
-  Move         r214, r197
-  MakeList     r215, 2, r213
-  Append       r6, r6, r215
-  AddInt       r138, r138, r136
-  Jump         L15
-L10:
+  Move         r298, r270
+  MakeList     r299, 2, r297
+  Append       r6, r6, r299
+  Const        r301, 1
+  AddInt       r186, r186, r301
+  Jump         L17
+L12:
   // sort by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r6, r6
   // c_custkey: 1,
-  Move         r219, r144
+  Const        r304, "c_custkey"
+  Const        r305, 1
   // c_name: "Alice",
-  Move         r220, r147
-  Const        r221, "Alice"
+  Const        r306, "c_name"
+  Const        r307, "Alice"
   // revenue: 1000.0 * 0.9, // 900.0
-  Move         r222, r17
-  Const        r225, 900
+  Const        r308, "revenue"
+  Const        r309, 1000
+  Const        r310, 0.9
+  Const        r311, 900
   // c_acctbal: 100.0,
-  Move         r226, r166
-  Const        r227, 100
+  Const        r312, "c_acctbal"
+  Const        r313, 100
   // n_name: "BRAZIL",
-  Move         r228, r169
-  Const        r229, "BRAZIL"
+  Const        r314, "n_name"
+  Const        r315, "BRAZIL"
   // c_address: "123 St",
-  Move         r230, r172
-  Const        r231, "123 St"
+  Const        r316, "c_address"
+  Const        r317, "123 St"
   // c_phone: "123-456",
-  Move         r232, r175
-  Const        r233, "123-456"
+  Const        r318, "c_phone"
+  Const        r319, "123-456"
   // c_comment: "Loyal"
-  Move         r234, r178
-  Const        r235, "Loyal"
+  Const        r320, "c_comment"
+  Const        r321, "Loyal"
   // c_custkey: 1,
-  Move         r236, r219
-  Move         r237, r136
+  Move         r322, r304
+  Move         r323, r305
   // c_name: "Alice",
-  Move         r238, r220
-  Move         r239, r221
+  Move         r324, r306
+  Move         r325, r307
   // revenue: 1000.0 * 0.9, // 900.0
-  Move         r240, r222
-  Move         r241, r225
+  Move         r326, r308
+  Move         r327, r311
   // c_acctbal: 100.0,
-  Move         r242, r226
-  Move         r243, r227
+  Move         r328, r312
+  Move         r329, r313
   // n_name: "BRAZIL",
-  Move         r244, r228
-  Move         r245, r229
+  Move         r330, r314
+  Move         r331, r315
   // c_address: "123 St",
-  Move         r246, r230
-  Move         r247, r231
+  Move         r332, r316
+  Move         r333, r317
   // c_phone: "123-456",
-  Move         r248, r232
-  Move         r249, r233
+  Move         r334, r318
+  Move         r335, r319
   // c_comment: "Loyal"
-  Move         r250, r234
-  Move         r251, r235
+  Move         r336, r320
+  Move         r337, r321
   // {
-  MakeMap      r253, 8, r236
+  MakeMap      r339, 8, r322
   // expect result == [
-  MakeList     r254, 1, r253
-  Equal        r255, r6, r254
-  Expect       r255
+  MakeList     r340, 1, r339
+  Equal        r341, r6, r340
+  Expect       r341
   Return       r0

--- a/tests/dataset/tpc-h/out/q11.ir.out
+++ b/tests/dataset/tpc-h/out/q11.ir.out
@@ -1,230 +1,292 @@
-func main (regs=24)
+func main (regs=195)
   // let nation = [
   Const        r0, [{"n_name": "GERMANY", "n_nationkey": 1}, {"n_name": "FRANCE", "n_nationkey": 2}]
   // let supplier = [
   Const        r1, [{"s_nationkey": 1, "s_suppkey": 100}, {"s_nationkey": 1, "s_suppkey": 200}, {"s_nationkey": 2, "s_suppkey": 300}]
   // let partsupp = [
   Const        r2, [{"ps_availqty": 100, "ps_partkey": 1000, "ps_suppkey": 100, "ps_supplycost": 10}, {"ps_availqty": 50, "ps_partkey": 1000, "ps_suppkey": 200, "ps_supplycost": 20}, {"ps_availqty": 10, "ps_partkey": 2000, "ps_suppkey": 100, "ps_supplycost": 5}, {"ps_availqty": 500, "ps_partkey": 3000, "ps_suppkey": 300, "ps_supplycost": 8}]
-L2:
   // let target_nation = "GERMANY"
   Const        r3, "GERMANY"
-L9:
   // from ps in partsupp
   Const        r4, []
   // where n.n_name == target_nation
   Const        r5, "n_name"
   // ps_partkey: ps.ps_partkey,
   Const        r6, "ps_partkey"
+  Const        r7, "ps_partkey"
   // value: ps.ps_supplycost * ps.ps_availqty
-  Const        r7, "value"
-  Const        r8, "ps_supplycost"
-L8:
-  Const        r9, "ps_availqty"
+  Const        r8, "value"
+  Const        r9, "ps_supplycost"
+  Const        r10, "ps_availqty"
   // from ps in partsupp
-  IterPrep     r10, r2
-  Len          r2, r10
+  IterPrep     r11, r2
+  Len          r12, r11
+  Const        r13, 0
 L6:
-  Const        r11, 0
-L5:
-  Move         r12, r11
-  LessInt      r13, r12, r2
-  JumpIfFalse  r13, L0
-L0:
-  Index        r2, r10, r12
-L4:
+  LessInt      r15, r13, r12
+  JumpIfFalse  r15, L0
+  Index        r17, r11, r13
   // join s in supplier on s.s_suppkey == ps.ps_suppkey
-  IterPrep     r10, r1
-L1:
-  Len          r1, r10
-L3:
-  Const        r14, "s_suppkey"
-  Const        r15, "ps_suppkey"
-  Move         r16, r11
-  LessInt      r17, r16, r1
-  JumpIfFalse  r17, L1
-  Index        r1, r10, r16
-  Index        r10, r1, r14
-  Index        r14, r2, r15
-  Equal        r15, r10, r14
-  JumpIfFalse  r15, L2
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  IterPrep     r15, r0
-  Len          r14, r15
-  Const        r10, "n_nationkey"
-  Const        r18, "s_nationkey"
-  Move         r19, r11
-  LessInt      r20, r19, r14
-  JumpIfFalse  r20, L2
-  Index        r20, r15, r19
-  Index        r15, r20, r10
-  Index        r10, r1, r18
-  Equal        r18, r15, r10
-  JumpIfFalse  r18, L0
+  IterPrep     r18, r1
+  Len          r19, r18
+  Const        r20, "s_suppkey"
+  Const        r21, "ps_suppkey"
   // where n.n_name == target_nation
-  Index        r18, r20, r5
-  Equal        r20, r18, r3
-  JumpIfFalse  r20, L0
+  Const        r22, "n_name"
   // ps_partkey: ps.ps_partkey,
-  Move         r20, r6
-  Index        r18, r2, r6
+  Const        r23, "ps_partkey"
+  Const        r24, "ps_partkey"
   // value: ps.ps_supplycost * ps.ps_availqty
-  Move         r3, r7
-  Index        r5, r2, r8
-  Index        r8, r2, r9
-  Mul          r2, r5, r8
-  // ps_partkey: ps.ps_partkey,
-  Move         r8, r20
-  Move         r20, r18
-  // value: ps.ps_supplycost * ps.ps_availqty
-  Move         r18, r3
-  Move         r3, r2
-  // select {
-  MakeMap      r2, 2, r8
-  // from ps in partsupp
-  Append       r4, r4, r2
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  Const        r2, 1
-  Add          r19, r19, r2
-  Jump         L3
+  Const        r25, "value"
+  Const        r26, "ps_supplycost"
+  Const        r27, "ps_availqty"
   // join s in supplier on s.s_suppkey == ps.ps_suppkey
-  Add          r16, r16, r2
-  Jump         L4
-  // from ps in partsupp
-  AddInt       r12, r12, r2
-  Jump         L5
-  // from x in filtered
-  Const        r19, []
-  // ps_partkey: g.key,
-  Const        r17, "key"
-  // from x in filtered
-  IterPrep     r16, r4
-  Len          r13, r16
-  Move         r12, r11
-  MakeMap      r3, 0, r0
-  LessInt      r18, r12, r13
-  JumpIfFalse  r18, L6
-  Index        r18, r16, r12
-  // group by x.ps_partkey into g
-  Index        r16, r18, r6
-  Str          r13, r16
-  In           r20, r13, r3
-  JumpIfTrue   r20, L7
-  // from x in filtered
-  Move         r20, r19
-  Const        r8, "__group__"
-  Const        r5, true
-  Move         r9, r17
-  // group by x.ps_partkey into g
-  Move         r10, r16
-  // from x in filtered
-  Const        r16, "items"
-  Move         r15, r20
-  Const        r20, "count"
-  Move         r1, r11
-  Move         r14, r8
-  Move         r8, r5
-  Move         r5, r9
-  Move         r21, r10
-  Move         r10, r16
-  Move         r22, r15
-  Move         r15, r20
-  Move         r23, r1
-  MakeMap      r1, 4, r14
-  SetIndex     r3, r13, r1
-L7:
-  Move         r1, r16
-  Index        r16, r3, r13
-  Index        r13, r16, r1
-  Append       r23, r13, r18
-  SetIndex     r16, r1, r23
-  Move         r23, r20
-  Index        r20, r16, r23
-  AddInt       r13, r20, r2
-  SetIndex     r16, r23, r13
-  AddInt       r12, r12, r2
-  Jump         L8
-  Values       13,3,0,0
-  Move         r3, r11
-  Len          r20, r13
-  LessInt      r23, r3, r20
-  JumpIfFalse  r23, L3
-  Index        r23, r13, r3
-  // ps_partkey: g.key,
-  Move         r13, r6
-  Index        r6, r23, r17
-  // value: sum(from r in g select r.value)
-  Move         r17, r7
-  Move         r20, r19
-  IterPrep     r16, r23
-  Len          r23, r16
-  Move         r9, r11
-  LessInt      r12, r9, r23
-  JumpIfFalse  r12, L9
-  Index        r12, r16, r9
-  Index        r16, r12, r7
-  Append       r20, r20, r16
-  AddInt       r9, r9, r2
-  Jump         L0
-  Sum          r12, r20
-  // ps_partkey: g.key,
-  Move         r20, r13
-  Move         r13, r6
-  // value: sum(from r in g select r.value)
-  Move         r6, r17
-  Move         r17, r12
+  Const        r28, 0
+L5:
+  LessInt      r30, r28, r19
+  JumpIfFalse  r30, L1
+  Index        r32, r18, r28
+  Const        r33, "s_suppkey"
+  Index        r34, r32, r33
+  Const        r35, "ps_suppkey"
+  Index        r36, r17, r35
+  Equal        r37, r34, r36
+  JumpIfFalse  r37, L2
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  IterPrep     r38, r0
+  Len          r39, r38
+  Const        r40, "n_nationkey"
+  Const        r41, "s_nationkey"
+  // where n.n_name == target_nation
+  Const        r42, "n_name"
+  // ps_partkey: ps.ps_partkey,
+  Const        r43, "ps_partkey"
+  Const        r44, "ps_partkey"
+  // value: ps.ps_supplycost * ps.ps_availqty
+  Const        r45, "value"
+  Const        r46, "ps_supplycost"
+  Const        r47, "ps_availqty"
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r48, 0
+L4:
+  LessInt      r50, r48, r39
+  JumpIfFalse  r50, L2
+  Index        r52, r38, r48
+  Const        r53, "n_nationkey"
+  Index        r54, r52, r53
+  Const        r55, "s_nationkey"
+  Index        r56, r32, r55
+  Equal        r57, r54, r56
+  JumpIfFalse  r57, L3
+  // where n.n_name == target_nation
+  Const        r58, "n_name"
+  Index        r59, r52, r58
+  Equal        r60, r59, r3
+  JumpIfFalse  r60, L3
+  // ps_partkey: ps.ps_partkey,
+  Const        r61, "ps_partkey"
+  Const        r62, "ps_partkey"
+  Index        r63, r17, r62
+  // value: ps.ps_supplycost * ps.ps_availqty
+  Const        r64, "value"
+  Const        r65, "ps_supplycost"
+  Index        r66, r17, r65
+  Const        r67, "ps_availqty"
+  Index        r68, r17, r67
+  Mul          r69, r66, r68
+  // ps_partkey: ps.ps_partkey,
+  Move         r70, r61
+  Move         r71, r63
+  // value: ps.ps_supplycost * ps.ps_availqty
+  Move         r72, r64
+  Move         r73, r69
   // select {
-  MakeMap      r9, 2, r20
-  // from x in filtered
-  Append       r19, r19, r9
-  AddInt       r3, r3, r2
-  Jump         L6
-  // sum(from x in filtered select x.value)
-  Const        r9, []
-  IterPrep     r17, r4
-  Len          r4, r17
-  Move         r16, r11
-  LessInt      r6, r16, r4
-  JumpIfFalse  r6, L10
-  Index        r6, r17, r16
-  Index        r17, r6, r7
-  Append       r9, r9, r17
-  AddInt       r16, r16, r2
+  MakeMap      r74, 2, r70
+  // from ps in partsupp
+  Append       r4, r4, r74
+L3:
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r76, 1
+  Add          r48, r48, r76
   Jump         L4
-L10:
-  Sum          r16, r9
-  // let threshold = total * 0.0001
-  Const        r9, 0.0001
-  MulFloat     r4, r16, r9
-  // from x in grouped
-  Const        r9, []
-  IterPrep     r16, r19
-  Len          r19, r16
-  Move         r13, r11
+L2:
+  // join s in supplier on s.s_suppkey == ps.ps_suppkey
+  Const        r77, 1
+  Add          r28, r28, r77
+  Jump         L5
+L1:
+  // from ps in partsupp
+  Const        r78, 1
+  AddInt       r13, r13, r78
+  Jump         L6
+L0:
+  // from x in filtered
+  Const        r79, []
+  // group by x.ps_partkey into g
+  Const        r80, "ps_partkey"
+  // ps_partkey: g.key,
+  Const        r81, "ps_partkey"
+  Const        r82, "key"
+  // value: sum(from r in g select r.value)
+  Const        r83, "value"
+  Const        r84, "value"
+  // from x in filtered
+  IterPrep     r85, r4
+  Len          r86, r85
+  Const        r87, 0
+  MakeMap      r88, 0, r0
+  Const        r89, []
+L9:
+  LessInt      r91, r87, r86
+  JumpIfFalse  r91, L7
+  Index        r92, r85, r87
+  Move         r93, r92
+  // group by x.ps_partkey into g
+  Const        r94, "ps_partkey"
+  Index        r95, r93, r94
+  Str          r96, r95
+  In           r97, r96, r88
+  JumpIfTrue   r97, L8
+  // from x in filtered
+  Const        r98, []
+  Const        r99, "__group__"
+  Const        r100, true
+  Const        r101, "key"
+  // group by x.ps_partkey into g
+  Move         r102, r95
+  // from x in filtered
+  Const        r103, "items"
+  Move         r104, r98
+  Const        r105, "count"
+  Const        r106, 0
+  Move         r107, r99
+  Move         r108, r100
+  Move         r109, r101
+  Move         r110, r102
+  Move         r111, r103
+  Move         r112, r104
+  Move         r113, r105
+  Move         r114, r106
+  MakeMap      r115, 4, r107
+  SetIndex     r88, r96, r115
+  Append       r89, r89, r115
+L8:
+  Const        r117, "items"
+  Index        r118, r88, r96
+  Index        r119, r118, r117
+  Append       r120, r119, r92
+  SetIndex     r118, r117, r120
+  Const        r121, "count"
+  Index        r122, r118, r121
+  Const        r123, 1
+  AddInt       r124, r122, r123
+  SetIndex     r118, r121, r124
+  Const        r125, 1
+  AddInt       r87, r87, r125
+  Jump         L9
+L7:
+  Const        r126, 0
+  Len          r128, r89
 L13:
-  LessInt      r11, r13, r19
-  JumpIfFalse  r11, L11
-  Index        r6, r16, r13
-  // where x.value > threshold
-  Index        r11, r6, r7
-  LessFloat    r19, r4, r11
-  JumpIfFalse  r19, L12
-  // sort by -x.value
-  Index        r19, r6, r7
-  Neg          r7, r19
-  // from x in grouped
-  Move         r19, r6
-  MakeList     r17, 2, r7
-  Append       r9, r9, r17
+  LessInt      r129, r126, r128
+  JumpIfFalse  r129, L10
+  Index        r131, r89, r126
+  // ps_partkey: g.key,
+  Const        r132, "ps_partkey"
+  Const        r133, "key"
+  Index        r134, r131, r133
+  // value: sum(from r in g select r.value)
+  Const        r135, "value"
+  Const        r136, []
+  Const        r137, "value"
+  IterPrep     r138, r131
+  Len          r139, r138
+  Const        r140, 0
 L12:
-  AddInt       r13, r13, r2
-  Jump         L13
+  LessInt      r142, r140, r139
+  JumpIfFalse  r142, L11
+  Index        r144, r138, r140
+  Const        r145, "value"
+  Index        r146, r144, r145
+  Append       r136, r136, r146
+  Const        r148, 1
+  AddInt       r140, r140, r148
+  Jump         L12
 L11:
+  Sum          r149, r136
+  // ps_partkey: g.key,
+  Move         r150, r132
+  Move         r151, r134
+  // value: sum(from r in g select r.value)
+  Move         r152, r135
+  Move         r153, r149
+  // select {
+  MakeMap      r154, 2, r150
+  // from x in filtered
+  Append       r79, r79, r154
+  Const        r156, 1
+  AddInt       r126, r126, r156
+  Jump         L13
+L10:
+  // sum(from x in filtered select x.value)
+  Const        r157, []
+  Const        r158, "value"
+  IterPrep     r159, r4
+  Len          r160, r159
+  Const        r161, 0
+L15:
+  LessInt      r163, r161, r160
+  JumpIfFalse  r163, L14
+  Index        r93, r159, r161
+  Const        r165, "value"
+  Index        r166, r93, r165
+  Append       r157, r157, r166
+  Const        r168, 1
+  AddInt       r161, r161, r168
+  Jump         L15
+L14:
+  Sum          r169, r157
+  // let threshold = total * 0.0001
+  Const        r170, 0.0001
+  MulFloat     r171, r169, r170
+  // from x in grouped
+  Const        r172, []
+  // where x.value > threshold
+  Const        r173, "value"
   // sort by -x.value
-  Sort         r9, r9
+  Const        r174, "value"
+  // from x in grouped
+  IterPrep     r175, r79
+  Len          r176, r175
+  Const        r177, 0
+L18:
+  LessInt      r179, r177, r176
+  JumpIfFalse  r179, L16
+  Index        r93, r175, r177
+  // where x.value > threshold
+  Const        r181, "value"
+  Index        r182, r93, r181
+  LessFloat    r183, r171, r182
+  JumpIfFalse  r183, L17
+  // sort by -x.value
+  Const        r184, "value"
+  Index        r185, r93, r184
+  Neg          r187, r185
+  // from x in grouped
+  Move         r188, r93
+  MakeList     r189, 2, r187
+  Append       r172, r172, r189
+L17:
+  Const        r191, 1
+  AddInt       r177, r177, r191
+  Jump         L18
+L16:
+  // sort by -x.value
+  Sort         r172, r172
   // json(result)
-  JSON         r9
+  JSON         r172
   // expect result == [
-  Const        r19, [{"ps_partkey": 1000, "value": 2000}, {"ps_partkey": 2000, "value": 50}]
-  Equal        r7, r9, r19
-  Expect       r7
+  Const        r193, [{"ps_partkey": 1000, "value": 2000}, {"ps_partkey": 2000, "value": 50}]
+  Equal        r194, r172, r193
+  Expect       r194
   Return       r0

--- a/tests/dataset/tpc-h/out/q12.ir.out
+++ b/tests/dataset/tpc-h/out/q12.ir.out
@@ -1,202 +1,254 @@
-func main (regs=27)
+func main (regs=176)
   // let orders = [
   Const        r0, [{"o_orderkey": 1, "o_orderpriority": "1-URGENT"}, {"o_orderkey": 2, "o_orderpriority": "3-MEDIUM"}]
   // let lineitem = [
   Const        r1, [{"l_commitdate": "1994-02-10", "l_orderkey": 1, "l_receiptdate": "1994-02-15", "l_shipdate": "1994-02-05", "l_shipmode": "MAIL"}, {"l_commitdate": "1994-03-01", "l_orderkey": 2, "l_receiptdate": "1994-02-28", "l_shipdate": "1994-02-27", "l_shipmode": "SHIP"}]
   // from l in lineitem
   Const        r2, []
-L1:
   // group by l.l_shipmode into g
   Const        r3, "l_shipmode"
-L4:
-  // (l.l_commitdate < l.l_receiptdate) &&
-  Const        r4, "l_commitdate"
-  Const        r5, "l_receiptdate"
-L5:
-  // (l.l_shipdate < l.l_commitdate) &&
-  Const        r6, "l_shipdate"
-  // l_shipmode: g.key,
-  Const        r7, "key"
-L0:
-  // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
-  Const        r8, "high_line_count"
-  Const        r9, "o"
-  Const        r10, "o_orderpriority"
-  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
-  Const        r11, "low_line_count"
-  // from l in lineitem
-  MakeMap      r12, 0, r0
-L3:
-  IterPrep     r13, r1
-  Len          r1, r13
-L7:
-  Const        r14, 0
-L9:
-  LessInt      r15, r14, r1
-  JumpIfFalse  r15, L0
-L6:
-  Index        r1, r13, r14
-  // join o in orders on o.o_orderkey == l.l_orderkey
-  IterPrep     r13, r0
-  Len          r16, r13
-  Move         r17, r14
-  LessInt      r18, r17, r16
-  JumpIfFalse  r18, L1
-L10:
-  Index        r16, r13, r17
-L2:
-  Const        r13, "o_orderkey"
-  Index        r19, r16, r13
-  Const        r13, "l_orderkey"
-  Index        r20, r1, r13
-  Equal        r13, r19, r20
-  JumpIfFalse  r13, L2
   // (l.l_shipmode in ["MAIL", "SHIP"]) &&
-  Index        r13, r1, r3
-  Const        r20, ["MAIL", "SHIP"]
-  In           r19, r13, r20
-  JumpIfFalse  r19, L3
+  Const        r4, "l_shipmode"
   // (l.l_commitdate < l.l_receiptdate) &&
-  Index        r19, r1, r4
-  Index        r20, r1, r5
-  Less         r13, r19, r20
-  JumpIfFalse  r13, L4
+  Const        r5, "l_commitdate"
+  Const        r6, "l_receiptdate"
   // (l.l_shipdate < l.l_commitdate) &&
-  Index        r13, r1, r6
-  Index        r6, r1, r4
-  Less         r4, r13, r6
-  JumpIfFalse  r4, L5
+  Const        r7, "l_shipdate"
+  Const        r8, "l_commitdate"
   // (l.l_receiptdate >= "1994-01-01") &&
-  Index        r4, r1, r5
-  Const        r6, "1994-01-01"
-  LessEq       r13, r6, r4
-  JumpIfFalse  r13, L5
+  Const        r9, "l_receiptdate"
   // (l.l_receiptdate < "1995-01-01")
-  Index        r6, r1, r5
-  Const        r5, "1995-01-01"
-  Less         r13, r6, r5
-  // (l.l_shipmode in ["MAIL", "SHIP"]) &&
-  JumpIfFalse  r13, L2
-  // from l in lineitem
-  Const        r5, "l"
-  Move         r6, r1
-  Move         r13, r16
-  MakeMap      r16, 2, r5
-  // group by l.l_shipmode into g
-  Index        r13, r1, r3
-  Str          r1, r13
-  In           r6, r1, r12
-  JumpIfTrue   r6, L2
-  // from l in lineitem
-  Move         r6, r2
-  Const        r5, "__group__"
-  Const        r4, true
-  Move         r20, r7
-  // group by l.l_shipmode into g
-  Move         r19, r13
-  // from l in lineitem
-  Const        r13, "items"
-  Move         r21, r6
-  Const        r6, "count"
-  Move         r22, r14
-  Move         r23, r5
-  Move         r5, r4
-  Move         r4, r20
-  Move         r20, r19
-  Move         r19, r13
-  Move         r24, r21
-  Move         r21, r6
-  Move         r25, r22
-  MakeMap      r26, 4, r23
-  SetIndex     r12, r1, r26
-  Move         r26, r13
-  Index        r13, r12, r1
-  Index        r1, r13, r26
-  Append       r25, r1, r16
-  SetIndex     r13, r26, r25
-  Move         r25, r6
-  Index        r6, r13, r25
-  Const        r1, 1
-  AddInt       r26, r6, r1
-  SetIndex     r13, r25, r26
-  // join o in orders on o.o_orderkey == l.l_orderkey
-  AddInt       r17, r17, r1
-  Jump         L6
-  // from l in lineitem
-  AddInt       r14, r14, r1
-  Jump         L7
-  Values       26,12,0,0
-  Move         r12, r22
-  Move         r22, r12
-  Len          r6, r26
-  LessInt      r25, r22, r6
-  JumpIfFalse  r25, L8
-  Index        r25, r26, r22
+  Const        r10, "l_receiptdate"
   // l_shipmode: g.key,
-  Move         r26, r3
-  Index        r3, r25, r7
+  Const        r11, "l_shipmode"
+  Const        r12, "key"
   // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
-  Move         r6, r8
-  Move         r8, r2
-  IterPrep     r13, r25
-  Len          r18, r13
-  Move         r17, r12
-  LessInt      r15, r17, r18
-  JumpIfFalse  r15, L6
-  Index        r18, r13, r17
-  Index        r13, r18, r9
-  Index        r14, r13, r10
-  Const        r13, ["1-URGENT", "2-HIGH"]
-  In           r16, r14, r13
-  JumpIfFalse  r16, L6
-  Append       r8, r8, r12
-  AddInt       r17, r17, r1
-  Jump         L9
-  Sum          r14, r8
+  Const        r13, "high_line_count"
+  Const        r14, "o"
+  Const        r15, "o_orderpriority"
   // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
-  Move         r16, r11
-  Move         r8, r2
-  IterPrep     r11, r25
-  Len          r17, r11
-  Move         r21, r12
-  LessInt      r24, r21, r17
-  JumpIfFalse  r24, L10
-  Index        r18, r11, r21
-  Index        r24, r18, r9
-  Index        r18, r24, r10
-  In           r24, r18, r13
-  Not          r18, r24
-  JumpIfFalse  r18, L10
-  Append       r8, r8, r12
-  AddInt       r21, r21, r1
-  Jump         L6
-  Sum          r24, r8
-  // l_shipmode: g.key,
-  Move         r8, r26
-  Move         r26, r3
-  // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
-  Move         r18, r6
-  Move         r6, r14
-  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
-  Move         r14, r16
-  Move         r16, r24
-  // select {
-  MakeMap      r24, 3, r8
+  Const        r16, "low_line_count"
+  Const        r17, "o"
+  Const        r18, "o_orderpriority"
   // sort by g.key
-  Index        r16, r25, r7
+  Const        r19, "key"
   // from l in lineitem
-  Move         r25, r24
-  MakeList     r24, 2, r16
-  Append       r2, r2, r24
-  AddInt       r22, r22, r1
-  Jump         L7
+  MakeMap      r20, 0, r0
+  Const        r21, []
+  IterPrep     r23, r1
+  Len          r24, r23
+  Const        r25, 0
+L9:
+  LessInt      r26, r25, r24
+  JumpIfFalse  r26, L0
+  Index        r28, r23, r25
+  // join o in orders on o.o_orderkey == l.l_orderkey
+  IterPrep     r29, r0
+  Len          r30, r29
+  Const        r31, 0
 L8:
+  LessInt      r32, r31, r30
+  JumpIfFalse  r32, L1
+  Index        r34, r29, r31
+  Const        r35, "o_orderkey"
+  Index        r36, r34, r35
+  Const        r37, "l_orderkey"
+  Index        r38, r28, r37
+  Equal        r39, r36, r38
+  JumpIfFalse  r39, L2
+  // (l.l_shipmode in ["MAIL", "SHIP"]) &&
+  Const        r40, "l_shipmode"
+  Index        r41, r28, r40
+  Const        r42, ["MAIL", "SHIP"]
+  In           r44, r41, r42
+  JumpIfFalse  r44, L3
+  // (l.l_commitdate < l.l_receiptdate) &&
+  Const        r45, "l_commitdate"
+  Index        r46, r28, r45
+  Const        r47, "l_receiptdate"
+  Index        r48, r28, r47
+  Less         r50, r46, r48
+L3:
+  JumpIfFalse  r50, L4
+  // (l.l_shipdate < l.l_commitdate) &&
+  Const        r51, "l_shipdate"
+  Index        r52, r28, r51
+  Const        r53, "l_commitdate"
+  Index        r54, r28, r53
+  Less         r56, r52, r54
+L4:
+  JumpIfFalse  r56, L5
+  // (l.l_receiptdate >= "1994-01-01") &&
+  Const        r57, "l_receiptdate"
+  Index        r58, r28, r57
+  Const        r59, "1994-01-01"
+  LessEq       r61, r59, r58
+L5:
+  JumpIfFalse  r61, L6
+  // (l.l_receiptdate < "1995-01-01")
+  Const        r62, "l_receiptdate"
+  Index        r63, r28, r62
+  Const        r64, "1995-01-01"
+  Less         r61, r63, r64
+L6:
+  // (l.l_shipmode in ["MAIL", "SHIP"]) &&
+  JumpIfFalse  r61, L2
+  // from l in lineitem
+  Const        r66, "l"
+  Move         r67, r28
+  Const        r68, "o"
+  Move         r69, r34
+  MakeMap      r70, 2, r66
+  // group by l.l_shipmode into g
+  Const        r71, "l_shipmode"
+  Index        r72, r28, r71
+  Str          r73, r72
+  In           r74, r73, r20
+  JumpIfTrue   r74, L7
+  // from l in lineitem
+  Const        r75, []
+  Const        r76, "__group__"
+  Const        r77, true
+  Const        r78, "key"
+  // group by l.l_shipmode into g
+  Move         r79, r72
+  // from l in lineitem
+  Const        r80, "items"
+  Move         r81, r75
+  Const        r82, "count"
+  Const        r83, 0
+  Move         r84, r76
+  Move         r85, r77
+  Move         r86, r78
+  Move         r87, r79
+  Move         r88, r80
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  MakeMap      r92, 4, r84
+  SetIndex     r20, r73, r92
+  Append       r21, r21, r92
+L7:
+  Const        r94, "items"
+  Index        r95, r20, r73
+  Index        r96, r95, r94
+  Append       r97, r96, r70
+  SetIndex     r95, r94, r97
+  Const        r98, "count"
+  Index        r99, r95, r98
+  Const        r100, 1
+  AddInt       r101, r99, r100
+  SetIndex     r95, r98, r101
+L2:
+  // join o in orders on o.o_orderkey == l.l_orderkey
+  Const        r102, 1
+  AddInt       r31, r31, r102
+  Jump         L8
+L1:
+  // from l in lineitem
+  Const        r103, 1
+  AddInt       r25, r25, r103
+  Jump         L9
+L0:
+  Const        r104, 0
+  Len          r106, r21
+L19:
+  LessInt      r107, r104, r106
+  JumpIfFalse  r107, L10
+  Index        r109, r21, r104
+  // l_shipmode: g.key,
+  Const        r110, "l_shipmode"
+  Const        r111, "key"
+  Index        r112, r109, r111
+  // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
+  Const        r113, "high_line_count"
+  Const        r114, []
+  Const        r115, "o"
+  Const        r116, "o_orderpriority"
+  IterPrep     r117, r109
+  Len          r118, r117
+  Const        r119, 0
+L14:
+  LessInt      r121, r119, r118
+  JumpIfFalse  r121, L11
+  Index        r123, r117, r119
+  Const        r124, "o"
+  Index        r125, r123, r124
+  Const        r126, "o_orderpriority"
+  Index        r127, r125, r126
+  Const        r128, ["1-URGENT", "2-HIGH"]
+  In           r129, r127, r128
+  JumpIfFalse  r129, L12
+  Const        r131, 1
+  Jump         L13
+L12:
+  Const        r131, 0
+L13:
+  Append       r114, r114, r131
+  Const        r134, 1
+  AddInt       r119, r119, r134
+  Jump         L14
+L11:
+  Sum          r135, r114
+  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
+  Const        r136, "low_line_count"
+  Const        r137, []
+  Const        r138, "o"
+  Const        r139, "o_orderpriority"
+  IterPrep     r140, r109
+  Len          r141, r140
+  Const        r142, 0
+L18:
+  LessInt      r144, r142, r141
+  JumpIfFalse  r144, L15
+  Index        r123, r140, r142
+  Const        r146, "o"
+  Index        r147, r123, r146
+  Const        r148, "o_orderpriority"
+  Index        r149, r147, r148
+  Const        r150, ["1-URGENT", "2-HIGH"]
+  In           r151, r149, r150
+  Not          r152, r151
+  JumpIfFalse  r152, L16
+  Const        r154, 1
+  Jump         L17
+L16:
+  Const        r154, 0
+L17:
+  Append       r137, r137, r154
+  Const        r157, 1
+  AddInt       r142, r142, r157
+  Jump         L18
+L15:
+  Sum          r158, r137
+  // l_shipmode: g.key,
+  Move         r159, r110
+  Move         r160, r112
+  // high_line_count: sum(from x in g select if x.o.o_orderpriority in ["1-URGENT", "2-HIGH"] { 1 } else { 0 }),
+  Move         r161, r113
+  Move         r162, r135
+  // low_line_count: sum(from x in g select if !(x.o.o_orderpriority in ["1-URGENT", "2-HIGH"]) { 1 } else { 0 })
+  Move         r163, r136
+  Move         r164, r158
+  // select {
+  MakeMap      r165, 3, r159
+  // sort by g.key
+  Const        r166, "key"
+  Index        r168, r109, r166
+  // from l in lineitem
+  Move         r169, r165
+  MakeList     r170, 2, r168
+  Append       r2, r2, r170
+  Const        r172, 1
+  AddInt       r104, r104, r172
+  Jump         L19
+L10:
   // sort by g.key
   Sort         r2, r2
   // json(result)
   JSON         r2
   // expect result == [
-  Const        r24, [{"high_line_count": 1, "l_shipmode": "MAIL", "low_line_count": 0}]
-  Equal        r25, r2, r24
-  Expect       r25
+  Const        r174, [{"high_line_count": 1, "l_shipmode": "MAIL", "low_line_count": 0}]
+  Equal        r175, r2, r174
+  Expect       r175
   Return       r0

--- a/tests/dataset/tpc-h/out/q13.ir.out
+++ b/tests/dataset/tpc-h/out/q13.ir.out
@@ -1,159 +1,190 @@
-func main (regs=23)
+func main (regs=128)
   // let customer = [
   Const        r0, [{"c_custkey": 1}, {"c_custkey": 2}, {"c_custkey": 3}]
   // let orders = [
   Const        r1, [{"o_comment": "fast delivery", "o_custkey": 1, "o_orderkey": 100}, {"o_comment": "no comment", "o_custkey": 1, "o_orderkey": 101}, {"o_comment": "special requests only", "o_custkey": 2, "o_orderkey": 102}]
-L5:
   // from c in customer
   Const        r2, []
   // c_count: count(
   Const        r3, "c_count"
-L2:
   // o.o_custkey == c.c_custkey &&
   Const        r4, "o_custkey"
   Const        r5, "c_custkey"
   // (!("special" in o.o_comment)) &&
   Const        r6, "o_comment"
-  // from c in customer
-  IterPrep     r7, r0
-  Len          r8, r7
-  Const        r9, 0
-L0:
-  Move         r10, r9
-L4:
-  LessInt      r11, r10, r8
-L8:
-  JumpIfFalse  r11, L0
-L6:
-  Index        r8, r7, r10
-  // c_count: count(
-  Move         r7, r3
-L1:
-  // from o in orders
-  Move         r12, r2
-  IterPrep     r13, r1
-  Len          r1, r13
-  Move         r14, r9
-  LessInt      r15, r14, r1
-  JumpIfFalse  r15, L1
-  Index        r1, r13, r14
-  // o.o_custkey == c.c_custkey &&
-  Index        r13, r1, r4
-  Index        r4, r8, r5
-  Equal        r8, r13, r4
-  JumpIfFalse  r8, L2
-  // (!("special" in o.o_comment)) &&
-  Const        r8, "special"
-  Index        r4, r1, r6
-  In           r13, r8, r4
-  Not          r4, r13
-  JumpIfFalse  r4, L3
   // (!("requests" in o.o_comment))
-  Const        r13, "requests"
-  Index        r8, r1, r6
-  In           r6, r13, r8
-  Not          r4, r6
+  Const        r7, "o_comment"
+  // from c in customer
+  IterPrep     r8, r0
+  Len          r9, r8
+  Const        r10, 0
+L6:
+  LessInt      r12, r10, r9
+  JumpIfFalse  r12, L0
+  Index        r14, r8, r10
+  // c_count: count(
+  Const        r15, "c_count"
+  // from o in orders
+  Const        r16, []
+  // o.o_custkey == c.c_custkey &&
+  Const        r17, "o_custkey"
+  Const        r18, "c_custkey"
+  // (!("special" in o.o_comment)) &&
+  Const        r19, "o_comment"
+  // (!("requests" in o.o_comment))
+  Const        r20, "o_comment"
+  // from o in orders
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L5:
+  LessInt      r25, r23, r22
+  JumpIfFalse  r25, L1
+  Index        r27, r21, r23
+  // o.o_custkey == c.c_custkey &&
+  Const        r28, "o_custkey"
+  Index        r29, r27, r28
+  Const        r30, "c_custkey"
+  Index        r31, r14, r30
+  Equal        r33, r29, r31
+  JumpIfFalse  r33, L2
+  // (!("special" in o.o_comment)) &&
+  Const        r34, "special"
+  Const        r35, "o_comment"
+  Index        r36, r27, r35
+  In           r37, r34, r36
+  Not          r39, r37
+L2:
+  JumpIfFalse  r39, L3
+  // (!("requests" in o.o_comment))
+  Const        r40, "requests"
+  Const        r41, "o_comment"
+  Index        r42, r27, r41
+  In           r43, r40, r42
+  Not          r39, r43
 L3:
   // where (
-  JumpIfFalse  r4, L1
+  JumpIfFalse  r39, L4
   // from o in orders
-  Append       r12, r12, r1
-  Const        r6, 1
-  AddInt       r14, r14, r6
-  Jump         L1
+  Append       r16, r16, r27
+L4:
+  Const        r46, 1
+  AddInt       r23, r23, r46
+  Jump         L5
+L1:
   // c_count: count(
-  Count        r15, r12
-  Move         r12, r7
-  Move         r7, r15
+  Count        r47, r16
+  Move         r48, r15
+  Move         r49, r47
   // select {
-  MakeMap      r15, 1, r12
+  MakeMap      r50, 1, r48
   // from c in customer
-  Append       r2, r2, r15
-  AddInt       r10, r10, r6
-  Jump         L4
-  // from x in per_customer
-  Const        r15, []
-  // select { c_count: g.key, custdist: count(g) }
-  Const        r7, "key"
-  Const        r12, "custdist"
-  // from x in per_customer
-  IterPrep     r11, r2
-  Len          r2, r11
-  Move         r10, r9
-  MakeMap      r14, 0, r0
-  LessInt      r8, r10, r2
-  JumpIfFalse  r8, L5
-  Index        r8, r11, r10
-  // group by x.c_count into g
-  Index        r11, r8, r3
-  Str          r2, r11
-  In           r13, r2, r14
-  JumpIfTrue   r13, L5
-  // from x in per_customer
-  Move         r4, r15
-  Const        r1, "__group__"
-  Const        r5, true
-  Move         r16, r7
-  // group by x.c_count into g
-  Move         r17, r11
-  // from x in per_customer
-  Const        r11, "items"
-  Move         r18, r4
-  Const        r4, "count"
-  Move         r19, r9
-  Move         r20, r1
-  Move         r1, r5
-  Move         r5, r16
-  Move         r16, r17
-  Move         r17, r11
-  Move         r21, r18
-  Move         r18, r4
-  Move         r22, r19
-  MakeMap      r19, 4, r20
-  SetIndex     r14, r2, r19
-  Move         r19, r11
-  Index        r11, r14, r2
-  Index        r2, r11, r19
-  Append       r22, r2, r8
-  SetIndex     r11, r19, r22
-  Move         r22, r4
-  Index        r4, r11, r22
-  AddInt       r2, r4, r6
-  SetIndex     r11, r22, r2
-  AddInt       r10, r10, r6
+  Append       r2, r2, r50
+  Const        r52, 1
+  AddInt       r10, r10, r52
   Jump         L6
-  Values       2,14,0,0
-  Move         r14, r9
-  Len          r9, r2
-  LessInt      r4, r14, r9
-  JumpIfFalse  r4, L7
-  Index        r4, r2, r14
-  // select { c_count: g.key, custdist: count(g) }
-  Move         r2, r3
-  Index        r3, r4, r7
-  Move         r9, r12
-  Index        r12, r4, r22
-  Move         r22, r2
-  Move         r2, r3
-  Move         r3, r9
-  Move         r9, r12
-  MakeMap      r12, 2, r22
-  // sort by -g.key
-  Index        r9, r4, r7
-  Neg          r4, r9
+L0:
   // from x in per_customer
-  Move         r9, r12
-  MakeList     r7, 2, r4
-  Append       r15, r15, r7
-  AddInt       r14, r14, r6
-  Jump         L8
-L7:
+  Const        r53, []
+  // group by x.c_count into g
+  Const        r54, "c_count"
+  // select { c_count: g.key, custdist: count(g) }
+  Const        r55, "c_count"
+  Const        r56, "key"
+  Const        r57, "custdist"
   // sort by -g.key
-  Sort         r15, r15
+  Const        r58, "key"
+  // from x in per_customer
+  IterPrep     r59, r2
+  Len          r60, r59
+  Const        r61, 0
+  MakeMap      r62, 0, r0
+  Const        r63, []
+L9:
+  LessInt      r65, r61, r60
+  JumpIfFalse  r65, L7
+  Index        r66, r59, r61
+  Move         r67, r66
+  // group by x.c_count into g
+  Const        r68, "c_count"
+  Index        r69, r67, r68
+  Str          r70, r69
+  In           r71, r70, r62
+  JumpIfTrue   r71, L8
+  // from x in per_customer
+  Const        r72, []
+  Const        r73, "__group__"
+  Const        r74, true
+  Const        r75, "key"
+  // group by x.c_count into g
+  Move         r76, r69
+  // from x in per_customer
+  Const        r77, "items"
+  Move         r78, r72
+  Const        r79, "count"
+  Const        r80, 0
+  Move         r81, r73
+  Move         r82, r74
+  Move         r83, r75
+  Move         r84, r76
+  Move         r85, r77
+  Move         r86, r78
+  Move         r87, r79
+  Move         r88, r80
+  MakeMap      r89, 4, r81
+  SetIndex     r62, r70, r89
+  Append       r63, r63, r89
+L8:
+  Const        r91, "items"
+  Index        r92, r62, r70
+  Index        r93, r92, r91
+  Append       r94, r93, r66
+  SetIndex     r92, r91, r94
+  Const        r95, "count"
+  Index        r96, r92, r95
+  Const        r97, 1
+  AddInt       r98, r96, r97
+  SetIndex     r92, r95, r98
+  Const        r99, 1
+  AddInt       r61, r61, r99
+  Jump         L9
+L7:
+  Const        r100, 0
+  Len          r102, r63
+L11:
+  LessInt      r103, r100, r102
+  JumpIfFalse  r103, L10
+  Index        r105, r63, r100
+  // select { c_count: g.key, custdist: count(g) }
+  Const        r106, "c_count"
+  Const        r107, "key"
+  Index        r108, r105, r107
+  Const        r109, "custdist"
+  Const        r110, "count"
+  Index        r111, r105, r110
+  Move         r112, r106
+  Move         r113, r108
+  Move         r114, r109
+  Move         r115, r111
+  MakeMap      r116, 2, r112
+  // sort by -g.key
+  Const        r117, "key"
+  Index        r118, r105, r117
+  Neg          r120, r118
+  // from x in per_customer
+  Move         r121, r116
+  MakeList     r122, 2, r120
+  Append       r53, r53, r122
+  Const        r124, 1
+  AddInt       r100, r100, r124
+  Jump         L11
+L10:
+  // sort by -g.key
+  Sort         r53, r53
   // json(grouped)
-  JSON         r15
+  JSON         r53
   // expect grouped == [
-  Const        r7, [{"c_count": 2, "custdist": 1}, {"c_count": 0, "custdist": 2}]
-  Equal        r9, r15, r7
-  Expect       r9
+  Const        r126, [{"c_count": 2, "custdist": 1}, {"c_count": 0, "custdist": 2}]
+  Equal        r127, r53, r126
+  Expect       r127
   Return       r0

--- a/tests/dataset/tpc-h/out/q14.ir.out
+++ b/tests/dataset/tpc-h/out/q14.ir.out
@@ -1,229 +1,268 @@
-func main (regs=30)
+func main (regs=162)
 L0:
   // let part = [
   Const        r0, [{"p_partkey": 1, "p_type": "PROMO LUXURY"}, {"p_partkey": 2, "p_type": "STANDARD BRASS"}]
-L1:
   // let lineitem = [
   Const        r1, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_partkey": 1, "l_shipdate": "1995-09-05"}, {"l_discount": 0, "l_extendedprice": 800, "l_partkey": 2, "l_shipdate": "1995-09-20"}, {"l_discount": 0.2, "l_extendedprice": 500, "l_partkey": 1, "l_shipdate": "1995-10-02"}]
   // let start_date = "1995-09-01"
   Const        r2, "1995-09-01"
   // let end_date = "1995-10-01"
   Const        r3, "1995-10-01"
-L12:
   // from l in lineitem
   Const        r4, []
   IterPrep     r5, r1
-  Len          r1, r5
+  Len          r6, r5
   // join p in part on p.p_partkey == l.l_partkey
-  IterPrep     r6, r0
-  Len          r7, r6
+  IterPrep     r7, r0
+  Len          r8, r7
+  // from l in lineitem
+  Const        r9, 0
+  EqualInt     r10, r6, r9
+  JumpIfTrue   r10, L0
+  EqualInt     r11, r8, r9
+  JumpIfTrue   r11, L0
+  LessEq       r12, r8, r6
+  JumpIfFalse  r12, L1
+  // join p in part on p.p_partkey == l.l_partkey
+  MakeMap      r13, 0, r0
+  Const        r14, 0
+L4:
+  LessInt      r15, r14, r8
+  JumpIfFalse  r15, L2
+  Index        r16, r7, r14
+  Move         r17, r16
+  Const        r18, "p_partkey"
+  Index        r19, r17, r18
+  Index        r20, r13, r19
+  Const        r21, nil
+  NotEqual     r22, r20, r21
+  JumpIfTrue   r22, L3
+  MakeList     r23, 0, r0
+  SetIndex     r13, r19, r23
+L3:
+  Index        r20, r13, r19
+  Append       r24, r20, r16
+  SetIndex     r13, r19, r24
+  Const        r25, 1
+  AddInt       r14, r14, r25
+  Jump         L4
 L2:
   // from l in lineitem
-  Const        r8, 0
-  EqualInt     r9, r1, r8
-  JumpIfTrue   r9, L0
-  EqualInt     r9, r7, r8
-L4:
-  JumpIfTrue   r9, L0
-L3:
-  LessEq       r9, r7, r1
-  JumpIfFalse  r9, L1
+  Const        r26, 0
+L9:
+  LessInt      r27, r26, r6
+  JumpIfFalse  r27, L0
+  Index        r29, r5, r26
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r30, "l_partkey"
+  Index        r31, r29, r30
+  // from l in lineitem
+  Index        r32, r13, r31
+  Const        r33, nil
+  NotEqual     r34, r32, r33
+  JumpIfFalse  r34, L5
+  Len          r35, r32
+  Const        r36, 0
+L8:
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L5
+  Index        r17, r32, r36
+  // where l.l_shipdate >= start_date && l.l_shipdate < end_date
+  Const        r39, "l_shipdate"
+  Index        r40, r29, r39
+  LessEq       r41, r2, r40
+  Const        r42, "l_shipdate"
+  Index        r43, r29, r42
+  Less         r44, r43, r3
+  Move         r45, r41
+  JumpIfFalse  r45, L6
+  Move         r45, r44
+L6:
+  JumpIfFalse  r45, L7
+  // is_promo: "PROMO" in p.p_type,
+  Const        r46, "is_promo"
+  Const        r47, "PROMO"
+  Const        r48, "p_type"
+  Index        r49, r17, r48
+  In           r50, r47, r49
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r51, "revenue"
+  Const        r52, "l_extendedprice"
+  Index        r53, r29, r52
+  Const        r54, 1
+  Const        r55, "l_discount"
+  Index        r56, r29, r55
+  Sub          r57, r54, r56
+  Mul          r58, r53, r57
+  // is_promo: "PROMO" in p.p_type,
+  Move         r59, r46
+  Move         r60, r50
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Move         r61, r51
+  Move         r62, r58
+  // select {
+  MakeMap      r63, 2, r59
+  // from l in lineitem
+  Append       r4, r4, r63
+L7:
+  Const        r65, 1
+  AddInt       r36, r36, r65
+  Jump         L8
+L5:
+  Const        r66, 1
+  AddInt       r26, r26, r66
+  Jump         L9
+L1:
+  MakeMap      r67, 0, r0
+  Const        r68, 0
+L12:
+  LessInt      r69, r68, r6
+  JumpIfFalse  r69, L10
+  Index        r70, r5, r68
+  Move         r29, r70
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r71, "l_partkey"
+  Index        r72, r29, r71
+  // from l in lineitem
+  Index        r73, r67, r72
+  Const        r74, nil
+  NotEqual     r75, r73, r74
+  JumpIfTrue   r75, L11
+  MakeList     r76, 0, r0
+  SetIndex     r67, r72, r76
+L11:
+  Index        r73, r67, r72
+  Append       r77, r73, r70
+  SetIndex     r67, r72, r77
+  Const        r78, 1
+  AddInt       r68, r68, r78
+  Jump         L12
 L10:
   // join p in part on p.p_partkey == l.l_partkey
-  MakeMap      r9, 0, r0
-  Move         r10, r8
-  LessInt      r11, r10, r7
-L7:
-  JumpIfFalse  r11, L2
-L6:
-  Index        r11, r6, r10
-L9:
-  Move         r12, r11
-  Const        r13, "p_partkey"
-  Index        r14, r12, r13
-L14:
-  Index        r15, r9, r14
-L5:
-  Const        r16, nil
-  NotEqual     r17, r15, r16
-L8:
-  JumpIfTrue   r17, L3
-  MakeList     r17, 0, r0
-  SetIndex     r9, r14, r17
-  Index        r15, r9, r14
-  Append       r17, r15, r11
-  SetIndex     r9, r14, r17
-  Const        r17, 1
-  AddInt       r10, r10, r17
-  Jump         L4
-  // from l in lineitem
-  Move         r10, r8
-  LessInt      r15, r10, r1
-  JumpIfFalse  r15, L0
-  Index        r15, r5, r10
-  // join p in part on p.p_partkey == l.l_partkey
-  Const        r14, "l_partkey"
-  Index        r11, r15, r14
-  // from l in lineitem
-  Index        r18, r9, r11
-  NotEqual     r11, r18, r16
-  JumpIfFalse  r11, L3
-  Len          r11, r18
-  Move         r9, r10
-  LessInt      r19, r9, r11
-  JumpIfFalse  r19, L3
-  Index        r12, r18, r9
-  // where l.l_shipdate >= start_date && l.l_shipdate < end_date
-  Const        r11, "l_shipdate"
-  Index        r18, r15, r11
-  LessEq       r20, r2, r18
-  Index        r18, r15, r11
-  Less         r21, r18, r3
-  Move         r18, r20
-  JumpIfFalse  r18, L5
-  Move         r18, r21
-  JumpIfFalse  r18, L4
-  // is_promo: "PROMO" in p.p_type,
-  Const        r18, "is_promo"
-  Const        r21, "PROMO"
-  Const        r20, "p_type"
-  Index        r22, r12, r20
-  In           r23, r21, r22
-  // revenue: l.l_extendedprice * (1 - l.l_discount)
-  Const        r22, "revenue"
-  Const        r24, "l_extendedprice"
-  Index        r25, r15, r24
-  Const        r26, "l_discount"
-  Index        r27, r15, r26
-  Sub          r28, r17, r27
-  Mul          r27, r25, r28
-  // is_promo: "PROMO" in p.p_type,
-  Move         r28, r18
-  Move         r25, r23
-  // revenue: l.l_extendedprice * (1 - l.l_discount)
-  Move         r23, r22
-  Move         r29, r27
-  // select {
-  MakeMap      r27, 2, r28
-  // from l in lineitem
-  Append       r4, r4, r27
-  AddInt       r9, r9, r17
-  Jump         L6
-  AddInt       r10, r10, r17
-  Jump         L7
-  MakeMap      r27, 0, r0
-  Move         r29, r8
-  LessInt      r23, r29, r1
-  JumpIfFalse  r23, L8
-  Index        r23, r5, r29
-  // join p in part on p.p_partkey == l.l_partkey
-  Index        r5, r23, r14
-  // from l in lineitem
-  Index        r14, r27, r5
-  Move         r1, r16
-  NotEqual     r16, r14, r1
-  JumpIfTrue   r16, L9
-  MakeList     r16, 0, r0
-  SetIndex     r27, r5, r16
-  Index        r14, r27, r5
-  Append       r16, r14, r23
-  SetIndex     r27, r5, r16
-  AddInt       r29, r29, r17
-  Jump         L10
-  // join p in part on p.p_partkey == l.l_partkey
-  Move         r16, r8
-  LessInt      r14, r16, r7
-  JumpIfFalse  r14, L11
-  Index        r12, r6, r16
-  Index        r14, r12, r13
-  Index        r13, r27, r14
-  NotEqual     r14, r13, r1
-  JumpIfFalse  r14, L10
-  Len          r14, r13
-  Move         r1, r16
-  LessInt      r27, r1, r14
-  JumpIfFalse  r27, L10
-  Index        r15, r13, r1
-  // where l.l_shipdate >= start_date && l.l_shipdate < end_date
-  Index        r27, r15, r11
-  LessEq       r14, r2, r27
-  Index        r27, r15, r11
-  Less         r11, r27, r3
-  Move         r27, r14
-  JumpIfFalse  r27, L12
-  Move         r27, r11
-  JumpIfFalse  r27, L13
-  // is_promo: "PROMO" in p.p_type,
-  Move         r27, r18
-  Index        r11, r12, r20
-  In           r20, r21, r11
-  // revenue: l.l_extendedprice * (1 - l.l_discount)
-  Move         r11, r22
-  Index        r21, r15, r24
-  Index        r24, r15, r26
-  Sub          r26, r17, r24
-  Mul          r24, r21, r26
-  // is_promo: "PROMO" in p.p_type,
-  Move         r26, r27
-  Move         r27, r20
-  // revenue: l.l_extendedprice * (1 - l.l_discount)
-  Move         r20, r11
-  Move         r11, r24
-  // select {
-  MakeMap      r24, 2, r26
-  // from l in lineitem
-  Append       r4, r4, r24
-L13:
-  // join p in part on p.p_partkey == l.l_partkey
-  AddInt       r1, r1, r17
-  Jump         L14
-  AddInt       r16, r16, r17
-  Jump         L6
-L11:
-  // let promo_sum = sum(from x in filtered where x.is_promo select x.revenue)
-  Const        r20, []
-  Move         r16, r18
-  Move         r18, r22
-  IterPrep     r22, r4
-  Len          r11, r22
-  Move         r24, r8
-L17:
-  LessInt      r27, r24, r11
-  JumpIfFalse  r27, L15
-  Index        r27, r22, r24
-  Index        r22, r27, r16
-  JumpIfFalse  r22, L16
-  Index        r22, r27, r18
-  Append       r20, r20, r22
-L16:
-  AddInt       r24, r24, r17
-  Jump         L17
-L15:
-  Sum          r22, r20
-  // let total_sum = sum(from x in filtered select x.revenue)
-  Const        r20, []
-  IterPrep     r24, r4
-  Len          r4, r24
-  Move         r16, r8
-L19:
-  LessInt      r8, r16, r4
-  JumpIfFalse  r8, L18
-  Index        r27, r24, r16
-  Index        r8, r27, r18
-  Append       r20, r20, r8
-  AddInt       r16, r16, r17
-  Jump         L19
+  Const        r79, 0
 L18:
-  Sum          r8, r20
+  LessInt      r80, r79, r8
+  JumpIfFalse  r80, L13
+  Index        r17, r7, r79
+  Const        r82, "p_partkey"
+  Index        r83, r17, r82
+  Index        r84, r67, r83
+  Const        r85, nil
+  NotEqual     r86, r84, r85
+  JumpIfFalse  r86, L14
+  Len          r87, r84
+  Const        r88, 0
+L17:
+  LessInt      r89, r88, r87
+  JumpIfFalse  r89, L14
+  Index        r29, r84, r88
+  // where l.l_shipdate >= start_date && l.l_shipdate < end_date
+  Const        r91, "l_shipdate"
+  Index        r92, r29, r91
+  LessEq       r93, r2, r92
+  Const        r94, "l_shipdate"
+  Index        r95, r29, r94
+  Less         r96, r95, r3
+  Move         r97, r93
+  JumpIfFalse  r97, L15
+  Move         r97, r96
+L15:
+  JumpIfFalse  r97, L16
+  // is_promo: "PROMO" in p.p_type,
+  Const        r98, "is_promo"
+  Const        r99, "PROMO"
+  Const        r100, "p_type"
+  Index        r101, r17, r100
+  In           r102, r99, r101
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r103, "revenue"
+  Const        r104, "l_extendedprice"
+  Index        r105, r29, r104
+  Const        r106, 1
+  Const        r107, "l_discount"
+  Index        r108, r29, r107
+  Sub          r109, r106, r108
+  Mul          r110, r105, r109
+  // is_promo: "PROMO" in p.p_type,
+  Move         r111, r98
+  Move         r112, r102
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Move         r113, r103
+  Move         r114, r110
+  // select {
+  MakeMap      r115, 2, r111
+  // from l in lineitem
+  Append       r4, r4, r115
+L16:
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r117, 1
+  AddInt       r88, r88, r117
+  Jump         L17
+L14:
+  Const        r118, 1
+  AddInt       r79, r79, r118
+  Jump         L18
+L13:
+  // let promo_sum = sum(from x in filtered where x.is_promo select x.revenue)
+  Const        r119, []
+  Const        r120, "is_promo"
+  Const        r121, "revenue"
+  IterPrep     r122, r4
+  Len          r123, r122
+  Const        r124, 0
+L21:
+  LessInt      r126, r124, r123
+  JumpIfFalse  r126, L19
+  Index        r128, r122, r124
+  Const        r129, "is_promo"
+  Index        r130, r128, r129
+  JumpIfFalse  r130, L20
+  Const        r131, "revenue"
+  Index        r132, r128, r131
+  Append       r119, r119, r132
+L20:
+  Const        r134, 1
+  AddInt       r124, r124, r134
+  Jump         L21
+L19:
+  Sum          r135, r119
+  // let total_sum = sum(from x in filtered select x.revenue)
+  Const        r136, []
+  Const        r137, "revenue"
+  IterPrep     r138, r4
+  Len          r139, r138
+  Const        r140, 0
+L23:
+  LessInt      r142, r140, r139
+  JumpIfFalse  r142, L22
+  Index        r128, r138, r140
+  Const        r144, "revenue"
+  Index        r145, r128, r144
+  Append       r136, r136, r145
+  Const        r147, 1
+  AddInt       r140, r140, r147
+  Jump         L23
+L22:
+  Sum          r148, r136
   // let result = 100.0 * promo_sum / total_sum
-  Const        r20, 100
-  MulFloat     r16, r20, r22
-  DivFloat     r20, r16, r8
+  Const        r149, 100
+  MulFloat     r150, r149, r135
+  DivFloat     r151, r150, r148
   // json(result)
-  JSON         r20
+  JSON         r151
+  // let promo = 1000.0 * 0.9       // = 900
+  Const        r152, 1000
+  Const        r153, 0.9
+  Const        r154, 900
+  // let total = 900 + 800.0        // = 1700
+  Const        r155, 900
+  Const        r156, 800
+  Const        r157, 1700
   // let expected = 100.0 * promo / total  // ≈ 52.94
-  Const        r16, 52.94117647058823
+  Const        r158, 100
+  Const        r159, 90000
+  Const        r160, 52.94117647058823
   // expect result == expected
-  EqualFloat   r8, r20, r16
-  Expect       r8
+  EqualFloat   r161, r151, r160
+  Expect       r161
   Return       r0

--- a/tests/dataset/tpc-h/out/q15.ir.out
+++ b/tests/dataset/tpc-h/out/q15.ir.out
@@ -1,8 +1,7 @@
-func main (regs=36)
-L8:
+func main (regs=273)
+L11:
   // let supplier = [
   Const        r0, [{"s_address": "123 Market St", "s_name": "Best Supplier", "s_phone": "123-456", "s_suppkey": 100}, {"s_address": "456 Elm St", "s_name": "Second Supplier", "s_phone": "987-654", "s_suppkey": 200}]
-L16:
   // let lineitem = [
   Const        r1, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_shipdate": "1996-01-15", "l_suppkey": 100}, {"l_discount": 0, "l_extendedprice": 500, "l_shipdate": "1996-03-20", "l_suppkey": 100}, {"l_discount": 0.05, "l_extendedprice": 800, "l_shipdate": "1995-12-30", "l_suppkey": 200}]
   // let start_date = "1996-01-01"
@@ -11,362 +10,416 @@ L16:
   Const        r3, "1996-04-01"
   // from l in lineitem
   Const        r4, []
-L1:
   // group by l.l_suppkey into g
   Const        r5, "l_suppkey"
   // where l.l_shipdate >= start_date && l.l_shipdate < end_date
   Const        r6, "l_shipdate"
+  Const        r7, "l_shipdate"
   // supplier_no: g.key,
-  Const        r7, "supplier_no"
-  Const        r8, "key"
+  Const        r8, "supplier_no"
+  Const        r9, "key"
   // total_revenue: sum(from x in g select x.l_extendedprice * (1 - x.l_discount))
-  Const        r9, "total_revenue"
-L6:
-  Const        r10, "l_extendedprice"
-  Const        r11, "l_discount"
-L3:
+  Const        r10, "total_revenue"
+  Const        r11, "l_extendedprice"
+  Const        r12, "l_discount"
   // from l in lineitem
-  IterPrep     r12, r1
-  Len          r1, r12
-  Const        r13, 0
-L0:
-  MakeMap      r14, 0, r0
-  LessInt      r15, r13, r1
-L12:
-  JumpIfFalse  r15, L0
+  IterPrep     r13, r1
+  Len          r14, r13
+  Const        r15, 0
+  MakeMap      r16, 0, r0
+  Const        r17, []
 L4:
-  Index        r1, r12, r13
-  Move         r12, r1
+  LessInt      r19, r15, r14
+  JumpIfFalse  r19, L0
+  Index        r20, r13, r15
+  Move         r21, r20
   // where l.l_shipdate >= start_date && l.l_shipdate < end_date
-  Index        r16, r12, r6
-L7:
-  LessEq       r17, r2, r16
+  Const        r22, "l_shipdate"
+  Index        r23, r21, r22
+  LessEq       r24, r2, r23
+  Const        r25, "l_shipdate"
+  Index        r26, r21, r25
+  Less         r27, r26, r3
+  Move         r28, r24
+  JumpIfFalse  r28, L1
+  Move         r28, r27
+L1:
+  JumpIfFalse  r28, L2
+  // group by l.l_suppkey into g
+  Const        r29, "l_suppkey"
+  Index        r30, r21, r29
+  Str          r31, r30
+  In           r32, r31, r16
+  JumpIfTrue   r32, L3
+  // from l in lineitem
+  Const        r33, []
+  Const        r34, "__group__"
+  Const        r35, true
+  Const        r36, "key"
+  // group by l.l_suppkey into g
+  Move         r37, r30
+  // from l in lineitem
+  Const        r38, "items"
+  Move         r39, r33
+  Const        r40, "count"
+  Const        r41, 0
+  Move         r42, r34
+  Move         r43, r35
+  Move         r44, r36
+  Move         r45, r37
+  Move         r46, r38
+  Move         r47, r39
+  Move         r48, r40
+  Move         r49, r41
+  MakeMap      r50, 4, r42
+  SetIndex     r16, r31, r50
+  Append       r17, r17, r50
+L3:
+  Const        r52, "items"
+  Index        r53, r16, r31
+  Index        r54, r53, r52
+  Append       r55, r54, r20
+  SetIndex     r53, r52, r55
+  Const        r56, "count"
+  Index        r57, r53, r56
+  Const        r58, 1
+  AddInt       r59, r57, r58
+  SetIndex     r53, r56, r59
 L2:
-  Index        r16, r12, r6
-L11:
-  Less         r6, r16, r3
-  Move         r16, r17
-  JumpIfFalse  r16, L1
-L9:
-  Move         r16, r6
-  JumpIfFalse  r16, L2
-L10:
-  // group by l.l_suppkey into g
-  Index        r16, r12, r5
-L14:
-  Str          r12, r16
-  In           r5, r12, r14
-  JumpIfTrue   r5, L3
-  // from l in lineitem
-  Move         r5, r4
-  Const        r6, "__group__"
-L13:
-  Const        r17, true
-  Move         r3, r8
-  // group by l.l_suppkey into g
-  Move         r2, r16
-  // from l in lineitem
-  Const        r16, "items"
-  Move         r18, r5
-  Const        r5, "count"
-  Move         r19, r13
-  Move         r20, r6
-  Move         r6, r17
-  Move         r17, r3
-  Move         r3, r2
-  Move         r2, r16
-  Move         r21, r18
-  Move         r18, r5
-  Move         r22, r19
-  MakeMap      r19, 4, r20
-  SetIndex     r14, r12, r19
-  Move         r19, r16
-  Index        r16, r14, r12
-  Index        r12, r16, r19
-  Append       r22, r12, r1
-  SetIndex     r16, r19, r22
-  Move         r22, r5
-  Index        r5, r16, r22
-  Const        r12, 1
-  AddInt       r19, r5, r12
-  SetIndex     r16, r22, r19
-  AddInt       r13, r13, r12
-  Jump         L0
-  Values       19,14,0,0
-  Const        r14, 0
-  Move         r5, r14
-  Len          r22, r19
-  LessInt      r16, r5, r22
-  JumpIfFalse  r16, L4
-  Index        r16, r19, r5
-  // supplier_no: g.key,
-  Move         r19, r7
-  Index        r22, r16, r8
-  // total_revenue: sum(from x in g select x.l_extendedprice * (1 - x.l_discount))
-  Move         r8, r9
-  Move         r15, r4
-  IterPrep     r13, r16
-  Len          r16, r13
-  Move         r1, r14
-  LessInt      r18, r1, r16
-  JumpIfFalse  r18, L5
-  Index        r16, r13, r1
-  Index        r13, r16, r10
-  Index        r10, r16, r11
-  Sub          r11, r12, r10
-  Mul          r10, r13, r11
-  Append       r15, r15, r10
-  AddInt       r1, r1, r12
-  Jump         L6
-L5:
-  Sum          r11, r15
-  // supplier_no: g.key,
-  Move         r15, r19
-  Move         r10, r22
-  // total_revenue: sum(from x in g select x.l_extendedprice * (1 - x.l_discount))
-  Move         r22, r8
-  Move         r8, r11
-  // select {
-  MakeMap      r11, 2, r15
-  // from l in lineitem
-  Append       r4, r4, r11
-  AddInt       r5, r5, r12
+  Const        r60, 1
+  AddInt       r15, r15, r60
   Jump         L4
-  // let revenues = from x in revenue0 select x.total_revenue
-  Const        r11, []
-  IterPrep     r8, r4
-  Len          r22, r8
-  Move         r15, r14
-  LessInt      r10, r15, r22
-  JumpIfFalse  r10, L7
-  Index        r16, r8, r15
-  Index        r10, r16, r9
-  Append       r11, r11, r10
-  AddInt       r15, r15, r12
-  Jump         L6
-  // let max_revenue = max(revenues)
-  Max          r15, r11
-  // let result = from s in supplier
-  Const        r11, []
-  IterPrep     r16, r0
-  Len          r22, r16
-  // join r in revenue0 on s.s_suppkey == r.supplier_no
-  IterPrep     r8, r4
-  Len          r4, r8
-  // let result = from s in supplier
-  EqualInt     r18, r22, r14
-  JumpIfTrue   r18, L8
-  EqualInt     r18, r4, r14
-  JumpIfTrue   r18, L8
-  LessEq       r18, r4, r22
-  JumpIfFalse  r18, L9
-  // join r in revenue0 on s.s_suppkey == r.supplier_no
-  MakeMap      r18, 0, r0
-  Move         r10, r14
-  LessInt      r5, r10, r4
-  JumpIfFalse  r5, L10
-  Index        r5, r8, r10
-  Index        r19, r5, r7
-  Index        r13, r18, r19
-  Const        r1, nil
-  NotEqual     r21, r13, r1
-  JumpIfTrue   r21, L11
-  MakeList     r21, 0, r0
-  SetIndex     r18, r19, r21
-  Index        r13, r18, r19
-  Append       r21, r13, r5
-  SetIndex     r18, r19, r21
-  AddInt       r10, r10, r12
+L0:
+  Const        r61, 0
+  Len          r63, r17
+L8:
+  LessInt      r64, r61, r63
+  JumpIfFalse  r64, L5
+  Index        r66, r17, r61
+  // supplier_no: g.key,
+  Const        r67, "supplier_no"
+  Const        r68, "key"
+  Index        r69, r66, r68
+  // total_revenue: sum(from x in g select x.l_extendedprice * (1 - x.l_discount))
+  Const        r70, "total_revenue"
+  Const        r71, []
+  Const        r72, "l_extendedprice"
+  Const        r73, "l_discount"
+  IterPrep     r74, r66
+  Len          r75, r74
+  Const        r76, 0
+L7:
+  LessInt      r78, r76, r75
+  JumpIfFalse  r78, L6
+  Index        r80, r74, r76
+  Const        r81, "l_extendedprice"
+  Index        r82, r80, r81
+  Const        r83, 1
+  Const        r84, "l_discount"
+  Index        r85, r80, r84
+  Sub          r86, r83, r85
+  Mul          r87, r82, r86
+  Append       r71, r71, r87
+  Const        r89, 1
+  AddInt       r76, r76, r89
   Jump         L7
-  // let result = from s in supplier
-  Move         r13, r14
-  LessInt      r19, r13, r22
-  JumpIfFalse  r19, L8
-  Index        r19, r16, r13
-  // join r in revenue0 on s.s_suppkey == r.supplier_no
-  Const        r5, "s_suppkey"
-  Index        r10, r19, r5
-  // let result = from s in supplier
-  Index        r2, r18, r10
-  NotEqual     r10, r2, r1
-  JumpIfFalse  r10, L11
-  Len          r10, r2
-  Move         r18, r13
-  LessInt      r21, r18, r10
-  JumpIfFalse  r21, L11
-  Index        r10, r2, r18
-  // where r.total_revenue == max_revenue
-  Index        r2, r10, r9
-  Equal        r21, r2, r15
-  JumpIfFalse  r21, L12
-  // s_suppkey: s.s_suppkey,
-  Move         r21, r5
-  Index        r2, r19, r5
-  // s_name: s.s_name,
-  Const        r3, "s_name"
-  Move         r17, r3
-  Index        r6, r19, r17
-  // s_address: s.s_address,
-  Const        r20, "s_address"
-  Move         r23, r20
-  Index        r24, r19, r23
-  // s_phone: s.s_phone,
-  Const        r25, "s_phone"
-  Move         r26, r25
-  Index        r27, r19, r26
-  // total_revenue: r.total_revenue
-  Move         r28, r9
-  Index        r29, r10, r9
-  // s_suppkey: s.s_suppkey,
-  Move         r30, r21
-  Move         r21, r2
-  // s_name: s.s_name,
-  Move         r2, r3
-  Move         r31, r6
-  // s_address: s.s_address,
-  Move         r6, r20
-  Move         r32, r24
-  // s_phone: s.s_phone,
-  Move         r24, r25
-  Move         r33, r27
-  // total_revenue: r.total_revenue
-  Move         r27, r28
-  Move         r34, r29
+L6:
+  Sum          r90, r71
+  // supplier_no: g.key,
+  Move         r91, r67
+  Move         r92, r69
+  // total_revenue: sum(from x in g select x.l_extendedprice * (1 - x.l_discount))
+  Move         r93, r70
+  Move         r94, r90
   // select {
-  MakeMap      r35, 5, r30
-  // sort by s.s_suppkey
-  Index        r27, r19, r5
-  // let result = from s in supplier
-  Move         r33, r35
-  MakeList     r35, 2, r27
-  Append       r11, r11, r35
-  AddInt       r18, r18, r12
-  Jump         L13
-  AddInt       r13, r13, r12
-  Jump         L14
-  MakeMap      r35, 0, r0
-  Move         r33, r14
-  LessInt      r27, r33, r22
-  JumpIfFalse  r27, L15
-  Index        r27, r16, r33
-  // join r in revenue0 on s.s_suppkey == r.supplier_no
-  Index        r16, r27, r5
-  // let result = from s in supplier
-  Index        r22, r35, r16
-  Move         r34, r1
-  NotEqual     r1, r22, r34
-  JumpIfTrue   r1, L10
-  MakeList     r1, 0, r0
-  SetIndex     r35, r16, r1
-  Index        r22, r35, r16
-  Append       r1, r22, r27
-  SetIndex     r35, r16, r1
-  AddInt       r33, r33, r12
-  Jump         L16
-L15:
-  // join r in revenue0 on s.s_suppkey == r.supplier_no
-  Move         r22, r14
-  LessInt      r14, r22, r4
-  JumpIfFalse  r14, L17
-  Index        r10, r8, r22
-  Index        r14, r10, r7
-  Index        r7, r35, r14
-  NotEqual     r14, r7, r34
-  JumpIfFalse  r14, L18
-  Len          r14, r7
-  Move         r34, r22
-  LessInt      r35, r34, r14
-  JumpIfFalse  r35, L18
-  Index        r19, r7, r34
-  // where r.total_revenue == max_revenue
-  Index        r35, r10, r9
-  Equal        r14, r35, r15
-  JumpIfFalse  r14, L19
-  // s_suppkey: s.s_suppkey,
-  Move         r14, r5
-  Index        r35, r19, r5
-  // s_name: s.s_name,
-  Move         r15, r3
-  Index        r3, r19, r17
-  // s_address: s.s_address,
-  Move         r17, r20
-  Index        r20, r19, r23
-  // s_phone: s.s_phone,
-  Move         r23, r25
-  Index        r25, r19, r26
-  // total_revenue: r.total_revenue
-  Move         r26, r28
-  Index        r28, r10, r9
-  // s_suppkey: s.s_suppkey,
-  Move         r1, r14
-  Move         r10, r35
-  // s_name: s.s_name,
-  Move         r35, r15
-  Move         r7, r3
-  // s_address: s.s_address,
-  Move         r3, r17
-  Move         r4, r20
-  // s_phone: s.s_phone,
-  Move         r20, r23
-  Move         r8, r25
-  // total_revenue: r.total_revenue
-  Move         r25, r26
-  Move         r26, r28
-  // select {
-  MakeMap      r28, 5, r1
-  // sort by s.s_suppkey
-  Index        r26, r19, r5
-  // let result = from s in supplier
-  Move         r5, r28
-  MakeList     r28, 2, r26
-  Append       r11, r11, r28
-L19:
-  // join r in revenue0 on s.s_suppkey == r.supplier_no
-  AddInt       r34, r34, r12
+  MakeMap      r95, 2, r91
+  // from l in lineitem
+  Append       r4, r4, r95
+  Const        r97, 1
+  AddInt       r61, r61, r97
+  Jump         L8
+L5:
+  // let revenues = from x in revenue0 select x.total_revenue
+  Const        r98, []
+  Const        r99, "total_revenue"
+  IterPrep     r100, r4
+  Len          r101, r100
+  Const        r102, 0
+L10:
+  LessInt      r104, r102, r101
+  JumpIfFalse  r104, L9
+  Index        r80, r100, r102
+  Const        r106, "total_revenue"
+  Index        r107, r80, r106
+  Append       r98, r98, r107
+  Const        r109, 1
+  AddInt       r102, r102, r109
   Jump         L10
+L9:
+  // let max_revenue = max(revenues)
+  Max          r110, r98
+  // let result = from s in supplier
+  Const        r111, []
+  IterPrep     r112, r0
+  Len          r113, r112
+  // join r in revenue0 on s.s_suppkey == r.supplier_no
+  IterPrep     r114, r4
+  Len          r115, r114
+  // let result = from s in supplier
+  Const        r116, 0
+  EqualInt     r117, r113, r116
+  JumpIfTrue   r117, L11
+  EqualInt     r118, r115, r116
+  JumpIfTrue   r118, L11
+  LessEq       r119, r115, r113
+  JumpIfFalse  r119, L12
+  // join r in revenue0 on s.s_suppkey == r.supplier_no
+  MakeMap      r120, 0, r0
+  Const        r121, 0
+L15:
+  LessInt      r122, r121, r115
+  JumpIfFalse  r122, L13
+  Index        r123, r114, r121
+  Move         r124, r123
+  Const        r125, "supplier_no"
+  Index        r126, r124, r125
+  Index        r127, r120, r126
+  Const        r128, nil
+  NotEqual     r129, r127, r128
+  JumpIfTrue   r129, L14
+  MakeList     r130, 0, r0
+  SetIndex     r120, r126, r130
+L14:
+  Index        r127, r120, r126
+  Append       r131, r127, r123
+  SetIndex     r120, r126, r131
+  Const        r132, 1
+  AddInt       r121, r121, r132
+  Jump         L15
+L13:
+  // let result = from s in supplier
+  Const        r133, 0
+L19:
+  LessInt      r134, r133, r113
+  JumpIfFalse  r134, L11
+  Index        r136, r112, r133
+  // join r in revenue0 on s.s_suppkey == r.supplier_no
+  Const        r137, "s_suppkey"
+  Index        r138, r136, r137
+  // let result = from s in supplier
+  Index        r139, r120, r138
+  Const        r140, nil
+  NotEqual     r141, r139, r140
+  JumpIfFalse  r141, L16
+  Len          r142, r139
+  Const        r143, 0
 L18:
-  AddInt       r22, r22, r12
-  Jump         L2
-L17:
+  LessInt      r144, r143, r142
+  JumpIfFalse  r144, L16
+  Index        r124, r139, r143
+  // where r.total_revenue == max_revenue
+  Const        r146, "total_revenue"
+  Index        r147, r124, r146
+  Equal        r148, r147, r110
+  JumpIfFalse  r148, L17
+  // s_suppkey: s.s_suppkey,
+  Const        r149, "s_suppkey"
+  Const        r150, "s_suppkey"
+  Index        r151, r136, r150
+  // s_name: s.s_name,
+  Const        r152, "s_name"
+  Const        r153, "s_name"
+  Index        r154, r136, r153
+  // s_address: s.s_address,
+  Const        r155, "s_address"
+  Const        r156, "s_address"
+  Index        r157, r136, r156
+  // s_phone: s.s_phone,
+  Const        r158, "s_phone"
+  Const        r159, "s_phone"
+  Index        r160, r136, r159
+  // total_revenue: r.total_revenue
+  Const        r161, "total_revenue"
+  Const        r162, "total_revenue"
+  Index        r163, r124, r162
+  // s_suppkey: s.s_suppkey,
+  Move         r164, r149
+  Move         r165, r151
+  // s_name: s.s_name,
+  Move         r166, r152
+  Move         r167, r154
+  // s_address: s.s_address,
+  Move         r168, r155
+  Move         r169, r157
+  // s_phone: s.s_phone,
+  Move         r170, r158
+  Move         r171, r160
+  // total_revenue: r.total_revenue
+  Move         r172, r161
+  Move         r173, r163
+  // select {
+  MakeMap      r174, 5, r164
   // sort by s.s_suppkey
-  Sort         r11, r11
+  Const        r175, "s_suppkey"
+  Index        r177, r136, r175
+  // let result = from s in supplier
+  Move         r178, r174
+  MakeList     r179, 2, r177
+  Append       r111, r111, r179
+L17:
+  Const        r181, 1
+  AddInt       r143, r143, r181
+  Jump         L18
+L16:
+  Const        r182, 1
+  AddInt       r133, r133, r182
+  Jump         L19
+L12:
+  MakeMap      r183, 0, r0
+  Const        r184, 0
+L22:
+  LessInt      r185, r184, r113
+  JumpIfFalse  r185, L20
+  Index        r186, r112, r184
+  Move         r136, r186
+  // join r in revenue0 on s.s_suppkey == r.supplier_no
+  Const        r187, "s_suppkey"
+  Index        r188, r136, r187
+  // let result = from s in supplier
+  Index        r189, r183, r188
+  Const        r190, nil
+  NotEqual     r191, r189, r190
+  JumpIfTrue   r191, L21
+  MakeList     r192, 0, r0
+  SetIndex     r183, r188, r192
+L21:
+  Index        r189, r183, r188
+  Append       r193, r189, r186
+  SetIndex     r183, r188, r193
+  Const        r194, 1
+  AddInt       r184, r184, r194
+  Jump         L22
+L20:
+  // join r in revenue0 on s.s_suppkey == r.supplier_no
+  Const        r195, 0
+L27:
+  LessInt      r196, r195, r115
+  JumpIfFalse  r196, L23
+  Index        r124, r114, r195
+  Const        r198, "supplier_no"
+  Index        r199, r124, r198
+  Index        r200, r183, r199
+  Const        r201, nil
+  NotEqual     r202, r200, r201
+  JumpIfFalse  r202, L24
+  Len          r203, r200
+  Const        r204, 0
+L26:
+  LessInt      r205, r204, r203
+  JumpIfFalse  r205, L24
+  Index        r136, r200, r204
+  // where r.total_revenue == max_revenue
+  Const        r207, "total_revenue"
+  Index        r208, r124, r207
+  Equal        r209, r208, r110
+  JumpIfFalse  r209, L25
+  // s_suppkey: s.s_suppkey,
+  Const        r210, "s_suppkey"
+  Const        r211, "s_suppkey"
+  Index        r212, r136, r211
+  // s_name: s.s_name,
+  Const        r213, "s_name"
+  Const        r214, "s_name"
+  Index        r215, r136, r214
+  // s_address: s.s_address,
+  Const        r216, "s_address"
+  Const        r217, "s_address"
+  Index        r218, r136, r217
+  // s_phone: s.s_phone,
+  Const        r219, "s_phone"
+  Const        r220, "s_phone"
+  Index        r221, r136, r220
+  // total_revenue: r.total_revenue
+  Const        r222, "total_revenue"
+  Const        r223, "total_revenue"
+  Index        r224, r124, r223
+  // s_suppkey: s.s_suppkey,
+  Move         r225, r210
+  Move         r226, r212
+  // s_name: s.s_name,
+  Move         r227, r213
+  Move         r228, r215
+  // s_address: s.s_address,
+  Move         r229, r216
+  Move         r230, r218
+  // s_phone: s.s_phone,
+  Move         r231, r219
+  Move         r232, r221
+  // total_revenue: r.total_revenue
+  Move         r233, r222
+  Move         r234, r224
+  // select {
+  MakeMap      r235, 5, r225
+  // sort by s.s_suppkey
+  Const        r236, "s_suppkey"
+  Index        r238, r136, r236
+  // let result = from s in supplier
+  Move         r239, r235
+  MakeList     r240, 2, r238
+  Append       r111, r111, r240
+L25:
+  // join r in revenue0 on s.s_suppkey == r.supplier_no
+  Const        r242, 1
+  AddInt       r204, r204, r242
+  Jump         L26
+L24:
+  Const        r243, 1
+  AddInt       r195, r195, r243
+  Jump         L27
+L23:
+  // sort by s.s_suppkey
+  Sort         r111, r111
   // json(result)
-  JSON         r11
+  JSON         r111
   // let rev = 1000.0 * 0.9 + 500.0
-  Const        r22, 1400
+  Const        r245, 1000
+  Const        r246, 0.9
+  Const        r247, 900
+  Const        r248, 500
+  Const        r249, 1400
   // s_suppkey: 100,
-  Move         r12, r14
-  Const        r14, 100
+  Const        r250, "s_suppkey"
+  Const        r251, 100
   // s_name: "Best Supplier",
-  Move         r5, r15
-  Const        r28, "Best Supplier"
+  Const        r252, "s_name"
+  Const        r253, "Best Supplier"
   // s_address: "123 Market St",
-  Move         r15, r17
-  Const        r17, "123 Market St"
+  Const        r254, "s_address"
+  Const        r255, "123 Market St"
   // s_phone: "123-456",
-  Move         r26, r23
-  Const        r23, "123-456"
+  Const        r256, "s_phone"
+  Const        r257, "123-456"
   // total_revenue: rev // 900 + 500 = 1400
-  Move         r34, r9
+  Const        r258, "total_revenue"
   // s_suppkey: 100,
-  Move         r9, r12
-  Move         r12, r14
+  Move         r259, r250
+  Move         r260, r251
   // s_name: "Best Supplier",
-  Move         r14, r5
-  Move         r5, r28
+  Move         r261, r252
+  Move         r262, r253
   // s_address: "123 Market St",
-  Move         r28, r15
-  Move         r15, r17
+  Move         r263, r254
+  Move         r264, r255
   // s_phone: "123-456",
-  Move         r17, r26
-  Move         r26, r23
+  Move         r265, r256
+  Move         r266, r257
   // total_revenue: rev // 900 + 500 = 1400
-  Move         r23, r34
-  Move         r34, r22
+  Move         r267, r258
+  Move         r268, r249
   // {
-  MakeMap      r22, 5, r9
+  MakeMap      r270, 5, r259
   // expect result == [
-  MakeList     r34, 1, r22
-  Equal        r22, r11, r34
-  Expect       r22
+  MakeList     r271, 1, r270
+  Equal        r272, r111, r271
+  Expect       r272
   Return       r0

--- a/tests/dataset/tpc-h/out/q16.ir.out
+++ b/tests/dataset/tpc-h/out/q16.ir.out
@@ -1,4 +1,4 @@
-func main (regs=25)
+func main (regs=169)
 L0:
   // let supplier = [
   Const        r0, [{"s_address": "123 Hilltop", "s_comment": "Reliable and efficient", "s_name": "AlphaSupply", "s_suppkey": 100}, {"s_address": "456 Riverside", "s_comment": "Known for Customer Complaints", "s_name": "BetaSupply", "s_suppkey": 200}]
@@ -8,241 +8,287 @@ L0:
   Const        r2, [{"ps_partkey": 1, "ps_suppkey": 100}, {"ps_partkey": 2, "ps_suppkey": 200}]
   // from ps in partsupp
   Const        r3, []
-L6:
   IterPrep     r4, r2
-  Len          r2, r4
+  Len          r5, r4
   // join p in part on p.p_partkey == ps.ps_partkey
-  IterPrep     r5, r1
-L3:
-  Len          r1, r5
+  IterPrep     r6, r1
+  Len          r7, r6
   // from ps in partsupp
-  Const        r6, 0
+  Const        r8, 0
+  EqualInt     r9, r5, r8
+  JumpIfTrue   r9, L0
+  EqualInt     r10, r7, r8
+  JumpIfTrue   r10, L0
+  LessEq       r11, r7, r5
+  JumpIfFalse  r11, L1
+  // join p in part on p.p_partkey == ps.ps_partkey
+  MakeMap      r12, 0, r0
+  Const        r13, 0
 L7:
-  EqualInt     r7, r2, r6
-L8:
-  JumpIfTrue   r7, L0
-L5:
-  EqualInt     r7, r1, r6
-  JumpIfTrue   r7, L0
-  LessEq       r7, r1, r2
-L14:
-  JumpIfFalse  r7, L1
-L13:
-  // join p in part on p.p_partkey == ps.ps_partkey
-  MakeMap      r7, 0, r0
-  Move         r8, r6
-L9:
-  LessInt      r9, r8, r1
-L11:
-  JumpIfFalse  r9, L1
-  Index        r9, r5, r8
-L10:
-  Move         r10, r9
-L2:
+  LessInt      r14, r13, r7
+  JumpIfFalse  r14, L2
+  Index        r15, r6, r13
+  Move         r16, r15
   // p.p_brand == "Brand#12" &&
-  Const        r11, "p_brand"
-  Index        r12, r10, r11
-L1:
-  Const        r13, "Brand#12"
-L12:
-  Equal        r14, r12, r13
+  Const        r17, "p_brand"
+  Index        r18, r16, r17
+  Const        r19, "Brand#12"
+  Equal        r20, r18, r19
   // p.p_size == 5
-  Const        r12, "p_size"
-  Index        r15, r10, r12
-  Const        r16, 5
-  Equal        r17, r15, r16
+  Const        r21, "p_size"
+  Index        r22, r16, r21
+  Const        r23, 5
+  Equal        r24, r22, r23
   // p.p_brand == "Brand#12" &&
-  Move         r15, r14
-  JumpIfFalse  r15, L2
-  Const        r15, "p_type"
-  Index        r14, r10, r15
+  Move         r25, r20
+  JumpIfFalse  r25, L3
+  Const        r26, "p_type"
+  Index        r27, r16, r26
   // p.p_type.contains("SMALL") &&
-  Const        r18, "SMALL"
-  In           r19, r18, r14
-  JumpIfFalse  r19, L2
-  Move         r19, r17
-  // p.p_brand == "Brand#12" &&
-  JumpIfFalse  r19, L3
-  // join p in part on p.p_partkey == ps.ps_partkey
-  Const        r19, "p_partkey"
-  Index        r14, r10, r19
-  Index        r17, r7, r14
-  Const        r20, nil
-  NotEqual     r21, r17, r20
-  JumpIfTrue   r21, L4
-  MakeList     r21, 0, r0
-  SetIndex     r7, r14, r21
+  Const        r28, "SMALL"
+  In           r30, r28, r27
+L3:
+  JumpIfFalse  r30, L4
+  Move         r30, r24
 L4:
-  Index        r17, r7, r14
-  Append       r21, r17, r9
-  SetIndex     r7, r14, r21
-  Const        r21, 1
-  AddInt       r8, r8, r21
-  Jump         L5
-  // from ps in partsupp
-  Move         r8, r6
-  LessInt      r17, r8, r2
-  JumpIfFalse  r17, L0
-  Index        r17, r4, r8
+  // p.p_brand == "Brand#12" &&
+  JumpIfFalse  r30, L5
   // join p in part on p.p_partkey == ps.ps_partkey
-  Const        r14, "ps_partkey"
-  Index        r9, r17, r14
-  // from ps in partsupp
-  Index        r22, r7, r9
-  NotEqual     r9, r22, r20
-  JumpIfFalse  r9, L1
-  Len          r9, r22
-  Move         r7, r8
-  LessInt      r23, r7, r9
-  JumpIfFalse  r23, L1
-  Index        r10, r22, r7
-  // p.p_brand == "Brand#12" &&
-  Index        r23, r10, r11
-  Equal        r9, r23, r13
-  // p.p_size == 5
-  Index        r23, r10, r12
-  Equal        r22, r23, r16
-  // p.p_brand == "Brand#12" &&
-  Move         r23, r9
-  JumpIfFalse  r23, L6
-  Index        r23, r10, r15
-  // p.p_type.contains("SMALL") &&
-  In           r24, r18, r23
-  JumpIfFalse  r24, L6
-  Move         r24, r22
-  // p.p_brand == "Brand#12" &&
-  JumpIfFalse  r24, L6
-  // select ps.ps_suppkey
-  Const        r24, "ps_suppkey"
-  Index        r23, r17, r24
-  // from ps in partsupp
-  Append       r3, r3, r23
-  AddInt       r7, r7, r21
-  Jump         L1
-  AddInt       r8, r8, r21
+  Const        r31, "p_partkey"
+  Index        r32, r16, r31
+  Index        r33, r12, r32
+  Const        r34, nil
+  NotEqual     r35, r33, r34
+  JumpIfTrue   r35, L6
+  MakeList     r36, 0, r0
+  SetIndex     r12, r32, r36
+L6:
+  Index        r33, r12, r32
+  Append       r37, r33, r15
+  SetIndex     r12, r32, r37
+L5:
+  Const        r38, 1
+  AddInt       r13, r13, r38
   Jump         L7
-  MakeMap      r23, 0, r0
-  Move         r9, r6
-  LessInt      r8, r9, r2
-  JumpIfFalse  r8, L8
-  Index        r8, r4, r9
-  // join p in part on p.p_partkey == ps.ps_partkey
-  Index        r4, r8, r14
+L2:
   // from ps in partsupp
-  Index        r14, r23, r4
-  Move         r2, r20
-  NotEqual     r20, r14, r2
-  JumpIfTrue   r20, L9
-  MakeList     r20, 0, r0
-  SetIndex     r23, r4, r20
-  Index        r14, r23, r4
-  Append       r20, r14, r8
-  SetIndex     r23, r4, r20
-  AddInt       r9, r9, r21
-  Jump         L10
+  Const        r39, 0
+L13:
+  LessInt      r40, r39, r5
+  JumpIfFalse  r40, L0
+  Index        r42, r4, r39
   // join p in part on p.p_partkey == ps.ps_partkey
-  Move         r14, r6
-  LessInt      r4, r14, r1
-  JumpIfFalse  r4, L11
-  Index        r10, r5, r14
-  Index        r4, r10, r19
-  Index        r19, r23, r4
-  NotEqual     r4, r19, r2
-  JumpIfFalse  r4, L12
-  Len          r4, r19
-  Move         r2, r14
-  LessInt      r23, r2, r4
-  JumpIfFalse  r23, L12
-  Index        r17, r19, r2
+  Const        r43, "ps_partkey"
+  Index        r44, r42, r43
+  // from ps in partsupp
+  Index        r45, r12, r44
+  Const        r46, nil
+  NotEqual     r47, r45, r46
+  JumpIfFalse  r47, L8
+  Len          r48, r45
+  Const        r49, 0
+L12:
+  LessInt      r50, r49, r48
+  JumpIfFalse  r50, L8
+  Index        r16, r45, r49
   // p.p_brand == "Brand#12" &&
-  Index        r23, r10, r11
-  Equal        r11, r23, r13
+  Const        r52, "p_brand"
+  Index        r53, r16, r52
+  Const        r54, "Brand#12"
+  Equal        r55, r53, r54
   // p.p_size == 5
-  Index        r20, r10, r12
-  Equal        r23, r20, r16
+  Const        r56, "p_size"
+  Index        r57, r16, r56
+  Const        r58, 5
+  Equal        r59, r57, r58
   // p.p_brand == "Brand#12" &&
-  Move         r20, r11
-  JumpIfFalse  r20, L11
-  Index        r20, r10, r15
+  Move         r60, r55
+  JumpIfFalse  r60, L9
+  Const        r61, "p_type"
+  Index        r62, r16, r61
   // p.p_type.contains("SMALL") &&
-  In           r15, r18, r20
-  JumpIfFalse  r15, L13
-  Move         r15, r23
+  Const        r63, "SMALL"
+  In           r65, r63, r62
+L9:
+  JumpIfFalse  r65, L10
+  Move         r65, r59
+L10:
   // p.p_brand == "Brand#12" &&
-  JumpIfFalse  r15, L11
+  JumpIfFalse  r65, L11
   // select ps.ps_suppkey
-  Index        r15, r17, r24
+  Const        r66, "ps_suppkey"
+  Index        r67, r42, r66
   // from ps in partsupp
-  Append       r3, r3, r15
-  // join p in part on p.p_partkey == ps.ps_partkey
-  AddInt       r2, r2, r21
+  Append       r3, r3, r67
+L11:
+  Const        r69, 1
+  AddInt       r49, r49, r69
+  Jump         L12
+L8:
+  Const        r70, 1
+  AddInt       r39, r39, r70
   Jump         L13
-  AddInt       r14, r14, r21
-  Jump         L14
-  // from s in supplier
-  Const        r2, []
-  // where !(s.s_suppkey in excluded_suppliers) && (!s.s_comment.contains("Customer")) && (!s.s_comment.contains("Complaints"))
-  Const        r24, "s_suppkey"
-  Const        r17, "s_comment"
-  // s_name: s.s_name,
-  Const        r20, "s_name"
-  // s_address: s.s_address
-  Const        r23, "s_address"
-  // from s in supplier
-  IterPrep     r18, r0
-  Len          r10, r18
-  Move         r14, r6
-L19:
-  LessInt      r6, r14, r10
-  JumpIfFalse  r6, L15
-  Index        r6, r18, r14
-  // where !(s.s_suppkey in excluded_suppliers) && (!s.s_comment.contains("Customer")) && (!s.s_comment.contains("Complaints"))
-  Index        r18, r6, r24
-  In           r24, r18, r3
-  Not          r18, r24
-  JumpIfFalse  r18, L16
-  Index        r18, r6, r17
-  Const        r15, "Customer"
-  In           r24, r15, r18
-  Not          r18, r24
+L1:
+  MakeMap      r71, 0, r0
+  Const        r72, 0
 L16:
-  JumpIfFalse  r18, L17
-  Index        r24, r6, r17
-  Const        r17, "Complaints"
-  In           r15, r17, r24
-  Not          r18, r15
-L17:
-  JumpIfFalse  r18, L18
-  // s_name: s.s_name,
-  Move         r15, r20
-  Index        r17, r6, r20
-  // s_address: s.s_address
-  Move         r24, r23
-  Index        r18, r6, r23
-  // s_name: s.s_name,
-  Move         r23, r15
-  Move         r15, r17
-  // s_address: s.s_address
-  Move         r17, r24
-  Move         r24, r18
-  // select {
-  MakeMap      r18, 2, r23
-  // order by s.s_name
-  Index        r24, r6, r20
-  // from s in supplier
-  Move         r6, r18
-  MakeList     r18, 2, r24
-  Append       r2, r2, r18
-L18:
-  AddInt       r14, r14, r21
-  Jump         L19
+  LessInt      r73, r72, r5
+  JumpIfFalse  r73, L14
+  Index        r74, r4, r72
+  Move         r42, r74
+  // join p in part on p.p_partkey == ps.ps_partkey
+  Const        r75, "ps_partkey"
+  Index        r76, r42, r75
+  // from ps in partsupp
+  Index        r77, r71, r76
+  Const        r78, nil
+  NotEqual     r79, r77, r78
+  JumpIfTrue   r79, L15
+  MakeList     r80, 0, r0
+  SetIndex     r71, r76, r80
 L15:
+  Index        r77, r71, r76
+  Append       r81, r77, r74
+  SetIndex     r71, r76, r81
+  Const        r82, 1
+  AddInt       r72, r72, r82
+  Jump         L16
+L14:
+  // join p in part on p.p_partkey == ps.ps_partkey
+  Const        r83, 0
+L23:
+  LessInt      r84, r83, r7
+  JumpIfFalse  r84, L17
+  Index        r16, r6, r83
+  Const        r86, "p_partkey"
+  Index        r87, r16, r86
+  Index        r88, r71, r87
+  Const        r89, nil
+  NotEqual     r90, r88, r89
+  JumpIfFalse  r90, L18
+  Len          r91, r88
+  Const        r92, 0
+L22:
+  LessInt      r93, r92, r91
+  JumpIfFalse  r93, L18
+  Index        r42, r88, r92
+  // p.p_brand == "Brand#12" &&
+  Const        r95, "p_brand"
+  Index        r96, r16, r95
+  Const        r97, "Brand#12"
+  Equal        r98, r96, r97
+  // p.p_size == 5
+  Const        r99, "p_size"
+  Index        r100, r16, r99
+  Const        r101, 5
+  Equal        r102, r100, r101
+  // p.p_brand == "Brand#12" &&
+  Move         r103, r98
+  JumpIfFalse  r103, L19
+  Const        r104, "p_type"
+  Index        r105, r16, r104
+  // p.p_type.contains("SMALL") &&
+  Const        r106, "SMALL"
+  In           r108, r106, r105
+L19:
+  JumpIfFalse  r108, L20
+  Move         r108, r102
+L20:
+  // p.p_brand == "Brand#12" &&
+  JumpIfFalse  r108, L21
+  // select ps.ps_suppkey
+  Const        r109, "ps_suppkey"
+  Index        r110, r42, r109
+  // from ps in partsupp
+  Append       r3, r3, r110
+L21:
+  // join p in part on p.p_partkey == ps.ps_partkey
+  Const        r112, 1
+  AddInt       r92, r92, r112
+  Jump         L22
+L18:
+  Const        r113, 1
+  AddInt       r83, r83, r113
+  Jump         L23
+L17:
+  // from s in supplier
+  Const        r114, []
+  // where !(s.s_suppkey in excluded_suppliers) && (!s.s_comment.contains("Customer")) && (!s.s_comment.contains("Complaints"))
+  Const        r115, "s_suppkey"
+  Const        r116, "s_comment"
+  Const        r117, "contains"
+  Const        r118, "s_comment"
+  Const        r119, "contains"
+  // s_name: s.s_name,
+  Const        r120, "s_name"
+  Const        r121, "s_name"
+  // s_address: s.s_address
+  Const        r122, "s_address"
+  Const        r123, "s_address"
   // order by s.s_name
-  Sort         r2, r2
+  Const        r124, "s_name"
+  // from s in supplier
+  IterPrep     r125, r0
+  Len          r126, r125
+  Const        r127, 0
+L28:
+  LessInt      r129, r127, r126
+  JumpIfFalse  r129, L24
+  Index        r131, r125, r127
+  // where !(s.s_suppkey in excluded_suppliers) && (!s.s_comment.contains("Customer")) && (!s.s_comment.contains("Complaints"))
+  Const        r132, "s_suppkey"
+  Index        r133, r131, r132
+  In           r134, r133, r3
+  Not          r136, r134
+  JumpIfFalse  r136, L25
+  Const        r137, "s_comment"
+  Index        r138, r131, r137
+  Const        r139, "Customer"
+  In           r140, r139, r138
+  Not          r142, r140
+L25:
+  JumpIfFalse  r142, L26
+  Const        r143, "s_comment"
+  Index        r144, r131, r143
+  Const        r145, "Complaints"
+  In           r146, r145, r144
+  Not          r142, r146
+L26:
+  JumpIfFalse  r142, L27
+  // s_name: s.s_name,
+  Const        r148, "s_name"
+  Const        r149, "s_name"
+  Index        r150, r131, r149
+  // s_address: s.s_address
+  Const        r151, "s_address"
+  Const        r152, "s_address"
+  Index        r153, r131, r152
+  // s_name: s.s_name,
+  Move         r154, r148
+  Move         r155, r150
+  // s_address: s.s_address
+  Move         r156, r151
+  Move         r157, r153
+  // select {
+  MakeMap      r158, 2, r154
+  // order by s.s_name
+  Const        r159, "s_name"
+  Index        r161, r131, r159
+  // from s in supplier
+  Move         r162, r158
+  MakeList     r163, 2, r161
+  Append       r114, r114, r163
+L27:
+  Const        r165, 1
+  AddInt       r127, r127, r165
+  Jump         L28
+L24:
+  // order by s.s_name
+  Sort         r114, r114
   // print(result)
-  Print        r2
+  Print        r114
   // expect result == []
-  Const        r18, []
-  Equal        r6, r2, r18
-  Expect       r6
+  Const        r167, []
+  Equal        r168, r114, r167
+  Expect       r168
   Return       r0

--- a/tests/dataset/tpc-h/out/q17.ir.out
+++ b/tests/dataset/tpc-h/out/q17.ir.out
@@ -1,18 +1,15 @@
-func main (regs=31)
+func main (regs=147)
 L0:
   // let part = [
   Const        r0, [{"p_brand": "Brand#23", "p_container": "MED BOX", "p_partkey": 1}, {"p_brand": "Brand#77", "p_container": "LG JAR", "p_partkey": 2}]
   // let lineitem = [
   Const        r1, [{"l_extendedprice": 100, "l_partkey": 1, "l_quantity": 1}, {"l_extendedprice": 1000, "l_partkey": 1, "l_quantity": 10}, {"l_extendedprice": 2000, "l_partkey": 1, "l_quantity": 20}, {"l_extendedprice": 500, "l_partkey": 2, "l_quantity": 5}]
-L13:
   // let brand = "Brand#23"
   Const        r2, "Brand#23"
-L22:
   // let container = "MED BOX"
   Const        r3, "MED BOX"
   // from l in lineitem
   Const        r4, []
-L5:
   IterPrep     r5, r1
   Len          r6, r5
   // join p in part on p.p_partkey == l.l_partkey
@@ -20,206 +17,251 @@ L5:
   Len          r8, r7
   // from l in lineitem
   Const        r9, 0
-L2:
   EqualInt     r10, r6, r9
-L8:
   JumpIfTrue   r10, L0
-  EqualInt     r10, r8, r9
-  JumpIfTrue   r10, L0
+  EqualInt     r11, r8, r9
+  JumpIfTrue   r11, L0
+  LessEq       r12, r8, r6
+  JumpIfFalse  r12, L1
+  // join p in part on p.p_partkey == l.l_partkey
+  MakeMap      r13, 0, r0
+  Const        r14, 0
 L4:
-  LessEq       r10, r8, r6
+  LessInt      r15, r14, r8
+  JumpIfFalse  r15, L2
+  Index        r16, r7, r14
+  Move         r17, r16
+  Const        r18, "p_partkey"
+  Index        r19, r17, r18
+  Index        r20, r13, r19
+  Const        r21, nil
+  NotEqual     r22, r20, r21
+  JumpIfTrue   r22, L3
+  MakeList     r23, 0, r0
+  SetIndex     r13, r19, r23
 L3:
-  JumpIfFalse  r10, L1
+  Index        r20, r13, r19
+  Append       r24, r20, r16
+  SetIndex     r13, r19, r24
+  Const        r25, 1
+  AddInt       r14, r14, r25
+  Jump         L4
+L2:
+  // from l in lineitem
+  Const        r26, 0
+L13:
+  LessInt      r27, r26, r6
+  JumpIfFalse  r27, L0
+  Index        r29, r5, r26
   // join p in part on p.p_partkey == l.l_partkey
-  MakeMap      r10, 0, r0
-L7:
-  Move         r11, r9
-  LessInt      r12, r11, r8
-L11:
-  JumpIfFalse  r12, L2
+  Const        r30, "l_partkey"
+  Index        r31, r29, r30
+  // from l in lineitem
+  Index        r32, r13, r31
+  Const        r33, nil
+  NotEqual     r34, r32, r33
+  JumpIfFalse  r34, L5
+  Len          r35, r32
+  Const        r36, 0
 L12:
-  Index        r12, r7, r11
-  Move         r13, r12
-  Const        r14, "p_partkey"
-  Index        r15, r13, r14
-  Index        r16, r10, r15
-L1:
-  Const        r17, nil
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L5
+  Index        r17, r32, r36
+  // (p.p_brand == brand) &&
+  Const        r39, "p_brand"
+  Index        r40, r17, r39
+  Equal        r42, r40, r2
+  JumpIfFalse  r42, L6
+  // (p.p_container == container) &&
+  Const        r43, "p_container"
+  Index        r44, r17, r43
+  Equal        r46, r44, r3
 L6:
-  NotEqual     r18, r16, r17
-  JumpIfTrue   r18, L3
-  MakeList     r18, 0, r0
-  SetIndex     r10, r15, r18
-L9:
-  Index        r16, r10, r15
-  Append       r18, r16, r12
-  SetIndex     r10, r15, r18
-  Const        r18, 1
-  AddInt       r11, r11, r18
-  Jump         L4
-  // from l in lineitem
-  Move         r11, r9
-  LessInt      r16, r11, r6
-  JumpIfFalse  r16, L0
-  Index        r16, r5, r11
-  // join p in part on p.p_partkey == l.l_partkey
-  Const        r15, "l_partkey"
-  Index        r12, r16, r15
-  // from l in lineitem
-  Index        r19, r10, r12
-  NotEqual     r12, r19, r17
-  JumpIfFalse  r12, L5
-  Len          r12, r19
-  Move         r10, r11
-  LessInt      r20, r10, r12
-  JumpIfFalse  r20, L5
-  Index        r13, r19, r10
-  // (p.p_brand == brand) &&
-  Const        r12, "p_brand"
-  Index        r19, r13, r12
-  Equal        r21, r19, r2
-  JumpIfFalse  r21, L6
-  // (p.p_container == container) &&
-  Const        r21, "p_container"
-  Index        r19, r13, r21
-  Equal        r22, r19, r3
-  JumpIfFalse  r22, L5
+  JumpIfFalse  r46, L7
   // (l.l_quantity < (
-  Const        r19, "l_quantity"
-  Index        r23, r16, r19
+  Const        r47, "l_quantity"
+  Index        r48, r29, r47
   // 0.2 * avg(
-  Const        r24, 0.2
+  Const        r49, 0.2
   // from x in lineitem
-  Move         r25, r4
-  IterPrep     r26, r1
-  Len          r27, r26
-  Move         r28, r9
-  LessInt      r29, r28, r27
-  JumpIfFalse  r29, L7
-  Index        r29, r26, r28
+  Const        r50, []
   // where x.l_partkey == p.p_partkey
-  Index        r26, r29, r15
-  Index        r27, r13, r14
-  Equal        r30, r26, r27
-  JumpIfFalse  r30, L8
+  Const        r51, "l_partkey"
+  Const        r52, "p_partkey"
   // select x.l_quantity
-  Index        r30, r29, r19
+  Const        r53, "l_quantity"
   // from x in lineitem
-  Append       r25, r25, r30
-  AddInt       r28, r28, r18
-  Jump         L9
-  // 0.2 * avg(
-  Avg          r28, r25
-  MulFloat     r25, r24, r28
-  // (l.l_quantity < (
-  LessFloat    r22, r23, r25
-  // where (
-  JumpIfFalse  r22, L10
-  // select l.l_extendedprice
-  Const        r30, "l_extendedprice"
-  Index        r25, r16, r30
-  // from l in lineitem
-  Append       r4, r4, r25
+  IterPrep     r54, r1
+  Len          r55, r54
+  Const        r56, 0
 L10:
-  AddInt       r10, r10, r18
-  Jump         L11
-  AddInt       r11, r11, r18
-  Jump         L12
-  MakeMap      r25, 0, r0
-  Move         r20, r9
-  LessInt      r10, r20, r6
-  JumpIfFalse  r10, L4
-  Index        r10, r5, r20
-  // join p in part on p.p_partkey == l.l_partkey
-  Index        r5, r10, r15
-  // from l in lineitem
-  Index        r6, r25, r5
-  Move         r11, r17
-  NotEqual     r17, r6, r11
-  JumpIfTrue   r17, L13
-  MakeList     r17, 0, r0
-  SetIndex     r25, r5, r17
-  Index        r6, r25, r5
-  Append       r17, r6, r10
-  SetIndex     r25, r5, r17
-  AddInt       r20, r20, r18
-  Jump         L7
-  // join p in part on p.p_partkey == l.l_partkey
-  Move         r6, r9
-  LessInt      r5, r6, r8
-  JumpIfFalse  r5, L14
-  Index        r13, r7, r6
-  Index        r5, r13, r14
-  Index        r8, r25, r5
-  NotEqual     r5, r8, r11
-  JumpIfFalse  r5, L15
-  Len          r5, r8
-  Move         r11, r6
-  LessInt      r25, r11, r5
-  JumpIfFalse  r25, L15
-  Index        r16, r8, r11
-  // (p.p_brand == brand) &&
-  Index        r17, r13, r12
-  Equal        r25, r17, r2
-  JumpIfFalse  r25, L16
-  // (p.p_container == container) &&
-  Index        r25, r13, r21
-  Equal        r21, r25, r3
-L16:
-  JumpIfFalse  r21, L17
-  // (l.l_quantity < (
-  Index        r25, r16, r19
-  // from x in lineitem
-  Const        r3, []
-  IterPrep     r17, r1
-  Len          r1, r17
-  Move         r2, r9
-L20:
-  LessInt      r9, r2, r1
-  JumpIfFalse  r9, L18
-  Index        r29, r17, r2
+  LessInt      r58, r56, r55
+  JumpIfFalse  r58, L8
+  Index        r60, r54, r56
   // where x.l_partkey == p.p_partkey
-  Index        r9, r29, r15
-  Index        r15, r13, r14
-  Equal        r14, r9, r15
-  JumpIfFalse  r14, L19
+  Const        r61, "l_partkey"
+  Index        r62, r60, r61
+  Const        r63, "p_partkey"
+  Index        r64, r17, r63
+  Equal        r65, r62, r64
+  JumpIfFalse  r65, L9
   // select x.l_quantity
-  Index        r14, r29, r19
+  Const        r66, "l_quantity"
+  Index        r67, r60, r66
   // from x in lineitem
-  Append       r3, r3, r14
-L19:
-  AddInt       r2, r2, r18
-  Jump         L20
-L18:
+  Append       r50, r50, r67
+L9:
+  Const        r69, 1
+  AddInt       r56, r56, r69
+  Jump         L10
+L8:
   // 0.2 * avg(
-  Avg          r2, r3
-  MulFloat     r3, r24, r2
+  Avg          r70, r50
+  MulFloat     r71, r49, r70
   // (l.l_quantity < (
-  LessFloat    r21, r25, r3
-L17:
+  LessFloat    r46, r48, r71
+L7:
   // where (
-  JumpIfFalse  r21, L21
+  JumpIfFalse  r46, L11
   // select l.l_extendedprice
-  Index        r3, r16, r30
+  Const        r73, "l_extendedprice"
+  Index        r74, r29, r73
   // from l in lineitem
-  Append       r4, r4, r3
-L21:
+  Append       r4, r4, r74
+L11:
+  Const        r76, 1
+  AddInt       r36, r36, r76
+  Jump         L12
+L5:
+  Const        r77, 1
+  AddInt       r26, r26, r77
+  Jump         L13
+L1:
+  MakeMap      r78, 0, r0
+  Const        r79, 0
+L16:
+  LessInt      r80, r79, r6
+  JumpIfFalse  r80, L14
+  Index        r81, r5, r79
+  Move         r29, r81
   // join p in part on p.p_partkey == l.l_partkey
-  AddInt       r11, r11, r18
-  Jump         L22
+  Const        r82, "l_partkey"
+  Index        r83, r29, r82
+  // from l in lineitem
+  Index        r84, r78, r83
+  Const        r85, nil
+  NotEqual     r86, r84, r85
+  JumpIfTrue   r86, L15
+  MakeList     r87, 0, r0
+  SetIndex     r78, r83, r87
 L15:
-  AddInt       r6, r6, r18
-  Jump         L4
+  Index        r84, r78, r83
+  Append       r88, r84, r81
+  SetIndex     r78, r83, r88
+  Const        r89, 1
+  AddInt       r79, r79, r89
+  Jump         L16
 L14:
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r90, 0
+L26:
+  LessInt      r91, r90, r8
+  JumpIfFalse  r91, L17
+  Index        r17, r7, r90
+  Const        r93, "p_partkey"
+  Index        r94, r17, r93
+  Index        r95, r78, r94
+  Const        r96, nil
+  NotEqual     r97, r95, r96
+  JumpIfFalse  r97, L18
+  Len          r98, r95
+  Const        r99, 0
+L25:
+  LessInt      r100, r99, r98
+  JumpIfFalse  r100, L18
+  Index        r29, r95, r99
+  // (p.p_brand == brand) &&
+  Const        r102, "p_brand"
+  Index        r103, r17, r102
+  Equal        r105, r103, r2
+  JumpIfFalse  r105, L19
+  // (p.p_container == container) &&
+  Const        r106, "p_container"
+  Index        r107, r17, r106
+  Equal        r109, r107, r3
+L19:
+  JumpIfFalse  r109, L20
+  // (l.l_quantity < (
+  Const        r110, "l_quantity"
+  Index        r111, r29, r110
+  // 0.2 * avg(
+  Const        r112, 0.2
+  // from x in lineitem
+  Const        r113, []
+  // where x.l_partkey == p.p_partkey
+  Const        r114, "l_partkey"
+  Const        r115, "p_partkey"
+  // select x.l_quantity
+  Const        r116, "l_quantity"
+  // from x in lineitem
+  IterPrep     r117, r1
+  Len          r118, r117
+  Const        r119, 0
+L23:
+  LessInt      r121, r119, r118
+  JumpIfFalse  r121, L21
+  Index        r60, r117, r119
+  // where x.l_partkey == p.p_partkey
+  Const        r123, "l_partkey"
+  Index        r124, r60, r123
+  Const        r125, "p_partkey"
+  Index        r126, r17, r125
+  Equal        r127, r124, r126
+  JumpIfFalse  r127, L22
+  // select x.l_quantity
+  Const        r128, "l_quantity"
+  Index        r129, r60, r128
+  // from x in lineitem
+  Append       r113, r113, r129
+L22:
+  Const        r131, 1
+  AddInt       r119, r119, r131
+  Jump         L23
+L21:
+  // 0.2 * avg(
+  Avg          r132, r113
+  MulFloat     r133, r112, r132
+  // (l.l_quantity < (
+  LessFloat    r109, r111, r133
+L20:
+  // where (
+  JumpIfFalse  r109, L24
+  // select l.l_extendedprice
+  Const        r135, "l_extendedprice"
+  Index        r136, r29, r135
+  // from l in lineitem
+  Append       r4, r4, r136
+L24:
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r138, 1
+  AddInt       r99, r99, r138
+  Jump         L25
+L18:
+  Const        r139, 1
+  AddInt       r90, r90, r139
+  Jump         L26
+L17:
   // let result = sum(filtered) / 7.0
-  Sum          r14, r4
-  Const        r4, 7
-  DivFloat     r3, r14, r4
+  Sum          r140, r4
+  Const        r141, 7
+  DivFloat     r142, r140, r141
   // print(result)
-  Print        r3
+  Print        r142
   // let expected = 100.0 / 7.0
-  Const        r4, 14.285714285714286
+  Const        r143, 100
+  Const        r144, 7
+  Const        r145, 14.285714285714286
   // expect result == expected
-  EqualFloat   r14, r3, r4
-  Expect       r14
+  EqualFloat   r146, r142, r145
+  Expect       r146
   Return       r0

--- a/tests/dataset/tpc-h/out/q18.ir.out
+++ b/tests/dataset/tpc-h/out/q18.ir.out
@@ -1,9 +1,8 @@
-func main (regs=40)
+func main (regs=308)
   // let nation = [
   Const        r0, [{"n_name": "GERMANY", "n_nationkey": 1}]
   // let customer = [
   Const        r1, [{"c_acctbal": 1000, "c_address": "123 Market St", "c_comment": "Premium client", "c_custkey": 1, "c_name": "Alice", "c_nationkey": 1, "c_phone": "123-456"}, {"c_acctbal": 200, "c_address": "456 Side St", "c_comment": "Frequent returns", "c_custkey": 2, "c_name": "Bob", "c_nationkey": 1, "c_phone": "987-654"}]
-L6:
   // let orders = [
   Const        r2, [{"o_custkey": 1, "o_orderkey": 100}, {"o_custkey": 1, "o_orderkey": 200}, {"o_custkey": 2, "o_orderkey": 300}]
   // let lineitem = [
@@ -12,312 +11,413 @@ L6:
   Const        r4, 200
   // from c in customer
   Const        r5, []
-L7:
   // c_name: c.c_name,
   Const        r6, "c_name"
+  Const        r7, "c_name"
   // c_custkey: c.c_custkey,
-  Const        r7, "c_custkey"
+  Const        r8, "c_custkey"
+  Const        r9, "c_custkey"
   // c_acctbal: c.c_acctbal,
-  Const        r8, "c_acctbal"
+  Const        r10, "c_acctbal"
+  Const        r11, "c_acctbal"
   // c_address: c.c_address,
-  Const        r9, "c_address"
+  Const        r12, "c_address"
+  Const        r13, "c_address"
   // c_phone: c.c_phone,
-  Const        r10, "c_phone"
+  Const        r14, "c_phone"
+  Const        r15, "c_phone"
   // c_comment: c.c_comment,
-  Const        r11, "c_comment"
+  Const        r16, "c_comment"
+  Const        r17, "c_comment"
   // n_name: n.n_name
-  Const        r12, "n_name"
+  Const        r18, "n_name"
+  Const        r19, "n_name"
   // having sum(from x in g select x.l.l_quantity) > threshold
-  Const        r13, "l"
-  Const        r14, "l_quantity"
+  Const        r20, "l"
+  Const        r21, "l_quantity"
   // c_name: g.key.c_name,
-  Const        r15, "key"
-L8:
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Const        r16, "revenue"
-  Const        r17, "l_extendedprice"
-  Const        r18, "l_discount"
-  // from c in customer
-  MakeMap      r19, 0, r0
-  IterPrep     r20, r1
-  Len          r1, r20
-L0:
-  Const        r21, 0
-  LessInt      r22, r21, r1
-L4:
-  JumpIfFalse  r22, L0
-L2:
-  Index        r1, r20, r21
-  // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r20, r2
-  Len          r2, r20
-L3:
-  Move         r23, r21
-  LessInt      r24, r23, r2
-  JumpIfFalse  r24, L1
-  Index        r2, r20, r23
-  Const        r20, "o_custkey"
-  Index        r25, r2, r20
-  Index        r20, r1, r7
-  Equal        r26, r25, r20
-  JumpIfFalse  r26, L1
-L1:
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r26, r3
-  Len          r3, r26
-  Move         r20, r21
-  LessInt      r25, r20, r3
-  JumpIfFalse  r25, L1
-  Index        r25, r26, r20
-  Const        r26, "l_orderkey"
-  Index        r3, r25, r26
-  Const        r26, "o_orderkey"
-  Index        r27, r2, r26
-  Equal        r26, r3, r27
-  JumpIfFalse  r26, L0
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r26, r0
-  Len          r27, r26
-  Move         r3, r20
-  LessInt      r28, r3, r27
-  JumpIfFalse  r28, L0
-  Index        r28, r26, r3
-  Const        r26, "n_nationkey"
-  Index        r27, r28, r26
-  Const        r26, "c_nationkey"
-  Index        r29, r1, r26
-  Equal        r26, r27, r29
-  JumpIfFalse  r26, L2
-  // from c in customer
-  Const        r26, "c"
-  Move         r29, r1
-  Const        r27, "o"
-  Move         r30, r2
-  Move         r2, r25
-  Const        r25, "n"
-  Move         r31, r28
-  MakeMap      r32, 4, r26
-  // c_name: c.c_name,
-  Move         r31, r6
-  Index        r25, r1, r6
-  // c_custkey: c.c_custkey,
-  Move         r2, r7
-  Index        r30, r1, r7
-  // c_acctbal: c.c_acctbal,
-  Move         r27, r8
-  Index        r29, r1, r8
-  // c_address: c.c_address,
-  Move         r26, r9
-  Index        r33, r1, r9
-  // c_phone: c.c_phone,
-  Move         r34, r10
-  Index        r35, r1, r10
-  // c_comment: c.c_comment,
-  Move         r36, r11
-  Index        r37, r1, r11
-  // n_name: n.n_name
-  Move         r1, r12
-  Index        r38, r28, r12
-  // c_name: c.c_name,
-  Move         r39, r31
-  Move         r31, r25
-  // c_custkey: c.c_custkey,
-  Move         r25, r2
-  Move         r2, r30
-  // c_acctbal: c.c_acctbal,
-  Move         r30, r27
-  Move         r27, r29
-  // c_address: c.c_address,
-  Move         r29, r26
-  Move         r26, r33
-  // c_phone: c.c_phone,
-  Move         r33, r34
-  Move         r34, r35
-  // c_comment: c.c_comment,
-  Move         r35, r36
-  Move         r36, r37
-  // n_name: n.n_name
-  Move         r37, r1
-  Move         r1, r38
-  // group by {
-  MakeMap      r38, 7, r39
-  Str          r1, r38
-  In           r37, r1, r19
-  JumpIfTrue   r37, L1
-  // from c in customer
-  Move         r37, r5
-  Const        r36, "__group__"
-  Const        r35, true
-  Move         r34, r15
-  // group by {
-  Move         r33, r38
-  // from c in customer
-  Const        r38, "items"
-  Move         r26, r37
-  Const        r37, "count"
-  Move         r29, r21
-  Move         r27, r36
-  Move         r36, r35
-  Move         r35, r34
-  Move         r34, r33
-  Move         r33, r38
-  Move         r30, r26
-  Move         r26, r37
-  Move         r2, r29
-  MakeMap      r25, 4, r27
-  SetIndex     r19, r1, r25
-  Move         r25, r38
-  Index        r38, r19, r1
-  Index        r1, r38, r25
-  Append       r2, r1, r32
-  SetIndex     r38, r25, r2
-  Move         r2, r37
-  Index        r37, r38, r2
-  Const        r1, 1
-  AddInt       r25, r37, r1
-  SetIndex     r38, r2, r25
-  // join n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r3, r3, r1
-  Jump         L3
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  AddInt       r20, r20, r1
-  Jump         L2
-  // join o in orders on o.o_custkey == c.c_custkey
-  AddInt       r23, r23, r1
-  Jump         L4
-  // from c in customer
-  AddInt       r21, r21, r1
-  Jump         L0
-  Values       25,19,0,0
-  Move         r19, r29
-  Move         r29, r19
-  Len          r24, r25
-  LessInt      r23, r29, r24
-  JumpIfFalse  r23, L5
-  Index        r23, r25, r29
-  // having sum(from x in g select x.l.l_quantity) > threshold
-  Move         r25, r5
-  IterPrep     r24, r23
-  Len          r22, r24
-  Move         r21, r19
-  LessInt      r37, r21, r22
-  JumpIfFalse  r37, L6
-  Index        r37, r24, r21
-  Index        r24, r37, r13
-  Index        r22, r24, r14
-  Append       r25, r25, r22
-  AddInt       r21, r21, r1
-  Jump         L0
-  Sum          r24, r25
-  Less         r25, r4, r24
-  JumpIfFalse  r25, L5
-  // c_name: g.key.c_name,
-  Move         r25, r6
-  Index        r24, r23, r15
-  Index        r4, r24, r6
+  Const        r22, "c_name"
+  Const        r23, "key"
+  Const        r24, "c_name"
   // c_custkey: g.key.c_custkey,
-  Move         r24, r7
-  Index        r6, r23, r15
-  Index        r21, r6, r7
+  Const        r25, "c_custkey"
+  Const        r26, "key"
+  Const        r27, "c_custkey"
   // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r6, r16
-  Move         r22, r5
-  IterPrep     r16, r23
-  Len          r7, r16
-  Move         r14, r19
-  LessInt      r2, r14, r7
-  JumpIfFalse  r2, L7
-  Index        r37, r16, r14
-  Index        r2, r37, r13
-  Index        r7, r2, r17
-  Index        r2, r37, r13
-  Index        r16, r2, r18
-  Sub          r2, r1, r16
-  Mul          r16, r7, r2
-  Append       r22, r22, r16
-  AddInt       r14, r14, r1
-  Jump         L8
-  Sum          r2, r22
+  Const        r28, "revenue"
+  Const        r29, "l"
+  Const        r30, "l_extendedprice"
+  Const        r31, "l"
+  Const        r32, "l_discount"
   // c_acctbal: g.key.c_acctbal,
-  Move         r22, r8
-  Index        r7, r23, r15
-  Index        r14, r7, r8
+  Const        r33, "c_acctbal"
+  Const        r34, "key"
+  Const        r35, "c_acctbal"
   // n_name: g.key.n_name,
-  Move         r7, r12
-  Index        r8, r23, r15
-  Index        r38, r8, r12
+  Const        r36, "n_name"
+  Const        r37, "key"
+  Const        r38, "n_name"
   // c_address: g.key.c_address,
-  Move         r8, r9
-  Index        r12, r23, r15
-  Index        r16, r12, r9
+  Const        r39, "c_address"
+  Const        r40, "key"
+  Const        r41, "c_address"
   // c_phone: g.key.c_phone,
-  Move         r12, r10
-  Index        r9, r23, r15
-  Index        r28, r9, r10
+  Const        r42, "c_phone"
+  Const        r43, "key"
+  Const        r44, "c_phone"
   // c_comment: g.key.c_comment
-  Move         r9, r11
-  Index        r10, r23, r15
-  Index        r15, r10, r11
-  // c_name: g.key.c_name,
-  Move         r10, r25
-  Move         r11, r4
-  // c_custkey: g.key.c_custkey,
-  Move         r4, r24
-  Move         r24, r21
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
-  Move         r21, r6
-  Move         r6, r2
-  // c_acctbal: g.key.c_acctbal,
-  Move         r2, r22
-  Move         r22, r14
-  // n_name: g.key.n_name,
-  Move         r14, r7
-  Move         r7, r38
-  // c_address: g.key.c_address,
-  Move         r38, r8
-  Move         r8, r16
-  // c_phone: g.key.c_phone,
-  Move         r16, r12
-  Move         r12, r28
-  // c_comment: g.key.c_comment
-  Move         r28, r9
-  Move         r9, r15
-  // select {
-  MakeMap      r15, 8, r10
+  Const        r45, "c_comment"
+  Const        r46, "key"
+  Const        r47, "c_comment"
   // order by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Move         r9, r5
-  IterPrep     r28, r23
-  Len          r23, r28
-  Move         r12, r19
-L10:
-  LessInt      r19, r12, r23
-  JumpIfFalse  r19, L9
-  Index        r37, r28, r12
-  Index        r19, r37, r13
-  Index        r23, r19, r17
-  Index        r19, r37, r13
-  Index        r37, r19, r18
-  Sub          r19, r1, r37
-  Mul          r37, r23, r19
-  Append       r9, r9, r37
-  AddInt       r12, r12, r1
-  Jump         L10
-L9:
-  Sum          r37, r9
-  Neg          r9, r37
+  Const        r48, "l"
+  Const        r49, "l_extendedprice"
+  Const        r50, "l"
+  Const        r51, "l_discount"
   // from c in customer
-  Move         r37, r15
-  MakeList     r15, 2, r9
-  Append       r5, r5, r15
-  AddInt       r29, r29, r1
-  Jump         L2
+  MakeMap      r52, 0, r0
+  Const        r53, []
+  IterPrep     r55, r1
+  Len          r56, r55
+  Const        r57, 0
+L9:
+  LessInt      r58, r57, r56
+  JumpIfFalse  r58, L0
+  Index        r60, r55, r57
+  // join o in orders on o.o_custkey == c.c_custkey
+  IterPrep     r61, r2
+  Len          r62, r61
+  Const        r63, 0
+L8:
+  LessInt      r64, r63, r62
+  JumpIfFalse  r64, L1
+  Index        r66, r61, r63
+  Const        r67, "o_custkey"
+  Index        r68, r66, r67
+  Const        r69, "c_custkey"
+  Index        r70, r60, r69
+  Equal        r71, r68, r70
+  JumpIfFalse  r71, L2
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  IterPrep     r72, r3
+  Len          r73, r72
+  Const        r74, 0
+L7:
+  LessInt      r75, r74, r73
+  JumpIfFalse  r75, L2
+  Index        r77, r72, r74
+  Const        r78, "l_orderkey"
+  Index        r79, r77, r78
+  Const        r80, "o_orderkey"
+  Index        r81, r66, r80
+  Equal        r82, r79, r81
+  JumpIfFalse  r82, L3
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  IterPrep     r83, r0
+  Len          r84, r83
+  Const        r85, 0
+L6:
+  LessInt      r86, r85, r84
+  JumpIfFalse  r86, L3
+  Index        r88, r83, r85
+  Const        r89, "n_nationkey"
+  Index        r90, r88, r89
+  Const        r91, "c_nationkey"
+  Index        r92, r60, r91
+  Equal        r93, r90, r92
+  JumpIfFalse  r93, L4
+  // from c in customer
+  Const        r94, "c"
+  Move         r95, r60
+  Const        r96, "o"
+  Move         r97, r66
+  Const        r98, "l"
+  Move         r99, r77
+  Const        r100, "n"
+  Move         r101, r88
+  MakeMap      r102, 4, r94
+  // c_name: c.c_name,
+  Const        r103, "c_name"
+  Const        r104, "c_name"
+  Index        r105, r60, r104
+  // c_custkey: c.c_custkey,
+  Const        r106, "c_custkey"
+  Const        r107, "c_custkey"
+  Index        r108, r60, r107
+  // c_acctbal: c.c_acctbal,
+  Const        r109, "c_acctbal"
+  Const        r110, "c_acctbal"
+  Index        r111, r60, r110
+  // c_address: c.c_address,
+  Const        r112, "c_address"
+  Const        r113, "c_address"
+  Index        r114, r60, r113
+  // c_phone: c.c_phone,
+  Const        r115, "c_phone"
+  Const        r116, "c_phone"
+  Index        r117, r60, r116
+  // c_comment: c.c_comment,
+  Const        r118, "c_comment"
+  Const        r119, "c_comment"
+  Index        r120, r60, r119
+  // n_name: n.n_name
+  Const        r121, "n_name"
+  Const        r122, "n_name"
+  Index        r123, r88, r122
+  // c_name: c.c_name,
+  Move         r124, r103
+  Move         r125, r105
+  // c_custkey: c.c_custkey,
+  Move         r126, r106
+  Move         r127, r108
+  // c_acctbal: c.c_acctbal,
+  Move         r128, r109
+  Move         r129, r111
+  // c_address: c.c_address,
+  Move         r130, r112
+  Move         r131, r114
+  // c_phone: c.c_phone,
+  Move         r132, r115
+  Move         r133, r117
+  // c_comment: c.c_comment,
+  Move         r134, r118
+  Move         r135, r120
+  // n_name: n.n_name
+  Move         r136, r121
+  Move         r137, r123
+  // group by {
+  MakeMap      r138, 7, r124
+  Str          r139, r138
+  In           r140, r139, r52
+  JumpIfTrue   r140, L5
+  // from c in customer
+  Const        r141, []
+  Const        r142, "__group__"
+  Const        r143, true
+  Const        r144, "key"
+  // group by {
+  Move         r145, r138
+  // from c in customer
+  Const        r146, "items"
+  Move         r147, r141
+  Const        r148, "count"
+  Const        r149, 0
+  Move         r150, r142
+  Move         r151, r143
+  Move         r152, r144
+  Move         r153, r145
+  Move         r154, r146
+  Move         r155, r147
+  Move         r156, r148
+  Move         r157, r149
+  MakeMap      r158, 4, r150
+  SetIndex     r52, r139, r158
+  Append       r53, r53, r158
 L5:
+  Const        r160, "items"
+  Index        r161, r52, r139
+  Index        r162, r161, r160
+  Append       r163, r162, r102
+  SetIndex     r161, r160, r163
+  Const        r164, "count"
+  Index        r165, r161, r164
+  Const        r166, 1
+  AddInt       r167, r165, r166
+  SetIndex     r161, r164, r167
+L4:
+  // join n in nation on n.n_nationkey == c.c_nationkey
+  Const        r168, 1
+  AddInt       r85, r85, r168
+  Jump         L6
+L3:
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  Const        r169, 1
+  AddInt       r74, r74, r169
+  Jump         L7
+L2:
+  // join o in orders on o.o_custkey == c.c_custkey
+  Const        r170, 1
+  AddInt       r63, r63, r170
+  Jump         L8
+L1:
+  // from c in customer
+  Const        r171, 1
+  AddInt       r57, r57, r171
+  Jump         L9
+L0:
+  Const        r172, 0
+  Len          r174, r53
+L17:
+  LessInt      r175, r172, r174
+  JumpIfFalse  r175, L10
+  Index        r177, r53, r172
+  // having sum(from x in g select x.l.l_quantity) > threshold
+  Const        r178, []
+  Const        r179, "l"
+  Const        r180, "l_quantity"
+  IterPrep     r181, r177
+  Len          r182, r181
+  Const        r183, 0
+L12:
+  LessInt      r185, r183, r182
+  JumpIfFalse  r185, L11
+  Index        r187, r181, r183
+  Const        r188, "l"
+  Index        r189, r187, r188
+  Const        r190, "l_quantity"
+  Index        r191, r189, r190
+  Append       r178, r178, r191
+  Const        r193, 1
+  AddInt       r183, r183, r193
+  Jump         L12
+L11:
+  Sum          r194, r178
+  Less         r195, r4, r194
+  JumpIfFalse  r195, L10
+  // c_name: g.key.c_name,
+  Const        r196, "c_name"
+  Const        r197, "key"
+  Index        r198, r177, r197
+  Const        r199, "c_name"
+  Index        r200, r198, r199
+  // c_custkey: g.key.c_custkey,
+  Const        r201, "c_custkey"
+  Const        r202, "key"
+  Index        r203, r177, r202
+  Const        r204, "c_custkey"
+  Index        r205, r203, r204
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Const        r206, "revenue"
+  Const        r207, []
+  Const        r208, "l"
+  Const        r209, "l_extendedprice"
+  Const        r210, "l"
+  Const        r211, "l_discount"
+  IterPrep     r212, r177
+  Len          r213, r212
+  Const        r214, 0
+L14:
+  LessInt      r216, r214, r213
+  JumpIfFalse  r216, L13
+  Index        r187, r212, r214
+  Const        r218, "l"
+  Index        r219, r187, r218
+  Const        r220, "l_extendedprice"
+  Index        r221, r219, r220
+  Const        r222, 1
+  Const        r223, "l"
+  Index        r224, r187, r223
+  Const        r225, "l_discount"
+  Index        r226, r224, r225
+  Sub          r227, r222, r226
+  Mul          r228, r221, r227
+  Append       r207, r207, r228
+  Const        r230, 1
+  AddInt       r214, r214, r230
+  Jump         L14
+L13:
+  Sum          r231, r207
+  // c_acctbal: g.key.c_acctbal,
+  Const        r232, "c_acctbal"
+  Const        r233, "key"
+  Index        r234, r177, r233
+  Const        r235, "c_acctbal"
+  Index        r236, r234, r235
+  // n_name: g.key.n_name,
+  Const        r237, "n_name"
+  Const        r238, "key"
+  Index        r239, r177, r238
+  Const        r240, "n_name"
+  Index        r241, r239, r240
+  // c_address: g.key.c_address,
+  Const        r242, "c_address"
+  Const        r243, "key"
+  Index        r244, r177, r243
+  Const        r245, "c_address"
+  Index        r246, r244, r245
+  // c_phone: g.key.c_phone,
+  Const        r247, "c_phone"
+  Const        r248, "key"
+  Index        r249, r177, r248
+  Const        r250, "c_phone"
+  Index        r251, r249, r250
+  // c_comment: g.key.c_comment
+  Const        r252, "c_comment"
+  Const        r253, "key"
+  Index        r254, r177, r253
+  Const        r255, "c_comment"
+  Index        r256, r254, r255
+  // c_name: g.key.c_name,
+  Move         r257, r196
+  Move         r258, r200
+  // c_custkey: g.key.c_custkey,
+  Move         r259, r201
+  Move         r260, r205
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount)),
+  Move         r261, r206
+  Move         r262, r231
+  // c_acctbal: g.key.c_acctbal,
+  Move         r263, r232
+  Move         r264, r236
+  // n_name: g.key.n_name,
+  Move         r265, r237
+  Move         r266, r241
+  // c_address: g.key.c_address,
+  Move         r267, r242
+  Move         r268, r246
+  // c_phone: g.key.c_phone,
+  Move         r269, r247
+  Move         r270, r251
+  // c_comment: g.key.c_comment
+  Move         r271, r252
+  Move         r272, r256
+  // select {
+  MakeMap      r273, 8, r257
+  // order by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Const        r274, []
+  Const        r275, "l"
+  Const        r276, "l_extendedprice"
+  Const        r277, "l"
+  Const        r278, "l_discount"
+  IterPrep     r279, r177
+  Len          r280, r279
+  Const        r281, 0
+L16:
+  LessInt      r283, r281, r280
+  JumpIfFalse  r283, L15
+  Index        r187, r279, r281
+  Const        r285, "l"
+  Index        r286, r187, r285
+  Const        r287, "l_extendedprice"
+  Index        r288, r286, r287
+  Const        r289, 1
+  Const        r290, "l"
+  Index        r291, r187, r290
+  Const        r292, "l_discount"
+  Index        r293, r291, r292
+  Sub          r294, r289, r293
+  Mul          r295, r288, r294
+  Append       r274, r274, r295
+  Const        r297, 1
+  AddInt       r281, r281, r297
+  Jump         L16
+L15:
+  Sum          r298, r274
+  Neg          r300, r298
+  // from c in customer
+  Move         r301, r273
+  MakeList     r302, 2, r300
+  Append       r5, r5, r302
+  Const        r304, 1
+  AddInt       r172, r172, r304
+  Jump         L17
+L10:
   // order by -sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
   Sort         r5, r5
   // json(result)
   JSON         r5
   // expect result == [
-  Const        r15, [{"c_acctbal": 1000, "c_address": "123 Market St", "c_comment": "Premium client", "c_custkey": 1, "c_name": "Alice", "c_phone": "123-456", "n_name": "GERMANY", "revenue": 1700}]
-  Equal        r37, r5, r15
-  Expect       r37
+  Const        r306, [{"c_acctbal": 1000, "c_address": "123 Market St", "c_comment": "Premium client", "c_custkey": 1, "c_name": "Alice", "c_phone": "123-456", "n_name": "GERMANY", "revenue": 1700}]
+  Equal        r307, r5, r306
+  Expect       r307
   Return       r0

--- a/tests/dataset/tpc-h/out/q19.ir.out
+++ b/tests/dataset/tpc-h/out/q19.ir.out
@@ -1,367 +1,450 @@
-func main (regs=41)
+func main (regs=282)
 L0:
   // let part = [
   Const        r0, [{"p_brand": "Brand#12", "p_container": "SM BOX", "p_partkey": 1, "p_size": 3}, {"p_brand": "Brand#23", "p_container": "MED BOX", "p_partkey": 2, "p_size": 5}, {"p_brand": "Brand#34", "p_container": "LG BOX", "p_partkey": 3, "p_size": 15}]
-L11:
   // let lineitem = [
   Const        r1, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_partkey": 1, "l_quantity": 5, "l_shipinstruct": "DELIVER IN PERSON", "l_shipmode": "AIR"}, {"l_discount": 0.05, "l_extendedprice": 2000, "l_partkey": 2, "l_quantity": 15, "l_shipinstruct": "DELIVER IN PERSON", "l_shipmode": "AIR REG"}, {"l_discount": 0, "l_extendedprice": 1500, "l_partkey": 3, "l_quantity": 35, "l_shipinstruct": "DELIVER IN PERSON", "l_shipmode": "AIR"}]
   // from l in lineitem
   Const        r2, []
   IterPrep     r3, r1
-  Len          r1, r3
+  Len          r4, r3
   // join p in part on p.p_partkey == l.l_partkey
-  IterPrep     r4, r0
-L5:
-  Len          r5, r4
+  IterPrep     r5, r0
+  Len          r6, r5
+  // from l in lineitem
+  Const        r7, 0
+  EqualInt     r8, r4, r7
+  JumpIfTrue   r8, L0
+  EqualInt     r9, r6, r7
+  JumpIfTrue   r9, L0
+  LessEq       r10, r6, r4
+  JumpIfFalse  r10, L1
+  // join p in part on p.p_partkey == l.l_partkey
+  MakeMap      r11, 0, r0
+  Const        r12, 0
+L4:
+  LessInt      r13, r12, r6
+  JumpIfFalse  r13, L2
+  Index        r14, r5, r12
+  Move         r15, r14
+  Const        r16, "p_partkey"
+  Index        r17, r15, r16
+  Index        r18, r11, r17
+  Const        r19, nil
+  NotEqual     r20, r18, r19
+  JumpIfTrue   r20, L3
+  MakeList     r21, 0, r0
+  SetIndex     r11, r17, r21
+L3:
+  Index        r18, r11, r17
+  Append       r22, r18, r14
+  SetIndex     r11, r17, r22
+  Const        r23, 1
+  AddInt       r12, r12, r23
+  Jump         L4
 L2:
   // from l in lineitem
-  Const        r6, 0
-  EqualInt     r7, r1, r6
-  JumpIfTrue   r7, L0
-  EqualInt     r7, r5, r6
-L4:
-  JumpIfTrue   r7, L0
-L3:
-  LessEq       r7, r5, r1
-  JumpIfFalse  r7, L1
-L15:
-  // join p in part on p.p_partkey == l.l_partkey
-  MakeMap      r7, 0, r0
-  Move         r8, r6
-  LessInt      r9, r8, r5
-L14:
-  JumpIfFalse  r9, L2
-  Index        r9, r4, r8
-L18:
-  Move         r10, r9
-L1:
-  Const        r11, "p_partkey"
-L19:
-  Index        r12, r10, r11
-L6:
-  Index        r13, r7, r12
-  Const        r14, nil
-  NotEqual     r15, r13, r14
-  JumpIfTrue   r15, L3
-L31:
-  MakeList     r15, 0, r0
-L13:
-  SetIndex     r7, r12, r15
-L9:
-  Index        r13, r7, r12
-  Append       r15, r13, r9
-L7:
-  SetIndex     r7, r12, r15
-L10:
-  Const        r15, 1
-L8:
-  AddInt       r8, r8, r15
-  Jump         L4
-  // from l in lineitem
-  Move         r8, r6
+  Const        r24, 0
 L20:
-  LessInt      r13, r8, r1
-  JumpIfFalse  r13, L0
+  LessInt      r25, r24, r4
+  JumpIfFalse  r25, L0
+  Index        r27, r3, r24
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r28, "l_partkey"
+  Index        r29, r27, r28
+  // from l in lineitem
+  Index        r30, r11, r29
+  Const        r31, nil
+  NotEqual     r32, r30, r31
+  JumpIfFalse  r32, L5
+  Len          r33, r30
+  Const        r34, 0
+L19:
+  LessInt      r35, r34, r33
+  JumpIfFalse  r35, L5
+  Index        r15, r30, r34
+  // (p.p_brand == "Brand#12") &&
+  Const        r37, "p_brand"
+  Index        r38, r15, r37
+  Const        r39, "Brand#12"
+  Equal        r41, r38, r39
+  JumpIfFalse  r41, L6
+  // (p.p_container in ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]) &&
+  Const        r42, "p_container"
+  Index        r43, r15, r42
+  Const        r44, ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]
+  In           r46, r43, r44
+L6:
+  JumpIfFalse  r46, L7
+  // (l.l_quantity >= 1 && l.l_quantity <= 11) &&
+  Const        r47, "l_quantity"
+  Index        r48, r27, r47
+  Const        r49, 1
+  LessEq       r50, r49, r48
+  Const        r51, "l_quantity"
+  Index        r52, r27, r51
+  Const        r53, 11
+  LessEq       r54, r52, r53
+  Move         r55, r50
+  JumpIfFalse  r55, L7
+L7:
+  Move         r56, r54
+  JumpIfFalse  r56, L8
+  // (p.p_size >= 1 && p.p_size <= 5)
+  Const        r57, "p_size"
+  Index        r58, r15, r57
+  Const        r59, 1
+  LessEq       r60, r59, r58
+  Const        r61, "p_size"
+  Index        r62, r15, r61
+  Const        r63, 5
+  LessEq       r64, r62, r63
+  Move         r65, r60
+  JumpIfFalse  r65, L8
+L8:
+  // ) || (
+  Move         r66, r64
+  JumpIfTrue   r66, L9
+  // (p.p_brand == "Brand#23") &&
+  Const        r67, "p_brand"
+  Index        r68, r15, r67
+  Const        r69, "Brand#23"
+  Equal        r71, r68, r69
+  JumpIfFalse  r71, L10
+  // (p.p_container in ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]) &&
+  Const        r72, "p_container"
+  Index        r73, r15, r72
+  Const        r74, ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]
+  In           r76, r73, r74
+L10:
+  JumpIfFalse  r76, L11
+  // (l.l_quantity >= 10 && l.l_quantity <= 20) &&
+  Const        r77, "l_quantity"
+  Index        r78, r27, r77
+  Const        r79, 10
+  LessEq       r80, r79, r78
+  Const        r81, "l_quantity"
+  Index        r82, r27, r81
+  Const        r83, 20
+  LessEq       r84, r82, r83
+  Move         r85, r80
+  JumpIfFalse  r85, L11
+L11:
+  Move         r86, r84
+  JumpIfFalse  r86, L9
+  // (p.p_size >= 1 && p.p_size <= 10)
+  Const        r87, "p_size"
+  Index        r88, r15, r87
+  Const        r89, 1
+  LessEq       r90, r89, r88
+  Const        r91, "p_size"
+  Index        r92, r15, r91
+  Const        r93, 10
+  LessEq       r94, r92, r93
+  Move         r95, r90
+  JumpIfFalse  r95, L9
+L9:
+  // ) || (
+  Move         r96, r94
+  JumpIfTrue   r96, L12
+  // (p.p_brand == "Brand#34") &&
+  Const        r97, "p_brand"
+  Index        r98, r15, r97
+  Const        r99, "Brand#34"
+  Equal        r101, r98, r99
+  JumpIfFalse  r101, L13
+  // (p.p_container in ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]) &&
+  Const        r102, "p_container"
+  Index        r103, r15, r102
+  Const        r104, ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]
+  In           r106, r103, r104
+L13:
+  JumpIfFalse  r106, L14
+  // (l.l_quantity >= 20 && l.l_quantity <= 30) &&
+  Const        r107, "l_quantity"
+  Index        r108, r27, r107
+  Const        r109, 20
+  LessEq       r110, r109, r108
+  Const        r111, "l_quantity"
+  Index        r112, r27, r111
+  Const        r113, 30
+  LessEq       r114, r112, r113
+  Move         r115, r110
+  JumpIfFalse  r115, L14
+L14:
+  Move         r116, r114
+  JumpIfFalse  r116, L15
+  // (p.p_size >= 1 && p.p_size <= 15)
+  Const        r117, "p_size"
+  Index        r118, r15, r117
+  Const        r119, 1
+  LessEq       r120, r119, r118
+  Const        r121, "p_size"
+  Index        r122, r15, r121
+  Const        r123, 15
+  LessEq       r124, r122, r123
+  Move         r125, r120
+  JumpIfFalse  r125, L15
+L15:
+  // ) || (
+  Move         r96, r124
 L12:
-  Index        r13, r3, r8
-  // join p in part on p.p_partkey == l.l_partkey
-  Const        r12, "l_partkey"
-  Index        r9, r13, r12
-  // from l in lineitem
-  Index        r16, r7, r9
-  NotEqual     r9, r16, r14
-  JumpIfFalse  r9, L5
-  Len          r9, r16
-  Move         r7, r8
-  LessInt      r17, r7, r9
-  JumpIfFalse  r17, L5
-  Index        r10, r16, r7
-  // (p.p_brand == "Brand#12") &&
-  Const        r9, "p_brand"
-  Index        r16, r10, r9
-  Const        r18, "Brand#12"
-  Equal        r19, r16, r18
-  JumpIfFalse  r19, L6
-  // (p.p_container in ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]) &&
-  Const        r19, "p_container"
-  Index        r16, r10, r19
-  Const        r20, ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]
-  In           r21, r16, r20
-  JumpIfFalse  r21, L6
-  // (l.l_quantity >= 1 && l.l_quantity <= 11) &&
-  Const        r21, "l_quantity"
-  Index        r16, r13, r21
-  LessEq       r22, r15, r16
-  Index        r16, r13, r21
-  Const        r23, 11
-  LessEq       r24, r16, r23
-  Move         r16, r22
-  JumpIfFalse  r16, L6
-  Move         r16, r24
-  JumpIfFalse  r16, L7
-  // (p.p_size >= 1 && p.p_size <= 5)
-  Const        r16, "p_size"
-  Index        r24, r10, r16
-  LessEq       r22, r15, r24
-  Index        r24, r10, r16
-  Const        r25, 5
-  LessEq       r26, r24, r25
-  Move         r24, r22
-  JumpIfFalse  r24, L7
-  // ) || (
-  Move         r24, r26
-  JumpIfTrue   r24, L8
-  // (p.p_brand == "Brand#23") &&
-  Index        r24, r10, r9
-  Const        r26, "Brand#23"
-  Equal        r22, r24, r26
-  JumpIfFalse  r22, L9
-  // (p.p_container in ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]) &&
-  Index        r22, r10, r19
-  Const        r24, ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]
-  In           r27, r22, r24
-  JumpIfFalse  r27, L10
-  // (l.l_quantity >= 10 && l.l_quantity <= 20) &&
-  Index        r27, r13, r21
-  Const        r22, 10
-  LessEq       r28, r22, r27
-  Index        r27, r13, r21
-  Const        r29, 20
-  LessEq       r30, r27, r29
-  Move         r27, r28
-  JumpIfFalse  r27, L10
-  Move         r27, r30
-  JumpIfFalse  r27, L8
-  // (p.p_size >= 1 && p.p_size <= 10)
-  Index        r27, r10, r16
-  LessEq       r30, r15, r27
-  Index        r27, r10, r16
-  LessEq       r28, r27, r22
-  Move         r27, r30
-  JumpIfFalse  r27, L8
-  // ) || (
-  Move         r27, r28
-  JumpIfTrue   r27, L11
-  // (p.p_brand == "Brand#34") &&
-  Index        r28, r10, r9
-  Const        r30, "Brand#34"
-  Equal        r31, r28, r30
-  JumpIfFalse  r31, L12
-  // (p.p_container in ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]) &&
-  Index        r31, r10, r19
-  Const        r28, ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]
-  In           r32, r31, r28
-  JumpIfFalse  r32, L13
-  // (l.l_quantity >= 20 && l.l_quantity <= 30) &&
-  Index        r32, r13, r21
-  LessEq       r31, r29, r32
-  Index        r32, r13, r21
-  Const        r33, 30
-  LessEq       r34, r32, r33
-  Move         r32, r31
-  JumpIfFalse  r32, L13
-  Move         r32, r34
-  JumpIfFalse  r32, L3
-  // (p.p_size >= 1 && p.p_size <= 15)
-  Index        r32, r10, r16
-  LessEq       r34, r15, r32
-  Index        r32, r10, r16
-  Const        r31, 15
-  LessEq       r35, r32, r31
-  Move         r32, r34
-  JumpIfFalse  r32, L3
-  // ) || (
-  Move         r27, r35
   // ) && l.l_shipmode in ["AIR", "AIR REG"]
-  Const        r32, "l_shipmode"
-  Index        r35, r13, r32
-  Const        r34, ["AIR", "AIR REG"]
-  In           r36, r35, r34
+  Const        r126, "l_shipmode"
+  Index        r127, r27, r126
+  Const        r128, ["AIR", "AIR REG"]
+  In           r129, r127, r128
   // && l.l_shipinstruct == "DELIVER IN PERSON"
-  Const        r35, "l_shipinstruct"
-  Index        r37, r13, r35
-  Const        r38, "DELIVER IN PERSON"
-  Equal        r39, r37, r38
+  Const        r130, "l_shipinstruct"
+  Index        r131, r27, r130
+  Const        r132, "DELIVER IN PERSON"
+  Equal        r133, r131, r132
   // ) && l.l_shipmode in ["AIR", "AIR REG"]
-  Move         r37, r27
-  JumpIfFalse  r37, L5
-  // && l.l_shipinstruct == "DELIVER IN PERSON"
-  Move         r37, r36
-  JumpIfFalse  r37, L13
-  Move         r37, r39
-  // where (
-  JumpIfFalse  r37, L13
-  // select sum(l.l_extendedprice * (1 - l.l_discount))
-  Const        r37, "l_extendedprice"
-  Index        r39, r13, r37
-  Const        r36, "l_discount"
-  Index        r27, r13, r36
-  Sub          r40, r15, r27
-  Mul          r27, r39, r40
-  // from l in lineitem
-  Append       r2, r2, r27
-  AddInt       r7, r7, r15
-  Jump         L13
-  AddInt       r8, r8, r15
-  Jump         L14
-  MakeMap      r27, 0, r0
-  Move         r17, r6
-  LessInt      r8, r17, r1
-  JumpIfFalse  r8, L5
-  Index        r8, r3, r17
-  // join p in part on p.p_partkey == l.l_partkey
-  Index        r3, r8, r12
-  // from l in lineitem
-  Index        r12, r27, r3
-  Move         r1, r14
-  NotEqual     r14, r12, r1
-  JumpIfTrue   r14, L5
-  MakeList     r14, 0, r0
-  SetIndex     r27, r3, r14
-  Index        r12, r27, r3
-  Append       r14, r12, r8
-  SetIndex     r27, r3, r14
-  AddInt       r17, r17, r15
-  Jump         L15
-  // join p in part on p.p_partkey == l.l_partkey
-  Move         r12, r6
-  LessInt      r6, r12, r5
-  JumpIfFalse  r6, L16
-  Index        r10, r4, r12
-  Index        r6, r10, r11
-  Index        r11, r27, r6
-  NotEqual     r6, r11, r1
-  JumpIfFalse  r6, L17
-  Len          r6, r11
-  Move         r1, r12
-  LessInt      r27, r1, r6
-  JumpIfFalse  r27, L17
-  Index        r13, r11, r1
-  // (p.p_brand == "Brand#12") &&
-  Index        r27, r10, r9
-  Equal        r6, r27, r18
-  JumpIfFalse  r6, L18
-  // (p.p_container in ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]) &&
-  Index        r6, r10, r19
-  In           r27, r6, r20
-  JumpIfFalse  r27, L19
-  // (l.l_quantity >= 1 && l.l_quantity <= 11) &&
-  Index        r27, r13, r21
-  LessEq       r6, r15, r27
-  Index        r27, r13, r21
-  LessEq       r20, r27, r23
-  Move         r27, r6
-  JumpIfFalse  r27, L19
-  Move         r14, r20
-  JumpIfFalse  r14, L20
-  // (p.p_size >= 1 && p.p_size <= 5)
-  Index        r27, r10, r16
-  LessEq       r20, r15, r27
-  Index        r27, r10, r16
-  LessEq       r6, r27, r25
-  Move         r27, r20
-  JumpIfFalse  r27, L20
-  // ) || (
-  Move         r27, r6
-  JumpIfTrue   r27, L21
-  // (p.p_brand == "Brand#23") &&
-  Index        r27, r10, r9
-  Equal        r6, r27, r26
-  JumpIfFalse  r6, L22
-  // (p.p_container in ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]) &&
-  Index        r6, r10, r19
-  In           r27, r6, r24
-L22:
-  JumpIfFalse  r27, L23
-  // (l.l_quantity >= 10 && l.l_quantity <= 20) &&
-  Index        r27, r13, r21
-  LessEq       r6, r22, r27
-  Index        r27, r13, r21
-  LessEq       r24, r27, r29
-  Move         r26, r6
-  JumpIfFalse  r26, L23
-L23:
-  Move         r26, r24
-  JumpIfFalse  r26, L21
-  // (p.p_size >= 1 && p.p_size <= 10)
-  Index        r26, r10, r16
-  LessEq       r24, r15, r26
-  Index        r26, r10, r16
-  LessEq       r6, r26, r22
-  Move         r26, r24
-  JumpIfFalse  r26, L21
-L21:
-  // ) || (
-  Move         r26, r6
-  JumpIfTrue   r26, L24
-  // (p.p_brand == "Brand#34") &&
-  Index        r6, r10, r9
-  Equal        r9, r6, r30
-  JumpIfFalse  r9, L25
-  // (p.p_container in ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]) &&
-  Index        r9, r10, r19
-  In           r19, r9, r28
-L25:
-  JumpIfFalse  r19, L26
-  // (l.l_quantity >= 20 && l.l_quantity <= 30) &&
-  Index        r19, r13, r21
-  LessEq       r9, r29, r19
-  Index        r19, r13, r21
-  LessEq       r21, r19, r33
-  Move         r19, r9
-  JumpIfFalse  r19, L26
-L26:
-  Move         r19, r21
-  JumpIfFalse  r19, L27
-  // (p.p_size >= 1 && p.p_size <= 15)
-  Index        r19, r10, r16
-  LessEq       r21, r15, r19
-  Index        r19, r10, r16
-  LessEq       r16, r19, r31
-  Move         r19, r21
-  JumpIfFalse  r19, L27
-L27:
-  // ) || (
-  Move         r26, r16
-L24:
-  // ) && l.l_shipmode in ["AIR", "AIR REG"]
-  Index        r19, r13, r32
-  In           r32, r19, r34
-  // && l.l_shipinstruct == "DELIVER IN PERSON"
-  Index        r19, r13, r35
-  Equal        r35, r19, r38
-  // ) && l.l_shipmode in ["AIR", "AIR REG"]
-  Move         r19, r26
-  JumpIfFalse  r19, L28
-L28:
-  // && l.l_shipinstruct == "DELIVER IN PERSON"
-  Move         r19, r32
-  JumpIfFalse  r19, L29
-  Move         r19, r35
-L29:
-  // where (
-  JumpIfFalse  r19, L30
-  // select sum(l.l_extendedprice * (1 - l.l_discount))
-  Index        r19, r13, r37
-  Index        r37, r13, r36
-  Sub          r36, r15, r37
-  Mul          r37, r19, r36
-  // from l in lineitem
-  Append       r2, r2, r37
-L30:
-  // join p in part on p.p_partkey == l.l_partkey
-  AddInt       r1, r1, r15
-  Jump         L31
-L17:
-  AddInt       r12, r12, r15
-  Jump         L13
+  Move         r134, r96
+  JumpIfFalse  r134, L16
 L16:
+  // && l.l_shipinstruct == "DELIVER IN PERSON"
+  Move         r135, r129
+  JumpIfFalse  r135, L17
+  Move         r135, r133
+L17:
+  // where (
+  JumpIfFalse  r135, L18
   // select sum(l.l_extendedprice * (1 - l.l_discount))
-  Sum          r37, r2
+  Const        r136, "l_extendedprice"
+  Index        r137, r27, r136
+  Const        r138, 1
+  Const        r139, "l_discount"
+  Index        r140, r27, r139
+  Sub          r141, r138, r140
+  Mul          r142, r137, r141
+  // from l in lineitem
+  Append       r2, r2, r142
+L18:
+  Const        r144, 1
+  AddInt       r34, r34, r144
+  Jump         L19
+L5:
+  Const        r145, 1
+  AddInt       r24, r24, r145
+  Jump         L20
+L1:
+  MakeMap      r146, 0, r0
+  Const        r147, 0
+L23:
+  LessInt      r148, r147, r4
+  JumpIfFalse  r148, L21
+  Index        r149, r3, r147
+  Move         r27, r149
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r150, "l_partkey"
+  Index        r151, r27, r150
+  // from l in lineitem
+  Index        r152, r146, r151
+  Const        r153, nil
+  NotEqual     r154, r152, r153
+  JumpIfTrue   r154, L22
+  MakeList     r155, 0, r0
+  SetIndex     r146, r151, r155
+L22:
+  Index        r152, r146, r151
+  Append       r156, r152, r149
+  SetIndex     r146, r151, r156
+  Const        r157, 1
+  AddInt       r147, r147, r157
+  Jump         L23
+L21:
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r158, 0
+L40:
+  LessInt      r159, r158, r6
+  JumpIfFalse  r159, L24
+  Index        r15, r5, r158
+  Const        r161, "p_partkey"
+  Index        r162, r15, r161
+  Index        r163, r146, r162
+  Const        r164, nil
+  NotEqual     r165, r163, r164
+  JumpIfFalse  r165, L25
+  Len          r166, r163
+  Const        r167, 0
+L39:
+  LessInt      r168, r167, r166
+  JumpIfFalse  r168, L25
+  Index        r27, r163, r167
+  // (p.p_brand == "Brand#12") &&
+  Const        r170, "p_brand"
+  Index        r171, r15, r170
+  Const        r172, "Brand#12"
+  Equal        r174, r171, r172
+  JumpIfFalse  r174, L26
+  // (p.p_container in ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]) &&
+  Const        r175, "p_container"
+  Index        r176, r15, r175
+  Const        r177, ["SM CASE", "SM BOX", "SM PACK", "SM PKG"]
+  In           r179, r176, r177
+L26:
+  JumpIfFalse  r179, L27
+  // (l.l_quantity >= 1 && l.l_quantity <= 11) &&
+  Const        r180, "l_quantity"
+  Index        r181, r27, r180
+  Const        r182, 1
+  LessEq       r183, r182, r181
+  Const        r184, "l_quantity"
+  Index        r185, r27, r184
+  Const        r186, 11
+  LessEq       r187, r185, r186
+  Move         r188, r183
+  JumpIfFalse  r188, L27
+L27:
+  Move         r189, r187
+  JumpIfFalse  r189, L28
+  // (p.p_size >= 1 && p.p_size <= 5)
+  Const        r190, "p_size"
+  Index        r191, r15, r190
+  Const        r192, 1
+  LessEq       r193, r192, r191
+  Const        r194, "p_size"
+  Index        r195, r15, r194
+  Const        r196, 5
+  LessEq       r197, r195, r196
+  Move         r198, r193
+  JumpIfFalse  r198, L28
+L28:
+  // ) || (
+  Move         r199, r197
+  JumpIfTrue   r199, L29
+  // (p.p_brand == "Brand#23") &&
+  Const        r200, "p_brand"
+  Index        r201, r15, r200
+  Const        r202, "Brand#23"
+  Equal        r204, r201, r202
+  JumpIfFalse  r204, L30
+  // (p.p_container in ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]) &&
+  Const        r205, "p_container"
+  Index        r206, r15, r205
+  Const        r207, ["MED BAG", "MED BOX", "MED PKG", "MED PACK"]
+  In           r209, r206, r207
+L30:
+  JumpIfFalse  r209, L31
+  // (l.l_quantity >= 10 && l.l_quantity <= 20) &&
+  Const        r210, "l_quantity"
+  Index        r211, r27, r210
+  Const        r212, 10
+  LessEq       r213, r212, r211
+  Const        r214, "l_quantity"
+  Index        r215, r27, r214
+  Const        r216, 20
+  LessEq       r217, r215, r216
+  Move         r218, r213
+  JumpIfFalse  r218, L31
+L31:
+  Move         r219, r217
+  JumpIfFalse  r219, L29
+  // (p.p_size >= 1 && p.p_size <= 10)
+  Const        r220, "p_size"
+  Index        r221, r15, r220
+  Const        r222, 1
+  LessEq       r223, r222, r221
+  Const        r224, "p_size"
+  Index        r225, r15, r224
+  Const        r226, 10
+  LessEq       r227, r225, r226
+  Move         r228, r223
+  JumpIfFalse  r228, L29
+L29:
+  // ) || (
+  Move         r229, r227
+  JumpIfTrue   r229, L32
+  // (p.p_brand == "Brand#34") &&
+  Const        r230, "p_brand"
+  Index        r231, r15, r230
+  Const        r232, "Brand#34"
+  Equal        r234, r231, r232
+  JumpIfFalse  r234, L33
+  // (p.p_container in ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]) &&
+  Const        r235, "p_container"
+  Index        r236, r15, r235
+  Const        r237, ["LG CASE", "LG BOX", "LG PACK", "LG PKG"]
+  In           r239, r236, r237
+L33:
+  JumpIfFalse  r239, L34
+  // (l.l_quantity >= 20 && l.l_quantity <= 30) &&
+  Const        r240, "l_quantity"
+  Index        r241, r27, r240
+  Const        r242, 20
+  LessEq       r243, r242, r241
+  Const        r244, "l_quantity"
+  Index        r245, r27, r244
+  Const        r246, 30
+  LessEq       r247, r245, r246
+  Move         r248, r243
+  JumpIfFalse  r248, L34
+L34:
+  Move         r249, r247
+  JumpIfFalse  r249, L35
+  // (p.p_size >= 1 && p.p_size <= 15)
+  Const        r250, "p_size"
+  Index        r251, r15, r250
+  Const        r252, 1
+  LessEq       r253, r252, r251
+  Const        r254, "p_size"
+  Index        r255, r15, r254
+  Const        r256, 15
+  LessEq       r257, r255, r256
+  Move         r258, r253
+  JumpIfFalse  r258, L35
+L35:
+  // ) || (
+  Move         r229, r257
+L32:
+  // ) && l.l_shipmode in ["AIR", "AIR REG"]
+  Const        r259, "l_shipmode"
+  Index        r260, r27, r259
+  Const        r261, ["AIR", "AIR REG"]
+  In           r262, r260, r261
+  // && l.l_shipinstruct == "DELIVER IN PERSON"
+  Const        r263, "l_shipinstruct"
+  Index        r264, r27, r263
+  Const        r265, "DELIVER IN PERSON"
+  Equal        r266, r264, r265
+  // ) && l.l_shipmode in ["AIR", "AIR REG"]
+  Move         r267, r229
+  JumpIfFalse  r267, L36
+L36:
+  // && l.l_shipinstruct == "DELIVER IN PERSON"
+  Move         r268, r262
+  JumpIfFalse  r268, L37
+  Move         r268, r266
+L37:
+  // where (
+  JumpIfFalse  r268, L38
+  // select sum(l.l_extendedprice * (1 - l.l_discount))
+  Const        r269, "l_extendedprice"
+  Index        r270, r27, r269
+  Const        r271, 1
+  Const        r272, "l_discount"
+  Index        r273, r27, r272
+  Sub          r274, r271, r273
+  Mul          r275, r270, r274
+  // from l in lineitem
+  Append       r2, r2, r275
+L38:
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r277, 1
+  AddInt       r167, r167, r277
+  Jump         L39
+L25:
+  Const        r278, 1
+  AddInt       r158, r158, r278
+  Jump         L40
+L24:
+  // select sum(l.l_extendedprice * (1 - l.l_discount))
+  Sum          r279, r2
   // print(result)
-  Print        r37
+  Print        r279
   // expect result == 2800.0
-  Const        r2, 2800
-  EqualFloat   r36, r37, r2
-  Expect       r36
+  Const        r280, 2800
+  EqualFloat   r281, r279, r280
+  Expect       r281
   Return       r0

--- a/tests/dataset/tpc-h/out/q2.ir.out
+++ b/tests/dataset/tpc-h/out/q2.ir.out
@@ -1,469 +1,630 @@
-func main (regs=29)
+func main (regs=389)
 L0:
   // let region = [
   Const        r0, [{"r_name": "EUROPE", "r_regionkey": 1}, {"r_name": "ASIA", "r_regionkey": 2}]
-L16:
   // let nation = [
   Const        r1, [{"n_name": "FRANCE", "n_nationkey": 10, "n_regionkey": 1}, {"n_name": "CHINA", "n_nationkey": 20, "n_regionkey": 2}]
   // let supplier = [
   Const        r2, [{"s_acctbal": 1000, "s_address": "123 Rue", "s_comment": "Fast and reliable", "s_name": "BestSupplier", "s_nationkey": 10, "s_phone": "123", "s_suppkey": 100}, {"s_acctbal": 500, "s_address": "456 Way", "s_comment": "Slow", "s_name": "AltSupplier", "s_nationkey": 20, "s_phone": "456", "s_suppkey": 200}]
-L13:
   // let part = [
   Const        r3, [{"p_mfgr": "M1", "p_partkey": 1000, "p_size": 15, "p_type": "LARGE BRASS"}, {"p_mfgr": "M2", "p_partkey": 2000, "p_size": 15, "p_type": "SMALL COPPER"}]
-L26:
   // let partsupp = [
   Const        r4, [{"ps_partkey": 1000, "ps_suppkey": 100, "ps_supplycost": 10}, {"ps_partkey": 1000, "ps_suppkey": 200, "ps_supplycost": 15}]
   // from r in region
   Const        r5, []
-L10:
   IterPrep     r6, r0
-L7:
   Len          r7, r6
-L20:
   // join n in nation on n.n_regionkey == r.r_regionkey
   IterPrep     r8, r1
-  Len          r1, r8
+  Len          r9, r8
+  // from r in region
+  Const        r10, 0
+  EqualInt     r11, r7, r10
+  JumpIfTrue   r11, L0
+  EqualInt     r12, r9, r10
+  JumpIfTrue   r12, L0
+  LessEq       r13, r9, r7
+  JumpIfFalse  r13, L1
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  MakeMap      r14, 0, r0
+  Const        r15, 0
+L4:
+  LessInt      r16, r15, r9
+  JumpIfFalse  r16, L2
+  Index        r17, r8, r15
+  Move         r18, r17
+  Const        r19, "n_regionkey"
+  Index        r20, r18, r19
+  Index        r21, r14, r20
+  Const        r22, nil
+  NotEqual     r23, r21, r22
+  JumpIfTrue   r23, L3
+  MakeList     r24, 0, r0
+  SetIndex     r14, r20, r24
+L3:
+  Index        r21, r14, r20
+  Append       r25, r21, r17
+  SetIndex     r14, r20, r25
+  Const        r26, 1
+  AddInt       r15, r15, r26
+  Jump         L4
 L2:
   // from r in region
-  Const        r9, 0
-L11:
-  EqualInt     r10, r7, r9
-L12:
-  JumpIfTrue   r10, L0
-L18:
-  EqualInt     r10, r1, r9
-L1:
-  JumpIfTrue   r10, L0
-L3:
-  LessEq       r10, r1, r7
+  Const        r27, 0
 L8:
-  JumpIfFalse  r10, L1
-L14:
+  LessInt      r28, r27, r7
+  JumpIfFalse  r28, L0
+  Index        r30, r6, r27
   // join n in nation on n.n_regionkey == r.r_regionkey
-  MakeMap      r10, 0, r0
-  Move         r11, r9
-L17:
-  LessInt      r12, r11, r1
+  Const        r31, "r_regionkey"
+  Index        r32, r30, r31
+  // from r in region
+  Index        r33, r14, r32
+  Const        r34, nil
+  NotEqual     r35, r33, r34
+  JumpIfFalse  r35, L5
+  Len          r36, r33
+  Const        r37, 0
+L7:
+  LessInt      r38, r37, r36
+  JumpIfFalse  r38, L5
+  Index        r18, r33, r37
+  // where r.r_name == "EUROPE"
+  Const        r40, "r_name"
+  Index        r41, r30, r40
+  Const        r42, "EUROPE"
+  Equal        r43, r41, r42
+  JumpIfFalse  r43, L6
+  // from r in region
+  Append       r5, r5, r18
 L6:
-  JumpIfFalse  r12, L2
-L9:
-  Index        r12, r8, r11
+  Const        r45, 1
+  AddInt       r37, r37, r45
+  Jump         L7
 L5:
-  Move         r13, r12
-L21:
-  Const        r14, "n_regionkey"
+  Const        r46, 1
+  AddInt       r27, r27, r46
+  Jump         L8
+L1:
+  MakeMap      r47, 0, r0
+  Const        r48, 0
+L12:
+  LessInt      r49, r48, r7
+  JumpIfFalse  r49, L9
+  Index        r50, r6, r48
+  Move         r30, r50
+  // where r.r_name == "EUROPE"
+  Const        r51, "r_name"
+  Index        r52, r30, r51
+  Const        r53, "EUROPE"
+  Equal        r54, r52, r53
+  JumpIfFalse  r54, L10
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  Const        r55, "r_regionkey"
+  Index        r56, r30, r55
+  // from r in region
+  Index        r57, r47, r56
+  Const        r58, nil
+  NotEqual     r59, r57, r58
+  JumpIfTrue   r59, L11
+  MakeList     r60, 0, r0
+  SetIndex     r47, r56, r60
+L11:
+  Index        r57, r47, r56
+  Append       r61, r57, r50
+  SetIndex     r47, r56, r61
+L10:
+  Const        r62, 1
+  AddInt       r48, r48, r62
+  Jump         L12
+L9:
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  Const        r63, 0
+L17:
+  LessInt      r64, r63, r9
+  JumpIfFalse  r64, L13
+  Index        r18, r8, r63
+  Const        r66, "n_regionkey"
+  Index        r67, r18, r66
+  Index        r68, r47, r67
+  Const        r69, nil
+  NotEqual     r70, r68, r69
+  JumpIfFalse  r70, L14
+  Len          r71, r68
+  Const        r72, 0
+L16:
+  LessInt      r73, r72, r71
+  JumpIfFalse  r73, L14
+  Index        r30, r68, r72
+  // where r.r_name == "EUROPE"
+  Const        r75, "r_name"
+  Index        r76, r30, r75
+  Const        r77, "EUROPE"
+  Equal        r78, r76, r77
+  JumpIfFalse  r78, L15
+  // from r in region
+  Append       r5, r5, r18
 L15:
-  Index        r15, r13, r14
-L19:
-  Index        r16, r10, r15
-  Const        r17, nil
-  NotEqual     r18, r16, r17
-  JumpIfTrue   r18, L3
-  MakeList     r18, 0, r0
-  SetIndex     r10, r15, r18
-  Index        r16, r10, r15
-  Append       r18, r16, r12
-  SetIndex     r10, r15, r18
-  Const        r18, 1
-  AddInt       r11, r11, r18
-  Jump         L1
-  // from r in region
-  Move         r11, r9
-  LessInt      r16, r11, r7
-  JumpIfFalse  r16, L0
-  Index        r16, r6, r11
   // join n in nation on n.n_regionkey == r.r_regionkey
-  Const        r15, "r_regionkey"
-  Index        r12, r16, r15
-  // from r in region
-  Index        r19, r10, r12
-  NotEqual     r12, r19, r17
-  JumpIfFalse  r12, L4
-  Len          r12, r19
-  Move         r10, r11
-  LessInt      r20, r10, r12
-  JumpIfFalse  r20, L4
-  Index        r13, r19, r10
-  // where r.r_name == "EUROPE"
-  Const        r12, "r_name"
-  Index        r19, r16, r12
-  Const        r21, "EUROPE"
-  Equal        r22, r19, r21
-  JumpIfFalse  r22, L3
-  // from r in region
-  Append       r5, r5, r13
-  AddInt       r10, r10, r18
-  Jump         L5
-L4:
-  AddInt       r11, r11, r18
-  Jump         L6
-  MakeMap      r20, 0, r0
-  Move         r11, r9
-  LessInt      r19, r11, r7
-  JumpIfFalse  r19, L7
-  Index        r22, r6, r11
-  Move         r16, r22
-  // where r.r_name == "EUROPE"
-  Index        r19, r16, r12
-  Equal        r7, r19, r21
-  JumpIfFalse  r7, L8
-  // join n in nation on n.n_regionkey == r.r_regionkey
-  Index        r7, r16, r15
-  // from r in region
-  Index        r15, r20, r7
-  Move         r19, r17
-  NotEqual     r6, r15, r19
-  JumpIfTrue   r6, L9
-  MakeList     r6, 0, r0
-  SetIndex     r20, r7, r6
-  Index        r15, r20, r7
-  Append       r6, r15, r22
-  SetIndex     r20, r7, r6
-  AddInt       r11, r11, r18
-  Jump         L10
-  // join n in nation on n.n_regionkey == r.r_regionkey
-  Move         r15, r9
-  LessInt      r7, r15, r1
-  JumpIfFalse  r7, L11
-  Index        r13, r8, r15
-  Index        r7, r13, r14
-  Index        r14, r20, r7
-  NotEqual     r6, r14, r19
-  JumpIfFalse  r6, L11
-  Len          r7, r14
-  Move         r6, r15
-  LessInt      r19, r6, r7
-  JumpIfFalse  r19, L11
-  Index        r16, r14, r6
-  // where r.r_name == "EUROPE"
-  Index        r19, r16, r12
-  Equal        r12, r19, r21
-  JumpIfFalse  r12, L8
-  // from r in region
-  Append       r5, r5, r13
-  // join n in nation on n.n_regionkey == r.r_regionkey
-  AddInt       r6, r6, r18
-  Jump         L12
-  AddInt       r15, r15, r18
-  Jump         L12
-  // from s in supplier
-  Const        r15, []
-  IterPrep     r19, r2
-  Len          r2, r19
-  // join n in europe_nations on s.s_nationkey == n.n_nationkey
-  IterPrep     r6, r5
-  Len          r5, r6
-  // from s in supplier
-  EqualInt     r21, r2, r9
-  JumpIfTrue   r21, L0
-  EqualInt     r21, r5, r9
-  JumpIfTrue   r21, L0
-  LessEq       r21, r5, r2
-  JumpIfFalse  r21, L13
-  // join n in europe_nations on s.s_nationkey == n.n_nationkey
-  MakeMap      r21, 0, r0
-  Move         r16, r9
-  LessInt      r7, r16, r5
-  JumpIfFalse  r7, L5
-  Index        r7, r6, r16
-  Move         r13, r7
-  Const        r12, "n_nationkey"
-  Index        r14, r13, r12
-  Index        r20, r21, r14
-  Move         r1, r17
-  NotEqual     r17, r20, r1
-  JumpIfTrue   r17, L5
-  MakeList     r17, 0, r0
-  SetIndex     r21, r14, r17
-  Index        r20, r21, r14
-  Append       r17, r20, r7
-  SetIndex     r21, r14, r17
-  AddInt       r16, r16, r18
-  Jump         L14
-  // from s in supplier
-  Move         r20, r9
-  LessInt      r14, r20, r2
-  JumpIfFalse  r14, L0
-  Index        r14, r19, r20
-  // join n in europe_nations on s.s_nationkey == n.n_nationkey
-  Const        r7, "s_nationkey"
-  Index        r16, r14, r7
-  // from s in supplier
-  Index        r8, r21, r16
-  NotEqual     r16, r8, r1
-  JumpIfFalse  r16, L7
-  Len          r16, r8
-  Move         r21, r20
-  LessInt      r11, r21, r16
-  JumpIfFalse  r11, L7
-  Index        r13, r8, r21
-  // select { s: s, n: n }
-  Const        r11, "s"
-  Const        r16, "n"
-  Move         r8, r11
-  Move         r22, r14
-  Move         r10, r16
-  Move         r23, r13
-  MakeMap      r24, 2, r8
-  // from s in supplier
-  Append       r15, r15, r24
-  AddInt       r21, r21, r18
-  Jump         L15
-  AddInt       r20, r20, r18
-  Jump         L6
-  MakeMap      r23, 0, r0
-  Move         r10, r9
-  LessInt      r22, r10, r2
-  JumpIfFalse  r22, L5
-  Index        r22, r19, r10
-  // join n in europe_nations on s.s_nationkey == n.n_nationkey
-  Index        r19, r22, r7
-  // from s in supplier
-  Index        r17, r23, r19
-  Move         r7, r1
-  NotEqual     r1, r17, r7
-  JumpIfTrue   r1, L9
-  MakeList     r1, 0, r0
-  SetIndex     r23, r19, r1
-  Index        r17, r23, r19
-  Append       r1, r17, r22
-  SetIndex     r23, r19, r1
-  AddInt       r10, r10, r18
+  Const        r80, 1
+  AddInt       r72, r72, r80
   Jump         L16
-  // join n in europe_nations on s.s_nationkey == n.n_nationkey
-  Move         r19, r9
-  LessInt      r22, r19, r5
-  JumpIfFalse  r22, L17
-  Index        r13, r6, r19
-  Index        r22, r13, r12
-  Index        r12, r23, r22
-  NotEqual     r22, r12, r7
-  JumpIfFalse  r22, L17
-  Len          r22, r12
-  Move         r7, r19
-  LessInt      r23, r7, r22
-  JumpIfFalse  r23, L17
-  Index        r14, r12, r7
-  // select { s: s, n: n }
-  Move         r23, r11
-  Move         r22, r16
-  Move         r20, r23
-  Move         r23, r14
-  Move         r12, r22
-  Move         r22, r13
-  MakeMap      r13, 2, r20
-  // from s in supplier
-  Append       r15, r15, r13
-  // join n in europe_nations on s.s_nationkey == n.n_nationkey
-  AddInt       r7, r7, r18
-  Jump         L18
-  AddInt       r19, r19, r18
+L14:
+  Const        r81, 1
+  AddInt       r63, r63, r81
   Jump         L17
-  // from p in part
-  Const        r22, []
-  // where p.p_size == 15 && p.p_type == "LARGE BRASS"
-  Const        r12, "p_size"
-  Const        r23, "p_type"
-  // from p in part
-  IterPrep     r7, r3
-  Len          r24, r7
-  Move         r3, r9
-  LessInt      r20, r3, r24
-  JumpIfFalse  r20, L5
-  Index        r20, r7, r3
-  // where p.p_size == 15 && p.p_type == "LARGE BRASS"
-  Index        r7, r20, r12
-  Const        r12, 15
-  Equal        r24, r7, r12
-  Index        r12, r20, r23
-  Const        r23, "LARGE BRASS"
-  Equal        r7, r12, r23
-  Move         r23, r24
-  JumpIfFalse  r23, L19
-  Move         r23, r7
-  JumpIfFalse  r23, L20
-  // from p in part
-  Append       r22, r22, r20
-  AddInt       r3, r3, r18
+L13:
+  // from s in supplier
+  Const        r82, []
+  IterPrep     r83, r2
+  Len          r84, r83
+  // join n in europe_nations on s.s_nationkey == n.n_nationkey
+  IterPrep     r85, r5
+  Len          r86, r85
+  // from s in supplier
+  Const        r87, 0
+  EqualInt     r88, r84, r87
+  JumpIfTrue   r88, L0
+  EqualInt     r89, r86, r87
+  JumpIfTrue   r89, L0
+  LessEq       r90, r86, r84
+  JumpIfFalse  r90, L18
+  // join n in europe_nations on s.s_nationkey == n.n_nationkey
+  MakeMap      r91, 0, r0
+  Const        r92, 0
+L21:
+  LessInt      r93, r92, r86
+  JumpIfFalse  r93, L19
+  Index        r94, r85, r92
+  Move         r18, r94
+  Const        r95, "n_nationkey"
+  Index        r96, r18, r95
+  Index        r97, r91, r96
+  Const        r98, nil
+  NotEqual     r99, r97, r98
+  JumpIfTrue   r99, L20
+  MakeList     r100, 0, r0
+  SetIndex     r91, r96, r100
+L20:
+  Index        r97, r91, r96
+  Append       r101, r97, r94
+  SetIndex     r91, r96, r101
+  Const        r102, 1
+  AddInt       r92, r92, r102
   Jump         L21
-  // from ps in partsupp
-  Const        r7, []
-  // s_acctbal: s.s.s_acctbal,
-  Const        r24, "s_acctbal"
-  Move         r3, r11
-  // s_name: s.s.s_name,
-  Const        r11, "s_name"
-  // n_name: s.n.n_name,
-  Const        r1, "n_name"
-  Move         r12, r16
-  // p_partkey: p.p_partkey,
-  Const        r16, "p_partkey"
-  // p_mfgr: p.p_mfgr,
-  Const        r5, "p_mfgr"
-  // s_address: s.s.s_address,
-  Const        r6, "s_address"
-  // s_phone: s.s.s_phone,
-  Const        r10, "s_phone"
-  // s_comment: s.s.s_comment,
-  Const        r17, "s_comment"
-  // ps_supplycost: ps.ps_supplycost
-  Const        r2, "ps_supplycost"
-  // from ps in partsupp
-  IterPrep     r8, r4
-  Len          r4, r8
-  Move         r21, r9
-  LessInt      r25, r21, r4
-  JumpIfFalse  r25, L22
-  Index        r25, r8, r21
-  // join p in target_parts on ps.ps_partkey == p.p_partkey
-  IterPrep     r8, r22
-  Len          r22, r8
-  Const        r19, "ps_partkey"
-  Move         r4, r9
-  LessInt      r26, r4, r22
-  JumpIfFalse  r26, L23
-  Index        r20, r8, r4
-  Index        r26, r25, r19
-  Index        r19, r20, r16
-  Equal        r22, r26, r19
-  JumpIfFalse  r22, L24
-  // join s in europe_suppliers on ps.ps_suppkey == s.s.s_suppkey
-  IterPrep     r22, r15
-  Len          r15, r22
-  Const        r13, "ps_suppkey"
-  Const        r19, "s_suppkey"
-  Move         r26, r9
-  LessInt      r8, r26, r15
-  JumpIfFalse  r8, L24
-  Index        r14, r22, r26
-  Index        r8, r25, r13
-  Index        r13, r14, r3
-  Index        r15, r13, r19
-  Equal        r13, r8, r15
-  JumpIfFalse  r13, L25
-  // s_acctbal: s.s.s_acctbal,
-  Move         r13, r24
-  Index        r15, r14, r3
-  Index        r8, r15, r24
-  // s_name: s.s.s_name,
-  Move         r15, r11
-  Index        r19, r14, r3
-  Index        r22, r19, r11
-  // n_name: s.n.n_name,
-  Move         r19, r1
-  Index        r11, r14, r12
-  Index        r12, r11, r1
-  // p_partkey: p.p_partkey,
-  Move         r11, r16
-  Index        r1, r20, r16
-  // p_mfgr: p.p_mfgr,
-  Move         r16, r5
-  Index        r23, r20, r5
-  // s_address: s.s.s_address,
-  Move         r5, r6
-  Index        r20, r14, r3
-  Index        r27, r20, r6
-  // s_phone: s.s.s_phone,
-  Move         r20, r10
-  Index        r6, r14, r3
-  Index        r28, r6, r10
-  // s_comment: s.s.s_comment,
-  Move         r6, r17
-  Index        r10, r14, r3
-  Index        r3, r10, r17
-  // ps_supplycost: ps.ps_supplycost
-  Move         r10, r2
-  Index        r17, r25, r2
-  // s_acctbal: s.s.s_acctbal,
-  Move         r25, r13
-  Move         r13, r8
-  // s_name: s.s.s_name,
-  Move         r8, r15
-  Move         r15, r22
-  // n_name: s.n.n_name,
-  Move         r22, r19
-  Move         r19, r12
-  // p_partkey: p.p_partkey,
-  Move         r12, r11
-  Move         r11, r1
-  // p_mfgr: p.p_mfgr,
-  Move         r1, r16
-  Move         r16, r23
-  // s_address: s.s.s_address,
-  Move         r23, r5
-  Move         r5, r27
-  // s_phone: s.s.s_phone,
-  Move         r27, r20
-  Move         r20, r28
-  // s_comment: s.s.s_comment,
-  Move         r28, r6
-  Move         r6, r3
-  // ps_supplycost: ps.ps_supplycost
-  Move         r3, r10
-  Move         r10, r17
-  // select {
-  MakeMap      r17, 1, r25
-  // from ps in partsupp
-  Append       r7, r7, r17
-L25:
-  // join s in europe_suppliers on ps.ps_suppkey == s.s.s_suppkey
-  Add          r26, r26, r18
-  Jump         L14
+L19:
+  // from s in supplier
+  Const        r103, 0
 L24:
-  // join p in target_parts on ps.ps_partkey == p.p_partkey
-  Add          r4, r4, r18
-  Jump         L26
+  LessInt      r104, r103, r84
+  JumpIfFalse  r104, L0
+  Index        r106, r83, r103
+  // join n in europe_nations on s.s_nationkey == n.n_nationkey
+  Const        r107, "s_nationkey"
+  Index        r108, r106, r107
+  // from s in supplier
+  Index        r109, r91, r108
+  Const        r110, nil
+  NotEqual     r111, r109, r110
+  JumpIfFalse  r111, L22
+  Len          r112, r109
+  Const        r113, 0
 L23:
-  // from ps in partsupp
-  AddInt       r21, r21, r18
-  Jump         L9
+  LessInt      r114, r113, r112
+  JumpIfFalse  r114, L22
+  Index        r18, r109, r113
+  // select { s: s, n: n }
+  Const        r116, "s"
+  Const        r117, "n"
+  Move         r118, r116
+  Move         r119, r106
+  Move         r120, r117
+  Move         r121, r18
+  MakeMap      r122, 2, r118
+  // from s in supplier
+  Append       r82, r82, r122
+  Const        r124, 1
+  AddInt       r113, r113, r124
+  Jump         L23
 L22:
-  // let costs = from x in target_partsupp select x.ps_supplycost
-  Const        r21, []
-  IterPrep     r10, r7
-  Len          r3, r10
-  Move         r6, r9
-L28:
-  LessInt      r28, r6, r3
-  JumpIfFalse  r28, L27
-  Index        r4, r10, r6
-  Index        r28, r4, r2
-  Append       r21, r21, r28
-  AddInt       r6, r6, r18
-  Jump         L28
+  Const        r125, 1
+  AddInt       r103, r103, r125
+  Jump         L24
+L18:
+  MakeMap      r126, 0, r0
+  Const        r127, 0
 L27:
-  // let min_cost = min(costs)
-  Min          r28, r21
-  // from x in target_partsupp
-  Const        r21, []
-  IterPrep     r6, r7
-  Len          r7, r6
-  Move         r3, r9
+  LessInt      r128, r127, r84
+  JumpIfFalse  r128, L25
+  Index        r129, r83, r127
+  Move         r106, r129
+  // join n in europe_nations on s.s_nationkey == n.n_nationkey
+  Const        r130, "s_nationkey"
+  Index        r131, r106, r130
+  // from s in supplier
+  Index        r132, r126, r131
+  Const        r133, nil
+  NotEqual     r134, r132, r133
+  JumpIfTrue   r134, L26
+  MakeList     r135, 0, r0
+  SetIndex     r126, r131, r135
+L26:
+  Index        r132, r126, r131
+  Append       r136, r132, r129
+  SetIndex     r126, r131, r136
+  Const        r137, 1
+  AddInt       r127, r127, r137
+  Jump         L27
+L25:
+  // join n in europe_nations on s.s_nationkey == n.n_nationkey
+  Const        r138, 0
 L31:
-  LessInt      r9, r3, r7
-  JumpIfFalse  r9, L29
-  Index        r4, r6, r3
-  // where x.ps_supplycost == min_cost
-  Index        r9, r4, r2
-  Equal        r2, r9, r28
-  JumpIfFalse  r2, L30
-  // sort by -x.s_acctbal
-  Index        r17, r4, r24
-  Neg          r2, r17
-  // from x in target_partsupp
-  Move         r17, r4
-  MakeList     r4, 2, r2
-  Append       r21, r21, r4
+  LessInt      r139, r138, r86
+  JumpIfFalse  r139, L28
+  Index        r18, r85, r138
+  Const        r141, "n_nationkey"
+  Index        r142, r18, r141
+  Index        r143, r126, r142
+  Const        r144, nil
+  NotEqual     r145, r143, r144
+  JumpIfFalse  r145, L29
+  Len          r146, r143
+  Const        r147, 0
 L30:
-  AddInt       r3, r3, r18
-  Jump         L31
+  LessInt      r148, r147, r146
+  JumpIfFalse  r148, L29
+  Index        r106, r143, r147
+  // select { s: s, n: n }
+  Const        r150, "s"
+  Const        r151, "n"
+  Move         r152, r150
+  Move         r153, r106
+  Move         r154, r151
+  Move         r155, r18
+  MakeMap      r156, 2, r152
+  // from s in supplier
+  Append       r82, r82, r156
+  // join n in europe_nations on s.s_nationkey == n.n_nationkey
+  Const        r158, 1
+  AddInt       r147, r147, r158
+  Jump         L30
 L29:
+  Const        r159, 1
+  AddInt       r138, r138, r159
+  Jump         L31
+L28:
+  // from p in part
+  Const        r160, []
+  // where p.p_size == 15 && p.p_type == "LARGE BRASS"
+  Const        r161, "p_size"
+  Const        r162, "p_type"
+  // from p in part
+  IterPrep     r163, r3
+  Len          r164, r163
+  Const        r165, 0
+L35:
+  LessInt      r167, r165, r164
+  JumpIfFalse  r167, L32
+  Index        r169, r163, r165
+  // where p.p_size == 15 && p.p_type == "LARGE BRASS"
+  Const        r170, "p_size"
+  Index        r171, r169, r170
+  Const        r172, 15
+  Equal        r173, r171, r172
+  Const        r174, "p_type"
+  Index        r175, r169, r174
+  Const        r176, "LARGE BRASS"
+  Equal        r177, r175, r176
+  Move         r178, r173
+  JumpIfFalse  r178, L33
+  Move         r178, r177
+L33:
+  JumpIfFalse  r178, L34
+  // from p in part
+  Append       r160, r160, r169
+L34:
+  Const        r180, 1
+  AddInt       r165, r165, r180
+  Jump         L35
+L32:
+  // from ps in partsupp
+  Const        r181, []
+  // s_acctbal: s.s.s_acctbal,
+  Const        r182, "s_acctbal"
+  Const        r183, "s"
+  Const        r184, "s_acctbal"
+  // s_name: s.s.s_name,
+  Const        r185, "s_name"
+  Const        r186, "s"
+  Const        r187, "s_name"
+  // n_name: s.n.n_name,
+  Const        r188, "n_name"
+  Const        r189, "n"
+  Const        r190, "n_name"
+  // p_partkey: p.p_partkey,
+  Const        r191, "p_partkey"
+  Const        r192, "p_partkey"
+  // p_mfgr: p.p_mfgr,
+  Const        r193, "p_mfgr"
+  Const        r194, "p_mfgr"
+  // s_address: s.s.s_address,
+  Const        r195, "s_address"
+  Const        r196, "s"
+  Const        r197, "s_address"
+  // s_phone: s.s.s_phone,
+  Const        r198, "s_phone"
+  Const        r199, "s"
+  Const        r200, "s_phone"
+  // s_comment: s.s.s_comment,
+  Const        r201, "s_comment"
+  Const        r202, "s"
+  Const        r203, "s_comment"
+  // ps_supplycost: ps.ps_supplycost
+  Const        r204, "ps_supplycost"
+  Const        r205, "ps_supplycost"
+  // from ps in partsupp
+  IterPrep     r206, r4
+  Len          r207, r206
+  Const        r208, 0
+L42:
+  LessInt      r210, r208, r207
+  JumpIfFalse  r210, L36
+  Index        r212, r206, r208
+  // join p in target_parts on ps.ps_partkey == p.p_partkey
+  IterPrep     r213, r160
+  Len          r214, r213
+  Const        r215, "ps_partkey"
+  Const        r216, "p_partkey"
+  // s_acctbal: s.s.s_acctbal,
+  Const        r217, "s_acctbal"
+  Const        r218, "s"
+  Const        r219, "s_acctbal"
+  // s_name: s.s.s_name,
+  Const        r220, "s_name"
+  Const        r221, "s"
+  Const        r222, "s_name"
+  // n_name: s.n.n_name,
+  Const        r223, "n_name"
+  Const        r224, "n"
+  Const        r225, "n_name"
+  // p_partkey: p.p_partkey,
+  Const        r226, "p_partkey"
+  Const        r227, "p_partkey"
+  // p_mfgr: p.p_mfgr,
+  Const        r228, "p_mfgr"
+  Const        r229, "p_mfgr"
+  // s_address: s.s.s_address,
+  Const        r230, "s_address"
+  Const        r231, "s"
+  Const        r232, "s_address"
+  // s_phone: s.s.s_phone,
+  Const        r233, "s_phone"
+  Const        r234, "s"
+  Const        r235, "s_phone"
+  // s_comment: s.s.s_comment,
+  Const        r236, "s_comment"
+  Const        r237, "s"
+  Const        r238, "s_comment"
+  // ps_supplycost: ps.ps_supplycost
+  Const        r239, "ps_supplycost"
+  Const        r240, "ps_supplycost"
+  // join p in target_parts on ps.ps_partkey == p.p_partkey
+  Const        r241, 0
+L41:
+  LessInt      r243, r241, r214
+  JumpIfFalse  r243, L37
+  Index        r169, r213, r241
+  Const        r245, "ps_partkey"
+  Index        r246, r212, r245
+  Const        r247, "p_partkey"
+  Index        r248, r169, r247
+  Equal        r249, r246, r248
+  JumpIfFalse  r249, L38
+  // join s in europe_suppliers on ps.ps_suppkey == s.s.s_suppkey
+  IterPrep     r250, r82
+  Len          r251, r250
+  Const        r252, "ps_suppkey"
+  Const        r253, "s"
+  Const        r254, "s_suppkey"
+  // s_acctbal: s.s.s_acctbal,
+  Const        r255, "s_acctbal"
+  Const        r256, "s"
+  Const        r257, "s_acctbal"
+  // s_name: s.s.s_name,
+  Const        r258, "s_name"
+  Const        r259, "s"
+  Const        r260, "s_name"
+  // n_name: s.n.n_name,
+  Const        r261, "n_name"
+  Const        r262, "n"
+  Const        r263, "n_name"
+  // p_partkey: p.p_partkey,
+  Const        r264, "p_partkey"
+  Const        r265, "p_partkey"
+  // p_mfgr: p.p_mfgr,
+  Const        r266, "p_mfgr"
+  Const        r267, "p_mfgr"
+  // s_address: s.s.s_address,
+  Const        r268, "s_address"
+  Const        r269, "s"
+  Const        r270, "s_address"
+  // s_phone: s.s.s_phone,
+  Const        r271, "s_phone"
+  Const        r272, "s"
+  Const        r273, "s_phone"
+  // s_comment: s.s.s_comment,
+  Const        r274, "s_comment"
+  Const        r275, "s"
+  Const        r276, "s_comment"
+  // ps_supplycost: ps.ps_supplycost
+  Const        r277, "ps_supplycost"
+  Const        r278, "ps_supplycost"
+  // join s in europe_suppliers on ps.ps_suppkey == s.s.s_suppkey
+  Const        r279, 0
+L40:
+  LessInt      r281, r279, r251
+  JumpIfFalse  r281, L38
+  Index        r106, r250, r279
+  Const        r283, "ps_suppkey"
+  Index        r284, r212, r283
+  Const        r285, "s"
+  Index        r286, r106, r285
+  Const        r287, "s_suppkey"
+  Index        r288, r286, r287
+  Equal        r289, r284, r288
+  JumpIfFalse  r289, L39
+  // s_acctbal: s.s.s_acctbal,
+  Const        r290, "s_acctbal"
+  Const        r291, "s"
+  Index        r292, r106, r291
+  Const        r293, "s_acctbal"
+  Index        r294, r292, r293
+  // s_name: s.s.s_name,
+  Const        r295, "s_name"
+  Const        r296, "s"
+  Index        r297, r106, r296
+  Const        r298, "s_name"
+  Index        r299, r297, r298
+  // n_name: s.n.n_name,
+  Const        r300, "n_name"
+  Const        r301, "n"
+  Index        r302, r106, r301
+  Const        r303, "n_name"
+  Index        r304, r302, r303
+  // p_partkey: p.p_partkey,
+  Const        r305, "p_partkey"
+  Const        r306, "p_partkey"
+  Index        r307, r169, r306
+  // p_mfgr: p.p_mfgr,
+  Const        r308, "p_mfgr"
+  Const        r309, "p_mfgr"
+  Index        r310, r169, r309
+  // s_address: s.s.s_address,
+  Const        r311, "s_address"
+  Const        r312, "s"
+  Index        r313, r106, r312
+  Const        r314, "s_address"
+  Index        r315, r313, r314
+  // s_phone: s.s.s_phone,
+  Const        r316, "s_phone"
+  Const        r317, "s"
+  Index        r318, r106, r317
+  Const        r319, "s_phone"
+  Index        r320, r318, r319
+  // s_comment: s.s.s_comment,
+  Const        r321, "s_comment"
+  Const        r322, "s"
+  Index        r323, r106, r322
+  Const        r324, "s_comment"
+  Index        r325, r323, r324
+  // ps_supplycost: ps.ps_supplycost
+  Const        r326, "ps_supplycost"
+  Const        r327, "ps_supplycost"
+  Index        r328, r212, r327
+  // s_acctbal: s.s.s_acctbal,
+  Move         r329, r290
+  Move         r330, r294
+  // s_name: s.s.s_name,
+  Move         r331, r295
+  Move         r332, r299
+  // n_name: s.n.n_name,
+  Move         r333, r300
+  Move         r334, r304
+  // p_partkey: p.p_partkey,
+  Move         r335, r305
+  Move         r336, r307
+  // p_mfgr: p.p_mfgr,
+  Move         r337, r308
+  Move         r338, r310
+  // s_address: s.s.s_address,
+  Move         r339, r311
+  Move         r340, r315
+  // s_phone: s.s.s_phone,
+  Move         r341, r316
+  Move         r342, r320
+  // s_comment: s.s.s_comment,
+  Move         r343, r321
+  Move         r344, r325
+  // ps_supplycost: ps.ps_supplycost
+  Move         r345, r326
+  Move         r346, r328
+  // select {
+  MakeMap      r347, 9, r329
+  // from ps in partsupp
+  Append       r181, r181, r347
+L39:
+  // join s in europe_suppliers on ps.ps_suppkey == s.s.s_suppkey
+  Const        r349, 1
+  Add          r279, r279, r349
+  Jump         L40
+L38:
+  // join p in target_parts on ps.ps_partkey == p.p_partkey
+  Const        r350, 1
+  Add          r241, r241, r350
+  Jump         L41
+L37:
+  // from ps in partsupp
+  Const        r351, 1
+  AddInt       r208, r208, r351
+  Jump         L42
+L36:
+  // let costs = from x in target_partsupp select x.ps_supplycost
+  Const        r352, []
+  Const        r353, "ps_supplycost"
+  IterPrep     r354, r181
+  Len          r355, r354
+  Const        r356, 0
+L44:
+  LessInt      r358, r356, r355
+  JumpIfFalse  r358, L43
+  Index        r360, r354, r356
+  Const        r361, "ps_supplycost"
+  Index        r362, r360, r361
+  Append       r352, r352, r362
+  Const        r364, 1
+  AddInt       r356, r356, r364
+  Jump         L44
+L43:
+  // let min_cost = min(costs)
+  Min          r365, r352
+  // from x in target_partsupp
+  Const        r366, []
+  // where x.ps_supplycost == min_cost
+  Const        r367, "ps_supplycost"
   // sort by -x.s_acctbal
-  Sort         r21, r21
+  Const        r368, "s_acctbal"
+  // from x in target_partsupp
+  IterPrep     r369, r181
+  Len          r370, r369
+  Const        r371, 0
+L47:
+  LessInt      r373, r371, r370
+  JumpIfFalse  r373, L45
+  Index        r360, r369, r371
+  // where x.ps_supplycost == min_cost
+  Const        r375, "ps_supplycost"
+  Index        r376, r360, r375
+  Equal        r377, r376, r365
+  JumpIfFalse  r377, L46
+  // sort by -x.s_acctbal
+  Const        r378, "s_acctbal"
+  Index        r379, r360, r378
+  Neg          r381, r379
+  // from x in target_partsupp
+  Move         r382, r360
+  MakeList     r383, 2, r381
+  Append       r366, r366, r383
+L46:
+  Const        r385, 1
+  AddInt       r371, r371, r385
+  Jump         L47
+L45:
+  // sort by -x.s_acctbal
+  Sort         r366, r366
   // json(result)
-  JSON         r21
+  JSON         r366
   // expect result == [
-  Const        r4, [{"n_name": "FRANCE", "p_mfgr": "M1", "p_partkey": 1000, "ps_supplycost": 10, "s_acctbal": 1000, "s_address": "123 Rue", "s_comment": "Fast and reliable", "s_name": "BestSupplier", "s_phone": "123"}]
-  Equal        r17, r21, r4
-  Expect       r17
+  Const        r387, [{"n_name": "FRANCE", "p_mfgr": "M1", "p_partkey": 1000, "ps_supplycost": 10, "s_acctbal": 1000, "s_address": "123 Rue", "s_comment": "Fast and reliable", "s_name": "BestSupplier", "s_phone": "123"}]
+  Equal        r388, r366, r387
+  Expect       r388
   Return       r0

--- a/tests/dataset/tpc-h/out/q20.ir.out
+++ b/tests/dataset/tpc-h/out/q20.ir.out
@@ -1,401 +1,482 @@
-func main (regs=28)
-L13:
+func main (regs=311)
+L18:
   // let nation = [
   Const        r0, [{"n_name": "CANADA", "n_nationkey": 1}, {"n_name": "GERMANY", "n_nationkey": 2}]
   // let supplier = [
   Const        r1, [{"s_address": "123 Forest Lane", "s_name": "Maple Supply", "s_nationkey": 1, "s_suppkey": 100}, {"s_address": "456 Iron Str", "s_name": "Berlin Metals", "s_nationkey": 2, "s_suppkey": 200}]
   // let part = [
   Const        r2, [{"p_name": "forest glade bricks", "p_partkey": 10}, {"p_name": "desert sand paper", "p_partkey": 20}]
-L16:
   // let partsupp = [
   Const        r3, [{"ps_availqty": 100, "ps_partkey": 10, "ps_suppkey": 100}, {"ps_availqty": 30, "ps_partkey": 20, "ps_suppkey": 200}]
-L6:
   // let lineitem = [
   Const        r4, [{"l_partkey": 10, "l_quantity": 100, "l_shipdate": "1994-05-15", "l_suppkey": 100}, {"l_partkey": 10, "l_quantity": 50, "l_shipdate": "1995-01-01", "l_suppkey": 100}]
   // let prefix = "forest"
   Const        r5, "forest"
-L11:
   // from l in lineitem
   Const        r6, []
-L12:
   // group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
   Const        r7, "partkey"
-L2:
   Const        r8, "l_partkey"
   Const        r9, "suppkey"
   Const        r10, "l_suppkey"
   // where l.l_shipdate >= "1994-01-01" && l.l_shipdate < "1995-01-01"
   Const        r11, "l_shipdate"
-L10:
+  Const        r12, "l_shipdate"
   // partkey: g.key.partkey,
-  Const        r12, "key"
+  Const        r13, "partkey"
+  Const        r14, "key"
+  Const        r15, "partkey"
+  // suppkey: g.key.suppkey,
+  Const        r16, "suppkey"
+  Const        r17, "key"
+  Const        r18, "suppkey"
   // qty: sum(from x in g select x.l_quantity)
-  Const        r13, "qty"
-  Const        r14, "l_quantity"
-L18:
+  Const        r19, "qty"
+  Const        r20, "l_quantity"
   // from l in lineitem
-  IterPrep     r15, r4
-L9:
-  Len          r4, r15
-  Const        r16, 0
-L3:
-  MakeMap      r17, 0, r0
+  IterPrep     r21, r4
+  Len          r22, r21
+  Const        r23, 0
+  MakeMap      r24, 0, r0
+  Const        r25, []
 L4:
-  LessInt      r18, r16, r4
-  JumpIfFalse  r18, L0
-L1:
-  Index        r4, r15, r16
-L5:
-  Move         r15, r4
+  LessInt      r27, r23, r22
+  JumpIfFalse  r27, L0
+  Index        r28, r21, r23
+  Move         r29, r28
   // where l.l_shipdate >= "1994-01-01" && l.l_shipdate < "1995-01-01"
-  Index        r19, r15, r11
-  Const        r20, "1994-01-01"
-  LessEq       r21, r20, r19
+  Const        r30, "l_shipdate"
+  Index        r31, r29, r30
+  Const        r32, "1994-01-01"
+  LessEq       r33, r32, r31
+  Const        r34, "l_shipdate"
+  Index        r35, r29, r34
+  Const        r36, "1995-01-01"
+  Less         r37, r35, r36
+  Move         r38, r33
+  JumpIfFalse  r38, L1
+  Move         r38, r37
+L1:
+  JumpIfFalse  r38, L2
+  // group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
+  Const        r39, "partkey"
+  Const        r40, "l_partkey"
+  Index        r41, r29, r40
+  Const        r42, "suppkey"
+  Const        r43, "l_suppkey"
+  Index        r44, r29, r43
+  Move         r45, r39
+  Move         r46, r41
+  Move         r47, r42
+  Move         r48, r44
+  MakeMap      r49, 2, r45
+  Str          r50, r49
+  In           r51, r50, r24
+  JumpIfTrue   r51, L3
+  // from l in lineitem
+  Const        r52, []
+  Const        r53, "__group__"
+  Const        r54, true
+  Const        r55, "key"
+  // group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
+  Move         r56, r49
+  // from l in lineitem
+  Const        r57, "items"
+  Move         r58, r52
+  Const        r59, "count"
+  Const        r60, 0
+  Move         r61, r53
+  Move         r62, r54
+  Move         r63, r55
+  Move         r64, r56
+  Move         r65, r57
+  Move         r66, r58
+  Move         r67, r59
+  Move         r68, r60
+  MakeMap      r69, 4, r61
+  SetIndex     r24, r50, r69
+  Append       r25, r25, r69
+L3:
+  Const        r71, "items"
+  Index        r72, r24, r50
+  Index        r73, r72, r71
+  Append       r74, r73, r28
+  SetIndex     r72, r71, r74
+  Const        r75, "count"
+  Index        r76, r72, r75
+  Const        r77, 1
+  AddInt       r78, r76, r77
+  SetIndex     r72, r75, r78
+L2:
+  Const        r79, 1
+  AddInt       r23, r23, r79
+  Jump         L4
 L0:
-  Index        r20, r15, r11
-  Const        r11, "1995-01-01"
-  Less         r19, r20, r11
-  Move         r11, r21
-  JumpIfFalse  r11, L1
-  Move         r11, r19
-  JumpIfFalse  r11, L0
-  // group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
-  Move         r11, r7
-  Index        r19, r15, r8
-  Move         r8, r9
-  Index        r21, r15, r10
-  Move         r15, r11
-  Move         r11, r19
-  Move         r19, r8
-  Move         r8, r21
-  MakeMap      r21, 2, r15
-  Str          r8, r21
-  In           r19, r8, r17
-  JumpIfTrue   r19, L2
-  // from l in lineitem
-  Move         r19, r6
-  Const        r11, "__group__"
-  Const        r15, true
-  Move         r10, r12
-  // group by { partkey: l.l_partkey, suppkey: l.l_suppkey } into g
-  Move         r20, r21
-  // from l in lineitem
-  Const        r21, "items"
-  Move         r22, r19
-  Const        r19, "count"
-  Move         r23, r16
-  Move         r24, r11
-  Move         r11, r15
-  Move         r15, r10
-  Move         r10, r20
-  Move         r20, r21
-  Move         r25, r22
-  Move         r22, r19
-  Move         r26, r23
-  MakeMap      r23, 4, r24
-  SetIndex     r17, r8, r23
-  Move         r23, r21
-  Index        r21, r17, r8
-  Index        r8, r21, r23
-  Append       r26, r8, r4
-  SetIndex     r21, r23, r26
-  Move         r26, r19
-  Index        r19, r21, r26
-  Const        r8, 1
-  AddInt       r23, r19, r8
-  SetIndex     r21, r26, r23
-  AddInt       r16, r16, r8
-  Jump         L3
-  Values       23,17,0,0
-  Const        r17, 0
-  Move         r19, r17
-  Len          r26, r23
-  LessInt      r21, r19, r26
-  JumpIfFalse  r21, L4
-  Index        r21, r23, r19
-  // partkey: g.key.partkey,
-  Move         r23, r7
-  Index        r26, r21, r12
-  Index        r18, r26, r7
-  // suppkey: g.key.suppkey,
-  Move         r26, r9
-  Index        r16, r21, r12
-  Index        r12, r16, r9
-  // qty: sum(from x in g select x.l_quantity)
-  Move         r16, r13
-  Move         r4, r6
-  IterPrep     r22, r21
-  Len          r21, r22
-  Move         r25, r17
-  LessInt      r20, r25, r21
-  JumpIfFalse  r20, L3
-  Index        r20, r22, r25
-  Index        r22, r20, r14
-  Append       r4, r4, r22
-  AddInt       r25, r25, r8
-  Jump         L5
-  Sum          r20, r4
-  // partkey: g.key.partkey,
-  Move         r25, r23
-  Move         r23, r18
-  // suppkey: g.key.suppkey,
-  Move         r18, r26
-  Move         r26, r12
-  // qty: sum(from x in g select x.l_quantity)
-  Move         r22, r16
-  Move         r16, r20
-  // select {
-  MakeMap      r20, 3, r25
-  // from l in lineitem
-  Append       r6, r6, r20
-  AddInt       r19, r19, r8
-  Jump         L6
-  // from ps in partsupp
-  Const        r20, []
-  // where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
-  Const        r16, "p_name"
-  Const        r26, "ps_availqty"
-  // select ps.ps_suppkey
-  Const        r18, "ps_suppkey"
-  // from ps in partsupp
-  IterPrep     r23, r3
-  Len          r3, r23
-  Move         r25, r17
-  LessInt      r22, r25, r3
-  JumpIfFalse  r22, L7
-  Index        r22, r23, r25
-  // join p in part on ps.ps_partkey == p.p_partkey
-  IterPrep     r23, r2
-  Len          r2, r23
-  Const        r3, "ps_partkey"
-  Const        r4, "p_partkey"
-  Move         r19, r17
-  LessInt      r12, r19, r2
-  JumpIfFalse  r12, L5
-  Index        r12, r23, r19
-  Index        r23, r22, r3
-  Index        r2, r12, r4
-  Equal        r4, r23, r2
-  JumpIfFalse  r4, L8
-  // join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
-  IterPrep     r4, r6
-  Len          r6, r4
-  Move         r2, r17
-  LessInt      r23, r2, r6
-  JumpIfFalse  r23, L8
-  Index        r23, r4, r2
-  Index        r6, r22, r3
-  Index        r3, r23, r7
-  Equal        r7, r6, r3
-  Index        r3, r22, r18
-  Index        r6, r23, r9
-  Equal        r9, r3, r6
-  Move         r6, r7
-  JumpIfFalse  r6, L6
-  Move         r6, r9
-  JumpIfFalse  r6, L9
-  // where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
-  Index        r6, r12, r16
-  Const        r12, 6
-  Slice        r16, r6, r17, r12
-  Index        r12, r22, r26
-  Const        r26, 0.5
-  Index        r6, r23, r13
-  MulFloat     r13, r26, r6
-  LessFloat    r26, r13, r12
-  Equal        r13, r16, r5
-  JumpIfFalse  r13, L10
-  Move         r13, r26
-  JumpIfFalse  r13, L9
-  // select ps.ps_suppkey
-  Index        r13, r22, r18
-  // from ps in partsupp
-  Append       r20, r20, r13
-  // join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
-  Add          r2, r2, r8
-  Jump         L11
+  Const        r80, 0
+  Len          r82, r25
 L8:
-  // join p in part on ps.ps_partkey == p.p_partkey
-  Add          r19, r19, r8
-  Jump         L12
-  // from ps in partsupp
-  AddInt       r25, r25, r8
-  Jump         L6
+  LessInt      r83, r80, r82
+  JumpIfFalse  r83, L5
+  Index        r85, r25, r80
+  // partkey: g.key.partkey,
+  Const        r86, "partkey"
+  Const        r87, "key"
+  Index        r88, r85, r87
+  Const        r89, "partkey"
+  Index        r90, r88, r89
+  // suppkey: g.key.suppkey,
+  Const        r91, "suppkey"
+  Const        r92, "key"
+  Index        r93, r85, r92
+  Const        r94, "suppkey"
+  Index        r95, r93, r94
+  // qty: sum(from x in g select x.l_quantity)
+  Const        r96, "qty"
+  Const        r97, []
+  Const        r98, "l_quantity"
+  IterPrep     r99, r85
+  Len          r100, r99
+  Const        r101, 0
 L7:
-  // from s in supplier
-  Const        r13, []
-  IterPrep     r6, r1
-  Len          r1, r6
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  IterPrep     r7, r0
-  Len          r2, r7
-  // from s in supplier
-  EqualInt     r4, r1, r17
-  JumpIfTrue   r4, L13
-  EqualInt     r4, r2, r17
-  JumpIfTrue   r4, L13
-  LessEq       r4, r2, r1
-  JumpIfFalse  r4, L14
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  MakeMap      r4, 0, r0
-  Move         r19, r17
-  LessInt      r22, r19, r2
-  JumpIfFalse  r22, L4
-  Index        r22, r7, r19
-  Move         r25, r22
-  Const        r18, "n_nationkey"
-  Index        r26, r25, r18
-  Index        r16, r4, r26
-  Const        r5, nil
-  NotEqual     r12, r16, r5
-  JumpIfTrue   r12, L15
-  MakeList     r12, 0, r0
-  SetIndex     r4, r26, r12
-L15:
-  Index        r16, r4, r26
-  Append       r12, r16, r22
-  SetIndex     r4, r26, r12
-  AddInt       r19, r19, r8
-  Jump         L10
-  // from s in supplier
-  Move         r16, r17
-  LessInt      r26, r16, r1
-  JumpIfFalse  r26, L13
-  Index        r23, r6, r16
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  Const        r26, "s_nationkey"
-  Index        r22, r23, r26
-  // from s in supplier
-  Index        r19, r4, r22
-  NotEqual     r22, r19, r5
-  JumpIfFalse  r22, L16
-  Len          r22, r19
-  Move         r4, r16
-  LessInt      r9, r4, r22
-  JumpIfFalse  r9, L16
-  Index        r25, r19, r4
-  // where s.s_suppkey in target_partkeys && n.n_name == "CANADA"
-  Const        r9, "s_suppkey"
-  Index        r22, r23, r9
-  In           r19, r22, r20
-  Const        r22, "n_name"
-  Index        r3, r25, r22
-  Const        r14, "CANADA"
-  Equal        r21, r3, r14
-  Move         r12, r19
-  JumpIfFalse  r12, L5
-  Move         r12, r21
-  JumpIfFalse  r12, L17
-  // s_name: s.s_name,
-  Const        r21, "s_name"
-  Move         r3, r21
-  Index        r19, r23, r3
-  // s_address: s.s_address
-  Const        r12, "s_address"
-  Move         r10, r12
-  Index        r15, r23, r10
-  // s_name: s.s_name,
-  Move         r11, r21
-  Move         r24, r19
-  // s_address: s.s_address
-  Move         r19, r12
-  Move         r27, r15
+  LessInt      r103, r101, r100
+  JumpIfFalse  r103, L6
+  Index        r105, r99, r101
+  Const        r106, "l_quantity"
+  Index        r107, r105, r106
+  Append       r97, r97, r107
+  Const        r109, 1
+  AddInt       r101, r101, r109
+  Jump         L7
+L6:
+  Sum          r110, r97
+  // partkey: g.key.partkey,
+  Move         r111, r86
+  Move         r112, r90
+  // suppkey: g.key.suppkey,
+  Move         r113, r91
+  Move         r114, r95
+  // qty: sum(from x in g select x.l_quantity)
+  Move         r115, r96
+  Move         r116, r110
   // select {
-  MakeMap      r15, 2, r11
-  // order by s.s_name
-  Index        r27, r23, r3
-  // from s in supplier
-  Move         r19, r15
-  MakeList     r15, 2, r27
-  Append       r13, r13, r15
+  MakeMap      r117, 3, r111
+  // from l in lineitem
+  Append       r6, r6, r117
+  Const        r119, 1
+  AddInt       r80, r80, r119
+  Jump         L8
+L5:
+  // from ps in partsupp
+  Const        r120, []
+  // where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
+  Const        r121, "p_name"
+  Const        r122, "ps_availqty"
+  Const        r123, "qty"
+  // select ps.ps_suppkey
+  Const        r124, "ps_suppkey"
+  // from ps in partsupp
+  IterPrep     r125, r3
+  Len          r126, r125
+  Const        r127, 0
 L17:
-  AddInt       r4, r4, r8
-  Jump         L18
-  AddInt       r16, r16, r8
-  Jump         L9
+  LessInt      r129, r127, r126
+  JumpIfFalse  r129, L9
+  Index        r131, r125, r127
+  // join p in part on ps.ps_partkey == p.p_partkey
+  IterPrep     r132, r2
+  Len          r133, r132
+  Const        r134, "ps_partkey"
+  Const        r135, "p_partkey"
+  // where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
+  Const        r136, "p_name"
+  Const        r137, "ps_availqty"
+  Const        r138, "qty"
+  // select ps.ps_suppkey
+  Const        r139, "ps_suppkey"
+  // join p in part on ps.ps_partkey == p.p_partkey
+  Const        r140, 0
+L16:
+  LessInt      r142, r140, r133
+  JumpIfFalse  r142, L10
+  Index        r144, r132, r140
+  Const        r145, "ps_partkey"
+  Index        r146, r131, r145
+  Const        r147, "p_partkey"
+  Index        r148, r144, r147
+  Equal        r149, r146, r148
+  JumpIfFalse  r149, L11
+  // join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
+  IterPrep     r150, r6
+  Len          r151, r150
+  Const        r152, "ps_partkey"
+  Const        r153, "partkey"
+  Const        r154, "ps_suppkey"
+  Const        r155, "suppkey"
+  // where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
+  Const        r156, "p_name"
+  Const        r157, "ps_availqty"
+  Const        r158, "qty"
+  // select ps.ps_suppkey
+  Const        r159, "ps_suppkey"
+  // join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
+  Const        r160, 0
+L15:
+  LessInt      r162, r160, r151
+  JumpIfFalse  r162, L11
+  Index        r164, r150, r160
+  Const        r165, "ps_partkey"
+  Index        r166, r131, r165
+  Const        r167, "partkey"
+  Index        r168, r164, r167
+  Equal        r169, r166, r168
+  Const        r170, "ps_suppkey"
+  Index        r171, r131, r170
+  Const        r172, "suppkey"
+  Index        r173, r164, r172
+  Equal        r174, r171, r173
+  Move         r175, r169
+  JumpIfFalse  r175, L12
+  Move         r175, r174
+L12:
+  JumpIfFalse  r175, L13
+  // where substring(p.p_name, 0, len(prefix)) == prefix && ps.ps_availqty > (0.5 * s.qty)
+  Const        r176, "p_name"
+  Index        r177, r144, r176
+  Const        r178, 0
+  Const        r179, 6
+  Slice        r180, r177, r178, r179
+  Const        r181, "ps_availqty"
+  Index        r182, r131, r181
+  Const        r183, 0.5
+  Const        r184, "qty"
+  Index        r185, r164, r184
+  MulFloat     r186, r183, r185
+  LessFloat    r187, r186, r182
+  Equal        r189, r180, r5
+  JumpIfFalse  r189, L14
+  Move         r189, r187
 L14:
-  MakeMap      r19, 0, r0
-  Move         r16, r17
+  JumpIfFalse  r189, L13
+  // select ps.ps_suppkey
+  Const        r190, "ps_suppkey"
+  Index        r191, r131, r190
+  // from ps in partsupp
+  Append       r120, r120, r191
+L13:
+  // join s in shipped_94 on ps.ps_partkey == s.partkey && ps.ps_suppkey == s.suppkey
+  Const        r193, 1
+  Add          r160, r160, r193
+  Jump         L15
+L11:
+  // join p in part on ps.ps_partkey == p.p_partkey
+  Const        r194, 1
+  Add          r140, r140, r194
+  Jump         L16
+L10:
+  // from ps in partsupp
+  Const        r195, 1
+  AddInt       r127, r127, r195
+  Jump         L17
+L9:
+  // from s in supplier
+  Const        r196, []
+  IterPrep     r197, r1
+  Len          r198, r197
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  IterPrep     r199, r0
+  Len          r200, r199
+  // from s in supplier
+  Const        r201, 0
+  EqualInt     r202, r198, r201
+  JumpIfTrue   r202, L18
+  EqualInt     r203, r200, r201
+  JumpIfTrue   r203, L18
+  LessEq       r204, r200, r198
+  JumpIfFalse  r204, L19
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  MakeMap      r205, 0, r0
+  Const        r206, 0
+L22:
+  LessInt      r207, r206, r200
+  JumpIfFalse  r207, L20
+  Index        r208, r199, r206
+  Move         r209, r208
+  Const        r210, "n_nationkey"
+  Index        r211, r209, r210
+  Index        r212, r205, r211
+  Const        r213, nil
+  NotEqual     r214, r212, r213
+  JumpIfTrue   r214, L21
+  MakeList     r215, 0, r0
+  SetIndex     r205, r211, r215
 L21:
-  LessInt      r27, r16, r1
-  JumpIfFalse  r27, L19
-  Index        r27, r6, r16
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  Index        r6, r27, r26
-  // from s in supplier
-  Index        r26, r19, r6
-  Move         r1, r5
-  NotEqual     r5, r26, r1
-  JumpIfTrue   r5, L20
-  MakeList     r5, 0, r0
-  SetIndex     r19, r6, r5
+  Index        r212, r205, r211
+  Append       r216, r212, r208
+  SetIndex     r205, r211, r216
+  Const        r217, 1
+  AddInt       r206, r206, r217
+  Jump         L22
 L20:
-  Index        r26, r19, r6
-  Append       r5, r26, r27
-  SetIndex     r19, r6, r5
-  AddInt       r16, r16, r8
-  Jump         L21
-L19:
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  Move         r5, r17
-L27:
-  LessInt      r15, r5, r2
-  JumpIfFalse  r15, L22
-  Index        r25, r7, r5
-  Index        r15, r25, r18
-  Index        r18, r19, r15
-  NotEqual     r15, r18, r1
-  JumpIfFalse  r15, L23
-  Len          r15, r18
-  Move         r1, r5
-L26:
-  LessInt      r19, r1, r15
-  JumpIfFalse  r19, L23
-  Index        r23, r18, r1
-  // where s.s_suppkey in target_partkeys && n.n_name == "CANADA"
-  Index        r19, r23, r9
-  In           r9, r19, r20
-  Index        r19, r25, r22
-  Equal        r22, r19, r14
-  Move         r19, r9
-  JumpIfFalse  r19, L24
-  Move         r19, r22
-L24:
-  JumpIfFalse  r19, L25
-  // s_name: s.s_name,
-  Move         r19, r21
-  Index        r21, r23, r3
-  // s_address: s.s_address
-  Move         r22, r12
-  Index        r12, r23, r10
-  // s_name: s.s_name,
-  Move         r10, r19
-  Move         r19, r21
-  // s_address: s.s_address
-  Move         r21, r22
-  Move         r22, r12
-  // select {
-  MakeMap      r12, 2, r10
-  // order by s.s_name
-  Index        r22, r23, r3
   // from s in supplier
-  Move         r3, r12
-  MakeList     r12, 2, r22
-  Append       r13, r13, r12
-L25:
+  Const        r218, 0
+L27:
+  LessInt      r219, r218, r198
+  JumpIfFalse  r219, L18
+  Index        r164, r197, r218
   // join n in nation on n.n_nationkey == s.s_nationkey
-  AddInt       r1, r1, r8
+  Const        r221, "s_nationkey"
+  Index        r222, r164, r221
+  // from s in supplier
+  Index        r223, r205, r222
+  Const        r224, nil
+  NotEqual     r225, r223, r224
+  JumpIfFalse  r225, L23
+  Len          r226, r223
+  Const        r227, 0
+L26:
+  LessInt      r228, r227, r226
+  JumpIfFalse  r228, L23
+  Index        r209, r223, r227
+  // where s.s_suppkey in target_partkeys && n.n_name == "CANADA"
+  Const        r230, "s_suppkey"
+  Index        r231, r164, r230
+  In           r232, r231, r120
+  Const        r233, "n_name"
+  Index        r234, r209, r233
+  Const        r235, "CANADA"
+  Equal        r236, r234, r235
+  Move         r237, r232
+  JumpIfFalse  r237, L24
+  Move         r237, r236
+L24:
+  JumpIfFalse  r237, L25
+  // s_name: s.s_name,
+  Const        r238, "s_name"
+  Const        r239, "s_name"
+  Index        r240, r164, r239
+  // s_address: s.s_address
+  Const        r241, "s_address"
+  Const        r242, "s_address"
+  Index        r243, r164, r242
+  // s_name: s.s_name,
+  Move         r244, r238
+  Move         r245, r240
+  // s_address: s.s_address
+  Move         r246, r241
+  Move         r247, r243
+  // select {
+  MakeMap      r248, 2, r244
+  // order by s.s_name
+  Const        r249, "s_name"
+  Index        r251, r164, r249
+  // from s in supplier
+  Move         r252, r248
+  MakeList     r253, 2, r251
+  Append       r196, r196, r253
+L25:
+  Const        r255, 1
+  AddInt       r227, r227, r255
   Jump         L26
 L23:
-  AddInt       r5, r5, r8
+  Const        r256, 1
+  AddInt       r218, r218, r256
   Jump         L27
-L22:
+L19:
+  MakeMap      r257, 0, r0
+  Const        r258, 0
+L30:
+  LessInt      r259, r258, r198
+  JumpIfFalse  r259, L28
+  Index        r260, r197, r258
+  Move         r164, r260
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r261, "s_nationkey"
+  Index        r262, r164, r261
+  // from s in supplier
+  Index        r263, r257, r262
+  Const        r264, nil
+  NotEqual     r265, r263, r264
+  JumpIfTrue   r265, L29
+  MakeList     r266, 0, r0
+  SetIndex     r257, r262, r266
+L29:
+  Index        r263, r257, r262
+  Append       r267, r263, r260
+  SetIndex     r257, r262, r267
+  Const        r268, 1
+  AddInt       r258, r258, r268
+  Jump         L30
+L28:
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r269, 0
+L36:
+  LessInt      r270, r269, r200
+  JumpIfFalse  r270, L31
+  Index        r209, r199, r269
+  Const        r272, "n_nationkey"
+  Index        r273, r209, r272
+  Index        r274, r257, r273
+  Const        r275, nil
+  NotEqual     r276, r274, r275
+  JumpIfFalse  r276, L32
+  Len          r277, r274
+  Const        r278, 0
+L35:
+  LessInt      r279, r278, r277
+  JumpIfFalse  r279, L32
+  Index        r164, r274, r278
+  // where s.s_suppkey in target_partkeys && n.n_name == "CANADA"
+  Const        r281, "s_suppkey"
+  Index        r282, r164, r281
+  In           r283, r282, r120
+  Const        r284, "n_name"
+  Index        r285, r209, r284
+  Const        r286, "CANADA"
+  Equal        r287, r285, r286
+  Move         r288, r283
+  JumpIfFalse  r288, L33
+  Move         r288, r287
+L33:
+  JumpIfFalse  r288, L34
+  // s_name: s.s_name,
+  Const        r289, "s_name"
+  Const        r290, "s_name"
+  Index        r291, r164, r290
+  // s_address: s.s_address
+  Const        r292, "s_address"
+  Const        r293, "s_address"
+  Index        r294, r164, r293
+  // s_name: s.s_name,
+  Move         r295, r289
+  Move         r296, r291
+  // s_address: s.s_address
+  Move         r297, r292
+  Move         r298, r294
+  // select {
+  MakeMap      r299, 2, r295
   // order by s.s_name
-  Sort         r13, r13
+  Const        r300, "s_name"
+  Index        r302, r164, r300
+  // from s in supplier
+  Move         r303, r299
+  MakeList     r304, 2, r302
+  Append       r196, r196, r304
+L34:
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r306, 1
+  AddInt       r278, r278, r306
+  Jump         L35
+L32:
+  Const        r307, 1
+  AddInt       r269, r269, r307
+  Jump         L36
+L31:
+  // order by s.s_name
+  Sort         r196, r196
   // json(result)
-  JSON         r13
+  JSON         r196
   // expect result == [
-  Const        r12, [{"s_address": "123 Forest Lane", "s_name": "Maple Supply"}]
-  Equal        r3, r13, r12
-  Expect       r3
+  Const        r309, [{"s_address": "123 Forest Lane", "s_name": "Maple Supply"}]
+  Equal        r310, r196, r309
+  Expect       r310
   Return       r0

--- a/tests/dataset/tpc-h/out/q21.ir.out
+++ b/tests/dataset/tpc-h/out/q21.ir.out
@@ -1,244 +1,285 @@
-func main (regs=28)
+func main (regs=190)
   // let nation = [
   Const        r0, [{"n_name": "SAUDI ARABIA", "n_nationkey": 1}, {"n_name": "FRANCE", "n_nationkey": 2}]
-L8:
   // let supplier = [
   Const        r1, [{"s_name": "Desert Trade", "s_nationkey": 1, "s_suppkey": 100}, {"s_name": "Euro Goods", "s_nationkey": 2, "s_suppkey": 200}]
   // let orders = [
   Const        r2, [{"o_orderkey": 500, "o_orderstatus": "F"}, {"o_orderkey": 600, "o_orderstatus": "O"}]
-L5:
   // let lineitem = [
   Const        r3, [{"l_commitdate": "1995-04-10", "l_orderkey": 500, "l_receiptdate": "1995-04-15", "l_suppkey": 100}, {"l_commitdate": "1995-04-12", "l_orderkey": 500, "l_receiptdate": "1995-04-12", "l_suppkey": 200}, {"l_commitdate": "1995-04-25", "l_orderkey": 600, "l_receiptdate": "1995-05-01", "l_suppkey": 100}]
   // from s in supplier
   Const        r4, []
   // group by s.s_name into g
   Const        r5, "s_name"
-L6:
   // o.o_orderstatus == "F" &&
   Const        r6, "o_orderstatus"
   // l1.l_receiptdate > l1.l_commitdate &&
   Const        r7, "l_receiptdate"
-L12:
   Const        r8, "l_commitdate"
-L9:
   // n.n_name == "SAUDI ARABIA" && (!exists(
   Const        r9, "n_name"
   // where x.l_orderkey == l1.l_orderkey && x.l_suppkey != l1.l_suppkey && x.l_receiptdate > x.l_commitdate
   Const        r10, "l_orderkey"
-L10:
-  Const        r11, "l_suppkey"
+  Const        r11, "l_orderkey"
+  Const        r12, "l_suppkey"
+  Const        r13, "l_suppkey"
+  Const        r14, "l_receiptdate"
+  Const        r15, "l_commitdate"
   // s_name: g.key,
-  Const        r12, "key"
-L1:
+  Const        r16, "s_name"
+  Const        r17, "key"
   // numwait: count(g)
-  Const        r13, "numwait"
+  Const        r18, "numwait"
+  // sort by [ -count(g), g.key ]
+  Const        r19, "key"
   // from s in supplier
-  MakeMap      r14, 0, r0
-  IterPrep     r15, r1
-  Len          r1, r15
-L14:
-  Const        r16, 0
-  LessInt      r17, r16, r1
-  JumpIfFalse  r17, L0
-L2:
-  Index        r1, r15, r16
-L7:
+  MakeMap      r20, 0, r0
+  Const        r21, []
+  IterPrep     r23, r1
+  Len          r24, r23
+  Const        r25, 0
+L17:
+  LessInt      r26, r25, r24
+  JumpIfFalse  r26, L0
+  Index        r28, r23, r25
   // join l1 in lineitem on s.s_suppkey == l1.l_suppkey
-  IterPrep     r15, r3
-  Len          r18, r15
-  Move         r19, r16
-L13:
-  LessInt      r20, r19, r18
-  JumpIfFalse  r20, L1
-L11:
-  Index        r18, r15, r19
-L4:
-  Const        r15, "s_suppkey"
-  Index        r21, r1, r15
-  Index        r15, r18, r11
-  Equal        r22, r21, r15
-  JumpIfFalse  r22, L2
+  IterPrep     r29, r3
+  Len          r30, r29
+  Const        r31, 0
+L16:
+  LessInt      r32, r31, r30
+  JumpIfFalse  r32, L1
+  Index        r34, r29, r31
+  Const        r35, "s_suppkey"
+  Index        r36, r28, r35
+  Const        r37, "l_suppkey"
+  Index        r38, r34, r37
+  Equal        r39, r36, r38
+  JumpIfFalse  r39, L2
   // join o in orders on o.o_orderkey == l1.l_orderkey
-  IterPrep     r22, r2
-  Len          r2, r22
-  Move         r15, r16
-  LessInt      r21, r15, r2
-  JumpIfFalse  r21, L2
-  Index        r21, r22, r15
-  Const        r22, "o_orderkey"
-  Index        r2, r21, r22
-  Index        r22, r18, r10
-  Equal        r23, r2, r22
-  JumpIfFalse  r23, L3
+  IterPrep     r40, r2
+  Len          r41, r40
+  Const        r42, 0
+L15:
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L2
+  Index        r45, r40, r42
+  Const        r46, "o_orderkey"
+  Index        r47, r45, r46
+  Const        r48, "l_orderkey"
+  Index        r49, r34, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L3
   // join n in nation on n.n_nationkey == s.s_nationkey
-  IterPrep     r23, r0
-  Len          r22, r23
-  Move         r2, r15
-  LessInt      r24, r2, r22
-  JumpIfFalse  r24, L3
-  Index        r24, r23, r2
-  Const        r23, "n_nationkey"
-  Index        r22, r24, r23
-  Const        r23, "s_nationkey"
-  Index        r25, r1, r23
-  Equal        r23, r22, r25
-  JumpIfFalse  r23, L4
+  IterPrep     r51, r0
+  Len          r52, r51
+  Const        r53, 0
+L14:
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L3
+  Index        r56, r51, r53
+  Const        r57, "n_nationkey"
+  Index        r58, r56, r57
+  Const        r59, "s_nationkey"
+  Index        r60, r28, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L4
   // o.o_orderstatus == "F" &&
-  Index        r23, r21, r6
+  Const        r62, "o_orderstatus"
+  Index        r63, r45, r62
   // l1.l_receiptdate > l1.l_commitdate &&
-  Index        r6, r18, r7
-  Index        r25, r18, r8
-  Less         r22, r25, r6
+  Const        r64, "l_receiptdate"
+  Index        r65, r34, r64
+  Const        r66, "l_commitdate"
+  Index        r67, r34, r66
+  Less         r68, r67, r65
   // o.o_orderstatus == "F" &&
-  Const        r25, "F"
-  Equal        r6, r23, r25
+  Const        r69, "F"
+  Equal        r70, r63, r69
   // n.n_name == "SAUDI ARABIA" && (!exists(
-  Index        r25, r24, r9
-  Const        r9, "SAUDI ARABIA"
-  Equal        r23, r25, r9
+  Const        r71, "n_name"
+  Index        r72, r56, r71
+  Const        r73, "SAUDI ARABIA"
+  Equal        r74, r72, r73
   // o.o_orderstatus == "F" &&
-  Move         r9, r6
-  JumpIfFalse  r9, L5
+  Move         r75, r70
+  JumpIfFalse  r75, L5
+L5:
   // l1.l_receiptdate > l1.l_commitdate &&
-  Move         r9, r22
-  JumpIfFalse  r9, L6
+  Move         r76, r68
+  JumpIfFalse  r76, L6
+L6:
   // n.n_name == "SAUDI ARABIA" && (!exists(
-  Move         r9, r23
-  JumpIfFalse  r9, L7
+  Move         r77, r74
+  JumpIfFalse  r77, L7
   // from x in lineitem
-  Move         r23, r4
-  IterPrep     r22, r3
-  Len          r3, r22
-  Move         r6, r16
-  Move         r25, r6
-  LessInt      r26, r25, r3
-  JumpIfFalse  r26, L8
-  Index        r26, r22, r25
+  Const        r78, []
   // where x.l_orderkey == l1.l_orderkey && x.l_suppkey != l1.l_suppkey && x.l_receiptdate > x.l_commitdate
-  Index        r22, r26, r10
-  Index        r3, r26, r7
-  Index        r7, r26, r8
-  Less         r8, r7, r3
-  Index        r7, r18, r10
-  Equal        r10, r22, r7
-  Index        r7, r26, r11
-  Index        r22, r18, r11
-  NotEqual     r11, r7, r22
-  Move         r22, r10
-  JumpIfFalse  r22, L9
-  Move         r22, r11
-  JumpIfFalse  r22, L10
-  Move         r22, r8
-  JumpIfFalse  r22, L11
+  Const        r79, "l_orderkey"
+  Const        r80, "l_orderkey"
+  Const        r81, "l_suppkey"
+  Const        r82, "l_suppkey"
+  Const        r83, "l_receiptdate"
+  Const        r84, "l_commitdate"
   // from x in lineitem
-  Append       r23, r23, r26
-  Const        r22, 1
-  AddInt       r25, r25, r22
+  IterPrep     r85, r3
+  Len          r86, r85
+  Const        r87, 0
+L12:
+  LessInt      r89, r87, r86
+  JumpIfFalse  r89, L8
+  Index        r91, r85, r87
+  // where x.l_orderkey == l1.l_orderkey && x.l_suppkey != l1.l_suppkey && x.l_receiptdate > x.l_commitdate
+  Const        r92, "l_orderkey"
+  Index        r93, r91, r92
+  Const        r94, "l_receiptdate"
+  Index        r95, r91, r94
+  Const        r96, "l_commitdate"
+  Index        r97, r91, r96
+  Less         r98, r97, r95
+  Const        r99, "l_orderkey"
+  Index        r100, r34, r99
+  Equal        r101, r93, r100
+  Const        r102, "l_suppkey"
+  Index        r103, r91, r102
+  Const        r104, "l_suppkey"
+  Index        r105, r34, r104
+  NotEqual     r106, r103, r105
+  Move         r107, r101
+  JumpIfFalse  r107, L9
+L9:
+  Move         r108, r106
+  JumpIfFalse  r108, L10
+  Move         r108, r98
+L10:
+  JumpIfFalse  r108, L11
+  // from x in lineitem
+  Append       r78, r78, r91
+L11:
+  Const        r110, 1
+  AddInt       r87, r87, r110
   Jump         L12
+L8:
   // n.n_name == "SAUDI ARABIA" && (!exists(
-  Exists       r8, r23
-  Not          r9, r8
+  Exists       r111, r78
+  Not          r77, r111
+L7:
   // o.o_orderstatus == "F" &&
-  JumpIfFalse  r9, L4
+  JumpIfFalse  r77, L4
   // from s in supplier
-  Const        r8, "s"
-  Move         r23, r1
-  Const        r9, "l1"
-  Move         r25, r18
-  Const        r18, "o"
-  Move         r11, r21
-  Const        r21, "n"
-  Move         r26, r24
-  MakeMap      r10, 4, r8
+  Const        r113, "s"
+  Move         r114, r28
+  Const        r115, "l1"
+  Move         r116, r34
+  Const        r117, "o"
+  Move         r118, r45
+  Const        r119, "n"
+  Move         r120, r56
+  MakeMap      r121, 4, r113
   // group by s.s_name into g
-  Index        r26, r1, r5
-  Str          r1, r26
-  In           r21, r1, r14
-  JumpIfTrue   r21, L6
+  Const        r122, "s_name"
+  Index        r123, r28, r122
+  Str          r124, r123
+  In           r125, r124, r20
+  JumpIfTrue   r125, L13
   // from s in supplier
-  Move         r21, r4
-  Const        r11, "__group__"
-  Const        r18, true
-  Move         r25, r12
+  Const        r126, []
+  Const        r127, "__group__"
+  Const        r128, true
+  Const        r129, "key"
   // group by s.s_name into g
-  Move         r9, r26
+  Move         r130, r123
   // from s in supplier
-  Const        r26, "items"
-  Move         r23, r21
-  Const        r21, "count"
-  Move         r8, r6
-  Move         r7, r11
-  Move         r11, r18
-  Move         r18, r25
-  Move         r25, r9
-  Move         r9, r26
-  Move         r3, r23
-  Move         r23, r21
-  Move         r27, r8
-  MakeMap      r8, 4, r7
-  SetIndex     r14, r1, r8
-  Move         r8, r26
-  Index        r26, r14, r1
-  Index        r1, r26, r8
-  Append       r27, r1, r10
-  SetIndex     r26, r8, r27
-  Move         r27, r21
-  Index        r21, r26, r27
-  AddInt       r1, r21, r22
-  SetIndex     r26, r27, r1
+  Const        r131, "items"
+  Move         r132, r126
+  Const        r133, "count"
+  Const        r134, 0
+  Move         r135, r127
+  Move         r136, r128
+  Move         r137, r129
+  Move         r138, r130
+  Move         r139, r131
+  Move         r140, r132
+  Move         r141, r133
+  Move         r142, r134
+  MakeMap      r143, 4, r135
+  SetIndex     r20, r124, r143
+  Append       r21, r21, r143
+L13:
+  Const        r145, "items"
+  Index        r146, r20, r124
+  Index        r147, r146, r145
+  Append       r148, r147, r121
+  SetIndex     r146, r145, r148
+  Const        r149, "count"
+  Index        r150, r146, r149
+  Const        r151, 1
+  AddInt       r152, r150, r151
+  SetIndex     r146, r149, r152
+L4:
   // join n in nation on n.n_nationkey == s.s_nationkey
-  AddInt       r2, r2, r22
-  Jump         L13
+  Const        r153, 1
+  AddInt       r53, r53, r153
+  Jump         L14
 L3:
   // join o in orders on o.o_orderkey == l1.l_orderkey
-  AddInt       r15, r15, r22
-  Jump         L8
+  Const        r154, 1
+  AddInt       r42, r42, r154
+  Jump         L15
+L2:
   // join l1 in lineitem on s.s_suppkey == l1.l_suppkey
-  AddInt       r19, r19, r22
-  Jump         L2
-  // from s in supplier
-  AddInt       r16, r16, r22
-  Jump         L14
-L0:
-  Values       1,14,0,0
-  Move         r14, r6
-  Len          r6, r1
-L16:
-  LessInt      r20, r14, r6
-  JumpIfFalse  r20, L15
-  Index        r20, r1, r14
-  // s_name: g.key,
-  Move         r1, r5
-  Index        r5, r20, r12
-  // numwait: count(g)
-  Move         r6, r13
-  Index        r13, r20, r27
-  // s_name: g.key,
-  Move         r19, r1
-  Move         r1, r5
-  // numwait: count(g)
-  Move         r5, r6
-  Move         r6, r13
-  // select {
-  MakeMap      r13, 2, r19
-  // sort by [ -count(g), g.key ]
-  Index        r6, r20, r27
-  Neg          r27, r6
-  Index        r6, r20, r12
-  MakeList     r20, 2, r27
-  // from s in supplier
-  Move         r6, r13
-  MakeList     r13, 2, r20
-  Append       r4, r4, r13
-  AddInt       r14, r14, r22
+  Const        r155, 1
+  AddInt       r31, r31, r155
   Jump         L16
-L15:
+L1:
+  // from s in supplier
+  Const        r156, 1
+  AddInt       r25, r25, r156
+  Jump         L17
+L0:
+  Const        r157, 0
+  Len          r159, r21
+L19:
+  LessInt      r160, r157, r159
+  JumpIfFalse  r160, L18
+  Index        r162, r21, r157
+  // s_name: g.key,
+  Const        r163, "s_name"
+  Const        r164, "key"
+  Index        r165, r162, r164
+  // numwait: count(g)
+  Const        r166, "numwait"
+  Const        r167, "count"
+  Index        r168, r162, r167
+  // s_name: g.key,
+  Move         r169, r163
+  Move         r170, r165
+  // numwait: count(g)
+  Move         r171, r166
+  Move         r172, r168
+  // select {
+  MakeMap      r173, 2, r169
+  // sort by [ -count(g), g.key ]
+  Const        r174, "count"
+  Index        r175, r162, r174
+  Neg          r177, r175
+  Const        r178, "key"
+  Index        r180, r162, r178
+  MakeList     r182, 2, r177
+  // from s in supplier
+  Move         r183, r173
+  MakeList     r184, 2, r182
+  Append       r4, r4, r184
+  Const        r186, 1
+  AddInt       r157, r157, r186
+  Jump         L19
+L18:
   // sort by [ -count(g), g.key ]
   Sort         r4, r4
   // json(result)
   JSON         r4
   // expect result == [
-  Const        r13, [{"numwait": 1, "s_name": "Desert Trade"}]
-  Equal        r6, r4, r13
-  Expect       r6
+  Const        r188, [{"numwait": 1, "s_name": "Desert Trade"}]
+  Equal        r189, r4, r188
+  Expect       r189
   Return       r0

--- a/tests/dataset/tpc-h/out/q22.ir.out
+++ b/tests/dataset/tpc-h/out/q22.ir.out
@@ -1,4 +1,4 @@
-func main (regs=24)
+func main (regs=198)
   // let customer = [
   Const        r0, [{"c_acctbal": 600, "c_custkey": 1, "c_phone": "13-123-4567"}, {"c_acctbal": 100, "c_custkey": 2, "c_phone": "31-456-7890"}, {"c_acctbal": 700, "c_custkey": 3, "c_phone": "30-000-0000"}]
   // let orders = [
@@ -10,240 +10,294 @@ func main (regs=24)
   // where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
   Const        r4, "c_acctbal"
   Const        r5, "c_phone"
-L7:
-  // from c in customer
-  IterPrep     r6, r0
-  Len          r7, r6
-  Const        r8, 0
-L2:
-  Move         r9, r8
-L3:
-  LessInt      r10, r9, r7
-  JumpIfFalse  r10, L0
-  Index        r7, r6, r9
-L13:
-  // where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
-  Index        r6, r7, r4
-L1:
-  Move         r11, r8
-L0:
-  LessFloat    r12, r11, r6
-L6:
-  Index        r6, r7, r5
-L8:
-  Const        r13, 2
-  Slice        r14, r6, r8, r13
-  In           r6, r14, r2
-  Move         r14, r12
-  JumpIfFalse  r14, L1
-  Move         r14, r6
-L12:
-  JumpIfFalse  r14, L2
   // select c.c_acctbal
-  Index        r14, r7, r4
+  Const        r6, "c_acctbal"
   // from c in customer
-  Append       r3, r3, r14
-  Const        r14, 1
-  AddInt       r9, r9, r14
+  IterPrep     r7, r0
+  Len          r8, r7
+  Const        r9, 0
+L3:
+  LessInt      r11, r9, r8
+  JumpIfFalse  r11, L0
+  Index        r13, r7, r9
+  // where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
+  Const        r14, "c_acctbal"
+  Index        r15, r13, r14
+  Const        r16, 0
+  LessFloat    r17, r16, r15
+  Const        r18, "c_phone"
+  Index        r19, r13, r18
+  Const        r20, 0
+  Const        r21, 2
+  Slice        r22, r19, r20, r21
+  In           r23, r22, r2
+  Move         r24, r17
+  JumpIfFalse  r24, L1
+  Move         r24, r23
+L1:
+  JumpIfFalse  r24, L2
+  // select c.c_acctbal
+  Const        r25, "c_acctbal"
+  Index        r26, r13, r25
+  // from c in customer
+  Append       r3, r3, r26
+L2:
+  Const        r28, 1
+  AddInt       r9, r9, r28
   Jump         L3
+L0:
   // avg(
-  Avg          r10, r3
+  Avg          r29, r3
   // from c in customer
-  Const        r3, []
+  Const        r30, []
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  Const        r31, "c_phone"
+  // c.c_acctbal > avg_balance && (!exists(
+  Const        r32, "c_acctbal"
   // where o.o_custkey == c.c_custkey
-  Const        r9, "o_custkey"
-  Const        r6, "c_custkey"
+  Const        r33, "o_custkey"
+  Const        r34, "c_custkey"
   // cntrycode: substring(c.c_phone, 0, 2),
-  Const        r12, "cntrycode"
-  // from c in customer
-  IterPrep     r15, r0
-  Len          r16, r15
-  Move         r17, r8
-  LessInt      r18, r17, r16
-  JumpIfFalse  r18, L2
-  Index        r7, r15, r17
-  // substring(c.c_phone, 0, 2) in valid_codes &&
-  Index        r18, r7, r5
-  Slice        r16, r18, r8, r13
-  // c.c_acctbal > avg_balance && (!exists(
-  Index        r18, r7, r4
-  LessFloat    r15, r10, r18
-  // substring(c.c_phone, 0, 2) in valid_codes &&
-  In           r18, r16, r2
-  JumpIfFalse  r18, L4
-L4:
-  // c.c_acctbal > avg_balance && (!exists(
-  Move         r18, r15
-  JumpIfFalse  r18, L5
-  // from o in orders
-  Move         r16, r3
-  IterPrep     r2, r1
-  Len          r1, r2
-  Move         r10, r8
-  LessInt      r19, r10, r1
-  JumpIfFalse  r19, L6
-  Index        r19, r2, r10
-  // where o.o_custkey == c.c_custkey
-  Index        r2, r19, r9
-  Index        r9, r7, r6
-  Equal        r6, r2, r9
-  JumpIfFalse  r6, L7
-  // from o in orders
-  Append       r16, r16, r19
-  AddInt       r10, r10, r14
-  Jump         L7
-  // c.c_acctbal > avg_balance && (!exists(
-  Exists       r6, r16
-  Not          r18, r6
-L5:
-  // substring(c.c_phone, 0, 2) in valid_codes &&
-  JumpIfFalse  r18, L8
-  // cntrycode: substring(c.c_phone, 0, 2),
-  Move         r6, r12
-  Index        r16, r7, r5
-  Slice        r5, r16, r8, r13
+  Const        r35, "cntrycode"
+  Const        r36, "c_phone"
   // c_acctbal: c.c_acctbal
-  Move         r16, r4
-  Index        r13, r7, r4
-  // cntrycode: substring(c.c_phone, 0, 2),
-  Move         r7, r6
-  Move         r6, r5
-  // c_acctbal: c.c_acctbal
-  Move         r5, r16
-  Move         r16, r13
-  // select {
-  MakeMap      r13, 2, r7
+  Const        r37, "c_acctbal"
+  Const        r38, "c_acctbal"
   // from c in customer
-  Append       r3, r3, r13
-  AddInt       r17, r17, r14
-  Jump         L0
-  // from c in eligible_customers
-  Const        r13, []
-  IterPrep     r16, r3
-  Len          r3, r16
-  Move         r5, r8
-  MakeMap      r6, 0, r0
-  LessInt      r7, r5, r3
-  JumpIfFalse  r7, L9
-  Index        r7, r16, r5
-  // group by c.cntrycode into g
-  Index        r16, r7, r12
-  Str          r3, r16
-  In           r15, r3, r6
-  JumpIfTrue   r15, L0
-  // from c in eligible_customers
-  Move         r15, r13
-  Const        r17, "__group__"
-  Const        r18, true
-  Const        r9, "key"
-  // group by c.cntrycode into g
-  Move         r2, r16
-  // from c in eligible_customers
-  Const        r16, "items"
-  Move         r19, r15
-  Const        r15, "count"
-  Move         r10, r5
-  Move         r1, r17
-  Move         r17, r18
-  Move         r18, r9
-  Move         r20, r2
-  Move         r2, r16
-  Move         r21, r19
-  Move         r19, r15
-  Move         r22, r10
-  MakeMap      r23, 4, r1
-  SetIndex     r6, r3, r23
-  Move         r23, r16
-  Index        r16, r6, r3
-  Index        r3, r16, r23
-  Append       r22, r3, r7
-  SetIndex     r16, r23, r22
-  Move         r22, r15
-  Index        r15, r16, r22
-  AddInt       r3, r15, r14
-  SetIndex     r16, r22, r3
-  AddInt       r5, r5, r14
-  Jump         L3
-L9:
-  Values       3,6,0,0
-  Move         r6, r8
-  Len          r15, r3
-  LessInt      r22, r6, r15
-  JumpIfFalse  r22, L2
-  Index        r22, r3, r6
-  Append       r13, r13, r22
-  AddInt       r6, r6, r14
-  Jump         L7
-  // var tmp = []
-  Const        r6, []
-  Move         r3, r6
-  // for g in groups {
-  IterPrep     r15, r13
-  Len          r13, r15
-  Move         r16, r8
-  Less         r10, r16, r13
-  JumpIfFalse  r10, L10
-  Index        r22, r15, r16
-  // var total = 0.0
-  Move         r10, r11
-  // for x in g.items {
-  Index        r11, r22, r23
-  IterPrep     r23, r11
-  Len          r11, r23
-  Move         r13, r16
-  Less         r15, r13, r11
-  JumpIfFalse  r15, L11
-  Index        r15, r23, r13
-  // total = total + x.c_acctbal
-  Index        r23, r15, r4
-  AddFloat     r10, r10, r23
-  // for x in g.items {
-  Add          r13, r13, r14
-  Jump         L12
+  IterPrep     r39, r0
+  Len          r40, r39
+  Const        r41, 0
 L11:
-  // let row = { cntrycode: g.key, numcust: count(g), totacctbal: total }
-  Move         r15, r12
-  Index        r13, r22, r9
-  Const        r9, "numcust"
-  Count        r4, r22
-  Const        r22, "totacctbal"
-  Move         r11, r15
-  Move         r15, r13
-  Move         r13, r9
-  Move         r9, r4
-  Move         r4, r22
-  Move         r22, r10
-  MakeMap      r10, 3, r11
-  // tmp = append(tmp, row)
-  Append       r3, r3, r10
-  // for g in groups {
-  Add          r16, r16, r14
-  Jump         L13
+  LessInt      r43, r41, r40
+  JumpIfFalse  r43, L4
+  Index        r13, r39, r41
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  Const        r45, "c_phone"
+  Index        r46, r13, r45
+  Const        r47, 0
+  Const        r48, 2
+  Slice        r49, r46, r47, r48
+  // c.c_acctbal > avg_balance && (!exists(
+  Const        r50, "c_acctbal"
+  Index        r51, r13, r50
+  LessFloat    r52, r29, r51
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  In           r54, r49, r2
+  JumpIfFalse  r54, L5
+L5:
+  // c.c_acctbal > avg_balance && (!exists(
+  Move         r55, r52
+  JumpIfFalse  r55, L6
+  // from o in orders
+  Const        r56, []
+  // where o.o_custkey == c.c_custkey
+  Const        r57, "o_custkey"
+  Const        r58, "c_custkey"
+  // from o in orders
+  IterPrep     r59, r1
+  Len          r60, r59
+  Const        r61, 0
+L9:
+  LessInt      r63, r61, r60
+  JumpIfFalse  r63, L7
+  Index        r65, r59, r61
+  // where o.o_custkey == c.c_custkey
+  Const        r66, "o_custkey"
+  Index        r67, r65, r66
+  Const        r68, "c_custkey"
+  Index        r69, r13, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L8
+  // from o in orders
+  Append       r56, r56, r65
+L8:
+  Const        r72, 1
+  AddInt       r61, r61, r72
+  Jump         L9
+L7:
+  // c.c_acctbal > avg_balance && (!exists(
+  Exists       r73, r56
+  Not          r55, r73
+L6:
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  JumpIfFalse  r55, L10
+  // cntrycode: substring(c.c_phone, 0, 2),
+  Const        r75, "cntrycode"
+  Const        r76, "c_phone"
+  Index        r77, r13, r76
+  Const        r78, 0
+  Const        r79, 2
+  Slice        r80, r77, r78, r79
+  // c_acctbal: c.c_acctbal
+  Const        r81, "c_acctbal"
+  Const        r82, "c_acctbal"
+  Index        r83, r13, r82
+  // cntrycode: substring(c.c_phone, 0, 2),
+  Move         r84, r75
+  Move         r85, r80
+  // c_acctbal: c.c_acctbal
+  Move         r86, r81
+  Move         r87, r83
+  // select {
+  MakeMap      r88, 2, r84
+  // from c in customer
+  Append       r30, r30, r88
 L10:
-  // from r in tmp
-  Move         r23, r6
-  IterPrep     r10, r3
-  Len          r3, r10
-  Move         r22, r8
-L15:
-  LessInt      r8, r22, r3
-  JumpIfFalse  r8, L14
-  Index        r8, r10, r22
-  // sort by r.cntrycode
-  Index        r10, r8, r12
-  // from r in tmp
-  Move         r12, r8
-  MakeList     r8, 2, r10
-  Append       r23, r23, r8
-  AddInt       r22, r22, r14
-  Jump         L15
+  Const        r90, 1
+  AddInt       r41, r41, r90
+  Jump         L11
+L4:
+  // from c in eligible_customers
+  Const        r91, []
+  // group by c.cntrycode into g
+  Const        r92, "cntrycode"
+  // from c in eligible_customers
+  IterPrep     r93, r30
+  Len          r94, r93
+  Const        r95, 0
+  MakeMap      r96, 0, r0
+  Const        r97, []
 L14:
+  LessInt      r99, r95, r94
+  JumpIfFalse  r99, L12
+  Index        r100, r93, r95
+  Move         r13, r100
+  // group by c.cntrycode into g
+  Const        r101, "cntrycode"
+  Index        r102, r13, r101
+  Str          r103, r102
+  In           r104, r103, r96
+  JumpIfTrue   r104, L13
+  // from c in eligible_customers
+  Const        r105, []
+  Const        r106, "__group__"
+  Const        r107, true
+  Const        r108, "key"
+  // group by c.cntrycode into g
+  Move         r109, r102
+  // from c in eligible_customers
+  Const        r110, "items"
+  Move         r111, r105
+  Const        r112, "count"
+  Const        r113, 0
+  Move         r114, r106
+  Move         r115, r107
+  Move         r116, r108
+  Move         r117, r109
+  Move         r118, r110
+  Move         r119, r111
+  Move         r120, r112
+  Move         r121, r113
+  MakeMap      r122, 4, r114
+  SetIndex     r96, r103, r122
+  Append       r97, r97, r122
+L13:
+  Const        r124, "items"
+  Index        r125, r96, r103
+  Index        r126, r125, r124
+  Append       r127, r126, r100
+  SetIndex     r125, r124, r127
+  Const        r128, "count"
+  Index        r129, r125, r128
+  Const        r130, 1
+  AddInt       r131, r129, r130
+  SetIndex     r125, r128, r131
+  Const        r132, 1
+  AddInt       r95, r95, r132
+  Jump         L14
+L12:
+  Const        r133, 0
+  Len          r135, r97
+L16:
+  LessInt      r136, r133, r135
+  JumpIfFalse  r136, L15
+  Index        r138, r97, r133
+  Append       r91, r91, r138
+  Const        r140, 1
+  AddInt       r133, r133, r140
+  Jump         L16
+L15:
+  // var tmp = []
+  Const        r142, []
+  // for g in groups {
+  IterPrep     r143, r91
+  Len          r144, r143
+  Const        r145, 0
+L20:
+  Less         r146, r145, r144
+  JumpIfFalse  r146, L17
+  Index        r138, r143, r145
+  // var total = 0.0
+  Const        r149, 0
+  // for x in g.items {
+  Const        r150, "items"
+  Index        r151, r138, r150
+  IterPrep     r152, r151
+  Len          r153, r152
+  Const        r154, 0
+L19:
+  Less         r155, r154, r153
+  JumpIfFalse  r155, L18
+  Index        r157, r152, r154
+  // total = total + x.c_acctbal
+  Const        r158, "c_acctbal"
+  Index        r159, r157, r158
+  AddFloat     r149, r149, r159
+  // for x in g.items {
+  Const        r161, 1
+  Add          r154, r154, r161
+  Jump         L19
+L18:
+  // let row = { cntrycode: g.key, numcust: count(g), totacctbal: total }
+  Const        r163, "cntrycode"
+  Const        r164, "key"
+  Index        r165, r138, r164
+  Const        r166, "numcust"
+  Count        r167, r138
+  Const        r168, "totacctbal"
+  Move         r169, r163
+  Move         r170, r165
+  Move         r171, r166
+  Move         r172, r167
+  Move         r173, r168
+  Move         r174, r149
+  MakeMap      r175, 3, r169
+  // tmp = append(tmp, row)
+  Append       r142, r142, r175
+  // for g in groups {
+  Const        r177, 1
+  Add          r145, r145, r177
+  Jump         L20
+L17:
+  // from r in tmp
+  Const        r179, []
   // sort by r.cntrycode
-  Sort         r23, r23
+  Const        r180, "cntrycode"
+  // from r in tmp
+  IterPrep     r181, r142
+  Len          r182, r181
+  Const        r183, 0
+L22:
+  LessInt      r185, r183, r182
+  JumpIfFalse  r185, L21
+  Index        r187, r181, r183
+  // sort by r.cntrycode
+  Const        r188, "cntrycode"
+  Index        r190, r187, r188
+  // from r in tmp
+  Move         r191, r187
+  MakeList     r192, 2, r190
+  Append       r179, r179, r192
+  Const        r194, 1
+  AddInt       r183, r183, r194
+  Jump         L22
+L21:
+  // sort by r.cntrycode
+  Sort         r179, r179
   // print(result)
-  Print        r23
+  Print        r179
   // expect result == [
-  Const        r8, [{"cntrycode": "13", "numcust": 1, "totacctbal": 600}, {"cntrycode": "30", "numcust": 1, "totacctbal": 700}]
-  Equal        r12, r23, r8
-  Expect       r12
+  Const        r196, [{"cntrycode": "13", "numcust": 1, "totacctbal": 600}, {"cntrycode": "30", "numcust": 1, "totacctbal": 700}]
+  Equal        r197, r179, r196
+  Expect       r197
   Return       r0

--- a/tests/dataset/tpc-h/out/q3.ir.out
+++ b/tests/dataset/tpc-h/out/q3.ir.out
@@ -1,8 +1,7 @@
-func main (regs=29)
-L2:
+func main (regs=320)
+L3:
   // let customer = [
   Const        r0, [{"c_custkey": 1, "c_mktsegment": "BUILDING"}, {"c_custkey": 2, "c_mktsegment": "AUTOMOBILE"}]
-L13:
   // let orders = [
   Const        r1, [{"o_custkey": 1, "o_orderdate": "1995-03-14", "o_orderkey": 100, "o_shippriority": 1}, {"o_custkey": 2, "o_orderdate": "1995-03-10", "o_orderkey": 200, "o_shippriority": 2}]
   // let lineitem = [
@@ -15,374 +14,474 @@ L13:
   Const        r5, []
   // where c.c_mktsegment == segment
   Const        r6, "c_mktsegment"
-L0:
   // from c in customer
   IterPrep     r7, r0
-L9:
   Len          r8, r7
-L17:
   Const        r9, 0
-L6:
-  Move         r10, r9
-L1:
-  LessInt      r11, r10, r8
-L3:
+L2:
+  LessInt      r11, r9, r8
   JumpIfFalse  r11, L0
-  Index        r8, r7, r10
-L8:
+  Index        r13, r7, r9
   // where c.c_mktsegment == segment
-  Index        r7, r8, r6
-L4:
-  Equal        r6, r7, r4
-L12:
-  JumpIfFalse  r6, L1
-L10:
+  Const        r14, "c_mktsegment"
+  Index        r15, r13, r14
+  Equal        r16, r15, r4
+  JumpIfFalse  r16, L1
   // from c in customer
-  Append       r5, r5, r8
-L5:
-  Const        r6, 1
-  AddInt       r10, r10, r6
-  Jump         L1
-L11:
+  Append       r5, r5, r13
+L1:
+  Const        r18, 1
+  AddInt       r9, r9, r18
+  Jump         L2
+L0:
   // from o in orders
-  Const        r11, []
-L15:
-  IterPrep     r10, r1
-  Len          r1, r10
+  Const        r19, []
+  IterPrep     r20, r1
+  Len          r21, r20
   // join c in building_customers on o.o_custkey == c.c_custkey
-  IterPrep     r7, r5
-  Len          r5, r7
+  IterPrep     r22, r5
+  Len          r23, r22
   // from o in orders
-  EqualInt     r4, r1, r9
-  JumpIfTrue   r4, L2
-  EqualInt     r4, r5, r9
-  JumpIfTrue   r4, L2
-  LessEq       r4, r5, r1
-  JumpIfFalse  r4, L3
+  Const        r24, 0
+  EqualInt     r25, r21, r24
+  JumpIfTrue   r25, L3
+  EqualInt     r26, r23, r24
+  JumpIfTrue   r26, L3
+  LessEq       r27, r23, r21
+  JumpIfFalse  r27, L4
   // join c in building_customers on o.o_custkey == c.c_custkey
-  MakeMap      r4, 0, r0
-  Move         r12, r9
-  LessInt      r13, r12, r5
-  JumpIfFalse  r13, L4
-  Index        r13, r7, r12
-  Move         r8, r13
-  Const        r14, "c_custkey"
-  Index        r15, r8, r14
-  Index        r16, r4, r15
-  Const        r17, nil
-  NotEqual     r18, r16, r17
-  JumpIfTrue   r18, L4
-  MakeList     r19, 0, r0
-  SetIndex     r4, r15, r19
-  Index        r16, r4, r15
-  Append       r19, r16, r13
-  SetIndex     r4, r15, r19
-  AddInt       r12, r12, r6
-  Jump         L5
-  // from o in orders
-  Move         r19, r9
-  LessInt      r18, r19, r1
-  JumpIfFalse  r18, L2
-  Index        r18, r10, r19
-  // join c in building_customers on o.o_custkey == c.c_custkey
-  Const        r16, "o_custkey"
-  Index        r15, r18, r16
-  // from o in orders
-  Index        r13, r4, r15
-  NotEqual     r15, r13, r17
-  JumpIfFalse  r15, L6
-  Len          r15, r13
-  Move         r13, r19
-  LessInt      r4, r13, r15
-  JumpIfFalse  r4, L6
-  // where o.o_orderdate < cutoff
-  Const        r4, "o_orderdate"
-  Index        r15, r18, r4
-  Less         r12, r15, r3
-  JumpIfFalse  r12, L7
-  // from o in orders
-  Append       r11, r11, r18
+  MakeMap      r28, 0, r0
+  Const        r29, 0
 L7:
-  AddInt       r13, r13, r6
-  Jump         L4
-  AddInt       r19, r19, r6
-  Jump         L3
-  MakeMap      r12, 0, r0
-  Move         r19, r9
-  LessInt      r13, r19, r1
-  JumpIfFalse  r13, L8
-  Index        r13, r10, r19
-  // join c in building_customers on o.o_custkey == c.c_custkey
-  Index        r10, r13, r16
+  LessInt      r30, r29, r23
+  JumpIfFalse  r30, L5
+  Index        r31, r22, r29
+  Move         r13, r31
+  Const        r32, "c_custkey"
+  Index        r33, r13, r32
+  Index        r34, r28, r33
+  Const        r35, nil
+  NotEqual     r36, r34, r35
+  JumpIfTrue   r36, L6
+  MakeList     r37, 0, r0
+  SetIndex     r28, r33, r37
+L6:
+  Index        r34, r28, r33
+  Append       r38, r34, r31
+  SetIndex     r28, r33, r38
+  Const        r39, 1
+  AddInt       r29, r29, r39
+  Jump         L7
+L5:
   // from o in orders
-  Index        r16, r12, r10
-  Move         r1, r17
-  NotEqual     r17, r16, r1
-  JumpIfTrue   r17, L9
-  MakeList     r15, 0, r0
-  SetIndex     r12, r10, r15
-  Index        r16, r12, r10
-  Append       r17, r16, r13
-  SetIndex     r12, r10, r17
-  AddInt       r19, r19, r6
-  Jump         L10
+  Const        r40, 0
+L11:
+  LessInt      r41, r40, r21
+  JumpIfFalse  r41, L3
+  Index        r43, r20, r40
   // join c in building_customers on o.o_custkey == c.c_custkey
-  Move         r16, r9
-  LessInt      r10, r16, r5
-  JumpIfFalse  r10, L11
-  Index        r8, r7, r16
-  Index        r10, r8, r14
-  Index        r14, r12, r10
-  NotEqual     r10, r14, r1
-  JumpIfFalse  r10, L3
-  Len          r10, r14
-  Move         r1, r16
-  LessInt      r12, r1, r10
-  JumpIfFalse  r12, L3
-  Index        r18, r14, r1
+  Const        r44, "o_custkey"
+  Index        r45, r43, r44
+  // from o in orders
+  Index        r46, r28, r45
+  Const        r47, nil
+  NotEqual     r48, r46, r47
+  JumpIfFalse  r48, L8
+  Len          r49, r46
+  Const        r50, 0
+L10:
+  LessInt      r51, r50, r49
+  JumpIfFalse  r51, L8
+  Index        r13, r46, r50
   // where o.o_orderdate < cutoff
-  Index        r17, r18, r4
-  Less         r12, r17, r3
-  JumpIfFalse  r12, L3
+  Const        r53, "o_orderdate"
+  Index        r54, r43, r53
+  Less         r55, r54, r3
+  JumpIfFalse  r55, L9
   // from o in orders
-  Append       r11, r11, r18
-  // join c in building_customers on o.o_custkey == c.c_custkey
-  AddInt       r1, r1, r6
-  Jump         L3
-  AddInt       r16, r16, r6
-  Jump         L12
-  // from l in lineitem
-  Const        r1, []
-  // where l.l_shipdate > cutoff
-  Const        r17, "l_shipdate"
-  // from l in lineitem
-  IterPrep     r10, r2
-  Len          r2, r10
-  Move         r14, r9
-  LessInt      r8, r14, r2
-  JumpIfFalse  r8, L13
-  Index        r8, r10, r14
-  // where l.l_shipdate > cutoff
-  Index        r10, r8, r17
-  Less         r17, r3, r10
-  JumpIfFalse  r17, L10
-  // from l in lineitem
-  Append       r1, r1, r8
-  AddInt       r14, r14, r6
+  Append       r19, r19, r43
+L9:
+  Const        r57, 1
+  AddInt       r50, r50, r57
   Jump         L10
-  // from o in valid_orders
-  Const        r10, []
-  // o_orderkey: o.o_orderkey,
-  Const        r14, "o_orderkey"
-  // o_shippriority: o.o_shippriority
-  Const        r16, "o_shippriority"
-  // l_orderkey: g.key.o_orderkey,
-  Const        r3, "l_orderkey"
-  Const        r2, "key"
-  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
-  Const        r5, "revenue"
-  Const        r7, "l"
-  Const        r13, "l_extendedprice"
-  Const        r19, "l_discount"
-  // from o in valid_orders
-  MakeMap      r15, 0, r0
-  IterPrep     r20, r11
-  Len          r12, r20
-  Move         r11, r9
-  LessInt      r21, r11, r12
-  JumpIfFalse  r21, L12
-  Index        r18, r20, r11
-  // join l in valid_lineitems on l.l_orderkey == o.o_orderkey
-  IterPrep     r21, r1
-  Len          r1, r21
-  Move         r20, r11
-  LessInt      r12, r20, r1
-  JumpIfFalse  r12, L14
-  Index        r8, r21, r20
-  Index        r12, r8, r3
-  Index        r1, r18, r14
-  Equal        r21, r12, r1
-  JumpIfFalse  r21, L5
-  // from o in valid_orders
-  Const        r21, "o"
-  Move         r1, r18
-  Move         r12, r8
-  MakeMap      r8, 2, r21
-  // o_orderkey: o.o_orderkey,
-  Move         r17, r14
-  Index        r12, r18, r14
-  // o_orderdate: o.o_orderdate,
-  Move         r1, r4
-  Index        r21, r18, r4
-  // o_shippriority: o.o_shippriority
-  Move         r22, r16
-  Index        r23, r18, r16
-  // o_orderkey: o.o_orderkey,
-  Move         r18, r17
-  Move         r17, r12
-  // o_orderdate: o.o_orderdate,
-  Move         r12, r1
-  Move         r1, r21
-  // o_shippriority: o.o_shippriority
-  Move         r21, r22
-  Move         r22, r23
-  // group by {
-  MakeMap      r23, 3, r18
-  Str          r22, r23
-  In           r21, r22, r15
-  JumpIfTrue   r21, L15
-  // from o in valid_orders
-  Move         r21, r10
-  Const        r1, "__group__"
-  Const        r12, true
-  Move         r17, r2
-  // group by {
-  Move         r18, r23
-  // from o in valid_orders
-  Const        r23, "items"
-  Move         r24, r21
-  Const        r21, "count"
-  Move         r25, r11
-  Move         r26, r1
-  Move         r1, r12
-  Move         r12, r17
-  Move         r17, r18
-  Move         r18, r23
-  Move         r27, r24
-  Move         r24, r21
-  Move         r28, r25
-  MakeMap      r25, 4, r26
-  SetIndex     r15, r22, r25
-  Move         r25, r23
-  Index        r23, r15, r22
-  Index        r22, r23, r25
-  Append       r28, r22, r8
-  SetIndex     r23, r25, r28
-  Move         r28, r21
-  Index        r22, r23, r28
-  AddInt       r25, r22, r6
-  SetIndex     r23, r28, r25
-  // join l in valid_lineitems on l.l_orderkey == o.o_orderkey
-  AddInt       r20, r20, r6
-  Jump         L5
-L14:
-  // from o in valid_orders
-  AddInt       r11, r11, r6
+L8:
+  Const        r58, 1
+  AddInt       r40, r40, r58
   Jump         L11
-  Values       25,15,0,0
-  Move         r15, r9
-  Len          r22, r25
-  LessInt      r28, r15, r22
-  JumpIfFalse  r28, L16
-  Index        r28, r25, r15
-  // l_orderkey: g.key.o_orderkey,
-  Move         r25, r3
-  Index        r22, r28, r2
-  Index        r23, r22, r14
-  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
-  Move         r22, r5
-  Move         r14, r10
-  IterPrep     r18, r28
-  Len          r21, r18
-  Move         r20, r9
-  LessInt      r11, r20, r21
-  JumpIfFalse  r11, L17
-  Index        r11, r18, r20
-  Index        r18, r11, r7
-  Index        r21, r18, r13
-  Index        r18, r11, r7
-  Index        r8, r18, r19
-  Sub          r18, r6, r8
-  Mul          r8, r21, r18
-  Append       r14, r14, r8
-  AddInt       r20, r20, r6
-  Jump         L9
-  Sum          r18, r14
-  // o_orderdate: g.key.o_orderdate,
-  Move         r14, r4
-  Index        r21, r28, r2
-  Index        r20, r21, r4
-  // o_shippriority: g.key.o_shippriority
-  Move         r21, r16
-  Index        r4, r28, r2
-  Index        r24, r4, r16
-  // l_orderkey: g.key.o_orderkey,
-  Move         r4, r25
-  Move         r25, r23
-  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
-  Move         r23, r22
-  Move         r22, r18
-  // o_orderdate: g.key.o_orderdate,
-  Move         r18, r14
-  Move         r16, r20
-  // o_shippriority: g.key.o_shippriority
-  Move         r20, r21
-  Move         r27, r24
-  // select {
-  MakeMap      r24, 4, r4
-  // -sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
-  Move         r27, r10
-  IterPrep     r20, r28
-  Len          r16, r20
-  Move         r18, r9
+L4:
+  MakeMap      r59, 0, r0
+  Const        r60, 0
+L14:
+  LessInt      r61, r60, r21
+  JumpIfFalse  r61, L12
+  Index        r62, r20, r60
+  Move         r43, r62
+  // join c in building_customers on o.o_custkey == c.c_custkey
+  Const        r63, "o_custkey"
+  Index        r64, r43, r63
+  // from o in orders
+  Index        r65, r59, r64
+  Const        r66, nil
+  NotEqual     r67, r65, r66
+  JumpIfTrue   r67, L13
+  MakeList     r68, 0, r0
+  SetIndex     r59, r64, r68
+L13:
+  Index        r65, r59, r64
+  Append       r69, r65, r62
+  SetIndex     r59, r64, r69
+  Const        r70, 1
+  AddInt       r60, r60, r70
+  Jump         L14
+L12:
+  // join c in building_customers on o.o_custkey == c.c_custkey
+  Const        r71, 0
 L19:
-  LessInt      r9, r18, r16
-  JumpIfFalse  r9, L18
-  Index        r11, r20, r18
-  Index        r9, r11, r7
-  Index        r16, r9, r13
-  Index        r9, r11, r7
-  Index        r11, r9, r19
-  Sub          r9, r6, r11
-  Mul          r11, r16, r9
-  Append       r27, r27, r11
-  AddInt       r18, r18, r6
-  Jump         L19
+  LessInt      r72, r71, r23
+  JumpIfFalse  r72, L15
+  Index        r13, r22, r71
+  Const        r74, "c_custkey"
+  Index        r75, r13, r74
+  Index        r76, r59, r75
+  Const        r77, nil
+  NotEqual     r78, r76, r77
+  JumpIfFalse  r78, L16
+  Len          r79, r76
+  Const        r80, 0
 L18:
-  Sum          r11, r27
-  Neg          r27, r11
-  // g.key.o_orderdate
-  Index        r11, r28, r2
-  // sort by [
-  MakeList     r28, 2, r27
-  // from o in valid_orders
-  Move         r8, r24
-  MakeList     r11, 2, r28
-  Append       r10, r10, r11
-  AddInt       r15, r15, r6
-  Jump         L17
+  LessInt      r81, r80, r79
+  JumpIfFalse  r81, L16
+  Index        r43, r76, r80
+  // where o.o_orderdate < cutoff
+  Const        r83, "o_orderdate"
+  Index        r84, r43, r83
+  Less         r85, r84, r3
+  JumpIfFalse  r85, L17
+  // from o in orders
+  Append       r19, r19, r43
+L17:
+  // join c in building_customers on o.o_custkey == c.c_custkey
+  Const        r87, 1
+  AddInt       r80, r80, r87
+  Jump         L18
 L16:
+  Const        r88, 1
+  AddInt       r71, r71, r88
+  Jump         L19
+L15:
+  // from l in lineitem
+  Const        r89, []
+  // where l.l_shipdate > cutoff
+  Const        r90, "l_shipdate"
+  // from l in lineitem
+  IterPrep     r91, r2
+  Len          r92, r91
+  Const        r93, 0
+L22:
+  LessInt      r95, r93, r92
+  JumpIfFalse  r95, L20
+  Index        r97, r91, r93
+  // where l.l_shipdate > cutoff
+  Const        r98, "l_shipdate"
+  Index        r99, r97, r98
+  Less         r100, r3, r99
+  JumpIfFalse  r100, L21
+  // from l in lineitem
+  Append       r89, r89, r97
+L21:
+  Const        r102, 1
+  AddInt       r93, r93, r102
+  Jump         L22
+L20:
+  // from o in valid_orders
+  Const        r103, []
+  // o_orderkey: o.o_orderkey,
+  Const        r104, "o_orderkey"
+  Const        r105, "o_orderkey"
+  // o_orderdate: o.o_orderdate,
+  Const        r106, "o_orderdate"
+  Const        r107, "o_orderdate"
+  // o_shippriority: o.o_shippriority
+  Const        r108, "o_shippriority"
+  Const        r109, "o_shippriority"
+  // l_orderkey: g.key.o_orderkey,
+  Const        r110, "l_orderkey"
+  Const        r111, "key"
+  Const        r112, "o_orderkey"
+  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+  Const        r113, "revenue"
+  Const        r114, "l"
+  Const        r115, "l_extendedprice"
+  Const        r116, "l"
+  Const        r117, "l_discount"
+  // o_orderdate: g.key.o_orderdate,
+  Const        r118, "o_orderdate"
+  Const        r119, "key"
+  Const        r120, "o_orderdate"
+  // o_shippriority: g.key.o_shippriority
+  Const        r121, "o_shippriority"
+  Const        r122, "key"
+  Const        r123, "o_shippriority"
+  // -sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+  Const        r124, "l"
+  Const        r125, "l_extendedprice"
+  Const        r126, "l"
+  Const        r127, "l_discount"
+  // g.key.o_orderdate
+  Const        r128, "key"
+  Const        r129, "o_orderdate"
+  // from o in valid_orders
+  MakeMap      r130, 0, r0
+  Const        r131, []
+  IterPrep     r133, r19
+  Len          r134, r133
+  Const        r135, 0
+L28:
+  LessInt      r136, r135, r134
+  JumpIfFalse  r136, L23
+  Index        r43, r133, r135
+  // join l in valid_lineitems on l.l_orderkey == o.o_orderkey
+  IterPrep     r138, r89
+  Len          r139, r138
+  Const        r140, 0
+L27:
+  LessInt      r141, r140, r139
+  JumpIfFalse  r141, L24
+  Index        r97, r138, r140
+  Const        r143, "l_orderkey"
+  Index        r144, r97, r143
+  Const        r145, "o_orderkey"
+  Index        r146, r43, r145
+  Equal        r147, r144, r146
+  JumpIfFalse  r147, L25
+  // from o in valid_orders
+  Const        r148, "o"
+  Move         r149, r43
+  Const        r150, "l"
+  Move         r151, r97
+  MakeMap      r152, 2, r148
+  // o_orderkey: o.o_orderkey,
+  Const        r153, "o_orderkey"
+  Const        r154, "o_orderkey"
+  Index        r155, r43, r154
+  // o_orderdate: o.o_orderdate,
+  Const        r156, "o_orderdate"
+  Const        r157, "o_orderdate"
+  Index        r158, r43, r157
+  // o_shippriority: o.o_shippriority
+  Const        r159, "o_shippriority"
+  Const        r160, "o_shippriority"
+  Index        r161, r43, r160
+  // o_orderkey: o.o_orderkey,
+  Move         r162, r153
+  Move         r163, r155
+  // o_orderdate: o.o_orderdate,
+  Move         r164, r156
+  Move         r165, r158
+  // o_shippriority: o.o_shippriority
+  Move         r166, r159
+  Move         r167, r161
+  // group by {
+  MakeMap      r168, 3, r162
+  Str          r169, r168
+  In           r170, r169, r130
+  JumpIfTrue   r170, L26
+  // from o in valid_orders
+  Const        r171, []
+  Const        r172, "__group__"
+  Const        r173, true
+  Const        r174, "key"
+  // group by {
+  Move         r175, r168
+  // from o in valid_orders
+  Const        r176, "items"
+  Move         r177, r171
+  Const        r178, "count"
+  Const        r179, 0
+  Move         r180, r172
+  Move         r181, r173
+  Move         r182, r174
+  Move         r183, r175
+  Move         r184, r176
+  Move         r185, r177
+  Move         r186, r178
+  Move         r187, r179
+  MakeMap      r188, 4, r180
+  SetIndex     r130, r169, r188
+  Append       r131, r131, r188
+L26:
+  Const        r190, "items"
+  Index        r191, r130, r169
+  Index        r192, r191, r190
+  Append       r193, r192, r152
+  SetIndex     r191, r190, r193
+  Const        r194, "count"
+  Index        r195, r191, r194
+  Const        r196, 1
+  AddInt       r197, r195, r196
+  SetIndex     r191, r194, r197
+L25:
+  // join l in valid_lineitems on l.l_orderkey == o.o_orderkey
+  Const        r198, 1
+  AddInt       r140, r140, r198
+  Jump         L27
+L24:
+  // from o in valid_orders
+  Const        r199, 1
+  AddInt       r135, r135, r199
+  Jump         L28
+L23:
+  Const        r200, 0
+  Len          r202, r131
+L34:
+  LessInt      r203, r200, r202
+  JumpIfFalse  r203, L29
+  Index        r205, r131, r200
+  // l_orderkey: g.key.o_orderkey,
+  Const        r206, "l_orderkey"
+  Const        r207, "key"
+  Index        r208, r205, r207
+  Const        r209, "o_orderkey"
+  Index        r210, r208, r209
+  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+  Const        r211, "revenue"
+  Const        r212, []
+  Const        r213, "l"
+  Const        r214, "l_extendedprice"
+  Const        r215, "l"
+  Const        r216, "l_discount"
+  IterPrep     r217, r205
+  Len          r218, r217
+  Const        r219, 0
+L31:
+  LessInt      r221, r219, r218
+  JumpIfFalse  r221, L30
+  Index        r223, r217, r219
+  Const        r224, "l"
+  Index        r225, r223, r224
+  Const        r226, "l_extendedprice"
+  Index        r227, r225, r226
+  Const        r228, 1
+  Const        r229, "l"
+  Index        r230, r223, r229
+  Const        r231, "l_discount"
+  Index        r232, r230, r231
+  Sub          r233, r228, r232
+  Mul          r234, r227, r233
+  Append       r212, r212, r234
+  Const        r236, 1
+  AddInt       r219, r219, r236
+  Jump         L31
+L30:
+  Sum          r237, r212
+  // o_orderdate: g.key.o_orderdate,
+  Const        r238, "o_orderdate"
+  Const        r239, "key"
+  Index        r240, r205, r239
+  Const        r241, "o_orderdate"
+  Index        r242, r240, r241
+  // o_shippriority: g.key.o_shippriority
+  Const        r243, "o_shippriority"
+  Const        r244, "key"
+  Index        r245, r205, r244
+  Const        r246, "o_shippriority"
+  Index        r247, r245, r246
+  // l_orderkey: g.key.o_orderkey,
+  Move         r248, r206
+  Move         r249, r210
+  // revenue: sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+  Move         r250, r211
+  Move         r251, r237
+  // o_orderdate: g.key.o_orderdate,
+  Move         r252, r238
+  Move         r253, r242
+  // o_shippriority: g.key.o_shippriority
+  Move         r254, r243
+  Move         r255, r247
+  // select {
+  MakeMap      r256, 4, r248
+  // -sum(from r in g select r.l.l_extendedprice * (1 - r.l.l_discount)),
+  Const        r257, []
+  Const        r258, "l"
+  Const        r259, "l_extendedprice"
+  Const        r260, "l"
+  Const        r261, "l_discount"
+  IterPrep     r262, r205
+  Len          r263, r262
+  Const        r264, 0
+L33:
+  LessInt      r266, r264, r263
+  JumpIfFalse  r266, L32
+  Index        r223, r262, r264
+  Const        r268, "l"
+  Index        r269, r223, r268
+  Const        r270, "l_extendedprice"
+  Index        r271, r269, r270
+  Const        r272, 1
+  Const        r273, "l"
+  Index        r274, r223, r273
+  Const        r275, "l_discount"
+  Index        r276, r274, r275
+  Sub          r277, r272, r276
+  Mul          r278, r271, r277
+  Append       r257, r257, r278
+  Const        r280, 1
+  AddInt       r264, r264, r280
+  Jump         L33
+L32:
+  Sum          r281, r257
+  Neg          r283, r281
+  // g.key.o_orderdate
+  Const        r284, "key"
+  Index        r285, r205, r284
+  Const        r286, "o_orderdate"
+  Index        r288, r285, r286
   // sort by [
-  Sort         r10, r10
+  MakeList     r290, 2, r283
+  // from o in valid_orders
+  Move         r291, r256
+  MakeList     r292, 2, r290
+  Append       r103, r103, r292
+  Const        r294, 1
+  AddInt       r200, r200, r294
+  Jump         L34
+L29:
+  // sort by [
+  Sort         r103, r103
   // json(order_line_join)
-  JSON         r10
+  JSON         r103
   // l_orderkey: 100,
-  Move         r11, r3
-  Const        r3, 100
+  Const        r296, "l_orderkey"
+  Const        r297, 100
   // revenue: 1000.0 * 0.95 + 500.0,
-  Move         r28, r5
-  Const        r5, 1450
+  Const        r298, "revenue"
+  Const        r299, 1000
+  Const        r300, 0.95
+  Const        r301, 950
+  Const        r302, 500
+  Const        r303, 1450
   // o_orderdate: "1995-03-14",
-  Move         r9, r14
-  Const        r14, "1995-03-14"
+  Const        r304, "o_orderdate"
+  Const        r305, "1995-03-14"
   // o_shippriority: 1
-  Move         r8, r21
+  Const        r306, "o_shippriority"
+  Const        r307, 1
   // l_orderkey: 100,
-  Move         r21, r11
-  Move         r11, r3
+  Move         r308, r296
+  Move         r309, r297
   // revenue: 1000.0 * 0.95 + 500.0,
-  Move         r3, r28
-  Move         r28, r5
+  Move         r310, r298
+  Move         r311, r303
   // o_orderdate: "1995-03-14",
-  Move         r5, r9
-  Move         r9, r14
+  Move         r312, r304
+  Move         r313, r305
   // o_shippriority: 1
-  Move         r14, r8
-  Move         r8, r6
+  Move         r314, r306
+  Move         r315, r307
   // {
-  MakeMap      r6, 4, r21
+  MakeMap      r317, 4, r308
   // expect order_line_join == [
-  MakeList     r8, 1, r6
-  Equal        r6, r10, r8
-  Expect       r6
+  MakeList     r318, 1, r317
+  Equal        r319, r103, r318
+  Expect       r319
   Return       r0

--- a/tests/dataset/tpc-h/out/q4.ir.out
+++ b/tests/dataset/tpc-h/out/q4.ir.out
@@ -1,182 +1,211 @@
-func main (regs=23)
+func main (regs=135)
   // let orders = [
   Const        r0, [{"o_orderdate": "1993-07-01", "o_orderkey": 1, "o_orderpriority": "1-URGENT"}, {"o_orderdate": "1993-07-15", "o_orderkey": 2, "o_orderpriority": "2-HIGH"}, {"o_orderdate": "1993-08-01", "o_orderkey": 3, "o_orderpriority": "3-NORMAL"}]
   // let lineitem = [
   Const        r1, [{"l_commitdate": "1993-07-10", "l_orderkey": 1, "l_receiptdate": "1993-07-12"}, {"l_commitdate": "1993-07-12", "l_orderkey": 1, "l_receiptdate": "1993-07-10"}, {"l_commitdate": "1993-07-20", "l_orderkey": 2, "l_receiptdate": "1993-07-25"}, {"l_commitdate": "1993-08-02", "l_orderkey": 3, "l_receiptdate": "1993-08-01"}, {"l_commitdate": "1993-08-05", "l_orderkey": 3, "l_receiptdate": "1993-08-10"}]
-L0:
   // let start_date = "1993-07-01"
   Const        r2, "1993-07-01"
-L7:
   // let end_date = "1993-08-01"
   Const        r3, "1993-08-01"
-L4:
   // from o in orders
   Const        r4, []
-L2:
   // where o.o_orderdate >= start_date && o.o_orderdate < end_date
   Const        r5, "o_orderdate"
+  Const        r6, "o_orderdate"
   // from o in orders
-  IterPrep     r6, r0
-L5:
-  Len          r7, r6
-  Const        r8, 0
-  Move         r9, r8
-L1:
-  LessInt      r10, r9, r7
-L6:
-  JumpIfFalse  r10, L0
-L9:
-  Index        r7, r6, r9
-  // where o.o_orderdate >= start_date && o.o_orderdate < end_date
-  Index        r6, r7, r5
+  IterPrep     r7, r0
+  Len          r8, r7
+  Const        r9, 0
 L3:
-  LessEq       r11, r2, r6
-  Index        r6, r7, r5
-  Less         r5, r6, r3
-  Move         r6, r11
-L10:
-  JumpIfFalse  r6, L1
-  Move         r6, r5
-  JumpIfFalse  r6, L2
+  LessInt      r11, r9, r8
+  JumpIfFalse  r11, L0
+  Index        r13, r7, r9
+  // where o.o_orderdate >= start_date && o.o_orderdate < end_date
+  Const        r14, "o_orderdate"
+  Index        r15, r13, r14
+  LessEq       r16, r2, r15
+  Const        r17, "o_orderdate"
+  Index        r18, r13, r17
+  Less         r19, r18, r3
+  Move         r20, r16
+  JumpIfFalse  r20, L1
+  Move         r20, r19
+L1:
+  JumpIfFalse  r20, L2
   // from o in orders
-  Append       r4, r4, r7
-  Const        r6, 1
-  AddInt       r9, r9, r6
-  Jump         L1
+  Append       r4, r4, r13
+L2:
+  Const        r22, 1
+  AddInt       r9, r9, r22
+  Jump         L3
+L0:
   // from o in date_filtered_orders
-  Const        r10, []
+  Const        r23, []
   // where l.l_orderkey == o.o_orderkey && l.l_commitdate < l.l_receiptdate
-  Const        r9, "l_orderkey"
-  Const        r5, "o_orderkey"
-  Const        r11, "l_commitdate"
-  Const        r3, "l_receiptdate"
+  Const        r24, "l_orderkey"
+  Const        r25, "o_orderkey"
+  Const        r26, "l_commitdate"
+  Const        r27, "l_receiptdate"
   // from o in date_filtered_orders
-  IterPrep     r2, r4
-  Len          r4, r2
-  Move         r12, r8
-  LessInt      r13, r12, r4
-  JumpIfFalse  r13, L3
-  Index        r7, r2, r12
+  IterPrep     r28, r4
+  Len          r29, r28
+  Const        r30, 0
+L10:
+  LessInt      r32, r30, r29
+  JumpIfFalse  r32, L4
+  Index        r13, r28, r30
   // from l in lineitem
-  Move         r13, r10
-  IterPrep     r4, r1
-  Len          r1, r4
-  Move         r2, r8
-  LessInt      r14, r2, r1
-  JumpIfFalse  r14, L4
-  Index        r14, r4, r2
+  Const        r34, []
   // where l.l_orderkey == o.o_orderkey && l.l_commitdate < l.l_receiptdate
-  Index        r4, r14, r9
-  Index        r9, r14, r11
-  Index        r11, r14, r3
-  Less         r3, r9, r11
-  Index        r11, r7, r5
-  Equal        r5, r4, r11
-  JumpIfFalse  r5, L5
-  Move         r5, r3
-  JumpIfFalse  r5, L6
+  Const        r35, "l_orderkey"
+  Const        r36, "o_orderkey"
+  Const        r37, "l_commitdate"
+  Const        r38, "l_receiptdate"
   // from l in lineitem
-  Append       r13, r13, r14
-  AddInt       r2, r2, r6
-  Jump         L7
-  // where exists(
-  Exists       r5, r13
-  JumpIfFalse  r5, L1
-  // from o in date_filtered_orders
-  Append       r10, r10, r7
-  AddInt       r12, r12, r6
-  Jump         L0
-  // from o in late_orders
-  Const        r5, []
-  // group by o.o_orderpriority into g
-  Const        r2, "o_orderpriority"
-  // o_orderpriority: g.key,
-  Const        r13, "key"
-  // order_count: count(g)
-  Const        r12, "order_count"
-  // from o in late_orders
-  IterPrep     r7, r10
-  Len          r10, r7
-  Move         r11, r8
-  MakeMap      r3, 0, r0
-  LessInt      r4, r11, r10
-  JumpIfFalse  r4, L8
-  Index        r4, r7, r11
-  // group by o.o_orderpriority into g
-  Index        r7, r4, r2
-  Str          r10, r7
-  In           r14, r10, r3
-  JumpIfTrue   r14, L9
-  // from o in late_orders
-  Move         r14, r5
-  Const        r9, "__group__"
-  Const        r1, true
-  Move         r15, r13
-  // group by o.o_orderpriority into g
-  Move         r16, r7
-  // from o in late_orders
-  Const        r7, "items"
-  Move         r17, r14
-  Const        r14, "count"
-  Move         r18, r8
-  Move         r19, r9
-  Move         r9, r1
-  Move         r1, r15
-  Move         r15, r16
-  Move         r16, r7
-  Move         r20, r17
-  Move         r17, r14
-  Move         r21, r18
-  MakeMap      r22, 4, r19
-  SetIndex     r3, r10, r22
-  Move         r22, r7
-  Index        r7, r3, r10
-  Index        r10, r7, r22
-  Append       r21, r10, r4
-  SetIndex     r7, r22, r21
-  Move         r21, r14
-  Index        r14, r7, r21
-  AddInt       r10, r14, r6
-  SetIndex     r7, r21, r10
-  AddInt       r11, r11, r6
-  Jump         L10
+  IterPrep     r39, r1
+  Len          r40, r39
+  Const        r41, 0
 L8:
-  Values       10,3,0,0
-  Move         r3, r8
-  Len          r8, r10
-L12:
-  LessInt      r14, r3, r8
-  JumpIfFalse  r14, L11
-  Index        r14, r10, r3
-  // o_orderpriority: g.key,
-  Move         r10, r2
-  Index        r2, r14, r13
-  // order_count: count(g)
-  Move         r8, r12
-  Index        r12, r14, r21
-  // o_orderpriority: g.key,
-  Move         r21, r10
-  Move         r10, r2
-  // order_count: count(g)
-  Move         r2, r8
-  Move         r8, r12
-  // select {
-  MakeMap      r12, 2, r21
-  // order by g.key
-  Index        r8, r14, r13
+  LessInt      r43, r41, r40
+  JumpIfFalse  r43, L5
+  Index        r45, r39, r41
+  // where l.l_orderkey == o.o_orderkey && l.l_commitdate < l.l_receiptdate
+  Const        r46, "l_orderkey"
+  Index        r47, r45, r46
+  Const        r48, "l_commitdate"
+  Index        r49, r45, r48
+  Const        r50, "l_receiptdate"
+  Index        r51, r45, r50
+  Less         r52, r49, r51
+  Const        r53, "o_orderkey"
+  Index        r54, r13, r53
+  Equal        r56, r47, r54
+  JumpIfFalse  r56, L6
+  Move         r56, r52
+L6:
+  JumpIfFalse  r56, L7
+  // from l in lineitem
+  Append       r34, r34, r45
+L7:
+  Const        r58, 1
+  AddInt       r41, r41, r58
+  Jump         L8
+L5:
+  // where exists(
+  Exists       r59, r34
+  JumpIfFalse  r59, L9
+  // from o in date_filtered_orders
+  Append       r23, r23, r13
+L9:
+  Const        r61, 1
+  AddInt       r30, r30, r61
+  Jump         L10
+L4:
   // from o in late_orders
-  Move         r14, r12
-  MakeList     r12, 2, r8
-  Append       r5, r5, r12
-  AddInt       r3, r3, r6
-  Jump         L12
-L11:
+  Const        r62, []
+  // group by o.o_orderpriority into g
+  Const        r63, "o_orderpriority"
+  // o_orderpriority: g.key,
+  Const        r64, "o_orderpriority"
+  Const        r65, "key"
+  // order_count: count(g)
+  Const        r66, "order_count"
   // order by g.key
-  Sort         r5, r5
+  Const        r67, "key"
+  // from o in late_orders
+  IterPrep     r68, r23
+  Len          r69, r68
+  Const        r70, 0
+  MakeMap      r71, 0, r0
+  Const        r72, []
+L13:
+  LessInt      r74, r70, r69
+  JumpIfFalse  r74, L11
+  Index        r75, r68, r70
+  Move         r13, r75
+  // group by o.o_orderpriority into g
+  Const        r76, "o_orderpriority"
+  Index        r77, r13, r76
+  Str          r78, r77
+  In           r79, r78, r71
+  JumpIfTrue   r79, L12
+  // from o in late_orders
+  Const        r80, []
+  Const        r81, "__group__"
+  Const        r82, true
+  Const        r83, "key"
+  // group by o.o_orderpriority into g
+  Move         r84, r77
+  // from o in late_orders
+  Const        r85, "items"
+  Move         r86, r80
+  Const        r87, "count"
+  Const        r88, 0
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  Move         r92, r84
+  Move         r93, r85
+  Move         r94, r86
+  Move         r95, r87
+  Move         r96, r88
+  MakeMap      r97, 4, r89
+  SetIndex     r71, r78, r97
+  Append       r72, r72, r97
+L12:
+  Const        r99, "items"
+  Index        r100, r71, r78
+  Index        r101, r100, r99
+  Append       r102, r101, r75
+  SetIndex     r100, r99, r102
+  Const        r103, "count"
+  Index        r104, r100, r103
+  Const        r105, 1
+  AddInt       r106, r104, r105
+  SetIndex     r100, r103, r106
+  Const        r107, 1
+  AddInt       r70, r70, r107
+  Jump         L13
+L11:
+  Const        r108, 0
+  Len          r110, r72
+L15:
+  LessInt      r111, r108, r110
+  JumpIfFalse  r111, L14
+  Index        r113, r72, r108
+  // o_orderpriority: g.key,
+  Const        r114, "o_orderpriority"
+  Const        r115, "key"
+  Index        r116, r113, r115
+  // order_count: count(g)
+  Const        r117, "order_count"
+  Const        r118, "count"
+  Index        r119, r113, r118
+  // o_orderpriority: g.key,
+  Move         r120, r114
+  Move         r121, r116
+  // order_count: count(g)
+  Move         r122, r117
+  Move         r123, r119
+  // select {
+  MakeMap      r124, 2, r120
+  // order by g.key
+  Const        r125, "key"
+  Index        r127, r113, r125
+  // from o in late_orders
+  Move         r128, r124
+  MakeList     r129, 2, r127
+  Append       r62, r62, r129
+  Const        r131, 1
+  AddInt       r108, r108, r131
+  Jump         L15
+L14:
+  // order by g.key
+  Sort         r62, r62
   // json(result)
-  JSON         r5
+  JSON         r62
   // expect result == [
-  Const        r12, [{"o_orderpriority": "1-URGENT", "order_count": 1}, {"o_orderpriority": "2-HIGH", "order_count": 1}]
-  Equal        r14, r5, r12
-  Expect       r14
+  Const        r133, [{"o_orderpriority": "1-URGENT", "order_count": 1}, {"o_orderpriority": "2-HIGH", "order_count": 1}]
+  Equal        r134, r62, r133
+  Expect       r134
   Return       r0

--- a/tests/dataset/tpc-h/out/q5.ir.out
+++ b/tests/dataset/tpc-h/out/q5.ir.out
@@ -1,386 +1,507 @@
-func main (regs=27)
+func main (regs=326)
 L0:
   // let region = [
   Const        r0, [{"r_name": "ASIA", "r_regionkey": 0}, {"r_name": "EUROPE", "r_regionkey": 1}]
-L17:
   // let nation = [
   Const        r1, [{"n_name": "JAPAN", "n_nationkey": 10, "n_regionkey": 0}, {"n_name": "INDIA", "n_nationkey": 20, "n_regionkey": 0}, {"n_name": "FRANCE", "n_nationkey": 30, "n_regionkey": 1}]
-L12:
   // let customer = [
   Const        r2, [{"c_custkey": 1, "c_nationkey": 10}, {"c_custkey": 2, "c_nationkey": 20}]
-L13:
   // let supplier = [
   Const        r3, [{"s_nationkey": 10, "s_suppkey": 100}, {"s_nationkey": 20, "s_suppkey": 200}]
   // let orders = [
   Const        r4, [{"o_custkey": 1, "o_orderdate": "1994-03-15", "o_orderkey": 1000}, {"o_custkey": 2, "o_orderdate": "1994-06-10", "o_orderkey": 2000}, {"o_custkey": 2, "o_orderdate": "1995-01-01", "o_orderkey": 3000}]
   // let lineitem = [
   Const        r5, [{"l_discount": 0.05, "l_extendedprice": 1000, "l_orderkey": 1000, "l_suppkey": 100}, {"l_discount": 0.1, "l_extendedprice": 800, "l_orderkey": 2000, "l_suppkey": 200}, {"l_discount": 0.05, "l_extendedprice": 900, "l_orderkey": 3000, "l_suppkey": 200}]
-L10:
   // from r in region
   Const        r6, []
   IterPrep     r7, r0
-L21:
   Len          r8, r7
-L14:
   // join n in nation on n.n_regionkey == r.r_regionkey
   IterPrep     r9, r1
-  Len          r1, r9
+  Len          r10, r9
+  // from r in region
+  Const        r11, 0
+  EqualInt     r12, r8, r11
+  JumpIfTrue   r12, L0
+  EqualInt     r13, r10, r11
+  JumpIfTrue   r13, L0
+  LessEq       r14, r10, r8
+  JumpIfFalse  r14, L1
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  MakeMap      r15, 0, r0
+  Const        r16, 0
+L4:
+  LessInt      r17, r16, r10
+  JumpIfFalse  r17, L2
+  Index        r18, r9, r16
+  Move         r19, r18
+  Const        r20, "n_regionkey"
+  Index        r21, r19, r20
+  Index        r22, r15, r21
+  Const        r23, nil
+  NotEqual     r24, r22, r23
+  JumpIfTrue   r24, L3
+  MakeList     r25, 0, r0
+  SetIndex     r15, r21, r25
+L3:
+  Index        r22, r15, r21
+  Append       r26, r22, r18
+  SetIndex     r15, r21, r26
+  Const        r27, 1
+  AddInt       r16, r16, r27
+  Jump         L4
 L2:
   // from r in region
-  Const        r10, 0
-L7:
-  EqualInt     r11, r8, r10
-L11:
-  JumpIfTrue   r11, L0
-L16:
-  EqualInt     r11, r1, r10
-L1:
-  JumpIfTrue   r11, L0
-L3:
-  LessEq       r11, r1, r8
-  JumpIfFalse  r11, L1
+  Const        r28, 0
 L8:
+  LessInt      r29, r28, r8
+  JumpIfFalse  r29, L0
+  Index        r31, r7, r28
   // join n in nation on n.n_regionkey == r.r_regionkey
-  MakeMap      r11, 0, r0
-  Move         r12, r10
-  LessInt      r13, r12, r1
+  Const        r32, "r_regionkey"
+  Index        r33, r31, r32
+  // from r in region
+  Index        r34, r15, r33
+  Const        r35, nil
+  NotEqual     r36, r34, r35
+  JumpIfFalse  r36, L5
+  Len          r37, r34
+  Const        r38, 0
+L7:
+  LessInt      r39, r38, r37
+  JumpIfFalse  r39, L5
+  Index        r19, r34, r38
+  // where r.r_name == "ASIA"
+  Const        r41, "r_name"
+  Index        r42, r31, r41
+  Const        r43, "ASIA"
+  Equal        r44, r42, r43
+  JumpIfFalse  r44, L6
+  // from r in region
+  Append       r6, r6, r19
 L6:
-  JumpIfFalse  r13, L2
-  Index        r13, r9, r12
-L5:
-  Move         r14, r13
-L18:
-  Const        r15, "n_regionkey"
-  Index        r16, r14, r15
-L15:
-  Index        r17, r11, r16
-  Const        r18, nil
-  NotEqual     r19, r17, r18
-  JumpIfTrue   r19, L3
-  MakeList     r19, 0, r0
-  SetIndex     r11, r16, r19
-  Index        r17, r11, r16
-  Append       r19, r17, r13
-  SetIndex     r11, r16, r19
-  Const        r19, 1
-  AddInt       r12, r12, r19
-  Jump         L1
-  // from r in region
-  Move         r12, r10
-  LessInt      r17, r12, r8
-  JumpIfFalse  r17, L0
-  Index        r17, r7, r12
-  // join n in nation on n.n_regionkey == r.r_regionkey
-  Const        r16, "r_regionkey"
-  Index        r13, r17, r16
-  // from r in region
-  Index        r20, r11, r13
-  NotEqual     r13, r20, r18
-  JumpIfFalse  r13, L4
-  Len          r13, r20
-  Move         r11, r12
-  LessInt      r21, r11, r13
-  JumpIfFalse  r21, L4
-  Index        r14, r20, r11
-  // where r.r_name == "ASIA"
-  Const        r13, "r_name"
-  Index        r20, r17, r13
-  Const        r22, "ASIA"
-  Equal        r23, r20, r22
-  JumpIfFalse  r23, L3
-  // from r in region
-  Append       r6, r6, r14
-  AddInt       r11, r11, r19
-  Jump         L5
-L4:
-  AddInt       r12, r12, r19
-  Jump         L6
-  MakeMap      r21, 0, r0
-  Move         r12, r10
-  LessInt      r20, r12, r8
-  JumpIfFalse  r20, L5
-  Index        r23, r7, r12
-  Move         r17, r23
-  // where r.r_name == "ASIA"
-  Index        r20, r17, r13
-  Equal        r8, r20, r22
-  JumpIfFalse  r8, L7
-  // join n in nation on n.n_regionkey == r.r_regionkey
-  Index        r8, r17, r16
-  // from r in region
-  Index        r16, r21, r8
-  Move         r20, r18
-  NotEqual     r18, r16, r20
-  JumpIfTrue   r18, L6
-  MakeList     r18, 0, r0
-  SetIndex     r21, r8, r18
-  Index        r16, r21, r8
-  Append       r18, r16, r23
-  SetIndex     r21, r8, r18
-  AddInt       r12, r12, r19
-  Jump         L8
-  // join n in nation on n.n_regionkey == r.r_regionkey
-  Move         r16, r10
-  LessInt      r8, r16, r1
-  JumpIfFalse  r8, L3
-  Index        r14, r9, r16
-  Index        r8, r14, r15
-  Index        r15, r21, r8
-  NotEqual     r18, r15, r20
-  JumpIfFalse  r18, L9
-  Len          r8, r15
-  Move         r18, r16
-  LessInt      r20, r18, r8
-  JumpIfFalse  r20, L9
-  Index        r17, r15, r18
-  // where r.r_name == "ASIA"
-  Index        r20, r17, r13
-  Equal        r13, r20, r22
-  JumpIfFalse  r13, L10
-  // from r in region
-  Append       r6, r6, r14
-  // join n in nation on n.n_regionkey == r.r_regionkey
-  AddInt       r18, r18, r19
-  Jump         L11
-L9:
-  AddInt       r16, r16, r19
-  Jump         L3
-  // from c in customer
-  Const        r20, []
-  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
-  Const        r18, "o_orderdate"
-  Const        r22, "s_nationkey"
-  Const        r17, "c_nationkey"
-  // nation: n.n_name,
-  Const        r8, "nation"
-  Const        r15, "n_name"
-  // revenue: l.l_extendedprice * (1 - l.l_discount)
-  Const        r21, "revenue"
-  Const        r1, "l_extendedprice"
-  Const        r9, "l_discount"
-  // from c in customer
-  IterPrep     r12, r2
-  Len          r2, r12
-  Move         r23, r10
-  LessInt      r16, r23, r2
-  JumpIfFalse  r16, L12
-  Index        r2, r12, r23
-  // join n in asia_nations on c.c_nationkey == n.n_nationkey
-  IterPrep     r12, r6
-  Len          r6, r12
-  Const        r16, "n_nationkey"
-  Move         r7, r10
-  LessInt      r11, r7, r6
-  JumpIfFalse  r11, L12
-  Index        r14, r12, r7
-  Index        r13, r2, r17
-  Index        r11, r14, r16
-  Equal        r16, r13, r11
-  JumpIfFalse  r16, L13
-  // join o in orders on o.o_custkey == c.c_custkey
-  IterPrep     r16, r4
-  Len          r4, r16
-  Const        r11, "o_custkey"
-  Const        r13, "c_custkey"
-  Move         r6, r10
-  LessInt      r12, r6, r4
-  JumpIfFalse  r12, L13
-  Index        r12, r16, r6
-  Index        r16, r12, r11
-  Index        r11, r2, r13
-  Equal        r13, r16, r11
-  JumpIfFalse  r13, L14
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  IterPrep     r13, r5
-  Len          r5, r13
-  Const        r11, "l_orderkey"
-  Const        r16, "o_orderkey"
-  Move         r4, r10
-  LessInt      r24, r4, r5
-  JumpIfFalse  r24, L14
-  Index        r24, r13, r4
-  Index        r13, r24, r11
-  Index        r11, r12, r16
-  Equal        r16, r13, r11
-  JumpIfFalse  r16, L1
-  // join s in supplier on s.s_suppkey == l.l_suppkey
-  IterPrep     r16, r3
-  Len          r3, r16
-  Const        r13, "s_suppkey"
-  Const        r5, "l_suppkey"
-  Move         r25, r10
-  LessInt      r26, r25, r3
-  JumpIfFalse  r26, L1
-  Index        r3, r16, r25
-  Index        r16, r3, r13
-  Index        r13, r24, r5
-  Equal        r5, r16, r13
-  JumpIfFalse  r5, L15
-  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
-  Index        r5, r12, r18
-  Const        r13, "1994-01-01"
-  LessEq       r16, r13, r5
-  Index        r13, r12, r18
-  Const        r12, "1995-01-01"
-  Less         r18, r13, r12
-  Index        r12, r3, r22
-  Index        r3, r2, r17
-  Equal        r2, r12, r3
-  Move         r3, r16
-  JumpIfFalse  r3, L16
-  Move         r3, r18
-  JumpIfFalse  r3, L14
-  Move         r3, r2
-  JumpIfFalse  r3, L15
-  // nation: n.n_name,
-  Move         r3, r8
-  Index        r2, r14, r15
-  // revenue: l.l_extendedprice * (1 - l.l_discount)
-  Move         r14, r21
-  Index        r18, r24, r1
-  Index        r1, r24, r9
-  Sub          r24, r19, r1
-  Mul          r1, r18, r24
-  // nation: n.n_name,
-  Move         r24, r3
-  Move         r3, r2
-  // revenue: l.l_extendedprice * (1 - l.l_discount)
-  Move         r2, r14
-  Move         r14, r1
-  // select {
-  MakeMap      r1, 2, r24
-  // from c in customer
-  Append       r20, r20, r1
-  // join s in supplier on s.s_suppkey == l.l_suppkey
-  Add          r25, r25, r19
-  Jump         L17
-  // join l in lineitem on l.l_orderkey == o.o_orderkey
-  Add          r4, r4, r19
-  Jump         L18
-  // join o in orders on o.o_custkey == c.c_custkey
-  Add          r6, r6, r19
+  Const        r46, 1
+  AddInt       r38, r38, r46
   Jump         L7
-  // join n in asia_nations on c.c_nationkey == n.n_nationkey
-  Add          r7, r7, r19
-  Jump         L15
+L5:
+  Const        r47, 1
+  AddInt       r28, r28, r47
+  Jump         L8
+L1:
+  MakeMap      r48, 0, r0
+  Const        r49, 0
+L12:
+  LessInt      r50, r49, r8
+  JumpIfFalse  r50, L9
+  Index        r51, r7, r49
+  Move         r31, r51
+  // where r.r_name == "ASIA"
+  Const        r52, "r_name"
+  Index        r53, r31, r52
+  Const        r54, "ASIA"
+  Equal        r55, r53, r54
+  JumpIfFalse  r55, L10
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  Const        r56, "r_regionkey"
+  Index        r57, r31, r56
+  // from r in region
+  Index        r58, r48, r57
+  Const        r59, nil
+  NotEqual     r60, r58, r59
+  JumpIfTrue   r60, L11
+  MakeList     r61, 0, r0
+  SetIndex     r48, r57, r61
+L11:
+  Index        r58, r48, r57
+  Append       r62, r58, r51
+  SetIndex     r48, r57, r62
+L10:
+  Const        r63, 1
+  AddInt       r49, r49, r63
+  Jump         L12
+L9:
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  Const        r64, 0
+L17:
+  LessInt      r65, r64, r10
+  JumpIfFalse  r65, L13
+  Index        r19, r9, r64
+  Const        r67, "n_regionkey"
+  Index        r68, r19, r67
+  Index        r69, r48, r68
+  Const        r70, nil
+  NotEqual     r71, r69, r70
+  JumpIfFalse  r71, L14
+  Len          r72, r69
+  Const        r73, 0
+L16:
+  LessInt      r74, r73, r72
+  JumpIfFalse  r74, L14
+  Index        r31, r69, r73
+  // where r.r_name == "ASIA"
+  Const        r76, "r_name"
+  Index        r77, r31, r76
+  Const        r78, "ASIA"
+  Equal        r79, r77, r78
+  JumpIfFalse  r79, L15
+  // from r in region
+  Append       r6, r6, r19
+L15:
+  // join n in nation on n.n_regionkey == r.r_regionkey
+  Const        r81, 1
+  AddInt       r73, r73, r81
+  Jump         L16
+L14:
+  Const        r82, 1
+  AddInt       r64, r64, r82
+  Jump         L17
+L13:
   // from c in customer
-  AddInt       r23, r23, r19
-  Jump         L2
-  // from r in local_customer_supplier_orders
-  Const        r24, []
-  // n_name: g.key,
-  Const        r12, "key"
-  // from r in local_customer_supplier_orders
-  IterPrep     r26, r20
-  Len          r20, r26
-  Move         r11, r10
-  MakeMap      r4, 0, r0
-  LessInt      r1, r11, r20
-  JumpIfFalse  r1, L19
-  Index        r20, r26, r11
-  // group by r.nation into g
-  Index        r26, r20, r8
-  Str          r8, r26
-  In           r1, r8, r4
-  JumpIfTrue   r1, L20
-  // from r in local_customer_supplier_orders
-  Move         r1, r24
-  Const        r6, "__group__"
-  Const        r7, true
-  Move         r23, r12
-  // group by r.nation into g
-  Move         r14, r26
-  // from r in local_customer_supplier_orders
-  Const        r26, "items"
-  Move         r2, r1
-  Const        r1, "count"
-  Move         r3, r11
-  Move         r25, r6
-  Move         r6, r7
-  Move         r7, r23
-  Move         r23, r14
-  Move         r14, r26
-  Move         r18, r2
-  Move         r2, r1
-  Move         r9, r3
-  MakeMap      r3, 4, r25
-  SetIndex     r4, r8, r3
-L20:
-  Move         r3, r26
-  Index        r26, r4, r8
-  Index        r8, r26, r3
-  Append       r9, r8, r20
-  SetIndex     r26, r3, r9
-  Move         r9, r1
-  Index        r1, r26, r9
-  AddInt       r8, r1, r19
-  SetIndex     r26, r9, r8
-  AddInt       r11, r11, r19
-  Jump         L21
-L19:
-  Values       1,4,0,0
-  Move         r4, r10
-  Len          r9, r1
+  Const        r83, []
+  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
+  Const        r84, "o_orderdate"
+  Const        r85, "o_orderdate"
+  Const        r86, "s_nationkey"
+  Const        r87, "c_nationkey"
+  // nation: n.n_name,
+  Const        r88, "nation"
+  Const        r89, "n_name"
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r90, "revenue"
+  Const        r91, "l_extendedprice"
+  Const        r92, "l_discount"
+  // from c in customer
+  IterPrep     r93, r2
+  Len          r94, r93
+  Const        r95, 0
+L30:
+  LessInt      r97, r95, r94
+  JumpIfFalse  r97, L18
+  Index        r99, r93, r95
+  // join n in asia_nations on c.c_nationkey == n.n_nationkey
+  IterPrep     r100, r6
+  Len          r101, r100
+  Const        r102, "c_nationkey"
+  Const        r103, "n_nationkey"
+  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
+  Const        r104, "o_orderdate"
+  Const        r105, "o_orderdate"
+  Const        r106, "s_nationkey"
+  Const        r107, "c_nationkey"
+  // nation: n.n_name,
+  Const        r108, "nation"
+  Const        r109, "n_name"
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r110, "revenue"
+  Const        r111, "l_extendedprice"
+  Const        r112, "l_discount"
+  // join n in asia_nations on c.c_nationkey == n.n_nationkey
+  Const        r113, 0
+L29:
+  LessInt      r115, r113, r101
+  JumpIfFalse  r115, L19
+  Index        r19, r100, r113
+  Const        r117, "c_nationkey"
+  Index        r118, r99, r117
+  Const        r119, "n_nationkey"
+  Index        r120, r19, r119
+  Equal        r121, r118, r120
+  JumpIfFalse  r121, L20
+  // join o in orders on o.o_custkey == c.c_custkey
+  IterPrep     r122, r4
+  Len          r123, r122
+  Const        r124, "o_custkey"
+  Const        r125, "c_custkey"
+  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
+  Const        r126, "o_orderdate"
+  Const        r127, "o_orderdate"
+  Const        r128, "s_nationkey"
+  Const        r129, "c_nationkey"
+  // nation: n.n_name,
+  Const        r130, "nation"
+  Const        r131, "n_name"
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r132, "revenue"
+  Const        r133, "l_extendedprice"
+  Const        r134, "l_discount"
+  // join o in orders on o.o_custkey == c.c_custkey
+  Const        r135, 0
+L28:
+  LessInt      r137, r135, r123
+  JumpIfFalse  r137, L20
+  Index        r139, r122, r135
+  Const        r140, "o_custkey"
+  Index        r141, r139, r140
+  Const        r142, "c_custkey"
+  Index        r143, r99, r142
+  Equal        r144, r141, r143
+  JumpIfFalse  r144, L21
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  IterPrep     r145, r5
+  Len          r146, r145
+  Const        r147, "l_orderkey"
+  Const        r148, "o_orderkey"
+  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
+  Const        r149, "o_orderdate"
+  Const        r150, "o_orderdate"
+  Const        r151, "s_nationkey"
+  Const        r152, "c_nationkey"
+  // nation: n.n_name,
+  Const        r153, "nation"
+  Const        r154, "n_name"
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r155, "revenue"
+  Const        r156, "l_extendedprice"
+  Const        r157, "l_discount"
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  Const        r158, 0
 L27:
-  LessInt      r26, r4, r9
-  JumpIfFalse  r26, L22
-  Index        r26, r1, r4
-  // n_name: g.key,
-  Move         r1, r15
-  Index        r15, r26, r12
-  // revenue: sum(from x in g select x.revenue)
-  Move         r12, r21
-  Move         r9, r24
-  IterPrep     r11, r26
-  Len          r3, r11
-  Move         r20, r10
-L24:
-  LessInt      r2, r20, r3
-  JumpIfFalse  r2, L23
-  Index        r2, r11, r20
-  Index        r11, r2, r21
-  Append       r9, r9, r11
-  AddInt       r20, r20, r19
-  Jump         L24
-L23:
-  Sum          r11, r9
-  // n_name: g.key,
-  Move         r9, r1
-  Move         r1, r15
-  // revenue: sum(from x in g select x.revenue)
-  Move         r8, r12
-  Move         r12, r11
-  // select {
-  MakeMap      r11, 2, r9
-  // sort by -sum(from x in g select x.revenue)
-  Move         r12, r24
-  IterPrep     r1, r26
-  Len          r26, r1
-  Move         r9, r10
+  LessInt      r160, r158, r146
+  JumpIfFalse  r160, L21
+  Index        r162, r145, r158
+  Const        r163, "l_orderkey"
+  Index        r164, r162, r163
+  Const        r165, "o_orderkey"
+  Index        r166, r139, r165
+  Equal        r167, r164, r166
+  JumpIfFalse  r167, L22
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  IterPrep     r168, r3
+  Len          r169, r168
+  Const        r170, "s_suppkey"
+  Const        r171, "l_suppkey"
+  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
+  Const        r172, "o_orderdate"
+  Const        r173, "o_orderdate"
+  Const        r174, "s_nationkey"
+  Const        r175, "c_nationkey"
+  // nation: n.n_name,
+  Const        r176, "nation"
+  Const        r177, "n_name"
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r178, "revenue"
+  Const        r179, "l_extendedprice"
+  Const        r180, "l_discount"
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  Const        r181, 0
 L26:
-  LessInt      r10, r9, r26
-  JumpIfFalse  r10, L25
-  Index        r2, r1, r9
-  Index        r10, r2, r21
-  Append       r12, r12, r10
-  AddInt       r9, r9, r19
-  Jump         L26
+  LessInt      r183, r181, r169
+  JumpIfFalse  r183, L22
+  Index        r185, r168, r181
+  Const        r186, "s_suppkey"
+  Index        r187, r185, r186
+  Const        r188, "l_suppkey"
+  Index        r189, r162, r188
+  Equal        r190, r187, r189
+  JumpIfFalse  r190, L23
+  // where o.o_orderdate >= "1994-01-01" && o.o_orderdate < "1995-01-01" && s.s_nationkey == c.c_nationkey
+  Const        r191, "o_orderdate"
+  Index        r192, r139, r191
+  Const        r193, "1994-01-01"
+  LessEq       r194, r193, r192
+  Const        r195, "o_orderdate"
+  Index        r196, r139, r195
+  Const        r197, "1995-01-01"
+  Less         r198, r196, r197
+  Const        r199, "s_nationkey"
+  Index        r200, r185, r199
+  Const        r201, "c_nationkey"
+  Index        r202, r99, r201
+  Equal        r203, r200, r202
+  Move         r204, r194
+  JumpIfFalse  r204, L24
+L24:
+  Move         r205, r198
+  JumpIfFalse  r205, L25
+  Move         r205, r203
 L25:
-  Sum          r10, r12
-  Neg          r12, r10
-  // from r in local_customer_supplier_orders
-  Move         r10, r11
-  MakeList     r11, 2, r12
-  Append       r24, r24, r11
-  AddInt       r4, r4, r19
-  Jump         L27
+  JumpIfFalse  r205, L23
+  // nation: n.n_name,
+  Const        r206, "nation"
+  Const        r207, "n_name"
+  Index        r208, r19, r207
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Const        r209, "revenue"
+  Const        r210, "l_extendedprice"
+  Index        r211, r162, r210
+  Const        r212, 1
+  Const        r213, "l_discount"
+  Index        r214, r162, r213
+  Sub          r215, r212, r214
+  Mul          r216, r211, r215
+  // nation: n.n_name,
+  Move         r217, r206
+  Move         r218, r208
+  // revenue: l.l_extendedprice * (1 - l.l_discount)
+  Move         r219, r209
+  Move         r220, r216
+  // select {
+  MakeMap      r221, 2, r217
+  // from c in customer
+  Append       r83, r83, r221
+L23:
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  Const        r223, 1
+  Add          r181, r181, r223
+  Jump         L26
 L22:
+  // join l in lineitem on l.l_orderkey == o.o_orderkey
+  Const        r224, 1
+  Add          r158, r158, r224
+  Jump         L27
+L21:
+  // join o in orders on o.o_custkey == c.c_custkey
+  Const        r225, 1
+  Add          r135, r135, r225
+  Jump         L28
+L20:
+  // join n in asia_nations on c.c_nationkey == n.n_nationkey
+  Const        r226, 1
+  Add          r113, r113, r226
+  Jump         L29
+L19:
+  // from c in customer
+  Const        r227, 1
+  AddInt       r95, r95, r227
+  Jump         L30
+L18:
+  // from r in local_customer_supplier_orders
+  Const        r228, []
+  // group by r.nation into g
+  Const        r229, "nation"
+  // n_name: g.key,
+  Const        r230, "n_name"
+  Const        r231, "key"
+  // revenue: sum(from x in g select x.revenue)
+  Const        r232, "revenue"
+  Const        r233, "revenue"
   // sort by -sum(from x in g select x.revenue)
-  Sort         r24, r24
+  Const        r234, "revenue"
+  // from r in local_customer_supplier_orders
+  IterPrep     r235, r83
+  Len          r236, r235
+  Const        r237, 0
+  MakeMap      r238, 0, r0
+  Const        r239, []
+L33:
+  LessInt      r241, r237, r236
+  JumpIfFalse  r241, L31
+  Index        r242, r235, r237
+  Move         r31, r242
+  // group by r.nation into g
+  Const        r243, "nation"
+  Index        r244, r31, r243
+  Str          r245, r244
+  In           r246, r245, r238
+  JumpIfTrue   r246, L32
+  // from r in local_customer_supplier_orders
+  Const        r247, []
+  Const        r248, "__group__"
+  Const        r249, true
+  Const        r250, "key"
+  // group by r.nation into g
+  Move         r251, r244
+  // from r in local_customer_supplier_orders
+  Const        r252, "items"
+  Move         r253, r247
+  Const        r254, "count"
+  Const        r255, 0
+  Move         r256, r248
+  Move         r257, r249
+  Move         r258, r250
+  Move         r259, r251
+  Move         r260, r252
+  Move         r261, r253
+  Move         r262, r254
+  Move         r263, r255
+  MakeMap      r264, 4, r256
+  SetIndex     r238, r245, r264
+  Append       r239, r239, r264
+L32:
+  Const        r266, "items"
+  Index        r267, r238, r245
+  Index        r268, r267, r266
+  Append       r269, r268, r242
+  SetIndex     r267, r266, r269
+  Const        r270, "count"
+  Index        r271, r267, r270
+  Const        r272, 1
+  AddInt       r273, r271, r272
+  SetIndex     r267, r270, r273
+  Const        r274, 1
+  AddInt       r237, r237, r274
+  Jump         L33
+L31:
+  Const        r275, 0
+  Len          r277, r239
+L39:
+  LessInt      r278, r275, r277
+  JumpIfFalse  r278, L34
+  Index        r280, r239, r275
+  // n_name: g.key,
+  Const        r281, "n_name"
+  Const        r282, "key"
+  Index        r283, r280, r282
+  // revenue: sum(from x in g select x.revenue)
+  Const        r284, "revenue"
+  Const        r285, []
+  Const        r286, "revenue"
+  IterPrep     r287, r280
+  Len          r288, r287
+  Const        r289, 0
+L36:
+  LessInt      r291, r289, r288
+  JumpIfFalse  r291, L35
+  Index        r293, r287, r289
+  Const        r294, "revenue"
+  Index        r295, r293, r294
+  Append       r285, r285, r295
+  Const        r297, 1
+  AddInt       r289, r289, r297
+  Jump         L36
+L35:
+  Sum          r298, r285
+  // n_name: g.key,
+  Move         r299, r281
+  Move         r300, r283
+  // revenue: sum(from x in g select x.revenue)
+  Move         r301, r284
+  Move         r302, r298
+  // select {
+  MakeMap      r303, 2, r299
+  // sort by -sum(from x in g select x.revenue)
+  Const        r304, []
+  Const        r305, "revenue"
+  IterPrep     r306, r280
+  Len          r307, r306
+  Const        r308, 0
+L38:
+  LessInt      r310, r308, r307
+  JumpIfFalse  r310, L37
+  Index        r293, r306, r308
+  Const        r312, "revenue"
+  Index        r313, r293, r312
+  Append       r304, r304, r313
+  Const        r315, 1
+  AddInt       r308, r308, r315
+  Jump         L38
+L37:
+  Sum          r316, r304
+  Neg          r318, r316
+  // from r in local_customer_supplier_orders
+  Move         r319, r303
+  MakeList     r320, 2, r318
+  Append       r228, r228, r320
+  Const        r322, 1
+  AddInt       r275, r275, r322
+  Jump         L39
+L34:
+  // sort by -sum(from x in g select x.revenue)
+  Sort         r228, r228
   // json(result)
-  JSON         r24
+  JSON         r228
   // expect result == [
-  Const        r11, [{"n_name": "JAPAN", "revenue": 950}, {"n_name": "INDIA", "revenue": 720}]
-  Equal        r10, r24, r11
-  Expect       r10
+  Const        r324, [{"n_name": "JAPAN", "revenue": 950}, {"n_name": "INDIA", "revenue": 720}]
+  Equal        r325, r228, r324
+  Expect       r325
   Return       r0

--- a/tests/dataset/tpc-h/out/q6.ir.out
+++ b/tests/dataset/tpc-h/out/q6.ir.out
@@ -1,70 +1,89 @@
-func main (regs=11)
+func main (regs=56)
   // let lineitem = [
   Const        r0, [{"l_discount": 0.06, "l_extendedprice": 1000, "l_quantity": 10, "l_shipdate": "1994-02-15"}, {"l_discount": 0.07, "l_extendedprice": 500, "l_quantity": 23, "l_shipdate": "1994-03-10"}, {"l_discount": 0.04, "l_extendedprice": 400, "l_quantity": 15, "l_shipdate": "1994-04-10"}, {"l_discount": 0.06, "l_extendedprice": 200, "l_quantity": 5, "l_shipdate": "1995-01-01"}]
   // let result = from l in lineitem
   Const        r1, []
   // (l.l_shipdate >= "1994-01-01") &&
   Const        r2, "l_shipdate"
-  // (l.l_discount >= 0.05) &&
-  Const        r3, "l_discount"
-  // (l.l_quantity < 24)
-  Const        r4, "l_quantity"
-  // select sum(l.l_extendedprice * l.l_discount)
-  Const        r5, "l_extendedprice"
-  // let result = from l in lineitem
-  IterPrep     r6, r0
-  Len          r7, r6
-  Const        r8, 0
-L5:
-  LessInt      r9, r8, r7
-  JumpIfFalse  r9, L0
-  Index        r9, r6, r8
-  // (l.l_shipdate >= "1994-01-01") &&
-  Index        r6, r9, r2
-  Const        r7, "1994-01-01"
-  LessEq       r10, r7, r6
-  JumpIfFalse  r10, L1
   // (l.l_shipdate < "1995-01-01") &&
-  Index        r10, r9, r2
-  Const        r2, "1995-01-01"
-  Less         r7, r10, r2
-L1:
-  JumpIfFalse  r7, L2
+  Const        r3, "l_shipdate"
   // (l.l_discount >= 0.05) &&
-  Index        r7, r9, r3
-  Const        r2, 0.05
-  LessEqFloat  r10, r2, r7
-L2:
-  JumpIfFalse  r10, L3
+  Const        r4, "l_discount"
   // (l.l_discount <= 0.07) &&
-  Index        r10, r9, r3
-  Const        r2, 0.07
-  LessEqFloat  r7, r10, r2
-L3:
-  JumpIfFalse  r7, L4
+  Const        r5, "l_discount"
   // (l.l_quantity < 24)
-  Index        r2, r9, r4
-  Const        r4, 24
-  Less         r7, r2, r4
+  Const        r6, "l_quantity"
+  // select sum(l.l_extendedprice * l.l_discount)
+  Const        r7, "l_extendedprice"
+  Const        r8, "l_discount"
+  // let result = from l in lineitem
+  IterPrep     r9, r0
+  Len          r10, r9
+  Const        r11, 0
+L6:
+  LessInt      r13, r11, r10
+  JumpIfFalse  r13, L0
+  Index        r15, r9, r11
+  // (l.l_shipdate >= "1994-01-01") &&
+  Const        r16, "l_shipdate"
+  Index        r17, r15, r16
+  Const        r18, "1994-01-01"
+  LessEq       r20, r18, r17
+  JumpIfFalse  r20, L1
+  // (l.l_shipdate < "1995-01-01") &&
+  Const        r21, "l_shipdate"
+  Index        r22, r15, r21
+  Const        r23, "1995-01-01"
+  Less         r25, r22, r23
+L1:
+  JumpIfFalse  r25, L2
+  // (l.l_discount >= 0.05) &&
+  Const        r26, "l_discount"
+  Index        r27, r15, r26
+  Const        r28, 0.05
+  LessEqFloat  r30, r28, r27
+L2:
+  JumpIfFalse  r30, L3
+  // (l.l_discount <= 0.07) &&
+  Const        r31, "l_discount"
+  Index        r32, r15, r31
+  Const        r33, 0.07
+  LessEqFloat  r35, r32, r33
+L3:
+  JumpIfFalse  r35, L4
+  // (l.l_quantity < 24)
+  Const        r36, "l_quantity"
+  Index        r37, r15, r36
+  Const        r38, 24
+  Less         r35, r37, r38
 L4:
   // (l.l_shipdate >= "1994-01-01") &&
-  JumpIfFalse  r7, L5
+  JumpIfFalse  r35, L5
   // select sum(l.l_extendedprice * l.l_discount)
-  Index        r4, r9, r5
-  Index        r5, r9, r3
-  Mul          r9, r4, r5
+  Const        r40, "l_extendedprice"
+  Index        r41, r15, r40
+  Const        r42, "l_discount"
+  Index        r43, r15, r42
+  Mul          r44, r41, r43
   // let result = from l in lineitem
-  Append       r1, r1, r9
-  Const        r9, 1
-  AddInt       r8, r8, r9
-  Jump         L5
+  Append       r1, r1, r44
+L5:
+  Const        r46, 1
+  AddInt       r11, r11, r46
+  Jump         L6
 L0:
   // select sum(l.l_extendedprice * l.l_discount)
-  Sum          r9, r1
+  Sum          r47, r1
   // json(result)
-  JSON         r9
+  JSON         r47
   // expect result == ((1000.0 * 0.06) + (500.0 * 0.07)) // 60 + 35 = 95
-  Const        r1, 95
-  EqualFloat   r8, r9, r1
-  Expect       r8
+  Const        r48, 1000
+  Const        r49, 0.06
+  Const        r50, 60
+  Const        r51, 500
+  Const        r52, 0.07
+  Const        r53, 35
+  Const        r54, 95
+  EqualFloat   r55, r47, r54
+  Expect       r55
   Return       r0

--- a/tests/dataset/tpc-h/out/q7.ir.out
+++ b/tests/dataset/tpc-h/out/q7.ir.out
@@ -1,11 +1,10 @@
-func main (regs=38)
+func main (regs=262)
   // let nation = [
   Const        r0, [{"n_name": "FRANCE", "n_nationkey": 1}, {"n_name": "GERMANY", "n_nationkey": 2}]
   // let supplier = [
   Const        r1, [{"s_nationkey": 1, "s_suppkey": 100}]
   // let customer = [
   Const        r2, [{"c_custkey": 200, "c_nationkey": 2}]
-L8:
   // let orders = [
   Const        r3, [{"o_custkey": 200, "o_orderkey": 1000}]
   // let lineitem = [
@@ -20,286 +19,357 @@ L8:
   Const        r8, "GERMANY"
   // from l in lineitem
   Const        r9, []
-L3:
   // supp_nation: n1.n_name,
   Const        r10, "supp_nation"
   Const        r11, "n_name"
   // cust_nation: n2.n_name,
   Const        r12, "cust_nation"
-L18:
+  Const        r13, "n_name"
   // l_year: substring(l.l_shipdate, 0, 4)
-  Const        r13, "l_year"
-  Const        r14, "l_shipdate"
-L2:
-  // supp_nation: g.key.supp_nation,
-  Const        r15, "key"
-L1:
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Const        r16, "revenue"
-  Const        r17, "l"
-  Const        r18, "l_extendedprice"
-  Const        r19, "l_discount"
-  // from l in lineitem
-  MakeMap      r20, 0, r0
-L5:
-  IterPrep     r21, r4
-L0:
-  Len          r4, r21
-L14:
-  Const        r22, 0
-L4:
-  LessInt      r23, r22, r4
-L17:
-  JumpIfFalse  r23, L0
-  Index        r24, r21, r22
-  Move         r25, r24
-L9:
-  // join o in orders on o.o_orderkey == l.l_orderkey
-  IterPrep     r26, r3
-L12:
-  Len          r3, r26
-L13:
-  Move         r27, r22
-  LessInt      r28, r27, r3
-  JumpIfFalse  r28, L1
-L11:
-  Index        r28, r26, r27
-  Const        r29, "o_orderkey"
-L6:
-  Index        r30, r28, r29
-L10:
-  Const        r29, "l_orderkey"
-  Index        r31, r25, r29
-  Equal        r29, r30, r31
-  JumpIfFalse  r29, L2
-  // join c in customer on c.c_custkey == o.o_custkey
-  IterPrep     r29, r2
-  Len          r2, r29
-  Move         r31, r22
-  LessInt      r30, r31, r2
-  JumpIfFalse  r30, L2
-  Index        r30, r29, r31
-  Const        r29, "c_custkey"
-  Index        r2, r30, r29
-  Const        r29, "o_custkey"
-  Index        r32, r28, r29
-  Equal        r29, r2, r32
-  JumpIfFalse  r29, L3
-  // join s in supplier on s.s_suppkey == l.l_suppkey
-  IterPrep     r29, r1
-  Len          r1, r29
-  Move         r32, r31
-  LessInt      r2, r32, r1
-  JumpIfFalse  r2, L3
-  Index        r2, r29, r32
-  Const        r29, "s_suppkey"
-  Index        r1, r2, r29
-  Const        r28, "l_suppkey"
-  Index        r33, r25, r28
-  Equal        r28, r1, r33
-  JumpIfFalse  r28, L3
-  // join n1 in nation on n1.n_nationkey == s.s_nationkey
-  IterPrep     r28, r0
-  Len          r33, r28
-  Move         r1, r22
-  LessInt      r34, r1, r33
-  JumpIfFalse  r34, L3
-  Index        r34, r28, r1
-  Const        r28, "n_nationkey"
-  Index        r33, r34, r28
-  Const        r35, "s_nationkey"
-  Index        r36, r2, r35
-  Equal        r35, r33, r36
-  JumpIfFalse  r35, L4
-  // join n2 in nation on n2.n_nationkey == c.c_nationkey
-  IterPrep     r35, r0
-  Len          r36, r35
-  Move         r2, r1
-  LessInt      r37, r2, r36
-  JumpIfFalse  r37, L4
-  Index        r37, r35, r2
-  Index        r35, r37, r28
-  Const        r28, "c_nationkey"
-  Index        r36, r30, r28
-  Equal        r28, r35, r36
-  JumpIfFalse  r28, L5
+  Const        r14, "l_year"
+  Const        r15, "l_shipdate"
   // l.l_shipdate >= start_date && l.l_shipdate <= end_date &&
-  Index        r28, r25, r14
-  LessEq       r35, r5, r28
-  Index        r28, r25, r14
-  LessEq       r5, r28, r6
-  Move         r28, r35
-  JumpIfFalse  r28, L6
-  Move         r28, r5
-  JumpIfFalse  r28, L7
+  Const        r16, "l_shipdate"
+  Const        r17, "l_shipdate"
   // (n1.n_name == nation1 && n2.n_name == nation2) ||
-  Index        r28, r34, r11
-  Equal        r5, r28, r7
-  Index        r28, r37, r11
-  Equal        r35, r28, r8
-  Move         r28, r5
-  JumpIfFalse  r28, L7
-L7:
-  Move         r28, r35
-  JumpIfTrue   r28, L8
+  Const        r18, "n_name"
+  Const        r19, "n_name"
   // (n1.n_name == nation2 && n2.n_name == nation1)
-  Index        r35, r34, r11
-  Equal        r5, r35, r8
-  Index        r35, r37, r11
-  Equal        r8, r35, r7
-  Move         r35, r5
-  JumpIfFalse  r35, L6
-  // (n1.n_name == nation1 && n2.n_name == nation2) ||
-  Move         r28, r8
-  // where (
-  JumpIfFalse  r28, L5
+  Const        r20, "n_name"
+  Const        r21, "n_name"
+  // supp_nation: g.key.supp_nation,
+  Const        r22, "supp_nation"
+  Const        r23, "key"
+  Const        r24, "supp_nation"
+  // cust_nation: g.key.cust_nation,
+  Const        r25, "cust_nation"
+  Const        r26, "key"
+  Const        r27, "cust_nation"
+  // l_year: g.key.l_year,
+  Const        r28, "l_year"
+  Const        r29, "key"
+  Const        r30, "l_year"
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Const        r31, "revenue"
+  Const        r32, "l"
+  Const        r33, "l_extendedprice"
+  Const        r34, "l"
+  Const        r35, "l_discount"
   // from l in lineitem
-  MakeMap      r35, 6, r17
-  // supp_nation: n1.n_name,
-  Move         r3, r10
-  Index        r26, r34, r11
-  // cust_nation: n2.n_name,
-  Move         r34, r12
-  Index        r24, r37, r11
-  // l_year: substring(l.l_shipdate, 0, 4)
-  Move         r37, r13
-  Index        r11, r25, r14
-  Move         r25, r1
-  Const        r14, 4
-  Slice        r4, r11, r25, r14
-  // supp_nation: n1.n_name,
-  Move         r14, r3
-  Move         r3, r26
-  // cust_nation: n2.n_name,
-  Move         r26, r34
-  Move         r34, r24
-  // l_year: substring(l.l_shipdate, 0, 4)
-  Move         r24, r37
-  Move         r37, r4
-  // group by {
-  MakeMap      r4, 3, r14
-  Str          r37, r4
-  In           r24, r37, r20
-  JumpIfTrue   r24, L9
-  // from l in lineitem
-  Move         r24, r9
-  Const        r34, "__group__"
-  Const        r26, true
-  Move         r3, r15
-  // group by {
-  Move         r14, r4
-  // from l in lineitem
-  Const        r4, "items"
-  Move         r11, r24
-  Const        r24, "count"
-  Move         r21, r25
-  Move         r8, r34
-  Move         r34, r26
-  Move         r26, r3
-  Move         r3, r14
-  Move         r14, r4
-  Move         r5, r11
-  Move         r11, r24
-  Move         r28, r21
-  MakeMap      r21, 4, r8
-  SetIndex     r20, r37, r21
-  Move         r21, r4
-  Index        r4, r20, r37
-  Index        r37, r4, r21
-  Append       r28, r37, r35
-  SetIndex     r4, r21, r28
-  Move         r28, r24
-  Index        r24, r4, r28
-  Const        r37, 1
-  AddInt       r21, r24, r37
-  SetIndex     r4, r28, r21
-  // join n2 in nation on n2.n_nationkey == c.c_nationkey
-  AddInt       r2, r2, r37
-  Jump         L10
-  // join n1 in nation on n1.n_nationkey == s.s_nationkey
-  AddInt       r1, r1, r37
-  Jump         L11
-  // join s in supplier on s.s_suppkey == l.l_suppkey
-  AddInt       r32, r32, r37
-  Jump         L12
-  // join c in customer on c.c_custkey == o.o_custkey
-  AddInt       r31, r31, r37
-  Jump         L13
+  MakeMap      r36, 0, r0
+  Const        r37, []
+  IterPrep     r39, r4
+  Len          r40, r39
+  Const        r41, 0
+L17:
+  LessInt      r42, r41, r40
+  JumpIfFalse  r42, L0
+  Index        r44, r39, r41
   // join o in orders on o.o_orderkey == l.l_orderkey
-  AddInt       r27, r27, r37
-  Jump         L5
-  // from l in lineitem
-  AddInt       r22, r22, r37
-  Jump         L14
-  Values       21,20,0,0
-  Move         r20, r25
-  Len          r23, r21
-  LessInt      r22, r20, r23
-  JumpIfFalse  r22, L15
-  Index        r22, r21, r20
-  // supp_nation: g.key.supp_nation,
-  Move         r21, r10
-  Index        r23, r22, r15
-  Index        r24, r23, r10
-  // cust_nation: g.key.cust_nation,
-  Move         r23, r12
-  Index        r10, r22, r15
-  Index        r28, r10, r12
-  // l_year: g.key.l_year,
-  Move         r10, r13
-  Index        r12, r22, r15
-  Index        r15, r12, r13
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Move         r12, r16
-  Move         r16, r9
-  IterPrep     r13, r22
-  Len          r22, r13
-  Move         r4, r25
-  LessInt      r25, r4, r22
-  JumpIfFalse  r25, L16
-  Index        r25, r13, r4
-  Index        r13, r25, r17
-  Index        r22, r13, r18
-  Index        r13, r25, r17
-  Index        r25, r13, r19
-  Sub          r13, r37, r25
-  Mul          r25, r22, r13
-  Append       r16, r16, r25
-  AddInt       r4, r4, r37
-  Jump         L17
+  IterPrep     r45, r3
+  Len          r46, r45
+  Const        r47, 0
 L16:
-  Sum          r13, r16
-  // supp_nation: g.key.supp_nation,
-  Move         r16, r21
-  Move         r21, r24
-  // cust_nation: g.key.cust_nation,
-  Move         r24, r23
-  Move         r23, r28
-  // l_year: g.key.l_year,
-  Move         r28, r10
-  Move         r10, r15
-  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Move         r15, r12
-  Move         r25, r13
-  // select {
-  MakeMap      r13, 4, r16
-  // sort by [supp_nation, cust_nation, l_year]
-  Move         r10, r15
-  Move         r28, r15
-  MakeList     r23, 3, r10
-  // from l in lineitem
-  Move         r28, r13
-  MakeList     r13, 2, r23
-  Append       r9, r9, r13
-  AddInt       r20, r20, r37
-  Jump         L18
+  LessInt      r48, r47, r46
+  JumpIfFalse  r48, L1
+  Index        r50, r45, r47
+  Const        r51, "o_orderkey"
+  Index        r52, r50, r51
+  Const        r53, "l_orderkey"
+  Index        r54, r44, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L2
+  // join c in customer on c.c_custkey == o.o_custkey
+  IterPrep     r56, r2
+  Len          r57, r56
+  Const        r58, 0
 L15:
+  LessInt      r59, r58, r57
+  JumpIfFalse  r59, L2
+  Index        r61, r56, r58
+  Const        r62, "c_custkey"
+  Index        r63, r61, r62
+  Const        r64, "o_custkey"
+  Index        r65, r50, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L3
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  IterPrep     r67, r1
+  Len          r68, r67
+  Const        r69, 0
+L14:
+  LessInt      r70, r69, r68
+  JumpIfFalse  r70, L3
+  Index        r72, r67, r69
+  Const        r73, "s_suppkey"
+  Index        r74, r72, r73
+  Const        r75, "l_suppkey"
+  Index        r76, r44, r75
+  Equal        r77, r74, r76
+  JumpIfFalse  r77, L4
+  // join n1 in nation on n1.n_nationkey == s.s_nationkey
+  IterPrep     r78, r0
+  Len          r79, r78
+  Const        r80, 0
+L13:
+  LessInt      r81, r80, r79
+  JumpIfFalse  r81, L4
+  Index        r83, r78, r80
+  Const        r84, "n_nationkey"
+  Index        r85, r83, r84
+  Const        r86, "s_nationkey"
+  Index        r87, r72, r86
+  Equal        r88, r85, r87
+  JumpIfFalse  r88, L5
+  // join n2 in nation on n2.n_nationkey == c.c_nationkey
+  IterPrep     r89, r0
+  Len          r90, r89
+  Const        r91, 0
+L12:
+  LessInt      r92, r91, r90
+  JumpIfFalse  r92, L5
+  Index        r94, r89, r91
+  Const        r95, "n_nationkey"
+  Index        r96, r94, r95
+  Const        r97, "c_nationkey"
+  Index        r98, r61, r97
+  Equal        r99, r96, r98
+  JumpIfFalse  r99, L6
+  // l.l_shipdate >= start_date && l.l_shipdate <= end_date &&
+  Const        r100, "l_shipdate"
+  Index        r101, r44, r100
+  LessEq       r102, r5, r101
+  Const        r103, "l_shipdate"
+  Index        r104, r44, r103
+  LessEq       r105, r104, r6
+  Move         r106, r102
+  JumpIfFalse  r106, L7
+L7:
+  Move         r107, r105
+  JumpIfFalse  r107, L8
+  // (n1.n_name == nation1 && n2.n_name == nation2) ||
+  Const        r108, "n_name"
+  Index        r109, r83, r108
+  Equal        r110, r109, r7
+  Const        r111, "n_name"
+  Index        r112, r94, r111
+  Equal        r113, r112, r8
+  Move         r114, r110
+  JumpIfFalse  r114, L8
+L8:
+  Move         r115, r113
+  JumpIfTrue   r115, L9
+  // (n1.n_name == nation2 && n2.n_name == nation1)
+  Const        r116, "n_name"
+  Index        r117, r83, r116
+  Equal        r118, r117, r8
+  Const        r119, "n_name"
+  Index        r120, r94, r119
+  Equal        r121, r120, r7
+  Move         r122, r118
+  JumpIfFalse  r122, L10
+L10:
+  // (n1.n_name == nation1 && n2.n_name == nation2) ||
+  Move         r115, r121
+L9:
+  // where (
+  JumpIfFalse  r115, L6
+  // from l in lineitem
+  Const        r123, "l"
+  Move         r124, r44
+  Const        r125, "o"
+  Move         r126, r50
+  Const        r127, "c"
+  Move         r128, r61
+  Const        r129, "s"
+  Move         r130, r72
+  Const        r131, "n1"
+  Move         r132, r83
+  Const        r133, "n2"
+  Move         r134, r94
+  MakeMap      r135, 6, r123
+  // supp_nation: n1.n_name,
+  Const        r136, "supp_nation"
+  Const        r137, "n_name"
+  Index        r138, r83, r137
+  // cust_nation: n2.n_name,
+  Const        r139, "cust_nation"
+  Const        r140, "n_name"
+  Index        r141, r94, r140
+  // l_year: substring(l.l_shipdate, 0, 4)
+  Const        r142, "l_year"
+  Const        r143, "l_shipdate"
+  Index        r144, r44, r143
+  Const        r145, 0
+  Const        r146, 4
+  Slice        r147, r144, r145, r146
+  // supp_nation: n1.n_name,
+  Move         r148, r136
+  Move         r149, r138
+  // cust_nation: n2.n_name,
+  Move         r150, r139
+  Move         r151, r141
+  // l_year: substring(l.l_shipdate, 0, 4)
+  Move         r152, r142
+  Move         r153, r147
+  // group by {
+  MakeMap      r154, 3, r148
+  Str          r155, r154
+  In           r156, r155, r36
+  JumpIfTrue   r156, L11
+  // from l in lineitem
+  Const        r157, []
+  Const        r158, "__group__"
+  Const        r159, true
+  Const        r160, "key"
+  // group by {
+  Move         r161, r154
+  // from l in lineitem
+  Const        r162, "items"
+  Move         r163, r157
+  Const        r164, "count"
+  Const        r165, 0
+  Move         r166, r158
+  Move         r167, r159
+  Move         r168, r160
+  Move         r169, r161
+  Move         r170, r162
+  Move         r171, r163
+  Move         r172, r164
+  Move         r173, r165
+  MakeMap      r174, 4, r166
+  SetIndex     r36, r155, r174
+  Append       r37, r37, r174
+L11:
+  Const        r176, "items"
+  Index        r177, r36, r155
+  Index        r178, r177, r176
+  Append       r179, r178, r135
+  SetIndex     r177, r176, r179
+  Const        r180, "count"
+  Index        r181, r177, r180
+  Const        r182, 1
+  AddInt       r183, r181, r182
+  SetIndex     r177, r180, r183
+L6:
+  // join n2 in nation on n2.n_nationkey == c.c_nationkey
+  Const        r184, 1
+  AddInt       r91, r91, r184
+  Jump         L12
+L5:
+  // join n1 in nation on n1.n_nationkey == s.s_nationkey
+  Const        r185, 1
+  AddInt       r80, r80, r185
+  Jump         L13
+L4:
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  Const        r186, 1
+  AddInt       r69, r69, r186
+  Jump         L14
+L3:
+  // join c in customer on c.c_custkey == o.o_custkey
+  Const        r187, 1
+  AddInt       r58, r58, r187
+  Jump         L15
+L2:
+  // join o in orders on o.o_orderkey == l.l_orderkey
+  Const        r188, 1
+  AddInt       r47, r47, r188
+  Jump         L16
+L1:
+  // from l in lineitem
+  Const        r189, 1
+  AddInt       r41, r41, r189
+  Jump         L17
+L0:
+  Const        r190, 0
+  Len          r192, r37
+L21:
+  LessInt      r193, r190, r192
+  JumpIfFalse  r193, L18
+  Index        r195, r37, r190
+  // supp_nation: g.key.supp_nation,
+  Const        r196, "supp_nation"
+  Const        r197, "key"
+  Index        r198, r195, r197
+  Const        r199, "supp_nation"
+  Index        r200, r198, r199
+  // cust_nation: g.key.cust_nation,
+  Const        r201, "cust_nation"
+  Const        r202, "key"
+  Index        r203, r195, r202
+  Const        r204, "cust_nation"
+  Index        r205, r203, r204
+  // l_year: g.key.l_year,
+  Const        r206, "l_year"
+  Const        r207, "key"
+  Index        r208, r195, r207
+  Const        r209, "l_year"
+  Index        r210, r208, r209
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Const        r211, "revenue"
+  Const        r212, []
+  Const        r213, "l"
+  Const        r214, "l_extendedprice"
+  Const        r215, "l"
+  Const        r216, "l_discount"
+  IterPrep     r217, r195
+  Len          r218, r217
+  Const        r219, 0
+L20:
+  LessInt      r221, r219, r218
+  JumpIfFalse  r221, L19
+  Index        r223, r217, r219
+  Const        r224, "l"
+  Index        r225, r223, r224
+  Const        r226, "l_extendedprice"
+  Index        r227, r225, r226
+  Const        r228, 1
+  Const        r229, "l"
+  Index        r230, r223, r229
+  Const        r231, "l_discount"
+  Index        r232, r230, r231
+  Sub          r233, r228, r232
+  Mul          r234, r227, r233
+  Append       r212, r212, r234
+  Const        r236, 1
+  AddInt       r219, r219, r236
+  Jump         L20
+L19:
+  Sum          r237, r212
+  // supp_nation: g.key.supp_nation,
+  Move         r238, r196
+  Move         r239, r200
+  // cust_nation: g.key.cust_nation,
+  Move         r240, r201
+  Move         r241, r205
+  // l_year: g.key.l_year,
+  Move         r242, r206
+  Move         r243, r210
+  // revenue: sum(from x in g select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Move         r244, r211
+  Move         r245, r237
+  // select {
+  MakeMap      r246, 4, r238
+  // sort by [supp_nation, cust_nation, l_year]
+  Move         r248, r247
+  Move         r250, r249
+  Move         r252, r251
+  MakeList     r254, 3, r248
+  // from l in lineitem
+  Move         r255, r246
+  MakeList     r256, 2, r254
+  Append       r9, r9, r256
+  Const        r258, 1
+  AddInt       r190, r190, r258
+  Jump         L21
+L18:
   // sort by [supp_nation, cust_nation, l_year]
   Sort         r9, r9
   // json(result)
   JSON         r9
   // expect result == [
-  Const        r13, [{"cust_nation": "GERMANY", "l_year": "1995", "revenue": 900, "supp_nation": "FRANCE"}]
-  Equal        r28, r9, r13
-  Expect       r28
+  Const        r260, [{"cust_nation": "GERMANY", "l_year": "1995", "revenue": 900, "supp_nation": "FRANCE"}]
+  Equal        r261, r9, r260
+  Expect       r261
   Return       r0

--- a/tests/dataset/tpc-h/out/q8.ir.out
+++ b/tests/dataset/tpc-h/out/q8.ir.out
@@ -1,20 +1,16 @@
-func main (regs=44)
+func main (regs=283)
   // let region = [
   Const        r0, [{"r_name": "AMERICA", "r_regionkey": 0}]
-L2:
   // let nation = [
   Const        r1, [{"n_name": "BRAZIL", "n_nationkey": 10, "n_regionkey": 0}, {"n_name": "CANADA", "n_nationkey": 20, "n_regionkey": 0}]
-L12:
   // let customer = [
   Const        r2, [{"c_custkey": 1, "c_nationkey": 10}, {"c_custkey": 2, "c_nationkey": 20}]
-L16:
   // let orders = [
   Const        r3, [{"o_custkey": 1, "o_orderdate": "1995-04-10", "o_orderkey": 100}, {"o_custkey": 2, "o_orderdate": "1995-07-15", "o_orderkey": 200}]
   // let lineitem = [
   Const        r4, [{"l_discount": 0.1, "l_extendedprice": 1000, "l_orderkey": 100, "l_partkey": 5000, "l_suppkey": 1000}, {"l_discount": 0.05, "l_extendedprice": 500, "l_orderkey": 200, "l_partkey": 5000, "l_suppkey": 2000}]
   // let supplier = [
   Const        r5, [{"s_suppkey": 1000}, {"s_suppkey": 2000}]
-L0:
   // let part = [
   Const        r6, [{"p_partkey": 5000, "p_type": "ECONOMY ANODIZED STEEL"}, {"p_partkey": 6000, "p_type": "SMALL BRASS"}]
   // let start_date = "1995-01-01"
@@ -27,290 +23,385 @@ L0:
   Const        r10, "BRAZIL"
   // from l in lineitem
   Const        r11, []
-L9:
   // group by substring(o.o_orderdate, 0, 4) into year
   Const        r12, "o_orderdate"
   // where (p.p_type == target_type && o.o_orderdate >= start_date && o.o_orderdate <= end_date && r.r_name == "AMERICA")
   Const        r13, "p_type"
-L4:
-  Const        r14, "r_name"
+  Const        r14, "o_orderdate"
+  Const        r15, "o_orderdate"
+  Const        r16, "r_name"
   // o_year: year.key,
-  Const        r15, "o_year"
-  Const        r16, "key"
+  Const        r17, "o_year"
+  Const        r18, "key"
   // mkt_share:
-  Const        r17, "mkt_share"
-L18:
+  Const        r19, "mkt_share"
   // sum(from x in year select match x.n.n_name == target_nation {
-  Const        r18, "n"
-  Const        r19, "n_name"
+  Const        r20, "n"
+  Const        r21, "n_name"
   // true => x.l.l_extendedprice * (1 - x.l.l_discount)
-  Const        r20, "l"
-  Const        r21, "l_extendedprice"
-  Const        r22, "l_discount"
-  // from l in lineitem
-  MakeMap      r23, 0, r0
-  IterPrep     r24, r4
-  Len          r4, r24
-L15:
-  Const        r25, 0
-  LessInt      r26, r25, r4
-  JumpIfFalse  r26, L0
-  Index        r27, r24, r25
-  Move         r28, r27
-L3:
-  // join from p in part on p.p_partkey == l.l_partkey
-  IterPrep     r29, r6
-  Len          r6, r29
-L13:
-  Move         r30, r25
-L14:
-  LessInt      r31, r30, r6
-  JumpIfFalse  r31, L0
-  Index        r32, r29, r30
-L11:
-  Const        r33, "p_partkey"
-  Index        r34, r32, r33
-  Const        r33, "l_partkey"
-  Index        r35, r28, r33
-  Equal        r33, r34, r35
-  JumpIfFalse  r33, L1
-L10:
-  // join from s in supplier on s.s_suppkey == l.l_suppkey
-  IterPrep     r33, r5
-  Len          r5, r33
-  Move         r35, r25
-  LessInt      r34, r35, r5
-  JumpIfFalse  r34, L1
-  Index        r34, r33, r35
-  Const        r33, "s_suppkey"
-  Index        r5, r34, r33
-  Const        r33, "l_suppkey"
-  Index        r36, r28, r33
-  Equal        r33, r5, r36
-  JumpIfFalse  r33, L2
-  // join from o in orders on o.o_orderkey == l.l_orderkey
-  IterPrep     r33, r3
-  Len          r3, r33
-  Move         r36, r35
-  LessInt      r5, r36, r3
-  JumpIfFalse  r5, L2
-  Index        r5, r33, r36
-  Const        r33, "o_orderkey"
-  Index        r3, r5, r33
-  Const        r37, "l_orderkey"
-  Index        r38, r28, r37
-  Equal        r37, r3, r38
-  JumpIfFalse  r37, L0
-  // join from c in customer on c.c_custkey == o.o_custkey
-  IterPrep     r37, r2
-  Len          r2, r37
-  Move         r38, r25
-  LessInt      r3, r38, r2
-  JumpIfFalse  r3, L0
-  Index        r3, r37, r38
-  Const        r37, "c_custkey"
-  Index        r2, r3, r37
-  Const        r37, "o_custkey"
-  Index        r39, r5, r37
-  Equal        r37, r2, r39
-  JumpIfFalse  r37, L3
-  // join from n in nation on n.n_nationkey == c.c_nationkey
-  IterPrep     r37, r1
-  Len          r1, r37
-  Move         r39, r38
-  LessInt      r40, r39, r1
-  JumpIfFalse  r40, L3
-  Index        r40, r37, r39
-  Const        r37, "n_nationkey"
-  Index        r1, r40, r37
-  Const        r37, "c_nationkey"
-  Index        r41, r3, r37
-  Equal        r3, r1, r41
-  JumpIfFalse  r3, L4
-  // join from r in region on r.r_regionkey == n.n_regionkey
-  IterPrep     r3, r0
-  Len          r41, r3
-  Move         r1, r38
-  LessInt      r42, r1, r41
-  JumpIfFalse  r42, L4
-  Index        r42, r3, r1
-  Const        r3, "r_regionkey"
-  Index        r41, r42, r3
-  Const        r3, "n_regionkey"
-  Index        r43, r40, r3
-  Equal        r3, r41, r43
-  JumpIfFalse  r3, L5
-  // where (p.p_type == target_type && o.o_orderdate >= start_date && o.o_orderdate <= end_date && r.r_name == "AMERICA")
-  Index        r3, r32, r13
-  Index        r32, r5, r12
-  LessEq       r13, r7, r32
-  Index        r32, r5, r12
-  LessEq       r7, r32, r8
-  Equal        r32, r3, r9
-  Index        r3, r42, r14
-  Const        r42, "AMERICA"
-  Equal        r14, r3, r42
-  Move         r42, r32
-  JumpIfFalse  r42, L6
-L6:
-  Move         r42, r13
-  JumpIfFalse  r42, L7
-L7:
-  Move         r42, r7
-  JumpIfFalse  r42, L8
-  Move         r42, r14
-L8:
-  JumpIfFalse  r42, L5
-  // from l in lineitem
-  MakeMap      r42, 7, r20
-  // group by substring(o.o_orderdate, 0, 4) into year
-  Index        r31, r5, r12
-  Move         r5, r1
-  Const        r12, 4
-  Slice        r6, r31, r5, r12
-  Str          r12, r6
-  In           r31, r12, r23
-  JumpIfTrue   r31, L9
-  // from l in lineitem
-  Move         r31, r11
-  Const        r29, "__group__"
-  Const        r28, true
-  Move         r27, r16
-  // group by substring(o.o_orderdate, 0, 4) into year
-  Move         r4, r6
-  // from l in lineitem
-  Const        r6, "items"
-  Move         r24, r31
-  Const        r31, "count"
-  Move         r14, r25
-  Move         r7, r29
-  Move         r29, r28
-  Move         r13, r27
-  Move         r27, r4
-  Move         r4, r6
-  Move         r32, r24
-  Move         r24, r31
-  Move         r3, r14
-  MakeMap      r14, 4, r7
-  SetIndex     r23, r12, r14
-  Move         r14, r6
-  Index        r6, r23, r12
-  Index        r12, r6, r14
-  Append       r3, r12, r42
-  SetIndex     r6, r14, r3
-  Move         r3, r31
-  Index        r31, r6, r3
-  Const        r12, 1
-  AddInt       r14, r31, r12
-  SetIndex     r6, r3, r14
-L5:
-  // join from r in region on r.r_regionkey == n.n_regionkey
-  AddInt       r1, r1, r12
-  Jump         L10
-  // join from n in nation on n.n_nationkey == c.c_nationkey
-  AddInt       r39, r39, r12
-  Jump         L11
-  // join from c in customer on c.c_custkey == o.o_custkey
-  AddInt       r38, r38, r12
-  Jump         L12
-  // join from o in orders on o.o_orderkey == l.l_orderkey
-  AddInt       r36, r36, r12
-  Jump         L13
-  // join from s in supplier on s.s_suppkey == l.l_suppkey
-  AddInt       r35, r35, r12
-  Jump         L14
-L1:
-  // join from p in part on p.p_partkey == l.l_partkey
-  AddInt       r30, r30, r12
-  Jump         L4
-  // from l in lineitem
-  AddInt       r25, r25, r12
-  Jump         L15
-  Values       14,23,0,0
-  Move         r23, r5
-  Len          r26, r14
-  LessInt      r25, r23, r26
-  JumpIfFalse  r25, L16
-  Index        r25, r14, r23
-  // o_year: year.key,
-  Move         r14, r15
-  Index        r26, r25, r16
-  // mkt_share:
-  Move         r31, r17
-  // sum(from x in year select match x.n.n_name == target_nation {
-  Move         r3, r11
-  IterPrep     r6, r25
-  Len          r43, r6
-  Move         r1, r5
-  LessInt      r37, r1, r43
-  JumpIfFalse  r37, L17
-  Index        r37, r6, r1
-  Index        r6, r37, r18
-  Index        r18, r6, r19
-  Equal        r6, r18, r10
-  // true => x.l.l_extendedprice * (1 - x.l.l_discount)
-  Equal        r18, r6, r28
-  JumpIfFalse  r18, L11
-  // sum(from x in year select match x.n.n_name == target_nation {
-  Append       r3, r3, r5
-  AddInt       r1, r1, r12
-  Jump         L18
-L17:
-  Sum          r6, r3
+  Const        r22, "l"
+  Const        r23, "l_extendedprice"
+  Const        r24, "l"
+  Const        r25, "l_discount"
   // sum(from x in year select x.l.l_extendedprice * (1 - x.l.l_discount))
-  Move         r3, r11
-  IterPrep     r18, r25
-  Len          r1, r18
-  Move         r28, r5
-  LessInt      r5, r28, r1
-  JumpIfFalse  r5, L19
-  Index        r37, r18, r28
-  Index        r5, r37, r20
-  Index        r1, r5, r21
-  Index        r5, r37, r20
-  Index        r37, r5, r22
-  Sub          r5, r12, r37
-  Mul          r37, r1, r5
-  Append       r3, r3, r37
-  AddInt       r28, r28, r12
-  Jump         L11
-L19:
-  Sum          r5, r3
-  // }) /
-  Div          r3, r6, r5
-  // o_year: year.key,
-  Move         r5, r14
-  Move         r14, r26
-  // mkt_share:
-  Move         r37, r31
-  Move         r31, r3
-  // select {
-  MakeMap      r3, 2, r5
+  Const        r26, "l"
+  Const        r27, "l_extendedprice"
+  Const        r28, "l"
+  Const        r29, "l_discount"
   // sort by year.key
-  Index        r31, r25, r16
+  Const        r30, "key"
   // from l in lineitem
-  Move         r25, r3
-  MakeList     r3, 2, r31
-  Append       r11, r11, r3
-  AddInt       r23, r23, r12
+  MakeMap      r31, 0, r0
+  Const        r32, []
+  IterPrep     r34, r4
+  Len          r35, r34
+  Const        r36, 0
+L18:
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L0
+  Index        r39, r34, r36
+  // join from p in part on p.p_partkey == l.l_partkey
+  IterPrep     r40, r6
+  Len          r41, r40
+  Const        r42, 0
+L17:
+  LessInt      r43, r42, r41
+  JumpIfFalse  r43, L1
+  Index        r45, r40, r42
+  Const        r46, "p_partkey"
+  Index        r47, r45, r46
+  Const        r48, "l_partkey"
+  Index        r49, r39, r48
+  Equal        r50, r47, r49
+  JumpIfFalse  r50, L2
+  // join from s in supplier on s.s_suppkey == l.l_suppkey
+  IterPrep     r51, r5
+  Len          r52, r51
+  Const        r53, 0
+L16:
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L2
+  Index        r56, r51, r53
+  Const        r57, "s_suppkey"
+  Index        r58, r56, r57
+  Const        r59, "l_suppkey"
+  Index        r60, r39, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r61, L3
+  // join from o in orders on o.o_orderkey == l.l_orderkey
+  IterPrep     r62, r3
+  Len          r63, r62
+  Const        r64, 0
+L15:
+  LessInt      r65, r64, r63
+  JumpIfFalse  r65, L3
+  Index        r67, r62, r64
+  Const        r68, "o_orderkey"
+  Index        r69, r67, r68
+  Const        r70, "l_orderkey"
+  Index        r71, r39, r70
+  Equal        r72, r69, r71
+  JumpIfFalse  r72, L4
+  // join from c in customer on c.c_custkey == o.o_custkey
+  IterPrep     r73, r2
+  Len          r74, r73
+  Const        r75, 0
+L14:
+  LessInt      r76, r75, r74
+  JumpIfFalse  r76, L4
+  Index        r78, r73, r75
+  Const        r79, "c_custkey"
+  Index        r80, r78, r79
+  Const        r81, "o_custkey"
+  Index        r82, r67, r81
+  Equal        r83, r80, r82
+  JumpIfFalse  r83, L5
+  // join from n in nation on n.n_nationkey == c.c_nationkey
+  IterPrep     r84, r1
+  Len          r85, r84
+  Const        r86, 0
+L13:
+  LessInt      r87, r86, r85
+  JumpIfFalse  r87, L5
+  Index        r89, r84, r86
+  Const        r90, "n_nationkey"
+  Index        r91, r89, r90
+  Const        r92, "c_nationkey"
+  Index        r93, r78, r92
+  Equal        r94, r91, r93
+  JumpIfFalse  r94, L6
+  // join from r in region on r.r_regionkey == n.n_regionkey
+  IterPrep     r95, r0
+  Len          r96, r95
+  Const        r97, 0
+L12:
+  LessInt      r98, r97, r96
+  JumpIfFalse  r98, L6
+  Index        r100, r95, r97
+  Const        r101, "r_regionkey"
+  Index        r102, r100, r101
+  Const        r103, "n_regionkey"
+  Index        r104, r89, r103
+  Equal        r105, r102, r104
+  JumpIfFalse  r105, L7
+  // where (p.p_type == target_type && o.o_orderdate >= start_date && o.o_orderdate <= end_date && r.r_name == "AMERICA")
+  Const        r106, "p_type"
+  Index        r107, r45, r106
+  Const        r108, "o_orderdate"
+  Index        r109, r67, r108
+  LessEq       r110, r7, r109
+  Const        r111, "o_orderdate"
+  Index        r112, r67, r111
+  LessEq       r113, r112, r8
+  Equal        r114, r107, r9
+  Const        r115, "r_name"
+  Index        r116, r100, r115
+  Const        r117, "AMERICA"
+  Equal        r118, r116, r117
+  Move         r119, r114
+  JumpIfFalse  r119, L8
+L8:
+  Move         r120, r110
+  JumpIfFalse  r120, L9
+L9:
+  Move         r121, r113
+  JumpIfFalse  r121, L10
+  Move         r121, r118
+L10:
+  JumpIfFalse  r121, L7
+  // from l in lineitem
+  Const        r122, "l"
+  Move         r123, r39
+  Const        r124, "p"
+  Move         r125, r45
+  Const        r126, "s"
+  Move         r127, r56
+  Const        r128, "o"
+  Move         r129, r67
+  Const        r130, "c"
+  Move         r131, r78
+  Const        r132, "n"
+  Move         r133, r89
+  Const        r134, "r"
+  Move         r135, r100
+  MakeMap      r136, 7, r122
+  // group by substring(o.o_orderdate, 0, 4) into year
+  Const        r137, "o_orderdate"
+  Index        r138, r67, r137
+  Const        r139, 0
+  Const        r140, 4
+  Slice        r141, r138, r139, r140
+  Str          r142, r141
+  In           r143, r142, r31
+  JumpIfTrue   r143, L11
+  // from l in lineitem
+  Const        r144, []
+  Const        r145, "__group__"
+  Const        r146, true
+  Const        r147, "key"
+  // group by substring(o.o_orderdate, 0, 4) into year
+  Move         r148, r141
+  // from l in lineitem
+  Const        r149, "items"
+  Move         r150, r144
+  Const        r151, "count"
+  Const        r152, 0
+  Move         r153, r145
+  Move         r154, r146
+  Move         r155, r147
+  Move         r156, r148
+  Move         r157, r149
+  Move         r158, r150
+  Move         r159, r151
+  Move         r160, r152
+  MakeMap      r161, 4, r153
+  SetIndex     r31, r142, r161
+  Append       r32, r32, r161
+L11:
+  Const        r163, "items"
+  Index        r164, r31, r142
+  Index        r165, r164, r163
+  Append       r166, r165, r136
+  SetIndex     r164, r163, r166
+  Const        r167, "count"
+  Index        r168, r164, r167
+  Const        r169, 1
+  AddInt       r170, r168, r169
+  SetIndex     r164, r167, r170
+L7:
+  // join from r in region on r.r_regionkey == n.n_regionkey
+  Const        r171, 1
+  AddInt       r97, r97, r171
+  Jump         L12
+L6:
+  // join from n in nation on n.n_nationkey == c.c_nationkey
+  Const        r172, 1
+  AddInt       r86, r86, r172
+  Jump         L13
+L5:
+  // join from c in customer on c.c_custkey == o.o_custkey
+  Const        r173, 1
+  AddInt       r75, r75, r173
+  Jump         L14
+L4:
+  // join from o in orders on o.o_orderkey == l.l_orderkey
+  Const        r174, 1
+  AddInt       r64, r64, r174
+  Jump         L15
+L3:
+  // join from s in supplier on s.s_suppkey == l.l_suppkey
+  Const        r175, 1
+  AddInt       r53, r53, r175
   Jump         L16
+L2:
+  // join from p in part on p.p_partkey == l.l_partkey
+  Const        r176, 1
+  AddInt       r42, r42, r176
+  Jump         L17
+L1:
+  // from l in lineitem
+  Const        r177, 1
+  AddInt       r36, r36, r177
+  Jump         L18
+L0:
+  Const        r178, 0
+  Len          r180, r32
+L26:
+  LessInt      r181, r178, r180
+  JumpIfFalse  r181, L19
+  Index        r183, r32, r178
+  // o_year: year.key,
+  Const        r184, "o_year"
+  Const        r185, "key"
+  Index        r186, r183, r185
+  // mkt_share:
+  Const        r187, "mkt_share"
+  // sum(from x in year select match x.n.n_name == target_nation {
+  Const        r188, []
+  Const        r189, "n"
+  Const        r190, "n_name"
+  // true => x.l.l_extendedprice * (1 - x.l.l_discount)
+  Const        r191, "l"
+  Const        r192, "l_extendedprice"
+  Const        r193, "l"
+  Const        r194, "l_discount"
+  // sum(from x in year select match x.n.n_name == target_nation {
+  IterPrep     r195, r183
+  Len          r196, r195
+  Const        r197, 0
+L23:
+  LessInt      r199, r197, r196
+  JumpIfFalse  r199, L20
+  Index        r201, r195, r197
+  Const        r202, "n"
+  Index        r203, r201, r202
+  Const        r204, "n_name"
+  Index        r205, r203, r204
+  Equal        r206, r205, r10
+  // true => x.l.l_extendedprice * (1 - x.l.l_discount)
+  Const        r209, true
+  Equal        r208, r206, r209
+  JumpIfFalse  r208, L21
+  Const        r210, "l"
+  Index        r211, r201, r210
+  Const        r212, "l_extendedprice"
+  Index        r213, r211, r212
+  Const        r214, 1
+  Const        r215, "l"
+  Index        r216, r201, r215
+  Const        r217, "l_discount"
+  Index        r218, r216, r217
+  Sub          r219, r214, r218
+  Mul          r207, r213, r219
+  Jump         L22
+L21:
+  // _ => 0
+  Const        r207, 0
+L22:
+  // sum(from x in year select match x.n.n_name == target_nation {
+  Append       r188, r188, r207
+  Const        r223, 1
+  AddInt       r197, r197, r223
+  Jump         L23
+L20:
+  Sum          r224, r188
+  // sum(from x in year select x.l.l_extendedprice * (1 - x.l.l_discount))
+  Const        r225, []
+  Const        r226, "l"
+  Const        r227, "l_extendedprice"
+  Const        r228, "l"
+  Const        r229, "l_discount"
+  IterPrep     r230, r183
+  Len          r231, r230
+  Const        r232, 0
+L25:
+  LessInt      r234, r232, r231
+  JumpIfFalse  r234, L24
+  Index        r201, r230, r232
+  Const        r236, "l"
+  Index        r237, r201, r236
+  Const        r238, "l_extendedprice"
+  Index        r239, r237, r238
+  Const        r240, 1
+  Const        r241, "l"
+  Index        r242, r201, r241
+  Const        r243, "l_discount"
+  Index        r244, r242, r243
+  Sub          r245, r240, r244
+  Mul          r246, r239, r245
+  Append       r225, r225, r246
+  Const        r248, 1
+  AddInt       r232, r232, r248
+  Jump         L25
+L24:
+  Sum          r249, r225
+  // }) /
+  Div          r250, r224, r249
+  // o_year: year.key,
+  Move         r251, r184
+  Move         r252, r186
+  // mkt_share:
+  Move         r253, r187
+  Move         r254, r250
+  // select {
+  MakeMap      r255, 2, r251
+  // sort by year.key
+  Const        r256, "key"
+  Index        r258, r183, r256
+  // from l in lineitem
+  Move         r259, r255
+  MakeList     r260, 2, r258
+  Append       r11, r11, r260
+  Const        r262, 1
+  AddInt       r178, r178, r262
+  Jump         L26
+L19:
   // sort by year.key
   Sort         r11, r11
   // print(result)
   Print        r11
+  // let numerator = 1000.0 * 0.9      // 900
+  Const        r264, 1000
+  Const        r265, 0.9
+  Const        r266, 900
+  // let denominator = numerator + (500.0 * 0.95) // 900 + 475 = 1375
+  Const        r267, 500
+  Const        r268, 0.95
+  Const        r269, 475
+  Const        r270, 1375
   // let share = numerator / denominator         // ≈ 0.6545
-  Const        r3, 0.6545454545454545
+  Const        r271, 0.6545454545454545
   // { o_year: "1995", mkt_share: share }
-  Move         r25, r15
-  Const        r15, "1995"
-  Move         r31, r17
-  Move         r17, r25
-  Move         r25, r15
-  Move         r15, r31
-  Move         r31, r3
-  MakeMap      r3, 2, r17
+  Const        r272, "o_year"
+  Const        r273, "1995"
+  Const        r274, "mkt_share"
+  Move         r275, r272
+  Move         r276, r273
+  Move         r277, r274
+  Move         r278, r271
+  MakeMap      r280, 2, r275
   // expect result == [
-  MakeList     r31, 1, r3
-  Equal        r3, r11, r31
-  Expect       r3
+  MakeList     r281, 1, r280
+  Equal        r282, r11, r281
+  Expect       r282
   Return       r0

--- a/tests/dataset/tpc-h/out/q9.ir.out
+++ b/tests/dataset/tpc-h/out/q9.ir.out
@@ -1,12 +1,10 @@
-func main (regs=38)
+func main (regs=289)
   // let nation = [
   Const        r0, [{"n_name": "BRAZIL", "n_nationkey": 1}, {"n_name": "CANADA", "n_nationkey": 2}]
   // let supplier = [
   Const        r1, [{"s_nationkey": 1, "s_suppkey": 100}, {"s_nationkey": 2, "s_suppkey": 200}]
-L9:
   // let part = [
   Const        r2, [{"p_name": "green metal box", "p_partkey": 1000}, {"p_name": "red plastic crate", "p_partkey": 2000}]
-L0:
   // let partsupp = [
   Const        r3, [{"ps_partkey": 1000, "ps_suppkey": 100, "ps_supplycost": 10}, {"ps_partkey": 1000, "ps_suppkey": 200, "ps_supplycost": 8}]
   // let orders = [
@@ -17,7 +15,6 @@ L0:
   Const        r6, "green"
   // let start_date = "1995-01-01"
   Const        r7, "1995-01-01"
-L7:
   // let end_date = "1996-12-31"
   Const        r8, "1996-12-31"
   // from l in lineitem
@@ -28,296 +25,388 @@ L7:
   // o_year: substring(o.o_orderdate, 0, 4) as int
   Const        r12, "o_year"
   Const        r13, "o_orderdate"
-L6:
   // where substring(p.p_name, 0, len(prefix)) == prefix &&
   Const        r14, "p_name"
-  // nation: g.key.nation,
-  Const        r15, "key"
-  // profit:
-  Const        r16, "profit"
-L12:
-  // select (x.l.l_extendedprice * (1 - x.l.l_discount)) -
-  Const        r17, "l"
-  Const        r18, "l_extendedprice"
-  Const        r19, "l_discount"
-  // (x.ps.ps_supplycost * x.l.l_quantity)
-  Const        r20, "ps"
-  Const        r21, "ps_supplycost"
-  Const        r22, "l_quantity"
-  // from l in lineitem
-  MakeMap      r23, 0, r0
-  IterPrep     r24, r5
-L4:
-  Len          r5, r24
-L3:
-  Const        r25, 0
-  LessInt      r26, r25, r5
-  JumpIfFalse  r26, L0
-L2:
-  Index        r27, r24, r25
-  Move         r28, r27
-L13:
-  // join p in part on p.p_partkey == l.l_partkey
-  IterPrep     r29, r2
-  Len          r2, r29
-  Move         r30, r25
-  LessInt      r31, r30, r2
-L8:
-  JumpIfFalse  r31, L1
-L1:
-  Index        r31, r29, r30
-L10:
-  Const        r29, "p_partkey"
-  Index        r2, r31, r29
-  Const        r29, "l_partkey"
-  Index        r32, r28, r29
-  Equal        r33, r2, r32
-  JumpIfFalse  r33, L2
-  // join s in supplier on s.s_suppkey == l.l_suppkey
-  IterPrep     r33, r1
-  Len          r1, r33
-  Move         r32, r25
-  LessInt      r2, r32, r1
-  JumpIfFalse  r2, L2
-  Index        r2, r33, r32
-  Const        r33, "s_suppkey"
-  Index        r1, r2, r33
-  Const        r33, "l_suppkey"
-  Index        r34, r28, r33
-  Equal        r35, r1, r34
-  JumpIfFalse  r35, L2
-  // join ps in partsupp on ps.ps_partkey == l.l_partkey && ps.ps_suppkey == l.l_suppkey
-  IterPrep     r35, r3
-  Len          r3, r35
-  Move         r34, r32
-  LessInt      r1, r34, r3
-  JumpIfFalse  r1, L2
-  Index        r1, r35, r34
-  Const        r35, "ps_partkey"
-  Index        r3, r1, r35
-  Index        r36, r28, r29
-  Equal        r29, r3, r36
-  Const        r36, "ps_suppkey"
-  Index        r3, r1, r36
-  Index        r36, r28, r33
-  Equal        r33, r3, r36
-  Move         r36, r29
-  JumpIfFalse  r36, L2
-  Move         r36, r33
-  JumpIfFalse  r36, L3
-  // join o in orders on o.o_orderkey == l.l_orderkey
-  IterPrep     r36, r4
-  Len          r4, r36
-  Move         r33, r25
-  LessInt      r29, r33, r4
-  JumpIfFalse  r29, L3
-  Index        r29, r36, r33
-  Const        r36, "o_orderkey"
-  Index        r4, r29, r36
-  Const        r36, "l_orderkey"
-  Index        r3, r28, r36
-  Equal        r36, r4, r3
-  JumpIfFalse  r36, L3
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  IterPrep     r36, r0
-  Len          r4, r36
-  Move         r28, r33
-  LessInt      r1, r28, r4
-  JumpIfFalse  r1, L3
-  Index        r1, r36, r28
-  Const        r36, "n_nationkey"
-  Index        r4, r1, r36
-  Const        r36, "s_nationkey"
-  Index        r37, r2, r36
-  Equal        r36, r4, r37
-  JumpIfFalse  r36, L4
-  // where substring(p.p_name, 0, len(prefix)) == prefix &&
-  Index        r37, r31, r14
-  Move         r31, r33
-  Const        r14, 5
-  Slice        r4, r37, r31, r14
   // o.o_orderdate >= start_date && o.o_orderdate <= end_date
-  Index        r14, r29, r13
-  LessEq       r37, r7, r14
-  Index        r14, r29, r13
-  LessEq       r7, r14, r8
-  // where substring(p.p_name, 0, len(prefix)) == prefix &&
-  Equal        r14, r4, r6
-  JumpIfFalse  r14, L5
-L5:
-  // o.o_orderdate >= start_date && o.o_orderdate <= end_date
-  Move         r14, r37
-  JumpIfFalse  r14, L6
-  Move         r14, r7
-  // where substring(p.p_name, 0, len(prefix)) == prefix &&
-  JumpIfFalse  r14, L4
-  // from l in lineitem
-  MakeMap      r14, 6, r17
-  // nation: n.n_name,
-  Move         r27, r10
-  Index        r5, r1, r11
-  // o_year: substring(o.o_orderdate, 0, 4) as int
-  Move         r1, r12
-  Index        r11, r29, r13
-  Const        r29, 4
-  Slice        r13, r11, r31, r29
-  Cast         r29, r13, int
-  // nation: n.n_name,
-  Move         r13, r27
-  Move         r27, r5
-  // o_year: substring(o.o_orderdate, 0, 4) as int
-  Move         r5, r1
-  Move         r1, r29
-  // group by {
-  MakeMap      r29, 2, r13
-  Str          r1, r29
-  In           r5, r1, r23
-  JumpIfTrue   r5, L7
-  // from l in lineitem
-  Move         r5, r9
-  Const        r27, "__group__"
-  Const        r13, true
-  Move         r11, r15
-  // group by {
-  Move         r24, r29
-  // from l in lineitem
-  Const        r29, "items"
-  Move         r7, r5
-  Const        r5, "count"
-  Move         r37, r31
-  Move         r4, r27
-  Move         r27, r13
-  Move         r13, r11
-  Move         r11, r24
-  Move         r24, r29
-  Move         r6, r7
-  Move         r7, r5
-  Move         r8, r37
-  MakeMap      r37, 4, r4
-  SetIndex     r23, r1, r37
-  Move         r37, r29
-  Index        r29, r23, r1
-  Index        r1, r29, r37
-  Append       r8, r1, r14
-  SetIndex     r29, r37, r8
-  Move         r8, r5
-  Index        r5, r29, r8
-  Const        r1, 1
-  AddInt       r37, r5, r1
-  SetIndex     r29, r8, r37
-  // join n in nation on n.n_nationkey == s.s_nationkey
-  AddInt       r28, r28, r1
-  Jump         L1
-  // join o in orders on o.o_orderkey == l.l_orderkey
-  AddInt       r33, r33, r1
-  Jump         L0
-  // join ps in partsupp on ps.ps_partkey == l.l_partkey && ps.ps_suppkey == l.l_suppkey
-  AddInt       r34, r34, r1
-  Jump         L8
-  // join s in supplier on s.s_suppkey == l.l_suppkey
-  AddInt       r32, r32, r1
-  Jump         L9
-  // join p in part on p.p_partkey == l.l_partkey
-  AddInt       r30, r30, r1
-  Jump         L10
-  // from l in lineitem
-  AddInt       r25, r25, r1
-  Jump         L3
-  Values       37,23,0,0
-  Move         r23, r31
-  Len          r26, r37
-  LessInt      r25, r23, r26
-  JumpIfFalse  r25, L10
-  Index        r25, r37, r23
+  Const        r15, "o_orderdate"
+  Const        r16, "o_orderdate"
   // nation: g.key.nation,
-  Move         r37, r10
-  Index        r26, r25, r15
-  Index        r5, r26, r10
+  Const        r17, "nation"
+  Const        r18, "key"
+  Const        r19, "nation"
   // o_year: str(g.key.o_year),
-  Move         r26, r12
-  Index        r8, r25, r15
-  Index        r29, r8, r12
-  Str          r8, r29
+  Const        r20, "o_year"
+  Const        r21, "key"
+  Const        r22, "o_year"
   // profit:
-  Move         r29, r16
-  // from x in g
-  Move         r12, r9
-  IterPrep     r36, r25
-  Len          r28, r36
-  Move         r3, r31
-  LessInt      r31, r3, r28
-  JumpIfFalse  r31, L11
-  Index        r31, r36, r3
+  Const        r23, "profit"
   // select (x.l.l_extendedprice * (1 - x.l.l_discount)) -
-  Index        r36, r31, r17
-  Index        r28, r36, r18
-  Index        r36, r31, r17
-  Index        r18, r36, r19
-  Sub          r36, r1, r18
-  Mul          r18, r28, r36
+  Const        r24, "l"
+  Const        r25, "l_extendedprice"
+  Const        r26, "l"
+  Const        r27, "l_discount"
   // (x.ps.ps_supplycost * x.l.l_quantity)
-  Index        r36, r31, r20
-  Index        r20, r36, r21
-  Index        r36, r31, r17
-  Index        r17, r36, r22
-  Mul          r36, r20, r17
-  // select (x.l.l_extendedprice * (1 - x.l.l_discount)) -
-  Sub          r17, r18, r36
-  // from x in g
-  Append       r12, r12, r17
-  AddInt       r3, r3, r1
-  Jump         L12
-L11:
-  // sum(
-  Sum          r36, r12
-  // nation: g.key.nation,
-  Move         r17, r37
-  Move         r12, r5
-  // o_year: str(g.key.o_year),
-  Move         r5, r26
-  Move         r18, r8
-  // profit:
-  Move         r8, r29
-  Move         r29, r36
-  // select {
-  MakeMap      r36, 3, r17
+  Const        r28, "ps"
+  Const        r29, "ps_supplycost"
+  Const        r30, "l"
+  Const        r31, "l_quantity"
   // sort by [ g.key.nation, -g.key.o_year ]
-  Index        r29, r25, r15
-  Index        r8, r29, r10
-  Index        r29, r25, r15
-  MakeList     r25, 2, r8
+  Const        r32, "key"
+  Const        r33, "nation"
+  Const        r34, "key"
+  Const        r35, "o_year"
   // from l in lineitem
-  Move         r29, r36
-  MakeList     r36, 2, r25
-  Append       r9, r9, r36
-  AddInt       r23, r23, r1
+  MakeMap      r36, 0, r0
+  Const        r37, []
+  IterPrep     r39, r5
+  Len          r40, r39
+  Const        r41, 0
+L16:
+  LessInt      r42, r41, r40
+  JumpIfFalse  r42, L0
+  Index        r44, r39, r41
+  // join p in part on p.p_partkey == l.l_partkey
+  IterPrep     r45, r2
+  Len          r46, r45
+  Const        r47, 0
+L15:
+  LessInt      r48, r47, r46
+  JumpIfFalse  r48, L1
+  Index        r50, r45, r47
+  Const        r51, "p_partkey"
+  Index        r52, r50, r51
+  Const        r53, "l_partkey"
+  Index        r54, r44, r53
+  Equal        r55, r52, r54
+  JumpIfFalse  r55, L2
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  IterPrep     r56, r1
+  Len          r57, r56
+  Const        r58, 0
+L14:
+  LessInt      r59, r58, r57
+  JumpIfFalse  r59, L2
+  Index        r61, r56, r58
+  Const        r62, "s_suppkey"
+  Index        r63, r61, r62
+  Const        r64, "l_suppkey"
+  Index        r65, r44, r64
+  Equal        r66, r63, r65
+  JumpIfFalse  r66, L3
+  // join ps in partsupp on ps.ps_partkey == l.l_partkey && ps.ps_suppkey == l.l_suppkey
+  IterPrep     r67, r3
+  Len          r68, r67
+  Const        r69, 0
+L13:
+  LessInt      r70, r69, r68
+  JumpIfFalse  r70, L3
+  Index        r72, r67, r69
+  Const        r73, "ps_partkey"
+  Index        r74, r72, r73
+  Const        r75, "l_partkey"
+  Index        r76, r44, r75
+  Equal        r77, r74, r76
+  Const        r78, "ps_suppkey"
+  Index        r79, r72, r78
+  Const        r80, "l_suppkey"
+  Index        r81, r44, r80
+  Equal        r82, r79, r81
+  Move         r83, r77
+  JumpIfFalse  r83, L4
+  Move         r83, r82
+L4:
+  JumpIfFalse  r83, L5
+  // join o in orders on o.o_orderkey == l.l_orderkey
+  IterPrep     r84, r4
+  Len          r85, r84
+  Const        r86, 0
+L12:
+  LessInt      r87, r86, r85
+  JumpIfFalse  r87, L5
+  Index        r89, r84, r86
+  Const        r90, "o_orderkey"
+  Index        r91, r89, r90
+  Const        r92, "l_orderkey"
+  Index        r93, r44, r92
+  Equal        r94, r91, r93
+  JumpIfFalse  r94, L6
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  IterPrep     r95, r0
+  Len          r96, r95
+  Const        r97, 0
+L11:
+  LessInt      r98, r97, r96
+  JumpIfFalse  r98, L6
+  Index        r100, r95, r97
+  Const        r101, "n_nationkey"
+  Index        r102, r100, r101
+  Const        r103, "s_nationkey"
+  Index        r104, r61, r103
+  Equal        r105, r102, r104
+  JumpIfFalse  r105, L7
+  // where substring(p.p_name, 0, len(prefix)) == prefix &&
+  Const        r106, "p_name"
+  Index        r107, r50, r106
+  Const        r108, 0
+  Const        r109, 5
+  Slice        r110, r107, r108, r109
+  // o.o_orderdate >= start_date && o.o_orderdate <= end_date
+  Const        r111, "o_orderdate"
+  Index        r112, r89, r111
+  LessEq       r113, r7, r112
+  Const        r114, "o_orderdate"
+  Index        r115, r89, r114
+  LessEq       r116, r115, r8
+  // where substring(p.p_name, 0, len(prefix)) == prefix &&
+  Equal        r118, r110, r6
+  JumpIfFalse  r118, L8
+L8:
+  // o.o_orderdate >= start_date && o.o_orderdate <= end_date
+  Move         r119, r113
+  JumpIfFalse  r119, L9
+  Move         r119, r116
+L9:
+  // where substring(p.p_name, 0, len(prefix)) == prefix &&
+  JumpIfFalse  r119, L7
+  // from l in lineitem
+  Const        r120, "l"
+  Move         r121, r44
+  Const        r122, "p"
+  Move         r123, r50
+  Const        r124, "s"
+  Move         r125, r61
+  Const        r126, "ps"
+  Move         r127, r72
+  Const        r128, "o"
+  Move         r129, r89
+  Const        r130, "n"
+  Move         r131, r100
+  MakeMap      r132, 6, r120
+  // nation: n.n_name,
+  Const        r133, "nation"
+  Const        r134, "n_name"
+  Index        r135, r100, r134
+  // o_year: substring(o.o_orderdate, 0, 4) as int
+  Const        r136, "o_year"
+  Const        r137, "o_orderdate"
+  Index        r138, r89, r137
+  Const        r139, 0
+  Const        r140, 4
+  Slice        r141, r138, r139, r140
+  Cast         r142, r141, int
+  // nation: n.n_name,
+  Move         r143, r133
+  Move         r144, r135
+  // o_year: substring(o.o_orderdate, 0, 4) as int
+  Move         r145, r136
+  Move         r146, r142
+  // group by {
+  MakeMap      r147, 2, r143
+  Str          r148, r147
+  In           r149, r148, r36
+  JumpIfTrue   r149, L10
+  // from l in lineitem
+  Const        r150, []
+  Const        r151, "__group__"
+  Const        r152, true
+  Const        r153, "key"
+  // group by {
+  Move         r154, r147
+  // from l in lineitem
+  Const        r155, "items"
+  Move         r156, r150
+  Const        r157, "count"
+  Const        r158, 0
+  Move         r159, r151
+  Move         r160, r152
+  Move         r161, r153
+  Move         r162, r154
+  Move         r163, r155
+  Move         r164, r156
+  Move         r165, r157
+  Move         r166, r158
+  MakeMap      r167, 4, r159
+  SetIndex     r36, r148, r167
+  Append       r37, r37, r167
+L10:
+  Const        r169, "items"
+  Index        r170, r36, r148
+  Index        r171, r170, r169
+  Append       r172, r171, r132
+  SetIndex     r170, r169, r172
+  Const        r173, "count"
+  Index        r174, r170, r173
+  Const        r175, 1
+  AddInt       r176, r174, r175
+  SetIndex     r170, r173, r176
+L7:
+  // join n in nation on n.n_nationkey == s.s_nationkey
+  Const        r177, 1
+  AddInt       r97, r97, r177
+  Jump         L11
+L6:
+  // join o in orders on o.o_orderkey == l.l_orderkey
+  Const        r178, 1
+  AddInt       r86, r86, r178
+  Jump         L12
+L5:
+  // join ps in partsupp on ps.ps_partkey == l.l_partkey && ps.ps_suppkey == l.l_suppkey
+  Const        r179, 1
+  AddInt       r69, r69, r179
   Jump         L13
+L3:
+  // join s in supplier on s.s_suppkey == l.l_suppkey
+  Const        r180, 1
+  AddInt       r58, r58, r180
+  Jump         L14
+L2:
+  // join p in part on p.p_partkey == l.l_partkey
+  Const        r181, 1
+  AddInt       r47, r47, r181
+  Jump         L15
+L1:
+  // from l in lineitem
+  Const        r182, 1
+  AddInt       r41, r41, r182
+  Jump         L16
+L0:
+  Const        r183, 0
+  Len          r185, r37
+L20:
+  LessInt      r186, r183, r185
+  JumpIfFalse  r186, L17
+  Index        r188, r37, r183
+  // nation: g.key.nation,
+  Const        r189, "nation"
+  Const        r190, "key"
+  Index        r191, r188, r190
+  Const        r192, "nation"
+  Index        r193, r191, r192
+  // o_year: str(g.key.o_year),
+  Const        r194, "o_year"
+  Const        r195, "key"
+  Index        r196, r188, r195
+  Const        r197, "o_year"
+  Index        r198, r196, r197
+  Str          r199, r198
+  // profit:
+  Const        r200, "profit"
+  // from x in g
+  Const        r201, []
+  // select (x.l.l_extendedprice * (1 - x.l.l_discount)) -
+  Const        r202, "l"
+  Const        r203, "l_extendedprice"
+  Const        r204, "l"
+  Const        r205, "l_discount"
+  // (x.ps.ps_supplycost * x.l.l_quantity)
+  Const        r206, "ps"
+  Const        r207, "ps_supplycost"
+  Const        r208, "l"
+  Const        r209, "l_quantity"
+  // from x in g
+  IterPrep     r210, r188
+  Len          r211, r210
+  Const        r212, 0
+L19:
+  LessInt      r214, r212, r211
+  JumpIfFalse  r214, L18
+  Index        r216, r210, r212
+  // select (x.l.l_extendedprice * (1 - x.l.l_discount)) -
+  Const        r217, "l"
+  Index        r218, r216, r217
+  Const        r219, "l_extendedprice"
+  Index        r220, r218, r219
+  Const        r221, 1
+  Const        r222, "l"
+  Index        r223, r216, r222
+  Const        r224, "l_discount"
+  Index        r225, r223, r224
+  Sub          r226, r221, r225
+  Mul          r227, r220, r226
+  // (x.ps.ps_supplycost * x.l.l_quantity)
+  Const        r228, "ps"
+  Index        r229, r216, r228
+  Const        r230, "ps_supplycost"
+  Index        r231, r229, r230
+  Const        r232, "l"
+  Index        r233, r216, r232
+  Const        r234, "l_quantity"
+  Index        r235, r233, r234
+  Mul          r236, r231, r235
+  // select (x.l.l_extendedprice * (1 - x.l.l_discount)) -
+  Sub          r237, r227, r236
+  // from x in g
+  Append       r201, r201, r237
+  Const        r239, 1
+  AddInt       r212, r212, r239
+  Jump         L19
+L18:
+  // sum(
+  Sum          r240, r201
+  // nation: g.key.nation,
+  Move         r241, r189
+  Move         r242, r193
+  // o_year: str(g.key.o_year),
+  Move         r243, r194
+  Move         r244, r199
+  // profit:
+  Move         r245, r200
+  Move         r246, r240
+  // select {
+  MakeMap      r247, 3, r241
+  // sort by [ g.key.nation, -g.key.o_year ]
+  Const        r248, "key"
+  Index        r249, r188, r248
+  Const        r250, "nation"
+  Index        r252, r249, r250
+  Const        r253, "key"
+  Index        r254, r188, r253
+  Const        r255, "o_year"
+  Index        r256, r254, r255
+  Neg          r258, r256
+  MakeList     r260, 2, r252
+  // from l in lineitem
+  Move         r261, r247
+  MakeList     r262, 2, r260
+  Append       r9, r9, r262
+  Const        r264, 1
+  AddInt       r183, r183, r264
+  Jump         L20
+L17:
   // sort by [ g.key.nation, -g.key.o_year ]
   Sort         r9, r9
   // print json(result)
   JSON         r9
+  // let revenue = 1000.0 * 0.9   // 900
+  Const        r267, 1000
+  Const        r268, 0.9
+  Const        r269, 900
+  // let cost = 5 * 10.0          // 50
+  Const        r270, 5
+  Const        r271, 10
+  Const        r272, 50
   // nation: "BRAZIL",
-  Move         r36, r37
-  Const        r37, "BRAZIL"
+  Const        r273, "nation"
+  Const        r274, "BRAZIL"
   // o_year: "1995",
-  Move         r29, r26
-  Const        r26, "1995"
+  Const        r275, "o_year"
+  Const        r276, "1995"
   // profit: revenue - cost   // 850
-  Move         r25, r16
-  Const        r16, 850
+  Const        r277, "profit"
+  Const        r278, 850
   // nation: "BRAZIL",
-  Move         r31, r36
-  Move         r36, r37
+  Move         r279, r273
+  Move         r280, r274
   // o_year: "1995",
-  Move         r37, r29
-  Move         r29, r26
+  Move         r281, r275
+  Move         r282, r276
   // profit: revenue - cost   // 850
-  Move         r26, r25
-  Move         r25, r16
+  Move         r283, r277
+  Move         r284, r278
   // {
-  MakeMap      r16, 3, r31
+  MakeMap      r286, 3, r279
   // expect result == [
-  MakeList     r25, 1, r16
-  Equal        r16, r9, r25
-  Expect       r16
+  MakeList     r287, 1, r286
+  Equal        r288, r9, r287
+  Expect       r288
   Return       r0


### PR DESCRIPTION
## Summary
- avoid peephole propagating moves into jump instructions
- regenerate tpch `.ir.out` files

## Testing
- `go test -tags slow ./tests/vm -run "TPCH/q1.mochi" -count=1`
- `go test -tags slow ./tests/vm -run "TPCH/q6.mochi" -count=1` *(fails: expect condition failed)*

------
https://chatgpt.com/codex/tasks/task_e_686261a6e51c832091ffcc2815b6a757