### PR TITLE
Enable constant register reuse in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1782,14 +1782,15 @@ type compiler struct {
 }
 
 type funcCompiler struct {
-	fn       Function
-	idx      int
-	comp     *compiler
-	vars     map[string]int
-	scopes   []map[string]int
-	loops    []*loopContext
-	tags     map[int]regTag
-	groupVar string
+	fn        Function
+	idx       int
+	comp      *compiler
+	vars      map[string]int
+	scopes    []map[string]int
+	loops     []*loopContext
+	tags      map[int]regTag
+	groupVar  string
+	constRegs map[string]int
 }
 
 func (fc *funcCompiler) freshConst(pos lexer.Position, v Value) int {
@@ -1884,7 +1885,7 @@ func compileProgram(p *parser.Program, env *types.Env) (*Program, error) {
 }
 
 func (c *compiler) compileFun(fn *parser.FunStmt) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: "", constRegs: map[string]int{}}
 	fc.fn.Name = fn.Name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(fn.Params)
@@ -1908,7 +1909,7 @@ func (c *compiler) compileFun(fn *parser.FunStmt) (Function, error) {
 }
 
 func (c *compiler) compileMethod(st types.StructType, fn *parser.FunStmt) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: "", constRegs: map[string]int{}}
 	fc.fn.Name = st.Name + "." + fn.Name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(st.Order) + len(fn.Params)
@@ -1962,7 +1963,7 @@ func (c *compiler) compileTypeMethods(td *parser.TypeDecl) error {
 }
 
 func (c *compiler) compileFunExpr(fn *parser.FunExpr, captures []string) int {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: "", constRegs: map[string]int{}}
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(captures) + len(fn.Params)
 	for i, name := range captures {
@@ -2004,7 +2005,7 @@ func (c *compiler) compileNamedFunExpr(name string, fn *parser.FunExpr, captures
 	prev, exists := c.fnIndex[name]
 	c.fnIndex[name] = idx
 
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: "", constRegs: map[string]int{}}
 	fc.fn.Name = name
 	fc.fn.Line = fn.Pos.Line
 	fc.fn.NumParams = len(captures) + len(fn.Params)
@@ -2046,7 +2047,7 @@ func (c *compiler) compileNamedFunExpr(name string, fn *parser.FunExpr, captures
 }
 
 func (c *compiler) compileMain(p *parser.Program) (Function, error) {
-	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: ""}
+	fc := &funcCompiler{comp: c, vars: map[string]int{}, tags: map[int]regTag{}, scopes: nil, groupVar: "", constRegs: map[string]int{}}
 	fc.fn.Name = "main"
 	fc.fn.Line = 0
 	fc.fn.NumParams = 0
@@ -2138,9 +2139,16 @@ func constKey(v Value) (string, bool) {
 }
 
 func (fc *funcCompiler) constReg(pos lexer.Position, v Value) int {
-	if _, ok := constKey(v); ok {
+	if key, ok := constKey(v); ok {
+		if r, exists := fc.constRegs[key]; exists {
+			return r
+		}
 		r := fc.newReg()
 		fc.emit(pos, Instr{Op: OpConst, A: r, Val: v})
+		if fc.constRegs == nil {
+			fc.constRegs = map[string]int{}
+		}
+		fc.constRegs[key] = r
 		return r
 	}
 	r := fc.newReg()
@@ -6308,7 +6316,7 @@ func (fc *funcCompiler) evalPureFunc(name string, args []Value) (Value, bool) {
 		env.SetValue(p.Name, valueToAny(args[i]), false)
 	}
 	tmpComp := &compiler{prog: fc.comp.prog, env: env}
-	tmpFC := &funcCompiler{comp: tmpComp}
+	tmpFC := &funcCompiler{comp: tmpComp, constRegs: map[string]int{}}
 	return tmpFC.evalConstExpr(ret.Value)
 }
 

--- a/tests/dataset/tpc-h/out/q22.ir.out
+++ b/tests/dataset/tpc-h/out/q22.ir.out
@@ -1,4 +1,4 @@
-func main (regs=198)
+func main (regs=158)
   // let customer = [
   Const        r0, [{"c_acctbal": 600, "c_custkey": 1, "c_phone": "13-123-4567"}, {"c_acctbal": 100, "c_custkey": 2, "c_phone": "31-456-7890"}, {"c_acctbal": 700, "c_custkey": 3, "c_phone": "30-000-0000"}]
   // let orders = [
@@ -10,294 +10,249 @@ func main (regs=198)
   // where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
   Const        r4, "c_acctbal"
   Const        r5, "c_phone"
-  // select c.c_acctbal
-  Const        r6, "c_acctbal"
   // from c in customer
-  IterPrep     r7, r0
-  Len          r8, r7
+  IterPrep     r6, r0
+  Len          r7, r6
   Const        r9, 0
+  Move         r8, r9
 L3:
-  LessInt      r11, r9, r8
-  JumpIfFalse  r11, L0
-  Index        r13, r7, r9
+  LessInt      r10, r8, r7
+  JumpIfFalse  r10, L0
+  Index        r12, r6, r8
   // where c.c_acctbal > 0.0 && substring(c.c_phone, 0, 2) in valid_codes
-  Const        r14, "c_acctbal"
-  Index        r15, r13, r14
-  Const        r16, 0
-  LessFloat    r17, r16, r15
-  Const        r18, "c_phone"
-  Index        r19, r13, r18
-  Const        r20, 0
-  Const        r21, 2
-  Slice        r22, r19, r20, r21
-  In           r23, r22, r2
-  Move         r24, r17
-  JumpIfFalse  r24, L1
-  Move         r24, r23
+  Index        r13, r12, r4
+  Const        r14, 0
+  LessFloat    r15, r14, r13
+  Index        r16, r12, r5
+  Const        r17, 2
+  Slice        r18, r16, r9, r17
+  In           r19, r18, r2
+  Move         r20, r15
+  JumpIfFalse  r20, L1
+  Move         r20, r19
 L1:
-  JumpIfFalse  r24, L2
+  JumpIfFalse  r20, L2
   // select c.c_acctbal
-  Const        r25, "c_acctbal"
-  Index        r26, r13, r25
+  Index        r21, r12, r4
   // from c in customer
-  Append       r3, r3, r26
+  Append       r3, r3, r21
 L2:
-  Const        r28, 1
-  AddInt       r9, r9, r28
+  Const        r23, 1
+  AddInt       r8, r8, r23
   Jump         L3
 L0:
   // avg(
-  Avg          r29, r3
+  Avg          r24, r3
   // from c in customer
-  Const        r30, []
-  // substring(c.c_phone, 0, 2) in valid_codes &&
-  Const        r31, "c_phone"
-  // c.c_acctbal > avg_balance && (!exists(
-  Const        r32, "c_acctbal"
+  Const        r25, []
   // where o.o_custkey == c.c_custkey
-  Const        r33, "o_custkey"
-  Const        r34, "c_custkey"
+  Const        r26, "o_custkey"
+  Const        r27, "c_custkey"
   // cntrycode: substring(c.c_phone, 0, 2),
-  Const        r35, "cntrycode"
-  Const        r36, "c_phone"
-  // c_acctbal: c.c_acctbal
-  Const        r37, "c_acctbal"
-  Const        r38, "c_acctbal"
+  Const        r28, "cntrycode"
   // from c in customer
-  IterPrep     r39, r0
-  Len          r40, r39
-  Const        r41, 0
-L11:
-  LessInt      r43, r41, r40
-  JumpIfFalse  r43, L4
-  Index        r13, r39, r41
-  // substring(c.c_phone, 0, 2) in valid_codes &&
-  Const        r45, "c_phone"
-  Index        r46, r13, r45
-  Const        r47, 0
-  Const        r48, 2
-  Slice        r49, r46, r47, r48
-  // c.c_acctbal > avg_balance && (!exists(
-  Const        r50, "c_acctbal"
-  Index        r51, r13, r50
-  LessFloat    r52, r29, r51
-  // substring(c.c_phone, 0, 2) in valid_codes &&
-  In           r54, r49, r2
-  JumpIfFalse  r54, L5
-L5:
-  // c.c_acctbal > avg_balance && (!exists(
-  Move         r55, r52
-  JumpIfFalse  r55, L6
-  // from o in orders
-  Const        r56, []
-  // where o.o_custkey == c.c_custkey
-  Const        r57, "o_custkey"
-  Const        r58, "c_custkey"
-  // from o in orders
-  IterPrep     r59, r1
-  Len          r60, r59
-  Const        r61, 0
-L9:
-  LessInt      r63, r61, r60
-  JumpIfFalse  r63, L7
-  Index        r65, r59, r61
-  // where o.o_custkey == c.c_custkey
-  Const        r66, "o_custkey"
-  Index        r67, r65, r66
-  Const        r68, "c_custkey"
-  Index        r69, r13, r68
-  Equal        r70, r67, r69
-  JumpIfFalse  r70, L8
-  // from o in orders
-  Append       r56, r56, r65
-L8:
-  Const        r72, 1
-  AddInt       r61, r61, r72
-  Jump         L9
-L7:
-  // c.c_acctbal > avg_balance && (!exists(
-  Exists       r73, r56
-  Not          r55, r73
-L6:
-  // substring(c.c_phone, 0, 2) in valid_codes &&
-  JumpIfFalse  r55, L10
-  // cntrycode: substring(c.c_phone, 0, 2),
-  Const        r75, "cntrycode"
-  Const        r76, "c_phone"
-  Index        r77, r13, r76
-  Const        r78, 0
-  Const        r79, 2
-  Slice        r80, r77, r78, r79
-  // c_acctbal: c.c_acctbal
-  Const        r81, "c_acctbal"
-  Const        r82, "c_acctbal"
-  Index        r83, r13, r82
-  // cntrycode: substring(c.c_phone, 0, 2),
-  Move         r84, r75
-  Move         r85, r80
-  // c_acctbal: c.c_acctbal
-  Move         r86, r81
-  Move         r87, r83
-  // select {
-  MakeMap      r88, 2, r84
-  // from c in customer
-  Append       r30, r30, r88
+  IterPrep     r29, r0
+  Len          r30, r29
+  Move         r31, r9
 L10:
-  Const        r90, 1
-  AddInt       r41, r41, r90
-  Jump         L11
+  LessInt      r32, r31, r30
+  JumpIfFalse  r32, L4
+  Index        r12, r29, r31
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  Index        r34, r12, r5
+  Slice        r35, r34, r9, r17
+  // c.c_acctbal > avg_balance && (!exists(
+  Index        r36, r12, r4
+  LessFloat    r37, r24, r36
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  In           r39, r35, r2
+  JumpIfFalse  r39, L5
+  Move         r39, r37
+  // c.c_acctbal > avg_balance && (!exists(
+  JumpIfFalse  r39, L5
+  // from o in orders
+  Const        r40, []
+  IterPrep     r41, r1
+  Len          r42, r41
+  Move         r43, r9
+L8:
+  LessInt      r44, r43, r42
+  JumpIfFalse  r44, L6
+  Index        r46, r41, r43
+  // where o.o_custkey == c.c_custkey
+  Index        r47, r46, r26
+  Index        r48, r12, r27
+  Equal        r49, r47, r48
+  JumpIfFalse  r49, L7
+  // from o in orders
+  Append       r40, r40, r46
+L7:
+  AddInt       r43, r43, r23
+  Jump         L8
+L6:
+  // c.c_acctbal > avg_balance && (!exists(
+  Exists       r51, r40
+  Not          r39, r51
+L5:
+  // substring(c.c_phone, 0, 2) in valid_codes &&
+  JumpIfFalse  r39, L9
+  // cntrycode: substring(c.c_phone, 0, 2),
+  Const        r53, "cntrycode"
+  Index        r54, r12, r5
+  Slice        r55, r54, r9, r17
+  // c_acctbal: c.c_acctbal
+  Const        r56, "c_acctbal"
+  Index        r57, r12, r4
+  // cntrycode: substring(c.c_phone, 0, 2),
+  Move         r58, r53
+  Move         r59, r55
+  // c_acctbal: c.c_acctbal
+  Move         r60, r56
+  Move         r61, r57
+  // select {
+  MakeMap      r62, 2, r58
+  // from c in customer
+  Append       r25, r25, r62
+L9:
+  AddInt       r31, r31, r23
+  Jump         L10
 L4:
   // from c in eligible_customers
-  Const        r91, []
-  // group by c.cntrycode into g
-  Const        r92, "cntrycode"
-  // from c in eligible_customers
-  IterPrep     r93, r30
-  Len          r94, r93
-  Const        r95, 0
-  MakeMap      r96, 0, r0
-  Const        r97, []
-L14:
-  LessInt      r99, r95, r94
-  JumpIfFalse  r99, L12
-  Index        r100, r93, r95
-  Move         r13, r100
-  // group by c.cntrycode into g
-  Const        r101, "cntrycode"
-  Index        r102, r13, r101
-  Str          r103, r102
-  In           r104, r103, r96
-  JumpIfTrue   r104, L13
-  // from c in eligible_customers
-  Const        r105, []
-  Const        r106, "__group__"
-  Const        r107, true
-  Const        r108, "key"
-  // group by c.cntrycode into g
-  Move         r109, r102
-  // from c in eligible_customers
-  Const        r110, "items"
-  Move         r111, r105
-  Const        r112, "count"
-  Const        r113, 0
-  Move         r114, r106
-  Move         r115, r107
-  Move         r116, r108
-  Move         r117, r109
-  Move         r118, r110
-  Move         r119, r111
-  Move         r120, r112
-  Move         r121, r113
-  MakeMap      r122, 4, r114
-  SetIndex     r96, r103, r122
-  Append       r97, r97, r122
+  Const        r64, []
+  IterPrep     r65, r25
+  Len          r66, r65
+  Const        r67, 0
+  MakeMap      r68, 0, r0
+  Const        r69, []
 L13:
-  Const        r124, "items"
-  Index        r125, r96, r103
-  Index        r126, r125, r124
-  Append       r127, r126, r100
-  SetIndex     r125, r124, r127
-  Const        r128, "count"
-  Index        r129, r125, r128
-  Const        r130, 1
-  AddInt       r131, r129, r130
-  SetIndex     r125, r128, r131
-  Const        r132, 1
-  AddInt       r95, r95, r132
-  Jump         L14
+  LessInt      r71, r67, r66
+  JumpIfFalse  r71, L11
+  Index        r72, r65, r67
+  // group by c.cntrycode into g
+  Index        r73, r72, r28
+  Str          r74, r73
+  In           r75, r74, r68
+  JumpIfTrue   r75, L12
+  // from c in eligible_customers
+  Const        r76, []
+  Const        r77, "__group__"
+  Const        r78, true
+  Const        r79, "key"
+  // group by c.cntrycode into g
+  Move         r80, r73
+  // from c in eligible_customers
+  Const        r81, "items"
+  Move         r82, r76
+  Const        r83, "count"
+  Const        r84, 0
+  Move         r85, r77
+  Move         r86, r78
+  Move         r87, r79
+  Move         r88, r80
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  Move         r92, r84
+  MakeMap      r93, 4, r85
+  SetIndex     r68, r74, r93
+  Append       r69, r69, r93
 L12:
-  Const        r133, 0
-  Len          r135, r97
-L16:
-  LessInt      r136, r133, r135
-  JumpIfFalse  r136, L15
-  Index        r138, r97, r133
-  Append       r91, r91, r138
-  Const        r140, 1
-  AddInt       r133, r133, r140
-  Jump         L16
+  Const        r95, "items"
+  Index        r96, r68, r74
+  Index        r97, r96, r95
+  Append       r98, r97, r72
+  SetIndex     r96, r95, r98
+  Const        r99, "count"
+  Index        r100, r96, r99
+  AddInt       r101, r100, r23
+  SetIndex     r96, r99, r101
+  AddInt       r67, r67, r23
+  Jump         L13
+L11:
+  Move         r102, r9
+  Len          r103, r69
 L15:
+  LessInt      r104, r102, r103
+  JumpIfFalse  r104, L14
+  Index        r106, r69, r102
+  Append       r64, r64, r106
+  AddInt       r102, r102, r23
+  Jump         L15
+L14:
   // var tmp = []
-  Const        r142, []
+  Const        r109, []
   // for g in groups {
-  IterPrep     r143, r91
-  Len          r144, r143
-  Const        r145, 0
-L20:
-  Less         r146, r145, r144
-  JumpIfFalse  r146, L17
-  Index        r138, r143, r145
-  // var total = 0.0
-  Const        r149, 0
-  // for x in g.items {
-  Const        r150, "items"
-  Index        r151, r138, r150
-  IterPrep     r152, r151
-  Len          r153, r152
-  Const        r154, 0
+  IterPrep     r110, r64
+  Len          r111, r110
+  Const        r112, 0
 L19:
-  Less         r155, r154, r153
-  JumpIfFalse  r155, L18
-  Index        r157, r152, r154
-  // total = total + x.c_acctbal
-  Const        r158, "c_acctbal"
-  Index        r159, r157, r158
-  AddFloat     r149, r149, r159
+  Less         r113, r112, r111
+  JumpIfFalse  r113, L16
+  Index        r106, r110, r112
+  // var total = 0.0
+  Move         r115, r14
   // for x in g.items {
-  Const        r161, 1
-  Add          r154, r154, r161
-  Jump         L19
+  Index        r116, r106, r95
+  IterPrep     r117, r116
+  Len          r118, r117
+  Const        r119, 0
 L18:
-  // let row = { cntrycode: g.key, numcust: count(g), totacctbal: total }
-  Const        r163, "cntrycode"
-  Const        r164, "key"
-  Index        r165, r138, r164
-  Const        r166, "numcust"
-  Count        r167, r138
-  Const        r168, "totacctbal"
-  Move         r169, r163
-  Move         r170, r165
-  Move         r171, r166
-  Move         r172, r167
-  Move         r173, r168
-  Move         r174, r149
-  MakeMap      r175, 3, r169
-  // tmp = append(tmp, row)
-  Append       r142, r142, r175
-  // for g in groups {
-  Const        r177, 1
-  Add          r145, r145, r177
-  Jump         L20
+  Less         r120, r119, r118
+  JumpIfFalse  r120, L17
+  Index        r122, r117, r119
+  // total = total + x.c_acctbal
+  Index        r123, r122, r4
+  AddFloat     r115, r115, r123
+  // for x in g.items {
+  Const        r125, 1
+  Add          r119, r119, r125
+  Jump         L18
 L17:
+  // let row = { cntrycode: g.key, numcust: count(g), totacctbal: total }
+  Const        r127, "cntrycode"
+  Const        r128, "key"
+  Index        r129, r106, r128
+  Const        r130, "numcust"
+  Count        r131, r106
+  Const        r132, "totacctbal"
+  Move         r133, r127
+  Move         r134, r129
+  Move         r135, r130
+  Move         r136, r131
+  Move         r137, r132
+  Move         r138, r115
+  MakeMap      r139, 3, r133
+  // tmp = append(tmp, row)
+  Append       r109, r109, r139
+  // for g in groups {
+  Const        r141, 1
+  Add          r112, r112, r141
+  Jump         L19
+L16:
   // from r in tmp
-  Const        r179, []
-  // sort by r.cntrycode
-  Const        r180, "cntrycode"
-  // from r in tmp
-  IterPrep     r181, r142
-  Len          r182, r181
-  Const        r183, 0
-L22:
-  LessInt      r185, r183, r182
-  JumpIfFalse  r185, L21
-  Index        r187, r181, r183
-  // sort by r.cntrycode
-  Const        r188, "cntrycode"
-  Index        r190, r187, r188
-  // from r in tmp
-  Move         r191, r187
-  MakeList     r192, 2, r190
-  Append       r179, r179, r192
-  Const        r194, 1
-  AddInt       r183, r183, r194
-  Jump         L22
+  Const        r143, []
+  IterPrep     r144, r109
+  Len          r145, r144
+  Move         r146, r9
 L21:
+  LessInt      r147, r146, r145
+  JumpIfFalse  r147, L20
+  Index        r149, r144, r146
   // sort by r.cntrycode
-  Sort         r179, r179
+  Index        r151, r149, r28
+  // from r in tmp
+  Move         r152, r149
+  MakeList     r153, 2, r151
+  Append       r143, r143, r153
+  AddInt       r146, r146, r23
+  Jump         L21
+L20:
+  // sort by r.cntrycode
+  Sort         r143, r143
   // print(result)
-  Print        r179
+  Print        r143
   // expect result == [
-  Const        r196, [{"cntrycode": "13", "numcust": 1, "totacctbal": 600}, {"cntrycode": "30", "numcust": 1, "totacctbal": 700}]
-  Equal        r197, r179, r196
-  Expect       r197
+  Const        r156, [{"cntrycode": "13", "numcust": 1, "totacctbal": 600}, {"cntrycode": "30", "numcust": 1, "totacctbal": 700}]
+  Equal        r157, r143, r156
+  Expect       r157
   Return       r0


### PR DESCRIPTION
## Summary
- reuse constant registers in the VM compiler so repeated constants are not re-emitted
- update IR output for TPC‑H q22 after compilation change

## Testing
- `go test ./tests/vm -tags slow -run TestVM_TPCH/q22.mochi -update -count=1`
- `go test ./tests/vm -tags slow -run TestVM_TPCH/q22.mochi -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68626c19d0d0832093c801b4bd5bf1c7