### PR TITLE
Fix VM disassembly newline

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -487,8 +487,10 @@ func (p *Program) Disassemble(src string) string {
 		}
 		b.WriteByte('\n')
 	}
-	out := b.String()
-	return strings.TrimRight(out, "\n")
+	// Normalize trailing newline so the disassembly matches
+	// checked-in golden files for dataset queries.
+	out := strings.TrimRight(b.String(), "\n")
+	return out + "\n"
 }
 
 type VM struct {


### PR DESCRIPTION
## Summary
- adjust `Disassemble` so IR listings keep a final newline

## Testing
- `go vet ./runtime/vm`
- `go build ./runtime/vm`


------
https://chatgpt.com/codex/tasks/task_e_6862915708dc8320bf2262966c76c1b4