### PR TITLE
Add empty list/map constant reuse

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2135,6 +2135,16 @@ func constKey(v Value) (string, bool) {
 		return "s" + v.Str, true
 	case ValueNull:
 		return "n", true
+	case ValueList:
+		if len(v.List) == 0 {
+			return "[]", true
+		}
+		return "", false
+	case ValueMap:
+		if len(v.Map) == 0 {
+			return "{}", true
+		}
+		return "", false
 	default:
 		return "", false
 	}


### PR DESCRIPTION
## Summary
- enhance `constKey` to reuse empty list and map constants
- regenerate TPCH q4 outputs

## Testing
- `go test ./...`
- `go test -tags slow ./...` *(fails: cobol compiler tests)*

------
https://chatgpt.com/codex/tasks/task_e_6862915878048320bfc1714df0d1f042