### PR TITLE
Add float const canonicalization

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2125,7 +2125,7 @@ func constKey(v Value) (string, bool) {
 	case ValueInt:
 		return fmt.Sprintf("i%v", v.Int), true
 	case ValueFloat:
-		return fmt.Sprintf("f%v", v.Float), true
+		return "f" + strconv.FormatFloat(v.Float, 'g', -1, 64), true
 	case ValueBool:
 		if v.Bool {
 			return "bt", true


### PR DESCRIPTION
## Summary
- canonicalize float constants in runtime VM `constKey`
- regenerate q5 IR output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68629159fcec8320b0ba4a302c485215