### PR TITLE
Enable TPCH Q11 in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2133,11 +2133,20 @@ func constKey(v Value) (string, bool) {
 		return "bf", true
 	case ValueStr:
 		return "s" + v.Str, true
+	case ValueList:
+		if len(v.List) == 0 {
+			return "[]", true
+		}
+	case ValueMap:
+		if len(v.Map) == 0 {
+			return "{}", true
+		}
 	case ValueNull:
 		return "n", true
 	default:
 		return "", false
 	}
+	return "", false
 }
 
 func (fc *funcCompiler) constReg(pos lexer.Position, v Value) int {


### PR DESCRIPTION
## Summary
- deduplicate empty list and map constants in the VM compiler
- regenerate TPCH query 11 IR after optimizer change

## Testing
- `go test ./tests/vm -run TPCH/q11 -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68629166c88c8320bfc6cde264f832f2