### PR TITLE
Update VM avg behavior

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1491,7 +1491,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				return Value{}, fmt.Errorf("avg expects list")
 			}
 			if len(lst.List) == 0 {
-				fr.regs[ins.A] = Value{Tag: ValueInt, Int: 0}
+				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: 0}
 			} else {
 				var sum float64
 				for _, v := range lst.List {


### PR DESCRIPTION
## Summary
- handle empty lists in `OpAvg` by returning float zero

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6862917668e4832098349424c0c3327d