### PR TITLE
Update VM constant reuse

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2133,6 +2133,16 @@ func constKey(v Value) (string, bool) {
 		return "bf", true
 	case ValueStr:
 		return "s" + v.Str, true
+	case ValueList:
+		if len(v.List) == 0 {
+			return "[]", true
+		}
+		return "", false
+	case ValueMap:
+		if len(v.Map) == 0 {
+			return "{}", true
+		}
+		return "", false
 	case ValueNull:
 		return "n", true
 	default:


### PR DESCRIPTION
## Summary
- enable reuse of empty list and map constants in the VM
- no changes to golden output needed for TPCH q20 but confirmed compilation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862917b798c832093dcbbe9c463e6ea