### PR TITLE
Improve constant reuse in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2135,6 +2135,16 @@ func constKey(v Value) (string, bool) {
 		return "s" + v.Str, true
 	case ValueNull:
 		return "n", true
+	case ValueList:
+		if len(v.List) == 0 {
+			return "[]", true
+		}
+		return "", false
+	case ValueMap:
+		if len(v.Map) == 0 {
+			return "{}", true
+		}
+		return "", false
 	default:
 		return "", false
 	}


### PR DESCRIPTION
## Summary
- reuse empty list and map constants in the VM
- regenerate IR output for TPC‑H query 21

## Testing
- `go test ./...`
- `go test -tags slow ./tests/vm -run TestVM_TPCH/q21\.mochi -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6862917cb7fc83209fe36289b2524e07