### PR TITLE
Add constant reuse for empty collections

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2133,6 +2133,16 @@ func constKey(v Value) (string, bool) {
 		return "bf", true
 	case ValueStr:
 		return "s" + v.Str, true
+	case ValueList:
+		if len(v.List) == 0 {
+			return "[]", true
+		}
+		return "", false
+	case ValueMap:
+		if len(v.Map) == 0 {
+			return "{}", true
+		}
+		return "", false
 	case ValueNull:
 		return "n", true
 	default:


### PR DESCRIPTION
## Summary
- enhance VM constant intern table so empty lists/maps reuse registers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862917f178c83209c27b504ac211536