### PR TITLE
Add numeric string support in toFloat

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6783,6 +6783,11 @@ func toFloat(v Value) float64 {
 		}
 		return 0
 	}
+	if v.Tag == ValueStr {
+		if f, err := strconv.ParseFloat(v.Str, 64); err == nil {
+			return f
+		}
+	}
 	return float64(v.Int)
 }
 


### PR DESCRIPTION
## Summary
- allow `toFloat` to parse numeric strings so datasets using strings for numeric values work in the VM

## Testing
- `go test -tags slow ./tests/vm -run TPCH/q6.mochi -count=1`
- `make test` *(fails: only type checker tests run)*

------
https://chatgpt.com/codex/tasks/task_e_6862a193bc9c8320b751bdae0f3927e8