### PR TITLE
Update tpc-ds IR outputs and improve union_all

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1062,7 +1062,11 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			if a.Tag != ValueList || b.Tag != ValueList {
 				return Value{}, m.newError(fmt.Errorf("union expects lists"), trace, ins.Line)
 			}
-			out := append(append([]Value(nil), a.List...), b.List...)
+			// Preallocate the result slice for efficiency when
+			// concatenating two lists.
+			out := make([]Value, 0, len(a.List)+len(b.List))
+			out = append(out, a.List...)
+			out = append(out, b.List...)
 			fr.regs[ins.A] = Value{Tag: ValueList, List: out}
 		case OpUnion:
 			a := fr.regs[ins.B]

--- a/tests/dataset/tpc-ds/out/q1.ir.out
+++ b/tests/dataset/tpc-ds/out/q1.ir.out
@@ -1,359 +1,273 @@
-func main (regs=239)
+func main (regs=171)
   // let store_returns = []
   Const        r0, []
-  // let date_dim = []
+  // from sr in store_returns
   Const        r1, []
-  // let store = []
-  Const        r2, []
-  // let customer = []
-  Const        r3, []
-  // from sr in store_returns
-  Const        r4, []
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Const        r5, "customer_sk"
-  Const        r6, "sr_customer_sk"
-  Const        r7, "store_sk"
-  Const        r8, "sr_store_sk"
+  Const        r2, "customer_sk"
+  Const        r3, "sr_customer_sk"
+  Const        r4, "store_sk"
+  Const        r5, "sr_store_sk"
   // where d.d_year == 1998
-  Const        r9, "d_year"
+  Const        r6, "d_year"
   // ctr_customer_sk: g.key.customer_sk,
-  Const        r10, "ctr_customer_sk"
-  Const        r11, "key"
-  Const        r12, "customer_sk"
+  Const        r7, "ctr_customer_sk"
+  Const        r8, "key"
   // ctr_store_sk: g.key.store_sk,
-  Const        r13, "ctr_store_sk"
-  Const        r14, "key"
-  Const        r15, "store_sk"
+  Const        r9, "ctr_store_sk"
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Const        r16, "ctr_total_return"
-  Const        r17, "sr_return_amt"
+  Const        r10, "ctr_total_return"
+  Const        r11, "sr_return_amt"
   // from sr in store_returns
-  MakeMap      r18, 0, r0
-  Const        r19, []
+  MakeMap      r12, 0, r0
+  Const        r13, []
+  IterPrep     r15, r0
+  Len          r16, r15
+  Const        r17, 0
+L5:
+  LessInt      r18, r17, r16
+  JumpIfFalse  r18, L0
+  Index        r20, r15, r17
+  // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
   IterPrep     r21, r0
   Len          r22, r21
   Const        r23, 0
-L5:
-  LessInt      r24, r23, r22
-  JumpIfFalse  r24, L0
-  Index        r26, r21, r23
-  // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  IterPrep     r27, r1
-  Len          r28, r27
-  Const        r29, 0
 L4:
-  LessInt      r30, r29, r28
-  JumpIfFalse  r30, L1
-  Index        r32, r27, r29
-  Const        r33, "sr_returned_date_sk"
-  Index        r34, r26, r33
-  Const        r35, "d_date_sk"
-  Index        r36, r32, r35
-  Equal        r37, r34, r36
-  JumpIfFalse  r37, L2
+  LessInt      r24, r23, r22
+  JumpIfFalse  r24, L1
+  Index        r26, r21, r23
+  Const        r27, "sr_returned_date_sk"
+  Index        r28, r20, r27
+  Const        r29, "d_date_sk"
+  Index        r30, r26, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L2
   // where d.d_year == 1998
-  Const        r38, "d_year"
-  Index        r39, r32, r38
-  Const        r40, 1998
-  Equal        r41, r39, r40
-  JumpIfFalse  r41, L2
+  Index        r32, r26, r6
+  Const        r33, 1998
+  Equal        r34, r32, r33
+  JumpIfFalse  r34, L2
   // from sr in store_returns
-  Const        r42, "sr"
-  Move         r43, r26
-  Const        r44, "d"
-  Move         r45, r32
-  MakeMap      r46, 2, r42
+  Const        r35, "sr"
+  Move         r36, r20
+  Const        r37, "d"
+  Move         r38, r26
+  MakeMap      r39, 2, r35
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Const        r47, "customer_sk"
-  Const        r48, "sr_customer_sk"
-  Index        r49, r26, r48
-  Const        r50, "store_sk"
-  Const        r51, "sr_store_sk"
-  Index        r52, r26, r51
-  Move         r53, r47
-  Move         r54, r49
-  Move         r55, r50
-  Move         r56, r52
-  MakeMap      r57, 2, r53
-  Str          r58, r57
-  In           r59, r58, r18
-  JumpIfTrue   r59, L3
+  Const        r40, "customer_sk"
+  Index        r41, r20, r3
+  Const        r42, "store_sk"
+  Index        r43, r20, r5
+  Move         r44, r40
+  Move         r45, r41
+  Move         r46, r42
+  Move         r47, r43
+  MakeMap      r48, 2, r44
+  Str          r49, r48
+  In           r50, r49, r12
+  JumpIfTrue   r50, L3
   // from sr in store_returns
-  Const        r60, []
-  Const        r61, "__group__"
-  Const        r62, true
-  Const        r63, "key"
+  Const        r51, []
+  Const        r52, "__group__"
+  Const        r53, true
+  Const        r54, "key"
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Move         r64, r57
+  Move         r55, r48
   // from sr in store_returns
-  Const        r65, "items"
-  Move         r66, r60
-  Const        r67, "count"
-  Const        r68, 0
-  Move         r69, r61
-  Move         r70, r62
-  Move         r71, r63
-  Move         r72, r64
-  Move         r73, r65
-  Move         r74, r66
-  Move         r75, r67
-  Move         r76, r68
-  MakeMap      r77, 4, r69
-  SetIndex     r18, r58, r77
-  Append       r19, r19, r77
+  Const        r56, "items"
+  Move         r57, r51
+  Const        r58, "count"
+  Const        r59, 0
+  Move         r60, r52
+  Move         r61, r53
+  Move         r62, r54
+  Move         r63, r55
+  Move         r64, r56
+  Move         r65, r57
+  Move         r66, r58
+  Move         r67, r59
+  MakeMap      r68, 4, r60
+  SetIndex     r12, r49, r68
+  Append       r13, r13, r68
 L3:
-  Const        r79, "items"
-  Index        r80, r18, r58
-  Index        r81, r80, r79
-  Append       r82, r81, r46
-  SetIndex     r80, r79, r82
-  Const        r83, "count"
-  Index        r84, r80, r83
-  Const        r85, 1
-  AddInt       r86, r84, r85
-  SetIndex     r80, r83, r86
+  Const        r70, "items"
+  Index        r71, r12, r49
+  Index        r72, r71, r70
+  Append       r73, r72, r39
+  SetIndex     r71, r70, r73
+  Const        r74, "count"
+  Index        r75, r71, r74
+  Const        r76, 1
+  AddInt       r77, r75, r76
+  SetIndex     r71, r74, r77
 L2:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  Const        r87, 1
-  AddInt       r29, r29, r87
+  AddInt       r23, r23, r76
   Jump         L4
 L1:
   // from sr in store_returns
-  Const        r88, 1
-  AddInt       r23, r23, r88
+  AddInt       r17, r17, r76
   Jump         L5
 L0:
-  Const        r89, 0
-  Len          r91, r19
+  Const        r79, 0
+  Move         r78, r79
+  Len          r80, r13
 L9:
-  LessInt      r92, r89, r91
-  JumpIfFalse  r92, L6
-  Index        r94, r19, r89
+  LessInt      r81, r78, r80
+  JumpIfFalse  r81, L6
+  Index        r83, r13, r78
   // ctr_customer_sk: g.key.customer_sk,
-  Const        r95, "ctr_customer_sk"
-  Const        r96, "key"
-  Index        r97, r94, r96
-  Const        r98, "customer_sk"
-  Index        r99, r97, r98
+  Const        r84, "ctr_customer_sk"
+  Index        r85, r83, r8
+  Index        r86, r85, r2
   // ctr_store_sk: g.key.store_sk,
-  Const        r100, "ctr_store_sk"
-  Const        r101, "key"
-  Index        r102, r94, r101
-  Const        r103, "store_sk"
-  Index        r104, r102, r103
+  Const        r87, "ctr_store_sk"
+  Index        r88, r83, r8
+  Index        r89, r88, r4
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Const        r105, "ctr_total_return"
-  Const        r106, []
-  Const        r107, "sr_return_amt"
-  IterPrep     r108, r94
-  Len          r109, r108
-  Const        r110, 0
+  Const        r90, "ctr_total_return"
+  Const        r91, []
+  IterPrep     r92, r83
+  Len          r93, r92
+  Move         r94, r79
 L8:
-  LessInt      r112, r110, r109
-  JumpIfFalse  r112, L7
-  Index        r114, r108, r110
-  Const        r115, "sr_return_amt"
-  Index        r116, r114, r115
-  Append       r106, r106, r116
-  Const        r118, 1
-  AddInt       r110, r110, r118
+  LessInt      r95, r94, r93
+  JumpIfFalse  r95, L7
+  Index        r97, r92, r94
+  Index        r98, r97, r11
+  Append       r91, r91, r98
+  AddInt       r94, r94, r76
   Jump         L8
 L7:
-  Sum          r119, r106
+  Sum          r100, r91
   // ctr_customer_sk: g.key.customer_sk,
-  Move         r120, r95
-  Move         r121, r99
+  Move         r101, r84
+  Move         r102, r86
   // ctr_store_sk: g.key.store_sk,
-  Move         r122, r100
-  Move         r123, r104
+  Move         r103, r87
+  Move         r104, r89
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Move         r124, r105
-  Move         r125, r119
+  Move         r105, r90
+  Move         r106, r100
   // select {
-  MakeMap      r126, 3, r120
+  MakeMap      r107, 3, r101
   // from sr in store_returns
-  Append       r4, r4, r126
-  Const        r128, 1
-  AddInt       r89, r89, r128
+  Append       r1, r1, r107
+  AddInt       r78, r78, r76
   Jump         L9
 L6:
   // from ctr1 in customer_total_return
-  Const        r129, []
-  // where ctr1.ctr_total_return > avg(
-  Const        r130, "ctr_total_return"
-  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Const        r131, "ctr_store_sk"
-  Const        r132, "ctr_store_sk"
-  // select ctr2.ctr_total_return
-  Const        r133, "ctr_total_return"
+  Const        r109, []
   // s.s_state == "TN"
-  Const        r134, "s_state"
+  Const        r110, "s_state"
   // select {c_customer_id: c.c_customer_id}
-  Const        r135, "c_customer_id"
-  Const        r136, "c_customer_id"
-  // sort by c.c_customer_id
-  Const        r137, "c_customer_id"
+  Const        r111, "c_customer_id"
   // from ctr1 in customer_total_return
-  IterPrep     r138, r4
-  Len          r139, r138
-  Const        r140, 0
+  IterPrep     r112, r1
+  Len          r113, r112
+  Move         r114, r79
 L20:
-  LessInt      r142, r140, r139
-  JumpIfFalse  r142, L10
-  Index        r144, r138, r140
+  LessInt      r115, r114, r113
+  JumpIfFalse  r115, L10
+  Index        r117, r112, r114
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  IterPrep     r145, r2
-  Len          r146, r145
-  Const        r147, "ctr_store_sk"
-  Const        r148, "s_store_sk"
-  // where ctr1.ctr_total_return > avg(
-  Const        r149, "ctr_total_return"
-  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Const        r150, "ctr_store_sk"
-  Const        r151, "ctr_store_sk"
-  // select ctr2.ctr_total_return
-  Const        r152, "ctr_total_return"
-  // s.s_state == "TN"
-  Const        r153, "s_state"
-  // select {c_customer_id: c.c_customer_id}
-  Const        r154, "c_customer_id"
-  Const        r155, "c_customer_id"
-  // sort by c.c_customer_id
-  Const        r156, "c_customer_id"
-  // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  Const        r157, 0
+  IterPrep     r118, r0
+  Len          r119, r118
+  Const        r120, "s_store_sk"
+  Move         r121, r79
 L19:
-  LessInt      r159, r157, r146
-  JumpIfFalse  r159, L11
-  Index        r161, r145, r157
-  Const        r162, "ctr_store_sk"
-  Index        r163, r144, r162
-  Const        r164, "s_store_sk"
-  Index        r165, r161, r164
-  Equal        r166, r163, r165
-  JumpIfFalse  r166, L12
+  LessInt      r122, r121, r119
+  JumpIfFalse  r122, L11
+  Index        r124, r118, r121
+  Index        r125, r117, r9
+  Index        r126, r124, r120
+  Equal        r127, r125, r126
+  JumpIfFalse  r127, L12
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  IterPrep     r167, r3
-  Len          r168, r167
-  Const        r169, "ctr_customer_sk"
-  Const        r170, "c_customer_sk"
-  // where ctr1.ctr_total_return > avg(
-  Const        r171, "ctr_total_return"
-  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Const        r172, "ctr_store_sk"
-  Const        r173, "ctr_store_sk"
-  // select ctr2.ctr_total_return
-  Const        r174, "ctr_total_return"
-  // s.s_state == "TN"
-  Const        r175, "s_state"
-  // select {c_customer_id: c.c_customer_id}
-  Const        r176, "c_customer_id"
-  Const        r177, "c_customer_id"
-  // sort by c.c_customer_id
-  Const        r178, "c_customer_id"
-  // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  Const        r179, 0
+  IterPrep     r128, r0
+  Len          r129, r128
+  Const        r130, "c_customer_sk"
+  Move         r131, r79
 L18:
-  LessInt      r181, r179, r168
-  JumpIfFalse  r181, L12
-  Index        r183, r167, r179
-  Const        r184, "ctr_customer_sk"
-  Index        r185, r144, r184
-  Const        r186, "c_customer_sk"
-  Index        r187, r183, r186
-  Equal        r188, r185, r187
-  JumpIfFalse  r188, L13
+  LessInt      r132, r131, r129
+  JumpIfFalse  r132, L12
+  Index        r134, r128, r131
+  Index        r135, r117, r7
+  Index        r136, r134, r130
+  Equal        r137, r135, r136
+  JumpIfFalse  r137, L13
   // where ctr1.ctr_total_return > avg(
-  Const        r189, "ctr_total_return"
-  Index        r190, r144, r189
+  Index        r138, r117, r10
   // from ctr2 in customer_total_return
-  Const        r191, []
-  // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Const        r192, "ctr_store_sk"
-  Const        r193, "ctr_store_sk"
-  // select ctr2.ctr_total_return
-  Const        r194, "ctr_total_return"
-  // from ctr2 in customer_total_return
-  IterPrep     r195, r4
-  Len          r196, r195
-  Const        r197, 0
+  Const        r139, []
+  IterPrep     r140, r1
+  Len          r141, r140
+  Move         r142, r79
 L16:
-  LessInt      r199, r197, r196
-  JumpIfFalse  r199, L14
-  Index        r201, r195, r197
+  LessInt      r143, r142, r141
+  JumpIfFalse  r143, L14
+  Index        r145, r140, r142
   // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Const        r202, "ctr_store_sk"
-  Index        r203, r144, r202
-  Const        r204, "ctr_store_sk"
-  Index        r205, r201, r204
-  Equal        r206, r203, r205
-  JumpIfFalse  r206, L15
+  Index        r146, r117, r9
+  Index        r147, r145, r9
+  Equal        r148, r146, r147
+  JumpIfFalse  r148, L15
   // select ctr2.ctr_total_return
-  Const        r207, "ctr_total_return"
-  Index        r208, r201, r207
+  Index        r149, r145, r10
   // from ctr2 in customer_total_return
-  Append       r191, r191, r208
+  Append       r139, r139, r149
 L15:
-  Const        r210, 1
-  AddInt       r197, r197, r210
+  AddInt       r142, r142, r76
   Jump         L16
 L14:
   // where ctr1.ctr_total_return > avg(
-  Avg          r211, r191
+  Avg          r151, r139
   // ) * 1.2 &&
-  Const        r212, 1.2
-  MulFloat     r213, r211, r212
+  Const        r152, 1.2
+  MulFloat     r153, r151, r152
   // where ctr1.ctr_total_return > avg(
-  LessFloat    r214, r213, r190
+  LessFloat    r154, r153, r138
   // s.s_state == "TN"
-  Const        r215, "s_state"
-  Index        r216, r161, r215
-  Const        r217, "TN"
-  Equal        r218, r216, r217
+  Index        r155, r124, r110
+  Const        r156, "TN"
+  Equal        r157, r155, r156
   // ) * 1.2 &&
-  Move         r219, r214
-  JumpIfFalse  r219, L17
-  Move         r219, r218
+  JumpIfFalse  r154, L17
+  Move         r154, r157
 L17:
   // where ctr1.ctr_total_return > avg(
-  JumpIfFalse  r219, L13
+  JumpIfFalse  r154, L13
   // select {c_customer_id: c.c_customer_id}
-  Const        r220, "c_customer_id"
-  Const        r221, "c_customer_id"
-  Index        r222, r183, r221
-  Move         r223, r220
-  Move         r224, r222
-  MakeMap      r225, 1, r223
+  Const        r158, "c_customer_id"
+  Index        r159, r134, r111
+  Move         r160, r158
+  Move         r161, r159
+  MakeMap      r162, 1, r160
   // sort by c.c_customer_id
-  Const        r226, "c_customer_id"
-  Index        r228, r183, r226
+  Index        r164, r134, r111
   // from ctr1 in customer_total_return
-  Move         r229, r225
-  MakeList     r230, 2, r228
-  Append       r129, r129, r230
+  Move         r165, r162
+  MakeList     r166, 2, r164
+  Append       r109, r109, r166
 L13:
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  Const        r232, 1
-  Add          r179, r179, r232
+  Add          r131, r131, r76
   Jump         L18
 L12:
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  Const        r233, 1
-  Add          r157, r157, r233
+  Add          r121, r121, r76
   Jump         L19
 L11:
   // from ctr1 in customer_total_return
-  Const        r234, 1
-  AddInt       r140, r140, r234
+  AddInt       r114, r114, r76
   Jump         L20
 L10:
   // sort by c.c_customer_id
-  Sort         r129, r129
+  Sort         r109, r109
   // json(result)
-  JSON         r129
+  JSON         r109
   // expect len(result) == 0
-  Len          r236, r129
-  Const        r237, 0
-  EqualInt     r238, r236, r237
-  Expect       r238
+  Len          r169, r109
+  EqualInt     r170, r169, r79
+  Expect       r170
   Return       r0

--- a/tests/dataset/tpc-ds/out/q2.ir.out
+++ b/tests/dataset/tpc-ds/out/q2.ir.out
@@ -1,463 +1,387 @@
-func main (regs=325)
+func main (regs=242)
   // let web_sales = []
   Const        r0, []
-  // let catalog_sales = []
+  // (from ws in web_sales
   Const        r1, []
-  // let date_dim = []
-  Const        r2, []
-  // (from ws in web_sales
-  Const        r3, []
   // sold_date_sk: ws.ws_sold_date_sk,
-  Const        r4, "sold_date_sk"
-  Const        r5, "ws_sold_date_sk"
+  Const        r2, "sold_date_sk"
+  Const        r3, "ws_sold_date_sk"
   // sales_price: ws.ws_ext_sales_price,
-  Const        r6, "sales_price"
-  Const        r7, "ws_ext_sales_price"
+  Const        r4, "sales_price"
+  Const        r5, "ws_ext_sales_price"
   // day: ws.ws_sold_date_name
-  Const        r8, "day"
-  Const        r9, "ws_sold_date_name"
+  Const        r6, "day"
+  Const        r7, "ws_sold_date_name"
   // (from ws in web_sales
-  IterPrep     r10, r0
-  Len          r11, r10
-  Const        r12, 0
+  IterPrep     r8, r0
+  Len          r9, r8
+  Const        r11, 0
+  Move         r10, r11
 L1:
-  LessInt      r14, r12, r11
-  JumpIfFalse  r14, L0
-  Index        r16, r10, r12
+  LessInt      r12, r10, r9
+  JumpIfFalse  r12, L0
+  Index        r14, r8, r10
   // sold_date_sk: ws.ws_sold_date_sk,
-  Const        r17, "sold_date_sk"
-  Const        r18, "ws_sold_date_sk"
-  Index        r19, r16, r18
+  Const        r15, "sold_date_sk"
+  Index        r16, r14, r3
   // sales_price: ws.ws_ext_sales_price,
-  Const        r20, "sales_price"
-  Const        r21, "ws_ext_sales_price"
-  Index        r22, r16, r21
+  Const        r17, "sales_price"
+  Index        r18, r14, r5
   // day: ws.ws_sold_date_name
-  Const        r23, "day"
-  Const        r24, "ws_sold_date_name"
-  Index        r25, r16, r24
+  Const        r19, "day"
+  Index        r20, r14, r7
   // sold_date_sk: ws.ws_sold_date_sk,
-  Move         r26, r17
-  Move         r27, r19
+  Move         r21, r15
+  Move         r22, r16
   // sales_price: ws.ws_ext_sales_price,
-  Move         r28, r20
-  Move         r29, r22
+  Move         r23, r17
+  Move         r24, r18
   // day: ws.ws_sold_date_name
-  Move         r30, r23
-  Move         r31, r25
+  Move         r25, r19
+  Move         r26, r20
   // select {
-  MakeMap      r32, 3, r26
+  MakeMap      r27, 3, r21
   // (from ws in web_sales
-  Append       r3, r3, r32
-  Const        r34, 1
-  AddInt       r12, r12, r34
+  Append       r1, r1, r27
+  Const        r29, 1
+  AddInt       r10, r10, r29
   Jump         L1
 L0:
   // from cs in catalog_sales
-  Const        r35, []
+  Const        r30, []
   // sold_date_sk: cs.cs_sold_date_sk,
-  Const        r36, "sold_date_sk"
-  Const        r37, "cs_sold_date_sk"
+  Const        r31, "cs_sold_date_sk"
   // sales_price: cs.cs_ext_sales_price,
-  Const        r38, "sales_price"
-  Const        r39, "cs_ext_sales_price"
+  Const        r32, "cs_ext_sales_price"
   // day: cs.cs_sold_date_name
-  Const        r40, "day"
-  Const        r41, "cs_sold_date_name"
+  Const        r33, "cs_sold_date_name"
   // from cs in catalog_sales
-  IterPrep     r42, r1
-  Len          r43, r42
-  Const        r44, 0
+  IterPrep     r34, r0
+  Len          r35, r34
+  Move         r36, r11
 L3:
-  LessInt      r46, r44, r43
-  JumpIfFalse  r46, L2
-  Index        r48, r42, r44
+  LessInt      r37, r36, r35
+  JumpIfFalse  r37, L2
+  Index        r39, r34, r36
   // sold_date_sk: cs.cs_sold_date_sk,
-  Const        r49, "sold_date_sk"
-  Const        r50, "cs_sold_date_sk"
-  Index        r51, r48, r50
+  Const        r40, "sold_date_sk"
+  Index        r41, r39, r31
   // sales_price: cs.cs_ext_sales_price,
-  Const        r52, "sales_price"
-  Const        r53, "cs_ext_sales_price"
-  Index        r54, r48, r53
+  Const        r42, "sales_price"
+  Index        r43, r39, r32
   // day: cs.cs_sold_date_name
-  Const        r55, "day"
-  Const        r56, "cs_sold_date_name"
-  Index        r57, r48, r56
+  Const        r44, "day"
+  Index        r45, r39, r33
   // sold_date_sk: cs.cs_sold_date_sk,
-  Move         r58, r49
-  Move         r59, r51
+  Move         r46, r40
+  Move         r47, r41
   // sales_price: cs.cs_ext_sales_price,
-  Move         r60, r52
-  Move         r61, r54
+  Move         r48, r42
+  Move         r49, r43
   // day: cs.cs_sold_date_name
-  Move         r62, r55
-  Move         r63, r57
+  Move         r50, r44
+  Move         r51, r45
   // select {
-  MakeMap      r64, 3, r58
+  MakeMap      r52, 3, r46
   // from cs in catalog_sales
-  Append       r35, r35, r64
-  Const        r66, 1
-  AddInt       r44, r44, r66
+  Append       r30, r30, r52
+  AddInt       r36, r36, r29
   Jump         L3
 L2:
   // }) union all (
-  UnionAll     r67, r3, r35
+  UnionAll     r54, r1, r30
   // from w in wscs
-  Const        r68, []
+  Const        r55, []
   // group by {week_seq: d.d_week_seq} into g
-  Const        r69, "week_seq"
-  Const        r70, "d_week_seq"
+  Const        r56, "week_seq"
+  Const        r57, "d_week_seq"
   // d_week_seq: g.key.week_seq,
-  Const        r71, "d_week_seq"
-  Const        r72, "key"
-  Const        r73, "week_seq"
+  Const        r58, "key"
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Const        r74, "sun_sales"
-  Const        r75, "day"
-  Const        r76, "sales_price"
+  Const        r59, "sun_sales"
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Const        r77, "mon_sales"
-  Const        r78, "day"
-  Const        r79, "sales_price"
+  Const        r60, "mon_sales"
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Const        r80, "tue_sales"
-  Const        r81, "day"
-  Const        r82, "sales_price"
+  Const        r61, "tue_sales"
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Const        r83, "wed_sales"
-  Const        r84, "day"
-  Const        r85, "sales_price"
+  Const        r62, "wed_sales"
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Const        r86, "thu_sales"
-  Const        r87, "day"
-  Const        r88, "sales_price"
+  Const        r63, "thu_sales"
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Const        r89, "fri_sales"
-  Const        r90, "day"
-  Const        r91, "sales_price"
+  Const        r64, "fri_sales"
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Const        r92, "sat_sales"
-  Const        r93, "day"
-  Const        r94, "sales_price"
+  Const        r65, "sat_sales"
   // from w in wscs
-  MakeMap      r95, 0, r0
-  Const        r96, []
-  IterPrep     r98, r67
-  Len          r99, r98
-  Const        r100, 0
+  MakeMap      r66, 0, r0
+  Const        r67, []
+  IterPrep     r69, r54
+  Len          r70, r69
+  Const        r71, 0
 L9:
-  LessInt      r101, r100, r99
-  JumpIfFalse  r101, L4
-  Index        r103, r98, r100
+  LessInt      r72, r71, r70
+  JumpIfFalse  r72, L4
+  Index        r74, r69, r71
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  IterPrep     r104, r2
-  Len          r105, r104
-  Const        r106, 0
+  IterPrep     r75, r0
+  Len          r76, r75
+  Const        r77, 0
 L8:
-  LessInt      r107, r106, r105
-  JumpIfFalse  r107, L5
-  Index        r109, r104, r106
-  Const        r110, "sold_date_sk"
-  Index        r111, r103, r110
-  Const        r112, "d_date_sk"
-  Index        r113, r109, r112
-  Equal        r114, r111, r113
-  JumpIfFalse  r114, L6
+  LessInt      r78, r77, r76
+  JumpIfFalse  r78, L5
+  Index        r80, r75, r77
+  Index        r81, r74, r2
+  Const        r82, "d_date_sk"
+  Index        r83, r80, r82
+  Equal        r84, r81, r83
+  JumpIfFalse  r84, L6
   // from w in wscs
-  Const        r115, "w"
-  Move         r116, r103
-  Const        r117, "d"
-  Move         r118, r109
-  MakeMap      r119, 2, r115
+  Const        r85, "w"
+  Move         r86, r74
+  Const        r87, "d"
+  Move         r88, r80
+  MakeMap      r89, 2, r85
   // group by {week_seq: d.d_week_seq} into g
-  Const        r120, "week_seq"
-  Const        r121, "d_week_seq"
-  Index        r122, r109, r121
-  Move         r123, r120
-  Move         r124, r122
-  MakeMap      r125, 1, r123
-  Str          r126, r125
-  In           r127, r126, r95
-  JumpIfTrue   r127, L7
+  Const        r90, "week_seq"
+  Index        r91, r80, r57
+  Move         r92, r90
+  Move         r93, r91
+  MakeMap      r94, 1, r92
+  Str          r95, r94
+  In           r96, r95, r66
+  JumpIfTrue   r96, L7
   // from w in wscs
-  Const        r128, []
-  Const        r129, "__group__"
-  Const        r130, true
-  Const        r131, "key"
+  Const        r97, []
+  Const        r98, "__group__"
+  Const        r99, true
+  Const        r100, "key"
   // group by {week_seq: d.d_week_seq} into g
-  Move         r132, r125
+  Move         r101, r94
   // from w in wscs
-  Const        r133, "items"
-  Move         r134, r128
-  Const        r135, "count"
-  Const        r136, 0
-  Move         r137, r129
-  Move         r138, r130
-  Move         r139, r131
-  Move         r140, r132
-  Move         r141, r133
-  Move         r142, r134
-  Move         r143, r135
-  Move         r144, r136
-  MakeMap      r145, 4, r137
-  SetIndex     r95, r126, r145
-  Append       r96, r96, r145
+  Const        r102, "items"
+  Move         r103, r97
+  Const        r104, "count"
+  Const        r105, 0
+  Move         r106, r98
+  Move         r107, r99
+  Move         r108, r100
+  Move         r109, r101
+  Move         r110, r102
+  Move         r111, r103
+  Move         r112, r104
+  Move         r113, r105
+  MakeMap      r114, 4, r106
+  SetIndex     r66, r95, r114
+  Append       r67, r67, r114
 L7:
-  Const        r147, "items"
-  Index        r148, r95, r126
-  Index        r149, r148, r147
-  Append       r150, r149, r119
-  SetIndex     r148, r147, r150
-  Const        r151, "count"
-  Index        r152, r148, r151
-  Const        r153, 1
-  AddInt       r154, r152, r153
-  SetIndex     r148, r151, r154
+  Const        r116, "items"
+  Index        r117, r66, r95
+  Index        r118, r117, r116
+  Append       r119, r118, r89
+  SetIndex     r117, r116, r119
+  Const        r120, "count"
+  Index        r121, r117, r120
+  AddInt       r122, r121, r29
+  SetIndex     r117, r120, r122
 L6:
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  Const        r155, 1
-  AddInt       r106, r106, r155
+  AddInt       r77, r77, r29
   Jump         L8
 L5:
   // from w in wscs
-  Const        r156, 1
-  AddInt       r100, r100, r156
+  AddInt       r71, r71, r29
   Jump         L9
 L4:
-  Const        r157, 0
-  Len          r159, r96
+  Move         r123, r11
+  Len          r124, r67
 L32:
-  LessInt      r160, r157, r159
-  JumpIfFalse  r160, L10
-  Index        r162, r96, r157
+  LessInt      r125, r123, r124
+  JumpIfFalse  r125, L10
+  Index        r127, r67, r123
   // d_week_seq: g.key.week_seq,
-  Const        r163, "d_week_seq"
-  Const        r164, "key"
-  Index        r165, r162, r164
-  Const        r166, "week_seq"
-  Index        r167, r165, r166
+  Const        r128, "d_week_seq"
+  Index        r129, r127, r58
+  Index        r130, r129, r56
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Const        r168, "sun_sales"
-  Const        r169, []
-  Const        r170, "day"
-  Const        r171, "sales_price"
-  IterPrep     r172, r162
-  Len          r173, r172
-  Const        r174, 0
+  Const        r131, "sun_sales"
+  Const        r132, []
+  IterPrep     r133, r127
+  Len          r134, r133
+  Move         r135, r11
 L13:
-  LessInt      r176, r174, r173
-  JumpIfFalse  r176, L11
-  Index        r178, r172, r174
-  Const        r179, "day"
-  Index        r180, r178, r179
-  Const        r181, "Sunday"
-  Equal        r182, r180, r181
-  JumpIfFalse  r182, L12
-  Const        r183, "sales_price"
-  Index        r184, r178, r183
-  Append       r169, r169, r184
+  LessInt      r136, r135, r134
+  JumpIfFalse  r136, L11
+  Index        r138, r133, r135
+  Index        r139, r138, r6
+  Const        r140, "Sunday"
+  Equal        r141, r139, r140
+  JumpIfFalse  r141, L12
+  Index        r142, r138, r4
+  Append       r132, r132, r142
 L12:
-  Const        r186, 1
-  AddInt       r174, r174, r186
+  AddInt       r135, r135, r29
   Jump         L13
 L11:
-  Sum          r187, r169
+  Sum          r144, r132
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Const        r188, "mon_sales"
-  Const        r189, []
-  Const        r190, "day"
-  Const        r191, "sales_price"
-  IterPrep     r192, r162
-  Len          r193, r192
-  Const        r194, 0
+  Const        r145, "mon_sales"
+  Const        r146, []
+  IterPrep     r147, r127
+  Len          r148, r147
+  Move         r149, r11
 L16:
-  LessInt      r196, r194, r193
-  JumpIfFalse  r196, L14
-  Index        r178, r192, r194
-  Const        r198, "day"
-  Index        r199, r178, r198
-  Const        r200, "Monday"
-  Equal        r201, r199, r200
-  JumpIfFalse  r201, L15
-  Const        r202, "sales_price"
-  Index        r203, r178, r202
-  Append       r189, r189, r203
+  LessInt      r150, r149, r148
+  JumpIfFalse  r150, L14
+  Index        r138, r147, r149
+  Index        r152, r138, r6
+  Const        r153, "Monday"
+  Equal        r154, r152, r153
+  JumpIfFalse  r154, L15
+  Index        r155, r138, r4
+  Append       r146, r146, r155
 L15:
-  Const        r205, 1
-  AddInt       r194, r194, r205
+  AddInt       r149, r149, r29
   Jump         L16
 L14:
-  Sum          r206, r189
+  Sum          r157, r146
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Const        r207, "tue_sales"
-  Const        r208, []
-  Const        r209, "day"
-  Const        r210, "sales_price"
-  IterPrep     r211, r162
-  Len          r212, r211
-  Const        r213, 0
+  Const        r158, "tue_sales"
+  Const        r159, []
+  IterPrep     r160, r127
+  Len          r161, r160
+  Move         r162, r11
 L19:
-  LessInt      r215, r213, r212
-  JumpIfFalse  r215, L17
-  Index        r178, r211, r213
-  Const        r217, "day"
-  Index        r218, r178, r217
-  Const        r219, "Tuesday"
-  Equal        r220, r218, r219
-  JumpIfFalse  r220, L18
-  Const        r221, "sales_price"
-  Index        r222, r178, r221
-  Append       r208, r208, r222
+  LessInt      r163, r162, r161
+  JumpIfFalse  r163, L17
+  Index        r138, r160, r162
+  Index        r165, r138, r6
+  Const        r166, "Tuesday"
+  Equal        r167, r165, r166
+  JumpIfFalse  r167, L18
+  Index        r168, r138, r4
+  Append       r159, r159, r168
 L18:
-  Const        r224, 1
-  AddInt       r213, r213, r224
+  AddInt       r162, r162, r29
   Jump         L19
 L17:
-  Sum          r225, r208
+  Sum          r170, r159
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Const        r226, "wed_sales"
-  Const        r227, []
-  Const        r228, "day"
-  Const        r229, "sales_price"
-  IterPrep     r230, r162
-  Len          r231, r230
-  Const        r232, 0
+  Const        r171, "wed_sales"
+  Const        r172, []
+  IterPrep     r173, r127
+  Len          r174, r173
+  Move         r175, r11
 L22:
-  LessInt      r234, r232, r231
-  JumpIfFalse  r234, L20
-  Index        r178, r230, r232
-  Const        r236, "day"
-  Index        r237, r178, r236
-  Const        r238, "Wednesday"
-  Equal        r239, r237, r238
-  JumpIfFalse  r239, L21
-  Const        r240, "sales_price"
-  Index        r241, r178, r240
-  Append       r227, r227, r241
+  LessInt      r176, r175, r174
+  JumpIfFalse  r176, L20
+  Index        r138, r173, r175
+  Index        r178, r138, r6
+  Const        r179, "Wednesday"
+  Equal        r180, r178, r179
+  JumpIfFalse  r180, L21
+  Index        r181, r138, r4
+  Append       r172, r172, r181
 L21:
-  Const        r243, 1
-  AddInt       r232, r232, r243
+  AddInt       r175, r175, r29
   Jump         L22
 L20:
-  Sum          r244, r227
+  Sum          r183, r172
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Const        r245, "thu_sales"
-  Const        r246, []
-  Const        r247, "day"
-  Const        r248, "sales_price"
-  IterPrep     r249, r162
-  Len          r250, r249
-  Const        r251, 0
+  Const        r184, "thu_sales"
+  Const        r185, []
+  IterPrep     r186, r127
+  Len          r187, r186
+  Move         r188, r11
 L25:
-  LessInt      r253, r251, r250
-  JumpIfFalse  r253, L23
-  Index        r178, r249, r251
-  Const        r255, "day"
-  Index        r256, r178, r255
-  Const        r257, "Thursday"
-  Equal        r258, r256, r257
-  JumpIfFalse  r258, L24
-  Const        r259, "sales_price"
-  Index        r260, r178, r259
-  Append       r246, r246, r260
+  LessInt      r189, r188, r187
+  JumpIfFalse  r189, L23
+  Index        r138, r186, r188
+  Index        r191, r138, r6
+  Const        r192, "Thursday"
+  Equal        r193, r191, r192
+  JumpIfFalse  r193, L24
+  Index        r194, r138, r4
+  Append       r185, r185, r194
 L24:
-  Const        r262, 1
-  AddInt       r251, r251, r262
+  AddInt       r188, r188, r29
   Jump         L25
 L23:
-  Sum          r263, r246
+  Sum          r196, r185
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Const        r264, "fri_sales"
-  Const        r265, []
-  Const        r266, "day"
-  Const        r267, "sales_price"
-  IterPrep     r268, r162
-  Len          r269, r268
-  Const        r270, 0
+  Const        r197, "fri_sales"
+  Const        r198, []
+  IterPrep     r199, r127
+  Len          r200, r199
+  Move         r201, r11
 L28:
-  LessInt      r272, r270, r269
-  JumpIfFalse  r272, L26
-  Index        r178, r268, r270
-  Const        r274, "day"
-  Index        r275, r178, r274
-  Const        r276, "Friday"
-  Equal        r277, r275, r276
-  JumpIfFalse  r277, L27
-  Const        r278, "sales_price"
-  Index        r279, r178, r278
-  Append       r265, r265, r279
+  LessInt      r202, r201, r200
+  JumpIfFalse  r202, L26
+  Index        r138, r199, r201
+  Index        r204, r138, r6
+  Const        r205, "Friday"
+  Equal        r206, r204, r205
+  JumpIfFalse  r206, L27
+  Index        r207, r138, r4
+  Append       r198, r198, r207
 L27:
-  Const        r281, 1
-  AddInt       r270, r270, r281
+  AddInt       r201, r201, r29
   Jump         L28
 L26:
-  Sum          r282, r265
+  Sum          r209, r198
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Const        r283, "sat_sales"
-  Const        r284, []
-  Const        r285, "day"
-  Const        r286, "sales_price"
-  IterPrep     r287, r162
-  Len          r288, r287
-  Const        r289, 0
+  Const        r210, "sat_sales"
+  Const        r211, []
+  IterPrep     r212, r127
+  Len          r213, r212
+  Move         r214, r11
 L31:
-  LessInt      r291, r289, r288
-  JumpIfFalse  r291, L29
-  Index        r178, r287, r289
-  Const        r293, "day"
-  Index        r294, r178, r293
-  Const        r295, "Saturday"
-  Equal        r296, r294, r295
-  JumpIfFalse  r296, L30
-  Const        r297, "sales_price"
-  Index        r298, r178, r297
-  Append       r284, r284, r298
+  LessInt      r215, r214, r213
+  JumpIfFalse  r215, L29
+  Index        r138, r212, r214
+  Index        r217, r138, r6
+  Const        r218, "Saturday"
+  Equal        r219, r217, r218
+  JumpIfFalse  r219, L30
+  Index        r220, r138, r4
+  Append       r211, r211, r220
 L30:
-  Const        r300, 1
-  AddInt       r289, r289, r300
+  AddInt       r214, r214, r29
   Jump         L31
 L29:
-  Sum          r301, r284
+  Sum          r222, r211
   // d_week_seq: g.key.week_seq,
-  Move         r302, r163
-  Move         r303, r167
+  Move         r223, r128
+  Move         r224, r130
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Move         r304, r168
-  Move         r305, r187
+  Move         r225, r131
+  Move         r226, r144
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Move         r306, r188
-  Move         r307, r206
+  Move         r227, r145
+  Move         r228, r157
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Move         r308, r207
-  Move         r309, r225
+  Move         r229, r158
+  Move         r230, r170
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Move         r310, r226
-  Move         r311, r244
+  Move         r231, r171
+  Move         r232, r183
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Move         r312, r245
-  Move         r313, r263
+  Move         r233, r184
+  Move         r234, r196
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Move         r314, r264
-  Move         r315, r282
+  Move         r235, r197
+  Move         r236, r209
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Move         r316, r283
-  Move         r317, r301
+  Move         r237, r210
+  Move         r238, r222
   // select {
-  MakeMap      r318, 8, r302
+  MakeMap      r239, 8, r223
   // from w in wscs
-  Append       r68, r68, r318
-  Const        r320, 1
-  AddInt       r157, r157, r320
+  Append       r55, r55, r239
+  AddInt       r123, r123, r29
   Jump         L32
 L10:
-  // let result = []
-  Const        r321, []
   // json(result)
-  JSON         r321
+  JSON         r0
   // expect len(result) == 0
-  Const        r322, 0
-  Const        r323, 0
-  Const        r324, true
-  Expect       r324
+  Const        r241, true
+  Expect       r241
   Return       r0

--- a/tests/dataset/tpc-ds/out/q3.ir.out
+++ b/tests/dataset/tpc-ds/out/q3.ir.out
@@ -1,286 +1,231 @@
-func main (regs=211)
+func main (regs=160)
   // let date_dim = []
   Const        r0, []
-  // let store_sales = []
+  // from dt in date_dim
   Const        r1, []
-  // let item = []
-  Const        r2, []
-  // from dt in date_dim
-  Const        r3, []
   // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Const        r4, "d_year"
-  Const        r5, "d_year"
-  Const        r6, "brand_id"
-  Const        r7, "i_brand_id"
-  Const        r8, "brand"
-  Const        r9, "i_brand"
+  Const        r2, "d_year"
+  Const        r3, "brand_id"
+  Const        r4, "i_brand_id"
+  Const        r5, "brand"
+  Const        r6, "i_brand"
   // where i.i_manufact_id == 100 && dt.d_moy == 12
-  Const        r10, "i_manufact_id"
-  Const        r11, "d_moy"
+  Const        r7, "i_manufact_id"
+  Const        r8, "d_moy"
   // d_year: g.key.d_year,
-  Const        r12, "d_year"
-  Const        r13, "key"
-  Const        r14, "d_year"
-  // brand_id: g.key.brand_id,
-  Const        r15, "brand_id"
-  Const        r16, "key"
-  Const        r17, "brand_id"
-  // brand: g.key.brand,
-  Const        r18, "brand"
-  Const        r19, "key"
-  Const        r20, "brand"
+  Const        r9, "key"
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Const        r21, "sum_agg"
-  Const        r22, "ss"
-  Const        r23, "ss_ext_sales_price"
-  // sort by [g.key.d_year,
-  Const        r24, "key"
-  Const        r25, "d_year"
-  // -sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r26, "ss"
-  Const        r27, "ss_ext_sales_price"
-  // g.key.brand_id]
-  Const        r28, "key"
-  Const        r29, "brand_id"
+  Const        r10, "sum_agg"
+  Const        r11, "ss"
+  Const        r12, "ss_ext_sales_price"
   // from dt in date_dim
-  MakeMap      r30, 0, r0
-  Const        r31, []
+  MakeMap      r13, 0, r0
+  Const        r14, []
+  IterPrep     r16, r0
+  Len          r17, r16
+  Const        r18, 0
+L8:
+  LessInt      r19, r18, r17
+  JumpIfFalse  r19, L0
+  Index        r21, r16, r18
+  // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
+  IterPrep     r22, r0
+  Len          r23, r22
+  Const        r24, 0
+L7:
+  LessInt      r25, r24, r23
+  JumpIfFalse  r25, L1
+  Index        r27, r22, r24
+  Const        r28, "d_date_sk"
+  Index        r29, r21, r28
+  Const        r30, "ss_sold_date_sk"
+  Index        r31, r27, r30
+  Equal        r32, r29, r31
+  JumpIfFalse  r32, L2
+  // join i in item on ss.ss_item_sk == i.i_item_sk
   IterPrep     r33, r0
   Len          r34, r33
   Const        r35, 0
-L8:
-  LessInt      r36, r35, r34
-  JumpIfFalse  r36, L0
-  Index        r38, r33, r35
-  // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
-  IterPrep     r39, r1
-  Len          r40, r39
-  Const        r41, 0
-L7:
-  LessInt      r42, r41, r40
-  JumpIfFalse  r42, L1
-  Index        r44, r39, r41
-  Const        r45, "d_date_sk"
-  Index        r46, r38, r45
-  Const        r47, "ss_sold_date_sk"
-  Index        r48, r44, r47
-  Equal        r49, r46, r48
-  JumpIfFalse  r49, L2
-  // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r50, r2
-  Len          r51, r50
-  Const        r52, 0
 L6:
-  LessInt      r53, r52, r51
-  JumpIfFalse  r53, L2
-  Index        r55, r50, r52
-  Const        r56, "ss_item_sk"
-  Index        r57, r44, r56
-  Const        r58, "i_item_sk"
-  Index        r59, r55, r58
-  Equal        r60, r57, r59
-  JumpIfFalse  r60, L3
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L2
+  Index        r38, r33, r35
+  Const        r39, "ss_item_sk"
+  Index        r40, r27, r39
+  Const        r41, "i_item_sk"
+  Index        r42, r38, r41
+  Equal        r43, r40, r42
+  JumpIfFalse  r43, L3
   // where i.i_manufact_id == 100 && dt.d_moy == 12
-  Const        r61, "i_manufact_id"
-  Index        r62, r55, r61
-  Const        r63, 100
-  Equal        r64, r62, r63
-  Const        r65, "d_moy"
-  Index        r66, r38, r65
-  Const        r67, 12
-  Equal        r68, r66, r67
-  Move         r69, r64
-  JumpIfFalse  r69, L4
-  Move         r69, r68
+  Index        r44, r38, r7
+  Const        r45, 100
+  Equal        r46, r44, r45
+  Index        r47, r21, r8
+  Const        r48, 12
+  Equal        r49, r47, r48
+  JumpIfFalse  r46, L4
+  Move         r46, r49
 L4:
-  JumpIfFalse  r69, L3
+  JumpIfFalse  r46, L3
   // from dt in date_dim
-  Const        r70, "dt"
-  Move         r71, r38
-  Const        r72, "ss"
-  Move         r73, r44
-  Const        r74, "i"
-  Move         r75, r55
-  MakeMap      r76, 3, r70
+  Const        r50, "dt"
+  Move         r51, r21
+  Move         r52, r27
+  Const        r53, "i"
+  Move         r54, r38
+  MakeMap      r55, 3, r50
   // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Const        r77, "d_year"
-  Const        r78, "d_year"
-  Index        r79, r38, r78
-  Const        r80, "brand_id"
-  Const        r81, "i_brand_id"
-  Index        r82, r55, r81
-  Const        r83, "brand"
-  Const        r84, "i_brand"
-  Index        r85, r55, r84
-  Move         r86, r77
+  Const        r56, "d_year"
+  Index        r57, r21, r2
+  Const        r58, "brand_id"
+  Index        r59, r38, r4
+  Const        r60, "brand"
+  Index        r61, r38, r6
+  Move         r62, r56
+  Move         r63, r57
+  Move         r64, r58
+  Move         r65, r59
+  Move         r66, r60
+  Move         r67, r61
+  MakeMap      r68, 3, r62
+  Str          r69, r68
+  In           r70, r69, r13
+  JumpIfTrue   r70, L5
+  // from dt in date_dim
+  Const        r71, []
+  Const        r72, "__group__"
+  Const        r73, true
+  Const        r74, "key"
+  // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
+  Move         r75, r68
+  // from dt in date_dim
+  Const        r76, "items"
+  Move         r77, r71
+  Const        r78, "count"
+  Const        r79, 0
+  Move         r80, r72
+  Move         r81, r73
+  Move         r82, r74
+  Move         r83, r75
+  Move         r84, r76
+  Move         r85, r77
+  Move         r86, r78
   Move         r87, r79
-  Move         r88, r80
-  Move         r89, r82
-  Move         r90, r83
-  Move         r91, r85
-  MakeMap      r92, 3, r86
-  Str          r93, r92
-  In           r94, r93, r30
-  JumpIfTrue   r94, L5
-  // from dt in date_dim
-  Const        r95, []
-  Const        r96, "__group__"
-  Const        r97, true
-  Const        r98, "key"
-  // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Move         r99, r92
-  // from dt in date_dim
-  Const        r100, "items"
-  Move         r101, r95
-  Const        r102, "count"
-  Const        r103, 0
-  Move         r104, r96
-  Move         r105, r97
-  Move         r106, r98
-  Move         r107, r99
-  Move         r108, r100
-  Move         r109, r101
-  Move         r110, r102
-  Move         r111, r103
-  MakeMap      r112, 4, r104
-  SetIndex     r30, r93, r112
-  Append       r31, r31, r112
+  MakeMap      r88, 4, r80
+  SetIndex     r13, r69, r88
+  Append       r14, r14, r88
 L5:
-  Const        r114, "items"
-  Index        r115, r30, r93
-  Index        r116, r115, r114
-  Append       r117, r116, r76
-  SetIndex     r115, r114, r117
-  Const        r118, "count"
-  Index        r119, r115, r118
-  Const        r120, 1
-  AddInt       r121, r119, r120
-  SetIndex     r115, r118, r121
+  Const        r90, "items"
+  Index        r91, r13, r69
+  Index        r92, r91, r90
+  Append       r93, r92, r55
+  SetIndex     r91, r90, r93
+  Const        r94, "count"
+  Index        r95, r91, r94
+  Const        r96, 1
+  AddInt       r97, r95, r96
+  SetIndex     r91, r94, r97
 L3:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  Const        r122, 1
-  AddInt       r52, r52, r122
+  AddInt       r35, r35, r96
   Jump         L6
 L2:
   // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
-  Const        r123, 1
-  AddInt       r41, r41, r123
+  AddInt       r24, r24, r96
   Jump         L7
 L1:
   // from dt in date_dim
-  Const        r124, 1
-  AddInt       r35, r35, r124
+  AddInt       r18, r18, r96
   Jump         L8
 L0:
-  Const        r125, 0
-  Len          r127, r31
+  Const        r99, 0
+  Move         r98, r99
+  Len          r100, r14
 L14:
-  LessInt      r128, r125, r127
-  JumpIfFalse  r128, L9
-  Index        r130, r31, r125
+  LessInt      r101, r98, r100
+  JumpIfFalse  r101, L9
+  Index        r103, r14, r98
   // d_year: g.key.d_year,
-  Const        r131, "d_year"
-  Const        r132, "key"
-  Index        r133, r130, r132
-  Const        r134, "d_year"
-  Index        r135, r133, r134
+  Const        r104, "d_year"
+  Index        r105, r103, r9
+  Index        r106, r105, r2
   // brand_id: g.key.brand_id,
-  Const        r136, "brand_id"
-  Const        r137, "key"
-  Index        r138, r130, r137
-  Const        r139, "brand_id"
-  Index        r140, r138, r139
+  Const        r107, "brand_id"
+  Index        r108, r103, r9
+  Index        r109, r108, r3
   // brand: g.key.brand,
-  Const        r141, "brand"
-  Const        r142, "key"
-  Index        r143, r130, r142
-  Const        r144, "brand"
-  Index        r145, r143, r144
+  Const        r110, "brand"
+  Index        r111, r103, r9
+  Index        r112, r111, r5
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Const        r146, "sum_agg"
-  Const        r147, []
-  Const        r148, "ss"
-  Const        r149, "ss_ext_sales_price"
-  IterPrep     r150, r130
-  Len          r151, r150
-  Const        r152, 0
+  Const        r113, "sum_agg"
+  Const        r114, []
+  IterPrep     r115, r103
+  Len          r116, r115
+  Move         r117, r99
 L11:
-  LessInt      r154, r152, r151
-  JumpIfFalse  r154, L10
-  Index        r156, r150, r152
-  Const        r157, "ss"
-  Index        r158, r156, r157
-  Const        r159, "ss_ext_sales_price"
-  Index        r160, r158, r159
-  Append       r147, r147, r160
-  Const        r162, 1
-  AddInt       r152, r152, r162
+  LessInt      r118, r117, r116
+  JumpIfFalse  r118, L10
+  Index        r120, r115, r117
+  Index        r121, r120, r11
+  Index        r122, r121, r12
+  Append       r114, r114, r122
+  AddInt       r117, r117, r96
   Jump         L11
 L10:
-  Sum          r163, r147
+  Sum          r124, r114
   // d_year: g.key.d_year,
-  Move         r164, r131
-  Move         r165, r135
+  Move         r125, r104
+  Move         r126, r106
   // brand_id: g.key.brand_id,
-  Move         r166, r136
-  Move         r167, r140
+  Move         r127, r107
+  Move         r128, r109
   // brand: g.key.brand,
-  Move         r168, r141
-  Move         r169, r145
+  Move         r129, r110
+  Move         r130, r112
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Move         r170, r146
-  Move         r171, r163
+  Move         r131, r113
+  Move         r132, r124
   // select {
-  MakeMap      r172, 4, r164
+  MakeMap      r133, 4, r125
   // sort by [g.key.d_year,
-  Const        r173, "key"
-  Index        r174, r130, r173
-  Const        r175, "d_year"
-  Index        r177, r174, r175
+  Index        r134, r103, r9
+  Index        r136, r134, r2
   // -sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r178, []
-  Const        r179, "ss"
-  Const        r180, "ss_ext_sales_price"
-  IterPrep     r181, r130
-  Len          r182, r181
-  Const        r183, 0
+  Const        r137, []
+  IterPrep     r138, r103
+  Len          r139, r138
+  Move         r140, r99
 L13:
-  LessInt      r185, r183, r182
-  JumpIfFalse  r185, L12
-  Index        r156, r181, r183
-  Const        r187, "ss"
-  Index        r188, r156, r187
-  Const        r189, "ss_ext_sales_price"
-  Index        r190, r188, r189
-  Append       r178, r178, r190
-  Const        r192, 1
-  AddInt       r183, r183, r192
+  LessInt      r141, r140, r139
+  JumpIfFalse  r141, L12
+  Index        r120, r138, r140
+  Index        r143, r120, r11
+  Index        r144, r143, r12
+  Append       r137, r137, r144
+  AddInt       r140, r140, r96
   Jump         L13
 L12:
-  Sum          r193, r178
-  Neg          r195, r193
+  Sum          r146, r137
+  Neg          r148, r146
   // g.key.brand_id]
-  Const        r196, "key"
-  Index        r197, r130, r196
-  Const        r198, "brand_id"
-  Index        r200, r197, r198
+  Index        r149, r103, r9
+  Index        r151, r149, r3
   // sort by [g.key.d_year,
-  MakeList     r202, 3, r177
+  MakeList     r153, 3, r136
   // from dt in date_dim
-  Move         r203, r172
-  MakeList     r204, 2, r202
-  Append       r3, r3, r204
-  Const        r206, 1
-  AddInt       r125, r125, r206
+  Move         r154, r133
+  MakeList     r155, 2, r153
+  Append       r1, r1, r155
+  AddInt       r98, r98, r96
   Jump         L14
 L9:
   // sort by [g.key.d_year,
-  Sort         r3, r3
+  Sort         r1, r1
   // json(result)
-  JSON         r3
+  JSON         r1
   // expect len(result) == 0
-  Len          r208, r3
-  Const        r209, 0
-  EqualInt     r210, r208, r209
-  Expect       r210
+  Len          r158, r1
+  EqualInt     r159, r158, r99
+  Expect       r159
   Return       r0

--- a/tests/dataset/tpc-ds/out/q4.ir.out
+++ b/tests/dataset/tpc-ds/out/q4.ir.out
@@ -1,1498 +1,888 @@
-func main (regs=1089)
+func main (regs=592)
   // let customer = []
   Const        r0, []
-  // let store_sales = []
+  // from c in customer
   Const        r1, []
-  // let catalog_sales = []
-  Const        r2, []
-  // let web_sales = []
-  Const        r3, []
-  // let date_dim = []
-  Const        r4, []
-  // from c in customer
-  Const        r5, []
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r6, "id"
-  Const        r7, "c_customer_id"
-  Const        r8, "first"
-  Const        r9, "c_first_name"
-  Const        r10, "last"
-  Const        r11, "c_last_name"
-  Const        r12, "login"
-  Const        r13, "c_login"
-  Const        r14, "year"
-  Const        r15, "d_year"
+  Const        r2, "id"
+  Const        r3, "c_customer_id"
+  Const        r4, "first"
+  Const        r5, "c_first_name"
+  Const        r6, "last"
+  Const        r7, "c_last_name"
+  Const        r8, "login"
+  Const        r9, "c_login"
+  Const        r10, "year"
+  Const        r11, "d_year"
   // customer_id: g.key.id,
-  Const        r16, "customer_id"
-  Const        r17, "key"
-  Const        r18, "id"
+  Const        r12, "customer_id"
+  Const        r13, "key"
   // customer_first_name: g.key.first,
-  Const        r19, "customer_first_name"
-  Const        r20, "key"
-  Const        r21, "first"
+  Const        r14, "customer_first_name"
   // customer_last_name: g.key.last,
-  Const        r22, "customer_last_name"
-  Const        r23, "key"
-  Const        r24, "last"
+  Const        r15, "customer_last_name"
   // customer_login: g.key.login,
-  Const        r25, "customer_login"
-  Const        r26, "key"
-  Const        r27, "login"
+  Const        r16, "customer_login"
   // dyear: g.key.year,
-  Const        r28, "dyear"
-  Const        r29, "key"
-  Const        r30, "year"
+  Const        r17, "dyear"
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Const        r31, "year_total"
-  Const        r32, "ss_ext_list_price"
-  Const        r33, "ss_ext_wholesale_cost"
-  Const        r34, "ss_ext_discount_amt"
-  Const        r35, "ss_ext_sales_price"
+  Const        r18, "year_total"
+  Const        r19, "ss_ext_list_price"
+  Const        r20, "ss_ext_wholesale_cost"
+  Const        r21, "ss_ext_discount_amt"
+  Const        r22, "ss_ext_sales_price"
   // sale_type: "s",
-  Const        r36, "sale_type"
+  Const        r23, "sale_type"
   // from c in customer
-  MakeMap      r37, 0, r0
-  Const        r38, []
-  IterPrep     r40, r0
-  Len          r41, r40
-  Const        r42, 0
+  MakeMap      r24, 0, r0
+  Const        r25, []
+  IterPrep     r27, r0
+  Len          r28, r27
+  Const        r29, 0
 L7:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L0
-  Index        r45, r40, r42
+  LessInt      r30, r29, r28
+  JumpIfFalse  r30, L0
+  Index        r32, r27, r29
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  IterPrep     r46, r1
-  Len          r47, r46
-  Const        r48, 0
+  IterPrep     r33, r0
+  Len          r34, r33
+  Const        r35, 0
 L6:
-  LessInt      r49, r48, r47
-  JumpIfFalse  r49, L1
-  Index        r51, r46, r48
-  Const        r52, "c_customer_sk"
-  Index        r53, r45, r52
-  Const        r54, "ss_customer_sk"
-  Index        r55, r51, r54
-  Equal        r56, r53, r55
-  JumpIfFalse  r56, L2
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L1
+  Index        r38, r33, r35
+  Const        r39, "c_customer_sk"
+  Index        r40, r32, r39
+  Const        r41, "ss_customer_sk"
+  Index        r42, r38, r41
+  Equal        r43, r40, r42
+  JumpIfFalse  r43, L2
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r57, r4
-  Len          r58, r57
-  Const        r59, 0
+  IterPrep     r44, r0
+  Len          r45, r44
+  Const        r46, 0
 L5:
-  LessInt      r60, r59, r58
-  JumpIfFalse  r60, L2
-  Index        r62, r57, r59
-  Const        r63, "ss_sold_date_sk"
-  Index        r64, r51, r63
-  Const        r65, "d_date_sk"
-  Index        r66, r62, r65
-  Equal        r67, r64, r66
-  JumpIfFalse  r67, L3
+  LessInt      r47, r46, r45
+  JumpIfFalse  r47, L2
+  Index        r49, r44, r46
+  Const        r50, "ss_sold_date_sk"
+  Index        r51, r38, r50
+  Const        r52, "d_date_sk"
+  Index        r53, r49, r52
+  Equal        r54, r51, r53
+  JumpIfFalse  r54, L3
   // from c in customer
-  Const        r68, "c"
-  Move         r69, r45
-  Const        r70, "s"
-  Move         r71, r51
-  Const        r72, "d"
-  Move         r73, r62
-  MakeMap      r74, 3, r68
+  Const        r55, "c"
+  Move         r56, r32
+  Const        r57, "s"
+  Move         r58, r38
+  Const        r59, "d"
+  Move         r60, r49
+  MakeMap      r61, 3, r55
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r75, "id"
-  Const        r76, "c_customer_id"
-  Index        r77, r45, r76
-  Const        r78, "first"
-  Const        r79, "c_first_name"
-  Index        r80, r45, r79
-  Const        r81, "last"
-  Const        r82, "c_last_name"
-  Index        r83, r45, r82
-  Const        r84, "login"
-  Const        r85, "c_login"
-  Index        r86, r45, r85
-  Const        r87, "year"
-  Const        r88, "d_year"
-  Index        r89, r62, r88
-  Move         r90, r75
-  Move         r91, r77
-  Move         r92, r78
-  Move         r93, r80
-  Move         r94, r81
-  Move         r95, r83
-  Move         r96, r84
-  Move         r97, r86
-  Move         r98, r87
-  Move         r99, r89
-  MakeMap      r100, 5, r90
-  Str          r101, r100
-  In           r102, r101, r37
-  JumpIfTrue   r102, L4
+  Const        r62, "id"
+  Index        r63, r32, r3
+  Const        r64, "first"
+  Index        r65, r32, r5
+  Const        r66, "last"
+  Index        r67, r32, r7
+  Const        r68, "login"
+  Index        r69, r32, r9
+  Const        r70, "year"
+  Index        r71, r49, r11
+  Move         r72, r62
+  Move         r73, r63
+  Move         r74, r64
+  Move         r75, r65
+  Move         r76, r66
+  Move         r77, r67
+  Move         r78, r68
+  Move         r79, r69
+  Move         r80, r70
+  Move         r81, r71
+  MakeMap      r82, 5, r72
+  Str          r83, r82
+  In           r84, r83, r24
+  JumpIfTrue   r84, L4
   // from c in customer
-  Const        r103, []
-  Const        r104, "__group__"
-  Const        r105, true
-  Const        r106, "key"
+  Const        r85, []
+  Const        r86, "__group__"
+  Const        r87, true
+  Const        r88, "key"
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r107, r100
+  Move         r89, r82
   // from c in customer
-  Const        r108, "items"
-  Move         r109, r103
-  Const        r110, "count"
-  Const        r111, 0
-  Move         r112, r104
-  Move         r113, r105
-  Move         r114, r106
-  Move         r115, r107
-  Move         r116, r108
-  Move         r117, r109
-  Move         r118, r110
-  Move         r119, r111
-  MakeMap      r120, 4, r112
-  SetIndex     r37, r101, r120
-  Append       r38, r38, r120
+  Const        r90, "items"
+  Move         r91, r85
+  Const        r92, "count"
+  Const        r93, 0
+  Move         r94, r86
+  Move         r95, r87
+  Move         r96, r88
+  Move         r97, r89
+  Move         r98, r90
+  Move         r99, r91
+  Move         r100, r92
+  Move         r101, r93
+  MakeMap      r102, 4, r94
+  SetIndex     r24, r83, r102
+  Append       r25, r25, r102
 L4:
-  Const        r122, "items"
-  Index        r123, r37, r101
-  Index        r124, r123, r122
-  Append       r125, r124, r74
-  SetIndex     r123, r122, r125
-  Const        r126, "count"
-  Index        r127, r123, r126
-  Const        r128, 1
-  AddInt       r129, r127, r128
-  SetIndex     r123, r126, r129
+  Const        r104, "items"
+  Index        r105, r24, r83
+  Index        r106, r105, r104
+  Append       r107, r106, r61
+  SetIndex     r105, r104, r107
+  Const        r108, "count"
+  Index        r109, r105, r108
+  Const        r110, 1
+  AddInt       r111, r109, r110
+  SetIndex     r105, r108, r111
 L3:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  Const        r130, 1
-  AddInt       r59, r59, r130
+  AddInt       r46, r46, r110
   Jump         L5
 L2:
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  Const        r131, 1
-  AddInt       r48, r48, r131
+  AddInt       r35, r35, r110
   Jump         L6
 L1:
   // from c in customer
-  Const        r132, 1
-  AddInt       r42, r42, r132
+  AddInt       r29, r29, r110
   Jump         L7
 L0:
-  Const        r133, 0
-  Len          r135, r38
+  Const        r113, 0
+  Move         r112, r113
+  Len          r114, r25
 L11:
-  LessInt      r136, r133, r135
-  JumpIfFalse  r136, L8
-  Index        r138, r38, r133
+  LessInt      r115, r112, r114
+  JumpIfFalse  r115, L8
+  Index        r117, r25, r112
   // customer_id: g.key.id,
-  Const        r139, "customer_id"
-  Const        r140, "key"
-  Index        r141, r138, r140
-  Const        r142, "id"
-  Index        r143, r141, r142
+  Const        r118, "customer_id"
+  Index        r119, r117, r13
+  Index        r120, r119, r2
   // customer_first_name: g.key.first,
-  Const        r144, "customer_first_name"
-  Const        r145, "key"
-  Index        r146, r138, r145
-  Const        r147, "first"
-  Index        r148, r146, r147
+  Const        r121, "customer_first_name"
+  Index        r122, r117, r13
+  Index        r123, r122, r4
   // customer_last_name: g.key.last,
-  Const        r149, "customer_last_name"
-  Const        r150, "key"
-  Index        r151, r138, r150
-  Const        r152, "last"
-  Index        r153, r151, r152
+  Const        r124, "customer_last_name"
+  Index        r125, r117, r13
+  Index        r126, r125, r6
   // customer_login: g.key.login,
-  Const        r154, "customer_login"
-  Const        r155, "key"
-  Index        r156, r138, r155
-  Const        r157, "login"
-  Index        r158, r156, r157
+  Const        r127, "customer_login"
+  Index        r128, r117, r13
+  Index        r129, r128, r8
   // dyear: g.key.year,
-  Const        r159, "dyear"
-  Const        r160, "key"
-  Index        r161, r138, r160
-  Const        r162, "year"
-  Index        r163, r161, r162
+  Const        r130, "dyear"
+  Index        r131, r117, r13
+  Index        r132, r131, r10
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Const        r164, "year_total"
-  Const        r165, []
-  Const        r166, "ss_ext_list_price"
-  Const        r167, "ss_ext_wholesale_cost"
-  Const        r168, "ss_ext_discount_amt"
-  Const        r169, "ss_ext_sales_price"
-  IterPrep     r170, r138
-  Len          r171, r170
-  Const        r172, 0
+  Const        r133, "year_total"
+  Const        r134, []
+  IterPrep     r135, r117
+  Len          r136, r135
+  Move         r137, r113
 L10:
-  LessInt      r174, r172, r171
-  JumpIfFalse  r174, L9
-  Index        r176, r170, r172
-  Const        r177, "ss_ext_list_price"
-  Index        r178, r176, r177
-  Const        r179, "ss_ext_wholesale_cost"
-  Index        r180, r176, r179
-  Sub          r181, r178, r180
-  Const        r182, "ss_ext_discount_amt"
-  Index        r183, r176, r182
-  Sub          r184, r181, r183
-  Const        r185, "ss_ext_sales_price"
-  Index        r186, r176, r185
-  Add          r187, r184, r186
-  Const        r188, 2
-  Div          r189, r187, r188
-  Append       r165, r165, r189
-  Const        r191, 1
-  AddInt       r172, r172, r191
+  LessInt      r138, r137, r136
+  JumpIfFalse  r138, L9
+  Index        r140, r135, r137
+  Index        r141, r140, r19
+  Index        r142, r140, r20
+  Sub          r143, r141, r142
+  Index        r144, r140, r21
+  Sub          r145, r143, r144
+  Index        r146, r140, r22
+  Add          r147, r145, r146
+  Const        r148, 2
+  Div          r149, r147, r148
+  Append       r134, r134, r149
+  AddInt       r137, r137, r110
   Jump         L10
 L9:
-  Sum          r192, r165
+  Sum          r151, r134
   // sale_type: "s",
-  Const        r193, "sale_type"
-  Const        r194, "s"
+  Const        r152, "sale_type"
   // customer_id: g.key.id,
-  Move         r195, r139
-  Move         r196, r143
+  Move         r153, r118
+  Move         r154, r120
   // customer_first_name: g.key.first,
-  Move         r197, r144
-  Move         r198, r148
+  Move         r155, r121
+  Move         r156, r123
   // customer_last_name: g.key.last,
-  Move         r199, r149
-  Move         r200, r153
+  Move         r157, r124
+  Move         r158, r126
   // customer_login: g.key.login,
-  Move         r201, r154
-  Move         r202, r158
+  Move         r159, r127
+  Move         r160, r129
   // dyear: g.key.year,
-  Move         r203, r159
-  Move         r204, r163
+  Move         r161, r130
+  Move         r162, r132
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Move         r205, r164
-  Move         r206, r192
+  Move         r163, r133
+  Move         r164, r151
   // sale_type: "s",
-  Move         r207, r193
-  Move         r208, r194
+  Move         r165, r152
+  Move         r166, r57
   // select {
-  MakeMap      r209, 7, r195
+  MakeMap      r167, 7, r153
   // from c in customer
-  Append       r5, r5, r209
-  Const        r211, 1
-  AddInt       r133, r133, r211
+  Append       r1, r1, r167
+  AddInt       r112, r112, r110
   Jump         L11
 L8:
   // from c in customer
-  Const        r212, []
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r213, "id"
-  Const        r214, "c_customer_id"
-  Const        r215, "first"
-  Const        r216, "c_first_name"
-  Const        r217, "last"
-  Const        r218, "c_last_name"
-  Const        r219, "login"
-  Const        r220, "c_login"
-  Const        r221, "year"
-  Const        r222, "d_year"
-  // customer_id: g.key.id,
-  Const        r223, "customer_id"
-  Const        r224, "key"
-  Const        r225, "id"
-  // customer_first_name: g.key.first,
-  Const        r226, "customer_first_name"
-  Const        r227, "key"
-  Const        r228, "first"
-  // customer_last_name: g.key.last,
-  Const        r229, "customer_last_name"
-  Const        r230, "key"
-  Const        r231, "last"
-  // customer_login: g.key.login,
-  Const        r232, "customer_login"
-  Const        r233, "key"
-  Const        r234, "login"
-  // dyear: g.key.year,
-  Const        r235, "dyear"
-  Const        r236, "key"
-  Const        r237, "year"
+  Const        r169, []
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Const        r238, "year_total"
-  Const        r239, "cs_ext_list_price"
-  Const        r240, "cs_ext_wholesale_cost"
-  Const        r241, "cs_ext_discount_amt"
-  Const        r242, "cs_ext_sales_price"
-  // sale_type: "c",
-  Const        r243, "sale_type"
+  Const        r170, "cs_ext_list_price"
+  Const        r171, "cs_ext_wholesale_cost"
+  Const        r172, "cs_ext_discount_amt"
+  Const        r173, "cs_ext_sales_price"
   // from c in customer
-  MakeMap      r244, 0, r0
-  Const        r245, []
-  IterPrep     r247, r0
-  Len          r248, r247
-  Const        r249, 0
+  MakeMap      r174, 0, r0
+  Const        r175, []
+  IterPrep     r177, r0
+  Len          r178, r177
+  Const        r179, 0
 L19:
-  LessInt      r250, r249, r248
-  JumpIfFalse  r250, L12
-  Index        r45, r247, r249
+  LessInt      r180, r179, r178
+  JumpIfFalse  r180, L12
+  Index        r32, r177, r179
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  IterPrep     r252, r2
-  Len          r253, r252
-  Const        r254, 0
+  IterPrep     r182, r0
+  Len          r183, r182
+  Const        r184, 0
 L18:
-  LessInt      r255, r254, r253
-  JumpIfFalse  r255, L13
-  Index        r257, r252, r254
-  Const        r258, "c_customer_sk"
-  Index        r259, r45, r258
-  Const        r260, "cs_bill_customer_sk"
-  Index        r261, r257, r260
-  Equal        r262, r259, r261
-  JumpIfFalse  r262, L14
+  LessInt      r185, r184, r183
+  JumpIfFalse  r185, L13
+  Index        r187, r182, r184
+  Index        r188, r32, r39
+  Const        r189, "cs_bill_customer_sk"
+  Index        r190, r187, r189
+  Equal        r191, r188, r190
+  JumpIfFalse  r191, L14
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r263, r4
-  Len          r264, r263
-  Const        r265, 0
+  IterPrep     r192, r0
+  Len          r193, r192
+  Const        r194, 0
 L17:
-  LessInt      r266, r265, r264
-  JumpIfFalse  r266, L14
-  Index        r268, r263, r265
-  Const        r269, "cs_sold_date_sk"
-  Index        r270, r257, r269
-  Const        r271, "d_date_sk"
-  Index        r272, r268, r271
-  Equal        r273, r270, r272
-  JumpIfFalse  r273, L15
+  LessInt      r195, r194, r193
+  JumpIfFalse  r195, L14
+  Index        r197, r192, r194
+  Const        r198, "cs_sold_date_sk"
+  Index        r199, r187, r198
+  Index        r200, r197, r52
+  Equal        r201, r199, r200
+  JumpIfFalse  r201, L15
   // from c in customer
-  Const        r274, "c"
-  Move         r275, r45
-  Const        r276, "cs"
-  Move         r277, r257
-  Const        r278, "d"
-  Move         r279, r268
-  MakeMap      r280, 3, r274
+  Move         r202, r32
+  Const        r203, "cs"
+  Move         r204, r187
+  Move         r205, r197
+  MakeMap      r206, 3, r55
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r281, "id"
-  Const        r282, "c_customer_id"
-  Index        r283, r45, r282
-  Const        r284, "first"
-  Const        r285, "c_first_name"
-  Index        r286, r45, r285
-  Const        r287, "last"
-  Const        r288, "c_last_name"
-  Index        r289, r45, r288
-  Const        r290, "login"
-  Const        r291, "c_login"
-  Index        r292, r45, r291
-  Const        r293, "year"
-  Const        r294, "d_year"
-  Index        r295, r268, r294
-  Move         r296, r281
-  Move         r297, r283
-  Move         r298, r284
-  Move         r299, r286
-  Move         r300, r287
-  Move         r301, r289
-  Move         r302, r290
-  Move         r303, r292
-  Move         r304, r293
-  Move         r305, r295
-  MakeMap      r306, 5, r296
-  Str          r307, r306
-  In           r308, r307, r244
-  JumpIfTrue   r308, L16
+  Const        r207, "id"
+  Index        r208, r32, r3
+  Const        r209, "first"
+  Index        r210, r32, r5
+  Const        r211, "last"
+  Index        r212, r32, r7
+  Const        r213, "login"
+  Index        r214, r32, r9
+  Const        r215, "year"
+  Index        r216, r197, r11
+  Move         r217, r207
+  Move         r218, r208
+  Move         r219, r209
+  Move         r220, r210
+  Move         r221, r211
+  Move         r222, r212
+  Move         r223, r213
+  Move         r224, r214
+  Move         r225, r215
+  Move         r226, r216
+  MakeMap      r227, 5, r217
+  Str          r228, r227
+  In           r229, r228, r174
+  JumpIfTrue   r229, L16
   // from c in customer
-  Const        r309, []
-  Const        r310, "__group__"
-  Const        r311, true
-  Const        r312, "key"
+  Const        r230, []
+  Const        r231, "__group__"
+  Const        r232, true
+  Const        r233, "key"
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r313, r306
+  Move         r234, r227
   // from c in customer
-  Const        r314, "items"
-  Move         r315, r309
-  Const        r316, "count"
-  Const        r317, 0
-  Move         r318, r310
-  Move         r319, r311
-  Move         r320, r312
-  Move         r321, r313
-  Move         r322, r314
-  Move         r323, r315
-  Move         r324, r316
-  Move         r325, r317
-  MakeMap      r326, 4, r318
-  SetIndex     r244, r307, r326
-  Append       r245, r245, r326
+  Const        r235, "items"
+  Move         r236, r230
+  Const        r237, "count"
+  Const        r238, 0
+  Move         r239, r231
+  Move         r240, r232
+  Move         r241, r233
+  Move         r242, r234
+  Move         r243, r235
+  Move         r244, r236
+  Move         r245, r237
+  Move         r246, r238
+  MakeMap      r247, 4, r239
+  SetIndex     r174, r228, r247
+  Append       r175, r175, r247
 L16:
-  Const        r328, "items"
-  Index        r329, r244, r307
-  Index        r330, r329, r328
-  Append       r331, r330, r280
-  SetIndex     r329, r328, r331
-  Const        r332, "count"
-  Index        r333, r329, r332
-  Const        r334, 1
-  AddInt       r335, r333, r334
-  SetIndex     r329, r332, r335
+  Index        r249, r174, r228
+  Index        r250, r249, r104
+  Append       r251, r250, r206
+  SetIndex     r249, r104, r251
+  Index        r252, r249, r108
+  AddInt       r253, r252, r110
+  SetIndex     r249, r108, r253
 L15:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  Const        r336, 1
-  AddInt       r265, r265, r336
+  AddInt       r194, r194, r110
   Jump         L17
 L14:
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  Const        r337, 1
-  AddInt       r254, r254, r337
+  AddInt       r184, r184, r110
   Jump         L18
 L13:
   // from c in customer
-  Const        r338, 1
-  AddInt       r249, r249, r338
+  AddInt       r179, r179, r110
   Jump         L19
 L12:
-  Const        r339, 0
-  Len          r341, r245
+  Move         r254, r113
+  Len          r255, r175
 L23:
-  LessInt      r342, r339, r341
-  JumpIfFalse  r342, L20
-  Index        r138, r245, r339
+  LessInt      r256, r254, r255
+  JumpIfFalse  r256, L20
+  Index        r117, r175, r254
   // customer_id: g.key.id,
-  Const        r344, "customer_id"
-  Const        r345, "key"
-  Index        r346, r138, r345
-  Const        r347, "id"
-  Index        r348, r346, r347
+  Const        r258, "customer_id"
+  Index        r259, r117, r13
+  Index        r260, r259, r2
   // customer_first_name: g.key.first,
-  Const        r349, "customer_first_name"
-  Const        r350, "key"
-  Index        r351, r138, r350
-  Const        r352, "first"
-  Index        r353, r351, r352
+  Const        r261, "customer_first_name"
+  Index        r262, r117, r13
+  Index        r263, r262, r4
   // customer_last_name: g.key.last,
-  Const        r354, "customer_last_name"
-  Const        r355, "key"
-  Index        r356, r138, r355
-  Const        r357, "last"
-  Index        r358, r356, r357
+  Const        r264, "customer_last_name"
+  Index        r265, r117, r13
+  Index        r266, r265, r6
   // customer_login: g.key.login,
-  Const        r359, "customer_login"
-  Const        r360, "key"
-  Index        r361, r138, r360
-  Const        r362, "login"
-  Index        r363, r361, r362
+  Const        r267, "customer_login"
+  Index        r268, r117, r13
+  Index        r269, r268, r8
   // dyear: g.key.year,
-  Const        r364, "dyear"
-  Const        r365, "key"
-  Index        r366, r138, r365
-  Const        r367, "year"
-  Index        r368, r366, r367
+  Const        r270, "dyear"
+  Index        r271, r117, r13
+  Index        r272, r271, r10
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Const        r369, "year_total"
-  Const        r370, []
-  Const        r371, "cs_ext_list_price"
-  Const        r372, "cs_ext_wholesale_cost"
-  Const        r373, "cs_ext_discount_amt"
-  Const        r374, "cs_ext_sales_price"
-  IterPrep     r375, r138
-  Len          r376, r375
-  Const        r377, 0
+  Const        r273, "year_total"
+  Const        r274, []
+  IterPrep     r275, r117
+  Len          r276, r275
+  Move         r277, r113
 L22:
-  LessInt      r379, r377, r376
-  JumpIfFalse  r379, L21
-  Index        r176, r375, r377
-  Const        r381, "cs_ext_list_price"
-  Index        r382, r176, r381
-  Const        r383, "cs_ext_wholesale_cost"
-  Index        r384, r176, r383
-  Sub          r385, r382, r384
-  Const        r386, "cs_ext_discount_amt"
-  Index        r387, r176, r386
-  Sub          r388, r385, r387
-  Const        r389, "cs_ext_sales_price"
-  Index        r390, r176, r389
-  Add          r391, r388, r390
-  Const        r392, 2
-  Div          r393, r391, r392
-  Append       r370, r370, r393
-  Const        r395, 1
-  AddInt       r377, r377, r395
+  LessInt      r278, r277, r276
+  JumpIfFalse  r278, L21
+  Index        r140, r275, r277
+  Index        r280, r140, r170
+  Index        r281, r140, r171
+  Sub          r282, r280, r281
+  Index        r283, r140, r172
+  Sub          r284, r282, r283
+  Index        r285, r140, r173
+  Add          r286, r284, r285
+  Div          r287, r286, r148
+  Append       r274, r274, r287
+  AddInt       r277, r277, r110
   Jump         L22
 L21:
-  Sum          r396, r370
+  Sum          r289, r274
   // sale_type: "c",
-  Const        r397, "sale_type"
-  Const        r398, "c"
+  Const        r290, "sale_type"
   // customer_id: g.key.id,
-  Move         r399, r344
-  Move         r400, r348
+  Move         r291, r258
+  Move         r292, r260
   // customer_first_name: g.key.first,
-  Move         r401, r349
-  Move         r402, r353
+  Move         r293, r261
+  Move         r294, r263
   // customer_last_name: g.key.last,
-  Move         r403, r354
-  Move         r404, r358
+  Move         r295, r264
+  Move         r296, r266
   // customer_login: g.key.login,
-  Move         r405, r359
-  Move         r406, r363
+  Move         r297, r267
+  Move         r298, r269
   // dyear: g.key.year,
-  Move         r407, r364
-  Move         r408, r368
+  Move         r299, r270
+  Move         r300, r272
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Move         r409, r369
-  Move         r410, r396
+  Move         r301, r273
+  Move         r302, r289
   // sale_type: "c",
-  Move         r411, r397
-  Move         r412, r398
+  Move         r303, r290
+  Move         r304, r55
   // select {
-  MakeMap      r413, 7, r399
+  MakeMap      r305, 7, r291
   // from c in customer
-  Append       r212, r212, r413
-  Const        r415, 1
-  AddInt       r339, r339, r415
+  Append       r169, r169, r305
+  AddInt       r254, r254, r110
   Jump         L23
 L20:
   // ) union all (
-  UnionAll     r416, r5, r212
+  UnionAll     r307, r1, r169
   // from c in customer
-  Const        r417, []
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r418, "id"
-  Const        r419, "c_customer_id"
-  Const        r420, "first"
-  Const        r421, "c_first_name"
-  Const        r422, "last"
-  Const        r423, "c_last_name"
-  Const        r424, "login"
-  Const        r425, "c_login"
-  Const        r426, "year"
-  Const        r427, "d_year"
-  // customer_id: g.key.id,
-  Const        r428, "customer_id"
-  Const        r429, "key"
-  Const        r430, "id"
-  // customer_first_name: g.key.first,
-  Const        r431, "customer_first_name"
-  Const        r432, "key"
-  Const        r433, "first"
-  // customer_last_name: g.key.last,
-  Const        r434, "customer_last_name"
-  Const        r435, "key"
-  Const        r436, "last"
-  // customer_login: g.key.login,
-  Const        r437, "customer_login"
-  Const        r438, "key"
-  Const        r439, "login"
-  // dyear: g.key.year,
-  Const        r440, "dyear"
-  Const        r441, "key"
-  Const        r442, "year"
+  Const        r308, []
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Const        r443, "year_total"
-  Const        r444, "ws_ext_list_price"
-  Const        r445, "ws_ext_wholesale_cost"
-  Const        r446, "ws_ext_discount_amt"
-  Const        r447, "ws_ext_sales_price"
-  // sale_type: "w",
-  Const        r448, "sale_type"
+  Const        r309, "ws_ext_list_price"
+  Const        r310, "ws_ext_wholesale_cost"
+  Const        r311, "ws_ext_discount_amt"
+  Const        r312, "ws_ext_sales_price"
   // from c in customer
-  MakeMap      r449, 0, r0
-  Const        r450, []
-  IterPrep     r452, r0
-  Len          r453, r452
-  Const        r454, 0
+  MakeMap      r313, 0, r0
+  Const        r314, []
+  IterPrep     r316, r0
+  Len          r317, r316
+  Const        r318, 0
 L31:
-  LessInt      r455, r454, r453
-  JumpIfFalse  r455, L24
-  Index        r45, r452, r454
+  LessInt      r319, r318, r317
+  JumpIfFalse  r319, L24
+  Index        r32, r316, r318
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  IterPrep     r457, r3
-  Len          r458, r457
-  Const        r459, 0
+  IterPrep     r321, r0
+  Len          r322, r321
+  Const        r323, 0
 L30:
-  LessInt      r460, r459, r458
-  JumpIfFalse  r460, L25
-  Index        r462, r457, r459
-  Const        r463, "c_customer_sk"
-  Index        r464, r45, r463
-  Const        r465, "ws_bill_customer_sk"
-  Index        r466, r462, r465
-  Equal        r467, r464, r466
-  JumpIfFalse  r467, L26
+  LessInt      r324, r323, r322
+  JumpIfFalse  r324, L25
+  Index        r326, r321, r323
+  Index        r327, r32, r39
+  Const        r328, "ws_bill_customer_sk"
+  Index        r329, r326, r328
+  Equal        r330, r327, r329
+  JumpIfFalse  r330, L26
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r468, r4
-  Len          r469, r468
-  Const        r470, 0
+  IterPrep     r331, r0
+  Len          r332, r331
+  Const        r333, 0
 L29:
-  LessInt      r471, r470, r469
-  JumpIfFalse  r471, L26
-  Index        r473, r468, r470
-  Const        r474, "ws_sold_date_sk"
-  Index        r475, r462, r474
-  Const        r476, "d_date_sk"
-  Index        r477, r473, r476
-  Equal        r478, r475, r477
-  JumpIfFalse  r478, L27
+  LessInt      r334, r333, r332
+  JumpIfFalse  r334, L26
+  Index        r336, r331, r333
+  Const        r337, "ws_sold_date_sk"
+  Index        r338, r326, r337
+  Index        r339, r336, r52
+  Equal        r340, r338, r339
+  JumpIfFalse  r340, L27
   // from c in customer
-  Const        r479, "c"
-  Move         r480, r45
-  Const        r481, "ws"
-  Move         r482, r462
-  Const        r483, "d"
-  Move         r484, r473
-  MakeMap      r485, 3, r479
+  Move         r341, r32
+  Const        r342, "ws"
+  Move         r343, r326
+  Move         r344, r336
+  MakeMap      r345, 3, r55
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r486, "id"
-  Const        r487, "c_customer_id"
-  Index        r488, r45, r487
-  Const        r489, "first"
-  Const        r490, "c_first_name"
-  Index        r491, r45, r490
-  Const        r492, "last"
-  Const        r493, "c_last_name"
-  Index        r494, r45, r493
-  Const        r495, "login"
-  Const        r496, "c_login"
-  Index        r497, r45, r496
-  Const        r498, "year"
-  Const        r499, "d_year"
-  Index        r500, r473, r499
-  Move         r501, r486
-  Move         r502, r488
-  Move         r503, r489
-  Move         r504, r491
-  Move         r505, r492
-  Move         r506, r494
-  Move         r507, r495
-  Move         r508, r497
-  Move         r509, r498
-  Move         r510, r500
-  MakeMap      r511, 5, r501
-  Str          r512, r511
-  In           r513, r512, r449
-  JumpIfTrue   r513, L28
+  Const        r346, "id"
+  Index        r347, r32, r3
+  Const        r348, "first"
+  Index        r349, r32, r5
+  Const        r350, "last"
+  Index        r351, r32, r7
+  Const        r352, "login"
+  Index        r353, r32, r9
+  Const        r354, "year"
+  Index        r355, r336, r11
+  Move         r356, r346
+  Move         r357, r347
+  Move         r358, r348
+  Move         r359, r349
+  Move         r360, r350
+  Move         r361, r351
+  Move         r362, r352
+  Move         r363, r353
+  Move         r364, r354
+  Move         r365, r355
+  MakeMap      r366, 5, r356
+  Str          r367, r366
+  In           r368, r367, r313
+  JumpIfTrue   r368, L28
   // from c in customer
-  Const        r514, []
-  Const        r515, "__group__"
-  Const        r516, true
-  Const        r517, "key"
+  Const        r369, []
+  Const        r370, "__group__"
+  Const        r371, true
+  Const        r372, "key"
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r518, r511
+  Move         r373, r366
   // from c in customer
-  Const        r519, "items"
-  Move         r520, r514
-  Const        r521, "count"
-  Const        r522, 0
-  Move         r523, r515
-  Move         r524, r516
-  Move         r525, r517
-  Move         r526, r518
-  Move         r527, r519
-  Move         r528, r520
-  Move         r529, r521
-  Move         r530, r522
-  MakeMap      r531, 4, r523
-  SetIndex     r449, r512, r531
-  Append       r450, r450, r531
+  Const        r374, "items"
+  Move         r375, r369
+  Const        r376, "count"
+  Const        r377, 0
+  Move         r378, r370
+  Move         r379, r371
+  Move         r380, r372
+  Move         r381, r373
+  Move         r382, r374
+  Move         r383, r375
+  Move         r384, r376
+  Move         r385, r377
+  MakeMap      r386, 4, r378
+  SetIndex     r313, r367, r386
+  Append       r314, r314, r386
 L28:
-  Const        r533, "items"
-  Index        r534, r449, r512
-  Index        r535, r534, r533
-  Append       r536, r535, r485
-  SetIndex     r534, r533, r536
-  Const        r537, "count"
-  Index        r538, r534, r537
-  Const        r539, 1
-  AddInt       r540, r538, r539
-  SetIndex     r534, r537, r540
+  Index        r388, r313, r367
+  Index        r389, r388, r104
+  Append       r390, r389, r345
+  SetIndex     r388, r104, r390
+  Index        r391, r388, r108
+  AddInt       r392, r391, r110
+  SetIndex     r388, r108, r392
 L27:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  Const        r541, 1
-  AddInt       r470, r470, r541
+  AddInt       r333, r333, r110
   Jump         L29
 L26:
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  Const        r542, 1
-  AddInt       r459, r459, r542
+  AddInt       r323, r323, r110
   Jump         L30
 L25:
   // from c in customer
-  Const        r543, 1
-  AddInt       r454, r454, r543
+  AddInt       r318, r318, r110
   Jump         L31
 L24:
-  Const        r544, 0
-  Len          r546, r450
+  Move         r393, r113
+  Len          r394, r314
 L35:
-  LessInt      r547, r544, r546
-  JumpIfFalse  r547, L32
-  Index        r138, r450, r544
+  LessInt      r395, r393, r394
+  JumpIfFalse  r395, L32
+  Index        r117, r314, r393
   // customer_id: g.key.id,
-  Const        r549, "customer_id"
-  Const        r550, "key"
-  Index        r551, r138, r550
-  Const        r552, "id"
-  Index        r553, r551, r552
+  Const        r397, "customer_id"
+  Index        r398, r117, r13
+  Index        r399, r398, r2
   // customer_first_name: g.key.first,
-  Const        r554, "customer_first_name"
-  Const        r555, "key"
-  Index        r556, r138, r555
-  Const        r557, "first"
-  Index        r558, r556, r557
+  Const        r400, "customer_first_name"
+  Index        r401, r117, r13
+  Index        r402, r401, r4
   // customer_last_name: g.key.last,
-  Const        r559, "customer_last_name"
-  Const        r560, "key"
-  Index        r561, r138, r560
-  Const        r562, "last"
-  Index        r563, r561, r562
+  Const        r403, "customer_last_name"
+  Index        r404, r117, r13
+  Index        r405, r404, r6
   // customer_login: g.key.login,
-  Const        r564, "customer_login"
-  Const        r565, "key"
-  Index        r566, r138, r565
-  Const        r567, "login"
-  Index        r568, r566, r567
+  Const        r406, "customer_login"
+  Index        r407, r117, r13
+  Index        r408, r407, r8
   // dyear: g.key.year,
-  Const        r569, "dyear"
-  Const        r570, "key"
-  Index        r571, r138, r570
-  Const        r572, "year"
-  Index        r573, r571, r572
+  Const        r409, "dyear"
+  Index        r410, r117, r13
+  Index        r411, r410, r10
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Const        r574, "year_total"
-  Const        r575, []
-  Const        r576, "ws_ext_list_price"
-  Const        r577, "ws_ext_wholesale_cost"
-  Const        r578, "ws_ext_discount_amt"
-  Const        r579, "ws_ext_sales_price"
-  IterPrep     r580, r138
-  Len          r581, r580
-  Const        r582, 0
+  Const        r412, "year_total"
+  Const        r413, []
+  IterPrep     r414, r117
+  Len          r415, r414
+  Move         r416, r113
 L34:
-  LessInt      r584, r582, r581
-  JumpIfFalse  r584, L33
-  Index        r176, r580, r582
-  Const        r586, "ws_ext_list_price"
-  Index        r587, r176, r586
-  Const        r588, "ws_ext_wholesale_cost"
-  Index        r589, r176, r588
-  Sub          r590, r587, r589
-  Const        r591, "ws_ext_discount_amt"
-  Index        r592, r176, r591
-  Sub          r593, r590, r592
-  Const        r594, "ws_ext_sales_price"
-  Index        r595, r176, r594
-  Add          r596, r593, r595
-  Const        r597, 2
-  Div          r598, r596, r597
-  Append       r575, r575, r598
-  Const        r600, 1
-  AddInt       r582, r582, r600
+  LessInt      r417, r416, r415
+  JumpIfFalse  r417, L33
+  Index        r140, r414, r416
+  Index        r419, r140, r309
+  Index        r420, r140, r310
+  Sub          r421, r419, r420
+  Index        r422, r140, r311
+  Sub          r423, r421, r422
+  Index        r424, r140, r312
+  Add          r425, r423, r424
+  Div          r426, r425, r148
+  Append       r413, r413, r426
+  AddInt       r416, r416, r110
   Jump         L34
 L33:
-  Sum          r601, r575
+  Sum          r428, r413
   // sale_type: "w",
-  Const        r602, "sale_type"
-  Const        r603, "w"
+  Const        r429, "sale_type"
+  Const        r430, "w"
   // customer_id: g.key.id,
-  Move         r604, r549
-  Move         r605, r553
+  Move         r431, r397
+  Move         r432, r399
   // customer_first_name: g.key.first,
-  Move         r606, r554
-  Move         r607, r558
+  Move         r433, r400
+  Move         r434, r402
   // customer_last_name: g.key.last,
-  Move         r608, r559
-  Move         r609, r563
+  Move         r435, r403
+  Move         r436, r405
   // customer_login: g.key.login,
-  Move         r610, r564
-  Move         r611, r568
+  Move         r437, r406
+  Move         r438, r408
   // dyear: g.key.year,
-  Move         r612, r569
-  Move         r613, r573
+  Move         r439, r409
+  Move         r440, r411
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Move         r614, r574
-  Move         r615, r601
+  Move         r441, r412
+  Move         r442, r428
   // sale_type: "w",
-  Move         r616, r602
-  Move         r617, r603
+  Move         r443, r429
+  Move         r444, r430
   // select {
-  MakeMap      r618, 7, r604
+  MakeMap      r445, 7, r431
   // from c in customer
-  Append       r417, r417, r618
-  Const        r620, 1
-  AddInt       r544, r544, r620
+  Append       r308, r308, r445
+  AddInt       r393, r393, r110
   Jump         L35
 L32:
   // ) union all (
-  UnionAll     r621, r416, r417
+  UnionAll     r447, r307, r308
   // from s1 in year_total
-  Const        r622, []
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r623, "sale_type"
-  Const        r624, "sale_type"
-  Const        r625, "sale_type"
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Const        r626, "sale_type"
-  Const        r627, "sale_type"
-  Const        r628, "sale_type"
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Const        r629, "dyear"
-  Const        r630, "dyear"
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Const        r631, "dyear"
-  Const        r632, "dyear"
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Const        r633, "dyear"
-  Const        r634, "dyear"
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Const        r635, "year_total"
-  Const        r636, "year_total"
-  Const        r637, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r638, "year_total"
-  Const        r639, "year_total"
-  Const        r640, "year_total"
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Const        r641, "year_total"
-  Const        r642, "year_total"
-  Const        r643, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r644, "year_total"
-  Const        r645, "year_total"
-  Const        r646, "year_total"
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Const        r647, "year_total"
-  Const        r648, "year_total"
-  Const        r649, "year_total"
-  // customer_id: s2.customer_id,
-  Const        r650, "customer_id"
-  Const        r651, "customer_id"
-  // customer_first_name: s2.customer_first_name,
-  Const        r652, "customer_first_name"
-  Const        r653, "customer_first_name"
-  // customer_last_name: s2.customer_last_name,
-  Const        r654, "customer_last_name"
-  Const        r655, "customer_last_name"
-  // customer_login: s2.customer_login,
-  Const        r656, "customer_login"
-  Const        r657, "customer_login"
-  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Const        r658, "customer_id"
-  Const        r659, "customer_first_name"
-  Const        r660, "customer_last_name"
-  Const        r661, "customer_login"
-  // from s1 in year_total
-  IterPrep     r662, r621
-  Len          r663, r662
-  Const        r664, 0
-L57:
-  LessInt      r666, r664, r663
-  JumpIfFalse  r666, L36
-  Index        r668, r662, r664
-  // join s2 in year_total on s2.customer_id == s1.customer_id
-  IterPrep     r669, r621
-  Len          r670, r669
-  Const        r671, "customer_id"
-  Const        r672, "customer_id"
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r673, "sale_type"
-  Const        r674, "sale_type"
-  Const        r675, "sale_type"
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Const        r676, "sale_type"
-  Const        r677, "sale_type"
-  Const        r678, "sale_type"
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Const        r679, "dyear"
-  Const        r680, "dyear"
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Const        r681, "dyear"
-  Const        r682, "dyear"
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Const        r683, "dyear"
-  Const        r684, "dyear"
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Const        r685, "year_total"
-  Const        r686, "year_total"
-  Const        r687, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r688, "year_total"
-  Const        r689, "year_total"
-  Const        r690, "year_total"
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Const        r691, "year_total"
-  Const        r692, "year_total"
-  Const        r693, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r694, "year_total"
-  Const        r695, "year_total"
-  Const        r696, "year_total"
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Const        r697, "year_total"
-  Const        r698, "year_total"
-  Const        r699, "year_total"
-  // customer_id: s2.customer_id,
-  Const        r700, "customer_id"
-  Const        r701, "customer_id"
-  // customer_first_name: s2.customer_first_name,
-  Const        r702, "customer_first_name"
-  Const        r703, "customer_first_name"
-  // customer_last_name: s2.customer_last_name,
-  Const        r704, "customer_last_name"
-  Const        r705, "customer_last_name"
-  // customer_login: s2.customer_login,
-  Const        r706, "customer_login"
-  Const        r707, "customer_login"
-  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Const        r708, "customer_id"
-  Const        r709, "customer_first_name"
-  Const        r710, "customer_last_name"
-  Const        r711, "customer_login"
-  // join s2 in year_total on s2.customer_id == s1.customer_id
-  Const        r712, 0
-L56:
-  LessInt      r714, r712, r670
-  JumpIfFalse  r714, L37
-  Index        r716, r669, r712
-  Const        r717, "customer_id"
-  Index        r718, r716, r717
-  Const        r719, "customer_id"
-  Index        r720, r668, r719
-  Equal        r721, r718, r720
-  JumpIfFalse  r721, L38
-  // join c1 in year_total on c1.customer_id == s1.customer_id
-  IterPrep     r722, r621
-  Len          r723, r722
-  Const        r724, "customer_id"
-  Const        r725, "customer_id"
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r726, "sale_type"
-  Const        r727, "sale_type"
-  Const        r728, "sale_type"
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Const        r729, "sale_type"
-  Const        r730, "sale_type"
-  Const        r731, "sale_type"
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Const        r732, "dyear"
-  Const        r733, "dyear"
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Const        r734, "dyear"
-  Const        r735, "dyear"
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Const        r736, "dyear"
-  Const        r737, "dyear"
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Const        r738, "year_total"
-  Const        r739, "year_total"
-  Const        r740, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r741, "year_total"
-  Const        r742, "year_total"
-  Const        r743, "year_total"
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Const        r744, "year_total"
-  Const        r745, "year_total"
-  Const        r746, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r747, "year_total"
-  Const        r748, "year_total"
-  Const        r749, "year_total"
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Const        r750, "year_total"
-  Const        r751, "year_total"
-  Const        r752, "year_total"
-  // customer_id: s2.customer_id,
-  Const        r753, "customer_id"
-  Const        r754, "customer_id"
-  // customer_first_name: s2.customer_first_name,
-  Const        r755, "customer_first_name"
-  Const        r756, "customer_first_name"
-  // customer_last_name: s2.customer_last_name,
-  Const        r757, "customer_last_name"
-  Const        r758, "customer_last_name"
-  // customer_login: s2.customer_login,
-  Const        r759, "customer_login"
-  Const        r760, "customer_login"
-  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Const        r761, "customer_id"
-  Const        r762, "customer_first_name"
-  Const        r763, "customer_last_name"
-  Const        r764, "customer_login"
-  // join c1 in year_total on c1.customer_id == s1.customer_id
-  Const        r765, 0
-L55:
-  LessInt      r767, r765, r723
-  JumpIfFalse  r767, L38
-  Index        r769, r722, r765
-  Const        r770, "customer_id"
-  Index        r771, r769, r770
-  Const        r772, "customer_id"
-  Index        r773, r668, r772
-  Equal        r774, r771, r773
-  JumpIfFalse  r774, L39
-  // join c2 in year_total on c2.customer_id == s1.customer_id
-  IterPrep     r775, r621
-  Len          r776, r775
-  Const        r777, "customer_id"
-  Const        r778, "customer_id"
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r779, "sale_type"
-  Const        r780, "sale_type"
-  Const        r781, "sale_type"
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Const        r782, "sale_type"
-  Const        r783, "sale_type"
-  Const        r784, "sale_type"
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Const        r785, "dyear"
-  Const        r786, "dyear"
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Const        r787, "dyear"
-  Const        r788, "dyear"
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Const        r789, "dyear"
-  Const        r790, "dyear"
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Const        r791, "year_total"
-  Const        r792, "year_total"
-  Const        r793, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r794, "year_total"
-  Const        r795, "year_total"
-  Const        r796, "year_total"
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Const        r797, "year_total"
-  Const        r798, "year_total"
-  Const        r799, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r800, "year_total"
-  Const        r801, "year_total"
-  Const        r802, "year_total"
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Const        r803, "year_total"
-  Const        r804, "year_total"
-  Const        r805, "year_total"
-  // customer_id: s2.customer_id,
-  Const        r806, "customer_id"
-  Const        r807, "customer_id"
-  // customer_first_name: s2.customer_first_name,
-  Const        r808, "customer_first_name"
-  Const        r809, "customer_first_name"
-  // customer_last_name: s2.customer_last_name,
-  Const        r810, "customer_last_name"
-  Const        r811, "customer_last_name"
-  // customer_login: s2.customer_login,
-  Const        r812, "customer_login"
-  Const        r813, "customer_login"
-  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Const        r814, "customer_id"
-  Const        r815, "customer_first_name"
-  Const        r816, "customer_last_name"
-  Const        r817, "customer_login"
-  // join c2 in year_total on c2.customer_id == s1.customer_id
-  Const        r818, 0
-L54:
-  LessInt      r820, r818, r776
-  JumpIfFalse  r820, L39
-  Index        r822, r775, r818
-  Const        r823, "customer_id"
-  Index        r824, r822, r823
-  Const        r825, "customer_id"
-  Index        r826, r668, r825
-  Equal        r827, r824, r826
-  JumpIfFalse  r827, L40
-  // join w1 in year_total on w1.customer_id == s1.customer_id
-  IterPrep     r828, r621
-  Len          r829, r828
-  Const        r830, "customer_id"
-  Const        r831, "customer_id"
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r832, "sale_type"
-  Const        r833, "sale_type"
-  Const        r834, "sale_type"
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Const        r835, "sale_type"
-  Const        r836, "sale_type"
-  Const        r837, "sale_type"
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Const        r838, "dyear"
-  Const        r839, "dyear"
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Const        r840, "dyear"
-  Const        r841, "dyear"
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Const        r842, "dyear"
-  Const        r843, "dyear"
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Const        r844, "year_total"
-  Const        r845, "year_total"
-  Const        r846, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r847, "year_total"
-  Const        r848, "year_total"
-  Const        r849, "year_total"
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Const        r850, "year_total"
-  Const        r851, "year_total"
-  Const        r852, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r853, "year_total"
-  Const        r854, "year_total"
-  Const        r855, "year_total"
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Const        r856, "year_total"
-  Const        r857, "year_total"
-  Const        r858, "year_total"
-  // customer_id: s2.customer_id,
-  Const        r859, "customer_id"
-  Const        r860, "customer_id"
-  // customer_first_name: s2.customer_first_name,
-  Const        r861, "customer_first_name"
-  Const        r862, "customer_first_name"
-  // customer_last_name: s2.customer_last_name,
-  Const        r863, "customer_last_name"
-  Const        r864, "customer_last_name"
-  // customer_login: s2.customer_login,
-  Const        r865, "customer_login"
-  Const        r866, "customer_login"
-  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Const        r867, "customer_id"
-  Const        r868, "customer_first_name"
-  Const        r869, "customer_last_name"
-  Const        r870, "customer_login"
-  // join w1 in year_total on w1.customer_id == s1.customer_id
-  Const        r871, 0
-L53:
-  LessInt      r873, r871, r829
-  JumpIfFalse  r873, L40
-  Index        r875, r828, r871
-  Const        r876, "customer_id"
-  Index        r877, r875, r876
-  Const        r878, "customer_id"
-  Index        r879, r668, r878
-  Equal        r880, r877, r879
-  JumpIfFalse  r880, L41
-  // join w2 in year_total on w2.customer_id == s1.customer_id
-  IterPrep     r881, r621
-  Len          r882, r881
-  Const        r883, "customer_id"
-  Const        r884, "customer_id"
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r885, "sale_type"
-  Const        r886, "sale_type"
-  Const        r887, "sale_type"
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Const        r888, "sale_type"
-  Const        r889, "sale_type"
-  Const        r890, "sale_type"
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Const        r891, "dyear"
-  Const        r892, "dyear"
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Const        r893, "dyear"
-  Const        r894, "dyear"
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Const        r895, "dyear"
-  Const        r896, "dyear"
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Const        r897, "year_total"
-  Const        r898, "year_total"
-  Const        r899, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r900, "year_total"
-  Const        r901, "year_total"
-  Const        r902, "year_total"
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Const        r903, "year_total"
-  Const        r904, "year_total"
-  Const        r905, "year_total"
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r906, "year_total"
-  Const        r907, "year_total"
-  Const        r908, "year_total"
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Const        r909, "year_total"
-  Const        r910, "year_total"
-  Const        r911, "year_total"
-  // customer_id: s2.customer_id,
-  Const        r912, "customer_id"
-  Const        r913, "customer_id"
-  // customer_first_name: s2.customer_first_name,
-  Const        r914, "customer_first_name"
-  Const        r915, "customer_first_name"
-  // customer_last_name: s2.customer_last_name,
-  Const        r916, "customer_last_name"
-  Const        r917, "customer_last_name"
-  // customer_login: s2.customer_login,
-  Const        r918, "customer_login"
-  Const        r919, "customer_login"
-  // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Const        r920, "customer_id"
-  Const        r921, "customer_first_name"
-  Const        r922, "customer_last_name"
-  Const        r923, "customer_login"
-  // join w2 in year_total on w2.customer_id == s1.customer_id
-  Const        r924, 0
-L52:
-  LessInt      r926, r924, r882
-  JumpIfFalse  r926, L41
-  Index        r928, r881, r924
-  Const        r929, "customer_id"
-  Index        r930, r928, r929
-  Const        r931, "customer_id"
-  Index        r932, r668, r931
-  Equal        r933, r930, r932
-  JumpIfFalse  r933, L42
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r934, "sale_type"
-  Index        r935, r668, r934
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Const        r936, "year_total"
-  Index        r937, r668, r936
-  Const        r938, 0
-  Less         r939, r938, r937
-  Const        r940, "year_total"
-  Index        r941, r769, r940
-  Const        r942, 0
-  Less         r943, r942, r941
-  Const        r944, "year_total"
-  Index        r945, r875, r944
-  Const        r946, 0
-  Less         r947, r946, r945
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r948, "year_total"
-  Index        r949, r769, r948
-  Const        r950, 0
-  Less         r951, r950, r949
-  JumpIfFalse  r951, L43
-  Const        r952, "year_total"
-  Index        r953, r822, r952
-  Const        r954, "year_total"
-  Index        r955, r769, r954
-  Div          r957, r953, r955
-  Jump         L44
-L43:
-  Const        r957, nil
-L44:
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Const        r959, "year_total"
-  Index        r960, r668, r959
-  Const        r961, 0
-  Less         r962, r961, r960
-  JumpIfFalse  r962, L45
-  Const        r963, "year_total"
-  Index        r964, r716, r963
-  Const        r965, "year_total"
-  Index        r966, r668, r965
-  Div          r968, r964, r966
-  Jump         L46
-L45:
-  Const        r968, nil
-L46:
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r970, r968, r957
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Const        r971, "year_total"
-  Index        r972, r769, r971
-  Const        r973, 0
-  Less         r974, r973, r972
-  JumpIfFalse  r974, L47
-  Const        r975, "year_total"
-  Index        r976, r822, r975
-  Const        r977, "year_total"
-  Index        r978, r769, r977
-  Div          r980, r976, r978
-  Jump         L48
-L47:
-  Const        r980, nil
-L48:
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Const        r982, "year_total"
-  Index        r983, r875, r982
-  Const        r984, 0
-  Less         r985, r984, r983
-  JumpIfFalse  r985, L49
-  Const        r986, "year_total"
-  Index        r987, r928, r986
-  Const        r988, "year_total"
-  Index        r989, r875, r988
-  Div          r991, r987, r989
-  Jump         L50
+  Const        r448, []
+  IterPrep     r449, r447
+  Len          r450, r449
+  Move         r451, r113
 L49:
-  Const        r991, nil
-L50:
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r993, r991, r980
+  LessInt      r452, r451, r450
+  JumpIfFalse  r452, L36
+  Index        r454, r449, r451
+  // join s2 in year_total on s2.customer_id == s1.customer_id
+  IterPrep     r455, r447
+  Len          r456, r455
+  Move         r457, r113
+L48:
+  LessInt      r458, r457, r456
+  JumpIfFalse  r458, L37
+  Index        r460, r455, r457
+  Index        r461, r460, r12
+  Index        r462, r454, r12
+  Equal        r463, r461, r462
+  JumpIfFalse  r463, L38
+  // join c1 in year_total on c1.customer_id == s1.customer_id
+  IterPrep     r464, r447
+  Len          r465, r464
+  Move         r466, r113
+L47:
+  LessInt      r467, r466, r465
+  JumpIfFalse  r467, L38
+  Index        r469, r464, r466
+  Index        r470, r469, r12
+  Index        r471, r454, r12
+  Equal        r472, r470, r471
+  JumpIfFalse  r472, L39
+  // join c2 in year_total on c2.customer_id == s1.customer_id
+  IterPrep     r473, r447
+  Len          r474, r473
+  Move         r475, r113
+L46:
+  LessInt      r476, r475, r474
+  JumpIfFalse  r476, L39
+  Index        r478, r473, r475
+  Index        r479, r478, r12
+  Index        r480, r454, r12
+  Equal        r481, r479, r480
+  JumpIfFalse  r481, L40
+  // join w1 in year_total on w1.customer_id == s1.customer_id
+  IterPrep     r482, r447
+  Len          r483, r482
+  Move         r484, r113
+L45:
+  LessInt      r485, r484, r483
+  JumpIfFalse  r485, L40
+  Index        r487, r482, r484
+  Index        r488, r487, r12
+  Index        r489, r454, r12
+  Equal        r490, r488, r489
+  JumpIfFalse  r490, L41
+  // join w2 in year_total on w2.customer_id == s1.customer_id
+  IterPrep     r491, r447
+  Len          r492, r491
+  Move         r493, r113
+L44:
+  LessInt      r494, r493, r492
+  JumpIfFalse  r494, L41
+  Index        r496, r491, r493
+  Index        r497, r496, r12
+  Index        r498, r454, r12
+  Equal        r499, r497, r498
+  JumpIfFalse  r499, L42
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Const        r994, "s"
-  Equal        r995, r935, r994
-  Const        r996, "sale_type"
-  Index        r997, r769, r996
-  Const        r998, "c"
-  Equal        r999, r997, r998
-  Const        r1000, "sale_type"
-  Index        r1001, r875, r1000
-  Const        r1002, "w"
-  Equal        r1003, r1001, r1002
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Const        r1004, "sale_type"
-  Index        r1005, r716, r1004
-  Const        r1006, "s"
-  Equal        r1007, r1005, r1006
-  Const        r1008, "sale_type"
-  Index        r1009, r822, r1008
-  Const        r1010, "c"
-  Equal        r1011, r1009, r1010
-  Const        r1012, "sale_type"
-  Index        r1013, r928, r1012
-  Const        r1014, "w"
-  Equal        r1015, r1013, r1014
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Const        r1016, "dyear"
-  Index        r1017, r668, r1016
-  Const        r1018, 2001
-  Equal        r1019, r1017, r1018
-  Const        r1020, "dyear"
-  Index        r1021, r716, r1020
-  Const        r1022, 2002
-  Equal        r1023, r1021, r1022
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Const        r1024, "dyear"
-  Index        r1025, r769, r1024
-  Const        r1026, 2001
-  Equal        r1027, r1025, r1026
-  Const        r1028, "dyear"
-  Index        r1029, r822, r1028
-  Const        r1030, 2002
-  Equal        r1031, r1029, r1030
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Const        r1032, "dyear"
-  Index        r1033, r875, r1032
-  Const        r1034, 2001
-  Equal        r1035, r1033, r1034
-  Const        r1036, "dyear"
-  Index        r1037, r928, r1036
-  Const        r1038, 2002
-  Equal        r1039, r1037, r1038
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Move         r1040, r995
-  JumpIfFalse  r1040, L51
-  Move         r1040, r999
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1003
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1007
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1011
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1015
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1019
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1023
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1027
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1031
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1035
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  JumpIfFalse  r1040, L51
-  Move         r1040, r1039
-  JumpIfFalse  r1040, L51
-  Move         r1040, r939
+  Index        r500, r454, r23
   // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  JumpIfFalse  r1040, L51
-  Move         r1040, r943
-  JumpIfFalse  r1040, L51
-  Move         r1040, r947
-  JumpIfFalse  r1040, L51
-  Move         r1040, r970
+  Index        r501, r454, r18
+  Less         r502, r113, r501
+  Index        r503, r469, r18
+  Less         r504, r113, r503
+  Index        r505, r487, r18
+  Less         r506, r113, r505
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Index        r507, r469, r18
+  Less         r508, r113, r507
+  Index        r509, r478, r18
+  Index        r510, r469, r18
+  Div          r511, r509, r510
+  Const        r512, nil
+  Select       513,508,511,512
   // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  JumpIfFalse  r1040, L51
-  Move         r1040, r993
-L51:
+  Index        r514, r454, r18
+  Less         r515, r113, r514
+  Index        r516, r460, r18
+  Index        r517, r454, r18
+  Div          r518, r516, r517
+  Select       519,515,518,512
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Less         r520, r519, r513
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Index        r521, r469, r18
+  Less         r522, r113, r521
+  Index        r523, r478, r18
+  Index        r524, r469, r18
+  Div          r525, r523, r524
+  Select       526,522,525,512
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Index        r527, r487, r18
+  Less         r528, r113, r527
+  Index        r529, r496, r18
+  Index        r530, r487, r18
+  Div          r531, r529, r530
+  Select       532,528,531,512
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Less         r533, r532, r526
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  JumpIfFalse  r1040, L42
+  Equal        r534, r500, r57
+  Index        r535, r469, r23
+  Equal        r536, r535, r55
+  Index        r537, r487, r23
+  Equal        r538, r537, r430
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Index        r539, r460, r23
+  Equal        r540, r539, r57
+  Index        r541, r478, r23
+  Equal        r542, r541, r55
+  Index        r543, r496, r23
+  Equal        r544, r543, r430
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Index        r545, r454, r17
+  Const        r546, 2001
+  Equal        r547, r545, r546
+  Index        r548, r460, r17
+  Const        r549, 2002
+  Equal        r550, r548, r549
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Index        r551, r469, r17
+  Equal        r552, r551, r546
+  Index        r553, r478, r17
+  Equal        r554, r553, r549
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Index        r555, r487, r17
+  Equal        r556, r555, r546
+  Index        r557, r496, r17
+  Equal        r558, r557, r549
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  JumpIfFalse  r534, L43
+  Move         r534, r536
+  JumpIfFalse  r534, L43
+  Move         r534, r538
+  JumpIfFalse  r534, L43
+  Move         r534, r540
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  JumpIfFalse  r534, L43
+  Move         r534, r542
+  JumpIfFalse  r534, L43
+  Move         r534, r544
+  JumpIfFalse  r534, L43
+  Move         r534, r547
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  JumpIfFalse  r534, L43
+  Move         r534, r550
+  JumpIfFalse  r534, L43
+  Move         r534, r552
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  JumpIfFalse  r534, L43
+  Move         r534, r554
+  JumpIfFalse  r534, L43
+  Move         r534, r556
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  JumpIfFalse  r534, L43
+  Move         r534, r558
+  JumpIfFalse  r534, L43
+  Move         r534, r502
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  JumpIfFalse  r534, L43
+  Move         r534, r504
+  JumpIfFalse  r534, L43
+  Move         r534, r506
+  JumpIfFalse  r534, L43
+  Move         r534, r520
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  JumpIfFalse  r534, L43
+  Move         r534, r533
+L43:
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  JumpIfFalse  r534, L42
   // customer_id: s2.customer_id,
-  Const        r1041, "customer_id"
-  Const        r1042, "customer_id"
-  Index        r1043, r716, r1042
+  Const        r559, "customer_id"
+  Index        r560, r460, r12
   // customer_first_name: s2.customer_first_name,
-  Const        r1044, "customer_first_name"
-  Const        r1045, "customer_first_name"
-  Index        r1046, r716, r1045
+  Const        r561, "customer_first_name"
+  Index        r562, r460, r14
   // customer_last_name: s2.customer_last_name,
-  Const        r1047, "customer_last_name"
-  Const        r1048, "customer_last_name"
-  Index        r1049, r716, r1048
+  Const        r563, "customer_last_name"
+  Index        r564, r460, r15
   // customer_login: s2.customer_login,
-  Const        r1050, "customer_login"
-  Const        r1051, "customer_login"
-  Index        r1052, r716, r1051
+  Const        r565, "customer_login"
+  Index        r566, r460, r16
   // customer_id: s2.customer_id,
-  Move         r1053, r1041
-  Move         r1054, r1043
+  Move         r567, r559
+  Move         r568, r560
   // customer_first_name: s2.customer_first_name,
-  Move         r1055, r1044
-  Move         r1056, r1046
+  Move         r569, r561
+  Move         r570, r562
   // customer_last_name: s2.customer_last_name,
-  Move         r1057, r1047
-  Move         r1058, r1049
+  Move         r571, r563
+  Move         r572, r564
   // customer_login: s2.customer_login,
-  Move         r1059, r1050
-  Move         r1060, r1052
+  Move         r573, r565
+  Move         r574, r566
   // select {
-  MakeMap      r1061, 4, r1053
+  MakeMap      r575, 4, r567
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Const        r1062, "customer_id"
-  Index        r1064, r716, r1062
-  Const        r1065, "customer_first_name"
-  Index        r1066, r716, r1065
-  Move         r1067, r1066
-  Const        r1068, "customer_last_name"
-  Index        r1070, r716, r1068
-  Const        r1071, "customer_login"
-  Index        r1073, r716, r1071
-  MakeList     r1075, 4, r1064
+  Index        r577, r460, r12
+  Index        r578, r460, r14
+  Move         r579, r578
+  Index        r580, r460, r15
+  Move         r581, r580
+  Index        r583, r460, r16
+  MakeList     r585, 4, r577
   // from s1 in year_total
-  Move         r1076, r1061
-  MakeList     r1077, 2, r1075
-  Append       r622, r622, r1077
+  Move         r586, r575
+  MakeList     r587, 2, r585
+  Append       r448, r448, r587
 L42:
   // join w2 in year_total on w2.customer_id == s1.customer_id
-  Const        r1079, 1
-  Add          r924, r924, r1079
-  Jump         L52
+  Add          r493, r493, r110
+  Jump         L44
 L41:
   // join w1 in year_total on w1.customer_id == s1.customer_id
-  Const        r1080, 1
-  Add          r871, r871, r1080
-  Jump         L53
+  Add          r484, r484, r110
+  Jump         L45
 L40:
   // join c2 in year_total on c2.customer_id == s1.customer_id
-  Const        r1081, 1
-  Add          r818, r818, r1081
-  Jump         L54
+  Add          r475, r475, r110
+  Jump         L46
 L39:
   // join c1 in year_total on c1.customer_id == s1.customer_id
-  Const        r1082, 1
-  Add          r765, r765, r1082
-  Jump         L55
+  Add          r466, r466, r110
+  Jump         L47
 L38:
   // join s2 in year_total on s2.customer_id == s1.customer_id
-  Const        r1083, 1
-  Add          r712, r712, r1083
-  Jump         L56
+  Add          r457, r457, r110
+  Jump         L48
 L37:
   // from s1 in year_total
-  Const        r1084, 1
-  AddInt       r664, r664, r1084
-  Jump         L57
+  AddInt       r451, r451, r110
+  Jump         L49
 L36:
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Sort         r622, r622
+  Sort         r448, r448
   // json(result)
-  JSON         r622
+  JSON         r448
   // expect len(result) == 0
-  Len          r1086, r622
-  Const        r1087, 0
-  EqualInt     r1088, r1086, r1087
-  Expect       r1088
+  Len          r590, r448
+  EqualInt     r591, r590, r113
+  Expect       r591
   Return       r0

--- a/tests/dataset/tpc-ds/out/q5.ir.out
+++ b/tests/dataset/tpc-ds/out/q5.ir.out
@@ -1,1690 +1,1351 @@
-func main (regs=1189)
+func main (regs=865)
   // let store_sales = []
   Const        r0, []
-  // let store_returns = []
+  // from ss in store_sales
   Const        r1, []
-  // let store = []
-  Const        r2, []
-  // let catalog_sales = []
-  Const        r3, []
-  // let catalog_returns = []
-  Const        r4, []
-  // let catalog_page = []
-  Const        r5, []
-  // let web_sales = []
-  Const        r6, []
-  // let web_returns = []
-  Const        r7, []
-  // let web_site = []
-  Const        r8, []
-  // let date_dim = []
-  Const        r9, []
-  // from ss in store_sales
-  Const        r10, []
   // group by s.s_store_id into g
-  Const        r11, "s_store_id"
+  Const        r2, "s_store_id"
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r12, "d_date"
-  Const        r13, "d_date"
+  Const        r3, "d_date"
   // channel: "store channel",
-  Const        r14, "channel"
+  Const        r4, "channel"
   // id: "store" + str(g.key),
-  Const        r15, "id"
-  Const        r16, "key"
+  Const        r5, "id"
+  Const        r6, "key"
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r17, "sales"
-  Const        r18, "ss"
-  Const        r19, "ss_ext_sales_price"
+  Const        r7, "sales"
+  Const        r8, "ss"
+  Const        r9, "ss_ext_sales_price"
   // returns: 0.0,
-  Const        r20, "returns"
+  Const        r10, "returns"
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Const        r21, "profit"
-  Const        r22, "ss"
-  Const        r23, "ss_net_profit"
+  Const        r11, "profit"
+  Const        r12, "ss_net_profit"
   // profit_loss: 0.0
-  Const        r24, "profit_loss"
+  Const        r13, "profit_loss"
   // from ss in store_sales
-  MakeMap      r25, 0, r0
-  Const        r26, []
-  IterPrep     r28, r0
-  Len          r29, r28
-  Const        r30, 0
+  MakeMap      r14, 0, r0
+  Const        r15, []
+  IterPrep     r17, r0
+  Len          r18, r17
+  Const        r19, 0
 L8:
-  LessInt      r31, r30, r29
-  JumpIfFalse  r31, L0
-  Index        r33, r28, r30
+  LessInt      r20, r19, r18
+  JumpIfFalse  r20, L0
+  Index        r22, r17, r19
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r34, r9
+  IterPrep     r23, r0
+  Len          r24, r23
+  Const        r25, 0
+L7:
+  LessInt      r26, r25, r24
+  JumpIfFalse  r26, L1
+  Index        r28, r23, r25
+  Const        r29, "ss_sold_date_sk"
+  Index        r30, r22, r29
+  Const        r31, "d_date_sk"
+  Index        r32, r28, r31
+  Equal        r33, r30, r32
+  JumpIfFalse  r33, L2
+  // join s in store on ss.ss_store_sk == s.s_store_sk
+  IterPrep     r34, r0
   Len          r35, r34
   Const        r36, 0
-L7:
+L6:
   LessInt      r37, r36, r35
-  JumpIfFalse  r37, L1
+  JumpIfFalse  r37, L2
   Index        r39, r34, r36
-  Const        r40, "ss_sold_date_sk"
-  Index        r41, r33, r40
-  Const        r42, "d_date_sk"
+  Const        r40, "ss_store_sk"
+  Index        r41, r22, r40
+  Const        r42, "s_store_sk"
   Index        r43, r39, r42
   Equal        r44, r41, r43
-  JumpIfFalse  r44, L2
-  // join s in store on ss.ss_store_sk == s.s_store_sk
-  IterPrep     r45, r2
-  Len          r46, r45
-  Const        r47, 0
-L6:
-  LessInt      r48, r47, r46
-  JumpIfFalse  r48, L2
-  Index        r50, r45, r47
-  Const        r51, "ss_store_sk"
-  Index        r52, r33, r51
-  Const        r53, "s_store_sk"
-  Index        r54, r50, r53
-  Equal        r55, r52, r54
-  JumpIfFalse  r55, L3
+  JumpIfFalse  r44, L3
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r56, "d_date"
-  Index        r57, r39, r56
-  Const        r58, "1998-12-01"
-  LessEq       r59, r58, r57
-  Const        r60, "d_date"
-  Index        r61, r39, r60
-  Const        r62, "1998-12-15"
-  LessEq       r63, r61, r62
-  Move         r64, r59
-  JumpIfFalse  r64, L4
-  Move         r64, r63
+  Index        r45, r28, r3
+  Const        r46, "1998-12-01"
+  LessEq       r47, r46, r45
+  Index        r48, r28, r3
+  Const        r49, "1998-12-15"
+  LessEq       r50, r48, r49
+  JumpIfFalse  r47, L4
+  Move         r47, r50
 L4:
-  JumpIfFalse  r64, L3
+  JumpIfFalse  r47, L3
   // from ss in store_sales
-  Const        r65, "ss"
-  Move         r66, r33
-  Const        r67, "d"
-  Move         r68, r39
-  Const        r69, "s"
-  Move         r70, r50
-  MakeMap      r71, 3, r65
+  Move         r51, r22
+  Const        r52, "d"
+  Move         r53, r28
+  Const        r54, "s"
+  Move         r55, r39
+  MakeMap      r56, 3, r8
   // group by s.s_store_id into g
-  Const        r72, "s_store_id"
-  Index        r73, r50, r72
-  Str          r74, r73
-  In           r75, r74, r25
-  JumpIfTrue   r75, L5
+  Index        r57, r39, r2
+  Str          r58, r57
+  In           r59, r58, r14
+  JumpIfTrue   r59, L5
   // from ss in store_sales
-  Const        r76, []
-  Const        r77, "__group__"
-  Const        r78, true
-  Const        r79, "key"
+  Const        r60, []
+  Const        r61, "__group__"
+  Const        r62, true
+  Const        r63, "key"
   // group by s.s_store_id into g
-  Move         r80, r73
+  Move         r64, r57
   // from ss in store_sales
-  Const        r81, "items"
-  Move         r82, r76
-  Const        r83, "count"
-  Const        r84, 0
-  Move         r85, r77
-  Move         r86, r78
-  Move         r87, r79
-  Move         r88, r80
-  Move         r89, r81
-  Move         r90, r82
-  Move         r91, r83
-  Move         r92, r84
-  MakeMap      r93, 4, r85
-  SetIndex     r25, r74, r93
-  Append       r26, r26, r93
+  Const        r65, "items"
+  Move         r66, r60
+  Const        r67, "count"
+  Const        r68, 0
+  Move         r69, r61
+  Move         r70, r62
+  Move         r71, r63
+  Move         r72, r64
+  Move         r73, r65
+  Move         r74, r66
+  Move         r75, r67
+  Move         r76, r68
+  MakeMap      r77, 4, r69
+  SetIndex     r14, r58, r77
+  Append       r15, r15, r77
 L5:
-  Const        r95, "items"
-  Index        r96, r25, r74
-  Index        r97, r96, r95
-  Append       r98, r97, r71
-  SetIndex     r96, r95, r98
-  Const        r99, "count"
-  Index        r100, r96, r99
-  Const        r101, 1
-  AddInt       r102, r100, r101
-  SetIndex     r96, r99, r102
+  Const        r79, "items"
+  Index        r80, r14, r58
+  Index        r81, r80, r79
+  Append       r82, r81, r56
+  SetIndex     r80, r79, r82
+  Const        r83, "count"
+  Index        r84, r80, r83
+  Const        r85, 1
+  AddInt       r86, r84, r85
+  SetIndex     r80, r83, r86
 L3:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  Const        r103, 1
-  AddInt       r47, r47, r103
+  AddInt       r36, r36, r85
   Jump         L6
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  Const        r104, 1
-  AddInt       r36, r36, r104
+  AddInt       r25, r25, r85
   Jump         L7
 L1:
   // from ss in store_sales
-  Const        r105, 1
-  AddInt       r30, r30, r105
+  AddInt       r19, r19, r85
   Jump         L8
 L0:
-  Const        r106, 0
-  Len          r108, r26
+  Const        r88, 0
+  Move         r87, r88
+  Len          r89, r15
 L14:
-  LessInt      r109, r106, r108
-  JumpIfFalse  r109, L9
-  Index        r111, r26, r106
+  LessInt      r90, r87, r89
+  JumpIfFalse  r90, L9
+  Index        r92, r15, r87
   // channel: "store channel",
-  Const        r112, "channel"
-  Const        r113, "store channel"
+  Const        r93, "channel"
+  Const        r94, "store channel"
   // id: "store" + str(g.key),
-  Const        r114, "id"
-  Const        r115, "store"
-  Const        r116, "key"
-  Index        r117, r111, r116
-  Str          r118, r117
-  Add          r119, r115, r118
+  Const        r95, "id"
+  Const        r96, "store"
+  Index        r97, r92, r6
+  Str          r98, r97
+  Add          r99, r96, r98
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r120, "sales"
-  Const        r121, []
-  Const        r122, "ss"
-  Const        r123, "ss_ext_sales_price"
-  IterPrep     r124, r111
-  Len          r125, r124
-  Const        r126, 0
+  Const        r100, "sales"
+  Const        r101, []
+  IterPrep     r102, r92
+  Len          r103, r102
+  Move         r104, r88
 L11:
-  LessInt      r128, r126, r125
-  JumpIfFalse  r128, L10
-  Index        r130, r124, r126
-  Const        r131, "ss"
-  Index        r132, r130, r131
-  Const        r133, "ss_ext_sales_price"
-  Index        r134, r132, r133
-  Append       r121, r121, r134
-  Const        r136, 1
-  AddInt       r126, r126, r136
+  LessInt      r105, r104, r103
+  JumpIfFalse  r105, L10
+  Index        r107, r102, r104
+  Index        r108, r107, r8
+  Index        r109, r108, r9
+  Append       r101, r101, r109
+  AddInt       r104, r104, r85
   Jump         L11
 L10:
-  Sum          r137, r121
+  Sum          r111, r101
   // returns: 0.0,
-  Const        r138, "returns"
-  Const        r139, 0
+  Const        r112, "returns"
+  Const        r113, 0
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Const        r140, "profit"
-  Const        r141, []
-  Const        r142, "ss"
-  Const        r143, "ss_net_profit"
-  IterPrep     r144, r111
-  Len          r145, r144
-  Const        r146, 0
+  Const        r114, "profit"
+  Const        r115, []
+  IterPrep     r116, r92
+  Len          r117, r116
+  Move         r118, r88
 L13:
-  LessInt      r148, r146, r145
-  JumpIfFalse  r148, L12
-  Index        r130, r144, r146
-  Const        r150, "ss"
-  Index        r151, r130, r150
-  Const        r152, "ss_net_profit"
-  Index        r153, r151, r152
-  Append       r141, r141, r153
-  Const        r155, 1
-  AddInt       r146, r146, r155
+  LessInt      r119, r118, r117
+  JumpIfFalse  r119, L12
+  Index        r107, r116, r118
+  Index        r121, r107, r8
+  Index        r122, r121, r12
+  Append       r115, r115, r122
+  AddInt       r118, r118, r85
   Jump         L13
 L12:
-  Sum          r156, r141
+  Sum          r124, r115
   // profit_loss: 0.0
-  Const        r157, "profit_loss"
-  Const        r158, 0
+  Const        r125, "profit_loss"
   // channel: "store channel",
-  Move         r159, r112
-  Move         r160, r113
+  Move         r126, r93
+  Move         r127, r94
   // id: "store" + str(g.key),
-  Move         r161, r114
-  Move         r162, r119
+  Move         r128, r95
+  Move         r129, r99
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Move         r163, r120
-  Move         r164, r137
+  Move         r130, r100
+  Move         r131, r111
   // returns: 0.0,
-  Move         r165, r138
-  Move         r166, r139
+  Move         r132, r112
+  Move         r133, r113
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Move         r167, r140
-  Move         r168, r156
+  Move         r134, r114
+  Move         r135, r124
   // profit_loss: 0.0
-  Move         r169, r157
-  Move         r170, r158
+  Move         r136, r125
+  Move         r137, r113
   // select {
-  MakeMap      r171, 6, r159
+  MakeMap      r138, 6, r126
   // from ss in store_sales
-  Append       r10, r10, r171
-  Const        r173, 1
-  AddInt       r106, r106, r173
+  Append       r1, r1, r138
+  AddInt       r87, r87, r85
   Jump         L14
 L9:
   // from sr in store_returns
-  Const        r174, []
-  // group by s.s_store_id into g
-  Const        r175, "s_store_id"
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r176, "d_date"
-  Const        r177, "d_date"
-  // channel: "store channel",
-  Const        r178, "channel"
-  // id: "store" + str(g.key),
-  Const        r179, "id"
-  Const        r180, "key"
-  // sales: 0.0,
-  Const        r181, "sales"
+  Const        r140, []
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Const        r182, "returns"
-  Const        r183, "sr"
-  Const        r184, "sr_return_amt"
-  // profit: 0.0,
-  Const        r185, "profit"
+  Const        r141, "sr"
+  Const        r142, "sr_return_amt"
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Const        r186, "profit_loss"
-  Const        r187, "sr"
-  Const        r188, "sr_net_loss"
+  Const        r143, "sr_net_loss"
   // from sr in store_returns
-  MakeMap      r189, 0, r0
-  Const        r190, []
-  IterPrep     r192, r1
-  Len          r193, r192
-  Const        r194, 0
+  MakeMap      r144, 0, r0
+  Const        r146, []
+  Move         r145, r146
+  IterPrep     r147, r0
+  Len          r148, r147
+  Const        r149, 0
 L23:
-  LessInt      r195, r194, r193
-  JumpIfFalse  r195, L15
-  Index        r197, r192, r194
+  LessInt      r150, r149, r148
+  JumpIfFalse  r150, L15
+  Index        r152, r147, r149
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  IterPrep     r198, r9
-  Len          r199, r198
-  Const        r200, 0
+  IterPrep     r153, r0
+  Len          r154, r153
+  Const        r155, 0
 L22:
-  LessInt      r201, r200, r199
-  JumpIfFalse  r201, L16
-  Index        r203, r198, r200
-  Const        r204, "sr_returned_date_sk"
-  Index        r205, r197, r204
-  Const        r206, "d_date_sk"
-  Index        r207, r203, r206
-  Equal        r208, r205, r207
-  JumpIfFalse  r208, L17
+  LessInt      r156, r155, r154
+  JumpIfFalse  r156, L16
+  Index        r158, r153, r155
+  Const        r159, "sr_returned_date_sk"
+  Index        r160, r152, r159
+  Index        r161, r158, r31
+  Equal        r162, r160, r161
+  JumpIfFalse  r162, L17
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  IterPrep     r209, r2
-  Len          r210, r209
-  Const        r211, 0
+  IterPrep     r163, r0
+  Len          r164, r163
+  Const        r165, 0
 L21:
-  LessInt      r212, r211, r210
-  JumpIfFalse  r212, L17
-  Index        r214, r209, r211
-  Const        r215, "sr_store_sk"
-  Index        r216, r197, r215
-  Const        r217, "s_store_sk"
-  Index        r218, r214, r217
-  Equal        r219, r216, r218
-  JumpIfFalse  r219, L18
+  LessInt      r166, r165, r164
+  JumpIfFalse  r166, L17
+  Index        r168, r163, r165
+  Const        r169, "sr_store_sk"
+  Index        r170, r152, r169
+  Index        r171, r168, r42
+  Equal        r172, r170, r171
+  JumpIfFalse  r172, L18
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r220, "d_date"
-  Index        r221, r203, r220
-  Const        r222, "1998-12-01"
-  LessEq       r223, r222, r221
-  Const        r224, "d_date"
-  Index        r225, r203, r224
-  Const        r226, "1998-12-15"
-  LessEq       r227, r225, r226
-  Move         r228, r223
-  JumpIfFalse  r228, L19
-  Move         r228, r227
+  Index        r173, r158, r3
+  LessEq       r174, r46, r173
+  Index        r175, r158, r3
+  LessEq       r176, r175, r49
+  JumpIfFalse  r174, L19
+  Move         r174, r176
 L19:
-  JumpIfFalse  r228, L18
+  JumpIfFalse  r174, L18
   // from sr in store_returns
-  Const        r229, "sr"
-  Move         r230, r197
-  Const        r231, "d"
-  Move         r232, r203
-  Const        r233, "s"
-  Move         r234, r214
-  MakeMap      r235, 3, r229
+  Move         r177, r152
+  Move         r178, r158
+  Move         r179, r168
+  MakeMap      r180, 3, r141
   // group by s.s_store_id into g
-  Const        r236, "s_store_id"
-  Index        r237, r214, r236
-  Str          r238, r237
-  In           r239, r238, r189
-  JumpIfTrue   r239, L20
+  Index        r181, r168, r2
+  Str          r182, r181
+  In           r183, r182, r144
+  JumpIfTrue   r183, L20
   // from sr in store_returns
-  Const        r240, []
-  Const        r241, "__group__"
-  Const        r242, true
-  Const        r243, "key"
+  Const        r184, []
+  Const        r185, "__group__"
+  Const        r186, true
+  Const        r187, "key"
   // group by s.s_store_id into g
-  Move         r244, r237
+  Move         r188, r181
   // from sr in store_returns
-  Const        r245, "items"
-  Move         r246, r240
-  Const        r247, "count"
-  Const        r248, 0
-  Move         r249, r241
-  Move         r250, r242
-  Move         r251, r243
-  Move         r252, r244
-  Move         r253, r245
-  Move         r254, r246
-  Move         r255, r247
-  Move         r256, r248
-  MakeMap      r257, 4, r249
-  SetIndex     r189, r238, r257
-  Append       r190, r190, r257
+  Const        r189, "items"
+  Move         r190, r184
+  Const        r191, "count"
+  Const        r192, 0
+  Move         r193, r185
+  Move         r194, r186
+  Move         r195, r187
+  Move         r196, r188
+  Move         r197, r189
+  Move         r198, r190
+  Move         r199, r191
+  Move         r200, r192
+  MakeMap      r201, 4, r193
+  SetIndex     r144, r182, r201
+  Append       r145, r145, r201
 L20:
-  Const        r259, "items"
-  Index        r260, r189, r238
-  Index        r261, r260, r259
-  Append       r262, r261, r235
-  SetIndex     r260, r259, r262
-  Const        r263, "count"
-  Index        r264, r260, r263
-  Const        r265, 1
-  AddInt       r266, r264, r265
-  SetIndex     r260, r263, r266
+  Index        r203, r144, r182
+  Index        r204, r203, r79
+  Append       r205, r204, r180
+  SetIndex     r203, r79, r205
+  Index        r206, r203, r83
+  AddInt       r207, r206, r85
+  SetIndex     r203, r83, r207
 L18:
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  Const        r267, 1
-  AddInt       r211, r211, r267
+  AddInt       r165, r165, r85
   Jump         L21
 L17:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  Const        r268, 1
-  AddInt       r200, r200, r268
+  AddInt       r155, r155, r85
   Jump         L22
 L16:
   // from sr in store_returns
-  Const        r269, 1
-  AddInt       r194, r194, r269
+  AddInt       r149, r149, r85
   Jump         L23
 L15:
-  Const        r270, 0
-  Len          r272, r190
+  Move         r208, r88
+  Len          r209, r145
 L29:
-  LessInt      r273, r270, r272
-  JumpIfFalse  r273, L24
-  Index        r111, r190, r270
+  LessInt      r210, r208, r209
+  JumpIfFalse  r210, L24
+  Index        r92, r145, r208
   // channel: "store channel",
-  Const        r275, "channel"
-  Const        r276, "store channel"
+  Const        r212, "channel"
   // id: "store" + str(g.key),
-  Const        r277, "id"
-  Const        r278, "store"
-  Const        r279, "key"
-  Index        r280, r111, r279
-  Str          r281, r280
-  Add          r282, r278, r281
+  Const        r213, "id"
+  Index        r214, r92, r6
+  Str          r215, r214
+  Add          r216, r96, r215
   // sales: 0.0,
-  Const        r283, "sales"
-  Const        r284, 0
+  Const        r217, "sales"
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Const        r285, "returns"
-  Const        r286, []
-  Const        r287, "sr"
-  Const        r288, "sr_return_amt"
-  IterPrep     r289, r111
-  Len          r290, r289
-  Const        r291, 0
+  Const        r218, "returns"
+  Const        r219, []
+  IterPrep     r220, r92
+  Len          r221, r220
+  Move         r222, r88
 L26:
-  LessInt      r293, r291, r290
-  JumpIfFalse  r293, L25
-  Index        r130, r289, r291
-  Const        r295, "sr"
-  Index        r296, r130, r295
-  Const        r297, "sr_return_amt"
-  Index        r298, r296, r297
-  Append       r286, r286, r298
-  Const        r300, 1
-  AddInt       r291, r291, r300
+  LessInt      r223, r222, r221
+  JumpIfFalse  r223, L25
+  Index        r107, r220, r222
+  Index        r225, r107, r141
+  Index        r226, r225, r142
+  Append       r219, r219, r226
+  AddInt       r222, r222, r85
   Jump         L26
 L25:
-  Sum          r301, r286
+  Sum          r228, r219
   // profit: 0.0,
-  Const        r302, "profit"
-  Const        r303, 0
+  Const        r229, "profit"
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Const        r304, "profit_loss"
-  Const        r305, []
-  Const        r306, "sr"
-  Const        r307, "sr_net_loss"
-  IterPrep     r308, r111
-  Len          r309, r308
-  Const        r310, 0
+  Const        r230, "profit_loss"
+  Const        r231, []
+  IterPrep     r232, r92
+  Len          r233, r232
+  Move         r234, r88
 L28:
-  LessInt      r312, r310, r309
-  JumpIfFalse  r312, L27
-  Index        r130, r308, r310
-  Const        r314, "sr"
-  Index        r315, r130, r314
-  Const        r316, "sr_net_loss"
-  Index        r317, r315, r316
-  Append       r305, r305, r317
-  Const        r319, 1
-  AddInt       r310, r310, r319
+  LessInt      r235, r234, r233
+  JumpIfFalse  r235, L27
+  Index        r107, r232, r234
+  Index        r237, r107, r141
+  Index        r238, r237, r143
+  Append       r231, r231, r238
+  AddInt       r234, r234, r85
   Jump         L28
 L27:
-  Sum          r320, r305
+  Sum          r240, r231
   // channel: "store channel",
-  Move         r321, r275
-  Move         r322, r276
+  Move         r241, r212
+  Move         r242, r94
   // id: "store" + str(g.key),
-  Move         r323, r277
-  Move         r324, r282
+  Move         r243, r213
+  Move         r244, r216
   // sales: 0.0,
-  Move         r325, r283
-  Move         r326, r284
+  Move         r245, r217
+  Move         r246, r113
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Move         r327, r285
-  Move         r328, r301
+  Move         r247, r218
+  Move         r248, r228
   // profit: 0.0,
-  Move         r329, r302
-  Move         r330, r303
+  Move         r249, r229
+  Move         r250, r113
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Move         r331, r304
-  Move         r332, r320
+  Move         r251, r230
+  Move         r252, r240
   // select {
-  MakeMap      r333, 6, r321
+  MakeMap      r253, 6, r241
   // from sr in store_returns
-  Append       r174, r174, r333
-  Const        r335, 1
-  AddInt       r270, r270, r335
+  Append       r140, r140, r253
+  AddInt       r208, r208, r85
   Jump         L29
 L24:
   // from cs in catalog_sales
-  Const        r336, []
+  Const        r255, []
   // group by cp.cp_catalog_page_id into g
-  Const        r337, "cp_catalog_page_id"
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r338, "d_date"
-  Const        r339, "d_date"
-  // channel: "catalog channel",
-  Const        r340, "channel"
-  // id: "catalog_page" + str(g.key),
-  Const        r341, "id"
-  Const        r342, "key"
+  Const        r256, "cp_catalog_page_id"
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Const        r343, "sales"
-  Const        r344, "cs"
-  Const        r345, "cs_ext_sales_price"
-  // returns: 0.0,
-  Const        r346, "returns"
+  Const        r257, "cs"
+  Const        r258, "cs_ext_sales_price"
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Const        r347, "profit"
-  Const        r348, "cs"
-  Const        r349, "cs_net_profit"
-  // profit_loss: 0.0
-  Const        r350, "profit_loss"
+  Const        r259, "cs_net_profit"
   // from cs in catalog_sales
-  MakeMap      r351, 0, r0
-  Const        r352, []
-  IterPrep     r354, r3
-  Len          r355, r354
-  Const        r356, 0
+  MakeMap      r260, 0, r0
+  Const        r262, []
+  Move         r261, r262
+  IterPrep     r263, r0
+  Len          r264, r263
+  Const        r265, 0
 L38:
-  LessInt      r357, r356, r355
-  JumpIfFalse  r357, L30
-  Index        r359, r354, r356
+  LessInt      r266, r265, r264
+  JumpIfFalse  r266, L30
+  Index        r268, r263, r265
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r360, r9
-  Len          r361, r360
-  Const        r362, 0
+  IterPrep     r269, r0
+  Len          r270, r269
+  Const        r271, 0
 L37:
-  LessInt      r363, r362, r361
-  JumpIfFalse  r363, L31
-  Index        r365, r360, r362
-  Const        r366, "cs_sold_date_sk"
-  Index        r367, r359, r366
-  Const        r368, "d_date_sk"
-  Index        r369, r365, r368
-  Equal        r370, r367, r369
-  JumpIfFalse  r370, L32
+  LessInt      r272, r271, r270
+  JumpIfFalse  r272, L31
+  Index        r274, r269, r271
+  Const        r275, "cs_sold_date_sk"
+  Index        r276, r268, r275
+  Index        r277, r274, r31
+  Equal        r278, r276, r277
+  JumpIfFalse  r278, L32
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r371, r5
-  Len          r372, r371
-  Const        r373, 0
+  IterPrep     r279, r0
+  Len          r280, r279
+  Const        r281, 0
 L36:
-  LessInt      r374, r373, r372
-  JumpIfFalse  r374, L32
-  Index        r376, r371, r373
-  Const        r377, "cs_catalog_page_sk"
-  Index        r378, r359, r377
-  Const        r379, "cp_catalog_page_sk"
-  Index        r380, r376, r379
-  Equal        r381, r378, r380
-  JumpIfFalse  r381, L33
+  LessInt      r282, r281, r280
+  JumpIfFalse  r282, L32
+  Index        r284, r279, r281
+  Const        r285, "cs_catalog_page_sk"
+  Index        r286, r268, r285
+  Const        r287, "cp_catalog_page_sk"
+  Index        r288, r284, r287
+  Equal        r289, r286, r288
+  JumpIfFalse  r289, L33
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r382, "d_date"
-  Index        r383, r365, r382
-  Const        r384, "1998-12-01"
-  LessEq       r385, r384, r383
-  Const        r386, "d_date"
-  Index        r387, r365, r386
-  Const        r388, "1998-12-15"
-  LessEq       r389, r387, r388
-  Move         r390, r385
-  JumpIfFalse  r390, L34
-  Move         r390, r389
+  Index        r290, r274, r3
+  LessEq       r291, r46, r290
+  Index        r292, r274, r3
+  LessEq       r293, r292, r49
+  JumpIfFalse  r291, L34
+  Move         r291, r293
 L34:
-  JumpIfFalse  r390, L33
+  JumpIfFalse  r291, L33
   // from cs in catalog_sales
-  Const        r391, "cs"
-  Move         r392, r359
-  Const        r393, "d"
-  Move         r394, r365
-  Const        r395, "cp"
-  Move         r396, r376
-  MakeMap      r397, 3, r391
+  Move         r294, r268
+  Move         r295, r274
+  Const        r296, "cp"
+  Move         r297, r284
+  MakeMap      r298, 3, r257
   // group by cp.cp_catalog_page_id into g
-  Const        r398, "cp_catalog_page_id"
-  Index        r399, r376, r398
-  Str          r400, r399
-  In           r401, r400, r351
-  JumpIfTrue   r401, L35
+  Index        r299, r284, r256
+  Str          r300, r299
+  In           r301, r300, r260
+  JumpIfTrue   r301, L35
   // from cs in catalog_sales
-  Const        r402, []
-  Const        r403, "__group__"
-  Const        r404, true
-  Const        r405, "key"
+  Const        r302, []
+  Const        r303, "__group__"
+  Const        r304, true
+  Const        r305, "key"
   // group by cp.cp_catalog_page_id into g
-  Move         r406, r399
+  Move         r306, r299
   // from cs in catalog_sales
-  Const        r407, "items"
-  Move         r408, r402
-  Const        r409, "count"
-  Const        r410, 0
-  Move         r411, r403
-  Move         r412, r404
-  Move         r413, r405
-  Move         r414, r406
-  Move         r415, r407
-  Move         r416, r408
-  Move         r417, r409
-  Move         r418, r410
-  MakeMap      r419, 4, r411
-  SetIndex     r351, r400, r419
-  Append       r352, r352, r419
+  Const        r307, "items"
+  Move         r308, r302
+  Const        r309, "count"
+  Const        r310, 0
+  Move         r311, r303
+  Move         r312, r304
+  Move         r313, r305
+  Move         r314, r306
+  Move         r315, r307
+  Move         r316, r308
+  Move         r317, r309
+  Move         r318, r310
+  MakeMap      r319, 4, r311
+  SetIndex     r260, r300, r319
+  Append       r261, r261, r319
 L35:
-  Const        r421, "items"
-  Index        r422, r351, r400
-  Index        r423, r422, r421
-  Append       r424, r423, r397
-  SetIndex     r422, r421, r424
-  Const        r425, "count"
-  Index        r426, r422, r425
-  Const        r427, 1
-  AddInt       r428, r426, r427
-  SetIndex     r422, r425, r428
+  Index        r321, r260, r300
+  Index        r322, r321, r79
+  Append       r323, r322, r298
+  SetIndex     r321, r79, r323
+  Index        r324, r321, r83
+  AddInt       r325, r324, r85
+  SetIndex     r321, r83, r325
 L33:
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  Const        r429, 1
-  AddInt       r373, r373, r429
+  AddInt       r281, r281, r85
   Jump         L36
 L32:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  Const        r430, 1
-  AddInt       r362, r362, r430
+  AddInt       r271, r271, r85
   Jump         L37
 L31:
   // from cs in catalog_sales
-  Const        r431, 1
-  AddInt       r356, r356, r431
+  AddInt       r265, r265, r85
   Jump         L38
 L30:
-  Const        r432, 0
-  Len          r434, r352
+  Move         r326, r88
+  Len          r327, r261
 L44:
-  LessInt      r435, r432, r434
-  JumpIfFalse  r435, L39
-  Index        r111, r352, r432
+  LessInt      r328, r326, r327
+  JumpIfFalse  r328, L39
+  Index        r92, r261, r326
   // channel: "catalog channel",
-  Const        r437, "channel"
-  Const        r438, "catalog channel"
+  Const        r330, "channel"
+  Const        r331, "catalog channel"
   // id: "catalog_page" + str(g.key),
-  Const        r439, "id"
-  Const        r440, "catalog_page"
-  Const        r441, "key"
-  Index        r442, r111, r441
-  Str          r443, r442
-  Add          r444, r440, r443
+  Const        r332, "id"
+  Const        r333, "catalog_page"
+  Index        r334, r92, r6
+  Str          r335, r334
+  Add          r336, r333, r335
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Const        r445, "sales"
-  Const        r446, []
-  Const        r447, "cs"
-  Const        r448, "cs_ext_sales_price"
-  IterPrep     r449, r111
-  Len          r450, r449
-  Const        r451, 0
+  Const        r337, "sales"
+  Const        r338, []
+  IterPrep     r339, r92
+  Len          r340, r339
+  Move         r341, r88
 L41:
-  LessInt      r453, r451, r450
-  JumpIfFalse  r453, L40
-  Index        r130, r449, r451
-  Const        r455, "cs"
-  Index        r456, r130, r455
-  Const        r457, "cs_ext_sales_price"
-  Index        r458, r456, r457
-  Append       r446, r446, r458
-  Const        r460, 1
-  AddInt       r451, r451, r460
+  LessInt      r342, r341, r340
+  JumpIfFalse  r342, L40
+  Index        r107, r339, r341
+  Index        r344, r107, r257
+  Index        r345, r344, r258
+  Append       r338, r338, r345
+  AddInt       r341, r341, r85
   Jump         L41
 L40:
-  Sum          r461, r446
+  Sum          r347, r338
   // returns: 0.0,
-  Const        r462, "returns"
-  Const        r463, 0
+  Const        r348, "returns"
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Const        r464, "profit"
-  Const        r465, []
-  Const        r466, "cs"
-  Const        r467, "cs_net_profit"
-  IterPrep     r468, r111
-  Len          r469, r468
-  Const        r470, 0
+  Const        r349, "profit"
+  Const        r350, []
+  IterPrep     r351, r92
+  Len          r352, r351
+  Move         r353, r88
 L43:
-  LessInt      r472, r470, r469
-  JumpIfFalse  r472, L42
-  Index        r130, r468, r470
-  Const        r474, "cs"
-  Index        r475, r130, r474
-  Const        r476, "cs_net_profit"
-  Index        r477, r475, r476
-  Append       r465, r465, r477
-  Const        r479, 1
-  AddInt       r470, r470, r479
+  LessInt      r354, r353, r352
+  JumpIfFalse  r354, L42
+  Index        r107, r351, r353
+  Index        r356, r107, r257
+  Index        r357, r356, r259
+  Append       r350, r350, r357
+  AddInt       r353, r353, r85
   Jump         L43
 L42:
-  Sum          r480, r465
+  Sum          r359, r350
   // profit_loss: 0.0
-  Const        r481, "profit_loss"
-  Const        r482, 0
+  Const        r360, "profit_loss"
   // channel: "catalog channel",
-  Move         r483, r437
-  Move         r484, r438
+  Move         r361, r330
+  Move         r362, r331
   // id: "catalog_page" + str(g.key),
-  Move         r485, r439
-  Move         r486, r444
+  Move         r363, r332
+  Move         r364, r336
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Move         r487, r445
-  Move         r488, r461
+  Move         r365, r337
+  Move         r366, r347
   // returns: 0.0,
-  Move         r489, r462
-  Move         r490, r463
+  Move         r367, r348
+  Move         r368, r113
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Move         r491, r464
-  Move         r492, r480
+  Move         r369, r349
+  Move         r370, r359
   // profit_loss: 0.0
-  Move         r493, r481
-  Move         r494, r482
+  Move         r371, r360
+  Move         r372, r113
   // select {
-  MakeMap      r495, 6, r483
+  MakeMap      r373, 6, r361
   // from cs in catalog_sales
-  Append       r336, r336, r495
-  Const        r497, 1
-  AddInt       r432, r432, r497
+  Append       r255, r255, r373
+  AddInt       r326, r326, r85
   Jump         L44
 L39:
   // from cr in catalog_returns
-  Const        r498, []
-  // group by cp.cp_catalog_page_id into g
-  Const        r499, "cp_catalog_page_id"
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r500, "d_date"
-  Const        r501, "d_date"
-  // channel: "catalog channel",
-  Const        r502, "channel"
-  // id: "catalog_page" + str(g.key),
-  Const        r503, "id"
-  Const        r504, "key"
-  // sales: 0.0,
-  Const        r505, "sales"
+  Const        r375, []
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Const        r506, "returns"
-  Const        r507, "cr"
-  Const        r508, "cr_return_amount"
-  // profit: 0.0,
-  Const        r509, "profit"
+  Const        r376, "cr"
+  Const        r377, "cr_return_amount"
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Const        r510, "profit_loss"
-  Const        r511, "cr"
-  Const        r512, "cr_net_loss"
+  Const        r378, "cr_net_loss"
   // from cr in catalog_returns
-  MakeMap      r513, 0, r0
-  Const        r514, []
-  IterPrep     r516, r4
-  Len          r517, r516
-  Const        r518, 0
+  MakeMap      r379, 0, r0
+  Const        r381, []
+  Move         r380, r381
+  IterPrep     r382, r0
+  Len          r383, r382
+  Const        r384, 0
 L53:
-  LessInt      r519, r518, r517
-  JumpIfFalse  r519, L45
-  Index        r521, r516, r518
+  LessInt      r385, r384, r383
+  JumpIfFalse  r385, L45
+  Index        r387, r382, r384
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  IterPrep     r522, r9
-  Len          r523, r522
-  Const        r524, 0
+  IterPrep     r388, r0
+  Len          r389, r388
+  Const        r390, 0
 L52:
-  LessInt      r525, r524, r523
-  JumpIfFalse  r525, L46
-  Index        r527, r522, r524
-  Const        r528, "cr_returned_date_sk"
-  Index        r529, r521, r528
-  Const        r530, "d_date_sk"
-  Index        r531, r527, r530
-  Equal        r532, r529, r531
-  JumpIfFalse  r532, L47
+  LessInt      r391, r390, r389
+  JumpIfFalse  r391, L46
+  Index        r393, r388, r390
+  Const        r394, "cr_returned_date_sk"
+  Index        r395, r387, r394
+  Index        r396, r393, r31
+  Equal        r397, r395, r396
+  JumpIfFalse  r397, L47
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r533, r5
-  Len          r534, r533
-  Const        r535, 0
+  IterPrep     r398, r0
+  Len          r399, r398
+  Const        r400, 0
 L51:
-  LessInt      r536, r535, r534
-  JumpIfFalse  r536, L47
-  Index        r538, r533, r535
-  Const        r539, "cr_catalog_page_sk"
-  Index        r540, r521, r539
-  Const        r541, "cp_catalog_page_sk"
-  Index        r542, r538, r541
-  Equal        r543, r540, r542
-  JumpIfFalse  r543, L48
+  LessInt      r401, r400, r399
+  JumpIfFalse  r401, L47
+  Index        r403, r398, r400
+  Const        r404, "cr_catalog_page_sk"
+  Index        r405, r387, r404
+  Index        r406, r403, r287
+  Equal        r407, r405, r406
+  JumpIfFalse  r407, L48
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r544, "d_date"
-  Index        r545, r527, r544
-  Const        r546, "1998-12-01"
-  LessEq       r547, r546, r545
-  Const        r548, "d_date"
-  Index        r549, r527, r548
-  Const        r550, "1998-12-15"
-  LessEq       r551, r549, r550
-  Move         r552, r547
-  JumpIfFalse  r552, L49
-  Move         r552, r551
+  Index        r408, r393, r3
+  LessEq       r409, r46, r408
+  Index        r410, r393, r3
+  LessEq       r411, r410, r49
+  JumpIfFalse  r409, L49
+  Move         r409, r411
 L49:
-  JumpIfFalse  r552, L48
+  JumpIfFalse  r409, L48
   // from cr in catalog_returns
-  Const        r553, "cr"
-  Move         r554, r521
-  Const        r555, "d"
-  Move         r556, r527
-  Const        r557, "cp"
-  Move         r558, r538
-  MakeMap      r559, 3, r553
+  Move         r412, r387
+  Move         r413, r393
+  Move         r414, r403
+  MakeMap      r415, 3, r376
   // group by cp.cp_catalog_page_id into g
-  Const        r560, "cp_catalog_page_id"
-  Index        r561, r538, r560
-  Str          r562, r561
-  In           r563, r562, r513
-  JumpIfTrue   r563, L50
+  Index        r416, r403, r256
+  Str          r417, r416
+  In           r418, r417, r379
+  JumpIfTrue   r418, L50
   // from cr in catalog_returns
-  Const        r564, []
-  Const        r565, "__group__"
-  Const        r566, true
-  Const        r567, "key"
+  Const        r419, []
+  Const        r420, "__group__"
+  Const        r421, true
+  Const        r422, "key"
   // group by cp.cp_catalog_page_id into g
-  Move         r568, r561
+  Move         r423, r416
   // from cr in catalog_returns
-  Const        r569, "items"
-  Move         r570, r564
-  Const        r571, "count"
-  Const        r572, 0
-  Move         r573, r565
-  Move         r574, r566
-  Move         r575, r567
-  Move         r576, r568
-  Move         r577, r569
-  Move         r578, r570
-  Move         r579, r571
-  Move         r580, r572
-  MakeMap      r581, 4, r573
-  SetIndex     r513, r562, r581
-  Append       r514, r514, r581
+  Const        r424, "items"
+  Move         r425, r419
+  Const        r426, "count"
+  Const        r427, 0
+  Move         r428, r420
+  Move         r429, r421
+  Move         r430, r422
+  Move         r431, r423
+  Move         r432, r424
+  Move         r433, r425
+  Move         r434, r426
+  Move         r435, r427
+  MakeMap      r436, 4, r428
+  SetIndex     r379, r417, r436
+  Append       r380, r380, r436
 L50:
-  Const        r583, "items"
-  Index        r584, r513, r562
-  Index        r585, r584, r583
-  Append       r586, r585, r559
-  SetIndex     r584, r583, r586
-  Const        r587, "count"
-  Index        r588, r584, r587
-  Const        r589, 1
-  AddInt       r590, r588, r589
-  SetIndex     r584, r587, r590
+  Index        r438, r379, r417
+  Index        r439, r438, r79
+  Append       r440, r439, r415
+  SetIndex     r438, r79, r440
+  Index        r441, r438, r83
+  AddInt       r442, r441, r85
+  SetIndex     r438, r83, r442
 L48:
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  Const        r591, 1
-  AddInt       r535, r535, r591
+  AddInt       r400, r400, r85
   Jump         L51
 L47:
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  Const        r592, 1
-  AddInt       r524, r524, r592
+  AddInt       r390, r390, r85
   Jump         L52
 L46:
   // from cr in catalog_returns
-  Const        r593, 1
-  AddInt       r518, r518, r593
+  AddInt       r384, r384, r85
   Jump         L53
 L45:
-  Const        r594, 0
-  Len          r596, r514
+  Move         r443, r88
+  Len          r444, r380
 L59:
-  LessInt      r597, r594, r596
-  JumpIfFalse  r597, L54
-  Index        r111, r514, r594
+  LessInt      r445, r443, r444
+  JumpIfFalse  r445, L54
+  Index        r92, r380, r443
   // channel: "catalog channel",
-  Const        r599, "channel"
-  Const        r600, "catalog channel"
+  Const        r447, "channel"
   // id: "catalog_page" + str(g.key),
-  Const        r601, "id"
-  Const        r602, "catalog_page"
-  Const        r603, "key"
-  Index        r604, r111, r603
-  Str          r605, r604
-  Add          r606, r602, r605
+  Const        r448, "id"
+  Index        r449, r92, r6
+  Str          r450, r449
+  Add          r451, r333, r450
   // sales: 0.0,
-  Const        r607, "sales"
-  Const        r608, 0
+  Const        r452, "sales"
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Const        r609, "returns"
-  Const        r610, []
-  Const        r611, "cr"
-  Const        r612, "cr_return_amount"
-  IterPrep     r613, r111
-  Len          r614, r613
-  Const        r615, 0
+  Const        r453, "returns"
+  Const        r454, []
+  IterPrep     r455, r92
+  Len          r456, r455
+  Move         r457, r88
 L56:
-  LessInt      r617, r615, r614
-  JumpIfFalse  r617, L55
-  Index        r130, r613, r615
-  Const        r619, "cr"
-  Index        r620, r130, r619
-  Const        r621, "cr_return_amount"
-  Index        r622, r620, r621
-  Append       r610, r610, r622
-  Const        r624, 1
-  AddInt       r615, r615, r624
+  LessInt      r458, r457, r456
+  JumpIfFalse  r458, L55
+  Index        r107, r455, r457
+  Index        r460, r107, r376
+  Index        r461, r460, r377
+  Append       r454, r454, r461
+  AddInt       r457, r457, r85
   Jump         L56
 L55:
-  Sum          r625, r610
+  Sum          r463, r454
   // profit: 0.0,
-  Const        r626, "profit"
-  Const        r627, 0
+  Const        r464, "profit"
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Const        r628, "profit_loss"
-  Const        r629, []
-  Const        r630, "cr"
-  Const        r631, "cr_net_loss"
-  IterPrep     r632, r111
-  Len          r633, r632
-  Const        r634, 0
+  Const        r465, "profit_loss"
+  Const        r466, []
+  IterPrep     r467, r92
+  Len          r468, r467
+  Move         r469, r88
 L58:
-  LessInt      r636, r634, r633
-  JumpIfFalse  r636, L57
-  Index        r130, r632, r634
-  Const        r638, "cr"
-  Index        r639, r130, r638
-  Const        r640, "cr_net_loss"
-  Index        r641, r639, r640
-  Append       r629, r629, r641
-  Const        r643, 1
-  AddInt       r634, r634, r643
+  LessInt      r470, r469, r468
+  JumpIfFalse  r470, L57
+  Index        r107, r467, r469
+  Index        r472, r107, r376
+  Index        r473, r472, r378
+  Append       r466, r466, r473
+  AddInt       r469, r469, r85
   Jump         L58
 L57:
-  Sum          r644, r629
+  Sum          r475, r466
   // channel: "catalog channel",
-  Move         r645, r599
-  Move         r646, r600
+  Move         r476, r447
+  Move         r477, r331
   // id: "catalog_page" + str(g.key),
-  Move         r647, r601
-  Move         r648, r606
+  Move         r478, r448
+  Move         r479, r451
   // sales: 0.0,
-  Move         r649, r607
-  Move         r650, r608
+  Move         r480, r452
+  Move         r481, r113
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Move         r651, r609
-  Move         r652, r625
+  Move         r482, r453
+  Move         r483, r463
   // profit: 0.0,
-  Move         r653, r626
-  Move         r654, r627
+  Move         r484, r464
+  Move         r485, r113
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Move         r655, r628
-  Move         r656, r644
+  Move         r486, r465
+  Move         r487, r475
   // select {
-  MakeMap      r657, 6, r645
+  MakeMap      r488, 6, r476
   // from cr in catalog_returns
-  Append       r498, r498, r657
-  Const        r659, 1
-  AddInt       r594, r594, r659
+  Append       r375, r375, r488
+  AddInt       r443, r443, r85
   Jump         L59
 L54:
   // from ws in web_sales
-  Const        r660, []
+  Const        r490, []
   // group by w.web_site_id into g
-  Const        r661, "web_site_id"
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r662, "d_date"
-  Const        r663, "d_date"
-  // channel: "web channel",
-  Const        r664, "channel"
-  // id: "web_site" + str(g.key),
-  Const        r665, "id"
-  Const        r666, "key"
+  Const        r491, "web_site_id"
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Const        r667, "sales"
-  Const        r668, "ws"
-  Const        r669, "ws_ext_sales_price"
-  // returns: 0.0,
-  Const        r670, "returns"
+  Const        r492, "ws"
+  Const        r493, "ws_ext_sales_price"
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Const        r671, "profit"
-  Const        r672, "ws"
-  Const        r673, "ws_net_profit"
-  // profit_loss: 0.0
-  Const        r674, "profit_loss"
+  Const        r494, "ws_net_profit"
   // from ws in web_sales
-  MakeMap      r675, 0, r0
-  Const        r676, []
-  IterPrep     r678, r6
-  Len          r679, r678
-  Const        r680, 0
+  MakeMap      r495, 0, r0
+  Const        r497, []
+  Move         r496, r497
+  IterPrep     r498, r0
+  Len          r499, r498
+  Const        r500, 0
 L68:
-  LessInt      r681, r680, r679
-  JumpIfFalse  r681, L60
-  Index        r683, r678, r680
+  LessInt      r501, r500, r499
+  JumpIfFalse  r501, L60
+  Index        r503, r498, r500
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r684, r9
-  Len          r685, r684
-  Const        r686, 0
+  IterPrep     r504, r0
+  Len          r505, r504
+  Const        r506, 0
 L67:
-  LessInt      r687, r686, r685
-  JumpIfFalse  r687, L61
-  Index        r689, r684, r686
-  Const        r690, "ws_sold_date_sk"
-  Index        r691, r683, r690
-  Const        r692, "d_date_sk"
-  Index        r693, r689, r692
-  Equal        r694, r691, r693
-  JumpIfFalse  r694, L62
+  LessInt      r507, r506, r505
+  JumpIfFalse  r507, L61
+  Index        r509, r504, r506
+  Const        r510, "ws_sold_date_sk"
+  Index        r511, r503, r510
+  Index        r512, r509, r31
+  Equal        r513, r511, r512
+  JumpIfFalse  r513, L62
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r695, r8
-  Len          r696, r695
-  Const        r697, 0
+  IterPrep     r514, r0
+  Len          r515, r514
+  Const        r516, 0
 L66:
-  LessInt      r698, r697, r696
-  JumpIfFalse  r698, L62
-  Index        r700, r695, r697
-  Const        r701, "ws_web_site_sk"
-  Index        r702, r683, r701
-  Const        r703, "web_site_sk"
-  Index        r704, r700, r703
-  Equal        r705, r702, r704
-  JumpIfFalse  r705, L63
+  LessInt      r517, r516, r515
+  JumpIfFalse  r517, L62
+  Index        r519, r514, r516
+  Const        r520, "ws_web_site_sk"
+  Index        r521, r503, r520
+  Const        r522, "web_site_sk"
+  Index        r523, r519, r522
+  Equal        r524, r521, r523
+  JumpIfFalse  r524, L63
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r706, "d_date"
-  Index        r707, r689, r706
-  Const        r708, "1998-12-01"
-  LessEq       r709, r708, r707
-  Const        r710, "d_date"
-  Index        r711, r689, r710
-  Const        r712, "1998-12-15"
-  LessEq       r713, r711, r712
-  Move         r714, r709
-  JumpIfFalse  r714, L64
-  Move         r714, r713
+  Index        r525, r509, r3
+  LessEq       r526, r46, r525
+  Index        r527, r509, r3
+  LessEq       r528, r527, r49
+  JumpIfFalse  r526, L64
+  Move         r526, r528
 L64:
-  JumpIfFalse  r714, L63
+  JumpIfFalse  r526, L63
   // from ws in web_sales
-  Const        r715, "ws"
-  Move         r716, r683
-  Const        r717, "d"
-  Move         r718, r689
-  Const        r719, "w"
-  Move         r720, r700
-  MakeMap      r721, 3, r715
+  Move         r529, r503
+  Move         r530, r509
+  Const        r531, "w"
+  Move         r532, r519
+  MakeMap      r533, 3, r492
   // group by w.web_site_id into g
-  Const        r722, "web_site_id"
-  Index        r723, r700, r722
-  Str          r724, r723
-  In           r725, r724, r675
-  JumpIfTrue   r725, L65
+  Index        r534, r519, r491
+  Str          r535, r534
+  In           r536, r535, r495
+  JumpIfTrue   r536, L65
   // from ws in web_sales
-  Const        r726, []
-  Const        r727, "__group__"
-  Const        r728, true
-  Const        r729, "key"
+  Const        r537, []
+  Const        r538, "__group__"
+  Const        r539, true
+  Const        r540, "key"
   // group by w.web_site_id into g
-  Move         r730, r723
+  Move         r541, r534
   // from ws in web_sales
-  Const        r731, "items"
-  Move         r732, r726
-  Const        r733, "count"
-  Const        r734, 0
-  Move         r735, r727
-  Move         r736, r728
-  Move         r737, r729
-  Move         r738, r730
-  Move         r739, r731
-  Move         r740, r732
-  Move         r741, r733
-  Move         r742, r734
-  MakeMap      r743, 4, r735
-  SetIndex     r675, r724, r743
-  Append       r676, r676, r743
+  Const        r542, "items"
+  Move         r543, r537
+  Const        r544, "count"
+  Const        r545, 0
+  Move         r546, r538
+  Move         r547, r539
+  Move         r548, r540
+  Move         r549, r541
+  Move         r550, r542
+  Move         r551, r543
+  Move         r552, r544
+  Move         r553, r545
+  MakeMap      r554, 4, r546
+  SetIndex     r495, r535, r554
+  Append       r496, r496, r554
 L65:
-  Const        r745, "items"
-  Index        r746, r675, r724
-  Index        r747, r746, r745
-  Append       r748, r747, r721
-  SetIndex     r746, r745, r748
-  Const        r749, "count"
-  Index        r750, r746, r749
-  Const        r751, 1
-  AddInt       r752, r750, r751
-  SetIndex     r746, r749, r752
+  Index        r556, r495, r535
+  Index        r557, r556, r79
+  Append       r558, r557, r533
+  SetIndex     r556, r79, r558
+  Index        r559, r556, r83
+  AddInt       r560, r559, r85
+  SetIndex     r556, r83, r560
 L63:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  Const        r753, 1
-  AddInt       r697, r697, r753
+  AddInt       r516, r516, r85
   Jump         L66
 L62:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  Const        r754, 1
-  AddInt       r686, r686, r754
+  AddInt       r506, r506, r85
   Jump         L67
 L61:
   // from ws in web_sales
-  Const        r755, 1
-  AddInt       r680, r680, r755
+  AddInt       r500, r500, r85
   Jump         L68
 L60:
-  Const        r756, 0
-  Len          r758, r676
+  Move         r561, r88
+  Len          r562, r496
 L74:
-  LessInt      r759, r756, r758
-  JumpIfFalse  r759, L69
-  Index        r111, r676, r756
+  LessInt      r563, r561, r562
+  JumpIfFalse  r563, L69
+  Index        r92, r496, r561
   // channel: "web channel",
-  Const        r761, "channel"
-  Const        r762, "web channel"
+  Const        r565, "channel"
+  Const        r566, "web channel"
   // id: "web_site" + str(g.key),
-  Const        r763, "id"
-  Const        r764, "web_site"
-  Const        r765, "key"
-  Index        r766, r111, r765
-  Str          r767, r766
-  Add          r768, r764, r767
+  Const        r567, "id"
+  Const        r568, "web_site"
+  Index        r569, r92, r6
+  Str          r570, r569
+  Add          r571, r568, r570
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Const        r769, "sales"
-  Const        r770, []
-  Const        r771, "ws"
-  Const        r772, "ws_ext_sales_price"
-  IterPrep     r773, r111
-  Len          r774, r773
-  Const        r775, 0
+  Const        r572, "sales"
+  Const        r573, []
+  IterPrep     r574, r92
+  Len          r575, r574
+  Move         r576, r88
 L71:
-  LessInt      r777, r775, r774
-  JumpIfFalse  r777, L70
-  Index        r130, r773, r775
-  Const        r779, "ws"
-  Index        r780, r130, r779
-  Const        r781, "ws_ext_sales_price"
-  Index        r782, r780, r781
-  Append       r770, r770, r782
-  Const        r784, 1
-  AddInt       r775, r775, r784
+  LessInt      r577, r576, r575
+  JumpIfFalse  r577, L70
+  Index        r107, r574, r576
+  Index        r579, r107, r492
+  Index        r580, r579, r493
+  Append       r573, r573, r580
+  AddInt       r576, r576, r85
   Jump         L71
 L70:
-  Sum          r785, r770
+  Sum          r582, r573
   // returns: 0.0,
-  Const        r786, "returns"
-  Const        r787, 0
+  Const        r583, "returns"
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Const        r788, "profit"
-  Const        r789, []
-  Const        r790, "ws"
-  Const        r791, "ws_net_profit"
-  IterPrep     r792, r111
-  Len          r793, r792
-  Const        r794, 0
+  Const        r584, "profit"
+  Const        r585, []
+  IterPrep     r586, r92
+  Len          r587, r586
+  Move         r588, r88
 L73:
-  LessInt      r796, r794, r793
-  JumpIfFalse  r796, L72
-  Index        r130, r792, r794
-  Const        r798, "ws"
-  Index        r799, r130, r798
-  Const        r800, "ws_net_profit"
-  Index        r801, r799, r800
-  Append       r789, r789, r801
-  Const        r803, 1
-  AddInt       r794, r794, r803
+  LessInt      r589, r588, r587
+  JumpIfFalse  r589, L72
+  Index        r107, r586, r588
+  Index        r591, r107, r492
+  Index        r592, r591, r494
+  Append       r585, r585, r592
+  AddInt       r588, r588, r85
   Jump         L73
 L72:
-  Sum          r804, r789
+  Sum          r594, r585
   // profit_loss: 0.0
-  Const        r805, "profit_loss"
-  Const        r806, 0
+  Const        r595, "profit_loss"
   // channel: "web channel",
-  Move         r807, r761
-  Move         r808, r762
+  Move         r596, r565
+  Move         r597, r566
   // id: "web_site" + str(g.key),
-  Move         r809, r763
-  Move         r810, r768
+  Move         r598, r567
+  Move         r599, r571
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Move         r811, r769
-  Move         r812, r785
+  Move         r600, r572
+  Move         r601, r582
   // returns: 0.0,
-  Move         r813, r786
-  Move         r814, r787
+  Move         r602, r583
+  Move         r603, r113
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Move         r815, r788
-  Move         r816, r804
+  Move         r604, r584
+  Move         r605, r594
   // profit_loss: 0.0
-  Move         r817, r805
-  Move         r818, r806
+  Move         r606, r595
+  Move         r607, r113
   // select {
-  MakeMap      r819, 6, r807
+  MakeMap      r608, 6, r596
   // from ws in web_sales
-  Append       r660, r660, r819
-  Const        r821, 1
-  AddInt       r756, r756, r821
+  Append       r490, r490, r608
+  AddInt       r561, r561, r85
   Jump         L74
 L69:
   // from wr in web_returns
-  Const        r822, []
-  // group by w.web_site_id into g
-  Const        r823, "web_site_id"
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r824, "d_date"
-  Const        r825, "d_date"
-  // channel: "web channel",
-  Const        r826, "channel"
-  // id: "web_site" + str(g.key),
-  Const        r827, "id"
-  Const        r828, "key"
-  // sales: 0.0,
-  Const        r829, "sales"
+  Const        r610, []
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Const        r830, "returns"
-  Const        r831, "wr"
-  Const        r832, "wr_return_amt"
-  // profit: 0.0,
-  Const        r833, "profit"
+  Const        r611, "wr"
+  Const        r612, "wr_return_amt"
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Const        r834, "profit_loss"
-  Const        r835, "wr"
-  Const        r836, "wr_net_loss"
+  Const        r613, "wr_net_loss"
   // from wr in web_returns
-  MakeMap      r837, 0, r0
-  Const        r838, []
-  IterPrep     r840, r7
-  Len          r841, r840
-  Const        r842, 0
+  MakeMap      r614, 0, r0
+  Const        r616, []
+  Move         r615, r616
+  IterPrep     r617, r0
+  Len          r618, r617
+  Const        r619, 0
 L86:
-  LessInt      r843, r842, r841
-  JumpIfFalse  r843, L75
-  Index        r845, r840, r842
+  LessInt      r620, r619, r618
+  JumpIfFalse  r620, L75
+  Index        r622, r617, r619
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  IterPrep     r846, r6
-  Len          r847, r846
-  Const        r848, 0
+  IterPrep     r623, r0
+  Len          r624, r623
+  Const        r625, 0
 L85:
-  LessInt      r849, r848, r847
-  JumpIfFalse  r849, L76
-  Index        r660, r846, r848
-  Const        r851, "wr_item_sk"
-  Index        r852, r845, r851
-  Const        r853, "ws_item_sk"
-  Index        r854, r660, r853
-  Equal        r855, r852, r854
-  Const        r856, "wr_order_number"
-  Index        r857, r845, r856
-  Const        r858, "ws_order_number"
-  Index        r859, r660, r858
-  Equal        r860, r857, r859
-  Move         r861, r855
-  JumpIfFalse  r861, L77
-  Move         r861, r860
+  LessInt      r626, r625, r624
+  JumpIfFalse  r626, L76
+  Index        r490, r623, r625
+  Const        r628, "wr_item_sk"
+  Index        r629, r622, r628
+  Const        r630, "ws_item_sk"
+  Index        r631, r490, r630
+  Equal        r632, r629, r631
+  Const        r633, "wr_order_number"
+  Index        r634, r622, r633
+  Const        r635, "ws_order_number"
+  Index        r636, r490, r635
+  Equal        r637, r634, r636
+  JumpIfFalse  r632, L77
+  Move         r632, r637
 L77:
-  JumpIfFalse  r861, L78
+  JumpIfFalse  r632, L78
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  IterPrep     r862, r9
-  Len          r863, r862
-  Const        r864, 0
+  IterPrep     r638, r0
+  Len          r639, r638
+  Const        r640, 0
 L84:
-  LessInt      r865, r864, r863
-  JumpIfFalse  r865, L78
-  Index        r867, r862, r864
-  Const        r868, "wr_returned_date_sk"
-  Index        r869, r845, r868
-  Const        r870, "d_date_sk"
-  Index        r871, r867, r870
-  Equal        r872, r869, r871
-  JumpIfFalse  r872, L79
+  LessInt      r641, r640, r639
+  JumpIfFalse  r641, L78
+  Index        r643, r638, r640
+  Const        r644, "wr_returned_date_sk"
+  Index        r645, r622, r644
+  Index        r646, r643, r31
+  Equal        r647, r645, r646
+  JumpIfFalse  r647, L79
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r873, r8
-  Len          r874, r873
-  Const        r875, 0
+  IterPrep     r648, r0
+  Len          r649, r648
+  Const        r650, 0
 L83:
-  LessInt      r876, r875, r874
-  JumpIfFalse  r876, L79
-  Index        r878, r873, r875
-  Const        r879, "ws_web_site_sk"
-  Index        r880, r660, r879
-  Const        r881, "web_site_sk"
-  Index        r882, r878, r881
-  Equal        r883, r880, r882
-  JumpIfFalse  r883, L80
+  LessInt      r651, r650, r649
+  JumpIfFalse  r651, L79
+  Index        r653, r648, r650
+  Index        r654, r490, r520
+  Index        r655, r653, r522
+  Equal        r656, r654, r655
+  JumpIfFalse  r656, L80
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Const        r884, "d_date"
-  Index        r885, r867, r884
-  Const        r886, "1998-12-01"
-  LessEq       r887, r886, r885
-  Const        r888, "d_date"
-  Index        r889, r867, r888
-  Const        r890, "1998-12-15"
-  LessEq       r891, r889, r890
-  Move         r892, r887
-  JumpIfFalse  r892, L81
-  Move         r892, r891
+  Index        r657, r643, r3
+  LessEq       r658, r46, r657
+  Index        r659, r643, r3
+  LessEq       r660, r659, r49
+  JumpIfFalse  r658, L81
+  Move         r658, r660
 L81:
-  JumpIfFalse  r892, L80
+  JumpIfFalse  r658, L80
   // from wr in web_returns
-  Const        r893, "wr"
-  Move         r894, r845
-  Const        r895, "ws"
-  Move         r896, r660
-  Const        r897, "d"
-  Move         r898, r867
-  Const        r899, "w"
-  Move         r900, r878
-  MakeMap      r901, 4, r893
+  Move         r661, r622
+  Move         r662, r490
+  Move         r663, r643
+  Move         r664, r653
+  MakeMap      r665, 4, r611
   // group by w.web_site_id into g
-  Const        r902, "web_site_id"
-  Index        r903, r878, r902
-  Str          r904, r903
-  In           r905, r904, r837
-  JumpIfTrue   r905, L82
+  Index        r666, r653, r491
+  Str          r667, r666
+  In           r668, r667, r614
+  JumpIfTrue   r668, L82
   // from wr in web_returns
-  Const        r906, []
-  Const        r907, "__group__"
-  Const        r908, true
-  Const        r909, "key"
+  Const        r669, []
+  Const        r670, "__group__"
+  Const        r671, true
+  Const        r672, "key"
   // group by w.web_site_id into g
-  Move         r910, r903
+  Move         r673, r666
   // from wr in web_returns
-  Const        r911, "items"
-  Move         r912, r906
-  Const        r913, "count"
-  Const        r914, 0
-  Move         r915, r907
-  Move         r916, r908
-  Move         r917, r909
-  Move         r918, r910
-  Move         r919, r911
-  Move         r920, r912
-  Move         r921, r913
-  Move         r922, r914
-  MakeMap      r923, 4, r915
-  SetIndex     r837, r904, r923
-  Append       r838, r838, r923
+  Const        r674, "items"
+  Move         r675, r669
+  Const        r676, "count"
+  Const        r677, 0
+  Move         r678, r670
+  Move         r679, r671
+  Move         r680, r672
+  Move         r681, r673
+  Move         r682, r674
+  Move         r683, r675
+  Move         r684, r676
+  Move         r685, r677
+  MakeMap      r686, 4, r678
+  SetIndex     r614, r667, r686
+  Append       r615, r615, r686
 L82:
-  Const        r925, "items"
-  Index        r926, r837, r904
-  Index        r927, r926, r925
-  Append       r928, r927, r901
-  SetIndex     r926, r925, r928
-  Const        r929, "count"
-  Index        r930, r926, r929
-  Const        r931, 1
-  AddInt       r932, r930, r931
-  SetIndex     r926, r929, r932
+  Index        r688, r614, r667
+  Index        r689, r688, r79
+  Append       r690, r689, r665
+  SetIndex     r688, r79, r690
+  Index        r691, r688, r83
+  AddInt       r692, r691, r85
+  SetIndex     r688, r83, r692
 L80:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  Const        r933, 1
-  AddInt       r875, r875, r933
+  AddInt       r650, r650, r85
   Jump         L83
 L79:
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  Const        r934, 1
-  AddInt       r864, r864, r934
+  AddInt       r640, r640, r85
   Jump         L84
 L78:
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  Const        r935, 1
-  AddInt       r848, r848, r935
+  AddInt       r625, r625, r85
   Jump         L85
 L76:
   // from wr in web_returns
-  Const        r936, 1
-  AddInt       r842, r842, r936
+  AddInt       r619, r619, r85
   Jump         L86
 L75:
-  Const        r937, 0
-  Len          r939, r838
+  Move         r693, r88
+  Len          r694, r615
 L92:
-  LessInt      r940, r937, r939
-  JumpIfFalse  r940, L87
-  Index        r111, r838, r937
+  LessInt      r695, r693, r694
+  JumpIfFalse  r695, L87
+  Index        r92, r615, r693
   // channel: "web channel",
-  Const        r942, "channel"
-  Const        r943, "web channel"
+  Const        r697, "channel"
   // id: "web_site" + str(g.key),
-  Const        r944, "id"
-  Const        r945, "web_site"
-  Const        r946, "key"
-  Index        r947, r111, r946
-  Str          r948, r947
-  Add          r949, r945, r948
+  Const        r698, "id"
+  Index        r699, r92, r6
+  Str          r700, r699
+  Add          r701, r568, r700
   // sales: 0.0,
-  Const        r950, "sales"
-  Const        r951, 0
+  Const        r702, "sales"
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Const        r952, "returns"
-  Const        r953, []
-  Const        r954, "wr"
-  Const        r955, "wr_return_amt"
-  IterPrep     r956, r111
-  Len          r957, r956
-  Const        r958, 0
+  Const        r703, "returns"
+  Const        r704, []
+  IterPrep     r705, r92
+  Len          r706, r705
+  Move         r707, r88
 L89:
-  LessInt      r960, r958, r957
-  JumpIfFalse  r960, L88
-  Index        r130, r956, r958
-  Const        r962, "wr"
-  Index        r963, r130, r962
-  Const        r964, "wr_return_amt"
-  Index        r965, r963, r964
-  Append       r953, r953, r965
-  Const        r967, 1
-  AddInt       r958, r958, r967
+  LessInt      r708, r707, r706
+  JumpIfFalse  r708, L88
+  Index        r107, r705, r707
+  Index        r710, r107, r611
+  Index        r711, r710, r612
+  Append       r704, r704, r711
+  AddInt       r707, r707, r85
   Jump         L89
 L88:
-  Sum          r968, r953
+  Sum          r713, r704
   // profit: 0.0,
-  Const        r969, "profit"
-  Const        r970, 0
+  Const        r714, "profit"
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Const        r971, "profit_loss"
-  Const        r972, []
-  Const        r973, "wr"
-  Const        r974, "wr_net_loss"
-  IterPrep     r975, r111
-  Len          r976, r975
-  Const        r977, 0
+  Const        r715, "profit_loss"
+  Const        r716, []
+  IterPrep     r717, r92
+  Len          r718, r717
+  Move         r719, r88
 L91:
-  LessInt      r979, r977, r976
-  JumpIfFalse  r979, L90
-  Index        r130, r975, r977
-  Const        r981, "wr"
-  Index        r982, r130, r981
-  Const        r983, "wr_net_loss"
-  Index        r984, r982, r983
-  Append       r972, r972, r984
-  Const        r986, 1
-  AddInt       r977, r977, r986
+  LessInt      r720, r719, r718
+  JumpIfFalse  r720, L90
+  Index        r107, r717, r719
+  Index        r722, r107, r611
+  Index        r723, r722, r613
+  Append       r716, r716, r723
+  AddInt       r719, r719, r85
   Jump         L91
 L90:
-  Sum          r987, r972
+  Sum          r725, r716
   // channel: "web channel",
-  Move         r988, r942
-  Move         r989, r943
+  Move         r726, r697
+  Move         r727, r566
   // id: "web_site" + str(g.key),
-  Move         r990, r944
-  Move         r991, r949
+  Move         r728, r698
+  Move         r729, r701
   // sales: 0.0,
-  Move         r992, r950
-  Move         r993, r951
+  Move         r730, r702
+  Move         r731, r113
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Move         r994, r952
-  Move         r995, r968
+  Move         r732, r703
+  Move         r733, r713
   // profit: 0.0,
-  Move         r996, r969
-  Move         r997, r970
+  Move         r734, r714
+  Move         r735, r113
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Move         r998, r971
-  Move         r999, r987
+  Move         r736, r715
+  Move         r737, r725
   // select {
-  MakeMap      r1000, 6, r988
+  MakeMap      r738, 6, r726
   // from wr in web_returns
-  Append       r822, r822, r1000
-  Const        r1002, 1
-  AddInt       r937, r937, r1002
+  Append       r610, r610, r738
+  AddInt       r693, r693, r85
   Jump         L92
 L87:
   // let per_channel = concat(ss union all sr, cs union all cr, ws union all wr)
-  UnionAll     r1003, r10, r174
-  UnionAll     r1004, r336, r498
-  UnionAll     r1005, r1003, r1004
-  UnionAll     r1006, r660, r822
-  UnionAll     r1007, r1005, r1006
+  UnionAll     r740, r1, r140
+  UnionAll     r741, r255, r375
+  UnionAll     r742, r740, r741
+  UnionAll     r743, r490, r610
+  UnionAll     r744, r742, r743
   // from p in per_channel
-  Const        r1008, []
-  // group by { channel: p.channel, id: p.id } into g
-  Const        r1009, "channel"
-  Const        r1010, "channel"
-  Const        r1011, "id"
-  Const        r1012, "id"
-  // channel: g.key.channel,
-  Const        r1013, "channel"
-  Const        r1014, "key"
-  Const        r1015, "channel"
-  // id: g.key.id,
-  Const        r1016, "id"
-  Const        r1017, "key"
-  Const        r1018, "id"
+  Const        r745, []
   // sales: sum(from x in g select x.p.sales),
-  Const        r1019, "sales"
-  Const        r1020, "p"
-  Const        r1021, "sales"
-  // returns: sum(from x in g select x.p.returns),
-  Const        r1022, "returns"
-  Const        r1023, "p"
-  Const        r1024, "returns"
-  // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Const        r1025, "profit"
-  Const        r1026, "p"
-  Const        r1027, "profit"
-  Const        r1028, "p"
-  Const        r1029, "profit_loss"
-  // sort by g.key.channel
-  Const        r1030, "key"
-  Const        r1031, "channel"
+  Const        r746, "p"
   // from p in per_channel
-  IterPrep     r1032, r1007
-  Len          r1033, r1032
-  Const        r1034, 0
-  MakeMap      r1035, 0, r0
-  Const        r1036, []
+  IterPrep     r747, r744
+  Len          r748, r747
+  Const        r749, 0
+  MakeMap      r750, 0, r0
+  Const        r751, []
 L95:
-  LessInt      r1038, r1034, r1033
-  JumpIfFalse  r1038, L93
-  Index        r1039, r1032, r1034
-  Move         r1040, r1039
+  LessInt      r753, r749, r748
+  JumpIfFalse  r753, L93
+  Index        r754, r747, r749
+  Move         r755, r754
   // group by { channel: p.channel, id: p.id } into g
-  Const        r1041, "channel"
-  Const        r1042, "channel"
-  Index        r1043, r1040, r1042
-  Const        r1044, "id"
-  Const        r1045, "id"
-  Index        r1046, r1040, r1045
-  Move         r1047, r1041
-  Move         r1048, r1043
-  Move         r1049, r1044
-  Move         r1050, r1046
-  MakeMap      r1051, 2, r1047
-  Str          r1052, r1051
-  In           r1053, r1052, r1035
-  JumpIfTrue   r1053, L94
+  Const        r756, "channel"
+  Index        r757, r755, r4
+  Const        r758, "id"
+  Index        r759, r755, r5
+  Move         r760, r756
+  Move         r761, r757
+  Move         r762, r758
+  Move         r763, r759
+  MakeMap      r764, 2, r760
+  Str          r765, r764
+  In           r766, r765, r750
+  JumpIfTrue   r766, L94
   // from p in per_channel
-  Const        r1054, []
-  Const        r1055, "__group__"
-  Const        r1056, true
-  Const        r1057, "key"
+  Const        r767, []
+  Const        r768, "__group__"
+  Const        r769, true
+  Const        r770, "key"
   // group by { channel: p.channel, id: p.id } into g
-  Move         r1058, r1051
+  Move         r771, r764
   // from p in per_channel
-  Const        r1059, "items"
-  Move         r1060, r1054
-  Const        r1061, "count"
-  Const        r1062, 0
-  Move         r1063, r1055
-  Move         r1064, r1056
-  Move         r1065, r1057
-  Move         r1066, r1058
-  Move         r1067, r1059
-  Move         r1068, r1060
-  Move         r1069, r1061
-  Move         r1070, r1062
-  MakeMap      r1071, 4, r1063
-  SetIndex     r1035, r1052, r1071
-  Append       r1036, r1036, r1071
+  Const        r772, "items"
+  Move         r773, r767
+  Const        r774, "count"
+  Const        r775, 0
+  Move         r776, r768
+  Move         r777, r769
+  Move         r778, r770
+  Move         r779, r771
+  Move         r780, r772
+  Move         r781, r773
+  Move         r782, r774
+  Move         r783, r775
+  MakeMap      r784, 4, r776
+  SetIndex     r750, r765, r784
+  Append       r751, r751, r784
 L94:
-  Const        r1073, "items"
-  Index        r1074, r1035, r1052
-  Index        r1075, r1074, r1073
-  Append       r1076, r1075, r1039
-  SetIndex     r1074, r1073, r1076
-  Const        r1077, "count"
-  Index        r1078, r1074, r1077
-  Const        r1079, 1
-  AddInt       r1080, r1078, r1079
-  SetIndex     r1074, r1077, r1080
-  Const        r1081, 1
-  AddInt       r1034, r1034, r1081
+  Index        r786, r750, r765
+  Index        r787, r786, r79
+  Append       r788, r787, r754
+  SetIndex     r786, r79, r788
+  Index        r789, r786, r83
+  AddInt       r790, r789, r85
+  SetIndex     r786, r83, r790
+  AddInt       r749, r749, r85
   Jump         L95
 L93:
-  Const        r1082, 0
-  Len          r1084, r1036
+  Move         r791, r88
+  Len          r792, r751
 L105:
-  LessInt      r1085, r1082, r1084
-  JumpIfFalse  r1085, L96
-  Index        r111, r1036, r1082
+  LessInt      r793, r791, r792
+  JumpIfFalse  r793, L96
+  Index        r92, r751, r791
   // channel: g.key.channel,
-  Const        r1087, "channel"
-  Const        r1088, "key"
-  Index        r1089, r111, r1088
-  Const        r1090, "channel"
-  Index        r1091, r1089, r1090
+  Const        r795, "channel"
+  Index        r796, r92, r6
+  Index        r797, r796, r4
   // id: g.key.id,
-  Const        r1092, "id"
-  Const        r1093, "key"
-  Index        r1094, r111, r1093
-  Const        r1095, "id"
-  Index        r1096, r1094, r1095
+  Const        r798, "id"
+  Index        r799, r92, r6
+  Index        r800, r799, r5
   // sales: sum(from x in g select x.p.sales),
-  Const        r1097, "sales"
-  Const        r1098, []
-  Const        r1099, "p"
-  Const        r1100, "sales"
-  IterPrep     r1101, r111
-  Len          r1102, r1101
-  Const        r1103, 0
+  Const        r801, "sales"
+  Const        r802, []
+  IterPrep     r803, r92
+  Len          r804, r803
+  Move         r805, r88
 L98:
-  LessInt      r1105, r1103, r1102
-  JumpIfFalse  r1105, L97
-  Index        r130, r1101, r1103
-  Const        r1107, "p"
-  Index        r1108, r130, r1107
-  Const        r1109, "sales"
-  Index        r1110, r1108, r1109
-  Append       r1098, r1098, r1110
-  Const        r1112, 1
-  AddInt       r1103, r1103, r1112
+  LessInt      r806, r805, r804
+  JumpIfFalse  r806, L97
+  Index        r107, r803, r805
+  Index        r808, r107, r746
+  Index        r809, r808, r7
+  Append       r802, r802, r809
+  AddInt       r805, r805, r85
   Jump         L98
 L97:
-  Sum          r1113, r1098
+  Sum          r811, r802
   // returns: sum(from x in g select x.p.returns),
-  Const        r1114, "returns"
-  Const        r1115, []
-  Const        r1116, "p"
-  Const        r1117, "returns"
-  IterPrep     r1118, r111
-  Len          r1119, r1118
-  Const        r1120, 0
+  Const        r812, "returns"
+  Const        r813, []
+  IterPrep     r814, r92
+  Len          r815, r814
+  Move         r816, r88
 L100:
-  LessInt      r1122, r1120, r1119
-  JumpIfFalse  r1122, L99
-  Index        r130, r1118, r1120
-  Const        r1124, "p"
-  Index        r1125, r130, r1124
-  Const        r1126, "returns"
-  Index        r1127, r1125, r1126
-  Append       r1115, r1115, r1127
-  Const        r1129, 1
-  AddInt       r1120, r1120, r1129
+  LessInt      r817, r816, r815
+  JumpIfFalse  r817, L99
+  Index        r107, r814, r816
+  Index        r819, r107, r746
+  Index        r820, r819, r10
+  Append       r813, r813, r820
+  AddInt       r816, r816, r85
   Jump         L100
 L99:
-  Sum          r1130, r1115
+  Sum          r822, r813
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Const        r1131, "profit"
-  Const        r1132, []
-  Const        r1133, "p"
-  Const        r1134, "profit"
-  IterPrep     r1135, r111
-  Len          r1136, r1135
-  Const        r1137, 0
+  Const        r823, "profit"
+  Const        r824, []
+  IterPrep     r825, r92
+  Len          r826, r825
+  Move         r827, r88
 L102:
-  LessInt      r1139, r1137, r1136
-  JumpIfFalse  r1139, L101
-  Index        r130, r1135, r1137
-  Const        r1141, "p"
-  Index        r1142, r130, r1141
-  Const        r1143, "profit"
-  Index        r1144, r1142, r1143
-  Append       r1132, r1132, r1144
-  Const        r1146, 1
-  AddInt       r1137, r1137, r1146
+  LessInt      r828, r827, r826
+  JumpIfFalse  r828, L101
+  Index        r107, r825, r827
+  Index        r830, r107, r746
+  Index        r831, r830, r11
+  Append       r824, r824, r831
+  AddInt       r827, r827, r85
   Jump         L102
 L101:
-  Sum          r1147, r1132
-  Const        r1148, []
-  Const        r1149, "p"
-  Const        r1150, "profit_loss"
-  IterPrep     r1151, r111
-  Len          r1152, r1151
-  Const        r1153, 0
+  Sum          r833, r824
+  Const        r834, []
+  IterPrep     r835, r92
+  Len          r836, r835
+  Move         r837, r88
 L104:
-  LessInt      r1155, r1153, r1152
-  JumpIfFalse  r1155, L103
-  Index        r130, r1151, r1153
-  Const        r1157, "p"
-  Index        r1158, r130, r1157
-  Const        r1159, "profit_loss"
-  Index        r1160, r1158, r1159
-  Append       r1148, r1148, r1160
-  Const        r1162, 1
-  AddInt       r1153, r1153, r1162
+  LessInt      r838, r837, r836
+  JumpIfFalse  r838, L103
+  Index        r107, r835, r837
+  Index        r840, r107, r746
+  Index        r841, r840, r13
+  Append       r834, r834, r841
+  AddInt       r837, r837, r85
   Jump         L104
 L103:
-  Sum          r1163, r1148
-  Sub          r1164, r1147, r1163
+  Sum          r843, r834
+  Sub          r844, r833, r843
   // channel: g.key.channel,
-  Move         r1165, r1087
-  Move         r1166, r1091
+  Move         r845, r795
+  Move         r846, r797
   // id: g.key.id,
-  Move         r1167, r1092
-  Move         r1168, r1096
+  Move         r847, r798
+  Move         r848, r800
   // sales: sum(from x in g select x.p.sales),
-  Move         r1169, r1097
-  Move         r1170, r1113
+  Move         r849, r801
+  Move         r850, r811
   // returns: sum(from x in g select x.p.returns),
-  Move         r1171, r1114
-  Move         r1172, r1130
+  Move         r851, r812
+  Move         r852, r822
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Move         r1173, r1131
-  Move         r1174, r1164
+  Move         r853, r823
+  Move         r854, r844
   // select {
-  MakeMap      r1175, 5, r1165
+  MakeMap      r855, 5, r845
   // sort by g.key.channel
-  Const        r1176, "key"
-  Index        r1177, r111, r1176
-  Const        r1178, "channel"
-  Index        r1180, r1177, r1178
+  Index        r856, r92, r6
+  Index        r858, r856, r4
   // from p in per_channel
-  Move         r1181, r1175
-  MakeList     r1182, 2, r1180
-  Append       r1008, r1008, r1182
-  Const        r1184, 1
-  AddInt       r1082, r1082, r1184
+  Move         r859, r855
+  MakeList     r860, 2, r858
+  Append       r745, r745, r860
+  AddInt       r791, r791, r85
   Jump         L105
 L96:
   // sort by g.key.channel
-  Sort         r1008, r1008
+  Sort         r745, r745
   // json(result)
-  JSON         r1008
+  JSON         r745
   // expect len(result) == 0
-  Len          r1186, r1008
-  Const        r1187, 0
-  EqualInt     r1188, r1186, r1187
-  Expect       r1188
+  Len          r863, r745
+  EqualInt     r864, r863, r88
+  Expect       r864
   Return       r0

--- a/tests/dataset/tpc-ds/out/q6.ir.out
+++ b/tests/dataset/tpc-ds/out/q6.ir.out
@@ -1,318 +1,275 @@
-func main (regs=210)
+func main (regs=172)
   // let customer_address = []
   Const        r0, []
-  // let customer = []
+  // from d in date_dim
   Const        r1, []
-  // let store_sales = []
-  Const        r2, []
-  // let date_dim = []
-  Const        r3, []
-  // let item = []
-  Const        r4, []
-  // from d in date_dim
-  Const        r5, []
   // where d.d_year == 1999 && d.d_moy == 5
-  Const        r6, "d_year"
-  Const        r7, "d_moy"
+  Const        r2, "d_year"
+  Const        r3, "d_moy"
   // select d.d_month_seq
-  Const        r8, "d_month_seq"
+  Const        r4, "d_month_seq"
   // from d in date_dim
-  IterPrep     r9, r3
-  Len          r10, r9
-  Const        r11, 0
+  IterPrep     r5, r0
+  Len          r6, r5
+  Const        r8, 0
+  Move         r7, r8
 L3:
-  LessInt      r13, r11, r10
-  JumpIfFalse  r13, L0
-  Index        r15, r9, r11
+  LessInt      r9, r7, r6
+  JumpIfFalse  r9, L0
+  Index        r11, r5, r7
   // where d.d_year == 1999 && d.d_moy == 5
-  Const        r16, "d_year"
-  Index        r17, r15, r16
-  Const        r18, 1999
-  Equal        r19, r17, r18
-  Const        r20, "d_moy"
-  Index        r21, r15, r20
-  Const        r22, 5
-  Equal        r23, r21, r22
-  Move         r24, r19
-  JumpIfFalse  r24, L1
-  Move         r24, r23
+  Index        r12, r11, r2
+  Const        r13, 1999
+  Equal        r14, r12, r13
+  Index        r15, r11, r3
+  Const        r16, 5
+  Equal        r17, r15, r16
+  JumpIfFalse  r14, L1
+  Move         r14, r17
 L1:
-  JumpIfFalse  r24, L2
+  JumpIfFalse  r14, L2
   // select d.d_month_seq
-  Const        r25, "d_month_seq"
-  Index        r26, r15, r25
+  Index        r18, r11, r4
   // from d in date_dim
-  Append       r5, r5, r26
+  Append       r1, r1, r18
 L2:
-  Const        r28, 1
-  AddInt       r11, r11, r28
+  Const        r20, 1
+  AddInt       r7, r7, r20
   Jump         L3
 L0:
   // let target_month_seq = max(
-  Max          r29, r5
+  Max          r21, r1
   // from a in customer_address
-  Const        r30, []
+  Const        r22, []
   // group by a.ca_state into g
-  Const        r31, "ca_state"
-  // where d.d_month_seq == target_month_seq &&
-  Const        r32, "d_month_seq"
+  Const        r23, "ca_state"
   // i.i_current_price > 1.2 * avg(
-  Const        r33, "i_current_price"
+  Const        r24, "i_current_price"
   // where j.i_category == i.i_category
-  Const        r34, "i_category"
-  Const        r35, "i_category"
-  // select j.i_current_price
-  Const        r36, "i_current_price"
+  Const        r25, "i_category"
   // select { state: g.key, cnt: count(g) }
-  Const        r37, "state"
-  Const        r38, "key"
-  Const        r39, "cnt"
-  // sort by [count(g), g.key]
-  Const        r40, "key"
+  Const        r26, "state"
+  Const        r27, "key"
+  Const        r28, "cnt"
   // from a in customer_address
-  MakeMap      r41, 0, r0
-  Const        r42, []
-  IterPrep     r44, r0
-  Len          r45, r44
-  Const        r46, 0
+  MakeMap      r29, 0, r0
+  Const        r30, []
+  IterPrep     r32, r0
+  Len          r33, r32
+  Const        r34, 0
 L19:
-  LessInt      r47, r46, r45
-  JumpIfFalse  r47, L4
-  Index        r49, r44, r46
+  LessInt      r35, r34, r33
+  JumpIfFalse  r35, L4
+  Index        r37, r32, r34
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  IterPrep     r50, r1
-  Len          r51, r50
-  Const        r52, 0
+  IterPrep     r38, r0
+  Len          r39, r38
+  Const        r40, 0
 L18:
-  LessInt      r53, r52, r51
-  JumpIfFalse  r53, L5
-  Index        r55, r50, r52
-  Const        r56, "ca_address_sk"
-  Index        r57, r49, r56
-  Const        r58, "c_current_addr_sk"
-  Index        r59, r55, r58
-  Equal        r60, r57, r59
-  JumpIfFalse  r60, L6
+  LessInt      r41, r40, r39
+  JumpIfFalse  r41, L5
+  Index        r43, r38, r40
+  Const        r44, "ca_address_sk"
+  Index        r45, r37, r44
+  Const        r46, "c_current_addr_sk"
+  Index        r47, r43, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L6
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  IterPrep     r61, r2
-  Len          r62, r61
-  Const        r63, 0
+  IterPrep     r49, r0
+  Len          r50, r49
+  Const        r51, 0
 L17:
-  LessInt      r64, r63, r62
-  JumpIfFalse  r64, L6
-  Index        r66, r61, r63
-  Const        r67, "c_customer_sk"
-  Index        r68, r55, r67
-  Const        r69, "ss_customer_sk"
-  Index        r70, r66, r69
-  Equal        r71, r68, r70
-  JumpIfFalse  r71, L7
+  LessInt      r52, r51, r50
+  JumpIfFalse  r52, L6
+  Index        r54, r49, r51
+  Const        r55, "c_customer_sk"
+  Index        r56, r43, r55
+  Const        r57, "ss_customer_sk"
+  Index        r58, r54, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L7
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r72, r3
-  Len          r73, r72
-  Const        r74, 0
+  IterPrep     r60, r0
+  Len          r61, r60
+  Const        r62, 0
 L16:
-  LessInt      r75, r74, r73
-  JumpIfFalse  r75, L7
-  Index        r15, r72, r74
-  Const        r77, "ss_sold_date_sk"
-  Index        r78, r66, r77
-  Const        r79, "d_date_sk"
-  Index        r80, r15, r79
-  Equal        r81, r78, r80
-  JumpIfFalse  r81, L8
+  LessInt      r63, r62, r61
+  JumpIfFalse  r63, L7
+  Index        r11, r60, r62
+  Const        r65, "ss_sold_date_sk"
+  Index        r66, r54, r65
+  Const        r67, "d_date_sk"
+  Index        r68, r11, r67
+  Equal        r69, r66, r68
+  JumpIfFalse  r69, L8
   // join i in item on s.ss_item_sk == i.i_item_sk
-  IterPrep     r82, r4
-  Len          r83, r82
-  Const        r84, 0
+  IterPrep     r70, r0
+  Len          r71, r70
+  Const        r72, 0
 L15:
-  LessInt      r85, r84, r83
-  JumpIfFalse  r85, L8
-  Index        r87, r82, r84
-  Const        r88, "ss_item_sk"
-  Index        r89, r66, r88
-  Const        r90, "i_item_sk"
-  Index        r91, r87, r90
-  Equal        r92, r89, r91
-  JumpIfFalse  r92, L9
+  LessInt      r73, r72, r71
+  JumpIfFalse  r73, L8
+  Index        r75, r70, r72
+  Const        r76, "ss_item_sk"
+  Index        r77, r54, r76
+  Const        r78, "i_item_sk"
+  Index        r79, r75, r78
+  Equal        r80, r77, r79
+  JumpIfFalse  r80, L9
   // where d.d_month_seq == target_month_seq &&
-  Const        r93, "d_month_seq"
-  Index        r94, r15, r93
+  Index        r81, r11, r4
   // i.i_current_price > 1.2 * avg(
-  Const        r95, 1.2
+  Const        r82, 1.2
   // from j in item
-  Const        r96, []
-  // where j.i_category == i.i_category
-  Const        r97, "i_category"
-  Const        r98, "i_category"
-  // select j.i_current_price
-  Const        r99, "i_current_price"
-  // from j in item
-  IterPrep     r100, r4
-  Len          r101, r100
-  Const        r102, 0
+  Const        r83, []
+  IterPrep     r84, r0
+  Len          r85, r84
+  Move         r86, r8
 L12:
-  LessInt      r104, r102, r101
-  JumpIfFalse  r104, L10
-  Index        r106, r100, r102
+  LessInt      r87, r86, r85
+  JumpIfFalse  r87, L10
+  Index        r89, r84, r86
   // where j.i_category == i.i_category
-  Const        r107, "i_category"
-  Index        r108, r106, r107
-  Const        r109, "i_category"
-  Index        r110, r87, r109
-  Equal        r111, r108, r110
-  JumpIfFalse  r111, L11
+  Index        r90, r89, r25
+  Index        r91, r75, r25
+  Equal        r92, r90, r91
+  JumpIfFalse  r92, L11
   // select j.i_current_price
-  Const        r112, "i_current_price"
-  Index        r113, r106, r112
+  Index        r93, r89, r24
   // from j in item
-  Append       r96, r96, r113
+  Append       r83, r83, r93
 L11:
-  Const        r115, 1
-  AddInt       r102, r102, r115
+  AddInt       r86, r86, r20
   Jump         L12
 L10:
   // i.i_current_price > 1.2 * avg(
-  Avg          r116, r96
-  MulFloat     r117, r95, r116
-  Const        r118, "i_current_price"
-  Index        r119, r87, r118
-  LessFloat    r120, r117, r119
+  Avg          r95, r83
+  MulFloat     r96, r82, r95
+  Index        r97, r75, r24
+  LessFloat    r98, r96, r97
   // where d.d_month_seq == target_month_seq &&
-  Equal        r122, r94, r29
-  JumpIfFalse  r122, L13
-  Move         r122, r120
+  Equal        r99, r81, r21
+  JumpIfFalse  r99, L13
+  Move         r99, r98
 L13:
-  JumpIfFalse  r122, L9
+  JumpIfFalse  r99, L9
   // from a in customer_address
-  Const        r123, "a"
-  Move         r124, r49
-  Const        r125, "c"
-  Move         r126, r55
-  Const        r127, "s"
-  Move         r128, r66
-  Const        r129, "d"
-  Move         r130, r15
-  Const        r131, "i"
-  Move         r132, r87
-  MakeMap      r133, 5, r123
+  Const        r100, "a"
+  Move         r101, r37
+  Const        r102, "c"
+  Move         r103, r43
+  Const        r104, "s"
+  Move         r105, r54
+  Const        r106, "d"
+  Move         r107, r11
+  Const        r108, "i"
+  Move         r109, r75
+  MakeMap      r110, 5, r100
   // group by a.ca_state into g
-  Const        r134, "ca_state"
-  Index        r135, r49, r134
-  Str          r136, r135
-  In           r137, r136, r41
-  JumpIfTrue   r137, L14
+  Index        r111, r37, r23
+  Str          r112, r111
+  In           r113, r112, r29
+  JumpIfTrue   r113, L14
   // from a in customer_address
-  Const        r138, []
-  Const        r139, "__group__"
-  Const        r140, true
-  Const        r141, "key"
+  Const        r114, []
+  Const        r115, "__group__"
+  Const        r116, true
+  Const        r117, "key"
   // group by a.ca_state into g
-  Move         r142, r135
+  Move         r118, r111
   // from a in customer_address
-  Const        r143, "items"
-  Move         r144, r138
-  Const        r145, "count"
-  Const        r146, 0
-  Move         r147, r139
-  Move         r148, r140
-  Move         r149, r141
-  Move         r150, r142
-  Move         r151, r143
-  Move         r152, r144
-  Move         r153, r145
-  Move         r154, r146
-  MakeMap      r155, 4, r147
-  SetIndex     r41, r136, r155
-  Append       r42, r42, r155
+  Const        r119, "items"
+  Move         r120, r114
+  Const        r121, "count"
+  Const        r122, 0
+  Move         r123, r115
+  Move         r124, r116
+  Move         r125, r117
+  Move         r126, r118
+  Move         r127, r119
+  Move         r128, r120
+  Move         r129, r121
+  Move         r130, r122
+  MakeMap      r131, 4, r123
+  SetIndex     r29, r112, r131
+  Append       r30, r30, r131
 L14:
-  Const        r157, "items"
-  Index        r158, r41, r136
-  Index        r159, r158, r157
-  Append       r160, r159, r133
-  SetIndex     r158, r157, r160
-  Const        r161, "count"
-  Index        r162, r158, r161
-  Const        r163, 1
-  AddInt       r164, r162, r163
-  SetIndex     r158, r161, r164
+  Const        r133, "items"
+  Index        r134, r29, r112
+  Index        r135, r134, r133
+  Append       r136, r135, r110
+  SetIndex     r134, r133, r136
+  Const        r137, "count"
+  Index        r138, r134, r137
+  AddInt       r139, r138, r20
+  SetIndex     r134, r137, r139
 L9:
   // join i in item on s.ss_item_sk == i.i_item_sk
-  Const        r165, 1
-  AddInt       r84, r84, r165
+  AddInt       r72, r72, r20
   Jump         L15
 L8:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  Const        r166, 1
-  AddInt       r74, r74, r166
+  AddInt       r62, r62, r20
   Jump         L16
 L7:
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  Const        r167, 1
-  AddInt       r63, r63, r167
+  AddInt       r51, r51, r20
   Jump         L17
 L6:
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  Const        r168, 1
-  AddInt       r52, r52, r168
+  AddInt       r40, r40, r20
   Jump         L18
 L5:
   // from a in customer_address
-  Const        r169, 1
-  AddInt       r46, r46, r169
+  AddInt       r34, r34, r20
   Jump         L19
 L4:
-  Const        r170, 0
-  Len          r172, r42
+  Move         r140, r8
+  Len          r141, r30
 L21:
-  LessInt      r173, r170, r172
-  JumpIfFalse  r173, L20
-  Index        r175, r42, r170
+  LessInt      r142, r140, r141
+  JumpIfFalse  r142, L20
+  Index        r144, r30, r140
   // having count(g) >= 10
-  Const        r176, "count"
-  Index        r177, r175, r176
-  Const        r178, 10
-  LessEq       r179, r178, r177
-  JumpIfFalse  r179, L20
+  Index        r145, r144, r137
+  Const        r146, 10
+  LessEq       r147, r146, r145
+  JumpIfFalse  r147, L20
   // select { state: g.key, cnt: count(g) }
-  Const        r180, "state"
-  Const        r181, "key"
-  Index        r182, r175, r181
-  Const        r183, "cnt"
-  Const        r184, "count"
-  Index        r185, r175, r184
-  Move         r186, r180
-  Move         r187, r182
-  Move         r188, r183
-  Move         r189, r185
-  MakeMap      r190, 2, r186
+  Const        r148, "state"
+  Index        r149, r144, r27
+  Const        r150, "cnt"
+  Index        r151, r144, r137
+  Move         r152, r148
+  Move         r153, r149
+  Move         r154, r150
+  Move         r155, r151
+  MakeMap      r156, 2, r152
   // sort by [count(g), g.key]
-  Const        r191, "count"
-  Index        r193, r175, r191
-  Const        r194, "key"
-  Index        r196, r175, r194
-  MakeList     r198, 2, r193
+  Index        r158, r144, r137
+  Index        r159, r144, r27
+  Move         r160, r159
+  MakeList     r162, 2, r158
   // from a in customer_address
-  Move         r199, r190
-  MakeList     r200, 2, r198
-  Append       r30, r30, r200
-  Const        r202, 1
-  AddInt       r170, r170, r202
+  Move         r163, r156
+  MakeList     r164, 2, r162
+  Append       r22, r22, r164
+  AddInt       r140, r140, r20
   Jump         L21
 L20:
   // sort by [count(g), g.key]
-  Sort         r30, r30
+  Sort         r22, r22
   // from a in customer_address
-  Const        r204, 0
+  Const        r167, 0
   // take 100
-  Const        r205, 100
+  Const        r168, 100
   // from a in customer_address
-  Slice        r30, r30, r204, r205
+  Slice        r22, r22, r167, r168
   // json(result)
-  JSON         r30
+  JSON         r22
   // expect len(result) == 0
-  Len          r207, r30
-  Const        r208, 0
-  EqualInt     r209, r207, r208
-  Expect       r209
+  Len          r170, r22
+  EqualInt     r171, r170, r8
+  Expect       r171
   Return       r0

--- a/tests/dataset/tpc-ds/out/q7.ir.out
+++ b/tests/dataset/tpc-ds/out/q7.ir.out
@@ -1,387 +1,329 @@
-func main (regs=265)
+func main (regs=207)
   // let store_sales = []
   Const        r0, []
-  // let customer_demographics = []
+  // from ss in store_sales
   Const        r1, []
-  // let date_dim = []
-  Const        r2, []
-  // let item = []
-  Const        r3, []
-  // let promotion = []
-  Const        r4, []
-  // from ss in store_sales
-  Const        r5, []
   // group by { i_item_id: i.i_item_id } into g
-  Const        r6, "i_item_id"
-  Const        r7, "i_item_id"
+  Const        r2, "i_item_id"
   // where cd.cd_gender == "M" &&
-  Const        r8, "cd_gender"
+  Const        r3, "cd_gender"
   // cd.cd_marital_status == "S" &&
-  Const        r9, "cd_marital_status"
+  Const        r4, "cd_marital_status"
   // cd.cd_education_status == "College" &&
-  Const        r10, "cd_education_status"
+  Const        r5, "cd_education_status"
   // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  Const        r11, "p_channel_email"
-  Const        r12, "p_channel_event"
+  Const        r6, "p_channel_email"
+  Const        r7, "p_channel_event"
   // d.d_year == 1998
-  Const        r13, "d_year"
+  Const        r8, "d_year"
   // i_item_id: g.key.i_item_id,
-  Const        r14, "i_item_id"
-  Const        r15, "key"
-  Const        r16, "i_item_id"
+  Const        r9, "key"
   // agg1: avg(from x in g select x.ss.ss_quantity),
-  Const        r17, "agg1"
-  Const        r18, "ss"
-  Const        r19, "ss_quantity"
+  Const        r10, "agg1"
+  Const        r11, "ss"
+  Const        r12, "ss_quantity"
   // agg2: avg(from x in g select x.ss.ss_list_price),
-  Const        r20, "agg2"
-  Const        r21, "ss"
-  Const        r22, "ss_list_price"
+  Const        r13, "agg2"
+  Const        r14, "ss_list_price"
   // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Const        r23, "agg3"
-  Const        r24, "ss"
-  Const        r25, "ss_coupon_amt"
+  Const        r15, "agg3"
+  Const        r16, "ss_coupon_amt"
   // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Const        r26, "agg4"
-  Const        r27, "ss"
-  Const        r28, "ss_sales_price"
-  // sort by g.key.i_item_id
-  Const        r29, "key"
-  Const        r30, "i_item_id"
+  Const        r17, "agg4"
+  Const        r18, "ss_sales_price"
   // from ss in store_sales
-  MakeMap      r31, 0, r0
-  Const        r32, []
-  IterPrep     r34, r0
-  Len          r35, r34
-  Const        r36, 0
+  MakeMap      r19, 0, r0
+  Const        r20, []
+  IterPrep     r22, r0
+  Len          r23, r22
+  Const        r24, 0
 L13:
-  LessInt      r37, r36, r35
-  JumpIfFalse  r37, L0
-  Index        r39, r34, r36
+  LessInt      r25, r24, r23
+  JumpIfFalse  r25, L0
+  Index        r27, r22, r24
   // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
-  IterPrep     r40, r1
-  Len          r41, r40
-  Const        r42, 0
+  IterPrep     r28, r0
+  Len          r29, r28
+  Const        r30, 0
 L12:
-  LessInt      r43, r42, r41
-  JumpIfFalse  r43, L1
-  Index        r45, r40, r42
-  Const        r46, "ss_cdemo_sk"
-  Index        r47, r39, r46
-  Const        r48, "cd_demo_sk"
-  Index        r49, r45, r48
-  Equal        r50, r47, r49
-  JumpIfFalse  r50, L2
+  LessInt      r31, r30, r29
+  JumpIfFalse  r31, L1
+  Index        r33, r28, r30
+  Const        r34, "ss_cdemo_sk"
+  Index        r35, r27, r34
+  Const        r36, "cd_demo_sk"
+  Index        r37, r33, r36
+  Equal        r38, r35, r37
+  JumpIfFalse  r38, L2
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r51, r2
-  Len          r52, r51
-  Const        r53, 0
+  IterPrep     r39, r0
+  Len          r40, r39
+  Const        r41, 0
 L11:
-  LessInt      r54, r53, r52
-  JumpIfFalse  r54, L2
-  Index        r56, r51, r53
-  Const        r57, "ss_sold_date_sk"
-  Index        r58, r39, r57
-  Const        r59, "d_date_sk"
-  Index        r60, r56, r59
-  Equal        r61, r58, r60
-  JumpIfFalse  r61, L3
+  LessInt      r42, r41, r40
+  JumpIfFalse  r42, L2
+  Index        r44, r39, r41
+  Const        r45, "ss_sold_date_sk"
+  Index        r46, r27, r45
+  Const        r47, "d_date_sk"
+  Index        r48, r44, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L3
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r62, r3
-  Len          r63, r62
-  Const        r64, 0
+  IterPrep     r50, r0
+  Len          r51, r50
+  Const        r52, 0
 L10:
-  LessInt      r65, r64, r63
-  JumpIfFalse  r65, L3
-  Index        r67, r62, r64
-  Const        r68, "ss_item_sk"
-  Index        r69, r39, r68
-  Const        r70, "i_item_sk"
-  Index        r71, r67, r70
-  Equal        r72, r69, r71
-  JumpIfFalse  r72, L4
+  LessInt      r53, r52, r51
+  JumpIfFalse  r53, L3
+  Index        r55, r50, r52
+  Const        r56, "ss_item_sk"
+  Index        r57, r27, r56
+  Const        r58, "i_item_sk"
+  Index        r59, r55, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L4
   // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
-  IterPrep     r73, r4
-  Len          r74, r73
-  Const        r75, 0
+  IterPrep     r61, r0
+  Len          r62, r61
+  Const        r63, 0
 L9:
-  LessInt      r76, r75, r74
-  JumpIfFalse  r76, L4
-  Index        r78, r73, r75
-  Const        r79, "ss_promo_sk"
-  Index        r80, r39, r79
-  Const        r81, "p_promo_sk"
-  Index        r82, r78, r81
-  Equal        r83, r80, r82
-  JumpIfFalse  r83, L5
+  LessInt      r64, r63, r62
+  JumpIfFalse  r64, L4
+  Index        r66, r61, r63
+  Const        r67, "ss_promo_sk"
+  Index        r68, r27, r67
+  Const        r69, "p_promo_sk"
+  Index        r70, r66, r69
+  Equal        r71, r68, r70
+  JumpIfFalse  r71, L5
   // where cd.cd_gender == "M" &&
-  Const        r84, "cd_gender"
-  Index        r85, r45, r84
-  Const        r86, "M"
-  Equal        r87, r85, r86
+  Index        r72, r33, r3
+  Const        r73, "M"
+  Equal        r74, r72, r73
   // cd.cd_marital_status == "S" &&
-  Const        r88, "cd_marital_status"
-  Index        r89, r45, r88
-  Const        r90, "S"
-  Equal        r91, r89, r90
+  Index        r75, r33, r4
+  Const        r76, "S"
+  Equal        r77, r75, r76
   // cd.cd_education_status == "College" &&
-  Const        r92, "cd_education_status"
-  Index        r93, r45, r92
-  Const        r94, "College"
-  Equal        r95, r93, r94
+  Index        r78, r33, r5
+  Const        r79, "College"
+  Equal        r80, r78, r79
   // d.d_year == 1998
-  Const        r96, "d_year"
-  Index        r97, r56, r96
-  Const        r98, 1998
-  Equal        r99, r97, r98
+  Index        r81, r44, r8
+  Const        r82, 1998
+  Equal        r83, r81, r82
   // where cd.cd_gender == "M" &&
-  Move         r100, r87
-  JumpIfFalse  r100, L6
-  Move         r100, r91
+  JumpIfFalse  r74, L6
+  Move         r74, r77
   // cd.cd_marital_status == "S" &&
-  JumpIfFalse  r100, L6
-  Move         r100, r95
+  JumpIfFalse  r74, L6
+  Move         r74, r80
   // cd.cd_education_status == "College" &&
-  JumpIfFalse  r100, L6
+  JumpIfFalse  r74, L6
   // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  Const        r101, "p_channel_email"
-  Index        r102, r78, r101
-  Const        r103, "N"
-  Equal        r104, r102, r103
-  Const        r105, "p_channel_event"
-  Index        r106, r78, r105
-  Const        r107, "N"
-  Equal        r108, r106, r107
-  Move         r109, r104
-  JumpIfTrue   r109, L7
+  Index        r84, r66, r6
+  Const        r85, "N"
+  Equal        r86, r84, r85
+  Index        r87, r66, r7
+  Equal        r88, r87, r85
+  JumpIfTrue   r86, L7
 L7:
   // cd.cd_education_status == "College" &&
-  Move         r100, r108
+  Move         r74, r88
   // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  JumpIfFalse  r100, L6
-  Move         r100, r99
+  JumpIfFalse  r74, L6
+  Move         r74, r83
 L6:
   // where cd.cd_gender == "M" &&
-  JumpIfFalse  r100, L5
+  JumpIfFalse  r74, L5
   // from ss in store_sales
-  Const        r110, "ss"
-  Move         r111, r39
-  Const        r112, "cd"
-  Move         r113, r45
-  Const        r114, "d"
-  Move         r115, r56
-  Const        r116, "i"
-  Move         r117, r67
-  Const        r118, "p"
-  Move         r119, r78
-  MakeMap      r120, 5, r110
+  Move         r89, r27
+  Const        r90, "cd"
+  Move         r91, r33
+  Const        r92, "d"
+  Move         r93, r44
+  Const        r94, "i"
+  Move         r95, r55
+  Const        r96, "p"
+  Move         r97, r66
+  MakeMap      r98, 5, r11
   // group by { i_item_id: i.i_item_id } into g
-  Const        r121, "i_item_id"
-  Const        r122, "i_item_id"
-  Index        r123, r67, r122
-  Move         r124, r121
-  Move         r125, r123
-  MakeMap      r126, 1, r124
-  Str          r127, r126
-  In           r128, r127, r31
-  JumpIfTrue   r128, L8
+  Const        r99, "i_item_id"
+  Index        r100, r55, r2
+  Move         r101, r99
+  Move         r102, r100
+  MakeMap      r103, 1, r101
+  Str          r104, r103
+  In           r105, r104, r19
+  JumpIfTrue   r105, L8
   // from ss in store_sales
-  Const        r129, []
-  Const        r130, "__group__"
-  Const        r131, true
-  Const        r132, "key"
+  Const        r106, []
+  Const        r107, "__group__"
+  Const        r108, true
+  Const        r109, "key"
   // group by { i_item_id: i.i_item_id } into g
-  Move         r133, r126
+  Move         r110, r103
   // from ss in store_sales
-  Const        r134, "items"
-  Move         r135, r129
-  Const        r136, "count"
-  Const        r137, 0
-  Move         r138, r130
-  Move         r139, r131
-  Move         r140, r132
-  Move         r141, r133
-  Move         r142, r134
-  Move         r143, r135
-  Move         r144, r136
-  Move         r145, r137
-  MakeMap      r146, 4, r138
-  SetIndex     r31, r127, r146
-  Append       r32, r32, r146
+  Const        r111, "items"
+  Move         r112, r106
+  Const        r113, "count"
+  Const        r114, 0
+  Move         r115, r107
+  Move         r116, r108
+  Move         r117, r109
+  Move         r118, r110
+  Move         r119, r111
+  Move         r120, r112
+  Move         r121, r113
+  Move         r122, r114
+  MakeMap      r123, 4, r115
+  SetIndex     r19, r104, r123
+  Append       r20, r20, r123
 L8:
-  Const        r148, "items"
-  Index        r149, r31, r127
-  Index        r150, r149, r148
-  Append       r151, r150, r120
-  SetIndex     r149, r148, r151
-  Const        r152, "count"
-  Index        r153, r149, r152
-  Const        r154, 1
-  AddInt       r155, r153, r154
-  SetIndex     r149, r152, r155
+  Const        r125, "items"
+  Index        r126, r19, r104
+  Index        r127, r126, r125
+  Append       r128, r127, r98
+  SetIndex     r126, r125, r128
+  Const        r129, "count"
+  Index        r130, r126, r129
+  Const        r131, 1
+  AddInt       r132, r130, r131
+  SetIndex     r126, r129, r132
 L5:
   // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
-  Const        r156, 1
-  AddInt       r75, r75, r156
+  AddInt       r63, r63, r131
   Jump         L9
 L4:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  Const        r157, 1
-  AddInt       r64, r64, r157
+  AddInt       r52, r52, r131
   Jump         L10
 L3:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  Const        r158, 1
-  AddInt       r53, r53, r158
+  AddInt       r41, r41, r131
   Jump         L11
 L2:
   // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
-  Const        r159, 1
-  AddInt       r42, r42, r159
+  AddInt       r30, r30, r131
   Jump         L12
 L1:
   // from ss in store_sales
-  Const        r160, 1
-  AddInt       r36, r36, r160
+  AddInt       r24, r24, r131
   Jump         L13
 L0:
-  Const        r161, 0
-  Len          r163, r32
+  Const        r134, 0
+  Move         r133, r134
+  Len          r135, r20
 L23:
-  LessInt      r164, r161, r163
-  JumpIfFalse  r164, L14
-  Index        r166, r32, r161
+  LessInt      r136, r133, r135
+  JumpIfFalse  r136, L14
+  Index        r138, r20, r133
   // i_item_id: g.key.i_item_id,
-  Const        r167, "i_item_id"
-  Const        r168, "key"
-  Index        r169, r166, r168
-  Const        r170, "i_item_id"
-  Index        r171, r169, r170
+  Const        r139, "i_item_id"
+  Index        r140, r138, r9
+  Index        r141, r140, r2
   // agg1: avg(from x in g select x.ss.ss_quantity),
-  Const        r172, "agg1"
-  Const        r173, []
-  Const        r174, "ss"
-  Const        r175, "ss_quantity"
-  IterPrep     r176, r166
-  Len          r177, r176
-  Const        r178, 0
+  Const        r142, "agg1"
+  Const        r143, []
+  IterPrep     r144, r138
+  Len          r145, r144
+  Move         r146, r134
 L16:
-  LessInt      r180, r178, r177
-  JumpIfFalse  r180, L15
-  Index        r182, r176, r178
-  Const        r183, "ss"
-  Index        r184, r182, r183
-  Const        r185, "ss_quantity"
-  Index        r186, r184, r185
-  Append       r173, r173, r186
-  Const        r188, 1
-  AddInt       r178, r178, r188
+  LessInt      r147, r146, r145
+  JumpIfFalse  r147, L15
+  Index        r149, r144, r146
+  Index        r150, r149, r11
+  Index        r151, r150, r12
+  Append       r143, r143, r151
+  AddInt       r146, r146, r131
   Jump         L16
 L15:
-  Avg          r189, r173
+  Avg          r153, r143
   // agg2: avg(from x in g select x.ss.ss_list_price),
-  Const        r190, "agg2"
-  Const        r191, []
-  Const        r192, "ss"
-  Const        r193, "ss_list_price"
-  IterPrep     r194, r166
-  Len          r195, r194
-  Const        r196, 0
+  Const        r154, "agg2"
+  Const        r155, []
+  IterPrep     r156, r138
+  Len          r157, r156
+  Move         r158, r134
 L18:
-  LessInt      r198, r196, r195
-  JumpIfFalse  r198, L17
-  Index        r182, r194, r196
-  Const        r200, "ss"
-  Index        r201, r182, r200
-  Const        r202, "ss_list_price"
-  Index        r203, r201, r202
-  Append       r191, r191, r203
-  Const        r205, 1
-  AddInt       r196, r196, r205
+  LessInt      r159, r158, r157
+  JumpIfFalse  r159, L17
+  Index        r149, r156, r158
+  Index        r161, r149, r11
+  Index        r162, r161, r14
+  Append       r155, r155, r162
+  AddInt       r158, r158, r131
   Jump         L18
 L17:
-  Avg          r206, r191
+  Avg          r164, r155
   // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Const        r207, "agg3"
-  Const        r208, []
-  Const        r209, "ss"
-  Const        r210, "ss_coupon_amt"
-  IterPrep     r211, r166
-  Len          r212, r211
-  Const        r213, 0
+  Const        r165, "agg3"
+  Const        r166, []
+  IterPrep     r167, r138
+  Len          r168, r167
+  Move         r169, r134
 L20:
-  LessInt      r215, r213, r212
-  JumpIfFalse  r215, L19
-  Index        r182, r211, r213
-  Const        r217, "ss"
-  Index        r218, r182, r217
-  Const        r219, "ss_coupon_amt"
-  Index        r220, r218, r219
-  Append       r208, r208, r220
-  Const        r222, 1
-  AddInt       r213, r213, r222
+  LessInt      r170, r169, r168
+  JumpIfFalse  r170, L19
+  Index        r149, r167, r169
+  Index        r172, r149, r11
+  Index        r173, r172, r16
+  Append       r166, r166, r173
+  AddInt       r169, r169, r131
   Jump         L20
 L19:
-  Avg          r223, r208
+  Avg          r175, r166
   // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Const        r224, "agg4"
-  Const        r225, []
-  Const        r226, "ss"
-  Const        r227, "ss_sales_price"
-  IterPrep     r228, r166
-  Len          r229, r228
-  Const        r230, 0
+  Const        r176, "agg4"
+  Const        r177, []
+  IterPrep     r178, r138
+  Len          r179, r178
+  Move         r180, r134
 L22:
-  LessInt      r232, r230, r229
-  JumpIfFalse  r232, L21
-  Index        r182, r228, r230
-  Const        r234, "ss"
-  Index        r235, r182, r234
-  Const        r236, "ss_sales_price"
-  Index        r237, r235, r236
-  Append       r225, r225, r237
-  Const        r239, 1
-  AddInt       r230, r230, r239
+  LessInt      r181, r180, r179
+  JumpIfFalse  r181, L21
+  Index        r149, r178, r180
+  Index        r183, r149, r11
+  Index        r184, r183, r18
+  Append       r177, r177, r184
+  AddInt       r180, r180, r131
   Jump         L22
 L21:
-  Avg          r240, r225
+  Avg          r186, r177
   // i_item_id: g.key.i_item_id,
-  Move         r241, r167
-  Move         r242, r171
+  Move         r187, r139
+  Move         r188, r141
   // agg1: avg(from x in g select x.ss.ss_quantity),
-  Move         r243, r172
-  Move         r244, r189
+  Move         r189, r142
+  Move         r190, r153
   // agg2: avg(from x in g select x.ss.ss_list_price),
-  Move         r245, r190
-  Move         r246, r206
+  Move         r191, r154
+  Move         r192, r164
   // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Move         r247, r207
-  Move         r248, r223
+  Move         r193, r165
+  Move         r194, r175
   // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Move         r249, r224
-  Move         r250, r240
+  Move         r195, r176
+  Move         r196, r186
   // select {
-  MakeMap      r251, 5, r241
+  MakeMap      r197, 5, r187
   // sort by g.key.i_item_id
-  Const        r252, "key"
-  Index        r253, r166, r252
-  Const        r254, "i_item_id"
-  Index        r256, r253, r254
+  Index        r198, r138, r9
+  Index        r200, r198, r2
   // from ss in store_sales
-  Move         r257, r251
-  MakeList     r258, 2, r256
-  Append       r5, r5, r258
-  Const        r260, 1
-  AddInt       r161, r161, r260
+  Move         r201, r197
+  MakeList     r202, 2, r200
+  Append       r1, r1, r202
+  AddInt       r133, r133, r131
   Jump         L23
 L14:
   // sort by g.key.i_item_id
-  Sort         r5, r5
+  Sort         r1, r1
   // json(result)
-  JSON         r5
+  JSON         r1
   // expect len(result) == 0
-  Len          r262, r5
-  Const        r263, 0
-  EqualInt     r264, r262, r263
-  Expect       r264
+  Len          r205, r1
+  EqualInt     r206, r205, r134
+  Expect       r206
   Return       r0

--- a/tests/dataset/tpc-ds/out/q8.ir.out
+++ b/tests/dataset/tpc-ds/out/q8.ir.out
@@ -1,24 +1,13 @@
-func main (regs=11)
+func main (regs=5)
   // let store_sales = []
   Const        r0, []
-  // let date_dim = []
-  Const        r1, []
-  // let store = []
-  Const        r2, []
-  // let customer_address = []
-  Const        r3, []
-  // let customer = []
-  Const        r4, []
   // reverse(substr("zip", 0, 2))
-  Const        r5, "zi"
-  Reverse      r6, r5
-  // let result = []
-  Const        r7, []
+  Const        r1, "zi"
+  Reverse      r2, r1
   // json(result)
-  JSON         r7
+  JSON         r0
   // expect len(result) == 0
-  Const        r8, 0
-  Const        r9, 0
-  Const        r10, true
-  Expect       r10
+  Const        r3, 0
+  Const        r4, true
+  Expect       r4
   Return       r0

--- a/tests/dataset/tpc-ds/out/q9.ir.out
+++ b/tests/dataset/tpc-ds/out/q9.ir.out
@@ -1,695 +1,507 @@
-func main (regs=402)
+func main (regs=253)
   // let store_sales = []
   Const        r0, []
-  // let reason = []
+  // if count(from s in store_sales
   Const        r1, []
-  // if count(from s in store_sales
-  Const        r2, []
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Const        r3, "ss_quantity"
-  Const        r4, "ss_quantity"
+  Const        r2, "ss_quantity"
   // if count(from s in store_sales
-  IterPrep     r5, r0
-  Len          r6, r5
-  Const        r7, 0
+  IterPrep     r3, r0
+  Len          r4, r3
+  Const        r6, 0
+  Move         r5, r6
 L3:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
+  LessInt      r7, r5, r4
+  JumpIfFalse  r7, L0
+  Index        r9, r3, r5
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Const        r12, "ss_quantity"
-  Index        r13, r11, r12
-  Const        r14, 1
-  LessEq       r15, r14, r13
-  Const        r16, "ss_quantity"
-  Index        r17, r11, r16
-  Const        r18, 20
-  LessEq       r19, r17, r18
-  Move         r20, r15
-  JumpIfFalse  r20, L1
-  Move         r20, r19
+  Index        r10, r9, r2
+  Const        r11, 1
+  LessEq       r12, r11, r10
+  Index        r13, r9, r2
+  Const        r14, 20
+  LessEq       r15, r13, r14
+  JumpIfFalse  r12, L1
+  Move         r12, r15
 L1:
-  JumpIfFalse  r20, L2
+  JumpIfFalse  r12, L2
   // if count(from s in store_sales
-  Append       r2, r2, r11
+  Append       r1, r1, r9
 L2:
-  Const        r22, 1
-  AddInt       r7, r7, r22
+  AddInt       r5, r5, r11
   Jump         L3
 L0:
-  Count        r23, r2
+  Count        r17, r1
   // select s) > 10 {
-  Const        r24, 10
-  LessInt      r25, r24, r23
-  // if count(from s in store_sales
-  JumpIfFalse  r25, L4
+  Const        r18, 10
+  LessInt      r19, r18, r17
   // avg(from s in store_sales
-  Const        r26, []
-  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Const        r27, "ss_quantity"
-  Const        r28, "ss_quantity"
+  Const        r20, []
   // select s.ss_ext_discount_amt)
-  Const        r29, "ss_ext_discount_amt"
+  Const        r21, "ss_ext_discount_amt"
   // avg(from s in store_sales
-  IterPrep     r30, r0
-  Len          r31, r30
-  Const        r32, 0
-L8:
-  LessInt      r34, r32, r31
-  JumpIfFalse  r34, L5
-  Index        r11, r30, r32
-  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Const        r36, "ss_quantity"
-  Index        r37, r11, r36
-  Const        r38, 1
-  LessEq       r39, r38, r37
-  Const        r40, "ss_quantity"
-  Index        r41, r11, r40
-  Const        r42, 20
-  LessEq       r43, r41, r42
-  Move         r44, r39
-  JumpIfFalse  r44, L6
-  Move         r44, r43
-L6:
-  JumpIfFalse  r44, L7
-  // select s.ss_ext_discount_amt)
-  Const        r45, "ss_ext_discount_amt"
-  Index        r46, r11, r45
-  // avg(from s in store_sales
-  Append       r26, r26, r46
+  IterPrep     r22, r0
+  Len          r23, r22
+  Move         r24, r6
 L7:
-  Const        r48, 1
-  AddInt       r32, r32, r48
-  Jump         L8
+  LessInt      r25, r24, r23
+  JumpIfFalse  r25, L4
+  Index        r9, r22, r24
+  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
+  Index        r27, r9, r2
+  LessEq       r28, r11, r27
+  Index        r29, r9, r2
+  LessEq       r30, r29, r14
+  JumpIfFalse  r28, L5
+  Move         r28, r30
 L5:
-  Avg          r50, r26
-  // if count(from s in store_sales
-  Jump         L9
+  JumpIfFalse  r28, L6
+  // select s.ss_ext_discount_amt)
+  Index        r31, r9, r21
+  // avg(from s in store_sales
+  Append       r20, r20, r31
+L6:
+  AddInt       r24, r24, r11
+  Jump         L7
 L4:
+  Avg          r33, r20
   // avg(from s in store_sales
-  Const        r51, []
-  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Const        r52, "ss_quantity"
-  Const        r53, "ss_quantity"
+  Const        r34, []
   // select s.ss_net_paid)
-  Const        r54, "ss_net_paid"
+  Const        r35, "ss_net_paid"
   // avg(from s in store_sales
-  IterPrep     r55, r0
-  Len          r56, r55
-  Const        r57, 0
-L13:
-  LessInt      r59, r57, r56
-  JumpIfFalse  r59, L10
-  Index        r11, r55, r57
-  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Const        r61, "ss_quantity"
-  Index        r62, r11, r61
-  Const        r63, 1
-  LessEq       r64, r63, r62
-  Const        r65, "ss_quantity"
-  Index        r66, r11, r65
-  Const        r67, 20
-  LessEq       r68, r66, r67
-  Move         r69, r64
-  JumpIfFalse  r69, L11
-  Move         r69, r68
+  IterPrep     r36, r0
+  Len          r37, r36
+  Move         r38, r6
 L11:
-  JumpIfFalse  r69, L12
-  // select s.ss_net_paid)
-  Const        r70, "ss_net_paid"
-  Index        r71, r11, r70
-  // avg(from s in store_sales
-  Append       r51, r51, r71
-L12:
-  Const        r73, 1
-  AddInt       r57, r57, r73
-  Jump         L13
-L10:
-  Avg          r50, r51
+  LessInt      r39, r38, r37
+  JumpIfFalse  r39, L8
+  Index        r9, r36, r38
+  // where s.ss_quantity >= 1 && s.ss_quantity <= 20
+  Index        r41, r9, r2
+  LessEq       r42, r11, r41
+  Index        r43, r9, r2
+  LessEq       r44, r43, r14
+  JumpIfFalse  r42, L9
+  Move         r42, r44
 L9:
+  JumpIfFalse  r42, L10
+  // select s.ss_net_paid)
+  Index        r45, r9, r35
+  // avg(from s in store_sales
+  Append       r34, r34, r45
+L10:
+  AddInt       r38, r38, r11
+  Jump         L11
+L8:
+  Avg          r47, r34
   // if count(from s in store_sales
-  Const        r75, []
+  Select       48,19,33,47
+  // if count(from s in store_sales
+  Const        r49, []
+  IterPrep     r50, r0
+  Len          r51, r50
+  Move         r52, r6
+L15:
+  LessInt      r53, r52, r51
+  JumpIfFalse  r53, L12
+  Index        r9, r50, r52
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Const        r76, "ss_quantity"
-  Const        r77, "ss_quantity"
+  Index        r55, r9, r2
+  Const        r56, 21
+  LessEq       r57, r56, r55
+  Index        r58, r9, r2
+  Const        r59, 40
+  LessEq       r60, r58, r59
+  JumpIfFalse  r57, L13
+  Move         r57, r60
+L13:
+  JumpIfFalse  r57, L14
   // if count(from s in store_sales
+  Append       r49, r49, r9
+L14:
+  AddInt       r52, r52, r11
+  Jump         L15
+L12:
+  Count        r62, r49
+  // select s) > 20 {
+  LessInt      r63, r14, r62
+  // avg(from s in store_sales
+  Const        r64, []
+  IterPrep     r65, r0
+  Len          r66, r65
+  Move         r67, r6
+L19:
+  LessInt      r68, r67, r66
+  JumpIfFalse  r68, L16
+  Index        r9, r65, r67
+  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
+  Index        r70, r9, r2
+  LessEq       r71, r56, r70
+  Index        r72, r9, r2
+  LessEq       r73, r72, r59
+  JumpIfFalse  r71, L17
+  Move         r71, r73
+L17:
+  JumpIfFalse  r71, L18
+  // select s.ss_ext_discount_amt)
+  Index        r74, r9, r21
+  // avg(from s in store_sales
+  Append       r64, r64, r74
+L18:
+  AddInt       r67, r67, r11
+  Jump         L19
+L16:
+  Avg          r76, r64
+  // avg(from s in store_sales
+  Const        r77, []
   IterPrep     r78, r0
   Len          r79, r78
-  Const        r80, 0
-L17:
-  LessInt      r82, r80, r79
-  JumpIfFalse  r82, L14
-  Index        r11, r78, r80
+  Move         r80, r6
+L23:
+  LessInt      r81, r80, r79
+  JumpIfFalse  r81, L20
+  Index        r9, r78, r80
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Const        r84, "ss_quantity"
-  Index        r85, r11, r84
-  Const        r86, 21
-  LessEq       r87, r86, r85
-  Const        r88, "ss_quantity"
-  Index        r89, r11, r88
-  Const        r90, 40
-  LessEq       r91, r89, r90
-  Move         r92, r87
-  JumpIfFalse  r92, L15
-  Move         r92, r91
-L15:
-  JumpIfFalse  r92, L16
-  // if count(from s in store_sales
-  Append       r75, r75, r11
-L16:
-  Const        r94, 1
-  AddInt       r80, r80, r94
-  Jump         L17
-L14:
-  Count        r95, r75
-  // select s) > 20 {
-  Const        r96, 20
-  LessInt      r97, r96, r95
-  // if count(from s in store_sales
-  JumpIfFalse  r97, L18
-  // avg(from s in store_sales
-  Const        r98, []
-  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Const        r99, "ss_quantity"
-  Const        r100, "ss_quantity"
-  // select s.ss_ext_discount_amt)
-  Const        r101, "ss_ext_discount_amt"
-  // avg(from s in store_sales
-  IterPrep     r102, r0
-  Len          r103, r102
-  Const        r104, 0
-L22:
-  LessInt      r106, r104, r103
-  JumpIfFalse  r106, L19
-  Index        r11, r102, r104
-  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Const        r108, "ss_quantity"
-  Index        r109, r11, r108
-  Const        r110, 21
-  LessEq       r111, r110, r109
-  Const        r112, "ss_quantity"
-  Index        r113, r11, r112
-  Const        r114, 40
-  LessEq       r115, r113, r114
-  Move         r116, r111
-  JumpIfFalse  r116, L20
-  Move         r116, r115
-L20:
-  JumpIfFalse  r116, L21
-  // select s.ss_ext_discount_amt)
-  Const        r117, "ss_ext_discount_amt"
-  Index        r118, r11, r117
-  // avg(from s in store_sales
-  Append       r98, r98, r118
+  Index        r83, r9, r2
+  LessEq       r84, r56, r83
+  Index        r85, r9, r2
+  LessEq       r86, r85, r59
+  JumpIfFalse  r84, L21
+  Move         r84, r86
 L21:
-  Const        r120, 1
-  AddInt       r104, r104, r120
-  Jump         L22
-L19:
-  Avg          r122, r98
-  // if count(from s in store_sales
+  JumpIfFalse  r84, L22
+  // select s.ss_net_paid)
+  Index        r87, r9, r35
+  // avg(from s in store_sales
+  Append       r77, r77, r87
+L22:
+  AddInt       r80, r80, r11
   Jump         L23
-L18:
-  // avg(from s in store_sales
-  Const        r123, []
-  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Const        r124, "ss_quantity"
-  Const        r125, "ss_quantity"
-  // select s.ss_net_paid)
-  Const        r126, "ss_net_paid"
-  // avg(from s in store_sales
-  IterPrep     r127, r0
-  Len          r128, r127
-  Const        r129, 0
+L20:
+  Avg          r89, r77
+  // if count(from s in store_sales
+  Select       90,63,76,89
+  // if count(from s in store_sales
+  Const        r91, []
+  IterPrep     r92, r0
+  Len          r93, r92
+  Move         r94, r6
 L27:
-  LessInt      r131, r129, r128
-  JumpIfFalse  r131, L24
-  Index        r11, r127, r129
-  // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Const        r133, "ss_quantity"
-  Index        r134, r11, r133
-  Const        r135, 21
-  LessEq       r136, r135, r134
-  Const        r137, "ss_quantity"
-  Index        r138, r11, r137
-  Const        r139, 40
-  LessEq       r140, r138, r139
-  Move         r141, r136
-  JumpIfFalse  r141, L25
-  Move         r141, r140
+  LessInt      r95, r94, r93
+  JumpIfFalse  r95, L24
+  Index        r9, r92, r94
+  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
+  Index        r97, r9, r2
+  Const        r98, 41
+  LessEq       r99, r98, r97
+  Index        r100, r9, r2
+  Const        r101, 60
+  LessEq       r102, r100, r101
+  JumpIfFalse  r99, L25
+  Move         r99, r102
 L25:
-  JumpIfFalse  r141, L26
-  // select s.ss_net_paid)
-  Const        r142, "ss_net_paid"
-  Index        r143, r11, r142
-  // avg(from s in store_sales
-  Append       r123, r123, r143
+  JumpIfFalse  r99, L26
+  // if count(from s in store_sales
+  Append       r91, r91, r9
 L26:
-  Const        r145, 1
-  AddInt       r129, r129, r145
+  AddInt       r94, r94, r11
   Jump         L27
 L24:
-  Avg          r122, r123
-L23:
-  // if count(from s in store_sales
-  Const        r147, []
-  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Const        r148, "ss_quantity"
-  Const        r149, "ss_quantity"
-  // if count(from s in store_sales
-  IterPrep     r150, r0
-  Len          r151, r150
-  Const        r152, 0
+  Count        r104, r91
+  // select s) > 30 {
+  Const        r105, 30
+  LessInt      r106, r105, r104
+  // avg(from s in store_sales
+  Const        r107, []
+  IterPrep     r108, r0
+  Len          r109, r108
+  Move         r110, r6
 L31:
-  LessInt      r154, r152, r151
-  JumpIfFalse  r154, L28
-  Index        r11, r150, r152
+  LessInt      r111, r110, r109
+  JumpIfFalse  r111, L28
+  Index        r9, r108, r110
   // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Const        r156, "ss_quantity"
-  Index        r157, r11, r156
-  Const        r158, 41
-  LessEq       r159, r158, r157
-  Const        r160, "ss_quantity"
-  Index        r161, r11, r160
-  Const        r162, 60
-  LessEq       r163, r161, r162
-  Move         r164, r159
-  JumpIfFalse  r164, L29
-  Move         r164, r163
+  Index        r113, r9, r2
+  LessEq       r114, r98, r113
+  Index        r115, r9, r2
+  LessEq       r116, r115, r101
+  JumpIfFalse  r114, L29
+  Move         r114, r116
 L29:
-  JumpIfFalse  r164, L30
-  // if count(from s in store_sales
-  Append       r147, r147, r11
+  JumpIfFalse  r114, L30
+  // select s.ss_ext_discount_amt)
+  Index        r117, r9, r21
+  // avg(from s in store_sales
+  Append       r107, r107, r117
 L30:
-  Const        r166, 1
-  AddInt       r152, r152, r166
+  AddInt       r110, r110, r11
   Jump         L31
 L28:
-  Count        r167, r147
-  // select s) > 30 {
-  Const        r168, 30
-  LessInt      r169, r168, r167
-  // if count(from s in store_sales
-  JumpIfFalse  r169, L32
+  Avg          r119, r107
   // avg(from s in store_sales
-  Const        r170, []
-  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Const        r171, "ss_quantity"
-  Const        r172, "ss_quantity"
-  // select s.ss_ext_discount_amt)
-  Const        r173, "ss_ext_discount_amt"
-  // avg(from s in store_sales
-  IterPrep     r174, r0
-  Len          r175, r174
-  Const        r176, 0
-L36:
-  LessInt      r178, r176, r175
-  JumpIfFalse  r178, L33
-  Index        r11, r174, r176
-  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Const        r180, "ss_quantity"
-  Index        r181, r11, r180
-  Const        r182, 41
-  LessEq       r183, r182, r181
-  Const        r184, "ss_quantity"
-  Index        r185, r11, r184
-  Const        r186, 60
-  LessEq       r187, r185, r186
-  Move         r188, r183
-  JumpIfFalse  r188, L34
-  Move         r188, r187
-L34:
-  JumpIfFalse  r188, L35
-  // select s.ss_ext_discount_amt)
-  Const        r189, "ss_ext_discount_amt"
-  Index        r190, r11, r189
-  // avg(from s in store_sales
-  Append       r170, r170, r190
+  Const        r120, []
+  IterPrep     r121, r0
+  Len          r122, r121
+  Move         r123, r6
 L35:
-  Const        r192, 1
-  AddInt       r176, r176, r192
-  Jump         L36
+  LessInt      r124, r123, r122
+  JumpIfFalse  r124, L32
+  Index        r9, r121, r123
+  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
+  Index        r126, r9, r2
+  LessEq       r127, r98, r126
+  Index        r128, r9, r2
+  LessEq       r129, r128, r101
+  JumpIfFalse  r127, L33
+  Move         r127, r129
 L33:
-  Avg          r194, r170
-  // if count(from s in store_sales
-  Jump         L37
+  JumpIfFalse  r127, L34
+  // select s.ss_net_paid)
+  Index        r130, r9, r35
+  // avg(from s in store_sales
+  Append       r120, r120, r130
+L34:
+  AddInt       r123, r123, r11
+  Jump         L35
 L32:
-  // avg(from s in store_sales
-  Const        r195, []
-  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Const        r196, "ss_quantity"
-  Const        r197, "ss_quantity"
-  // select s.ss_net_paid)
-  Const        r198, "ss_net_paid"
-  // avg(from s in store_sales
-  IterPrep     r199, r0
-  Len          r200, r199
-  Const        r201, 0
-L41:
-  LessInt      r203, r201, r200
-  JumpIfFalse  r203, L38
-  Index        r11, r199, r201
-  // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Const        r205, "ss_quantity"
-  Index        r206, r11, r205
-  Const        r207, 41
-  LessEq       r208, r207, r206
-  Const        r209, "ss_quantity"
-  Index        r210, r11, r209
-  Const        r211, 60
-  LessEq       r212, r210, r211
-  Move         r213, r208
-  JumpIfFalse  r213, L39
-  Move         r213, r212
+  Avg          r132, r120
+  // if count(from s in store_sales
+  Select       133,106,119,132
+  // if count(from s in store_sales
+  Const        r134, []
+  IterPrep     r135, r0
+  Len          r136, r135
+  Move         r137, r6
 L39:
-  JumpIfFalse  r213, L40
-  // select s.ss_net_paid)
-  Const        r214, "ss_net_paid"
-  Index        r215, r11, r214
-  // avg(from s in store_sales
-  Append       r195, r195, r215
-L40:
-  Const        r217, 1
-  AddInt       r201, r201, r217
-  Jump         L41
-L38:
-  Avg          r194, r195
+  LessInt      r138, r137, r136
+  JumpIfFalse  r138, L36
+  Index        r9, r135, r137
+  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
+  Index        r140, r9, r2
+  Const        r141, 61
+  LessEq       r142, r141, r140
+  Index        r143, r9, r2
+  Const        r144, 80
+  LessEq       r145, r143, r144
+  JumpIfFalse  r142, L37
+  Move         r142, r145
 L37:
+  JumpIfFalse  r142, L38
   // if count(from s in store_sales
-  Const        r219, []
-  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Const        r220, "ss_quantity"
-  Const        r221, "ss_quantity"
-  // if count(from s in store_sales
-  IterPrep     r222, r0
-  Len          r223, r222
-  Const        r224, 0
-L45:
-  LessInt      r226, r224, r223
-  JumpIfFalse  r226, L42
-  Index        r11, r222, r224
-  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Const        r228, "ss_quantity"
-  Index        r229, r11, r228
-  Const        r230, 61
-  LessEq       r231, r230, r229
-  Const        r232, "ss_quantity"
-  Index        r233, r11, r232
-  Const        r234, 80
-  LessEq       r235, r233, r234
-  Move         r236, r231
-  JumpIfFalse  r236, L43
-  Move         r236, r235
-L43:
-  JumpIfFalse  r236, L44
-  // if count(from s in store_sales
-  Append       r219, r219, r11
-L44:
-  Const        r238, 1
-  AddInt       r224, r224, r238
-  Jump         L45
-L42:
-  Count        r239, r219
+  Append       r134, r134, r9
+L38:
+  AddInt       r137, r137, r11
+  Jump         L39
+L36:
+  Count        r147, r134
   // select s) > 40 {
-  Const        r240, 40
-  LessInt      r241, r240, r239
-  // if count(from s in store_sales
-  JumpIfFalse  r241, L46
+  LessInt      r148, r59, r147
   // avg(from s in store_sales
-  Const        r242, []
+  Const        r149, []
+  IterPrep     r150, r0
+  Len          r151, r150
+  Move         r152, r6
+L43:
+  LessInt      r153, r152, r151
+  JumpIfFalse  r153, L40
+  Index        r9, r150, r152
   // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Const        r243, "ss_quantity"
-  Const        r244, "ss_quantity"
+  Index        r155, r9, r2
+  LessEq       r156, r141, r155
+  Index        r157, r9, r2
+  LessEq       r158, r157, r144
+  JumpIfFalse  r156, L41
+  Move         r156, r158
+L41:
+  JumpIfFalse  r156, L42
   // select s.ss_ext_discount_amt)
-  Const        r245, "ss_ext_discount_amt"
+  Index        r159, r9, r21
   // avg(from s in store_sales
-  IterPrep     r246, r0
-  Len          r247, r246
-  Const        r248, 0
-L50:
-  LessInt      r250, r248, r247
-  JumpIfFalse  r250, L47
-  Index        r11, r246, r248
-  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Const        r252, "ss_quantity"
-  Index        r253, r11, r252
-  Const        r254, 61
-  LessEq       r255, r254, r253
-  Const        r256, "ss_quantity"
-  Index        r257, r11, r256
-  Const        r258, 80
-  LessEq       r259, r257, r258
-  Move         r260, r255
-  JumpIfFalse  r260, L48
-  Move         r260, r259
-L48:
-  JumpIfFalse  r260, L49
-  // select s.ss_ext_discount_amt)
-  Const        r261, "ss_ext_discount_amt"
-  Index        r262, r11, r261
+  Append       r149, r149, r159
+L42:
+  AddInt       r152, r152, r11
+  Jump         L43
+L40:
+  Avg          r161, r149
   // avg(from s in store_sales
-  Append       r242, r242, r262
-L49:
-  Const        r264, 1
-  AddInt       r248, r248, r264
-  Jump         L50
+  Const        r162, []
+  IterPrep     r163, r0
+  Len          r164, r163
+  Move         r165, r6
 L47:
-  Avg          r266, r242
-  // if count(from s in store_sales
-  Jump         L51
+  LessInt      r166, r165, r164
+  JumpIfFalse  r166, L44
+  Index        r9, r163, r165
+  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
+  Index        r168, r9, r2
+  LessEq       r169, r141, r168
+  Index        r170, r9, r2
+  LessEq       r171, r170, r144
+  JumpIfFalse  r169, L45
+  Move         r169, r171
+L45:
+  JumpIfFalse  r169, L46
+  // select s.ss_net_paid)
+  Index        r172, r9, r35
+  // avg(from s in store_sales
+  Append       r162, r162, r172
 L46:
+  AddInt       r165, r165, r11
+  Jump         L47
+L44:
+  Avg          r174, r162
+  // if count(from s in store_sales
+  Select       175,148,161,174
+  // if count(from s in store_sales
+  Const        r176, []
+  IterPrep     r177, r0
+  Len          r178, r177
+  Move         r179, r6
+L51:
+  LessInt      r180, r179, r178
+  JumpIfFalse  r180, L48
+  Index        r9, r177, r179
+  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
+  Index        r182, r9, r2
+  Const        r183, 81
+  LessEq       r184, r183, r182
+  Index        r185, r9, r2
+  Const        r186, 100
+  LessEq       r187, r185, r186
+  JumpIfFalse  r184, L49
+  Move         r184, r187
+L49:
+  JumpIfFalse  r184, L50
+  // if count(from s in store_sales
+  Append       r176, r176, r9
+L50:
+  AddInt       r179, r179, r11
+  Jump         L51
+L48:
+  Count        r189, r176
+  // select s) > 50 {
+  Const        r190, 50
+  LessInt      r191, r190, r189
   // avg(from s in store_sales
-  Const        r267, []
-  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Const        r268, "ss_quantity"
-  Const        r269, "ss_quantity"
-  // select s.ss_net_paid)
-  Const        r270, "ss_net_paid"
-  // avg(from s in store_sales
-  IterPrep     r271, r0
-  Len          r272, r271
-  Const        r273, 0
+  Const        r192, []
+  IterPrep     r193, r0
+  Len          r194, r193
+  Move         r195, r6
 L55:
-  LessInt      r275, r273, r272
-  JumpIfFalse  r275, L52
-  Index        r11, r271, r273
-  // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Const        r277, "ss_quantity"
-  Index        r278, r11, r277
-  Const        r279, 61
-  LessEq       r280, r279, r278
-  Const        r281, "ss_quantity"
-  Index        r282, r11, r281
-  Const        r283, 80
-  LessEq       r284, r282, r283
-  Move         r285, r280
-  JumpIfFalse  r285, L53
-  Move         r285, r284
+  LessInt      r196, r195, r194
+  JumpIfFalse  r196, L52
+  Index        r9, r193, r195
+  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
+  Index        r198, r9, r2
+  LessEq       r199, r183, r198
+  Index        r200, r9, r2
+  LessEq       r201, r200, r186
+  JumpIfFalse  r199, L53
+  Move         r199, r201
 L53:
-  JumpIfFalse  r285, L54
-  // select s.ss_net_paid)
-  Const        r286, "ss_net_paid"
-  Index        r287, r11, r286
+  JumpIfFalse  r199, L54
+  // select s.ss_ext_discount_amt)
+  Index        r202, r9, r21
   // avg(from s in store_sales
-  Append       r267, r267, r287
+  Append       r192, r192, r202
 L54:
-  Const        r289, 1
-  AddInt       r273, r273, r289
+  AddInt       r195, r195, r11
   Jump         L55
 L52:
-  Avg          r266, r267
-L51:
-  // if count(from s in store_sales
-  Const        r291, []
-  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Const        r292, "ss_quantity"
-  Const        r293, "ss_quantity"
-  // if count(from s in store_sales
-  IterPrep     r294, r0
-  Len          r295, r294
-  Const        r296, 0
+  Avg          r204, r192
+  // avg(from s in store_sales
+  Const        r205, []
+  IterPrep     r206, r0
+  Len          r207, r206
+  Move         r208, r6
 L59:
-  LessInt      r298, r296, r295
-  JumpIfFalse  r298, L56
-  Index        r11, r294, r296
+  LessInt      r209, r208, r207
+  JumpIfFalse  r209, L56
+  Index        r9, r206, r208
   // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Const        r300, "ss_quantity"
-  Index        r301, r11, r300
-  Const        r302, 81
-  LessEq       r303, r302, r301
-  Const        r304, "ss_quantity"
-  Index        r305, r11, r304
-  Const        r306, 100
-  LessEq       r307, r305, r306
-  Move         r308, r303
-  JumpIfFalse  r308, L57
-  Move         r308, r307
+  Index        r211, r9, r2
+  LessEq       r212, r183, r211
+  Index        r213, r9, r2
+  LessEq       r214, r213, r186
+  JumpIfFalse  r212, L57
+  Move         r212, r214
 L57:
-  JumpIfFalse  r308, L58
-  // if count(from s in store_sales
-  Append       r291, r291, r11
+  JumpIfFalse  r212, L58
+  // select s.ss_net_paid)
+  Index        r215, r9, r35
+  // avg(from s in store_sales
+  Append       r205, r205, r215
 L58:
-  Const        r310, 1
-  AddInt       r296, r296, r310
+  AddInt       r208, r208, r11
   Jump         L59
 L56:
-  Count        r311, r291
-  // select s) > 50 {
-  Const        r312, 50
-  LessInt      r313, r312, r311
+  Avg          r217, r205
   // if count(from s in store_sales
-  JumpIfFalse  r313, L60
-  // avg(from s in store_sales
-  Const        r314, []
-  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Const        r315, "ss_quantity"
-  Const        r316, "ss_quantity"
-  // select s.ss_ext_discount_amt)
-  Const        r317, "ss_ext_discount_amt"
-  // avg(from s in store_sales
-  IterPrep     r318, r0
-  Len          r319, r318
-  Const        r320, 0
-L64:
-  LessInt      r322, r320, r319
-  JumpIfFalse  r322, L61
-  Index        r11, r318, r320
-  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Const        r324, "ss_quantity"
-  Index        r325, r11, r324
-  Const        r326, 81
-  LessEq       r327, r326, r325
-  Const        r328, "ss_quantity"
-  Index        r329, r11, r328
-  Const        r330, 100
-  LessEq       r331, r329, r330
-  Move         r332, r327
-  JumpIfFalse  r332, L62
-  Move         r332, r331
+  Select       218,191,204,217
+  // from r in reason
+  Const        r219, []
+  // where r.r_reason_sk == 1
+  Const        r220, "r_reason_sk"
+  // bucket1: bucket1,
+  Const        r221, "bucket1"
+  // bucket2: bucket2,
+  Const        r222, "bucket2"
+  // bucket3: bucket3,
+  Const        r223, "bucket3"
+  // bucket4: bucket4,
+  Const        r224, "bucket4"
+  // bucket5: bucket5
+  Const        r225, "bucket5"
+  // from r in reason
+  IterPrep     r226, r0
+  Len          r227, r226
+  Move         r228, r6
 L62:
-  JumpIfFalse  r332, L63
-  // select s.ss_ext_discount_amt)
-  Const        r333, "ss_ext_discount_amt"
-  Index        r334, r11, r333
-  // avg(from s in store_sales
-  Append       r314, r314, r334
-L63:
-  Const        r336, 1
-  AddInt       r320, r320, r336
-  Jump         L64
-L61:
-  Avg          r338, r314
-  // if count(from s in store_sales
-  Jump         L65
-L60:
-  // avg(from s in store_sales
-  Const        r339, []
-  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Const        r340, "ss_quantity"
-  Const        r341, "ss_quantity"
-  // select s.ss_net_paid)
-  Const        r342, "ss_net_paid"
-  // avg(from s in store_sales
-  IterPrep     r343, r0
-  Len          r344, r343
-  Const        r345, 0
-L69:
-  LessInt      r347, r345, r344
-  JumpIfFalse  r347, L66
-  Index        r11, r343, r345
-  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Const        r349, "ss_quantity"
-  Index        r350, r11, r349
-  Const        r351, 81
-  LessEq       r352, r351, r350
-  Const        r353, "ss_quantity"
-  Index        r354, r11, r353
-  Const        r355, 100
-  LessEq       r356, r354, r355
-  Move         r357, r352
-  JumpIfFalse  r357, L67
-  Move         r357, r356
-L67:
-  JumpIfFalse  r357, L68
-  // select s.ss_net_paid)
-  Const        r358, "ss_net_paid"
-  Index        r359, r11, r358
-  // avg(from s in store_sales
-  Append       r339, r339, r359
-L68:
-  Const        r361, 1
-  AddInt       r345, r345, r361
-  Jump         L69
-L66:
-  Avg          r338, r339
-L65:
-  // from r in reason
-  Const        r363, []
+  LessInt      r229, r228, r227
+  JumpIfFalse  r229, L60
+  Index        r231, r226, r228
   // where r.r_reason_sk == 1
-  Const        r364, "r_reason_sk"
+  Index        r232, r231, r220
+  Equal        r233, r232, r11
+  JumpIfFalse  r233, L61
   // bucket1: bucket1,
-  Const        r365, "bucket1"
+  Const        r234, "bucket1"
   // bucket2: bucket2,
-  Const        r366, "bucket2"
+  Const        r235, "bucket2"
   // bucket3: bucket3,
-  Const        r367, "bucket3"
+  Const        r236, "bucket3"
   // bucket4: bucket4,
-  Const        r368, "bucket4"
+  Const        r237, "bucket4"
   // bucket5: bucket5
-  Const        r369, "bucket5"
-  // from r in reason
-  IterPrep     r370, r1
-  Len          r371, r370
-  Const        r372, 0
-L72:
-  LessInt      r374, r372, r371
-  JumpIfFalse  r374, L70
-  Index        r376, r370, r372
-  // where r.r_reason_sk == 1
-  Const        r377, "r_reason_sk"
-  Index        r378, r376, r377
-  Const        r379, 1
-  Equal        r380, r378, r379
-  JumpIfFalse  r380, L71
+  Const        r238, "bucket5"
   // bucket1: bucket1,
-  Const        r381, "bucket1"
+  Move         r239, r234
+  Move         r240, r48
   // bucket2: bucket2,
-  Const        r382, "bucket2"
+  Move         r241, r235
+  Move         r242, r90
   // bucket3: bucket3,
-  Const        r383, "bucket3"
+  Move         r243, r236
+  Move         r244, r133
   // bucket4: bucket4,
-  Const        r384, "bucket4"
+  Move         r245, r237
+  Move         r246, r175
   // bucket5: bucket5
-  Const        r385, "bucket5"
-  // bucket1: bucket1,
-  Move         r386, r381
-  Move         r387, r50
-  // bucket2: bucket2,
-  Move         r388, r382
-  Move         r389, r122
-  // bucket3: bucket3,
-  Move         r390, r383
-  Move         r391, r194
-  // bucket4: bucket4,
-  Move         r392, r384
-  Move         r393, r266
-  // bucket5: bucket5
-  Move         r394, r385
-  Move         r395, r338
+  Move         r247, r238
+  Move         r248, r218
   // select {
-  MakeMap      r396, 5, r386
+  MakeMap      r249, 5, r239
   // from r in reason
-  Append       r363, r363, r396
-L71:
-  Const        r398, 1
-  AddInt       r372, r372, r398
-  Jump         L72
-L70:
+  Append       r219, r219, r249
+L61:
+  AddInt       r228, r228, r11
+  Jump         L62
+L60:
   // json(result)
-  JSON         r363
+  JSON         r219
   // expect len(result) == 0
-  Len          r399, r363
-  Const        r400, 0
-  EqualInt     r401, r399, r400
-  Expect       r401
+  Len          r251, r219
+  EqualInt     r252, r251, r6
+  Expect       r252
   Return       r0


### PR DESCRIPTION
## Summary
- optimize `union_all` to preallocate slice space
- regenerate tpc-ds IR golden files (q1–q9)

## Testing
- `for i in {1..9}; do go test -tags slow ./tests/vm -run "TestVM_TPCDS/q${i}.mochi"; done`


------
https://chatgpt.com/codex/tasks/task_e_6862a1c8adbc8320b2d18bdb50694436