### PR TITLE
Update VM const reuse and refresh TPC‑DS IR

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -5136,17 +5136,17 @@ func (fc *funcCompiler) compileGroupAccum(q *parser.QueryExpr, elemReg, varReg, 
 	jump := len(fc.fn.Code)
 	fc.emit(q.Group.Pos, Instr{Op: OpJumpIfTrue, A: exists})
 
-	items := fc.freshConst(q.Pos, Value{Tag: ValueList, List: []Value{}})
-	k1 := fc.freshConst(q.Pos, Value{Tag: ValueStr, Str: "__group__"})
-	v1 := fc.freshConst(q.Pos, Value{Tag: ValueBool, Bool: true})
-	k2 := fc.freshConst(q.Pos, Value{Tag: ValueStr, Str: "key"})
+	items := fc.constReg(q.Pos, Value{Tag: ValueList, List: []Value{}})
+	k1 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "__group__"})
+	v1 := fc.constReg(q.Pos, Value{Tag: ValueBool, Bool: true})
+	k2 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "key"})
 	v2 := fc.newReg()
 	fc.emit(q.Group.Pos, Instr{Op: OpMove, A: v2, B: key})
-	k3 := fc.freshConst(q.Pos, Value{Tag: ValueStr, Str: "items"})
+	k3 := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "items"})
 	v3 := fc.newReg()
 	fc.emit(q.Pos, Instr{Op: OpMove, A: v3, B: items})
-	kcnt := fc.freshConst(q.Pos, Value{Tag: ValueStr, Str: "count"})
-	vcnt := fc.freshConst(q.Pos, Value{Tag: ValueInt, Int: 0})
+	kcnt := fc.constReg(q.Pos, Value{Tag: ValueStr, Str: "count"})
+	vcnt := fc.constReg(q.Pos, Value{Tag: ValueInt, Int: 0})
 	pairsGrp := []int{k1, v1, k2, v2, k3, v3, kcnt, vcnt}
 	if len(fieldNames) > 0 {
 		for i, name := range fieldNames {

--- a/tests/dataset/tpc-ds/out/q60.ir.out
+++ b/tests/dataset/tpc-ds/out/q60.ir.out
@@ -1,4 +1,4 @@
-func main (regs=21)
+func main (regs=20)
   // let store_sales = [
   Const        r0, [{"item": 1, "price": 10}, {"item": 1, "price": 20}]
   // let catalog_sales = [
@@ -18,18 +18,17 @@ L1:
   LessInt      r11, r9, r8
   JumpIfFalse  r11, L0
   Index        r13, r7, r9
-  Const        r14, "price"
-  Index        r15, r13, r14
-  Append       r5, r5, r15
-  Const        r17, 1
-  AddInt       r9, r9, r17
+  Index        r14, r13, r6
+  Append       r5, r5, r14
+  Const        r16, 1
+  AddInt       r9, r9, r16
   Jump         L1
 L0:
-  Sum          r18, r5
+  Sum          r17, r5
   // json(result)
-  JSON         r18
+  JSON         r17
   // expect result == 60
-  Const        r19, 60
-  Equal        r20, r18, r19
-  Expect       r20
+  Const        r18, 60
+  Equal        r19, r17, r18
+  Expect       r19
   Return       r0

--- a/tests/dataset/tpc-ds/out/q61.ir.out
+++ b/tests/dataset/tpc-ds/out/q61.ir.out
@@ -1,4 +1,4 @@
-func main (regs=36)
+func main (regs=30)
   // let sales = [
   Const        r0, [{"price": 20, "promo": true}, {"price": 41, "promo": true}, {"price": 39, "promo": false}]
   // let promotions = sum(from s in sales where s.promo select s.price)
@@ -7,49 +7,45 @@ func main (regs=36)
   Const        r3, "price"
   IterPrep     r4, r0
   Len          r5, r4
-  Const        r6, 0
+  Const        r7, 0
+  Move         r6, r7
 L2:
   LessInt      r8, r6, r5
   JumpIfFalse  r8, L0
   Index        r10, r4, r6
-  Const        r11, "promo"
-  Index        r12, r10, r11
-  JumpIfFalse  r12, L1
-  Const        r13, "price"
-  Index        r14, r10, r13
-  Append       r1, r1, r14
+  Index        r11, r10, r2
+  JumpIfFalse  r11, L1
+  Index        r12, r10, r3
+  Append       r1, r1, r12
 L1:
-  Const        r16, 1
-  AddInt       r6, r6, r16
+  Const        r14, 1
+  AddInt       r6, r6, r14
   Jump         L2
 L0:
-  Sum          r17, r1
+  Sum          r15, r1
   // let total = sum(from s in sales select s.price)
-  Const        r18, []
-  Const        r19, "price"
-  IterPrep     r20, r0
-  Len          r21, r20
-  Const        r22, 0
+  Const        r16, []
+  IterPrep     r17, r0
+  Len          r18, r17
+  Move         r19, r7
 L4:
-  LessInt      r24, r22, r21
-  JumpIfFalse  r24, L3
-  Index        r10, r20, r22
-  Const        r26, "price"
-  Index        r27, r10, r26
-  Append       r18, r18, r27
-  Const        r29, 1
-  AddInt       r22, r22, r29
+  LessInt      r20, r19, r18
+  JumpIfFalse  r20, L3
+  Index        r10, r17, r19
+  Index        r22, r10, r3
+  Append       r16, r16, r22
+  AddInt       r19, r19, r14
   Jump         L4
 L3:
-  Sum          r30, r18
+  Sum          r24, r16
   // let result = promotions * 100 / total
-  Const        r31, 100
-  Mul          r32, r17, r31
-  Div          r33, r32, r30
+  Const        r25, 100
+  Mul          r26, r15, r25
+  Div          r27, r26, r24
   // json(result)
-  JSON         r33
+  JSON         r27
   // expect result == 61
-  Const        r34, 61
-  Equal        r35, r33, r34
-  Expect       r35
+  Const        r28, 61
+  Equal        r29, r27, r28
+  Expect       r29
   Return       r0

--- a/tests/dataset/tpc-ds/out/q63.ir.out
+++ b/tests/dataset/tpc-ds/out/q63.ir.out
@@ -1,139 +1,122 @@
-func main (regs=102)
+func main (regs=82)
   // let sales = [
   Const        r0, [{"amount": 30, "mgr": 1}, {"amount": 33, "mgr": 2}]
   // from s in sales
   Const        r1, []
   // group by {mgr: s.mgr} into g
   Const        r2, "mgr"
-  Const        r3, "mgr"
   // select {mgr: g.key.mgr, sum_sales: sum(from x in g select x.amount)}
-  Const        r4, "mgr"
-  Const        r5, "key"
-  Const        r6, "mgr"
-  Const        r7, "sum_sales"
-  Const        r8, "amount"
+  Const        r3, "key"
+  Const        r4, "sum_sales"
+  Const        r5, "amount"
   // from s in sales
-  IterPrep     r9, r0
-  Len          r10, r9
-  Const        r11, 0
-  MakeMap      r12, 0, r0
-  Const        r13, []
+  IterPrep     r6, r0
+  Len          r7, r6
+  Const        r8, 0
+  MakeMap      r9, 0, r0
+  Const        r10, []
 L2:
-  LessInt      r15, r11, r10
-  JumpIfFalse  r15, L0
-  Index        r16, r9, r11
-  Move         r17, r16
+  LessInt      r12, r8, r7
+  JumpIfFalse  r12, L0
+  Index        r13, r6, r8
+  Move         r14, r13
   // group by {mgr: s.mgr} into g
-  Const        r18, "mgr"
-  Const        r19, "mgr"
-  Index        r20, r17, r19
-  Move         r21, r18
-  Move         r22, r20
-  MakeMap      r23, 1, r21
-  Str          r24, r23
-  In           r25, r24, r12
-  JumpIfTrue   r25, L1
+  Const        r15, "mgr"
+  Index        r16, r14, r2
+  Move         r17, r15
+  Move         r18, r16
+  MakeMap      r19, 1, r17
+  Str          r20, r19
+  In           r21, r20, r9
+  JumpIfTrue   r21, L1
   // from s in sales
-  Const        r26, []
-  Const        r27, "__group__"
-  Const        r28, true
-  Const        r29, "key"
+  Const        r22, []
+  Const        r23, "__group__"
+  Const        r24, true
   // group by {mgr: s.mgr} into g
+  Move         r25, r19
+  // from s in sales
+  Const        r26, "items"
+  Move         r27, r22
+  Const        r28, "count"
+  Const        r29, 0
   Move         r30, r23
-  // from s in sales
-  Const        r31, "items"
-  Move         r32, r26
-  Const        r33, "count"
-  Const        r34, 0
+  Move         r31, r24
+  Move         r32, r3
+  Move         r33, r25
+  Move         r34, r26
   Move         r35, r27
   Move         r36, r28
   Move         r37, r29
-  Move         r38, r30
-  Move         r39, r31
-  Move         r40, r32
-  Move         r41, r33
-  Move         r42, r34
-  MakeMap      r43, 4, r35
-  SetIndex     r12, r24, r43
-  Append       r13, r13, r43
+  MakeMap      r38, 4, r30
+  SetIndex     r9, r20, r38
+  Append       r10, r10, r38
 L1:
-  Const        r45, "items"
-  Index        r46, r12, r24
-  Index        r47, r46, r45
-  Append       r48, r47, r16
-  SetIndex     r46, r45, r48
-  Const        r49, "count"
-  Index        r50, r46, r49
-  Const        r51, 1
-  AddInt       r52, r50, r51
-  SetIndex     r46, r49, r52
-  Const        r53, 1
-  AddInt       r11, r11, r53
+  Index        r40, r9, r20
+  Index        r41, r40, r26
+  Append       r42, r41, r13
+  SetIndex     r40, r26, r42
+  Index        r43, r40, r28
+  Const        r44, 1
+  AddInt       r45, r43, r44
+  SetIndex     r40, r28, r45
+  AddInt       r8, r8, r44
   Jump         L2
 L0:
-  Const        r54, 0
-  Len          r56, r13
+  Move         r46, r29
+  Len          r47, r10
 L6:
-  LessInt      r57, r54, r56
-  JumpIfFalse  r57, L3
-  Index        r59, r13, r54
+  LessInt      r48, r46, r47
+  JumpIfFalse  r48, L3
+  Index        r50, r10, r46
   // select {mgr: g.key.mgr, sum_sales: sum(from x in g select x.amount)}
-  Const        r60, "mgr"
-  Const        r61, "key"
-  Index        r62, r59, r61
-  Const        r63, "mgr"
-  Index        r64, r62, r63
-  Const        r65, "sum_sales"
-  Const        r66, []
-  Const        r67, "amount"
-  IterPrep     r68, r59
-  Len          r69, r68
-  Const        r70, 0
+  Const        r51, "mgr"
+  Index        r52, r50, r3
+  Index        r53, r52, r2
+  Const        r54, "sum_sales"
+  Const        r55, []
+  IterPrep     r56, r50
+  Len          r57, r56
+  Move         r58, r29
 L5:
-  LessInt      r72, r70, r69
-  JumpIfFalse  r72, L4
-  Index        r74, r68, r70
-  Const        r75, "amount"
-  Index        r76, r74, r75
-  Append       r66, r66, r76
-  Const        r78, 1
-  AddInt       r70, r70, r78
+  LessInt      r59, r58, r57
+  JumpIfFalse  r59, L4
+  Index        r61, r56, r58
+  Index        r62, r61, r5
+  Append       r55, r55, r62
+  AddInt       r58, r58, r44
   Jump         L5
 L4:
-  Sum          r79, r66
-  Move         r80, r60
-  Move         r81, r64
-  Move         r82, r65
-  Move         r83, r79
-  MakeMap      r84, 2, r80
+  Sum          r64, r55
+  Move         r65, r51
+  Move         r66, r53
+  Move         r67, r54
+  Move         r68, r64
+  MakeMap      r69, 2, r65
   // from s in sales
-  Append       r1, r1, r84
-  Const        r86, 1
-  AddInt       r54, r54, r86
+  Append       r1, r1, r69
+  AddInt       r46, r46, r44
   Jump         L6
 L3:
   // let result = sum(from x in by_mgr select x.sum_sales)
-  Const        r87, []
-  Const        r88, "sum_sales"
-  IterPrep     r89, r1
-  Len          r90, r89
-  Const        r91, 0
+  Const        r71, []
+  IterPrep     r72, r1
+  Len          r73, r72
+  Move         r74, r29
 L8:
-  LessInt      r93, r91, r90
-  JumpIfFalse  r93, L7
-  Index        r74, r89, r91
-  Const        r95, "sum_sales"
-  Index        r96, r74, r95
-  Append       r87, r87, r96
-  Const        r98, 1
-  AddInt       r91, r91, r98
+  LessInt      r75, r74, r73
+  JumpIfFalse  r75, L7
+  Index        r61, r72, r74
+  Index        r77, r61, r4
+  Append       r71, r71, r77
+  AddInt       r74, r74, r44
   Jump         L8
 L7:
-  Sum          r99, r87
+  Sum          r79, r71
   // json(result)
-  JSON         r99
+  JSON         r79
   // expect result == 63
-  Const        r100, 63
-  Equal        r101, r99, r100
-  Expect       r101
+  Const        r80, 63
+  Equal        r81, r79, r80
+  Expect       r81
   Return       r0

--- a/tests/dataset/tpc-ds/out/q64.ir.out
+++ b/tests/dataset/tpc-ds/out/q64.ir.out
@@ -12,9 +12,9 @@ func main (regs=11)
   Const        r7, 19
   Const        r8, 64
   // json(result)
-  JSON         r8
-  // expect result == 64
   Const        r9, 64
+  JSON         r9
+  // expect result == 64
   Const        r10, true
   Expect       r10
   Return       r0

--- a/tests/dataset/tpc-ds/out/q65.ir.out
+++ b/tests/dataset/tpc-ds/out/q65.ir.out
@@ -1,4 +1,4 @@
-func main (regs=4)
+func main (regs=3)
   // let store_sales = [
   Const        r0, [{"item": 1, "price": 1, "store": 1}, {"item": 1, "price": 1, "store": 1}, {"item": 2, "price": 60, "store": 1}]
   // let result = 65
@@ -6,7 +6,6 @@ func main (regs=4)
   // json(result)
   JSON         r1
   // expect result == 65
-  Const        r2, 65
-  Const        r3, true
-  Expect       r3
+  Const        r2, true
+  Expect       r2
   Return       r0

--- a/tests/dataset/tpc-ds/out/q66.ir.out
+++ b/tests/dataset/tpc-ds/out/q66.ir.out
@@ -1,4 +1,4 @@
-func main (regs=33)
+func main (regs=28)
   // let web_sales = [
   Const        r0, [{"net": 30}]
   // let catalog_sales = [
@@ -8,41 +8,38 @@ func main (regs=33)
   Const        r3, "net"
   IterPrep     r4, r0
   Len          r5, r4
-  Const        r6, 0
+  Const        r7, 0
+  Move         r6, r7
 L1:
   LessInt      r8, r6, r5
   JumpIfFalse  r8, L0
   Index        r10, r4, r6
-  Const        r11, "net"
-  Index        r12, r10, r11
-  Append       r2, r2, r12
-  Const        r14, 1
-  AddInt       r6, r6, r14
+  Index        r11, r10, r3
+  Append       r2, r2, r11
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
-  Sum          r15, r2
-  Const        r16, []
-  Const        r17, "net"
-  IterPrep     r18, r1
-  Len          r19, r18
-  Const        r20, 0
+  Sum          r14, r2
+  Const        r15, []
+  IterPrep     r16, r1
+  Len          r17, r16
+  Move         r18, r7
 L3:
-  LessInt      r22, r20, r19
-  JumpIfFalse  r22, L2
-  Index        r24, r18, r20
-  Const        r25, "net"
-  Index        r26, r24, r25
-  Append       r16, r16, r26
-  Const        r28, 1
-  AddInt       r20, r20, r28
+  LessInt      r19, r18, r17
+  JumpIfFalse  r19, L2
+  Index        r21, r16, r18
+  Index        r22, r21, r3
+  Append       r15, r15, r22
+  AddInt       r18, r18, r13
   Jump         L3
 L2:
-  Sum          r29, r16
-  Add          r30, r15, r29
+  Sum          r24, r15
+  Add          r25, r14, r24
   // json(result)
-  JSON         r30
+  JSON         r25
   // expect result == 66
-  Const        r31, 66
-  Equal        r32, r30, r31
-  Expect       r32
+  Const        r26, 66
+  Equal        r27, r25, r26
+  Expect       r27
   Return       r0

--- a/tests/dataset/tpc-ds/out/q67.ir.out
+++ b/tests/dataset/tpc-ds/out/q67.ir.out
@@ -1,4 +1,4 @@
-func main (regs=5)
+func main (regs=4)
   // let store_sales = [
   Const        r0, [{"price": 40, "reason": 1}, {"price": 27, "reason": 2}]
   // let reason = [
@@ -8,7 +8,6 @@ func main (regs=5)
   // json(result)
   JSON         r2
   // expect result == 67
-  Const        r3, 67
-  Const        r4, true
-  Expect       r4
+  Const        r3, true
+  Expect       r3
   Return       r0

--- a/tests/dataset/tpc-ds/out/q68.ir.out
+++ b/tests/dataset/tpc-ds/out/q68.ir.out
@@ -1,4 +1,4 @@
-func main (regs=35)
+func main (regs=30)
   // let catalog_sales = [
   Const        r0, [{"item": 1, "profit": 30}, {"item": 2, "profit": 38}]
   // let store_sales = [
@@ -8,43 +8,40 @@ func main (regs=35)
   Const        r3, "profit"
   IterPrep     r4, r0
   Len          r5, r4
-  Const        r6, 0
+  Const        r7, 0
+  Move         r6, r7
 L1:
   LessInt      r8, r6, r5
   JumpIfFalse  r8, L0
   Index        r10, r4, r6
-  Const        r11, "profit"
-  Index        r12, r10, r11
-  Append       r2, r2, r12
-  Const        r14, 1
-  AddInt       r6, r6, r14
+  Index        r11, r10, r3
+  Append       r2, r2, r11
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
-  Sum          r15, r2
-  Const        r16, []
-  Const        r17, "profit"
-  IterPrep     r18, r1
-  Len          r19, r18
-  Const        r20, 0
+  Sum          r14, r2
+  Const        r15, []
+  IterPrep     r16, r1
+  Len          r17, r16
+  Move         r18, r7
 L3:
-  LessInt      r22, r20, r19
-  JumpIfFalse  r22, L2
-  Index        r24, r18, r20
-  Const        r25, "profit"
-  Index        r26, r24, r25
-  Append       r16, r16, r26
-  Const        r28, 1
-  AddInt       r20, r20, r28
+  LessInt      r19, r18, r17
+  JumpIfFalse  r19, L2
+  Index        r21, r16, r18
+  Index        r22, r21, r3
+  Append       r15, r15, r22
+  AddInt       r18, r18, r13
   Jump         L3
 L2:
-  Sum          r29, r16
-  Sub          r30, r15, r29
-  Const        r31, 30
-  Add          r32, r30, r31
+  Sum          r24, r15
+  Sub          r25, r14, r24
+  Const        r26, 30
+  Add          r27, r25, r26
   // json(result)
-  JSON         r32
+  JSON         r27
   // expect result == 68
-  Const        r33, 68
-  Equal        r34, r32, r33
-  Expect       r34
+  Const        r28, 68
+  Equal        r29, r27, r28
+  Expect       r29
   Return       r0

--- a/tests/dataset/tpc-ds/out/q69.ir.out
+++ b/tests/dataset/tpc-ds/out/q69.ir.out
@@ -1,4 +1,4 @@
-func main (regs=33)
+func main (regs=28)
   // let web_sales = [
   Const        r0, [{"amount": 34}]
   // let store_sales = [
@@ -8,41 +8,38 @@ func main (regs=33)
   Const        r3, "amount"
   IterPrep     r4, r0
   Len          r5, r4
-  Const        r6, 0
+  Const        r7, 0
+  Move         r6, r7
 L1:
   LessInt      r8, r6, r5
   JumpIfFalse  r8, L0
   Index        r10, r4, r6
-  Const        r11, "amount"
-  Index        r12, r10, r11
-  Append       r2, r2, r12
-  Const        r14, 1
-  AddInt       r6, r6, r14
+  Index        r11, r10, r3
+  Append       r2, r2, r11
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
-  Sum          r15, r2
-  Const        r16, []
-  Const        r17, "amount"
-  IterPrep     r18, r1
-  Len          r19, r18
-  Const        r20, 0
+  Sum          r14, r2
+  Const        r15, []
+  IterPrep     r16, r1
+  Len          r17, r16
+  Move         r18, r7
 L3:
-  LessInt      r22, r20, r19
-  JumpIfFalse  r22, L2
-  Index        r24, r18, r20
-  Const        r25, "amount"
-  Index        r26, r24, r25
-  Append       r16, r16, r26
-  Const        r28, 1
-  AddInt       r20, r20, r28
+  LessInt      r19, r18, r17
+  JumpIfFalse  r19, L2
+  Index        r21, r16, r18
+  Index        r22, r21, r3
+  Append       r15, r15, r22
+  AddInt       r18, r18, r13
   Jump         L3
 L2:
-  Sum          r29, r16
-  Add          r30, r15, r29
+  Sum          r24, r15
+  Add          r25, r14, r24
   // json(result)
-  JSON         r30
+  JSON         r25
   // expect result == 69
-  Const        r31, 69
-  Equal        r32, r30, r31
-  Expect       r32
+  Const        r26, 69
+  Equal        r27, r25, r26
+  Expect       r27
   Return       r0


### PR DESCRIPTION
## Summary
- reuse constant registers when building grouped records in the VM compiler
- refresh TPC-DS IR disassembly for queries q60–q69

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q60 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q61 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q62 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q63 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q64 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q65 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q66 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q67 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q68 -update -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q69 -update -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6862a22aa7a88320b9f259582d22d4a4