### PR TITLE
Update TPC‑DS IR outputs

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6774,14 +6774,18 @@ func formatRegs(start, n int) string {
 }
 
 func toFloat(v Value) float64 {
-	if v.Tag == ValueFloat {
+	switch v.Tag {
+	case ValueFloat:
 		return v.Float
-	}
-	if v.Tag == ValueBool {
+	case ValueBool:
 		if v.Bool {
 			return 1
 		}
 		return 0
+	case ValueStr:
+		if f, err := strconv.ParseFloat(v.Str, 64); err == nil {
+			return f
+		}
 	}
 	return float64(v.Int)
 }

--- a/tests/dataset/tpc-ds/out/q80.ir.out
+++ b/tests/dataset/tpc-ds/out/q80.ir.out
@@ -1,4 +1,4 @@
-func main (regs=61)
+func main (regs=47)
   // let store_sales = [
   Const        r0, [{"price": 20, "ret": 5}, {"price": 10, "ret": 2}, {"price": 5, "ret": 0}]
   // let catalog_sales = [
@@ -11,74 +11,63 @@ func main (regs=61)
   Const        r5, "ret"
   IterPrep     r6, r0
   Len          r7, r6
-  Const        r8, 0
+  Const        r9, 0
+  Move         r8, r9
 L1:
   LessInt      r10, r8, r7
   JumpIfFalse  r10, L0
   Index        r12, r6, r8
-  Const        r13, "price"
-  Index        r14, r12, r13
-  Const        r15, "ret"
-  Index        r16, r12, r15
-  Sub          r17, r14, r16
-  Append       r3, r3, r17
-  Const        r19, 1
-  AddInt       r8, r8, r19
+  Index        r13, r12, r4
+  Index        r14, r12, r5
+  Sub          r15, r13, r14
+  Append       r3, r3, r15
+  Const        r17, 1
+  AddInt       r8, r8, r17
   Jump         L1
 L0:
-  Sum          r20, r3
+  Sum          r18, r3
   // sum(from c in catalog_sales select c.price - c.ret) +
-  Const        r21, []
-  Const        r22, "price"
-  Const        r23, "ret"
-  IterPrep     r24, r1
-  Len          r25, r24
-  Const        r26, 0
+  Const        r19, []
+  IterPrep     r20, r1
+  Len          r21, r20
+  Move         r22, r9
 L3:
-  LessInt      r28, r26, r25
-  JumpIfFalse  r28, L2
-  Index        r30, r24, r26
-  Const        r31, "price"
-  Index        r32, r30, r31
-  Const        r33, "ret"
-  Index        r34, r30, r33
-  Sub          r35, r32, r34
-  Append       r21, r21, r35
-  Const        r37, 1
-  AddInt       r26, r26, r37
+  LessInt      r23, r22, r21
+  JumpIfFalse  r23, L2
+  Index        r25, r20, r22
+  Index        r26, r25, r4
+  Index        r27, r25, r5
+  Sub          r28, r26, r27
+  Append       r19, r19, r28
+  AddInt       r22, r22, r17
   Jump         L3
 L2:
-  Sum          r38, r21
+  Sum          r30, r19
   // sum(from s in store_sales select s.price - s.ret) +
-  Add          r39, r20, r38
+  Add          r31, r18, r30
   // sum(from w in web_sales select w.price - w.ret)
-  Const        r40, []
-  Const        r41, "price"
-  Const        r42, "ret"
-  IterPrep     r43, r2
-  Len          r44, r43
-  Const        r45, 0
+  Const        r32, []
+  IterPrep     r33, r2
+  Len          r34, r33
+  Move         r35, r9
 L5:
-  LessInt      r47, r45, r44
-  JumpIfFalse  r47, L4
-  Index        r49, r43, r45
-  Const        r50, "price"
-  Index        r51, r49, r50
-  Const        r52, "ret"
-  Index        r53, r49, r52
-  Sub          r54, r51, r53
-  Append       r40, r40, r54
-  Const        r56, 1
-  AddInt       r45, r45, r56
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L4
+  Index        r38, r33, r35
+  Index        r39, r38, r4
+  Index        r40, r38, r5
+  Sub          r41, r39, r40
+  Append       r32, r32, r41
+  AddInt       r35, r35, r17
   Jump         L5
 L4:
-  Sum          r57, r40
+  Sum          r43, r32
   // sum(from c in catalog_sales select c.price - c.ret) +
-  Add          r58, r39, r57
+  Add          r44, r31, r43
   // json(total_profit)
-  JSON         r58
+  JSON         r44
   // expect total_profit == 80.0
-  Const        r59, 80
-  EqualFloat   r60, r58, r59
-  Expect       r60
+  Const        r45, 80
+  EqualFloat   r46, r44, r45
+  Expect       r46
   Return       r0

--- a/tests/dataset/tpc-ds/out/q81.ir.out
+++ b/tests/dataset/tpc-ds/out/q81.ir.out
@@ -1,4 +1,4 @@
-func main (regs=125)
+func main (regs=100)
   // let catalog_returns = [
   Const        r0, [{"amt": 40, "cust": 1, "state": "CA"}, {"amt": 50, "cust": 2, "state": "CA"}, {"amt": 81, "cust": 3, "state": "CA"}, {"amt": 30, "cust": 4, "state": "TX"}, {"amt": 20, "cust": 5, "state": "TX"}]
   // from r in catalog_returns
@@ -6,178 +6,152 @@ func main (regs=125)
   // group by r.state into g
   Const        r2, "state"
   // select {state: g.key, avg_amt: avg(from x in g select x.amt)}
-  Const        r3, "state"
-  Const        r4, "key"
-  Const        r5, "avg_amt"
-  Const        r6, "amt"
+  Const        r3, "key"
+  Const        r4, "avg_amt"
+  Const        r5, "amt"
   // from r in catalog_returns
-  IterPrep     r7, r0
-  Len          r8, r7
-  Const        r9, 0
-  MakeMap      r10, 0, r0
-  Const        r11, []
+  IterPrep     r6, r0
+  Len          r7, r6
+  Const        r8, 0
+  MakeMap      r9, 0, r0
+  Const        r10, []
 L2:
-  LessInt      r13, r9, r8
-  JumpIfFalse  r13, L0
-  Index        r14, r7, r9
-  Move         r15, r14
+  LessInt      r12, r8, r7
+  JumpIfFalse  r12, L0
+  Index        r13, r6, r8
   // group by r.state into g
-  Const        r16, "state"
-  Index        r17, r15, r16
-  Str          r18, r17
-  In           r19, r18, r10
-  JumpIfTrue   r19, L1
+  Index        r15, r13, r2
+  Str          r16, r15
+  In           r17, r16, r9
+  JumpIfTrue   r17, L1
   // from r in catalog_returns
-  Const        r20, []
-  Const        r21, "__group__"
-  Const        r22, true
-  Const        r23, "key"
+  Const        r18, []
+  Const        r19, "__group__"
+  Const        r20, true
+  Const        r21, "key"
   // group by r.state into g
-  Move         r24, r17
+  Move         r22, r15
   // from r in catalog_returns
-  Const        r25, "items"
-  Move         r26, r20
-  Const        r27, "count"
-  Const        r28, 0
+  Const        r23, "items"
+  Move         r24, r18
+  Const        r25, "count"
+  Const        r26, 0
+  Move         r27, r19
+  Move         r28, r20
   Move         r29, r21
   Move         r30, r22
   Move         r31, r23
   Move         r32, r24
   Move         r33, r25
   Move         r34, r26
-  Move         r35, r27
-  Move         r36, r28
-  MakeMap      r37, 4, r29
-  SetIndex     r10, r18, r37
-  Append       r11, r11, r37
+  MakeMap      r35, 4, r27
+  SetIndex     r9, r16, r35
+  Append       r10, r10, r35
 L1:
-  Const        r39, "items"
-  Index        r40, r10, r18
-  Index        r41, r40, r39
-  Append       r42, r41, r14
-  SetIndex     r40, r39, r42
-  Const        r43, "count"
-  Index        r44, r40, r43
-  Const        r45, 1
-  AddInt       r46, r44, r45
-  SetIndex     r40, r43, r46
-  Const        r47, 1
-  AddInt       r9, r9, r47
+  Const        r37, "items"
+  Index        r38, r9, r16
+  Index        r39, r38, r37
+  Append       r40, r39, r13
+  SetIndex     r38, r37, r40
+  Const        r41, "count"
+  Index        r42, r38, r41
+  Const        r43, 1
+  AddInt       r44, r42, r43
+  SetIndex     r38, r41, r44
+  AddInt       r8, r8, r43
   Jump         L2
 L0:
-  Const        r48, 0
-  Len          r50, r11
+  Const        r46, 0
+  Move         r45, r46
+  Len          r47, r10
 L6:
-  LessInt      r51, r48, r50
-  JumpIfFalse  r51, L3
-  Index        r53, r11, r48
+  LessInt      r48, r45, r47
+  JumpIfFalse  r48, L3
+  Index        r50, r10, r45
   // select {state: g.key, avg_amt: avg(from x in g select x.amt)}
-  Const        r54, "state"
-  Const        r55, "key"
-  Index        r56, r53, r55
-  Const        r57, "avg_amt"
-  Const        r58, []
-  Const        r59, "amt"
-  IterPrep     r60, r53
-  Len          r61, r60
-  Const        r62, 0
+  Const        r51, "state"
+  Index        r52, r50, r3
+  Const        r53, "avg_amt"
+  Const        r54, []
+  IterPrep     r55, r50
+  Len          r56, r55
+  Move         r57, r46
 L5:
-  LessInt      r64, r62, r61
-  JumpIfFalse  r64, L4
-  Index        r66, r60, r62
-  Const        r67, "amt"
-  Index        r68, r66, r67
-  Append       r58, r58, r68
-  Const        r70, 1
-  AddInt       r62, r62, r70
+  LessInt      r58, r57, r56
+  JumpIfFalse  r58, L4
+  Index        r60, r55, r57
+  Index        r61, r60, r5
+  Append       r54, r54, r61
+  AddInt       r57, r57, r43
   Jump         L5
 L4:
-  Avg          r71, r58
-  Move         r72, r54
-  Move         r73, r56
-  Move         r74, r57
-  Move         r75, r71
-  MakeMap      r76, 2, r72
+  Avg          r63, r54
+  Move         r64, r51
+  Move         r65, r52
+  Move         r66, r53
+  Move         r67, r63
+  MakeMap      r68, 2, r64
   // from r in catalog_returns
-  Append       r1, r1, r76
-  Const        r78, 1
-  AddInt       r48, r48, r78
+  Append       r1, r1, r68
+  AddInt       r45, r45, r43
   Jump         L6
 L3:
   // first(from a in avg_list
-  Const        r79, []
-  // where a.state == "CA"
-  Const        r80, "state"
-  // first(from a in avg_list
-  IterPrep     r81, r1
-  Len          r82, r81
-  Const        r83, 0
+  Const        r70, []
+  IterPrep     r71, r1
+  Len          r72, r71
+  Move         r73, r46
 L9:
-  LessInt      r85, r83, r82
-  JumpIfFalse  r85, L7
-  Index        r87, r81, r83
+  LessInt      r74, r73, r72
+  JumpIfFalse  r74, L7
+  Index        r76, r71, r73
   // where a.state == "CA"
-  Const        r88, "state"
-  Index        r89, r87, r88
-  Const        r90, "CA"
-  Equal        r91, r89, r90
-  JumpIfFalse  r91, L8
+  Index        r77, r76, r2
+  Const        r78, "CA"
+  Equal        r79, r77, r78
+  JumpIfFalse  r79, L8
   // first(from a in avg_list
-  Append       r79, r79, r87
+  Append       r70, r70, r76
 L8:
-  Const        r93, 1
-  AddInt       r83, r83, r93
+  AddInt       r73, r73, r43
   Jump         L9
 L7:
-  First        r94, r79
+  First        r81, r70
   // from r in catalog_returns
-  Const        r95, []
-  // where r.state == "CA" && r.amt > avg_state.avg_amt * 1.2
-  Const        r96, "state"
-  Const        r97, "amt"
-  Const        r98, "avg_amt"
-  // select r.amt
-  Const        r99, "amt"
-  // from r in catalog_returns
-  IterPrep     r100, r0
-  Len          r101, r100
-  Const        r102, 0
+  Const        r82, []
+  IterPrep     r83, r0
+  Len          r84, r83
+  Move         r85, r46
 L13:
-  LessInt      r104, r102, r101
-  JumpIfFalse  r104, L10
-  Index        r15, r100, r102
+  LessInt      r86, r85, r84
+  JumpIfFalse  r86, L10
+  Index        r14, r83, r85
   // where r.state == "CA" && r.amt > avg_state.avg_amt * 1.2
-  Const        r106, "state"
-  Index        r107, r15, r106
-  Const        r108, "avg_amt"
-  Index        r109, r94, r108
-  Const        r110, 1.2
-  MulFloat     r111, r109, r110
-  Const        r112, "amt"
-  Index        r113, r15, r112
-  LessFloat    r114, r111, r113
-  Const        r115, "CA"
-  Equal        r117, r107, r115
-  JumpIfFalse  r117, L11
-  Move         r117, r114
+  Index        r88, r14, r2
+  Index        r89, r81, r4
+  Const        r90, 1.2
+  MulFloat     r91, r89, r90
+  Index        r92, r14, r5
+  LessFloat    r93, r91, r92
+  Equal        r94, r88, r78
+  JumpIfFalse  r94, L11
+  Move         r94, r93
 L11:
-  JumpIfFalse  r117, L12
+  JumpIfFalse  r94, L12
   // select r.amt
-  Const        r118, "amt"
-  Index        r119, r15, r118
+  Index        r95, r14, r5
   // from r in catalog_returns
-  Append       r95, r95, r119
+  Append       r82, r82, r95
 L12:
-  Const        r121, 1
-  AddInt       r102, r102, r121
+  AddInt       r85, r85, r43
   Jump         L13
 L10:
   // let result = first(result_list)
-  First        r122, r95
+  First        r97, r82
   // json(result)
-  JSON         r122
+  JSON         r97
   // expect result == 81.0
-  Const        r123, 81
-  EqualFloat   r124, r122, r123
-  Expect       r124
+  Const        r98, 81
+  EqualFloat   r99, r97, r98
+  Expect       r99
   Return       r0

--- a/tests/dataset/tpc-ds/out/q82.ir.out
+++ b/tests/dataset/tpc-ds/out/q82.ir.out
@@ -1,4 +1,4 @@
-func main (regs=30)
+func main (regs=29)
   // let item = [
   Const        r0, [{"id": 1}, {"id": 2}, {"id": 3}]
   // let inventory = [
@@ -26,29 +26,28 @@ L3:
   // if inv.item == s.item {
   Const        r16, "item"
   Index        r17, r9, r16
-  Const        r18, "item"
-  Index        r19, r15, r18
-  Equal        r20, r17, r19
-  JumpIfFalse  r20, L2
+  Index        r18, r15, r16
+  Equal        r19, r17, r18
+  JumpIfFalse  r19, L2
   // result = result + inv.qty
-  Const        r21, "qty"
-  Index        r22, r9, r21
-  Add          r3, r3, r22
+  Const        r20, "qty"
+  Index        r21, r9, r20
+  Add          r3, r3, r21
 L2:
   // for s in store_sales {
-  Const        r24, 1
-  Add          r12, r12, r24
+  Const        r23, 1
+  Add          r12, r12, r23
   Jump         L3
 L1:
   // for inv in inventory {
-  Const        r26, 1
-  Add          r6, r6, r26
+  Const        r25, 1
+  Add          r6, r6, r25
   Jump         L4
 L0:
   // json(result)
   JSON         r3
   // expect result == 82
-  Const        r28, 82
-  Equal        r29, r3, r28
-  Expect       r29
+  Const        r27, 82
+  Equal        r28, r3, r27
+  Expect       r28
   Return       r0

--- a/tests/dataset/tpc-ds/out/q83.ir.out
+++ b/tests/dataset/tpc-ds/out/q83.ir.out
@@ -1,4 +1,4 @@
-func main (regs=47)
+func main (regs=38)
   // let sr_items = [
   Const        r0, [{"qty": 10}, {"qty": 5}]
   // let cr_items = [
@@ -10,63 +10,57 @@ func main (regs=47)
   Const        r4, "qty"
   IterPrep     r5, r0
   Len          r6, r5
-  Const        r7, 0
+  Const        r8, 0
+  Move         r7, r8
 L1:
   LessInt      r9, r7, r6
   JumpIfFalse  r9, L0
   Index        r11, r5, r7
-  Const        r12, "qty"
-  Index        r13, r11, r12
-  Append       r3, r3, r13
-  Const        r15, 1
-  AddInt       r7, r7, r15
+  Index        r12, r11, r4
+  Append       r3, r3, r12
+  Const        r14, 1
+  AddInt       r7, r7, r14
   Jump         L1
 L0:
-  Sum          r16, r3
+  Sum          r15, r3
   // sum(from x in cr_items select x.qty) +
-  Const        r17, []
-  Const        r18, "qty"
-  IterPrep     r19, r1
-  Len          r20, r19
-  Const        r21, 0
+  Const        r16, []
+  IterPrep     r17, r1
+  Len          r18, r17
+  Move         r19, r8
 L3:
-  LessInt      r23, r21, r20
-  JumpIfFalse  r23, L2
-  Index        r11, r19, r21
-  Const        r25, "qty"
-  Index        r26, r11, r25
-  Append       r17, r17, r26
-  Const        r28, 1
-  AddInt       r21, r21, r28
+  LessInt      r20, r19, r18
+  JumpIfFalse  r20, L2
+  Index        r11, r17, r19
+  Index        r22, r11, r4
+  Append       r16, r16, r22
+  AddInt       r19, r19, r14
   Jump         L3
 L2:
-  Sum          r29, r17
+  Sum          r24, r16
   // let result = sum(from x in sr_items select x.qty) +
-  Add          r30, r16, r29
+  Add          r25, r15, r24
   // sum(from x in wr_items select x.qty)
-  Const        r31, []
-  Const        r32, "qty"
-  IterPrep     r33, r2
-  Len          r34, r33
-  Const        r35, 0
+  Const        r26, []
+  IterPrep     r27, r2
+  Len          r28, r27
+  Move         r29, r8
 L5:
-  LessInt      r37, r35, r34
-  JumpIfFalse  r37, L4
-  Index        r11, r33, r35
-  Const        r39, "qty"
-  Index        r40, r11, r39
-  Append       r31, r31, r40
-  Const        r42, 1
-  AddInt       r35, r35, r42
+  LessInt      r30, r29, r28
+  JumpIfFalse  r30, L4
+  Index        r11, r27, r29
+  Index        r32, r11, r4
+  Append       r26, r26, r32
+  AddInt       r29, r29, r14
   Jump         L5
 L4:
-  Sum          r43, r31
+  Sum          r34, r26
   // sum(from x in cr_items select x.qty) +
-  Add          r44, r30, r43
+  Add          r35, r25, r34
   // json(result)
-  JSON         r44
+  JSON         r35
   // expect result == 83
-  Const        r45, 83
-  Equal        r46, r44, r45
-  Expect       r46
+  Const        r36, 83
+  Equal        r37, r35, r36
+  Expect       r37
   Return       r0

--- a/tests/dataset/tpc-ds/out/q85.ir.out
+++ b/tests/dataset/tpc-ds/out/q85.ir.out
@@ -1,4 +1,4 @@
-func main (regs=17)
+func main (regs=16)
   // let web_returns = [
   Const        r0, [{"cash": 20, "fee": 1, "qty": 60}, {"cash": 30, "fee": 2, "qty": 100}, {"cash": 25, "fee": 3, "qty": 95}]
   // let result = avg(from r in web_returns select r.qty)
@@ -11,18 +11,17 @@ L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Const        r10, "qty"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  Index        r10, r9, r2
+  Append       r1, r1, r10
+  Const        r12, 1
+  AddInt       r5, r5, r12
   Jump         L1
 L0:
-  Avg          r14, r1
+  Avg          r13, r1
   // json(result)
-  JSON         r14
+  JSON         r13
   // expect result == 85.0
-  Const        r15, 85
-  EqualFloat   r16, r14, r15
-  Expect       r16
+  Const        r14, 85
+  EqualFloat   r15, r13, r14
+  Expect       r15
   Return       r0

--- a/tests/dataset/tpc-ds/out/q86.ir.out
+++ b/tests/dataset/tpc-ds/out/q86.ir.out
@@ -1,4 +1,4 @@
-func main (regs=28)
+func main (regs=24)
   // let web_sales = [
   Const        r0, [{"cat": "A", "class": "B", "net": 40}, {"cat": "A", "class": "B", "net": 46}, {"cat": "A", "class": "C", "net": 10}, {"cat": "B", "class": "B", "net": 20}]
   // sum(from ws in web_sales
@@ -17,34 +17,30 @@ L3:
   JumpIfFalse  r9, L0
   Index        r11, r5, r7
   // where ws.cat == "A" && ws.class == "B"
-  Const        r12, "cat"
-  Index        r13, r11, r12
-  Const        r14, "A"
-  Equal        r15, r13, r14
-  Const        r16, "class"
-  Index        r17, r11, r16
-  Const        r18, "B"
-  Equal        r19, r17, r18
-  Move         r20, r15
-  JumpIfFalse  r20, L1
-  Move         r20, r19
+  Index        r12, r11, r2
+  Const        r13, "A"
+  Equal        r14, r12, r13
+  Index        r15, r11, r3
+  Const        r16, "B"
+  Equal        r17, r15, r16
+  JumpIfFalse  r14, L1
+  Move         r14, r17
 L1:
-  JumpIfFalse  r20, L2
+  JumpIfFalse  r14, L2
   // select ws.net)
-  Const        r21, "net"
-  Index        r22, r11, r21
+  Index        r18, r11, r4
   // sum(from ws in web_sales
-  Append       r1, r1, r22
+  Append       r1, r1, r18
 L2:
-  Const        r24, 1
-  AddInt       r7, r7, r24
+  Const        r20, 1
+  AddInt       r7, r7, r20
   Jump         L3
 L0:
-  Sum          r25, r1
+  Sum          r21, r1
   // json(result)
-  JSON         r25
+  JSON         r21
   // expect result == 86.0
-  Const        r26, 86
-  EqualFloat   r27, r25, r26
-  Expect       r27
+  Const        r22, 86
+  EqualFloat   r23, r21, r22
+  Expect       r23
   Return       r0

--- a/tests/dataset/tpc-ds/out/q87.ir.out
+++ b/tests/dataset/tpc-ds/out/q87.ir.out
@@ -1,4 +1,4 @@
-func main (regs=6)
+func main (regs=5)
   // let store_sales = [
   Const        r0, [{"cust": "A"}, {"cust": "B"}, {"cust": "B"}, {"cust": "C"}]
   // let catalog_sales = [
@@ -10,9 +10,8 @@ func main (regs=6)
   // json(result)
   JSON         r3
   // expect result == 87
-  Const        r4, 87
-  Const        r5, true
-  Expect       r5
+  Const        r4, true
+  Expect       r4
   Return       r0
 
   // fun distinct(xs: list<any>): list<any> {

--- a/tests/dataset/tpc-ds/out/q88.ir.out
+++ b/tests/dataset/tpc-ds/out/q88.ir.out
@@ -1,4 +1,4 @@
-func main (regs=5)
+func main (regs=4)
   // let time_dim = [
   Const        r0, [{"hour": 8, "minute": 30, "time_sk": 1}, {"hour": 9, "minute": 0, "time_sk": 2}, {"hour": 11, "minute": 15, "time_sk": 3}]
   // let store_sales = [
@@ -8,7 +8,6 @@ func main (regs=5)
   // json(result)
   JSON         r2
   // expect result == 88
-  Const        r3, 88
-  Const        r4, true
-  Expect       r4
+  Const        r3, true
+  Expect       r3
   Return       r0

--- a/tests/dataset/tpc-ds/out/q89.ir.out
+++ b/tests/dataset/tpc-ds/out/q89.ir.out
@@ -1,4 +1,4 @@
-func main (regs=17)
+func main (regs=16)
   // let store_sales = [
   Const        r0, [{"price": 40}, {"price": 30}, {"price": 19}]
   // let result = sum(from s in store_sales select s.price)
@@ -11,18 +11,17 @@ L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
   Index        r9, r3, r5
-  Const        r10, "price"
-  Index        r11, r9, r10
-  Append       r1, r1, r11
-  Const        r13, 1
-  AddInt       r5, r5, r13
+  Index        r10, r9, r2
+  Append       r1, r1, r10
+  Const        r12, 1
+  AddInt       r5, r5, r12
   Jump         L1
 L0:
-  Sum          r14, r1
+  Sum          r13, r1
   // json(result)
-  JSON         r14
+  JSON         r13
   // expect result == 89.0
-  Const        r15, 89
-  EqualFloat   r16, r14, r15
-  Expect       r16
+  Const        r14, 89
+  EqualFloat   r15, r13, r14
+  Expect       r15
   Return       r0


### PR DESCRIPTION
## Summary
- allow `toFloat` to parse numeric strings
- regenerate TPC‑DS IR for queries q80-q89

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862a23146e88320a53e3c4a5da46ede