### PR TITLE
Improve vmreport build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ cd mochi
 make install # install Deno for TypeScript tests
 make build
 make test
+
+# Build the optional `vmreport` tool without heavy CGO dependencies
+CGO_ENABLED=0 go build -o vmreport ./tools/vmreport
 ```
 
 This installs `mochi` into `~/bin` and runs the full test suite.

--- a/tools/vmreport/README.md
+++ b/tools/vmreport/README.md
@@ -1,0 +1,20 @@
+# vmreport
+
+`vmreport` disassembles a Mochi program and shows register inference for each function. The repository already defines every VM operation used in the sample query outputs such as `q19.ir.out`.
+
+## Building
+
+The tool depends on packages that enable DuckDB integration. They require CGO and can take a long time to compile. For a quick build you can disable CGO:
+
+```bash
+CGO_ENABLED=0 go build -o vmreport ./tools/vmreport
+```
+
+## Usage
+
+Run the compiled binary with the path to a `.mochi` file:
+
+```bash
+./vmreport tests/dataset/tpc-h/q19.mochi
+```
+


### PR DESCRIPTION
## Summary
- add README for `vmreport` tool
- mention how to build `vmreport` without CGO in README

## Testing
- `CGO_ENABLED=0 go build -o vmreport ./tools/vmreport`

------
https://chatgpt.com/codex/tasks/task_e_6862a5b00d4c8320b124c2a0a4ba98fb