### PR TITLE
Enable numeric strings in runtime vm

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -633,7 +633,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			} else if b.Tag == ValueFloat || c.Tag == ValueFloat {
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: toFloat(b) + toFloat(c)}
 			} else {
-				fr.regs[ins.A] = Value{Tag: ValueInt, Int: b.Int + c.Int}
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: toInt(b) + toInt(c)}
 			}
 		case OpAddInt:
 			b := toInt(fr.regs[ins.B])
@@ -649,7 +649,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			if b.Tag == ValueFloat || c.Tag == ValueFloat {
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: toFloat(b) - toFloat(c)}
 			} else {
-				fr.regs[ins.A] = Value{Tag: ValueInt, Int: b.Int - c.Int}
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: toInt(b) - toInt(c)}
 			}
 		case OpSubInt:
 			b := toInt(fr.regs[ins.B])
@@ -678,7 +678,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			if b.Tag == ValueFloat || c.Tag == ValueFloat {
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: toFloat(b) * toFloat(c)}
 			} else {
-				fr.regs[ins.A] = Value{Tag: ValueInt, Int: b.Int * c.Int}
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: toInt(b) * toInt(c)}
 			}
 		case OpMulInt:
 			b := toInt(fr.regs[ins.B])
@@ -691,13 +691,13 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 		case OpDiv:
 			b := fr.regs[ins.B]
 			c := fr.regs[ins.C]
-			if (c.Tag == ValueInt && c.Int == 0) || (c.Tag == ValueFloat && c.Float == 0) {
+			if toFloat(c) == 0 {
 				return Value{}, m.newError(fmt.Errorf("division by zero"), trace, ins.Line)
 			}
 			if b.Tag == ValueFloat || c.Tag == ValueFloat {
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: toFloat(b) / toFloat(c)}
 			} else {
-				fr.regs[ins.A] = Value{Tag: ValueInt, Int: b.Int / c.Int}
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: toInt(b) / toInt(c)}
 			}
 		case OpDivInt:
 			b := toInt(fr.regs[ins.B])
@@ -716,13 +716,13 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 		case OpMod:
 			b := fr.regs[ins.B]
 			c := fr.regs[ins.C]
-			if (c.Tag == ValueInt && c.Int == 0) || (c.Tag == ValueFloat && c.Float == 0) {
+			if toFloat(c) == 0 {
 				return Value{}, m.newError(fmt.Errorf("division by zero"), trace, ins.Line)
 			}
 			if b.Tag == ValueFloat || c.Tag == ValueFloat {
 				fr.regs[ins.A] = Value{Tag: ValueFloat, Float: math.Mod(toFloat(b), toFloat(c))}
 			} else {
-				fr.regs[ins.A] = Value{Tag: ValueInt, Int: b.Int % c.Int}
+				fr.regs[ins.A] = Value{Tag: ValueInt, Int: toInt(b) % toInt(c)}
 			}
 		case OpModInt:
 			b := toInt(fr.regs[ins.B])

--- a/tests/dataset/tpc-ds/out/q20.ir.out
+++ b/tests/dataset/tpc-ds/out/q20.ir.out
@@ -1,11 +1,10 @@
-func main (regs=368)
-L19:
+func main (regs=286)
   // let catalog_sales = [
-  Const        r0, [{"cs_ext_sales_price": 100, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_sales_price": 200, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_sales_price": 150, "cs_item_sk": 2, "cs_sold_date_sk": 1}]
+  Const        r0, [{"cs_ext_sales_price": 100, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_sales_price": 200, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_sales_price": 150, "cs_item_sk": 2, "cs_sold_date_sk": 1}, {"cs_ext_sales_price": 300, "cs_item_sk": 1, "cs_sold_date_sk": 2}, {"cs_ext_sales_price": 150, "cs_item_sk": 2, "cs_sold_date_sk": 2}, {"cs_ext_sales_price": 50, "cs_item_sk": 3, "cs_sold_date_sk": 1}]
   // let item = [
-  Const        r1, [{"i_category": "A", "i_class": "X", "i_current_price": 10, "i_item_desc": "Item One", "i_item_id": "ITEM1", "i_item_sk": 1}, {"i_category": "A", "i_class": "X", "i_current_price": 20, "i_item_desc": "Item Two", "i_item_id": "ITEM2", "i_item_sk": 2}]
-  // let date_dim = [ { d_date_sk: 1, d_date: "2000-02-10" } ]
-  Const        r2, [{"d_date": "2000-02-10", "d_date_sk": 1}]
+  Const        r1, [{"i_category": "A", "i_class": "X", "i_current_price": 10, "i_item_desc": "Item One", "i_item_id": "ITEM1", "i_item_sk": 1}, {"i_category": "A", "i_class": "X", "i_current_price": 20, "i_item_desc": "Item Two", "i_item_id": "ITEM2", "i_item_sk": 2}, {"i_category": "D", "i_class": "Y", "i_current_price": 15, "i_item_desc": "Item Three", "i_item_id": "ITEM3", "i_item_sk": 3}]
+  // let date_dim = [
+  Const        r2, [{"d_date": "2000-02-10", "d_date_sk": 1}, {"d_date": "2000-02-20", "d_date_sk": 2}]
   // from cs in catalog_sales
   Const        r3, []
   // id: i.i_item_id,
@@ -32,19 +31,19 @@ L19:
   Const        r17, "cs_ext_sales_price"
   // from cs in catalog_sales
   MakeMap      r18, 0, r0
-  Move         r19, r3
+  Const        r19, []
   IterPrep     r21, r0
   Len          r22, r21
   Const        r23, 0
-L1:
+L8:
   LessInt      r24, r23, r22
   JumpIfFalse  r24, L0
   Index        r26, r21, r23
   // join i in item on cs.cs_item_sk == i.i_item_sk
   IterPrep     r27, r1
   Len          r28, r27
-  Move         r29, r23
-L2:
+  Const        r29, 0
+L7:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L1
   Index        r32, r27, r29
@@ -57,8 +56,8 @@ L2:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   IterPrep     r38, r2
   Len          r39, r38
-  Move         r40, r23
-L7:
+  Const        r40, 0
+L6:
   LessInt      r41, r40, r39
   JumpIfFalse  r41, L2
   Index        r43, r38, r40
@@ -79,479 +78,360 @@ L7:
   LessEq       r55, r53, r54
   // where i.i_category in ["A", "B", "C"] &&
   Const        r56, ["A", "B", "C"]
-  In           r58, r49, r56
-  JumpIfFalse  r58, L4
-L4:
+  In           r57, r49, r56
+  JumpIfFalse  r57, L4
+  Move         r57, r52
   // d.d_date >= "2000-02-01" && d.d_date <= "2000-03-02"
-  Move         r59, r52
-  JumpIfFalse  r59, L5
-  Move         r59, r55
-L5:
+  JumpIfFalse  r57, L4
+  Move         r57, r55
+L4:
   // where i.i_category in ["A", "B", "C"] &&
-  JumpIfFalse  r59, L3
+  JumpIfFalse  r57, L3
   // from cs in catalog_sales
-  Const        r60, "cs"
-  Move         r61, r26
-  Const        r62, "i"
-  Move         r63, r32
-  Const        r64, "d"
-  Move         r65, r43
-  MakeMap      r66, 3, r60
+  Const        r58, "cs"
+  Move         r59, r26
+  Const        r60, "i"
+  Move         r61, r32
+  Const        r62, "d"
+  Move         r63, r43
+  MakeMap      r64, 3, r58
   // id: i.i_item_id,
-  Move         r67, r4
-  Index        r68, r32, r5
+  Const        r65, "id"
+  Index        r66, r32, r5
   // desc: i.i_item_desc,
-  Move         r69, r6
-  Index        r70, r32, r7
+  Const        r67, "desc"
+  Index        r68, r32, r7
   // cat: i.i_category,
-  Move         r71, r8
-  Index        r72, r32, r9
+  Const        r69, "cat"
+  Index        r70, r32, r9
   // class: i.i_class,
-  Move         r73, r10
-  Index        r74, r32, r11
+  Const        r71, "class"
+  Index        r72, r32, r11
   // price: i.i_current_price
-  Move         r75, r12
-  Index        r76, r32, r13
+  Const        r73, "price"
+  Index        r74, r32, r13
   // id: i.i_item_id,
+  Move         r75, r65
+  Move         r76, r66
+  // desc: i.i_item_desc,
   Move         r77, r67
   Move         r78, r68
-  // desc: i.i_item_desc,
+  // cat: i.i_category,
   Move         r79, r69
   Move         r80, r70
-  // cat: i.i_category,
+  // class: i.i_class,
   Move         r81, r71
   Move         r82, r72
-  // class: i.i_class,
+  // price: i.i_current_price
   Move         r83, r73
   Move         r84, r74
-  // price: i.i_current_price
-  Move         r85, r75
-  Move         r86, r76
   // group by {
-  MakeMap      r87, 5, r77
-  Str          r88, r87
-  In           r89, r88, r18
-  JumpIfTrue   r89, L6
+  MakeMap      r85, 5, r75
+  Str          r86, r85
+  In           r87, r86, r18
+  JumpIfTrue   r87, L5
   // from cs in catalog_sales
-  Move         r90, r3
-  Const        r91, "__group__"
-  Const        r92, true
-  Move         r93, r15
+  Const        r88, []
+  Const        r89, "__group__"
+  Const        r90, true
+  Const        r91, "key"
   // group by {
-  Move         r94, r87
+  Move         r92, r85
   // from cs in catalog_sales
-  Const        r95, "items"
-  Move         r96, r90
-  Const        r97, "count"
-  Move         r98, r40
+  Const        r93, "items"
+  Move         r94, r88
+  Const        r95, "count"
+  Const        r96, 0
+  Move         r97, r89
+  Move         r98, r90
   Move         r99, r91
   Move         r100, r92
   Move         r101, r93
   Move         r102, r94
   Move         r103, r95
   Move         r104, r96
-  Move         r105, r97
-  Move         r106, r98
-  MakeMap      r107, 4, r99
-  SetIndex     r18, r88, r107
-  Append       r19, r19, r107
-L6:
-  Move         r109, r95
-  Index        r110, r18, r88
-  Index        r111, r110, r109
-  Append       r112, r111, r66
-  SetIndex     r110, r109, r112
-  Move         r113, r97
-  Index        r114, r110, r113
-  Const        r115, 1
-  AddInt       r116, r114, r115
-  SetIndex     r110, r113, r116
+  MakeMap      r105, 4, r97
+  SetIndex     r18, r86, r105
+  Append       r19, r19, r105
+L5:
+  Const        r107, "items"
+  Index        r108, r18, r86
+  Index        r109, r108, r107
+  Append       r110, r109, r64
+  SetIndex     r108, r107, r110
+  Const        r111, "count"
+  Index        r112, r108, r111
+  Const        r113, 1
+  AddInt       r114, r112, r113
+  SetIndex     r108, r111, r114
 L3:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r40, r40, r115
+  AddInt       r40, r40, r113
+  Jump         L6
+L2:
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  AddInt       r29, r29, r113
   Jump         L7
+L1:
+  // from cs in catalog_sales
+  AddInt       r23, r23, r113
+  Jump         L8
 L0:
-  // from cs in catalog_sales
-  Move         r118, r23
-  Move         r117, r118
-  Len          r119, r19
+  Const        r116, 0
+  Move         r115, r116
+  Len          r117, r19
+L12:
+  LessInt      r118, r115, r117
+  JumpIfFalse  r118, L9
+  Index        r120, r19, r115
+  // i_item_id: g.key.id,
+  Const        r121, "i_item_id"
+  Index        r122, r120, r15
+  Index        r123, r122, r4
+  // i_item_desc: g.key.desc,
+  Const        r124, "i_item_desc"
+  Index        r125, r120, r15
+  Index        r126, r125, r6
+  // i_category: g.key.cat,
+  Const        r127, "i_category"
+  Index        r128, r120, r15
+  Index        r129, r128, r8
+  // i_class: g.key.class,
+  Const        r130, "i_class"
+  Index        r131, r120, r15
+  Index        r132, r131, r10
+  // i_current_price: g.key.price,
+  Const        r133, "i_current_price"
+  Index        r134, r120, r15
+  Index        r135, r134, r12
+  // itemrevenue: sum(from x in g select x.cs_ext_sales_price)
+  Const        r136, "itemrevenue"
+  Const        r137, []
+  IterPrep     r138, r120
+  Len          r139, r138
+  Move         r140, r116
 L11:
-  LessInt      r120, r117, r119
-  JumpIfFalse  r120, L8
-  Index        r122, r19, r117
-  // i_item_id: g.key.id,
-  Move         r123, r5
-  Index        r124, r122, r15
-  Index        r125, r124, r4
-  // i_item_desc: g.key.desc,
-  Move         r126, r7
-  Index        r127, r122, r15
-  Index        r128, r127, r6
-  // i_category: g.key.cat,
-  Move         r129, r9
-  Index        r130, r122, r15
-  Index        r131, r130, r8
-  // i_class: g.key.class,
-  Move         r132, r11
-  Index        r133, r122, r15
-  Index        r134, r133, r10
-  // i_current_price: g.key.price,
-  Move         r135, r13
-  Index        r136, r122, r15
-  Index        r137, r136, r12
-  // itemrevenue: sum(from x in g select x.cs_ext_sales_price)
-  Move         r138, r16
-  Move         r139, r90
-  IterPrep     r140, r122
-  Len          r141, r140
-  Move         r142, r118
-L10:
-  LessInt      r143, r142, r141
-  JumpIfFalse  r143, L9
-  Index        r145, r140, r142
-  Index        r146, r145, r17
-  Append       r139, r139, r146
-  AddInt       r142, r142, r115
-  Jump         L10
-L9:
-  Sum          r148, r139
-  // i_item_id: g.key.id,
-  Move         r149, r123
-  Move         r150, r125
-  // i_item_desc: g.key.desc,
-  Move         r151, r126
-  Move         r152, r128
-  // i_category: g.key.cat,
-  Move         r153, r129
-  Move         r154, r131
-  // i_class: g.key.class,
-  Move         r155, r132
-  Move         r156, r134
-  // i_current_price: g.key.price,
-  Move         r157, r135
-  Move         r158, r137
-  // itemrevenue: sum(from x in g select x.cs_ext_sales_price)
-  Move         r159, r138
-  Move         r160, r148
-  // select {
-  MakeMap      r161, 6, r149
-  // from cs in catalog_sales
-  Append       r3, r3, r161
-  AddInt       r117, r117, r115
+  LessInt      r141, r140, r139
+  JumpIfFalse  r141, L10
+  Index        r143, r138, r140
+  Index        r144, r143, r17
+  Append       r137, r137, r144
+  AddInt       r140, r140, r113
   Jump         L11
-L8:
+L10:
+  Sum          r146, r137
+  // i_item_id: g.key.id,
+  Move         r147, r121
+  Move         r148, r123
+  // i_item_desc: g.key.desc,
+  Move         r149, r124
+  Move         r150, r126
+  // i_category: g.key.cat,
+  Move         r151, r127
+  Move         r152, r129
+  // i_class: g.key.class,
+  Move         r153, r130
+  Move         r154, r132
+  // i_current_price: g.key.price,
+  Move         r155, r133
+  Move         r156, r135
+  // itemrevenue: sum(from x in g select x.cs_ext_sales_price)
+  Move         r157, r136
+  Move         r158, r146
+  // select {
+  MakeMap      r159, 6, r147
+  // from cs in catalog_sales
+  Append       r3, r3, r159
+  AddInt       r115, r115, r113
+  Jump         L12
+L9:
   // from f in filtered
-  Const        r163, []
+  Const        r161, []
   // select { class: g.key, total: sum(from x in g select x.itemrevenue) }
-  Const        r164, "total"
+  Const        r162, "total"
   // from f in filtered
-  IterPrep     r165, r3
-  Len          r166, r165
-  Move         r167, r118
-  MakeMap      r168, 0, r0
-  Move         r169, r163
-L14:
-  LessInt      r171, r167, r166
-  JumpIfFalse  r171, L12
-  Index        r172, r165, r167
+  IterPrep     r163, r3
+  Len          r164, r163
+  Const        r165, 0
+  MakeMap      r166, 0, r0
+  Const        r167, []
+L15:
+  LessInt      r169, r165, r164
+  JumpIfFalse  r169, L13
+  Index        r170, r163, r165
   // group by f.i_class into g
-  Index        r174, r172, r11
-  Str          r175, r174
-  In           r176, r175, r168
-  JumpIfTrue   r176, L13
+  Index        r172, r170, r11
+  Str          r173, r172
+  In           r174, r173, r166
+  JumpIfTrue   r174, L14
   // from f in filtered
-  Move         r177, r163
-  Move         r178, r91
-  Move         r179, r92
-  Move         r180, r15
+  Const        r175, []
+  Const        r176, "__group__"
+  Const        r177, true
+  Const        r178, "key"
   // group by f.i_class into g
-  Move         r181, r174
+  Move         r179, r172
   // from f in filtered
-  Move         r182, r95
-  Move         r183, r177
-  Move         r184, r97
-  Move         r185, r118
+  Const        r180, "items"
+  Move         r181, r175
+  Const        r182, "count"
+  Const        r183, 0
+  Move         r184, r176
+  Move         r185, r177
   Move         r186, r178
   Move         r187, r179
   Move         r188, r180
   Move         r189, r181
   Move         r190, r182
   Move         r191, r183
-  Move         r192, r184
-  Move         r193, r185
-  MakeMap      r194, 4, r186
-  SetIndex     r168, r175, r194
-  Append       r169, r169, r194
+  MakeMap      r192, 4, r184
+  SetIndex     r166, r173, r192
+  Append       r167, r167, r192
+L14:
+  Index        r194, r166, r173
+  Index        r195, r194, r107
+  Append       r196, r195, r170
+  SetIndex     r194, r107, r196
+  Index        r197, r194, r111
+  AddInt       r198, r197, r113
+  SetIndex     r194, r111, r198
+  AddInt       r165, r165, r113
+  Jump         L15
 L13:
-  Index        r196, r168, r175
-  Index        r197, r196, r109
-  Append       r198, r197, r172
-  SetIndex     r196, r109, r198
-  Index        r199, r196, r113
-  AddInt       r200, r199, r115
-  SetIndex     r196, r113, r200
-  AddInt       r167, r167, r115
-  Jump         L14
-L12:
-  Move         r201, r118
-  Len          r202, r169
-L18:
-  LessInt      r203, r201, r202
-  JumpIfFalse  r203, L15
-  Index        r122, r169, r201
+  Move         r199, r116
+  Len          r200, r167
+L19:
+  LessInt      r201, r199, r200
+  JumpIfFalse  r201, L16
+  Index        r120, r167, r199
   // select { class: g.key, total: sum(from x in g select x.itemrevenue) }
-  Move         r205, r10
-  Index        r206, r122, r15
-  Move         r207, r164
-  Move         r208, r177
-  IterPrep     r209, r122
-  Len          r210, r209
-  Move         r211, r118
-L17:
-  LessInt      r212, r211, r210
-  JumpIfFalse  r212, L16
-  Index        r145, r209, r211
-  Index        r214, r145, r16
-  Append       r208, r208, r214
-  AddInt       r211, r211, r115
-  Jump         L17
-L16:
-  Sum          r216, r208
-  Move         r217, r205
-  Move         r218, r206
-  Move         r219, r207
-  Move         r220, r216
-  MakeMap      r221, 2, r217
-  // from f in filtered
-  Append       r163, r163, r221
-  AddInt       r201, r201, r115
+  Const        r203, "class"
+  Index        r204, r120, r15
+  Const        r205, "total"
+  Const        r206, []
+  IterPrep     r207, r120
+  Len          r208, r207
+  Move         r209, r116
+L18:
+  LessInt      r210, r209, r208
+  JumpIfFalse  r210, L17
+  Index        r143, r207, r209
+  Index        r212, r143, r16
+  Append       r206, r206, r212
+  AddInt       r209, r209, r113
   Jump         L18
-L15:
+L17:
+  Sum          r214, r206
+  Move         r215, r203
+  Move         r216, r204
+  Move         r217, r205
+  Move         r218, r214
+  MakeMap      r219, 2, r215
   // from f in filtered
-  Const        r223, []
-  IterPrep     r224, r3
+  Append       r161, r161, r219
+  AddInt       r199, r199, r113
+  Jump         L19
+L16:
+  // from f in filtered
+  Const        r221, []
+  IterPrep     r222, r3
+  Len          r223, r222
+  // join t in class_totals on f.i_class == t.class
+  IterPrep     r224, r161
   Len          r225, r224
-  // join t in class_totals on f.i_class == t.class
-  IterPrep     r226, r163
-  Len          r227, r226
+  // revenueratio: (f.itemrevenue * 100.0) / t.total
+  Const        r226, "revenueratio"
   // from f in filtered
-  EqualInt     r228, r225, r118
-  JumpIfTrue   r228, L19
-  EqualInt     r229, r227, r118
-  JumpIfTrue   r229, L19
-  LessEq       r230, r227, r225
-  JumpIfFalse  r230, L20
+  Const        r227, 0
+L24:
+  LessInt      r228, r227, r223
+  JumpIfFalse  r228, L20
+  Index        r171, r222, r227
   // join t in class_totals on f.i_class == t.class
-  MakeMap      r231, 0, r0
-  Move         r232, r185
+  Const        r230, 0
 L23:
-  LessInt      r233, r232, r227
-  JumpIfFalse  r233, L21
-  Index        r234, r226, r232
-  Index        r236, r234, r10
-  Index        r237, r231, r236
-  Const        r238, nil
-  NotEqual     r239, r237, r238
-  JumpIfTrue   r239, L22
-  MakeList     r240, 0, r0
-  SetIndex     r231, r236, r240
+  LessInt      r231, r230, r225
+  JumpIfFalse  r231, L21
+  Index        r233, r224, r230
+  Index        r234, r171, r11
+  Index        r235, r233, r10
+  Equal        r236, r234, r235
+  JumpIfFalse  r236, L22
+  // i_item_id: f.i_item_id,
+  Const        r237, "i_item_id"
+  Index        r238, r171, r5
+  // i_item_desc: f.i_item_desc,
+  Const        r239, "i_item_desc"
+  Index        r240, r171, r7
+  // i_category: f.i_category,
+  Const        r241, "i_category"
+  Index        r242, r171, r9
+  // i_class: f.i_class,
+  Const        r243, "i_class"
+  Index        r244, r171, r11
+  // i_current_price: f.i_current_price,
+  Const        r245, "i_current_price"
+  Index        r246, r171, r13
+  // itemrevenue: f.itemrevenue,
+  Const        r247, "itemrevenue"
+  Index        r248, r171, r16
+  // revenueratio: (f.itemrevenue * 100.0) / t.total
+  Const        r249, "revenueratio"
+  Index        r250, r171, r16
+  Const        r251, 100
+  MulFloat     r252, r250, r251
+  Index        r253, r233, r162
+  DivFloat     r254, r252, r253
+  // i_item_id: f.i_item_id,
+  Move         r255, r237
+  Move         r256, r238
+  // i_item_desc: f.i_item_desc,
+  Move         r257, r239
+  Move         r258, r240
+  // i_category: f.i_category,
+  Move         r259, r241
+  Move         r260, r242
+  // i_class: f.i_class,
+  Move         r261, r243
+  Move         r262, r244
+  // i_current_price: f.i_current_price,
+  Move         r263, r245
+  Move         r264, r246
+  // itemrevenue: f.itemrevenue,
+  Move         r265, r247
+  Move         r266, r248
+  // revenueratio: (f.itemrevenue * 100.0) / t.total
+  Move         r267, r249
+  Move         r268, r254
+  // select {
+  MakeMap      r269, 7, r255
+  // sort by [f.i_category, f.i_class, f.i_item_id, f.i_item_desc]
+  Index        r271, r171, r9
+  Index        r272, r171, r11
+  Move         r273, r272
+  Index        r274, r171, r5
+  Move         r275, r274
+  Index        r277, r171, r7
+  MakeList     r279, 4, r271
+  // from f in filtered
+  Move         r280, r269
+  MakeList     r281, 2, r279
+  Append       r221, r221, r281
 L22:
-  Index        r237, r231, r236
-  Append       r241, r237, r234
-  SetIndex     r231, r236, r241
-  AddInt       r232, r232, r115
+  // join t in class_totals on f.i_class == t.class
+  AddInt       r230, r230, r113
   Jump         L23
 L21:
   // from f in filtered
-  Move         r242, r23
-L26:
-  LessInt      r243, r242, r225
-  JumpIfFalse  r243, L19
-  Index        r173, r224, r242
-  // join t in class_totals on f.i_class == t.class
-  Index        r245, r173, r11
-  // from f in filtered
-  Index        r246, r231, r245
-  NotEqual     r248, r246, r238
-  JumpIfFalse  r248, L24
-  Len          r249, r246
-  Move         r250, r242
-L25:
-  LessInt      r251, r250, r249
-  JumpIfFalse  r251, L24
-  Index        r235, r246, r250
-  // i_item_id: f.i_item_id,
-  Move         r253, r5
-  Index        r254, r173, r5
-  // i_item_desc: f.i_item_desc,
-  Move         r255, r7
-  Index        r256, r173, r7
-  // i_category: f.i_category,
-  Move         r257, r9
-  Index        r258, r173, r9
-  // i_class: f.i_class,
-  Move         r259, r11
-  Index        r260, r173, r11
-  // i_current_price: f.i_current_price,
-  Move         r261, r13
-  Index        r262, r173, r13
-  // itemrevenue: f.itemrevenue,
-  Move         r263, r16
-  Index        r264, r173, r16
-  // revenueratio: (f.itemrevenue * 100.0) / t.total
-  Const        r265, "revenueratio"
-  Index        r266, r173, r16
-  Const        r267, 100
-  MulFloat     r268, r266, r267
-  Index        r269, r235, r164
-  DivFloat     r270, r268, r269
-  // i_item_id: f.i_item_id,
-  Move         r271, r253
-  Move         r272, r254
-  // i_item_desc: f.i_item_desc,
-  Move         r273, r255
-  Move         r274, r256
-  // i_category: f.i_category,
-  Move         r275, r257
-  Move         r276, r258
-  // i_class: f.i_class,
-  Move         r277, r259
-  Move         r278, r260
-  // i_current_price: f.i_current_price,
-  Move         r279, r261
-  Move         r280, r262
-  // itemrevenue: f.itemrevenue,
-  Move         r281, r263
-  Move         r282, r264
-  // revenueratio: (f.itemrevenue * 100.0) / t.total
-  Move         r283, r265
-  Move         r284, r270
-  // select {
-  MakeMap      r285, 7, r271
-  // sort by [f.i_category, f.i_class, f.i_item_id, f.i_item_desc]
-  Index        r287, r173, r9
-  Index        r288, r173, r11
-  Move         r289, r288
-  Index        r290, r173, r5
-  MakeList     r295, 4, r287
-  // from f in filtered
-  Move         r296, r285
-  MakeList     r297, 2, r295
-  Append       r223, r223, r297
-  AddInt       r250, r250, r115
-  Jump         L25
-L24:
-  AddInt       r242, r242, r115
-  Jump         L26
+  AddInt       r227, r227, r113
+  Jump         L24
 L20:
-  MakeMap      r299, 0, r0
-  Move         r300, r23
-L29:
-  LessInt      r301, r300, r225
-  JumpIfFalse  r301, L27
-  Index        r302, r224, r300
-  // join t in class_totals on f.i_class == t.class
-  Index        r303, r302, r11
-  // from f in filtered
-  Index        r304, r299, r303
-  Move         r305, r238
-  NotEqual     r306, r304, r305
-  JumpIfTrue   r306, L28
-  MakeList     r307, 0, r0
-  SetIndex     r299, r303, r307
-L28:
-  Index        r304, r299, r303
-  Append       r308, r304, r302
-  SetIndex     r299, r303, r308
-  AddInt       r300, r300, r115
-  Jump         L29
-L27:
-  // join t in class_totals on f.i_class == t.class
-  Move         r309, r23
-L33:
-  LessInt      r310, r309, r227
-  JumpIfFalse  r310, L30
-  Index        r235, r226, r309
-  Index        r312, r235, r10
-  Index        r313, r299, r312
-  NotEqual     r315, r313, r305
-  JumpIfFalse  r315, L31
-  Len          r316, r313
-  Move         r317, r309
-L32:
-  LessInt      r318, r317, r316
-  JumpIfFalse  r318, L31
-  Index        r173, r313, r317
-  // i_item_id: f.i_item_id,
-  Move         r320, r253
-  Index        r321, r173, r5
-  // i_item_desc: f.i_item_desc,
-  Move         r322, r255
-  Index        r323, r173, r7
-  // i_category: f.i_category,
-  Move         r324, r257
-  Index        r325, r173, r9
-  // i_class: f.i_class,
-  Move         r326, r259
-  Index        r327, r173, r11
-  // i_current_price: f.i_current_price,
-  Move         r328, r261
-  Index        r329, r173, r13
-  // itemrevenue: f.itemrevenue,
-  Move         r330, r263
-  Index        r331, r173, r16
-  // revenueratio: (f.itemrevenue * 100.0) / t.total
-  Move         r332, r265
-  Index        r333, r173, r16
-  MulFloat     r334, r333, r267
-  Index        r335, r235, r164
-  DivFloat     r336, r334, r335
-  // i_item_id: f.i_item_id,
-  Move         r337, r320
-  Move         r338, r321
-  // i_item_desc: f.i_item_desc,
-  Move         r339, r322
-  Move         r340, r323
-  // i_category: f.i_category,
-  Move         r341, r324
-  Move         r342, r325
-  // i_class: f.i_class,
-  Move         r343, r326
-  Move         r344, r327
-  // i_current_price: f.i_current_price,
-  Move         r345, r328
-  Move         r346, r329
-  // itemrevenue: f.itemrevenue,
-  Move         r347, r330
-  Move         r348, r331
-  // revenueratio: (f.itemrevenue * 100.0) / t.total
-  Move         r349, r332
-  Move         r350, r336
-  // select {
-  MakeMap      r351, 7, r337
   // sort by [f.i_category, f.i_class, f.i_item_id, f.i_item_desc]
-  Index        r353, r173, r9
-  Index        r354, r173, r11
-  Move         r355, r354
-  Index        r356, r173, r5
-  MakeList     r361, 4, r353
-  // from f in filtered
-  Move         r362, r351
-  MakeList     r363, 2, r361
-  Append       r223, r223, r363
-  // join t in class_totals on f.i_class == t.class
-  AddInt       r317, r317, r115
-  Jump         L32
-L31:
-  AddInt       r309, r309, r115
-  Jump         L33
-L30:
-  // sort by [f.i_category, f.i_class, f.i_item_id, f.i_item_desc]
-  Sort         r223, r223
+  Sort         r221, r221
   // json(result)
-  JSON         r223
+  JSON         r221
   // expect result == [
-  Const        r366, [{"i_category": "A", "i_class": "X", "i_current_price": 10, "i_item_desc": "Item One", "i_item_id": "ITEM1", "itemrevenue": 300, "revenueratio": 66.66666666666666}, {"i_category": "A", "i_class": "X", "i_current_price": 20, "i_item_desc": "Item Two", "i_item_id": "ITEM2", "itemrevenue": 150, "revenueratio": 33.33333333333333}]
-  Equal        r367, r223, r366
-  Expect       r367
+  Const        r284, [{"i_category": "A", "i_class": "X", "i_current_price": 10, "i_item_desc": "Item One", "i_item_id": "ITEM1", "itemrevenue": 300, "revenueratio": 66.66666666666666}, {"i_category": "A", "i_class": "X", "i_current_price": 20, "i_item_desc": "Item Two", "i_item_id": "ITEM2", "itemrevenue": 150, "revenueratio": 33.33333333333333}]
+  Equal        r285, r221, r284
+  Expect       r285
   Return       r0

--- a/tests/dataset/tpc-ds/out/q21.ir.out
+++ b/tests/dataset/tpc-ds/out/q21.ir.out
@@ -1,11 +1,11 @@
-func main (regs=316)
+func main (regs=310)
   // let inventory = [
-  Const        r0, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 30, "inv_warehouse_sk": 1}, {"inv_date_sk": 2, "inv_item_sk": 1, "inv_quantity_on_hand": 40, "inv_warehouse_sk": 1}]
-  // let warehouse = [ { w_warehouse_sk: 1, w_warehouse_name: "Main" } ]
-  Const        r1, [{"w_warehouse_name": "Main", "w_warehouse_sk": 1}]
-  // let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
-  Const        r2, [{"i_item_id": "ITEM1", "i_item_sk": 1}]
-  // let date_dim = [ { d_date_sk: 1, d_date: "2000-03-01" }, { d_date_sk: 2, d_date: "2000-03-20" } ]
+  Const        r0, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 30, "inv_warehouse_sk": 1}, {"inv_date_sk": 2, "inv_item_sk": 1, "inv_quantity_on_hand": 40, "inv_warehouse_sk": 1}, {"inv_date_sk": 1, "inv_item_sk": 2, "inv_quantity_on_hand": 20, "inv_warehouse_sk": 2}, {"inv_date_sk": 2, "inv_item_sk": 2, "inv_quantity_on_hand": 20, "inv_warehouse_sk": 2}]
+  // let warehouse = [
+  Const        r1, [{"w_warehouse_name": "Main", "w_warehouse_sk": 1}, {"w_warehouse_name": "Backup", "w_warehouse_sk": 2}]
+  // let item = [
+  Const        r2, [{"i_item_id": "ITEM1", "i_item_sk": 1}, {"i_item_id": "ITEM2", "i_item_sk": 2}]
+  // let date_dim = [
   Const        r3, [{"d_date": "2000-03-01", "d_date_sk": 1}, {"d_date": "2000-03-20", "d_date_sk": 2}]
   // from inv in inventory
   Const        r4, []
@@ -22,19 +22,19 @@ func main (regs=316)
   Const        r12, "inv_quantity_on_hand"
   // from inv in inventory
   MakeMap      r13, 0, r0
-  Move         r14, r4
+  Const        r14, []
   IterPrep     r16, r0
   Len          r17, r16
   Const        r18, 0
-L1:
+L5:
   LessInt      r19, r18, r17
   JumpIfFalse  r19, L0
   Index        r21, r16, r18
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
   IterPrep     r22, r3
   Len          r23, r22
-  Move         r24, r18
-L2:
+  Const        r24, 0
+L4:
   LessInt      r25, r24, r23
   JumpIfFalse  r25, L1
   Index        r27, r22, r24
@@ -56,9 +56,9 @@ L2:
   Move         r39, r27
   MakeMap      r40, 2, r36
   // group by { w: inv.inv_warehouse_sk, i: inv.inv_item_sk } into g
-  Move         r41, r5
+  Const        r41, "w"
   Index        r42, r21, r6
-  Move         r43, r7
+  Const        r43, "i"
   Index        r44, r21, r8
   Move         r45, r41
   Move         r46, r42
@@ -69,17 +69,17 @@ L2:
   In           r51, r50, r13
   JumpIfTrue   r51, L3
   // from inv in inventory
-  Move         r52, r4
+  Const        r52, []
   Const        r53, "__group__"
   Const        r54, true
-  Move         r55, r10
+  Const        r55, "key"
   // group by { w: inv.inv_warehouse_sk, i: inv.inv_item_sk } into g
   Move         r56, r49
   // from inv in inventory
   Const        r57, "items"
   Move         r58, r52
   Const        r59, "count"
-  Move         r60, r18
+  Const        r60, 0
   Move         r61, r53
   Move         r62, r54
   Move         r63, r55
@@ -92,48 +92,53 @@ L2:
   SetIndex     r13, r50, r69
   Append       r14, r14, r69
 L3:
-  Move         r71, r57
+  Const        r71, "items"
   Index        r72, r13, r50
   Index        r73, r72, r71
   Append       r74, r73, r40
   SetIndex     r72, r71, r74
-  Move         r75, r59
+  Const        r75, "count"
   Index        r76, r72, r75
   Const        r77, 1
   AddInt       r78, r76, r77
   SetIndex     r72, r75, r78
+L2:
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
-  Jump         L2
-L0:
+  AddInt       r24, r24, r77
+  Jump         L4
+L1:
   // from inv in inventory
-  Move         r80, r60
+  AddInt       r18, r18, r77
+  Jump         L5
+L0:
+  Const        r80, 0
   Move         r79, r80
   Len          r81, r14
-L7:
+L9:
   LessInt      r82, r79, r81
-  JumpIfFalse  r82, L4
+  JumpIfFalse  r82, L6
   Index        r84, r14, r79
   // select { w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand) }
-  Move         r85, r5
+  Const        r85, "w"
   Index        r86, r84, r10
   Index        r87, r86, r5
-  Move         r88, r7
+  Const        r88, "i"
   Index        r89, r84, r10
   Index        r90, r89, r7
-  Move         r91, r11
-  Move         r92, r52
+  Const        r91, "qty"
+  Const        r92, []
   IterPrep     r93, r84
   Len          r94, r93
   Move         r95, r80
-L6:
+L8:
   LessInt      r96, r95, r94
-  JumpIfFalse  r96, L5
+  JumpIfFalse  r96, L7
   Index        r98, r93, r95
   Index        r99, r98, r12
   Append       r92, r92, r99
   AddInt       r95, r95, r77
-  Jump         L6
-L5:
+  Jump         L8
+L7:
   Sum          r101, r92
   Move         r102, r85
   Move         r103, r87
@@ -145,315 +150,312 @@ L5:
   // from inv in inventory
   Append       r4, r4, r108
   AddInt       r79, r79, r77
-  Jump         L7
-L4:
+  Jump         L9
+L6:
   // from inv in inventory
   Const        r110, []
   MakeMap      r111, 0, r0
-  Move         r112, r110
+  Const        r112, []
   IterPrep     r114, r0
   Len          r115, r114
-  Move         r116, r18
-L13:
+  Const        r116, 0
+L15:
   LessInt      r117, r116, r115
-  JumpIfFalse  r117, L8
+  JumpIfFalse  r117, L10
   Index        r21, r114, r116
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
   IterPrep     r119, r3
   Len          r120, r119
-  Move         r121, r116
-L12:
+  Const        r121, 0
+L14:
   LessInt      r122, r121, r120
-  JumpIfFalse  r122, L9
+  JumpIfFalse  r122, L11
   Index        r124, r119, r121
   Index        r125, r21, r28
   Index        r126, r124, r30
   Equal        r127, r125, r126
-  JumpIfFalse  r127, L10
+  JumpIfFalse  r127, L12
   // where d.d_date >= "2000-03-15"
   Index        r128, r124, r9
   LessEq       r129, r34, r128
-  JumpIfFalse  r129, L10
+  JumpIfFalse  r129, L12
   // from inv in inventory
-  Move         r130, r36
-  Move         r131, r21
-  Move         r132, r38
-  Move         r133, r124
-  MakeMap      r134, 2, r130
+  Move         r130, r21
+  Move         r131, r124
+  MakeMap      r132, 2, r36
   // group by { w: inv.inv_warehouse_sk, i: inv.inv_item_sk } into g
-  Move         r135, r85
-  Index        r136, r21, r6
-  Move         r137, r88
-  Index        r138, r21, r8
+  Const        r133, "w"
+  Index        r134, r21, r6
+  Const        r135, "i"
+  Index        r136, r21, r8
+  Move         r137, r133
+  Move         r138, r134
   Move         r139, r135
   Move         r140, r136
-  Move         r141, r137
-  Move         r142, r138
-  MakeMap      r143, 2, r139
-  Str          r144, r143
-  In           r145, r144, r111
-  JumpIfTrue   r145, L11
+  MakeMap      r141, 2, r137
+  Str          r142, r141
+  In           r143, r142, r111
+  JumpIfTrue   r143, L13
   // from inv in inventory
-  Move         r146, r110
-  Move         r147, r53
-  Move         r148, r54
-  Move         r149, r10
+  Const        r144, []
+  Const        r145, "__group__"
+  Const        r146, true
+  Const        r147, "key"
   // group by { w: inv.inv_warehouse_sk, i: inv.inv_item_sk } into g
-  Move         r150, r143
+  Move         r148, r141
   // from inv in inventory
-  Move         r151, r57
-  Move         r152, r146
-  Move         r153, r59
-  Move         r154, r116
+  Const        r149, "items"
+  Move         r150, r144
+  Const        r151, "count"
+  Const        r152, 0
+  Move         r153, r145
+  Move         r154, r146
   Move         r155, r147
   Move         r156, r148
   Move         r157, r149
   Move         r158, r150
   Move         r159, r151
   Move         r160, r152
-  Move         r161, r153
-  Move         r162, r154
-  MakeMap      r163, 4, r155
-  SetIndex     r111, r144, r163
-  Append       r112, r112, r163
-L11:
-  Index        r165, r111, r144
-  Index        r166, r165, r71
-  Append       r167, r166, r134
-  SetIndex     r165, r71, r167
-  Index        r168, r165, r75
-  AddInt       r169, r168, r77
-  SetIndex     r165, r75, r169
-L10:
+  MakeMap      r161, 4, r153
+  SetIndex     r111, r142, r161
+  Append       r112, r112, r161
+L13:
+  Index        r163, r111, r142
+  Index        r164, r163, r71
+  Append       r165, r164, r132
+  SetIndex     r163, r71, r165
+  Index        r166, r163, r75
+  AddInt       r167, r166, r77
+  SetIndex     r163, r75, r167
+L12:
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
   AddInt       r121, r121, r77
-  Jump         L12
-L9:
+  Jump         L14
+L11:
   // from inv in inventory
   AddInt       r116, r116, r77
-  Jump         L13
-L8:
-  Move         r170, r80
-  Len          r171, r112
-L17:
-  LessInt      r172, r170, r171
-  JumpIfFalse  r172, L14
-  Index        r84, r112, r170
-  // select { w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand) }
-  Move         r174, r5
-  Index        r175, r84, r10
-  Index        r176, r175, r5
-  Move         r177, r7
-  Index        r178, r84, r10
-  Index        r179, r178, r7
-  Move         r180, r11
-  Move         r181, r146
-  IterPrep     r182, r84
-  Len          r183, r182
-  Move         r184, r80
-L16:
-  LessInt      r185, r184, r183
-  JumpIfFalse  r185, L15
-  Index        r98, r182, r184
-  Index        r187, r98, r12
-  Append       r181, r181, r187
-  AddInt       r184, r184, r77
-  Jump         L16
-L15:
-  Sum          r189, r181
-  Move         r190, r174
-  Move         r191, r176
-  Move         r192, r177
-  Move         r193, r179
-  Move         r194, r180
-  Move         r195, r189
-  MakeMap      r196, 3, r190
-  // from inv in inventory
-  Append       r110, r110, r196
-  AddInt       r170, r170, r77
-  Jump         L17
-L14:
-  // from b in before
-  Const        r198, []
-  // w_name: w.w_warehouse_name,
-  Const        r199, "w_name"
-  Const        r200, "w_warehouse_name"
-  // i_id: it.i_item_id,
-  Const        r201, "i_id"
-  Const        r202, "i_item_id"
-  // before_qty: b.qty,
-  Const        r203, "before_qty"
-  // after_qty: a.qty,
-  Const        r204, "after_qty"
-  // ratio: a.qty / b.qty
-  Const        r205, "ratio"
-  // from b in before
-  IterPrep     r206, r4
-  Len          r207, r206
-  Move         r208, r80
-L27:
-  LessInt      r209, r208, r207
-  JumpIfFalse  r209, L18
-  Index        r211, r206, r208
-  // join a in after on b.w == a.w && b.i == a.i
-  IterPrep     r212, r110
-  Len          r213, r212
-  Move         r214, r80
-L26:
-  LessInt      r215, r214, r213
-  JumpIfFalse  r215, L19
-  Index        r217, r212, r214
-  Index        r218, r211, r5
-  Index        r219, r217, r5
-  Equal        r220, r218, r219
-  Index        r221, r211, r7
-  Index        r222, r217, r7
-  Equal        r223, r221, r222
-  Move         r224, r220
-  JumpIfFalse  r224, L20
-  Move         r224, r223
-L20:
-  JumpIfFalse  r224, L21
-  // join w in warehouse on w.w_warehouse_sk == b.w
-  IterPrep     r225, r1
-  Len          r226, r225
-  Const        r227, "w_warehouse_sk"
-  Move         r228, r80
-L25:
-  LessInt      r229, r228, r226
-  JumpIfFalse  r229, L21
-  Index        r231, r225, r228
-  Index        r232, r231, r227
-  Index        r233, r211, r5
-  Equal        r234, r232, r233
-  JumpIfFalse  r234, L22
-  // join it in item on it.i_item_sk == b.i
-  IterPrep     r235, r2
-  Len          r236, r235
-  Const        r237, "i_item_sk"
-  Move         r238, r80
-L24:
-  LessInt      r239, r238, r236
-  JumpIfFalse  r239, L22
-  Index        r241, r235, r238
-  Index        r242, r241, r237
-  Index        r243, r211, r7
-  Equal        r244, r242, r243
-  JumpIfFalse  r244, L23
-  // w_name: w.w_warehouse_name,
-  Move         r245, r199
-  Index        r246, r231, r200
-  // i_id: it.i_item_id,
-  Move         r247, r201
-  Index        r248, r241, r202
-  // before_qty: b.qty,
-  Move         r249, r203
-  Index        r250, r211, r11
-  // after_qty: a.qty,
-  Move         r251, r204
-  Index        r252, r217, r11
-  // ratio: a.qty / b.qty
-  Move         r253, r205
-  Index        r254, r217, r11
-  Index        r255, r211, r11
-  Div          r256, r254, r255
-  // w_name: w.w_warehouse_name,
-  Move         r257, r245
-  Move         r258, r246
-  // i_id: it.i_item_id,
-  Move         r259, r247
-  Move         r260, r248
-  // before_qty: b.qty,
-  Move         r261, r249
-  Move         r262, r250
-  // after_qty: a.qty,
-  Move         r263, r251
-  Move         r264, r252
-  // ratio: a.qty / b.qty
-  Move         r265, r253
-  Move         r266, r256
-  // select {
-  MakeMap      r267, 5, r257
-  // from b in before
-  Append       r198, r198, r267
-L23:
-  // join it in item on it.i_item_sk == b.i
-  Add          r238, r238, r77
-  Jump         L24
-L22:
-  // join w in warehouse on w.w_warehouse_sk == b.w
-  Add          r228, r228, r77
-  Jump         L25
-L21:
-  // join a in after on b.w == a.w && b.i == a.i
-  Add          r214, r214, r77
-  Jump         L26
+  Jump         L15
+L10:
+  Move         r168, r80
+  Len          r169, r112
 L19:
-  // from b in before
-  AddInt       r208, r208, r77
-  Jump         L27
+  LessInt      r170, r168, r169
+  JumpIfFalse  r170, L16
+  Index        r84, r112, r168
+  // select { w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand) }
+  Const        r172, "w"
+  Index        r173, r84, r10
+  Index        r174, r173, r5
+  Const        r175, "i"
+  Index        r176, r84, r10
+  Index        r177, r176, r7
+  Const        r178, "qty"
+  Const        r179, []
+  IterPrep     r180, r84
+  Len          r181, r180
+  Move         r182, r80
 L18:
-  // from r in joined
-  Const        r269, []
-  // select { w_warehouse_name: r.w_name, i_item_id: r.i_id, inv_before: r.before_qty, inv_after: r.after_qty }
-  Const        r270, "inv_before"
-  Const        r271, "inv_after"
-  // from r in joined
-  IterPrep     r272, r198
-  Len          r273, r272
-  Move         r274, r80
-L31:
-  LessInt      r275, r274, r273
-  JumpIfFalse  r275, L28
-  Index        r277, r272, r274
-  // where r.ratio >= (2.0 / 3.0) && r.ratio <= (3.0 / 2.0)
-  Index        r278, r277, r205
-  Const        r281, 0.6666666666666666
-  LessEqFloat  r282, r281, r278
-  Index        r283, r277, r205
-  Const        r284, 1.5
-  LessEqFloat  r285, r283, r284
-  Move         r286, r282
-  JumpIfFalse  r286, L29
-  Move         r286, r285
+  LessInt      r183, r182, r181
+  JumpIfFalse  r183, L17
+  Index        r98, r180, r182
+  Index        r185, r98, r12
+  Append       r179, r179, r185
+  AddInt       r182, r182, r77
+  Jump         L18
+L17:
+  Sum          r187, r179
+  Move         r188, r172
+  Move         r189, r174
+  Move         r190, r175
+  Move         r191, r177
+  Move         r192, r178
+  Move         r193, r187
+  MakeMap      r194, 3, r188
+  // from inv in inventory
+  Append       r110, r110, r194
+  AddInt       r168, r168, r77
+  Jump         L19
+L16:
+  // from b in before
+  Const        r196, []
+  // w_name: w.w_warehouse_name,
+  Const        r197, "w_name"
+  Const        r198, "w_warehouse_name"
+  // i_id: it.i_item_id,
+  Const        r199, "i_id"
+  Const        r200, "i_item_id"
+  // before_qty: b.qty,
+  Const        r201, "before_qty"
+  // after_qty: a.qty,
+  Const        r202, "after_qty"
+  // ratio: a.qty / b.qty
+  Const        r203, "ratio"
+  // from b in before
+  IterPrep     r204, r4
+  Len          r205, r204
+  Move         r206, r80
 L29:
-  JumpIfFalse  r286, L30
+  LessInt      r207, r206, r205
+  JumpIfFalse  r207, L20
+  Index        r209, r204, r206
+  // join a in after on b.w == a.w && b.i == a.i
+  IterPrep     r210, r110
+  Len          r211, r210
+  Move         r212, r80
+L28:
+  LessInt      r213, r212, r211
+  JumpIfFalse  r213, L21
+  Index        r215, r210, r212
+  Index        r216, r209, r5
+  Index        r217, r215, r5
+  Equal        r218, r216, r217
+  Index        r219, r209, r7
+  Index        r220, r215, r7
+  Equal        r221, r219, r220
+  JumpIfFalse  r218, L22
+  Move         r218, r221
+L22:
+  JumpIfFalse  r218, L23
+  // join w in warehouse on w.w_warehouse_sk == b.w
+  IterPrep     r222, r1
+  Len          r223, r222
+  Const        r224, "w_warehouse_sk"
+  Move         r225, r80
+L27:
+  LessInt      r226, r225, r223
+  JumpIfFalse  r226, L23
+  Index        r228, r222, r225
+  Index        r229, r228, r224
+  Index        r230, r209, r5
+  Equal        r231, r229, r230
+  JumpIfFalse  r231, L24
+  // join it in item on it.i_item_sk == b.i
+  IterPrep     r232, r2
+  Len          r233, r232
+  Const        r234, "i_item_sk"
+  Move         r235, r80
+L26:
+  LessInt      r236, r235, r233
+  JumpIfFalse  r236, L24
+  Index        r238, r232, r235
+  Index        r239, r238, r234
+  Index        r240, r209, r7
+  Equal        r241, r239, r240
+  JumpIfFalse  r241, L25
+  // w_name: w.w_warehouse_name,
+  Const        r242, "w_name"
+  Index        r243, r228, r198
+  // i_id: it.i_item_id,
+  Const        r244, "i_id"
+  Index        r245, r238, r200
+  // before_qty: b.qty,
+  Const        r246, "before_qty"
+  Index        r247, r209, r11
+  // after_qty: a.qty,
+  Const        r248, "after_qty"
+  Index        r249, r215, r11
+  // ratio: a.qty / b.qty
+  Const        r250, "ratio"
+  Index        r251, r215, r11
+  Index        r252, r209, r11
+  Div          r253, r251, r252
+  // w_name: w.w_warehouse_name,
+  Move         r254, r242
+  Move         r255, r243
+  // i_id: it.i_item_id,
+  Move         r256, r244
+  Move         r257, r245
+  // before_qty: b.qty,
+  Move         r258, r246
+  Move         r259, r247
+  // after_qty: a.qty,
+  Move         r260, r248
+  Move         r261, r249
+  // ratio: a.qty / b.qty
+  Move         r262, r250
+  Move         r263, r253
+  // select {
+  MakeMap      r264, 5, r254
+  // from b in before
+  Append       r196, r196, r264
+L25:
+  // join it in item on it.i_item_sk == b.i
+  Add          r235, r235, r77
+  Jump         L26
+L24:
+  // join w in warehouse on w.w_warehouse_sk == b.w
+  Add          r225, r225, r77
+  Jump         L27
+L23:
+  // join a in after on b.w == a.w && b.i == a.i
+  Add          r212, r212, r77
+  Jump         L28
+L21:
+  // from b in before
+  AddInt       r206, r206, r77
+  Jump         L29
+L20:
+  // from r in joined
+  Const        r266, []
   // select { w_warehouse_name: r.w_name, i_item_id: r.i_id, inv_before: r.before_qty, inv_after: r.after_qty }
-  Move         r287, r200
-  Index        r288, r277, r199
-  Move         r289, r202
-  Index        r290, r277, r201
-  Move         r291, r270
-  Index        r292, r277, r203
-  Move         r293, r271
-  Index        r294, r277, r204
+  Const        r267, "inv_before"
+  Const        r268, "inv_after"
+  // from r in joined
+  IterPrep     r269, r196
+  Len          r270, r269
+  Move         r271, r80
+L33:
+  LessInt      r272, r271, r270
+  JumpIfFalse  r272, L30
+  Index        r274, r269, r271
+  // where r.ratio >= (2.0 / 3.0) && r.ratio <= (3.0 / 2.0)
+  Index        r275, r274, r203
+  Const        r276, 0.6666666666666666
+  LessEqFloat  r277, r276, r275
+  Index        r278, r274, r203
+  Const        r279, 1.5
+  LessEqFloat  r280, r278, r279
+  JumpIfFalse  r277, L31
+  Move         r277, r280
+L31:
+  JumpIfFalse  r277, L32
+  // select { w_warehouse_name: r.w_name, i_item_id: r.i_id, inv_before: r.before_qty, inv_after: r.after_qty }
+  Const        r281, "w_warehouse_name"
+  Index        r282, r274, r197
+  Const        r283, "i_item_id"
+  Index        r284, r274, r199
+  Const        r285, "inv_before"
+  Index        r286, r274, r201
+  Const        r287, "inv_after"
+  Index        r288, r274, r202
+  Move         r289, r281
+  Move         r290, r282
+  Move         r291, r283
+  Move         r292, r284
+  Move         r293, r285
+  Move         r294, r286
   Move         r295, r287
   Move         r296, r288
-  Move         r297, r289
-  Move         r298, r290
-  Move         r299, r291
-  Move         r300, r292
-  Move         r301, r293
-  Move         r302, r294
-  MakeMap      r303, 4, r295
+  MakeMap      r297, 4, r289
   // sort by [r.w_name, r.i_id]
-  Index        r305, r277, r199
-  Index        r306, r277, r201
-  MakeList     r309, 2, r305
+  Index        r299, r274, r197
+  Index        r300, r274, r199
+  Move         r301, r300
+  MakeList     r303, 2, r299
   // from r in joined
-  Move         r310, r303
-  MakeList     r311, 2, r309
-  Append       r269, r269, r311
+  Move         r304, r297
+  MakeList     r305, 2, r303
+  Append       r266, r266, r305
+L32:
+  AddInt       r271, r271, r77
+  Jump         L33
 L30:
-  AddInt       r274, r274, r77
-  Jump         L31
-L28:
   // sort by [r.w_name, r.i_id]
-  Sort         r269, r269
+  Sort         r266, r266
   // json(result)
-  JSON         r269
+  JSON         r266
   // expect result == [
-  Const        r314, [{"i_item_id": "ITEM1", "inv_after": 40, "inv_before": 30, "w_warehouse_name": "Main"}]
-  Equal        r315, r269, r314
-  Expect       r315
+  Const        r308, [{"i_item_id": "ITEM1", "inv_after": 40, "inv_before": 30, "w_warehouse_name": "Main"}]
+  Equal        r309, r266, r308
+  Expect       r309
   Return       r0

--- a/tests/dataset/tpc-ds/out/q22.ir.out
+++ b/tests/dataset/tpc-ds/out/q22.ir.out
@@ -1,10 +1,10 @@
-func main (regs=149)
+func main (regs=148)
   // let inventory = [
-  Const        r0, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 10}, {"inv_date_sk": 2, "inv_item_sk": 1, "inv_quantity_on_hand": 20}]
-  // let date_dim = [ { d_date_sk: 1, d_month_seq: 0 }, { d_date_sk: 2, d_month_seq: 1 } ]
-  Const        r1, [{"d_date_sk": 1, "d_month_seq": 0}, {"d_date_sk": 2, "d_month_seq": 1}]
+  Const        r0, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 10}, {"inv_date_sk": 2, "inv_item_sk": 1, "inv_quantity_on_hand": 20}, {"inv_date_sk": 3, "inv_item_sk": 1, "inv_quantity_on_hand": 10}, {"inv_date_sk": 4, "inv_item_sk": 1, "inv_quantity_on_hand": 20}, {"inv_date_sk": 1, "inv_item_sk": 2, "inv_quantity_on_hand": 50}]
+  // let date_dim = [
+  Const        r1, [{"d_date_sk": 1, "d_month_seq": 0}, {"d_date_sk": 2, "d_month_seq": 1}, {"d_date_sk": 3, "d_month_seq": 2}, {"d_date_sk": 4, "d_month_seq": 3}]
   // let item = [
-  Const        r2, [{"i_brand": "Brand1", "i_category": "Cat1", "i_class": "Class1", "i_item_sk": 1, "i_product_name": "Prod1"}]
+  Const        r2, [{"i_brand": "Brand1", "i_category": "Cat1", "i_class": "Class1", "i_item_sk": 1, "i_product_name": "Prod1"}, {"i_brand": "Brand2", "i_category": "Cat2", "i_class": "Class2", "i_item_sk": 2, "i_product_name": "Prod2"}]
   // from inv in inventory
   Const        r3, []
   // product_name: i.i_product_name,
@@ -28,19 +28,19 @@ func main (regs=149)
   Const        r15, "inv_quantity_on_hand"
   // from inv in inventory
   MakeMap      r16, 0, r0
-  Move         r17, r3
+  Const        r17, []
   IterPrep     r19, r0
   Len          r20, r19
   Const        r21, 0
-L1:
+L8:
   LessInt      r22, r21, r20
   JumpIfFalse  r22, L0
   Index        r24, r19, r21
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
   IterPrep     r25, r1
   Len          r26, r25
-  Move         r27, r21
-L2:
+  Const        r27, 0
+L7:
   LessInt      r28, r27, r26
   JumpIfFalse  r28, L1
   Index        r30, r25, r27
@@ -53,7 +53,7 @@ L2:
   // join i in item on inv.inv_item_sk == i.i_item_sk
   IterPrep     r36, r2
   Len          r37, r36
-  Move         r38, r21
+  Const        r38, 0
 L6:
   LessInt      r39, r38, r37
   JumpIfFalse  r39, L2
@@ -66,65 +66,65 @@ L6:
   JumpIfFalse  r46, L3
   // where d.d_month_seq >= 0 && d.d_month_seq <= 11
   Index        r47, r30, r12
-  Move         r48, r38
+  Const        r48, 0
   LessEq       r49, r48, r47
   Index        r50, r30, r12
   Const        r51, 11
   LessEq       r52, r50, r51
-  Move         r53, r49
-  JumpIfFalse  r53, L4
-  Move         r53, r52
+  JumpIfFalse  r49, L4
+  Move         r49, r52
 L4:
-  JumpIfFalse  r53, L3
+  JumpIfFalse  r49, L3
   // from inv in inventory
-  Const        r54, "inv"
-  Move         r55, r24
-  Const        r56, "d"
-  Move         r57, r30
-  Const        r58, "i"
-  Move         r59, r41
-  MakeMap      r60, 3, r54
+  Const        r53, "inv"
+  Move         r54, r24
+  Const        r55, "d"
+  Move         r56, r30
+  Const        r57, "i"
+  Move         r58, r41
+  MakeMap      r59, 3, r53
   // product_name: i.i_product_name,
-  Move         r61, r4
-  Index        r62, r41, r5
+  Const        r60, "product_name"
+  Index        r61, r41, r5
   // brand: i.i_brand,
-  Move         r63, r6
-  Index        r64, r41, r7
+  Const        r62, "brand"
+  Index        r63, r41, r7
   // class: i.i_class,
-  Move         r65, r8
-  Index        r66, r41, r9
+  Const        r64, "class"
+  Index        r65, r41, r9
   // category: i.i_category
-  Move         r67, r10
-  Index        r68, r41, r11
+  Const        r66, "category"
+  Index        r67, r41, r11
   // product_name: i.i_product_name,
+  Move         r68, r60
   Move         r69, r61
-  Move         r70, r62
   // brand: i.i_brand,
+  Move         r70, r62
   Move         r71, r63
-  Move         r72, r64
   // class: i.i_class,
+  Move         r72, r64
   Move         r73, r65
-  Move         r74, r66
   // category: i.i_category
+  Move         r74, r66
   Move         r75, r67
-  Move         r76, r68
   // group by {
-  MakeMap      r77, 4, r69
-  Str          r78, r77
-  In           r79, r78, r16
-  JumpIfTrue   r79, L5
+  MakeMap      r76, 4, r68
+  Str          r77, r76
+  In           r78, r77, r16
+  JumpIfTrue   r78, L5
   // from inv in inventory
-  Move         r80, r3
-  Const        r81, "__group__"
-  Const        r82, true
-  Move         r83, r13
+  Const        r79, []
+  Const        r80, "__group__"
+  Const        r81, true
+  Const        r82, "key"
   // group by {
-  Move         r84, r77
+  Move         r83, r76
   // from inv in inventory
-  Const        r85, "items"
-  Move         r86, r80
-  Const        r87, "count"
-  Move         r88, r21
+  Const        r84, "items"
+  Move         r85, r79
+  Const        r86, "count"
+  Const        r87, 0
+  Move         r88, r80
   Move         r89, r81
   Move         r90, r82
   Move         r91, r83
@@ -132,91 +132,97 @@ L4:
   Move         r93, r85
   Move         r94, r86
   Move         r95, r87
-  Move         r96, r88
-  MakeMap      r97, 4, r89
-  SetIndex     r16, r78, r97
-  Append       r17, r17, r97
+  MakeMap      r96, 4, r88
+  SetIndex     r16, r77, r96
+  Append       r17, r17, r96
 L5:
-  Move         r99, r85
-  Index        r100, r16, r78
-  Index        r101, r100, r99
-  Append       r102, r101, r60
-  SetIndex     r100, r99, r102
-  Move         r103, r87
-  Index        r104, r100, r103
-  Const        r105, 1
-  AddInt       r106, r104, r105
-  SetIndex     r100, r103, r106
+  Const        r98, "items"
+  Index        r99, r16, r77
+  Index        r100, r99, r98
+  Append       r101, r100, r59
+  SetIndex     r99, r98, r101
+  Const        r102, "count"
+  Index        r103, r99, r102
+  Const        r104, 1
+  AddInt       r105, r103, r104
+  SetIndex     r99, r102, r105
 L3:
   // join i in item on inv.inv_item_sk == i.i_item_sk
-  AddInt       r38, r38, r105
+  AddInt       r38, r38, r104
   Jump         L6
+L2:
+  // join d in date_dim on inv.inv_date_sk == d.d_date_sk
+  AddInt       r27, r27, r104
+  Jump         L7
+L1:
+  // from inv in inventory
+  AddInt       r21, r21, r104
+  Jump         L8
 L0:
-  // from inv in inventory
-  Move         r107, r48
-  Len          r108, r17
+  Move         r106, r48
+  Len          r107, r17
+L12:
+  LessInt      r108, r106, r107
+  JumpIfFalse  r108, L9
+  Index        r110, r17, r106
+  // i_product_name: g.key.product_name,
+  Const        r111, "i_product_name"
+  Index        r112, r110, r13
+  Index        r113, r112, r4
+  // i_brand: g.key.brand,
+  Const        r114, "i_brand"
+  Index        r115, r110, r13
+  Index        r116, r115, r6
+  // i_class: g.key.class,
+  Const        r117, "i_class"
+  Index        r118, r110, r13
+  Index        r119, r118, r8
+  // i_category: g.key.category,
+  Const        r120, "i_category"
+  Index        r121, r110, r13
+  Index        r122, r121, r10
+  // qoh: avg(from x in g select x.inv_quantity_on_hand)
+  Const        r123, "qoh"
+  Const        r124, []
+  IterPrep     r125, r110
+  Len          r126, r125
+  Move         r127, r48
+L11:
+  LessInt      r128, r127, r126
+  JumpIfFalse  r128, L10
+  Index        r130, r125, r127
+  Index        r131, r130, r15
+  Append       r124, r124, r131
+  AddInt       r127, r127, r104
+  Jump         L11
 L10:
-  LessInt      r109, r107, r108
-  JumpIfFalse  r109, L7
-  Index        r111, r17, r107
+  Avg          r133, r124
   // i_product_name: g.key.product_name,
-  Move         r112, r5
-  Index        r113, r111, r13
-  Index        r114, r113, r4
+  Move         r134, r111
+  Move         r135, r113
   // i_brand: g.key.brand,
-  Move         r115, r7
-  Index        r116, r111, r13
-  Index        r117, r116, r6
-  // i_class: g.key.class,
-  Move         r118, r9
-  Index        r119, r111, r13
-  Index        r120, r119, r8
-  // i_category: g.key.category,
-  Move         r121, r11
-  Index        r122, r111, r13
-  Index        r123, r122, r10
-  // qoh: avg(from x in g select x.inv_quantity_on_hand)
-  Move         r124, r14
-  Move         r125, r80
-  IterPrep     r126, r111
-  Len          r127, r126
-  Move         r128, r48
-L9:
-  LessInt      r129, r128, r127
-  JumpIfFalse  r129, L8
-  Index        r131, r126, r128
-  Index        r132, r131, r15
-  Append       r125, r125, r132
-  AddInt       r128, r128, r105
-  Jump         L9
-L8:
-  Avg          r134, r125
-  // i_product_name: g.key.product_name,
-  Move         r135, r112
   Move         r136, r114
-  // i_brand: g.key.brand,
-  Move         r137, r115
-  Move         r138, r117
+  Move         r137, r116
   // i_class: g.key.class,
-  Move         r139, r118
-  Move         r140, r120
+  Move         r138, r117
+  Move         r139, r119
   // i_category: g.key.category,
-  Move         r141, r121
-  Move         r142, r123
+  Move         r140, r120
+  Move         r141, r122
   // qoh: avg(from x in g select x.inv_quantity_on_hand)
-  Move         r143, r124
-  Move         r144, r134
+  Move         r142, r123
+  Move         r143, r133
   // select {
-  MakeMap      r145, 5, r135
+  MakeMap      r144, 5, r134
   // from inv in inventory
-  Append       r3, r3, r145
-  AddInt       r107, r107, r105
-  Jump         L10
-L7:
+  Append       r3, r3, r144
+  AddInt       r106, r106, r104
+  Jump         L12
+L9:
   // json(qoh)
   JSON         r3
   // expect qoh == [
-  Const        r147, [{"i_brand": "Brand1", "i_category": "Cat1", "i_class": "Class1", "i_product_name": "Prod1", "qoh": 15}]
-  Equal        r148, r3, r147
-  Expect       r148
+  Const        r146, [{"i_brand": "Brand1", "i_category": "Cat1", "i_class": "Class1", "i_product_name": "Prod1", "qoh": 15}]
+  Equal        r147, r3, r146
+  Expect       r147
   Return       r0

--- a/tests/dataset/tpc-ds/out/q23.ir.out
+++ b/tests/dataset/tpc-ds/out/q23.ir.out
@@ -1,29 +1,419 @@
-func main (regs=16)
-  // let t = [{id: 1, val: 23}]
-  Const        r0, [{"id": 1, "val": 23}]
-  // let vals = from r in t select r.val
-  Const        r1, []
-  Const        r2, "val"
-  IterPrep     r3, r0
-  Len          r4, r3
-  Const        r6, 0
-  Move         r5, r6
+func main (regs=260)
+  // let store_sales = [
+  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}, {"ss_customer_sk": 1, "ss_item_sk": 1, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}, {"ss_customer_sk": 1, "ss_item_sk": 1, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}, {"ss_customer_sk": 1, "ss_item_sk": 1, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}, {"ss_customer_sk": 1, "ss_item_sk": 1, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}, {"ss_customer_sk": 2, "ss_item_sk": 2, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}, {"ss_customer_sk": 2, "ss_item_sk": 2, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}, {"ss_customer_sk": 2, "ss_item_sk": 2, "ss_quantity": 1, "ss_sales_price": 10, "ss_sold_date_sk": 1}]
+  // let date_dim = [ { d_date_sk: 1, d_year: 2000, d_moy: 1 } ]
+  Const        r1, [{"d_date_sk": 1, "d_moy": 1, "d_year": 2000}]
+  // let item = [ { i_item_sk: 1 }, { i_item_sk: 2 } ]
+  Const        r2, [{"i_item_sk": 1}, {"i_item_sk": 2}]
+  // let catalog_sales = [
+  Const        r3, [{"cs_bill_customer_sk": 1, "cs_item_sk": 1, "cs_list_price": 10, "cs_quantity": 2, "cs_sold_date_sk": 1}, {"cs_bill_customer_sk": 2, "cs_item_sk": 2, "cs_list_price": 10, "cs_quantity": 2, "cs_sold_date_sk": 1}]
+  // let web_sales = [
+  Const        r4, [{"ws_bill_customer_sk": 1, "ws_item_sk": 1, "ws_list_price": 10, "ws_quantity": 3, "ws_sold_date_sk": 1}, {"ws_bill_customer_sk": 2, "ws_item_sk": 2, "ws_list_price": 10, "ws_quantity": 1, "ws_sold_date_sk": 1}]
+  // from ss in store_sales
+  Const        r5, []
+  // group by { item_sk: i.i_item_sk, date_sk: d.d_date_sk } into g
+  Const        r6, "item_sk"
+  Const        r7, "i_item_sk"
+  Const        r8, "date_sk"
+  Const        r9, "d_date_sk"
+  // where d.d_year == 2000
+  Const        r10, "d_year"
+  // select g.key.item_sk
+  Const        r11, "key"
+  // from ss in store_sales
+  MakeMap      r12, 0, r0
+  Const        r13, []
+  IterPrep     r15, r0
+  Len          r16, r15
+  Const        r17, 0
+L7:
+  LessInt      r18, r17, r16
+  JumpIfFalse  r18, L0
+  Index        r20, r15, r17
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r21, r1
+  Len          r22, r21
+  Const        r23, 0
+L6:
+  LessInt      r24, r23, r22
+  JumpIfFalse  r24, L1
+  Index        r26, r21, r23
+  Const        r27, "ss_sold_date_sk"
+  Index        r28, r20, r27
+  Index        r29, r26, r9
+  Equal        r30, r28, r29
+  JumpIfFalse  r30, L2
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r31, r2
+  Len          r32, r31
+  Const        r33, 0
+L5:
+  LessInt      r34, r33, r32
+  JumpIfFalse  r34, L2
+  Index        r36, r31, r33
+  Const        r37, "ss_item_sk"
+  Index        r38, r20, r37
+  Index        r39, r36, r7
+  Equal        r40, r38, r39
+  JumpIfFalse  r40, L3
+  // where d.d_year == 2000
+  Index        r41, r26, r10
+  Const        r42, 2000
+  Equal        r43, r41, r42
+  JumpIfFalse  r43, L3
+  // from ss in store_sales
+  Const        r44, "ss"
+  Move         r45, r20
+  Const        r46, "d"
+  Move         r47, r26
+  Const        r48, "i"
+  Move         r49, r36
+  MakeMap      r50, 3, r44
+  // group by { item_sk: i.i_item_sk, date_sk: d.d_date_sk } into g
+  Const        r51, "item_sk"
+  Index        r52, r36, r7
+  Const        r53, "date_sk"
+  Index        r54, r26, r9
+  Move         r55, r51
+  Move         r56, r52
+  Move         r57, r53
+  Move         r58, r54
+  MakeMap      r59, 2, r55
+  Str          r60, r59
+  In           r61, r60, r12
+  JumpIfTrue   r61, L4
+  // from ss in store_sales
+  Const        r62, []
+  Const        r63, "__group__"
+  Const        r64, true
+  Const        r65, "key"
+  // group by { item_sk: i.i_item_sk, date_sk: d.d_date_sk } into g
+  Move         r66, r59
+  // from ss in store_sales
+  Const        r67, "items"
+  Move         r68, r62
+  Const        r69, "count"
+  Const        r70, 0
+  Move         r71, r63
+  Move         r72, r64
+  Move         r73, r65
+  Move         r74, r66
+  Move         r75, r67
+  Move         r76, r68
+  Move         r77, r69
+  Move         r78, r70
+  MakeMap      r79, 4, r71
+  SetIndex     r12, r60, r79
+  Append       r13, r13, r79
+L4:
+  Const        r81, "items"
+  Index        r82, r12, r60
+  Index        r83, r82, r81
+  Append       r84, r83, r50
+  SetIndex     r82, r81, r84
+  Const        r85, "count"
+  Index        r86, r82, r85
+  Const        r87, 1
+  AddInt       r88, r86, r87
+  SetIndex     r82, r85, r88
+L3:
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  AddInt       r33, r33, r87
+  Jump         L5
+L2:
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  AddInt       r23, r23, r87
+  Jump         L6
 L1:
-  LessInt      r7, r5, r4
-  JumpIfFalse  r7, L0
-  Index        r9, r3, r5
-  Index        r10, r9, r2
-  Append       r1, r1, r10
-  Const        r12, 1
-  AddInt       r5, r5, r12
-  Jump         L1
+  // from ss in store_sales
+  AddInt       r17, r17, r87
+  Jump         L7
 L0:
-  // let result = vals[0]
-  Index        r13, r1, r6
+  Const        r90, 0
+  Move         r89, r90
+  Len          r91, r13
+L9:
+  LessInt      r92, r89, r91
+  JumpIfFalse  r92, L8
+  Index        r94, r13, r89
+  // having count(g) > 4
+  Index        r95, r94, r85
+  Const        r96, 4
+  Less         r97, r96, r95
+  JumpIfFalse  r97, L8
+  // select g.key.item_sk
+  Index        r98, r94, r11
+  Index        r99, r98, r6
+  // from ss in store_sales
+  Append       r5, r5, r99
+  AddInt       r89, r89, r87
+  Jump         L9
+L8:
+  // from ss in store_sales
+  Const        r101, []
+  // group by ss.ss_customer_sk into g
+  Const        r102, "ss_customer_sk"
+  // select { cust: g.key, sales: sum(from x in g select x.ss_quantity * x.ss_sales_price) }
+  Const        r103, "cust"
+  Const        r104, "sales"
+  Const        r105, "ss_quantity"
+  Const        r106, "ss_sales_price"
+  // from ss in store_sales
+  IterPrep     r107, r0
+  Len          r108, r107
+  Const        r109, 0
+  MakeMap      r110, 0, r0
+  Const        r111, []
+L12:
+  LessInt      r113, r109, r108
+  JumpIfFalse  r113, L10
+  Index        r114, r107, r109
+  // group by ss.ss_customer_sk into g
+  Index        r115, r114, r102
+  Str          r116, r115
+  In           r117, r116, r110
+  JumpIfTrue   r117, L11
+  // from ss in store_sales
+  Const        r118, []
+  Const        r119, "__group__"
+  Const        r120, true
+  Const        r121, "key"
+  // group by ss.ss_customer_sk into g
+  Move         r122, r115
+  // from ss in store_sales
+  Const        r123, "items"
+  Move         r124, r118
+  Const        r125, "count"
+  Const        r126, 0
+  Move         r127, r119
+  Move         r128, r120
+  Move         r129, r121
+  Move         r130, r122
+  Move         r131, r123
+  Move         r132, r124
+  Move         r133, r125
+  Move         r134, r126
+  MakeMap      r135, 4, r127
+  SetIndex     r110, r116, r135
+  Append       r111, r111, r135
+L11:
+  Index        r137, r110, r116
+  Index        r138, r137, r81
+  Append       r139, r138, r114
+  SetIndex     r137, r81, r139
+  Index        r140, r137, r85
+  AddInt       r141, r140, r87
+  SetIndex     r137, r85, r141
+  AddInt       r109, r109, r87
+  Jump         L12
+L10:
+  Move         r142, r90
+  Len          r143, r111
+L16:
+  LessInt      r144, r142, r143
+  JumpIfFalse  r144, L13
+  Index        r94, r111, r142
+  // select { cust: g.key, sales: sum(from x in g select x.ss_quantity * x.ss_sales_price) }
+  Const        r146, "cust"
+  Index        r147, r94, r11
+  Const        r148, "sales"
+  Const        r149, []
+  IterPrep     r150, r94
+  Len          r151, r150
+  Move         r152, r90
+L15:
+  LessInt      r153, r152, r151
+  JumpIfFalse  r153, L14
+  Index        r155, r150, r152
+  Index        r156, r155, r105
+  Index        r157, r155, r106
+  Mul          r158, r156, r157
+  Append       r149, r149, r158
+  AddInt       r152, r152, r87
+  Jump         L15
+L14:
+  Sum          r160, r149
+  Move         r161, r146
+  Move         r162, r147
+  Move         r163, r148
+  Move         r164, r160
+  MakeMap      r165, 2, r161
+  // from ss in store_sales
+  Append       r101, r101, r165
+  AddInt       r142, r142, r87
+  Jump         L16
+L13:
+  // let max_sales = max(from c in customer_totals select c.sales)
+  Const        r167, []
+  IterPrep     r168, r101
+  Len          r169, r168
+  Move         r170, r90
+L18:
+  LessInt      r171, r170, r169
+  JumpIfFalse  r171, L17
+  Index        r173, r168, r170
+  Index        r174, r173, r104
+  Append       r167, r167, r174
+  AddInt       r170, r170, r87
+  Jump         L18
+L17:
+  Max          r176, r167
+  // from c in customer_totals
+  Const        r177, []
+  IterPrep     r178, r101
+  Len          r179, r178
+  Move         r180, r90
+L21:
+  LessInt      r181, r180, r179
+  JumpIfFalse  r181, L19
+  Index        r173, r178, r180
+  // where c.sales > 0.95 * max_sales
+  Index        r183, r173, r104
+  Const        r184, 0.95
+  MulFloat     r185, r184, r176
+  LessFloat    r186, r185, r183
+  JumpIfFalse  r186, L20
+  // select c.cust
+  Index        r187, r173, r103
+  // from c in customer_totals
+  Append       r177, r177, r187
+L20:
+  AddInt       r180, r180, r87
+  Jump         L21
+L19:
+  // from cs in catalog_sales
+  Const        r189, []
+  IterPrep     r190, r3
+  Len          r191, r190
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  IterPrep     r192, r1
+  Len          r193, r192
+  Const        r194, "cs_sold_date_sk"
+  // where d.d_year == 2000 && d.d_moy == 1 && cs.cs_bill_customer_sk in best_ss_customer && cs.cs_item_sk in frequent_ss_items
+  Const        r195, "d_moy"
+  Const        r196, "cs_bill_customer_sk"
+  Const        r197, "cs_item_sk"
+  // select cs.cs_quantity * cs.cs_list_price
+  Const        r198, "cs_quantity"
+  Const        r199, "cs_list_price"
+  // from cs in catalog_sales
+  Const        r200, 0
+L27:
+  LessInt      r201, r200, r191
+  JumpIfFalse  r201, L22
+  Index        r203, r190, r200
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  Const        r204, 0
+L26:
+  LessInt      r205, r204, r193
+  JumpIfFalse  r205, L23
+  Index        r207, r192, r204
+  Index        r208, r203, r194
+  Index        r209, r207, r9
+  Equal        r210, r208, r209
+  JumpIfFalse  r210, L24
+  // where d.d_year == 2000 && d.d_moy == 1 && cs.cs_bill_customer_sk in best_ss_customer && cs.cs_item_sk in frequent_ss_items
+  Index        r211, r207, r10
+  Equal        r212, r211, r42
+  Index        r213, r207, r195
+  Equal        r214, r213, r87
+  Index        r215, r203, r196
+  In           r216, r215, r177
+  Index        r217, r203, r197
+  In           r218, r217, r5
+  JumpIfFalse  r212, L25
+  Move         r212, r214
+  JumpIfFalse  r212, L25
+  Move         r212, r216
+  JumpIfFalse  r212, L25
+  Move         r212, r218
+L25:
+  JumpIfFalse  r212, L24
+  // select cs.cs_quantity * cs.cs_list_price
+  Index        r219, r203, r198
+  Index        r220, r203, r199
+  Mul          r221, r219, r220
+  // from cs in catalog_sales
+  Append       r189, r189, r221
+L24:
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  AddInt       r204, r204, r87
+  Jump         L26
+L23:
+  // from cs in catalog_sales
+  AddInt       r200, r200, r87
+  Jump         L27
+L22:
+  // from ws in web_sales
+  Const        r223, []
+  IterPrep     r224, r4
+  Len          r225, r224
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  IterPrep     r226, r1
+  Len          r227, r226
+  Const        r228, "ws_sold_date_sk"
+  // where d.d_year == 2000 && d.d_moy == 1 && ws.ws_bill_customer_sk in best_ss_customer && ws.ws_item_sk in frequent_ss_items
+  Const        r229, "ws_bill_customer_sk"
+  Const        r230, "ws_item_sk"
+  // select ws.ws_quantity * ws.ws_list_price
+  Const        r231, "ws_quantity"
+  Const        r232, "ws_list_price"
+  // from ws in web_sales
+  Const        r233, 0
+L33:
+  LessInt      r234, r233, r225
+  JumpIfFalse  r234, L28
+  Index        r236, r224, r233
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  Const        r237, 0
+L32:
+  LessInt      r238, r237, r227
+  JumpIfFalse  r238, L29
+  Index        r207, r226, r237
+  Index        r240, r236, r228
+  Index        r241, r207, r9
+  Equal        r242, r240, r241
+  JumpIfFalse  r242, L30
+  // where d.d_year == 2000 && d.d_moy == 1 && ws.ws_bill_customer_sk in best_ss_customer && ws.ws_item_sk in frequent_ss_items
+  Index        r243, r207, r10
+  Equal        r244, r243, r42
+  Index        r245, r207, r195
+  Equal        r246, r245, r87
+  Index        r247, r236, r229
+  In           r248, r247, r177
+  Index        r249, r236, r230
+  In           r250, r249, r5
+  JumpIfFalse  r244, L31
+  Move         r244, r246
+  JumpIfFalse  r244, L31
+  Move         r244, r248
+  JumpIfFalse  r244, L31
+  Move         r244, r250
+L31:
+  JumpIfFalse  r244, L30
+  // select ws.ws_quantity * ws.ws_list_price
+  Index        r251, r236, r231
+  Index        r252, r236, r232
+  Mul          r253, r251, r252
+  // from ws in web_sales
+  Append       r223, r223, r253
+L30:
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  AddInt       r237, r237, r87
+  Jump         L32
+L29:
+  // from ws in web_sales
+  AddInt       r233, r233, r87
+  Jump         L33
+L28:
+  // let result = sum(catalog) + sum(web)
+  Sum          r255, r189
+  Sum          r256, r223
+  Add          r257, r255, r256
   // json(result)
-  JSON         r13
-  // expect result == 23
-  Const        r14, 23
-  Equal        r15, r13, r14
-  Expect       r15
+  JSON         r257
+  // expect result == 50.0
+  Const        r258, 50
+  EqualFloat   r259, r257, r258
+  Expect       r259
   Return       r0

--- a/tests/dataset/tpc-ds/out/q24.ir.out
+++ b/tests/dataset/tpc-ds/out/q24.ir.out
@@ -1,16 +1,16 @@
-func main (regs=263)
+func main (regs=259)
   // let store_sales = [
-  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_net_paid": 100, "ss_store_sk": 1, "ss_ticket_number": 1}]
-  // let store_returns = [ { sr_ticket_number: 1, sr_item_sk: 1 } ]
-  Const        r1, [{"sr_item_sk": 1, "sr_ticket_number": 1}]
+  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_net_paid": 100, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 2, "ss_item_sk": 2, "ss_net_paid": 50, "ss_store_sk": 1, "ss_ticket_number": 2}]
+  // let store_returns = [
+  Const        r1, [{"sr_item_sk": 1, "sr_ticket_number": 1}, {"sr_item_sk": 2, "sr_ticket_number": 2}]
   // let store = [ { s_store_sk: 1, s_store_name: "Store1", s_market_id: 5, s_state: "CA", s_zip: "12345" } ]
   Const        r2, [{"s_market_id": 5, "s_state": "CA", "s_store_name": "Store1", "s_store_sk": 1, "s_zip": "12345"}]
-  // let item = [ { i_item_sk: 1, i_color: "RED", i_current_price: 10.0, i_manager_id: 1, i_units: "EA", i_size: "M" } ]
-  Const        r3, [{"i_color": "RED", "i_current_price": 10, "i_item_sk": 1, "i_manager_id": 1, "i_size": "M", "i_units": "EA"}]
-  // let customer = [ { c_customer_sk: 1, c_first_name: "Ann", c_last_name: "Smith", c_current_addr_sk: 1, c_birth_country: "Canada" } ]
-  Const        r4, [{"c_birth_country": "Canada", "c_current_addr_sk": 1, "c_customer_sk": 1, "c_first_name": "Ann", "c_last_name": "Smith"}]
-  // let customer_address = [ { ca_address_sk: 1, ca_state: "CA", ca_country: "USA", ca_zip: "12345" } ]
-  Const        r5, [{"ca_address_sk": 1, "ca_country": "USA", "ca_state": "CA", "ca_zip": "12345"}]
+  // let item = [
+  Const        r3, [{"i_color": "RED", "i_current_price": 10, "i_item_sk": 1, "i_manager_id": 1, "i_size": "M", "i_units": "EA"}, {"i_color": "BLUE", "i_current_price": 20, "i_item_sk": 2, "i_manager_id": 2, "i_size": "L", "i_units": "EA"}]
+  // let customer = [
+  Const        r4, [{"c_birth_country": "Canada", "c_current_addr_sk": 1, "c_customer_sk": 1, "c_first_name": "Ann", "c_last_name": "Smith"}, {"c_birth_country": "USA", "c_current_addr_sk": 2, "c_customer_sk": 2, "c_first_name": "Bob", "c_last_name": "Jones"}]
+  // let customer_address = [
+  Const        r5, [{"ca_address_sk": 1, "ca_country": "USA", "ca_state": "CA", "ca_zip": "12345"}, {"ca_address_sk": 2, "ca_country": "USA", "ca_state": "CA", "ca_zip": "54321"}]
   // from ss in store_sales
   Const        r6, []
   // last: c.c_last_name,
@@ -39,19 +39,19 @@ func main (regs=263)
   Const        r23, "ss_net_paid"
   // from ss in store_sales
   MakeMap      r24, 0, r0
-  Move         r25, r6
+  Const        r25, []
   IterPrep     r27, r0
   Len          r28, r27
   Const        r29, 0
-L1:
+L15:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L0
   Index        r32, r27, r29
   // join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
   IterPrep     r33, r1
   Len          r34, r33
-  Move         r35, r29
-L3:
+  Const        r35, 0
+L14:
   LessInt      r36, r35, r34
   JumpIfFalse  r36, L1
   Index        r38, r33, r35
@@ -65,318 +65,323 @@ L3:
   Const        r46, "sr_item_sk"
   Index        r47, r38, r46
   Equal        r48, r45, r47
-  Move         r49, r43
-  JumpIfFalse  r49, L2
-  Move         r49, r48
+  JumpIfFalse  r43, L2
+  Move         r43, r48
 L2:
-  JumpIfFalse  r49, L3
+  JumpIfFalse  r43, L3
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  IterPrep     r50, r2
-  Len          r51, r50
-  Move         r52, r29
-L14:
-  LessInt      r53, r52, r51
-  JumpIfFalse  r53, L3
-  Index        r55, r50, r52
-  Const        r56, "ss_store_sk"
-  Index        r57, r32, r56
-  Const        r58, "s_store_sk"
-  Index        r59, r55, r58
-  Equal        r60, r57, r59
-  JumpIfFalse  r60, L4
-  // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r61, r3
-  Len          r62, r61
-  Move         r63, r52
+  IterPrep     r49, r2
+  Len          r50, r49
+  Const        r51, 0
 L13:
-  LessInt      r64, r63, r62
-  JumpIfFalse  r64, L4
-  Index        r66, r61, r63
-  Index        r67, r32, r44
-  Const        r68, "i_item_sk"
-  Index        r69, r66, r68
-  Equal        r70, r67, r69
-  JumpIfFalse  r70, L5
-  // join c in customer on ss.ss_customer_sk == c.c_customer_sk
-  IterPrep     r71, r4
-  Len          r72, r71
-  Move         r73, r29
+  LessInt      r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r54, r49, r51
+  Const        r55, "ss_store_sk"
+  Index        r56, r32, r55
+  Const        r57, "s_store_sk"
+  Index        r58, r54, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r60, r3
+  Len          r61, r60
+  Const        r62, 0
 L12:
-  LessInt      r74, r73, r72
-  JumpIfFalse  r74, L5
-  Index        r76, r71, r73
-  Const        r77, "ss_customer_sk"
-  Index        r78, r32, r77
-  Const        r79, "c_customer_sk"
-  Index        r80, r76, r79
-  Equal        r81, r78, r80
-  JumpIfFalse  r81, L6
-  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  IterPrep     r82, r5
-  Len          r83, r82
-  Move         r84, r73
+  LessInt      r63, r62, r61
+  JumpIfFalse  r63, L4
+  Index        r65, r60, r62
+  Index        r66, r32, r44
+  Const        r67, "i_item_sk"
+  Index        r68, r65, r67
+  Equal        r69, r66, r68
+  JumpIfFalse  r69, L5
+  // join c in customer on ss.ss_customer_sk == c.c_customer_sk
+  IterPrep     r70, r4
+  Len          r71, r70
+  Const        r72, 0
 L11:
-  LessInt      r85, r84, r83
-  JumpIfFalse  r85, L6
-  Index        r87, r82, r84
-  Const        r88, "c_current_addr_sk"
-  Index        r89, r76, r88
-  Const        r90, "ca_address_sk"
-  Index        r91, r87, r90
-  Equal        r92, r89, r91
-  JumpIfFalse  r92, L7
+  LessInt      r73, r72, r71
+  JumpIfFalse  r73, L5
+  Index        r75, r70, r72
+  Const        r76, "ss_customer_sk"
+  Index        r77, r32, r76
+  Const        r78, "c_customer_sk"
+  Index        r79, r75, r78
+  Equal        r80, r77, r79
+  JumpIfFalse  r80, L6
+  // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
+  IterPrep     r81, r5
+  Len          r82, r81
+  Const        r83, 0
+L10:
+  LessInt      r84, r83, r82
+  JumpIfFalse  r84, L6
+  Index        r86, r81, r83
+  Const        r87, "c_current_addr_sk"
+  Index        r88, r75, r87
+  Const        r89, "ca_address_sk"
+  Index        r90, r86, r89
+  Equal        r91, r88, r90
+  JumpIfFalse  r91, L7
   // where c.c_birth_country != strings.ToUpper(ca.ca_country) && s.s_zip == ca.ca_zip && s.s_market_id == 5
-  Index        r93, r76, r15
-  Index        r95, r94, r16
-  Index        r96, r87, r17
-  CallV        r98, r95, 1, r96
-  NotEqual     r99, r93, r98
-  Index        r100, r55, r18
-  Index        r101, r87, r19
-  Equal        r102, r100, r101
-  Index        r103, r55, r20
-  Const        r104, 5
-  Equal        r105, r103, r104
-  Move         r106, r99
-  JumpIfFalse  r106, L8
+  Index        r92, r75, r15
+  Index        r94, r93, r16
+  Index        r95, r86, r17
+  CallV        r97, r94, 1, r95
+  NotEqual     r98, r92, r97
+  Index        r99, r54, r18
+  Index        r100, r86, r19
+  Equal        r101, r99, r100
+  Index        r102, r54, r20
+  Const        r103, 5
+  Equal        r104, r102, r103
+  JumpIfFalse  r98, L8
+  Move         r98, r101
+  JumpIfFalse  r98, L8
+  Move         r98, r104
 L8:
-  Move         r107, r102
-  JumpIfFalse  r107, L9
-  Move         r107, r105
-L9:
-  JumpIfFalse  r107, L7
+  JumpIfFalse  r98, L7
   // from ss in store_sales
-  Const        r108, "ss"
-  Move         r109, r32
-  Const        r110, "sr"
-  Move         r111, r38
-  Const        r112, "s"
-  Move         r113, r55
-  Const        r114, "i"
-  Move         r115, r66
-  Const        r116, "c"
-  Move         r117, r76
-  Const        r118, "ca"
-  Move         r119, r87
-  MakeMap      r120, 6, r108
+  Const        r105, "ss"
+  Move         r106, r32
+  Const        r107, "sr"
+  Move         r108, r38
+  Const        r109, "s"
+  Move         r110, r54
+  Const        r111, "i"
+  Move         r112, r65
+  Const        r113, "c"
+  Move         r114, r75
+  Const        r115, "ca"
+  Move         r116, r86
+  MakeMap      r117, 6, r105
   // last: c.c_last_name,
-  Move         r121, r7
-  Index        r122, r76, r8
+  Const        r118, "last"
+  Index        r119, r75, r8
   // first: c.c_first_name,
-  Move         r123, r9
-  Index        r124, r76, r10
+  Const        r120, "first"
+  Index        r121, r75, r10
   // store_name: s.s_store_name,
-  Move         r125, r11
-  Index        r126, r55, r12
+  Const        r122, "store_name"
+  Index        r123, r54, r12
   // color: i.i_color
-  Move         r127, r13
-  Index        r128, r66, r14
+  Const        r124, "color"
+  Index        r125, r65, r14
   // last: c.c_last_name,
+  Move         r126, r118
+  Move         r127, r119
+  // first: c.c_first_name,
+  Move         r128, r120
   Move         r129, r121
-  Move         r130, r122
-  // first: c.c_first_name,
-  Move         r131, r123
-  Move         r132, r124
   // store_name: s.s_store_name,
-  Move         r133, r125
-  Move         r134, r126
+  Move         r130, r122
+  Move         r131, r123
   // color: i.i_color
-  Move         r135, r127
-  Move         r136, r128
+  Move         r132, r124
+  Move         r133, r125
   // group by {
-  MakeMap      r137, 4, r129
-  Str          r138, r137
-  In           r139, r138, r24
-  JumpIfTrue   r139, L10
+  MakeMap      r134, 4, r126
+  Str          r135, r134
+  In           r136, r135, r24
+  JumpIfTrue   r136, L9
   // from ss in store_sales
-  Move         r140, r6
-  Const        r141, "__group__"
-  Const        r142, true
-  Move         r143, r21
+  Const        r137, []
+  Const        r138, "__group__"
+  Const        r139, true
+  Const        r140, "key"
   // group by {
-  Move         r144, r137
+  Move         r141, r134
   // from ss in store_sales
-  Const        r145, "items"
-  Move         r146, r140
-  Const        r147, "count"
-  Move         r148, r73
+  Const        r142, "items"
+  Move         r143, r137
+  Const        r144, "count"
+  Const        r145, 0
+  Move         r146, r138
+  Move         r147, r139
+  Move         r148, r140
   Move         r149, r141
   Move         r150, r142
   Move         r151, r143
   Move         r152, r144
   Move         r153, r145
-  Move         r154, r146
-  Move         r155, r147
-  Move         r156, r148
-  MakeMap      r157, 4, r149
-  SetIndex     r24, r138, r157
-  Append       r25, r25, r157
-L10:
-  Move         r159, r145
-  Index        r160, r24, r138
-  Index        r161, r160, r159
-  Append       r162, r161, r120
-  SetIndex     r160, r159, r162
-  Move         r163, r147
-  Index        r164, r160, r163
-  Const        r165, 1
-  AddInt       r166, r164, r165
-  SetIndex     r160, r163, r166
+  MakeMap      r154, 4, r146
+  SetIndex     r24, r135, r154
+  Append       r25, r25, r154
+L9:
+  Const        r156, "items"
+  Index        r157, r24, r135
+  Index        r158, r157, r156
+  Append       r159, r158, r117
+  SetIndex     r157, r156, r159
+  Const        r160, "count"
+  Index        r161, r157, r160
+  Const        r162, 1
+  AddInt       r163, r161, r162
+  SetIndex     r157, r160, r163
 L7:
   // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  AddInt       r84, r84, r165
-  Jump         L11
+  AddInt       r83, r83, r162
+  Jump         L10
 L6:
   // join c in customer on ss.ss_customer_sk == c.c_customer_sk
-  AddInt       r73, r73, r165
-  Jump         L12
+  AddInt       r72, r72, r162
+  Jump         L11
 L5:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r63, r63, r165
-  Jump         L13
+  AddInt       r62, r62, r162
+  Jump         L12
 L4:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r52, r52, r165
+  AddInt       r51, r51, r162
+  Jump         L13
+L3:
+  // join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
+  AddInt       r35, r35, r162
   Jump         L14
+L1:
+  // from ss in store_sales
+  AddInt       r29, r29, r162
+  Jump         L15
 L0:
-  // from ss in store_sales
-  Move         r168, r148
-  Move         r167, r168
-  Len          r169, r25
-L18:
-  LessInt      r170, r167, r169
-  JumpIfFalse  r170, L15
-  Index        r172, r25, r167
-  // c_last_name: g.key.last,
-  Move         r173, r8
-  Index        r174, r172, r21
-  Index        r175, r174, r7
-  // c_first_name: g.key.first,
-  Move         r176, r10
-  Index        r177, r172, r21
-  Index        r178, r177, r9
-  // s_store_name: g.key.store_name,
-  Move         r179, r12
-  Index        r180, r172, r21
-  Index        r181, r180, r11
-  // color: g.key.color,
-  Move         r182, r13
-  Index        r183, r172, r21
-  Index        r184, r183, r13
-  // netpaid: sum(from x in g select x.ss_net_paid)
-  Move         r185, r22
-  Move         r186, r140
-  IterPrep     r187, r172
-  Len          r188, r187
-  Move         r189, r168
-L17:
-  LessInt      r190, r189, r188
-  JumpIfFalse  r190, L16
-  Index        r192, r187, r189
-  Index        r193, r192, r23
-  Append       r186, r186, r193
-  AddInt       r189, r189, r165
-  Jump         L17
-L16:
-  Sum          r195, r186
-  // c_last_name: g.key.last,
-  Move         r196, r173
-  Move         r197, r175
-  // c_first_name: g.key.first,
-  Move         r198, r176
-  Move         r199, r178
-  // s_store_name: g.key.store_name,
-  Move         r200, r179
-  Move         r201, r181
-  // color: g.key.color,
-  Move         r202, r182
-  Move         r203, r184
-  // netpaid: sum(from x in g select x.ss_net_paid)
-  Move         r204, r185
-  Move         r205, r195
-  // select {
-  MakeMap      r206, 5, r196
-  // from ss in store_sales
-  Append       r6, r6, r206
-  AddInt       r167, r167, r165
-  Jump         L18
-L15:
-  // let avg_paid = avg(from x in ssales select x.netpaid)
-  Const        r208, []
-  IterPrep     r209, r6
-  Len          r210, r209
-  Move         r211, r168
-L20:
-  LessInt      r212, r211, r210
-  JumpIfFalse  r212, L19
-  Index        r192, r209, r211
-  Index        r214, r192, r22
-  Append       r208, r208, r214
-  AddInt       r211, r211, r165
-  Jump         L20
+  Const        r165, 0
+  Move         r164, r165
+  Len          r166, r25
 L19:
-  Avg          r216, r208
+  LessInt      r167, r164, r166
+  JumpIfFalse  r167, L16
+  Index        r169, r25, r164
+  // c_last_name: g.key.last,
+  Const        r170, "c_last_name"
+  Index        r171, r169, r21
+  Index        r172, r171, r7
+  // c_first_name: g.key.first,
+  Const        r173, "c_first_name"
+  Index        r174, r169, r21
+  Index        r175, r174, r9
+  // s_store_name: g.key.store_name,
+  Const        r176, "s_store_name"
+  Index        r177, r169, r21
+  Index        r178, r177, r11
+  // color: g.key.color,
+  Const        r179, "color"
+  Index        r180, r169, r21
+  Index        r181, r180, r13
+  // netpaid: sum(from x in g select x.ss_net_paid)
+  Const        r182, "netpaid"
+  Const        r183, []
+  IterPrep     r184, r169
+  Len          r185, r184
+  Move         r186, r165
+L18:
+  LessInt      r187, r186, r185
+  JumpIfFalse  r187, L17
+  Index        r189, r184, r186
+  Index        r190, r189, r23
+  Append       r183, r183, r190
+  AddInt       r186, r186, r162
+  Jump         L18
+L17:
+  Sum          r192, r183
+  // c_last_name: g.key.last,
+  Move         r193, r170
+  Move         r194, r172
+  // c_first_name: g.key.first,
+  Move         r195, r173
+  Move         r196, r175
+  // s_store_name: g.key.store_name,
+  Move         r197, r176
+  Move         r198, r178
+  // color: g.key.color,
+  Move         r199, r179
+  Move         r200, r181
+  // netpaid: sum(from x in g select x.ss_net_paid)
+  Move         r201, r182
+  Move         r202, r192
+  // select {
+  MakeMap      r203, 5, r193
+  // from ss in store_sales
+  Append       r6, r6, r203
+  AddInt       r164, r164, r162
+  Jump         L19
+L16:
+  // let avg_paid = avg(from x in ssales select x.netpaid)
+  Const        r205, []
+  IterPrep     r206, r6
+  Len          r207, r206
+  Move         r208, r165
+L21:
+  LessInt      r209, r208, r207
+  JumpIfFalse  r209, L20
+  Index        r189, r206, r208
+  Index        r211, r189, r22
+  Append       r205, r205, r211
+  AddInt       r208, r208, r162
+  Jump         L21
+L20:
+  Avg          r213, r205
   // from x in ssales
-  Const        r217, []
+  Const        r214, []
   // select { c_last_name: x.c_last_name, c_first_name: x.c_first_name, s_store_name: x.s_store_name, paid: x.netpaid }
-  Const        r218, "paid"
+  Const        r215, "paid"
   // from x in ssales
-  IterPrep     r219, r6
-  Len          r220, r219
-  Move         r221, r168
-L24:
-  LessInt      r222, r221, r220
-  JumpIfFalse  r222, L21
-  Index        r192, r219, r221
+  IterPrep     r216, r6
+  Len          r217, r216
+  Move         r218, r165
+L25:
+  LessInt      r219, r218, r217
+  JumpIfFalse  r219, L22
+  Index        r189, r216, r218
   // where x.color == "RED" && x.netpaid > 0.05 * avg_paid
-  Index        r224, r192, r13
-  Const        r225, 0.05
-  MulFloat     r226, r225, r216
-  Index        r227, r192, r22
-  LessFloat    r228, r226, r227
-  Const        r229, "RED"
-  Equal        r231, r224, r229
-  JumpIfFalse  r231, L22
-  Move         r231, r228
-L22:
-  JumpIfFalse  r231, L23
+  Index        r221, r189, r13
+  Const        r222, 0.05
+  MulFloat     r223, r222, r213
+  Index        r224, r189, r22
+  LessFloat    r225, r223, r224
+  Const        r226, "RED"
+  Equal        r227, r221, r226
+  JumpIfFalse  r227, L23
+  Move         r227, r225
+L23:
+  JumpIfFalse  r227, L24
   // select { c_last_name: x.c_last_name, c_first_name: x.c_first_name, s_store_name: x.s_store_name, paid: x.netpaid }
-  Move         r232, r8
-  Index        r233, r192, r8
-  Move         r234, r10
-  Index        r235, r192, r10
-  Move         r236, r12
-  Index        r237, r192, r12
-  Move         r238, r218
-  Index        r239, r192, r22
+  Const        r228, "c_last_name"
+  Index        r229, r189, r8
+  Const        r230, "c_first_name"
+  Index        r231, r189, r10
+  Const        r232, "s_store_name"
+  Index        r233, r189, r12
+  Const        r234, "paid"
+  Index        r235, r189, r22
+  Move         r236, r228
+  Move         r237, r229
+  Move         r238, r230
+  Move         r239, r231
   Move         r240, r232
   Move         r241, r233
   Move         r242, r234
   Move         r243, r235
-  Move         r244, r236
-  Move         r245, r237
-  Move         r246, r238
-  Move         r247, r239
-  MakeMap      r248, 4, r240
+  MakeMap      r244, 4, r236
   // sort by [x.c_last_name, x.c_first_name, x.s_store_name]
-  Index        r250, r192, r8
-  Index        r251, r192, r10
-  Move         r252, r251
-  MakeList     r256, 3, r250
+  Index        r246, r189, r8
+  Index        r247, r189, r10
+  Move         r248, r247
+  Index        r250, r189, r12
+  MakeList     r252, 3, r246
   // from x in ssales
-  Move         r257, r248
-  MakeList     r258, 2, r256
-  Append       r217, r217, r258
-L23:
-  AddInt       r221, r221, r165
-  Jump         L24
-L21:
+  Move         r253, r244
+  MakeList     r254, 2, r252
+  Append       r214, r214, r254
+L24:
+  AddInt       r218, r218, r162
+  Jump         L25
+L22:
   // sort by [x.c_last_name, x.c_first_name, x.s_store_name]
-  Sort         r217, r217
+  Sort         r214, r214
   // json(result)
-  JSON         r217
+  JSON         r214
   // expect result == [ { c_last_name: "Smith", c_first_name: "Ann", s_store_name: "Store1", paid: 100.0 } ]
-  Const        r261, [{"c_first_name": "Ann", "c_last_name": "Smith", "paid": 100, "s_store_name": "Store1"}]
-  Equal        r262, r217, r261
-  Expect       r262
+  Const        r257, [{"c_first_name": "Ann", "c_last_name": "Smith", "paid": 100, "s_store_name": "Store1"}]
+  Equal        r258, r214, r257
+  Expect       r258
   Return       r0

--- a/tests/dataset/tpc-ds/out/q25.ir.out
+++ b/tests/dataset/tpc-ds/out/q25.ir.out
@@ -1,16 +1,16 @@
-func main (regs=266)
+func main (regs=259)
   // let store_sales = [
-  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_net_profit": 50, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}]
+  Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_net_profit": 50, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 2, "ss_item_sk": 2, "ss_net_profit": 20, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}]
   // let store_returns = [
-  Const        r1, [{"sr_customer_sk": 1, "sr_item_sk": 1, "sr_net_loss": 10, "sr_returned_date_sk": 2, "sr_ticket_number": 1}]
+  Const        r1, [{"sr_customer_sk": 1, "sr_item_sk": 1, "sr_net_loss": 10, "sr_returned_date_sk": 2, "sr_ticket_number": 1}, {"sr_customer_sk": 2, "sr_item_sk": 2, "sr_net_loss": 5, "sr_returned_date_sk": 2, "sr_ticket_number": 2}]
   // let catalog_sales = [
-  Const        r2, [{"cs_bill_customer_sk": 1, "cs_item_sk": 1, "cs_net_profit": 30, "cs_sold_date_sk": 3}]
+  Const        r2, [{"cs_bill_customer_sk": 1, "cs_item_sk": 1, "cs_net_profit": 30, "cs_sold_date_sk": 3}, {"cs_bill_customer_sk": 2, "cs_item_sk": 2, "cs_net_profit": 15, "cs_sold_date_sk": 3}]
   // let date_dim = [
   Const        r3, [{"d_date_sk": 1, "d_moy": 4, "d_year": 2000}, {"d_date_sk": 2, "d_moy": 5, "d_year": 2000}, {"d_date_sk": 3, "d_moy": 6, "d_year": 2000}]
   // let store = [ { s_store_sk: 1, s_store_id: "S1", s_store_name: "Store1" } ]
   Const        r4, [{"s_store_id": "S1", "s_store_name": "Store1", "s_store_sk": 1}]
-  // let item = [ { i_item_sk: 1, i_item_id: "ITEM1", i_item_desc: "Desc1" } ]
-  Const        r5, [{"i_item_desc": "Desc1", "i_item_id": "ITEM1", "i_item_sk": 1}]
+  // let item = [
+  Const        r5, [{"i_item_desc": "Desc1", "i_item_id": "ITEM1", "i_item_sk": 1}, {"i_item_desc": "Desc2", "i_item_id": "ITEM2", "i_item_sk": 2}]
   // from ss in store_sales
   Const        r6, []
   // group by { item_id: i.i_item_id, item_desc: i.i_item_desc, s_store_id: s.s_store_id, s_store_name: s.s_store_name } into g
@@ -36,19 +36,19 @@ func main (regs=266)
   Const        r21, "cs_net_profit"
   // from ss in store_sales
   MakeMap      r22, 0, r0
-  Move         r23, r6
+  Const        r23, []
   IterPrep     r25, r0
   Len          r26, r25
   Const        r27, 0
-L1:
+L20:
   LessInt      r28, r27, r26
   JumpIfFalse  r28, L0
   Index        r30, r25, r27
   // join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
   IterPrep     r31, r1
   Len          r32, r31
-  Move         r33, r27
-L3:
+  Const        r33, 0
+L19:
   LessInt      r34, r33, r32
   JumpIfFalse  r34, L1
   Index        r36, r31, r33
@@ -62,335 +62,335 @@ L3:
   Const        r44, "sr_item_sk"
   Index        r45, r36, r44
   Equal        r46, r43, r45
-  Move         r47, r41
-  JumpIfFalse  r47, L2
-  Move         r47, r46
+  JumpIfFalse  r41, L2
+  Move         r41, r46
 L2:
-  JumpIfFalse  r47, L3
+  JumpIfFalse  r41, L3
   // join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
-  IterPrep     r48, r2
-  Len          r49, r48
-  Move         r50, r27
-L22:
-  LessInt      r51, r50, r49
-  JumpIfFalse  r51, L3
-  Index        r53, r48, r50
-  Const        r54, "sr_customer_sk"
-  Index        r55, r36, r54
-  Const        r56, "cs_bill_customer_sk"
-  Index        r57, r53, r56
-  Equal        r58, r55, r57
-  Index        r59, r36, r44
-  Const        r60, "cs_item_sk"
-  Index        r61, r53, r60
-  Equal        r62, r59, r61
-  Move         r63, r58
-  JumpIfFalse  r63, L4
-  Move         r63, r62
-L4:
-  JumpIfFalse  r63, L5
-  // join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
-  IterPrep     r64, r3
-  Len          r65, r64
-  Move         r66, r50
-L21:
-  LessInt      r67, r66, r65
-  JumpIfFalse  r67, L5
-  Index        r69, r64, r66
-  Const        r70, "d_date_sk"
-  Index        r71, r69, r70
-  Const        r72, "ss_sold_date_sk"
-  Index        r73, r30, r72
-  Equal        r74, r71, r73
-  JumpIfFalse  r74, L6
-  // join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
-  IterPrep     r75, r3
-  Len          r76, r75
-  Move         r77, r27
-L20:
-  LessInt      r78, r77, r76
-  JumpIfFalse  r78, L6
-  Index        r80, r75, r77
-  Index        r81, r80, r70
-  Const        r82, "sr_returned_date_sk"
-  Index        r83, r36, r82
-  Equal        r84, r81, r83
-  JumpIfFalse  r84, L7
-  // join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
-  IterPrep     r85, r3
-  Len          r86, r85
-  Move         r87, r77
-L19:
-  LessInt      r88, r87, r86
-  JumpIfFalse  r88, L7
-  Index        r90, r85, r87
-  Index        r91, r90, r70
-  Const        r92, "cs_sold_date_sk"
-  Index        r93, r53, r92
-  Equal        r94, r91, r93
-  JumpIfFalse  r94, L8
-  // join s in store on s.s_store_sk == ss.ss_store_sk
-  IterPrep     r95, r4
-  Len          r96, r95
-  Move         r97, r77
+  IterPrep     r47, r2
+  Len          r48, r47
+  Const        r49, 0
 L18:
-  LessInt      r98, r97, r96
-  JumpIfFalse  r98, L8
-  Index        r100, r95, r97
-  Const        r101, "s_store_sk"
-  Index        r102, r100, r101
-  Const        r103, "ss_store_sk"
-  Index        r104, r30, r103
-  Equal        r105, r102, r104
-  JumpIfFalse  r105, L9
-  // join i in item on i.i_item_sk == ss.ss_item_sk
-  IterPrep     r106, r5
-  Len          r107, r106
-  Move         r108, r97
+  LessInt      r50, r49, r48
+  JumpIfFalse  r50, L3
+  Index        r52, r47, r49
+  Const        r53, "sr_customer_sk"
+  Index        r54, r36, r53
+  Const        r55, "cs_bill_customer_sk"
+  Index        r56, r52, r55
+  Equal        r57, r54, r56
+  Index        r58, r36, r44
+  Const        r59, "cs_item_sk"
+  Index        r60, r52, r59
+  Equal        r61, r58, r60
+  JumpIfFalse  r57, L4
+  Move         r57, r61
+L4:
+  JumpIfFalse  r57, L5
+  // join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
+  IterPrep     r62, r3
+  Len          r63, r62
+  Const        r64, 0
 L17:
-  LessInt      r109, r108, r107
-  JumpIfFalse  r109, L9
-  Index        r111, r106, r108
-  Const        r112, "i_item_sk"
-  Index        r113, r111, r112
-  Index        r114, r30, r42
-  Equal        r115, r113, r114
-  JumpIfFalse  r115, L10
-  // where d1.d_moy == 4 && d1.d_year == 2000 && d2.d_moy >= 4 && d2.d_moy <= 10 && d3.d_moy >= 4 && d3.d_moy <= 10
-  Index        r116, r69, r13
-  Index        r117, r80, r13
-  Const        r118, 4
-  LessEq       r119, r118, r117
-  Index        r120, r80, r13
-  Const        r121, 10
-  LessEq       r122, r120, r121
-  Index        r123, r90, r13
-  LessEq       r124, r118, r123
-  Index        r125, r90, r13
-  LessEq       r126, r125, r121
-  Equal        r127, r116, r118
-  Index        r128, r69, r14
-  Const        r129, 2000
-  Equal        r130, r128, r129
-  Move         r131, r127
-  JumpIfFalse  r131, L11
-L11:
-  Move         r132, r130
-  JumpIfFalse  r132, L12
-L12:
-  Move         r133, r119
-  JumpIfFalse  r133, L13
-L13:
-  Move         r134, r122
-  JumpIfFalse  r134, L14
-L14:
-  Move         r135, r124
-  JumpIfFalse  r135, L15
-  Move         r135, r126
-L15:
-  JumpIfFalse  r135, L10
-  // from ss in store_sales
-  Const        r136, "ss"
-  Move         r137, r30
-  Const        r138, "sr"
-  Move         r139, r36
-  Const        r140, "cs"
-  Move         r141, r53
-  Const        r142, "d1"
-  Move         r143, r69
-  Const        r144, "d2"
-  Move         r145, r80
-  Const        r146, "d3"
-  Move         r147, r90
-  Const        r148, "s"
-  Move         r149, r100
-  Const        r150, "i"
-  Move         r151, r111
-  MakeMap      r152, 8, r136
-  // group by { item_id: i.i_item_id, item_desc: i.i_item_desc, s_store_id: s.s_store_id, s_store_name: s.s_store_name } into g
-  Move         r153, r7
-  Index        r154, r111, r8
-  Move         r155, r9
-  Index        r156, r111, r10
-  Move         r157, r11
-  Index        r158, r100, r11
-  Move         r159, r12
-  Index        r160, r100, r12
-  Move         r161, r153
-  Move         r162, r154
-  Move         r163, r155
-  Move         r164, r156
-  Move         r165, r157
-  Move         r166, r158
-  Move         r167, r159
-  Move         r168, r160
-  MakeMap      r169, 4, r161
-  Str          r170, r169
-  In           r171, r170, r22
-  JumpIfTrue   r171, L16
-  // from ss in store_sales
-  Move         r172, r6
-  Const        r173, "__group__"
-  Const        r174, true
-  Move         r175, r15
-  // group by { item_id: i.i_item_id, item_desc: i.i_item_desc, s_store_id: s.s_store_id, s_store_name: s.s_store_name } into g
-  Move         r176, r169
-  // from ss in store_sales
-  Const        r177, "items"
-  Move         r178, r172
-  Const        r179, "count"
-  Move         r180, r27
-  Move         r181, r173
-  Move         r182, r174
-  Move         r183, r175
-  Move         r184, r176
-  Move         r185, r177
-  Move         r186, r178
-  Move         r187, r179
-  Move         r188, r180
-  MakeMap      r189, 4, r181
-  SetIndex     r22, r170, r189
-  Append       r23, r23, r189
+  LessInt      r65, r64, r63
+  JumpIfFalse  r65, L5
+  Index        r67, r62, r64
+  Const        r68, "d_date_sk"
+  Index        r69, r67, r68
+  Const        r70, "ss_sold_date_sk"
+  Index        r71, r30, r70
+  Equal        r72, r69, r71
+  JumpIfFalse  r72, L6
+  // join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
+  IterPrep     r73, r3
+  Len          r74, r73
+  Const        r75, 0
 L16:
-  Move         r191, r177
-  Index        r192, r22, r170
-  Index        r193, r192, r191
-  Append       r194, r193, r152
-  SetIndex     r192, r191, r194
-  Move         r195, r179
-  Index        r196, r192, r195
-  Const        r197, 1
-  AddInt       r198, r196, r197
-  SetIndex     r192, r195, r198
+  LessInt      r76, r75, r74
+  JumpIfFalse  r76, L6
+  Index        r78, r73, r75
+  Index        r79, r78, r68
+  Const        r80, "sr_returned_date_sk"
+  Index        r81, r36, r80
+  Equal        r82, r79, r81
+  JumpIfFalse  r82, L7
+  // join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
+  IterPrep     r83, r3
+  Len          r84, r83
+  Const        r85, 0
+L15:
+  LessInt      r86, r85, r84
+  JumpIfFalse  r86, L7
+  Index        r88, r83, r85
+  Index        r89, r88, r68
+  Const        r90, "cs_sold_date_sk"
+  Index        r91, r52, r90
+  Equal        r92, r89, r91
+  JumpIfFalse  r92, L8
+  // join s in store on s.s_store_sk == ss.ss_store_sk
+  IterPrep     r93, r4
+  Len          r94, r93
+  Const        r95, 0
+L14:
+  LessInt      r96, r95, r94
+  JumpIfFalse  r96, L8
+  Index        r98, r93, r95
+  Const        r99, "s_store_sk"
+  Index        r100, r98, r99
+  Const        r101, "ss_store_sk"
+  Index        r102, r30, r101
+  Equal        r103, r100, r102
+  JumpIfFalse  r103, L9
+  // join i in item on i.i_item_sk == ss.ss_item_sk
+  IterPrep     r104, r5
+  Len          r105, r104
+  Const        r106, 0
+L13:
+  LessInt      r107, r106, r105
+  JumpIfFalse  r107, L9
+  Index        r109, r104, r106
+  Const        r110, "i_item_sk"
+  Index        r111, r109, r110
+  Index        r112, r30, r42
+  Equal        r113, r111, r112
+  JumpIfFalse  r113, L10
+  // where d1.d_moy == 4 && d1.d_year == 2000 && d2.d_moy >= 4 && d2.d_moy <= 10 && d3.d_moy >= 4 && d3.d_moy <= 10
+  Index        r114, r67, r13
+  Index        r115, r78, r13
+  Const        r116, 4
+  LessEq       r117, r116, r115
+  Index        r118, r78, r13
+  Const        r119, 10
+  LessEq       r120, r118, r119
+  Index        r121, r88, r13
+  LessEq       r122, r116, r121
+  Index        r123, r88, r13
+  LessEq       r124, r123, r119
+  Equal        r125, r114, r116
+  Index        r126, r67, r14
+  Const        r127, 2000
+  Equal        r128, r126, r127
+  JumpIfFalse  r125, L11
+  Move         r125, r128
+  JumpIfFalse  r125, L11
+  Move         r125, r117
+  JumpIfFalse  r125, L11
+  Move         r125, r120
+  JumpIfFalse  r125, L11
+  Move         r125, r122
+  JumpIfFalse  r125, L11
+  Move         r125, r124
+L11:
+  JumpIfFalse  r125, L10
+  // from ss in store_sales
+  Const        r129, "ss"
+  Move         r130, r30
+  Const        r131, "sr"
+  Move         r132, r36
+  Const        r133, "cs"
+  Move         r134, r52
+  Const        r135, "d1"
+  Move         r136, r67
+  Const        r137, "d2"
+  Move         r138, r78
+  Const        r139, "d3"
+  Move         r140, r88
+  Const        r141, "s"
+  Move         r142, r98
+  Const        r143, "i"
+  Move         r144, r109
+  MakeMap      r145, 8, r129
+  // group by { item_id: i.i_item_id, item_desc: i.i_item_desc, s_store_id: s.s_store_id, s_store_name: s.s_store_name } into g
+  Const        r146, "item_id"
+  Index        r147, r109, r8
+  Const        r148, "item_desc"
+  Index        r149, r109, r10
+  Const        r150, "s_store_id"
+  Index        r151, r98, r11
+  Const        r152, "s_store_name"
+  Index        r153, r98, r12
+  Move         r154, r146
+  Move         r155, r147
+  Move         r156, r148
+  Move         r157, r149
+  Move         r158, r150
+  Move         r159, r151
+  Move         r160, r152
+  Move         r161, r153
+  MakeMap      r162, 4, r154
+  Str          r163, r162
+  In           r164, r163, r22
+  JumpIfTrue   r164, L12
+  // from ss in store_sales
+  Const        r165, []
+  Const        r166, "__group__"
+  Const        r167, true
+  Const        r168, "key"
+  // group by { item_id: i.i_item_id, item_desc: i.i_item_desc, s_store_id: s.s_store_id, s_store_name: s.s_store_name } into g
+  Move         r169, r162
+  // from ss in store_sales
+  Const        r170, "items"
+  Move         r171, r165
+  Const        r172, "count"
+  Const        r173, 0
+  Move         r174, r166
+  Move         r175, r167
+  Move         r176, r168
+  Move         r177, r169
+  Move         r178, r170
+  Move         r179, r171
+  Move         r180, r172
+  Move         r181, r173
+  MakeMap      r182, 4, r174
+  SetIndex     r22, r163, r182
+  Append       r23, r23, r182
+L12:
+  Const        r184, "items"
+  Index        r185, r22, r163
+  Index        r186, r185, r184
+  Append       r187, r186, r145
+  SetIndex     r185, r184, r187
+  Const        r188, "count"
+  Index        r189, r185, r188
+  Const        r190, 1
+  AddInt       r191, r189, r190
+  SetIndex     r185, r188, r191
 L10:
   // join i in item on i.i_item_sk == ss.ss_item_sk
-  AddInt       r108, r108, r197
-  Jump         L17
+  AddInt       r106, r106, r190
+  Jump         L13
 L9:
   // join s in store on s.s_store_sk == ss.ss_store_sk
-  AddInt       r97, r97, r197
-  Jump         L18
+  AddInt       r95, r95, r190
+  Jump         L14
 L8:
   // join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
-  AddInt       r87, r87, r197
-  Jump         L19
+  AddInt       r85, r85, r190
+  Jump         L15
 L7:
   // join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
-  AddInt       r77, r77, r197
-  Jump         L20
+  AddInt       r75, r75, r190
+  Jump         L16
 L6:
   // join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
-  AddInt       r66, r66, r197
-  Jump         L21
+  AddInt       r64, r64, r190
+  Jump         L17
 L5:
   // join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
-  AddInt       r50, r50, r197
-  Jump         L22
-L0:
+  AddInt       r49, r49, r190
+  Jump         L18
+L3:
+  // join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
+  AddInt       r33, r33, r190
+  Jump         L19
+L1:
   // from ss in store_sales
-  Move         r200, r180
-  Move         r199, r200
-  Len          r201, r23
-L30:
-  LessInt      r202, r199, r201
-  JumpIfFalse  r202, L23
-  Index        r204, r23, r199
+  AddInt       r27, r27, r190
+  Jump         L20
+L0:
+  Const        r193, 0
+  Move         r192, r193
+  Len          r194, r23
+L28:
+  LessInt      r195, r192, r194
+  JumpIfFalse  r195, L21
+  Index        r197, r23, r192
   // i_item_id: g.key.item_id,
-  Move         r205, r8
-  Index        r206, r204, r15
-  Index        r207, r206, r7
+  Const        r198, "i_item_id"
+  Index        r199, r197, r15
+  Index        r200, r199, r7
   // i_item_desc: g.key.item_desc,
-  Move         r208, r10
-  Index        r209, r204, r15
-  Index        r210, r209, r9
+  Const        r201, "i_item_desc"
+  Index        r202, r197, r15
+  Index        r203, r202, r9
   // s_store_id: g.key.s_store_id,
-  Move         r211, r11
-  Index        r212, r204, r15
-  Index        r213, r212, r11
+  Const        r204, "s_store_id"
+  Index        r205, r197, r15
+  Index        r206, r205, r11
   // s_store_name: g.key.s_store_name,
-  Move         r214, r12
-  Index        r215, r204, r15
-  Index        r216, r215, r12
+  Const        r207, "s_store_name"
+  Index        r208, r197, r15
+  Index        r209, r208, r12
   // store_sales_profit: sum(from x in g select x.ss_net_profit),
-  Move         r217, r16
-  Move         r218, r172
-  IterPrep     r219, r204
-  Len          r220, r219
-  Move         r221, r200
+  Const        r210, "store_sales_profit"
+  Const        r211, []
+  IterPrep     r212, r197
+  Len          r213, r212
+  Move         r214, r193
+L23:
+  LessInt      r215, r214, r213
+  JumpIfFalse  r215, L22
+  Index        r217, r212, r214
+  Index        r218, r217, r17
+  Append       r211, r211, r218
+  AddInt       r214, r214, r190
+  Jump         L23
+L22:
+  Sum          r220, r211
+  // store_returns_loss: sum(from x in g select x.sr_net_loss),
+  Const        r221, "store_returns_loss"
+  Const        r222, []
+  IterPrep     r223, r197
+  Len          r224, r223
+  Move         r225, r193
 L25:
-  LessInt      r222, r221, r220
-  JumpIfFalse  r222, L24
-  Index        r224, r219, r221
-  Index        r225, r224, r17
-  Append       r218, r218, r225
-  AddInt       r221, r221, r197
+  LessInt      r226, r225, r224
+  JumpIfFalse  r226, L24
+  Index        r217, r223, r225
+  Index        r228, r217, r19
+  Append       r222, r222, r228
+  AddInt       r225, r225, r190
   Jump         L25
 L24:
-  Sum          r227, r218
-  // store_returns_loss: sum(from x in g select x.sr_net_loss),
-  Move         r228, r18
-  Move         r229, r6
-  IterPrep     r230, r204
-  Len          r231, r230
-  Move         r232, r200
+  Sum          r230, r222
+  // catalog_sales_profit: sum(from x in g select x.cs_net_profit)
+  Const        r231, "catalog_sales_profit"
+  Const        r232, []
+  IterPrep     r233, r197
+  Len          r234, r233
+  Move         r235, r193
 L27:
-  LessInt      r233, r232, r231
-  JumpIfFalse  r233, L26
-  Index        r224, r230, r232
-  Index        r235, r224, r19
-  Append       r229, r229, r235
-  AddInt       r232, r232, r197
+  LessInt      r236, r235, r234
+  JumpIfFalse  r236, L26
+  Index        r217, r233, r235
+  Index        r238, r217, r21
+  Append       r232, r232, r238
+  AddInt       r235, r235, r190
   Jump         L27
 L26:
-  Sum          r237, r229
-  // catalog_sales_profit: sum(from x in g select x.cs_net_profit)
-  Move         r238, r20
-  Move         r239, r6
-  IterPrep     r240, r204
-  Len          r241, r240
-  Move         r242, r200
-L29:
-  LessInt      r243, r242, r241
-  JumpIfFalse  r243, L28
-  Index        r224, r240, r242
-  Index        r245, r224, r21
-  Append       r239, r239, r245
-  AddInt       r242, r242, r197
-  Jump         L29
-L28:
-  Sum          r247, r239
+  Sum          r240, r232
   // i_item_id: g.key.item_id,
-  Move         r248, r205
-  Move         r249, r207
+  Move         r241, r198
+  Move         r242, r200
   // i_item_desc: g.key.item_desc,
-  Move         r250, r208
-  Move         r251, r210
+  Move         r243, r201
+  Move         r244, r203
   // s_store_id: g.key.s_store_id,
-  Move         r252, r211
-  Move         r253, r213
+  Move         r245, r204
+  Move         r246, r206
   // s_store_name: g.key.s_store_name,
-  Move         r254, r214
-  Move         r255, r216
+  Move         r247, r207
+  Move         r248, r209
   // store_sales_profit: sum(from x in g select x.ss_net_profit),
-  Move         r256, r217
-  Move         r257, r227
+  Move         r249, r210
+  Move         r250, r220
   // store_returns_loss: sum(from x in g select x.sr_net_loss),
-  Move         r258, r228
-  Move         r259, r237
+  Move         r251, r221
+  Move         r252, r230
   // catalog_sales_profit: sum(from x in g select x.cs_net_profit)
-  Move         r260, r238
-  Move         r261, r247
+  Move         r253, r231
+  Move         r254, r240
   // select {
-  MakeMap      r262, 7, r248
+  MakeMap      r255, 7, r241
   // from ss in store_sales
-  Append       r6, r6, r262
-  AddInt       r199, r199, r197
-  Jump         L30
-L23:
+  Append       r6, r6, r255
+  AddInt       r192, r192, r190
+  Jump         L28
+L21:
   // json(result)
   JSON         r6
   // expect result == [
-  Const        r264, [{"catalog_sales_profit": 30, "i_item_desc": "Desc1", "i_item_id": "ITEM1", "s_store_id": "S1", "s_store_name": "Store1", "store_returns_loss": 10, "store_sales_profit": 50}]
-  Equal        r265, r6, r264
-  Expect       r265
+  Const        r257, [{"catalog_sales_profit": 30, "i_item_desc": "Desc1", "i_item_id": "ITEM1", "s_store_id": "S1", "s_store_name": "Store1", "store_returns_loss": 10, "store_sales_profit": 50}]
+  Equal        r258, r6, r257
+  Expect       r258
   Return       r0

--- a/tests/dataset/tpc-ds/out/q26.ir.out
+++ b/tests/dataset/tpc-ds/out/q26.ir.out
@@ -1,14 +1,14 @@
-func main (regs=201)
+func main (regs=196)
   // let catalog_sales = [
-  Const        r0, [{"cs_bill_cdemo_sk": 1, "cs_coupon_amt": 5, "cs_item_sk": 1, "cs_list_price": 100, "cs_promo_sk": 1, "cs_quantity": 10, "cs_sales_price": 95, "cs_sold_date_sk": 1}]
+  Const        r0, [{"cs_bill_cdemo_sk": 1, "cs_coupon_amt": 5, "cs_item_sk": 1, "cs_list_price": 100, "cs_promo_sk": 1, "cs_quantity": 10, "cs_sales_price": 95, "cs_sold_date_sk": 1}, {"cs_bill_cdemo_sk": 2, "cs_coupon_amt": 2, "cs_item_sk": 2, "cs_list_price": 50, "cs_promo_sk": 2, "cs_quantity": 5, "cs_sales_price": 48, "cs_sold_date_sk": 1}]
   // let customer_demographics = [
-  Const        r1, [{"cd_demo_sk": 1, "cd_education_status": "College", "cd_gender": "M", "cd_marital_status": "S"}]
+  Const        r1, [{"cd_demo_sk": 1, "cd_education_status": "College", "cd_gender": "M", "cd_marital_status": "S"}, {"cd_demo_sk": 2, "cd_education_status": "High School", "cd_gender": "F", "cd_marital_status": "M"}]
   // let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
   Const        r2, [{"d_date_sk": 1, "d_year": 2000}]
-  // let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
-  Const        r3, [{"i_item_id": "ITEM1", "i_item_sk": 1}]
-  // let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" } ]
-  Const        r4, [{"p_channel_email": "N", "p_channel_event": "Y", "p_promo_sk": 1}]
+  // let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" } ]
+  Const        r3, [{"i_item_id": "ITEM1", "i_item_sk": 1}, {"i_item_id": "ITEM2", "i_item_sk": 2}]
+  // let promotion = [ { p_promo_sk: 1, p_channel_email: "N", p_channel_event: "Y" }, { p_promo_sk: 2, p_channel_email: "Y", p_channel_event: "N" } ]
+  Const        r4, [{"p_channel_email": "N", "p_channel_event": "Y", "p_promo_sk": 1}, {"p_channel_email": "Y", "p_channel_event": "N", "p_promo_sk": 2}]
   // from cs in catalog_sales
   Const        r5, []
   // group by i.i_item_id into g
@@ -36,19 +36,19 @@ func main (regs=201)
   Const        r21, "cs_sales_price"
   // from cs in catalog_sales
   MakeMap      r22, 0, r0
-  Move         r23, r5
+  Const        r23, []
   IterPrep     r25, r0
   Len          r26, r25
   Const        r27, 0
-L1:
+L13:
   LessInt      r28, r27, r26
   JumpIfFalse  r28, L0
   Index        r30, r25, r27
   // join cd in customer_demographics on cs.cs_bill_cdemo_sk == cd.cd_demo_sk
   IterPrep     r31, r1
   Len          r32, r31
-  Move         r33, r27
-L2:
+  Const        r33, 0
+L12:
   LessInt      r34, r33, r32
   JumpIfFalse  r34, L1
   Index        r36, r31, r33
@@ -61,8 +61,8 @@ L2:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   IterPrep     r42, r2
   Len          r43, r42
-  Move         r44, r27
-L13:
+  Const        r44, 0
+L11:
   LessInt      r45, r44, r43
   JumpIfFalse  r45, L2
   Index        r47, r42, r44
@@ -75,8 +75,8 @@ L13:
   // join i in item on cs.cs_item_sk == i.i_item_sk
   IterPrep     r53, r3
   Len          r54, r53
-  Move         r55, r44
-L12:
+  Const        r55, 0
+L10:
   LessInt      r56, r55, r54
   JumpIfFalse  r56, L3
   Index        r58, r53, r55
@@ -89,8 +89,8 @@ L12:
   // join p in promotion on cs.cs_promo_sk == p.p_promo_sk
   IterPrep     r64, r4
   Len          r65, r64
-  Move         r66, r27
-L11:
+  Const        r66, 0
+L9:
   LessInt      r67, r66, r65
   JumpIfFalse  r67, L4
   Index        r69, r64, r66
@@ -113,192 +113,195 @@ L11:
   Index        r84, r47, r12
   Const        r85, 2000
   Equal        r86, r84, r85
-  Move         r87, r77
-  JumpIfFalse  r87, L6
-L6:
-  Move         r88, r80
-  JumpIfFalse  r88, L7
+  JumpIfFalse  r77, L6
+  Move         r77, r80
+  JumpIfFalse  r77, L6
+  Move         r77, r83
+  JumpIfFalse  r77, L6
+  Index        r87, r69, r10
+  Const        r88, "N"
+  Equal        r89, r87, r88
+  Index        r90, r69, r11
+  Equal        r91, r90, r88
+  JumpIfTrue   r89, L7
 L7:
-  Move         r89, r83
-  JumpIfFalse  r89, L8
-  Index        r90, r69, r10
-  Const        r91, "N"
-  Equal        r92, r90, r91
-  Index        r93, r69, r11
-  Equal        r94, r93, r91
-  Move         r95, r92
-  JumpIfTrue   r95, L8
-L8:
-  Move         r96, r94
-  JumpIfFalse  r96, L9
-  Move         r96, r86
-L9:
-  JumpIfFalse  r96, L5
+  Move         r77, r91
+  JumpIfFalse  r77, L6
+  Move         r77, r86
+L6:
+  JumpIfFalse  r77, L5
   // from cs in catalog_sales
-  Const        r97, "cs"
-  Move         r98, r30
-  Const        r99, "cd"
-  Move         r100, r36
-  Const        r101, "d"
-  Move         r102, r47
-  Const        r103, "i"
-  Move         r104, r58
-  Const        r105, "p"
-  Move         r106, r69
-  MakeMap      r107, 5, r97
+  Const        r92, "cs"
+  Move         r93, r30
+  Const        r94, "cd"
+  Move         r95, r36
+  Const        r96, "d"
+  Move         r97, r47
+  Const        r98, "i"
+  Move         r99, r58
+  Const        r100, "p"
+  Move         r101, r69
+  MakeMap      r102, 5, r92
   // group by i.i_item_id into g
-  Index        r108, r58, r6
-  Str          r109, r108
-  In           r110, r109, r22
-  JumpIfTrue   r110, L10
+  Index        r103, r58, r6
+  Str          r104, r103
+  In           r105, r104, r22
+  JumpIfTrue   r105, L8
   // from cs in catalog_sales
-  Move         r111, r5
-  Const        r112, "__group__"
-  Const        r113, true
-  Move         r114, r13
+  Const        r106, []
+  Const        r107, "__group__"
+  Const        r108, true
+  Const        r109, "key"
   // group by i.i_item_id into g
-  Move         r115, r108
+  Move         r110, r103
   // from cs in catalog_sales
-  Const        r116, "items"
-  Move         r117, r111
-  Const        r118, "count"
-  Move         r119, r66
+  Const        r111, "items"
+  Move         r112, r106
+  Const        r113, "count"
+  Const        r114, 0
+  Move         r115, r107
+  Move         r116, r108
+  Move         r117, r109
+  Move         r118, r110
+  Move         r119, r111
   Move         r120, r112
   Move         r121, r113
   Move         r122, r114
-  Move         r123, r115
-  Move         r124, r116
-  Move         r125, r117
-  Move         r126, r118
-  Move         r127, r119
-  MakeMap      r128, 4, r120
-  SetIndex     r22, r109, r128
-  Append       r23, r23, r128
-L10:
-  Move         r130, r116
-  Index        r131, r22, r109
-  Index        r132, r131, r130
-  Append       r133, r132, r107
-  SetIndex     r131, r130, r133
-  Move         r134, r118
-  Index        r135, r131, r134
-  Const        r136, 1
-  AddInt       r137, r135, r136
-  SetIndex     r131, r134, r137
+  MakeMap      r123, 4, r115
+  SetIndex     r22, r104, r123
+  Append       r23, r23, r123
+L8:
+  Const        r125, "items"
+  Index        r126, r22, r104
+  Index        r127, r126, r125
+  Append       r128, r127, r102
+  SetIndex     r126, r125, r128
+  Const        r129, "count"
+  Index        r130, r126, r129
+  Const        r131, 1
+  AddInt       r132, r130, r131
+  SetIndex     r126, r129, r132
 L5:
   // join p in promotion on cs.cs_promo_sk == p.p_promo_sk
-  AddInt       r66, r66, r136
-  Jump         L11
+  AddInt       r66, r66, r131
+  Jump         L9
 L4:
   // join i in item on cs.cs_item_sk == i.i_item_sk
-  AddInt       r55, r55, r136
-  Jump         L12
+  AddInt       r55, r55, r131
+  Jump         L10
 L3:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r44, r44, r136
+  AddInt       r44, r44, r131
+  Jump         L11
+L2:
+  // join cd in customer_demographics on cs.cs_bill_cdemo_sk == cd.cd_demo_sk
+  AddInt       r33, r33, r131
+  Jump         L12
+L1:
+  // from cs in catalog_sales
+  AddInt       r27, r27, r131
   Jump         L13
 L0:
-  // from cs in catalog_sales
-  Move         r139, r27
-  Move         r138, r139
-  Len          r140, r23
+  Const        r134, 0
+  Move         r133, r134
+  Len          r135, r23
 L23:
-  LessInt      r141, r138, r140
-  JumpIfFalse  r141, L14
-  Index        r143, r23, r138
+  LessInt      r136, r133, r135
+  JumpIfFalse  r136, L14
+  Index        r138, r23, r133
   // i_item_id: g.key,
-  Move         r144, r6
-  Index        r145, r143, r13
+  Const        r139, "i_item_id"
+  Index        r140, r138, r13
   // agg1: avg(from x in g select x.cs_quantity),
-  Move         r146, r14
-  Move         r147, r111
-  IterPrep     r148, r143
-  Len          r149, r148
-  Move         r150, r139
+  Const        r141, "agg1"
+  Const        r142, []
+  IterPrep     r143, r138
+  Len          r144, r143
+  Move         r145, r134
 L16:
-  LessInt      r151, r150, r149
-  JumpIfFalse  r151, L15
-  Index        r153, r148, r150
-  Index        r154, r153, r15
-  Append       r147, r147, r154
-  AddInt       r150, r150, r136
+  LessInt      r146, r145, r144
+  JumpIfFalse  r146, L15
+  Index        r148, r143, r145
+  Index        r149, r148, r15
+  Append       r142, r142, r149
+  AddInt       r145, r145, r131
   Jump         L16
 L15:
-  Avg          r156, r147
+  Avg          r151, r142
   // agg2: avg(from x in g select x.cs_list_price),
-  Move         r157, r16
-  Move         r158, r5
-  IterPrep     r159, r143
-  Len          r160, r159
-  Move         r161, r139
+  Const        r152, "agg2"
+  Const        r153, []
+  IterPrep     r154, r138
+  Len          r155, r154
+  Move         r156, r134
 L18:
-  LessInt      r162, r161, r160
-  JumpIfFalse  r162, L17
-  Index        r153, r159, r161
-  Index        r164, r153, r17
-  Append       r158, r158, r164
-  AddInt       r161, r161, r136
+  LessInt      r157, r156, r155
+  JumpIfFalse  r157, L17
+  Index        r148, r154, r156
+  Index        r159, r148, r17
+  Append       r153, r153, r159
+  AddInt       r156, r156, r131
   Jump         L18
 L17:
-  Avg          r166, r158
+  Avg          r161, r153
   // agg3: avg(from x in g select x.cs_coupon_amt),
-  Move         r167, r18
-  Move         r168, r5
-  IterPrep     r169, r143
-  Len          r170, r169
-  Move         r171, r139
+  Const        r162, "agg3"
+  Const        r163, []
+  IterPrep     r164, r138
+  Len          r165, r164
+  Move         r166, r134
 L20:
-  LessInt      r172, r171, r170
-  JumpIfFalse  r172, L19
-  Index        r153, r169, r171
-  Index        r174, r153, r19
-  Append       r168, r168, r174
-  AddInt       r171, r171, r136
+  LessInt      r167, r166, r165
+  JumpIfFalse  r167, L19
+  Index        r148, r164, r166
+  Index        r169, r148, r19
+  Append       r163, r163, r169
+  AddInt       r166, r166, r131
   Jump         L20
 L19:
-  Avg          r176, r168
+  Avg          r171, r163
   // agg4: avg(from x in g select x.cs_sales_price)
-  Move         r177, r20
-  Move         r178, r5
-  IterPrep     r179, r143
-  Len          r180, r179
-  Move         r181, r139
+  Const        r172, "agg4"
+  Const        r173, []
+  IterPrep     r174, r138
+  Len          r175, r174
+  Move         r176, r134
 L22:
-  LessInt      r182, r181, r180
-  JumpIfFalse  r182, L21
-  Index        r153, r179, r181
-  Index        r184, r153, r21
-  Append       r178, r178, r184
-  AddInt       r181, r181, r136
+  LessInt      r177, r176, r175
+  JumpIfFalse  r177, L21
+  Index        r148, r174, r176
+  Index        r179, r148, r21
+  Append       r173, r173, r179
+  AddInt       r176, r176, r131
   Jump         L22
 L21:
-  Avg          r186, r178
+  Avg          r181, r173
   // i_item_id: g.key,
-  Move         r187, r144
-  Move         r188, r145
+  Move         r182, r139
+  Move         r183, r140
   // agg1: avg(from x in g select x.cs_quantity),
-  Move         r189, r146
-  Move         r190, r156
+  Move         r184, r141
+  Move         r185, r151
   // agg2: avg(from x in g select x.cs_list_price),
-  Move         r191, r157
-  Move         r192, r166
+  Move         r186, r152
+  Move         r187, r161
   // agg3: avg(from x in g select x.cs_coupon_amt),
-  Move         r193, r167
-  Move         r194, r176
+  Move         r188, r162
+  Move         r189, r171
   // agg4: avg(from x in g select x.cs_sales_price)
-  Move         r195, r177
-  Move         r196, r186
+  Move         r190, r172
+  Move         r191, r181
   // select {
-  MakeMap      r197, 5, r187
+  MakeMap      r192, 5, r182
   // from cs in catalog_sales
-  Append       r5, r5, r197
-  AddInt       r138, r138, r136
+  Append       r5, r5, r192
+  AddInt       r133, r133, r131
   Jump         L23
 L14:
   // json(result)
   JSON         r5
   // expect result == [
-  Const        r199, [{"agg1": 10, "agg2": 100, "agg3": 5, "agg4": 95, "i_item_id": "ITEM1"}]
-  Equal        r200, r5, r199
-  Expect       r200
+  Const        r194, [{"agg1": 10, "agg2": 100, "agg3": 5, "agg4": 95, "i_item_id": "ITEM1"}]
+  Equal        r195, r5, r194
+  Expect       r195
   Return       r0

--- a/tests/dataset/tpc-ds/out/q27.ir.out
+++ b/tests/dataset/tpc-ds/out/q27.ir.out
@@ -1,14 +1,14 @@
-func main (regs=224)
+func main (regs=220)
   // let store_sales = [
-  Const        r0, [{"ss_cdemo_sk": 1, "ss_coupon_amt": 10, "ss_item_sk": 1, "ss_list_price": 100, "ss_quantity": 5, "ss_sales_price": 90, "ss_sold_date_sk": 1, "ss_store_sk": 1}]
-  // let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" } ]
-  Const        r1, [{"cd_demo_sk": 1, "cd_education_status": "College", "cd_gender": "F", "cd_marital_status": "M"}]
+  Const        r0, [{"ss_cdemo_sk": 1, "ss_coupon_amt": 10, "ss_item_sk": 1, "ss_list_price": 100, "ss_quantity": 5, "ss_sales_price": 90, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_cdemo_sk": 2, "ss_coupon_amt": 5, "ss_item_sk": 2, "ss_list_price": 50, "ss_quantity": 2, "ss_sales_price": 45, "ss_sold_date_sk": 1, "ss_store_sk": 2}]
+  // let customer_demographics = [ { cd_demo_sk: 1, cd_gender: "F", cd_marital_status: "M", cd_education_status: "College" }, { cd_demo_sk: 2, cd_gender: "M", cd_marital_status: "S", cd_education_status: "College" } ]
+  Const        r1, [{"cd_demo_sk": 1, "cd_education_status": "College", "cd_gender": "F", "cd_marital_status": "M"}, {"cd_demo_sk": 2, "cd_education_status": "College", "cd_gender": "M", "cd_marital_status": "S"}]
   // let date_dim = [ { d_date_sk: 1, d_year: 2000 } ]
   Const        r2, [{"d_date_sk": 1, "d_year": 2000}]
-  // let store = [ { s_store_sk: 1, s_state: "CA" } ]
-  Const        r3, [{"s_state": "CA", "s_store_sk": 1}]
-  // let item = [ { i_item_sk: 1, i_item_id: "ITEM1" } ]
-  Const        r4, [{"i_item_id": "ITEM1", "i_item_sk": 1}]
+  // let store = [ { s_store_sk: 1, s_state: "CA" }, { s_store_sk: 2, s_state: "TX" } ]
+  Const        r3, [{"s_state": "CA", "s_store_sk": 1}, {"s_state": "TX", "s_store_sk": 2}]
+  // let item = [ { i_item_sk: 1, i_item_id: "ITEM1" }, { i_item_sk: 2, i_item_id: "ITEM2" } ]
+  Const        r4, [{"i_item_id": "ITEM1", "i_item_sk": 1}, {"i_item_id": "ITEM2", "i_item_sk": 2}]
   // from ss in store_sales
   Const        r5, []
   // group by { item_id: i.i_item_id, state: s.s_state } into g
@@ -37,19 +37,19 @@ func main (regs=224)
   Const        r22, "ss_sales_price"
   // from ss in store_sales
   MakeMap      r23, 0, r0
-  Move         r24, r5
+  Const        r24, []
   IterPrep     r26, r0
   Len          r27, r26
   Const        r28, 0
-L1:
+L12:
   LessInt      r29, r28, r27
   JumpIfFalse  r29, L0
   Index        r31, r26, r28
   // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
   IterPrep     r32, r1
   Len          r33, r32
-  Move         r34, r28
-L2:
+  Const        r34, 0
+L11:
   LessInt      r35, r34, r33
   JumpIfFalse  r35, L1
   Index        r37, r32, r34
@@ -62,8 +62,8 @@ L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   IterPrep     r43, r2
   Len          r44, r43
-  Move         r45, r28
-L13:
+  Const        r45, 0
+L10:
   LessInt      r46, r45, r44
   JumpIfFalse  r46, L2
   Index        r48, r43, r45
@@ -76,8 +76,8 @@ L13:
   // join s in store on ss.ss_store_sk == s.s_store_sk
   IterPrep     r54, r3
   Len          r55, r54
-  Move         r56, r45
-L12:
+  Const        r56, 0
+L9:
   LessInt      r57, r56, r55
   JumpIfFalse  r57, L3
   Index        r59, r54, r56
@@ -90,8 +90,8 @@ L12:
   // join i in item on ss.ss_item_sk == i.i_item_sk
   IterPrep     r65, r4
   Len          r66, r65
-  Move         r67, r28
-L11:
+  Const        r67, 0
+L8:
   LessInt      r68, r67, r66
   JumpIfFalse  r68, L4
   Index        r70, r65, r67
@@ -117,210 +117,214 @@ L11:
   Index        r88, r59, r9
   Const        r89, ["CA"]
   In           r90, r88, r89
-  Move         r91, r78
-  JumpIfFalse  r91, L6
+  JumpIfFalse  r78, L6
+  Move         r78, r81
+  JumpIfFalse  r78, L6
+  Move         r78, r84
+  JumpIfFalse  r78, L6
+  Move         r78, r87
+  JumpIfFalse  r78, L6
+  Move         r78, r90
 L6:
-  Move         r92, r81
-  JumpIfFalse  r92, L7
-L7:
-  Move         r93, r84
-  JumpIfFalse  r93, L8
-L8:
-  Move         r94, r87
-  JumpIfFalse  r94, L9
-  Move         r94, r90
-L9:
-  JumpIfFalse  r94, L5
+  JumpIfFalse  r78, L5
   // from ss in store_sales
-  Const        r95, "ss"
-  Move         r96, r31
-  Const        r97, "cd"
-  Move         r98, r37
-  Const        r99, "d"
-  Move         r100, r48
-  Const        r101, "s"
-  Move         r102, r59
-  Const        r103, "i"
-  Move         r104, r70
-  MakeMap      r105, 5, r95
+  Const        r91, "ss"
+  Move         r92, r31
+  Const        r93, "cd"
+  Move         r94, r37
+  Const        r95, "d"
+  Move         r96, r48
+  Const        r97, "s"
+  Move         r98, r59
+  Const        r99, "i"
+  Move         r100, r70
+  MakeMap      r101, 5, r91
   // group by { item_id: i.i_item_id, state: s.s_state } into g
-  Move         r106, r6
-  Index        r107, r70, r7
-  Move         r108, r8
-  Index        r109, r59, r9
-  Move         r110, r106
-  Move         r111, r107
-  Move         r112, r108
-  Move         r113, r109
-  MakeMap      r114, 2, r110
-  Str          r115, r114
-  In           r116, r115, r23
-  JumpIfTrue   r116, L10
+  Const        r102, "item_id"
+  Index        r103, r70, r7
+  Const        r104, "state"
+  Index        r105, r59, r9
+  Move         r106, r102
+  Move         r107, r103
+  Move         r108, r104
+  Move         r109, r105
+  MakeMap      r110, 2, r106
+  Str          r111, r110
+  In           r112, r111, r23
+  JumpIfTrue   r112, L7
   // from ss in store_sales
-  Move         r117, r5
-  Const        r118, "__group__"
-  Const        r119, true
-  Move         r120, r14
+  Const        r113, []
+  Const        r114, "__group__"
+  Const        r115, true
+  Const        r116, "key"
   // group by { item_id: i.i_item_id, state: s.s_state } into g
-  Move         r121, r114
+  Move         r117, r110
   // from ss in store_sales
-  Const        r122, "items"
-  Move         r123, r117
-  Const        r124, "count"
-  Move         r125, r67
+  Const        r118, "items"
+  Move         r119, r113
+  Const        r120, "count"
+  Const        r121, 0
+  Move         r122, r114
+  Move         r123, r115
+  Move         r124, r116
+  Move         r125, r117
   Move         r126, r118
   Move         r127, r119
   Move         r128, r120
   Move         r129, r121
-  Move         r130, r122
-  Move         r131, r123
-  Move         r132, r124
-  Move         r133, r125
-  MakeMap      r134, 4, r126
-  SetIndex     r23, r115, r134
-  Append       r24, r24, r134
-L10:
-  Move         r136, r122
-  Index        r137, r23, r115
-  Index        r138, r137, r136
-  Append       r139, r138, r105
-  SetIndex     r137, r136, r139
-  Move         r140, r124
-  Index        r141, r137, r140
-  Const        r142, 1
-  AddInt       r143, r141, r142
-  SetIndex     r137, r140, r143
+  MakeMap      r130, 4, r122
+  SetIndex     r23, r111, r130
+  Append       r24, r24, r130
+L7:
+  Const        r132, "items"
+  Index        r133, r23, r111
+  Index        r134, r133, r132
+  Append       r135, r134, r101
+  SetIndex     r133, r132, r135
+  Const        r136, "count"
+  Index        r137, r133, r136
+  Const        r138, 1
+  AddInt       r139, r137, r138
+  SetIndex     r133, r136, r139
 L5:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r67, r67, r142
-  Jump         L11
+  AddInt       r67, r67, r138
+  Jump         L8
 L4:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r56, r56, r142
-  Jump         L12
+  AddInt       r56, r56, r138
+  Jump         L9
 L3:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r45, r45, r142
-  Jump         L13
+  AddInt       r45, r45, r138
+  Jump         L10
+L2:
+  // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
+  AddInt       r34, r34, r138
+  Jump         L11
+L1:
+  // from ss in store_sales
+  AddInt       r28, r28, r138
+  Jump         L12
 L0:
-  // from ss in store_sales
-  Move         r145, r28
-  Move         r144, r145
-  Len          r146, r24
-L23:
-  LessInt      r147, r144, r146
-  JumpIfFalse  r147, L14
-  Index        r149, r24, r144
-  // i_item_id: g.key.item_id,
-  Move         r150, r7
-  Index        r151, r149, r14
-  Index        r152, r151, r6
-  // s_state: g.key.state,
-  Move         r153, r9
-  Index        r154, r149, r14
-  Index        r155, r154, r8
-  // agg1: avg(from x in g select x.ss_quantity),
-  Move         r156, r15
-  Move         r157, r117
-  IterPrep     r158, r149
-  Len          r159, r158
-  Move         r160, r145
-L16:
-  LessInt      r161, r160, r159
-  JumpIfFalse  r161, L15
-  Index        r163, r158, r160
-  Index        r164, r163, r16
-  Append       r157, r157, r164
-  AddInt       r160, r160, r142
-  Jump         L16
-L15:
-  Avg          r166, r157
-  // agg2: avg(from x in g select x.ss_list_price),
-  Move         r167, r17
-  Move         r168, r5
-  IterPrep     r169, r149
-  Len          r170, r169
-  Move         r171, r145
-L18:
-  LessInt      r172, r171, r170
-  JumpIfFalse  r172, L17
-  Index        r163, r169, r171
-  Index        r174, r163, r18
-  Append       r168, r168, r174
-  AddInt       r171, r171, r142
-  Jump         L18
-L17:
-  Avg          r176, r168
-  // agg3: avg(from x in g select x.ss_coupon_amt),
-  Move         r177, r19
-  Move         r178, r5
-  IterPrep     r179, r149
-  Len          r180, r179
-  Move         r181, r145
-L20:
-  LessInt      r182, r181, r180
-  JumpIfFalse  r182, L19
-  Index        r163, r179, r181
-  Index        r184, r163, r20
-  Append       r178, r178, r184
-  AddInt       r181, r181, r142
-  Jump         L20
-L19:
-  Avg          r186, r178
-  // agg4: avg(from x in g select x.ss_sales_price)
-  Move         r187, r21
-  Move         r188, r5
-  IterPrep     r189, r149
-  Len          r190, r189
-  Move         r191, r145
+  Const        r141, 0
+  Move         r140, r141
+  Len          r142, r24
 L22:
-  LessInt      r192, r191, r190
-  JumpIfFalse  r192, L21
-  Index        r163, r189, r191
-  Index        r194, r163, r22
-  Append       r188, r188, r194
-  AddInt       r191, r191, r142
-  Jump         L22
-L21:
-  Avg          r196, r188
+  LessInt      r143, r140, r142
+  JumpIfFalse  r143, L13
+  Index        r145, r24, r140
   // i_item_id: g.key.item_id,
-  Move         r197, r150
-  Move         r198, r152
+  Const        r146, "i_item_id"
+  Index        r147, r145, r14
+  Index        r148, r147, r6
   // s_state: g.key.state,
-  Move         r199, r153
-  Move         r200, r155
+  Const        r149, "s_state"
+  Index        r150, r145, r14
+  Index        r151, r150, r8
   // agg1: avg(from x in g select x.ss_quantity),
-  Move         r201, r156
-  Move         r202, r166
-  // agg2: avg(from x in g select x.ss_list_price),
-  Move         r203, r167
-  Move         r204, r176
-  // agg3: avg(from x in g select x.ss_coupon_amt),
-  Move         r205, r177
-  Move         r206, r186
-  // agg4: avg(from x in g select x.ss_sales_price)
-  Move         r207, r187
-  Move         r208, r196
-  // select {
-  MakeMap      r209, 6, r197
-  // sort by [g.key.item_id, g.key.state]
-  Index        r210, r149, r14
-  Index        r212, r210, r6
-  Index        r213, r149, r14
-  MakeList     r217, 2, r212
-  // from ss in store_sales
-  Move         r218, r209
-  MakeList     r219, 2, r217
-  Append       r5, r5, r219
-  AddInt       r144, r144, r142
-  Jump         L23
+  Const        r152, "agg1"
+  Const        r153, []
+  IterPrep     r154, r145
+  Len          r155, r154
+  Move         r156, r141
+L15:
+  LessInt      r157, r156, r155
+  JumpIfFalse  r157, L14
+  Index        r159, r154, r156
+  Index        r160, r159, r16
+  Append       r153, r153, r160
+  AddInt       r156, r156, r138
+  Jump         L15
 L14:
+  Avg          r162, r153
+  // agg2: avg(from x in g select x.ss_list_price),
+  Const        r163, "agg2"
+  Const        r164, []
+  IterPrep     r165, r145
+  Len          r166, r165
+  Move         r167, r141
+L17:
+  LessInt      r168, r167, r166
+  JumpIfFalse  r168, L16
+  Index        r159, r165, r167
+  Index        r170, r159, r18
+  Append       r164, r164, r170
+  AddInt       r167, r167, r138
+  Jump         L17
+L16:
+  Avg          r172, r164
+  // agg3: avg(from x in g select x.ss_coupon_amt),
+  Const        r173, "agg3"
+  Const        r174, []
+  IterPrep     r175, r145
+  Len          r176, r175
+  Move         r177, r141
+L19:
+  LessInt      r178, r177, r176
+  JumpIfFalse  r178, L18
+  Index        r159, r175, r177
+  Index        r180, r159, r20
+  Append       r174, r174, r180
+  AddInt       r177, r177, r138
+  Jump         L19
+L18:
+  Avg          r182, r174
+  // agg4: avg(from x in g select x.ss_sales_price)
+  Const        r183, "agg4"
+  Const        r184, []
+  IterPrep     r185, r145
+  Len          r186, r185
+  Move         r187, r141
+L21:
+  LessInt      r188, r187, r186
+  JumpIfFalse  r188, L20
+  Index        r159, r185, r187
+  Index        r190, r159, r22
+  Append       r184, r184, r190
+  AddInt       r187, r187, r138
+  Jump         L21
+L20:
+  Avg          r192, r184
+  // i_item_id: g.key.item_id,
+  Move         r193, r146
+  Move         r194, r148
+  // s_state: g.key.state,
+  Move         r195, r149
+  Move         r196, r151
+  // agg1: avg(from x in g select x.ss_quantity),
+  Move         r197, r152
+  Move         r198, r162
+  // agg2: avg(from x in g select x.ss_list_price),
+  Move         r199, r163
+  Move         r200, r172
+  // agg3: avg(from x in g select x.ss_coupon_amt),
+  Move         r201, r173
+  Move         r202, r182
+  // agg4: avg(from x in g select x.ss_sales_price)
+  Move         r203, r183
+  Move         r204, r192
+  // select {
+  MakeMap      r205, 6, r193
+  // sort by [g.key.item_id, g.key.state]
+  Index        r206, r145, r14
+  Index        r208, r206, r6
+  Index        r209, r145, r14
+  Index        r211, r209, r8
+  MakeList     r213, 2, r208
+  // from ss in store_sales
+  Move         r214, r205
+  MakeList     r215, 2, r213
+  Append       r5, r5, r215
+  AddInt       r140, r140, r138
+  Jump         L22
+L13:
   // sort by [g.key.item_id, g.key.state]
   Sort         r5, r5
   // json(result)
   JSON         r5
   // expect result == [
-  Const        r222, [{"agg1": 5, "agg2": 100, "agg3": 10, "agg4": 90, "i_item_id": "ITEM1", "s_state": "CA"}]
-  Equal        r223, r5, r222
-  Expect       r223
+  Const        r218, [{"agg1": 5, "agg2": 100, "agg3": 10, "agg4": 90, "i_item_id": "ITEM1", "s_state": "CA"}]
+  Equal        r219, r5, r218
+  Expect       r219
   Return       r0

--- a/tests/dataset/tpc-ds/out/q28.ir.out
+++ b/tests/dataset/tpc-ds/out/q28.ir.out
@@ -1,6 +1,6 @@
-func main (regs=206)
+func main (regs=192)
   // let store_sales = [
-  Const        r0, [{"ss_coupon_amt": 50, "ss_list_price": 100, "ss_quantity": 3, "ss_wholesale_cost": 30}, {"ss_coupon_amt": 10, "ss_list_price": 80, "ss_quantity": 8, "ss_wholesale_cost": 20}]
+  Const        r0, [{"ss_coupon_amt": 50, "ss_list_price": 100, "ss_quantity": 3, "ss_wholesale_cost": 30}, {"ss_coupon_amt": 10, "ss_list_price": 80, "ss_quantity": 8, "ss_wholesale_cost": 20}, {"ss_coupon_amt": 5, "ss_list_price": 60, "ss_quantity": 12, "ss_wholesale_cost": 15}]
   // from ss in store_sales
   Const        r1, []
   // where ss.ss_quantity >= 0 && ss.ss_quantity <= 5
@@ -14,7 +14,7 @@ func main (regs=206)
   Len          r7, r6
   Const        r9, 0
   Move         r8, r9
-L7:
+L6:
   LessInt      r10, r8, r7
   JumpIfFalse  r10, L0
   Index        r12, r6, r8
@@ -24,291 +24,281 @@ L7:
   Index        r15, r12, r2
   Const        r16, 5
   LessEq       r17, r15, r16
-  Move         r18, r14
-  JumpIfFalse  r18, L1
-L1:
+  JumpIfFalse  r14, L1
+  Move         r14, r17
   // && ((ss.ss_list_price >= 0 && ss.ss_list_price <= 110) || (ss.ss_coupon_amt >= 0 && ss.ss_coupon_amt <= 1000) || (ss.ss_wholesale_cost >= 0 && ss.ss_wholesale_cost <= 50))
-  Move         r19, r17
-  JumpIfFalse  r19, L2
+  JumpIfFalse  r14, L1
+  Index        r18, r12, r3
+  LessEq       r19, r9, r18
   Index        r20, r12, r3
-  LessEq       r21, r9, r20
-  Index        r22, r12, r3
-  Const        r23, 110
-  LessEq       r24, r22, r23
-  Move         r25, r21
-  JumpIfFalse  r25, L3
-L3:
-  Move         r26, r24
-  JumpIfTrue   r26, L4
-  Index        r27, r12, r4
-  LessEq       r28, r9, r27
-  Index        r29, r12, r4
-  Const        r30, 1000
-  LessEq       r31, r29, r30
-  Move         r32, r28
-  JumpIfFalse  r32, L4
-L4:
-  Move         r33, r31
-  JumpIfTrue   r33, L5
-  Index        r34, r12, r5
-  LessEq       r35, r9, r34
-  Index        r36, r12, r5
-  Const        r37, 50
-  LessEq       r38, r36, r37
-  Move         r39, r35
-  JumpIfFalse  r39, L5
-L5:
-  Move         r19, r38
+  Const        r21, 110
+  LessEq       r22, r20, r21
+  JumpIfFalse  r19, L2
+  Move         r19, r22
 L2:
+  JumpIfTrue   r19, L3
+  Index        r23, r12, r4
+  LessEq       r24, r9, r23
+  Index        r25, r12, r4
+  Const        r26, 1000
+  LessEq       r27, r25, r26
+  JumpIfFalse  r24, L4
+L4:
+  Move         r19, r27
+  JumpIfTrue   r19, L3
+  Index        r28, r12, r5
+  LessEq       r29, r9, r28
+  Index        r30, r12, r5
+  Const        r31, 50
+  LessEq       r32, r30, r31
+  JumpIfFalse  r29, L3
+L3:
+  Move         r14, r32
+L1:
   // where ss.ss_quantity >= 0 && ss.ss_quantity <= 5
-  JumpIfFalse  r19, L6
+  JumpIfFalse  r14, L5
   // from ss in store_sales
   Append       r1, r1, r12
-L6:
-  Const        r41, 1
-  AddInt       r8, r8, r41
-  Jump         L7
+L5:
+  Const        r34, 1
+  AddInt       r8, r8, r34
+  Jump         L6
 L0:
   // from ss in store_sales
-  Const        r42, []
-  IterPrep     r43, r0
-  Len          r44, r43
-  Move         r45, r9
-L15:
-  LessInt      r46, r45, r44
-  JumpIfFalse  r46, L8
-  Index        r12, r43, r45
-  // where ss.ss_quantity >= 6 && ss.ss_quantity <= 10
-  Index        r48, r12, r2
-  Const        r49, 6
-  LessEq       r50, r49, r48
-  Index        r51, r12, r2
-  Const        r52, 10
-  LessEq       r53, r51, r52
-  Move         r54, r50
-  JumpIfFalse  r54, L9
-L9:
-  // && ((ss.ss_list_price >= 0 && ss.ss_list_price <= 110) || (ss.ss_coupon_amt >= 0 && ss.ss_coupon_amt <= 1000) || (ss.ss_wholesale_cost >= 0 && ss.ss_wholesale_cost <= 50))
-  Move         r55, r53
-  JumpIfFalse  r55, L10
-  Index        r56, r12, r3
-  LessEq       r57, r9, r56
-  Index        r58, r12, r3
-  LessEq       r59, r58, r23
-  Move         r60, r57
-  JumpIfFalse  r60, L11
-L11:
-  Move         r61, r59
-  JumpIfTrue   r61, L12
-  Index        r62, r12, r4
-  LessEq       r63, r9, r62
-  Index        r64, r12, r4
-  LessEq       r65, r64, r30
-  Move         r66, r63
-  JumpIfFalse  r66, L12
-L12:
-  Move         r67, r65
-  JumpIfTrue   r67, L13
-  Index        r68, r12, r5
-  LessEq       r69, r9, r68
-  Index        r70, r12, r5
-  LessEq       r71, r70, r37
-  Move         r72, r69
-  JumpIfFalse  r72, L13
+  Const        r35, []
+  IterPrep     r36, r0
+  Len          r37, r36
+  Move         r38, r9
 L13:
-  Move         r55, r71
-L10:
+  LessInt      r39, r38, r37
+  JumpIfFalse  r39, L7
+  Index        r12, r36, r38
   // where ss.ss_quantity >= 6 && ss.ss_quantity <= 10
-  JumpIfFalse  r55, L14
-  // from ss in store_sales
-  Append       r42, r42, r12
-L14:
-  AddInt       r45, r45, r41
-  Jump         L15
+  Index        r41, r12, r2
+  Const        r42, 6
+  LessEq       r43, r42, r41
+  Index        r44, r12, r2
+  Const        r45, 10
+  LessEq       r46, r44, r45
+  JumpIfFalse  r43, L8
+  Move         r43, r46
+  // && ((ss.ss_list_price >= 0 && ss.ss_list_price <= 110) || (ss.ss_coupon_amt >= 0 && ss.ss_coupon_amt <= 1000) || (ss.ss_wholesale_cost >= 0 && ss.ss_wholesale_cost <= 50))
+  JumpIfFalse  r43, L8
+  Index        r47, r12, r3
+  LessEq       r48, r9, r47
+  Index        r49, r12, r3
+  LessEq       r50, r49, r21
+  JumpIfFalse  r48, L9
+  Move         r48, r50
+L9:
+  JumpIfTrue   r48, L10
+  Index        r51, r12, r4
+  LessEq       r52, r9, r51
+  Index        r53, r12, r4
+  LessEq       r54, r53, r26
+  JumpIfFalse  r52, L11
+L11:
+  Move         r48, r54
+  JumpIfTrue   r48, L10
+  Index        r55, r12, r5
+  LessEq       r56, r9, r55
+  Index        r57, r12, r5
+  LessEq       r58, r57, r31
+  JumpIfFalse  r56, L10
+L10:
+  Move         r43, r58
 L8:
+  // where ss.ss_quantity >= 6 && ss.ss_quantity <= 10
+  JumpIfFalse  r43, L12
+  // from ss in store_sales
+  Append       r35, r35, r12
+L12:
+  AddInt       r38, r38, r34
+  Jump         L13
+L7:
   // B1_LP: avg(from x in bucket1 select x.ss_list_price),
-  Const        r74, "B1_LP"
-  Const        r75, []
+  Const        r60, "B1_LP"
+  Const        r61, []
+  IterPrep     r62, r1
+  Len          r63, r62
+  Move         r64, r9
+L15:
+  LessInt      r65, r64, r63
+  JumpIfFalse  r65, L14
+  Index        r67, r62, r64
+  Index        r68, r67, r3
+  Append       r61, r61, r68
+  AddInt       r64, r64, r34
+  Jump         L15
+L14:
+  Avg          r70, r61
+  // B1_CNT: count(bucket1),
+  Const        r71, "B1_CNT"
+  Count        r72, r1
+  // B1_CNTD: count(from x in bucket1 group by x.ss_list_price into g select g.key),
+  Const        r73, "B1_CNTD"
+  Const        r74, []
+  Const        r75, "key"
   IterPrep     r76, r1
   Len          r77, r76
-  Move         r78, r9
-L17:
-  LessInt      r79, r78, r77
-  JumpIfFalse  r79, L16
-  Index        r81, r76, r78
-  Index        r82, r81, r3
-  Append       r75, r75, r82
-  AddInt       r78, r78, r41
-  Jump         L17
-L16:
-  Avg          r84, r75
-  // B1_CNT: count(bucket1),
-  Const        r85, "B1_CNT"
-  Count        r86, r1
-  // B1_CNTD: count(from x in bucket1 group by x.ss_list_price into g select g.key),
-  Const        r87, "B1_CNTD"
-  Const        r88, []
-  Const        r89, "key"
-  IterPrep     r90, r1
-  Len          r91, r90
-  Move         r92, r9
-  MakeMap      r93, 0, r0
-  Move         r94, r88
-L20:
-  LessInt      r96, r92, r91
-  JumpIfFalse  r96, L18
-  Index        r97, r90, r92
-  Index        r98, r97, r3
-  Str          r99, r98
-  In           r100, r99, r93
-  JumpIfTrue   r100, L19
-  Move         r101, r88
-  Const        r102, "__group__"
-  Const        r103, true
-  Move         r104, r89
-  Move         r105, r98
-  Const        r106, "items"
-  Move         r107, r101
-  Const        r108, "count"
-  Move         r109, r9
-  Move         r110, r102
-  Move         r111, r103
-  Move         r112, r104
-  Move         r113, r105
-  Move         r114, r106
-  Move         r115, r107
-  Move         r116, r108
-  Move         r117, r109
-  MakeMap      r118, 4, r110
-  SetIndex     r93, r99, r118
-  Append       r94, r94, r118
-L19:
-  Move         r120, r106
-  Index        r121, r93, r99
-  Index        r122, r121, r120
-  Append       r123, r122, r97
-  SetIndex     r121, r120, r123
-  Move         r124, r108
-  Index        r125, r121, r124
-  AddInt       r126, r125, r41
-  SetIndex     r121, r124, r126
-  AddInt       r92, r92, r41
-  Jump         L20
+  Const        r78, 0
+  MakeMap      r79, 0, r0
+  Const        r80, []
 L18:
-  Move         r127, r9
-  Len          r128, r94
+  LessInt      r82, r78, r77
+  JumpIfFalse  r82, L16
+  Index        r83, r76, r78
+  Index        r84, r83, r3
+  Str          r85, r84
+  In           r86, r85, r79
+  JumpIfTrue   r86, L17
+  Const        r87, []
+  Const        r88, "__group__"
+  Const        r89, true
+  Const        r90, "key"
+  Move         r91, r84
+  Const        r92, "items"
+  Move         r93, r87
+  Const        r94, "count"
+  Const        r95, 0
+  Move         r96, r88
+  Move         r97, r89
+  Move         r98, r90
+  Move         r99, r91
+  Move         r100, r92
+  Move         r101, r93
+  Move         r102, r94
+  Move         r103, r95
+  MakeMap      r104, 4, r96
+  SetIndex     r79, r85, r104
+  Append       r80, r80, r104
+L17:
+  Const        r106, "items"
+  Index        r107, r79, r85
+  Index        r108, r107, r106
+  Append       r109, r108, r83
+  SetIndex     r107, r106, r109
+  Const        r110, "count"
+  Index        r111, r107, r110
+  AddInt       r112, r111, r34
+  SetIndex     r107, r110, r112
+  AddInt       r78, r78, r34
+  Jump         L18
+L16:
+  Move         r113, r9
+  Len          r114, r80
+L20:
+  LessInt      r115, r113, r114
+  JumpIfFalse  r115, L19
+  Index        r117, r80, r113
+  Index        r118, r117, r75
+  Append       r74, r74, r118
+  AddInt       r113, r113, r34
+  Jump         L20
+L19:
+  Count        r120, r74
+  // B2_LP: avg(from x in bucket2 select x.ss_list_price),
+  Const        r121, "B2_LP"
+  Const        r122, []
+  IterPrep     r123, r35
+  Len          r124, r123
+  Move         r125, r9
 L22:
-  LessInt      r129, r127, r128
-  JumpIfFalse  r129, L21
-  Index        r131, r94, r127
-  Index        r132, r131, r89
-  Append       r88, r88, r132
-  AddInt       r127, r127, r41
+  LessInt      r126, r125, r124
+  JumpIfFalse  r126, L21
+  Index        r67, r123, r125
+  Index        r128, r67, r3
+  Append       r122, r122, r128
+  AddInt       r125, r125, r34
   Jump         L22
 L21:
-  Count        r134, r88
-  // B2_LP: avg(from x in bucket2 select x.ss_list_price),
-  Const        r135, "B2_LP"
-  Move         r136, r101
-  IterPrep     r137, r42
-  Len          r138, r137
-  Move         r139, r9
-L24:
-  LessInt      r140, r139, r138
-  JumpIfFalse  r140, L23
-  Index        r81, r137, r139
-  Index        r142, r81, r3
-  Append       r136, r136, r142
-  AddInt       r139, r139, r41
-  Jump         L24
-L23:
-  Avg          r144, r136
+  Avg          r130, r122
   // B2_CNT: count(bucket2),
-  Const        r145, "B2_CNT"
-  Count        r146, r42
+  Const        r131, "B2_CNT"
+  Count        r132, r35
   // B2_CNTD: count(from x in bucket2 group by x.ss_list_price into g select g.key)
-  Const        r147, "B2_CNTD"
-  Const        r148, []
-  IterPrep     r149, r42
-  Len          r150, r149
-  Move         r151, r109
-  MakeMap      r152, 0, r0
-  Move         r153, r148
-L27:
-  LessInt      r155, r151, r150
-  JumpIfFalse  r155, L25
-  Index        r156, r149, r151
-  Index        r157, r156, r3
-  Str          r158, r157
-  In           r159, r158, r152
-  JumpIfTrue   r159, L26
-  Move         r160, r148
-  Move         r161, r102
-  Move         r162, r103
-  Move         r163, r89
-  Move         r164, r157
-  Move         r165, r106
-  Move         r166, r160
-  Move         r167, r108
-  Move         r168, r9
-  Move         r169, r161
-  Move         r170, r162
-  Move         r171, r163
-  Move         r172, r164
-  Move         r173, r165
-  Move         r174, r166
-  Move         r175, r167
-  Move         r176, r168
-  MakeMap      r177, 4, r169
-  SetIndex     r152, r158, r177
-  Append       r153, r153, r177
-L26:
-  Index        r179, r152, r158
-  Index        r180, r179, r120
-  Append       r181, r180, r156
-  SetIndex     r179, r120, r181
-  Index        r182, r179, r124
-  AddInt       r183, r182, r41
-  SetIndex     r179, r124, r183
-  AddInt       r151, r151, r41
-  Jump         L27
+  Const        r133, "B2_CNTD"
+  Const        r134, []
+  IterPrep     r135, r35
+  Len          r136, r135
+  Const        r137, 0
+  MakeMap      r138, 0, r0
+  Const        r139, []
 L25:
-  Move         r184, r9
-  Len          r185, r153
-L29:
-  LessInt      r186, r184, r185
-  JumpIfFalse  r186, L28
-  Index        r131, r153, r184
-  Index        r188, r131, r89
-  Append       r148, r148, r188
-  AddInt       r184, r184, r41
-  Jump         L29
-L28:
-  Count        r190, r148
+  LessInt      r141, r137, r136
+  JumpIfFalse  r141, L23
+  Index        r142, r135, r137
+  Index        r143, r142, r3
+  Str          r144, r143
+  In           r145, r144, r138
+  JumpIfTrue   r145, L24
+  Const        r146, []
+  Const        r147, "__group__"
+  Const        r148, true
+  Const        r149, "key"
+  Move         r150, r143
+  Const        r151, "items"
+  Move         r152, r146
+  Const        r153, "count"
+  Const        r154, 0
+  Move         r155, r147
+  Move         r156, r148
+  Move         r157, r149
+  Move         r158, r150
+  Move         r159, r151
+  Move         r160, r152
+  Move         r161, r153
+  Move         r162, r154
+  MakeMap      r163, 4, r155
+  SetIndex     r138, r144, r163
+  Append       r139, r139, r163
+L24:
+  Index        r165, r138, r144
+  Index        r166, r165, r106
+  Append       r167, r166, r142
+  SetIndex     r165, r106, r167
+  Index        r168, r165, r110
+  AddInt       r169, r168, r34
+  SetIndex     r165, r110, r169
+  AddInt       r137, r137, r34
+  Jump         L25
+L23:
+  Move         r170, r9
+  Len          r171, r139
+L27:
+  LessInt      r172, r170, r171
+  JumpIfFalse  r172, L26
+  Index        r117, r139, r170
+  Index        r174, r117, r75
+  Append       r134, r134, r174
+  AddInt       r170, r170, r34
+  Jump         L27
+L26:
+  Count        r176, r134
   // B1_LP: avg(from x in bucket1 select x.ss_list_price),
-  Move         r191, r74
-  Move         r192, r84
+  Move         r177, r60
+  Move         r178, r70
   // B1_CNT: count(bucket1),
-  Move         r193, r85
-  Move         r194, r86
+  Move         r179, r71
+  Move         r180, r72
   // B1_CNTD: count(from x in bucket1 group by x.ss_list_price into g select g.key),
-  Move         r195, r87
-  Move         r196, r134
+  Move         r181, r73
+  Move         r182, r120
   // B2_LP: avg(from x in bucket2 select x.ss_list_price),
-  Move         r197, r135
-  Move         r198, r144
+  Move         r183, r121
+  Move         r184, r130
   // B2_CNT: count(bucket2),
-  Move         r199, r145
-  Move         r200, r146
+  Move         r185, r131
+  Move         r186, r132
   // B2_CNTD: count(from x in bucket2 group by x.ss_list_price into g select g.key)
-  Move         r201, r147
-  Move         r202, r190
+  Move         r187, r133
+  Move         r188, r176
   // let result = {
-  MakeMap      r203, 6, r191
+  MakeMap      r189, 6, r177
   // json(result)
-  JSON         r203
+  JSON         r189
   // expect result == {
-  Const        r204, {"B1_CNT": 1, "B1_CNTD": 1, "B1_LP": 100, "B2_CNT": 1, "B2_CNTD": 1, "B2_LP": 80}
-  Equal        r205, r203, r204
-  Expect       r205
+  Const        r190, {"B1_CNT": 1, "B1_CNTD": 1, "B1_LP": 100, "B2_CNT": 1, "B2_CNTD": 1, "B2_LP": 80}
+  Equal        r191, r189, r190
+  Expect       r191
   Return       r0

--- a/tests/dataset/tpc-ds/out/q29.ir.out
+++ b/tests/dataset/tpc-ds/out/q29.ir.out
@@ -1,4 +1,4 @@
-func main (regs=521)
+func main (regs=278)
   // let store_sales = [
   Const        r0, [{"ss_customer_sk": 1, "ss_item_sk": 1, "ss_quantity": 10, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}]
   // let store_returns = [
@@ -16,724 +16,427 @@ func main (regs=521)
   // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
   Const        r7, "d_moy"
   Const        r8, "d_year"
-  Const        r9, "d_moy"
-  Const        r10, "d_moy"
-  Const        r11, "d_year"
   // ss_quantity: ss.ss_quantity,
-  Const        r12, "ss_quantity"
-  Const        r13, "ss_quantity"
+  Const        r9, "ss_quantity"
   // sr_return_quantity: sr.sr_return_quantity,
-  Const        r14, "sr_return_quantity"
-  Const        r15, "sr_return_quantity"
+  Const        r10, "sr_return_quantity"
   // cs_quantity: cs.cs_quantity,
-  Const        r16, "cs_quantity"
-  Const        r17, "cs_quantity"
+  Const        r11, "cs_quantity"
   // i_item_id: i.i_item_id,
-  Const        r18, "i_item_id"
-  Const        r19, "i_item_id"
+  Const        r12, "i_item_id"
   // i_item_desc: i.i_item_desc,
-  Const        r20, "i_item_desc"
-  Const        r21, "i_item_desc"
+  Const        r13, "i_item_desc"
   // s_store_id: s.s_store_id,
-  Const        r22, "s_store_id"
-  Const        r23, "s_store_id"
+  Const        r14, "s_store_id"
   // s_store_name: s.s_store_name,
-  Const        r24, "s_store_name"
-  Const        r25, "s_store_name"
+  Const        r15, "s_store_name"
   // from ss in store_sales
-  IterPrep     r26, r0
-  Len          r27, r26
-  Const        r28, 0
+  IterPrep     r16, r0
+  Len          r17, r16
+  Const        r19, 0
+  Move         r18, r19
 L19:
-  LessInt      r30, r28, r27
-  JumpIfFalse  r30, L0
-  Index        r32, r26, r28
+  LessInt      r20, r18, r17
+  JumpIfFalse  r20, L0
+  Index        r22, r16, r18
   // join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
-  IterPrep     r33, r1
-  Len          r34, r33
-  Const        r35, "ss_ticket_number"
-  Const        r36, "sr_ticket_number"
-  Const        r37, "ss_item_sk"
-  Const        r38, "sr_item_sk"
-  // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r39, "d_moy"
-  Const        r40, "d_year"
-  Const        r41, "d_moy"
-  Const        r42, "d_moy"
-  Const        r43, "d_year"
-  // ss_quantity: ss.ss_quantity,
-  Const        r44, "ss_quantity"
-  Const        r45, "ss_quantity"
-  // sr_return_quantity: sr.sr_return_quantity,
-  Const        r46, "sr_return_quantity"
-  Const        r47, "sr_return_quantity"
-  // cs_quantity: cs.cs_quantity,
-  Const        r48, "cs_quantity"
-  Const        r49, "cs_quantity"
-  // i_item_id: i.i_item_id,
-  Const        r50, "i_item_id"
-  Const        r51, "i_item_id"
-  // i_item_desc: i.i_item_desc,
-  Const        r52, "i_item_desc"
-  Const        r53, "i_item_desc"
-  // s_store_id: s.s_store_id,
-  Const        r54, "s_store_id"
-  Const        r55, "s_store_id"
-  // s_store_name: s.s_store_name,
-  Const        r56, "s_store_name"
-  Const        r57, "s_store_name"
-  // join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
-  Const        r58, 0
+  IterPrep     r23, r1
+  Len          r24, r23
+  Const        r25, "ss_ticket_number"
+  Const        r26, "sr_ticket_number"
+  Const        r27, "ss_item_sk"
+  Const        r28, "sr_item_sk"
+  Move         r29, r19
 L18:
-  LessInt      r60, r58, r34
-  JumpIfFalse  r60, L1
-  Index        r62, r33, r58
-  Const        r63, "ss_ticket_number"
-  Index        r64, r32, r63
-  Const        r65, "sr_ticket_number"
-  Index        r66, r62, r65
-  Equal        r67, r64, r66
-  Const        r68, "ss_item_sk"
-  Index        r69, r32, r68
-  Const        r70, "sr_item_sk"
-  Index        r71, r62, r70
-  Equal        r72, r69, r71
-  Move         r73, r67
-  JumpIfFalse  r73, L2
-  Move         r73, r72
+  LessInt      r30, r29, r24
+  JumpIfFalse  r30, L1
+  Index        r32, r23, r29
+  Index        r33, r22, r25
+  Index        r34, r32, r26
+  Equal        r35, r33, r34
+  Index        r36, r22, r27
+  Index        r37, r32, r28
+  Equal        r38, r36, r37
+  JumpIfFalse  r35, L2
+  Move         r35, r38
 L2:
-  JumpIfFalse  r73, L3
+  JumpIfFalse  r35, L3
   // join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
-  IterPrep     r74, r2
-  Len          r75, r74
-  Const        r76, "sr_customer_sk"
-  Const        r77, "cs_bill_customer_sk"
-  Const        r78, "sr_item_sk"
-  Const        r79, "cs_item_sk"
-  // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r80, "d_moy"
-  Const        r81, "d_year"
-  Const        r82, "d_moy"
-  Const        r83, "d_moy"
-  Const        r84, "d_year"
-  // ss_quantity: ss.ss_quantity,
-  Const        r85, "ss_quantity"
-  Const        r86, "ss_quantity"
-  // sr_return_quantity: sr.sr_return_quantity,
-  Const        r87, "sr_return_quantity"
-  Const        r88, "sr_return_quantity"
-  // cs_quantity: cs.cs_quantity,
-  Const        r89, "cs_quantity"
-  Const        r90, "cs_quantity"
-  // i_item_id: i.i_item_id,
-  Const        r91, "i_item_id"
-  Const        r92, "i_item_id"
-  // i_item_desc: i.i_item_desc,
-  Const        r93, "i_item_desc"
-  Const        r94, "i_item_desc"
-  // s_store_id: s.s_store_id,
-  Const        r95, "s_store_id"
-  Const        r96, "s_store_id"
-  // s_store_name: s.s_store_name,
-  Const        r97, "s_store_name"
-  Const        r98, "s_store_name"
-  // join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
-  Const        r99, 0
+  IterPrep     r39, r2
+  Len          r40, r39
+  Const        r41, "sr_customer_sk"
+  Const        r42, "cs_bill_customer_sk"
+  Const        r43, "cs_item_sk"
+  Move         r44, r19
 L17:
-  LessInt      r101, r99, r75
-  JumpIfFalse  r101, L3
-  Index        r103, r74, r99
-  Const        r104, "sr_customer_sk"
-  Index        r105, r62, r104
-  Const        r106, "cs_bill_customer_sk"
-  Index        r107, r103, r106
-  Equal        r108, r105, r107
-  Const        r109, "sr_item_sk"
-  Index        r110, r62, r109
-  Const        r111, "cs_item_sk"
-  Index        r112, r103, r111
-  Equal        r113, r110, r112
-  Move         r114, r108
-  JumpIfFalse  r114, L4
-  Move         r114, r113
+  LessInt      r45, r44, r40
+  JumpIfFalse  r45, L3
+  Index        r47, r39, r44
+  Index        r48, r32, r41
+  Index        r49, r47, r42
+  Equal        r50, r48, r49
+  Index        r51, r32, r28
+  Index        r52, r47, r43
+  Equal        r53, r51, r52
+  JumpIfFalse  r50, L4
+  Move         r50, r53
 L4:
-  JumpIfFalse  r114, L5
+  JumpIfFalse  r50, L5
   // join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
-  IterPrep     r115, r3
-  Len          r116, r115
-  Const        r117, "d_date_sk"
-  Const        r118, "ss_sold_date_sk"
-  // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r119, "d_moy"
-  Const        r120, "d_year"
-  Const        r121, "d_moy"
-  Const        r122, "d_moy"
-  Const        r123, "d_year"
-  // ss_quantity: ss.ss_quantity,
-  Const        r124, "ss_quantity"
-  Const        r125, "ss_quantity"
-  // sr_return_quantity: sr.sr_return_quantity,
-  Const        r126, "sr_return_quantity"
-  Const        r127, "sr_return_quantity"
-  // cs_quantity: cs.cs_quantity,
-  Const        r128, "cs_quantity"
-  Const        r129, "cs_quantity"
-  // i_item_id: i.i_item_id,
-  Const        r130, "i_item_id"
-  Const        r131, "i_item_id"
-  // i_item_desc: i.i_item_desc,
-  Const        r132, "i_item_desc"
-  Const        r133, "i_item_desc"
-  // s_store_id: s.s_store_id,
-  Const        r134, "s_store_id"
-  Const        r135, "s_store_id"
-  // s_store_name: s.s_store_name,
-  Const        r136, "s_store_name"
-  Const        r137, "s_store_name"
-  // join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
-  Const        r138, 0
+  IterPrep     r54, r3
+  Len          r55, r54
+  Const        r56, "d_date_sk"
+  Const        r57, "ss_sold_date_sk"
+  Move         r58, r19
 L16:
-  LessInt      r140, r138, r116
-  JumpIfFalse  r140, L5
-  Index        r142, r115, r138
-  Const        r143, "d_date_sk"
-  Index        r144, r142, r143
-  Const        r145, "ss_sold_date_sk"
-  Index        r146, r32, r145
-  Equal        r147, r144, r146
-  JumpIfFalse  r147, L6
+  LessInt      r59, r58, r55
+  JumpIfFalse  r59, L5
+  Index        r61, r54, r58
+  Index        r62, r61, r56
+  Index        r63, r22, r57
+  Equal        r64, r62, r63
+  JumpIfFalse  r64, L6
   // join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
-  IterPrep     r148, r3
-  Len          r149, r148
-  Const        r150, "d_date_sk"
-  Const        r151, "sr_returned_date_sk"
-  // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r152, "d_moy"
-  Const        r153, "d_year"
-  Const        r154, "d_moy"
-  Const        r155, "d_moy"
-  Const        r156, "d_year"
-  // ss_quantity: ss.ss_quantity,
-  Const        r157, "ss_quantity"
-  Const        r158, "ss_quantity"
-  // sr_return_quantity: sr.sr_return_quantity,
-  Const        r159, "sr_return_quantity"
-  Const        r160, "sr_return_quantity"
-  // cs_quantity: cs.cs_quantity,
-  Const        r161, "cs_quantity"
-  Const        r162, "cs_quantity"
-  // i_item_id: i.i_item_id,
-  Const        r163, "i_item_id"
-  Const        r164, "i_item_id"
-  // i_item_desc: i.i_item_desc,
-  Const        r165, "i_item_desc"
-  Const        r166, "i_item_desc"
-  // s_store_id: s.s_store_id,
-  Const        r167, "s_store_id"
-  Const        r168, "s_store_id"
-  // s_store_name: s.s_store_name,
-  Const        r169, "s_store_name"
-  Const        r170, "s_store_name"
-  // join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
-  Const        r171, 0
+  IterPrep     r65, r3
+  Len          r66, r65
+  Const        r67, "sr_returned_date_sk"
+  Move         r68, r19
 L15:
-  LessInt      r173, r171, r149
-  JumpIfFalse  r173, L6
-  Index        r175, r148, r171
-  Const        r176, "d_date_sk"
-  Index        r177, r175, r176
-  Const        r178, "sr_returned_date_sk"
-  Index        r179, r62, r178
-  Equal        r180, r177, r179
-  JumpIfFalse  r180, L7
+  LessInt      r69, r68, r66
+  JumpIfFalse  r69, L6
+  Index        r71, r65, r68
+  Index        r72, r71, r56
+  Index        r73, r32, r67
+  Equal        r74, r72, r73
+  JumpIfFalse  r74, L7
   // join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
-  IterPrep     r181, r3
-  Len          r182, r181
-  Const        r183, "d_date_sk"
-  Const        r184, "cs_sold_date_sk"
-  // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r185, "d_moy"
-  Const        r186, "d_year"
-  Const        r187, "d_moy"
-  Const        r188, "d_moy"
-  Const        r189, "d_year"
-  // ss_quantity: ss.ss_quantity,
-  Const        r190, "ss_quantity"
-  Const        r191, "ss_quantity"
-  // sr_return_quantity: sr.sr_return_quantity,
-  Const        r192, "sr_return_quantity"
-  Const        r193, "sr_return_quantity"
-  // cs_quantity: cs.cs_quantity,
-  Const        r194, "cs_quantity"
-  Const        r195, "cs_quantity"
-  // i_item_id: i.i_item_id,
-  Const        r196, "i_item_id"
-  Const        r197, "i_item_id"
-  // i_item_desc: i.i_item_desc,
-  Const        r198, "i_item_desc"
-  Const        r199, "i_item_desc"
-  // s_store_id: s.s_store_id,
-  Const        r200, "s_store_id"
-  Const        r201, "s_store_id"
-  // s_store_name: s.s_store_name,
-  Const        r202, "s_store_name"
-  Const        r203, "s_store_name"
-  // join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
-  Const        r204, 0
+  IterPrep     r75, r3
+  Len          r76, r75
+  Const        r77, "cs_sold_date_sk"
+  Move         r78, r19
 L14:
-  LessInt      r206, r204, r182
-  JumpIfFalse  r206, L7
-  Index        r208, r181, r204
-  Const        r209, "d_date_sk"
-  Index        r210, r208, r209
-  Const        r211, "cs_sold_date_sk"
-  Index        r212, r103, r211
-  Equal        r213, r210, r212
-  JumpIfFalse  r213, L8
+  LessInt      r79, r78, r76
+  JumpIfFalse  r79, L7
+  Index        r81, r75, r78
+  Index        r82, r81, r56
+  Index        r83, r47, r77
+  Equal        r84, r82, r83
+  JumpIfFalse  r84, L8
   // join s in store on s.s_store_sk == ss.ss_store_sk
-  IterPrep     r214, r4
-  Len          r215, r214
-  Const        r216, "s_store_sk"
-  Const        r217, "ss_store_sk"
-  // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r218, "d_moy"
-  Const        r219, "d_year"
-  Const        r220, "d_moy"
-  Const        r221, "d_moy"
-  Const        r222, "d_year"
-  // ss_quantity: ss.ss_quantity,
-  Const        r223, "ss_quantity"
-  Const        r224, "ss_quantity"
-  // sr_return_quantity: sr.sr_return_quantity,
-  Const        r225, "sr_return_quantity"
-  Const        r226, "sr_return_quantity"
-  // cs_quantity: cs.cs_quantity,
-  Const        r227, "cs_quantity"
-  Const        r228, "cs_quantity"
-  // i_item_id: i.i_item_id,
-  Const        r229, "i_item_id"
-  Const        r230, "i_item_id"
-  // i_item_desc: i.i_item_desc,
-  Const        r231, "i_item_desc"
-  Const        r232, "i_item_desc"
-  // s_store_id: s.s_store_id,
-  Const        r233, "s_store_id"
-  Const        r234, "s_store_id"
-  // s_store_name: s.s_store_name,
-  Const        r235, "s_store_name"
-  Const        r236, "s_store_name"
-  // join s in store on s.s_store_sk == ss.ss_store_sk
-  Const        r237, 0
+  IterPrep     r85, r4
+  Len          r86, r85
+  Const        r87, "s_store_sk"
+  Const        r88, "ss_store_sk"
+  Move         r89, r19
 L13:
-  LessInt      r239, r237, r215
-  JumpIfFalse  r239, L8
-  Index        r241, r214, r237
-  Const        r242, "s_store_sk"
-  Index        r243, r241, r242
-  Const        r244, "ss_store_sk"
-  Index        r245, r32, r244
-  Equal        r246, r243, r245
-  JumpIfFalse  r246, L9
+  LessInt      r90, r89, r86
+  JumpIfFalse  r90, L8
+  Index        r92, r85, r89
+  Index        r93, r92, r87
+  Index        r94, r22, r88
+  Equal        r95, r93, r94
+  JumpIfFalse  r95, L9
   // join i in item on i.i_item_sk == ss.ss_item_sk
-  IterPrep     r247, r5
-  Len          r248, r247
-  Const        r249, "i_item_sk"
-  Const        r250, "ss_item_sk"
-  // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r251, "d_moy"
-  Const        r252, "d_year"
-  Const        r253, "d_moy"
-  Const        r254, "d_moy"
-  Const        r255, "d_year"
-  // ss_quantity: ss.ss_quantity,
-  Const        r256, "ss_quantity"
-  Const        r257, "ss_quantity"
-  // sr_return_quantity: sr.sr_return_quantity,
-  Const        r258, "sr_return_quantity"
-  Const        r259, "sr_return_quantity"
-  // cs_quantity: cs.cs_quantity,
-  Const        r260, "cs_quantity"
-  Const        r261, "cs_quantity"
-  // i_item_id: i.i_item_id,
-  Const        r262, "i_item_id"
-  Const        r263, "i_item_id"
-  // i_item_desc: i.i_item_desc,
-  Const        r264, "i_item_desc"
-  Const        r265, "i_item_desc"
-  // s_store_id: s.s_store_id,
-  Const        r266, "s_store_id"
-  Const        r267, "s_store_id"
-  // s_store_name: s.s_store_name,
-  Const        r268, "s_store_name"
-  Const        r269, "s_store_name"
-  // join i in item on i.i_item_sk == ss.ss_item_sk
-  Const        r270, 0
+  IterPrep     r96, r5
+  Len          r97, r96
+  Const        r98, "i_item_sk"
+  Move         r99, r19
 L12:
-  LessInt      r272, r270, r248
-  JumpIfFalse  r272, L9
-  Index        r274, r247, r270
-  Const        r275, "i_item_sk"
-  Index        r276, r274, r275
-  Const        r277, "ss_item_sk"
-  Index        r278, r32, r277
-  Equal        r279, r276, r278
-  JumpIfFalse  r279, L10
+  LessInt      r100, r99, r97
+  JumpIfFalse  r100, L9
+  Index        r102, r96, r99
+  Index        r103, r102, r98
+  Index        r104, r22, r27
+  Equal        r105, r103, r104
+  JumpIfFalse  r105, L10
   // where d1.d_moy == 4 && d1.d_year == 1999 && d2.d_moy >= 4 && d2.d_moy <= 7 && d3.d_year in [1999,2000,2001]
-  Const        r280, "d_moy"
-  Index        r281, r142, r280
-  Const        r282, "d_moy"
-  Index        r283, r175, r282
-  Const        r284, 4
-  LessEq       r285, r284, r283
-  Const        r286, "d_moy"
-  Index        r287, r175, r286
-  Const        r288, 7
-  LessEq       r289, r287, r288
-  Const        r290, 4
-  Equal        r291, r281, r290
-  Const        r292, "d_year"
-  Index        r293, r142, r292
-  Const        r294, 1999
-  Equal        r295, r293, r294
-  Const        r296, "d_year"
-  Index        r297, r208, r296
-  Const        r298, [1999, 2000, 2001]
-  In           r299, r297, r298
-  Move         r300, r291
-  JumpIfFalse  r300, L11
-  Move         r300, r295
-  JumpIfFalse  r300, L11
-  Move         r300, r285
-  JumpIfFalse  r300, L11
-  Move         r300, r289
-  JumpIfFalse  r300, L11
-  Move         r300, r299
+  Index        r106, r61, r7
+  Index        r107, r71, r7
+  Const        r108, 4
+  LessEq       r109, r108, r107
+  Index        r110, r71, r7
+  Const        r111, 7
+  LessEq       r112, r110, r111
+  Equal        r113, r106, r108
+  Index        r114, r61, r8
+  Const        r115, 1999
+  Equal        r116, r114, r115
+  Index        r117, r81, r8
+  Const        r118, [1999, 2000, 2001]
+  In           r119, r117, r118
+  JumpIfFalse  r113, L11
+  Move         r113, r116
+  JumpIfFalse  r113, L11
+  Move         r113, r109
+  JumpIfFalse  r113, L11
+  Move         r113, r112
+  JumpIfFalse  r113, L11
+  Move         r113, r119
 L11:
-  JumpIfFalse  r300, L10
+  JumpIfFalse  r113, L10
   // ss_quantity: ss.ss_quantity,
-  Const        r301, "ss_quantity"
-  Const        r302, "ss_quantity"
-  Index        r303, r32, r302
+  Const        r120, "ss_quantity"
+  Index        r121, r22, r9
   // sr_return_quantity: sr.sr_return_quantity,
-  Const        r304, "sr_return_quantity"
-  Const        r305, "sr_return_quantity"
-  Index        r306, r62, r305
+  Const        r122, "sr_return_quantity"
+  Index        r123, r32, r10
   // cs_quantity: cs.cs_quantity,
-  Const        r307, "cs_quantity"
-  Const        r308, "cs_quantity"
-  Index        r309, r103, r308
+  Const        r124, "cs_quantity"
+  Index        r125, r47, r11
   // i_item_id: i.i_item_id,
-  Const        r310, "i_item_id"
-  Const        r311, "i_item_id"
-  Index        r312, r274, r311
+  Const        r126, "i_item_id"
+  Index        r127, r102, r12
   // i_item_desc: i.i_item_desc,
-  Const        r313, "i_item_desc"
-  Const        r314, "i_item_desc"
-  Index        r315, r274, r314
+  Const        r128, "i_item_desc"
+  Index        r129, r102, r13
   // s_store_id: s.s_store_id,
-  Const        r316, "s_store_id"
-  Const        r317, "s_store_id"
-  Index        r318, r241, r317
+  Const        r130, "s_store_id"
+  Index        r131, r92, r14
   // s_store_name: s.s_store_name,
-  Const        r319, "s_store_name"
-  Const        r320, "s_store_name"
-  Index        r321, r241, r320
+  Const        r132, "s_store_name"
+  Index        r133, r92, r15
   // ss_quantity: ss.ss_quantity,
-  Move         r322, r301
-  Move         r323, r303
+  Move         r134, r120
+  Move         r135, r121
   // sr_return_quantity: sr.sr_return_quantity,
-  Move         r324, r304
-  Move         r325, r306
+  Move         r136, r122
+  Move         r137, r123
   // cs_quantity: cs.cs_quantity,
-  Move         r326, r307
-  Move         r327, r309
+  Move         r138, r124
+  Move         r139, r125
   // i_item_id: i.i_item_id,
-  Move         r328, r310
-  Move         r329, r312
+  Move         r140, r126
+  Move         r141, r127
   // i_item_desc: i.i_item_desc,
-  Move         r330, r313
-  Move         r331, r315
+  Move         r142, r128
+  Move         r143, r129
   // s_store_id: s.s_store_id,
-  Move         r332, r316
-  Move         r333, r318
+  Move         r144, r130
+  Move         r145, r131
   // s_store_name: s.s_store_name,
-  Move         r334, r319
-  Move         r335, r321
+  Move         r146, r132
+  Move         r147, r133
   // select {
-  MakeMap      r336, 7, r322
+  MakeMap      r148, 7, r134
   // from ss in store_sales
-  Append       r6, r6, r336
+  Append       r6, r6, r148
 L10:
   // join i in item on i.i_item_sk == ss.ss_item_sk
-  Const        r338, 1
-  Add          r270, r270, r338
+  Const        r150, 1
+  Add          r99, r99, r150
   Jump         L12
 L9:
   // join s in store on s.s_store_sk == ss.ss_store_sk
-  Const        r339, 1
-  Add          r237, r237, r339
+  Add          r89, r89, r150
   Jump         L13
 L8:
   // join d3 in date_dim on d3.d_date_sk == cs.cs_sold_date_sk
-  Const        r340, 1
-  Add          r204, r204, r340
+  Add          r78, r78, r150
   Jump         L14
 L7:
   // join d2 in date_dim on d2.d_date_sk == sr.sr_returned_date_sk
-  Const        r341, 1
-  Add          r171, r171, r341
+  Add          r68, r68, r150
   Jump         L15
 L6:
   // join d1 in date_dim on d1.d_date_sk == ss.ss_sold_date_sk
-  Const        r342, 1
-  Add          r138, r138, r342
+  Add          r58, r58, r150
   Jump         L16
 L5:
   // join cs in catalog_sales on sr.sr_customer_sk == cs.cs_bill_customer_sk && sr.sr_item_sk == cs.cs_item_sk
-  Const        r343, 1
-  Add          r99, r99, r343
+  Add          r44, r44, r150
   Jump         L17
 L3:
   // join sr in store_returns on ss.ss_ticket_number == sr.sr_ticket_number && ss.ss_item_sk == sr.sr_item_sk
-  Const        r344, 1
-  Add          r58, r58, r344
+  Add          r29, r29, r150
   Jump         L18
 L1:
   // from ss in store_sales
-  Const        r345, 1
-  AddInt       r28, r28, r345
+  AddInt       r18, r18, r150
   Jump         L19
 L0:
   // from b in base
-  Const        r346, []
+  Const        r151, []
   // group by { item_id: b.i_item_id, item_desc: b.i_item_desc, s_store_id: b.s_store_id, s_store_name: b.s_store_name } into g
-  Const        r347, "item_id"
-  Const        r348, "i_item_id"
-  Const        r349, "item_desc"
-  Const        r350, "i_item_desc"
-  Const        r351, "s_store_id"
-  Const        r352, "s_store_id"
-  Const        r353, "s_store_name"
-  Const        r354, "s_store_name"
+  Const        r152, "item_id"
+  Const        r153, "item_desc"
   // i_item_id: g.key.item_id,
-  Const        r355, "i_item_id"
-  Const        r356, "key"
-  Const        r357, "item_id"
-  // i_item_desc: g.key.item_desc,
-  Const        r358, "i_item_desc"
-  Const        r359, "key"
-  Const        r360, "item_desc"
-  // s_store_id: g.key.s_store_id,
-  Const        r361, "s_store_id"
-  Const        r362, "key"
-  Const        r363, "s_store_id"
-  // s_store_name: g.key.s_store_name,
-  Const        r364, "s_store_name"
-  Const        r365, "key"
-  Const        r366, "s_store_name"
+  Const        r154, "key"
   // store_sales_quantity: sum(from x in g select x.ss_quantity),
-  Const        r367, "store_sales_quantity"
-  Const        r368, "ss_quantity"
+  Const        r155, "store_sales_quantity"
   // store_returns_quantity: sum(from x in g select x.sr_return_quantity),
-  Const        r369, "store_returns_quantity"
-  Const        r370, "sr_return_quantity"
+  Const        r156, "store_returns_quantity"
   // catalog_sales_quantity: sum(from x in g select x.cs_quantity)
-  Const        r371, "catalog_sales_quantity"
-  Const        r372, "cs_quantity"
+  Const        r157, "catalog_sales_quantity"
   // from b in base
-  IterPrep     r373, r6
-  Len          r374, r373
-  Const        r375, 0
-  MakeMap      r376, 0, r0
-  Const        r377, []
+  IterPrep     r158, r6
+  Len          r159, r158
+  Const        r160, 0
+  MakeMap      r161, 0, r0
+  Const        r162, []
 L22:
-  LessInt      r379, r375, r374
-  JumpIfFalse  r379, L20
-  Index        r380, r373, r375
-  Move         r381, r380
+  LessInt      r164, r160, r159
+  JumpIfFalse  r164, L20
+  Index        r165, r158, r160
+  Move         r166, r165
   // group by { item_id: b.i_item_id, item_desc: b.i_item_desc, s_store_id: b.s_store_id, s_store_name: b.s_store_name } into g
-  Const        r382, "item_id"
-  Const        r383, "i_item_id"
-  Index        r384, r381, r383
-  Const        r385, "item_desc"
-  Const        r386, "i_item_desc"
-  Index        r387, r381, r386
-  Const        r388, "s_store_id"
-  Const        r389, "s_store_id"
-  Index        r390, r381, r389
-  Const        r391, "s_store_name"
-  Const        r392, "s_store_name"
-  Index        r393, r381, r392
-  Move         r394, r382
-  Move         r395, r384
-  Move         r396, r385
-  Move         r397, r387
-  Move         r398, r388
-  Move         r399, r390
-  Move         r400, r391
-  Move         r401, r393
-  MakeMap      r402, 4, r394
-  Str          r403, r402
-  In           r404, r403, r376
-  JumpIfTrue   r404, L21
+  Const        r167, "item_id"
+  Index        r168, r166, r12
+  Const        r169, "item_desc"
+  Index        r170, r166, r13
+  Const        r171, "s_store_id"
+  Index        r172, r166, r14
+  Const        r173, "s_store_name"
+  Index        r174, r166, r15
+  Move         r175, r167
+  Move         r176, r168
+  Move         r177, r169
+  Move         r178, r170
+  Move         r179, r171
+  Move         r180, r172
+  Move         r181, r173
+  Move         r182, r174
+  MakeMap      r183, 4, r175
+  Str          r184, r183
+  In           r185, r184, r161
+  JumpIfTrue   r185, L21
   // from b in base
-  Const        r405, []
-  Const        r406, "__group__"
-  Const        r407, true
-  Const        r408, "key"
+  Const        r186, []
+  Const        r187, "__group__"
+  Const        r188, true
+  Const        r189, "key"
   // group by { item_id: b.i_item_id, item_desc: b.i_item_desc, s_store_id: b.s_store_id, s_store_name: b.s_store_name } into g
-  Move         r409, r402
+  Move         r190, r183
   // from b in base
-  Const        r410, "items"
-  Move         r411, r405
-  Const        r412, "count"
-  Const        r413, 0
-  Move         r414, r406
-  Move         r415, r407
-  Move         r416, r408
-  Move         r417, r409
-  Move         r418, r410
-  Move         r419, r411
-  Move         r420, r412
-  Move         r421, r413
-  MakeMap      r422, 4, r414
-  SetIndex     r376, r403, r422
-  Append       r377, r377, r422
+  Const        r191, "items"
+  Move         r192, r186
+  Const        r193, "count"
+  Const        r194, 0
+  Move         r195, r187
+  Move         r196, r188
+  Move         r197, r189
+  Move         r198, r190
+  Move         r199, r191
+  Move         r200, r192
+  Move         r201, r193
+  Move         r202, r194
+  MakeMap      r203, 4, r195
+  SetIndex     r161, r184, r203
+  Append       r162, r162, r203
 L21:
-  Const        r424, "items"
-  Index        r425, r376, r403
-  Index        r426, r425, r424
-  Append       r427, r426, r380
-  SetIndex     r425, r424, r427
-  Const        r428, "count"
-  Index        r429, r425, r428
-  Const        r430, 1
-  AddInt       r431, r429, r430
-  SetIndex     r425, r428, r431
-  Const        r432, 1
-  AddInt       r375, r375, r432
+  Const        r205, "items"
+  Index        r206, r161, r184
+  Index        r207, r206, r205
+  Append       r208, r207, r165
+  SetIndex     r206, r205, r208
+  Const        r209, "count"
+  Index        r210, r206, r209
+  AddInt       r211, r210, r150
+  SetIndex     r206, r209, r211
+  AddInt       r160, r160, r150
   Jump         L22
 L20:
-  Const        r433, 0
-  Len          r435, r377
+  Move         r212, r19
+  Len          r213, r162
 L30:
-  LessInt      r436, r433, r435
-  JumpIfFalse  r436, L23
-  Index        r438, r377, r433
+  LessInt      r214, r212, r213
+  JumpIfFalse  r214, L23
+  Index        r216, r162, r212
   // i_item_id: g.key.item_id,
-  Const        r439, "i_item_id"
-  Const        r440, "key"
-  Index        r441, r438, r440
-  Const        r442, "item_id"
-  Index        r443, r441, r442
+  Const        r217, "i_item_id"
+  Index        r218, r216, r154
+  Index        r219, r218, r152
   // i_item_desc: g.key.item_desc,
-  Const        r444, "i_item_desc"
-  Const        r445, "key"
-  Index        r446, r438, r445
-  Const        r447, "item_desc"
-  Index        r448, r446, r447
+  Const        r220, "i_item_desc"
+  Index        r221, r216, r154
+  Index        r222, r221, r153
   // s_store_id: g.key.s_store_id,
-  Const        r449, "s_store_id"
-  Const        r450, "key"
-  Index        r451, r438, r450
-  Const        r452, "s_store_id"
-  Index        r453, r451, r452
+  Const        r223, "s_store_id"
+  Index        r224, r216, r154
+  Index        r225, r224, r14
   // s_store_name: g.key.s_store_name,
-  Const        r454, "s_store_name"
-  Const        r455, "key"
-  Index        r456, r438, r455
-  Const        r457, "s_store_name"
-  Index        r458, r456, r457
+  Const        r226, "s_store_name"
+  Index        r227, r216, r154
+  Index        r228, r227, r15
   // store_sales_quantity: sum(from x in g select x.ss_quantity),
-  Const        r459, "store_sales_quantity"
-  Const        r460, []
-  Const        r461, "ss_quantity"
-  IterPrep     r462, r438
-  Len          r463, r462
-  Const        r464, 0
+  Const        r229, "store_sales_quantity"
+  Const        r230, []
+  IterPrep     r231, r216
+  Len          r232, r231
+  Move         r233, r19
 L25:
-  LessInt      r466, r464, r463
-  JumpIfFalse  r466, L24
-  Index        r468, r462, r464
-  Const        r469, "ss_quantity"
-  Index        r470, r468, r469
-  Append       r460, r460, r470
-  Const        r472, 1
-  AddInt       r464, r464, r472
+  LessInt      r234, r233, r232
+  JumpIfFalse  r234, L24
+  Index        r236, r231, r233
+  Index        r237, r236, r9
+  Append       r230, r230, r237
+  AddInt       r233, r233, r150
   Jump         L25
 L24:
-  Sum          r473, r460
+  Sum          r239, r230
   // store_returns_quantity: sum(from x in g select x.sr_return_quantity),
-  Const        r474, "store_returns_quantity"
-  Const        r475, []
-  Const        r476, "sr_return_quantity"
-  IterPrep     r477, r438
-  Len          r478, r477
-  Const        r479, 0
+  Const        r240, "store_returns_quantity"
+  Const        r241, []
+  IterPrep     r242, r216
+  Len          r243, r242
+  Move         r244, r19
 L27:
-  LessInt      r481, r479, r478
-  JumpIfFalse  r481, L26
-  Index        r468, r477, r479
-  Const        r483, "sr_return_quantity"
-  Index        r484, r468, r483
-  Append       r475, r475, r484
-  Const        r486, 1
-  AddInt       r479, r479, r486
+  LessInt      r245, r244, r243
+  JumpIfFalse  r245, L26
+  Index        r236, r242, r244
+  Index        r247, r236, r10
+  Append       r241, r241, r247
+  AddInt       r244, r244, r150
   Jump         L27
 L26:
-  Sum          r487, r475
+  Sum          r249, r241
   // catalog_sales_quantity: sum(from x in g select x.cs_quantity)
-  Const        r488, "catalog_sales_quantity"
-  Const        r489, []
-  Const        r490, "cs_quantity"
-  IterPrep     r491, r438
-  Len          r492, r491
-  Const        r493, 0
+  Const        r250, "catalog_sales_quantity"
+  Const        r251, []
+  IterPrep     r252, r216
+  Len          r253, r252
+  Move         r254, r19
 L29:
-  LessInt      r495, r493, r492
-  JumpIfFalse  r495, L28
-  Index        r468, r491, r493
-  Const        r497, "cs_quantity"
-  Index        r498, r468, r497
-  Append       r489, r489, r498
-  Const        r500, 1
-  AddInt       r493, r493, r500
+  LessInt      r255, r254, r253
+  JumpIfFalse  r255, L28
+  Index        r236, r252, r254
+  Index        r257, r236, r11
+  Append       r251, r251, r257
+  AddInt       r254, r254, r150
   Jump         L29
 L28:
-  Sum          r501, r489
+  Sum          r259, r251
   // i_item_id: g.key.item_id,
-  Move         r502, r439
-  Move         r503, r443
+  Move         r260, r217
+  Move         r261, r219
   // i_item_desc: g.key.item_desc,
-  Move         r504, r444
-  Move         r505, r448
+  Move         r262, r220
+  Move         r263, r222
   // s_store_id: g.key.s_store_id,
-  Move         r506, r449
-  Move         r507, r453
+  Move         r264, r223
+  Move         r265, r225
   // s_store_name: g.key.s_store_name,
-  Move         r508, r454
-  Move         r509, r458
+  Move         r266, r226
+  Move         r267, r228
   // store_sales_quantity: sum(from x in g select x.ss_quantity),
-  Move         r510, r459
-  Move         r511, r473
+  Move         r268, r229
+  Move         r269, r239
   // store_returns_quantity: sum(from x in g select x.sr_return_quantity),
-  Move         r512, r474
-  Move         r513, r487
+  Move         r270, r240
+  Move         r271, r249
   // catalog_sales_quantity: sum(from x in g select x.cs_quantity)
-  Move         r514, r488
-  Move         r515, r501
+  Move         r272, r250
+  Move         r273, r259
   // select {
-  MakeMap      r516, 7, r502
+  MakeMap      r274, 7, r260
   // from b in base
-  Append       r346, r346, r516
-  Const        r518, 1
-  AddInt       r433, r433, r518
+  Append       r151, r151, r274
+  AddInt       r212, r212, r150
   Jump         L30
 L23:
   // json(result)
-  JSON         r346
+  JSON         r151
   // expect result == [
-  Const        r519, [{"catalog_sales_quantity": 5, "i_item_desc": "Desc1", "i_item_id": "ITEM1", "s_store_id": "S1", "s_store_name": "Store1", "store_returns_quantity": 2, "store_sales_quantity": 10}]
-  Equal        r520, r346, r519
-  Expect       r520
+  Const        r276, [{"catalog_sales_quantity": 5, "i_item_desc": "Desc1", "i_item_id": "ITEM1", "s_store_id": "S1", "s_store_name": "Store1", "store_returns_quantity": 2, "store_sales_quantity": 10}]
+  Equal        r277, r151, r276
+  Expect       r277
   Return       r0


### PR DESCRIPTION
## Summary
- add numeric string handling to generic arithmetic operations
- regenerate tpc-ds IR for queries 20-29

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862a6769e688320bce4ea5f135a30a4