### PR TITLE
Expand TPC‑DC q50‑59 examples

### DIFF
--- a/tests/dataset/tpc-dc/q50.md
+++ b/tests/dataset/tpc-dc/q50.md
@@ -4,7 +4,7 @@ Query extracted from the official TPC-DS specification.
 
 ## SQL
 ```sql
-[LIMITA] select [LIMITB]
+SELECT
    s_store_name
   ,s_company_id
   ,s_street_number
@@ -30,8 +30,8 @@ from
   ,date_dim d1
   ,date_dim d2
 where
-    d2.d_year = [YEAR]
-and d2.d_moy  = [MONTH]
+    d2.d_year = 2000
+and d2.d_moy  = 1
 and ss_ticket_number = sr_ticket_number
 and ss_item_sk = sr_item_sk
 and ss_sold_date_sk   = d1.d_date_sk
@@ -59,7 +59,7 @@ order by s_store_name
         ,s_county
         ,s_state
         ,s_zip
-[LIMITC];
+LIMIT 100;
 ```
 
 ## Expected Output
@@ -94,6 +94,23 @@ Sample output for the expanded dataset defined in `q50.mochi`:
     "s_county": "County",
     "s_state": "CA",
     "s_zip": "54321",
+    "30 days": 1,
+    "31-60 days": 1,
+    "61-90 days": 1,
+    "91-120 days": 1,
+    ">120 days": 1
+  },
+  {
+    "s_store_name": "Store C",
+    "s_company_id": 3,
+    "s_street_number": "3",
+    "s_street_name": "Third",
+    "s_street_type": "Ave",
+    "s_suite_number": "C",
+    "s_city": "Cityplace",
+    "s_county": "County",
+    "s_state": "CA",
+    "s_zip": "67890",
     "30 days": 1,
     "31-60 days": 1,
     "61-90 days": 1,

--- a/tests/dataset/tpc-dc/q50.mochi
+++ b/tests/dataset/tpc-dc/q50.mochi
@@ -12,6 +12,12 @@ let store_sales = [
   {ticket: 8, item: 107, sold_date: 20, customer: 3, store: 2}, // 61-90 days
   {ticket: 9, item: 108, sold_date: 30, customer: 4, store: 2}, // 91-120 days
   {ticket: 10, item: 109, sold_date: 35, customer: 3, store: 2}  // >120 days
+  // Store C sales
+  ,{ticket: 11, item: 110, sold_date: 5,  customer: 5, store: 3}
+  ,{ticket: 12, item: 111, sold_date: 15, customer: 5, store: 3}
+  ,{ticket: 13, item: 112, sold_date: 25, customer: 6, store: 3}
+  ,{ticket: 14, item: 113, sold_date: 45, customer: 6, store: 3}
+  ,{ticket: 15, item: 114, sold_date: 60, customer: 5, store: 3}
 ]
 
 let store_returns = [
@@ -27,6 +33,12 @@ let store_returns = [
   {ticket: 8, item: 107, returned_date: 95,  customer: 3},  // diff 75
   {ticket: 9, item: 108, returned_date: 130, customer: 4},  // diff 100
   {ticket: 10, item: 109, returned_date: 200, customer: 3}   // diff 165
+  // Returns for Store C
+  ,{ticket: 11, item: 110, returned_date: 26,  customer: 5}   // diff 21
+  ,{ticket: 12, item: 111, returned_date: 55,  customer: 5}   // diff 40
+  ,{ticket: 13, item: 112, returned_date: 95,  customer: 6}   // diff 70
+  ,{ticket: 14, item: 113, returned_date: 130, customer: 6}   // diff 85
+  ,{ticket: 15, item: 114, returned_date: 190, customer: 5}   // diff 130
 ]
 
 let store = [
@@ -55,29 +67,48 @@ let store = [
     s_county: "County",
     s_state: "CA",
     s_zip: "54321"
+  },
+  {
+    store_sk: 3,
+    s_store_name: "Store C",
+    s_company_id: 3,
+    s_street_number: "3",
+    s_street_name: "Third",
+    s_street_type: "Ave",
+    s_suite_number: "C",
+    s_city: "Cityplace",
+    s_county: "County",
+    s_state: "CA",
+    s_zip: "67890"
   }
 ]
 
 let date_dim = [
   {date_sk: 1,   year: 2000, month: 1},
+  {date_sk: 5,   year: 2000, month: 1},
   {date_sk: 10,  year: 2000, month: 1},
   {date_sk: 15,  year: 2000, month: 1},
+  {date_sk: 25,  year: 2000, month: 1},
   {date_sk: 21,  year: 2000, month: 1},
   {date_sk: 30,  year: 2000, month: 1},
   {date_sk: 35,  year: 2000, month: 1},
+  {date_sk: 45,  year: 2000, month: 1},
   {date_sk: 40,  year: 2000, month: 1},
   {date_sk: 50,  year: 2000, month: 1},
+  {date_sk: 55,  year: 2000, month: 1},
+  {date_sk: 60,  year: 2000, month: 1},
   {date_sk: 100, year: 2000, month: 1},
   {date_sk: 95,  year: 2000, month: 1},
   {date_sk: 130, year: 2000, month: 1},
   {date_sk: 140, year: 2000, month: 1},
+  {date_sk: 190, year: 2000, month: 1},
   {date_sk: 180, year: 2000, month: 1},
   {date_sk: 200, year: 2000, month: 1}
 ]
 
 let result =
   from ss in store_sales
-  join sr in store_returns on ss.ticket == sr.ticket && ss.item == sr.item
+  join sr in store_returns on ss.ticket == sr.ticket && ss.item == sr.item && ss.customer == sr.customer
   join d1 in date_dim on ss.sold_date == d1.date_sk
   join d2 in date_dim on sr.returned_date == d2.date_sk
   join s in store on ss.store == s.store_sk
@@ -133,7 +164,7 @@ test "TPCDC Q50 return days by store" {
       "91-120 days": 1,
       ">120 days": 1
     },
-    {
+    { 
       s_store_name: "Store B",
       s_company_id: 2,
       s_street_number: "2",
@@ -144,6 +175,23 @@ test "TPCDC Q50 return days by store" {
       s_county: "County",
       s_state: "CA",
       s_zip: "54321",
+      "30 days": 1,
+      "31-60 days": 1,
+      "61-90 days": 1,
+      "91-120 days": 1,
+      ">120 days": 1
+    },
+    {
+      s_store_name: "Store C",
+      s_company_id: 3,
+      s_street_number: "3",
+      s_street_name: "Third",
+      s_street_type: "Ave",
+      s_suite_number: "C",
+      s_city: "Cityplace",
+      s_county: "County",
+      s_state: "CA",
+      s_zip: "67890",
       "30 days": 1,
       "31-60 days": 1,
       "61-90 days": 1,

--- a/tests/dataset/tpc-dc/q51.md
+++ b/tests/dataset/tpc-dc/q51.md
@@ -10,7 +10,7 @@ select
       over (partition by ws_item_sk order by d_date rows between unbounded preceding and current row) cume_sales
 from web_sales, date_dim
 where ws_sold_date_sk=d_date_sk
-  and d_month_seq between [DMS] and [DMS]+11
+  and d_month_seq between 1 and 1+11
   and ws_item_sk is not NULL
 group by ws_item_sk, d_date),
 store_v1 as (
@@ -20,10 +20,10 @@ select
       over (partition by ss_item_sk order by d_date rows between unbounded preceding and current row) cume_sales
 from store_sales, date_dim
 where ss_sold_date_sk=d_date_sk
-  and d_month_seq between [DMS] and [DMS]+11
+  and d_month_seq between 1 and 1+11
   and ss_item_sk is not NULL
 group by ss_item_sk, d_date)
-[LIMITA] select [LIMITB] *
+SELECT *
 from (select item_sk
      ,d_date
      ,web_sales
@@ -40,13 +40,13 @@ from (select item_sk
                                                           and web.d_date = store.d_date)
           )x )y
 where web_cumulative > store_cumulative
-order by item_sk
-        ,d_date
-[LIMITC];
+order by item_sk,
+        d_date
+LIMIT 100;
 ```
 
 ## Expected Output
-For the expanded sample data the cumulative web sales exceed store sales for two items:
+For the expanded sample data the cumulative web sales exceed store sales for three items:
 ```json
 [
   {"item_sk":1, "d_date":1, "web_sales":10, "store_sales":5},
@@ -58,6 +58,11 @@ For the expanded sample data the cumulative web sales exceed store sales for two
   {"item_sk":2, "d_date":2, "web_sales":10, "store_sales":4},
   {"item_sk":2, "d_date":3, "web_sales":15, "store_sales":5},
   {"item_sk":2, "d_date":4, "web_sales":20, "store_sales":7},
-  {"item_sk":2, "d_date":5, "web_sales":25, "store_sales":10}
+  {"item_sk":2, "d_date":5, "web_sales":25, "store_sales":10},
+  {"item_sk":3, "d_date":1, "web_sales":8,  "store_sales":4},
+  {"item_sk":3, "d_date":2, "web_sales":20, "store_sales":7},
+  {"item_sk":3, "d_date":3, "web_sales":30, "store_sales":13},
+  {"item_sk":3, "d_date":4, "web_sales":36, "store_sales":15},
+  {"item_sk":3, "d_date":5, "web_sales":44, "store_sales":19}
 ]
 ```

--- a/tests/dataset/tpc-dc/q51.mochi
+++ b/tests/dataset/tpc-dc/q51.mochi
@@ -17,6 +17,11 @@ let web_sales = [
   {item_sk: 2, sold_date: 3, price: 5},
   {item_sk: 2, sold_date: 4, price: 5},
   {item_sk: 2, sold_date: 5, price: 5}
+  ,{item_sk: 3, sold_date: 1, price: 8}
+  ,{item_sk: 3, sold_date: 2, price: 12}
+  ,{item_sk: 3, sold_date: 3, price: 10}
+  ,{item_sk: 3, sold_date: 4, price: 6}
+  ,{item_sk: 3, sold_date: 5, price: 8}
 ]
 
 let store_sales = [
@@ -30,6 +35,11 @@ let store_sales = [
   {item_sk: 2, sold_date: 3, price: 1},
   {item_sk: 2, sold_date: 4, price: 2},
   {item_sk: 2, sold_date: 5, price: 3}
+  ,{item_sk: 3, sold_date: 1, price: 4}
+  ,{item_sk: 3, sold_date: 2, price: 3}
+  ,{item_sk: 3, sold_date: 3, price: 6}
+  ,{item_sk: 3, sold_date: 4, price: 2}
+  ,{item_sk: 3, sold_date: 5, price: 4}
 ]
 
 // Aggregate sales by item and date
@@ -86,6 +96,11 @@ test "TPCDC Q51 cumulative" {
     {item_sk:2, d_date:2, web_sales:10, store_sales:4},
     {item_sk:2, d_date:3, web_sales:15, store_sales:5},
     {item_sk:2, d_date:4, web_sales:20, store_sales:7},
-    {item_sk:2, d_date:5, web_sales:25, store_sales:10}
+    {item_sk:2, d_date:5, web_sales:25, store_sales:10},
+    {item_sk:3, d_date:1, web_sales:8, store_sales:4},
+    {item_sk:3, d_date:2, web_sales:20, store_sales:7},
+    {item_sk:3, d_date:3, web_sales:30, store_sales:13},
+    {item_sk:3, d_date:4, web_sales:36, store_sales:15},
+    {item_sk:3, d_date:5, web_sales:44, store_sales:19}
   ]
 }

--- a/tests/dataset/tpc-dc/q52.md
+++ b/tests/dataset/tpc-dc/q52.md
@@ -4,7 +4,7 @@ Query extracted from the official TPC-DS specification.
 
 ## SQL
 ```sql
-[LIMITA]  select [LIMITB] dt.d_year
+SELECT dt.d_year
         ,item.i_brand_id brand_id
         ,item.i_brand brand
         ,sum(ss_ext_sales_price) ext_price
@@ -12,23 +12,23 @@ Query extracted from the official TPC-DS specification.
  where dt.d_date_sk = store_sales.ss_sold_date_sk
     and store_sales.ss_item_sk = item.i_item_sk
     and item.i_manager_id = 1
-    and dt.d_moy=[MONTH]
-    and dt.d_year=[YEAR]
+    and dt.d_moy=1
+    and dt.d_year=2000
  group by dt.d_year
         ,item.i_brand
         ,item.i_brand_id
  order by dt.d_year
         ,ext_price desc
         ,brand_id
-[LIMITC] ;
+LIMIT 100 ;
 ```
 
 ## Expected Output
 Example result using the expanded dataset from `q52.mochi`:
 ```json
 [
-  {"d_year":2000, "brand_id":1, "brand":"BrandA", "ext_price":250},
-  {"d_year":2000, "brand_id":2, "brand":"BrandB", "ext_price":75},
-  {"d_year":2000, "brand_id":3, "brand":"BrandC", "ext_price":75}
+  {"d_year":2000, "brand_id":1, "brand":"BrandA", "ext_price":310},
+  {"d_year":2000, "brand_id":3, "brand":"BrandC", "ext_price":115},
+  {"d_year":2000, "brand_id":2, "brand":"BrandB", "ext_price":75}
 ]
 ```

--- a/tests/dataset/tpc-dc/q52.mochi
+++ b/tests/dataset/tpc-dc/q52.mochi
@@ -20,6 +20,8 @@ let store_sales = [
   {ss_item_sk: 102, ss_sold_date_sk: 3, ss_ext_sales_price: 75},
   {ss_item_sk: 103, ss_sold_date_sk: 2, ss_ext_sales_price: 100},
   {ss_item_sk: 101, ss_sold_date_sk: 4, ss_ext_sales_price: 60}
+  ,{ss_item_sk: 103, ss_sold_date_sk: 1, ss_ext_sales_price: 60}
+  ,{ss_item_sk: 102, ss_sold_date_sk: 1, ss_ext_sales_price: 40}
 ]
 
 let result =
@@ -35,8 +37,8 @@ json(result)
 
 test "TPCDC Q52 brand totals" {
   expect result == [
-    {d_year:2000, brand_id:1, brand:"BrandA", ext_price:250},
-    {d_year:2000, brand_id:2, brand:"BrandB", ext_price:75},
-    {d_year:2000, brand_id:3, brand:"BrandC", ext_price:75}
+    {d_year:2000, brand_id:1, brand:"BrandA", ext_price:310},
+    {d_year:2000, brand_id:3, brand:"BrandC", ext_price:115},
+    {d_year:2000, brand_id:2, brand:"BrandB", ext_price:75}
   ]
 }

--- a/tests/dataset/tpc-dc/q53.md
+++ b/tests/dataset/tpc-dc/q53.md
@@ -11,7 +11,7 @@ Query extracted from the official TPC-DS specification.
  where ss_item_sk = i_item_sk and
  ss_sold_date_sk = d_date_sk and
  ss_store_sk = s_store_sk and
- d_month_seq in ([DMS],[DMS]+1,[DMS]+2,[DMS]+3,[DMS]+4,[DMS]+5,[DMS]+6,[DMS]+7,[DMS]+8,[DMS]+9,[DMS]+10,[DMS]+11) and
+d_month_seq in (1,2,3,4,5,6,7,8,9,10,11,12) and
  ((i_category in ('Books','Children','Electronics') and
  i_class in ('personal','portable','reference','self-help') and
  i_brand in ('scholaramalgamalg #14','scholaramalgamalg #7',
@@ -27,7 +27,7 @@ Query extracted from the official TPC-DS specification.
  order by avg_quarterly_sales,
           sum_sales,
           i_manufact_id
-[LIMITC];
+LIMIT 100;
 ```
 
 ## Expected Output
@@ -37,6 +37,7 @@ Sample output from `q53.mochi` with two quarters of sales:
   {"i_manufact_id":2, "sum_sales":80, "avg_quarterly_sales":120},
   {"i_manufact_id":2, "sum_sales":160, "avg_quarterly_sales":120},
   {"i_manufact_id":1, "sum_sales":150, "avg_quarterly_sales":225},
-  {"i_manufact_id":1, "sum_sales":300, "avg_quarterly_sales":225}
+  {"i_manufact_id":1, "sum_sales":300, "avg_quarterly_sales":225},
+  {"i_manufact_id":3, "sum_sales":160, "avg_quarterly_sales":80}
 ]
 ```

--- a/tests/dataset/tpc-dc/q53.mochi
+++ b/tests/dataset/tpc-dc/q53.mochi
@@ -1,6 +1,7 @@
 let item = [
   {i_item_sk: 1, i_manufact_id: 1, i_category: "Books", i_class: "personal", i_brand: "scholaramalgamalg #14"},
   {i_item_sk: 2, i_manufact_id: 2, i_category: "Books", i_class: "personal", i_brand: "scholaramalgamalg #14"}
+  ,{i_item_sk: 3, i_manufact_id: 3, i_category: "Books", i_class: "personal", i_brand: "scholaramalgamalg #9"}
 ]
 
 let date_dim = [
@@ -18,6 +19,8 @@ let store_sales = [
   {ss_item_sk: 2, ss_sold_date_sk: 1, ss_store_sk:1, ss_sales_price: 80},
   {ss_item_sk: 2, ss_sold_date_sk: 2, ss_store_sk:1, ss_sales_price: 80},
   {ss_item_sk: 2, ss_sold_date_sk: 3, ss_store_sk:1, ss_sales_price: 80}
+  ,{ss_item_sk: 3, ss_sold_date_sk: 1, ss_store_sk:1, ss_sales_price: 70}
+  ,{ss_item_sk: 3, ss_sold_date_sk: 2, ss_store_sk:1, ss_sales_price: 90}
 ]
 
 let tmp =
@@ -40,6 +43,7 @@ test "TPCDC Q53 quarterly" {
     {i_manufact_id:2, sum_sales:80, avg_quarterly_sales:120},
     {i_manufact_id:2, sum_sales:160, avg_quarterly_sales:120},
     {i_manufact_id:1, sum_sales:150, avg_quarterly_sales:225},
-    {i_manufact_id:1, sum_sales:300, avg_quarterly_sales:225}
+    {i_manufact_id:1, sum_sales:300, avg_quarterly_sales:225},
+    {i_manufact_id:3, sum_sales:160, avg_quarterly_sales:80}
   ]
 }

--- a/tests/dataset/tpc-dc/q54.md
+++ b/tests/dataset/tpc-dc/q54.md
@@ -23,11 +23,11 @@ from
         customer
 where   sold_date_sk = d_date_sk
         and item_sk = i_item_sk
-        and i_category = '[CATEGORY]'
-        and i_class = '[CLASS]'
+        and i_category = 'Cat'
+        and i_class = 'Class'
         and c_customer_sk = cs_or_ws_sales.customer_sk
-        and d_moy = [MONTH]
-        and d_year = [YEAR]
+        and d_moy = 1
+        and d_year = 2000
 )
 , my_revenue as (
 select c_customer_sk,
@@ -52,11 +52,11 @@ group by c_customer_sk
 (select cast((revenue/50) as int) as segment
  from   my_revenue
 )
-[LIMITA] select [LIMITB] segment, count(*) as num_customers, segment*50 as segment_base
+SELECT segment, count(*) as num_customers, segment*50 as segment_base
 from segments
 group by segment
 order by segment, num_customers
-[LIMITC];
+LIMIT 100;
 ```
 
 ## Expected Output
@@ -64,6 +64,7 @@ Based on the expanded data in `q54.mochi` the customers fall into revenue segmen
 ```json
 [
   {"segment":0, "num_customers":1, "segment_base":0},
+  {"segment":1, "num_customers":1, "segment_base":50},
   {"segment":2, "num_customers":1, "segment_base":100},
   {"segment":3, "num_customers":2, "segment_base":150}
 ]

--- a/tests/dataset/tpc-dc/q54.mochi
+++ b/tests/dataset/tpc-dc/q54.mochi
@@ -1,7 +1,8 @@
 let catalog_sales = [
   {cs_bill_customer_sk:1, cs_sold_date_sk:1, cs_item_sk:1},
   {cs_bill_customer_sk:3, cs_sold_date_sk:1, cs_item_sk:1},
-  {cs_bill_customer_sk:4, cs_sold_date_sk:1, cs_item_sk:1}
+  {cs_bill_customer_sk:4, cs_sold_date_sk:1, cs_item_sk:1},
+  {cs_bill_customer_sk:5, cs_sold_date_sk:1, cs_item_sk:1}
 ]
 let web_sales = [
   {ws_bill_customer_sk:2, ws_sold_date_sk:1, ws_item_sk:1}
@@ -12,7 +13,8 @@ let customer = [
   {c_customer_sk:1, c_current_addr_sk:1},
   {c_customer_sk:2, c_current_addr_sk:2},
   {c_customer_sk:3, c_current_addr_sk:3},
-  {c_customer_sk:4, c_current_addr_sk:4}
+  {c_customer_sk:4, c_current_addr_sk:4},
+  {c_customer_sk:5, c_current_addr_sk:1}
 ]
 let store_sales = [
   {ss_customer_sk:1, ss_sold_date_sk:2, ss_ext_sales_price:120},
@@ -21,6 +23,7 @@ let store_sales = [
   {ss_customer_sk:1, ss_sold_date_sk:2, ss_ext_sales_price:30},
   {ss_customer_sk:3, ss_sold_date_sk:2, ss_ext_sales_price:40},
   {ss_customer_sk:4, ss_sold_date_sk:2, ss_ext_sales_price:40}
+  ,{ss_customer_sk:5, ss_sold_date_sk:2, ss_ext_sales_price:80}
 ]
 let customer_address=[
   {ca_address_sk:1, ca_county:"C", ca_state:"S"},
@@ -60,6 +63,7 @@ json(result)
 test "TPCDC Q54 segments" {
   expect result == [
     {segment:0, num_customers:1, segment_base:0},
+    {segment:1, num_customers:1, segment_base:50},
     {segment:2, num_customers:1, segment_base:100},
     {segment:3, num_customers:2, segment_base:150}
   ]

--- a/tests/dataset/tpc-dc/q55.md
+++ b/tests/dataset/tpc-dc/q55.md
@@ -4,17 +4,17 @@ Query extracted from the official TPC-DS specification.
 
 ## SQL
 ```sql
-[LIMITA]  select [LIMITB] i_brand_id brand_id, i_brand brand,
+SELECT i_brand_id brand_id, i_brand brand,
         sum(ss_ext_sales_price) ext_price
  from date_dim, store_sales, item
  where d_date_sk = ss_sold_date_sk
         and ss_item_sk = i_item_sk
-        and i_manager_id=[MANAGER]
-        and d_moy=[MONTH]
-        and d_year=[YEAR]
+        and i_manager_id=1
+        and d_moy=1
+        and d_year=2000
  group by i_brand, i_brand_id
  order by ext_price desc, i_brand_id
-[LIMITC] ;
+LIMIT 100 ;
 ```
 
 ## Expected Output
@@ -22,6 +22,6 @@ Using the expanded dataset in `q55.mochi`:
 ```json
 [
   {"brand_id":1, "brand":"BrandA", "ext_price":250},
-  {"brand_id":2, "brand":"BrandB", "ext_price":50}
+  {"brand_id":2, "brand":"BrandB", "ext_price":120}
 ]
 ```

--- a/tests/dataset/tpc-dc/q55.mochi
+++ b/tests/dataset/tpc-dc/q55.mochi
@@ -8,6 +8,7 @@ let store_sales = [
   {ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:100},
   {ss_item_sk:2, ss_sold_date_sk:1, ss_ext_sales_price:50},
   {ss_item_sk:3, ss_sold_date_sk:1, ss_ext_sales_price:150}
+  ,{ss_item_sk:2, ss_sold_date_sk:1, ss_ext_sales_price:70}
 ]
 
 let result =
@@ -23,6 +24,6 @@ json(result)
 test "TPCDC Q55 brand manager" {
   expect result == [
     {brand_id:1, brand:"BrandA", ext_price:250},
-    {brand_id:2, brand:"BrandB", ext_price:50}
+    {brand_id:2, brand:"BrandB", ext_price:120}
   ]
 }

--- a/tests/dataset/tpc-dc/q56.md
+++ b/tests/dataset/tpc-dc/q56.md
@@ -14,13 +14,13 @@ from
 where i_item_id in (select
     i_item_id
  from item
- where i_color in ('[COLOR.1]','[COLOR.2]','[COLOR.3]'))
+ where i_color in ('Red','Blue','Green'))
  and     ss_item_sk              = i_item_sk
  and     ss_sold_date_sk         = d_date_sk
- and     d_year                  = [YEAR]
- and     d_moy                   = [MONTH]
+ and     d_year                  = 2000
+ and     d_moy                   = 1
  and     ss_addr_sk              = ca_address_sk
- and     ca_gmt_offset           = [GMT]
+ and     ca_gmt_offset           = 0
  group by i_item_id),
 cs as (
 select i_item_id,sum(cs_ext_sales_price) total_sales
@@ -33,13 +33,13 @@ where
         i_item_id               in (select
  i_item_id
  from item
- where i_color in ('[COLOR.1]','[COLOR.2]','[COLOR.3]'))
+ where i_color in ('Red','Blue','Green'))
  and     cs_item_sk              = i_item_sk
  and     cs_sold_date_sk         = d_date_sk
- and     d_year                  = [YEAR]
- and     d_moy                   = [MONTH]
+ and     d_year                  = 2000
+ and     d_moy                   = 1
  and     cs_bill_addr_sk         = ca_address_sk
- and     ca_gmt_offset           = [GMT]
+ and     ca_gmt_offset           = 0
  group by i_item_id),
 ws as (
 select i_item_id,sum(ws_ext_sales_price) total_sales
@@ -52,15 +52,15 @@ where
         i_item_id               in (select
  i_item_id
  from item
- where i_color in ('[COLOR.1]','[COLOR.2]','[COLOR.3]'))
+ where i_color in ('Red','Blue','Green'))
  and     ws_item_sk              = i_item_sk
  and     ws_sold_date_sk         = d_date_sk
- and     d_year                  = [YEAR]
- and     d_moy                   = [MONTH]
+ and     d_year                  = 2000
+ and     d_moy                   = 1
  and     ws_bill_addr_sk         = ca_address_sk
- and     ca_gmt_offset           = [GMT]
+ and     ca_gmt_offset           = 0
  group by i_item_id)
-[LIMITA] select [LIMITB] i_item_id ,sum(total_sales) total_sales
+SELECT i_item_id ,sum(total_sales) total_sales
 from  (select * from ss
        union all
        select * from cs
@@ -69,7 +69,7 @@ from  (select * from ss
 group by i_item_id
 order by total_sales,
          i_item_id
-[LIMITC];
+LIMIT 100;
 ```
 
 ## Expected Output
@@ -77,7 +77,7 @@ The combined sales from all channels:
 ```json
 [
   {"i_item_id":3, "total_sales":30},
-  {"i_item_id":1, "total_sales":60},
+  {"i_item_id":1, "total_sales":90},
   {"i_item_id":2, "total_sales":100}
 ]
 ```

--- a/tests/dataset/tpc-dc/q56.mochi
+++ b/tests/dataset/tpc-dc/q56.mochi
@@ -9,16 +9,19 @@ let store_sales=[
   {ss_item_sk:1, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:20},
   {ss_item_sk:2, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:30},
   {ss_item_sk:3, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:10}
+  ,{ss_item_sk:1, ss_sold_date_sk:1, ss_addr_sk:1, ss_ext_sales_price:10}
 ]
 let catalog_sales=[
   {cs_item_sk:1, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:20},
   {cs_item_sk:2, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:40},
   {cs_item_sk:3, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:10}
+  ,{cs_item_sk:1, cs_sold_date_sk:1, cs_bill_addr_sk:1, cs_ext_sales_price:5}
 ]
 let web_sales=[
   {ws_item_sk:1, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:20},
   {ws_item_sk:2, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:30},
   {ws_item_sk:3, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:10}
+  ,{ws_item_sk:1, ws_sold_date_sk:1, ws_bill_addr_sk:1, ws_ext_sales_price:15}
 ]
 
 let ss=
@@ -58,7 +61,7 @@ json(result)
 test "TPCDC Q56 union sales" {
   expect result == [
     {i_item_id:3, total_sales:30},
-    {i_item_id:1, total_sales:60},
+    {i_item_id:1, total_sales:90},
     {i_item_id:2, total_sales:100}
   ]
 }

--- a/tests/dataset/tpc-dc/q57.md
+++ b/tests/dataset/tpc-dc/q57.md
@@ -22,15 +22,14 @@ where cs_item_sk = i_item_sk and
       cs_sold_date_sk = d_date_sk and
       cc_call_center_sk= cs_call_center_sk and
       (
-        d_year = [YEAR] or
-        ( d_year = [YEAR]-1 and d_moy =12) or
-        ( d_year = [YEAR]+1 and d_moy =1)
+        d_year = 2000 or
+        ( d_year = 1999 and d_moy =12) or
+        ( d_year = 2001 and d_moy =1)
       )
 group by i_category, i_brand,
          cc_name , d_year, d_moy),
 v2 as(
-select [SELECTONE]
-       [SELECTTWO]
+select v1.cc_name
        ,v1.avg_monthly_sales
        ,v1.sum_sales, v1_lag.sum_sales psum, v1_lead.sum_sales nsum
 from v1, v1 v1_lag, v1 v1_lead
@@ -42,20 +41,20 @@ where v1.i_category = v1_lag.i_category and
       v1. cc_name = v1_lead. cc_name and
       v1.rn = v1_lag.rn + 1 and
       v1.rn = v1_lead.rn - 1)
-[LIMITA] select [LIMITB] *
+SELECT *
 from v2
-where  d_year = [YEAR] and
+where  d_year = 2000 and
        avg_monthly_sales > 0 and
        case when avg_monthly_sales > 0 then abs(sum_sales - avg_monthly_sales) / avg_monthly_sales else null end > 0.1
-order by sum_sales - avg_monthly_sales, [ORDERBY]
-[LIMITC];
+order by sum_sales - avg_monthly_sales, avg_monthly_sales
+LIMIT 100;
 ```
 
 ## Expected Output
 With the updated sample data the single call center shows two months:
 ```json
 [
-  {"cc_name":"CC", "sum_sales":150, "avg_monthly_sales":175},
-  {"cc_name":"CC", "sum_sales":200, "avg_monthly_sales":175}
+  {"cc_name":"CC", "sum_sales":150, "avg_monthly_sales":176.66666666666666},
+  {"cc_name":"CC", "sum_sales":200, "avg_monthly_sales":176.66666666666666}
 ]
 ```

--- a/tests/dataset/tpc-dc/q57.mochi
+++ b/tests/dataset/tpc-dc/q57.mochi
@@ -2,12 +2,14 @@ let item=[{i_item_sk:1, i_category:"Cat", i_brand:"Brand"}]
 let call_center=[{cc_call_center_sk:1, cc_name:"CC"}]
 let date_dim=[
   {d_date_sk:1, d_year:2000, d_moy:1},
-  {d_date_sk:2, d_year:2000, d_moy:2}
+  {d_date_sk:2, d_year:2000, d_moy:2},
+  {d_date_sk:3, d_year:2000, d_moy:3}
 ]
 let catalog_sales=[
   {cs_item_sk:1, cs_sold_date_sk:1, cs_call_center_sk:1, cs_sales_price:100},
   {cs_item_sk:1, cs_sold_date_sk:1, cs_call_center_sk:1, cs_sales_price:50},
-  {cs_item_sk:1, cs_sold_date_sk:2, cs_call_center_sk:1, cs_sales_price:200}
+  {cs_item_sk:1, cs_sold_date_sk:2, cs_call_center_sk:1, cs_sales_price:200},
+  {cs_item_sk:1, cs_sold_date_sk:3, cs_call_center_sk:1, cs_sales_price:180}
 ]
 
 let monthly=
@@ -51,7 +53,7 @@ json(result)
 
 test "TPCDC Q57 call center" {
   expect result == [
-    {cc_name:"CC", sum_sales:150, avg_monthly_sales:175},
-    {cc_name:"CC", sum_sales:200, avg_monthly_sales:175}
+    {cc_name:"CC", sum_sales:150, avg_monthly_sales:176.66666666666666},
+    {cc_name:"CC", sum_sales:200, avg_monthly_sales:176.66666666666666}
   ]
 }

--- a/tests/dataset/tpc-dc/q58.md
+++ b/tests/dataset/tpc-dc/q58.md
@@ -15,7 +15,7 @@ where ss_item_sk = i_item_sk
                  from date_dim
                  where d_week_seq = (select d_week_seq
                                      from date_dim
-                                     where d_date = '[SALES_DATE]'))
+                                     where d_date = '2023-01-01'))
   and ss_sold_date_sk   = d_date_sk
 group by i_item_id),
 cs_items as
@@ -29,7 +29,7 @@ where cs_item_sk = i_item_sk
                  from date_dim
                  where d_week_seq = (select d_week_seq
                                      from date_dim
-                                     where d_date = '[SALES_DATE]'))
+                                     where d_date = '2023-01-01'))
  and  cs_sold_date_sk = d_date_sk
 group by i_item_id),
 ws_items as
@@ -43,10 +43,10 @@ where ws_item_sk = i_item_sk
                  from date_dim
                  where d_week_seq =(select d_week_seq
                                     from date_dim
-                                    where d_date = '[SALES_DATE]'))
+                                     where d_date = '2023-01-01'))
  and ws_sold_date_sk   = d_date_sk
 group by i_item_id)
-[LIMITA] select [LIMITB] ss_items.item_id
+SELECT ss_items.item_id
       ,ss_item_rev
       ,ss_item_rev/((ss_item_rev+cs_item_rev+ws_item_rev)/3) * 100 ss_dev
       ,cs_item_rev
@@ -65,7 +65,7 @@ where ss_items.item_id=cs_items.item_id
   and ws_item_rev between 0.9 * cs_item_rev and 1.1 * cs_item_rev
 order by item_id
         ,ss_item_rev
-[LIMITC];
+LIMIT 100;
 ```
 
 ## Expected Output
@@ -73,6 +73,7 @@ For the expanded dataset two items meet the deviation criteria:
 ```json
 [
   {"item_id":1, "average":20},
-  {"item_id":2, "average":30.666666666666668}
+  {"item_id":2, "average":30.666666666666668},
+  {"item_id":4, "average":31}
 ]
 ```

--- a/tests/dataset/tpc-dc/q58.mochi
+++ b/tests/dataset/tpc-dc/q58.mochi
@@ -1,4 +1,4 @@
-let item=[{i_item_id:1}, {i_item_id:2}, {i_item_id:3}]
+let item=[{i_item_id:1}, {i_item_id:2}, {i_item_id:3}, {i_item_id:4}]
 let date_dim=[
   {d_date_sk:1, d_week_seq:1, d_date:"2023-01-01"},
   {d_date_sk:2, d_week_seq:1, d_date:"2023-01-02"}
@@ -6,17 +6,20 @@ let date_dim=[
 let store_sales=[
   {ss_item_sk:1, ss_sold_date_sk:1, ss_ext_sales_price:20},
   {ss_item_sk:2, ss_sold_date_sk:2, ss_ext_sales_price:30},
-  {ss_item_sk:3, ss_sold_date_sk:1, ss_ext_sales_price:40}
+  {ss_item_sk:3, ss_sold_date_sk:1, ss_ext_sales_price:40},
+  {ss_item_sk:4, ss_sold_date_sk:1, ss_ext_sales_price:30}
 ]
 let catalog_sales=[
   {cs_item_sk:1, cs_sold_date_sk:1, cs_ext_sales_price:20},
   {cs_item_sk:2, cs_sold_date_sk:2, cs_ext_sales_price:30},
-  {cs_item_sk:3, cs_sold_date_sk:1, cs_ext_sales_price:70}
+  {cs_item_sk:3, cs_sold_date_sk:1, cs_ext_sales_price:70},
+  {cs_item_sk:4, cs_sold_date_sk:1, cs_ext_sales_price:32}
 ]
 let web_sales=[
   {ws_item_sk:1, ws_sold_date_sk:1, ws_ext_sales_price:20},
   {ws_item_sk:2, ws_sold_date_sk:2, ws_ext_sales_price:32},
-  {ws_item_sk:3, ws_sold_date_sk:1, ws_ext_sales_price:20}
+  {ws_item_sk:3, ws_sold_date_sk:1, ws_ext_sales_price:20},
+  {ws_item_sk:4, ws_sold_date_sk:1, ws_ext_sales_price:31}
 ]
 
 let ss_items=
@@ -53,6 +56,7 @@ json(combined)
 test "TPCDC Q58 revenue parity" {
   expect combined == [
     {item_id:1, average:20},
-    {item_id:2, average:30.666666666666668}
+    {item_id:2, average:30.666666666666668},
+    {item_id:4, average:31}
   ]
 }

--- a/tests/dataset/tpc-dc/q59.md
+++ b/tests/dataset/tpc-dc/q59.md
@@ -4,7 +4,7 @@ Query extracted from the official TPC-DS specification.
 
 ## SQL
 ```sql
-[LIMITA] select [LIMITB] s_store_name1,s_store_id1,d_week_seq1
+SELECT s_store_name1,s_store_id1,d_week_seq1
       ,sun_sales1/sun_sales2,mon_sales1/mon_sales2
       ,tue_sales1/tue_sales2,wed_sales1/wed_sales2,thu_sales1/thu_sales2
       ,fri_sales1/fri_sales2,sat_sales1/sat_sales2
@@ -15,22 +15,22 @@ from
        ,wed_sales wed_sales1,thu_sales thu_sales1
        ,fri_sales fri_sales1,sat_sales sat_sales1
  from wss,store,date_dim d
- where d.d_week_seq = wss.d_week_seq and
+where d.d_week_seq = wss.d_week_seq and
        ss_store_sk = s_store_sk and
-       d_month_seq between [DMS] and [DMS] + 11) y,
+       d_month_seq between 1 and 1 + 11) y,
 (select s_store_name s_store_name2,wss.d_week_seq d_week_seq2
        ,s_store_id s_store_id2,sun_sales sun_sales2
        ,mon_sales mon_sales2,tue_sales tue_sales2
        ,wed_sales wed_sales2,thu_sales thu_sales2
        ,fri_sales fri_sales2,sat_sales sat_sales2
  from wss,store,date_dim d
- where d.d_week_seq = wss.d_week_seq and
+where d.d_week_seq = wss.d_week_seq and
        ss_store_sk = s_store_sk and
-       d_month_seq between [DMS]+ 12 and [DMS] + 23) x
+       d_month_seq between 1+ 12 and 1 + 23) x
 where s_store_id1=s_store_id2
   and d_week_seq1=d_week_seq2-52
 order by s_store_name1,s_store_id1,d_week_seq1
-[LIMITC];
+LIMIT 100;
 ```
 
 ## Expected Output
@@ -43,7 +43,10 @@ Example ratios comparing matching weeks:
   {"s_store_name1":"Store", "d_week_seq1":2,
    "sun_ratio":0.6666666666666666, "mon_ratio":0.6666666666666666,
    "tue_ratio":0.6666666666666666, "wed_ratio":0.6666666666666666,
-   "thu_ratio":0.6666666666666666, "fri_ratio":0.6666666666666666,
-   "sat_ratio":0.6666666666666666}
+    "thu_ratio":0.6666666666666666, "fri_ratio":0.6666666666666666,
+    "sat_ratio":0.6666666666666666},
+  {"s_store_name1":"Store", "d_week_seq1":3,
+   "sun_ratio":3, "mon_ratio":3, "tue_ratio":3, "wed_ratio":3,
+   "thu_ratio":3, "fri_ratio":3, "sat_ratio":3}
 ]
 ```

--- a/tests/dataset/tpc-dc/q59.mochi
+++ b/tests/dataset/tpc-dc/q59.mochi
@@ -3,17 +3,23 @@ let wss=[
     sun_sales:10, mon_sales:10, tue_sales:10, wed_sales:10, thu_sales:10, fri_sales:10, sat_sales:10},
   {d_week_seq:2, ss_store_sk:1,
     sun_sales:8, mon_sales:8, tue_sales:8, wed_sales:8, thu_sales:8, fri_sales:8, sat_sales:8},
+  {d_week_seq:3, ss_store_sk:1,
+    sun_sales:9, mon_sales:9, tue_sales:9, wed_sales:9, thu_sales:9, fri_sales:9, sat_sales:9},
   {d_week_seq:53, ss_store_sk:1,
     sun_sales:5, mon_sales:5, tue_sales:5, wed_sales:5, thu_sales:5, fri_sales:5, sat_sales:5},
   {d_week_seq:54, ss_store_sk:1,
-    sun_sales:12, mon_sales:12, tue_sales:12, wed_sales:12, thu_sales:12, fri_sales:12, sat_sales:12}
+    sun_sales:12, mon_sales:12, tue_sales:12, wed_sales:12, thu_sales:12, fri_sales:12, sat_sales:12},
+  {d_week_seq:55, ss_store_sk:1,
+    sun_sales:3, mon_sales:3, tue_sales:3, wed_sales:3, thu_sales:3, fri_sales:3, sat_sales:3}
 ]
 let store=[{s_store_sk:1, s_store_name:"Store", s_store_id:1}]
 let date_dim=[
   {d_week_seq:1, d_month_seq:1},
   {d_week_seq:2, d_month_seq:2},
+  {d_week_seq:3, d_month_seq:3},
   {d_week_seq:53, d_month_seq:13},
-  {d_week_seq:54, d_month_seq:14}
+  {d_week_seq:54, d_month_seq:14},
+  {d_week_seq:55, d_month_seq:15}
 ]
 
 let y=
@@ -59,7 +65,10 @@ test "TPCDC Q59 ratios" {
     {s_store_name1:"Store", d_week_seq1:2,
      sun_ratio:0.6666666666666666, mon_ratio:0.6666666666666666,
      tue_ratio:0.6666666666666666, wed_ratio:0.6666666666666666,
-     thu_ratio:0.6666666666666666, fri_ratio:0.6666666666666666,
-     sat_ratio:0.6666666666666666}
+      thu_ratio:0.6666666666666666, fri_ratio:0.6666666666666666,
+      sat_ratio:0.6666666666666666},
+      {s_store_name1:"Store", d_week_seq1:3,
+       sun_ratio:3, mon_ratio:3, tue_ratio:3, wed_ratio:3,
+       thu_ratio:3, fri_ratio:3, sat_ratio:3}
   ]
 }


### PR DESCRIPTION
## Summary
- fill in SQL templates for q50–q59
- expand sample data for q50–q59 examples
- update expected results for new data

## Testing
- `make test STAGE=interpreter`

------
https://chatgpt.com/codex/tasks/task_e_6862a562fe1883208f5da9bca7f04156