### PR TITLE
Improve row map assembly

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -5439,11 +5439,23 @@ func (fc *funcCompiler) buildRowMap(q *parser.QueryExpr) int {
 			}
 		}
 	}
-	contig := make([]int, len(pairs))
-	for i, r := range pairs {
-		nr := fc.newReg()
-		fc.emit(q.Pos, Instr{Op: OpMove, A: nr, B: r})
-		contig[i] = nr
+	contig := pairs
+	if len(pairs) > 0 {
+		ok := true
+		for i := 1; i < len(pairs); i++ {
+			if pairs[i] != pairs[i-1]+1 {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			contig = make([]int, len(pairs))
+			for i, r := range pairs {
+				nr := fc.newReg()
+				fc.emit(q.Pos, Instr{Op: OpMove, A: nr, B: r})
+				contig[i] = nr
+			}
+		}
 	}
 	row := fc.newReg()
 	start := 0


### PR DESCRIPTION
## Summary
- optimize `buildRowMap` to avoid copying when key/value pairs are already contiguous

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCH/q14 -count=1`
- `go test -tags slow ./tests/vm -run TestVM_TPCH/q14 -update -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6862a8172e8c83208c921c2bc121339d