### PR TITLE
Update TPC-DS IR outputs q1-q9

### DIFF
--- a/tests/dataset/tpc-ds/out/q1.ir.out
+++ b/tests/dataset/tpc-ds/out/q1.ir.out
@@ -20,14 +20,16 @@ func main (regs=171)
   Const        r11, "sr_return_amt"
   // from sr in store_returns
   MakeMap      r12, 0, r0
-  Const        r13, []
+  Const        r14, []
+  Move         r13, r14
   IterPrep     r15, r0
   Len          r16, r15
   Const        r17, 0
 L5:
   LessInt      r18, r17, r16
   JumpIfFalse  r18, L0
-  Index        r20, r15, r17
+  Index        r19, r15, r17
+  Move         r20, r19
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
   IterPrep     r21, r0
   Len          r22, r21
@@ -35,7 +37,8 @@ L5:
 L4:
   LessInt      r24, r23, r22
   JumpIfFalse  r24, L1
-  Index        r26, r21, r23
+  Index        r25, r21, r23
+  Move         r26, r25
   Const        r27, "sr_returned_date_sk"
   Index        r28, r20, r27
   Const        r29, "d_date_sk"
@@ -52,54 +55,55 @@ L4:
   Move         r36, r20
   Const        r37, "d"
   Move         r38, r26
-  MakeMap      r39, 2, r35
+  Move         r39, r35
+  Move         r40, r36
+  Move         r41, r37
+  Move         r42, r38
+  MakeMap      r43, 2, r39
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Const        r40, "customer_sk"
-  Index        r41, r20, r3
-  Const        r42, "store_sk"
-  Index        r43, r20, r5
-  Move         r44, r40
-  Move         r45, r41
-  Move         r46, r42
-  Move         r47, r43
-  MakeMap      r48, 2, r44
-  Str          r49, r48
-  In           r50, r49, r12
-  JumpIfTrue   r50, L3
+  Const        r44, "customer_sk"
+  Index        r45, r20, r3
+  Const        r46, "store_sk"
+  Index        r47, r20, r5
+  Move         r48, r44
+  Move         r49, r45
+  Move         r50, r46
+  Move         r51, r47
+  MakeMap      r52, 2, r48
+  Str          r53, r52
+  In           r54, r53, r12
+  JumpIfTrue   r54, L3
   // from sr in store_returns
-  Const        r51, []
-  Const        r52, "__group__"
-  Const        r53, true
-  Const        r54, "key"
+  Const        r55, "__group__"
+  Const        r56, true
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Move         r55, r48
+  Move         r57, r52
   // from sr in store_returns
-  Const        r56, "items"
-  Move         r57, r51
-  Const        r58, "count"
-  Const        r59, 0
-  Move         r60, r52
-  Move         r61, r53
-  Move         r62, r54
-  Move         r63, r55
-  Move         r64, r56
+  Const        r58, "items"
+  Move         r59, r0
+  Const        r60, "count"
+  Const        r61, 0
+  Move         r62, r55
+  Move         r63, r56
+  Move         r64, r8
   Move         r65, r57
   Move         r66, r58
   Move         r67, r59
-  MakeMap      r68, 4, r60
-  SetIndex     r12, r49, r68
-  Append       r13, r13, r68
+  Move         r68, r60
+  Move         r69, r61
+  MakeMap      r70, 4, r62
+  SetIndex     r12, r53, r70
+  Append       r71, r13, r70
+  Move         r13, r71
 L3:
-  Const        r70, "items"
-  Index        r71, r12, r49
-  Index        r72, r71, r70
-  Append       r73, r72, r39
-  SetIndex     r71, r70, r73
-  Const        r74, "count"
-  Index        r75, r71, r74
+  Index        r72, r12, r53
+  Index        r73, r72, r58
+  Append       r74, r73, r43
+  SetIndex     r72, r58, r74
+  Index        r75, r72, r60
   Const        r76, 1
   AddInt       r77, r75, r76
-  SetIndex     r71, r74, r77
+  SetIndex     r72, r60, r77
 L2:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
   AddInt       r23, r23, r76
@@ -109,165 +113,178 @@ L1:
   AddInt       r17, r17, r76
   Jump         L5
 L0:
-  Const        r79, 0
-  Move         r78, r79
-  Len          r80, r13
+  Move         r78, r61
+  Len          r79, r13
 L9:
-  LessInt      r81, r78, r80
-  JumpIfFalse  r81, L6
-  Index        r83, r13, r78
+  LessInt      r80, r78, r79
+  JumpIfFalse  r80, L6
+  Index        r81, r13, r78
+  Move         r82, r81
   // ctr_customer_sk: g.key.customer_sk,
-  Const        r84, "ctr_customer_sk"
-  Index        r85, r83, r8
-  Index        r86, r85, r2
+  Const        r83, "ctr_customer_sk"
+  Index        r84, r82, r8
+  Index        r85, r84, r2
   // ctr_store_sk: g.key.store_sk,
-  Const        r87, "ctr_store_sk"
-  Index        r88, r83, r8
-  Index        r89, r88, r4
+  Const        r86, "ctr_store_sk"
+  Index        r87, r82, r8
+  Index        r88, r87, r4
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Const        r90, "ctr_total_return"
-  Const        r91, []
-  IterPrep     r92, r83
-  Len          r93, r92
-  Move         r94, r79
+  Const        r89, "ctr_total_return"
+  Const        r90, []
+  IterPrep     r91, r82
+  Len          r92, r91
+  Move         r93, r61
 L8:
-  LessInt      r95, r94, r93
-  JumpIfFalse  r95, L7
-  Index        r97, r92, r94
-  Index        r98, r97, r11
-  Append       r91, r91, r98
-  AddInt       r94, r94, r76
+  LessInt      r94, r93, r92
+  JumpIfFalse  r94, L7
+  Index        r95, r91, r93
+  Move         r96, r95
+  Index        r97, r96, r11
+  Append       r98, r90, r97
+  Move         r90, r98
+  AddInt       r93, r93, r76
   Jump         L8
 L7:
-  Sum          r100, r91
+  Sum          r99, r90
   // ctr_customer_sk: g.key.customer_sk,
-  Move         r101, r84
-  Move         r102, r86
+  Move         r100, r83
+  Move         r101, r85
   // ctr_store_sk: g.key.store_sk,
-  Move         r103, r87
-  Move         r104, r89
+  Move         r102, r86
+  Move         r103, r88
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Move         r105, r90
-  Move         r106, r100
+  Move         r104, r89
+  Move         r105, r99
   // select {
-  MakeMap      r107, 3, r101
+  MakeMap      r106, 3, r100
   // from sr in store_returns
-  Append       r1, r1, r107
+  Append       r107, r1, r106
+  Move         r1, r107
   AddInt       r78, r78, r76
   Jump         L9
 L6:
   // from ctr1 in customer_total_return
-  Const        r109, []
+  Const        r108, []
   // s.s_state == "TN"
-  Const        r110, "s_state"
+  Const        r109, "s_state"
   // select {c_customer_id: c.c_customer_id}
-  Const        r111, "c_customer_id"
+  Const        r110, "c_customer_id"
   // from ctr1 in customer_total_return
-  IterPrep     r112, r1
-  Len          r113, r112
-  Move         r114, r79
+  IterPrep     r111, r1
+  Len          r112, r111
+  Move         r113, r61
 L20:
-  LessInt      r115, r114, r113
-  JumpIfFalse  r115, L10
-  Index        r117, r112, r114
+  LessInt      r114, r113, r112
+  JumpIfFalse  r114, L10
+  Index        r115, r111, r113
+  Move         r116, r115
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  IterPrep     r118, r0
-  Len          r119, r118
-  Const        r120, "s_store_sk"
-  Move         r121, r79
+  IterPrep     r117, r0
+  Len          r118, r117
+  Const        r119, "s_store_sk"
+  Move         r120, r61
 L19:
-  LessInt      r122, r121, r119
-  JumpIfFalse  r122, L11
-  Index        r124, r118, r121
-  Index        r125, r117, r9
-  Index        r126, r124, r120
-  Equal        r127, r125, r126
-  JumpIfFalse  r127, L12
+  LessInt      r121, r120, r118
+  JumpIfFalse  r121, L11
+  Index        r122, r117, r120
+  Move         r123, r122
+  Index        r124, r116, r9
+  Index        r125, r123, r119
+  Equal        r126, r124, r125
+  JumpIfFalse  r126, L12
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  IterPrep     r128, r0
-  Len          r129, r128
-  Const        r130, "c_customer_sk"
-  Move         r131, r79
+  IterPrep     r127, r0
+  Len          r128, r127
+  Const        r129, "c_customer_sk"
+  Move         r130, r61
 L18:
-  LessInt      r132, r131, r129
-  JumpIfFalse  r132, L12
-  Index        r134, r128, r131
-  Index        r135, r117, r7
-  Index        r136, r134, r130
-  Equal        r137, r135, r136
-  JumpIfFalse  r137, L13
+  LessInt      r131, r130, r128
+  JumpIfFalse  r131, L12
+  Index        r132, r127, r130
+  Move         r133, r132
+  Index        r134, r116, r7
+  Index        r135, r133, r129
+  Equal        r136, r134, r135
+  JumpIfFalse  r136, L13
   // where ctr1.ctr_total_return > avg(
-  Index        r138, r117, r10
+  Index        r137, r116, r10
   // from ctr2 in customer_total_return
-  Const        r139, []
-  IterPrep     r140, r1
-  Len          r141, r140
-  Move         r142, r79
+  Const        r138, []
+  IterPrep     r139, r1
+  Len          r140, r139
+  Move         r141, r61
 L16:
-  LessInt      r143, r142, r141
-  JumpIfFalse  r143, L14
-  Index        r145, r140, r142
+  LessInt      r142, r141, r140
+  JumpIfFalse  r142, L14
+  Index        r143, r139, r141
+  Move         r144, r143
   // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Index        r146, r117, r9
-  Index        r147, r145, r9
-  Equal        r148, r146, r147
-  JumpIfFalse  r148, L15
+  Index        r145, r116, r9
+  Index        r146, r144, r9
+  Equal        r147, r145, r146
+  JumpIfFalse  r147, L15
   // select ctr2.ctr_total_return
-  Index        r149, r145, r10
+  Index        r148, r144, r10
   // from ctr2 in customer_total_return
-  Append       r139, r139, r149
+  Append       r149, r138, r148
+  Move         r138, r149
 L15:
-  AddInt       r142, r142, r76
+  AddInt       r141, r141, r76
   Jump         L16
 L14:
   // where ctr1.ctr_total_return > avg(
-  Avg          r151, r139
+  Avg          r150, r138
   // ) * 1.2 &&
-  Const        r152, 1.2
-  MulFloat     r153, r151, r152
+  Const        r151, 1.2
+  MulFloat     r152, r150, r151
   // where ctr1.ctr_total_return > avg(
-  LessFloat    r154, r153, r138
+  LessFloat    r153, r152, r137
   // s.s_state == "TN"
-  Index        r155, r124, r110
-  Const        r156, "TN"
-  Equal        r157, r155, r156
+  Index        r154, r123, r109
+  Const        r155, "TN"
+  Equal        r156, r154, r155
   // ) * 1.2 &&
-  JumpIfFalse  r154, L17
-  Move         r154, r157
+  Move         r157, r153
+  JumpIfFalse  r157, L17
+  Move         r157, r156
 L17:
   // where ctr1.ctr_total_return > avg(
-  JumpIfFalse  r154, L13
+  JumpIfFalse  r157, L13
   // select {c_customer_id: c.c_customer_id}
   Const        r158, "c_customer_id"
-  Index        r159, r134, r111
+  Index        r159, r133, r110
   Move         r160, r158
   Move         r161, r159
   MakeMap      r162, 1, r160
   // sort by c.c_customer_id
-  Index        r164, r134, r111
+  Index        r163, r133, r110
+  Move         r164, r163
   // from ctr1 in customer_total_return
   Move         r165, r162
   MakeList     r166, 2, r164
-  Append       r109, r109, r166
+  Append       r167, r108, r166
+  Move         r108, r167
 L13:
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  Add          r131, r131, r76
+  Add          r130, r130, r76
   Jump         L18
 L12:
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  Add          r121, r121, r76
+  Add          r120, r120, r76
   Jump         L19
 L11:
   // from ctr1 in customer_total_return
-  AddInt       r114, r114, r76
+  AddInt       r113, r113, r76
   Jump         L20
 L10:
   // sort by c.c_customer_id
-  Sort         r109, r109
+  Sort         r168, r108
+  // from ctr1 in customer_total_return
+  Move         r108, r168
   // json(result)
-  JSON         r109
+  JSON         r108
   // expect len(result) == 0
-  Len          r169, r109
-  EqualInt     r170, r169, r79
+  Len          r169, r108
+  EqualInt     r170, r169, r61
   Expect       r170
   Return       r0

--- a/tests/dataset/tpc-ds/out/q2.ir.out
+++ b/tests/dataset/tpc-ds/out/q2.ir.out
@@ -1,4 +1,4 @@
-func main (regs=242)
+func main (regs=241)
   // let web_sales = []
   Const        r0, []
   // (from ws in web_sales
@@ -20,7 +20,8 @@ func main (regs=242)
 L1:
   LessInt      r12, r10, r9
   JumpIfFalse  r12, L0
-  Index        r14, r8, r10
+  Index        r13, r8, r10
+  Move         r14, r13
   // sold_date_sk: ws.ws_sold_date_sk,
   Const        r15, "sold_date_sk"
   Index        r16, r14, r3
@@ -42,7 +43,8 @@ L1:
   // select {
   MakeMap      r27, 3, r21
   // (from ws in web_sales
-  Append       r1, r1, r27
+  Append       r28, r1, r27
+  Move         r1, r28
   Const        r29, 1
   AddInt       r10, r10, r29
   Jump         L1
@@ -62,7 +64,8 @@ L0:
 L3:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L2
-  Index        r39, r34, r36
+  Index        r38, r34, r36
+  Move         r39, r38
   // sold_date_sk: cs.cs_sold_date_sk,
   Const        r40, "sold_date_sk"
   Index        r41, r39, r31
@@ -84,7 +87,8 @@ L3:
   // select {
   MakeMap      r52, 3, r46
   // from cs in catalog_sales
-  Append       r30, r30, r52
+  Append       r53, r30, r52
+  Move         r30, r53
   AddInt       r36, r36, r29
   Jump         L3
 L2:
@@ -113,14 +117,16 @@ L2:
   Const        r65, "sat_sales"
   // from w in wscs
   MakeMap      r66, 0, r0
-  Const        r67, []
+  Const        r68, []
+  Move         r67, r68
   IterPrep     r69, r54
   Len          r70, r69
   Const        r71, 0
 L9:
   LessInt      r72, r71, r70
   JumpIfFalse  r72, L4
-  Index        r74, r69, r71
+  Index        r73, r69, r71
+  Move         r74, r73
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
   IterPrep     r75, r0
   Len          r76, r75
@@ -128,7 +134,8 @@ L9:
 L8:
   LessInt      r78, r77, r76
   JumpIfFalse  r78, L5
-  Index        r80, r75, r77
+  Index        r79, r75, r77
+  Move         r80, r79
   Index        r81, r74, r2
   Const        r82, "d_date_sk"
   Index        r83, r80, r82
@@ -139,49 +146,49 @@ L8:
   Move         r86, r74
   Const        r87, "d"
   Move         r88, r80
-  MakeMap      r89, 2, r85
+  Move         r89, r85
+  Move         r90, r86
+  Move         r91, r87
+  Move         r92, r88
+  MakeMap      r93, 2, r89
   // group by {week_seq: d.d_week_seq} into g
-  Const        r90, "week_seq"
-  Index        r91, r80, r57
-  Move         r92, r90
-  Move         r93, r91
-  MakeMap      r94, 1, r92
-  Str          r95, r94
-  In           r96, r95, r66
-  JumpIfTrue   r96, L7
+  Const        r94, "week_seq"
+  Index        r95, r80, r57
+  Move         r96, r94
+  Move         r97, r95
+  MakeMap      r98, 1, r96
+  Str          r99, r98
+  In           r100, r99, r66
+  JumpIfTrue   r100, L7
   // from w in wscs
-  Const        r97, []
-  Const        r98, "__group__"
-  Const        r99, true
-  Const        r100, "key"
+  Const        r101, "__group__"
+  Const        r102, true
   // group by {week_seq: d.d_week_seq} into g
-  Move         r101, r94
+  Move         r103, r98
   // from w in wscs
-  Const        r102, "items"
-  Move         r103, r97
-  Const        r104, "count"
-  Const        r105, 0
-  Move         r106, r98
-  Move         r107, r99
-  Move         r108, r100
-  Move         r109, r101
-  Move         r110, r102
-  Move         r111, r103
-  Move         r112, r104
-  Move         r113, r105
-  MakeMap      r114, 4, r106
-  SetIndex     r66, r95, r114
-  Append       r67, r67, r114
+  Const        r104, "items"
+  Move         r105, r0
+  Const        r106, "count"
+  Move         r107, r101
+  Move         r108, r102
+  Move         r109, r58
+  Move         r110, r103
+  Move         r111, r104
+  Move         r112, r105
+  Move         r113, r106
+  Move         r114, r11
+  MakeMap      r115, 4, r107
+  SetIndex     r66, r99, r115
+  Append       r116, r67, r115
+  Move         r67, r116
 L7:
-  Const        r116, "items"
-  Index        r117, r66, r95
-  Index        r118, r117, r116
-  Append       r119, r118, r89
-  SetIndex     r117, r116, r119
-  Const        r120, "count"
-  Index        r121, r117, r120
-  AddInt       r122, r121, r29
-  SetIndex     r117, r120, r122
+  Index        r117, r66, r99
+  Index        r118, r117, r104
+  Append       r119, r118, r93
+  SetIndex     r117, r104, r119
+  Index        r120, r117, r106
+  AddInt       r121, r120, r29
+  SetIndex     r117, r106, r121
 L6:
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
   AddInt       r77, r77, r29
@@ -191,197 +198,213 @@ L5:
   AddInt       r71, r71, r29
   Jump         L9
 L4:
-  Move         r123, r11
-  Len          r124, r67
+  Move         r122, r11
+  Len          r123, r67
 L32:
-  LessInt      r125, r123, r124
-  JumpIfFalse  r125, L10
-  Index        r127, r67, r123
+  LessInt      r124, r122, r123
+  JumpIfFalse  r124, L10
+  Index        r125, r67, r122
+  Move         r126, r125
   // d_week_seq: g.key.week_seq,
-  Const        r128, "d_week_seq"
-  Index        r129, r127, r58
-  Index        r130, r129, r56
+  Const        r127, "d_week_seq"
+  Index        r128, r126, r58
+  Index        r129, r128, r56
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Const        r131, "sun_sales"
-  Const        r132, []
-  IterPrep     r133, r127
-  Len          r134, r133
-  Move         r135, r11
+  Const        r130, "sun_sales"
+  Const        r131, []
+  IterPrep     r132, r126
+  Len          r133, r132
+  Move         r134, r11
 L13:
-  LessInt      r136, r135, r134
-  JumpIfFalse  r136, L11
-  Index        r138, r133, r135
-  Index        r139, r138, r6
-  Const        r140, "Sunday"
-  Equal        r141, r139, r140
-  JumpIfFalse  r141, L12
-  Index        r142, r138, r4
-  Append       r132, r132, r142
+  LessInt      r135, r134, r133
+  JumpIfFalse  r135, L11
+  Index        r136, r132, r134
+  Move         r137, r136
+  Index        r138, r137, r6
+  Const        r139, "Sunday"
+  Equal        r140, r138, r139
+  JumpIfFalse  r140, L12
+  Index        r141, r137, r4
+  Append       r142, r131, r141
+  Move         r131, r142
 L12:
-  AddInt       r135, r135, r29
+  AddInt       r134, r134, r29
   Jump         L13
 L11:
-  Sum          r144, r132
+  Sum          r143, r131
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Const        r145, "mon_sales"
-  Const        r146, []
-  IterPrep     r147, r127
-  Len          r148, r147
-  Move         r149, r11
+  Const        r144, "mon_sales"
+  Const        r145, []
+  IterPrep     r146, r126
+  Len          r147, r146
+  Move         r148, r11
 L16:
-  LessInt      r150, r149, r148
-  JumpIfFalse  r150, L14
-  Index        r138, r147, r149
-  Index        r152, r138, r6
-  Const        r153, "Monday"
-  Equal        r154, r152, r153
-  JumpIfFalse  r154, L15
-  Index        r155, r138, r4
-  Append       r146, r146, r155
+  LessInt      r149, r148, r147
+  JumpIfFalse  r149, L14
+  Index        r150, r146, r148
+  Move         r137, r150
+  Index        r151, r137, r6
+  Const        r152, "Monday"
+  Equal        r153, r151, r152
+  JumpIfFalse  r153, L15
+  Index        r154, r137, r4
+  Append       r155, r145, r154
+  Move         r145, r155
 L15:
-  AddInt       r149, r149, r29
+  AddInt       r148, r148, r29
   Jump         L16
 L14:
-  Sum          r157, r146
+  Sum          r156, r145
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Const        r158, "tue_sales"
-  Const        r159, []
-  IterPrep     r160, r127
-  Len          r161, r160
-  Move         r162, r11
+  Const        r157, "tue_sales"
+  Const        r158, []
+  IterPrep     r159, r126
+  Len          r160, r159
+  Move         r161, r11
 L19:
-  LessInt      r163, r162, r161
-  JumpIfFalse  r163, L17
-  Index        r138, r160, r162
-  Index        r165, r138, r6
-  Const        r166, "Tuesday"
-  Equal        r167, r165, r166
-  JumpIfFalse  r167, L18
-  Index        r168, r138, r4
-  Append       r159, r159, r168
+  LessInt      r162, r161, r160
+  JumpIfFalse  r162, L17
+  Index        r163, r159, r161
+  Move         r137, r163
+  Index        r164, r137, r6
+  Const        r165, "Tuesday"
+  Equal        r166, r164, r165
+  JumpIfFalse  r166, L18
+  Index        r167, r137, r4
+  Append       r168, r158, r167
+  Move         r158, r168
 L18:
-  AddInt       r162, r162, r29
+  AddInt       r161, r161, r29
   Jump         L19
 L17:
-  Sum          r170, r159
+  Sum          r169, r158
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Const        r171, "wed_sales"
-  Const        r172, []
-  IterPrep     r173, r127
-  Len          r174, r173
-  Move         r175, r11
+  Const        r170, "wed_sales"
+  Const        r171, []
+  IterPrep     r172, r126
+  Len          r173, r172
+  Move         r174, r11
 L22:
-  LessInt      r176, r175, r174
-  JumpIfFalse  r176, L20
-  Index        r138, r173, r175
-  Index        r178, r138, r6
-  Const        r179, "Wednesday"
-  Equal        r180, r178, r179
-  JumpIfFalse  r180, L21
-  Index        r181, r138, r4
-  Append       r172, r172, r181
+  LessInt      r175, r174, r173
+  JumpIfFalse  r175, L20
+  Index        r176, r172, r174
+  Move         r137, r176
+  Index        r177, r137, r6
+  Const        r178, "Wednesday"
+  Equal        r179, r177, r178
+  JumpIfFalse  r179, L21
+  Index        r180, r137, r4
+  Append       r181, r171, r180
+  Move         r171, r181
 L21:
-  AddInt       r175, r175, r29
+  AddInt       r174, r174, r29
   Jump         L22
 L20:
-  Sum          r183, r172
+  Sum          r182, r171
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Const        r184, "thu_sales"
-  Const        r185, []
-  IterPrep     r186, r127
-  Len          r187, r186
-  Move         r188, r11
+  Const        r183, "thu_sales"
+  Const        r184, []
+  IterPrep     r185, r126
+  Len          r186, r185
+  Move         r187, r11
 L25:
-  LessInt      r189, r188, r187
-  JumpIfFalse  r189, L23
-  Index        r138, r186, r188
-  Index        r191, r138, r6
-  Const        r192, "Thursday"
-  Equal        r193, r191, r192
-  JumpIfFalse  r193, L24
-  Index        r194, r138, r4
-  Append       r185, r185, r194
+  LessInt      r188, r187, r186
+  JumpIfFalse  r188, L23
+  Index        r189, r185, r187
+  Move         r137, r189
+  Index        r190, r137, r6
+  Const        r191, "Thursday"
+  Equal        r192, r190, r191
+  JumpIfFalse  r192, L24
+  Index        r193, r137, r4
+  Append       r194, r184, r193
+  Move         r184, r194
 L24:
-  AddInt       r188, r188, r29
+  AddInt       r187, r187, r29
   Jump         L25
 L23:
-  Sum          r196, r185
+  Sum          r195, r184
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Const        r197, "fri_sales"
-  Const        r198, []
-  IterPrep     r199, r127
-  Len          r200, r199
-  Move         r201, r11
+  Const        r196, "fri_sales"
+  Const        r197, []
+  IterPrep     r198, r126
+  Len          r199, r198
+  Move         r200, r11
 L28:
-  LessInt      r202, r201, r200
-  JumpIfFalse  r202, L26
-  Index        r138, r199, r201
-  Index        r204, r138, r6
-  Const        r205, "Friday"
-  Equal        r206, r204, r205
-  JumpIfFalse  r206, L27
-  Index        r207, r138, r4
-  Append       r198, r198, r207
+  LessInt      r201, r200, r199
+  JumpIfFalse  r201, L26
+  Index        r202, r198, r200
+  Move         r137, r202
+  Index        r203, r137, r6
+  Const        r204, "Friday"
+  Equal        r205, r203, r204
+  JumpIfFalse  r205, L27
+  Index        r206, r137, r4
+  Append       r207, r197, r206
+  Move         r197, r207
 L27:
-  AddInt       r201, r201, r29
+  AddInt       r200, r200, r29
   Jump         L28
 L26:
-  Sum          r209, r198
+  Sum          r208, r197
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Const        r210, "sat_sales"
-  Const        r211, []
-  IterPrep     r212, r127
-  Len          r213, r212
-  Move         r214, r11
+  Const        r209, "sat_sales"
+  Const        r210, []
+  IterPrep     r211, r126
+  Len          r212, r211
+  Move         r213, r11
 L31:
-  LessInt      r215, r214, r213
-  JumpIfFalse  r215, L29
-  Index        r138, r212, r214
-  Index        r217, r138, r6
-  Const        r218, "Saturday"
-  Equal        r219, r217, r218
-  JumpIfFalse  r219, L30
-  Index        r220, r138, r4
-  Append       r211, r211, r220
+  LessInt      r214, r213, r212
+  JumpIfFalse  r214, L29
+  Index        r215, r211, r213
+  Move         r137, r215
+  Index        r216, r137, r6
+  Const        r217, "Saturday"
+  Equal        r218, r216, r217
+  JumpIfFalse  r218, L30
+  Index        r219, r137, r4
+  Append       r220, r210, r219
+  Move         r210, r220
 L30:
-  AddInt       r214, r214, r29
+  AddInt       r213, r213, r29
   Jump         L31
 L29:
-  Sum          r222, r211
+  Sum          r221, r210
   // d_week_seq: g.key.week_seq,
-  Move         r223, r128
-  Move         r224, r130
+  Move         r222, r127
+  Move         r223, r129
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Move         r225, r131
-  Move         r226, r144
+  Move         r224, r130
+  Move         r225, r143
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Move         r227, r145
-  Move         r228, r157
+  Move         r226, r144
+  Move         r227, r156
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Move         r229, r158
-  Move         r230, r170
+  Move         r228, r157
+  Move         r229, r169
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Move         r231, r171
-  Move         r232, r183
+  Move         r230, r170
+  Move         r231, r182
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Move         r233, r184
-  Move         r234, r196
+  Move         r232, r183
+  Move         r233, r195
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Move         r235, r197
-  Move         r236, r209
+  Move         r234, r196
+  Move         r235, r208
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Move         r237, r210
-  Move         r238, r222
+  Move         r236, r209
+  Move         r237, r221
   // select {
-  MakeMap      r239, 8, r223
+  MakeMap      r238, 8, r222
   // from w in wscs
-  Append       r55, r55, r239
-  AddInt       r123, r123, r29
+  Append       r239, r55, r238
+  Move         r55, r239
+  AddInt       r122, r122, r29
   Jump         L32
 L10:
   // json(result)
   JSON         r0
   // expect len(result) == 0
-  Const        r241, true
-  Expect       r241
+  Const        r240, true
+  Expect       r240
   Return       r0

--- a/tests/dataset/tpc-ds/out/q3.ir.out
+++ b/tests/dataset/tpc-ds/out/q3.ir.out
@@ -1,4 +1,4 @@
-func main (regs=160)
+func main (regs=162)
   // let date_dim = []
   Const        r0, []
   // from dt in date_dim
@@ -20,14 +20,16 @@ func main (regs=160)
   Const        r12, "ss_ext_sales_price"
   // from dt in date_dim
   MakeMap      r13, 0, r0
-  Const        r14, []
+  Const        r15, []
+  Move         r14, r15
   IterPrep     r16, r0
   Len          r17, r16
   Const        r18, 0
 L8:
   LessInt      r19, r18, r17
   JumpIfFalse  r19, L0
-  Index        r21, r16, r18
+  Index        r20, r16, r18
+  Move         r21, r20
   // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
   IterPrep     r22, r0
   Len          r23, r22
@@ -35,7 +37,8 @@ L8:
 L7:
   LessInt      r25, r24, r23
   JumpIfFalse  r25, L1
-  Index        r27, r22, r24
+  Index        r26, r22, r24
+  Move         r27, r26
   Const        r28, "d_date_sk"
   Index        r29, r21, r28
   Const        r30, "ss_sold_date_sk"
@@ -49,7 +52,8 @@ L7:
 L6:
   LessInt      r36, r35, r34
   JumpIfFalse  r36, L2
-  Index        r38, r33, r35
+  Index        r37, r33, r35
+  Move         r38, r37
   Const        r39, "ss_item_sk"
   Index        r40, r27, r39
   Const        r41, "i_item_sk"
@@ -63,169 +67,184 @@ L6:
   Index        r47, r21, r8
   Const        r48, 12
   Equal        r49, r47, r48
-  JumpIfFalse  r46, L4
-  Move         r46, r49
+  Move         r50, r46
+  JumpIfFalse  r50, L4
+  Move         r50, r49
 L4:
-  JumpIfFalse  r46, L3
+  JumpIfFalse  r50, L3
   // from dt in date_dim
-  Const        r50, "dt"
-  Move         r51, r21
-  Move         r52, r27
-  Const        r53, "i"
-  Move         r54, r38
-  MakeMap      r55, 3, r50
+  Const        r51, "dt"
+  Move         r52, r21
+  Move         r53, r27
+  Const        r54, "i"
+  Move         r55, r38
+  Move         r56, r51
+  Move         r57, r52
+  Move         r58, r11
+  Move         r59, r53
+  Move         r60, r54
+  Move         r61, r55
+  MakeMap      r62, 3, r56
   // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Const        r56, "d_year"
-  Index        r57, r21, r2
-  Const        r58, "brand_id"
-  Index        r59, r38, r4
-  Const        r60, "brand"
-  Index        r61, r38, r6
-  Move         r62, r56
-  Move         r63, r57
-  Move         r64, r58
-  Move         r65, r59
-  Move         r66, r60
-  Move         r67, r61
-  MakeMap      r68, 3, r62
-  Str          r69, r68
-  In           r70, r69, r13
-  JumpIfTrue   r70, L5
+  Const        r63, "d_year"
+  Index        r64, r21, r2
+  Const        r65, "brand_id"
+  Index        r66, r38, r4
+  Const        r67, "brand"
+  Index        r68, r38, r6
+  Move         r69, r63
+  Move         r70, r64
+  Move         r71, r65
+  Move         r72, r66
+  Move         r73, r67
+  Move         r74, r68
+  MakeMap      r75, 3, r69
+  Str          r76, r75
+  In           r77, r76, r13
+  JumpIfTrue   r77, L5
   // from dt in date_dim
-  Const        r71, []
-  Const        r72, "__group__"
-  Const        r73, true
-  Const        r74, "key"
+  Const        r78, "__group__"
+  Const        r79, true
   // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Move         r75, r68
+  Move         r80, r75
   // from dt in date_dim
-  Const        r76, "items"
-  Move         r77, r71
-  Const        r78, "count"
-  Const        r79, 0
-  Move         r80, r72
-  Move         r81, r73
-  Move         r82, r74
-  Move         r83, r75
-  Move         r84, r76
-  Move         r85, r77
-  Move         r86, r78
-  Move         r87, r79
-  MakeMap      r88, 4, r80
-  SetIndex     r13, r69, r88
-  Append       r14, r14, r88
+  Const        r81, "items"
+  Move         r82, r0
+  Const        r83, "count"
+  Const        r84, 0
+  Move         r85, r78
+  Move         r86, r79
+  Move         r87, r9
+  Move         r88, r80
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  Move         r92, r84
+  MakeMap      r93, 4, r85
+  SetIndex     r13, r76, r93
+  Append       r94, r14, r93
+  Move         r14, r94
 L5:
-  Const        r90, "items"
-  Index        r91, r13, r69
-  Index        r92, r91, r90
-  Append       r93, r92, r55
-  SetIndex     r91, r90, r93
-  Const        r94, "count"
-  Index        r95, r91, r94
-  Const        r96, 1
-  AddInt       r97, r95, r96
-  SetIndex     r91, r94, r97
+  Index        r95, r13, r76
+  Index        r96, r95, r81
+  Append       r97, r96, r62
+  SetIndex     r95, r81, r97
+  Index        r98, r95, r83
+  Const        r99, 1
+  AddInt       r100, r98, r99
+  SetIndex     r95, r83, r100
 L3:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r35, r35, r96
+  AddInt       r35, r35, r99
   Jump         L6
 L2:
   // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
-  AddInt       r24, r24, r96
+  AddInt       r24, r24, r99
   Jump         L7
 L1:
   // from dt in date_dim
-  AddInt       r18, r18, r96
+  AddInt       r18, r18, r99
   Jump         L8
 L0:
-  Const        r99, 0
-  Move         r98, r99
-  Len          r100, r14
+  Move         r101, r84
+  Len          r102, r14
 L14:
-  LessInt      r101, r98, r100
-  JumpIfFalse  r101, L9
-  Index        r103, r14, r98
+  LessInt      r103, r101, r102
+  JumpIfFalse  r103, L9
+  Index        r104, r14, r101
+  Move         r105, r104
   // d_year: g.key.d_year,
-  Const        r104, "d_year"
-  Index        r105, r103, r9
-  Index        r106, r105, r2
+  Const        r106, "d_year"
+  Index        r107, r105, r9
+  Index        r108, r107, r2
   // brand_id: g.key.brand_id,
-  Const        r107, "brand_id"
-  Index        r108, r103, r9
-  Index        r109, r108, r3
+  Const        r109, "brand_id"
+  Index        r110, r105, r9
+  Index        r111, r110, r3
   // brand: g.key.brand,
-  Const        r110, "brand"
-  Index        r111, r103, r9
-  Index        r112, r111, r5
+  Const        r112, "brand"
+  Index        r113, r105, r9
+  Index        r114, r113, r5
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Const        r113, "sum_agg"
-  Const        r114, []
-  IterPrep     r115, r103
-  Len          r116, r115
-  Move         r117, r99
+  Const        r115, "sum_agg"
+  Const        r116, []
+  IterPrep     r117, r105
+  Len          r118, r117
+  Move         r119, r84
 L11:
-  LessInt      r118, r117, r116
-  JumpIfFalse  r118, L10
-  Index        r120, r115, r117
-  Index        r121, r120, r11
-  Index        r122, r121, r12
-  Append       r114, r114, r122
-  AddInt       r117, r117, r96
+  LessInt      r120, r119, r118
+  JumpIfFalse  r120, L10
+  Index        r121, r117, r119
+  Move         r122, r121
+  Index        r123, r122, r11
+  Index        r124, r123, r12
+  Append       r125, r116, r124
+  Move         r116, r125
+  AddInt       r119, r119, r99
   Jump         L11
 L10:
-  Sum          r124, r114
+  Sum          r126, r116
   // d_year: g.key.d_year,
-  Move         r125, r104
-  Move         r126, r106
+  Move         r127, r106
+  Move         r128, r108
   // brand_id: g.key.brand_id,
-  Move         r127, r107
-  Move         r128, r109
+  Move         r129, r109
+  Move         r130, r111
   // brand: g.key.brand,
-  Move         r129, r110
-  Move         r130, r112
+  Move         r131, r112
+  Move         r132, r114
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Move         r131, r113
-  Move         r132, r124
+  Move         r133, r115
+  Move         r134, r126
   // select {
-  MakeMap      r133, 4, r125
+  MakeMap      r135, 4, r127
   // sort by [g.key.d_year,
-  Index        r134, r103, r9
-  Index        r136, r134, r2
+  Index        r136, r105, r9
+  Index        r137, r136, r2
+  Move         r138, r137
   // -sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r137, []
-  IterPrep     r138, r103
-  Len          r139, r138
-  Move         r140, r99
+  Const        r139, []
+  IterPrep     r140, r105
+  Len          r141, r140
+  Move         r142, r84
 L13:
-  LessInt      r141, r140, r139
-  JumpIfFalse  r141, L12
-  Index        r120, r138, r140
-  Index        r143, r120, r11
-  Index        r144, r143, r12
-  Append       r137, r137, r144
-  AddInt       r140, r140, r96
+  LessInt      r143, r142, r141
+  JumpIfFalse  r143, L12
+  Index        r144, r140, r142
+  Move         r122, r144
+  Index        r145, r122, r11
+  Index        r146, r145, r12
+  Append       r147, r139, r146
+  Move         r139, r147
+  AddInt       r142, r142, r99
   Jump         L13
 L12:
-  Sum          r146, r137
-  Neg          r148, r146
+  Sum          r148, r139
+  Neg          r149, r148
+  Move         r150, r149
   // g.key.brand_id]
-  Index        r149, r103, r9
-  Index        r151, r149, r3
+  Index        r151, r105, r9
+  Index        r152, r151, r3
+  Move         r153, r152
   // sort by [g.key.d_year,
-  MakeList     r153, 3, r136
+  MakeList     r154, 3, r138
+  Move         r155, r154
   // from dt in date_dim
-  Move         r154, r133
-  MakeList     r155, 2, r153
-  Append       r1, r1, r155
-  AddInt       r98, r98, r96
+  Move         r156, r135
+  MakeList     r157, 2, r155
+  Append       r158, r1, r157
+  Move         r1, r158
+  AddInt       r101, r101, r99
   Jump         L14
 L9:
   // sort by [g.key.d_year,
-  Sort         r1, r1
+  Sort         r159, r1
+  // from dt in date_dim
+  Move         r1, r159
   // json(result)
   JSON         r1
   // expect len(result) == 0
-  Len          r158, r1
-  EqualInt     r159, r158, r99
-  Expect       r159
+  Len          r160, r1
+  EqualInt     r161, r160, r84
+  Expect       r161
   Return       r0

--- a/tests/dataset/tpc-ds/out/q4.ir.out
+++ b/tests/dataset/tpc-ds/out/q4.ir.out
@@ -1,4 +1,4 @@
-func main (regs=592)
+func main (regs=607)
   // let customer = []
   Const        r0, []
   // from c in customer
@@ -35,14 +35,16 @@ func main (regs=592)
   Const        r23, "sale_type"
   // from c in customer
   MakeMap      r24, 0, r0
-  Const        r25, []
+  Const        r26, []
+  Move         r25, r26
   IterPrep     r27, r0
   Len          r28, r27
   Const        r29, 0
 L7:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L0
-  Index        r32, r27, r29
+  Index        r31, r27, r29
+  Move         r32, r31
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
   IterPrep     r33, r0
   Len          r34, r33
@@ -50,7 +52,8 @@ L7:
 L6:
   LessInt      r36, r35, r34
   JumpIfFalse  r36, L1
-  Index        r38, r33, r35
+  Index        r37, r33, r35
+  Move         r38, r37
   Const        r39, "c_customer_sk"
   Index        r40, r32, r39
   Const        r41, "ss_customer_sk"
@@ -64,7 +67,8 @@ L6:
 L5:
   LessInt      r47, r46, r45
   JumpIfFalse  r47, L2
-  Index        r49, r44, r46
+  Index        r48, r44, r46
+  Move         r49, r48
   Const        r50, "ss_sold_date_sk"
   Index        r51, r38, r50
   Const        r52, "d_date_sk"
@@ -78,324 +82,335 @@ L5:
   Move         r58, r38
   Const        r59, "d"
   Move         r60, r49
-  MakeMap      r61, 3, r55
+  Move         r61, r55
+  Move         r62, r56
+  Move         r63, r57
+  Move         r64, r58
+  Move         r65, r59
+  Move         r66, r60
+  MakeMap      r67, 3, r61
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r62, "id"
-  Index        r63, r32, r3
-  Const        r64, "first"
-  Index        r65, r32, r5
-  Const        r66, "last"
-  Index        r67, r32, r7
-  Const        r68, "login"
-  Index        r69, r32, r9
-  Const        r70, "year"
-  Index        r71, r49, r11
-  Move         r72, r62
-  Move         r73, r63
-  Move         r74, r64
-  Move         r75, r65
-  Move         r76, r66
-  Move         r77, r67
+  Const        r68, "id"
+  Index        r69, r32, r3
+  Const        r70, "first"
+  Index        r71, r32, r5
+  Const        r72, "last"
+  Index        r73, r32, r7
+  Const        r74, "login"
+  Index        r75, r32, r9
+  Const        r76, "year"
+  Index        r77, r49, r11
   Move         r78, r68
   Move         r79, r69
   Move         r80, r70
   Move         r81, r71
-  MakeMap      r82, 5, r72
-  Str          r83, r82
-  In           r84, r83, r24
-  JumpIfTrue   r84, L4
+  Move         r82, r72
+  Move         r83, r73
+  Move         r84, r74
+  Move         r85, r75
+  Move         r86, r76
+  Move         r87, r77
+  MakeMap      r88, 5, r78
+  Str          r89, r88
+  In           r90, r89, r24
+  JumpIfTrue   r90, L4
   // from c in customer
-  Const        r85, []
-  Const        r86, "__group__"
-  Const        r87, true
-  Const        r88, "key"
+  Const        r91, "__group__"
+  Const        r92, true
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r89, r82
+  Move         r93, r88
   // from c in customer
-  Const        r90, "items"
-  Move         r91, r85
-  Const        r92, "count"
-  Const        r93, 0
-  Move         r94, r86
-  Move         r95, r87
-  Move         r96, r88
-  Move         r97, r89
-  Move         r98, r90
-  Move         r99, r91
-  Move         r100, r92
+  Const        r94, "items"
+  Move         r95, r0
+  Const        r96, "count"
+  Const        r97, 0
+  Move         r98, r91
+  Move         r99, r92
+  Move         r100, r13
   Move         r101, r93
-  MakeMap      r102, 4, r94
-  SetIndex     r24, r83, r102
-  Append       r25, r25, r102
+  Move         r102, r94
+  Move         r103, r95
+  Move         r104, r96
+  Move         r105, r97
+  MakeMap      r106, 4, r98
+  SetIndex     r24, r89, r106
+  Append       r107, r25, r106
+  Move         r25, r107
 L4:
-  Const        r104, "items"
-  Index        r105, r24, r83
-  Index        r106, r105, r104
-  Append       r107, r106, r61
-  SetIndex     r105, r104, r107
-  Const        r108, "count"
-  Index        r109, r105, r108
-  Const        r110, 1
-  AddInt       r111, r109, r110
-  SetIndex     r105, r108, r111
+  Index        r108, r24, r89
+  Index        r109, r108, r94
+  Append       r110, r109, r67
+  SetIndex     r108, r94, r110
+  Index        r111, r108, r96
+  Const        r112, 1
+  AddInt       r113, r111, r112
+  SetIndex     r108, r96, r113
 L3:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  AddInt       r46, r46, r110
+  AddInt       r46, r46, r112
   Jump         L5
 L2:
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  AddInt       r35, r35, r110
+  AddInt       r35, r35, r112
   Jump         L6
 L1:
   // from c in customer
-  AddInt       r29, r29, r110
+  AddInt       r29, r29, r112
   Jump         L7
 L0:
-  Const        r113, 0
-  Move         r112, r113
-  Len          r114, r25
+  Move         r114, r97
+  Len          r115, r25
 L11:
-  LessInt      r115, r112, r114
-  JumpIfFalse  r115, L8
-  Index        r117, r25, r112
+  LessInt      r116, r114, r115
+  JumpIfFalse  r116, L8
+  Index        r117, r25, r114
+  Move         r118, r117
   // customer_id: g.key.id,
-  Const        r118, "customer_id"
-  Index        r119, r117, r13
-  Index        r120, r119, r2
+  Const        r119, "customer_id"
+  Index        r120, r118, r13
+  Index        r121, r120, r2
   // customer_first_name: g.key.first,
-  Const        r121, "customer_first_name"
-  Index        r122, r117, r13
-  Index        r123, r122, r4
+  Const        r122, "customer_first_name"
+  Index        r123, r118, r13
+  Index        r124, r123, r4
   // customer_last_name: g.key.last,
-  Const        r124, "customer_last_name"
-  Index        r125, r117, r13
-  Index        r126, r125, r6
+  Const        r125, "customer_last_name"
+  Index        r126, r118, r13
+  Index        r127, r126, r6
   // customer_login: g.key.login,
-  Const        r127, "customer_login"
-  Index        r128, r117, r13
-  Index        r129, r128, r8
+  Const        r128, "customer_login"
+  Index        r129, r118, r13
+  Index        r130, r129, r8
   // dyear: g.key.year,
-  Const        r130, "dyear"
-  Index        r131, r117, r13
-  Index        r132, r131, r10
+  Const        r131, "dyear"
+  Index        r132, r118, r13
+  Index        r133, r132, r10
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Const        r133, "year_total"
-  Const        r134, []
-  IterPrep     r135, r117
-  Len          r136, r135
-  Move         r137, r113
+  Const        r134, "year_total"
+  Const        r135, []
+  IterPrep     r136, r118
+  Len          r137, r136
+  Move         r138, r97
 L10:
-  LessInt      r138, r137, r136
-  JumpIfFalse  r138, L9
-  Index        r140, r135, r137
-  Index        r141, r140, r19
-  Index        r142, r140, r20
-  Sub          r143, r141, r142
-  Index        r144, r140, r21
-  Sub          r145, r143, r144
-  Index        r146, r140, r22
-  Add          r147, r145, r146
-  Const        r148, 2
-  Div          r149, r147, r148
-  Append       r134, r134, r149
-  AddInt       r137, r137, r110
+  LessInt      r139, r138, r137
+  JumpIfFalse  r139, L9
+  Index        r140, r136, r138
+  Move         r141, r140
+  Index        r142, r141, r19
+  Index        r143, r141, r20
+  Sub          r144, r142, r143
+  Index        r145, r141, r21
+  Sub          r146, r144, r145
+  Index        r147, r141, r22
+  Add          r148, r146, r147
+  Const        r149, 2
+  Div          r150, r148, r149
+  Append       r151, r135, r150
+  Move         r135, r151
+  AddInt       r138, r138, r112
   Jump         L10
 L9:
-  Sum          r151, r134
+  Sum          r152, r135
   // sale_type: "s",
-  Const        r152, "sale_type"
+  Const        r153, "sale_type"
   // customer_id: g.key.id,
-  Move         r153, r118
-  Move         r154, r120
-  // customer_first_name: g.key.first,
+  Move         r154, r119
   Move         r155, r121
-  Move         r156, r123
-  // customer_last_name: g.key.last,
+  // customer_first_name: g.key.first,
+  Move         r156, r122
   Move         r157, r124
-  Move         r158, r126
-  // customer_login: g.key.login,
+  // customer_last_name: g.key.last,
+  Move         r158, r125
   Move         r159, r127
-  Move         r160, r129
-  // dyear: g.key.year,
+  // customer_login: g.key.login,
+  Move         r160, r128
   Move         r161, r130
-  Move         r162, r132
-  // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
+  // dyear: g.key.year,
+  Move         r162, r131
   Move         r163, r133
-  Move         r164, r151
-  // sale_type: "s",
+  // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
+  Move         r164, r134
   Move         r165, r152
-  Move         r166, r57
+  // sale_type: "s",
+  Move         r166, r153
+  Move         r167, r57
   // select {
-  MakeMap      r167, 7, r153
+  MakeMap      r168, 7, r154
   // from c in customer
-  Append       r1, r1, r167
-  AddInt       r112, r112, r110
+  Append       r169, r1, r168
+  Move         r1, r169
+  AddInt       r114, r114, r112
   Jump         L11
 L8:
   // from c in customer
-  Const        r169, []
+  Const        r170, []
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Const        r170, "cs_ext_list_price"
-  Const        r171, "cs_ext_wholesale_cost"
-  Const        r172, "cs_ext_discount_amt"
-  Const        r173, "cs_ext_sales_price"
+  Const        r171, "cs_ext_list_price"
+  Const        r172, "cs_ext_wholesale_cost"
+  Const        r173, "cs_ext_discount_amt"
+  Const        r174, "cs_ext_sales_price"
   // from c in customer
-  MakeMap      r174, 0, r0
-  Const        r175, []
-  IterPrep     r177, r0
-  Len          r178, r177
-  Const        r179, 0
+  MakeMap      r175, 0, r0
+  Const        r177, []
+  Move         r176, r177
+  IterPrep     r178, r0
+  Len          r179, r178
+  Const        r180, 0
 L19:
-  LessInt      r180, r179, r178
-  JumpIfFalse  r180, L12
-  Index        r32, r177, r179
+  LessInt      r181, r180, r179
+  JumpIfFalse  r181, L12
+  Index        r182, r178, r180
+  Move         r32, r182
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  IterPrep     r182, r0
-  Len          r183, r182
-  Const        r184, 0
+  IterPrep     r183, r0
+  Len          r184, r183
+  Const        r185, 0
 L18:
-  LessInt      r185, r184, r183
-  JumpIfFalse  r185, L13
-  Index        r187, r182, r184
-  Index        r188, r32, r39
-  Const        r189, "cs_bill_customer_sk"
-  Index        r190, r187, r189
-  Equal        r191, r188, r190
-  JumpIfFalse  r191, L14
+  LessInt      r186, r185, r184
+  JumpIfFalse  r186, L13
+  Index        r187, r183, r185
+  Move         r188, r187
+  Index        r189, r32, r39
+  Const        r190, "cs_bill_customer_sk"
+  Index        r191, r188, r190
+  Equal        r192, r189, r191
+  JumpIfFalse  r192, L14
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r192, r0
-  Len          r193, r192
-  Const        r194, 0
+  IterPrep     r193, r0
+  Len          r194, r193
+  Const        r195, 0
 L17:
-  LessInt      r195, r194, r193
-  JumpIfFalse  r195, L14
-  Index        r197, r192, r194
-  Const        r198, "cs_sold_date_sk"
-  Index        r199, r187, r198
-  Index        r200, r197, r52
-  Equal        r201, r199, r200
-  JumpIfFalse  r201, L15
+  LessInt      r196, r195, r194
+  JumpIfFalse  r196, L14
+  Index        r197, r193, r195
+  Move         r198, r197
+  Const        r199, "cs_sold_date_sk"
+  Index        r200, r188, r199
+  Index        r201, r198, r52
+  Equal        r202, r200, r201
+  JumpIfFalse  r202, L15
   // from c in customer
-  Move         r202, r32
-  Const        r203, "cs"
-  Move         r204, r187
-  Move         r205, r197
-  MakeMap      r206, 3, r55
+  Move         r203, r32
+  Const        r204, "cs"
+  Move         r205, r188
+  Move         r206, r198
+  Move         r207, r55
+  Move         r208, r203
+  Move         r209, r204
+  Move         r210, r205
+  Move         r211, r59
+  Move         r212, r206
+  MakeMap      r213, 3, r207
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r207, "id"
-  Index        r208, r32, r3
-  Const        r209, "first"
-  Index        r210, r32, r5
-  Const        r211, "last"
-  Index        r212, r32, r7
-  Const        r213, "login"
-  Index        r214, r32, r9
-  Const        r215, "year"
-  Index        r216, r197, r11
-  Move         r217, r207
-  Move         r218, r208
-  Move         r219, r209
-  Move         r220, r210
-  Move         r221, r211
-  Move         r222, r212
-  Move         r223, r213
+  Const        r214, "id"
+  Index        r215, r32, r3
+  Const        r216, "first"
+  Index        r217, r32, r5
+  Const        r218, "last"
+  Index        r219, r32, r7
+  Const        r220, "login"
+  Index        r221, r32, r9
+  Const        r222, "year"
+  Index        r223, r198, r11
   Move         r224, r214
   Move         r225, r215
   Move         r226, r216
-  MakeMap      r227, 5, r217
-  Str          r228, r227
-  In           r229, r228, r174
-  JumpIfTrue   r229, L16
+  Move         r227, r217
+  Move         r228, r218
+  Move         r229, r219
+  Move         r230, r220
+  Move         r231, r221
+  Move         r232, r222
+  Move         r233, r223
+  MakeMap      r234, 5, r224
+  Str          r235, r234
+  In           r236, r235, r175
+  JumpIfTrue   r236, L16
+  Move         r237, r234
   // from c in customer
-  Const        r230, []
-  Const        r231, "__group__"
-  Const        r232, true
-  Const        r233, "key"
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r234, r227
-  // from c in customer
-  Const        r235, "items"
-  Move         r236, r230
-  Const        r237, "count"
-  Const        r238, 0
-  Move         r239, r231
-  Move         r240, r232
-  Move         r241, r233
-  Move         r242, r234
-  Move         r243, r235
-  Move         r244, r236
-  Move         r245, r237
-  Move         r246, r238
+  Move         r238, r0
+  Move         r239, r91
+  Move         r240, r92
+  Move         r241, r13
+  Move         r242, r237
+  Move         r243, r94
+  Move         r244, r238
+  Move         r245, r96
+  Move         r246, r97
   MakeMap      r247, 4, r239
-  SetIndex     r174, r228, r247
-  Append       r175, r175, r247
+  SetIndex     r175, r235, r247
+  Append       r248, r176, r247
+  Move         r176, r248
 L16:
-  Index        r249, r174, r228
-  Index        r250, r249, r104
-  Append       r251, r250, r206
-  SetIndex     r249, r104, r251
-  Index        r252, r249, r108
-  AddInt       r253, r252, r110
-  SetIndex     r249, r108, r253
+  Index        r249, r175, r235
+  Index        r250, r249, r94
+  Append       r251, r250, r213
+  SetIndex     r249, r94, r251
+  Index        r252, r249, r96
+  AddInt       r253, r252, r112
+  SetIndex     r249, r96, r253
 L15:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r194, r194, r110
+  AddInt       r195, r195, r112
   Jump         L17
 L14:
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  AddInt       r184, r184, r110
+  AddInt       r185, r185, r112
   Jump         L18
 L13:
   // from c in customer
-  AddInt       r179, r179, r110
+  AddInt       r180, r180, r112
   Jump         L19
 L12:
-  Move         r254, r113
-  Len          r255, r175
+  Move         r254, r97
+  Len          r255, r176
 L23:
   LessInt      r256, r254, r255
   JumpIfFalse  r256, L20
-  Index        r117, r175, r254
+  Index        r257, r176, r254
+  Move         r118, r257
   // customer_id: g.key.id,
   Const        r258, "customer_id"
-  Index        r259, r117, r13
+  Index        r259, r118, r13
   Index        r260, r259, r2
   // customer_first_name: g.key.first,
   Const        r261, "customer_first_name"
-  Index        r262, r117, r13
+  Index        r262, r118, r13
   Index        r263, r262, r4
   // customer_last_name: g.key.last,
   Const        r264, "customer_last_name"
-  Index        r265, r117, r13
+  Index        r265, r118, r13
   Index        r266, r265, r6
   // customer_login: g.key.login,
   Const        r267, "customer_login"
-  Index        r268, r117, r13
+  Index        r268, r118, r13
   Index        r269, r268, r8
   // dyear: g.key.year,
   Const        r270, "dyear"
-  Index        r271, r117, r13
+  Index        r271, r118, r13
   Index        r272, r271, r10
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
   Const        r273, "year_total"
   Const        r274, []
-  IterPrep     r275, r117
+  IterPrep     r275, r118
   Len          r276, r275
-  Move         r277, r113
+  Move         r277, r97
 L22:
   LessInt      r278, r277, r276
   JumpIfFalse  r278, L21
-  Index        r140, r275, r277
-  Index        r280, r140, r170
-  Index        r281, r140, r171
+  Index        r279, r275, r277
+  Move         r141, r279
+  Index        r280, r141, r171
+  Index        r281, r141, r172
   Sub          r282, r280, r281
-  Index        r283, r140, r172
+  Index        r283, r141, r173
   Sub          r284, r282, r283
-  Index        r285, r140, r173
+  Index        r285, r141, r174
   Add          r286, r284, r285
-  Div          r287, r286, r148
-  Append       r274, r274, r287
-  AddInt       r277, r277, r110
+  Div          r287, r286, r149
+  Append       r288, r274, r287
+  Move         r274, r288
+  AddInt       r277, r277, r112
   Jump         L22
 L21:
   Sum          r289, r274
@@ -425,12 +440,13 @@ L21:
   // select {
   MakeMap      r305, 7, r291
   // from c in customer
-  Append       r169, r169, r305
-  AddInt       r254, r254, r110
+  Append       r306, r170, r305
+  Move         r170, r306
+  AddInt       r254, r254, r112
   Jump         L23
 L20:
   // ) union all (
-  UnionAll     r307, r1, r169
+  UnionAll     r307, r1, r170
   // from c in customer
   Const        r308, []
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
@@ -440,14 +456,16 @@ L20:
   Const        r312, "ws_ext_sales_price"
   // from c in customer
   MakeMap      r313, 0, r0
-  Const        r314, []
+  Const        r315, []
+  Move         r314, r315
   IterPrep     r316, r0
   Len          r317, r316
   Const        r318, 0
 L31:
   LessInt      r319, r318, r317
   JumpIfFalse  r319, L24
-  Index        r32, r316, r318
+  Index        r320, r316, r318
+  Move         r32, r320
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
   IterPrep     r321, r0
   Len          r322, r321
@@ -455,7 +473,8 @@ L31:
 L30:
   LessInt      r324, r323, r322
   JumpIfFalse  r324, L25
-  Index        r326, r321, r323
+  Index        r325, r321, r323
+  Move         r326, r325
   Index        r327, r32, r39
   Const        r328, "ws_bill_customer_sk"
   Index        r329, r326, r328
@@ -468,7 +487,8 @@ L30:
 L29:
   LessInt      r334, r333, r332
   JumpIfFalse  r334, L26
-  Index        r336, r331, r333
+  Index        r335, r331, r333
+  Move         r336, r335
   Const        r337, "ws_sold_date_sk"
   Index        r338, r326, r337
   Index        r339, r336, r52
@@ -479,410 +499,455 @@ L29:
   Const        r342, "ws"
   Move         r343, r326
   Move         r344, r336
-  MakeMap      r345, 3, r55
+  Move         r345, r55
+  Move         r346, r341
+  Move         r347, r342
+  Move         r348, r343
+  Move         r349, r59
+  Move         r350, r344
+  MakeMap      r351, 3, r345
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r346, "id"
-  Index        r347, r32, r3
-  Const        r348, "first"
-  Index        r349, r32, r5
-  Const        r350, "last"
-  Index        r351, r32, r7
-  Const        r352, "login"
-  Index        r353, r32, r9
-  Const        r354, "year"
-  Index        r355, r336, r11
-  Move         r356, r346
-  Move         r357, r347
-  Move         r358, r348
-  Move         r359, r349
-  Move         r360, r350
-  Move         r361, r351
+  Const        r352, "id"
+  Index        r353, r32, r3
+  Const        r354, "first"
+  Index        r355, r32, r5
+  Const        r356, "last"
+  Index        r357, r32, r7
+  Const        r358, "login"
+  Index        r359, r32, r9
+  Const        r360, "year"
+  Index        r361, r336, r11
   Move         r362, r352
   Move         r363, r353
   Move         r364, r354
   Move         r365, r355
-  MakeMap      r366, 5, r356
-  Str          r367, r366
-  In           r368, r367, r313
-  JumpIfTrue   r368, L28
+  Move         r366, r356
+  Move         r367, r357
+  Move         r368, r358
+  Move         r369, r359
+  Move         r370, r360
+  Move         r371, r361
+  MakeMap      r372, 5, r362
+  Str          r373, r372
+  In           r374, r373, r313
+  JumpIfTrue   r374, L28
+  Move         r375, r372
   // from c in customer
-  Const        r369, []
-  Const        r370, "__group__"
-  Const        r371, true
-  Const        r372, "key"
-  // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r373, r366
-  // from c in customer
-  Const        r374, "items"
-  Move         r375, r369
-  Const        r376, "count"
-  Const        r377, 0
-  Move         r378, r370
-  Move         r379, r371
-  Move         r380, r372
-  Move         r381, r373
-  Move         r382, r374
-  Move         r383, r375
-  Move         r384, r376
-  Move         r385, r377
-  MakeMap      r386, 4, r378
-  SetIndex     r313, r367, r386
-  Append       r314, r314, r386
+  Move         r376, r0
+  Move         r377, r91
+  Move         r378, r92
+  Move         r379, r13
+  Move         r380, r375
+  Move         r381, r94
+  Move         r382, r376
+  Move         r383, r96
+  Move         r384, r97
+  MakeMap      r385, 4, r377
+  SetIndex     r313, r373, r385
+  Append       r386, r314, r385
+  Move         r314, r386
 L28:
-  Index        r388, r313, r367
-  Index        r389, r388, r104
-  Append       r390, r389, r345
-  SetIndex     r388, r104, r390
-  Index        r391, r388, r108
-  AddInt       r392, r391, r110
-  SetIndex     r388, r108, r392
+  Index        r387, r313, r373
+  Index        r388, r387, r94
+  Append       r389, r388, r351
+  SetIndex     r387, r94, r389
+  Index        r390, r387, r96
+  AddInt       r391, r390, r112
+  SetIndex     r387, r96, r391
 L27:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  AddInt       r333, r333, r110
+  AddInt       r333, r333, r112
   Jump         L29
 L26:
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  AddInt       r323, r323, r110
+  AddInt       r323, r323, r112
   Jump         L30
 L25:
   // from c in customer
-  AddInt       r318, r318, r110
+  AddInt       r318, r318, r112
   Jump         L31
 L24:
-  Move         r393, r113
-  Len          r394, r314
+  Move         r392, r97
+  Len          r393, r314
 L35:
-  LessInt      r395, r393, r394
-  JumpIfFalse  r395, L32
-  Index        r117, r314, r393
+  LessInt      r394, r392, r393
+  JumpIfFalse  r394, L32
+  Index        r395, r314, r392
+  Move         r118, r395
   // customer_id: g.key.id,
-  Const        r397, "customer_id"
-  Index        r398, r117, r13
-  Index        r399, r398, r2
+  Const        r396, "customer_id"
+  Index        r397, r118, r13
+  Index        r398, r397, r2
   // customer_first_name: g.key.first,
-  Const        r400, "customer_first_name"
-  Index        r401, r117, r13
-  Index        r402, r401, r4
+  Const        r399, "customer_first_name"
+  Index        r400, r118, r13
+  Index        r401, r400, r4
   // customer_last_name: g.key.last,
-  Const        r403, "customer_last_name"
-  Index        r404, r117, r13
-  Index        r405, r404, r6
+  Const        r402, "customer_last_name"
+  Index        r403, r118, r13
+  Index        r404, r403, r6
   // customer_login: g.key.login,
-  Const        r406, "customer_login"
-  Index        r407, r117, r13
-  Index        r408, r407, r8
+  Const        r405, "customer_login"
+  Index        r406, r118, r13
+  Index        r407, r406, r8
   // dyear: g.key.year,
-  Const        r409, "dyear"
-  Index        r410, r117, r13
-  Index        r411, r410, r10
+  Const        r408, "dyear"
+  Index        r409, r118, r13
+  Index        r410, r409, r10
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Const        r412, "year_total"
-  Const        r413, []
-  IterPrep     r414, r117
-  Len          r415, r414
-  Move         r416, r113
+  Const        r411, "year_total"
+  Const        r412, []
+  IterPrep     r413, r118
+  Len          r414, r413
+  Move         r415, r97
 L34:
-  LessInt      r417, r416, r415
-  JumpIfFalse  r417, L33
-  Index        r140, r414, r416
-  Index        r419, r140, r309
-  Index        r420, r140, r310
-  Sub          r421, r419, r420
-  Index        r422, r140, r311
-  Sub          r423, r421, r422
-  Index        r424, r140, r312
-  Add          r425, r423, r424
-  Div          r426, r425, r148
-  Append       r413, r413, r426
-  AddInt       r416, r416, r110
+  LessInt      r416, r415, r414
+  JumpIfFalse  r416, L33
+  Index        r417, r413, r415
+  Move         r141, r417
+  Index        r418, r141, r309
+  Index        r419, r141, r310
+  Sub          r420, r418, r419
+  Index        r421, r141, r311
+  Sub          r422, r420, r421
+  Index        r423, r141, r312
+  Add          r424, r422, r423
+  Div          r425, r424, r149
+  Append       r426, r412, r425
+  Move         r412, r426
+  AddInt       r415, r415, r112
   Jump         L34
 L33:
-  Sum          r428, r413
+  Sum          r427, r412
   // sale_type: "w",
-  Const        r429, "sale_type"
-  Const        r430, "w"
+  Const        r428, "sale_type"
+  Const        r429, "w"
   // customer_id: g.key.id,
-  Move         r431, r397
-  Move         r432, r399
+  Move         r430, r396
+  Move         r431, r398
   // customer_first_name: g.key.first,
-  Move         r433, r400
-  Move         r434, r402
+  Move         r432, r399
+  Move         r433, r401
   // customer_last_name: g.key.last,
-  Move         r435, r403
-  Move         r436, r405
+  Move         r434, r402
+  Move         r435, r404
   // customer_login: g.key.login,
-  Move         r437, r406
-  Move         r438, r408
+  Move         r436, r405
+  Move         r437, r407
   // dyear: g.key.year,
-  Move         r439, r409
-  Move         r440, r411
+  Move         r438, r408
+  Move         r439, r410
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Move         r441, r412
-  Move         r442, r428
+  Move         r440, r411
+  Move         r441, r427
   // sale_type: "w",
+  Move         r442, r428
   Move         r443, r429
-  Move         r444, r430
   // select {
-  MakeMap      r445, 7, r431
+  MakeMap      r444, 7, r430
   // from c in customer
-  Append       r308, r308, r445
-  AddInt       r393, r393, r110
+  Append       r445, r308, r444
+  Move         r308, r445
+  AddInt       r392, r392, r112
   Jump         L35
 L32:
   // ) union all (
-  UnionAll     r447, r307, r308
+  UnionAll     r446, r307, r308
   // from s1 in year_total
-  Const        r448, []
-  IterPrep     r449, r447
-  Len          r450, r449
-  Move         r451, r113
-L49:
-  LessInt      r452, r451, r450
-  JumpIfFalse  r452, L36
-  Index        r454, r449, r451
+  Const        r447, []
+  IterPrep     r448, r446
+  Len          r449, r448
+  Move         r450, r97
+L64:
+  LessInt      r451, r450, r449
+  JumpIfFalse  r451, L36
+  Index        r452, r448, r450
+  Move         r453, r452
   // join s2 in year_total on s2.customer_id == s1.customer_id
-  IterPrep     r455, r447
-  Len          r456, r455
-  Move         r457, r113
-L48:
-  LessInt      r458, r457, r456
-  JumpIfFalse  r458, L37
-  Index        r460, r455, r457
-  Index        r461, r460, r12
-  Index        r462, r454, r12
-  Equal        r463, r461, r462
-  JumpIfFalse  r463, L38
+  IterPrep     r454, r446
+  Len          r455, r454
+  Move         r456, r97
+L63:
+  LessInt      r457, r456, r455
+  JumpIfFalse  r457, L37
+  Index        r458, r454, r456
+  Move         r459, r458
+  Index        r460, r459, r12
+  Index        r461, r453, r12
+  Equal        r462, r460, r461
+  JumpIfFalse  r462, L38
   // join c1 in year_total on c1.customer_id == s1.customer_id
-  IterPrep     r464, r447
-  Len          r465, r464
-  Move         r466, r113
-L47:
-  LessInt      r467, r466, r465
-  JumpIfFalse  r467, L38
-  Index        r469, r464, r466
-  Index        r470, r469, r12
-  Index        r471, r454, r12
-  Equal        r472, r470, r471
-  JumpIfFalse  r472, L39
+  IterPrep     r463, r446
+  Len          r464, r463
+  Move         r465, r97
+L62:
+  LessInt      r466, r465, r464
+  JumpIfFalse  r466, L38
+  Index        r467, r463, r465
+  Move         r468, r467
+  Index        r469, r468, r12
+  Index        r470, r453, r12
+  Equal        r471, r469, r470
+  JumpIfFalse  r471, L39
   // join c2 in year_total on c2.customer_id == s1.customer_id
-  IterPrep     r473, r447
-  Len          r474, r473
-  Move         r475, r113
-L46:
-  LessInt      r476, r475, r474
-  JumpIfFalse  r476, L39
-  Index        r478, r473, r475
-  Index        r479, r478, r12
-  Index        r480, r454, r12
-  Equal        r481, r479, r480
-  JumpIfFalse  r481, L40
+  IterPrep     r472, r446
+  Len          r473, r472
+  Move         r474, r97
+L61:
+  LessInt      r475, r474, r473
+  JumpIfFalse  r475, L39
+  Index        r476, r472, r474
+  Move         r477, r476
+  Index        r478, r477, r12
+  Index        r479, r453, r12
+  Equal        r480, r478, r479
+  JumpIfFalse  r480, L40
   // join w1 in year_total on w1.customer_id == s1.customer_id
-  IterPrep     r482, r447
-  Len          r483, r482
-  Move         r484, r113
-L45:
-  LessInt      r485, r484, r483
-  JumpIfFalse  r485, L40
-  Index        r487, r482, r484
-  Index        r488, r487, r12
-  Index        r489, r454, r12
-  Equal        r490, r488, r489
-  JumpIfFalse  r490, L41
+  IterPrep     r481, r446
+  Len          r482, r481
+  Move         r483, r97
+L60:
+  LessInt      r484, r483, r482
+  JumpIfFalse  r484, L40
+  Index        r485, r481, r483
+  Move         r486, r485
+  Index        r487, r486, r12
+  Index        r488, r453, r12
+  Equal        r489, r487, r488
+  JumpIfFalse  r489, L41
   // join w2 in year_total on w2.customer_id == s1.customer_id
-  IterPrep     r491, r447
-  Len          r492, r491
-  Move         r493, r113
-L44:
-  LessInt      r494, r493, r492
-  JumpIfFalse  r494, L41
-  Index        r496, r491, r493
-  Index        r497, r496, r12
-  Index        r498, r454, r12
-  Equal        r499, r497, r498
-  JumpIfFalse  r499, L42
+  IterPrep     r490, r446
+  Len          r491, r490
+  Move         r492, r97
+L59:
+  LessInt      r493, r492, r491
+  JumpIfFalse  r493, L41
+  Index        r494, r490, r492
+  Move         r495, r494
+  Index        r496, r495, r12
+  Index        r497, r453, r12
+  Equal        r498, r496, r497
+  JumpIfFalse  r498, L42
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Index        r500, r454, r23
+  Index        r499, r453, r23
   // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Index        r501, r454, r18
-  Less         r502, r113, r501
-  Index        r503, r469, r18
-  Less         r504, r113, r503
-  Index        r505, r487, r18
-  Less         r506, r113, r505
+  Index        r500, r453, r18
+  Less         r501, r97, r500
+  Index        r502, r468, r18
+  Less         r503, r97, r502
+  Index        r504, r486, r18
+  Less         r505, r97, r504
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Index        r507, r469, r18
-  Less         r508, r113, r507
-  Index        r509, r478, r18
-  Index        r510, r469, r18
-  Div          r511, r509, r510
-  Const        r512, nil
-  Select       513,508,511,512
+  Index        r506, r468, r18
+  Less         r507, r97, r506
+  Index        r508, r477, r18
+  Index        r509, r468, r18
+  Div          r510, r508, r509
+  Const        r511, nil
+  Select       512,507,510,511
   // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Index        r514, r454, r18
-  Less         r515, r113, r514
-  Index        r516, r460, r18
-  Index        r517, r454, r18
-  Div          r518, r516, r517
-  Select       519,515,518,512
+  Index        r513, r453, r18
+  Less         r514, r97, r513
+  Index        r515, r459, r18
+  Index        r516, r453, r18
+  Div          r517, r515, r516
+  Select       518,514,517,511
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r520, r519, r513
+  Less         r519, r518, r512
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Index        r521, r469, r18
-  Less         r522, r113, r521
-  Index        r523, r478, r18
-  Index        r524, r469, r18
-  Div          r525, r523, r524
-  Select       526,522,525,512
+  Index        r520, r468, r18
+  Less         r521, r97, r520
+  Index        r522, r477, r18
+  Index        r523, r468, r18
+  Div          r524, r522, r523
+  Select       525,521,524,511
   // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Index        r527, r487, r18
-  Less         r528, r113, r527
-  Index        r529, r496, r18
-  Index        r530, r487, r18
-  Div          r531, r529, r530
-  Select       532,528,531,512
+  Index        r526, r486, r18
+  Less         r527, r97, r526
+  Index        r528, r495, r18
+  Index        r529, r486, r18
+  Div          r530, r528, r529
+  Select       531,527,530,511
   // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r533, r532, r526
+  Less         r532, r531, r525
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Equal        r534, r500, r57
-  Index        r535, r469, r23
-  Equal        r536, r535, r55
-  Index        r537, r487, r23
-  Equal        r538, r537, r430
+  Equal        r533, r499, r57
+  Index        r534, r468, r23
+  Equal        r535, r534, r55
+  Index        r536, r486, r23
+  Equal        r537, r536, r429
   // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Index        r539, r460, r23
-  Equal        r540, r539, r57
-  Index        r541, r478, r23
-  Equal        r542, r541, r55
-  Index        r543, r496, r23
-  Equal        r544, r543, r430
+  Index        r538, r459, r23
+  Equal        r539, r538, r57
+  Index        r540, r477, r23
+  Equal        r541, r540, r55
+  Index        r542, r495, r23
+  Equal        r543, r542, r429
   // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Index        r545, r454, r17
-  Const        r546, 2001
-  Equal        r547, r545, r546
-  Index        r548, r460, r17
-  Const        r549, 2002
-  Equal        r550, r548, r549
+  Index        r544, r453, r17
+  Const        r545, 2001
+  Equal        r546, r544, r545
+  Index        r547, r459, r17
+  Const        r548, 2002
+  Equal        r549, r547, r548
   // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Index        r551, r469, r17
-  Equal        r552, r551, r546
-  Index        r553, r478, r17
-  Equal        r554, r553, r549
+  Index        r550, r468, r17
+  Equal        r551, r550, r545
+  Index        r552, r477, r17
+  Equal        r553, r552, r548
   // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Index        r555, r487, r17
-  Equal        r556, r555, r546
-  Index        r557, r496, r17
-  Equal        r558, r557, r549
+  Index        r554, r486, r17
+  Equal        r555, r554, r545
+  Index        r556, r495, r17
+  Equal        r557, r556, r548
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  JumpIfFalse  r534, L43
-  Move         r534, r536
-  JumpIfFalse  r534, L43
-  Move         r534, r538
-  JumpIfFalse  r534, L43
-  Move         r534, r540
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  JumpIfFalse  r534, L43
-  Move         r534, r542
-  JumpIfFalse  r534, L43
-  Move         r534, r544
-  JumpIfFalse  r534, L43
-  Move         r534, r547
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  JumpIfFalse  r534, L43
-  Move         r534, r550
-  JumpIfFalse  r534, L43
-  Move         r534, r552
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  JumpIfFalse  r534, L43
-  Move         r534, r554
-  JumpIfFalse  r534, L43
-  Move         r534, r556
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  JumpIfFalse  r534, L43
-  Move         r534, r558
-  JumpIfFalse  r534, L43
-  Move         r534, r502
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  JumpIfFalse  r534, L43
-  Move         r534, r504
-  JumpIfFalse  r534, L43
-  Move         r534, r506
-  JumpIfFalse  r534, L43
-  Move         r534, r520
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  JumpIfFalse  r534, L43
-  Move         r534, r533
+  Move         r558, r533
+  JumpIfFalse  r558, L43
+  Move         r558, r535
 L43:
+  Move         r559, r558
+  JumpIfFalse  r559, L44
+  Move         r559, r537
+L44:
+  Move         r560, r559
+  JumpIfFalse  r560, L45
+  Move         r560, r539
+L45:
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Move         r561, r560
+  JumpIfFalse  r561, L46
+  Move         r561, r541
+L46:
+  Move         r562, r561
+  JumpIfFalse  r562, L47
+  Move         r562, r543
+L47:
+  Move         r563, r562
+  JumpIfFalse  r563, L48
+  Move         r563, r546
+L48:
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Move         r564, r563
+  JumpIfFalse  r564, L49
+  Move         r564, r549
+L49:
+  Move         r565, r564
+  JumpIfFalse  r565, L50
+  Move         r565, r551
+L50:
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Move         r566, r565
+  JumpIfFalse  r566, L51
+  Move         r566, r553
+L51:
+  Move         r567, r566
+  JumpIfFalse  r567, L52
+  Move         r567, r555
+L52:
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Move         r568, r567
+  JumpIfFalse  r568, L53
+  Move         r568, r557
+L53:
+  Move         r569, r568
+  JumpIfFalse  r569, L54
+  Move         r569, r501
+L54:
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Move         r570, r569
+  JumpIfFalse  r570, L55
+  Move         r570, r503
+L55:
+  Move         r571, r570
+  JumpIfFalse  r571, L56
+  Move         r571, r505
+L56:
+  Move         r572, r571
+  JumpIfFalse  r572, L57
+  Move         r572, r519
+L57:
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Move         r573, r572
+  JumpIfFalse  r573, L58
+  Move         r573, r532
+L58:
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  JumpIfFalse  r534, L42
+  JumpIfFalse  r573, L42
   // customer_id: s2.customer_id,
-  Const        r559, "customer_id"
-  Index        r560, r460, r12
+  Const        r574, "customer_id"
+  Index        r575, r459, r12
   // customer_first_name: s2.customer_first_name,
-  Const        r561, "customer_first_name"
-  Index        r562, r460, r14
+  Const        r576, "customer_first_name"
+  Index        r577, r459, r14
   // customer_last_name: s2.customer_last_name,
-  Const        r563, "customer_last_name"
-  Index        r564, r460, r15
+  Const        r578, "customer_last_name"
+  Index        r579, r459, r15
   // customer_login: s2.customer_login,
-  Const        r565, "customer_login"
-  Index        r566, r460, r16
+  Const        r580, "customer_login"
+  Index        r581, r459, r16
   // customer_id: s2.customer_id,
-  Move         r567, r559
-  Move         r568, r560
+  Move         r582, r574
+  Move         r583, r575
   // customer_first_name: s2.customer_first_name,
-  Move         r569, r561
-  Move         r570, r562
+  Move         r584, r576
+  Move         r585, r577
   // customer_last_name: s2.customer_last_name,
-  Move         r571, r563
-  Move         r572, r564
+  Move         r586, r578
+  Move         r587, r579
   // customer_login: s2.customer_login,
-  Move         r573, r565
-  Move         r574, r566
+  Move         r588, r580
+  Move         r589, r581
   // select {
-  MakeMap      r575, 4, r567
+  MakeMap      r590, 4, r582
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Index        r577, r460, r12
-  Index        r578, r460, r14
-  Move         r579, r578
-  Index        r580, r460, r15
-  Move         r581, r580
-  Index        r583, r460, r16
-  MakeList     r585, 4, r577
+  Index        r591, r459, r12
+  Move         r592, r591
+  Index        r593, r459, r14
+  Move         r594, r593
+  Index        r595, r459, r15
+  Move         r596, r595
+  Index        r597, r459, r16
+  Move         r598, r597
+  MakeList     r599, 4, r592
+  Move         r600, r599
   // from s1 in year_total
-  Move         r586, r575
-  MakeList     r587, 2, r585
-  Append       r448, r448, r587
+  Move         r601, r590
+  MakeList     r602, 2, r600
+  Append       r603, r447, r602
+  Move         r447, r603
 L42:
   // join w2 in year_total on w2.customer_id == s1.customer_id
-  Add          r493, r493, r110
-  Jump         L44
+  Add          r492, r492, r112
+  Jump         L59
 L41:
   // join w1 in year_total on w1.customer_id == s1.customer_id
-  Add          r484, r484, r110
-  Jump         L45
+  Add          r483, r483, r112
+  Jump         L60
 L40:
   // join c2 in year_total on c2.customer_id == s1.customer_id
-  Add          r475, r475, r110
-  Jump         L46
+  Add          r474, r474, r112
+  Jump         L61
 L39:
   // join c1 in year_total on c1.customer_id == s1.customer_id
-  Add          r466, r466, r110
-  Jump         L47
+  Add          r465, r465, r112
+  Jump         L62
 L38:
   // join s2 in year_total on s2.customer_id == s1.customer_id
-  Add          r457, r457, r110
-  Jump         L48
+  Add          r456, r456, r112
+  Jump         L63
 L37:
   // from s1 in year_total
-  AddInt       r451, r451, r110
-  Jump         L49
+  AddInt       r450, r450, r112
+  Jump         L64
 L36:
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Sort         r448, r448
+  Sort         r604, r447
+  // from s1 in year_total
+  Move         r447, r604
   // json(result)
-  JSON         r448
+  JSON         r447
   // expect len(result) == 0
-  Len          r590, r448
-  EqualInt     r591, r590, r113
-  Expect       r591
+  Len          r605, r447
+  EqualInt     r606, r605, r97
+  Expect       r606
   Return       r0

--- a/tests/dataset/tpc-ds/out/q5.ir.out
+++ b/tests/dataset/tpc-ds/out/q5.ir.out
@@ -1,4 +1,4 @@
-func main (regs=865)
+func main (regs=863)
   // let store_sales = []
   Const        r0, []
   // from ss in store_sales
@@ -25,14 +25,16 @@ func main (regs=865)
   Const        r13, "profit_loss"
   // from ss in store_sales
   MakeMap      r14, 0, r0
-  Const        r15, []
+  Const        r16, []
+  Move         r15, r16
   IterPrep     r17, r0
   Len          r18, r17
   Const        r19, 0
 L8:
   LessInt      r20, r19, r18
   JumpIfFalse  r20, L0
-  Index        r22, r17, r19
+  Index        r21, r17, r19
+  Move         r22, r21
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   IterPrep     r23, r0
   Len          r24, r23
@@ -40,7 +42,8 @@ L8:
 L7:
   LessInt      r26, r25, r24
   JumpIfFalse  r26, L1
-  Index        r28, r23, r25
+  Index        r27, r23, r25
+  Move         r28, r27
   Const        r29, "ss_sold_date_sk"
   Index        r30, r22, r29
   Const        r31, "d_date_sk"
@@ -54,7 +57,8 @@ L7:
 L6:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L2
-  Index        r39, r34, r36
+  Index        r38, r34, r36
+  Move         r39, r38
   Const        r40, "ss_store_sk"
   Index        r41, r22, r40
   Const        r42, "s_store_sk"
@@ -68,1284 +72,1343 @@ L6:
   Index        r48, r28, r3
   Const        r49, "1998-12-15"
   LessEq       r50, r48, r49
-  JumpIfFalse  r47, L4
-  Move         r47, r50
+  Move         r51, r47
+  JumpIfFalse  r51, L4
+  Move         r51, r50
 L4:
-  JumpIfFalse  r47, L3
+  JumpIfFalse  r51, L3
   // from ss in store_sales
-  Move         r51, r22
-  Const        r52, "d"
-  Move         r53, r28
-  Const        r54, "s"
-  Move         r55, r39
-  MakeMap      r56, 3, r8
+  Move         r52, r22
+  Const        r53, "d"
+  Move         r54, r28
+  Const        r55, "s"
+  Move         r56, r39
+  Move         r57, r8
+  Move         r58, r52
+  Move         r59, r53
+  Move         r60, r54
+  Move         r61, r55
+  Move         r62, r56
+  MakeMap      r63, 3, r57
   // group by s.s_store_id into g
-  Index        r57, r39, r2
-  Str          r58, r57
-  In           r59, r58, r14
-  JumpIfTrue   r59, L5
+  Index        r64, r39, r2
+  Str          r65, r64
+  In           r66, r65, r14
+  JumpIfTrue   r66, L5
   // from ss in store_sales
-  Const        r60, []
-  Const        r61, "__group__"
-  Const        r62, true
-  Const        r63, "key"
+  Const        r67, "__group__"
+  Const        r68, true
   // group by s.s_store_id into g
-  Move         r64, r57
+  Move         r69, r64
   // from ss in store_sales
-  Const        r65, "items"
-  Move         r66, r60
-  Const        r67, "count"
-  Const        r68, 0
-  Move         r69, r61
-  Move         r70, r62
-  Move         r71, r63
-  Move         r72, r64
-  Move         r73, r65
-  Move         r74, r66
-  Move         r75, r67
-  Move         r76, r68
-  MakeMap      r77, 4, r69
-  SetIndex     r14, r58, r77
-  Append       r15, r15, r77
+  Const        r70, "items"
+  Move         r71, r0
+  Const        r72, "count"
+  Const        r73, 0
+  Move         r74, r67
+  Move         r75, r68
+  Move         r76, r6
+  Move         r77, r69
+  Move         r78, r70
+  Move         r79, r71
+  Move         r80, r72
+  Move         r81, r73
+  MakeMap      r82, 4, r74
+  SetIndex     r14, r65, r82
+  Append       r83, r15, r82
+  Move         r15, r83
 L5:
-  Const        r79, "items"
-  Index        r80, r14, r58
-  Index        r81, r80, r79
-  Append       r82, r81, r56
-  SetIndex     r80, r79, r82
-  Const        r83, "count"
-  Index        r84, r80, r83
-  Const        r85, 1
-  AddInt       r86, r84, r85
-  SetIndex     r80, r83, r86
+  Index        r84, r14, r65
+  Index        r85, r84, r70
+  Append       r86, r85, r63
+  SetIndex     r84, r70, r86
+  Index        r87, r84, r72
+  Const        r88, 1
+  AddInt       r89, r87, r88
+  SetIndex     r84, r72, r89
 L3:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r36, r36, r85
+  AddInt       r36, r36, r88
   Jump         L6
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r25, r25, r85
+  AddInt       r25, r25, r88
   Jump         L7
 L1:
   // from ss in store_sales
-  AddInt       r19, r19, r85
+  AddInt       r19, r19, r88
   Jump         L8
 L0:
-  Const        r88, 0
-  Move         r87, r88
-  Len          r89, r15
+  Move         r90, r73
+  Len          r91, r15
 L14:
-  LessInt      r90, r87, r89
-  JumpIfFalse  r90, L9
-  Index        r92, r15, r87
+  LessInt      r92, r90, r91
+  JumpIfFalse  r92, L9
+  Index        r93, r15, r90
+  Move         r94, r93
   // channel: "store channel",
-  Const        r93, "channel"
-  Const        r94, "store channel"
+  Const        r95, "channel"
+  Const        r96, "store channel"
   // id: "store" + str(g.key),
-  Const        r95, "id"
-  Const        r96, "store"
-  Index        r97, r92, r6
-  Str          r98, r97
-  Add          r99, r96, r98
+  Const        r97, "id"
+  Const        r98, "store"
+  Index        r99, r94, r6
+  Str          r100, r99
+  Add          r101, r98, r100
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r100, "sales"
-  Const        r101, []
-  IterPrep     r102, r92
-  Len          r103, r102
-  Move         r104, r88
+  Const        r102, "sales"
+  Const        r103, []
+  IterPrep     r104, r94
+  Len          r105, r104
+  Move         r106, r73
 L11:
-  LessInt      r105, r104, r103
-  JumpIfFalse  r105, L10
-  Index        r107, r102, r104
-  Index        r108, r107, r8
-  Index        r109, r108, r9
-  Append       r101, r101, r109
-  AddInt       r104, r104, r85
+  LessInt      r107, r106, r105
+  JumpIfFalse  r107, L10
+  Index        r108, r104, r106
+  Move         r109, r108
+  Index        r110, r109, r8
+  Index        r111, r110, r9
+  Append       r112, r103, r111
+  Move         r103, r112
+  AddInt       r106, r106, r88
   Jump         L11
 L10:
-  Sum          r111, r101
+  Sum          r113, r103
   // returns: 0.0,
-  Const        r112, "returns"
-  Const        r113, 0
+  Const        r114, "returns"
+  Const        r115, 0
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Const        r114, "profit"
-  Const        r115, []
-  IterPrep     r116, r92
-  Len          r117, r116
-  Move         r118, r88
+  Const        r116, "profit"
+  Const        r117, []
+  IterPrep     r118, r94
+  Len          r119, r118
+  Move         r120, r73
 L13:
-  LessInt      r119, r118, r117
-  JumpIfFalse  r119, L12
-  Index        r107, r116, r118
-  Index        r121, r107, r8
-  Index        r122, r121, r12
-  Append       r115, r115, r122
-  AddInt       r118, r118, r85
+  LessInt      r121, r120, r119
+  JumpIfFalse  r121, L12
+  Index        r122, r118, r120
+  Move         r109, r122
+  Index        r123, r109, r8
+  Index        r124, r123, r12
+  Append       r125, r117, r124
+  Move         r117, r125
+  AddInt       r120, r120, r88
   Jump         L13
 L12:
-  Sum          r124, r115
+  Sum          r126, r117
   // profit_loss: 0.0
-  Const        r125, "profit_loss"
+  Const        r127, "profit_loss"
   // channel: "store channel",
-  Move         r126, r93
-  Move         r127, r94
-  // id: "store" + str(g.key),
   Move         r128, r95
-  Move         r129, r99
+  Move         r129, r96
+  // id: "store" + str(g.key),
+  Move         r130, r97
+  Move         r131, r101
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Move         r130, r100
-  Move         r131, r111
-  // returns: 0.0,
-  Move         r132, r112
+  Move         r132, r102
   Move         r133, r113
-  // profit: sum(from x in g select x.ss.ss_net_profit),
+  // returns: 0.0,
   Move         r134, r114
-  Move         r135, r124
+  Move         r135, r115
+  // profit: sum(from x in g select x.ss.ss_net_profit),
+  Move         r136, r116
+  Move         r137, r126
   // profit_loss: 0.0
-  Move         r136, r125
-  Move         r137, r113
+  Move         r138, r127
+  Move         r139, r115
   // select {
-  MakeMap      r138, 6, r126
+  MakeMap      r140, 6, r128
   // from ss in store_sales
-  Append       r1, r1, r138
-  AddInt       r87, r87, r85
+  Append       r141, r1, r140
+  Move         r1, r141
+  AddInt       r90, r90, r88
   Jump         L14
 L9:
   // from sr in store_returns
-  Const        r140, []
+  Const        r142, []
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Const        r141, "sr"
-  Const        r142, "sr_return_amt"
+  Const        r143, "sr"
+  Const        r144, "sr_return_amt"
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Const        r143, "sr_net_loss"
+  Const        r145, "sr_net_loss"
   // from sr in store_returns
-  MakeMap      r144, 0, r0
-  Const        r146, []
-  Move         r145, r146
-  IterPrep     r147, r0
-  Len          r148, r147
-  Const        r149, 0
+  MakeMap      r146, 0, r0
+  Const        r148, []
+  Move         r147, r148
+  IterPrep     r149, r0
+  Len          r150, r149
+  Const        r151, 0
 L23:
-  LessInt      r150, r149, r148
-  JumpIfFalse  r150, L15
-  Index        r152, r147, r149
+  LessInt      r152, r151, r150
+  JumpIfFalse  r152, L15
+  Index        r153, r149, r151
+  Move         r154, r153
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  IterPrep     r153, r0
-  Len          r154, r153
-  Const        r155, 0
+  IterPrep     r155, r0
+  Len          r156, r155
+  Const        r157, 0
 L22:
-  LessInt      r156, r155, r154
-  JumpIfFalse  r156, L16
-  Index        r158, r153, r155
-  Const        r159, "sr_returned_date_sk"
-  Index        r160, r152, r159
-  Index        r161, r158, r31
-  Equal        r162, r160, r161
-  JumpIfFalse  r162, L17
+  LessInt      r158, r157, r156
+  JumpIfFalse  r158, L16
+  Index        r159, r155, r157
+  Move         r160, r159
+  Const        r161, "sr_returned_date_sk"
+  Index        r162, r154, r161
+  Index        r163, r160, r31
+  Equal        r164, r162, r163
+  JumpIfFalse  r164, L17
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  IterPrep     r163, r0
-  Len          r164, r163
-  Const        r165, 0
+  IterPrep     r165, r0
+  Len          r166, r165
+  Const        r167, 0
 L21:
-  LessInt      r166, r165, r164
-  JumpIfFalse  r166, L17
-  Index        r168, r163, r165
-  Const        r169, "sr_store_sk"
-  Index        r170, r152, r169
-  Index        r171, r168, r42
-  Equal        r172, r170, r171
-  JumpIfFalse  r172, L18
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r173, r158, r3
-  LessEq       r174, r46, r173
-  Index        r175, r158, r3
-  LessEq       r176, r175, r49
-  JumpIfFalse  r174, L19
-  Move         r174, r176
-L19:
+  LessInt      r168, r167, r166
+  JumpIfFalse  r168, L17
+  Index        r169, r165, r167
+  Move         r170, r169
+  Const        r171, "sr_store_sk"
+  Index        r172, r154, r171
+  Index        r173, r170, r42
+  Equal        r174, r172, r173
   JumpIfFalse  r174, L18
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Index        r175, r160, r3
+  LessEq       r176, r46, r175
+  Index        r177, r160, r3
+  LessEq       r178, r177, r49
+  Move         r179, r176
+  JumpIfFalse  r179, L19
+  Move         r179, r178
+L19:
+  JumpIfFalse  r179, L18
   // from sr in store_returns
-  Move         r177, r152
-  Move         r178, r158
-  Move         r179, r168
-  MakeMap      r180, 3, r141
+  Move         r180, r154
+  Move         r181, r160
+  Move         r182, r170
+  Move         r183, r143
+  Move         r184, r180
+  Move         r185, r53
+  Move         r186, r181
+  Move         r187, r55
+  Move         r188, r182
+  MakeMap      r189, 3, r183
   // group by s.s_store_id into g
-  Index        r181, r168, r2
-  Str          r182, r181
-  In           r183, r182, r144
-  JumpIfTrue   r183, L20
+  Index        r190, r170, r2
+  Str          r191, r190
+  In           r192, r191, r146
+  JumpIfTrue   r192, L20
+  Move         r193, r190
   // from sr in store_returns
-  Const        r184, []
-  Const        r185, "__group__"
-  Const        r186, true
-  Const        r187, "key"
-  // group by s.s_store_id into g
-  Move         r188, r181
-  // from sr in store_returns
-  Const        r189, "items"
-  Move         r190, r184
-  Const        r191, "count"
-  Const        r192, 0
-  Move         r193, r185
-  Move         r194, r186
-  Move         r195, r187
-  Move         r196, r188
-  Move         r197, r189
-  Move         r198, r190
-  Move         r199, r191
-  Move         r200, r192
-  MakeMap      r201, 4, r193
-  SetIndex     r144, r182, r201
-  Append       r145, r145, r201
+  Move         r194, r0
+  Move         r195, r67
+  Move         r196, r68
+  Move         r197, r6
+  Move         r198, r193
+  Move         r199, r70
+  Move         r200, r194
+  Move         r201, r72
+  Move         r202, r73
+  MakeMap      r203, 4, r195
+  SetIndex     r146, r191, r203
+  Append       r204, r147, r203
+  Move         r147, r204
 L20:
-  Index        r203, r144, r182
-  Index        r204, r203, r79
-  Append       r205, r204, r180
-  SetIndex     r203, r79, r205
-  Index        r206, r203, r83
-  AddInt       r207, r206, r85
-  SetIndex     r203, r83, r207
+  Index        r205, r146, r191
+  Index        r206, r205, r70
+  Append       r207, r206, r189
+  SetIndex     r205, r70, r207
+  Index        r208, r205, r72
+  AddInt       r209, r208, r88
+  SetIndex     r205, r72, r209
 L18:
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  AddInt       r165, r165, r85
+  AddInt       r167, r167, r88
   Jump         L21
 L17:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  AddInt       r155, r155, r85
+  AddInt       r157, r157, r88
   Jump         L22
 L16:
   // from sr in store_returns
-  AddInt       r149, r149, r85
+  AddInt       r151, r151, r88
   Jump         L23
 L15:
-  Move         r208, r88
-  Len          r209, r145
+  Move         r210, r73
+  Len          r211, r147
 L29:
-  LessInt      r210, r208, r209
-  JumpIfFalse  r210, L24
-  Index        r92, r145, r208
+  LessInt      r212, r210, r211
+  JumpIfFalse  r212, L24
+  Index        r213, r147, r210
+  Move         r94, r213
   // channel: "store channel",
-  Const        r212, "channel"
+  Const        r214, "channel"
   // id: "store" + str(g.key),
-  Const        r213, "id"
-  Index        r214, r92, r6
-  Str          r215, r214
-  Add          r216, r96, r215
+  Const        r215, "id"
+  Index        r216, r94, r6
+  Str          r217, r216
+  Add          r218, r98, r217
   // sales: 0.0,
-  Const        r217, "sales"
+  Const        r219, "sales"
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Const        r218, "returns"
-  Const        r219, []
-  IterPrep     r220, r92
-  Len          r221, r220
-  Move         r222, r88
+  Const        r220, "returns"
+  Const        r221, []
+  IterPrep     r222, r94
+  Len          r223, r222
+  Move         r224, r73
 L26:
-  LessInt      r223, r222, r221
-  JumpIfFalse  r223, L25
-  Index        r107, r220, r222
-  Index        r225, r107, r141
-  Index        r226, r225, r142
-  Append       r219, r219, r226
-  AddInt       r222, r222, r85
+  LessInt      r225, r224, r223
+  JumpIfFalse  r225, L25
+  Index        r226, r222, r224
+  Move         r109, r226
+  Index        r227, r109, r143
+  Index        r228, r227, r144
+  Append       r229, r221, r228
+  Move         r221, r229
+  AddInt       r224, r224, r88
   Jump         L26
 L25:
-  Sum          r228, r219
+  Sum          r230, r221
   // profit: 0.0,
-  Const        r229, "profit"
+  Const        r231, "profit"
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Const        r230, "profit_loss"
-  Const        r231, []
-  IterPrep     r232, r92
-  Len          r233, r232
-  Move         r234, r88
+  Const        r232, "profit_loss"
+  Const        r233, []
+  IterPrep     r234, r94
+  Len          r235, r234
+  Move         r236, r73
 L28:
-  LessInt      r235, r234, r233
-  JumpIfFalse  r235, L27
-  Index        r107, r232, r234
-  Index        r237, r107, r141
-  Index        r238, r237, r143
-  Append       r231, r231, r238
-  AddInt       r234, r234, r85
+  LessInt      r237, r236, r235
+  JumpIfFalse  r237, L27
+  Index        r238, r234, r236
+  Move         r109, r238
+  Index        r239, r109, r143
+  Index        r240, r239, r145
+  Append       r241, r233, r240
+  Move         r233, r241
+  AddInt       r236, r236, r88
   Jump         L28
 L27:
-  Sum          r240, r231
+  Sum          r242, r233
   // channel: "store channel",
-  Move         r241, r212
-  Move         r242, r94
+  Move         r243, r214
+  Move         r244, r96
   // id: "store" + str(g.key),
-  Move         r243, r213
-  Move         r244, r216
+  Move         r245, r215
+  Move         r246, r218
   // sales: 0.0,
-  Move         r245, r217
-  Move         r246, r113
+  Move         r247, r219
+  Move         r248, r115
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Move         r247, r218
-  Move         r248, r228
+  Move         r249, r220
+  Move         r250, r230
   // profit: 0.0,
-  Move         r249, r229
-  Move         r250, r113
+  Move         r251, r231
+  Move         r252, r115
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Move         r251, r230
-  Move         r252, r240
+  Move         r253, r232
+  Move         r254, r242
   // select {
-  MakeMap      r253, 6, r241
+  MakeMap      r255, 6, r243
   // from sr in store_returns
-  Append       r140, r140, r253
-  AddInt       r208, r208, r85
+  Append       r256, r142, r255
+  Move         r142, r256
+  AddInt       r210, r210, r88
   Jump         L29
 L24:
   // from cs in catalog_sales
-  Const        r255, []
+  Const        r257, []
   // group by cp.cp_catalog_page_id into g
-  Const        r256, "cp_catalog_page_id"
+  Const        r258, "cp_catalog_page_id"
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Const        r257, "cs"
-  Const        r258, "cs_ext_sales_price"
+  Const        r259, "cs"
+  Const        r260, "cs_ext_sales_price"
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Const        r259, "cs_net_profit"
+  Const        r261, "cs_net_profit"
   // from cs in catalog_sales
-  MakeMap      r260, 0, r0
-  Const        r262, []
-  Move         r261, r262
-  IterPrep     r263, r0
-  Len          r264, r263
-  Const        r265, 0
+  MakeMap      r262, 0, r0
+  Const        r264, []
+  Move         r263, r264
+  IterPrep     r265, r0
+  Len          r266, r265
+  Const        r267, 0
 L38:
-  LessInt      r266, r265, r264
-  JumpIfFalse  r266, L30
-  Index        r268, r263, r265
+  LessInt      r268, r267, r266
+  JumpIfFalse  r268, L30
+  Index        r269, r265, r267
+  Move         r270, r269
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r269, r0
-  Len          r270, r269
-  Const        r271, 0
+  IterPrep     r271, r0
+  Len          r272, r271
+  Const        r273, 0
 L37:
-  LessInt      r272, r271, r270
-  JumpIfFalse  r272, L31
-  Index        r274, r269, r271
-  Const        r275, "cs_sold_date_sk"
-  Index        r276, r268, r275
-  Index        r277, r274, r31
-  Equal        r278, r276, r277
-  JumpIfFalse  r278, L32
+  LessInt      r274, r273, r272
+  JumpIfFalse  r274, L31
+  Index        r275, r271, r273
+  Move         r276, r275
+  Const        r277, "cs_sold_date_sk"
+  Index        r278, r270, r277
+  Index        r279, r276, r31
+  Equal        r280, r278, r279
+  JumpIfFalse  r280, L32
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r279, r0
-  Len          r280, r279
-  Const        r281, 0
+  IterPrep     r281, r0
+  Len          r282, r281
+  Const        r283, 0
 L36:
-  LessInt      r282, r281, r280
-  JumpIfFalse  r282, L32
-  Index        r284, r279, r281
-  Const        r285, "cs_catalog_page_sk"
-  Index        r286, r268, r285
-  Const        r287, "cp_catalog_page_sk"
-  Index        r288, r284, r287
-  Equal        r289, r286, r288
-  JumpIfFalse  r289, L33
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r290, r274, r3
-  LessEq       r291, r46, r290
-  Index        r292, r274, r3
-  LessEq       r293, r292, r49
-  JumpIfFalse  r291, L34
-  Move         r291, r293
-L34:
+  LessInt      r284, r283, r282
+  JumpIfFalse  r284, L32
+  Index        r285, r281, r283
+  Move         r286, r285
+  Const        r287, "cs_catalog_page_sk"
+  Index        r288, r270, r287
+  Const        r289, "cp_catalog_page_sk"
+  Index        r290, r286, r289
+  Equal        r291, r288, r290
   JumpIfFalse  r291, L33
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Index        r292, r276, r3
+  LessEq       r293, r46, r292
+  Index        r294, r276, r3
+  LessEq       r295, r294, r49
+  Move         r296, r293
+  JumpIfFalse  r296, L34
+  Move         r296, r295
+L34:
+  JumpIfFalse  r296, L33
   // from cs in catalog_sales
-  Move         r294, r268
-  Move         r295, r274
-  Const        r296, "cp"
-  Move         r297, r284
-  MakeMap      r298, 3, r257
+  Move         r297, r270
+  Move         r298, r276
+  Const        r299, "cp"
+  Move         r300, r286
+  Move         r301, r259
+  Move         r302, r297
+  Move         r303, r53
+  Move         r304, r298
+  Move         r305, r299
+  Move         r306, r300
+  MakeMap      r307, 3, r301
   // group by cp.cp_catalog_page_id into g
-  Index        r299, r284, r256
-  Str          r300, r299
-  In           r301, r300, r260
-  JumpIfTrue   r301, L35
+  Index        r308, r286, r258
+  Str          r309, r308
+  In           r310, r309, r262
+  JumpIfTrue   r310, L35
+  Move         r311, r308
   // from cs in catalog_sales
-  Const        r302, []
-  Const        r303, "__group__"
-  Const        r304, true
-  Const        r305, "key"
-  // group by cp.cp_catalog_page_id into g
-  Move         r306, r299
-  // from cs in catalog_sales
-  Const        r307, "items"
-  Move         r308, r302
-  Const        r309, "count"
-  Const        r310, 0
-  Move         r311, r303
-  Move         r312, r304
-  Move         r313, r305
-  Move         r314, r306
-  Move         r315, r307
-  Move         r316, r308
-  Move         r317, r309
-  Move         r318, r310
-  MakeMap      r319, 4, r311
-  SetIndex     r260, r300, r319
-  Append       r261, r261, r319
+  Move         r312, r0
+  Move         r313, r67
+  Move         r314, r68
+  Move         r315, r6
+  Move         r316, r311
+  Move         r317, r70
+  Move         r318, r312
+  Move         r319, r72
+  Move         r320, r73
+  MakeMap      r321, 4, r313
+  SetIndex     r262, r309, r321
+  Append       r322, r263, r321
+  Move         r263, r322
 L35:
-  Index        r321, r260, r300
-  Index        r322, r321, r79
-  Append       r323, r322, r298
-  SetIndex     r321, r79, r323
-  Index        r324, r321, r83
-  AddInt       r325, r324, r85
-  SetIndex     r321, r83, r325
+  Index        r323, r262, r309
+  Index        r324, r323, r70
+  Append       r325, r324, r307
+  SetIndex     r323, r70, r325
+  Index        r326, r323, r72
+  AddInt       r327, r326, r88
+  SetIndex     r323, r72, r327
 L33:
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  AddInt       r281, r281, r85
+  AddInt       r283, r283, r88
   Jump         L36
 L32:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r271, r271, r85
+  AddInt       r273, r273, r88
   Jump         L37
 L31:
   // from cs in catalog_sales
-  AddInt       r265, r265, r85
+  AddInt       r267, r267, r88
   Jump         L38
 L30:
-  Move         r326, r88
-  Len          r327, r261
+  Move         r328, r73
+  Len          r329, r263
 L44:
-  LessInt      r328, r326, r327
-  JumpIfFalse  r328, L39
-  Index        r92, r261, r326
+  LessInt      r330, r328, r329
+  JumpIfFalse  r330, L39
+  Index        r331, r263, r328
+  Move         r94, r331
   // channel: "catalog channel",
-  Const        r330, "channel"
-  Const        r331, "catalog channel"
+  Const        r332, "channel"
+  Const        r333, "catalog channel"
   // id: "catalog_page" + str(g.key),
-  Const        r332, "id"
-  Const        r333, "catalog_page"
-  Index        r334, r92, r6
-  Str          r335, r334
-  Add          r336, r333, r335
+  Const        r334, "id"
+  Const        r335, "catalog_page"
+  Index        r336, r94, r6
+  Str          r337, r336
+  Add          r338, r335, r337
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Const        r337, "sales"
-  Const        r338, []
-  IterPrep     r339, r92
-  Len          r340, r339
-  Move         r341, r88
+  Const        r339, "sales"
+  Const        r340, []
+  IterPrep     r341, r94
+  Len          r342, r341
+  Move         r343, r73
 L41:
-  LessInt      r342, r341, r340
-  JumpIfFalse  r342, L40
-  Index        r107, r339, r341
-  Index        r344, r107, r257
-  Index        r345, r344, r258
-  Append       r338, r338, r345
-  AddInt       r341, r341, r85
+  LessInt      r344, r343, r342
+  JumpIfFalse  r344, L40
+  Index        r345, r341, r343
+  Move         r109, r345
+  Index        r346, r109, r259
+  Index        r347, r346, r260
+  Append       r348, r340, r347
+  Move         r340, r348
+  AddInt       r343, r343, r88
   Jump         L41
 L40:
-  Sum          r347, r338
+  Sum          r349, r340
   // returns: 0.0,
-  Const        r348, "returns"
+  Const        r350, "returns"
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Const        r349, "profit"
-  Const        r350, []
-  IterPrep     r351, r92
-  Len          r352, r351
-  Move         r353, r88
+  Const        r351, "profit"
+  Const        r352, []
+  IterPrep     r353, r94
+  Len          r354, r353
+  Move         r355, r73
 L43:
-  LessInt      r354, r353, r352
-  JumpIfFalse  r354, L42
-  Index        r107, r351, r353
-  Index        r356, r107, r257
-  Index        r357, r356, r259
-  Append       r350, r350, r357
-  AddInt       r353, r353, r85
+  LessInt      r356, r355, r354
+  JumpIfFalse  r356, L42
+  Index        r357, r353, r355
+  Move         r109, r357
+  Index        r358, r109, r259
+  Index        r359, r358, r261
+  Append       r360, r352, r359
+  Move         r352, r360
+  AddInt       r355, r355, r88
   Jump         L43
 L42:
-  Sum          r359, r350
+  Sum          r361, r352
   // profit_loss: 0.0
-  Const        r360, "profit_loss"
+  Const        r362, "profit_loss"
   // channel: "catalog channel",
-  Move         r361, r330
-  Move         r362, r331
-  // id: "catalog_page" + str(g.key),
   Move         r363, r332
-  Move         r364, r336
+  Move         r364, r333
+  // id: "catalog_page" + str(g.key),
+  Move         r365, r334
+  Move         r366, r338
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Move         r365, r337
-  Move         r366, r347
+  Move         r367, r339
+  Move         r368, r349
   // returns: 0.0,
-  Move         r367, r348
-  Move         r368, r113
+  Move         r369, r350
+  Move         r370, r115
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Move         r369, r349
-  Move         r370, r359
+  Move         r371, r351
+  Move         r372, r361
   // profit_loss: 0.0
-  Move         r371, r360
-  Move         r372, r113
+  Move         r373, r362
+  Move         r374, r115
   // select {
-  MakeMap      r373, 6, r361
+  MakeMap      r375, 6, r363
   // from cs in catalog_sales
-  Append       r255, r255, r373
-  AddInt       r326, r326, r85
+  Append       r376, r257, r375
+  Move         r257, r376
+  AddInt       r328, r328, r88
   Jump         L44
 L39:
   // from cr in catalog_returns
-  Const        r375, []
+  Const        r377, []
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Const        r376, "cr"
-  Const        r377, "cr_return_amount"
+  Const        r378, "cr"
+  Const        r379, "cr_return_amount"
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Const        r378, "cr_net_loss"
+  Const        r380, "cr_net_loss"
   // from cr in catalog_returns
-  MakeMap      r379, 0, r0
-  Const        r381, []
-  Move         r380, r381
-  IterPrep     r382, r0
-  Len          r383, r382
-  Const        r384, 0
+  MakeMap      r381, 0, r0
+  Const        r383, []
+  Move         r382, r383
+  IterPrep     r384, r0
+  Len          r385, r384
+  Const        r386, 0
 L53:
-  LessInt      r385, r384, r383
-  JumpIfFalse  r385, L45
-  Index        r387, r382, r384
+  LessInt      r387, r386, r385
+  JumpIfFalse  r387, L45
+  Index        r388, r384, r386
+  Move         r389, r388
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  IterPrep     r388, r0
-  Len          r389, r388
-  Const        r390, 0
+  IterPrep     r390, r0
+  Len          r391, r390
+  Const        r392, 0
 L52:
-  LessInt      r391, r390, r389
-  JumpIfFalse  r391, L46
-  Index        r393, r388, r390
-  Const        r394, "cr_returned_date_sk"
-  Index        r395, r387, r394
-  Index        r396, r393, r31
-  Equal        r397, r395, r396
-  JumpIfFalse  r397, L47
+  LessInt      r393, r392, r391
+  JumpIfFalse  r393, L46
+  Index        r394, r390, r392
+  Move         r395, r394
+  Const        r396, "cr_returned_date_sk"
+  Index        r397, r389, r396
+  Index        r398, r395, r31
+  Equal        r399, r397, r398
+  JumpIfFalse  r399, L47
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r398, r0
-  Len          r399, r398
-  Const        r400, 0
+  IterPrep     r400, r0
+  Len          r401, r400
+  Const        r402, 0
 L51:
-  LessInt      r401, r400, r399
-  JumpIfFalse  r401, L47
-  Index        r403, r398, r400
-  Const        r404, "cr_catalog_page_sk"
-  Index        r405, r387, r404
-  Index        r406, r403, r287
-  Equal        r407, r405, r406
-  JumpIfFalse  r407, L48
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r408, r393, r3
-  LessEq       r409, r46, r408
-  Index        r410, r393, r3
-  LessEq       r411, r410, r49
-  JumpIfFalse  r409, L49
-  Move         r409, r411
-L49:
+  LessInt      r403, r402, r401
+  JumpIfFalse  r403, L47
+  Index        r404, r400, r402
+  Move         r405, r404
+  Const        r406, "cr_catalog_page_sk"
+  Index        r407, r389, r406
+  Index        r408, r405, r289
+  Equal        r409, r407, r408
   JumpIfFalse  r409, L48
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Index        r410, r395, r3
+  LessEq       r411, r46, r410
+  Index        r412, r395, r3
+  LessEq       r413, r412, r49
+  Move         r414, r411
+  JumpIfFalse  r414, L49
+  Move         r414, r413
+L49:
+  JumpIfFalse  r414, L48
   // from cr in catalog_returns
-  Move         r412, r387
-  Move         r413, r393
-  Move         r414, r403
-  MakeMap      r415, 3, r376
+  Move         r415, r389
+  Move         r416, r395
+  Move         r417, r405
+  Move         r418, r378
+  Move         r419, r415
+  Move         r420, r53
+  Move         r421, r416
+  Move         r422, r299
+  Move         r423, r417
+  MakeMap      r424, 3, r418
   // group by cp.cp_catalog_page_id into g
-  Index        r416, r403, r256
-  Str          r417, r416
-  In           r418, r417, r379
-  JumpIfTrue   r418, L50
+  Index        r425, r405, r258
+  Str          r426, r425
+  In           r427, r426, r381
+  JumpIfTrue   r427, L50
+  Move         r428, r425
   // from cr in catalog_returns
-  Const        r419, []
-  Const        r420, "__group__"
-  Const        r421, true
-  Const        r422, "key"
-  // group by cp.cp_catalog_page_id into g
-  Move         r423, r416
-  // from cr in catalog_returns
-  Const        r424, "items"
-  Move         r425, r419
-  Const        r426, "count"
-  Const        r427, 0
-  Move         r428, r420
-  Move         r429, r421
-  Move         r430, r422
-  Move         r431, r423
-  Move         r432, r424
-  Move         r433, r425
-  Move         r434, r426
-  Move         r435, r427
-  MakeMap      r436, 4, r428
-  SetIndex     r379, r417, r436
-  Append       r380, r380, r436
+  Move         r429, r0
+  Move         r430, r67
+  Move         r431, r68
+  Move         r432, r6
+  Move         r433, r428
+  Move         r434, r70
+  Move         r435, r429
+  Move         r436, r72
+  Move         r437, r73
+  MakeMap      r438, 4, r430
+  SetIndex     r381, r426, r438
+  Append       r439, r382, r438
+  Move         r382, r439
 L50:
-  Index        r438, r379, r417
-  Index        r439, r438, r79
-  Append       r440, r439, r415
-  SetIndex     r438, r79, r440
-  Index        r441, r438, r83
-  AddInt       r442, r441, r85
-  SetIndex     r438, r83, r442
+  Index        r440, r381, r426
+  Index        r441, r440, r70
+  Append       r442, r441, r424
+  SetIndex     r440, r70, r442
+  Index        r443, r440, r72
+  AddInt       r444, r443, r88
+  SetIndex     r440, r72, r444
 L48:
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  AddInt       r400, r400, r85
+  AddInt       r402, r402, r88
   Jump         L51
 L47:
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  AddInt       r390, r390, r85
+  AddInt       r392, r392, r88
   Jump         L52
 L46:
   // from cr in catalog_returns
-  AddInt       r384, r384, r85
+  AddInt       r386, r386, r88
   Jump         L53
 L45:
-  Move         r443, r88
-  Len          r444, r380
+  Move         r445, r73
+  Len          r446, r382
 L59:
-  LessInt      r445, r443, r444
-  JumpIfFalse  r445, L54
-  Index        r92, r380, r443
+  LessInt      r447, r445, r446
+  JumpIfFalse  r447, L54
+  Index        r448, r382, r445
+  Move         r94, r448
   // channel: "catalog channel",
-  Const        r447, "channel"
+  Const        r449, "channel"
   // id: "catalog_page" + str(g.key),
-  Const        r448, "id"
-  Index        r449, r92, r6
-  Str          r450, r449
-  Add          r451, r333, r450
+  Const        r450, "id"
+  Index        r451, r94, r6
+  Str          r452, r451
+  Add          r453, r335, r452
   // sales: 0.0,
-  Const        r452, "sales"
+  Const        r454, "sales"
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Const        r453, "returns"
-  Const        r454, []
-  IterPrep     r455, r92
-  Len          r456, r455
-  Move         r457, r88
+  Const        r455, "returns"
+  Const        r456, []
+  IterPrep     r457, r94
+  Len          r458, r457
+  Move         r459, r73
 L56:
-  LessInt      r458, r457, r456
-  JumpIfFalse  r458, L55
-  Index        r107, r455, r457
-  Index        r460, r107, r376
-  Index        r461, r460, r377
-  Append       r454, r454, r461
-  AddInt       r457, r457, r85
+  LessInt      r460, r459, r458
+  JumpIfFalse  r460, L55
+  Index        r461, r457, r459
+  Move         r109, r461
+  Index        r462, r109, r378
+  Index        r463, r462, r379
+  Append       r464, r456, r463
+  Move         r456, r464
+  AddInt       r459, r459, r88
   Jump         L56
 L55:
-  Sum          r463, r454
+  Sum          r465, r456
   // profit: 0.0,
-  Const        r464, "profit"
+  Const        r466, "profit"
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Const        r465, "profit_loss"
-  Const        r466, []
-  IterPrep     r467, r92
-  Len          r468, r467
-  Move         r469, r88
+  Const        r467, "profit_loss"
+  Const        r468, []
+  IterPrep     r469, r94
+  Len          r470, r469
+  Move         r471, r73
 L58:
-  LessInt      r470, r469, r468
-  JumpIfFalse  r470, L57
-  Index        r107, r467, r469
-  Index        r472, r107, r376
-  Index        r473, r472, r378
-  Append       r466, r466, r473
-  AddInt       r469, r469, r85
+  LessInt      r472, r471, r470
+  JumpIfFalse  r472, L57
+  Index        r473, r469, r471
+  Move         r109, r473
+  Index        r474, r109, r378
+  Index        r475, r474, r380
+  Append       r476, r468, r475
+  Move         r468, r476
+  AddInt       r471, r471, r88
   Jump         L58
 L57:
-  Sum          r475, r466
+  Sum          r477, r468
   // channel: "catalog channel",
-  Move         r476, r447
-  Move         r477, r331
+  Move         r478, r449
+  Move         r479, r333
   // id: "catalog_page" + str(g.key),
-  Move         r478, r448
-  Move         r479, r451
+  Move         r480, r450
+  Move         r481, r453
   // sales: 0.0,
-  Move         r480, r452
-  Move         r481, r113
+  Move         r482, r454
+  Move         r483, r115
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Move         r482, r453
-  Move         r483, r463
+  Move         r484, r455
+  Move         r485, r465
   // profit: 0.0,
-  Move         r484, r464
-  Move         r485, r113
+  Move         r486, r466
+  Move         r487, r115
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Move         r486, r465
-  Move         r487, r475
+  Move         r488, r467
+  Move         r489, r477
   // select {
-  MakeMap      r488, 6, r476
+  MakeMap      r490, 6, r478
   // from cr in catalog_returns
-  Append       r375, r375, r488
-  AddInt       r443, r443, r85
+  Append       r491, r377, r490
+  Move         r377, r491
+  AddInt       r445, r445, r88
   Jump         L59
 L54:
   // from ws in web_sales
-  Const        r490, []
+  Const        r492, []
   // group by w.web_site_id into g
-  Const        r491, "web_site_id"
+  Const        r493, "web_site_id"
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Const        r492, "ws"
-  Const        r493, "ws_ext_sales_price"
+  Const        r494, "ws"
+  Const        r495, "ws_ext_sales_price"
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Const        r494, "ws_net_profit"
+  Const        r496, "ws_net_profit"
   // from ws in web_sales
-  MakeMap      r495, 0, r0
-  Const        r497, []
-  Move         r496, r497
-  IterPrep     r498, r0
-  Len          r499, r498
-  Const        r500, 0
+  MakeMap      r497, 0, r0
+  Const        r499, []
+  Move         r498, r499
+  IterPrep     r500, r0
+  Len          r501, r500
+  Const        r502, 0
 L68:
-  LessInt      r501, r500, r499
-  JumpIfFalse  r501, L60
-  Index        r503, r498, r500
+  LessInt      r503, r502, r501
+  JumpIfFalse  r503, L60
+  Index        r504, r500, r502
+  Move         r505, r504
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r504, r0
-  Len          r505, r504
-  Const        r506, 0
+  IterPrep     r506, r0
+  Len          r507, r506
+  Const        r508, 0
 L67:
-  LessInt      r507, r506, r505
-  JumpIfFalse  r507, L61
-  Index        r509, r504, r506
-  Const        r510, "ws_sold_date_sk"
-  Index        r511, r503, r510
-  Index        r512, r509, r31
-  Equal        r513, r511, r512
-  JumpIfFalse  r513, L62
+  LessInt      r509, r508, r507
+  JumpIfFalse  r509, L61
+  Index        r510, r506, r508
+  Move         r511, r510
+  Const        r512, "ws_sold_date_sk"
+  Index        r513, r505, r512
+  Index        r514, r511, r31
+  Equal        r515, r513, r514
+  JumpIfFalse  r515, L62
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r514, r0
-  Len          r515, r514
-  Const        r516, 0
+  IterPrep     r516, r0
+  Len          r517, r516
+  Const        r518, 0
 L66:
-  LessInt      r517, r516, r515
-  JumpIfFalse  r517, L62
-  Index        r519, r514, r516
-  Const        r520, "ws_web_site_sk"
-  Index        r521, r503, r520
-  Const        r522, "web_site_sk"
-  Index        r523, r519, r522
-  Equal        r524, r521, r523
-  JumpIfFalse  r524, L63
-  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r525, r509, r3
-  LessEq       r526, r46, r525
-  Index        r527, r509, r3
-  LessEq       r528, r527, r49
-  JumpIfFalse  r526, L64
-  Move         r526, r528
-L64:
+  LessInt      r519, r518, r517
+  JumpIfFalse  r519, L62
+  Index        r520, r516, r518
+  Move         r521, r520
+  Const        r522, "ws_web_site_sk"
+  Index        r523, r505, r522
+  Const        r524, "web_site_sk"
+  Index        r525, r521, r524
+  Equal        r526, r523, r525
   JumpIfFalse  r526, L63
+  // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
+  Index        r527, r511, r3
+  LessEq       r528, r46, r527
+  Index        r529, r511, r3
+  LessEq       r530, r529, r49
+  Move         r531, r528
+  JumpIfFalse  r531, L64
+  Move         r531, r530
+L64:
+  JumpIfFalse  r531, L63
   // from ws in web_sales
-  Move         r529, r503
-  Move         r530, r509
-  Const        r531, "w"
-  Move         r532, r519
-  MakeMap      r533, 3, r492
+  Move         r532, r505
+  Move         r533, r511
+  Const        r534, "w"
+  Move         r535, r521
+  Move         r536, r494
+  Move         r537, r532
+  Move         r538, r53
+  Move         r539, r533
+  Move         r540, r534
+  Move         r541, r535
+  MakeMap      r542, 3, r536
   // group by w.web_site_id into g
-  Index        r534, r519, r491
-  Str          r535, r534
-  In           r536, r535, r495
-  JumpIfTrue   r536, L65
+  Index        r543, r521, r493
+  Str          r544, r543
+  In           r545, r544, r497
+  JumpIfTrue   r545, L65
+  Move         r546, r543
   // from ws in web_sales
-  Const        r537, []
-  Const        r538, "__group__"
-  Const        r539, true
-  Const        r540, "key"
-  // group by w.web_site_id into g
-  Move         r541, r534
-  // from ws in web_sales
-  Const        r542, "items"
-  Move         r543, r537
-  Const        r544, "count"
-  Const        r545, 0
-  Move         r546, r538
-  Move         r547, r539
-  Move         r548, r540
-  Move         r549, r541
-  Move         r550, r542
-  Move         r551, r543
-  Move         r552, r544
-  Move         r553, r545
-  MakeMap      r554, 4, r546
-  SetIndex     r495, r535, r554
-  Append       r496, r496, r554
+  Move         r547, r0
+  Move         r548, r67
+  Move         r549, r68
+  Move         r550, r6
+  Move         r551, r546
+  Move         r552, r70
+  Move         r553, r547
+  Move         r554, r72
+  Move         r555, r73
+  MakeMap      r556, 4, r548
+  SetIndex     r497, r544, r556
+  Append       r557, r498, r556
+  Move         r498, r557
 L65:
-  Index        r556, r495, r535
-  Index        r557, r556, r79
-  Append       r558, r557, r533
-  SetIndex     r556, r79, r558
-  Index        r559, r556, r83
-  AddInt       r560, r559, r85
-  SetIndex     r556, r83, r560
+  Index        r558, r497, r544
+  Index        r559, r558, r70
+  Append       r560, r559, r542
+  SetIndex     r558, r70, r560
+  Index        r561, r558, r72
+  AddInt       r562, r561, r88
+  SetIndex     r558, r72, r562
 L63:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  AddInt       r516, r516, r85
+  AddInt       r518, r518, r88
   Jump         L66
 L62:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  AddInt       r506, r506, r85
+  AddInt       r508, r508, r88
   Jump         L67
 L61:
   // from ws in web_sales
-  AddInt       r500, r500, r85
+  AddInt       r502, r502, r88
   Jump         L68
 L60:
-  Move         r561, r88
-  Len          r562, r496
+  Move         r563, r73
+  Len          r564, r498
 L74:
-  LessInt      r563, r561, r562
-  JumpIfFalse  r563, L69
-  Index        r92, r496, r561
+  LessInt      r565, r563, r564
+  JumpIfFalse  r565, L69
+  Index        r566, r498, r563
+  Move         r94, r566
   // channel: "web channel",
-  Const        r565, "channel"
-  Const        r566, "web channel"
+  Const        r567, "channel"
+  Const        r568, "web channel"
   // id: "web_site" + str(g.key),
-  Const        r567, "id"
-  Const        r568, "web_site"
-  Index        r569, r92, r6
-  Str          r570, r569
-  Add          r571, r568, r570
+  Const        r569, "id"
+  Const        r570, "web_site"
+  Index        r571, r94, r6
+  Str          r572, r571
+  Add          r573, r570, r572
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Const        r572, "sales"
-  Const        r573, []
-  IterPrep     r574, r92
-  Len          r575, r574
-  Move         r576, r88
+  Const        r574, "sales"
+  Const        r575, []
+  IterPrep     r576, r94
+  Len          r577, r576
+  Move         r578, r73
 L71:
-  LessInt      r577, r576, r575
-  JumpIfFalse  r577, L70
-  Index        r107, r574, r576
-  Index        r579, r107, r492
-  Index        r580, r579, r493
-  Append       r573, r573, r580
-  AddInt       r576, r576, r85
+  LessInt      r579, r578, r577
+  JumpIfFalse  r579, L70
+  Index        r580, r576, r578
+  Move         r109, r580
+  Index        r581, r109, r494
+  Index        r582, r581, r495
+  Append       r583, r575, r582
+  Move         r575, r583
+  AddInt       r578, r578, r88
   Jump         L71
 L70:
-  Sum          r582, r573
+  Sum          r584, r575
   // returns: 0.0,
-  Const        r583, "returns"
+  Const        r585, "returns"
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Const        r584, "profit"
-  Const        r585, []
-  IterPrep     r586, r92
-  Len          r587, r586
-  Move         r588, r88
+  Const        r586, "profit"
+  Const        r587, []
+  IterPrep     r588, r94
+  Len          r589, r588
+  Move         r590, r73
 L73:
-  LessInt      r589, r588, r587
-  JumpIfFalse  r589, L72
-  Index        r107, r586, r588
-  Index        r591, r107, r492
-  Index        r592, r591, r494
-  Append       r585, r585, r592
-  AddInt       r588, r588, r85
+  LessInt      r591, r590, r589
+  JumpIfFalse  r591, L72
+  Index        r592, r588, r590
+  Move         r109, r592
+  Index        r593, r109, r494
+  Index        r594, r593, r496
+  Append       r595, r587, r594
+  Move         r587, r595
+  AddInt       r590, r590, r88
   Jump         L73
 L72:
-  Sum          r594, r585
+  Sum          r596, r587
   // profit_loss: 0.0
-  Const        r595, "profit_loss"
+  Const        r597, "profit_loss"
   // channel: "web channel",
-  Move         r596, r565
-  Move         r597, r566
-  // id: "web_site" + str(g.key),
   Move         r598, r567
-  Move         r599, r571
+  Move         r599, r568
+  // id: "web_site" + str(g.key),
+  Move         r600, r569
+  Move         r601, r573
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Move         r600, r572
-  Move         r601, r582
+  Move         r602, r574
+  Move         r603, r584
   // returns: 0.0,
-  Move         r602, r583
-  Move         r603, r113
+  Move         r604, r585
+  Move         r605, r115
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Move         r604, r584
-  Move         r605, r594
+  Move         r606, r586
+  Move         r607, r596
   // profit_loss: 0.0
-  Move         r606, r595
-  Move         r607, r113
+  Move         r608, r597
+  Move         r609, r115
   // select {
-  MakeMap      r608, 6, r596
+  MakeMap      r610, 6, r598
   // from ws in web_sales
-  Append       r490, r490, r608
-  AddInt       r561, r561, r85
+  Append       r611, r492, r610
+  Move         r492, r611
+  AddInt       r563, r563, r88
   Jump         L74
 L69:
   // from wr in web_returns
-  Const        r610, []
+  Const        r612, []
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Const        r611, "wr"
-  Const        r612, "wr_return_amt"
+  Const        r613, "wr"
+  Const        r614, "wr_return_amt"
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Const        r613, "wr_net_loss"
+  Const        r615, "wr_net_loss"
   // from wr in web_returns
-  MakeMap      r614, 0, r0
-  Const        r616, []
-  Move         r615, r616
-  IterPrep     r617, r0
-  Len          r618, r617
-  Const        r619, 0
+  MakeMap      r616, 0, r0
+  Const        r618, []
+  Move         r617, r618
+  IterPrep     r619, r0
+  Len          r620, r619
+  Const        r621, 0
 L86:
-  LessInt      r620, r619, r618
-  JumpIfFalse  r620, L75
-  Index        r622, r617, r619
+  LessInt      r622, r621, r620
+  JumpIfFalse  r622, L75
+  Index        r623, r619, r621
+  Move         r624, r623
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  IterPrep     r623, r0
-  Len          r624, r623
-  Const        r625, 0
+  IterPrep     r625, r0
+  Len          r626, r625
+  Const        r627, 0
 L85:
-  LessInt      r626, r625, r624
-  JumpIfFalse  r626, L76
-  Index        r490, r623, r625
-  Const        r628, "wr_item_sk"
-  Index        r629, r622, r628
-  Const        r630, "ws_item_sk"
-  Index        r631, r490, r630
-  Equal        r632, r629, r631
-  Const        r633, "wr_order_number"
-  Index        r634, r622, r633
-  Const        r635, "ws_order_number"
-  Index        r636, r490, r635
-  Equal        r637, r634, r636
-  JumpIfFalse  r632, L77
-  Move         r632, r637
+  LessInt      r628, r627, r626
+  JumpIfFalse  r628, L76
+  Index        r629, r625, r627
+  Move         r492, r629
+  Const        r630, "wr_item_sk"
+  Index        r631, r624, r630
+  Const        r632, "ws_item_sk"
+  Index        r633, r492, r632
+  Equal        r634, r631, r633
+  Const        r635, "wr_order_number"
+  Index        r636, r624, r635
+  Const        r637, "ws_order_number"
+  Index        r638, r492, r637
+  Equal        r639, r636, r638
+  Move         r640, r634
+  JumpIfFalse  r640, L77
+  Move         r640, r639
 L77:
-  JumpIfFalse  r632, L78
+  JumpIfFalse  r640, L78
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  IterPrep     r638, r0
-  Len          r639, r638
-  Const        r640, 0
+  IterPrep     r641, r0
+  Len          r642, r641
+  Const        r643, 0
 L84:
-  LessInt      r641, r640, r639
-  JumpIfFalse  r641, L78
-  Index        r643, r638, r640
-  Const        r644, "wr_returned_date_sk"
-  Index        r645, r622, r644
-  Index        r646, r643, r31
-  Equal        r647, r645, r646
-  JumpIfFalse  r647, L79
+  LessInt      r644, r643, r642
+  JumpIfFalse  r644, L78
+  Index        r645, r641, r643
+  Move         r646, r645
+  Const        r647, "wr_returned_date_sk"
+  Index        r648, r624, r647
+  Index        r649, r646, r31
+  Equal        r650, r648, r649
+  JumpIfFalse  r650, L79
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r648, r0
-  Len          r649, r648
-  Const        r650, 0
+  IterPrep     r651, r0
+  Len          r652, r651
+  Const        r653, 0
 L83:
-  LessInt      r651, r650, r649
-  JumpIfFalse  r651, L79
-  Index        r653, r648, r650
-  Index        r654, r490, r520
-  Index        r655, r653, r522
-  Equal        r656, r654, r655
-  JumpIfFalse  r656, L80
+  LessInt      r654, r653, r652
+  JumpIfFalse  r654, L79
+  Index        r655, r651, r653
+  Move         r656, r655
+  Index        r657, r492, r522
+  Index        r658, r656, r524
+  Equal        r659, r657, r658
+  JumpIfFalse  r659, L80
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r657, r643, r3
-  LessEq       r658, r46, r657
-  Index        r659, r643, r3
-  LessEq       r660, r659, r49
-  JumpIfFalse  r658, L81
-  Move         r658, r660
+  Index        r660, r646, r3
+  LessEq       r661, r46, r660
+  Index        r662, r646, r3
+  LessEq       r663, r662, r49
+  Move         r664, r661
+  JumpIfFalse  r664, L81
+  Move         r664, r663
 L81:
-  JumpIfFalse  r658, L80
+  JumpIfFalse  r664, L80
   // from wr in web_returns
-  Move         r661, r622
-  Move         r662, r490
-  Move         r663, r643
-  Move         r664, r653
-  MakeMap      r665, 4, r611
+  Move         r665, r624
+  Move         r666, r492
+  Move         r667, r646
+  Move         r668, r656
+  Move         r669, r613
+  Move         r670, r665
+  Move         r671, r494
+  Move         r672, r666
+  Move         r673, r53
+  Move         r674, r667
+  Move         r675, r534
+  Move         r676, r668
+  MakeMap      r677, 4, r669
   // group by w.web_site_id into g
-  Index        r666, r653, r491
-  Str          r667, r666
-  In           r668, r667, r614
-  JumpIfTrue   r668, L82
+  Index        r678, r656, r493
+  Str          r679, r678
+  In           r680, r679, r616
+  JumpIfTrue   r680, L82
+  Move         r681, r678
   // from wr in web_returns
-  Const        r669, []
-  Const        r670, "__group__"
-  Const        r671, true
-  Const        r672, "key"
-  // group by w.web_site_id into g
-  Move         r673, r666
-  // from wr in web_returns
-  Const        r674, "items"
-  Move         r675, r669
-  Const        r676, "count"
-  Const        r677, 0
-  Move         r678, r670
-  Move         r679, r671
-  Move         r680, r672
-  Move         r681, r673
-  Move         r682, r674
-  Move         r683, r675
-  Move         r684, r676
-  Move         r685, r677
-  MakeMap      r686, 4, r678
-  SetIndex     r614, r667, r686
-  Append       r615, r615, r686
+  Move         r682, r0
+  Move         r683, r67
+  Move         r684, r68
+  Move         r685, r6
+  Move         r686, r681
+  Move         r687, r70
+  Move         r688, r682
+  Move         r689, r72
+  Move         r690, r73
+  MakeMap      r691, 4, r683
+  SetIndex     r616, r679, r691
+  Append       r692, r617, r691
+  Move         r617, r692
 L82:
-  Index        r688, r614, r667
-  Index        r689, r688, r79
-  Append       r690, r689, r665
-  SetIndex     r688, r79, r690
-  Index        r691, r688, r83
-  AddInt       r692, r691, r85
-  SetIndex     r688, r83, r692
+  Index        r693, r616, r679
+  Index        r694, r693, r70
+  Append       r695, r694, r677
+  SetIndex     r693, r70, r695
+  Index        r696, r693, r72
+  AddInt       r697, r696, r88
+  SetIndex     r693, r72, r697
 L80:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  AddInt       r650, r650, r85
+  AddInt       r653, r653, r88
   Jump         L83
 L79:
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  AddInt       r640, r640, r85
+  AddInt       r643, r643, r88
   Jump         L84
 L78:
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  AddInt       r625, r625, r85
+  AddInt       r627, r627, r88
   Jump         L85
 L76:
   // from wr in web_returns
-  AddInt       r619, r619, r85
+  AddInt       r621, r621, r88
   Jump         L86
 L75:
-  Move         r693, r88
-  Len          r694, r615
+  Move         r698, r73
+  Len          r699, r617
 L92:
-  LessInt      r695, r693, r694
-  JumpIfFalse  r695, L87
-  Index        r92, r615, r693
+  LessInt      r700, r698, r699
+  JumpIfFalse  r700, L87
+  Index        r701, r617, r698
+  Move         r94, r701
   // channel: "web channel",
-  Const        r697, "channel"
+  Const        r702, "channel"
   // id: "web_site" + str(g.key),
-  Const        r698, "id"
-  Index        r699, r92, r6
-  Str          r700, r699
-  Add          r701, r568, r700
+  Const        r703, "id"
+  Index        r704, r94, r6
+  Str          r705, r704
+  Add          r706, r570, r705
   // sales: 0.0,
-  Const        r702, "sales"
+  Const        r707, "sales"
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Const        r703, "returns"
-  Const        r704, []
-  IterPrep     r705, r92
-  Len          r706, r705
-  Move         r707, r88
+  Const        r708, "returns"
+  Const        r709, []
+  IterPrep     r710, r94
+  Len          r711, r710
+  Move         r712, r73
 L89:
-  LessInt      r708, r707, r706
-  JumpIfFalse  r708, L88
-  Index        r107, r705, r707
-  Index        r710, r107, r611
-  Index        r711, r710, r612
-  Append       r704, r704, r711
-  AddInt       r707, r707, r85
+  LessInt      r713, r712, r711
+  JumpIfFalse  r713, L88
+  Index        r714, r710, r712
+  Move         r109, r714
+  Index        r715, r109, r613
+  Index        r716, r715, r614
+  Append       r717, r709, r716
+  Move         r709, r717
+  AddInt       r712, r712, r88
   Jump         L89
 L88:
-  Sum          r713, r704
+  Sum          r718, r709
   // profit: 0.0,
-  Const        r714, "profit"
+  Const        r719, "profit"
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Const        r715, "profit_loss"
-  Const        r716, []
-  IterPrep     r717, r92
-  Len          r718, r717
-  Move         r719, r88
+  Const        r720, "profit_loss"
+  Const        r721, []
+  IterPrep     r722, r94
+  Len          r723, r722
+  Move         r724, r73
 L91:
-  LessInt      r720, r719, r718
-  JumpIfFalse  r720, L90
-  Index        r107, r717, r719
-  Index        r722, r107, r611
-  Index        r723, r722, r613
-  Append       r716, r716, r723
-  AddInt       r719, r719, r85
+  LessInt      r725, r724, r723
+  JumpIfFalse  r725, L90
+  Index        r726, r722, r724
+  Move         r109, r726
+  Index        r727, r109, r613
+  Index        r728, r727, r615
+  Append       r729, r721, r728
+  Move         r721, r729
+  AddInt       r724, r724, r88
   Jump         L91
 L90:
-  Sum          r725, r716
+  Sum          r730, r721
   // channel: "web channel",
-  Move         r726, r697
-  Move         r727, r566
+  Move         r731, r702
+  Move         r732, r568
   // id: "web_site" + str(g.key),
-  Move         r728, r698
-  Move         r729, r701
+  Move         r733, r703
+  Move         r734, r706
   // sales: 0.0,
-  Move         r730, r702
-  Move         r731, r113
+  Move         r735, r707
+  Move         r736, r115
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Move         r732, r703
-  Move         r733, r713
+  Move         r737, r708
+  Move         r738, r718
   // profit: 0.0,
-  Move         r734, r714
-  Move         r735, r113
+  Move         r739, r719
+  Move         r740, r115
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Move         r736, r715
-  Move         r737, r725
+  Move         r741, r720
+  Move         r742, r730
   // select {
-  MakeMap      r738, 6, r726
+  MakeMap      r743, 6, r731
   // from wr in web_returns
-  Append       r610, r610, r738
-  AddInt       r693, r693, r85
+  Append       r744, r612, r743
+  Move         r612, r744
+  AddInt       r698, r698, r88
   Jump         L92
 L87:
   // let per_channel = concat(ss union all sr, cs union all cr, ws union all wr)
-  UnionAll     r740, r1, r140
-  UnionAll     r741, r255, r375
-  UnionAll     r742, r740, r741
-  UnionAll     r743, r490, r610
-  UnionAll     r744, r742, r743
+  UnionAll     r745, r1, r142
+  UnionAll     r746, r257, r377
+  UnionAll     r747, r745, r746
+  UnionAll     r748, r492, r612
+  UnionAll     r749, r747, r748
   // from p in per_channel
-  Const        r745, []
+  Const        r750, []
   // sales: sum(from x in g select x.p.sales),
-  Const        r746, "p"
+  Const        r751, "p"
   // from p in per_channel
-  IterPrep     r747, r744
-  Len          r748, r747
-  Const        r749, 0
-  MakeMap      r750, 0, r0
-  Const        r751, []
+  IterPrep     r752, r749
+  Len          r753, r752
+  Const        r754, 0
+  MakeMap      r755, 0, r0
+  Const        r757, []
+  Move         r756, r757
 L95:
-  LessInt      r753, r749, r748
-  JumpIfFalse  r753, L93
-  Index        r754, r747, r749
-  Move         r755, r754
+  LessInt      r758, r754, r753
+  JumpIfFalse  r758, L93
+  Index        r759, r752, r754
+  Move         r760, r759
   // group by { channel: p.channel, id: p.id } into g
-  Const        r756, "channel"
-  Index        r757, r755, r4
-  Const        r758, "id"
-  Index        r759, r755, r5
-  Move         r760, r756
-  Move         r761, r757
-  Move         r762, r758
-  Move         r763, r759
-  MakeMap      r764, 2, r760
-  Str          r765, r764
-  In           r766, r765, r750
-  JumpIfTrue   r766, L94
+  Const        r761, "channel"
+  Index        r762, r760, r4
+  Const        r763, "id"
+  Index        r764, r760, r5
+  Move         r765, r761
+  Move         r766, r762
+  Move         r767, r763
+  Move         r768, r764
+  MakeMap      r769, 2, r765
+  Str          r770, r769
+  In           r771, r770, r755
+  JumpIfTrue   r771, L94
+  Move         r772, r769
   // from p in per_channel
-  Const        r767, []
-  Const        r768, "__group__"
-  Const        r769, true
-  Const        r770, "key"
-  // group by { channel: p.channel, id: p.id } into g
-  Move         r771, r764
-  // from p in per_channel
-  Const        r772, "items"
-  Move         r773, r767
-  Const        r774, "count"
-  Const        r775, 0
-  Move         r776, r768
-  Move         r777, r769
-  Move         r778, r770
-  Move         r779, r771
-  Move         r780, r772
-  Move         r781, r773
-  Move         r782, r774
-  Move         r783, r775
-  MakeMap      r784, 4, r776
-  SetIndex     r750, r765, r784
-  Append       r751, r751, r784
+  Move         r773, r0
+  Move         r774, r67
+  Move         r775, r68
+  Move         r776, r6
+  Move         r777, r772
+  Move         r778, r70
+  Move         r779, r773
+  Move         r780, r72
+  Move         r781, r73
+  MakeMap      r782, 4, r774
+  SetIndex     r755, r770, r782
+  Append       r783, r756, r782
+  Move         r756, r783
 L94:
-  Index        r786, r750, r765
-  Index        r787, r786, r79
-  Append       r788, r787, r754
-  SetIndex     r786, r79, r788
-  Index        r789, r786, r83
-  AddInt       r790, r789, r85
-  SetIndex     r786, r83, r790
-  AddInt       r749, r749, r85
+  Index        r784, r755, r770
+  Index        r785, r784, r70
+  Append       r786, r785, r759
+  SetIndex     r784, r70, r786
+  Index        r787, r784, r72
+  AddInt       r788, r787, r88
+  SetIndex     r784, r72, r788
+  AddInt       r754, r754, r88
   Jump         L95
 L93:
-  Move         r791, r88
-  Len          r792, r751
+  Move         r789, r73
+  Len          r790, r756
 L105:
-  LessInt      r793, r791, r792
-  JumpIfFalse  r793, L96
-  Index        r92, r751, r791
+  LessInt      r791, r789, r790
+  JumpIfFalse  r791, L96
+  Index        r792, r756, r789
+  Move         r94, r792
   // channel: g.key.channel,
-  Const        r795, "channel"
-  Index        r796, r92, r6
-  Index        r797, r796, r4
+  Const        r793, "channel"
+  Index        r794, r94, r6
+  Index        r795, r794, r4
   // id: g.key.id,
-  Const        r798, "id"
-  Index        r799, r92, r6
-  Index        r800, r799, r5
+  Const        r796, "id"
+  Index        r797, r94, r6
+  Index        r798, r797, r5
   // sales: sum(from x in g select x.p.sales),
-  Const        r801, "sales"
-  Const        r802, []
-  IterPrep     r803, r92
-  Len          r804, r803
-  Move         r805, r88
+  Const        r799, "sales"
+  Const        r800, []
+  IterPrep     r801, r94
+  Len          r802, r801
+  Move         r803, r73
 L98:
-  LessInt      r806, r805, r804
-  JumpIfFalse  r806, L97
-  Index        r107, r803, r805
-  Index        r808, r107, r746
-  Index        r809, r808, r7
-  Append       r802, r802, r809
-  AddInt       r805, r805, r85
+  LessInt      r804, r803, r802
+  JumpIfFalse  r804, L97
+  Index        r805, r801, r803
+  Move         r109, r805
+  Index        r806, r109, r751
+  Index        r807, r806, r7
+  Append       r808, r800, r807
+  Move         r800, r808
+  AddInt       r803, r803, r88
   Jump         L98
 L97:
-  Sum          r811, r802
+  Sum          r809, r800
   // returns: sum(from x in g select x.p.returns),
-  Const        r812, "returns"
-  Const        r813, []
-  IterPrep     r814, r92
-  Len          r815, r814
-  Move         r816, r88
+  Const        r810, "returns"
+  Const        r811, []
+  IterPrep     r812, r94
+  Len          r813, r812
+  Move         r814, r73
 L100:
-  LessInt      r817, r816, r815
-  JumpIfFalse  r817, L99
-  Index        r107, r814, r816
-  Index        r819, r107, r746
-  Index        r820, r819, r10
-  Append       r813, r813, r820
-  AddInt       r816, r816, r85
+  LessInt      r815, r814, r813
+  JumpIfFalse  r815, L99
+  Index        r816, r812, r814
+  Move         r109, r816
+  Index        r817, r109, r751
+  Index        r818, r817, r10
+  Append       r819, r811, r818
+  Move         r811, r819
+  AddInt       r814, r814, r88
   Jump         L100
 L99:
-  Sum          r822, r813
+  Sum          r820, r811
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Const        r823, "profit"
-  Const        r824, []
-  IterPrep     r825, r92
-  Len          r826, r825
-  Move         r827, r88
+  Const        r821, "profit"
+  Const        r822, []
+  IterPrep     r823, r94
+  Len          r824, r823
+  Move         r825, r73
 L102:
-  LessInt      r828, r827, r826
-  JumpIfFalse  r828, L101
-  Index        r107, r825, r827
-  Index        r830, r107, r746
-  Index        r831, r830, r11
-  Append       r824, r824, r831
-  AddInt       r827, r827, r85
+  LessInt      r826, r825, r824
+  JumpIfFalse  r826, L101
+  Index        r827, r823, r825
+  Move         r109, r827
+  Index        r828, r109, r751
+  Index        r829, r828, r11
+  Append       r830, r822, r829
+  Move         r822, r830
+  AddInt       r825, r825, r88
   Jump         L102
 L101:
-  Sum          r833, r824
-  Const        r834, []
-  IterPrep     r835, r92
-  Len          r836, r835
-  Move         r837, r88
+  Sum          r831, r822
+  Const        r832, []
+  IterPrep     r833, r94
+  Len          r834, r833
+  Move         r835, r73
 L104:
-  LessInt      r838, r837, r836
-  JumpIfFalse  r838, L103
-  Index        r107, r835, r837
-  Index        r840, r107, r746
-  Index        r841, r840, r13
-  Append       r834, r834, r841
-  AddInt       r837, r837, r85
+  LessInt      r836, r835, r834
+  JumpIfFalse  r836, L103
+  Index        r837, r833, r835
+  Move         r109, r837
+  Index        r838, r109, r751
+  Index        r839, r838, r13
+  Append       r840, r832, r839
+  Move         r832, r840
+  AddInt       r835, r835, r88
   Jump         L104
 L103:
-  Sum          r843, r834
-  Sub          r844, r833, r843
+  Sum          r841, r832
+  Sub          r842, r831, r841
   // channel: g.key.channel,
-  Move         r845, r795
-  Move         r846, r797
+  Move         r843, r793
+  Move         r844, r795
   // id: g.key.id,
-  Move         r847, r798
-  Move         r848, r800
+  Move         r845, r796
+  Move         r846, r798
   // sales: sum(from x in g select x.p.sales),
-  Move         r849, r801
-  Move         r850, r811
+  Move         r847, r799
+  Move         r848, r809
   // returns: sum(from x in g select x.p.returns),
-  Move         r851, r812
-  Move         r852, r822
+  Move         r849, r810
+  Move         r850, r820
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Move         r853, r823
-  Move         r854, r844
+  Move         r851, r821
+  Move         r852, r842
   // select {
-  MakeMap      r855, 5, r845
+  MakeMap      r853, 5, r843
   // sort by g.key.channel
-  Index        r856, r92, r6
-  Index        r858, r856, r4
+  Index        r854, r94, r6
+  Index        r855, r854, r4
+  Move         r856, r855
   // from p in per_channel
-  Move         r859, r855
-  MakeList     r860, 2, r858
-  Append       r745, r745, r860
-  AddInt       r791, r791, r85
+  Move         r857, r853
+  MakeList     r858, 2, r856
+  Append       r859, r750, r858
+  Move         r750, r859
+  AddInt       r789, r789, r88
   Jump         L105
 L96:
   // sort by g.key.channel
-  Sort         r745, r745
+  Sort         r860, r750
+  // from p in per_channel
+  Move         r750, r860
   // json(result)
-  JSON         r745
+  JSON         r750
   // expect len(result) == 0
-  Len          r863, r745
-  EqualInt     r864, r863, r88
-  Expect       r864
+  Len          r861, r750
+  EqualInt     r862, r861, r73
+  Expect       r862
   Return       r0

--- a/tests/dataset/tpc-ds/out/q6.ir.out
+++ b/tests/dataset/tpc-ds/out/q6.ir.out
@@ -1,4 +1,4 @@
-func main (regs=172)
+func main (regs=179)
   // let customer_address = []
   Const        r0, []
   // from d in date_dim
@@ -16,7 +16,8 @@ func main (regs=172)
 L3:
   LessInt      r9, r7, r6
   JumpIfFalse  r9, L0
-  Index        r11, r5, r7
+  Index        r10, r5, r7
+  Move         r11, r10
   // where d.d_year == 1999 && d.d_moy == 5
   Index        r12, r11, r2
   Const        r13, 1999
@@ -24,252 +25,275 @@ L3:
   Index        r15, r11, r3
   Const        r16, 5
   Equal        r17, r15, r16
-  JumpIfFalse  r14, L1
-  Move         r14, r17
+  Move         r18, r14
+  JumpIfFalse  r18, L1
+  Move         r18, r17
 L1:
-  JumpIfFalse  r14, L2
+  JumpIfFalse  r18, L2
   // select d.d_month_seq
-  Index        r18, r11, r4
+  Index        r19, r11, r4
   // from d in date_dim
-  Append       r1, r1, r18
+  Append       r20, r1, r19
+  Move         r1, r20
 L2:
-  Const        r20, 1
-  AddInt       r7, r7, r20
+  Const        r21, 1
+  AddInt       r7, r7, r21
   Jump         L3
 L0:
   // let target_month_seq = max(
-  Max          r21, r1
+  Max          r22, r1
   // from a in customer_address
-  Const        r22, []
+  Const        r23, []
   // group by a.ca_state into g
-  Const        r23, "ca_state"
+  Const        r24, "ca_state"
   // i.i_current_price > 1.2 * avg(
-  Const        r24, "i_current_price"
+  Const        r25, "i_current_price"
   // where j.i_category == i.i_category
-  Const        r25, "i_category"
+  Const        r26, "i_category"
   // select { state: g.key, cnt: count(g) }
-  Const        r26, "state"
-  Const        r27, "key"
-  Const        r28, "cnt"
+  Const        r27, "state"
+  Const        r28, "key"
+  Const        r29, "cnt"
   // from a in customer_address
-  MakeMap      r29, 0, r0
-  Const        r30, []
-  IterPrep     r32, r0
-  Len          r33, r32
-  Const        r34, 0
+  MakeMap      r30, 0, r0
+  Const        r32, []
+  Move         r31, r32
+  IterPrep     r33, r0
+  Len          r34, r33
+  Const        r35, 0
 L19:
-  LessInt      r35, r34, r33
-  JumpIfFalse  r35, L4
-  Index        r37, r32, r34
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L4
+  Index        r37, r33, r35
+  Move         r38, r37
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  IterPrep     r38, r0
-  Len          r39, r38
-  Const        r40, 0
+  IterPrep     r39, r0
+  Len          r40, r39
+  Const        r41, 0
 L18:
-  LessInt      r41, r40, r39
-  JumpIfFalse  r41, L5
-  Index        r43, r38, r40
-  Const        r44, "ca_address_sk"
-  Index        r45, r37, r44
-  Const        r46, "c_current_addr_sk"
-  Index        r47, r43, r46
-  Equal        r48, r45, r47
-  JumpIfFalse  r48, L6
+  LessInt      r42, r41, r40
+  JumpIfFalse  r42, L5
+  Index        r43, r39, r41
+  Move         r44, r43
+  Const        r45, "ca_address_sk"
+  Index        r46, r38, r45
+  Const        r47, "c_current_addr_sk"
+  Index        r48, r44, r47
+  Equal        r49, r46, r48
+  JumpIfFalse  r49, L6
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  IterPrep     r49, r0
-  Len          r50, r49
-  Const        r51, 0
+  IterPrep     r50, r0
+  Len          r51, r50
+  Const        r52, 0
 L17:
-  LessInt      r52, r51, r50
-  JumpIfFalse  r52, L6
-  Index        r54, r49, r51
-  Const        r55, "c_customer_sk"
-  Index        r56, r43, r55
-  Const        r57, "ss_customer_sk"
-  Index        r58, r54, r57
-  Equal        r59, r56, r58
-  JumpIfFalse  r59, L7
+  LessInt      r53, r52, r51
+  JumpIfFalse  r53, L6
+  Index        r54, r50, r52
+  Move         r55, r54
+  Const        r56, "c_customer_sk"
+  Index        r57, r44, r56
+  Const        r58, "ss_customer_sk"
+  Index        r59, r55, r58
+  Equal        r60, r57, r59
+  JumpIfFalse  r60, L7
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r60, r0
-  Len          r61, r60
-  Const        r62, 0
+  IterPrep     r61, r0
+  Len          r62, r61
+  Const        r63, 0
 L16:
-  LessInt      r63, r62, r61
-  JumpIfFalse  r63, L7
-  Index        r11, r60, r62
-  Const        r65, "ss_sold_date_sk"
-  Index        r66, r54, r65
-  Const        r67, "d_date_sk"
-  Index        r68, r11, r67
-  Equal        r69, r66, r68
-  JumpIfFalse  r69, L8
+  LessInt      r64, r63, r62
+  JumpIfFalse  r64, L7
+  Index        r65, r61, r63
+  Move         r11, r65
+  Const        r66, "ss_sold_date_sk"
+  Index        r67, r55, r66
+  Const        r68, "d_date_sk"
+  Index        r69, r11, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L8
   // join i in item on s.ss_item_sk == i.i_item_sk
-  IterPrep     r70, r0
-  Len          r71, r70
-  Const        r72, 0
+  IterPrep     r71, r0
+  Len          r72, r71
+  Const        r73, 0
 L15:
-  LessInt      r73, r72, r71
-  JumpIfFalse  r73, L8
-  Index        r75, r70, r72
-  Const        r76, "ss_item_sk"
-  Index        r77, r54, r76
-  Const        r78, "i_item_sk"
-  Index        r79, r75, r78
-  Equal        r80, r77, r79
-  JumpIfFalse  r80, L9
+  LessInt      r74, r73, r72
+  JumpIfFalse  r74, L8
+  Index        r75, r71, r73
+  Move         r76, r75
+  Const        r77, "ss_item_sk"
+  Index        r78, r55, r77
+  Const        r79, "i_item_sk"
+  Index        r80, r76, r79
+  Equal        r81, r78, r80
+  JumpIfFalse  r81, L9
   // where d.d_month_seq == target_month_seq &&
-  Index        r81, r11, r4
+  Index        r82, r11, r4
   // i.i_current_price > 1.2 * avg(
-  Const        r82, 1.2
+  Const        r83, 1.2
   // from j in item
-  Const        r83, []
-  IterPrep     r84, r0
-  Len          r85, r84
-  Move         r86, r8
+  Const        r84, []
+  IterPrep     r85, r0
+  Len          r86, r85
+  Move         r87, r8
 L12:
-  LessInt      r87, r86, r85
-  JumpIfFalse  r87, L10
-  Index        r89, r84, r86
+  LessInt      r88, r87, r86
+  JumpIfFalse  r88, L10
+  Index        r89, r85, r87
+  Move         r90, r89
   // where j.i_category == i.i_category
-  Index        r90, r89, r25
-  Index        r91, r75, r25
-  Equal        r92, r90, r91
-  JumpIfFalse  r92, L11
+  Index        r91, r90, r26
+  Index        r92, r76, r26
+  Equal        r93, r91, r92
+  JumpIfFalse  r93, L11
   // select j.i_current_price
-  Index        r93, r89, r24
+  Index        r94, r90, r25
   // from j in item
-  Append       r83, r83, r93
+  Append       r95, r84, r94
+  Move         r84, r95
 L11:
-  AddInt       r86, r86, r20
+  AddInt       r87, r87, r21
   Jump         L12
 L10:
   // i.i_current_price > 1.2 * avg(
-  Avg          r95, r83
-  MulFloat     r96, r82, r95
-  Index        r97, r75, r24
-  LessFloat    r98, r96, r97
+  Avg          r96, r84
+  MulFloat     r97, r83, r96
+  Index        r98, r76, r25
+  LessFloat    r99, r97, r98
   // where d.d_month_seq == target_month_seq &&
-  Equal        r99, r81, r21
-  JumpIfFalse  r99, L13
-  Move         r99, r98
+  Equal        r100, r82, r22
+  Move         r101, r100
+  JumpIfFalse  r101, L13
+  Move         r101, r99
 L13:
-  JumpIfFalse  r99, L9
+  JumpIfFalse  r101, L9
   // from a in customer_address
-  Const        r100, "a"
-  Move         r101, r37
-  Const        r102, "c"
-  Move         r103, r43
-  Const        r104, "s"
-  Move         r105, r54
-  Const        r106, "d"
-  Move         r107, r11
-  Const        r108, "i"
-  Move         r109, r75
-  MakeMap      r110, 5, r100
+  Const        r102, "a"
+  Move         r103, r38
+  Const        r104, "c"
+  Move         r105, r44
+  Const        r106, "s"
+  Move         r107, r55
+  Const        r108, "d"
+  Move         r109, r11
+  Const        r110, "i"
+  Move         r111, r76
+  Move         r112, r102
+  Move         r113, r103
+  Move         r114, r104
+  Move         r115, r105
+  Move         r116, r106
+  Move         r117, r107
+  Move         r118, r108
+  Move         r119, r109
+  Move         r120, r110
+  Move         r121, r111
+  MakeMap      r122, 5, r112
   // group by a.ca_state into g
-  Index        r111, r37, r23
-  Str          r112, r111
-  In           r113, r112, r29
-  JumpIfTrue   r113, L14
+  Index        r123, r38, r24
+  Str          r124, r123
+  In           r125, r124, r30
+  JumpIfTrue   r125, L14
   // from a in customer_address
-  Const        r114, []
-  Const        r115, "__group__"
-  Const        r116, true
-  Const        r117, "key"
+  Const        r126, "__group__"
+  Const        r127, true
   // group by a.ca_state into g
-  Move         r118, r111
+  Move         r128, r123
   // from a in customer_address
-  Const        r119, "items"
-  Move         r120, r114
-  Const        r121, "count"
-  Const        r122, 0
-  Move         r123, r115
-  Move         r124, r116
-  Move         r125, r117
-  Move         r126, r118
-  Move         r127, r119
-  Move         r128, r120
-  Move         r129, r121
-  Move         r130, r122
-  MakeMap      r131, 4, r123
-  SetIndex     r29, r112, r131
-  Append       r30, r30, r131
+  Const        r129, "items"
+  Move         r130, r0
+  Const        r131, "count"
+  Move         r132, r126
+  Move         r133, r127
+  Move         r134, r28
+  Move         r135, r128
+  Move         r136, r129
+  Move         r137, r130
+  Move         r138, r131
+  Move         r139, r8
+  MakeMap      r140, 4, r132
+  SetIndex     r30, r124, r140
+  Append       r141, r31, r140
+  Move         r31, r141
 L14:
-  Const        r133, "items"
-  Index        r134, r29, r112
-  Index        r135, r134, r133
-  Append       r136, r135, r110
-  SetIndex     r134, r133, r136
-  Const        r137, "count"
-  Index        r138, r134, r137
-  AddInt       r139, r138, r20
-  SetIndex     r134, r137, r139
+  Index        r142, r30, r124
+  Index        r143, r142, r129
+  Append       r144, r143, r122
+  SetIndex     r142, r129, r144
+  Index        r145, r142, r131
+  AddInt       r146, r145, r21
+  SetIndex     r142, r131, r146
 L9:
   // join i in item on s.ss_item_sk == i.i_item_sk
-  AddInt       r72, r72, r20
+  AddInt       r73, r73, r21
   Jump         L15
 L8:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  AddInt       r62, r62, r20
+  AddInt       r63, r63, r21
   Jump         L16
 L7:
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  AddInt       r51, r51, r20
+  AddInt       r52, r52, r21
   Jump         L17
 L6:
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  AddInt       r40, r40, r20
+  AddInt       r41, r41, r21
   Jump         L18
 L5:
   // from a in customer_address
-  AddInt       r34, r34, r20
+  AddInt       r35, r35, r21
   Jump         L19
 L4:
-  Move         r140, r8
-  Len          r141, r30
+  Move         r147, r8
+  Len          r148, r31
 L21:
-  LessInt      r142, r140, r141
-  JumpIfFalse  r142, L20
-  Index        r144, r30, r140
+  LessInt      r149, r147, r148
+  JumpIfFalse  r149, L20
+  Index        r150, r31, r147
+  Move         r151, r150
   // having count(g) >= 10
-  Index        r145, r144, r137
-  Const        r146, 10
-  LessEq       r147, r146, r145
-  JumpIfFalse  r147, L20
+  Index        r152, r151, r131
+  Const        r153, 10
+  LessEq       r154, r153, r152
+  JumpIfFalse  r154, L20
   // select { state: g.key, cnt: count(g) }
-  Const        r148, "state"
-  Index        r149, r144, r27
-  Const        r150, "cnt"
-  Index        r151, r144, r137
-  Move         r152, r148
-  Move         r153, r149
-  Move         r154, r150
-  Move         r155, r151
-  MakeMap      r156, 2, r152
+  Const        r155, "state"
+  Index        r156, r151, r28
+  Const        r157, "cnt"
+  Index        r158, r151, r131
+  Move         r159, r155
+  Move         r160, r156
+  Move         r161, r157
+  Move         r162, r158
+  MakeMap      r163, 2, r159
   // sort by [count(g), g.key]
-  Index        r158, r144, r137
-  Index        r159, r144, r27
-  Move         r160, r159
-  MakeList     r162, 2, r158
+  Index        r164, r151, r131
+  Move         r165, r164
+  Index        r166, r151, r28
+  Move         r167, r166
+  MakeList     r168, 2, r165
+  Move         r169, r168
   // from a in customer_address
-  Move         r163, r156
-  MakeList     r164, 2, r162
-  Append       r22, r22, r164
-  AddInt       r140, r140, r20
+  Move         r170, r163
+  MakeList     r171, 2, r169
+  Append       r172, r23, r171
+  Move         r23, r172
+  AddInt       r147, r147, r21
   Jump         L21
 L20:
   // sort by [count(g), g.key]
-  Sort         r22, r22
+  Sort         r173, r23
   // from a in customer_address
-  Const        r167, 0
+  Move         r23, r173
+  Const        r174, 0
   // take 100
-  Const        r168, 100
+  Const        r175, 100
   // from a in customer_address
-  Slice        r22, r22, r167, r168
+  Slice        r176, r23, r174, r175
+  Move         r23, r176
   // json(result)
-  JSON         r22
+  JSON         r23
   // expect len(result) == 0
-  Len          r170, r22
-  EqualInt     r171, r170, r8
-  Expect       r171
+  Len          r177, r23
+  EqualInt     r178, r177, r8
+  Expect       r178
   Return       r0

--- a/tests/dataset/tpc-ds/out/q7.ir.out
+++ b/tests/dataset/tpc-ds/out/q7.ir.out
@@ -1,4 +1,4 @@
-func main (regs=207)
+func main (regs=217)
   // let store_sales = []
   Const        r0, []
   // from ss in store_sales
@@ -33,22 +33,25 @@ func main (regs=207)
   Const        r18, "ss_sales_price"
   // from ss in store_sales
   MakeMap      r19, 0, r0
-  Const        r20, []
+  Const        r21, []
+  Move         r20, r21
   IterPrep     r22, r0
   Len          r23, r22
   Const        r24, 0
-L13:
+L16:
   LessInt      r25, r24, r23
   JumpIfFalse  r25, L0
-  Index        r27, r22, r24
+  Index        r26, r22, r24
+  Move         r27, r26
   // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
   IterPrep     r28, r0
   Len          r29, r28
   Const        r30, 0
-L12:
+L15:
   LessInt      r31, r30, r29
   JumpIfFalse  r31, L1
-  Index        r33, r28, r30
+  Index        r32, r28, r30
+  Move         r33, r32
   Const        r34, "ss_cdemo_sk"
   Index        r35, r27, r34
   Const        r36, "cd_demo_sk"
@@ -59,10 +62,11 @@ L12:
   IterPrep     r39, r0
   Len          r40, r39
   Const        r41, 0
-L11:
+L14:
   LessInt      r42, r41, r40
   JumpIfFalse  r42, L2
-  Index        r44, r39, r41
+  Index        r43, r39, r41
+  Move         r44, r43
   Const        r45, "ss_sold_date_sk"
   Index        r46, r27, r45
   Const        r47, "d_date_sk"
@@ -73,10 +77,11 @@ L11:
   IterPrep     r50, r0
   Len          r51, r50
   Const        r52, 0
-L10:
+L13:
   LessInt      r53, r52, r51
   JumpIfFalse  r53, L3
-  Index        r55, r50, r52
+  Index        r54, r50, r52
+  Move         r55, r54
   Const        r56, "ss_item_sk"
   Index        r57, r27, r56
   Const        r58, "i_item_sk"
@@ -87,10 +92,11 @@ L10:
   IterPrep     r61, r0
   Len          r62, r61
   Const        r63, 0
-L9:
+L12:
   LessInt      r64, r63, r62
   JumpIfFalse  r64, L4
-  Index        r66, r61, r63
+  Index        r65, r61, r63
+  Move         r66, r65
   Const        r67, "ss_promo_sk"
   Index        r68, r27, r67
   Const        r69, "p_promo_sk"
@@ -114,216 +120,243 @@ L9:
   Const        r82, 1998
   Equal        r83, r81, r82
   // where cd.cd_gender == "M" &&
-  JumpIfFalse  r74, L6
-  Move         r74, r77
-  // cd.cd_marital_status == "S" &&
-  JumpIfFalse  r74, L6
-  Move         r74, r80
-  // cd.cd_education_status == "College" &&
-  JumpIfFalse  r74, L6
-  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  Index        r84, r66, r6
-  Const        r85, "N"
-  Equal        r86, r84, r85
-  Index        r87, r66, r7
-  Equal        r88, r87, r85
-  JumpIfTrue   r86, L7
-L7:
-  // cd.cd_education_status == "College" &&
-  Move         r74, r88
-  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  JumpIfFalse  r74, L6
-  Move         r74, r83
+  Move         r84, r74
+  JumpIfFalse  r84, L6
+  Move         r84, r77
 L6:
-  // where cd.cd_gender == "M" &&
-  JumpIfFalse  r74, L5
-  // from ss in store_sales
-  Move         r89, r27
-  Const        r90, "cd"
-  Move         r91, r33
-  Const        r92, "d"
-  Move         r93, r44
-  Const        r94, "i"
-  Move         r95, r55
-  Const        r96, "p"
-  Move         r97, r66
-  MakeMap      r98, 5, r11
-  // group by { i_item_id: i.i_item_id } into g
-  Const        r99, "i_item_id"
-  Index        r100, r55, r2
-  Move         r101, r99
-  Move         r102, r100
-  MakeMap      r103, 1, r101
-  Str          r104, r103
-  In           r105, r104, r19
-  JumpIfTrue   r105, L8
-  // from ss in store_sales
-  Const        r106, []
-  Const        r107, "__group__"
-  Const        r108, true
-  Const        r109, "key"
-  // group by { i_item_id: i.i_item_id } into g
-  Move         r110, r103
-  // from ss in store_sales
-  Const        r111, "items"
-  Move         r112, r106
-  Const        r113, "count"
-  Const        r114, 0
-  Move         r115, r107
-  Move         r116, r108
-  Move         r117, r109
-  Move         r118, r110
-  Move         r119, r111
-  Move         r120, r112
-  Move         r121, r113
-  Move         r122, r114
-  MakeMap      r123, 4, r115
-  SetIndex     r19, r104, r123
-  Append       r20, r20, r123
+  // cd.cd_marital_status == "S" &&
+  Move         r85, r84
+  JumpIfFalse  r85, L7
+  Move         r85, r80
+L7:
+  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
+  Index        r86, r66, r6
+  Const        r87, "N"
+  Equal        r88, r86, r87
+  Index        r89, r66, r7
+  Equal        r90, r89, r87
+  Move         r91, r88
+  JumpIfTrue   r91, L8
+  Move         r91, r90
 L8:
-  Const        r125, "items"
-  Index        r126, r19, r104
-  Index        r127, r126, r125
-  Append       r128, r127, r98
-  SetIndex     r126, r125, r128
-  Const        r129, "count"
-  Index        r130, r126, r129
-  Const        r131, 1
-  AddInt       r132, r130, r131
-  SetIndex     r126, r129, r132
+  // cd.cd_education_status == "College" &&
+  Move         r92, r85
+  JumpIfFalse  r92, L9
+  Move         r92, r91
+L9:
+  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
+  Move         r93, r92
+  JumpIfFalse  r93, L10
+  Move         r93, r83
+L10:
+  // where cd.cd_gender == "M" &&
+  JumpIfFalse  r93, L5
+  // from ss in store_sales
+  Move         r94, r27
+  Const        r95, "cd"
+  Move         r96, r33
+  Const        r97, "d"
+  Move         r98, r44
+  Const        r99, "i"
+  Move         r100, r55
+  Const        r101, "p"
+  Move         r102, r66
+  Move         r103, r11
+  Move         r104, r94
+  Move         r105, r95
+  Move         r106, r96
+  Move         r107, r97
+  Move         r108, r98
+  Move         r109, r99
+  Move         r110, r100
+  Move         r111, r101
+  Move         r112, r102
+  MakeMap      r113, 5, r103
+  // group by { i_item_id: i.i_item_id } into g
+  Const        r114, "i_item_id"
+  Index        r115, r55, r2
+  Move         r116, r114
+  Move         r117, r115
+  MakeMap      r118, 1, r116
+  Str          r119, r118
+  In           r120, r119, r19
+  JumpIfTrue   r120, L11
+  // from ss in store_sales
+  Const        r121, "__group__"
+  Const        r122, true
+  // group by { i_item_id: i.i_item_id } into g
+  Move         r123, r118
+  // from ss in store_sales
+  Const        r124, "items"
+  Move         r125, r0
+  Const        r126, "count"
+  Const        r127, 0
+  Move         r128, r121
+  Move         r129, r122
+  Move         r130, r9
+  Move         r131, r123
+  Move         r132, r124
+  Move         r133, r125
+  Move         r134, r126
+  Move         r135, r127
+  MakeMap      r136, 4, r128
+  SetIndex     r19, r119, r136
+  Append       r137, r20, r136
+  Move         r20, r137
+L11:
+  Index        r138, r19, r119
+  Index        r139, r138, r124
+  Append       r140, r139, r113
+  SetIndex     r138, r124, r140
+  Index        r141, r138, r126
+  Const        r142, 1
+  AddInt       r143, r141, r142
+  SetIndex     r138, r126, r143
 L5:
   // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
-  AddInt       r63, r63, r131
-  Jump         L9
+  AddInt       r63, r63, r142
+  Jump         L12
 L4:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r52, r52, r131
-  Jump         L10
+  AddInt       r52, r52, r142
+  Jump         L13
 L3:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r41, r41, r131
-  Jump         L11
+  AddInt       r41, r41, r142
+  Jump         L14
 L2:
   // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
-  AddInt       r30, r30, r131
-  Jump         L12
+  AddInt       r30, r30, r142
+  Jump         L15
 L1:
   // from ss in store_sales
-  AddInt       r24, r24, r131
-  Jump         L13
-L0:
-  Const        r134, 0
-  Move         r133, r134
-  Len          r135, r20
-L23:
-  LessInt      r136, r133, r135
-  JumpIfFalse  r136, L14
-  Index        r138, r20, r133
-  // i_item_id: g.key.i_item_id,
-  Const        r139, "i_item_id"
-  Index        r140, r138, r9
-  Index        r141, r140, r2
-  // agg1: avg(from x in g select x.ss.ss_quantity),
-  Const        r142, "agg1"
-  Const        r143, []
-  IterPrep     r144, r138
-  Len          r145, r144
-  Move         r146, r134
-L16:
-  LessInt      r147, r146, r145
-  JumpIfFalse  r147, L15
-  Index        r149, r144, r146
-  Index        r150, r149, r11
-  Index        r151, r150, r12
-  Append       r143, r143, r151
-  AddInt       r146, r146, r131
+  AddInt       r24, r24, r142
   Jump         L16
-L15:
-  Avg          r153, r143
-  // agg2: avg(from x in g select x.ss.ss_list_price),
-  Const        r154, "agg2"
-  Const        r155, []
-  IterPrep     r156, r138
-  Len          r157, r156
-  Move         r158, r134
-L18:
-  LessInt      r159, r158, r157
-  JumpIfFalse  r159, L17
-  Index        r149, r156, r158
-  Index        r161, r149, r11
-  Index        r162, r161, r14
-  Append       r155, r155, r162
-  AddInt       r158, r158, r131
-  Jump         L18
-L17:
-  Avg          r164, r155
-  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Const        r165, "agg3"
-  Const        r166, []
-  IterPrep     r167, r138
-  Len          r168, r167
-  Move         r169, r134
-L20:
-  LessInt      r170, r169, r168
-  JumpIfFalse  r170, L19
-  Index        r149, r167, r169
-  Index        r172, r149, r11
-  Index        r173, r172, r16
-  Append       r166, r166, r173
-  AddInt       r169, r169, r131
-  Jump         L20
-L19:
-  Avg          r175, r166
-  // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Const        r176, "agg4"
-  Const        r177, []
-  IterPrep     r178, r138
-  Len          r179, r178
-  Move         r180, r134
-L22:
-  LessInt      r181, r180, r179
-  JumpIfFalse  r181, L21
-  Index        r149, r178, r180
-  Index        r183, r149, r11
-  Index        r184, r183, r18
-  Append       r177, r177, r184
-  AddInt       r180, r180, r131
-  Jump         L22
-L21:
-  Avg          r186, r177
+L0:
+  Move         r144, r127
+  Len          r145, r20
+L26:
+  LessInt      r146, r144, r145
+  JumpIfFalse  r146, L17
+  Index        r147, r20, r144
+  Move         r148, r147
   // i_item_id: g.key.i_item_id,
-  Move         r187, r139
-  Move         r188, r141
+  Const        r149, "i_item_id"
+  Index        r150, r148, r9
+  Index        r151, r150, r2
   // agg1: avg(from x in g select x.ss.ss_quantity),
-  Move         r189, r142
-  Move         r190, r153
+  Const        r152, "agg1"
+  Const        r153, []
+  IterPrep     r154, r148
+  Len          r155, r154
+  Move         r156, r127
+L19:
+  LessInt      r157, r156, r155
+  JumpIfFalse  r157, L18
+  Index        r158, r154, r156
+  Move         r159, r158
+  Index        r160, r159, r11
+  Index        r161, r160, r12
+  Append       r162, r153, r161
+  Move         r153, r162
+  AddInt       r156, r156, r142
+  Jump         L19
+L18:
+  Avg          r163, r153
   // agg2: avg(from x in g select x.ss.ss_list_price),
-  Move         r191, r154
-  Move         r192, r164
+  Const        r164, "agg2"
+  Const        r165, []
+  IterPrep     r166, r148
+  Len          r167, r166
+  Move         r168, r127
+L21:
+  LessInt      r169, r168, r167
+  JumpIfFalse  r169, L20
+  Index        r170, r166, r168
+  Move         r159, r170
+  Index        r171, r159, r11
+  Index        r172, r171, r14
+  Append       r173, r165, r172
+  Move         r165, r173
+  AddInt       r168, r168, r142
+  Jump         L21
+L20:
+  Avg          r174, r165
   // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Move         r193, r165
-  Move         r194, r175
-  // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Move         r195, r176
-  Move         r196, r186
-  // select {
-  MakeMap      r197, 5, r187
-  // sort by g.key.i_item_id
-  Index        r198, r138, r9
-  Index        r200, r198, r2
-  // from ss in store_sales
-  Move         r201, r197
-  MakeList     r202, 2, r200
-  Append       r1, r1, r202
-  AddInt       r133, r133, r131
+  Const        r175, "agg3"
+  Const        r176, []
+  IterPrep     r177, r148
+  Len          r178, r177
+  Move         r179, r127
+L23:
+  LessInt      r180, r179, r178
+  JumpIfFalse  r180, L22
+  Index        r181, r177, r179
+  Move         r159, r181
+  Index        r182, r159, r11
+  Index        r183, r182, r16
+  Append       r184, r176, r183
+  Move         r176, r184
+  AddInt       r179, r179, r142
   Jump         L23
-L14:
+L22:
+  Avg          r185, r176
+  // agg4: avg(from x in g select x.ss.ss_sales_price)
+  Const        r186, "agg4"
+  Const        r187, []
+  IterPrep     r188, r148
+  Len          r189, r188
+  Move         r190, r127
+L25:
+  LessInt      r191, r190, r189
+  JumpIfFalse  r191, L24
+  Index        r192, r188, r190
+  Move         r159, r192
+  Index        r193, r159, r11
+  Index        r194, r193, r18
+  Append       r195, r187, r194
+  Move         r187, r195
+  AddInt       r190, r190, r142
+  Jump         L25
+L24:
+  Avg          r196, r187
+  // i_item_id: g.key.i_item_id,
+  Move         r197, r149
+  Move         r198, r151
+  // agg1: avg(from x in g select x.ss.ss_quantity),
+  Move         r199, r152
+  Move         r200, r163
+  // agg2: avg(from x in g select x.ss.ss_list_price),
+  Move         r201, r164
+  Move         r202, r174
+  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
+  Move         r203, r175
+  Move         r204, r185
+  // agg4: avg(from x in g select x.ss.ss_sales_price)
+  Move         r205, r186
+  Move         r206, r196
+  // select {
+  MakeMap      r207, 5, r197
   // sort by g.key.i_item_id
-  Sort         r1, r1
+  Index        r208, r148, r9
+  Index        r209, r208, r2
+  Move         r210, r209
+  // from ss in store_sales
+  Move         r211, r207
+  MakeList     r212, 2, r210
+  Append       r213, r1, r212
+  Move         r1, r213
+  AddInt       r144, r144, r142
+  Jump         L26
+L17:
+  // sort by g.key.i_item_id
+  Sort         r214, r1
+  // from ss in store_sales
+  Move         r1, r214
   // json(result)
   JSON         r1
   // expect len(result) == 0
-  Len          r205, r1
-  EqualInt     r206, r205, r134
-  Expect       r206
+  Len          r215, r1
+  EqualInt     r216, r215, r127
+  Expect       r216
   Return       r0

--- a/tests/dataset/tpc-ds/out/q9.ir.out
+++ b/tests/dataset/tpc-ds/out/q9.ir.out
@@ -1,4 +1,4 @@
-func main (regs=253)
+func main (regs=268)
   // let store_sales = []
   Const        r0, []
   // if count(from s in store_sales
@@ -13,7 +13,8 @@ func main (regs=253)
 L3:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
-  Index        r9, r3, r5
+  Index        r8, r3, r5
+  Move         r9, r8
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
   Index        r10, r9, r2
   Const        r11, 1
@@ -21,487 +22,533 @@ L3:
   Index        r13, r9, r2
   Const        r14, 20
   LessEq       r15, r13, r14
-  JumpIfFalse  r12, L1
-  Move         r12, r15
+  Move         r16, r12
+  JumpIfFalse  r16, L1
+  Move         r16, r15
 L1:
-  JumpIfFalse  r12, L2
+  JumpIfFalse  r16, L2
   // if count(from s in store_sales
-  Append       r1, r1, r9
+  Append       r17, r1, r9
+  Move         r1, r17
 L2:
   AddInt       r5, r5, r11
   Jump         L3
 L0:
-  Count        r17, r1
+  Count        r18, r1
   // select s) > 10 {
-  Const        r18, 10
-  LessInt      r19, r18, r17
+  Const        r19, 10
+  LessInt      r20, r19, r18
   // avg(from s in store_sales
-  Const        r20, []
+  Const        r21, []
   // select s.ss_ext_discount_amt)
-  Const        r21, "ss_ext_discount_amt"
+  Const        r22, "ss_ext_discount_amt"
   // avg(from s in store_sales
-  IterPrep     r22, r0
-  Len          r23, r22
-  Move         r24, r6
+  IterPrep     r23, r0
+  Len          r24, r23
+  Move         r25, r6
 L7:
-  LessInt      r25, r24, r23
-  JumpIfFalse  r25, L4
-  Index        r9, r22, r24
+  LessInt      r26, r25, r24
+  JumpIfFalse  r26, L4
+  Index        r27, r23, r25
+  Move         r9, r27
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Index        r27, r9, r2
-  LessEq       r28, r11, r27
-  Index        r29, r9, r2
-  LessEq       r30, r29, r14
-  JumpIfFalse  r28, L5
-  Move         r28, r30
+  Index        r28, r9, r2
+  LessEq       r29, r11, r28
+  Index        r30, r9, r2
+  LessEq       r31, r30, r14
+  Move         r32, r29
+  JumpIfFalse  r32, L5
+  Move         r32, r31
 L5:
-  JumpIfFalse  r28, L6
+  JumpIfFalse  r32, L6
   // select s.ss_ext_discount_amt)
-  Index        r31, r9, r21
+  Index        r33, r9, r22
   // avg(from s in store_sales
-  Append       r20, r20, r31
+  Append       r34, r21, r33
+  Move         r21, r34
 L6:
-  AddInt       r24, r24, r11
+  AddInt       r25, r25, r11
   Jump         L7
 L4:
-  Avg          r33, r20
+  Avg          r35, r21
   // avg(from s in store_sales
-  Const        r34, []
+  Const        r36, []
   // select s.ss_net_paid)
-  Const        r35, "ss_net_paid"
+  Const        r37, "ss_net_paid"
   // avg(from s in store_sales
-  IterPrep     r36, r0
-  Len          r37, r36
-  Move         r38, r6
+  IterPrep     r38, r0
+  Len          r39, r38
+  Move         r40, r6
 L11:
-  LessInt      r39, r38, r37
-  JumpIfFalse  r39, L8
-  Index        r9, r36, r38
+  LessInt      r41, r40, r39
+  JumpIfFalse  r41, L8
+  Index        r42, r38, r40
+  Move         r9, r42
   // where s.ss_quantity >= 1 && s.ss_quantity <= 20
-  Index        r41, r9, r2
-  LessEq       r42, r11, r41
   Index        r43, r9, r2
-  LessEq       r44, r43, r14
-  JumpIfFalse  r42, L9
-  Move         r42, r44
+  LessEq       r44, r11, r43
+  Index        r45, r9, r2
+  LessEq       r46, r45, r14
+  Move         r47, r44
+  JumpIfFalse  r47, L9
+  Move         r47, r46
 L9:
-  JumpIfFalse  r42, L10
+  JumpIfFalse  r47, L10
   // select s.ss_net_paid)
-  Index        r45, r9, r35
+  Index        r48, r9, r37
   // avg(from s in store_sales
-  Append       r34, r34, r45
+  Append       r49, r36, r48
+  Move         r36, r49
 L10:
-  AddInt       r38, r38, r11
+  AddInt       r40, r40, r11
   Jump         L11
 L8:
-  Avg          r47, r34
+  Avg          r50, r36
   // if count(from s in store_sales
-  Select       48,19,33,47
+  Select       51,20,35,50
   // if count(from s in store_sales
-  Const        r49, []
-  IterPrep     r50, r0
-  Len          r51, r50
-  Move         r52, r6
+  Const        r52, []
+  IterPrep     r53, r0
+  Len          r54, r53
+  Move         r55, r6
 L15:
-  LessInt      r53, r52, r51
-  JumpIfFalse  r53, L12
-  Index        r9, r50, r52
+  LessInt      r56, r55, r54
+  JumpIfFalse  r56, L12
+  Index        r57, r53, r55
+  Move         r9, r57
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Index        r55, r9, r2
-  Const        r56, 21
-  LessEq       r57, r56, r55
   Index        r58, r9, r2
-  Const        r59, 40
-  LessEq       r60, r58, r59
-  JumpIfFalse  r57, L13
-  Move         r57, r60
+  Const        r59, 21
+  LessEq       r60, r59, r58
+  Index        r61, r9, r2
+  Const        r62, 40
+  LessEq       r63, r61, r62
+  Move         r64, r60
+  JumpIfFalse  r64, L13
+  Move         r64, r63
 L13:
-  JumpIfFalse  r57, L14
+  JumpIfFalse  r64, L14
   // if count(from s in store_sales
-  Append       r49, r49, r9
+  Append       r65, r52, r9
+  Move         r52, r65
 L14:
-  AddInt       r52, r52, r11
+  AddInt       r55, r55, r11
   Jump         L15
 L12:
-  Count        r62, r49
+  Count        r66, r52
   // select s) > 20 {
-  LessInt      r63, r14, r62
+  LessInt      r67, r14, r66
   // avg(from s in store_sales
-  Const        r64, []
-  IterPrep     r65, r0
-  Len          r66, r65
-  Move         r67, r6
+  Const        r68, []
+  IterPrep     r69, r0
+  Len          r70, r69
+  Move         r71, r6
 L19:
-  LessInt      r68, r67, r66
-  JumpIfFalse  r68, L16
-  Index        r9, r65, r67
+  LessInt      r72, r71, r70
+  JumpIfFalse  r72, L16
+  Index        r73, r69, r71
+  Move         r9, r73
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Index        r70, r9, r2
-  LessEq       r71, r56, r70
-  Index        r72, r9, r2
-  LessEq       r73, r72, r59
-  JumpIfFalse  r71, L17
-  Move         r71, r73
+  Index        r74, r9, r2
+  LessEq       r75, r59, r74
+  Index        r76, r9, r2
+  LessEq       r77, r76, r62
+  Move         r78, r75
+  JumpIfFalse  r78, L17
+  Move         r78, r77
 L17:
-  JumpIfFalse  r71, L18
+  JumpIfFalse  r78, L18
   // select s.ss_ext_discount_amt)
-  Index        r74, r9, r21
+  Index        r79, r9, r22
   // avg(from s in store_sales
-  Append       r64, r64, r74
+  Append       r80, r68, r79
+  Move         r68, r80
 L18:
-  AddInt       r67, r67, r11
+  AddInt       r71, r71, r11
   Jump         L19
 L16:
-  Avg          r76, r64
+  Avg          r81, r68
   // avg(from s in store_sales
-  Const        r77, []
-  IterPrep     r78, r0
-  Len          r79, r78
-  Move         r80, r6
+  Const        r82, []
+  IterPrep     r83, r0
+  Len          r84, r83
+  Move         r85, r6
 L23:
-  LessInt      r81, r80, r79
-  JumpIfFalse  r81, L20
-  Index        r9, r78, r80
+  LessInt      r86, r85, r84
+  JumpIfFalse  r86, L20
+  Index        r87, r83, r85
+  Move         r9, r87
   // where s.ss_quantity >= 21 && s.ss_quantity <= 40
-  Index        r83, r9, r2
-  LessEq       r84, r56, r83
-  Index        r85, r9, r2
-  LessEq       r86, r85, r59
-  JumpIfFalse  r84, L21
-  Move         r84, r86
+  Index        r88, r9, r2
+  LessEq       r89, r59, r88
+  Index        r90, r9, r2
+  LessEq       r91, r90, r62
+  Move         r92, r89
+  JumpIfFalse  r92, L21
+  Move         r92, r91
 L21:
-  JumpIfFalse  r84, L22
+  JumpIfFalse  r92, L22
   // select s.ss_net_paid)
-  Index        r87, r9, r35
+  Index        r93, r9, r37
   // avg(from s in store_sales
-  Append       r77, r77, r87
+  Append       r94, r82, r93
+  Move         r82, r94
 L22:
-  AddInt       r80, r80, r11
+  AddInt       r85, r85, r11
   Jump         L23
 L20:
-  Avg          r89, r77
+  Avg          r95, r82
   // if count(from s in store_sales
-  Select       90,63,76,89
+  Select       96,67,81,95
   // if count(from s in store_sales
-  Const        r91, []
-  IterPrep     r92, r0
-  Len          r93, r92
-  Move         r94, r6
+  Const        r97, []
+  IterPrep     r98, r0
+  Len          r99, r98
+  Move         r100, r6
 L27:
-  LessInt      r95, r94, r93
-  JumpIfFalse  r95, L24
-  Index        r9, r92, r94
+  LessInt      r101, r100, r99
+  JumpIfFalse  r101, L24
+  Index        r102, r98, r100
+  Move         r9, r102
   // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Index        r97, r9, r2
-  Const        r98, 41
-  LessEq       r99, r98, r97
-  Index        r100, r9, r2
-  Const        r101, 60
-  LessEq       r102, r100, r101
-  JumpIfFalse  r99, L25
-  Move         r99, r102
+  Index        r103, r9, r2
+  Const        r104, 41
+  LessEq       r105, r104, r103
+  Index        r106, r9, r2
+  Const        r107, 60
+  LessEq       r108, r106, r107
+  Move         r109, r105
+  JumpIfFalse  r109, L25
+  Move         r109, r108
 L25:
-  JumpIfFalse  r99, L26
+  JumpIfFalse  r109, L26
   // if count(from s in store_sales
-  Append       r91, r91, r9
+  Append       r110, r97, r9
+  Move         r97, r110
 L26:
-  AddInt       r94, r94, r11
+  AddInt       r100, r100, r11
   Jump         L27
 L24:
-  Count        r104, r91
+  Count        r111, r97
   // select s) > 30 {
-  Const        r105, 30
-  LessInt      r106, r105, r104
+  Const        r112, 30
+  LessInt      r113, r112, r111
   // avg(from s in store_sales
-  Const        r107, []
-  IterPrep     r108, r0
-  Len          r109, r108
-  Move         r110, r6
+  Const        r114, []
+  IterPrep     r115, r0
+  Len          r116, r115
+  Move         r117, r6
 L31:
-  LessInt      r111, r110, r109
-  JumpIfFalse  r111, L28
-  Index        r9, r108, r110
+  LessInt      r118, r117, r116
+  JumpIfFalse  r118, L28
+  Index        r119, r115, r117
+  Move         r9, r119
   // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Index        r113, r9, r2
-  LessEq       r114, r98, r113
-  Index        r115, r9, r2
-  LessEq       r116, r115, r101
-  JumpIfFalse  r114, L29
-  Move         r114, r116
+  Index        r120, r9, r2
+  LessEq       r121, r104, r120
+  Index        r122, r9, r2
+  LessEq       r123, r122, r107
+  Move         r124, r121
+  JumpIfFalse  r124, L29
+  Move         r124, r123
 L29:
-  JumpIfFalse  r114, L30
+  JumpIfFalse  r124, L30
   // select s.ss_ext_discount_amt)
-  Index        r117, r9, r21
+  Index        r125, r9, r22
   // avg(from s in store_sales
-  Append       r107, r107, r117
+  Append       r126, r114, r125
+  Move         r114, r126
 L30:
-  AddInt       r110, r110, r11
+  AddInt       r117, r117, r11
   Jump         L31
 L28:
-  Avg          r119, r107
+  Avg          r127, r114
   // avg(from s in store_sales
-  Const        r120, []
-  IterPrep     r121, r0
-  Len          r122, r121
-  Move         r123, r6
+  Const        r128, []
+  IterPrep     r129, r0
+  Len          r130, r129
+  Move         r131, r6
 L35:
-  LessInt      r124, r123, r122
-  JumpIfFalse  r124, L32
-  Index        r9, r121, r123
+  LessInt      r132, r131, r130
+  JumpIfFalse  r132, L32
+  Index        r133, r129, r131
+  Move         r9, r133
   // where s.ss_quantity >= 41 && s.ss_quantity <= 60
-  Index        r126, r9, r2
-  LessEq       r127, r98, r126
-  Index        r128, r9, r2
-  LessEq       r129, r128, r101
-  JumpIfFalse  r127, L33
-  Move         r127, r129
+  Index        r134, r9, r2
+  LessEq       r135, r104, r134
+  Index        r136, r9, r2
+  LessEq       r137, r136, r107
+  Move         r138, r135
+  JumpIfFalse  r138, L33
+  Move         r138, r137
 L33:
-  JumpIfFalse  r127, L34
+  JumpIfFalse  r138, L34
   // select s.ss_net_paid)
-  Index        r130, r9, r35
+  Index        r139, r9, r37
   // avg(from s in store_sales
-  Append       r120, r120, r130
+  Append       r140, r128, r139
+  Move         r128, r140
 L34:
-  AddInt       r123, r123, r11
+  AddInt       r131, r131, r11
   Jump         L35
 L32:
-  Avg          r132, r120
+  Avg          r141, r128
   // if count(from s in store_sales
-  Select       133,106,119,132
+  Select       142,113,127,141
   // if count(from s in store_sales
-  Const        r134, []
-  IterPrep     r135, r0
-  Len          r136, r135
-  Move         r137, r6
+  Const        r143, []
+  IterPrep     r144, r0
+  Len          r145, r144
+  Move         r146, r6
 L39:
-  LessInt      r138, r137, r136
-  JumpIfFalse  r138, L36
-  Index        r9, r135, r137
+  LessInt      r147, r146, r145
+  JumpIfFalse  r147, L36
+  Index        r148, r144, r146
+  Move         r9, r148
   // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Index        r140, r9, r2
-  Const        r141, 61
-  LessEq       r142, r141, r140
-  Index        r143, r9, r2
-  Const        r144, 80
-  LessEq       r145, r143, r144
-  JumpIfFalse  r142, L37
-  Move         r142, r145
+  Index        r149, r9, r2
+  Const        r150, 61
+  LessEq       r151, r150, r149
+  Index        r152, r9, r2
+  Const        r153, 80
+  LessEq       r154, r152, r153
+  Move         r155, r151
+  JumpIfFalse  r155, L37
+  Move         r155, r154
 L37:
-  JumpIfFalse  r142, L38
+  JumpIfFalse  r155, L38
   // if count(from s in store_sales
-  Append       r134, r134, r9
+  Append       r156, r143, r9
+  Move         r143, r156
 L38:
-  AddInt       r137, r137, r11
+  AddInt       r146, r146, r11
   Jump         L39
 L36:
-  Count        r147, r134
+  Count        r157, r143
   // select s) > 40 {
-  LessInt      r148, r59, r147
+  LessInt      r158, r62, r157
   // avg(from s in store_sales
-  Const        r149, []
-  IterPrep     r150, r0
-  Len          r151, r150
-  Move         r152, r6
+  Const        r159, []
+  IterPrep     r160, r0
+  Len          r161, r160
+  Move         r162, r6
 L43:
-  LessInt      r153, r152, r151
-  JumpIfFalse  r153, L40
-  Index        r9, r150, r152
+  LessInt      r163, r162, r161
+  JumpIfFalse  r163, L40
+  Index        r164, r160, r162
+  Move         r9, r164
   // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Index        r155, r9, r2
-  LessEq       r156, r141, r155
-  Index        r157, r9, r2
-  LessEq       r158, r157, r144
-  JumpIfFalse  r156, L41
-  Move         r156, r158
+  Index        r165, r9, r2
+  LessEq       r166, r150, r165
+  Index        r167, r9, r2
+  LessEq       r168, r167, r153
+  Move         r169, r166
+  JumpIfFalse  r169, L41
+  Move         r169, r168
 L41:
-  JumpIfFalse  r156, L42
+  JumpIfFalse  r169, L42
   // select s.ss_ext_discount_amt)
-  Index        r159, r9, r21
+  Index        r170, r9, r22
   // avg(from s in store_sales
-  Append       r149, r149, r159
+  Append       r171, r159, r170
+  Move         r159, r171
 L42:
-  AddInt       r152, r152, r11
+  AddInt       r162, r162, r11
   Jump         L43
 L40:
-  Avg          r161, r149
+  Avg          r172, r159
   // avg(from s in store_sales
-  Const        r162, []
-  IterPrep     r163, r0
-  Len          r164, r163
-  Move         r165, r6
+  Const        r173, []
+  IterPrep     r174, r0
+  Len          r175, r174
+  Move         r176, r6
 L47:
-  LessInt      r166, r165, r164
-  JumpIfFalse  r166, L44
-  Index        r9, r163, r165
+  LessInt      r177, r176, r175
+  JumpIfFalse  r177, L44
+  Index        r178, r174, r176
+  Move         r9, r178
   // where s.ss_quantity >= 61 && s.ss_quantity <= 80
-  Index        r168, r9, r2
-  LessEq       r169, r141, r168
-  Index        r170, r9, r2
-  LessEq       r171, r170, r144
-  JumpIfFalse  r169, L45
-  Move         r169, r171
+  Index        r179, r9, r2
+  LessEq       r180, r150, r179
+  Index        r181, r9, r2
+  LessEq       r182, r181, r153
+  Move         r183, r180
+  JumpIfFalse  r183, L45
+  Move         r183, r182
 L45:
-  JumpIfFalse  r169, L46
+  JumpIfFalse  r183, L46
   // select s.ss_net_paid)
-  Index        r172, r9, r35
+  Index        r184, r9, r37
   // avg(from s in store_sales
-  Append       r162, r162, r172
+  Append       r185, r173, r184
+  Move         r173, r185
 L46:
-  AddInt       r165, r165, r11
+  AddInt       r176, r176, r11
   Jump         L47
 L44:
-  Avg          r174, r162
+  Avg          r186, r173
   // if count(from s in store_sales
-  Select       175,148,161,174
+  Select       187,158,172,186
   // if count(from s in store_sales
-  Const        r176, []
-  IterPrep     r177, r0
-  Len          r178, r177
-  Move         r179, r6
+  Const        r188, []
+  IterPrep     r189, r0
+  Len          r190, r189
+  Move         r191, r6
 L51:
-  LessInt      r180, r179, r178
-  JumpIfFalse  r180, L48
-  Index        r9, r177, r179
+  LessInt      r192, r191, r190
+  JumpIfFalse  r192, L48
+  Index        r193, r189, r191
+  Move         r9, r193
   // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Index        r182, r9, r2
-  Const        r183, 81
-  LessEq       r184, r183, r182
-  Index        r185, r9, r2
-  Const        r186, 100
-  LessEq       r187, r185, r186
-  JumpIfFalse  r184, L49
-  Move         r184, r187
+  Index        r194, r9, r2
+  Const        r195, 81
+  LessEq       r196, r195, r194
+  Index        r197, r9, r2
+  Const        r198, 100
+  LessEq       r199, r197, r198
+  Move         r200, r196
+  JumpIfFalse  r200, L49
+  Move         r200, r199
 L49:
-  JumpIfFalse  r184, L50
+  JumpIfFalse  r200, L50
   // if count(from s in store_sales
-  Append       r176, r176, r9
+  Append       r201, r188, r9
+  Move         r188, r201
 L50:
-  AddInt       r179, r179, r11
+  AddInt       r191, r191, r11
   Jump         L51
 L48:
-  Count        r189, r176
+  Count        r202, r188
   // select s) > 50 {
-  Const        r190, 50
-  LessInt      r191, r190, r189
-  // avg(from s in store_sales
-  Const        r192, []
-  IterPrep     r193, r0
-  Len          r194, r193
-  Move         r195, r6
-L55:
-  LessInt      r196, r195, r194
-  JumpIfFalse  r196, L52
-  Index        r9, r193, r195
-  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
-  Index        r198, r9, r2
-  LessEq       r199, r183, r198
-  Index        r200, r9, r2
-  LessEq       r201, r200, r186
-  JumpIfFalse  r199, L53
-  Move         r199, r201
-L53:
-  JumpIfFalse  r199, L54
-  // select s.ss_ext_discount_amt)
-  Index        r202, r9, r21
-  // avg(from s in store_sales
-  Append       r192, r192, r202
-L54:
-  AddInt       r195, r195, r11
-  Jump         L55
-L52:
-  Avg          r204, r192
+  Const        r203, 50
+  LessInt      r204, r203, r202
   // avg(from s in store_sales
   Const        r205, []
   IterPrep     r206, r0
   Len          r207, r206
   Move         r208, r6
-L59:
+L55:
   LessInt      r209, r208, r207
-  JumpIfFalse  r209, L56
-  Index        r9, r206, r208
+  JumpIfFalse  r209, L52
+  Index        r210, r206, r208
+  Move         r9, r210
   // where s.ss_quantity >= 81 && s.ss_quantity <= 100
   Index        r211, r9, r2
-  LessEq       r212, r183, r211
+  LessEq       r212, r195, r211
   Index        r213, r9, r2
-  LessEq       r214, r213, r186
-  JumpIfFalse  r212, L57
-  Move         r212, r214
-L57:
-  JumpIfFalse  r212, L58
-  // select s.ss_net_paid)
-  Index        r215, r9, r35
+  LessEq       r214, r213, r198
+  Move         r215, r212
+  JumpIfFalse  r215, L53
+  Move         r215, r214
+L53:
+  JumpIfFalse  r215, L54
+  // select s.ss_ext_discount_amt)
+  Index        r216, r9, r22
   // avg(from s in store_sales
-  Append       r205, r205, r215
-L58:
+  Append       r217, r205, r216
+  Move         r205, r217
+L54:
   AddInt       r208, r208, r11
+  Jump         L55
+L52:
+  Avg          r218, r205
+  // avg(from s in store_sales
+  Const        r219, []
+  IterPrep     r220, r0
+  Len          r221, r220
+  Move         r222, r6
+L59:
+  LessInt      r223, r222, r221
+  JumpIfFalse  r223, L56
+  Index        r224, r220, r222
+  Move         r9, r224
+  // where s.ss_quantity >= 81 && s.ss_quantity <= 100
+  Index        r225, r9, r2
+  LessEq       r226, r195, r225
+  Index        r227, r9, r2
+  LessEq       r228, r227, r198
+  Move         r229, r226
+  JumpIfFalse  r229, L57
+  Move         r229, r228
+L57:
+  JumpIfFalse  r229, L58
+  // select s.ss_net_paid)
+  Index        r230, r9, r37
+  // avg(from s in store_sales
+  Append       r231, r219, r230
+  Move         r219, r231
+L58:
+  AddInt       r222, r222, r11
   Jump         L59
 L56:
-  Avg          r217, r205
+  Avg          r232, r219
   // if count(from s in store_sales
-  Select       218,191,204,217
+  Select       233,204,218,232
   // from r in reason
-  Const        r219, []
+  Const        r234, []
   // where r.r_reason_sk == 1
-  Const        r220, "r_reason_sk"
+  Const        r235, "r_reason_sk"
   // bucket1: bucket1,
-  Const        r221, "bucket1"
+  Const        r236, "bucket1"
   // bucket2: bucket2,
-  Const        r222, "bucket2"
+  Const        r237, "bucket2"
   // bucket3: bucket3,
-  Const        r223, "bucket3"
+  Const        r238, "bucket3"
   // bucket4: bucket4,
-  Const        r224, "bucket4"
+  Const        r239, "bucket4"
   // bucket5: bucket5
-  Const        r225, "bucket5"
+  Const        r240, "bucket5"
   // from r in reason
-  IterPrep     r226, r0
-  Len          r227, r226
-  Move         r228, r6
+  IterPrep     r241, r0
+  Len          r242, r241
+  Move         r243, r6
 L62:
-  LessInt      r229, r228, r227
-  JumpIfFalse  r229, L60
-  Index        r231, r226, r228
+  LessInt      r244, r243, r242
+  JumpIfFalse  r244, L60
+  Index        r245, r241, r243
+  Move         r246, r245
   // where r.r_reason_sk == 1
-  Index        r232, r231, r220
-  Equal        r233, r232, r11
-  JumpIfFalse  r233, L61
+  Index        r247, r246, r235
+  Equal        r248, r247, r11
+  JumpIfFalse  r248, L61
   // bucket1: bucket1,
-  Const        r234, "bucket1"
+  Const        r249, "bucket1"
   // bucket2: bucket2,
-  Const        r235, "bucket2"
+  Const        r250, "bucket2"
   // bucket3: bucket3,
-  Const        r236, "bucket3"
+  Const        r251, "bucket3"
   // bucket4: bucket4,
-  Const        r237, "bucket4"
+  Const        r252, "bucket4"
   // bucket5: bucket5
-  Const        r238, "bucket5"
+  Const        r253, "bucket5"
   // bucket1: bucket1,
-  Move         r239, r234
-  Move         r240, r48
+  Move         r254, r249
+  Move         r255, r51
   // bucket2: bucket2,
-  Move         r241, r235
-  Move         r242, r90
+  Move         r256, r250
+  Move         r257, r96
   // bucket3: bucket3,
-  Move         r243, r236
-  Move         r244, r133
+  Move         r258, r251
+  Move         r259, r142
   // bucket4: bucket4,
-  Move         r245, r237
-  Move         r246, r175
+  Move         r260, r252
+  Move         r261, r187
   // bucket5: bucket5
-  Move         r247, r238
-  Move         r248, r218
+  Move         r262, r253
+  Move         r263, r233
   // select {
-  MakeMap      r249, 5, r239
+  MakeMap      r264, 5, r254
   // from r in reason
-  Append       r219, r219, r249
+  Append       r265, r234, r264
+  Move         r234, r265
 L61:
-  AddInt       r228, r228, r11
+  AddInt       r243, r243, r11
   Jump         L62
 L60:
   // json(result)
-  JSON         r219
+  JSON         r234
   // expect len(result) == 0
-  Len          r251, r219
-  EqualInt     r252, r251, r6
-  Expect       r252
+  Len          r266, r234
+  EqualInt     r267, r266, r6
+  Expect       r267
   Return       r0


### PR DESCRIPTION
## Summary
- disable optimizer when `MOCHI_NO_OPT` is set
- update TPC-DS golden IR outputs for queries q1–q9

## Testing
- `go test -tags slow ./tests/vm -run TPCDS/q1.mochi -count=1`
- `go test -tags slow ./tests/vm -run 'TPCDS/q[2-9]\.mochi' -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6862a9f077e083208604bb6d70bd7eb6