### PR TITLE
Update tpc‑ds VM IR for q80‑q89

### DIFF
--- a/tests/dataset/tpc-ds/out/q80.ir.out
+++ b/tests/dataset/tpc-ds/out/q80.ir.out
@@ -16,11 +16,13 @@ func main (regs=47)
 L1:
   LessInt      r10, r8, r7
   JumpIfFalse  r10, L0
-  Index        r12, r6, r8
+  Index        r11, r6, r8
+  Move         r12, r11
   Index        r13, r12, r4
   Index        r14, r12, r5
   Sub          r15, r13, r14
-  Append       r3, r3, r15
+  Append       r16, r3, r15
+  Move         r3, r16
   Const        r17, 1
   AddInt       r8, r8, r17
   Jump         L1
@@ -34,11 +36,13 @@ L0:
 L3:
   LessInt      r23, r22, r21
   JumpIfFalse  r23, L2
-  Index        r25, r20, r22
+  Index        r24, r20, r22
+  Move         r25, r24
   Index        r26, r25, r4
   Index        r27, r25, r5
   Sub          r28, r26, r27
-  Append       r19, r19, r28
+  Append       r29, r19, r28
+  Move         r19, r29
   AddInt       r22, r22, r17
   Jump         L3
 L2:
@@ -53,11 +57,13 @@ L2:
 L5:
   LessInt      r36, r35, r34
   JumpIfFalse  r36, L4
-  Index        r38, r33, r35
+  Index        r37, r33, r35
+  Move         r38, r37
   Index        r39, r38, r4
   Index        r40, r38, r5
   Sub          r41, r39, r40
-  Append       r32, r32, r41
+  Append       r42, r32, r41
+  Move         r32, r42
   AddInt       r35, r35, r17
   Jump         L5
 L4:

--- a/tests/dataset/tpc-ds/out/q81.ir.out
+++ b/tests/dataset/tpc-ds/out/q81.ir.out
@@ -1,4 +1,4 @@
-func main (regs=100)
+func main (regs=97)
   // let catalog_returns = [
   Const        r0, [{"amt": 40, "cust": 1, "state": "CA"}, {"amt": 50, "cust": 2, "state": "CA"}, {"amt": 81, "cust": 3, "state": "CA"}, {"amt": 30, "cust": 4, "state": "TX"}, {"amt": 20, "cust": 5, "state": "TX"}]
   // from r in catalog_returns
@@ -14,13 +14,15 @@ func main (regs=100)
   Len          r7, r6
   Const        r8, 0
   MakeMap      r9, 0, r0
-  Const        r10, []
+  Const        r11, []
+  Move         r10, r11
 L2:
   LessInt      r12, r8, r7
   JumpIfFalse  r12, L0
   Index        r13, r6, r8
+  Move         r14, r13
   // group by r.state into g
-  Index        r15, r13, r2
+  Index        r15, r14, r2
   Str          r16, r15
   In           r17, r16, r9
   JumpIfTrue   r17, L1
@@ -28,130 +30,136 @@ L2:
   Const        r18, []
   Const        r19, "__group__"
   Const        r20, true
-  Const        r21, "key"
   // group by r.state into g
-  Move         r22, r15
+  Move         r21, r15
   // from r in catalog_returns
-  Const        r23, "items"
-  Move         r24, r18
-  Const        r25, "count"
-  Const        r26, 0
-  Move         r27, r19
-  Move         r28, r20
+  Const        r22, "items"
+  Move         r23, r18
+  Const        r24, "count"
+  Const        r25, 0
+  Move         r26, r19
+  Move         r27, r20
+  Move         r28, r3
   Move         r29, r21
   Move         r30, r22
   Move         r31, r23
   Move         r32, r24
   Move         r33, r25
-  Move         r34, r26
-  MakeMap      r35, 4, r27
-  SetIndex     r9, r16, r35
-  Append       r10, r10, r35
+  MakeMap      r34, 4, r26
+  SetIndex     r9, r16, r34
+  Append       r35, r10, r34
+  Move         r10, r35
 L1:
-  Const        r37, "items"
-  Index        r38, r9, r16
-  Index        r39, r38, r37
-  Append       r40, r39, r13
-  SetIndex     r38, r37, r40
-  Const        r41, "count"
-  Index        r42, r38, r41
-  Const        r43, 1
-  AddInt       r44, r42, r43
-  SetIndex     r38, r41, r44
-  AddInt       r8, r8, r43
+  Index        r36, r9, r16
+  Index        r37, r36, r22
+  Append       r38, r37, r13
+  SetIndex     r36, r22, r38
+  Index        r39, r36, r24
+  Const        r40, 1
+  AddInt       r41, r39, r40
+  SetIndex     r36, r24, r41
+  AddInt       r8, r8, r40
   Jump         L2
 L0:
-  Const        r46, 0
-  Move         r45, r46
-  Len          r47, r10
+  Move         r42, r25
+  Len          r43, r10
 L6:
-  LessInt      r48, r45, r47
-  JumpIfFalse  r48, L3
-  Index        r50, r10, r45
+  LessInt      r44, r42, r43
+  JumpIfFalse  r44, L3
+  Index        r45, r10, r42
+  Move         r46, r45
   // select {state: g.key, avg_amt: avg(from x in g select x.amt)}
-  Const        r51, "state"
-  Index        r52, r50, r3
-  Const        r53, "avg_amt"
-  Const        r54, []
-  IterPrep     r55, r50
-  Len          r56, r55
-  Move         r57, r46
+  Const        r47, "state"
+  Index        r48, r46, r3
+  Const        r49, "avg_amt"
+  Const        r50, []
+  IterPrep     r51, r46
+  Len          r52, r51
+  Move         r53, r25
 L5:
-  LessInt      r58, r57, r56
-  JumpIfFalse  r58, L4
-  Index        r60, r55, r57
-  Index        r61, r60, r5
-  Append       r54, r54, r61
-  AddInt       r57, r57, r43
+  LessInt      r54, r53, r52
+  JumpIfFalse  r54, L4
+  Index        r55, r51, r53
+  Move         r56, r55
+  Index        r57, r56, r5
+  Append       r58, r50, r57
+  Move         r50, r58
+  AddInt       r53, r53, r40
   Jump         L5
 L4:
-  Avg          r63, r54
-  Move         r64, r51
-  Move         r65, r52
-  Move         r66, r53
-  Move         r67, r63
-  MakeMap      r68, 2, r64
+  Avg          r59, r50
+  Move         r60, r47
+  Move         r61, r48
+  Move         r62, r49
+  Move         r63, r59
+  MakeMap      r64, 2, r60
   // from r in catalog_returns
-  Append       r1, r1, r68
-  AddInt       r45, r45, r43
+  Append       r65, r1, r64
+  Move         r1, r65
+  AddInt       r42, r42, r40
   Jump         L6
 L3:
   // first(from a in avg_list
-  Const        r70, []
-  IterPrep     r71, r1
-  Len          r72, r71
-  Move         r73, r46
+  Const        r66, []
+  IterPrep     r67, r1
+  Len          r68, r67
+  Move         r69, r25
 L9:
-  LessInt      r74, r73, r72
-  JumpIfFalse  r74, L7
-  Index        r76, r71, r73
+  LessInt      r70, r69, r68
+  JumpIfFalse  r70, L7
+  Index        r71, r67, r69
+  Move         r72, r71
   // where a.state == "CA"
-  Index        r77, r76, r2
-  Const        r78, "CA"
-  Equal        r79, r77, r78
-  JumpIfFalse  r79, L8
+  Index        r73, r72, r2
+  Const        r74, "CA"
+  Equal        r75, r73, r74
+  JumpIfFalse  r75, L8
   // first(from a in avg_list
-  Append       r70, r70, r76
+  Append       r76, r66, r72
+  Move         r66, r76
 L8:
-  AddInt       r73, r73, r43
+  AddInt       r69, r69, r40
   Jump         L9
 L7:
-  First        r81, r70
+  First        r77, r66
   // from r in catalog_returns
-  Const        r82, []
-  IterPrep     r83, r0
-  Len          r84, r83
-  Move         r85, r46
+  Const        r78, []
+  IterPrep     r79, r0
+  Len          r80, r79
+  Move         r81, r25
 L13:
-  LessInt      r86, r85, r84
-  JumpIfFalse  r86, L10
-  Index        r14, r83, r85
+  LessInt      r82, r81, r80
+  JumpIfFalse  r82, L10
+  Index        r83, r79, r81
+  Move         r14, r83
   // where r.state == "CA" && r.amt > avg_state.avg_amt * 1.2
-  Index        r88, r14, r2
-  Index        r89, r81, r4
-  Const        r90, 1.2
-  MulFloat     r91, r89, r90
-  Index        r92, r14, r5
-  LessFloat    r93, r91, r92
-  Equal        r94, r88, r78
-  JumpIfFalse  r94, L11
-  Move         r94, r93
+  Index        r84, r14, r2
+  Index        r85, r77, r4
+  Const        r86, 1.2
+  MulFloat     r87, r85, r86
+  Index        r88, r14, r5
+  LessFloat    r89, r87, r88
+  Equal        r90, r84, r74
+  Move         r91, r90
+  JumpIfFalse  r91, L11
+  Move         r91, r89
 L11:
-  JumpIfFalse  r94, L12
+  JumpIfFalse  r91, L12
   // select r.amt
-  Index        r95, r14, r5
+  Index        r92, r14, r5
   // from r in catalog_returns
-  Append       r82, r82, r95
+  Append       r93, r78, r92
+  Move         r78, r93
 L12:
-  AddInt       r85, r85, r43
+  AddInt       r81, r81, r40
   Jump         L13
 L10:
   // let result = first(result_list)
-  First        r97, r82
+  First        r94, r78
   // json(result)
-  JSON         r97
+  JSON         r94
   // expect result == 81.0
-  Const        r98, 81
-  EqualFloat   r99, r97, r98
-  Expect       r99
+  Const        r95, 81
+  EqualFloat   r96, r94, r95
+  Expect       r96
   Return       r0

--- a/tests/dataset/tpc-ds/out/q82.ir.out
+++ b/tests/dataset/tpc-ds/out/q82.ir.out
@@ -14,7 +14,8 @@ func main (regs=29)
 L4:
   Less         r7, r6, r5
   JumpIfFalse  r7, L0
-  Index        r9, r4, r6
+  Index        r8, r4, r6
+  Move         r9, r8
   // for s in store_sales {
   IterPrep     r10, r2
   Len          r11, r10
@@ -22,7 +23,8 @@ L4:
 L3:
   Less         r13, r12, r11
   JumpIfFalse  r13, L1
-  Index        r15, r10, r12
+  Index        r14, r10, r12
+  Move         r15, r14
   // if inv.item == s.item {
   Const        r16, "item"
   Index        r17, r9, r16
@@ -32,16 +34,19 @@ L3:
   // result = result + inv.qty
   Const        r20, "qty"
   Index        r21, r9, r20
-  Add          r3, r3, r21
+  Add          r22, r3, r21
+  Move         r3, r22
 L2:
   // for s in store_sales {
   Const        r23, 1
-  Add          r12, r12, r23
+  Add          r24, r12, r23
+  Move         r12, r24
   Jump         L3
 L1:
   // for inv in inventory {
   Const        r25, 1
-  Add          r6, r6, r25
+  Add          r26, r6, r25
+  Move         r6, r26
   Jump         L4
 L0:
   // json(result)

--- a/tests/dataset/tpc-ds/out/q83.ir.out
+++ b/tests/dataset/tpc-ds/out/q83.ir.out
@@ -15,9 +15,11 @@ func main (regs=38)
 L1:
   LessInt      r9, r7, r6
   JumpIfFalse  r9, L0
-  Index        r11, r5, r7
+  Index        r10, r5, r7
+  Move         r11, r10
   Index        r12, r11, r4
-  Append       r3, r3, r12
+  Append       r13, r3, r12
+  Move         r3, r13
   Const        r14, 1
   AddInt       r7, r7, r14
   Jump         L1
@@ -31,9 +33,11 @@ L0:
 L3:
   LessInt      r20, r19, r18
   JumpIfFalse  r20, L2
-  Index        r11, r17, r19
+  Index        r21, r17, r19
+  Move         r11, r21
   Index        r22, r11, r4
-  Append       r16, r16, r22
+  Append       r23, r16, r22
+  Move         r16, r23
   AddInt       r19, r19, r14
   Jump         L3
 L2:
@@ -48,9 +52,11 @@ L2:
 L5:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L4
-  Index        r11, r27, r29
+  Index        r31, r27, r29
+  Move         r11, r31
   Index        r32, r11, r4
-  Append       r26, r26, r32
+  Append       r33, r26, r32
+  Move         r26, r33
   AddInt       r29, r29, r14
   Jump         L5
 L4:

--- a/tests/dataset/tpc-ds/out/q85.ir.out
+++ b/tests/dataset/tpc-ds/out/q85.ir.out
@@ -6,13 +6,16 @@ func main (regs=16)
   Const        r2, "qty"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r5, 0
+  Const        r6, 0
+  Move         r5, r6
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
-  Index        r9, r3, r5
+  Index        r8, r3, r5
+  Move         r9, r8
   Index        r10, r9, r2
-  Append       r1, r1, r10
+  Append       r11, r1, r10
+  Move         r1, r11
   Const        r12, 1
   AddInt       r5, r5, r12
   Jump         L1

--- a/tests/dataset/tpc-ds/out/q86.ir.out
+++ b/tests/dataset/tpc-ds/out/q86.ir.out
@@ -1,4 +1,4 @@
-func main (regs=24)
+func main (regs=25)
   // let web_sales = [
   Const        r0, [{"cat": "A", "class": "B", "net": 40}, {"cat": "A", "class": "B", "net": 46}, {"cat": "A", "class": "C", "net": 10}, {"cat": "B", "class": "B", "net": 20}]
   // sum(from ws in web_sales
@@ -11,11 +11,13 @@ func main (regs=24)
   // sum(from ws in web_sales
   IterPrep     r5, r0
   Len          r6, r5
-  Const        r7, 0
+  Const        r8, 0
+  Move         r7, r8
 L3:
   LessInt      r9, r7, r6
   JumpIfFalse  r9, L0
-  Index        r11, r5, r7
+  Index        r10, r5, r7
+  Move         r11, r10
   // where ws.cat == "A" && ws.class == "B"
   Index        r12, r11, r2
   Const        r13, "A"
@@ -23,24 +25,26 @@ L3:
   Index        r15, r11, r3
   Const        r16, "B"
   Equal        r17, r15, r16
-  JumpIfFalse  r14, L1
-  Move         r14, r17
+  Move         r18, r14
+  JumpIfFalse  r18, L1
+  Move         r18, r17
 L1:
-  JumpIfFalse  r14, L2
+  JumpIfFalse  r18, L2
   // select ws.net)
-  Index        r18, r11, r4
+  Index        r19, r11, r4
   // sum(from ws in web_sales
-  Append       r1, r1, r18
+  Append       r20, r1, r19
+  Move         r1, r20
 L2:
-  Const        r20, 1
-  AddInt       r7, r7, r20
+  Const        r21, 1
+  AddInt       r7, r7, r21
   Jump         L3
 L0:
-  Sum          r21, r1
+  Sum          r22, r1
   // json(result)
-  JSON         r21
+  JSON         r22
   // expect result == 86.0
-  Const        r22, 86
-  EqualFloat   r23, r21, r22
-  Expect       r23
+  Const        r23, 86
+  EqualFloat   r24, r22, r23
+  Expect       r24
   Return       r0

--- a/tests/dataset/tpc-ds/out/q87.ir.out
+++ b/tests/dataset/tpc-ds/out/q87.ir.out
@@ -17,7 +17,8 @@ func main (regs=5)
   // fun distinct(xs: list<any>): list<any> {
 func distinct (regs=14)
   // var out = []
-  Const        r2, []
+  Const        r1, []
+  Move         r2, r1
   // for x in xs {
   IterPrep     r3, r0
   Len          r4, r3
@@ -25,16 +26,19 @@ func distinct (regs=14)
 L2:
   Less         r6, r5, r4
   JumpIfFalse  r6, L0
-  Index        r8, r3, r5
+  Index        r7, r3, r5
+  Move         r8, r7
   // if !contains(out, x) {
   Not          r10, r9
   JumpIfFalse  r10, L1
   // out = append(out, x)
-  Append       r2, r2, r8
+  Append       r11, r2, r8
+  Move         r2, r11
 L1:
   // for x in xs {
   Const        r12, 1
-  Add          r5, r5, r12
+  Add          r13, r5, r12
+  Move         r5, r13
   Jump         L2
 L0:
   // return out
@@ -51,12 +55,15 @@ func concat (regs=12)
 L1:
   Less         r6, r5, r4
   JumpIfFalse  r6, L0
-  Index        r8, r3, r5
+  Index        r7, r3, r5
+  Move         r8, r7
   // out = append(out, x)
-  Append       r2, r2, r8
+  Append       r9, r2, r8
+  Move         r2, r9
   // for x in b {
   Const        r10, 1
-  Add          r5, r5, r10
+  Add          r11, r5, r10
+  Move         r5, r11
   Jump         L1
 L0:
   // return out

--- a/tests/dataset/tpc-ds/out/q89.ir.out
+++ b/tests/dataset/tpc-ds/out/q89.ir.out
@@ -6,13 +6,16 @@ func main (regs=16)
   Const        r2, "price"
   IterPrep     r3, r0
   Len          r4, r3
-  Const        r5, 0
+  Const        r6, 0
+  Move         r5, r6
 L1:
   LessInt      r7, r5, r4
   JumpIfFalse  r7, L0
-  Index        r9, r3, r5
+  Index        r8, r3, r5
+  Move         r9, r8
   Index        r10, r9, r2
-  Append       r1, r1, r10
+  Append       r11, r1, r10
+  Move         r1, r11
   Const        r12, 1
   AddInt       r5, r5, r12
   Jump         L1


### PR DESCRIPTION
## Summary
- update IR golden files for tpc-ds queries q80–q89 after VM improvements

## Testing
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q80.mochi`
- `go test -tags slow ./tests/vm -run TestVM_TPCDS/q8[1-9].mochi`


------
https://chatgpt.com/codex/tasks/task_e_6862aa0ec3748320ab3922d35aac60ff