### PR TITLE
Update lower builtin folding and TPC-DS IR outputs

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6078,6 +6078,15 @@ func (fc *funcCompiler) foldCallValue(call *parser.CallExpr) (Value, bool) {
 			return Value{}, false
 		}
 		return Value{Tag: ValueStr, Str: fmt.Sprint(valueToAny(args[0]))}, true
+	case "lower":
+		if len(args) != 1 {
+			return Value{}, false
+		}
+		v := args[0]
+		if v.Tag == ValueStr {
+			return Value{Tag: ValueStr, Str: strings.ToLower(v.Str)}, true
+		}
+		return Value{Tag: ValueStr, Str: strings.ToLower(fmt.Sprint(valueToAny(v)))}, true
 	case "substring":
 		if len(args) != 3 {
 			return Value{}, false

--- a/tests/dataset/tpc-ds/out/q50.ir.out
+++ b/tests/dataset/tpc-ds/out/q50.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 50}]
   Const        r0, [{"id": 1, "val": 50}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 50
-  Const        r16, 50
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 50
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q51.ir.out
+++ b/tests/dataset/tpc-ds/out/q51.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 51}]
   Const        r0, [{"id": 1, "val": 51}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 51
-  Const        r16, 51
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 51
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q52.ir.out
+++ b/tests/dataset/tpc-ds/out/q52.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 52}]
   Const        r0, [{"id": 1, "val": 52}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 52
-  Const        r16, 52
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 52
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q53.ir.out
+++ b/tests/dataset/tpc-ds/out/q53.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 53}]
   Const        r0, [{"id": 1, "val": 53}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 53
-  Const        r16, 53
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 53
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q54.ir.out
+++ b/tests/dataset/tpc-ds/out/q54.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 54}]
   Const        r0, [{"id": 1, "val": 54}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 54
-  Const        r16, 54
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 54
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q55.ir.out
+++ b/tests/dataset/tpc-ds/out/q55.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 55}]
   Const        r0, [{"id": 1, "val": 55}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 55
-  Const        r16, 55
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 55
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q56.ir.out
+++ b/tests/dataset/tpc-ds/out/q56.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 56}]
   Const        r0, [{"id": 1, "val": 56}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 56
-  Const        r16, 56
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 56
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q57.ir.out
+++ b/tests/dataset/tpc-ds/out/q57.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 57}]
   Const        r0, [{"id": 1, "val": 57}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 57
-  Const        r16, 57
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 57
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q58.ir.out
+++ b/tests/dataset/tpc-ds/out/q58.ir.out
@@ -1,31 +1,33 @@
-func main (regs=18)
+func main (regs=17)
   // let t = [{id: 1, val: 58}]
   Const        r0, [{"id": 1, "val": 58}]
   // let tmp = lower("ignore")
   Const        r1, "ignore"
-  Const        r2, "ignore"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 58
-  Const        r16, 58
-  Equal        r17, r15, r16
-  Expect       r17
+  Const        r15, 58
+  Equal        r16, r14, r15
+  Expect       r16
   Return       r0

--- a/tests/dataset/tpc-ds/out/q59.ir.out
+++ b/tests/dataset/tpc-ds/out/q59.ir.out
@@ -2,29 +2,32 @@ func main (regs=17)
   // let t = [{id: 1, val: 59}]
   Const        r0, [{"id": 1, "val": 59}]
   // let tmp = lower(59)
-  Const        r1, 59
-  Const        r2, "59"
+  Const        r1, "59"
   // let vals = from r in t select r.val
-  Const        r3, []
-  Const        r4, "val"
-  IterPrep     r5, r0
-  Len          r6, r5
+  Const        r2, []
+  Const        r3, "val"
+  IterPrep     r4, r0
+  Len          r5, r4
   Const        r7, 0
+  Move         r6, r7
 L1:
-  LessInt      r9, r7, r6
-  JumpIfFalse  r9, L0
-  Index        r11, r5, r7
-  Index        r12, r11, r4
-  Append       r3, r3, r12
-  Const        r14, 1
-  AddInt       r7, r7, r14
+  LessInt      r8, r6, r5
+  JumpIfFalse  r8, L0
+  Index        r9, r4, r6
+  Move         r10, r9
+  Index        r11, r10, r3
+  Append       r12, r2, r11
+  Move         r2, r12
+  Const        r13, 1
+  AddInt       r6, r6, r13
   Jump         L1
 L0:
   // let result = first(vals)
-  First        r15, r3
+  First        r14, r2
   // json(result)
-  JSON         r15
+  JSON         r14
   // expect result == 59
-  Equal        r16, r15, r1
+  Const        r15, 59
+  Equal        r16, r14, r15
   Expect       r16
   Return       r0


### PR DESCRIPTION
## Summary
- support constant folding for `lower` builtin in the VM compiler
- regenerate IR output for TPC‑DS queries q50–q59 to reflect the updated compiler behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862aa0298588320bdee85ae21c4f291