### PR TITLE
Enable stable map keys in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -787,7 +787,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 					}
 				}
 			case ValueMap:
-				key := fmt.Sprint(valueToAny(item))
+				key := valueToString(item)
 				_, found = container.Map[key]
 			case ValueStr:
 				if item.Tag == ValueStr {
@@ -1204,7 +1204,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 				fr.regs[ins.A] = fr.regs[ins.D]
 			}
 		case OpStr:
-			fr.regs[ins.A] = Value{Tag: ValueStr, Str: fmt.Sprint(valueToAny(fr.regs[ins.B]))}
+			fr.regs[ins.A] = Value{Tag: ValueStr, Str: valueToString(fr.regs[ins.B])}
 		case OpUpper:
 			b := fr.regs[ins.B]
 			if b.Tag != ValueStr {
@@ -6077,7 +6077,7 @@ func (fc *funcCompiler) foldCallValue(call *parser.CallExpr) (Value, bool) {
 		if len(args) != 1 {
 			return Value{}, false
 		}
-		return Value{Tag: ValueStr, Str: fmt.Sprint(valueToAny(args[0]))}, true
+		return Value{Tag: ValueStr, Str: valueToString(args[0])}, true
 	case "substring":
 		if len(args) != 3 {
 			return Value{}, false

--- a/tests/dataset/tpc-ds/out/q30.ir.out
+++ b/tests/dataset/tpc-ds/out/q30.ir.out
@@ -1,4 +1,4 @@
-func main (regs=241)
+func main (regs=237)
   // let web_returns = [
   Const        r0, [{"wr_return_amt": 100, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}, {"wr_return_amt": 30, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 2, "wr_returning_customer_sk": 2}, {"wr_return_amt": 50, "wr_returned_date_sk": 1, "wr_returning_addr_sk": 1, "wr_returning_customer_sk": 1}]
   // let date_dim = [
@@ -26,14 +26,16 @@ func main (regs=241)
   Const        r14, "wr_return_amt"
   // from wr in web_returns
   MakeMap      r15, 0, r0
-  Const        r16, []
+  Const        r17, []
+  Move         r16, r17
   IterPrep     r18, r0
   Len          r19, r18
   Const        r20, 0
 L8:
   LessInt      r21, r20, r19
   JumpIfFalse  r21, L0
-  Index        r23, r18, r20
+  Index        r22, r18, r20
+  Move         r23, r22
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
   IterPrep     r24, r1
   Len          r25, r24
@@ -41,7 +43,8 @@ L8:
 L7:
   LessInt      r27, r26, r25
   JumpIfFalse  r27, L1
-  Index        r29, r24, r26
+  Index        r28, r24, r26
+  Move         r29, r28
   Const        r30, "wr_returned_date_sk"
   Index        r31, r23, r30
   Const        r32, "d_date_sk"
@@ -55,7 +58,8 @@ L7:
 L6:
   LessInt      r38, r37, r36
   JumpIfFalse  r38, L2
-  Index        r40, r35, r37
+  Index        r39, r35, r37
+  Move         r40, r39
   Const        r41, "wr_returning_addr_sk"
   Index        r42, r23, r41
   Const        r43, "ca_address_sk"
@@ -69,305 +73,315 @@ L6:
   Index        r49, r40, r8
   Const        r50, "CA"
   Equal        r51, r49, r50
-  JumpIfFalse  r48, L4
-  Move         r48, r51
+  Move         r52, r48
+  JumpIfFalse  r52, L4
+  Move         r52, r51
 L4:
-  JumpIfFalse  r48, L3
+  JumpIfFalse  r52, L3
   // from wr in web_returns
-  Const        r52, "wr"
-  Move         r53, r23
-  Const        r54, "d"
-  Move         r55, r29
-  Const        r56, "ca"
-  Move         r57, r40
-  MakeMap      r58, 3, r52
+  Const        r53, "wr"
+  Move         r54, r23
+  Const        r55, "d"
+  Move         r56, r29
+  Const        r57, "ca"
+  Move         r58, r40
+  Move         r59, r53
+  Move         r60, r54
+  Move         r61, r55
+  Move         r62, r56
+  Move         r63, r57
+  Move         r64, r58
+  MakeMap      r65, 3, r59
   // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
-  Const        r59, "cust"
-  Index        r60, r23, r6
-  Const        r61, "state"
-  Index        r62, r40, r8
-  Move         r63, r59
-  Move         r64, r60
-  Move         r65, r61
-  Move         r66, r62
-  MakeMap      r67, 2, r63
-  Str          r68, r67
-  In           r69, r68, r15
-  JumpIfTrue   r69, L5
+  Const        r66, "cust"
+  Index        r67, r23, r6
+  Const        r68, "state"
+  Index        r69, r40, r8
+  Move         r70, r66
+  Move         r71, r67
+  Move         r72, r68
+  Move         r73, r69
+  MakeMap      r74, 2, r70
+  Str          r75, r74
+  In           r76, r75, r15
+  JumpIfTrue   r76, L5
   // from wr in web_returns
-  Const        r70, []
-  Const        r71, "__group__"
-  Const        r72, true
-  Const        r73, "key"
+  Const        r77, []
+  Const        r78, "__group__"
+  Const        r79, true
   // group by {cust: wr.wr_returning_customer_sk, state: ca.ca_state} into g
-  Move         r74, r67
+  Move         r80, r74
   // from wr in web_returns
-  Const        r75, "items"
-  Move         r76, r70
-  Const        r77, "count"
-  Const        r78, 0
-  Move         r79, r71
-  Move         r80, r72
-  Move         r81, r73
-  Move         r82, r74
-  Move         r83, r75
-  Move         r84, r76
-  Move         r85, r77
-  Move         r86, r78
-  MakeMap      r87, 4, r79
-  SetIndex     r15, r68, r87
-  Append       r16, r16, r87
+  Const        r81, "items"
+  Move         r82, r77
+  Const        r83, "count"
+  Const        r84, 0
+  Move         r85, r78
+  Move         r86, r79
+  Move         r87, r11
+  Move         r88, r80
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  Move         r92, r84
+  MakeMap      r93, 4, r85
+  SetIndex     r15, r75, r93
+  Append       r94, r16, r93
+  Move         r16, r94
 L5:
-  Const        r89, "items"
-  Index        r90, r15, r68
-  Index        r91, r90, r89
-  Append       r92, r91, r58
-  SetIndex     r90, r89, r92
-  Const        r93, "count"
-  Index        r94, r90, r93
-  Const        r95, 1
-  AddInt       r96, r94, r95
-  SetIndex     r90, r93, r96
+  Index        r95, r15, r75
+  Index        r96, r95, r81
+  Append       r97, r96, r65
+  SetIndex     r95, r81, r97
+  Index        r98, r95, r83
+  Const        r99, 1
+  AddInt       r100, r98, r99
+  SetIndex     r95, r83, r100
 L3:
   // join ca in customer_address on wr.wr_returning_addr_sk == ca.ca_address_sk
-  AddInt       r37, r37, r95
+  AddInt       r37, r37, r99
   Jump         L6
 L2:
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  AddInt       r26, r26, r95
+  AddInt       r26, r26, r99
   Jump         L7
 L1:
   // from wr in web_returns
-  AddInt       r20, r20, r95
+  AddInt       r20, r20, r99
   Jump         L8
 L0:
-  Const        r98, 0
-  Move         r97, r98
-  Len          r99, r16
+  Move         r101, r84
+  Len          r102, r16
 L12:
-  LessInt      r100, r97, r99
-  JumpIfFalse  r100, L9
-  Index        r102, r16, r97
+  LessInt      r103, r101, r102
+  JumpIfFalse  r103, L9
+  Index        r104, r16, r101
+  Move         r105, r104
   // ctr_customer_sk: g.key.cust,
-  Const        r103, "ctr_customer_sk"
-  Index        r104, r102, r11
-  Index        r105, r104, r5
+  Const        r106, "ctr_customer_sk"
+  Index        r107, r105, r11
+  Index        r108, r107, r5
   // ctr_state: g.key.state,
-  Const        r106, "ctr_state"
-  Index        r107, r102, r11
-  Index        r108, r107, r7
+  Const        r109, "ctr_state"
+  Index        r110, r105, r11
+  Index        r111, r110, r7
   // ctr_total_return: sum(from x in g select x.wr_return_amt)
-  Const        r109, "ctr_total_return"
-  Const        r110, []
-  IterPrep     r111, r102
-  Len          r112, r111
-  Move         r113, r98
+  Const        r112, "ctr_total_return"
+  Const        r113, []
+  IterPrep     r114, r105
+  Len          r115, r114
+  Move         r116, r84
 L11:
-  LessInt      r114, r113, r112
-  JumpIfFalse  r114, L10
-  Index        r116, r111, r113
-  Index        r117, r116, r14
-  Append       r110, r110, r117
-  AddInt       r113, r113, r95
+  LessInt      r117, r116, r115
+  JumpIfFalse  r117, L10
+  Index        r118, r114, r116
+  Move         r119, r118
+  Index        r120, r119, r14
+  Append       r121, r113, r120
+  Move         r113, r121
+  AddInt       r116, r116, r99
   Jump         L11
 L10:
-  Sum          r119, r110
+  Sum          r122, r113
   // ctr_customer_sk: g.key.cust,
-  Move         r120, r103
-  Move         r121, r105
+  Move         r123, r106
+  Move         r124, r108
   // ctr_state: g.key.state,
-  Move         r122, r106
-  Move         r123, r108
+  Move         r125, r109
+  Move         r126, r111
   // ctr_total_return: sum(from x in g select x.wr_return_amt)
-  Move         r124, r109
-  Move         r125, r119
+  Move         r127, r112
+  Move         r128, r122
   // select {
-  MakeMap      r126, 3, r120
+  MakeMap      r129, 3, r123
   // from wr in web_returns
-  Append       r4, r4, r126
-  AddInt       r97, r97, r95
+  Append       r130, r4, r129
+  Move         r4, r130
+  AddInt       r101, r101, r99
   Jump         L12
 L9:
   // from ctr in customer_total_return
-  Const        r128, []
+  Const        r131, []
   // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
-  Const        r129, "avg_return"
+  Const        r132, "avg_return"
   // from ctr in customer_total_return
-  IterPrep     r130, r4
-  Len          r131, r130
-  Const        r132, 0
-  MakeMap      r133, 0, r0
-  Const        r134, []
+  IterPrep     r133, r4
+  Len          r134, r133
+  Const        r135, 0
+  MakeMap      r136, 0, r0
+  Const        r138, []
+  Move         r137, r138
 L15:
-  LessInt      r136, r132, r131
-  JumpIfFalse  r136, L13
-  Index        r137, r130, r132
+  LessInt      r139, r135, r134
+  JumpIfFalse  r139, L13
+  Index        r140, r133, r135
+  Move         r141, r140
   // group by ctr.ctr_state into g
-  Index        r139, r137, r12
-  Str          r140, r139
-  In           r141, r140, r133
-  JumpIfTrue   r141, L14
+  Index        r142, r141, r12
+  Str          r143, r142
+  In           r144, r143, r136
+  JumpIfTrue   r144, L14
+  Move         r145, r142
   // from ctr in customer_total_return
-  Const        r142, []
-  Const        r143, "__group__"
-  Const        r144, true
-  Const        r145, "key"
-  // group by ctr.ctr_state into g
-  Move         r146, r139
-  // from ctr in customer_total_return
-  Const        r147, "items"
-  Move         r148, r142
-  Const        r149, "count"
-  Const        r150, 0
-  Move         r151, r143
-  Move         r152, r144
-  Move         r153, r145
-  Move         r154, r146
-  Move         r155, r147
-  Move         r156, r148
-  Move         r157, r149
-  Move         r158, r150
-  MakeMap      r159, 4, r151
-  SetIndex     r133, r140, r159
-  Append       r134, r134, r159
+  Move         r146, r77
+  Move         r147, r78
+  Move         r148, r79
+  Move         r149, r11
+  Move         r150, r145
+  Move         r151, r81
+  Move         r152, r146
+  Move         r153, r83
+  Move         r154, r84
+  MakeMap      r155, 4, r147
+  SetIndex     r136, r143, r155
+  Append       r156, r137, r155
+  Move         r137, r156
 L14:
-  Index        r161, r133, r140
-  Index        r162, r161, r89
-  Append       r163, r162, r137
-  SetIndex     r161, r89, r163
-  Index        r164, r161, r93
-  AddInt       r165, r164, r95
-  SetIndex     r161, r93, r165
-  AddInt       r132, r132, r95
+  Index        r157, r136, r143
+  Index        r158, r157, r81
+  Append       r159, r158, r140
+  SetIndex     r157, r81, r159
+  Index        r160, r157, r83
+  AddInt       r161, r160, r99
+  SetIndex     r157, r83, r161
+  AddInt       r135, r135, r99
   Jump         L15
 L13:
-  Move         r166, r98
-  Len          r167, r134
+  Move         r162, r84
+  Len          r163, r137
 L19:
-  LessInt      r168, r166, r167
-  JumpIfFalse  r168, L16
-  Index        r102, r134, r166
+  LessInt      r164, r162, r163
+  JumpIfFalse  r164, L16
+  Index        r165, r137, r162
+  Move         r105, r165
   // select {state: g.key, avg_return: avg(from x in g select x.ctr_total_return)}
-  Const        r170, "state"
-  Index        r171, r102, r11
-  Const        r172, "avg_return"
-  Const        r173, []
-  IterPrep     r174, r102
-  Len          r175, r174
-  Move         r176, r98
+  Const        r166, "state"
+  Index        r167, r105, r11
+  Const        r168, "avg_return"
+  Const        r169, []
+  IterPrep     r170, r105
+  Len          r171, r170
+  Move         r172, r84
 L18:
-  LessInt      r177, r176, r175
-  JumpIfFalse  r177, L17
-  Index        r116, r174, r176
-  Index        r179, r116, r13
-  Append       r173, r173, r179
-  AddInt       r176, r176, r95
+  LessInt      r173, r172, r171
+  JumpIfFalse  r173, L17
+  Index        r174, r170, r172
+  Move         r119, r174
+  Index        r175, r119, r13
+  Append       r176, r169, r175
+  Move         r169, r176
+  AddInt       r172, r172, r99
   Jump         L18
 L17:
-  Avg          r181, r173
-  Move         r182, r170
-  Move         r183, r171
-  Move         r184, r172
-  Move         r185, r181
-  MakeMap      r186, 2, r182
+  Avg          r177, r169
+  Move         r178, r166
+  Move         r179, r167
+  Move         r180, r168
+  Move         r181, r177
+  MakeMap      r182, 2, r178
   // from ctr in customer_total_return
-  Append       r128, r128, r186
-  AddInt       r166, r166, r95
+  Append       r183, r131, r182
+  Move         r131, r183
+  AddInt       r162, r162, r99
   Jump         L19
 L16:
   // from ctr in customer_total_return
-  Const        r188, []
+  Const        r184, []
   // c_customer_id: c.c_customer_id,
-  Const        r189, "c_customer_id"
+  Const        r185, "c_customer_id"
   // c_first_name: c.c_first_name,
-  Const        r190, "c_first_name"
+  Const        r186, "c_first_name"
   // c_last_name: c.c_last_name,
-  Const        r191, "c_last_name"
+  Const        r187, "c_last_name"
   // from ctr in customer_total_return
-  IterPrep     r192, r4
-  Len          r193, r192
-  Move         r194, r98
+  IterPrep     r188, r4
+  Len          r189, r188
+  Move         r190, r84
 L26:
-  LessInt      r195, r194, r193
-  JumpIfFalse  r195, L20
-  Index        r138, r192, r194
+  LessInt      r191, r190, r189
+  JumpIfFalse  r191, L20
+  Index        r192, r188, r190
+  Move         r141, r192
   // join avg in avg_by_state on ctr.ctr_state == avg.state
-  IterPrep     r197, r128
-  Len          r198, r197
-  Move         r199, r98
+  IterPrep     r193, r131
+  Len          r194, r193
+  Move         r195, r84
 L25:
-  LessInt      r200, r199, r198
-  JumpIfFalse  r200, L21
-  Index        r202, r197, r199
-  Index        r203, r138, r12
-  Index        r204, r202, r7
-  Equal        r205, r203, r204
-  JumpIfFalse  r205, L22
+  LessInt      r196, r195, r194
+  JumpIfFalse  r196, L21
+  Index        r197, r193, r195
+  Move         r198, r197
+  Index        r199, r141, r12
+  Index        r200, r198, r7
+  Equal        r201, r199, r200
+  JumpIfFalse  r201, L22
   // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
-  IterPrep     r206, r3
-  Len          r207, r206
-  Const        r208, "c_customer_sk"
-  Move         r209, r98
+  IterPrep     r202, r3
+  Len          r203, r202
+  Const        r204, "c_customer_sk"
+  Move         r205, r84
 L24:
-  LessInt      r210, r209, r207
-  JumpIfFalse  r210, L22
-  Index        r212, r206, r209
-  Index        r213, r138, r10
-  Index        r214, r212, r208
-  Equal        r215, r213, r214
-  JumpIfFalse  r215, L23
+  LessInt      r206, r205, r203
+  JumpIfFalse  r206, L22
+  Index        r207, r202, r205
+  Move         r208, r207
+  Index        r209, r141, r10
+  Index        r210, r208, r204
+  Equal        r211, r209, r210
+  JumpIfFalse  r211, L23
   // where ctr.ctr_total_return > avg.avg_return * 1.2
-  Index        r216, r138, r13
-  Index        r217, r202, r129
-  Const        r218, 1.2
-  MulFloat     r219, r217, r218
-  LessFloat    r220, r219, r216
-  JumpIfFalse  r220, L23
+  Index        r212, r141, r13
+  Index        r213, r198, r132
+  Const        r214, 1.2
+  MulFloat     r215, r213, r214
+  LessFloat    r216, r215, r212
+  JumpIfFalse  r216, L23
   // c_customer_id: c.c_customer_id,
-  Const        r221, "c_customer_id"
-  Index        r222, r212, r189
+  Const        r217, "c_customer_id"
+  Index        r218, r208, r185
   // c_first_name: c.c_first_name,
-  Const        r223, "c_first_name"
-  Index        r224, r212, r190
+  Const        r219, "c_first_name"
+  Index        r220, r208, r186
   // c_last_name: c.c_last_name,
-  Const        r225, "c_last_name"
-  Index        r226, r212, r191
+  Const        r221, "c_last_name"
+  Index        r222, r208, r187
   // ctr_total_return: ctr.ctr_total_return
-  Const        r227, "ctr_total_return"
-  Index        r228, r138, r13
+  Const        r223, "ctr_total_return"
+  Index        r224, r141, r13
   // c_customer_id: c.c_customer_id,
+  Move         r225, r217
+  Move         r226, r218
+  // c_first_name: c.c_first_name,
+  Move         r227, r219
+  Move         r228, r220
+  // c_last_name: c.c_last_name,
   Move         r229, r221
   Move         r230, r222
-  // c_first_name: c.c_first_name,
+  // ctr_total_return: ctr.ctr_total_return
   Move         r231, r223
   Move         r232, r224
-  // c_last_name: c.c_last_name,
-  Move         r233, r225
-  Move         r234, r226
-  // ctr_total_return: ctr.ctr_total_return
-  Move         r235, r227
-  Move         r236, r228
   // select {
-  MakeMap      r237, 4, r229
+  MakeMap      r233, 4, r225
   // from ctr in customer_total_return
-  Append       r188, r188, r237
+  Append       r234, r184, r233
+  Move         r184, r234
 L23:
   // join c in customer on ctr.ctr_customer_sk == c.c_customer_sk
-  Add          r209, r209, r95
+  Add          r205, r205, r99
   Jump         L24
 L22:
   // join avg in avg_by_state on ctr.ctr_state == avg.state
-  Add          r199, r199, r95
+  Add          r195, r195, r99
   Jump         L25
 L21:
   // from ctr in customer_total_return
-  AddInt       r194, r194, r95
+  AddInt       r190, r190, r99
   Jump         L26
 L20:
   // json(result)
-  JSON         r188
+  JSON         r184
   // expect result == [{c_customer_id: "C1", c_first_name: "John", c_last_name: "Doe", ctr_total_return: 150.0}]
-  Const        r239, [{"c_customer_id": "C1", "c_first_name": "John", "c_last_name": "Doe", "ctr_total_return": 150}]
-  Equal        r240, r188, r239
-  Expect       r240
+  Const        r235, [{"c_customer_id": "C1", "c_first_name": "John", "c_last_name": "Doe", "ctr_total_return": 150}]
+  Equal        r236, r184, r235
+  Expect       r236
   Return       r0

--- a/tests/dataset/tpc-ds/out/q31.ir.out
+++ b/tests/dataset/tpc-ds/out/q31.ir.out
@@ -1,4 +1,4 @@
-func main (regs=131)
+func main (regs=138)
   // let store_sales = [
   Const        r0, [{"ca_county": "A", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 100}, {"ca_county": "A", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 120}, {"ca_county": "A", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 160}, {"ca_county": "B", "d_qoy": 1, "d_year": 2000, "ss_ext_sales_price": 80}, {"ca_county": "B", "d_qoy": 2, "d_year": 2000, "ss_ext_sales_price": 90}, {"ca_county": "B", "d_qoy": 3, "d_year": 2000, "ss_ext_sales_price": 100}]
   // let web_sales = [
@@ -6,7 +6,8 @@ func main (regs=131)
   // let counties = ["A", "B"]
   Const        r2, ["A", "B"]
   // var result = []
-  Const        r4, []
+  Const        r3, []
+  Move         r4, r3
   // for county in counties {
   Const        r5, ["A", "B"]
   IterPrep     r6, r5
@@ -15,7 +16,8 @@ func main (regs=131)
 L27:
   Less         r9, r8, r7
   JumpIfFalse  r9, L0
-  Index        r11, r6, r8
+  Index        r10, r6, r8
+  Move         r11, r10
   // let ss1 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 1 select s.ss_ext_sales_price)
   Const        r12, []
   Const        r13, "ca_county"
@@ -28,205 +30,226 @@ L27:
 L4:
   LessInt      r20, r18, r17
   JumpIfFalse  r20, L1
-  Index        r22, r16, r18
+  Index        r21, r16, r18
+  Move         r22, r21
   Index        r23, r22, r13
   Equal        r24, r23, r11
   Index        r25, r22, r14
   Const        r26, 1
   Equal        r27, r25, r26
-  JumpIfFalse  r24, L2
-  Move         r24, r27
+  Move         r28, r24
+  JumpIfFalse  r28, L2
+  Move         r28, r27
 L2:
-  JumpIfFalse  r24, L3
-  Index        r28, r22, r15
-  Append       r12, r12, r28
+  JumpIfFalse  r28, L3
+  Index        r29, r22, r15
+  Append       r30, r12, r29
+  Move         r12, r30
 L3:
   AddInt       r18, r18, r26
   Jump         L4
 L1:
-  Sum          r30, r12
+  Sum          r31, r12
   // let ss2 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 2 select s.ss_ext_sales_price)
-  Const        r31, []
-  IterPrep     r32, r0
-  Len          r33, r32
-  Move         r34, r19
+  Const        r32, []
+  IterPrep     r33, r0
+  Len          r34, r33
+  Move         r35, r19
 L8:
-  LessInt      r35, r34, r33
-  JumpIfFalse  r35, L5
-  Index        r22, r32, r34
-  Index        r37, r22, r13
-  Equal        r38, r37, r11
-  Index        r39, r22, r14
-  Const        r40, 2
-  Equal        r41, r39, r40
-  JumpIfFalse  r38, L6
-  Move         r38, r41
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L5
+  Index        r37, r33, r35
+  Move         r22, r37
+  Index        r38, r22, r13
+  Equal        r39, r38, r11
+  Index        r40, r22, r14
+  Const        r41, 2
+  Equal        r42, r40, r41
+  Move         r43, r39
+  JumpIfFalse  r43, L6
+  Move         r43, r42
 L6:
-  JumpIfFalse  r38, L7
-  Index        r42, r22, r15
-  Append       r31, r31, r42
+  JumpIfFalse  r43, L7
+  Index        r44, r22, r15
+  Append       r45, r32, r44
+  Move         r32, r45
 L7:
-  AddInt       r34, r34, r26
+  AddInt       r35, r35, r26
   Jump         L8
 L5:
-  Sum          r44, r31
+  Sum          r46, r32
   // let ss3 = sum(from s in store_sales where s.ca_county == county && s.d_qoy == 3 select s.ss_ext_sales_price)
-  Const        r45, []
-  IterPrep     r46, r0
-  Len          r47, r46
-  Move         r48, r19
+  Const        r47, []
+  IterPrep     r48, r0
+  Len          r49, r48
+  Move         r50, r19
 L12:
-  LessInt      r49, r48, r47
-  JumpIfFalse  r49, L9
-  Index        r22, r46, r48
-  Index        r51, r22, r13
-  Equal        r52, r51, r11
-  Index        r53, r22, r14
-  Const        r54, 3
-  Equal        r55, r53, r54
-  JumpIfFalse  r52, L10
-  Move         r52, r55
+  LessInt      r51, r50, r49
+  JumpIfFalse  r51, L9
+  Index        r52, r48, r50
+  Move         r22, r52
+  Index        r53, r22, r13
+  Equal        r54, r53, r11
+  Index        r55, r22, r14
+  Const        r56, 3
+  Equal        r57, r55, r56
+  Move         r58, r54
+  JumpIfFalse  r58, L10
+  Move         r58, r57
 L10:
-  JumpIfFalse  r52, L11
-  Index        r56, r22, r15
-  Append       r45, r45, r56
+  JumpIfFalse  r58, L11
+  Index        r59, r22, r15
+  Append       r60, r47, r59
+  Move         r47, r60
 L11:
-  AddInt       r48, r48, r26
+  AddInt       r50, r50, r26
   Jump         L12
 L9:
-  Sum          r58, r45
+  Sum          r61, r47
   // let ws1 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 1 select w.ws_ext_sales_price)
-  Const        r59, []
-  Const        r60, "ws_ext_sales_price"
-  IterPrep     r61, r1
-  Len          r62, r61
-  Move         r63, r19
+  Const        r62, []
+  Const        r63, "ws_ext_sales_price"
+  IterPrep     r64, r1
+  Len          r65, r64
+  Move         r66, r19
 L16:
-  LessInt      r64, r63, r62
-  JumpIfFalse  r64, L13
-  Index        r66, r61, r63
-  Index        r67, r66, r13
-  Equal        r68, r67, r11
-  Index        r69, r66, r14
-  Equal        r70, r69, r26
-  JumpIfFalse  r68, L14
-  Move         r68, r70
+  LessInt      r67, r66, r65
+  JumpIfFalse  r67, L13
+  Index        r68, r64, r66
+  Move         r69, r68
+  Index        r70, r69, r13
+  Equal        r71, r70, r11
+  Index        r72, r69, r14
+  Equal        r73, r72, r26
+  Move         r74, r71
+  JumpIfFalse  r74, L14
+  Move         r74, r73
 L14:
-  JumpIfFalse  r68, L15
-  Index        r71, r66, r60
-  Append       r59, r59, r71
+  JumpIfFalse  r74, L15
+  Index        r75, r69, r63
+  Append       r76, r62, r75
+  Move         r62, r76
 L15:
-  AddInt       r63, r63, r26
+  AddInt       r66, r66, r26
   Jump         L16
 L13:
-  Sum          r73, r59
+  Sum          r77, r62
   // let ws2 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 2 select w.ws_ext_sales_price)
-  Const        r74, []
-  IterPrep     r75, r1
-  Len          r76, r75
-  Move         r77, r19
+  Const        r78, []
+  IterPrep     r79, r1
+  Len          r80, r79
+  Move         r81, r19
 L20:
-  LessInt      r78, r77, r76
-  JumpIfFalse  r78, L17
-  Index        r66, r75, r77
-  Index        r80, r66, r13
-  Equal        r81, r80, r11
-  Index        r82, r66, r14
-  Equal        r83, r82, r40
-  JumpIfFalse  r81, L18
-  Move         r81, r83
+  LessInt      r82, r81, r80
+  JumpIfFalse  r82, L17
+  Index        r83, r79, r81
+  Move         r69, r83
+  Index        r84, r69, r13
+  Equal        r85, r84, r11
+  Index        r86, r69, r14
+  Equal        r87, r86, r41
+  Move         r88, r85
+  JumpIfFalse  r88, L18
+  Move         r88, r87
 L18:
-  JumpIfFalse  r81, L19
-  Index        r84, r66, r60
-  Append       r74, r74, r84
+  JumpIfFalse  r88, L19
+  Index        r89, r69, r63
+  Append       r90, r78, r89
+  Move         r78, r90
 L19:
-  AddInt       r77, r77, r26
+  AddInt       r81, r81, r26
   Jump         L20
 L17:
-  Sum          r86, r74
+  Sum          r91, r78
   // let ws3 = sum(from w in web_sales where w.ca_county == county && w.d_qoy == 3 select w.ws_ext_sales_price)
-  Const        r87, []
-  IterPrep     r88, r1
-  Len          r89, r88
-  Move         r90, r19
+  Const        r92, []
+  IterPrep     r93, r1
+  Len          r94, r93
+  Move         r95, r19
 L24:
-  LessInt      r91, r90, r89
-  JumpIfFalse  r91, L21
-  Index        r66, r88, r90
-  Index        r93, r66, r13
-  Equal        r94, r93, r11
-  Index        r95, r66, r14
-  Equal        r96, r95, r54
-  JumpIfFalse  r94, L22
-  Move         r94, r96
+  LessInt      r96, r95, r94
+  JumpIfFalse  r96, L21
+  Index        r97, r93, r95
+  Move         r69, r97
+  Index        r98, r69, r13
+  Equal        r99, r98, r11
+  Index        r100, r69, r14
+  Equal        r101, r100, r56
+  Move         r102, r99
+  JumpIfFalse  r102, L22
+  Move         r102, r101
 L22:
-  JumpIfFalse  r94, L23
-  Index        r97, r66, r60
-  Append       r87, r87, r97
+  JumpIfFalse  r102, L23
+  Index        r103, r69, r63
+  Append       r104, r92, r103
+  Move         r92, r104
 L23:
-  AddInt       r90, r90, r26
+  AddInt       r95, r95, r26
   Jump         L24
 L21:
-  Sum          r99, r87
+  Sum          r105, r92
   // let web_g1 = ws2 / ws1
-  Div          r100, r86, r73
+  Div          r106, r91, r77
   // let store_g1 = ss2 / ss1
-  Div          r101, r44, r30
+  Div          r107, r46, r31
   // let web_g2 = ws3 / ws2
-  Div          r102, r99, r86
+  Div          r108, r105, r91
   // let store_g2 = ss3 / ss2
-  Div          r103, r58, r44
+  Div          r109, r61, r46
   // if web_g1 > store_g1 && web_g2 > store_g2 {
-  Less         r104, r101, r100
-  Less         r105, r103, r102
-  JumpIfFalse  r104, L25
-  Move         r104, r105
+  Less         r110, r107, r106
+  Less         r111, r109, r108
+  Move         r112, r110
+  JumpIfFalse  r112, L25
+  Move         r112, r111
 L25:
-  JumpIfFalse  r104, L26
+  JumpIfFalse  r112, L26
   // ca_county: county,
-  Const        r106, "ca_county"
+  Const        r113, "ca_county"
   // d_year: 2000,
-  Const        r107, "d_year"
-  Const        r108, 2000
+  Const        r114, "d_year"
+  Const        r115, 2000
   // web_q1_q2_increase: web_g1,
-  Const        r109, "web_q1_q2_increase"
+  Const        r116, "web_q1_q2_increase"
   // store_q1_q2_increase: store_g1,
-  Const        r110, "store_q1_q2_increase"
+  Const        r117, "store_q1_q2_increase"
   // web_q2_q3_increase: web_g2,
-  Const        r111, "web_q2_q3_increase"
+  Const        r118, "web_q2_q3_increase"
   // store_q2_q3_increase: store_g2
-  Const        r112, "store_q2_q3_increase"
+  Const        r119, "store_q2_q3_increase"
   // ca_county: county,
-  Move         r113, r106
-  Move         r114, r11
+  Move         r120, r113
+  Move         r121, r11
   // d_year: 2000,
-  Move         r115, r107
-  Move         r116, r108
+  Move         r122, r114
+  Move         r123, r115
   // web_q1_q2_increase: web_g1,
-  Move         r117, r109
-  Move         r118, r100
+  Move         r124, r116
+  Move         r125, r106
   // store_q1_q2_increase: store_g1,
-  Move         r119, r110
-  Move         r120, r101
+  Move         r126, r117
+  Move         r127, r107
   // web_q2_q3_increase: web_g2,
-  Move         r121, r111
-  Move         r122, r102
+  Move         r128, r118
+  Move         r129, r108
   // store_q2_q3_increase: store_g2
-  Move         r123, r112
-  Move         r124, r103
+  Move         r130, r119
+  Move         r131, r109
   // result = append(result, {
-  MakeMap      r125, 6, r113
-  Append       r4, r4, r125
+  MakeMap      r132, 6, r120
+  Append       r133, r4, r132
+  Move         r4, r133
 L26:
   // for county in counties {
-  Const        r127, 1
-  Add          r8, r8, r127
+  Const        r134, 1
+  Add          r135, r8, r134
+  Move         r8, r135
   Jump         L27
 L0:
   // json(result)
   JSON         r4
   // expect result == [
-  Const        r129, [{"ca_county": "A", "d_year": 2000, "store_q1_q2_increase": 1.2, "store_q2_q3_increase": 1.3333333333333333, "web_q1_q2_increase": 1.5, "web_q2_q3_increase": 1.6666666666666667}]
-  Equal        r130, r4, r129
-  Expect       r130
+  Const        r136, [{"ca_county": "A", "d_year": 2000, "store_q1_q2_increase": 1.2, "store_q2_q3_increase": 1.3333333333333333, "web_q1_q2_increase": 1.5, "web_q2_q3_increase": 1.6666666666666667}]
+  Equal        r137, r4, r136
+  Expect       r137
   Return       r0

--- a/tests/dataset/tpc-ds/out/q32.ir.out
+++ b/tests/dataset/tpc-ds/out/q32.ir.out
@@ -1,4 +1,4 @@
-func main (regs=59)
+func main (regs=60)
   // let catalog_sales = [
   Const        r0, [{"cs_ext_discount_amt": 5, "cs_item_sk": 1, "cs_sold_date_sk": 1}, {"cs_ext_discount_amt": 10, "cs_item_sk": 1, "cs_sold_date_sk": 2}, {"cs_ext_discount_amt": 20, "cs_item_sk": 1, "cs_sold_date_sk": 3}]
   // let item = [
@@ -20,7 +20,8 @@ func main (regs=59)
 L7:
   LessInt      r11, r9, r8
   JumpIfFalse  r11, L0
-  Index        r13, r7, r9
+  Index        r12, r7, r9
+  Move         r13, r12
   // join i in item on cs.cs_item_sk == i.i_item_sk
   IterPrep     r14, r1
   Len          r15, r14
@@ -30,7 +31,8 @@ L7:
 L6:
   LessInt      r19, r18, r15
   JumpIfFalse  r19, L1
-  Index        r21, r14, r18
+  Index        r20, r14, r18
+  Move         r21, r20
   Index        r22, r13, r16
   Index        r23, r21, r17
   Equal        r24, r22, r23
@@ -44,7 +46,8 @@ L6:
 L5:
   LessInt      r30, r29, r26
   JumpIfFalse  r30, L2
-  Index        r32, r25, r29
+  Index        r31, r25, r29
+  Move         r32, r31
   Index        r33, r13, r27
   Index        r34, r32, r28
   Equal        r35, r33, r34
@@ -56,14 +59,16 @@ L5:
   Index        r39, r32, r5
   Const        r40, 2000
   Equal        r41, r39, r40
-  JumpIfFalse  r38, L4
-  Move         r38, r41
+  Move         r42, r38
+  JumpIfFalse  r42, L4
+  Move         r42, r41
 L4:
-  JumpIfFalse  r38, L3
+  JumpIfFalse  r42, L3
   // select cs.cs_ext_discount_amt
-  Index        r42, r13, r6
+  Index        r43, r13, r6
   // from cs in catalog_sales
-  Append       r3, r3, r42
+  Append       r44, r3, r43
+  Move         r3, r44
 L3:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
   Add          r29, r29, r37
@@ -78,30 +83,32 @@ L1:
   Jump         L7
 L0:
   // let avg_discount = avg(filtered)
-  Avg          r44, r3
+  Avg          r45, r3
   // let result = sum(from x in filtered where x > avg_discount * 1.3 select x)
-  Const        r45, []
-  IterPrep     r46, r3
-  Len          r47, r46
-  Move         r48, r10
+  Const        r46, []
+  IterPrep     r47, r3
+  Len          r48, r47
+  Move         r49, r10
 L10:
-  LessInt      r49, r48, r47
-  JumpIfFalse  r49, L8
-  Index        r51, r46, r48
-  Const        r52, 1.3
-  MulFloat     r53, r44, r52
-  LessFloat    r54, r53, r51
-  JumpIfFalse  r54, L9
-  Append       r45, r45, r51
+  LessInt      r50, r49, r48
+  JumpIfFalse  r50, L8
+  Index        r51, r47, r49
+  Move         r52, r51
+  Const        r53, 1.3
+  MulFloat     r54, r45, r53
+  LessFloat    r55, r54, r52
+  JumpIfFalse  r55, L9
+  Append       r56, r46, r52
+  Move         r46, r56
 L9:
-  AddInt       r48, r48, r37
+  AddInt       r49, r49, r37
   Jump         L10
 L8:
-  Sum          r56, r45
+  Sum          r57, r46
   // json(result)
-  JSON         r56
+  JSON         r57
   // expect result == 20.0
-  Const        r57, 20
-  EqualFloat   r58, r56, r57
-  Expect       r58
+  Const        r58, 20
+  EqualFloat   r59, r57, r58
+  Expect       r59
   Return       r0

--- a/tests/dataset/tpc-ds/out/q33.ir.out
+++ b/tests/dataset/tpc-ds/out/q33.ir.out
@@ -1,4 +1,4 @@
-func main (regs=266)
+func main (regs=271)
   // let item = [
   Const        r0, [{"i_category": "Books", "i_item_sk": 1, "i_manufact_id": 1}, {"i_category": "Books", "i_item_sk": 2, "i_manufact_id": 2}]
   // let date_dim = [
@@ -32,20 +32,22 @@ func main (regs=266)
   Len          r18, r17
   Const        r20, 0
   Move         r19, r20
-L9:
+L11:
   LessInt      r21, r19, r18
   JumpIfFalse  r21, L0
-  Index        r23, r17, r19
+  Index        r22, r17, r19
+  Move         r23, r22
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   IterPrep     r24, r1
   Len          r25, r24
   Const        r26, "ss_sold_date_sk"
   Const        r27, "d_date_sk"
   Move         r28, r20
-L8:
+L10:
   LessInt      r29, r28, r25
   JumpIfFalse  r29, L1
-  Index        r31, r24, r28
+  Index        r30, r24, r28
+  Move         r31, r30
   Index        r32, r23, r26
   Index        r33, r31, r27
   Equal        r34, r32, r33
@@ -56,10 +58,11 @@ L8:
   Const        r37, "ss_addr_sk"
   Const        r38, "ca_address_sk"
   Move         r39, r20
-L7:
+L9:
   LessInt      r40, r39, r36
   JumpIfFalse  r40, L2
-  Index        r42, r35, r39
+  Index        r41, r35, r39
+  Move         r42, r41
   Index        r43, r23, r37
   Index        r44, r42, r38
   Equal        r45, r43, r44
@@ -70,10 +73,11 @@ L7:
   Const        r48, "ss_item_sk"
   Const        r49, "i_item_sk"
   Move         r50, r20
-L6:
+L8:
   LessInt      r51, r50, r47
   JumpIfFalse  r51, L3
-  Index        r53, r46, r50
+  Index        r52, r46, r50
+  Move         r53, r52
   Index        r54, r23, r48
   Index        r55, r53, r49
   Equal        r56, r54, r55
@@ -89,355 +93,389 @@ L6:
   Index        r64, r42, r12
   Const        r65, -5
   Equal        r66, r64, r65
-  JumpIfFalse  r59, L5
-  Move         r59, r61
-  JumpIfFalse  r59, L5
-  Move         r59, r63
-  JumpIfFalse  r59, L5
-  Move         r59, r66
+  Move         r67, r59
+  JumpIfFalse  r67, L5
+  Move         r67, r61
 L5:
-  JumpIfFalse  r59, L4
+  Move         r68, r67
+  JumpIfFalse  r68, L6
+  Move         r68, r63
+L6:
+  Move         r69, r68
+  JumpIfFalse  r69, L7
+  Move         r69, r66
+L7:
+  JumpIfFalse  r69, L4
   // select {manu: i.i_manufact_id, price: ss.ss_ext_sales_price},
-  Const        r67, "manu"
-  Index        r68, r53, r14
-  Const        r69, "price"
-  Index        r70, r23, r16
-  Move         r71, r67
-  Move         r72, r68
-  Move         r73, r69
+  Const        r70, "manu"
+  Index        r71, r53, r14
+  Const        r72, "price"
+  Index        r73, r23, r16
   Move         r74, r70
-  MakeMap      r75, 2, r71
+  Move         r75, r71
+  Move         r76, r72
+  Move         r77, r73
+  MakeMap      r78, 2, r74
   // from ss in store_sales
-  Append       r8, r8, r75
+  Append       r79, r8, r78
+  Move         r8, r79
 L4:
   // join i in item on ss.ss_item_sk == i.i_item_sk
   Add          r50, r50, r6
-  Jump         L6
+  Jump         L8
 L3:
   // join ca in customer_address on ss.ss_addr_sk == ca.ca_address_sk
   Add          r39, r39, r6
-  Jump         L7
+  Jump         L9
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   Add          r28, r28, r6
-  Jump         L8
+  Jump         L10
 L1:
   // from ss in store_sales
   AddInt       r19, r19, r6
-  Jump         L9
+  Jump         L11
 L0:
   // from cs in catalog_sales
-  Const        r77, []
+  Const        r80, []
   // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
-  Const        r78, "cs_ext_sales_price"
+  Const        r81, "cs_ext_sales_price"
   // from cs in catalog_sales
-  IterPrep     r79, r4
-  Len          r80, r79
-  Move         r81, r20
-L19:
-  LessInt      r82, r81, r80
-  JumpIfFalse  r82, L10
-  Index        r84, r79, r81
-  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r85, r1
-  Len          r86, r85
-  Const        r87, "cs_sold_date_sk"
-  Move         r88, r20
-L18:
-  LessInt      r89, r88, r86
-  JumpIfFalse  r89, L11
-  Index        r31, r85, r88
-  Index        r91, r84, r87
-  Index        r92, r31, r27
-  Equal        r93, r91, r92
-  JumpIfFalse  r93, L12
-  // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
-  IterPrep     r94, r2
-  Len          r95, r94
-  Const        r96, "cs_bill_addr_sk"
-  Move         r97, r20
-L17:
-  LessInt      r98, r97, r95
-  JumpIfFalse  r98, L12
-  Index        r42, r94, r97
-  Index        r100, r84, r96
-  Index        r101, r42, r38
-  Equal        r102, r100, r101
-  JumpIfFalse  r102, L13
-  // join i in item on cs.cs_item_sk == i.i_item_sk
-  IterPrep     r103, r0
-  Len          r104, r103
-  Const        r105, "cs_item_sk"
-  Move         r106, r20
-L16:
-  LessInt      r107, r106, r104
-  JumpIfFalse  r107, L13
-  Index        r53, r103, r106
-  Index        r109, r84, r105
-  Index        r110, r53, r49
-  Equal        r111, r109, r110
-  JumpIfFalse  r111, L14
-  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
-  Index        r112, r53, r9
-  Equal        r113, r112, r58
-  Index        r114, r31, r10
-  Equal        r115, r114, r7
-  Index        r116, r31, r11
-  Equal        r117, r116, r6
-  Index        r118, r42, r12
-  Equal        r119, r118, r65
-  JumpIfFalse  r113, L15
-  Move         r113, r115
-  JumpIfFalse  r113, L15
-  Move         r113, r117
-  JumpIfFalse  r113, L15
-  Move         r113, r119
-L15:
-  JumpIfFalse  r113, L14
-  // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
-  Const        r120, "manu"
-  Index        r121, r53, r14
-  Const        r122, "price"
-  Index        r123, r84, r78
-  Move         r124, r120
-  Move         r125, r121
-  Move         r126, r122
-  Move         r127, r123
-  MakeMap      r128, 2, r124
-  // from cs in catalog_sales
-  Append       r77, r77, r128
-L14:
-  // join i in item on cs.cs_item_sk == i.i_item_sk
-  Add          r106, r106, r6
-  Jump         L16
-L13:
-  // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
-  Add          r97, r97, r6
-  Jump         L17
-L12:
-  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  Add          r88, r88, r6
-  Jump         L18
-L11:
-  // from cs in catalog_sales
-  AddInt       r81, r81, r6
-  Jump         L19
-L10:
-  // let union_sales = concat(
-  UnionAll     r130, r8, r77
-  // from ws in web_sales
-  Const        r131, []
-  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
-  Const        r132, "ws_ext_sales_price"
-  // from ws in web_sales
-  IterPrep     r133, r5
-  Len          r134, r133
-  Move         r135, r20
-L29:
-  LessInt      r136, r135, r134
-  JumpIfFalse  r136, L20
-  Index        r138, r133, r135
-  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r139, r1
-  Len          r140, r139
-  Const        r141, "ws_sold_date_sk"
-  Move         r142, r20
-L28:
-  LessInt      r143, r142, r140
-  JumpIfFalse  r143, L21
-  Index        r31, r139, r142
-  Index        r145, r138, r141
-  Index        r146, r31, r27
-  Equal        r147, r145, r146
-  JumpIfFalse  r147, L22
-  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
-  IterPrep     r148, r2
-  Len          r149, r148
-  Const        r150, "ws_bill_addr_sk"
-  Move         r151, r20
-L27:
-  LessInt      r152, r151, r149
-  JumpIfFalse  r152, L22
-  Index        r42, r148, r151
-  Index        r154, r138, r150
-  Index        r155, r42, r38
-  Equal        r156, r154, r155
-  JumpIfFalse  r156, L23
-  // join i in item on ws.ws_item_sk == i.i_item_sk
-  IterPrep     r157, r0
-  Len          r158, r157
-  Const        r159, "ws_item_sk"
-  Move         r160, r20
-L26:
-  LessInt      r161, r160, r158
-  JumpIfFalse  r161, L23
-  Index        r53, r157, r160
-  Index        r163, r138, r159
-  Index        r164, r53, r49
-  Equal        r165, r163, r164
-  JumpIfFalse  r165, L24
-  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
-  Index        r166, r53, r9
-  Equal        r167, r166, r58
-  Index        r168, r31, r10
-  Equal        r169, r168, r7
-  Index        r170, r31, r11
-  Equal        r171, r170, r6
-  Index        r172, r42, r12
-  Equal        r173, r172, r65
-  JumpIfFalse  r167, L25
-  Move         r167, r169
-  JumpIfFalse  r167, L25
-  Move         r167, r171
-  JumpIfFalse  r167, L25
-  Move         r167, r173
-L25:
-  JumpIfFalse  r167, L24
-  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
-  Const        r174, "manu"
-  Index        r175, r53, r14
-  Const        r176, "price"
-  Index        r177, r138, r132
-  Move         r178, r174
-  Move         r179, r175
-  Move         r180, r176
-  Move         r181, r177
-  MakeMap      r182, 2, r178
-  // from ws in web_sales
-  Append       r131, r131, r182
-L24:
-  // join i in item on ws.ws_item_sk == i.i_item_sk
-  Add          r160, r160, r6
-  Jump         L26
+  IterPrep     r82, r4
+  Len          r83, r82
+  Move         r84, r20
 L23:
-  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
-  Add          r151, r151, r6
-  Jump         L27
+  LessInt      r85, r84, r83
+  JumpIfFalse  r85, L12
+  Index        r86, r82, r84
+  Move         r87, r86
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  IterPrep     r88, r1
+  Len          r89, r88
+  Const        r90, "cs_sold_date_sk"
+  Move         r91, r20
 L22:
-  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  Add          r142, r142, r6
-  Jump         L28
+  LessInt      r92, r91, r89
+  JumpIfFalse  r92, L13
+  Index        r93, r88, r91
+  Move         r31, r93
+  Index        r94, r87, r90
+  Index        r95, r31, r27
+  Equal        r96, r94, r95
+  JumpIfFalse  r96, L14
+  // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
+  IterPrep     r97, r2
+  Len          r98, r97
+  Const        r99, "cs_bill_addr_sk"
+  Move         r100, r20
 L21:
-  // from ws in web_sales
-  AddInt       r135, r135, r6
-  Jump         L29
+  LessInt      r101, r100, r98
+  JumpIfFalse  r101, L14
+  Index        r102, r97, r100
+  Move         r42, r102
+  Index        r103, r87, r99
+  Index        r104, r42, r38
+  Equal        r105, r103, r104
+  JumpIfFalse  r105, L15
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  IterPrep     r106, r0
+  Len          r107, r106
+  Const        r108, "cs_item_sk"
+  Move         r109, r20
 L20:
+  LessInt      r110, r109, r107
+  JumpIfFalse  r110, L15
+  Index        r111, r106, r109
+  Move         r53, r111
+  Index        r112, r87, r108
+  Index        r113, r53, r49
+  Equal        r114, r112, r113
+  JumpIfFalse  r114, L16
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Index        r115, r53, r9
+  Equal        r116, r115, r58
+  Index        r117, r31, r10
+  Equal        r118, r117, r7
+  Index        r119, r31, r11
+  Equal        r120, r119, r6
+  Index        r121, r42, r12
+  Equal        r122, r121, r65
+  Move         r123, r116
+  JumpIfFalse  r123, L17
+  Move         r123, r118
+L17:
+  Move         r124, r123
+  JumpIfFalse  r124, L18
+  Move         r124, r120
+L18:
+  Move         r125, r124
+  JumpIfFalse  r125, L19
+  Move         r125, r122
+L19:
+  JumpIfFalse  r125, L16
+  // select {manu: i.i_manufact_id, price: cs.cs_ext_sales_price},
+  Const        r126, "manu"
+  Index        r127, r53, r14
+  Const        r128, "price"
+  Index        r129, r87, r81
+  Move         r130, r126
+  Move         r131, r127
+  Move         r132, r128
+  Move         r133, r129
+  MakeMap      r134, 2, r130
+  // from cs in catalog_sales
+  Append       r135, r80, r134
+  Move         r80, r135
+L16:
+  // join i in item on cs.cs_item_sk == i.i_item_sk
+  Add          r109, r109, r6
+  Jump         L20
+L15:
+  // join ca in customer_address on cs.cs_bill_addr_sk == ca.ca_address_sk
+  Add          r100, r100, r6
+  Jump         L21
+L14:
+  // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
+  Add          r91, r91, r6
+  Jump         L22
+L13:
+  // from cs in catalog_sales
+  AddInt       r84, r84, r6
+  Jump         L23
+L12:
   // let union_sales = concat(
-  UnionAll     r184, r130, r131
-  // from s in union_sales
-  Const        r185, []
-  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
-  Const        r186, "key"
-  Const        r187, "total_sales"
-  // from s in union_sales
-  IterPrep     r188, r184
-  Len          r189, r188
-  Const        r190, 0
-  MakeMap      r191, 0, r0
-  Const        r192, []
-L32:
-  LessInt      r194, r190, r189
-  JumpIfFalse  r194, L30
-  Index        r195, r188, r190
-  // group by s.manu into g
-  Index        r197, r195, r13
-  Str          r198, r197
-  In           r199, r198, r191
-  JumpIfTrue   r199, L31
-  // from s in union_sales
-  Const        r200, []
-  Const        r201, "__group__"
-  Const        r202, true
-  Const        r203, "key"
-  // group by s.manu into g
-  Move         r204, r197
-  // from s in union_sales
-  Const        r205, "items"
-  Move         r206, r200
-  Const        r207, "count"
-  Const        r208, 0
-  Move         r209, r201
-  Move         r210, r202
-  Move         r211, r203
-  Move         r212, r204
-  Move         r213, r205
-  Move         r214, r206
-  Move         r215, r207
-  Move         r216, r208
-  MakeMap      r217, 4, r209
-  SetIndex     r191, r198, r217
-  Append       r192, r192, r217
-L31:
-  Const        r219, "items"
-  Index        r220, r191, r198
-  Index        r221, r220, r219
-  Append       r222, r221, r195
-  SetIndex     r220, r219, r222
-  Const        r223, "count"
-  Index        r224, r220, r223
-  AddInt       r225, r224, r6
-  SetIndex     r220, r223, r225
-  AddInt       r190, r190, r6
-  Jump         L32
-L30:
-  Move         r226, r20
-  Len          r227, r192
-L38:
-  LessInt      r228, r226, r227
-  JumpIfFalse  r228, L33
-  Index        r230, r192, r226
-  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
-  Const        r231, "i_manufact_id"
-  Index        r232, r230, r186
-  Const        r233, "total_sales"
-  Const        r234, []
-  IterPrep     r235, r230
-  Len          r236, r235
-  Move         r237, r20
+  UnionAll     r136, r8, r80
+  // from ws in web_sales
+  Const        r137, []
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r138, "ws_ext_sales_price"
+  // from ws in web_sales
+  IterPrep     r139, r5
+  Len          r140, r139
+  Move         r141, r20
 L35:
-  LessInt      r238, r237, r236
-  JumpIfFalse  r238, L34
-  Index        r240, r235, r237
-  Index        r241, r240, r15
-  Append       r234, r234, r241
-  AddInt       r237, r237, r6
-  Jump         L35
+  LessInt      r142, r141, r140
+  JumpIfFalse  r142, L24
+  Index        r143, r139, r141
+  Move         r144, r143
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  IterPrep     r145, r1
+  Len          r146, r145
+  Const        r147, "ws_sold_date_sk"
+  Move         r148, r20
 L34:
-  Sum          r243, r234
-  Move         r244, r231
-  Move         r245, r232
-  Move         r246, r233
-  Move         r247, r243
-  MakeMap      r248, 2, r244
-  // sort by -sum(from x in g select x.price)
-  Const        r249, []
-  IterPrep     r250, r230
-  Len          r251, r250
-  Move         r252, r20
-L37:
-  LessInt      r253, r252, r251
-  JumpIfFalse  r253, L36
-  Index        r240, r250, r252
-  Index        r255, r240, r15
-  Append       r249, r249, r255
-  AddInt       r252, r252, r6
-  Jump         L37
-L36:
-  Sum          r257, r249
-  Neg          r259, r257
-  // from s in union_sales
-  Move         r260, r248
-  MakeList     r261, 2, r259
-  Append       r185, r185, r261
-  AddInt       r226, r226, r6
-  Jump         L38
+  LessInt      r149, r148, r146
+  JumpIfFalse  r149, L25
+  Index        r150, r145, r148
+  Move         r31, r150
+  Index        r151, r144, r147
+  Index        r152, r31, r27
+  Equal        r153, r151, r152
+  JumpIfFalse  r153, L26
+  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
+  IterPrep     r154, r2
+  Len          r155, r154
+  Const        r156, "ws_bill_addr_sk"
+  Move         r157, r20
 L33:
+  LessInt      r158, r157, r155
+  JumpIfFalse  r158, L26
+  Index        r159, r154, r157
+  Move         r42, r159
+  Index        r160, r144, r156
+  Index        r161, r42, r38
+  Equal        r162, r160, r161
+  JumpIfFalse  r162, L27
+  // join i in item on ws.ws_item_sk == i.i_item_sk
+  IterPrep     r163, r0
+  Len          r164, r163
+  Const        r165, "ws_item_sk"
+  Move         r166, r20
+L32:
+  LessInt      r167, r166, r164
+  JumpIfFalse  r167, L27
+  Index        r168, r163, r166
+  Move         r53, r168
+  Index        r169, r144, r165
+  Index        r170, r53, r49
+  Equal        r171, r169, r170
+  JumpIfFalse  r171, L28
+  // where i.i_category == "Books" && d.d_year == year && d.d_moy == month && ca.ca_gmt_offset == (-5)
+  Index        r172, r53, r9
+  Equal        r173, r172, r58
+  Index        r174, r31, r10
+  Equal        r175, r174, r7
+  Index        r176, r31, r11
+  Equal        r177, r176, r6
+  Index        r178, r42, r12
+  Equal        r179, r178, r65
+  Move         r180, r173
+  JumpIfFalse  r180, L29
+  Move         r180, r175
+L29:
+  Move         r181, r180
+  JumpIfFalse  r181, L30
+  Move         r181, r177
+L30:
+  Move         r182, r181
+  JumpIfFalse  r182, L31
+  Move         r182, r179
+L31:
+  JumpIfFalse  r182, L28
+  // select {manu: i.i_manufact_id, price: ws.ws_ext_sales_price}
+  Const        r183, "manu"
+  Index        r184, r53, r14
+  Const        r185, "price"
+  Index        r186, r144, r138
+  Move         r187, r183
+  Move         r188, r184
+  Move         r189, r185
+  Move         r190, r186
+  MakeMap      r191, 2, r187
+  // from ws in web_sales
+  Append       r192, r137, r191
+  Move         r137, r192
+L28:
+  // join i in item on ws.ws_item_sk == i.i_item_sk
+  Add          r166, r166, r6
+  Jump         L32
+L27:
+  // join ca in customer_address on ws.ws_bill_addr_sk == ca.ca_address_sk
+  Add          r157, r157, r6
+  Jump         L33
+L26:
+  // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
+  Add          r148, r148, r6
+  Jump         L34
+L25:
+  // from ws in web_sales
+  AddInt       r141, r141, r6
+  Jump         L35
+L24:
+  // let union_sales = concat(
+  UnionAll     r193, r136, r137
+  // from s in union_sales
+  Const        r194, []
+  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
+  Const        r195, "key"
+  Const        r196, "total_sales"
+  // from s in union_sales
+  IterPrep     r197, r193
+  Len          r198, r197
+  Const        r199, 0
+  MakeMap      r200, 0, r0
+  Const        r202, []
+  Move         r201, r202
+L38:
+  LessInt      r203, r199, r198
+  JumpIfFalse  r203, L36
+  Index        r204, r197, r199
+  Move         r205, r204
+  // group by s.manu into g
+  Index        r206, r205, r13
+  Str          r207, r206
+  In           r208, r207, r200
+  JumpIfTrue   r208, L37
+  // from s in union_sales
+  Const        r209, []
+  Const        r210, "__group__"
+  Const        r211, true
+  // group by s.manu into g
+  Move         r212, r206
+  // from s in union_sales
+  Const        r213, "items"
+  Move         r214, r209
+  Const        r215, "count"
+  Move         r216, r210
+  Move         r217, r211
+  Move         r218, r195
+  Move         r219, r212
+  Move         r220, r213
+  Move         r221, r214
+  Move         r222, r215
+  Move         r223, r20
+  MakeMap      r224, 4, r216
+  SetIndex     r200, r207, r224
+  Append       r225, r201, r224
+  Move         r201, r225
+L37:
+  Index        r226, r200, r207
+  Index        r227, r226, r213
+  Append       r228, r227, r204
+  SetIndex     r226, r213, r228
+  Index        r229, r226, r215
+  AddInt       r230, r229, r6
+  SetIndex     r226, r215, r230
+  AddInt       r199, r199, r6
+  Jump         L38
+L36:
+  Move         r231, r20
+  Len          r232, r201
+L44:
+  LessInt      r233, r231, r232
+  JumpIfFalse  r233, L39
+  Index        r234, r201, r231
+  Move         r235, r234
+  // select {i_manufact_id: g.key, total_sales: sum(from x in g select x.price)}
+  Const        r236, "i_manufact_id"
+  Index        r237, r235, r195
+  Const        r238, "total_sales"
+  Const        r239, []
+  IterPrep     r240, r235
+  Len          r241, r240
+  Move         r242, r20
+L41:
+  LessInt      r243, r242, r241
+  JumpIfFalse  r243, L40
+  Index        r244, r240, r242
+  Move         r245, r244
+  Index        r246, r245, r15
+  Append       r247, r239, r246
+  Move         r239, r247
+  AddInt       r242, r242, r6
+  Jump         L41
+L40:
+  Sum          r248, r239
+  Move         r249, r236
+  Move         r250, r237
+  Move         r251, r238
+  Move         r252, r248
+  MakeMap      r253, 2, r249
   // sort by -sum(from x in g select x.price)
-  Sort         r185, r185
+  Const        r254, []
+  IterPrep     r255, r235
+  Len          r256, r255
+  Move         r257, r20
+L43:
+  LessInt      r258, r257, r256
+  JumpIfFalse  r258, L42
+  Index        r259, r255, r257
+  Move         r245, r259
+  Index        r260, r245, r15
+  Append       r261, r254, r260
+  Move         r254, r261
+  AddInt       r257, r257, r6
+  Jump         L43
+L42:
+  Sum          r262, r254
+  Neg          r263, r262
+  Move         r264, r263
+  // from s in union_sales
+  Move         r265, r253
+  MakeList     r266, 2, r264
+  Append       r267, r194, r266
+  Move         r194, r267
+  AddInt       r231, r231, r6
+  Jump         L44
+L39:
+  // sort by -sum(from x in g select x.price)
+  Sort         r268, r194
+  // from s in union_sales
+  Move         r194, r268
   // json(result)
-  JSON         r185
+  JSON         r194
   // expect result == [
-  Const        r264, [{"i_manufact_id": 1, "total_sales": 150}, {"i_manufact_id": 2, "total_sales": 50}]
-  Equal        r265, r185, r264
-  Expect       r265
+  Const        r269, [{"i_manufact_id": 1, "total_sales": 150}, {"i_manufact_id": 2, "total_sales": 50}]
+  Equal        r270, r194, r269
+  Expect       r270
   Return       r0

--- a/tests/dataset/tpc-ds/out/q34.ir.out
+++ b/tests/dataset/tpc-ds/out/q34.ir.out
@@ -1,4 +1,4 @@
-func main (regs=210)
+func main (regs=221)
   // let store_sales = [
   Const        r0, [{"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 1, "ss_hdemo_sk": 1, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 1}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}, {"ss_customer_sk": 2, "ss_hdemo_sk": 2, "ss_sold_date_sk": 1, "ss_store_sk": 1, "ss_ticket_number": 2}]
   // let date_dim = [
@@ -28,22 +28,25 @@ func main (regs=210)
   Const        r17, "cnt"
   // from ss in store_sales
   MakeMap      r18, 0, r0
-  Const        r19, []
+  Const        r20, []
+  Move         r19, r20
   IterPrep     r21, r0
   Len          r22, r21
   Const        r23, 0
-L11:
+L15:
   LessInt      r24, r23, r22
   JumpIfFalse  r24, L0
-  Index        r26, r21, r23
+  Index        r25, r21, r23
+  Move         r26, r25
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   IterPrep     r27, r1
   Len          r28, r27
   Const        r29, 0
-L10:
+L14:
   LessInt      r30, r29, r28
   JumpIfFalse  r30, L1
-  Index        r32, r27, r29
+  Index        r31, r27, r29
+  Move         r32, r31
   Const        r33, "ss_sold_date_sk"
   Index        r34, r26, r33
   Const        r35, "d_date_sk"
@@ -54,10 +57,11 @@ L10:
   IterPrep     r38, r2
   Len          r39, r38
   Const        r40, 0
-L9:
+L13:
   LessInt      r41, r40, r39
   JumpIfFalse  r41, L2
-  Index        r43, r38, r40
+  Index        r42, r38, r40
+  Move         r43, r42
   Const        r44, "ss_store_sk"
   Index        r45, r26, r44
   Const        r46, "s_store_sk"
@@ -68,10 +72,11 @@ L9:
   IterPrep     r49, r3
   Len          r50, r49
   Const        r51, 0
-L8:
+L12:
   LessInt      r52, r51, r50
   JumpIfFalse  r52, L3
-  Index        r54, r49, r51
+  Index        r53, r49, r51
+  Move         r54, r53
   Const        r55, "ss_hdemo_sk"
   Index        r56, r26, r55
   Const        r57, "hd_demo_sk"
@@ -85,225 +90,249 @@ L8:
   Index        r63, r32, r10
   Const        r64, 3
   LessEq       r65, r63, r64
-  JumpIfFalse  r62, L5
-  Move         r62, r65
+  Move         r66, r62
+  JumpIfFalse  r66, L5
+  Move         r66, r65
 L5:
-  Index        r66, r54, r12
-  Const        r67, 0
-  Less         r68, r67, r66
-  Index        r69, r54, r13
-  Index        r70, r54, r12
-  Div          r71, r69, r70
-  Const        r72, 1.2
-  LessFloat    r73, r72, r71
-  Index        r74, r54, r11
-  Const        r75, ">10000"
-  Equal        r76, r74, r75
-  Index        r77, r32, r14
-  Const        r78, 2000
-  Equal        r79, r77, r78
-  Index        r80, r43, r15
-  Const        r81, "A"
-  Equal        r82, r80, r81
-  JumpIfFalse  r62, L6
-  Move         r62, r76
-  JumpIfFalse  r62, L6
-  Move         r62, r68
-  JumpIfFalse  r62, L6
-  Move         r62, r73
-  JumpIfFalse  r62, L6
-  Move         r62, r79
-  JumpIfFalse  r62, L6
-  Move         r62, r82
+  Index        r67, r54, r12
+  Const        r68, 0
+  Less         r69, r68, r67
+  Index        r70, r54, r13
+  Index        r71, r54, r12
+  Div          r72, r70, r71
+  Const        r73, 1.2
+  LessFloat    r74, r73, r72
+  Index        r75, r54, r11
+  Const        r76, ">10000"
+  Equal        r77, r75, r76
+  Index        r78, r32, r14
+  Const        r79, 2000
+  Equal        r80, r78, r79
+  Index        r81, r43, r15
+  Const        r82, "A"
+  Equal        r83, r81, r82
+  Move         r84, r66
+  JumpIfFalse  r84, L6
+  Move         r84, r77
 L6:
-  JumpIfFalse  r62, L4
-  // from ss in store_sales
-  Const        r83, "ss"
-  Move         r84, r26
-  Const        r85, "d"
-  Move         r86, r32
-  Const        r87, "s"
-  Move         r88, r43
-  Const        r89, "hd"
-  Move         r90, r54
-  MakeMap      r91, 4, r83
-  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
-  Const        r92, "ticket"
-  Index        r93, r26, r7
-  Const        r94, "cust"
-  Index        r95, r26, r9
-  Move         r96, r92
-  Move         r97, r93
-  Move         r98, r94
-  Move         r99, r95
-  MakeMap      r100, 2, r96
-  Str          r101, r100
-  In           r102, r101, r18
-  JumpIfTrue   r102, L7
-  // from ss in store_sales
-  Const        r103, []
-  Const        r104, "__group__"
-  Const        r105, true
-  Const        r106, "key"
-  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
-  Move         r107, r100
-  // from ss in store_sales
-  Const        r108, "items"
-  Move         r109, r103
-  Const        r110, "count"
-  Const        r111, 0
-  Move         r112, r104
-  Move         r113, r105
-  Move         r114, r106
-  Move         r115, r107
-  Move         r116, r108
-  Move         r117, r109
-  Move         r118, r110
-  Move         r119, r111
-  MakeMap      r120, 4, r112
-  SetIndex     r18, r101, r120
-  Append       r19, r19, r120
+  Move         r85, r84
+  JumpIfFalse  r85, L7
+  Move         r85, r69
 L7:
-  Const        r122, "items"
-  Index        r123, r18, r101
-  Index        r124, r123, r122
-  Append       r125, r124, r91
-  SetIndex     r123, r122, r125
-  Const        r126, "count"
-  Index        r127, r123, r126
-  AddInt       r128, r127, r61
-  SetIndex     r123, r126, r128
+  Move         r86, r85
+  JumpIfFalse  r86, L8
+  Move         r86, r74
+L8:
+  Move         r87, r86
+  JumpIfFalse  r87, L9
+  Move         r87, r80
+L9:
+  Move         r88, r87
+  JumpIfFalse  r88, L10
+  Move         r88, r83
+L10:
+  JumpIfFalse  r88, L4
+  // from ss in store_sales
+  Const        r89, "ss"
+  Move         r90, r26
+  Const        r91, "d"
+  Move         r92, r32
+  Const        r93, "s"
+  Move         r94, r43
+  Const        r95, "hd"
+  Move         r96, r54
+  Move         r97, r89
+  Move         r98, r90
+  Move         r99, r91
+  Move         r100, r92
+  Move         r101, r93
+  Move         r102, r94
+  Move         r103, r95
+  Move         r104, r96
+  MakeMap      r105, 4, r97
+  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
+  Const        r106, "ticket"
+  Index        r107, r26, r7
+  Const        r108, "cust"
+  Index        r109, r26, r9
+  Move         r110, r106
+  Move         r111, r107
+  Move         r112, r108
+  Move         r113, r109
+  MakeMap      r114, 2, r110
+  Str          r115, r114
+  In           r116, r115, r18
+  JumpIfTrue   r116, L11
+  // from ss in store_sales
+  Const        r117, []
+  Const        r118, "__group__"
+  Const        r119, true
+  // group by {ticket: ss.ss_ticket_number, cust: ss.ss_customer_sk} into g
+  Move         r120, r114
+  // from ss in store_sales
+  Const        r121, "items"
+  Move         r122, r117
+  Const        r123, "count"
+  Move         r124, r118
+  Move         r125, r119
+  Move         r126, r16
+  Move         r127, r120
+  Move         r128, r121
+  Move         r129, r122
+  Move         r130, r123
+  Move         r131, r68
+  MakeMap      r132, 4, r124
+  SetIndex     r18, r115, r132
+  Append       r133, r19, r132
+  Move         r19, r133
+L11:
+  Index        r134, r18, r115
+  Index        r135, r134, r121
+  Append       r136, r135, r105
+  SetIndex     r134, r121, r136
+  Index        r137, r134, r123
+  AddInt       r138, r137, r61
+  SetIndex     r134, r123, r138
 L4:
   // join hd in household_demographics on ss.ss_hdemo_sk == hd.hd_demo_sk
   AddInt       r51, r51, r61
-  Jump         L8
+  Jump         L12
 L3:
   // join s in store on ss.ss_store_sk == s.s_store_sk
   AddInt       r40, r40, r61
-  Jump         L9
+  Jump         L13
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   AddInt       r29, r29, r61
-  Jump         L10
+  Jump         L14
 L1:
   // from ss in store_sales
   AddInt       r23, r23, r61
-  Jump         L11
+  Jump         L15
 L0:
-  Move         r129, r67
-  Len          r130, r19
-L13:
-  LessInt      r131, r129, r130
-  JumpIfFalse  r131, L12
-  Index        r133, r19, r129
-  // select {ss_ticket_number: g.key.ticket, ss_customer_sk: g.key.cust, cnt: count(g)}
-  Const        r134, "ss_ticket_number"
-  Index        r135, r133, r16
-  Index        r136, r135, r6
-  Const        r137, "ss_customer_sk"
-  Index        r138, r133, r16
-  Index        r139, r138, r8
-  Const        r140, "cnt"
-  Index        r141, r133, r126
-  Move         r142, r134
-  Move         r143, r136
-  Move         r144, r137
-  Move         r145, r139
-  Move         r146, r140
-  Move         r147, r141
-  MakeMap      r148, 3, r142
-  // from ss in store_sales
-  Append       r5, r5, r148
-  AddInt       r129, r129, r61
-  Jump         L13
-L12:
-  // from dn1 in dn
-  Const        r150, []
-  IterPrep     r151, r5
-  Len          r152, r151
-  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
-  IterPrep     r153, r4
-  Len          r154, r153
-  Const        r155, "c_customer_sk"
-  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
-  Const        r156, "c_last_name"
-  Const        r157, "c_first_name"
-  Const        r158, "c_salutation"
-  Const        r159, "c_preferred_cust_flag"
-  // from dn1 in dn
-  Const        r160, 0
-L19:
-  LessInt      r161, r160, r152
-  JumpIfFalse  r161, L14
-  Index        r163, r151, r160
-  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
-  Const        r164, 0
-L18:
-  LessInt      r165, r164, r154
-  JumpIfFalse  r165, L15
-  Index        r167, r153, r164
-  Index        r168, r163, r9
-  Index        r169, r167, r155
-  Equal        r170, r168, r169
-  JumpIfFalse  r170, L16
-  // where dn1.cnt >= 15 && dn1.cnt <= 20
-  Index        r171, r163, r17
-  Const        r172, 15
-  LessEq       r173, r172, r171
-  Index        r174, r163, r17
-  Const        r175, 20
-  LessEq       r176, r174, r175
-  JumpIfFalse  r173, L17
-  Move         r173, r176
+  Move         r139, r68
+  Len          r140, r19
 L17:
-  JumpIfFalse  r173, L16
-  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
-  Const        r177, "c_last_name"
-  Index        r178, r167, r156
-  Const        r179, "c_first_name"
-  Index        r180, r167, r157
-  Const        r181, "c_salutation"
-  Index        r182, r167, r158
-  Const        r183, "c_preferred_cust_flag"
-  Index        r184, r167, r159
-  Const        r185, "ss_ticket_number"
-  Index        r186, r163, r7
-  Const        r187, "cnt"
-  Index        r188, r163, r17
-  Move         r189, r177
-  Move         r190, r178
-  Move         r191, r179
-  Move         r192, r180
-  Move         r193, r181
-  Move         r194, r182
-  Move         r195, r183
-  Move         r196, r184
-  Move         r197, r185
-  Move         r198, r186
-  Move         r199, r187
-  Move         r200, r188
-  MakeMap      r201, 6, r189
-  // sort by c.c_last_name
-  Index        r203, r167, r156
-  // from dn1 in dn
-  Move         r204, r201
-  MakeList     r205, 2, r203
-  Append       r150, r150, r205
+  LessInt      r141, r139, r140
+  JumpIfFalse  r141, L16
+  Index        r142, r19, r139
+  Move         r143, r142
+  // select {ss_ticket_number: g.key.ticket, ss_customer_sk: g.key.cust, cnt: count(g)}
+  Const        r144, "ss_ticket_number"
+  Index        r145, r143, r16
+  Index        r146, r145, r6
+  Const        r147, "ss_customer_sk"
+  Index        r148, r143, r16
+  Index        r149, r148, r8
+  Const        r150, "cnt"
+  Index        r151, r143, r123
+  Move         r152, r144
+  Move         r153, r146
+  Move         r154, r147
+  Move         r155, r149
+  Move         r156, r150
+  Move         r157, r151
+  MakeMap      r158, 3, r152
+  // from ss in store_sales
+  Append       r159, r5, r158
+  Move         r5, r159
+  AddInt       r139, r139, r61
+  Jump         L17
 L16:
-  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
-  AddInt       r164, r164, r61
-  Jump         L18
-L15:
   // from dn1 in dn
-  AddInt       r160, r160, r61
-  Jump         L19
-L14:
+  Const        r160, []
+  IterPrep     r161, r5
+  Len          r162, r161
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  IterPrep     r163, r4
+  Len          r164, r163
+  Const        r165, "c_customer_sk"
+  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
+  Const        r166, "c_last_name"
+  Const        r167, "c_first_name"
+  Const        r168, "c_salutation"
+  Const        r169, "c_preferred_cust_flag"
+  // from dn1 in dn
+  Const        r170, 0
+L23:
+  LessInt      r171, r170, r162
+  JumpIfFalse  r171, L18
+  Index        r172, r161, r170
+  Move         r173, r172
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  Const        r174, 0
+L22:
+  LessInt      r175, r174, r164
+  JumpIfFalse  r175, L19
+  Index        r176, r163, r174
+  Move         r177, r176
+  Index        r178, r173, r9
+  Index        r179, r177, r165
+  Equal        r180, r178, r179
+  JumpIfFalse  r180, L20
+  // where dn1.cnt >= 15 && dn1.cnt <= 20
+  Index        r181, r173, r17
+  Const        r182, 15
+  LessEq       r183, r182, r181
+  Index        r184, r173, r17
+  Const        r185, 20
+  LessEq       r186, r184, r185
+  Move         r187, r183
+  JumpIfFalse  r187, L21
+  Move         r187, r186
+L21:
+  JumpIfFalse  r187, L20
+  // select {c_last_name: c.c_last_name, c_first_name: c.c_first_name, c_salutation: c.c_salutation, c_preferred_cust_flag: c.c_preferred_cust_flag, ss_ticket_number: dn1.ss_ticket_number, cnt: dn1.cnt}
+  Const        r188, "c_last_name"
+  Index        r189, r177, r166
+  Const        r190, "c_first_name"
+  Index        r191, r177, r167
+  Const        r192, "c_salutation"
+  Index        r193, r177, r168
+  Const        r194, "c_preferred_cust_flag"
+  Index        r195, r177, r169
+  Const        r196, "ss_ticket_number"
+  Index        r197, r173, r7
+  Const        r198, "cnt"
+  Index        r199, r173, r17
+  Move         r200, r188
+  Move         r201, r189
+  Move         r202, r190
+  Move         r203, r191
+  Move         r204, r192
+  Move         r205, r193
+  Move         r206, r194
+  Move         r207, r195
+  Move         r208, r196
+  Move         r209, r197
+  Move         r210, r198
+  Move         r211, r199
+  MakeMap      r212, 6, r200
   // sort by c.c_last_name
-  Sort         r150, r150
+  Index        r213, r177, r166
+  Move         r214, r213
+  // from dn1 in dn
+  Move         r215, r212
+  MakeList     r216, 2, r214
+  Append       r217, r160, r216
+  Move         r160, r217
+L20:
+  // join c in customer on dn1.ss_customer_sk == c.c_customer_sk
+  AddInt       r174, r174, r61
+  Jump         L22
+L19:
+  // from dn1 in dn
+  AddInt       r170, r170, r61
+  Jump         L23
+L18:
+  // sort by c.c_last_name
+  Sort         r218, r160
+  // from dn1 in dn
+  Move         r160, r218
   // json(result)
-  JSON         r150
+  JSON         r160
   // expect result == [{c_last_name: "Smith", c_first_name: "John", c_salutation: "Mr.", c_preferred_cust_flag: "Y", ss_ticket_number: 1, cnt: 16}]
-  Const        r208, [{"c_first_name": "John", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Mr.", "cnt": 16, "ss_ticket_number": 1}]
-  Equal        r209, r150, r208
-  Expect       r209
+  Const        r219, [{"c_first_name": "John", "c_last_name": "Smith", "c_preferred_cust_flag": "Y", "c_salutation": "Mr.", "cnt": 16, "ss_ticket_number": 1}]
+  Equal        r220, r160, r219
+  Expect       r220
   Return       r0

--- a/tests/dataset/tpc-ds/out/q35.ir.out
+++ b/tests/dataset/tpc-ds/out/q35.ir.out
@@ -1,4 +1,4 @@
-func main (regs=188)
+func main (regs=191)
   // let customer = [
   Const        r0, [{"c_current_addr_sk": 1, "c_current_cdemo_sk": 1, "c_customer_sk": 1}, {"c_current_addr_sk": 2, "c_current_cdemo_sk": 2, "c_customer_sk": 2}]
   // let customer_address = [
@@ -28,13 +28,15 @@ func main (regs=188)
 L5:
   LessInt      r16, r15, r7
   JumpIfFalse  r16, L0
-  Index        r18, r6, r15
+  Index        r17, r6, r15
+  Move         r18, r17
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   Const        r19, 0
 L4:
   LessInt      r20, r19, r9
   JumpIfFalse  r20, L1
-  Index        r22, r8, r19
+  Index        r21, r8, r19
+  Move         r22, r21
   Index        r23, r18, r10
   Index        r24, r22, r11
   Equal        r25, r23, r24
@@ -46,235 +48,247 @@ L4:
   Less         r29, r27, r28
   Const        r30, 2000
   Equal        r31, r26, r30
-  JumpIfFalse  r31, L3
-  Move         r31, r29
+  Move         r32, r31
+  JumpIfFalse  r32, L3
+  Move         r32, r29
 L3:
-  JumpIfFalse  r31, L2
+  JumpIfFalse  r32, L2
   // select ss.ss_customer_sk
-  Index        r32, r18, r14
+  Index        r33, r18, r14
   // from ss in store_sales
-  Append       r5, r5, r32
+  Append       r34, r5, r33
+  Move         r5, r34
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  Const        r34, 1
-  AddInt       r19, r19, r34
+  Const        r35, 1
+  AddInt       r19, r19, r35
   Jump         L4
 L1:
   // from ss in store_sales
-  AddInt       r15, r15, r34
+  AddInt       r15, r15, r35
   Jump         L5
 L0:
   // from c in customer
-  Const        r35, []
+  Const        r36, []
   // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
-  Const        r36, "state"
-  Const        r37, "ca_state"
-  Const        r38, "gender"
-  Const        r39, "cd_gender"
-  Const        r40, "marital"
-  Const        r41, "cd_marital_status"
-  Const        r42, "dep"
-  Const        r43, "cd_dep_count"
-  Const        r44, "emp"
-  Const        r45, "cd_dep_employed_count"
-  Const        r46, "col"
-  Const        r47, "cd_dep_college_count"
+  Const        r37, "state"
+  Const        r38, "ca_state"
+  Const        r39, "gender"
+  Const        r40, "cd_gender"
+  Const        r41, "marital"
+  Const        r42, "cd_marital_status"
+  Const        r43, "dep"
+  Const        r44, "cd_dep_count"
+  Const        r45, "emp"
+  Const        r46, "cd_dep_employed_count"
+  Const        r47, "col"
+  Const        r48, "cd_dep_college_count"
   // where c.c_customer_sk in purchased
-  Const        r48, "c_customer_sk"
+  Const        r49, "c_customer_sk"
   // ca_state: g.key.state,
-  Const        r49, "key"
+  Const        r50, "key"
   // cnt: count(g)
-  Const        r50, "cnt"
+  Const        r51, "cnt"
   // from c in customer
-  MakeMap      r51, 0, r0
-  Const        r52, []
-  IterPrep     r54, r0
-  Len          r55, r54
-  Const        r56, 0
+  MakeMap      r52, 0, r0
+  Const        r54, []
+  Move         r53, r54
+  IterPrep     r55, r0
+  Len          r56, r55
+  Const        r57, 0
 L13:
-  LessInt      r57, r56, r55
-  JumpIfFalse  r57, L6
-  Index        r59, r54, r56
+  LessInt      r58, r57, r56
+  JumpIfFalse  r58, L6
+  Index        r59, r55, r57
+  Move         r60, r59
   // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  IterPrep     r60, r1
-  Len          r61, r60
-  Const        r62, 0
+  IterPrep     r61, r1
+  Len          r62, r61
+  Const        r63, 0
 L12:
-  LessInt      r63, r62, r61
-  JumpIfFalse  r63, L7
-  Index        r65, r60, r62
-  Const        r66, "c_current_addr_sk"
-  Index        r67, r59, r66
-  Const        r68, "ca_address_sk"
-  Index        r69, r65, r68
-  Equal        r70, r67, r69
-  JumpIfFalse  r70, L8
+  LessInt      r64, r63, r62
+  JumpIfFalse  r64, L7
+  Index        r65, r61, r63
+  Move         r66, r65
+  Const        r67, "c_current_addr_sk"
+  Index        r68, r60, r67
+  Const        r69, "ca_address_sk"
+  Index        r70, r66, r69
+  Equal        r71, r68, r70
+  JumpIfFalse  r71, L8
   // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
-  IterPrep     r71, r2
-  Len          r72, r71
-  Const        r73, 0
+  IterPrep     r72, r2
+  Len          r73, r72
+  Const        r74, 0
 L11:
-  LessInt      r74, r73, r72
-  JumpIfFalse  r74, L8
-  Index        r76, r71, r73
-  Const        r77, "c_current_cdemo_sk"
-  Index        r78, r59, r77
-  Const        r79, "cd_demo_sk"
-  Index        r80, r76, r79
-  Equal        r81, r78, r80
-  JumpIfFalse  r81, L9
+  LessInt      r75, r74, r73
+  JumpIfFalse  r75, L8
+  Index        r76, r72, r74
+  Move         r77, r76
+  Const        r78, "c_current_cdemo_sk"
+  Index        r79, r60, r78
+  Const        r80, "cd_demo_sk"
+  Index        r81, r77, r80
+  Equal        r82, r79, r81
+  JumpIfFalse  r82, L9
   // where c.c_customer_sk in purchased
-  Index        r82, r59, r48
-  In           r83, r82, r5
-  JumpIfFalse  r83, L9
+  Index        r83, r60, r49
+  In           r84, r83, r5
+  JumpIfFalse  r84, L9
   // from c in customer
-  Const        r84, "c"
-  Move         r85, r59
-  Const        r86, "ca"
-  Move         r87, r65
-  Const        r88, "cd"
-  Move         r89, r76
-  MakeMap      r90, 3, r84
+  Const        r85, "c"
+  Move         r86, r60
+  Const        r87, "ca"
+  Move         r88, r66
+  Const        r89, "cd"
+  Move         r90, r77
+  Move         r91, r85
+  Move         r92, r86
+  Move         r93, r87
+  Move         r94, r88
+  Move         r95, r89
+  Move         r96, r90
+  MakeMap      r97, 3, r91
   // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
-  Const        r91, "state"
-  Index        r92, r65, r37
-  Const        r93, "gender"
-  Index        r94, r76, r39
-  Const        r95, "marital"
-  Index        r96, r76, r41
-  Const        r97, "dep"
-  Index        r98, r76, r43
-  Const        r99, "emp"
-  Index        r100, r76, r45
-  Const        r101, "col"
-  Index        r102, r76, r47
-  Move         r103, r91
-  Move         r104, r92
-  Move         r105, r93
-  Move         r106, r94
-  Move         r107, r95
-  Move         r108, r96
-  Move         r109, r97
+  Const        r98, "state"
+  Index        r99, r66, r38
+  Const        r100, "gender"
+  Index        r101, r77, r40
+  Const        r102, "marital"
+  Index        r103, r77, r42
+  Const        r104, "dep"
+  Index        r105, r77, r44
+  Const        r106, "emp"
+  Index        r107, r77, r46
+  Const        r108, "col"
+  Index        r109, r77, r48
   Move         r110, r98
   Move         r111, r99
   Move         r112, r100
   Move         r113, r101
   Move         r114, r102
-  MakeMap      r115, 6, r103
-  Str          r116, r115
-  In           r117, r116, r51
-  JumpIfTrue   r117, L10
+  Move         r115, r103
+  Move         r116, r104
+  Move         r117, r105
+  Move         r118, r106
+  Move         r119, r107
+  Move         r120, r108
+  Move         r121, r109
+  MakeMap      r122, 6, r110
+  Str          r123, r122
+  In           r124, r123, r52
+  JumpIfTrue   r124, L10
   // from c in customer
-  Const        r118, []
-  Const        r119, "__group__"
-  Const        r120, true
-  Const        r121, "key"
+  Const        r125, []
+  Const        r126, "__group__"
+  Const        r127, true
   // group by {state: ca.ca_state, gender: cd.cd_gender, marital: cd.cd_marital_status, dep: cd.cd_dep_count, emp: cd.cd_dep_employed_count, col: cd.cd_dep_college_count} into g
-  Move         r122, r115
+  Move         r128, r122
   // from c in customer
-  Const        r123, "items"
-  Move         r124, r118
-  Const        r125, "count"
-  Const        r126, 0
-  Move         r127, r119
-  Move         r128, r120
-  Move         r129, r121
-  Move         r130, r122
-  Move         r131, r123
-  Move         r132, r124
-  Move         r133, r125
-  Move         r134, r126
-  MakeMap      r135, 4, r127
-  SetIndex     r51, r116, r135
-  Append       r52, r52, r135
+  Const        r129, "items"
+  Move         r130, r125
+  Const        r131, "count"
+  Const        r132, 0
+  Move         r133, r126
+  Move         r134, r127
+  Move         r135, r50
+  Move         r136, r128
+  Move         r137, r129
+  Move         r138, r130
+  Move         r139, r131
+  Move         r140, r132
+  MakeMap      r141, 4, r133
+  SetIndex     r52, r123, r141
+  Append       r142, r53, r141
+  Move         r53, r142
 L10:
-  Const        r137, "items"
-  Index        r138, r51, r116
-  Index        r139, r138, r137
-  Append       r140, r139, r90
-  SetIndex     r138, r137, r140
-  Const        r141, "count"
-  Index        r142, r138, r141
-  AddInt       r143, r142, r34
-  SetIndex     r138, r141, r143
+  Index        r143, r52, r123
+  Index        r144, r143, r129
+  Append       r145, r144, r97
+  SetIndex     r143, r129, r145
+  Index        r146, r143, r131
+  AddInt       r147, r146, r35
+  SetIndex     r143, r131, r147
 L9:
   // join cd in customer_demographics on c.c_current_cdemo_sk == cd.cd_demo_sk
-  AddInt       r73, r73, r34
+  AddInt       r74, r74, r35
   Jump         L11
 L8:
   // join ca in customer_address on c.c_current_addr_sk == ca.ca_address_sk
-  AddInt       r62, r62, r34
+  AddInt       r63, r63, r35
   Jump         L12
 L7:
   // from c in customer
-  AddInt       r56, r56, r34
+  AddInt       r57, r57, r35
   Jump         L13
 L6:
-  Const        r144, 0
-  Len          r146, r52
+  Move         r148, r132
+  Len          r149, r53
 L15:
-  LessInt      r147, r144, r146
-  JumpIfFalse  r147, L14
-  Index        r149, r52, r144
+  LessInt      r150, r148, r149
+  JumpIfFalse  r150, L14
+  Index        r151, r53, r148
+  Move         r152, r151
   // ca_state: g.key.state,
-  Const        r150, "ca_state"
-  Index        r151, r149, r49
-  Index        r152, r151, r36
+  Const        r153, "ca_state"
+  Index        r154, r152, r50
+  Index        r155, r154, r37
   // cd_gender: g.key.gender,
-  Const        r153, "cd_gender"
-  Index        r154, r149, r49
-  Index        r155, r154, r38
+  Const        r156, "cd_gender"
+  Index        r157, r152, r50
+  Index        r158, r157, r39
   // cd_marital_status: g.key.marital,
-  Const        r156, "cd_marital_status"
-  Index        r157, r149, r49
-  Index        r158, r157, r40
+  Const        r159, "cd_marital_status"
+  Index        r160, r152, r50
+  Index        r161, r160, r41
   // cd_dep_count: g.key.dep,
-  Const        r159, "cd_dep_count"
-  Index        r160, r149, r49
-  Index        r161, r160, r42
+  Const        r162, "cd_dep_count"
+  Index        r163, r152, r50
+  Index        r164, r163, r43
   // cd_dep_employed_count: g.key.emp,
-  Const        r162, "cd_dep_employed_count"
-  Index        r163, r149, r49
-  Index        r164, r163, r44
+  Const        r165, "cd_dep_employed_count"
+  Index        r166, r152, r50
+  Index        r167, r166, r45
   // cd_dep_college_count: g.key.col,
-  Const        r165, "cd_dep_college_count"
-  Index        r166, r149, r49
-  Index        r167, r166, r46
+  Const        r168, "cd_dep_college_count"
+  Index        r169, r152, r50
+  Index        r170, r169, r47
   // cnt: count(g)
-  Const        r168, "cnt"
-  Index        r169, r149, r141
+  Const        r171, "cnt"
+  Index        r172, r152, r131
   // ca_state: g.key.state,
-  Move         r170, r150
-  Move         r171, r152
+  Move         r173, r153
+  Move         r174, r155
   // cd_gender: g.key.gender,
-  Move         r172, r153
-  Move         r173, r155
+  Move         r175, r156
+  Move         r176, r158
   // cd_marital_status: g.key.marital,
-  Move         r174, r156
-  Move         r175, r158
+  Move         r177, r159
+  Move         r178, r161
   // cd_dep_count: g.key.dep,
-  Move         r176, r159
-  Move         r177, r161
+  Move         r179, r162
+  Move         r180, r164
   // cd_dep_employed_count: g.key.emp,
-  Move         r178, r162
-  Move         r179, r164
+  Move         r181, r165
+  Move         r182, r167
   // cd_dep_college_count: g.key.col,
-  Move         r180, r165
-  Move         r181, r167
+  Move         r183, r168
+  Move         r184, r170
   // cnt: count(g)
-  Move         r182, r168
-  Move         r183, r169
+  Move         r185, r171
+  Move         r186, r172
   // select {
-  MakeMap      r184, 7, r170
+  MakeMap      r187, 7, r173
   // from c in customer
-  Append       r35, r35, r184
-  AddInt       r144, r144, r34
+  Append       r188, r36, r187
+  Move         r36, r188
+  AddInt       r148, r148, r35
   Jump         L15
 L14:
   // json(groups)
-  JSON         r35
+  JSON         r36
   // expect groups == [{ca_state: "CA", cd_gender: "M", cd_marital_status: "S", cd_dep_count: 1, cd_dep_employed_count: 1, cd_dep_college_count: 0, cnt: 1}]
-  Const        r186, [{"ca_state": "CA", "cd_dep_college_count": 0, "cd_dep_count": 1, "cd_dep_employed_count": 1, "cd_gender": "M", "cd_marital_status": "S", "cnt": 1}]
-  Equal        r187, r35, r186
-  Expect       r187
+  Const        r189, [{"ca_state": "CA", "cd_dep_college_count": 0, "cd_dep_count": 1, "cd_dep_employed_count": 1, "cd_gender": "M", "cd_marital_status": "S", "cnt": 1}]
+  Equal        r190, r36, r189
+  Expect       r190
   Return       r0

--- a/tests/dataset/tpc-ds/out/q36.ir.out
+++ b/tests/dataset/tpc-ds/out/q36.ir.out
@@ -1,4 +1,4 @@
-func main (regs=167)
+func main (regs=173)
   // let store_sales = [
   Const        r0, [{"ss_ext_sales_price": 100, "ss_item_sk": 1, "ss_net_profit": 20, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 200, "ss_item_sk": 2, "ss_net_profit": 50, "ss_sold_date_sk": 1, "ss_store_sk": 1}, {"ss_ext_sales_price": 150, "ss_item_sk": 3, "ss_net_profit": 30, "ss_sold_date_sk": 1, "ss_store_sk": 2}]
   // let item = [
@@ -25,14 +25,16 @@ func main (regs=167)
   Const        r14, "ss_ext_sales_price"
   // from ss in store_sales
   MakeMap      r15, 0, r0
-  Const        r16, []
+  Const        r17, []
+  Move         r16, r17
   IterPrep     r18, r0
   Len          r19, r18
   Const        r20, 0
 L11:
   LessInt      r21, r20, r19
   JumpIfFalse  r21, L0
-  Index        r23, r18, r20
+  Index        r22, r18, r20
+  Move         r23, r22
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
   IterPrep     r24, r3
   Len          r25, r24
@@ -40,7 +42,8 @@ L11:
 L10:
   LessInt      r27, r26, r25
   JumpIfFalse  r27, L1
-  Index        r29, r24, r26
+  Index        r28, r24, r26
+  Move         r29, r28
   Const        r30, "ss_sold_date_sk"
   Index        r31, r23, r30
   Const        r32, "d_date_sk"
@@ -54,7 +57,8 @@ L10:
 L9:
   LessInt      r38, r37, r36
   JumpIfFalse  r38, L2
-  Index        r40, r35, r37
+  Index        r39, r35, r37
+  Move         r40, r39
   Const        r41, "ss_item_sk"
   Index        r42, r23, r41
   Const        r43, "i_item_sk"
@@ -68,7 +72,8 @@ L9:
 L8:
   LessInt      r49, r48, r47
   JumpIfFalse  r49, L3
-  Index        r51, r46, r48
+  Index        r50, r46, r48
+  Move         r51, r50
   Const        r52, "ss_store_sk"
   Index        r53, r23, r52
   Const        r54, "s_store_sk"
@@ -79,168 +84,187 @@ L8:
   Index        r57, r29, r9
   Const        r58, 2000
   Equal        r59, r57, r58
-  JumpIfFalse  r59, L5
   Index        r60, r51, r10
   Const        r61, "A"
   Equal        r62, r60, r61
   Index        r63, r51, r10
   Const        r64, "B"
   Equal        r65, r63, r64
-  JumpIfTrue   r62, L6
-L6:
-  Move         r59, r65
+  Move         r66, r62
+  JumpIfTrue   r66, L5
+  Move         r66, r65
 L5:
-  JumpIfFalse  r59, L4
+  Move         r67, r59
+  JumpIfFalse  r67, L6
+  Move         r67, r66
+L6:
+  JumpIfFalse  r67, L4
   // from ss in store_sales
-  Const        r66, "ss"
-  Move         r67, r23
-  Const        r68, "d"
-  Move         r69, r29
-  Const        r70, "i"
-  Move         r71, r40
-  Const        r72, "s"
-  Move         r73, r51
-  MakeMap      r74, 4, r66
+  Const        r68, "ss"
+  Move         r69, r23
+  Const        r70, "d"
+  Move         r71, r29
+  Const        r72, "i"
+  Move         r73, r40
+  Const        r74, "s"
+  Move         r75, r51
+  Move         r76, r68
+  Move         r77, r69
+  Move         r78, r70
+  Move         r79, r71
+  Move         r80, r72
+  Move         r81, r73
+  Move         r82, r74
+  Move         r83, r75
+  MakeMap      r84, 4, r76
   // group by {category: i.i_category, class: i.i_class} into g
-  Const        r75, "category"
-  Index        r76, r40, r6
-  Const        r77, "class"
-  Index        r78, r40, r8
-  Move         r79, r75
-  Move         r80, r76
-  Move         r81, r77
-  Move         r82, r78
-  MakeMap      r83, 2, r79
-  Str          r84, r83
-  In           r85, r84, r15
-  JumpIfTrue   r85, L7
+  Const        r85, "category"
+  Index        r86, r40, r6
+  Const        r87, "class"
+  Index        r88, r40, r8
+  Move         r89, r85
+  Move         r90, r86
+  Move         r91, r87
+  Move         r92, r88
+  MakeMap      r93, 2, r89
+  Str          r94, r93
+  In           r95, r94, r15
+  JumpIfTrue   r95, L7
   // from ss in store_sales
-  Const        r86, []
-  Const        r87, "__group__"
-  Const        r88, true
-  Const        r89, "key"
+  Const        r96, []
+  Const        r97, "__group__"
+  Const        r98, true
   // group by {category: i.i_category, class: i.i_class} into g
-  Move         r90, r83
+  Move         r99, r93
   // from ss in store_sales
-  Const        r91, "items"
-  Move         r92, r86
-  Const        r93, "count"
-  Const        r94, 0
-  Move         r95, r87
-  Move         r96, r88
-  Move         r97, r89
-  Move         r98, r90
-  Move         r99, r91
-  Move         r100, r92
-  Move         r101, r93
-  Move         r102, r94
-  MakeMap      r103, 4, r95
-  SetIndex     r15, r84, r103
-  Append       r16, r16, r103
+  Const        r100, "items"
+  Move         r101, r96
+  Const        r102, "count"
+  Const        r103, 0
+  Move         r104, r97
+  Move         r105, r98
+  Move         r106, r11
+  Move         r107, r99
+  Move         r108, r100
+  Move         r109, r101
+  Move         r110, r102
+  Move         r111, r103
+  MakeMap      r112, 4, r104
+  SetIndex     r15, r94, r112
+  Append       r113, r16, r112
+  Move         r16, r113
 L7:
-  Const        r105, "items"
-  Index        r106, r15, r84
-  Index        r107, r106, r105
-  Append       r108, r107, r74
-  SetIndex     r106, r105, r108
-  Const        r109, "count"
-  Index        r110, r106, r109
-  Const        r111, 1
-  AddInt       r112, r110, r111
-  SetIndex     r106, r109, r112
+  Index        r114, r15, r94
+  Index        r115, r114, r100
+  Append       r116, r115, r84
+  SetIndex     r114, r100, r116
+  Index        r117, r114, r102
+  Const        r118, 1
+  AddInt       r119, r117, r118
+  SetIndex     r114, r102, r119
 L4:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r48, r48, r111
+  AddInt       r48, r48, r118
   Jump         L8
 L3:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r37, r37, r111
+  AddInt       r37, r37, r118
   Jump         L9
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r26, r26, r111
+  AddInt       r26, r26, r118
   Jump         L10
 L1:
   // from ss in store_sales
-  AddInt       r20, r20, r111
+  AddInt       r20, r20, r118
   Jump         L11
 L0:
-  Const        r114, 0
-  Move         r113, r114
-  Len          r115, r16
+  Move         r120, r103
+  Len          r121, r16
 L17:
-  LessInt      r116, r113, r115
-  JumpIfFalse  r116, L12
-  Index        r118, r16, r113
+  LessInt      r122, r120, r121
+  JumpIfFalse  r122, L12
+  Index        r123, r16, r120
+  Move         r124, r123
   // i_category: g.key.category,
-  Const        r119, "i_category"
-  Index        r120, r118, r11
-  Index        r121, r120, r5
+  Const        r125, "i_category"
+  Index        r126, r124, r11
+  Index        r127, r126, r5
   // i_class: g.key.class,
-  Const        r122, "i_class"
-  Index        r123, r118, r11
-  Index        r124, r123, r7
+  Const        r128, "i_class"
+  Index        r129, r124, r11
+  Index        r130, r129, r7
   // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
-  Const        r125, "gross_margin"
-  Const        r126, []
-  IterPrep     r127, r118
-  Len          r128, r127
-  Move         r129, r114
+  Const        r131, "gross_margin"
+  Const        r132, []
+  IterPrep     r133, r124
+  Len          r134, r133
+  Move         r135, r103
 L14:
-  LessInt      r130, r129, r128
-  JumpIfFalse  r130, L13
-  Index        r132, r127, r129
-  Index        r133, r132, r13
-  Append       r126, r126, r133
-  AddInt       r129, r129, r111
+  LessInt      r136, r135, r134
+  JumpIfFalse  r136, L13
+  Index        r137, r133, r135
+  Move         r138, r137
+  Index        r139, r138, r13
+  Append       r140, r132, r139
+  Move         r132, r140
+  AddInt       r135, r135, r118
   Jump         L14
 L13:
-  Sum          r135, r126
-  Const        r136, []
-  IterPrep     r137, r118
-  Len          r138, r137
-  Move         r139, r114
+  Sum          r141, r132
+  Const        r142, []
+  IterPrep     r143, r124
+  Len          r144, r143
+  Move         r145, r103
 L16:
-  LessInt      r140, r139, r138
-  JumpIfFalse  r140, L15
-  Index        r132, r137, r139
-  Index        r142, r132, r14
-  Append       r136, r136, r142
-  AddInt       r139, r139, r111
+  LessInt      r146, r145, r144
+  JumpIfFalse  r146, L15
+  Index        r147, r143, r145
+  Move         r138, r147
+  Index        r148, r138, r14
+  Append       r149, r142, r148
+  Move         r142, r149
+  AddInt       r145, r145, r118
   Jump         L16
 L15:
-  Sum          r144, r136
-  Div          r145, r135, r144
+  Sum          r150, r142
+  Div          r151, r141, r150
   // i_category: g.key.category,
-  Move         r146, r119
-  Move         r147, r121
+  Move         r152, r125
+  Move         r153, r127
   // i_class: g.key.class,
-  Move         r148, r122
-  Move         r149, r124
+  Move         r154, r128
+  Move         r155, r130
   // gross_margin: sum(from x in g select x.ss_net_profit) / sum(from x in g select x.ss_ext_sales_price)
-  Move         r150, r125
-  Move         r151, r145
+  Move         r156, r131
+  Move         r157, r151
   // select {
-  MakeMap      r152, 3, r146
+  MakeMap      r158, 3, r152
   // sort by [g.key.category, g.key.class]
-  Index        r153, r118, r11
-  Index        r155, r153, r5
-  Index        r156, r118, r11
-  Index        r158, r156, r7
-  MakeList     r160, 2, r155
+  Index        r159, r124, r11
+  Index        r160, r159, r5
+  Move         r161, r160
+  Index        r162, r124, r11
+  Index        r163, r162, r7
+  Move         r164, r163
+  MakeList     r165, 2, r161
+  Move         r166, r165
   // from ss in store_sales
-  Move         r161, r152
-  MakeList     r162, 2, r160
-  Append       r4, r4, r162
-  AddInt       r113, r113, r111
+  Move         r167, r158
+  MakeList     r168, 2, r166
+  Append       r169, r4, r168
+  Move         r4, r169
+  AddInt       r120, r120, r118
   Jump         L17
 L12:
   // sort by [g.key.category, g.key.class]
-  Sort         r4, r4
+  Sort         r170, r4
+  // from ss in store_sales
+  Move         r4, r170
   // json(result)
   JSON         r4
   // expect result == [
-  Const        r165, [{"gross_margin": 0.2, "i_category": "Books", "i_class": "C1"}, {"gross_margin": 0.25, "i_category": "Books", "i_class": "C2"}, {"gross_margin": 0.2, "i_category": "Electronics", "i_class": "C3"}]
-  Equal        r166, r4, r165
-  Expect       r166
+  Const        r171, [{"gross_margin": 0.2, "i_category": "Books", "i_class": "C1"}, {"gross_margin": 0.25, "i_category": "Books", "i_class": "C2"}, {"gross_margin": 0.2, "i_category": "Electronics", "i_class": "C3"}]
+  Equal        r172, r4, r171
+  Expect       r172
   Return       r0

--- a/tests/dataset/tpc-ds/out/q37.ir.out
+++ b/tests/dataset/tpc-ds/out/q37.ir.out
@@ -1,4 +1,4 @@
-func main (regs=155)
+func main (regs=164)
   // let item = [
   Const        r0, [{"i_current_price": 30, "i_item_desc": "Item1", "i_item_id": "I1", "i_item_sk": 1, "i_manufact_id": 800}, {"i_current_price": 60, "i_item_desc": "Item2", "i_item_id": "I2", "i_item_sk": 2, "i_manufact_id": 801}]
   // let inventory = [
@@ -23,22 +23,25 @@ func main (regs=155)
   Const        r13, "key"
   // from i in item
   MakeMap      r14, 0, r0
-  Const        r15, []
+  Const        r16, []
+  Move         r15, r16
   IterPrep     r17, r0
   Len          r18, r17
   Const        r19, 0
-L10:
+L14:
   LessInt      r20, r19, r18
   JumpIfFalse  r20, L0
-  Index        r22, r17, r19
+  Index        r21, r17, r19
+  Move         r22, r21
   // join inv in inventory on i.i_item_sk == inv.inv_item_sk
   IterPrep     r23, r1
   Len          r24, r23
   Const        r25, 0
-L9:
+L13:
   LessInt      r26, r25, r24
   JumpIfFalse  r26, L1
-  Index        r28, r23, r25
+  Index        r27, r23, r25
+  Move         r28, r27
   Const        r29, "i_item_sk"
   Index        r30, r22, r29
   Const        r31, "inv_item_sk"
@@ -49,10 +52,11 @@ L9:
   IterPrep     r34, r2
   Len          r35, r34
   Const        r36, 0
-L8:
+L12:
   LessInt      r37, r36, r35
   JumpIfFalse  r37, L2
-  Index        r39, r34, r36
+  Index        r38, r34, r36
+  Move         r39, r38
   Const        r40, "inv_date_sk"
   Index        r41, r28, r40
   Const        r42, "d_date_sk"
@@ -63,10 +67,11 @@ L8:
   IterPrep     r45, r3
   Len          r46, r45
   Const        r47, 0
-L7:
+L11:
   LessInt      r48, r47, r46
   JumpIfFalse  r48, L3
-  Index        r50, r45, r47
+  Index        r49, r45, r47
+  Move         r50, r49
   Const        r51, "cs_item_sk"
   Index        r52, r50, r51
   Index        r53, r22, r29
@@ -91,135 +96,155 @@ L7:
   Index        r70, r28, r12
   Const        r71, 500
   LessEq       r72, r70, r71
-  JumpIfFalse  r57, L5
-  Move         r57, r60
-  JumpIfFalse  r57, L5
-  Move         r57, r63
-  JumpIfFalse  r57, L5
-  Move         r57, r66
-  JumpIfFalse  r57, L5
-  Move         r57, r69
-  JumpIfFalse  r57, L5
-  Move         r57, r72
+  Move         r73, r57
+  JumpIfFalse  r73, L5
+  Move         r73, r60
 L5:
-  JumpIfFalse  r57, L4
-  // from i in item
-  Const        r73, "i"
-  Move         r74, r22
-  Const        r75, "inv"
-  Move         r76, r28
-  Const        r77, "d"
-  Move         r78, r39
-  Const        r79, "cs"
-  Move         r80, r50
-  MakeMap      r81, 4, r73
-  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
-  Const        r82, "id"
-  Index        r83, r22, r6
-  Const        r84, "desc"
-  Index        r85, r22, r8
-  Const        r86, "price"
-  Index        r87, r22, r10
-  Move         r88, r82
-  Move         r89, r83
-  Move         r90, r84
-  Move         r91, r85
-  Move         r92, r86
-  Move         r93, r87
-  MakeMap      r94, 3, r88
-  Str          r95, r94
-  In           r96, r95, r14
-  JumpIfTrue   r96, L6
-  // from i in item
-  Const        r97, []
-  Const        r98, "__group__"
-  Const        r99, true
-  Const        r100, "key"
-  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
-  Move         r101, r94
-  // from i in item
-  Const        r102, "items"
-  Move         r103, r97
-  Const        r104, "count"
-  Const        r105, 0
-  Move         r106, r98
-  Move         r107, r99
-  Move         r108, r100
-  Move         r109, r101
-  Move         r110, r102
-  Move         r111, r103
-  Move         r112, r104
-  Move         r113, r105
-  MakeMap      r114, 4, r106
-  SetIndex     r14, r95, r114
-  Append       r15, r15, r114
+  Move         r74, r73
+  JumpIfFalse  r74, L6
+  Move         r74, r63
 L6:
-  Const        r116, "items"
-  Index        r117, r14, r95
-  Index        r118, r117, r116
-  Append       r119, r118, r81
-  SetIndex     r117, r116, r119
-  Const        r120, "count"
-  Index        r121, r117, r120
-  Const        r122, 1
-  AddInt       r123, r121, r122
-  SetIndex     r117, r120, r123
+  Move         r75, r74
+  JumpIfFalse  r75, L7
+  Move         r75, r66
+L7:
+  Move         r76, r75
+  JumpIfFalse  r76, L8
+  Move         r76, r69
+L8:
+  Move         r77, r76
+  JumpIfFalse  r77, L9
+  Move         r77, r72
+L9:
+  JumpIfFalse  r77, L4
+  // from i in item
+  Const        r78, "i"
+  Move         r79, r22
+  Const        r80, "inv"
+  Move         r81, r28
+  Const        r82, "d"
+  Move         r83, r39
+  Const        r84, "cs"
+  Move         r85, r50
+  Move         r86, r78
+  Move         r87, r79
+  Move         r88, r80
+  Move         r89, r81
+  Move         r90, r82
+  Move         r91, r83
+  Move         r92, r84
+  Move         r93, r85
+  MakeMap      r94, 4, r86
+  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
+  Const        r95, "id"
+  Index        r96, r22, r6
+  Const        r97, "desc"
+  Index        r98, r22, r8
+  Const        r99, "price"
+  Index        r100, r22, r10
+  Move         r101, r95
+  Move         r102, r96
+  Move         r103, r97
+  Move         r104, r98
+  Move         r105, r99
+  Move         r106, r100
+  MakeMap      r107, 3, r101
+  Str          r108, r107
+  In           r109, r108, r14
+  JumpIfTrue   r109, L10
+  // from i in item
+  Const        r110, []
+  Const        r111, "__group__"
+  Const        r112, true
+  // group by {id: i.i_item_id, desc: i.i_item_desc, price: i.i_current_price} into g
+  Move         r113, r107
+  // from i in item
+  Const        r114, "items"
+  Move         r115, r110
+  Const        r116, "count"
+  Const        r117, 0
+  Move         r118, r111
+  Move         r119, r112
+  Move         r120, r13
+  Move         r121, r113
+  Move         r122, r114
+  Move         r123, r115
+  Move         r124, r116
+  Move         r125, r117
+  MakeMap      r126, 4, r118
+  SetIndex     r14, r108, r126
+  Append       r127, r15, r126
+  Move         r15, r127
+L10:
+  Index        r128, r14, r108
+  Index        r129, r128, r114
+  Append       r130, r129, r94
+  SetIndex     r128, r114, r130
+  Index        r131, r128, r116
+  Const        r132, 1
+  AddInt       r133, r131, r132
+  SetIndex     r128, r116, r133
 L4:
   // join cs in catalog_sales on cs.cs_item_sk == i.i_item_sk
-  AddInt       r47, r47, r122
-  Jump         L7
+  AddInt       r47, r47, r132
+  Jump         L11
 L3:
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
-  AddInt       r36, r36, r122
-  Jump         L8
+  AddInt       r36, r36, r132
+  Jump         L12
 L2:
   // join inv in inventory on i.i_item_sk == inv.inv_item_sk
-  AddInt       r25, r25, r122
-  Jump         L9
+  AddInt       r25, r25, r132
+  Jump         L13
 L1:
   // from i in item
-  AddInt       r19, r19, r122
-  Jump         L10
+  AddInt       r19, r19, r132
+  Jump         L14
 L0:
-  Const        r124, 0
-  Len          r126, r15
-L12:
-  LessInt      r127, r124, r126
-  JumpIfFalse  r127, L11
-  Index        r129, r15, r124
+  Move         r134, r117
+  Len          r135, r15
+L16:
+  LessInt      r136, r134, r135
+  JumpIfFalse  r136, L15
+  Index        r137, r15, r134
+  Move         r138, r137
   // select {i_item_id: g.key.id, i_item_desc: g.key.desc, i_current_price: g.key.price}
-  Const        r130, "i_item_id"
-  Index        r131, r129, r13
-  Index        r132, r131, r5
-  Const        r133, "i_item_desc"
-  Index        r134, r129, r13
-  Index        r135, r134, r7
-  Const        r136, "i_current_price"
-  Index        r137, r129, r13
-  Index        r138, r137, r9
-  Move         r139, r130
-  Move         r140, r132
-  Move         r141, r133
-  Move         r142, r135
-  Move         r143, r136
-  Move         r144, r138
-  MakeMap      r145, 3, r139
+  Const        r139, "i_item_id"
+  Index        r140, r138, r13
+  Index        r141, r140, r5
+  Const        r142, "i_item_desc"
+  Index        r143, r138, r13
+  Index        r144, r143, r7
+  Const        r145, "i_current_price"
+  Index        r146, r138, r13
+  Index        r147, r146, r9
+  Move         r148, r139
+  Move         r149, r141
+  Move         r150, r142
+  Move         r151, r144
+  Move         r152, r145
+  Move         r153, r147
+  MakeMap      r154, 3, r148
   // sort by g.key.id
-  Index        r146, r129, r13
-  Index        r148, r146, r5
+  Index        r155, r138, r13
+  Index        r156, r155, r5
+  Move         r157, r156
   // from i in item
-  Move         r149, r145
-  MakeList     r150, 2, r148
-  Append       r4, r4, r150
-  AddInt       r124, r124, r122
-  Jump         L12
-L11:
+  Move         r158, r154
+  MakeList     r159, 2, r157
+  Append       r160, r4, r159
+  Move         r4, r160
+  AddInt       r134, r134, r132
+  Jump         L16
+L15:
   // sort by g.key.id
-  Sort         r4, r4
+  Sort         r161, r4
+  // from i in item
+  Move         r4, r161
   // json(result)
   JSON         r4
   // expect result == [{i_item_id: "I1", i_item_desc: "Item1", i_current_price: 30.0}]
-  Const        r153, [{"i_current_price": 30, "i_item_desc": "Item1", "i_item_id": "I1"}]
-  Equal        r154, r4, r153
-  Expect       r154
+  Const        r162, [{"i_current_price": 30, "i_item_desc": "Item1", "i_item_id": "I1"}]
+  Equal        r163, r4, r162
+  Expect       r163
   Return       r0

--- a/tests/dataset/tpc-ds/out/q38.ir.out
+++ b/tests/dataset/tpc-ds/out/q38.ir.out
@@ -1,4 +1,4 @@
-func main (regs=58)
+func main (regs=61)
   // let customer = [
   Const        r0, [{"c_customer_sk": 1, "c_first_name": "John", "c_last_name": "Smith"}, {"c_customer_sk": 2, "c_first_name": "Alice", "c_last_name": "Jones"}]
   // let store_sales = [
@@ -18,91 +18,101 @@ func main (regs=58)
 L3:
   LessInt      r11, r9, r8
   JumpIfFalse  r11, L0
-  Index        r13, r7, r9
+  Index        r12, r7, r9
+  Move         r13, r12
   Index        r14, r13, r5
   Const        r15, 1200
   LessEq       r16, r15, r14
   Index        r17, r13, r5
   Const        r18, 1211
   LessEq       r19, r17, r18
-  JumpIfFalse  r16, L1
-  Move         r16, r19
+  Move         r20, r16
+  JumpIfFalse  r20, L1
+  Move         r20, r19
 L1:
-  JumpIfFalse  r16, L2
-  Index        r20, r13, r6
-  Append       r4, r4, r20
+  JumpIfFalse  r20, L2
+  Index        r21, r13, r6
+  Append       r22, r4, r21
+  Move         r4, r22
 L2:
-  Const        r22, 1
-  AddInt       r9, r9, r22
+  Const        r23, 1
+  AddInt       r9, r9, r23
   Jump         L3
 L0:
-  Distinct     23,4,0,0
+  Distinct     24,4,0,0
   // let catalog_ids = distinct(from c in catalog_sales where c.d_month_seq >= 1200 && c.d_month_seq <= 1211 select c.cs_bill_customer_sk)
-  Const        r24, []
-  Const        r25, "cs_bill_customer_sk"
-  IterPrep     r26, r2
-  Len          r27, r26
-  Move         r28, r10
+  Const        r25, []
+  Const        r26, "cs_bill_customer_sk"
+  IterPrep     r27, r2
+  Len          r28, r27
+  Move         r29, r10
 L7:
-  LessInt      r29, r28, r27
-  JumpIfFalse  r29, L4
-  Index        r31, r26, r28
-  Index        r32, r31, r5
-  LessEq       r33, r15, r32
-  Index        r34, r31, r5
-  LessEq       r35, r34, r18
-  JumpIfFalse  r33, L5
-  Move         r33, r35
+  LessInt      r30, r29, r28
+  JumpIfFalse  r30, L4
+  Index        r31, r27, r29
+  Move         r32, r31
+  Index        r33, r32, r5
+  LessEq       r34, r15, r33
+  Index        r35, r32, r5
+  LessEq       r36, r35, r18
+  Move         r37, r34
+  JumpIfFalse  r37, L5
+  Move         r37, r36
 L5:
-  JumpIfFalse  r33, L6
-  Index        r36, r31, r25
-  Append       r24, r24, r36
+  JumpIfFalse  r37, L6
+  Index        r38, r32, r26
+  Append       r39, r25, r38
+  Move         r25, r39
 L6:
-  AddInt       r28, r28, r22
+  AddInt       r29, r29, r23
   Jump         L7
 L4:
-  Distinct     38,24,0,0
+  Distinct     40,25,0,0
   // let web_ids = distinct(from w in web_sales where w.d_month_seq >= 1200 && w.d_month_seq <= 1211 select w.ws_bill_customer_sk)
-  Const        r39, []
-  Const        r40, "ws_bill_customer_sk"
-  IterPrep     r41, r3
-  Len          r42, r41
-  Move         r43, r10
+  Const        r41, []
+  Const        r42, "ws_bill_customer_sk"
+  IterPrep     r43, r3
+  Len          r44, r43
+  Move         r45, r10
 L11:
-  LessInt      r44, r43, r42
-  JumpIfFalse  r44, L8
-  Index        r46, r41, r43
-  Index        r47, r46, r5
-  LessEq       r48, r15, r47
-  Index        r49, r46, r5
-  LessEq       r50, r49, r18
-  JumpIfFalse  r48, L9
-  Move         r48, r50
+  LessInt      r46, r45, r44
+  JumpIfFalse  r46, L8
+  Index        r47, r43, r45
+  Move         r48, r47
+  Index        r49, r48, r5
+  LessEq       r50, r15, r49
+  Index        r51, r48, r5
+  LessEq       r52, r51, r18
+  Move         r53, r50
+  JumpIfFalse  r53, L9
+  Move         r53, r52
 L9:
-  JumpIfFalse  r48, L10
-  Index        r51, r46, r40
-  Append       r39, r39, r51
+  JumpIfFalse  r53, L10
+  Index        r54, r48, r42
+  Append       r55, r41, r54
+  Move         r41, r55
 L10:
-  AddInt       r43, r43, r22
+  AddInt       r45, r45, r23
   Jump         L11
 L8:
-  Distinct     53,39,0,0
+  Distinct     56,41,0,0
   // let hot = store_ids intersect catalog_ids intersect web_ids
-  Intersect    r54, r23, r38
-  Intersect    r55, r54, r53
+  Intersect    r57, r24, r40
+  Intersect    r58, r57, r56
   // let result = len(hot)
-  Len          r56, r55
+  Len          r59, r58
   // json(result)
-  JSON         r56
+  JSON         r59
   // expect result == 1
-  EqualInt     r57, r56, r22
-  Expect       r57
+  EqualInt     r60, r59, r23
+  Expect       r60
   Return       r0
 
   // fun distinct(xs: list<any>): list<any> {
 func distinct (regs=14)
   // var out = []
-  Const        r2, []
+  Const        r1, []
+  Move         r2, r1
   // for x in xs {
   IterPrep     r3, r0
   Len          r4, r3
@@ -110,16 +120,19 @@ func distinct (regs=14)
 L2:
   Less         r6, r5, r4
   JumpIfFalse  r6, L0
-  Index        r8, r3, r5
+  Index        r7, r3, r5
+  Move         r8, r7
   // if !contains(out, x) {
   Not          r10, r9
   JumpIfFalse  r10, L1
   // out = append(out, x)
-  Append       r2, r2, r8
+  Append       r11, r2, r8
+  Move         r2, r11
 L1:
   // for x in xs {
   Const        r12, 1
-  Add          r5, r5, r12
+  Add          r13, r5, r12
+  Move         r5, r13
   Jump         L2
 L0:
   // return out

--- a/tests/dataset/tpc-ds/out/q39.ir.out
+++ b/tests/dataset/tpc-ds/out/q39.ir.out
@@ -1,4 +1,4 @@
-func main (regs=241)
+func main (regs=244)
   // let inventory = [
   Const        r0, [{"inv_date_sk": 1, "inv_item_sk": 1, "inv_quantity_on_hand": 10, "inv_warehouse_sk": 1}, {"inv_date_sk": 2, "inv_item_sk": 1, "inv_quantity_on_hand": 10, "inv_warehouse_sk": 1}, {"inv_date_sk": 3, "inv_item_sk": 1, "inv_quantity_on_hand": 250, "inv_warehouse_sk": 1}]
   // let item = [
@@ -24,14 +24,16 @@ func main (regs=241)
   Const        r14, "inv_quantity_on_hand"
   // from inv in inventory
   MakeMap      r15, 0, r0
-  Const        r16, []
+  Const        r17, []
+  Move         r16, r17
   IterPrep     r18, r0
   Len          r19, r18
   Const        r20, 0
 L9:
   LessInt      r21, r20, r19
   JumpIfFalse  r21, L0
-  Index        r23, r18, r20
+  Index        r22, r18, r20
+  Move         r23, r22
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
   IterPrep     r24, r3
   Len          r25, r24
@@ -39,7 +41,8 @@ L9:
 L8:
   LessInt      r27, r26, r25
   JumpIfFalse  r27, L1
-  Index        r29, r24, r26
+  Index        r28, r24, r26
+  Move         r29, r28
   Const        r30, "inv_date_sk"
   Index        r31, r23, r30
   Const        r32, "d_date_sk"
@@ -53,7 +56,8 @@ L8:
 L7:
   LessInt      r38, r37, r36
   JumpIfFalse  r38, L2
-  Index        r40, r35, r37
+  Index        r39, r35, r37
+  Move         r40, r39
   Const        r41, "inv_item_sk"
   Index        r42, r23, r41
   Index        r43, r40, r8
@@ -66,7 +70,8 @@ L7:
 L6:
   LessInt      r48, r47, r46
   JumpIfFalse  r48, L3
-  Index        r50, r45, r47
+  Index        r49, r45, r47
+  Move         r50, r49
   Const        r51, "inv_warehouse_sk"
   Index        r52, r23, r51
   Index        r53, r50, r6
@@ -84,264 +89,287 @@ L6:
   Move         r61, r29
   Move         r62, r40
   Move         r63, r50
-  MakeMap      r64, 4, r58
+  Move         r64, r58
+  Move         r65, r59
+  Move         r66, r60
+  Move         r67, r61
+  Move         r68, r7
+  Move         r69, r62
+  Move         r70, r5
+  Move         r71, r63
+  MakeMap      r72, 4, r64
   // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
-  Const        r65, "w"
-  Index        r66, r50, r6
-  Const        r67, "i"
-  Index        r68, r40, r8
-  Const        r69, "month"
-  Index        r70, r29, r10
-  Move         r71, r65
-  Move         r72, r66
-  Move         r73, r67
-  Move         r74, r68
-  Move         r75, r69
-  Move         r76, r70
-  MakeMap      r77, 3, r71
-  Str          r78, r77
-  In           r79, r78, r15
-  JumpIfTrue   r79, L5
+  Const        r73, "w"
+  Index        r74, r50, r6
+  Const        r75, "i"
+  Index        r76, r40, r8
+  Const        r77, "month"
+  Index        r78, r29, r10
+  Move         r79, r73
+  Move         r80, r74
+  Move         r81, r75
+  Move         r82, r76
+  Move         r83, r77
+  Move         r84, r78
+  MakeMap      r85, 3, r79
+  Str          r86, r85
+  In           r87, r86, r15
+  JumpIfTrue   r87, L5
   // from inv in inventory
-  Const        r80, []
-  Const        r81, "__group__"
-  Const        r82, true
-  Const        r83, "key"
+  Const        r88, []
+  Const        r89, "__group__"
+  Const        r90, true
   // group by {w: w.w_warehouse_sk, i: i.i_item_sk, month: d.d_moy} into g
-  Move         r84, r77
+  Move         r91, r85
   // from inv in inventory
-  Const        r85, "items"
-  Move         r86, r80
-  Const        r87, "count"
-  Const        r88, 0
-  Move         r89, r81
-  Move         r90, r82
-  Move         r91, r83
-  Move         r92, r84
-  Move         r93, r85
-  Move         r94, r86
-  Move         r95, r87
-  Move         r96, r88
-  MakeMap      r97, 4, r89
-  SetIndex     r15, r78, r97
-  Append       r16, r16, r97
+  Const        r92, "items"
+  Move         r93, r88
+  Const        r94, "count"
+  Const        r95, 0
+  Move         r96, r89
+  Move         r97, r90
+  Move         r98, r12
+  Move         r99, r91
+  Move         r100, r92
+  Move         r101, r93
+  Move         r102, r94
+  Move         r103, r95
+  MakeMap      r104, 4, r96
+  SetIndex     r15, r86, r104
+  Append       r105, r16, r104
+  Move         r16, r105
 L5:
-  Const        r99, "items"
-  Index        r100, r15, r78
-  Index        r101, r100, r99
-  Append       r102, r101, r64
-  SetIndex     r100, r99, r102
-  Const        r103, "count"
-  Index        r104, r100, r103
-  Const        r105, 1
-  AddInt       r106, r104, r105
-  SetIndex     r100, r103, r106
+  Index        r106, r15, r86
+  Index        r107, r106, r92
+  Append       r108, r107, r72
+  SetIndex     r106, r92, r108
+  Index        r109, r106, r94
+  Const        r110, 1
+  AddInt       r111, r109, r110
+  SetIndex     r106, r94, r111
 L4:
   // join w in warehouse on inv.inv_warehouse_sk == w.w_warehouse_sk
-  AddInt       r47, r47, r105
+  AddInt       r47, r47, r110
   Jump         L6
 L3:
   // join i in item on inv.inv_item_sk == i.i_item_sk
-  AddInt       r37, r37, r105
+  AddInt       r37, r37, r110
   Jump         L7
 L2:
   // join d in date_dim on inv.inv_date_sk == d.d_date_sk
-  AddInt       r26, r26, r105
+  AddInt       r26, r26, r110
   Jump         L8
 L1:
   // from inv in inventory
-  AddInt       r20, r20, r105
+  AddInt       r20, r20, r110
   Jump         L9
 L0:
-  Const        r108, 0
-  Move         r107, r108
-  Len          r109, r16
+  Move         r112, r95
+  Len          r113, r16
 L13:
-  LessInt      r110, r107, r109
-  JumpIfFalse  r110, L10
-  Index        r112, r16, r107
+  LessInt      r114, r112, r113
+  JumpIfFalse  r114, L10
+  Index        r115, r16, r112
+  Move         r116, r115
   // select {w: g.key.w, i: g.key.i, qty: sum(from x in g select x.inv_quantity_on_hand)}
-  Const        r113, "w"
-  Index        r114, r112, r12
-  Index        r115, r114, r5
-  Const        r116, "i"
-  Index        r117, r112, r12
-  Index        r118, r117, r7
-  Const        r119, "qty"
-  Const        r120, []
-  IterPrep     r121, r112
-  Len          r122, r121
-  Move         r123, r108
+  Const        r117, "w"
+  Index        r118, r116, r12
+  Index        r119, r118, r5
+  Const        r120, "i"
+  Index        r121, r116, r12
+  Index        r122, r121, r7
+  Const        r123, "qty"
+  Const        r124, []
+  IterPrep     r125, r116
+  Len          r126, r125
+  Move         r127, r95
 L12:
-  LessInt      r124, r123, r122
-  JumpIfFalse  r124, L11
-  Index        r126, r121, r123
-  Index        r127, r126, r14
-  Append       r120, r120, r127
-  AddInt       r123, r123, r105
+  LessInt      r128, r127, r126
+  JumpIfFalse  r128, L11
+  Index        r129, r125, r127
+  Move         r130, r129
+  Index        r131, r130, r14
+  Append       r132, r124, r131
+  Move         r124, r132
+  AddInt       r127, r127, r110
   Jump         L12
 L11:
-  Sum          r129, r120
-  Move         r130, r113
-  Move         r131, r115
-  Move         r132, r116
-  Move         r133, r118
-  Move         r134, r119
-  Move         r135, r129
-  MakeMap      r136, 3, r130
+  Sum          r133, r124
+  Move         r134, r117
+  Move         r135, r119
+  Move         r136, r120
+  Move         r137, r122
+  Move         r138, r123
+  Move         r139, r133
+  MakeMap      r140, 3, r134
   // from inv in inventory
-  Append       r4, r4, r136
-  AddInt       r107, r107, r105
+  Append       r141, r4, r140
+  Move         r4, r141
+  AddInt       r112, r112, r110
   Jump         L13
 L10:
   // var grouped: map<string, map<string, any>> = {}
-  Const        r139, {}
+  Const        r142, {}
+  Move         r143, r142
   // for m in monthly {
-  IterPrep     r140, r4
-  Len          r141, r140
-  Const        r142, 0
+  IterPrep     r144, r4
+  Len          r145, r144
+  Const        r146, 0
 L17:
-  Less         r143, r142, r141
-  JumpIfFalse  r143, L14
-  Index        r145, r140, r142
+  Less         r147, r146, r145
+  JumpIfFalse  r147, L14
+  Index        r148, r144, r146
+  Move         r149, r148
   // let key = str({w: m.w, i: m.i})
-  Const        r146, "w"
-  Index        r147, r145, r5
-  Const        r148, "i"
-  Index        r149, r145, r7
-  Move         r150, r146
-  Move         r151, r147
-  Move         r152, r148
-  Move         r153, r149
-  MakeMap      r154, 2, r150
-  Str          r155, r154
+  Const        r150, "w"
+  Index        r151, r149, r5
+  Const        r152, "i"
+  Index        r153, r149, r7
+  Move         r154, r150
+  Move         r155, r151
+  Move         r156, r152
+  Move         r157, r153
+  MakeMap      r158, 2, r154
+  Str          r159, r158
   // if key in grouped {
-  In           r156, r155, r139
-  JumpIfFalse  r156, L15
+  In           r160, r159, r143
+  JumpIfFalse  r160, L15
   // let g = grouped[key]
-  Index        r157, r139, r155
+  Index        r161, r143, r159
   // grouped[key] = {w: g.w, i: g.i, qtys: append(g.qtys, m.qty)}
-  Const        r158, "w"
-  Index        r159, r157, r5
-  Const        r160, "i"
-  Index        r161, r157, r7
-  Const        r162, "qtys"
-  Const        r163, "qtys"
-  Index        r164, r157, r163
-  Index        r165, r145, r13
-  Append       r166, r164, r165
-  Move         r167, r158
-  Move         r168, r159
-  Move         r169, r160
-  Move         r170, r161
+  Const        r162, "w"
+  Index        r163, r161, r5
+  Const        r164, "i"
+  Index        r165, r161, r7
+  Const        r166, "qtys"
+  Const        r167, "qtys"
+  Index        r168, r161, r167
+  Index        r169, r149, r13
+  Append       r170, r168, r169
   Move         r171, r162
-  Move         r172, r166
-  MakeMap      r173, 3, r167
-  SetIndex     r139, r155, r173
+  Move         r172, r163
+  Move         r173, r164
+  Move         r174, r165
+  Move         r175, r166
+  Move         r176, r170
+  MakeMap      r177, 3, r171
+  SetIndex     r143, r159, r177
   // if key in grouped {
   Jump         L16
 L15:
   // grouped[key] = {w: m.w, i: m.i, qtys: [m.qty]}
-  Const        r174, "w"
-  Index        r175, r145, r5
-  Const        r176, "i"
-  Index        r177, r145, r7
-  Const        r178, "qtys"
-  Index        r180, r145, r13
-  MakeList     r181, 1, r180
-  Move         r182, r174
-  Move         r183, r175
-  Move         r184, r176
-  Move         r185, r177
+  Const        r178, "w"
+  Index        r179, r149, r5
+  Const        r180, "i"
+  Index        r181, r149, r7
+  Const        r182, "qtys"
+  Index        r183, r149, r13
+  Move         r184, r183
+  MakeList     r185, 1, r184
   Move         r186, r178
-  Move         r187, r181
-  MakeMap      r188, 3, r182
-  SetIndex     r139, r155, r188
+  Move         r187, r179
+  Move         r188, r180
+  Move         r189, r181
+  Move         r190, r182
+  Move         r191, r185
+  MakeMap      r192, 3, r186
+  SetIndex     r143, r159, r192
 L16:
   // for m in monthly {
-  Const        r189, 1
-  Add          r142, r142, r189
+  Const        r193, 1
+  Add          r194, r146, r193
+  Move         r146, r194
   Jump         L17
 L14:
   // var summary = []
-  Const        r192, []
+  Move         r195, r88
   // for g in values(grouped) {
-  Const        r193, []
-  IterPrep     r194, r193
-  Len          r195, r194
-  Const        r196, 0
+  Const        r196, []
+  IterPrep     r197, r196
+  Len          r198, r197
+  Const        r199, 0
 L22:
-  Less         r197, r196, r195
-  JumpIfFalse  r197, L18
-  Index        r112, r194, r196
+  Less         r200, r199, r198
+  JumpIfFalse  r200, L18
+  Index        r201, r197, r199
+  Move         r116, r201
   // let mean = avg(g.qtys)
-  Index        r199, r112, r163
-  Avg          r200, r199
+  Index        r202, r116, r167
+  Avg          r203, r202
   // var sumsq = 0.0
-  Const        r202, 0
+  Const        r204, 0
+  Move         r205, r204
   // for q in g.qtys {
-  Index        r203, r112, r163
-  IterPrep     r204, r203
-  Len          r205, r204
-  Const        r206, 0
+  Index        r206, r116, r167
+  IterPrep     r207, r206
+  Len          r208, r207
+  Const        r209, 0
 L20:
-  Less         r207, r206, r205
-  JumpIfFalse  r207, L19
-  Index        r209, r204, r206
+  Less         r210, r209, r208
+  JumpIfFalse  r210, L19
+  Index        r211, r207, r209
+  Move         r212, r211
   // sumsq = sumsq + (q - mean) * (q - mean)
-  SubFloat     r210, r209, r200
-  SubFloat     r211, r209, r200
-  MulFloat     r212, r210, r211
-  AddFloat     r202, r202, r212
+  SubFloat     r213, r212, r203
+  SubFloat     r214, r212, r203
+  MulFloat     r215, r213, r214
+  AddFloat     r216, r205, r215
+  Move         r205, r216
   // for q in g.qtys {
-  Const        r214, 1
-  Add          r206, r206, r214
+  Const        r217, 1
+  Add          r218, r209, r217
+  Move         r209, r218
   Jump         L20
 L19:
   // let variance = sumsq / len(g.qtys)
-  Index        r216, r112, r163
-  Len          r217, r216
-  DivFloat     r219, r202, r217
+  Index        r219, r116, r167
+  Len          r220, r219
+  DivFloat     r221, r205, r220
   // let cov = sqrt(variance) / mean
-  Call         r220, sqrt, r219
-  DivFloat     r221, r220, r200
+  Move         r222, r221
+  Call         r223, sqrt, r222
+  DivFloat     r224, r223, r203
   // if cov > 1.5 {
-  Const        r222, 1.5
-  LessFloat    r223, r222, r221
-  JumpIfFalse  r223, L21
+  Const        r225, 1.5
+  LessFloat    r226, r225, r224
+  JumpIfFalse  r226, L21
   // summary = append(summary, {w_warehouse_sk: g.w, i_item_sk: g.i, cov: cov})
-  Const        r224, "w_warehouse_sk"
-  Index        r225, r112, r5
-  Const        r226, "i_item_sk"
-  Index        r227, r112, r7
-  Const        r228, "cov"
-  Move         r229, r224
-  Move         r230, r225
-  Move         r231, r226
+  Const        r227, "w_warehouse_sk"
+  Index        r228, r116, r5
+  Const        r229, "i_item_sk"
+  Index        r230, r116, r7
+  Const        r231, "cov"
   Move         r232, r227
   Move         r233, r228
-  Move         r234, r221
-  MakeMap      r235, 3, r229
-  Append       r192, r192, r235
+  Move         r234, r229
+  Move         r235, r230
+  Move         r236, r231
+  Move         r237, r224
+  MakeMap      r238, 3, r232
+  Append       r239, r195, r238
+  Move         r195, r239
 L21:
   // for g in values(grouped) {
-  Const        r237, 1
-  Add          r196, r196, r237
+  Const        r240, 1
+  Add          r241, r199, r240
+  Move         r199, r241
   Jump         L22
 L18:
   // json(summary)
-  JSON         r192
+  JSON         r195
   // expect summary == [{w_warehouse_sk: 1, i_item_sk: 1, cov: 1.5396007178390022}]
-  Const        r239, [{"cov": 1.539600717839002, "i_item_sk": 1, "w_warehouse_sk": 1}]
-  Equal        r240, r192, r239
-  Expect       r240
+  Const        r242, [{"cov": 1.539600717839002, "i_item_sk": 1, "w_warehouse_sk": 1}]
+  Equal        r243, r195, r242
+  Expect       r243
   Return       r0
 
   // fun sqrt(x: float): float {
 func sqrt (regs=13)
   // let guess = x / 2.0
   Const        r1, 2
-  DivFloat     r3, r0, r1
+  DivFloat     r2, r0, r1
+  // var result = guess
+  Move         r3, r2
   // for i in 0..5 {
   Const        r4, 0
   Const        r5, 5
@@ -352,10 +380,12 @@ L1:
   // result = (result + x / result) / 2.0
   DivFloat     r8, r0, r3
   AddFloat     r9, r3, r8
-  DivFloat     r3, r9, r1
+  DivFloat     r10, r9, r1
+  Move         r3, r10
   // for i in 0..5 {
   Const        r11, 1
-  Add          r6, r6, r11
+  Add          r12, r6, r11
+  Move         r6, r12
   Jump         L1
 L0:
   // return result


### PR DESCRIPTION
## Summary
- ensure string conversion uses a stable order
- fix map membership checks to use stable keys
- regenerate TPC-DS IR outputs for q30–q39

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862a9fb699c832095a363d2f40bf852