### PR TITLE
Update vm reverse folding

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6089,6 +6089,25 @@ func (fc *funcCompiler) foldCallValue(call *parser.CallExpr) (Value, bool) {
 			return Value{Tag: ValueStr, Str: strings.ToLower(v.Str)}, true
 		}
 		return Value{Tag: ValueStr, Str: strings.ToLower(fmt.Sprint(valueToAny(v)))}, true
+	case "reverse":
+		if len(args) != 1 {
+			return Value{}, false
+		}
+		v := args[0]
+		switch v.Tag {
+		case ValueList:
+			out := append([]Value(nil), v.List...)
+			for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+				out[i], out[j] = out[j], out[i]
+			}
+			return Value{Tag: ValueList, List: out}, true
+		case ValueStr:
+			r := []rune(v.Str)
+			for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+				r[i], r[j] = r[j], r[i]
+			}
+			return Value{Tag: ValueStr, Str: string(r)}, true
+		}
 	case "substring":
 		if len(args) != 3 {
 			return Value{}, false

--- a/tests/dataset/tpc-ds/out/q8.ir.out
+++ b/tests/dataset/tpc-ds/out/q8.ir.out
@@ -1,13 +1,12 @@
-func main (regs=5)
+func main (regs=4)
   // let store_sales = []
   Const        r0, []
   // reverse(substr("zip", 0, 2))
-  Const        r1, "zi"
-  Reverse      r2, r1
+  Const        r1, "iz"
   // json(result)
   JSON         r0
   // expect len(result) == 0
-  Const        r3, 0
-  Const        r4, true
-  Expect       r4
+  Const        r2, 0
+  Const        r3, true
+  Expect       r3
   Return       r0


### PR DESCRIPTION
## Summary
- fold constant `reverse` calls at compile time
- refresh IR golden for tpc-ds q8

## Testing
- `go test -tags slow ./tests/vm -run "TPCDS/q[1-9]\.mochi$" -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6862aeaf410c8320af622849dc372d40