### PR TITLE
Support legacy arg patterns in tpc‑ds queries

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -602,8 +602,10 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 		return Value{Tag: ValueFunc, Func: cl}, nil
 	}
 	if len(args) > fn.NumParams {
-		// Older dataset queries may pass extraneous arguments to built-in
-		// functions. Drop any excess arguments instead of failing.
+		// Some legacy tpc-ds queries (for example q20-q29) invoke
+		// built-ins with more arguments than the current signatures
+		// accept. Drop any extra arguments instead of failing so that
+		// those queries can still run.
 		args = args[:fn.NumParams]
 	}
 	f := &frame{fn: fn, regs: make([]Value, fn.NumRegs)}


### PR DESCRIPTION
## Summary
- document handling of extra arguments when invoking built‑ins

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862aeb524dc8320ad4b7030eb4eb7e4