### PR TITLE
Enable VM pure function arg truncation

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6312,8 +6312,11 @@ func (fc *funcCompiler) evalPureFunc(name string, args []Value) (Value, bool) {
 	if !ok {
 		return Value{}, false
 	}
-	if len(fn.Params) != len(args) || len(fn.Body) != 1 {
+	if len(args) < len(fn.Params) || len(fn.Body) != 1 {
 		return Value{}, false
+	}
+	if len(args) > len(fn.Params) {
+		args = args[:len(fn.Params)]
 	}
 	ret := fn.Body[0].Return
 	if ret == nil {

--- a/tests/dataset/tpc-ds/out/q72.ir.out
+++ b/tests/dataset/tpc-ds/out/q72.ir.out
@@ -448,3 +448,4 @@ L25:
   Equal        r275, r7, r274
   Expect       r275
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q73.ir.out
+++ b/tests/dataset/tpc-ds/out/q73.ir.out
@@ -390,3 +390,4 @@ L21:
   Equal        r230, r165, r229
   Expect       r230
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q74.ir.out
+++ b/tests/dataset/tpc-ds/out/q74.ir.out
@@ -554,3 +554,4 @@ L43:
   Equal        r368, r366, r367
   Expect       r368
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q75.ir.out
+++ b/tests/dataset/tpc-ds/out/q75.ir.out
@@ -519,3 +519,4 @@ L30:
   Equal        r351, r349, r350
   Expect       r351
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q76.ir.out
+++ b/tests/dataset/tpc-ds/out/q76.ir.out
@@ -464,3 +464,4 @@ L24:
   Equal        r301, r185, r300
   Expect       r301
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q77.ir.out
+++ b/tests/dataset/tpc-ds/out/q77.ir.out
@@ -1337,3 +1337,4 @@ L96:
   Equal        r852, r751, r851
   Expect       r852
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q78.ir.out
+++ b/tests/dataset/tpc-ds/out/q78.ir.out
@@ -622,3 +622,4 @@ L0:
   Equal        r417, r3, r416
   Expect       r417
   Return       r0
+

--- a/tests/dataset/tpc-ds/out/q79.ir.out
+++ b/tests/dataset/tpc-ds/out/q79.ir.out
@@ -388,3 +388,4 @@ L23:
   Equal        r250, r187, r249
   Expect       r250
   Return       r0
+


### PR DESCRIPTION
## Summary
- drop extra args when evaluating pure functions
- ensure trailing newlines for TPC-DS query IR outputs

## Testing
- `go test ./... -run TestVM_TPCDS -tags slow -count=1` *(fails: couldn't complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6862aec62dcc83208f6f67bae70693f8