### PR TITLE
Update VM float formatting

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -6732,7 +6732,11 @@ func valueToString(v Value) string {
 		case ValueInt:
 			return fmt.Sprintf("%d", val.Int)
 		case ValueFloat:
-			return fmt.Sprintf("%g", val.Float)
+			s := strconv.FormatFloat(val.Float, 'f', -1, 64)
+			if !strings.Contains(s, ".") {
+				s += ".0"
+			}
+			return s
 		case ValueBool:
 			return fmt.Sprintf("%v", val.Bool)
 		case ValueStr:


### PR DESCRIPTION
## Summary
- keep one decimal place when printing float values
- refresh q6 VM IR output to show `95.0`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862af1affa08320b1d3c43c1779a242