### PR TITLE
Enable tpc‑ds queries

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -602,10 +602,10 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 		return Value{Tag: ValueFunc, Func: cl}, nil
 	}
 	if len(args) > fn.NumParams {
-		// Some legacy tpc-ds queries (for example q20-q29) invoke
-		// built-ins with more arguments than the current signatures
-		// accept. Drop any extra arguments instead of failing so that
-		// those queries can still run.
+		// Some legacy TPC-DS queries (for example q20–q29) invoke
+		// built-ins with more arguments than their current
+		// signatures accept.  Drop any extra arguments instead of
+		// failing so that those queries continue to run.
 		args = args[:fn.NumParams]
 	}
 	f := &frame{fn: fn, regs: make([]Value, fn.NumRegs)}

--- a/tests/dataset/tpc-ds/out/q1.ir.out
+++ b/tests/dataset/tpc-ds/out/q1.ir.out
@@ -1,4 +1,4 @@
-func main (regs=171)
+func main (regs=170)
   // let store_returns = []
   Const        r0, []
   // from sr in store_returns
@@ -20,271 +20,270 @@ func main (regs=171)
   Const        r11, "sr_return_amt"
   // from sr in store_returns
   MakeMap      r12, 0, r0
-  Const        r14, []
-  Move         r13, r14
-  IterPrep     r15, r0
-  Len          r16, r15
-  Const        r17, 0
+  Move         r13, r0
+  IterPrep     r14, r0
+  Len          r15, r14
+  Const        r16, 0
 L5:
-  LessInt      r18, r17, r16
-  JumpIfFalse  r18, L0
-  Index        r19, r15, r17
-  Move         r20, r19
+  LessInt      r17, r16, r15
+  JumpIfFalse  r17, L0
+  Index        r18, r14, r16
+  Move         r19, r18
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  IterPrep     r21, r0
-  Len          r22, r21
-  Const        r23, 0
+  IterPrep     r20, r0
+  Len          r21, r20
+  Const        r22, 0
 L4:
-  LessInt      r24, r23, r22
-  JumpIfFalse  r24, L1
-  Index        r25, r21, r23
-  Move         r26, r25
-  Const        r27, "sr_returned_date_sk"
-  Index        r28, r20, r27
-  Const        r29, "d_date_sk"
-  Index        r30, r26, r29
-  Equal        r31, r28, r30
-  JumpIfFalse  r31, L2
+  LessInt      r23, r22, r21
+  JumpIfFalse  r23, L1
+  Index        r24, r20, r22
+  Move         r25, r24
+  Const        r26, "sr_returned_date_sk"
+  Index        r27, r19, r26
+  Const        r28, "d_date_sk"
+  Index        r29, r25, r28
+  Equal        r30, r27, r29
+  JumpIfFalse  r30, L2
   // where d.d_year == 1998
-  Index        r32, r26, r6
-  Const        r33, 1998
-  Equal        r34, r32, r33
-  JumpIfFalse  r34, L2
+  Index        r31, r25, r6
+  Const        r32, 1998
+  Equal        r33, r31, r32
+  JumpIfFalse  r33, L2
   // from sr in store_returns
-  Const        r35, "sr"
-  Move         r36, r20
-  Const        r37, "d"
-  Move         r38, r26
+  Const        r34, "sr"
+  Move         r35, r19
+  Const        r36, "d"
+  Move         r37, r25
+  Move         r38, r34
   Move         r39, r35
   Move         r40, r36
   Move         r41, r37
-  Move         r42, r38
-  MakeMap      r43, 2, r39
+  MakeMap      r42, 2, r38
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Const        r44, "customer_sk"
-  Index        r45, r20, r3
-  Const        r46, "store_sk"
-  Index        r47, r20, r5
+  Const        r43, "customer_sk"
+  Index        r44, r19, r3
+  Const        r45, "store_sk"
+  Index        r46, r19, r5
+  Move         r47, r43
   Move         r48, r44
   Move         r49, r45
   Move         r50, r46
-  Move         r51, r47
-  MakeMap      r52, 2, r48
-  Str          r53, r52
-  In           r54, r53, r12
-  JumpIfTrue   r54, L3
+  MakeMap      r51, 2, r47
+  Str          r52, r51
+  In           r53, r52, r12
+  JumpIfTrue   r53, L3
   // from sr in store_returns
-  Const        r55, "__group__"
-  Const        r56, true
+  Const        r54, "__group__"
+  Const        r55, true
   // group by {customer_sk: sr.sr_customer_sk, store_sk: sr.sr_store_sk} into g
-  Move         r57, r52
+  Move         r56, r51
   // from sr in store_returns
-  Const        r58, "items"
-  Move         r59, r0
-  Const        r60, "count"
-  Const        r61, 0
+  Const        r57, "items"
+  Move         r58, r0
+  Const        r59, "count"
+  Const        r60, 0
+  Move         r61, r54
   Move         r62, r55
-  Move         r63, r56
-  Move         r64, r8
+  Move         r63, r8
+  Move         r64, r56
   Move         r65, r57
   Move         r66, r58
   Move         r67, r59
   Move         r68, r60
-  Move         r69, r61
-  MakeMap      r70, 4, r62
-  SetIndex     r12, r53, r70
-  Append       r71, r13, r70
-  Move         r13, r71
+  MakeMap      r69, 4, r61
+  SetIndex     r12, r52, r69
+  Append       r70, r13, r69
+  Move         r13, r70
 L3:
-  Index        r72, r12, r53
-  Index        r73, r72, r58
-  Append       r74, r73, r43
-  SetIndex     r72, r58, r74
-  Index        r75, r72, r60
-  Const        r76, 1
-  AddInt       r77, r75, r76
-  SetIndex     r72, r60, r77
+  Index        r71, r12, r52
+  Index        r72, r71, r57
+  Append       r73, r72, r42
+  SetIndex     r71, r57, r73
+  Index        r74, r71, r59
+  Const        r75, 1
+  AddInt       r76, r74, r75
+  SetIndex     r71, r59, r76
 L2:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  AddInt       r23, r23, r76
+  AddInt       r22, r22, r75
   Jump         L4
 L1:
   // from sr in store_returns
-  AddInt       r17, r17, r76
+  AddInt       r16, r16, r75
   Jump         L5
 L0:
-  Move         r78, r61
-  Len          r79, r13
+  Move         r77, r60
+  Len          r78, r13
 L9:
-  LessInt      r80, r78, r79
-  JumpIfFalse  r80, L6
-  Index        r81, r13, r78
-  Move         r82, r81
+  LessInt      r79, r77, r78
+  JumpIfFalse  r79, L6
+  Index        r80, r13, r77
+  Move         r81, r80
   // ctr_customer_sk: g.key.customer_sk,
-  Const        r83, "ctr_customer_sk"
-  Index        r84, r82, r8
-  Index        r85, r84, r2
+  Const        r82, "ctr_customer_sk"
+  Index        r83, r81, r8
+  Index        r84, r83, r2
   // ctr_store_sk: g.key.store_sk,
-  Const        r86, "ctr_store_sk"
-  Index        r87, r82, r8
-  Index        r88, r87, r4
+  Const        r85, "ctr_store_sk"
+  Index        r86, r81, r8
+  Index        r87, r86, r4
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Const        r89, "ctr_total_return"
-  Const        r90, []
-  IterPrep     r91, r82
-  Len          r92, r91
-  Move         r93, r61
+  Const        r88, "ctr_total_return"
+  Const        r89, []
+  IterPrep     r90, r81
+  Len          r91, r90
+  Move         r92, r60
 L8:
-  LessInt      r94, r93, r92
-  JumpIfFalse  r94, L7
-  Index        r95, r91, r93
-  Move         r96, r95
-  Index        r97, r96, r11
-  Append       r98, r90, r97
-  Move         r90, r98
-  AddInt       r93, r93, r76
+  LessInt      r93, r92, r91
+  JumpIfFalse  r93, L7
+  Index        r94, r90, r92
+  Move         r95, r94
+  Index        r96, r95, r11
+  Append       r97, r89, r96
+  Move         r89, r97
+  AddInt       r92, r92, r75
   Jump         L8
 L7:
-  Sum          r99, r90
+  Sum          r98, r89
   // ctr_customer_sk: g.key.customer_sk,
-  Move         r100, r83
-  Move         r101, r85
+  Move         r99, r82
+  Move         r100, r84
   // ctr_store_sk: g.key.store_sk,
-  Move         r102, r86
-  Move         r103, r88
+  Move         r101, r85
+  Move         r102, r87
   // ctr_total_return: sum(from x in g select x.sr_return_amt)
-  Move         r104, r89
-  Move         r105, r99
+  Move         r103, r88
+  Move         r104, r98
   // select {
-  MakeMap      r106, 3, r100
+  MakeMap      r105, 3, r99
   // from sr in store_returns
-  Append       r107, r1, r106
-  Move         r1, r107
-  AddInt       r78, r78, r76
+  Append       r106, r1, r105
+  Move         r1, r106
+  AddInt       r77, r77, r75
   Jump         L9
 L6:
   // from ctr1 in customer_total_return
-  Const        r108, []
+  Const        r107, []
   // s.s_state == "TN"
-  Const        r109, "s_state"
+  Const        r108, "s_state"
   // select {c_customer_id: c.c_customer_id}
-  Const        r110, "c_customer_id"
+  Const        r109, "c_customer_id"
   // from ctr1 in customer_total_return
-  IterPrep     r111, r1
-  Len          r112, r111
-  Move         r113, r61
+  IterPrep     r110, r1
+  Len          r111, r110
+  Move         r112, r60
 L20:
-  LessInt      r114, r113, r112
-  JumpIfFalse  r114, L10
-  Index        r115, r111, r113
-  Move         r116, r115
+  LessInt      r113, r112, r111
+  JumpIfFalse  r113, L10
+  Index        r114, r110, r112
+  Move         r115, r114
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  IterPrep     r117, r0
-  Len          r118, r117
-  Const        r119, "s_store_sk"
-  Move         r120, r61
+  IterPrep     r116, r0
+  Len          r117, r116
+  Const        r118, "s_store_sk"
+  Move         r119, r60
 L19:
-  LessInt      r121, r120, r118
-  JumpIfFalse  r121, L11
-  Index        r122, r117, r120
-  Move         r123, r122
-  Index        r124, r116, r9
-  Index        r125, r123, r119
-  Equal        r126, r124, r125
-  JumpIfFalse  r126, L12
+  LessInt      r120, r119, r117
+  JumpIfFalse  r120, L11
+  Index        r121, r116, r119
+  Move         r122, r121
+  Index        r123, r115, r9
+  Index        r124, r122, r118
+  Equal        r125, r123, r124
+  JumpIfFalse  r125, L12
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  IterPrep     r127, r0
-  Len          r128, r127
-  Const        r129, "c_customer_sk"
-  Move         r130, r61
+  IterPrep     r126, r0
+  Len          r127, r126
+  Const        r128, "c_customer_sk"
+  Move         r129, r60
 L18:
-  LessInt      r131, r130, r128
-  JumpIfFalse  r131, L12
-  Index        r132, r127, r130
-  Move         r133, r132
-  Index        r134, r116, r7
-  Index        r135, r133, r129
-  Equal        r136, r134, r135
-  JumpIfFalse  r136, L13
+  LessInt      r130, r129, r127
+  JumpIfFalse  r130, L12
+  Index        r131, r126, r129
+  Move         r132, r131
+  Index        r133, r115, r7
+  Index        r134, r132, r128
+  Equal        r135, r133, r134
+  JumpIfFalse  r135, L13
   // where ctr1.ctr_total_return > avg(
-  Index        r137, r116, r10
+  Index        r136, r115, r10
   // from ctr2 in customer_total_return
-  Const        r138, []
-  IterPrep     r139, r1
-  Len          r140, r139
-  Move         r141, r61
+  Const        r137, []
+  IterPrep     r138, r1
+  Len          r139, r138
+  Move         r140, r60
 L16:
-  LessInt      r142, r141, r140
-  JumpIfFalse  r142, L14
-  Index        r143, r139, r141
-  Move         r144, r143
+  LessInt      r141, r140, r139
+  JumpIfFalse  r141, L14
+  Index        r142, r138, r140
+  Move         r143, r142
   // where ctr1.ctr_store_sk == ctr2.ctr_store_sk
-  Index        r145, r116, r9
-  Index        r146, r144, r9
-  Equal        r147, r145, r146
-  JumpIfFalse  r147, L15
+  Index        r144, r115, r9
+  Index        r145, r143, r9
+  Equal        r146, r144, r145
+  JumpIfFalse  r146, L15
   // select ctr2.ctr_total_return
-  Index        r148, r144, r10
+  Index        r147, r143, r10
   // from ctr2 in customer_total_return
-  Append       r149, r138, r148
-  Move         r138, r149
+  Append       r148, r137, r147
+  Move         r137, r148
 L15:
-  AddInt       r141, r141, r76
+  AddInt       r140, r140, r75
   Jump         L16
 L14:
   // where ctr1.ctr_total_return > avg(
-  Avg          r150, r138
+  Avg          r149, r137
   // ) * 1.2 &&
-  Const        r151, 1.2
-  MulFloat     r152, r150, r151
+  Const        r150, 1.2
+  MulFloat     r151, r149, r150
   // where ctr1.ctr_total_return > avg(
-  LessFloat    r153, r152, r137
+  LessFloat    r152, r151, r136
   // s.s_state == "TN"
-  Index        r154, r123, r109
-  Const        r155, "TN"
-  Equal        r156, r154, r155
+  Index        r153, r122, r108
+  Const        r154, "TN"
+  Equal        r155, r153, r154
   // ) * 1.2 &&
-  Move         r157, r153
-  JumpIfFalse  r157, L17
-  Move         r157, r156
+  Move         r156, r152
+  JumpIfFalse  r156, L17
+  Move         r156, r155
 L17:
   // where ctr1.ctr_total_return > avg(
-  JumpIfFalse  r157, L13
+  JumpIfFalse  r156, L13
   // select {c_customer_id: c.c_customer_id}
-  Const        r158, "c_customer_id"
-  Index        r159, r133, r110
+  Const        r157, "c_customer_id"
+  Index        r158, r132, r109
+  Move         r159, r157
   Move         r160, r158
-  Move         r161, r159
-  MakeMap      r162, 1, r160
+  MakeMap      r161, 1, r159
   // sort by c.c_customer_id
-  Index        r163, r133, r110
-  Move         r164, r163
+  Index        r162, r132, r109
+  Move         r163, r162
   // from ctr1 in customer_total_return
-  Move         r165, r162
-  MakeList     r166, 2, r164
-  Append       r167, r108, r166
-  Move         r108, r167
+  Move         r164, r161
+  MakeList     r165, 2, r163
+  Append       r166, r107, r165
+  Move         r107, r166
 L13:
   // join c in customer on ctr1.ctr_customer_sk == c.c_customer_sk
-  Add          r130, r130, r76
+  Add          r129, r129, r75
   Jump         L18
 L12:
   // join s in store on ctr1.ctr_store_sk == s.s_store_sk
-  Add          r120, r120, r76
+  Add          r119, r119, r75
   Jump         L19
 L11:
   // from ctr1 in customer_total_return
-  AddInt       r113, r113, r76
+  AddInt       r112, r112, r75
   Jump         L20
 L10:
   // sort by c.c_customer_id
-  Sort         r168, r108
+  Sort         r167, r107
   // from ctr1 in customer_total_return
-  Move         r108, r168
+  Move         r107, r167
   // json(result)
-  JSON         r108
+  JSON         r107
   // expect len(result) == 0
-  Len          r169, r108
-  EqualInt     r170, r169, r61
-  Expect       r170
+  Len          r168, r107
+  EqualInt     r169, r168, r60
+  Expect       r169
   Return       r0

--- a/tests/dataset/tpc-ds/out/q2.ir.out
+++ b/tests/dataset/tpc-ds/out/q2.ir.out
@@ -1,4 +1,4 @@
-func main (regs=241)
+func main (regs=240)
   // let web_sales = []
   Const        r0, []
   // (from ws in web_sales
@@ -117,294 +117,293 @@ L2:
   Const        r65, "sat_sales"
   // from w in wscs
   MakeMap      r66, 0, r0
-  Const        r68, []
-  Move         r67, r68
-  IterPrep     r69, r54
-  Len          r70, r69
-  Const        r71, 0
+  Move         r67, r0
+  IterPrep     r68, r54
+  Len          r69, r68
+  Const        r70, 0
 L9:
-  LessInt      r72, r71, r70
-  JumpIfFalse  r72, L4
-  Index        r73, r69, r71
-  Move         r74, r73
+  LessInt      r71, r70, r69
+  JumpIfFalse  r71, L4
+  Index        r72, r68, r70
+  Move         r73, r72
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  IterPrep     r75, r0
-  Len          r76, r75
-  Const        r77, 0
+  IterPrep     r74, r0
+  Len          r75, r74
+  Const        r76, 0
 L8:
-  LessInt      r78, r77, r76
-  JumpIfFalse  r78, L5
-  Index        r79, r75, r77
-  Move         r80, r79
-  Index        r81, r74, r2
-  Const        r82, "d_date_sk"
-  Index        r83, r80, r82
-  Equal        r84, r81, r83
-  JumpIfFalse  r84, L6
+  LessInt      r77, r76, r75
+  JumpIfFalse  r77, L5
+  Index        r78, r74, r76
+  Move         r79, r78
+  Index        r80, r73, r2
+  Const        r81, "d_date_sk"
+  Index        r82, r79, r81
+  Equal        r83, r80, r82
+  JumpIfFalse  r83, L6
   // from w in wscs
-  Const        r85, "w"
-  Move         r86, r74
-  Const        r87, "d"
-  Move         r88, r80
+  Const        r84, "w"
+  Move         r85, r73
+  Const        r86, "d"
+  Move         r87, r79
+  Move         r88, r84
   Move         r89, r85
   Move         r90, r86
   Move         r91, r87
-  Move         r92, r88
-  MakeMap      r93, 2, r89
+  MakeMap      r92, 2, r88
   // group by {week_seq: d.d_week_seq} into g
-  Const        r94, "week_seq"
-  Index        r95, r80, r57
+  Const        r93, "week_seq"
+  Index        r94, r79, r57
+  Move         r95, r93
   Move         r96, r94
-  Move         r97, r95
-  MakeMap      r98, 1, r96
-  Str          r99, r98
-  In           r100, r99, r66
-  JumpIfTrue   r100, L7
+  MakeMap      r97, 1, r95
+  Str          r98, r97
+  In           r99, r98, r66
+  JumpIfTrue   r99, L7
   // from w in wscs
-  Const        r101, "__group__"
-  Const        r102, true
+  Const        r100, "__group__"
+  Const        r101, true
   // group by {week_seq: d.d_week_seq} into g
-  Move         r103, r98
+  Move         r102, r97
   // from w in wscs
-  Const        r104, "items"
-  Move         r105, r0
-  Const        r106, "count"
+  Const        r103, "items"
+  Move         r104, r0
+  Const        r105, "count"
+  Move         r106, r100
   Move         r107, r101
-  Move         r108, r102
-  Move         r109, r58
+  Move         r108, r58
+  Move         r109, r102
   Move         r110, r103
   Move         r111, r104
   Move         r112, r105
-  Move         r113, r106
-  Move         r114, r11
-  MakeMap      r115, 4, r107
-  SetIndex     r66, r99, r115
-  Append       r116, r67, r115
-  Move         r67, r116
+  Move         r113, r11
+  MakeMap      r114, 4, r106
+  SetIndex     r66, r98, r114
+  Append       r115, r67, r114
+  Move         r67, r115
 L7:
-  Index        r117, r66, r99
-  Index        r118, r117, r104
-  Append       r119, r118, r93
-  SetIndex     r117, r104, r119
-  Index        r120, r117, r106
-  AddInt       r121, r120, r29
-  SetIndex     r117, r106, r121
+  Index        r116, r66, r98
+  Index        r117, r116, r103
+  Append       r118, r117, r92
+  SetIndex     r116, r103, r118
+  Index        r119, r116, r105
+  AddInt       r120, r119, r29
+  SetIndex     r116, r105, r120
 L6:
   // join d in date_dim on w.sold_date_sk == d.d_date_sk
-  AddInt       r77, r77, r29
+  AddInt       r76, r76, r29
   Jump         L8
 L5:
   // from w in wscs
-  AddInt       r71, r71, r29
+  AddInt       r70, r70, r29
   Jump         L9
 L4:
-  Move         r122, r11
-  Len          r123, r67
+  Move         r121, r11
+  Len          r122, r67
 L32:
-  LessInt      r124, r122, r123
-  JumpIfFalse  r124, L10
-  Index        r125, r67, r122
-  Move         r126, r125
+  LessInt      r123, r121, r122
+  JumpIfFalse  r123, L10
+  Index        r124, r67, r121
+  Move         r125, r124
   // d_week_seq: g.key.week_seq,
-  Const        r127, "d_week_seq"
-  Index        r128, r126, r58
-  Index        r129, r128, r56
+  Const        r126, "d_week_seq"
+  Index        r127, r125, r58
+  Index        r128, r127, r56
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Const        r130, "sun_sales"
-  Const        r131, []
-  IterPrep     r132, r126
-  Len          r133, r132
-  Move         r134, r11
+  Const        r129, "sun_sales"
+  Const        r130, []
+  IterPrep     r131, r125
+  Len          r132, r131
+  Move         r133, r11
 L13:
-  LessInt      r135, r134, r133
-  JumpIfFalse  r135, L11
-  Index        r136, r132, r134
-  Move         r137, r136
-  Index        r138, r137, r6
-  Const        r139, "Sunday"
-  Equal        r140, r138, r139
-  JumpIfFalse  r140, L12
-  Index        r141, r137, r4
-  Append       r142, r131, r141
-  Move         r131, r142
+  LessInt      r134, r133, r132
+  JumpIfFalse  r134, L11
+  Index        r135, r131, r133
+  Move         r136, r135
+  Index        r137, r136, r6
+  Const        r138, "Sunday"
+  Equal        r139, r137, r138
+  JumpIfFalse  r139, L12
+  Index        r140, r136, r4
+  Append       r141, r130, r140
+  Move         r130, r141
 L12:
-  AddInt       r134, r134, r29
+  AddInt       r133, r133, r29
   Jump         L13
 L11:
-  Sum          r143, r131
+  Sum          r142, r130
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Const        r144, "mon_sales"
-  Const        r145, []
-  IterPrep     r146, r126
-  Len          r147, r146
-  Move         r148, r11
+  Const        r143, "mon_sales"
+  Const        r144, []
+  IterPrep     r145, r125
+  Len          r146, r145
+  Move         r147, r11
 L16:
-  LessInt      r149, r148, r147
-  JumpIfFalse  r149, L14
-  Index        r150, r146, r148
-  Move         r137, r150
-  Index        r151, r137, r6
-  Const        r152, "Monday"
-  Equal        r153, r151, r152
-  JumpIfFalse  r153, L15
-  Index        r154, r137, r4
-  Append       r155, r145, r154
-  Move         r145, r155
+  LessInt      r148, r147, r146
+  JumpIfFalse  r148, L14
+  Index        r149, r145, r147
+  Move         r136, r149
+  Index        r150, r136, r6
+  Const        r151, "Monday"
+  Equal        r152, r150, r151
+  JumpIfFalse  r152, L15
+  Index        r153, r136, r4
+  Append       r154, r144, r153
+  Move         r144, r154
 L15:
-  AddInt       r148, r148, r29
+  AddInt       r147, r147, r29
   Jump         L16
 L14:
-  Sum          r156, r145
+  Sum          r155, r144
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Const        r157, "tue_sales"
-  Const        r158, []
-  IterPrep     r159, r126
-  Len          r160, r159
-  Move         r161, r11
+  Const        r156, "tue_sales"
+  Const        r157, []
+  IterPrep     r158, r125
+  Len          r159, r158
+  Move         r160, r11
 L19:
-  LessInt      r162, r161, r160
-  JumpIfFalse  r162, L17
-  Index        r163, r159, r161
-  Move         r137, r163
-  Index        r164, r137, r6
-  Const        r165, "Tuesday"
-  Equal        r166, r164, r165
-  JumpIfFalse  r166, L18
-  Index        r167, r137, r4
-  Append       r168, r158, r167
-  Move         r158, r168
+  LessInt      r161, r160, r159
+  JumpIfFalse  r161, L17
+  Index        r162, r158, r160
+  Move         r136, r162
+  Index        r163, r136, r6
+  Const        r164, "Tuesday"
+  Equal        r165, r163, r164
+  JumpIfFalse  r165, L18
+  Index        r166, r136, r4
+  Append       r167, r157, r166
+  Move         r157, r167
 L18:
-  AddInt       r161, r161, r29
+  AddInt       r160, r160, r29
   Jump         L19
 L17:
-  Sum          r169, r158
+  Sum          r168, r157
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Const        r170, "wed_sales"
-  Const        r171, []
-  IterPrep     r172, r126
-  Len          r173, r172
-  Move         r174, r11
+  Const        r169, "wed_sales"
+  Const        r170, []
+  IterPrep     r171, r125
+  Len          r172, r171
+  Move         r173, r11
 L22:
-  LessInt      r175, r174, r173
-  JumpIfFalse  r175, L20
-  Index        r176, r172, r174
-  Move         r137, r176
-  Index        r177, r137, r6
-  Const        r178, "Wednesday"
-  Equal        r179, r177, r178
-  JumpIfFalse  r179, L21
-  Index        r180, r137, r4
-  Append       r181, r171, r180
-  Move         r171, r181
+  LessInt      r174, r173, r172
+  JumpIfFalse  r174, L20
+  Index        r175, r171, r173
+  Move         r136, r175
+  Index        r176, r136, r6
+  Const        r177, "Wednesday"
+  Equal        r178, r176, r177
+  JumpIfFalse  r178, L21
+  Index        r179, r136, r4
+  Append       r180, r170, r179
+  Move         r170, r180
 L21:
-  AddInt       r174, r174, r29
+  AddInt       r173, r173, r29
   Jump         L22
 L20:
-  Sum          r182, r171
+  Sum          r181, r170
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Const        r183, "thu_sales"
-  Const        r184, []
-  IterPrep     r185, r126
-  Len          r186, r185
-  Move         r187, r11
+  Const        r182, "thu_sales"
+  Const        r183, []
+  IterPrep     r184, r125
+  Len          r185, r184
+  Move         r186, r11
 L25:
-  LessInt      r188, r187, r186
-  JumpIfFalse  r188, L23
-  Index        r189, r185, r187
-  Move         r137, r189
-  Index        r190, r137, r6
-  Const        r191, "Thursday"
-  Equal        r192, r190, r191
-  JumpIfFalse  r192, L24
-  Index        r193, r137, r4
-  Append       r194, r184, r193
-  Move         r184, r194
+  LessInt      r187, r186, r185
+  JumpIfFalse  r187, L23
+  Index        r188, r184, r186
+  Move         r136, r188
+  Index        r189, r136, r6
+  Const        r190, "Thursday"
+  Equal        r191, r189, r190
+  JumpIfFalse  r191, L24
+  Index        r192, r136, r4
+  Append       r193, r183, r192
+  Move         r183, r193
 L24:
-  AddInt       r187, r187, r29
+  AddInt       r186, r186, r29
   Jump         L25
 L23:
-  Sum          r195, r184
+  Sum          r194, r183
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Const        r196, "fri_sales"
-  Const        r197, []
-  IterPrep     r198, r126
-  Len          r199, r198
-  Move         r200, r11
+  Const        r195, "fri_sales"
+  Const        r196, []
+  IterPrep     r197, r125
+  Len          r198, r197
+  Move         r199, r11
 L28:
-  LessInt      r201, r200, r199
-  JumpIfFalse  r201, L26
-  Index        r202, r198, r200
-  Move         r137, r202
-  Index        r203, r137, r6
-  Const        r204, "Friday"
-  Equal        r205, r203, r204
-  JumpIfFalse  r205, L27
-  Index        r206, r137, r4
-  Append       r207, r197, r206
-  Move         r197, r207
+  LessInt      r200, r199, r198
+  JumpIfFalse  r200, L26
+  Index        r201, r197, r199
+  Move         r136, r201
+  Index        r202, r136, r6
+  Const        r203, "Friday"
+  Equal        r204, r202, r203
+  JumpIfFalse  r204, L27
+  Index        r205, r136, r4
+  Append       r206, r196, r205
+  Move         r196, r206
 L27:
-  AddInt       r200, r200, r29
+  AddInt       r199, r199, r29
   Jump         L28
 L26:
-  Sum          r208, r197
+  Sum          r207, r196
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Const        r209, "sat_sales"
-  Const        r210, []
-  IterPrep     r211, r126
-  Len          r212, r211
-  Move         r213, r11
+  Const        r208, "sat_sales"
+  Const        r209, []
+  IterPrep     r210, r125
+  Len          r211, r210
+  Move         r212, r11
 L31:
-  LessInt      r214, r213, r212
-  JumpIfFalse  r214, L29
-  Index        r215, r211, r213
-  Move         r137, r215
-  Index        r216, r137, r6
-  Const        r217, "Saturday"
-  Equal        r218, r216, r217
-  JumpIfFalse  r218, L30
-  Index        r219, r137, r4
-  Append       r220, r210, r219
-  Move         r210, r220
+  LessInt      r213, r212, r211
+  JumpIfFalse  r213, L29
+  Index        r214, r210, r212
+  Move         r136, r214
+  Index        r215, r136, r6
+  Const        r216, "Saturday"
+  Equal        r217, r215, r216
+  JumpIfFalse  r217, L30
+  Index        r218, r136, r4
+  Append       r219, r209, r218
+  Move         r209, r219
 L30:
-  AddInt       r213, r213, r29
+  AddInt       r212, r212, r29
   Jump         L31
 L29:
-  Sum          r221, r210
+  Sum          r220, r209
   // d_week_seq: g.key.week_seq,
-  Move         r222, r127
-  Move         r223, r129
+  Move         r221, r126
+  Move         r222, r128
   // sun_sales: sum(from x in g where x.day == "Sunday" select x.sales_price),
-  Move         r224, r130
-  Move         r225, r143
+  Move         r223, r129
+  Move         r224, r142
   // mon_sales: sum(from x in g where x.day == "Monday" select x.sales_price),
-  Move         r226, r144
-  Move         r227, r156
+  Move         r225, r143
+  Move         r226, r155
   // tue_sales: sum(from x in g where x.day == "Tuesday" select x.sales_price),
-  Move         r228, r157
-  Move         r229, r169
+  Move         r227, r156
+  Move         r228, r168
   // wed_sales: sum(from x in g where x.day == "Wednesday" select x.sales_price),
-  Move         r230, r170
-  Move         r231, r182
+  Move         r229, r169
+  Move         r230, r181
   // thu_sales: sum(from x in g where x.day == "Thursday" select x.sales_price),
-  Move         r232, r183
-  Move         r233, r195
+  Move         r231, r182
+  Move         r232, r194
   // fri_sales: sum(from x in g where x.day == "Friday" select x.sales_price),
-  Move         r234, r196
-  Move         r235, r208
+  Move         r233, r195
+  Move         r234, r207
   // sat_sales: sum(from x in g where x.day == "Saturday" select x.sales_price)
-  Move         r236, r209
-  Move         r237, r221
+  Move         r235, r208
+  Move         r236, r220
   // select {
-  MakeMap      r238, 8, r222
+  MakeMap      r237, 8, r221
   // from w in wscs
-  Append       r239, r55, r238
-  Move         r55, r239
-  AddInt       r122, r122, r29
+  Append       r238, r55, r237
+  Move         r55, r238
+  AddInt       r121, r121, r29
   Jump         L32
 L10:
   // json(result)
   JSON         r0
   // expect len(result) == 0
-  Const        r240, true
-  Expect       r240
+  Const        r239, true
+  Expect       r239
   Return       r0

--- a/tests/dataset/tpc-ds/out/q3.ir.out
+++ b/tests/dataset/tpc-ds/out/q3.ir.out
@@ -1,4 +1,4 @@
-func main (regs=162)
+func main (regs=161)
   // let date_dim = []
   Const        r0, []
   // from dt in date_dim
@@ -20,231 +20,230 @@ func main (regs=162)
   Const        r12, "ss_ext_sales_price"
   // from dt in date_dim
   MakeMap      r13, 0, r0
-  Const        r15, []
-  Move         r14, r15
-  IterPrep     r16, r0
-  Len          r17, r16
-  Const        r18, 0
+  Move         r14, r0
+  IterPrep     r15, r0
+  Len          r16, r15
+  Const        r17, 0
 L8:
-  LessInt      r19, r18, r17
-  JumpIfFalse  r19, L0
-  Index        r20, r16, r18
-  Move         r21, r20
+  LessInt      r18, r17, r16
+  JumpIfFalse  r18, L0
+  Index        r19, r15, r17
+  Move         r20, r19
   // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
-  IterPrep     r22, r0
-  Len          r23, r22
-  Const        r24, 0
+  IterPrep     r21, r0
+  Len          r22, r21
+  Const        r23, 0
 L7:
-  LessInt      r25, r24, r23
-  JumpIfFalse  r25, L1
-  Index        r26, r22, r24
-  Move         r27, r26
-  Const        r28, "d_date_sk"
-  Index        r29, r21, r28
-  Const        r30, "ss_sold_date_sk"
-  Index        r31, r27, r30
-  Equal        r32, r29, r31
-  JumpIfFalse  r32, L2
+  LessInt      r24, r23, r22
+  JumpIfFalse  r24, L1
+  Index        r25, r21, r23
+  Move         r26, r25
+  Const        r27, "d_date_sk"
+  Index        r28, r20, r27
+  Const        r29, "ss_sold_date_sk"
+  Index        r30, r26, r29
+  Equal        r31, r28, r30
+  JumpIfFalse  r31, L2
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r33, r0
-  Len          r34, r33
-  Const        r35, 0
+  IterPrep     r32, r0
+  Len          r33, r32
+  Const        r34, 0
 L6:
-  LessInt      r36, r35, r34
-  JumpIfFalse  r36, L2
-  Index        r37, r33, r35
-  Move         r38, r37
-  Const        r39, "ss_item_sk"
-  Index        r40, r27, r39
-  Const        r41, "i_item_sk"
-  Index        r42, r38, r41
-  Equal        r43, r40, r42
-  JumpIfFalse  r43, L3
+  LessInt      r35, r34, r33
+  JumpIfFalse  r35, L2
+  Index        r36, r32, r34
+  Move         r37, r36
+  Const        r38, "ss_item_sk"
+  Index        r39, r26, r38
+  Const        r40, "i_item_sk"
+  Index        r41, r37, r40
+  Equal        r42, r39, r41
+  JumpIfFalse  r42, L3
   // where i.i_manufact_id == 100 && dt.d_moy == 12
-  Index        r44, r38, r7
-  Const        r45, 100
-  Equal        r46, r44, r45
-  Index        r47, r21, r8
-  Const        r48, 12
-  Equal        r49, r47, r48
-  Move         r50, r46
-  JumpIfFalse  r50, L4
-  Move         r50, r49
+  Index        r43, r37, r7
+  Const        r44, 100
+  Equal        r45, r43, r44
+  Index        r46, r20, r8
+  Const        r47, 12
+  Equal        r48, r46, r47
+  Move         r49, r45
+  JumpIfFalse  r49, L4
+  Move         r49, r48
 L4:
-  JumpIfFalse  r50, L3
+  JumpIfFalse  r49, L3
   // from dt in date_dim
-  Const        r51, "dt"
-  Move         r52, r21
-  Move         r53, r27
-  Const        r54, "i"
-  Move         r55, r38
+  Const        r50, "dt"
+  Move         r51, r20
+  Move         r52, r26
+  Const        r53, "i"
+  Move         r54, r37
+  Move         r55, r50
   Move         r56, r51
-  Move         r57, r52
-  Move         r58, r11
+  Move         r57, r11
+  Move         r58, r52
   Move         r59, r53
   Move         r60, r54
-  Move         r61, r55
-  MakeMap      r62, 3, r56
+  MakeMap      r61, 3, r55
   // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Const        r63, "d_year"
-  Index        r64, r21, r2
-  Const        r65, "brand_id"
-  Index        r66, r38, r4
-  Const        r67, "brand"
-  Index        r68, r38, r6
+  Const        r62, "d_year"
+  Index        r63, r20, r2
+  Const        r64, "brand_id"
+  Index        r65, r37, r4
+  Const        r66, "brand"
+  Index        r67, r37, r6
+  Move         r68, r62
   Move         r69, r63
   Move         r70, r64
   Move         r71, r65
   Move         r72, r66
   Move         r73, r67
-  Move         r74, r68
-  MakeMap      r75, 3, r69
-  Str          r76, r75
-  In           r77, r76, r13
-  JumpIfTrue   r77, L5
+  MakeMap      r74, 3, r68
+  Str          r75, r74
+  In           r76, r75, r13
+  JumpIfTrue   r76, L5
   // from dt in date_dim
-  Const        r78, "__group__"
-  Const        r79, true
+  Const        r77, "__group__"
+  Const        r78, true
   // group by { d_year: dt.d_year, brand_id: i.i_brand_id, brand: i.i_brand } into g
-  Move         r80, r75
+  Move         r79, r74
   // from dt in date_dim
-  Const        r81, "items"
-  Move         r82, r0
-  Const        r83, "count"
-  Const        r84, 0
+  Const        r80, "items"
+  Move         r81, r0
+  Const        r82, "count"
+  Const        r83, 0
+  Move         r84, r77
   Move         r85, r78
-  Move         r86, r79
-  Move         r87, r9
+  Move         r86, r9
+  Move         r87, r79
   Move         r88, r80
   Move         r89, r81
   Move         r90, r82
   Move         r91, r83
-  Move         r92, r84
-  MakeMap      r93, 4, r85
-  SetIndex     r13, r76, r93
-  Append       r94, r14, r93
-  Move         r14, r94
+  MakeMap      r92, 4, r84
+  SetIndex     r13, r75, r92
+  Append       r93, r14, r92
+  Move         r14, r93
 L5:
-  Index        r95, r13, r76
-  Index        r96, r95, r81
-  Append       r97, r96, r62
-  SetIndex     r95, r81, r97
-  Index        r98, r95, r83
-  Const        r99, 1
-  AddInt       r100, r98, r99
-  SetIndex     r95, r83, r100
+  Index        r94, r13, r75
+  Index        r95, r94, r80
+  Append       r96, r95, r61
+  SetIndex     r94, r80, r96
+  Index        r97, r94, r82
+  Const        r98, 1
+  AddInt       r99, r97, r98
+  SetIndex     r94, r82, r99
 L3:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r35, r35, r99
+  AddInt       r34, r34, r98
   Jump         L6
 L2:
   // join ss in store_sales on dt.d_date_sk == ss.ss_sold_date_sk
-  AddInt       r24, r24, r99
+  AddInt       r23, r23, r98
   Jump         L7
 L1:
   // from dt in date_dim
-  AddInt       r18, r18, r99
+  AddInt       r17, r17, r98
   Jump         L8
 L0:
-  Move         r101, r84
-  Len          r102, r14
+  Move         r100, r83
+  Len          r101, r14
 L14:
-  LessInt      r103, r101, r102
-  JumpIfFalse  r103, L9
-  Index        r104, r14, r101
-  Move         r105, r104
+  LessInt      r102, r100, r101
+  JumpIfFalse  r102, L9
+  Index        r103, r14, r100
+  Move         r104, r103
   // d_year: g.key.d_year,
-  Const        r106, "d_year"
-  Index        r107, r105, r9
-  Index        r108, r107, r2
+  Const        r105, "d_year"
+  Index        r106, r104, r9
+  Index        r107, r106, r2
   // brand_id: g.key.brand_id,
-  Const        r109, "brand_id"
-  Index        r110, r105, r9
-  Index        r111, r110, r3
+  Const        r108, "brand_id"
+  Index        r109, r104, r9
+  Index        r110, r109, r3
   // brand: g.key.brand,
-  Const        r112, "brand"
-  Index        r113, r105, r9
-  Index        r114, r113, r5
+  Const        r111, "brand"
+  Index        r112, r104, r9
+  Index        r113, r112, r5
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Const        r115, "sum_agg"
-  Const        r116, []
-  IterPrep     r117, r105
-  Len          r118, r117
-  Move         r119, r84
+  Const        r114, "sum_agg"
+  Const        r115, []
+  IterPrep     r116, r104
+  Len          r117, r116
+  Move         r118, r83
 L11:
-  LessInt      r120, r119, r118
-  JumpIfFalse  r120, L10
-  Index        r121, r117, r119
-  Move         r122, r121
-  Index        r123, r122, r11
-  Index        r124, r123, r12
-  Append       r125, r116, r124
-  Move         r116, r125
-  AddInt       r119, r119, r99
+  LessInt      r119, r118, r117
+  JumpIfFalse  r119, L10
+  Index        r120, r116, r118
+  Move         r121, r120
+  Index        r122, r121, r11
+  Index        r123, r122, r12
+  Append       r124, r115, r123
+  Move         r115, r124
+  AddInt       r118, r118, r98
   Jump         L11
 L10:
-  Sum          r126, r116
+  Sum          r125, r115
   // d_year: g.key.d_year,
-  Move         r127, r106
-  Move         r128, r108
+  Move         r126, r105
+  Move         r127, r107
   // brand_id: g.key.brand_id,
-  Move         r129, r109
-  Move         r130, r111
+  Move         r128, r108
+  Move         r129, r110
   // brand: g.key.brand,
-  Move         r131, r112
-  Move         r132, r114
+  Move         r130, r111
+  Move         r131, r113
   // sum_agg: sum(from x in g select x.ss.ss_ext_sales_price)
-  Move         r133, r115
-  Move         r134, r126
+  Move         r132, r114
+  Move         r133, r125
   // select {
-  MakeMap      r135, 4, r127
+  MakeMap      r134, 4, r126
   // sort by [g.key.d_year,
-  Index        r136, r105, r9
-  Index        r137, r136, r2
-  Move         r138, r137
+  Index        r135, r104, r9
+  Index        r136, r135, r2
+  Move         r137, r136
   // -sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r139, []
-  IterPrep     r140, r105
-  Len          r141, r140
-  Move         r142, r84
+  Const        r138, []
+  IterPrep     r139, r104
+  Len          r140, r139
+  Move         r141, r83
 L13:
-  LessInt      r143, r142, r141
-  JumpIfFalse  r143, L12
-  Index        r144, r140, r142
-  Move         r122, r144
-  Index        r145, r122, r11
-  Index        r146, r145, r12
-  Append       r147, r139, r146
-  Move         r139, r147
-  AddInt       r142, r142, r99
+  LessInt      r142, r141, r140
+  JumpIfFalse  r142, L12
+  Index        r143, r139, r141
+  Move         r121, r143
+  Index        r144, r121, r11
+  Index        r145, r144, r12
+  Append       r146, r138, r145
+  Move         r138, r146
+  AddInt       r141, r141, r98
   Jump         L13
 L12:
-  Sum          r148, r139
-  Neg          r149, r148
-  Move         r150, r149
+  Sum          r147, r138
+  Neg          r148, r147
+  Move         r149, r148
   // g.key.brand_id]
-  Index        r151, r105, r9
-  Index        r152, r151, r3
-  Move         r153, r152
+  Index        r150, r104, r9
+  Index        r151, r150, r3
+  Move         r152, r151
   // sort by [g.key.d_year,
-  MakeList     r154, 3, r138
-  Move         r155, r154
+  MakeList     r153, 3, r137
+  Move         r154, r153
   // from dt in date_dim
-  Move         r156, r135
-  MakeList     r157, 2, r155
-  Append       r158, r1, r157
-  Move         r1, r158
-  AddInt       r101, r101, r99
+  Move         r155, r134
+  MakeList     r156, 2, r154
+  Append       r157, r1, r156
+  Move         r1, r157
+  AddInt       r100, r100, r98
   Jump         L14
 L9:
   // sort by [g.key.d_year,
-  Sort         r159, r1
+  Sort         r158, r1
   // from dt in date_dim
-  Move         r1, r159
+  Move         r1, r158
   // json(result)
   JSON         r1
   // expect len(result) == 0
-  Len          r160, r1
-  EqualInt     r161, r160, r84
-  Expect       r161
+  Len          r159, r1
+  EqualInt     r160, r159, r83
+  Expect       r160
   Return       r0

--- a/tests/dataset/tpc-ds/out/q4.ir.out
+++ b/tests/dataset/tpc-ds/out/q4.ir.out
@@ -1,4 +1,4 @@
-func main (regs=607)
+func main (regs=589)
   // let customer = []
   Const        r0, []
   // from c in customer
@@ -35,71 +35,71 @@ func main (regs=607)
   Const        r23, "sale_type"
   // from c in customer
   MakeMap      r24, 0, r0
-  Const        r26, []
-  Move         r25, r26
-  IterPrep     r27, r0
-  Len          r28, r27
-  Const        r29, 0
+  Move         r25, r0
+  IterPrep     r26, r0
+  Len          r27, r26
+  Const        r28, 0
 L7:
-  LessInt      r30, r29, r28
-  JumpIfFalse  r30, L0
-  Index        r31, r27, r29
-  Move         r32, r31
+  LessInt      r29, r28, r27
+  JumpIfFalse  r29, L0
+  Index        r30, r26, r28
+  Move         r31, r30
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  IterPrep     r33, r0
-  Len          r34, r33
-  Const        r35, 0
+  IterPrep     r32, r0
+  Len          r33, r32
+  Const        r34, 0
 L6:
-  LessInt      r36, r35, r34
-  JumpIfFalse  r36, L1
-  Index        r37, r33, r35
-  Move         r38, r37
-  Const        r39, "c_customer_sk"
-  Index        r40, r32, r39
-  Const        r41, "ss_customer_sk"
-  Index        r42, r38, r41
-  Equal        r43, r40, r42
-  JumpIfFalse  r43, L2
+  LessInt      r35, r34, r33
+  JumpIfFalse  r35, L1
+  Index        r36, r32, r34
+  Move         r37, r36
+  Const        r38, "c_customer_sk"
+  Index        r39, r31, r38
+  Const        r40, "ss_customer_sk"
+  Index        r41, r37, r40
+  Equal        r42, r39, r41
+  JumpIfFalse  r42, L2
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r44, r0
-  Len          r45, r44
-  Const        r46, 0
+  IterPrep     r43, r0
+  Len          r44, r43
+  Const        r45, 0
 L5:
-  LessInt      r47, r46, r45
-  JumpIfFalse  r47, L2
-  Index        r48, r44, r46
-  Move         r49, r48
-  Const        r50, "ss_sold_date_sk"
-  Index        r51, r38, r50
-  Const        r52, "d_date_sk"
-  Index        r53, r49, r52
-  Equal        r54, r51, r53
-  JumpIfFalse  r54, L3
+  LessInt      r46, r45, r44
+  JumpIfFalse  r46, L2
+  Index        r47, r43, r45
+  Move         r48, r47
+  Const        r49, "ss_sold_date_sk"
+  Index        r50, r37, r49
+  Const        r51, "d_date_sk"
+  Index        r52, r48, r51
+  Equal        r53, r50, r52
+  JumpIfFalse  r53, L3
   // from c in customer
-  Const        r55, "c"
-  Move         r56, r32
-  Const        r57, "s"
-  Move         r58, r38
-  Const        r59, "d"
-  Move         r60, r49
+  Const        r54, "c"
+  Move         r55, r31
+  Const        r56, "s"
+  Move         r57, r37
+  Const        r58, "d"
+  Move         r59, r48
+  Move         r60, r54
   Move         r61, r55
   Move         r62, r56
   Move         r63, r57
   Move         r64, r58
   Move         r65, r59
-  Move         r66, r60
-  MakeMap      r67, 3, r61
+  MakeMap      r66, 3, r60
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r68, "id"
-  Index        r69, r32, r3
-  Const        r70, "first"
-  Index        r71, r32, r5
-  Const        r72, "last"
-  Index        r73, r32, r7
-  Const        r74, "login"
-  Index        r75, r32, r9
-  Const        r76, "year"
-  Index        r77, r49, r11
+  Const        r67, "id"
+  Index        r68, r31, r3
+  Const        r69, "first"
+  Index        r70, r31, r5
+  Const        r71, "last"
+  Index        r72, r31, r7
+  Const        r73, "login"
+  Index        r74, r31, r9
+  Const        r75, "year"
+  Index        r76, r48, r11
+  Move         r77, r67
   Move         r78, r68
   Move         r79, r69
   Move         r80, r70
@@ -109,209 +109,209 @@ L5:
   Move         r84, r74
   Move         r85, r75
   Move         r86, r76
-  Move         r87, r77
-  MakeMap      r88, 5, r78
-  Str          r89, r88
-  In           r90, r89, r24
-  JumpIfTrue   r90, L4
+  MakeMap      r87, 5, r77
+  Str          r88, r87
+  In           r89, r88, r24
+  JumpIfTrue   r89, L4
   // from c in customer
-  Const        r91, "__group__"
-  Const        r92, true
+  Const        r90, "__group__"
+  Const        r91, true
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Move         r93, r88
+  Move         r92, r87
   // from c in customer
-  Const        r94, "items"
-  Move         r95, r0
-  Const        r96, "count"
-  Const        r97, 0
+  Const        r93, "items"
+  Move         r94, r0
+  Const        r95, "count"
+  Const        r96, 0
+  Move         r97, r90
   Move         r98, r91
-  Move         r99, r92
-  Move         r100, r13
+  Move         r99, r13
+  Move         r100, r92
   Move         r101, r93
   Move         r102, r94
   Move         r103, r95
   Move         r104, r96
-  Move         r105, r97
-  MakeMap      r106, 4, r98
-  SetIndex     r24, r89, r106
-  Append       r107, r25, r106
-  Move         r25, r107
+  MakeMap      r105, 4, r97
+  SetIndex     r24, r88, r105
+  Append       r106, r25, r105
+  Move         r25, r106
 L4:
-  Index        r108, r24, r89
-  Index        r109, r108, r94
-  Append       r110, r109, r67
-  SetIndex     r108, r94, r110
-  Index        r111, r108, r96
-  Const        r112, 1
-  AddInt       r113, r111, r112
-  SetIndex     r108, r96, r113
+  Index        r107, r24, r88
+  Index        r108, r107, r93
+  Append       r109, r108, r66
+  SetIndex     r107, r93, r109
+  Index        r110, r107, r95
+  Const        r111, 1
+  AddInt       r112, r110, r111
+  SetIndex     r107, r95, r112
 L3:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  AddInt       r46, r46, r112
+  AddInt       r45, r45, r111
   Jump         L5
 L2:
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  AddInt       r35, r35, r112
+  AddInt       r34, r34, r111
   Jump         L6
 L1:
   // from c in customer
-  AddInt       r29, r29, r112
+  AddInt       r28, r28, r111
   Jump         L7
 L0:
-  Move         r114, r97
-  Len          r115, r25
+  Move         r113, r96
+  Len          r114, r25
 L11:
-  LessInt      r116, r114, r115
-  JumpIfFalse  r116, L8
-  Index        r117, r25, r114
-  Move         r118, r117
+  LessInt      r115, r113, r114
+  JumpIfFalse  r115, L8
+  Index        r116, r25, r113
+  Move         r117, r116
   // customer_id: g.key.id,
-  Const        r119, "customer_id"
-  Index        r120, r118, r13
-  Index        r121, r120, r2
+  Const        r118, "customer_id"
+  Index        r119, r117, r13
+  Index        r120, r119, r2
   // customer_first_name: g.key.first,
-  Const        r122, "customer_first_name"
-  Index        r123, r118, r13
-  Index        r124, r123, r4
+  Const        r121, "customer_first_name"
+  Index        r122, r117, r13
+  Index        r123, r122, r4
   // customer_last_name: g.key.last,
-  Const        r125, "customer_last_name"
-  Index        r126, r118, r13
-  Index        r127, r126, r6
+  Const        r124, "customer_last_name"
+  Index        r125, r117, r13
+  Index        r126, r125, r6
   // customer_login: g.key.login,
-  Const        r128, "customer_login"
-  Index        r129, r118, r13
-  Index        r130, r129, r8
+  Const        r127, "customer_login"
+  Index        r128, r117, r13
+  Index        r129, r128, r8
   // dyear: g.key.year,
-  Const        r131, "dyear"
-  Index        r132, r118, r13
-  Index        r133, r132, r10
+  Const        r130, "dyear"
+  Index        r131, r117, r13
+  Index        r132, r131, r10
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Const        r134, "year_total"
-  Const        r135, []
-  IterPrep     r136, r118
-  Len          r137, r136
-  Move         r138, r97
+  Const        r133, "year_total"
+  Const        r134, []
+  IterPrep     r135, r117
+  Len          r136, r135
+  Move         r137, r96
 L10:
-  LessInt      r139, r138, r137
-  JumpIfFalse  r139, L9
-  Index        r140, r136, r138
-  Move         r141, r140
-  Index        r142, r141, r19
-  Index        r143, r141, r20
-  Sub          r144, r142, r143
-  Index        r145, r141, r21
-  Sub          r146, r144, r145
-  Index        r147, r141, r22
-  Add          r148, r146, r147
-  Const        r149, 2
-  Div          r150, r148, r149
-  Append       r151, r135, r150
-  Move         r135, r151
-  AddInt       r138, r138, r112
+  LessInt      r138, r137, r136
+  JumpIfFalse  r138, L9
+  Index        r139, r135, r137
+  Move         r140, r139
+  Index        r141, r140, r19
+  Index        r142, r140, r20
+  Sub          r143, r141, r142
+  Index        r144, r140, r21
+  Sub          r145, r143, r144
+  Index        r146, r140, r22
+  Add          r147, r145, r146
+  Const        r148, 2
+  Div          r149, r147, r148
+  Append       r150, r134, r149
+  Move         r134, r150
+  AddInt       r137, r137, r111
   Jump         L10
 L9:
-  Sum          r152, r135
+  Sum          r151, r134
   // sale_type: "s",
-  Const        r153, "sale_type"
+  Const        r152, "sale_type"
   // customer_id: g.key.id,
-  Move         r154, r119
-  Move         r155, r121
+  Move         r153, r118
+  Move         r154, r120
   // customer_first_name: g.key.first,
-  Move         r156, r122
-  Move         r157, r124
+  Move         r155, r121
+  Move         r156, r123
   // customer_last_name: g.key.last,
-  Move         r158, r125
-  Move         r159, r127
+  Move         r157, r124
+  Move         r158, r126
   // customer_login: g.key.login,
-  Move         r160, r128
-  Move         r161, r130
+  Move         r159, r127
+  Move         r160, r129
   // dyear: g.key.year,
-  Move         r162, r131
-  Move         r163, r133
+  Move         r161, r130
+  Move         r162, r132
   // year_total: sum(from x in g select ((x.ss_ext_list_price - x.ss_ext_wholesale_cost - x.ss_ext_discount_amt) + x.ss_ext_sales_price) / 2),
-  Move         r164, r134
-  Move         r165, r152
+  Move         r163, r133
+  Move         r164, r151
   // sale_type: "s",
-  Move         r166, r153
-  Move         r167, r57
+  Move         r165, r152
+  Move         r166, r56
   // select {
-  MakeMap      r168, 7, r154
+  MakeMap      r167, 7, r153
   // from c in customer
-  Append       r169, r1, r168
-  Move         r1, r169
-  AddInt       r114, r114, r112
+  Append       r168, r1, r167
+  Move         r1, r168
+  AddInt       r113, r113, r111
   Jump         L11
 L8:
   // from c in customer
-  Const        r170, []
+  Const        r169, []
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Const        r171, "cs_ext_list_price"
-  Const        r172, "cs_ext_wholesale_cost"
-  Const        r173, "cs_ext_discount_amt"
-  Const        r174, "cs_ext_sales_price"
+  Const        r170, "cs_ext_list_price"
+  Const        r171, "cs_ext_wholesale_cost"
+  Const        r172, "cs_ext_discount_amt"
+  Const        r173, "cs_ext_sales_price"
   // from c in customer
-  MakeMap      r175, 0, r0
-  Const        r177, []
-  Move         r176, r177
-  IterPrep     r178, r0
-  Len          r179, r178
-  Const        r180, 0
+  MakeMap      r174, 0, r0
+  Move         r175, r0
+  IterPrep     r176, r0
+  Len          r177, r176
+  Const        r178, 0
 L19:
-  LessInt      r181, r180, r179
-  JumpIfFalse  r181, L12
-  Index        r182, r178, r180
-  Move         r32, r182
+  LessInt      r179, r178, r177
+  JumpIfFalse  r179, L12
+  Index        r180, r176, r178
+  Move         r31, r180
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  IterPrep     r183, r0
-  Len          r184, r183
-  Const        r185, 0
+  IterPrep     r181, r0
+  Len          r182, r181
+  Const        r183, 0
 L18:
-  LessInt      r186, r185, r184
-  JumpIfFalse  r186, L13
-  Index        r187, r183, r185
-  Move         r188, r187
-  Index        r189, r32, r39
-  Const        r190, "cs_bill_customer_sk"
-  Index        r191, r188, r190
-  Equal        r192, r189, r191
-  JumpIfFalse  r192, L14
+  LessInt      r184, r183, r182
+  JumpIfFalse  r184, L13
+  Index        r185, r181, r183
+  Move         r186, r185
+  Index        r187, r31, r38
+  Const        r188, "cs_bill_customer_sk"
+  Index        r189, r186, r188
+  Equal        r190, r187, r189
+  JumpIfFalse  r190, L14
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r193, r0
-  Len          r194, r193
-  Const        r195, 0
+  IterPrep     r191, r0
+  Len          r192, r191
+  Const        r193, 0
 L17:
-  LessInt      r196, r195, r194
-  JumpIfFalse  r196, L14
-  Index        r197, r193, r195
-  Move         r198, r197
-  Const        r199, "cs_sold_date_sk"
-  Index        r200, r188, r199
-  Index        r201, r198, r52
-  Equal        r202, r200, r201
-  JumpIfFalse  r202, L15
+  LessInt      r194, r193, r192
+  JumpIfFalse  r194, L14
+  Index        r195, r191, r193
+  Move         r196, r195
+  Const        r197, "cs_sold_date_sk"
+  Index        r198, r186, r197
+  Index        r199, r196, r51
+  Equal        r200, r198, r199
+  JumpIfFalse  r200, L15
   // from c in customer
-  Move         r203, r32
-  Const        r204, "cs"
-  Move         r205, r188
-  Move         r206, r198
-  Move         r207, r55
+  Move         r201, r31
+  Const        r202, "cs"
+  Move         r203, r186
+  Move         r204, r196
+  Move         r205, r54
+  Move         r206, r201
+  Move         r207, r202
   Move         r208, r203
-  Move         r209, r204
-  Move         r210, r205
-  Move         r211, r59
-  Move         r212, r206
-  MakeMap      r213, 3, r207
+  Move         r209, r58
+  Move         r210, r204
+  MakeMap      r211, 3, r205
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r214, "id"
-  Index        r215, r32, r3
-  Const        r216, "first"
-  Index        r217, r32, r5
-  Const        r218, "last"
-  Index        r219, r32, r7
-  Const        r220, "login"
-  Index        r221, r32, r9
-  Const        r222, "year"
-  Index        r223, r198, r11
+  Const        r212, "id"
+  Index        r213, r31, r3
+  Const        r214, "first"
+  Index        r215, r31, r5
+  Const        r216, "last"
+  Index        r217, r31, r7
+  Const        r218, "login"
+  Index        r219, r31, r9
+  Const        r220, "year"
+  Index        r221, r196, r11
+  Move         r222, r212
+  Move         r223, r213
   Move         r224, r214
   Move         r225, r215
   Move         r226, r216
@@ -320,203 +320,203 @@ L17:
   Move         r229, r219
   Move         r230, r220
   Move         r231, r221
-  Move         r232, r222
-  Move         r233, r223
-  MakeMap      r234, 5, r224
-  Str          r235, r234
-  In           r236, r235, r175
-  JumpIfTrue   r236, L16
-  Move         r237, r234
+  MakeMap      r232, 5, r222
+  Str          r233, r232
+  In           r234, r233, r174
+  JumpIfTrue   r234, L16
+  Move         r235, r232
   // from c in customer
-  Move         r238, r0
-  Move         r239, r91
-  Move         r240, r92
-  Move         r241, r13
-  Move         r242, r237
-  Move         r243, r94
-  Move         r244, r238
-  Move         r245, r96
-  Move         r246, r97
-  MakeMap      r247, 4, r239
-  SetIndex     r175, r235, r247
-  Append       r248, r176, r247
-  Move         r176, r248
+  Move         r236, r0
+  Move         r237, r90
+  Move         r238, r91
+  Move         r239, r13
+  Move         r240, r235
+  Move         r241, r93
+  Move         r242, r236
+  Move         r243, r95
+  Move         r244, r96
+  MakeMap      r245, 4, r237
+  SetIndex     r174, r233, r245
+  Append       r246, r175, r245
+  Move         r175, r246
 L16:
-  Index        r249, r175, r235
-  Index        r250, r249, r94
-  Append       r251, r250, r213
-  SetIndex     r249, r94, r251
-  Index        r252, r249, r96
-  AddInt       r253, r252, r112
-  SetIndex     r249, r96, r253
+  Index        r247, r174, r233
+  Index        r248, r247, r93
+  Append       r249, r248, r211
+  SetIndex     r247, r93, r249
+  Index        r250, r247, r95
+  AddInt       r251, r250, r111
+  SetIndex     r247, r95, r251
 L15:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r195, r195, r112
+  AddInt       r193, r193, r111
   Jump         L17
 L14:
   // join cs in catalog_sales on c.c_customer_sk == cs.cs_bill_customer_sk
-  AddInt       r185, r185, r112
+  AddInt       r183, r183, r111
   Jump         L18
 L13:
   // from c in customer
-  AddInt       r180, r180, r112
+  AddInt       r178, r178, r111
   Jump         L19
 L12:
-  Move         r254, r97
-  Len          r255, r176
+  Move         r252, r96
+  Len          r253, r175
 L23:
-  LessInt      r256, r254, r255
-  JumpIfFalse  r256, L20
-  Index        r257, r176, r254
-  Move         r118, r257
+  LessInt      r254, r252, r253
+  JumpIfFalse  r254, L20
+  Index        r255, r175, r252
+  Move         r117, r255
   // customer_id: g.key.id,
-  Const        r258, "customer_id"
-  Index        r259, r118, r13
-  Index        r260, r259, r2
+  Const        r256, "customer_id"
+  Index        r257, r117, r13
+  Index        r258, r257, r2
   // customer_first_name: g.key.first,
-  Const        r261, "customer_first_name"
-  Index        r262, r118, r13
-  Index        r263, r262, r4
+  Const        r259, "customer_first_name"
+  Index        r260, r117, r13
+  Index        r261, r260, r4
   // customer_last_name: g.key.last,
-  Const        r264, "customer_last_name"
-  Index        r265, r118, r13
-  Index        r266, r265, r6
+  Const        r262, "customer_last_name"
+  Index        r263, r117, r13
+  Index        r264, r263, r6
   // customer_login: g.key.login,
-  Const        r267, "customer_login"
-  Index        r268, r118, r13
-  Index        r269, r268, r8
+  Const        r265, "customer_login"
+  Index        r266, r117, r13
+  Index        r267, r266, r8
   // dyear: g.key.year,
-  Const        r270, "dyear"
-  Index        r271, r118, r13
-  Index        r272, r271, r10
+  Const        r268, "dyear"
+  Index        r269, r117, r13
+  Index        r270, r269, r10
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Const        r273, "year_total"
-  Const        r274, []
-  IterPrep     r275, r118
-  Len          r276, r275
-  Move         r277, r97
+  Const        r271, "year_total"
+  Const        r272, []
+  IterPrep     r273, r117
+  Len          r274, r273
+  Move         r275, r96
 L22:
-  LessInt      r278, r277, r276
-  JumpIfFalse  r278, L21
-  Index        r279, r275, r277
-  Move         r141, r279
-  Index        r280, r141, r171
-  Index        r281, r141, r172
+  LessInt      r276, r275, r274
+  JumpIfFalse  r276, L21
+  Index        r277, r273, r275
+  Move         r140, r277
+  Index        r278, r140, r170
+  Index        r279, r140, r171
+  Sub          r280, r278, r279
+  Index        r281, r140, r172
   Sub          r282, r280, r281
-  Index        r283, r141, r173
-  Sub          r284, r282, r283
-  Index        r285, r141, r174
-  Add          r286, r284, r285
-  Div          r287, r286, r149
-  Append       r288, r274, r287
-  Move         r274, r288
-  AddInt       r277, r277, r112
+  Index        r283, r140, r173
+  Add          r284, r282, r283
+  Div          r285, r284, r148
+  Append       r286, r272, r285
+  Move         r272, r286
+  AddInt       r275, r275, r111
   Jump         L22
 L21:
-  Sum          r289, r274
+  Sum          r287, r272
   // sale_type: "c",
-  Const        r290, "sale_type"
+  Const        r288, "sale_type"
   // customer_id: g.key.id,
-  Move         r291, r258
-  Move         r292, r260
+  Move         r289, r256
+  Move         r290, r258
   // customer_first_name: g.key.first,
-  Move         r293, r261
-  Move         r294, r263
+  Move         r291, r259
+  Move         r292, r261
   // customer_last_name: g.key.last,
-  Move         r295, r264
-  Move         r296, r266
+  Move         r293, r262
+  Move         r294, r264
   // customer_login: g.key.login,
-  Move         r297, r267
-  Move         r298, r269
+  Move         r295, r265
+  Move         r296, r267
   // dyear: g.key.year,
-  Move         r299, r270
-  Move         r300, r272
+  Move         r297, r268
+  Move         r298, r270
   // year_total: sum(from x in g select ((x.cs_ext_list_price - x.cs_ext_wholesale_cost - x.cs_ext_discount_amt) + x.cs_ext_sales_price) / 2),
-  Move         r301, r273
-  Move         r302, r289
+  Move         r299, r271
+  Move         r300, r287
   // sale_type: "c",
-  Move         r303, r290
-  Move         r304, r55
+  Move         r301, r288
+  Move         r302, r54
   // select {
-  MakeMap      r305, 7, r291
+  MakeMap      r303, 7, r289
   // from c in customer
-  Append       r306, r170, r305
-  Move         r170, r306
-  AddInt       r254, r254, r112
+  Append       r304, r169, r303
+  Move         r169, r304
+  AddInt       r252, r252, r111
   Jump         L23
 L20:
   // ) union all (
-  UnionAll     r307, r1, r170
+  UnionAll     r305, r1, r169
   // from c in customer
-  Const        r308, []
+  Const        r306, []
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Const        r309, "ws_ext_list_price"
-  Const        r310, "ws_ext_wholesale_cost"
-  Const        r311, "ws_ext_discount_amt"
-  Const        r312, "ws_ext_sales_price"
+  Const        r307, "ws_ext_list_price"
+  Const        r308, "ws_ext_wholesale_cost"
+  Const        r309, "ws_ext_discount_amt"
+  Const        r310, "ws_ext_sales_price"
   // from c in customer
-  MakeMap      r313, 0, r0
-  Const        r315, []
-  Move         r314, r315
-  IterPrep     r316, r0
-  Len          r317, r316
-  Const        r318, 0
+  MakeMap      r311, 0, r0
+  Move         r312, r0
+  IterPrep     r313, r0
+  Len          r314, r313
+  Const        r315, 0
 L31:
-  LessInt      r319, r318, r317
-  JumpIfFalse  r319, L24
-  Index        r320, r316, r318
-  Move         r32, r320
+  LessInt      r316, r315, r314
+  JumpIfFalse  r316, L24
+  Index        r317, r313, r315
+  Move         r31, r317
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  IterPrep     r321, r0
-  Len          r322, r321
-  Const        r323, 0
+  IterPrep     r318, r0
+  Len          r319, r318
+  Const        r320, 0
 L30:
-  LessInt      r324, r323, r322
-  JumpIfFalse  r324, L25
-  Index        r325, r321, r323
-  Move         r326, r325
-  Index        r327, r32, r39
-  Const        r328, "ws_bill_customer_sk"
-  Index        r329, r326, r328
-  Equal        r330, r327, r329
-  JumpIfFalse  r330, L26
+  LessInt      r321, r320, r319
+  JumpIfFalse  r321, L25
+  Index        r322, r318, r320
+  Move         r323, r322
+  Index        r324, r31, r38
+  Const        r325, "ws_bill_customer_sk"
+  Index        r326, r323, r325
+  Equal        r327, r324, r326
+  JumpIfFalse  r327, L26
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r331, r0
-  Len          r332, r331
-  Const        r333, 0
+  IterPrep     r328, r0
+  Len          r329, r328
+  Const        r330, 0
 L29:
-  LessInt      r334, r333, r332
-  JumpIfFalse  r334, L26
-  Index        r335, r331, r333
-  Move         r336, r335
-  Const        r337, "ws_sold_date_sk"
-  Index        r338, r326, r337
-  Index        r339, r336, r52
-  Equal        r340, r338, r339
-  JumpIfFalse  r340, L27
+  LessInt      r331, r330, r329
+  JumpIfFalse  r331, L26
+  Index        r332, r328, r330
+  Move         r333, r332
+  Const        r334, "ws_sold_date_sk"
+  Index        r335, r323, r334
+  Index        r336, r333, r51
+  Equal        r337, r335, r336
+  JumpIfFalse  r337, L27
   // from c in customer
-  Move         r341, r32
-  Const        r342, "ws"
-  Move         r343, r326
-  Move         r344, r336
-  Move         r345, r55
-  Move         r346, r341
-  Move         r347, r342
-  Move         r348, r343
-  Move         r349, r59
-  Move         r350, r344
-  MakeMap      r351, 3, r345
+  Move         r338, r31
+  Const        r339, "ws"
+  Move         r340, r323
+  Move         r341, r333
+  Move         r342, r54
+  Move         r343, r338
+  Move         r344, r339
+  Move         r345, r340
+  Move         r346, r58
+  Move         r347, r341
+  MakeMap      r348, 3, r342
   // group by {id: c.c_customer_id, first: c.c_first_name, last: c.c_last_name, login: c.c_login, year: d.d_year} into g
-  Const        r352, "id"
-  Index        r353, r32, r3
-  Const        r354, "first"
-  Index        r355, r32, r5
-  Const        r356, "last"
-  Index        r357, r32, r7
-  Const        r358, "login"
-  Index        r359, r32, r9
-  Const        r360, "year"
-  Index        r361, r336, r11
+  Const        r349, "id"
+  Index        r350, r31, r3
+  Const        r351, "first"
+  Index        r352, r31, r5
+  Const        r353, "last"
+  Index        r354, r31, r7
+  Const        r355, "login"
+  Index        r356, r31, r9
+  Const        r357, "year"
+  Index        r358, r333, r11
+  Move         r359, r349
+  Move         r360, r350
+  Move         r361, r351
   Move         r362, r352
   Move         r363, r353
   Move         r364, r354
@@ -524,430 +524,397 @@ L29:
   Move         r366, r356
   Move         r367, r357
   Move         r368, r358
-  Move         r369, r359
-  Move         r370, r360
-  Move         r371, r361
-  MakeMap      r372, 5, r362
-  Str          r373, r372
-  In           r374, r373, r313
-  JumpIfTrue   r374, L28
-  Move         r375, r372
+  MakeMap      r369, 5, r359
+  Str          r370, r369
+  In           r371, r370, r311
+  JumpIfTrue   r371, L28
+  Move         r372, r369
   // from c in customer
-  Move         r376, r0
-  Move         r377, r91
-  Move         r378, r92
-  Move         r379, r13
-  Move         r380, r375
-  Move         r381, r94
-  Move         r382, r376
-  Move         r383, r96
-  Move         r384, r97
-  MakeMap      r385, 4, r377
-  SetIndex     r313, r373, r385
-  Append       r386, r314, r385
-  Move         r314, r386
+  Move         r373, r0
+  Move         r374, r90
+  Move         r375, r91
+  Move         r376, r13
+  Move         r377, r372
+  Move         r378, r93
+  Move         r379, r373
+  Move         r380, r95
+  Move         r381, r96
+  MakeMap      r382, 4, r374
+  SetIndex     r311, r370, r382
+  Append       r383, r312, r382
+  Move         r312, r383
 L28:
-  Index        r387, r313, r373
-  Index        r388, r387, r94
-  Append       r389, r388, r351
-  SetIndex     r387, r94, r389
-  Index        r390, r387, r96
-  AddInt       r391, r390, r112
-  SetIndex     r387, r96, r391
+  Index        r384, r311, r370
+  Index        r385, r384, r93
+  Append       r386, r385, r348
+  SetIndex     r384, r93, r386
+  Index        r387, r384, r95
+  AddInt       r388, r387, r111
+  SetIndex     r384, r95, r388
 L27:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  AddInt       r333, r333, r112
+  AddInt       r330, r330, r111
   Jump         L29
 L26:
   // join ws in web_sales on c.c_customer_sk == ws.ws_bill_customer_sk
-  AddInt       r323, r323, r112
+  AddInt       r320, r320, r111
   Jump         L30
 L25:
   // from c in customer
-  AddInt       r318, r318, r112
+  AddInt       r315, r315, r111
   Jump         L31
 L24:
-  Move         r392, r97
-  Len          r393, r314
+  Move         r389, r96
+  Len          r390, r312
 L35:
-  LessInt      r394, r392, r393
-  JumpIfFalse  r394, L32
-  Index        r395, r314, r392
-  Move         r118, r395
+  LessInt      r391, r389, r390
+  JumpIfFalse  r391, L32
+  Index        r392, r312, r389
+  Move         r117, r392
   // customer_id: g.key.id,
-  Const        r396, "customer_id"
-  Index        r397, r118, r13
-  Index        r398, r397, r2
+  Const        r393, "customer_id"
+  Index        r394, r117, r13
+  Index        r395, r394, r2
   // customer_first_name: g.key.first,
-  Const        r399, "customer_first_name"
-  Index        r400, r118, r13
-  Index        r401, r400, r4
+  Const        r396, "customer_first_name"
+  Index        r397, r117, r13
+  Index        r398, r397, r4
   // customer_last_name: g.key.last,
-  Const        r402, "customer_last_name"
-  Index        r403, r118, r13
-  Index        r404, r403, r6
+  Const        r399, "customer_last_name"
+  Index        r400, r117, r13
+  Index        r401, r400, r6
   // customer_login: g.key.login,
-  Const        r405, "customer_login"
-  Index        r406, r118, r13
-  Index        r407, r406, r8
+  Const        r402, "customer_login"
+  Index        r403, r117, r13
+  Index        r404, r403, r8
   // dyear: g.key.year,
-  Const        r408, "dyear"
-  Index        r409, r118, r13
-  Index        r410, r409, r10
+  Const        r405, "dyear"
+  Index        r406, r117, r13
+  Index        r407, r406, r10
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Const        r411, "year_total"
-  Const        r412, []
-  IterPrep     r413, r118
-  Len          r414, r413
-  Move         r415, r97
+  Const        r408, "year_total"
+  Const        r409, []
+  IterPrep     r410, r117
+  Len          r411, r410
+  Move         r412, r96
 L34:
-  LessInt      r416, r415, r414
-  JumpIfFalse  r416, L33
-  Index        r417, r413, r415
-  Move         r141, r417
-  Index        r418, r141, r309
-  Index        r419, r141, r310
-  Sub          r420, r418, r419
-  Index        r421, r141, r311
-  Sub          r422, r420, r421
-  Index        r423, r141, r312
-  Add          r424, r422, r423
-  Div          r425, r424, r149
-  Append       r426, r412, r425
-  Move         r412, r426
-  AddInt       r415, r415, r112
+  LessInt      r413, r412, r411
+  JumpIfFalse  r413, L33
+  Index        r414, r410, r412
+  Move         r140, r414
+  Index        r415, r140, r307
+  Index        r416, r140, r308
+  Sub          r417, r415, r416
+  Index        r418, r140, r309
+  Sub          r419, r417, r418
+  Index        r420, r140, r310
+  Add          r421, r419, r420
+  Div          r422, r421, r148
+  Append       r423, r409, r422
+  Move         r409, r423
+  AddInt       r412, r412, r111
   Jump         L34
 L33:
-  Sum          r427, r412
+  Sum          r424, r409
   // sale_type: "w",
-  Const        r428, "sale_type"
-  Const        r429, "w"
+  Const        r425, "sale_type"
+  Const        r426, "w"
   // customer_id: g.key.id,
-  Move         r430, r396
-  Move         r431, r398
+  Move         r427, r393
+  Move         r428, r395
   // customer_first_name: g.key.first,
-  Move         r432, r399
-  Move         r433, r401
+  Move         r429, r396
+  Move         r430, r398
   // customer_last_name: g.key.last,
-  Move         r434, r402
-  Move         r435, r404
+  Move         r431, r399
+  Move         r432, r401
   // customer_login: g.key.login,
-  Move         r436, r405
-  Move         r437, r407
+  Move         r433, r402
+  Move         r434, r404
   // dyear: g.key.year,
-  Move         r438, r408
-  Move         r439, r410
+  Move         r435, r405
+  Move         r436, r407
   // year_total: sum(from x in g select ((x.ws_ext_list_price - x.ws_ext_wholesale_cost - x.ws_ext_discount_amt) + x.ws_ext_sales_price) / 2),
-  Move         r440, r411
-  Move         r441, r427
+  Move         r437, r408
+  Move         r438, r424
   // sale_type: "w",
-  Move         r442, r428
-  Move         r443, r429
+  Move         r439, r425
+  Move         r440, r426
   // select {
-  MakeMap      r444, 7, r430
+  MakeMap      r441, 7, r427
   // from c in customer
-  Append       r445, r308, r444
-  Move         r308, r445
-  AddInt       r392, r392, r112
+  Append       r442, r306, r441
+  Move         r306, r442
+  AddInt       r389, r389, r111
   Jump         L35
 L32:
   // ) union all (
-  UnionAll     r446, r307, r308
+  UnionAll     r443, r305, r306
   // from s1 in year_total
-  Const        r447, []
-  IterPrep     r448, r446
-  Len          r449, r448
-  Move         r450, r97
-L64:
-  LessInt      r451, r450, r449
-  JumpIfFalse  r451, L36
-  Index        r452, r448, r450
-  Move         r453, r452
-  // join s2 in year_total on s2.customer_id == s1.customer_id
-  IterPrep     r454, r446
-  Len          r455, r454
-  Move         r456, r97
-L63:
-  LessInt      r457, r456, r455
-  JumpIfFalse  r457, L37
-  Index        r458, r454, r456
-  Move         r459, r458
-  Index        r460, r459, r12
-  Index        r461, r453, r12
-  Equal        r462, r460, r461
-  JumpIfFalse  r462, L38
-  // join c1 in year_total on c1.customer_id == s1.customer_id
-  IterPrep     r463, r446
-  Len          r464, r463
-  Move         r465, r97
-L62:
-  LessInt      r466, r465, r464
-  JumpIfFalse  r466, L38
-  Index        r467, r463, r465
-  Move         r468, r467
-  Index        r469, r468, r12
-  Index        r470, r453, r12
-  Equal        r471, r469, r470
-  JumpIfFalse  r471, L39
-  // join c2 in year_total on c2.customer_id == s1.customer_id
-  IterPrep     r472, r446
-  Len          r473, r472
-  Move         r474, r97
-L61:
-  LessInt      r475, r474, r473
-  JumpIfFalse  r475, L39
-  Index        r476, r472, r474
-  Move         r477, r476
-  Index        r478, r477, r12
-  Index        r479, r453, r12
-  Equal        r480, r478, r479
-  JumpIfFalse  r480, L40
-  // join w1 in year_total on w1.customer_id == s1.customer_id
-  IterPrep     r481, r446
-  Len          r482, r481
-  Move         r483, r97
-L60:
-  LessInt      r484, r483, r482
-  JumpIfFalse  r484, L40
-  Index        r485, r481, r483
-  Move         r486, r485
-  Index        r487, r486, r12
-  Index        r488, r453, r12
-  Equal        r489, r487, r488
-  JumpIfFalse  r489, L41
-  // join w2 in year_total on w2.customer_id == s1.customer_id
-  IterPrep     r490, r446
-  Len          r491, r490
-  Move         r492, r97
-L59:
-  LessInt      r493, r492, r491
-  JumpIfFalse  r493, L41
-  Index        r494, r490, r492
-  Move         r495, r494
-  Index        r496, r495, r12
-  Index        r497, r453, r12
-  Equal        r498, r496, r497
-  JumpIfFalse  r498, L42
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Index        r499, r453, r23
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Index        r500, r453, r18
-  Less         r501, r97, r500
-  Index        r502, r468, r18
-  Less         r503, r97, r502
-  Index        r504, r486, r18
-  Less         r505, r97, r504
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Index        r506, r468, r18
-  Less         r507, r97, r506
-  Index        r508, r477, r18
-  Index        r509, r468, r18
-  Div          r510, r508, r509
-  Const        r511, nil
-  Select       512,507,510,511
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Index        r513, r453, r18
-  Less         r514, r97, r513
-  Index        r515, r459, r18
-  Index        r516, r453, r18
-  Div          r517, r515, r516
-  Select       518,514,517,511
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r519, r518, r512
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Index        r520, r468, r18
-  Less         r521, r97, r520
-  Index        r522, r477, r18
-  Index        r523, r468, r18
-  Div          r524, r522, r523
-  Select       525,521,524,511
-  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
-  Index        r526, r486, r18
-  Less         r527, r97, r526
-  Index        r528, r495, r18
-  Index        r529, r486, r18
-  Div          r530, r528, r529
-  Select       531,527,530,511
-  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
-  Less         r532, r531, r525
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Equal        r533, r499, r57
-  Index        r534, r468, r23
-  Equal        r535, r534, r55
-  Index        r536, r486, r23
-  Equal        r537, r536, r429
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Index        r538, r459, r23
-  Equal        r539, r538, r57
-  Index        r540, r477, r23
-  Equal        r541, r540, r55
-  Index        r542, r495, r23
-  Equal        r543, r542, r429
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Index        r544, r453, r17
-  Const        r545, 2001
-  Equal        r546, r544, r545
-  Index        r547, r459, r17
-  Const        r548, 2002
-  Equal        r549, r547, r548
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Index        r550, r468, r17
-  Equal        r551, r550, r545
-  Index        r552, r477, r17
-  Equal        r553, r552, r548
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Index        r554, r486, r17
-  Equal        r555, r554, r545
-  Index        r556, r495, r17
-  Equal        r557, r556, r548
-  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  Move         r558, r533
-  JumpIfFalse  r558, L43
-  Move         r558, r535
-L43:
-  Move         r559, r558
-  JumpIfFalse  r559, L44
-  Move         r559, r537
-L44:
-  Move         r560, r559
-  JumpIfFalse  r560, L45
-  Move         r560, r539
-L45:
-  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
-  Move         r561, r560
-  JumpIfFalse  r561, L46
-  Move         r561, r541
-L46:
-  Move         r562, r561
-  JumpIfFalse  r562, L47
-  Move         r562, r543
-L47:
-  Move         r563, r562
-  JumpIfFalse  r563, L48
-  Move         r563, r546
-L48:
-  // s1.dyear == 2001 && s2.dyear == 2002 &&
-  Move         r564, r563
-  JumpIfFalse  r564, L49
-  Move         r564, r549
+  Const        r444, []
+  IterPrep     r445, r443
+  Len          r446, r445
+  Move         r447, r96
 L49:
-  Move         r565, r564
-  JumpIfFalse  r565, L50
-  Move         r565, r551
-L50:
-  // c1.dyear == 2001 && c2.dyear == 2002 &&
-  Move         r566, r565
-  JumpIfFalse  r566, L51
-  Move         r566, r553
-L51:
-  Move         r567, r566
-  JumpIfFalse  r567, L52
-  Move         r567, r555
-L52:
-  // w1.dyear == 2001 && w2.dyear == 2002 &&
-  Move         r568, r567
-  JumpIfFalse  r568, L53
-  Move         r568, r557
-L53:
-  Move         r569, r568
-  JumpIfFalse  r569, L54
-  Move         r569, r501
-L54:
-  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
-  Move         r570, r569
-  JumpIfFalse  r570, L55
-  Move         r570, r503
-L55:
-  Move         r571, r570
-  JumpIfFalse  r571, L56
-  Move         r571, r505
-L56:
-  Move         r572, r571
-  JumpIfFalse  r572, L57
-  Move         r572, r519
-L57:
-  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
-  Move         r573, r572
-  JumpIfFalse  r573, L58
-  Move         r573, r532
-L58:
+  LessInt      r448, r447, r446
+  JumpIfFalse  r448, L36
+  Index        r449, r445, r447
+  Move         r450, r449
+  // join s2 in year_total on s2.customer_id == s1.customer_id
+  IterPrep     r451, r443
+  Len          r452, r451
+  Move         r453, r96
+L48:
+  LessInt      r454, r453, r452
+  JumpIfFalse  r454, L37
+  Index        r455, r451, r453
+  Move         r456, r455
+  Index        r457, r456, r12
+  Index        r458, r450, r12
+  Equal        r459, r457, r458
+  JumpIfFalse  r459, L38
+  // join c1 in year_total on c1.customer_id == s1.customer_id
+  IterPrep     r460, r443
+  Len          r461, r460
+  Move         r462, r96
+L47:
+  LessInt      r463, r462, r461
+  JumpIfFalse  r463, L38
+  Index        r464, r460, r462
+  Move         r465, r464
+  Index        r466, r465, r12
+  Index        r467, r450, r12
+  Equal        r468, r466, r467
+  JumpIfFalse  r468, L39
+  // join c2 in year_total on c2.customer_id == s1.customer_id
+  IterPrep     r469, r443
+  Len          r470, r469
+  Move         r471, r96
+L46:
+  LessInt      r472, r471, r470
+  JumpIfFalse  r472, L39
+  Index        r473, r469, r471
+  Move         r474, r473
+  Index        r475, r474, r12
+  Index        r476, r450, r12
+  Equal        r477, r475, r476
+  JumpIfFalse  r477, L40
+  // join w1 in year_total on w1.customer_id == s1.customer_id
+  IterPrep     r478, r443
+  Len          r479, r478
+  Move         r480, r96
+L45:
+  LessInt      r481, r480, r479
+  JumpIfFalse  r481, L40
+  Index        r482, r478, r480
+  Move         r483, r482
+  Index        r484, r483, r12
+  Index        r485, r450, r12
+  Equal        r486, r484, r485
+  JumpIfFalse  r486, L41
+  // join w2 in year_total on w2.customer_id == s1.customer_id
+  IterPrep     r487, r443
+  Len          r488, r487
+  Move         r489, r96
+L44:
+  LessInt      r490, r489, r488
+  JumpIfFalse  r490, L41
+  Index        r491, r487, r489
+  Move         r492, r491
+  Index        r493, r492, r12
+  Index        r494, r450, r12
+  Equal        r495, r493, r494
+  JumpIfFalse  r495, L42
   // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
-  JumpIfFalse  r573, L42
+  Index        r496, r450, r23
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  Index        r497, r450, r18
+  Less         r498, r96, r497
+  Index        r499, r465, r18
+  Less         r500, r96, r499
+  Index        r501, r483, r18
+  Less         r502, r96, r501
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Index        r503, r465, r18
+  Less         r504, r96, r503
+  Index        r505, r474, r18
+  Index        r506, r465, r18
+  Div          r507, r505, r506
+  Const        r508, nil
+  Select       509,504,507,508
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  Index        r510, r450, r18
+  Less         r511, r96, r510
+  Index        r512, r456, r18
+  Index        r513, r450, r18
+  Div          r514, r512, r513
+  Select       515,511,514,508
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Less         r516, r515, r509
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Index        r517, r465, r18
+  Less         r518, r96, r517
+  Index        r519, r474, r18
+  Index        r520, r465, r18
+  Div          r521, r519, r520
+  Select       522,518,521,508
+  // (if w1.year_total > 0 { w2.year_total / w1.year_total } else { null })
+  Index        r523, r483, r18
+  Less         r524, r96, r523
+  Index        r525, r492, r18
+  Index        r526, r483, r18
+  Div          r527, r525, r526
+  Select       528,524,527,508
+  // (if c1.year_total > 0 { c2.year_total / c1.year_total } else { null }) >
+  Less         r529, r528, r522
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Equal        r530, r496, r56
+  Index        r531, r465, r23
+  Equal        r532, r531, r54
+  Index        r533, r483, r23
+  Equal        r534, r533, r426
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  Index        r535, r456, r23
+  Equal        r536, r535, r56
+  Index        r537, r474, r23
+  Equal        r538, r537, r54
+  Index        r539, r492, r23
+  Equal        r540, r539, r426
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  Index        r541, r450, r17
+  Const        r542, 2001
+  Equal        r543, r541, r542
+  Index        r544, r456, r17
+  Const        r545, 2002
+  Equal        r546, r544, r545
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  Index        r547, r465, r17
+  Equal        r548, r547, r542
+  Index        r549, r474, r17
+  Equal        r550, r549, r545
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  Index        r551, r483, r17
+  Equal        r552, r551, r542
+  Index        r553, r492, r17
+  Equal        r554, r553, r545
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  Move         r555, r530
+  JumpIfFalse  r555, L43
+  Move         r555, r532
+  JumpIfFalse  r555, L43
+  Move         r555, r534
+  JumpIfFalse  r555, L43
+  Move         r555, r536
+  // s2.sale_type == "s" && c2.sale_type == "c" && w2.sale_type == "w" &&
+  JumpIfFalse  r555, L43
+  Move         r555, r538
+  JumpIfFalse  r555, L43
+  Move         r555, r540
+  JumpIfFalse  r555, L43
+  Move         r555, r543
+  // s1.dyear == 2001 && s2.dyear == 2002 &&
+  JumpIfFalse  r555, L43
+  Move         r555, r546
+  JumpIfFalse  r555, L43
+  Move         r555, r548
+  // c1.dyear == 2001 && c2.dyear == 2002 &&
+  JumpIfFalse  r555, L43
+  Move         r555, r550
+  JumpIfFalse  r555, L43
+  Move         r555, r552
+  // w1.dyear == 2001 && w2.dyear == 2002 &&
+  JumpIfFalse  r555, L43
+  Move         r555, r554
+  JumpIfFalse  r555, L43
+  Move         r555, r498
+  // s1.year_total > 0 && c1.year_total > 0 && w1.year_total > 0 &&
+  JumpIfFalse  r555, L43
+  Move         r555, r500
+  JumpIfFalse  r555, L43
+  Move         r555, r502
+  JumpIfFalse  r555, L43
+  Move         r555, r516
+  // (if s1.year_total > 0 { s2.year_total / s1.year_total } else { null }) &&
+  JumpIfFalse  r555, L43
+  Move         r555, r529
+L43:
+  // where s1.sale_type == "s" && c1.sale_type == "c" && w1.sale_type == "w" &&
+  JumpIfFalse  r555, L42
   // customer_id: s2.customer_id,
-  Const        r574, "customer_id"
-  Index        r575, r459, r12
+  Const        r556, "customer_id"
+  Index        r557, r456, r12
   // customer_first_name: s2.customer_first_name,
-  Const        r576, "customer_first_name"
-  Index        r577, r459, r14
+  Const        r558, "customer_first_name"
+  Index        r559, r456, r14
   // customer_last_name: s2.customer_last_name,
-  Const        r578, "customer_last_name"
-  Index        r579, r459, r15
+  Const        r560, "customer_last_name"
+  Index        r561, r456, r15
   // customer_login: s2.customer_login,
-  Const        r580, "customer_login"
-  Index        r581, r459, r16
+  Const        r562, "customer_login"
+  Index        r563, r456, r16
   // customer_id: s2.customer_id,
-  Move         r582, r574
-  Move         r583, r575
+  Move         r564, r556
+  Move         r565, r557
   // customer_first_name: s2.customer_first_name,
-  Move         r584, r576
-  Move         r585, r577
+  Move         r566, r558
+  Move         r567, r559
   // customer_last_name: s2.customer_last_name,
-  Move         r586, r578
-  Move         r587, r579
+  Move         r568, r560
+  Move         r569, r561
   // customer_login: s2.customer_login,
-  Move         r588, r580
-  Move         r589, r581
+  Move         r570, r562
+  Move         r571, r563
   // select {
-  MakeMap      r590, 4, r582
+  MakeMap      r572, 4, r564
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Index        r591, r459, r12
-  Move         r592, r591
-  Index        r593, r459, r14
-  Move         r594, r593
-  Index        r595, r459, r15
-  Move         r596, r595
-  Index        r597, r459, r16
-  Move         r598, r597
-  MakeList     r599, 4, r592
-  Move         r600, r599
+  Index        r573, r456, r12
+  Move         r574, r573
+  Index        r575, r456, r14
+  Move         r576, r575
+  Index        r577, r456, r15
+  Move         r578, r577
+  Index        r579, r456, r16
+  Move         r580, r579
+  MakeList     r581, 4, r574
+  Move         r582, r581
   // from s1 in year_total
-  Move         r601, r590
-  MakeList     r602, 2, r600
-  Append       r603, r447, r602
-  Move         r447, r603
+  Move         r583, r572
+  MakeList     r584, 2, r582
+  Append       r585, r444, r584
+  Move         r444, r585
 L42:
   // join w2 in year_total on w2.customer_id == s1.customer_id
-  Add          r492, r492, r112
-  Jump         L59
+  Add          r489, r489, r111
+  Jump         L44
 L41:
   // join w1 in year_total on w1.customer_id == s1.customer_id
-  Add          r483, r483, r112
-  Jump         L60
+  Add          r480, r480, r111
+  Jump         L45
 L40:
   // join c2 in year_total on c2.customer_id == s1.customer_id
-  Add          r474, r474, r112
-  Jump         L61
+  Add          r471, r471, r111
+  Jump         L46
 L39:
   // join c1 in year_total on c1.customer_id == s1.customer_id
-  Add          r465, r465, r112
-  Jump         L62
+  Add          r462, r462, r111
+  Jump         L47
 L38:
   // join s2 in year_total on s2.customer_id == s1.customer_id
-  Add          r456, r456, r112
-  Jump         L63
+  Add          r453, r453, r111
+  Jump         L48
 L37:
   // from s1 in year_total
-  AddInt       r450, r450, r112
-  Jump         L64
+  AddInt       r447, r447, r111
+  Jump         L49
 L36:
   // sort by [s2.customer_id, s2.customer_first_name, s2.customer_last_name, s2.customer_login]
-  Sort         r604, r447
+  Sort         r586, r444
   // from s1 in year_total
-  Move         r447, r604
+  Move         r444, r586
   // json(result)
-  JSON         r447
+  JSON         r444
   // expect len(result) == 0
-  Len          r605, r447
-  EqualInt     r606, r605, r97
-  Expect       r606
+  Len          r587, r444
+  EqualInt     r588, r587, r96
+  Expect       r588
   Return       r0

--- a/tests/dataset/tpc-ds/out/q5.ir.out
+++ b/tests/dataset/tpc-ds/out/q5.ir.out
@@ -1,4 +1,4 @@
-func main (regs=863)
+func main (regs=856)
   // let store_sales = []
   Const        r0, []
   // from ss in store_sales
@@ -25,1390 +25,1383 @@ func main (regs=863)
   Const        r13, "profit_loss"
   // from ss in store_sales
   MakeMap      r14, 0, r0
-  Const        r16, []
-  Move         r15, r16
-  IterPrep     r17, r0
-  Len          r18, r17
-  Const        r19, 0
+  Move         r15, r0
+  IterPrep     r16, r0
+  Len          r17, r16
+  Const        r18, 0
 L8:
-  LessInt      r20, r19, r18
-  JumpIfFalse  r20, L0
-  Index        r21, r17, r19
-  Move         r22, r21
+  LessInt      r19, r18, r17
+  JumpIfFalse  r19, L0
+  Index        r20, r16, r18
+  Move         r21, r20
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r23, r0
-  Len          r24, r23
-  Const        r25, 0
+  IterPrep     r22, r0
+  Len          r23, r22
+  Const        r24, 0
 L7:
-  LessInt      r26, r25, r24
-  JumpIfFalse  r26, L1
-  Index        r27, r23, r25
-  Move         r28, r27
-  Const        r29, "ss_sold_date_sk"
-  Index        r30, r22, r29
-  Const        r31, "d_date_sk"
-  Index        r32, r28, r31
-  Equal        r33, r30, r32
-  JumpIfFalse  r33, L2
+  LessInt      r25, r24, r23
+  JumpIfFalse  r25, L1
+  Index        r26, r22, r24
+  Move         r27, r26
+  Const        r28, "ss_sold_date_sk"
+  Index        r29, r21, r28
+  Const        r30, "d_date_sk"
+  Index        r31, r27, r30
+  Equal        r32, r29, r31
+  JumpIfFalse  r32, L2
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  IterPrep     r34, r0
-  Len          r35, r34
-  Const        r36, 0
+  IterPrep     r33, r0
+  Len          r34, r33
+  Const        r35, 0
 L6:
-  LessInt      r37, r36, r35
-  JumpIfFalse  r37, L2
-  Index        r38, r34, r36
-  Move         r39, r38
-  Const        r40, "ss_store_sk"
-  Index        r41, r22, r40
-  Const        r42, "s_store_sk"
-  Index        r43, r39, r42
-  Equal        r44, r41, r43
-  JumpIfFalse  r44, L3
+  LessInt      r36, r35, r34
+  JumpIfFalse  r36, L2
+  Index        r37, r33, r35
+  Move         r38, r37
+  Const        r39, "ss_store_sk"
+  Index        r40, r21, r39
+  Const        r41, "s_store_sk"
+  Index        r42, r38, r41
+  Equal        r43, r40, r42
+  JumpIfFalse  r43, L3
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r45, r28, r3
-  Const        r46, "1998-12-01"
-  LessEq       r47, r46, r45
-  Index        r48, r28, r3
-  Const        r49, "1998-12-15"
-  LessEq       r50, r48, r49
-  Move         r51, r47
-  JumpIfFalse  r51, L4
-  Move         r51, r50
+  Index        r44, r27, r3
+  Const        r45, "1998-12-01"
+  LessEq       r46, r45, r44
+  Index        r47, r27, r3
+  Const        r48, "1998-12-15"
+  LessEq       r49, r47, r48
+  Move         r50, r46
+  JumpIfFalse  r50, L4
+  Move         r50, r49
 L4:
-  JumpIfFalse  r51, L3
+  JumpIfFalse  r50, L3
   // from ss in store_sales
-  Move         r52, r22
-  Const        r53, "d"
-  Move         r54, r28
-  Const        r55, "s"
-  Move         r56, r39
-  Move         r57, r8
+  Move         r51, r21
+  Const        r52, "d"
+  Move         r53, r27
+  Const        r54, "s"
+  Move         r55, r38
+  Move         r56, r8
+  Move         r57, r51
   Move         r58, r52
   Move         r59, r53
   Move         r60, r54
   Move         r61, r55
-  Move         r62, r56
-  MakeMap      r63, 3, r57
+  MakeMap      r62, 3, r56
   // group by s.s_store_id into g
-  Index        r64, r39, r2
-  Str          r65, r64
-  In           r66, r65, r14
-  JumpIfTrue   r66, L5
+  Index        r63, r38, r2
+  Str          r64, r63
+  In           r65, r64, r14
+  JumpIfTrue   r65, L5
   // from ss in store_sales
-  Const        r67, "__group__"
-  Const        r68, true
+  Const        r66, "__group__"
+  Const        r67, true
   // group by s.s_store_id into g
-  Move         r69, r64
+  Move         r68, r63
   // from ss in store_sales
-  Const        r70, "items"
-  Move         r71, r0
-  Const        r72, "count"
-  Const        r73, 0
+  Const        r69, "items"
+  Move         r70, r0
+  Const        r71, "count"
+  Const        r72, 0
+  Move         r73, r66
   Move         r74, r67
-  Move         r75, r68
-  Move         r76, r6
+  Move         r75, r6
+  Move         r76, r68
   Move         r77, r69
   Move         r78, r70
   Move         r79, r71
   Move         r80, r72
-  Move         r81, r73
-  MakeMap      r82, 4, r74
-  SetIndex     r14, r65, r82
-  Append       r83, r15, r82
-  Move         r15, r83
+  MakeMap      r81, 4, r73
+  SetIndex     r14, r64, r81
+  Append       r82, r15, r81
+  Move         r15, r82
 L5:
-  Index        r84, r14, r65
-  Index        r85, r84, r70
-  Append       r86, r85, r63
-  SetIndex     r84, r70, r86
-  Index        r87, r84, r72
-  Const        r88, 1
-  AddInt       r89, r87, r88
-  SetIndex     r84, r72, r89
+  Index        r83, r14, r64
+  Index        r84, r83, r69
+  Append       r85, r84, r62
+  SetIndex     r83, r69, r85
+  Index        r86, r83, r71
+  Const        r87, 1
+  AddInt       r88, r86, r87
+  SetIndex     r83, r71, r88
 L3:
   // join s in store on ss.ss_store_sk == s.s_store_sk
-  AddInt       r36, r36, r88
+  AddInt       r35, r35, r87
   Jump         L6
 L2:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r25, r25, r88
+  AddInt       r24, r24, r87
   Jump         L7
 L1:
   // from ss in store_sales
-  AddInt       r19, r19, r88
+  AddInt       r18, r18, r87
   Jump         L8
 L0:
-  Move         r90, r73
-  Len          r91, r15
+  Move         r89, r72
+  Len          r90, r15
 L14:
-  LessInt      r92, r90, r91
-  JumpIfFalse  r92, L9
-  Index        r93, r15, r90
-  Move         r94, r93
+  LessInt      r91, r89, r90
+  JumpIfFalse  r91, L9
+  Index        r92, r15, r89
+  Move         r93, r92
   // channel: "store channel",
-  Const        r95, "channel"
-  Const        r96, "store channel"
+  Const        r94, "channel"
+  Const        r95, "store channel"
   // id: "store" + str(g.key),
-  Const        r97, "id"
-  Const        r98, "store"
-  Index        r99, r94, r6
-  Str          r100, r99
-  Add          r101, r98, r100
+  Const        r96, "id"
+  Const        r97, "store"
+  Index        r98, r93, r6
+  Str          r99, r98
+  Add          r100, r97, r99
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Const        r102, "sales"
-  Const        r103, []
-  IterPrep     r104, r94
-  Len          r105, r104
-  Move         r106, r73
+  Const        r101, "sales"
+  Const        r102, []
+  IterPrep     r103, r93
+  Len          r104, r103
+  Move         r105, r72
 L11:
-  LessInt      r107, r106, r105
-  JumpIfFalse  r107, L10
-  Index        r108, r104, r106
-  Move         r109, r108
-  Index        r110, r109, r8
-  Index        r111, r110, r9
-  Append       r112, r103, r111
-  Move         r103, r112
-  AddInt       r106, r106, r88
+  LessInt      r106, r105, r104
+  JumpIfFalse  r106, L10
+  Index        r107, r103, r105
+  Move         r108, r107
+  Index        r109, r108, r8
+  Index        r110, r109, r9
+  Append       r111, r102, r110
+  Move         r102, r111
+  AddInt       r105, r105, r87
   Jump         L11
 L10:
-  Sum          r113, r103
+  Sum          r112, r102
   // returns: 0.0,
-  Const        r114, "returns"
-  Const        r115, 0
+  Const        r113, "returns"
+  Const        r114, 0.0
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Const        r116, "profit"
-  Const        r117, []
-  IterPrep     r118, r94
-  Len          r119, r118
-  Move         r120, r73
+  Const        r115, "profit"
+  Const        r116, []
+  IterPrep     r117, r93
+  Len          r118, r117
+  Move         r119, r72
 L13:
-  LessInt      r121, r120, r119
-  JumpIfFalse  r121, L12
-  Index        r122, r118, r120
-  Move         r109, r122
-  Index        r123, r109, r8
-  Index        r124, r123, r12
-  Append       r125, r117, r124
-  Move         r117, r125
-  AddInt       r120, r120, r88
+  LessInt      r120, r119, r118
+  JumpIfFalse  r120, L12
+  Index        r121, r117, r119
+  Move         r108, r121
+  Index        r122, r108, r8
+  Index        r123, r122, r12
+  Append       r124, r116, r123
+  Move         r116, r124
+  AddInt       r119, r119, r87
   Jump         L13
 L12:
-  Sum          r126, r117
+  Sum          r125, r116
   // profit_loss: 0.0
-  Const        r127, "profit_loss"
+  Const        r126, "profit_loss"
   // channel: "store channel",
+  Move         r127, r94
   Move         r128, r95
-  Move         r129, r96
   // id: "store" + str(g.key),
-  Move         r130, r97
-  Move         r131, r101
+  Move         r129, r96
+  Move         r130, r100
   // sales: sum(from x in g select x.ss.ss_ext_sales_price),
-  Move         r132, r102
-  Move         r133, r113
+  Move         r131, r101
+  Move         r132, r112
   // returns: 0.0,
+  Move         r133, r113
   Move         r134, r114
-  Move         r135, r115
   // profit: sum(from x in g select x.ss.ss_net_profit),
-  Move         r136, r116
-  Move         r137, r126
+  Move         r135, r115
+  Move         r136, r125
   // profit_loss: 0.0
-  Move         r138, r127
-  Move         r139, r115
+  Move         r137, r126
+  Move         r138, r114
   // select {
-  MakeMap      r140, 6, r128
+  MakeMap      r139, 6, r127
   // from ss in store_sales
-  Append       r141, r1, r140
-  Move         r1, r141
-  AddInt       r90, r90, r88
+  Append       r140, r1, r139
+  Move         r1, r140
+  AddInt       r89, r89, r87
   Jump         L14
 L9:
   // from sr in store_returns
-  Const        r142, []
+  Const        r141, []
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Const        r143, "sr"
-  Const        r144, "sr_return_amt"
+  Const        r142, "sr"
+  Const        r143, "sr_return_amt"
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Const        r145, "sr_net_loss"
+  Const        r144, "sr_net_loss"
   // from sr in store_returns
-  MakeMap      r146, 0, r0
-  Const        r148, []
-  Move         r147, r148
-  IterPrep     r149, r0
-  Len          r150, r149
-  Const        r151, 0
+  MakeMap      r145, 0, r0
+  Move         r146, r0
+  IterPrep     r147, r0
+  Len          r148, r147
+  Const        r149, 0
 L23:
-  LessInt      r152, r151, r150
-  JumpIfFalse  r152, L15
-  Index        r153, r149, r151
-  Move         r154, r153
+  LessInt      r150, r149, r148
+  JumpIfFalse  r150, L15
+  Index        r151, r147, r149
+  Move         r152, r151
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  IterPrep     r155, r0
-  Len          r156, r155
-  Const        r157, 0
+  IterPrep     r153, r0
+  Len          r154, r153
+  Const        r155, 0
 L22:
-  LessInt      r158, r157, r156
-  JumpIfFalse  r158, L16
-  Index        r159, r155, r157
-  Move         r160, r159
-  Const        r161, "sr_returned_date_sk"
-  Index        r162, r154, r161
-  Index        r163, r160, r31
-  Equal        r164, r162, r163
-  JumpIfFalse  r164, L17
+  LessInt      r156, r155, r154
+  JumpIfFalse  r156, L16
+  Index        r157, r153, r155
+  Move         r158, r157
+  Const        r159, "sr_returned_date_sk"
+  Index        r160, r152, r159
+  Index        r161, r158, r30
+  Equal        r162, r160, r161
+  JumpIfFalse  r162, L17
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  IterPrep     r165, r0
-  Len          r166, r165
-  Const        r167, 0
+  IterPrep     r163, r0
+  Len          r164, r163
+  Const        r165, 0
 L21:
-  LessInt      r168, r167, r166
-  JumpIfFalse  r168, L17
-  Index        r169, r165, r167
-  Move         r170, r169
-  Const        r171, "sr_store_sk"
-  Index        r172, r154, r171
-  Index        r173, r170, r42
-  Equal        r174, r172, r173
-  JumpIfFalse  r174, L18
+  LessInt      r166, r165, r164
+  JumpIfFalse  r166, L17
+  Index        r167, r163, r165
+  Move         r168, r167
+  Const        r169, "sr_store_sk"
+  Index        r170, r152, r169
+  Index        r171, r168, r41
+  Equal        r172, r170, r171
+  JumpIfFalse  r172, L18
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r175, r160, r3
-  LessEq       r176, r46, r175
-  Index        r177, r160, r3
-  LessEq       r178, r177, r49
-  Move         r179, r176
-  JumpIfFalse  r179, L19
-  Move         r179, r178
+  Index        r173, r158, r3
+  LessEq       r174, r45, r173
+  Index        r175, r158, r3
+  LessEq       r176, r175, r48
+  Move         r177, r174
+  JumpIfFalse  r177, L19
+  Move         r177, r176
 L19:
-  JumpIfFalse  r179, L18
+  JumpIfFalse  r177, L18
   // from sr in store_returns
-  Move         r180, r154
-  Move         r181, r160
-  Move         r182, r170
-  Move         r183, r143
-  Move         r184, r180
-  Move         r185, r53
-  Move         r186, r181
-  Move         r187, r55
-  Move         r188, r182
-  MakeMap      r189, 3, r183
+  Move         r178, r152
+  Move         r179, r158
+  Move         r180, r168
+  Move         r181, r142
+  Move         r182, r178
+  Move         r183, r52
+  Move         r184, r179
+  Move         r185, r54
+  Move         r186, r180
+  MakeMap      r187, 3, r181
   // group by s.s_store_id into g
-  Index        r190, r170, r2
-  Str          r191, r190
-  In           r192, r191, r146
-  JumpIfTrue   r192, L20
-  Move         r193, r190
+  Index        r188, r168, r2
+  Str          r189, r188
+  In           r190, r189, r145
+  JumpIfTrue   r190, L20
+  Move         r191, r188
   // from sr in store_returns
-  Move         r194, r0
-  Move         r195, r67
-  Move         r196, r68
-  Move         r197, r6
-  Move         r198, r193
-  Move         r199, r70
-  Move         r200, r194
-  Move         r201, r72
-  Move         r202, r73
-  MakeMap      r203, 4, r195
-  SetIndex     r146, r191, r203
-  Append       r204, r147, r203
-  Move         r147, r204
+  Move         r192, r0
+  Move         r193, r66
+  Move         r194, r67
+  Move         r195, r6
+  Move         r196, r191
+  Move         r197, r69
+  Move         r198, r192
+  Move         r199, r71
+  Move         r200, r72
+  MakeMap      r201, 4, r193
+  SetIndex     r145, r189, r201
+  Append       r202, r146, r201
+  Move         r146, r202
 L20:
-  Index        r205, r146, r191
-  Index        r206, r205, r70
-  Append       r207, r206, r189
-  SetIndex     r205, r70, r207
-  Index        r208, r205, r72
-  AddInt       r209, r208, r88
-  SetIndex     r205, r72, r209
+  Index        r203, r145, r189
+  Index        r204, r203, r69
+  Append       r205, r204, r187
+  SetIndex     r203, r69, r205
+  Index        r206, r203, r71
+  AddInt       r207, r206, r87
+  SetIndex     r203, r71, r207
 L18:
   // join s in store on sr.sr_store_sk == s.s_store_sk
-  AddInt       r167, r167, r88
+  AddInt       r165, r165, r87
   Jump         L21
 L17:
   // join d in date_dim on sr.sr_returned_date_sk == d.d_date_sk
-  AddInt       r157, r157, r88
+  AddInt       r155, r155, r87
   Jump         L22
 L16:
   // from sr in store_returns
-  AddInt       r151, r151, r88
+  AddInt       r149, r149, r87
   Jump         L23
 L15:
-  Move         r210, r73
-  Len          r211, r147
+  Move         r208, r72
+  Len          r209, r146
 L29:
-  LessInt      r212, r210, r211
-  JumpIfFalse  r212, L24
-  Index        r213, r147, r210
-  Move         r94, r213
+  LessInt      r210, r208, r209
+  JumpIfFalse  r210, L24
+  Index        r211, r146, r208
+  Move         r93, r211
   // channel: "store channel",
-  Const        r214, "channel"
+  Const        r212, "channel"
   // id: "store" + str(g.key),
-  Const        r215, "id"
-  Index        r216, r94, r6
-  Str          r217, r216
-  Add          r218, r98, r217
+  Const        r213, "id"
+  Index        r214, r93, r6
+  Str          r215, r214
+  Add          r216, r97, r215
   // sales: 0.0,
-  Const        r219, "sales"
+  Const        r217, "sales"
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Const        r220, "returns"
-  Const        r221, []
-  IterPrep     r222, r94
-  Len          r223, r222
-  Move         r224, r73
+  Const        r218, "returns"
+  Const        r219, []
+  IterPrep     r220, r93
+  Len          r221, r220
+  Move         r222, r72
 L26:
-  LessInt      r225, r224, r223
-  JumpIfFalse  r225, L25
-  Index        r226, r222, r224
-  Move         r109, r226
-  Index        r227, r109, r143
-  Index        r228, r227, r144
-  Append       r229, r221, r228
-  Move         r221, r229
-  AddInt       r224, r224, r88
+  LessInt      r223, r222, r221
+  JumpIfFalse  r223, L25
+  Index        r224, r220, r222
+  Move         r108, r224
+  Index        r225, r108, r142
+  Index        r226, r225, r143
+  Append       r227, r219, r226
+  Move         r219, r227
+  AddInt       r222, r222, r87
   Jump         L26
 L25:
-  Sum          r230, r221
+  Sum          r228, r219
   // profit: 0.0,
-  Const        r231, "profit"
+  Const        r229, "profit"
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Const        r232, "profit_loss"
-  Const        r233, []
-  IterPrep     r234, r94
-  Len          r235, r234
-  Move         r236, r73
+  Const        r230, "profit_loss"
+  Const        r231, []
+  IterPrep     r232, r93
+  Len          r233, r232
+  Move         r234, r72
 L28:
-  LessInt      r237, r236, r235
-  JumpIfFalse  r237, L27
-  Index        r238, r234, r236
-  Move         r109, r238
-  Index        r239, r109, r143
-  Index        r240, r239, r145
-  Append       r241, r233, r240
-  Move         r233, r241
-  AddInt       r236, r236, r88
+  LessInt      r235, r234, r233
+  JumpIfFalse  r235, L27
+  Index        r236, r232, r234
+  Move         r108, r236
+  Index        r237, r108, r142
+  Index        r238, r237, r144
+  Append       r239, r231, r238
+  Move         r231, r239
+  AddInt       r234, r234, r87
   Jump         L28
 L27:
-  Sum          r242, r233
+  Sum          r240, r231
   // channel: "store channel",
-  Move         r243, r214
-  Move         r244, r96
+  Move         r241, r212
+  Move         r242, r95
   // id: "store" + str(g.key),
-  Move         r245, r215
-  Move         r246, r218
+  Move         r243, r213
+  Move         r244, r216
   // sales: 0.0,
-  Move         r247, r219
-  Move         r248, r115
+  Move         r245, r217
+  Move         r246, r114
   // returns: sum(from x in g select x.sr.sr_return_amt),
-  Move         r249, r220
-  Move         r250, r230
+  Move         r247, r218
+  Move         r248, r228
   // profit: 0.0,
-  Move         r251, r231
-  Move         r252, r115
+  Move         r249, r229
+  Move         r250, r114
   // profit_loss: sum(from x in g select x.sr.sr_net_loss)
-  Move         r253, r232
-  Move         r254, r242
+  Move         r251, r230
+  Move         r252, r240
   // select {
-  MakeMap      r255, 6, r243
+  MakeMap      r253, 6, r241
   // from sr in store_returns
-  Append       r256, r142, r255
-  Move         r142, r256
-  AddInt       r210, r210, r88
+  Append       r254, r141, r253
+  Move         r141, r254
+  AddInt       r208, r208, r87
   Jump         L29
 L24:
   // from cs in catalog_sales
-  Const        r257, []
+  Const        r255, []
   // group by cp.cp_catalog_page_id into g
-  Const        r258, "cp_catalog_page_id"
+  Const        r256, "cp_catalog_page_id"
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Const        r259, "cs"
-  Const        r260, "cs_ext_sales_price"
+  Const        r257, "cs"
+  Const        r258, "cs_ext_sales_price"
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Const        r261, "cs_net_profit"
+  Const        r259, "cs_net_profit"
   // from cs in catalog_sales
-  MakeMap      r262, 0, r0
-  Const        r264, []
-  Move         r263, r264
-  IterPrep     r265, r0
-  Len          r266, r265
-  Const        r267, 0
+  MakeMap      r260, 0, r0
+  Move         r261, r0
+  IterPrep     r262, r0
+  Len          r263, r262
+  Const        r264, 0
 L38:
-  LessInt      r268, r267, r266
-  JumpIfFalse  r268, L30
-  Index        r269, r265, r267
-  Move         r270, r269
+  LessInt      r265, r264, r263
+  JumpIfFalse  r265, L30
+  Index        r266, r262, r264
+  Move         r267, r266
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  IterPrep     r271, r0
-  Len          r272, r271
-  Const        r273, 0
+  IterPrep     r268, r0
+  Len          r269, r268
+  Const        r270, 0
 L37:
-  LessInt      r274, r273, r272
-  JumpIfFalse  r274, L31
-  Index        r275, r271, r273
-  Move         r276, r275
-  Const        r277, "cs_sold_date_sk"
-  Index        r278, r270, r277
-  Index        r279, r276, r31
-  Equal        r280, r278, r279
-  JumpIfFalse  r280, L32
+  LessInt      r271, r270, r269
+  JumpIfFalse  r271, L31
+  Index        r272, r268, r270
+  Move         r273, r272
+  Const        r274, "cs_sold_date_sk"
+  Index        r275, r267, r274
+  Index        r276, r273, r30
+  Equal        r277, r275, r276
+  JumpIfFalse  r277, L32
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r281, r0
-  Len          r282, r281
-  Const        r283, 0
+  IterPrep     r278, r0
+  Len          r279, r278
+  Const        r280, 0
 L36:
-  LessInt      r284, r283, r282
-  JumpIfFalse  r284, L32
-  Index        r285, r281, r283
-  Move         r286, r285
-  Const        r287, "cs_catalog_page_sk"
-  Index        r288, r270, r287
-  Const        r289, "cp_catalog_page_sk"
-  Index        r290, r286, r289
-  Equal        r291, r288, r290
-  JumpIfFalse  r291, L33
+  LessInt      r281, r280, r279
+  JumpIfFalse  r281, L32
+  Index        r282, r278, r280
+  Move         r283, r282
+  Const        r284, "cs_catalog_page_sk"
+  Index        r285, r267, r284
+  Const        r286, "cp_catalog_page_sk"
+  Index        r287, r283, r286
+  Equal        r288, r285, r287
+  JumpIfFalse  r288, L33
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r292, r276, r3
-  LessEq       r293, r46, r292
-  Index        r294, r276, r3
-  LessEq       r295, r294, r49
-  Move         r296, r293
-  JumpIfFalse  r296, L34
-  Move         r296, r295
+  Index        r289, r273, r3
+  LessEq       r290, r45, r289
+  Index        r291, r273, r3
+  LessEq       r292, r291, r48
+  Move         r293, r290
+  JumpIfFalse  r293, L34
+  Move         r293, r292
 L34:
-  JumpIfFalse  r296, L33
+  JumpIfFalse  r293, L33
   // from cs in catalog_sales
-  Move         r297, r270
-  Move         r298, r276
-  Const        r299, "cp"
-  Move         r300, r286
-  Move         r301, r259
-  Move         r302, r297
-  Move         r303, r53
-  Move         r304, r298
-  Move         r305, r299
-  Move         r306, r300
-  MakeMap      r307, 3, r301
+  Move         r294, r267
+  Move         r295, r273
+  Const        r296, "cp"
+  Move         r297, r283
+  Move         r298, r257
+  Move         r299, r294
+  Move         r300, r52
+  Move         r301, r295
+  Move         r302, r296
+  Move         r303, r297
+  MakeMap      r304, 3, r298
   // group by cp.cp_catalog_page_id into g
-  Index        r308, r286, r258
-  Str          r309, r308
-  In           r310, r309, r262
-  JumpIfTrue   r310, L35
-  Move         r311, r308
+  Index        r305, r283, r256
+  Str          r306, r305
+  In           r307, r306, r260
+  JumpIfTrue   r307, L35
+  Move         r308, r305
   // from cs in catalog_sales
-  Move         r312, r0
-  Move         r313, r67
-  Move         r314, r68
-  Move         r315, r6
-  Move         r316, r311
-  Move         r317, r70
-  Move         r318, r312
-  Move         r319, r72
-  Move         r320, r73
-  MakeMap      r321, 4, r313
-  SetIndex     r262, r309, r321
-  Append       r322, r263, r321
-  Move         r263, r322
+  Move         r309, r0
+  Move         r310, r66
+  Move         r311, r67
+  Move         r312, r6
+  Move         r313, r308
+  Move         r314, r69
+  Move         r315, r309
+  Move         r316, r71
+  Move         r317, r72
+  MakeMap      r318, 4, r310
+  SetIndex     r260, r306, r318
+  Append       r319, r261, r318
+  Move         r261, r319
 L35:
-  Index        r323, r262, r309
-  Index        r324, r323, r70
-  Append       r325, r324, r307
-  SetIndex     r323, r70, r325
-  Index        r326, r323, r72
-  AddInt       r327, r326, r88
-  SetIndex     r323, r72, r327
+  Index        r320, r260, r306
+  Index        r321, r320, r69
+  Append       r322, r321, r304
+  SetIndex     r320, r69, r322
+  Index        r323, r320, r71
+  AddInt       r324, r323, r87
+  SetIndex     r320, r71, r324
 L33:
   // join cp in catalog_page on cs.cs_catalog_page_sk == cp.cp_catalog_page_sk
-  AddInt       r283, r283, r88
+  AddInt       r280, r280, r87
   Jump         L36
 L32:
   // join d in date_dim on cs.cs_sold_date_sk == d.d_date_sk
-  AddInt       r273, r273, r88
+  AddInt       r270, r270, r87
   Jump         L37
 L31:
   // from cs in catalog_sales
-  AddInt       r267, r267, r88
+  AddInt       r264, r264, r87
   Jump         L38
 L30:
-  Move         r328, r73
-  Len          r329, r263
+  Move         r325, r72
+  Len          r326, r261
 L44:
-  LessInt      r330, r328, r329
-  JumpIfFalse  r330, L39
-  Index        r331, r263, r328
-  Move         r94, r331
+  LessInt      r327, r325, r326
+  JumpIfFalse  r327, L39
+  Index        r328, r261, r325
+  Move         r93, r328
   // channel: "catalog channel",
-  Const        r332, "channel"
-  Const        r333, "catalog channel"
+  Const        r329, "channel"
+  Const        r330, "catalog channel"
   // id: "catalog_page" + str(g.key),
-  Const        r334, "id"
-  Const        r335, "catalog_page"
-  Index        r336, r94, r6
-  Str          r337, r336
-  Add          r338, r335, r337
+  Const        r331, "id"
+  Const        r332, "catalog_page"
+  Index        r333, r93, r6
+  Str          r334, r333
+  Add          r335, r332, r334
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Const        r339, "sales"
-  Const        r340, []
-  IterPrep     r341, r94
-  Len          r342, r341
-  Move         r343, r73
+  Const        r336, "sales"
+  Const        r337, []
+  IterPrep     r338, r93
+  Len          r339, r338
+  Move         r340, r72
 L41:
-  LessInt      r344, r343, r342
-  JumpIfFalse  r344, L40
-  Index        r345, r341, r343
-  Move         r109, r345
-  Index        r346, r109, r259
-  Index        r347, r346, r260
-  Append       r348, r340, r347
-  Move         r340, r348
-  AddInt       r343, r343, r88
+  LessInt      r341, r340, r339
+  JumpIfFalse  r341, L40
+  Index        r342, r338, r340
+  Move         r108, r342
+  Index        r343, r108, r257
+  Index        r344, r343, r258
+  Append       r345, r337, r344
+  Move         r337, r345
+  AddInt       r340, r340, r87
   Jump         L41
 L40:
-  Sum          r349, r340
+  Sum          r346, r337
   // returns: 0.0,
-  Const        r350, "returns"
+  Const        r347, "returns"
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Const        r351, "profit"
-  Const        r352, []
-  IterPrep     r353, r94
-  Len          r354, r353
-  Move         r355, r73
+  Const        r348, "profit"
+  Const        r349, []
+  IterPrep     r350, r93
+  Len          r351, r350
+  Move         r352, r72
 L43:
-  LessInt      r356, r355, r354
-  JumpIfFalse  r356, L42
-  Index        r357, r353, r355
-  Move         r109, r357
-  Index        r358, r109, r259
-  Index        r359, r358, r261
-  Append       r360, r352, r359
-  Move         r352, r360
-  AddInt       r355, r355, r88
+  LessInt      r353, r352, r351
+  JumpIfFalse  r353, L42
+  Index        r354, r350, r352
+  Move         r108, r354
+  Index        r355, r108, r257
+  Index        r356, r355, r259
+  Append       r357, r349, r356
+  Move         r349, r357
+  AddInt       r352, r352, r87
   Jump         L43
 L42:
-  Sum          r361, r352
+  Sum          r358, r349
   // profit_loss: 0.0
-  Const        r362, "profit_loss"
+  Const        r359, "profit_loss"
   // channel: "catalog channel",
-  Move         r363, r332
-  Move         r364, r333
+  Move         r360, r329
+  Move         r361, r330
   // id: "catalog_page" + str(g.key),
-  Move         r365, r334
-  Move         r366, r338
+  Move         r362, r331
+  Move         r363, r335
   // sales: sum(from x in g select x.cs.cs_ext_sales_price),
-  Move         r367, r339
-  Move         r368, r349
+  Move         r364, r336
+  Move         r365, r346
   // returns: 0.0,
-  Move         r369, r350
-  Move         r370, r115
+  Move         r366, r347
+  Move         r367, r114
   // profit: sum(from x in g select x.cs.cs_net_profit),
-  Move         r371, r351
-  Move         r372, r361
+  Move         r368, r348
+  Move         r369, r358
   // profit_loss: 0.0
-  Move         r373, r362
-  Move         r374, r115
+  Move         r370, r359
+  Move         r371, r114
   // select {
-  MakeMap      r375, 6, r363
+  MakeMap      r372, 6, r360
   // from cs in catalog_sales
-  Append       r376, r257, r375
-  Move         r257, r376
-  AddInt       r328, r328, r88
+  Append       r373, r255, r372
+  Move         r255, r373
+  AddInt       r325, r325, r87
   Jump         L44
 L39:
   // from cr in catalog_returns
-  Const        r377, []
+  Const        r374, []
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Const        r378, "cr"
-  Const        r379, "cr_return_amount"
+  Const        r375, "cr"
+  Const        r376, "cr_return_amount"
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Const        r380, "cr_net_loss"
+  Const        r377, "cr_net_loss"
   // from cr in catalog_returns
-  MakeMap      r381, 0, r0
-  Const        r383, []
-  Move         r382, r383
-  IterPrep     r384, r0
-  Len          r385, r384
-  Const        r386, 0
+  MakeMap      r378, 0, r0
+  Move         r379, r0
+  IterPrep     r380, r0
+  Len          r381, r380
+  Const        r382, 0
 L53:
-  LessInt      r387, r386, r385
-  JumpIfFalse  r387, L45
-  Index        r388, r384, r386
-  Move         r389, r388
+  LessInt      r383, r382, r381
+  JumpIfFalse  r383, L45
+  Index        r384, r380, r382
+  Move         r385, r384
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  IterPrep     r390, r0
-  Len          r391, r390
-  Const        r392, 0
+  IterPrep     r386, r0
+  Len          r387, r386
+  Const        r388, 0
 L52:
-  LessInt      r393, r392, r391
-  JumpIfFalse  r393, L46
-  Index        r394, r390, r392
-  Move         r395, r394
-  Const        r396, "cr_returned_date_sk"
-  Index        r397, r389, r396
-  Index        r398, r395, r31
-  Equal        r399, r397, r398
-  JumpIfFalse  r399, L47
+  LessInt      r389, r388, r387
+  JumpIfFalse  r389, L46
+  Index        r390, r386, r388
+  Move         r391, r390
+  Const        r392, "cr_returned_date_sk"
+  Index        r393, r385, r392
+  Index        r394, r391, r30
+  Equal        r395, r393, r394
+  JumpIfFalse  r395, L47
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  IterPrep     r400, r0
-  Len          r401, r400
-  Const        r402, 0
+  IterPrep     r396, r0
+  Len          r397, r396
+  Const        r398, 0
 L51:
-  LessInt      r403, r402, r401
-  JumpIfFalse  r403, L47
-  Index        r404, r400, r402
-  Move         r405, r404
-  Const        r406, "cr_catalog_page_sk"
-  Index        r407, r389, r406
-  Index        r408, r405, r289
-  Equal        r409, r407, r408
-  JumpIfFalse  r409, L48
+  LessInt      r399, r398, r397
+  JumpIfFalse  r399, L47
+  Index        r400, r396, r398
+  Move         r401, r400
+  Const        r402, "cr_catalog_page_sk"
+  Index        r403, r385, r402
+  Index        r404, r401, r286
+  Equal        r405, r403, r404
+  JumpIfFalse  r405, L48
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r410, r395, r3
-  LessEq       r411, r46, r410
-  Index        r412, r395, r3
-  LessEq       r413, r412, r49
-  Move         r414, r411
-  JumpIfFalse  r414, L49
-  Move         r414, r413
+  Index        r406, r391, r3
+  LessEq       r407, r45, r406
+  Index        r408, r391, r3
+  LessEq       r409, r408, r48
+  Move         r410, r407
+  JumpIfFalse  r410, L49
+  Move         r410, r409
 L49:
-  JumpIfFalse  r414, L48
+  JumpIfFalse  r410, L48
   // from cr in catalog_returns
-  Move         r415, r389
-  Move         r416, r395
-  Move         r417, r405
-  Move         r418, r378
-  Move         r419, r415
-  Move         r420, r53
-  Move         r421, r416
-  Move         r422, r299
-  Move         r423, r417
-  MakeMap      r424, 3, r418
+  Move         r411, r385
+  Move         r412, r391
+  Move         r413, r401
+  Move         r414, r375
+  Move         r415, r411
+  Move         r416, r52
+  Move         r417, r412
+  Move         r418, r296
+  Move         r419, r413
+  MakeMap      r420, 3, r414
   // group by cp.cp_catalog_page_id into g
-  Index        r425, r405, r258
-  Str          r426, r425
-  In           r427, r426, r381
-  JumpIfTrue   r427, L50
-  Move         r428, r425
+  Index        r421, r401, r256
+  Str          r422, r421
+  In           r423, r422, r378
+  JumpIfTrue   r423, L50
+  Move         r424, r421
   // from cr in catalog_returns
-  Move         r429, r0
-  Move         r430, r67
-  Move         r431, r68
-  Move         r432, r6
-  Move         r433, r428
-  Move         r434, r70
-  Move         r435, r429
-  Move         r436, r72
-  Move         r437, r73
-  MakeMap      r438, 4, r430
-  SetIndex     r381, r426, r438
-  Append       r439, r382, r438
-  Move         r382, r439
+  Move         r425, r0
+  Move         r426, r66
+  Move         r427, r67
+  Move         r428, r6
+  Move         r429, r424
+  Move         r430, r69
+  Move         r431, r425
+  Move         r432, r71
+  Move         r433, r72
+  MakeMap      r434, 4, r426
+  SetIndex     r378, r422, r434
+  Append       r435, r379, r434
+  Move         r379, r435
 L50:
-  Index        r440, r381, r426
-  Index        r441, r440, r70
-  Append       r442, r441, r424
-  SetIndex     r440, r70, r442
-  Index        r443, r440, r72
-  AddInt       r444, r443, r88
-  SetIndex     r440, r72, r444
+  Index        r436, r378, r422
+  Index        r437, r436, r69
+  Append       r438, r437, r420
+  SetIndex     r436, r69, r438
+  Index        r439, r436, r71
+  AddInt       r440, r439, r87
+  SetIndex     r436, r71, r440
 L48:
   // join cp in catalog_page on cr.cr_catalog_page_sk == cp.cp_catalog_page_sk
-  AddInt       r402, r402, r88
+  AddInt       r398, r398, r87
   Jump         L51
 L47:
   // join d in date_dim on cr.cr_returned_date_sk == d.d_date_sk
-  AddInt       r392, r392, r88
+  AddInt       r388, r388, r87
   Jump         L52
 L46:
   // from cr in catalog_returns
-  AddInt       r386, r386, r88
+  AddInt       r382, r382, r87
   Jump         L53
 L45:
-  Move         r445, r73
-  Len          r446, r382
+  Move         r441, r72
+  Len          r442, r379
 L59:
-  LessInt      r447, r445, r446
-  JumpIfFalse  r447, L54
-  Index        r448, r382, r445
-  Move         r94, r448
+  LessInt      r443, r441, r442
+  JumpIfFalse  r443, L54
+  Index        r444, r379, r441
+  Move         r93, r444
   // channel: "catalog channel",
-  Const        r449, "channel"
+  Const        r445, "channel"
   // id: "catalog_page" + str(g.key),
-  Const        r450, "id"
-  Index        r451, r94, r6
-  Str          r452, r451
-  Add          r453, r335, r452
+  Const        r446, "id"
+  Index        r447, r93, r6
+  Str          r448, r447
+  Add          r449, r332, r448
   // sales: 0.0,
-  Const        r454, "sales"
+  Const        r450, "sales"
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Const        r455, "returns"
-  Const        r456, []
-  IterPrep     r457, r94
-  Len          r458, r457
-  Move         r459, r73
+  Const        r451, "returns"
+  Const        r452, []
+  IterPrep     r453, r93
+  Len          r454, r453
+  Move         r455, r72
 L56:
-  LessInt      r460, r459, r458
-  JumpIfFalse  r460, L55
-  Index        r461, r457, r459
-  Move         r109, r461
-  Index        r462, r109, r378
-  Index        r463, r462, r379
-  Append       r464, r456, r463
-  Move         r456, r464
-  AddInt       r459, r459, r88
+  LessInt      r456, r455, r454
+  JumpIfFalse  r456, L55
+  Index        r457, r453, r455
+  Move         r108, r457
+  Index        r458, r108, r375
+  Index        r459, r458, r376
+  Append       r460, r452, r459
+  Move         r452, r460
+  AddInt       r455, r455, r87
   Jump         L56
 L55:
-  Sum          r465, r456
+  Sum          r461, r452
   // profit: 0.0,
-  Const        r466, "profit"
+  Const        r462, "profit"
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Const        r467, "profit_loss"
-  Const        r468, []
-  IterPrep     r469, r94
-  Len          r470, r469
-  Move         r471, r73
+  Const        r463, "profit_loss"
+  Const        r464, []
+  IterPrep     r465, r93
+  Len          r466, r465
+  Move         r467, r72
 L58:
-  LessInt      r472, r471, r470
-  JumpIfFalse  r472, L57
-  Index        r473, r469, r471
-  Move         r109, r473
-  Index        r474, r109, r378
-  Index        r475, r474, r380
-  Append       r476, r468, r475
-  Move         r468, r476
-  AddInt       r471, r471, r88
+  LessInt      r468, r467, r466
+  JumpIfFalse  r468, L57
+  Index        r469, r465, r467
+  Move         r108, r469
+  Index        r470, r108, r375
+  Index        r471, r470, r377
+  Append       r472, r464, r471
+  Move         r464, r472
+  AddInt       r467, r467, r87
   Jump         L58
 L57:
-  Sum          r477, r468
+  Sum          r473, r464
   // channel: "catalog channel",
-  Move         r478, r449
-  Move         r479, r333
+  Move         r474, r445
+  Move         r475, r330
   // id: "catalog_page" + str(g.key),
-  Move         r480, r450
-  Move         r481, r453
+  Move         r476, r446
+  Move         r477, r449
   // sales: 0.0,
-  Move         r482, r454
-  Move         r483, r115
+  Move         r478, r450
+  Move         r479, r114
   // returns: sum(from x in g select x.cr.cr_return_amount),
-  Move         r484, r455
-  Move         r485, r465
+  Move         r480, r451
+  Move         r481, r461
   // profit: 0.0,
-  Move         r486, r466
-  Move         r487, r115
+  Move         r482, r462
+  Move         r483, r114
   // profit_loss: sum(from x in g select x.cr.cr_net_loss)
-  Move         r488, r467
-  Move         r489, r477
+  Move         r484, r463
+  Move         r485, r473
   // select {
-  MakeMap      r490, 6, r478
+  MakeMap      r486, 6, r474
   // from cr in catalog_returns
-  Append       r491, r377, r490
-  Move         r377, r491
-  AddInt       r445, r445, r88
+  Append       r487, r374, r486
+  Move         r374, r487
+  AddInt       r441, r441, r87
   Jump         L59
 L54:
   // from ws in web_sales
-  Const        r492, []
+  Const        r488, []
   // group by w.web_site_id into g
-  Const        r493, "web_site_id"
+  Const        r489, "web_site_id"
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Const        r494, "ws"
-  Const        r495, "ws_ext_sales_price"
+  Const        r490, "ws"
+  Const        r491, "ws_ext_sales_price"
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Const        r496, "ws_net_profit"
+  Const        r492, "ws_net_profit"
   // from ws in web_sales
-  MakeMap      r497, 0, r0
-  Const        r499, []
-  Move         r498, r499
-  IterPrep     r500, r0
-  Len          r501, r500
-  Const        r502, 0
+  MakeMap      r493, 0, r0
+  Move         r494, r0
+  IterPrep     r495, r0
+  Len          r496, r495
+  Const        r497, 0
 L68:
-  LessInt      r503, r502, r501
-  JumpIfFalse  r503, L60
-  Index        r504, r500, r502
-  Move         r505, r504
+  LessInt      r498, r497, r496
+  JumpIfFalse  r498, L60
+  Index        r499, r495, r497
+  Move         r500, r499
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  IterPrep     r506, r0
-  Len          r507, r506
-  Const        r508, 0
+  IterPrep     r501, r0
+  Len          r502, r501
+  Const        r503, 0
 L67:
-  LessInt      r509, r508, r507
-  JumpIfFalse  r509, L61
-  Index        r510, r506, r508
-  Move         r511, r510
-  Const        r512, "ws_sold_date_sk"
-  Index        r513, r505, r512
-  Index        r514, r511, r31
-  Equal        r515, r513, r514
-  JumpIfFalse  r515, L62
+  LessInt      r504, r503, r502
+  JumpIfFalse  r504, L61
+  Index        r505, r501, r503
+  Move         r506, r505
+  Const        r507, "ws_sold_date_sk"
+  Index        r508, r500, r507
+  Index        r509, r506, r30
+  Equal        r510, r508, r509
+  JumpIfFalse  r510, L62
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r516, r0
-  Len          r517, r516
-  Const        r518, 0
+  IterPrep     r511, r0
+  Len          r512, r511
+  Const        r513, 0
 L66:
-  LessInt      r519, r518, r517
-  JumpIfFalse  r519, L62
-  Index        r520, r516, r518
-  Move         r521, r520
-  Const        r522, "ws_web_site_sk"
-  Index        r523, r505, r522
-  Const        r524, "web_site_sk"
-  Index        r525, r521, r524
-  Equal        r526, r523, r525
-  JumpIfFalse  r526, L63
+  LessInt      r514, r513, r512
+  JumpIfFalse  r514, L62
+  Index        r515, r511, r513
+  Move         r516, r515
+  Const        r517, "ws_web_site_sk"
+  Index        r518, r500, r517
+  Const        r519, "web_site_sk"
+  Index        r520, r516, r519
+  Equal        r521, r518, r520
+  JumpIfFalse  r521, L63
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r527, r511, r3
-  LessEq       r528, r46, r527
-  Index        r529, r511, r3
-  LessEq       r530, r529, r49
-  Move         r531, r528
-  JumpIfFalse  r531, L64
-  Move         r531, r530
+  Index        r522, r506, r3
+  LessEq       r523, r45, r522
+  Index        r524, r506, r3
+  LessEq       r525, r524, r48
+  Move         r526, r523
+  JumpIfFalse  r526, L64
+  Move         r526, r525
 L64:
-  JumpIfFalse  r531, L63
+  JumpIfFalse  r526, L63
   // from ws in web_sales
-  Move         r532, r505
-  Move         r533, r511
-  Const        r534, "w"
-  Move         r535, r521
-  Move         r536, r494
-  Move         r537, r532
-  Move         r538, r53
-  Move         r539, r533
-  Move         r540, r534
-  Move         r541, r535
-  MakeMap      r542, 3, r536
+  Move         r527, r500
+  Move         r528, r506
+  Const        r529, "w"
+  Move         r530, r516
+  Move         r531, r490
+  Move         r532, r527
+  Move         r533, r52
+  Move         r534, r528
+  Move         r535, r529
+  Move         r536, r530
+  MakeMap      r537, 3, r531
   // group by w.web_site_id into g
-  Index        r543, r521, r493
-  Str          r544, r543
-  In           r545, r544, r497
-  JumpIfTrue   r545, L65
-  Move         r546, r543
+  Index        r538, r516, r489
+  Str          r539, r538
+  In           r540, r539, r493
+  JumpIfTrue   r540, L65
+  Move         r541, r538
   // from ws in web_sales
-  Move         r547, r0
-  Move         r548, r67
-  Move         r549, r68
-  Move         r550, r6
-  Move         r551, r546
-  Move         r552, r70
-  Move         r553, r547
-  Move         r554, r72
-  Move         r555, r73
-  MakeMap      r556, 4, r548
-  SetIndex     r497, r544, r556
-  Append       r557, r498, r556
-  Move         r498, r557
+  Move         r542, r0
+  Move         r543, r66
+  Move         r544, r67
+  Move         r545, r6
+  Move         r546, r541
+  Move         r547, r69
+  Move         r548, r542
+  Move         r549, r71
+  Move         r550, r72
+  MakeMap      r551, 4, r543
+  SetIndex     r493, r539, r551
+  Append       r552, r494, r551
+  Move         r494, r552
 L65:
-  Index        r558, r497, r544
-  Index        r559, r558, r70
-  Append       r560, r559, r542
-  SetIndex     r558, r70, r560
-  Index        r561, r558, r72
-  AddInt       r562, r561, r88
-  SetIndex     r558, r72, r562
+  Index        r553, r493, r539
+  Index        r554, r553, r69
+  Append       r555, r554, r537
+  SetIndex     r553, r69, r555
+  Index        r556, r553, r71
+  AddInt       r557, r556, r87
+  SetIndex     r553, r71, r557
 L63:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  AddInt       r518, r518, r88
+  AddInt       r513, r513, r87
   Jump         L66
 L62:
   // join d in date_dim on ws.ws_sold_date_sk == d.d_date_sk
-  AddInt       r508, r508, r88
+  AddInt       r503, r503, r87
   Jump         L67
 L61:
   // from ws in web_sales
-  AddInt       r502, r502, r88
+  AddInt       r497, r497, r87
   Jump         L68
 L60:
-  Move         r563, r73
-  Len          r564, r498
+  Move         r558, r72
+  Len          r559, r494
 L74:
-  LessInt      r565, r563, r564
-  JumpIfFalse  r565, L69
-  Index        r566, r498, r563
-  Move         r94, r566
+  LessInt      r560, r558, r559
+  JumpIfFalse  r560, L69
+  Index        r561, r494, r558
+  Move         r93, r561
   // channel: "web channel",
-  Const        r567, "channel"
-  Const        r568, "web channel"
+  Const        r562, "channel"
+  Const        r563, "web channel"
   // id: "web_site" + str(g.key),
-  Const        r569, "id"
-  Const        r570, "web_site"
-  Index        r571, r94, r6
-  Str          r572, r571
-  Add          r573, r570, r572
+  Const        r564, "id"
+  Const        r565, "web_site"
+  Index        r566, r93, r6
+  Str          r567, r566
+  Add          r568, r565, r567
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Const        r574, "sales"
-  Const        r575, []
-  IterPrep     r576, r94
-  Len          r577, r576
-  Move         r578, r73
+  Const        r569, "sales"
+  Const        r570, []
+  IterPrep     r571, r93
+  Len          r572, r571
+  Move         r573, r72
 L71:
-  LessInt      r579, r578, r577
-  JumpIfFalse  r579, L70
-  Index        r580, r576, r578
-  Move         r109, r580
-  Index        r581, r109, r494
-  Index        r582, r581, r495
-  Append       r583, r575, r582
-  Move         r575, r583
-  AddInt       r578, r578, r88
+  LessInt      r574, r573, r572
+  JumpIfFalse  r574, L70
+  Index        r575, r571, r573
+  Move         r108, r575
+  Index        r576, r108, r490
+  Index        r577, r576, r491
+  Append       r578, r570, r577
+  Move         r570, r578
+  AddInt       r573, r573, r87
   Jump         L71
 L70:
-  Sum          r584, r575
+  Sum          r579, r570
   // returns: 0.0,
-  Const        r585, "returns"
+  Const        r580, "returns"
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Const        r586, "profit"
-  Const        r587, []
-  IterPrep     r588, r94
-  Len          r589, r588
-  Move         r590, r73
+  Const        r581, "profit"
+  Const        r582, []
+  IterPrep     r583, r93
+  Len          r584, r583
+  Move         r585, r72
 L73:
-  LessInt      r591, r590, r589
-  JumpIfFalse  r591, L72
-  Index        r592, r588, r590
-  Move         r109, r592
-  Index        r593, r109, r494
-  Index        r594, r593, r496
-  Append       r595, r587, r594
-  Move         r587, r595
-  AddInt       r590, r590, r88
+  LessInt      r586, r585, r584
+  JumpIfFalse  r586, L72
+  Index        r587, r583, r585
+  Move         r108, r587
+  Index        r588, r108, r490
+  Index        r589, r588, r492
+  Append       r590, r582, r589
+  Move         r582, r590
+  AddInt       r585, r585, r87
   Jump         L73
 L72:
-  Sum          r596, r587
+  Sum          r591, r582
   // profit_loss: 0.0
-  Const        r597, "profit_loss"
+  Const        r592, "profit_loss"
   // channel: "web channel",
-  Move         r598, r567
-  Move         r599, r568
+  Move         r593, r562
+  Move         r594, r563
   // id: "web_site" + str(g.key),
-  Move         r600, r569
-  Move         r601, r573
+  Move         r595, r564
+  Move         r596, r568
   // sales: sum(from x in g select x.ws.ws_ext_sales_price),
-  Move         r602, r574
-  Move         r603, r584
+  Move         r597, r569
+  Move         r598, r579
   // returns: 0.0,
-  Move         r604, r585
-  Move         r605, r115
+  Move         r599, r580
+  Move         r600, r114
   // profit: sum(from x in g select x.ws.ws_net_profit),
-  Move         r606, r586
-  Move         r607, r596
+  Move         r601, r581
+  Move         r602, r591
   // profit_loss: 0.0
-  Move         r608, r597
-  Move         r609, r115
+  Move         r603, r592
+  Move         r604, r114
   // select {
-  MakeMap      r610, 6, r598
+  MakeMap      r605, 6, r593
   // from ws in web_sales
-  Append       r611, r492, r610
-  Move         r492, r611
-  AddInt       r563, r563, r88
+  Append       r606, r488, r605
+  Move         r488, r606
+  AddInt       r558, r558, r87
   Jump         L74
 L69:
   // from wr in web_returns
-  Const        r612, []
+  Const        r607, []
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Const        r613, "wr"
-  Const        r614, "wr_return_amt"
+  Const        r608, "wr"
+  Const        r609, "wr_return_amt"
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Const        r615, "wr_net_loss"
+  Const        r610, "wr_net_loss"
   // from wr in web_returns
-  MakeMap      r616, 0, r0
-  Const        r618, []
-  Move         r617, r618
+  MakeMap      r611, 0, r0
+  Move         r612, r0
+  IterPrep     r613, r0
+  Len          r614, r613
+  Const        r615, 0
+L86:
+  LessInt      r616, r615, r614
+  JumpIfFalse  r616, L75
+  Index        r617, r613, r615
+  Move         r618, r617
+  // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
   IterPrep     r619, r0
   Len          r620, r619
   Const        r621, 0
-L86:
-  LessInt      r622, r621, r620
-  JumpIfFalse  r622, L75
-  Index        r623, r619, r621
-  Move         r624, r623
-  // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  IterPrep     r625, r0
-  Len          r626, r625
-  Const        r627, 0
 L85:
-  LessInt      r628, r627, r626
-  JumpIfFalse  r628, L76
-  Index        r629, r625, r627
-  Move         r492, r629
-  Const        r630, "wr_item_sk"
-  Index        r631, r624, r630
-  Const        r632, "ws_item_sk"
-  Index        r633, r492, r632
-  Equal        r634, r631, r633
-  Const        r635, "wr_order_number"
-  Index        r636, r624, r635
-  Const        r637, "ws_order_number"
-  Index        r638, r492, r637
-  Equal        r639, r636, r638
-  Move         r640, r634
-  JumpIfFalse  r640, L77
-  Move         r640, r639
+  LessInt      r622, r621, r620
+  JumpIfFalse  r622, L76
+  Index        r623, r619, r621
+  Move         r488, r623
+  Const        r624, "wr_item_sk"
+  Index        r625, r618, r624
+  Const        r626, "ws_item_sk"
+  Index        r627, r488, r626
+  Equal        r628, r625, r627
+  Const        r629, "wr_order_number"
+  Index        r630, r618, r629
+  Const        r631, "ws_order_number"
+  Index        r632, r488, r631
+  Equal        r633, r630, r632
+  Move         r634, r628
+  JumpIfFalse  r634, L77
+  Move         r634, r633
 L77:
-  JumpIfFalse  r640, L78
+  JumpIfFalse  r634, L78
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  IterPrep     r641, r0
-  Len          r642, r641
-  Const        r643, 0
+  IterPrep     r635, r0
+  Len          r636, r635
+  Const        r637, 0
 L84:
-  LessInt      r644, r643, r642
-  JumpIfFalse  r644, L78
-  Index        r645, r641, r643
-  Move         r646, r645
-  Const        r647, "wr_returned_date_sk"
-  Index        r648, r624, r647
-  Index        r649, r646, r31
-  Equal        r650, r648, r649
-  JumpIfFalse  r650, L79
+  LessInt      r638, r637, r636
+  JumpIfFalse  r638, L78
+  Index        r639, r635, r637
+  Move         r640, r639
+  Const        r641, "wr_returned_date_sk"
+  Index        r642, r618, r641
+  Index        r643, r640, r30
+  Equal        r644, r642, r643
+  JumpIfFalse  r644, L79
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  IterPrep     r651, r0
-  Len          r652, r651
-  Const        r653, 0
+  IterPrep     r645, r0
+  Len          r646, r645
+  Const        r647, 0
 L83:
-  LessInt      r654, r653, r652
-  JumpIfFalse  r654, L79
-  Index        r655, r651, r653
-  Move         r656, r655
-  Index        r657, r492, r522
-  Index        r658, r656, r524
-  Equal        r659, r657, r658
-  JumpIfFalse  r659, L80
+  LessInt      r648, r647, r646
+  JumpIfFalse  r648, L79
+  Index        r649, r645, r647
+  Move         r650, r649
+  Index        r651, r488, r517
+  Index        r652, r650, r519
+  Equal        r653, r651, r652
+  JumpIfFalse  r653, L80
   // where d.d_date >= "1998-12-01" && d.d_date <= "1998-12-15"
-  Index        r660, r646, r3
-  LessEq       r661, r46, r660
-  Index        r662, r646, r3
-  LessEq       r663, r662, r49
-  Move         r664, r661
-  JumpIfFalse  r664, L81
-  Move         r664, r663
+  Index        r654, r640, r3
+  LessEq       r655, r45, r654
+  Index        r656, r640, r3
+  LessEq       r657, r656, r48
+  Move         r658, r655
+  JumpIfFalse  r658, L81
+  Move         r658, r657
 L81:
-  JumpIfFalse  r664, L80
+  JumpIfFalse  r658, L80
   // from wr in web_returns
-  Move         r665, r624
-  Move         r666, r492
-  Move         r667, r646
-  Move         r668, r656
-  Move         r669, r613
-  Move         r670, r665
-  Move         r671, r494
-  Move         r672, r666
-  Move         r673, r53
-  Move         r674, r667
-  Move         r675, r534
-  Move         r676, r668
-  MakeMap      r677, 4, r669
+  Move         r659, r618
+  Move         r660, r488
+  Move         r661, r640
+  Move         r662, r650
+  Move         r663, r608
+  Move         r664, r659
+  Move         r665, r490
+  Move         r666, r660
+  Move         r667, r52
+  Move         r668, r661
+  Move         r669, r529
+  Move         r670, r662
+  MakeMap      r671, 4, r663
   // group by w.web_site_id into g
-  Index        r678, r656, r493
-  Str          r679, r678
-  In           r680, r679, r616
-  JumpIfTrue   r680, L82
-  Move         r681, r678
+  Index        r672, r650, r489
+  Str          r673, r672
+  In           r674, r673, r611
+  JumpIfTrue   r674, L82
+  Move         r675, r672
   // from wr in web_returns
-  Move         r682, r0
-  Move         r683, r67
-  Move         r684, r68
-  Move         r685, r6
-  Move         r686, r681
-  Move         r687, r70
-  Move         r688, r682
-  Move         r689, r72
-  Move         r690, r73
-  MakeMap      r691, 4, r683
-  SetIndex     r616, r679, r691
-  Append       r692, r617, r691
-  Move         r617, r692
+  Move         r676, r0
+  Move         r677, r66
+  Move         r678, r67
+  Move         r679, r6
+  Move         r680, r675
+  Move         r681, r69
+  Move         r682, r676
+  Move         r683, r71
+  Move         r684, r72
+  MakeMap      r685, 4, r677
+  SetIndex     r611, r673, r685
+  Append       r686, r612, r685
+  Move         r612, r686
 L82:
-  Index        r693, r616, r679
-  Index        r694, r693, r70
-  Append       r695, r694, r677
-  SetIndex     r693, r70, r695
-  Index        r696, r693, r72
-  AddInt       r697, r696, r88
-  SetIndex     r693, r72, r697
+  Index        r687, r611, r673
+  Index        r688, r687, r69
+  Append       r689, r688, r671
+  SetIndex     r687, r69, r689
+  Index        r690, r687, r71
+  AddInt       r691, r690, r87
+  SetIndex     r687, r71, r691
 L80:
   // join w in web_site on ws.ws_web_site_sk == w.web_site_sk
-  AddInt       r653, r653, r88
+  AddInt       r647, r647, r87
   Jump         L83
 L79:
   // join d in date_dim on wr.wr_returned_date_sk == d.d_date_sk
-  AddInt       r643, r643, r88
+  AddInt       r637, r637, r87
   Jump         L84
 L78:
   // join ws in web_sales on wr.wr_item_sk == ws.ws_item_sk && wr.wr_order_number == ws.ws_order_number
-  AddInt       r627, r627, r88
+  AddInt       r621, r621, r87
   Jump         L85
 L76:
   // from wr in web_returns
-  AddInt       r621, r621, r88
+  AddInt       r615, r615, r87
   Jump         L86
 L75:
-  Move         r698, r73
-  Len          r699, r617
+  Move         r692, r72
+  Len          r693, r612
 L92:
-  LessInt      r700, r698, r699
-  JumpIfFalse  r700, L87
-  Index        r701, r617, r698
-  Move         r94, r701
+  LessInt      r694, r692, r693
+  JumpIfFalse  r694, L87
+  Index        r695, r612, r692
+  Move         r93, r695
   // channel: "web channel",
-  Const        r702, "channel"
+  Const        r696, "channel"
   // id: "web_site" + str(g.key),
-  Const        r703, "id"
-  Index        r704, r94, r6
-  Str          r705, r704
-  Add          r706, r570, r705
+  Const        r697, "id"
+  Index        r698, r93, r6
+  Str          r699, r698
+  Add          r700, r565, r699
   // sales: 0.0,
-  Const        r707, "sales"
+  Const        r701, "sales"
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Const        r708, "returns"
-  Const        r709, []
-  IterPrep     r710, r94
-  Len          r711, r710
-  Move         r712, r73
+  Const        r702, "returns"
+  Const        r703, []
+  IterPrep     r704, r93
+  Len          r705, r704
+  Move         r706, r72
 L89:
-  LessInt      r713, r712, r711
-  JumpIfFalse  r713, L88
-  Index        r714, r710, r712
-  Move         r109, r714
-  Index        r715, r109, r613
-  Index        r716, r715, r614
-  Append       r717, r709, r716
-  Move         r709, r717
-  AddInt       r712, r712, r88
+  LessInt      r707, r706, r705
+  JumpIfFalse  r707, L88
+  Index        r708, r704, r706
+  Move         r108, r708
+  Index        r709, r108, r608
+  Index        r710, r709, r609
+  Append       r711, r703, r710
+  Move         r703, r711
+  AddInt       r706, r706, r87
   Jump         L89
 L88:
-  Sum          r718, r709
+  Sum          r712, r703
   // profit: 0.0,
-  Const        r719, "profit"
+  Const        r713, "profit"
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Const        r720, "profit_loss"
-  Const        r721, []
-  IterPrep     r722, r94
-  Len          r723, r722
-  Move         r724, r73
+  Const        r714, "profit_loss"
+  Const        r715, []
+  IterPrep     r716, r93
+  Len          r717, r716
+  Move         r718, r72
 L91:
-  LessInt      r725, r724, r723
-  JumpIfFalse  r725, L90
-  Index        r726, r722, r724
-  Move         r109, r726
-  Index        r727, r109, r613
-  Index        r728, r727, r615
-  Append       r729, r721, r728
-  Move         r721, r729
-  AddInt       r724, r724, r88
+  LessInt      r719, r718, r717
+  JumpIfFalse  r719, L90
+  Index        r720, r716, r718
+  Move         r108, r720
+  Index        r721, r108, r608
+  Index        r722, r721, r610
+  Append       r723, r715, r722
+  Move         r715, r723
+  AddInt       r718, r718, r87
   Jump         L91
 L90:
-  Sum          r730, r721
+  Sum          r724, r715
   // channel: "web channel",
-  Move         r731, r702
-  Move         r732, r568
+  Move         r725, r696
+  Move         r726, r563
   // id: "web_site" + str(g.key),
-  Move         r733, r703
-  Move         r734, r706
+  Move         r727, r697
+  Move         r728, r700
   // sales: 0.0,
-  Move         r735, r707
-  Move         r736, r115
+  Move         r729, r701
+  Move         r730, r114
   // returns: sum(from x in g select x.wr.wr_return_amt),
-  Move         r737, r708
-  Move         r738, r718
+  Move         r731, r702
+  Move         r732, r712
   // profit: 0.0,
-  Move         r739, r719
-  Move         r740, r115
+  Move         r733, r713
+  Move         r734, r114
   // profit_loss: sum(from x in g select x.wr.wr_net_loss)
-  Move         r741, r720
-  Move         r742, r730
+  Move         r735, r714
+  Move         r736, r724
   // select {
-  MakeMap      r743, 6, r731
+  MakeMap      r737, 6, r725
   // from wr in web_returns
-  Append       r744, r612, r743
-  Move         r612, r744
-  AddInt       r698, r698, r88
+  Append       r738, r607, r737
+  Move         r607, r738
+  AddInt       r692, r692, r87
   Jump         L92
 L87:
   // let per_channel = concat(ss union all sr, cs union all cr, ws union all wr)
-  UnionAll     r745, r1, r142
-  UnionAll     r746, r257, r377
-  UnionAll     r747, r745, r746
-  UnionAll     r748, r492, r612
-  UnionAll     r749, r747, r748
+  UnionAll     r739, r1, r141
+  UnionAll     r740, r255, r374
+  UnionAll     r741, r739, r740
+  UnionAll     r742, r488, r607
+  UnionAll     r743, r741, r742
   // from p in per_channel
-  Const        r750, []
+  Const        r744, []
   // sales: sum(from x in g select x.p.sales),
-  Const        r751, "p"
+  Const        r745, "p"
   // from p in per_channel
-  IterPrep     r752, r749
-  Len          r753, r752
-  Const        r754, 0
-  MakeMap      r755, 0, r0
-  Const        r757, []
-  Move         r756, r757
+  IterPrep     r746, r743
+  Len          r747, r746
+  Const        r748, 0
+  MakeMap      r749, 0, r0
+  Move         r750, r0
 L95:
-  LessInt      r758, r754, r753
-  JumpIfFalse  r758, L93
-  Index        r759, r752, r754
-  Move         r760, r759
+  LessInt      r751, r748, r747
+  JumpIfFalse  r751, L93
+  Index        r752, r746, r748
+  Move         r753, r752
   // group by { channel: p.channel, id: p.id } into g
-  Const        r761, "channel"
-  Index        r762, r760, r4
-  Const        r763, "id"
-  Index        r764, r760, r5
-  Move         r765, r761
-  Move         r766, r762
-  Move         r767, r763
-  Move         r768, r764
-  MakeMap      r769, 2, r765
-  Str          r770, r769
-  In           r771, r770, r755
-  JumpIfTrue   r771, L94
-  Move         r772, r769
+  Const        r754, "channel"
+  Index        r755, r753, r4
+  Const        r756, "id"
+  Index        r757, r753, r5
+  Move         r758, r754
+  Move         r759, r755
+  Move         r760, r756
+  Move         r761, r757
+  MakeMap      r762, 2, r758
+  Str          r763, r762
+  In           r764, r763, r749
+  JumpIfTrue   r764, L94
+  Move         r765, r762
   // from p in per_channel
-  Move         r773, r0
-  Move         r774, r67
-  Move         r775, r68
-  Move         r776, r6
-  Move         r777, r772
-  Move         r778, r70
-  Move         r779, r773
-  Move         r780, r72
-  Move         r781, r73
-  MakeMap      r782, 4, r774
-  SetIndex     r755, r770, r782
-  Append       r783, r756, r782
-  Move         r756, r783
+  Move         r766, r0
+  Move         r767, r66
+  Move         r768, r67
+  Move         r769, r6
+  Move         r770, r765
+  Move         r771, r69
+  Move         r772, r766
+  Move         r773, r71
+  Move         r774, r72
+  MakeMap      r775, 4, r767
+  SetIndex     r749, r763, r775
+  Append       r776, r750, r775
+  Move         r750, r776
 L94:
-  Index        r784, r755, r770
-  Index        r785, r784, r70
-  Append       r786, r785, r759
-  SetIndex     r784, r70, r786
-  Index        r787, r784, r72
-  AddInt       r788, r787, r88
-  SetIndex     r784, r72, r788
-  AddInt       r754, r754, r88
+  Index        r777, r749, r763
+  Index        r778, r777, r69
+  Append       r779, r778, r752
+  SetIndex     r777, r69, r779
+  Index        r780, r777, r71
+  AddInt       r781, r780, r87
+  SetIndex     r777, r71, r781
+  AddInt       r748, r748, r87
   Jump         L95
 L93:
-  Move         r789, r73
-  Len          r790, r756
+  Move         r782, r72
+  Len          r783, r750
 L105:
-  LessInt      r791, r789, r790
-  JumpIfFalse  r791, L96
-  Index        r792, r756, r789
-  Move         r94, r792
+  LessInt      r784, r782, r783
+  JumpIfFalse  r784, L96
+  Index        r785, r750, r782
+  Move         r93, r785
   // channel: g.key.channel,
-  Const        r793, "channel"
-  Index        r794, r94, r6
-  Index        r795, r794, r4
+  Const        r786, "channel"
+  Index        r787, r93, r6
+  Index        r788, r787, r4
   // id: g.key.id,
-  Const        r796, "id"
-  Index        r797, r94, r6
-  Index        r798, r797, r5
+  Const        r789, "id"
+  Index        r790, r93, r6
+  Index        r791, r790, r5
   // sales: sum(from x in g select x.p.sales),
-  Const        r799, "sales"
-  Const        r800, []
-  IterPrep     r801, r94
-  Len          r802, r801
-  Move         r803, r73
+  Const        r792, "sales"
+  Const        r793, []
+  IterPrep     r794, r93
+  Len          r795, r794
+  Move         r796, r72
 L98:
-  LessInt      r804, r803, r802
-  JumpIfFalse  r804, L97
-  Index        r805, r801, r803
-  Move         r109, r805
-  Index        r806, r109, r751
-  Index        r807, r806, r7
-  Append       r808, r800, r807
-  Move         r800, r808
-  AddInt       r803, r803, r88
+  LessInt      r797, r796, r795
+  JumpIfFalse  r797, L97
+  Index        r798, r794, r796
+  Move         r108, r798
+  Index        r799, r108, r745
+  Index        r800, r799, r7
+  Append       r801, r793, r800
+  Move         r793, r801
+  AddInt       r796, r796, r87
   Jump         L98
 L97:
-  Sum          r809, r800
+  Sum          r802, r793
   // returns: sum(from x in g select x.p.returns),
-  Const        r810, "returns"
-  Const        r811, []
-  IterPrep     r812, r94
-  Len          r813, r812
-  Move         r814, r73
+  Const        r803, "returns"
+  Const        r804, []
+  IterPrep     r805, r93
+  Len          r806, r805
+  Move         r807, r72
 L100:
-  LessInt      r815, r814, r813
-  JumpIfFalse  r815, L99
-  Index        r816, r812, r814
-  Move         r109, r816
-  Index        r817, r109, r751
-  Index        r818, r817, r10
-  Append       r819, r811, r818
-  Move         r811, r819
-  AddInt       r814, r814, r88
+  LessInt      r808, r807, r806
+  JumpIfFalse  r808, L99
+  Index        r809, r805, r807
+  Move         r108, r809
+  Index        r810, r108, r745
+  Index        r811, r810, r10
+  Append       r812, r804, r811
+  Move         r804, r812
+  AddInt       r807, r807, r87
   Jump         L100
 L99:
-  Sum          r820, r811
+  Sum          r813, r804
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Const        r821, "profit"
-  Const        r822, []
-  IterPrep     r823, r94
-  Len          r824, r823
-  Move         r825, r73
+  Const        r814, "profit"
+  Const        r815, []
+  IterPrep     r816, r93
+  Len          r817, r816
+  Move         r818, r72
 L102:
-  LessInt      r826, r825, r824
-  JumpIfFalse  r826, L101
-  Index        r827, r823, r825
-  Move         r109, r827
-  Index        r828, r109, r751
-  Index        r829, r828, r11
-  Append       r830, r822, r829
-  Move         r822, r830
-  AddInt       r825, r825, r88
+  LessInt      r819, r818, r817
+  JumpIfFalse  r819, L101
+  Index        r820, r816, r818
+  Move         r108, r820
+  Index        r821, r108, r745
+  Index        r822, r821, r11
+  Append       r823, r815, r822
+  Move         r815, r823
+  AddInt       r818, r818, r87
   Jump         L102
 L101:
-  Sum          r831, r822
-  Const        r832, []
-  IterPrep     r833, r94
-  Len          r834, r833
-  Move         r835, r73
+  Sum          r824, r815
+  Const        r825, []
+  IterPrep     r826, r93
+  Len          r827, r826
+  Move         r828, r72
 L104:
-  LessInt      r836, r835, r834
-  JumpIfFalse  r836, L103
-  Index        r837, r833, r835
-  Move         r109, r837
-  Index        r838, r109, r751
-  Index        r839, r838, r13
-  Append       r840, r832, r839
-  Move         r832, r840
-  AddInt       r835, r835, r88
+  LessInt      r829, r828, r827
+  JumpIfFalse  r829, L103
+  Index        r830, r826, r828
+  Move         r108, r830
+  Index        r831, r108, r745
+  Index        r832, r831, r13
+  Append       r833, r825, r832
+  Move         r825, r833
+  AddInt       r828, r828, r87
   Jump         L104
 L103:
-  Sum          r841, r832
-  Sub          r842, r831, r841
+  Sum          r834, r825
+  Sub          r835, r824, r834
   // channel: g.key.channel,
-  Move         r843, r793
-  Move         r844, r795
+  Move         r836, r786
+  Move         r837, r788
   // id: g.key.id,
-  Move         r845, r796
-  Move         r846, r798
+  Move         r838, r789
+  Move         r839, r791
   // sales: sum(from x in g select x.p.sales),
-  Move         r847, r799
-  Move         r848, r809
+  Move         r840, r792
+  Move         r841, r802
   // returns: sum(from x in g select x.p.returns),
-  Move         r849, r810
-  Move         r850, r820
+  Move         r842, r803
+  Move         r843, r813
   // profit: sum(from x in g select x.p.profit) - sum(from x in g select x.p.profit_loss)
-  Move         r851, r821
-  Move         r852, r842
+  Move         r844, r814
+  Move         r845, r835
   // select {
-  MakeMap      r853, 5, r843
+  MakeMap      r846, 5, r836
   // sort by g.key.channel
-  Index        r854, r94, r6
-  Index        r855, r854, r4
-  Move         r856, r855
+  Index        r847, r93, r6
+  Index        r848, r847, r4
+  Move         r849, r848
   // from p in per_channel
-  Move         r857, r853
-  MakeList     r858, 2, r856
-  Append       r859, r750, r858
-  Move         r750, r859
-  AddInt       r789, r789, r88
+  Move         r850, r846
+  MakeList     r851, 2, r849
+  Append       r852, r744, r851
+  Move         r744, r852
+  AddInt       r782, r782, r87
   Jump         L105
 L96:
   // sort by g.key.channel
-  Sort         r860, r750
+  Sort         r853, r744
   // from p in per_channel
-  Move         r750, r860
+  Move         r744, r853
   // json(result)
-  JSON         r750
+  JSON         r744
   // expect len(result) == 0
-  Len          r861, r750
-  EqualInt     r862, r861, r73
-  Expect       r862
+  Len          r854, r744
+  EqualInt     r855, r854, r72
+  Expect       r855
   Return       r0

--- a/tests/dataset/tpc-ds/out/q6.ir.out
+++ b/tests/dataset/tpc-ds/out/q6.ir.out
@@ -1,4 +1,4 @@
-func main (regs=179)
+func main (regs=178)
   // let customer_address = []
   Const        r0, []
   // from d in date_dim
@@ -56,127 +56,127 @@ L0:
   Const        r29, "cnt"
   // from a in customer_address
   MakeMap      r30, 0, r0
-  Const        r32, []
-  Move         r31, r32
-  IterPrep     r33, r0
-  Len          r34, r33
-  Const        r35, 0
+  Move         r31, r0
+  IterPrep     r32, r0
+  Len          r33, r32
+  Const        r34, 0
 L19:
-  LessInt      r36, r35, r34
-  JumpIfFalse  r36, L4
-  Index        r37, r33, r35
-  Move         r38, r37
+  LessInt      r35, r34, r33
+  JumpIfFalse  r35, L4
+  Index        r36, r32, r34
+  Move         r37, r36
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  IterPrep     r39, r0
-  Len          r40, r39
-  Const        r41, 0
+  IterPrep     r38, r0
+  Len          r39, r38
+  Const        r40, 0
 L18:
-  LessInt      r42, r41, r40
-  JumpIfFalse  r42, L5
-  Index        r43, r39, r41
-  Move         r44, r43
-  Const        r45, "ca_address_sk"
-  Index        r46, r38, r45
-  Const        r47, "c_current_addr_sk"
-  Index        r48, r44, r47
-  Equal        r49, r46, r48
-  JumpIfFalse  r49, L6
+  LessInt      r41, r40, r39
+  JumpIfFalse  r41, L5
+  Index        r42, r38, r40
+  Move         r43, r42
+  Const        r44, "ca_address_sk"
+  Index        r45, r37, r44
+  Const        r46, "c_current_addr_sk"
+  Index        r47, r43, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L6
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  IterPrep     r50, r0
-  Len          r51, r50
-  Const        r52, 0
+  IterPrep     r49, r0
+  Len          r50, r49
+  Const        r51, 0
 L17:
-  LessInt      r53, r52, r51
-  JumpIfFalse  r53, L6
-  Index        r54, r50, r52
-  Move         r55, r54
-  Const        r56, "c_customer_sk"
-  Index        r57, r44, r56
-  Const        r58, "ss_customer_sk"
-  Index        r59, r55, r58
-  Equal        r60, r57, r59
-  JumpIfFalse  r60, L7
+  LessInt      r52, r51, r50
+  JumpIfFalse  r52, L6
+  Index        r53, r49, r51
+  Move         r54, r53
+  Const        r55, "c_customer_sk"
+  Index        r56, r43, r55
+  Const        r57, "ss_customer_sk"
+  Index        r58, r54, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L7
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r61, r0
-  Len          r62, r61
-  Const        r63, 0
+  IterPrep     r60, r0
+  Len          r61, r60
+  Const        r62, 0
 L16:
-  LessInt      r64, r63, r62
-  JumpIfFalse  r64, L7
-  Index        r65, r61, r63
-  Move         r11, r65
-  Const        r66, "ss_sold_date_sk"
-  Index        r67, r55, r66
-  Const        r68, "d_date_sk"
-  Index        r69, r11, r68
-  Equal        r70, r67, r69
-  JumpIfFalse  r70, L8
+  LessInt      r63, r62, r61
+  JumpIfFalse  r63, L7
+  Index        r64, r60, r62
+  Move         r11, r64
+  Const        r65, "ss_sold_date_sk"
+  Index        r66, r54, r65
+  Const        r67, "d_date_sk"
+  Index        r68, r11, r67
+  Equal        r69, r66, r68
+  JumpIfFalse  r69, L8
   // join i in item on s.ss_item_sk == i.i_item_sk
-  IterPrep     r71, r0
-  Len          r72, r71
-  Const        r73, 0
+  IterPrep     r70, r0
+  Len          r71, r70
+  Const        r72, 0
 L15:
-  LessInt      r74, r73, r72
-  JumpIfFalse  r74, L8
-  Index        r75, r71, r73
-  Move         r76, r75
-  Const        r77, "ss_item_sk"
-  Index        r78, r55, r77
-  Const        r79, "i_item_sk"
-  Index        r80, r76, r79
-  Equal        r81, r78, r80
-  JumpIfFalse  r81, L9
+  LessInt      r73, r72, r71
+  JumpIfFalse  r73, L8
+  Index        r74, r70, r72
+  Move         r75, r74
+  Const        r76, "ss_item_sk"
+  Index        r77, r54, r76
+  Const        r78, "i_item_sk"
+  Index        r79, r75, r78
+  Equal        r80, r77, r79
+  JumpIfFalse  r80, L9
   // where d.d_month_seq == target_month_seq &&
-  Index        r82, r11, r4
+  Index        r81, r11, r4
   // i.i_current_price > 1.2 * avg(
-  Const        r83, 1.2
+  Const        r82, 1.2
   // from j in item
-  Const        r84, []
-  IterPrep     r85, r0
-  Len          r86, r85
-  Move         r87, r8
+  Const        r83, []
+  IterPrep     r84, r0
+  Len          r85, r84
+  Move         r86, r8
 L12:
-  LessInt      r88, r87, r86
-  JumpIfFalse  r88, L10
-  Index        r89, r85, r87
-  Move         r90, r89
+  LessInt      r87, r86, r85
+  JumpIfFalse  r87, L10
+  Index        r88, r84, r86
+  Move         r89, r88
   // where j.i_category == i.i_category
-  Index        r91, r90, r26
-  Index        r92, r76, r26
-  Equal        r93, r91, r92
-  JumpIfFalse  r93, L11
+  Index        r90, r89, r26
+  Index        r91, r75, r26
+  Equal        r92, r90, r91
+  JumpIfFalse  r92, L11
   // select j.i_current_price
-  Index        r94, r90, r25
+  Index        r93, r89, r25
   // from j in item
-  Append       r95, r84, r94
-  Move         r84, r95
+  Append       r94, r83, r93
+  Move         r83, r94
 L11:
-  AddInt       r87, r87, r21
+  AddInt       r86, r86, r21
   Jump         L12
 L10:
   // i.i_current_price > 1.2 * avg(
-  Avg          r96, r84
-  MulFloat     r97, r83, r96
-  Index        r98, r76, r25
-  LessFloat    r99, r97, r98
+  Avg          r95, r83
+  MulFloat     r96, r82, r95
+  Index        r97, r75, r25
+  LessFloat    r98, r96, r97
   // where d.d_month_seq == target_month_seq &&
-  Equal        r100, r82, r22
-  Move         r101, r100
-  JumpIfFalse  r101, L13
-  Move         r101, r99
+  Equal        r99, r81, r22
+  Move         r100, r99
+  JumpIfFalse  r100, L13
+  Move         r100, r98
 L13:
-  JumpIfFalse  r101, L9
+  JumpIfFalse  r100, L9
   // from a in customer_address
-  Const        r102, "a"
-  Move         r103, r38
-  Const        r104, "c"
-  Move         r105, r44
-  Const        r106, "s"
-  Move         r107, r55
-  Const        r108, "d"
-  Move         r109, r11
-  Const        r110, "i"
-  Move         r111, r76
+  Const        r101, "a"
+  Move         r102, r37
+  Const        r103, "c"
+  Move         r104, r43
+  Const        r105, "s"
+  Move         r106, r54
+  Const        r107, "d"
+  Move         r108, r11
+  Const        r109, "i"
+  Move         r110, r75
+  Move         r111, r101
   Move         r112, r102
   Move         r113, r103
   Move         r114, r104
@@ -186,114 +186,113 @@ L13:
   Move         r118, r108
   Move         r119, r109
   Move         r120, r110
-  Move         r121, r111
-  MakeMap      r122, 5, r112
+  MakeMap      r121, 5, r111
   // group by a.ca_state into g
-  Index        r123, r38, r24
-  Str          r124, r123
-  In           r125, r124, r30
-  JumpIfTrue   r125, L14
+  Index        r122, r37, r24
+  Str          r123, r122
+  In           r124, r123, r30
+  JumpIfTrue   r124, L14
   // from a in customer_address
-  Const        r126, "__group__"
-  Const        r127, true
+  Const        r125, "__group__"
+  Const        r126, true
   // group by a.ca_state into g
-  Move         r128, r123
+  Move         r127, r122
   // from a in customer_address
-  Const        r129, "items"
-  Move         r130, r0
-  Const        r131, "count"
+  Const        r128, "items"
+  Move         r129, r0
+  Const        r130, "count"
+  Move         r131, r125
   Move         r132, r126
-  Move         r133, r127
-  Move         r134, r28
+  Move         r133, r28
+  Move         r134, r127
   Move         r135, r128
   Move         r136, r129
   Move         r137, r130
-  Move         r138, r131
-  Move         r139, r8
-  MakeMap      r140, 4, r132
-  SetIndex     r30, r124, r140
-  Append       r141, r31, r140
-  Move         r31, r141
+  Move         r138, r8
+  MakeMap      r139, 4, r131
+  SetIndex     r30, r123, r139
+  Append       r140, r31, r139
+  Move         r31, r140
 L14:
-  Index        r142, r30, r124
-  Index        r143, r142, r129
-  Append       r144, r143, r122
-  SetIndex     r142, r129, r144
-  Index        r145, r142, r131
-  AddInt       r146, r145, r21
-  SetIndex     r142, r131, r146
+  Index        r141, r30, r123
+  Index        r142, r141, r128
+  Append       r143, r142, r121
+  SetIndex     r141, r128, r143
+  Index        r144, r141, r130
+  AddInt       r145, r144, r21
+  SetIndex     r141, r130, r145
 L9:
   // join i in item on s.ss_item_sk == i.i_item_sk
-  AddInt       r73, r73, r21
+  AddInt       r72, r72, r21
   Jump         L15
 L8:
   // join d in date_dim on s.ss_sold_date_sk == d.d_date_sk
-  AddInt       r63, r63, r21
+  AddInt       r62, r62, r21
   Jump         L16
 L7:
   // join s in store_sales on c.c_customer_sk == s.ss_customer_sk
-  AddInt       r52, r52, r21
+  AddInt       r51, r51, r21
   Jump         L17
 L6:
   // join c in customer on a.ca_address_sk == c.c_current_addr_sk
-  AddInt       r41, r41, r21
+  AddInt       r40, r40, r21
   Jump         L18
 L5:
   // from a in customer_address
-  AddInt       r35, r35, r21
+  AddInt       r34, r34, r21
   Jump         L19
 L4:
-  Move         r147, r8
-  Len          r148, r31
+  Move         r146, r8
+  Len          r147, r31
 L21:
-  LessInt      r149, r147, r148
-  JumpIfFalse  r149, L20
-  Index        r150, r31, r147
-  Move         r151, r150
+  LessInt      r148, r146, r147
+  JumpIfFalse  r148, L20
+  Index        r149, r31, r146
+  Move         r150, r149
   // having count(g) >= 10
-  Index        r152, r151, r131
-  Const        r153, 10
-  LessEq       r154, r153, r152
-  JumpIfFalse  r154, L20
+  Index        r151, r150, r130
+  Const        r152, 10
+  LessEq       r153, r152, r151
+  JumpIfFalse  r153, L20
   // select { state: g.key, cnt: count(g) }
-  Const        r155, "state"
-  Index        r156, r151, r28
-  Const        r157, "cnt"
-  Index        r158, r151, r131
+  Const        r154, "state"
+  Index        r155, r150, r28
+  Const        r156, "cnt"
+  Index        r157, r150, r130
+  Move         r158, r154
   Move         r159, r155
   Move         r160, r156
   Move         r161, r157
-  Move         r162, r158
-  MakeMap      r163, 2, r159
+  MakeMap      r162, 2, r158
   // sort by [count(g), g.key]
-  Index        r164, r151, r131
-  Move         r165, r164
-  Index        r166, r151, r28
-  Move         r167, r166
-  MakeList     r168, 2, r165
-  Move         r169, r168
+  Index        r163, r150, r130
+  Move         r164, r163
+  Index        r165, r150, r28
+  Move         r166, r165
+  MakeList     r167, 2, r164
+  Move         r168, r167
   // from a in customer_address
-  Move         r170, r163
-  MakeList     r171, 2, r169
-  Append       r172, r23, r171
-  Move         r23, r172
-  AddInt       r147, r147, r21
+  Move         r169, r162
+  MakeList     r170, 2, r168
+  Append       r171, r23, r170
+  Move         r23, r171
+  AddInt       r146, r146, r21
   Jump         L21
 L20:
   // sort by [count(g), g.key]
-  Sort         r173, r23
+  Sort         r172, r23
   // from a in customer_address
-  Move         r23, r173
-  Const        r174, 0
+  Move         r23, r172
+  Const        r173, 0
   // take 100
-  Const        r175, 100
+  Const        r174, 100
   // from a in customer_address
-  Slice        r176, r23, r174, r175
-  Move         r23, r176
+  Slice        r175, r23, r173, r174
+  Move         r23, r175
   // json(result)
   JSON         r23
   // expect len(result) == 0
-  Len          r177, r23
-  EqualInt     r178, r177, r8
-  Expect       r178
+  Len          r176, r23
+  EqualInt     r177, r176, r8
+  Expect       r177
   Return       r0

--- a/tests/dataset/tpc-ds/out/q7.ir.out
+++ b/tests/dataset/tpc-ds/out/q7.ir.out
@@ -1,4 +1,4 @@
-func main (regs=217)
+func main (regs=213)
   // let store_sales = []
   Const        r0, []
   // from ss in store_sales
@@ -33,330 +33,324 @@ func main (regs=217)
   Const        r18, "ss_sales_price"
   // from ss in store_sales
   MakeMap      r19, 0, r0
-  Const        r21, []
-  Move         r20, r21
-  IterPrep     r22, r0
-  Len          r23, r22
-  Const        r24, 0
-L16:
-  LessInt      r25, r24, r23
-  JumpIfFalse  r25, L0
-  Index        r26, r22, r24
-  Move         r27, r26
-  // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
-  IterPrep     r28, r0
-  Len          r29, r28
-  Const        r30, 0
-L15:
-  LessInt      r31, r30, r29
-  JumpIfFalse  r31, L1
-  Index        r32, r28, r30
-  Move         r33, r32
-  Const        r34, "ss_cdemo_sk"
-  Index        r35, r27, r34
-  Const        r36, "cd_demo_sk"
-  Index        r37, r33, r36
-  Equal        r38, r35, r37
-  JumpIfFalse  r38, L2
-  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  IterPrep     r39, r0
-  Len          r40, r39
-  Const        r41, 0
-L14:
-  LessInt      r42, r41, r40
-  JumpIfFalse  r42, L2
-  Index        r43, r39, r41
-  Move         r44, r43
-  Const        r45, "ss_sold_date_sk"
-  Index        r46, r27, r45
-  Const        r47, "d_date_sk"
-  Index        r48, r44, r47
-  Equal        r49, r46, r48
-  JumpIfFalse  r49, L3
-  // join i in item on ss.ss_item_sk == i.i_item_sk
-  IterPrep     r50, r0
-  Len          r51, r50
-  Const        r52, 0
+  Move         r20, r0
+  IterPrep     r21, r0
+  Len          r22, r21
+  Const        r23, 0
 L13:
-  LessInt      r53, r52, r51
-  JumpIfFalse  r53, L3
-  Index        r54, r50, r52
-  Move         r55, r54
-  Const        r56, "ss_item_sk"
-  Index        r57, r27, r56
-  Const        r58, "i_item_sk"
-  Index        r59, r55, r58
-  Equal        r60, r57, r59
-  JumpIfFalse  r60, L4
-  // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
-  IterPrep     r61, r0
-  Len          r62, r61
-  Const        r63, 0
+  LessInt      r24, r23, r22
+  JumpIfFalse  r24, L0
+  Index        r25, r21, r23
+  Move         r26, r25
+  // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
+  IterPrep     r27, r0
+  Len          r28, r27
+  Const        r29, 0
 L12:
-  LessInt      r64, r63, r62
-  JumpIfFalse  r64, L4
-  Index        r65, r61, r63
-  Move         r66, r65
-  Const        r67, "ss_promo_sk"
-  Index        r68, r27, r67
-  Const        r69, "p_promo_sk"
-  Index        r70, r66, r69
-  Equal        r71, r68, r70
-  JumpIfFalse  r71, L5
-  // where cd.cd_gender == "M" &&
-  Index        r72, r33, r3
-  Const        r73, "M"
-  Equal        r74, r72, r73
-  // cd.cd_marital_status == "S" &&
-  Index        r75, r33, r4
-  Const        r76, "S"
-  Equal        r77, r75, r76
-  // cd.cd_education_status == "College" &&
-  Index        r78, r33, r5
-  Const        r79, "College"
-  Equal        r80, r78, r79
-  // d.d_year == 1998
-  Index        r81, r44, r8
-  Const        r82, 1998
-  Equal        r83, r81, r82
-  // where cd.cd_gender == "M" &&
-  Move         r84, r74
-  JumpIfFalse  r84, L6
-  Move         r84, r77
-L6:
-  // cd.cd_marital_status == "S" &&
-  Move         r85, r84
-  JumpIfFalse  r85, L7
-  Move         r85, r80
-L7:
-  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  Index        r86, r66, r6
-  Const        r87, "N"
-  Equal        r88, r86, r87
-  Index        r89, r66, r7
-  Equal        r90, r89, r87
-  Move         r91, r88
-  JumpIfTrue   r91, L8
-  Move         r91, r90
-L8:
-  // cd.cd_education_status == "College" &&
-  Move         r92, r85
-  JumpIfFalse  r92, L9
-  Move         r92, r91
-L9:
-  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
-  Move         r93, r92
-  JumpIfFalse  r93, L10
-  Move         r93, r83
+  LessInt      r30, r29, r28
+  JumpIfFalse  r30, L1
+  Index        r31, r27, r29
+  Move         r32, r31
+  Const        r33, "ss_cdemo_sk"
+  Index        r34, r26, r33
+  Const        r35, "cd_demo_sk"
+  Index        r36, r32, r35
+  Equal        r37, r34, r36
+  JumpIfFalse  r37, L2
+  // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
+  IterPrep     r38, r0
+  Len          r39, r38
+  Const        r40, 0
+L11:
+  LessInt      r41, r40, r39
+  JumpIfFalse  r41, L2
+  Index        r42, r38, r40
+  Move         r43, r42
+  Const        r44, "ss_sold_date_sk"
+  Index        r45, r26, r44
+  Const        r46, "d_date_sk"
+  Index        r47, r43, r46
+  Equal        r48, r45, r47
+  JumpIfFalse  r48, L3
+  // join i in item on ss.ss_item_sk == i.i_item_sk
+  IterPrep     r49, r0
+  Len          r50, r49
+  Const        r51, 0
 L10:
+  LessInt      r52, r51, r50
+  JumpIfFalse  r52, L3
+  Index        r53, r49, r51
+  Move         r54, r53
+  Const        r55, "ss_item_sk"
+  Index        r56, r26, r55
+  Const        r57, "i_item_sk"
+  Index        r58, r54, r57
+  Equal        r59, r56, r58
+  JumpIfFalse  r59, L4
+  // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
+  IterPrep     r60, r0
+  Len          r61, r60
+  Const        r62, 0
+L9:
+  LessInt      r63, r62, r61
+  JumpIfFalse  r63, L4
+  Index        r64, r60, r62
+  Move         r65, r64
+  Const        r66, "ss_promo_sk"
+  Index        r67, r26, r66
+  Const        r68, "p_promo_sk"
+  Index        r69, r65, r68
+  Equal        r70, r67, r69
+  JumpIfFalse  r70, L5
   // where cd.cd_gender == "M" &&
-  JumpIfFalse  r93, L5
+  Index        r71, r32, r3
+  Const        r72, "M"
+  Equal        r73, r71, r72
+  // cd.cd_marital_status == "S" &&
+  Index        r74, r32, r4
+  Const        r75, "S"
+  Equal        r76, r74, r75
+  // cd.cd_education_status == "College" &&
+  Index        r77, r32, r5
+  Const        r78, "College"
+  Equal        r79, r77, r78
+  // d.d_year == 1998
+  Index        r80, r43, r8
+  Const        r81, 1998
+  Equal        r82, r80, r81
+  // where cd.cd_gender == "M" &&
+  Move         r83, r73
+  JumpIfFalse  r83, L6
+  Move         r83, r76
+  // cd.cd_marital_status == "S" &&
+  JumpIfFalse  r83, L6
+  Move         r83, r79
+  // cd.cd_education_status == "College" &&
+  JumpIfFalse  r83, L6
+  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
+  Index        r84, r65, r6
+  Const        r85, "N"
+  Equal        r86, r84, r85
+  Index        r87, r65, r7
+  Equal        r88, r87, r85
+  Move         r89, r86
+  JumpIfTrue   r89, L7
+  Move         r89, r88
+L7:
+  // cd.cd_education_status == "College" &&
+  Move         r83, r89
+  // (p.p_channel_email == "N" || p.p_channel_event == "N") &&
+  JumpIfFalse  r83, L6
+  Move         r83, r82
+L6:
+  // where cd.cd_gender == "M" &&
+  JumpIfFalse  r83, L5
   // from ss in store_sales
-  Move         r94, r27
-  Const        r95, "cd"
-  Move         r96, r33
-  Const        r97, "d"
-  Move         r98, r44
-  Const        r99, "i"
-  Move         r100, r55
-  Const        r101, "p"
-  Move         r102, r66
-  Move         r103, r11
+  Move         r90, r26
+  Const        r91, "cd"
+  Move         r92, r32
+  Const        r93, "d"
+  Move         r94, r43
+  Const        r95, "i"
+  Move         r96, r54
+  Const        r97, "p"
+  Move         r98, r65
+  Move         r99, r11
+  Move         r100, r90
+  Move         r101, r91
+  Move         r102, r92
+  Move         r103, r93
   Move         r104, r94
   Move         r105, r95
   Move         r106, r96
   Move         r107, r97
   Move         r108, r98
-  Move         r109, r99
-  Move         r110, r100
-  Move         r111, r101
-  Move         r112, r102
-  MakeMap      r113, 5, r103
+  MakeMap      r109, 5, r99
   // group by { i_item_id: i.i_item_id } into g
-  Const        r114, "i_item_id"
-  Index        r115, r55, r2
-  Move         r116, r114
-  Move         r117, r115
-  MakeMap      r118, 1, r116
-  Str          r119, r118
-  In           r120, r119, r19
-  JumpIfTrue   r120, L11
+  Const        r110, "i_item_id"
+  Index        r111, r54, r2
+  Move         r112, r110
+  Move         r113, r111
+  MakeMap      r114, 1, r112
+  Str          r115, r114
+  In           r116, r115, r19
+  JumpIfTrue   r116, L8
   // from ss in store_sales
-  Const        r121, "__group__"
-  Const        r122, true
+  Const        r117, "__group__"
+  Const        r118, true
   // group by { i_item_id: i.i_item_id } into g
-  Move         r123, r118
+  Move         r119, r114
   // from ss in store_sales
-  Const        r124, "items"
-  Move         r125, r0
-  Const        r126, "count"
-  Const        r127, 0
-  Move         r128, r121
-  Move         r129, r122
-  Move         r130, r9
+  Const        r120, "items"
+  Move         r121, r0
+  Const        r122, "count"
+  Const        r123, 0
+  Move         r124, r117
+  Move         r125, r118
+  Move         r126, r9
+  Move         r127, r119
+  Move         r128, r120
+  Move         r129, r121
+  Move         r130, r122
   Move         r131, r123
-  Move         r132, r124
-  Move         r133, r125
-  Move         r134, r126
-  Move         r135, r127
-  MakeMap      r136, 4, r128
-  SetIndex     r19, r119, r136
-  Append       r137, r20, r136
-  Move         r20, r137
-L11:
-  Index        r138, r19, r119
-  Index        r139, r138, r124
-  Append       r140, r139, r113
-  SetIndex     r138, r124, r140
-  Index        r141, r138, r126
-  Const        r142, 1
-  AddInt       r143, r141, r142
-  SetIndex     r138, r126, r143
+  MakeMap      r132, 4, r124
+  SetIndex     r19, r115, r132
+  Append       r133, r20, r132
+  Move         r20, r133
+L8:
+  Index        r134, r19, r115
+  Index        r135, r134, r120
+  Append       r136, r135, r109
+  SetIndex     r134, r120, r136
+  Index        r137, r134, r122
+  Const        r138, 1
+  AddInt       r139, r137, r138
+  SetIndex     r134, r122, r139
 L5:
   // join p in promotion on ss.ss_promo_sk == p.p_promo_sk
-  AddInt       r63, r63, r142
-  Jump         L12
+  AddInt       r62, r62, r138
+  Jump         L9
 L4:
   // join i in item on ss.ss_item_sk == i.i_item_sk
-  AddInt       r52, r52, r142
-  Jump         L13
+  AddInt       r51, r51, r138
+  Jump         L10
 L3:
   // join d in date_dim on ss.ss_sold_date_sk == d.d_date_sk
-  AddInt       r41, r41, r142
-  Jump         L14
+  AddInt       r40, r40, r138
+  Jump         L11
 L2:
   // join cd in customer_demographics on ss.ss_cdemo_sk == cd.cd_demo_sk
-  AddInt       r30, r30, r142
-  Jump         L15
+  AddInt       r29, r29, r138
+  Jump         L12
 L1:
   // from ss in store_sales
-  AddInt       r24, r24, r142
-  Jump         L16
+  AddInt       r23, r23, r138
+  Jump         L13
 L0:
-  Move         r144, r127
-  Len          r145, r20
-L26:
-  LessInt      r146, r144, r145
-  JumpIfFalse  r146, L17
-  Index        r147, r20, r144
-  Move         r148, r147
-  // i_item_id: g.key.i_item_id,
-  Const        r149, "i_item_id"
-  Index        r150, r148, r9
-  Index        r151, r150, r2
-  // agg1: avg(from x in g select x.ss.ss_quantity),
-  Const        r152, "agg1"
-  Const        r153, []
-  IterPrep     r154, r148
-  Len          r155, r154
-  Move         r156, r127
-L19:
-  LessInt      r157, r156, r155
-  JumpIfFalse  r157, L18
-  Index        r158, r154, r156
-  Move         r159, r158
-  Index        r160, r159, r11
-  Index        r161, r160, r12
-  Append       r162, r153, r161
-  Move         r153, r162
-  AddInt       r156, r156, r142
-  Jump         L19
-L18:
-  Avg          r163, r153
-  // agg2: avg(from x in g select x.ss.ss_list_price),
-  Const        r164, "agg2"
-  Const        r165, []
-  IterPrep     r166, r148
-  Len          r167, r166
-  Move         r168, r127
-L21:
-  LessInt      r169, r168, r167
-  JumpIfFalse  r169, L20
-  Index        r170, r166, r168
-  Move         r159, r170
-  Index        r171, r159, r11
-  Index        r172, r171, r14
-  Append       r173, r165, r172
-  Move         r165, r173
-  AddInt       r168, r168, r142
-  Jump         L21
-L20:
-  Avg          r174, r165
-  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Const        r175, "agg3"
-  Const        r176, []
-  IterPrep     r177, r148
-  Len          r178, r177
-  Move         r179, r127
+  Move         r140, r123
+  Len          r141, r20
 L23:
-  LessInt      r180, r179, r178
-  JumpIfFalse  r180, L22
-  Index        r181, r177, r179
-  Move         r159, r181
-  Index        r182, r159, r11
-  Index        r183, r182, r16
-  Append       r184, r176, r183
-  Move         r176, r184
-  AddInt       r179, r179, r142
-  Jump         L23
-L22:
-  Avg          r185, r176
-  // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Const        r186, "agg4"
-  Const        r187, []
-  IterPrep     r188, r148
-  Len          r189, r188
-  Move         r190, r127
-L25:
-  LessInt      r191, r190, r189
-  JumpIfFalse  r191, L24
-  Index        r192, r188, r190
-  Move         r159, r192
-  Index        r193, r159, r11
-  Index        r194, r193, r18
-  Append       r195, r187, r194
-  Move         r187, r195
-  AddInt       r190, r190, r142
-  Jump         L25
-L24:
-  Avg          r196, r187
+  LessInt      r142, r140, r141
+  JumpIfFalse  r142, L14
+  Index        r143, r20, r140
+  Move         r144, r143
   // i_item_id: g.key.i_item_id,
-  Move         r197, r149
-  Move         r198, r151
+  Const        r145, "i_item_id"
+  Index        r146, r144, r9
+  Index        r147, r146, r2
   // agg1: avg(from x in g select x.ss.ss_quantity),
-  Move         r199, r152
-  Move         r200, r163
+  Const        r148, "agg1"
+  Const        r149, []
+  IterPrep     r150, r144
+  Len          r151, r150
+  Move         r152, r123
+L16:
+  LessInt      r153, r152, r151
+  JumpIfFalse  r153, L15
+  Index        r154, r150, r152
+  Move         r155, r154
+  Index        r156, r155, r11
+  Index        r157, r156, r12
+  Append       r158, r149, r157
+  Move         r149, r158
+  AddInt       r152, r152, r138
+  Jump         L16
+L15:
+  Avg          r159, r149
   // agg2: avg(from x in g select x.ss.ss_list_price),
-  Move         r201, r164
-  Move         r202, r174
-  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
-  Move         r203, r175
-  Move         r204, r185
-  // agg4: avg(from x in g select x.ss.ss_sales_price)
-  Move         r205, r186
-  Move         r206, r196
-  // select {
-  MakeMap      r207, 5, r197
-  // sort by g.key.i_item_id
-  Index        r208, r148, r9
-  Index        r209, r208, r2
-  Move         r210, r209
-  // from ss in store_sales
-  Move         r211, r207
-  MakeList     r212, 2, r210
-  Append       r213, r1, r212
-  Move         r1, r213
-  AddInt       r144, r144, r142
-  Jump         L26
+  Const        r160, "agg2"
+  Const        r161, []
+  IterPrep     r162, r144
+  Len          r163, r162
+  Move         r164, r123
+L18:
+  LessInt      r165, r164, r163
+  JumpIfFalse  r165, L17
+  Index        r166, r162, r164
+  Move         r155, r166
+  Index        r167, r155, r11
+  Index        r168, r167, r14
+  Append       r169, r161, r168
+  Move         r161, r169
+  AddInt       r164, r164, r138
+  Jump         L18
 L17:
+  Avg          r170, r161
+  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
+  Const        r171, "agg3"
+  Const        r172, []
+  IterPrep     r173, r144
+  Len          r174, r173
+  Move         r175, r123
+L20:
+  LessInt      r176, r175, r174
+  JumpIfFalse  r176, L19
+  Index        r177, r173, r175
+  Move         r155, r177
+  Index        r178, r155, r11
+  Index        r179, r178, r16
+  Append       r180, r172, r179
+  Move         r172, r180
+  AddInt       r175, r175, r138
+  Jump         L20
+L19:
+  Avg          r181, r172
+  // agg4: avg(from x in g select x.ss.ss_sales_price)
+  Const        r182, "agg4"
+  Const        r183, []
+  IterPrep     r184, r144
+  Len          r185, r184
+  Move         r186, r123
+L22:
+  LessInt      r187, r186, r185
+  JumpIfFalse  r187, L21
+  Index        r188, r184, r186
+  Move         r155, r188
+  Index        r189, r155, r11
+  Index        r190, r189, r18
+  Append       r191, r183, r190
+  Move         r183, r191
+  AddInt       r186, r186, r138
+  Jump         L22
+L21:
+  Avg          r192, r183
+  // i_item_id: g.key.i_item_id,
+  Move         r193, r145
+  Move         r194, r147
+  // agg1: avg(from x in g select x.ss.ss_quantity),
+  Move         r195, r148
+  Move         r196, r159
+  // agg2: avg(from x in g select x.ss.ss_list_price),
+  Move         r197, r160
+  Move         r198, r170
+  // agg3: avg(from x in g select x.ss.ss_coupon_amt),
+  Move         r199, r171
+  Move         r200, r181
+  // agg4: avg(from x in g select x.ss.ss_sales_price)
+  Move         r201, r182
+  Move         r202, r192
+  // select {
+  MakeMap      r203, 5, r193
   // sort by g.key.i_item_id
-  Sort         r214, r1
+  Index        r204, r144, r9
+  Index        r205, r204, r2
+  Move         r206, r205
   // from ss in store_sales
-  Move         r1, r214
+  Move         r207, r203
+  MakeList     r208, 2, r206
+  Append       r209, r1, r208
+  Move         r1, r209
+  AddInt       r140, r140, r138
+  Jump         L23
+L14:
+  // sort by g.key.i_item_id
+  Sort         r210, r1
+  // from ss in store_sales
+  Move         r1, r210
   // json(result)
   JSON         r1
   // expect len(result) == 0
-  Len          r215, r1
-  EqualInt     r216, r215, r127
-  Expect       r216
+  Len          r211, r1
+  EqualInt     r212, r211, r123
+  Expect       r212
   Return       r0

--- a/tests/dataset/tpc-ds/out/q8.ir.out
+++ b/tests/dataset/tpc-ds/out/q8.ir.out
@@ -1,13 +1,12 @@
-func main (regs=5)
+func main (regs=4)
   // let store_sales = []
   Const        r0, []
   // reverse(substr("zip", 0, 2))
-  Const        r1, "zi"
-  Reverse      r2, r1
+  Const        r1, "iz"
   // json(result)
   JSON         r0
   // expect len(result) == 0
-  Const        r3, 0
-  Const        r4, true
-  Expect       r4
+  Const        r2, 0
+  Const        r3, true
+  Expect       r3
   Return       r0


### PR DESCRIPTION
## Summary
- allow runtime to ignore extra arguments to built-ins used by old TPC‑DS sources
- refresh IR golden outputs for TPC‑DS queries q1–q9

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862b5dd37c48320ab2f7a0be53c931a