### PR TITLE
Update VM first builtin

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -34,7 +34,8 @@ The VM supports a small but useful subset of Mochi:
 * List and string slicing with `[start:end]` syntax (supports negative indices)
 * Pattern matching
 * Test blocks with `expect` statements
-* Capable of running the full suite of simplified TPC‑DS benchmark queries
+* Capable of running the full suite of simplified TPC‑DS benchmark queries,
+  including queries `q10` through `q19`
 
 ## Unsupported features
 

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1265,6 +1265,10 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fr.regs[ins.A] = Value{Tag: ValueStr, Str: line}
 		case OpFirst:
 			lst := fr.regs[ins.B]
+			if lst.Tag == ValueNull {
+				fr.regs[ins.A] = Value{Tag: ValueNull}
+				break
+			}
 			if lst.Tag != ValueList {
 				return Value{}, m.newError(fmt.Errorf("first expects list"), trace, ins.Line)
 			}


### PR DESCRIPTION
## Summary
- allow `first` to handle `null`
- mention TPC-DS query support in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862b5e0a70c8320bdd08cd53c769541