### PR TITLE
Update tpc‑ds IR outputs

### DIFF
--- a/tests/dataset/tpc-ds/out/q80.ir.out
+++ b/tests/dataset/tpc-ds/out/q80.ir.out
@@ -1,10 +1,10 @@
 func main (regs=47)
   // let store_sales = [
-  Const        r0, [{"price": 20, "ret": 5}, {"price": 10, "ret": 2}, {"price": 5, "ret": 0}]
+  Const        r0, [{"price": 20.0, "ret": 5.0}, {"price": 10.0, "ret": 2.0}, {"price": 5.0, "ret": 0.0}]
   // let catalog_sales = [
-  Const        r1, [{"price": 15, "ret": 3}, {"price": 8, "ret": 1}]
+  Const        r1, [{"price": 15.0, "ret": 3.0}, {"price": 8.0, "ret": 1.0}]
   // let web_sales = [
-  Const        r2, [{"price": 25, "ret": 5}, {"price": 15, "ret": 8}, {"price": 8, "ret": 2}]
+  Const        r2, [{"price": 25.0, "ret": 5.0}, {"price": 15.0, "ret": 8.0}, {"price": 8.0, "ret": 2.0}]
   // sum(from s in store_sales select s.price - s.ret) +
   Const        r3, []
   Const        r4, "price"
@@ -73,7 +73,7 @@ L4:
   // json(total_profit)
   JSON         r44
   // expect total_profit == 80.0
-  Const        r45, 80
+  Const        r45, 80.0
   EqualFloat   r46, r44, r45
   Expect       r46
   Return       r0

--- a/tests/dataset/tpc-ds/out/q81.ir.out
+++ b/tests/dataset/tpc-ds/out/q81.ir.out
@@ -1,6 +1,6 @@
-func main (regs=97)
+func main (regs=96)
   // let catalog_returns = [
-  Const        r0, [{"amt": 40, "cust": 1, "state": "CA"}, {"amt": 50, "cust": 2, "state": "CA"}, {"amt": 81, "cust": 3, "state": "CA"}, {"amt": 30, "cust": 4, "state": "TX"}, {"amt": 20, "cust": 5, "state": "TX"}]
+  Const        r0, [{"amt": 40.0, "cust": 1, "state": "CA"}, {"amt": 50.0, "cust": 2, "state": "CA"}, {"amt": 81.0, "cust": 3, "state": "CA"}, {"amt": 30.0, "cust": 4, "state": "TX"}, {"amt": 20.0, "cust": 5, "state": "TX"}]
   // from r in catalog_returns
   Const        r1, []
   // group by r.state into g
@@ -27,139 +27,138 @@ L2:
   In           r17, r16, r9
   JumpIfTrue   r17, L1
   // from r in catalog_returns
-  Const        r18, []
-  Const        r19, "__group__"
-  Const        r20, true
+  Const        r18, "__group__"
+  Const        r19, true
   // group by r.state into g
-  Move         r21, r15
+  Move         r20, r15
   // from r in catalog_returns
-  Const        r22, "items"
-  Move         r23, r18
-  Const        r24, "count"
-  Const        r25, 0
+  Const        r21, "items"
+  Move         r22, r11
+  Const        r23, "count"
+  Const        r24, 0
+  Move         r25, r18
   Move         r26, r19
-  Move         r27, r20
-  Move         r28, r3
+  Move         r27, r3
+  Move         r28, r20
   Move         r29, r21
   Move         r30, r22
   Move         r31, r23
   Move         r32, r24
-  Move         r33, r25
-  MakeMap      r34, 4, r26
-  SetIndex     r9, r16, r34
-  Append       r35, r10, r34
-  Move         r10, r35
+  MakeMap      r33, 4, r25
+  SetIndex     r9, r16, r33
+  Append       r34, r10, r33
+  Move         r10, r34
 L1:
-  Index        r36, r9, r16
-  Index        r37, r36, r22
-  Append       r38, r37, r13
-  SetIndex     r36, r22, r38
-  Index        r39, r36, r24
-  Const        r40, 1
-  AddInt       r41, r39, r40
-  SetIndex     r36, r24, r41
-  AddInt       r8, r8, r40
+  Index        r35, r9, r16
+  Index        r36, r35, r21
+  Append       r37, r36, r13
+  SetIndex     r35, r21, r37
+  Index        r38, r35, r23
+  Const        r39, 1
+  AddInt       r40, r38, r39
+  SetIndex     r35, r23, r40
+  AddInt       r8, r8, r39
   Jump         L2
 L0:
-  Move         r42, r25
-  Len          r43, r10
+  Move         r41, r24
+  Len          r42, r10
 L6:
-  LessInt      r44, r42, r43
-  JumpIfFalse  r44, L3
-  Index        r45, r10, r42
-  Move         r46, r45
+  LessInt      r43, r41, r42
+  JumpIfFalse  r43, L3
+  Index        r44, r10, r41
+  Move         r45, r44
   // select {state: g.key, avg_amt: avg(from x in g select x.amt)}
-  Const        r47, "state"
-  Index        r48, r46, r3
-  Const        r49, "avg_amt"
-  Const        r50, []
-  IterPrep     r51, r46
-  Len          r52, r51
-  Move         r53, r25
+  Const        r46, "state"
+  Index        r47, r45, r3
+  Const        r48, "avg_amt"
+  Const        r49, []
+  IterPrep     r50, r45
+  Len          r51, r50
+  Move         r52, r24
 L5:
-  LessInt      r54, r53, r52
-  JumpIfFalse  r54, L4
-  Index        r55, r51, r53
-  Move         r56, r55
-  Index        r57, r56, r5
-  Append       r58, r50, r57
-  Move         r50, r58
-  AddInt       r53, r53, r40
+  LessInt      r53, r52, r51
+  JumpIfFalse  r53, L4
+  Index        r54, r50, r52
+  Move         r55, r54
+  Index        r56, r55, r5
+  Append       r57, r49, r56
+  Move         r49, r57
+  AddInt       r52, r52, r39
   Jump         L5
 L4:
-  Avg          r59, r50
+  Avg          r58, r49
+  Move         r59, r46
   Move         r60, r47
   Move         r61, r48
-  Move         r62, r49
-  Move         r63, r59
-  MakeMap      r64, 2, r60
+  Move         r62, r58
+  MakeMap      r63, 2, r59
   // from r in catalog_returns
-  Append       r65, r1, r64
-  Move         r1, r65
-  AddInt       r42, r42, r40
+  Append       r64, r1, r63
+  Move         r1, r64
+  AddInt       r41, r41, r39
   Jump         L6
 L3:
   // first(from a in avg_list
-  Const        r66, []
-  IterPrep     r67, r1
-  Len          r68, r67
-  Move         r69, r25
+  Const        r65, []
+  IterPrep     r66, r1
+  Len          r67, r66
+  Move         r68, r24
 L9:
-  LessInt      r70, r69, r68
-  JumpIfFalse  r70, L7
-  Index        r71, r67, r69
-  Move         r72, r71
+  LessInt      r69, r68, r67
+  JumpIfFalse  r69, L7
+  Index        r70, r66, r68
+  Move         r71, r70
   // where a.state == "CA"
-  Index        r73, r72, r2
-  Const        r74, "CA"
-  Equal        r75, r73, r74
-  JumpIfFalse  r75, L8
+  Index        r72, r71, r2
+  Const        r73, "CA"
+  Equal        r74, r72, r73
+  JumpIfFalse  r74, L8
   // first(from a in avg_list
-  Append       r76, r66, r72
-  Move         r66, r76
+  Append       r75, r65, r71
+  Move         r65, r75
 L8:
-  AddInt       r69, r69, r40
+  AddInt       r68, r68, r39
   Jump         L9
 L7:
-  First        r77, r66
+  First        r76, r65
   // from r in catalog_returns
-  Const        r78, []
-  IterPrep     r79, r0
-  Len          r80, r79
-  Move         r81, r25
+  Const        r77, []
+  IterPrep     r78, r0
+  Len          r79, r78
+  Move         r80, r24
 L13:
-  LessInt      r82, r81, r80
-  JumpIfFalse  r82, L10
-  Index        r83, r79, r81
-  Move         r14, r83
+  LessInt      r81, r80, r79
+  JumpIfFalse  r81, L10
+  Index        r82, r78, r80
+  Move         r14, r82
   // where r.state == "CA" && r.amt > avg_state.avg_amt * 1.2
-  Index        r84, r14, r2
-  Index        r85, r77, r4
-  Const        r86, 1.2
-  MulFloat     r87, r85, r86
-  Index        r88, r14, r5
-  LessFloat    r89, r87, r88
-  Equal        r90, r84, r74
-  Move         r91, r90
-  JumpIfFalse  r91, L11
-  Move         r91, r89
+  Index        r83, r14, r2
+  Index        r84, r76, r4
+  Const        r85, 1.2
+  MulFloat     r86, r84, r85
+  Index        r87, r14, r5
+  LessFloat    r88, r86, r87
+  Equal        r89, r83, r73
+  Move         r90, r89
+  JumpIfFalse  r90, L11
+  Move         r90, r88
 L11:
-  JumpIfFalse  r91, L12
+  JumpIfFalse  r90, L12
   // select r.amt
-  Index        r92, r14, r5
+  Index        r91, r14, r5
   // from r in catalog_returns
-  Append       r93, r78, r92
-  Move         r78, r93
+  Append       r92, r77, r91
+  Move         r77, r92
 L12:
-  AddInt       r81, r81, r40
+  AddInt       r80, r80, r39
   Jump         L13
 L10:
   // let result = first(result_list)
-  First        r94, r78
+  First        r93, r77
   // json(result)
-  JSON         r94
+  JSON         r93
   // expect result == 81.0
-  Const        r95, 81
-  EqualFloat   r96, r94, r95
-  Expect       r96
+  Const        r94, 81.0
+  EqualFloat   r95, r93, r94
+  Expect       r95
   Return       r0

--- a/tests/dataset/tpc-ds/out/q82.ir.out
+++ b/tests/dataset/tpc-ds/out/q82.ir.out
@@ -12,7 +12,7 @@ func main (regs=29)
   Len          r5, r4
   Const        r6, 0
 L4:
-  Less         r7, r6, r5
+  LessInt      r7, r6, r5
   JumpIfFalse  r7, L0
   Index        r8, r4, r6
   Move         r9, r8
@@ -21,7 +21,7 @@ L4:
   Len          r11, r10
   Const        r12, 0
 L3:
-  Less         r13, r12, r11
+  LessInt      r13, r12, r11
   JumpIfFalse  r13, L1
   Index        r14, r10, r12
   Move         r15, r14
@@ -39,13 +39,13 @@ L3:
 L2:
   // for s in store_sales {
   Const        r23, 1
-  Add          r24, r12, r23
+  AddInt       r24, r12, r23
   Move         r12, r24
   Jump         L3
 L1:
   // for inv in inventory {
   Const        r25, 1
-  Add          r26, r6, r25
+  AddInt       r26, r6, r25
   Move         r6, r26
   Jump         L4
 L0:

--- a/tests/dataset/tpc-ds/out/q85.ir.out
+++ b/tests/dataset/tpc-ds/out/q85.ir.out
@@ -1,6 +1,6 @@
 func main (regs=16)
   // let web_returns = [
-  Const        r0, [{"cash": 20, "fee": 1, "qty": 60}, {"cash": 30, "fee": 2, "qty": 100}, {"cash": 25, "fee": 3, "qty": 95}]
+  Const        r0, [{"cash": 20.0, "fee": 1.0, "qty": 60}, {"cash": 30.0, "fee": 2.0, "qty": 100}, {"cash": 25.0, "fee": 3.0, "qty": 95}]
   // let result = avg(from r in web_returns select r.qty)
   Const        r1, []
   Const        r2, "qty"
@@ -24,7 +24,7 @@ L0:
   // json(result)
   JSON         r13
   // expect result == 85.0
-  Const        r14, 85
+  Const        r14, 85.0
   EqualFloat   r15, r13, r14
   Expect       r15
   Return       r0

--- a/tests/dataset/tpc-ds/out/q86.ir.out
+++ b/tests/dataset/tpc-ds/out/q86.ir.out
@@ -1,6 +1,6 @@
 func main (regs=25)
   // let web_sales = [
-  Const        r0, [{"cat": "A", "class": "B", "net": 40}, {"cat": "A", "class": "B", "net": 46}, {"cat": "A", "class": "C", "net": 10}, {"cat": "B", "class": "B", "net": 20}]
+  Const        r0, [{"cat": "A", "class": "B", "net": 40.0}, {"cat": "A", "class": "B", "net": 46.0}, {"cat": "A", "class": "C", "net": 10.0}, {"cat": "B", "class": "B", "net": 20.0}]
   // sum(from ws in web_sales
   Const        r1, []
   // where ws.cat == "A" && ws.class == "B"
@@ -44,7 +44,7 @@ L0:
   // json(result)
   JSON         r22
   // expect result == 86.0
-  Const        r23, 86
+  Const        r23, 86.0
   EqualFloat   r24, r22, r23
   Expect       r24
   Return       r0

--- a/tests/dataset/tpc-ds/out/q87.ir.out
+++ b/tests/dataset/tpc-ds/out/q87.ir.out
@@ -24,7 +24,7 @@ func distinct (regs=14)
   Len          r4, r3
   Const        r5, 0
 L2:
-  Less         r6, r5, r4
+  LessInt      r6, r5, r4
   JumpIfFalse  r6, L0
   Index        r7, r3, r5
   Move         r8, r7
@@ -37,7 +37,7 @@ L2:
 L1:
   // for x in xs {
   Const        r12, 1
-  Add          r13, r5, r12
+  AddInt       r13, r5, r12
   Move         r5, r13
   Jump         L2
 L0:
@@ -53,7 +53,7 @@ func concat (regs=12)
   Len          r4, r3
   Const        r5, 0
 L1:
-  Less         r6, r5, r4
+  LessInt      r6, r5, r4
   JumpIfFalse  r6, L0
   Index        r7, r3, r5
   Move         r8, r7
@@ -62,7 +62,7 @@ L1:
   Move         r2, r9
   // for x in b {
   Const        r10, 1
-  Add          r11, r5, r10
+  AddInt       r11, r5, r10
   Move         r5, r11
   Jump         L1
 L0:

--- a/tests/dataset/tpc-ds/out/q89.ir.out
+++ b/tests/dataset/tpc-ds/out/q89.ir.out
@@ -1,6 +1,6 @@
 func main (regs=16)
   // let store_sales = [
-  Const        r0, [{"price": 40}, {"price": 30}, {"price": 19}]
+  Const        r0, [{"price": 40.0}, {"price": 30.0}, {"price": 19.0}]
   // let result = sum(from s in store_sales select s.price)
   Const        r1, []
   Const        r2, "price"
@@ -24,7 +24,7 @@ L0:
   // json(result)
   JSON         r13
   // expect result == 89.0
-  Const        r14, 89
+  Const        r14, 89.0
   EqualFloat   r15, r13, r14
   Expect       r15
   Return       r0


### PR DESCRIPTION
## Summary
- regenerate the VM IR for tpc-ds sample queries q80-q89
- decimals are now preserved in constant values

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862b6040a7083208a2aad8aa1dfed2c