### PR TITLE
Update TPCH q13 IR for VM runtime

### DIFF
--- a/tests/dataset/tpc-h/out/q13.ir.out
+++ b/tests/dataset/tpc-h/out/q13.ir.out
@@ -1,4 +1,4 @@
-func main (regs=102)
+func main (regs=100)
   // let customer = [
   Const        r0, [{"c_custkey": 1}, {"c_custkey": 2}, {"c_custkey": 3}]
   // let orders = [
@@ -17,7 +17,7 @@ func main (regs=102)
   Len          r8, r7
   Const        r10, 0
   Move         r9, r10
-L6:
+L5:
   LessInt      r11, r9, r8
   JumpIfFalse  r11, L0
   Index        r12, r7, r9
@@ -29,7 +29,7 @@ L6:
   IterPrep     r16, r1
   Len          r17, r16
   Move         r18, r10
-L5:
+L4:
   LessInt      r19, r18, r17
   JumpIfFalse  r19, L1
   Index        r20, r16, r18
@@ -38,140 +38,138 @@ L5:
   Index        r22, r21, r4
   Index        r23, r13, r5
   Equal        r24, r22, r23
+  Move         r25, r24
+  JumpIfFalse  r25, L2
   // (!("special" in o.o_comment)) &&
-  Const        r25, "special"
-  Index        r26, r21, r6
-  In           r27, r25, r26
-  Not          r28, r27
+  Const        r26, "special"
+  Index        r27, r21, r6
+  In           r28, r26, r27
+  Not          r29, r28
   // o.o_custkey == c.c_custkey &&
-  Move         r29, r24
-  JumpIfFalse  r29, L2
-  Move         r29, r28
-L2:
+  Move         r25, r29
+  // (!("special" in o.o_comment)) &&
+  JumpIfFalse  r25, L2
   // (!("requests" in o.o_comment))
   Const        r30, "requests"
   Index        r31, r21, r6
   In           r32, r30, r31
   Not          r33, r32
   // (!("special" in o.o_comment)) &&
-  Move         r34, r29
-  JumpIfFalse  r34, L3
-  Move         r34, r33
-L3:
+  Move         r25, r33
+L2:
   // where (
-  JumpIfFalse  r34, L4
+  JumpIfFalse  r25, L3
   // from o in orders
-  Append       r35, r15, r21
-  Move         r15, r35
-L4:
-  Const        r36, 1
-  AddInt       r18, r18, r36
-  Jump         L5
+  Append       r34, r15, r21
+  Move         r15, r34
+L3:
+  Const        r35, 1
+  AddInt       r18, r18, r35
+  Jump         L4
 L1:
   // c_count: count(
-  Count        r37, r15
-  Move         r38, r14
-  Move         r39, r37
+  Count        r36, r15
+  Move         r37, r14
+  Move         r38, r36
   // select {
-  MakeMap      r40, 1, r38
+  MakeMap      r39, 1, r37
   // from c in customer
-  Append       r41, r2, r40
-  Move         r2, r41
-  AddInt       r9, r9, r36
-  Jump         L6
+  Append       r40, r2, r39
+  Move         r2, r40
+  AddInt       r9, r9, r35
+  Jump         L5
 L0:
   // from x in per_customer
-  Const        r42, []
+  Const        r41, []
   // select { c_count: g.key, custdist: count(g) }
-  Const        r43, "key"
-  Const        r44, "custdist"
+  Const        r42, "key"
+  Const        r43, "custdist"
   // from x in per_customer
-  IterPrep     r45, r2
-  Len          r46, r45
-  Const        r47, 0
-  MakeMap      r48, 0, r0
-  Const        r50, []
-  Move         r49, r50
-L9:
-  LessInt      r51, r47, r46
-  JumpIfFalse  r51, L7
-  Index        r52, r45, r47
-  Move         r53, r52
+  IterPrep     r44, r2
+  Len          r45, r44
+  Const        r46, 0
+  MakeMap      r47, 0, r0
+  Const        r49, []
+  Move         r48, r49
+L8:
+  LessInt      r50, r46, r45
+  JumpIfFalse  r50, L6
+  Index        r51, r44, r46
+  Move         r52, r51
   // group by x.c_count into g
-  Index        r54, r53, r3
-  Str          r55, r54
-  In           r56, r55, r48
-  JumpIfTrue   r56, L8
+  Index        r53, r52, r3
+  Str          r54, r53
+  In           r55, r54, r47
+  JumpIfTrue   r55, L7
   // from x in per_customer
-  Const        r57, []
-  Const        r58, "__group__"
-  Const        r59, true
+  Const        r56, "__group__"
+  Const        r57, true
   // group by x.c_count into g
-  Move         r60, r54
+  Move         r58, r53
   // from x in per_customer
-  Const        r61, "items"
-  Move         r62, r57
-  Const        r63, "count"
-  Move         r64, r58
-  Move         r65, r59
-  Move         r66, r43
+  Const        r59, "items"
+  Move         r60, r49
+  Const        r61, "count"
+  Move         r62, r56
+  Move         r63, r57
+  Move         r64, r42
+  Move         r65, r58
+  Move         r66, r59
   Move         r67, r60
   Move         r68, r61
-  Move         r69, r62
-  Move         r70, r63
-  Move         r71, r10
-  MakeMap      r72, 4, r64
-  SetIndex     r48, r55, r72
-  Append       r73, r49, r72
-  Move         r49, r73
-L8:
-  Index        r74, r48, r55
-  Index        r75, r74, r61
-  Append       r76, r75, r52
-  SetIndex     r74, r61, r76
-  Index        r77, r74, r63
-  AddInt       r78, r77, r36
-  SetIndex     r74, r63, r78
-  AddInt       r47, r47, r36
-  Jump         L9
+  Move         r69, r10
+  MakeMap      r70, 4, r62
+  SetIndex     r47, r54, r70
+  Append       r71, r48, r70
+  Move         r48, r71
 L7:
-  Move         r79, r10
-  Len          r80, r49
-L11:
-  LessInt      r81, r79, r80
-  JumpIfFalse  r81, L10
-  Index        r82, r49, r79
-  Move         r83, r82
+  Index        r72, r47, r54
+  Index        r73, r72, r59
+  Append       r74, r73, r51
+  SetIndex     r72, r59, r74
+  Index        r75, r72, r61
+  AddInt       r76, r75, r35
+  SetIndex     r72, r61, r76
+  AddInt       r46, r46, r35
+  Jump         L8
+L6:
+  Move         r77, r10
+  Len          r78, r48
+L10:
+  LessInt      r79, r77, r78
+  JumpIfFalse  r79, L9
+  Index        r80, r48, r77
+  Move         r81, r80
   // select { c_count: g.key, custdist: count(g) }
-  Const        r84, "c_count"
-  Index        r85, r83, r43
-  Const        r86, "custdist"
-  Index        r87, r83, r63
+  Const        r82, "c_count"
+  Index        r83, r81, r42
+  Const        r84, "custdist"
+  Index        r85, r81, r61
+  Move         r86, r82
+  Move         r87, r83
   Move         r88, r84
   Move         r89, r85
-  Move         r90, r86
-  Move         r91, r87
-  MakeMap      r92, 2, r88
+  MakeMap      r90, 2, r86
   // sort by -g.key
-  Index        r93, r83, r43
-  Neg          r94, r93
-  Move         r95, r94
+  Index        r91, r81, r42
+  Neg          r92, r91
+  Move         r93, r92
   // from x in per_customer
-  Move         r96, r92
-  MakeList     r97, 2, r95
-  Append       r98, r42, r97
-  Move         r42, r98
-  AddInt       r79, r79, r36
-  Jump         L11
-L10:
+  Move         r94, r90
+  MakeList     r95, 2, r93
+  Append       r96, r41, r95
+  Move         r41, r96
+  AddInt       r77, r77, r35
+  Jump         L10
+L9:
   // sort by -g.key
-  Sort         r99, r42
+  Sort         r97, r41
   // from x in per_customer
-  Move         r42, r99
+  Move         r41, r97
   // json(grouped)
-  JSON         r42
+  JSON         r41
   // expect grouped == [
-  Const        r100, [{"c_count": 2, "custdist": 1}, {"c_count": 0, "custdist": 2}]
-  Equal        r101, r42, r100
-  Expect       r101
+  Const        r98, [{"c_count": 2, "custdist": 1}, {"c_count": 0, "custdist": 2}]
+  Equal        r99, r41, r98
+  Expect       r99
   Return       r0


### PR DESCRIPTION
## Summary
- regenerate the bytecode IR output for the TPCH q13 test
- ensures the VM tests for TPCH q13 pass with the latest compiler

## Testing
- `go test ./tests/vm -run TPCH/q13\.mochi -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_6862b63a852883209f87b6cfa56f0421