### PR TITLE
Add group sum handling in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -3026,6 +3026,21 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 			fc.emit(p.Pos, Instr{Op: OpAvg, A: dst, B: arg})
 			return dst
 		case "sum":
+			if fc.groupVar != "" {
+				if name, ok := identName(p.Call.Args[0]); ok && name == fc.groupVar {
+					greg, ok := fc.vars[fc.groupVar]
+					if !ok {
+						greg = fc.newReg()
+						fc.vars[fc.groupVar] = greg
+					}
+					key := fc.constReg(p.Pos, Value{Tag: ValueStr, Str: "items"})
+					lst := fc.newReg()
+					fc.emit(p.Pos, Instr{Op: OpIndex, A: lst, B: greg, C: key})
+					dst := fc.newReg()
+					fc.emit(p.Pos, Instr{Op: OpSum, A: dst, B: lst})
+					return dst
+				}
+			}
 			arg := fc.compileExpr(p.Call.Args[0])
 			dst := fc.newReg()
 			fc.emit(p.Pos, Instr{Op: OpSum, A: dst, B: arg})


### PR DESCRIPTION
## Summary
- support `sum(g)` when compiling group queries in the VM

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862c300b23083208e299f17aac6459a