### PR TITLE
Add fuzz harness for VM

### DIFF
--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -1,0 +1,13 @@
+# VM Fuzzing
+
+This directory contains a simple fuzz harness for the Mochi bytecode virtual machine.
+
+## Running
+
+Use Go's built-in fuzzing support to exercise the parser, type checker, compiler and VM with random inputs:
+
+```bash
+go test ./tools/fuzz -run FuzzVM -fuzz FuzzVM -fuzztime 10s
+```
+
+The harness ignores parse, type and runtime errors but fails on any panic.

--- a/tools/fuzz/fuzz_vm_test.go
+++ b/tools/fuzz/fuzz_vm_test.go
@@ -1,0 +1,43 @@
+package fuzz
+
+import (
+	"io"
+	"testing"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func FuzzVM(f *testing.F) {
+	seeds := []string{
+		"print(1)",
+		"let x = 1 + 2\nprint(x)",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, src string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic: %v", r)
+			}
+		}()
+
+		prog, err := parser.ParseString(src)
+		if err != nil {
+			return
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return
+		}
+		p, err := vm.Compile(prog, env)
+		if err != nil {
+			return
+		}
+		m := vm.New(p, io.Discard)
+		_ = m.Run()
+	})
+}


### PR DESCRIPTION
## Summary
- add `tools/fuzz` directory
- implement `FuzzVM` to parse, type-check, compile and execute random inputs
- document how to run the fuzz tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862f49265448320992adb70fad9f77c