### PR TITLE
Add fuzz tests for parser and VM

### DIFF
--- a/tools/fuzz/README.md
+++ b/tools/fuzz/README.md
@@ -1,0 +1,16 @@
+# Fuzz Testing
+
+This directory contains fuzz tests for the Mochi parser and virtual machine
+compiler. The tests rely on Go's built in fuzzing support introduced in Go 1.18
+and later.
+
+To run the fuzz tests for a short time execute:
+
+```bash
+go test -run=Fuzz -fuzz=.
+```
+
+The fuzz targets use a simple program generator to systematically explore the
+Mochi syntax tree. Generated programs are fed to Go's fuzzing engine which then
+mutates them further. Any crashes or panics will be reported by the engine.
+

--- a/tools/fuzz/gen/generator.go
+++ b/tools/fuzz/gen/generator.go
@@ -1,0 +1,111 @@
+package gen
+
+import (
+	"math/rand"
+	"strings"
+)
+
+// Generator produces random Mochi programs.
+type Generator struct {
+	r *rand.Rand
+}
+
+// New returns a new generator seeded with r.
+func New(r *rand.Rand) *Generator {
+	return &Generator{r: r}
+}
+
+// Program returns a randomly generated program string with the given depth.
+// Increasing depth yields larger programs.
+func (g *Generator) Program(depth int) string {
+	if depth <= 0 {
+		depth = 1
+	}
+	n := 1 + g.r.Intn(depth+1)
+	stmts := make([]string, n)
+	for i := 0; i < n; i++ {
+		stmts[i] = g.statement(depth)
+	}
+	return strings.Join(stmts, "\n")
+}
+
+func (g *Generator) statement(depth int) string {
+	if depth <= 0 {
+		return g.simpleStmt()
+	}
+	switch g.r.Intn(10) {
+	case 0:
+		return "let " + g.ident() + " = " + g.expr(depth-1)
+	case 1:
+		return "var " + g.ident() + " = " + g.expr(depth-1)
+	case 2:
+		return g.ident() + " = " + g.expr(depth-1)
+	case 3:
+		return "fun " + g.ident() + "(" + g.ident() + ": int) { return " + g.expr(depth-1) + " }"
+	case 4:
+		return "return " + g.expr(depth-1)
+	case 5:
+		return "if " + g.expr(depth-1) + " { " + g.statement(depth-1) + " } else { " + g.statement(depth-1) + " }"
+	case 6:
+		return "while " + g.expr(depth-1) + " { " + g.statement(depth-1) + " }"
+	case 7:
+		return "for " + g.ident() + " in [" + g.expr(depth-1) + "] { " + g.statement(depth-1) + " }"
+	case 8:
+		return "break"
+	case 9:
+		return "continue"
+	default:
+		return g.simpleStmt()
+	}
+}
+
+func (g *Generator) simpleStmt() string {
+	return "print(" + g.expr(0) + ")"
+}
+
+func (g *Generator) expr(depth int) string {
+	if depth <= 0 {
+		return g.atom()
+	}
+	switch g.r.Intn(8) {
+	case 0:
+		return g.expr(depth-1) + " + " + g.expr(depth-1)
+	case 1:
+		return "-" + g.expr(depth-1)
+	case 2:
+		return g.ident() + "(" + g.expr(depth-1) + ")"
+	case 3:
+		return g.ident() + "." + g.ident()
+	case 4:
+		return "[" + g.expr(depth-1) + ", " + g.expr(depth-1) + "]"
+	case 5:
+		return "{" + g.ident() + ": " + g.expr(depth-1) + "}"
+	case 6:
+		return "fun(" + g.ident() + ": int) { return " + g.expr(depth-1) + " }"
+	default:
+		return g.atom()
+	}
+}
+
+func (g *Generator) atom() string {
+	switch g.r.Intn(4) {
+	case 0:
+		return "1"
+	case 1:
+		return "true"
+	case 2:
+		return "\"str\""
+	default:
+		return g.ident()
+	}
+}
+
+func (g *Generator) ident() string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	l := 1 + g.r.Intn(3)
+	b := make([]rune, l)
+	for i := range b {
+		b[i] = letters[g.r.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/tools/fuzz/parser_fuzz_test.go
+++ b/tools/fuzz/parser_fuzz_test.go
@@ -1,0 +1,23 @@
+package fuzz
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"mochi/parser"
+	"mochi/tools/fuzz/gen"
+)
+
+// FuzzParser ensures the parser can handle arbitrary input without panicking.
+func FuzzParser(f *testing.F) {
+	g := gen.New(rand.New(rand.NewSource(time.Now().UnixNano())))
+	for i := 0; i < 50; i++ {
+		f.Add(g.Program(3))
+	}
+
+	f.Fuzz(func(t *testing.T, src string) {
+		// Errors are ignored; we only care about crashes.
+		parser.ParseString(src)
+	})
+}

--- a/tools/fuzz/vm_fuzz_test.go
+++ b/tools/fuzz/vm_fuzz_test.go
@@ -1,0 +1,33 @@
+package fuzz
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/tools/fuzz/gen"
+	"mochi/types"
+)
+
+// FuzzVMCompile parses input and attempts to compile it with the VM compiler.
+// Any errors are ignored; the goal is to catch panics during compilation.
+func FuzzVMCompile(f *testing.F) {
+	g := gen.New(rand.New(rand.NewSource(time.Now().UnixNano())))
+	for i := 0; i < 50; i++ {
+		f.Add(g.Program(3))
+	}
+
+	f.Fuzz(func(t *testing.T, src string) {
+		prog, err := parser.ParseString(src)
+		if err != nil {
+			return
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return
+		}
+		_, _ = vm.Compile(prog, env)
+	})
+}


### PR DESCRIPTION
## Summary
- add generator for producing random Mochi programs
- use generator to supply seeds for parser and VM fuzz tests
- document fuzz generator usage

## Testing
- `go test ./tools/fuzz -run=Fuzz -fuzz=FuzzParser -fuzztime=1x`
- `go test ./tools/fuzz -run=Fuzz -fuzz=FuzzVMCompile -fuzztime=1x`


------
https://chatgpt.com/codex/tasks/task_e_6862f4eb5f448320b21dbe00a2ff72e8